### PR TITLE
Rename secret status pending to staged

### DIFF
--- a/cmd/juju/secrets/list_test.go
+++ b/cmd/juju/secrets/list_test.go
@@ -88,7 +88,7 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 		}, {
 			Metadata: coresecrets.SecretMetadata{
 				URL: secretUrl2, ID: 667, Version: 1, Revision: 1, Path: "app/gitlab/apitoken", Provider: "juju",
-				Status: coresecrets.StatusPending,
+				Status: coresecrets.StatusStaged,
 			},
 			Error: "boom",
 		}}, nil)
@@ -117,7 +117,7 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
   URL: secret://app/gitlab/apitoken
   revision: 1
   path: app/gitlab/apitoken
-  status: pending
+  status: staged
   version: 1
   backend: juju
   create-time: 0001-01-01T00:00:00Z

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -18,14 +18,14 @@ import (
 type SecretStatus string
 
 const (
-	StatusPending = SecretStatus("pending")
-	StatusActive  = SecretStatus("active")
+	StatusStaged = SecretStatus("staged")
+	StatusActive = SecretStatus("active")
 )
 
 // IsValid returns true if s is a valid secret status.
 func (s SecretStatus) IsValid() bool {
 	switch s {
-	case StatusActive, StatusPending:
+	case StatusActive, StatusStaged:
 		return true
 	}
 	return false

--- a/go.sum
+++ b/go.sum
@@ -402,7 +402,6 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ansiterm v0.0.0-20160907234532-b99631de12cf/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5 h1:Q5klzs6BL5FkassBX65t+KkG0XjYcjxEm+GNcQAsuaw=
 github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/juju/ansiterm v0.0.0-20210929141451-8b71cc96ebdc h1:ZQrgZFsLzkw7o3CoDzsfBhx0bf/1rVBXrLy8dXKRe8o=
 github.com/juju/ansiterm v0.0.0-20210929141451-8b71cc96ebdc/go.mod h1:PyXUpnI3olx3bsPcHt98FGPX/KCFZ1Fi+hw1XLI6384=
@@ -650,14 +649,12 @@ github.com/masterzen/xmlpath v0.0.0-20140218185901-13f4951698ad/go.mod h1:A0zPC5
 github.com/mattn/go-colorable v0.0.6/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.10 h1:KWqbp83oZ6YOEgIbNW3BM1Jbe2tz4jgmWA9FOuAF8bw=
 github.com/mattn/go-colorable v0.1.10/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.0-20160806122752-66b8e73f3f5c/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1yA=
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -221,7 +221,7 @@ func (s *SecretsSuite) TestUpdateAll(c *gc.C) {
 	newData := map[string]string{"foo": "bar", "hello": "world"}
 	newDescription := "big secret"
 	newTags := map[string]string{"goodbye": "world"}
-	newStatus := secrets.StatusPending
+	newStatus := secrets.StatusStaged
 	s.assertUpdatedSecret(c, md.URL, newData, durationPtr(2*time.Hour), &newDescription, &newStatus, &newTags, 2)
 }
 

--- a/worker/uniter/runner/jujuc/secret-create.go
+++ b/worker/uniter/runner/jujuc/secret-create.go
@@ -22,7 +22,7 @@ type secretCreateCommand struct {
 	id             string
 	asBase64       bool
 	rotateInterval time.Duration
-	pending        bool
+	staged         bool
 	description    string
 	tags           map[string]string
 	data           map[string]string
@@ -64,8 +64,8 @@ Examples:
 func (c *secretCreateCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.asBase64, "base64", false,
 		`specify the supplied values are base64 encoded strings`)
-	f.BoolVar(&c.pending, "pending", false,
-		"specify whether the secret should be pending rather than active")
+	f.BoolVar(&c.staged, "staged", false,
+		"specify whether the secret should be staged rather than active")
 	f.DurationVar(&c.rotateInterval, "rotate", 0, "how often the secret should be rotated")
 	f.StringVar(&c.description, "description", "", "the secret description")
 	f.Var(cmd.StringMap{&c.tags}, "tag", "tag to apply to the secret")
@@ -93,8 +93,8 @@ func (c *secretCreateCommand) Init(args []string) error {
 func (c *secretCreateCommand) Run(ctx *cmd.Context) error {
 	value := secrets.NewSecretValue(c.data)
 	status := secrets.StatusActive
-	if c.pending {
-		status = secrets.StatusPending
+	if c.staged {
+		status = secrets.StatusStaged
 	}
 	id, err := c.ctx.CreateSecret(c.id, &UpsertArgs{
 		Type:           secrets.TypeBlob,

--- a/worker/uniter/runner/jujuc/secret-create_test.go
+++ b/worker/uniter/runner/jujuc/secret-create_test.go
@@ -82,7 +82,7 @@ func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
 		"password", "secret", "--rotate", "1h",
 		"--description", "sssshhhh",
 		"--tag", "foo=bar", "--tag", "hello=world",
-		"--pending",
+		"--staged",
 	})
 
 	c.Assert(code, gc.Equals, 0)
@@ -91,7 +91,7 @@ func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
 		Type:           coresecrets.TypeBlob,
 		Value:          val,
 		RotateInterval: durationPtr(time.Hour),
-		Status:         statusPtr(coresecrets.StatusPending),
+		Status:         statusPtr(coresecrets.StatusStaged),
 		Description:    stringPtr("sssshhhh"),
 		Tags:           tagPtr(map[string]string{"foo": "bar", "hello": "world"}),
 	}

--- a/worker/uniter/runner/jujuc/secret-update_test.go
+++ b/worker/uniter/runner/jujuc/secret-update_test.go
@@ -41,6 +41,9 @@ func (s *SecretUpdateSuite) TestUpdateSecretInvalidArgs(c *gc.C) {
 		}, {
 			args: []string{"password", "foo=bar", "--rotate", "-1h"},
 			err:  `ERROR rotate interval "-1h0m0s" not valid`,
+		}, {
+			args: []string{"password", "--staged", "--active"},
+			err:  `ERROR specifying both --staged and --active not valid`,
 		},
 	} {
 		com, err := jujuc.NewCommand(hctx, cmdString("secret-update"))
@@ -63,7 +66,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 		"password", "secret", "--rotate", "1h",
 		"--description", "sssshhhh",
 		"--tag", "foo=bar", "--tag", "hello=world",
-		"--pending",
+		"--staged",
 	})
 
 	c.Assert(code, gc.Equals, 0)
@@ -71,7 +74,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 	args := &jujuc.UpsertArgs{
 		Value:          val,
 		RotateInterval: durationPtr(time.Hour),
-		Status:         statusPtr(coresecrets.StatusPending),
+		Status:         statusPtr(coresecrets.StatusStaged),
 		Description:    stringPtr("sssshhhh"),
 		Tags:           tagPtr(map[string]string{"foo": "bar", "hello": "world"}),
 	}


### PR DESCRIPTION
A small PR to rename secret status "pending" to "staged".

## QA steps

From a hook:
secret-create --staged password s3ke3t
secret-create apikey deadbeef
secret-update apikey --staged

then

juju secrets
