### PR TITLE
Create a channel in a more permissive manner

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1947,11 +1947,7 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 
 	var channel charm.Channel
 	if origin.Channel != nil {
-		var err error
-		channel, err = charm.MakeChannel(origin.Channel.Track, origin.Channel.Risk, origin.Channel.Branch)
-		if err != nil {
-			return description.CharmOriginArgs{}, errors.Trace(err)
-		}
+		channel = charm.MakePermissiveChannel(origin.Channel.Track, origin.Channel.Risk, origin.Channel.Branch)
 	}
 	var platform corecharm.Platform
 	if origin.Platform != nil {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3641,3 +3641,63 @@ func TransformEmptyManifestsToNil(pool *StatePool) error {
 		return nil
 	}))
 }
+
+func EnsureCharmOriginRisk(pool *StatePool) error {
+	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
+		col, closer := st.db().GetCollection(applicationsC)
+		defer closer()
+
+		var docs []applicationDoc
+		if err := col.Find(nil).All(&docs); err != nil {
+			return errors.Trace(err)
+		}
+
+		var ops []txn.Op
+		for _, doc := range docs {
+			// This should never happen, instead we should always have one.
+			// See: AddCharmOriginToApplications
+			if doc.CharmOrigin == nil {
+				continue
+			}
+
+			// If the "cs-channel" is empty, then we want to ensure that the
+			// channel isn't just empty, but also set to something useful.
+			channel := doc.Channel
+			if channel == "" {
+				channel = "stable"
+			}
+
+			var originChannel *Channel
+			if doc.CharmOrigin.Channel == nil {
+				originChannel = &Channel{
+					Risk: channel,
+				}
+			} else if doc.CharmOrigin.Channel.Risk == "" {
+				originChannel = &Channel{
+					Risk:   channel,
+					Track:  doc.CharmOrigin.Channel.Track,
+					Branch: doc.CharmOrigin.Channel.Branch,
+				}
+			}
+			// Nothing to do, we have a valid channel.
+			if originChannel == nil {
+				continue
+			}
+
+			ops = append(ops, txn.Op{
+				C:      applicationsC,
+				Id:     doc.DocID,
+				Assert: txn.DocExists,
+				Update: bson.D{{
+					"$set", bson.D{{
+						"charm-origin.channel", originChannel,
+					}},
+				}},
+			})
+		}
+		if len(ops) > 0 {
+			return errors.Trace(st.db().RunTransaction(ops))
+		}
+		return nil
+	}))
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5410,6 +5410,211 @@ func (s *upgradesSuite) TestTransformEmptyManifestsToNil(c *gc.C) {
 	)
 }
 
