### PR TITLE
[2.9] Ignore fan subnets when querying equinix API

### DIFF
--- a/provider/equinix/environ_test.go
+++ b/provider/equinix/environ_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -238,6 +239,20 @@ func (s *environProviderSuite) TestStopInstance(c *gc.C) {
 	c.Assert(env, gc.NotNil)
 	err = env.StopInstances(environContext.NewCloudCallContext(context.TODO()), "100")
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environProviderSuite) TestMapJujuSubnetsToReservationIDs(c *gc.C) {
+	in := []map[network.Id][]string{
+		{
+			"subnet-abcdef-aa": []string{"fr"},
+		},
+		{
+			"subnet-INFAN-42": []string{""},
+		},
+	}
+	exp := []string{"abcdef-aa"}
+	got := mapJujuSubnetsToReservationIDs(in)
+	c.Assert(got, gc.DeepEquals, exp, gc.Commentf("expected FAN subnet to be filtered out"))
 }
 
 type packngoCreateDeviceMatcher struct {


### PR DESCRIPTION
When the provider prepares a new instance for which space constraints have been specified, it queries the equinix API for each subnet that Juju specifies in the StartInstance argument.

Before creating the instance (device in equinix terminology) the provider queries the equinix API to resolve each requested Juju subnet ID into a subnet CIDR which is then passed to the equinix create device API. However, the current provider implementation does not filter FAN subnets (FAN is automatically enabled on equinix metal) so the resolution for the FAN subnets fails (a 404 is returned back from the API) and the instance fails to be provisioned.

## QA steps

Deploy a charm on equinix metal using space constraints

## Bug reference
https://bugs.launchpad.net/juju/+bug/1941912