### PR TITLE
Add --force to destroy-controller CLI

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -41,7 +41,7 @@ var facadeVersions = map[string]int{
 	"Cleaner":                      2,
 	"Client":                       3,
 	"Cloud":                        7,
-	"Controller":                   10,
+	"Controller":                   11,
 	"CredentialManager":            1,
 	"CredentialValidator":          2,
 	"CrossController":              1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -213,6 +213,7 @@ func AllFacades() *facade.Registry {
 	reg("Controller", 8, controller.NewControllerAPIv8)
 	reg("Controller", 9, controller.NewControllerAPIv9)
 	reg("Controller", 10, controller.NewControllerAPIv10)
+	reg("Controller", 11, controller.NewControllerAPIv11)
 	reg("CrossModelRelations", 1, crossmodelrelations.NewStateCrossModelRelationsAPIV1)
 	reg("CrossModelRelations", 2, crossmodelrelations.NewStateCrossModelRelationsAPI) // Adds WatchRelationChanges, removes WatchRelationUnits
 	reg("CrossController", 1, crosscontroller.NewStateCrossControllerAPI)

--- a/apiserver/common/modeldestroy.go
+++ b/apiserver/common/modeldestroy.go
@@ -43,6 +43,9 @@ func DestroyController(
 	st ModelManagerBackend,
 	destroyHostedModels bool,
 	destroyStorage *bool,
+	force *bool,
+	maxWait *time.Duration,
+	modelTimeout *time.Duration,
 ) error {
 	modelTag := st.ModelTag()
 	controllerModelTag := st.ControllerModelTag()
@@ -82,6 +85,9 @@ func DestroyController(
 	return destroyModel(st, state.DestroyModelParams{
 		DestroyHostedModels: destroyHostedModels,
 		DestroyStorage:      destroyStorage,
+		Force:               force,
+		MaxWait:             MaxWait(maxWait),
+		Timeout:             modelTimeout,
 	})
 }
 

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -57,10 +57,16 @@ type ControllerAPI struct {
 	multiwatcherFactory multiwatcher.Factory
 }
 
+// ControllerAPIv10 provides the v10 controller API. The only difference between
+// this and the v11 is that v10 doesn't support force destroy.
+type ControllerAPIv10 struct {
+	*ControllerAPI
+}
+
 // ControllerAPIv9 provides the v9 controller API. The only difference between
 // this and the v10 is that v9 use the cloudspec api v1
 type ControllerAPIv9 struct {
-	*ControllerAPI
+	*ControllerAPIv10
 }
 
 // ControllerAPIv8 provides the v8 Controller API. The only difference
@@ -101,10 +107,10 @@ type ControllerAPIv3 struct {
 
 // LatestAPI is used for testing purposes to create the latest
 // controller API.
-var LatestAPI = NewControllerAPIv10
+var LatestAPI = NewControllerAPIv11
 
-// NewControllerAPIv10 creates a new ControllerAPIv10
-func NewControllerAPIv10(ctx facade.Context) (*ControllerAPI, error) {
+// NewControllerAPIv11 creates a new ControllerAPIv11
+func NewControllerAPIv11(ctx facade.Context) (*ControllerAPI, error) {
 	st := ctx.State()
 	authorizer := ctx.Auth()
 	pool := ctx.StatePool()
@@ -124,6 +130,15 @@ func NewControllerAPIv10(ctx facade.Context) (*ControllerAPI, error) {
 		factory,
 		controller,
 	)
+}
+
+// NewControllerAPIv10 creates a new ControllerAPIv10.
+func NewControllerAPIv10(ctx facade.Context) (*ControllerAPIv10, error) {
+	v11, err := NewControllerAPIv11(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ControllerAPIv10{v11}, nil
 }
 
 // NewControllerAPIv9 creates a new ControllerAPIv9.

--- a/apiserver/facades/client/controller/destroy.go
+++ b/apiserver/facades/client/controller/destroy.go
@@ -69,6 +69,7 @@ func destroyController(
 	backend := common.NewModelManagerBackend(model, pool)
 	return errors.Trace(common.DestroyController(
 		backend, args.DestroyModels, args.DestroyStorage,
+		args.Force, args.MaxWait, args.ModelTimeout,
 	))
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -19649,7 +19649,7 @@
     {
         "Name": "Controller",
         "Description": "ControllerAPI provides the Controller API.",
-        "Version": 10,
+        "Version": 11,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -20102,6 +20102,15 @@
                         },
                         "destroy-storage": {
                             "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        },
+                        "model-timeout": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -3,7 +3,11 @@
 
 package params
 
-import "github.com/juju/juju/core/life"
+import (
+	"time"
+
+	"github.com/juju/juju/core/life"
+)
 
 // DestroyControllerArgs holds the arguments for destroying a controller.
 type DestroyControllerArgs struct {
@@ -19,6 +23,18 @@ type DestroyControllerArgs struct {
 	// storage in the model (or hosted models), an error with the code
 	// params.CodeHasPersistentStorage will be returned.
 	DestroyStorage *bool `json:"destroy-storage,omitempty"`
+
+	// Force specifies whether hosted model destruction will be forced,
+	// i.e. keep going despite operational errors.
+	Force *bool `json:"force,omitempty"`
+
+	// MaxWait specifies the amount of time that each hosted model destroy step
+	// will wait before forcing the next step to kick-off.
+	// This parameter only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
+
+	// ModelTimeout specifies how long to wait for each hosted model destroy process.
+	ModelTimeout *time.Duration `json:"model-timeout,omitempty"`
 }
 
 // ModelBlockInfo holds information about an model and its

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -63,7 +63,7 @@ that --force will also remove all units of the application, its subordinates
 and, potentially, machines without given them the opportunity to shutdown cleanly.
 
 Application removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step has finished. 
+proceed to the next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -76,7 +76,7 @@ that --force will remove a unit and, potentially, its machine without
 given them the opportunity to shutdown cleanly.
 
 Unit removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step has finished.
+proceed to the next step until the current step has finished.
 However, when using --force, users can also specify --no-wait to progress through steps
 without delay waiting for each step to complete.
 

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -86,7 +86,7 @@ that --force will also remove all units of any hosted applications, their subord
 and, potentially, machines without given them the opportunity to shutdown cleanly.
 
 Model destruction is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step has finished. 
+proceed to the next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -331,8 +331,10 @@ func (s *DestroySuite) TestDestroyWithDestroyAllModelsFlag(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "DestroyController", "AllModels", "ModelStatus", "Close")
+	timeout := 30 * time.Minute
 	s.api.CheckCall(c, 0, "DestroyController", apicontroller.DestroyControllerParams{
 		DestroyModels: true,
+		ModelTimeout:  &timeout,
 	})
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
@@ -341,8 +343,10 @@ func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlag(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	destroyStorage := true
+	timeout := 30 * time.Minute
 	s.api.CheckCall(c, 0, "DestroyController", apicontroller.DestroyControllerParams{
 		DestroyStorage: &destroyStorage,
+		ModelTimeout:   &timeout,
 	})
 }
 
@@ -350,14 +354,27 @@ func (s *DestroySuite) TestDestroyWithDestroyReleaseStorageFlag(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y", "--release-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	destroyStorage := false
+	timeout := 30 * time.Minute
 	s.api.CheckCall(c, 0, "DestroyController", apicontroller.DestroyControllerParams{
 		DestroyStorage: &destroyStorage,
+		ModelTimeout:   &timeout,
 	})
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyDestroyReleaseStorageFlagsMutuallyExclusive(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-storage", "--release-storage")
 	c.Assert(err, gc.ErrorMatches, "--destroy-storage and --release-storage cannot both be specified")
+}
+
+func (s *DestroySuite) TestDestroyWithForceFlag(c *gc.C) {
+	_, err := s.runDestroyCommand(c, "test1", "-y", "--force", "--model-timeout", "10m")
+	c.Assert(err, jc.ErrorIsNil)
+	force := true
+	timeout := 10 * time.Minute
+	s.api.CheckCall(c, 0, "DestroyController", apicontroller.DestroyControllerParams{
+		Force:        &force,
+		ModelTimeout: &timeout,
+	})
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlagUnspecified(c *gc.C) {

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -50,7 +50,7 @@ option; this will also remove those units and containers without giving
 them an opportunity to shut down cleanly.
 
 Machine removal is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step has finished. 
+proceed to the next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -90,7 +90,7 @@ that --force will also remove all units of the application, its subordinates
 and, potentially, machines without given them the opportunity to shutdown cleanly.
 
 Model destruction is a multi-step process. Under normal circumstances, Juju will not
-proceed to a next step until the current step has finished. 
+proceed to the next step until the current step has finished. 
 However, when using --force, users can also specify --no-wait to progress through steps 
 without delay waiting for each step to complete.
 


### PR DESCRIPTION
Add --force to juju destroy-controller.
The api backend for destroying hosted models supports --force, and the error message when trying to destroy a stuck model tells the user to use --force, bu the CLI did not implement it. We also need to weave it through the DestoryController API.

## QA steps

bootstrap and destroy a controller to check things still work
simulate a stuck model and use destroy-controller --force

## Bug reference

https://bugs.launchpad.net/juju/+bug/1938950
