### PR TITLE
update-k8s also updates any controller proxy

### DIFF
--- a/caas/kubernetes/provider/proxy/proxier_test.go
+++ b/caas/kubernetes/provider/proxy/proxier_test.go
@@ -35,3 +35,20 @@ func (p *proxySuite) TestProxierMarshalling(c *gc.C) {
 
 	c.Assert(unmarshalledConfig, jc.DeepEquals, config)
 }
+
+func (p *proxySuite) TestSetAPIHost(c *gc.C) {
+	config := proxy.ProxierConfig{
+		APIHost: "https://localhost:1234",
+	}
+
+	proxier := proxy.NewProxier(config)
+	proxier.SetAPIHost("https://localhost:666")
+	yamlConf, err := yaml.Marshal(proxier)
+	c.Assert(err, jc.ErrorIsNil)
+
+	unmarshalledConfig := proxy.ProxierConfig{}
+	c.Assert(yaml.Unmarshal(yamlConf, &unmarshalledConfig), jc.ErrorIsNil)
+
+	config.APIHost = "https://localhost:666"
+	c.Assert(unmarshalledConfig, jc.DeepEquals, config)
+}

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -105,6 +105,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"pki",
 		"provider/lxd/lxdnames",
 		"proxy",
+		"proxy/errors",
 		"resource",
 		"rpc",
 		"rpc/jsoncodec",

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/apiserver/params"
 	jujucaas "github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/caas/kubernetes/provider/proxy"
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/caas"
@@ -348,7 +349,12 @@ func NewMockClientStore() *jujuclient.MemStore {
 		User: "foouser",
 	}
 	store.Controllers["foo"] = jujuclient.ControllerDetails{
-		APIEndpoints: []string{"0.1.2.3:1234"},
+		APIEndpoints:   []string{"0.1.2.3:1234"},
+		ControllerUUID: "uuid",
+		Cloud:          "microk8s",
+		Proxy: &jujuclient.ProxyConfWrapper{
+			Proxier: proxy.NewProxier(proxy.ProxierConfig{APIHost: "10.0.0.1"}),
+		},
 	}
 	store.Models["foo"] = &jujuclient.ControllerModels{
 		CurrentModel: "admin/bar",

--- a/cmd/juju/caas/export_test.go
+++ b/cmd/juju/caas/export_test.go
@@ -64,6 +64,7 @@ func NewUpdateCAASCommandForTest(
 			return cloud.Cloud{
 					Name:      cloudName,
 					Type:      "kubernetes",
+					Endpoint:  "http://10.1.0.0:666",
 					AuthTypes: cloud.AuthTypes{"certificate"},
 				},
 				&cloud.Credential{

--- a/cmd/juju/caas/update.go
+++ b/cmd/juju/caas/update.go
@@ -6,6 +6,7 @@ package caas
 import (
 	stdcontext "context"
 	"fmt"
+	"net/url"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
@@ -17,6 +18,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/caas/kubernetes/provider/proxy"
 	jujucloud "github.com/juju/juju/cloud"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/cloud"
@@ -201,7 +203,8 @@ func maybeBuiltInCloud(cloudName string) (jujucloud.Cloud, *jujucloud.Credential
 // Run is defined on the Command interface.
 func (c *UpdateCAASCommand) Run(ctx *cmd.Context) (err error) {
 	var newCloud *jujucloud.Cloud
-	haveLocalCloud := false
+	havePersonalCloud := false
+	haveBuiltinCloud := false
 	// First, see if we're updating a built-in cloud.
 	builtinCloud, credential, credentialName, err := c.builtInCloudsFunc(c.caasName)
 	if err != nil && !errors.IsNotFound(err) {
@@ -212,11 +215,8 @@ func (c *UpdateCAASCommand) Run(ctx *cmd.Context) (err error) {
 			ctx.Infof("%q is a built-in cloud and does not support specifying a cloud YAML file.", c.caasName)
 			return cmd.ErrSilent
 		}
-		if c.Client {
-			ctx.Infof("%q is a built-in cloud and cannot be updated on the client.", c.caasName)
-			return cmd.ErrSilent
-		}
 		newCloud = &builtinCloud
+		haveBuiltinCloud = true
 	} else if c.CloudFile != "" {
 		r := &cloud.CloudFileReader{
 			CloudMetadataStore: c.cloudMetadataStore,
@@ -236,7 +236,7 @@ func (c *UpdateCAASCommand) Run(ctx *cmd.Context) (err error) {
 			return errors.NotFoundf("cloud %s", c.caasName)
 		} else {
 			newCloud = &localCloud
-			haveLocalCloud = true
+			havePersonalCloud = true
 		}
 	}
 
@@ -273,13 +273,14 @@ func (c *UpdateCAASCommand) Run(ctx *cmd.Context) (err error) {
 		ctx.Infof(successMsg)
 	}
 	if c.Client {
-		if newCloud == nil || haveLocalCloud {
-			ctx.Infof("To update k8s cloud %q on this client, a cloud definition file is required.", c.caasName)
-			returnErr = cmd.ErrSilent
-		} else {
-			err := updateCloudOnLocal(c.cloudMetadataStore, *newCloud)
-			processErr(err, fmt.Sprintf("k8s cloud %q updated on this client using provided file.", c.caasName))
+		if !haveBuiltinCloud && !havePersonalCloud {
+			if err := updateCloudOnLocal(c.cloudMetadataStore, *newCloud); err != nil {
+				ctx.Infof("%v", err)
+				return cmd.ErrSilent
+			}
 		}
+		err = updateControllerProxyOnLocal(c.Store, *newCloud)
+		processErr(err, fmt.Sprintf("k8s cloud %q updated on this client.", c.caasName))
 	}
 	if c.ControllerName != "" {
 		if err := jujuclient.ValidateControllerName(c.ControllerName); err != nil {
@@ -320,6 +321,35 @@ func updateCloudOnLocal(cloudMetadataStore CloudMetadataStore, updatedCloud juju
 	}
 	personalClouds[updatedCloud.Name] = updatedCloud
 	return cloudMetadataStore.WritePersonalCloudMetadata(personalClouds)
+}
+
+// updateControllerProxyOnLocal ensures that any local controller proxy config
+// is updated to have the endpoint connectivity required by the updatedCloud.
+func updateControllerProxyOnLocal(store jujuclient.ControllerStore, updatedCloud jujucloud.Cloud) error {
+	all, err := store.AllControllers()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for name, details := range all {
+		if details.Cloud != updatedCloud.Name || details.Proxy == nil {
+			continue
+		}
+		k8sProxier, ok := details.Proxy.Proxier.(*proxy.Proxier)
+		if !ok {
+			continue
+		}
+		host := updatedCloud.Endpoint
+		if apiURL, err := url.Parse(updatedCloud.Endpoint); err == nil {
+			host = apiURL.Host
+		}
+		k8sProxier.SetAPIHost(host)
+		details.Proxy.Proxier = k8sProxier
+		err = store.UpdateController(name, details)
+		if err != nil {
+			return errors.Annotate(err, "saving controller details for updated k8s cluster")
+		}
+	}
+	return nil
 }
 
 func (c *UpdateCAASCommand) updateCredentialOnController(ctx *cmd.Context, apiClient UpdateCloudAPI, newCredential jujucloud.Credential, cloudName, credentialName string) error {

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -15,13 +15,16 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/apiserver/params"
 	jujucaas "github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
+	"github.com/juju/juju/caas/kubernetes/provider/proxy"
 	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/caas"
+	"github.com/juju/juju/jujuclient"
 
 	// To allow a maas cloud type to be parsed in the test data.
 	_ "github.com/juju/juju/provider/maas"
@@ -34,6 +37,7 @@ type updateCAASSuite struct {
 	fakeCloudAPI                  *fakeUpdateCloudAPI
 	fakeK8sClusterMetadataChecker *fakeK8sClusterMetadataChecker
 	cloudMetadataStore            *fakeCloudMetadataStore
+	clientStore                   *jujuclient.MemStore
 	fakeK8SConfigFunc             *clientconfig.ClientConfigFunc
 }
 
@@ -105,6 +109,7 @@ func (s *updateCAASSuite) SetUpTest(c *gc.C) {
 	s.dir = c.MkDir()
 
 	var logger loggo.Logger
+	s.clientStore = NewMockClientStore()
 	s.fakeCloudAPI = &fakeUpdateCloudAPI{
 		CallMocker: jujutesting.NewCallMocker(logger),
 	}
@@ -131,7 +136,7 @@ func (s *updateCAASSuite) SetUpTest(c *gc.C) {
 func (s *updateCAASSuite) makeCommand() cmd.Command {
 	return caas.NewUpdateCAASCommandForTest(
 		s.cloudMetadataStore,
-		NewMockClientStore(),
+		s.clientStore,
 		func() (caas.UpdateCloudAPI, error) {
 			return s.fakeCloudAPI, nil
 		},
@@ -239,17 +244,9 @@ func (s *updateCAASSuite) TestLocalOnly(c *gc.C) {
 		command := s.makeCommand()
 		ctx, err := s.runCommand(c, command, "myk8s", "-f", "mycloud.yaml", "--client")
 		c.Assert(err, jc.ErrorIsNil)
-		expected := `k8s cloud "myk8s" updated on this client using provided file.`
+		expected := `k8s cloud "myk8s" updated on this client.`
 		c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals, expected)
 	}, "myk8s", "gce/us-east1", "", "operator-sc", testData{client: true})
-}
-
-func (s *updateCAASSuite) TestCloudFileRequired(c *gc.C) {
-	command := s.makeCommand()
-	ctx, err := s.runCommand(c, command, "myk8s", "--client")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
-		`To update k8s cloud "myk8s" on this client, a cloud definition file is required.`)
 }
 
 func (s *updateCAASSuite) TestInvalidControllerCloud(c *gc.C) {
@@ -275,16 +272,23 @@ func (s *updateCAASSuite) TestControllerAndClient(c *gc.C) {
 		ctx, err := s.runCommand(c, command, "myk8s", "-f", "mycloud.yaml", "-c", "foo", "--client")
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
-			`k8s cloud "myk8s" updated on this client using provided file.k8s cloud "myk8s" updated on controller "foo".`)
+			`k8s cloud "myk8s" updated on this client.k8s cloud "myk8s" updated on controller "foo".`)
 	}, "myk8s", "gce/us-east1", "", "operator-sc", testData{client: true, controller: true})
 }
 
-func (s *updateCAASSuite) TestBuiltinLocalNotAllowed(c *gc.C) {
+func (s *updateCAASSuite) TestBuiltinLocal(c *gc.C) {
 	command := s.makeCommand()
 	ctx, err := s.runCommand(c, command, "microk8s", "--client")
-	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals,
-		`"microk8s" is a built-in cloud and cannot be updated on the client.`)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := `k8s cloud "microk8s" updated on this client.`
+	c.Assert(strings.Replace(cmdtesting.Stderr(ctx), "\n", "", -1), gc.Equals, expected)
+	ctrl, ok := s.clientStore.Controllers["foo"]
+	c.Assert(ok, jc.IsTrue)
+	p, ok := ctrl.Proxy.Proxier.(*proxy.Proxier)
+	c.Assert(ok, jc.IsTrue)
+	y, err := yaml.Marshal(p)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(strings.ReplaceAll(string(y), "\n", ""), gc.Matches, ".*api-host: 10.1.0.0:666.*")
 }
 
 func (s *updateCAASSuite) TestBuiltinWithFile(c *gc.C) {
@@ -311,6 +315,7 @@ func (s *updateCAASSuite) TestBuiltinToController(c *gc.C) {
 	s.fakeK8sClusterMetadataChecker.CheckCall(c, 0, "GetClusterMetadata")
 	expectedCloudToUpdate := cloud.Cloud{
 		Name:            "microk8s",
+		Endpoint:        "http://10.1.0.0:666",
 		HostCloudRegion: "",
 		Type:            "kubernetes",
 		Description:     "",

--- a/jujuclient/proxy.go
+++ b/jujuclient/proxy.go
@@ -16,7 +16,7 @@ const (
 )
 
 var (
-	NewProxierFactory func() (*proxy.Factory, error) = proxy.NewDefaultFactory
+	NewProxierFactory = proxy.NewDefaultFactory
 )
 
 // ProxyConfWrapper is wrapper around proxier interfaces so that they can be

--- a/proxy/errors/errors.go
+++ b/proxy/errors/errors.go
@@ -1,0 +1,36 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import (
+	"github.com/juju/errors"
+)
+
+type proxyConnectError struct {
+	error
+	proxyType string
+}
+
+// NewProxyConnectError returns a proxy connect error.
+func NewProxyConnectError(err error, proxyType string) *proxyConnectError {
+	return &proxyConnectError{error: err, proxyType: proxyType}
+}
+
+// IsProxyConnectError reports whether err
+// was created with NewProxyConnectError.
+func IsProxyConnectError(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*proxyConnectError)
+	return ok
+}
+
+// ProxyType returns the type of proxy which generated
+// the specified proxy connect error.
+func ProxyType(err error) string {
+	proxyErr, ok := errors.Cause(err).(*proxyConnectError)
+	if !ok {
+		return ""
+	}
+	return proxyErr.proxyType
+}

--- a/proxy/errors/errors_test.go
+++ b/proxy/errors/errors_test.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors_test
+
+import (
+	stderrors "errors"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/proxy/errors"
+)
+
+var _ = gc.Suite(&ErrorsSuite{})
+
+type ErrorsSuite struct {
+	testing.IsolationSuite
+}
+
+func (*ErrorsSuite) TestIsProxyConnectError(c *gc.C) {
+	c.Assert(errors.IsProxyConnectError(nil), jc.IsFalse)
+	err := stderrors.New("foo")
+	c.Assert(errors.IsProxyConnectError(err), jc.IsFalse)
+	err = errors.NewProxyConnectError(stderrors.New("foo"), "")
+	c.Assert(errors.IsProxyConnectError(err), jc.IsTrue)
+}
+
+func (*ErrorsSuite) TestProxyType(c *gc.C) {
+	err := errors.NewProxyConnectError(stderrors.New("foo"), "bar")
+	c.Assert(errors.ProxyType(err), gc.Equals, "bar")
+}

--- a/proxy/errors/package_test.go
+++ b/proxy/errors/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
When a k8s cloud endpoint changes, update-k8s is supported to be able to make the changes to any local client copy of that info. However, the recently added proxy endpoint was not updated. This PR fixes that, plus adds support for prompting the user to run update-k8s if a client connect fails and the proxy is suspected of being the cause.

There was a little bit of incorrect logic in the update-k8s command that was fixed as well, specifically around the handling of built in clouds like microk8s. The fixes made the new proxy update logic work as intended.

## QA steps

bootstrap microk8s 
manually edit the ~/.local/share/juju/controllers.yaml file to change the proxy-config api host value.

```
$ juju status
ERROR cannot connect to k8s api server; try running 'juju update-k8s --client <k8sname>'

$ juju update-k8s --client microk8s
k8s cloud "microk8s" updated on this client.

$ juju status
...
```

## Bug reference

https://bugs.launchpad.net/bugs/1946218
