### PR TITLE
Fix reportHookError blocking when relation hook fails due to missing relation

### DIFF
--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -329,8 +329,7 @@ func (r *relationStateTracker) IsImplicit(id int) (bool, error) {
 	if rel := r.relationers[id]; rel != nil {
 		return rel.IsImplicit(), nil
 	}
-
-	return false, errors.Errorf("unknown relation: %d", id)
+	return false, errors.NotFoundf("relation: %d", id)
 }
 
 // IsPeerRelation returns true if the endpoint for a relation ID has a Peer role.
@@ -339,7 +338,7 @@ func (r *relationStateTracker) IsPeerRelation(id int) (bool, error) {
 		return r.isPeerRelation[id], nil
 	}
 
-	return false, errors.Errorf("unknown relation: %d", id)
+	return false, errors.NotFoundf("relation: %d", id)
 }
 
 // HasContainerScope returns true if the specified relation ID has a container
@@ -349,7 +348,7 @@ func (r *relationStateTracker) HasContainerScope(id int) (bool, error) {
 		return rel.RelationUnit().Endpoint().Scope == charm.ScopeContainer, nil
 	}
 
-	return false, errors.Errorf("unknown relation: %d", id)
+	return false, errors.NotFoundf("relation: %d", id)
 }
 
 // RelationCreated returns true if a relation created hook has been
@@ -371,7 +370,7 @@ func (r *relationStateTracker) State(id int) (*State, error) {
 		return r.stateMgr.Relation(id)
 	}
 
-	return nil, errors.Errorf("unknown relation: %d", id)
+	return nil, errors.NotFoundf("relation: %d", id)
 }
 
 func (r *relationStateTracker) StateFound(id int) bool {
@@ -438,7 +437,7 @@ func (r *relationStateTracker) GetInfo() map[int]*context.RelationInfo {
 func (r *relationStateTracker) Name(id int) (string, error) {
 	relationer, found := r.relationers[id]
 	if !found {
-		return "", errors.Errorf("unknown relation: %d", id)
+		return "", errors.NotFoundf("relation: %d", id)
 	}
 	return relationer.RelationUnit().Endpoint().Name, nil
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -941,6 +941,7 @@ func (u *Uniter) reportHookError(hookInfo hook.Info) error {
 	// hook is interrupted (e.g. unit agent crashes), rather than immediately
 	// after attempting a runHookOp.
 	hookName := string(hookInfo.Kind)
+	hookMessage := string(hookInfo.Kind)
 	statusData := map[string]interface{}{}
 	if hookInfo.Kind.IsRelation() {
 		statusData["relation-id"] = hookInfo.RelationId
@@ -949,12 +950,14 @@ func (u *Uniter) reportHookError(hookInfo hook.Info) error {
 		}
 		relationName, err := u.relationStateTracker.Name(hookInfo.RelationId)
 		if err != nil {
-			return errors.Trace(err)
+			hookMessage = fmt.Sprintf("%s: %v", hookInfo.Kind, err)
+		} else {
+			hookName = fmt.Sprintf("%s-%s", relationName, hookInfo.Kind)
+			hookMessage = hookName
 		}
-		hookName = fmt.Sprintf("%s-%s", relationName, hookInfo.Kind)
 	}
 	statusData["hook"] = hookName
-	statusMessage := fmt.Sprintf("hook failed: %q", hookName)
+	statusMessage := fmt.Sprintf("hook failed: %q", hookMessage)
 	return setAgentStatus(u, status.Error, statusMessage, statusData)
 }
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -802,7 +803,17 @@ func (s waitUnitAgent) step(c *gc.C, ctx *testContext) {
 			}
 			if s.data != nil {
 				if len(statusInfo.Data) != len(s.data) {
-					c.Logf("want %d status data value(s), got %d; still waiting", len(s.data), len(statusInfo.Data))
+					wantKeys := []string{}
+					for k := range s.data {
+						wantKeys = append(wantKeys, k)
+					}
+					sort.Strings(wantKeys)
+					gotKeys := []string{}
+					for k := range statusInfo.Data {
+						gotKeys = append(gotKeys, k)
+					}
+					sort.Strings(gotKeys)
+					c.Logf("want {%s} status data value(s), got {%s}; still waiting", strings.Join(wantKeys, ", "), strings.Join(gotKeys, ", "))
 					continue
 				}
 				for key, value := range s.data {


### PR DESCRIPTION
Fix reportHookError blocking when relation hook fails due to missing relation.

If the unit has a queued relation hook, restarted while the same relation is forced removed it enters a worker restart loop from the resolver.

## QA steps

- Wait for a unit to idle
- juju_stop_unit
- poke mongo to update unit's unitstates document queueing a relation-* hook with an invalid relation-id.
- juju_start_unit
- unit should fail gracefully and not enter a worker restart loop

## Documentation changes

N/A

## Bug reference

Somewhat related to https://bugs.launchpad.net/charm-ceph-mon/+bug/1940983