### PR TITLE
[JUJU-194] [2.9] Remove `charm-assumes` feature flag

### DIFF
--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/caas"
 	k8s "github.com/juju/juju/caas/kubernetes/provider"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
-	"github.com/juju/juju/controller"
 	coreapplication "github.com/juju/juju/core/application"
 	coreassumes "github.com/juju/juju/core/assumes"
 	corecharm "github.com/juju/juju/core/charm"
@@ -39,7 +38,6 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/provider"
@@ -2435,13 +2433,6 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfied(c *gc.C) {
 		},
 	}
 
-	// Enable controller flag so we can enforce "assumes" blocks
-	ctrlCfg := coretesting.FakeControllerConfig()
-	ctrlCfg[controller.Features] = []interface{}{
-		feature.CharmAssumes,
-	}
-	s.backend.controllerCfg = &ctrlCfg
-
 	// Try to upgrade the charm
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
@@ -2461,13 +2452,6 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfiedWithForce(c *gc.C) {
 			},
 		},
 	}
-
-	// Enable controller flag so we can enforce "assumes" blocks
-	ctrlCfg := coretesting.FakeControllerConfig()
-	ctrlCfg[controller.Features] = []interface{}{
-		feature.CharmAssumes,
-	}
-	s.backend.controllerCfg = &ctrlCfg
 
 	// Try to upgrade the charm
 	err := s.api.SetCharm(params.ApplicationSetCharm{

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/storage"
@@ -208,15 +207,6 @@ func stateCharmOrigin(origin corecharm.Origin) *state.CharmOrigin {
 
 func assertCharmAssumptions(assumesExprTree *assumes.ExpressionTree, model Model, ctrlCfgGetter func() (controller.Config, error)) error {
 	if assumesExprTree == nil {
-		return nil
-	}
-
-	ctrlCfg, err := ctrlCfgGetter()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if !ctrlCfg.Features().Contains(feature.CharmAssumes) {
 		return nil
 	}
 

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testcharms"
 	coretesting "github.com/juju/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -476,12 +475,7 @@ func (s *DeployLocalSuite) TestDeployWithUnmetCharmRequirements(c *gc.C) {
 	charm, err := testing.PutCharm(s.State, curl, ch)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Enable controller flag so we can enforce "assumes" blocks
-	ctrlCfg := coretesting.FakeControllerConfig()
-	ctrlCfg[controller.Features] = []interface{}{
-		feature.CharmAssumes,
-	}
-	var f = fakeDeployer{controllerCfg: &ctrlCfg}
+	var f = fakeDeployer{}
 
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -502,12 +496,7 @@ func (s *DeployLocalSuite) TestDeployWithUnmetCharmRequirementsAndForce(c *gc.C)
 	charm, err := testing.PutCharm(s.State, curl, ch)
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Enable controller flag so we can enforce "assumes" blocks
-	ctrlCfg := coretesting.FakeControllerConfig()
-	ctrlCfg[controller.Features] = []interface{}{
-		feature.CharmAssumes,
-	}
-	var f = fakeDeployer{controllerCfg: &ctrlCfg}
+	var f = fakeDeployer{}
 
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -32,7 +32,6 @@ import (
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/version"
@@ -103,19 +102,10 @@ func (s *modelInfoSuite) SetUpTest(c *gc.C) {
 	}
 	s.st.controllerModel = controllerModel
 
-	// TODO(achilleasa): as the supported features reporting is behind a
-	// flag we need to set it here so we can test the actual code. This
-	// should be removed once the feature goes live.
-	ctrlCfg := coretesting.FakeControllerConfig()
-	ctrlCfg[controller.Features] = []interface{}{
-		feature.CharmAssumes,
-	}
 	s.ctlrSt = &mockState{
 		model:           controllerModel,
 		controllerModel: controllerModel,
-		controllerCfg:   &ctrlCfg,
 	}
-	s.st.controllerCfg = &ctrlCfg
 
 	s.st.model = &mockModel{
 		owner:          names.NewUserTag("bob@local"),
@@ -229,7 +219,6 @@ func (s *modelInfoSuite) TestModelInfoV7(c *gc.C) {
 		{"ControllerNodes", nil},
 		{"HAPrimaryMachine", nil},
 		{"LatestMigration", nil},
-		{"ControllerConfig", nil},
 	})
 }
 
@@ -310,7 +299,6 @@ func (s *modelInfoSuite) TestModelInfo(c *gc.C) {
 		{"ControllerNodes", nil},
 		{"HAPrimaryMachine", nil},
 		{"LatestMigration", nil},
-		{"ControllerConfig", nil},
 		{"CloudCredential", []interface{}{names.NewCloudCredentialTag("some-cloud/bob/some-credential")}},
 	})
 }

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -36,7 +36,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/space"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/tools"
@@ -1300,30 +1299,21 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag) (params.ModelInfo, er
 		}
 	}
 
-	// TODO(achilleasa): remove this check when we are ready to roll out
-	// support for "assumes" expressions.
-	ctrlConf, err := st.ControllerConfig()
+	fs, err := supportedFeaturesGetter(model, environs.New)
 	if err != nil {
 		return params.ModelInfo{}, err
 	}
