### PR TITLE
Fix intermittent failure in TestRecallUnit

### DIFF
--- a/worker/deployer/nested.go
+++ b/worker/deployer/nested.go
@@ -380,6 +380,10 @@ func (c *nestedContext) stopUnitWorkers(unitName string) error {
 		return nil
 	}
 	if err := c.runner.StopAndRemoveWorker(unitName, nil); err != nil {
+		if errors.IsNotFound(err) {
+			// NotFound, assume it's already stopped.
+			return nil
+		}
 		// StopWorker only ever returns an error when the runner is dead.
 		// In that case, it is fine to return errors back to the deployer worker.
 		return errors.Annotatef(err, "unable to stop workers for %q", unitName)


### PR DESCRIPTION
Presumably this is due to changing StopWorker with StopAndRemoveWorker, which now returns an error if the worker is not found: https://github.com/juju/juju/commit/79a364e0bda7e8e0573b3ba8bc01257a53029f52

Failure example from https://jenkins.juju.canonical.com/job/github-make-check-juju/13198/consoleFull below:

```
14:46:15 ----------------------------------------------------------------------
14:46:15 FAIL: nested_test.go:178: NestedContextSuite.TestRecallUnit
14:46:15
14:46:15 [LOG] 0:00.000 DEBUG juju.agent read agent config, format "2.0"
14:46:15 [LOG] 0:00.000 TRACE test.nestedcontext created subscriber 0xc000da8100 for 0x1db7b60
14:46:15 [LOG] 0:00.000 TRACE test.nestedcontext created subscriber 0xc000da8180 for 0x1db7b60
14:46:15 [LOG] 0:00.000 TRACE test.nestedcontext created subscriber 0xc000da8200 for 0x1db7b60
14:46:15 [LOG] 0:00.000 INFO test.nestedcontext new context: units "", stopped ""
14:46:15 [LOG] 0:00.000 TRACE test.nestedcontext create unit agent config for "unit-something-0"
14:46:15 [LOG] 0:00.001 TRACE test.nestedcontext starting the unit workers for "something/0"
14:46:15 [LOG] 0:00.001 TRACE test.nestedcontext creating symlink for "something/0" to tools directory for jujuc
14:46:15 [LOG] 0:00.001 INFO test.nestedcontext creating new agent config for "something/0"
14:46:15 [LOG] 0:00.001 DEBUG juju.agent read agent config, format "2.0"
14:46:15 [LOG] 0:00.001 INFO test.nestedcontext starting workers for "something/0"
14:46:15 [LOG] 0:00.001 TRACE test.nestedcontext updating the deployed units to add "something/0"
14:46:15 [LOG] 0:00.001 TRACE test.nestedcontext starting workers for "something/0"
14:46:15 [LOG] 0:00.001 ERROR test.nestedcontext unable to prime /tmp/check-259760408/31/unit-something-0.log (proceeding anyway): chown /tmp/check-259760408/31/unit-something-0.log: operation not permitted
14:46:15 [LOG] 0:00.001 TRACE test.nestedcontext creating unit manifolds for "something/0"
14:46:15 [LOG] 0:00.001 TRACE test.nestedcontext installing manifolds for "something/0"
14:46:15 [LOG] 0:00.001 TRACE test.nestedcontext engine for "something/0" running
14:46:15 [LOG] 0:00.001 INFO test.nestedcontext manifold start called for "something/0"
14:46:15 [LOG] 0:00.001 INFO test.nestedcontext "something/0" start
14:46:15 [LOG] 0:00.001 INFO test.nestedcontext "something/0" kill
14:46:15 nested_test.go:201:
14:46:15     c.Assert(err, jc.ErrorIsNil)
14:46:15 ... value *errors.Err = &errors.unformatter{message:"", cause:(*errors.notFound)(0xc0008474a0), previous:(*errors.Err)(0xc0008474f0), file:"github.com/juju/juju/worker/deployer/nested.go", line:489} ("unable to stop workers for \"something/0\": worker \"something/0\" not found")
14:46:15 ... error stack:
14:46:15 	/home/jenkins/go/pkg/mod/github.com/juju/worker/v3@v3.0.0-20211015025416-7586be9e222a/runner.go:306: worker "something/0" not found
14:46:15 	github.com/juju/juju/worker/deployer/nested.go:385: unable to stop workers for "something/0"
14:46:15 	github.com/juju/juju/worker/deployer/nested.go:489:
14:46:15
14:46:15
14:46:15 ----------------------------------------------------------------------
```