### PR TITLE
Lease Manager: Dropped Operation

### DIFF
--- a/core/lease/errors.go
+++ b/core/lease/errors.go
@@ -37,6 +37,11 @@ var (
 	// ErrAborted indicates that the stop channel returned before the operation
 	// succeeded or failed.
 	ErrAborted = errors.New("lease operation aborted")
+
+	// ErrDropped indicated that the underlying request was dropped. This is
+	// indicative of no valid connection to propagate the lease operation to
+	// the leader.
+	ErrDropped = errors.New("lease operation dropped")
 )
 
 // IsInvalid returns whether the specified error represents ErrInvalid
@@ -67,4 +72,10 @@ func IsAborted(err error) bool {
 // (even if it's wrapped).
 func IsNotHeld(err error) bool {
 	return errors.Cause(err) == ErrNotHeld
+}
+
+// IsDropped returns whether the specified error represents ErrErrDropped
+// (even if it's wrapped).
+func IsDropped(err error) bool {
+	return errors.Cause(err) == ErrDropped
 }

--- a/worker/lease/manager_claim_test.go
+++ b/worker/lease/manager_claim_test.go
@@ -295,6 +295,50 @@ func (s *ClaimSuite) TestExtendLease_Failure_OtherHolder(c *gc.C) {
 	})
 }
 
+func (s *ClaimSuite) TestExtendLease_Failure_Dropped(c *gc.C) {
+	fix := &Fixture{
+		leases: map[corelease.Key]corelease.Info{
+			key("redis"): {
+				Holder: "redis/0",
+				Expiry: offset(time.Second),
+			},
+		},
+		expectCalls: []call{{
+			method: "ExtendLease",
+			args: []interface{}{
+				corelease.Key{
+					Namespace: "namespace",
+					ModelUUID: "modelUUID",
+					Lease:     "redis",
+				},
+				corelease.Request{"redis/0", time.Minute},
+			},
+			err: corelease.ErrDropped,
+			callback: func(leases map[corelease.Key]corelease.Info) {
+				leases[key("redis")] = corelease.Info{
+					Holder: "redis/1",
+					Expiry: offset(time.Second),
+				}
+			},
+		}},
+	}
+	fix.RunTest(c, func(manager *lease.Manager, clock *testclock.Clock) {
+		// When the Claim starts, it will first get a LeaseInvalid, it will then
+		// wait 50ms before trying again, since it is clear that our Leases map
+		// does not have the most up-to-date information. We then wake up again
+		// and see that our leases have expired and thus let things go.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			err := getClaimer(c, manager).Claim("redis", "redis/0", time.Minute)
+			c.Check(err, gc.Equals, corelease.ErrClaimDenied)
+			wg.Done()
+		}()
+		c.Check(clock.WaitAdvance(50*time.Millisecond, testing.LongWait, 2), jc.ErrorIsNil)
+		wg.Wait()
+	})
+}
+
 func (s *ClaimSuite) TestExtendLease_Failure_Error(c *gc.C) {
 	fix := &Fixture{
 		leases: map[corelease.Key]corelease.Info{


### PR DESCRIPTION
The following exposes a dropped operation error inside the lease
manager. Both pubsub client and the new up and coming raft lease client
have the potential to drop requests.

The dropped requests are a manifestation of when a connection doesn't
exist to a remote server (controller). Attempting to connect to the
remote server in a ad hoc fashion (lazy), is problematic. The
operational lease generally have small timeouts (5 seconds) and
connection to a given remote server can extend up to minutes (worst
case). Instead we should allow the clients to setup a connection in the
background and if there isn't one return an error that the lease manager
can work with. The pubsub client will still silently drop operations and
return nil, a timeout waiting for the result then be trigger as there
isn't a way to apply back pressure easily. Future PRs will address the
ErrDropped by applying more delay, to ensure that the lease manager
isn't requesting leases on a leader with no connection.

The code for this PR is simple, introduce a new sentinel error and
handle the result of the error in the lease manager. As nothing is
triggering this error atm, it shouldn't impact any running operations.

## QA steps

Test pass, along with enabling HA

```sh
$ juju bootstrap lxd test
$ juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE;juju.worker.raft=TRACE"
$ juju enable-ha
$ juju debug-log -m controller
```
