### PR TITLE
new charmhub metrics: replace current method with new and use for current metrics.

### DIFF
--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -22,7 +22,7 @@ type ConfigModel interface {
 }
 
 // CharmhubClient creates a new charmhub Client based on this model's config.
-func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.Logger, metadata map[string]string) (*charmhub.Client, error) {
+func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.Logger) (*charmhub.Client, error) {
 	model, err := mg.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -34,7 +34,6 @@ func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.
 	url, _ := modelConfig.CharmHubURL()
 
 	config, err := charmhub.CharmHubConfigFromURL(url, logger,
-		charmhub.WithMetadataHeaders(metadata),
 		charmhub.WithHTTPTransport(func(charmhub.Logger) charmhub.Transport {
 			return httpClient
 		}),

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -826,10 +826,10 @@ func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 
 	s.ctrl = gomock.NewController(c)
 	charmhubClient := mocks.NewMockCharmhubRefreshClient(s.ctrl)
-	charmhubClient.EXPECT().Refresh(gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{
+	charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{
 		{Entity: transport.RefreshEntity{Revision: 42}},
 	}, nil)
-	newCharmhubClient := func(st charmrevisionupdater.State, metadata map[string]string) (charmrevisionupdater.CharmhubRefreshClient, error) {
+	newCharmhubClient := func(st charmrevisionupdater.State) (charmrevisionupdater.CharmhubRefreshClient, error) {
 		return charmhubClient, nil
 	}
 

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
+	"github.com/juju/juju/core/charm/metrics"
 )
 
 // charmhubID holds identifying information for several charms for a
@@ -40,12 +41,12 @@ type charmhubResult struct {
 // CharmhubRefreshClient is an interface for the methods of the charmhub
 // client that we need.
 type CharmhubRefreshClient interface {
-	Refresh(ctx context.Context, config charmhub.RefreshConfig) ([]transport.RefreshResponse, error)
+	RefreshWithRequestMetrics(ctx context.Context, config charmhub.RefreshConfig, metrics map[metrics.MetricKey]map[metrics.MetricKey]string) ([]transport.RefreshResponse, error)
 }
 
 // charmhubLatestCharmInfo fetches the latest information about the given
 // charms from charmhub's "charm_refresh" API.
-func charmhubLatestCharmInfo(client CharmhubRefreshClient, ids []charmhubID) ([]charmhubResult, error) {
+func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID) ([]charmhubResult, error) {
 	cfgs := make([]charmhub.RefreshConfig, len(ids))
 	for i, id := range ids {
 		base := charmhub.RefreshBase{
@@ -63,7 +64,7 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, ids []charmhubID) ([]
 
 	ctx, cancel := context.WithTimeout(context.TODO(), charmhub.RefreshTimeout)
 	defer cancel()
-	responses, err := client.Refresh(ctx, config)
+	responses, err := client.RefreshWithRequestMetrics(ctx, config, metrics)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/charmrevisionupdater/interface.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface.go
@@ -42,6 +42,7 @@ type Model interface {
 	CloudRegion() string
 	Config() (*config.Config, error)
 	IsControllerModel() bool
+	Metrics() (state.ModelMetrics, error)
 	UUID() string
 }
 

--- a/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
+++ b/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
@@ -6,6 +6,8 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v9"
 	params "github.com/juju/charmrepo/v7/csclient/params"
@@ -14,36 +16,36 @@ import (
 	transport "github.com/juju/juju/charmhub/transport"
 	cloud "github.com/juju/juju/cloud"
 	controller "github.com/juju/juju/controller"
+	metrics "github.com/juju/juju/core/charm/metrics"
 	config "github.com/juju/juju/environs/config"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockApplication is a mock of Application interface
+// MockApplication is a mock of Application interface.
 type MockApplication struct {
 	ctrl     *gomock.Controller
 	recorder *MockApplicationMockRecorder
 }
 
-// MockApplicationMockRecorder is the mock recorder for MockApplication
+// MockApplicationMockRecorder is the mock recorder for MockApplication.
 type MockApplicationMockRecorder struct {
 	mock *MockApplication
 }
 
-// NewMockApplication creates a new mock instance
+// NewMockApplication creates a new mock instance.
 func NewMockApplication(ctrl *gomock.Controller) *MockApplication {
 	mock := &MockApplication{ctrl: ctrl}
 	mock.recorder = &MockApplicationMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 	return m.recorder
 }
 
-// ApplicationTag mocks base method
+// ApplicationTag mocks base method.
 func (m *MockApplication) ApplicationTag() names.ApplicationTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationTag")
@@ -51,13 +53,13 @@ func (m *MockApplication) ApplicationTag() names.ApplicationTag {
 	return ret0
 }
 
-// ApplicationTag indicates an expected call of ApplicationTag
+// ApplicationTag indicates an expected call of ApplicationTag.
 func (mr *MockApplicationMockRecorder) ApplicationTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationTag", reflect.TypeOf((*MockApplication)(nil).ApplicationTag))
 }
 
-// Channel mocks base method
+// Channel mocks base method.
 func (m *MockApplication) Channel() params.Channel {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Channel")
@@ -65,13 +67,13 @@ func (m *MockApplication) Channel() params.Channel {
 	return ret0
 }
 
-// Channel indicates an expected call of Channel
+// Channel indicates an expected call of Channel.
 func (mr *MockApplicationMockRecorder) Channel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Channel", reflect.TypeOf((*MockApplication)(nil).Channel))
 }
 
-// CharmOrigin mocks base method
+// CharmOrigin mocks base method.
 func (m *MockApplication) CharmOrigin() *state.CharmOrigin {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmOrigin")
@@ -79,13 +81,13 @@ func (m *MockApplication) CharmOrigin() *state.CharmOrigin {
 	return ret0
 }
 
-// CharmOrigin indicates an expected call of CharmOrigin
+// CharmOrigin indicates an expected call of CharmOrigin.
 func (mr *MockApplicationMockRecorder) CharmOrigin() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmOrigin", reflect.TypeOf((*MockApplication)(nil).CharmOrigin))
 }
 
-// CharmURL mocks base method
+// CharmURL mocks base method.
 func (m *MockApplication) CharmURL() (*charm.URL, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
@@ -94,74 +96,74 @@ func (m *MockApplication) CharmURL() (*charm.URL, bool) {
 	return ret0, ret1
 }
 
-// CharmURL indicates an expected call of CharmURL
+// CharmURL indicates an expected call of CharmURL.
 func (mr *MockApplicationMockRecorder) CharmURL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockApplication)(nil).CharmURL))
 }
 
-// MockCharmhubRefreshClient is a mock of CharmhubRefreshClient interface
+// MockCharmhubRefreshClient is a mock of CharmhubRefreshClient interface.
 type MockCharmhubRefreshClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockCharmhubRefreshClientMockRecorder
 }
 
-// MockCharmhubRefreshClientMockRecorder is the mock recorder for MockCharmhubRefreshClient
+// MockCharmhubRefreshClientMockRecorder is the mock recorder for MockCharmhubRefreshClient.
 type MockCharmhubRefreshClientMockRecorder struct {
 	mock *MockCharmhubRefreshClient
 }
 
-// NewMockCharmhubRefreshClient creates a new mock instance
+// NewMockCharmhubRefreshClient creates a new mock instance.
 func NewMockCharmhubRefreshClient(ctrl *gomock.Controller) *MockCharmhubRefreshClient {
 	mock := &MockCharmhubRefreshClient{ctrl: ctrl}
 	mock.recorder = &MockCharmhubRefreshClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCharmhubRefreshClient) EXPECT() *MockCharmhubRefreshClientMockRecorder {
 	return m.recorder
 }
 
-// Refresh mocks base method
-func (m *MockCharmhubRefreshClient) Refresh(arg0 context.Context, arg1 charmhub.RefreshConfig) ([]transport.RefreshResponse, error) {
+// RefreshWithRequestMetrics mocks base method.
+func (m *MockCharmhubRefreshClient) RefreshWithRequestMetrics(arg0 context.Context, arg1 charmhub.RefreshConfig, arg2 map[metrics.MetricKey]map[metrics.MetricKey]string) ([]transport.RefreshResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh", arg0, arg1)
+	ret := m.ctrl.Call(m, "RefreshWithRequestMetrics", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]transport.RefreshResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Refresh indicates an expected call of Refresh
-func (mr *MockCharmhubRefreshClientMockRecorder) Refresh(arg0, arg1 interface{}) *gomock.Call {
+// RefreshWithRequestMetrics indicates an expected call of RefreshWithRequestMetrics.
+func (mr *MockCharmhubRefreshClientMockRecorder) RefreshWithRequestMetrics(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockCharmhubRefreshClient)(nil).Refresh), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshWithRequestMetrics", reflect.TypeOf((*MockCharmhubRefreshClient)(nil).RefreshWithRequestMetrics), arg0, arg1, arg2)
 }
 
-// MockModel is a mock of Model interface
+// MockModel is a mock of Model interface.
 type MockModel struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelMockRecorder
 }
 
-// MockModelMockRecorder is the mock recorder for MockModel
+// MockModelMockRecorder is the mock recorder for MockModel.
 type MockModelMockRecorder struct {
 	mock *MockModel
 }
 
-// NewMockModel creates a new mock instance
+// NewMockModel creates a new mock instance.
 func NewMockModel(ctrl *gomock.Controller) *MockModel {
 	mock := &MockModel{ctrl: ctrl}
 	mock.recorder = &MockModelMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModel) EXPECT() *MockModelMockRecorder {
 	return m.recorder
 }
 
-// CloudName mocks base method
+// CloudName mocks base method.
 func (m *MockModel) CloudName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudName")
@@ -169,13 +171,13 @@ func (m *MockModel) CloudName() string {
 	return ret0
 }
 
-// CloudName indicates an expected call of CloudName
+// CloudName indicates an expected call of CloudName.
 func (mr *MockModelMockRecorder) CloudName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudName", reflect.TypeOf((*MockModel)(nil).CloudName))
 }
 
-// CloudRegion mocks base method
+// CloudRegion mocks base method.
 func (m *MockModel) CloudRegion() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudRegion")
@@ -183,13 +185,13 @@ func (m *MockModel) CloudRegion() string {
 	return ret0
 }
 
-// CloudRegion indicates an expected call of CloudRegion
+// CloudRegion indicates an expected call of CloudRegion.
 func (mr *MockModelMockRecorder) CloudRegion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudRegion", reflect.TypeOf((*MockModel)(nil).CloudRegion))
 }
 
-// Config mocks base method
+// Config mocks base method.
 func (m *MockModel) Config() (*config.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
@@ -198,13 +200,13 @@ func (m *MockModel) Config() (*config.Config, error) {
 	return ret0, ret1
 }
 
-// Config indicates an expected call of Config
+// Config indicates an expected call of Config.
 func (mr *MockModelMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockModel)(nil).Config))
 }
 
