### PR TITLE
Fix pod-spec uniter exits on pending action op when remote caas container died

### DIFF
--- a/worker/uniter/actions/resolver_test.go
+++ b/worker/uniter/actions/resolver_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/worker/uniter/actions"
+	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/resolver"
@@ -115,6 +116,47 @@ func (s *actionsSuite) TestNextActionBlockedRemoteInit(c *gc.C) {
 	c.Assert(op, gc.IsNil)
 }
 
+func (s *actionsSuite) TestNextActionBlockedRemoteInitInProgress(c *gc.C) {
+	actionResolver := s.newResolver()
+	actionId := "actionB"
+	localState := resolver.LocalState{
+		State: operation.State{
+			Kind:     operation.RunAction,
+			ActionId: &actionId,
+		},
+		CompletedActions:    map[string]struct{}{"actionA": {}},
+		OutdatedRemoteCharm: true,
+	}
+	remoteState := remotestate.Snapshot{
+		ActionsPending: []string{"actionA", "actionB"},
+		ActionsBlocked: false,
+	}
+	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, gc.DeepEquals, mockFailAction("actionB"))
+}
+
+func (s *actionsSuite) TestNextActionBlockedRemoteInitSkipHook(c *gc.C) {
+	actionResolver := s.newResolver()
+	actionId := "actionBad"
+	localState := resolver.LocalState{
+		State: operation.State{
+			Kind:     operation.RunAction,
+			ActionId: &actionId,
+			Hook:     &hook.Info{Kind: "test"},
+		},
+		CompletedActions:    map[string]struct{}{"actionA": {}},
+		OutdatedRemoteCharm: false,
+	}
+	remoteState := remotestate.Snapshot{
+		ActionsPending: []string{"actionA", "actionB"},
+		ActionsBlocked: true,
+	}
+	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, gc.DeepEquals, mockSkipHook(*localState.Hook))
+}
+
 func (s *actionsSuite) TestActionStateKindRunAction(c *gc.C) {
 	actionResolver := s.newResolver()
 	var actionA string = "actionA"
@@ -132,6 +174,26 @@ func (s *actionsSuite) TestActionStateKindRunAction(c *gc.C) {
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op, jc.DeepEquals, mockOp("actionA"))
+}
+
+func (s *actionsSuite) TestActionStateKindRunActionSkipHook(c *gc.C) {
+	actionResolver := s.newResolver()
+	var actionA string = "actionA"
+
+	localState := resolver.LocalState{
+		State: operation.State{
+			Kind:     operation.RunAction,
+			ActionId: &actionA,
+			Hook:     &hook.Info{Kind: "test"},
+		},
+		CompletedActions: map[string]struct{}{},
+	}
+	remoteState := remotestate.Snapshot{
+		ActionsPending: []string{},
+	}
+	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, jc.DeepEquals, mockSkipHook(*localState.Hook))
 }
 
 func (s *actionsSuite) TestActionStateKindRunActionPendingRemote(c *gc.C) {
@@ -165,12 +227,20 @@ func (m *mockOperations) NewFailAction(id string) (operation.Operation, error) {
 	return mockFailAction(id), nil
 }
 
+func (m *mockOperations) NewSkipHook(hookInfo hook.Info) (operation.Operation, error) {
+	return mockSkipHook(hookInfo), nil
+}
+
 func mockOp(name string) operation.Operation {
 	return &mockOperation{name: name}
 }
 
 func mockFailAction(name string) operation.Operation {
 	return &mockFailOp{name: name}
+}
+
+func mockSkipHook(hookInfo hook.Info) operation.Operation {
+	return &mockSkipHookOp{hookInfo: hookInfo}
 }
 
 type mockOperation struct {
@@ -189,4 +259,13 @@ type mockFailOp struct {
 
 func (op *mockFailOp) String() string {
 	return op.name
+}
+
+type mockSkipHookOp struct {
+	operation.Operation
+	hookInfo hook.Info
+}
+
+func (op *mockSkipHookOp) String() string {
+	return string(op.hookInfo.Kind)
 }


### PR DESCRIPTION
Fixes issue where the uniter gets into a worker retry loop due to a pending run-action op but the remote caas container has gone away/upgraded. 

## QA steps

Get the workload pod of a pod-spec application in a CrashLoopBackOff
Run an action and watch the unit worker/caasoperator for:
```
application-coredns: 11:28:27 ERROR juju.worker.caasoperator.runner exited "coredns/2": unknown operation kind run-action
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1943776
