### PR TITLE
[JUJU-177] Check for available disk space before doing a juju backup

### DIFF
--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -56,7 +56,7 @@ func (a *APIv2) Create(args params.BackupsCreateArgs) (params.BackupsMetadataRes
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	dbInfo, err := backups.NewDBInfo(mgoInfo, session, mongoVersion)
+	dbInfo, err := backups.NewDBInfo(mgoInfo, sessionShim{session}, mongoVersion)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/client/backups/shim.go
+++ b/apiserver/facades/client/backups/shim.go
@@ -5,12 +5,14 @@ package backups
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/backups"
 )
 
 // This file contains untested shims to let us wrap state in a sensible
@@ -108,4 +110,12 @@ type Machine interface {
 
 	// Series has machine's series.
 	Series() string
+}
+
+type sessionShim struct {
+	*mgo.Session
+}
+
+func (s sessionShim) DB(name string) backups.Database {
+	return s.Session.DB(name)
 }

--- a/state/backups/archive.go
+++ b/state/backups/archive.go
@@ -62,7 +62,7 @@ func NewCanonicalArchivePaths() ArchivePaths {
 	}
 }
 
-// NonCanonicalArchivePaths builds a new ArchivePaths using default
+// NewNonCanonicalArchivePaths builds a new ArchivePaths using default
 // values, rooted at the provided rootDir. The path separator used is
 // platform-dependent. The resulting paths are suitable for locating
 // backup archive contents in a directory into which an archive has
