### PR TITLE
Deploy by rev origin if already downloaded

### DIFF
--- a/apiserver/facades/client/application/updateseries_test.go
+++ b/apiserver/facades/client/application/updateseries_test.go
@@ -185,6 +185,7 @@ func (s CharmhubValidatorSuite) TestValidateApplication(c *gc.C) {
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+		ID:       "mycharmhubid",
 		Revision: &revision,
 		Platform: &state.Platform{
 			Architecture: "amd64",
@@ -230,6 +231,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationWithClientRefreshError(c 
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+		ID:       "mycharmhubid",
 		Revision: &revision,
 		Platform: &state.Platform{
 			Architecture: "amd64",
@@ -260,6 +262,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationWithRefreshError(c *gc.C)
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+		ID:       "mycharmhubid",
 		Revision: &revision,
 		Platform: &state.Platform{
 			Architecture: "amd64",
@@ -293,6 +296,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationWithRefreshErrorAndForce(
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+		ID:       "mycharmhubid",
 		Revision: &revision,
 		Platform: &state.Platform{
 			Architecture: "amd64",

--- a/apiserver/facades/client/client/testing/suite.go
+++ b/apiserver/facades/client/client/testing/suite.go
@@ -188,6 +188,7 @@ func (s *CharmSuite) AddApplication(c *gc.C, charmName, applicationName string) 
 		Charm:  ch,
 		Series: "quantal",
 		CharmOrigin: &state.CharmOrigin{
+			ID: "mycharmhubid",
 			Platform: &state.Platform{
 				Architecture: "amd64",
 				OS:           "ubuntu",

--- a/apiserver/facades/client/machinemanager/upgradeseries_test.go
+++ b/apiserver/facades/client/machinemanager/upgradeseries_test.go
@@ -504,6 +504,7 @@ func (s CharmhubValidatorSuite) TestValidateApplications(c *gc.C) {
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+		ID:       "mycharmhubid",
 		Revision: &revision,
 		Platform: &state.Platform{
 			Architecture: "amd64",
@@ -553,6 +554,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationsWithClientRefreshError(c
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+		ID:       "mycharmhubid",
 		Revision: &revision,
 		Platform: &state.Platform{
 			Architecture: "amd64",
@@ -585,6 +587,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationsWithRefreshError(c *gc.C
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+		ID:       "mycharmhubid",
 		Revision: &revision,
 		Platform: &state.Platform{
 			Architecture: "amd64",
@@ -620,6 +623,7 @@ func (s CharmhubValidatorSuite) TestValidateApplicationsWithRefreshErrorAndForce
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+		ID:       "mycharmhubid",
 		Revision: &revision,
 		Platform: &state.Platform{
 			Architecture: "amd64",

--- a/apiserver/facades/client/resources/base_test.go
+++ b/apiserver/facades/client/resources/base_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/juju/charm/v9"
 	charmresource "github.com/juju/charm/v9/resource"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -42,14 +43,14 @@ func (s *BaseSuite) newCSClient() (CharmStore, error) {
 	return s.csClient, nil
 }
 
-func (s *BaseSuite) newCSFactory() func(CharmID) (NewCharmRepository, error) {
-	return func(chID CharmID) (NewCharmRepository, error) {
-		return newCharmStoreClient(s.csClient, chID), nil
+func (s *BaseSuite) newCSFactory() func(_ *charm.URL) (NewCharmRepository, error) {
+	return func(_ *charm.URL) (NewCharmRepository, error) {
+		return newCharmStoreClient(s.csClient), nil
 	}
 }
 
-func (s *BaseSuite) newLocalFactory() func(CharmID) (NewCharmRepository, error) {
-	return func(chID CharmID) (NewCharmRepository, error) {
+func (s *BaseSuite) newLocalFactory() func(_ *charm.URL) (NewCharmRepository, error) {
+	return func(_ *charm.URL) (NewCharmRepository, error) {
 		return &localClient{}, nil
 	}
 }
@@ -188,8 +189,8 @@ type stubFactory struct {
 	ReturnResources []charmresource.Resource
 }
 
-func (s *stubFactory) ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error) {
-	s.AddCall("ResolveResources", resources)
+func (s *stubFactory) ResolveResources(resources []charmresource.Resource, charmID CharmID) ([]charmresource.Resource, error) {
+	s.AddCall("ResolveResources", resources, charmID)
 
 	if err := s.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/resources/mocks/logger.go
+++ b/apiserver/facades/client/resources/mocks/logger.go
@@ -50,6 +50,23 @@ func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
 }
 
+// Errorf mocks base method.
+func (m *MockLogger) Errorf(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Errorf", varargs...)
+}
+
+// Errorf indicates an expected call of Errorf.
+func (mr *MockLoggerMockRecorder) Errorf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Errorf", reflect.TypeOf((*MockLogger)(nil).Errorf), varargs...)
+}
+
 // Tracef mocks base method.
 func (m *MockLogger) Tracef(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/resources/repository.go
+++ b/apiserver/facades/client/resources/repository.go
@@ -18,7 +18,7 @@ import (
 )
 
 type NewCharmRepository interface {
-	ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error)
+	ResolveResources(resources []charmresource.Resource, id CharmID) ([]charmresource.Resource, error)
 }
 
 // NOTE: There maybe a better way to do this.  Juju's charmhub package is equivalent
@@ -53,11 +53,11 @@ type ResourceClient interface {
 type Logger interface {
 	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})
+	Errorf(string, ...interface{})
 }
 
 type resourceClient struct {
 	client ResourceClient
-	id     CharmID
 	logger Logger
 }
 
@@ -66,6 +66,7 @@ type resourceClient struct {
 // resources along with those in the charm backend (if any).
 func (c *resourceClient) resolveResources(resources []charmresource.Resource,
 	storeResources map[string]charmresource.Resource,
+	id CharmID,
 ) ([]charmresource.Resource, error) {
 	allResolved := make([]charmresource.Resource, len(resources))
 	copy(allResolved, resources)
@@ -77,7 +78,7 @@ func (c *resourceClient) resolveResources(resources []charmresource.Resource,
 			continue
 		}
 
-		resolved, err := c.resolveStoreResource(res, storeResources)
+		resolved, err := c.resolveStoreResource(res, storeResources, id)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -90,6 +91,7 @@ func (c *resourceClient) resolveResources(resources []charmresource.Resource,
 // between the provided and latest info based on the revision.
 func (c *resourceClient) resolveStoreResource(res charmresource.Resource,
 	storeResources map[string]charmresource.Resource,
+	id CharmID,
 ) (charmresource.Resource, error) {
 	storeRes, ok := storeResources[res.Name]
 	if !ok {
@@ -113,7 +115,7 @@ func (c *resourceClient) resolveStoreResource(res charmresource.Resource,
 		// The caller wants resource info from the charm backend, but with
 		// a different resource revision than the one associated with
 		// the charm in the backend.
-		return c.client.ResourceInfo(c.id.URL, c.id.Origin, res.Name, res.Revision)
+		return c.client.ResourceInfo(id.URL, id.Origin, res.Name, res.Revision)
 	}
 	// The caller fully-specified a resource with a different resource
 	// revision than the one associated with the charm in the backend. So
@@ -126,13 +128,12 @@ type charmHubClient struct {
 	client CharmHub
 }
 
-func newCharmHubClient(client CharmHub, logger Logger, id CharmID) *charmHubClient {
+func newCharmHubClient(client CharmHub, logger Logger) *charmHubClient {
 	c := &charmHubClient{
 		client: client,
 	}
 	c.resourceClient = resourceClient{
 		client: c,
-		id:     id,
 		logger: logger,
 	}
 	return c
@@ -198,7 +199,8 @@ func (ch *charmHubClient) ResourceInfo(curl *charm.URL, origin corecharm.Origin,
 
 		for _, entity := range resp.Entity.Resources {
 			if entity.Name == name && entity.Revision == revision {
-				return resourceFromRevision(entity)
+				rfr, err := resourceFromRevision(entity)
+				return rfr, err
 			}
 		}
 	}
@@ -208,27 +210,26 @@ func (ch *charmHubClient) ResourceInfo(curl *charm.URL, origin corecharm.Origin,
 // ResolveResources, looks at the provided, charmhub and backend (already
 // downloaded) resources to determine which to use. Provided (uploaded) take
 // precedence. If charmhub has a newer resource than the back end, use that.
-func (ch *charmHubClient) ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error) {
-	revisionResources, err := ch.listResourcesIfRevisions(resources)
+func (ch *charmHubClient) ResolveResources(resources []charmresource.Resource, id CharmID) ([]charmresource.Resource, error) {
+	revisionResources, err := ch.listResourcesIfRevisions(resources, id.URL)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	storeResources, err := ch.listResources()
+	storeResources, err := ch.listResources(id)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	for k, v := range revisionResources {
 		storeResources[k] = v
 	}
-	resolved, err := ch.resolveResources(resources, storeResources)
+	resolved, err := ch.resolveResources(resources, storeResources, id)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return resolved, nil
 }
 
-func (ch *charmHubClient) listResourcesIfRevisions(resources []charmresource.Resource) (map[string]charmresource.Resource, error) {
-	url := ch.id.URL
+func (ch *charmHubClient) listResourcesIfRevisions(resources []charmresource.Resource, curl *charm.URL) (map[string]charmresource.Resource, error) {
 	results := make(map[string]charmresource.Resource, 0)
 	for _, resource := range resources {
 		// If not revision is specified, or the resource has already been
@@ -236,9 +237,9 @@ func (ch *charmHubClient) listResourcesIfRevisions(resources []charmresource.Res
 		if resource.Revision == -1 || resource.Origin == charmresource.OriginUpload {
 			continue
 		}
-		refreshResp, err := ch.client.ListResourceRevisions(context.TODO(), url.Name, resource.Name)
+		refreshResp, err := ch.client.ListResourceRevisions(context.TODO(), curl.Name, resource.Name)
 		if err != nil {
-			return nil, errors.Annotatef(err, "refreshing charm %q", url.String())
+			return nil, errors.Annotatef(err, "refreshing charm %q", curl.String())
 		}
 		if len(refreshResp) == 0 {
 			return nil, errors.Errorf("no download refresh responses received")
@@ -257,24 +258,39 @@ func (ch *charmHubClient) listResourcesIfRevisions(resources []charmresource.Res
 
 // listResources composes, a map of details for each of the charm's
 // resources. Those details are those associated with the specific
-// charm revision. They include the resource's metadata and revision.
+// charm channel. They include the resource's metadata and revision.
 // Found via the CharmHub api.
-func (ch *charmHubClient) listResources() (map[string]charmresource.Resource, error) {
-	url := ch.id.URL
-	origin := ch.id.Origin
+func (ch *charmHubClient) listResources(id CharmID) (map[string]charmresource.Resource, error) {
+	curl := id.URL
+	origin := id.Origin
 	refBase := charmhub.RefreshBase{
 		Architecture: origin.Platform.Architecture,
 		Name:         origin.Platform.OS,
 		Channel:      origin.Platform.Series,
 	}
-	cfg, err := charmhub.DownloadOneFromChannel(origin.ID, origin.Channel.String(), refBase)
-	if err != nil {
-		return nil, errors.Annotatef(err, "creating resources config for charm %q", url.String())
+	var cfg charmhub.RefreshConfig
+	var err error
+	switch {
+	// Do not get resource data via revision here, it is only provided if explicitly
+	// asked for by resource revision.  The purpose here is to find a resource revision
+	// in the channel, if one was not provided on the cli.
+	case origin.ID != "":
+		cfg, err = charmhub.DownloadOneFromChannel(origin.ID, origin.Channel.String(), refBase)
+		if err != nil {
+			ch.logger.Errorf("creating resources config for charm (%q, %q): %s", origin.ID, origin.Channel.String(), err)
+			return nil, errors.Annotatef(err, "creating resources config for charm %q", curl.String())
+		}
+	case origin.ID == "":
+		cfg, err = charmhub.DownloadOneFromChannelByName(curl.Name, origin.Channel.String(), refBase)
+		if err != nil {
+			ch.logger.Errorf("creating resources config for charm (%q, %q): %s", curl.Name, origin.Channel.String(), err)
+			return nil, errors.Annotatef(err, "creating resources config for charm %q", curl.String())
+		}
 	}
 
 	refreshResp, err := ch.client.Refresh(context.TODO(), cfg)
 	if err != nil {
-		return nil, errors.Annotatef(err, "refreshing charm %q", url.String())
+		return nil, errors.Annotatef(err, "refreshing charm %q", curl.String())
 	}
 	if len(refreshResp) == 0 {
 		return nil, errors.Errorf("no download refresh responses received")
@@ -282,7 +298,7 @@ func (ch *charmHubClient) listResources() (map[string]charmresource.Resource, er
 	resp := refreshResp[0]
 
 	if resp.Error != nil {
-		return nil, errors.Annotatef(errors.New(resp.Error.Message), "listing resources for charm %q", url.String())
+		return nil, errors.Annotatef(errors.New(resp.Error.Message), "listing resources for charm %q", curl.String())
 	}
 	results := make(map[string]charmresource.Resource, len(resp.Entity.Resources))
 	for _, v := range resp.Entity.Resources {
@@ -336,23 +352,22 @@ type charmStoreClient struct {
 	client CharmStore
 }
 
-func newCharmStoreClient(client CharmStore, id CharmID) *charmStoreClient {
+func newCharmStoreClient(client CharmStore) *charmStoreClient {
 	c := &charmStoreClient{
 		client: client,
 	}
 	c.resourceClient = resourceClient{
 		client: c,
-		id:     id,
 	}
 	return c
 }
 
-func (cs *charmStoreClient) ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error) {
-	storeResources, err := cs.resourcesFromCharmstore(cs.id)
+func (cs *charmStoreClient) ResolveResources(resources []charmresource.Resource, id CharmID) ([]charmresource.Resource, error) {
+	storeResources, err := cs.resourcesFromCharmstore(id)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	resolved, err := cs.resolveResources(resources, storeResources)
+	resolved, err := cs.resolveResources(resources, storeResources, id)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -410,7 +425,7 @@ func (cs *charmStoreClient) ResourceInfo(url *charm.URL, origin corecharm.Origin
 
 type localClient struct{}
 
-func (lc *localClient) ResolveResources(resources []charmresource.Resource) ([]charmresource.Resource, error) {
+func (lc *localClient) ResolveResources(resources []charmresource.Resource, _ CharmID) ([]charmresource.Resource, error) {
 	var resolved []charmresource.Resource
 	for _, res := range resources {
 		resolved = append(resolved, charmresource.Resource{

--- a/apiserver/facades/client/resources/server_test.go
+++ b/apiserver/facades/client/resources/server_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"github.com/juju/charm/v9"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 )
@@ -15,12 +16,12 @@ type FacadeSuite struct {
 }
 
 func (s *FacadeSuite) TestNewFacadeOkay(c *gc.C) {
-	_, err := NewResourcesAPI(s.data, func(chID CharmID) (NewCharmRepository, error) { return &stubFactory{}, nil })
+	_, err := NewResourcesAPI(s.data, func(*charm.URL) (NewCharmRepository, error) { return &stubFactory{}, nil })
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *FacadeSuite) TestNewFacadeMissingDataStore(c *gc.C) {
-	_, err := NewResourcesAPI(nil, func(chID CharmID) (NewCharmRepository, error) { return &stubFactory{}, nil })
+	_, err := NewResourcesAPI(nil, func(*charm.URL) (NewCharmRepository, error) { return &stubFactory{}, nil })
 	c.Check(err, gc.ErrorMatches, `missing data backend`)
 }
 

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -162,8 +162,8 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 				logger.Errorf("charm %s has no origin, skipping", curl)
 				continue
 			}
-			if origin.Revision == nil || origin.Channel == nil || origin.Platform == nil {
-				logger.Errorf("charm %s has missing revision (%p), channel (%p), or platform (%p), skipping",
+			if origin.ID == "" || origin.Revision == nil || origin.Channel == nil || origin.Platform == nil {
+				logger.Errorf("charm %s has missing id(%s), revision (%p), channel (%p), or platform (%p), skipping",
 					curl, origin.Revision, origin.Channel, origin.Platform)
 				continue
 			}

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -292,6 +292,15 @@ func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 	})
 }
 
+func (s *RefreshConfigSuite) TestRefreshOneFail(c *gc.C) {
+	_, err := RefreshOne("", 1, "latest/stable", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}
+
 func (s *RefreshConfigSuite) TestRefreshOneEnsure(c *gc.C) {
 	config, err := RefreshOne("foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
@@ -308,7 +317,7 @@ func (s *RefreshConfigSuite) TestRefreshOneEnsure(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *RefreshConfigSuite) TestInstallOneBuildRevision(c *gc.C) {
+func (s *RefreshConfigSuite) TestInstallOneFromRevisionBuild(c *gc.C) {
 	revision := 1
 
 	name := "foo"
@@ -329,6 +338,11 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevision(c *gc.C) {
 		}},
 		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
 	})
+}
+
+func (s *RefreshConfigSuite) TestInstallOneFromRevisionFail(c *gc.C) {
+	_, err := InstallOneFromRevision("", 1)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (s *RefreshConfigSuite) TestInstallOneBuildRevisionResources(c *gc.C) {
@@ -402,6 +416,15 @@ func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 	})
 }
 
+func (s *RefreshConfigSuite) TestInstallOneChannelFail(c *gc.C) {
+	_, err := InstallOneFromChannel("", "stable", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}
+
 func (s *RefreshConfigSuite) TestInstallOneWithPartialPlatform(c *gc.C) {
 	channel := "latest/stable"
 
@@ -444,22 +467,6 @@ func (s *RefreshConfigSuite) TestInstallOneWithMissingArch(c *gc.C) {
 	c.Assert(errors.IsNotValid(err), jc.IsTrue)
 }
 
-func (s *RefreshConfigSuite) TestInstallOneEnsure(c *gc.C) {
-	config, err := InstallOneFromChannel("foo", "latest/stable", RefreshBase{
-		Name:         "ubuntu",
-		Channel:      "20.04",
-		Architecture: arch.DefaultArchitecture,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	config = DefineInstanceKey(c, config, "foo-bar")
-
-	err = config.Ensure([]transport.RefreshResponse{{
-		InstanceKey: "foo-bar",
-	}})
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *RefreshConfigSuite) TestInstallOneFromChannelEnsure(c *gc.C) {
 	config, err := InstallOneFromChannel("foo", "latest/stable", RefreshBase{
 		Name:         "ubuntu",
@@ -476,20 +483,67 @@ func (s *RefreshConfigSuite) TestInstallOneFromChannelEnsure(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *RefreshConfigSuite) TestDownloadOneEnsure(c *gc.C) {
-	config, err := DownloadOne("foo", 1, "latest/stable", RefreshBase{
+func (s *RefreshConfigSuite) TestInstallOneFromChannelFail(c *gc.C) {
+	_, err := InstallOneFromChannel("foo", "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneFromRevisionBuild(c *gc.C) {
+	rev := 4
+	id := "foo"
+	config, err := DownloadOneFromRevision(id, rev)
+	c.Assert(err, jc.ErrorIsNil)
 
 	config = DefineInstanceKey(c, config, "foo-bar")
 
-	err = config.Ensure([]transport.RefreshResponse{{
-		InstanceKey: "foo-bar",
-	}})
+	req, _, err := config.Build()
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{},
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "download",
+			InstanceKey: "foo-bar",
+			ID:          &id,
+			Revision:    &rev,
+		}},
+		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
+	})
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneFromRevisionFail(c *gc.C) {
+	_, err := DownloadOneFromRevision("", 7)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneFromRevisionByNameBuild(c *gc.C) {
+	rev := 4
+	name := "foo"
+	config, err := DownloadOneFromRevisionByName(name, rev)
+	c.Assert(err, jc.ErrorIsNil)
+
+	config = DefineInstanceKey(c, config, "foo-bar")
+
+	req, _, err := config.Build()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{},
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "download",
+			InstanceKey: "foo-bar",
+			Name:        &name,
+			Revision:    &rev,
+		}},
+		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
+	})
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneFromRevisionByNameFail(c *gc.C) {
+	_, err := DownloadOneFromRevisionByName("", 7)
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
@@ -520,6 +574,54 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
 			},
 		}},
 	})
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneFromChannelFail(c *gc.C) {
+	_, err := DownloadOneFromChannel("", "latest/stable", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneFromChannelByNameBuild(c *gc.C) {
+	channel := "latest/stable"
+	name := "foo"
+	config, err := DownloadOneFromChannelByName(name, channel, RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	config = DefineInstanceKey(c, config, "foo-bar")
+
+	req, _, err := config.Build()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{},
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "download",
+			InstanceKey: "foo-bar",
+			Name:        &name,
+			Channel:     &channel,
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
+				Architecture: arch.DefaultArchitecture,
+			},
+		}},
+	})
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneFromChannelByNameFail(c *gc.C) {
+	_, err := DownloadOneFromChannel("", "latest/stable", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotValid)
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuildK8s(c *gc.C) {

--- a/core/charm/downloader/downloader.go
+++ b/core/charm/downloader/downloader.go
@@ -6,6 +6,7 @@ package downloader
 import (
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strings"
 
@@ -35,6 +36,7 @@ type CharmArchive interface {
 
 // CharmRepository provides an API for downloading charms/bundles.
 type CharmRepository interface {
+	GetDownloadURL(*charm.URL, corecharm.Origin, macaroon.Slice) (*url.URL, corecharm.Origin, error)
 	ResolveWithPreferredChannel(charmURL *charm.URL, requestedOrigin corecharm.Origin, macaroons macaroon.Slice) (*charm.URL, corecharm.Origin, []string, error)
 	DownloadCharm(charmURL *charm.URL, requestedOrigin corecharm.Origin, macaroons macaroon.Slice, archivePath string) (corecharm.CharmArchive, corecharm.Origin, error)
 }
@@ -137,7 +139,7 @@ func (d *Downloader) DownloadAndStore(charmURL *charm.URL, requestedOrigin corec
 			if err != nil {
 				return corecharm.Origin{}, errors.Trace(err)
 			}
-			_, resolvedOrigin, _, err := repo.ResolveWithPreferredChannel(charmURL, requestedOrigin, macaroons)
+			_, resolvedOrigin, err := repo.GetDownloadURL(charmURL, requestedOrigin, macaroons)
 			return resolvedOrigin, errors.Trace(err)
 		}
 

--- a/core/charm/downloader/downloader_mocks.go
+++ b/core/charm/downloader/downloader_mocks.go
@@ -5,38 +5,38 @@
 package downloader
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	v9 "github.com/juju/charm/v9"
 	charm "github.com/juju/juju/core/charm"
 	macaroon_v2 "gopkg.in/macaroon.v2"
+	url "net/url"
+	reflect "reflect"
 )
 
-// MockLogger is a mock of Logger interface.
+// MockLogger is a mock of Logger interface
 type MockLogger struct {
 	ctrl     *gomock.Controller
 	recorder *MockLoggerMockRecorder
 }
 
-// MockLoggerMockRecorder is the mock recorder for MockLogger.
+// MockLoggerMockRecorder is the mock recorder for MockLogger
 type MockLoggerMockRecorder struct {
 	mock *MockLogger
 }
 
-// NewMockLogger creates a new mock instance.
+// NewMockLogger creates a new mock instance
 func NewMockLogger(ctrl *gomock.Controller) *MockLogger {
 	mock := &MockLogger{ctrl: ctrl}
 	mock.recorder = &MockLoggerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
-// Debugf mocks base method.
+// Debugf mocks base method
 func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -46,14 +46,14 @@ func (m *MockLogger) Debugf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Debugf", varargs...)
 }
 
-// Debugf indicates an expected call of Debugf.
+// Debugf indicates an expected call of Debugf
 func (mr *MockLoggerMockRecorder) Debugf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debugf", reflect.TypeOf((*MockLogger)(nil).Debugf), varargs...)
 }
 
-// Tracef mocks base method.
+// Tracef mocks base method
 func (m *MockLogger) Tracef(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -63,14 +63,14 @@ func (m *MockLogger) Tracef(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Tracef", varargs...)
 }
 
-// Tracef indicates an expected call of Tracef.
+// Tracef indicates an expected call of Tracef
 func (mr *MockLoggerMockRecorder) Tracef(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tracef", reflect.TypeOf((*MockLogger)(nil).Tracef), varargs...)
 }
 
-// Warningf mocks base method.
+// Warningf mocks base method
 func (m *MockLogger) Warningf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -80,37 +80,37 @@ func (m *MockLogger) Warningf(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Warningf", varargs...)
 }
 
-// Warningf indicates an expected call of Warningf.
+// Warningf indicates an expected call of Warningf
 func (mr *MockLoggerMockRecorder) Warningf(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warningf", reflect.TypeOf((*MockLogger)(nil).Warningf), varargs...)
 }
 
-// MockCharmArchive is a mock of CharmArchive interface.
+// MockCharmArchive is a mock of CharmArchive interface
 type MockCharmArchive struct {
 	ctrl     *gomock.Controller
 	recorder *MockCharmArchiveMockRecorder
 }
 
-// MockCharmArchiveMockRecorder is the mock recorder for MockCharmArchive.
+// MockCharmArchiveMockRecorder is the mock recorder for MockCharmArchive
 type MockCharmArchiveMockRecorder struct {
 	mock *MockCharmArchive
 }
 
-// NewMockCharmArchive creates a new mock instance.
+// NewMockCharmArchive creates a new mock instance
 func NewMockCharmArchive(ctrl *gomock.Controller) *MockCharmArchive {
 	mock := &MockCharmArchive{ctrl: ctrl}
 	mock.recorder = &MockCharmArchiveMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockCharmArchive) EXPECT() *MockCharmArchiveMockRecorder {
 	return m.recorder
 }
 
-// Actions mocks base method.
+// Actions mocks base method
 func (m *MockCharmArchive) Actions() *v9.Actions {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Actions")
@@ -118,13 +118,13 @@ func (m *MockCharmArchive) Actions() *v9.Actions {
 	return ret0
 }
 
-// Actions indicates an expected call of Actions.
+// Actions indicates an expected call of Actions
 func (mr *MockCharmArchiveMockRecorder) Actions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Actions", reflect.TypeOf((*MockCharmArchive)(nil).Actions))
 }
 
-// Config mocks base method.
+// Config mocks base method
 func (m *MockCharmArchive) Config() *v9.Config {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
@@ -132,13 +132,13 @@ func (m *MockCharmArchive) Config() *v9.Config {
 	return ret0
 }
 
-// Config indicates an expected call of Config.
+// Config indicates an expected call of Config
 func (mr *MockCharmArchiveMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockCharmArchive)(nil).Config))
 }
 
-// LXDProfile mocks base method.
+// LXDProfile mocks base method
 func (m *MockCharmArchive) LXDProfile() *v9.LXDProfile {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfile")
@@ -146,13 +146,13 @@ func (m *MockCharmArchive) LXDProfile() *v9.LXDProfile {
 	return ret0
 }
 
-// LXDProfile indicates an expected call of LXDProfile.
+// LXDProfile indicates an expected call of LXDProfile
 func (mr *MockCharmArchiveMockRecorder) LXDProfile() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfile", reflect.TypeOf((*MockCharmArchive)(nil).LXDProfile))
 }
 
-// Manifest mocks base method.
+// Manifest mocks base method
 func (m *MockCharmArchive) Manifest() *v9.Manifest {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Manifest")
@@ -160,13 +160,13 @@ func (m *MockCharmArchive) Manifest() *v9.Manifest {
 	return ret0
 }
 
-// Manifest indicates an expected call of Manifest.
+// Manifest indicates an expected call of Manifest
 func (mr *MockCharmArchiveMockRecorder) Manifest() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Manifest", reflect.TypeOf((*MockCharmArchive)(nil).Manifest))
 }
 
-// Meta mocks base method.
+// Meta mocks base method
 func (m *MockCharmArchive) Meta() *v9.Meta {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Meta")
@@ -174,13 +174,13 @@ func (m *MockCharmArchive) Meta() *v9.Meta {
 	return ret0
 }
 
-// Meta indicates an expected call of Meta.
+// Meta indicates an expected call of Meta
 func (mr *MockCharmArchiveMockRecorder) Meta() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Meta", reflect.TypeOf((*MockCharmArchive)(nil).Meta))
 }
 
-// Metrics mocks base method.
+// Metrics mocks base method
 func (m *MockCharmArchive) Metrics() *v9.Metrics {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Metrics")
@@ -188,13 +188,13 @@ func (m *MockCharmArchive) Metrics() *v9.Metrics {
 	return ret0
 }
 
-// Metrics indicates an expected call of Metrics.
+// Metrics indicates an expected call of Metrics
 func (mr *MockCharmArchiveMockRecorder) Metrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockCharmArchive)(nil).Metrics))
 }
 
-// Revision mocks base method.
+// Revision mocks base method
 func (m *MockCharmArchive) Revision() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revision")
@@ -202,13 +202,13 @@ func (m *MockCharmArchive) Revision() int {
 	return ret0
 }
 
-// Revision indicates an expected call of Revision.
+// Revision indicates an expected call of Revision
 func (mr *MockCharmArchiveMockRecorder) Revision() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharmArchive)(nil).Revision))
 }
 
-// Version mocks base method.
+// Version mocks base method
 func (m *MockCharmArchive) Version() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
@@ -216,36 +216,36 @@ func (m *MockCharmArchive) Version() string {
 	return ret0
 }
 
-// Version indicates an expected call of Version.
+// Version indicates an expected call of Version
 func (mr *MockCharmArchiveMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockCharmArchive)(nil).Version))
 }
 
-// MockCharmRepository is a mock of CharmRepository interface.
+// MockCharmRepository is a mock of CharmRepository interface
 type MockCharmRepository struct {
 	ctrl     *gomock.Controller
 	recorder *MockCharmRepositoryMockRecorder
 }
 
-// MockCharmRepositoryMockRecorder is the mock recorder for MockCharmRepository.
+// MockCharmRepositoryMockRecorder is the mock recorder for MockCharmRepository
 type MockCharmRepositoryMockRecorder struct {
 	mock *MockCharmRepository
 }
 
-// NewMockCharmRepository creates a new mock instance.
+// NewMockCharmRepository creates a new mock instance
 func NewMockCharmRepository(ctrl *gomock.Controller) *MockCharmRepository {
 	mock := &MockCharmRepository{ctrl: ctrl}
 	mock.recorder = &MockCharmRepositoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockCharmRepository) EXPECT() *MockCharmRepositoryMockRecorder {
 	return m.recorder
 }
 
-// DownloadCharm mocks base method.
+// DownloadCharm mocks base method
 func (m *MockCharmRepository) DownloadCharm(arg0 *v9.URL, arg1 charm.Origin, arg2 macaroon_v2.Slice, arg3 string) (charm.CharmArchive, charm.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DownloadCharm", arg0, arg1, arg2, arg3)
@@ -255,13 +255,29 @@ func (m *MockCharmRepository) DownloadCharm(arg0 *v9.URL, arg1 charm.Origin, arg
 	return ret0, ret1, ret2
 }
 
-// DownloadCharm indicates an expected call of DownloadCharm.
+// DownloadCharm indicates an expected call of DownloadCharm
 func (mr *MockCharmRepositoryMockRecorder) DownloadCharm(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadCharm", reflect.TypeOf((*MockCharmRepository)(nil).DownloadCharm), arg0, arg1, arg2, arg3)
 }
 
-// ResolveWithPreferredChannel mocks base method.
+// GetDownloadURL mocks base method
+func (m *MockCharmRepository) GetDownloadURL(arg0 *v9.URL, arg1 charm.Origin, arg2 macaroon_v2.Slice) (*url.URL, charm.Origin, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDownloadURL", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*url.URL)
+	ret1, _ := ret[1].(charm.Origin)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDownloadURL indicates an expected call of GetDownloadURL
+func (mr *MockCharmRepositoryMockRecorder) GetDownloadURL(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadURL", reflect.TypeOf((*MockCharmRepository)(nil).GetDownloadURL), arg0, arg1, arg2)
+}
+
+// ResolveWithPreferredChannel mocks base method
 func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 *v9.URL, arg1 charm.Origin, arg2 macaroon_v2.Slice) (*v9.URL, charm.Origin, []string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1, arg2)
@@ -272,36 +288,36 @@ func (m *MockCharmRepository) ResolveWithPreferredChannel(arg0 *v9.URL, arg1 cha
 	return ret0, ret1, ret2, ret3
 }
 
-// ResolveWithPreferredChannel indicates an expected call of ResolveWithPreferredChannel.
+// ResolveWithPreferredChannel indicates an expected call of ResolveWithPreferredChannel
 func (mr *MockCharmRepositoryMockRecorder) ResolveWithPreferredChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithPreferredChannel", reflect.TypeOf((*MockCharmRepository)(nil).ResolveWithPreferredChannel), arg0, arg1, arg2)
 }
 
-// MockRepositoryGetter is a mock of RepositoryGetter interface.
+// MockRepositoryGetter is a mock of RepositoryGetter interface
 type MockRepositoryGetter struct {
 	ctrl     *gomock.Controller
 	recorder *MockRepositoryGetterMockRecorder
 }
 
-// MockRepositoryGetterMockRecorder is the mock recorder for MockRepositoryGetter.
+// MockRepositoryGetterMockRecorder is the mock recorder for MockRepositoryGetter
 type MockRepositoryGetterMockRecorder struct {
 	mock *MockRepositoryGetter
 }
 
-// NewMockRepositoryGetter creates a new mock instance.
+// NewMockRepositoryGetter creates a new mock instance
 func NewMockRepositoryGetter(ctrl *gomock.Controller) *MockRepositoryGetter {
 	mock := &MockRepositoryGetter{ctrl: ctrl}
 	mock.recorder = &MockRepositoryGetterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockRepositoryGetter) EXPECT() *MockRepositoryGetterMockRecorder {
 	return m.recorder
 }
 
-// GetCharmRepository mocks base method.
+// GetCharmRepository mocks base method
 func (m *MockRepositoryGetter) GetCharmRepository(arg0 charm.Source) (CharmRepository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCharmRepository", arg0)
@@ -310,36 +326,36 @@ func (m *MockRepositoryGetter) GetCharmRepository(arg0 charm.Source) (CharmRepos
 	return ret0, ret1
 }
 
-// GetCharmRepository indicates an expected call of GetCharmRepository.
+// GetCharmRepository indicates an expected call of GetCharmRepository
 func (mr *MockRepositoryGetterMockRecorder) GetCharmRepository(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmRepository", reflect.TypeOf((*MockRepositoryGetter)(nil).GetCharmRepository), arg0)
 }
 
-// MockStorage is a mock of Storage interface.
+// MockStorage is a mock of Storage interface
 type MockStorage struct {
 	ctrl     *gomock.Controller
 	recorder *MockStorageMockRecorder
 }
 
-// MockStorageMockRecorder is the mock recorder for MockStorage.
+// MockStorageMockRecorder is the mock recorder for MockStorage
 type MockStorageMockRecorder struct {
 	mock *MockStorage
 }
 
-// NewMockStorage creates a new mock instance.
+// NewMockStorage creates a new mock instance
 func NewMockStorage(ctrl *gomock.Controller) *MockStorage {
 	mock := &MockStorage{ctrl: ctrl}
 	mock.recorder = &MockStorageMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
 	return m.recorder
 }
 
-// PrepareToStoreCharm mocks base method.
+// PrepareToStoreCharm mocks base method
 func (m *MockStorage) PrepareToStoreCharm(arg0 *v9.URL) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareToStoreCharm", arg0)
@@ -347,13 +363,13 @@ func (m *MockStorage) PrepareToStoreCharm(arg0 *v9.URL) error {
 	return ret0
 }
 
-// PrepareToStoreCharm indicates an expected call of PrepareToStoreCharm.
+// PrepareToStoreCharm indicates an expected call of PrepareToStoreCharm
 func (mr *MockStorageMockRecorder) PrepareToStoreCharm(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareToStoreCharm", reflect.TypeOf((*MockStorage)(nil).PrepareToStoreCharm), arg0)
 }
 
-// Store mocks base method.
+// Store mocks base method
 func (m *MockStorage) Store(arg0 *v9.URL, arg1 DownloadedCharm) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Store", arg0, arg1)
@@ -361,7 +377,7 @@ func (m *MockStorage) Store(arg0 *v9.URL, arg1 DownloadedCharm) error {
 	return ret0
 }
 
-// Store indicates an expected call of Store.
+// Store indicates an expected call of Store
 func (mr *MockStorageMockRecorder) Store(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockStorage)(nil).Store), arg0, arg1)

--- a/resource/resourceadapters/charmhub_test.go
+++ b/resource/resourceadapters/charmhub_test.go
@@ -39,6 +39,7 @@ func (s *CharmHubSuite) TestGetResource(c *gc.C) {
 		CharmID: repositories.CharmID{
 			URL: curl,
 			Origin: state.CharmOrigin{
+				ID:      "mycharmhubid",
 				Channel: &state.Channel{Risk: "stable"},
 				Platform: &state.Platform{
 					Architecture: "amd64",


### PR DESCRIPTION
Ensure that deploy by revision with resources is working. Allow for querying resources by name or by ID.

Add checks to the Refresh Config functions to verify that a non empty id or name is provided.

Do clean up for a single CharmID in ResolveResources, rather than 2 sources of truth.

Resolve a bug found while working to fix issues around deploy by revision: If the charm has already been downloaded, the origin returned from DownloadAndStore must include an origin with an ID and Hash. Otherwise charm upgrades and deploying with resources will fail.

## QA steps

```sh
$ juju deploy juju-qa-test
Located charm "juju-qa-test" in charm-hub, revision 13
Deploying "juju-qa-test" from charm-hub charm "juju-qa-test", revision 13 in channel stable
$ juju resources juju-qa-test
Resource  Supplied by  Revision
foo-file  charmstore   2

$ juju deploy juju-qa-test --revision 9 --channel 2.0/stable juju-qa-test-rev-nine
Located charm "juju-qa-test" in charm-hub, revision 9
Deploying "juju-qa-test-rev-nine" from charm-hub charm "juju-qa-test", revision 9 in channel 2.0/stable
$ juju resources juju-qa-test-rev-nine
Resource  Supplied by  Revision
foo-file  charmstore   1

$ juju deploy juju-qa-test --resource foo-file=4 four
Located charm "juju-qa-test" in charm-hub, revision 13
Deploying "four" from charm-hub charm "juju-qa-test", revision 13 in channel stable
$ juju resources four
Resource  Supplied by  Revision
foo-file  charmstore   4

$ juju deploy juju-qa-test --revision 9 --channel 2.0/stable --resource foo-file=4 by-rev-nine-with-four
Located charm "juju-qa-test" in charm-hub, revision 9
Deploying "by-rev-nine-with-four" from charm-hub charm "juju-qa-test", revision 9 in channel 2.0/stable
$ juju resources by-rev-nine-with-four
juju resources by-rev-nine-with-four
Resource  Supplied by  Revision
foo-file  charmstore   4

# verify ID/hash in db.
juju:PRIMARY> db.applications.find({},{"charm-origin":1}).pretty()
```

