### PR TITLE
2.9 proxy issue 4

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -1257,7 +1257,7 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 		`export HTTP_PROXY=http://user@10.0.0.1`,
 		`export no_proxy=0.1.2.3,10.0.3.1,localhost`,
 		`export NO_PROXY=0.1.2.3,10.0.3.1,localhost`,
-                ``,
+		``,
 		`(printf '%s\n' 'export http_proxy=http://user@10.0.0.1
 export HTTP_PROXY=http://user@10.0.0.1
 export no_proxy=0.1.2.3,10.0.3.1,localhost

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -1257,10 +1257,12 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 		`export HTTP_PROXY=http://user@10.0.0.1`,
 		`export no_proxy=0.1.2.3,10.0.3.1,localhost`,
 		`export NO_PROXY=0.1.2.3,10.0.3.1,localhost`,
+                ``,
 		`(printf '%s\n' 'export http_proxy=http://user@10.0.0.1
 export HTTP_PROXY=http://user@10.0.0.1
 export no_proxy=0.1.2.3,10.0.3.1,localhost
-export NO_PROXY=0.1.2.3,10.0.3.1,localhost' > /etc/juju-proxy.conf && chmod 0644 /etc/juju-proxy.conf)`,
+export NO_PROXY=0.1.2.3,10.0.3.1,localhost
+' > /etc/juju-proxy.conf && chmod 0644 /etc/juju-proxy.conf)`,
 		`printf '%s\n' '# To allow juju to control the global systemd proxy settings,
 # create symbolic links to this file from within /etc/systemd/system.conf.d/
 # and /etc/systemd/users.conf.d/.
@@ -1271,7 +1273,7 @@ DefaultEnvironment="http_proxy=http://user@10.0.0.1" "HTTP_PROXY=http://user@10.
 	found := false
 	for i, cmd := range cmds {
 		if cmd == first {
-			c.Assert(cmds[i+1:i+7], jc.DeepEquals, expected)
+			c.Assert(cmds[i+1:i+8], jc.DeepEquals, expected)
 			found = true
 			break
 		}

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/juju/os/v2 v2.1.2
 	github.com/juju/packaging/v2 v2.0.0-20210628104420-5487e24f1350
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
-	github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4
+	github.com/juju/proxy v0.0.0-20210817195502-c6015cfe0258
 	github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 	github.com/juju/replicaset v0.0.0-20210302050932-0303c8575745

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,8 @@ github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93/go.mod h1:zrbmo4nBKaiP/Ez3F67ewkMbzGYfXyMvRtbOfuAwG0w=
 github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSwAjh/uLXDM=
 github.com/juju/proxy v0.0.0-20180516023828-df38202e4713/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
-github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4 h1:y2eoq0Uof/dWLAXRyKKGOJuF0TEkauPscQI7Q1XQqvM=
-github.com/juju/proxy v0.0.0-20180523025733-5f8741c297b4/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
+github.com/juju/proxy v0.0.0-20210817195502-c6015cfe0258 h1:oQ4i531nGh54FPEkAA5j1rbXPANQjUw84FM9O7EsNOo=
+github.com/juju/proxy v0.0.0-20210817195502-c6015cfe0258/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
 github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b h1:EwjCZIeRDkUzIM7hFFmq339tBZA5NBXIzOUXM6KR3U8=
 github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b/go.mod h1:+fw+MJGVa006M85prHvwS9pQrCjkkaaH8Ds1wvEMpXQ=
 github.com/juju/qthttptest v0.0.1/go.mod h1://LCf/Ls22/rPw2u1yWukUJvYtfPY4nYpWUl2uZhryo=


### PR DESCRIPTION
Update to the new change from stgraber.

proxy: Add trailing newline to AsScriptEnvironment

This makes /etc/juju-proxy.conf be a properly formatted shell script
with a trailing new line (makes it easier to read).

## QA steps

When using a proxy in the environment, see that /etc/proxy.conf now contains a trailing newline.

```sh
$ juju bootstrap --config ftp-proxy=https://test.invalid
```

## Documentation changes

None

## Bug reference

None