@@ -131,7 +131,7 @@ func (ws *ArchiveWorkspace) UnpackFilesBundle(targetRoot string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer tarFile.Close()
+	defer func() { _ = tarFile.Close() }()
 
 	err = tar.UntarFiles(tarFile, targetRoot)
 	return errors.Trace(err)
@@ -151,7 +151,7 @@ func (ws *ArchiveWorkspace) OpenBundledFile(filename string) (io.Reader, error) 
 
 	_, file, err := tar.FindFile(tarFile, filename)
 	if err != nil {
-		tarFile.Close()
+		_ = tarFile.Close()
 		return nil, errors.Trace(err)
 	}
 	return file, nil
@@ -163,7 +163,7 @@ func (ws *ArchiveWorkspace) Metadata() (*Metadata, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	defer metaFile.Close()
+	defer func() { _ = metaFile.Close() }()
 
 	meta, err := NewMetadataJSONReader(metaFile)
 	return meta, errors.Trace(err)
@@ -189,7 +189,7 @@ func NewArchiveData(data []byte) *ArchiveData {
 	}
 }
 
-// NewArchiveReader returns a new archive data wrapper for the data in
+// NewArchiveDataReader returns a new archive data wrapper for the data in
 // the provided reader. Note that the entire archive will be read into
 // memory and kept there. So for relatively large archives it will often
 // be more appropriate to use ArchiveWorkspace instead.
@@ -198,7 +198,7 @@ func NewArchiveDataReader(r io.Reader) (*ArchiveData, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	defer gzr.Close()
+	defer func() { _ = gzr.Close() }()
 
 	data, err := ioutil.ReadAll(gzr)
 	if err != nil {

--- a/state/backups/backups.go
+++ b/state/backups/backups.go
@@ -72,6 +72,9 @@ var (
 	availableDisk = func(path string) uint64 {
 		return du.NewDiskUsage(path).Available()
 	}
+	totalDisk = func(path string) uint64 {
+		return du.NewDiskUsage(path).Size()
+	}
 	dirSize = totalDirSize
 )
 
@@ -186,6 +189,7 @@ func (b *backups) Create(meta *Metadata, paths *Paths, dbInfo *DBInfo, keepCopy,
 		filesToBackUp:          filesToBackUp,
 		db:                     dumper,
 		availableDisk:          availableDisk,
+		totalDisk:              totalDisk,
 		metadataReader:         metadataFile,
 		noDownload:             noDownload,
 		approxSpaceRequiredMib: int(totalFizeSizesMiB),

--- a/state/backups/backups.go
+++ b/state/backups/backups.go
@@ -39,12 +39,15 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	"github.com/juju/utils/v2/du"
 	"github.com/juju/utils/v2/filestorage"
 )
 
@@ -65,7 +68,11 @@ var (
 	finishMeta       = func(meta *Metadata, result *createResult) error {
 		return meta.MarkComplete(result.size, result.checksum)
 	}
-	storeArchive = StoreArchive
+	storeArchive  = StoreArchive
+	availableDisk = func(path string) uint64 {
+		return du.NewDiskUsage(path).Available()
+	}
+	dirSize = totalDirSize
 )
 
 // StoreArchive sends the backup archive and its metadata to storage.
@@ -120,6 +127,20 @@ func NewBackups(stor filestorage.FileStorage) Backups {
 	return &b
 }
 
+func totalDirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
+}
+
 // Create creates and stores a new juju backup archive (based on arguments)
 // and updates the provided metadata.  A filename to download the backup is provided.
 func (b *backups) Create(meta *Metadata, paths *Paths, dbInfo *DBInfo, keepCopy, noDownload bool) (string, error) {
@@ -137,22 +158,43 @@ func (b *backups) Create(meta *Metadata, paths *Paths, dbInfo *DBInfo, keepCopy,
 	}
 
 	// Create the archive.
-	filesToBackUp, err := getFilesToBackUp("", paths, meta.Origin.Machine)
+	filesToBackUp, err := getFilesToBackUp("", paths)
 	if err != nil {
 		return "", errors.Annotate(err, "while listing files to back up")
 	}
+
+	var totalFileSizes int64
+	for _, f := range filesToBackUp {
+		size, err := dirSize(f)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		totalFileSizes += size
+	}
+
+	totalFizeSizesMiB := int64(dbInfo.ApproxSizeMB) + totalFileSizes/humanize.MiByte
+	logger.Infof("backing up %dMiB (files) and %dMiB (database) = %dMiB",
+		totalFizeSizesMiB, dbInfo.ApproxSizeMB, int(totalFizeSizesMiB)+dbInfo.ApproxSizeMB)
 
 	dumper, err := getDBDumper(dbInfo)
 	if err != nil {
 		return "", errors.Annotate(err, "while preparing for DB dump")
 	}
 
-	args := createArgs{paths.BackupDir, filesToBackUp, dumper, metadataFile, noDownload}
+	args := createArgs{
+		backupDir:              paths.BackupDir,
+		filesToBackUp:          filesToBackUp,
+		db:                     dumper,
+		availableDisk:          availableDisk,
+		metadataReader:         metadataFile,
+		noDownload:             noDownload,
+		approxSpaceRequiredMib: int(totalFizeSizesMiB),
+	}
 	result, err := runCreate(&args)
 	if err != nil {
 		return "", errors.Annotate(err, "while creating backup archive")
 	}
-	defer result.archiveFile.Close()
+	defer func() { _ = result.archiveFile.Close() }()
 
 	// Finalize the metadata.
 	err = finishMeta(meta, result)
@@ -169,6 +211,12 @@ func (b *backups) Create(meta *Metadata, paths *Paths, dbInfo *DBInfo, keepCopy,
 	}
 
 	return result.filename, nil
+}
+
+type diskUsage struct{}
+
+func (diskUsage) Available(path string) uint64 {
+	return du.NewDiskUsage(path).Available()
 }
 
 // Add stores the backup archive and returns its new ID.

--- a/state/backups/backups_test.go
+++ b/state/backups/backups_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"time" // Only used for time types.
 
+	"github.com/dustin/go-humanize"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -26,6 +27,10 @@ type backupsSuite struct {
 	backupstesting.BaseSuite
 
 	api backups.Backups
+
+	availableDiskMiB uint64
+	dirSizeBytes     int64
+	dbSizeMiB        int
 }
 
 var _ = gc.Suite(&backupsSuite{}) // Register the suite.
@@ -34,6 +39,12 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	s.api = backups.NewBackups(s.Storage)
+	s.PatchValue(backups.AvailableDisk, func(string) uint64 {
+		return s.availableDiskMiB
+	})
+	s.PatchValue(backups.DirSize, func(path string) (int64, error) {
+		return s.dirSizeBytes, nil
+	})
 }
 
 func (s *backupsSuite) setStored(id string) *time.Time {
@@ -58,7 +69,10 @@ func (s *backupsSuite) checkFailure(c *gc.C, expected string) {
 
 	paths := backups.Paths{DataDir: "/var/lib/juju"}
 	targets := set.NewStrings("juju", "admin")
-	dbInfo := backups.DBInfo{"a", "b", "c", targets, mongo.Mongo32wt}
+	dbInfo := backups.DBInfo{
+		Address: "a", Username: "b", Password: "c",
+		Targets:      targets,
+		MongoVersion: mongo.Mongo32wt, ApproxSizeMB: s.dbSizeMiB}
 	meta := backupstesting.NewMetadataStarted()
 	meta.Notes = "some notes"
 
@@ -98,7 +112,7 @@ func (s *backupsSuite) testCreateOkay(c *gc.C, keepCopy, noDownload bool) {
 	s.PatchValue(backups.RunCreate, testCreate)
 
 	rootDir := "<was never set>"
-	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths, oldmachine string) ([]string, error) {
+	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths) ([]string, error) {
 		rootDir = root
 		return []string{"<some file>"}, nil
 	})
@@ -114,7 +128,10 @@ func (s *backupsSuite) testCreateOkay(c *gc.C, keepCopy, noDownload bool) {
 	// Run the backup.
 	paths := backups.Paths{BackupDir: backupDir, DataDir: dataDir}
 	targets := set.NewStrings("juju", "admin")
-	dbInfo := backups.DBInfo{"a", "b", "c", targets, mongo.Mongo32wt}
+	dbInfo := backups.DBInfo{
+		Address: "a", Username: "b", Password: "c",
+		Targets:      targets,
+		MongoVersion: mongo.Mongo32wt, ApproxSizeMB: s.dbSizeMiB}
 	meta := backupstesting.NewMetadataStarted()
 	backupstesting.SetOrigin(meta, "<model ID>", "<machine ID>", "<hostname>")
 	meta.Notes = "some notes"
@@ -166,7 +183,7 @@ func (s *backupsSuite) testCreateOkay(c *gc.C, keepCopy, noDownload bool) {
 }
 
 func (s *backupsSuite) TestCreateFailToListFiles(c *gc.C) {
-	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths, oldmachine string) ([]string, error) {
+	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths) ([]string, error) {
 		return nil, errors.New("failed!")
 	})
 
@@ -174,7 +191,7 @@ func (s *backupsSuite) TestCreateFailToListFiles(c *gc.C) {
 }
 
 func (s *backupsSuite) TestCreateFailToCreate(c *gc.C) {
-	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths, oldmachine string) ([]string, error) {
+	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths) ([]string, error) {
 		return []string{}, nil
 	})
 	s.PatchValue(backups.RunCreate, backups.NewTestCreateFailure("failed!"))
@@ -183,7 +200,7 @@ func (s *backupsSuite) TestCreateFailToCreate(c *gc.C) {
 }
 
 func (s *backupsSuite) TestCreateFailToFinishMeta(c *gc.C) {
-	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths, oldmachine string) ([]string, error) {
+	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths) ([]string, error) {
 		return []string{}, nil
 	})
 	_, testCreate := backups.NewTestCreate(nil)
