### PR TITLE
Implement azure container registry;

### DIFF
--- a/docker/registry/internal/base.go
+++ b/docker/registry/internal/base.go
@@ -4,6 +4,7 @@
 package internal
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -244,4 +245,17 @@ func getNextLink(resp *http.Response) (string, error) {
 		}
 	}
 	return "", errNoMorePages
+}
+
+// unpackAuthToken returns the unpacked username and password.
+func unpackAuthToken(auth string) (username string, password string, err error) {
+	content, err := base64.StdEncoding.DecodeString(auth)
+	if err != nil {
+		return "", "", errors.Annotate(err, "doing base64 decode on the auth token")
+	}
+	parts := strings.Split(string(content), ":")
+	if len(parts) < 2 {
+		return "", "", errors.NotValidf("registry auth token")
+	}
+	return parts[0], parts[1], nil
 }


### PR DESCRIPTION
This PR introduces Azure `acr` support for

- pulling `jujud-operator`, `juju-db` and `charm-base` images from k8s controllers, application operators, and sidecar pods;
- fetching available controller versions to upgrade for `upgrade-controller` command;


Tested registries are(the rest of the registries will be implemented and tested in the following PRs):

| Registry | Public | Private |
| --- | --- | --- |
| azurecr.io | :x: | :white_check_mark: |
| docker.io | :white_check_mark: | :white_check_mark: |
| ecr | :x: | :white_check_mark: |
| gcr.io | :white_check_mark: | :white_check_mark: |
| ghcr.io | :x: | :white_check_mark: |
| registry.gitlab.com | :x: | :white_check_mark: |
| quay.io | :white_check_mark: | :white_check_mark: |

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
# setup service principal account with owner role of your repository
# https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-service-principal

$ cat acr.json
{
    "serveraddress": "jujuqa.azurecr.io",
    "repository": "jujuqa.azurecr.io",
    "username": "<Service principal ID>",
    "password": "<Service principal password>",
}

$ juju bootstrap microk8s k1 --config caas-image-repo="'$(cat acr.json)'" 

$ mkubectl -ncontroller-k1 get secret/juju-image-pull-secret -o json | jq -r '.data[".dockerconfigjson"]' | base64 --decode | jq
{
  "auths": {
    "jujuqa.azurecr.io": {
      "auth": "xxxx==",
      "username": "<Service principal ID>",
      "password": "<Service principal password>",
      "serveraddress": "jujuqa.azurecr.io"
    }
  }
}

$ mkubectl -ncontroller-k1 get pod -o json | jq '.items[].spec.containers[].image'
"jujuqa.azurecr.io/juju-db:4.0"
"jujuqa.azurecr.io/jujud-operator:2.9.16"
"jujuqa.azurecr.io/jujud-operator:2.9.16"

$ juju upgrade-controller --agent-stream=develop

```

## Documentation changes

https://discourse.charmhub.io/t/initial-private-registry-support/5079

## Bug reference


https://bugs.launchpad.net/juju/+bug/1935830
https://bugs.launchpad.net/juju/+bug/1940820
https://bugs.launchpad.net/juju/+bug/1935953