### PR TITLE
Add initial create and get secrets hook commands

### DIFF
--- a/api/secrets/client.go
+++ b/api/secrets/client.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secrets
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/core/secrets"
+)
+
+// Client is the api client for the Secrets facade.
+type Client struct {
+	facade base.FacadeCaller
+}
+
+// NewClient creates a secrets api client.
+func NewClient(caller base.APICaller) *Client {
+	return &Client{
+		facade: base.NewFacadeCaller(caller, "Secrets"),
+	}
+}
+
+// Create creates a new secret.
+func (c *Client) Create(name string, value secrets.SecretValue) (string, error) {
+	return "", errors.NotImplementedf("Create Secret")
+}
+
+// GetValue returns the value of a secret.
+func (c *Client) GetValue(name string) (secrets.SecretValue, error) {
+	return nil, errors.NotImplementedf("Get Secret")
+}

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -10,6 +10,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 )
 
@@ -18,6 +19,11 @@ type HelpToolSuite struct {
 }
 
 var _ = gc.Suite(&HelpToolSuite{})
+
+func (suite *HelpToolSuite) SetUpTest(c *gc.C) {
+	suite.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	setFeatureFlags(feature.Secrets)
+}
 
 func (suite *HelpToolSuite) TestHelpToolHelp(c *gc.C) {
 	output := badrun(c, 0, "help", "help-tool")
@@ -126,6 +132,8 @@ var expectedCommands = []string{
 	"relation-list",
 	"relation-set",
 	"resource-get",
+	"secret-create",
+	"secret-get",
 	"state-delete",
 	"state-get",
 	"state-set",

--- a/core/secrets/createsecret.go
+++ b/core/secrets/createsecret.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// SecretData holds secret key values.
+type SecretData map[string][]byte
+
+// CreatSecretData creates a secret data bag from a list of arguments.
+// The arguments are either all key=value or a singular value.
+// If base64 is true, then the supplied value(s) are already base64 encoded,
+// otherwise the values are base64 encoded as they are added to the data bag.
+func CreatSecretData(asBase64 bool, args []string) (SecretData, error) {
+	data := make(SecretData)
+	haveSingularalue := false
+	for i, val := range args {
+		// Remove any base64 padding ("=") before splitting the key=value.
+		stripped := strings.TrimRight(val, string(base64.StdPadding))
+		idx := strings.Index(stripped, "=")
+		keyVal := []string{val}
+		if idx > 0 {
+			keyVal = []string{
+				val[0:idx],
+				val[idx+1:],
+			}
+		}
+
+		var (
+			key   string
+			value string
+		)
+		if len(keyVal) == 1 {
+			if i > 0 {
+				return nil, errors.NewNotValid(nil, fmt.Sprintf("singular value %q not valid when other key values are specified", val))
+			}
+			key = singularSecretKey
+			value = keyVal[0]
+			haveSingularalue = true
+		} else {
+			key = keyVal[0]
+			value = keyVal[1]
+		}
+		if haveSingularalue && i > 0 {
+			return nil, errors.NewNotValid(nil, fmt.Sprintf("key value %q not valid when a singular value has already been specified", val))
+		}
+		if !asBase64 {
+			value = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v", value)))
+		}
+		data[key] = []byte(value)
+	}
+	return data, nil
+}

--- a/core/secrets/createsecret_test.go
+++ b/core/secrets/createsecret_test.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+)
+
+type CreateSecretSuite struct {
+	base64Foo []byte
+	base64Bar []byte
+}
+
+var _ = gc.Suite(&CreateSecretSuite{})
+
+func (s *CreateSecretSuite) TestInvalidSingularValue(c *gc.C) {
+	_, err := secrets.CreatSecretData(false, []string{"token", "foo=bar"})
+	c.Assert(err, gc.ErrorMatches, `key value "foo=bar" not valid when a singular value has already been specified`)
+
+	_, err = secrets.CreatSecretData(false, []string{"foo=bar", "token"})
+	c.Assert(err, gc.ErrorMatches, `singular value "token" not valid when other key values are specified`)
+}
+
+func (s *CreateSecretSuite) TestSingularValue(c *gc.C) {
+	data, err := secrets.CreatSecretData(false, []string{"token"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, secrets.SecretData{
+		"data": []byte("dG9rZW4="),
+	})
+}
+
+func (s *CreateSecretSuite) TestSingularValueBase64(c *gc.C) {
+	data, err := secrets.CreatSecretData(true, []string{"key="})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, secrets.SecretData{
+		"data": []byte("key="),
+	})
+}
+
+func (s *CreateSecretSuite) TestValues(c *gc.C) {
+	data, err := secrets.CreatSecretData(false, []string{"foo=bar", "hello=world"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, secrets.SecretData{
+		"foo":   []byte("YmFy"),
+		"hello": []byte("d29ybGQ="),
+	})
+}
+
+func (s *CreateSecretSuite) TestValuesBase64(c *gc.C) {
+	data, err := secrets.CreatSecretData(true, []string{"foo=bar", "hello=world"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, secrets.SecretData{
+		"foo":   []byte("bar"),
+		"hello": []byte("world"),
+	})
+}

--- a/core/secrets/package_test.go
+++ b/core/secrets/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/core/secrets/secretvalue.go
+++ b/core/secrets/secretvalue.go
@@ -1,0 +1,117 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// SecretValue holds the value of a secret.
+// Instances of SecretValue are returned by a secret store
+// when a secret look up is performed. The underlying value
+// is a map of base64 encoded values represented as []byte.
+// Convenience methods exist to retrieve singular decoded string
+// and encoded base64 string values.
+type SecretValue interface {
+	// EncodedValues returns the key values of a secret as
+	// the raw base64 encoded strings.
+	// For the special case where the secret only has a
+	// single key value "data", then use BinaryValue()
+	//to get the result.
+	EncodedValues() map[string]string
+
+	// Values returns the key values of a secret as strings.
+	// For the special case where the secret only has a
+	// single key value "data", then use StringValue()
+	//to get the result.
+	Values() (map[string]string, error)
+
+	// Singular returns true if the secret value represents a
+	// single data value rather than key values.
+	Singular() bool
+
+	// EncodedValue returns the value of the secret as the raw
+	// base64 encoded string.
+	// The secret must be a singular value.
+	EncodedValue() (string, error)
+
+	// Value returns the value of the secret as a string.
+	// The secret must be a singular value.
+	Value() (string, error)
+}
+
+type secretValue struct {
+	// Data holds the key values of a secret.
+	// We use a map to hold multiple values, eg cert and key
+	// The serialised form of any string values is a
+	// base64 encoded string, representing arbitrary values.
+	data map[string][]byte
+}
+
+// NewSecretValue returns a secret using the specified map of values.
+// The map values are assumed to be already base64 encoded.
+func NewSecretValue(data map[string][]byte) SecretValue {
+	dataCopy := make(map[string][]byte, len(data))
+	for k, v := range data {
+		dataCopy[k] = append([]byte(nil), v...)
+	}
+	return &secretValue{data: dataCopy}
+}
+
+const singularSecretKey = "data"
+
+// EncodedValues implements SecretValue.
+func (v *secretValue) EncodedValues() map[string]string {
+	dataCopy := make(map[string]string, len(v.data))
+	for k, val := range v.data {
+		dataCopy[k] = string(val)
+	}
+	return dataCopy
+}
+
+// Values implements SecretValue.
+func (v *secretValue) Values() (map[string]string, error) {
+	dataCopy := v.EncodedValues()
+	for k, v := range dataCopy {
+		data, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		dataCopy[k] = string(data)
+	}
+	return dataCopy, nil
+}
+
+// Singular implements SecretValue.
+func (v *secretValue) Singular() bool {
+	_, ok := v.data[singularSecretKey]
+	return ok && len(v.data) == 1
+}
+
+// EncodedValue implements SecretValue.
+func (v *secretValue) EncodedValue() (string, error) {
+	if !v.Singular() {
+		return "", errors.NewNotValid(nil, "secret is not a singular value")
+	}
+	return string(v.data[singularSecretKey]), nil
+}
+
+// Value implements SecretValue.
+func (v *secretValue) Value() (string, error) {
+	s, err := v.EncodedValue()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	// The stored value is always base64 encoded.
+	b64 := base64.NewDecoder(base64.StdEncoding, strings.NewReader(s))
+	result, err := ioutil.ReadAll(b64)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return string(result), nil
+}

--- a/core/secrets/secretvalue_test.go
+++ b/core/secrets/secretvalue_test.go
@@ -1,0 +1,78 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	"encoding/base64"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+)
+
+type SecretValueSuite struct {
+	base64Foo []byte
+	base64Bar []byte
+}
+
+var _ = gc.Suite(&SecretValueSuite{})
+
+func (s *SecretValueSuite) TestEncodedValues(c *gc.C) {
+	in := map[string][]byte{
+		"a": []byte(base64.StdEncoding.EncodeToString([]byte("foo"))),
+		"b": []byte(base64.StdEncoding.EncodeToString([]byte("1"))),
+	}
+	val := secrets.NewSecretValue(in)
+
+	c.Assert(val.EncodedValues(), jc.DeepEquals, map[string]string{
+		"a": base64.StdEncoding.EncodeToString([]byte("foo")),
+		"b": base64.StdEncoding.EncodeToString([]byte("1")),
+	})
+
+	c.Assert(val.Singular(), jc.IsFalse)
+	_, err := val.EncodedValue()
+	c.Assert(err, gc.ErrorMatches, "secret is not a singular value")
+}
+
+func (s *SecretValueSuite) TestValues(c *gc.C) {
+	in := map[string][]byte{
+		"a": []byte(base64.StdEncoding.EncodeToString([]byte("foo"))),
+		"b": []byte(base64.StdEncoding.EncodeToString([]byte("1"))),
+	}
+	val := secrets.NewSecretValue(in)
+
+	strValues, err := val.Values()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(strValues, jc.DeepEquals, map[string]string{
+		"a": "foo",
+		"b": "1",
+	})
+
+	_, err = val.Value()
+	c.Assert(err, gc.ErrorMatches, "secret is not a singular value")
+}
+
+func (s *SecretValueSuite) TestSingularValue(c *gc.C) {
+	in := map[string][]byte{
+		"data": []byte(base64.StdEncoding.EncodeToString([]byte("foo"))),
+	}
+	val := secrets.NewSecretValue(in)
+
+	sval, err := val.Value()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sval, gc.Equals, "foo")
+}
+
+func (s *SecretValueSuite) TestSingularEncodedValue(c *gc.C) {
+	in := map[string][]byte{
+		"data": []byte(base64.StdEncoding.EncodeToString([]byte("foo"))),
+	}
+	val := secrets.NewSecretValue(in)
+	c.Assert(val.Singular(), jc.IsTrue)
+
+	bval, err := val.EncodedValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bval, gc.Equals, string(in["data"]))
+}

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -50,3 +50,6 @@ const RawK8sSpec = "raw-k8s-spec"
 
 // ActionsV2 enables the next generation actions UX.
 const ActionsV2 = "actions-v2"
