### PR TITLE
[JUJU-185] Use the correct ingress resource version for the k8s cluster

### DIFF
--- a/caas/kubernetes/provider/specs/ingress.go
+++ b/caas/kubernetes/provider/specs/ingress.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -64,4 +65,138 @@ func (ing K8sIngress) Validate() error {
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// IngressSpecToV1 converts a beta1 spec to the equivalent v1 version.
+func IngressSpecToV1(in *networkingv1beta1.IngressSpec) *networkingv1.IngressSpec {
+	if in == nil {
+		return nil
+	}
+	out := &networkingv1.IngressSpec{
+		IngressClassName: in.IngressClassName,
+		DefaultBackend:   backendToV1(in.Backend),
+	}
+	for _, tls := range in.TLS {
+		out.TLS = append(out.TLS, networkingv1.IngressTLS{
+			Hosts:      tls.Hosts,
+			SecretName: tls.SecretName,
+		})
+	}
+	for _, rule := range in.Rules {
+		out.Rules = append(out.Rules, networkingv1.IngressRule{
+			Host: rule.Host,
+			IngressRuleValue: networkingv1.IngressRuleValue{
+				HTTP: httpRuleToV1(rule.HTTP),
+			},
+		})
+	}
+	return out
+}
+
+func backendToV1(in *networkingv1beta1.IngressBackend) *networkingv1.IngressBackend {
+	if in == nil {
+		return nil
+	}
+	out := &networkingv1.IngressBackend{
+		Service:  serviceToV1(in),
+		Resource: in.Resource,
+	}
+	return out
+}
+
+func serviceToV1(in *networkingv1beta1.IngressBackend) *networkingv1.IngressServiceBackend {
+	if in == nil || in.ServiceName == "" {
+		return nil
+	}
+	out := &networkingv1.IngressServiceBackend{
+		Name: in.ServiceName,
+		Port: networkingv1.ServiceBackendPort{
+			Name:   in.ServicePort.StrVal,
+			Number: in.ServicePort.IntVal,
+		},
+	}
+	return out
+}
+
+func httpRuleToV1(in *networkingv1beta1.HTTPIngressRuleValue) *networkingv1.HTTPIngressRuleValue {
+	if in == nil {
+		return nil
+	}
+	out := &networkingv1.HTTPIngressRuleValue{}
+	for _, path := range in.Paths {
+		outPath := networkingv1.HTTPIngressPath{
+			Path:    path.Path,
+			Backend: *backendToV1(&path.Backend),
+		}
+		pathType := networkingv1.PathTypeImplementationSpecific
+		if path.PathType != nil {
+			pathType = networkingv1.PathType(*path.PathType)
+		}
+		outPath.PathType = &pathType
+		out.Paths = append(out.Paths, outPath)
+	}
+	return out
+}
+
+// IngressSpecFromV1 converts a v1 spec to the equivalent v1beta1 version.
+func IngressSpecFromV1(in *networkingv1.IngressSpec) *networkingv1beta1.IngressSpec {
+	if in == nil {
+		return nil
+	}
+	out := &networkingv1beta1.IngressSpec{
+		IngressClassName: in.IngressClassName,
+		Backend:          backendToBeta1(in.DefaultBackend),
+	}
+	for _, tls := range in.TLS {
+		out.TLS = append(out.TLS, networkingv1beta1.IngressTLS{
+			Hosts:      tls.Hosts,
+			SecretName: tls.SecretName,
+		})
+	}
+	for _, rule := range in.Rules {
+		out.Rules = append(out.Rules, networkingv1beta1.IngressRule{
+			Host: rule.Host,
+			IngressRuleValue: networkingv1beta1.IngressRuleValue{
+				HTTP: httpRuleToBeta1(rule.HTTP),
+			},
+		})
+	}
+	return out
+}
+
+func backendToBeta1(in *networkingv1.IngressBackend) *networkingv1beta1.IngressBackend {
+	if in == nil {
+		return nil
+	}
+	out := &networkingv1beta1.IngressBackend{
+		Resource: in.Resource,
+	}
+	if in.Service != nil {
+		out.ServiceName = in.Service.Name
+		if in.Service.Port.Name != "" {
+			out.ServicePort = intstr.FromString(in.Service.Port.Name)
+		} else {
+			out.ServicePort = intstr.FromInt(int(in.Service.Port.Number))
+		}
+	}
+	return out
+}
+
+func httpRuleToBeta1(in *networkingv1.HTTPIngressRuleValue) *networkingv1beta1.HTTPIngressRuleValue {
+	if in == nil {
+		return nil
+	}
+	out := &networkingv1beta1.HTTPIngressRuleValue{}
+	for _, path := range in.Paths {
+		outPath := networkingv1beta1.HTTPIngressPath{
+			Path:    path.Path,
+			Backend: *backendToBeta1(&path.Backend),
+		}
+		if path.PathType != nil {
+			pathType := networkingv1beta1.PathType(*path.PathType)
+			outPath.PathType = &pathType
+		}
+		out.Paths = append(out.Paths, outPath)
+	}
+	return out
 }


### PR DESCRIPTION
k8s from 1.22 onwards drops support for the networkingv1beta1 api. This breaks charms that still want to specify beta1 ingress resources. And even if the charms are upgraded to use the v1 ingress definition, they cannot then be deployed on older k8s.

This PR detects the k8s version is use and if necessary, converts the ingress resource spec from the charm to match. k8s 1.19 onwards supports v1.

## QA steps

On microk8s 1.22, deploy a charm still using v1beta1 ingress resources.
On microk8s 1.18, deploy a charm still using v1 ingress resources.

## Bug reference

Partial fix for:
https://bugs.launchpad.net/juju/+bug/1939278

(crds not converted, only ingress resources)
