### PR TITLE
Inject featureflags to controller machine command for k8s controllers;

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1345,12 +1345,12 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 		c.fileNameAgentConf,
 	)
 	var jujudCmds []string
-	pushCMD := func(cmd string) {
+	pushCmd := func(cmd string) {
 		jujudCmds = append(jujudCmds, cmd)
 	}
 	featureFlags := featureflag.AsEnvironmentValue()
 	if featureFlags != "" {
-		featureFlags = fmt.Sprintf("%s=%s ", osenv.JujuFeatureFlagEnvKey, featureFlags)
+		featureFlags = fmt.Sprintf("%s=%s", osenv.JujuFeatureFlagEnvKey, featureFlags)
 	}
 	if c.pcfg.ControllerId == agent.BootstrapControllerId {
 		guiCmd, err := c.setUpGUICommand()
@@ -1358,10 +1358,10 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 			return errors.Trace(err)
 		}
 		if guiCmd != "" {
-			pushCMD(guiCmd)
+			pushCmd(guiCmd)
 		}
 		// only do bootstrap-state on the bootstrap controller - controller-0.
-		bootstrapStateCMD := fmt.Sprintf(
+		bootstrapStateCmd := fmt.Sprintf(
 			"%s bootstrap-state %s --data-dir $JUJU_DATA_DIR %s --timeout %s",
 			c.pathJoin("$JUJU_TOOLS_DIR", "jujud"),
 			c.pathJoin("$JUJU_DATA_DIR", c.fileNameBootstrapParams),
@@ -1369,26 +1369,26 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 			c.timeout.String(),
 		)
 		if featureFlags != "" {
-			bootstrapStateCMD = fmt.Sprintf("%s %s", featureFlags, bootstrapStateCMD)
+			bootstrapStateCmd = fmt.Sprintf("%s %s", featureFlags, bootstrapStateCmd)
 		}
-		pushCMD(
+		pushCmd(
 			fmt.Sprintf(
 				"test -e %s || %s",
 				c.pathJoin("$JUJU_DATA_DIR", agentConfigRelativePath),
-				bootstrapStateCMD,
+				bootstrapStateCmd,
 			),
 		)
 	}
-	machineCMD := fmt.Sprintf(
+	machineCmd := fmt.Sprintf(
 		"%s machine --data-dir $JUJU_DATA_DIR --controller-id %s --log-to-stderr %s",
 		c.pathJoin("$JUJU_TOOLS_DIR", "jujud"),
 		c.pcfg.ControllerId,
 		loggingOption,
 	)
 	if featureFlags != "" {
-		machineCMD = fmt.Sprintf("%s %s", featureFlags, machineCMD)
+		machineCmd = fmt.Sprintf("%s %s", featureFlags, machineCmd)
 	}
-	pushCMD(machineCMD)
+	pushCmd(machineCmd)
 	containers, err := generateContainerSpecs(strings.Join(jujudCmds, "\n"))
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -722,8 +722,8 @@ mkdir -p $gui
 curl -sSf -o $gui/gui.tar.bz2 --retry 10 'http://gui-url' || echo Unable to retrieve Juju Dashboard
 [ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
 [ -f $gui/jujugui.sha256 ] && (grep 'deadbeef' $gui/jujugui.sha256 && printf %s '{"version":"6.6.6","url":"http://gui-url","sha256":"deadbeef","size":999}' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
-test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_DATA_DIR/bootstrap-params --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s
-$JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-to-stderr --debug
+test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf || JUJU_DEV_FEATURE_FLAGS=private-registry $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_DATA_DIR/bootstrap-params --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s
+JUJU_DEV_FEATURE_FLAGS=private-registry $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-to-stderr --debug
 `[1:],
 			},
 			WorkingDir: "/var/lib/juju",

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -7922,7 +7922,13 @@ func (s *K8sBrokerSuite) TestExposeServiceGetDefaultIngressClass(c *gc.C) {
 }
 
 func initContainers() []core.Container {
-	jujudCmd := "export JUJU_DATA_DIR=/var/lib/juju\nexport JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools\n\nmkdir -p $JUJU_TOOLS_DIR\ncp /opt/jujud $JUJU_TOOLS_DIR/jujud"
+	jujudCmd := `
+export JUJU_DATA_DIR=/var/lib/juju
+export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
+
+mkdir -p $JUJU_TOOLS_DIR
+cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+`[1:]
 	jujudCmd += `
 initCmd=$($JUJU_TOOLS_DIR/jujud help commands | grep caas-unit-init)
 if test -n "$initCmd"; then

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -78,6 +78,7 @@ export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+
 $JUJU_TOOLS_DIR/jujud caasoperator --application-name=test --debug
 `[1:],
 			},

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -11,6 +11,7 @@ export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/%[2]s
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+
 %[3]s
 `[1:]
 


### PR DESCRIPTION

*This PR makes `JUJU_DEV_FEATURE_FLAGS` working for k8s controllers;*

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


```console
# copy your dockerhub credentials from ~/.docker/config.json
$ cat tttt.json
{
    // "auth": "xxxxxx==",
    "username": "a",
    "password": "pwd",
    "repository": "ycliuhw"
}


$ JUJU_DEV_FEATURE_FLAGS=private-registry juju bootstrap microk8s k1 --config caas-image-repo="'$(cat tttt.json)'"

$ mkubectl -ncontroller-k1 get pod/controller-0 -o json | jq .spec.imagePullSecrets
[
  {
    "name": "juju-image-pull-secret"
  }
]

$ mkubectl -ncontroller-k1 get secret/juju-image-pull-secret -o json | jq -r '.data[".dockerconfigjson"]' | base64 --decode | jq
{
  "auths": {
    "https://index.docker.io/v1/": {
      "username": "a",
      "password": "pwd",
      "auth": "xxxxxx=="
    }
  }
}

```

## Documentation changes

Yes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1941055
