### PR TITLE
backport Charmhub metrics

### DIFF
--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -48,6 +48,12 @@ type Origin struct {
 	OS string
 	// Series describes the series of the OS intended to be used by the charm.
 	Series string
+
+	// InstanceKey is a unique string associated with the application. To
+	// assist with keeping KPI data in charmhub, it must be the same for every
+	// charmhub Refresh action related to an application. Create with the
+	// charmhub.CreateInstanceKey method. LP: 1944582
+	InstanceKey string
 }
 
 // WithSeries allows to update the series of an origin.
@@ -83,6 +89,7 @@ func (o Origin) ParamsCharmOrigin() params.CharmOrigin {
 		Architecture: o.Architecture,
 		OS:           o.OS,
 		Series:       o.Series,
+		InstanceKey:  o.InstanceKey,
 	}
 }
 
@@ -111,6 +118,7 @@ func (o Origin) CoreCharmOrigin() corecharm.Origin {
 			OS:           o.OS,
 			Series:       o.Series,
 		},
+		InstanceKey: o.InstanceKey,
 	}
 }
 
@@ -128,6 +136,7 @@ func APICharmOrigin(origin params.CharmOrigin) Origin {
 		Architecture: origin.Architecture,
 		OS:           origin.OS,
 		Series:       origin.Series,
+		InstanceKey:  origin.InstanceKey,
 	}
 }
 
@@ -153,5 +162,6 @@ func CoreCharmOrigin(origin corecharm.Origin) Origin {
 		Architecture: origin.Platform.Architecture,
 		OS:           origin.Platform.OS,
 		Series:       origin.Platform.Series,
+		InstanceKey:  origin.InstanceKey,
 	}
 }

--- a/apiserver/common/charmhub.go
+++ b/apiserver/common/charmhub.go
@@ -22,7 +22,7 @@ type ConfigModel interface {
 }
 
 // CharmhubClient creates a new charmhub Client based on this model's config.
-func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.Logger, metadata map[string]string) (*charmhub.Client, error) {
+func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.Logger) (*charmhub.Client, error) {
 	model, err := mg.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -34,7 +34,6 @@ func CharmhubClient(mg ModelGetter, httpClient charmhub.Transport, logger loggo.
 	url, _ := modelConfig.CharmHubURL()
 
 	config, err := charmhub.CharmHubConfigFromURL(url, logger,
-		charmhub.WithMetadataHeaders(metadata),
 		charmhub.WithHTTPTransport(func(charmhub.Logger) charmhub.Transport {
 			return httpClient
 		}),

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1489,6 +1489,7 @@ func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmU
 		return result, nil
 	}
 	result.Origin = makeParamsCharmOrigin(chOrigin)
+	result.Origin.InstanceKey = charmhub.CreateInstanceKey(api.model.UUID(), args.ApplicationName)
 	return result, nil
 }
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -985,12 +986,13 @@ func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 			Series:       "focal",
 		},
 	}
-	s.AddTestingApplicationWithOrigin(c, "wordpress", ch, &expectedOrigin)
+	app := s.AddTestingApplicationWithOrigin(c, "wordpress", ch, &expectedOrigin)
 	result, err := s.applicationAPI.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "wordpress"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.URL, gc.Equals, "local:quantal/wordpress-3")
 	latest := "latest"
+
 	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
 		Source:       "local",
 		Risk:         "stable",
@@ -999,6 +1001,7 @@ func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 		Architecture: "amd64",
 		OS:           "ubuntu",
 		Series:       "focal",
+		InstanceKey:  charmhub.CreateInstanceKey(s.Model.UUID(), app.Name()),
 	})
 }
 

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -196,6 +196,7 @@ type Model interface {
 	Owner() names.UserTag
 	Tag() names.Tag
 	Type() state.ModelType
+	UUID() string
 	ModelConfig() (*config.Config, error)
 	AgentVersion() (version.Number, error)
 	OpenedPortRangesForMachine(string) (state.MachinePortRanges, error)

--- a/apiserver/facades/client/charms/charmhubrepo.go
+++ b/apiserver/facades/client/charms/charmhubrepo.go
@@ -113,13 +113,14 @@ func (c *chRepo) ResolveWithPreferredChannel(curl *charm.URL, origin corecharm.O
 	// Only charms being upgraded will have an ID and Hash. Those values should
 	// only ever be updated in FindDownloadURL.
 	resOrigin := corecharm.Origin{
-		Source:   origin.Source,
-		ID:       origin.ID,
-		Hash:     origin.Hash,
-		Type:     string(res.Entity.Type),
-		Channel:  &channel,
-		Revision: &revision,
-		Platform: input.Platform,
+		Source:      origin.Source,
+		ID:          origin.ID,
+		Hash:        origin.Hash,
+		Type:        string(res.Entity.Type),
+		Channel:     &channel,
+		Revision:    &revision,
+		Platform:    input.Platform,
+		InstanceKey: origin.InstanceKey,
 	}
 
 	outputOrigin, err := sanitizeCharmOrigin(resOrigin, origin)
@@ -464,7 +465,7 @@ func refreshConfig(curl *charm.URL, origin corecharm.Origin) (charmhub.RefreshCo
 	case MethodID:
 		// This must be a charm upgrade if we have an ID.  Use the refresh
 		// action for metric keeping on the CharmHub side.
-		cfg, err = charmhub.RefreshOne(origin.ID, rev, channel, base)
+		cfg, err = charmhub.RefreshOne(origin.InstanceKey, origin.ID, rev, channel, base)
 	default:
 		return nil, errors.NotValidf("origin %v", origin)
 	}

--- a/apiserver/facades/client/charms/charmhubrepo_test.go
+++ b/apiserver/facades/client/charms/charmhubrepo_test.go
@@ -37,7 +37,7 @@ func (s *charmHubRepositoriesSuite) TestResolveForDeploy(c *gc.C) {
 
 func (s *charmHubRepositoriesSuite) TestResolveForUpgrade(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	cfg, err := charmhub.RefreshOne("charmCHARMcharmCHARMcharmCHARM01", 16, "latest/stable", charmhub.RefreshBase{
+	cfg, err := charmhub.RefreshOne("instance-key", "charmCHARMcharmCHARMcharmCHARM01", 16, "latest/stable", charmhub.RefreshBase{
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -59,6 +59,9 @@ func (s *charmHubRepositoriesSuite) testResolve(c *gc.C, id string) {
 			OS:           "ubuntu",
 			Series:       "focal",
 		},
+	}
+	if id != "" {
+		origin.InstanceKey = "instance-key"
 	}
 
 	resolver := &chRepo{client: s.client}
@@ -521,9 +524,10 @@ func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 	curl := charm.MustParseURL("ch:wordpress")
 	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
 	origin := corecharm.Origin{
-		ID:       id,
-		Platform: platform,
-		Revision: &revision,
+		ID:          id,
+		Platform:    platform,
+		Revision:    &revision,
+		InstanceKey: "instance-key",
 	}
 
 	cfg, err := refreshConfig(curl, origin)

--- a/apiserver/facades/client/charms/conversions.go
+++ b/apiserver/facades/client/charms/conversions.go
@@ -30,6 +30,7 @@ func convertOrigin(origin corecharm.Origin) params.CharmOrigin {
 		Architecture: origin.Platform.Architecture,
 		OS:           origin.Platform.OS,
 		Series:       origin.Platform.Series,
+		InstanceKey:  origin.InstanceKey,
 	}
 }
 
@@ -53,5 +54,6 @@ func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 			OS:           origin.OS,
 			Series:       origin.Series,
 		},
+		InstanceKey: origin.InstanceKey,
 	}
 }

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -826,10 +826,10 @@ func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 
 	s.ctrl = gomock.NewController(c)
 	charmhubClient := mocks.NewMockCharmhubRefreshClient(s.ctrl)
-	charmhubClient.EXPECT().Refresh(gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{
+	charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{
 		{Entity: transport.RefreshEntity{Revision: 42}},
 	}, nil)
-	newCharmhubClient := func(st charmrevisionupdater.State, metadata map[string]string) (charmrevisionupdater.CharmhubRefreshClient, error) {
+	newCharmhubClient := func(st charmrevisionupdater.State) (charmrevisionupdater.CharmhubRefreshClient, error) {
 		return charmhubClient, nil
 	}
 

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -312,5 +312,6 @@ func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 			OS:           origin.OS,
 			Series:       origin.Series,
 		},
+		InstanceKey: origin.InstanceKey,
 	}
 }

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -27,6 +27,12 @@ type charmhubID struct {
 	series   string
 	arch     string
 	metrics  map[metrics.MetricKey]string
+	// Required for charmhub only.  instanceKey is a unique string associated
+	// with the application. To assist with keeping KPI data in charmhub, it
+	// must be the same for every charmhub Refresh action related to an
+	// application. Create with the charmhub.CreateInstanceKey method.
+	// LP: 1944582
+	instanceKey string
 }
 
 // charmhubResult is the type charmhubLatestCharmInfo returns: information
@@ -47,7 +53,7 @@ type CharmhubRefreshClient interface {
 
 // charmhubLatestCharmInfo fetches the latest information about the given
 // charms from charmhub's "charm_refresh" API.
-func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID) ([]charmhubResult, error) {
+func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID, modelUUID string) ([]charmhubResult, error) {
 	cfgs := make([]charmhub.RefreshConfig, len(ids))
 	for i, id := range ids {
 		base := charmhub.RefreshBase{
@@ -55,7 +61,7 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.M
 			Name:         id.os,
 			Channel:      id.series,
 		}
-		cfg, err := charmhub.RefreshOne(id.id, id.revision, id.channel, base)
+		cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, base)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -26,6 +26,7 @@ type charmhubID struct {
 	os       string
 	series   string
 	arch     string
+	metrics  map[metrics.MetricKey]string
 }
 
 // charmhubResult is the type charmhubLatestCharmInfo returns: information
@@ -55,6 +56,10 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.M
 			Channel:      id.series,
 		}
 		cfg, err := charmhub.RefreshOne(id.id, id.revision, id.channel, base)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		cfg, err = charmhub.AddConfigMetrics(cfg, id.metrics)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
+	"github.com/juju/juju/core/charm/metrics"
 )
 
 // charmhubID holds identifying information for several charms for a
@@ -40,12 +41,12 @@ type charmhubResult struct {
 // CharmhubRefreshClient is an interface for the methods of the charmhub
 // client that we need.
 type CharmhubRefreshClient interface {
-	Refresh(ctx context.Context, config charmhub.RefreshConfig) ([]transport.RefreshResponse, error)
+	RefreshWithRequestMetrics(ctx context.Context, config charmhub.RefreshConfig, metrics map[metrics.MetricKey]map[metrics.MetricKey]string) ([]transport.RefreshResponse, error)
 }
 
 // charmhubLatestCharmInfo fetches the latest information about the given
 // charms from charmhub's "charm_refresh" API.
-func charmhubLatestCharmInfo(client CharmhubRefreshClient, ids []charmhubID) ([]charmhubResult, error) {
+func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.MetricKey]map[metrics.MetricKey]string, ids []charmhubID) ([]charmhubResult, error) {
 	cfgs := make([]charmhub.RefreshConfig, len(ids))
 	for i, id := range ids {
 		base := charmhub.RefreshBase{
@@ -63,7 +64,7 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, ids []charmhubID) ([]
 
 	ctx, cancel := context.WithTimeout(context.TODO(), charmhub.RefreshTimeout)
 	defer cancel()
-	responses, err := client.Refresh(ctx, config)
+	responses, err := client.RefreshWithRequestMetrics(ctx, config, metrics)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/charmrevisionupdater/interface.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface.go
@@ -42,6 +42,7 @@ type Model interface {
 	CloudRegion() string
 	Config() (*config.Config, error)
 	IsControllerModel() bool
+	Metrics() (state.ModelMetrics, error)
 	UUID() string
 }
 

--- a/apiserver/facades/controller/charmrevisionupdater/interface.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface.go
@@ -26,6 +26,7 @@ type State interface {
 	ControllerUUID() string
 	Model() (Model, error)
 	Resources() (state.Resources, error)
+	AliveRelationKeys() []string
 }
 
 // Application is the subset of *state.Application that we need.
@@ -34,6 +35,7 @@ type Application interface {
 	CharmOrigin() *state.CharmOrigin
 	Channel() csparams.Channel
 	ApplicationTag() names.ApplicationTag
+	UnitCount() int
 }
 
 // Model is the subset of *state.Model that we need.
@@ -67,7 +69,7 @@ func (s StateShim) Model() (Model, error) {
 	return s.State.Model()
 }
 
-// charmhubClientStateShim takes a *state.State and and implements common.ModelGetter.
+// charmhubClientStateShim takes a *state.State and implements common.ModelGetter.
 type charmhubClientStateShim struct {
 	state State
 }

--- a/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
+++ b/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
@@ -102,6 +102,20 @@ func (mr *MockApplicationMockRecorder) CharmURL() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockApplication)(nil).CharmURL))
 }
 
