### PR TITLE
[JUJU-199] Remove an an old legacy cmr fallback and add upgrade step

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -198,13 +198,6 @@ func GetOfferingRelationTokens(backend Backend, tag names.RelationTag) (string, 
 	}
 	appToken, err := backend.GetToken(names.NewApplicationTag(offerName))
 	if err != nil {
-		// TODO(babbageclunk): do we need to try getting the appToken
-		// for the application name instead (opposite of the fallback
-		// in
-		// apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go:296)?
-		// I don't think so because this method is only called from
-		// API methods that were added after the transition to offer
-		// name as the app token.
 		return "", "", errors.Annotatef(err, "getting token for application %q", offerName)
 	}
 	return relationToken, appToken, nil

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -74,7 +74,7 @@ func (st stateShim) ControllerTag() names.ControllerTag {
 	return st.Model.ControllerTag()
 }
 
-// ControllerTag returns the tag of the controller in which we are operating.
+// ModelTag returns the tag of the model in which we are operating.
 // This is a temporary transitional step.
 func (st stateShim) ModelTag() names.ModelTag {
 	return st.Model.ModelTag()

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -182,7 +182,7 @@ func (st *mockState) ImportRemoteEntity(entity names.Tag, token string) error {
 	if err := st.NextErr(); err != nil {
 		return err
 	}
-	if _, ok := st.remoteEntities[entity]; ok {
+	if existing, ok := st.remoteEntities[entity]; ok && existing != token {
 		return errors.AlreadyExistsf(entity.Id())
 	}
 	st.remoteEntities[entity] = token

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -396,6 +396,9 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 		Assert: txn.DocExists,
 		Remove: true,
 	}, decRefOp)
+	r := op.offerStore.st.RemoteEntities()
+	tokenOps := r.removeRemoteEntityOps(names.NewApplicationTag(offer.OfferName))
+	ops = append(ops, tokenOps...)
 	return ops, nil
 }
 

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -85,10 +85,17 @@ func (s *applicationOffersSuite) TestEndpoints(c *gc.C) {
 
 func (s *applicationOffersSuite) TestRemove(c *gc.C) {
 	offer := s.createDefaultOffer(c)
+	r := s.State.RemoteEntities()
+	_, err := r.ExportLocalEntity(names.NewApplicationTag(offer.OfferName))
+	c.Assert(err, jc.ErrorIsNil)
+
 	sd := state.NewApplicationOffers(s.State)
-	err := sd.Remove(offer.OfferName, false)
+	err = sd.Remove(offer.OfferName, false)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = sd.ApplicationOffer(offer.OfferName)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	_, err = r.GetToken(names.NewApplicationTag(offer.OfferName))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5733,6 +5733,72 @@ func (s *upgradesSuite) TestDropLegacyAssumesSectionsFromCharmMetadata(c *gc.C) 
 	)
 }
 
