### PR TITLE
Add updated JIMM facades

### DIFF
--- a/generate/schemagen/gen/groups.go
+++ b/generate/schemagen/gen/groups.go
@@ -114,7 +114,7 @@ func jimmFacades(facades []facade.Details) []facade.Details {
 	required := map[string][]int{
 		"Bundle":              {1},
 		"Cloud":               {1, 2, 3, 4, 5},
-		"Controller":          {3, 4, 5, 6, 7, 8, 9},
+		"Controller":          {3, 4, 5, 6, 7, 8, 9, 10, 11},
 		"ModelManager":        {2, 3, 4, 5},
 		"ModelSummaryManager": {1},
 		"Pinger":              {1},


### PR DESCRIPTION
It looks like the schema gen was missing the latest controller facade
versions for schema gen. It also looks like we need to drop older facade
versions for JIMM and this will require some coordination.

For now, we'll bump the facade versions and deal with the coordination
for a later date.

## QA steps

```sh
go run github.com/juju/juju/generate/schemagen -admin-facades --facade-group=client,jimm ./apiserver/facades/schema.json
```
