### PR TITLE
[2.9] Remove if containers then caas logic from cli

### DIFF
--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -59,8 +59,6 @@ func (*importSuite) TestImports(c *gc.C) {
 		"cmd",
 		"controller",
 		"core/application",
-		"core/arch",
-		"core/charm",
 		"core/charm/metrics",
 		"core/constraints",
 		"core/devices",

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1285,16 +1285,6 @@ func (s *DeploySuite) TestForceMachine(c *gc.C) {
 	s.assertForceMachine(c, machine.Id())
 }
 
-func (s *DeploySuite) TestInvalidSeriesForModel(c *gc.C) {
-	charmDir := testcharms.RepoWithSeries("kubernetes").ClonedDir(c.MkDir(), "mariadb")
-	curl := charm.MustParseURL("local:kubernetes/mariadb-1")
-	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
-	withCharmDeployable(s.fakeAPI, curl, "kubernetes", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
-
-	err := s.runDeployForState(c, charmDir.Path, "portlandia", "--series", "kubernetes")
-	c.Assert(err, gc.ErrorMatches, `cannot add application "portlandia": container-based charm for non container-based model type not valid`)
-}
-
 func (s *DeploySuite) TestForceMachineExistingContainer(c *gc.C) {
 	charmDir := testcharms.RepoWithSeries("bionic").ClonedDir(c.MkDir(), "dummy")
 	curl := charm.MustParseURL("local:bionic/dummy-1")

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -340,21 +340,6 @@ func (s *deployerSuite) TestValidateResourcesNeededForLocalDeployIAAS(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *deployerSuite) TestValidateResourcesNeededForLocalDeployCAASWithIAAS(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.modelCommand.EXPECT().ModelType().Return(model.CAAS, nil).AnyTimes()
-
-	f := &factory{
-		model: s.modelCommand,
-	}
-
-	err := f.validateResourcesNeededForLocalDeploy(&charm.Meta{
-		Series: []string{series.Focal.String()},
-	})
-	c.Assert(err, gc.ErrorMatches, `expected container-based charm metadata, unexpected series or base`)
-}
-
 func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithApplicationName(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectModelGet(c)
@@ -362,7 +347,6 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithApplicationName(c *gc.C)
 	s.charmReader.EXPECT().ReadCharm("meshuggah").Return(s.charm, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
 	s.charm.EXPECT().Meta().Return(&charm.Meta{Series: []string{"focal"}}).AnyTimes()
-	s.modelCommand.EXPECT().ModelType().Return(model.CAAS, nil)
 
 	f := &factory{
 		clock:           clock.WallClock,
@@ -373,7 +357,7 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithApplicationName(c *gc.C)
 	}
 
 	_, err := f.maybeReadLocalCharm(s.modelConfigGetter)
-	c.Assert(err, gc.ErrorMatches, `cannot add application "meshuggah": non container-based charm for container-based model type not valid`)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc.C) {
@@ -383,7 +367,6 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc
 	s.charmReader.EXPECT().ReadCharm("meshuggah").Return(s.charm, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
 	s.charm.EXPECT().Meta().Return(&charm.Meta{Name: "meshuggah", Series: []string{"focal"}}).AnyTimes()
-	s.modelCommand.EXPECT().ModelType().Return(model.CAAS, nil)
 
 	f := &factory{
 		clock:         clock.WallClock,
@@ -393,7 +376,7 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc
 	}
 
 	_, err := f.maybeReadLocalCharm(s.modelConfigGetter)
-	c.Assert(err, gc.ErrorMatches, `cannot add application "meshuggah": non container-based charm for container-based model type not valid`)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *deployerSuite) makeBundleDir(c *gc.C, content string) string {

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -185,17 +185,13 @@ func (*ImportSuite) TestImports(c *gc.C) {
 
 	// This package only brings in other core packages.
 	c.Assert(found, jc.SameContents, []string{
-		"core/arch",
-		"core/charm",
 		"core/constraints",
 		"core/instance",
 		"core/life",
 		"core/lxdprofile",
 		"core/model",
 		"core/network",
-		"core/os",
 		"core/permission",
-		"core/series",
 		"core/settings",
 		"core/status",
 	})

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -3,12 +3,6 @@
 
 package model
 
-import (
-	"github.com/juju/charm/v8"
-	"github.com/juju/errors"
-	corecharm "github.com/juju/juju/core/charm"
-)
-
 // ModelType indicates a model type.
 type ModelType string
 
@@ -35,26 +29,4 @@ type Model struct {
 
 	// ModelType is the type of model.
 	ModelType ModelType
-}
-
-// ValidateModelTarget ensures the charm is valid for the model target type.
-// This works for both v1 and v2 of the charm metadata. By looking if the
-// series for v1 charm contains kubernetes or by checking the existence of
-// containers within the v2 metadata as a way to see if kubernetes is supported.
-func ValidateModelTarget(modelType ModelType, charmMeta charm.CharmMeta) error {
-	isIAAS := !corecharm.IsKubernetes(charmMeta)
-
-	switch modelType {
-	case CAAS:
-		if isIAAS {
-			return errors.NotValidf("non container-based charm for container-based model type")
-		}
-	case IAAS:
-		if !isIAAS {
-			return errors.NotValidf("container-based charm for non container-based model type")
-		}
-	default:
-		return errors.Errorf("invalid model type")
-	}
-	return nil
 }

--- a/core/model/model_test.go
+++ b/core/model/model_test.go
@@ -4,8 +4,6 @@
 package model_test
 
 import (
-	"github.com/golang/mock/gomock"
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -19,45 +17,6 @@ type ModelSuite struct {
 }
 
 var _ = gc.Suite(&ModelSuite{})
-
-func (*ModelSuite) TestValidateSeries(c *gc.C) {
-	for _, t := range []struct {
-		modelType model.ModelType
-		meta      charm.Meta
-		valid     bool
-	}{
-		{model.IAAS, charm.Meta{Series: []string{"bionic"}}, true},
-		{model.IAAS, charm.Meta{Series: []string{"kubernetes"}}, false},
-		{model.IAAS, charm.Meta{Containers: map[string]charm.Container{"focal": {}}}, false},
-		{model.CAAS, charm.Meta{Series: []string{"bionic"}}, false},
-		{model.CAAS, charm.Meta{Series: []string{"kubernetes"}}, true},
-		{model.CAAS, charm.Meta{Containers: map[string]charm.Container{"focal": {}}}, true},
-	} {
-		ctrl := gomock.NewController(c)
-		defer ctrl.Finish()
-		cm := NewMockCharmMeta(ctrl)
-		cm.EXPECT().Meta().Return(&t.meta).AnyTimes()
-		if len(t.meta.Containers) > 0 {
-			cm.EXPECT().Manifest().Return(&charm.Manifest{
-				Bases: []charm.Base{
-					{Name: "ubuntu", Channel: charm.Channel{
-						Track: "20.04",
-						Risk:  "stable",
-					}},
-				},
-			}).AnyTimes()
-		} else {
-			cm.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
-		}
-
-		err := model.ValidateModelTarget(t.modelType, cm)
-		if t.valid {
-			c.Check(err, jc.ErrorIsNil)
-		} else {
-			c.Check(err, jc.Satisfies, errors.IsNotValid)
-		}
-	}
-}
 
 func (*ModelSuite) TestValidateBranchName(c *gc.C) {
 	for _, t := range []struct {

--- a/core/multiwatcher/package_test.go
+++ b/core/multiwatcher/package_test.go
@@ -26,17 +26,12 @@ func (*ImportTest) TestImports(c *gc.C) {
 	// This package should only depend on other core packages.
 	// If this test fails with a non-core package, please check the dependencies.
 	c.Assert(found, jc.SameContents, []string{
-		"core/arch",
-		"core/charm",
 		"core/constraints",
 		"core/instance",
 		"core/life",
-		"core/lxdprofile",
 		"core/model",
 		"core/network",
-		"core/os",
 		"core/permission",
-		"core/series",
 		"core/status",
 	})
 }

--- a/state/charm.go
+++ b/state/charm.go
@@ -18,7 +18,6 @@ import (
 	jujutxn "github.com/juju/txn"
 	"gopkg.in/macaroon.v2"
 
-	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/mongo"
 	mongoutils "github.com/juju/juju/mongo/utils"
 	stateerrors "github.com/juju/juju/state/errors"
@@ -689,13 +688,6 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 
 	minVer := info.Charm.Meta().MinJujuVersion
 	if err := jujuversion.CheckJujuMinVersion(minVer, jujuversion.Current); err != nil {
-		return nil, errors.Trace(err)
-	}
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := coremodel.ValidateModelTarget(coremodel.ModelType(model.Type()), info.Charm); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -466,12 +466,6 @@ func (s *CharmSuite) TestPrepareCharmUpload(c *gc.C) {
 	c.Assert(sch, jc.DeepEquals, schCopy)
 }
 
-func (s *CharmSuite) TestIncompatibleSeries(c *gc.C) {
-	info := s.dummyCAASCharm(c, "cs:kubernetes/dummy-2")
-	_, err := s.State.AddCharm(info)
-	c.Assert(err, gc.ErrorMatches, `container-based charm for non container-based model type not valid`)
-}
-
 func (s *CharmSuite) TestUpdateUploadedCharm(c *gc.C) {
 	info := s.dummyCharm(c, "")
 	_, err := s.State.AddCharm(info)

--- a/state/state.go
+++ b/state/state.go
@@ -34,7 +34,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lease"
-	coremodel "github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/permission"
@@ -1096,9 +1095,6 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 
 	model, err := st.Model()
 	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if err := coremodel.ValidateModelTarget(coremodel.ModelType(model.Type()), args.Charm); err != nil {
 		return nil, errors.Trace(err)
 	}
 


### PR DESCRIPTION
This change makes charm deployment best-effort. It allows us to deploy
k8s charms that do not explicitly define a "containers" section
(LP1928991).

The intent is to replace these checks with "assumes" expressions that
charm authors can optionally provide to specify the exact set of
features they require.

## QA steps

```sh
# Bootstrap mk8s
$ juju bootstrap microk8s mk8s --no-gui

# This charm uses v2 metadata but does not define a "containers" section
# You should not be able to deploy this with an earlier Juju version
$ juju deploy --channel beta juju-qa-test-assumes-v2
Located charm "juju-qa-test-assumes-v2" in charm-hub, revision 2
Deploying "juju-qa-test-assumes-v2" from charm-hub charm "juju-qa-test-assumes-v2", revision 2 in channel beta
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1928991
