### PR TITLE
[2.9] Preserve empty openvswitch blocks when merging netplan configurations

### DIFF
--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -87,10 +87,19 @@ type BridgeParameters struct {
 }
 
 type Bridge struct {
-	Interfaces    []string `yaml:"interfaces,omitempty,flow"`
-	Interface     `yaml:",inline"`
-	Parameters    BridgeParameters       `yaml:"parameters,omitempty"`
-	OVSParameters map[string]interface{} `yaml:"openvswitch,omitempty"`
+	Interfaces []string `yaml:"interfaces,omitempty,flow"`
+	Interface  `yaml:",inline"`
+	Parameters BridgeParameters `yaml:"parameters,omitempty"`
+
+	// According to the netplan examples, this section typically includes
+	// some OVS-specific configuration bits. However, MAAS may just
+	// include an empty block to indicate the presence of an OVS-managed
+	// bridge (LP1942328). As a workaround, we make this an optional map
+	// so we can tell whether it is present (but empty) vs not being
+	// present.
+	//
+	// See: https://github.com/canonical/netplan/blob/main/examples/openvswitch.yaml
+	OVSParameters *map[string]interface{} `yaml:"openvswitch,omitempty"`
 }
 
 type Route struct {

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -124,6 +124,23 @@ network:
 `)
 }
 
+func (s *NetplanSuite) TestStructuresWithOptionalOVSBlock(c *gc.C) {
+	checkNetplanRoundTrips(c, `
+network:
+  version: 2
+  renderer: NetworkManager
+  bridges:
+    br0:
+      interfaces: [wlp1s0, switchports]
+      dhcp4: false
+    ovs0:
+      interfaces: [patch0-1, eth0, bond0]
+      addresses:
+      - 10.5.48.11/20
+      openvswitch: {}
+`)
+}
+
 func (s *NetplanSuite) TestSerializationOfEthernetDevicesWithLinkLocalFields(c *gc.C) {
 	np := MustNetplanFromYaml(c, `
 network:


### PR DESCRIPTION
When merging netplan configs, Juju was operating under the assumption that the `openvswitch` block would contain at least a single KV entry (based on [this](https://github.com/canonical/netplan/blob/main/examples/openvswitch.yaml) example in the netplan repo).

However, when using MAAS to provision machines with a pre-configured OVS bridge, the initial netplan might simply contain an empty `openvswitch: {}` block to indicate that a particular bridge is managed by OVS. As Juju used an `omitempty` (like we do for all other netplan fields), it omitted the empty openvswitch block when marshaling the merged netplan configuration.

As a workaround, this PR makes that particular field optional (also retaining the `omitempty`) by converting the initial `map[string]interface{}` definition into a `*map[string]interface{}`. This allows us to tell whether the map is present (but empty) vs not being present when merging netplan configurations.

## QA steps

```console
$ juju bootstap finfolk ff --bootstrap-contstraints="tags=ovs" --no-gui
$ juju switch controller
$  juju deploy cs:~juju-qa/bionic/space-invader --constraints='tags=ovs' --to lxd:0 --bind 'space1 invade-b=space2'
$ juju ssh 0 'sudo cat /etc/netplan/99-juju.yaml | grep -B13 openvswitch'
    br-ovs:
      interfaces: [bond0]
      addresses:
      - 10.0.30.118/24
      gateway4: 10.0.30.1
      nameservers:
        search: [maas]
        addresses: [10.0.30.1]
      macaddress: 52:54:00:a2:1f:03
      mtu: 1500
      parameters:
        forward-delay: 15
        stp: false
      openvswitch: {}   <----- you are looking for this
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1942328