### PR TITLE
Remove unnecessary txn watcher started channel/topic

### DIFF
--- a/state/machine_ports_test.go
+++ b/state/machine_ports_test.go
@@ -4,8 +4,6 @@
 package state_test
 
 import (
-	"time"
-
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/txn"
@@ -15,7 +13,6 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -422,12 +419,6 @@ func (s *MachinePortsDocSuite) TestWatchMachinePorts(c *gc.C) {
 	// No port ranges open initially, no changes.
 	w := s.State.WatchOpenedPorts()
 	c.Assert(w, gc.NotNil)
-	select {
-	case <-s.StatePool.TxnWatcherStarted():
-		// Started successfully
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out waiting for ports watcher to start")
-	}
 
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, s.State, w)

--- a/state/pool.go
+++ b/state/pool.go
@@ -113,15 +113,12 @@ type StatePool struct {
 	// hub is used to pass the transaction changes from the TxnWatcher
 	// to the various HubWatchers that are used in each state object created
 	// by the state pool.
-	hub        *pubsub.SimpleHub
-	hubUnsubFn func()
+	hub *pubsub.SimpleHub
 
 	// watcherRunner makes sure the TxnWatcher stays running.
 	watcherRunner *worker.Runner
 	// txnWatcherSession is used exclusively for the TxnWatcher.
 	txnWatcherSession *mgo.Session
-	// watcherStarted is closed after the TxnWatcher is fully started.
-	watcherStarted chan struct{}
 }
 
 // OpenStatePool returns a new StatePool instance.
@@ -132,9 +129,8 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 	}
 
 	pool := &StatePool{
-		pool:           make(map[string]*PoolItem),
-		hub:            pubsub.NewSimpleHub(nil),
-		watcherStarted: make(chan struct{}),
+		pool: make(map[string]*PoolItem),
+		hub:  pubsub.NewSimpleHub(nil),
 	}
 
 	session := args.MongoSession.Copy()
@@ -180,9 +176,6 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 		IsFatal:      func(err error) bool { return errors.Cause(err) == errPoolClosed },
 		RestartDelay: time.Second,
 		Clock:        args.Clock,
-	})
-	pool.hubUnsubFn = pool.hub.Subscribe(watcher.TxnWatcherStarting, func(string, interface{}) {
-		close(pool.watcherStarted)
 	})
 	pool.txnWatcherSession = args.MongoSession.Copy()
 	if err = pool.watcherRunner.StartWorker(txnLogWorker, func() (worker.Worker, error) {
@@ -430,10 +423,6 @@ func (p *StatePool) Close() error {
 		_ = worker.Stop(p.watcherRunner)
 		p.txnWatcherSession.Close()
 	}
-	if p.hubUnsubFn != nil {
-		p.hubUnsubFn()
-		p.hubUnsubFn = nil
-	}
 	p.mu.Unlock()
 	// As with above and the other watchers. Unlock while releas
 	if err := p.systemState.Close(); err != nil {
@@ -488,10 +477,4 @@ func (p *StatePool) Report() map[string]interface{} {
 	}
 	p.mu.Unlock()
 	return report
-}
-
-// TxnWatcherStarted returns a channel that is closed when the pool's
-// TxnWatcher has fully started.
-func (p *StatePool) TxnWatcherStarted() <-chan struct{} {
-	return p.watcherStarted
 }

--- a/state/watcher/hubwatcher.go
+++ b/state/watcher/hubwatcher.go
@@ -173,8 +173,6 @@ func newHubWatcher(hub HubSource, clock Clock, modelUUID string, logger Logger) 
 
 func (w *HubWatcher) receiveEvent(topic string, data interface{}) {
 	switch topic {
-	case TxnWatcherStarting:
-		// We don't do anything on a start.
 	case TxnWatcherSyncErr:
 		syncErr, ok := data.(error)
 		if ok {

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -31,9 +31,6 @@ type Clock interface {
 }
 
 const (
-	// TxnWatcherStarting is published to the TxnWatcher's hub after it has
-	// fully started up.
-	TxnWatcherStarting = "starting"
 	// TxnWatcherSyncErr is published to the TxnWatcher's hub if there's a
 	// sync error (e.g., an error iterating through the collection's rows).
 	TxnWatcherSyncErr = "sync err"
@@ -288,7 +285,6 @@ func (w *TxnWatcher) loop() error {
 	backoff := backoffStrategy.NewTimer(now)
 	d, _ := backoff.NextSleep(now)
 	next := w.clock.After(d)
-	_ = w.hub.Publish(TxnWatcherStarting, nil)
 	for {
 		select {
 		case <-w.tomb.Dying():


### PR DESCRIPTION
As seen in the linked bug, there can be a panic if the txn watcher worker bounces and closes a "watcherStarted" channel twice. However, that channel and associated pubsub topic is unnecessary in the first place, so this PR removes them both.

## QA steps

bootstrap and deploy a couple of charms and relate

## Bug reference

https://bugs.launchpad.net/juju/+bug/1942421
