### PR TITLE
Add secret grant/revoke hook command CLI

### DIFF
--- a/api/secretsmanager/client.go
+++ b/api/secretsmanager/client.go
@@ -198,3 +198,23 @@ func (c *Client) SecretRotated(url string, when time.Time) error {
 	}
 	return nil
 }
+
+// SecretRevokeGrantArgs holds the args used to grant or revoke access to a secret.
+// To grant access, specify one of ApplicationName or UnitName, plus optionally RelationId.
+// To revoke access, specify one of ApplicationName or UnitName.
+type SecretRevokeGrantArgs struct {
+	ApplicationName *string
+	UnitName        *string
+	RelationId      *int
+	Role            secrets.SecretRole
+}
+
+// Grant grants access to the specified secret.
+func (c *Client) Grant(url string, args *SecretRevokeGrantArgs) error {
+	return errors.NotImplementedf("Grant")
+}
+
+// Revoke revokes access to the specified secret.
+func (c *Client) Revoke(url string, args *SecretRevokeGrantArgs) error {
+	return errors.NotImplementedf("Revoke")
+}

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -134,6 +134,8 @@ var expectedCommands = []string{
 	"resource-get",
 	"secret-create",
 	"secret-get",
+	"secret-grant",
+	"secret-revoke",
 	"secret-update",
 	"state-delete",
 	"state-get",

--- a/core/secrets/rbac.go
+++ b/core/secrets/rbac.go
@@ -1,0 +1,13 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets
+
+// SecretRole is an access role on a secret.
+type SecretRole string
+
+const (
+	RoleView   = SecretRole("view")
+	RoleRotate = SecretRole("rotate")
+	RoleManage = SecretRole("manage")
+)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -779,7 +779,7 @@ func (ctx *HookContext) GetSecret(name string) (coresecrets.SecretValue, error) 
 }
 
 // CreateSecret creates a secret with the specified data.
