### PR TITLE
Fix assess_model_migration_versions

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -268,6 +268,7 @@ def assert_model_migrated_successfully(
     assert_deployed_charm_is_responding(client, resource_contents)
     ensure_model_is_functional(client, application)
 
+
 def migrate_model_to_controller(
         source_model, source_client, dest_client, include_user_name=False):
     log.info('Initiating migration process')

--- a/acceptancetests/assess_model_migration_versions.py
+++ b/acceptancetests/assess_model_migration_versions.py
@@ -60,8 +60,6 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
             stable_client = stable_bsm.client
             devel_client = devel_bsm.client
             resource_contents = get_random_string()
-            # Possible stable version doesn't handle migration subords (a fixed
-            # bug in later versions.)
             test_stable_model, application = deploy_simple_server_to_new_model(
                 stable_client,
                 'version-migration',
@@ -77,14 +75,13 @@ def assess_model_migration_versions(stable_bsm, devel_bsm, args):
                 another_bsm.client.get_controller_client().wait_for(
                     AllMachinesRunning())
                 another_migration_client = migrate_model_to_controller(
-                    test_stable_model,
+                    migration_target_client.acquire_model_client('version-migration'),
                     migration_target_client, another_bsm.client)
                 assert_model_migrated_successfully(
                     another_migration_client, application, resource_contents)
 
 
 class AllMachinesRunning(BaseCondition):
-
     def iter_blocking_state(self, status):
         for machine_no, status in status.iter_machines():
             if status['machine-status']['current'] != 'running':

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1638,9 +1638,10 @@ class ModelClient:
         for model in models:
             # 2.2-rc1 introduced new model listing output name/short-name.
             model_name = model.get('short-name', model['name'])
-            yield self._acquire_model_client(model_name, model.get('owner'))
+            yield self.acquire_model_client(model_name, model.get('owner'))
 
-    def get_controller_model_name(self):
+    @staticmethod
+    def get_controller_model_name():
         """Return the name of the 'controller' model.
 
         Return the name of the environment when an 'controller' model does
@@ -1648,7 +1649,7 @@ class ModelClient:
         """
         return 'controller'
 
-    def _acquire_model_client(self, name, owner=None):
+    def acquire_model_client(self, name, owner=None):
         """Get a client for a model with the supplied name.
 
         If the name matches self, self is used.  Otherwise, a clone is used.
@@ -1696,7 +1697,7 @@ class ModelClient:
         This may be inaccurate for models created using add_model
         rather than bootstrap.
         """
-        return self._acquire_model_client(self.get_controller_model_name())
+        return self.acquire_model_client(self.get_controller_model_name())
 
     def list_controllers(self):
         """List the controllers."""

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -1729,20 +1729,20 @@ class TestModelClient(ClientTest):
     def test__acquire_model_client_returns_self_when_match(self):
         client = ModelClient(JujuData('foo', {}), None, None)
 
-        self.assertEqual(client._acquire_model_client('foo'), client)
-        self.assertEqual(client._acquire_model_client('foo', None), client)
+        self.assertEqual(client.acquire_model_client('foo'), client)
+        self.assertEqual(client.acquire_model_client('foo', None), client)
 
     def test__acquire_model_client_adds_username_component(self):
         client = ModelClient(JujuData('foo', {}), None, None)
 
-        new_client = client._acquire_model_client('bar', None)
+        new_client = client.acquire_model_client('bar', None)
         self.assertEqual(new_client.model_name, 'bar')
 
-        new_client = client._acquire_model_client('bar', 'user1')
+        new_client = client.acquire_model_client('bar', 'user1')
         self.assertEqual(new_client.model_name, 'user1/bar')
 
         client.env.user_name = 'admin'
-        new_client = client._acquire_model_client('baz', 'admin')
+        new_client = client.acquire_model_client('baz', 'admin')
         self.assertEqual(new_client.model_name, 'baz')
 
     def test_get_controller_model_name(self):


### PR DESCRIPTION
The `assess_model_migration_versions` acceptance test migrates a model through 2 controllers. On the second migration, we were using the model client from when it resided on the first controller, resulting in an error.

Here we reacquire the model client from the correct controller to use in the second migration.

Any error calling status in a bootstrap context is now logged instead of thrown. This is a big hammer approach that will quell status errors during controller destruction once and for all.

## QA steps

- `cd acceptancetests`.
- `./assess model_migration_versions --juju <wherever yours is> --logging-config '<root>=DEBUG'`.

## Documentation changes

None.

## Bug reference

N/A
