### PR TITLE
Acceptance tests - move away from unsupported series

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -358,7 +358,7 @@ def raise_if_shared_machines(unit_machines):
     if not unit_machines:
         raise ValueError('Cannot share 0 machines. Empty list provided.')
     if len(unit_machines) != len(set(unit_machines)):
-        raise JujuAssertionError('Appliction units reside on the same machine')
+        raise JujuAssertionError('Application units reside on the same machine')
 
 
 def ensure_model_logs_are_migrated(source_client, dest_client, timeout=600):

--- a/acceptancetests/jujupy/workloads.py
+++ b/acceptancetests/jujupy/workloads.py
@@ -78,6 +78,7 @@ def assert_mediawiki_is_responding(client):
     if '<title>Please set name of wiki</title>' not in resp.content:
         raise AssertionError('Got unexpected mediawiki page content: {}'.format(resp.content))
 
+
 def deploy_keystone_with_db(client):
     client.deploy('cs:percona-cluster')
     client.wait_for_started()
@@ -94,6 +95,7 @@ def deploy_keystone_with_db(client):
     client.juju('expose', 'keystone')
     client.wait_for_workloads()
     client.wait_for_started()
+
 
 def assert_keystone_is_responding(client):
     log.debug('Assert keystone is responding.')
@@ -112,7 +114,7 @@ def assert_keystone_is_responding(client):
 
 
 def deploy_simple_server_to_new_model(
-        client, model_name, resource_contents=None, series='xenial'):
+        client, model_name, resource_contents=None, series='bionic'):
     # As per bug LP:1709773 deploy 2 primary apps and have a subordinate
     #  related to both
     new_model = client.add_model(client.env.clone(model_name))
@@ -137,7 +139,7 @@ def deploy_simple_server_to_new_model(
 
 
 def deploy_simple_resource_server(
-        client, resource_contents=None, series='xenial'):
+        client, resource_contents=None, series='bionic'):
     application_name = 'simple-resource-http'
     log.info('Deploying charm: {}'.format(application_name))
     charm_path = local_charm_path(
@@ -157,7 +159,7 @@ def deploy_simple_resource_server(
 
     client.wait_for_started()
     client.wait_for_workloads()
-    client.juju('expose', (application_name))
+    client.juju('expose', application_name)
     return application_name
 
 

--- a/acceptancetests/repository/charms/dummy-source/metadata.yaml
+++ b/acceptancetests/repository/charms/dummy-source/metadata.yaml
@@ -9,10 +9,7 @@ requires:
 categories:
   - misc
 series:
-  - trusty
   - xenial
-  - artful
   - bionic
-  - eoan
   - focal
 

--- a/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
+++ b/acceptancetests/repository/charms/simple-resource-http/metadata.yaml
@@ -9,11 +9,8 @@ provides:
 categories:
   - misc
 series:
-  - trusty
   - xenial
-  - artful
   - bionic
-  - eoan
   - focal
 
 resources:


### PR DESCRIPTION
Ensures that we default to Bionic (updated from Xenial) when workload deployment is not supplied a series.

Unsupported series are removed from the metadata of local test charms.

## QA steps

Run the model migration test:
`./assess --juju ~/go/bin/juju --logging-config '<root>=DEBUG' --substrate aws model_migration`

## Documentation changes

None.

## Bug reference

N/A
