### PR TITLE
fix bundle changes sort infinite loop

### DIFF
--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -164,30 +164,13 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 	r, err := s.facade.GetChanges(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
-		Id:     "addCharm-0",
-		Method: "addCharm",
-		Args:   []interface{}{"django", "", ""},
-	}, {
-		Id:     "deploy-1",
-		Method: "deploy",
-		Args: []interface{}{
-			"$addCharm-0",
-			"",
-			"django",
-			map[string]interface{}{"debug": true},
-			"",
-			map[string]string{"tmpfs": "tmpfs,1G"},
-			map[string]string{"bitcoinminer": "2,nvidia.com/gpu"},
-			map[string]string{},
-			map[string]int{},
-			0,
-			"",
-		},
-		Requires: []string{"addCharm-0"},
-	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
 		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty", ""},
+	}, {
+		Id:     "addCharm-0",
+		Method: "addCharm",
+		Args:   []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -205,6 +188,23 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 			"",
 		},
 		Requires: []string{"addCharm-2"},
+	}, {
+		Id:     "deploy-1",
+		Method: "deploy",
+		Args: []interface{}{
+			"$addCharm-0",
+			"",
+			"django",
+			map[string]interface{}{"debug": true},
+			"",
+			map[string]string{"tmpfs": "tmpfs,1G"},
+			map[string]string{"bitcoinminer": "2,nvidia.com/gpu"},
+			map[string]string{},
+			map[string]int{},
+			0,
+			"",
+		},
+		Requires: []string{"addCharm-0"},
 	}, {
 		Id:       "addRelation-4",
 		Method:   "addRelation",
@@ -238,30 +238,12 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
 	r, err := s.facade.GetChanges(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
-		Id:     "addCharm-0",
-		Method: "addCharm",
-		Args:   []interface{}{"django", "", ""},
-	}, {
-		Id:     "deploy-1",
-		Method: "deploy",
-		Args: []interface{}{
-			"$addCharm-0",
-			"",
-			"django",
-			map[string]interface{}{"debug": true},
-			"",
-			map[string]string{"tmpfs": "tmpfs,1G"},
-			map[string]string{"bitcoinminer": "2,nvidia.com/gpu"},
-			map[string]string{},
-			map[string]int{},
-			1,
-			"",
-		},
-		Requires: []string{"addCharm-0"},
-	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
 		Args:   []interface{}{"cs:haproxy-42", "", ""},
+	}, {Id: "addCharm-0",
+		Method: "addCharm",
+		Args:   []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -279,6 +261,23 @@ func (s *bundleSuite) TestGetChangesKubernetes(c *gc.C) {
 			"",
 		},
 		Requires: []string{"addCharm-2"},
+	}, {
+		Id:     "deploy-1",
+		Method: "deploy",
+		Args: []interface{}{
+			"$addCharm-0",
+			"",
+			"django",
+			map[string]interface{}{"debug": true},
+			"",
+			map[string]string{"tmpfs": "tmpfs,1G"},
+			map[string]string{"bitcoinminer": "2,nvidia.com/gpu"},
+			map[string]string{},
+			map[string]int{},
+			1,
+			"",
+		},
+		Requires: []string{"addCharm-0"},
 	}, {
 		Id:       "addRelation-4",
 		Method:   "addRelation",
@@ -313,29 +312,13 @@ func (s *bundleSuite) TestGetChangesSuccessV1(c *gc.C) {
 	r, err := apiv1.GetChanges(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
-		Id:     "addCharm-0",
-		Method: "addCharm",
-		Args:   []interface{}{"django", "", ""},
-	}, {
-		Id:     "deploy-1",
-		Method: "deploy",
-		Args: []interface{}{
-			"$addCharm-0",
-			"",
-			"django",
-			map[string]interface{}{"debug": true},
-			"",
-			map[string]string{"tmpfs": "tmpfs,1G"},
-			map[string]string{},
-			map[string]int{},
-			0,
-			"",
-		},
-		Requires: []string{"addCharm-0"},
-	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
 		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty", ""},
+	}, {
+		Id:     "addCharm-0",
+		Method: "addCharm",
+		Args:   []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -352,6 +335,22 @@ func (s *bundleSuite) TestGetChangesSuccessV1(c *gc.C) {
 			"",
 		},
 		Requires: []string{"addCharm-2"},
+	}, {
+		Id:     "deploy-1",
+		Method: "deploy",
+		Args: []interface{}{
+			"$addCharm-0",
+			"",
+			"django",
+			map[string]interface{}{"debug": true},
+			"",
+			map[string]string{"tmpfs": "tmpfs,1G"},
+			map[string]string{},
+			map[string]int{},
+			0,
+			"",
+		},
+		Requires: []string{"addCharm-0"},
 	}, {
 		Id:       "addRelation-4",
 		Method:   "addRelation",
@@ -509,11 +508,27 @@ func (s *bundleSuite) TestGetChangesMapArgsSuccess(c *gc.C) {
 	r, err := s.facade.GetChangesMapArgs(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChangesMapArgs{{
+		Id:     "addCharm-2",
+		Method: "addCharm",
+		Args: map[string]interface{}{
+			"charm":  "cs:trusty/haproxy-42",
+			"series": "trusty",
+		},
+	}, {
 		Id:     "addCharm-0",
 		Method: "addCharm",
 		Args: map[string]interface{}{
 			"charm": "django",
 		},
+	}, {
+		Id:     "deploy-3",
+		Method: "deploy",
+		Args: map[string]interface{}{
+			"application": "haproxy",
+			"charm":       "$addCharm-2",
+			"series":      "trusty",
+		},
+		Requires: []string{"addCharm-2"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -531,22 +546,6 @@ func (s *bundleSuite) TestGetChangesMapArgsSuccess(c *gc.C) {
 			},
 		},
 		Requires: []string{"addCharm-0"},
-	}, {
-		Id:     "addCharm-2",
-		Method: "addCharm",
-		Args: map[string]interface{}{
-			"charm":  "cs:trusty/haproxy-42",
-			"series": "trusty",
-		},
-	}, {
-		Id:     "deploy-3",
-		Method: "deploy",
-		Args: map[string]interface{}{
-			"application": "haproxy",
-			"charm":       "$addCharm-2",
-			"series":      "trusty",
-		},
-		Requires: []string{"addCharm-2"},
 	}, {
 		Id:     "addRelation-4",
 		Method: "addRelation",
@@ -583,11 +582,25 @@ func (s *bundleSuite) TestGetChangesMapArgsKubernetes(c *gc.C) {
 	r, err := s.facade.GetChangesMapArgs(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChangesMapArgs{{
+		Id:     "addCharm-2",
+		Method: "addCharm",
+		Args: map[string]interface{}{
+			"charm": "cs:haproxy-42",
+		},
+	}, {
 		Id:     "addCharm-0",
 		Method: "addCharm",
 		Args: map[string]interface{}{
 			"charm": "django",
 		},
+	}, {
+		Id:     "deploy-3",
+		Method: "deploy",
+		Args: map[string]interface{}{
+			"application": "haproxy",
+			"charm":       "$addCharm-2",
+		},
+		Requires: []string{"addCharm-2"},
 	}, {
 		Id:     "deploy-1",
 		Method: "deploy",
@@ -606,20 +619,6 @@ func (s *bundleSuite) TestGetChangesMapArgsKubernetes(c *gc.C) {
 			},
 		},
 		Requires: []string{"addCharm-0"},
-	}, {
-		Id:     "addCharm-2",
-		Method: "addCharm",
-		Args: map[string]interface{}{
-			"charm": "cs:haproxy-42",
-		},
-	}, {
-		Id:     "deploy-3",
-		Method: "deploy",
-		Args: map[string]interface{}{
-			"application": "haproxy",
-			"charm":       "$addCharm-2",
-		},
-		Requires: []string{"addCharm-2"},
 	}, {
 		Id:     "addRelation-4",
 		Method: "addRelation",

--- a/apiserver/facades/client/client/bundles_test.go
+++ b/apiserver/facades/client/client/bundles_test.go
@@ -34,29 +34,13 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 	r, err := s.client.GetBundleChanges(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChange{{
-		Id:     "addCharm-0",
-		Method: "addCharm",
-		Args:   []interface{}{"django", "", ""},
-	}, {
-		Id:     "deploy-1",
-		Method: "deploy",
-		Args: []interface{}{
-			"$addCharm-0",
-			"",
-			"django",
-			map[string]interface{}{"debug": true},
-			"",
-			map[string]string{"tmpfs": "tmpfs,1G"},
-			map[string]string{},
-			map[string]int{},
-			0,
-			"",
-		},
-		Requires: []string{"addCharm-0"},
-	}, {
 		Id:     "addCharm-2",
 		Method: "addCharm",
 		Args:   []interface{}{"cs:trusty/haproxy-42", "trusty", ""},
+	}, {
+		Id:     "addCharm-0",
+		Method: "addCharm",
+		Args:   []interface{}{"django", "", ""},
 	}, {
 		Id:     "deploy-3",
 		Method: "deploy",
@@ -73,6 +57,22 @@ func (s *serverSuite) TestGetBundleChangesSuccess(c *gc.C) {
 			"",
 		},
 		Requires: []string{"addCharm-2"},
+	}, {
+		Id:     "deploy-1",
+		Method: "deploy",
+		Args: []interface{}{
+			"$addCharm-0",
+			"",
+			"django",
+			map[string]interface{}{"debug": true},
+			"",
+			map[string]string{"tmpfs": "tmpfs,1G"},
+			map[string]string{},
+			map[string]int{},
+			0,
+			"",
+		},
+		Requires: []string{"addCharm-0"},
 	}, {
 		Id:       "addRelation-4",
 		Method:   "addRelation",

--- a/core/bundle/changes/changes.go
+++ b/core/bundle/changes/changes.go
@@ -1228,7 +1228,7 @@ func (cs *changeset) dependents() map[string][]string {
 func (cs *changeset) sorted() ([]Change, error) {
 	// Exit it early if there is nothing to sort.
 	if len(cs.changes) == 0 {
-		return []Change{}, nil
+		return nil, nil
 	}
 
 	// Create a map to sort the data.
@@ -1242,7 +1242,7 @@ func (cs *changeset) sorted() ([]Change, error) {
 		data[c.Id()] = c.Requires()
 		dataOrder[i] = c.Id()
 	}
-	sortedChangeIDs, err := toposort_flatten(dataOrder, data)
+	sortedChangeIDs, err := toposortFlatten(dataOrder, data)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1261,14 +1261,16 @@ func (cs *changeset) sorted() ([]Change, error) {
 	return sortedChanges, nil
 }
 
-// toposort_flatten performs a topographical flattened sort on the provided
+// toposortFlatten performs a topographical flattened sort on the provided
 // data.  dataOrder is a slice of the originally ordered changes. data is a
 // map of change to requirements.  To be idempotent, requirements must be in
 // the same order each time.  Use along with data to ensure that this method
 // is deterministic.
 //
 // Adapted from https://tylercipriani.com/blog/2017/09/13/topographical-sorting-in-golang/
-func toposort_flatten(dataOrder []string, data map[string][]string) ([]string, error) {
+// Blog post: Topographical Sorting in Golang
+// Copyright © 2017 Tyler Cipriani
+func toposortFlatten(dataOrder []string, data map[string][]string) ([]string, error) {
 
 	// Create a map to handle degrees, all vertices start at 0.
 	inDegree := make(map[string]int, len(dataOrder))

--- a/core/bundle/changes/changes.go
+++ b/core/bundle/changes/changes.go
@@ -106,7 +106,7 @@ func FromData(config ChangesConfig) ([]Change, error) {
 			return nil, errors.Trace(err)
 		}
 	}
-	return changes.sorted(), nil
+	return changes.sorted()
 }
 
 // alreadyDeployedApplicationsFromBundle returns a set consisting of the
@@ -1225,29 +1225,110 @@ func (cs *changeset) dependents() map[string][]string {
 }
 
 // sorted returns the changes sorted by requirements, required first.
-func (cs *changeset) sorted() []Change {
-	done := set.NewStrings()
-	var sorted []Change
-	changes := cs.changes[:]
-mainloop:
-	for len(changes) != 0 {
-		// Note that all valid bundles have at least two changes
-		// (add one charm and deploy one application).
-		change := changes[0]
-		changes = changes[1:]
-		for _, r := range change.Requires() {
-			if !done.Contains(r) {
+func (cs *changeset) sorted() ([]Change, error) {
+	// Exit it early if there is nothing to sort.
+	if len(cs.changes) == 0 {
+		return []Change{}, nil
+	}
 
-				// This change requires a change which is not yet listed.
-				// Push this change at the end of the list and retry later.
-				changes = append(changes, change)
-				continue mainloop
+	// Create a map to sort the data.
+	data := make(map[string][]string, len(cs.changes))
+	dataOrder := make([]string, len(cs.changes))
+	for i, c := range cs.changes {
+		// Sorting the requirements can be removed if the place in
+		// handlers.go where the order of requirements is not
+		// idempotent can be found and fixed.
+		sort.Sort(sort.StringSlice(c.Requires()))
+		data[c.Id()] = c.Requires()
+		dataOrder[i] = c.Id()
+	}
+	sortedChangeIDs, err := toposort_flatten(dataOrder, data)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// convert the sorted change IDs to a sorted slice
+	// of changes
+	var sortedChanges []Change
+	for _, changeID := range sortedChangeIDs {
+		for _, change := range cs.changes {
+			if changeID == change.Id() {
+				sortedChanges = append(sortedChanges, change)
+				break
 			}
 		}
-		done.Add(change.Id())
-		sorted = append(sorted, change)
 	}
-	return sorted
+	return sortedChanges, nil
+}
+
+// toposort_flatten performs a topographical flattened sort on the provided
+// data.  dataOrder is a slice of the originally ordered changes. data is a
+// map of change to requirements.  To be idempotent, requirements must be in
+// the same order each time.  Use along with data to ensure that this method
+// is deterministic.
+//
+// Adapted from https://tylercipriani.com/blog/2017/09/13/topographical-sorting-in-golang/
+func toposort_flatten(dataOrder []string, data map[string][]string) ([]string, error) {
+
+	// Create a map to handle degrees, all vertices start at 0.
+	inDegree := make(map[string]int, len(dataOrder))
+	for n := range data {
+		inDegree[n] = 0
+	}
+
+	// For each vertex, adjacent to "u", increment the degree.
+	for _, adjacent := range data {
+		for _, v := range adjacent {
+			inDegree[v]++
+		}
+	}
+
+	// Make a list of next, containing all vertex that have a degree
+	// of 0.
+	var next []string
+	for _, k := range dataOrder {
+		v := inDegree[k]
+		if v != 0 {
+			continue
+		}
+		next = append(next, k)
+	}
+
+	// Use an idx to insert items into the linearOrder from
+	// the end to the beginning, to avoid reversing the order later.
+	linearOrder := make([]string, len(dataOrder))
+	idx := len(linearOrder)
+
+	// While next is not empty
+	for ; len(next) > 0; idx -= 1 {
+		// Pop a vertex off next list
+		u := next[0]
+		next = next[1:]
+
+		if idx > 0 {
+			// Add it the linearOrder of vertices, starting
+			// from the end.
+			linearOrder[idx-1] = u
+		}
+
+		// For each vertex adjacent to the current one,
+		// decrement the degree, and if now 0, add to the
+		// next list.
+		for _, v := range data[u] {
+			inDegree[v]--
+			if inDegree[v] == 0 {
+				next = append(next, v)
+			}
+		}
+	}
+
+	if idx != 0 {
+		intersection := set.NewStrings(linearOrder...).Difference(set.NewStrings(dataOrder...))
+		return nil, errors.Errorf("sort failed, %q is not a valid changeID",
+			strings.Join(intersection.SortedValues(), ", "))
+	}
+
+	return linearOrder, nil
 }
 
 func storeLocation(schema string) string {

--- a/core/bundle/changes/changessort_test.go
+++ b/core/bundle/changes/changessort_test.go
@@ -1,0 +1,199 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bundlechanges
+
+import (
+	"strings"
+
+	"github.com/juju/collections/set"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type changesSortSuite struct {
+}
+
+var _ = gc.Suite(&changesSortSuite{})
+
+func (s *changesSortSuite) TestSortVerifyRequirementsMet(c *gc.C) {
+	ahead := set.NewStrings()
+	sorted, err := csOne().sorted()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(sorted), jc.GreaterThan, 0)
+	for i, change := range sorted {
+		if i == 0 {
+			c.Assert(change.Requires(), gc.HasLen, 0)
+		} else {
+			for _, req := range change.Requires() {
+				c.Assert(ahead.Contains(req), jc.IsTrue, gc.Commentf("%q, not one of %q", req, strings.Join(ahead.Values(), ", ")))
+			}
+		}
+		ahead.Add(change.Id())
+	}
+}
+
+func (s *changesSortSuite) TestSortIdempotent(c *gc.C) {
+	for i := 0; i > 10; i += 1 {
+		results, err := csOne().sorted()
+		c.Assert(err, jc.ErrorIsNil)
+		resultstwo, err := csTwo().sorted()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(results, jc.DeepEquals, resultstwo)
+	}
+}
+
+func (s *changesSortSuite) TestInvalidDataForSort(c *gc.C) {
+	cs := &changeset{}
+
+	// addCharm-0:
+	c0 := newAddCharmChange(AddCharmParams{})
+	cs.add(c0)
+	// deploy-1: addCharm-0
+	d1 := newAddApplicationChange(AddApplicationParams{}, c0.Id(), "failme")
+	cs.add(d1)
+	// addCharm-2:
+	c2 := newAddCharmChange(AddCharmParams{})
+	cs.add(c2)
+	// 	deploy-3: addCharm-2
+	d3 := newAddApplicationChange(AddApplicationParams{}, c2.Id())
+	cs.add(d3)
+	_, err := cs.sorted()
+	c.Assert(err, gc.NotNil)
+}
+
+func csOne() *changeset {
+	// TestSiblingContainers
+	// applications:
+	//  mysql:
+	//    charm: cs:mysql
+	//    num_units: 3
+	//    to: ["lxd:new"]
+	//	keystone:
+	//	  charm: cs:keystone
+	//	  num_units: 3
+	//	  to: ["lxd:mysql"]
+
+	// It's possible for requirements to be in different orders and thus give different
+	// results: m13, m14, 15 have requirements a different order than csTwo.
+	cs := &changeset{}
+
+	// addCharm-0:
+	c0 := newAddCharmChange(AddCharmParams{})
+	cs.add(c0)
+	// deploy-1: addCharm-0
+	d1 := newAddApplicationChange(AddApplicationParams{}, c0.Id())
+	cs.add(d1)
+	// addCharm-2:
+	c2 := newAddCharmChange(AddCharmParams{})
+	cs.add(c2)
+	// 	deploy-3: addCharm-2
+	d3 := newAddApplicationChange(AddApplicationParams{}, c2.Id())
+	cs.add(d3)
+	// addUnit-4: deploy-1, addMachines-13
+	u4 := newAddUnitChange(AddUnitParams{}, d1.Id())
+	cs.add(u4)
+	// addUnit-5: deploy-1, addMachines-14, addUnit-4
+	u5 := newAddUnitChange(AddUnitParams{}, d1.Id(), "addMachines-14", u4.Id())
+	cs.add(u5)
+	// addUnit-6: deploy-1, addMachines-15, addUnit-5
+	u6 := newAddUnitChange(AddUnitParams{}, d1.Id(), "addMachines-15", u5.Id())
+	cs.add(u6)
+	// addUnit-7: deploy-3, addMachines-10
+	u7 := newAddUnitChange(AddUnitParams{}, d3.Id(), "addMachines-10")
+	cs.add(u7)
+	// addUnit-8: deploy-3, addMachines-11, addUnit-7
+	u8 := newAddUnitChange(AddUnitParams{}, d3.Id(), "addMachines-11", u7.Id())
+	cs.add(u8)
+	// addUnit-9: deploy-3, addMachines-12, addUnit-8
+	u9 := newAddUnitChange(AddUnitParams{}, d3.Id(), "addMachines-12", u8.Id())
+	cs.add(u9)
+	// addMachines-10:
+	m10 := newAddMachineChange(AddMachineParams{})
+	cs.add(m10)
+	// addMachines-11: addMachines-10
+	m11 := newAddMachineChange(AddMachineParams{}, m10.Id())
+	cs.add(m11)
+	// addMachines-12: addMachines-10, addMachines-11
+	m12 := newAddMachineChange(AddMachineParams{}, m10.Id(), m11.Id())
+	cs.add(m12)
+	// addMachines-13: addUnit-7, addMachines-10, addMachines-11, addMachines-12
+	m13 := newAddMachineChange(AddMachineParams{}, u7.Id(), m10.Id(), m11.Id(), m12.Id())
+	cs.add(m13)
+	// addMachines-14: addUnit-8, addMachines-10, addMachines-11, addMachines-12, addMachines-13
+	m14 := newAddMachineChange(AddMachineParams{}, u8.Id(), m10.Id(), m11.Id(), m12.Id(), m13.Id())
+	cs.add(m14)
+	// addMachines-15: addUnit-9, addMachines-11, addMachines-12, addMachines-13, addMachines-14, addMachines-10
+	m15 := newAddMachineChange(AddMachineParams{}, u9.Id(), m11.Id(), m12.Id(), m13.Id(), m14.Id(), m10.Id())
+	cs.add(m15)
+
+	return cs
+}
+
+func csTwo() *changeset {
+	// TestSiblingContainers
+	// applications:
+	//  mysql:
+	//    charm: cs:mysql
+	//    num_units: 3
+	//    to: ["lxd:new"]
+	//	keystone:
+	//	  charm: cs:keystone
+	//	  num_units: 3
+	//	  to: ["lxd:mysql"]
+
+	// It's possible for requirements to be in different orders and thus give different
+	// results: m13, m14, 15 have requirements a different order than csOne.
+	cs := &changeset{}
+
+	// addCharm-0:
+	c0 := newAddCharmChange(AddCharmParams{})
+	cs.add(c0)
+	// deploy-1: addCharm-0
+	d1 := newAddApplicationChange(AddApplicationParams{}, c0.Id())
+	cs.add(d1)
+	// addCharm-2:
+	c2 := newAddCharmChange(AddCharmParams{})
+	cs.add(c2)
+	// 	deploy-3: addCharm-2
+	d3 := newAddApplicationChange(AddApplicationParams{}, c2.Id())
+	cs.add(d3)
+	// addUnit-4: deploy-1, addMachines-13
+	u4 := newAddUnitChange(AddUnitParams{}, d1.Id())
+	cs.add(u4)
+	// addUnit-5: deploy-1, addMachines-14, addUnit-4
+	u5 := newAddUnitChange(AddUnitParams{}, d1.Id(), "addMachines-14", u4.Id())
+	cs.add(u5)
+	// addUnit-6: deploy-1, addMachines-15, addUnit-5
+	u6 := newAddUnitChange(AddUnitParams{}, d1.Id(), "addMachines-15", u5.Id())
+	cs.add(u6)
+	// addUnit-7: deploy-3, addMachines-10
+	u7 := newAddUnitChange(AddUnitParams{}, d3.Id(), "addMachines-10")
+	cs.add(u7)
+	// addUnit-8: deploy-3, addMachines-11, addUnit-7
+	u8 := newAddUnitChange(AddUnitParams{}, d3.Id(), "addMachines-11", u7.Id())
+	cs.add(u8)
+	// addUnit-9: deploy-3, addMachines-12, addUnit-8
+	u9 := newAddUnitChange(AddUnitParams{}, d3.Id(), "addMachines-12", u8.Id())
+	cs.add(u9)
+	// addMachines-10:
+	m10 := newAddMachineChange(AddMachineParams{})
+	cs.add(m10)
+	// addMachines-11: addMachines-10
+	m11 := newAddMachineChange(AddMachineParams{}, m10.Id())
+	cs.add(m11)
+	// addMachines-12: addMachines-10, addMachines-11
+	m12 := newAddMachineChange(AddMachineParams{}, m10.Id(), m11.Id())
+	cs.add(m12)
+	// addMachines-13: addMachines-12, addUnit-7, addMachines-10
+	m13 := newAddMachineChange(AddMachineParams{}, m11.Id(), m12.Id(), u7.Id(), m10.Id())
+	cs.add(m13)
+	// addMachines-14: addMachines-11, addMachines-12, addMachines-13, addMachines-10, addUnit-8
+	m14 := newAddMachineChange(AddMachineParams{}, m11.Id(), m12.Id(), m13.Id(), m10.Id(), u8.Id())
+	cs.add(m14)
+	// addMachines-15: addMachines-14, addUnit-9, addMachines-10, addMachines-11, addMachines-12, addMachines-13
+	m15 := newAddMachineChange(AddMachineParams{}, m14.Id(), u9.Id(), m10.Id(), m11.Id(), m12.Id(), m13.Id())
+	cs.add(m15)
+
+	return cs
+}

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -219,10 +219,10 @@ juju_bootstrap() {
 		esac
 	fi
 
-  # TODO(walllyworld) - remove when we fix the nested lxd and snap/focal issue
-  # Snap doesn't work in nested focal LXD containers.
-  # So we force the model default series to be bionic.
-  model_default_series=
+	# TODO(walllyworld) - remove when we fix the nested lxd and snap/focal issue
+	# Snap doesn't work in nested focal LXD containers.
+	# So we force the model default series to be bionic.
+	model_default_series=
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"localhost" | "lxd" | "lxd-remote")
 		model_default_series="--model-default default-series=bionic"


### PR DESCRIPTION
The current sort algorithm for bundle changes causes some unit tests to timeout.  The panic traces show an infinite loop in the sort.

Replacing the bundle changes sort algorithm for a topological sort.  This brought to light some bugs with bundle changes not having all necessary requirements listed for the sort to be accurate for deployment. Such as ensuring the machines are created in the order of specification so that machine IDs match.  And ensuring the upgrade charm is run after the new charm is added to the controller.

This change does change the order of output for deploying a bundle, however it should not change the results.

## QA steps

Run many types of bundle deployments including:
- Using existing machines
- Bundles that will fail, such as series mismatch with charm or defined machine.
- Bundles which upgrade charms
- Bundles specifying machines, using --map-existing for some already existing machines in the model.