+func (s *upgradesSuite) TestMigrateLegacyCrossModelTokens(c *gc.C) {
+	model1 := s.makeModel(c, "model-1", coretesting.Attrs{})
+	model2 := s.makeModel(c, "model-2", coretesting.Attrs{})
+	defer func() {
+		_ = model1.Close()
+		_ = model2.Close()
+	}()
+
+	uuid1 := model1.ModelUUID()
+	uuid2 := model2.ModelUUID()
+
+	makeOffer := func(st *State, username, exportedName string) (string, string) {
+		ch := AddTestingCharm(c, st, "mysql")
+		AddTestingApplication(c, st, "test", ch)
+		_, err := st.AddUser(username, username, "secret", "admin")
+		c.Assert(err, jc.ErrorIsNil)
+		sd := NewApplicationOffers(st)
+		offerArgs := crossmodel.AddApplicationOfferArgs{
+			OfferName:       "testoffer",
+			ApplicationName: "test",
+			Endpoints:       map[string]string{"db": "server"},
+			Owner:           username,
+		}
+		_, err = sd.AddOffer(offerArgs)
+		c.Assert(err, jc.ErrorIsNil)
+
+		r := st.RemoteEntities()
+		token, err := r.ExportLocalEntity(names.NewApplicationTag(exportedName))
+		c.Assert(err, jc.ErrorIsNil)
+		relToken, err := r.ExportLocalEntity(names.NewRelationTag("foo:bar"))
+		c.Assert(err, jc.ErrorIsNil)
+		return token, relToken
+	}
+
+	token1, relToken1 := makeOffer(model1, "fred", "test")
+	token2, relToken2 := makeOffer(model2, "mary", "testoffer")
+
+	expected := bsonMById{
+		{
+			"_id":        ensureModelUUID(uuid1, "application-testoffer"),
+			"model-uuid": uuid1,
+			"token":      token1,
+		}, {
+			"_id":        ensureModelUUID(uuid1, "relation-foo.bar"),
+			"model-uuid": uuid1,
+			"token":      relToken1,
+		}, {
+			"_id":        ensureModelUUID(uuid2, "application-testoffer"),
+			"model-uuid": uuid2,
+			"token":      token2,
+		}, {
+			"_id":        ensureModelUUID(uuid2, "relation-foo.bar"),
+			"model-uuid": uuid2,
+			"token":      relToken2,
+		},
+	}
+	sort.Sort(expected)
+
+	col, closer := s.state.db().GetRawCollection(remoteEntitiesC)
+	defer closer()
+
+	s.assertUpgradedData(c, MigrateLegacyCrossModelTokens,
+		upgradedData(col, expected),
+	)
+}
+
 type docById []bson.M
 
 func (d docById) Len() int           { return len(d) }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -99,6 +99,7 @@ type StateBackend interface {
 	EnsureCharmOriginRisk() error
 	RemoveOrphanedCrossModelProxies() error
 	DropLegacyAssumesSectionsFromCharmMetadata() error
+	MigrateLegacyCrossModelTokens() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -427,4 +428,8 @@ func (s stateBackend) RemoveOrphanedCrossModelProxies() error {
 
 func (s stateBackend) DropLegacyAssumesSectionsFromCharmMetadata() error {
 	return state.DropLegacyAssumesSectionsFromCharmMetadata(s.pool)
+}
+
+func (s stateBackend) MigrateLegacyCrossModelTokens() error {
+	return state.MigrateLegacyCrossModelTokens(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -53,6 +53,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.12"), stateStepsFor2912()},
 		upgradeToVersion{version.MustParse("2.9.15"), stateStepsFor2915()},
 		upgradeToVersion{version.MustParse("2.9.17"), stateStepsFor2917()},
+		upgradeToVersion{version.MustParse("2.9.19"), stateStepsFor2919()},
 	}
 	return steps
 }

--- a/upgrades/steps_2919.go
+++ b/upgrades/steps_2919.go
@@ -1,0 +1,17 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2919 returns upgrade steps for juju 2.9.19
+func stateStepsFor2919() []Step {
+	return []Step{
+		&upgradeStep{
+			description: `migrate legacy cross model tokens`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().MigrateLegacyCrossModelTokens()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2919_test.go
+++ b/upgrades/steps_2919_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2919 = version.MustParse("2.9.19")
+
+type steps2919Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2919Suite{})
+
+func (s *steps2919Suite) TestMigrateLegacyCrossModelTokens(c *gc.C) {
+	step := findStateStep(c, v2919, `migrate legacy cross model tokens`)
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -643,6 +643,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.12",
 		"2.9.15",
 		"2.9.17",
+		"2.9.19",
 	})
 }
 


### PR DESCRIPTION
When setting up a cross model relation, there was a fallback from the time of Juju 2.5 - the fallback would look for an exported token for the offered application name, not the offer name. This could lead to a scenario where the wrong token is used if an offer and/or application is force removed and the offer created again later.

This PR contains 3 fixes:
- remove the legacy fallback
- add an upgrade step to convert any legacy data (unlikely to have any, but just in case)
- ensure that when an offer is removed, any corresponding tokens are removed also

## QA steps

Without deploying juju 2.5, this scenario isn't reproducible without hacking the db.
Regression test by deploying a cmr relation in 2.8 and upgrading.

## Bug reference

https://bugs.launchpad.net/bugs/1940983
