### PR TITLE
Do not close stdout

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -364,8 +364,12 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 		return nil, errors.Trace(err)
 	}
 	if model.Type() == state.ModelTypeCAAS {
-		// CAAS controller writes log to stdOut.
-		srv.logSinkWriter = os.Stdout
+		// CAAS controller writes log to stdout. We should ensure that we don't
+		// close the logSinkWriter when we stopping the tomb, otherwise we get
+		// no output to stdout anymore.
+		srv.logSinkWriter = nonCloseableWriter{
+			WriteCloser: os.Stdout,
+		}
 	} else {
 		srv.logSinkWriter, err = logsink.NewFileWriter(filepath.Join(srv.logDir, "logsink.log"))
 		if err != nil {
@@ -399,6 +403,18 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 	}
 
 	return srv, nil
+}
+
+// nonCloseableWriter ensures that we never close the underlying writer. If the
+// underlying writer is os.stdout and we close that, then nothing will be
+// written until a new instance of the program is launched.
+type nonCloseableWriter struct {
+	io.WriteCloser
+}
+
+// Close does not do anything in this instance.
+func (nonCloseableWriter) Close() error {
+	return nil
 }
 
 // Report is shown in the juju_engine_report.


### PR DESCRIPTION
The API server when killed will attempt to clean up any dependencies it
has created in its lifetime. Except that one of those for the CAAS
model type is stdout. If you close stdout you can no longer write to it.

Turns out, our tests exercised this code path and we closed stdout
preventing the writing of any test descriptions to stdout. The tool to
analyze the output of the log then assumed there was a panic and marked
all our tests in this package as failed. Why it wasn't reported as a
panic in Jenkins was because the test coverage tool only looked for the
PANIC key phrase.

This was PAINFUL to debug...


## QA steps

Run this with this PR and without:

```sh
$ go test ./apiserver -check.v -v -check.f=caasToolsSuite
```

The output should be:

```sh
=== RUN   TestPackage
PASS: tools_test.go:568: caasToolsSuite.TestToolDownloadNotSharedCAASController 0.815s
OK: 1 passed
--- PASS: TestPackage (6.89s)
PASS
ok      github.com/juju/juju/apiserver  6.924s
```

Not:

```sh
=== RUN   TestPackage
OK: 1 passed
ok      github.com/juju/juju/apiserver  6.868s
```
