### PR TITLE
[JUJU-148] Zero Latency Raft Op Batching

### DIFF
--- a/core/raft/queue/opqueue.go
+++ b/core/raft/queue/opqueue.go
@@ -134,6 +134,9 @@ func (q *OpQueue) loop() error {
 		}
 
 		ops := q.consume()
+		if len(ops) == 0 {
+			continue
+		}
 
 		// Send the batch operations.
 		select {
@@ -169,9 +172,7 @@ func (q *OpQueue) consume() []Operation {
 				return ops
 			}
 		default:
-			if len(ops) > 0 {
-				return ops
-			}
+			return ops
 		}
 	}
 }

--- a/core/raft/queue/opqueue.go
+++ b/core/raft/queue/opqueue.go
@@ -151,6 +151,10 @@ func (q *OpQueue) loop() error {
 // blocked :writers. We return whatever we have accrued whenever:
 // - There are no blocked writers.
 // - We reach the maximum batch size.
+// TODO (manadart 2021-11-08): Note that his batching takes effect when there
+// are multiple concurrent callers to the Raft client API, but *not* for a
+// batch of operations enqueued synchronously. Further work would be required
+// to accommodate such a scenario.
 func (q *OpQueue) consume() []Operation {
 	ops := make([]Operation, 0)
 


### PR DESCRIPTION
Trying to batch Raft operations based on a time-to-wait introduces a needless delay in processing sparse operations load.

Here we simply remove time-out concerns and batch up to the maximum allowable number if we can read off the queue, otherwise dispatch what we have. This should dramatically reduce latency.

We do retain a short pause in the consume loop for when there are no incoming results. This prevents a thrashing loop from monopolising CPU.

## QA steps

- Bootstrap to LXD with `--config features="[raft-api-leases,raft-batch-fsm]"`.
- `juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.raft=TRACE`.
- `juju enable-ha`.
- `for id in {1..20}; do juju deploy ubuntu "u$id"; done`.
- You *may* have to stop the containers and restart them en-mass to get batched op dispatching.
- `juju debug-log -m controller --replay|grep Dequeued`.
- There should be logs exhibiting batching like this:
```
machine-0: 11:14:48 TRACE juju.worker.raft Dequeued 3 commands to be applied on the raft log
```
- Bonus for publish times (though the scenario is controved): `juju debug-log -m controller --replay|grep elapsed`.
```
...
machine-0: 11:31:17 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 12ms
machine-0: 11:31:18 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 14ms
machine-1: 11:31:20 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 13ms
machine-1: 11:31:38 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 9ms
machine-2: 11:31:42 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 15ms
machine-2: 11:31:45 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 14ms
machine-0: 11:31:45 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 24ms
machine-0: 11:31:46 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 18ms
machine-2: 11:31:46 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 13ms
machine-0: 11:31:46 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 15ms
machine-0: 11:31:47 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 15ms
machine-0: 11:31:48 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 17ms
machine-1: 11:31:50 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 10ms
machine-1: 11:32:08 TRACE juju.core.raftlease runOnLeader extend, elapsed from publish: 16ms
```

## Documentation changes

None.

## Bug reference

N/A
