### PR TITLE
[JUJU-154] [2.9] Refactor provisioning task to improve parallelism

### DIFF
--- a/api/controller/legacy_test.go
+++ b/api/controller/legacy_test.go
@@ -184,6 +184,10 @@ func (s *legacySuite) TestWatchAllModels(c *gc.C) {
 		case float64:
 			modelInfo.Config[config.NetBondReconfigureDelayKey] = int(val)
 		}
+		switch val := modelInfo.Config[config.NumProvisionWorkersKey].(type) {
+		case float64:
+			modelInfo.Config[config.NumProvisionWorkersKey] = int(val)
+		}
 
 		expectedStatus := params.StatusInfo{
 			Current: status.Status,

--- a/core/workerpool/package_test.go
+++ b/core/workerpool/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workerpool
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
+}

--- a/core/workerpool/workerpool.go
+++ b/core/workerpool/workerpool.go
@@ -1,0 +1,162 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workerpool
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/juju/errors"
+)
+
+// Logger defines the logging methods that the worker pool uses.
+type Logger interface {
+	Errorf(string, ...interface{})
+	Debugf(string, ...interface{})
+}
+
+// Task represents a unit of work which should be executed by the pool workers.
+type Task struct {
+	// Type is a short, optional description of the task which will be
+	// included in emitted log messages.
+	Type string
+
+	// Process encapsulates the logic for processing a task.
+	Process func() error
+}
+
+// WorkerPool implements a fixed-size worker pool for processing tasks in
+// parallel. If any of the tasks fails, the pool workers will be shut down, and
+// any detected errors (different tasks may fail concurrently) will be
+// consolidated and reported when the pool's Close() method is invoked.
+//
+// New tasks can be enqueued by writing to the channel returned by the
+// pool's Queue() method while the pool's Done() method returns a channel
+// which can be used by callers to detect when an error occurred and the
+// pool is shutting down.
+type WorkerPool struct {
+	logger Logger
+
+	// A channel used to signal workers that they should finish their
+	// work and exit.
+	shutdownTriggerCh chan struct{}
+
+	// The worker pool can be stopped either via a call to Shutdown() or
+	// directly by one of the workers when it encounters an error. A
+	// sync.Once primitive ensures that the shutdown trigger channel can
+	// only be closed once.
+	shutdownTrigger   sync.Once
+	closeErrorChannel sync.Once
+
+	// A waitgroup for ensuring that all workers have exited. It is used
+	// both when the pool is being shutdown and also as a barrier to ensure
+	// that workers have exited before draining the error reporting channel.
+	wg sync.WaitGroup
+
+	// A buffered channel (cap equal to pool size) which workers monitor
+	// for incoming processing tasks.
+	taskQueueCh chan Task
+
+	// A buffered channel (cap equal to pool size) which workers emit
+	// any errors they encounter before taskuesting the pool to be shut
+	// down.
+	taskErrCh chan error
+}
+
+// NewWorkerPool returns a pool with the taskuested number of workers. Callers
+// must ensure to call the pool's Close() method to avoid leaking goroutines.
+func NewWorkerPool(logger Logger, size int) *WorkerPool {
+	// Size must be at least one
+	if size <= 0 {
+		size = 1
+	}
+
+	wp := &WorkerPool{
+		logger:            logger,
+		shutdownTriggerCh: make(chan struct{}),
+		taskQueueCh:       make(chan Task, size),
+		taskErrCh:         make(chan error, size),
+	}
+
+	wp.wg.Add(size)
+	for workerID := 0; workerID < size; workerID++ {
+		go wp.taskWorker(workerID)
+	}
+
+	return wp
+}
+
+// Size returns the number of workers in the pool.
+func (wp *WorkerPool) Size() int {
+	return cap(wp.taskQueueCh)
+}
+
+// Queue returns a channel for enqueueing processing tasks.
+func (wp *WorkerPool) Queue() chan<- Task {
+	return wp.taskQueueCh
+}
+
+// Done returns a channel which is closed if the pool has detected one or more
+// errors and is shutting down. Callers must then invoke the pool's Close method
+// to obtain any reported errors.
+func (wp *WorkerPool) Done() <-chan struct{} {
+	return wp.shutdownTriggerCh
+}
+
+// Close the pool and return any queued errors. The method signals and waits
+// for all workers to exit before draining the worker error channel and
+// returning a combined error (if any errors were reported) value. After a call
+// to Shutdown, no further provision tasks will be accepted by the pool.
+func (wp *WorkerPool) Close() error {
+	wp.triggerShutdown()
+	wp.wg.Wait() // wait for workers to exit and write any errors they encounter
+
+	// Now we can safely close and drain the error channel.
+	wp.closeErrorChannel.Do(func() {
+		close(wp.taskErrCh)
+	})
+
+	var errList []string
+	for err := range wp.taskErrCh {
+		errList = append(errList, err.Error())
+	}
+
+	if len(errList) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(errList, "\n"))
+}
+
+func (wp *WorkerPool) taskWorker(workerID int) {
+	defer wp.wg.Done()
+	for {
+		select {
+		case task := <-wp.taskQueueCh:
+			wp.logger.Debugf("worker %d: processing a %q task", workerID, task.Type)
+			if err := task.Process(); err != nil {
+				wp.logger.Errorf("worker %d: shutting down pool due to error while handling a %q task: %v", workerID, task.Type, err)
+
+				// This is a buffered channel to allow every pool worker to report
+				// a single error before it exits. Consequently, this call can never
+				// block.
+				wp.taskErrCh <- err
+				wp.triggerShutdown()
+
+				return // worker cannot process any further tasks.
+			}
+		case <-wp.shutdownTriggerCh:
+			wp.logger.Debugf("worker %d: terminating as worker pool is shutting down", workerID)
+			return
+		}
+	}
+}
+
+// triggerShutdown notifies all workers to exit once they complete the tasks
+// they are currently processing. Workers can only be notified once; subsequent
+// calls to this method are no-ops.
+func (wp *WorkerPool) triggerShutdown() {
+	wp.shutdownTrigger.Do(func() {
+		close(wp.shutdownTriggerCh)
+	})
+}

