### PR TITLE
Fix assess_upgrade_series again

### DIFF
--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -78,9 +78,7 @@ def reboot_machine(client, machine):
     try:
         client.juju('ssh', (machine, 'sudo shutdown -r now'))
     except subprocess.CalledProcessError as e:
-        if e.returncode != 255:
-            raise e
-        log.info("Ignoring `juju ssh` exit status after triggering reboot")
+        log.info("Ignoring `juju ssh` exit code {} after triggering reboot".format(e.returncode))
 
     log.info("waiting for reboot")
     hostname = client.get_status().get_machine_dns_name(machine)

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -20,7 +20,7 @@ VERBOSE=1
 RUN_ALL="false"
 SKIP_LIST=""
 RUN_LIST=""
-ARITFACT_FILE=""
+ARTIFACT_FILE=""
 OUTPUT_FILE=""
 
 import_subdir_files() {
@@ -160,7 +160,7 @@ while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
 		SKIP_LIST="${OPTARG}"
 		;;
 	a)
-		ARITFACT_FILE="${OPTARG}"
+		ARTIFACT_FILE="${OPTARG}"
 		;;
 	x)
 		OUTPUT_FILE="${OPTARG}"
@@ -279,19 +279,19 @@ cleanup() {
 	echo "==> TEST COMPLETE"
 }
 
-# Move any artifacts to the choosen location
+# Move any artifacts to the chosen location
 archive_logs() {
-	if [[ -z ${ARITFACT_FILE} ]]; then
+	if [[ -z ${ARTIFACT_FILE} ]]; then
 		return
 	fi
 
 	archive_type="${1}"
 
-	echo "==> Test ${archive_type} artifact: ${ARITFACT_FILE}"
+	echo "==> Test ${archive_type} artifact: ${ARTIFACT_FILE}"
 	if [[ -f ${OUTPUT_FILE} ]]; then
 		cp "${OUTPUT_FILE}" "${TEST_DIR}"
 	fi
-	TAR_OUTPUT=$(tar -C "${TEST_DIR}" --transform s/./artifacts/ -zcvf "${ARITFACT_FILE}" ./ 2>&1)
+	TAR_OUTPUT=$(tar -C "${TEST_DIR}" --transform s/./artifacts/ -zcvf "${ARTIFACT_FILE}" ./ 2>&1)
 	# shellcheck disable=SC2181
 	if [[ $? -eq 0 ]]; then
 		echo "==> Test ${archive_type} artifact: COMPLETED"


### PR DESCRIPTION
When running the series-upgrade acceptance test, just ignore whatever return code comes back from rebooting the machine via SSH. It is not the part that we should be hinging test failure on.

## QA steps

- With the appropriate virtualenv activated: `(cd acceptancetests ; ./assess upgrade_series --juju $YOUR-JUJU --logging-config '<root>=DEBUG')`
- You might see this output in the test logging:
```
ERROR subprocess encountered error code 255
2021-09-13 11:38:22 INFO Ignoring `juju ssh` exit code 1 after triggering reboot
```

## Documentation changes

None.

## Bug reference

N/A
