### PR TITLE
Remove app status history when destorying an app; add support for apps in show-status-log

### DIFF
--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -603,8 +603,8 @@ func (w *relationStatusWatcher) loop(initialChanges []params.RelationLifeSuspend
 				// at this point, so just return.
 				return nil
 			}
-			new := copyChanges(data.(*params.RelationLifeSuspendedStatusWatchResult).Changes)
-			changes = w.mergeChanges(changes, new)
+			newChanges := copyChanges(data.(*params.RelationLifeSuspendedStatusWatchResult).Changes)
+			changes = w.mergeChanges(changes, newChanges)
 			out = w.out
 		case out <- changes:
 			out = nil
@@ -695,8 +695,8 @@ func (w *offerStatusWatcher) loop(initialChanges []params.OfferStatusChange) err
 				// at this point, so just return.
 				return nil
 			}
-			new := copyChanges(data.(*params.OfferStatusWatchResult).Changes)
-			changes = w.mergeChanges(changes, new)
+			newChanges := copyChanges(data.(*params.OfferStatusWatchResult).Changes)
+			changes = w.mergeChanges(changes, newChanges)
 			out = w.out
 		case out <- changes:
 			out = nil

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -78,13 +78,13 @@ type Backend interface {
 	// SaveIngressNetworks stores in state the ingress networks for the relation.
 	SaveIngressNetworks(relationKey string, cidrs []string) (state.RelationNetworks, error)
 
-	// Networks returns the networks for the specified relation.
+	// IngressNetworks returns the networks for the specified relation.
 	IngressNetworks(relationKey string) (state.RelationNetworks, error)
 
 	// ApplicationOfferForUUID returns the application offer for the UUID.
 	ApplicationOfferForUUID(offerUUID string) (*crossmodel.ApplicationOffer, error)
 
-	// WatchStatus returns a watcher that notifies of changes to the status
+	// WatchOfferStatus returns a watcher that notifies of changes to the status
 	// of the offer.
 	WatchOfferStatus(offerUUID string) (state.NotifyWatcher, error)
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2424,7 +2424,7 @@ func (api *APIBase) saveRemoteApplication(
 		remoteSpaces[i] = providerSpaceInfoFromParams(space)
 	}
 
-	// If the a remote application with the same name and endpoints from the same
+	// If a remote application with the same name and endpoints from the same
 	// source model already exists, we will use that one.
 	remoteApp, err := api.maybeUpdateExistingApplicationEndpoints(applicationName, sourceModelTag, remoteEps)
 	if err == nil {
@@ -2479,9 +2479,6 @@ func (api *APIBase) maybeUpdateExistingApplicationEndpoints(
 ) (RemoteApplication, error) {
 	existingRemoteApp, err := api.backend.RemoteApplication(applicationName)
 	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err != nil && !errors.IsNotFound(err) {
 		return nil, errors.Trace(err)
 	}
 	if existingRemoteApp.SourceModel().Id() != sourceModelTag.Id() {

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -46,7 +46,7 @@ type Backend interface {
 	AllSubnets() ([]*state.Subnet, error)
 	Annotations(state.GlobalEntity) (map[string]string, error)
 	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
-	Application(string) (*state.Application, error)
+	Application(string) (Application, error)
 	Charm(*charm.URL) (*state.Charm, error)
 	ControllerConfig() (controller.Config, error)
 	ControllerNodes() ([]state.ControllerNode, error)
@@ -108,6 +108,11 @@ type Pool interface {
 	SystemState() *state.State
 }
 
+// Application represents a state.Application.
+type Application interface {
+	StatusHistory(status.StatusHistoryFilter) ([]status.StatusInfo, error)
+}
+
 // Unit represents a state.Unit.
 type Unit interface {
 	status.StatusHistoryGetter
@@ -138,6 +143,14 @@ func (s *stateShim) Annotations(entity state.GlobalEntity) (map[string]string, e
 
 func (s *stateShim) SetAnnotations(entity state.GlobalEntity, ann map[string]string) error {
 	return s.model.SetAnnotations(entity, ann)
+}
+
+func (s *stateShim) Application(name string) (Application, error) {
+	a, err := s.State.Application(name)
+	if err != nil {
+		return nil, err
+	}
+	return a, nil
 }
 
 func (s *stateShim) Unit(name string) (Unit, error) {

--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -129,6 +129,28 @@ func (s *statusHistoryTestSuite) TestNoConflictingFilters(c *gc.C) {
 	c.Assert(r.Results[0].Error.Message, gc.Equals, "cannot validate status history filter: Date and Delta together not valid")
 }
 
+func (s *statusHistoryTestSuite) TestStatusHistoryApplication(c *gc.C) {
+	s.st.appHistory = statusInfoWithDates([]status.StatusInfo{
+		{
+			Status:  status.Maintenance,
+			Message: "working",
+		},
+		{
+			Status:  status.Active,
+			Message: "running",
+		},
+	})
+	h := s.api.StatusHistory(params.StatusHistoryRequests{
+		Requests: []params.StatusHistoryRequest{{
+			Tag:    "application-app",
+			Kind:   status.KindApplication.String(),
+			Filter: params.StatusHistoryFilter{Size: 10},
+		}}})
+	c.Assert(h.Results, gc.HasLen, 1)
+	c.Assert(h.Results[0].Error, gc.IsNil)
+	checkStatusInfo(c, h.Results[0].History.Statuses, reverseStatusInfo(s.st.appHistory))
+}
+
 func (s *statusHistoryTestSuite) TestStatusHistoryUnitOnly(c *gc.C) {
 	s.st.unitHistory = statusInfoWithDates([]status.StatusInfo{
 		{
@@ -249,6 +271,7 @@ func (s *statusHistoryTestSuite) TestStatusHistoryModelOnly(c *gc.C) {
 
 type mockState struct {
 	client.Backend
+	appHistory   []status.StatusInfo
 	unitHistory  []status.StatusInfo
 	agentHistory []status.StatusInfo
 	modelHistory []status.StatusInfo
@@ -280,12 +303,30 @@ func (m *mockState) Unit(name string) (client.Unit, error) {
 	}, nil
 }
 
+func (m *mockState) Application(name string) (client.Application, error) {
+	if name != "app" {
+		return nil, errors.NotFoundf("%v", name)
+	}
+	return &mockApplication{
+		status: m.appHistory,
+	}, nil
+}
+
 type mockModel struct {
 	status statuses
 	client.Model
 }
 
 func (m mockModel) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
+	return m.status.StatusHistory(filter)
+}
+
+type mockApplication struct {
+	status statuses
+	client.Application
+}
+
+func (m *mockApplication) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
 	return m.status.StatusHistory(filter)
 }
 

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -219,6 +219,11 @@ func (c *statusHistoryCommand) Run(ctx *cmd.Context) error {
 			return errors.Errorf("%q is not a valid name for a %s", c.entityName, kind)
 		}
 		tag = names.NewUnitTag(c.entityName)
+	case status.KindApplication, status.KindSAAS:
+		if !names.IsValidApplication(c.entityName) {
+			return errors.Errorf("%q is not a valid name for an application", c.entityName)
+		}
+		tag = names.NewApplicationTag(c.entityName)
 	default:
 		if !names.IsValidMachine(c.entityName) {
 			return errors.Errorf("%q is not a valid name for a %s", c.entityName, kind)

--- a/core/status/status_history.go
+++ b/core/status/status_history.go
@@ -69,7 +69,7 @@ type History []DetailedStatus
 //
 type HistoryKind string
 
-// IMPORTANT DEV NOTE: when changing this HistoryKind list in anyway, these may need to be revised:
+// IMPORTANT DEV NOTE: when changing this HistoryKind list in any way, these may need to be revised:
 //
 // * HistoryKind.Valid()
 // * AllHistoryKind()
@@ -77,6 +77,10 @@ type HistoryKind string
 const (
 	// KindModel represents the model itself.
 	KindModel HistoryKind = "model"
+	// KindApplication represents an entry for an application.
+	KindApplication HistoryKind = "application"
+	// KindSAAS represents an entry for a saas application.
+	KindSAAS HistoryKind = "saas"
 	// KindUnit represents agent and workload combined.
 	KindUnit HistoryKind = "unit"
 	// KindUnitAgent represent a unit agent status history entry.
@@ -102,6 +106,7 @@ func (k HistoryKind) String() string {
 func (k HistoryKind) Valid() bool {
 	switch k {
 	case KindModel, KindUnit, KindUnitAgent, KindWorkload,
+		KindApplication, KindSAAS,
 		KindMachineInstance, KindMachine,
 		KindContainerInstance, KindContainer:
 		return true
@@ -113,6 +118,8 @@ func (k HistoryKind) Valid() bool {
 func AllHistoryKind() map[HistoryKind]string {
 	return map[HistoryKind]string{
 		KindModel:             "statuses for the model itself",
+		KindApplication:       "statuses for the specified application",
+		KindSAAS:              "statuses for the specified SAAS application",
 		KindUnit:              "statuses for specified unit and its workload",
 		KindUnitAgent:         "statuses from the agent that is managing a unit",
 		KindWorkload:          "statuses for unit's workload",

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -1056,7 +1056,7 @@ func (s *ActionSuite) TestMergeIds(c *gc.C) {
 		expected := sliceify("", test.expected)
 
 		c.Log(fmt.Sprintf("test number %d %#v", ix, test))
-		err := state.WatcherMergeIds(s.State, &changes, updates, state.MakeActionIdConverter(s.State))
+		err := state.WatcherMergeIds(&changes, updates, state.MakeActionIdConverter(s.State))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(changes, jc.SameContents, expected)
 	}
@@ -1076,7 +1076,7 @@ func (s *ActionSuite) TestMergeIdsErrors(c *gc.C) {
 	for _, test := range tests {
 		changes, updates := []string{}, map[interface{}]bool{}
 		updates[test.key] = true
-		err := state.WatcherMergeIds(s.State, &changes, updates, state.MakeActionIdConverter(s.State))
+		err := state.WatcherMergeIds(&changes, updates, state.MakeActionIdConverter(s.State))
 		c.Assert(err, gc.ErrorMatches, "id is not of type string, got "+test.name)
 	}
 }

--- a/state/application.go
+++ b/state/application.go
@@ -338,7 +338,13 @@ func (op *DestroyApplicationOperation) Build(attempt int) ([]txn.Op, error) {
 // Done is part of the ModelOperation interface.
 func (op *DestroyApplicationOperation) Done(err error) error {
 	if err == nil {
-		return err
+		if err := op.eraseHistory(); err != nil {
+			if !op.Force {
+				logger.Errorf("cannot delete history for application %q: %v", op.app, err)
+			}
+			op.AddError(errors.Errorf("force erase application %q history proceeded despite encountering ERROR %v", op.app, err))
+		}
+		return nil
 	}
 	connected, err2 := applicationHasConnectedOffers(op.app.st, op.app.Name())
 	if err2 != nil {
@@ -361,6 +367,16 @@ func (op *DestroyApplicationOperation) Done(err error) error {
 	}
 
 	return errors.Annotatef(err, "cannot destroy application %q", op.app)
+}
+
+func (op *DestroyApplicationOperation) eraseHistory() error {
+	if err := eraseStatusHistory(op.app.st, op.app.globalKey()); err != nil {
+		one := errors.Annotate(err, "application")
+		if op.FatalError(one) {
+			return one
+		}
+	}
+	return nil
 }
 
 // destroyOps returns the operations required to destroy the application. If it

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2884,6 +2884,24 @@ func (s *ApplicationSuite) TestDestroySimple(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *ApplicationSuite) TestDestroyRemovesStatusHistory(c *gc.C) {
+	err := s.mysql.SetStatus(status.StatusInfo{
+		Status: status.Active,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	filter := status.StatusHistoryFilter{Size: 100}
+	agentInfo, err := s.mysql.StatusHistory(filter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(agentInfo), gc.Equals, 2)
+
+	err = s.mysql.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	agentInfo, err = s.mysql.StatusHistory(filter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(agentInfo, gc.HasLen, 0)
+}
+
 func (s *ApplicationSuite) TestDestroyStillHasUnits(c *gc.C) {
 	unit, err := s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -401,8 +401,8 @@ func CheckUserExists(st *State, name string) (bool, error) {
 	return st.checkUserExists(name)
 }
 
-func WatcherMergeIds(st *State, changeset *[]string, updates map[interface{}]bool, idconv func(string) (string, error)) error {
-	return mergeIds(st, changeset, updates, idconv)
+func WatcherMergeIds(changeset *[]string, updates map[interface{}]bool, idconv func(string) (string, error)) error {
+	return mergeIds(changeset, updates, idconv)
 }
 
 func WatcherEnsureSuffixFn(marker string) func(string) string {

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -172,6 +172,18 @@ func (s *RemoteApplication) Life() Life {
 	return s.doc.Life
 }
 
+// StatusHistory returns a slice of at most filter.Size StatusInfo items
+// or items as old as filter.Date or items newer than now - filter.Delta time
+// representing past statuses for this remote application.
+func (a *RemoteApplication) StatusHistory(filter status.StatusHistoryFilter) ([]status.StatusInfo, error) {
+	args := &statusHistoryArgs{
+		db:        a.st.db(),
+		globalKey: a.globalKey(),
+		filter:    filter,
+	}
+	return statusHistory(args)
+}
+
 // Spaces returns the remote spaces this application is connected to.
 func (s *RemoteApplication) Spaces() []RemoteSpace {
 	var result []RemoteSpace
@@ -303,6 +315,22 @@ func (op *DestroyRemoteApplicationOperation) Done(err error) error {
 			return errors.Annotatef(err, "cannot destroy remote application %q", op.app)
 		}
 		op.AddError(errors.Errorf("force destroy of remote application %v failed but proceeded despite encountering ERROR %v", op.app, err))
+	}
+	if err := op.eraseHistory(); err != nil {
+		if !op.Force {
+			logger.Errorf("cannot delete history for remote application %q: %v", op.app, err)
+		}
+		op.AddError(errors.Errorf("force erase remote application %q history proceeded despite encountering ERROR %v", op.app, err))
+	}
+	return nil
+}
+
+func (op *DestroyRemoteApplicationOperation) eraseHistory() error {
+	if err := eraseStatusHistory(op.app.st, op.app.globalKey()); err != nil {
+		one := errors.Annotate(err, "remote application")
+		if op.FatalError(one) {
+			return one
+		}
 	}
 	return nil
 }
@@ -891,6 +919,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 			},
 		}
 		if !args.IsConsumerProxy {
+			logger.Criticalf("SET STATUS %v", appDoc.Name)
 			statusDoc := statusDoc{
 				ModelUUID: st.ModelUUID(),
 				Status:    status.Unknown,

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -862,6 +862,24 @@ func (s *remoteApplicationSuite) assertDestroyWithReferencedRelation(c *gc.C, re
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *remoteApplicationSuite) TestDestroyRemovesStatusHistory(c *gc.C) {
+	err := s.application.SetStatus(status.StatusInfo{
+		Status: status.Active,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	filter := status.StatusHistoryFilter{Size: 100}
+	agentInfo, err := s.application.StatusHistory(filter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(agentInfo), gc.Equals, 1)
+
+	err = s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	agentInfo, err = s.application.StatusHistory(filter)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(agentInfo, gc.HasLen, 0)
+}
+
 func (s *remoteApplicationSuite) assertInScope(c *gc.C, relUnit *state.RelationUnit, inScope bool) {
 	ok, err := relUnit.InScope()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2944,7 +2944,7 @@ func (w *collectionWatcher) initial() ([]string, error) {
 // Additionally, mergeIds strips the model UUID prefix from the id
 // before emitting it through the watcher.
 func (w *collectionWatcher) mergeIds(changes *[]string, updates map[interface{}]bool) error {
-	return mergeIds(w.backend, changes, updates, w.convertId)
+	return mergeIds(changes, updates, w.convertId)
 }
 
 func (w *collectionWatcher) convertId(id string) (string, error) {
@@ -2963,7 +2963,7 @@ func (w *collectionWatcher) convertId(id string) (string, error) {
 	return id, nil
 }
 
-func mergeIds(st modelBackend, changes *[]string, updates map[interface{}]bool, idconv func(string) (string, error)) error {
+func mergeIds(changes *[]string, updates map[interface{}]bool, idconv func(string) (string, error)) error {
 	for val, idExists := range updates {
 		id, ok := val.(string)
 		if !ok {
@@ -3170,7 +3170,7 @@ func (w *actionNotificationWatcher) filterPendingAndMergeIds(changes *[]string, 
 }
 
 func (w *actionNotificationWatcher) mergeIds(changes *[]string, updates map[interface{}]bool) error {
-	return mergeIds(w.backend, changes, updates, func(id string) (string, error) {
+	return mergeIds(changes, updates, func(id string) (string, error) {
 		return actionNotificationIdToActionId(id), nil
 	})
 }


### PR DESCRIPTION
Investigating a CMR issue, the following problem was observed.
An offer is consumed and the SAAS status entry correctly reflects the app status in the offering model, eg Active.
Remove the SAAS using `juju remove-saas` and consume again. Status is now showing "unknown". But it will be correctly updated next time the offer application changes after that.

The issue is that deleting the SAAS leaves the status history behind. And the next time the offer is consumed, the new status is the same as the last historical value and no update is done, so it is left as unknown.

The issue of not removing app status history also affect local applications. So this PR fixes this for both local and SAAS apps. The implementation is as per what is done for erasing unit history (do it in the Done() method it the destroy operation).

The PR also tweaks the show-status-log CLI tool to support both `application` and `saas` types for printing status history.

As a driveby, fix a few lint issues as well.

## QA steps

deploy 2 models and offer mariadb in one of them
in the other model, juju consume mariadb
then
```
juju show-status-log --type saas mariadb

Time                        Type  Status   Message
30 Aug 2021 14:29:44+10:00  saas  active   ready
```
remove the saas
```
juju remove-saas mariadb
juju show-status-log --type saas mariadb
ERROR while processing the request: fetching status history for "application-mariadb": remote application "mariadb" not found
```
Consume the offer again
```
juju consume othermodel.mariadb
juju show-status-log --type saas mariadb

Time                        Type  Status   Message
30 Aug 2021 14:31:28+10:00  saas  active   ready
```

Also run juju status to see the SAAS status is "Active".

Previously juju status would have shown "unknown".