### PR TITLE
[JUJU-202] Lease manager test fix and trace logging

### DIFF
--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -589,6 +589,8 @@ func (manager *Manager) setNextTimeout(t time.Time) {
 	// Ensure we never walk the next check back without have performed a
 	// scheduled check *unless* we think our last check was in the past.
 	if !manager.nextTimeout.Before(now) && !t.Before(manager.nextTimeout) {
+		manager.config.Logger.Tracef("[%s] not rescheduling check from %v to %v based on current time %v",
+			manager.logContext, manager.nextTimeout, t, now)
 		return
 	}
 	manager.nextTimeout = t

--- a/worker/lease/manager_block_test.go
+++ b/worker/lease/manager_block_test.go
@@ -34,7 +34,7 @@ func (s *WaitUntilExpiredSuite) SetUpTest(c *gc.C) {
 func (s *WaitUntilExpiredSuite) TestLeadershipNoLeaseBlockEvaluatedNextTick(c *gc.C) {
 	fix := &Fixture{
 		leases: map[corelease.Key]corelease.Info{
-			key("redis"): {
+			key("postgresql"): {
 				Holder: "postgresql/0",
 				Expiry: offset(time.Second),
 			},


### PR DESCRIPTION
Looking into an odd failure in the `Unit-RunUnitTests-race-amd64`, I noticed that one of the lease manager tests was composed incorrectly. That is rectified here.

For diagnostic purposes we also emit trace-level logging when we eschew rescheduling the next block check.

## QA steps

Run the tests in the `WaitUntilExpiredSuite` suite.

Note that we will still get lines like this for unit tests:
```
[LOG] 0:00.051 TRACE lease_test [] not rescheduling check from 2073-03-03 01:00:02.000000005 -0840 -0840 to 2073-03-03 02:00:03.000000005 -0840 -0840 based on current time 2073-03-03 01:00:02.000000005 -0840 -0840
```
This is because we advance the test clock exactly to the time that our block check should execute, so our last scheduled check never looks like it was in the past, and we don't walk the schedule back to the default configured wait (1 hour).

In practice this will never happen because if a scheduled check runs, the next call to `time.Now()` can not be earlier than the scheduled time.

## Documentation changes

None.

## Bug reference

N/A