-// IsControllerModel mocks base method
+// IsControllerModel mocks base method.
 func (m *MockModel) IsControllerModel() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsControllerModel")
@@ -212,13 +214,28 @@ func (m *MockModel) IsControllerModel() bool {
 	return ret0
 }
 
-// IsControllerModel indicates an expected call of IsControllerModel
+// IsControllerModel indicates an expected call of IsControllerModel.
 func (mr *MockModelMockRecorder) IsControllerModel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsControllerModel", reflect.TypeOf((*MockModel)(nil).IsControllerModel))
 }
 
-// UUID mocks base method
+// Metrics mocks base method.
+func (m *MockModel) Metrics() (state.ModelMetrics, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Metrics")
+	ret0, _ := ret[0].(state.ModelMetrics)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Metrics indicates an expected call of Metrics.
+func (mr *MockModelMockRecorder) Metrics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockModel)(nil).Metrics))
+}
+
+// UUID mocks base method.
 func (m *MockModel) UUID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UUID")
@@ -226,36 +243,36 @@ func (m *MockModel) UUID() string {
 	return ret0
 }
 
-// UUID indicates an expected call of UUID
+// UUID indicates an expected call of UUID.
 func (mr *MockModelMockRecorder) UUID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UUID", reflect.TypeOf((*MockModel)(nil).UUID))
 }
 
