### PR TITLE
Network devices from config host_name

### DIFF
--- a/container/lxd/export_test.go
+++ b/container/lxd/export_test.go
@@ -61,11 +61,11 @@ func VerifyNICsWithConfigFile(svr *Server, nics map[string]device, reader func(s
 	return svr.verifyNICsWithConfigFile(nics, reader)
 }
 
-func NetworkDevicesFromConfig(mgr container.Manager, netConfig *container.NetworkConfig, machineID string) (
+func NetworkDevicesFromConfig(mgr container.Manager, netConfig *container.NetworkConfig) (
 	map[string]device, []string, error,
 ) {
 	cMgr := mgr.(*containerManager)
-	return cMgr.networkDevicesFromConfig(netConfig, machineID)
+	return cMgr.networkDevicesFromConfig(netConfig)
 }
 
 func NewTestingServer(svr lxdclient.ContainerServer, clock clock.Clock) (*Server, error) {

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -287,11 +287,13 @@ func (m *containerManager) networkDevicesFromConfig(netConfig *container.Network
 	if len(netConfig.Interfaces) > 0 {
 		return DevicesFromInterfaceInfo(netConfig.Interfaces, machineID)
 	} else if netConfig.Device != "" {
+		// For the eth0 case do not generate an interface name, instead let
+		// LXD select a host_name for that device.
 		return map[string]device{
 			"eth0": newNICDevice(
 				"eth0",
 				netConfig.Device,
-				makeHostInterfaceName(machineID, 0),
+				"",
 				corenetwork.GenerateVirtualMACAddress(),
 				netConfig.MTU,
 			),

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -293,7 +293,6 @@ func (m *containerManager) networkDevicesFromConfig(netConfig *container.Network
 			"eth0": newNICDevice(
 				"eth0",
 				netConfig.Device,
-				"",
 				corenetwork.GenerateVirtualMACAddress(),
 				netConfig.MTU,
 			),

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -179,7 +179,7 @@ func (m *containerManager) getContainerSpec(
 		return ContainerSpec{}, errors.Trace(err)
 	}
 
-	nics, unknown, err := m.networkDevicesFromConfig(networkConfig, instanceConfig.MachineId)
+	nics, unknown, err := m.networkDevicesFromConfig(networkConfig)
 	if err != nil {
 		return ContainerSpec{}, errors.Trace(err)
 	}
@@ -283,12 +283,12 @@ func (m *containerManager) getImageSources() ([]ServerSpec, error) {
 // name, return a single "eth0" device with the bridge as its parent.
 // The last fall-back is to return the NIC devices from the default profile.
 // Names for any networks without a known CIDR are returned in a slice.
-func (m *containerManager) networkDevicesFromConfig(netConfig *container.NetworkConfig, machineID string) (map[string]device, []string, error) {
+// The host interface will be assigned a random unique value by LXD
+// (https://bugs.launchpad.net/juju/+bug/1932180/comments/5).
+func (m *containerManager) networkDevicesFromConfig(netConfig *container.NetworkConfig) (map[string]device, []string, error) {
 	if len(netConfig.Interfaces) > 0 {
-		return DevicesFromInterfaceInfo(netConfig.Interfaces, machineID)
+		return DevicesFromInterfaceInfo(netConfig.Interfaces)
 	} else if netConfig.Device != "" {
-		// For the eth0 case do not generate an interface name, instead let
-		// LXD select a host_name for that device.
 		return map[string]device{
 			"eth0": newNICDevice(
 				"eth0",

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -376,12 +376,11 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 
 	expected := map[string]map[string]string{
 		"eth0": {
-			"hwaddr":    "aa:bb:cc:dd:ee:f0",
-			"name":      "eth0",
-			"nictype":   "bridged",
-			"parent":    "br-eth0",
-			"type":      "nic",
-			"host_name": "1lxd2-0",
+			"hwaddr":  "aa:bb:cc:dd:ee:f0",
+			"name":    "eth0",
+			"nictype": "bridged",
+			"parent":  "br-eth0",
+			"type":    "nic",
 		},
 	}
 

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -355,7 +355,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C
 	s.makeManager(c)
 	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Interfaces: interfaces,
-	}, "0/lxd/0")
+	})
 
 	c.Assert(err, gc.ErrorMatches, "parent interface name is empty")
 	c.Assert(result, gc.IsNil)
@@ -388,7 +388,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 	result, unknown, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Device:     "lxdbr0",
 		Interfaces: interfaces,
-	}, "1/lxd/2")
+	})
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, expected)
@@ -411,7 +411,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfig(c *gc.C) {
 	s.makeManager(c)
 	result, unknown, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Device: "lxdbr0",
-	}, "1/lxd/2")
+	})
 
 	c.Assert(err, jc.ErrorIsNil)
 	// Ensure the resulting hw address isn't empty, but because it's random
@@ -437,7 +437,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigUnknownCIDR(c *gc.C) {
 	_, unknown, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
 		Device:     "lxdbr0",
 		Interfaces: interfaces,
-	}, "1/lxd/2")
+	})
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(unknown, gc.DeepEquals, []string{"br-eth0"})
@@ -450,7 +450,7 @@ func (s *managerSuite) TestNetworkDevicesFromConfigNoInputGetsProfileNICs(c *gc.
 	s.cSvr.EXPECT().GetProfile("default").Return(defaultLegacyProfileWithNIC(), lxdtesting.ETag, nil)
 
 	s.makeManager(c)
-	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{}, "1/lxd/2")
+	result, _, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := map[string]map[string]string{

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -396,6 +396,34 @@ func (s *managerSuite) TestNetworkDevicesFromConfigWithParentDevice(c *gc.C) {
 	c.Check(unknown, gc.HasLen, 0)
 }
 
+func (s *managerSuite) TestNetworkDevicesFromConfig(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	expected := map[string]map[string]string{
+		"eth0": {
+			"hwaddr":  "aa:bb:cc:dd:ee:f0",
+			"name":    "eth0",
+			"nictype": "bridged",
+			"parent":  "lxdbr0",
+			"type":    "nic",
+		},
+	}
+
+	s.makeManager(c)
+	result, unknown, err := lxd.NetworkDevicesFromConfig(s.manager, &container.NetworkConfig{
+		Device: "lxdbr0",
+	}, "1/lxd/2")
+
+	c.Assert(err, jc.ErrorIsNil)
+	// Ensure the resulting hw address isn't empty, but because it's random
+	// we have to set it to the expected one, so that our assertion does the
+	// right thing.
+	c.Assert(result["eth0"]["hwaddr"], gc.HasLen, 17)
+	result["eth0"]["hwaddr"] = expected["eth0"]["hwaddr"]
+	c.Check(result, jc.DeepEquals, expected)
+	c.Check(unknown, gc.HasLen, 0)
+}
+
 func (s *managerSuite) TestNetworkDevicesFromConfigUnknownCIDR(c *gc.C) {
 	defer s.setup(c).Finish()
 

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -468,10 +468,8 @@ const errIPV6NotSupported = `socket: address family not supported by protocol`
 
 // DevicesFromInterfaceInfo uses the input interface info collection to create
 // a map of network device configuration in the LXD format. Names for any
-// networks without a known CIDR are returned in a slice. The machineID arg is
-// used for generating predictable host interface names for the container's
-// ethernet devices.
-func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos, machineID string) (map[string]device, []string, error) {
+// networks without a known CIDR are returned in a slice.
+func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos) (map[string]device, []string, error) {
 	nics := make(map[string]device, len(interfaces))
 	var unknown []string
 	for _, v := range interfaces {
@@ -499,8 +497,6 @@ func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos, machineID s
 // This will involve interrogating the parent device, via the server if it is
 // LXD managed, or via the container.NetworkConfig.DeviceType that this is
 // being generated from.
-// It's important to note, that the host interface will be assigned a random
-// unique value by LXD (https://bugs.launchpad.net/juju/+bug/1932180/comments/5).
 func newNICDevice(deviceName, parentDevice, hwAddr string, mtu int) device {
 	device := map[string]string{
 		"type":    "nic",

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -474,7 +474,6 @@ const errIPV6NotSupported = `socket: address family not supported by protocol`
 func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos, machineID string) (map[string]device, []string, error) {
 	nics := make(map[string]device, len(interfaces))
 	var unknown []string
-	var nicCount int
 	for _, v := range interfaces {
 		if v.InterfaceType == corenetwork.LoopbackDevice {
 			continue
@@ -488,9 +487,7 @@ func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos, machineID s
 		if v.PrimaryAddress().CIDR == "" {
 			unknown = append(unknown, v.ParentInterfaceName)
 		}
-		hostIfaceName := makeHostInterfaceName(machineID, nicCount)
-		nics[v.InterfaceName] = newNICDevice(v.InterfaceName, v.ParentInterfaceName, hostIfaceName, v.MACAddress, v.MTU)
-		nicCount++
+		nics[v.InterfaceName] = newNICDevice(v.InterfaceName, v.ParentInterfaceName, v.MACAddress, v.MTU)
 	}
 
 	return nics, unknown, nil
@@ -501,18 +498,15 @@ func DevicesFromInterfaceInfo(interfaces corenetwork.InterfaceInfos, machineID s
 // TODO (manadart 2018-06-21) We want to support nictype=macvlan too.
 // This will involve interrogating the parent device, via the server if it is
 // LXD managed, or via the container.NetworkConfig.DeviceType that this is
-// being generated from. If the hostIfaceName argument is not empty, LXD will
-// use its value as the name of the container's virtual eth device on the host.
-// Otherwise, the host interface will be assigned a random unique value by LXD.
-func newNICDevice(deviceName, parentDevice, hostIfaceName, hwAddr string, mtu int) device {
+// being generated from.
+// It's important to note, that the host interface will be assigned a random
+// unique value by LXD (https://bugs.launchpad.net/juju/+bug/1932180/comments/5).
+func newNICDevice(deviceName, parentDevice, hwAddr string, mtu int) device {
 	device := map[string]string{
 		"type":    "nic",
 		"nictype": nicTypeBridged,
 		"name":    deviceName,
 		"parent":  parentDevice,
-	}
-	if hostIfaceName != "" {
-		device["host_name"] = hostIfaceName
 	}
 	if hwAddr != "" {
 		device["hwaddr"] = hwAddr
@@ -521,13 +515,4 @@ func newNICDevice(deviceName, parentDevice, hostIfaceName, hwAddr string, mtu in
 		device["mtu"] = fmt.Sprintf("%v", mtu)
 	}
 	return device
-}
-
-// makeHostInterfaceName constructs and return a suitable name for the host
-// NIC that represents a virtual ethernet device attached to a container.
-func makeHostInterfaceName(machineID string, nicIndex int) string {
-	// Remove the slashes to make the final device name easier to parse,
-	// e.g. 0lxd1-1.
-	machineID = strings.Replace(machineID, "/", "", -1)
-	return fmt.Sprintf("%s-%d", machineID, nicIndex)
 }

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -659,7 +659,7 @@ func (s *networkSuite) TestEnableHTTPSListenerWithErrors(c *gc.C) {
 }
 
 func (s *networkSuite) TestNewNICDeviceWithoutMACAddressOrMTUGreaterThanZero(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "", "", 0)
+	device := lxd.NewNICDevice("eth1", "br-eth1", "", 0)
 	expected := map[string]string{
 		"name":    "eth1",
 		"nictype": "bridged",
@@ -670,7 +670,7 @@ func (s *networkSuite) TestNewNICDeviceWithoutMACAddressOrMTUGreaterThanZero(c *
 }
 
 func (s *networkSuite) TestNewNICDeviceWithMACAddressButNoMTU(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "", "aa:bb:cc:dd:ee:f0", 0)
+	device := lxd.NewNICDevice("eth1", "br-eth1", "aa:bb:cc:dd:ee:f0", 0)
 	expected := map[string]string{
 		"hwaddr":  "aa:bb:cc:dd:ee:f0",
 		"name":    "eth1",
@@ -682,7 +682,7 @@ func (s *networkSuite) TestNewNICDeviceWithMACAddressButNoMTU(c *gc.C) {
 }
 
 func (s *networkSuite) TestNewNICDeviceWithoutMACAddressButMTUGreaterThanZero(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "", "", 1492)
+	device := lxd.NewNICDevice("eth1", "br-eth1", "", 1492)
 	expected := map[string]string{
 		"mtu":     "1492",
 		"name":    "eth1",
@@ -694,7 +694,7 @@ func (s *networkSuite) TestNewNICDeviceWithoutMACAddressButMTUGreaterThanZero(c 
 }
 
 func (s *networkSuite) TestNewNICDeviceWithMACAddressAndMTUGreaterThanZero(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "", "aa:bb:cc:dd:ee:f0", 9000)
+	device := lxd.NewNICDevice("eth1", "br-eth1", "aa:bb:cc:dd:ee:f0", 9000)
 	expected := map[string]string{
 		"hwaddr":  "aa:bb:cc:dd:ee:f0",
 		"mtu":     "9000",
@@ -702,18 +702,6 @@ func (s *networkSuite) TestNewNICDeviceWithMACAddressAndMTUGreaterThanZero(c *gc
 		"nictype": "bridged",
 		"parent":  "br-eth1",
 		"type":    "nic",
-	}
-	c.Assert(device, gc.DeepEquals, expected)
-}
-
-func (s *networkSuite) TestNewNICDeviceWithAssignedHostNICName(c *gc.C) {
-	device := lxd.NewNICDevice("eth1", "br-eth1", "1lxd2-0", "", 0)
-	expected := map[string]string{
-		"name":      "eth1",
-		"nictype":   "bridged",
-		"parent":    "br-eth1",
-		"type":      "nic",
-		"host_name": "1lxd2-0",
 	}
 	c.Assert(device, gc.DeepEquals, expected)
 }


### PR DESCRIPTION
The following changes ensures that the eth0 device gets a unique name.
This is given to us via LXD. Unfortunately, we're unsure currently why
you would have interfaces the first time around and then devices another
time around, which seems to be the only way to trip this up?

More information from the host machine would be required to find the
underlying bug `ip a` and a list of all the nics.

For now, this seems like it has the potential to unblock containers being
created.

## QA steps

Can you run this branch and then if you encounter the issue, give us the
results of `ip a` and all the nics?

## Bug reference

https://bugs.launchpad.net/juju/+bug/1932180
