### PR TITLE
charmhub application metrics

### DIFF
--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -26,6 +26,7 @@ type charmhubID struct {
 	os       string
 	series   string
 	arch     string
+	metrics  map[metrics.MetricKey]string
 }
 
 // charmhubResult is the type charmhubLatestCharmInfo returns: information
@@ -55,6 +56,10 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.M
 			Channel:      id.series,
 		}
 		cfg, err := charmhub.RefreshOne(id.id, id.revision, id.channel, base)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		cfg, err = charmhub.AddConfigMetrics(cfg, id.metrics)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/charmrevisionupdater/interface.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface.go
@@ -26,6 +26,7 @@ type State interface {
 	ControllerUUID() string
 	Model() (Model, error)
 	Resources() (state.Resources, error)
+	AliveRelationKeys() []string
 }
 
 // Application is the subset of *state.Application that we need.
@@ -34,6 +35,7 @@ type Application interface {
 	CharmOrigin() *state.CharmOrigin
 	Channel() csparams.Channel
 	ApplicationTag() names.ApplicationTag
+	UnitCount() int
 }
 
 // Model is the subset of *state.Model that we need.
@@ -67,7 +69,7 @@ func (s StateShim) Model() (Model, error) {
 	return s.State.Model()
 }
 
-// charmhubClientStateShim takes a *state.State and and implements common.ModelGetter.
+// charmhubClientStateShim takes a *state.State and implements common.ModelGetter.
 type charmhubClientStateShim struct {
 	state State
 }

--- a/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
+++ b/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
@@ -102,6 +102,20 @@ func (mr *MockApplicationMockRecorder) CharmURL() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockApplication)(nil).CharmURL))
 }
 
+// UnitCount mocks base method.
+func (m *MockApplication) UnitCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnitCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// UnitCount indicates an expected call of UnitCount.
+func (mr *MockApplicationMockRecorder) UnitCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitCount", reflect.TypeOf((*MockApplication)(nil).UnitCount))
+}
+
 // MockCharmhubRefreshClient is a mock of CharmhubRefreshClient interface.
 type MockCharmhubRefreshClient struct {
 	ctrl     *gomock.Controller
@@ -284,6 +298,20 @@ func (m *MockState) AddCharmPlaceholder(arg0 *charm.URL) error {
 func (mr *MockStateMockRecorder) AddCharmPlaceholder(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmPlaceholder", reflect.TypeOf((*MockState)(nil).AddCharmPlaceholder), arg0)
+}
+
+// AliveRelationKeys mocks base method.
+func (m *MockState) AliveRelationKeys() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AliveRelationKeys")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// AliveRelationKeys indicates an expected call of AliveRelationKeys.
+func (mr *MockStateMockRecorder) AliveRelationKeys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AliveRelationKeys", reflect.TypeOf((*MockState)(nil).AliveRelationKeys))
 }
 
 // AllApplications mocks base method.

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/charm/v9"
 	"github.com/juju/charm/v9/resource"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -190,6 +191,11 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 				series:   origin.Platform.Series,
 				arch:     origin.Platform.Architecture,
 			}
