### PR TITLE
Raft worker errors

### DIFF
--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -310,6 +310,9 @@ func (w *Worker) loop(raftConfig *raft.Config) (loopErr error) {
 
 	rawLogStore, err := NewLogStore(w.config.StorageDir, syncMode)
 	if err != nil {
+		// Required logging, as ErrStartTimeout can mask the underlying error
+		// and we never know the original failure.
+		w.config.Logger.Errorf("Failed to setup raw log store, err: %v", err)
 		return errors.Trace(err)
 	}
 
@@ -326,11 +329,17 @@ func (w *Worker) loop(raftConfig *raft.Config) (loopErr error) {
 	}
 	snapshotStore, err := NewSnapshotStore(w.config.StorageDir, snapshotRetention, w.config.Logger)
 	if err != nil {
+		// Required logging, as ErrStartTimeout can mask the underlying error
+		// and we never know the original failure.
+		w.config.Logger.Errorf("Failed to setup snapshot store, err: %v", err)
 		return errors.Trace(err)
 	}
 
 	r, err := raft.NewRaft(raftConfig, w.config.FSM, logStore, rawLogStore, snapshotStore, w.config.Transport)
 	if err != nil {
+		// Required logging, as ErrStartTimeout can mask the underlying error
+		// and we never know the original failure.
+		w.config.Logger.Errorf("Failed to setup raft instance, err: %v", err)
 		return errors.Trace(err)
 	}
 	defer func() {


### PR DESCRIPTION
In order to improve the readability of why a raft worker is restarting, the
following introduces logging error messages.

The problem isn't helped by the masked ErrStartTimeout waiting for a new
raft channel. As the catacomb is killed by the ErrStartTimeout, we lose
the original error message.

## QA steps

```sh
$ snap install juju --classic
$ /snap/bin/juju bootstrap lxd test
$ go get github.com/lxc/lxd@172613bf35d31b8e788f00fe93069b8d0d19b947
$ juju upgrade-controller --build-agent
$ juju debug-log -m controller
```

You should see the following error message

```
machine-0: 16:26:49 ERROR juju.worker.raft Failed to setup raft instance, err: failed to get last log at index 52: msgpack decode error [pos 13]: invalid length of bytes for decoding time - expecting 4 or 8 or 12, got 15
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1943075
