### PR TITLE
Update charmrepo dependency.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/google/go-querystring v1.0.0
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.4.1
-	github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474
 	github.com/gorilla/schema v0.0.0-20160426231512-08023a0215e7
 	github.com/gorilla/websocket v1.4.2
 	github.com/gosuri/uitable v0.0.1
@@ -50,7 +49,7 @@ require (
 	github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5
 	github.com/juju/blobstore/v2 v2.0.0-20210302045357-edd2b24570b7
 	github.com/juju/charm/v9 v9.0.0-20210922083844-6bd7c961dbc6
-	github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae
+	github.com/juju/charmrepo/v7 v7.0.0-20210923152136-0ae2f26643bf
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd/v3 v3.0.0-20210809234809-65029dab4cd0
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
@@ -140,7 +139,10 @@ require (
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 )
 
-require github.com/aws/aws-sdk-go v1.40.46
+require (
+	github.com/aws/aws-sdk-go v1.40.46
+	github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474
+)
 
 require (
 	cloud.google.com/go v0.56.0 // indirect
@@ -177,7 +179,6 @@ require (
 	github.com/juju/go4 v0.0.0-20160222163258-40d72ab9641a // indirect
 	github.com/juju/gojsonpointer v0.0.0-20150204194629-afe8b77aa08f // indirect
 	github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 // indirect
-	github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 // indirect
 	github.com/juju/lru v0.0.0-20190314140547-92a0afabdc41 // indirect
 	github.com/juju/txn v0.0.0-20210302043154-251cea9e140a // indirect
 	github.com/juju/usso v1.0.1 // indirect
@@ -214,7 +215,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/juju/names.v2 v2.0.0-20190813004204-e057c73bd1be // indirect
 	gopkg.in/macaroon-bakery.v2 v2.3.0 // indirect
-	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -412,8 +412,8 @@ github.com/juju/charm/v9 v9.0.0-20210421060150-6a300db18162/go.mod h1:GR/jjdIQ0V
 github.com/juju/charm/v9 v9.0.0-20210427070932-bc9b40c9b0f4/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
 github.com/juju/charm/v9 v9.0.0-20210922083844-6bd7c961dbc6 h1:uUQ8sqZ2k589pD6DH3cLYVsFoveN6NTQ9GsAG+SObSU=
 github.com/juju/charm/v9 v9.0.0-20210922083844-6bd7c961dbc6/go.mod h1:GR/jjdIQ0V9Yss8krrfqy3rRKJabbvDOXXRjfO+110M=
-github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae h1:TSnFigLC+7oV40UoyVjadtusvavzImpMl35kvAedFCg=
-github.com/juju/charmrepo/v7 v7.0.0-20210901102801-513fb9274dae/go.mod h1:wvP5voVa8s9ap6FSwenJmxw2g5cf8aSgjE8N8LOEwKc=
+github.com/juju/charmrepo/v7 v7.0.0-20210923152136-0ae2f26643bf h1:S+O2G9PIha/4mNy18ZASYyyU++pDDlI6c8iTCuoYRII=
+github.com/juju/charmrepo/v7 v7.0.0-20210923152136-0ae2f26643bf/go.mod h1:wvP5voVa8s9ap6FSwenJmxw2g5cf8aSgjE8N8LOEwKc=
 github.com/juju/clock v0.0.0-20180524022203-d293bb356ca4/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20180808021310-bab88fc67299/go.mod h1:nD0vlnrUjcjJhqN5WuCWZyzfd5AHZAC9/ajvbSx69xA=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=
@@ -455,7 +455,6 @@ github.com/juju/http v0.0.0-20201019013536-69ae1d429836 h1:F+KhYWcKHSUf/R7Ovoz+s
 github.com/juju/http v0.0.0-20201019013536-69ae1d429836/go.mod h1:lbZ9zbaOw9vMW7XMHGxYTgFadDDfzc4r8Aa7gP8GOYo=
 github.com/juju/http/v2 v2.0.0-20210623153641-418e83b0dab4 h1:rG3LBPCjMbyJS49DmiTG3tn/taVkaDiN898aDf+6fdk=
 github.com/juju/http/v2 v2.0.0-20210623153641-418e83b0dab4/go.mod h1:1cSFAPYQcBMP3uzXzAkTrX756GmMM/Dw0WxcnhNNntc=
-github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767 h1:COsaGcfAONDdIDnGS8yFdxOyReP7zKQEr7jFzCHKDkM=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/httprequest v1.0.1/go.mod h1:K+CyYVHU/NcfbMpK7YIVobh4U4Fci3EUB2AqIRtl+xs=
 github.com/juju/idmclient v0.0.0-20161107140250-fb1dc7175251 h1:BtpU10VkuUbEbsfttDqkHfaZGboeHTgQ3nqA5CRdwsY=


### PR DESCRIPTION
The charmrepo dependency brought in a init function that added http
`/debug/pprof/`. This, unfortunately, brought it in twice, which is a bit
problematic as it caused a panic.

## QA steps

Can bootstrap and deploy a `cs:` charm.

```sh
$ juju bootstrap lxd test
$ juju deploy cs:ubuntu
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1944740
