### PR TITLE
Pass HTTP Client through

### DIFF
--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -71,6 +71,12 @@ func (s ServerSpec) WithSkipGetServer(b bool) ServerSpec {
 	return s
 }
 
+// WithHTTPClient adds the option of passing the http client to the server spec.
+func (s ServerSpec) WithHTTPClient(client *http.Client) ServerSpec {
+	s.connectionArgs.HTTPClient = client
+	return s
+}
+
 // NewInsecureServerSpec creates a ServerSpec without certificate requirements,
 // which also bypasses the TLS verification.
 // It also ensures the HTTPS for the host implicitly

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	jujuhttp "github.com/juju/http/v2"
 	"github.com/juju/jsonschema"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
@@ -113,8 +114,11 @@ var cloudSchema = &jsonschema.Schema{
 
 // NewProvider returns a new LXD EnvironProvider.
 func NewProvider() environs.CloudEnvironProvider {
+	httpClient := jujuhttp.NewClient(
+		jujuhttp.WithLogger(logger.Child("http")),
+	)
 	configReader := lxcConfigReader{}
-	factory := NewServerFactory()
+	factory := NewServerFactory(httpClient.Client())
 	credentials := environProviderCredentials{
 		certReadWriter:  certificateReadWriter{},
 		certGenerator:   certificateGenerator{},


### PR DESCRIPTION
The following changes passes in a http client that can be used to
improve retries in certain situations. The status codes that are
retryable are defined in juju/http/v2;

 - http.StatusBadGateway
 - http.StatusGatewayTimeout
 - http.StatusServiceUnavailable
 - http.StatusTooManyRequests

All other status codes are deemed unretryable from a server and HTTP RFC
perspective.

The code is simple, inject a http.Client in the provider when generating
a LXD remote server and LXD will automatically pick this up.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-machine --series=xenial -n 2
$ juju add-machine --series=bionic -n 3
$ juju add-machine --series=focal -n 4
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1930596
