### PR TITLE
Github action for windows

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -26,13 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS-latest is disabled because there is an issue of the tests timing
-        # out. No effort has been done to work out why they currently timeout
-        # on macOS, but we should investigate that to improve our coverage on
-        # other clients.
-        # To turn on macOS, just update the os to include it.
-        # os: [ubuntu-latest, macOS-latest, windows-latest]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
 
@@ -41,6 +35,33 @@ jobs:
       with:
         go-version: 1.14
       id: go
+
+    - name: Debug
+      run: |
+        go version
+
+        cat <<EOF > main.go
+        package main
+
+        import (
+          "fmt"
+          "log"
+
+          "github.com/juju/os/v2/series"
+        )
+
+        func main() {
+          s, err := series.HostSeries()
+          if err != nil {
+            log.Fatal(err)
+          }
+
+          fmt.Printf("OS: %q\nSeries: %q\n", series.MustOSFromSeries(s).String(), s)
+        }
+        EOF
+        go mod init main
+        go run main.go
+      shell: bash
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -58,18 +79,6 @@ jobs:
 
         make install-mongo-dependencies
 
-    - name: "Remove Mongo Dependencies: windows-latest"
-      if: (matrix.os == 'windows-latest')
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: uninstall mongodb mongodb.install -y --all-versions
-
-    - name: "Install Mongo Dependencies: windows-latest"
-      if: (matrix.os == 'windows-latest')
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install mongodb.install --version=4.0.21 --allow-downgrade
-
     # GitHub runners already have preinstalled version of mongodb, but
     # we specifically need 4.0.21, otherwise our tests will not pass
     - name: "Install Mongo Dependencies: macOS-latest"
@@ -85,19 +94,19 @@ jobs:
         sudo ln -s /usr/local/mongodb/mongod /usr/local/bin/mongod
       shell: bash
 
-    - name: "Test client: macOS-latest"
-      if: (matrix.os == 'macOS-latest')
-      run: |
-        # There is a concurrency issue with macos setup for the "./cmd/juju/..." packages.
-        # So we have to limit amount of used CPUs and therefore parallelization
-        go test -v -p 1 ./cmd/juju/... -check.v
-        go test -v  ./cmd/plugins/... -check.v
-      shell: bash
-
-    - name: "Test client: ubuntu-latest"
+    - name: "Test client: ubuntu"
       if: (matrix.os == 'ubuntu-latest')
       run: |
         # Jenkins can perform the full jujud testing.
         go test -v ./cmd/juju/... -check.v -coverprofile=coverage.txt -covermode=atomic
         go test -v ./cmd/plugins/... -check.v
+      shell: bash
+
+    - name: "Test client: macOS && windows"
+      if: (matrix.os == 'macOS-latest' || matrix.os == 'windows-latest')
+      run: |
+        # There is a concurrency issue with macos setup for the "./cmd/juju/..." packages.
+        # So we have to limit amount of used CPUs and therefore parallelization
+        go test -v -p 1 ./cmd/juju/... -check.v
+        go test -v  ./cmd/plugins/... -check.v
       shell: bash

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Debug
       run: |
         go version
+        go env
 
         cat <<EOF > main.go
         package main
@@ -107,6 +108,6 @@ jobs:
       run: |
         # There is a concurrency issue with macos setup for the "./cmd/juju/..." packages.
         # So we have to limit amount of used CPUs and therefore parallelization
-        go test -v -p 1 ./cmd/juju/... -check.v
+        GOARCH=amd64 CGO_ENABLED=0 go test -v -p 1 ./cmd/juju/... -check.v
         go test -v  ./cmd/plugins/... -check.v
       shell: bash

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"os"
 	"regexp"
 
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -32,6 +33,10 @@ var _ = gc.Suite(&AddRemoteRelationSuiteNewAPI{})
 func (s *AddRemoteRelationSuiteNewAPI) SetUpTest(c *gc.C) {
 	s.baseAddRemoteRelationSuite.SetUpTest(c)
 	s.mockAPI.version = 5
+}
+
+func (s *AddRemoteRelationSuiteNewAPI) TearDownSuite(c *gc.C) {
+	os.Exit(1)
 }
 
 func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationNoRemoteApplications(c *gc.C) {

--- a/environs/filestorage/filestorage.go
+++ b/environs/filestorage/filestorage.go
@@ -146,6 +146,7 @@ func (f *fileStorageWriter) Put(name string, r io.Reader, length int64) error {
 		}
 	}
 	fullpath := f.fullPath(name)
+	fmt.Println("!!!!", fullpath)
 	dir := filepath.Dir(fullpath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -161,6 +162,7 @@ func (f *fileStorageWriter) Put(name string, r io.Reader, length int64) error {
 		return err
 	}
 	_, err = io.CopyN(file, r, length)
+	fmt.Println("????", file.Name(), fullpath)
 	file.Close()
 	if err != nil {
 		os.Remove(file.Name())

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -479,6 +479,7 @@ var writeMetadataFiles = func(stor storage.Storage, metadataInfo []MetadataFile)
 	for _, md := range metadataInfo {
 		filePath := path.Join(storage.BaseToolsPath, md.Path)
 		logger.Infof("Writing %s", filePath)
+		logger.Criticalf("Setting %v", filePath, string(md.Data))
 		err := stor.Put(filePath, bytes.NewReader(md.Data), int64(len(md.Data)))
 		if err != nil {
 			return err

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -130,7 +130,9 @@ func FindToolsForCloud(ss SimplestreamsFetcher,
 		if err != nil {
 			return nil, err
 		}
+		logger.Debugf("Look for stream %v %v", stream, toolsConstraint)
 		toolsMetadata, _, err := Fetch(ss, sources, toolsConstraint)
+		logger.Debugf("Toolsmetadata %v %v", toolsMetadata, err)
 		if errors.IsNotFound(err) {
 			noToolsCount++
 			continue

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -429,8 +429,9 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 	}
 	osTypes := set.NewStrings("ubuntu")
 	osTypes.Add(coreos.HostOSTypeName())
+	osTypes.Remove("ubuntu")
 	var versions []version.Binary
-	for _, osType := range osTypes.Values() {
+	for _, osType := range append(osTypes.SortedValues(), "ubuntu") {
 		versions = append(versions, version.Binary{
 			Number:  agentVersion,
 			Arch:    arch.HostArch(),

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -429,9 +429,8 @@ func DefaultVersions(conf *config.Config) []version.Binary {
 	}
 	osTypes := set.NewStrings("ubuntu")
 	osTypes.Add(coreos.HostOSTypeName())
-	osTypes.Remove("ubuntu")
 	var versions []version.Binary
-	for _, osType := range append(osTypes.SortedValues(), "ubuntu") {
+	for _, osType := range osTypes.SortedValues() {
 		versions = append(versions, version.Binary{
 			Number:  agentVersion,
 			Arch:    arch.HostArch(),


### PR DESCRIPTION
The following adds github windows action for client only tests. As we're
only testing clients only and not workloads, we don't _really_ need the
correct version of mongo here. All full end to end tests should be
officially identified and either moved to a better location or
re-written to prevent full stack testing. The CLI shouldn't be
exercising the full stack, that if anything should be apiserver and
down.

## QA steps

Github actions pass.