+
+// Secrets enables the secrets feature.
+const Secrets = "secrets"

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/secrets"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -126,9 +127,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if !ok {
 				return nil, errors.Errorf("expected a unit tag, got %v", tag)
 			}
-			uniterFacade := uniter.NewState(apiConn, unitTag)
 			uniter, err := NewUniter(&UniterParams{
-				UniterFacade:                 uniterFacade,
+				UniterFacade:                 uniter.NewState(apiConn, unitTag),
+				SecretsFacade:                secrets.NewClient(apiConn),
 				UnitTag:                      unitTag,
 				ModelType:                    config.ModelType,
 				LeadershipTrackerFunc:        leadershipTrackerFunc,

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
+	"github.com/juju/juju/api/secrets"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -862,4 +863,34 @@ func (s *mockHookContextSuite) TestMissingAction(c *gc.C) {
 	context.WithActionContext(hookContext, nil, nil)
 	err := hookContext.Flush("action", charmrunner.NewMissingHookError("noaction"))
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *mockHookContextSuite) TestSecretGet(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "Secrets")
+		c.Assert(version, gc.Equals, 0)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "GetSecrets")
+		return nil
+	})
+	client := secrets.NewClient(apiCaller)
+	hookContext := context.NewMockUnitHookContextWithSecrets("wordpress/0", s.mockUnit, client)
+	_, err := hookContext.GetSecret("password")
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+}
+
+func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "Secrets")
+		c.Assert(version, gc.Equals, 0)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "CreateSecrets")
+		return nil
+	})
+	client := secrets.NewClient(apiCaller)
+	hookContext := context.NewMockUnitHookContextWithSecrets("wordpress/0", s.mockUnit, client)
+	_, err := hookContext.CreateSecret("password", nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/api/secrets"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -67,6 +68,7 @@ type contextFactory struct {
 	// API connection fields; unit should be deprecated, but isn't yet.
 	unit    *uniter.Unit
 	state   *uniter.State
+	secrets *secrets.Client
 	tracker leadership.Tracker
 
 	logger loggo.Logger
@@ -94,6 +96,7 @@ type contextFactory struct {
 // for the context factory.
 type FactoryConfig struct {
 	State            *uniter.State
+	Secrets          *secrets.Client
 	Unit             *uniter.Unit
 	Tracker          leadership.Tracker
 	GetRelationInfos RelationsFunc
@@ -135,6 +138,7 @@ func NewContextFactory(config FactoryConfig) (ContextFactory, error) {
 	f := &contextFactory{
 		unit:             config.Unit,
 		state:            config.State,
+		secrets:          config.Secrets,
 		tracker:          config.Tracker,
 		logger:           config.Logger,
 		paths:            config.Paths,
@@ -169,6 +173,7 @@ func (f *contextFactory) coreContext() (*HookContext, error) {
 	ctx := &HookContext{
 		unit:               f.unit,
 		state:              f.state,
+		secretFacade:       f.secrets,
 		LeadershipContext:  leadershipContext,
 		uuid:               f.modelUUID,
 		modelName:          f.modelName,

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/proxy"
 
+	"github.com/juju/juju/api/secrets"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -102,6 +103,14 @@ func NewMockUnitHookContextWithState(unitName string, mockUnit *mocks.MockHookUn
 		state:            state,
 		logger:           loggo.GetLogger("test"),
 		portRangeChanges: newPortRangeChangeRecorder(names.NewUnitTag(unitName), nil),
+	}
+}
+
+func NewMockUnitHookContextWithSecrets(unitName string, mockUnit *mocks.MockHookUnit, client *secrets.Client) *HookContext {
+	return &HookContext{
+		unit:         mockUnit,
+		secretFacade: client,
+		logger:       loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/uniter/runner/context/mocks/hookunit_mock.go
+++ b/worker/uniter/runner/context/mocks/hookunit_mock.go
@@ -5,39 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	uniter "github.com/juju/juju/api/uniter"
 	params "github.com/juju/juju/apiserver/params"
 	status "github.com/juju/juju/core/status"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockHookUnit is a mock of HookUnit interface
+// MockHookUnit is a mock of HookUnit interface.
 type MockHookUnit struct {
 	ctrl     *gomock.Controller
 	recorder *MockHookUnitMockRecorder
 }
 
-// MockHookUnitMockRecorder is the mock recorder for MockHookUnit
+// MockHookUnitMockRecorder is the mock recorder for MockHookUnit.
 type MockHookUnitMockRecorder struct {
 	mock *MockHookUnit
 }
 
-// NewMockHookUnit creates a new mock instance
+// NewMockHookUnit creates a new mock instance.
 func NewMockHookUnit(ctrl *gomock.Controller) *MockHookUnit {
 	mock := &MockHookUnit{ctrl: ctrl}
 	mock.recorder = &MockHookUnitMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHookUnit) EXPECT() *MockHookUnitMockRecorder {
 	return m.recorder
 }
 
-// Application mocks base method
+// Application mocks base method.
 func (m *MockHookUnit) Application() (*uniter.Application, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application")
@@ -46,13 +47,13 @@ func (m *MockHookUnit) Application() (*uniter.Application, error) {
 	return ret0, ret1
 }
 
-// Application indicates an expected call of Application
+// Application indicates an expected call of Application.
 func (mr *MockHookUnitMockRecorder) Application() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockHookUnit)(nil).Application))
 }
 
-// ApplicationName mocks base method
+// ApplicationName mocks base method.
 func (m *MockHookUnit) ApplicationName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationName")
@@ -60,27 +61,13 @@ func (m *MockHookUnit) ApplicationName() string {
 	return ret0
 }
 
-// ApplicationName indicates an expected call of ApplicationName
+// ApplicationName indicates an expected call of ApplicationName.
 func (mr *MockHookUnitMockRecorder) ApplicationName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationName", reflect.TypeOf((*MockHookUnit)(nil).ApplicationName))
 }
 
-// ClosePorts mocks base method
-func (m *MockHookUnit) ClosePorts(arg0 string, arg1, arg2 int) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClosePorts", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ClosePorts indicates an expected call of ClosePorts
-func (mr *MockHookUnitMockRecorder) ClosePorts(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePorts", reflect.TypeOf((*MockHookUnit)(nil).ClosePorts), arg0, arg1, arg2)
-}
-
-// CommitHookChanges mocks base method
+// CommitHookChanges mocks base method.
 func (m *MockHookUnit) CommitHookChanges(arg0 params.CommitHookChangesArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommitHookChanges", arg0)
@@ -88,13 +75,13 @@ func (m *MockHookUnit) CommitHookChanges(arg0 params.CommitHookChangesArgs) erro
 	return ret0
 }
 
-// CommitHookChanges indicates an expected call of CommitHookChanges
+// CommitHookChanges indicates an expected call of CommitHookChanges.
 func (mr *MockHookUnitMockRecorder) CommitHookChanges(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHookChanges", reflect.TypeOf((*MockHookUnit)(nil).CommitHookChanges), arg0)
 }
 
-// ConfigSettings mocks base method
+// ConfigSettings mocks base method.
 func (m *MockHookUnit) ConfigSettings() (charm.Settings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigSettings")
@@ -103,13 +90,13 @@ func (m *MockHookUnit) ConfigSettings() (charm.Settings, error) {
 	return ret0, ret1
 }
 
-// ConfigSettings indicates an expected call of ConfigSettings
+// ConfigSettings indicates an expected call of ConfigSettings.
 func (mr *MockHookUnitMockRecorder) ConfigSettings() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockHookUnit)(nil).ConfigSettings))
 }
 
-// LogActionMessage mocks base method
+// LogActionMessage mocks base method.
 func (m *MockHookUnit) LogActionMessage(arg0 names.ActionTag, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogActionMessage", arg0, arg1)
@@ -117,13 +104,13 @@ func (m *MockHookUnit) LogActionMessage(arg0 names.ActionTag, arg1 string) error
 	return ret0
 }
 
-// LogActionMessage indicates an expected call of LogActionMessage
+// LogActionMessage indicates an expected call of LogActionMessage.
 func (mr *MockHookUnitMockRecorder) LogActionMessage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockHookUnit)(nil).LogActionMessage), arg0, arg1)
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockHookUnit) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -131,13 +118,13 @@ func (m *MockHookUnit) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockHookUnitMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHookUnit)(nil).Name))
 }
 
