### PR TITLE
Static analysis github action cache go install.

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/cache@v2
       id: cache-go
       with: 
-        path: /usr/local/go/bin/go
+        path: /home/runner/go
         key: ${{ runner.os }}-go
 
     - name: Set up Go 1.14

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,7 +7,15 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
 
+    - name: Cache install go
+      uses: actions/cache@v2
+      id: cache-go
+      with: 
+        path: /usr/local/go/bin/go
+        key: ${{ runner.os }}-go
+
     - name: Set up Go 1.14
+      if: steps.cache-go.outputs.cache-hit != 'true'
       uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.14

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,24 +4,32 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    #if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     steps:
 
     - name: Cache install go
       uses: actions/cache@v2
-      id: cache-go
+      id: lint-cache-go
       with: 
         path: /home/runner/go
         key: ${{ runner.os }}-go
 
     - name: Set up Go 1.14
-      if: steps.cache-go.outputs.cache-hit != 'true'
+      if: steps.lint-cache-go.outputs.cache-hit != 'true'
       uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.14
       id: go
 
+    - name: Cache install dependencies
+      uses: actions/cache@v2
+      id: cache-install-dependencies
+      with:
+        path: /home/runner/go/bin/golangci-lint
+        key: ${{ runner.os }}-golangci-lint
+
     - name: Install Dependencies
+      if: steps.cache-install-dependencies.cache-hit != 'true'
       run: |
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -59,8 +67,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
+    - name: Cache install go
+      uses: actions/cache@v2
+      id: schema-cache-go
+      with: 
+        path: /home/runner/go
+        key: ${{ runner.os }}-go
 
     - name: Set up Go 1.14
+      if: steps.schema-cache-go.outputs.cache-hit != 'true'
       uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.14


### PR DESCRIPTION
## Please provide the following details to expedite review (and delete this heading)

Add cache keys to GitHub actions to skip repetitive installation packages to save time.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Because this is a GitHub action related solution, wait until the static-analysis action finishes. Check that step `Set up Go 1.14` was run. Rerun the same file and check how step `Cache install go` finds the previous go installation and skips the `Set up Go 1.14` step.

