### PR TITLE
Restart cmr workers after offer has been removed

### DIFF
--- a/apiserver/common/unitcommon/accessor_test.go
+++ b/apiserver/common/unitcommon/accessor_test.go
@@ -62,6 +62,8 @@ func (s *UnitAccessorSuite) TestUnitAgent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	ok := authFunc(names.NewUnitTag("gitlab/0"))
 	c.Assert(ok, jc.IsTrue)
+	ok = authFunc(names.NewApplicationTag("gitlab"))
+	c.Assert(ok, jc.IsTrue)
 	ok = authFunc(names.NewUnitTag("gitlab/1"))
 	c.Assert(ok, jc.IsFalse)
 	ok = authFunc(names.NewUnitTag("mysql/0"))

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1753,7 +1753,7 @@ func (u *UniterAPI) LeaveScope(args params.RelationUnits) (params.ErrorResults, 
 	for i, arg := range args.RelationUnits {
 		unit, err := names.ParseUnitTag(arg.Unit)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
+			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
 		relUnit, err := u.getRelationUnit(canAccess, arg.Relation, unit)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2178,11 +2178,11 @@ func (s *uniterSuite) TestLeaveScope(c *gc.C) {
 			{apiservertesting.ErrUnauthorized},
 			{apiservertesting.ErrUnauthorized},
 			{apiservertesting.ErrUnauthorized},
+			{&params.Error{Message: `"bar" is not a valid tag`}},
 			{apiservertesting.ErrUnauthorized},
-			{apiservertesting.ErrUnauthorized},
-			{apiservertesting.ErrUnauthorized},
-			{apiservertesting.ErrUnauthorized},
-			{apiservertesting.ErrUnauthorized},
+			{&params.Error{Message: `"application-wordpress" is not a valid unit tag`}},
+			{&params.Error{Message: `"application-mysql" is not a valid unit tag`}},
+			{&params.Error{Message: `"user-foo" is not a valid unit tag`}},
 		},
 	})
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -3429,7 +3429,7 @@ func (s *applicationSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {
 
 	endpoints := []string{"wordpress", "hosted-mysql:nope"}
 	_, err := s.applicationAPI.AddRelation(params.AddRelation{Endpoints: endpoints})
-	c.Assert(err, gc.ErrorMatches, `remote application "hosted-mysql" has no "nope" relation`)
+	c.Assert(err, gc.ErrorMatches, `saas application "hosted-mysql" has no "nope" relation`)
 }
 
 func (s *applicationSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -310,6 +310,7 @@ type RemoteApplication interface {
 	Spaces() []state.RemoteSpace
 	Destroy() error
 	DestroyOperation(force bool) *state.DestroyRemoteApplicationOperation
+	Status() (status.StatusInfo, error)
 }
 
 func (s stateShim) RemoteApplication(name string) (RemoteApplication, error) {

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -321,11 +321,16 @@ type mockRemoteApplication struct {
 	spaces         []state.RemoteSpace
 	offerUUID      string
 	offerURL       string
+	status         status.Status
 	mac            *macaroon.Macaroon
 }
 
 func (m *mockRemoteApplication) Name() string {
 	return m.name
+}
+
+func (m *mockRemoteApplication) Status() (status.StatusInfo, error) {
+	return status.StatusInfo{Status: m.status}, nil
 }
 
 func (m *mockRemoteApplication) SourceModel() names.ModelTag {
@@ -721,6 +726,7 @@ func (m *mockBackend) AddRemoteApplication(args state.AddRemoteApplicationParams
 		offerURL:       args.URL,
 		bindings:       args.Bindings,
 		mac:            args.Macaroon,
+		status:         status.Active,
 	}
 	for _, ep := range args.Endpoints {
 		app.endpoints = append(app.endpoints, state.Endpoint{
@@ -761,7 +767,7 @@ func (m *mockBackend) RemoteApplication(name string) (application.RemoteApplicat
 	}
 	app, ok := m.remoteApplications[name]
 	if !ok {
-		return nil, errors.NotFoundf("remote application %q", name)
+		return nil, errors.NotFoundf("saas application %q", name)
 	}
 	return app, nil
 }

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -396,7 +396,7 @@ func (api *OffersAPI) getApplicationOffers(user names.UserTag, urls params.Offer
 		}
 		if url.HasEndpoint() {
 			results.Results[i].Error = apiservererrors.ServerError(
-				errors.Errorf("remote application %q shouldn't include endpoint", url))
+				errors.Errorf("saas application %q shouldn't include endpoint", url))
 			continue
 		}
 		if url.Source != "" {

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -552,7 +552,7 @@ func (s *applicationOffersSuite) TestShowRejectsEndpoints(c *gc.C) {
 	found, err := s.api.ApplicationOffers(filter)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found.Results, gc.HasLen, 1)
-	c.Assert(found.Results[0].Error.Message, gc.Equals, `remote application "fred@external/prod.hosted-db2:db" shouldn't include endpoint`)
+	c.Assert(found.Results[0].Error.Message, gc.Equals, `saas application "fred@external/prod.hosted-db2:db" shouldn't include endpoint`)
 }
 
 func (s *applicationOffersSuite) TestShowErrorMsgMultipleURLs(c *gc.C) {
@@ -1174,7 +1174,7 @@ func (s *consumeSuite) TestConsumeDetailsRejectsEndpoints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error != nil, jc.IsTrue)
-	c.Assert(results.Results[0].Error.Message, gc.Equals, `remote application "fred@external/prod.application:db" shouldn't include endpoint`)
+	c.Assert(results.Results[0].Error.Message, gc.Equals, `saas application "fred@external/prod.application:db" shouldn't include endpoint`)
 }
 
 func (s *consumeSuite) TestConsumeDetailsNoPermission(c *gc.C) {

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -247,7 +247,7 @@ func (st *mockState) RemoteApplication(id string) (commoncrossmodel.RemoteApplic
 	}
 	a, ok := st.remoteApplications[id]
 	if !ok {
-		return nil, errors.NotFoundf("remote application %q", id)
+		return nil, errors.NotFoundf("saas application %q", id)
 	}
 	return a, nil
 }

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -164,7 +164,7 @@ func (st *mockState) RemoteApplication(id string) (common.RemoteApplication, err
 	}
 	a, ok := st.remoteApplications[id]
 	if !ok {
-		return nil, errors.NotFoundf("remote application %q", id)
+		return nil, errors.NotFoundf("saas application %q", id)
 	}
 	return a, nil
 }

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -96,7 +96,7 @@ func (s *restSuite) TestGetReturnsNotFoundWhenMissing(c *gc.C) {
 	resp := s.sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
 	s.assertErrorResponse(
 		c, resp, http.StatusNotFound,
-		`cannot retrieve model data: remote application "foo" not found`,
+		`cannot retrieve model data: saas application "foo" not found`,
 	)
 }
 

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -125,7 +125,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	if url.HasEndpoint() {
-		return errors.Errorf("remote offer %q shouldn't include endpoint", c.remoteApplication)
+		return errors.Errorf("saas offer %q shouldn't include endpoint", c.remoteApplication)
 	}
 	if url.User == "" {
 		url.User = accountDetails.User

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1356,7 +1356,7 @@ func (h *bundleHandler) consumeOffer(change *bundlechanges.ConsumeOfferChange) e
 		return errors.Trace(err)
 	}
 	if url.HasEndpoint() {
-		return errors.Errorf("remote offer %q shouldn't include endpoint", p.URL)
+		return errors.Errorf("saas offer %q shouldn't include endpoint", p.URL)
 	}
 	if url.User == "" {
 		url.User = h.accountUser

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -596,7 +596,7 @@ func (s *crossmodelSuite) TestRemoveSaas(c *gc.C) {
 		"-m", "admin/controller", "hosted-mysql")
 	c.Check(err, gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, `
-removing SAAS application hosted-mysql failed: remote application "hosted-mysql" not found
+removing SAAS application hosted-mysql failed: saas application "hosted-mysql" not found
 `[1:])
 }
 
@@ -616,7 +616,7 @@ func (s *crossmodelSuite) TestRemoveSaasForce(c *gc.C) {
 		"-m", "admin/controller", "hosted-mysql")
 	c.Check(err, gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, `
-removing SAAS application hosted-mysql failed: remote application "hosted-mysql" not found
+removing SAAS application hosted-mysql failed: saas application "hosted-mysql" not found
 `[1:])
 }
 
@@ -640,6 +640,6 @@ func (s *crossmodelSuite) TestRemoveSaasNoWait(c *gc.C) {
 		"-m", "admin/controller", "hosted-mysql")
 	c.Check(err, gc.ErrorMatches, "cmd: error out silently")
 	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Equals, `
-removing SAAS application hosted-mysql failed: remote application "hosted-mysql" not found
+removing SAAS application hosted-mysql failed: saas application "hosted-mysql" not found
 `[1:])
 }

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -842,7 +842,7 @@ type backingRemoteApplication remoteApplicationDoc
 func (app *backingRemoteApplication) updated(ctx *allWatcherContext) error {
 	allWatcherLogger.Tracef(`remote application "%s:%s" updated`, ctx.modelUUID, ctx.id)
 	if app.Name == "" {
-		return errors.Errorf("remote application name is not set")
+		return errors.Errorf("saas application name is not set")
 	}
 	if app.IsConsumerProxy {
 		// Since this is a consumer proxy, we update the offer
@@ -861,12 +861,12 @@ func (app *backingRemoteApplication) updated(ctx *allWatcherContext) error {
 		allWatcherLogger.Debugf("new remote application %q added to backing state", app.Name)
 		// Fetch the status.
 		key := remoteApplicationGlobalKey(app.Name)
-		appStatus, err := ctx.getStatus(key, "remote application")
+		appStatus, err := ctx.getStatus(key, "saas application")
 		if err != nil {
 			return errors.Annotatef(err, "reading remote application status for key %s", key)
 		}
 		info.Status = appStatus
-		allWatcherLogger.Debugf("remote application status %#v", info.Status)
+		allWatcherLogger.Debugf("saas application status %#v", info.Status)
 	} else {
 		allWatcherLogger.Debugf("use status from existing app")
 		switch t := oldInfo.(type) {

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -718,8 +718,7 @@ func (s *applicationOffersSuite) TestRemoveOffersWithConnectionsForce(c *gc.C) {
 	s.assertInScope(c, wpru, false)
 	s.assertInScope(c, mysqlru, true)
 	err = wordpress.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
-	assertLife(c, wordpress, state.Dying)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *applicationOffersSuite) TestRemoveOneOfferSameApplication(c *gc.C) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -673,6 +673,15 @@ func ResetMigrationMode(c *gc.C, st *State) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (a *RemoteApplication) SetDead() error {
+	ops := []txn.Op{{
+		C:      remoteApplicationsC,
+		Id:     a.doc.Name,
+		Update: bson.D{{"$set", bson.D{{"life", Dead}}}},
+	}}
+	return a.st.db().RunTransaction(ops)
+}
+
 func RemoveRelationStatus(c *gc.C, rel *Relation) {
 	st := rel.st
 	ops := []txn.Op{removeStatusOp(st, rel.globalScope())}

--- a/state/relation.go
+++ b/state/relation.go
@@ -332,6 +332,43 @@ func (r *Relation) Destroy() error {
 	return err
 }
 
+// destroyCrossModelRelationUnitsOps returns the operations necessary for the units
+// of the specified remote application to leave scope.
+func destroyCrossModelRelationUnitsOps(op *ForcedOperation, remoteApp *RemoteApplication, rel *Relation, onlyForTerminated bool) ([]txn.Op, error) {
+	if onlyForTerminated {
+		statusInfo, err := remoteApp.Status()
+		if op.FatalError(err) && !errors.IsNotFound(err) {
+			return nil, errors.Trace(err)
+		}
+		if err != nil || statusInfo.Status != status.Terminated {
+			return nil, nil
+		}
+	}
+	logger.Debugf("forcing cleanup of units for %v", remoteApp.Name())
+	remoteUnits, err := rel.AllRemoteUnits(remoteApp.Name())
+	if op.FatalError(err) {
+		return nil, errors.Trace(err)
+	} else if err != nil {
+		logger.Warningf("could not get remote units for %q: %v", remoteApp.Name(), err)
+	}
+
+	var ops []txn.Op
+	logger.Debugf("got %v relation units to clean", len(remoteUnits))
+	failRemoteUnits := false
+	for _, ru := range remoteUnits {
+		leaveScopeOps, err := ru.leaveScopeForcedOps(op)
+		if err != nil && err != jujutxn.ErrNoOperations {
+			op.AddError(err)
+			failRemoteUnits = true
+		}
+		ops = append(ops, leaveScopeOps...)
+	}
+	if !op.Force && failRemoteUnits {
+		return nil, errors.Trace(op.LastError())
+	}
+	return ops, nil
+}
+
 // When 'force' is set, this call will construct and apply needed operations
 // as well as accumulate all operational errors encountered.
 // If the 'force' is not set, any error will be fatal and no operations will be applied.
@@ -354,30 +391,11 @@ func (op *DestroyRelationOperation) internalDestroy() (ops []txn.Op, err error) 
 		// If the status of the consumed app is terminated, we will never
 		// get an orderly exit of units from scope so force the issue.
 		if isCrossModel {
-			statusInfo, err := remoteApp.Status()
-			if op.FatalError(err) && !errors.IsNotFound(err) {
+			destroyOps, err := destroyCrossModelRelationUnitsOps(&op.ForcedOperation, remoteApp, op.r, true)
+			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			if err == nil && statusInfo.Status == status.Terminated {
-				logger.Debugf("forcing cleanup of units for %v", remoteApp.Name())
-				remoteUnits, err := rel.AllRemoteUnits(remoteApp.Name())
-				if op.FatalError(err) {
-					return nil, errors.Trace(err)
-				}
-				logger.Debugf("got %v relation units to clean", len(remoteUnits))
-				failRemoteUnits := false
-				for _, ru := range remoteUnits {
-					leaveScopeOps, err := ru.leaveScopeForcedOps(&op.ForcedOperation)
-					if err != nil && err != jujutxn.ErrNoOperations {
-						op.AddError(err)
-						failRemoteUnits = true
-					}
-					ops = append(ops, leaveScopeOps...)
-				}
-				if !op.Force && failRemoteUnits {
-					return nil, errors.Trace(op.LastError())
-				}
-			}
+			ops = append(ops, destroyOps...)
 		}
 	}
 
@@ -592,10 +610,7 @@ func (r *Relation) removeRemoteEndpointOps(ep Endpoint, unitDying bool) ([]txn.O
 		hasLastRef := bson.D{{"life", Dying}, {"relationcount", 1}}
 		removable := append(bson.D{{"_id", ep.ApplicationName}}, hasLastRef...)
 		if err := applications.Find(removable).One(&app.doc); err == nil {
-			removeOps, err := app.removeOps(hasLastRef)
-			if err != nil {
-				return nil, err
-			}
+			removeOps := app.removeOps(hasLastRef)
 			return removeOps, nil
 		} else if err != mgo.ErrNotFound {
 			return nil, err

--- a/state/relationunit_test.go
+++ b/state/relationunit_test.go
@@ -211,7 +211,7 @@ func (s *RelationUnitSuite) TestRemoteUnitErrors(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `"mysql" is not a valid unit name`)
 
 	_, err = rel.RemoteUnit("wordpress/0")
-	c.Assert(err, gc.ErrorMatches, `remote application "wordpress" not found`)
+	c.Assert(err, gc.ErrorMatches, `saas application "wordpress" not found`)
 
 	_, err = rel.RemoteUnit("mysql1/0")
 	c.Assert(err, gc.ErrorMatches, `application "mysql1" is not a member of "wordpress:db mysql:server"`)

--- a/state/state.go
+++ b/state/state.go
@@ -1017,7 +1017,7 @@ func (st *State) addPeerRelationsOps(applicationName string, peers map[string]ch
 }
 
 var (
-	errSameNameRemoteApplicationExists = errors.Errorf("remote application with same name already exists")
+	errSameNameRemoteApplicationExists = errors.Errorf("saas application with same name already exists")
 	errLocalApplicationExists          = errors.Errorf("application already exists")
 )
 
@@ -2023,7 +2023,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 		return nil, err
 	}
 	if app1.IsRemote() && app2.IsRemote() {
-		return nil, errors.Errorf("cannot add relation between remote applications %q and %q", eps[0].ApplicationName, eps[1].ApplicationName)
+		return nil, errors.Errorf("cannot add relation between saas applications %q and %q", eps[0].ApplicationName, eps[1].ApplicationName)
 	}
 	remoteRelation := app1.IsRemote() || app2.IsRemote()
 	ep0ok := app1.IsRemote() || eps[0].Scope == charm.ScopeGlobal

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1704,7 +1704,7 @@ func (s *StateSuite) TestAddApplicationSameRemoteExists(c *gc.C) {
 		Name: "s1", SourceModel: s.Model.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
-	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": remote application with same name already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": saas application with same name already exists`)
 }
 
 func (s *StateSuite) TestAddApplicationRemoteAddedAfterInitial(c *gc.C) {
@@ -1718,7 +1718,7 @@ func (s *StateSuite) TestAddApplicationRemoteAddedAfterInitial(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}).Check()
 	_, err := s.State.AddApplication(state.AddApplicationArgs{Name: "s1", Charm: charm})
-	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": remote application with same name already exists`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "s1": saas application with same name already exists`)
 }
 
 func (s *StateSuite) TestAddApplicationSameLocalExists(c *gc.C) {

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -153,6 +153,7 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 					Life:            app.life,
 					ModelUUID:       app.modelUUID,
 					IsConsumerProxy: app.registered,
+					Status:          string(app.status),
 					Macaroon:        mac,
 				},
 			}
@@ -412,6 +413,7 @@ type mockRemoteApplication struct {
 	life       life.Value
 	modelUUID  string
 	registered bool
+	status     status.Status
 }
 
 type mockRemoteRelationWatcher struct {

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -19,6 +19,7 @@ import (
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 )
@@ -127,6 +128,9 @@ type Config struct {
 	NewRemoteModelFacadeFunc newRemoteRelationsFacadeFunc
 	Clock                    clock.Clock
 	Logger                   Logger
+
+	// Used for testing.
+	Runner *worker.Runner
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -155,9 +159,9 @@ func New(config Config) (*Worker, error) {
 		return nil, errors.Trace(err)
 	}
 
-	w := &Worker{
-		config: config,
-		runner: worker.NewRunner(worker.RunnerParams{
+	runner := config.Runner
+	if runner == nil {
+		runner = worker.NewRunner(worker.RunnerParams{
 			Clock: config.Clock,
 
 			// One of the remote application workers failing should not
@@ -166,7 +170,12 @@ func New(config Config) (*Worker, error) {
 
 			// For any failures, try again in 15 seconds.
 			RestartDelay: 15 * time.Second,
-		}),
+		})
+	}
+	w := &Worker{
+		config:     config,
+		offerUUIDs: make(map[string]string),
+		runner:     runner,
 	}
 	err := catacomb.Invoke(catacomb.Plan{
 		Site: &w.catacomb,
@@ -184,6 +193,9 @@ type Worker struct {
 	logger   loggo.Logger
 
 	runner *worker.Runner
+
+	// offerUUIDs records the offer UUID used for each saas name.
+	offerUUIDs map[string]string
 }
 
 // Kill is defined on worker.Worker.
@@ -240,23 +252,45 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 
 	for i, result := range results {
 		name := applicationIds[i]
-		if result.Error != nil {
-			// The the remote application has been removed, stop its worker.
-			if params.IsCodeNotFound(result.Error) {
-				if err := w.runner.StopWorker(name); err != nil {
-					return err
+
+		// The remote application may refer to an offer that has been removed from
+		// the offering model, or it may refer to a new offer with a different UUID.
+		// If it is for a new offer, we need to stop any current worker for the old offer.
+		appGone := result.Error != nil && params.IsCodeNotFound(result.Error)
+		if result.Error != nil && !appGone {
+			return errors.Annotatef(result.Error, "querying remote application %q", name)
+		}
+
+		var remoteApp *params.RemoteApplication
+		offerChanged := false
+		if !appGone {
+			remoteApp = result.Result
+			existingOfferUUID, ok := w.offerUUIDs[result.Result.Name]
+			appGone = remoteApp.Status == string(status.Terminated) || remoteApp.Life == life.Dead
+			offerChanged = ok && existingOfferUUID != result.Result.OfferUUID
+		}
+		if appGone || offerChanged {
+			// The remote application has been removed, stop its worker.
+			logger.Debugf("saas application %q gone from offering model", name)
+			existingWorker, err := w.runner.Worker(name, w.catacomb.Dying())
+			if err != nil {
+				w.logger.Warningf("error getting existing saas worker for %q", name, err)
+			}
+			if existingWorker != nil {
+				existingWorker.Kill()
+				if err := existingWorker.Wait(); err != nil {
+					w.logger.Warningf("error stopping saas worker for %q", name, err)
 				}
+			}
+			delete(w.offerUUIDs, name)
+			if appGone {
 				continue
 			}
-			return errors.Annotatef(err, "querying remote application %q", name)
-		}
-		if _, err := w.runner.Worker(name, w.catacomb.Dying()); err == nil {
-			// TODO(wallyworld): handle application dying or dead.
-			// As of now, if the worker is already running, that's all we need.
+		} else if _, err := w.runner.Worker(name, w.catacomb.Dying()); err == nil {
+			w.logger.Criticalf("already running remote application worker for %q", name)
 			continue
 		}
 
-		remoteApp := *result.Result
 		startFunc := func() (worker.Worker, error) {
 			appWorker := &remoteApplicationWorker{
 				offerUUID:                         remoteApp.OfferUUID,
@@ -285,6 +319,7 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 		if err := w.runner.StartWorker(name, startFunc); err != nil {
 			return errors.Annotate(err, "error starting remote application worker")
 		}
+		w.offerUUIDs[name] = remoteApp.OfferUUID
 	}
 	return nil
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -964,7 +964,7 @@ func (ctx *HookContext) RemoteUnitName() (string, error) {
 // Implements jujuc.RelationHookContext.relationHookContext, part of runner.Context.
 func (ctx *HookContext) RemoteApplicationName() (string, error) {
 	if ctx.remoteApplicationName == "" {
-		return "", errors.NotFoundf("remote application")
+		return "", errors.NotFoundf("saas application")
 	}
 	return ctx.remoteApplicationName, nil
 }

--- a/worker/uniter/runner/jujuc/jujuctesting/relationhook.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relationhook.go
@@ -58,7 +58,7 @@ func (c *ContextRelationHook) RemoteApplicationName() (string, error) {
 	_ = c.stub.NextErr()
 	var err error
 	if c.info.RemoteApplicationName == "" {
-		err = errors.NotFoundf("remote application")
+		err = errors.NotFoundf("saas application")
 	}
 
 	return c.info.RemoteApplicationName, err


### PR DESCRIPTION
There's scenarios which can break cross model relations deployments. This PR contains a fix for some of the issues.  In addition, investigating this found a problem with the unit agent permission checks which is also fixed. Finally, the key user facing errors out of state have been tweaked to use the term "saas" rather than "remote" as this matches what we show in status.

The key fixes:
1. consuming a terminated offer a second time
When an offer is removed, it is marked as terminated in the consuming model. A new offer can be consumed again, but if it has the same name as before, the terminated offer record was not replaced properly. To get the consuming model to notice the offer is consumed again, the old terminated one has to be marked as Dead and then removed.

Part of doing that fix resulted in some common "iterate over relations and leave scope" code pulled into a new method.

2. remote relations workers
Fixing  issue 1 fired events to the remote relations worker. But this worker was not properly noticing that the consumed application was for a different offer uuid (the name was the same). So extra logic was added to stop and start a new worker as needed. Also, when an offer is terminated, we need to immediately stop the status watcher.

3. Unit agent permissions
If a unit agent asks the Life or CharmModifiedVersion or CharmURL of its application, the unit agent permission checks were rejecting this. This isn't directly a cmr issue but is fixed here as a driveby.
Also, if an invalid unit tag is passed in to LeaveScope() surface that error rather than a permission one.

Still todo - when an offer is --force removed, not all internal cross model artefacts are cleaned up and the next time a new offer of the same name is used, the set up is not properly done and relations don't run all the hooks.

## QA steps

Create an offer
Consume the offer but do not relate to it
Remove the offer
Observe the saas application goes to terminated.
Consume the offer again (do not remove the terminated saas app first) and relate to it
Observe the relation hooks running

Previously consuming the offer a second time would not set up the workers to process the relation.

## Bug reference

Partial fix for https://bugs.launchpad.net/bugs/1940983