-// NetworkInfo mocks base method
+// NetworkInfo mocks base method.
 func (m *MockHookUnit) NetworkInfo(arg0 []string, arg1 *int) (map[string]params.NetworkInfoResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1)
@@ -146,27 +133,13 @@ func (m *MockHookUnit) NetworkInfo(arg0 []string, arg1 *int) (map[string]params.
 	return ret0, ret1
 }
 
-// NetworkInfo indicates an expected call of NetworkInfo
+// NetworkInfo indicates an expected call of NetworkInfo.
 func (mr *MockHookUnitMockRecorder) NetworkInfo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockHookUnit)(nil).NetworkInfo), arg0, arg1)
 }
 
-// OpenPorts mocks base method
-func (m *MockHookUnit) OpenPorts(arg0 string, arg1, arg2 int) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenPorts", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// OpenPorts indicates an expected call of OpenPorts
-func (mr *MockHookUnitMockRecorder) OpenPorts(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPorts", reflect.TypeOf((*MockHookUnit)(nil).OpenPorts), arg0, arg1, arg2)
-}
-
-// RequestReboot mocks base method
+// RequestReboot mocks base method.
 func (m *MockHookUnit) RequestReboot() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestReboot")
@@ -174,13 +147,13 @@ func (m *MockHookUnit) RequestReboot() error {
 	return ret0
 }
 
