### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -101,6 +101,7 @@ var facadeVersions = map[string]int{
 	"ResourcesHookContext":         1,
 	"Resumer":                      2,
 	"RetryStrategy":                1,
+	"SecretsManager":               1,
 	"Singular":                     2,
 	"Spaces":                       6,
 	"SSHClient":                    2,

--- a/api/secretsmanager/client.go
+++ b/api/secretsmanager/client.go
@@ -1,0 +1,80 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsmanager
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/secrets"
+)
+
+// Client is the api client for the Secrets facade.
+type Client struct {
+	facade base.FacadeCaller
+}
+
+// NewClient creates a secrets api client.
+func NewClient(caller base.APICaller) *Client {
+	return &Client{
+		facade: base.NewFacadeCaller(caller, "SecretsManager"),
+	}
+}
+
+// Create creates a new secret.
+func (c *Client) Create(cfg *secrets.SecretConfig, value secrets.SecretValue) (string, error) {
+	if err := cfg.Validate(); err != nil {
+		return "", errors.Trace(err)
+	}
+
+	var data secrets.SecretData
+	if value != nil {
+		data = value.EncodedValues()
+	}
+
+	var results params.StringResults
+
+	if err := c.facade.FacadeCall("CreateSecrets", params.CreateSecretArgs{
+		Args: []params.CreateSecretArg{{
+			Type:   string(cfg.Type),
+			Path:   cfg.Path,
+			Scope:  string(cfg.Scope),
+			Params: cfg.Params,
+			Data:   data,
+		}},
+	}, &results); err != nil {
+		return "", errors.Trace(err)
+	}
+	if n := len(results.Results); n != 1 {
+		return "", errors.Errorf("expected 1 result, got %d", n)
+	}
+	if err := results.Results[0].Error; err != nil {
+		return "", err
+	}
+	return results.Results[0].Result, nil
+}
+
+// GetValue returns the value of a secret.
+func (c *Client) GetValue(ID string) (secrets.SecretValue, error) {
+	//TODO(wallyworld) - validate ID format
+
+	var results params.SecretValueResults
+
+	if err := c.facade.FacadeCall("GetSecretValues", params.GetSecretArgs{
+		Args: []params.GetSecretArg{{
+			ID: ID,
+		}},
+	}, &results); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if n := len(results.Results); n != 1 {
+		return nil, errors.Errorf("expected 1 result, got %d", n)
+	}
+
+	if err := results.Results[0].Error; err != nil {
+		return nil, err
+	}
+	return secrets.NewSecretValue(results.Results[0].Data), nil
+}

--- a/api/secretsmanager/client_test.go
+++ b/api/secretsmanager/client_test.go
@@ -1,0 +1,121 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsmanager_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/secretsmanager"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/core/secrets"
+	coretesting "github.com/juju/juju/testing"
+)
+
+var _ = gc.Suite(&SecretsSuite{})
+
+type SecretsSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *SecretsSuite) TestNewClient(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return nil
+	})
+	client := secretsmanager.NewClient(apiCaller)
+	c.Assert(client, gc.NotNil)
+}
+
+func (s *SecretsSuite) TestCreateSecret(c *gc.C) {
+	data := map[string]string{"foo": "bar"}
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "SecretsManager")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "CreateSecrets")
+		c.Check(arg, gc.DeepEquals, params.CreateSecretArgs{
+			Args: []params.CreateSecretArg{{
+				Type:  "password",
+				Path:  "app.password",
+				Scope: "application",
+				Params: map[string]interface{}{
+					"password-length":        10,
+					"password-special-chars": true,
+				},
+				Data: data,
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
+		*(result.(*params.StringResults)) = params.StringResults{
+			[]params.StringResult{{
+				Result: "secret://foo",
+			}},
+		}
+		return nil
+	})
+	client := secretsmanager.NewClient(apiCaller)
+	value := secrets.NewSecretValue(data)
+	result, err := client.Create(secrets.NewPasswordSecretConfig(10, true, "app", "password"), value)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, "secret://foo")
+}
+
+func (s *SecretsSuite) TestCreateSecretsError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.StringResults)) = params.StringResults{
+			[]params.StringResult{{
+				Error: &params.Error{Message: "boom"},
+			}},
+		}
+		return nil
+	})
+	client := secretsmanager.NewClient(apiCaller)
+	value := secrets.NewSecretValue(nil)
+	result, err := client.Create(secrets.NewSecretConfig("app", "password"), value)
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(result, gc.Equals, "")
+}
+
+func (s *SecretsSuite) TestGetSecret(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "SecretsManager")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "GetSecretValues")
+		c.Check(arg, gc.DeepEquals, params.GetSecretArgs{
+			Args: []params.GetSecretArg{{
+				ID: "secret://foo",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.SecretValueResults{})
+		*(result.(*params.SecretValueResults)) = params.SecretValueResults{
+			[]params.SecretValueResult{{
+				Name: "foo",
+				Data: map[string]string{"foo": "bar"},
+			}},
+		}
+		return nil
+	})
+	client := secretsmanager.NewClient(apiCaller)
+	result, err := client.GetValue("secret://foo")
+	c.Assert(err, jc.ErrorIsNil)
+	value := secrets.NewSecretValue(map[string]string{"foo": "bar"})
+	c.Assert(result, jc.DeepEquals, value)
+}
+
+func (s *SecretsSuite) TestGetSecretsError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.SecretValueResults)) = params.SecretValueResults{
+			[]params.SecretValueResult{{
+				Error: &params.Error{Message: "boom"},
+			}},
+		}
+		return nil
+	})
+	client := secretsmanager.NewClient(apiCaller)
+	result, err := client.GetValue("secret://foo")
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(result, gc.IsNil)
+}

--- a/api/secretsmanager/package_test.go
+++ b/api/secretsmanager/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsmanager_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/reboot"
 	"github.com/juju/juju/apiserver/facades/agent/resourceshookcontext"
 	"github.com/juju/juju/apiserver/facades/agent/retrystrategy"
+	"github.com/juju/juju/apiserver/facades/agent/secretsmanager"
 	"github.com/juju/juju/apiserver/facades/agent/storageprovisioner"
 	"github.com/juju/juju/apiserver/facades/agent/unitassigner"
 	"github.com/juju/juju/apiserver/facades/agent/uniter"
@@ -294,6 +295,7 @@ func AllFacades() *facade.Registry {
 	reg("Resumer", 2, resumer.NewResumerAPI)
 	reg("RetryStrategy", 1, retrystrategy.NewRetryStrategyAPI)
 	reg("Singular", 2, singular.NewExternalFacade)
+	reg("SecretsManager", 1, secretsmanager.NewSecretManagerAPI)
 
 	reg("SSHClient", 1, sshclient.NewFacade)
 	reg("SSHClient", 2, sshclient.NewFacade) // v2 adds AllAddresses() method.

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -98,7 +98,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(c *gc.C) { workertest.CleanKill(c, multiWatcherWorker) })
 
 	machineTag := names.NewMachineTag("0")
-	hub := centralhub.New(machineTag)
+	hub := centralhub.New(machineTag, centralhub.PubsubNoOpMetrics{})
 
 	initialized := gate.NewLock()
 	modelCache, err := modelcache.NewWorker(modelcache.Config{

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsmanager
+
+import (
+	"github.com/juju/errors"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/params"
+)
+
+// SecretsManagerAPI is the backend for the SecretsManager facade.
+type SecretsManagerAPI struct {
+}
+
+// NewSecretManagerAPI creates a SecretsManagerAPI.
+func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
+	if !context.Auth().AuthUnitAgent() {
+		return nil, apiservererrors.ErrPerm
+	}
+	return &SecretsManagerAPI{}, nil
+}
+
+// CreateSecrets creates new secrets.
+func (s *SecretsManagerAPI) CreateSecrets(arg params.CreateSecretArg) (params.StringResults, error) {
+	return params.StringResults{}, apiservererrors.ServerError(errors.NotImplementedf("CreateSecrets"))
+}
+
+// GetSecretValues returns the secret values for the specified secrets.
+func (s *SecretsManagerAPI) GetSecretValues(arg params.GetSecretArgs) (params.SecretValueResults, error) {
+	return params.SecretValueResults{}, apiservererrors.ServerError(errors.NotImplementedf("GetSecretValues"))
+}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39266,6 +39266,203 @@
         }
     },
     {
+        "Name": "SecretsManager",
+        "Description": "SecretsManagerAPI is the backend for the SecretsManager facade.",
+        "Version": 1,
+        "AvailableTo": [
+            "unit-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "CreateSecrets": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CreateSecretArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    },
+                    "description": "CreateSecrets creates new secrets."
+                },
+                "GetSecretValues": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/GetSecretArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretValueResults"
+                        }
+                    },
+                    "description": "GetSecretValues returns the secret values for the specified secrets."
+                }
+            },
+            "definitions": {
+                "CreateSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "path",
+                        "scope"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "GetSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id"
+                    ]
+                },
+                "GetSecretArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GetSecretArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "SecretValueResult": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "data"
+                    ]
+                },
+                "SecretValueResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretValueResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
         "Name": "Singular",
         "Description": "Facade allows controller machines to request exclusive rights to administer\nsome specific model or controller for a limited time.",
         "Version": 2,

--- a/apiserver/params/secrets.go
+++ b/apiserver/params/secrets.go
@@ -1,0 +1,50 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package params
+
+// CreateSecretArgs holds args for creating secrets.
+type CreateSecretArgs struct {
+	Args []CreateSecretArg `json:"args"`
+}
+
+// CreateSecretArg holds the args for creating a secret.
+type CreateSecretArg struct {
+	// Type is "blob" for secrets where the data is passed
+	// in here; "password" is use for where the actual
+	// value is generated server side using arguments
+	// in Params.
+	Type string `json:"type"`
+	// Path represents a unique string used to identify a secret.
+	Path string `json:"path"`
+	// Scope defines the context in which a secret can be used.
+	// eg "application" or "model".
+	Scope string `json:"scope"`
+	// Params are used when generating secrets server side.
+	// See core/secrets/secret.go.
+	Params map[string]interface{} `json:"params,omitempty"`
+	// Data is the key values of the secret value itself.
+	Data map[string]string `json:"data,omitempty"`
+}
+
+// GetSecretArgs holds the args for getting secrets.
+type GetSecretArgs struct {
+	Args []GetSecretArg `json:"args"`
+}
+
+// GetSecretArg holds the args for getting a secret.
+type GetSecretArg struct {
+	ID string `json:"id"`
+}
+
+// SecretValueResults holds secret value results.
+type SecretValueResults struct {
+	Results []SecretValueResult `json:"results"`
+}
+
+// SecretValueResult is the result of getting a secret value.
+type SecretValueResult struct {
+	Name  string            `json:"name"`
+	Data  map[string]string `json:"data"`
+	Error *Error            `json:"error,omitempty"`
+}

--- a/apiserver/testserver/server.go
+++ b/apiserver/testserver/server.go
@@ -37,7 +37,7 @@ func DefaultServerConfig(c *gc.C, testclock clock.Clock) apiserver.ServerConfig 
 		testclock = clock.WallClock
 	}
 	fakeOrigin := names.NewMachineTag("0")
-	hub := centralhub.New(fakeOrigin)
+	hub := centralhub.New(fakeOrigin, centralhub.PubsubNoOpMetrics{})
 	return apiserver.ServerConfig{
 		Clock:               testclock,
 		Tag:                 names.NewMachineTag("0"),

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -10,6 +10,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 )
 
@@ -18,6 +19,11 @@ type HelpToolSuite struct {
 }
 
 var _ = gc.Suite(&HelpToolSuite{})
