### PR TITLE
Lease manager - never unblock immediately

### DIFF
--- a/worker/lease/manager_block_test.go
+++ b/worker/lease/manager_block_test.go
@@ -31,15 +31,6 @@ func (s *WaitUntilExpiredSuite) SetUpTest(c *gc.C) {
 	logger.SetLogLevel(loggo.TRACE)
 }
 
-func (s *WaitUntilExpiredSuite) TestLeadershipNotHeld(c *gc.C) {
-	fix := &Fixture{}
-	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		blockTest := newBlockTest(c, manager, key("redis"))
-		err := blockTest.assertUnblocked(c)
-		c.Check(err, jc.ErrorIsNil)
-	})
-}
-
 func (s *WaitUntilExpiredSuite) TestLeadershipExpires(c *gc.C) {
 	fix := &Fixture{
 		leases: map[corelease.Key]corelease.Info{
@@ -245,11 +236,8 @@ func (bt *blockTest) assertBlocked(c *gc.C) {
 	select {
 	case err := <-bt.done:
 		c.Errorf("unblocked unexpectedly with %v", err)
-	case <-time.After(time.Millisecond):
-		// happy that we are still blocked, success
-		// TODO(jam): 2019-02-05 should this be testing.ShortWait? It used to be
-		//  just plain 'default:', which didn't even give the helper goroutine
-		//  a timeslice to start to even evaluate if WaitUntilExpired had returned.
+	case <-time.After(testing.ShortWait):
+		// Happy that we are still blocked; success.
 	}
 }
 

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb"
 	"github.com/juju/clock"
@@ -181,7 +181,7 @@ func Bootstrap(config Config) error {
 	// During bootstrap we use an in-memory transport. We just need
 	// to make sure we use the same local address as we'll use later.
 	_, transport := raft.NewInmemTransport(bootstrapAddress)
-	defer transport.Close()
+	defer func() { _ = transport.Close() }()
 	config.Transport = transport
 
 	// During bootstrap, we do not require an FSM.
@@ -267,8 +267,8 @@ func (w *Worker) Raft() (*raft.Raft, error) {
 			return nil, err
 		}
 		return nil, ErrWorkerStopped
-	case raft := <-w.raftCh:
-		return raft, nil
+	case r := <-w.raftCh:
+		return r, nil
 	}
 }
 
@@ -319,7 +319,7 @@ func (w *Worker) loop(raftConfig *raft.Config) (loopErr error) {
 	// StableStore methods, because we aren't giving out a reference
 	// to the StableStore - only the raft instance uses it.
 	logStore := &syncLogStore{store: rawLogStore}
-	defer logStore.Close()
+	defer func() { _ = logStore.Close() }()
 
 	snapshotRetention := w.config.SnapshotRetention
 	if snapshotRetention == 0 {
@@ -399,7 +399,7 @@ func NewRaftConfig(config Config) (*raft.Config, error) {
 	// stops when it's demoted if it's the leader.
 	raftConfig.ShutdownOnRemove = false
 
-	logWriter := &raftutil.LoggoWriter{config.Logger, loggo.DEBUG}
+	logWriter := &raftutil.LoggoWriter{Logger: config.Logger, Level: loggo.DEBUG}
 	raftConfig.Logger = log.New(logWriter, "", 0)
 
 	maybeOverrideDuration := func(d time.Duration, target *time.Duration) {
@@ -417,22 +417,23 @@ func NewRaftConfig(config Config) (*raft.Config, error) {
 	return raftConfig, nil
 }
 
-// SyncMode defines the supported sync modes when writing to the raft log store.
+// SyncMode defines the supported sync modes
+// when writing to the raft log store.
 type SyncMode bool
 
 const (
-	// SyncWrites ensures that an fsync call is performed after each write.
+	// SyncAfterWrite ensures that an fsync call is performed after each write.
 	SyncAfterWrite SyncMode = false
 
-	// NoSyncAfterWrite ensures that no fsync calls are performed between
-	// writes.
+	// NoSyncAfterWrite ensures that no fsync
+	// calls are performed between writes.
 	NoSyncAfterWrite SyncMode = true
 )
 
 // NewLogStore opens a boltDB logstore in the specified directory. If the
 // directory doesn't already exist it'll be created. If the caller passes
-// NonSyncedAfterWrite as the value of the syncMode argument, the underlying store
-// will NOT perform fsync calls between log writes.
+// NonSyncedAfterWrite as the value of the syncMode argument, the underlying
+// store will NOT perform fsync calls between log writes.
 func NewLogStore(dir string, syncMode SyncMode) (*raftboltdb.BoltStore, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, errors.Trace(err)
@@ -458,7 +459,7 @@ func NewSnapshotStore(
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, errors.Trace(err)
 	}
-	logWriter := &raftutil.LoggoWriter{logger, loggo.DEBUG}
+	logWriter := &raftutil.LoggoWriter{Logger: logger, Level: loggo.DEBUG}
 	logLogger := log.New(logWriter, logPrefix, 0)
 
 	snaps, err := raft.NewFileSnapshotStoreWithLogger(dir, retain, logLogger)
@@ -473,7 +474,7 @@ func NewSnapshotStore(
 type BootstrapFSM struct{}
 
 // Apply is part of raft.FSM.
-func (BootstrapFSM) Apply(log *raft.Log) interface{} {
+func (BootstrapFSM) Apply(_ *raft.Log) interface{} {
 	panic("Apply should not be called during bootstrap")
 }
 


### PR DESCRIPTION
When quiescing in HA, there can be a situation where:
1. The local FSM is not yet in sync with the master and has no lease claimant.
2. We attempt to claim a lease.
3. The lease claim is rejected and a block is added for the lease.
4. The block is immediately removed because we have no lease in the local FSM.
5. Go to 2.

For example:
```
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 24ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 16ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 5ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 10ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 6ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 5ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 15ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 6ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 18ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 3ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 5ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 4ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 11ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 5ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 5ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 5ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 8ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 5ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 4ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 6ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-3: 17:22:23 TRACE juju.core.raftlease got response, err lease already held
machine-3: 17:22:23 WARNING juju.core.raftlease command Command(ver: 1, op: claim, ns: application-leadership, model: e97a6c, lease: ubuntu, holder: ubuntu/2): lease already held
machine-3: 17:22:23 TRACE juju.core.raftlease runOnLeader claim, elapsed from publish: 5ms
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, held by by another entity; local Raft node may be syncing
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] adding block for: ubuntu
machine-3: 17:22:23 TRACE juju.worker.lease.raft [69cba6] ubuntu/2 asked for lease ubuntu, no lease found, claiming for 1m0s
machine-1: 17:22:22 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
```

Here we remove the check and unblock that immediately follows the addition of a block. The block is only ever added when there is already a claimant, so accommodating the out-of-sync scenario should be safe - blocks will be checked in the not-too-distant future anyway.

_Note for reviewers: It is safe to disregard the first commit, which mostly regards formatting, comments etc._

## QA steps

This is hard to replicate exactly.

- Bootstrap.
- `juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE"`
- `juju deploy ubuntu -n 3`
- `juju enable-ha` and wait for it to settle.
- Check that leases still change hands by shelling to the leader ubuntu unit and stopping its jujud service. Another unit should become leader within about a minute.
- Restart the machine agent.
- Run `juju debug-log` for the controller model and observe which machine is ticking the lease clock.
- Use `juju remove-machine` to remove that machine.
- Once this settles, run `juju enable-ha` again.
- Check that we don't get the repetitive logging above.

## Documentation changes

None.

## Bug reference

N/A