-// RequestReboot indicates an expected call of RequestReboot
+// RequestReboot indicates an expected call of RequestReboot.
 func (mr *MockHookUnitMockRecorder) RequestReboot() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockHookUnit)(nil).RequestReboot))
 }
 
-// SetAgentStatus mocks base method
+// SetAgentStatus mocks base method.
 func (m *MockHookUnit) SetAgentStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAgentStatus", arg0, arg1, arg2)
@@ -188,13 +161,13 @@ func (m *MockHookUnit) SetAgentStatus(arg0 status.Status, arg1 string, arg2 map[
 	return ret0
 }
 
-// SetAgentStatus indicates an expected call of SetAgentStatus
+// SetAgentStatus indicates an expected call of SetAgentStatus.
 func (mr *MockHookUnitMockRecorder) SetAgentStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAgentStatus", reflect.TypeOf((*MockHookUnit)(nil).SetAgentStatus), arg0, arg1, arg2)
 }
 
-// SetUnitStatus mocks base method
+// SetUnitStatus mocks base method.
 func (m *MockHookUnit) SetUnitStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUnitStatus", arg0, arg1, arg2)
@@ -202,13 +175,13 @@ func (m *MockHookUnit) SetUnitStatus(arg0 status.Status, arg1 string, arg2 map[s
 	return ret0
 }
 
-// SetUnitStatus indicates an expected call of SetUnitStatus
+// SetUnitStatus indicates an expected call of SetUnitStatus.
 func (mr *MockHookUnitMockRecorder) SetUnitStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockHookUnit)(nil).SetUnitStatus), arg0, arg1, arg2)
 }
 
