### PR TITLE
stable refresh action instance key 

### DIFF
--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -48,6 +48,12 @@ type Origin struct {
 	OS string
 	// Series describes the series of the OS intended to be used by the charm.
 	Series string
+
+	// InstanceKey is a unique string associated with the application. To
+	// assist with keeping KPI data in charmhub, it must be the same for every
+	// charmhub Refresh action related to an application. Create with the
+	// charmhub.CreateInstanceKey method. LP: 1944582
+	InstanceKey string
 }
 
 // WithSeries allows to update the series of an origin.
@@ -83,6 +89,7 @@ func (o Origin) ParamsCharmOrigin() params.CharmOrigin {
 		Architecture: o.Architecture,
 		OS:           o.OS,
 		Series:       o.Series,
+		InstanceKey:  o.InstanceKey,
 	}
 }
 
@@ -111,6 +118,7 @@ func (o Origin) CoreCharmOrigin() corecharm.Origin {
 			OS:           o.OS,
 			Series:       o.Series,
 		},
+		InstanceKey: o.InstanceKey,
 	}
 }
 
@@ -128,6 +136,7 @@ func APICharmOrigin(origin params.CharmOrigin) Origin {
 		Architecture: origin.Architecture,
 		OS:           origin.OS,
 		Series:       origin.Series,
+		InstanceKey:  origin.InstanceKey,
 	}
 }
 
@@ -153,5 +162,6 @@ func CoreCharmOrigin(origin corecharm.Origin) Origin {
 		Architecture: origin.Platform.Architecture,
 		OS:           origin.Platform.OS,
 		Series:       origin.Platform.Series,
+		InstanceKey:  origin.InstanceKey,
 	}
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1200,6 +1200,7 @@ func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmU
 		return result, nil
 	}
 	result.Origin = makeParamsCharmOrigin(chOrigin)
+	result.Origin.InstanceKey = charmhub.CreateInstanceKey(api.model.UUID(), args.ApplicationName)
 	return result, nil
 }
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -715,12 +716,13 @@ func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 			Series:       "focal",
 		},
 	}
-	s.AddTestingApplicationWithOrigin(c, "wordpress", ch, &expectedOrigin)
+	app := s.AddTestingApplicationWithOrigin(c, "wordpress", ch, &expectedOrigin)
 	result, err := s.applicationAPI.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.URL, gc.Equals, "local:quantal/wordpress-3")
 	latest := "latest"
+
 	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
 		Source:       "local",
 		Risk:         "stable",
@@ -729,6 +731,7 @@ func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 		Architecture: "amd64",
 		OS:           "ubuntu",
 		Series:       "focal",
+		InstanceKey:  charmhub.CreateInstanceKey(s.Model.UUID(), app.Name()),
 	})
 }
 

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -196,6 +196,7 @@ type Model interface {
 	Owner() names.UserTag
 	Tag() names.Tag
 	Type() state.ModelType
+	UUID() string
 	ModelConfig() (*config.Config, error)
 	AgentVersion() (version.Number, error)
 	OpenedPortRangesForMachine(string) (state.MachinePortRanges, error)

--- a/apiserver/facades/client/charms/conversions.go
+++ b/apiserver/facades/client/charms/conversions.go
@@ -30,6 +30,7 @@ func convertOrigin(origin corecharm.Origin) params.CharmOrigin {
 		Architecture: origin.Platform.Architecture,
 		OS:           origin.Platform.OS,
 		Series:       origin.Platform.Series,
+		InstanceKey:  origin.InstanceKey,
 	}
 }
 
@@ -53,5 +54,6 @@ func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 			OS:           origin.OS,
 			Series:       origin.Series,
 		},
+		InstanceKey: origin.InstanceKey,
 	}
 }

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	corecharm "github.com/juju/juju/core/charm"
 	charmrepo "github.com/juju/juju/core/charm/repository"
+	"github.com/juju/juju/core/logger"
 )
 
 // CharmRepoFactoryConfig encapsulates the information required for creating a
@@ -103,7 +104,7 @@ func (f *CharmRepoFactory) GetCharmRepository(src corecharm.Source) (corecharm.R
 		}
 
 		repo = charmrepo.NewCharmHubRepository(
-			f.logger.Child("charmhubrepo"),
+			f.logger.ChildWithLabels("charmhubrepo", logger.CHARMHUB),
 			chClient,
 		)
 	default:

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -310,5 +310,6 @@ func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 			OS:           origin.OS,
 			Series:       origin.Series,
 		},
