### PR TITLE
[dev] Implement batch charm lookup

### DIFF
--- a/apiserver/facades/client/charms/mocks/repository.go
+++ b/apiserver/facades/client/charms/mocks/repository.go
@@ -70,6 +70,25 @@ func (mr *MockRepositoryMockRecorder) GetDownloadURL(arg0, arg1, arg2 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadURL", reflect.TypeOf((*MockRepository)(nil).GetDownloadURL), arg0, arg1, arg2)
 }
 
+// GetEssentialMetadata mocks base method.
+func (m *MockRepository) GetEssentialMetadata(arg0 ...charm0.MetadataRequest) ([]charm0.EssentialMetadata, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetEssentialMetadata", varargs...)
+	ret0, _ := ret[0].([]charm0.EssentialMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEssentialMetadata indicates an expected call of GetEssentialMetadata.
+func (mr *MockRepositoryMockRecorder) GetEssentialMetadata(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEssentialMetadata", reflect.TypeOf((*MockRepository)(nil).GetEssentialMetadata), arg0...)
+}
+
 // ListResources mocks base method.
 func (m *MockRepository) ListResources(arg0 *charm.URL, arg1 charm0.Origin, arg2 macaroon.Slice) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -30,6 +30,11 @@ type Repository interface {
 	// this charm.
 	ResolveWithPreferredChannel(*charm.URL, Origin, macaroon.Slice) (*charm.URL, Origin, []string, error)
 
+	// GetEssentialMetadata resolves each provided MetadataRequest and
+	// returns back a slice with the results. The results include the
+	// minimum set of metadata that is required for deploying each charm.
+	GetEssentialMetadata(...MetadataRequest) ([]EssentialMetadata, error)
+
 	// ListResources returns a list of resources associated with a given charm.
 	ListResources(*charm.URL, Origin, macaroon.Slice) ([]charmresource.Resource, error)
 }
@@ -45,4 +50,23 @@ type CharmArchive interface {
 
 	Version() string
 	LXDProfile() *charm.LXDProfile
+}
+
+// MetadataRequest encapsulates the arguments for a charm essential metadata
+// resolution request.
+type MetadataRequest struct {
+	CharmURL  *charm.URL
+	Origin    Origin
+	Macaroons macaroon.Slice
+}
+
+// EssentialMetadata encapsulates the essential metadata required for deploying
+// a particular charm.
+type EssentialMetadata struct {
+	ResolvedOrigin Origin
+
+	Meta       *charm.Meta
+	Manifest   *charm.Manifest
+	Config     *charm.Config
+	LXDProfile *charm.LXDProfile
 }

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -5,8 +5,11 @@ package repository
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/juju/charm/v9"
@@ -335,6 +338,74 @@ func (c *CharmHubRepository) ListResources(charmURL *charm.URL, origin corecharm
 	}
 
 	return results, nil
+}
+
+// GetEssentialMetadata resolves each provided MetadataRequest and returns back
+// a slice with the results. The results include the minimum set of metadata
+// that is required for deploying each charm.
+func (c *CharmHubRepository) GetEssentialMetadata(reqs ...corecharm.MetadataRequest) ([]corecharm.EssentialMetadata, error) {
+	// Group reqs in batches based on the provided macaroons
+	var urlToReqIdx = make(map[*charm.URL]int)
+	var reqGroups = make(map[string][]corecharm.MetadataRequest)
+	for reqIdx, req := range reqs {
+		urlToReqIdx[req.CharmURL] = reqIdx
+		if len(req.Macaroons) == 0 {
+			reqGroups[""] = append(reqGroups[""], req)
+			continue
+		}
+
+		// Calculate the concatenated signatures for all specified
+		// macaroons, convert them to a hex string and use that as
+		// the map key; this allows us to group together requests that
+		// reference the same set of macaroons.
+		var macSigs []byte
+		for _, mac := range req.Macaroons {
+			macSigs = append(macSigs, mac.Signature()...)
+		}
+		macSig := hex.EncodeToString(macSigs)
+		reqGroups[macSig] = append(reqGroups[macSig], req)
+	}
+
+	// Make a batch request for each group
+	var res = make([]corecharm.EssentialMetadata, len(reqs))
+	for _, reqGroup := range reqGroups {
+		resGroup, err := c.getEssentialMetadataForBatch(reqGroup)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		for groupResIdx, groupRes := range resGroup {
+			reqURL := reqGroup[groupResIdx].CharmURL
+			res[urlToReqIdx[reqURL]] = groupRes
+		}
+	}
+
+	return res, nil
+}
+
+func (c *CharmHubRepository) getEssentialMetadataForBatch(reqs []corecharm.MetadataRequest) ([]corecharm.EssentialMetadata, error) {
+	var res = make([]corecharm.EssentialMetadata, len(reqs))
+	for reqIdx, req := range reqs {
+		tmpFile, err := ioutil.TempFile("", "charm-")
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		_ = tmpFile.Close()
+
+		chArchive, resolvedOrigin, err := c.DownloadCharm(req.CharmURL, req.Origin, req.Macaroons, tmpFile.Name())
+		_ = os.Remove(tmpFile.Name())
+		if err != nil {
+			return nil, errors.Annotatef(err, "downloading charm %q", req.CharmURL)
+		}
+
+		res[reqIdx].ResolvedOrigin = resolvedOrigin
+		res[reqIdx].Meta = chArchive.Meta()
+		res[reqIdx].Manifest = chArchive.Manifest()
+		res[reqIdx].Config = chArchive.Config()
+		res[reqIdx].LXDProfile = chArchive.LXDProfile()
+	}
+
+	return res, nil
 }
 
 func (c *CharmHubRepository) refreshOne(charmURL *charm.URL, origin corecharm.Origin, _ macaroon.Slice) (transport.RefreshResponse, error) {

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/charm/repository/mocks"
+	"github.com/juju/juju/testcharms"
 )
 
 type charmHubRepositorySuite struct {
 	testing.IsolationSuite
+
 	client *mocks.MockCharmHubClient
 	logger *mocks.MockLogger
 }
@@ -364,6 +366,62 @@ func (s *charmHubRepositorySuite) TestGetDownloadURL(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotURL, gc.DeepEquals, resolvedURL)
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
+}
+
+func (s *charmHubRepositorySuite) TestGetEssentialMetadata(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	curl := charm.MustParseURL("ch:wordpress")
+	requestedOrigin := corecharm.Origin{
+		Source: "charm-hub",
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+			OS:           "ubuntu",
+			Series:       "focal",
+		},
+		Channel: &charm.Channel{
+			Track: "latest",
+			Risk:  "stable",
+		},
+	}
+
+	resolvedURL, err := url.Parse("ch:amd64/focal/wordpress-42")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create test archive and inject a manifest file.
+	pathToArchive := testcharms.Repo.CharmArchivePath(c.MkDir(), "dummy")
+	err = testcharms.InjectFilesToCharmArchive(pathToArchive, map[string]string{
+		"manifest.yaml": `
+bases:
+- architectures:
+  - amd64
+  channel: '20.04'
+  name: ubuntu
+charmcraft-started-at: '2021-05-07T05:37:27.320518Z'
+charmcraft-version: 0.10.0
+`[1:],
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	resolvedArchive, err := charm.ReadCharmArchive(pathToArchive)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.expectCharmRefreshInstallOneFromChannel(c)
+	s.client.EXPECT().DownloadAndRead(context.TODO(), resolvedURL, gomock.Any()).Return(resolvedArchive, nil)
+
+	repo := NewCharmHubRepository(s.logger, s.client)
+
+	got, err := repo.GetEssentialMetadata(corecharm.MetadataRequest{
+		CharmURL: curl,
+		Origin:   requestedOrigin,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, gc.HasLen, 1)
+	c.Assert(got[0].Meta.Name, gc.Equals, "dummy")
+	c.Assert(got[0].Config.Options["title"], gc.Not(gc.IsNil))
+	c.Assert(got[0].Manifest.Bases, gc.HasLen, 1)
+	c.Assert(got[0].LXDProfile, gc.Not(gc.IsNil))
+	c.Assert(got[0].ResolvedOrigin.ID, gc.Equals, "charmCHARMcharmCHARMcharmCHARM01", gc.Commentf("expected origin to be resolved"))
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannel(c *gc.C) {

--- a/core/charm/repository/charmstore.go
+++ b/core/charm/repository/charmstore.go
@@ -4,6 +4,7 @@
 package repository
 
 import (
+	"io"
 	"net/url"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
@@ -11,6 +12,7 @@ import (
 	charmresource "github.com/juju/charm/v9/resource"
 	"github.com/juju/charmrepo/v7"
 	"github.com/juju/charmrepo/v7/csclient"
+	"github.com/juju/charmrepo/v7/csclient/params"
 	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/errors"
 	"gopkg.in/macaroon.v2"
@@ -23,7 +25,9 @@ import (
 // CharmStoreClient describes the API exposed by the charmstore client.
 type CharmStoreClient interface {
 	Get(charmURL *charm.URL, archivePath string) (*charm.CharmArchive, error)
-	ResolveWithPreferredChannel(*charm.URL, csparams.Channel) (*charm.URL, csparams.Channel, []string, error)
+	ResolveWithPreferredChannel(charmURL *charm.URL, channel csparams.Channel) (*charm.URL, csparams.Channel, []string, error)
+	Meta(*charm.URL, interface{}) (*charm.URL, error)
+	GetFileFromArchive(charmURL *charm.URL, filename string) (io.ReadCloser, error)
 }
 
 // CharmStoreRepository provides an API for charm-related operations using charmstore.
@@ -133,6 +137,54 @@ func (c *CharmStoreRepository) GetDownloadURL(charmURL *charm.URL, requestedOrig
 func (c *CharmStoreRepository) ListResources(charmURL *charm.URL, _ corecharm.Origin, _ macaroon.Slice) ([]charmresource.Resource, error) {
 	c.logger.Tracef("ListResources %q", charmURL)
 	return nil, nil
+}
+
+// GetEssentialMetadata resolves each provided MetadataRequest and returns back
+// a slice with the results. The results include the minimum set of metadata
+// that is required for deploying each charm.
+func (c *CharmStoreRepository) GetEssentialMetadata(reqs ...corecharm.MetadataRequest) ([]corecharm.EssentialMetadata, error) {
+	var res = make([]corecharm.EssentialMetadata, len(reqs))
+
+	for reqIdx, req := range reqs {
+		// NOTE(achilleas): due to the way that the charmstore client
+		// was originally implemented we unfortunately need to create a
+		// new client per request.
+		channel := csparams.Channel(req.Origin.Channel.Risk)
+		client, err := c.clientFactory(c.charmstoreURL, channel, req.Macaroons)
+		if err != nil {
+			return nil, errors.Annotatef(err, "obain charmstore client for %q", req.CharmURL)
+		}
+
+		if _, err = client.Meta(req.CharmURL, &res[reqIdx]); err != nil {
+			return nil, errors.Annotatef(err, "retrieving metadata for %q", req.CharmURL)
+		}
+		res[reqIdx].ResolvedOrigin = req.Origin
+
+		// The metadata call does not return back LXD profile
+		// information.  We need to make a separate call to grab it
+		// from within the archive.
+		profileReader, fetchErr := client.GetFileFromArchive(req.CharmURL, "lxd-profile.yaml")
+		if fetchErr != nil {
+			// It's fine if the charm does not provide an lxd profile
+			if errors.Cause(fetchErr) == params.ErrNotFound {
+				continue
+			}
+
+			return nil, errors.Annotatef(err, "retrieving metadata for %q", req.CharmURL)
+		}
+
+		res[reqIdx].LXDProfile, err = charm.ReadLXDProfile(profileReader)
+		if cErr := profileReader.Close(); cErr != nil {
+			c.logger.Errorf("unable to close LXD profile reader while retrieving metadata for %q: %v", req.CharmURL, cErr)
+			// NOTE(achilleasa): this is a non-fatal error; if the
+			// profile was successfully read we should continue.
+		}
+		if err != nil {
+			return nil, errors.Annotatef(err, "parsing lxd profile for %q", req.CharmURL)
+		}
+	}
+
+	return res, nil
 }
 
 func makeCharmStoreClient(charmstoreURL string, defaultChannel csparams.Channel, macaroons macaroon.Slice) (CharmStoreClient, error) {

--- a/core/charm/repository/charmstore_test.go
+++ b/core/charm/repository/charmstore_test.go
@@ -4,6 +4,10 @@
 package repository
 
 import (
+	"io"
+	"io/ioutil"
+	"strings"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
 	csparams "github.com/juju/charmrepo/v7/csclient/params"
@@ -162,6 +166,130 @@ func (s *charmStoreRepositorySuite) TestGetDownloadURL(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotURL.String(), gc.Equals, "cs:charm/ubuntu-lite")
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
+}
+
+func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithLXDProfile(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	curl := charm.MustParseURL("cs:ubuntu-lite")
+	requestedOrigin := corecharm.Origin{
+		Source:  "charm-store",
+		Channel: &charm.Channel{Risk: "edge"},
+	}
+	mac, err := macaroon.New(nil, []byte("id"), "", macaroon.LatestVersion)
+	c.Assert(err, jc.ErrorIsNil)
+	macaroons := macaroon.Slice{mac}
+
+	expMeta := new(charm.Meta)
+	expConfig := new(charm.Config)
+	expManifest := new(charm.Manifest)
+	rawProfile := `
+description: lxd profile for testing, will pass validation
+config:
+  security.nesting: "true"
+  security.privileged: "true"
+  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
+  environment.http_proxy: ""
+devices:
+  tun:
+    path: /dev/net/tun
+    type: unix-char
+  sony:
+    type: usb
+    vendorid: 0fce
+    productid: 51da
+  bdisk:
+    type: unix-block
+    source: /dev/loop0
+  gpu:
+    type: gpu
+`[1:]
+	expProfile, err := charm.ReadLXDProfile(strings.NewReader(rawProfile))
+	c.Assert(err, jc.ErrorIsNil)
+
+	repo := NewCharmStoreRepository(s.logger, "store-api-endpoint")
+	repo.clientFactory = func(gotStoreURL string, gotChannel csparams.Channel, gotMacaroons macaroon.Slice) (CharmStoreClient, error) {
+		c.Assert(gotStoreURL, gc.Equals, "store-api-endpoint", gc.Commentf("the provided store API endpoint was not passed to the client factory"))
+		c.Assert(gotChannel, gc.Equals, csparams.Channel("edge"), gc.Commentf("the channel from the provided origin was not passed to the client factory"))
+		c.Assert(gotMacaroons, gc.DeepEquals, macaroons, gc.Commentf("the provided macaroons were not passed to the client factory"))
+		return s.client, nil
+	}
+	s.client.EXPECT().Meta(curl, gomock.Any()).DoAndReturn(
+		func(charmURL *charm.URL, dstIface interface{}) (*charm.URL, error) {
+			dst := dstIface.(*corecharm.EssentialMetadata)
+			dst.Meta = expMeta
+			dst.Config = expConfig
+			dst.Manifest = expManifest
+			return charmURL, nil
+		},
+	)
+	s.client.EXPECT().GetFileFromArchive(curl, "lxd-profile.yaml").DoAndReturn(
+		func(*charm.URL, string) (io.ReadCloser, error) {
+			return ioutil.NopCloser(strings.NewReader(rawProfile)), nil
+		},
+	)
+
+	gotMeta, err := repo.GetEssentialMetadata(corecharm.MetadataRequest{
+		CharmURL:  curl,
+		Origin:    requestedOrigin,
+		Macaroons: macaroons,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotMeta, gc.HasLen, 1)
+	// NOTE: we use pointer equality checks here.
+	c.Assert(gotMeta[0].Meta, gc.Equals, expMeta)
+	c.Assert(gotMeta[0].Config, gc.Equals, expConfig)
+	c.Assert(gotMeta[0].Manifest, gc.Equals, expManifest)
+	// NOTE: we need to use a deep equal check for the lxd profile.
+	c.Assert(gotMeta[0].LXDProfile, gc.DeepEquals, expProfile)
+}
+
+func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithoutLXDProfile(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	curl := charm.MustParseURL("cs:ubuntu-lite")
+	requestedOrigin := corecharm.Origin{
+		Source:  "charm-store",
+		Channel: &charm.Channel{Risk: "edge"},
+	}
+	mac, err := macaroon.New(nil, []byte("id"), "", macaroon.LatestVersion)
+	c.Assert(err, jc.ErrorIsNil)
+	macaroons := macaroon.Slice{mac}
+
+	expMeta := new(charm.Meta)
+	expConfig := new(charm.Config)
+	expManifest := new(charm.Manifest)
+
+	repo := NewCharmStoreRepository(s.logger, "store-api-endpoint")
+	repo.clientFactory = func(gotStoreURL string, gotChannel csparams.Channel, gotMacaroons macaroon.Slice) (CharmStoreClient, error) {
+		c.Assert(gotStoreURL, gc.Equals, "store-api-endpoint", gc.Commentf("the provided store API endpoint was not passed to the client factory"))
+		c.Assert(gotChannel, gc.Equals, csparams.Channel("edge"), gc.Commentf("the channel from the provided origin was not passed to the client factory"))
+		c.Assert(gotMacaroons, gc.DeepEquals, macaroons, gc.Commentf("the provided macaroons were not passed to the client factory"))
+		return s.client, nil
+	}
+	s.client.EXPECT().Meta(curl, gomock.Any()).DoAndReturn(
+		func(charmURL *charm.URL, dstIface interface{}) (*charm.URL, error) {
+			dst := dstIface.(*corecharm.EssentialMetadata)
+			dst.Meta = expMeta
+			dst.Config = expConfig
+			dst.Manifest = expManifest
+			return charmURL, nil
+		},
+	)
+	s.client.EXPECT().GetFileFromArchive(curl, "lxd-profile.yaml").Return(nil, csparams.ErrNotFound)
+
+	gotMeta, err := repo.GetEssentialMetadata(corecharm.MetadataRequest{
+		CharmURL:  curl,
+		Origin:    requestedOrigin,
+		Macaroons: macaroons,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(gotMeta, gc.HasLen, 1)
+	// NOTE: we use pointer equality checks here.
+	c.Assert(gotMeta[0].Meta, gc.Equals, expMeta)
+	c.Assert(gotMeta[0].Config, gc.Equals, expConfig)
+	c.Assert(gotMeta[0].Manifest, gc.Equals, expManifest)
+	c.Assert(gotMeta[0].LXDProfile, gc.IsNil, gc.Commentf("expected a nil profile when the charm does not provide an lxd profile"))
 }
 
 func (s *charmStoreRepositorySuite) setupMocks(c *gc.C) *gomock.Controller {

--- a/core/charm/repository/mocks/charmstore_client_mock.go
+++ b/core/charm/repository/mocks/charmstore_client_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	io "io"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -48,6 +49,36 @@ func (m *MockCharmStoreClient) Get(arg0 *charm.URL, arg1 string) (*charm.CharmAr
 func (mr *MockCharmStoreClientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCharmStoreClient)(nil).Get), arg0, arg1)
+}
+
+// GetFileFromArchive mocks base method.
+func (m *MockCharmStoreClient) GetFileFromArchive(arg0 *charm.URL, arg1 string) (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFileFromArchive", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFileFromArchive indicates an expected call of GetFileFromArchive.
+func (mr *MockCharmStoreClientMockRecorder) GetFileFromArchive(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileFromArchive", reflect.TypeOf((*MockCharmStoreClient)(nil).GetFileFromArchive), arg0, arg1)
+}
+
+// Meta mocks base method.
+func (m *MockCharmStoreClient) Meta(arg0 *charm.URL, arg1 interface{}) (*charm.URL, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Meta", arg0, arg1)
+	ret0, _ := ret[0].(*charm.URL)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Meta indicates an expected call of Meta.
+func (mr *MockCharmStoreClientMockRecorder) Meta(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Meta", reflect.TypeOf((*MockCharmStoreClient)(nil).Meta), arg0, arg1)
 }
 
 // ResolveWithPreferredChannel mocks base method.

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/charm/v9 v9.0.0-20210722104222-d3c79ce32e77
-	github.com/juju/charmrepo/v7 v7.0.0-20210427073450-742f84f1c0ff
+	github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd/v3 v3.0.0-20210809234809-65029dab4cd0
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/juju/charm/v9 v9.0.0-20210421060150-6a300db18162/go.mod h1:GR/jjdIQ0V
 github.com/juju/charm/v9 v9.0.0-20210427070932-bc9b40c9b0f4/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
 github.com/juju/charm/v9 v9.0.0-20210722104222-d3c79ce32e77 h1:yvqGk4cfK+T9FuCO2euIOEsnxBqiDcAl6yVvbot4K4A=
 github.com/juju/charm/v9 v9.0.0-20210722104222-d3c79ce32e77/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
-github.com/juju/charmrepo/v7 v7.0.0-20210427073450-742f84f1c0ff h1:NGaJPM0wjmGXYB+iSZJpXUuVzn8BVuz2pXZuoJa1xIg=
-github.com/juju/charmrepo/v7 v7.0.0-20210427073450-742f84f1c0ff/go.mod h1:o/cqA9eHmPn+73AFnIbKORn6oSizCdYLh988zvguWFc=
+github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae h1:TSnFigLC+7oV40UoyVjadtusvavzImpMl35kvAedFCg=
+github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae/go.mod h1:wvP5voVa8s9ap6FSwenJmxw2g5cf8aSgjE8N8LOEwKc=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20180808021310-bab88fc67299/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=


### PR DESCRIPTION
This PR builds on top of #13260 and is part of the work for implementing server-side bundle expansion.

It expands the charm repository interface with a new method (`GetEssentialMetadata`). The new method provides a mechanism for querying the essential (minimum set of metadata for deploying a charm) metadata for a list of charms. 

The key idea here is to have the `AddCharm` facade make a lightweight API call (also leveraging charmhub's support for batch requests) to the store and only fetch the metadata (as opposed to fetching the full charm blob) needed to start a deployment (metadata.yaml, manifest.yaml, config.yaml and lxd-profile.yaml), persist it to state and backfill the remaining bits of metadata (e.g. actions, metrics etc.) when the gets asynchronously downloaded (and before the uniter can retrieve the charm blob). The end goal is to reduce the _perceived_  execution time of `juju deploy` (and improve it even further when server-side bundle expansion gets implemented) for the end-users.

The _charmstore_ implementation is pretty straight forward and requires two API calls per charm. The first call gets all the information we need _with the exception of the lxd profile_. For the latter we need to perform a second call to grab the profile (if present) from the charm archive.

The _charmhub_ implementation is, for the time being, _emulating_ the required behavior. It groups together lookup requests based on the provided macaroon values (note: charmhub does not support macaroons so all requests get lumped up in a single group), then downloading the complete charm for each request and extracts the metadata we need. 

The charmhub API currently _only_ allows us to get the contents of the `metadata.yaml` file (via the /refresh endpoint). We have put together a [spec](https://docs.google.com/document/d/1CPwwYipBV03cBq3cVO2BRW614XZEJ0Phv0tziT3xbVw/edit#) for extending the list of fields we can get out of the refresh endpoint so we can pull the additional metadata we need. Once the required changes to the charmhub API become available to us we will amend the implementation to use it.

Note that the above methods are not currently used but will be wired in in a separate PR.

## QA steps

Just check that juju compiles; the changes are not currently used.