-// MockState is a mock of State interface
+// MockState is a mock of State interface.
 type MockState struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateMockRecorder
 }
 
-// MockStateMockRecorder is the mock recorder for MockState
+// MockStateMockRecorder is the mock recorder for MockState.
 type MockStateMockRecorder struct {
 	mock *MockState
 }
 
-// NewMockState creates a new mock instance
+// NewMockState creates a new mock instance.
 func NewMockState(ctrl *gomock.Controller) *MockState {
 	mock := &MockState{ctrl: ctrl}
 	mock.recorder = &MockStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AddCharmPlaceholder mocks base method
+// AddCharmPlaceholder mocks base method.
 func (m *MockState) AddCharmPlaceholder(arg0 *charm.URL) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddCharmPlaceholder", arg0)
@@ -263,13 +280,13 @@ func (m *MockState) AddCharmPlaceholder(arg0 *charm.URL) error {
 	return ret0
 }
 
-// AddCharmPlaceholder indicates an expected call of AddCharmPlaceholder
+// AddCharmPlaceholder indicates an expected call of AddCharmPlaceholder.
 func (mr *MockStateMockRecorder) AddCharmPlaceholder(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmPlaceholder", reflect.TypeOf((*MockState)(nil).AddCharmPlaceholder), arg0)
 }
 
-// AllApplications mocks base method
+// AllApplications mocks base method.
 func (m *MockState) AllApplications() ([]charmrevisionupdater.Application, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllApplications")
@@ -278,13 +295,13 @@ func (m *MockState) AllApplications() ([]charmrevisionupdater.Application, error
 	return ret0, ret1
 }
 
-// AllApplications indicates an expected call of AllApplications
+// AllApplications indicates an expected call of AllApplications.
 func (mr *MockStateMockRecorder) AllApplications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllApplications", reflect.TypeOf((*MockState)(nil).AllApplications))
 }
 
-// Charm mocks base method
+// Charm mocks base method.
 func (m *MockState) Charm(arg0 *charm.URL) (*state.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
@@ -293,13 +310,13 @@ func (m *MockState) Charm(arg0 *charm.URL) (*state.Charm, error) {
 	return ret0, ret1
 }
 
-// Charm indicates an expected call of Charm
+// Charm indicates an expected call of Charm.
 func (mr *MockStateMockRecorder) Charm(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockState)(nil).Charm), arg0)
 }
 
-// Cloud mocks base method
+// Cloud mocks base method.
 func (m *MockState) Cloud(arg0 string) (cloud.Cloud, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cloud", arg0)
@@ -308,13 +325,13 @@ func (m *MockState) Cloud(arg0 string) (cloud.Cloud, error) {
 	return ret0, ret1
 }
 
-// Cloud indicates an expected call of Cloud
+// Cloud indicates an expected call of Cloud.
 func (mr *MockStateMockRecorder) Cloud(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cloud", reflect.TypeOf((*MockState)(nil).Cloud), arg0)
 }
 
-// ControllerConfig mocks base method
+// ControllerConfig mocks base method.
 func (m *MockState) ControllerConfig() (controller.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerConfig")
@@ -323,13 +340,13 @@ func (m *MockState) ControllerConfig() (controller.Config, error) {
 	return ret0, ret1
 }
 
-// ControllerConfig indicates an expected call of ControllerConfig
+// ControllerConfig indicates an expected call of ControllerConfig.
 func (mr *MockStateMockRecorder) ControllerConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockState)(nil).ControllerConfig))
 }
 
-// ControllerUUID mocks base method
+// ControllerUUID mocks base method.
 func (m *MockState) ControllerUUID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerUUID")
@@ -337,13 +354,13 @@ func (m *MockState) ControllerUUID() string {
 	return ret0
 }
 
-// ControllerUUID indicates an expected call of ControllerUUID
+// ControllerUUID indicates an expected call of ControllerUUID.
 func (mr *MockStateMockRecorder) ControllerUUID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerUUID", reflect.TypeOf((*MockState)(nil).ControllerUUID))
 }
 
-// Model mocks base method
+// Model mocks base method.
 func (m *MockState) Model() (charmrevisionupdater.Model, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
@@ -352,13 +369,13 @@ func (m *MockState) Model() (charmrevisionupdater.Model, error) {
 	return ret0, ret1
 }
 
-// Model indicates an expected call of Model
+// Model indicates an expected call of Model.
 func (mr *MockStateMockRecorder) Model() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockState)(nil).Model))
 }
 
-// Resources mocks base method
+// Resources mocks base method.
 func (m *MockState) Resources() (state.Resources, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resources")
@@ -367,7 +384,7 @@ func (m *MockState) Resources() (state.Resources, error) {
 	return ret0, ret1
 }
 
-// Resources indicates an expected call of Resources
+// Resources indicates an expected call of Resources.
 func (mr *MockStateMockRecorder) Resources() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resources", reflect.TypeOf((*MockState)(nil).Resources))

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -14,17 +14,25 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/charmhub/transport"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
 	statemocks "github.com/juju/juju/state/mocks"
+	"github.com/juju/juju/testing"
 )
 