+
+func (suite *HelpToolSuite) SetUpTest(c *gc.C) {
+	suite.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	setFeatureFlags(feature.Secrets)
+}
 
 func (suite *HelpToolSuite) TestHelpToolHelp(c *gc.C) {
 	output := badrun(c, 0, "help", "help-tool")
@@ -126,6 +132,8 @@ var expectedCommands = []string{
 	"relation-list",
 	"relation-set",
 	"resource-get",
+	"secret-create",
+	"secret-get",
 	"state-delete",
 	"state-get",
 	"state-set",

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -99,7 +99,7 @@ func (f *FakeEnsureMongo) InitiateMongo(p peergrouper.InitiateMongoParams) error
 	return nil
 }
 
-// agentSuite is a fixture to be used by agent test suites.
+// AgentSuite is a fixture to be used by agent test suites.
 type AgentSuite struct {
 	testing.JujuConnSuite
 }

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -119,7 +119,7 @@ func bootstrapRaft(c *gc.C, dataDir string) {
 	err := raftworker.Bootstrap(raftworker.Config{
 		Clock:      clock.WallClock,
 		StorageDir: filepath.Join(dataDir, "raft"),
-		LocalID:    raft.ServerID("0"),
+		LocalID:    "0",
 		Logger:     loggo.GetLogger("machine_test.raft"),
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/raftlease/client.go
+++ b/core/raftlease/client.go
@@ -1,0 +1,169 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftlease
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/pubsub/v2"
+	"github.com/juju/utils/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Client defines the methods for broadcasting a command.
+type Client interface {
+	Request(context.Context, *Command) error
+}
+
+// ClientMetrics represents the metrics during a client request.
+type ClientMetrics interface {
+	RecordOperation(string, string, time.Time)
+}
+
+type PubsubClient struct {
+	hub            *pubsub.StructuredHub
+	requestID      uint64
+	requestTopic   string
+	metrics        ClientMetrics
+	forwardTimeout time.Duration
+	clock          clock.Clock
+}
+
+// PubsubClientConfig holds resources and settings needed to run the
+// PubsubClient.
+type PubsubClientConfig struct {
+	Hub            *pubsub.StructuredHub
+	RequestTopic   string
+	ClientMetrics  ClientMetrics
+	Clock          clock.Clock
+	ForwardTimeout time.Duration
+}
+
+// NewPubsubClient creates a PubSub raftlease client.
+func NewPubsubClient(config PubsubClientConfig) *PubsubClient {
+	return &PubsubClient{
+		hub:            config.Hub,
+		requestTopic:   config.RequestTopic,
+		metrics:        config.ClientMetrics,
+		forwardTimeout: config.ForwardTimeout,
+		clock:          config.Clock,
+	}
+}
+
+func (c *PubsubClient) Request(ctx context.Context, command *Command) error {
+	bytes, err := command.Marshal()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	start := time.Now()
+
+	responseTopic := utils.MustNewUUID().String()
+
+	responseChan := make(chan ForwardResponse)
+	errChan := make(chan error)
+	unsubscribe, err := c.hub.Subscribe(
+		responseTopic,
+		func(_ string, resp ForwardResponse, err error) {
+			if err != nil {
+				errChan <- err
+			} else {
+				responseChan <- resp
+			}
+		},
+	)
+	if err != nil {
+		return errors.Annotatef(err, "running %s", command)
+	}
+	defer unsubscribe()
+
+	delivered, err := c.hub.Publish(c.requestTopic, ForwardRequest{
+		Command:       string(bytes),
+		ResponseTopic: responseTopic,
+	})
+	if err != nil {
+		c.record(command.Operation, "error", start)
+		return errors.Annotatef(err, "publishing %s", command)
+	}
+
+	// First block until subscribers are notified.
+	// In practice, this will be the Raft forwarder running on the leader node.
+	// This is an explicit step so that we can more accurately diagnose issues
+	// in-theatre.
+	select {
+	case <-pubsub.Wait(delivered):
+	case <-c.clock.After(c.forwardTimeout):
+		logger.Warningf("delivery timeout waiting for %s to be processed", command)
+		c.record(command.Operation, "delivery timeout", start)
+		return lease.ErrTimeout
+	}
+
+	// Now wait for the response.
+	// The timeout starts again here, which is deliberate.
+	// It is the same timeout that is used by the Raft forwarder
+	// when `Apply` is called on the FSM.
+	select {
+	case response := <-responseChan:
+		err := RecoverError(response.Error)
+		logger.Tracef("got response, err %v", err)
+		result := "success"
+		if err != nil {
+			logger.Warningf("command %s: %v", command, err)
+			result = "failure"
+		}
+		c.record(command.Operation, result, start)
+		return err
+	case err := <-errChan:
+		logger.Warningf("processing %s: %v", command, err)
+		c.record(command.Operation, "error", start)
+		return errors.Trace(err)
+	case <-ctx.Done():
+		return aborted(command)
+	case <-c.clock.After(c.forwardTimeout):
+		// TODO (thumper) 2019-12-20, bug 1857072
+		// Scale testing hit this a *lot*,
+		// perhaps we need to consider batching messages to run on the leader?
+		logger.Warningf("response timeout waiting for %s to be processed", command)
+		c.record(command.Operation, "response timeout", start)
+		return lease.ErrTimeout
+	}
+}
+
+func (c PubsubClient) record(operation, result string, start time.Time) {
+	c.metrics.RecordOperation(operation, result, start)
+}
+
+type OperationClientMetrics struct {
+	metrics *metricsCollector
+	clock   clock.Clock
+}
+
+func NewOperationClientMetrics(clock clock.Clock) *OperationClientMetrics {
+	return &OperationClientMetrics{
+		metrics: newMetricsCollector(),
+		clock:   clock,
+	}
+}
+
+func (m OperationClientMetrics) RecordOperation(operation, result string, start time.Time) {
+	elapsedMS := float64(m.clock.Now().Sub(start)) / float64(time.Millisecond)
+	m.metrics.requests.With(prometheus.Labels{
+		"operation": operation,
+		"result":    result,
+	}).Observe(elapsedMS)
+}
+
+// Describe is part of prometheus.Collector.
+func (c *OperationClientMetrics) Describe(ch chan<- *prometheus.Desc) {
+	c.metrics.Describe(ch)
+}
+
+// Collect is part of prometheus.Collector.
+func (c *OperationClientMetrics) Collect(ch chan<- prometheus.Metric) {
+	c.metrics.Collect(ch)
+}

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -63,7 +63,7 @@ type FSMResponse interface {
 	Notify(NotifyTarget)
 }
 
-// groupKey stores the namespace and model uuid that identifies all of
+// groupKey stores the namespace and model uuid that identifies all
 // the leases for a particular model and lease type.
 type groupKey struct {
 	namespace string
@@ -88,7 +88,7 @@ func NewFSM() *FSM {
 
 // FSM stores the state of leases in the system.
 type FSM struct {
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	globalTime time.Time
 	groups     map[groupKey]map[lease.Key]*entry
 
@@ -97,8 +97,8 @@ type FSM struct {
 	// against their key.
 	// This allows different Juju concerns to pin leases, but remove only
 	// their own pins. It is done to avoid restoring normal expiration
-	// to a lease pinned by another concern operating under under the
-	// assumption that the lease holder will not change.
+	// to a lease pinned by another concern operating under the
+	// assumption that the lease-holder will not change.
 	pinned map[lease.Key]set.Strings
 }
 
@@ -121,7 +121,7 @@ func (f *FSM) claim(key lease.Key, holder string, duration time.Duration) *respo
 	entries := f.ensureGroup(key)
 	if entry, found := entries[key]; found {
 		// If the claim is for a lease held by someone else,
-		// indicate it is already held so they should not retry.
+		// indicate it is already held, so they should not retry.
 		if entry.holder != holder {
 			return alreadyHeldResponse()
 		}
@@ -218,8 +218,9 @@ func (f *FSM) setTime(oldTime, newTime time.Time) *response {
 	return &response{expired: f.removeExpired(newTime)}
 }
 
-// expired returns a collection of keys for leases that have expired.
-// Any pinned leases are not included in the return.
+// removeExpired deletes leases that have expired and
+// returns a collection of the deleted lease keys.
+// Pinned leases are not deleted.
 func (f *FSM) removeExpired(newTime time.Time) []lease.Key {
 	var expired []lease.Key
 	for gKey, entries := range f.groups {
@@ -242,7 +243,7 @@ func (f *FSM) GlobalTime() time.Time {
 	return f.globalTime
 }
 
-// Leases gets information about all of the leases in the system,
+// Leases gets information about all the leases in the system,
 // optionally filtered by the input lease keys.
 func (f *FSM) Leases(getLocalTime func() time.Time, keys ...lease.Key) map[lease.Key]lease.Info {
 	if len(keys) > 0 {
@@ -256,8 +257,11 @@ func (f *FSM) Leases(getLocalTime func() time.Time, keys ...lease.Key) map[lease
 // filter list and retrieving from entries will be fastest by far.
 func (f *FSM) filteredLeases(getLocalTime func() time.Time, keys []lease.Key) map[lease.Key]lease.Info {
 	results := make(map[lease.Key]lease.Info)
-	f.mu.Lock()
 	localTime := getLocalTime()
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for _, key := range keys {
 		entries, found := f.getGroup(key)
 		if !found {
@@ -267,20 +271,21 @@ func (f *FSM) filteredLeases(getLocalTime func() time.Time, keys []lease.Key) ma
 			results[key] = f.infoFromEntry(localTime, key, entry)
 		}
 	}
-	f.mu.Unlock()
 	return results
 }
 
 func (f *FSM) allLeases(getLocalTime func() time.Time) map[lease.Key]lease.Info {
 	results := make(map[lease.Key]lease.Info)
-	f.mu.Lock()
 	localTime := getLocalTime()
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for _, entries := range f.groups {
 		for key, entry := range entries {
 			results[key] = f.infoFromEntry(localTime, key, entry)
 		}
 	}
-	f.mu.Unlock()
 	return results
 }
 
@@ -306,8 +311,9 @@ func (f *FSM) infoFromEntry(localTime time.Time, key lease.Key, entry *entry) le
 // when there are many models this is more efficient than getting all
 // the leases and filtering by model.
 func (f *FSM) LeaseGroup(getLocalTime func() time.Time, namespace, modelUUID string) map[lease.Key]lease.Info {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	gKey := groupKey{namespace: namespace, modelUUID: modelUUID}
 	entries, found := f.groups[gKey]
 	if !found {
@@ -321,17 +327,19 @@ func (f *FSM) LeaseGroup(getLocalTime func() time.Time, namespace, modelUUID str
 	return results
 }
 
-// Pinned returns all of the currently known lease pins and applications
-// requiring the pinned behaviour.
+// Pinned returns all the currently known lease pins and
+// applications requiring the pinned behaviour.
 func (f *FSM) Pinned() map[lease.Key][]string {
-	f.mu.Lock()
 	pinned := make(map[lease.Key][]string)
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for key, entities := range f.pinned {
 		if !entities.IsEmpty() {
 			pinned[key] = entities.SortedValues()
 		}
 	}
-	f.mu.Unlock()
 	return pinned
 }
 
@@ -413,9 +421,11 @@ func (f *FSM) Apply(log *raft.Log) interface{} {
 
 // Snapshot is part of raft.FSM.
 func (f *FSM) Snapshot() (raft.FSMSnapshot, error) {
-	f.mu.Lock()
-
 	entries := make(map[SnapshotKey]SnapshotEntry)
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
 	for _, group := range f.groups {
 		for key, entry := range group {
 			entries[SnapshotKey{
@@ -441,8 +451,6 @@ func (f *FSM) Snapshot() (raft.FSMSnapshot, error) {
 			Lease:     key.Lease,
 		}] = entities.SortedValues()
 	}
-
-	f.mu.Unlock()
 
 	return &Snapshot{
 		Version:    SnapshotVersion,
@@ -501,10 +509,11 @@ func (f *FSM) Restore(reader io.ReadCloser) error {
 	}
 
 	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	f.globalTime = snapshot.GlobalTime
 	f.groups = newGroups
 	f.pinned = newPinned
-	f.mu.Unlock()
 
 	return nil
 }
@@ -554,8 +563,8 @@ type SnapshotEntry struct {
 
 // Command captures the details of an operation to be run on the FSM.
 type Command struct {
-	// Version of the command format, in case it changes and we need
-	// to handle multiple formats.
+	// Version of the command format in case it changes,
+	// and we need to handle multiple formats.
 	Version int `yaml:"version"`
 
 	// Operation is one of claim, extend, expire or setTime.

--- a/core/raftlease/metrics.go
+++ b/core/raftlease/metrics.go
@@ -11,6 +11,14 @@ const (
 	metricsNamespace = "juju_raftlease"
 )
 
+type MetricsCollector interface {
+	// Describe is part of prometheus.Collector.
+	Describe(ch chan<- *prometheus.Desc)
+
+	// Collect is part of prometheus.Collector.
+	Collect(ch chan<- prometheus.Metric)
+}
+
 // metricsCollector is a prometheus.Collector that collects metrics
 // about lease store operations.
 type metricsCollector struct {

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -4,15 +4,13 @@
 package raftlease
 
 import (
+	"context"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/pubsub/v2"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/core/globalclock"
@@ -77,37 +75,29 @@ type ReadonlyFSM interface {
 
 // StoreConfig holds resources and settings needed to run the Store.
 type StoreConfig struct {
-	FSM           ReadonlyFSM
-	Hub           *pubsub.StructuredHub
-	Trapdoor      TrapdoorFunc
-	RequestTopic  string
-	ResponseTopic func(requestID uint64) string
+	FSM              ReadonlyFSM
+	Client           Client
+	Trapdoor         TrapdoorFunc
+	Clock            clock.Clock
+	MetricsCollector MetricsCollector
+}
 
-	Clock          clock.Clock
-	ForwardTimeout time.Duration
+// Store manages a raft FSM and forwards writes through a pubsub hub.
+type Store struct {
+	fsm     ReadonlyFSM
+	config  StoreConfig
+	metrics MetricsCollector
+	client  Client
 }
 
 // NewStore returns a core/lease.Store that manages leases in Raft.
 func NewStore(config StoreConfig) *Store {
 	return &Store{
-		fsm:      config.FSM,
-		hub:      config.Hub,
-		config:   config,
-		prevTime: config.FSM.GlobalTime(),
-		metrics:  newMetricsCollector(),
+		fsm:     config.FSM,
+		config:  config,
+		client:  config.Client,
+		metrics: config.MetricsCollector,
 	}
-}
-
-// Store manages a raft FSM and forwards writes through a pubsub hub.
-type Store struct {
-	fsm       ReadonlyFSM
-	hub       *pubsub.StructuredHub
-	requestID uint64
-	config    StoreConfig
-	metrics   *metricsCollector
-
-	prevTimeMu sync.Mutex
-	prevTime   time.Time
 }
 
 // ClaimLease is part of lease.Store.
@@ -196,94 +186,26 @@ func (s *Store) pinOp(operation string, key lease.Key, entity string, stop <-cha
 }
 
 func (s *Store) runOnLeader(command *Command, stop <-chan struct{}) error {
-	bytes, err := command.Marshal()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	requestID := atomic.AddUint64(&s.requestID, 1)
-	responseTopic := s.config.ResponseTopic(requestID)
-
-	responseChan := make(chan ForwardResponse)
-	errChan := make(chan error)
-	unsubscribe, err := s.hub.Subscribe(
-		responseTopic,
-		func(_ string, resp ForwardResponse, err error) {
-			if err != nil {
-				errChan <- err
-			} else {
-				responseChan <- resp
-			}
-		},
-	)
-	if err != nil {
-		return errors.Annotatef(err, "running %s", command)
-	}
-	defer unsubscribe()
-
-	start := time.Now()
+	start := s.config.Clock.Now()
 	defer func() {
-		elapsed := time.Since(start)
+		elapsed := s.config.Clock.Now().Sub(start)
 		logger.Tracef("runOnLeader %v, elapsed from publish: %v", command.Operation, elapsed.Round(time.Millisecond))
 	}()
 
-	delivered, err := s.hub.Publish(s.config.RequestTopic, ForwardRequest{
-		Command:       string(bytes),
-		ResponseTopic: responseTopic,
-	})
-	if err != nil {
-		s.record(command.Operation, "error", start)
-		return errors.Annotatef(err, "publishing %s", command)
-	}
+	ch := make(chan struct{})
+	defer close(ch)
 
-	// First block until subscribers are notified.
-	// In practice, this will be the Raft forwarder running on the leader node.
-	// This is an explicit step so that we can more accurately diagnose issues
-	// in-theatre.
-	select {
-	case <-pubsub.Wait(delivered):
-	case <-s.config.Clock.After(s.config.ForwardTimeout):
-		logger.Warningf("delivery timeout waiting for %s to be processed", command)
-		s.record(command.Operation, "delivery timeout", start)
-		return lease.ErrTimeout
-	}
-
-	// Now wait for the response.
-	// The timeout starts again here, which is deliberate.
-	// It is the same timeout that is used by the Raft forwarder
-	// when `Apply` is called on the FSM.
-	select {
-	case response := <-responseChan:
-		err := RecoverError(response.Error)
-		logger.Tracef("got response, err %v", err)
-		result := "success"
-		if err != nil {
-			logger.Warningf("command %s: %v", command, err)
-			result = "failure"
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	go func() {
+		select {
+		case <-stop:
+			cancel()
+		case <-ch:
 		}
-		s.record(command.Operation, result, start)
-		return err
-	case err := <-errChan:
-		logger.Warningf("processing %s: %v", command, err)
-		s.record(command.Operation, "error", start)
-		return errors.Trace(err)
-	case <-stop:
-		return aborted(command)
-	case <-s.config.Clock.After(s.config.ForwardTimeout):
-		// TODO (thumper) 2019-12-20, bug 1857072
-		// Scale testing hit this a *lot*,
-		// perhaps we need to consider batching messages to run on the leader?
-		logger.Warningf("response timeout waiting for %s to be processed", command)
-		s.record(command.Operation, "response timeout", start)
-		return lease.ErrTimeout
-	}
-}
+	}()
 
-func (s *Store) record(operation, result string, start time.Time) {
-	elapsedMS := float64(time.Now().Sub(start)) / float64(time.Millisecond)
-	s.metrics.requests.With(prometheus.Labels{
-		"operation": operation,
-		"result":    result,
-	}).Observe(elapsedMS)
+	return s.client.Request(ctx, command)
 }
 
 // ForwardRequest is a message sent over the hub to the raft forwarder

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -43,16 +43,20 @@ func (s *storeSuite) SetUpTest(c *gc.C) {
 		globalTime: s.clock.Now(),
 	}
 	s.hub = pubsub.NewStructuredHub(nil)
+
+	metrics := raftlease.NewOperationClientMetrics(s.clock)
 	s.store = raftlease.NewStore(raftlease.StoreConfig{
-		FSM:          s.fsm,
-		Hub:          s.hub,
-		Trapdoor:     FakeTrapdoor,
-		RequestTopic: "lease.request",
-		ResponseTopic: func(reqID uint64) string {
-			return fmt.Sprintf("lease.request.%d", reqID)
-		},
-		Clock:          s.clock,
-		ForwardTimeout: time.Second,
+		FSM:      s.fsm,
+		Trapdoor: FakeTrapdoor,
+		Client: raftlease.NewPubsubClient(raftlease.PubsubClientConfig{
+			Hub:            s.hub,
+			RequestTopic:   "lease.request",
+			Clock:          s.clock,
+			ForwardTimeout: time.Second,
+			ClientMetrics:  metrics,
+		}),
+		Clock:            s.clock,
+		MetricsCollector: metrics,
 	})
 }
 

--- a/core/secrets/createsecret.go
+++ b/core/secrets/createsecret.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// SecretData holds secret key values.
+type SecretData map[string]string
+
+// CreatSecretData creates a secret data bag from a list of arguments.
+// The arguments are either all key=value or a singular value.
+// If base64 is true, then the supplied value(s) are already base64 encoded,
+// otherwise the values are base64 encoded as they are added to the data bag.
+func CreatSecretData(asBase64 bool, args []string) (SecretData, error) {
+	data := make(SecretData)
+	haveSingularalue := false
+	for i, val := range args {
+		// Remove any base64 padding ("=") before splitting the key=value.
+		stripped := strings.TrimRight(val, string(base64.StdPadding))
+		idx := strings.Index(stripped, "=")
+		keyVal := []string{val}
+		if idx > 0 {
+			keyVal = []string{
+				val[0:idx],
+				val[idx+1:],
+			}
+		}
+
+		var (
+			key   string
+			value string
+		)
+		if len(keyVal) == 1 {
+			if i > 0 {
+				return nil, errors.NewNotValid(nil, fmt.Sprintf("singular value %q not valid when other key values are specified", val))
+			}
+			key = singularSecretKey
+			value = keyVal[0]
+			haveSingularalue = true
+		} else {
+			key = keyVal[0]
+			value = keyVal[1]
+		}
+		if haveSingularalue && i > 0 {
+			return nil, errors.NewNotValid(nil, fmt.Sprintf("key value %q not valid when a singular value has already been specified", val))
+		}
+		if !asBase64 {
+			value = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v", value)))
+		}
+		data[key] = value
+	}
+	return data, nil
+}

--- a/core/secrets/createsecret_test.go
+++ b/core/secrets/createsecret_test.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+)
+
+type CreateSecretSuite struct {
+	base64Foo []byte
+	base64Bar []byte
+}
+
+var _ = gc.Suite(&CreateSecretSuite{})
+
+func (s *CreateSecretSuite) TestInvalidSingularValue(c *gc.C) {
+	_, err := secrets.CreatSecretData(false, []string{"token", "foo=bar"})
+	c.Assert(err, gc.ErrorMatches, `key value "foo=bar" not valid when a singular value has already been specified`)
+
+	_, err = secrets.CreatSecretData(false, []string{"foo=bar", "token"})
+	c.Assert(err, gc.ErrorMatches, `singular value "token" not valid when other key values are specified`)
+}
+
+func (s *CreateSecretSuite) TestSingularValue(c *gc.C) {
+	data, err := secrets.CreatSecretData(false, []string{"token"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, secrets.SecretData{
+		"data": "dG9rZW4=",
+	})
+}
+
+func (s *CreateSecretSuite) TestSingularValueBase64(c *gc.C) {
+	data, err := secrets.CreatSecretData(true, []string{"key="})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, secrets.SecretData{
+		"data": "key=",
+	})
+}
+
+func (s *CreateSecretSuite) TestValues(c *gc.C) {
+	data, err := secrets.CreatSecretData(false, []string{"foo=bar", "hello=world"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, secrets.SecretData{
+		"foo":   "YmFy",
+		"hello": "d29ybGQ=",
+	})
+}
+
+func (s *CreateSecretSuite) TestValuesBase64(c *gc.C) {
+	data, err := secrets.CreatSecretData(true, []string{"foo=bar", "hello=world"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, secrets.SecretData{
+		"foo":   "bar",
+		"hello": "world",
+	})
+}

--- a/core/secrets/package_test.go
+++ b/core/secrets/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -1,0 +1,88 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// Scope represents the scope of a secret.
+type Scope string
+
+const (
+	ScopeApplication = Scope("application")
+)
+
+var validScopes = map[Scope]bool{
+	ScopeApplication: true,
+}
+
+// SecretType is the type of a secret.
+// This is used when creating a secret.
+type SecretType string
+
+const (
+	TypeBlob     = SecretType("blob")
+	TypePassword = SecretType("password")
+)
+
+var validTypes = map[SecretType]bool{
+	TypeBlob:     true,
+	TypePassword: true,
+}
+
+// SecretConfig is used when cresting a secret.
+type SecretConfig struct {
+	Type   SecretType
+	Path   string
+	Scope  Scope
+	Params map[string]interface{}
+}
+
+// NewSecretConfig is used to create an application scoped blob secret.
+func NewSecretConfig(nameParts ...string) *SecretConfig {
+	return &SecretConfig{
+		Type:  TypeBlob,
+		Scope: ScopeApplication,
+		Path:  strings.Join(nameParts, "."),
+	}
+}
+
+// TODO(wallyworld) - use a schema to describe the config
+const (
+	PasswordLength       = "password-length"
+	PasswordSpecialChars = "password-special-chars"
+)
+
+// NewPasswordSecretConfig is used to create an application scoped password secret.
+func NewPasswordSecretConfig(length int, specialChars bool, nameParts ...string) *SecretConfig {
+	return &SecretConfig{
+		Type:  TypePassword,
+		Scope: ScopeApplication,
+		Path:  strings.Join(nameParts, "."),
+		Params: map[string]interface{}{
+			PasswordLength:       length,
+			PasswordSpecialChars: specialChars,
+		},
+	}
+}
+
+var pathRegexp = regexp.MustCompile(`^[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*$`)
+
+// Validate returns an error if the config is not valid.
+func (c *SecretConfig) Validate() error {
+	if _, ok := validTypes[c.Type]; !ok {
+		return errors.NotValidf("secret type %q", c.Type)
+	}
+	if _, ok := validScopes[c.Scope]; !ok {
+		return errors.NotValidf("secret scope %q", c.Scope)
+	}
+	if !pathRegexp.MatchString(c.Path) {
+		return errors.NotValidf("secret path %q", c.Path)
+	}
+	return nil
+}

--- a/core/secrets/secret_test.go
+++ b/core/secrets/secret_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+)
+
+type SecretConfigSuite struct{}
+
+var _ = gc.Suite(&SecretConfigSuite{})
+
+func (s *SecretConfigSuite) TestNewSecretConfig(c *gc.C) {
+	cfg := secrets.NewSecretConfig("app", "catalog")
+	err := cfg.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, jc.DeepEquals, &secrets.SecretConfig{
+		Type:   secrets.TypeBlob,
+		Path:   "app.catalog",
+		Scope:  secrets.ScopeApplication,
+		Params: nil,
+	})
+}
+
+func (s *SecretConfigSuite) TestNewPasswordSecretConfig(c *gc.C) {
+	cfg := secrets.NewPasswordSecretConfig(10, true, "app", "password")
+	err := cfg.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, jc.DeepEquals, &secrets.SecretConfig{
+		Type:  secrets.TypePassword,
+		Path:  "app.password",
+		Scope: secrets.ScopeApplication,
+		Params: map[string]interface{}{
+			"password-length":        10,
+			"password-special-chars": true,
+		},
+	})
+}
+
+func (s *SecretConfigSuite) TestSecretConfigInvalidScope(c *gc.C) {
+	cfg := secrets.NewPasswordSecretConfig(10, true, "app", "password")
+	cfg.Scope = "foo"
+	err := cfg.Validate()
+	c.Assert(err, gc.ErrorMatches, `secret scope "foo" not valid`)
+}
+
+func (s *SecretConfigSuite) TestSecretConfigInvalidType(c *gc.C) {
+	cfg := secrets.NewPasswordSecretConfig(10, true, "app", "password")
+	cfg.Type = "foo"
+	err := cfg.Validate()
+	c.Assert(err, gc.ErrorMatches, `secret type "foo" not valid`)
+}
+
+func (s *SecretConfigSuite) TestSecretConfigPath(c *gc.C) {
+	cfg := secrets.NewPasswordSecretConfig(10, true, "app", "password")
+	cfg.Path = "foo=bar"
+	err := cfg.Validate()
+	c.Assert(err, gc.ErrorMatches, `secret path "foo=bar" not valid`)
+}

--- a/core/secrets/secretvalue.go
+++ b/core/secrets/secretvalue.go
@@ -1,0 +1,117 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// SecretValue holds the value of a secret.
+// Instances of SecretValue are returned by a secret store
+// when a secret look up is performed. The underlying value
+// is a map of base64 encoded values represented as []byte.
+// Convenience methods exist to retrieve singular decoded string
+// and encoded base64 string values.
+type SecretValue interface {
+	// EncodedValues returns the key values of a secret as
+	// the raw base64 encoded strings.
+	// For the special case where the secret only has a
+	// single key value "data", then use BinaryValue()
+	//to get the result.
+	EncodedValues() map[string]string
+
+	// Values returns the key values of a secret as strings.
+	// For the special case where the secret only has a
+	// single key value "data", then use StringValue()
+	//to get the result.
+	Values() (map[string]string, error)
+
+	// Singular returns true if the secret value represents a
+	// single data value rather than key values.
+	Singular() bool
+
+	// EncodedValue returns the value of the secret as the raw
+	// base64 encoded string.
+	// The secret must be a singular value.
+	EncodedValue() (string, error)
+
+	// Value returns the value of the secret as a string.
+	// The secret must be a singular value.
+	Value() (string, error)
+}
+
+type secretValue struct {
+	// Data holds the key values of a secret.
+	// We use a map to hold multiple values, eg cert and key
+	// The serialised form of any string values is a
+	// base64 encoded string, representing arbitrary values.
+	data map[string][]byte
+}
+
+// NewSecretValue returns a secret using the specified map of values.
+// The map values are assumed to be already base64 encoded.
+func NewSecretValue(data map[string]string) SecretValue {
+	dataCopy := make(map[string][]byte, len(data))
+	for k, v := range data {
+		dataCopy[k] = append([]byte(nil), v...)
+	}
+	return &secretValue{data: dataCopy}
+}
+
+const singularSecretKey = "data"
+
+// EncodedValues implements SecretValue.
+func (v *secretValue) EncodedValues() map[string]string {
+	dataCopy := make(map[string]string, len(v.data))
+	for k, val := range v.data {
+		dataCopy[k] = string(val)
+	}
+	return dataCopy
+}
+
+// Values implements SecretValue.
+func (v *secretValue) Values() (map[string]string, error) {
+	dataCopy := v.EncodedValues()
+	for k, v := range dataCopy {
+		data, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		dataCopy[k] = string(data)
+	}
+	return dataCopy, nil
+}
+
+// Singular implements SecretValue.
+func (v *secretValue) Singular() bool {
+	_, ok := v.data[singularSecretKey]
+	return ok && len(v.data) == 1
+}
+
+// EncodedValue implements SecretValue.
+func (v *secretValue) EncodedValue() (string, error) {
+	if !v.Singular() {
+		return "", errors.NewNotValid(nil, "secret is not a singular value")
+	}
+	return string(v.data[singularSecretKey]), nil
+}
+
+// Value implements SecretValue.
+func (v *secretValue) Value() (string, error) {
+	s, err := v.EncodedValue()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	// The stored value is always base64 encoded.
+	b64 := base64.NewDecoder(base64.StdEncoding, strings.NewReader(s))
+	result, err := ioutil.ReadAll(b64)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return string(result), nil
+}

--- a/core/secrets/secretvalue_test.go
+++ b/core/secrets/secretvalue_test.go
@@ -1,0 +1,75 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	"encoding/base64"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+)
+
+type SecretValueSuite struct{}
+
+var _ = gc.Suite(&SecretValueSuite{})
+
+func (s *SecretValueSuite) TestEncodedValues(c *gc.C) {
+	in := map[string]string{
+		"a": base64.StdEncoding.EncodeToString([]byte("foo")),
+		"b": base64.StdEncoding.EncodeToString([]byte("1")),
+	}
+	val := secrets.NewSecretValue(in)
+
+	c.Assert(val.EncodedValues(), jc.DeepEquals, map[string]string{
+		"a": base64.StdEncoding.EncodeToString([]byte("foo")),
+		"b": base64.StdEncoding.EncodeToString([]byte("1")),
+	})
+
+	c.Assert(val.Singular(), jc.IsFalse)
+	_, err := val.EncodedValue()
+	c.Assert(err, gc.ErrorMatches, "secret is not a singular value")
+}
+
+func (s *SecretValueSuite) TestValues(c *gc.C) {
+	in := map[string]string{
+		"a": base64.StdEncoding.EncodeToString([]byte("foo")),
+		"b": base64.StdEncoding.EncodeToString([]byte("1")),
+	}
+	val := secrets.NewSecretValue(in)
+
+	strValues, err := val.Values()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(strValues, jc.DeepEquals, map[string]string{
+		"a": "foo",
+		"b": "1",
+	})
+
+	_, err = val.Value()
+	c.Assert(err, gc.ErrorMatches, "secret is not a singular value")
+}
+
+func (s *SecretValueSuite) TestSingularValue(c *gc.C) {
+	in := map[string]string{
+		"data": base64.StdEncoding.EncodeToString([]byte("foo")),
+	}
+	val := secrets.NewSecretValue(in)
+
+	sval, err := val.Value()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sval, gc.Equals, "foo")
+}
+
+func (s *SecretValueSuite) TestSingularEncodedValue(c *gc.C) {
+	in := map[string]string{
+		"data": base64.StdEncoding.EncodeToString([]byte("foo")),
+	}
+	val := secrets.NewSecretValue(in)
+	c.Assert(val.Singular(), jc.IsTrue)
+
+	bval, err := val.EncodedValue()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(bval, gc.Equals, in["data"])
+}

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -42,3 +42,6 @@ const RawK8sSpec = "raw-k8s-spec"
 
 // ActionsV2 enables the next generation actions UX.
 const ActionsV2 = "actions-v2"
+
+// Secrets enables the secrets feature.
+const Secrets = "secrets"

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/juju/packaging/v2 v2.0.0-20210628104420-5487e24f1350
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
-	github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289
+	github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 	github.com/juju/replicaset/v2 v2.0.0-20210310024806-bbbdc5f31eb3
 	github.com/juju/retry v0.0.0-20180821225755-9058e192b216

--- a/go.sum
+++ b/go.sum
@@ -495,8 +495,8 @@ github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSw
 github.com/juju/proxy v0.0.0-20180516023828-df38202e4713/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
 github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4 h1:y2eoq0Uof/dWLAXRyKKGOJuF0TEkauPscQI7Q1XQqvM=
 github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
-github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289 h1:JPKuGuO4eDWUstv4puLCAdikIiI4235jYUCiYILjgjI=
-github.com/juju/pubsub/v2 v2.0.0-20210723162818-835a4be34289/go.mod h1:muz5gqZ/u1pTC84e9scTKhEtmvE02wbuK1kvyLzIwQc=
+github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b h1:EwjCZIeRDkUzIM7hFFmq339tBZA5NBXIzOUXM6KR3U8=
+github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b/go.mod h1:+fw+MJGVa006M85prHvwS9pQrCjkkaaH8Ds1wvEMpXQ=
 github.com/juju/qthttptest v0.0.1/go.mod h1://LCf/Ls22/rPw2u1yWukUJvYtfPY4nYpWUl2uZhryo=
 github.com/juju/qthttptest v0.1.1 h1:JPju5P5CDMCy8jmBJV2wGLjDItUsx2KKL514EfOYueM=
 github.com/juju/qthttptest v0.1.1/go.mod h1:aTlAv8TYaflIiTDIQYzxnl1QdPjAg8Q8qJMErpKy6A4=

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -945,7 +945,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			machineTag := names.NewMachineTag("0")
 			estate.httpServer.StartTLS()
 			estate.presence = &fakePresence{make(map[string]presence.Status)}
-			estate.hub = centralhub.New(machineTag)
+			estate.hub = centralhub.New(machineTag, centralhub.PubsubNoOpMetrics{})
 
 			estate.leaseManager, err = leaseManager(
 				icfg.Controller.Config.ControllerUUID(),

--- a/pubsub/centralhub/centralhub.go
+++ b/pubsub/centralhub/centralhub.go
@@ -15,7 +15,7 @@ import (
 // New returns a new structured hub using yaml marshalling with an origin
 // specified. The post processing ensures that the maps all have string keys
 // so they messages can be marshalled between apiservers.
-func New(origin names.Tag) *pubsub.StructuredHub {
+func New(origin names.Tag, metrics pubsub.Metrics) *pubsub.StructuredHub {
 	return pubsub.NewStructuredHub(
 		&pubsub.StructuredHubConfig{
 			Logger:     loggo.GetLogger("juju.centralhub"),
@@ -23,6 +23,7 @@ func New(origin names.Tag) *pubsub.StructuredHub {
 			Annotations: map[string]interface{}{
 				"origin": origin.String(),
 			},
+			Metrics:     metrics,
 			PostProcess: ensureStringMaps,
 		})
 }

--- a/pubsub/centralhub/centralhub_test.go
+++ b/pubsub/centralhub/centralhub_test.go
@@ -28,7 +28,7 @@ func (*CentralHubSuite) waitForSubscribers(c *gc.C, done <-chan struct{}) {
 }
 
 func (s *CentralHubSuite) TestSetsOrigin(c *gc.C) {
-	hub := centralhub.New(names.NewControllerAgentTag("42"))
+	hub := centralhub.New(names.NewControllerAgentTag("42"), centralhub.PubsubNoOpMetrics{})
 	topic := "testing"
 	var called bool
 	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, func(t string, data map[string]interface{}) {
@@ -55,7 +55,7 @@ type IntStruct struct {
 }
 
 func (s *CentralHubSuite) TestYAMLMarshalling(c *gc.C) {
-	hub := centralhub.New(names.NewMachineTag("42"))
+	hub := centralhub.New(names.NewMachineTag("42"), centralhub.PubsubNoOpMetrics{})
 	topic := "testing"
 	var called bool
 	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, func(t string, data map[string]interface{}) {
@@ -87,7 +87,7 @@ func (s *CentralHubSuite) TestPostProcessingMaps(c *gc.C) {
 	// Due to the need to send the resulting maps over the API, nested structs
 	// need to be map[string]interface{} not map[interface{}]interface{},
 	// which is what the YAML marshaller will give us.
-	hub := centralhub.New(names.NewMachineTag("42"))
+	hub := centralhub.New(names.NewMachineTag("42"), centralhub.PubsubNoOpMetrics{})
 	topic := "testing"
 	var called bool
 	unsub, err := hub.SubscribeMatch(pubsub.MatchAll, func(t string, data map[string]interface{}) {

--- a/pubsub/centralhub/metrics.go
+++ b/pubsub/centralhub/metrics.go
@@ -1,0 +1,136 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package centralhub
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "juju"
+	metricsSubsytem  = "pubsub"
+)
+
+// PubsubMetrics implements pubsub.Metrics for gaining information about the
+// current work hub and it's subscribers are undertaking.
+type PubsubMetrics struct {
+	subscriptions prometheus.Gauge
+	published     *prometheus.GaugeVec
+	queue         *prometheus.GaugeVec
+	consumed      *prometheus.SummaryVec
+}
+
+// NewPubsubMetrics creates a new set of pubsub metrics for collecting
+// information about the ongoing work for a given central hub.
+func NewPubsubMetrics() *PubsubMetrics {
+	return &PubsubMetrics{
+		subscriptions: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsytem,
+			Name:      "subscriptions",
+			Help:      "Number of subscriptions on a hub",
+		}),
+		published: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsytem,
+			Name:      "published",
+			Help:      "Number of published message per topic",
+		}, []string{
+			"topic",
+		}),
+		queue: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsytem,
+			Name:      "queue",
+			Help:      "Queue length for a given callback identifier",
+		}, []string{
+			"ident",
+		}),
+		consumed: prometheus.NewSummaryVec(prometheus.SummaryOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsytem,
+			Name:      "consumed",
+			Help:      "Consumed times for a pubsub message",
+			Objectives: map[float64]float64{
+				0.5:  0.05,
+				0.9:  0.01,
+				0.99: 0.001,
+			},
+		}, []string{
+			"ident",
+		}),
+	}
+}
+
+func (m *PubsubMetrics) Subscribed() {
+	m.subscriptions.Inc()
+}
+
+func (m *PubsubMetrics) Unsubscribed() {
+	m.subscriptions.Dec()
+}
+
+var leaseRequestRegex = regexp.MustCompile("lease.request.[0-9a-f]+.[0-9]+")
+
+func (m PubsubMetrics) Published(topic string) {
+	// Pubsub synchronous callback hack needs to be worked around, otherwise
+	// we explode the cardinality of the metrics.
+	if leaseRequestRegex.MatchString(topic) {
+		if index := strings.LastIndex(topic, "."); index > 0 {
+			topic = topic[:index]
+		}
+	}
+
+	m.published.With(prometheus.Labels{
+		"topic": topic,
+	}).Inc()
+}
+
+func (m PubsubMetrics) Enqueued(ident string) {
+	m.queue.With(prometheus.Labels{
+		"ident": ident,
+	}).Inc()
+}
+
+func (m PubsubMetrics) Dequeued(ident string) {
+	m.queue.With(prometheus.Labels{
+		"ident": ident,
+	}).Dec()
+}
+
+func (m PubsubMetrics) Consumed(ident string, duration time.Duration) {
+	elapsedMS := float64(duration) / float64(time.Millisecond)
+	m.consumed.With(prometheus.Labels{
+		"ident": ident,
+	}).Observe(elapsedMS)
+}
+
+// Describe is part of prometheus.Collector.
+func (m PubsubMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.subscriptions.Describe(ch)
+	m.published.Describe(ch)
+	m.queue.Describe(ch)
+	m.consumed.Describe(ch)
+}
+
+// Collect is part of prometheus.Collector.
+func (m PubsubMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.subscriptions.Collect(ch)
+	m.published.Collect(ch)
+	m.queue.Collect(ch)
+	m.consumed.Collect(ch)
+}
+
+type PubsubNoOpMetrics struct{}
+
+func (PubsubNoOpMetrics) Subscribed()                                   {}
+func (PubsubNoOpMetrics) Unsubscribed()                                 {}
+func (PubsubNoOpMetrics) Published(topic string)                        {}
+func (PubsubNoOpMetrics) Enqueued(ident string)                         {}
+func (PubsubNoOpMetrics) Dequeued(ident string)                         {}
+func (PubsubNoOpMetrics) Consumed(ident string, duration time.Duration) {}

--- a/pubsub/centralhub/metrics_test.go
+++ b/pubsub/centralhub/metrics_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package centralhub
+
+import (
+	"github.com/juju/testing"
+	"github.com/prometheus/client_golang/prometheus"
+	gc "gopkg.in/check.v1"
+)
+
+type MetricsSuite struct {
+	testing.IsolationSuite
+	collector prometheus.Collector
+}
+
+var _ = gc.Suite(&MetricsSuite{})
+
+func (s *MetricsSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.collector = NewPubsubMetrics()
+}
+
+func (s *MetricsSuite) TestDescribe(c *gc.C) {
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		defer close(ch)
+		s.collector.Describe(ch)
+	}()
+	var descs []*prometheus.Desc
+	for desc := range ch {
+		descs = append(descs, desc)
+	}
+	c.Assert(descs, gc.HasLen, 4)
+	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_pubsub_subscriptions".*`)
+	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_pubsub_published".*`)
+	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_pubsub_queue".*`)
+	c.Assert(descs[3].String(), gc.Matches, `.*fqName: "juju_pubsub_consumed".*`)
+}
+
+func (s *MetricsSuite) TestCollect(c *gc.C) {
+	ch := make(chan prometheus.Metric)
+	go func() {
+		defer close(ch)
+		s.collector.Collect(ch)
+	}()
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+	c.Assert(metrics, gc.HasLen, 1)
+}

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -219,9 +219,19 @@ juju_bootstrap() {
 		esac
 	fi
 
+  # TODO(walllyworld) - remove when we fix the nested lxd and snap/focal issue
+  # Snap doesn't work in nested focal LXD containers.
+  # So we force the model default series to be bionic.
+  model_default_series=
+	case "${BOOTSTRAP_PROVIDER:-}" in
+	"localhost" | "lxd" | "lxd-remote")
+		model_default_series="--model-default default-series=bionic"
+		;;
+	esac
+
 	pre_bootstrap
 
-	command="juju bootstrap ${series} --build-agent=${BUILD_AGENT} ${cloud} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${series} ${model_default_series} --build-agent=${BUILD_AGENT} ${cloud} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -10,8 +10,6 @@ package manifold
 // import cycle.
 
 import (
-	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/juju/clock"
@@ -135,19 +133,19 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 
 	st := statePool.SystemState()
 
-	source := rand.NewSource(clock.Now().UnixNano())
-	runID := rand.New(source).Int31()
-
+	metrics := raftlease.NewOperationClientMetrics(clock)
 	s.store = s.config.NewStore(raftlease.StoreConfig{
-		FSM:          s.config.FSM,
-		Hub:          hub,
-		Trapdoor:     st.LeaseTrapdoorFunc(),
-		RequestTopic: s.config.RequestTopic,
-		ResponseTopic: func(requestID uint64) string {
-			return fmt.Sprintf("%s.%08x.%d", s.config.RequestTopic, runID, requestID)
-		},
-		Clock:          clock,
-		ForwardTimeout: ForwardTimeout,
+		FSM:      s.config.FSM,
+		Trapdoor: st.LeaseTrapdoorFunc(),
+		Client: raftlease.NewPubsubClient(raftlease.PubsubClientConfig{
+			Hub:            hub,
+			RequestTopic:   s.config.RequestTopic,
+			Clock:          clock,
+			ForwardTimeout: ForwardTimeout,
+			ClientMetrics:  metrics,
+		}),
+		Clock:            clock,
+		MetricsCollector: metrics,
 	})
 
 	controllerUUID := agent.CurrentConfig().Controller().Id()

--- a/worker/lease/manifold/manifold_test.go
+++ b/worker/lease/manifold/manifold_test.go
@@ -149,16 +149,15 @@ func (s *manifoldSuite) TestStart(c *gc.C) {
 	c.Assert(args, gc.HasLen, 1)
 	c.Assert(args[0], gc.FitsTypeOf, raftlease.StoreConfig{})
 	storeConfig := args[0].(raftlease.StoreConfig)
-	c.Assert(storeConfig.ResponseTopic(1234), gc.Matches, "lease.manifold_test.[0-9a-f]{8}.1234")
-	storeConfig.ResponseTopic = nil
+
 	assertTrapdoorFuncsEqual(c, storeConfig.Trapdoor, s.stateTracker.pool.SystemState().LeaseTrapdoorFunc())
 	storeConfig.Trapdoor = nil
+	storeConfig.Client = nil
+	storeConfig.MetricsCollector = nil
+
 	c.Assert(storeConfig, gc.DeepEquals, raftlease.StoreConfig{
-		FSM:            s.fsm,
-		Hub:            s.hub,
-		RequestTopic:   "lease.manifold_test",
-		Clock:          s.clock,
-		ForwardTimeout: 5 * time.Second,
+		FSM:   s.fsm,
+		Clock: s.clock,
 	})
 
 	args = s.stub.Calls()[1].Args

--- a/worker/presence/presence_test.go
+++ b/worker/presence/presence_test.go
@@ -39,7 +39,7 @@ var _ = gc.Suite(&PresenceSuite{})
 
 func (s *PresenceSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.hub = centralhub.New(ourTag)
+	s.hub = centralhub.New(ourTag, centralhub.PubsubNoOpMetrics{})
 	s.clock = testclock.NewClock(time.Time{})
 	s.recorder = corepresence.New(s.clock)
 	s.recorder.Enable()

--- a/worker/pubsub/remoteserver_test.go
+++ b/worker/pubsub/remoteserver_test.go
@@ -44,7 +44,7 @@ func (s *RemoteServerSuite) SetUpTest(c *gc.C) {
 	s.connectionOpener = &fakeConnectionOpener{}
 	tag := names.NewMachineTag("42")
 	s.clock = testclock.NewClock(time.Now())
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.origin = tag.String()
 	s.config = psworker.RemoteServerConfig{
 		Hub:    s.hub,

--- a/worker/pubsub/subscriber_test.go
+++ b/worker/pubsub/subscriber_test.go
@@ -137,7 +137,7 @@ func (s *SubscriberSuite) SetUpTest(c *gc.C) {
 	// loggo.GetLogger("pubsub").SetLogLevel(loggo.TRACE)
 	tag := names.NewMachineTag("42")
 	s.clock = testclock.NewClock(time.Now())
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.origin = tag.String()
 	s.remotes = &fakeRemoteTracker{
 		remotes: make(map[string]*fakeRemote),
@@ -296,7 +296,7 @@ func (s *SubscriberSuite) TestSameMessagesForwardedForMachine(c *gc.C) {
 func (s *SubscriberSuite) TestSameMessagesForwardedForController(c *gc.C) {
 	tag := names.NewControllerAgentTag("42")
 	s.origin = tag.String()
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.config.Origin = s.origin
 	s.config.Hub = s.hub
 	s.config.APIInfo.Tag = tag

--- a/worker/raft/raftbackstop/worker_test.go
+++ b/worker/raft/raftbackstop/worker_test.go
@@ -38,7 +38,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	tag := names.NewMachineTag("23")
 	s.raft = &mockRaft{}
 	s.logStore = &mockLogStore{}
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.config = raftbackstop.Config{
 		Raft:     s.raft,
 		LogStore: s.logStore,

--- a/worker/raft/raftclusterer/worker_test.go
+++ b/worker/raft/raftclusterer/worker_test.go
@@ -31,7 +31,7 @@ type workerFixture struct {
 func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.FSM = &jujuraft.SimpleFSM{}
 	s.RaftFixture.SetUpTest(c)
-	s.hub = centralhub.New(names.NewMachineTag("0"))
+	s.hub = centralhub.New(names.NewMachineTag("0"), centralhub.PubsubNoOpMetrics{})
 	s.config = raftclusterer.Config{
 		Raft: s.Raft,
 		Hub:  s.hub,

--- a/worker/raft/raftforwarder/worker_test.go
+++ b/worker/raft/raftforwarder/worker_test.go
@@ -44,7 +44,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		response: s.response,
 	}}
 	s.target = &fakeTarget{}
-	s.hub = centralhub.New(names.NewMachineTag("17"))
+	s.hub = centralhub.New(names.NewMachineTag("17"), centralhub.PubsubNoOpMetrics{})
 	s.config = raftforwarder.Config{
 		Hub:                  s.hub,
 		Raft:                 s.raft,

--- a/worker/raft/rafttransport/manifold_test.go
+++ b/worker/raft/rafttransport/manifold_test.go
@@ -58,7 +58,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		},
 	}
 	s.auth = &mockAuthenticator{}
-	s.hub = centralhub.New(tag)
+	s.hub = centralhub.New(tag, centralhub.PubsubNoOpMetrics{})
 	s.mux = &apiserverhttp.Mux{}
 	s.stub.ResetCalls()
 	s.worker = &mockTransportWorker{

--- a/worker/raft/rafttransport/worker_test.go
+++ b/worker/raft/rafttransport/worker_test.go
@@ -52,7 +52,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 			Addrs:    []string{"testing.invalid:1234"},
 		},
 		DialConn:      rafttransport.DialConn,
-		Hub:           centralhub.New(tag),
+		Hub:           centralhub.New(tag, centralhub.PubsubNoOpMetrics{}),
 		Mux:           apiserverhttp.NewMux(),
 		Authenticator: &mockAuthenticator{auth: s.auth},
 		Path:          "/raft/path",

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb"
 	"github.com/juju/clock"
@@ -181,7 +181,7 @@ func Bootstrap(config Config) error {
 	// During bootstrap we use an in-memory transport. We just need
 	// to make sure we use the same local address as we'll use later.
 	_, transport := raft.NewInmemTransport(bootstrapAddress)
-	defer transport.Close()
+	defer func() { _ = transport.Close() }()
 	config.Transport = transport
 
 	// During bootstrap, we do not require an FSM.
@@ -267,8 +267,8 @@ func (w *Worker) Raft() (*raft.Raft, error) {
 			return nil, err
 		}
 		return nil, ErrWorkerStopped
-	case raft := <-w.raftCh:
-		return raft, nil
+	case r := <-w.raftCh:
+		return r, nil
 	}
 }
 
@@ -319,7 +319,7 @@ func (w *Worker) loop(raftConfig *raft.Config) (loopErr error) {
 	// StableStore methods, because we aren't giving out a reference
 	// to the StableStore - only the raft instance uses it.
 	logStore := &syncLogStore{store: rawLogStore}
-	defer logStore.Close()
+	defer func() { _ = logStore.Close() }()
 
 	snapshotRetention := w.config.SnapshotRetention
 	if snapshotRetention == 0 {
@@ -399,7 +399,7 @@ func NewRaftConfig(config Config) (*raft.Config, error) {
 	// stops when it's demoted if it's the leader.
 	raftConfig.ShutdownOnRemove = false
 
-	logWriter := &raftutil.LoggoWriter{config.Logger, loggo.DEBUG}
+	logWriter := &raftutil.LoggoWriter{Logger: config.Logger, Level: loggo.DEBUG}
 	raftConfig.Logger = log.New(logWriter, "", 0)
 
 	maybeOverrideDuration := func(d time.Duration, target *time.Duration) {
@@ -417,22 +417,23 @@ func NewRaftConfig(config Config) (*raft.Config, error) {
 	return raftConfig, nil
 }
 
-// SyncMode defines the supported sync modes when writing to the raft log store.
+// SyncMode defines the supported sync modes
+// when writing to the raft log store.
 type SyncMode bool
 
 const (
-	// SyncWrites ensures that an fsync call is performed after each write.
+	// SyncAfterWrite ensures that an fsync call is performed after each write.
 	SyncAfterWrite SyncMode = false
 
-	// NoSyncAfterWrite ensures that no fsync calls are performed between
-	// writes.
+	// NoSyncAfterWrite ensures that no fsync
+	// calls are performed between writes.
 	NoSyncAfterWrite SyncMode = true
 )
 
 // NewLogStore opens a boltDB logstore in the specified directory. If the
 // directory doesn't already exist it'll be created. If the caller passes
-// NonSyncedAfterWrite as the value of the syncMode argument, the underlying store
-// will NOT perform fsync calls between log writes.
+// NonSyncedAfterWrite as the value of the syncMode argument, the underlying
+// store will NOT perform fsync calls between log writes.
 func NewLogStore(dir string, syncMode SyncMode) (*raftboltdb.BoltStore, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, errors.Trace(err)
@@ -458,7 +459,7 @@ func NewSnapshotStore(
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, errors.Trace(err)
 	}
-	logWriter := &raftutil.LoggoWriter{logger, loggo.DEBUG}
+	logWriter := &raftutil.LoggoWriter{Logger: logger, Level: loggo.DEBUG}
 	logLogger := log.New(logWriter, logPrefix, 0)
 
 	snaps, err := raft.NewFileSnapshotStoreWithLogger(dir, retain, logLogger)
@@ -473,7 +474,7 @@ func NewSnapshotStore(
 type BootstrapFSM struct{}
 
 // Apply is part of raft.FSM.
-func (BootstrapFSM) Apply(log *raft.Log) interface{} {
+func (BootstrapFSM) Apply(_ *raft.Log) interface{} {
 	panic("Apply should not be called during bootstrap")
 }
 

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/secretsmanager"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -126,9 +127,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if !ok {
 				return nil, errors.Errorf("expected a unit tag, got %v", tag)
 			}
-			uniterFacade := uniter.NewState(apiConn, unitTag)
 			uniter, err := NewUniter(&UniterParams{
-				UniterFacade:                 uniterFacade,
+				UniterFacade:                 uniter.NewState(apiConn, unitTag),
+				SecretsFacade:                secretsmanager.NewClient(apiConn),
 				UnitTag:                      unitTag,
 				ModelType:                    config.ModelType,
 				LeadershipTrackerFunc:        leadershipTrackerFunc,

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/proxy"
 
 	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/secretsmanager"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
@@ -28,6 +29,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/quota"
+	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/version"
@@ -171,6 +173,9 @@ type HookContext struct {
 	// over fully to API calls on State.  This adds that ability, but we're
 	// not fully there yet.
 	state *uniter.State
+
+	// secretFacade allows the context to access the secrets backend.
+	secretFacade *secretsmanager.Client
 
 	// LeadershipContext supplies several hooks.Context methods.
 	LeadershipContext
@@ -744,7 +749,7 @@ func (ctx *HookContext) OpenedPortRanges() network.GroupedPortRanges {
 	return ctx.portRangeChanges.OpenedUnitPortRanges()
 }
 
-// Config returns the current application configuration of the executing unit.
+// ConfigSettings returns the current application configuration of the executing unit.
 // Implements jujuc.HookContext.ContextUnit, part of runner.Context.
 func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
 	if ctx.configSettings == nil {
@@ -759,6 +764,21 @@ func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
 		result[name] = value
 	}
 	return result, nil
+}
+
+// GetSecret returns the value of the specified secret.
+func (ctx *HookContext) GetSecret(name string) (coresecrets.SecretValue, error) {
+	v, err := ctx.secretFacade.GetValue(name)
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// CreateSecret creates a secret with the specified data.
+func (ctx *HookContext) CreateSecret(name string, value coresecrets.SecretValue) (string, error) {
+	app, _ := names.UnitApplication(ctx.UnitName())
+	return ctx.secretFacade.Create(coresecrets.NewSecretConfig(app, name), value)
 }
 
 // GoalState returns the goal state for the current unit.

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -16,12 +16,14 @@ import (
 	gc "gopkg.in/check.v1"
 
 	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/secretsmanager"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/quota"
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/worker/common/charmrunner"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -850,4 +852,69 @@ func (s *mockHookContextSuite) TestMissingAction(c *gc.C) {
 	context.WithActionContext(hookContext, nil, nil)
 	err := hookContext.Flush("action", charmrunner.NewMissingHookError("noaction"))
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *mockHookContextSuite) TestSecretGet(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "SecretsManager")
+		c.Assert(version, gc.Equals, 0)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "GetSecretValues")
+		c.Assert(arg, gc.DeepEquals, params.GetSecretArgs{
+			Args: []params.GetSecretArg{{
+				ID: "secret://foo",
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.SecretValueResults{})
+		*(result.(*params.SecretValueResults)) = params.SecretValueResults{
+			[]params.SecretValueResult{{
+				Name: "foo",
+				Data: map[string]string{"foo": "bar"},
+			}},
+		}
+		return nil
+	})
+	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
+	client := secretsmanager.NewClient(apiCaller)
+	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
+	value, err := hookContext.GetSecret("secret://foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(value.EncodedValues(), jc.DeepEquals, map[string]string{
+		"foo": "bar",
+	})
+}
+
+func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	value := secrets.NewSecretValue(data)
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "SecretsManager")
+		c.Assert(version, gc.Equals, 0)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "CreateSecrets")
+		c.Check(arg, gc.DeepEquals, params.CreateSecretArgs{
+			Args: []params.CreateSecretArg{{
+				Type:  "blob",
+				Path:  "wordpress.password",
+				Scope: "application",
+				Data:  data,
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
+		*(result.(*params.StringResults)) = params.StringResults{
+			[]params.StringResult{{
+				Result: "secret://foo",
+			}},
+		}
+		return nil
+	})
+	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
+	client := secretsmanager.NewClient(apiCaller)
+	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
+	id, err := hookContext.CreateSecret("password", value)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(id, gc.Equals, "secret://foo")
 }

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/api/secretsmanager"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -67,6 +68,7 @@ type contextFactory struct {
 	// API connection fields; unit should be deprecated, but isn't yet.
 	unit    *uniter.Unit
 	state   *uniter.State
+	secrets *secretsmanager.Client
 	tracker leadership.Tracker
 
 	logger loggo.Logger
@@ -94,6 +96,7 @@ type contextFactory struct {
 // for the context factory.
 type FactoryConfig struct {
 	State            *uniter.State
+	Secrets          *secretsmanager.Client
 	Unit             *uniter.Unit
 	Tracker          leadership.Tracker
 	GetRelationInfos RelationsFunc
@@ -135,6 +138,7 @@ func NewContextFactory(config FactoryConfig) (ContextFactory, error) {
 	f := &contextFactory{
 		unit:             config.Unit,
 		state:            config.State,
+		secrets:          config.Secrets,
 		tracker:          config.Tracker,
 		logger:           config.Logger,
 		paths:            config.Paths,
@@ -169,6 +173,7 @@ func (f *contextFactory) coreContext() (*HookContext, error) {
 	ctx := &HookContext{
 		unit:               f.unit,
 		state:              f.state,
+		secretFacade:       f.secrets,
 		LeadershipContext:  leadershipContext,
 		uuid:               f.modelUUID,
 		modelName:          f.modelName,

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/proxy"
 
+	"github.com/juju/juju/api/secretsmanager"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -102,6 +103,15 @@ func NewMockUnitHookContextWithState(unitName string, mockUnit *mocks.MockHookUn
 		state:            state,
 		logger:           loggo.GetLogger("test"),
 		portRangeChanges: newPortRangeChangeRecorder(names.NewUnitTag(unitName), nil),
+	}
+}
+
+func NewMockUnitHookContextWithSecrets(mockUnit *mocks.MockHookUnit, client *secretsmanager.Client) *HookContext {
+	return &HookContext{
+		unitName:     mockUnit.Tag().Id(),
+		unit:         mockUnit,
+		secretFacade: client,
+		logger:       loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/uniter/runner/context/mocks/hookunit_mock.go
+++ b/worker/uniter/runner/context/mocks/hookunit_mock.go
@@ -5,39 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v9"
 	uniter "github.com/juju/juju/api/uniter"
 	params "github.com/juju/juju/apiserver/params"
 	status "github.com/juju/juju/core/status"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockHookUnit is a mock of HookUnit interface
+// MockHookUnit is a mock of HookUnit interface.
 type MockHookUnit struct {
 	ctrl     *gomock.Controller
 	recorder *MockHookUnitMockRecorder
 }
 
-// MockHookUnitMockRecorder is the mock recorder for MockHookUnit
+// MockHookUnitMockRecorder is the mock recorder for MockHookUnit.
 type MockHookUnitMockRecorder struct {
 	mock *MockHookUnit
 }
 
-// NewMockHookUnit creates a new mock instance
+// NewMockHookUnit creates a new mock instance.
 func NewMockHookUnit(ctrl *gomock.Controller) *MockHookUnit {
 	mock := &MockHookUnit{ctrl: ctrl}
 	mock.recorder = &MockHookUnitMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHookUnit) EXPECT() *MockHookUnitMockRecorder {
 	return m.recorder
 }
 
-// Application mocks base method
+// Application mocks base method.
 func (m *MockHookUnit) Application() (*uniter.Application, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application")
@@ -46,13 +47,13 @@ func (m *MockHookUnit) Application() (*uniter.Application, error) {
 	return ret0, ret1
 }
 
-// Application indicates an expected call of Application
+// Application indicates an expected call of Application.
 func (mr *MockHookUnitMockRecorder) Application() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockHookUnit)(nil).Application))
 }
 
-// ApplicationName mocks base method
+// ApplicationName mocks base method.
 func (m *MockHookUnit) ApplicationName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationName")
@@ -60,13 +61,13 @@ func (m *MockHookUnit) ApplicationName() string {
 	return ret0
 }
 
-// ApplicationName indicates an expected call of ApplicationName
+// ApplicationName indicates an expected call of ApplicationName.
 func (mr *MockHookUnitMockRecorder) ApplicationName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationName", reflect.TypeOf((*MockHookUnit)(nil).ApplicationName))
 }
 
-// CommitHookChanges mocks base method
+// CommitHookChanges mocks base method.
 func (m *MockHookUnit) CommitHookChanges(arg0 params.CommitHookChangesArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommitHookChanges", arg0)
@@ -74,13 +75,13 @@ func (m *MockHookUnit) CommitHookChanges(arg0 params.CommitHookChangesArgs) erro
 	return ret0
 }
 
-// CommitHookChanges indicates an expected call of CommitHookChanges
+// CommitHookChanges indicates an expected call of CommitHookChanges.
 func (mr *MockHookUnitMockRecorder) CommitHookChanges(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHookChanges", reflect.TypeOf((*MockHookUnit)(nil).CommitHookChanges), arg0)
 }
 
-// ConfigSettings mocks base method
+// ConfigSettings mocks base method.
 func (m *MockHookUnit) ConfigSettings() (charm.Settings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfigSettings")
@@ -89,13 +90,13 @@ func (m *MockHookUnit) ConfigSettings() (charm.Settings, error) {
 	return ret0, ret1
 }
 
-// ConfigSettings indicates an expected call of ConfigSettings
+// ConfigSettings indicates an expected call of ConfigSettings.
 func (mr *MockHookUnitMockRecorder) ConfigSettings() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockHookUnit)(nil).ConfigSettings))
 }
 
-// LogActionMessage mocks base method
+// LogActionMessage mocks base method.
 func (m *MockHookUnit) LogActionMessage(arg0 names.ActionTag, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogActionMessage", arg0, arg1)
@@ -103,13 +104,13 @@ func (m *MockHookUnit) LogActionMessage(arg0 names.ActionTag, arg1 string) error
 	return ret0
 }
 
-// LogActionMessage indicates an expected call of LogActionMessage
+// LogActionMessage indicates an expected call of LogActionMessage.
 func (mr *MockHookUnitMockRecorder) LogActionMessage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockHookUnit)(nil).LogActionMessage), arg0, arg1)
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockHookUnit) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -117,13 +118,13 @@ func (m *MockHookUnit) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockHookUnitMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHookUnit)(nil).Name))
 }
 
-// NetworkInfo mocks base method
+// NetworkInfo mocks base method.
 func (m *MockHookUnit) NetworkInfo(arg0 []string, arg1 *int) (map[string]params.NetworkInfoResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1)
@@ -132,13 +133,13 @@ func (m *MockHookUnit) NetworkInfo(arg0 []string, arg1 *int) (map[string]params.
 	return ret0, ret1
 }
 
-// NetworkInfo indicates an expected call of NetworkInfo
+// NetworkInfo indicates an expected call of NetworkInfo.
 func (mr *MockHookUnitMockRecorder) NetworkInfo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockHookUnit)(nil).NetworkInfo), arg0, arg1)
 }
 
-// RequestReboot mocks base method
+// RequestReboot mocks base method.
 func (m *MockHookUnit) RequestReboot() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestReboot")
@@ -146,13 +147,13 @@ func (m *MockHookUnit) RequestReboot() error {
 	return ret0
 }
 
-// RequestReboot indicates an expected call of RequestReboot
+// RequestReboot indicates an expected call of RequestReboot.
 func (mr *MockHookUnitMockRecorder) RequestReboot() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockHookUnit)(nil).RequestReboot))
 }
 
-// SetAgentStatus mocks base method
+// SetAgentStatus mocks base method.
 func (m *MockHookUnit) SetAgentStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAgentStatus", arg0, arg1, arg2)
@@ -160,13 +161,13 @@ func (m *MockHookUnit) SetAgentStatus(arg0 status.Status, arg1 string, arg2 map[
 	return ret0
 }
 
-// SetAgentStatus indicates an expected call of SetAgentStatus
+// SetAgentStatus indicates an expected call of SetAgentStatus.
 func (mr *MockHookUnitMockRecorder) SetAgentStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAgentStatus", reflect.TypeOf((*MockHookUnit)(nil).SetAgentStatus), arg0, arg1, arg2)
 }
 
-// SetUnitStatus mocks base method
+// SetUnitStatus mocks base method.
 func (m *MockHookUnit) SetUnitStatus(arg0 status.Status, arg1 string, arg2 map[string]interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUnitStatus", arg0, arg1, arg2)
@@ -174,13 +175,13 @@ func (m *MockHookUnit) SetUnitStatus(arg0 status.Status, arg1 string, arg2 map[s
 	return ret0
 }
 
-// SetUnitStatus indicates an expected call of SetUnitStatus
+// SetUnitStatus indicates an expected call of SetUnitStatus.
 func (mr *MockHookUnitMockRecorder) SetUnitStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitStatus", reflect.TypeOf((*MockHookUnit)(nil).SetUnitStatus), arg0, arg1, arg2)
 }
 
-// State mocks base method
+// State mocks base method.
 func (m *MockHookUnit) State() (params.UnitStateResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State")
@@ -189,13 +190,13 @@ func (m *MockHookUnit) State() (params.UnitStateResult, error) {
 	return ret0, ret1
 }
 
-// State indicates an expected call of State
+// State indicates an expected call of State.
 func (mr *MockHookUnitMockRecorder) State() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockHookUnit)(nil).State))
 }
 
-// Tag mocks base method
+// Tag mocks base method.
 func (m *MockHookUnit) Tag() names.UnitTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -203,13 +204,13 @@ func (m *MockHookUnit) Tag() names.UnitTag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag
+// Tag indicates an expected call of Tag.
 func (mr *MockHookUnitMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockHookUnit)(nil).Tag))
 }
 
-// UnitStatus mocks base method
+// UnitStatus mocks base method.
 func (m *MockHookUnit) UnitStatus() (params.StatusResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitStatus")
@@ -218,13 +219,13 @@ func (m *MockHookUnit) UnitStatus() (params.StatusResult, error) {
 	return ret0, ret1
 }
 
-// UnitStatus indicates an expected call of UnitStatus
+// UnitStatus indicates an expected call of UnitStatus.
 func (mr *MockHookUnitMockRecorder) UnitStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockHookUnit)(nil).UnitStatus))
 }
 
-// UpdateNetworkInfo mocks base method
+// UpdateNetworkInfo mocks base method.
 func (m *MockHookUnit) UpdateNetworkInfo() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateNetworkInfo")
@@ -232,7 +233,7 @@ func (m *MockHookUnit) UpdateNetworkInfo() error {
 	return ret0
 }
 
-// UpdateNetworkInfo indicates an expected call of UpdateNetworkInfo
+// UpdateNetworkInfo indicates an expected call of UpdateNetworkInfo.
 func (mr *MockHookUnitMockRecorder) UpdateNetworkInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNetworkInfo", reflect.TypeOf((*MockHookUnit)(nil).UpdateNetworkInfo))

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/storage"
 )
 
@@ -46,6 +47,7 @@ type HookContext interface {
 	ContextComponents
 	ContextRelations
 	ContextVersion
+	ContextSecrets
 
 	// GetLogger returns a juju loggo Logger for the supplied module that is
 	// correctly wired up for the given context
@@ -159,6 +161,15 @@ type ContextUnit interface {
 
 	// CloudSpec returns the unit's cloud specification
 	CloudSpec() (*params.CloudSpec, error)
+}
+
+// ContextSecrets is the part of a hook context related to secrets.
+type ContextSecrets interface {
+	// GetSecret returns the value of the specified secret.
+	GetSecret(ID string) (secrets.SecretValue, error)
+
+	// CreateSecret creates a secret with the specified data.
+	CreateSecret(name string, value secrets.SecretValue) (string, error)
 }
 
 // ContextStatus is the part of a hook context related to the unit's status.

--- a/worker/uniter/runner/jujuc/jujuctesting/context.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/context.go
@@ -73,6 +73,7 @@ type Context struct {
 	ContextActionHook
 	ContextVersion
 	ContextWorkloadHook
+	ContextSecrets
 }
 
 // NewContext builds a jujuc.Context test double.
@@ -106,6 +107,7 @@ func NewContext(stub *testing.Stub, info *ContextInfo) *Context {
 	ctx.ContextUnitCharmState.info = &info.UnitCharmState
 	ctx.ContextWorkloadHook.stub = stub
 	ctx.ContextWorkloadHook.info = &info.WorkloadHook
+	ctx.ContextSecrets.stub = stub
 	return &ctx
 }
 

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuctesting
+
+import (
+	"github.com/juju/juju/core/secrets"
+)
+
+// ContextSecrets is a test double for jujuc.ContextSecrets.
+type ContextSecrets struct {
+	contextBase
+
+	SecretValue secrets.SecretValue
+}
+
+// GetSecret implements jujuc.ContextSecrets.
+func (c *ContextSecrets) GetSecret(ID string) (secrets.SecretValue, error) {
+	c.stub.AddCall("GetSecret", ID)
+	return c.SecretValue, nil
+}
+
+// CreateSecret implements jujuc.ContextSecrets.
+func (c *ContextSecrets) CreateSecret(name string, value secrets.SecretValue) (string, error) {
+	c.stub.AddCall("CreateSecret", name, value)
+	return "secret://app." + name, nil
+}

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -13,6 +13,7 @@ import (
 	params "github.com/juju/juju/apiserver/params"
 	application "github.com/juju/juju/core/application"
 	network "github.com/juju/juju/core/network"
+	secrets "github.com/juju/juju/core/secrets"
 	jujuc "github.com/juju/juju/worker/uniter/runner/jujuc"
 	loggo "github.com/juju/loggo"
 	names "github.com/juju/names/v4"
@@ -187,6 +188,21 @@ func (mr *MockContextMockRecorder) ConfigSettings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockContext)(nil).ConfigSettings))
 }
 
+// CreateSecret mocks base method.
+func (m *MockContext) CreateSecret(arg0 string, arg1 secrets.SecretValue) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSecret indicates an expected call of CreateSecret.
+func (mr *MockContextMockRecorder) CreateSecret(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockContext)(nil).CreateSecret), arg0, arg1)
+}
+
 // DeleteCharmStateValue mocks base method.
 func (m *MockContext) DeleteCharmStateValue(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -273,6 +289,21 @@ func (m *MockContext) GetRawK8sSpec() (string, error) {
 func (mr *MockContextMockRecorder) GetRawK8sSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawK8sSpec", reflect.TypeOf((*MockContext)(nil).GetRawK8sSpec))
+}
+
+// GetSecret mocks base method.
+func (m *MockContext) GetSecret(arg0 string) (secrets.SecretValue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecret", arg0)
+	ret0, _ := ret[0].(secrets.SecretValue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecret indicates an expected call of GetSecret.
+func (mr *MockContextMockRecorder) GetSecret(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0)
 }
 
 // GoalState mocks base method.

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/secrets"
 )
 
 // ErrRestrictedContext indicates a method is not implemented in the given context.
@@ -218,5 +219,15 @@ func (*RestrictedContext) SetUnitWorkloadVersion(string) error {
 
 // WorkloadName implements hooks.Context.
 func (*RestrictedContext) WorkloadName() (string, error) {
+	return "", ErrRestrictedContext
+}
+
+// GetSecret implements runner.Context.
+func (ctx *RestrictedContext) GetSecret(ID string) (secrets.SecretValue, error) {
+	return nil, ErrRestrictedContext
+}
+
+// CreateSecret implements runner.Context.
+func (ctx *RestrictedContext) CreateSecret(name string, value secrets.SecretValue) (string, error) {
 	return "", ErrRestrictedContext
 }

--- a/worker/uniter/runner/jujuc/secret-create.go
+++ b/worker/uniter/runner/jujuc/secret-create.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/juju/core/secrets"
+
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+type secretCreateCommand struct {
+	cmd.CommandBase
+	ctx Context
+
+	id       string
+	asBase64 bool
+	data     map[string]string
+}
+
+// NewSecretCreateCommand returns a command to create a secret.
+func NewSecretCreateCommand(ctx Context) (cmd.Command, error) {
+	return &secretCreateCommand{ctx: ctx}, nil
+}
+
+// Info implements cmd.Command.
+func (c *secretCreateCommand) Info() *cmd.Info {
+	doc := `
+Create a secret with either a single value or a list of key values.
+If --base64 is specified, the values are already in base64 format and no
+encoding will be performed, otherwise the values will be base64 encoded
+prior to being stored.
+`
+	return jujucmd.Info(&cmd.Info{
+		Name:    "secret-create",
+		Args:    "<id> [--base64] [value|key=value...]",
+		Purpose: "create a new secret",
+		Doc:     doc,
+	})
+}
+
+// SetFlags implements cmd.Command.
+func (c *secretCreateCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.asBase64, "base64", false,
+		`specify the supplied values are base64 encoded strings`)
+}
+
+// Init implements cmd.Command.
+func (c *secretCreateCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("missing secret id")
+	}
+	if len(args) < 2 {
+		return errors.New("missing secret value")
+	}
+	c.id = args[0]
+
+	var err error
+	c.data, err = secrets.CreatSecretData(c.asBase64, args[1:])
+	return err
+}
+
+// Run implements cmd.Command.
+func (c *secretCreateCommand) Run(ctx *cmd.Context) error {
+	value := secrets.NewSecretValue(c.data)
+	id, err := c.ctx.CreateSecret(c.id, value)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(ctx.Stdout, id)
+	return nil
+}

--- a/worker/uniter/runner/jujuc/secret-create_test.go
+++ b/worker/uniter/runner/jujuc/secret-create_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type SecretCreateSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&SecretCreateSuite{})
+
+func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	for _, t := range []struct {
+		args []string
+		err  string
+	}{
+		{
+			args: []string{},
+			err:  "ERROR missing secret id",
+		}, {
+			args: []string{"password", "s3cret", "foo=bar"},
+			err:  `ERROR key value "foo=bar" not valid when a singular value has already been specified`,
+		}, {
+			args: []string{"password", "foo=bar", "s3cret"},
+			err:  `ERROR singular value "s3cret" not valid when other key values are specified`,
+		},
+	} {
+		com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+		c.Assert(err, jc.ErrorIsNil)
+		ctx := cmdtesting.Context(c)
+		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
+
+		c.Assert(code, gc.Equals, 2)
+		c.Assert(bufferString(ctx.Stderr), gc.Equals, t.err+"\n")
+	}
+}
+
+func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"password", "secret"})
+
+	c.Assert(code, gc.Equals, 0)
+	val := coresecrets.NewSecretValue(map[string]string{"data": "c2VjcmV0"})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "CreateSecret", Args: []interface{}{"password", val}}})
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret://app.password\n")
+}
+
+func (s *SecretCreateSuite) TestCreateSecretBase64(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--base64", "apikey", "token=key="})
+
+	c.Assert(code, gc.Equals, 0)
+	val := coresecrets.NewSecretValue(map[string]string{"token": "key="})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "CreateSecret", Args: []interface{}{"apikey", val}}})
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret://app.apikey\n")
+}

