### PR TITLE
Batching fsm

### DIFF
--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -387,20 +387,26 @@ func (r *response) Notify(target NotifyTarget) {
 	}
 }
 
+// Apply log is invoked once a log entry is committed.
+// It returns a value which will be made available in the
+// ApplyFuture returned by Raft.Apply method if that
+// method was called on the same Raft node as the FSM.
 // Apply is part of raft.FSM.
 func (f *FSM) Apply(log *raft.Log) interface{} {
-	var command Command
-	err := yaml.Unmarshal(log.Data, &command)
+	command, err := unmarshalCommand(log)
 	if err != nil {
-		return &response{err: errors.Trace(err)}
-	}
-	if err := command.Validate(); err != nil {
 		return &response{err: errors.Trace(err)}
 	}
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	return f.apply(command)
+}
+
+// apply extacts out of the command operation invocations, so that the batching
+// FSM can make use of the same logic.
+func (f *FSM) apply(command Command) *response {
 	switch command.Operation {
 	case OperationClaim:
 		return f.claim(command.LeaseKey(), command.Holder, command.Duration)
@@ -417,6 +423,18 @@ func (f *FSM) Apply(log *raft.Log) interface{} {
 	default:
 		return &response{err: errors.NotValidf("operation %q", command.Operation)}
 	}
+}
+
+func unmarshalCommand(log *raft.Log) (Command, error) {
+	var command Command
+	err := yaml.Unmarshal(log.Data, &command)
+	if err != nil {
+		return command, errors.Trace(err)
+	}
+	if err := command.Validate(); err != nil {
+		return command, errors.Trace(err)
+	}
+	return command, nil
 }
 
 // Snapshot is part of raft.FSM.
@@ -516,6 +534,79 @@ func (f *FSM) Restore(reader io.ReadCloser) error {
 	f.pinned = newPinned
 
 	return nil
+}
+
+// BatchFSM creates a FSM that allows for batching operations. Raft takes
+// care of applying the batches in chunked sizes, which allows for restoring
+// and snapshotting a the library level. Those should be transparent to the
+// the FSM.
+type BatchFSM struct {
+	*FSM
+}
+
+// NewBatchFSM creates a BatchFSM from an existing FSM. By lifting the FSM
+// into a BatchFSM allows for better performance when applying logs, it does
+// this by only stealing a lock only when required.
+func NewBatchFSM(fsm *FSM) *BatchFSM {
+	return &BatchFSM{
+		FSM: fsm,
+	}
+}
+
+type batchValue struct {
+	Command  Command
+	Response *response
+}
+
+// ApplyBatch is invoked once a batch of log entries has been committed and
+// are ready to be applied to the FSM. ApplyBatch will take in an array of
+// log entries. These log entries will be in the order they were committed,
+// will not have gaps, and could be of a few log types. Clients should check
+// the log type prior to attempting to decode the data attached. Presently
+// the LogCommand and LogConfiguration types will be sent.
+//
+// The returned slice must be the same length as the input and each response
+// should correlate to the log at the same index of the input. The returned
+// values will be made available in the ApplyFuture returned by Raft.Apply
+// method if that method was called on the same Raft node as the FSM.
+// ApplyBatch is part of raft.BatchingFSM.
+func (f *BatchFSM) ApplyBatch(logs []*raft.Log) interface{} {
+	// Unmarshal all the logs up front, we can validate them without
+	// stealing the lock. Additionally we can ensure that we get the correct
+	// type of log.
+	values := make([]batchValue, len(logs))
+	for i, log := range logs {
+		command, err := unmarshalCommand(log)
+		if err != nil {
+			values[i] = batchValue{
+				Response: &response{err: errors.Trace(err)},
+			}
+			continue
+		}
+
+		values[i] = batchValue{
+			Command: command,
+		}
+	}
+
+	// Ensure we steal the lock so we serialize all log applications. That way
+	// we never allow another Apply or ApplyBatch to intervene.
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	responses := make([]interface{}, len(values))
+	for i, value := range values {
+		// We already have a response for the batch item. This happens if we
+		// are unable to unmarshal the command from the raft.Log.
+		if value.Response != nil {
+			responses[i] = value.Response
+			continue
+		}
+
+		responses[i] = f.apply(value.Command)
+	}
+
+	return responses
 }
 
 // Snapshot defines the format of the FSM snapshot.

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -53,3 +53,7 @@ const ActionsV2 = "actions-v2"
 
 // Secrets enables the secrets feature.
 const Secrets = "secrets"
+
+// RaftBatchFSM will use the batching FSM instead of the singular FSM to attempt
+// to commit logs.
+const RaftBatchFSM = "raft-batch-fsm"

--- a/worker/raft/manifold.go
+++ b/worker/raft/manifold.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	raftleasestore "github.com/juju/juju/state/raftlease"
 	"github.com/juju/juju/worker/common"
@@ -120,6 +121,24 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	}
 
 	st := statePool.SystemState()
+
+	// We require the controller config to get the feature flags.
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot fetch the controller config")
+	}
+
+	fsm := config.FSM
+	if controllerConfig.Features().Contains(feature.RaftBatchFSM) {
+		if raftLeaseFSM, ok := fsm.(*raftlease.FSM); ok {
+			fsm = raftlease.NewBatchFSM(raftLeaseFSM)
+			config.Logger.Infof("Using batching FSM for processing leases")
+		} else {
+			// We shouldn't error out here, we can just report that we're not
+			// using batching.
+			config.Logger.Errorf("Unable to use batching FSM, unknown FSM type %T", fsm)
+		}
+	}
 
 	// TODO(axw) make the directory path configurable, so we can
 	// potentially have multiple Rafts. The dqlite raft should go


### PR DESCRIPTION
The following introduces the BatchingFSM, the idea behind this, is to
reduce lock contention and allow for applying log changes in chunks.
This is intended to work out if there is any performance gains by using
this with either transport (API or pubsub).

I suspect when load testing that we won't actually see any changes for
the API version, as we intentionally serialise there. So changes to
consolidate multiple logs at once will be required. The pubsub one
should actually go faster as we don't have to wait for the log to be
applied.

## QA steps

TBA

```sh
QA steps here
```