-type updaterSuite struct{}
+type updaterSuite struct {
+	model     *mocks.MockModel
+	state     *mocks.MockState
+	resources *statemocks.MockResources
+}
 
 var _ = gc.Suite(&updaterSuite{})
 
-type newCharmhubClientFunc = func(st charmrevisionupdater.State, metadata map[string]string) (charmrevisionupdater.CharmhubRefreshClient, error)
+type newCharmhubClientFunc = func(st charmrevisionupdater.State) (charmrevisionupdater.CharmhubRefreshClient, error)
 
 func (s *updaterSuite) newCharmhubClient(client charmrevisionupdater.CharmhubRefreshClient) newCharmhubClientFunc {
-	return func(st charmrevisionupdater.State, metadata map[string]string) (charmrevisionupdater.CharmhubRefreshClient, error) {
+	return func(st charmrevisionupdater.State) (charmrevisionupdater.CharmhubRefreshClient, error) {
 		return client, nil
 	}
 }
@@ -46,15 +54,16 @@ func (s *updaterSuite) TestNewAuthFailure(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmHubModel()
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
 		{"charm-1", 22},
 		{"charm-2", 41},
 	}}
-	client.EXPECT().Refresh(gomock.Any(), matcher).Return([]transport.RefreshResponse{
+	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{Revision: 23},
 			ID:     "charm-1",
@@ -67,15 +76,52 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 		},
 	}, nil)
 
-	state := makeState(c, ctrl, nil)
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "ch", "mysql", "charm-1", "app-1", 22),
 		makeApplication(ctrl, "ch", "postgresql", "charm-2", "app-2", 41),
 	}, nil).AnyTimes()
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:mysql-23")).Return(nil)
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:mysql-23")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, nil, s.newCharmhubClient(client))
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, nil, s.newCharmhubClient(client))
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := updater.UpdateLatestRevisions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+}
+
+func (s *updaterSuite) TestCharmhubUpdateWithMetrics(c *gc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.expectCharmHubModel()
+
+	client := mocks.NewMockCharmhubRefreshClient(ctrl)
+	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
+		{"charm-1", 22},
+		{"charm-2", 41},
+	}}
+	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, charmhubMetricsMatcher{c: c}).Return([]transport.RefreshResponse{
+		{
+			Entity: transport.RefreshEntity{Revision: 23},
+			ID:     "charm-1",
+			Name:   "mysql",
+		},
+		{
+			Entity: transport.RefreshEntity{Revision: 42},
+			ID:     "charm-2",
+			Name:   "postgresql",
+		},
+	}, nil)
+
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+		makeApplication(ctrl, "ch", "mysql", "charm-1", "app-1", 22),
+		makeApplication(ctrl, "ch", "postgresql", "charm-2", "app-2", 41),
+	}, nil).AnyTimes()
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:mysql-23")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
+
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, nil, s.newCharmhubClient(client))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -84,21 +130,21 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmHubModel()
 
 	expectedResources := []resource.Resource{
 		makeResource(c, "reza", 7, 5, "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f"),
 		makeResource(c, "rezb", 1, 6, "03130092073c5ac523ecb21f548b9ad6e1387d1cb05f3cb892fcc26029d01428afbe74025b6c567b6564a3168a47179a"),
 	}
-	resources := statemocks.NewMockResources(ctrl)
-	resources.EXPECT().SetCharmStoreResources("app-1", expectedResources, gomock.Any()).Return(nil).AnyTimes()
+	s.resources.EXPECT().SetCharmStoreResources("app-1", expectedResources, gomock.Any()).Return(nil)
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
 		{"charm-3", 1},
 	}}
-	client.EXPECT().Refresh(gomock.Any(), matcher).Return([]transport.RefreshResponse{
+	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{
 				Resources: []transport.ResourceRevision{
@@ -128,14 +174,14 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 		},
 	}, nil)
 
-	state := makeState(c, ctrl, resources)
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().Resources().Return(s.resources, nil).AnyTimes()
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "ch", "resourcey", "charm-3", "app-1", 1),
 	}, nil).AnyTimes()
 
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:resourcey-1")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:resourcey-1")).Return(nil)
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, nil, s.newCharmhubClient(client))
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, nil, s.newCharmhubClient(client))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -144,14 +190,15 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmHubModel()
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
 		{"charm-2", 42},
 	}}
-	client.EXPECT().Refresh(gomock.Any(), matcher).Return([]transport.RefreshResponse{
+	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{Revision: 42},
 			ID:     "charm-2",
@@ -159,13 +206,12 @@ func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
 		},
 	}, nil)
 
-	state := makeState(c, ctrl, nil)
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "ch", "postgresql", "charm-2", "app-2", 42),
 	}, nil).AnyTimes()
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, nil, s.newCharmhubClient(client))
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, nil, s.newCharmhubClient(client))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -174,19 +220,20 @@ func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmNotInStore(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmStoreModel(c)
+	s.expectCharmHubModel()
 
 	charmhubClient := mocks.NewMockCharmhubRefreshClient(ctrl)
-	charmhubClient.EXPECT().Refresh(gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{}, nil)
+	charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{}, nil)
 
