### PR TITLE
Fix/registry basic auth

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1345,7 +1345,7 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 		c.fileNameAgentConf,
 	)
 	var jujudCmds []string
-	pushCMD := func(cmd string) {
+	pushCmd := func(cmd string) {
 		jujudCmds = append(jujudCmds, cmd)
 	}
 	featureFlags := featureflag.AsEnvironmentValue()
@@ -1358,10 +1358,10 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 			return errors.Trace(err)
 		}
 		if guiCmd != "" {
-			pushCMD(guiCmd)
+			pushCmd(guiCmd)
 		}
 		// only do bootstrap-state on the bootstrap controller - controller-0.
-		bootstrapStateCMD := fmt.Sprintf(
+		bootstrapStateCmd := fmt.Sprintf(
 			"%s bootstrap-state %s --data-dir $JUJU_DATA_DIR %s --timeout %s",
 			c.pathJoin("$JUJU_TOOLS_DIR", "jujud"),
 			c.pathJoin("$JUJU_DATA_DIR", c.fileNameBootstrapParams),
@@ -1369,26 +1369,26 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 			c.timeout.String(),
 		)
 		if featureFlags != "" {
-			bootstrapStateCMD = fmt.Sprintf("%s %s", featureFlags, bootstrapStateCMD)
+			bootstrapStateCmd = fmt.Sprintf("%s %s", featureFlags, bootstrapStateCmd)
 		}
-		pushCMD(
+		pushCmd(
 			fmt.Sprintf(
 				"test -e %s || %s",
 				c.pathJoin("$JUJU_DATA_DIR", agentConfigRelativePath),
-				bootstrapStateCMD,
+				bootstrapStateCmd,
 			),
 		)
 	}
-	machineCMD := fmt.Sprintf(
+	machineCmd := fmt.Sprintf(
 		"%s machine --data-dir $JUJU_DATA_DIR --controller-id %s --log-to-stderr %s",
 		c.pathJoin("$JUJU_TOOLS_DIR", "jujud"),
 		c.pcfg.ControllerId,
 		loggingOption,
 	)
 	if featureFlags != "" {
-		machineCMD = fmt.Sprintf("%s %s", featureFlags, machineCMD)
+		machineCmd = fmt.Sprintf("%s %s", featureFlags, machineCmd)
 	}
-	pushCMD(machineCMD)
+	pushCmd(machineCmd)
 	containers, err := generateContainerSpecs(strings.Join(jujudCmds, "\n"))
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1350,7 +1350,7 @@ func (c *controllerStack) buildContainerSpecForController(statefulset *apps.Stat
 	}
 	featureFlags := featureflag.AsEnvironmentValue()
 	if featureFlags != "" {
-		featureFlags = fmt.Sprintf("%s=%s ", osenv.JujuFeatureFlagEnvKey, featureFlags)
+		featureFlags = fmt.Sprintf("%s=%s", osenv.JujuFeatureFlagEnvKey, featureFlags)
 	}
 	if c.pcfg.ControllerId == agent.BootstrapControllerId {
 		guiCmd, err := c.setUpGUICommand()

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -722,8 +722,8 @@ mkdir -p $gui
 curl -sSf -o $gui/gui.tar.bz2 --retry 10 'http://gui-url' || echo Unable to retrieve Juju Dashboard
 [ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
 [ -f $gui/jujugui.sha256 ] && (grep 'deadbeef' $gui/jujugui.sha256 && printf %s '{"version":"6.6.6","url":"http://gui-url","sha256":"deadbeef","size":999}' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
-test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf || $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_DATA_DIR/bootstrap-params --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s
-$JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-to-stderr --debug
+test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf || JUJU_DEV_FEATURE_FLAGS=private-registry $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_DATA_DIR/bootstrap-params --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s
+JUJU_DEV_FEATURE_FLAGS=private-registry $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-to-stderr --debug
 `[1:],
 			},
 			WorkingDir: "/var/lib/juju",

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -7922,7 +7922,13 @@ func (s *K8sBrokerSuite) TestExposeServiceGetDefaultIngressClass(c *gc.C) {
 }
 
 func initContainers() []core.Container {
-	jujudCmd := "export JUJU_DATA_DIR=/var/lib/juju\nexport JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools\n\nmkdir -p $JUJU_TOOLS_DIR\ncp /opt/jujud $JUJU_TOOLS_DIR/jujud"
+	jujudCmd := `
+export JUJU_DATA_DIR=/var/lib/juju
+export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
+
+mkdir -p $JUJU_TOOLS_DIR
+cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+`[1:]
 	jujudCmd += `
 initCmd=$($JUJU_TOOLS_DIR/jujud help commands | grep caas-unit-init)
 if test -n "$initCmd"; then

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -78,6 +78,7 @@ export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+
 $JUJU_TOOLS_DIR/jujud caasoperator --application-name=test --debug
 `[1:],
 			},

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -11,6 +11,7 @@ export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/%[2]s
 
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+
 %[3]s
 `[1:]
 

--- a/controller/config.go
+++ b/controller/config.go
@@ -856,11 +856,14 @@ func validateCAASImageRepo(imageRepo string) (string, error) {
 	if err = imageDetails.Validate(); err != nil {
 		return "", errors.Trace(err)
 	}
-	r, err := registry.NewRegistry(*imageDetails)
-	if err != nil {
-		return "", errors.Trace(err)
+	if imageDetails.IsPrivate() {
+		r, err := registry.NewRegistry(*imageDetails)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		*imageDetails = r.ImageRepoDetails()
 	}
-	return r.ImageRepoDetails().String(), nil
+	return imageDetails.String(), nil
 }
 
 // CAASImageRepo sets the url of the docker repo

--- a/controller/config.go
+++ b/controller/config.go
@@ -856,10 +856,11 @@ func validateCAASImageRepo(imageRepo string) (string, error) {
 	if err = imageDetails.Validate(); err != nil {
 		return "", errors.Trace(err)
 	}
-	if _, err = registry.NewRegistry(*imageDetails); err != nil {
+	r, err := registry.NewRegistry(*imageDetails)
+	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return imageDetails.String(), nil
+	return r.ImageRepoDetails().String(), nil
 }
 
 // CAASImageRepo sets the url of the docker repo

--- a/docker/auth.go
+++ b/docker/auth.go
@@ -84,6 +84,9 @@ func (ba *BasicAuthConfig) Validate() error {
 }
 
 func (ba *BasicAuthConfig) init() error {
+	if ba.Empty() {
+		return nil
+	}
 	if ba.Auth == "" {
 		ba.Auth = base64.StdEncoding.EncodeToString([]byte(ba.Username + ":" + ba.Password))
 	}

--- a/docker/auth.go
+++ b/docker/auth.go
@@ -4,6 +4,7 @@
 package docker
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -27,6 +28,10 @@ const (
 	// APIVersionV2 is the API version v2.
 	APIVersionV2 APIVersion = "v2"
 )
+
+func (v APIVersion) String() string {
+	return string(v)
+}
 
 // TokenAuthConfig contains authorization information for token auth.
 // Juju does not support the docker credential helper because k8s does not support it either.
@@ -70,7 +75,13 @@ func (ba BasicAuthConfig) Empty() bool {
 }
 
 // Validate validates the spec.
-func (ba BasicAuthConfig) Validate() error {
+func (ba *BasicAuthConfig) Validate() error {
+	if ba.Empty() {
+		return nil
+	}
+	if ba.Auth == "" {
+		ba.Auth = base64.StdEncoding.EncodeToString([]byte(ba.Username + ":" + ba.Password))
+	}
 	return nil
 }
 
@@ -115,13 +126,13 @@ func (rid ImageRepoDetails) SecretData() ([]byte, error) {
 }
 
 // String returns yaml format.
-func (rid *ImageRepoDetails) String() string {
+func (rid ImageRepoDetails) String() string {
 	d, _ := yaml.Marshal(rid)
 	return string(d)
 }
 
 // Validate validates the spec.
-func (rid ImageRepoDetails) Validate() error {
+func (rid *ImageRepoDetails) Validate() error {
 	if rid.Repository == "" {
 		return errors.NotValidf("empty repository")
 	}
@@ -176,6 +187,9 @@ func NewImageRepoDetails(contentOrPath string) (o *ImageRepoDetails, err error) 
 		return &ImageRepoDetails{Repository: contentOrPath}, nil
 	}
 
+	if err = o.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if o.IsPrivate() && !featureflag.Enabled(feature.PrivateRegistry) {
 		return nil, errors.New(
 			fmt.Sprintf("private registry support is under development, enable feature flag %q to test it out", feature.PrivateRegistry),

--- a/docker/registry/mocks/registry_mock.go
+++ b/docker/registry/mocks/registry_mock.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	docker "github.com/juju/juju/docker"
 	tools "github.com/juju/juju/tools"
 )
 
@@ -46,6 +47,20 @@ func (m *MockRegistry) Close() error {
 func (mr *MockRegistryMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRegistry)(nil).Close))
+}
+
+// ImageRepoDetails mocks base method.
+func (m *MockRegistry) ImageRepoDetails() docker.ImageRepoDetails {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImageRepoDetails")
+	ret0, _ := ret[0].(docker.ImageRepoDetails)
+	return ret0
+}
+
+// ImageRepoDetails indicates an expected call of ImageRepoDetails.
+func (mr *MockRegistryMockRecorder) ImageRepoDetails() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageRepoDetails", reflect.TypeOf((*MockRegistry)(nil).ImageRepoDetails))
 }
 
 // Ping mocks base method.

--- a/docker/registry/registry.go
+++ b/docker/registry/registry.go
@@ -28,6 +28,11 @@ const (
 	dockerServerAddress = "index.docker.io"
 )
 
+var (
+	// Override for testing.
+	DefaultTransport = http.DefaultTransport
+)
+
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/http_mock.go net/http RoundTripper
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/registry_mock.go github.com/juju/juju/docker/registry Registry
 
@@ -47,7 +52,7 @@ type Registry interface {
 
 // NewRegistry creates a new registry.
 func NewRegistry(repoDetails docker.ImageRepoDetails) (Registry, error) {
-	return newRegistry(repoDetails, http.DefaultTransport)
+	return newRegistry(repoDetails, DefaultTransport)
 }
 
 func newRegistry(repoDetails docker.ImageRepoDetails, transport http.RoundTripper) (Registry, error) {

--- a/docker/registry/registry_test.go
+++ b/docker/registry/registry_test.go
@@ -64,8 +64,8 @@ func (s *registrySuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Control
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer xxxxx=="}})
-					c.Assert(req.Method, jc.DeepEquals, `GET`)
-					c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io/v2`)
+					c.Assert(req.Method, gc.Equals, `GET`)
+					c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2`)
 					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
 				},
 			),
@@ -83,8 +83,8 @@ func (s *registrySuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Control
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Basic": []string{"xxxxx=="}})
-					c.Assert(req.Method, jc.DeepEquals, `GET`)
-					c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io/v1`)
+					c.Assert(req.Method, gc.Equals, `GET`)
+					c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v1`)
 					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
 				},
 			),
@@ -118,8 +118,8 @@ func (s *registrySuite) TestTagsV1(c *gc.C) {
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
 			c.Assert(req.Header, jc.DeepEquals, http.Header{"Basic": []string{"xxxxx=="}})
-			c.Assert(req.Method, jc.DeepEquals, `GET`)
-			c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io/v1/repositories/jujuqa/jujud-operator/tags`)
+			c.Assert(req.Method, gc.Equals, `GET`)
+			c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v1/repositories/jujuqa/jujud-operator/tags`)
 			resps := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       ioutil.NopCloser(strings.NewReader(data)),
@@ -148,8 +148,8 @@ func (s *registrySuite) TestTagsV2(c *gc.C) {
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
 			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer xxxxx=="}})
-			c.Assert(req.Method, jc.DeepEquals, `GET`)
-			c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Assert(req.Method, gc.Equals, `GET`)
+			c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       ioutil.NopCloser(strings.NewReader(data)),
@@ -177,8 +177,8 @@ func (s *registrySuite) TestTagsErrorResponse(c *gc.C) {
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
 			c.Assert(req.Header, jc.DeepEquals, http.Header{"Basic": []string{"xxxxx=="}})
-			c.Assert(req.Method, jc.DeepEquals, `GET`)
-			c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io/v1/repositories/jujuqa/jujud-operator/tags`)
+			c.Assert(req.Method, gc.Equals, `GET`)
+			c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v1/repositories/jujuqa/jujud-operator/tags`)
 			resps := &http.Response{
 				StatusCode: http.StatusForbidden,
 				Body:       ioutil.NopCloser(strings.NewReader(data)),

--- a/docker/registry/registry_test.go
+++ b/docker/registry/registry_test.go
@@ -65,7 +65,7 @@ func (s *registrySuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Control
 				func(req *http.Request) (*http.Response, error) {
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer xxxxx=="}})
 					c.Assert(req.Method, jc.DeepEquals, `GET`)
-					c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io`)
+					c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io/v2`)
 					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
 				},
 			),
@@ -84,7 +84,7 @@ func (s *registrySuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Control
 				func(req *http.Request) (*http.Response, error) {
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Basic": []string{"xxxxx=="}})
 					c.Assert(req.Method, jc.DeepEquals, `GET`)
-					c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io`)
+					c.Assert(req.URL.String(), jc.DeepEquals, `https://quay.io/v1`)
 					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
 				},
 			),


### PR DESCRIPTION
*This PR changes to use same base URL for dockerhub registry API v1 and v2;*

Note: It would be better to review https://github.com/juju/juju/pull/13281 first.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps


```console
# copy your dockerhub credentials from ~/.docker/config.json
$ cat tttt.json
{
    // "auth": "xxxxxx==",
    "username": "a",
    "password": "pwd",
    "repository": "ycliuhw"
}


$ JUJU_DEV_FEATURE_FLAGS=private-registry juju bootstrap microk8s k1 --config caas-image-repo="'$(cat tttt.json)'"

$ mkubectl -ncontroller-k1 get pod/controller-0 -o json | jq .spec.imagePullSecrets
[
  {
    "name": "juju-image-pull-secret"
  }
]

$ mkubectl -ncontroller-k1 get secret/juju-image-pull-secret -o json | jq -r '.data[".dockerconfigjson"]' | base64 --decode | jq
{
  "auths": {
    "https://index.docker.io/v1/": {
      "username": "a",
      "password": "pwd",
      "auth": "xxxxxx=="
    }
  }
}

```

## Documentation changes

Yes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1935830

