### PR TITLE
Ensure global clock updater checks fsm errors

### DIFF
--- a/worker/globalclockupdater/updater.go
+++ b/worker/globalclockupdater/updater.go
@@ -102,7 +102,6 @@ func (u *updater) Advance(duration time.Duration, stop <-chan struct{}) error {
 
 			// Ensure we also check the FSMResponse error.
 			if err = response.Error(); err == nil {
-
 				response.Notify(u.expiryNotifyTarget)
 				u.prevTime = newTime
 

--- a/worker/globalclockupdater/updater_test.go
+++ b/worker/globalclockupdater/updater_test.go
@@ -51,6 +51,39 @@ func (s *updaterSuite) TestAdvance(c *gc.C) {
 	c.Assert(updater.prevTime, gc.Equals, now.Add(time.Second))
 }
 
+func (s *updaterSuite) TestAdvanceErrorThenSucceeds(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	now := time.Now()
+
+	enqueueErr := raft.ErrEnqueueTimeout
+
+	s.expectGlobalClock(c, now)
+
+	// The first one will timeout.
+	s.expectTimeout(c)
+	s.expectRaftApply(c, now, enqueueErr)
+	s.clock.EXPECT().GlobalTime().Return(now)
+
+	// The second one will succeed.
+	s.expectTimeout(c)
+	s.expectRaftApply(c, now, nil)
+
+	done := make(chan struct{}, 1)
+
+	updater := newUpdater(s.raftApplier, s.notifyTarget, s.clock, s.sleeper, s.timer, s.logger)
+	err := updater.Advance(time.Second, done)
+	c.Assert(err, gc.ErrorMatches, globalclock.ErrTimeout.Error())
+
+	c.Assert(updater.prevTime, gc.Equals, now)
+
+	err = updater.Advance(time.Second, done)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the previous time is updated after an advance.
+	c.Assert(updater.prevTime, gc.Equals, now.Add(time.Second))
+}
+
 func (s *updaterSuite) TestAdvanceErrEnqueueTimeout(c *gc.C) {
 	// Ensure we get an error that allows us to retry.
 	defer s.setupMocks(c).Finish()


### PR DESCRIPTION
Whilst load testing at a very high rate, sometimes the clock updater can
not tick. Turns out we weren't checking for the FSM error response.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE;juju.worker.raft=TRACE"
$ juju enable-ha
$ juju debug-log -m controller
```

Additionally you can always follow the following steps https://github.com/juju/juju/pull/13418
