### PR TITLE
[JUJU-195] Format logs for mongo version more nicely

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -685,7 +685,7 @@ func logVersion(mongoPath string) {
 		logger.Infof("failed to read the output from %s --version: %v", mongoPath, err)
 		return
 	}
-	logger.Debugf("using mongod: %s --version: %q", mongoPath, output)
+	logger.Debugf("using mongod: %s --version:\n%s", mongoPath, output)
 }
 
 func installMongod(mongoDep packaging.Dependency, usingMongoFromSnap bool, hostSeries, dataDir string) (err error) {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -198,7 +198,7 @@ func (s *MongoSuite) TestEnsureServer(c *gc.C) {
 	any := `(.|\n)*`
 	start := "^" + any
 	tail := any + "$"
-	c.Assert(tlog, gc.Matches, start+`using mongod: .*mongod --version: "db version v\d\.\d\.\d`+tail)
+	c.Assert(tlog, gc.Matches, start+`using mongod: .*mongod --version:\sdb version v\d\.\d\.\d`+tail)
 }
 
 func (s *MongoSuite) TestEnsureServerServerExistsAndRunning(c *gc.C) {


### PR DESCRIPTION
New mongo versions give detailed version info over multiple lines. This
looks bad in logs, so instead of quoting and escaping, just print the
raw string over multiple lines

https://bugs.launchpad.net/juju/+bug/1949582

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
go test github.com/juju/juju/mongo
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1949582
