### PR TITLE
Fix OS detection for controller charm tests

### DIFF
--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -301,9 +301,10 @@ func (s *BootstrapSuite) TestDashboardArchiveSuccess(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestLocalControllerCharm(c *gc.C) {
-	if runtime.GOOS != "linux" {
+	if coreos.HostOS() != coreos.Ubuntu {
 		c.Skip("controller charm only supported on Ubuntu")
 	}
+
 	_, cmd, err := s.initBootstrapCommand(c, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -322,9 +323,10 @@ func (s *BootstrapSuite) TestLocalControllerCharm(c *gc.C) {
 }
 
 func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
-	if runtime.GOOS != "linux" {
+	if coreos.HostOS() != coreos.Ubuntu {
 		c.Skip("controller charm only supported on Ubuntu")
 	}
+
 	// Remove the local controller charm so we use the store one.
 	controllerCharmPath := filepath.Join(s.dataDir, "charms", "controller.charm")
 	err := os.Remove(controllerCharmPath)


### PR DESCRIPTION
Controller charm tests are failing on CentOS, because the charm series is not supported. We should be skipping these tests, but we are only detecting Linux.

Here we look instead specifically for Ubuntu, meaning that the tests will be skipped on CentOS.

## QA steps

Run the `BootstrapSuite` tests and ensure that they run on Ubuntu. This verifies OS detection. They should then be skipped on CentOS.

## Documentation changes

None.

## Bug reference

N/A
