### PR TITLE
Secret get attribute

### DIFF
--- a/api/secrets/client.go
+++ b/api/secrets/client.go
@@ -42,8 +42,16 @@ func (api *Client) ListSecrets(showSecrets bool) ([]SecretDetails, error) {
 	}
 	result := make([]SecretDetails, len(response.Results))
 	for i, r := range response.Results {
+		URL, err := secrets.ParseURL(r.URL)
+		if err != nil {
+			result[i] = SecretDetails{
+				Error: err,
+			}
+			continue
+		}
 		result[i] = SecretDetails{
 			Metadata: secrets.SecretMetadata{
+				URL:         URL,
 				Path:        r.Path,
 				Scope:       secrets.Scope(r.Scope),
 				Version:     r.Version,

--- a/api/secrets/client_test.go
+++ b/api/secrets/client_test.go
@@ -44,6 +44,7 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.ListSecretResults{})
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			[]params.ListSecretResult{{
+				URL:         "secret://v1/app.password",
 				Path:        "app.password",
 				Scope:       "application",
 				Version:     1,
@@ -63,8 +64,10 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 	client := apisecrets.NewClient(apiCaller)
 	result, err := client.ListSecrets(true)
 	c.Assert(err, jc.ErrorIsNil)
+	URL := secrets.NewURL(1, "", "", "app.password", "")
 	c.Assert(result, jc.DeepEquals, []apisecrets.SecretDetails{{
 		Metadata: secrets.SecretMetadata{
+			URL:         URL,
 			Path:        "app.password",
 			Scope:       "application",
 			Version:     1,
@@ -85,6 +88,7 @@ func (s *SecretsSuite) TestListSecretsError(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			[]params.ListSecretResult{{
+				URL: "secret://v1/app.password",
 				Value: &params.SecretValueResult{
 					Error: &params.Error{Message: "boom"},
 				},

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -5,17 +5,16 @@ package secrets
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/apiserver/common"
-	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/permission"
+	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/secrets"
 	"github.com/juju/juju/secrets/provider"
 	"github.com/juju/juju/secrets/provider/juju"
@@ -91,7 +90,9 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 	}
 	result.Results = make([]params.ListSecretResult, len(metadata))
 	for i, m := range metadata {
+		URL := coresecrets.NewURL(m.Version, s.controllerUUID, s.modelUUID, m.Path, "")
 		secretResult := params.ListSecretResult{
+			URL:         URL.String(),
 			Path:        m.Path,
 			Scope:       string(m.Scope),
 			Version:     m.Version,
@@ -105,12 +106,6 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			UpdateTime:  m.UpdateTime,
 		}
 		if arg.ShowSecrets {
-			URL := &coresecrets.URL{
-				Version:        fmt.Sprintf("v%d", m.Version),
-				ControllerUUID: s.controllerUUID,
-				ModelUUID:      s.modelUUID,
-				Path:           m.Path,
-			}
 			val, err := s.secretsService.GetSecretValue(ctx, URL)
 			valueResult := &params.SecretValueResult{
 				Error: apiservererrors.ServerError(err),

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -89,13 +89,13 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	)
 
 	var valueResult *params.SecretValueResult
+	URL := &coresecrets.URL{
+		Version:        "v1",
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		Path:           "app.password",
+	}
 	if show {
-		URL := &coresecrets.URL{
-			Version:        "v1",
-			ControllerUUID: coretesting.ControllerTag.Id(),
-			ModelUUID:      coretesting.ModelTag.Id(),
-			Path:           "app.password",
-		}
 		valueResult = &params.SecretValueResult{
 			Data: map[string]string{"foo": "bar"},
 		}
@@ -108,6 +108,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
+			URL:         URL.String(),
 			Path:        "app.password",
 			Scope:       "application",
 			Version:     1,

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39762,6 +39762,9 @@
                             "type": "string",
                             "format": "date-time"
                         },
+                        "url": {
+                            "type": "string"
+                        },
                         "value": {
                             "$ref": "#/definitions/SecretValueResult"
                         },
@@ -39771,6 +39774,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
+                        "url",
                         "path",
                         "scope",
                         "version",

--- a/apiserver/params/secrets.go
+++ b/apiserver/params/secrets.go
@@ -64,6 +64,7 @@ type ListSecretResults struct {
 
 // ListSecretResult is the result of getting secret metadata.
 type ListSecretResult struct {
+	URL         string             `json:"url"`
 	Path        string             `json:"path"`
 	Scope       string             `json:"scope"`
 	Version     int                `json:"version"`

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -94,6 +94,7 @@ type secretValueDetails struct {
 
 type secretDisplayDetails struct {
 	ID          int                 `json:"ID" yaml:"ID"`
+	URL         string              `json:"URL" yaml:"URL"`
 	Revision    int                 `json:"revision" yaml:"revision"`
 	Path        string              `json:"path" yaml:"path"`
 	Scope       secrets.Scope       `json:"scope" yaml:"scope"`
@@ -120,13 +121,14 @@ func (c *listSecretsCommand) Run(ctxt *cmd.Context) error {
 	}
 	defer api.Close()
 
-	secrets, err := api.ListSecrets(c.showSecrets)
+	result, err := api.ListSecrets(c.showSecrets)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	details := make([]secretDisplayDetails, len(secrets))
-	for i, m := range secrets {
+	details := make([]secretDisplayDetails, len(result))
+	for i, m := range result {
 		details[i] = secretDisplayDetails{
+			URL:         m.Metadata.URL.ShortString(),
 			Path:        m.Metadata.Path,
 			Scope:       m.Metadata.Scope,
 			Version:     m.Metadata.Version,

--- a/cmd/juju/secrets/list_test.go
+++ b/cmd/juju/secrets/list_test.go
@@ -65,10 +65,12 @@ ID         Scope  Revision  Backend  Path          Age
 func (s *ListSuite) TestListYAML(c *gc.C) {
 	defer s.setup(c).Finish()
 
+	URL, err := coresecrets.ParseURL("secret://v1/app.password")
+	c.Assert(err, jc.ErrorIsNil)
 	s.secretsAPI.EXPECT().ListSecrets(true).Return(
 		[]apisecrets.SecretDetails{{
 			Metadata: coresecrets.SecretMetadata{
-				ID: 666, Scope: coresecrets.ScopeApplication,
+				URL: URL, ID: 666, Scope: coresecrets.ScopeApplication,
 				Version: 1, Revision: 2, Path: "app.password", Provider: "juju"},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
 		}}, nil)
@@ -79,6 +81,7 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
 - ID: 666
+  URL: secret://v1/app.password
   revision: 2
   path: app.password
   scope: application
@@ -94,10 +97,12 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 func (s *ListSuite) TestListJSON(c *gc.C) {
 	defer s.setup(c).Finish()
 
+	URL, err := coresecrets.ParseURL("secret://v1/app.password")
+	c.Assert(err, jc.ErrorIsNil)
 	s.secretsAPI.EXPECT().ListSecrets(true).Return(
 		[]apisecrets.SecretDetails{{
 			Metadata: coresecrets.SecretMetadata{
-				ID: 666, Scope: coresecrets.ScopeApplication,
+				URL: URL, ID: 666, Scope: coresecrets.ScopeApplication,
 				Version: 1, Revision: 2, Path: "app.password", Provider: "juju"},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
 		}}, nil)
@@ -107,6 +112,6 @@ func (s *ListSuite) TestListJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, `
-[{"ID":666,"revision":2,"path":"app.password","scope":"application","version":1,"backend":"juju","create-time":"0001-01-01T00:00:00Z","update-time":"0001-01-01T00:00:00Z","value":{"Data":{"foo":"bar"}}}]
+[{"ID":666,"URL":"secret://v1/app.password","revision":2,"path":"app.password","scope":"application","version":1,"backend":"juju","create-time":"0001-01-01T00:00:00Z","update-time":"0001-01-01T00:00:00Z","value":{"Data":{"foo":"bar"}}}]
 `[1:])
 }

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -142,8 +142,32 @@ func ParseURL(str string) (*URL, error) {
 	return result, nil
 }
 
+// NewURL returns a URL with the specified attributes.
+func NewURL(version int, controllerUUID, modelUUID, path, attribute string) *URL {
+	return &URL{
+		Version:        fmt.Sprintf("v%d", version),
+		ControllerUUID: controllerUUID,
+		ModelUUID:      modelUUID,
+		Path:           path,
+		Attribute:      attribute,
+	}
+}
+
+// ID returns the URL string without any Attribute.
+func (u *URL) ID() string {
+	if u == nil {
+		return ""
+	}
+	urlCopy := *u
+	urlCopy.Attribute = ""
+	return urlCopy.String()
+}
+
 // ShortString prints the URL without controller or model UUID.
 func (u *URL) ShortString() string {
+	if u == nil {
+		return ""
+	}
 	fullPath := []string{"secret:/", u.Version}
 	fullPath = append(fullPath, u.Path)
 	str := strings.Join(fullPath, "/")
@@ -155,6 +179,9 @@ func (u *URL) ShortString() string {
 
 // String prints the URL as a string.
 func (u *URL) String() string {
+	if u == nil {
+		return ""
+	}
 	fullPath := []string{"secret:/", u.Version}
 	if u.ControllerUUID != "" {
 		fullPath = append(fullPath, u.ControllerUUID)
@@ -173,6 +200,7 @@ func (u *URL) String() string {
 // SecretMetadata holds metadata about a secret.
 type SecretMetadata struct {
 	// Read only after creation.
+	URL   *URL
 	Path  string
 	Scope Scope
 

--- a/core/secrets/secret_test.go
+++ b/core/secrets/secret_test.go
@@ -179,3 +179,19 @@ func (s *SecretURLSuite) TestShortString(c *gc.C) {
 	expected.ModelUUID = ""
 	c.Assert(url, jc.DeepEquals, expected)
 }
+
+func (s *SecretURLSuite) TestID(c *gc.C) {
+	expected := &secrets.URL{
+		Version:        "v1",
+		ControllerUUID: controllerUUID,
+		ModelUUID:      modelUUID,
+		Path:           "app.password",
+		Attribute:      "attr",
+	}
+	c.Assert(expected.ID(), gc.Equals, "secret://v1/"+controllerUUID+"/"+modelUUID+"/app.password")
+}
+
+func (s *SecretURLSuite) TestNewURL(c *gc.C) {
+	URL := secrets.NewURL(1, controllerUUID, modelUUID, "app.password", "attr")
+	c.Assert(URL.String(), gc.Equals, "secret://v1/"+controllerUUID+"/"+modelUUID+"/app.password#attr")
+}

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -110,6 +110,49 @@ func (s *SecretsSuite) TestGetValue(c *gc.C) {
 	})
 }
 
+func (s *SecretsSuite) TestGetValueAttribute(c *gc.C) {
+	p := state.CreateSecretParams{
+		ControllerUUID: s.State.ControllerUUID(),
+		ModelUUID:      s.State.ModelUUID(),
+		Version:        1,
+		ProviderLabel:  "juju",
+		Type:           "blob",
+		Path:           "app.password",
+		Scope:          "application",
+		Params:         nil,
+		Data:           map[string]string{"foo": "bar", "hello": "world"},
+	}
+	URL, _, err := s.store.CreateSecret(p)
+	c.Assert(err, jc.ErrorIsNil)
+
+	URL.Attribute = "hello"
+	val, err := s.store.GetSecretValue(URL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(val.EncodedValues(), jc.DeepEquals, map[string]string{
+		"hello": "world",
+	})
+}
+
+func (s *SecretsSuite) TestGetValueAttributeNotFound(c *gc.C) {
+	p := state.CreateSecretParams{
+		ControllerUUID: s.State.ControllerUUID(),
+		ModelUUID:      s.State.ModelUUID(),
+		Version:        1,
+		ProviderLabel:  "juju",
+		Type:           "blob",
+		Path:           "app.password",
+		Scope:          "application",
+		Params:         nil,
+		Data:           map[string]string{"foo": "bar", "hello": "world"},
+	}
+	URL, _, err := s.store.CreateSecret(p)
+	c.Assert(err, jc.ErrorIsNil)
+
+	URL.Attribute = "goodbye"
+	_, err = s.store.GetSecretValue(URL)
+	c.Assert(err, gc.ErrorMatches, `secret attribute "goodbye" not found`)
+}
+
 func (s *SecretsSuite) TestList(c *gc.C) {
 	p := state.CreateSecretParams{
 		ControllerUUID: s.State.ControllerUUID(),

--- a/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-get_test.go
@@ -31,10 +31,10 @@ func (s *SecretGetSuite) TestSecretGetSingularString(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "s3cret!\n")
 }
@@ -48,10 +48,10 @@ func (s *SecretGetSuite) TestSecretGetStringJson(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--format", "json"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password", "--format", "json"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `{"key":"s3cret!"}`+"\n")
 }
@@ -65,10 +65,10 @@ func (s *SecretGetSuite) TestSecretGetSingularEncoded(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--base64"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password", "--base64"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "czNjcmV0IQ==\n")
 }
@@ -83,10 +83,10 @@ func (s *SecretGetSuite) TestSecretGet(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
 cert: cert
@@ -105,14 +105,32 @@ func (s *SecretGetSuite) TestSecretGetEncoded(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app.password", "--base64"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password", "--base64"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
 cert: Y2VydA==
 key: a2V5
 
 `[1:])
+}
+
+func (s *SecretGetSuite) TestSecretGetAttribute(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
+		"cert": base64.StdEncoding.EncodeToString([]byte("cert")),
+		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
+	})
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password#cert"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password#cert"}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "cert\n")
 }


### PR DESCRIPTION
Support secret-get #attribute and display URL in list-secrets

The `secret-get` hook command now accepts a secret URL with an `#attribute` and will just print that attribute's value.
Also, when listing secrets, include the URL in the YAML and JSON output.

## QA steps

bootstrap and deploy an ubuntu charm

```
juju exec --unit ubuntu/0 "secret-create password foo=bar hello=world"
secret://v1/ede39b7b-d4d4-418e-8428-a0d958e1e3b7/fccba40d-27ba-435c-871c-12290838a002/ubuntu.password

juju exec --unit ubuntu/0 "secret-get secret://v1/ubuntu.password"
foo: bar
hello: world

juju exec --unit ubuntu/0 "secret-get secret://v1/ubuntu.password#foo"
bar

juju secrets --format yaml
- ID: 1
  URL: secret://v1/ubuntu.password
  revision: 1
  path: ubuntu.password2
  scope: application
  version: 1
  backend: juju
  create-time: 2021-08-18T02:45:18Z
  update-time: 2021-08-18T02:45:18Z
```