+func (s *upgradesSuite) TestEnsureCharmOriginRisk(c *gc.C) {
+	model1 := s.makeModel(c, "model-1", coretesting.Attrs{})
+	model2 := s.makeModel(c, "model-2", coretesting.Attrs{})
+	defer func() {
+		_ = model1.Close()
+		_ = model2.Close()
+	}()
+
+	uuid1 := model1.ModelUUID()
+	uuid2 := model2.ModelUUID()
+
+	appColl, appCloser := s.state.db().GetRawCollection(applicationsC)
+	defer appCloser()
+
+	var err error
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid1, "app1"),
+		"name":       "app1",
+		"model-uuid": uuid1,
+		"charmurl":   charm.MustParseURL("cs:test").String(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid1, "app2"),
+		"name":       "app2",
+		"model-uuid": uuid1,
+		"charmurl":   charm.MustParseURL("local:test").String(),
+		"charm-origin": bson.M{
+			"source":   "local",
+			"type":     "charm",
+			"revision": 12,
+			"channel": bson.M{
+				"track": "latest",
+				"risk":  "edge",
+			},
+			"platform": bson.M{
+				"architecture": "amd64",
+				"series":       "focal",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid2, "app3"),
+		"name":       "app3",
+		"model-uuid": uuid2,
+		"charmurl":   charm.MustParseURL("local:test2").String(),
+		"charm-origin": bson.M{
+			"source":   "local",
+			"type":     "charm",
+			"id":       "local:test",
+			"hash":     "",
+			"revision": -1,
+			"channel": bson.M{
+				"track": "latest",
+				"risk":  "",
+			},
+			"platform": bson.M{
+				"architecture": "amd64",
+				"series":       "focal",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid2, "app4"),
+		"name":       "app4",
+		"model-uuid": uuid2,
+		"charmurl":   charm.MustParseURL("cs:focal/test-13").String(),
+		"cs-channel": "edge",
+		"charm-origin": bson.M{
+			"source":   "charm-store",
+			"type":     "charm",
+			"revision": 12,
+			"channel": bson.M{
+				"track": "latest",
+				"risk":  "",
+			},
+			"platform": bson.M{
+				"architecture": "amd64",
+				"series":       "focal",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid2, "app5"),
+		"name":       "app5",
+		"model-uuid": uuid2,
+		"charmurl":   charm.MustParseURL("ch:amd64/focal/test").String(),
+		"charm-origin": bson.M{
+			"source":   "charm-hub",
+			"type":     "charm",
+			"id":       "yyyy",
+			"hash":     "xxxx",
+			"revision": 12,
+			"channel": bson.M{
+				"track": "latest",
+				"risk":  "",
+			},
+			"platform": bson.M{
+				"architecture": "amd64",
+				"series":       "focal",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := bsonMById{
+		{
+			"_id":        ensureModelUUID(uuid1, "app1"),
+			"model-uuid": uuid1,
+			"name":       "app1",
+			"charmurl":   "cs:test",
+		},
+		{
+			"_id":        ensureModelUUID(uuid1, "app2"),
+			"model-uuid": uuid1,
+			"name":       "app2",
+			"charmurl":   "local:test",
+			"charm-origin": bson.M{
+				"source":   "local",
+				"type":     "charm",
+				"revision": 12,
+				"channel": bson.M{
+					"track": "latest",
+					"risk":  "edge",
+				},
+				"platform": bson.M{
+					"architecture": "amd64",
+					"series":       "focal",
+				},
+			},
+		},
+		{
+			"_id":        ensureModelUUID(uuid2, "app3"),
+			"model-uuid": uuid2,
+			"name":       "app3",
+			"charmurl":   "local:test2",
+			"charm-origin": bson.M{
+				"source":   "local",
+				"type":     "charm",
+				"id":       "local:test",
+				"hash":     "",
+				"revision": -1,
+				"channel": bson.M{
+					"track": "latest",
+					"risk":  "stable",
+				},
+				"platform": bson.M{
+					"architecture": "amd64",
+					"series":       "focal",
+				},
+			},
+		},
+		{
+			"_id":        ensureModelUUID(uuid2, "app4"),
+			"model-uuid": uuid2,
+			"name":       "app4",
+			"charmurl":   "cs:focal/test-13",
+			"cs-channel": "edge",
+			"charm-origin": bson.M{
+				"source":   "charm-store",
+				"type":     "charm",
+				"revision": 12,
+				"channel": bson.M{
+					"track": "latest",
+					"risk":  "edge",
+				},
+				"platform": bson.M{
+					"architecture": "amd64",
+					"series":       "focal",
+				},
+			},
+		},
+		{
+			"_id":        ensureModelUUID(uuid2, "app5"),
+			"model-uuid": uuid2,
+			"name":       "app5",
+			"charmurl":   "ch:amd64/focal/test",
+			"charm-origin": bson.M{
+				"source":   "charm-hub",
+				"type":     "charm",
+				"revision": 12,
+				"hash":     "xxxx",
+				"id":       "yyyy",
+				"channel": bson.M{
+					"track": "latest",
+					"risk":  "stable",
+				},
+				"platform": bson.M{
+					"architecture": "amd64",
+					"series":       "focal",
+				},
+			},
+		},
+	}
+
+	sort.Sort(expected)
+	s.assertUpgradedData(c, EnsureCharmOriginRisk,
+		upgradedData(appColl, expected),
+	)
+}
+
 type docById []bson.M
 
 func (d docById) Len() int           { return len(d) }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -96,6 +96,7 @@ type StateBackend interface {
 	KubernetesInClusterCredentialSpec() (environscloudspec.CloudSpec, *config.Config, string, error)
 	AddSpawnedTaskCountToOperations() error
 	TransformEmptyManifestsToNil() error
+	EnsureCharmOriginRisk() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -412,4 +413,8 @@ func (s stateBackend) AddSpawnedTaskCountToOperations() error {
 
 func (s stateBackend) TransformEmptyManifestsToNil() error {
 	return state.TransformEmptyManifestsToNil(s.pool)
+}
+
+func (s stateBackend) EnsureCharmOriginRisk() error {
+	return state.EnsureCharmOriginRisk(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -50,6 +50,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.6"), stateStepsFor296()},
 		upgradeToVersion{version.MustParse("2.9.9"), stateStepsFor299()},
 		upgradeToVersion{version.MustParse("2.9.10"), stateStepsFor2910()},
+		upgradeToVersion{version.MustParse("2.9.12"), stateStepsFor2912()},
 	}
 	return steps
 }

--- a/upgrades/steps_2912.go
+++ b/upgrades/steps_2912.go
@@ -1,0 +1,17 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2912 returns upgrade steps for juju 2.9.12
+func stateStepsFor2912() []Step {
+	return []Step{
+		&upgradeStep{
+			description: `ensure correct charm-origin risk`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().EnsureCharmOriginRisk()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2912_test.go
+++ b/upgrades/steps_2912_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2912 = version.MustParse("2.9.12")
+
+type steps2912Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2912Suite{})
+
+func (s *steps2912Suite) TestTransformEmptyManifestsToNil(c *gc.C) {
+	step := findStateStep(c, v2912, `ensure correct charm-origin risk`)
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -640,6 +640,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.6",
 		"2.9.9",
 		"2.9.10",
+		"2.9.12",
 	})
 }
 


### PR DESCRIPTION
The following allows migrations and exporting of bundles in a more
permissive manner. In that, they allow you to create a channel without a
risk. This risk is then set to stable once we normalise it at a later
stage, which ensures we always have the right value.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju  deploy cs:ubuntu  ubuntua
$ juju deploy cs:ubuntu  ubuntub
$ juju deploy cs:ubuntu  ubuntuc
$ juju mongo
# Replace $MODEL_ID with your model id.
$ db.applications.updateOne({_id:"$MODEL_ID:ubuntuc"}, {$set:{"charm-origin.channel.risk":""}})
$ exit
$ juju export-bundle
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1939601
