### PR TITLE
Add test to ec2 + ensure ec2 SecurityGroup mutates use only group id

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1859,7 +1859,6 @@ func (e *environ) closePortsInGroup(ctx context.ProviderCallContext, name string
 	}
 	_, err = e.ec2Client.RevokeSecurityGroupIngress(ctx, &ec2.RevokeSecurityGroupIngressInput{
 		GroupId:       g.GroupId,
-		GroupName:     g.GroupName,
 		IpPermissions: rulesToIPPerms(rules),
 	})
 	if err != nil {
@@ -2139,8 +2138,7 @@ var deleteSecurityGroupInsistently = func(client SecurityGroupCleaner, ctx conte
 		Clock:       clock,
 		Func: func() error {
 			_, err := client.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{
-				GroupId:   g.GroupId,
-				GroupName: g.GroupName,
+				GroupId: g.GroupId,
 			})
 			if err == nil || isNotFoundError(err) {
 				logger.Debugf("deleting security group %q", aws.ToString(g.GroupName))

--- a/provider/ec2/internal/testing/securty_groups.go
+++ b/provider/ec2/internal/testing/securty_groups.go
@@ -48,6 +48,9 @@ func (srv *Server) CreateSecurityGroup(ctx context.Context, in *ec2.CreateSecuri
 func (srv *Server) DeleteSecurityGroup(ctx context.Context, in *ec2.DeleteSecurityGroupInput, opts ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+	if in.GroupName != nil {
+		return nil, apiError("InvalidParameterValue", "group should only be accessed by id")
+	}
 	g := srv.group(types.GroupIdentifier{
 		GroupId:   in.GroupId,
 		GroupName: in.GroupName,
@@ -94,6 +97,9 @@ func (srv *Server) group(group types.GroupIdentifier) *securityGroup {
 func (srv *Server) AuthorizeSecurityGroupIngress(ctx context.Context, in *ec2.AuthorizeSecurityGroupIngressInput, opts ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+	if in.GroupName != nil {
+		return nil, apiError("InvalidParameterValue", "group should only be accessed by id")
+	}
 	g := srv.group(types.GroupIdentifier{
 		GroupId:   in.GroupId,
 		GroupName: in.GroupName,
@@ -121,6 +127,9 @@ func (srv *Server) AuthorizeSecurityGroupIngress(ctx context.Context, in *ec2.Au
 func (srv *Server) RevokeSecurityGroupIngress(ctx context.Context, in *ec2.RevokeSecurityGroupIngressInput, opts ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupIngressOutput, error) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+	if in.GroupName != nil {
+		return nil, apiError("InvalidParameterValue", "group should only be accessed by id")
+	}
 	g := srv.group(types.GroupIdentifier{
 		GroupId:   in.GroupId,
 		GroupName: in.GroupName,


### PR DESCRIPTION
Follow up to #13316 to correct testing of security groups and also handle revoke/delete of ec2 security groups.

## QA steps

- Bootstrap to aws with non-default VPC id
- Deploy charm
- Expose app
- Check sg has opened the ports
- Delete app check sg is deleted

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1942948