-// State mocks base method
+// State mocks base method.
 func (m *MockHookUnit) State() (params.UnitStateResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State")
@@ -217,13 +190,13 @@ func (m *MockHookUnit) State() (params.UnitStateResult, error) {
 	return ret0, ret1
 }
 
-// State indicates an expected call of State
+// State indicates an expected call of State.
 func (mr *MockHookUnitMockRecorder) State() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockHookUnit)(nil).State))
 }
 
-// Tag mocks base method
+// Tag mocks base method.
 func (m *MockHookUnit) Tag() names.UnitTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -231,13 +204,13 @@ func (m *MockHookUnit) Tag() names.UnitTag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag
+// Tag indicates an expected call of Tag.
 func (mr *MockHookUnitMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockHookUnit)(nil).Tag))
 }
 
-// UnitStatus mocks base method
+// UnitStatus mocks base method.
 func (m *MockHookUnit) UnitStatus() (params.StatusResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitStatus")
@@ -246,13 +219,13 @@ func (m *MockHookUnit) UnitStatus() (params.StatusResult, error) {
 	return ret0, ret1
 }
 
-// UnitStatus indicates an expected call of UnitStatus
+// UnitStatus indicates an expected call of UnitStatus.
 func (mr *MockHookUnitMockRecorder) UnitStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockHookUnit)(nil).UnitStatus))
 }
 
-// UpdateNetworkInfo mocks base method
+// UpdateNetworkInfo mocks base method.
 func (m *MockHookUnit) UpdateNetworkInfo() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateNetworkInfo")
@@ -260,7 +233,7 @@ func (m *MockHookUnit) UpdateNetworkInfo() error {
 	return ret0
 }
 
-// UpdateNetworkInfo indicates an expected call of UpdateNetworkInfo
+// UpdateNetworkInfo indicates an expected call of UpdateNetworkInfo.
 func (mr *MockHookUnitMockRecorder) UpdateNetworkInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNetworkInfo", reflect.TypeOf((*MockHookUnit)(nil).UpdateNetworkInfo))

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/storage"
 )
 