--- a/core/workerpool/workerpool_test.go
+++ b/core/workerpool/workerpool_test.go
@@ -1,0 +1,104 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package workerpool
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/errors"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+)
+
+var _ = gc.Suite(&ProvisionerWorkerPoolSuite{})
+
+type ProvisionerWorkerPoolSuite struct {
+}
+
+func (s *ProvisionerWorkerPoolSuite) TestProcessMoreTasksThanWorkers(c *gc.C) {
+	doneCh := make(chan struct{}, 10)
+	wp := NewWorkerPool(loggo.GetLogger("test"), 5)
+	c.Assert(wp.Size(), gc.Equals, 5)
+
+	for i := 0; i < 10; i++ {
+		task := Task{
+			Type: "alien invasion",
+			Process: func() error {
+				doneCh <- struct{}{}
+				return nil
+			},
+		}
+
+		select {
+		case wp.Queue() <- task:
+		case <-time.After(coretesting.LongWait):
+			c.Fatal("timeout waiting to enqueue task")
+		}
+	}
+
+	for i := 0; i < 10; i++ {
+		select {
+		case <-doneCh: // task ACK'd
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("timeout waiting for task %d to complete", i)
+		}
+	}
+
+	// Shutdown the pool and ensure that no errors got reported.
+	c.Assert(wp.Close(), jc.ErrorIsNil)
+}
+
+func (s *ProvisionerWorkerPoolSuite) TestConsolidateErrors(c *gc.C) {
+	var (
+		wg      sync.WaitGroup
+		barrier = make(chan struct{})
+		wp      = NewWorkerPool(loggo.GetLogger("test"), 3)
+	)
+
+	wg.Add(3)
+	for i := 0; i < 3; i++ {
+		// The even-numbered workers emit an error while the odd ones
+		// do not.
+		var expErr error
+		var task = Task{Type: "alien abduction"}
+		if i%2 == 0 {
+			expErr = errors.Errorf("worker %d out of fuel error", i)
+		}
+		task.Process = func() error {
+			// Signal that we are ready to process and wait for
+			// barrier to be released.
+			wg.Done()
+			<-barrier
+
+			return expErr
+		}
+
+		select {
+		case wp.Queue() <- task:
+		case <-time.After(coretesting.LongWait):
+			c.Fatal("timeout waiting to enqueue task")
+		}
+	}
+
+	// Wait for each worker to grab a taskuest and the lift the barrier
+	wg.Wait()
+	close(barrier)
+
+	// Wait for all workers to complete and exit
+	err := wp.Close()
+	c.Assert(err, gc.Not(gc.IsNil), gc.Commentf("expected individual worker errors to be consolidated into a single error"))
+
+	// Errors can appear in any order so we need to sort them first
+	errLines := strings.Split(err.Error(), "\n")
+	c.Assert(len(errLines), gc.Equals, 2, gc.Commentf("expected 2 errors to be consolidated"))
+	sort.Strings(errLines)
+	c.Assert(errLines[0], gc.Equals, "worker 0 out of fuel error")
+	c.Assert(errLines[1], gc.Equals, "worker 2 out of fuel error")
+}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -75,6 +75,10 @@ const (
 	// ProvisionerHarvestModeKey stores the key for this setting.
 	ProvisionerHarvestModeKey = "provisioner-harvest-mode"
 
+	// NumProvisionWorkersKey is the key for the number of provisioner
+	// workers settings.
+	NumProvisionWorkersKey = "num-provision-workers"
+
 	// AgentStreamKey stores the key for this setting.
 	AgentStreamKey = "agent-stream"
 
@@ -487,6 +491,7 @@ var defaultConfigValues = map[string]interface{}{
 
 	"default-series":              jujuversion.DefaultSupportedLTS(),
 	ProvisionerHarvestModeKey:     HarvestDestroyed.String(),
+	NumProvisionWorkersKey:        16,
 	ResourceTagsKey:               "",
 	"logging-config":              "",
 	AutomaticallyRetryHooks:       true,
@@ -1300,6 +1305,12 @@ func (c *Config) ProvisionerHarvestMode() HarvestMode {
 	}
 }
 
+// NumProvisionWorkers returns the number of provisioner workers to use.
+func (c *Config) NumProvisionWorkers() int {
+	value, _ := c.defined[NumProvisionWorkersKey].(int)
+	return value
+}
+
 // ImageStream returns the simplestreams stream
 // used to identify which image ids to search
 // when starting an instance.
@@ -1626,6 +1637,7 @@ var alwaysOptional = schema.Defaults{
 	"firewall-mode":               schema.Omit,
 	"logging-config":              schema.Omit,
 	ProvisionerHarvestModeKey:     schema.Omit,
+	NumProvisionWorkersKey:        schema.Omit,
 	HTTPProxyKey:                  schema.Omit,
 	HTTPSProxyKey:                 schema.Omit,
 	FTPProxyKey:                   schema.Omit,
@@ -2046,6 +2058,11 @@ global or per instance security groups.`,
 		Description: "What to do with unknown machines. See https://jujucharms.com/stable/config-general#juju-lifecycle-and-harvesting (default destroyed)",
 		Type:        environschema.Tstring,
 		Values:      []interface{}{"all", "none", "unknown", "destroyed"},
+		Group:       environschema.EnvironGroup,
+	},
+	NumProvisionWorkersKey: {
+		Description: "The number of provisioning workers to use per model",
+		Type:        environschema.Tint,
 		Group:       environschema.EnvironGroup,
 	},
 	"proxy-ssh": {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -349,6 +349,16 @@ var configTests = []configTest{
 		}),
 		err: `provisioner-harvest-mode: expected one of \[all none unknown destroyed], got "yes please"`,
 	}, {
+		about: fmt.Sprintf(
+			"%s: %d",
+			"num-provision-workers",
+			42,
+		),
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"num-provision-workers": "42",
+		}),
+	}, {
 		about:       "default image stream",
 		useDefaults: config.UseDefaults,
 		attrs:       minimalConfigAttrs,
@@ -500,7 +510,9 @@ var configTests = []configTest{
 			"syslog-client-cert": testing.CACert,
 			"syslog-client-key":  testing.CAKey,
 		}),
-		err: `invalid syslog forwarding config: validating TLS config: parsing CA certificate: asn1: syntax error: data truncated`,
+		// NOTE(achilleasa): TLS parsing errors have changed in go 1.17
+		// hence the alternative in the regex.
+		err: `invalid syslog forwarding config: validating TLS config: parsing CA certificate: (?:asn1: syntax error: data truncated|x509: malformed certificate)`,
 	}, {
 		about:       "invalid syslog cert",
 		useDefaults: config.UseDefaults,
@@ -511,7 +523,9 @@ var configTests = []configTest{
 			"syslog-client-cert": invalidCACert,
 			"syslog-client-key":  testing.CAKey,
 		}),
-		err: `invalid syslog forwarding config: validating TLS config: parsing client key pair: asn1: syntax error: data truncated`,
+		// NOTE(achilleasa): TLS parsing errors have changed in go 1.17
+		// hence the alternative in the regex.
+		err: `invalid syslog forwarding config: validating TLS config: parsing client key pair: (?:asn1: syntax error: data truncated|x509: malformed certificate)`,
 	}, {
 		about:       "invalid syslog key",
 		useDefaults: config.UseDefaults,

--- a/worker/provisioner/mocks/lxdprofileinstancebroker_mock.go
+++ b/worker/provisioner/mocks/lxdprofileinstancebroker_mock.go
@@ -5,39 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	instance "github.com/juju/juju/core/instance"
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	environs "github.com/juju/juju/environs"
 	context "github.com/juju/juju/environs/context"
 	instances "github.com/juju/juju/environs/instances"
-	reflect "reflect"
 )
 
-// MockLXDProfileInstanceBroker is a mock of LXDProfileInstanceBroker interface
+// MockLXDProfileInstanceBroker is a mock of LXDProfileInstanceBroker interface.
 type MockLXDProfileInstanceBroker struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileInstanceBrokerMockRecorder
 }
 
-// MockLXDProfileInstanceBrokerMockRecorder is the mock recorder for MockLXDProfileInstanceBroker
+// MockLXDProfileInstanceBrokerMockRecorder is the mock recorder for MockLXDProfileInstanceBroker.
 type MockLXDProfileInstanceBrokerMockRecorder struct {
 	mock *MockLXDProfileInstanceBroker
 }
 
-// NewMockLXDProfileInstanceBroker creates a new mock instance
+// NewMockLXDProfileInstanceBroker creates a new mock instance.
 func NewMockLXDProfileInstanceBroker(ctrl *gomock.Controller) *MockLXDProfileInstanceBroker {
 	mock := &MockLXDProfileInstanceBroker{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileInstanceBrokerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLXDProfileInstanceBroker) EXPECT() *MockLXDProfileInstanceBrokerMockRecorder {
 	return m.recorder
 }
 
-// AllInstances mocks base method
+// AllInstances mocks base method.
 func (m *MockLXDProfileInstanceBroker) AllInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllInstances", arg0)
@@ -46,13 +47,13 @@ func (m *MockLXDProfileInstanceBroker) AllInstances(arg0 context.ProviderCallCon
 	return ret0, ret1
 }
 
-// AllInstances indicates an expected call of AllInstances
+// AllInstances indicates an expected call of AllInstances.
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) AllInstances(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllInstances", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).AllInstances), arg0)
 }
 
-// AllRunningInstances mocks base method
+// AllRunningInstances mocks base method.
 func (m *MockLXDProfileInstanceBroker) AllRunningInstances(arg0 context.ProviderCallContext) ([]instances.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllRunningInstances", arg0)
@@ -61,13 +62,13 @@ func (m *MockLXDProfileInstanceBroker) AllRunningInstances(arg0 context.Provider
 	return ret0, ret1
 }
 
-// AllRunningInstances indicates an expected call of AllRunningInstances
+// AllRunningInstances indicates an expected call of AllRunningInstances.
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) AllRunningInstances(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRunningInstances", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).AllRunningInstances), arg0)
 }
 
-// AssignLXDProfiles mocks base method
+// AssignLXDProfiles mocks base method.
 func (m *MockLXDProfileInstanceBroker) AssignLXDProfiles(arg0 string, arg1 []string, arg2 []lxdprofile.ProfilePost) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignLXDProfiles", arg0, arg1, arg2)
@@ -76,13 +77,13 @@ func (m *MockLXDProfileInstanceBroker) AssignLXDProfiles(arg0 string, arg1 []str
 	return ret0, ret1
 }
 
-// AssignLXDProfiles indicates an expected call of AssignLXDProfiles
+// AssignLXDProfiles indicates an expected call of AssignLXDProfiles.
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) AssignLXDProfiles(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignLXDProfiles", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).AssignLXDProfiles), arg0, arg1, arg2)
 }
 
-// LXDProfileNames mocks base method
+// LXDProfileNames mocks base method.
 func (m *MockLXDProfileInstanceBroker) LXDProfileNames(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfileNames", arg0)
@@ -91,13 +92,13 @@ func (m *MockLXDProfileInstanceBroker) LXDProfileNames(arg0 string) ([]string, e
 	return ret0, ret1
 }
 
-// LXDProfileNames indicates an expected call of LXDProfileNames
+// LXDProfileNames indicates an expected call of LXDProfileNames.
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) LXDProfileNames(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileNames", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).LXDProfileNames), arg0)
 }
 
-// MaybeWriteLXDProfile mocks base method
+// MaybeWriteLXDProfile mocks base method.
 func (m *MockLXDProfileInstanceBroker) MaybeWriteLXDProfile(arg0 string, arg1 lxdprofile.Profile) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeWriteLXDProfile", arg0, arg1)
@@ -105,13 +106,13 @@ func (m *MockLXDProfileInstanceBroker) MaybeWriteLXDProfile(arg0 string, arg1 lx
 	return ret0
 }
 
-// MaybeWriteLXDProfile indicates an expected call of MaybeWriteLXDProfile
+// MaybeWriteLXDProfile indicates an expected call of MaybeWriteLXDProfile.
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) MaybeWriteLXDProfile(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeWriteLXDProfile", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).MaybeWriteLXDProfile), arg0, arg1)
 }
 
-// StartInstance mocks base method
+// StartInstance mocks base method.
 func (m *MockLXDProfileInstanceBroker) StartInstance(arg0 context.ProviderCallContext, arg1 environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0, arg1)
@@ -120,13 +121,13 @@ func (m *MockLXDProfileInstanceBroker) StartInstance(arg0 context.ProviderCallCo
 	return ret0, ret1
 }
 
-// StartInstance indicates an expected call of StartInstance
+// StartInstance indicates an expected call of StartInstance.
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) StartInstance(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstance", reflect.TypeOf((*MockLXDProfileInstanceBroker)(nil).StartInstance), arg0, arg1)
 }
 
-// StopInstances mocks base method
+// StopInstances mocks base method.
 func (m *MockLXDProfileInstanceBroker) StopInstances(arg0 context.ProviderCallContext, arg1 ...instance.Id) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -138,7 +139,7 @@ func (m *MockLXDProfileInstanceBroker) StopInstances(arg0 context.ProviderCallCo
 	return ret0
 }
 
-// StopInstances indicates an expected call of StopInstances
+// StopInstances indicates an expected call of StopInstances.
 func (mr *MockLXDProfileInstanceBrokerMockRecorder) StopInstances(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)

--- a/worker/provisioner/provisioner.go
+++ b/worker/provisioner/provisioner.go
@@ -177,6 +177,8 @@ func (p *provisioner) getStartTask(harvestMode config.HarvestMode) (ProvisionerT
 		modelCfg.ImageStream(),
 		RetryStrategy{retryDelay: retryStrategyDelay, retryCount: retryStrategyCount},
 		p.callContextFunc,
+		modelCfg.NumProvisionWorkers(),
+		nil, // event callback is currently only being used by tests
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -264,6 +266,7 @@ func (p *environProvisioner) loop() error {
 				return errors.Annotate(err, "loaded invalid model configuration")
 			}
 			task.SetHarvestMode(modelConfig.ProvisionerHarvestMode())
+			task.SetNumProvisionWorkers(modelConfig.NumProvisionWorkers())
 		}
 	}
 }

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -419,7 +419,7 @@ func (task *provisionerTask) pendingOrDead(
 	defer task.machinesMutex.RUnlock()
 	for _, id := range ids {
 		// Ignore machines that have been either queued for deferred
-		// stopping or they are currently sopping
+		// stopping or they are currently stopping
 		if _, found := task.machinesStopDeferred[id]; found {
 			task.logger.Tracef("pendingOrDead: ignoring machine %q; machine has deferred stop flag set", id)
 			continue // ignore: will be stopped once started

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -715,7 +715,7 @@ func (s *ProvisionerTaskSuite) TestDeferStopRequestsForMachinesStillProvisioning
 	// change will trigger a StartInstance call against the broker.  While
 	// in that call (i.e. the machine is still being started from the
 	// provisioner's perspective), we will set the machine as dead, queue a
-	// cahnge event for the same machine and wait until it has been
+	// change event for the same machine and wait until it has been
 	// processed and the event processed callback invoked.
 	//
 	// The change event for the dead machine should not immediately trigger

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -45,6 +45,8 @@ import (
 	"github.com/juju/juju/worker/provisioner"
 )
 
+const numProvisionWorkersForTesting = 4
+
 type ProvisionerTaskSuite struct {
 	testing.IsolationSuite
 
@@ -116,6 +118,7 @@ func (s *ProvisionerTaskSuite) TestStartStop(c *gc.C) {
 		config.HarvestAll,
 		&mockDistributionGroupFinder{},
 		mockToolsFinder{},
+		numProvisionWorkersForTesting,
 	)
 	workertest.CheckAlive(c, task)
 	workertest.CleanKill(c, task)
@@ -135,6 +138,7 @@ func (s *ProvisionerTaskSuite) TestStopInstancesIgnoresMachinesWithKeep(c *gc.C)
 		config.HarvestAll,
 		&mockDistributionGroupFinder{},
 		mockToolsFinder{},
+		numProvisionWorkersForTesting,
 	)
 	defer workertest.CleanKill(c, task)
 
@@ -190,6 +194,7 @@ func (s *ProvisionerTaskSuite) TestProvisionerRetries(c *gc.C) {
 		&mockDistributionGroupFinder{},
 		mockToolsFinder{},
 		provisioner.NewRetryStrategy(0*time.Second, 1),
+		numProvisionWorkersForTesting,
 	)
 
 	m0 := &testMachine{
@@ -251,7 +256,7 @@ func (s *ProvisionerTaskSuite) TestEvenZonePlacement(c *gc.C) {
 		c.Assert(expectedIds.Size(), gc.Equals, 0)
 	})
 
-	task := s.newProvisionerTaskWithBroker(c, broker, nil)
+	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
 	s.sendModelMachinesChange(c, expectedIds.Values()...)
 
 	shortAttempt := &utils.AttemptStrategy{
@@ -338,7 +343,7 @@ func (s *ProvisionerTaskSuite) TestMultipleSpaceConstraints(c *gc.C) {
 	}, nil).Do(func(_ ...interface{}) {
 		go func() { started <- struct{}{} }()
 	})
-	task := s.newProvisionerTaskWithBroker(c, broker, nil)
+	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
 	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 
 	s.sendModelMachinesChange(c, "0")
@@ -368,7 +373,7 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoZoneAvailable(c *gc.C) {
 	broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil)
 
 	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
-	task := s.newProvisionerTaskWithBroker(c, broker, nil)
+	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
 	s.sendModelMachinesChange(c, "0")
 	s.waitForWorkerSetup(c, "worker not set up")
 
@@ -419,7 +424,7 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoDistributionGroup(c *gc.C) {
 	})
 	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 
-	task := s.newProvisionerTaskWithBroker(c, broker, nil)
+	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
 
 	s.sendModelMachinesChange(c, "0")
 
@@ -453,7 +458,7 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoDistributionGroupRetry(c *gc
 		}),
 	)
 
-	task := s.newProvisionerTaskWithBroker(c, broker, nil)
+	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
 
 	m0 := &testMachine{
 		id:          "0",
@@ -507,7 +512,7 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsWithDistributionGroup(c *gc.C)
 	// so we expect the machine to be created in az2.
 	task := s.newProvisionerTaskWithBroker(c, broker, map[names.MachineTag][]string{
 		names.NewMachineTag("0"): {"az1"},
-	})
+	}, numProvisionWorkersForTesting)
 
 	s.sendModelMachinesChange(c, "0")
 	select {
@@ -544,7 +549,7 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsWithDistributionGroupRetry(c *
 	// so we expect the machine to be created in az2.
 	task := s.newProvisionerTaskWithBroker(c, broker, map[names.MachineTag][]string{
 		names.NewMachineTag("0"): {"az1"},
-	})
+	}, numProvisionWorkersForTesting)
 
 	m0 := &testMachine{
 		id:          "0",
@@ -589,7 +594,7 @@ func (s *ProvisionerTaskSuite) TestZoneRestrictiveConstraintsWithDistributionGro
 	task := s.newProvisionerTaskWithBroker(c, broker, map[names.MachineTag][]string{
 		names.NewMachineTag("0"): {"az2"},
 		names.NewMachineTag("1"): {"az3"},
-	})
+	}, numProvisionWorkersForTesting)
 
 	m0 := &testMachine{
 		id:          "0",
@@ -621,12 +626,184 @@ func (s *ProvisionerTaskSuite) TestPopulateAZMachinesErrorWorkerStopped(c *gc.C)
 
 	task := s.newProvisionerTaskWithBroker(c, broker, map[names.MachineTag][]string{
 		names.NewMachineTag("0"): {"az1"},
-	})
+	}, numProvisionWorkersForTesting)
 	s.sendModelMachinesChange(c, "0")
 	s.waitForWorkerSetup(c, "worker not set up")
 
 	err := workertest.CheckKill(c, task)
 	c.Assert(err, gc.ErrorMatches, "failed to process updated machines: .* boom")
+}
+
+func (s *ProvisionerTaskSuite) TestDedupStopRequests(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	// m0 is a machine that should be terminated.
+	i0 := &testInstance{id: "zero"}
+	m0 := &testMachine{
+		id:       "0",
+		life:     life.Dead,
+		instance: i0,
+	}
+
+	broker := s.setUpZonedEnviron(ctrl, m0)
+
+	// This is a complex scenario. Here is how everything is set up:
+	//
+	// We will register an event processed callback as a synchronization
+	// point.
+	//
+	// The first machine change event will trigger a StopInstance call
+	// against the broker. While in that call (i.e. the machine is still
+	// being stopped from the provisioner's perspective), we will trigger
+	// another machine change event for the same machine and wait until it
+	// has been processed and the event processed callback invoked.
+	//
+	// Then, doneCh which instructs the test to perform a CleanKill for
+	// the worker and make sure that no errors got reported.
+	//
+	// This verifies that machines being stopped are ignored when processing
+	// machine changes concurrently.
+
+	doneCh := make(chan struct{})
+	barrier := make(chan struct{}, 1)
+	var barrierCb = func(evt string) {
+		if evt == "processed-machines" {
+			barrier <- struct{}{}
+		}
+	}
+
+	// StopInstances should only be called once for m0.
+	broker.EXPECT().StopInstances(s.callCtx, gomock.Any()).Do(func(ctx interface{}, ids ...interface{}) {
+		c.Assert(len(ids), gc.Equals, 1)
+		c.Assert(ids[0], gc.DeepEquals, instance.Id("0"))
+
+		// While one of the pool workers is executing this code, we
+		// will wait until the machine change event gets processed
+		// and the main loop is ready to process the next event.
+		<-barrier
+
+		// Trigger another change while machine 0 is still being stopped
+		// and wait until the event has been processed by the provisioner
+		// main loop before returning
+		s.sendModelMachinesChange(c, "0")
+		<-barrier
+		close(doneCh)
+	})
+
+	task := s.newProvisionerTaskWithBrokerAndEventCb(c, broker, nil, numProvisionWorkersForTesting, barrierCb)
+
+	s.sendModelMachinesChange(c, "0")
+
+	// This ensures that the worker pool within the provisioner gets cleanly
+	// shutdown and that any pending requests are processed.
+	<-doneCh
+	workertest.CleanKill(c, task)
+}
+
+func (s *ProvisionerTaskSuite) TestDeferStopRequestsForMachinesStillProvisioning(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	// m0 is a machine that should be started.
+	m0 := &testMachine{
+		id:          "0",
+		life:        life.Alive,
+		constraints: "zones=az1",
+	}
+
+	broker := s.setUpZonedEnviron(ctrl, m0)
+
+	// This is a complex scenario to ensure the provisioner works as expected
+	// when the equivalent of "juju add-machine; juju remove-machine 0" is
+	// executed. Here is how everything is set up:
+	//
+	// We will register an event processed callback as a synchronization
+	// point.
+	//
+	// Machine 0 is alive but not yes started. Processing the first machine
+	// change will trigger a StartInstance call against the broker.  While
+	// in that call (i.e. the machine is still being started from the
+	// provisioner's perspective), we will set the machine as dead, queue a
+	// cahnge event for the same machine and wait until it has been
+	// processed and the event processed callback invoked.
+	//
+	// The change event for the dead machine should not immediately trigger
+	// a StopInstance call but rather the provisioner will detect that the
+	// machine is still being started and defer the stopping of the machine
+	// until the machine gets started (immediately when StartInstance
+	// returns).
+	//
+	// Finally, doneCh which instructs the test to perform a CleanKill for
+	// the worker and make sure that no errors got reported.
+
+	doneCh := make(chan struct{})
+	barrier := make(chan struct{}, 1)
+	var barrierCb = func(evt string) {
+		if evt == "processed-machines" {
+			barrier <- struct{}{}
+		}
+	}
+
+	azConstraints := newAZConstraintStartInstanceParamsMatcher("az1")
+	broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil).AnyTimes()
+	gomock.InOrder(
+		broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(&environs.StartInstanceResult{
+			Instance: &testInstance{id: "instance-0"},
+		}, nil).Do(func(ctx, params interface{}) {
+			// While one of the pool workers is executing this code, we
+			// will wait until the machine change event gets processed
+			// and the main loop is ready to process the next event.
+			<-barrier
+
+			// While the machine is still starting, flag it as dead,
+			// trigger another change and wait for it to be processed.
+			// We expect that the defer stop flag is going to be set for
+			// the machine and a StopInstance call to be issued once we
+			// return.
+			m0.life = life.Dead
+			s.sendModelMachinesChange(c, "0")
+			<-barrier
+		}),
+		broker.EXPECT().StopInstances(s.callCtx, gomock.Any()).Do(func(ctx interface{}, ids ...interface{}) {
+			c.Assert(len(ids), gc.Equals, 1)
+			c.Assert(ids[0], gc.DeepEquals, instance.Id("0"))
+
+			// Signal the test to shut down the worker.
+			close(doneCh)
+		}),
+	)
+
+	task := s.newProvisionerTaskWithBrokerAndEventCb(c, broker, nil, numProvisionWorkersForTesting, barrierCb)
+
+	// Send change for machine 0
+	s.sendModelMachinesChange(c, "0")
+
+	// This ensures that the worker pool within the provisioner gets cleanly
+	// shutdown and that any pending requests are processed.
+	<-doneCh
+	workertest.CleanKill(c, task)
+}
+
+func (s *ProvisionerTaskSuite) TestResizeWorkerPool(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	barrier := make(chan struct{}, 1)
+	var barrierCb = func(evt string) {
+		if evt == "resized-worker-pool" {
+			close(barrier)
+		}
+	}
+
+	broker := s.setUpZonedEnviron(ctrl)
+	task := s.newProvisionerTaskWithBrokerAndEventCb(c, broker, nil, numProvisionWorkersForTesting, barrierCb)
+
+	// Resize the pool
+	task.SetNumProvisionWorkers(numProvisionWorkersForTesting + 1)
+
+	<-barrier
+	workertest.CleanKill(c, task)
 }
 
 // setUpZonedEnviron creates a mock environ with instances based on those set
@@ -660,7 +837,7 @@ func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller, machin
 	}
 
 	exp := broker.EXPECT()
-	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil).Times(2)
+	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil).MinTimes(2)
 	exp.InstanceAvailabilityZoneNames(s.callCtx, instanceIds).Return(map[instance.Id]string{}, nil).Do(func(_ ...interface{}) {
 		close(s.setupDone)
 	})
@@ -713,12 +890,14 @@ func (s *ProvisionerTaskSuite) newProvisionerTask(
 	harvestingMethod config.HarvestMode,
 	distributionGroupFinder provisioner.DistributionGroupFinder,
 	toolsFinder provisioner.ToolsFinder,
+	numProvisionWorkers int,
 ) provisioner.ProvisionerTask {
 	return s.newProvisionerTaskWithRetry(c,
 		harvestingMethod,
 		distributionGroupFinder,
 		toolsFinder,
 		provisioner.NewRetryStrategy(0*time.Second, 0),
+		numProvisionWorkers,
 	)
 }
 
@@ -728,6 +907,7 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithRetry(
 	distributionGroupFinder provisioner.DistributionGroupFinder,
 	toolsFinder provisioner.ToolsFinder,
 	retryStrategy provisioner.RetryStrategy,
+	numProvisionWorkers int,
 ) provisioner.ProvisionerTask {
 	w, err := provisioner.NewProvisionerTask(
 		coretesting.ControllerTag.Id(),
@@ -744,14 +924,18 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithRetry(
 		imagemetadata.ReleasedStream,
 		retryStrategy,
 		func(_ stdcontext.Context) context.ProviderCallContext { return s.callCtx },
+		numProvisionWorkers,
+		nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return w
 }
 
-func (s *ProvisionerTaskSuite) newProvisionerTaskWithBroker(
-	c *gc.C, broker environs.InstanceBroker, distributionGroups map[names.MachineTag][]string,
-) provisioner.ProvisionerTask {
+func (s *ProvisionerTaskSuite) newProvisionerTaskWithBroker(c *gc.C, broker environs.InstanceBroker, distributionGroups map[names.MachineTag][]string, numProvisionWorkers int) provisioner.ProvisionerTask {
+	return s.newProvisionerTaskWithBrokerAndEventCb(c, broker, distributionGroups, numProvisionWorkers, nil)
+}
+
+func (s *ProvisionerTaskSuite) newProvisionerTaskWithBrokerAndEventCb(c *gc.C, broker environs.InstanceBroker, distributionGroups map[names.MachineTag][]string, numProvisionWorkers int, evtCb func(string)) provisioner.ProvisionerTask {
 	task, err := provisioner.NewProvisionerTask(
 		coretesting.ControllerTag.Id(),
 		names.NewMachineTag("0"),
@@ -767,6 +951,8 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithBroker(
 		imagemetadata.ReleasedStream,
 		provisioner.NewRetryStrategy(0*time.Second, 0),
 		func(_ stdcontext.Context) context.ProviderCallContext { return s.callCtx },
+		numProvisionWorkers,
+		evtCb,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return task

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -249,12 +249,6 @@ func (s *ProvisionerTaskSuite) TestEvenZonePlacement(c *gc.C) {
 			zoneLock.Unlock()
 		})
 	}
-	broker.EXPECT().StopInstances(s.callCtx, gomock.Any()).Do(func(ctx interface{}, ids ...interface{}) {
-		for _, id := range ids {
-			expectedIds.Remove(fmt.Sprintf("%s", id))
-		}
-		c.Assert(expectedIds.Size(), gc.Equals, 0)
-	})
 
 	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
 	s.sendModelMachinesChange(c, expectedIds.Values()...)
@@ -344,7 +338,6 @@ func (s *ProvisionerTaskSuite) TestMultipleSpaceConstraints(c *gc.C) {
 		go func() { started <- struct{}{} }()
 	})
 	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
-	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 
 	s.sendModelMachinesChange(c, "0")
 
@@ -372,7 +365,6 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoZoneAvailable(c *gc.C) {
 	azConstraints := newAZConstraintStartInstanceParamsMatcher("az9")
 	broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil)
 
-	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
 	s.sendModelMachinesChange(c, "0")
 	s.waitForWorkerSetup(c, "worker not set up")
@@ -422,7 +414,6 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoDistributionGroup(c *gc.C) {
 	}, nil).Do(func(_ ...interface{}) {
 		go func() { started <- struct{}{} }()
 	})
-	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 
 	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
 
@@ -506,7 +497,6 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsWithDistributionGroup(c *gc.C)
 	}, nil).Do(func(_ ...interface{}) {
 		go func() { started <- struct{}{} }()
 	})
-	broker.EXPECT().StopInstances(s.callCtx, []instance.Id{"0"})
 
 	// Another machine from the same distribution group is already in az1,
 	// so we expect the machine to be created in az2.

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1327,6 +1327,8 @@ func (s *ProvisionerSuite) newProvisionerTaskWithRetryStrategy(
 		imagemetadata.ReleasedStream,
 		retryStrategy,
 		func(_ stdcontext.Context) context.ProviderCallContext { return s.callCtx },
+		numProvisionWorkersForTesting,
+		nil,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return w


### PR DESCRIPTION
The previous implementation got triggered via a machine change event and
then attempted to parallelize the starting of the pending machines
within the batch. The same codepath also obtained a list of dead
machines and asked the provider to terminate a subset (depending on the
configured harvest mode) of them.

Both these operations are blocking so the provisioner task was unable to
process any other pending changes until it has finished processing the
current batch. In some substrates, machines can take up to a couple of
minutes to start. As a result, we could (reproducibly) bump into
pathological cases (LP1942100) where the machine creation was
effectively serialized and would significantly increase the time it took
to deploy complex bundles such as charmed k8s.

A similar problem is also seen when tearing down models (e.g.  during
our CI runs) where the provisioner has to wait for a set of machines to
be terminated by the environment before it has a chance to process the
next set of dead machines.

This PR changes the behavior of the provisioner task so as to
improve parallelism when starting/stopping instances. This is achieved
via the introduction of a worker pool into the provisioner task where
start/stop requests can be delegated thus freeing the provisioner task's
main loop to process any queued events.

This change comes with a few caveats which require additional logic in
the provisioner task:

1) As the starting/stopping of machines is handled by the worker pool,
provisioning-related errors are reported asynchronously. When any of the
pool workers detects an error, it queues it (in a buffered channel) and
then requests the pool to shutdown once all workers complete their work
and report any errors they may encounter. The main task loop can detect
when the pool is shutting down (by monitoring the channel returned via
the pool's Done() method) and invokes the pool's Close() method which
waits for the pool to shut down and returns any errors that got emitted
by the pool workers.

2) As the provisioner enumerates the dead machines every time it
processes a machine change (empty or not), it can observe the same dead
machines multiple times and try to stop the same machine twice. To avoid
this, the task keeps track of the machine IDs that are currently being
(asynchronously) terminated and ignores them if it encounters them again
as part of another processed change.

3) In a scenario where we run 'juju add-machine && juju kill-machine X',
the provisioner would normally attempt to start the machine and then try
to stop it while it is still being provisioned. This would result in an
error when the provisioner tries to set the status of the machine
(machine dead or not found) and cause the error to bubble up and cause
the provisioner task main loop to exit and get restarted.

To work around this problem, the provisioner tracks the machine IDs that
are currently being provisioned. If it detects that a machine which is
still provisioning is dead, it will not try to stop it immediately but
instead flag it so that we can defer stopping it until the machine comes
online. Once the StartInstance broker call returns, the code will check
if the machine was flagged for deferred stopping and immediately queue
a termination request for the machine.

Out of the box, each provisioner task (one **per model**) uses a pool of **16** workers.
However, this value can be customized on a per-model basis by changing the `num-provisioning-workers`
config option. The provisioner task gets notified when the config value changes and
resizes the pool (min workers is capped to 1) on demand.

## QA steps

You will need to test various scenarios on different substrates. For example:
1) A regular, bootstrap, deploy, (wait), remove scenario
2) Spin up multiple machines and kill some of them, e.g. `juju add-machine -n 10 && sleep 2 && juju remove-machine 1 3`.
3) Check that the AZ distribution logic has not been affected.
4) Test that `juju destroy-model` cleans up all machines
5) In HA mode, start some machines, kill some machines and then kill the leader; verify that we are not leaking instances.

To get better visibility in the provisioner internals: 

```
juju model-config logging-config="<root>=INFO;juju.worker.provisioner=DEBUG"
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1622813
https://bugs.launchpad.net/juju/+bug/1942100