### PR TITLE
[JUJU-180] Correct affected unit reporting in upgrade-series

### DIFF
--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -322,12 +322,13 @@ func (c *upgradeSeriesCommand) retrieveUnits() ([]string, error) {
 	var units []string
 	for _, application := range fullStatus.Applications {
 		for name, unit := range application.Units {
-			if unit.Machine == machineID {
-				units = append(units, name)
+			if unit.Machine != machineID {
+				continue
 			}
+			units = append(units, name)
 			for subName, subordinate := range unit.Subordinates {
 				if subordinate.Machine != "" && subordinate.Machine != machineID {
-					return nil, errors.Errorf("subordinate %q machine has unexpected instance id %s", subName, machineID)
+					return nil, errors.Errorf("subordinate %q machine has unexpected machine id %s", subName, machineID)
 				}
 				units = append(units, subName)
 			}


### PR DESCRIPTION

A simple error in the unit processing loop for that _upgrade-series_ command was incorrectly reporting all subordinate units for a related application as being affected, rather than just those on the machine.

This is corrected.

## QA steps

- `juju deploy ubuntu -n 2`.
- `juju deploy ntp`.
- `juju relate ubuntu ntp`
- `juju upgrade-series 0 prepare focal`
- Observe the prompt reads:
```
Units running on the machine will also be upgraded. These units include:
  - ntp/0
  - ubuntu/0
```
Instead of:
```
Units running on the machine will also be upgraded. These units include:
  - ntp/0
  - ntp/1
  - ubuntu/0
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1940960
