### PR TITLE
deploy by revision: deploy and export bundles with revision tag.

### DIFF
--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -558,6 +558,39 @@ func (s *bundleSuite) TestGetChangesMapArgsSuccess(c *gc.C) {
 	c.Assert(r.Errors, gc.IsNil)
 }
 
+func (s *bundleSuite) TestGetChangesMapArgsSuccessCharmHubRevision(c *gc.C) {
+	args := params.BundleChangesParams{
+		BundleDataYAML: `
+            applications:
+                django:
+                    charm: django
+                    revision: 76
+                    channel: candidate
+        `,
+	}
+	r, err := s.facade.GetChangesMapArgs(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(r.Changes, jc.DeepEquals, []*params.BundleChangesMapArgs{{
+		Id:     "addCharm-0",
+		Method: "addCharm",
+		Args: map[string]interface{}{
+			"revision": float64(76),
+			"channel":  "candidate",
+			"charm":    "django",
+		},
+	}, {
+		Id:     "deploy-1",
+		Method: "deploy",
+		Args: map[string]interface{}{
+			"application": "django",
+			"channel":     "candidate",
+			"charm":       "$addCharm-0",
+		},
+		Requires: []string{"addCharm-0"},
+	}})
+	c.Assert(r.Errors, gc.IsNil)
+}
+
 func (s *bundleSuite) TestGetChangesMapArgsKubernetes(c *gc.C) {
 	args := params.BundleChangesParams{
 		BundleDataYAML: `

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -336,6 +336,32 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			return errors.Trace(err)
 		}
 
+		// To deploy by revision, the revision number must be in the origin for a
+		// charmhub charm and in the url for a charmstore charm.
+		if charm.CharmHub.Matches(ch.Schema) {
+			if ch.Revision != -1 {
+				return errors.Errorf("cannot specify revision in %q, please use revision", ch)
+			}
+			channel, err := charm.ParseChannelNormalize(spec.Channel)
+			if err != nil {
+				return errors.Errorf("")
+			}
+			if spec.Revision != nil && *spec.Revision != -1 && channel.Empty() {
+				return errors.Errorf("application %q with a revision requires a channel for future upgrades, please use channel", name)
+			}
+		} else if charm.CharmStore.Matches(ch.Schema) {
+			if ch.Revision != -1 && spec.Revision != nil && *spec.Revision != -1 && ch.Revision != *spec.Revision {
+				return errors.Errorf("two different revisions to deploy %q: specified %d and %d, please choose one.", name, ch.Revision, *spec.Revision)
+			}
+			if ch.Revision == -1 && spec.Revision != nil && *spec.Revision != -1 {
+				ch = ch.WithRevision(*spec.Revision)
+			}
+		}
+		urlForOrigin := ch
+		if spec.Revision != nil && *spec.Revision != -1 {
+			urlForOrigin = urlForOrigin.WithRevision(*spec.Revision)
+		}
+
 		channel, origin, err := h.constructChannelAndOrigin(ch, spec.Series, spec.Channel, cons)
 		if err != nil {
 			return errors.Trace(err)
@@ -378,7 +404,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 	return nil
 }
 
-func (h *bundleHandler) resolveCharmChannelAndRevision(charmURL, charmSeries, charmChannel, arch string) (string, int, error) {
+func (h *bundleHandler) resolveCharmChannelAndRevision(charmURL, charmSeries, charmChannel, arch string, revision int) (string, int, error) {
 	if h.isLocalCharm(charmURL) {
 		return charmChannel, -1, nil
 	}
@@ -405,11 +431,16 @@ func (h *bundleHandler) resolveCharmChannelAndRevision(charmURL, charmSeries, ch
 		cons = constraints.Value{Arch: &arch}
 	}
 
+	// Charmhub charms require the revision in the origin, but not the charm url used.
+	// Add it here temporarily to construct the origin.
+	if revision != -1 {
+		ch = ch.WithRevision(revision)
+	}
+
 	_, origin, err := h.constructChannelAndOrigin(ch, charmSeries, charmChannel, cons)
 	if err != nil {
 		return "", -1, errors.Trace(err)
 	}
-
 	_, origin, _, err = h.bundleResolver.ResolveCharm(ch, origin, false) // no --switch possible.
 	if err != nil {
 		return "", -1, errors.Annotatef(err, "cannot resolve charm or bundle %q", ch.Name)
@@ -625,6 +656,16 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		return errors.Trace(err)
 	}
 
+	// Verification of the revision piece was done when the bundle was
+	// read in.  Ensure that the validated charm has correct revision.
+	if charm.CharmStore.Matches(ch.Schema) && change.Params.Revision != nil && *change.Params.Revision >= 0 {
+		ch = ch.WithRevision(*change.Params.Revision)
+	}
+	urlForOrigin := ch
+	if change.Params.Revision != nil && *change.Params.Revision >= 0 {
+		urlForOrigin = urlForOrigin.WithRevision(*change.Params.Revision)
+	}
+
 	// Ensure that we use the architecture from the add charm change params.
 	var cons constraints.Value
 	if change.Params.Architecture != "" {
@@ -651,7 +692,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		channel = corecharm.MakeRiskOnlyChannel(chParams.Channel)
 	}
 
-	origin, err := utils.DeduceOrigin(ch, channel, platform)
+	origin, err := utils.DeduceOrigin(urlForOrigin, channel, platform)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -342,9 +342,12 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 			if ch.Revision != -1 {
 				return errors.Errorf("cannot specify revision in %q, please use revision", ch)
 			}
-			channel, err := charm.ParseChannelNormalize(spec.Channel)
-			if err != nil {
-				return errors.Errorf("")
+			var channel charm.Channel
+			if spec.Channel != "" {
+				channel, err = charm.ParseChannelNormalize(spec.Channel)
+				if err != nil {
+					return errors.Annotatef(err, "for application %q", spec.Charm)
+				}
 			}
 			if spec.Revision != nil && *spec.Revision != -1 && channel.Empty() {
 				return errors.Errorf("application %q with a revision requires a channel for future upgrades, please use channel", name)

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -1906,6 +1906,9 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleLocalDeployment(c *gc.C) {
 }
 
 func (s *BundleDeployRepositorySuite) TestApplicationsForMachineChange(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectResolveCharmWithSeries([]string{"xenial"}, nil)
+	s.expectResolveCharmWithSeries([]string{"xenial"}, nil)
 	spec := s.bundleDeploySpec()
 	bundleData, err := charm.ReadBundleData(strings.NewReader(machineUnitPlacementBundle))
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -2548,7 +2548,7 @@ func (s *BundleHandlerResolverSuite) TestResolveCharmChannelAndRevision(c *gc.C)
 
 	resolver.EXPECT().ResolveCharm(charmURL, origin, false).Return(charmURL, resolvedOrigin, nil, nil)
 
-	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch)
+	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch, -1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(channel, gc.DeepEquals, "stable")
 	c.Assert(rev, gc.Equals, rev)
@@ -2580,7 +2580,7 @@ func (s *BundleHandlerResolverSuite) TestResolveCharmChannelWithoutRevision(c *g
 
 	resolver.EXPECT().ResolveCharm(charmURL, origin, false).Return(charmURL, resolvedOrigin, nil, nil)
 
-	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch)
+	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch, -1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(channel, gc.DeepEquals, "stable")
 	c.Assert(rev, gc.Equals, -1)
@@ -2597,7 +2597,7 @@ func (s *BundleHandlerResolverSuite) TestResolveLocalCharm(c *gc.C) {
 	charmChannel := "stable"
 	arch := "amd64"
 
-	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch)
+	channel, rev, err := handler.resolveCharmChannelAndRevision(charmURL.String(), charmSeries, charmChannel, arch, -1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(channel, gc.DeepEquals, "stable")
 	c.Assert(rev, gc.Equals, -1)

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -64,13 +64,29 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 			}
 		}
 
+		revision := -1
+		if application.Revision != nil {
+			revision = *application.Revision
+		} else {
+			// The case of upgrade charmhub charm with by channel... need the correct revision,
+			// or we will not have an addCharmChange corresponding to the upgradeCharmChange.
+			if r.charmResolver != nil {
+				_, rev, err := r.charmResolver(application.Charm, application.Series, application.Channel, arch, revision)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				revision = rev
+			}
+		}
+
 		// Add the addCharm record if one hasn't been added yet, this means
 		// if the arch and series differ from an existing charm, then we create
 		// a new charm.
-		key := applicationKey(application.Charm, arch, series, application.Channel)
-		if charms[key] == "" && !existing.matchesCharmPermutation(application.Charm, arch, series, application.Channel, r.constraintGetter) {
+		key := applicationKey(application.Charm, arch, series, application.Channel, revision)
+		if charms[key] == "" && !existing.matchesCharmPermutation(application.Charm, arch, series, application.Channel, revision, r.constraintGetter) {
 			change = newAddCharmChange(AddCharmParams{
 				Charm:        application.Charm,
+				Revision:     application.Revision,
 				Series:       series,
 				Channel:      application.Channel,
 				Architecture: arch,
@@ -267,8 +283,12 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 		resolvedRev  = -1
 	)
 	if r.charmResolver != nil {
+		rev := -1
+		if bundleApp.Revision != nil {
+			rev = *bundleApp.Revision
+		}
 		var err error
-		resolvedChan, resolvedRev, err = r.charmResolver(bundleApp.Charm, bundleApp.Series, bundleApp.Channel, bundleArch)
+		resolvedChan, resolvedRev, err = r.charmResolver(bundleApp.Charm, bundleApp.Series, bundleApp.Channel, bundleArch, rev)
 		if err != nil {
 			return false, errors.Trace(err)
 		}
@@ -280,9 +300,12 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 		}
 		return false, errors.Errorf("upgrades not supported across channels (existing: %q, %s: %q); use --force to override", existingApp.Channel, verb, resolvedChan)
 	}
+
+	// The revision number is in the origin for a charmhub charm and in the url for a charmstore charm.
 	if resolvedRev > existingApp.Revision {
 		return true, nil
-	} else if resolvedRev != -1 && resolvedRev < existingApp.Revision {
+	}
+	if resolvedRev != -1 && resolvedRev < existingApp.Revision {
 		// For charmhub charms, we currently don't support downgrades.
 		return false, errors.Errorf("downgrades are not currently supported")
 	}
@@ -1187,8 +1210,8 @@ func placeholder(changeID string) string {
 	return "$" + changeID
 }
 
-func applicationKey(charm, arch, series, channel string) string {
-	return fmt.Sprintf("%s:%s:%s:%s", charm, arch, series, channel)
+func applicationKey(charm, arch, series, channel string, revision int) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%d", charm, arch, series, channel, revision)
 }
 
 // getSeries retrieves the series of a application from the ApplicationSpec or from the

--- a/core/bundle/changes/handlers_test.go
+++ b/core/bundle/changes/handlers_test.go
@@ -45,7 +45,7 @@ func (s *resolverSuite) TestAllowUpgradeWithSameChannel(c *gc.C) {
 
 	r := resolver{
 		force: true,
-		charmResolver: func(charm, series, channel, arch string) (string, int, error) {
+		charmResolver: func(string, string, string, string, int) (string, int, error) {
 			return "stable", 1, nil
 		},
 	}
@@ -68,7 +68,7 @@ func (s *resolverSuite) TestAllowUpgradeWithDowngrades(c *gc.C) {
 
 	r := resolver{
 		force: true,
-		charmResolver: func(charm, series, channel, arch string) (string, int, error) {
+		charmResolver: func(string, string, string, string, int) (string, int, error) {
 			return "stable", 1, nil
 		},
 	}
@@ -91,7 +91,7 @@ func (s *resolverSuite) TestAllowUpgradeWithSameRevision(c *gc.C) {
 
 	r := resolver{
 		force: true,
-		charmResolver: func(charm, series, channel, arch string) (string, int, error) {
+		charmResolver: func(string, string, string, string, int) (string, int, error) {
 			return "stable", 1, nil
 		},
 	}
@@ -147,7 +147,7 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannelAndForce(c *gc.C) {
 
 	r := resolver{
 		force: true,
-		charmResolver: func(charm, series, channel, arch string) (string, int, error) {
+		charmResolver: func(string, string, string, string, int) (string, int, error) {
 			return "stable", 1, nil
 		},
 	}

--- a/core/bundle/changes/model.go
+++ b/core/bundle/changes/model.go
@@ -234,21 +234,21 @@ type Machine struct {
 	Annotations map[string]string
 }
 
-func (m *Model) hasCharm(charm string) bool {
+func (m *Model) hasCharm(charm string, revision int) bool {
 	if len(m.Applications) == 0 {
 		return false
 	}
 	for _, app := range m.Applications {
-		if app.Charm == charm {
+		if app.Charm == charm && ((revision >= 0 && revision == app.Revision) || revision < 0) {
 			return true
 		}
 	}
 	return false
 }
 
-func (m *Model) matchesCharmPermutation(charm, arch, series, channel string, constraintGetter ConstraintGetter) bool {
+func (m *Model) matchesCharmPermutation(charm, arch, series, channel string, revision int, constraintGetter ConstraintGetter) bool {
 	if arch == "" && series == "" && channel == "" {
-		return m.hasCharm(charm)
+		return m.hasCharm(charm, revision)
 	}
 
 	for _, app := range m.Applications {
@@ -263,7 +263,11 @@ func (m *Model) matchesCharmPermutation(charm, arch, series, channel string, con
 			}
 		}
 
-		if app.Charm == charm && appArch == arch && app.Series == series && app.Channel == channel {
+		if app.Charm == charm &&
+			appArch == arch &&
+			app.Series == series &&
+			app.Channel == channel &&
+			((revision >= 0 && revision == app.Revision) || revision < 0) {
 			return true
 		}
 	}

--- a/core/bundle/changes/model_test.go
+++ b/core/bundle/changes/model_test.go
@@ -35,21 +35,22 @@ func (*modelSuite) TestGetApplication(c *gc.C) {
 
 func (*modelSuite) TestHasCharmNilApplications(c *gc.C) {
 	model := &Model{}
-	c.Assert(model.hasCharm("foo"), jc.IsFalse)
+	c.Assert(model.hasCharm("foo", -1), jc.IsFalse)
 }
 
 func (*modelSuite) TestHasCharm(c *gc.C) {
 	app := &Application{
-		Name:  "foo",
-		Charm: "cs:foo",
+		Name:     "foo",
+		Charm:    "cs:foo",
+		Revision: -1,
 	}
 	model := &Model{
 		Applications: map[string]*Application{
 			"foo": app},
 	}
 	// Match must be exact.
-	c.Assert(model.hasCharm("foo"), jc.IsFalse)
-	c.Assert(model.hasCharm("cs:foo"), jc.IsTrue)
+	c.Assert(model.hasCharm("foo", -1), jc.IsFalse)
+	c.Assert(model.hasCharm("cs:foo", -1), jc.IsTrue)
 }
 
 func (*modelSuite) TestHasRelation(c *gc.C) {

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -68,7 +68,8 @@ func (s *cmdExportBundleSuite) TestExportBundle(c *gc.C) {
 series: quantal
 applications:
   logging:
-    charm: cs:quantal/logging-43
+    charm: cs:quantal/logging
+    revision: 43
     options:
       foo: bar
     bindings:
@@ -77,7 +78,8 @@ applications:
       logging-client: alpha
       logging-directory: alpha
   wordpress:
-    charm: cs:quantal/wordpress-23
+    charm: cs:quantal/wordpress
+    revision: 23
     bindings:
       "": alpha
       admin-api: alpha

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
-	github.com/juju/charm/v9 v9.0.0-20210722104222-d3c79ce32e77
+	github.com/juju/charm/v9 v9.0.0-20210909151651-7e12eccc1e76
 	github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd/v3 v3.0.0-20210809234809-65029dab4cd0

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7 h1:zEIYPqGRtR6R2
 github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7/go.mod h1:GFZ3KcDmWTesil7L3nuSsN5aeGZuL2pNdUoGWswDTgM=
 github.com/juju/charm/v9 v9.0.0-20210421060150-6a300db18162/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
 github.com/juju/charm/v9 v9.0.0-20210427070932-bc9b40c9b0f4/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
-github.com/juju/charm/v9 v9.0.0-20210722104222-d3c79ce32e77 h1:yvqGk4cfK+T9FuCO2euIOEsnxBqiDcAl6yVvbot4K4A=
-github.com/juju/charm/v9 v9.0.0-20210722104222-d3c79ce32e77/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
+github.com/juju/charm/v9 v9.0.0-20210909151651-7e12eccc1e76 h1:p+2WvoV7paZIcwz2dhsDo8nP7A7OeCMItf1Mk+mwm4U=
+github.com/juju/charm/v9 v9.0.0-20210909151651-7e12eccc1e76/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
 github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae h1:TSnFigLC+7oV40UoyVjadtusvavzImpMl35kvAedFCg=
 github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae/go.mod h1:wvP5voVa8s9ap6FSwenJmxw2g5cf8aSgjE8N8LOEwKc=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=


### PR DESCRIPTION
The last bit of work related to the deploy by revision feature for charmhub charms.

Allow for a revision tag to be used in a bundle to deploy a charm.  If it's a charmhub charm, a channel is required.  Ensure that the revision tag is used in export-bundle.

## QA steps

```console
$ juju bootstrap localhost testme

# Setup a model
$ juju deploy ./tests/suites/deploy/bundles/telegraf_bundle.yaml
$ juju deploy juju-qa-test --revision 9 --channel 2.0/stable --resource foo-file=4
$ juju deploy ntp
$ juju add-relation ntp ubuntu

# Export the bundle
$ juju export-bundle > /tmp/test-bundle.yaml

# Try to deploy it a 2nd time, to verify the bundle is what's in the model.
$ juju deploy /tmp/test-bundle.yaml
.... 
No changes to apply.

# To test upgrade via bundle, setup a new model and deploy the exported bundle.
$ juju add-model eight
$ juju deploy /tmp/test-bundle.yaml

# verify the default model has the same contents as model eight.

# Edit /tmp/test-bundle.yaml removing the following lines:
      revision: 22
      revision: 18
# Causing both the influx-db and ubuntu charms to upgrade when the bundle is run a 2nd time.
$ juju deploy /tmp/test-bundle.yaml
...
Executing changes:
- upload charm ubuntu from charm-hub for series bionic from channel stable with architecture=amd64
- upload charm influxdb from charm-store for series bionic from channel stable with architecture=amd64
- upgrade ubuntu from charm-hub using charm ubuntu for series bionic from channel stable
- upgrade influxdb from charm-store using charm influxdb for series bionic from channel stable
Deploy of bundle completed.
```