--- a/worker/uniter/runner/jujuc/secret-get.go
+++ b/worker/uniter/runner/jujuc/secret-get.go
@@ -1,0 +1,108 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+type secretGetCommand struct {
+	cmd.CommandBase
+	ctx Context
+	out cmd.Output
+
+	id       string
+	asBase64 bool
+}
+
+// NewSecretGetCommand returns a command to get a secret value.
+func NewSecretGetCommand(ctx Context) (cmd.Command, error) {
+	return &secretGetCommand{ctx: ctx}, nil
+}
+
+// Info implements cmd.Command.
+func (c *secretGetCommand) Info() *cmd.Info {
+	doc := `
+Get the value of a secret with a given secret ID.
+For secrets with a singular value, the decoded string
+is printed, unless --base64 is specified, in which case
+the encoded base64 value is printed.
+Multiple key value secrets are printed as YAML.
+`
+	return jujucmd.Info(&cmd.Info{
+		Name:    "secret-get",
+		Args:    "<ID>",
+		Purpose: "get the value of a secret",
+		Doc:     doc,
+	})
+}
+
+// SetFlags implements cmd.Command.
+func (c *secretGetCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "plain", map[string]cmd.Formatter{
+		"yaml":  cmd.FormatYaml,
+		"json":  cmd.FormatJson,
+		"plain": printPlainOutput,
+	})
+	f.BoolVar(&c.asBase64, "base64", false,
+		`print the singular secret value as the base64 encoded string`)
+}
+
+func printPlainOutput(writer io.Writer, val interface{}) error {
+	var str string
+	switch v := val.(type) {
+	case string:
+		str = v
+	default:
+		return cmd.FormatYaml(writer, val)
+	}
+	fmt.Fprintf(writer, str)
+	return nil
+}
+
+// Init implements cmd.Command.
+func (c *secretGetCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("missing secret ID")
+	}
+	c.id = args[0]
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run implements cmd.Command.
+func (c *secretGetCommand) Run(ctx *cmd.Context) error {
+	value, err := c.ctx.GetSecret(c.id)
+	if err != nil {
+		return err
+	}
+
+	var val interface{}
+	if c.asBase64 {
+		if value.Singular() {
+			val, _ = value.EncodedValue()
+		} else {
+			val = value.EncodedValues()
+		}
+	} else {
+		if value.Singular() {
+			val, err = value.Value()
+			if err != nil {
+				return err
+			}
+		} else {
+			val, err = value.Values()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return c.out.Write(ctx, val)
+}

--- a/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-get_test.go
@@ -1,0 +1,118 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"encoding/base64"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type SecretGetSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&SecretGetSuite{})
+
+func (s *SecretGetSuite) TestSecretGetSingularString(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
+		"data": base64.StdEncoding.EncodeToString([]byte("s3cret!")),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "s3cret!\n")
+}
+
+func (s *SecretGetSuite) TestSecretGetStringJson(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
+		"key": base64.StdEncoding.EncodeToString([]byte("s3cret!")),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--format", "json"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `{"key":"s3cret!"}`+"\n")
+}
+
+func (s *SecretGetSuite) TestSecretGetSingularEncoded(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
+		"data": base64.StdEncoding.EncodeToString([]byte("s3cret!")),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--base64"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "czNjcmV0IQ==\n")
+}
+
+func (s *SecretGetSuite) TestSecretGet(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
+		"cert": base64.StdEncoding.EncodeToString([]byte("cert")),
+		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
+cert: cert
+key: key
+
+`[1:])
+}
+
+func (s *SecretGetSuite) TestSecretGetEncoded(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
+		"cert": base64.StdEncoding.EncodeToString([]byte("cert")),
+		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--base64"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
+cert: Y2VydA==
+key: a2V5
+
+`[1:])
+}

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013, 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// The worker/uniter/runner/jujuc package implements the server side of the
+// Package jujuc implements the server side of the
 // jujuc proxy tool, which forwards command invocations to the unit agent
 // process so that they can be executed against specific state.
 package jujuc
