### PR TITLE
Add engine reports for cross model relations and uniter workers

### DIFF
--- a/worker/remoterelations/relationunitsworker.go
+++ b/worker/remoterelations/relationunitsworker.go
@@ -4,6 +4,9 @@
 package remoterelations
 
 import (
+	"sync"
+	"time"
+
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -27,7 +30,14 @@ type RelationUnitChangeEvent struct {
 // Local changes are exported to the remote model.
 // Remote changes are consumed by the local model.
 type relationUnitsWorker struct {
-	catacomb    catacomb.Catacomb
+	catacomb catacomb.Catacomb
+
+	mu sync.Mutex
+
+	// mostRecentChange is stored here for the engine report.
+	mostRecentChange RelationUnitChangeEvent
+	changeSince      time.Time
+
 	relationTag names.RelationTag
 	rrw         watcher.RemoteRelationWatcher
 	changes     chan<- RelationUnitChangeEvent
@@ -101,10 +111,14 @@ func (w *relationUnitsWorker) loop() error {
 			change.Macaroons = macaroon.Slice{w.macaroon}
 			change.BakeryVersion = bakery.LatestVersion
 
-			event := RelationUnitChangeEvent{
+			w.mu.Lock()
+			w.mostRecentChange = RelationUnitChangeEvent{
 				Tag:                       w.relationTag,
 				RemoteRelationChangeEvent: change,
 			}
+			w.changeSince = time.Now()
+			event := w.mostRecentChange
+			w.mu.Unlock()
 			// Send in lockstep so we don't drop events (otherwise
 			// we'd need to merge them - not too hard in this
 			// case but probably not needed).
@@ -119,4 +133,23 @@ func (w *relationUnitsWorker) loop() error {
 
 func isEmpty(change params.RemoteRelationChangeEvent) bool {
 	return len(change.ChangedUnits)+len(change.DepartedUnits) == 0 && change.ApplicationSettings == nil
+}
+
+// Report provides information for the engine report.
+func (w *relationUnitsWorker) Report() map[string]interface{} {
+	result := make(map[string]interface{})
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.mostRecentChange.Tag.Id() != "" {
+		var changed []int
+		for _, c := range w.mostRecentChange.ChangedUnits {
+			changed = append(changed, c.UnitId)
+		}
+		result["departed"] = w.mostRecentChange.DepartedUnits
+		result["changed"] = changed
+		result["since"] = w.changeSince.Format(time.RFC1123Z)
+	}
+
+	return result
 }

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -4,6 +4,8 @@
 package remoterelations
 
 import (
+	"sync"
+
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -28,6 +30,8 @@ import (
 type remoteApplicationWorker struct {
 	catacomb catacomb.Catacomb
 
+	mu sync.Mutex
+
 	// These attributes are relevant to dealing with a specific
 	// remote application proxy.
 	offerUUID             string
@@ -38,6 +42,9 @@ type remoteApplicationWorker struct {
 	consumeVersion        int
 	localRelationChanges  chan RelationUnitChangeEvent
 	remoteRelationChanges chan RelationUnitChangeEvent
+
+	// relations is stored here for the engine report.
+	relations map[string]*relation
 
 	// offerMacaroon is used to confirm that permission has been granted to consume
 	// the remote application to which this worker pertains.
@@ -163,7 +170,9 @@ func (w *remoteApplicationWorker) loop() (err error) {
 		offerStatusChanges = offerStatusWatcher.Changes()
 	}
 
-	relations := make(map[string]*relation)
+	w.mu.Lock()
+	w.relations = make(map[string]*relation)
+	w.mu.Unlock()
 	for {
 		select {
 		case <-w.catacomb.Dying():
@@ -180,7 +189,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 			}
 			for i, result := range results {
 				key := change[i]
-				if err := w.relationChanged(key, result, relations); err != nil {
+				if err := w.relationChanged(key, result); err != nil {
 					if errors.IsNotFound(err) || params.IsCodeNotFound(err) {
 						// Relation has been deleted, cleanup will occur
 						// via additional events arriving.
@@ -201,7 +210,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 				}
 				return errors.Annotatef(err, "publishing relation change %+v to remote model %v", change, w.remoteModelUUID)
 			}
-			if err := w.localRelationChanged(change.Tag.Id(), change.UnitCount, relations); err != nil {
+			if err := w.localRelationChanged(change.Tag.Id(), change.UnitCount); err != nil {
 				return errors.Annotatef(err, "processing local relation change for %v", change.Tag.Id())
 			}
 		case change := <-w.remoteRelationChanges:
@@ -361,11 +370,12 @@ func (w *remoteApplicationWorker) processLocalRelationRemoved(key string, relati
 // localRelationChanged processes changes to the relation
 // as recorded in the local model; the primary function
 // is to shut down workers when the relation is dead.
-func (w *remoteApplicationWorker) localRelationChanged(
-	key string, unitCount *int, relations map[string]*relation,
-) error {
+func (w *remoteApplicationWorker) localRelationChanged(key string, unitCount *int) error {
 	w.logger.Debugf("local relation %v changed", key)
-	relation, ok := relations[key]
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	relation, ok := w.relations[key]
 	if !ok {
 		return nil
 	}
@@ -376,7 +386,7 @@ func (w *remoteApplicationWorker) localRelationChanged(
 		w.logger.Debugf("relation dead but still has %d units in scope", *unitCount)
 		return nil
 	}
-	delete(relations, key)
+	delete(w.relations, key)
 	w.logger.Debugf("local relation %v is dead", key)
 
 	// For the unit watchers, check to see if these are nil before stopping.
@@ -400,20 +410,21 @@ func (w *remoteApplicationWorker) localRelationChanged(
 
 // relationChanged processes changes to the relation as recorded in the
 // local model when a change event arrives from the remote model.
-func (w *remoteApplicationWorker) relationChanged(
-	key string, localRelation params.RemoteRelationResult, relations map[string]*relation,
-) (err error) {
+func (w *remoteApplicationWorker) relationChanged(key string, localRelation params.RemoteRelationResult) (err error) {
 	w.logger.Debugf("relation %q changed in local model: %#v", key, localRelation)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	defer func() {
 		if err == nil || !params.IsCodeNotFound(err) {
 			return
 		}
-		if err2 := w.processLocalRelationRemoved(key, relations); err2 != nil {
+		if err2 := w.processLocalRelationRemoved(key, w.relations); err2 != nil {
 			err = errors.Annotate(err2, "processing local relation removed")
 		}
-		if r := relations[key]; r != nil {
+		if r := w.relations[key]; r != nil {
 			r.localDead = true
-			relations[key] = r
+			w.relations[key] = r
 		}
 	}()
 	if localRelation.Error != nil {
@@ -423,12 +434,12 @@ func (w *remoteApplicationWorker) relationChanged(
 
 	// If we have previously started the watcher and the
 	// relation is now suspended, stop the watcher.
-	if r := relations[key]; r != nil {
+	if r := w.relations[key]; r != nil {
 		wasSuspended := r.suspended
 		r.suspended = localRelationInfo.Suspended
-		relations[key] = r
+		w.relations[key] = r
 		if localRelationInfo.Suspended {
-			return w.processRelationSuspended(key, localRelationInfo.Life, relations)
+			return w.processRelationSuspended(key, localRelationInfo.Life, w.relations)
 		}
 		if !wasSuspended && localRelationInfo.Life == life.Alive {
 			// Nothing to do, we have previously started the watcher.
@@ -440,7 +451,7 @@ func (w *remoteApplicationWorker) relationChanged(
 		// Nothing else to do on the offering side.
 		return nil
 	}
-	return w.processConsumingRelation(key, relations, localRelationInfo)
+	return w.processConsumingRelation(key, localRelationInfo)
 }
 
 // startUnitsWorkers starts 2 workers to watch for unit settings or departed changes;
@@ -506,7 +517,6 @@ func (w *remoteApplicationWorker) startUnitsWorkers(
 // after being suspended.
 func (w *remoteApplicationWorker) processConsumingRelation(
 	key string,
-	relations map[string]*relation,
 	remoteRelation *params.RemoteRelation,
 ) error {
 
@@ -524,7 +534,7 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 	}
 
 	// Have we seen the relation before.
-	r, relationKnown := relations[key]
+	r, relationKnown := w.relations[key]
 	if !relationKnown {
 		// Totally new so start the lifecycle watcher.
 		remoteRelationsWatcher, err := w.remoteModelFacade.WatchRelationSuspendedStatus(params.RemoteEntityArg{
@@ -561,7 +571,7 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 			applicationToken:   applicationToken,
 			relationToken:      relationToken,
 		}
-		relations[key] = r
+		w.relations[key] = r
 	}
 
 	if r.localRuw == nil && !remoteRelation.Suspended {
@@ -649,4 +659,40 @@ func (w *remoteApplicationWorker) registerRemoteRelation(
 			err, "importing remote application %v to local model", w.applicationName))
 	}
 	return applicationToken, offeringAppToken, relationToken, registerResult.Macaroon, nil
+}
+
+// Report provides information for the engine report.
+func (w *remoteApplicationWorker) Report() map[string]interface{} {
+	result := make(map[string]interface{})
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	relationsInfo := make(map[string]interface{})
+	for rel, info := range w.relations {
+		relationsInfo[rel] = map[string]interface{}{
+			"relation-id":        info.relationId,
+			"local-dead":         info.localDead,
+			"suspended":          info.suspended,
+			"application-token":  info.applicationToken,
+			"relation-token":     info.relationToken,
+			"local-endpoint":     info.localEndpoint.Name,
+			"remote-endpoint":    info.remoteEndpointName,
+			"last-status-event":  info.remoteRrw.Report(),
+			"last-local-change":  info.localRuw.Report(),
+			"last-remote-change": info.remoteRuw.Report(),
+		}
+	}
+	if len(relationsInfo) > 0 {
+		result["relations"] = relationsInfo
+	}
+	result["remote-model-uuid"] = w.remoteModelUUID
+	if w.isConsumerProxy {
+		result["consumer-proxy"] = true
+		result["consume-version"] = w.consumeVersion
+	} else {
+		result["saas-application"] = true
+		result["offer-uuid"] = w.offerUUID
+	}
+
+	return result
 }

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -4,6 +4,9 @@
 package remoterelations
 
 import (
+	"sync"
+	"time"
+
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 
@@ -16,6 +19,12 @@ import (
 // life and status of a relation in the offering model.
 type remoteRelationsWorker struct {
 	catacomb catacomb.Catacomb
+
+	mu sync.Mutex
+
+	// mostRecentEvent is stored here for the engine report.
+	mostRecentEvent RelationUnitChangeEvent
+	changeSince     time.Time
 
 	relationTag         names.RelationTag
 	remoteRelationToken string
@@ -86,7 +95,8 @@ func (w *remoteRelationsWorker) loop() error {
 			change := relChanges[len(relChanges)-1]
 			w.logger.Debugf("relation status changed for %v: %v", w.relationTag, change)
 			suspended := change.Suspended
-			event = RelationUnitChangeEvent{
+			w.mu.Lock()
+			w.mostRecentEvent = RelationUnitChangeEvent{
 				Tag: w.relationTag,
 				RemoteRelationChangeEvent: params.RemoteRelationChangeEvent{
 					RelationToken:    w.remoteRelationToken,
@@ -96,10 +106,28 @@ func (w *remoteRelationsWorker) loop() error {
 					SuspendedReason:  change.SuspendedReason,
 				},
 			}
+			w.changeSince = time.Now()
+			event = w.mostRecentEvent
+			w.mu.Unlock()
 			changes = w.changes
 
 		case changes <- event:
 			changes = nil
 		}
 	}
+}
+
+// Report provides information for the engine report.
+func (w *remoteRelationsWorker) Report() map[string]interface{} {
+	result := make(map[string]interface{})
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.mostRecentEvent.Tag.Id() != "" {
+		result["life"] = w.mostRecentEvent.Life
+		result["suspended"] = w.mostRecentEvent.Suspended
+		result["since"] = w.changeSince.Format(time.RFC1123Z)
+	}
+
+	return result
 }

--- a/worker/uniter/relation/interface.go
+++ b/worker/uniter/relation/interface.go
@@ -74,6 +74,9 @@ type RelationStateTracker interface {
 	// LocalUnitAndApplicationLife returns the life values for the local
 	// unit and application.
 	LocalUnitAndApplicationLife() (life.Value, life.Value, error)
+
+	// Report provides information for the engine report.
+	Report() map[string]interface{}
 }
 
 // SubordinateDestroyer destroys all subordinates of a unit.

--- a/worker/uniter/relation/mocks/mock_statetracker.go
+++ b/worker/uniter/relation/mocks/mock_statetracker.go
@@ -5,39 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	life "github.com/juju/juju/core/life"
 	hook "github.com/juju/juju/worker/uniter/hook"
 	relation "github.com/juju/juju/worker/uniter/relation"
 	remotestate "github.com/juju/juju/worker/uniter/remotestate"
 	context "github.com/juju/juju/worker/uniter/runner/context"
-	reflect "reflect"
 )
 
-// MockRelationStateTracker is a mock of RelationStateTracker interface
+// MockRelationStateTracker is a mock of RelationStateTracker interface.
 type MockRelationStateTracker struct {
 	ctrl     *gomock.Controller
 	recorder *MockRelationStateTrackerMockRecorder
 }
 
-// MockRelationStateTrackerMockRecorder is the mock recorder for MockRelationStateTracker
+// MockRelationStateTrackerMockRecorder is the mock recorder for MockRelationStateTracker.
 type MockRelationStateTrackerMockRecorder struct {
 	mock *MockRelationStateTracker
 }
 
-// NewMockRelationStateTracker creates a new mock instance
+// NewMockRelationStateTracker creates a new mock instance.
 func NewMockRelationStateTracker(ctrl *gomock.Controller) *MockRelationStateTracker {
 	mock := &MockRelationStateTracker{ctrl: ctrl}
 	mock.recorder = &MockRelationStateTrackerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRelationStateTracker) EXPECT() *MockRelationStateTrackerMockRecorder {
 	return m.recorder
 }
 
-// CommitHook mocks base method
+// CommitHook mocks base method.
 func (m *MockRelationStateTracker) CommitHook(arg0 hook.Info) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommitHook", arg0)
@@ -45,13 +46,13 @@ func (m *MockRelationStateTracker) CommitHook(arg0 hook.Info) error {
 	return ret0
 }
 
-// CommitHook indicates an expected call of CommitHook
+// CommitHook indicates an expected call of CommitHook.
 func (mr *MockRelationStateTrackerMockRecorder) CommitHook(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHook", reflect.TypeOf((*MockRelationStateTracker)(nil).CommitHook), arg0)
 }
 
-// GetInfo mocks base method
+// GetInfo mocks base method.
 func (m *MockRelationStateTracker) GetInfo() map[int]*context.RelationInfo {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInfo")
@@ -59,13 +60,13 @@ func (m *MockRelationStateTracker) GetInfo() map[int]*context.RelationInfo {
 	return ret0
 }
 
-// GetInfo indicates an expected call of GetInfo
+// GetInfo indicates an expected call of GetInfo.
 func (mr *MockRelationStateTrackerMockRecorder) GetInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInfo", reflect.TypeOf((*MockRelationStateTracker)(nil).GetInfo))
 }
 
-// HasContainerScope mocks base method
+// HasContainerScope mocks base method.
 func (m *MockRelationStateTracker) HasContainerScope(arg0 int) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasContainerScope", arg0)
@@ -74,13 +75,13 @@ func (m *MockRelationStateTracker) HasContainerScope(arg0 int) (bool, error) {
 	return ret0, ret1
 }
 
-// HasContainerScope indicates an expected call of HasContainerScope
+// HasContainerScope indicates an expected call of HasContainerScope.
 func (mr *MockRelationStateTrackerMockRecorder) HasContainerScope(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasContainerScope", reflect.TypeOf((*MockRelationStateTracker)(nil).HasContainerScope), arg0)
 }
 
-// IsImplicit mocks base method
+// IsImplicit mocks base method.
 func (m *MockRelationStateTracker) IsImplicit(arg0 int) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsImplicit", arg0)
@@ -89,13 +90,13 @@ func (m *MockRelationStateTracker) IsImplicit(arg0 int) (bool, error) {
 	return ret0, ret1
 }
 
-// IsImplicit indicates an expected call of IsImplicit
+// IsImplicit indicates an expected call of IsImplicit.
 func (mr *MockRelationStateTrackerMockRecorder) IsImplicit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsImplicit", reflect.TypeOf((*MockRelationStateTracker)(nil).IsImplicit), arg0)
 }
 
-// IsKnown mocks base method
+// IsKnown mocks base method.
 func (m *MockRelationStateTracker) IsKnown(arg0 int) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsKnown", arg0)
@@ -103,13 +104,13 @@ func (m *MockRelationStateTracker) IsKnown(arg0 int) bool {
 	return ret0
 }
 
-// IsKnown indicates an expected call of IsKnown
+// IsKnown indicates an expected call of IsKnown.
 func (mr *MockRelationStateTrackerMockRecorder) IsKnown(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsKnown", reflect.TypeOf((*MockRelationStateTracker)(nil).IsKnown), arg0)
 }
 
-// IsPeerRelation mocks base method
+// IsPeerRelation mocks base method.
 func (m *MockRelationStateTracker) IsPeerRelation(arg0 int) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPeerRelation", arg0)
@@ -118,13 +119,13 @@ func (m *MockRelationStateTracker) IsPeerRelation(arg0 int) (bool, error) {
 	return ret0, ret1
 }
 
-// IsPeerRelation indicates an expected call of IsPeerRelation
+// IsPeerRelation indicates an expected call of IsPeerRelation.
 func (mr *MockRelationStateTrackerMockRecorder) IsPeerRelation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPeerRelation", reflect.TypeOf((*MockRelationStateTracker)(nil).IsPeerRelation), arg0)
 }
 
-// LocalUnitAndApplicationLife mocks base method
+// LocalUnitAndApplicationLife mocks base method.
 func (m *MockRelationStateTracker) LocalUnitAndApplicationLife() (life.Value, life.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LocalUnitAndApplicationLife")
@@ -134,13 +135,13 @@ func (m *MockRelationStateTracker) LocalUnitAndApplicationLife() (life.Value, li
 	return ret0, ret1, ret2
 }
 
-// LocalUnitAndApplicationLife indicates an expected call of LocalUnitAndApplicationLife
+// LocalUnitAndApplicationLife indicates an expected call of LocalUnitAndApplicationLife.
 func (mr *MockRelationStateTrackerMockRecorder) LocalUnitAndApplicationLife() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalUnitAndApplicationLife", reflect.TypeOf((*MockRelationStateTracker)(nil).LocalUnitAndApplicationLife))
 }
 
-// LocalUnitName mocks base method
+// LocalUnitName mocks base method.
 func (m *MockRelationStateTracker) LocalUnitName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LocalUnitName")
@@ -148,13 +149,13 @@ func (m *MockRelationStateTracker) LocalUnitName() string {
 	return ret0
 }
 
-// LocalUnitName indicates an expected call of LocalUnitName
+// LocalUnitName indicates an expected call of LocalUnitName.
 func (mr *MockRelationStateTrackerMockRecorder) LocalUnitName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalUnitName", reflect.TypeOf((*MockRelationStateTracker)(nil).LocalUnitName))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockRelationStateTracker) Name(arg0 int) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name", arg0)
@@ -163,13 +164,13 @@ func (m *MockRelationStateTracker) Name(arg0 int) (string, error) {
 	return ret0, ret1
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockRelationStateTrackerMockRecorder) Name(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockRelationStateTracker)(nil).Name), arg0)
 }
 
-// PrepareHook mocks base method
+// PrepareHook mocks base method.
 func (m *MockRelationStateTracker) PrepareHook(arg0 hook.Info) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareHook", arg0)
@@ -178,13 +179,13 @@ func (m *MockRelationStateTracker) PrepareHook(arg0 hook.Info) (string, error) {
 	return ret0, ret1
 }
 
-// PrepareHook indicates an expected call of PrepareHook
+// PrepareHook indicates an expected call of PrepareHook.
 func (mr *MockRelationStateTrackerMockRecorder) PrepareHook(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareHook", reflect.TypeOf((*MockRelationStateTracker)(nil).PrepareHook), arg0)
 }
 
-// RelationCreated mocks base method
+// RelationCreated mocks base method.
 func (m *MockRelationStateTracker) RelationCreated(arg0 int) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RelationCreated", arg0)
@@ -192,13 +193,13 @@ func (m *MockRelationStateTracker) RelationCreated(arg0 int) bool {
 	return ret0
 }
 
-// RelationCreated indicates an expected call of RelationCreated
+// RelationCreated indicates an expected call of RelationCreated.
 func (mr *MockRelationStateTrackerMockRecorder) RelationCreated(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationCreated", reflect.TypeOf((*MockRelationStateTracker)(nil).RelationCreated), arg0)
 }
 
-// RemoteApplication mocks base method
+// RemoteApplication mocks base method.
 func (m *MockRelationStateTracker) RemoteApplication(arg0 int) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteApplication", arg0)
@@ -206,13 +207,27 @@ func (m *MockRelationStateTracker) RemoteApplication(arg0 int) string {
 	return ret0
 }
 
-// RemoteApplication indicates an expected call of RemoteApplication
+// RemoteApplication indicates an expected call of RemoteApplication.
 func (mr *MockRelationStateTrackerMockRecorder) RemoteApplication(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteApplication", reflect.TypeOf((*MockRelationStateTracker)(nil).RemoteApplication), arg0)
 }
 
-// State mocks base method
+// Report mocks base method.
+func (m *MockRelationStateTracker) Report() map[string]interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Report")
+	ret0, _ := ret[0].(map[string]interface{})
+	return ret0
+}
+
+// Report indicates an expected call of Report.
+func (mr *MockRelationStateTrackerMockRecorder) Report() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockRelationStateTracker)(nil).Report))
+}
+
+// State mocks base method.
 func (m *MockRelationStateTracker) State(arg0 int) (*relation.State, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State", arg0)
@@ -221,13 +236,13 @@ func (m *MockRelationStateTracker) State(arg0 int) (*relation.State, error) {
 	return ret0, ret1
 }
 
-// State indicates an expected call of State
+// State indicates an expected call of State.
 func (mr *MockRelationStateTrackerMockRecorder) State(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockRelationStateTracker)(nil).State), arg0)
 }
 
-// StateFound mocks base method
+// StateFound mocks base method.
 func (m *MockRelationStateTracker) StateFound(arg0 int) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateFound", arg0)
@@ -235,13 +250,13 @@ func (m *MockRelationStateTracker) StateFound(arg0 int) bool {
 	return ret0
 }
 
-// StateFound indicates an expected call of StateFound
+// StateFound indicates an expected call of StateFound.
 func (mr *MockRelationStateTrackerMockRecorder) StateFound(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateFound", reflect.TypeOf((*MockRelationStateTracker)(nil).StateFound), arg0)
 }
 
-// SynchronizeScopes mocks base method
+// SynchronizeScopes mocks base method.
 func (m *MockRelationStateTracker) SynchronizeScopes(arg0 remotestate.Snapshot) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SynchronizeScopes", arg0)
@@ -249,7 +264,7 @@ func (m *MockRelationStateTracker) SynchronizeScopes(arg0 remotestate.Snapshot) 
 	return ret0
 }
 
-// SynchronizeScopes indicates an expected call of SynchronizeScopes
+// SynchronizeScopes indicates an expected call of SynchronizeScopes.
 func (mr *MockRelationStateTrackerMockRecorder) SynchronizeScopes(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SynchronizeScopes", reflect.TypeOf((*MockRelationStateTracker)(nil).SynchronizeScopes), arg0)

--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -5,6 +5,7 @@ package relation
 
 import (
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/juju/charm/v8"
@@ -490,4 +491,23 @@ func (r *relationStateTracker) LocalUnitAndApplicationLife() (life.Value, life.V
 	}
 
 	return r.unit.Life(), app.Life(), nil
+}
+
+// Report provides information for the engine report.
+func (r *relationStateTracker) Report() map[string]interface{} {
+	result := make(map[string]interface{})
+
+	for id, st := range r.stateMgr.(*stateManager).relationState {
+		relationer := r.relationers[id]
+		result[strconv.Itoa(id)] = map[string]interface{}{
+			"application-members": st.ApplicationMembers,
+			"members":             st.Members,
+			"is-peer":             r.isPeerRelation[id],
+			"dying":               relationer.IsDying(),
+			"endpoint":            relationer.RelationUnit().Endpoint().Name,
+			"relation":            relationer.RelationUnit().Relation().String(),
+		}
+	}
+
+	return result
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -983,3 +983,13 @@ func (u *Uniter) Terminate() error {
 	}
 	return nil
 }
+
+// Report provides information for the engine report.
+func (u *Uniter) Report() map[string]interface{} {
+	result := make(map[string]interface{})
+
+	result["unit"] = u.unit.Name()
+	result["relations"] = u.relationStateTracker.Report()
+
+	return result
+}


### PR DESCRIPTION
To aid in diagnosing problems in the field, we add engine reports for the cross model remote relations worker as well as the uniter worker.

## QA steps

Deploy a cross model relation.

In the controller model:
```
$ juju_engine_report
...
              remote-relations:
                inputs:
                - agent
                - api-caller
                - migration-fortress
                - migration-inactive-flag
                report:
                  workers:
                    mariadb:
                      offer-uuid: e2820bd6-1ebe-45a6-858b-54e564c86801
                      relations:
                        mediawiki:db mariadb:db:
                          application-token: 500c6368-4f2b-4b01-8694-5a32494f141a
                          last-local-change:
                            changed:
                            - 0
                            departed: []
                            since: Wed, 20 Oct 2021 05:28:47 +0000
                          last-remote-change:
                            changed:
                            - 0
                            departed: []
                            since: Wed, 20 Oct 2021 05:28:47 +0000
                          last-status-event:
                            life: alive
                            since: Wed, 20 Oct 2021 05:28:47 +0000
                            suspended: false
                          local-dead: false
                          local-endpoint: db
                          relation-id: 0
                          relation-token: 2d31dbd8-78e0-428f-894b-ea2259bf139a
                          remote-endpoint: db
                          suspended: false
                      remote-model-uuid: 22fab421-ee40-4856-8c4b-e0b4f5cc6f6f
                      saas-application: true
...
```

In a model with some units:
```
$ juju_engine_report
...
                uniter:
                  inputs:
                  - agent
                  - api-caller
                  - leadership-tracker
                  - charm-dir
                  - hook-retry-strategy
                  - migration-fortress
                  - migration-inactive-flag
                  report:
                    relations:
                      "0":
                        application-members:
                          mariadb: 0
                        dying: false
                        endpoint: cluster
                        is-peer: false
                        members: {}
                        relation: mariadb:cluster
                      "1":
                        application-members:
                          remote-500c63684f2b4b0186945a32494f141a: 0
                        dying: false
                        endpoint: db
                        is-peer: false
                        members:
                          remote-500c63684f2b4b0186945a32494f141a/0: 0
                        relation: remote-500c63684f2b4b0186945a32494f141a:db mariadb:db
                    unit: mariadb/0
                  start-count: 1
                  started: "2021-10-20 05:29:09"
                  state: started

...
```


