### PR TITLE
Make the mongod version parsing more robust

### DIFF
--- a/mongo/mongodfinder_test.go
+++ b/mongo/mongodfinder_test.go
@@ -299,7 +299,8 @@ build environment:
 `
 
 // mongodb409Version is the output of 'mongodb --version' from the 4.0/stable snap.
-const mongodb409Version = `db version v4.0.9
+const mongodb409Version = `EXTRA CONTENT
+db version v4.0.9
 git version: fc525e2d9b0e4bceff5c2201457e564362909765
 OpenSSL version: OpenSSL 1.1.0g  2 Nov 2017
 allocator: tcmalloc


### PR DESCRIPTION
On an impish host, bootstrapping to a focal lxd controller fails due to `mongod --version` having extra output

```
ubuntu@juju-22ef4c-0:~$ /snap/bin/juju-db.mongod --version
WARNING: cgroup v2 is not fully supported yet, proceeding with partial confinement
db version v4.0.9
```

This PR makes the version parsing more robust.

## QA steps

On an impish host

juju bootstrap lxd

## Bug reference

https://bugs.launchpad.net/juju/+bug/1945752
