### PR TITLE
[dev] Use batch metadata resolver for async charm downloads

### DIFF
--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -181,18 +181,37 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
 	}
 
 	if _, err := downloader.DownloadAndStore(pendingCharmURL, *resolvedOrigin, macaroons, force); err != nil {
+		now = a.clock.Now()
+		// Update app status; it's fine if this fails as we just want
+		// to report the download error back. Also, we use a fairly
+		// generic error message instead of the actual error to avoid
+		// accidentally leaking any auth-related details that may be
+		// contained in the error.
+		statusErr := app.SetStatus(status.StatusInfo{
+			Status:  status.Blocked,
+			Message: "unable to download charm",
+			Since:   &now,
+		})
+		if statusErr != nil {
+			logger.Errorf("unable to set application status: %v", err)
+		}
 		return errors.Trace(err)
 	}
 
 	// Update app status; it's fine if this fails as the charm has been
 	// stored and can be fetched by the machine agents.
 	now = a.clock.Now()
-	_ = app.SetStatus(status.StatusInfo{
+	statusErr := app.SetStatus(status.StatusInfo{
 		// Let the charm set the application status
-		Status:  status.Unknown,
-		Message: "downloaded charm",
+		Status: status.Unknown,
+		// Just clear the "downloading charm" message to reduce noise
+		// in juju status output.
+		Message: "",
 		Since:   &now,
 	})
+	if statusErr != nil {
+		logger.Errorf("unable to set application status: %v", err)
+	}
 
 	return nil
 }

--- a/core/charm/repository/charmstore_test.go
+++ b/core/charm/repository/charmstore_test.go
@@ -182,7 +182,6 @@ func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithLXDProfile(c *gc
 
 	expMeta := new(charm.Meta)
 	expConfig := new(charm.Config)
-	expManifest := new(charm.Manifest)
 	rawProfile := `
 description: lxd profile for testing, will pass validation
 config:
@@ -216,10 +215,9 @@ devices:
 	}
 	s.client.EXPECT().Meta(curl, gomock.Any()).DoAndReturn(
 		func(charmURL *charm.URL, dstIface interface{}) (*charm.URL, error) {
-			dst := dstIface.(*corecharm.EssentialMetadata)
-			dst.Meta = expMeta
-			dst.Config = expConfig
-			dst.Manifest = expManifest
+			dst := dstIface.(*csMetadataResponse)
+			dst.CharmMetadata = expMeta
+			dst.CharmConfig = expConfig
 			return charmURL, nil
 		},
 	)
@@ -239,7 +237,6 @@ devices:
 	// NOTE: we use pointer equality checks here.
 	c.Assert(gotMeta[0].Meta, gc.Equals, expMeta)
 	c.Assert(gotMeta[0].Config, gc.Equals, expConfig)
-	c.Assert(gotMeta[0].Manifest, gc.Equals, expManifest)
 	// NOTE: we need to use a deep equal check for the lxd profile.
 	c.Assert(gotMeta[0].LXDProfile, gc.DeepEquals, expProfile)
 }
@@ -258,7 +255,6 @@ func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithoutLXDProfile(c 
 
 	expMeta := new(charm.Meta)
 	expConfig := new(charm.Config)
-	expManifest := new(charm.Manifest)
 
 	repo := NewCharmStoreRepository(s.logger, "store-api-endpoint")
 	repo.clientFactory = func(gotStoreURL string, gotChannel csparams.Channel, gotMacaroons macaroon.Slice) (CharmStoreClient, error) {
@@ -269,10 +265,9 @@ func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithoutLXDProfile(c 
 	}
 	s.client.EXPECT().Meta(curl, gomock.Any()).DoAndReturn(
 		func(charmURL *charm.URL, dstIface interface{}) (*charm.URL, error) {
-			dst := dstIface.(*corecharm.EssentialMetadata)
-			dst.Meta = expMeta
-			dst.Config = expConfig
-			dst.Manifest = expManifest
+			dst := dstIface.(*csMetadataResponse)
+			dst.CharmMetadata = expMeta
+			dst.CharmConfig = expConfig
 			return charmURL, nil
 		},
 	)
@@ -288,7 +283,6 @@ func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithoutLXDProfile(c 
 	// NOTE: we use pointer equality checks here.
 	c.Assert(gotMeta[0].Meta, gc.Equals, expMeta)
 	c.Assert(gotMeta[0].Config, gc.Equals, expConfig)
-	c.Assert(gotMeta[0].Manifest, gc.Equals, expManifest)
 	c.Assert(gotMeta[0].LXDProfile, gc.IsNil, gc.Commentf("expected a nil profile when the charm does not provide an lxd profile"))
 }
 


### PR DESCRIPTION
This PR updates the asynchronous charm download codepath (it's hidden behind a controller feature flag) in the client/charms facade to use the `GetEssentialMetadata` repository method which was introduced in #13298 instead of downloading the full charm and extracting the metadata we need.


## QA steps

```sh
$ juju bootstrap lxd test
$ juju controller-config 'features=[async-charm-downloads]'
```

### Check that deploying a charmstore bundle works (and is 🚀  compared to deploying synchronously)
```sh
$ juju add-model ludicrous-speed

# Deploy this or any of the other large charmstore bundles (e.g. openstack, hadoop etc.)
$ time juju deploy cs:bundle/charmed-kubernetes-761

# Monitor the status and wait until everything settles
$ watch juju status
```

### Check that deploying a charmhub bundle also works (and takes the same time as a synch deployment)

```sh
$ juju add-model normal-speed

# Deploy the charmhub version 
$ time juju deploy charmed-kubernetes

# Monitor the status and wait until everything settles
$ watch juju status
```

NOTE: the reason why this takes the same amount of time as the synchronous version is that the GetEssentialMetadata implementation for charmhub has to fetch the entire charm archive due to API-related limitations (see #13298).