### PR TITLE
For older machine agents, there needs to be a symlink for the series based tools

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -23,12 +23,14 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/agent"
+	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/core/os"
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/upstart"
+	"github.com/juju/os/v2/series"
 )
 
 var logger = loggo.GetLogger("juju.cloudconfig")
@@ -580,6 +582,21 @@ func (w *unixConfigure) addDownloadToolsCmds() error {
 			tools.SHA256, tools.Version),
 		"tar zxf $bin/tools.tar.gz -C $bin",
 	)
+
+	// When adding a machine to a 2.8 or earlier model on a 2.9 controller,
+	// we need to add a symlink named after the series so that the 2.x agent
+	// can still find the binaries when deploying units.
+	if vers := w.icfg.AgentVersion(); vers.Major == 2 && vers.Minor <= 8 {
+		hostSeries, err := series.HostSeries()
+		if err != nil {
+			return err
+		}
+		legacyVers := w.icfg.AgentVersion()
+		legacyVers.Release = hostSeries
+		w.conf.AddScripts(
+			fmt.Sprintf("ln -s $bin %s", agenttools.SharedToolsDir(w.icfg.DataDir, legacyVers)),
+		)
+	}
 
 	toolsJson, err := json.Marshal(tools)
 	if err != nil {


### PR DESCRIPTION
When a 2.9 controller provisions a machine on a 2.8 model, the agent binary directory is like  `2.8.11-ubuntu-amd64`.
The machine agent symlink is correctly set up so the machine agent can run.

When a unit is deployed to that machine, the older 2.8 agent tries to read agent binaries from the series based directory, eg `2.8.11-bionic-amd64`.

This PR creates an extra symlink for the series based naming so that the 2.8 agent can use it. As soon as the model is upgraded to 2.9, the issue goes away regardless.

## QA steps

bootstrap 2.8 controller
add a model
upgrade the controller to 2.9
add a machine
deploy a unit to the previously added machine

before this fix, the unit would stay initialising and the logs would contain an error about missing agent directory

After that, upgrade the model to 2.9 and check provisioning again.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1945536
