### PR TITLE
[JUJU-137] Batch expire the expired leases

### DIFF
--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -388,8 +388,11 @@ func (r *response) Notify(target NotifyTarget) error {
 			errs = append(errs, errors.Annotatef(err, "claim lease"))
 		}
 	}
-	if err := target.Expiries(r.expired); err != nil {
-		errs = append(errs, errors.Annotatef(err, "expirying leases"))
+	// One call expiries when we have some expired keys.
+	if len(r.expired) > 0 {
+		if err := target.Expiries(r.expired); err != nil {
+			errs = append(errs, errors.Annotatef(err, "expirying leases"))
+		}
 	}
 	if errs == nil {
 		return nil

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -195,7 +195,10 @@ func (f *FSM) revoke(key lease.Key, holder string) *response {
 	if len(entries) == 0 {
 		delete(f.groups, groupKeyFor(key))
 	}
-	return &response{expired: []lease.Key{key}}
+	return &response{expired: []Expired{{
+		Key:    key,
+		Holder: holder,
+	}}}
 }
 
 func (f *FSM) pin(key lease.Key, entity string) *response {
@@ -224,14 +227,17 @@ func (f *FSM) setTime(oldTime, newTime time.Time) *response {
 // removeExpired deletes leases that have expired and
 // returns a collection of the deleted lease keys.
 // Pinned leases are not deleted.
-func (f *FSM) removeExpired(newTime time.Time) []lease.Key {
-	var expired []lease.Key
+func (f *FSM) removeExpired(newTime time.Time) []Expired {
+	var expired []Expired
 	for gKey, entries := range f.groups {
 		for key, entry := range entries {
 			expiry := entry.start.Add(entry.duration)
 			if expiry.Before(newTime) && !f.isPinned(key) {
 				delete(entries, key)
-				expired = append(expired, key)
+				expired = append(expired, Expired{
+					Key:    key,
+					Holder: entry.holder,
+				})
 			}
 		}
 		if len(entries) == 0 {
@@ -365,12 +371,19 @@ type entry struct {
 
 var _ FSMResponse = (*response)(nil)
 
+// Expired holds the expiry for a given lease. It includes the information about
+// the current existing holder.
+type Expired struct {
+	Key    lease.Key
+	Holder string
+}
+
 // response stores what happened as a result of applying a command.
 type response struct {
 	err     error
 	claimer string
 	claimed lease.Key
-	expired []lease.Key
+	expired []Expired
 }
 
 // Error is part of FSMResponse.

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -388,10 +388,8 @@ func (r *response) Notify(target NotifyTarget) error {
 			errs = append(errs, errors.Annotatef(err, "claim lease"))
 		}
 	}
-	for _, expiredKey := range r.expired {
-		if err := target.Expired(expiredKey); err != nil {
-			errs = append(errs, errors.Annotatef(err, "expire lease"))
-		}
+	if err := target.Expiries(r.expired); err != nil {
+		errs = append(errs, errors.Annotatef(err, "expirying leases"))
 	}
 	if errs == nil {
 		return nil

--- a/core/raftlease/fsm_test.go
+++ b/core/raftlease/fsm_test.go
@@ -1052,8 +1052,8 @@ func (t *fakeTarget) Claimed(key lease.Key, holder string) error {
 	return t.NextErr()
 }
 
-func (t *fakeTarget) Expired(key lease.Key) error {
-	t.AddCall("Expired", key)
+func (t *fakeTarget) Expiries(keys []lease.Key) error {
+	t.AddCall("Expiries", keys)
 	return t.NextErr()
 }
 

--- a/core/raftlease/fsm_test.go
+++ b/core/raftlease/fsm_test.go
@@ -1025,15 +1025,17 @@ func assertExpired(c *gc.C, resp raftlease.FSMResponse, keys ...lease.Key) {
 	}
 	var target fakeTarget
 	resp.Notify(&target)
-	c.Assert(target.Calls(), gc.HasLen, len(keys))
 	for _, call := range target.Calls() {
-		c.Assert(call.FuncName, gc.Equals, "Expired")
+		c.Assert(call.FuncName, gc.Equals, "Expiries")
 		c.Assert(call.Args, gc.HasLen, 1)
-		key, ok := call.Args[0].(lease.Key)
+
+		paramKeys, ok := call.Args[0].([]lease.Key)
 		c.Assert(ok, gc.Equals, true)
-		_, found := keySet[key]
-		c.Assert(found, gc.Equals, true)
-		delete(keySet, key)
+		for _, key := range paramKeys {
+			_, found := keySet[key]
+			c.Assert(found, gc.Equals, true)
+			delete(keySet, key)
+		}
 	}
 }
 

--- a/core/raftlease/fsm_test.go
+++ b/core/raftlease/fsm_test.go
@@ -1029,12 +1029,12 @@ func assertExpired(c *gc.C, resp raftlease.FSMResponse, keys ...lease.Key) {
 		c.Assert(call.FuncName, gc.Equals, "Expiries")
 		c.Assert(call.Args, gc.HasLen, 1)
 
-		paramKeys, ok := call.Args[0].([]lease.Key)
+		paramExpiries, ok := call.Args[0].([]raftlease.Expired)
 		c.Assert(ok, gc.Equals, true)
-		for _, key := range paramKeys {
-			_, found := keySet[key]
+		for _, expired := range paramExpiries {
+			_, found := keySet[expired.Key]
 			c.Assert(found, gc.Equals, true)
-			delete(keySet, key)
+			delete(keySet, expired.Key)
 		}
 	}
 }
@@ -1054,8 +1054,8 @@ func (t *fakeTarget) Claimed(key lease.Key, holder string) error {
 	return t.NextErr()
 }
 
-func (t *fakeTarget) Expiries(keys []lease.Key) error {
-	t.AddCall("Expiries", keys)
+func (t *fakeTarget) Expiries(expiries []raftlease.Expired) error {
+	t.AddCall("Expiries", expiries)
 	return t.NextErr()
 }
 

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -40,8 +40,8 @@ type NotifyTarget interface {
 	// Claimed will be called when a new lease has been claimed.
 	Claimed(lease.Key, string) error
 
-	// Expired will be called when an existing lease has expired.
-	Expired(lease.Key) error
+	// Expiries will be called when a set of existing leases have expired.
+	Expiries([]lease.Key) error
 }
 
 // TrapdoorFunc returns a trapdoor to be attached to lease details for

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -41,7 +41,7 @@ type NotifyTarget interface {
 	Claimed(lease.Key, string) error
 
 	// Expiries will be called when a set of existing leases have expired.
-	Expiries([]lease.Key) error
+	Expiries([]Expired) error
 }
 
 // TrapdoorFunc returns a trapdoor to be attached to lease details for

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -96,7 +96,10 @@ func (s *leaseStore) RevokeLease(key lease.Key, holder string, stop <-chan struc
 		return lease.ErrInvalid
 	}
 	delete(s.entries, key)
-	_ = s.target.Expiries([]lease.Key{key})
+	_ = s.target.Expiries([]raftlease.Expired{{
+		Key:    key,
+		Holder: holder,
+	}})
 	return nil
 }
 

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -96,7 +96,7 @@ func (s *leaseStore) RevokeLease(key lease.Key, holder string, stop <-chan struc
 		return lease.ErrInvalid
 	}
 	delete(s.entries, key)
-	_ = s.target.Expired(key)
+	_ = s.target.Expiries([]lease.Key{key})
 	return nil
 }
 

--- a/state/raftlease/target_test.go
+++ b/state/raftlease/target_test.go
@@ -193,7 +193,10 @@ func (s *targetSuite) TestExpired(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.newTarget().Expiries([]lease.Key{{"leadership", "model", "twin"}})
+	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+		Key:    lease.Key{"leadership", "model", "twin"},
+		Holder: "kitamura",
+	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.getRows(c), gc.HasLen, 0)
 }
@@ -217,10 +220,13 @@ func (s *targetSuite) TestExpires(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.newTarget().Expiries([]lease.Key{
-		{"leadership", "model", "twin1"},
-		{"leadership", "model", "twin2"},
-	})
+	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+		Key:    lease.Key{"leadership", "model", "twin1"},
+		Holder: "kitamura1",
+	}, {
+		Key:    lease.Key{"leadership", "model", "twin2"},
+		Holder: "kitamura2",
+	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.getRows(c), gc.HasLen, 0)
 }
@@ -244,11 +250,16 @@ func (s *targetSuite) TestExpiresWithDuplicateEntries(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.newTarget().Expiries([]lease.Key{
-		{"leadership", "model", "twin1"},
-		{"leadership", "model", "twin2"},
-		{"leadership", "model", "twin1"},
-	})
+	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+		Key:    lease.Key{"leadership", "model", "twin1"},
+		Holder: "kitamura1",
+	}, {
+		Key:    lease.Key{"leadership", "model", "twin2"},
+		Holder: "kitamura2",
+	}, {
+		Key:    lease.Key{"leadership", "model", "twin1"},
+		Holder: "kitamura1",
+	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.getRows(c), gc.HasLen, 0)
 }
@@ -265,16 +276,22 @@ func (s *targetSuite) TestExpiresWithMissingRecord(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.newTarget().Expiries([]lease.Key{
-		{"leadership", "model", "twin1"},
-		{"leadership", "model", "twin2"},
-	})
+	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+		Key:    lease.Key{"leadership", "model", "twin1"},
+		Holder: "kitamura1",
+	}, {
+		Key:    lease.Key{"leadership", "model", "twin2"},
+		Holder: "kitamura2",
+	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.getRows(c), gc.HasLen, 0)
 }
 
 func (s *targetSuite) TestExpiredNoRecord(c *gc.C) {
-	err := s.newTarget().Expiries([]lease.Key{{"leadership", "model", "twin"}})
+	err := s.newTarget().Expiries([]coreraftlease.Expired{{
+		Key:    lease.Key{"leadership", "model", "twin"},
+		Holder: "kitamura",
+	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.getRows(c), gc.HasLen, 0)
 }
@@ -296,7 +313,10 @@ func (s *targetSuite) TestExpiredRemovedWhileRunning(c *gc.C) {
 		c.Assert(coll.Remove(nil), jc.ErrorIsNil)
 	}).Check()
 
-	err = s.newTarget().Expiries([]lease.Key{{"leadership", "model", "twin"}})
+	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+		Key:    lease.Key{"leadership", "model", "twin"},
+		Holder: "kitamura",
+	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.getRows(c), gc.HasLen, 0)
 }
@@ -318,7 +338,10 @@ func (s *targetSuite) TestExpiredError(c *gc.C) {
 
 	s.mongo.txnErr = errors.Errorf("oops!")
 
-	err = s.newTarget().Expiries([]lease.Key{{"leadership", "model", "twin"}})
+	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+		Key:    lease.Key{"leadership", "model", "twin"},
+		Holder: "kitamura",
+	}})
 	c.Assert(err, gc.ErrorMatches, `\[model:leadership#twin#\] in db: oops!`)
 	c.Assert(logWriter.Log(), jc.LogMatches, []string{
 		`expiring leases \[model:leadership#twin#\]`,

--- a/state/raftlease/target_test.go
+++ b/state/raftlease/target_test.go
@@ -261,6 +261,15 @@ func (s *targetSuite) TestExpiresWithDifferentHolder(c *gc.C) {
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.getRows(c), gc.HasLen, 1)
+
+	// First write should win.
+	c.Assert(s.getRows(c), gc.DeepEquals, []bson.M{{
+		"_id":        "model:leadership#twin1#",
+		"namespace":  "leadership",
+		"model-uuid": "model",
+		"lease":      "twin1",
+		"holder":     "kitamuraA",
+	}})
 }
 
 func (s *targetSuite) TestExpiresWithDuplicateEntries(c *gc.C) {

--- a/state/raftlease/target_test.go
+++ b/state/raftlease/target_test.go
@@ -231,6 +231,38 @@ func (s *targetSuite) TestExpires(c *gc.C) {
 	c.Assert(s.getRows(c), gc.HasLen, 0)
 }
 
+func (s *targetSuite) TestExpiresWithDifferentHolder(c *gc.C) {
+	err := s.db.C(collection).Insert(
+		bson.M{
+			"_id":        "model:leadership#twin1#",
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "twin1",
+			"holder":     "kitamuraA",
+		},
+		bson.M{
+			"_id":        "model:leadership#twin2#",
+			"namespace":  "leadership",
+			"model-uuid": "model",
+			"lease":      "twin2",
+			"holder":     "kitamura2",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Attempt to expire this one, but it won't match. We should still expire
+	// the second lease.
+	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+		Key:    lease.Key{"leadership", "model", "twin1"},
+		Holder: "kitamura1",
+	}, {
+		Key:    lease.Key{"leadership", "model", "twin2"},
+		Holder: "kitamura2",
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.getRows(c), gc.HasLen, 1)
+}
+
 func (s *targetSuite) TestExpiresWithDuplicateEntries(c *gc.C) {
 	err := s.db.C(collection).Insert(
 		bson.M{

--- a/worker/globalclockupdater/manifold_test.go
+++ b/worker/globalclockupdater/manifold_test.go
@@ -239,6 +239,6 @@ func (noopTarget) Claimed(lease.Key, string) error {
 }
 
 // Expired will be called when a set if existing leases have expired.
-func (noopTarget) Expiries([]lease.Key) error {
+func (noopTarget) Expiries([]raftlease.Expired) error {
 	return nil
 }

--- a/worker/globalclockupdater/manifold_test.go
+++ b/worker/globalclockupdater/manifold_test.go
@@ -238,8 +238,7 @@ func (noopTarget) Claimed(lease.Key, string) error {
 	return nil
 }
 
-// Expired will be called when an existing lease has expired. Not
-// allowed to return an error because this is purely advisory.
-func (noopTarget) Expired(lease.Key) error {
+// Expired will be called when a set if existing leases have expired.
+func (noopTarget) Expiries([]lease.Key) error {
 	return nil
 }

--- a/worker/globalclockupdater/raftlease_test.go
+++ b/worker/globalclockupdater/raftlease_test.go
@@ -50,18 +50,18 @@ func (mr *MockNotifyTargetMockRecorder) Claimed(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Claimed", reflect.TypeOf((*MockNotifyTarget)(nil).Claimed), arg0, arg1)
 }
 
-// Expired mocks base method.
-func (m *MockNotifyTarget) Expired(arg0 lease.Key) error {
+// Expiries mocks base method.
+func (m *MockNotifyTarget) Expiries(arg0 []lease.Key) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Expired", arg0)
+	ret := m.ctrl.Call(m, "Expiries", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Expired indicates an expected call of Expired.
-func (mr *MockNotifyTargetMockRecorder) Expired(arg0 interface{}) *gomock.Call {
+// Expiries indicates an expected call of Expiries.
+func (mr *MockNotifyTargetMockRecorder) Expiries(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expired", reflect.TypeOf((*MockNotifyTarget)(nil).Expired), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expiries", reflect.TypeOf((*MockNotifyTarget)(nil).Expiries), arg0)
 }
 
 // MockReadOnlyClock is a mock of ReadOnlyClock interface.

--- a/worker/globalclockupdater/raftlease_test.go
+++ b/worker/globalclockupdater/raftlease_test.go
@@ -51,7 +51,7 @@ func (mr *MockNotifyTargetMockRecorder) Claimed(arg0, arg1 interface{}) *gomock.
 }
 
 // Expiries mocks base method.
-func (m *MockNotifyTarget) Expiries(arg0 []lease.Key) error {
+func (m *MockNotifyTarget) Expiries(arg0 []raftlease.Expired) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Expiries", arg0)
 	ret0, _ := ret[0].(error)

--- a/worker/raft/raftforwarder/worker.go
+++ b/worker/raft/raftforwarder/worker.go
@@ -31,6 +31,7 @@ type Logger interface {
 	Errorf(string, ...interface{})
 	Warningf(string, ...interface{})
 	Infof(string, ...interface{})
+	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})
 }
 

--- a/worker/raft/raftlease_mock_test.go
+++ b/worker/raft/raftlease_mock_test.go
@@ -50,7 +50,7 @@ func (mr *MockNotifyTargetMockRecorder) Claimed(arg0, arg1 interface{}) *gomock.
 }
 
 // Expiries mocks base method.
-func (m *MockNotifyTarget) Expiries(arg0 []lease.Key) error {
+func (m *MockNotifyTarget) Expiries(arg0 []raftlease.Expired) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Expiries", arg0)
 	ret0, _ := ret[0].(error)

--- a/worker/raft/raftlease_mock_test.go
+++ b/worker/raft/raftlease_mock_test.go
@@ -49,18 +49,18 @@ func (mr *MockNotifyTargetMockRecorder) Claimed(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Claimed", reflect.TypeOf((*MockNotifyTarget)(nil).Claimed), arg0, arg1)
 }
 
-// Expired mocks base method.
-func (m *MockNotifyTarget) Expired(arg0 lease.Key) error {
+// Expiries mocks base method.
+func (m *MockNotifyTarget) Expiries(arg0 []lease.Key) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Expired", arg0)
+	ret := m.ctrl.Call(m, "Expiries", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Expired indicates an expected call of Expired.
-func (mr *MockNotifyTargetMockRecorder) Expired(arg0 interface{}) *gomock.Call {
+// Expiries indicates an expected call of Expiries.
+func (mr *MockNotifyTargetMockRecorder) Expiries(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expired", reflect.TypeOf((*MockNotifyTarget)(nil).Expired), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expiries", reflect.TypeOf((*MockNotifyTarget)(nil).Expiries), arg0)
 }
 
 // MockFSMResponse is a mock of FSMResponse interface.

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -585,7 +585,7 @@ func (BootstrapNotifyTarget) Claimed(lease.Key, string) error {
 }
 
 // Expiries will be called when a set of existing leases have expired.
-func (BootstrapNotifyTarget) Expiries([]lease.Key) error {
+func (BootstrapNotifyTarget) Expiries([]raftlease.Expired) error {
 	return nil
 }
 

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -584,8 +584,8 @@ func (BootstrapNotifyTarget) Claimed(lease.Key, string) error {
 	return nil
 }
 
-// Expired will be called when an existing lease has expired.
-func (BootstrapNotifyTarget) Expired(lease.Key) error {
+// Expiries will be called when a set of existing leases have expired.
+func (BootstrapNotifyTarget) Expiries([]lease.Key) error {
 	return nil
 }
 


### PR DESCRIPTION
This is the forerunner to batching all the notify targets. Essentially this
is a best-effort of removing a lease. The next step would be
to batch all claims as well, but that can be done in another PR.

The following should easily benefit both pubsub and API raft lease
transports.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju enable-ha
$ juju deploy ubuntu -n 3
$ juju mongo
```

Ensure you have a claim in the database. Then remove the leader
via `remove-unit` or just stop the agent and wait for another one
to steal it.

```
$ juju remove-unit ubuntu/0
$ juju mongo
```

Ensure that someone else has claimed that lease.

JIRA: [JUJU-137]

[JUJU-137]: https://warthogs.atlassian.net/browse/JUJU-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