### PR TITLE
Enhanced logging detail when starting side-car agents

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1246,6 +1246,7 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			"--data-dir", jujuDataDir,
 			"--charm-modified-version", strconv.Itoa(config.CharmModifiedVersion),
 			"--append-env", "PATH=$PATH:/charm/bin",
+			"--show-log",
 		},
 		Env: env,
 		SecurityContext: &corev1.SecurityContext{

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -480,7 +480,13 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 			Image:           "ubuntu:20.04",
 			WorkingDir:      jujuDataDir,
 			Command:         []string{"/charm/bin/containeragent"},
-			Args:            []string{"unit", "--data-dir", jujuDataDir, "--charm-modified-version", "9001", "--append-env", "PATH=$PATH:/charm/bin"},
+			Args: []string{
+				"unit",
+				"--data-dir", jujuDataDir,
+				"--charm-modified-version", "9001",
+				"--append-env", "PATH=$PATH:/charm/bin",
+				"--show-log",
+			},
 			Env: []corev1.EnvVar{
 				{
 					Name:  "JUJU_CONTAINER_NAMES",


### PR DESCRIPTION
There have been multiple reports of sidecar unit agents failing to come up, with no information beyond a status of waiting/allocating and the message "installing agent".

Here we ensure a little more diagnostic capability by:
- Passing the package logger to the `Runner` that runs the agent.
- Returning non-nil errors from the call to `Run`.
- Logging when the agent is terminating.

These logs were not previously written to stdout/stderr, and so were not visible when interrogating the pod's logs directly. Now, `--show-log` is passed to the `containeragent` invocation so that now they are.

## QA steps

- Bootstrap to microk8s.
- `juju add-model tester --config logging-config="<root>=INFO;juju.cmd.containeragent.unit=DEBUG"`.
- Have `microk8s.kubectl -n tester logs -f hello-kubecon-0 -c charm` running in a separate terminal.
- `juju deploy hello-kubecon`.
- Once quiesced, run `juju remove-application hello-kubecon`.
- The life cycle should be visible in the pod logs, including the runner activity (from runner.go):
```
2021-11-03 09:21:49 INFO juju.cmd supercommand.go:56 running containerAgent [2.9.18 0 d11d5ee30354001a3ef78db049c3fd8bd6974ab2 gc go1.17.1]
starting containeragent unit command
containeragent unit "unit-hello-kubecon-0" start (2.9.18 [gc])
2021-11-03 09:21:49 INFO juju.cmd.containeragent.unit runner.go:556 start "unit"
2021-11-03 09:21:49 INFO juju.worker.upgradesteps worker.go:60 upgrade steps for 2.9.18 have already been run.
2021-11-03 09:21:49 INFO juju.worker.probehttpserver server.go:157 starting http server on [::]:3856
2021-11-03 09:21:49 INFO juju.api apiclient.go:1051 cannot resolve "controller-service.controller-mk8s.svc.cluster.local": operation was canceled
2021-11-03 09:21:49 INFO juju.api apiclient.go:680 connection established to "wss://10.152.183.90:17070/model/2f824ec7-1fd2-4bb4-84fa-657d7122fd53/api"
2021-11-03 09:21:49 INFO juju.worker.apicaller connect.go:158 [2f824e] "unit-hello-kubecon-0" successfully connected to "10.152.183.90:17070"
2021-11-03 09:21:49 INFO juju.api apiclient.go:1051 cannot resolve "controller-service.controller-mk8s.svc.cluster.local": operation was canceled
2021-11-03 09:21:49 INFO juju.api apiclient.go:680 connection established to "wss://10.152.183.90:17070/model/2f824ec7-1fd2-4bb4-84fa-657d7122fd53/api"
2021-11-03 09:21:49 INFO juju.worker.apicaller connect.go:158 [2f824e] "unit-hello-kubecon-0" successfully connected to "10.152.183.90:17070"
2021-11-03 09:21:49 INFO juju.worker.migrationminion worker.go:140 migration phase is now: NONE
2021-11-03 09:21:49 INFO juju.worker.logger logger.go:120 logger worker started
2021-11-03 09:21:49 WARNING juju.worker.proxyupdater proxyupdater.go:282 unable to set snap core settings [proxy.http= proxy.https= proxy.store=]: exec: "snap": executable file not found in $PATH, output: ""
2021-11-03 09:21:49 INFO juju.worker.caasupgrader upgrader.go:113 abort check blocked until version event received
2021-11-03 09:21:49 INFO juju.worker.caasupgrader upgrader.go:119 unblocking abort check
2021-11-03 09:21:49 INFO juju.worker.leadership tracker.go:194 hello-kubecon/0 promoted to leadership of hello-kubecon
2021-11-03 09:21:49 INFO juju.agent.tools symlinks.go:20 ensure jujuc symlinks in /var/lib/juju/tools/unit-hello-kubecon-0
2021-11-03 09:21:49 INFO juju.worker.uniter uniter.go:339 unit "hello-kubecon/0" started
2021-11-03 09:21:49 INFO juju.worker.uniter uniter.go:643 resuming charm install
2021-11-03 09:21:49 INFO juju.worker.uniter.charm bundles.go:79 downloading ch:amd64/focal/hello-kubecon-13 from API server
2021-11-03 09:21:49 INFO juju.downloader download.go:111 downloading from ch:amd64/focal/hello-kubecon-13
2021-11-03 09:21:49 INFO juju.downloader download.go:94 download complete ("ch:amd64/focal/hello-kubecon-13")
2021-11-03 09:21:49 INFO juju.downloader download.go:174 download verified ("ch:amd64/focal/hello-kubecon-13")
2021-11-03 09:21:55 INFO juju.worker.uniter uniter.go:357 hooks are retried true
2021-11-03 09:21:55 INFO juju.worker.uniter resolver.go:154 found queued "install" hook
2021-11-03 09:21:55 INFO juju-log Running legacy hooks/install.
2021-11-03 09:21:55 INFO juju-log Downloading site from https://jnsgr.uk/demo-site
2021-11-03 09:21:56 INFO juju.worker.uniter.operation runhook.go:152 ran "install" hook (via hook dispatching script: dispatch)
2021-11-03 09:21:56 INFO juju.worker.uniter resolver.go:154 found queued "leader-elected" hook
2021-11-03 09:21:56 INFO juju.worker.uniter.operation runhook.go:152 ran "leader-elected" hook (via hook dispatching script: dispatch)
2021-11-03 09:21:57 INFO juju.worker.uniter.operation runhook.go:152 ran "gosherve-pebble-ready" hook (via hook dispatching script: dispatch)
2021-11-03 09:21:57 INFO juju.worker.uniter.operation runhook.go:152 ran "webroot-storage-attached" hook (via hook dispatching script: dispatch)
2021-11-03 09:21:57 INFO juju-log Added updated layer 'gosherve' to Pebble plan
2021-11-03 09:21:58 INFO juju-log Restarted gosherve service
2021-11-03 09:21:59 INFO juju.worker.uniter.operation runhook.go:152 ran "config-changed" hook (via hook dispatching script: dispatch)
2021-11-03 09:21:59 INFO juju.worker.uniter resolver.go:154 found queued "start" hook
2021-11-03 09:21:59 INFO juju-log Running legacy hooks/start.
2021-11-03 09:21:59 INFO juju.worker.uniter.operation runhook.go:152 ran "start" hook (via hook dispatching script: dispatch)
2021-11-03 09:27:01 INFO juju.worker.uniter.operation runhook.go:152 ran "update-status" hook (via hook dispatching script: dispatch)
2021-11-03 09:29:14 WARNING juju.worker.uniter.operation leader.go:123 we should run a leader-deposed hook here, but we can't yet
2021-11-03 09:29:14 INFO juju.worker.caasunitterminationworker worker.go:82 terminating due to SIGTERM
2021-11-03 09:29:14 INFO juju.worker.uniter.operation runhook.go:152 ran "leader-settings-changed" hook (via hook dispatching script: dispatch)
2021-11-03 09:29:15 INFO juju.worker.uniter.operation runhook.go:152 ran "webroot-storage-detaching" hook (via hook dispatching script: dispatch)
2021-11-03 09:29:15 INFO juju.worker.uniter.operation runhook.go:152 ran "stop" hook (via hook dispatching script: dispatch)
2021-11-03 09:29:15 INFO juju.worker.uniter.operation runhook.go:152 ran "remove" hook (via hook dispatching script: dispatch)
2021-11-03 09:29:16 INFO juju.worker.uniter uniter.go:323 unit "hello-kubecon/0" shutting down: agent should be terminated
2021-11-03 09:29:19 ERROR juju.worker.uniter pebblepoller.go:99 pebble poll failed for container "gosherve": failed to get pebble info: cannot obtain system details: cannot communicate with server: Get "http://localhost/v1/system-info": dial unix /charm/containers/gosherve/pebble.socket: connect: no such file or directory
2021-11-03 09:29:19 INFO juju.worker.logger logger.go:136 logger worker stopped
2021-11-03 09:29:19 INFO juju.cmd.containeragent.unit runner.go:587 stopped "unit", err: agent should be terminated
2021-11-03 09:29:19 DEBUG juju.cmd.containeragent.unit runner.go:406 "unit" done: agent should be terminated
2021-11-03 09:29:19 ERROR juju.cmd.containeragent.unit runner.go:459 fatal "unit": agent should be terminated
2021-11-03 09:29:19 INFO juju.cmd.containeragent.unit agent.go:384 agent terminating
2021-11-03 09:29:19 INFO cmd supercommand.go:544 command finished
```

## Documentation changes

None.

## Bug reference

In service of https://bugs.launchpad.net/juju/+bug/1946382
