### PR TITLE
Search only for LXD "container" images

### DIFF
--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -84,8 +84,8 @@ func (s *Server) FindImage(
 			continue
 		}
 		for _, alias := range aliases {
-			if result, _, err := source.GetImageAlias(alias); err == nil && result != nil && result.Target != "" {
-				target = result.Target
+			if res, _, err := source.GetImageAliasType("container", alias); err == nil && res != nil && res.Target != "" {
+				target = res.Target
 				break
 			}
 		}

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -98,12 +98,13 @@ func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 		"server-that-has-image": rSvr2,
 	})
 
+	const imageType = "container"
 	image := lxdapi.Image{Filename: "this-is-our-image"}
 	alias := lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-remote-target"}}
 	gomock.InOrder(
 		iSvr.EXPECT().GetImageAlias("juju/xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found")),
-		rSvr1.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found")),
-		rSvr2.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
+		rSvr1.EXPECT().GetImageAliasType(imageType, "xenial/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found")),
+		rSvr2.EXPECT().GetImageAliasType(imageType, "xenial/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
 		rSvr2.EXPECT().GetImage("foo-remote-target").Return(&image, lxdtesting.ETag, nil),
 	)
 
@@ -141,7 +142,7 @@ func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 	copyReq := &lxdclient.ImageCopyArgs{Aliases: []lxdapi.ImageAlias{{Name: localAlias}}}
 	gomock.InOrder(
 		iSvr.EXPECT().GetImageAlias(localAlias).Return(nil, lxdtesting.ETag, nil),
-		rSvr.EXPECT().GetImageAlias("xenial/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
+		rSvr.EXPECT().GetImageAliasType("container", "xenial/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
 		rSvr.EXPECT().GetImage("foo-remote-target").Return(&image, lxdtesting.ETag, nil),
 		iSvr.EXPECT().CopyImage(rSvr, image, copyReq).Return(copyOp, nil),
 	)
@@ -171,7 +172,7 @@ func (s *imageSuite) TestFindImageRemoteServersNotFound(c *gc.C) {
 	alias := lxdapi.ImageAliasesEntry{ImageAliasesEntryPut: lxdapi.ImageAliasesEntryPut{Target: "foo-remote-target"}}
 	gomock.InOrder(
 		iSvr.EXPECT().GetImageAlias("juju/bionic/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found")),
-		rSvr.EXPECT().GetImageAlias("bionic/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
+		rSvr.EXPECT().GetImageAliasType("container", "bionic/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
 		rSvr.EXPECT().GetImage("foo-remote-target").Return(
 			nil, lxdtesting.ETag, errors.New("failed to retrieve image")),
 	)


### PR DESCRIPTION
The linked bug describes an issue where searching simple-streams for LXD images by alias sometimes returns VM images, which are unsuitable for containers.

Here we ensure that we only ever look on remote servers for _container_ images specifically.

## QA steps

Bootstrap, add some machines and ensure `juju add-machine lxd:<machine ID>` always results in successful provisioning.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1943088
