### PR TITLE
[JUJU-186] Raft client logging levels

### DIFF
--- a/api/raftlease/client.go
+++ b/api/raftlease/client.go
@@ -29,6 +29,8 @@ import (
 // Logger is a in place interface to represent a logger for consuming.
 type Logger interface {
 	Errorf(string, ...interface{})
+	Warningf(string, ...interface{})
+	Infof(string, ...interface{})
 	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})
 }
@@ -150,7 +152,7 @@ func (c *Client) Request(ctx context.Context, command *raftlease.Command) error 
 		// If we can't find a remote server for any reason, then return an
 		// ErrDropped. This will cause the lease manager to correctly retry.
 		if errors.IsNotFound(err) {
-			c.config.Logger.Errorf("Masking %q with lease.ErrDropped to allow for retries", err)
+			c.config.Logger.Debugf("Masking %q with lease.ErrDropped to allow for retries", err)
 			return lease.ErrDropped
 		}
 		return errors.Trace(err)
@@ -220,7 +222,7 @@ func (c *Client) handleRetryRequestError(command *raftlease.Command, remote Remo
 		if notLeaderError.ServerAddress() == "" {
 			// The raft instance isn't clustered, we don't have a way
 			// forward, so send back a dropped error.
-			c.config.Logger.Errorf("No leader found and no cluster available, dropping command: %v", command)
+			c.config.Logger.Infof("No leader found and no cluster available, dropping command: %v", command)
 		}
 
 		// If it is a not leader error and we haven't got a remote, just
@@ -231,7 +233,7 @@ func (c *Client) handleRetryRequestError(command *raftlease.Command, remote Remo
 		// Enqueuing into the queue just timed out, we should just
 		// log this error and try again if possible. The lease manager
 		// will know if a retry at that level is possible.
-		c.config.Logger.Errorf("Deadline exceeded enqueuing command.")
+		c.config.Logger.Warningf("Rate limit enqueuing %q command. Deadline exceeded for lease %s model: %v.", command.Operation, command.Lease, command.ModelUUID)
 		return remote, lease.ErrDropped
 	}
 
@@ -448,7 +450,7 @@ func (c *Client) ensureServers(addresses map[string]string) error {
 		if err := remote.Wait(); err != nil {
 			// We don't care in reality about the death rattle of a server, as
 			// it's already dead to us.
-			c.config.Logger.Errorf("error waiting for remote server death: %v", err)
+			c.config.Logger.Warningf("error waiting for remote server death: %v", err)
 		}
 		// Ensure we still delete the id from the server list, even though the
 		// remote Wait might have failed.

--- a/api/raftlease/client_test.go
+++ b/api/raftlease/client_test.go
@@ -616,9 +616,11 @@ func (s *RaftLeaseRemoteSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 type fakeLogger struct{}
 
-func (fakeLogger) Errorf(string, ...interface{}) {}
-func (fakeLogger) Debugf(string, ...interface{}) {}
-func (fakeLogger) Tracef(string, ...interface{}) {}
+func (fakeLogger) Errorf(string, ...interface{})   {}
+func (fakeLogger) Warningf(string, ...interface{}) {}
+func (fakeLogger) Infof(string, ...interface{})    {}
+func (fakeLogger) Debugf(string, ...interface{})   {}
+func (fakeLogger) Tracef(string, ...interface{})   {}
 
 type fakeClientMetrics struct{}
 

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -33,6 +33,7 @@ import (
 
 type Logger interface {
 	Errorf(string, ...interface{})
+	Warningf(string, ...interface{})
 	Infof(string, ...interface{})
 	Debugf(string, ...interface{})
 	Tracef(string, ...interface{})


### PR DESCRIPTION
The logging levels for the raft lease client were all set at error. This
prevented the operator from really understanding what is classified as a
real error. The following drops the levels from error to something more
appropriate, whilst also adding more context to some.

## QA steps

See for Q&A steps https://github.com/juju/juju/pull/13453
