### PR TITLE
Context queue

### DIFF
--- a/apiserver/raft.go
+++ b/apiserver/raft.go
@@ -64,7 +64,7 @@ func (m *raftMediator) ApplyLease(ctx context.Context, cmd []byte) error {
 
 	m.queue.Enqueue(queue.Operation{
 		Command: cmd,
-		Stop:    ctx.Done(),
+		Stop:    ctx.Done,
 		Done: func(err error) {
 			// We can do this, because the caller of done, is in another
 			// goroutine, otherwise this is a sure fire way to deadlock.

--- a/apiserver/raft.go
+++ b/apiserver/raft.go
@@ -5,7 +5,6 @@ package apiserver
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/juju/clock"
@@ -65,6 +64,7 @@ func (m *raftMediator) ApplyLease(ctx context.Context, cmd []byte) error {
 
 	m.queue.Enqueue(queue.Operation{
 		Command: cmd,
+		Stop:    ctx.Done(),
 		Done: func(err error) {
 			// We can do this, because the caller of done, is in another
 			// goroutine, otherwise this is a sure fire way to deadlock.
@@ -83,11 +83,6 @@ func (m *raftMediator) ApplyLease(ctx context.Context, cmd []byte) error {
 			m.logger.Tracef("Applying lease %s took: %v with error: %s", string(cmd), elapsed, err)
 		}
 
-	case <-ctx.Done():
-		m.logger.Errorf("Context was marked as done whilst waiting for enqueue: %v", m.clock.Now().Sub(start))
-		msg := fmt.Sprintf("Apply lease context deadline exceeded: %s", ctx.Err())
-		return apiservererrors.NewDeadlineExceededError(msg)
-
 	case <-m.clock.After(ApplyLeaseTimeout):
 		m.logger.Errorf("Applying Lease timed out, waiting for enqueue: %v", m.clock.Now().Sub(start))
 		return apiservererrors.NewDeadlineExceededError("Apply lease upper bound timeout")
@@ -105,8 +100,13 @@ func (m *raftMediator) ApplyLease(ctx context.Context, cmd []byte) error {
 		return apiservererrors.NewNotLeaderError(leaderErr.ServerAddress(), leaderErr.ServerID())
 
 	case queue.IsDeadlineExceeded(err):
-		// If the deadline is exceeded, get original callee to handle the
+		// If the deadline is exceeded, get original caller to handle the
 		// timeout correctly.
+		return apiservererrors.NewDeadlineExceededError(err.Error())
+
+	case queue.IsCanceled(err):
+		// If the apply lease is canceled from the context (facade), then let
+		// the original caller handle it correctly.
 		return apiservererrors.NewDeadlineExceededError(err.Error())
 
 	}

--- a/apiserver/raft_test.go
+++ b/apiserver/raft_test.go
@@ -99,10 +99,7 @@ func (s *raftMediatorSuite) TestApplyLeaseDeadlineExceededError(c *gc.C) {
 func (s *raftMediatorSuite) TestApplyLeaseContextDoneError(c *gc.C) {
 	cmd := []byte("do it")
 
-	deadLineErr := queue.ErrDeadlineExceeded
 	q := queue.NewOpQueue(clock.WallClock)
-
-	results := s.consume(c, q, 1, deadLineErr)
 
 	mediator := raftMediator{
 		queue:  q,
@@ -116,10 +113,8 @@ func (s *raftMediatorSuite) TestApplyLeaseContextDoneError(c *gc.C) {
 	cancel()
 
 	err := mediator.ApplyLease(ctx, cmd)
-	c.Assert(err, gc.ErrorMatches, `Apply lease context deadline exceeded: context canceled`)
+	c.Assert(err, gc.ErrorMatches, `enqueueing canceled`)
 	c.Assert(apiservererrors.IsDeadlineExceededError(err), jc.IsTrue)
-
-	s.matcheOne(c, results, string(cmd))
 }
 
 func (s *raftMediatorSuite) consume(c *gc.C, q *queue.OpQueue, n int, err error) chan queue.Operation {

--- a/core/raft/queue/opqueue_test.go
+++ b/core/raft/queue/opqueue_test.go
@@ -60,7 +60,9 @@ func (s *OpQueueSuite) TestEnqueueWithStopped(c *gc.C) {
 	done := make(chan error)
 	go queue.Enqueue(Operation{
 		Command: command(),
-		Stop:    canceled,
+		Stop: func() <-chan struct{} {
+			return canceled
+		},
 		Done: func(err error) {
 			done <- err
 		},
@@ -240,7 +242,9 @@ func (s *OpQueueSuite) TestMultipleEnqueueWithStop(c *gc.C) {
 
 		go queue.Enqueue(Operation{
 			Command: opName(i),
-			Stop:    canceled,
+			Stop: func() <-chan struct{} {
+				return canceled
+			},
 			Done: func(err error) {
 				done <- err
 			},


### PR DESCRIPTION
~~Requires https://github.com/juju/juju/pull/13453 to land first.~~

## QA steps

See the discourse post for more history: https://discourse.charmhub.io/t/raft-api-leases-part-ii/5267/4

### Apply the following patch

```diff
--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -92,6 +92,7 @@ func (m *leadershipService) ClaimLeadership(args params.ClaimLeadershipBulkParam
                case names.ApplicationTag:
                        canClaim = m.authorizer.AuthOwner(applicationTag)
                }
+               canClaim = true
                if !canClaim {
                        result.Error = common.ServerError(common.ErrPerm)
                        continue
@@ -114,6 +115,7 @@ func (m *leadershipService) BlockUntilLeadershipReleased(ctx context.Context, ap
        case names.ApplicationTag:
                hasPerm = m.authorizer.AuthOwner(applicationTag)
        }
+       hasPerm = true

        if !hasPerm {
                return params.ErrorResult{Error: common.ServerError(common.ErrPerm)}, nil
```

### Setup controller

```sh
$ juju bootstrap lxd test1 --build-agent --config features="[raft-api-leases,raft-batch-fsm]" --config agent-ratelimit-max=0
$ juju switch controller
$ juju enable-ha
$ juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE;juju.worker.raft=TRACE"
$ juju add-user prometheus
$ juju grant prometheus read controller
$ juju change-user-password prometheus 
```

### Create the bundle and overlay:

```yaml
series: focal
applications:
  controller:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 3
    to:
    - "0"
    - "1"
    - "2"
  grafana:
    charm: cs:grafana-49
    num_units: 1
    to:
    - "1"
    expose: true
  prometheus:
    charm: cs:prometheus2-24
    num_units: 1
    to:
    - "0"
  telegraf:
    charm: cs:telegraf-43
    options:
      hostname: '{unit}'
      tags: juju_model=controller
machines:
  "0":
  "1":
  "2":
relations:
- - controller:juju-info
  - telegraf:juju-info
- - prometheus:grafana-source
  - grafana:grafana-source
- - telegraf:prometheus-client
  - prometheus:target
```

### Change the controller targets and password.

```yaml
applications:
  prometheus:
    options:
      scrape-jobs: |
        - job_name: juju
          metrics_path: /introspection/metrics
          scheme: https
          static_configs:
              - targets:
                - '$CONTROLLER_IP_0:17070'
                labels:
                    juju_model: controller
                    host: controller-0
              - targets:
                - '$CONTROLLER_IP_1:17070'
                labels:
                    juju_model: controller
                    host: controller-1
              - targets:
                - '$CONTROLLER_IP_2:17070'
                labels:
                    juju_model: controller
                    host: controller-2
          basic_auth:
            username: user-prometheus
            password: $PASSWORD
          tls_config:
            insecure_skip_verify: true
```

### Deploy the bundle

```sh
$ juju deploy ./bundle.yaml --overlay=overlay.yaml --map-machines=existing
$ juju config prometheus scrape-interval=1s
$ juju config prometheus scrape-timeout=1s
```

### Get the grafana login details

```sh
$ juju run-action grafana/0 --wait get-login-info -m controller
```

Update the grafana dashboard

Import the following grafana dashboard https://paste.ubuntu.com/p/jtTt5PyrPH/

### Deploy ubuntu

```sh
$ juju switch default
$ juju deploy ubuntu -n 3
```

### Setup testing

```sh
$ cd scripts/leadershipclaimer
$ go build leadershipclaimer.go
```

### Edit the run.sh to point to the correct controllers

Ensure you get the agent password from ubuntu machine unit.

```sh
$ ./run.sh
``` 

View the results in grafana.