### PR TITLE
Reduce read contention in Raft FSM

### DIFF
--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -63,7 +63,7 @@ type FSMResponse interface {
 	Notify(NotifyTarget)
 }
 
-// groupKey stores the namespace and model uuid that identifies all of
+// groupKey stores the namespace and model uuid that identifies all
 // the leases for a particular model and lease type.
 type groupKey struct {
 	namespace string
@@ -97,8 +97,8 @@ type FSM struct {
 	// against their key.
 	// This allows different Juju concerns to pin leases, but remove only
 	// their own pins. It is done to avoid restoring normal expiration
-	// to a lease pinned by another concern operating under under the
-	// assumption that the lease holder will not change.
+	// to a lease pinned by another concern operating under the
+	// assumption that the lease-holder will not change.
 	pinned map[lease.Key]set.Strings
 }
 
@@ -121,7 +121,7 @@ func (f *FSM) claim(key lease.Key, holder string, duration time.Duration) *respo
 	entries := f.ensureGroup(key)
 	if entry, found := entries[key]; found {
 		// If the claim is for a lease held by someone else,
-		// indicate it is already held so they should not retry.
+		// indicate it is already held, so they should not retry.
 		if entry.holder != holder {
 			return alreadyHeldResponse()
 		}
@@ -218,8 +218,9 @@ func (f *FSM) setTime(oldTime, newTime time.Time) *response {
 	return &response{expired: f.removeExpired(newTime)}
 }
 
-// expired returns a collection of keys for leases that have expired.
-// Any pinned leases are not included in the return.
+// removeExpired deletes leases that have expired and
+// returns a collection of the deleted lease keys.
+// Pinned leases are not deleted.
 func (f *FSM) removeExpired(newTime time.Time) []lease.Key {
 	var expired []lease.Key
 	for gKey, entries := range f.groups {
@@ -242,7 +243,7 @@ func (f *FSM) GlobalTime() time.Time {
 	return f.globalTime
 }
 
-// Leases gets information about all of the leases in the system,
+// Leases gets information about all the leases in the system,
 // optionally filtered by the input lease keys.
 func (f *FSM) Leases(getLocalTime func() time.Time, keys ...lease.Key) map[lease.Key]lease.Info {
 	if len(keys) > 0 {
@@ -256,8 +257,11 @@ func (f *FSM) Leases(getLocalTime func() time.Time, keys ...lease.Key) map[lease
 // filter list and retrieving from entries will be fastest by far.
 func (f *FSM) filteredLeases(getLocalTime func() time.Time, keys []lease.Key) map[lease.Key]lease.Info {
 	results := make(map[lease.Key]lease.Info)
-	f.mu.RLock()
 	localTime := getLocalTime()
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for _, key := range keys {
 		entries, found := f.getGroup(key)
 		if !found {
@@ -267,20 +271,21 @@ func (f *FSM) filteredLeases(getLocalTime func() time.Time, keys []lease.Key) ma
 			results[key] = f.infoFromEntry(localTime, key, entry)
 		}
 	}
-	f.mu.RUnlock()
 	return results
 }
 
 func (f *FSM) allLeases(getLocalTime func() time.Time) map[lease.Key]lease.Info {
 	results := make(map[lease.Key]lease.Info)
-	f.mu.RLock()
 	localTime := getLocalTime()
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for _, entries := range f.groups {
 		for key, entry := range entries {
 			results[key] = f.infoFromEntry(localTime, key, entry)
 		}
 	}
-	f.mu.RUnlock()
 	return results
 }
 
@@ -308,6 +313,7 @@ func (f *FSM) infoFromEntry(localTime time.Time, key lease.Key, entry *entry) le
 func (f *FSM) LeaseGroup(getLocalTime func() time.Time, namespace, modelUUID string) map[lease.Key]lease.Info {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
+
 	gKey := groupKey{namespace: namespace, modelUUID: modelUUID}
 	entries, found := f.groups[gKey]
 	if !found {
@@ -321,17 +327,19 @@ func (f *FSM) LeaseGroup(getLocalTime func() time.Time, namespace, modelUUID str
 	return results
 }
 
-// Pinned returns all of the currently known lease pins and applications
-// requiring the pinned behaviour.
+// Pinned returns all the currently known lease pins and
+// applications requiring the pinned behaviour.
 func (f *FSM) Pinned() map[lease.Key][]string {
-	f.mu.RLock()
 	pinned := make(map[lease.Key][]string)
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for key, entities := range f.pinned {
 		if !entities.IsEmpty() {
 			pinned[key] = entities.SortedValues()
 		}
 	}
-	f.mu.RUnlock()
 	return pinned
 }
 
@@ -413,9 +421,11 @@ func (f *FSM) Apply(log *raft.Log) interface{} {
 
 // Snapshot is part of raft.FSM.
 func (f *FSM) Snapshot() (raft.FSMSnapshot, error) {
-	f.mu.RLock()
-
 	entries := make(map[SnapshotKey]SnapshotEntry)
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for _, group := range f.groups {
 		for key, entry := range group {
 			entries[SnapshotKey{
@@ -441,8 +451,6 @@ func (f *FSM) Snapshot() (raft.FSMSnapshot, error) {
 			Lease:     key.Lease,
 		}] = entities.SortedValues()
 	}
-
-	f.mu.RUnlock()
 
 	return &Snapshot{
 		Version:    SnapshotVersion,
@@ -501,10 +509,11 @@ func (f *FSM) Restore(reader io.ReadCloser) error {
 	}
 
 	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	f.globalTime = snapshot.GlobalTime
 	f.groups = newGroups
 	f.pinned = newPinned
-	f.mu.Unlock()
 
 	return nil
 }
@@ -554,8 +563,8 @@ type SnapshotEntry struct {
 
 // Command captures the details of an operation to be run on the FSM.
 type Command struct {
-	// Version of the command format, in case it changes and we need
-	// to handle multiple formats.
+	// Version of the command format in case it changes,
+	// and we need to handle multiple formats.
 	Version int `yaml:"version"`
 
 	// Operation is one of claim, extend, expire or setTime.


### PR DESCRIPTION
This is a simple mechanical change to use `sync.RWMutex` instead of `sync.Mutex` in our Raft FSM implementation.

We only need normal locks for mutating; I.e. `Apply` and `Restore`. Everything else is read-lock protected allowing concurrent reads.

## QA steps

Run test suite with `-race` flag.