@@ -46,6 +47,7 @@ type HookContext interface {
 	ContextComponents
 	ContextRelations
 	ContextVersion
+	ContextSecrets
 
 	// GetLogger returns a juju loggo Logger for the supplied module that is
 	// correctly wired up for the given context
@@ -159,6 +161,15 @@ type ContextUnit interface {
 
 	// CloudSpec returns the unit's cloud specification
 	CloudSpec() (*params.CloudSpec, error)
+}
+
+// ContextSecrets is the part of a hook context related to secrets.
+type ContextSecrets interface {
+	// GetSecret returns the value of the specified secret.
+	GetSecret(ID string) (secrets.SecretValue, error)
+
+	// CreateSecret creates a secret with the specified data.
+	CreateSecret(name string, value secrets.SecretValue) (string, error)
 }
 
 // ContextStatus is the part of a hook context related to the unit's status.

--- a/worker/uniter/runner/jujuc/jujuctesting/context.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/context.go
@@ -73,6 +73,7 @@ type Context struct {
 	ContextActionHook
 	ContextVersion
 	ContextWorkloadHook
+	ContextSecrets
 }
 
 // NewContext builds a jujuc.Context test double.
@@ -106,6 +107,7 @@ func NewContext(stub *testing.Stub, info *ContextInfo) *Context {
 	ctx.ContextUnitCharmState.info = &info.UnitCharmState
 	ctx.ContextWorkloadHook.stub = stub
 	ctx.ContextWorkloadHook.info = &info.WorkloadHook
+	ctx.ContextSecrets.stub = stub
 	return &ctx
 }
 

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuctesting
+
+import (
+	"github.com/juju/juju/core/secrets"
+)
+
+// ContextSecrets is a test double for jujuc.ContextSecrets.
+type ContextSecrets struct {
+	contextBase
+
+	SecretValue secrets.SecretValue
+}
+
+// GetSecret implements jujuc.ContextSecrets.
+func (c *ContextSecrets) GetSecret(ID string) (secrets.SecretValue, error) {
+	c.stub.AddCall("GetSecret", ID)
+	return c.SecretValue, nil
+}
+
+// CreateSecret implements jujuc.ContextSecrets.
+func (c *ContextSecrets) CreateSecret(name string, value secrets.SecretValue) (string, error) {
+	c.stub.AddCall("CreateSecret", name, value)
+	return "secret://app." + name, nil
+}

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -13,6 +13,7 @@ import (
 	params "github.com/juju/juju/apiserver/params"
 	application "github.com/juju/juju/core/application"
 	network "github.com/juju/juju/core/network"
+	secrets "github.com/juju/juju/core/secrets"
 	jujuc "github.com/juju/juju/worker/uniter/runner/jujuc"
 	loggo "github.com/juju/loggo"
 	names "github.com/juju/names/v4"
@@ -187,6 +188,21 @@ func (mr *MockContextMockRecorder) ConfigSettings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockContext)(nil).ConfigSettings))
 }
 
+// CreateSecret mocks base method.
+func (m *MockContext) CreateSecret(arg0 string, arg1 secrets.SecretValue) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSecret indicates an expected call of CreateSecret.
+func (mr *MockContextMockRecorder) CreateSecret(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockContext)(nil).CreateSecret), arg0, arg1)
+}
+
 // DeleteCharmStateValue mocks base method.
 func (m *MockContext) DeleteCharmStateValue(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -273,6 +289,21 @@ func (m *MockContext) GetRawK8sSpec() (string, error) {
 func (mr *MockContextMockRecorder) GetRawK8sSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawK8sSpec", reflect.TypeOf((*MockContext)(nil).GetRawK8sSpec))
+}
+
+// GetSecret mocks base method.
+func (m *MockContext) GetSecret(arg0 string) (secrets.SecretValue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecret", arg0)
+	ret0, _ := ret[0].(secrets.SecretValue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecret indicates an expected call of GetSecret.
+func (mr *MockContextMockRecorder) GetSecret(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0)
 }
 
 // GoalState mocks base method.

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/secrets"
 )
 
 // ErrRestrictedContext indicates a method is not implemented in the given context.
@@ -218,5 +219,15 @@ func (*RestrictedContext) SetUnitWorkloadVersion(string) error {
 
 // WorkloadName implements hooks.Context.
 func (*RestrictedContext) WorkloadName() (string, error) {
+	return "", ErrRestrictedContext
+}
+
+// GetSecret implements runner.Context.
+func (ctx *RestrictedContext) GetSecret(ID string) (secrets.SecretValue, error) {
+	return nil, ErrRestrictedContext
+}
+
+// CreateSecret implements runner.Context.
+func (ctx *RestrictedContext) CreateSecret(name string, value secrets.SecretValue) (string, error) {
 	return "", ErrRestrictedContext
 }

--- a/worker/uniter/runner/jujuc/secret-create.go
+++ b/worker/uniter/runner/jujuc/secret-create.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/juju/core/secrets"
+
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+type secretCreateCommand struct {
+	cmd.CommandBase
+	ctx Context
+
+	id       string
+	asBase64 bool
+	data     map[string][]byte
+}
+
+// NewSecretCreateCommand returns a command to create a secret.
+func NewSecretCreateCommand(ctx Context) (cmd.Command, error) {
+	return &secretCreateCommand{ctx: ctx}, nil
+}
+
+// Info implements cmd.Command.
+func (c *secretCreateCommand) Info() *cmd.Info {
+	doc := `
+Create a secret with either a single value or a list of key values.
+If --base64 is specified, the values are already in base64 format and no
+encoding will be performed, otherwise the values will be base64 encoded
+prior to being stored.
+`
+	return jujucmd.Info(&cmd.Info{
+		Name:    "secret-create",
+		Args:    "<id> [--base64] [value|key=value...]",
+		Purpose: "create a new secret",
+		Doc:     doc,
+	})
+}
+
+// SetFlags implements cmd.Command.
+func (c *secretCreateCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.asBase64, "base64", false,
+		`specify the supplied values are base64 encoded strings`)
+}
+
+// Init implements cmd.Command.
+func (c *secretCreateCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("missing secret id")
+	}
+	if len(args) < 2 {
+		return errors.New("missing secret value")
+	}
+	c.id = args[0]
+
+	var err error
+	c.data, err = secrets.CreatSecretData(c.asBase64, args[1:])
+	return err
+}
+
+// Run implements cmd.Command.
+func (c *secretCreateCommand) Run(ctx *cmd.Context) error {
+	value := secrets.NewSecretValue(c.data)
+	id, err := c.ctx.CreateSecret(c.id, value)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(ctx.Stdout, id)
+	return nil
+}

