### PR TITLE
Ensure lease manager block checks are at lease 1 second apart

### DIFF
--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -473,7 +473,7 @@ func (manager *Manager) handleCheck(check check) error {
 			// Someone thought they were the lease-holder, otherwise they
 			// wouldn't be confirming via the check. However, the lease has
 			// expired, and they are out of sync. Schedule a block check.
-			manager.ensureNextTimeout(time.Millisecond)
+			manager.setNextTimeout(manager.config.Clock.Now().Add(time.Second))
 
 			manager.config.Logger.Tracef("[%s] handling Check for lease %s on behalf of %s, not found",
 				manager.logContext, key.Lease, check.holderName)
@@ -541,7 +541,15 @@ func (manager *Manager) computeNextTimeout(leases map[lease.Key]lease.Info) {
 
 func (manager *Manager) setNextTimeout(t time.Time) {
 	manager.muNextTimeout.Lock()
+	defer manager.muNextTimeout.Unlock()
+
+	// Ensure we never walk the next check back without have performed a
+	// scheduled check *unless* we're just starting up.
+	if !manager.nextTimeout.IsZero() && t.After(manager.nextTimeout) {
+		return
+	}
 	manager.nextTimeout = t
+
 	d := t.Sub(manager.config.Clock.Now())
 	if manager.timer == nil {
 		manager.timer = manager.config.Clock.NewTimer(d)
@@ -559,22 +567,6 @@ func (manager *Manager) setNextTimeout(t time.Time) {
 		}
 		manager.timer.Reset(d)
 	}
-	manager.muNextTimeout.Unlock()
-}
-
-// ensureNextTimeout makes sure that the next timeout happens no-later than
-// duration from now.
-func (manager *Manager) ensureNextTimeout(d time.Duration) {
-	manager.muNextTimeout.Lock()
-	next := manager.nextTimeout
-	proposed := manager.config.Clock.Now().Add(d)
-	if next.After(proposed) {
-		manager.config.Logger.Tracef("[%s] ensuring we wake up before %v at %v\n",
-			manager.logContext, d, proposed)
-		manager.nextTimeout = proposed
-		manager.timer.Reset(d)
-	}
-	manager.muNextTimeout.Unlock()
 }
 
 func (manager *Manager) startRetry() *retry.Attempt {

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -292,14 +292,6 @@ func (manager *Manager) retryingClaim(claim claim) {
 			claim.respond(lease.ErrClaimDenied)
 			return
 		}
-		// now, this isn't strictly true, as the lease can be given for longer
-		// than the requested duration. However, it cannot be shorter.
-		// Doing it this way, we'll wake up, and then see we can sleep
-		// for a bit longer. But we'll always wake up in time.
-		manager.ensureNextTimeout(claim.duration)
-		// respond after ensuring the timeout, at least for the test suite to
-		// be sure the timer has been updated by the time it gets Claim()
-		// to return.
 		claim.respond(nil)
 	} else {
 		switch {


### PR DESCRIPTION
Under #13238 we ensured that we do not schedule lease manager block checks based on leases expiring sooner than in a second.

Here we also ensure that this same logic is applied for claim checks on leases that are not held. 

We also unify time-out setting in one method, discarding `ensureNextTimeout`.

## QA steps

Unit tests verify the timing. Same test as #13238 checks for regression.

## Documentation changes

None.

## Bug reference

N/A
