### PR TITLE
Backport mongo 4.4 fixes

### DIFF
--- a/state/database.go
+++ b/state/database.go
@@ -225,6 +225,9 @@ func createCollection(raw *mgo.Collection, spec *mgo.CollectionInfo) error {
 	if err == nil || strings.HasSuffix(err.Error(), "already exists") {
 		return nil
 	}
+	if mgoAlreadyExistsErr(err) {
+		return nil
+	}
 	return err
 }
 

--- a/state/logs.go
+++ b/state/logs.go
@@ -984,6 +984,12 @@ func collStats(coll *mgo.Collection) (bson.M, error) {
 		}
 		return nil, errors.Trace(err)
 	}
+	// For mongo 4.4, if the collection exists,
+	// there will be a "capped" attribute.
+	_, ok := result["capped"]
+	if !ok {
+		return nil, errors.NotFoundf("Collection [%s.%s]", coll.Database.Name, coll.Name)
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
The following was already fixed in the develop branch. If you indirectly
run `snap install juju-db` without targeting `--channel=4.0/stable` then
you can end up having issues.

As this isn't really going to break anything in 2.9 it's worthwhile to backport.

See: https://github.com/juju/juju/pull/12595

## QA steps

```sh
$ snap install juju-db
$ go test -v ./apiserver/facades/controller/metricsmanager -check.v
```