@@ -194,7 +211,7 @@ func (s *backupsSuite) TestCreateFailToFinishMeta(c *gc.C) {
 }
 
 func (s *backupsSuite) TestCreateFailToStoreArchive(c *gc.C) {
-	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths, oldmachine string) ([]string, error) {
+	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths) ([]string, error) {
 		return []string{}, nil
 	})
 	_, testCreate := backups.NewTestCreate(nil)
@@ -222,15 +239,17 @@ func (s *backupsSuite) TestStoreArchive(c *gc.C) {
 
 func (s *backupsSuite) TestGetFileName(c *gc.C) {
 	backupDir := c.MkDir()
-	os.MkdirAll(backupDir, 0644)
+	err := os.MkdirAll(backupDir, 0644)
+	c.Assert(err, jc.ErrorIsNil)
 	backupFilename := path.Join(backupDir, backups.TempFilename)
 	backupFile, err := os.Create(backupFilename)
 	c.Assert(err, jc.ErrorIsNil)
-	backupFile.Write([]byte("archive file testing"))
+	_, err = backupFile.Write([]byte("archive file testing"))
+	c.Assert(err, jc.ErrorIsNil)
 
 	resultMeta, resultArchive, err := s.api.Get(backupFilename)
 	c.Assert(err, jc.ErrorIsNil)
-	defer resultArchive.Close()
+	defer func() { _ = resultArchive.Close() }()
 	resultMeta.FileMetadata.Checksum()
 
 	// Purpose for metadata here is for the checksum to be used by the
@@ -242,4 +261,26 @@ func (s *backupsSuite) TestGetFileName(c *gc.C) {
 
 	_, err = ioutil.ReadDir(backupDir)
 	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("open %s: no such file or directory", backupDir))
+}
+
+func (s *backupsSuite) TestNotEnoughDiskSpaceSmallBackup(c *gc.C) {
+	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths) ([]string, error) {
+		return []string{"file1"}, nil
+	})
+	s.dbSizeMiB = 6
+	s.dirSizeBytes = 3 * humanize.MiByte
+	s.availableDiskMiB = 10 * humanize.MiByte
+
+	s.checkFailure(c, "while creating backup archive: not enough free space in .*; want 5129MiB, have 10MiB")
+}
+
+func (s *backupsSuite) TestNotEnoughDiskSpaceLargeBackup(c *gc.C) {
+	s.PatchValue(backups.TestGetFilesToBackUp, func(root string, paths *backups.Paths) ([]string, error) {
+		return []string{"file1"}, nil
+	})
+	s.dbSizeMiB = 100
+	s.dirSizeBytes = 50 * humanize.GiByte
+	s.availableDiskMiB = 10 * humanize.MiByte
+
+	s.checkFailure(c, "while creating backup archive: not enough free space in .*; want 61560MiB, have 10MiB")
 }

