### PR TITLE
Tweaks to make consuming cmr offers more robust

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -105,8 +105,12 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 		}
 		if err == nil && remoteApp.IsConsumerProxy() {
 			logger.Debugf("destroy consuming app proxy for %v", applicationTag.Id())
-			if err := remoteApp.Destroy(); err != nil {
+			opErrs, err := remoteApp.DestroyWithForce(true, 0)
+			if err != nil {
 				return errors.Trace(err)
+			}
+			if len(opErrs) > 0 {
+				logger.Warningf("errors removing consuming app proxy for %v: %v", applicationTag.Id(), opErrs)
 			}
 		}
 

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -4,6 +4,8 @@
 package crossmodel
 
 import (
+	"time"
+
 	"github.com/juju/charm/v8"
 	"gopkg.in/macaroon.v2"
 
@@ -234,10 +236,10 @@ type Charm interface {
 // RemoteApplication represents the state of an application hosted in an external
 // (remote) model.
 type RemoteApplication interface {
-	// Destroy ensures that this remote application reference and all its relations
-	// will be removed at some point; if no relation involving the
-	// application has any units in scope, they are all removed immediately.
-	Destroy() error
+	// DestroyWithForce in addition to doing what Destroy() does,
+	// when force is passed in as 'true', forces th destruction of remote application,
+	// ignoring errors.
+	DestroyWithForce(bool, time.Duration) (opErrs []error, err error)
 
 	// Name returns the name of the remote application.
 	Name() string

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -239,7 +239,7 @@ type RemoteApplication interface {
 	// DestroyWithForce in addition to doing what Destroy() does,
 	// when force is passed in as 'true', forces th destruction of remote application,
 	// ignoring errors.
-	DestroyWithForce(bool, time.Duration) (opErrs []error, err error)
+	DestroyWithForce(force bool, maxWait time.Duration) (opErrs []error, err error)
 
 	// Name returns the name of the remote application.
 	Name() string

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -7,6 +7,7 @@
 package application
 
 import (
+	"fmt"
 	"math"
 	"net"
 	"reflect"
@@ -2496,6 +2497,9 @@ func (api *APIBase) maybeUpdateExistingApplicationEndpoints(
 	}
 	if existingRemoteApp.SourceModel().Id() != sourceModelTag.Id() {
 		return nil, "", errors.AlreadyExistsf("saas application called %q from a different model", applicationName)
+	}
+	if existingRemoteApp.Life() != state.Alive {
+		return nil, "", errors.NewAlreadyExists(nil, fmt.Sprintf("saas application called %q exists but is terminating", applicationName))
 	}
 	appStatus, err := existingRemoteApp.Status()
 	if err != nil {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1784,6 +1784,36 @@ func (s *ApplicationSuite) TestConsumeRemoteAppExistsDifferentSourceModel(c *gc.
 	c.Assert(results.OneError(), gc.ErrorMatches, `saas application called "hosted-mysql" from a different model already exists`)
 }
 
+func (s *ApplicationSuite) TestConsumeRemoteAppDying(c *gc.C) {
+	arg := params.ConsumeApplicationArg{
+		ApplicationOfferDetails: params.ApplicationOfferDetails{
+			SourceModelTag:         coretesting.ModelTag.String(),
+			OfferName:              "hosted-mysql",
+			OfferUUID:              "hosted-mysql-uuid",
+			ApplicationDescription: "a database",
+			Endpoints:              []params.RemoteEndpoint{{Name: "database", Interface: "mysql", Role: "provider"}},
+			OfferURL:               "othermodel.hosted-mysql",
+		},
+	}
+	results, err := s.api.Consume(params.ConsumeApplicationArgs{
+		Args: []params.ConsumeApplicationArg{arg},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+
+	originalApp, ok := s.backend.remoteApplications["hosted-mysql"].(*mockRemoteApplication)
+	c.Assert(ok, jc.IsTrue)
+	originalApp.life = state.Dying
+	s.backend.remoteApplications["hosted-mysql"] = originalApp
+
+	results, err = s.api.Consume(params.ConsumeApplicationArgs{
+		Args: []params.ConsumeApplicationArg{arg},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.OneError(), gc.ErrorMatches, `saas application called "hosted-mysql" exists but is terminating`)
+}
+
 func (s *ApplicationSuite) TestConsumeRemoteAppTerminated(c *gc.C) {
 	arg := params.ConsumeApplicationArg{
 		ApplicationOfferDetails: params.ApplicationOfferDetails{

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -311,6 +311,7 @@ type RemoteApplication interface {
 	Destroy() error
 	DestroyOperation(force bool) *state.DestroyRemoteApplicationOperation
 	Status() (status.StatusInfo, error)
+	Life() state.Life
 }
 
 func (s stateShim) RemoteApplication(name string) (RemoteApplication, error) {

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -315,6 +315,7 @@ func (m *mockApplication) MergeBindings(bindings *state.Bindings, force bool) er
 type mockRemoteApplication struct {
 	jtesting.Stub
 	name           string
+	life           state.Life
 	sourceModelTag names.ModelTag
 	endpoints      []state.Endpoint
 	bindings       map[string]string
@@ -327,6 +328,10 @@ type mockRemoteApplication struct {
 
 func (m *mockRemoteApplication) Name() string {
 	return m.name
+}
+
+func (m *mockRemoteApplication) Life() state.Life {
+	return m.life
 }
 
 func (m *mockRemoteApplication) Status() (status.StatusInfo, error) {

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -363,7 +363,7 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 
 			// Force any remote units to leave scope so the offer can be cleaned up.
 			destroyRelUnitOps, err := destroyCrossModelRelationUnitsOps(&op.ForcedOperation, remoteApp, rel, false)
-			if err != nil {
+			if err != nil && err != jujutxn.ErrNoOperations {
 				return nil, errors.Trace(err)
 			}
 			ops = append(ops, destroyRelUnitOps...)

--- a/state/relation.go
+++ b/state/relation.go
@@ -341,7 +341,7 @@ func destroyCrossModelRelationUnitsOps(op *ForcedOperation, remoteApp *RemoteApp
 			return nil, errors.Trace(err)
 		}
 		if err != nil || statusInfo.Status != status.Terminated {
-			return nil, nil
+			return nil, jujutxn.ErrNoOperations
 		}
 	}
 	logger.Debugf("forcing cleanup of units for %v", remoteApp.Name())
@@ -392,7 +392,7 @@ func (op *DestroyRelationOperation) internalDestroy() (ops []txn.Op, err error) 
 		// get an orderly exit of units from scope so force the issue.
 		if isCrossModel {
 			destroyOps, err := destroyCrossModelRelationUnitsOps(&op.ForcedOperation, remoteApp, op.r, true)
-			if err != nil {
+			if err != nil && err != jujutxn.ErrNoOperations {
 				return nil, errors.Trace(err)
 			}
 			ops = append(ops, destroyOps...)

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -406,7 +406,7 @@ func (op *DestroyRemoteApplicationOperation) destroyOps() (ops []txn.Op, err err
 			// If the remote app has been terminated, we may have been offline
 			// and not noticed so need to clean up any exiting relation units.
 			destroyRelUnitOps, err := destroyCrossModelRelationUnitsOps(&op.ForcedOperation, op.app, rel, true)
-			if err != nil {
+			if err != nil && err != jujutxn.ErrNoOperations {
 				return nil, errors.Trace(err)
 			}
 			ops = append(ops, destroyRelUnitOps...)
@@ -567,7 +567,7 @@ func (op *terminateRemoteApplicationOperation) Build(attempt int) ([]txn.Op, err
 	// Destroying each relation also forces remote units to leave scope.
 	for _, rel := range rels {
 		relOps, err := destroyCrossModelRelationUnitsOps(&ForcedOperation{Force: true}, op.app, rel, false)
-		if err != nil {
+		if err != nil && err != jujutxn.ErrNoOperations {
 			return nil, errors.Annotatef(err, "removing relation %q", rel)
 		}
 		ops = append(ops, relOps...)

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -496,6 +496,11 @@ func (s *RemoteApplication) Status() (status.StatusInfo, error) {
 
 // SetStatus sets the status for the application.
 func (s *RemoteApplication) SetStatus(info status.StatusInfo) error {
+	// We only care about status for alive apps; we want to
+	// avoid stray updates from the other model.
+	if s.Life() != Alive {
+		return nil
+	}
 	if !info.Status.KnownWorkloadStatus() {
 		return errors.Errorf("cannot set invalid status %q", info.Status)
 	}

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -203,7 +203,7 @@ func (s *remoteApplicationSuite) TestGetSetStatusNotFound(c *gc.C) {
 		Since:   &now,
 	}
 	err = s.application.SetStatus(sInfo)
-	c.Check(err, gc.ErrorMatches, `cannot set status: saas application "mysql" not found`)
+	c.Check(err, jc.ErrorIsNil)
 
 	statusInfo, err := s.application.Status()
 	c.Check(err, gc.ErrorMatches, `cannot get status: saas application "mysql" not found`)

--- a/state/remoteentities.go
+++ b/state/remoteentities.go
@@ -262,6 +262,15 @@ func (r *RemoteEntities) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) 
 		macJSON = string(b)
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			// The entity may have been removed; if so,
+			// return a not found error.
+			_, err := r.GetToken(entity)
+			if err == nil {
+				return nil, errors.Errorf("unexpected entity %q", entity)
+			}
+			return nil, errors.Trace(err)
+		}
 		ops := []txn.Op{{
 			C:      remoteEntitiesC,
 			Id:     entity.String(),

--- a/state/remoteentities_test.go
+++ b/state/remoteentities_test.go
@@ -74,6 +74,10 @@ func (s *RemoteEntitiesSuite) TestMacaroon(c *gc.C) {
 	re := s.State.RemoteEntities()
 	mac, err := newMacaroon("id")
 	c.Assert(err, jc.ErrorIsNil)
+
+	err = re.SaveMacaroon(names.NewApplicationTag("foo"), mac)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
 	err = re.SaveMacaroon(entity, mac)
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
When removing and re-consuming a cross model offer, it's possible that the remote proxy might be removed in the middle of the remote relation worker updating things like the macaroon to use. This PR handles that sort of case and make the worker more resilient to not found errors.
Also, when a consuming saas application is dying, we ignore status updates from the offering side as these can interfere with a clean status history.
On the offering side, we use "force" to destroy the consuming app proxy to ensure it is removed, otherwise it's possible a dying entitiy can remain and wedge the offering processing of events.

## QA steps

Deploy a cmr scenario like in #13349 and on the consuming side, remove the saas app and check logs for errors.

## Bug reference

https://bugs.launchpad.net/charm-ceph-mon/+bug/1940983