### PR TITLE
[JUJU-121] Adds support for auto create of instance profiles.

### DIFF
--- a/environs/broker.go
+++ b/environs/broker.go
@@ -93,7 +93,7 @@ type StartInstanceParams struct {
 
 	// CleanupCallback is a callback to be used to clean up any residual
 	// status-reporting output from StatusCallback.
-	CleanupCallback func(info string) error
+	CleanupCallback func() error
 
 	// StatusCallback is a callback to be used by the instance to report
 	// changes in status. Its signature is consistent with other

--- a/environs/instancerole.go
+++ b/environs/instancerole.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environs
+
+import (
+	"github.com/juju/juju/environs/context"
+)
+
+const (
+	// InstanceProfileAutoCreate defines the const value used for the constraint
+	// when instance profile creation should be done on behalf of the user.
+	InstanceProfileAutoCreate = "auto"
+)
+
+// InstanceRole defines the interface for environ providers to implement when
+// they offer InstanceRole support for their respective cloud.
+type InstanceRole interface {
+	// CreateAutoInstanceRole is responsible for setting up an instance role on
+	// behalf of the user.
+	CreateAutoInstanceRole(context.ProviderCallContext, BootstrapParams) (string, error)
+
+	// SupportsInstanceRoles indicates if Instance Roles are supported by this
+	// environ.
+	SupportsInstanceRoles(context.ProviderCallContext) bool
+}

--- a/provider/ec2/client.go
+++ b/provider/ec2/client.go
@@ -53,6 +53,9 @@ type Client interface {
 	// here https://discourse.charmhub.io/t/juju-aws-permissions/5307
 	// We must keep this policy inline with our usage for operators that are
 	// using very strict permissions for Juju.
+	//
+	// You must also update the controllerRolePolicy document found in
+	// iam_docs.go.
 	AssociateIamInstanceProfile(context.Context, *ec2.AssociateIamInstanceProfileInput, ...func(*ec2.Options)) (*ec2.AssociateIamInstanceProfileOutput, error)
 	DescribeIamInstanceProfileAssociations(context.Context, *ec2.DescribeIamInstanceProfileAssociationsInput, ...func(*ec2.Options)) (*ec2.DescribeIamInstanceProfileAssociationsOutput, error)
 	DescribeInstances(context.Context, *ec2.DescribeInstancesInput, ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)

--- a/provider/ec2/config.go
+++ b/provider/ec2/config.go
@@ -12,13 +12,6 @@ import (
 	"github.com/juju/juju/environs/config"
 )
 
-const (
-	// awsInstanceProfileAutoCreateVal is the key used for the instance profile
-	// constraint to tell Juju to auto create an instance profile in AWS for the
-	// machine. This is only used for bootstrapped controllers.
-	awsInstanceProfileAutoCreateVal = "auto"
-)
-
 var configSchema = environschema.Fields{
 	"vpc-id": {
 		Description: "Use a specific AWS VPC ID (optional). When not specified, Juju requires a default VPC or EC2-Classic features to be available for the account/region.",

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -194,15 +194,6 @@ func (e *environ) FinaliseBootstrapCredential(
 	}
 
 	instanceRoleName := *args.BootstrapConstraints.InstanceRole
-	if instanceRoleName == awsInstanceProfileAutoCreateVal {
-		controllerName, ok := args.ControllerConfig[controller.ControllerName].(string)
-		if !ok {
-			return cred, errors.NewNotValid(nil, "cannot find controller name in config")
-		}
-
-		instanceRoleName = controllerInstanceProfileName(controllerName)
-	}
-
 	newCred := cloud.NewCredential(cloud.InstanceRoleAuthType, map[string]string{
 		"instance-profile-name": instanceRoleName,
 	})
@@ -212,33 +203,39 @@ func (e *environ) FinaliseBootstrapCredential(
 // Bootstrap is part of the Environ interface.
 func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.ProviderCallContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
 	// We are going to take a look at the Bootstrap constraints and see if we have to make an instance profile
-	if args.BootstrapConstraints.HasInstanceRole() &&
-		*args.BootstrapConstraints.InstanceRole == awsInstanceProfileAutoCreateVal {
-		_, exists := args.ControllerConfig[controller.ControllerName]
-		if !exists {
-			return nil, errors.NewNotValid(nil, "cannot find controller name in config")
-		}
-		controllerName, ok := args.ControllerConfig[controller.ControllerName].(string)
-		if !ok {
-			return nil, errors.NewNotValid(nil, "controller name in config is not a valid string")
-		}
-		controllerUUID := args.ControllerConfig[controller.ControllerUUIDKey].(string)
-		instProfile, cleanups, err := ensureControllerInstanceProfile(
-			ctx.Context(),
-			e.iamClient,
-			controllerName,
-			controllerUUID)
-		if err != nil {
-			for _, c := range cleanups {
-				c()
-			}
-			return nil, err
-		}
-		args.BootstrapConstraints.InstanceRole = instProfile.InstanceProfileName
-	}
-
 	r, err := common.Bootstrap(ctx, e, callCtx, args)
 	return r, maybeConvertCredentialError(err, callCtx)
+}
+
+func (e *environ) CreateAutoInstanceRole(
+	ctx context.ProviderCallContext,
+	args environs.BootstrapParams,
+) (string, error) {
+	_, exists := args.ControllerConfig[controller.ControllerName]
+	if !exists {
+		return "", errors.NewNotValid(nil, "cannot find controller name in config")
+	}
+	controllerName, ok := args.ControllerConfig[controller.ControllerName].(string)
+	if !ok {
+		return "", errors.NewNotValid(nil, "controller name in config is not a valid string")
+	}
+	controllerUUID := args.ControllerConfig[controller.ControllerUUIDKey].(string)
+	instProfile, cleanups, err := ensureControllerInstanceProfile(
+		ctx,
+		e.iamClient,
+		controllerName,
+		controllerUUID)
+	if err != nil {
+		for _, c := range cleanups {
+			c()
+		}
+		return "", err
+	}
+	return *instProfile.InstanceProfileName, nil
+}
+
+func (e *environ) SupportsInstanceRoles(_ context.ProviderCallContext) bool {
+	return true
 }
 
 // SupportsSpaces is specified on environs.Networking.

--- a/provider/ec2/iam_docs.go
+++ b/provider/ec2/iam_docs.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ec2
+
+const (
+	// controllerRoleAssumePolicy describes the polciy for the controller roll
+	// stating what principals can assume the role. We only allow ec2 instances
+	// in this case.
+	controllerRoleAssumePolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+	  "Principal": {
+	    "Service": "ec2.amazonaws.com"
+	  },
+	  "Action": "sts:AssumeRole"
+	}
+  ]
+}
+`
+	// controllerRolePolicy is the AWS IAM policy used for controller role
+	// permissions. This JSON document must be kept in line with the AWS
+	// permissions used by Juju.
+	controllerRolePolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "JujuEC2Actions",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AssociateIamInstanceProfile",
+        "ec2:AttachVolume",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteVolume",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeIamInstanceProfileAssociations",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSpotPriceHistory",
+        "ec2:DescribeSubnets",
+        "ec2:DescibeVolumes",
+        "ec2:DescribeVpcs",
+        "ec2:DetachVolume",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "JujuIAMActions",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateInstanceProfile",
+		"iam:CreateRole",
+		"iam:DeleteInstanceProfile",
+		"iam:DeleteRole",
+		"iam:DeleteRolePolicy",
+        "iam:GetInstanceProfile",
+		"iam:GetRole",
+		"iam:PutRolePolicy",
+		"iam:RemoveRoleFromInstanceProfile"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "JujuSSMActions",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:ListInstanceAssociations",
+        "ssm:UpdateInstanceInformation"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+`
+)

--- a/provider/ec2/iam_docs.go
+++ b/provider/ec2/iam_docs.go
@@ -50,7 +50,7 @@ const (
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSpotPriceHistory",
         "ec2:DescribeSubnets",
-        "ec2:DescibeVolumes",
+        "ec2:DescribeVolumes",
         "ec2:DescribeVpcs",
         "ec2:DetachVolume",
         "ec2:RevokeSecurityGroupIngress",
@@ -70,6 +70,7 @@ const (
 		"iam:DeleteRolePolicy",
         "iam:GetInstanceProfile",
 		"iam:GetRole",
+		"iam:PassRole",
 		"iam:PutRolePolicy",
 		"iam:RemoveRoleFromInstanceProfile"
       ],

--- a/provider/ec2/iam_test.go
+++ b/provider/ec2/iam_test.go
@@ -4,26 +4,13 @@
 package ec2
 
 import (
-	//	"context"
-	//	"net/http"
-	//	time "time"
-	//
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	//	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
-	"github.com/aws/aws-sdk-go-v2/service/iam"
-
-	//	"github.com/aws/aws-sdk-go-v2/service/iam/types"
-	//	smithyhttp "github.com/aws/smithy-go/transport/http"
-	//	"github.com/juju/errors"
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	//
-	//	"github.com/juju/juju/environs/tags"
 
 	"github.com/juju/juju/provider/ec2/internal/testing"
 )

--- a/provider/ec2/internal/testing/iam_server.go
+++ b/provider/ec2/internal/testing/iam_server.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+type InlinePolicy struct {
+	PolicyDocument *string
+	PolicyName     *string
+}
+
+// IAMServer implements an IAM simulator for use in testing
+type IAMServer struct {
+	mu sync.Mutex
+
+	instanceProfiles map[string]*types.InstanceProfile
+	roles            map[string]*types.Role
+	roleInlinePolicy map[string]*InlinePolicy
+}
+
+func NewIAMServer() (*IAMServer, error) {
+	srv := &IAMServer{}
+	srv.Reset()
+	return srv, nil
+}
+
+func (i *IAMServer) Reset() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.instanceProfiles = make(map[string]*types.InstanceProfile)
+	i.roles = make(map[string]*types.Role)
+	i.roleInlinePolicy = make(map[string]*InlinePolicy)
+}

--- a/provider/ec2/internal/testing/instanceprofile.go
+++ b/provider/ec2/internal/testing/instanceprofile.go
@@ -1,0 +1,143 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+func (i *IAMServer) AddRoleToInstanceProfile(
+	ctx context.Context,
+	input *iam.AddRoleToInstanceProfileInput,
+	opts ...func(*iam.Options),
+) (*iam.AddRoleToInstanceProfileOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	role, exists := i.roles[*input.RoleName]
+	if !exists {
+		return nil, apiError("InvalidRole.NotFound", "role not found")
+	}
+
+	instanceProfile, exists := i.instanceProfiles[*input.InstanceProfileName]
+	if !exists {
+		return nil, apiError("InvalidInstanceProfile.NotFound", "instance profile not found")
+	}
+
+	if len(instanceProfile.Roles) != 0 {
+		return nil, apiError("InstanceProfile", "already has role attached")
+	}
+
+	instanceProfile.Roles = []types.Role{*role}
+	return &iam.AddRoleToInstanceProfileOutput{}, nil
+}
+
+func (i *IAMServer) CreateInstanceProfile(
+	ctx context.Context,
+	input *iam.CreateInstanceProfileInput,
+	opts ...func(*iam.Options),
+) (*iam.CreateInstanceProfileOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if ip, exists := i.instanceProfiles[*input.InstanceProfileName]; exists {
+		return &iam.CreateInstanceProfileOutput{
+				InstanceProfile: ip,
+			}, &types.EntityAlreadyExistsException{
+				Message: aws.String(fmt.Sprintf("instance profile %s", *input.InstanceProfileName)),
+			}
+	}
+
+	createDate := time.Now()
+	i.instanceProfiles[*input.InstanceProfileName] = &types.InstanceProfile{
+		Arn:                 input.InstanceProfileName,
+		CreateDate:          &createDate,
+		InstanceProfileName: input.InstanceProfileName,
+		Path:                input.Path,
+		Tags:                input.Tags,
+	}
+	return &iam.CreateInstanceProfileOutput{
+		InstanceProfile: i.instanceProfiles[*input.InstanceProfileName],
+	}, nil
+}
+
+func (i *IAMServer) DeleteInstanceProfile(
+	ctx context.Context,
+	input *iam.DeleteInstanceProfileInput,
+	opts ...func(*iam.Options),
+) (*iam.DeleteInstanceProfileOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if _, exists := i.instanceProfiles[*input.InstanceProfileName]; !exists {
+		return nil, apiError("InvalidInstanceProfile.NotFound", "instance profile not found")
+	}
+
+	delete(i.instanceProfiles, *input.InstanceProfileName)
+	return &iam.DeleteInstanceProfileOutput{}, nil
+}
+
+func (i *IAMServer) GetInstanceProfile(
+	ctx context.Context,
+	input *iam.GetInstanceProfileInput,
+	opts ...func(*iam.Options),
+) (*iam.GetInstanceProfileOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	ip, exists := i.instanceProfiles[*input.InstanceProfileName]
+	if !exists {
+		return nil, &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{
+					&http.Response{
+						StatusCode: http.StatusNotFound,
+					},
+				},
+			},
+		}
+	}
+
+	return &iam.GetInstanceProfileOutput{
+		InstanceProfile: ip,
+	}, nil
+}
+
+func (i *IAMServer) RemoveRoleFromInstanceProfile(
+	ctx context.Context,
+	input *iam.RemoveRoleFromInstanceProfileInput,
+	opts ...func(*iam.Options),
+) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	ip, exists := i.instanceProfiles[*input.InstanceProfileName]
+	if !exists {
+		return nil, apiError("InvalidInstanceProfile.NotFound", "instance profile not found")
+	}
+
+	if len(ip.Roles) > 1 {
+		return nil, apiError("InvalidInstanceProfile.RoleCount", "Instance profile has more then 1 role")
+	} else if len(ip.Roles) == 0 {
+		return nil, apiError("InvalidInstanceProfile.NoRole", "Instance profile has no role attached")
+	}
+
+	if *ip.Roles[1].RoleName != *input.RoleName {
+		return nil, apiError(
+			"InvalidInstanceProfile.Role",
+			"role %s is not attached to instance profile", *ip.Roles[1].RoleName)
+	}
+
+	ip.Roles = []types.Role{}
+	return &iam.RemoveRoleFromInstanceProfileOutput{}, nil
+}

