### PR TITLE
add multi-part yaml support to GetChanges for the bundle facade

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -23,7 +23,7 @@ var facadeVersions = map[string]int{
 	"ApplicationScaler":            1,
 	"Backups":                      2,
 	"Block":                        2,
-	"Bundle":                       5,
+	"Bundle":                       6,
 	"CAASAgent":                    2,
 	"CAASAdmission":                1,
 	"CAASApplication":              1,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -177,6 +177,7 @@ func AllFacades() *facade.Registry {
 	reg("Bundle", 3, bundle.NewFacadeV3)
 	reg("Bundle", 4, bundle.NewFacadeV4)
 	reg("Bundle", 5, bundle.NewFacadeV5)
+	reg("Bundle", 6, bundle.NewFacadeV6)
 	reg("CharmHub", 1, charmhub.NewFacade)
 	reg("CharmRevisionUpdater", 2, charmrevisionupdater.NewCharmRevisionUpdaterAPI)
 	reg("Charms", 2, charms.NewFacadeV2)

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -219,7 +219,8 @@ type validators struct {
 func getBundleChanges(args params.BundleChangesParams,
 	vs validators,
 ) ([]bundlechanges.Change, []error, error) {
-	data, err := charm.ReadBundleData(strings.NewReader(args.BundleDataYAML))
+	dataSource, _ := charm.StreamBundleDataSource(strings.NewReader(args.BundleDataYAML), args.BundleURL)
+	data, err := charm.ReadAndMergeBundleData(dataSource)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "cannot read bundle YAML")
 	}

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -63,8 +63,16 @@ type APIv4 struct {
 // identical to V4 with the exception that the V5 adds an arg to export
 // bundle to control what is exported..
 type APIv5 struct {
+	*APIv6
+}
+
+// APIv6 provides the Bundle API facade for version 6. It is otherwise
+// identical to V5 with the exception that the V6 adds the support for
+// multi-part yaml handling to GetChanges and GetChangesMapArgs.
+type APIv6 struct {
 	*BundleAPI
 }
+
 
 // BundleAPI implements the Bundle interface and is the concrete implementation
 // of the API end point.
@@ -118,11 +126,21 @@ func NewFacadeV4(ctx facade.Context) (*APIv4, error) {
 // NewFacadeV5 provides the signature required for facade registration
 // for version 5.
 func NewFacadeV5(ctx facade.Context) (*APIv5, error) {
-	api, err := newFacade(ctx)
+	api, err := NewFacadeV6(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &APIv5{api}, nil
+}
+
+// NewFacadeV6 provides the signature required for facade registration
+// for version 6.
+func NewFacadeV6(ctx facade.Context) (*APIv6, error) {
+	api, err := newFacade(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv6{api}, nil
 }
 
 // NewFacade provides the required signature for facade registration.
@@ -166,7 +184,7 @@ func NewBundleAPIv1(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &APIv1{&APIv2{&APIv3{&APIv4{&APIv5{api}}}}}, nil
+	return &APIv1{&APIv2{&APIv3{&APIv4{&APIv5{&APIv6{api}}}}}}, nil
 }
 
 func (b *BundleAPI) checkCanRead() error {

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -73,7 +73,6 @@ type APIv6 struct {
 	*BundleAPI
 }
 
-
 // BundleAPI implements the Bundle interface and is the concrete implementation
 // of the API end point.
 type BundleAPI struct {

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -213,7 +213,7 @@ func (s *bundleSuite) TestGetChangesSuccessV2(c *gc.C) {
 	c.Assert(r.Errors, gc.IsNil)
 }
 
-func (s *bundleSuite) TestGetChangesSuccessV2WithOverlays(c *gc.C) {
+func (s *bundleSuite) TestGetChangesSuccessWithOverlays(c *gc.C) {
 	args := params.BundleChangesParams{
 		BundleDataYAML: `
             applications:

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -5820,8 +5820,8 @@
     },
     {
         "Name": "Bundle",
-        "Description": "APIv5 provides the Bundle API facade for version 5. It is otherwise\nidentical to V4 with the exception that the V5 adds an arg to export\nbundle to control what is exported..",
-        "Version": 5,
+        "Description": "APIv6 provides the Bundle API facade for version 6. It is otherwise\nidentical to V5 with the exception that the V6 adds the support for\nmulti-part yaml handling to GetChanges and GetChangesMapArgs.",
+        "Version": 6,
         "AvailableTo": [
             "controller-user",
             "model-user"


### PR DESCRIPTION
### Description

`pylibjuju` uses the bundle facade to get the changes for a bundle to be deployed. However, currently the `GetChanges` function that the facade uses only handles single-part yaml files, so this PR adds the support for multi-part yaml handling (which the Juju cli uses) to enable the use of overlays in bundles.

### QA steps

```sh
  $ cd juju/apiserver/facades/client/bundle/
  $ go test -gocheck.f TestGetChangesWithOverlaysV6
  $ go test -gocheck.f TestGetChangesWithOverlaysV1_5
```

### Notes & Discussion

This PR is needed for https://github.com/juju/python-libjuju/pull/566, which adds the support for overlays in deploying bundles.
