### PR TITLE
RemoteConnectionStatus: KeyRelation not found

### DIFF
--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -94,6 +94,21 @@ func (s *offerConnectionsSuite) TestAddOfferConnection(c *gc.C) {
 		gc.Equals, fmt.Sprintf(`connection to "offer-uuid" by "fred" for relation %d`, s.activeRel.Id()))
 }
 
+func (s *offerConnectionsSuite) TestAddOfferConnectioNotFound(c *gc.C) {
+	_, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
+		SourceModelUUID: testing.ModelTag.Id(),
+		RelationId:      s.activeRel.Id(),
+		Username:        "fred",
+		OfferUUID:       "offer-uuid",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	rc, err := s.State.RemoteConnectionStatus("offer-uuid")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rc.TotalConnectionCount(), gc.Equals, 1)
+	c.Assert(rc.ActiveConnectionCount(), gc.Equals, 0)
+}
+
 func (s *offerConnectionsSuite) TestAddOfferConnectionTwice(c *gc.C) {
 	_, err := s.State.AddOfferConnection(state.AddOfferConnectionParams{
 		SourceModelUUID: testing.ModelTag.Id(),


### PR DESCRIPTION
When attempting to calculate the RemoteConnectionStatus in the
AllWatcher, it is not the time to bomb out when you can't find a
KeyRelation. As the RemoteConnectionStatus only wants to know the active
count, the very fact that you can't find the KeyRelation indicates that
it's no longer active. Ignoring the error and continuing onward should
suffice.

Other code found at[1] also deals with the error in exactly the same
way.

 1. apiserver/facades/client/client/status.go#fetchOffers

## QA steps

```sh
TBA
```

## Bug reference

https://bugs.launchpad.net/charm-ceph-mon/+bug/1940983