-func (ctx *HookContext) CreateSecret(name string, args *jujuc.UpsertArgs) (string, error) {
+func (ctx *HookContext) CreateSecret(name string, args *jujuc.SecretUpsertArgs) (string, error) {
 	app, _ := names.UnitApplication(ctx.UnitName())
 	cfg := coresecrets.NewSecretConfig(coresecrets.AppSnippet, app, name)
 	cfg.RotateInterval = args.RotateInterval
@@ -790,7 +790,7 @@ func (ctx *HookContext) CreateSecret(name string, args *jujuc.UpsertArgs) (strin
 }
 
 // UpdateSecret creates a secret with the specified data.
-func (ctx *HookContext) UpdateSecret(name string, args *jujuc.UpsertArgs) (string, error) {
+func (ctx *HookContext) UpdateSecret(name string, args *jujuc.SecretUpsertArgs) (string, error) {
 	app, _ := names.UnitApplication(ctx.UnitName())
 	cfg := coresecrets.NewSecretConfig(coresecrets.AppSnippet, app, name)
 	cfg.RotateInterval = args.RotateInterval
@@ -799,6 +799,30 @@ func (ctx *HookContext) UpdateSecret(name string, args *jujuc.UpsertArgs) (strin
 	cfg.Tags = args.Tags
 	URL := coresecrets.NewSimpleURL(cfg.Path)
 	return ctx.secretFacade.Update(URL.ID(), cfg, args.Value)
+}
+
+// GrantSecret grants access to a specified secret.
+func (ctx *HookContext) GrantSecret(name string, args *jujuc.SecretGrantRevokeArgs) error {
+	app, _ := names.UnitApplication(ctx.UnitName())
+	cfg := coresecrets.NewSecretConfig(coresecrets.AppSnippet, app, name)
+	URL := coresecrets.NewSimpleURL(cfg.Path)
+	return ctx.secretFacade.Grant(URL.ID(), &secretsmanager.SecretRevokeGrantArgs{
+		ApplicationName: args.ApplicationName,
+		UnitName:        args.UnitName,
+		RelationId:      args.RelationId,
+		Role:            coresecrets.RoleView,
+	})
+}
+
+// RevokeSecret revokes access to a specified secret.
+func (ctx *HookContext) RevokeSecret(name string, args *jujuc.SecretGrantRevokeArgs) error {
+	app, _ := names.UnitApplication(ctx.UnitName())
+	cfg := coresecrets.NewSecretConfig(coresecrets.AppSnippet, app, name)
+	URL := coresecrets.NewSimpleURL(cfg.Path)
+	return ctx.secretFacade.Revoke(URL.ID(), &secretsmanager.SecretRevokeGrantArgs{
+		ApplicationName: args.ApplicationName,
+		UnitName:        args.UnitName,
+	})
 }
 
 // GoalState returns the goal state for the current unit.

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -944,7 +944,7 @@ func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
 	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
 	client := secretsmanager.NewClient(apiCaller)
 	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
-	id, err := hookContext.CreateSecret("password", &jujuc.UpsertArgs{
+	id, err := hookContext.CreateSecret("password", &jujuc.SecretUpsertArgs{
 		Type:           secrets.TypeBlob,
 		Value:          value,
 		RotateInterval: durationPtr(time.Hour),
@@ -987,7 +987,7 @@ func (s *mockHookContextSuite) TestSecretUpdate(c *gc.C) {
 	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
 	client := secretsmanager.NewClient(apiCaller)
 	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
-	id, err := hookContext.UpdateSecret("password", &jujuc.UpsertArgs{
+	id, err := hookContext.UpdateSecret("password", &jujuc.SecretUpsertArgs{
 		Value:          value,
 		RotateInterval: durationPtr(time.Hour),
 		Status:         statusPtr(secrets.StatusActive),
@@ -996,4 +996,48 @@ func (s *mockHookContextSuite) TestSecretUpdate(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(id, gc.Equals, "secret://app/wordpress/password")
+}
+
+func (s *mockHookContextSuite) TestSecretGrant(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "SecretsManager")
+		c.Assert(version, gc.Equals, 0)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "GrantSecrets")
+		c.Fatalf("TODO")
+		return nil
+	})
+	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
+	client := secretsmanager.NewClient(apiCaller)
+	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
+	app := "mariadb"
+	relationId := 666
+	err := hookContext.GrantSecret("password", &jujuc.SecretGrantRevokeArgs{
+		ApplicationName: &app,
+		RelationId:      &relationId,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
+}
+
+func (s *mockHookContextSuite) TestSecretRevoke(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Assert(objType, gc.Equals, "SecretsManager")
+		c.Assert(version, gc.Equals, 0)
+		c.Assert(id, gc.Equals, "")
+		c.Assert(request, gc.Equals, "RevokeSecrets")
+		c.Fatalf("TODO")
+		return nil
+	})
+	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
+	client := secretsmanager.NewClient(apiCaller)
+	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
+	app := "mariadb"
+	err := hookContext.GrantSecret("password", &jujuc.SecretGrantRevokeArgs{
+		ApplicationName: &app,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotImplemented)
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -163,8 +163,8 @@ type ContextUnit interface {
 	CloudSpec() (*params.CloudSpec, error)
 }
 
-// UpsertArgs specifies args used to create or update a secret.
-type UpsertArgs struct {
+// SecretUpsertArgs specifies args used to create or update a secret.
+type SecretUpsertArgs struct {
 	// Type is the secret type (only used for insert).
 	Type secrets.SecretType
 
@@ -184,15 +184,30 @@ type UpsertArgs struct {
 	Tags *map[string]string
 }
 
+// SecretGrantRevokeArgs specify the args used to grant or revoke access to a secret.
+type SecretGrantRevokeArgs struct {
+	ApplicationName *string
+	UnitName        *string
+	RelationId      *int
+	Role            *secrets.SecretRole
+}
+
 // ContextSecrets is the part of a hook context related to secrets.
 type ContextSecrets interface {
 	// GetSecret returns the value of the specified secret.
 	GetSecret(ID string) (secrets.SecretValue, error)
 
 	// CreateSecret creates a secret with the specified data.
-	CreateSecret(name string, args *UpsertArgs) (string, error)
+	CreateSecret(name string, args *SecretUpsertArgs) (string, error)
 
-	UpdateSecret(name string, args *UpsertArgs) (string, error)
+	// UpdateSecret creates a secret with the specified data.
+	UpdateSecret(name string, args *SecretUpsertArgs) (string, error)
+
+	// GrantSecret grants access to the specified secret.
+	GrantSecret(name string, args *SecretGrantRevokeArgs) error
+
+	// RevokeSecret revokes access to the specified secret.
+	RevokeSecret(name string, args *SecretGrantRevokeArgs) error
 }
 
 // ContextStatus is the part of a hook context related to the unit's status.

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -22,13 +22,25 @@ func (c *ContextSecrets) GetSecret(ID string) (secrets.SecretValue, error) {
 }
 
 // CreateSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) CreateSecret(name string, args *jujuc.UpsertArgs) (string, error) {
+func (c *ContextSecrets) CreateSecret(name string, args *jujuc.SecretUpsertArgs) (string, error) {
 	c.stub.AddCall("CreateSecret", name, args)
 	return "secret://app." + name, nil
 }
 
 // UpdateSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) UpdateSecret(name string, args *jujuc.UpsertArgs) (string, error) {
+func (c *ContextSecrets) UpdateSecret(name string, args *jujuc.SecretUpsertArgs) (string, error) {
 	c.stub.AddCall("UpdateSecret", name, args)
 	return "secret://app." + name, nil
+}
+
+// GrantSecret implements jujuc.ContextSecrets.
+func (c *ContextSecrets) GrantSecret(name string, args *jujuc.SecretGrantRevokeArgs) error {
+	c.stub.AddCall("GrantSecret", name, args)
+	return nil
+}
+
+// RevokeSecret implements jujuc.ContextSecrets.
+func (c *ContextSecrets) RevokeSecret(name string, args *jujuc.SecretGrantRevokeArgs) error {
+	c.stub.AddCall("RevokeSecret", name, args)
+	return nil
 }

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -189,7 +189,7 @@ func (mr *MockContextMockRecorder) ConfigSettings() *gomock.Call {
 }
 
 // CreateSecret mocks base method.
-func (m *MockContext) CreateSecret(arg0 string, arg1 *jujuc.UpsertArgs) (string, error) {
+func (m *MockContext) CreateSecret(arg0 string, arg1 *jujuc.SecretUpsertArgs) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -319,6 +319,20 @@ func (m *MockContext) GoalState() (*application.GoalState, error) {
 func (mr *MockContextMockRecorder) GoalState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoalState", reflect.TypeOf((*MockContext)(nil).GoalState))
+}
+
+// GrantSecret mocks base method.
+func (m *MockContext) GrantSecret(arg0 string, arg1 *jujuc.SecretGrantRevokeArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GrantSecret", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GrantSecret indicates an expected call of GrantSecret.
+func (mr *MockContextMockRecorder) GrantSecret(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantSecret", reflect.TypeOf((*MockContext)(nil).GrantSecret), arg0, arg1)
 }
 
 // HookRelation mocks base method.
@@ -542,6 +556,20 @@ func (mr *MockContextMockRecorder) RequestReboot(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockContext)(nil).RequestReboot), arg0)
 }
 
+// RevokeSecret mocks base method.
+func (m *MockContext) RevokeSecret(arg0 string, arg1 *jujuc.SecretGrantRevokeArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeSecret", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokeSecret indicates an expected call of RevokeSecret.
+func (mr *MockContextMockRecorder) RevokeSecret(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecret", reflect.TypeOf((*MockContext)(nil).RevokeSecret), arg0, arg1)
+}
+
 // SetActionFailed mocks base method.
 func (m *MockContext) SetActionFailed() error {
 	m.ctrl.T.Helper()
@@ -743,7 +771,7 @@ func (mr *MockContextMockRecorder) UpdateActionResults(arg0, arg1 interface{}) *
 }
 
 // UpdateSecret mocks base method.
-func (m *MockContext) UpdateSecret(arg0 string, arg1 *jujuc.UpsertArgs) (string, error) {
+func (m *MockContext) UpdateSecret(arg0 string, arg1 *jujuc.SecretUpsertArgs) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1)
 	ret0, _ := ret[0].(string)

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -228,11 +228,21 @@ func (ctx *RestrictedContext) GetSecret(ID string) (secrets.SecretValue, error) 
 }
 
 // CreateSecret implements runner.Context.
-func (ctx *RestrictedContext) CreateSecret(name string, args *UpsertArgs) (string, error) {
+func (ctx *RestrictedContext) CreateSecret(name string, args *SecretUpsertArgs) (string, error) {
 	return "", ErrRestrictedContext
 }
 
 // UpdateSecret implements runner.Context.
-func (ctx *RestrictedContext) UpdateSecret(name string, args *UpsertArgs) (string, error) {
+func (ctx *RestrictedContext) UpdateSecret(name string, args *SecretUpsertArgs) (string, error) {
 	return "", ErrRestrictedContext
+}
+
+// GrantSecret implements runner.Context.
+func (c *RestrictedContext) GrantSecret(name string, args *SecretGrantRevokeArgs) error {
+	return nil
+}
+
+// RevokeSecret implements runner.Context.
+func (c *RestrictedContext) RevokeSecret(name string, args *SecretGrantRevokeArgs) error {
+	return nil
 }

--- a/worker/uniter/runner/jujuc/secret-create.go
+++ b/worker/uniter/runner/jujuc/secret-create.go
@@ -74,7 +74,7 @@ func (c *secretCreateCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements cmd.Command.
 func (c *secretCreateCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.New("missing secret id")
+		return errors.New("missing secret name")
 	}
 	if len(args) < 2 {
 		return errors.New("missing secret value")
@@ -96,7 +96,7 @@ func (c *secretCreateCommand) Run(ctx *cmd.Context) error {
 	if c.staged {
 		status = secrets.StatusStaged
 	}
-	id, err := c.ctx.CreateSecret(c.id, &UpsertArgs{
+	id, err := c.ctx.CreateSecret(c.id, &SecretUpsertArgs{
 		Type:           secrets.TypeBlob,
 		Value:          value,
 		RotateInterval: &c.rotateInterval,

--- a/worker/uniter/runner/jujuc/secret-create_test.go
+++ b/worker/uniter/runner/jujuc/secret-create_test.go
@@ -31,7 +31,7 @@ func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
 	}{
 		{
 			args: []string{},
-			err:  "ERROR missing secret id",
+			err:  "ERROR missing secret name",
 		}, {
 			args: []string{"password"},
 			err:  "ERROR missing secret value",
@@ -87,7 +87,7 @@ func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
 
 	c.Assert(code, gc.Equals, 0)
 	val := coresecrets.NewSecretValue(map[string]string{"data": "c2VjcmV0"})
-	args := &jujuc.UpsertArgs{
+	args := &jujuc.SecretUpsertArgs{
 		Type:           coresecrets.TypeBlob,
 		Value:          val,
 		RotateInterval: durationPtr(time.Hour),
@@ -109,7 +109,7 @@ func (s *SecretCreateSuite) TestCreateSecretBase64(c *gc.C) {
 
 	c.Assert(code, gc.Equals, 0)
 	val := coresecrets.NewSecretValue(map[string]string{"token": "key="})
-	args := &jujuc.UpsertArgs{
+	args := &jujuc.SecretUpsertArgs{
 		Type:           coresecrets.TypeBlob,
 		Value:          val,
 		RotateInterval: durationPtr(0),

--- a/worker/uniter/runner/jujuc/secret-get.go
+++ b/worker/uniter/runner/jujuc/secret-get.go
@@ -72,7 +72,7 @@ func printPlainOutput(writer io.Writer, val interface{}) error {
 // Init implements cmd.Command.
 func (c *secretGetCommand) Init(args []string) (err error) {
 	if len(args) < 1 {
-		return errors.New("missing secret ID")
+		return errors.New("missing secret name")
 	}
 	c.secretUrl, err = secrets.ParseURL(args[0])
 	if err != nil {

--- a/worker/uniter/runner/jujuc/secret-grant.go
+++ b/worker/uniter/runner/jujuc/secret-grant.go
@@ -1,0 +1,103 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
+
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+type secretGrantCommand struct {
+	cmd.CommandBase
+	ctx Context
+
+	name string
+	app  string
+	unit string
+
+	relationId      int
+	relationIdProxy gnuflag.Value
+}
+
+// NewSecretGrantCommand returns a command to grant access to a secret.
+func NewSecretGrantCommand(ctx Context) (cmd.Command, error) {
+	cmd := &secretGrantCommand{ctx: ctx}
+	var err error
+	cmd.relationIdProxy, err = NewRelationIdValue(ctx, &cmd.relationId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return cmd, nil
+}
+
+// Info implements cmd.Command.
+func (c *secretGrantCommand) Info() *cmd.Info {
+	doc := `
+Grant access to view the value of a specified secret.
+Access may be granted to an application (all units of that application
+have access), or to a specified unit. Unless revoked earlier, when the
+allowed application or unit is removed, so too is the access grant.
+
+A relation may also be specified. This ties the access to the life of  
+that relation - when the relation is removed, so too is the access grant.
+
+Examples:
+    secret-grant password --app mediawiki
+    secret-grant password --unit mediawiki/6 
+    secret-grant password --app mediawiki --relation db:2
+`
+	return jujucmd.Info(&cmd.Info{
+		Name:    "secret-grant",
+		Args:    "<name>",
+		Purpose: "grant access to a secret",
+		Doc:     doc,
+	})
+}
+
+// SetFlags implements cmd.Command.
+func (c *secretGrantCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.app, "app", "", "the application to grant access")
+	f.StringVar(&c.app, "application", "", "")
+	f.StringVar(&c.unit, "unit", "", "the unit to grant access")
+	f.Var(c.relationIdProxy, "r", "Specify a relation by id")
+	f.Var(c.relationIdProxy, "relation", "the relation with which to associate the grant")
+}
+
+// Init implements cmd.Command.
+func (c *secretGrantCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("missing secret name")
+	}
+	if c.app == "" && c.unit == "" {
+		return errors.New("missing application or unit")
+	}
+	if c.app != "" && !names.IsValidApplication(c.app) {
+		return errors.NotValidf("application %q", c.app)
+	}
+	if c.unit != "" && !names.IsValidUnit(c.unit) {
+		return errors.NotValidf("unit %q", c.unit)
+	}
+	c.name = args[0]
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run implements cmd.Command.
+func (c *secretGrantCommand) Run(_ *cmd.Context) error {
+	args := &SecretGrantRevokeArgs{}
+	if c.app != "" {
+		args.ApplicationName = &c.app
+	}
+	if c.unit != "" {
+		args.UnitName = &c.unit
+	}
+	if c.relationId != -1 {
+		args.RelationId = &c.relationId
+	}
+
+	return c.ctx.GrantSecret(c.name, args)
+}

--- a/worker/uniter/runner/jujuc/secret-grant_test.go
+++ b/worker/uniter/runner/jujuc/secret-grant_test.go
@@ -1,0 +1,80 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type SecretGrantSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&SecretGrantSuite{})
+
+func (s *SecretGrantSuite) TestGrantSecretInvalidArgs(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	for _, t := range []struct {
+		args []string
+		err  string
+	}{
+		{
+			args: []string{},
+			err:  "ERROR missing secret name",
+		}, {
+			args: []string{"password"},
+			err:  `ERROR missing application or unit`,
+		}, {
+			args: []string{"password", "--app", "0/foo"},
+			err:  `ERROR application "0/foo" not valid`,
+		}, {
+			args: []string{"password", "--unit", "foo"},
+			err:  `ERROR unit "foo" not valid`,
+		}, {
+			args: []string{"password", "--app", "foo", "--relation", "foo"},
+			err:  `ERROR invalid value "foo" for option --relation: invalid relation id`,
+		}, {
+			args: []string{"password", "--app", "foo", "--relation", "-666"},
+			err:  `ERROR invalid value "-666" for option --relation: relation not found`,
+		},
+	} {
+		com, err := jujuc.NewCommand(hctx, cmdString("secret-grant"))
+		c.Assert(err, jc.ErrorIsNil)
+		ctx := cmdtesting.Context(c)
+		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
+
+		c.Assert(code, gc.Equals, 2)
+		c.Assert(bufferString(ctx.Stderr), gc.Equals, t.err+"\n")
+	}
+}
+
+func (s *SecretGrantSuite) TestGrantSecret(c *gc.C) {
+	hctx, info := s.ContextSuite.NewHookContext()
+	info.SetNewRelation(1, "db", s.Stub)
+	info.SetAsRelationHook(1, "mediawiki")
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-grant"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
+		"password", "--app", "foo",
+		"--relation", "db:1",
+	})
+
+	c.Assert(code, gc.Equals, 0)
+	app := "foo"
+	relId := 1
+	args := &jujuc.SecretGrantRevokeArgs{
+		ApplicationName: &app,
+		RelationId:      &relId,
+	}
+	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "GrantSecret")
+	s.Stub.CheckCall(c, 4, "GrantSecret", "password", args)
+}

--- a/worker/uniter/runner/jujuc/secret-revoke.go
+++ b/worker/uniter/runner/jujuc/secret-revoke.go
@@ -1,0 +1,84 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
+
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+type secretRevokeCommand struct {
+	cmd.CommandBase
+	ctx Context
+
+	name string
+	app  string
+	unit string
+}
+
+// NewSecretRevokeCommand returns a command to revoke access to a secret.
+func NewSecretRevokeCommand(ctx Context) (cmd.Command, error) {
+	return &secretRevokeCommand{ctx: ctx}, nil
+}
+
+// Info implements cmd.Command.
+func (c *secretRevokeCommand) Info() *cmd.Info {
+	doc := `
+Revoke access to view the value of a specified secret.
+Access may be revoked from an application (all units of
+that application lose access), or from a specified unit.
+
+Examples:
+    secret-revoke password --app mediawiki
+    secret-revoke password --unit mediawiki/6
+`
+	return jujucmd.Info(&cmd.Info{
+		Name:    "secret-revoke",
+		Args:    "<name>",
+		Purpose: "revoke access to a secret",
+		Doc:     doc,
+	})
+}
+
+// SetFlags implements cmd.Command.
+func (c *secretRevokeCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.app, "app", "", "the application to revoke access")
+	f.StringVar(&c.app, "application", "", "")
+	f.StringVar(&c.unit, "unit", "", "the unit to revoke access")
+}
+
+// Init implements cmd.Command.
+func (c *secretRevokeCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("missing secret name")
+	}
+	if c.app == "" && c.unit == "" {
+		return errors.New("missing application or unit")
+	}
+	if c.app != "" && !names.IsValidApplication(c.app) {
+		return errors.NotValidf("application %q", c.app)
+	}
+	if c.unit != "" && !names.IsValidUnit(c.unit) {
+		return errors.NotValidf("unit %q", c.unit)
+	}
+	c.name = args[0]
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run implements cmd.Command.
+func (c *secretRevokeCommand) Run(_ *cmd.Context) error {
+	args := &SecretGrantRevokeArgs{}
+	if c.app != "" {
+		args.ApplicationName = &c.app
+	}
+	if c.unit != "" {
+		args.UnitName = &c.unit
+	}
+
+	return c.ctx.RevokeSecret(c.name, args)
+}

--- a/worker/uniter/runner/jujuc/secret-revoke_test.go
+++ b/worker/uniter/runner/jujuc/secret-revoke_test.go
@@ -1,0 +1,69 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type SecretRevokeSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&SecretRevokeSuite{})
+
+func (s *SecretRevokeSuite) TestRevokeSecretInvalidArgs(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	for _, t := range []struct {
+		args []string
+		err  string
+	}{
+		{
+			args: []string{},
+			err:  "ERROR missing secret name",
+		}, {
+			args: []string{"password"},
+			err:  `ERROR missing application or unit`,
+		}, {
+			args: []string{"password", "--app", "0/foo"},
+			err:  `ERROR application "0/foo" not valid`,
+		}, {
+			args: []string{"password", "--unit", "foo"},
+			err:  `ERROR unit "foo" not valid`,
+		},
+	} {
+		com, err := jujuc.NewCommand(hctx, cmdString("secret-revoke"))
+		c.Assert(err, jc.ErrorIsNil)
+		ctx := cmdtesting.Context(c)
+		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
+
+		c.Assert(code, gc.Equals, 2)
+		c.Assert(bufferString(ctx.Stderr), gc.Equals, t.err+"\n")
+	}
+}
+
+func (s *SecretRevokeSuite) TestRevokeSecret(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, cmdString("secret-revoke"))
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
+		"password", "--app", "foo",
+	})
+
+	c.Assert(code, gc.Equals, 0)
+	app := "foo"
+	args := &jujuc.SecretGrantRevokeArgs{
+		ApplicationName: &app,
+	}
+	s.Stub.CheckCallNames(c, "RevokeSecret")
+	s.Stub.CheckCall(c, 0, "RevokeSecret", "password", args)
+}

--- a/worker/uniter/runner/jujuc/secret-update.go
+++ b/worker/uniter/runner/jujuc/secret-update.go
@@ -19,7 +19,7 @@ type secretUpdateCommand struct {
 	cmd.CommandBase
 	ctx Context
 
-	id             string
+	name           string
 	asBase64       bool
 	rotateInterval time.Duration
 	active         bool
@@ -56,7 +56,7 @@ Examples:
 `
 	return jujucmd.Info(&cmd.Info{
 		Name:    "secret-update",
-		Args:    "<id> [value|key=value...]",
+		Args:    "<name> [value|key=value...]",
 		Purpose: "update an existing secret",
 		Doc:     doc,
 	})
@@ -78,7 +78,7 @@ func (c *secretUpdateCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements cmd.Command.
 func (c *secretUpdateCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.New("missing secret id")
+		return errors.New("missing secret name")
 	}
 	if c.rotateInterval < -1 {
 		return errors.NotValidf("rotate interval %q", c.rotateInterval)
@@ -86,7 +86,7 @@ func (c *secretUpdateCommand) Init(args []string) error {
 	if c.staged && c.active {
 		return errors.NotValidf("specifying both --staged and --active")
 	}
-	c.id = args[0]
+	c.name = args[0]
 
 	var err error
 	if len(args) > 1 {
@@ -102,7 +102,7 @@ func (c *secretUpdateCommand) Run(ctx *cmd.Context) error {
 	if c.staged {
 		status = secrets.StatusStaged
 	}
-	args := UpsertArgs{
+	args := SecretUpsertArgs{
 		Value:  value,
 		Status: &status,
 		Tags:   &c.tags,
@@ -113,7 +113,7 @@ func (c *secretUpdateCommand) Run(ctx *cmd.Context) error {
 	if c.description != "" {
 		args.Description = &c.description
 	}
-	id, err := c.ctx.UpdateSecret(c.id, &args)
+	id, err := c.ctx.UpdateSecret(c.name, &args)
 	if err != nil {
 		return err
 	}

--- a/worker/uniter/runner/jujuc/secret-update_test.go
+++ b/worker/uniter/runner/jujuc/secret-update_test.go
@@ -31,7 +31,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretInvalidArgs(c *gc.C) {
 	}{
 		{
 			args: []string{},
-			err:  "ERROR missing secret id",
+			err:  "ERROR missing secret name",
 		}, {
 			args: []string{"password", "s3cret", "foo=bar"},
 			err:  `ERROR key value "foo=bar" not valid when a singular value has already been specified`,
@@ -71,7 +71,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 
 	c.Assert(code, gc.Equals, 0)
 	val := coresecrets.NewSecretValue(map[string]string{"data": "c2VjcmV0"})
-	args := &jujuc.UpsertArgs{
+	args := &jujuc.SecretUpsertArgs{
 		Value:          val,
 		RotateInterval: durationPtr(time.Hour),
 		Status:         statusPtr(coresecrets.StatusStaged),
@@ -92,7 +92,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretBase64(c *gc.C) {
 
 	c.Assert(code, gc.Equals, 0)
 	val := coresecrets.NewSecretValue(map[string]string{"token": "key="})
-	args := &jujuc.UpsertArgs{
+	args := &jujuc.SecretUpsertArgs{
 		Value:  val,
 		Status: statusPtr(coresecrets.StatusActive),
 		Tags:   tagPtr(nil),
@@ -110,7 +110,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretRotateInterval(c *gc.C) {
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--rotate", "5h", "apikey"})
 
 	c.Assert(code, gc.Equals, 0)
-	args := &jujuc.UpsertArgs{
+	args := &jujuc.SecretUpsertArgs{
 		Value:          coresecrets.NewSecretValue(nil),
 		RotateInterval: durationPtr(5 * time.Hour),
 		Status:         statusPtr(coresecrets.StatusActive),

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -98,6 +98,8 @@ var secretCommands = map[string]creator{
 	"secret-create" + cmdSuffix: NewSecretCreateCommand,
 	"secret-update" + cmdSuffix: NewSecretUpdateCommand,
 	"secret-get" + cmdSuffix:    NewSecretGetCommand,
+	"secret-grant" + cmdSuffix:  NewSecretGrantCommand,
+	"secret-revoke" + cmdSuffix: NewSecretRevokeCommand,
 }
 
 var storageCommands = map[string]creator{


### PR DESCRIPTION
Adds new hook command CLI to grant or revoke access to a secret.
secret-grant
secret-revoke

These are just the front end CLI at this stage.

Also tweak a couple of names of structs and attributes to clean things up a bit.

## QA steps

None yet - the CLI needs to be wired up.

