### PR TITLE
Fix intial trust and scale for sidecar deploy.

### DIFF
--- a/api/caasapplicationprovisioner/client.go
+++ b/api/caasapplicationprovisioner/client.go
@@ -123,6 +123,8 @@ type ProvisioningInfo struct {
 	ImageRepo            docker.ImageRepoDetails
 	CharmModifiedVersion int
 	CharmURL             *charm.URL
+	Trust                bool
+	Scale                int
 }
 
 // ProvisioningInfo returns the info needed to provision an operator for an application.
@@ -168,6 +170,8 @@ func (c *Client) ProvisioningInfo(applicationName string) (ProvisioningInfo, err
 		Series:               r.Series,
 		ImageRepo:            imageRepo,
 		CharmModifiedVersion: r.CharmModifiedVersion,
+		Trust:                r.Trust,
+		Scale:                r.Scale,
 	}
 
 	for _, fs := range r.Filesystems {

--- a/api/caasapplicationprovisioner/client_test.go
+++ b/api/caasapplicationprovisioner/client_test.go
@@ -155,6 +155,8 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 				ImageRepo:            params.DockerImageInfo{Repository: "jujuqa"},
 				CharmModifiedVersion: 1,
 				CharmURL:             "cs:~test/charm-1",
+				Trust:                true,
+				Scale:                3,
 			}}}
 		return nil
 	})
@@ -169,6 +171,8 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 		ImageRepo:            docker.ImageRepoDetails{Repository: "jujuqa"},
 		CharmModifiedVersion: 1,
 		CharmURL:             &charm.URL{Schema: "cs", User: "test", Name: "charm", Revision: 1},
+		Trust:                true,
+		Scale:                3,
 	})
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/caasapplicationprovisioner"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/resources"
@@ -191,6 +192,8 @@ type mockApplication struct {
 	storageConstraints   map[string]state.StorageConstraints
 	deviceConstraints    map[string]state.DeviceConstraints
 	charmModifiedVersion int
+	config               application.ConfigAttributes
+	scale                int
 }
 
 func (a *mockApplication) Tag() names.Tag {
@@ -289,6 +292,16 @@ func (a *mockApplication) CharmModifiedVersion() int {
 func (a *mockApplication) CharmURL() (curl *charm.URL, force bool) {
 	a.MethodCall(a, "CharmURL")
 	return a.charm.URL(), false
+}
+
+func (a *mockApplication) ApplicationConfig() (application.ConfigAttributes, error) {
+	a.MethodCall(a, "ApplicationConfig")
+	return a.config, a.NextErr()
+}
+
+func (a *mockApplication) GetScale() int {
+	a.MethodCall(a, "GetScale")
+	return a.scale
 }
 
 type mockCharm struct {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/caas"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
@@ -258,7 +259,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 	}
 	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, vers.ToPatch(), version.OfficialBuild)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "getting juju oci image path")
 	}
 	imageRepo := cfg.CAASImageRepo()
 	imageInfo := params.DockerImageInfo{
@@ -292,6 +293,10 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 	}
 	caCert, _ := cfg.CACert()
 	charmURL, _ := app.CharmURL()
+	appConfig, err := app.ApplicationConfig()
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting application config")
+	}
 	return &params.CAASApplicationProvisioningInfo{
 		ImagePath:            imagePath,
 		Version:              vers,
@@ -305,6 +310,8 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		ImageRepo:            imageInfo,
 		CharmModifiedVersion: app.CharmModifiedVersion(),
 		CharmURL:             charmURL.String(),
+		Trust:                appConfig.GetBool(application.TrustConfigOptionName, false),
+		Scale:                app.GetScale(),
 	}, nil
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/caasapplicationprovisioner"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/docker"
@@ -96,6 +97,10 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 			},
 		},
 		charmModifiedVersion: 10,
+		scale:                3,
+		config: application.ConfigAttributes{
+			"trust": true,
+		},
 	}
 	result, err := s.api.ProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -113,6 +118,8 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 			},
 			CharmURL:             "cs:gitlab",
 			CharmModifiedVersion: 10,