+// UnitCount mocks base method.
+func (m *MockApplication) UnitCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnitCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// UnitCount indicates an expected call of UnitCount.
+func (mr *MockApplicationMockRecorder) UnitCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitCount", reflect.TypeOf((*MockApplication)(nil).UnitCount))
+}
+
 // MockCharmhubRefreshClient is a mock of CharmhubRefreshClient interface.
 type MockCharmhubRefreshClient struct {
 	ctrl     *gomock.Controller
@@ -284,6 +298,20 @@ func (m *MockState) AddCharmPlaceholder(arg0 *charm.URL) error {
 func (mr *MockStateMockRecorder) AddCharmPlaceholder(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmPlaceholder", reflect.TypeOf((*MockState)(nil).AddCharmPlaceholder), arg0)
+}
+
+// AliveRelationKeys mocks base method.
+func (m *MockState) AliveRelationKeys() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AliveRelationKeys")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// AliveRelationKeys indicates an expected call of AliveRelationKeys.
+func (mr *MockStateMockRecorder) AliveRelationKeys() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AliveRelationKeys", reflect.TypeOf((*MockState)(nil).AliveRelationKeys))
 }
 
 // AllApplications mocks base method.

--- a/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
+++ b/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
@@ -6,6 +6,8 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	params "github.com/juju/charmrepo/v6/csclient/params"
@@ -14,36 +16,36 @@ import (
 	transport "github.com/juju/juju/charmhub/transport"
 	cloud "github.com/juju/juju/cloud"
 	controller "github.com/juju/juju/controller"
+	metrics "github.com/juju/juju/core/charm/metrics"
 	config "github.com/juju/juju/environs/config"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockApplication is a mock of Application interface
+// MockApplication is a mock of Application interface.
 type MockApplication struct {
 	ctrl     *gomock.Controller
 	recorder *MockApplicationMockRecorder
 }
 
-// MockApplicationMockRecorder is the mock recorder for MockApplication
+// MockApplicationMockRecorder is the mock recorder for MockApplication.
 type MockApplicationMockRecorder struct {
 	mock *MockApplication
 }
 
-// NewMockApplication creates a new mock instance
+// NewMockApplication creates a new mock instance.
 func NewMockApplication(ctrl *gomock.Controller) *MockApplication {
 	mock := &MockApplication{ctrl: ctrl}
 	mock.recorder = &MockApplicationMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 	return m.recorder
 }
 
-// ApplicationTag mocks base method
+// ApplicationTag mocks base method.
 func (m *MockApplication) ApplicationTag() names.ApplicationTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationTag")
@@ -51,13 +53,13 @@ func (m *MockApplication) ApplicationTag() names.ApplicationTag {
 	return ret0
 }
 
-// ApplicationTag indicates an expected call of ApplicationTag
+// ApplicationTag indicates an expected call of ApplicationTag.
 func (mr *MockApplicationMockRecorder) ApplicationTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationTag", reflect.TypeOf((*MockApplication)(nil).ApplicationTag))
 }
 
-// Channel mocks base method
+// Channel mocks base method.
 func (m *MockApplication) Channel() params.Channel {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Channel")
@@ -65,13 +67,13 @@ func (m *MockApplication) Channel() params.Channel {
 	return ret0
 }
 
-// Channel indicates an expected call of Channel
+// Channel indicates an expected call of Channel.
 func (mr *MockApplicationMockRecorder) Channel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Channel", reflect.TypeOf((*MockApplication)(nil).Channel))
 }
 
-// CharmOrigin mocks base method
+// CharmOrigin mocks base method.
 func (m *MockApplication) CharmOrigin() *state.CharmOrigin {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmOrigin")
@@ -79,13 +81,13 @@ func (m *MockApplication) CharmOrigin() *state.CharmOrigin {
 	return ret0
 }
 
-// CharmOrigin indicates an expected call of CharmOrigin
+// CharmOrigin indicates an expected call of CharmOrigin.
 func (mr *MockApplicationMockRecorder) CharmOrigin() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmOrigin", reflect.TypeOf((*MockApplication)(nil).CharmOrigin))
 }
 
-// CharmURL mocks base method
+// CharmURL mocks base method.
 func (m *MockApplication) CharmURL() (*charm.URL, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
@@ -94,74 +96,74 @@ func (m *MockApplication) CharmURL() (*charm.URL, bool) {
 	return ret0, ret1
 }
 
-// CharmURL indicates an expected call of CharmURL
+// CharmURL indicates an expected call of CharmURL.
 func (mr *MockApplicationMockRecorder) CharmURL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockApplication)(nil).CharmURL))
 }
 
