### PR TITLE
Better error message adding a k8s model and namespace exists

### DIFF
--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -220,7 +220,7 @@ func (s *BaseSuite) setupController(c *gc.C) *gomock.Controller {
 	s.mockNamespaces.EXPECT().Get(gomock.Any(), s.getNamespace(), v1.GetOptions{}).Times(2).
 		Return(nil, s.k8sNotFoundError())
 
-	return s.setupBroker(c, ctrl, coretesting.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc)
+	return s.setupBroker(c, ctrl, coretesting.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc, "")
 }
 
 func (s *BaseSuite) setupBroker(
@@ -228,6 +228,7 @@ func (s *BaseSuite) setupBroker(
 	newK8sClientFunc provider.NewK8sClientFunc,
 	newK8sRestFunc k8sspecs.NewK8sRestClientFunc,
 	randomPrefixFunc utils.RandomPrefixFunc,
+	expectErr string,
 ) *gomock.Controller {
 	s.clock = testclock.NewClock(time.Time{})
 
@@ -254,7 +255,11 @@ func (s *BaseSuite) setupBroker(
 	var err error
 	s.broker, err = provider.NewK8sBroker(controllerUUID, s.k8sRestConfig, s.cfg, s.getNamespace(), newK8sClientFunc, newK8sRestFunc,
 		watcherFn, stringsWatcherFn, randomPrefixFunc, s.clock)
-	c.Assert(err, jc.ErrorIsNil)
+	if expectErr == "" {
+		c.Assert(err, jc.ErrorIsNil)
+	} else {
+		c.Assert(err, gc.ErrorMatches, expectErr)
+	}
 	return ctrl
 }
 

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -215,6 +215,9 @@ func newK8sBroker(
 		isLegacyLabels: isLegacy,
 	}
 	if err := client.ensureNamespaceAnnotationForControllerUUID(controllerUUID, isLegacy); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errors.NewAlreadyExists(nil, fmt.Sprintf("namespace %q may already be in use", cfg.Name()))
+		}
 		return nil, errors.Trace(err)
 	}
 	return client, nil

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -820,7 +820,7 @@ func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDMigrated(
 		s.mockNamespaces.EXPECT().Update(gomock.Any(), &nsAfter, v1.UpdateOptions{}).Times(1).
 			Return(&nsAfter, nil),
 	)
-	s.setupBroker(c, ctrl, newControllerUUID, newK8sClientFunc, newK8sRestFunc, randomPrefixFunc).Finish()
+	s.setupBroker(c, ctrl, newControllerUUID, newK8sClientFunc, newK8sRestFunc, randomPrefixFunc, "").Finish()
 }
 
 func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDNotMigrated(c *gc.C) {
@@ -841,7 +841,7 @@ func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDNotMigrat
 		s.mockNamespaces.EXPECT().Get(gomock.Any(), s.getNamespace(), v1.GetOptions{}).Times(2).
 			Return(ns, nil),
 	)
-	s.setupBroker(c, ctrl, testing.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc).Finish()
+	s.setupBroker(c, ctrl, testing.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc, "").Finish()
 }
 
 func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDNameSpaceNotCreatedYet(c *gc.C) {
@@ -856,7 +856,26 @@ func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDNameSpace
 		s.mockNamespaces.EXPECT().Get(gomock.Any(), s.getNamespace(), v1.GetOptions{}).Times(2).
 			Return(nil, s.k8sNotFoundError()),
 	)
-	s.setupBroker(c, ctrl, testing.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc).Finish()
+	s.setupBroker(c, ctrl, testing.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc, "").Finish()
+}
+
+func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDNameSpaceExists(c *gc.C) {
+	ctrl := gomock.NewController(c)
+
+	newK8sClientFunc, newK8sRestFunc := s.setupK8sRestClient(c, ctrl, s.getNamespace())
+	randomPrefixFunc := func() (string, error) {
+		return "appuuid", nil
+	}
+
+	gomock.InOrder(
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), s.getNamespace(), v1.GetOptions{}).Times(2).
+			Return(&core.Namespace{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test",
+				},
+			}, nil),
+	)
+	s.setupBroker(c, ctrl, testing.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc, `namespace "test" may already be in use`).Finish()
 }
 
 func (s *K8sBrokerSuite) TestFileSetToVolumeFiles(c *gc.C) {

--- a/caas/kubernetes/provider/namespaces.go
+++ b/caas/kubernetes/provider/namespaces.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/juju/errors"
 	core "k8s.io/api/core/v1"
@@ -124,7 +125,7 @@ func (k *kubernetesClient) createNamespace(name string) error {
 
 	if err := k.ensureNamespaceAnnotations(ns); err != nil {
 		if errors.IsNotFound(err) {
-			return errors.Annotatef(err, "namespace may already be in use")
+			return errors.NewAlreadyExists(nil, fmt.Sprintf("namespace %q may already be in use", name))
 		}
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
When adding a model on k8s, the the namespace is already created by something else, print a better error message.
Some previous refactoring to handle label migration broke the error message.

## QA steps

bootstrap k8s
juju add-model default
ERROR the model cannot be created because a namespace with the proposed
model name already exists in the k8s cluster.
Please choose a different model name.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1946363