+		InstanceKey: origin.InstanceKey,
 	}
 }

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -27,6 +27,12 @@ type charmhubID struct {
 	series   string
 	arch     string
 	metrics  map[metrics.MetricKey]string
+	// Required for charmhub only.  instanceKey is a unique string associated
+	// with the application. To assist with keeping KPI data in charmhub, it
+	// must be the same for every charmhub Refresh action related to an
+	// application. Create with the charmhub.CreateInstanceKey method.
+	// LP: 1944582
+	instanceKey string
 }
 
 // charmhubResult is the type charmhubLatestCharmInfo returns: information
@@ -47,7 +53,7 @@ type CharmhubRefreshClient interface {
 
 // charmhubLatestCharmInfo fetches the latest information about the given
 // charms from charmhub's "charm_refresh" API.
-func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID) ([]charmhubResult, error) {
+func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID, modelUUID string) ([]charmhubResult, error) {
 	cfgs := make([]charmhub.RefreshConfig, len(ids))
 	for i, id := range ids {
 		base := charmhub.RefreshBase{
@@ -55,7 +61,7 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.M
 			Name:         id.os,
 			Channel:      id.series,
 		}
-		cfg, err := charmhub.RefreshOne(id.id, id.revision, id.channel, base)
+		cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, base)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -184,12 +184,13 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 				return nil, errors.Trace(err)
 			}
 			cid := charmhubID{
-				id:       origin.ID,
-				revision: *origin.Revision,
-				channel:  channel.String(),
-				os:       strings.ToLower(origin.Platform.OS), // charmhub API requires lowercase OS name
-				series:   origin.Platform.Series,
-				arch:     origin.Platform.Architecture,
+				id:          origin.ID,
+				revision:    *origin.Revision,
+				channel:     channel.String(),
+				os:          strings.ToLower(origin.Platform.OS), // charmhub API requires lowercase OS key
+				series:      origin.Platform.Series,
+				arch:        origin.Platform.Architecture,
+				instanceKey: charmhub.CreateInstanceKey(cfg.UUID(), application.ApplicationTag().Name),
 			}
 			if telemetry {
 				cid.metrics = map[charmmetrics.MetricKey]string{
@@ -393,7 +394,7 @@ func (api *CharmRevisionUpdaterAPI) fetchCharmhubInfos(cfg *config.Config, ids [
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	results, err := charmhubLatestCharmInfo(client, requestMetrics, ids)
+	results, err := charmhubLatestCharmInfo(client, requestMetrics, ids, cfg.UUID())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2919,6 +2919,9 @@
                         "id": {
                             "type": "string"
                         },
+                        "instance-key": {
+                            "type": "string"
+                        },
                         "os": {
                             "type": "string"
                         },
@@ -15387,6 +15390,9 @@
                             "type": "string"
                         },
                         "id": {
+                            "type": "string"
+                        },
+                        "instance-key": {
                             "type": "string"
                         },
                         "os": {
@@ -38750,6 +38756,9 @@
                             "type": "string"
                         },
                         "id": {
+                            "type": "string"
+                        },
+                        "instance-key": {
                             "type": "string"
                         },
                         "os": {

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -38,6 +38,12 @@ type CharmOrigin struct {
 	Architecture string `json:"architecture,omitempty"`
 	OS           string `json:"os,omitempty"`
 	Series       string `json:"series,omitempty"`
+
+	// InstanceKey is a unique string associated with the application. To
+	// assist with keeping KPI data in charmhub, it must be the same for every
+	// charmhub Refresh action related to an application. Create with the
+	// charmhub.CreateInstanceKey method. LP: 1944582
+	InstanceKey string `json:"instance-key,omitempty"`
 }
 
 // ApplicationDeploy holds the parameters for making the application Deploy

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v2"
 	gc "gopkg.in/check.v1"
 
 	path "github.com/juju/juju/charmhub/path"
@@ -37,7 +38,7 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	id := "meshuggah"
 	body := transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			ID:          id,
 			Revision:    1,
 			Base: transport.Base{
@@ -49,19 +50,17 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 		}},
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "refresh",
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			ID:          &id,
 		}},
 	}
 
