### PR TITLE
Ensure Raft clock updater synchronisation

### DIFF
--- a/worker/globalclockupdater/updater.go
+++ b/worker/globalclockupdater/updater.go
@@ -55,7 +55,6 @@ type Timer interface {
 type updater struct {
 	raft               RaftApplier
 	clock              raftlease.ReadOnlyClock
-	prevTime           time.Time
 	logger             Logger
 	sleeper            Sleeper
 	timer              Timer
@@ -74,7 +73,6 @@ func newUpdater(
 		raft:               r,
 		expiryNotifyTarget: notifyTarget,
 		clock:              clock,
-		prevTime:           clock.GlobalTime(),
 		sleeper:            sleeper,
 		timer:              timer,
 		logger:             logger,
@@ -86,8 +84,8 @@ func newUpdater(
 func (u *updater) Advance(duration time.Duration, stop <-chan struct{}) error {
 	becomingLeaderTimeout := u.timer.After(leaderTimeout)
 	for {
-		newTime := u.prevTime.Add(duration)
-		cmd, err := u.createCommand(newTime)
+		oldTime := u.clock.GlobalTime()
+		cmd, err := u.createCommand(oldTime, oldTime.Add(duration))
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -103,8 +101,6 @@ func (u *updater) Advance(duration time.Duration, stop <-chan struct{}) error {
 			// Ensure we also check the FSMResponse error.
 			if err = response.Error(); err == nil {
 				response.Notify(u.expiryNotifyTarget)
-				u.prevTime = newTime
-
 				break
 			}
 		}
@@ -121,9 +117,7 @@ func (u *updater) Advance(duration time.Duration, stop <-chan struct{}) error {
 			u.logger.Warningf("clock update still pending; local Raft state is %q", u.raft.State())
 
 		case raft.ErrEnqueueTimeout:
-			// Reset our last known global time from the FSM and convert
-			// the error to one retryable by the updater worker.
-			u.prevTime = u.clock.GlobalTime()
+			// Convert the error to one retryable by the updater worker.
 			return globalclock.ErrTimeout
 
 		default:
@@ -143,11 +137,11 @@ func (u *updater) Advance(duration time.Duration, stop <-chan struct{}) error {
 	return nil
 }
 
-func (u *updater) createCommand(newTime time.Time) ([]byte, error) {
+func (u *updater) createCommand(oldTime, newTime time.Time) ([]byte, error) {
 	cmd, err := (&raftlease.Command{
 		Version:   raftlease.CommandVersion,
 		Operation: raftlease.OperationSetTime,
-		OldTime:   u.prevTime,
+		OldTime:   oldTime,
 		NewTime:   newTime,
 	}).Marshal()
 


### PR DESCRIPTION
It is possible to get into an error spiral where the Raft clock updater is not in sync with the FSM time, and can not _get_ in sync. This results in the following messages repeated in the logs every second.
```
machine-0: 17:34:09 WARNING juju.worker.globalclockupdater.raft clock update attempt by out-of-sync caller, retry
machine-0: 17:34:09 INFO juju.worker.globalclockupdater.raft retrying lease clock update in 1s
```

In terms of behaviour, it effectively prevents any leases from expiring.

The sync mechanism relies on a `prevTime` member, which gets set at worker start-up, and when we successfully tick the clock. This is vestigial from old forms of the worker that ran on all controllers, and needed to ensure monotonic clock updates.

Since we use a single instance of the worker, always running on the leader, we can do away with synchronising in this way, and simply request the current clock time from the FSM before each update.

## QA steps

I got into this situation by doing the following:
- Bootstrapping 2.9 HEAD on LXD.
- Make some non-functional change and `juju upgrade-controller --build-agent`.
- Observe the controller logging mentioned above.

Resolution:
- Using this patch, `juju upgrade-controller --build-agent` again.
- Observe clean logs.
- Deploy a multi-unit workload (like ubuntu-lite).
- `lxc stop` the container for the leader unit.
- Observe a leadership change.

## Documentation changes

None.

## Bug reference

N/A