+			Scale:                3,
+			Trust:                true,
 		}},
 	})
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -59,6 +60,8 @@ type Application interface {
 	SetStatus(statusInfo status.StatusInfo) error
 	CharmModifiedVersion() int
 	CharmURL() (curl *charm.URL, force bool)
+	ApplicationConfig() (application.ConfigAttributes, error)
+	GetScale() int
 }
 
 type Charm interface {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -7019,6 +7019,9 @@
                         "image-repo": {
                             "$ref": "#/definitions/DockerImageInfo"
                         },
+                        "scale": {
+                            "type": "integer"
+                        },
                         "series": {
                             "type": "string"
                         },
@@ -7029,6 +7032,9 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "trust": {
+                            "type": "boolean"
                         },
                         "version": {
                             "$ref": "#/definitions/Number"

--- a/apiserver/params/caas.go
+++ b/apiserver/params/caas.go
@@ -56,6 +56,8 @@ type CAASApplicationProvisioningInfo struct {
 	ImageRepo            DockerImageInfo              `json:"image-repo,omitempty"`
 	CharmModifiedVersion int                          `json:"charm-modified-version,omitempty"`
 	CharmURL             string                       `json:"charm-url,omitempty"`
+	Trust                bool                         `json:"trust,omitempty"`
+	Scale                int                          `json:"scale,omitempty"`
 	Error                *Error                       `json:"error,omitempty"`
 }
 

--- a/caas/application.go
+++ b/caas/application.go
@@ -118,6 +118,13 @@ type ApplicationConfig struct {
 
 	// Devices is a set of parameters for Devices that is required.
 	Devices []devices.KubernetesDeviceParams
+
+	// Trust is set to true to give the application cloud access.
+	Trust bool
+
+	// InitialScale is used to provide the initial desired scale of the application.
+	// After the application is created, InitialScale has no effect.
+	InitialScale int
 }
 
 // ContainerConfig describes a container that is deployed alonside the uniter/charm container.

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -192,7 +192,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 				Labels:      a.labels(),
 				Annotations: a.annotations(config),
 			},
-			Rules: defaultApplicationNamespaceRules,
+			Rules: a.roleRules(config.Trust),
 		},
 	}
 	applier.Apply(&role)
@@ -227,7 +227,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 				Labels:      a.labels(),
 				Annotations: a.annotations(config),
 			},
-			Rules: defaultApplicationClusterRules,
+			Rules: a.clusterRoleRules(config.Trust),
 		},
 	}
 	applier.Apply(&clusterRole)
