### PR TITLE
Add support for updating secrets

### DIFF
--- a/api/secrets/client_test.go
+++ b/api/secrets/client_test.go
@@ -100,5 +100,5 @@ func (s *SecretsSuite) TestListSecretsError(c *gc.C) {
 	result, err := client.ListSecrets(true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
-	c.Assert(result[0].Error, gc.ErrorMatches, "boom")
+	c.Assert(result[0].Error, gc.Equals, "boom")
 }

--- a/api/secrets/client_test.go
+++ b/api/secrets/client_test.go
@@ -64,7 +64,7 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 	client := apisecrets.NewClient(apiCaller)
 	result, err := client.ListSecrets(true)
 	c.Assert(err, jc.ErrorIsNil)
-	URL := secrets.NewURL(1, "", "", "app.password", "")
+	URL := secrets.NewSimpleURL(1, "app.password")
 	c.Assert(result, jc.DeepEquals, []apisecrets.SecretDetails{{
 		Metadata: secrets.SecretMetadata{
 			URL:            URL,

--- a/api/secretsmanager/client_test.go
+++ b/api/secretsmanager/client_test.go
@@ -61,7 +61,7 @@ func (s *SecretsSuite) TestCreateSecret(c *gc.C) {
 	value := secrets.NewSecretValue(data)
 	cfg := secrets.NewPasswordSecretConfig(10, true, "app", "password")
 	cfg.RotateInterval = time.Hour
-	result, err := client.Create(cfg, value)
+	result, err := client.Create(cfg, secrets.TypePassword, value)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.Equals, "secret://foo")
 }
@@ -77,7 +77,60 @@ func (s *SecretsSuite) TestCreateSecretsError(c *gc.C) {
 	})
 	client := secretsmanager.NewClient(apiCaller)
 	value := secrets.NewSecretValue(nil)
-	result, err := client.Create(secrets.NewSecretConfig("app", "password"), value)
+	result, err := client.Create(secrets.NewSecretConfig("app", "password"), secrets.TypeBlob, value)
+	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(result, gc.Equals, "")
+}
+
+func (s *SecretsSuite) TestUpdateSecret(c *gc.C) {
+	data := map[string]string{"foo": "bar"}
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "SecretsManager")
+		c.Check(version, gc.Equals, 0)
+		c.Check(id, gc.Equals, "")
+		c.Check(request, gc.Equals, "UpdateSecrets")
+		c.Check(arg, gc.DeepEquals, params.UpdateSecretArgs{
+			Args: []params.UpdateSecretArg{{
+				URL: "secret://v1/foo",
+				RotateInterval: time.Hour,
+				Params: map[string]interface{}{
+					"password-length":        10,
+					"password-special-chars": true,
+				},
+				Data: data,
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
+		*(result.(*params.StringResults)) = params.StringResults{
+			[]params.StringResult{{
+				Result: "secret://v1/foo?revision=2",
+			}},
+		}
+		return nil
+	})
+	client := secretsmanager.NewClient(apiCaller)
+	value := secrets.NewSecretValue(data)
+	cfg := secrets.NewPasswordSecretConfig(10, true, "app", "password")
+	cfg.RotateInterval = time.Hour
+	URL := secrets.NewSimpleURL(1, "foo")
+	result, err := client.Update(URL, cfg, value)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, "secret://v1/foo?revision=2")
+}
+
+func (s *SecretsSuite) TestUpdateSecretsError(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		*(result.(*params.StringResults)) = params.StringResults{
+			[]params.StringResult{{
+				Error: &params.Error{Message: "boom"},
+			}},
+		}
+		return nil
+	})
+	client := secretsmanager.NewClient(apiCaller)
+	value := secrets.NewSecretValue(nil)
+	URL := secrets.NewSimpleURL(1, "foo")
+	result, err := client.Update(URL, secrets.NewSecretConfig("app", "password"), value)
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(result, gc.Equals, "")
 }
