### PR TITLE
Record how long an apply vs success/failure takes

### DIFF
--- a/worker/raft/apply.go
+++ b/worker/raft/apply.go
@@ -88,13 +88,18 @@ func NewApplier(raft Raft, target raftlease.NotifyTarget, metrics ApplierMetrics
 // the fsm.
 func (a *Applier) ApplyOperation(ops []queue.Operation, applyTimeout time.Duration) {
 	start := a.clock.Now()
+	leaderErr := a.currentLeaderState()
 
 	// Operations are iterated through optimistically, so if there is an error,
 	// then continue onwards.
 	for i, op := range ops {
 		// If there is a leader error, finish the operations with the leader
-		// error.
-		if leaderErr := a.currentLeaderState(); leaderErr != nil {
+		// error. We only request the leader state once, as it's not a cheap
+		// operation. We can reasonably assume that during a tight loop of batch
+		// operations, the changing of a leader state should be small. If it
+		// does happen, then the operation will end up back here after another
+		// redirect.
+		if leaderErr != nil {
 			a.metrics.RecordLeaderError(start)
 			op.Done(leaderErr)
 			continue
@@ -126,6 +131,8 @@ func (a *Applier) applyOperation(i int, op queue.Operation, applyTimeout time.Du
 		op.Done(err)
 		return
 	}
+
+	a.metrics.Record(start, "apply")
 
 	response := future.Response()
 	fsmResponse, ok := response.(raftlease.FSMResponse)


### PR DESCRIPTION
The following ensures that the recording of metrics differentiates
between success/failure and apply. This is important when load testing
as we want to see what part of the application leases is struggling.

## QA steps

See the discourse post for more history: https://discourse.charmhub.io/t/raft-api-leases-part-ii/5267/4

### Apply the following patch

```diff
--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -92,6 +92,7 @@ func (m *leadershipService) ClaimLeadership(args params.ClaimLeadershipBulkParam
                case names.ApplicationTag:
                        canClaim = m.authorizer.AuthOwner(applicationTag)
                }
+               canClaim = true
                if !canClaim {
                        result.Error = common.ServerError(common.ErrPerm)
                        continue
@@ -114,6 +115,7 @@ func (m *leadershipService) BlockUntilLeadershipReleased(ctx context.Context, ap
        case names.ApplicationTag:
                hasPerm = m.authorizer.AuthOwner(applicationTag)
        }
+       hasPerm = true

        if !hasPerm {
                return params.ErrorResult{Error: common.ServerError(common.ErrPerm)}, nil
```

### Setup controller

```sh
$ juju bootstrap lxd test1 --build-agent --config features="[raft-api-leases,raft-batch-fsm]" --config agent-ratelimit-max=0
$ juju switch controller
$ juju enable-ha
$ juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE;juju.worker.raft=TRACE"
$ juju add-user prometheus
$ juju grant prometheus read controller
$ juju change-user-password prometheus 
```

### Create the bundle and overlay:

```yaml
series: focal
applications:
  controller:
    charm: cs:~jameinel/ubuntu-lite
    num_units: 3
    to:
    - "0"
    - "1"
    - "2"
  grafana:
    charm: cs:grafana-49
    num_units: 1
    to:
    - "1"
    expose: true
  prometheus:
    charm: cs:prometheus2-24
    num_units: 1
    to:
    - "0"
  telegraf:
    charm: cs:telegraf-43
    options:
      hostname: '{unit}'
      tags: juju_model=controller
machines:
  "0":
  "1":
  "2":
relations:
- - controller:juju-info
  - telegraf:juju-info
- - prometheus:grafana-source
  - grafana:grafana-source
- - telegraf:prometheus-client
  - prometheus:target
```

### Change the controller targets and password.

```yaml
applications:
  prometheus:
    options:
      scrape-jobs: |
        - job_name: juju
          metrics_path: /introspection/metrics
          scheme: https
          static_configs:
              - targets:
                - '$CONTROLLER_IP_0:17070'
                labels:
                    juju_model: controller
                    host: controller-0
              - targets:
                - '$CONTROLLER_IP_1:17070'
                labels:
                    juju_model: controller
                    host: controller-1
              - targets:
                - '$CONTROLLER_IP_2:17070'
                labels:
                    juju_model: controller
                    host: controller-2
          basic_auth:
            username: user-prometheus
            password: $PASSWORD
          tls_config:
            insecure_skip_verify: true
```

### Deploy the bundle

```sh
$ juju deploy ./bundle.yaml --overlay=overlay.yaml --map-machines=existing
$ juju config prometheus scrape-interval=1s
$ juju config prometheus scrape-timeout=1s
```

### Get the grafana login details

```sh
$ juju run-action grafana/0 --wait get-login-info -m controller
```

Update the grafana dashboard

Import the following grafana dashboard https://paste.ubuntu.com/p/jtTt5PyrPH/

### Deploy ubuntu

```sh
$ juju switch default
$ juju deploy ubuntu -n 3
```

### Setup testing

```sh
$ cd scripts/leadershipclaimer
$ go build leadershipclaimer.go
```

### Edit the run.sh to point to the correct controllers

Ensure you get the agent password from ubuntu machine unit.

```sh
$ ./run.sh
``` 

View the results in grafana.