-// MockCharmhubRefreshClient is a mock of CharmhubRefreshClient interface
+// MockCharmhubRefreshClient is a mock of CharmhubRefreshClient interface.
 type MockCharmhubRefreshClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockCharmhubRefreshClientMockRecorder
 }
 
-// MockCharmhubRefreshClientMockRecorder is the mock recorder for MockCharmhubRefreshClient
+// MockCharmhubRefreshClientMockRecorder is the mock recorder for MockCharmhubRefreshClient.
 type MockCharmhubRefreshClientMockRecorder struct {
 	mock *MockCharmhubRefreshClient
 }
 
-// NewMockCharmhubRefreshClient creates a new mock instance
+// NewMockCharmhubRefreshClient creates a new mock instance.
 func NewMockCharmhubRefreshClient(ctrl *gomock.Controller) *MockCharmhubRefreshClient {
 	mock := &MockCharmhubRefreshClient{ctrl: ctrl}
 	mock.recorder = &MockCharmhubRefreshClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCharmhubRefreshClient) EXPECT() *MockCharmhubRefreshClientMockRecorder {
 	return m.recorder
 }
 
-// Refresh mocks base method
-func (m *MockCharmhubRefreshClient) Refresh(arg0 context.Context, arg1 charmhub.RefreshConfig) ([]transport.RefreshResponse, error) {
+// RefreshWithRequestMetrics mocks base method.
+func (m *MockCharmhubRefreshClient) RefreshWithRequestMetrics(arg0 context.Context, arg1 charmhub.RefreshConfig, arg2 map[metrics.MetricKey]map[metrics.MetricKey]string) ([]transport.RefreshResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Refresh", arg0, arg1)
+	ret := m.ctrl.Call(m, "RefreshWithRequestMetrics", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]transport.RefreshResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Refresh indicates an expected call of Refresh
-func (mr *MockCharmhubRefreshClientMockRecorder) Refresh(arg0, arg1 interface{}) *gomock.Call {
+// RefreshWithRequestMetrics indicates an expected call of RefreshWithRequestMetrics.
+func (mr *MockCharmhubRefreshClientMockRecorder) RefreshWithRequestMetrics(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Refresh", reflect.TypeOf((*MockCharmhubRefreshClient)(nil).Refresh), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshWithRequestMetrics", reflect.TypeOf((*MockCharmhubRefreshClient)(nil).RefreshWithRequestMetrics), arg0, arg1, arg2)
 }
 
-// MockModel is a mock of Model interface
+// MockModel is a mock of Model interface.
 type MockModel struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelMockRecorder
 }
 
-// MockModelMockRecorder is the mock recorder for MockModel
+// MockModelMockRecorder is the mock recorder for MockModel.
 type MockModelMockRecorder struct {
 	mock *MockModel
 }
 
-// NewMockModel creates a new mock instance
+// NewMockModel creates a new mock instance.
 func NewMockModel(ctrl *gomock.Controller) *MockModel {
 	mock := &MockModel{ctrl: ctrl}
 	mock.recorder = &MockModelMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModel) EXPECT() *MockModelMockRecorder {
 	return m.recorder
 }
 
-// CloudName mocks base method
+// CloudName mocks base method.
 func (m *MockModel) CloudName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudName")
@@ -169,13 +171,13 @@ func (m *MockModel) CloudName() string {
 	return ret0
 }
 
-// CloudName indicates an expected call of CloudName
+// CloudName indicates an expected call of CloudName.
 func (mr *MockModelMockRecorder) CloudName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudName", reflect.TypeOf((*MockModel)(nil).CloudName))
 }
 
-// CloudRegion mocks base method
+// CloudRegion mocks base method.
 func (m *MockModel) CloudRegion() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudRegion")
@@ -183,13 +185,13 @@ func (m *MockModel) CloudRegion() string {
 	return ret0
 }
 
-// CloudRegion indicates an expected call of CloudRegion
+// CloudRegion indicates an expected call of CloudRegion.
 func (mr *MockModelMockRecorder) CloudRegion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudRegion", reflect.TypeOf((*MockModel)(nil).CloudRegion))
 }
 
-// Config mocks base method
+// Config mocks base method.
 func (m *MockModel) Config() (*config.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
@@ -198,13 +200,13 @@ func (m *MockModel) Config() (*config.Config, error) {
 	return ret0, ret1
 }
 
-// Config indicates an expected call of Config
+// Config indicates an expected call of Config.
 func (mr *MockModelMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockModel)(nil).Config))
 }
 
-// IsControllerModel mocks base method
+// IsControllerModel mocks base method.
 func (m *MockModel) IsControllerModel() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsControllerModel")
@@ -212,13 +214,28 @@ func (m *MockModel) IsControllerModel() bool {
 	return ret0
 }
 
-// IsControllerModel indicates an expected call of IsControllerModel
+// IsControllerModel indicates an expected call of IsControllerModel.
 func (mr *MockModelMockRecorder) IsControllerModel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsControllerModel", reflect.TypeOf((*MockModel)(nil).IsControllerModel))
 }
 
-// UUID mocks base method
+// Metrics mocks base method.
+func (m *MockModel) Metrics() (state.ModelMetrics, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Metrics")
+	ret0, _ := ret[0].(state.ModelMetrics)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Metrics indicates an expected call of Metrics.
+func (mr *MockModelMockRecorder) Metrics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockModel)(nil).Metrics))
+}
+
+// UUID mocks base method.
 func (m *MockModel) UUID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UUID")
@@ -226,36 +243,36 @@ func (m *MockModel) UUID() string {
 	return ret0
 }
 
-// UUID indicates an expected call of UUID
+// UUID indicates an expected call of UUID.
 func (mr *MockModelMockRecorder) UUID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UUID", reflect.TypeOf((*MockModel)(nil).UUID))
 }
 
-// MockState is a mock of State interface
+// MockState is a mock of State interface.
 type MockState struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateMockRecorder
 }
 
-// MockStateMockRecorder is the mock recorder for MockState
+// MockStateMockRecorder is the mock recorder for MockState.
 type MockStateMockRecorder struct {
 	mock *MockState
 }
 
-// NewMockState creates a new mock instance
+// NewMockState creates a new mock instance.
 func NewMockState(ctrl *gomock.Controller) *MockState {
 	mock := &MockState{ctrl: ctrl}
 	mock.recorder = &MockStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AddCharmPlaceholder mocks base method
+// AddCharmPlaceholder mocks base method.
 func (m *MockState) AddCharmPlaceholder(arg0 *charm.URL) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddCharmPlaceholder", arg0)
@@ -263,13 +280,13 @@ func (m *MockState) AddCharmPlaceholder(arg0 *charm.URL) error {
 	return ret0
 }
 
-// AddCharmPlaceholder indicates an expected call of AddCharmPlaceholder
+// AddCharmPlaceholder indicates an expected call of AddCharmPlaceholder.
 func (mr *MockStateMockRecorder) AddCharmPlaceholder(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCharmPlaceholder", reflect.TypeOf((*MockState)(nil).AddCharmPlaceholder), arg0)
 }
 
-// AllApplications mocks base method
+// AllApplications mocks base method.
 func (m *MockState) AllApplications() ([]charmrevisionupdater.Application, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllApplications")
@@ -278,13 +295,13 @@ func (m *MockState) AllApplications() ([]charmrevisionupdater.Application, error
 	return ret0, ret1
 }
 
-// AllApplications indicates an expected call of AllApplications
+// AllApplications indicates an expected call of AllApplications.
 func (mr *MockStateMockRecorder) AllApplications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllApplications", reflect.TypeOf((*MockState)(nil).AllApplications))
 }
 
-// Charm mocks base method
+// Charm mocks base method.
 func (m *MockState) Charm(arg0 *charm.URL) (*state.Charm, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
@@ -293,13 +310,13 @@ func (m *MockState) Charm(arg0 *charm.URL) (*state.Charm, error) {
 	return ret0, ret1
 }
 
-// Charm indicates an expected call of Charm
+// Charm indicates an expected call of Charm.
 func (mr *MockStateMockRecorder) Charm(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockState)(nil).Charm), arg0)
 }
 
