### PR TITLE
Fix introspection posix shell

### DIFF
--- a/worker/introspection/script_test.go
+++ b/worker/introspection/script_test.go
@@ -40,5 +40,5 @@ func (s *profileSuite) TestLinux(c *gc.C) {
 
 	content, err := ioutil.ReadFile(profileFilename(dir))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(content), gc.Equals, bashFuncs)
+	c.Assert(string(content), gc.Equals, shellFuncs)
 }

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -205,7 +205,7 @@ func (w *socketListener) RegisterHTTPHandlers(
 	handle("/metrics", promhttp.HandlerFor(w.prometheusGatherer, promhttp.HandlerOpts{}))
 	// The trailing slash is kept for metrics because we don't want to
 	// break the metrics exporting that is using the internal charm. Since
-	// we don't know if it is using the exported bash function, or calling
+	// we don't know if it is using the exported shell function, or calling
 	// the introspection endpoint directly.
 	handle("/metrics/", promhttp.HandlerFor(w.prometheusGatherer, promhttp.HandlerOpts{}))
 	// Unit agents don't have a presence recorder to pass in.


### PR DESCRIPTION
This is a rebase of https://github.com/juju/juju/pull/13299 targeting the 2.9 branch.
It changes the `/etc/profile.d/juju-introspection.sh` which had some bash-isms that break if your user's shell is not bash. (dash, or zsh, etc). We can't use bashisms because all shells read /etc/profile.d.

## QA steps

See the original PR.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1770437