### PR TITLE
[JUJU-221] Fix vol attachment life asserts for force remove

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -1560,7 +1560,7 @@ func cleanupDyingEntityStorage(sb *storageBackend, hostTag names.Tag, manual boo
 			if IsContainsFilesystem(err) {
 				// The volume will be destroyed when the
 				// contained filesystem is removed, whose
-				// destruction is initiated below.
+				// destruction is initiated above.
 				continue
 			}
 			if !force {

--- a/state/storage.go
+++ b/state/storage.go
@@ -1561,19 +1561,14 @@ func (sb *storageBackend) detachStorageAttachmentOps(si *storageInstance, unitTa
 			return nil, nil
 		}
 
-		lifeAssert := isAliveDoc
-		if force {
-			// Since we are force destroying, life assert should be current volume's life.
-			lifeAssert = bson.D{{"life", volume.Life()}}
-		}
 		if plans, err := sb.machineVolumeAttachmentPlans(hostTag, volume.VolumeTag()); err != nil {
 			return nil, errors.Trace(err)
 		} else {
 			if len(plans) > 0 {
-				return detachStorageAttachmentOps(hostTag, volume.VolumeTag(), lifeAssert), nil
+				return sb.detachVolumeAttachmentPlanOps(hostTag, volume.VolumeTag(), force)
 			}
 		}
-		return detachVolumeOps(hostTag, volume.VolumeTag(), lifeAssert), nil
+		return sb.detachVolumeOps(hostTag, volume.VolumeTag(), force)
 
 	case StorageKindFilesystem:
 		filesystem, err := sb.storageInstanceFilesystem(si.StorageTag())


### PR DESCRIPTION
A 2.9 model that had been upgraded from 2.4 had a stuck machine that `remove-machine --force` could not delete.
It turned out that the `life` values of the attached volume and attachment entities had got out of sync and there was an incorrect assert constructed to use with the destroy txn ops. 
The change is to not assert that an attachment being destroyed is the same as that of the volume - instead, when force is used, do what we do elsewhere and assert that the life doesn't change during the txn.

## QA steps

It's "impossible" to the database into such an unexpected state with a modern juju.
db surgery was done on site to fix the core issue.
QA is just deploying a charm with storage and removing the machine.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1950928