@@ -90,7 +143,7 @@ func (s *SecretsSuite) TestGetSecret(c *gc.C) {
 		c.Check(request, gc.Equals, "GetSecretValues")
 		c.Check(arg, gc.DeepEquals, params.GetSecretArgs{
 			Args: []params.GetSecretArg{{
-				ID: "secret://foo",
+				ID: "secret://v1/foo",
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretValueResults{})
@@ -102,7 +155,7 @@ func (s *SecretsSuite) TestGetSecret(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	result, err := client.GetValue("secret://foo")
+	result, err := client.GetValue("secret://v1/foo")
 	c.Assert(err, jc.ErrorIsNil)
 	value := secrets.NewSecretValue(map[string]string{"foo": "bar"})
 	c.Assert(result, jc.DeepEquals, value)
@@ -118,7 +171,7 @@ func (s *SecretsSuite) TestGetSecretsError(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	result, err := client.GetValue("secret://foo")
+	result, err := client.GetValue("secret://v1/foo")
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(result, gc.IsNil)
 }

--- a/api/secretsmanager/client_test.go
+++ b/api/secretsmanager/client_test.go
@@ -91,7 +91,7 @@ func (s *SecretsSuite) TestUpdateSecret(c *gc.C) {
 		c.Check(request, gc.Equals, "UpdateSecrets")
 		c.Check(arg, gc.DeepEquals, params.UpdateSecretArgs{
 			Args: []params.UpdateSecretArg{{
-				URL: "secret://v1/foo",
+				URL:            "secret://v1/foo",
 				RotateInterval: time.Hour,
 				Params: map[string]interface{}{
 					"password-length":        10,

--- a/apiserver/facades/agent/secretsmanager/mocks/secretservice.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretservice.go
@@ -37,18 +37,18 @@ func (m *MockSecretsService) EXPECT() *MockSecretsServiceMockRecorder {
 }
 
 // CreateSecret mocks base method.
-func (m *MockSecretsService) CreateSecret(arg0 context.Context, arg1 secrets0.CreateParams) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsService) CreateSecret(arg0 context.Context, arg1 *secrets.URL, arg2 secrets0.CreateParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecret indicates an expected call of CreateSecret.
-func (mr *MockSecretsServiceMockRecorder) CreateSecret(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSecretsServiceMockRecorder) CreateSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSecretsService)(nil).CreateSecret), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSecretsService)(nil).CreateSecret), arg0, arg1, arg2)
 }
 
 // DeleteSecret mocks base method.

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/permission"
-	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/secrets"
 	"github.com/juju/juju/secrets/provider"
 	"github.com/juju/juju/secrets/provider/juju"
@@ -90,9 +89,8 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 	}
 	result.Results = make([]params.ListSecretResult, len(metadata))
 	for i, m := range metadata {
-		URL := coresecrets.NewURL(m.Version, s.controllerUUID, s.modelUUID, m.Path, "")
 		secretResult := params.ListSecretResult{
-			URL:            URL.String(),
+			URL:            m.URL.String(),
 			Path:           m.Path,
 			RotateInterval: m.RotateInterval,
 			Version:        m.Version,
@@ -106,7 +104,7 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			UpdateTime:     m.UpdateTime,
 		}
 		if arg.ShowSecrets {
-			val, err := s.secretsService.GetSecretValue(ctx, URL)
+			val, err := s.secretsService.GetSecretValue(ctx, m.URL)
 			valueResult := &params.SecretValueResult{
 				Error: apiservererrors.ServerError(err),
 			}

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -71,7 +71,14 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	now := time.Now()
+	URL := &coresecrets.URL{
+		Version:        "v1",
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		Path:           "app.password",
+	}
 	metadata := []*coresecrets.SecretMetadata{{
+		URL:            URL,
 		Path:           "app.password",
 		RotateInterval: time.Hour,
 		Version:        1,
@@ -89,12 +96,6 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	)
 
 	var valueResult *params.SecretValueResult
-	URL := &coresecrets.URL{
-		Version:        "v1",
-		ControllerUUID: coretesting.ControllerTag.Id(),
-		ModelUUID:      coretesting.ModelTag.Id(),
-		Path:           "app.password",
-	}
 	if show {
 		valueResult = &params.SecretValueResult{
 			Data: map[string]string{"foo": "bar"},

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39865,6 +39865,18 @@
                         }
                     },
                     "description": "GetSecretValues returns the secret values for the specified secrets."
+                },
+                "UpdateSecrets": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateSecretArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    },
+                    "description": "UpdateSecrets updates the specified secrets."
                 }
             },
             "definitions": {
@@ -40032,6 +40044,54 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "UpdateSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "rotate-interval": {
+                            "type": "integer"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "url",
+                        "rotate-interval"
+                    ]
+                },
+                "UpdateSecretArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateSecretArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
                     ]
                 }
             }

--- a/apiserver/params/secrets.go
+++ b/apiserver/params/secrets.go
@@ -30,6 +30,26 @@ type CreateSecretArg struct {
 	Data map[string]string `json:"data,omitempty"`
 }
 
