### PR TITLE
Apply a floor to the calculated next lease manager tick

### DIFF
--- a/worker/lease/manager_block_test.go
+++ b/worker/lease/manager_block_test.go
@@ -46,7 +46,7 @@ func (s *WaitUntilExpiredSuite) TestLeadershipNoLeaseBlockEvaluatedNextTick(c *g
 
 		// Check that *another* lease expiry causes the unassociated block to
 		// be checked and in the absence of its lease, get unblocked.
-		c.Assert(clock.WaitAdvance(time.Second, testing.ShortWait, 1), jc.ErrorIsNil)
+		c.Assert(clock.WaitAdvance(2*time.Second, testing.ShortWait, 1), jc.ErrorIsNil)
 		err := blockTest.assertUnblocked(c)
 		c.Check(err, jc.ErrorIsNil)
 	})
@@ -66,7 +66,7 @@ func (s *WaitUntilExpiredSuite) TestLeadershipExpires(c *gc.C) {
 		blockTest.assertBlocked(c)
 
 		// Trigger expiry.
-		c.Assert(clock.WaitAdvance(time.Second, testing.ShortWait, 1), jc.ErrorIsNil)
+		c.Assert(clock.WaitAdvance(2*time.Second, testing.ShortWait, 1), jc.ErrorIsNil)
 		err := blockTest.assertUnblocked(c)
 		c.Check(err, jc.ErrorIsNil)
 	})

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -32,7 +32,7 @@ func (s *CrossSuite) testClaims(c *gc.C, lease1, lease2 corelease.Key) {
 			method: "ClaimLease",
 			args: []interface{}{
 				lease1,
-				corelease.Request{"sgt-howie", time.Minute},
+				corelease.Request{Holder: "sgt-howie", Duration: time.Minute},
 			},
 			callback: func(leases map[corelease.Key]corelease.Info) {
 				leases[lease1] = corelease.Info{
@@ -44,7 +44,7 @@ func (s *CrossSuite) testClaims(c *gc.C, lease1, lease2 corelease.Key) {
 			method: "ClaimLease",
 			args: []interface{}{
 				lease2,
-				corelease.Request{"rowan", time.Minute},
+				corelease.Request{Holder: "rowan", Duration: time.Minute},
 			},
 			callback: func(leases map[corelease.Key]corelease.Info) {
 				leases[lease2] = corelease.Info{
@@ -104,7 +104,7 @@ func (s *CrossSuite) testWaits(c *gc.C, lease1, lease2 corelease.Key) {
 		b1.assertBlocked(c)
 		b2.assertBlocked(c)
 
-		clock.Advance(time.Second)
+		clock.Advance(2 * time.Second)
 
 		err := b1.assertUnblocked(c)
 		c.Assert(err, jc.ErrorIsNil)
@@ -210,12 +210,12 @@ func (s *CrossSuite) TestDifferentNamespaceValidation(c *gc.C) {
 type OtherSecretary struct{}
 
 // CheckLease is part of the lease.Secretary interface.
-func (OtherSecretary) CheckLease(key corelease.Key) error {
+func (OtherSecretary) CheckLease(_ corelease.Key) error {
 	return errors.NotValidf("lease name")
 }
 
 // CheckHolder is part of the lease.Secretary interface.
-func (OtherSecretary) CheckHolder(name string) error {
+func (OtherSecretary) CheckHolder(_ string) error {
 	return errors.NotValidf("holder name")
 }
 


### PR DESCRIPTION
If multiple entities fail to renew their lease, and their expiries are less than a second apart, a tick in the lease manager can cause leases to be checked, but no work to be done.

This is because expired leases are only removed from the Raft FSM upon ticks of the global clock updater I.e. at 1 second intervals.

Reading the leases acquires a read lock in the FSM, so we want to minimise accessing them if there might be nothing to do.

Here we simple add a second to any calculated `nextTick` time, ensuring that we reassess blocks no sooner than a second from the last check.

## QA steps

- Bootstrap to LXD.
- `juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE"`.
- `for id in {1..20}; do juju deploy ubuntu "u$id"; done` and wait for quiescence.
- Stop the containers with a 0.5 second pause between (use your model ID for container names): `for id in {0..19}; do lxc stop "juju-034fd1-$id"; sleep 0.5; done`.
- Wait a couple of minutes and run `juju debug-log -m controller --replay | grep 'next expire'`.
- There should be no intervals less than 1s. Lowest should look like this:
```
machine-0: 15:10:42 TRACE juju.worker.lease.raft [dd150c] next expire in 1s 2021-08-12 13:10:43.42272571 +0000 UTC m=+2173.880530472
```

## Documentation changes

None.

## Bug reference

N/A
