### PR TITLE
Trap signal interrupt during upgrade-series

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -395,16 +395,18 @@ func (c *upgradeSeriesCommand) promptConfirmation(ctx *cmd.Context, affectedUnit
 	affectedMsg := ""
 	if len(affectedUnits) > 0 {
 		apps := set.NewStrings()
+		units := set.NewStrings()
 		for _, unit := range affectedUnits {
 			app, err := names.UnitApplication(unit)
 			if err != nil {
 				return errors.Annotatef(err, "deriving application for unit %q", unit)
 			}
-			apps.Add(app)
+			apps.Add(fmt.Sprintf("- %s", app))
+			units.Add(fmt.Sprintf("- %s", unit))
 		}
 
 		affectedMsg = fmt.Sprintf(
-			upgradeSeriesAffectedMsg, strings.Join(affectedUnits, "\n  "), strings.Join(apps.SortedValues(), "\n  "))
+			upgradeSeriesAffectedMsg, strings.Join(units.SortedValues(), "\n  "), strings.Join(apps.SortedValues(), "\n  "))
 	}
 
 	fmt.Fprintf(ctx.Stdout, upgradeSeriesConfirmationMsg, c.machineNumber, c.series, affectedMsg)


### PR DESCRIPTION
During an upgrade series we should heavily notify users that cancelling
an upgrade series is not advised. Until we get a new command to allow
users to undo an upgrade-series it's the best we can do.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --series=bionic
$ juju upgrade-series 0 prepare focal
```
Enter "y" and `ctrl-c` straight afterwards.

The output should be like the following:

```sh
WARNING: This command will mark machine "0" as being upgraded to series "focal".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  ubuntu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  ubuntu

Continue [y/N]?y
machine-0 validation of upgrade series from "xenial" to "focal"
machine-0 started upgrade series from "xenial" to "focal"
^C
Ctrl-C pressed, cancelling an upgrade-series is not recommended. Ctrl-C to proceed anyway.
^C
Ctrl-C pressed, cancelling an upgrade-series.
```
