### PR TITLE
Fixes spelling error in bootstrap cred finalizer.

### DIFF
--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -622,8 +622,8 @@ func bootstrapIAAS(
 		environVersion = e.Provider().Version()
 	}
 
-	if finalizer, ok := environ.(environs.BootstrapCredentialsFinalizer); ok {
-		cred, err := finalizer.FinalizeBootstrapCredential(
+	if finalizer, ok := environ.(environs.BootstrapCredentialsFinaliser); ok {
+		cred, err := finalizer.FinaliseBootstrapCredential(
 			ctx,
 			bootstrapParams,
 			args.CloudCredential)

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -141,13 +141,13 @@ type ProviderCredentials interface {
 	) (*cloud.Credential, error)
 }
 
-// BootstrapCredentialsFinalizer is an interface for environs to provide a
+// BootstrapCredentialsFinaliser is an interface for environs to provide a
 // method for finalizing bootstrap credentials before being passed to a
 // newly bootstrapped controller.
-type BootstrapCredentialsFinalizer interface {
+type BootstrapCredentialsFinaliser interface {
 	// FinalizeBootstrapCredential finalizes credential as the last step of a
 	// bootstrap process.
-	FinalizeBootstrapCredential(BootstrapContext, BootstrapParams, *cloud.Credential) (*cloud.Credential, error)
+	FinaliseBootstrapCredential(BootstrapContext, BootstrapParams, *cloud.Credential) (*cloud.Credential, error)
 }
 
 // ProviderCredentialsRegister is an interface that an EnvironProvider

--- a/provider/ec2/client.go
+++ b/provider/ec2/client.go
@@ -47,6 +47,12 @@ type ClientFunc = func(context.Context, cloudspec.CloudSpec, ...ClientOption) (C
 
 // Client defines the subset of *ec2.Client methods that we currently use.
 type Client interface {
+	// STOP!!
+	// Are you about to add a new function to this interface?
+	// If so please make sure you update Juju permission policy on discourse
+	// here https://discourse.charmhub.io/t/juju-aws-permissions/5307
+	// We must keep this policy inline with our usage for operators that are
+	// using very strict permissions for Juju.
 	AssociateIamInstanceProfile(context.Context, *ec2.AssociateIamInstanceProfileInput, ...func(*ec2.Options)) (*ec2.AssociateIamInstanceProfileOutput, error)
 	DescribeIamInstanceProfileAssociations(context.Context, *ec2.DescribeIamInstanceProfileAssociationsInput, ...func(*ec2.Options)) (*ec2.DescribeIamInstanceProfileAssociationsOutput, error)
 	DescribeInstances(context.Context, *ec2.DescribeInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)

--- a/provider/ec2/iam.go
+++ b/provider/ec2/iam.go
@@ -39,6 +39,12 @@ type instanceProfileClient interface {
 // IAMClient is a subset interface of the AWS IAM client. This interface aims
 // to define the small set of what Juju's needs from the larger client.
 type IAMClient interface {
+	// STOP!!
+	// Are you about to add a new function to this interface?
+	// If so please make sure you update Juju permission policy on discourse
+	// here https://discourse.charmhub.io/t/juju-aws-permissions/5307
+	// We must keep this policy inline with our usage for operators that are
+	// using very strict permissions for Juju.
 	CreateInstanceProfile(stdcontext.Context, *iam.CreateInstanceProfileInput, ...func(*iam.Options)) (*iam.CreateInstanceProfileOutput, error)
 	GetInstanceProfile(stdcontext.Context, *iam.GetInstanceProfileInput, ...func(*iam.Options)) (*iam.GetInstanceProfileOutput, error)
 }


### PR DESCRIPTION
Spelling mistake in the boostrap credential finalizer interface was causing instance profile bootstrapping to not work properly.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Not required.

## Documentation changes

N/A

## Bug reference

N/A
