### PR TITLE
[dev] Rely on instancemutator to apply lxd profiles in async charm dl mode

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -485,7 +485,7 @@ func (adapter charmInfoAdapter) Config() *charm.Config {
 }
 
 func (adapter charmInfoAdapter) LXDProfile() *charm.LXDProfile {
-	return adapter.meta.LXDProfile
+	return nil // not part of the essential metadata
 }
 
 func (adapter charmInfoAdapter) Metrics() *charm.Metrics {

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -48,6 +48,7 @@ func (c *Charm) setDetails(details CharmChange) {
 	})
 
 	c.details = details
+	c.hub.Publish(modelCharmChanged, details)
 }
 
 // copy returns a copy of the unit, ensuring appropriate deep copying.

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -137,12 +137,15 @@ func (m *Machine) WatchContainers() (*PredicateStringsWatcher, error) {
 //     2. A unit being removed has a profile and other units
 //        exist on the machine.
 //     3. The LXD profile of an application with a unit on this
-//        machine is added, removed, or exists.
+//        machine is added, removed, or exists. This also includes scenarios
+//        where the charm is being downloaded asynchronously and its metadata
+//        gets updated once the download is complete.
 //     4. The machine's instanceId is changed, indicating it
 //        has been provisioned.
 func (m *Machine) WatchLXDProfileVerificationNeeded() (*MachineLXDProfileWatcher, error) {
 	return newMachineLXDProfileWatcher(MachineLXDProfileWatcherConfig{
 		appTopic:         applicationCharmURLChange,
+		charmTopic:       modelCharmChanged,
 		provisionedTopic: m.topic(machineProvisioned),
 		unitAddTopic:     modelUnitAdd,
 		unitRemoveTopic:  modelUnitRemove,

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -21,6 +21,8 @@ import (
 const (
 	// Model config has changed.
 	modelConfigChange = "model-config-change"
+	// Charm metadata has changed.
+	modelCharmChanged = "charm-change"
 	// A machine has been added to, or removed from the model.
 	modelAddRemoveMachine = "model-add-remove-machine"
 	// A unit has landed on a machine, or a subordinate unit has been changed,

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -65,8 +65,7 @@ type MetadataRequest struct {
 type EssentialMetadata struct {
 	ResolvedOrigin Origin
 
-	Meta       *charm.Meta
-	Manifest   *charm.Manifest
-	Config     *charm.Config
-	LXDProfile *charm.LXDProfile
+	Meta     *charm.Meta
+	Manifest *charm.Manifest
+	Config   *charm.Config
 }

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -402,7 +402,6 @@ func (c *CharmHubRepository) getEssentialMetadataForBatch(reqs []corecharm.Metad
 		res[reqIdx].Meta = chArchive.Meta()
 		res[reqIdx].Manifest = chArchive.Manifest()
 		res[reqIdx].Config = chArchive.Config()
-		res[reqIdx].LXDProfile = chArchive.LXDProfile()
 	}
 
 	return res, nil

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -420,7 +420,6 @@ charmcraft-version: 0.10.0
 	c.Assert(got[0].Meta.Name, gc.Equals, "dummy")
 	c.Assert(got[0].Config.Options["title"], gc.Not(gc.IsNil))
 	c.Assert(got[0].Manifest.Bases, gc.HasLen, 1)
-	c.Assert(got[0].LXDProfile, gc.Not(gc.IsNil))
 	c.Assert(got[0].ResolvedOrigin.ID, gc.Equals, "charmCHARMcharmCHARMcharmCHARM01", gc.Commentf("expected origin to be resolved"))
 }
 

--- a/core/charm/repository/charmstore.go
+++ b/core/charm/repository/charmstore.go
@@ -12,7 +12,6 @@ import (
 	charmresource "github.com/juju/charm/v9/resource"
 	"github.com/juju/charmrepo/v7"
 	"github.com/juju/charmrepo/v7/csclient"
-	"github.com/juju/charmrepo/v7/csclient/params"
 	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/errors"
 	"gopkg.in/macaroon.v2"
@@ -172,29 +171,6 @@ func (c *CharmStoreRepository) GetEssentialMetadata(reqs ...corecharm.MetadataRe
 		res[reqIdx].Meta = csMetaRes.CharmMetadata
 		res[reqIdx].Config = csMetaRes.CharmConfig
 		res[reqIdx].ResolvedOrigin = req.Origin
-
-		// The metadata call does not return back LXD profile
-		// information.  We need to make a separate call to grab it
-		// from within the archive.
-		profileReader, fetchErr := client.GetFileFromArchive(req.CharmURL, "lxd-profile.yaml")
-		if fetchErr != nil {
-			// It's fine if the charm does not provide an lxd profile
-			if errors.Cause(fetchErr) == params.ErrNotFound {
-				continue
-			}
-
-			return nil, errors.Annotatef(err, "retrieving metadata for %q", req.CharmURL)
-		}
-
-		res[reqIdx].LXDProfile, err = charm.ReadLXDProfile(profileReader)
-		if cErr := profileReader.Close(); cErr != nil {
-			c.logger.Errorf("unable to close LXD profile reader while retrieving metadata for %q: %v", req.CharmURL, cErr)
-			// NOTE(achilleasa): this is a non-fatal error; if the
-			// profile was successfully read we should continue.
-		}
-		if err != nil {
-			return nil, errors.Annotatef(err, "parsing lxd profile for %q", req.CharmURL)
-		}
 	}
 
 	return res, nil

--- a/core/charm/repository/charmstore_test.go
+++ b/core/charm/repository/charmstore_test.go
@@ -4,10 +4,6 @@
 package repository
 
 import (
-	"io"
-	"io/ioutil"
-	"strings"
-
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
 	csparams "github.com/juju/charmrepo/v7/csclient/params"
@@ -168,80 +164,7 @@ func (s *charmStoreRepositorySuite) TestGetDownloadURL(c *gc.C) {
 	c.Assert(gotOrigin, gc.DeepEquals, resolvedOrigin)
 }
 
-func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithLXDProfile(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-
-	curl := charm.MustParseURL("cs:ubuntu-lite")
-	requestedOrigin := corecharm.Origin{
-		Source:  "charm-store",
-		Channel: &charm.Channel{Risk: "edge"},
-	}
-	mac, err := macaroon.New(nil, []byte("id"), "", macaroon.LatestVersion)
-	c.Assert(err, jc.ErrorIsNil)
-	macaroons := macaroon.Slice{mac}
-
-	expMeta := new(charm.Meta)
-	expConfig := new(charm.Config)
-	rawProfile := `
-description: lxd profile for testing, will pass validation
-config:
-  security.nesting: "true"
-  security.privileged: "true"
-  linux.kernel_modules: openvswitch,nbd,ip_tables,ip6_tables
-  environment.http_proxy: ""
-devices:
-  tun:
-    path: /dev/net/tun
-    type: unix-char
-  sony:
-    type: usb
-    vendorid: 0fce
-    productid: 51da
-  bdisk:
-    type: unix-block
-    source: /dev/loop0
-  gpu:
-    type: gpu
-`[1:]
-	expProfile, err := charm.ReadLXDProfile(strings.NewReader(rawProfile))
-	c.Assert(err, jc.ErrorIsNil)
-
-	repo := NewCharmStoreRepository(s.logger, "store-api-endpoint")
-	repo.clientFactory = func(gotStoreURL string, gotChannel csparams.Channel, gotMacaroons macaroon.Slice) (CharmStoreClient, error) {
-		c.Assert(gotStoreURL, gc.Equals, "store-api-endpoint", gc.Commentf("the provided store API endpoint was not passed to the client factory"))
-		c.Assert(gotChannel, gc.Equals, csparams.Channel("edge"), gc.Commentf("the channel from the provided origin was not passed to the client factory"))
-		c.Assert(gotMacaroons, gc.DeepEquals, macaroons, gc.Commentf("the provided macaroons were not passed to the client factory"))
-		return s.client, nil
-	}
-	s.client.EXPECT().Meta(curl, gomock.Any()).DoAndReturn(
-		func(charmURL *charm.URL, dstIface interface{}) (*charm.URL, error) {
-			dst := dstIface.(*csMetadataResponse)
-			dst.CharmMetadata = expMeta
-			dst.CharmConfig = expConfig
-			return charmURL, nil
-		},
-	)
-	s.client.EXPECT().GetFileFromArchive(curl, "lxd-profile.yaml").DoAndReturn(
-		func(*charm.URL, string) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader(rawProfile)), nil
-		},
-	)
-
-	gotMeta, err := repo.GetEssentialMetadata(corecharm.MetadataRequest{
-		CharmURL:  curl,
-		Origin:    requestedOrigin,
-		Macaroons: macaroons,
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotMeta, gc.HasLen, 1)
-	// NOTE: we use pointer equality checks here.
-	c.Assert(gotMeta[0].Meta, gc.Equals, expMeta)
-	c.Assert(gotMeta[0].Config, gc.Equals, expConfig)
-	// NOTE: we need to use a deep equal check for the lxd profile.
-	c.Assert(gotMeta[0].LXDProfile, gc.DeepEquals, expProfile)
-}
-
-func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithoutLXDProfile(c *gc.C) {
+func (s *charmStoreRepositorySuite) TestGetEssentialMetadata(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	curl := charm.MustParseURL("cs:ubuntu-lite")
@@ -271,7 +194,6 @@ func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithoutLXDProfile(c 
 			return charmURL, nil
 		},
 	)
-	s.client.EXPECT().GetFileFromArchive(curl, "lxd-profile.yaml").Return(nil, csparams.ErrNotFound)
 
 	gotMeta, err := repo.GetEssentialMetadata(corecharm.MetadataRequest{
 		CharmURL:  curl,
@@ -283,7 +205,6 @@ func (s *charmStoreRepositorySuite) TestGetEssentialMetadataWithoutLXDProfile(c 
 	// NOTE: we use pointer equality checks here.
 	c.Assert(gotMeta[0].Meta, gc.Equals, expMeta)
 	c.Assert(gotMeta[0].Config, gc.Equals, expConfig)
-	c.Assert(gotMeta[0].LXDProfile, gc.IsNil, gc.Commentf("expected a nil profile when the charm does not provide an lxd profile"))
 }
 
 func (s *charmStoreRepositorySuite) setupMocks(c *gc.C) *gomock.Controller {


### PR DESCRIPTION
This PR improves the solution from #13305 by omitting the retrieval of lxd-profiles when fetching the essential charm metadata in the context of an asynchronous download flow.

Instead, we wait for the lxd-profile (if any) to be backfilled with the remaining charm metadata (actions, metrics etc.) once the charm download is complete and rely on the instancemutator worker to pick up the change and apply the profile to any already-running instances that use the particular charm.

This change gets rid of an extra API call in the charmstore repository's `GetEssentialMetadata` implementation which improves even further the time it takes for a `juju deploy` command to complete.

## QA steps

Apply this patch to the code from this PR:

```diff
diff --git a/apiserver/facades/controller/charmdownloader/charmdownloader.go b/apiserver/facades/controller/charmdownloader/charmdownloader.go
index 86f2be5dc6..6d536ab4e8 100644
--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -5,6 +5,7 @@ package charmdownloader

 import (
        "sync"
+       "time"

        "github.com/juju/clock"
        "github.com/juju/errors"
@@ -20,6 +21,7 @@ import (
        "github.com/juju/juju/core/status"
        "github.com/juju/juju/state/storage"
        "github.com/juju/juju/state/watcher"
+       "github.com/juju/juju/wrench"
 )

 var logger = loggo.GetLogger("juju.apiserver.charmdownloader")
@@ -180,6 +182,14 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
                return errors.Trace(err)
        }

+       //
+       _ = wrench.SetEnabled(true)
+       for wrench.IsActive("async", "block-meta-update") {
+               logger.Infof("!!! block-meta-update wrench in place; waiting 5sec for it to be removed")
+               <-a.clock.After(5 * time.Second)
+       }
+       //
+
        if _, err := downloader.DownloadAndStore(pendingCharmURL, *resolvedOrigin, macaroons, force); err != nil {
                now = a.clock.Now()
                // Update app status; it's fine if this fails as we just want
```

```sh
$ juju bootstap lxd --no-dashboard
$ juju controller-config 'features=[async-charm-downloads]'
$ juju ssh -m controller 0 'sudo mkdir /var/lib/juju/wrench && echo "block-meta-update" | sudo tee /var/lib/juju/wrench/async'

# Deploy a charm with an lxd profile. 
$ juju deploy cs:~juju-qa/bionic/lxd-profile-0

# The charmdownloader will block waiting for the wrench to be removed (you should see this in the *controller* logs)
# Wait until the machine is online and you start seeing error like this in the *model* logs
# ERROR juju.worker.dependency "uniter" manifold worker returned unexpected error: ... cannot retrieve charm: cs:~juju-qa/bionic/lxd-profile-0

# Then, remove the wrench:
$ juju ssh -m controller 0 'sudo rm -f /var/lib/juju/wrench/async'

# The instancemutator will apply the lxd profile; you can verify this by either displaying the profile for the container
# or by checking the logs for this device which is defined by the charm-included lxd profile
machine-0: 17:44:31 INFO juju.worker.diskmanager block devices changed: []storage.BlockDevice{storage.BlockDevice{DeviceName:"loop0", DeviceLinks:[]string(nil), Label:"", UUID:"", HardwareId:"", WWN:"", BusAddress:"", Size:0x37, FilesystemType:"", InUse:true, MountPoint:"", SerialId:""}}
```