-
-	if ctrlConf.Features().Contains(feature.CharmAssumes) {
-		fs, err := supportedFeaturesGetter(model, environs.New)
-		if err != nil {
-			return params.ModelInfo{}, err
+	for _, feat := range fs.AsList() {
+		mappedFeat := params.SupportedFeature{
+			Name:        feat.Name,
+			Description: feat.Description,
 		}
-		for _, feat := range fs.AsList() {
-			mappedFeat := params.SupportedFeature{
-				Name:        feat.Name,
-				Description: feat.Description,
-			}
 
-			if feat.Version != nil {
-				mappedFeat.Version = feat.Version.String()
-			}
-
-			info.SupportedFeatures = append(info.SupportedFeatures, mappedFeat)
+		if feat.Version != nil {
+			mappedFeat.Version = feat.Version.String()
 		}
+
+		info.SupportedFeatures = append(info.SupportedFeatures, mappedFeat)
 	}
 	return info, nil
 }

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -287,7 +287,6 @@ func (s *modelManagerSuite) TestCreateModelArgs(c *gc.C) {
 		"ControllerNodes",
 		"HAPrimaryMachine",
 		"LatestMigration",
-		"ControllerConfig",
 	)
 
 	// Check that Model.LastModelConnection is called three times
@@ -460,7 +459,6 @@ func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {
 		"ControllerNodes",
 		"HAPrimaryMachine",
 		"LatestMigration",
-		"ControllerConfig",
 	)
 	s.caasBroker.CheckCallNames(c, "Create")
 

--- a/core/assumes/feature_descriptions.go
+++ b/core/assumes/feature_descriptions.go
@@ -1,0 +1,16 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package assumes
+
+var (
+	// A set of user-friendly descriptions for potentially supported
+	// features that are known to the controller. This allows us to
+	// generate better error messages when an "assumes" expression requests a
+	// feature that is not included in the feature set supported by the
+	// current model.
+	UserFriendlyFeatureDescriptions = map[string]string{
+		"juju":    "the version of Juju used by the model",
+		"k8s-api": "the Kubernetes API lets charms query and manipulate the state of API objects in a Kubernetes cluster",
+	}
+)

--- a/core/assumes/sat_checker.go
+++ b/core/assumes/sat_checker.go
@@ -8,18 +8,6 @@ import (
 	"github.com/juju/errors"
 )
 
-var (
-	// A set of user-friendly descriptions for potentially supported
-	// features that are known to the controller. This allows us to
-	// generate better error messages when an "assumes" expression requests a
-	// feature that is not included in the feature set supported by the
-	// current model.
-	UserFriendlyFeatureDescriptions = map[string]string{
-		"juju":    "the version of Juju used by the model",
-		"k8s-api": "the Kubernetes API lets charms query and manipulate the state of API objects in a Kubernetes cluster",
-	}
-)
-
 // A link to a web page with additional information about features,
 // the Juju versions that support them etc.
 const featureDocsURL = "https://juju.is/docs/olm/supported-features"

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -61,8 +61,3 @@ const RaftBatchFSM = "raft-batch-fsm"
 // RaftAPILeases will switch all lease store management transport, currently
 // handled by Pubsub to facade API interaction.
 const RaftAPILeases = "raft-api-leases"
-
-// CharmAssumes instructs Juju to process assumes expressions from charm
-// metadata when attempting to deploy charms. In addition, it enables reporting
-// of supported features as part of the 'juju show-model' output.
-const CharmAssumes = "charm-assumes"

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -193,8 +193,12 @@ controller:
     owner: admin
     cloud: dummy
     validity-check: valid
+  supported-features:
+  - name: juju
+    description: the version of Juju used by the model
+    version: %v
 `[1:]
-	c.Assert(cmdtesting.Stdout(context), gc.Matches, fmt.Sprintf(expectedOutput, version.Current))
+	c.Assert(cmdtesting.Stdout(context), gc.Matches, fmt.Sprintf(expectedOutput, version.Current, version.Current))
 }
 
 func (s *cmdControllerSuite) TestListModelsYAMLWithExactTime(c *gc.C) {


### PR DESCRIPTION
This PR removes the `charm-assumes` feature flag and enables full support for parsing and/or enforcing `assumes` requirements as specified in the charm metadata.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju show-model | grep -A42 'features':
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 2.9.19.1

$  juju deploy juju-qa-test-assumes-v2       
Located charm "juju-qa-test-assumes-v2" in charm-hub, revision 3
Deploying "juju-qa-test-assumes-v2" from charm-hub charm "juju-qa-test-assumes-v2", revision 3 in channel stable
ERROR Charm feature requirements cannot be met:
  - charm requires feature "juju" (version >= 42.0.0) but model currently supports version 2.9.19.1

Feature descriptions:
  - "juju": the version of Juju used by the model

For additional information please see: https://juju.is/docs/olm/supported-features

$ juju deploy  juju-qa-test-assumes-v2 --force
Located charm "juju-qa-test-assumes-v2" in charm-hub, revision 3
Deploying "juju-qa-test-assumes-v2" from charm-hub charm "juju-qa-test-assumes-v2", revision 3 in channel stable
```