### PR TITLE
Add extra tracing to relation related workflow

### DIFF
--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1223,7 +1223,7 @@ func (r *Relation) WatchUnits(appName string) (RelationUnitsWatcher, error) {
 	}
 	rsw := watchRelationScope(r.st, r.globalScope(), ep.Role, "")
 	appSettingsKey := relationApplicationSettingsKey(r.Id(), appName)
-	logger.Tracef("Relation.WatchUnits(%q) watching: %q", appName, appSettingsKey)
+	logger.Child("relationunits").Tracef("Relation.WatchUnits(%q) watching: %q", appName, appSettingsKey)
 	return newRelationUnitsWatcher(r.st, rsw, []string{appSettingsKey}), nil
 }
 
@@ -1402,7 +1402,9 @@ func (w *relationUnitsWatcher) loop() (err error) {
 				return watcher.EnsureErr(w.sw)
 			}
 			gotInitialScopeWatcher = true
-			w.logger.Tracef("relationUnitsWatcher %q scope Changes(): %# v", w.sw.prefix, pretty.Formatter(c))
+			if w.logger.IsTraceEnabled() {
+				w.logger.Tracef("relationUnitsWatcher %q scope Changes(): %# v", w.sw.prefix, pretty.Formatter(c))
+			}
 			if err = w.mergeScope(&changes, c); err != nil {
 				return err
 			}
@@ -1439,7 +1441,9 @@ func (w *relationUnitsWatcher) loop() (err error) {
 				out = w.out
 			}
 		case out <- changes:
-			w.logger.Tracef("relationUnitsWatcher %q sent changes %# v", w.sw.prefix, pretty.Formatter(changes))
+			if w.logger.IsTraceEnabled() {
+				w.logger.Tracef("relationUnitsWatcher %q sent changes %# v", w.sw.prefix, pretty.Formatter(changes))
+			}
 			sentInitial = true
 			changes = corewatcher.RelationUnitsChange{}
 			out = nil

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -193,7 +193,11 @@ func (w *Worker) Kill() {
 
 // Wait is defined on worker.Worker.
 func (w *Worker) Wait() error {
-	return w.catacomb.Wait()
+	err := w.catacomb.Wait()
+	if err != nil {
+		w.logger.Errorf("error in top level remote relations worker: %v", err)
+	}
+	return err
 }
 
 func (w *Worker) loop() (err error) {

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -56,7 +56,11 @@ func (w *remoteRelationsWorker) Kill() {
 
 // Wait is defined on worker.Worker
 func (w *remoteRelationsWorker) Wait() error {
-	return w.catacomb.Wait()
+	err := w.catacomb.Wait()
+	if err != nil {
+		w.logger.Errorf("error in remote relations worker for relation %v: %v", w.relationTag.Id(), err)
+	}
+	return err
 }
 
 func (w *remoteRelationsWorker) loop() error {

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -34,6 +34,7 @@ type Logger interface {
 	Infof(string, ...interface{})
 	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})
+	IsTraceEnabled() bool
 
 	Child(string) loggo.Logger
 }

--- a/worker/uniter/relation/interface.go
+++ b/worker/uniter/relation/interface.go
@@ -26,7 +26,7 @@ type RelationStateTracker interface {
 	// current relation state.
 	CommitHook(hook.Info) error
 
-	// SyncronizeScopes ensures that the locally tracked relation scopes
+	// SynchronizeScopes ensures that the locally tracked relation scopes
 	// reflect the contents of the remote state snapshot by entering or
 	// exiting scopes as required.
 	SynchronizeScopes(remotestate.Snapshot) error
@@ -153,7 +153,7 @@ type Unit interface {
 	// Watch returns a watcher for observing changes to the unit.
 	Watch() (watcher.NotifyWatcher, error)
 
-	// Destroy, when called on a Alive unit, advances its lifecycle as far as
+	// Destroy when called on a Alive unit, advances its lifecycle as far as
 	// possible; it otherwise has no effect. In most situations, the unit's
 	// life is just set to Dying; but if a principal unit that is not assigned
 	// to a provisioned machine is Destroyed, it will be removed from state

--- a/worker/uniter/relation/relationer.go
+++ b/worker/uniter/relation/relationer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v2/dependency"
+	"github.com/kr/pretty"
 
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -151,9 +152,9 @@ func (r *relationer) CommitHook(hi hook.Info) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = st.UpdateStateForHook(hi)
-	if err != nil {
-		return r.stateMgr.RemoveRelation(st.RelationId, r.unitGetter, map[string]bool{})
+	st.UpdateStateForHook(hi)
+	if r.logger.IsTraceEnabled() {
+		r.logger.Tracef("commit hook %q for %d (remote unit %q): %# v", hi.Kind, hi.RelationId, hi.RemoteUnit, pretty.Formatter(st))
 	}
 	return r.stateMgr.SetRelation(st)
 }

--- a/worker/uniter/relation/resolver_test.go
+++ b/worker/uniter/relation/resolver_test.go
@@ -1230,7 +1230,7 @@ func (s *relationCreatedResolverSuite) TestCreatedRelationResolverForRelationInS
 		r.EXPECT().RelationCreated(1).Return(true),
 	)
 
-	createdRelationsResolver := relation.NewCreatedRelationResolver(r)
+	createdRelationsResolver := relation.NewCreatedRelationResolver(r, loggo.GetLogger("test"))
 	_, err := createdRelationsResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation, gc.Commentf("unexpected hook from created relations resolver for already joined relation"))
 }
@@ -1274,7 +1274,7 @@ func (s *relationCreatedResolverSuite) TestCreatedRelationResolverFordRelationNo
 		r.EXPECT().RemoteApplication(1).Return("mysql"),
 	)
 
