### PR TITLE
Fix issue updating controller-url config for controller charm

### DIFF
--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -12,8 +12,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/testing/factory"
 )
 
 type ControllerSuite struct {
@@ -217,6 +219,32 @@ func (s *ControllerSuite) TestControllerInfo(c *gc.C) {
 	info, err = s.State.ControllerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.ControllerIds, jc.DeepEquals, []string{node.Id()})
+}
+
+func (s *ControllerSuite) TestSetMachineAddressesControllerCharm(c *gc.C) {
+	controller, err := s.State.AddMachine("quantal", state.JobManageModel, state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+	worker, err := s.State.AddMachine("quantal", state.JobHostUnits)
+	c.Assert(err, jc.ErrorIsNil)
+
+	controllerApp := s.AddTestingApplication(c, "controller", s.AddTestingCharm(c, "juju-controller"))
+	s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: controllerApp,
+		Machine:     controller,
+	})
+
+	addresses := network.NewSpaceAddresses("10.0.0.1")
+	err = controller.SetMachineAddresses(addresses...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Updating a worker machine does not affect charm config.
+	addresses = network.NewSpaceAddresses("10.0.0.2")
+	err = worker.SetMachineAddresses(addresses...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := controllerApp.CharmConfig(model.GenerationMaster)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg["controller-url"], gc.Equals, "wss://10.0.0.1:17777/api")
 }
 
 func (s *ControllerSuite) testOpenParams() state.OpenParams {

--- a/state/machine.go
+++ b/state/machine.go
@@ -1718,8 +1718,10 @@ func (m *Machine) setAddresses(machineAddresses, providerAddresses *[]network.Sp
 			"machine %q preferred public address changed from %q to %q",
 			m.Id(), oldPublic, newPublic.networkAddress(),
 		)
-		if err := m.st.maybeUpdateControllerCharm(m.doc.PreferredPublicAddress.Value); err != nil {
-			return errors.Trace(err)
+		if isController(&m.doc) {
+			if err := m.st.maybeUpdateControllerCharm(m.doc.PreferredPublicAddress.Value); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 	return nil

--- a/testcharms/charm-repo/quantal/juju-controller/config.yaml
+++ b/testcharms/charm-repo/quantal/juju-controller/config.yaml
@@ -1,0 +1,4 @@
+options:
+  controller-url:
+    default: ""
+    type: string


### PR DESCRIPTION
The controller charm `controller-url` config was being updated for any machine address change, when it should have just been for the controller address.

## QA steps

bootstrap
deploy the [dashboard charm](https://github.com/canonical-web-and-design/juju-dashboard-charm)
juju relate controller juju-dashboard
juju show-unit juju-dashboard/0
see that the controller-url value matches the controller ip address