@@ -348,7 +348,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 		}
 		var numPods *int32
 		if !exists {
-			numPods = pointer.Int32Ptr(1)
+			numPods = pointer.Int32Ptr(int32(config.InitialScale))
 		}
 		statefulset := resources.StatefulSet{
 			StatefulSet: appsv1.StatefulSet{
@@ -410,7 +410,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 		}
 		var numPods *int32
 		if !exists {
-			numPods = pointer.Int32Ptr(1)
+			numPods = pointer.Int32Ptr(int32(config.InitialScale))
 		}
 		// Config storage to update the podspec with storage info.
 		if err = configureStorage(storageUniqueID, handlePVCForStatelessResource); err != nil {

--- a/caas/kubernetes/provider/application/scale_test.go
+++ b/caas/kubernetes/provider/application/scale_test.go
@@ -17,7 +17,7 @@ import (
 
 func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
 	ss, err := s.client.AppsV1().StatefulSets(s.namespace).Get(
@@ -31,7 +31,7 @@ func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateless, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
 	dep, err := s.client.AppsV1().Deployments(s.namespace).Get(
@@ -45,7 +45,7 @@ func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationScaleStatefulLessThanZero(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
 
 	c.Assert(errors.IsNotValid(app.Scale(-1)), jc.IsTrue)
 }

--- a/caas/kubernetes/provider/application/trust_test.go
+++ b/caas/kubernetes/provider/application/trust_test.go
@@ -80,13 +80,7 @@ func (s *applicationSuite) TestTrustClusterRoleNotFound(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	role, err := s.client.RbacV1().Roles(s.namespace).Get(context.Background(), s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(role.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{"*"},
-			Resources: []string{"*"},
-			Verbs:     []string{"*"},
-		},
-	})
+	c.Assert(role.Rules, jc.DeepEquals, []rbacv1.PolicyRule(nil))
 	_, err = s.client.RbacV1().ClusterRoles().Get(context.Background(), s.namespace+"-"+s.appName, metav1.GetOptions{})
 	c.Assert(err, jc.Satisfies, k8serrors.IsNotFound)
 }

--- a/caas/kubernetes/provider/resources/clusterrole.go
+++ b/caas/kubernetes/provider/resources/clusterrole.go
@@ -61,6 +61,9 @@ func (r *ClusterRole) Apply(ctx context.Context, client kubernetes.Interface) er
 			FieldManager: JujuFieldManager,
 		})
 	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "cluster role %q", r.Name)
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/resources/clusterrolebinding.go
+++ b/caas/kubernetes/provider/resources/clusterrolebinding.go
@@ -44,8 +44,8 @@ func (rb *ClusterRoleBinding) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *ClusterRoleBinding) ID() ID {
-	return ID{"ClusterRoleBinding", r.Name, r.Namespace}
+func (rb *ClusterRoleBinding) ID() ID {
+	return ID{"ClusterRoleBinding", rb.Name, rb.Namespace}
 }
 
 // Apply patches the resource change.
@@ -62,6 +62,9 @@ func (rb *ClusterRoleBinding) Apply(ctx context.Context, client kubernetes.Inter
 		res, err = api.Create(ctx, &rb.ClusterRoleBinding, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "cluster role binding %q", rb.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/daemonset.go
+++ b/caas/kubernetes/provider/resources/daemonset.go
@@ -43,8 +43,8 @@ func (ds *DaemonSet) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *DaemonSet) ID() ID {
-	return ID{"DaemonSet", r.Name, r.Namespace}
+func (ds *DaemonSet) ID() ID {
+	return ID{"DaemonSet", ds.Name, ds.Namespace}
 }
 
 // Apply patches the resource change.
@@ -61,6 +61,9 @@ func (ds *DaemonSet) Apply(ctx context.Context, client kubernetes.Interface) err
 		res, err = api.Create(ctx, &ds.DaemonSet, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "daemon set %q", ds.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/deployment.go
+++ b/caas/kubernetes/provider/resources/deployment.go
@@ -43,8 +43,8 @@ func (d *Deployment) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *Deployment) ID() ID {
-	return ID{"Deployment", r.Name, r.Namespace}
+func (d *Deployment) ID() ID {
+	return ID{"Deployment", d.Name, d.Namespace}
 }
 
 // Apply patches the resource change.
@@ -61,6 +61,9 @@ func (d *Deployment) Apply(ctx context.Context, client kubernetes.Interface) err
 		res, err = api.Create(ctx, &d.Deployment, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "deployment %q", d.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/interface.go
+++ b/caas/kubernetes/provider/resources/interface.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/core/status"
@@ -22,6 +23,7 @@ const (
 
 // Resource defines methods for manipulating a k8s resource.
 type Resource interface {
+	metav1.ObjectMetaAccessor
 	// Clone returns a copy of the resource.
 	Clone() Resource
 	// Apply patches the resource change.

--- a/caas/kubernetes/provider/resources/mocks/resources_mock.go
+++ b/caas/kubernetes/provider/resources/mocks/resources_mock.go
@@ -13,6 +13,7 @@ import (
 	resources "github.com/juju/juju/caas/kubernetes/provider/resources"
 	status "github.com/juju/juju/core/status"
 	v1 "k8s.io/api/core/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubernetes "k8s.io/client-go/kubernetes"
 )
 
@@ -125,6 +126,20 @@ func (m *MockResource) Get(arg0 context.Context, arg1 kubernetes.Interface) erro
 func (mr *MockResourceMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockResource)(nil).Get), arg0, arg1)
+}
+
+// GetObjectMeta mocks base method.
+func (m *MockResource) GetObjectMeta() v10.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetObjectMeta")
+	ret0, _ := ret[0].(v10.Object)
+	return ret0
+}
+
+// GetObjectMeta indicates an expected call of GetObjectMeta.
+func (mr *MockResourceMockRecorder) GetObjectMeta() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectMeta", reflect.TypeOf((*MockResource)(nil).GetObjectMeta))
 }
 
 // ID mocks base method.

--- a/caas/kubernetes/provider/resources/persistentvolume.go
+++ b/caas/kubernetes/provider/resources/persistentvolume.go
@@ -41,8 +41,8 @@ func (pv *PersistentVolume) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *PersistentVolume) ID() ID {
-	return ID{"PersistentVolume", r.Name, r.Namespace}
+func (pv *PersistentVolume) ID() ID {
+	return ID{"PersistentVolume", pv.Name, pv.Namespace}
 }
 
 // Apply patches the resource change.
@@ -59,6 +59,9 @@ func (pv *PersistentVolume) Apply(ctx context.Context, client kubernetes.Interfa
 		res, err = api.Create(ctx, &pv.PersistentVolume, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "persistent volume %q", pv.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/persistentvolumeclaim.go
+++ b/caas/kubernetes/provider/resources/persistentvolumeclaim.go
@@ -62,8 +62,8 @@ func (pvc *PersistentVolumeClaim) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *PersistentVolumeClaim) ID() ID {
-	return ID{"PersistentVolumeClaim", r.Name, r.Namespace}
+func (pvc *PersistentVolumeClaim) ID() ID {
+	return ID{"PersistentVolumeClaim", pvc.Name, pvc.Namespace}
 }
 
 // Apply patches the resource change.
@@ -80,6 +80,9 @@ func (pvc *PersistentVolumeClaim) Apply(ctx context.Context, client kubernetes.I
 		res, err = api.Create(ctx, &pvc.PersistentVolumeClaim, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "persistent volume claim %q", pvc.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/pod.go
+++ b/caas/kubernetes/provider/resources/pod.go
@@ -62,8 +62,8 @@ func (p *Pod) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *Pod) ID() ID {
-	return ID{"Pod", r.Name, r.Namespace}
+func (p *Pod) ID() ID {
+	return ID{"Pod", p.Name, p.Namespace}
 }
 
 // Apply patches the resource change.
@@ -80,6 +80,9 @@ func (p *Pod) Apply(ctx context.Context, client kubernetes.Interface) error {
 		res, err = api.Create(ctx, &p.Pod, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "pod %q", p.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/role.go
+++ b/caas/kubernetes/provider/resources/role.go
@@ -62,6 +62,9 @@ func (r *Role) Apply(ctx context.Context, client kubernetes.Interface) error {
 			FieldManager: JujuFieldManager,
 		})
 	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "role %q", r.Name)
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/resources/rolebinding.go
+++ b/caas/kubernetes/provider/resources/rolebinding.go
@@ -43,8 +43,8 @@ func (rb *RoleBinding) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *RoleBinding) ID() ID {
-	return ID{"RoleBinding", r.Name, r.Namespace}
+func (rb *RoleBinding) ID() ID {
+	return ID{"RoleBinding", rb.Name, rb.Namespace}
 }
 
 // Apply patches the resource change.
@@ -61,6 +61,9 @@ func (rb *RoleBinding) Apply(ctx context.Context, client kubernetes.Interface) e
 		res, err = api.Create(ctx, &rb.RoleBinding, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "role binding %q", rb.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/secret.go
+++ b/caas/kubernetes/provider/resources/secret.go
@@ -62,8 +62,8 @@ func (s *Secret) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *Secret) ID() ID {
-	return ID{"Secret", r.Name, r.Namespace}
+func (s *Secret) ID() ID {
+	return ID{"Secret", s.Name, s.Namespace}
 }
 
 // Apply patches the resource change.
@@ -80,6 +80,9 @@ func (s *Secret) Apply(ctx context.Context, client kubernetes.Interface) error {
 		res, err = api.Create(ctx, &s.Secret, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "secret %q", s.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/service.go
+++ b/caas/kubernetes/provider/resources/service.go
@@ -42,8 +42,8 @@ func (s *Service) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *Service) ID() ID {
-	return ID{"Service", r.Name, r.Namespace}
+func (s *Service) ID() ID {
+	return ID{"Service", s.Name, s.Namespace}
 }
 
 // Apply patches the resource change.
@@ -60,6 +60,9 @@ func (s *Service) Apply(ctx context.Context, client kubernetes.Interface) error 
 		res, err = api.Create(ctx, &s.Service, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "service %q", s.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/serviceaccount.go
+++ b/caas/kubernetes/provider/resources/serviceaccount.go
@@ -42,8 +42,8 @@ func (sa *ServiceAccount) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *ServiceAccount) ID() ID {
-	return ID{"ServiceAccount", r.Name, r.Namespace}
+func (sa *ServiceAccount) ID() ID {
+	return ID{"ServiceAccount", sa.Name, sa.Namespace}
 }
 
 // Apply patches the resource change.
@@ -60,6 +60,9 @@ func (sa *ServiceAccount) Apply(ctx context.Context, client kubernetes.Interface
 		res, err = api.Create(ctx, &sa.ServiceAccount, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "service account %q", sa.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/statefulset.go
+++ b/caas/kubernetes/provider/resources/statefulset.go
@@ -43,8 +43,8 @@ func (ss *StatefulSet) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *StatefulSet) ID() ID {
-	return ID{"StatefulSet", r.Name, r.Namespace}
+func (ss *StatefulSet) ID() ID {
+	return ID{"StatefulSet", ss.Name, ss.Namespace}
 }
 
 // Apply patches the resource change.
@@ -61,6 +61,9 @@ func (ss *StatefulSet) Apply(ctx context.Context, client kubernetes.Interface) e
 		res, err = api.Create(ctx, &ss.StatefulSet, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "stateful set %q", ss.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/resources/storageclass.go
+++ b/caas/kubernetes/provider/resources/storageclass.go
@@ -62,8 +62,8 @@ func (sc *StorageClass) Clone() Resource {
 }
 
 // ID returns a comparable ID for the Resource
-func (r *StorageClass) ID() ID {
-	return ID{"StorageClass", r.Name, r.Namespace}
+func (sc *StorageClass) ID() ID {
+	return ID{"StorageClass", sc.Name, sc.Namespace}
 }
 
 // Apply patches the resource change.
@@ -80,6 +80,9 @@ func (sc *StorageClass) Apply(ctx context.Context, client kubernetes.Interface) 
 		res, err = api.Create(ctx, &sc.StorageClass, metav1.CreateOptions{
 			FieldManager: JujuFieldManager,
 		})
+	}
+	if k8serrors.IsConflict(err) {
+		return errors.Annotatef(errConflict, "storage class %q", sc.Name)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -720,6 +720,8 @@ func (a *appWorker) alive(app caas.Application) error {
 		CharmBaseImagePath:   charmBaseImage,
 		Containers:           containers,
 		CharmModifiedVersion: provisionInfo.CharmModifiedVersion,
+		Trust:                provisionInfo.Trust,
+		InitialScale:         provisionInfo.Scale,
 	}
 	reason := "unchanged"
 	// TODO(sidecar): implement Equals method for caas.ApplicationConfig

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -112,6 +112,8 @@ func (s *ApplicationWorkerSuite) getWorker(c *gc.C) (func(...*gomock.Call) worke
 			Name:     "test",
 			Revision: -1,
 		},
+		Trust: true,
+		Scale: 3,
 	}
 	s.ociResources = map[string]resources.DockerImageDetails{
 		"test-oci": {
@@ -171,6 +173,8 @@ func (s *ApplicationWorkerSuite) getWorker(c *gc.C) (func(...*gomock.Call) worke
 							},
 						},
 					},
+					Trust:        true,
+					InitialScale: 3,
 				})
 				return nil
 			}),


### PR DESCRIPTION
- Fixes both trust and scale when k8s sidecar charm deploy specifies either.
- Fixes sidecar charm upgrade where trust needs to be preserved.
- Improves conflict handling in k8s resources.

## QA steps

`juju deploy mycharm -n 3 --trust`

Statefulset should be created with scale=3 and service account with privileged role/clusterroles.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1942792
https://bugs.launchpad.net/juju/+bug/1940526