--- a/provider/ec2/internal/testing/roles.go
+++ b/provider/ec2/internal/testing/roles.go
@@ -1,0 +1,134 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+func (i *IAMServer) CreateRole(
+	ctx context.Context,
+	input *iam.CreateRoleInput,
+	opts ...func(*iam.Options),
+) (*iam.CreateRoleOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if role, exists := i.roles[*input.RoleName]; exists {
+		return &iam.CreateRoleOutput{
+				Role: role,
+			}, &types.EntityAlreadyExistsException{
+				Message: aws.String(fmt.Sprintf("role %s", *input.RoleName)),
+			}
+	}
+
+	createDate := time.Now()
+	i.roles[*input.RoleName] = &types.Role{
+		Arn:                      input.RoleName,
+		CreateDate:               &createDate,
+		RoleName:                 input.RoleName,
+		AssumeRolePolicyDocument: input.AssumeRolePolicyDocument,
+		Description:              input.Description,
+		MaxSessionDuration:       input.MaxSessionDuration,
+		Path:                     input.Path,
+		Tags:                     input.Tags,
+	}
+
+	return &iam.CreateRoleOutput{
+		Role: i.roles[*input.RoleName],
+	}, nil
+}
+
+func (i *IAMServer) DeleteRole(
+	ctx context.Context,
+	input *iam.DeleteRoleInput,
+	opts ...func(*iam.Options),
+) (*iam.DeleteRoleOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if _, exists := i.roles[*input.RoleName]; !exists {
+		return nil, apiError("InvalidRole.NotFound", "role not found")
+	}
+
+	delete(i.roleInlinePolicy, *input.RoleName)
+	delete(i.roles, *input.RoleName)
+	return &iam.DeleteRoleOutput{}, nil
+}
+
+func (i *IAMServer) DeleteRolePolicy(
+	ctx context.Context,
+	input *iam.DeleteRolePolicyInput,
+	opts ...func(*iam.Options),
+) (*iam.DeleteRolePolicyOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	inlinePolicy, exists := i.roleInlinePolicy[*input.RoleName]
+	if !exists {
+		return nil, apiError("InvalidRolePolicy.NotFound", "role has no policy")
+	}
+
+	if *inlinePolicy.PolicyName != *input.PolicyName {
+		return nil, apiError("InvalidRolePolicy.NotFound", "role has no policy")
+	}
+
+	delete(i.roleInlinePolicy, *input.RoleName)
+	return &iam.DeleteRolePolicyOutput{}, nil
+}
+
+func (i *IAMServer) GetRole(
+	ctx context.Context,
+	input *iam.GetRoleInput,
+	opts ...func(*iam.Options),
+) (*iam.GetRoleOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	role, exists := i.roles[*input.RoleName]
+	if !exists {
+		return nil, &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{
+					&http.Response{
+						StatusCode: http.StatusNotFound,
+					},
+				},
+			},
+		}
+	}
+	return &iam.GetRoleOutput{
+		Role: role,
+	}, nil
+}
+
+func (i *IAMServer) PutRolePolicy(
+	ctx context.Context,
+	input *iam.PutRolePolicyInput,
+	opts ...func(*iam.Options),
+) (*iam.PutRolePolicyOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	role, exists := i.roles[*input.RoleName]
+	if !exists {
+		return nil, apiError("InvalidRole.NotFound", "role not found")
+	}
+
+	inlinePolicy := &InlinePolicy{
+		PolicyDocument: input.PolicyDocument,
+		PolicyName:     input.PolicyName,
+	}
+
+	i.roleInlinePolicy[*role.RoleName] = inlinePolicy
+	return &iam.PutRolePolicyOutput{}, nil
+}

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -94,19 +94,15 @@ func (env *environ) newContainer(
 	// are made, instead of at a higher level in the package, so as not to
 	// assume that all providers will have the same need to be implemented
 	// in the same way.
-	longestMsg := 0
 	statusCallback := func(currentStatus status.Status, msg string, data map[string]interface{}) error {
 		if args.StatusCallback != nil {
 			_ = args.StatusCallback(currentStatus, msg, nil)
-		}
-		if len(msg) > longestMsg {
-			longestMsg = len(msg)
 		}
 		return nil
 	}
 	cleanupCallback := func() {
 		if args.CleanupCallback != nil {
-			_ = args.CleanupCallback(strings.Repeat(" ", longestMsg))
+			_ = args.CleanupCallback()
 		}
 	}
 	defer cleanupCallback()

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -25,6 +25,7 @@ type constraintsDoc struct {
 	Mem              *uint64
 	RootDisk         *uint64
 	RootDiskSource   *string
+	InstanceRole     *string
 	InstanceType     *string
 	Container        *instance.ContainerType
 	Tags             *[]string
@@ -43,6 +44,7 @@ func newConstraintsDoc(cons constraints.Value, id string) constraintsDoc {
 		Mem:              cons.Mem,
 		RootDisk:         cons.RootDisk,
 		RootDiskSource:   cons.RootDiskSource,
+		InstanceRole:     cons.InstanceRole,
 		InstanceType:     cons.InstanceType,
 		Container:        cons.Container,
 		Tags:             cons.Tags,
@@ -62,6 +64,7 @@ func (doc constraintsDoc) value() constraints.Value {
 		Mem:              doc.Mem,
 		RootDisk:         doc.RootDisk,
 		RootDiskSource:   doc.RootDiskSource,
+		InstanceRole:     doc.InstanceRole,
 		InstanceType:     doc.InstanceType,
 		Container:        doc.Container,
 		Tags:             doc.Tags,

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -584,6 +584,7 @@ func (s *MigrationSuite) TestConstraintsDocFields(c *gc.C) {
 		"Mem",
 		"RootDisk",
 		"RootDiskSource",
+		"InstanceRole",
 		"InstanceType",
 		"Container",
 		"Tags",


### PR DESCRIPTION
This commit adds support instance profiles auto creation. Including the associated role and policy needed to scope permissions correctly.

Accompanying this PR is also a discourse doc on the permissions Juju requires when talking with AWS.

## QA steps

```sh
juju bootstrap --bootstrap-constraints="instance-role=auto" aws/ap-southeast-2 test-tlm-controller
```

You then need to confirm with the aws cli that the associated instance profile elements were created. Make sure that you see a role with the same here attached to the instance profile.

```sh
aws iam get-instance-profile --instance-profile-name juju-controller-test-tlm-controller
```

Add some machines to Juju and deploy a charm with storage to confirm permissions are operating correctly.

Check HA works

```
$ juju enable-ha
juju enable-ha
maintaining machines: 0
adding machines: 1, 2
$ juju status
Model       Controller     Cloud/Region        Version   SLA          Timestamp
controller  test-tlm-controller aws/ap-southeast-2  2.9.20.1  unsupported  09:34:28+10:00

Machine  State    DNS           Inst id              Series  AZ               Message
0        started  13.211.59.65  i-f00f00f00f00f00f00  focal   ap-southeast-2b  running
1        pending                pending              focal                    attaching aws instance profile arn:aws:iam::123456789:instance-profile/juju-controller-test-tlm-controller
2        pending                pending              focal                    attaching aws instance profile arn:aws:iam::123456789:instance-profile/juju-controller-test-tlm-controller
```

Check destroy-controller works
```
$ juju destroy-controller test-tlm-controller --destroy-all-models
```

## Documentation changes

Permission list: https://discourse.charmhub.io/t/juju-aws-permissions/5307
Doc Link: https://discourse.charmhub.io/t/using-aws-instance-profiles-with-juju-2-9/5185/3

## Bug reference

N/A
