### PR TITLE
[JUJU-167] Retry azure api requests with an updated token if there's an auth failure

### DIFF
--- a/provider/azure/auth.go
+++ b/provider/azure/auth.go
@@ -5,6 +5,7 @@ package azure
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2016-06-01/subscriptions"
@@ -15,6 +16,7 @@ import (
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/provider/azure/internal/azureauth"
 	"github.com/juju/juju/provider/azure/internal/useragent"
+	"github.com/juju/juju/provider/common"
 )
 
 // cloudSpecAuth provides an implementation of autorest.Authorizer.
@@ -28,23 +30,43 @@ type cloudSpecAuth struct {
 
 func (c *cloudSpecAuth) auth() *autorest.BearerAuthorizerCallback {
 	return autorest.NewBearerAuthorizerCallback(c.sender, func(tenantID, resourceID string) (*autorest.BearerAuthorizer, error) {
-		token, err := c.getToken(resourceID)
+		token, resourceID, err := c.getToken(resourceID)
 		if err != nil {
-			return nil, errors.Annotate(err, "constructing service principal token for secret")
+			return nil, errors.Annotatef(err, "constructing service principal token for resource %q", resourceID)
 		}
 		return autorest.NewBearerAuthorizer(token), nil
 	})
 }
 
-func (c *cloudSpecAuth) refresh() error {
-	token, err := c.getToken("")
+func (c *cloudSpecAuth) refreshToken(resourceID string) error {
+	token, resourceID, err := c.getToken(resourceID)
 	if err != nil {
-		return err
+		return errors.Annotatef(err, "getting token to refresh for resource %q", resourceID)
 	}
-	return token.Refresh()
+	return errors.Annotatef(token.Refresh(), "refreshing token for resource %q", resourceID)
 }
 
-func (c *cloudSpecAuth) getToken(resourceID string) (*adal.ServicePrincipalToken, error) {
+func (c *cloudSpecAuth) purgeToken(resourceID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.tokens == nil {
+		return nil
+	}
+
+	if resourceID == "" {
+		var err error
+		resourceID, err = azureauth.ResourceManagerResourceId(c.cloud.StorageEndpoint)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	logger.Debugf("removing invalid token for %q", resourceID)
+	delete(c.tokens, resourceID)
+	return nil
+}
+
+func (c *cloudSpecAuth) getToken(resourceID string) (*adal.ServicePrincipalToken, string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.tokens == nil {
@@ -55,22 +77,22 @@ func (c *cloudSpecAuth) getToken(resourceID string) (*adal.ServicePrincipalToken
 		var err error
 		resourceID, err = azureauth.ResourceManagerResourceId(c.cloud.StorageEndpoint)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, "", errors.Trace(err)
 		}
 	}
 
 	if token := c.tokens[resourceID]; token != nil {
-		return token, nil
+		return token, resourceID, nil
 	}
 	logger.Debugf("get auth token for %v", resourceID)
 	token, tenantID, err := AuthToken(c.cloud, c.sender, resourceID)
 	if err != nil {
-		return nil, errors.Annotate(err, "constructing service principal token for secret")
+		return nil, resourceID, errors.Annotatef(err, "constructing service principal token for resource %q", resourceID)
 	}
 
 	c.tokens[resourceID] = token
 	c.tenantID = tenantID
-	return token, nil
+	return token, resourceID, nil
 }
 
 // AuthToken returns a service principal token, suitable for authorizing
@@ -83,6 +105,7 @@ func AuthToken(cloud environscloudspec.CloudSpec, sender autorest.Sender, resour
 		return nil, "", errors.NotSupportedf("auth-type %q", authType)
 	}
 
+	logger.Debugf("getting new auth token for resource %q", resourceID)
 	credAttrs := cloud.Credential.Attributes()
 	subscriptionId := credAttrs[credAttrSubscriptionId]
 	appId := credAttrs[credAttrAppId]
@@ -101,6 +124,10 @@ func AuthToken(cloud environscloudspec.CloudSpec, sender autorest.Sender, resour
 		appId,
 		appPassword,
 		resourceID,
+		func(t adal.Token) error {
+			logger.Debugf("auth token refreshed for resource %q", resourceID)
+			return nil
+		},
 	)
 	if err != nil {
 		return nil, "", errors.Annotate(err, "constructing service principal token")
@@ -110,4 +137,50 @@ func AuthToken(cloud environscloudspec.CloudSpec, sender autorest.Sender, resour
 	tokenClient.Sender = sender
 	token.SetSender(&tokenClient)
 	return token, tenantID, nil
+}
+
+// doRetryForStaleCredential is an autorest.SendDecorator which attempts to transparently
+// recover from situations where the oauth token has become stale. It will first attempt
+// to refresh the existing token, and if that fails, will get a brand new one using the
+// current service principal credential.
+func doRetryForStaleCredential(authorizer *cloudSpecAuth) autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (resp *http.Response, err error) {
+			rr := autorest.NewRetriableRequest(r)
+			// We make 3 attempts:
+			// 1. the original request
+			// 2. try again with a refreshed token
+			// 3. try again with a brand new token
+			for attempt := 1; attempt <= 3; attempt++ {
+				var refreshErr error
+				switch attempt {
+				case 2:
+					logger.Warningf("azure API call failed, attempting to refresh existing token: %v", err)
+					refreshErr = authorizer.refreshToken("")
+				case 3:
+					logger.Warningf("azure API call failed, attempting to replace token: %v", err)
+					refreshErr = authorizer.purgeToken("")
+				}
+				if refreshErr != nil {
+					return nil, errors.Errorf("send request failed: %v\nand could not refresh oauth token: %v", err, refreshErr)
+				}
+				if err = rr.Prepare(); err != nil {
+					return resp, errors.Trace(err)
+				}
+				if err = autorest.DrainResponseBody(resp); err != nil {
+					return resp, errors.Trace(err)
+				}
+				resp, err = s.Do(rr.Request())
+				// Exit if we get a non token refresh error.
+				if err != nil && !autorest.IsTokenRefreshError(err) {
+					break
+				}
+				// Exit if the response is not an auth issue.
+				if err == nil && !autorest.ResponseHasStatusCode(resp, common.AuthorisationFailureStatusCodes.Values()...) {
+					break
+				}
+			}
+			return resp, errors.Trace(err)
+		})
+	}
 }

--- a/provider/azure/deployments.go
+++ b/provider/azure/deployments.go
@@ -4,8 +4,6 @@
 package azure
 
 import (
-	stdcontext "context"
-
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	"github.com/juju/errors"
 
@@ -31,15 +29,11 @@ func createDeployment(
 			Mode:     resources.Incremental,
 		},
 	}
-	sdkCtx := stdcontext.Background()
 	_, err = client.CreateOrUpdate(
-		sdkCtx,
+		ctx,
 		resourceGroup,
 		deploymentName,
 		deployment,
 	)
-	if err != nil {
-		return errorutils.HandleCredentialError(errors.Annotatef(err, "creating deployment %q", deploymentName), ctx)
-	}
-	return nil
+	return errorutils.HandleCredentialError(errors.Annotatef(err, "creating deployment %q", deploymentName), ctx)
 }

--- a/provider/azure/environprovider.go
+++ b/provider/azure/environprovider.go
@@ -184,6 +184,7 @@ func validateCloudSpec(spec environscloudspec.CloudSpec) error {
 // error will be returned, and the original error will be logged at debug
 // level.
 var verifyCredentials = func(e *azureEnviron, ctx context.ProviderCallContext) error {
-	// TODO(axw) user-friendly error message
-	return errorutils.HandleCredentialError(e.authorizer.refresh(), ctx)
+	// This is used at bootstrap - the ctx invalid credential callback will log
+	// a suitable message.
+	return errorutils.HandleCredentialError(e.authorizer.refreshToken(""), ctx)
 }

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -65,7 +65,6 @@ func fakeServicePrincipalCredential() *cloud.Credential {
 
 func (s *environProviderSuite) TestPrepareConfig(c *gc.C) {
 	cfg := makeTestModelConfig(c)
-	s.sender = azuretesting.Senders{tokenRefreshSender()}
 	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
 		Cloud:  s.spec,
 		Config: cfg,

--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -57,7 +57,7 @@ func MaybeInvalidateCredential(err error, ctx context.ProviderCallContext) bool 
 	if ctx == nil {
 		return false
 	}
-	if !hasDenialStatusCode(err) {
+	if !HasDenialStatusCode(err) {
 		return false
 	}
 
@@ -69,7 +69,9 @@ func MaybeInvalidateCredential(err error, ctx context.ProviderCallContext) bool 
 	return true
 }
 
-func hasDenialStatusCode(err error) bool {
+// HasDenialStatusCode returns true of the error has a status code
+// meaning that the credential is invalid.
+func HasDenialStatusCode(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -78,7 +80,8 @@ func hasDenialStatusCode(err error) bool {
 		if d.Response != nil {
 			return common.AuthorisationFailureStatusCodes.Contains(d.Response.StatusCode)
 		}
-		return common.AuthorisationFailureStatusCodes.Contains(d.StatusCode.(int))
+		statusCode, _ := d.StatusCode.(int)
+		return common.AuthorisationFailureStatusCodes.Contains(statusCode)
 	}
 	return false
 }

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -46,6 +46,15 @@ func (s *ErrorSuite) TestNilContext(c *gc.C) {
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
 }
 
+func (s *ErrorSuite) TestHasDenialStatusCode(c *gc.C) {
+	c.Assert(errorutils.HasDenialStatusCode(
+		autorest.DetailedError{StatusCode: http.StatusUnauthorized}), jc.IsTrue)
+	c.Assert(errorutils.HasDenialStatusCode(
+		autorest.DetailedError{StatusCode: http.StatusNotFound}), jc.IsFalse)
+	c.Assert(errorutils.HasDenialStatusCode(nil), jc.IsFalse)
+	c.Assert(errorutils.HasDenialStatusCode(errors.New("FAIL")), jc.IsFalse)
+}
+
 func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx := context.NewEmptyCloudCallContext()
 	ctx.InvalidateCredentialFunc = func(msg string) error {

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -4,6 +4,7 @@
 package azure_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"net/http"
 
@@ -65,6 +66,7 @@ func (s *storageSuite) SetUpTest(c *gc.C) {
 	s.provider, err = env.StorageProvider("azure")
 	c.Assert(err, jc.ErrorIsNil)
 	s.cloudCallCtx = &context.CloudCallContext{
+		Context: stdcontext.TODO(),
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -272,12 +274,10 @@ func (s *storageSuite) TestCreateVolumes(c *gc.C) {
 	assertRequestBody(c, s.requests[4], makeDisk("volume-2", 1))
 }
 
-func (s *storageSuite) createSenderWithUnauthorisedStatusCode(c *gc.C) {
-	mockSender := mocks.NewSender()
-	mockSender.AppendResponse(mocks.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized))
-	s.sender = azuretesting.Senders{
-		mockSender,
-	}
+func (s *storageSuite) createSenderWithUnauthorisedStatusCode() {
+	unauthSender := mocks.NewSender()
+	unauthSender.AppendAndRepeatResponse(mocks.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized), 3)
+	s.sender = azuretesting.Senders{unauthSender, unauthSender, unauthSender}
 }
 
 func (s *storageSuite) TestCreateVolumesWithInvalidCredential(c *gc.C) {
@@ -305,7 +305,7 @@ func (s *storageSuite) TestCreateVolumesWithInvalidCredential(c *gc.C) {
 
 	volumeSource := s.volumeSource(c, false)
 	s.requests = nil
-	s.createSenderWithUnauthorisedStatusCode(c)
+	s.createSenderWithUnauthorisedStatusCode()
 
 	c.Assert(s.invalidCredential, jc.IsFalse)
 	results, err := volumeSource.CreateVolumes(s.cloudCallCtx, params)
@@ -322,11 +322,13 @@ func (s *storageSuite) TestCreateVolumesWithInvalidCredential(c *gc.C) {
 	c.Assert(s.invalidCredential, jc.IsTrue)
 
 	// Validate HTTP request bodies.
-	// account for the retry attemptd for volumes 1,2
-	c.Assert(s.requests, gc.HasLen, 5)
+	// account for the retry attempts for volumes 1,2
+	// The authorised workflow attempts to refresh to token so
+	// there's additional requests to account for as well.
+	c.Assert(s.requests, gc.HasLen, 7)
 	c.Assert(s.requests[0].Method, gc.Equals, "PUT") // create volume-0
-	c.Assert(s.requests[1].Method, gc.Equals, "PUT") // create volume-1
-	c.Assert(s.requests[3].Method, gc.Equals, "PUT") // create volume-2
+	c.Assert(s.requests[3].Method, gc.Equals, "PUT") // create volume-1
+	c.Assert(s.requests[5].Method, gc.Equals, "PUT") // create volume-2
 
 	makeDisk := func(name string, size int32) *compute.Disk {
 		tags := map[string]*string{
@@ -346,10 +348,10 @@ func (s *storageSuite) TestCreateVolumesWithInvalidCredential(c *gc.C) {
 			},
 		}
 	}
-	// account for the retry attemptd for volumes 1,2
+	// account for the retry attempts for volumes 1,2
 	assertRequestBody(c, s.requests[0], makeDisk("volume-0", 1))
-	assertRequestBody(c, s.requests[1], makeDisk("volume-1", 2))
-	assertRequestBody(c, s.requests[3], makeDisk("volume-2", 1))
+	assertRequestBody(c, s.requests[3], makeDisk("volume-1", 2))
+	assertRequestBody(c, s.requests[5], makeDisk("volume-2", 1))
 }
 
 func (s *storageSuite) TestCreateVolumesLegacy(c *gc.C) {
@@ -544,7 +546,7 @@ func (s *storageSuite) TestListVolumes(c *gc.C) {
 
 func (s *storageSuite) TestListVolumesWithInvalidCredential(c *gc.C) {
 	volumeSource := s.volumeSource(c, false)
-	s.createSenderWithUnauthorisedStatusCode(c)
+	s.createSenderWithUnauthorisedStatusCode()
 
 	c.Assert(s.invalidCredential, jc.IsFalse)
 	_, err := volumeSource.ListVolumes(s.cloudCallCtx)
@@ -628,7 +630,7 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 
 func (s *storageSuite) TestDescribeVolumesWithInvalidCredential(c *gc.C) {
 	volumeSource := s.volumeSource(c, false)
-	s.createSenderWithUnauthorisedStatusCode(c)
+	s.createSenderWithUnauthorisedStatusCode()
 
 	c.Assert(s.invalidCredential, jc.IsFalse)
 	_, err := volumeSource.DescribeVolumes(s.cloudCallCtx, []string{"volume-0"})
@@ -718,7 +720,7 @@ func (s *storageSuite) TestDestroyVolumes(c *gc.C) {
 func (s *storageSuite) TestDestroyVolumesWithInvalidCredential(c *gc.C) {
 	volumeSource := s.volumeSource(c, false)
 
-	s.createSenderWithUnauthorisedStatusCode(c)
+	s.createSenderWithUnauthorisedStatusCode()
 	c.Assert(s.invalidCredential, jc.IsFalse)
 	results, err := volumeSource.DestroyVolumes(s.cloudCallCtx, []string{"volume-0"})
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/azure/upgrades_test.go
+++ b/provider/azure/upgrades_test.go
@@ -4,6 +4,7 @@
 package azure_test
 
 import (
+	stdcontext "context"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
@@ -50,6 +51,7 @@ func (s *environUpgradeSuite) SetUpTest(c *gc.C) {
 	s.requests = nil
 	s.invalidCredential = false
 	s.callCtx = &context.CloudCallContext{
+		Context: stdcontext.TODO(),
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -221,9 +223,9 @@ func (s *environUpgradeSuite) TestEnvironUpgradeOperationCreateCommonDeploymentC
 	trueString := "true"
 	controllerTags["juju-is-controller"] = &trueString
 
-	mockSender := mocks.NewSender()
-	mockSender.AppendResponse(mocks.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized))
-	s.sender = append(s.sender, mockSender)
+	unauthSender := mocks.NewSender()
+	unauthSender.AppendAndRepeatResponse(mocks.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized), 3)
+	s.sender = append(s.sender, unauthSender, tokenRefreshSender(), unauthSender, unauthSender)
 
 	c.Assert(s.invalidCredential, jc.IsFalse)
 	op0 := upgrader.UpgradeOperations(s.callCtx, environs.UpgradeOperationsParams{})[0]


### PR DESCRIPTION
Juju uses a service principal oauth token when making api requests to azure.
It seems that despite auto refresh being true, the token can go stale and api requests start returning 401, and this causes juju to suspend the model as the credential has become invalid.

The user can reset things by running `update-credential` with the exact same credential - this effectively causes a new token to be generated.

This PR adds a new send decorator to the azure client request sender; the decorator will respond to auth failures by trying to:
- refresh the current token manually, and if that fails
- generate a whole new token using the cloud credential
After each of the above, the request is retried.

There was a slight refactor of the `getToken` method to allow better logging.

In addition, azure has a built in decorator that can transparently retry requests if there's been transient failures. This is added also, which should make the azure provider more robust.

Finally, there were some places where the juju environ provider context was not being used to make azure api calls,so this has been fixed also.

## QA steps

It's hard to fully test without an expired oauth token. I just bootstrapped a controller and destroyed it to ensure the provider is still functional. I also added a temporary decorator which randomly returned an invalid credential error.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1841880

