### PR TITLE
Filter on offer uuid when processing offer relations on removal of an offer

### DIFF
--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -499,6 +499,7 @@ func (s *applicationOffersSuite) addOfferConnection(c *gc.C, offerUUID string) *
 	app, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "wordpress",
 		SourceModel: testing.ModelTag,
+		OfferUUID:   offerUUID,
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Name:      "server",
@@ -668,7 +669,7 @@ func (s *applicationOffersSuite) TestRemoveOffersWithConnectionsForce(c *gc.C) {
 	rwordpress, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name:        "remote-wordpress",
 		SourceModel: names.NewModelTag("source-model"),
-		OfferUUID:   "offer-uuid",
+		OfferUUID:   offer.OfferUUID,
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Limit:     1,
@@ -706,6 +707,7 @@ func (s *applicationOffersSuite) TestRemoveOffersWithConnectionsForce(c *gc.C) {
 
 	s.addOfferConnection(c, offer.OfferUUID)
 	ao := state.NewApplicationOffers(s.State)
+
 	err = ao.Remove("hosted-mysql", true)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = ao.ApplicationOffer("hosted-mysql")
@@ -718,6 +720,35 @@ func (s *applicationOffersSuite) TestRemoveOffersWithConnectionsForce(c *gc.C) {
 	err = wordpress.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	assertLife(c, wordpress, state.Dying)
+}
+
+func (s *applicationOffersSuite) TestRemoveOneOfferSameApplication(c *gc.C) {
+	offer, owner := s.createOffer(c, "hosted-mysql", "offer one")
+	sd := state.NewApplicationOffers(s.State)
+	offerArgs := crossmodel.AddApplicationOfferArgs{
+		OfferName:              "mysql-admin",
+		ApplicationName:        "mysql",
+		ApplicationDescription: "mysql admin",
+		Endpoints:              map[string]string{"db-admin": "server-admin"},
+		Owner:                  owner,
+	}
+	offer2, err := sd.AddOffer(offerArgs)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.addOfferConnection(c, offer.OfferUUID)
+	ao := state.NewApplicationOffers(s.State)
+
+	err = ao.Remove(offer2.OfferName, false)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = ao.ApplicationOffer("mysql-admin")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	// The other offer is unaffected.
+	appOffer, err := ao.ApplicationOffer("hosted-mysql")
+	c.Assert(err, jc.ErrorIsNil)
+	conn, err := s.State.OfferConnections(appOffer.OfferUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(conn, gc.HasLen, 1)
 }
 
 func (s *applicationOffersSuite) TestRemovingApplicationFailsRace(c *gc.C) {


### PR DESCRIPTION
When removing an offer, we build up a list of txn ops to apply. If there's active relations to the offer, we return `ErrTransientFailure` to allow cleanup of those relations to complete. Except that we weren't matching on offer uuid and so if the offer were one of many to a given application, the txn logic would fail with a "state changing too quickly" error.

This PR simply adds the missing check, and also does some error processing in the operation `Done` method to give some extra context if there is a contention error.

## QA steps

deploy an application like mysql
create 2 offers, eg
juju offer mysql:db offer1
juju offer mysql:db-admin offer2

deploy mediawiki in another model and relate to the mysql offer1

remove the offer2
(this would have previously given an error)

## Bug reference

https://bugs.launchpad.net/juju/+bug/1873472