-// Cloud mocks base method
+// Cloud mocks base method.
 func (m *MockState) Cloud(arg0 string) (cloud.Cloud, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Cloud", arg0)
@@ -308,13 +325,13 @@ func (m *MockState) Cloud(arg0 string) (cloud.Cloud, error) {
 	return ret0, ret1
 }
 
-// Cloud indicates an expected call of Cloud
+// Cloud indicates an expected call of Cloud.
 func (mr *MockStateMockRecorder) Cloud(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cloud", reflect.TypeOf((*MockState)(nil).Cloud), arg0)
 }
 
-// ControllerConfig mocks base method
+// ControllerConfig mocks base method.
 func (m *MockState) ControllerConfig() (controller.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerConfig")
@@ -323,13 +340,13 @@ func (m *MockState) ControllerConfig() (controller.Config, error) {
 	return ret0, ret1
 }
 
-// ControllerConfig indicates an expected call of ControllerConfig
+// ControllerConfig indicates an expected call of ControllerConfig.
 func (mr *MockStateMockRecorder) ControllerConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockState)(nil).ControllerConfig))
 }
 
-// ControllerUUID mocks base method
+// ControllerUUID mocks base method.
 func (m *MockState) ControllerUUID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerUUID")
@@ -337,13 +354,13 @@ func (m *MockState) ControllerUUID() string {
 	return ret0
 }
 
-// ControllerUUID indicates an expected call of ControllerUUID
+// ControllerUUID indicates an expected call of ControllerUUID.
 func (mr *MockStateMockRecorder) ControllerUUID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerUUID", reflect.TypeOf((*MockState)(nil).ControllerUUID))
 }
 
-// Model mocks base method
+// Model mocks base method.
 func (m *MockState) Model() (charmrevisionupdater.Model, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
@@ -352,13 +369,13 @@ func (m *MockState) Model() (charmrevisionupdater.Model, error) {
 	return ret0, ret1
 }
 
-// Model indicates an expected call of Model
+// Model indicates an expected call of Model.
 func (mr *MockStateMockRecorder) Model() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockState)(nil).Model))
 }
 
-// Resources mocks base method
+// Resources mocks base method.
 func (m *MockState) Resources() (state.Resources, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resources")
@@ -367,7 +384,7 @@ func (m *MockState) Resources() (state.Resources, error) {
 	return ret0, ret1
 }
 
-// Resources indicates an expected call of Resources
+// Resources indicates an expected call of Resources.
 func (mr *MockStateMockRecorder) Resources() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resources", reflect.TypeOf((*MockState)(nil).Resources))

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -184,12 +184,13 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 				return nil, errors.Trace(err)
 			}
 			cid := charmhubID{
-				id:       origin.ID,
-				revision: *origin.Revision,
-				channel:  channel.String(),
-				os:       strings.ToLower(origin.Platform.OS), // charmhub API requires lowercase OS name
-				series:   origin.Platform.Series,
-				arch:     origin.Platform.Architecture,
+				id:          origin.ID,
+				revision:    *origin.Revision,
+				channel:     channel.String(),
+				os:          strings.ToLower(origin.Platform.OS), // charmhub API requires lowercase OS key
+				series:      origin.Platform.Series,
+				arch:        origin.Platform.Architecture,
+				instanceKey: charmhub.CreateInstanceKey(cfg.UUID(), application.ApplicationTag().Name),
 			}
 			if telemetry {
 				cid.metrics = map[charmmetrics.MetricKey]string{
@@ -393,7 +394,7 @@ func (api *CharmRevisionUpdaterAPI) fetchCharmhubInfos(cfg *config.Config, ids [
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	results, err := charmhubLatestCharmInfo(client, requestMetrics, ids)
+	results, err := charmhubLatestCharmInfo(client, requestMetrics, ids, cfg.UUID())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -286,7 +286,6 @@ func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(cfg *config.Config, ids
 }
 
 func (api *CharmRevisionUpdaterAPI) fetchCharmhubInfos(cfg *config.Config, ids []charmhubID, appInfos []appInfo) ([]latestCharmInfo, error) {
-	cfg.Telemetry()
 	var requestMetrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string
 	if cfg.Telemetry() {
 		var err error

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmstore"
 	charmmetrics "github.com/juju/juju/core/charm/metrics"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/version"
 )
@@ -141,6 +142,15 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	model, err := api.state.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cfg, err := model.Config()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	telemetry := cfg.Telemetry()
 
 	// Partition the charms into charmhub vs charmstore so we can query each
 	// batch separately.
@@ -196,10 +206,12 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 			cid := charmstore.CharmID{
 				URL:     curl,
 				Channel: application.Channel(),
-				Metadata: map[string]string{
+			}
+			if telemetry {
+				cid.Metadata = map[string]string{
 					"series": origin.Platform.Series,
 					"arch":   origin.Platform.Architecture,
-				},
+				}
 			}
 			charmstoreIDs = append(charmstoreIDs, cid)
 			charmstoreApps = append(charmstoreApps, appInfo{
@@ -214,14 +226,14 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 
 	var latest []latestCharmInfo
 	if len(charmstoreIDs) > 0 {
-		storeLatest, err := api.fetchCharmstoreInfos(charmstoreIDs, charmstoreApps)
+		storeLatest, err := api.fetchCharmstoreInfos(cfg, charmstoreIDs, charmstoreApps)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		latest = append(latest, storeLatest...)
 	}
 	if len(charmhubIDs) > 0 {
-		hubLatest, err := api.fetchCharmhubInfos(charmhubIDs, charmhubApps)
+		hubLatest, err := api.fetchCharmhubInfos(cfg, charmhubIDs, charmhubApps)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -231,20 +243,20 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 	return latest, nil
 }
 
-func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(ids []charmstore.CharmID, appInfos []appInfo) ([]latestCharmInfo, error) {
+func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(cfg *config.Config, ids []charmstore.CharmID, appInfos []appInfo) ([]latestCharmInfo, error) {
 	client, err := api.newCharmstoreClient(api.state)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	metadata, err := charmstoreApiMetadata(api.state)
-	if err != nil {
-		return nil, errors.Trace(err)
+
+	var metadata map[string]string
+	if cfg.Telemetry() {
+		metadata, err = charmstoreApiMetadata(api.state)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		metadata["environment_uuid"] = cfg.UUID() // duplicates model_uuid, but send to charmstore for legacy reasons
 	}
-	model, err := api.state.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	metadata["environment_uuid"] = model.UUID() // duplicates model_uuid, but send to charmstore for legacy reasons
 	results, err := charmstore.LatestCharmInfo(client, ids, metadata)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -273,10 +285,15 @@ func (api *CharmRevisionUpdaterAPI) fetchCharmstoreInfos(ids []charmstore.CharmI
 	return latest, nil
 }
 
-func (api *CharmRevisionUpdaterAPI) fetchCharmhubInfos(ids []charmhubID, appInfos []appInfo) ([]latestCharmInfo, error) {
-	requestMetrics, err := charmhubRequestMetadata(api.state)
-	if err != nil {
-		return nil, errors.Trace(err)
+func (api *CharmRevisionUpdaterAPI) fetchCharmhubInfos(cfg *config.Config, ids []charmhubID, appInfos []appInfo) ([]latestCharmInfo, error) {
+	cfg.Telemetry()
+	var requestMetrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string
+	if cfg.Telemetry() {
+		var err error
+		requestMetrics, err = charmhubRequestMetadata(api.state)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	client, err := api.newCharmhubClient(api.state)
 	if err != nil {

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -14,17 +14,25 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/charmhub/transport"
+	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/state"
 	statemocks "github.com/juju/juju/state/mocks"
+	"github.com/juju/juju/testing"
 )
 
-type updaterSuite struct{}
+type updaterSuite struct {
+	model     *mocks.MockModel
+	state     *mocks.MockState
+	resources *statemocks.MockResources
+}
 
 var _ = gc.Suite(&updaterSuite{})
 
-type newCharmhubClientFunc = func(st charmrevisionupdater.State, metadata map[string]string) (charmrevisionupdater.CharmhubRefreshClient, error)
+type newCharmhubClientFunc = func(st charmrevisionupdater.State) (charmrevisionupdater.CharmhubRefreshClient, error)
 
 func (s *updaterSuite) newCharmhubClient(client charmrevisionupdater.CharmhubRefreshClient) newCharmhubClientFunc {
-	return func(st charmrevisionupdater.State, metadata map[string]string) (charmrevisionupdater.CharmhubRefreshClient, error) {
+	return func(st charmrevisionupdater.State) (charmrevisionupdater.CharmhubRefreshClient, error) {
 		return client, nil
 	}
 }
@@ -46,15 +54,16 @@ func (s *updaterSuite) TestNewAuthFailure(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmHubModel()
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
 		{"charm-1", 22},
 		{"charm-2", 41},
 	}}
-	client.EXPECT().Refresh(gomock.Any(), matcher).Return([]transport.RefreshResponse{
+	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{Revision: 23},
 			ID:     "charm-1",
@@ -67,15 +76,52 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 		},
 	}, nil)
 
-	state := makeState(c, ctrl, nil)
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "ch", "mysql", "charm-1", "app-1", 22),
 		makeApplication(ctrl, "ch", "postgresql", "charm-2", "app-2", 41),
 	}, nil).AnyTimes()
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:mysql-23")).Return(nil)
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:mysql-23")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, nil, s.newCharmhubClient(client))
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, nil, s.newCharmhubClient(client))
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := updater.UpdateLatestRevisions()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+}
+
+func (s *updaterSuite) TestCharmhubUpdateWithMetrics(c *gc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.expectCharmHubModel()
+
+	client := mocks.NewMockCharmhubRefreshClient(ctrl)
+	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
+		{"charm-1", 22},
+		{"charm-2", 41},
+	}}
+	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, charmhubMetricsMatcher{c: c}).Return([]transport.RefreshResponse{
+		{
+			Entity: transport.RefreshEntity{Revision: 23},
+			ID:     "charm-1",
+			Name:   "mysql",
+		},
+		{
+			Entity: transport.RefreshEntity{Revision: 42},
+			ID:     "charm-2",
+			Name:   "postgresql",
+		},
+	}, nil)
+
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+		makeApplication(ctrl, "ch", "mysql", "charm-1", "app-1", 22),
+		makeApplication(ctrl, "ch", "postgresql", "charm-2", "app-2", 41),
+	}, nil).AnyTimes()
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:mysql-23")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
+
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, nil, s.newCharmhubClient(client))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -84,21 +130,21 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmHubModel()
 
 	expectedResources := []resource.Resource{
 		makeResource(c, "reza", 7, 5, "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f"),
 		makeResource(c, "rezb", 1, 6, "03130092073c5ac523ecb21f548b9ad6e1387d1cb05f3cb892fcc26029d01428afbe74025b6c567b6564a3168a47179a"),
 	}
-	resources := statemocks.NewMockResources(ctrl)
-	resources.EXPECT().SetCharmStoreResources("app-1", expectedResources, gomock.Any()).Return(nil).AnyTimes()
+	s.resources.EXPECT().SetCharmStoreResources("app-1", expectedResources, gomock.Any()).Return(nil)
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
 		{"charm-3", 1},
 	}}
-	client.EXPECT().Refresh(gomock.Any(), matcher).Return([]transport.RefreshResponse{
+	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{
 				Resources: []transport.ResourceRevision{
@@ -128,14 +174,14 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 		},
 	}, nil)
 
-	state := makeState(c, ctrl, resources)
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().Resources().Return(s.resources, nil).AnyTimes()
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "ch", "resourcey", "charm-3", "app-1", 1),
 	}, nil).AnyTimes()
 
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:resourcey-1")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:resourcey-1")).Return(nil)
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, nil, s.newCharmhubClient(client))
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, nil, s.newCharmhubClient(client))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -144,14 +190,15 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmHubModel()
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
 		{"charm-2", 42},
 	}}
