### PR TITLE
Fix podspec deployment/statefulset/daemonset upgrade.

### DIFF
--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -25,7 +25,7 @@ func (k *kubernetesClient) Upgrade(agentTag string, vers version.Number) error {
 		return errors.Annotate(err, "parsing agent tag to upgrade")
 	}
 
-	logger.Infof("handling upgrade request for tag %q", tag)
+	logger.Infof("handling upgrade request for tag %q to %s", tag, vers.String())
 
 	switch tag.Kind() {
 	case names.MachineTagKind:


### PR DESCRIPTION
Upgrades previously would fail with coredns charm due to malformed patching unable to resolve port list (requires uniqueness on port/name).

No changed unit tests as previous tests in operator_upgrade_test.go check side-effects.

## QA steps

- Bootstrap juju 2.8.x on microk8s `juju bootstrap microk8s`
- Deploy coredns `juju deploy --config=forward=8.8.8.8 cs:~containers/coredns-10`
- Upgrade controller to this PR.
- Upgrade model to this PR.
- Check deployment init container is updated to this version of juju/check debug-log.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/charm-coredns/+bug/1934004