--- a/worker/uniter/runner/jujuc/secret-create_test.go
+++ b/worker/uniter/runner/jujuc/secret-create_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type SecretCreateSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&SecretCreateSuite{})
+
+func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	for _, t := range []struct {
+		args []string
+		err  string
+	}{
+		{
+			args: []string{},
+			err:  "ERROR missing secret id",
+		}, {
+			args: []string{"password", "s3cret", "foo=bar"},
+			err:  `ERROR key value "foo=bar" not valid when a singular value has already been specified`,
+		}, {
+			args: []string{"password", "foo=bar", "s3cret"},
+			err:  `ERROR singular value "s3cret" not valid when other key values are specified`,
+		},
+	} {
+		com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+		c.Assert(err, jc.ErrorIsNil)
+		ctx := cmdtesting.Context(c)
+		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
+
+		c.Assert(code, gc.Equals, 2)
+		c.Assert(bufferString(ctx.Stderr), gc.Equals, t.err+"\n")
+	}
+}
+
+func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"password", "secret"})
+
+	c.Assert(code, gc.Equals, 0)
+	val := coresecrets.NewSecretValue(map[string][]byte{"data": []byte("c2VjcmV0")})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "CreateSecret", Args: []interface{}{"password", val}}})
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret://app.password\n")
+}
+
+func (s *SecretCreateSuite) TestCreateSecretBase64(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--base64", "apikey", "token=key="})
+
+	c.Assert(code, gc.Equals, 0)
+	val := coresecrets.NewSecretValue(map[string][]byte{"token": []byte("key=")})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "CreateSecret", Args: []interface{}{"apikey", val}}})
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret://app.apikey\n")
+}

--- a/worker/uniter/runner/jujuc/secret-get.go
+++ b/worker/uniter/runner/jujuc/secret-get.go
@@ -1,0 +1,108 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+type secretGetCommand struct {
+	cmd.CommandBase
+	ctx Context
+	out cmd.Output
+
+	id       string
+	asBase64 bool
+}
+
+// NewSecretGetCommand returns a command to get a secret value.
+func NewSecretGetCommand(ctx Context) (cmd.Command, error) {
+	return &secretGetCommand{ctx: ctx}, nil
+}
+
+// Info implements cmd.Command.
+func (c *secretGetCommand) Info() *cmd.Info {
+	doc := `
+Get the value of a secret with a given secret ID.
+For secrets with a singular value, the decoded string
+is printed, unless --base64 is specified, in which case
+the encoded base64 value is printed.
+Multiple key value secrets are printed as YAML.
+`
+	return jujucmd.Info(&cmd.Info{
+		Name:    "secret-get",
+		Args:    "<ID>",
+		Purpose: "get the value of a secret",
+		Doc:     doc,
+	})
+}
+
+// SetFlags implements cmd.Command.
+func (c *secretGetCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "plain", map[string]cmd.Formatter{
+		"yaml":  cmd.FormatYaml,
+		"json":  cmd.FormatJson,
+		"plain": printPlainOutput,
+	})
+	f.BoolVar(&c.asBase64, "base64", false,
+		`print the singular secret value as the base64 encoded string`)
+}
+
+func printPlainOutput(writer io.Writer, val interface{}) error {
+	var str string
+	switch v := val.(type) {
+	case string:
+		str = v
+	default:
+		return cmd.FormatYaml(writer, val)
+	}
+	fmt.Fprintf(writer, str)
+	return nil
+}
+
+// Init implements cmd.Command.
+func (c *secretGetCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("missing secret ID")
+	}
+	c.id = args[0]
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run implements cmd.Command.
+func (c *secretGetCommand) Run(ctx *cmd.Context) error {
+	value, err := c.ctx.GetSecret(c.id)
+	if err != nil {
+		return err
+	}
+
+	var val interface{}
+	if c.asBase64 {
+		if value.Singular() {
+			val, _ = value.EncodedValue()
+		} else {
+			val = value.EncodedValues()
+		}
+	} else {
+		if value.Singular() {
+			val, err = value.Value()
+			if err != nil {
+				return err
+			}
+		} else {
+			val, err = value.Values()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return c.out.Write(ctx, val)
+}

--- a/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-get_test.go
@@ -1,0 +1,118 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"encoding/base64"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type SecretGetSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&SecretGetSuite{})
+
+func (s *SecretGetSuite) TestSecretGetSingularString(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string][]byte{
+		"data": []byte(base64.StdEncoding.EncodeToString([]byte("s3cret!"))),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "s3cret!\n")
+}
+
+func (s *SecretGetSuite) TestSecretGetStringJson(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string][]byte{
+		"key": []byte(base64.StdEncoding.EncodeToString([]byte("s3cret!"))),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--format", "json"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `{"key":"s3cret!"}`+"\n")
+}
+
+func (s *SecretGetSuite) TestSecretGetSingularEncoded(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string][]byte{
+		"data": []byte(base64.StdEncoding.EncodeToString([]byte("s3cret!"))),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--base64"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "czNjcmV0IQ==\n")
+}
+
+func (s *SecretGetSuite) TestSecretGet(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string][]byte{
+		"cert": []byte(base64.StdEncoding.EncodeToString([]byte("cert"))),
+		"key":  []byte(base64.StdEncoding.EncodeToString([]byte("key"))),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
+cert: cert
+key: key
+
+`[1:])
+}
+
+func (s *SecretGetSuite) TestSecretGetEncoded(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string][]byte{
+		"cert": []byte(base64.StdEncoding.EncodeToString([]byte("cert"))),
+		"key":  []byte(base64.StdEncoding.EncodeToString([]byte("key"))),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--base64"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
+cert: Y2VydA==
+key: a2V5
+
+`[1:])
+}

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013, 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// The worker/uniter/runner/jujuc package implements the server side of the
+// Package jujuc implements the server side of the
 // jujuc proxy tool, which forwards command invocations to the unit agent
 // process so that they can be executed against specific state.
 package jujuc
