### PR TITLE
Add tags and description and status to secret metadata; adjust URL syntax

### DIFF
--- a/api/secrets/client.go
+++ b/api/secrets/client.go
@@ -47,6 +47,7 @@ func (api *Client) ListSecrets(showSecrets bool) ([]SecretDetails, error) {
 				Path:           r.Path,
 				RotateInterval: r.RotateInterval,
 				Version:        r.Version,
+				Status:         secrets.SecretStatus(r.Status),
 				Description:    r.Description,
 				Tags:           r.Tags,
 				ID:             r.ID,

--- a/api/secrets/client_test.go
+++ b/api/secrets/client_test.go
@@ -44,10 +44,11 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.ListSecretResults{})
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			[]params.ListSecretResult{{
-				URL:            "secret://v1/app.password",
-				Path:           "app.password",
+				URL:            "secret://app/mariadb/password",
+				Path:           "app/password",
 				RotateInterval: time.Hour,
 				Version:        1,
+				Status:         "active",
 				Description:    "shhh",
 				Tags:           map[string]string{"foo": "bar"},
 				ID:             1,
@@ -64,13 +65,14 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 	client := apisecrets.NewClient(apiCaller)
 	result, err := client.ListSecrets(true)
 	c.Assert(err, jc.ErrorIsNil)
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	c.Assert(result, jc.DeepEquals, []apisecrets.SecretDetails{{
 		Metadata: secrets.SecretMetadata{
 			URL:            URL,
-			Path:           "app.password",
+			Path:           "app/password",
 			RotateInterval: time.Hour,
 			Version:        1,
+			Status:         secrets.StatusActive,
 			Description:    "shhh",
 			Tags:           map[string]string{"foo": "bar"},
 			ID:             1,
@@ -88,7 +90,7 @@ func (s *SecretsSuite) TestListSecretsError(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			[]params.ListSecretResult{{
-				URL: "secret://v1/app.password",
+				URL: "secret://app/password",
 				Value: &params.SecretValueResult{
 					Error: &params.Error{Message: "boom"},
 				},

--- a/api/secretsmanager/client.go
+++ b/api/secretsmanager/client.go
@@ -38,14 +38,26 @@ func (c *Client) Create(cfg *secrets.SecretConfig, secretType secrets.SecretType
 
 	var results params.StringResults
 
+	arg := params.CreateSecretArg{
+		Type:   string(secretType),
+		Path:   cfg.Path,
+		Params: cfg.Params,
+		Data:   data,
+	}
+	if cfg.Status != nil {
+		arg.Status = string(*cfg.Status)
+	}
+	if cfg.RotateInterval != nil {
+		arg.RotateInterval = *cfg.RotateInterval
+	}
+	if cfg.Description != nil {
+		arg.Description = *cfg.Description
+	}
+	if cfg.Tags != nil {
+		arg.Tags = *cfg.Tags
+	}
 	if err := c.facade.FacadeCall("CreateSecrets", params.CreateSecretArgs{
-		Args: []params.CreateSecretArg{{
-			Type:           string(secretType),
-			Path:           cfg.Path,
-			RotateInterval: cfg.RotateInterval,
-			Params:         cfg.Params,
-			Data:           data,
-		}},
+		Args: []params.CreateSecretArg{arg},
 	}, &results); err != nil {
 		return "", errors.Trace(err)
 	}
@@ -74,13 +86,20 @@ func (c *Client) Update(URL *secrets.URL, cfg *secrets.SecretConfig, value secre
 
 	var results params.StringResults
 
+	arg := params.UpdateSecretArg{
+		URL:            URL.ID(),
+		RotateInterval: cfg.RotateInterval,
+		Description:    cfg.Description,
+		Tags:           cfg.Tags,
+		Params:         cfg.Params,
+		Data:           data,
+	}
+	if cfg.Status != nil {
+		statusStr := string(*cfg.Status)
+		arg.Status = &statusStr
+	}
 	if err := c.facade.FacadeCall("UpdateSecrets", params.UpdateSecretArgs{
-		Args: []params.UpdateSecretArg{{
-			URL:            URL.ID(),
-			RotateInterval: cfg.RotateInterval,
-			Params:         cfg.Params,
-			Data:           data,
-		}},
+		Args: []params.UpdateSecretArg{arg},
 	}, &results); err != nil {
 		return "", errors.Trace(err)
 	}

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -519,9 +519,10 @@ func (s *watcherSuite) setupSecretRotationWatcher(
 	c *gc.C,
 ) (func(corewatcher.SecretRotationChange), func(), func()) {
 	store := state.NewSecretsStore(s.State)
-	URL := secrets.NewSimpleURL(1, "mysql.password")
+	URL := secrets.NewSimpleURL("app/mysql/password")
 	_, err := store.CreateSecret(URL, state.CreateSecretParams{
-		Path:           "mysql.password",
+		Owner:          "application-mysql",
+		Path:           "app/mysql/password",
 		Type:           "blob",
 		RotateInterval: time.Hour,
 	})
@@ -590,9 +591,10 @@ func (s *watcherSuite) TestSecretsRotationWatcher(c *gc.C) {
 	defer stop()
 
 	store := state.NewSecretsStore(s.State)
-	URL := secrets.NewSimpleURL(1, "mysql.password")
+	URL := secrets.NewSimpleURL("app/mysql/password")
+	minute := time.Minute
 	_, err := store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: time.Minute,
+		RotateInterval: &minute,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -6,6 +6,7 @@ package secretsmanager
 import (
 	"testing"
 
+	"github.com/juju/names/v4"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
@@ -35,6 +36,7 @@ func NewTestAPI(
 	}
 
 	return &SecretsManagerAPI{
+		authOwner:      names.NewApplicationTag("app"),
 		controllerUUID: coretesting.ControllerTag.Id(),
 		modelUUID:      coretesting.ModelTag.Id(),
 		resources:      resources,

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -29,6 +29,7 @@ type SecretsManagerAPI struct {
 	secretsService secrets.SecretsService
 	resources      facade.Resources
 	secretsWatcher SecretsWatcher
+	authOwner      names.Tag
 }
 
 // NewSecretManagerAPI creates a SecretsManagerAPI.
@@ -36,6 +37,9 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 	if !context.Auth().AuthUnitAgent() {
 		return nil, apiservererrors.ErrPerm
 	}
+	unitOwner := context.Auth().GetAuthTag().(names.UnitTag)
+	owner, _ := names.UnitApplication(unitOwner.Id())
+
 	// For now we just support the Juju secrets provider.
 	service, err := provider.NewSecretProvider(juju.Provider, secrets.ProviderConfig{
 		juju.ParamBackend: context.State(),
@@ -44,6 +48,7 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		return nil, errors.Annotate(err, "creating juju secrets service")
 	}
 	return &SecretsManagerAPI{
+		authOwner:      names.NewApplicationTag(owner),
 		controllerUUID: context.State().ControllerUUID(),
 		modelUUID:      context.State().ModelUUID(),
 		secretsService: service,
@@ -71,24 +76,31 @@ func (s *SecretsManagerAPI) createSecret(ctx context.Context, arg params.CreateS
 	if arg.RotateInterval < 0 {
 		return "", errors.NotValidf("rotate interval %q", arg.RotateInterval)
 	}
+	if !coresecrets.SecretStatus(arg.Status).IsValid() {
+		return "", errors.NotValidf("secret status %q", arg.Status)
+	}
 	if len(arg.Data) == 0 {
 		return "", errors.NotValidf("empty secret value")
 	}
-	URL := coresecrets.NewSimpleURL(secrets.Version, arg.Path)
+	URL := coresecrets.NewSimpleURL(arg.Path)
 	URL.ControllerUUID = s.controllerUUID
 	URL.ModelUUID = s.modelUUID
 	md, err := s.secretsService.CreateSecret(ctx, URL, secrets.CreateParams{
-		Type:           arg.Type,
+		Type:           coresecrets.SecretType(arg.Type),
 		Version:        secrets.Version,
+		Owner:          s.authOwner.String(),
 		Path:           arg.Path,
 		RotateInterval: arg.RotateInterval,
+		Status:         coresecrets.SecretStatus(arg.Status),
+		Description:    arg.Description,
+		Tags:           arg.Tags,
 		Params:         arg.Params,
 		Data:           arg.Data,
 	})
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return md.URL.String(), nil
+	return md.URL.ShortString(), nil
 }
 
 // UpdateSecrets updates the specified secrets.
@@ -103,6 +115,14 @@ func (s *SecretsManagerAPI) UpdateSecrets(args params.UpdateSecretArgs) (params.
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil
+}
+
+func secretStatusPtr(in *string) *coresecrets.SecretStatus {
+	if in == nil {
+		return nil
+	}
+	s := coresecrets.SecretStatus(*in)
+	return &s
 }
 
 func (s *SecretsManagerAPI) updateSecret(ctx context.Context, arg params.UpdateSecretArg) (string, error) {
@@ -122,20 +142,30 @@ func (s *SecretsManagerAPI) updateSecret(ctx context.Context, arg params.UpdateS
 	if URL.ModelUUID != "" && URL.ModelUUID != s.modelUUID {
 		return "", errors.NotValidf("secret URL with model UUID %q", URL.ModelUUID)
 	}
-	if arg.RotateInterval < 0 && len(arg.Data) == 0 {
-		return "", errors.New("either rotate interval or data must be specified")
+	if arg.RotateInterval == nil && arg.Description == nil && arg.Status == nil &&
+		arg.Tags == nil && len(arg.Params) == 0 && len(arg.Data) == 0 {
+		return "", errors.New("at least one attribute to update must be specified")
+	}
+	if arg.RotateInterval != nil && *arg.RotateInterval < 0 {
+		return "", errors.NotValidf("rotate interval %v", *arg.RotateInterval)
+	}
+	if arg.Status != nil && !coresecrets.SecretStatus(*arg.Status).IsValid() {
+		return "", errors.NotValidf("secret status %q", arg.Status)
 	}
 	URL.ControllerUUID = s.controllerUUID
 	URL.ModelUUID = s.modelUUID
 	md, err := s.secretsService.UpdateSecret(ctx, URL, secrets.UpdateParams{
 		RotateInterval: arg.RotateInterval,
+		Status:         secretStatusPtr(arg.Status),
+		Description:    arg.Description,
+		Tags:           arg.Tags,
 		Params:         arg.Params,
 		Data:           arg.Data,
 	})
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return md.URL.WithRevision(md.Revision).String(), nil
+	return md.URL.WithRevision(md.Revision).ShortString(), nil
 }
 
 // GetSecretValues returns the secret values for the specified secrets.

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -94,6 +94,7 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			Path:           m.Path,
 			RotateInterval: m.RotateInterval,
 			Version:        m.Version,
+			Status:         string(m.Status),
 			Description:    m.Description,
 			Tags:           m.Tags,
 			ID:             m.ID,

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -72,16 +72,16 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 
 	now := time.Now()
 	URL := &coresecrets.URL{
-		Version:        "v1",
 		ControllerUUID: coretesting.ControllerTag.Id(),
 		ModelUUID:      coretesting.ModelTag.Id(),
-		Path:           "app.password",
+		Path:           "app/password",
 	}
 	metadata := []*coresecrets.SecretMetadata{{
 		URL:            URL,
-		Path:           "app.password",
+		Path:           "app/password",
 		RotateInterval: time.Hour,
 		Version:        1,
+		Status:         coresecrets.StatusActive,
 		Description:    "shhh",
 		Tags:           map[string]string{"foo": "bar"},
 		ID:             666,
@@ -110,9 +110,10 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
 			URL:            URL.String(),
-			Path:           "app.password",
+			Path:           "app/password",
 			RotateInterval: time.Hour,
 			Version:        1,
+			Status:         "active",
 			Description:    "shhh",
 			Tags:           map[string]string{"foo": "bar"},
 			ID:             666,

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39881,6 +39881,9 @@
                         "rotate-interval": {
                             "type": "integer"
                         },
+                        "status": {
+                            "type": "string"
+                        },
                         "tags": {
                             "type": "object",
                             "patternProperties": {
@@ -39909,6 +39912,7 @@
                         "path",
                         "version",
                         "rotate-interval",
+                        "status",
                         "int",
                         "provider",
                         "revision",
@@ -40034,6 +40038,9 @@
                                 }
                             }
                         },
+                        "description": {
+                            "type": "string"
+                        },
                         "params": {
                             "type": "object",
                             "patternProperties": {
@@ -40049,6 +40056,17 @@
                         "rotate-interval": {
                             "type": "integer"
                         },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "type": {
                             "type": "string"
                         }
@@ -40057,7 +40075,8 @@
                     "required": [
                         "type",
                         "path",
-                        "rotate-interval"
+                        "rotate-interval",
+                        "status"
                     ]
                 },
                 "CreateSecretArgs": {
@@ -40289,6 +40308,9 @@
                                 }
                             }
                         },
+                        "description": {
+                            "type": "string"
+                        },
                         "params": {
                             "type": "object",
                             "patternProperties": {
@@ -40301,6 +40323,17 @@
                         "rotate-interval": {
                             "type": "integer"
                         },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "url": {
                             "type": "string"
                         }
@@ -40308,7 +40341,8 @@
                     "additionalProperties": false,
                     "required": [
                         "url",
-                        "rotate-interval"
+                        "rotate-interval",
+                        "status"
                     ]
                 },
                 "UpdateSecretArgs": {

--- a/apiserver/params/secrets.go
+++ b/apiserver/params/secrets.go
@@ -23,9 +23,15 @@ type CreateSecretArg struct {
 	Path string `json:"path"`
 	// RotateInterval is how often a secret should be rotated.
 	RotateInterval time.Duration `json:"rotate-interval"`
+	// Status represents the secret's status.
+	Status string `json:"status"`
+	// Description represents the secret's description.
+	Description string `json:"description,omitempty"`
 	// Params are used when generating secrets server side.
 	// See core/secrets/secret.go.
 	Params map[string]interface{} `json:"params,omitempty"`
+	// Tags are the secret tags.
+	Tags map[string]string `json:"tags,omitempty"`
 	// Data is the key values of the secret value itself.
 	Data map[string]string `json:"data,omitempty"`
 }
@@ -40,8 +46,13 @@ type UpdateSecretArg struct {
 	// URL identifies the secret to update.
 	URL string `json:"url"`
 	// RotateInterval is how often a secret should be rotated.
-	// Use a value < 0 to keep the current rotate interval.
-	RotateInterval time.Duration `json:"rotate-interval"`
+	RotateInterval *time.Duration `json:"rotate-interval"`
+	// Status represents the secret's status.
+	Status *string `json:"status"`
+	// Description represents the secret's description.
+	Description *string `json:"description,omitempty"`
+	// Tags are the secret tags.
+	Tags *map[string]string `json:"tags,omitempty"`
 	// Params are used when generating secrets server side.
 	// See core/secrets/secret.go.
 	Params map[string]interface{} `json:"params,omitempty"`
@@ -87,6 +98,7 @@ type ListSecretResult struct {
 	Path           string             `json:"path"`
 	Version        int                `json:"version"`
 	RotateInterval time.Duration      `json:"rotate-interval"`
+	Status         string             `json:"status"`
 	Description    string             `json:"description,omitempty"`
 	Tags           map[string]string  `json:"tags,omitempty"`
 	ID             int                `json:"int"`

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -93,20 +93,21 @@ type secretValueDetails struct {
 }
 
 type secretDisplayDetails struct {
-	ID             int                 `json:"ID" yaml:"ID"`
-	URL            string              `json:"URL" yaml:"URL"`
-	Revision       int                 `json:"revision" yaml:"revision"`
-	Path           string              `json:"path" yaml:"path"`
-	RotateInterval time.Duration       `json:"rotate-interval,omitempty" yaml:"rotate-interval,omitempty"`
-	Version        int                 `json:"version" yaml:"version"`
-	Description    string              `json:"description,omitempty" yaml:"description,omitempty"`
-	Tags           map[string]string   `json:"tags,omitempty" yaml:"tags,omitempty"`
-	Provider       string              `json:"backend" yaml:"backend"`
-	ProviderID     string              `json:"backend-id,omitempty" yaml:"backend-id,omitempty"`
-	CreateTime     time.Time           `json:"create-time" yaml:"create-time"`
-	UpdateTime     time.Time           `json:"update-time" yaml:"update-time"`
-	Error          string              `json:"error,omitempty" yaml:"error,omitempty"`
-	Value          *secretValueDetails `json:"value,omitempty" yaml:"value,omitempty"`
+	ID             int                  `json:"ID" yaml:"ID"`
+	URL            string               `json:"URL" yaml:"URL"`
+	Revision       int                  `json:"revision" yaml:"revision"`
+	Path           string               `json:"path" yaml:"path"`
+	Status         secrets.SecretStatus `json:"status" yaml:"status"`
+	RotateInterval time.Duration        `json:"rotate-interval,omitempty" yaml:"rotate-interval,omitempty"`
+	Version        int                  `json:"version" yaml:"version"`
+	Description    string               `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags           map[string]string    `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Provider       string               `json:"backend" yaml:"backend"`
+	ProviderID     string               `json:"backend-id,omitempty" yaml:"backend-id,omitempty"`
+	CreateTime     time.Time            `json:"create-time" yaml:"create-time"`
+	UpdateTime     time.Time            `json:"update-time" yaml:"update-time"`
+	Error          string               `json:"error,omitempty" yaml:"error,omitempty"`
+	Value          *secretValueDetails  `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Run implements cmd.Run.
@@ -133,6 +134,7 @@ func (c *listSecretsCommand) Run(ctxt *cmd.Context) error {
 			Path:           m.Metadata.Path,
 			RotateInterval: m.Metadata.RotateInterval,
 			Version:        m.Metadata.Version,
+			Status:         m.Metadata.Status,
 			Description:    m.Metadata.Description,
 			Tags:           m.Metadata.Tags,
 			ID:             m.Metadata.ID,

--- a/secrets/interface.go
+++ b/secrets/interface.go
@@ -19,16 +19,23 @@ const (
 type CreateParams struct {
 	ProviderLabel  string
 	Version        int
-	Type           string
+	Type           secrets.SecretType
+	Owner          string
 	Path           string
 	RotateInterval time.Duration
+	Status         secrets.SecretStatus
+	Description    string
+	Tags           map[string]string
 	Params         map[string]interface{}
 	Data           map[string]string
 }
 
 // UpdateParams are used to update a secret.
 type UpdateParams struct {
-	RotateInterval time.Duration
+	RotateInterval *time.Duration
+	Status         *secrets.SecretStatus
+	Description    *string
+	Tags           *map[string]string
 	Params         map[string]interface{}
 	Data           map[string]string
 }

--- a/secrets/provider/juju/mongosecrets.go
+++ b/secrets/provider/juju/mongosecrets.go
@@ -41,8 +41,12 @@ func (s secretsService) CreateSecret(ctx context.Context, URL *coresecrets.URL, 
 		ProviderLabel:  Provider,
 		Version:        p.Version,
 		Type:           p.Type,
+		Owner:          p.Owner,
 		Path:           p.Path,
 		RotateInterval: p.RotateInterval,
+		Description:    p.Description,
+		Status:         p.Status,
+		Tags:           p.Tags,
 		Params:         p.Params,
 		Data:           p.Data,
 	})
@@ -79,6 +83,9 @@ func (s secretsService) ListSecrets(ctx context.Context, filter secrets.Filter) 
 func (s secretsService) UpdateSecret(ctx context.Context, URL *coresecrets.URL, p secrets.UpdateParams) (*coresecrets.SecretMetadata, error) {
 	metadata, err := s.backend.UpdateSecret(URL, state.UpdateSecretParams{
 		RotateInterval: p.RotateInterval,
+		Description:    p.Description,
+		Status:         p.Status,
+		Tags:           p.Tags,
 		Params:         p.Params,
 		Data:           p.Data,
 	})

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -29,13 +29,13 @@ func (s *SecretsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *SecretsSuite) TestCreate(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	p := state.CreateSecretParams{
 		Version:        1,
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar"},
@@ -63,13 +63,13 @@ func (s *SecretsSuite) TestCreate(c *gc.C) {
 }
 
 func (s *SecretsSuite) TestCreateIncrementsID(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	p := state.CreateSecretParams{
 		Version:        1,
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar"},
@@ -77,7 +77,7 @@ func (s *SecretsSuite) TestCreateIncrementsID(c *gc.C) {
 	_, err := s.store.CreateSecret(URL, p)
 	c.Assert(err, jc.ErrorIsNil)
 
-	URL.Path = "app.password2"
+	URL.Path = "app/mariadb/password2"
 	p.Path = URL.Path
 	md, err := s.store.CreateSecret(URL, p)
 	c.Assert(err, jc.ErrorIsNil)
@@ -86,20 +86,20 @@ func (s *SecretsSuite) TestCreateIncrementsID(c *gc.C) {
 }
 
 func (s *SecretsSuite) TestGetValueNotFound(c *gc.C) {
-	URL, _ := secrets.ParseURL("secret://v1/app.password")
+	URL, _ := secrets.ParseURL("secret://app/mariadb/password")
 	_, err := s.store.GetSecretValue(URL)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *SecretsSuite) TestGetValue(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	p := state.CreateSecretParams{
 		Version:        1,
 		ProviderLabel:  "juju",
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar"},
@@ -115,14 +115,14 @@ func (s *SecretsSuite) TestGetValue(c *gc.C) {
 }
 
 func (s *SecretsSuite) TestGetValueAttribute(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	p := state.CreateSecretParams{
 		Version:        1,
 		ProviderLabel:  "juju",
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar", "hello": "world"},
@@ -138,14 +138,14 @@ func (s *SecretsSuite) TestGetValueAttribute(c *gc.C) {
 }
 
 func (s *SecretsSuite) TestGetValueAttributeNotFound(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	p := state.CreateSecretParams{
 		Version:        1,
 		ProviderLabel:  "juju",
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar", "hello": "world"},
@@ -158,14 +158,14 @@ func (s *SecretsSuite) TestGetValueAttributeNotFound(c *gc.C) {
 }
 
 func (s *SecretsSuite) TestList(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	p := state.CreateSecretParams{
 		Version:        1,
 		ProviderLabel:  "juju",
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar"},
@@ -178,7 +178,7 @@ func (s *SecretsSuite) TestList(c *gc.C) {
 	now := s.Clock.Now().Round(time.Second).UTC()
 	c.Assert(list, jc.DeepEquals, []*secrets.SecretMetadata{{
 		URL:            URL,
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Version:        1,
 		Description:    "",
@@ -193,25 +193,25 @@ func (s *SecretsSuite) TestList(c *gc.C) {
 }
 
 func (s *SecretsSuite) TestUpdateNothing(c *gc.C) {
-	up := state.UpdateSecretParams{
-		RotateInterval: -1,
-		Params:         nil,
-		Data:           nil,
-	}
-	URL := secrets.NewSimpleURL(1, "password")
+	up := state.UpdateSecretParams{}
+	URL := secrets.NewSimpleURL("password")
 	_, err := s.store.UpdateSecret(URL, up)
 	c.Assert(err, gc.ErrorMatches, "must specify a new value or metadata to update a secret")
 }
 
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
+}
+
 func (s *SecretsSuite) TestUpdateAll(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	cp := state.CreateSecretParams{
 		Version:        1,
 		ProviderLabel:  "juju",
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar"},
@@ -219,51 +219,60 @@ func (s *SecretsSuite) TestUpdateAll(c *gc.C) {
 	md, err := s.store.CreateSecret(URL, cp)
 	c.Assert(err, jc.ErrorIsNil)
 	newData := map[string]string{"foo": "bar", "hello": "world"}
-	s.assertUpdatedSecret(c, md.URL, newData, 2*time.Hour, 2)
+	newDescription := "big secret"
+	newTags := map[string]string{"goodbye": "world"}
+	newStatus := secrets.StatusPending
+	s.assertUpdatedSecret(c, md.URL, newData, durationPtr(2*time.Hour), &newDescription, &newStatus, &newTags, 2)
 }
 
 func (s *SecretsSuite) TestUpdateRotateInterval(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	cp := state.CreateSecretParams{
 		Version:        1,
 		ProviderLabel:  "juju",
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar"},
 	}
 	md, err := s.store.CreateSecret(URL, cp)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertUpdatedSecret(c, md.URL, nil, 2*time.Hour, 1)
+	s.assertUpdatedSecret(c, md.URL, nil, durationPtr(2*time.Hour), nil, nil, nil, 1)
 }
 
 func (s *SecretsSuite) TestUpdateData(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 	cp := state.CreateSecretParams{
-		Version:        1,
 		ProviderLabel:  "juju",
+		Version:        1,
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
+		Description:    "my secret",
+		Status:         secrets.StatusActive,
+		Tags:           map[string]string{"hello": "world"},
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar"},
 	}
 	md, err := s.store.CreateSecret(URL, cp)
 	c.Assert(err, jc.ErrorIsNil)
 	newData := map[string]string{"foo": "bar", "hello": "world"}
-	s.assertUpdatedSecret(c, md.URL, newData, -1, 2)
+	s.assertUpdatedSecret(c, md.URL, newData, nil, nil, nil, nil, 2)
 }
 
-func (s *SecretsSuite) assertUpdatedSecret(c *gc.C, URL *secrets.URL, data map[string]string, rotateInterval time.Duration, expectedRevision int) {
+func (s *SecretsSuite) assertUpdatedSecret(c *gc.C, URL *secrets.URL, data map[string]string, rotateInterval *time.Duration, description *string, status *secrets.SecretStatus, tags *map[string]string, expectedRevision int) {
 	created := s.Clock.Now().Round(time.Second).UTC()
 
 	up := state.UpdateSecretParams{
 		RotateInterval: rotateInterval,
+		Description:    description,
+		Status:         status,
+		Tags:           tags,
 		Params:         nil,
 		Data:           data,
 	}
@@ -271,41 +280,38 @@ func (s *SecretsSuite) assertUpdatedSecret(c *gc.C, URL *secrets.URL, data map[s
 	updated := s.Clock.Now().Round(time.Second).UTC()
 	md, err := s.store.UpdateSecret(URL.WithRevision(0), up)
 	c.Assert(err, jc.ErrorIsNil)
-	expectedRotateInterval := time.Hour
-	if rotateInterval >= 0 {
-		expectedRotateInterval = rotateInterval
-	}
-	c.Assert(md, jc.DeepEquals, &secrets.SecretMetadata{
+	expected := &secrets.SecretMetadata{
 		URL:            md.URL,
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		Version:        1,
-		Description:    "",
-		Tags:           map[string]string{},
-		RotateInterval: expectedRotateInterval,
+		RotateInterval: md.RotateInterval,
+		Status:         md.Status,
+		Description:    md.Description,
+		Tags:           md.Tags,
 		ID:             1,
 		Provider:       "juju",
 		ProviderID:     "",
 		Revision:       expectedRevision,
 		CreateTime:     created,
 		UpdateTime:     updated,
-	})
+	}
+	if rotateInterval != nil {
+		expected.RotateInterval = *rotateInterval
+	}
+	if status != nil {
+		expected.Status = *status
+	}
+	if description != nil {
+		expected.Description = *description
+	}
+	if tags != nil {
+		expected.Tags = *tags
+	}
+	c.Assert(md, jc.DeepEquals, expected)
 
 	list, err := s.store.ListSecrets(state.SecretsFilter{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(list, jc.DeepEquals, []*secrets.SecretMetadata{{
-		URL:            md.URL,
-		Path:           "app.password",
-		RotateInterval: expectedRotateInterval,
-		Version:        1,
-		Description:    "",
-		Tags:           map[string]string{},
-		ID:             1,
-		Provider:       "juju",
-		ProviderID:     "",
-		Revision:       expectedRevision,
-		CreateTime:     created,
-		UpdateTime:     updated,
-	}})
+	c.Assert(list, jc.DeepEquals, []*secrets.SecretMetadata{expected})
 	expectedData := map[string]string{"foo": "bar"}
 	if data != nil {
 		expectedData = data
@@ -316,7 +322,7 @@ func (s *SecretsSuite) assertUpdatedSecret(c *gc.C, URL *secrets.URL, data map[s
 }
 
 func (s *SecretsSuite) TestUpdateConcurrent(c *gc.C) {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	URL.ControllerUUID = s.State.ControllerUUID()
 	URL.ModelUUID = s.State.ModelUUID()
 
@@ -324,7 +330,7 @@ func (s *SecretsSuite) TestUpdateConcurrent(c *gc.C) {
 		Version:        1,
 		ProviderLabel:  "juju",
 		Type:           "blob",
-		Path:           "app.password",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 		Params:         nil,
 		Data:           map[string]string{"foo": "bar"},
@@ -333,7 +339,7 @@ func (s *SecretsSuite) TestUpdateConcurrent(c *gc.C) {
 
 	state.SetBeforeHooks(c, s.State, func() {
 		up := state.UpdateSecretParams{
-			RotateInterval: 3 * time.Hour,
+			RotateInterval: durationPtr(3 * time.Hour),
 			Params:         nil,
 			Data:           map[string]string{"foo": "baz", "goodbye": "world"},
 		}
@@ -341,7 +347,7 @@ func (s *SecretsSuite) TestUpdateConcurrent(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	})
 	newData := map[string]string{"foo": "bar", "hello": "world"}
-	s.assertUpdatedSecret(c, md.URL, newData, 2*time.Hour, 3)
+	s.assertUpdatedSecret(c, md.URL, newData, durationPtr(2*time.Hour), nil, nil, nil, 3)
 }
 
 type SecretsWatcherSuite struct {
@@ -357,14 +363,15 @@ func (s *SecretsWatcherSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *SecretsWatcherSuite) setupWatcher(c *gc.C) state.SecretsRotationWatcher {
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	md, err := s.store.CreateSecret(URL, state.CreateSecretParams{
 		Version:        1,
-		Path:           "app.password",
+		Owner:          "application-mariadb",
+		Path:           "app/mariadb/password",
 		RotateInterval: time.Hour,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	w := s.State.WatchSecretsRotationChanges("application-app")
+	w := s.State.WatchSecretsRotationChanges("application-mariadb")
 
 	now := s.Clock.Now().Round(time.Second).UTC()
 	wc := testing.NewSecretsRotationWatcherC(c, s.State, w)
@@ -388,9 +395,9 @@ func (s *SecretsWatcherSuite) TestWatchSingleUpdate(c *gc.C) {
 	wc := testing.NewSecretsRotationWatcherC(c, s.State, w)
 	defer testing.AssertStop(c, w)
 
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	md, err := s.store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: time.Minute,
+		RotateInterval: durationPtr(time.Minute),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -408,9 +415,9 @@ func (s *SecretsWatcherSuite) TestWatchDelete(c *gc.C) {
 	wc := testing.NewSecretsRotationWatcherC(c, s.State, w)
 	defer testing.AssertStop(c, w)
 
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	md, err := s.store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: 0,
+		RotateInterval: durationPtr(0),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -427,13 +434,13 @@ func (s *SecretsWatcherSuite) TestWatchMultipleUpdatesSameSecret(c *gc.C) {
 	wc := testing.NewSecretsRotationWatcherC(c, s.State, w)
 	defer testing.AssertStop(c, w)
 
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	_, err := s.store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: time.Minute,
+		RotateInterval: durationPtr(time.Minute),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	md, err := s.store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: time.Second,
+		RotateInterval: durationPtr(time.Second),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -451,13 +458,13 @@ func (s *SecretsWatcherSuite) TestWatchMultipleUpdatesSameSecretDeleted(c *gc.C)
 	wc := testing.NewSecretsRotationWatcherC(c, s.State, w)
 	defer testing.AssertStop(c, w)
 
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	_, err := s.store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: time.Minute,
+		RotateInterval: durationPtr(time.Minute),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	md, err := s.store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: 0,
+		RotateInterval: durationPtr(0),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -474,22 +481,23 @@ func (s *SecretsWatcherSuite) TestWatchMultipleUpdates(c *gc.C) {
 	wc := testing.NewSecretsRotationWatcherC(c, s.State, w)
 	defer testing.AssertStop(c, w)
 
-	URL := secrets.NewSimpleURL(1, "app.password")
+	URL := secrets.NewSimpleURL("app/mariadb/password")
 	_, err := s.store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: time.Minute,
+		RotateInterval: durationPtr(time.Minute),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	URL2 := secrets.NewSimpleURL(1, "app.password2")
+	URL2 := secrets.NewSimpleURL("app/mariadb/password2")
 	md2, err := s.store.CreateSecret(URL2, state.CreateSecretParams{
 		Version:        1,
-		Path:           "app.password2",
+		Owner:          "application-mariadb",
+		Path:           "app/mariadb/password2",
 		RotateInterval: time.Hour,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	md, err := s.store.UpdateSecret(URL, state.UpdateSecretParams{
-		RotateInterval: 0,
+		RotateInterval: durationPtr(0),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -778,17 +778,23 @@ func (ctx *HookContext) GetSecret(name string) (coresecrets.SecretValue, error) 
 // CreateSecret creates a secret with the specified data.
 func (ctx *HookContext) CreateSecret(name string, args *jujuc.UpsertArgs) (string, error) {
 	app, _ := names.UnitApplication(ctx.UnitName())
-	cfg := coresecrets.NewSecretConfig(app, name)
+	cfg := coresecrets.NewSecretConfig(coresecrets.AppSnippet, app, name)
 	cfg.RotateInterval = args.RotateInterval
+	cfg.Status = args.Status
+	cfg.Description = args.Description
+	cfg.Tags = args.Tags
 	return ctx.secretFacade.Create(cfg, args.Type, args.Value)
 }
 
 // UpdateSecret creates a secret with the specified data.
 func (ctx *HookContext) UpdateSecret(name string, args *jujuc.UpsertArgs) (string, error) {
 	app, _ := names.UnitApplication(ctx.UnitName())
-	cfg := coresecrets.NewSecretConfig(app, name)
+	cfg := coresecrets.NewSecretConfig(coresecrets.AppSnippet, app, name)
 	cfg.RotateInterval = args.RotateInterval
-	URL := coresecrets.NewSimpleURL(1, cfg.Path)
+	cfg.Status = args.Status
+	cfg.Description = args.Description
+	cfg.Tags = args.Tags
+	URL := coresecrets.NewSimpleURL(cfg.Path)
 	return ctx.secretFacade.Update(URL, cfg, args.Value)
 }
 

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -896,6 +896,22 @@ func (s *mockHookContextSuite) TestSecretGet(c *gc.C) {
 	})
 }
 
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func statusPtr(s secrets.SecretStatus) *secrets.SecretStatus {
+	return &s
+}
+
+func tagPtr(t map[string]string) *map[string]string {
+	return &t
+}
+
 func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -909,15 +925,18 @@ func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
 		c.Check(arg, gc.DeepEquals, params.CreateSecretArgs{
 			Args: []params.CreateSecretArg{{
 				Type:           "blob",
-				Path:           "wordpress.password",
+				Path:           "app/wordpress/password",
 				RotateInterval: time.Hour,
+				Status:         "active",
+				Description:    "my secret",
+				Tags:           map[string]string{"hello": "world"},
 				Data:           data,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
 		*(result.(*params.StringResults)) = params.StringResults{
 			[]params.StringResult{{
-				Result: "secret://foo",
+				Result: "secret://app/foo",
 			}},
 		}
 		return nil
@@ -928,8 +947,53 @@ func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
 	id, err := hookContext.CreateSecret("password", &jujuc.UpsertArgs{
 		Type:           secrets.TypeBlob,
 		Value:          value,
-		RotateInterval: time.Hour,
+		RotateInterval: durationPtr(time.Hour),
+		Status:         statusPtr(secrets.StatusActive),
+		Description:    stringPtr("my secret"),
+		Tags:           tagPtr(map[string]string{"hello": "world"}),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(id, gc.Equals, "secret://foo")
+	c.Assert(id, gc.Equals, "secret://app/foo")
+}
+
+func (s *mockHookContextSuite) TestSecretUpdate(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	value := secrets.NewSecretValue(data)
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "SecretsManager")
+		c.Assert(version, gc.Equals, 0)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "UpdateSecrets")
+		c.Check(arg, gc.DeepEquals, params.UpdateSecretArgs{
+			Args: []params.UpdateSecretArg{{
+				URL:            "secret://app/wordpress/password",
+				RotateInterval: durationPtr(time.Hour),
+				Status:         stringPtr("active"),
+				Description:    stringPtr("my secret"),
+				Tags:           tagPtr(map[string]string{"hello": "world"}),
+				Data:           data,
+			}},
+		})
+		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
+		*(result.(*params.StringResults)) = params.StringResults{
+			[]params.StringResult{{
+				Result: "secret://app/wordpress/password",
+			}},
+		}
+		return nil
+	})
+	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
+	client := secretsmanager.NewClient(apiCaller)
+	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
+	id, err := hookContext.UpdateSecret("password", &jujuc.UpsertArgs{
+		Value:          value,
+		RotateInterval: durationPtr(time.Hour),
+		Status:         statusPtr(secrets.StatusActive),
+		Description:    stringPtr("my secret"),
+		Tags:           tagPtr(map[string]string{"hello": "world"}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(id, gc.Equals, "secret://app/wordpress/password")
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -171,8 +171,17 @@ type UpsertArgs struct {
 	// Value is the new secret value or nil to not update.
 	Value secrets.SecretValue
 
-	// RotateInterval is the new rotate interval or -1 to not update.
-	RotateInterval time.Duration
+	// RotateInterval is the new rotate interval or nil to not update.
+	RotateInterval *time.Duration
+
+	// Status is whether a secret is pending or active or nil to not update.
+	Status *secrets.SecretStatus
+
+	// Description describes the secret or nil to not update.
+	Description *string
+
+	// Tags are stored with the secret metadata or nil to not update.
+	Tags *map[string]string
 }
 
 // ContextSecrets is the part of a hook context related to secrets.

--- a/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-get_test.go
@@ -31,10 +31,10 @@ func (s *SecretGetSuite) TestSecretGetSingularString(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "s3cret!\n")
 }
@@ -48,10 +48,10 @@ func (s *SecretGetSuite) TestSecretGetStringJson(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password", "--format", "json"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password", "--format", "json"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `{"key":"s3cret!"}`+"\n")
 }
@@ -65,10 +65,10 @@ func (s *SecretGetSuite) TestSecretGetSingularEncoded(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password", "--base64"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password", "--base64"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "czNjcmV0IQ==\n")
 }
@@ -83,10 +83,10 @@ func (s *SecretGetSuite) TestSecretGet(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
 cert: cert
@@ -105,10 +105,10 @@ func (s *SecretGetSuite) TestSecretGetEncoded(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password", "--base64"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password", "--base64"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
 cert: Y2VydA==
@@ -127,10 +127,10 @@ func (s *SecretGetSuite) TestSecretGetAttribute(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, cmdString("secret-get"))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://v1/app.password#cert"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password#cert"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://v1/app.password#cert"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password#cert"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "cert\n")
 }


### PR DESCRIPTION
The secret-create and secret-update hook commands can now set additional secret metadata:
- description
- tags
- status

Secret status defaults to 'active' and can be set to 'pending' via the CLI option `--pending`. It can be used when rotating secrets.

The secret URL format has changed also. The main change is the removal of version from the URL and the introduction of an 'app' namespace component (more to come). Also, the use of '.' as a path separator is removed, replaced by '/'.

## QA steps

bootstrap and deploy ubuntu charm

```
juju deploy ubuntu
$ juju exec --unit ubuntu/0 "secret-create password --description 'my secret' --tag foo=bar --tag hello=world data=s3cret!"
secret://app/ubuntu/password

$ juju exec --unit ubuntu/0 "secret-get secret://app/ubuntu/password"
s3cret!

$ juju exec --unit ubuntu/0 "secret-update password --rotate 5h --description 'ssshhh'"
secret://app/ubuntu/password?revision=1

$ juju secrets --format yaml
- ID: 1
  URL: secret://app/ubuntu/password
  revision: 1
  path: app/ubuntu/password
  status: active
  rotate-interval: 5h0m0s
  version: 1
  description: ssshhh
  tags:
    foo: bar
    hello: world
  backend: juju
  create-time: 2021-09-10T00:48:49Z
  update-time: 2021-09-10T00:50:26Z

$ juju exec --unit ubuntu/0 "secret-update password --pending data=another"
secret://app/ubuntu/password?revision=2

$ juju secrets --format yaml --show-secrets
- ID: 1
  URL: secret://app/ubuntu/password
  revision: 2
  path: app/ubuntu/password
  status: pending
  rotate-interval: 5h0m0s
  version: 1
  description: ssshhh
  tags:
    foo: bar
    hello: world
  backend: juju
  create-time: 2021-09-10T00:48:49Z
  update-time: 2021-09-10T00:52:42Z
  value:
    data: another
```