### PR TITLE
[JUJU-215] Ignore notfound error from fetching pod status for updating unit status;

### DIFF
--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -311,10 +311,12 @@ func (w *RemoteStateWatcher) setUp(unitTag names.UnitTag) (err error) {
 		providerID := w.unit.ProviderID()
 		if providerID != "" {
 			running, err := w.containerRunningStatusFunc(providerID)
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				return errors.Trace(err)
 			}
-			w.containerRunningStatus(*running)
+			if running != nil {
+				w.containerRunningStatus(*running)
+			}
 		}
 	}
 	return nil
@@ -576,10 +578,12 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 				}
 			}
 			runningStatus, err := w.containerRunningStatusFunc(w.current.ProviderID)
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				return errors.Annotatef(err, "getting container running status for %q", unitTag.String())
 			}
-			w.containerRunningStatus(*runningStatus)
+			if runningStatus != nil {
+				w.containerRunningStatus(*runningStatus)
+			}
 
 		case hashes, ok := <-charmConfigw.Changes():
 			w.logger.Debugf("got config change for %s: ok=%t, hashes=%v", w.unit.Tag().Id(), ok, hashes)


### PR DESCRIPTION
When we scale down a CAAS application with lots of units, the uniters running on the operator pod might be too busy and may not be able to call `EnsureDead()` to set the unit life to `dead` before the unit pod gets deleted by k8s.
This will cause the uniter to keep restarting when it tries to fetch the unit pod status and k8s API returns the `not found` error. Then these staled units will be kept in the system forever and never be removed even the unit pods have gone.
This issue might also happen when the `deployment` type CAAS application has some unit pods that keep restarting/re-creating due to the container itself can't be stabilized. 

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju add-model t1 microk8s

$ juju deploy charmed-osm-mariadb-k8s mariadb

$ juju deploy wordpress-k8s

$ juju relate wordpress-k8s mariadb:MySQL

$ juju scale-application wordpress-k8s 30

# The 29 units were removed correctly
$ juju scale-application wordpress-k8s 1

$ juju scale-application wordpress-k8s 30

# The existing 30 units were replaced correctly by the 30 newly created units
$ mkubectl -nt1 delete pods -l app.kubernetes.io/name=wordpress-k8s
pod "wordpress-k8s-5967df594-2dc25" deleted
pod "wordpress-k8s-5967df594-xpq4c" deleted
pod "wordpress-k8s-5967df594-6lx48" deleted
pod "wordpress-k8s-5967df594-jx9sz" deleted
pod "wordpress-k8s-5967df594-5nn8f" deleted
pod "wordpress-k8s-5967df594-5lhxt" deleted
pod "wordpress-k8s-5967df594-vbvfq" deleted
pod "wordpress-k8s-5967df594-vwrqm" deleted
pod "wordpress-k8s-5967df594-xhrbc" deleted
pod "wordpress-k8s-5967df594-7bf78" deleted
pod "wordpress-k8s-5967df594-nwjc4" deleted
pod "wordpress-k8s-5967df594-nlx4q" deleted
pod "wordpress-k8s-5967df594-nwp6h" deleted
pod "wordpress-k8s-5967df594-rnjpn" deleted
pod "wordpress-k8s-5967df594-4jpvv" deleted
pod "wordpress-k8s-5967df594-9xwcc" deleted
pod "wordpress-k8s-5967df594-tk82w" deleted
pod "wordpress-k8s-5967df594-vh5rr" deleted
pod "wordpress-k8s-5967df594-grjrz" deleted
pod "wordpress-k8s-5967df594-zclgn" deleted
pod "wordpress-k8s-5967df594-4xzff" deleted
pod "wordpress-k8s-5967df594-f6fg9" deleted
pod "wordpress-k8s-5967df594-6gh7n" deleted
pod "wordpress-k8s-5967df594-mmcgr" deleted
pod "wordpress-k8s-5967df594-jnc9s" deleted
pod "wordpress-k8s-5967df594-ct6jn" deleted
pod "wordpress-k8s-5967df594-mnmgk" deleted
pod "wordpress-k8s-5967df594-pxcgv" deleted
pod "wordpress-k8s-5967df594-k6tvl" deleted
pod "wordpress-k8s-5967df594-hhgfc" deleted

# The 29 units were removed correctly
$ juju scale-application wordpress-k8s 1

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1950705
