### PR TITLE
Fix worker restarts for changed SAAS offers

### DIFF
--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -61,6 +61,9 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	s.remoteRelationsFacade = newMockRemoteRelationsFacade(s.stub)
 
 	clk := testclock.NewClock(time.Time{})
+
+	logger := loggo.GetLogger("test")
+
 	s.config = remoterelations.Config{
 		ModelUUID:       "local-model-uuid",
 		RelationsFacade: s.relationsFacade,
@@ -68,11 +71,12 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 			return s.remoteRelationsFacade, nil
 		},
 		Clock:  clk,
-		Logger: loggo.GetLogger("test"),
+		Logger: logger,
 		Runner: worker.NewRunner(worker.RunnerParams{
 			Clock:        clk,
 			IsFatal:      func(error) bool { return false },
 			RestartDelay: time.Second,
+			Logger:       logger,
 		}),
 	}
 }


### PR DESCRIPTION
When the remote-relations worker detects that a remote SAAS offer has a different ID (as when the offer is removed and re-added quickly) it kills the old worker for the offer and starts a new one in its place.

Although we `Kill` and `Wait` for the worker itself, the runner can take some time to detect this and flush it completely. If we attempt to start a new worker with the same ID before this has occurred, the new worker fails to start.

Here we ensure that when we replace the worker for a changed SAAS offer, the old worker has been discarded by the runner before we attempt to start a new one for the same ID.

## QA steps

Run `TestRemoteApplicationOfferChanged` in a long loop and ensure there are no failures.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1945999
