### PR TITLE
No need to error here for not found networks

### DIFF
--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -70,8 +70,13 @@ func (e *environ) Subnets(ctx context.ProviderCallContext, inst instance.Id, sub
 	for _, networkName := range networkNames {
 		// Query the details for this network and skip non-bridge networks.
 		networkDetails, _, err := srv.GetNetwork(networkName)
+
 		if err != nil {
-			return nil, errors.Annotatef(err, "querying lxd server for details of network %q", networkName)
+			// Networks can be removed as a side effect
+			// between the srv.GetNetworkNames() and the
+			// srv.GetNetwork() calls above
+			logger.Warningf("network %q has dissappeared from the lxd server, err while querying was %v", networkName, err)
+			continue
 		} else if networkDetails.Type != "bridge" {
 			continue
 		}


### PR DESCRIPTION
### Description

So we get the network names from the lxd server, and then start querying the server with those names one by one for the network details. Sometimes right between these two operations a network goes away and the server reports that it hasn't got that network anymore (#raceisreal). This happens very often in pylibjuju's integration tests on CI. Here it makes sense to log a warning instead of erroring, since this is not actually an error.

### QA Steps

Pylibjuju's CI integration tests pass

### Notes & Discussion

This is related to https://github.com/juju/python-libjuju/pull/547.

Includes 1 commit that has the code change. As this is due to race conditions, recreating the error as well as writing a test for it is non-trivial (and I'm not entirely sure how to do either).