### PR TITLE
LXD network retrieval efficiency

### DIFF
--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -418,7 +418,7 @@ func (e *environ) SupportsSpaces(context.ProviderCallContext) (bool, error) {
 	// Really old lxd versions (e.g. xenial/ppc64) do not even support the
 	// network API extension so the subnet discovery code path will not
 	// work there.
-	return e.hasLXDNetworkAPISupport()
+	return e.server().HasExtension("network"), nil
 }
 
 // AreSpacesRoutable returns whether the communication between the
@@ -449,18 +449,4 @@ func (*environ) ReleaseContainerAddresses(context.ProviderCallContext, []network
 // SSHAddresses filters the input addresses to those suitable for SSH use.
 func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
 	return addresses, nil
-}
-
-// hasLXDNetworkAPISupport makes a request to the networks API endpoint and
-// checks whether the lxd server supports the network API extension or not. Any
-// other error except "missing API extension" will be returned to the caller.
-func (e *environ) hasLXDNetworkAPISupport() (bool, error) {
-	srv := e.server()
-	_, err := srv.GetNetworkNames()
-	if isErrMissingAPIExtension(err, "network") {
-		return false, nil
-	} else if err != nil {
-		return false, errors.Trace(err)
-	}
-	return true, nil
 }

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -54,7 +54,7 @@ func (s *environNetSuite) TestSubnetsForServersThatLackRequiredAPIExtensions(c *
 	c.Assert(supportsSpaces, jc.IsFalse, gc.Commentf("expected SupportsSpaces to return false when the lxd server lacks the 'network' extension"))
 
 	// Try to grab subnet details anyway!
-	srv.EXPECT().GetNetworkNames().Return(nil, errors.New(`server is missing the required "network" API extension`))
+	srv.EXPECT().GetNetworks().Return(nil, errors.New(`server is missing the required "network" API extension`))
 	srv.EXPECT().GetServer().Return(&lxdapi.Server{
 		Environment: lxdapi.ServerEnvironment{
 			ServerName: "locutus",
@@ -77,17 +77,25 @@ func (s *environNetSuite) TestSubnetsForKnownContainer(c *gc.C) {
 			ServerName: "locutus",
 		},
 	}, "", nil)
-	srv.EXPECT().GetNetworkNames().Return([]string{"ovs-system", "lxdbr0", "phys-nic-0"}, nil)
-	srv.EXPECT().GetNetwork("ovs-system").Return(&lxdapi.Network{
-		Type: "bridge",
-	}, "", nil)
+	srv.EXPECT().GetNetworks().Return([]lxdapi.Network{
+		{
+			Name: "ovs-system",
+			Type: "bridge",
+		},
+		{
+			Name: "lxdbr0",
+			Type: "bridge",
+		},
+		// This should be filtered, as it is not a bridge.
+		{
+			Name: "phys-nic-0",
+			Type: "physical",
+		},
+	}, nil)
 	srv.EXPECT().GetNetworkState("ovs-system").Return(&lxdapi.NetworkState{
 		Type:  "broadcast",
 		State: "down", // should be filtered out because it's down
 	}, nil)
-	srv.EXPECT().GetNetwork("lxdbr0").Return(&lxdapi.Network{
-		Type: "bridge",
-	}, "", nil)
 	srv.EXPECT().GetNetworkState("lxdbr0").Return(&lxdapi.NetworkState{
 		Type:  "broadcast",
 		State: "up",
@@ -112,9 +120,6 @@ func (s *environNetSuite) TestSubnetsForKnownContainer(c *gc.C) {
 			},
 		},
 	}, nil)
-	srv.EXPECT().GetNetwork("phys-nic-0").Return(&lxdapi.Network{
-		Type: "physical", // should be ignored as it is not a bridge.
-	}, "", nil)
 
 	env := s.NewEnviron(c, srv, nil).(environs.Networking)
 
@@ -152,10 +157,10 @@ func (s *environNetSuite) TestSubnetsForKnownContainerAndSubnetFiltering(c *gc.C
 			ServerName: "locutus",
 		},
 	}, "", nil)
