### PR TITLE
[JUJU-207] Apply synchronously, respond asynchronously

### DIFF
--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -88,14 +88,14 @@ type Logger interface {
 // allowing for client side backoff.
 type Queue interface {
 	// Queue returns the queue of operations. Removing an item from the channel
-	// will unblock to allow another to take it's place.
+	// will unblock to allow another to take its place.
 	Queue() <-chan []queue.Operation
 }
 
 // LeaseApplier applies operations from the queue onto the underlying raft
 // instance.
 type LeaseApplier interface {
-	// ApplyOperation applies an lease opeartion against the raft instance. If
+	// ApplyOperation applies a lease opeartion against the raft instance. If
 	// the raft instance isn't the leader, then an error is returned with the
 	// leader information if available.
 	// This Raft spec outlines this "The first option, which we recommend ...,


### PR DESCRIPTION
The following changes how apply works in a subtle way. Instead of
applying and waiting for apply log and response synchronously, we split
it into two phases. The first phase is synchronous, applying the log and
putting back pressure onto the caller and the queue. Waiting for the
raft response is then done asynchronously, so we don't have to wait for
the flush to disk.

The second phase is done in a similar way to how the pubsub queue is
implemented. The idea behind this change is to give enough back pressure
to the client, but not so much that we're now waiting for raft and mongo
to finish writing to the disk.

The potential downside to this is a spike in goroutines.


## QA steps

See for Q&A steps for a larger in-depth test https://github.com/juju/juju/pull/13453

```
$ juju bootstrap lxd test1 --build-agent --config features="[raft-api-leases,raft-batch-fsm]"
$ juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE;juju.worker.raft=TRACE"
$ juju debug-log -m controller
```

Ensure there are no errors.