### PR TITLE
Ensure unsubscribe on error

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -346,11 +346,13 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 	// The auth context for authenticating access to application offers.
 	srv.offerAuthCtxt, err = newOfferAuthcontext(cfg.StatePool)
 	if err != nil {
+		unsubscribeControllerConfig()
 		return nil, errors.Trace(err)
 	}
 
 	model, err := srv.shared.statePool.SystemState().Model()
 	if err != nil {
+		unsubscribeControllerConfig()
 		return nil, errors.Trace(err)
 	}
 	if model.Type() == state.ModelTypeCAAS {
@@ -367,6 +369,7 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 		srv.tomb.Kill(dependency.ErrBounce)
 	})
 	if err != nil {
+		unsubscribeControllerConfig()
 		return nil, errors.Annotate(err, "unable to subscribe to restart message")
 	}
 

--- a/worker/raft/raftbackstop/worker.go
+++ b/worker/raft/raftbackstop/worker.go
@@ -92,6 +92,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		LocalOnly: true,
 	}
 	if _, err := config.Hub.Publish(apiserver.DetailsRequestTopic, req); err != nil {
+		unsubscribe()
 		return nil, errors.Annotate(err, "requesting current apiserver details")
 	}
 

--- a/worker/raft/raftclusterer/worker.go
+++ b/worker/raft/raftclusterer/worker.go
@@ -60,6 +60,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		LocalOnly: true,
 	}
 	if _, err := config.Hub.Publish(apiserver.DetailsRequestTopic, req); err != nil {
+		unsubscribe()
 		return nil, errors.Annotate(err, "requesting current apiserver details")
 	}
 

--- a/worker/raft/rafttransport/streamlayer.go
+++ b/worker/raft/rafttransport/streamlayer.go
@@ -60,6 +60,7 @@ func newStreamLayer(
 		LocalOnly: true,
 	}
 	if _, err := hub.Publish(apiserver.DetailsRequestTopic, req); err != nil {
+		unsubscribe()
 		return nil, errors.Trace(err)
 	}
 


### PR DESCRIPTION
If we subscribe to a given topic, we need to ensure that we unsubscribe
when we get an error. If we don't do this, then we can end up having a
instance hanging around forever. This could end up being a leak of
resources.

Unfortunately, pubsub is never tied to the lifecycle of an instance. It 
would be nice to either pass in a tomb or a context to do auto
unsubscribing once a lifecycle is complete.

## QA steps

Tests pass.

