### PR TITLE
Ensure secrets worker and facade are set up properly on k8s.

### DIFF
--- a/apiserver/facades/agent/secretsmanager/access.go
+++ b/apiserver/facades/agent/secretsmanager/access.go
@@ -4,34 +4,19 @@
 package secretsmanager
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/facade"
 )
 
-func secretAccessor(authorizer facade.Authorizer) common.GetAuthFunc {
+func secretAccessor(agentAppName string) common.GetAuthFunc {
 	return func() (common.AuthFunc, error) {
-		switch tag := authorizer.GetAuthTag().(type) {
-		case names.UnitTag:
-			return unitAgentSecretAccessor(tag)
-		default:
-			return nil, errors.Errorf("expected names.UnitTag, got %T", tag)
-		}
+		return func(secretOwnerTag names.Tag) bool {
+			// We currently only support secrets owned by applications.
+			if secretOwnerTag.Kind() != names.ApplicationTagKind {
+				return false
+			}
+			return agentAppName == secretOwnerTag.Id()
+		}, nil
 	}
-}
-
-func unitAgentSecretAccessor(unitTag names.UnitTag) (common.AuthFunc, error) {
-	return func(ownerTag names.Tag) bool {
-		switch ownerTag.Kind() {
-		case names.ApplicationTagKind:
-			appName, err := names.UnitApplication(unitTag.Id())
-			return err == nil && appName == ownerTag.Id()
-		case names.UnitTagKind:
-			return unitTag.Id() == ownerTag.Id()
-		default:
-			return false
-		}
-	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -30,13 +30,14 @@ func NewTestAPI(
 	service secrets.SecretsService,
 	secretsWatcher SecretsWatcher,
 	accessSecret common.GetAuthFunc,
+	ownerTag names.Tag,
 ) (*SecretsManagerAPI, error) {
-	if !authorizer.AuthUnitAgent() {
+	if !authorizer.AuthUnitAgent() && !authorizer.AuthApplicationAgent() {
 		return nil, apiservererrors.ErrPerm
 	}
 
 	return &SecretsManagerAPI{
-		authOwner:      names.NewApplicationTag("app"),
+		authOwner:      ownerTag,
 		controllerUUID: coretesting.ControllerTag.Id(),
 		modelUUID:      coretesting.ModelTag.Id(),
 		resources:      resources,

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39972,7 +39972,10 @@
         "Description": "SecretsManagerAPI is the implementation for the SecretsManager facade.",
         "Version": 1,
         "AvailableTo": [
-            "unit-agent"
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
         ],
         "Schema": {
             "type": "object",

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	apileadership "github.com/juju/juju/api/leadership"
+	"github.com/juju/juju/api/secretsmanager"
 	apiuniter "github.com/juju/juju/api/uniter"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
@@ -32,6 +33,7 @@ import (
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/leadership"
+	"github.com/juju/juju/worker/secretrotate"
 	"github.com/juju/juju/worker/uniter"
 	"github.com/juju/juju/worker/uniter/charm"
 	"github.com/juju/juju/worker/uniter/operation"
@@ -192,6 +194,18 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				}
 			}
 
+			secretRotateWatcherFunc := func(unitTag names.UnitTag, rotateSecrets chan []string) (worker.Worker, error) {
+				client := secretsmanager.NewClient(apiCaller)
+				appName, _ := names.UnitApplication(unitTag.Id())
+				return secretrotate.New(secretrotate.Config{
+					SecretManagerFacade: client,
+					Clock:               clock,
+					Logger:              config.Logger.Child("secretsrotate"),
+					SecretOwner:         names.NewApplicationTag(appName),
+					RotateSecrets:       rotateSecrets,
+				})
+			}
+
 			wCfg := Config{
 				Logger:                config.Logger,
 				ModelUUID:             agentConfig.Model().Id(),
@@ -227,17 +241,18 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			wCfg.OperatorInfo = *operatorInfo
 			wCfg.UniterParams = &uniter.UniterParams{
-				NewOperationExecutor: operation.NewExecutor,
-				NewDeployer:          charm.NewDeployer,
-				NewProcessRunner:     runner.NewRunner,
-				DataDir:              agentConfig.DataDir(),
-				Clock:                clock,
-				MachineLock:          config.MachineLock,
-				CharmDirGuard:        charmDirGuard,
-				UpdateStatusSignal:   uniter.NewUpdateStatusTimer(),
-				HookRetryStrategy:    hookRetryStrategy,
-				TranslateResolverErr: config.TranslateResolverErr,
-				Logger:               wCfg.Logger.Child("uniter"),
+				NewOperationExecutor:    operation.NewExecutor,
+				NewDeployer:             charm.NewDeployer,
+				NewProcessRunner:        runner.NewRunner,
+				DataDir:                 agentConfig.DataDir(),
+				Clock:                   clock,
+				MachineLock:             config.MachineLock,
+				CharmDirGuard:           charmDirGuard,
+				UpdateStatusSignal:      uniter.NewUpdateStatusTimer(),
+				HookRetryStrategy:       hookRetryStrategy,
+				TranslateResolverErr:    config.TranslateResolverErr,
+				SecretRotateWatcherFunc: secretRotateWatcherFunc,
+				Logger:                  wCfg.Logger.Child("uniter"),
 			}
 			wCfg.UniterParams.SocketConfig, err = socketConfig(operatorInfo)
 			if err != nil {

--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -182,6 +182,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(config.UniterParams.NewOperationExecutor, gc.NotNil)
 	c.Assert(config.UniterParams.NewProcessRunner, gc.NotNil)
 	c.Assert(config.UniterParams.NewDeployer, gc.NotNil)
+	c.Assert(config.UniterParams.SecretRotateWatcherFunc, gc.NotNil)
 	c.Assert(config.Logger, gc.NotNil)
 	c.Assert(config.ExecClientGetter, gc.NotNil)
 	config.LeadershipTrackerFunc = nil
@@ -192,6 +193,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.UniterParams.NewOperationExecutor = nil
 	config.UniterParams.NewDeployer = nil
 	config.UniterParams.NewProcessRunner = nil
+	config.UniterParams.SecretRotateWatcherFunc = nil
 	config.Logger = nil
 	config.ExecClientGetter = nil
 


### PR DESCRIPTION
The k8s operator agent was missing initialisation for the secrets rotation watcher, causing a nil pointer error when deploying an operator k8s charm.. The UniterParams attribute for the k8s agent is now configured the same way it is done for IAAS models.

Also, the auth for the secretsmanager facade is updated to deal with k8s operator agents. Sidecar charms are not affected.

## QA steps

bootstrap k8s and deploy an operator charm
check status