### PR TITLE
lxd: Update IsLXDNotFound to deal with Go HTTP spelling

### DIFF
--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -319,5 +319,5 @@ func (s *Server) SupportedArches() []string {
 // IsLXDNotFound checks if an error from the LXD API indicates that a requested
 // entity was not found.
 func IsLXDNotFound(err error) bool {
-	return err != nil && err.Error() == "not found"
+	return err != nil && (err.Error() == "not found" || err.Error() == "Not Found")
 }


### PR DESCRIPTION
LXD is now using Go's native HTTP error which comes with different
capitalization, so update to support both.

In the future, it'd be preferable for Juju to gain support for LXD's
StatusError type which allows for direct comparison with HTTP errors as
well as retrieving the HTTP error code directly.

In general, string matching on errors is a very bad idea, and the LXD team
would like to get notified when that's necessary so we can come up with
an alternative.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>

## QA steps

Unit tests pass.
