### PR TITLE
Use system state to construct StateControllerConfig for remote relations

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -171,7 +171,7 @@ func (api *CrossModelRelationsAPI) PublishRelationChanges(
 	return results, nil
 }
 
-// RegisterRemoteRelationArgs sets up the model to participate
+// RegisterRemoteRelations sets up the model to participate
 // in the specified relations. This operation is idempotent.
 func (api *CrossModelRelationsAPI) RegisterRemoteRelations(
 	relations params.RegisterRemoteRelationArgs,

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -31,7 +31,7 @@ type API struct {
 	authorizer facade.Authorizer
 }
 
-// NewAPI creates a new server-side API facade backed by global state.
+// NewAPIv1 creates a new server-side API facade backed by global state.
 func NewAPIv1(ctx facade.Context) (*APIv1, error) {
 	api, err := NewAPI(ctx)
 	if err != nil {
@@ -44,7 +44,7 @@ func NewAPIv1(ctx facade.Context) (*APIv1, error) {
 func NewAPI(ctx facade.Context) (*API, error) {
 	return NewRemoteRelationsAPI(
 		stateShim{st: ctx.State(), Backend: commoncrossmodel.GetBackend(ctx.State())},
-		common.NewStateControllerConfig(ctx.State()),
+		common.NewStateControllerConfig(ctx.StatePool().SystemState()),
 		ctx.Resources(), ctx.Auth(),
 	)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -21187,7 +21187,7 @@
                             "$ref": "#/definitions/RegisterRemoteRelationResults"
                         }
                     },
-                    "description": "RegisterRemoteRelationArgs sets up the model to participate\nin the specified relations. This operation is idempotent."
+                    "description": "RegisterRemoteRelations sets up the model to participate\nin the specified relations. This operation is idempotent."
                 },
                 "WatchEgressAddressesForRelations": {
                     "type": "object",

--- a/state/interface.go
+++ b/state/interface.go
@@ -113,7 +113,7 @@ type UnitsWatcher interface {
 	WatchUnits() StringsWatcher
 }
 
-// ModelMachinesWatcher defines a the methods required for listening to
+// ModelMachinesWatcher defines the methods required for listening to
 // machine lifecycle events or a combination of lifecycle events and changes
 // to the agent start time field.
 // WatchModelMachines.

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -28,7 +28,7 @@ import (
 type remoteApplicationWorker struct {
 	catacomb catacomb.Catacomb
 
-	// These attribute are relevant to dealing with a specific
+	// These attributes are relevant to dealing with a specific
 	// remote application proxy.
 	offerUUID             string
 	applicationName       string // name of the remote application proxy in the local model
@@ -135,7 +135,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 		if err := w.newRemoteRelationsFacadeWithRedirect(); err != nil {
 			return errors.Trace(err)
 		}
-		defer func() { w.remoteModelFacade.Close() }()
+		defer func() { _ = w.remoteModelFacade.Close() }()
 
 		arg := params.OfferArg{
 			OfferUUID: w.offerUUID,

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -48,7 +48,7 @@ type RemoteModelRelationsFacade interface {
 	// model hosting the remote application involved in the relation.
 	PublishRelationChange(params.RemoteRelationChangeEvent) error
 
-	// WatchRelationUnits returns a watcher that notifies of changes
+	// WatchRelationChanges returns a watcher that notifies of changes
 	// to the units in the remote model for the relation with the
 	// given remote token. We need to pass the application token for
 	// the case where we're talking to a v1 API and the client needs


### PR DESCRIPTION
When we watch a remote offer, we need to obtain the API info for the remote controller. To do this, we send the info of the offer that we are watching, which includes the source model.

This model is then passed to `ControllerAccessor.ControllerInfo`, which determines where the model is hosted, and returns the API info for that controller.

A bug is manifest when the offer is:
- made from a model running on a CAAS controller and;
- consumed by another model running on the _same_ controller.

Because we instantiate `ControllerConfigAPI` with the hosting model state in the `remoterelations` API, we get an error because `APIHostPorts` can only be called on the system state for CAAS models.

The solution is to construct `ControllerConfigAPI` with model's _controller_ state.

## QA steps

- `make microk8s-operator-update`
- `juju bootstrap microk8s mk8s --no-gui`
- `juju add-model lma`
- `juju deploy lma-light --channel=edge`
- `juju offer prometheus:monitoring`
- `juju add-model prod`
- `juju consume admin/lma.prometheus`
- `juju status` should then show the prometheus SAAS, and log should be error free.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1940298
