### PR TITLE
Raft queue: Blocking queue

### DIFF
--- a/worker/raft/queue/blockingqueue.go
+++ b/worker/raft/queue/blockingqueue.go
@@ -1,0 +1,67 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package queue
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/errors"
+)
+
+// Operation holds the operations that a queue can hold.
+type Operation struct {
+	Command []byte
+	Timeout time.Duration
+}
+
+// BlockingOpQueue holds the operations in a blocking queue. The purpose of this
+// queue is to allow the backing off of operations at the source of enqueueing,
+// and not at the consuming of the queue.
+type BlockingOpQueue struct {
+	queue chan Operation
+	err   chan error
+}
+
+// NewBlockingOpQueue creates a new BlockingOpQueue.
+func NewBlockingOpQueue() *BlockingOpQueue {
+	return &BlockingOpQueue{
+		queue: make(chan Operation),
+		err:   make(chan error),
+	}
+}
+
+// Enqueue will add an operation to the queue. As this is a blocking queue, any
+// additional enqueue operations will block and wait for subsequent operations
+// to be completed.
+// The design of this is to ensure that people calling this will have to
+// correctly handle backing off from enqueueing.
+func (q *BlockingOpQueue) Enqueue(ctx context.Context, op Operation) error {
+	// Block adding the operation to the queue, but if the timeout happens
+	// before then, bail out.
+	select {
+	case q.queue <- op:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Block on the resulting error from the queue.
+	select {
+	case err := <-q.err:
+		return errors.Trace(err)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Queue returns the queue of operations. Removing an item from the channel
+// will unblock to allow another to take it's place.
+func (q *BlockingOpQueue) Queue() <-chan Operation {
+	return q.queue
+}
+
+// Error places the resulting error for the enqueue to pick it up.
+func (q *BlockingOpQueue) Error() chan<- error {
+	return q.err
+}

--- a/worker/raft/queue/blockingqueue_test.go
+++ b/worker/raft/queue/blockingqueue_test.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/clock"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -22,158 +22,95 @@ type BlockingOpQueueSuite struct {
 var _ = gc.Suite(&BlockingOpQueueSuite{})
 
 func (s *BlockingOpQueueSuite) TestEnqueue(c *gc.C) {
-	queue := NewBlockingOpQueue(clock.WallClock)
+	now := time.Now()
+	queue := NewBlockingOpQueue(testclock.NewClock(now))
 
-	go func() {
-		for op := range queue.Queue() {
-			c.Assert(op.Command, gc.DeepEquals, []byte("abc"))
-			queue.Error() <- nil
-
-			break
-		}
-	}()
+	results := consumeN(c, queue, 1)
 
 	err := queue.Enqueue(Operation{
-		Command:  []byte("abc"),
-		Deadline: clock.WallClock.Now().Add(time.Second),
+		Command:  opName(0),
+		Deadline: now.Add(time.Second),
 	})
 	c.Assert(err, jc.ErrorIsNil)
+
+	var count int
+	for result := range results {
+		c.Assert(result, gc.DeepEquals, opName(count))
+		count++
+	}
+	c.Assert(count, gc.Equals, 1)
 }
 
 func (s *BlockingOpQueueSuite) TestEnqueueWithError(c *gc.C) {
-	queue := NewBlockingOpQueue(clock.WallClock)
+	now := time.Now()
+	queue := NewBlockingOpQueue(testclock.NewClock(now))
 
-	var (
-		mutex   sync.Mutex
-		results []string
-	)
-
-	go func() {
-		for op := range queue.Queue() {
-			mutex.Lock()
-			results = append(results, string(op.Command))
-			mutex.Unlock()
-
-			queue.Error() <- errors.New("boom")
-			break
-		}
-	}()
+	results := consumeNUntilErr(c, queue, 1, errors.New("boom"))
 
 	err := queue.Enqueue(Operation{
-		Command:  []byte("abc"),
-		Deadline: clock.WallClock.Now().Add(time.Second),
+		Command:  opName(0),
+		Deadline: now.Add(time.Second),
 	})
 	c.Assert(err, gc.ErrorMatches, `boom`)
 
-	mutex.Lock()
-	defer mutex.Unlock()
-	c.Assert(results, jc.DeepEquals, []string{"abc"})
+	var count int
+	for result := range results {
+		c.Assert(result, gc.DeepEquals, opName(count))
+		count++
+	}
+	c.Assert(count, gc.Equals, 1)
 }
 
 func (s *BlockingOpQueueSuite) TestEnqueueTimesout(c *gc.C) {
-	queue := NewBlockingOpQueue(clock.WallClock)
-
-	var (
-		mutex   sync.Mutex
-		results []string
-	)
+	now := time.Now()
+	clock := testclock.NewClock(now)
+	queue := NewBlockingOpQueue(clock)
 
 	go func() {
-		var count int
-		for op := range queue.Queue() {
-			mutex.Lock()
-			results = append(results, string(op.Command))
-			mutex.Unlock()
-
-			queue.Error() <- nil
-
-			count++
-			switch count {
-			case 1:
-				time.Sleep(time.Millisecond * 500)
-			case 2:
-				return
-			}
-		}
+		c.Assert(clock.WaitAdvance(time.Millisecond, testing.ShortWait, 1), jc.ErrorIsNil)
 	}()
 
 	err := queue.Enqueue(Operation{
 		Command:  []byte("abc-1"),
-		Deadline: clock.WallClock.Now().Add(time.Second),
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = queue.Enqueue(Operation{
-		Command:  []byte("abc-2"),
-		Deadline: clock.WallClock.Now().Add(time.Millisecond),
+		Deadline: now.Add(time.Nanosecond),
 	})
 	c.Assert(err, gc.ErrorMatches, `deadline exceeded`)
-
-	mutex.Lock()
-	defer mutex.Unlock()
-	c.Assert(results, jc.DeepEquals, []string{"abc-1"})
 }
 
 func (s *BlockingOpQueueSuite) TestMultipleEnqueue(c *gc.C) {
-	queue := NewBlockingOpQueue(clock.WallClock)
+	now := time.Now()
+	queue := NewBlockingOpQueue(testclock.NewClock(now))
 
-	var (
-		mutex   sync.Mutex
-		results []string
-	)
-
-	cmd := func(i int) []byte {
-		return []byte(fmt.Sprintf("abc-%d", i))
-	}
-
-	go func() {
-		var count int
-		for op := range queue.Queue() {
-			mutex.Lock()
-			results = append(results, string(op.Command))
-			mutex.Unlock()
-			queue.Error() <- nil
-
-			count++
-
-			if count == 2 {
-				break
-			}
-		}
-	}()
+	results := consumeN(c, queue, 2)
 
 	for i := 0; i < 2; i++ {
 		err := queue.Enqueue(Operation{
-			Command:  cmd(i),
-			Deadline: clock.WallClock.Now().Add(time.Second),
+			Command:  opName(i),
+			Deadline: now.Add(time.Second),
 		})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	mutex.Lock()
-	defer mutex.Unlock()
-	c.Assert(results, jc.DeepEquals, []string{"abc-0", "abc-1"})
+	var count int
+	for result := range results {
+		c.Assert(result, gc.DeepEquals, opName(count))
+		count++
+	}
+	c.Assert(count, gc.Equals, 2)
 }
 
 func (s *BlockingOpQueueSuite) TestMultipleEnqueueWithErrors(c *gc.C) {
-	queue := NewBlockingOpQueue(clock.WallClock)
+	now := time.Now()
+	clock := testclock.NewClock(now)
+	queue := NewBlockingOpQueue(clock)
 
-	var (
-		mutex   sync.Mutex
-		results []string
-	)
-
-	cmd := func(i int) []byte {
-		return []byte(fmt.Sprintf("abc-%d", i))
-	}
-
+	results := make(chan []byte, 3)
 	go func() {
+		defer close(results)
+
 		var count int
 		for op := range queue.Queue() {
-			mutex.Lock()
-			results = append(results, string(op.Command))
-			mutex.Unlock()
-
+			results <- op.Command
 			queue.Error() <- nil
 
 			count++
@@ -188,55 +125,50 @@ func (s *BlockingOpQueueSuite) TestMultipleEnqueueWithErrors(c *gc.C) {
 	}()
 
 	err := queue.Enqueue(Operation{
-		Command:  cmd(0),
-		Deadline: clock.WallClock.Now().Add(time.Second),
+		Command:  opName(0),
+		Deadline: now.Add(time.Nanosecond),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		c.Assert(clock.WaitAdvance(time.Millisecond, testing.ShortWait, 2), jc.ErrorIsNil)
+	}()
+
 	// Fail this one
 	err = queue.Enqueue(Operation{
-		Command:  cmd(1),
-		Deadline: clock.WallClock.Now().Add(time.Millisecond),
+		Command:  opName(1),
+		Deadline: now.Add(time.Nanosecond),
 	})
 	c.Assert(err, gc.ErrorMatches, `deadline exceeded`)
 
 	err = queue.Enqueue(Operation{
-		Command:  cmd(2),
-		Deadline: clock.WallClock.Now().Add(time.Second),
+		Command:  opName(2),
+		Deadline: now.Add(time.Millisecond * 100),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	mutex.Lock()
-	defer mutex.Unlock()
-	c.Assert(results, jc.DeepEquals, []string{"abc-0", "abc-2"})
+	var received []string
+	for result := range results {
+		received = append(received, string(result))
+	}
+	c.Assert(len(received), gc.Equals, 2)
+	c.Assert(received, gc.DeepEquals, []string{
+		"abc-0", "abc-2",
+	})
+
+	// Ensure that we actually did advance correctly.
+	wg.Wait()
 }
 
 func (s *BlockingOpQueueSuite) TestMultipleEnqueues(c *gc.C) {
-	queue := NewBlockingOpQueue(clock.WallClock)
+	now := time.Now()
+	queue := NewBlockingOpQueue(testclock.NewClock(now))
 
-	var (
-		mutex   sync.Mutex
-		results []string
-	)
-
-	cmd := func(i int) []byte {
-		return []byte(fmt.Sprintf("abc-%d", i))
-	}
-
-	go func() {
-		for op := range queue.Queue() {
-			mutex.Lock()
-			results = append(results, string(op.Command))
-			num := len(results)
-			mutex.Unlock()
-
-			queue.Error() <- nil
-
-			if num > 10 {
-				break
-			}
-		}
-	}()
+	results := consumeN(c, queue, 10)
 
 	var wg sync.WaitGroup
 	wg.Add(10)
@@ -245,16 +177,63 @@ func (s *BlockingOpQueueSuite) TestMultipleEnqueues(c *gc.C) {
 			defer wg.Done()
 
 			err := queue.Enqueue(Operation{
-				Command:  cmd(i),
-				Deadline: clock.WallClock.Now().Add(time.Second),
+				Command:  opName(i),
+				Deadline: now.Add(time.Second),
 			})
 			c.Assert(err, jc.ErrorIsNil)
 		}(i)
 	}
 	wg.Wait()
 
-	c.Assert(results, jc.SameContents, []string{
+	var received []string
+	for result := range results {
+		received = append(received, string(result))
+	}
+	c.Assert(len(received), gc.Equals, 10)
+	c.Assert(received, jc.SameContents, []string{
 		"abc-0", "abc-1", "abc-2", "abc-3", "abc-4",
 		"abc-5", "abc-6", "abc-7", "abc-8", "abc-9",
 	})
+}
+
+func opName(i int) []byte {
+	return []byte(fmt.Sprintf("abc-%d", i))
+}
+
+func consumeN(c *gc.C, queue *BlockingOpQueue, n int) <-chan []byte {
+	return consumeNUntilErr(c, queue, n, nil)
+}
+
+func consumeNUntilErr(c *gc.C, queue *BlockingOpQueue, n int, err error) <-chan []byte {
+	results := make(chan []byte, n)
+
+	go func() {
+		defer close(results)
+
+		var count int
+		for op := range queue.Queue() {
+			select {
+			case results <- op.Command:
+			case <-time.After(testing.LongWait):
+				c.Fatal("timed out setting results")
+			}
+
+			count++
+			var e error
+			if count == n {
+				e = err
+			}
+			select {
+			case queue.Error() <- e:
+			case <-time.After(testing.LongWait):
+				c.Fatal("timed out setting error")
+			}
+
+			if count == n {
+				break
+			}
+		}
+	}()
+
+	return results
 }

--- a/worker/raft/queue/blockingqueue_test.go
+++ b/worker/raft/queue/blockingqueue_test.go
@@ -4,12 +4,12 @@
 package queue
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -22,7 +22,7 @@ type BlockingOpQueueSuite struct {
 var _ = gc.Suite(&BlockingOpQueueSuite{})
 
 func (s *BlockingOpQueueSuite) TestEnqueue(c *gc.C) {
-	queue := NewBlockingOpQueue()
+	queue := NewBlockingOpQueue(clock.WallClock)
 
 	go func() {
 		for op := range queue.Queue() {
@@ -33,14 +33,15 @@ func (s *BlockingOpQueueSuite) TestEnqueue(c *gc.C) {
 		}
 	}()
 
-	err := queue.Enqueue(context.TODO(), Operation{
-		Command: []byte("abc"),
+	err := queue.Enqueue(Operation{
+		Command:  []byte("abc"),
+		Deadline: clock.WallClock.Now().Add(time.Second),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *BlockingOpQueueSuite) TestEnqueueWithError(c *gc.C) {
-	queue := NewBlockingOpQueue()
+	queue := NewBlockingOpQueue(clock.WallClock)
 
 	var (
 		mutex   sync.Mutex
@@ -58,8 +59,9 @@ func (s *BlockingOpQueueSuite) TestEnqueueWithError(c *gc.C) {
 		}
 	}()
 
-	err := queue.Enqueue(context.TODO(), Operation{
-		Command: []byte("abc"),
+	err := queue.Enqueue(Operation{
+		Command:  []byte("abc"),
+		Deadline: clock.WallClock.Now().Add(time.Second),
 	})
 	c.Assert(err, gc.ErrorMatches, `boom`)
 
@@ -69,29 +71,51 @@ func (s *BlockingOpQueueSuite) TestEnqueueWithError(c *gc.C) {
 }
 
 func (s *BlockingOpQueueSuite) TestEnqueueTimesout(c *gc.C) {
-	queue := NewBlockingOpQueue()
+	queue := NewBlockingOpQueue(clock.WallClock)
+
+	var (
+		mutex   sync.Mutex
+		results []string
+	)
 
 	go func() {
+		var count int
 		for op := range queue.Queue() {
-			c.Assert(op.Command, gc.DeepEquals, []byte("abc"))
-			time.Sleep(time.Millisecond * 500)
+			mutex.Lock()
+			results = append(results, string(op.Command))
+			mutex.Unlock()
+
 			queue.Error() <- nil
 
-			break
+			count++
+			switch count {
+			case 1:
+				time.Sleep(time.Millisecond * 500)
+			case 2:
+				return
+			}
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond)
-	defer cancel()
-
-	err := queue.Enqueue(ctx, Operation{
-		Command: []byte("abc"),
+	err := queue.Enqueue(Operation{
+		Command:  []byte("abc-1"),
+		Deadline: clock.WallClock.Now().Add(time.Second),
 	})
-	c.Assert(err, gc.ErrorMatches, `context deadline exceeded`)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = queue.Enqueue(Operation{
+		Command:  []byte("abc-2"),
+		Deadline: clock.WallClock.Now().Add(time.Millisecond),
+	})
+	c.Assert(err, gc.ErrorMatches, `deadline exceeded`)
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	c.Assert(results, jc.DeepEquals, []string{"abc-1"})
 }
 
 func (s *BlockingOpQueueSuite) TestMultipleEnqueue(c *gc.C) {
-	queue := NewBlockingOpQueue()
+	queue := NewBlockingOpQueue(clock.WallClock)
 
 	var (
 		mutex   sync.Mutex
@@ -119,8 +143,9 @@ func (s *BlockingOpQueueSuite) TestMultipleEnqueue(c *gc.C) {
 	}()
 
 	for i := 0; i < 2; i++ {
-		err := queue.Enqueue(context.TODO(), Operation{
-			Command: cmd(i),
+		err := queue.Enqueue(Operation{
+			Command:  cmd(i),
+			Deadline: clock.WallClock.Now().Add(time.Second),
 		})
 		c.Assert(err, jc.ErrorIsNil)
 	}
@@ -131,7 +156,7 @@ func (s *BlockingOpQueueSuite) TestMultipleEnqueue(c *gc.C) {
 }
 
 func (s *BlockingOpQueueSuite) TestMultipleEnqueueWithErrors(c *gc.C) {
-	queue := NewBlockingOpQueue()
+	queue := NewBlockingOpQueue(clock.WallClock)
 
 	var (
 		mutex   sync.Mutex
@@ -152,31 +177,32 @@ func (s *BlockingOpQueueSuite) TestMultipleEnqueueWithErrors(c *gc.C) {
 			queue.Error() <- nil
 
 			count++
-			if count == 1 {
+			switch count {
+			case 1:
 				time.Sleep(time.Millisecond * 500)
 				count++
-			}
-			if count == 3 {
-				break
+			case 3:
+				return
 			}
 		}
 	}()
 
-	err := queue.Enqueue(context.TODO(), Operation{
-		Command: cmd(0),
+	err := queue.Enqueue(Operation{
+		Command:  cmd(0),
+		Deadline: clock.WallClock.Now().Add(time.Second),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Fail this one
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond)
-	defer cancel()
-	err = queue.Enqueue(ctx, Operation{
-		Command: cmd(1),
+	err = queue.Enqueue(Operation{
+		Command:  cmd(1),
+		Deadline: clock.WallClock.Now().Add(time.Millisecond),
 	})
-	c.Assert(err, gc.ErrorMatches, `context deadline exceeded`)
+	c.Assert(err, gc.ErrorMatches, `deadline exceeded`)
 
-	err = queue.Enqueue(context.TODO(), Operation{
-		Command: cmd(2),
+	err = queue.Enqueue(Operation{
+		Command:  cmd(2),
+		Deadline: clock.WallClock.Now().Add(time.Second),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -186,7 +212,7 @@ func (s *BlockingOpQueueSuite) TestMultipleEnqueueWithErrors(c *gc.C) {
 }
 
 func (s *BlockingOpQueueSuite) TestMultipleEnqueues(c *gc.C) {
-	queue := NewBlockingOpQueue()
+	queue := NewBlockingOpQueue(clock.WallClock)
 
 	var (
 		mutex   sync.Mutex
@@ -218,8 +244,9 @@ func (s *BlockingOpQueueSuite) TestMultipleEnqueues(c *gc.C) {
 		go func(i int) {
 			defer wg.Done()
 
-			err := queue.Enqueue(context.TODO(), Operation{
-				Command: cmd(i),
+			err := queue.Enqueue(Operation{
+				Command:  cmd(i),
+				Deadline: clock.WallClock.Now().Add(time.Second),
 			})
 			c.Assert(err, jc.ErrorIsNil)
 		}(i)

--- a/worker/raft/queue/blockingqueue_test.go
+++ b/worker/raft/queue/blockingqueue_test.go
@@ -1,0 +1,233 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package queue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type BlockingOpQueueSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&BlockingOpQueueSuite{})
+
+func (s *BlockingOpQueueSuite) TestEnqueue(c *gc.C) {
+	queue := NewBlockingOpQueue()
+
+	go func() {
+		for op := range queue.Queue() {
+			c.Assert(op.Command, gc.DeepEquals, []byte("abc"))
+			queue.Error() <- nil
+
+			break
+		}
+	}()
+
+	err := queue.Enqueue(context.TODO(), Operation{
+		Command: []byte("abc"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BlockingOpQueueSuite) TestEnqueueWithError(c *gc.C) {
+	queue := NewBlockingOpQueue()
+
+	var (
+		mutex   sync.Mutex
+		results []string
+	)
+
+	go func() {
+		for op := range queue.Queue() {
+			mutex.Lock()
+			results = append(results, string(op.Command))
+			mutex.Unlock()
+
+			queue.Error() <- errors.New("boom")
+			break
+		}
+	}()
+
+	err := queue.Enqueue(context.TODO(), Operation{
+		Command: []byte("abc"),
+	})
+	c.Assert(err, gc.ErrorMatches, `boom`)
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	c.Assert(results, jc.DeepEquals, []string{"abc"})
+}
+
+func (s *BlockingOpQueueSuite) TestEnqueueTimesout(c *gc.C) {
+	queue := NewBlockingOpQueue()
+
+	go func() {
+		for op := range queue.Queue() {
+			c.Assert(op.Command, gc.DeepEquals, []byte("abc"))
+			time.Sleep(time.Millisecond * 500)
+			queue.Error() <- nil
+
+			break
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond)
+	defer cancel()
+
+	err := queue.Enqueue(ctx, Operation{
+		Command: []byte("abc"),
+	})
+	c.Assert(err, gc.ErrorMatches, `context deadline exceeded`)
+}
+
+func (s *BlockingOpQueueSuite) TestMultipleEnqueue(c *gc.C) {
+	queue := NewBlockingOpQueue()
+
+	var (
+		mutex   sync.Mutex
+		results []string
+	)
+
+	cmd := func(i int) []byte {
+		return []byte(fmt.Sprintf("abc-%d", i))
+	}
+
+	go func() {
+		var count int
+		for op := range queue.Queue() {
+			mutex.Lock()
+			results = append(results, string(op.Command))
+			mutex.Unlock()
+			queue.Error() <- nil
+
+			count++
+
+			if count == 2 {
+				break
+			}
+		}
+	}()
+
+	for i := 0; i < 2; i++ {
+		err := queue.Enqueue(context.TODO(), Operation{
+			Command: cmd(i),
+		})
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	c.Assert(results, jc.DeepEquals, []string{"abc-0", "abc-1"})
+}
+
+func (s *BlockingOpQueueSuite) TestMultipleEnqueueWithErrors(c *gc.C) {
+	queue := NewBlockingOpQueue()
+
+	var (
+		mutex   sync.Mutex
+		results []string
+	)
+
+	cmd := func(i int) []byte {
+		return []byte(fmt.Sprintf("abc-%d", i))
+	}
+
+	go func() {
+		var count int
+		for op := range queue.Queue() {
+			mutex.Lock()
+			results = append(results, string(op.Command))
+			mutex.Unlock()
+
+			queue.Error() <- nil
+
+			count++
+			if count == 1 {
+				time.Sleep(time.Millisecond * 500)
+				count++
+			}
+			if count == 3 {
+				break
+			}
+		}
+	}()
+
+	err := queue.Enqueue(context.TODO(), Operation{
+		Command: cmd(0),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Fail this one
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond)
+	defer cancel()
+	err = queue.Enqueue(ctx, Operation{
+		Command: cmd(1),
+	})
+	c.Assert(err, gc.ErrorMatches, `context deadline exceeded`)
+
+	err = queue.Enqueue(context.TODO(), Operation{
+		Command: cmd(2),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	c.Assert(results, jc.DeepEquals, []string{"abc-0", "abc-2"})
+}
+
+func (s *BlockingOpQueueSuite) TestMultipleEnqueues(c *gc.C) {
+	queue := NewBlockingOpQueue()
+
+	var (
+		mutex   sync.Mutex
+		results []string
+	)
+
+	cmd := func(i int) []byte {
+		return []byte(fmt.Sprintf("abc-%d", i))
+	}
+
+	go func() {
+		for op := range queue.Queue() {
+			mutex.Lock()
+			results = append(results, string(op.Command))
+			num := len(results)
+			mutex.Unlock()
+
+			queue.Error() <- nil
+
+			if num > 10 {
+				break
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			err := queue.Enqueue(context.TODO(), Operation{
+				Command: cmd(i),
+			})
+			c.Assert(err, jc.ErrorIsNil)
+		}(i)
+	}
+	wg.Wait()
+
+	c.Assert(results, jc.SameContents, []string{
+		"abc-0", "abc-1", "abc-2", "abc-3", "abc-4",
+		"abc-5", "abc-6", "abc-7", "abc-8", "abc-9",
+	})
+}

--- a/worker/raft/queue/package_test.go
+++ b/worker/raft/queue/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package queue
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/secretrotate/secretrotate_test.go
+++ b/worker/secretrotate/secretrotate_test.go
@@ -95,7 +95,7 @@ func (s *workerSuite) expectWorker() {
 	s.facade.EXPECT().WatchSecretsRotationChanges(s.config.SecretOwner.String()).Return(s.rotateWatcher, nil)
 	s.rotateWatcher.EXPECT().Changes().AnyTimes().Return(s.rotateConfigChanges)
 	s.rotateWatcher.EXPECT().Kill().MaxTimes(1)
-	s.rotateWatcher.EXPECT().Wait().Return(nil).MaxTimes(1)
+	s.rotateWatcher.EXPECT().Wait().Return(nil).MinTimes(1)
 }
 
 func (s *workerSuite) TestStartStop(c *gc.C) {


### PR DESCRIPTION
The following adds a blocking queue for apply raft commands. The queue
is a blocking queue to force back pressure on to the enqueuing side.
This is the opposite of the current implementation of applying raft
leases, where the pubsub client can't doesn't apply back pressure for
all applications, as the very nature is fire and forget. Workarounds for
this including subscribing to a one of event topic to see the result,
although that takes a lot of time to wait for the result.

The code is simple, wrap two channels, that allow the enqueuing of
operations and wait for the error channel for the result. It's then up
to the raft worker (to be following in another commit) to consume the
queue and to enqueue the error accordingly.

## QA steps

Test pass.