--- a/state/backups/db_dump_test.go
+++ b/state/backups/db_dump_test.go
@@ -31,7 +31,10 @@ func (s *dumpSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	targets := set.NewStrings("juju", "admin")
-	s.dbInfo = &backups.DBInfo{"a", "b", "c", targets, mongo.Mongo24}
+	s.dbInfo = &backups.DBInfo{
+		Address: "a", Username: "b", Password: "c",
+		Targets:      targets,
+		MongoVersion: mongo.Mongo24, ApproxSizeMB: 100}
 	s.targets = targets
 	s.dumpDir = c.MkDir()
 }

--- a/state/backups/db_info_test.go
+++ b/state/backups/db_info_test.go
@@ -4,6 +4,9 @@
 package backups_test
 
 import (
+	"github.com/dustin/go-humanize"
+	"github.com/juju/errors"
+	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -21,14 +24,42 @@ type dbInfoSuite struct {
 
 type fakeSession struct {
 	dbNames []string
+	db      *fakeDatabase
+}
+
+type fakeDatabase struct {
+	result bson.M
 }
 
 func (f *fakeSession) DatabaseNames() ([]string, error) {
 	return f.dbNames, nil
 }
 
+func (f *fakeSession) DB(name string) backups.Database {
+	return f.db
+}
+
+func (f *fakeDatabase) Run(cmd interface{}, result interface{}) error {
+	cmdInfo, ok := cmd.(bson.D)
+	if !ok || len(cmdInfo) < 2 {
+		return errors.Errorf("unexpected cmd data %#v", cmd)
+	}
+	if name := cmdInfo[0].Name; name != "dbStats" {
+		return errors.Errorf("unexpected cmd %q", name)
+	}
+	if cmdInfo[1].Name != "scale" || cmdInfo[1].Value != humanize.MiByte {
+		return errors.Errorf("unexpected cmd parameter %#v", cmdInfo[1])
+	}
+	*(result.(*bson.M)) = f.result
+	return nil
+}
+
 func (s *dbInfoSuite) TestNewDBInfoOkay(c *gc.C) {
-	session := fakeSession{}
+	session := fakeSession{
+		dbNames: []string{"juju"},
+		db: &fakeDatabase{
+			result: bson.M{"dataSize": 666.0},
+		}}
 
 	tag, err := names.ParseTag("machine-0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -45,6 +76,7 @@ func (s *dbInfoSuite) TestNewDBInfoOkay(c *gc.C) {
 	c.Check(dbInfo.Address, gc.Equals, "localhost:8080")
 	c.Check(dbInfo.Username, gc.Equals, "machine-0")
 	c.Check(dbInfo.Password, gc.Equals, "eggs")
+	c.Check(dbInfo.ApproxSizeMB, gc.Equals, 666)
 }
 
 func (s *dbInfoSuite) TestNewDBInfoMissingTag(c *gc.C) {

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -30,6 +30,8 @@ var (
 	RunCommand            = &runCommandFn
 	ReplaceableFolders    = &replaceableFolders
 	MongoInstalledVersion = &mongoInstalledVersion
+	AvailableDisk         = &availableDisk
+	DirSize               = &dirSize
 )
 
 var _ filestorage.DocStorage = (*backupsDocStorage)(nil)
@@ -101,6 +103,9 @@ func NewTestCreateArgs(backupDir string, filesToBackUp []string, db DBDumper, me
 		db:             db,
 		metadataReader: metar,
 		noDownload:     noDownload,
+		availableDisk: func(string) uint64 {
+			return 6666 * 1024 * 1024
+		},
 	}
 	return &args
 }

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -31,6 +31,7 @@ var (
 	ReplaceableFolders    = &replaceableFolders
 	MongoInstalledVersion = &mongoInstalledVersion
 	AvailableDisk         = &availableDisk
+	TotalDisk             = &totalDisk
 	DirSize               = &dirSize
 )
 
@@ -105,6 +106,9 @@ func NewTestCreateArgs(backupDir string, filesToBackUp []string, db DBDumper, me
 		noDownload:     noDownload,
 		availableDisk: func(string) uint64 {
 			return 6666 * 1024 * 1024
+		},
+		totalDisk: func(string) uint64 {
+			return 8666 * 1024 * 1024
 		},
 	}
 	return &args

--- a/state/backups/files.go
+++ b/state/backups/files.go
@@ -41,9 +41,14 @@ type Paths struct {
 	LogsDir   string
 }
 
+// DiskUsage instances are used to find disk usage for a path.
+type DiskUsage interface {
+	Available(path string) uint64
+}
+
 // GetFilesToBackUp returns the paths that should be included in the
 // backup archive.
-func GetFilesToBackUp(rootDir string, paths *Paths, oldmachine string) ([]string, error) {
+func GetFilesToBackUp(rootDir string, paths *Paths) ([]string, error) {
 	var glob string
 
 	glob = filepath.Join(rootDir, paths.DataDir, agentsDir, agentsConfs)

--- a/state/backups/files_test.go
+++ b/state/backups/files_test.go
@@ -112,19 +112,21 @@ func (s *filesSuite) checkSameStrings(c *gc.C, actual, expected []string) {
 	}
 }
 
-func (s *filesSuite) TestGetFilesToBackUpMachine0(c *gc.C) {
+func (s *filesSuite) TestGetFilesToBackUp(c *gc.C) {
 	paths := backups.Paths{
 		DataDir: "/var/lib/juju",
 		LogsDir: "/var/log/juju",
 	}
 	s.createFiles(c, paths, s.root, "0", false)
+	s.createFiles(c, paths, s.root, "1", false)
 
-	files, err := backups.GetFilesToBackUp(s.root, &paths, "0")
+	files, err := backups.GetFilesToBackUp(s.root, &paths)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := []string{
 		filepath.Join(s.root, "/home/ubuntu/.ssh/authorized_keys"),
 		filepath.Join(s.root, "/var/lib/juju/agents/machine-0.conf"),
+		filepath.Join(s.root, "/var/lib/juju/agents/machine-1.conf"),
 		filepath.Join(s.root, "/var/lib/juju/nonce.txt"),
 		filepath.Join(s.root, "/var/lib/juju/server.pem"),
 		filepath.Join(s.root, "/var/lib/juju/shared-secret"),
@@ -227,30 +229,6 @@ func (s *filesSuite) TestReplaceableFoldersMongo3(c *gc.C) {
 	})
 }
 
-func (s *filesSuite) TestGetFilesToBackUpMachine10(c *gc.C) {
-	paths := backups.Paths{
-		DataDir: "/var/lib/juju",
-		LogsDir: "/var/log/juju",
-	}
-	s.createFiles(c, paths, s.root, "10", false)
-
-	files, err := backups.GetFilesToBackUp(s.root, &paths, "10")
-	c.Assert(err, jc.ErrorIsNil)
-
-	expected := []string{
-		filepath.Join(s.root, "/home/ubuntu/.ssh/authorized_keys"),
-		filepath.Join(s.root, "/var/lib/juju/agents/machine-10.conf"),
-		filepath.Join(s.root, "/var/lib/juju/nonce.txt"),
-		filepath.Join(s.root, "/var/lib/juju/server.pem"),
-		filepath.Join(s.root, "/var/lib/juju/shared-secret"),
-		filepath.Join(s.root, "/var/lib/juju/system-identity"),
-		filepath.Join(s.root, "/var/lib/juju/tools"),
-		filepath.Join(s.root, "/var/lib/juju/init/juju-db"),
-	}
-	c.Check(files, jc.SameContents, expected)
-	s.checkSameStrings(c, files, expected)
-}
-
 func (s *filesSuite) TestGetFilesToBackUpMissing(c *gc.C) {
 	paths := backups.Paths{
 		DataDir: "/var/lib/juju",
@@ -267,7 +245,7 @@ func (s *filesSuite) TestGetFilesToBackUpMissing(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	files, err := backups.GetFilesToBackUp(s.root, &paths, "0")
+	files, err := backups.GetFilesToBackUp(s.root, &paths)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := []string{
@@ -291,7 +269,7 @@ func (s *filesSuite) TestGetFilesToBackUpSnap(c *gc.C) {
 	}
 	s.createFiles(c, paths, s.root, "0", true)
 
-	files, err := backups.GetFilesToBackUp(s.root, &paths, "0")
+	files, err := backups.GetFilesToBackUp(s.root, &paths)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := []string{


### PR DESCRIPTION
When doing a `juju create-backup`, we should check for available disk space to ensure there's enough room.

This PR adds that check - it will run a mongo `dbStats` on each database we are backing up, plus gets the size of each directory in the backup set. We then check that there's at least an extra 20% buffer free, or 5GiB, whichever is greater.

Also did some lint cleanup as a driveby.

## QA steps

bootstrap and run `juju create-backup`

## Bug reference

https://bugs.launchpad.net/juju/+bug/1693780
