### PR TITLE
Simplify Raft forwarder response topic generation

### DIFF
--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -108,7 +108,7 @@ func (f *FakeEnsureMongo) InitiateMongo(p peergrouper.InitiateMongoParams) error
 	return nil
 }
 
-// agentSuite is a fixture to be used by agent test suites.
+// AgentSuite is a fixture to be used by agent test suites.
 type AgentSuite struct {
 	testing.JujuConnSuite
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -117,7 +117,7 @@ func bootstrapRaft(c *gc.C, dataDir string) {
 	err := raftworker.Bootstrap(raftworker.Config{
 		Clock:      clock.WallClock,
 		StorageDir: filepath.Join(dataDir, "raft"),
-		LocalID:    raft.ServerID("0"),
+		LocalID:    "0",
 		Logger:     loggo.GetLogger("machine_test.raft"),
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -49,11 +49,8 @@ func (s *storeSuite) SetUpTest(c *gc.C) {
 		FSM:      s.fsm,
 		Trapdoor: FakeTrapdoor,
 		Client: raftlease.NewPubsubClient(raftlease.PubsubClientConfig{
-			Hub:          s.hub,
-			RequestTopic: "lease.request",
-			ResponseTopic: func(reqID uint64) string {
-				return fmt.Sprintf("lease.request.%d", reqID)
-			},
+			Hub:            s.hub,
+			RequestTopic:   "lease.request",
 			Clock:          s.clock,
 			ForwardTimeout: time.Second,
 			ClientMetrics:  metrics,

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -10,8 +10,6 @@ package manifold
 // import cycle.
 
 import (
-	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/juju/clock"
@@ -135,19 +133,13 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 
 	st := statePool.SystemState()
 
-	source := rand.NewSource(clock.Now().UnixNano())
-	runID := rand.New(source).Int31()
-
 	metrics := raftlease.NewOperationClientMetrics(clock)
 	s.store = s.config.NewStore(raftlease.StoreConfig{
 		FSM:      s.config.FSM,
 		Trapdoor: st.LeaseTrapdoorFunc(),
 		Client: raftlease.NewPubsubClient(raftlease.PubsubClientConfig{
-			Hub:          hub,
-			RequestTopic: s.config.RequestTopic,
-			ResponseTopic: func(requestID uint64) string {
-				return fmt.Sprintf("%s.%08x.%d", s.config.RequestTopic, runID, requestID)
-			},
+			Hub:            hub,
+			RequestTopic:   s.config.RequestTopic,
 			Clock:          clock,
 			ForwardTimeout: ForwardTimeout,
 			ClientMetrics:  metrics,


### PR DESCRIPTION
There was a race involving the Raft lease client in the `jujud` agent tests.

Here, we resolve the race by simplifying the process of generating a unique response topic for the Raft forwarder. Gone is the random generation of run ID and the atomic request incrementation; instead we just use a UUID.

## QA steps

Run `TestMigratingModelWorkers` from the jujud agent `MachineSuite` with `-race`.

## Documentation changes

None.

## Bug reference

N/A