@@ -19,10 +19,12 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
+	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/v2/exec"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/sockets"
 )
 
@@ -92,6 +94,11 @@ func constructCommandCreator(name string, newCmd functionCmdCreator) creator {
 	}
 }
 
+var secretCommands = map[string]creator{
+	"secret-create" + cmdSuffix: NewSecretCreateCommand,
+	"secret-get" + cmdSuffix:    NewSecretGetCommand,
+}
+
 var storageCommands = map[string]creator{
 	"storage-add" + cmdSuffix:  NewStorageAddCommand,
 	"storage-get" + cmdSuffix:  NewStorageGetCommand,
@@ -114,6 +121,9 @@ func allEnabledCommands() map[string]creator {
 	add(baseCommands)
 	add(storageCommands)
 	add(leaderCommands)
+	if featureflag.Enabled(feature.Secrets) {
+		add(secretCommands)
+	}
 	add(registeredCommands)
 	return all
 }

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/juju/juju/feature"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
@@ -42,6 +43,7 @@ type ContextSuite struct {
 }
 
 func (s *ContextSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.Secrets)
 	s.ContextSuite.SetUpTest(c)
 	s.BaseSuite.SetUpTest(c)
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/worker/v2/catacomb"
 
 	"github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/api/secrets"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -78,6 +79,7 @@ type RemoteInitFunc func(remotestate.ContainerRunningStatus, <-chan struct{}) er
 type Uniter struct {
 	catacomb                     catacomb.Catacomb
 	st                           *uniter.State
+	secrets                      *secrets.Client
 	paths                        Paths
 	unit                         *uniter.Unit
 	modelType                    model.ModelType
@@ -171,6 +173,7 @@ type Uniter struct {
 // UniterParams hold all the necessary parameters for a new Uniter.
 type UniterParams struct {
 	UniterFacade                  *uniter.State
+	SecretsFacade                 *secrets.Client
 	UnitTag                       names.UnitTag
 	ModelType                     model.ModelType
 	LeadershipTrackerFunc         func(names.UnitTag) leadership.TrackerWorker
@@ -243,6 +246,7 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 	startFunc := func() (worker.Worker, error) {
 		u := &Uniter{
 			st:                            uniterParams.UniterFacade,
+			secrets:                       uniterParams.SecretsFacade,
 			paths:                         NewPaths(uniterParams.DataDir, uniterParams.UnitTag, uniterParams.SocketConfig),
 			modelType:                     uniterParams.ModelType,
 			hookLock:                      uniterParams.MachineLock,
@@ -797,6 +801,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	}
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
 		State:            u.st,
+		Secrets:          u.secrets,
 		Unit:             u.unit,
 		Tracker:          u.leadershipTracker,
 		GetRelationInfos: u.relationStateTracker.GetInfo,


### PR DESCRIPTION
As a first step in implementing secrets, the MVP for create and get secret hook commands are implemented (these will likely evolve a bit but for now provide what's needed to get end-end working). There are wired up as far as the secrets api client - anything further downstream is not yet done. Also still todo is the hook command to grant access to a secret.

A new core/secrets package is added. This initially contains logic to parse a list of arguments into a secrets key value data bag, plus code which encapsulates a secrets value.

Secrets are stored as base64 encoded strings. The hook commands can also create a secret using already base64 encoded data by passing the `--base64` flag. Similarly, secret values are decoded back to strings again when printed, unless `--base64` is used to print out the base64 data.

## QA steps

None yet, just unit tests.