+			if telemetry {
+				cid.metrics = map[charmmetrics.MetricKey]string{
+					charmmetrics.NumUnits: strconv.Itoa(application.UnitCount()),
+				}
+			}
 			charmhubIDs = append(charmhubIDs, cid)
 			charmhubApps = append(charmhubApps, appInfo{
 				id:       application.ApplicationTag().Id(),
@@ -233,6 +239,12 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 		latest = append(latest, storeLatest...)
 	}
 	if len(charmhubIDs) > 0 {
+		if telemetry {
+			charmhubIDs, err = api.addMetricsToCharmhubInfos(charmhubIDs, charmhubApps)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
 		hubLatest, err := api.fetchCharmhubInfos(cfg, charmhubIDs, charmhubApps)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -241,6 +253,89 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 	}
 
 	return latest, nil
+}
+
+func (api *CharmRevisionUpdaterAPI) addMetricsToCharmhubInfos(ids []charmhubID, appInfos []appInfo) ([]charmhubID, error) {
+	relationKeys := api.state.AliveRelationKeys()
+	if len(relationKeys) == 0 {
+		return ids, nil
+	}
+	for k, v := range convertRelations(appInfos, relationKeys) {
+		for i, app := range appInfos {
+			if app.id != k {
+				continue
+			}
+			if ids[i].metrics == nil {
+				ids[i].metrics = map[charmmetrics.MetricKey]string{}
+			}
+			ids[i].metrics[charmmetrics.Relations] = strings.Join(v, ",")
+		}
+	}
+	return ids, nil
+}
+
+// convertRelations converts the list of relations by application name to charm name
+// for the metrics response.
+func convertRelations(appInfos []appInfo, relationKeys []string) map[string][]string {
+	// Map application names to its charm name.
+	appToCharm := make(map[string]string)
+	for _, v := range appInfos {
+		if v.charmURL != nil {
+			appToCharm[v.id] = v.charmURL.Name
+		}
+	}
+
+	// relationsByAppName is a map of relation providers, by application name,
+	// to a slice of requirers, by application name.
+	relationsByAppName := make(map[string][]string)
+	for _, key := range relationKeys {
+		one, two, use := relationApplicationNames(key)
+		if !use {
+			continue
+		}
+		values, _ := relationsByAppName[one]
+		values = append(values, two)
+		relationsByAppName[one] = values
+		rValues, _ := relationsByAppName[two]
+		rValues = append(rValues, one)
+		relationsByAppName[two] = rValues
+	}
+
+	// Put them together to create a map of relations, by
+	// application name, to a slice of relations, by charm name.
+	relations := make(map[string][]string)
+	for appName, appNameRels := range relationsByAppName {
+		// It is possible the same charm is deployed more than once with
+		// different names.
+		c := relations[appName]
+		relatedTo := set.NewStrings(c...)
+		// Using a set, also ensures there are no duplicates.
+		for _, v := range appNameRels {
+			relatedTo.Add(appToCharm[v])
+		}
+		relations[appName] = relatedTo.SortedValues()
+	}
+
+	return relations
+}
+
+// relationApplicationNames returns the application names in the relation.
+// Peer relations are filtered out, not needed for metrics.
+// Keys are in the format: "appName:endpoint appName:endpoint"
+func relationApplicationNames(str string) (string, string, bool) {
+	endpoints := strings.Split(str, " ")
+	if len(endpoints) != 2 {
+		return "", "", false
+	}
+	one := strings.Split(endpoints[0], ":")
+	if len(one) != 2 {
+		return "", "", false
+	}
+	two := strings.Split(endpoints[1], ":")
+	if len(two) != 2 {
+		return "", "", false
+	}
+	return one[0], two[0], true
 }
 
 func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(cfg *config.Config, ids []charmstore.CharmID, appInfos []appInfo) ([]latestCharmInfo, error) {

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -60,8 +60,8 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
-		{"charm-1", 22},
-		{"charm-2", 41},
+		{id: "charm-1", revision: 22},
+		{id: "charm-2", revision: 41},
 	}}
 	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
@@ -94,8 +94,27 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 func (s *updaterSuite) TestCharmhubUpdateWithMetrics(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
-	s.expectCharmHubModel(c)
-	s.testCharmhubUpdateMetrics(c, ctrl, true)
+	uuid := testing.ModelTag.Id()
+	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
+		"name": "model",
+		"type": "type",
+		"uuid": uuid,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.model.EXPECT().Config().Return(cfg, nil).AnyTimes()
+	s.model.EXPECT().Metrics().Return(state.ModelMetrics{
+		UUID:           uuid,
+		ControllerUUID: "controller-1",
+		CloudName:      "cloud",
+	}, nil).AnyTimes()
+	s.state.EXPECT().AliveRelationKeys().Return([]string{
+		"app-1:end app-2:point",
+	})
+	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
+		{id: "charm-1", revision: 22, relMetric: "postgresql"},
+		{id: "charm-2", revision: 41, relMetric: "mysql"},
+	}}
+	s.testCharmhubUpdateMetrics(c, ctrl, matcher, true)
 }
 
 func (s *updaterSuite) TestCharmhubUpdateWithNoMetrics(c *gc.C) {
@@ -109,15 +128,16 @@ func (s *updaterSuite) TestCharmhubUpdateWithNoMetrics(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.model.EXPECT().Config().Return(cfg, nil).AnyTimes()
-	s.testCharmhubUpdateMetrics(c, ctrl, false)
+	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
+		{id: "charm-1", revision: 22},
+		{id: "charm-2", revision: 41},
+	}}
+	s.testCharmhubUpdateMetrics(c, ctrl, matcher, false)
 }
 
