### PR TITLE
[JUJU-193] [2.9] Populate supported assumes features for k8s provider

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -50,6 +50,7 @@ import (
 	"github.com/juju/juju/cloudconfig/podcfg"
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/paths"
@@ -2704,7 +2705,7 @@ func (k *kubernetesClient) deploymentName(appName string, legacySupport bool) st
 func (k *kubernetesClient) SupportedFeatures() (assumes.FeatureSet, error) {
 	var fs assumes.FeatureSet
 
-	k8sAPIVersion, err := k.APIVersion()
+	k8sAPIVersion, err := k.Version()
 	if err != nil {
 		return fs, errors.Annotatef(err, "querying kubernetes API version")
 	}
@@ -2712,7 +2713,8 @@ func (k *kubernetesClient) SupportedFeatures() (assumes.FeatureSet, error) {
 	fs.Add(
 		assumes.Feature{
 			Name:        "k8s-api",
-			Description: "the version of kubernetes API that charms can access",
+			Description: assumes.UserFriendlyFeatureDescriptions["k8s-api"],
+			Version:     k8sAPIVersion,
 		},
 	)
 	return fs, nil

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2700,6 +2700,24 @@ func (k *kubernetesClient) deploymentName(appName string, legacySupport bool) st
 	return appName
 }
 
+// SupportedFeatures implements environs.SupportedFeatureEnumerator.
+func (k *kubernetesClient) SupportedFeatures() (assumes.FeatureSet, error) {
+	var fs assumes.FeatureSet
+
+	k8sAPIVersion, err := k.APIVersion()
+	if err != nil {
+		return fs, errors.Annotatef(err, "querying kubernetes API version")
+	}
+
+	fs.Add(
+		assumes.Feature{
+			Name:        "k8s-api",
+			Description: "the version of kubernetes API that charms can access",
+		},
+	)
+	return fs, nil
+}
+
 func isLegacyName(resourceName string) bool {
 	return strings.HasPrefix(resourceName, "juju-")
 }

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/juju/juju/caas/specs"
 	"github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/network"
@@ -2979,6 +2980,27 @@ func (s *K8sBrokerSuite) TestVersion(c *gc.C) {
 	ver, err := s.broker.Version()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ver, gc.DeepEquals, &version.Number{Major: 1, Minor: 15})
+}
+
+func (s *K8sBrokerSuite) TestSupportedFeatures(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	gomock.InOrder(
+		s.mockDiscovery.EXPECT().ServerVersion().Return(&k8sversion.Info{
+			Major: "1", Minor: "15+",
+		}, nil),
+	)
+
+	fs, err := s.broker.SupportedFeatures()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(fs.AsList(), gc.DeepEquals, []assumes.Feature{
+		{
+			Name:        "k8s-api",
+			Description: "the Kubernetes API lets charms query and manipulate the state of API objects in a Kubernetes cluster",
+			Version:     &version.Number{Major: 1, Minor: 15},
+		},
+	})
 }
 
 func (s *K8sBrokerSuite) TestGetServiceSvcNotFound(c *gc.C) {

--- a/core/assumes/sat_checker.go
+++ b/core/assumes/sat_checker.go
@@ -15,7 +15,8 @@ var (
 	// feature that is not included in the feature set supported by the
 	// current model.
 	UserFriendlyFeatureDescriptions = map[string]string{
-		"juju": "the version of Juju used by the model",
+		"juju":    "the version of Juju used by the model",
+		"k8s-api": "the Kubernetes API lets charms query and manipulate the state of API objects in a Kubernetes cluster",
 	}
 )
 

--- a/core/assumes/sat_checker.go
+++ b/core/assumes/sat_checker.go
@@ -14,7 +14,9 @@ var (
 	// generate better error messages when an "assumes" expression requests a
 	// feature that is not included in the feature set supported by the
 	// current model.
-	userFriendlyFeatureDescriptions = map[string]string{}
+	UserFriendlyFeatureDescriptions = map[string]string{
+		"juju": "the version of Juju used by the model",
+	}
 )
 
 // A link to a web page with additional information about features,
@@ -46,7 +48,7 @@ func satisfyExpr(fs FeatureSet, expr chassumes.Expression, exprTreeDepth int) er
 func satisfyFeatureExpr(fs FeatureSet, expr chassumes.FeatureExpression) error {
 	supported, defined := fs.Get(expr.Name)
 	if !defined {
-		featDescr := userFriendlyFeatureDescriptions[expr.Name]
+		featDescr := UserFriendlyFeatureDescriptions[expr.Name]
 		return featureError(
 			expr.Name, featDescr,
 			"charm requires feature %q but model does not support it", expr.Name,
@@ -77,7 +79,7 @@ func satisfyFeatureExpr(fs FeatureSet, expr chassumes.FeatureExpression) error {
 	if featDescr == "" {
 		// The feature set should always have a feature description.
 		// Try the fallback descriptions if it is missing.
-		featDescr = userFriendlyFeatureDescriptions[featDescr]
+		featDescr = UserFriendlyFeatureDescriptions[featDescr]
 	}
 	return featureError(
 		expr.Name, featDescr,

--- a/state/stateenvirons/features.go
+++ b/state/stateenvirons/features.go
@@ -5,13 +5,16 @@ package stateenvirons
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/state"
 )
 
 var (
 	// Overridden by tests
-	environGetter = environs.GetEnviron
+	iaasEnvironGetter = GetNewEnvironFunc(environs.New)
+	caasBrokerGetter  = GetNewCAASBrokerFunc(caas.New)
 )
 
 // SupportedFeatures returns the set of features that the model makes available
@@ -34,9 +37,22 @@ func SupportedFeatures(model Model, newEnviron environs.NewEnvironFunc) (assumes
 
 	// Access the environment associated with the model and query any
 	// substrate-specific features that might be available.
-	env, err := environGetter(EnvironConfigGetter{Model: model}, newEnviron)
-	if err != nil {
-		return fs, errors.Annotate(err, "accessing model environment")
+	var env interface{}
+	switch model.Type() {
+	case state.ModelTypeIAAS:
+		iaasEnv, err := iaasEnvironGetter(model)
+		if err != nil {
+			return fs, errors.Annotate(err, "accessing model environment")
+		}
+		env = iaasEnv
+	case state.ModelTypeCAAS:
+		caasEnv, err := caasBrokerGetter(model)
+		if err != nil {
+			return fs, errors.Annotate(err, "accessing model environment")
+		}
+		env = caasEnv
+	default:
+		return fs, errors.NotSupportedf("model type %q", model.Type())
 	}
 
 	if featureEnumerator, supported := env.(environs.SupportedFeatureEnumerator); supported {

--- a/state/stateenvirons/features.go
+++ b/state/stateenvirons/features.go
@@ -28,7 +28,7 @@ func SupportedFeatures(model Model, newEnviron environs.NewEnvironFunc) (assumes
 	agentVersion, _ := modelConf.AgentVersion()
 	fs.Add(assumes.Feature{
 		Name:        "juju",
-		Description: "the version of Juju used by the model",
+		Description: assumes.UserFriendlyFeatureDescriptions["juju"],
 		Version:     &agentVersion,
 	})
 


### PR DESCRIPTION
This PR implements the `environs.SupportedFeaturesEnumerator` interface for the k8s provider which will allow us to write charms that request a particular `k8s-api` version via an `assumes` expression.

As with the previous PRs in this stream of work (support for assumes), these changes are also behind the `charm-assumes` controller feature flag.

## QA steps

## IAAS test
 
```sh
$ juju bootstrap lxd test --no-gui
$ juju show-model | grep -A42 'features:'

$  juju controller-config 'features=[charm-assumes]'
$ juju show-model | grep -A42 'features:'
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 2.9.19.1
```

## CAAS test
 
```sh
# If testing on microk8s
$ make microk8s-operator-update

$ juju bootstrap microk8s mk8s --no-gui
$ juju add-model foo
$ juju show-model | grep -A42 'features:'

$  juju controller-config 'features=[charm-assumes]'
$ juju show-model | grep -A42 'features:'
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 2.9.19
  - name: k8s-api
    description: the Kubernetes API lets charms query and manipulate the state of
      API objects in a Kubernetes cluster
    version: 1.21.0
```

## Documentation changes

We need to create and populate the contents of: https://juju.is/docs/olm/supported-features