-	client.EXPECT().Refresh(gomock.Any(), matcher).Return([]transport.RefreshResponse{
+	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{Revision: 42},
 			ID:     "charm-2",
@@ -159,13 +206,12 @@ func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
 		},
 	}, nil)
 
-	state := makeState(c, ctrl, nil)
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "ch", "postgresql", "charm-2", "app-2", 42),
 	}, nil).AnyTimes()
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("ch:postgresql-42")).Return(nil)
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, nil, s.newCharmhubClient(client))
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, nil, s.newCharmhubClient(client))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -174,19 +220,20 @@ func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmNotInStore(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmStoreModel(c)
+	s.expectCharmHubModel()
 
 	charmhubClient := mocks.NewMockCharmhubRefreshClient(ctrl)
-	charmhubClient.EXPECT().Refresh(gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{}, nil)
+	charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{}, nil)
 
-	state := makeState(c, ctrl, nil)
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "ch", "varnish", "charm-5", "app-1", 1),
 		makeApplication(ctrl, "cs", "varnish", "charm-6", "app-2", 2),
 	}, nil).AnyTimes()
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, newFakeCharmstoreClient, s.newCharmhubClient(charmhubClient))
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, newFakeCharmstoreClient, s.newCharmhubClient(charmhubClient))
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -195,21 +242,20 @@ func (s *updaterSuite) TestCharmNotInStore(c *gc.C) {
 }
 
 func (s *updaterSuite) TestCharmstoreUpdate(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
+	s.expectCharmStoreModel(c)
 
-	state := makeState(c, ctrl, nil)
-
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "cs", "mysql", "charm-1", "app-1", 22),
 		makeApplication(ctrl, "cs", "wordpress", "charm-2", "app-2", 26),
 		makeApplication(ctrl, "cs", "varnish", "charm-3", "app-3", 5), // doesn't exist in store
 	}, nil)
 
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:mysql-23")).Return(nil)
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:wordpress-26")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:mysql-23")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:wordpress-26")).Return(nil)
 
