### PR TITLE
Fix juju_machine_lock introspection

### DIFF
--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -114,9 +114,7 @@ juju_statetracker_report () {
 }
 
 juju_machine_lock () {
-  for agent in $(ls /var/lib/juju/agents); do
-    juju_agent machinelock $agent 2> /dev/null
-  done
+  juju_agent machinelock 2> /dev/null
 }
 
 juju_unit_status () {


### PR DESCRIPTION
Since the unit and machine agents got combined, the juju_machine_lock introspection broke.

## QA steps

ssh to a juju machine
```
$ juju_machine_lock 
machine-0:
  holder: none
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1946622
