### PR TITLE
Make upgrade smoke test workflow more robust

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -125,7 +125,7 @@ jobs:
 
         attempt=0
         while true; do
-          UPDATED=$(juju machines -m controller --format=json | jq -r '.machines | .["0"] | .["juju-status"] | .version')
+          UPDATED=$(juju machines -m controller --format=json || : | jq -r '.machines | .["0"] | .["juju-status"] | .version')
           if [ "$CURRENT" != "$UPDATED" ]; then
               break
           fi
@@ -176,7 +176,7 @@ jobs:
 
         attempt=0
         while true; do
-          UPDATED=$(juju show-model default --format=json | jq -r '.default | .["agent-version"]')
+          UPDATED=$(juju show-model default --format=json || : | jq -r '.default | .["agent-version"]')
           if [ "$CURRENT" != "$UPDATED" ]; then
               break
           fi


### PR DESCRIPTION
In the GitHub workflow for smoke testing upgrades, we can attempt to acquire the current version from the controller while it is down for the upgrade, resulting in an API dial error.

```
++ juju machines -m controller --format=json
++ jq -r '.machines | .["0"] | .["juju-status"] | .version'
ERROR unable to connect to API: dial tcp 10.74.192.196:17070: connect: connection refused
+ UPDATED=null
Error: Process completed with exit code 1.
```

Here we simply swallow that error, relying on the loop to later return the correct version, or fail for running out of attempts.