-	state := makeState(c, ctrl, nil)
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "ch", "varnish", "charm-5", "app-1", 1),
 		makeApplication(ctrl, "cs", "varnish", "charm-6", "app-2", 2),
 	}, nil).AnyTimes()
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, newFakeCharmstoreClient, s.newCharmhubClient(charmhubClient))
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, newFakeCharmstoreClient, s.newCharmhubClient(charmhubClient))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -195,21 +242,20 @@ func (s *updaterSuite) TestCharmNotInStore(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmstoreUpdate(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmStoreModel(c)
 
-	state := makeState(c, ctrl, nil)
-
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "cs", "mysql", "charm-1", "app-1", 22),
 		makeApplication(ctrl, "cs", "wordpress", "charm-2", "app-2", 26),
 		makeApplication(ctrl, "cs", "varnish", "charm-3", "app-3", 5), // doesn't exist in store
 	}, nil)
 
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:mysql-23")).Return(nil)
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:wordpress-26")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:mysql-23")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:wordpress-26")).Return(nil)
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, newFakeCharmstoreClient, nil)
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, newFakeCharmstoreClient, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -217,13 +263,75 @@ func (s *updaterSuite) TestCharmstoreUpdate(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	// Update mysql version and run update again.
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "cs", "mysql", "charm-1", "app-1", 23),
 	}, nil)
 
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:mysql-23")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:mysql-23")).Return(nil)
 
 	result, err = updater.UpdateLatestRevisions()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
+}
+
+func (s *updaterSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := s.setupMocksNoResources(c)
+	s.resources.EXPECT().SetCharmStoreResources(gomock.Any(), gomock.Len(0), gomock.Any()).Return(nil).AnyTimes()
+
+	return ctrl
+}
+
+func (s *updaterSuite) setupMocksNoResources(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.model = mocks.NewMockModel(ctrl)
+	s.resources = statemocks.NewMockResources(ctrl)
+	s.state = mocks.NewMockState(ctrl)
+
+	s.state.EXPECT().Cloud(gomock.Any()).Return(cloud.Cloud{Type: "cloud"}, nil).AnyTimes()
+	s.state.EXPECT().ControllerUUID().Return("controller-1").AnyTimes()
+	s.state.EXPECT().Model().Return(s.model, nil).AnyTimes()
+	s.state.EXPECT().Resources().Return(s.resources, nil).AnyTimes()
+	return ctrl
+}
+
+func (s *updaterSuite) expectCharmStoreModel(c *gc.C) {
+	mExp := s.model.EXPECT()
+	mExp.CloudName().Return("testcloud").AnyTimes()
+	mExp.CloudRegion().Return("juju-land").AnyTimes()
+	uuid := testing.ModelTag.Id()
+	cfg, err := config.New(true, map[string]interface{}{
+		"charmhub-url": "https://api.staging.charmhub.io", // not actually used in tests
+		"name":         "model",
+		"type":         "type",
+		"uuid":         uuid,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	mExp.Config().Return(cfg, nil).AnyTimes()
+	mExp.IsControllerModel().Return(false).AnyTimes()
+	mExp.UUID().Return(uuid).AnyTimes()
+}
+
+func (s *updaterSuite) expectCharmHubModel() {
+	uuid := testing.ModelTag.Id()
+	s.model.EXPECT().Metrics().Return(state.ModelMetrics{
+		UUID:           uuid,
+		ControllerUUID: "controller-1",
+		CloudName:      "cloud",
+	}, nil).AnyTimes()
+}
+
+func (s *updaterSuite) expectResources(c *gc.C, name string, revision, size int, hexFingerprint string) {
+	fingerprint, err := resource.ParseFingerprint(hexFingerprint)
+	c.Assert(err, jc.ErrorIsNil)
+	resources := resource.Resource{
+		Meta: resource.Meta{
+			Name: name,
+			Type: resource.TypeFile,
+		},
+		Origin:      resource.OriginStore,
+		Revision:    revision,
+		Fingerprint: fingerprint,
+		Size:        int64(size),
+	}
+	s.state.EXPECT().Resources().Return(resources, nil).AnyTimes()
 }

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -32,6 +32,7 @@ import (
 
 	charmhubpath "github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
+	charmmetrics "github.com/juju/juju/core/charm/metrics"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/version"
 )
@@ -269,10 +270,16 @@ func (c *Client) Find(ctx context.Context, name string, options ...FindOption) (
 	return c.findClient.Find(ctx, name, options...)
 }
 
-// Refresh defines a client for making refresh API calls, that allow for
-// updating a series of charms to the latest version.
+// Refresh defines a client for making refresh API calls with different actions.
 func (c *Client) Refresh(ctx context.Context, config RefreshConfig) ([]transport.RefreshResponse, error) {
 	return c.refreshClient.Refresh(ctx, config)
+}
+
+// RefreshWithRequestMetrics defines a client for making refresh API calls.
+// Specifically to use the refresh action and provide metrics.  Intended for
+// use in the charm revision updater facade only.  Otherwise use Refresh.
+func (c *Client) RefreshWithRequestMetrics(ctx context.Context, config RefreshConfig, metrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string) ([]transport.RefreshResponse, error) {
+	return c.refreshClient.RefreshWithRequestMetrics(ctx, config, metrics)
 }
 
 // Download defines a client for downloading charms directly.

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
+	charmmetrics "github.com/juju/juju/core/charm/metrics"
 	corelogger "github.com/juju/juju/core/logger"
 	coreseries "github.com/juju/juju/core/series"
 )
@@ -88,7 +89,34 @@ func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	return c.refresh(ctx, config.Ensure, req, headers)
+}
 