-func (s *updaterSuite) testCharmhubUpdateMetrics(c *gc.C, ctrl *gomock.Controller, exist bool) {
+func (s *updaterSuite) testCharmhubUpdateMetrics(c *gc.C, ctrl *gomock.Controller, matcher gomock.Matcher, exist bool) {
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
-	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
-		{"charm-1", 22},
-		{"charm-2", 41},
-	}}
+
 	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, charmhubMetricsMatcher{c: c, exist: exist}).Return([]transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{Revision: 23},
@@ -159,7 +179,7 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
-		{"charm-3", 1},
+		{id: "charm-3", revision: 1},
 	}}
 	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
@@ -213,7 +233,7 @@ func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
-		{"charm-2", 42},
+		{id: "charm-2", revision: 42},
 	}}
 	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
@@ -348,11 +368,6 @@ func (s *updaterSuite) expectCharmStoreModel(c *gc.C) {
 func (s *updaterSuite) expectCharmHubModel(c *gc.C) {
 	mExp := s.model.EXPECT()
 	uuid := testing.ModelTag.Id()
-	mExp.Metrics().Return(state.ModelMetrics{
-		UUID:           uuid,
-		ControllerUUID: "controller-1",
-		CloudName:      "cloud",
-	}, nil).AnyTimes()
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name": "model",
 		"type": "type",
@@ -360,6 +375,12 @@ func (s *updaterSuite) expectCharmHubModel(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	mExp.Config().Return(cfg, nil).AnyTimes()
+	mExp.Metrics().Return(state.ModelMetrics{
+		UUID:           uuid,
+		ControllerUUID: "controller-1",
+		CloudName:      "cloud",
+	}, nil).AnyTimes()
+	s.state.EXPECT().AliveRelationKeys().Return(nil)
 }
 
 func (s *updaterSuite) expectResources(c *gc.C, name string, revision, size int, hexFingerprint string) {

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -381,8 +381,8 @@ func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
 			},
 			TrackingChannel: "latest/stable",
 			Metrics: map[string]string{
-				"provider":         "openstack",
-				"num-applications": "4",
+				"provider":     "openstack",
+				"applications": "4",
 			},
 		}},
 		Actions: []transport.RefreshRequestAction{{

--- a/charmhub/refreshconfig.go
+++ b/charmhub/refreshconfig.go
@@ -237,6 +237,9 @@ func RefreshMany(configs ...RefreshConfig) RefreshConfig {
 
 // Build a refresh request that can be past to the API.
 func (c refreshMany) Build() (transport.RefreshRequest, Headers, error) {
+	if len(c.Configs) == 0 {
+		return transport.RefreshRequest{}, nil, errors.NotFoundf("configs")
+	}
 	var composedHeaders Headers
 	// Not all configs built here have a context, start out with an empty
 	// slice, so we do not call Refresh with a nil context.

--- a/core/charm/metrics/metrics.go
+++ b/core/charm/metrics/metrics.go
@@ -37,17 +37,17 @@ const (
 	// Cloud is the name of the cloud this model is operating in.
 	Cloud MetricKey = "cloud"
 	// NumApplications is the number of applications in the model.
-	NumApplications MetricKey = "num-applications"
+	NumApplications MetricKey = "applications"
 	// NumMachines is the number of machines in the model.
-	NumMachines MetricKey = "num-machines"
+	NumMachines MetricKey = "machines"
 	// NumUnits is the number of units in the model.
-	NumUnits MetricKey = "num-units"
+	NumUnits MetricKey = "units"
 
 	//
 	// Charm metrics, included in the RefreshRequestContext Metrics.
 	//
 
-	// CharmURL is the url of the deployed charm, it includes the
-	// type, name, base and revision of the running charm.
-	CharmURL MetricKey = "charm-url"
+	// Relations is a common separated list of charms currently related
+	// to an application.  (no spaces)
+	Relations MetricKey = "relations"
 )

--- a/state/state.go
+++ b/state/state.go
@@ -2241,6 +2241,25 @@ func (st *State) AllRelations() (relations []*Relation, err error) {
 	return
 }
 
+// AliveRelationKeys returns the relation keys of all live relations in
+// the model.  Used in charmhub metrics collection.
+func (st *State) AliveRelationKeys() []string {
+	relationsCollection, closer := st.db().GetCollection(relationsC)
+	defer closer()
+	var doc struct {
+		Key string `bson:"key"`
+	}
+
+	var keys []string
+	iter := relationsCollection.Find(isAliveDoc).Iter()
+	defer func() { _ = iter.Close() }()
+	for iter.Next(&doc) {
+		key := doc.Key
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 // Report conforms to the Dependency Engine Report() interface, giving an opportunity to introspect
 // what is going on at runtime.
 func (st *State) Report() map[string]interface{} {


### PR DESCRIPTION
Part of the charmhub metrics feature work.

Setup and send application level metrics: the number of units and what charms the application is related to.  Helper added to state to get the live relation keys.  These relation keys are then translated to charm names to be sent as relation data.

Data such as charm name, channel, base, and revision is already included in the Refresh context.  No need to duplicate it in the metrics sent.

The application metrics should obey the telemetry model config value.

Includes a drive-by to ensure that configs exist when building RefreshMany.  Provides a better error message than when no context sent across the wire.

## QA steps

```console
# setup 
$ juju bootstrap localhost tuesday
$ juju deploy ubuntu --series focal focal
$ juju deploy ubuntu --series bionic bionic
$ juju deploy juju-qa-test
$ juju deploy ntp
$ juju relate ntp focal
$ juju relate ntp bionic
$ juju relate ntp:juju-info juju-qa-test:juju-info

# let it settle, then enable messages.
juju model-config -m controller "logging-config='#charmhub=TRACE';<root>=INFO"

# disable telemetry on the controller model, to verify application metrics not passed.
juju model-config disable-telemetry=true -m controller

# bounce the controller machine agent to trigger the charmrevisionupdater worker.
juju ssh -m controller 0 -- sudo systemctl restart jujud-machine-0.service

# wait a bit for the agent to restart, then look for logging:
$ juju debug-log -m controller  | grep metrics
            metrics:     {"units":"1", "relations":"ntp"},
            metrics:     {"units":"1", "relations":"ntp"},
            metrics:     {"units":"1", "relations":"ntp"},
            metrics:     {"units":"3", "relations":"juju-qa-test,ubuntu"},
{"context":[{"instance-key":"5b16b371-b217-4ee8-89d3-9378a88e2618","id":"DksXQKAQTZfsUmBAGanZAhpoS4dpmXel","revision":19,"base":{"architecture":"amd64","name":"ubuntu","channel":"18.04"},"tracking-channel":"stable","metrics":{"relations":"ntp","units":"1"}},{"instance-key":"2ea88998-bbc1-4892-8a01-1ea8d82643af","id":"DksXQKAQTZfsUmBAGanZAhpoS4dpmXel","revision":19,"base":{"architecture":"amd64","name":"ubuntu","channel":"20.04"},"tracking-channel":"stable","metrics":{"relations":"ntp","units":"1"}},{"instance-key":"419f5482-bb83-4a42-8b46-edf886e76bb6","id":"Hw30RWzpUBnJLGtO71SX8VDWvd3WrjaJ","revision":13,"base":{"architecture":"amd64","name":"ubuntu","channel":"18.04"},"tracking-channel":"stable","metrics":{"relations":"ntp","units":"1"}},{"instance-key":"97b8fdea-342e-49b4-80a3-2149d964aa4a","id":"SLOkZHn8HVy160M2oJdvXatzlu7ZBEVx","revision":47,"base":{"architecture":"amd64","name":"ubuntu","channel":"20.04"},"tracking-channel":"stable","metrics":{"relations":"juju-qa-test,ubuntu","units":"3"}}],"actions":[{"action":"refresh","instance-key":"5b16b371-b217-4ee8-89d3-9378a88e2618","id":"DksXQKAQTZfsUmBAGanZAhpoS4dpmXel","base":null},{"action":"refresh","instance-key":"2ea88998-bbc1-4892-8a01-1ea8d82643af","id":"DksXQKAQTZfsUmBAGanZAhpoS4dpmXel","base":null},{"action":"refresh","instance-key":"419f5482-bb83-4a42-8b46-edf886e76bb6","id":"Hw30RWzpUBnJLGtO71SX8VDWvd3WrjaJ","base":null},{"action":"refresh","instance-key":"97b8fdea-342e-49b4-80a3-2149d964aa4a","id":"SLOkZHn8HVy160M2oJdvXatzlu7ZBEVx","base":null}],"metrics":{"controller":{"juju-version":"3.0-beta1.1","uuid":"40610c89-f019-474e-877d-5ad7614277cb"},"model":{"applications":"4","cloud":"localhost","machines":"3","provider":"lxd","region":"localhost","units":"6","uuid":"0eeac84f-2aec-4212-8bda-264acf22bbf8"}}}
            metrics:     {},
```