-	srv.EXPECT().GetNetworkNames().Return([]string{"lxdbr0"}, nil)
-	srv.EXPECT().GetNetwork("lxdbr0").Return(&lxdapi.Network{
+	srv.EXPECT().GetNetworks().Return([]lxdapi.Network{{
+		Name: "lxdbr0",
 		Type: "bridge",
-	}, "", nil)
+	}}, nil)
 	srv.EXPECT().GetNetworkState("lxdbr0").Return(&lxdapi.NetworkState{
 		Type:  "broadcast",
 		State: "up",
@@ -215,10 +220,10 @@ func (s *environNetSuite) TestSubnetDiscoveryFallbackForOlderLXDs(c *gc.C) {
 	// into the container we will be introspecting and so this subnet will
 	// not be reported back. This is a caveat of the fallback code.
 	srv.EXPECT().HasExtension("network").Return(true)
-	srv.EXPECT().GetNetworkNames().Return([]string{"ovsbr0", "lxdbr0"}, nil)
-	srv.EXPECT().GetNetwork("ovsbr0").Return(&lxdapi.Network{
+	srv.EXPECT().GetNetworks().Return([]lxdapi.Network{{
+		Name: "ovsbr0",
 		Type: "bridge",
-	}, "", nil)
+	}}, nil)
 
 	// This error will trigger the fallback codepath
 	srv.EXPECT().GetNetworkState("ovsbr0").Return(nil, errors.New(`server is missing the required "network_state" API extension`))

--- a/provider/lxd/package_mock_test.go
+++ b/provider/lxd/package_mock_test.go
@@ -382,37 +382,6 @@ func (mr *MockServerMockRecorder) GetNICsFromProfile(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNICsFromProfile", reflect.TypeOf((*MockServer)(nil).GetNICsFromProfile), arg0)
 }
 
-// GetNetwork mocks base method.
-func (m *MockServer) GetNetwork(arg0 string) (*api.Network, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNetwork", arg0)
-	ret0, _ := ret[0].(*api.Network)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetNetwork indicates an expected call of GetNetwork.
-func (mr *MockServerMockRecorder) GetNetwork(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetwork", reflect.TypeOf((*MockServer)(nil).GetNetwork), arg0)
-}
-
-// GetNetworkNames mocks base method.
-func (m *MockServer) GetNetworkNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNetworkNames")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNetworkNames indicates an expected call of GetNetworkNames.
-func (mr *MockServerMockRecorder) GetNetworkNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkNames", reflect.TypeOf((*MockServer)(nil).GetNetworkNames))
-}
-
 // GetNetworkState mocks base method.
 func (m *MockServer) GetNetworkState(arg0 string) (*api.NetworkState, error) {
 	m.ctrl.T.Helper()
@@ -426,6 +395,21 @@ func (m *MockServer) GetNetworkState(arg0 string) (*api.NetworkState, error) {
 func (mr *MockServerMockRecorder) GetNetworkState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkState", reflect.TypeOf((*MockServer)(nil).GetNetworkState), arg0)
+}
+
+// GetNetworks mocks base method.
+func (m *MockServer) GetNetworks() ([]api.Network, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetworks")
+	ret0, _ := ret[0].([]api.Network)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetworks indicates an expected call of GetNetworks.
+func (mr *MockServerMockRecorder) GetNetworks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworks", reflect.TypeOf((*MockServer)(nil).GetNetworks))
 }
 
 // GetProfile mocks base method.

--- a/provider/lxd/package_mock_test.go
+++ b/provider/lxd/package_mock_test.go
@@ -522,6 +522,20 @@ func (mr *MockServerMockRecorder) GetStoragePools() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoragePools", reflect.TypeOf((*MockServer)(nil).GetStoragePools))
 }
 
+// HasExtension mocks base method.
+func (m *MockServer) HasExtension(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasExtension", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasExtension indicates an expected call of HasExtension.
+func (mr *MockServerMockRecorder) HasExtension(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasExtension", reflect.TypeOf((*MockServer)(nil).HasExtension), arg0)
+}
+
 // HasProfile mocks base method.
 func (m *MockServer) HasProfile(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -80,8 +80,7 @@ type Server interface {
 	GetClusterMembers() (members []lxdapi.ClusterMember, err error)
 	Name() string
 	HasExtension(extension string) (exists bool)
-	GetNetworkNames() ([]string, error)
-	GetNetwork(name string) (*lxdapi.Network, string, error)
+	GetNetworks() ([]lxdapi.Network, error)
 	GetNetworkState(name string) (*lxdapi.NetworkState, error)
 	GetContainer(name string) (*lxdapi.Container, string, error)
 	GetContainerState(name string) (*lxdapi.ContainerState, string, error)

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -79,6 +79,7 @@ type Server interface {
 	UseTargetServer(name string) (*lxd.Server, error)
 	GetClusterMembers() (members []lxdapi.ClusterMember, err error)
 	Name() string
+	HasExtension(extension string) (exists bool)
 	GetNetworkNames() ([]string, error)
 	GetNetwork(name string) (*lxdapi.Network, string, error)
 	GetNetworkState(name string) (*lxdapi.NetworkState, error)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -437,10 +437,6 @@ type StubClient struct {
 	NetworkState       map[string]api.NetworkState
 }
 
-func (conn *StubClient) GetNetwork(string) (*api.Network, string, error) {
-	return nil, "", errors.NotImplementedf("GetNetwork")
-}
-
 func (conn *StubClient) FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error) {
 	conn.AddCall("FilterContainers", prefix, statuses)
 	if err := conn.NextErr(); err != nil {
@@ -728,7 +724,7 @@ func (*StubClient) HasExtension(_ string) bool {
 	panic("this stub is deprecated; use mocks instead")
 }
 
-func (*StubClient) GetNetworkNames() ([]string, error) {
+func (conn *StubClient) GetNetworks() ([]api.Network, error) {
 	panic("this stub is deprecated; use mocks instead")
 }
 

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -724,6 +724,10 @@ func (conn *StubClient) UseProject(string) {
 	panic("this stub is deprecated; use mocks instead")
 }
 
+func (*StubClient) HasExtension(_ string) bool {
+	panic("this stub is deprecated; use mocks instead")
+}
+
 func (*StubClient) GetNetworkNames() ([]string, error) {
 	panic("this stub is deprecated; use mocks instead")
 }


### PR DESCRIPTION
Instead of using the LXD API to call `GetNetworkNames`, and then `GetNetwork` for each of the results, we simply call `GetNetworks` to retrieve them all at once.

A further efficiency gain is included to use the `HasExtension` call directly for "networks" instead testing for the extension by calling `GetNetworkNames`.

## QA steps

- Bootstrap to LXD.
- `juju subnets` should reflect the networks on your local system.

## Documentation changes

None.

## Bug reference

N/A
