### PR TITLE
Backport lxd error handling

### DIFF
--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -4,6 +4,9 @@
 package lxd
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/utils/v2/arch"
@@ -299,5 +302,21 @@ func (s *Server) HostArch() string {
 // IsLXDNotFound checks if an error from the LXD API indicates that a requested
 // entity was not found.
 func IsLXDNotFound(err error) bool {
-	return err != nil && err.Error() == "not found"
+	if err == nil {
+		return false
+	}
+
+	// TODO (stickupkid): This is a hack until we can correctly upstream the
+	// lxd project.
+	if statusErr, ok := errors.Cause(err).(lxdStatusError); ok && statusErr.Status() == http.StatusNotFound {
+		return true
+	}
+
+	return strings.ToLower(err.Error()) == "not found"
+}
+
+// lxdStatusError allows us to check if an error conforms to the lxd status
+// error type.
+type lxdStatusError interface {
+	Status() int
 }


### PR DESCRIPTION
This is the backport of https://github.com/juju/juju/pull/13320

## QA steps

```sh
$ snap install juju --classic
$ /snap/bin/juju bootstrap lxd test
$ juju upgrade-controller --build-agent
$ juju debug-log -m controller
```

Ensure that the single-controller does settle and has started. 

```sh
$ juju ssh -m controller 0
$ juju_engine_report | less
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1949705