### PR TITLE
Fix typo on caas cmd usage details

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -113,7 +113,7 @@ Examples:
     juju add-k8s myk8scloud --cloud cloudNameOrCloudType --region=someregion
     juju add-k8s myk8scloud --cloud cloudNameOrCloudType --storage mystorageclass
 
-    KUBECONFIG=path-to-kubuconfig-file juju add-k8s myk8scloud --cluster-name=my_cluster_name
+    KUBECONFIG=path-to-kubeconfig-file juju add-k8s myk8scloud --cluster-name=my_cluster_name
     kubectl config view --raw | juju add-k8s myk8scloud --cluster-name=my_cluster_name
 
     juju add-k8s --gke myk8scloud


### PR DESCRIPTION
Rename `path-to-kubuconfig-file` to `path-to-kubeconfig-file` on the command line example for caas.


