### PR TITLE
Update to latest Pebble

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.9.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20211004014426-2fbdfdef40c7
+	github.com/canonical/pebble v0.0.0-20211017212823-71d8e376806f
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.0.0-20200316104309-cb8b64719ae3
 	github.com/dnaeon/go-vcr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20211004014426-2fbdfdef40c7 h1:+ZeDZM45AI/MSQF7W4DFL77SdTKtsc4Woelr0U/atX8=
-github.com/canonical/pebble v0.0.0-20211004014426-2fbdfdef40c7/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
+github.com/canonical/pebble v0.0.0-20211017212823-71d8e376806f h1:5SP7EqeBNxfAINGbYxIo5hHerEX1h7gw21Z2xbupx18=
+github.com/canonical/pebble v0.0.0-20211017212823-71d8e376806f/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/worker/uniter/pebblepoller_test.go
+++ b/worker/uniter/pebblepoller_test.go
@@ -55,10 +55,10 @@ func (s *pebblePollerSuite) TestStart(c *gc.C) {
 			err: errors.Errorf("not yet workin"),
 		},
 	}
-	newClient := func(cfg *pebbleclient.Config) uniter.PebbleClient {
+	newClient := func(cfg *pebbleclient.Config) (uniter.PebbleClient, error) {
 		c.Assert(cfg.Socket, gc.Matches, pebbleSocketPathRegexpString)
 		res := pebbleSocketPathRegexp.FindAllStringSubmatch(cfg.Socket, 1)
-		return clients[res[0][1]]
+		return clients[res[0][1]], nil
 	}
 	clock := testclock.NewClock(time.Time{})
 	containerNames := []string{

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -561,16 +561,16 @@ func (s startUniter) step(c *gc.C, ctx *testContext) {
 		RebootQuerier:  s.rebootQuerier,
 		Logger:         loggo.GetLogger("test"),
 		ContainerNames: ctx.containerNames,
-		NewPebbleClient: func(cfg *pebbleclient.Config) uniter.PebbleClient {
+		NewPebbleClient: func(cfg *pebbleclient.Config) (uniter.PebbleClient, error) {
 			res := pebbleSocketPathRegexp.FindAllStringSubmatch(cfg.Socket, 1)
 			if res == nil {
-				return &fakePebbleClient{err: errors.NotFoundf("container not found")}
+				return nil, errors.NotFoundf("container")
 			}
 			client, ok := ctx.pebbleClients[res[0][1]]
 			if !ok {
-				return &fakePebbleClient{err: errors.NotFoundf("container not found")}
+				return nil, errors.NotFoundf("container")
 			}
-			return client
+			return client, nil
 		},
 		SecretRotateWatcherFunc: func(u names.UnitTag, secretsChanged chan []string) (worker.Worker, error) {
 			c.Assert(u.String(), gc.Equals, s.unitTag)


### PR DESCRIPTION
This includes https://github.com/canonical/pebble/pull/73, Pebble exec client tests and the client.New() signature change to return an error.
