### PR TITLE
Add tests to ensure simplestreams client does gzip compression

### DIFF
--- a/environs/simplestreams/export_test.go
+++ b/environs/simplestreams/export_test.go
@@ -3,6 +3,8 @@
 
 package simplestreams
 
+import jujuhttp "github.com/juju/http/v2"
+
 func ExtractCatalogsForProducts(metadata CloudMetadata, productIds []string) []MetadataCatalog {
 	return metadata.extractCatalogsForProducts(productIds)
 }
@@ -24,3 +26,11 @@ func Filter(entries IndexMetadataSlice, match func(*IndexMetadata) bool) IndexMe
 }
 
 var FetchData = fetchData
+
+func HttpClient(ds DataSource) *jujuhttp.Client {
+	urlds, ok := ds.(*urlDataSource)
+	if ok {
+		return urlds.httpClient
+	}
+	return nil
+}

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -1,7 +1,7 @@
 // Copyright 2013 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// The simplestreams package supports locating, parsing, and filtering metadata in simplestreams format.
+// Package simplestreams supports locating, parsing, and filtering metadata in simplestreams format.
 // See http://launchpad.net/simplestreams and in particular the doc/README file in that project for more information
 // about the file formats.
 //
@@ -163,7 +163,7 @@ type Indices struct {
 	Format  string                    `json:"format"`
 }
 
-// Exported for testing.
+// IndexReference is exported for testing.
 type IndexReference struct {
 	Indices
 	MirroredProductsPath string
@@ -238,7 +238,7 @@ func (entries MirrorRefSlice) filter(match func(*MirrorReference) bool) MirrorRe
 // cloudImageMetadata that are for the given product IDs.  They are kept in
 // the order of the parameter.
 func (metadata *CloudMetadata) extractCatalogsForProducts(productIds []string) []MetadataCatalog {
-	result := []MetadataCatalog{}
+	var result []MetadataCatalog
 	for _, id := range productIds {
 		if catalog, ok := metadata.Products[id]; ok {
 			result = append(result, catalog)
@@ -341,6 +341,7 @@ const (
 
 	// These constants define the currently supported simplestreams data
 	// formats.
+
 	IndexFormat   = "index:1.0"
 	ProductFormat = "products:1.0"
 	MirrorFormat  = "mirrors:1.0"


### PR DESCRIPTION
The `streams.canonical.com` server now supports serving gzip encoding of simplestreame metadata.
This PR simply adds tests to ensure we haven't accidentally disabled compression on the http transport, which would
prevent the gzip by default handling from being done by the underlying transport.

Also a few drive by lint fixes.

## QA steps

bootstrap any provider