### PR TITLE
Re-deploying bundles with local charms

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -287,9 +287,9 @@ func (h *bundleHandler) makeModel(
 // fully qualified, meaning they have a source and revision id.
 // Effectively the logic this method follows is:
 //   * if the bundle specifies a local charm, and the application
-//     exists already, then override the charm URL in the bundle
-//     spec to match the charm name from the model. We don't
-//     upgrade local charms as part of a bundle deploy.
+//     exists already, then remove the charm in the bundle spec
+//     (i.e. ignore it). We don't upgrade local charms as part of a
+//     bundle deploy.
 //   * the charm URL is resolved and the bundle spec is replaced
 //     with the fully resolved charm URL - i.e.: with rev id.
 //   * check all endpoints, and if any of them have implicit endpoints,
@@ -304,9 +304,8 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 		var cons constraints.Value
 		if app != nil {
 			if h.isLocalCharm(spec.Charm) {
-				logger.Debugf("%s exists in model uses a local charm, replacing with %q", name, app.Charm)
-				// Replace with charm from model
-				spec.Charm = app.Charm
+				logger.Debugf("%s exists in model uses a local charm, ignoring", name, app.Charm)
+				delete(h.data.Applications, name)
 				continue
 			}
 			// If the charm matches, don't bother resolving.

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -296,7 +296,6 @@ func (h *bundleHandler) makeModel(
 //     and if they do, resolve the implicitness in order to compare
 //     with relations in the model.
 func (h *bundleHandler) resolveCharmsAndEndpoints() error {
-	deployedApps := set.NewStrings()
 
 	for _, name := range h.applications.SortedValues() {
 		spec := h.data.Applications[name]
@@ -304,8 +303,6 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 
 		var cons constraints.Value
 		if app != nil {
-			deployedApps.Add(name)
-
 			if h.isLocalCharm(spec.Charm) {
 				logger.Debugf("%s exists in model uses a local charm, replacing with %q", name, app.Charm)
 				// Replace with charm from model

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -1643,7 +1643,7 @@ func (s *BundleHandlerResolverSuite) TestAvoidRedeployAlreadyDeployedLocalCharm(
 	bundle_data_to_be_deployed := &charm.BundleData{
 		Applications: map[string]*charm.ApplicationSpec{
 			"test-app": {
-				Charm: "./some-local.charm",
+				Charm: "/home/user/go/some-folder/some-local.charm",
 			},
 		},
 	}
@@ -1664,7 +1664,11 @@ func (s *BundleHandlerResolverSuite) TestAvoidRedeployAlreadyDeployedLocalCharm(
 	err := handler.resolveCharmsAndEndpoints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(handler.data, gc.DeepEquals, &charm.BundleData{
-		Applications: map[string]*charm.ApplicationSpec{},
+		Applications: map[string]*charm.ApplicationSpec{
+			"test-app": {
+				Charm: "./some-local.charm",
+			},
+		},
 	})
 
 }


### PR DESCRIPTION
### Description

#### Problem

Re-deploying a local bundle, with an application from a local charm results in an error like:

`ERROR cannot deploy bundle: cannot deploy local charm at "/home/caner/work/cderici/tmp/somecharm": file does not exist`

where `somecharm` is the name of charm for the app, not the local bundle file.

Here's the bug reference  : https://bugs.launchpad.net/juju/+bug/1942937

Juju's previous behavior for this (e.g. when it deploys a bundle that has an app -on a local charm- which is already on the model) was to ignore the charm by replacing the charm URL on the (to be deployed) bundle spec with charm's local URL in the model and have `getChanges` to return `no change` for this[**]. This seems to be wrong for multiple reasons, one being that it generates a path that doesn't exists (which is the main trigger for the error above), and secondly it's impossible to generate that path because we no longer have the filename information from which the initial charm was deployed in the first place.

[**] The comments in the code also states `We don't upgrade local charms as part of a bundle deploy`.

#### Solution

We change this behavior and treat deploying bundles that have local charms as refreshes on the charms, so we resolve the local charm and re-upload it.

## QA steps

Let's say you have a `bundle.yaml` with the following with a local `test.charm` with an application `foo`:

```yaml
bundle: kubernetes
applications:
  an-app:
    charm: ./test.charm
    scale: 1
```

```sh
$ juju deploy ./bundle.yaml
Executing changes:
- upload charm <path>/test.charm for series focal with architecture=amd64
- deploy application foo on focal
Deploy of bundle completed.
```

The second run should produce the following instead of the error above:

```sh
$ juju deploy ./bundle.yaml
Executing changes:
- upload charm <path>/test.charm for series focal with architecture=amd64
- upgrade hello-kubeconusing charm ./test.charm for series focal
- Deploy of bundle completed.
```

### Notes & Discussion

As referenced in the description, this PR attempts to solve https://bugs.launchpad.net/juju/+bug/1942937

This also removes a map that's being filled with application names but never seems to be used anywhere.

This also exposes a problem with URLs, where we write to the DB something like `local:appname-0` for a local charm URL as well, which is not a correct locator for a local charm (not a path, like `./../../../filename.charm`). This is a problem because `juju migrate` and `juju export-bundle` should be using that path to resolve a local charm.