### PR TITLE
opt out telemetry

### DIFF
--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -286,7 +286,6 @@ func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(cfg *config.Config, ids
 }
 
 func (api *CharmRevisionUpdaterAPI) fetchCharmhubInfos(cfg *config.Config, ids []charmhubID, appInfos []appInfo) ([]latestCharmInfo, error) {
-	cfg.Telemetry()
 	var requestMetrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string
 	if cfg.Telemetry() {
 		var err error

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmstore"
 	charmmetrics "github.com/juju/juju/core/charm/metrics"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
 )
@@ -141,6 +142,15 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	model, err := api.state.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, err := model.Config()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	telemetry := cfg.Telemetry()
 
 	// Partition the charms into charmhub vs charmstore so we can query each
 	// batch separately.
@@ -196,10 +206,12 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 			cid := charmstore.CharmID{
 				URL:     curl,
 				Channel: application.Channel(),
-				Metadata: map[string]string{
+			}
+			if telemetry {
+				cid.Metadata = map[string]string{
 					"series": origin.Platform.Series,
 					"arch":   origin.Platform.Architecture,
-				},
+				}
 			}
 			charmstoreIDs = append(charmstoreIDs, cid)
 			charmstoreApps = append(charmstoreApps, appInfo{
@@ -214,14 +226,14 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 
 	var latest []latestCharmInfo
 	if len(charmstoreIDs) > 0 {
-		storeLatest, err := api.fetchCharmstoreInfos(charmstoreIDs, charmstoreApps)
+		storeLatest, err := api.fetchCharmstoreInfos(cfg, charmstoreIDs, charmstoreApps)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		latest = append(latest, storeLatest...)
 	}
 	if len(charmhubIDs) > 0 {
-		hubLatest, err := api.fetchCharmhubInfos(charmhubIDs, charmhubApps)
+		hubLatest, err := api.fetchCharmhubInfos(cfg, charmhubIDs, charmhubApps)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -231,20 +243,20 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 	return latest, nil
 }
 
-func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(ids []charmstore.CharmID, appInfos []appInfo) ([]latestCharmInfo, error) {
+func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(cfg *config.Config, ids []charmstore.CharmID, appInfos []appInfo) ([]latestCharmInfo, error) {
 	client, err := api.newCharmstoreClient(api.state)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	metadata, err := charmstoreApiMetadata(api.state)
-	if err != nil {
-		return nil, errors.Trace(err)
+
+	var metadata map[string]string
+	if cfg.Telemetry() {
+		metadata, err = charmstoreApiMetadata(api.state)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		metadata["environment_uuid"] = cfg.UUID() // duplicates model_uuid, but send to charmstore for legacy reasons
 	}
-	model, err := api.state.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	metadata["environment_uuid"] = model.UUID() // duplicates model_uuid, but send to charmstore for legacy reasons
 	results, err := charmstore.LatestCharmInfo(client, ids, metadata)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -273,10 +285,15 @@ func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(ids []charmstore.CharmI
 	return latest, nil
 }
 
-func (api *CharmRevisionUpdaterAPI) fetchCharmhubInfos(ids []charmhubID, appInfos []appInfo) ([]latestCharmInfo, error) {
-	requestMetrics, err := charmhubRequestMetadata(api.state)
-	if err != nil {
-		return nil, errors.Trace(err)
+func (api *CharmRevisionUpdaterAPI) fetchCharmhubInfos(cfg *config.Config, ids []charmhubID, appInfos []appInfo) ([]latestCharmInfo, error) {
+	cfg.Telemetry()
+	var requestMetrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string
+	if cfg.Telemetry() {
+		var err error
+		requestMetrics, err = charmhubRequestMetadata(api.state)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	client, err := api.newCharmhubClient(api.state)
 	if err != nil {

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -280,6 +280,10 @@ const (
 	// TestModeKey is the key for identifying the model should be run in test
 	// mode.
 	TestModeKey = "test-mode"
+
+	// DisableTelemetryKey is a key for determining whether telemetry on juju
+	// models will be done.
+	DisableTelemetryKey = "disable-telemetry"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -490,6 +494,7 @@ var defaultConfigValues = map[string]interface{}{
 	"enable-os-upgrade":           true,
 	"development":                 false,
 	TestModeKey:                   false,
+	DisableTelemetryKey:           false,
 	TransmitVendorMetricsKey:      true,
 	UpdateStatusHookInterval:      DefaultUpdateStatusHookInterval,
 	EgressSubnets:                 "",
@@ -1536,6 +1541,12 @@ func (c *Config) LXDSnapChannel() string {
 	return c.asString(LXDSnapChannel)
 }
 
+// Telemetry returns whether telemetry is enabled for the model.
+func (c *Config) Telemetry() bool {
+	value, _ := c.defined[DisableTelemetryKey].(bool)
+	return !value
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1652,6 +1663,7 @@ var alwaysOptional = schema.Defaults{
 	IgnoreMachineAddresses:        schema.Omit,
 	AutomaticallyRetryHooks:       schema.Omit,
 	TestModeKey:                   schema.Omit,
+	DisableTelemetryKey:           schema.Omit,
 	ModeKey:                       schema.Omit,
 	TransmitVendorMetricsKey:      schema.Omit,
 	NetBondReconfigureDelayKey:    schema.Omit,
@@ -2093,6 +2105,11 @@ If true, accessing the charm store does not affect statistical
 data of the store. (default false)`,
 		Type:  environschema.Tbool,
 		Group: environschema.EnvironGroup,
+	},
+	DisableTelemetryKey: {
+		Description: `Whether the model disables telemetry`,
+		Type:        environschema.Tbool,
+		Group:       environschema.EnvironGroup,
 	},
 	ModeKey: {
 		Description: `Mode sets the type of mode the model should run in.

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -2107,7 +2107,7 @@ data of the store. (default false)`,
 		Group: environschema.EnvironGroup,
 	},
 	DisableTelemetryKey: {
-		Description: `Whether the model disables telemetry`,
+		Description: `Disable telemetry reporting of model information`,
 		Type:        environschema.Tbool,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1516,6 +1516,27 @@ func (s *ConfigSuite) TestLXDSnapChannelConfig(c *gc.C) {
 	c.Assert(config.LXDSnapChannel(), gc.Equals, "latest/candidate")
 }
 
+func (s *ConfigSuite) TestTelemetryConfig(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{})
+	c.Assert(cfg.Telemetry(), jc.IsTrue)
+}
+
+func (s *ConfigSuite) TestTelemetryConfigTrue(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{config.DisableTelemetryKey: true})
+	c.Assert(cfg.Telemetry(), jc.IsFalse)
+}
+
+func (s *ConfigSuite) TestTelemetryConfigDoesNotExist(c *gc.C) {
+	final := testing.Attrs{
+		"type": "my-type", "name": "my-name",
+		"uuid": testing.ModelTag.Id(),
+	}
+
+	cfg, err := config.New(config.NoDefaults, final)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Telemetry(), jc.IsTrue)
+}
+
 var serverKey2 = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIBPAIBAAJBALgI8m2TSdKefUOXkaluDrqbv1ua9gl2ec2ZrYQPDOQwDUoFXxQp


### PR DESCRIPTION
2nd PR for charmhub metrics feature work.

Add a disable-telemetry model-config with a default value of False.  This keeps current behavior and facilities upgrades and migration code.  Internally to juju the call will be Telemetry and return true.

This value acts on a per model basis for any repository charm and general model metrics.

## QA steps

```console
# Setup for test and migration.
$ juju bootstrap localhost destination
$ juju bootstrap localhost testme
$ juju add-model move-me
$ juju add-model six ; juju deploy ubuntu ; juju deploy ntp ; juju relate ntp ubuntu

# Disable metrics on one model and see they do not get passed. Trigger the charmrevisionupdater by upgrading the controller. 
$ juju model-config -m controller "logging-config='#charmhub=TRACE';<root>=INFO"
$ juju model-config disable-telemetry=true
$ juju upgrade-controller --build-agent

# Verify metrics disabled, only the controller model metric data should be visible
$ juju debug-log -m controller | grep metrics

# Migrate the model and verify the config didn't change.
$ juju migrate move-me destination
$ juju switch destination:admin/move-me
$ juju model-config disable-telemetry
True
```
