### PR TITLE
Be smarter about container NIC MTUs when using the Fan

### DIFF
--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -105,11 +105,11 @@ func (m *containerManager) CreateContainer(
 	cons constraints.Value,
 	series string,
 	networkConfig *container.NetworkConfig,
-	storageConfig *container.StorageConfig,
+	_ *container.StorageConfig,
 	callback environs.StatusCallbackFunc,
 ) (instances.Instance, *instance.HardwareCharacteristics, error) {
 	_ = callback(status.Provisioning, "Creating container spec", nil)
-	spec, err := m.getContainerSpec(instanceConfig, cons, series, networkConfig, storageConfig, callback)
+	spec, err := m.getContainerSpec(instanceConfig, cons, series, networkConfig, callback)
 	if err != nil {
 		_ = callback(status.ProvisioningError, fmt.Sprintf("Creating container spec: %v", err), nil)
 		return nil, nil, errors.Trace(err)
@@ -154,7 +154,6 @@ func (m *containerManager) getContainerSpec(
 	cons constraints.Value,
 	series string,
 	networkConfig *container.NetworkConfig,
-	storageConfig *container.StorageConfig,
 	callback environs.StatusCallbackFunc,
 ) (ContainerSpec, error) {
 	imageSources, err := m.getImageSources()

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -29,6 +29,10 @@ var skippedDeviceNames = set.NewStrings(
 	network.DefaultKVMBridge,
 )
 
+// namedNICsBySpace is a type alias for a map of link-layer devices
+// keyed by name, keyed in turn by the space they are in.
+type namedNICsBySpace = map[string]map[string]LinkLayerDevice
+
 // BridgePolicy defines functionality that helps us create and define bridges
 // for guests inside a host machine, along with the creation of network
 // devices on those bridges for the containers to use.
@@ -243,7 +247,7 @@ func linkLayerDevicesForSpaces(host Machine, spaces corenetwork.SpaceInfos) (map
 		return nil, errors.Trace(err)
 	}
 	processedDeviceNames := set.NewStrings()
-	spaceToDevices := make(map[string]map[string]LinkLayerDevice, 0)
+	spaceToDevices := make(namedNICsBySpace, 0)
 
 	// First pass, iterate the addresses, lookup the associated spaces, and
 	// gather the devices.
@@ -315,7 +319,7 @@ func linkLayerDevicesByName(host Machine) (map[string]LinkLayerDevice, error) {
 	return deviceByName, nil
 }
 
-func includeDevice(spaceToDevices map[string]map[string]LinkLayerDevice, spaceID string, device LinkLayerDevice) map[string]map[string]LinkLayerDevice {
+func includeDevice(spaceToDevices namedNICsBySpace, spaceID string, device LinkLayerDevice) namedNICsBySpace {
 	spaceInfo, ok := spaceToDevices[spaceID]
 	if !ok {
 		spaceInfo = make(map[string]LinkLayerDevice)

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -639,6 +639,7 @@ func (s *linkLayerDevicesStateSuite) TestEthernetDeviceForBridge(c *gc.C) {
 	c.Check(child.ParentInterfaceName, gc.Equals, "br0")
 	c.Check(child.PrimaryAddress().CIDR, gc.Equals, "10.0.0.0/24")
 	c.Check(child.ProviderSubnetId, gc.Equals, corenetwork.Id("ps-01"))
+	c.Check(child.MTU, gc.Equals, int(dev.MTU()))
 
 	child, err = dev.EthernetDeviceForBridge("eth0", false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -649,6 +650,50 @@ func (s *linkLayerDevicesStateSuite) TestEthernetDeviceForBridge(c *gc.C) {
 	dev = s.addNamedDevice(c, "bond0")
 	_, err = dev.EthernetDeviceForBridge("eth0", false)
 	c.Assert(err, gc.NotNil)
+}
+
+func (s *linkLayerDevicesStateSuite) TestEthernetDeviceForBridgeFanMTU(c *gc.C) {
+	_, err := s.State.AddSubnet(corenetwork.SubnetInfo{
+		CIDR:       "10.0.0.0/24",
+		ProviderId: "ps-01",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.AddSubnet(corenetwork.SubnetInfo{
+		CIDR: "250.0.0.0/8",
+		FanInfo: &corenetwork.FanCIDRs{
+			FanOverlay:       "240.0.0.0/4",
+			FanLocalUnderlay: "10.0.0.0/24",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	fanBridgeName := "fan-250"
+
+	// Both of these devices are created with MTU=1450.
+	s.createNICWithIP(c, s.machine, "enp5s0", "10.0.0.6/24")
+	s.createBridgeWithIP(c, s.machine, fanBridgeName, "250.0.0.9/8")
+
+	// Create the VXLAN device used by the Fan.
+	err = s.machine.SetLinkLayerDevices(
+		state.LinkLayerDeviceArgs{
+			Name:       "ftun0",
+			Type:       corenetwork.VXLANDevice,
+			ParentName: fanBridgeName,
+			IsUp:       true,
+			MTU:        1400,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	dev, err := s.machine.LinkLayerDevice("fan-250")
+	c.Assert(err, jc.ErrorIsNil)
+
+	child, err := dev.EthernetDeviceForBridge("eth0", true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// A child device of the fan should get an MTU equal to the VXLAN.
+	c.Assert(child.MTU, gc.Equals, 1400)
 }
 
 func (s *linkLayerDevicesStateSuite) TestAddAddressOps(c *gc.C) {
@@ -729,6 +774,7 @@ func (s *linkLayerDevicesStateSuite) createNICWithIP(c *gc.C, machine *state.Mac
 			Type:       corenetwork.EthernetDevice,
 			ParentName: "",
 			IsUp:       true,
+			MTU:        1450,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -769,6 +815,7 @@ func (s *linkLayerDevicesStateSuite) createBridgeWithIP(c *gc.C, machine *state.
 			Type:       corenetwork.BridgeDevice,
 			ParentName: "",
 			IsUp:       true,
+			MTU:        1450,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
The linked bug describes an OpenStack issue when using container Fan networking.

Neutron/OVN by default will create a tenant/overlay network with MTU=1442 (1500-58), but the MTU of Fan devices is statically set to a higher value - 1480 or (usually) 1450, which appears to be a lazy lowering from the standard 1500.

In turn containers do not have network connectivity, because their devices get the same MTU as the parent bridge.

This change ensures that when creating container NICs for Fan bridges, we use the MTU from the VXLAN device that is a child of the bridge. This has the MTU correctly offset from the underlay network.

See the commit list for other sundry tidy-ups.

## QA steps
- `juju bootstrap canonistack canonistack-test --no-gui --debug --config network=net_instances --build-agent`
- `juju model-config -m controller logging-config="<root>=info;juju.network.containerizer=trace"`.
- `juju add-machine 0`.
- Connect to mongo and run `db.linklayerdevices.find().pretty()`.
- In the output you will observe regular NICs with MTU=1458, Fan bridges with MTU=1450, and VXLAN NICs with MTU=1408.
- `juju add-machine lxd:0`
- Logs will show container device configured with MTU from the VXLAN device, even though the parent is the Fan bridge:
```
machine-0: 20:04:23 DEBUG juju.network.containerizer prepared container "0/lxd/0" network config: [{DeviceIndex:0 MACAddress:00:16:3e:8b:25:54 ProviderId: ProviderSubnetId: ProviderNetworkId: ProviderSpaceId: ProviderVLANId: ProviderAddressId: AvailabilityZones:[] VLANTag:0 InterfaceName:eth0 ParentInterfaceName:fan-252 InterfaceType:ethernet Disabled:false NoAutoStart:false ConfigType:dhcp Addresses:[] ShadowAddresses:[] DNSServers:[] MTU:1408 DNSSearchDomains:[] GatewayAddress: Routes:[] IsDefaultGateway:false VirtualPortType: Origin:}]
```
- `juju ssh 0`.
- `sudo lxc exec juju-<model ID>-0-lxd-0 -- ip a`
- Output should include eth0 with an MTU of 1408.
```
...
6: eth0@if7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1408 qdisc noqueue state UP group default qlen 1000
    link/ether 00:16:3e:8b:25:54 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 252.5.250.91/8 brd 252.255.255.255 scope global dynamic eth0
       valid_lft 3441sec preferred_lft 3441sec
    inet6 fe80::216:3eff:fe8b:2554/64 scope link
       valid_lft forever preferred_lft forever
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/ubuntu/+source/ubuntu-fan/+bug/1936842