-	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, newFakeCharmstoreClient, nil)
+	updater, err := charmrevisionupdater.NewCharmRevisionUpdaterAPIState(s.state, newFakeCharmstoreClient, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := updater.UpdateLatestRevisions()
@@ -217,13 +263,75 @@ func (s *updaterSuite) TestCharmstoreUpdate(c *gc.C) {
 	c.Assert(result.Error, gc.IsNil)
 
 	// Update mysql version and run update again.
-	state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
+	s.state.EXPECT().AllApplications().Return([]charmrevisionupdater.Application{
 		makeApplication(ctrl, "cs", "mysql", "charm-1", "app-1", 23),
 	}, nil)
 
-	state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:mysql-23")).Return(nil)
+	s.state.EXPECT().AddCharmPlaceholder(charm.MustParseURL("cs:mysql-23")).Return(nil)
 
 	result, err = updater.UpdateLatestRevisions()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
+}
+
+func (s *updaterSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := s.setupMocksNoResources(c)
+	s.resources.EXPECT().SetCharmStoreResources(gomock.Any(), gomock.Len(0), gomock.Any()).Return(nil).AnyTimes()
+
+	return ctrl
+}
+
+func (s *updaterSuite) setupMocksNoResources(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.model = mocks.NewMockModel(ctrl)
+	s.resources = statemocks.NewMockResources(ctrl)
+	s.state = mocks.NewMockState(ctrl)
+
+	s.state.EXPECT().Cloud(gomock.Any()).Return(cloud.Cloud{Type: "cloud"}, nil).AnyTimes()
+	s.state.EXPECT().ControllerUUID().Return("controller-1").AnyTimes()
+	s.state.EXPECT().Model().Return(s.model, nil).AnyTimes()
+	s.state.EXPECT().Resources().Return(s.resources, nil).AnyTimes()
+	return ctrl
+}
+
+func (s *updaterSuite) expectCharmStoreModel(c *gc.C) {
+	mExp := s.model.EXPECT()
+	mExp.CloudName().Return("testcloud").AnyTimes()
+	mExp.CloudRegion().Return("juju-land").AnyTimes()
+	uuid := testing.ModelTag.Id()
+	cfg, err := config.New(true, map[string]interface{}{
+		"charmhub-url": "https://api.staging.charmhub.io", // not actually used in tests
+		"name":         "model",
+		"type":         "type",
+		"uuid":         uuid,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	mExp.Config().Return(cfg, nil).AnyTimes()
+	mExp.IsControllerModel().Return(false).AnyTimes()
+	mExp.UUID().Return(uuid).AnyTimes()
+}
+
+func (s *updaterSuite) expectCharmHubModel() {
+	uuid := testing.ModelTag.Id()
+	s.model.EXPECT().Metrics().Return(state.ModelMetrics{
+		UUID:           uuid,
+		ControllerUUID: "controller-1",
+		CloudName:      "cloud",
+	}, nil).AnyTimes()
+}
+
+func (s *updaterSuite) expectResources(c *gc.C, name string, revision, size int, hexFingerprint string) {
+	fingerprint, err := resource.ParseFingerprint(hexFingerprint)
+	c.Assert(err, jc.ErrorIsNil)
+	resources := resource.Resource{
+		Meta: resource.Meta{
+			Name: name,
+			Type: resource.TypeFile,
+		},
+		Origin:      resource.OriginStore,
+		Revision:    revision,
+		Fingerprint: fingerprint,
+		Size:        int64(size),
+	}
+	s.state.EXPECT().Resources().Return(resources, nil).AnyTimes()
 }

--- a/apiserver/facades/controller/charmrevisionupdater/updater_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater_test.go
@@ -60,8 +60,8 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
-		{"charm-1", 22},
-		{"charm-2", 41},
+		{id: "charm-1", revision: 22},
+		{id: "charm-2", revision: 41},
 	}}
 	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
@@ -94,8 +94,27 @@ func (s *updaterSuite) TestCharmhubUpdate(c *gc.C) {
 func (s *updaterSuite) TestCharmhubUpdateWithMetrics(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
-	s.expectCharmHubModel(c)
-	s.testCharmhubUpdateMetrics(c, ctrl, true)
+	uuid := testing.ModelTag.Id()
+	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
+		"name": "model",
+		"type": "type",
+		"uuid": uuid,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.model.EXPECT().Config().Return(cfg, nil).AnyTimes()
+	s.model.EXPECT().Metrics().Return(state.ModelMetrics{
+		UUID:           uuid,
+		ControllerUUID: "controller-1",
+		CloudName:      "cloud",
+	}, nil).AnyTimes()
+	s.state.EXPECT().AliveRelationKeys().Return([]string{
+		"app-1:end app-2:point",
+	})
+	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
+		{id: "charm-1", revision: 22, relMetric: "postgresql"},
+		{id: "charm-2", revision: 41, relMetric: "mysql"},
+	}}
+	s.testCharmhubUpdateMetrics(c, ctrl, matcher, true)
 }
 
 func (s *updaterSuite) TestCharmhubUpdateWithNoMetrics(c *gc.C) {
@@ -109,15 +128,16 @@ func (s *updaterSuite) TestCharmhubUpdateWithNoMetrics(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	s.model.EXPECT().Config().Return(cfg, nil).AnyTimes()
-	s.testCharmhubUpdateMetrics(c, ctrl, false)
+	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
+		{id: "charm-1", revision: 22},
+		{id: "charm-2", revision: 41},
+	}}
+	s.testCharmhubUpdateMetrics(c, ctrl, matcher, false)
 }
 
