### PR TITLE
Stick the secret revision in the URL path not as a query parameter

### DIFF
--- a/api/secretsmanager/client_test.go
+++ b/api/secretsmanager/client_test.go
@@ -128,7 +128,7 @@ func (s *SecretsSuite) TestUpdateSecret(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.StringResults{})
 		*(result.(*params.StringResults)) = params.StringResults{
 			[]params.StringResult{{
-				Result: "secret://app/foo?revision=2",
+				Result: "secret://app/foo/2",
 			}},
 		}
 		return nil
@@ -142,7 +142,7 @@ func (s *SecretsSuite) TestUpdateSecret(c *gc.C) {
 	cfg.Tags = tagPtr(map[string]string{"foo": "bar"})
 	result, err := client.Update("secret://app/foo", cfg, value)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.Equals, "secret://app/foo?revision=2")
+	c.Assert(result, gc.Equals, "secret://app/foo/2")
 }
 
 func (s *SecretsSuite) TestUpdateSecretsError(c *gc.C) {

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -105,7 +105,7 @@ func (s *SecretsManagerAPI) createSecret(ctx context.Context, arg params.CreateS
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return md.URL.ShortString(), nil
+	return md.URL.WithRevision(md.Revision).ShortString(), nil
 }
 
 // UpdateSecrets updates the specified secrets.

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -95,8 +95,9 @@ func (s *SecretsManagerSuite) TestCreateSecrets(c *gc.C) {
 	s.secretsService.EXPECT().CreateSecret(gomock.Any(), URL, p).DoAndReturn(
 		func(_ context.Context, URL *coresecrets.URL, p secrets.CreateParams) (*coresecrets.SecretMetadata, error) {
 			md := &coresecrets.SecretMetadata{
-				URL:  URL,
-				Path: "app/mariadb/password",
+				URL:      URL,
+				Path:     "app/mariadb/password",
+				Revision: 1,
 			}
 			return md, nil
 		},
@@ -123,7 +124,7 @@ func (s *SecretsManagerSuite) TestCreateSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{{
-			Result: URL.ShortString(),
+			Result: URL.WithRevision(1).ShortString(),
 		}, {
 			Error: &params.Error{Message: `rotate interval "-1h0m0s" not valid`},
 		}, {

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -86,7 +86,7 @@ func NewPasswordSecretConfig(length int, specialChars bool, nameParts ...string)
 const (
 	// AppSnippet denotes a secret belonging to an application.
 	AppSnippet  = "app"
-	pathSnippet = AppSnippet + `/[a-zA-Z0-9-]+(/[a-zA-Z0-9-]+)*`
+	pathSnippet = AppSnippet + `/[a-zA-Z0-9-]+((/[a-zA-Z0-9-]+)*/[a-zA-Z]+[a-zA-Z0-9-]*)*`
 )
 
 var pathRegexp = regexp.MustCompile("^" + pathSnippet + "$")
@@ -112,10 +112,9 @@ type URL struct {
 Example secret URLs:
 	secret://app/gitlab/apitoken
 	secret://app/mariadb/dbpass
-	secret://app/apache/catalog/password
-	secret://app/apache/catalog/password?revision=666
+	secret://app/apache/catalog/password/666
 	secret://app/proxy#key
-	secret://app/proxy#key?revision=666
+	secret://app/proxy/666#key
 	secret://cfed9630-053e-447a-9751-2dc4ed429d51/app/mariadb/password
 	secret://cfed9630-053e-447a-9751-2dc4ed429d51/11111111-053e-447a-6666-2dc4ed429d51/app/mariadb/password
 */
@@ -129,7 +128,7 @@ const (
 
 var secretURLParse = regexp.MustCompile(`^` +
 	fmt.Sprintf(
-		`((?P<controllerUUID>%s)\/)?((?P<modelUUID>%s)\/)?(?P<path>%s)(?P<revision>\?revision=[0-9]+)?(?P<attribute>#[0-9a-zA-Z]+)?`,
+		`((?P<controllerUUID>%s)/)?((?P<modelUUID>%s)/)?(?P<path>%s)(/(?P<revision>[0-9]+))?(?P<attribute>#[0-9a-zA-Z]+)?`,
 		uuidSnippet, uuidSnippet, pathSnippet) +
 	`$`)
 
@@ -149,9 +148,9 @@ func ParseURL(str string) (*URL, error) {
 		return nil, errors.NotValidf("secret URL %q", str)
 	}
 	revision := 0
-	revisionParam := u.Query().Get("revision")
+	revisionParam := matches[9]
 	if revisionParam != "" {
-		revision, err = strconv.Atoi(revisionParam)
+		revision, err = strconv.Atoi(strings.Trim(revisionParam, "/"))
 		if err != nil {
 			return nil, errors.NotValidf("secret revision %q", revisionParam)
 		}
@@ -234,14 +233,14 @@ func (u *URL) String() string {
 		fullPath = append(fullPath, u.ModelUUID)
 	}
 	fullPath = append(fullPath, u.Path)
+	if u.Revision > 0 {
+		fullPath = append(fullPath, strconv.Itoa(u.Revision))
+	}
 	str := strings.Join(fullPath, "/")
 	urlValue := url.URL{
 		Scheme:   SecretScheme,
 		Path:     str,
 		Fragment: u.Attribute,
-	}
-	if u.Revision > 0 {
-		urlValue.RawQuery = fmt.Sprintf("revision=%d", u.Revision)
 	}
 	return urlValue.String()
 }

--- a/core/secrets/secret_test.go
+++ b/core/secrets/secret_test.go
@@ -76,19 +76,16 @@ func (s *SecretURLSuite) TestParseURL(c *gc.C) {
 			str: "secret://a.b#",
 			err: `secret URL "secret://a.b#" not valid`,
 		}, {
-			str: "secret://app/mariadb/password?revision=xxx",
-			err: `secret revision "xxx" not valid`,
-		}, {
 			str:      "secret://app/mariadb/password",
 			shortStr: "secret://app/mariadb/password",
 			expected: &secrets.URL{
 				Path: "app/mariadb/password",
 			},
 		}, {
-			str:      "secret://app/mariadb/password?revision=666",
-			shortStr: "secret://app/mariadb/password?revision=666",
+			str:      "secret://app/mariadb/password2/666",
+			shortStr: "secret://app/mariadb/password2/666",
 			expected: &secrets.URL{
-				Path:     "app/mariadb/password",
+				Path:     "app/mariadb/password2",
 				Revision: 666,
 			},
 		}, {
@@ -99,8 +96,8 @@ func (s *SecretURLSuite) TestParseURL(c *gc.C) {
 				Attribute: "attr",
 			},
 		}, {
-			str:      "secret://app/mariadb/password?revision=666#attr",
-			shortStr: "secret://app/mariadb/password?revision=666#attr",
+			str:      "secret://app/mariadb/password/666#attr",
+			shortStr: "secret://app/mariadb/password/666#attr",
 			expected: &secrets.URL{
 				Path:      "app/mariadb/password",
 				Attribute: "attr",
@@ -168,7 +165,7 @@ func (s *SecretURLSuite) TestStringWithRevision(c *gc.C) {
 	c.Assert(str, gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password#attr")
 	URL.Revision = 1
 	str = URL.String()
-	c.Assert(str, gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password?revision=1#attr")
+	c.Assert(str, gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password/1#attr")
 }
 
 func (s *SecretURLSuite) TestShortString(c *gc.C) {
@@ -205,7 +202,7 @@ func (s *SecretURLSuite) TestWithRevision(c *gc.C) {
 		Attribute:      "attr",
 	}
 	expected = expected.WithRevision(666)
-	c.Assert(expected.String(), gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password?revision=666#attr")
+	c.Assert(expected.String(), gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password/666#attr")
 }
 
 func (s *SecretURLSuite) TestWithAttribute(c *gc.C) {


### PR DESCRIPTION
Instead of having the secret revision as a query parameter in the URL, make it the last part of the path.

## QA steps

deploy ubuntu charm
```
$ juju exec --unit ubuntu/0 "secret-create password foo=bar hello=world"
secret://app/ubuntu/password/1
$ juju exec --unit ubuntu/0 "secret-update password --tag hello=world data=foo"
secret://app/ubuntu/password/2
$ juju exec --unit ubuntu/0 "secret-get secret://app/ubuntu/password"
foo
$ juju exec --unit ubuntu/0 "secret-get secret://app/ubuntu/password/2"
foo
$ juju exec --unit ubuntu/0 "secret-get secret://app/ubuntu/password/1"
foo: bar
hello: world
```
