### PR TITLE
Allow github container registry using password;

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -865,6 +865,7 @@ func validateCAASImageRepo(imageRepo string) (string, error) {
 
 	if err = r.Ping(); registryutils.IsPublicAPINotAvailableError(err) {
 		logger.Warningf("docker registry for %q requires authentication: %v", imageDetails.Repository, err)
+		logger.Warningf("upgrade controller will not work if no authentication provided!")
 	} else if err != nil {
 		return "", errors.Trace(err)
 	}


### PR DESCRIPTION
This PR allows Github Container Registry using username and password to be authenticated for

- pulling `jujud-operator`, `juju-db` and `charm-base` images from k8s controllers, application operators, and sidecar pods;
- fetching available controller versions to upgrade for `upgrade-controller` command;


Tested registries are(the rest of the registries will be implemented and tested in the following PRs):

| Registry | Public | Private |
| --- | --- | --- |
| azurecr.io | :x: | :white_check_mark: |
| docker.io | :white_check_mark: | :white_check_mark: |
| ecr | :x: | :white_check_mark: |
| gcr.io | :white_check_mark: | :white_check_mark: |
| ghcr.io | :x: | :white_check_mark: |
| registry.gitlab.com | :x: | :white_check_mark: |
| quay.io | :white_check_mark: | :white_check_mark: |

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ cat credential.json
{
    "auth": "xxx==",
    "repository": "ghcr.io/jujuqa"
}

# or 
$ cat credential.json
{
    "repository": "ghcr.io/jujuqa",
    "password": "ghp_xxxxxx"
}

$ juju bootstrap microk8s k1 --config caas-image-repo="'$(cat credential.json)'" 

```

## Documentation changes

https://discourse.charmhub.io/t/initial-private-registry-support/5079

## Bug reference


https://bugs.launchpad.net/juju/+bug/1935830
https://bugs.launchpad.net/juju/+bug/1940820
https://bugs.launchpad.net/juju/+bug/1935953