### PR TITLE
Don't use GroupName when opening ports on AWS

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1819,7 +1819,6 @@ func (e *environ) openPortsInGroup(ctx context.ProviderCallContext, name string,
 	ipPerms := rulesToIPPerms(rules)
 	_, err = e.ec2Client.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId:       g.GroupId,
-		GroupName:     g.GroupName,
 		IpPermissions: ipPerms,
 	})
 	if err != nil && ec2ErrCode(err) == "InvalidPermission.Duplicate" {
@@ -1833,7 +1832,6 @@ func (e *environ) openPortsInGroup(ctx context.ProviderCallContext, name string,
 		for i := range ipPerms {
 			_, err := e.ec2Client.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
 				GroupId:       g.GroupId,
-				GroupName:     g.GroupName,
 				IpPermissions: ipPerms[i : i+1],
 			})
 			if err != nil && ec2ErrCode(err) != "InvalidPermission.Duplicate" {


### PR DESCRIPTION
AWS only expects a GroupName in calls to AuthorizeSecurityGroupIngress when the Security Group is in EC2-Classic or the default VPC.

## QA steps

- Bootstrap to aws with non-default VPC id
- Deploy charm
- Expose app
- Check sg has opened the ports

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1942948
