### PR TITLE
[JUJU-223] Fix panic when retrieving application config

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -2796,10 +2796,15 @@ func (a *Application) updateBranchConfig(branchName string, current *Settings, v
 // ApplicationConfig returns the configuration for the application itself.
 func (a *Application) ApplicationConfig() (application.ConfigAttributes, error) {
 	config, err := readSettings(a.st.db(), settingsC, a.applicationConfigKey())
-	if errors.IsNotFound(err) || len(config.Keys()) == 0 {
-		return application.ConfigAttributes(nil), nil
-	} else if err != nil {
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return application.ConfigAttributes(nil), nil
+		}
 		return nil, errors.Annotatef(err, "application config for application %q", a.doc.Name)
+	}
+
+	if len(config.Keys()) == 0 {
+		return application.ConfigAttributes(nil), nil
 	}
 	return config.Map(), nil
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -4240,6 +4240,18 @@ func (s *ApplicationSuite) TestUpdateApplicationConfig(c *gc.C) {
 	}
 }
 
+func (s *ApplicationSuite) TestApplicationConfigNotFoundNoError(c *gc.C) {
+	ch := s.AddTestingCharm(c, "dummy")
+	app := s.AddTestingApplication(c, "dummy-application", ch)
+
+	// Delete all the settings. We should get a nil return, but no error.
+	_, _ = s.State.MongoSession().DB("juju").C("settings").RemoveAll(nil)
+
+	cfg, err := app.ApplicationConfig()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cfg, gc.IsNil)
+}
+
 func (s *ApplicationSuite) TestStatusInitial(c *gc.C) {
 	appStatus, err := s.mysql.Status()
 	c.Check(err, jc.ErrorIsNil)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -933,10 +933,6 @@ func AppStorageConstraints(app *Application) (map[string]StorageConstraints, err
 	return readStorageConstraints(app.st, app.storageConstraintsKey())
 }
 
-func AppDeviceConstraints(app *Application) (map[string]DeviceConstraints, error) {
-	return readDeviceConstraints(app.st, app.deviceConstraintsKey())
-}
-
 func RemoveRelation(c *gc.C, rel *Relation, force bool) {
 	op := &ForcedOperation{Force: force}
 	ops, err := rel.removeOps("", "", op)

--- a/state/statetest/persistence_stubs.go
+++ b/state/statetest/persistence_stubs.go
@@ -17,7 +17,7 @@ type StubPersistence struct {
 
 	RunFunc func(jujutxn.TransactionSource) error
 
-	ReturnAll interface{} // homegenous(?) list of doc struct (not pointers)
+	ReturnAll interface{} // homogenous(?) list of doc struct (not pointers)
 	ReturnOne interface{} // a doc struct (not a pointer)
 
 	ReturnApplicationExistsOps       []txn.Op


### PR DESCRIPTION
This panic was observed when interrogating prodstack logs:
https://pastebin.canonical.com/p/7gWgsxSPhW/

It is corrected here.

## QA steps

Apply the following patch against this one. It effectively reverts the fix, while causing a non `NotFound` error to be returned by the new test. It should result in a panic.

Then restore state/application.go to this patch version. The test will fail without a panic.
```diff
diff --git a/state/application.go b/state/application.go
index d2092809d3..9554d74bd4 100644
--- a/state/application.go
+++ b/state/application.go
@@ -2796,15 +2796,10 @@ func (a *Application) updateBranchConfig(branchName string, current *Settings, v
 // ApplicationConfig returns the configuration for the application itself.
 func (a *Application) ApplicationConfig() (application.ConfigAttributes, error) {
 	config, err := readSettings(a.st.db(), settingsC, a.applicationConfigKey())
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return application.ConfigAttributes(nil), nil
-		}
-		return nil, errors.Annotatef(err, "application config for application %q", a.doc.Name)
-	}
-
-	if len(config.Keys()) == 0 {
+	if errors.IsNotFound(err) || len(config.Keys()) == 0 {
 		return application.ConfigAttributes(nil), nil
+	} else if err != nil {
+		return nil, errors.Annotatef(err, "application config for application %q", a.doc.Name)
 	}
 	return config.Map(), nil
 }
diff --git a/state/settings.go b/state/settings.go
index a8022e1fa2..2fb5cc341f 100644
--- a/state/settings.go
+++ b/state/settings.go
@@ -262,9 +262,9 @@ func readSettingsDoc(db Database, collection, key string) (*settingsDoc, error)
 	defer closer()
 
 	err := col.FindId(key).One(&doc)
-	if err == mgo.ErrNotFound {
-		err = errors.NotFoundf("settings")
-	}
+	//if err == mgo.ErrNotFound {
+	//	err = errors.NotFoundf("settings")
+	//}
 	return &doc, err
 }
 ```

## Documentation changes

None.

## Bug reference

N/A
