### PR TITLE
Fix /etc/profile.d/juju-introspection.sh not being POSIX-shell compatible

### DIFF
--- a/worker/introspection/script_test.go
+++ b/worker/introspection/script_test.go
@@ -40,5 +40,5 @@ func (s *profileSuite) TestLinux(c *gc.C) {
 
 	content, err := ioutil.ReadFile(profileFilename(dir))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(content), gc.Equals, bashFuncs)
+	c.Assert(string(content), gc.Equals, shellFuncs)
 }

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -205,7 +205,7 @@ func (w *socketListener) RegisterHTTPHandlers(
 	handle("/metrics", promhttp.HandlerFor(w.prometheusGatherer, promhttp.HandlerOpts{}))
 	// The trailing slash is kept for metrics because we don't want to
 	// break the metrics exporting that is using the internal charm. Since
-	// we don't know if it is using the exported bash function, or calling
+	// we don't know if it is using the exported shell function, or calling
 	// the introspection endpoint directly.
 	handle("/metrics/", promhttp.HandlerFor(w.prometheusGatherer, promhttp.HandlerOpts{}))
 	// Unit agents don't have a presence recorder to pass in.


### PR DESCRIPTION
/etc/profile.d/juju-introspection.sh contains a few bash arrays, breaking POSIX shell compatibility and at least some packages post-installation as it is loaded as a profile script.

For example, on a model deployed with Juju 2.9.11, installing spamassassin yields a _Syntax error_ as spamassassin post-installation script attempts to run sa-update as debian-spamd user, having /bin/sh as shell.

The change includes variables name changes (and a comment) to avoid future updates breaking POSIX compatibility.
Feel free to update the comment to whatever you see fit.

## QA steps

* Check it builds properly
* Deploy a model with spamassassin installation (eg. charm cs:mailman3-core) and check it doesn't fail during SA install.

## Bug reference

Fixes https://bugs.launchpad.net/juju/+bug/1942430
Probable iteration of https://bugs.launchpad.net/juju/+bug/1770437