@@ -19,10 +19,12 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
+	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/v2/exec"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/sockets"
 )
 
@@ -92,6 +94,11 @@ func constructCommandCreator(name string, newCmd functionCmdCreator) creator {
 	}
 }
 
+var secretCommands = map[string]creator{
+	"secret-create" + cmdSuffix: NewSecretCreateCommand,
+	"secret-get" + cmdSuffix:    NewSecretGetCommand,
+}
+
 var storageCommands = map[string]creator{
 	"storage-add" + cmdSuffix:  NewStorageAddCommand,
 	"storage-get" + cmdSuffix:  NewStorageGetCommand,
@@ -114,6 +121,9 @@ func allEnabledCommands() map[string]creator {
 	add(baseCommands)
 	add(storageCommands)
 	add(leaderCommands)
+	if featureflag.Enabled(feature.Secrets) {
+		add(secretCommands)
+	}
 	add(registeredCommands)
 	return all
 }

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/juju/juju/feature"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/testing"
@@ -42,6 +43,7 @@ type ContextSuite struct {
 }
 
 func (s *ContextSuite) SetUpTest(c *gc.C) {
+	s.SetInitialFeatureFlags(feature.Secrets)
 	s.ContextSuite.SetUpTest(c)
 	s.BaseSuite.SetUpTest(c)
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/worker/v2/catacomb"
 
 	"github.com/juju/juju/agent/tools"
+	"github.com/juju/juju/api/secretsmanager"
 	"github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/leadership"
@@ -78,6 +79,7 @@ type RemoteInitFunc func(remotestate.ContainerRunningStatus, <-chan struct{}) er
 type Uniter struct {
 	catacomb                     catacomb.Catacomb
 	st                           *uniter.State
+	secrets                      *secretsmanager.Client
 	paths                        Paths
 	unit                         *uniter.Unit
 	modelType                    model.ModelType
@@ -171,6 +173,7 @@ type Uniter struct {
 // UniterParams hold all the necessary parameters for a new Uniter.
 type UniterParams struct {
 	UniterFacade                  *uniter.State
+	SecretsFacade                 *secretsmanager.Client
 	UnitTag                       names.UnitTag
 	ModelType                     model.ModelType
 	LeadershipTrackerFunc         func(names.UnitTag) leadership.TrackerWorker
@@ -243,6 +246,7 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 	startFunc := func() (worker.Worker, error) {
 		u := &Uniter{
 			st:                            uniterParams.UniterFacade,
+			secrets:                       uniterParams.SecretsFacade,
 			paths:                         NewPaths(uniterParams.DataDir, uniterParams.UnitTag, uniterParams.SocketConfig),
 			modelType:                     uniterParams.ModelType,
 			hookLock:                      uniterParams.MachineLock,
@@ -797,6 +801,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 	}
 	contextFactory, err := context.NewContextFactory(context.FactoryConfig{
 		State:            u.st,
+		Secrets:          u.secrets,
 		Unit:             u.unit,
 		Tracker:          u.leadershipTracker,
 		GetRelationInfos: u.relationStateTracker.GetInfo,


### PR DESCRIPTION
Merge from 2.9 bringing forward:
- #13243 from manadart/2.9-lease-forwarder-respose-topic
- #13241 from wallyworld/lxd-test-workaround
- #13237 from wallyworld/secrets-api-client
- #13234 from wallyworld/secrets-hook-commands
- #13236 from jujubot/increment-to-2.9.12
- #13232 from manadart/2.9-lease-manager-unblock
- #13235 from manadart/2.9-raft-fsm-locking
- #13228 from SimonRichardson/pubsub-metrics
- #13223 from SimonRichardson/2.9-lease-client-abstraction

No substantive conflicts.