+// RefreshWithRequestMetrics is to get refreshed charm data and provide metrics
+// at the same time.  Used as part of the charm revision updater facade.
+func (c *RefreshClient) RefreshWithRequestMetrics(ctx context.Context, config RefreshConfig, metrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string) ([]transport.RefreshResponse, error) {
+	c.logger.Tracef("RefreshWithRequestMetrics(%s, %+v)", pretty.Sprint(config), metrics)
+	req, headers, err := config.Build()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	m := make(transport.RequestMetrics, 0)
+	for k, v := range metrics {
+		// verify top level "model" and "controller" keys
+		if k != charmmetrics.Controller && k != charmmetrics.Model {
+			return nil, errors.Trace(errors.NotValidf("highlevel metrics label %q", k))
+		}
+		ctxM := make(map[string]string, len(v))
+		for k2, v2 := range v {
+			ctxM[k2.String()] = v2
+		}
+		m[k.String()] = ctxM
+	}
+	req.Metrics = m
+	return c.refresh(ctx, config.Ensure, req, headers)
+}
+
+func (c *RefreshClient) refresh(ctx context.Context, ensure func(responses []transport.RefreshResponse) error, req transport.RefreshRequest, headers Headers) ([]transport.RefreshResponse, error) {
 	httpHeaders := make(http.Header)
 	for k, values := range headers {
 		for _, value := range values {
@@ -109,7 +137,7 @@ func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 	}
 
 	c.logger.Tracef("Refresh() unmarshalled: %s", pretty.Sprint(resp.Results))
-	return resp.Results, config.Ensure(resp.Results)
+	return resp.Results, ensure(resp.Results)
 }
 
 // RefreshOne creates a request config for requesting only one charm.
@@ -166,6 +194,23 @@ func AddResource(config RefreshConfig, name string, revision int) (RefreshConfig
 		Revision: revision,
 	})
 	return c, true
+}
+
+// AddConfigMetrics adds metrics to a refreshOne config.  All values are
+// applied at once, subsequent calls, replace all values.
+func AddConfigMetrics(config RefreshConfig, metrics map[charmmetrics.MetricKey]string) (RefreshConfig, error) {
+	c, ok := config.(refreshOne)
+	if !ok {
+		return config, nil // error?
+	}
+	if len(metrics) < 1 {
+		return c, nil
+	}
+	c.metrics = make(transport.ContextMetrics, 0)
+	for k, v := range metrics {
+		c.metrics[k.String()] = v
+	}
+	return c, nil
 }
 
 // InstallOneFromChannel creates a request config using the channel and not the

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -18,6 +18,7 @@ import (
 	path "github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/juju/core/arch"
+	charmmetrics "github.com/juju/juju/core/charm/metrics"
 )
 
 type RefreshSuite struct {
@@ -197,6 +198,63 @@ func (s *RefreshSuite) TestRefreshMetadata(c *gc.C) {
 	})
 }
 
+func (s *RefreshSuite) RefreshWithRequestMetrics(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	id := "meshuggah"
+	body := transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{{
+			InstanceKey: "foo-bar",
+			ID:          id,
+			Revision:    1,
+			Base: transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
+				Architecture: arch.DefaultArchitecture,
+			},
+			TrackingChannel: "latest/stable",
+		}},
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "refresh",
+			InstanceKey: "foo-bar",
+			ID:          &id,
+		}},
+	}
+
+	config1, err := RefreshOne("foo", 1, "latest/stable", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: "amd64",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	config1 = DefineInstanceKey(c, config1, "key-foo")
+
+	config2, err := RefreshOne("bar", 2, "latest/edge", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "14.04",
+		Architecture: "amd64",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	config2 = DefineInstanceKey(c, config2, "key-bar")
+
+	config := RefreshMany(config1, config2)
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectPost(c, restClient, path, id, body)
+
+	metrics := map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string{}
+
+	client := NewRefreshClient(path, restClient, &FakeLogger{})
+	responses, err := client.RefreshWithRequestMetrics(context.TODO(), config, metrics)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(responses), gc.Equals, 1)
+	c.Assert(responses[0].Name, gc.Equals, id)
+}
+
 func (s *RefreshSuite) TestRefreshFailure(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -283,6 +341,49 @@ func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 				Architecture: arch.DefaultArchitecture,
 			},
 			TrackingChannel: "latest/stable",
