### PR TITLE
Fix tool downloads for IAAS hosted model on CAAS

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -677,6 +677,7 @@ func configDirs() []string {
 	dirs = append(dirs, filepath.Join(utils.Home(), ".config", "lxc"))
 	if runtime.GOOS == "linux" {
 		dirs = append(dirs, filepath.Join(utils.Home(), "snap", "lxd", "current", ".config", "lxc"))
+		dirs = append(dirs, filepath.Join(utils.Home(), "snap", "lxd", "common", "config"))
 	}
 	return dirs
 }


### PR DESCRIPTION
- Fix tool downloads for IAAS hosted model on CAAS
- Fixes snap LXD config path

## QA steps

- Bootstrap microk8s
- `lxc remote add lxdcloud my.ip.add.ress`
- `juju autoload-credentials`
- `juju add-model lxdcloud lxdcloud`
- `juju deploy apache2` (might need a custom simplestream or manually edit version/version.go to a previous version)
- Machine should start and charm should become ready

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1943265
