### PR TITLE
[JUJU-176] Fix mongo service enable by using start not restart.

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -723,9 +723,24 @@ func installMongod(mongoDep packaging.Dependency, usingMongoFromSnap bool, hostS
 
 	if usingMongoFromSnap {
 		defer func() {
+			if err != nil {
+				return
+			}
 			err = snapSvc.ConfigOverride()
-			if err == nil {
-				err = snapSvc.Restart()
+			if err != nil {
+				err = errors.Annotate(err, "cannot override mongo service config")
+				return
+			}
+			// TODO(juju3): refactor and update tests during merge
+			err = snapSvc.Stop()
+			if err != nil {
+				err = errors.Annotate(err, "cannot stop mongo service")
+				return
+			}
+			err = snapSvc.Start()
+			if err != nil {
+				err = errors.Annotate(err, "cannot start mongo service")
+				return
 			}
 		}()
 	}


### PR DESCRIPTION
Mongo snap would not autostart service after restart because it was never enabled.

This uses stop/start separately, both are idempotent, but more importantly start can enable the service.

## QA steps

```
$ juju bootstrap localhost --config juju-db-snap-channel=4.4/candidate
$ juju ssh -m controller 0
controller-0$ snap service list
snap services
Service         Startup  Current   Notes
juju-db.daemon  enabled  active    -
lxd.activate    enabled  inactive  -
lxd.daemon      enabled  inactive  socket-activated
``` 

juju-db.daemon should be enabled and active.

## Documentation changes

N/A

## Bug reference

N/A