### PR TITLE
Improve run hook error when charm is missing

### DIFF
--- a/worker/uniter/runner/args.go
+++ b/worker/uniter/runner/args.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/juju/errors"
 	jujuos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/worker/common/charmrunner"
 )
@@ -83,4 +85,13 @@ func hookCommand(hook string) []string {
 		}
 	}
 	return []string{hook}
+}
+
+func checkCharmExists(charmDir string) error {
+	if _, err := os.Stat(path.Join(charmDir, "metadata.yaml")); os.IsNotExist(err) {
+		return errors.New("charm missing from disk")
+	} else if err != nil {
+		return errors.Annotatef(err, "failed to check for metadata.yaml")
+	}
+	return nil
 }

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -688,6 +688,10 @@ func (runner *runner) runCharmProcessOnLocal(hook, hookName, charmDir string, en
 // check for the given hookName.  Based on what is discovered, return the
 // HookHandlerType and the actual script to be run.
 func (runner *runner) discoverHookHandler(hookName, charmDir, charmLocation string) (HookHandlerType, string, error) {
+	err := checkCharmExists(charmDir)
+	if err != nil {
+		return InvalidHookHandler, "", errors.Trace(err)
+	}
 	hook, err := discoverHookScript(charmDir, hookDispatcherScript)
 	if err == nil {
 		return DispatchingHookHandler, hook, nil

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -105,6 +105,15 @@ var runHookTests = []struct {
 		err:      "fork/exec.*: exec format error",
 		hookType: runner.ExplicitHookHandler,
 	}, {
+		summary: "report error with missing charm",
+		relid:   -1,
+		spec: hookSpec{
+			charmMissing: true,
+			perm:         0700,
+		},
+		err:      "charm missing from disk",
+		hookType: runner.InvalidHookHandler,
+	}, {
 		summary: "output logging",
 		relid:   -1,
 		spec: hookSpec{
@@ -163,6 +172,8 @@ func (s *RunHookSuite) TestRunHook(c *gc.C) {
 			c.Logf("makeCharm %#v", spec)
 			makeCharm(c, spec, paths.GetCharmDir())
 			hookExists = true
+		} else if !t.spec.charmMissing {
+			makeCharmMetadata(c, paths.GetCharmDir())
 		}
 		t0 := time.Now()
 		hookType, err := rnr.RunHook("something-happened")


### PR DESCRIPTION
When juju checks to see if a hook exists before skipping it, it should also check to see if the charm exists at all.
Otherwise the check is ambiguous.

## QA steps

bootstrap microk8s
`juju deploy cs:~containers/coredns-10`
`juju config coredns forward=8.8.8.8`
delete charm from disk on operator
wait for a hook to run, it should error better than just skipping the hook

## Documentation changes

N/A

## Bug reference

Doesn't fix but is related to https://bugs.launchpad.net/juju/+bug/1948833