-	config, err := RefreshOne(id, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-
-	config = DefineInstanceKey(c, config, "foo-bar")
 
 	restClient := NewMockRESTClient(ctrl)
 	s.expectPost(c, restClient, path, id, body)
@@ -148,11 +147,11 @@ func (s *RefreshSuite) TestRefreshMetadata(c *gc.C) {
   "results": [
     {
       "id": "foo",
-      "instance-key": "key-foo"
+      "instance-key": "instance-key-foo"
     },
     {
       "id": "bar",
-      "instance-key": "key-bar"
+      "instance-key": "instance-key-bar"
     }
   ]
 }
@@ -163,21 +162,19 @@ func (s *RefreshSuite) TestRefreshMetadata(c *gc.C) {
 	restClient := NewHTTPRESTClient(httpTransport, headers)
 	client := NewRefreshClient(path, restClient, &FakeLogger{})
 
-	config1, err := RefreshOne("foo", 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne("instance-key-foo", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	config1 = DefineInstanceKey(c, config1, "key-foo")
 
-	config2, err := RefreshOne("bar", 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne("instance-key-bar", "bar", 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	config2 = DefineInstanceKey(c, config2, "key-bar")
 
 	config := RefreshMany(config1, config2)
 
@@ -193,8 +190,8 @@ func (s *RefreshSuite) TestRefreshMetadata(c *gc.C) {
 	c.Assert(httpTransport.requestHeaders["User-Agent"], jc.SameContents, []string{"Test Agent 1.0"})
 
 	c.Assert(response, gc.DeepEquals, []transport.RefreshResponse{
-		{ID: "foo", InstanceKey: "key-foo"},
-		{ID: "bar", InstanceKey: "key-bar"},
+		{ID: "foo", InstanceKey: "instance-key-foo"},
+		{ID: "bar", InstanceKey: "instance-key-bar"},
 	})
 }
 
@@ -225,21 +222,19 @@ func (s *RefreshSuite) RefreshWithRequestMetrics(c *gc.C) {
 		}},
 	}
 
-	config1, err := RefreshOne("foo", 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne("instance-key-foo", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	config1 = DefineInstanceKey(c, config1, "key-foo")
 
-	config2, err := RefreshOne("bar", 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne("instance-key-var", "bar", 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: "amd64",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	config2 = DefineInstanceKey(c, config2, "key-bar")
 
 	config := RefreshMany(config1, config2)
 
@@ -264,14 +259,12 @@ func (s *RefreshSuite) TestRefreshFailure(c *gc.C) {
 	path := path.MakePath(baseURL)
 	name := "meshuggah"
 
-	config, err := RefreshOne(name, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne("instance-key", name, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-
-	config = DefineInstanceKey(c, config, "foo-bar")
 
 	restClient := NewMockRESTClient(ctrl)
 	s.expectPostFailure(c, restClient)
@@ -284,7 +277,7 @@ func (s *RefreshSuite) TestRefreshFailure(c *gc.C) {
 func (s *RefreshSuite) expectPost(c *gc.C, client *MockRESTClient, p path.Path, name string, body interface{}) {
 	client.EXPECT().Post(gomock.Any(), p, gomock.Any(), body, gomock.Any()).Do(func(_ context.Context, _ path.Path, _ map[string][]string, _ transport.RefreshRequest, responses *transport.RefreshResponses) {
 		responses.Results = []transport.RefreshResponse{{
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			Name:        name,
 		}}
 	}).Return(RESTResponse{StatusCode: http.StatusOK}, nil)
@@ -319,20 +312,18 @@ var _ = gc.Suite(&RefreshConfigSuite{})
 
 func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 	id := "foo"
-	config, err := RefreshOne(id, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	config = DefineInstanceKey(c, config, "foo-bar")
-
 	req, _, err := config.Build()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			ID:          "foo",
 			Revision:    1,
 			Base: transport.Base{
@@ -344,22 +335,33 @@ func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 		}},
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "refresh",
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			ID:          &id,
 		}},
 	})
 }
 
-func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
+func (s *RefreshConfigSuite) TestRefreshOneBuildInstanceKeyCompatibility(c *gc.C) {
 	id := "foo"
-	config, err := RefreshOne(id, 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne("", id, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	config = DefineInstanceKey(c, config, "foo-bar")
+	key := ExtractConfigInstanceKey(config)
+	c.Assert(utils.IsValidUUIDString(key), jc.IsTrue)
+}
+
+func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
+	id := "foo"
+	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, jc.ErrorIsNil)
 
 	config, err = AddConfigMetrics(config, map[charmmetrics.MetricKey]string{
 		charmmetrics.Provider:        "openstack",
@@ -371,7 +373,7 @@ func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			ID:          "foo",
 			Revision:    1,
 			Base: transport.Base{
@@ -387,14 +389,14 @@ func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
 		}},
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "refresh",
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			ID:          &id,
 		}},
 	})
 }
 
 func (s *RefreshConfigSuite) TestRefreshOneFail(c *gc.C) {
-	_, err := RefreshOne("", 1, "latest/stable", RefreshBase{
+	_, err := RefreshOne("instance-key", "", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -403,17 +405,15 @@ func (s *RefreshConfigSuite) TestRefreshOneFail(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestRefreshOneEnsure(c *gc.C) {
-	config, err := RefreshOne("foo", 1, "latest/stable", RefreshBase{
+	config, err := RefreshOne("instance-key", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	config = DefineInstanceKey(c, config, "foo-bar")
-
 	err = config.Ensure([]transport.RefreshResponse{{
-		InstanceKey: "foo-bar",
+		InstanceKey: "instance-key",
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -476,7 +476,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevisionResources(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestAddResourceFail(c *gc.C) {
-	config, err := RefreshOne("testingID", 7, "latest/edge", RefreshBase{
+	config, err := RefreshOne("instance-key", "testingID", 7, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
@@ -794,22 +794,20 @@ func (s *RefreshConfigSuite) TestRefreshManyBuildContextNotNil(c *gc.C) {
 
 func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 	id1 := "foo"
-	config1, err := RefreshOne(id1, 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne("instance-key", id1, 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	config1 = DefineInstanceKey(c, config1, "foo-bar")
 
 	id2 := "bar"
-	config2, err := RefreshOne(id2, 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne("instance-key2", id2, 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	config2 = DefineInstanceKey(c, config2, "foo-baz")
 
 	channel := "1/stable"
 
@@ -836,7 +834,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req, gc.DeepEquals, transport.RefreshRequest{
 		Context: []transport.RefreshRequestContext{{
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			ID:          "foo",
 			Revision:    1,
 			Base: transport.Base{
@@ -846,7 +844,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 			},
 			TrackingChannel: "latest/stable",
 		}, {
-			InstanceKey: "foo-baz",
+			InstanceKey: "instance-key2",
 			ID:          "bar",
 			Revision:    2,
 			Base: transport.Base{
@@ -858,11 +856,11 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 		}},
 		Actions: []transport.RefreshRequestAction{{
 			Action:      "refresh",
-			InstanceKey: "foo-bar",
+			InstanceKey: "instance-key",
 			ID:          &id1,
 		}, {
 			Action:      "refresh",
-			InstanceKey: "foo-baz",
+			InstanceKey: "instance-key2",
 			ID:          &id2,
 		}, {
 			Action:      "install",
@@ -885,28 +883,26 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 }
 
 func (s *RefreshConfigSuite) TestRefreshManyEnsure(c *gc.C) {
-	config1, err := RefreshOne("foo", 1, "latest/stable", RefreshBase{
+	config1, err := RefreshOne("instance-key", "foo", 1, "latest/stable", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "20.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	config1 = DefineInstanceKey(c, config1, "foo-bar")
 
-	config2, err := RefreshOne("bar", 2, "latest/edge", RefreshBase{
+	config2, err := RefreshOne("instance-key2", "bar", 2, "latest/edge", RefreshBase{
 		Name:         "ubuntu",
 		Channel:      "14.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	config2 = DefineInstanceKey(c, config2, "foo-baz")
 
 	config := RefreshMany(config1, config2)
 
 	err = config.Ensure([]transport.RefreshResponse{{
-		InstanceKey: "foo-bar",
+		InstanceKey: "instance-key",
 	}, {
-		InstanceKey: "foo-baz",
+		InstanceKey: "instance-key2",
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -47,6 +47,12 @@ type Origin struct {
 	Revision *int
 	Channel  *charm.Channel
 	Platform Platform
+
+	// InstanceKey is a unique string associated with the application. To
+	// assist with keeping KPI data in charmhub, it must be the same for every
+	// charmhub Refresh action related to an application. Create with the
+	// charmhub.CreateInstanceKey method. LP: 1944582
+	InstanceKey string
 }
 
 // Platform describes the platform used to install the charm with.

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -154,13 +154,14 @@ func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, re
 	// Only charms being upgraded will have an ID and Hash. Those values should
 	// only ever be updated in DownloadURL.
 	resOrigin := corecharm.Origin{
-		Source:   requestedOrigin.Source,
-		ID:       requestedOrigin.ID,
-		Hash:     requestedOrigin.Hash,
-		Type:     string(res.Entity.Type),
-		Channel:  &channel,
-		Revision: &revision,
-		Platform: chSuggestedOrigin.Platform,
+		Source:      requestedOrigin.Source,
+		ID:          requestedOrigin.ID,
+		Hash:        requestedOrigin.Hash,
+		Type:        string(res.Entity.Type),
+		Channel:     &channel,
+		Revision:    &revision,
+		Platform:    chSuggestedOrigin.Platform,
+		InstanceKey: requestedOrigin.InstanceKey,
 	}
 
 	outputOrigin, err := sanitizeCharmOrigin(resOrigin, requestedOrigin)
@@ -592,7 +593,7 @@ func refreshConfig(charmURL *charm.URL, origin corecharm.Origin) (charmhub.Refre
 	case MethodID:
 		// This must be a charm upgrade if we have an ID.  Use the refresh
 		// action for metric keeping on the CharmHub side.
-		cfg, err = charmhub.RefreshOne(origin.ID, rev, channel, base)
+		cfg, err = charmhub.RefreshOne(origin.InstanceKey, origin.ID, rev, channel, base)
 	default:
 		return nil, errors.NotValidf("origin %v", origin)
 	}

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -41,7 +41,7 @@ func (s *charmHubRepositorySuite) TestResolveForDeploy(c *gc.C) {
 
 func (s *charmHubRepositorySuite) TestResolveForUpgrade(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	cfg, err := charmhub.RefreshOne("charmCHARMcharmCHARMcharmCHARM01", 16, "latest/stable", charmhub.RefreshBase{
+	cfg, err := charmhub.RefreshOne("instance-key", "charmCHARMcharmCHARMcharmCHARM01", 16, "latest/stable", charmhub.RefreshBase{
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -65,6 +65,9 @@ func (s *charmHubRepositorySuite) testResolve(c *gc.C, id string) {
 			Series:       "focal",
 		},
 		Channel: &channel,
+	}
+	if id != "" {
+		origin.InstanceKey = "instance-key"
 	}
 
 	repo := NewCharmHubRepository(s.logger, s.client)
@@ -674,11 +677,12 @@ func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
 	channel := corecharm.MustParseChannel("stable")
 	origin := corecharm.Origin{
-		Type:     transport.CharmType.String(),
-		ID:       id,
-		Platform: platform,
-		Revision: &revision,
-		Channel:  &channel,
+		Type:        transport.CharmType.String(),
+		ID:          id,
+		Platform:    platform,
+		Revision:    &revision,
+		Channel:     &channel,
+		InstanceKey: "instance-key",
 	}
 
 	cfg, err := refreshConfig(curl, origin)


### PR DESCRIPTION

Related to charmhub KPIs and LP: 1944582. Provide a stable, unique InstanceKey when using the refresh action for charmhub. The easiest one is to combine the model UUID and the application name.  There is a helper to ensure the two values are combined in the same way everywhere.

Setup for most calls in GetCharmURLOrigin, to be used when creating a RefreshConfig down in CharmHubRepository's refreshConfig.  All client initiated refresh actions end up there, however the data required isn't easily available.

The charmrevisionupdater refresh action is put together in a facade and has easy access to the model UUID and application name.

For compatibility with older clients, if no InstanceKey is provided to RefreshOne, create a uuid. These will be distinguishable from the stable instance-keys.

Drive by change to include CharmHubRepository with the logging label: charmhub

## QA steps

```console
# setup
$ juju bootstrap localhost testme
$ juju deploy ubuntu
$ juju deploy juju-qa-test --channel 2.0/edge

# let it settle, then enable messages.
juju model-config -m controller "logging-config='#charmhub=TRACE';<root>=INFO"

# trigger the charmrevisionupdater and other cases where the refresh action would be used.
$ juju upgrade-controller --build-agent

# verify the instance-key, values should be in the form <model-uuid>:a#<application-name>
# "instance-key":"3101a87c-98de-4c7a-810e-962d6a2f68f2:a#juju-qa-test"
# note the juju-qa-test instance-key
$ juju debug-log -m controller | grep instance-key

# refresh the juju-qa-test charm and verify that the instance-key has not changed from above where "result":"refresh"
# the value will be a uuid where "result":"download"
$ juju refresh juju-qa-test --channel latest/edge
$ juju debug-log -m controller | grep instance-key
```

Test with 2.9.15 models and a 3.0x controller for compatibility.  I found an unrelated problem preventing upgrading 2.9.15 to 3.0-beta

## Bug reference

https://bugs.launchpad.net/juju/+bug/1944582
