### PR TITLE
Apply Fan subnet fixes to Address collection in incoming network configuration

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -91,33 +91,40 @@ func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetw
 	return errors.Trace(api.st.ApplyOperation(api.getModelOp(m, devs)))
 }
 
-// fixUpFanSubnets takes network config and updates
-// Fan subnets with proper CIDR.
-// See network/fan.go for more detail on how Fan overlays
-// are divided into segments.
+// fixUpFanSubnets takes network config and updates any addresses in Fan
+// networks with the CIDR of the zone-specific segments. We need to do this
+// because they are detected on-machine as being in the /8 overlay subnet,
+// which is a superset of the zone segments.
+// See core/network/fan.go for more detail on how Fan overlays are divided
+// into segments.
 func (api *NetworkConfigAPI) fixUpFanSubnets(networkConfig []params.NetworkConfig) ([]params.NetworkConfig, error) {
 	subnets, err := api.st.AllSubnetInfos()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	var fanSubnets network.SubnetInfos
+	fanSubnets := make(map[string]*net.IPNet)
 	for _, subnet := range subnets {
 		if subnet.FanOverlay() != "" {
-			fanSubnets = append(fanSubnets, subnet)
-		}
-	}
-	for i := range networkConfig {
-		localIP := net.ParseIP(networkConfig[i].Address)
-
-		for _, sub := range fanSubnets {
-			fanNet, err := sub.ParsedCIDRNetwork()
+			fanSub, err := subnet.ParsedCIDRNetwork()
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			if fanNet != nil && fanNet.Contains(localIP) {
-				networkConfig[i].CIDR = sub.CIDR
-				break
+			fanSubnets[subnet.CIDR] = fanSub
+		}
+	}
+
+	if len(fanSubnets) == 0 {
+		return networkConfig, nil
+	}
+
+	for i := range networkConfig {
+		for j := range networkConfig[i].Addresses {
+			for cidr, fanNet := range fanSubnets {
+				if fanNet != nil && fanNet.Contains(net.ParseIP(networkConfig[i].Addresses[j].Value)) {
+					networkConfig[i].Addresses[j].CIDR = cidr
+					break
+				}
 			}
 		}
 	}

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -120,8 +120,9 @@ func (api *NetworkConfigAPI) fixUpFanSubnets(networkConfig []params.NetworkConfi
 
 	for i := range networkConfig {
 		for j := range networkConfig[i].Addresses {
+			ip := net.ParseIP(networkConfig[i].Addresses[j].Value)
 			for cidr, fanNet := range fanSubnets {
-				if fanNet != nil && fanNet.Contains(net.ParseIP(networkConfig[i].Addresses[j].Value)) {
+				if fanNet != nil && fanNet.Contains(ip) {
 					networkConfig[i].Addresses[j].CIDR = cidr
 					break
 				}

--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// modelOpRecorder is a no-op model operation that can store the
-// devices passed to to it for later interrogation.
+// modelOpRecorder is a no-op model operation that can store
+// the devices passed to it for later interrogation.
 type modelOpRecorder struct {
 	devs network.InterfaceInfos
 }
@@ -140,7 +140,7 @@ func (s *networkConfigSuite) TestSetObservedNetworkConfigFixesFanSubs(c *gc.C) {
 
 	s.state.EXPECT().AllSubnetInfos().Return(network.SubnetInfos{
 		{
-			CIDR: "0.10.0.0/16",
+			CIDR: "10.10.0.0/16",
 			FanInfo: &network.FanCIDRs{
 				FanLocalUnderlay: "",
 				FanOverlay:       "anything-not-empty",
@@ -155,8 +155,15 @@ func (s *networkConfigSuite) TestSetObservedNetworkConfigFixesFanSubs(c *gc.C) {
 			InterfaceName: "eth0",
 			InterfaceType: "ethernet",
 			MACAddress:    "aa:bb:cc:dd:ee:f0",
-			CIDR:          "0.10.1.0/24",
-			Address:       "0.10.0.2",
+			Address:       "10.10.10.2",
+			Addresses: []params.Address{
+				{
+					Value: "10.10.10.2",
+					CIDR:  "10.0.0.0/8",
+					Type:  string(network.IPv4Address),
+					Scope: string(network.ScopeCloudLocal),
+				},
+			},
 		},
 	})
 
@@ -167,7 +174,7 @@ func (s *networkConfigSuite) TestSetObservedNetworkConfigFixesFanSubs(c *gc.C) {
 			MACAddress:    "aa:bb:cc:dd:ee:f0",
 			// Gets the CIDR from the Fan segment.
 			Addresses: network.ProviderAddresses{
-				network.NewProviderAddress("0.10.0.2", network.WithCIDR("0.10.0.0/16")),
+				network.NewProviderAddress("10.10.10.2", network.WithCIDR("10.10.0.0/16")),
 			},
 			GatewayAddress: network.NewProviderAddress(""),
 		},


### PR DESCRIPTION
Some time ago we did a significant overhaul of the payload delivery for updating machine address configuration. Included were changes to use members of the `NetworkConfig.Addresses` entries instead of those on the top level `NetworkConfig`. One of these was the address subnet CIDR.

What we missed at the time was to change`NetworkConfigAPI.fixUpFanSubnets` so that it applied the Fan updates to the `Addresses` entries and not the top-level `CIDR` member.

This meant that Fan addresses were being stored with subnets indicating the /8 overlay instead of the zone-specific /12 segments in AWS, resulting in the observed bug.

Here we fix `fixUpFanSubnets` so that we get the fixed Fan segment subnets against incoming addresses.

## QA steps

- `juju bootstrap aws patch-test --debug --no-gui --build-agent`
- `juju add-space space-1 172.31.0.0/20`
- `juju add-machine --constraints "spaces=space-1" --series bionic`
- `juju deploy cs:ubuntu --to lxd:0 --series focal --constraints "spaces=space-1" --bind "space-1"`
- Observe that the container is provisioned.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1942950