-	createdRelationsResolver := relation.NewCreatedRelationResolver(r)
+	createdRelationsResolver := relation.NewCreatedRelationResolver(r, loggo.GetLogger("test"))
 	op, err := createdRelationsResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, gc.DeepEquals, &mockOperation{
@@ -1304,7 +1304,7 @@ func (s *relationCreatedResolverSuite) TestCreatedRelationsResolverWithPendingHo
 		Life: life.Alive,
 	}
 
-	createdRelationsResolver := relation.NewCreatedRelationResolver(r)
+	createdRelationsResolver := relation.NewCreatedRelationResolver(r, loggo.GetLogger("test"))
 	_, err := createdRelationsResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(errors.Cause(err), gc.Equals, resolver.ErrNoOperation, gc.Commentf("expected to get ErrNoOperation when a RunHook operation is pending"))
 }

--- a/worker/uniter/relation/state.go
+++ b/worker/uniter/relation/state.go
@@ -98,10 +98,10 @@ func (s *State) Validate(hi hook.Info) (err error) {
 // It must be called after the respective hook was executed successfully.
 // UpdateStateForHook doesn't validate hi but guarantees that successive
 // changes of the same hi are idempotent.
-func (s *State) UpdateStateForHook(hi hook.Info) (err error) {
-	defer errors.DeferredAnnotatef(&err, "failed to write %q hook info for %q in state", hi.Kind, hi.RemoteUnit)
+func (s *State) UpdateStateForHook(hi hook.Info) {
 	if hi.Kind == hooks.RelationBroken {
-		return errors.New("broken relation, remove")
+		// Nothing to do for relation-broken hooks.
+		return
 	}
 	isApp := hi.RemoteUnit == ""
 	// Get a copy of current state to modify, so we only update current
@@ -113,7 +113,7 @@ func (s *State) UpdateStateForHook(hi hook.Info) (err error) {
 		} else {
 			delete(s.Members, hi.RemoteUnit)
 		}
-		return nil
+		return
 	}
 	// Update own state.
 	if isApp {
@@ -126,7 +126,6 @@ func (s *State) UpdateStateForHook(hi hook.Info) (err error) {
 	} else {
 		s.ChangedPending = ""
 	}
-	return nil
 }
 
 func (s *State) YamlString() (string, error) {

--- a/worker/uniter/relation/state_test.go
+++ b/worker/uniter/relation/state_test.go
@@ -241,8 +241,8 @@ func (s *stateSuite) TestWriteMultiHookDepartedJoinedChanged(c *gc.C) {
 	runWriteHookTest(c, st, expectedState, hiChanged)
 }
 
-func (s *stateSuite) TestWriteMultiHookDepartedDepartedBroken(c *gc.C) {
-	c.Logf("relation-departed foo/1 and relation-departed foo/2 and relation-broken")
+func (s *stateSuite) TestWriteMultiHookDepartedDeparted(c *gc.C) {
+	c.Logf("relation-departed foo/1 and relation-departed foo/2")
 
 	// Setup initial state
 	st := s.setupTestState()
@@ -269,16 +269,6 @@ func (s *stateSuite) TestWriteMultiHookDepartedDepartedBroken(c *gc.C) {
 	delete(expectedState.Members, "foo/2")
 
 	runWriteHookTest(c, st, expectedState, hiDeparted2)
-
-	// Setup Broken Hook mocks
-	hiBroken := hook.Info{
-		Kind:              hooks.RelationBroken,
-		RelationId:        123,
-		RemoteApplication: "foo",
-	}
-
-	err := st.UpdateStateForHook(hiBroken)
-	c.Assert(err, gc.NotNil)
 }
 
 func (s *stateSuite) setupTestState() *relation.State {
@@ -297,12 +287,10 @@ func (s *stateSuite) setupTestState() *relation.State {
 func runWriteHookTest(c *gc.C, st, expectedState *relation.State, hi hook.Info) {
 	err := st.Validate(hi)
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.UpdateStateForHook(hi)
-	c.Assert(err, jc.ErrorIsNil)
+	st.UpdateStateForHook(hi)
 	c.Assert(*expectedState, jc.DeepEquals, *st)
 	// Check that writing the same change again is OK.
-	err = st.UpdateStateForHook(hi)
-	c.Assert(err, jc.ErrorIsNil)
+	st.UpdateStateForHook(hi)
 	c.Assert(*expectedState, jc.DeepEquals, *st)
 }
 

--- a/worker/uniter/relation/statemanager.go
+++ b/worker/uniter/relation/statemanager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
+	"github.com/kr/pretty"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
@@ -28,7 +29,7 @@ type stateManager struct {
 	mu            sync.Mutex
 }
 
-// RelationState returns a copy of the relation state for
+// Relation returns a copy of the relation state for
 // the given id. Returns NotFound.
 func (m *stateManager) Relation(id int) (*State, error) {
 	m.mu.Lock()
@@ -95,7 +96,7 @@ func (m *stateManager) KnownIDs() []int {
 	return ids
 }
 
-// SetRelationState persists the given state, overwriting the previous
+// SetRelation persists the given state, overwriting the previous
 // state for a given id or creating state at a new id. The change to
 //the manager is only made when the data is successfully saved.
 func (m *stateManager) SetRelation(st *State) error {
@@ -124,6 +125,9 @@ func (m *stateManager) initialize() error {
 		return errors.Trace(err)
 	}
 	m.relationState = make(map[int]State, len(unitState.RelationState))
+	if m.logger.IsTraceEnabled() {
+		m.logger.Tracef("initialising state manager: %# v", pretty.Formatter(unitState.RelationState))
+	}
 	for k, v := range unitState.RelationState {
 		var state State
 		if err = yaml.Unmarshal([]byte(v), &state); err != nil {

--- a/worker/uniter/relation/statetracker_test.go
+++ b/worker/uniter/relation/statetracker_test.go
@@ -83,6 +83,7 @@ func (s *stateTrackerSuite) TestLoadInitialState(c *gc.C) {
 	s.expectStateMgrRelationFound(1)
 	s.expectRelationerJoin()
 	s.expectRelationSetStatusJoined()
+	s.expectUnitName()
 	s.expectUnitTag()
 	s.expectRelationUnit()
 	s.expectWatch(c)
@@ -127,6 +128,7 @@ func (s *stateTrackerSuite) TestLoadInitialStateInScopeSuspended(c *gc.C) {
 	s.expectStateMgrRelationFound(1)
 	s.expectRelation(relTag)
 	s.expectRelationID(1)
+	s.expectUnitName()
 	s.expectUnitTag()
 	s.expectRelationUnit()
 	s.expectWatch(c)
@@ -483,6 +485,7 @@ func (s *syncScopesSuite) TestSynchronizeScopesJoinRelation(c *gc.C) {
 	s.expectRelationOtherApplication()
 
 	// Setup for joinRelation()
+	s.expectUnitName()
 	s.expectUnitTag()
 	s.expectWatch(c)
 	s.expectRelationerJoin()
@@ -689,6 +692,10 @@ func (s *syncScopesSuite) expectRelationById(id int) {
 //
 func (s *baseStateTrackerSuite) expectUnitTag() {
 	s.unit.EXPECT().Tag().Return(s.unitTag)
+}
+
+func (s *baseStateTrackerSuite) expectUnitName() {
+	s.unit.EXPECT().Name().Return(s.unitTag.Id())
 }
 
 func (s *baseStateTrackerSuite) expectUnitDestroy() {

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -473,7 +473,8 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 			Leadership: uniterleadership.NewResolver(
 				u.logger.Child("leadership"),
 			),
-			CreatedRelations: relation.NewCreatedRelationResolver(u.relationStateTracker),
+			CreatedRelations: relation.NewCreatedRelationResolver(
+				u.relationStateTracker, u.logger.Child("relation")),
 			Relations: relation.NewRelationResolver(
 				u.relationStateTracker, u.unit, u.logger.Child("relation")),
 			Storage: storage.NewResolver(


### PR DESCRIPTION
To aid in debugging relation hook issues, extra (mostly) trace logging has been added to various workers which deal with relations. The bulk of the changes are in the uniter relation handling. Also, in the state package, a child "relationunits" logger is now used to that tracing can be turned on for just that bit and not the rest of state.

As an additional debugging aid, we log a warning if the relation joined processing is wedged waiting for a unit watcher event to tirgger.

For a uniter, a few other changes were made. When a relation is removed, we were not deleting ids from all required maps. And the relation resolver is made to be like the relation created resolver in that it doesn't do any processing if there's another operation pending. Also, the method to update the state in the controller when a hook is committed was unnecessarily returning an error for the relation-broken hook when it is never called for that hook anyway.

Also some drive by lint fixes.

## QA steps

deploy and relate 2 applications
show-status-log to check for relation created, joined, changed hooks
remove the relation and check for departed, broken hooks
add back the relation, rinse and repeat
