### PR TITLE
Protect fakeStatusAPI.errors from concurrent access

### DIFF
--- a/api/monitor_internal_test.go
+++ b/api/monitor_internal_test.go
@@ -19,9 +19,9 @@ var _ = gc.Suite(&MonitorSuite{})
 type MonitorSuite struct {
 	testing.IsolationSuite
 	clock   *testclock.Clock
-	closed  chan (struct{})
-	dead    chan (struct{})
-	broken  chan (struct{})
+	closed  chan struct{}
+	dead    chan struct{}
+	broken  chan struct{}
 	monitor *monitor
 }
 


### PR DESCRIPTION
Rewrites `TestGoodCallWatch` as `TestWatchUntilError` preventing the race seen here:
https://jenkins.juju.canonical.com/job/Unit-RunUnitTests-race-amd64/845/console

## QA steps

Run `MinimalStatusSuite` tests with `-race` in a loop. Observe no race detection.
