### PR TITLE
[JUJU-192] Use yaml.safe_load instead of yaml.load

### DIFF
--- a/acceptancetests/assess_add_credentials.py
+++ b/acceptancetests/assess_add_credentials.py
@@ -101,7 +101,7 @@ def get_credentials(env, creds_path=juju_home):
     :return: Dict of credential information
     """
     with open(os.path.join(creds_path, 'credentials.yaml')) as f:
-        creds_dict = yaml.load(f)
+        creds_dict = yaml.safe_load(f)
     cred = creds_dict['credentials'][env]
     return cred
 
@@ -126,7 +126,7 @@ def verify_credentials_match(env, cred):
     :param cred: Dict of credential information
     """
     with open(os.path.join(os.environ['JUJU_DATA'], 'credentials.yaml')) as f:
-        test_creds = yaml.load(f)
+        test_creds = yaml.safe_load(f)
         test_creds = test_creds['credentials'][env][env]
     if not test_creds == cred['credentials']:
         error = 'Credential miss-match after manual add'

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -536,7 +536,7 @@ def setup_spaces(maas, bundle=None):
         return
     with open(bundle) as f:
         data = f.read()
-        bundle_yaml = yaml.load(data)
+        bundle_yaml = yaml.safe_load(data)
     existing_spaces = maas.spaces()
     new_spaces = _setup_spaces(bundle_yaml, existing_spaces)
     for space in new_spaces:

--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -317,7 +317,7 @@ class JujuData:
     @classmethod
     def for_existing(cls, juju_data_dir, controller_name, model_name):
         with open(get_bootstrap_config_path(juju_data_dir)) as f:
-            all_bootstrap = yaml.load(f)
+            all_bootstrap = yaml.safe_load(f)
         ctrl_config = all_bootstrap['controllers'][controller_name]
         config = ctrl_config['controller-config']
         # config is expected to have a 1.x style of config, so mash up

--- a/acceptancetests/repository/trusty/haproxy/hooks/charmhelpers/core/services/helpers.py
+++ b/acceptancetests/repository/trusty/haproxy/hooks/charmhelpers/core/services/helpers.py
@@ -179,7 +179,7 @@ class RequiredConfig(dict):
         self.required_options = args
         self['config'] = hookenv.config()
         with open(os.path.join(hookenv.charm_dir(), 'config.yaml')) as fp:
-            self.config = yaml.load(fp).get('options', {})
+            self.config = yaml.safe_load(fp).get('options', {})
 
     def __bool__(self):
         for option in self.required_options:
@@ -227,7 +227,7 @@ class StoredContext(dict):
         if not os.path.isabs(file_name):
             file_name = os.path.join(hookenv.charm_dir(), file_name)
         with open(file_name, 'r') as file_stream:
-            data = yaml.load(file_stream)
+            data = yaml.safe_load(file_stream)
             if not data:
                 raise OSError("%s is empty" % file_name)
             return data

--- a/acceptancetests/repository/trusty/haproxy/hooks/hooks.py
+++ b/acceptancetests/repository/trusty/haproxy/hooks/hooks.py
@@ -274,7 +274,7 @@ def update_service_ports(old_service_ports=None, new_service_ports=None):
 # update_sysctl: create a sysctl.conf file from YAML-formatted 'sysctl' config
 # -----------------------------------------------------------------------------
 def update_sysctl(config_data):
-    sysctl_dict = yaml.load(config_data.get("sysctl", "{}"))
+    sysctl_dict = yaml.safe_load(config_data.get("sysctl", "{}"))
     if sysctl_dict:
         sysctl_file = open("/etc/sysctl.d/50-haproxy.conf", "w")
         for key in sysctl_dict:

--- a/acceptancetests/tests/test_deploy_stack.py
+++ b/acceptancetests/tests/test_deploy_stack.py
@@ -213,7 +213,7 @@ class DeployStackTestCase(FakeHomeTestCase):
             dump_juju_timings(client, fake_dir)
             with open(os.path.join(fake_dir,
                       'juju_command_times.yaml')) as out_file:
-                file_data = yaml.load(out_file)
+                file_data = yaml.safe_load(out_file)
         self.assertEqual(file_data, expected)
 
     def test_check_token(self):

--- a/acceptancetests/tests/test_jujucharm.py
+++ b/acceptancetests/tests/test_jujucharm.py
@@ -58,7 +58,7 @@ class TestCharm(TestCase):
             charm.to_dir(charm_dir)
             metafile = os.path.join(charm_dir, 'metadata.yaml')
             with open(metafile) as f:
-                metadata = yaml.load(f)
+                metadata = yaml.safe_load(f)
         expected = {
             'name': 'test',
             'summary': 'a summary',
@@ -73,7 +73,7 @@ class TestCharm(TestCase):
             charm.to_repo_dir(repo_dir)
             metafile = os.path.join(repo_dir, 'wily', 'test', 'metadata.yaml')
             with open(metafile) as f:
-                metadata = yaml.load(f)
+                metadata = yaml.safe_load(f)
         expected = {
             'name': 'test',
             'summary': 'a summary',


### PR DESCRIPTION
The python function yaml.load without a loader param now raises a TypeError for recent
versions of PyYaml. Even in the older versions we run, this raises a DeprecationWarning

Where this appears, replace it with yaml.safe_load

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run Jenkins acceptance tests
