### PR TITLE
deploy by revision integration tests

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -5,9 +5,9 @@ run_deploy_bundle() {
 
 	ensure "test-bundles-deploy" "${file}"
 
-	juju deploy cs:~juju-qa/bundle/basic-0
-	wait_for "ubuntu" ".applications | keys[0]"
-	wait_for "ubuntu-lite" ".applications | keys[1]"
+	juju deploy juju-qa-bundle-test
+	wait_for "juju-qa-test" ".applications | keys[0]"
+	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"
 
 	destroy_model "test-bundles-deploy"
 }

--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -1,0 +1,88 @@
+run_deploy_revision() {
+	echo
+
+	model_name="test-deploy-revision"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	# revision 9 is in channel 2.0/edge
+	juju deploy juju-qa-test --revision 9 --channel 2.0/stable
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
+
+	# check resource revision per channel specified.
+	juju resources juju-qa-test --format json | jq -S '.resources[0] | .[ "revision"] == "3"'
+
+	destroy_model "${model_name}"
+}
+
+run_deploy_revision_resource() {
+	echo
+
+	model_name="test-deploy-revision-resource"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	# revision 9 is in channel 2.0/edge
+	juju deploy juju-qa-test --revision 9 --channel 2.0/stable --resource foo-file=4
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
+
+	# check resource revision as specified in command.
+	juju resources juju-qa-test --format json | jq -S '.resources[0] | .[ "revision"] == "4"'
+
+	destroy_model "${model_name}"
+}
+
+run_deploy_revision_fail() {
+	echo
+
+	model_name="test-deploy-revision-fail"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	got=$(juju deploy juju-qa-test --revision 9 2>&1 || true)
+	check_contains "${got}" 'ERROR invalid channel for "ch:juju-qa-test": channel cannot be empty'
+
+	destroy_model "${model_name}"
+}
+
+run_deploy_revision_upgrade() {
+	echo
+
+	model_name="test-deploy-upgrade"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	# revision 9 is in channel 2.0/edge
+	juju deploy juju-qa-test --revision 9 --channel latest/edge
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
+
+	# Ensure that upgrade-charm gets the revision from the channel
+	# listed at deploy.
+	# revision 15 is in channel latest/edge
+	juju upgrade-charm juju-qa-test
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 15)"
+
+	destroy_model "${model_name}"
+}
+
+test_deploy_revision() {
+	if [ "$(skip 'test_deploy_revision')" ]; then
+		echo "==> TEST SKIPPED: deploy revision"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_deploy_revision"
+		run "run_deploy_revision_resource"
+		run "run_deploy_revision_fail"
+		run "run_deploy_revision_upgrade"
+	)
+}

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -17,6 +17,7 @@ test_deploy() {
 	test_deploy_bundles
 	test_cmr_bundles_export_overlay
 	test_deploy_os
+	test_deploy_revision
 
 	destroy_controller "test-deploy-ctl"
 }


### PR DESCRIPTION
Implement integration tests for deploy by revision:
1. A basic deployment with a revision and a channel.
2. A basic deployment with a revision, a channel and a specific resource revision.
3. A basic deployment with a revision, which fail due to lack of channel.
4. A basic deployment with a revision and a channel.  Then run upgrade-charm and verify the new revision is from the channel specified at deploy

Updated the bundle used in run_bundle_deploy(), it used 'services' no longer supported in juju 3.0.  Other bundles used in bundle tests do as well, those still need to be resolved.

## QA steps

```sh
(cd tests ; ./main.sh  deploy test_deploy_revision )

# At least the first one, run_bundle_deploy should pass.
(cd tests ; ./main.sh deploy test_deploy_bundles )
```

