### PR TITLE
Cleanly exit remote relation units worker on not found error

### DIFF
--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -430,17 +430,11 @@ func newMockRemoteRelationWatcher() *mockRemoteRelationWatcher {
 	return w
 }
 
+func (w *mockRemoteRelationWatcher) kill(err error) {
+	w.Tomb.Kill(err)
+}
+
 func (w *mockRemoteRelationWatcher) Changes() <-chan params.RemoteRelationChangeEvent {
-	w.MethodCall(w, "Changes")
-	return w.changes
-}
-
-type mockRelationUnitsWatcher struct {
-	mockWatcher
-	changes chan watcher.RelationUnitsChange
-}
-
-func (w *mockRelationUnitsWatcher) Changes() watcher.RelationUnitsChannel {
 	w.MethodCall(w, "Changes")
 	return w.changes
 }

--- a/worker/remoterelations/relationunitsworker.go
+++ b/worker/remoterelations/relationunitsworker.go
@@ -69,7 +69,10 @@ func (w *relationUnitsWorker) Kill() {
 // Wait is defined on worker.Worker
 func (w *relationUnitsWorker) Wait() error {
 	err := w.catacomb.Wait()
-	if err != nil && !errors.IsNotFound(err) {
+	if errors.IsNotFound(err) || params.IsCodeNotFound(err) {
+		err = nil
+	}
+	if err != nil {
 		w.logger.Errorf("error in relation units worker for %v: %v", w.relationTag.Id(), err)
 	}
 	return err


### PR DESCRIPTION
The workers for managing cross model relations use watchers on the remote model. If things get out of sync, the remote relation units watcher may encounter a NotFound error when inside the underlying Next() API call. This kills the watcher but also brings down the host worker, which bounces and restarts the parent worker also. This causes the CMR to be reestablished which then fails the same way and so on.

The patch here is to exit the worker cleanly on not found, since the other side is gone anyway.

Note - here and in many other places, we are exposed to the underlying params.Error which is unfortunate. There's a little used helper function apiserver/errors.RestoreError() which we should use to replace all of the various maybeNotFound() helpers, but it's an invasive change with perhaps side effect; we can address that in a separate PR.

## QA steps

I managed to wedge a CMR scenario and fix it using this patch, but reproducing the issue is trial and error.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1940983
