### PR TITLE
Adds controller tag support to instance profile.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -190,7 +190,12 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 		if !ok {
 			return nil, errors.NewNotValid(nil, "cannot find controller name in config")
 		}
-		instProfile, err := ensureControllerInstanceProfile(ctx.Context(), e.iamClient, controllerName)
+		controllerUUID := args.ControllerConfig[controller.ControllerUUIDKey].(string)
+		instProfile, err := ensureControllerInstanceProfile(
+			ctx.Context(),
+			e.iamClient,
+			controllerName,
+			controllerUUID)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/ec2/iam.go
+++ b/provider/ec2/iam.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/environs/tags"
 )
 
 // instanceProfileClient is a subset interface of the ec2 client for attaching
@@ -70,10 +71,17 @@ func ensureControllerInstanceProfile(
 	ctx stdcontext.Context,
 	client IAMClient,
 	controllerName string,
+	controllerUUID string,
 ) (*iamtypes.InstanceProfile, error) {
 	profileName := fmt.Sprintf("juju-controller-%s", controllerName)
 	res, err := client.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
 		InstanceProfileName: aws.String(profileName),
+		Tags: []iamtypes.Tag{
+			{
+				Key:   aws.String(tags.JujuController),
+				Value: aws.String(controllerUUID),
+			},
+		},
 	})
 	if err != nil {
 		var alreadyExistsErr *iamtypes.EntityAlreadyExistsException


### PR DESCRIPTION
Instance profiles created by the controller now contain the controller
tag that they are made for.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap an AWS controller with `juju bootstrap aws/ap-southeast-2 --bootstrap-constraints="instance-role=auto" testmctestface`

Check that the corresponding Instance Profile has the controller uuid tag set with:

aws iam list-instance-profile-tags --instance-profile-name "juju-controller-testmctestface"