-func (s *updaterSuite) testCharmhubUpdateMetrics(c *gc.C, ctrl *gomock.Controller, exist bool) {
+func (s *updaterSuite) testCharmhubUpdateMetrics(c *gc.C, ctrl *gomock.Controller, matcher gomock.Matcher, exist bool) {
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
-	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
-		{"charm-1", 22},
-		{"charm-2", 41},
-	}}
+
 	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, charmhubMetricsMatcher{c: c, exist: exist}).Return([]transport.RefreshResponse{
 		{
 			Entity: transport.RefreshEntity{Revision: 23},
@@ -159,7 +179,7 @@ func (s *updaterSuite) TestCharmhubUpdateWithResources(c *gc.C) {
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
-		{"charm-3", 1},
+		{id: "charm-3", revision: 1},
 	}}
 	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
@@ -213,7 +233,7 @@ func (s *updaterSuite) TestCharmhubNoUpdate(c *gc.C) {
 
 	client := mocks.NewMockCharmhubRefreshClient(ctrl)
 	matcher := charmhubConfigMatcher{expected: []charmhubConfigExpected{
-		{"charm-2", 42},
+		{id: "charm-2", revision: 42},
 	}}
 	client.EXPECT().RefreshWithRequestMetrics(gomock.Any(), matcher, gomock.Any()).Return([]transport.RefreshResponse{
 		{
@@ -348,11 +368,6 @@ func (s *updaterSuite) expectCharmStoreModel(c *gc.C) {
 func (s *updaterSuite) expectCharmHubModel(c *gc.C) {
 	mExp := s.model.EXPECT()
 	uuid := testing.ModelTag.Id()
-	mExp.Metrics().Return(state.ModelMetrics{
-		UUID:           uuid,
-		ControllerUUID: "controller-1",
-		CloudName:      "cloud",
-	}, nil).AnyTimes()
 	cfg, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name": "model",
 		"type": "type",
@@ -360,6 +375,12 @@ func (s *updaterSuite) expectCharmHubModel(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	mExp.Config().Return(cfg, nil).AnyTimes()
+	mExp.Metrics().Return(state.ModelMetrics{
+		UUID:           uuid,
+		ControllerUUID: "controller-1",
+		CloudName:      "cloud",
+	}, nil).AnyTimes()
+	s.state.EXPECT().AliveRelationKeys().Return(nil)
 }
 
 func (s *updaterSuite) expectResources(c *gc.C, name string, revision, size int, hexFingerprint string) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3166,6 +3166,9 @@
                         "id": {
                             "type": "string"
                         },
+                        "instance-key": {
+                            "type": "string"
+                        },
                         "os": {
                             "type": "string"
                         },
@@ -15549,6 +15552,9 @@
                             "type": "string"
                         },
                         "id": {
+                            "type": "string"
+                        },
+                        "instance-key": {
                             "type": "string"
                         },
                         "os": {
@@ -38996,6 +39002,9 @@
                             "type": "string"
                         },
                         "id": {
+                            "type": "string"
+                        },
+                        "instance-key": {
                             "type": "string"
                         },
                         "os": {

--- a/apiserver/params/applications.go
+++ b/apiserver/params/applications.go
@@ -38,6 +38,12 @@ type CharmOrigin struct {
 	Architecture string `json:"architecture,omitempty"`
 	OS           string `json:"os,omitempty"`
 	Series       string `json:"series,omitempty"`
+
+	// InstanceKey is a unique string associated with the application. To
+	// assist with keeping KPI data in charmhub, it must be the same for every
+	// charmhub Refresh action related to an application. Create with the
+	// charmhub.CreateInstanceKey method. LP: 1944582
+	InstanceKey string `json:"instance-key,omitempty"`
 }
 
 // ApplicationDeploy holds the parameters for making the application Deploy

--- a/charmhub/client.go
+++ b/charmhub/client.go
@@ -32,6 +32,7 @@ import (
 
 	charmhubpath "github.com/juju/juju/charmhub/path"
 	"github.com/juju/juju/charmhub/transport"
+	charmmetrics "github.com/juju/juju/core/charm/metrics"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/version"
 )
@@ -269,10 +270,16 @@ func (c *Client) Find(ctx context.Context, name string, options ...FindOption) (
 	return c.findClient.Find(ctx, name, options...)
 }
 
-// Refresh defines a client for making refresh API calls, that allow for
-// updating a series of charms to the latest version.
+// Refresh defines a client for making refresh API calls with different actions.
 func (c *Client) Refresh(ctx context.Context, config RefreshConfig) ([]transport.RefreshResponse, error) {
 	return c.refreshClient.Refresh(ctx, config)
+}
+
+// RefreshWithRequestMetrics defines a client for making refresh API calls.
+// Specifically to use the refresh action and provide metrics.  Intended for
+// use in the charm revision updater facade only.  Otherwise use Refresh.
+func (c *Client) RefreshWithRequestMetrics(ctx context.Context, config RefreshConfig, metrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string) ([]transport.RefreshResponse, error) {
+	return c.refreshClient.RefreshWithRequestMetrics(ctx, config, metrics)
 }
 
 // Download defines a client for downloading charms directly.

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -430,6 +430,9 @@ func RefreshMany(configs ...RefreshConfig) RefreshConfig {
 
 // Build a refresh request that can be past to the API.
 func (c refreshMany) Build() (transport.RefreshRequest, Headers, error) {
+	if len(c.Configs) == 0 {
+		return transport.RefreshRequest{}, nil, errors.NotFoundf("configs")
+	}
 	var composedHeaders Headers
 	// Not all configs built here have a context, start out with an empty
 	// slice, so we do not call Refresh with a nil context.

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -174,21 +174,36 @@ func (c refreshOne) String() string {
 }
 
 // RefreshOne creates a request config for requesting only one charm.
-func RefreshOne(id string, revision int, channel string, base RefreshBase) (RefreshConfig, error) {
+func RefreshOne(key, id string, revision int, channel string, base RefreshBase) (RefreshConfig, error) {
+	if key == "" {
+		// This is for compatibility reasons.  With older clients, the
+		// key created in GetCharmURLOrigin will be lost to and from
+		// the client.  Since a key is required, ensure we have one.
+		uuid, err := utils.NewUUID()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		key = uuid.String()
+	}
 	if err := validateBase(base); err != nil {
 		return nil, errors.Trace(err)
 	}
-	uuid, err := utils.NewUUID()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	return refreshOne{
-		instanceKey: uuid.String(),
+		instanceKey: key,
 		ID:          id,
 		Revision:    revision,
 		Channel:     channel,
 		Base:        base,
 	}, nil
+}
+
+// CreateInstanceKey creates an InstanceKey which can be unique and stable
+// from Refresh action to Refresh action.  Required for KPI collection
+// on the charmhub side, see LP:1944582.  Rather than saving in
+// state, use the model uuid + the app name, which are unique.  Modeled
+// after the applicationDoc DocID and globalKey in state.
+func CreateInstanceKey(uuid, appName string) string {
+	return uuid + ":a#" + appName
 }
 
 // Build a refresh request that can be past to the API.

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -378,8 +378,8 @@ func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
 			},
 			TrackingChannel: "latest/stable",
 			Metrics: map[string]string{
-				"provider":         "openstack",
-				"num-applications": "4",
+				"provider":     "openstack",
+				"applications": "4",
 			},
 		}},
 		Actions: []transport.RefreshRequestAction{{

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -13,7 +13,12 @@ type RefreshRequest struct {
 	// be always present and hence the no omitempty.
 	Context []RefreshRequestContext `json:"context"`
 	Actions []RefreshRequestAction  `json:"actions"`
+	Metrics RequestMetrics          `json:"metrics,omitempty"`
 }
+
+// RequestMetrics are a map of key value pairs of metrics for the controller
+// and the model in the request.
+type RequestMetrics map[string]map[string]string
 
 // RefreshRequestContext can request a given context for making multiple
 // requests to one given entity.
@@ -21,11 +26,16 @@ type RefreshRequestContext struct {
 	InstanceKey string `json:"instance-key"`
 	ID          string `json:"id"`
 
-	Revision        int        `json:"revision"`
-	Base            Base       `json:"base,omitempty"`
-	TrackingChannel string     `json:"tracking-channel,omitempty"`
-	RefreshedDate   *time.Time `json:"refresh-date,omitempty"`
+	Revision        int            `json:"revision"`
+	Base            Base           `json:"base,omitempty"`
+	TrackingChannel string         `json:"tracking-channel,omitempty"`
+	RefreshedDate   *time.Time     `json:"refresh-date,omitempty"`
+	Metrics         ContextMetrics `json:"metrics,omitempty"`
 }
+
+// ContextMetrics are a map of key value pairs of metrics for the specific
+// charm/application in the context.
+type ContextMetrics map[string]string
 
 // RefreshRequestAction defines a action to perform against the Refresh API.
 type RefreshRequestAction struct {

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -61,6 +61,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"core/application",
 		"core/arch",
 		"core/charm",
+		"core/charm/metrics",
 		"core/constraints",
 		"core/devices",
 		"core/instance",

--- a/core/charm/metrics/metrics.go
+++ b/core/charm/metrics/metrics.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package metrics
+
+// MetricKey represents metrics keys collected and sent to charmhub.
+type MetricKey string
+
+func (c MetricKey) String() string {
+	return string(c)
+}
+
+const (
+	// Controller is used in RequestMetrics
+	Controller MetricKey = "controller"
+
+	// Model is used in RequestMetrics
+	Model MetricKey = "model"
+
+	//
+	// Controller and Model, included in the RefreshRequest Metrics.
+	//
+
+	// UUID is the uuid of a model, either controller or model.
+	UUID MetricKey = "uuid"
+	// JujuVersion is the version of juju running in this model.
+	JujuVersion MetricKey = "juju-version"
+
+	//
+	// Model metrics, included in the RefreshRequest Metrics.
+	//
+
+	// Provider matches the provider type defined in juju.
+	Provider MetricKey = "provider"
+	// Region is the region this model is operating in.
+	Region MetricKey = "region"
+	// Cloud is the name of the cloud this model is operating in.
+	Cloud MetricKey = "cloud"
+	// NumApplications is the number of applications in the model.
+	NumApplications MetricKey = "num-applications"
+	// NumMachines is the number of machines in the model.
+	NumMachines MetricKey = "num-machines"
+	// NumUnits is the number of units in the model.
+	NumUnits MetricKey = "num-units"
+
+	//
+	// Charm metrics, included in the RefreshRequestContext Metrics.
+	//
+
+	// CharmURL is the url of the deployed charm, it includes the
+	// type, name, base and revision of the running charm.
+	CharmURL MetricKey = "charm-url"
+)

--- a/core/charm/metrics/metrics.go
+++ b/core/charm/metrics/metrics.go
@@ -37,17 +37,17 @@ const (
 	// Cloud is the name of the cloud this model is operating in.
 	Cloud MetricKey = "cloud"
 	// NumApplications is the number of applications in the model.
-	NumApplications MetricKey = "num-applications"
+	NumApplications MetricKey = "applications"
 	// NumMachines is the number of machines in the model.
-	NumMachines MetricKey = "num-machines"
+	NumMachines MetricKey = "machines"
 	// NumUnits is the number of units in the model.
-	NumUnits MetricKey = "num-units"
+	NumUnits MetricKey = "units"
 
 	//
 	// Charm metrics, included in the RefreshRequestContext Metrics.
 	//
 
-	// CharmURL is the url of the deployed charm, it includes the
-	// type, name, base and revision of the running charm.
-	CharmURL MetricKey = "charm-url"
+	// Relations is a common separated list of charms currently related
+	// to an application.  (no spaces)
+	Relations MetricKey = "relations"
 )

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -47,6 +47,12 @@ type Origin struct {
 	Revision *int
 	Channel  *charm.Channel
 	Platform Platform
+
+	// InstanceKey is a unique string associated with the application. To
+	// assist with keeping KPI data in charmhub, it must be the same for every
+	// charmhub Refresh action related to an application. Create with the
+	// charmhub.CreateInstanceKey method. LP: 1944582
+	InstanceKey string
 }
 
 // Platform describes the platform used to install the charm with.

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -280,6 +280,10 @@ const (
 	// TestModeKey is the key for identifying the model should be run in test
 	// mode.
 	TestModeKey = "test-mode"
+
+	// DisableTelemetryKey is a key for determining whether telemetry on juju
+	// models will be done.
+	DisableTelemetryKey = "disable-telemetry"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -490,6 +494,7 @@ var defaultConfigValues = map[string]interface{}{
 	"enable-os-upgrade":           true,
 	"development":                 false,
 	TestModeKey:                   false,
+	DisableTelemetryKey:           false,
 	TransmitVendorMetricsKey:      true,
 	UpdateStatusHookInterval:      DefaultUpdateStatusHookInterval,
 	EgressSubnets:                 "",
@@ -1536,6 +1541,12 @@ func (c *Config) LXDSnapChannel() string {
 	return c.asString(LXDSnapChannel)
 }
 
+// Telemetry returns whether telemetry is enabled for the model.
+func (c *Config) Telemetry() bool {
+	value, _ := c.defined[DisableTelemetryKey].(bool)
+	return !value
+}
+
 // UnknownAttrs returns a copy of the raw configuration attributes
 // that are supposedly specific to the environment type. They could
 // also be wrong attributes, though. Only the specific environment
@@ -1652,6 +1663,7 @@ var alwaysOptional = schema.Defaults{
 	IgnoreMachineAddresses:        schema.Omit,
 	AutomaticallyRetryHooks:       schema.Omit,
 	TestModeKey:                   schema.Omit,
+	DisableTelemetryKey:           schema.Omit,
 	ModeKey:                       schema.Omit,
 	TransmitVendorMetricsKey:      schema.Omit,
 	NetBondReconfigureDelayKey:    schema.Omit,
@@ -2093,6 +2105,11 @@ If true, accessing the charm store does not affect statistical
 data of the store. (default false)`,
 		Type:  environschema.Tbool,
 		Group: environschema.EnvironGroup,
+	},
+	DisableTelemetryKey: {
+		Description: `Whether the model disables telemetry`,
+		Type:        environschema.Tbool,
+		Group:       environschema.EnvironGroup,
 	},
 	ModeKey: {
 		Description: `Mode sets the type of mode the model should run in.

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -2107,7 +2107,7 @@ data of the store. (default false)`,
 		Group: environschema.EnvironGroup,
 	},
 	DisableTelemetryKey: {
-		Description: `Whether the model disables telemetry`,
+		Description: `Disable telemetry reporting of model information`,
 		Type:        environschema.Tbool,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1516,6 +1516,27 @@ func (s *ConfigSuite) TestLXDSnapChannelConfig(c *gc.C) {
 	c.Assert(config.LXDSnapChannel(), gc.Equals, "latest/candidate")
 }
 
+func (s *ConfigSuite) TestTelemetryConfig(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{})
+	c.Assert(cfg.Telemetry(), jc.IsTrue)
+}
+
+func (s *ConfigSuite) TestTelemetryConfigTrue(c *gc.C) {
+	cfg := newTestConfig(c, testing.Attrs{config.DisableTelemetryKey: true})
+	c.Assert(cfg.Telemetry(), jc.IsFalse)
+}
+
+func (s *ConfigSuite) TestTelemetryConfigDoesNotExist(c *gc.C) {
+	final := testing.Attrs{
+		"type": "my-type", "name": "my-name",
+		"uuid": testing.ModelTag.Id(),
+	}
+
+	cfg, err := config.New(config.NoDefaults, final)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Telemetry(), jc.IsTrue)
+}
+
 var serverKey2 = `
 -----BEGIN RSA PRIVATE KEY-----
 MIIBPAIBAAJBALgI8m2TSdKefUOXkaluDrqbv1ua9gl2ec2ZrYQPDOQwDUoFXxQp

--- a/state/model.go
+++ b/state/model.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -967,6 +968,70 @@ func (m *Model) AllUnits() ([]*Unit, error) {
 		units = append(units, newUnit(m.st, m.Type(), &docs[i]))
 	}
 	return units, nil
+}
+
+// ModelMetrics contains metrics to be collected and sent to
+// Charmhub via the charm revision updater for a model.
+type ModelMetrics struct {
+	ApplicationCount string
+	MachineCount     string
+	UnitCount        string
+	CloudName        string
+	CloudRegion      string
+	Provider         string
+	UUID             string
+	ControllerUUID   string
+}
+
+// Metrics returns model level metrics to be collected and sent to
+// Charmhub via the charm revision updater.
+func (m *Model) Metrics() (ModelMetrics, error) {
+	cloud, err := m.Cloud()
+	if err != nil {
+		return ModelMetrics{}, errors.Trace(err)
+	}
+
+	appCnt, err := m.applicationCount()
+	if err != nil {
+		return ModelMetrics{}, errors.Trace(err)
+	}
+	machCnt, err := m.machineCount()
+	if err != nil {
+		return ModelMetrics{}, errors.Trace(err)
+	}
+	unitCnt, err := m.unitCount()
+	if err != nil {
+		return ModelMetrics{}, errors.Trace(err)
+	}
+
+	return ModelMetrics{
+		ApplicationCount: strconv.Itoa(appCnt),
+		MachineCount:     strconv.Itoa(machCnt),
+		UnitCount:        strconv.Itoa(unitCnt),
+		CloudName:        cloud.Name,
+		CloudRegion:      m.CloudRegion(),
+		Provider:         cloud.Type,
+		UUID:             m.UUID(),
+		ControllerUUID:   m.doc.ControllerUUID,
+	}, nil
+}
+
+func (m *Model) applicationCount() (int, error) {
+	coll, closer := m.st.db().GetCollection(applicationsC)
+	defer closer()
+	return coll.Count()
+}
+
+func (m *Model) machineCount() (int, error) {
+	coll, closer := m.st.db().GetCollection(machinesC)
+	defer closer()
+	return coll.Count()
+}
+
+func (m *Model) unitCount() (int, error) {
+	coll, closer := m.st.db().GetCollection(unitsC)
+	defer closer()
+	return coll.Count()
 }
 
 // AllEndpointBindings returns all endpoint->space bindings

--- a/state/model.go
+++ b/state/model.go
@@ -1019,19 +1019,19 @@ func (m *Model) Metrics() (ModelMetrics, error) {
 func (m *Model) applicationCount() (int, error) {
 	coll, closer := m.st.db().GetCollection(applicationsC)
 	defer closer()
-	return coll.Count()
+	return coll.Find(isAliveDoc).Count()
 }
 
 func (m *Model) machineCount() (int, error) {
 	coll, closer := m.st.db().GetCollection(machinesC)
 	defer closer()
-	return coll.Count()
+	return coll.Find(isAliveDoc).Count()
 }
 
 func (m *Model) unitCount() (int, error) {
 	coll, closer := m.st.db().GetCollection(unitsC)
 	defer closer()
-	return coll.Count()
+	return coll.Find(isAliveDoc).Count()
 }
 
 // AllEndpointBindings returns all endpoint->space bindings

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -553,6 +553,37 @@ func (s *ModelSuite) TestAllUnits(c *gc.C) {
 	})
 }
 
+func (s *ModelSuite) TestMetrics(c *gc.C) {
+	wordpress := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "wordpress",
+	})
+	mysql := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "mysql",
+	})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
+
+	model, err := s.State.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtained, err := model.Metrics()
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := state.ModelMetrics{
+		ApplicationCount: "2",
+		MachineCount:     "3",
+		UnitCount:        "3",
+		CloudName:        "dummy",
+		CloudRegion:      "dummy-region",
+		Provider:         "dummy",
+		UUID:             s.Model.UUID(),
+		ControllerUUID:   s.Model.ControllerUUID(),
+	}
+
+	c.Assert(obtained, jc.DeepEquals, expected)
+}
+
 func (s *ModelSuite) TestAllEndpointBindings(c *gc.C) {
 	oneSpace := s.Factory.MakeSpace(c, &factory.SpaceParams{
 		Name: "one", ProviderID: network.Id("provider"), IsPublic: true})

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -564,6 +564,20 @@ func (s *ModelSuite) TestMetrics(c *gc.C) {
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
 	s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
 
+	// Add a machine/unit/application and destroy it, to
+	// ensure we're only counting entities that are alive.
+	m := s.Factory.MakeMachine(c, &factory.MachineParams{})
+	err := m.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	one := s.Factory.MakeApplication(c, &factory.ApplicationParams{
+		Name: "one",
+	})
+	u := s.Factory.MakeUnit(c, &factory.UnitParams{Application: mysql})
+	err = one.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/state.go
+++ b/state/state.go
@@ -2270,6 +2270,25 @@ func (st *State) AllRelations() (relations []*Relation, err error) {
 	return
 }
 
+// AliveRelationKeys returns the relation keys of all live relations in
+// the model.  Used in charmhub metrics collection.
+func (st *State) AliveRelationKeys() []string {
+	relationsCollection, closer := st.db().GetCollection(relationsC)
+	defer closer()
+	var doc struct {
+		Key string `bson:"key"`
+	}
+
+	var keys []string
+	iter := relationsCollection.Find(isAliveDoc).Iter()
+	defer func() { _ = iter.Close() }()
+	for iter.Next(&doc) {
+		key := doc.Key
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 // Report conforms to the Dependency Engine Report() interface, giving an opportunity to introspect
 // what is going on at runtime.
 func (st *State) Report() map[string]interface{} {


### PR DESCRIPTION
Back port of PRs related to charmhub metrics work.

- #13338 
  - commit fc7fa2577f575b3a4225f14a057a2dd4c4996507 did not cherry-pick cleaning, please review in detail.
- #13355 
- #13367 
  - commit a6fdf3f57144e7e52d2c9d0a1fc7b2a6017041cc did not cherry-pick cleaning, please review in detail.
  - commit a745b07decca7bd0bb2f3bfa1ea46144d466841e did not cherry-pick cleaning, please review in detail.
- #13379 
  - commit f7fbd430155608b4f6121d30fec73d6f0d416ebb skipped, doesn't apply to 2.9
  - commit 7e919369da2496891ee44b6d098fa1367277893d did not cherry-pick cleaning, please review in detail.


## QA steps

Test with steps from PRs above.  Test upgrade from 2.9.15, for addition of new config: disable-telemetry.