+// UpdateSecretArgs holds args for creating secrets.
+type UpdateSecretArgs struct {
+	Args []UpdateSecretArg `json:"args"`
+}
+
+// UpdateSecretArg holds the args for creating a secret.
+type UpdateSecretArg struct {
+	// URL identifies the secret to update.
+	URL string `json:"url"`
+	// RotateInterval is how often a secret should be rotated.
+	// Use a value < 0 to keep the current rotate interval.
+	RotateInterval time.Duration `json:"rotate-interval"`
+	// Params are used when generating secrets server side.
+	// See core/secrets/secret.go.
+	Params map[string]interface{} `json:"params,omitempty"`
+	// Data is the key values of the secret value itself.
+	// Use an empty value to keep the current value.
+	Data map[string]string `json:"data,omitempty"`
+}
+
 // GetSecretArgs holds the args for getting secrets.
 type GetSecretArgs struct {
 	Args []GetSecretArg `json:"args"`

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -134,6 +134,7 @@ var expectedCommands = []string{
 	"resource-get",
 	"secret-create",
 	"secret-get",
+	"secret-update",
 	"state-delete",
 	"state-get",
 	"state-set",

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -105,6 +105,7 @@ type secretDisplayDetails struct {
 	ProviderID     string              `json:"backend-id,omitempty" yaml:"backend-id,omitempty"`
 	CreateTime     time.Time           `json:"create-time" yaml:"create-time"`
 	UpdateTime     time.Time           `json:"update-time" yaml:"update-time"`
+	Error          string              `json:"error,omitempty" yaml:"error,omitempty"`
 	Value          *secretValueDetails `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
@@ -140,20 +141,17 @@ func (c *listSecretsCommand) Run(ctxt *cmd.Context) error {
 			Revision:       m.Metadata.Revision,
 			CreateTime:     m.Metadata.CreateTime,
 			UpdateTime:     m.Metadata.UpdateTime,
+			Error:          m.Error,
 		}
 		if c.showSecrets && m.Value != nil {
-			details[i].Value = &secretValueDetails{
-				Error: m.Error,
-			}
-			if m.Error != nil {
-				continue
-			}
+			valueDetails := &secretValueDetails{}
 			val, err := m.Value.Values()
 			if err != nil {
-				details[i].Value.Error = err
+				valueDetails.Error = err
 			} else {
-				details[i].Value.Data = val
+				valueDetails.Data = val
 			}
+			details[i].Value = valueDetails
 		}
 	}
 	return c.out.Write(ctxt, details)

--- a/cmd/juju/secrets/list_test.go
+++ b/cmd/juju/secrets/list_test.go
@@ -74,12 +74,18 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 
 	URL, err := coresecrets.ParseURL("secret://v1/app.password")
 	c.Assert(err, jc.ErrorIsNil)
+	URL2, err := coresecrets.ParseURL("secret://v1/app.apitoken")
+	c.Assert(err, jc.ErrorIsNil)
 	s.secretsAPI.EXPECT().ListSecrets(true).Return(
 		[]apisecrets.SecretDetails{{
 			Metadata: coresecrets.SecretMetadata{
 				URL: URL, ID: 666, RotateInterval: time.Hour,
 				Version: 1, Revision: 2, Path: "app.password", Provider: "juju"},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
+		}, {
+			Metadata: coresecrets.SecretMetadata{
+				URL: URL2, ID: 667, Version: 1, Revision: 1, Path: "app.apitoken", Provider: "juju"},
+			Error: "boom",
 		}}, nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
@@ -98,6 +104,15 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
   update-time: 0001-01-01T00:00:00Z
   value:
     foo: bar
+- ID: 667
+  URL: secret://v1/app.apitoken
+  revision: 1
+  path: app.apitoken
+  version: 1
+  backend: juju
+  create-time: 0001-01-01T00:00:00Z
+  update-time: 0001-01-01T00:00:00Z
+  error: boom
 `[1:])
 }
 

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -23,11 +23,6 @@ const (
 	TypePassword = SecretType("password")
 )
 
-var validTypes = map[SecretType]bool{
-	TypeBlob:     true,
-	TypePassword: true,
-}
-
 // SecretConfig is used when cresting a secret.
 type SecretConfig struct {
 	Path           string
@@ -136,8 +131,8 @@ func ParseURL(str string) (*URL, error) {
 // NewSimpleURL returns a URL with the specified path.
 func NewSimpleURL(version int, path string) *URL {
 	return &URL{
-		Version:        fmt.Sprintf("v%d", version),
-		Path:           path,
+		Version: fmt.Sprintf("v%d", version),
+		Path:    path,
 	}
 }
 
@@ -185,7 +180,7 @@ func (u *URL) String() string {
 	if u == nil {
 		return ""
 	}
-	fullPath := []string{"secret:/", u.Version}
+	fullPath := []string{u.Version}
 	if u.ControllerUUID != "" {
 		fullPath = append(fullPath, u.ControllerUUID)
 	}
@@ -194,13 +189,15 @@ func (u *URL) String() string {
 	}
 	fullPath = append(fullPath, u.Path)
 	str := strings.Join(fullPath, "/")
+	urlValue := url.URL{
+		Scheme:   "secret",
+		Path:     str,
+		Fragment: u.Attribute,
+	}
 	if u.Revision > 0 {
-		str += fmt.Sprintf("?revision=%d", u.Revision)
+		urlValue.RawQuery = fmt.Sprintf("revision=%d", u.Revision)
 	}
-	if u.Attribute != "" {
-		str += "#" + u.Attribute
-	}
-	return str
+	return urlValue.String()
 }
 
 // SecretMetadata holds metadata about a secret.

--- a/secrets/interface.go
+++ b/secrets/interface.go
@@ -17,8 +17,6 @@ const (
 
 // CreateParams are used to create a secret.
 type CreateParams struct {
-	ControllerUUID string
-	ModelUUID      string
 	ProviderLabel  string
 	Version        int
 	Type           string
@@ -43,7 +41,7 @@ type Filter struct {
 // SecretsService instances provide a backend for storing secrets values.
 type SecretsService interface {
 	// CreateSecret creates a new secret and returns a URL for accessing the secret value.
-	CreateSecret(ctx context.Context, p CreateParams) (*secrets.SecretMetadata, error)
+	CreateSecret(ctx context.Context, URL *secrets.URL, p CreateParams) (*secrets.SecretMetadata, error)
 
 	// UpdateSecret updates a given secret with a new secret value.
 	UpdateSecret(ctx context.Context, URL *secrets.URL, p UpdateParams) (*secrets.SecretMetadata, error)

--- a/secrets/provider/juju/mocks/secretstore.go
+++ b/secrets/provider/juju/mocks/secretstore.go
@@ -36,18 +36,18 @@ func (m *MockSecretsStore) EXPECT() *MockSecretsStoreMockRecorder {
 }
 
 // CreateSecret mocks base method.
-func (m *MockSecretsStore) CreateSecret(arg0 state.CreateSecretParams) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsStore) CreateSecret(arg0 *secrets.URL, arg1 state.CreateSecretParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecret", arg0)
+	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecret indicates an expected call of CreateSecret.
-func (mr *MockSecretsStoreMockRecorder) CreateSecret(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretsStoreMockRecorder) CreateSecret(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSecretsStore)(nil).CreateSecret), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSecretsStore)(nil).CreateSecret), arg0, arg1)
 }
 
 // GetSecret mocks base method.

--- a/secrets/provider/juju/mocks/secretstore.go
+++ b/secrets/provider/juju/mocks/secretstore.go
@@ -50,6 +50,21 @@ func (mr *MockSecretsStoreMockRecorder) CreateSecret(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSecretsStore)(nil).CreateSecret), arg0)
 }
 
