### PR TITLE
Force nested lxd containers to be bionic by default in bash tests

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -219,9 +219,19 @@ juju_bootstrap() {
 		esac
 	fi
 
+  # TODO(walllyworld) - remove when we fix the nested lxd and snap/focal issue
+  # Snap doesn't work in nested focal LXD containers.
+  # So we force the model default series to be bionic.
+  model_default_series=
+	case "${BOOTSTRAP_PROVIDER:-}" in
+	"localhost" | "lxd" | "lxd-remote")
+		model_default_series="--model-default default-series=bionic"
+		;;
+	esac
+
 	pre_bootstrap
 
-	command="juju bootstrap ${series} --build-agent=${BUILD_AGENT} ${cloud} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${series} ${model_default_series} --build-agent=${BUILD_AGENT} ${cloud} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"


### PR DESCRIPTION
Nested focal lxd containers cannot run snap due to an apparmor namespace issue.
CI tests are failing because we try and start a focal workload machine when running on LXD.
For now, until we port the test infrastructure to use something like ephemeral nodes, change the default workload series to bionic.

## QA steps

```sh
cd tests
./main smoke
```
