### PR TITLE
[JUJU-197] Raft lease retries with exceeded dropped

### DIFF
--- a/api/raftlease/client.go
+++ b/api/raftlease/client.go
@@ -234,7 +234,7 @@ func (c *Client) handleRetryRequestError(command *raftlease.Command, remote Remo
 		// log this error and try again if possible. The lease manager
 		// will know if a retry at that level is possible.
 		c.config.Logger.Warningf("Rate limit enqueuing %q command. Deadline exceeded for lease %s model: %v.", command.Operation, command.Lease, command.ModelUUID)
-		return remote, lease.ErrDropped
+		return remote, lease.ErrDeadlineExceeded
 	}
 
 	// If we can't find a remote, we should just return that the error was

--- a/api/raftlease/client_test.go
+++ b/api/raftlease/client_test.go
@@ -208,7 +208,7 @@ func (s *RaftLeaseClientSuite) TestRequestWithDeadlineExceededError(c *gc.C) {
 	c.Assert(client.lastKnownRemote, gc.NotNil)
 
 	err = client.Request(context.TODO(), cmd)
-	c.Assert(err, gc.ErrorMatches, `lease operation dropped`)
+	c.Assert(err, gc.ErrorMatches, `lease deadline exceeded`)
 
 	// Ensure that a lease operation that has the deadline exceeded does not
 	// drop the lastKnownRemote.

--- a/core/lease/errors.go
+++ b/core/lease/errors.go
@@ -42,6 +42,10 @@ var (
 	// indicative of no valid connection to propagate the lease operation to
 	// the leader.
 	ErrDropped = errors.New("lease operation dropped")
+
+	// ErrDeadlineExceeded indicates if the underlying request was rejected
+	// because enqueuing exceeded the timeout.
+	ErrDeadlineExceeded = errors.New("lease deadline exceeded")
 )
 
 // IsInvalid returns whether the specified error represents ErrInvalid
@@ -80,11 +84,17 @@ func IsDropped(err error) bool {
 	return errors.Cause(err) == ErrDropped
 }
 
+// IsDeadlineExceeded returns whether the specified errors represents
+// ErrDeadlineExceeded (even if it's wrapped).
+func IsDeadlineExceeded(err error) bool {
+	return errors.Cause(err) == ErrDeadlineExceeded
+}
+
 // IsLeaseError returns whether the specified error is part of the collection
 // of lease errors.
 func IsLeaseError(err error) bool {
 	switch errors.Cause(err) {
-	case ErrInvalid, ErrHeld, ErrTimeout, ErrAborted, ErrNotHeld, ErrDropped:
+	case ErrInvalid, ErrHeld, ErrTimeout, ErrAborted, ErrNotHeld, ErrDropped, ErrDeadlineExceeded:
 		return true
 	}
 	return false

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -27,6 +27,10 @@ const (
 	// there are timeouts.
 	maxRetries = 10
 
+	// maxDeadlineRetries gives the maximum number of deadline attempts we'll
+	// try if there are timeouts.
+	maxDeadlineRetries = 3
+
 	// initialRetryDelay is the starting delay - this will be
 	// increased exponentially up maxRetries.
 	initialRetryDelay = 50 * time.Millisecond
@@ -679,7 +683,7 @@ func isFatalClaimRetryError(act action, err error, count int) bool {
 	case lease.IsDeadlineExceeded(err):
 		// Extend action we want to retry if the count is less that the number
 		// of retries.
-		if act == extendAction && count < 3 {
+		if act == extendAction && count < maxDeadlineRetries {
 			return false
 		}
 	}

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -278,8 +278,9 @@ func (manager *Manager) retryingClaim(claim claim) {
 	)
 
 	for a := manager.startRetry(); a.Next(); {
-		success, err = manager.handleClaim(claim)
-		if isFatalRetryError(err) {
+		var act action
+		act, success, err = manager.handleClaim(claim)
+		if isFatalClaimRetryError(act, err, a.Count()) {
 			break
 		}
 
@@ -338,6 +339,13 @@ func (manager *Manager) retryingClaim(claim claim) {
 				manager.logContext, claim.leaseKey, claim.holderName)
 			claim.respond(lease.ErrClaimDenied)
 
+		case lease.IsDeadlineExceeded(err):
+			// This can happen if we where unable to process the claim in a
+			// given time. We should just return the claim denied.
+			manager.config.Logger.Warningf("[%s] deadline exceeded while handling claim %q for %q",
+				manager.logContext, claim.leaseKey, claim.holderName)
+			claim.respond(lease.ErrClaimDenied)
+
 		default:
 			// Stop the main loop because we got an abnormal error
 			manager.catacomb.Kill(errors.Trace(err))
@@ -345,30 +353,49 @@ func (manager *Manager) retryingClaim(claim claim) {
 	}
 }
 
+type action string
+
+const (
+	claimAction  action = "claim"
+	extendAction action = "extend"
+)
+
+func (a action) String() string {
+	switch a {
+	case claimAction:
+		return "claiming"
+	case extendAction:
+		return "extending"
+	}
+	return "unknown"
+}
+
 // handleClaim processes the supplied claim. It will only return
 // unrecoverable errors or timeouts; mere failure to claim just
 // indicates a bad request, and is returned as (false, nil).
-func (manager *Manager) handleClaim(claim claim) (bool, error) {
+func (manager *Manager) handleClaim(claim claim) (action, bool, error) {
 	store := manager.config.Store
 	request := lease.Request{Holder: claim.holderName, Duration: claim.duration}
-	var err error
-	var action string
+	var (
+		err error
+		act action
+	)
 	select {
 	case <-manager.catacomb.Dying():
-		return false, manager.catacomb.ErrDying()
+		return "unknown", false, manager.catacomb.ErrDying()
 	default:
 		info, found := manager.lookupLease(claim.leaseKey)
 		switch {
 		case !found:
 			manager.config.Logger.Tracef("[%s] %s asked for lease %s, no lease found, claiming for %s",
 				manager.logContext, claim.holderName, claim.leaseKey.Lease, claim.duration)
-			action = "claiming"
+			act = claimAction
 			err = store.ClaimLease(claim.leaseKey, request, manager.catacomb.Dying())
 
 		case info.Holder == claim.holderName:
 			manager.config.Logger.Tracef("[%s] %s extending lease %s for %s",
 				manager.logContext, claim.holderName, claim.leaseKey.Lease, claim.duration)
-			action = "extending"
+			act = extendAction
 			err = store.ExtendLease(claim.leaseKey, request, manager.catacomb.Dying())
 
 		default:
@@ -377,18 +404,18 @@ func (manager *Manager) handleClaim(claim claim) (bool, error) {
 			remaining := info.Expiry.Sub(manager.config.Clock.Now())
 			manager.config.Logger.Tracef("[%s] %s asked for lease %s, held by %s for another %s, rejecting",
 				manager.logContext, claim.holderName, claim.leaseKey.Lease, info.Holder, remaining)
-			return false, nil
+			return "unknown", false, nil
 		}
 	}
 	if lease.IsAborted(err) {
-		return false, manager.catacomb.ErrDying()
+		return act, false, manager.catacomb.ErrDying()
 	}
 	if err != nil {
-		return false, errors.Trace(err)
+		return act, false, errors.Trace(err)
 	}
 	manager.config.Logger.Tracef("[%s] %s %s lease %s for %s successful",
-		manager.logContext, claim.holderName, action, claim.leaseKey.Lease, claim.duration)
-	return true, nil
+		manager.logContext, claim.holderName, act.String(), claim.leaseKey.Lease, claim.duration)
+	return act, true, nil
 }
 
 // retryingRevoke handles timeouts when revoking, and responds to the
@@ -449,6 +476,11 @@ func (manager *Manager) retryingRevoke(revoke revoke) {
 
 		case lease.IsDropped(err):
 			manager.config.Logger.Warningf("[%s] dropped while handling revoke %q for %q",
+				manager.logContext, revoke.leaseKey, revoke.holderName)
+			revoke.respond(lease.ErrDropped)
+
+		case lease.IsDeadlineExceeded(err):
+			manager.config.Logger.Warningf("[%s] deadline exceeded while handling revoke %q for %q",
 				manager.logContext, revoke.leaseKey, revoke.holderName)
 			revoke.respond(lease.ErrDropped)
 
@@ -632,6 +664,24 @@ func isFatalRetryError(err error) bool {
 		return false
 	case lease.IsDropped(err):
 		return false
+	}
+	return true
+}
+
+func isFatalClaimRetryError(act action, err error, count int) bool {
+	switch {
+	case lease.IsTimeout(err):
+		return false
+	case lease.IsInvalid(err):
+		return false
+	case lease.IsDropped(err):
+		return false
+	case lease.IsDeadlineExceeded(err):
+		// Extend action we want to retry if the count is less that the number
+		// of retries.
+		if act == extendAction && count < 3 {
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
The following ensures that we identify the error when we can't enqueue
onto the raft lease queue. If that occurs we shouldn't retry for claims,
but we do want to retry for extensions, but only a limited number of
times.

This is because when performing load testing we identified a problem
where we retried enqueuing command failures. This caused issues when
attempting to claim or extend in subsequent calls. Why attempt to claim
and extend if we know the deadline will already be exceeded. We should
fail fast and fail early.

The changes here just expose that error instead of ErrDropped and use
ErrDeadlineExceeded. That way we can identify that error and better deal
with those situations.

Note: this is made worse because we bumped the number of retries from
5 to 10 in the following PR https://github.com/juju/juju/pull/9745.

## QA steps

See for Q&A steps for a larger in-depth test https://github.com/juju/juju/pull/13453

```
$ juju bootstrap lxd test1 --build-agent --config features="[raft-api-leases,raft-batch-fsm]"
$ juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE;juju.worker.raft=TRACE"
$ juju debug-log -m controller
```

Ensure there are no errors.