+// GetSecret mocks base method.
+func (m *MockSecretsStore) GetSecret(arg0 *secrets.URL) (*secrets.SecretMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecret", arg0)
+	ret0, _ := ret[0].(*secrets.SecretMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecret indicates an expected call of GetSecret.
+func (mr *MockSecretsStoreMockRecorder) GetSecret(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockSecretsStore)(nil).GetSecret), arg0)
+}
+
 // GetSecretValue mocks base method.
 func (m *MockSecretsStore) GetSecretValue(arg0 *secrets.URL) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()

--- a/secrets/provider/juju/mongosecrets.go
+++ b/secrets/provider/juju/mongosecrets.go
@@ -56,7 +56,20 @@ func (s secretsService) CreateSecret(ctx context.Context, p secrets.CreateParams
 
 // GetSecretValue implements SecretsService.
 func (s secretsService) GetSecretValue(ctx context.Context, URL *coresecrets.URL) (coresecrets.SecretValue, error) {
+	// If no specific revision asked for, use the latest.
+	if URL.Revision == 0 {
+		metadata, err := s.GetSecret(ctx, URL)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		URL = metadata.URL.WithRevision(metadata.Revision)
+	}
 	return s.backend.GetSecretValue(URL)
+}
+
+// GetSecret implements SecretsService.
+func (s secretsService) GetSecret(ctx context.Context, URL *coresecrets.URL) (*coresecrets.SecretMetadata, error) {
+	return s.backend.GetSecret(URL.WithRevision(0).WithAttribute(""))
 }
 
 // ListSecrets implements SecretsService.
@@ -78,11 +91,6 @@ func (s secretsService) UpdateSecret(ctx context.Context, URL *coresecrets.URL, 
 }
 
 // TODO(wallyworld)
-
-// GetSecret implements SecretsService.
-func (s secretsService) GetSecret(ctx context.Context, URL *coresecrets.URL) (*coresecrets.SecretMetadata, error) {
-	return nil, errors.NotImplementedf("GetSecret")
-}
 
 // DeleteSecret implements SecretsService.
 func (s secretsService) DeleteSecret(ctx context.Context, URL *coresecrets.URL) error {

--- a/secrets/provider/juju/mongosecrets.go
+++ b/secrets/provider/juju/mongosecrets.go
@@ -36,10 +36,8 @@ func NewSecretService(cfg secrets.ProviderConfig) (*secretsService, error) {
 }
 
 // CreateSecret implements SecretsService.
-func (s secretsService) CreateSecret(ctx context.Context, p secrets.CreateParams) (*coresecrets.SecretMetadata, error) {
-	metadata, err := s.backend.CreateSecret(state.CreateSecretParams{
-		ControllerUUID: p.ControllerUUID,
-		ModelUUID:      p.ModelUUID,
+func (s secretsService) CreateSecret(ctx context.Context, URL *coresecrets.URL, p secrets.CreateParams) (*coresecrets.SecretMetadata, error) {
+	metadata, err := s.backend.CreateSecret(URL, state.CreateSecretParams{
 		ProviderLabel:  Provider,
 		Version:        p.Version,
 		Type:           p.Type,

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -45,6 +45,7 @@ type SecretsFilter struct{}
 type SecretsStore interface {
 	CreateSecret(p CreateSecretParams) (*secrets.SecretMetadata, error)
 	UpdateSecret(URL *secrets.URL, p UpdateSecretParams) (*secrets.SecretMetadata, error)
+	GetSecret(URL *secrets.URL) (*secrets.SecretMetadata, error)
 	GetSecretValue(URL *secrets.URL) (secrets.SecretValue, error)
 	ListSecrets(filter SecretsFilter) ([]*secrets.SecretMetadata, error)
 }
@@ -96,16 +97,23 @@ type secretsStore struct {
 	st *State
 }
 
-func (s *secretsStore) secretMetadataDoc(URL *secrets.URL, p *CreateSecretParams) (*secretMetadataDoc, error) {
+func (s *secretsStore) secretMetadataDoc(p *CreateSecretParams) (*secrets.URL, *secretMetadataDoc, error) {
 	id, err := sequenceWithMin(s.st, "secret", 1)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
-	return &secretMetadataDoc{
+	interval := p.RotateInterval
+	if interval < 0 {
+		interval = 0
+	}
+	URL := secrets.NewSimpleURL(p.Version, p.Path)
+	URL.ControllerUUID = p.ControllerUUID
+	URL.ModelUUID = p.ModelUUID
+	md := &secretMetadataDoc{
 		DocID:          URL.String(),
 		Path:           p.Path,
 		Version:        p.Version,
-		RotateInterval: p.RotateInterval,
+		RotateInterval: interval,
 		Description:    "",
 		Tags:           nil,
 		ID:             id,
@@ -114,13 +122,20 @@ func (s *secretsStore) secretMetadataDoc(URL *secrets.URL, p *CreateSecretParams
 		Revision:       1,
 		CreateTime:     s.st.nowToTheSecond(),
 		UpdateTime:     s.st.nowToTheSecond(),
-	}, nil
+	}
+	return URL.WithRevision(md.Revision), md, nil
 }
 
-func (s *secretsStore) updateSecretMetadataDoc(doc *secretMetadataDoc, p *UpdateSecretParams) {
+func (s *secretsStore) updateSecretMetadataDoc(doc *secretMetadataDoc, baseURL *secrets.URL, p *UpdateSecretParams) *secrets.URL {
+	if p.RotateInterval >= 0 {
+		doc.RotateInterval = p.RotateInterval
+	}
+	if len(p.Data) > 0 {
+		doc.Revision++
+	}
+	updatedURL := *baseURL.WithRevision(doc.Revision)
 	doc.UpdateTime = s.st.nowToTheSecond()
-	doc.RotateInterval = p.RotateInterval
-	doc.Revision = doc.Revision + 1
+	return &updatedURL
 }
 
 func (s *secretsStore) secretValueDoc(url *secrets.URL, data secrets.SecretData) *secretValueDoc {
@@ -136,14 +151,7 @@ func (s *secretsStore) secretValueDoc(url *secrets.URL, data secrets.SecretData)
 
 // CreateSecret creates a new secret.
 func (s *secretsStore) CreateSecret(p CreateSecretParams) (*secrets.SecretMetadata, error) {
-	URL := &secrets.URL{
-		Version:        fmt.Sprintf("v%d", p.Version),
-		ControllerUUID: p.ControllerUUID,
-		ModelUUID:      p.ModelUUID,
-		Path:           p.Path,
-		Revision:       1,
-	}
-	metadataDoc, err := s.secretMetadataDoc(URL, &p)
+	URL, metadataDoc, err := s.secretMetadataDoc(&p)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -173,9 +181,7 @@ func (s *secretsStore) CreateSecret(p CreateSecretParams) (*secrets.SecretMetada
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	metadata := s.toSecretMetadata(metadataDoc)
-	metadata.URL = URL
-	return metadata, nil
+	return s.toSecretMetadata(metadataDoc)
 }
 
 // UpdateSecret updates an existing secret.
@@ -183,39 +189,41 @@ func (s *secretsStore) UpdateSecret(URL *secrets.URL, p UpdateSecretParams) (*se
 	if URL.Revision > 0 {
 		return nil, errors.New("cannot specify a revision when updating a secret")
 	}
+	if len(p.Data) == 0 && p.RotateInterval < 0 && len(p.Params) == 0 {
+		return nil, errors.New("must specify a new value or metadata to update a secret")
+	}
 	secretMetadataCollection, closer := s.st.db().GetCollection(secretMetadataC)
 	defer closer()
 
 	var metadataDoc secretMetadataDoc
-	baseURL := URL.WithRevision(0)
-	updatedURL := *URL
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		err := secretMetadataCollection.FindId(baseURL.ID()).One(&metadataDoc)
+		err := secretMetadataCollection.FindId(URL.ID()).One(&metadataDoc)
 		if errors.Cause(err) == mgo.ErrNotFound {
-			return nil, errors.NotFoundf("secret %q", baseURL.ID())
+			return nil, errors.NotFoundf("secret %q", URL.ID())
 		}
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		s.updateSecretMetadataDoc(&metadataDoc, &p)
-		updatedURL = *updatedURL.WithRevision(metadataDoc.Revision)
-		if _, err := s.GetSecretValue(&updatedURL); err == nil {
-			return nil, errors.AlreadyExistsf("secret value for %q", URL.ID())
-		}
-
-		valueDoc := s.secretValueDoc(&updatedURL, p.Data)
+		updatedURL := s.updateSecretMetadataDoc(&metadataDoc, URL, &p)
 		ops := []txn.Op{
 			{
 				C:      secretMetadataC,
 				Id:     metadataDoc.DocID,
 				Assert: txn.DocExists,
 				Update: bson.M{"$set": metadataDoc},
-			}, {
+			},
+		}
+		if len(p.Data) > 0 {
+			if _, err := s.GetSecretValue(updatedURL); err == nil {
+				return nil, errors.AlreadyExistsf("secret value for %q", URL.ID())
+			}
+			valueDoc := s.secretValueDoc(updatedURL, p.Data)
+			ops = append(ops, txn.Op{
 				C:      secretValuesC,
 				Id:     valueDoc.DocID,
 				Assert: txn.DocMissing,
 				Insert: *valueDoc,
-			},
+			})
 		}
 		return ops, nil
 	}
@@ -223,13 +231,16 @@ func (s *secretsStore) UpdateSecret(URL *secrets.URL, p UpdateSecretParams) (*se
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	metadata := s.toSecretMetadata(&metadataDoc)
-	metadata.URL = &updatedURL
-	return metadata, nil
+	return s.toSecretMetadata(&metadataDoc)
 }
 
-func (s *secretsStore) toSecretMetadata(doc *secretMetadataDoc) *secrets.SecretMetadata {
+func (s *secretsStore) toSecretMetadata(doc *secretMetadataDoc) (*secrets.SecretMetadata, error) {
+	URL, err := secrets.ParseURL(doc.DocID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &secrets.SecretMetadata{
+		URL:            URL,
 		Path:           doc.Path,
 		Version:        doc.Version,
 		RotateInterval: doc.RotateInterval,
@@ -241,7 +252,7 @@ func (s *secretsStore) toSecretMetadata(doc *secretMetadataDoc) *secrets.SecretM
 		Revision:       doc.Revision,
 		CreateTime:     doc.CreateTime,
 		UpdateTime:     doc.UpdateTime,
-	}
+	}, nil
 }
 
 // GetSecretValue gets the secret value for the specified URL.
@@ -270,6 +281,22 @@ func (s *secretsStore) GetSecretValue(URL *secrets.URL) (secrets.SecretValue, er
 	return secrets.NewSecretValue(data), nil
 }
 
+// GetSecret gets the secret metadata for the specified URL.
+func (s *secretsStore) GetSecret(URL *secrets.URL) (*secrets.SecretMetadata, error) {
+	secretMetadataCollection, closer := s.st.db().GetCollection(secretMetadataC)
+	defer closer()
+
+	var doc secretMetadataDoc
+	err := secretMetadataCollection.FindId(URL.WithRevision(0).ID()).One(&doc)
+	if errors.Cause(err) == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("secret %q", URL.String())
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return s.toSecretMetadata(&doc)
+}
+
 // ListSecrets list the secrets using the specified filter.
 // TODO(wallywolrd) - implement filter
 func (s *secretsStore) ListSecrets(filter SecretsFilter) ([]*secrets.SecretMetadata, error) {
@@ -284,7 +311,10 @@ func (s *secretsStore) ListSecrets(filter SecretsFilter) ([]*secrets.SecretMetad
 	}
 	result := make([]*secrets.SecretMetadata, len(docs))
 	for i, doc := range docs {
-		result[i] = s.toSecretMetadata(&doc)
+		result[i], err = s.toSecretMetadata(&doc)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	return result, nil
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -780,7 +780,16 @@ func (ctx *HookContext) CreateSecret(name string, args *jujuc.UpsertArgs) (strin
 	app, _ := names.UnitApplication(ctx.UnitName())
 	cfg := coresecrets.NewSecretConfig(app, name)
 	cfg.RotateInterval = args.RotateInterval
-	return ctx.secretFacade.Create(cfg, args.Value)
+	return ctx.secretFacade.Create(cfg, args.Type, args.Value)
+}
+
+// UpdateSecret creates a secret with the specified data.
+func (ctx *HookContext) UpdateSecret(name string, args *jujuc.UpsertArgs) (string, error) {
+	app, _ := names.UnitApplication(ctx.UnitName())
+	cfg := coresecrets.NewSecretConfig(app, name)
+	cfg.RotateInterval = args.RotateInterval
+	URL := coresecrets.NewSimpleURL(1, cfg.Path)
+	return ctx.secretFacade.Update(URL, cfg, args.Value)
 }
 
 // GoalState returns the goal state for the current unit.

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -926,6 +926,7 @@ func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
 	client := secretsmanager.NewClient(apiCaller)
 	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
 	id, err := hookContext.CreateSecret("password", &jujuc.UpsertArgs{
+		Type:           secrets.TypeBlob,
 		Value:          value,
 		RotateInterval: time.Hour,
 	})

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -165,6 +165,9 @@ type ContextUnit interface {
 
 // UpsertArgs specifies args used to create or update a secret.
 type UpsertArgs struct {
+	// Type is the secret type (only used for insert).
+	Type secrets.SecretType
+
 	// Value is the new secret value or nil to not update.
 	Value secrets.SecretValue
 
@@ -179,6 +182,8 @@ type ContextSecrets interface {
 
 	// CreateSecret creates a secret with the specified data.
 	CreateSecret(name string, args *UpsertArgs) (string, error)
+
+	UpdateSecret(name string, args *UpsertArgs) (string, error)
 }
 
 // ContextStatus is the part of a hook context related to the unit's status.

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -26,3 +26,9 @@ func (c *ContextSecrets) CreateSecret(name string, args *jujuc.UpsertArgs) (stri
 	c.stub.AddCall("CreateSecret", name, args)
 	return "secret://app." + name, nil
 }
+
+// UpdateSecret implements jujuc.ContextSecrets.
+func (c *ContextSecrets) UpdateSecret(name string, args *jujuc.UpsertArgs) (string, error) {
+	c.stub.AddCall("UpdateSecret", name, args)
+	return "secret://app." + name, nil
+}

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -742,6 +742,21 @@ func (mr *MockContextMockRecorder) UpdateActionResults(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActionResults", reflect.TypeOf((*MockContext)(nil).UpdateActionResults), arg0, arg1)
 }
 
+// UpdateSecret mocks base method.
+func (m *MockContext) UpdateSecret(arg0 string, arg1 *jujuc.UpsertArgs) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateSecret indicates an expected call of UpdateSecret.
+func (mr *MockContextMockRecorder) UpdateSecret(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecret", reflect.TypeOf((*MockContext)(nil).UpdateSecret), arg0, arg1)
+}
+
 // WorkloadName mocks base method.
 func (m *MockContext) WorkloadName() (string, error) {
 	m.ctrl.T.Helper()

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -231,3 +231,8 @@ func (ctx *RestrictedContext) GetSecret(ID string) (secrets.SecretValue, error) 
 func (ctx *RestrictedContext) CreateSecret(name string, args *UpsertArgs) (string, error) {
 	return "", ErrRestrictedContext
 }
+
+// UpdateSecret implements runner.Context.
+func (ctx *RestrictedContext) UpdateSecret(name string, args *UpsertArgs) (string, error) {
+	return "", ErrRestrictedContext
+}

--- a/worker/uniter/runner/jujuc/secret-update_test.go
+++ b/worker/uniter/runner/jujuc/secret-update_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
-type SecretCreateSuite struct {
+type SecretUpdateSuite struct {
 	ContextSuite
 }
 
-var _ = gc.Suite(&SecretCreateSuite{})
+var _ = gc.Suite(&SecretUpdateSuite{})
 
-func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
+func (s *SecretUpdateSuite) TestUpdateSecretInvalidArgs(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
 	for _, t := range []struct {
@@ -32,9 +32,6 @@ func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
 		{
 			args: []string{},
 			err:  "ERROR missing secret id",
-		}, {
-			args: []string{"password"},
-			err:  "ERROR missing secret value",
 		}, {
 			args: []string{"password", "s3cret", "foo=bar"},
 			err:  `ERROR key value "foo=bar" not valid when a singular value has already been specified`,
@@ -46,7 +43,7 @@ func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR rotate interval "-1h0m0s" not valid`,
 		},
 	} {
-		com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+		com, err := jujuc.NewCommand(hctx, cmdString("secret-update"))
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -56,10 +53,10 @@ func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
 	}
 }
 
-func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
+func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-update"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"password", "secret", "--rotate", "1h"})
@@ -67,18 +64,17 @@ func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 	val := coresecrets.NewSecretValue(map[string]string{"data": "c2VjcmV0"})
 	args := &jujuc.UpsertArgs{
-		Type:           coresecrets.TypeBlob,
 		Value:          val,
 		RotateInterval: time.Hour,
 	}
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "CreateSecret", Args: []interface{}{"password", args}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UpdateSecret", Args: []interface{}{"password", args}}})
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret://app.password\n")
 }
 
-func (s *SecretCreateSuite) TestCreateSecretBase64(c *gc.C) {
+func (s *SecretUpdateSuite) TestUpdateSecretBase64(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewCommand(hctx, cmdString("secret-create"))
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-update"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--base64", "apikey", "token=key="})
@@ -86,9 +82,26 @@ func (s *SecretCreateSuite) TestCreateSecretBase64(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 	val := coresecrets.NewSecretValue(map[string]string{"token": "key="})
 	args := &jujuc.UpsertArgs{
-		Type:  coresecrets.TypeBlob,
-		Value: val,
+		Value:          val,
+		RotateInterval: -1,
 	}
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "CreateSecret", Args: []interface{}{"apikey", args}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UpdateSecret", Args: []interface{}{"apikey", args}}})
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret://app.apikey\n")
+}
+
+func (s *SecretUpdateSuite) TestUpdateSecretRotateInterval(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-update"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--rotate", "5h", "apikey"})
+
+	c.Assert(code, gc.Equals, 0)
+	args := &jujuc.UpsertArgs{
+		Value:          coresecrets.NewSecretValue(nil),
+		RotateInterval: 5 * time.Hour,
+	}
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UpdateSecret", Args: []interface{}{"apikey", args}}})
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret://app.apikey\n")
 }

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -96,6 +96,7 @@ func constructCommandCreator(name string, newCmd functionCmdCreator) creator {
 
 var secretCommands = map[string]creator{
 	"secret-create" + cmdSuffix: NewSecretCreateCommand,
+	"secret-update" + cmdSuffix: NewSecretUpdateCommand,
 	"secret-get" + cmdSuffix:    NewSecretGetCommand,
 }
 


### PR DESCRIPTION
Add support for updating secrets:
- secrets-update hook command
- api and apiserver facade methods
- "juju" services service methods
- mongo / state methods

The hook command can be used to update either the secret data, the rotate interval, or both.

Also tweak error landing in the list-secrets CLI so errors are displayed in YAML/JSON output.

## QA steps

bootstrap and deploy ubuntu charm

Create the secret
```plain
$ juju exec --unit ubuntu/0 "secret-create password foo=bar hello=world"
secret://v1/5a4f74fc-3b37-46d9-8aa0-611f7f838197/df931ce7-ce22-4ce5-849a-4d315c805832/ubuntu.password
$ juju exec --unit ubuntu/0 "secret-get secret://v1/ubuntu.password"
foo: bar
hello: world

$ juju secrets
ID  Revision  Rotate  Backend  Path             Age
1          1  never   juju     ubuntu.password  33 seconds ago  
```

Update the rotate interval
```
$ juju exec --unit ubuntu/0 "secret-update password --rotate=1h"
secret://v1/5a4f74fc-3b37-46d9-8aa0-611f7f838197/df931ce7-ce22-4ce5-849a-4d315c805832/ubuntu.password?revision=1
$ juju secrets
ID  Revision  Rotate  Backend  Path             Age
1          1  1h      juju     ubuntu.password  8 seconds ago  

$ juju secrets --format yaml --show-secrets
- ID: 1
  URL: secret://v1/ubuntu.password
  revision: 1
  path: ubuntu.password
  rotate-interval: 1h0m0s
  version: 1
  backend: juju
  create-time: 2021-08-24T03:22:07Z
  update-time: 2021-08-24T03:23:43Z
  value:
    foo: bar
    hello: world
```

Update the value
```
$ juju exec --unit ubuntu/0 "secret-update password foo2=bar"
secret://v1/5a4f74fc-3b37-46d9-8aa0-611f7f838197/df931ce7-ce22-4ce5-849a-4d315c805832/ubuntu.password?revision=2
$ juju secrets --format yaml --show-secrets
- ID: 1
  URL: secret://v1/ubuntu.password
  revision: 2
  path: ubuntu.password
  rotate-interval: 1h0m0s
  version: 1
  backend: juju
  create-time: 2021-08-24T03:22:07Z
  update-time: 2021-08-24T03:24:46Z
  value:
    foo2: bar
```

Set rotate interval back to "never"
```
$ juju exec --unit ubuntu/0 "secret-update password --rotate=0"
secret://v1/5a4f74fc-3b37-46d9-8aa0-611f7f838197/df931ce7-ce22-4ce5-849a-4d315c805832/ubuntu.password?revision=2
$ juju secrets --format yaml --show-secrets
- ID: 1
  URL: secret://v1/ubuntu.password
  revision: 1
  path: ubuntu.password
  version: 1
  backend: juju
  create-time: 2021-08-24T03:22:07Z
  update-time: 2021-08-24T03:25:25Z
  value:
    foo2: bar

$ juju secrets
ID  Revision  Rotate  Backend  Path             Age
1          3  never   juju     ubuntu.password  11 seconds ago  
```