### PR TITLE
Move snap proxy setting to cloud init runcmd rather than bootcmd

### DIFF
--- a/cloudconfig/cloudinit/helpers_test.go
+++ b/cloudconfig/cloudinit/helpers_test.go
@@ -15,6 +15,7 @@ var _ = gc.Suite(HelperSuite{})
 type fakeCfg struct {
 	CloudConfig
 	packageProxySettings proxy.Settings
+	snapProxySettings    proxy.Settings
 	packageMirror        string
 	addUpdateScripts     bool
 	addUpgradeScripts    bool
@@ -38,6 +39,7 @@ func (f *fakeCfg) addRequiredPackages() {
 }
 func (f *fakeCfg) updateProxySettings(s PackageManagerProxyConfig) error {
 	f.packageProxySettings = s.AptProxy()
+	f.snapProxySettings = s.SnapProxy()
 	return nil
 }
 
@@ -50,9 +52,13 @@ func (HelperSuite) TestAddPkgCmdsCommon(c *gc.C) {
 		Ftp:     "ftp",
 		NoProxy: "noproxy",
 	}
+	sps := proxy.Settings{
+		Http: "snap-http",
+	}
 	proxyCfg := packageManagerProxySettings{
 		aptProxy:  pps,
 		aptMirror: "mirror",
+		snapProxy: sps,
 	}
 
 	upd, upg := true, true
@@ -60,6 +66,7 @@ func (HelperSuite) TestAddPkgCmdsCommon(c *gc.C) {
 	err := addPackageCommandsCommon(f, proxyCfg, upd, upg, "trusty")
 	c.Assert(err, gc.IsNil)
 	c.Assert(f.packageProxySettings, gc.Equals, pps)
+	c.Assert(f.snapProxySettings, gc.Equals, sps)
 	c.Assert(f.packageMirror, gc.Equals, proxyCfg.aptMirror)
 	c.Assert(f.addUpdateScripts, gc.Equals, upd)
 	c.Assert(f.addUpgradeScripts, gc.Equals, upg)
@@ -70,6 +77,7 @@ func (HelperSuite) TestAddPkgCmdsCommon(c *gc.C) {
 	err = addPackageCommandsCommon(f, proxyCfg, upd, upg, "trusty")
 	c.Assert(err, gc.IsNil)
 	c.Assert(f.packageProxySettings, gc.Equals, pps)
+	c.Assert(f.snapProxySettings, gc.Equals, sps)
 	c.Assert(f.packageMirror, gc.Equals, proxyCfg.aptMirror)
 	c.Assert(f.addUpdateScripts, gc.Equals, upd)
 	c.Assert(f.addUpgradeScripts, gc.Equals, upg)
@@ -80,6 +88,7 @@ func (HelperSuite) TestAddPkgCmdsCommon(c *gc.C) {
 	err = addPackageCommandsCommon(f, proxyCfg, upd, upg, "precise")
 	c.Assert(err, gc.IsNil)
 	c.Assert(f.packageProxySettings, gc.Equals, pps)
+	c.Assert(f.snapProxySettings, gc.Equals, sps)
 	c.Assert(f.packageMirror, gc.Equals, proxyCfg.aptMirror)
 	// for precise we need to override addUpdateScripts to always be true
 	c.Assert(f.addUpdateScripts, gc.Equals, true)


### PR DESCRIPTION
It seems on some machines the snapd seeding process take take a while such that the cloud init boot cmds to set up snap proxies fail.
This PR defers the snap proxy setup to run cmds instead and also add a small script to wait for snapd to be seeded.

## QA steps

bootstrap
juju model-config snap-http-proxy="http://10.0.0.1:8000"
juju add-machine

ensure machine comes up
grep cloudinit-output-log on machine to see
```
+ printf Attempt 1 to wait for snapd to be seeded...\n
Attempt 1 to wait for snapd to be seeded...
+ snap wait core seed.loaded
+ break
+ snap set system proxy.http=http://10.0.0.1:8000
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1940445
