### PR TITLE
Update to latest version of Pebble (exec terminal/interactive params)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.9.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20211020232555-f1cb2d5a71b7
+	github.com/canonical/pebble v0.0.0-20211103232324-2ce34ccd3350
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.0.0-20200316104309-cb8b64719ae3
 	github.com/dnaeon/go-vcr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20211020232555-f1cb2d5a71b7 h1:K0nrBT3pTUMv0eJBmvp8QeXsUUCMieH8qsYNY0TbQaw=
-github.com/canonical/pebble v0.0.0-20211020232555-f1cb2d5a71b7/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
+github.com/canonical/pebble v0.0.0-20211103232324-2ce34ccd3350 h1:kMaRiOV9BVtAWoWOehMfoX/DxBThnE/5Z4LevrEV0fE=
+github.com/canonical/pebble v0.0.0-20211103232324-2ce34ccd3350/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
This pulls in https://github.com/canonical/pebble/pull/81

It shouldn't actually affect Juju usage at all, because the old "use-terminal" parameter was not provided (defaulted to false) by the Python Operator Framework -- interactive doesn't apply there. But good to have the latest Pebble and Pebble CLI version anyway.