### PR TITLE
Added lower bound for run_action wait timeout.

### DIFF
--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -113,7 +113,7 @@ func (c *runActionCommand) Init(args []string) (err error) {
 		return errors.New("no action specified")
 	}
 
-	// force timeout to be equal or larger than 100ms
+	// force timeout to be greater or equal to 1ms
 	if c.wait.String() != "" {
 		if c.wait.d.Milliseconds() < 1 {
 			return errors.New("timeout must be greater or equal to 1 ms")

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -116,7 +116,7 @@ func (c *runActionCommand) Init(args []string) (err error) {
 	// force timeout to be equal or larger than 100ms
 	if c.wait.String() != "" {
 		if c.wait.d.Milliseconds() < 1 {
-			return errors.New("timeout must be greater or equal than 1 ms")
+			return errors.New("timeout must be greater or equal to 1 ms")
 		}
 	}
 

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -115,8 +115,8 @@ func (c *runActionCommand) Init(args []string) (err error) {
 
 	// force timeout to be equal or larger than 100ms
 	if c.wait.String() != "" {
-		if time.Duration(c.wait.d.Milliseconds()) < time.Millisecond {
-			return errors.New("timeout must equal or greater than 1 ms")
+		if c.wait.d.Milliseconds() < 1 {
+			return errors.New("timeout must greater or equal than 1 ms")
 		}
 	}
 

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -113,6 +113,13 @@ func (c *runActionCommand) Init(args []string) (err error) {
 		return errors.New("no action specified")
 	}
 
+	// force timeout to be equal or larger than 100ms
+	if c.wait.String() != "" {
+		if time.Duration(c.wait.d.Milliseconds()) < time.Millisecond {
+			return errors.New("timeout must equal or greater than 1 ms")
+		}
+	}
+
 	// Parse CLI key-value args if they exist.
 	c.args = make([][]string, 0)
 	for _, arg := range args[len(c.unitReceivers)+1:] {

--- a/cmd/juju/action/runaction.go
+++ b/cmd/juju/action/runaction.go
@@ -116,7 +116,7 @@ func (c *runActionCommand) Init(args []string) (err error) {
 	// force timeout to be equal or larger than 100ms
 	if c.wait.String() != "" {
 		if c.wait.d.Milliseconds() < 1 {
-			return errors.New("timeout must greater or equal than 1 ms")
+			return errors.New("timeout must be greater or equal than 1 ms")
 		}
 	}
 

--- a/cmd/juju/action/runaction_test.go
+++ b/cmd/juju/action/runaction_test.go
@@ -183,7 +183,7 @@ func (s *RunActionSuite) TestInit(c *gc.C) {
 		expectKVArgs: [][]string{},
 	}, {
 		should:      "reject timeouts smaller than 1 ms",
-		args:        []string{"mysql/leader", "valid-action-name", "--wait=10ns"},
+		args:        []string{"mysql/leader", "valid-action-name", "--wait=99ms"},
 		expectError: "timeout must equal or greater than 1 ms",
 	}}
 

--- a/cmd/juju/action/runaction_test.go
+++ b/cmd/juju/action/runaction_test.go
@@ -184,7 +184,7 @@ func (s *RunActionSuite) TestInit(c *gc.C) {
 	}, {
 		should:      "reject timeouts smaller than 1 ms",
 		args:        []string{"mysql/leader", "valid-action-name", "--wait=99ns"},
-		expectError: "timeout must equal or greater than 1 ms",
+		expectError: "timeout must be greater or equal than 1 ms",
 	}}
 
 	for i, t := range tests {

--- a/cmd/juju/action/runaction_test.go
+++ b/cmd/juju/action/runaction_test.go
@@ -184,7 +184,7 @@ func (s *RunActionSuite) TestInit(c *gc.C) {
 	}, {
 		should:      "reject timeouts smaller than 1 ms",
 		args:        []string{"mysql/leader", "valid-action-name", "--wait=99ns"},
-		expectError: "timeout must be greater or equal than 1 ms",
+		expectError: "timeout must be greater or equal to 1 ms",
 	}}
 
 	for i, t := range tests {

--- a/cmd/juju/action/runaction_test.go
+++ b/cmd/juju/action/runaction_test.go
@@ -181,6 +181,10 @@ func (s *RunActionSuite) TestInit(c *gc.C) {
 		expectUnits:  []string{"mysql/leader"},
 		expectAction: "valid-action-name",
 		expectKVArgs: [][]string{},
+	}, {
+		should:      "reject timeouts smaller than 1 ms",
+		args:        []string{"mysql/leader", "valid-action-name", "--wait=10ns"},
+		expectError: "timeout must equal or greater than 1 ms",
 	}}
 
 	for i, t := range tests {

--- a/cmd/juju/action/runaction_test.go
+++ b/cmd/juju/action/runaction_test.go
@@ -183,7 +183,7 @@ func (s *RunActionSuite) TestInit(c *gc.C) {
 		expectKVArgs: [][]string{},
 	}, {
 		should:      "reject timeouts smaller than 1 ms",
-		args:        []string{"mysql/leader", "valid-action-name", "--wait=99ms"},
+		args:        []string{"mysql/leader", "valid-action-name", "--wait=99ns"},
 		expectError: "timeout must equal or greater than 1 ms",
 	}}
 


### PR DESCRIPTION
The `juju run_action` has a param `wait=10ms` that sets a timeout to stop the active waiting. This PR simply adds a lower timeout limitation of 1ms to avoid ridiculous situations where the user sets the wait param to be one nanosecond or similar.

This branch limits this timeout to be at least 1 millisecond.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
juju bootstrap microk8s test
juju deploy hello-kubecon
juju run-action hello-kubecon/0 pull-site --wait=700ns
ERROR timeout must greater or equal than 1 ms
juju run-action hello-kubecon/0 pull-site --wait=1ms
{}
ERROR timeout reached
juju run-action hello-kubecon/0 pull-site --wait=5s
unit-hello-kubecon-0:
  UnitId: hello-kubecon/0
  id: "55"
  results:
    result: site pulled
  status: completed
  timing:
    completed: 2021-11-04 15:46:58 +0000 UTC
    enqueued: 2021-11-04 15:46:57 +0000 UTC
    started: 2021-11-04 15:46:57 +0000 UTC
```

## Documentation changes

Juju documentation must be changed to mention this limitation. https://juju.is/docs/olm/working-with-actions