+		}},
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "refresh",
+			InstanceKey: "foo-bar",
+			ID:          &id,
+		}},
+	})
+}
+
+func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
+	id := "foo"
+	config, err := RefreshOne(id, 1, "latest/stable", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	config = DefineInstanceKey(c, config, "foo-bar")
+
+	config, err = AddConfigMetrics(config, map[charmmetrics.MetricKey]string{
+		charmmetrics.Provider:        "openstack",
+		charmmetrics.NumApplications: "4",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	req, _, err := config.Build()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{{
+			InstanceKey: "foo-bar",
+			ID:          "foo",
+			Revision:    1,
+			Base: transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
+				Architecture: arch.DefaultArchitecture,
+			},
+			TrackingChannel: "latest/stable",
+			Metrics: map[string]string{
+				"provider":         "openstack",
+				"num-applications": "4",
+			},
 		}},
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "refresh",

--- a/charmhub/refreshconfig.go
+++ b/charmhub/refreshconfig.go
@@ -33,6 +33,7 @@ type refreshOne struct {
 	// instanceKey is a private unique key that we construct for CharmHub API
 	// asynchronous calls.
 	instanceKey string
+	metrics     transport.ContextMetrics
 }
 
 // InstanceKey returns the underlying instance key.
@@ -59,6 +60,7 @@ func (c refreshOne) Build() (transport.RefreshRequest, Headers, error) {
 			Revision:        c.Revision,
 			Base:            base,
 			TrackingChannel: c.Channel,
+			Metrics:         c.metrics,
 			// TODO (stickupkid): We need to model the refreshed date. It's
 			// currently optional, but will be required at some point. This
 			// is the installed date of the charm on the system.

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -14,7 +14,12 @@ type RefreshRequest struct {
 	Context []RefreshRequestContext `json:"context"`
 	Actions []RefreshRequestAction  `json:"actions"`
 	Fields  []string                `json:"fields,omitempty"`
+	Metrics RequestMetrics          `json:"metrics,omitempty"`
 }
+
+// RequestMetrics are a map of key value pairs of metrics for the controller
+// and the model in the request.
+type RequestMetrics map[string]map[string]string
 
 // RefreshRequestContext can request a given context for making multiple
 // requests to one given entity.
@@ -22,11 +27,16 @@ type RefreshRequestContext struct {
 	InstanceKey string `json:"instance-key"`
 	ID          string `json:"id"`
 
-	Revision        int        `json:"revision"`
-	Base            Base       `json:"base,omitempty"`
-	TrackingChannel string     `json:"tracking-channel,omitempty"`
-	RefreshedDate   *time.Time `json:"refresh-date,omitempty"`
+	Revision        int            `json:"revision"`
+	Base            Base           `json:"base,omitempty"`
+	TrackingChannel string         `json:"tracking-channel,omitempty"`
+	RefreshedDate   *time.Time     `json:"refresh-date,omitempty"`
+	Metrics         ContextMetrics `json:"metrics,omitempty"`
 }
+
+// ContextMetrics are a map of key value pairs of metrics for the specific
+// charm/application in the context.
+type ContextMetrics map[string]string
 
 // RefreshRequestAction defines a action to perform against the Refresh API.
 type RefreshRequestAction struct {

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -60,6 +60,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"controller",
 		"core/application",
 		"core/charm",
+		"core/charm/metrics",
 		"core/constraints",
 		"core/devices",
 		"core/instance",

--- a/core/charm/metrics/metrics.go
+++ b/core/charm/metrics/metrics.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metrics
+
+// MetricKey represents metrics keys collected and sent to charmhub.
+type MetricKey string
+
+func (c MetricKey) String() string {
+	return string(c)
+}
+
+const (
+	// Controller is used in RequestMetrics
+	Controller MetricKey = "controller"
+
+	// Model is used in RequestMetrics
+	Model MetricKey = "model"
+
+	//
+	// Controller and Model, included in the RefreshRequest Metrics.
+	//
+
+	// UUID is the uuid of a model, either controller or model.
+	UUID MetricKey = "uuid"
+	// JujuVersion is the version of juju running in this model.
+	JujuVersion MetricKey = "juju-version"
+
+	//
+	// Model metrics, included in the RefreshRequest Metrics.
+	//
+
+	// Provider matches the provider type defined in juju.
+	Provider MetricKey = "provider"
+	// Region is the region this model is operating in.
+	Region MetricKey = "region"
+	// Cloud is the name of the cloud this model is operating in.
+	Cloud MetricKey = "cloud"
+	// NumApplications is the number of applications in the model.
+	NumApplications MetricKey = "num-applications"
+	// NumMachines is the number of machines in the model.
+	NumMachines MetricKey = "num-machines"
+	// NumUnits is the number of units in the model.
+	NumUnits MetricKey = "num-units"
+
+	//
+	// Charm metrics, included in the RefreshRequestContext Metrics.
+	//
+
+	// CharmURL is the url of the deployed charm, it includes the
+	// type, name, base and revision of the running charm.
+	CharmURL MetricKey = "charm-url"
+)

--- a/state/model.go
+++ b/state/model.go
@@ -1015,19 +1015,19 @@ func (m *Model) Metrics() (ModelMetrics, error) {
 func (m *Model) applicationCount() (int, error) {
 	coll, closer := m.st.db().GetCollection(applicationsC)
 	defer closer()
-	return coll.Count()
+	return coll.Find(isAliveDoc).Count()
 }
 
 func (m *Model) machineCount() (int, error) {
 	coll, closer := m.st.db().GetCollection(machinesC)
 	defer closer()
-	return coll.Count()
+	return coll.Find(isAliveDoc).Count()
 }
 
 func (m *Model) unitCount() (int, error) {
 	coll, closer := m.st.db().GetCollection(unitsC)
 	defer closer()
-	return coll.Count()
+	return coll.Find(isAliveDoc).Count()
 }
 
 // AllEndpointBindings returns all endpoint->space bindings

--- a/state/model.go
+++ b/state/model.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -963,6 +964,70 @@ func (m *Model) AllUnits() ([]*Unit, error) {
 		units = append(units, newUnit(m.st, m.Type(), &docs[i]))
 	}
 	return units, nil
+}
+
+// ModelMetrics contains metrics to be collected and sent to
+// Charmhub via the charm revision updater for a model.
+type ModelMetrics struct {
+	ApplicationCount string
+	MachineCount     string
+	UnitCount        string
+	CloudName        string
+	CloudRegion      string
+	Provider         string
+	UUID             string
+	ControllerUUID   string
+}
+
+// Metrics returns model level metrics to be collected and sent to
+// Charmhub via the charm revision updater.
+func (m *Model) Metrics() (ModelMetrics, error) {
+	cloud, err := m.Cloud()
+	if err != nil {
+		return ModelMetrics{}, errors.Trace(err)
+	}
+
+	appCnt, err := m.applicationCount()
+	if err != nil {
+		return ModelMetrics{}, errors.Trace(err)
+	}
+	machCnt, err := m.machineCount()
+	if err != nil {
+		return ModelMetrics{}, errors.Trace(err)
+	}
+	unitCnt, err := m.unitCount()
+	if err != nil {
+		return ModelMetrics{}, errors.Trace(err)
+	}
+
+	return ModelMetrics{
+		ApplicationCount: strconv.Itoa(appCnt),
+		MachineCount:     strconv.Itoa(machCnt),
+		UnitCount:        strconv.Itoa(unitCnt),
+		CloudName:        cloud.Name,
+		CloudRegion:      m.CloudRegion(),
+		Provider:         cloud.Type,
+		UUID:             m.UUID(),
+		ControllerUUID:   m.doc.ControllerUUID,
+	}, nil
+}
+
+func (m *Model) applicationCount() (int, error) {
+	coll, closer := m.st.db().GetCollection(applicationsC)
+	defer closer()
+	return coll.Count()
+}
+
+func (m *Model) machineCount() (int, error) {
+	coll, closer := m.st.db().GetCollection(machinesC)
+	defer closer()
+	return coll.Count()
+}
+
+func (m *Model) unitCount() (int, error) {
+	coll, closer := m.st.db().GetCollection(unitsC)
+	defer closer()
+	return coll.Count()
 }
 
 // AllEndpointBindings returns all endpoint->space bindings

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -553,6 +553,37 @@ func (s *ModelSuite) TestAllUnits(c *gc.C) {
 	})
 }
 
+func (s *ModelSuite) TestMetrics(c *gc.C) {
+	wordpress := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "wordpress",
+	})
+	mysql := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "mysql",
+	})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
+
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained, err := model.Metrics()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := state.ModelMetrics{
+		ApplicationCount: "2",
+		MachineCount:     "3",
+		UnitCount:        "3",
+		CloudName:        "dummy",
+		CloudRegion:      "dummy-region",
+		Provider:         "dummy",
+		UUID:             s.Model.UUID(),
+		ControllerUUID:   s.Model.ControllerUUID(),
+	}
+
+	c.Assert(obtained, jc.DeepEquals, expected)
+}
+
 func (s *ModelSuite) TestAllEndpointBindings(c *gc.C) {
 	oneSpace := s.Factory.MakeSpace(c, &factory.SpaceParams{
 		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -564,6 +564,20 @@ func (s *ModelSuite) TestMetrics(c *gc.C) {
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
 
+	// Add a machine/unit/application and destroy it, to
+	// ensure we're only counting entities that are alive.
+	m := s.Factory.MakeMachine(c, &factory.MachineParams{})
+	err := m.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	one := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "one",
+	})
+	u := s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
+	err = one.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
Initial commit of charmhub metrics work.

We will be moving the metrics from metadata sent in the http header to data sent to charmhub in the refresh api structures.  This allows us to send more specific controller, model and multiple application specific metrics together in a Refresh request.  E.g. with charmstore, we'd add series=bionic to the metadata, for all applications in the model using bionic having no way to specify with application was using bionic.

Add new structures to the charmhub transport to pass the metrics in a refresh request via both the context and request.  AddConfigMetrics allows you to add application specific metrics to a RefreshConfig.  RefreshWithRequestMetrics will use a RefreshConfig and controller/model metrics to send the request.

In state, the new Metrics method for a model will aggregate all the metrics data we required for a model into a single call and allow for easy addition of new data in the future. Beyond the former model data gathered, juju will now gather the unit, machine and application counts.

RefreshWithRequestMetrics is intended to only be used with the charm revision updater facade so that metrics are only sent once every 24 hours.  Update the charm revision updater facade to use the new functionality in both charmhub and state.

## QA steps

```sh
# Setup 
$ juju bootstrap locahost testme
$ juju deploy ubuntu
$ juju deploy ntp
$ juju relate ntp ubuntu

# Enable logging to verify the changes and upgrade the controller as a easy way to trigger the charm revision updater worker to run.
$ juju model-config -m controller "logging-config='#charmhub=TRACE';<root>=INFO"
$ juju upgrade-controller --build-agent

# Verify that metrics are now passed as part of a Refresh request from  charm revision updater worker.  You'll see data for both the default and controller models.
$ juju debug-log -m controller | grep metrics
            metrics:     {},
            metrics:     {},
{"context":[{"instance-key":"35cffc30-19d1-4252-896a-792da29ba512","id":"SLOkZHn8HVy160M2oJdvXatzlu7ZBEVx","revision":47,"base":{"architecture":"amd64","name":"ubuntu","channel":"20.04"},"tracking-channel":"stable"},{"instance-key":"14ca644b-4fe2-46ce-8e88-0d453a1e6c5c","id":"DksXQKAQTZfsUmBAGanZAhpoS4dpmXel","revision":19,"base":{"architecture":"amd64","name":"ubuntu","channel":"20.04"},"tracking-channel":"stable"}],"actions":[{"action":"refresh","instance-key":"35cffc30-19d1-4252-896a-792da29ba512","id":"SLOkZHn8HVy160M2oJdvXatzlu7ZBEVx","base":null},{"action":"refresh","instance-key":"14ca644b-4fe2-46ce-8e88-0d453a1e6c5c","id":"DksXQKAQTZfsUmBAGanZAhpoS4dpmXel","base":null}],"metrics":{"controller":{"juju-version":"3.0-beta1.2","uuid":"3cf1d39b-59c8-4482-848a-c06c0f88b8cf"},"model":{"cloud":"localhost","num-applications":"2","num-machines":"1","num-units":"2","provider":"lxd","region":"localhost","uuid":"cc5af0a6-f72d-4964-8f87-735ddb05ab83"}}}
            metrics:     {},
{"context":[{"instance-key":"bd3809bb-c408-430c-83f8-bc29b5abd791","id":"WV4pShb4jnG1eXAB8HMypujHRKRXMRW9","revision":5,"base":{"architecture":"amd64","name":"ubuntu","channel":"16.04"},"tracking-channel":"beta"}],"actions":[{"action":"refresh","instance-key":"bd3809bb-c408-430c-83f8-bc29b5abd791","id":"WV4pShb4jnG1eXAB8HMypujHRKRXMRW9","base":null}],"metrics":{"controller":{"juju-version":"3.0-beta1.2","uuid":"3cf1d39b-59c8-4482-848a-c06c0f88b8cf"},"model":{"cloud":"localhost","num-applications":"1","num-machines":"1","num-units":"1","provider":"lxd","region":"localhost","uuid":"978bc235-6185-4785-868f-2e096e2964e2"}}}
```

