### PR TITLE
Be more lenient if the charm dir is deleted after a relation is joined

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -554,14 +554,14 @@ func (op *caasOperator) loop() (err error) {
 					if err := op.runner.StopWorker(unitID); err != nil {
 						return errors.Trace(err)
 					}
-					logger.Debugf("removing unit dir for dead unit %q", unitID)
-					// Remove the unit's directory
-					if err := op.removeUnitDir(unitTag); err != nil {
-						return errors.Trace(err)
-					}
 					logger.Debugf("removing dead unit %q", unitID)
 					// Remove the unit from state.
 					if err := op.config.UnitRemover.RemoveUnit(unitID); err != nil {
+						return errors.Trace(err)
+					}
+					logger.Debugf("removing unit dir for dead unit %q", unitID)
+					// Remove the unit's directory
+					if err := op.removeUnitDir(unitTag); err != nil {
 						return errors.Trace(err)
 					}
 					// Nothing to do for a dead unit further.

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -27,8 +27,9 @@ type Info struct {
 	// It is only set when Kind indicates a relation hook.
 	RelationId int `yaml:"relation-id,omitempty"`
 
-	// RemoteUnit is the name of the unit that triggered the hook. It is only
-	// set when Kind indicates a relation hook other than relation-broken.
+	// RemoteUnit is the name of the unit that triggered the hook.
+	// It is only set when Kind indicates a relation hook other than
+	// relation-created or relation-broken.
 	RemoteUnit string `yaml:"remote-unit,omitempty"`
 
 	// RemoteApplication is always set if either an app or a unit triggers

--- a/worker/uniter/relation/relationer.go
+++ b/worker/uniter/relation/relationer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v2/dependency"
-	"github.com/kr/pretty"
 
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/runner/context"
@@ -152,9 +151,6 @@ func (r *relationer) CommitHook(hi hook.Info) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	st.UpdateStateForHook(hi)
-	if r.logger.IsTraceEnabled() {
-		r.logger.Tracef("commit hook %q for %d (remote unit %q): %# v", hi.Kind, hi.RelationId, hi.RemoteUnit, pretty.Formatter(st))
-	}
+	st.UpdateStateForHook(hi, r.logger)
 	return r.stateMgr.SetRelation(st)
 }

--- a/worker/uniter/relation/state.go
+++ b/worker/uniter/relation/state.go
@@ -1,7 +1,7 @@
 // Copyright 2012-2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// relation implements persistent local storage of a unit's relation state, and
+// Package relation implements persistent local storage of a unit's relation state, and
 // translation of relation changes into hooks that need to be run.
 package relation
 
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
+	"github.com/kr/pretty"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/worker/uniter/hook"
@@ -98,7 +99,12 @@ func (s *State) Validate(hi hook.Info) (err error) {
 // It must be called after the respective hook was executed successfully.
 // UpdateStateForHook doesn't validate hi but guarantees that successive
 // changes of the same hi are idempotent.
-func (s *State) UpdateStateForHook(hi hook.Info) {
+func (s *State) UpdateStateForHook(hi hook.Info, logger Logger) {
+	if logger.IsTraceEnabled() {
+		defer func() {
+			logger.Tracef("updated relation state %# v\nfor hook %# v", pretty.Formatter(s), pretty.Formatter(hi))
+		}()
+	}
 	if hi.Kind == hooks.RelationBroken {
 		// Nothing to do for relation-broken hooks.
 		return

--- a/worker/uniter/relation/state_test.go
+++ b/worker/uniter/relation/state_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/charm/v8/hooks"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -287,10 +288,11 @@ func (s *stateSuite) setupTestState() *relation.State {
 func runWriteHookTest(c *gc.C, st, expectedState *relation.State, hi hook.Info) {
 	err := st.Validate(hi)
 	c.Assert(err, jc.ErrorIsNil)
-	st.UpdateStateForHook(hi)
+	logger := loggo.GetLogger("test")
+	st.UpdateStateForHook(hi, logger)
 	c.Assert(*expectedState, jc.DeepEquals, *st)
 	// Check that writing the same change again is OK.
-	st.UpdateStateForHook(hi)
+	st.UpdateStateForHook(hi, logger)
 	c.Assert(*expectedState, jc.DeepEquals, *st)
 }
 

--- a/worker/uniter/relation/statetracker_test.go
+++ b/worker/uniter/relation/statetracker_test.go
@@ -516,9 +516,11 @@ func (s *syncScopesSuite) TestSynchronizeScopesJoinRelation(c *gc.C) {
 	c.Assert(rst.RemoteApplication(1), gc.Equals, "mysql")
 }
 
-func (s *syncScopesSuite) TestSynchronizeScopesFailImplementedBy(c *gc.C) {
-	// wordpress unit with mysql relation
-	s.setupCharmDir(c)
+func (s *syncScopesSuite) assertSynchronizeScopesFailImplementedBy(c *gc.C, createCharmDir bool) {
+	if createCharmDir {
+		// wordpress unit with mysql relation
+		s.setupCharmDir(c)
+	}
 	defer s.setupMocks(c).Finish()
 	// Setup for SynchronizeScopes()
 	s.expectRelationById(1)
@@ -530,7 +532,9 @@ func (s *syncScopesSuite) TestSynchronizeScopesFailImplementedBy(c *gc.C) {
 			Interface: "db",
 			Scope:     charm.ScopeGlobal,
 		}}
+	s.expectRelationOtherApplication()
 	s.expectRelationEndpoint(ep)
+	s.expectString()
 
 	rst := s.newSyncScopesStateTracker(c,
 		make(map[int]relation.Relationer),
@@ -553,6 +557,14 @@ func (s *syncScopesSuite) TestSynchronizeScopesFailImplementedBy(c *gc.C) {
 
 	err := rst.SynchronizeScopes(remoteState)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *syncScopesSuite) TestSynchronizeScopesFailImplementedBy(c *gc.C) {
+	s.assertSynchronizeScopesFailImplementedBy(c, true)
+}
+
+func (s *syncScopesSuite) TestSynchronizeScopesIgnoresMissingCharmDir(c *gc.C) {
+	s.assertSynchronizeScopesFailImplementedBy(c, false)
 }
 
 func (s *syncScopesSuite) TestSynchronizeScopesSeenNotDying(c *gc.C) {


### PR DESCRIPTION
There's an intermittent issue that has been reported where a k8s unit is removed / replaced and the charm directory is removed and the unit agent tries to run a hook and fails. The hook is typically a relation tear down hook like relation-broken. Given the nature of the issue, this PR makes the unit agent more robust rather than provide a definitive root case fix (which is yet to be fully identified).

The only reason the unit agent reads the charm dir while running a relation hook is to check that the charm supports the relation endpoint. This is only relevant when a relation is first created. So the logic is tweaked to not do the check every hook, but just once as the relation is being created. And if the directory is missing, a warning is logged at that point rather than error out and bounce the agent - downstream processing in the agent will error if needed. For operator charms, since the issue is very intermittent, a tweak is also done to remove the directory last, after the dead unit is removed from state - this shouldn't matter but it doesn't hurt.

Also a few lint fixes and a bit of extra logging.

## QA steps

deploy and relate 2 k8s charms
remove and add a relation
check show-status-log to ensure the created, joined, departed, broken hooks have run

## Bug reference

https://bugs.launchpad.net/juju/+bug/1882600
