### PR TITLE
[JUJU-235] Remove bogus attachment dead warnings

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/watchers.go
+++ b/apiserver/facades/agent/storageprovisioner/internal/filesystemwatcher/watchers.go
@@ -279,7 +279,7 @@ func (fw Watchers) WatchMachineManagedFilesystemAttachments(m names.MachineTag) 
 	return w
 }
 
-// WatchMachineManagedFilesystemAttachments returns a strings watcher that
+// WatchUnitManagedFilesystemAttachments returns a strings watcher that
 // reports lifecycle changes for attachments to both unit-scoped filesystems,
 // and model-scoped, volume-backed filesystems that are attached to units of the
 // specified application.

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -1568,7 +1568,7 @@ func (s *StorageProvisionerAPIv3) Remove(args params.Entities) (params.ErrorResu
 	return results, nil
 }
 
-// RemoveAttachments removes the specified machine storage attachments
+// RemoveAttachment removes the specified machine storage attachments
 // from state.
 func (s *StorageProvisionerAPIv3) RemoveAttachment(args params.MachineStorageIds) (params.ErrorResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -42883,7 +42883,7 @@
                             "$ref": "#/definitions/ErrorResults"
                         }
                     },
-                    "description": "RemoveAttachments removes the specified machine storage attachments\nfrom state."
+                    "description": "RemoveAttachment removes the specified machine storage attachments\nfrom state."
                 },
                 "RemoveFilesystemParams": {
                     "type": "object",

--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -43,7 +43,7 @@ type BlockDevicesResult struct {
 	Error  *Error                `json:"error,omitempty"`
 }
 
-// BlockDevicseResults holds the result of an API call to retrieve details
+// BlockDevicesResults holds the result of an API call to retrieve details
 // of all block devices relating to some entities.
 type BlockDevicesResults struct {
 	Results []BlockDevicesResult `json:"results,omitempty"`
@@ -134,7 +134,7 @@ type StorageAttachmentIdsResult struct {
 	Error  *Error               `json:"error,omitempty"`
 }
 
-// StorageAttachmentIdsResult holds the result of an API call to retrieve the
+// StorageAttachmentIdsResults holds the result of an API call to retrieve the
 // IDs of multiple units attached storage instances.
 type StorageAttachmentIdsResults struct {
 	Results []StorageAttachmentIdsResult `json:"results,omitempty"`
@@ -187,7 +187,7 @@ type Volume struct {
 	Info      VolumeInfo `json:"info"`
 }
 
-// Volume describes a storage volume in the model.
+// VolumeInfo describes a storage volume in the model.
 type VolumeInfo struct {
 	VolumeId   string `json:"volume-id"`
 	HardwareId string `json:"hardware-id,omitempty"`
@@ -214,7 +214,7 @@ type VolumeAttachment struct {
 	Info       VolumeAttachmentInfo `json:"info"`
 }
 
-// VolumeAttachment identifies and describes a volume attachment.
+// VolumeAttachmentPlan identifies and describes a volume attachment plan.
 type VolumeAttachmentPlan struct {
 	VolumeTag  string                   `json:"volume-tag"`
 	MachineTag string                   `json:"machine-tag"`
@@ -334,7 +334,7 @@ type VolumeResults struct {
 	Results []VolumeResult `json:"results,omitempty"`
 }
 
-// VolumeParamsResults holds provisioning parameters for a volume.
+// VolumeParamsResult holds provisioning parameters for a volume.
 type VolumeParamsResult struct {
 	Result VolumeParams `json:"result"`
 	Error  *Error       `json:"error,omitempty"`
@@ -345,7 +345,7 @@ type VolumeParamsResults struct {
 	Results []VolumeParamsResult `json:"results,omitempty"`
 }
 
-// RemoveVolumeParamsResults holds parameters for destroying a volume.
+// RemoveVolumeParamsResult holds parameters for destroying a volume.
 type RemoveVolumeParamsResult struct {
 	Result RemoveVolumeParams `json:"result"`
 	Error  *Error             `json:"error,omitempty"`
@@ -356,7 +356,7 @@ type RemoveVolumeParamsResults struct {
 	Results []RemoveVolumeParamsResult `json:"results,omitempty"`
 }
 
-// VolumeAttachmentParamsResults holds provisioning parameters for a volume
+// VolumeAttachmentParamsResult holds provisioning parameters for a volume
 // attachment.
 type VolumeAttachmentParamsResult struct {
 	Result VolumeAttachmentParams `json:"result"`
@@ -376,7 +376,7 @@ type Filesystem struct {
 	Info          FilesystemInfo `json:"info"`
 }
 
-// Filesystem describes a storage filesystem in the model.
+// FilesystemInfo describes a storage filesystem in the model.
 type FilesystemInfo struct {
 	FilesystemId string `json:"filesystem-id"`
 	// Pool is the name of the storage pool used to
@@ -471,7 +471,7 @@ type FilesystemResults struct {
 	Results []FilesystemResult `json:"results,omitempty"`
 }
 
-// FilesystemParamsResults holds provisioning parameters for a filesystem.
+// FilesystemParamsResult holds provisioning parameters for a filesystem.
 type FilesystemParamsResult struct {
 	Result FilesystemParams `json:"result"`
 	Error  *Error           `json:"error,omitempty"`
@@ -495,7 +495,7 @@ type RemoveFilesystemParamsResults struct {
 	Results []RemoveFilesystemParamsResult `json:"results,omitempty"`
 }
 
-// FilesystemAttachmentParamsResults holds provisioning parameters for a filesystem
+// FilesystemAttachmentParamsResult holds provisioning parameters for a filesystem
 // attachment.
 type FilesystemAttachmentParamsResult struct {
 	Result FilesystemAttachmentParams `json:"result"`

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -892,6 +892,24 @@ func (s *StorageStateSuite) TestAttachStorageTakesOwnership(c *gc.C) {
 	c.Assert(owner, gc.Equals, u2.Tag())
 }
 
+func (s *StorageStateSuite) TestAttachStorageIdempotent(c *gc.C) {
+	app, u, storageTag := s.setupSingleStorageDetachable(c, "block", "modelscoped")
+	u2, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Detach, but do not destroy, the storage.
+	err = s.storageBackend.DetachStorage(storageTag, u.UnitTag(), false, dontWait)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Now attach the storage to the second unit.
+	err = s.storageBackend.AttachStorage(storageTag, u2.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// And again.
+	err = s.storageBackend.AttachStorage(storageTag, u2.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *StorageStateSuite) TestAttachStorageAssignedMachine(c *gc.C) {
 	app, u, storageTag := s.setupSingleStorageDetachable(c, "block", "modelscoped")
 	u2, err := app.AddUnit(state.AddUnitParams{})

--- a/worker/storageprovisioner/filesystem_events.go
+++ b/worker/storageprovisioner/filesystem_events.go
@@ -69,7 +69,7 @@ func filesystemsChanged(ctx *context, changes []string) error {
 // attachments with the provided IDs have been seen to have changed.
 func filesystemAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageId) error {
 	ids := copyMachineStorageIds(watcherIds)
-	alive, dying, dead, err := attachmentLife(ctx, ids)
+	alive, dying, dead, gone, err := attachmentLife(ctx, ids)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -78,6 +78,10 @@ func filesystemAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStor
 		// We should not see dead filesystem attachments;
 		// attachments go directly from Dying to removed.
 		ctx.config.Logger.Warningf("unexpected dead filesystem attachments: %v", dead)
+	}
+	// Clean up any attachments which have been removed.
+	for _, id := range gone {
+		delete(ctx.filesystemAttachments, id)
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -17,7 +17,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs/context"
@@ -120,7 +119,7 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 
 	volumeInfoSet := make(chan interface{})
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	volumeAccessor.setVolumeInfo = func(volumes []params.Volume) ([]params.ErrorResult, error) {
 		defer close(volumeInfoSet)
 		c.Assert(volumes, jc.SameContents, expectedVolumes)
@@ -160,7 +159,7 @@ func (s *storageProvisionerSuite) TestVolumeAdded(c *gc.C) {
 
 func (s *storageProvisionerSuite) TestCreateVolumeCreatesAttachment(c *gc.C) {
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 
 	volumeAttachmentInfoSet := make(chan interface{})
 	volumeAccessor.setVolumeAttachmentInfo = func(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
@@ -220,7 +219,7 @@ func (s *storageProvisionerSuite) TestCreateVolumeCreatesAttachment(c *gc.C) {
 func (s *storageProvisionerSuite) TestCreateVolumeRetry(c *gc.C) {
 	volumeInfoSet := make(chan interface{})
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	volumeAccessor.setVolumeInfo = func(volumes []params.Volume) ([]params.ErrorResult, error) {
 		defer close(volumeInfoSet)
 		return make([]params.ErrorResult, len(volumes)), nil
@@ -289,7 +288,7 @@ func (s *storageProvisionerSuite) TestCreateVolumeRetry(c *gc.C) {
 func (s *storageProvisionerSuite) TestCreateFilesystemRetry(c *gc.C) {
 	filesystemInfoSet := make(chan interface{})
 	filesystemAccessor := newMockFilesystemAccessor()
-	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	filesystemAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	filesystemAccessor.setFilesystemInfo = func(filesystems []params.Filesystem) ([]params.ErrorResult, error) {
 		defer close(filesystemInfoSet)
 		return make([]params.ErrorResult, len(filesystems)), nil
@@ -358,7 +357,7 @@ func (s *storageProvisionerSuite) TestCreateFilesystemRetry(c *gc.C) {
 func (s *storageProvisionerSuite) TestAttachVolumeRetry(c *gc.C) {
 	volumeInfoSet := make(chan interface{})
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	volumeAccessor.setVolumeInfo = func(volumes []params.Volume) ([]params.ErrorResult, error) {
 		defer close(volumeInfoSet)
 		return make([]params.ErrorResult, len(volumes)), nil
@@ -440,7 +439,7 @@ func (s *storageProvisionerSuite) TestAttachVolumeRetry(c *gc.C) {
 func (s *storageProvisionerSuite) TestAttachFilesystemRetry(c *gc.C) {
 	filesystemInfoSet := make(chan interface{})
 	filesystemAccessor := newMockFilesystemAccessor()
-	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	filesystemAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	filesystemAccessor.setFilesystemInfo = func(filesystems []params.Filesystem) ([]params.ErrorResult, error) {
 		defer close(filesystemInfoSet)
 		return make([]params.ErrorResult, len(filesystems)), nil
@@ -521,7 +520,7 @@ func (s *storageProvisionerSuite) TestAttachFilesystemRetry(c *gc.C) {
 
 func (s *storageProvisionerSuite) TestValidateVolumeParams(c *gc.C) {
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	volumeAccessor.provisionedVolumes["volume-3"] = params.Volume{
 		VolumeTag: "volume-3",
 		Info:      params.VolumeInfo{VolumeId: "vol-ume"},
@@ -615,7 +614,7 @@ func (s *storageProvisionerSuite) TestValidateVolumeParams(c *gc.C) {
 
 func (s *storageProvisionerSuite) TestValidateFilesystemParams(c *gc.C) {
 	filesystemAccessor := newMockFilesystemAccessor()
-	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	filesystemAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	filesystemAccessor.provisionedFilesystems["filesystem-3"] = params.Filesystem{
 		FilesystemTag: "filesystem-3",
 		Info:          params.FilesystemInfo{FilesystemId: "fs-id"},
@@ -844,8 +843,8 @@ func (s *storageProvisionerSuite) TestVolumeAttachmentAdded(c *gc.C) {
 			VolumeId: "vol-123",
 		},
 	}
-	volumeAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-0"] = "already-provisioned-0"
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 
 	// machine-0/volume-1 attachment is already created.
 	// We should see a reattachment.
@@ -903,8 +902,8 @@ func (s *storageProvisionerSuite) TestVolumeAttachmentNoStaticReattachment(c *gc
 			VolumeId: "vol-123",
 		},
 	}
-	volumeAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-0"] = "already-provisioned-0"
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 
 	alreadyAttached := params.MachineStorageId{
 		MachineTag:    "machine-0",
@@ -967,8 +966,8 @@ func (s *storageProvisionerSuite) TestFilesystemAttachmentAdded(c *gc.C) {
 			FilesystemId: "fs-123",
 		},
 	}
-	filesystemAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
-	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	filesystemAccessor.provisionedMachines["machine-0"] = "already-provisioned-0"
+	filesystemAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 
 	// machine-0/filesystem-1 attachment is already created.
 	// We should see a reattachment.
@@ -1097,7 +1096,7 @@ func (s *storageProvisionerSuite) TestAttachVolumeBackedFilesystem(c *gc.C) {
 			Size:         123,
 		},
 	}
-	filesystemAccessor.provisionedMachines["machine-0"] = instance.Id("already-provisioned-0")
+	filesystemAccessor.provisionedMachines["machine-0"] = "already-provisioned-0"
 
 	args.volumes.blockDevices[params.MachineStorageId{
 		MachineTag:    "machine-0",
@@ -1154,7 +1153,7 @@ func (s *storageProvisionerSuite) TestAttachVolumeBackedFilesystem(c *gc.C) {
 func (s *storageProvisionerSuite) TestResourceTags(c *gc.C) {
 	volumeInfoSet := make(chan interface{})
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	volumeAccessor.setVolumeInfo = func(volumes []params.Volume) ([]params.ErrorResult, error) {
 		defer close(volumeInfoSet)
 		return nil, nil
@@ -1162,7 +1161,7 @@ func (s *storageProvisionerSuite) TestResourceTags(c *gc.C) {
 
 	filesystemInfoSet := make(chan interface{})
 	filesystemAccessor := newMockFilesystemAccessor()
-	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	filesystemAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	filesystemAccessor.setFilesystemInfo = func(filesystems []params.Filesystem) ([]params.ErrorResult, error) {
 		defer close(filesystemInfoSet)
 		return nil, nil
@@ -1217,7 +1216,7 @@ func (s *storageProvisionerSuite) TestResourceTags(c *gc.C) {
 
 func (s *storageProvisionerSuite) TestSetVolumeInfoErrorStopsWorker(c *gc.C) {
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	volumeAccessor.setVolumeInfo = func(volumes []params.Volume) ([]params.ErrorResult, error) {
 		return nil, errors.New("belly up")
 	}
@@ -1240,7 +1239,7 @@ func (s *storageProvisionerSuite) TestSetVolumeInfoErrorStopsWorker(c *gc.C) {
 
 func (s *storageProvisionerSuite) TestSetVolumeInfoErrorResultDoesNotStopWorker(c *gc.C) {
 	volumeAccessor := newMockVolumeAccessor()
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 	volumeAccessor.setVolumeInfo = func(volumes []params.Volume) ([]params.ErrorResult, error) {
 		return []params.ErrorResult{{Error: &params.Error{Message: "message", Code: "code"}}}, nil
 	}
@@ -1341,7 +1340,7 @@ func (s *storageProvisionerSuite) TestDetachVolumes(c *gc.C) {
 			VolumeId: "vol-123",
 		},
 	}
-	volumeAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 
 	args := &workerArgs{
 		volumes: volumeAccessor,
@@ -1385,7 +1384,7 @@ func (s *storageProvisionerSuite) TestDetachVolumesRetry(c *gc.C) {
 			VolumeId: "vol-123",
 		},
 	}
-	volumeAccessor.provisionedMachines[machine.String()] = instance.Id("already-provisioned-1")
+	volumeAccessor.provisionedMachines[machine.String()] = "already-provisioned-1"
 
 	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
 		return []params.LifeResult{{Life: life.Dying}}, nil
@@ -1462,6 +1461,86 @@ func (s *storageProvisionerSuite) TestDetachVolumesRetry(c *gc.C) {
 		{Tag: "volume-1", Status: "detaching", Info: "badness"},
 		{Tag: "volume-1", Status: "detached", Info: ""},
 	})
+}
+
+func (s *storageProvisionerSuite) TestDetachVolumesNotFound(c *gc.C) {
+	// This test just checks that there are no unexpected api calls
+	// if a volume attachment is deleted from state.
+	var attached bool
+	volumeAttachmentInfoSet := make(chan interface{})
+	volumeAccessor := newMockVolumeAccessor()
+	volumeAccessor.setVolumeAttachmentInfo = func(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
+		close(volumeAttachmentInfoSet)
+		attached = true
+		for _, a := range volumeAttachments {
+			id := params.MachineStorageId{
+				MachineTag:    a.MachineTag,
+				AttachmentTag: a.VolumeTag,
+			}
+			volumeAccessor.provisionedAttachments[id] = a
+		}
+		return make([]params.ErrorResult, len(volumeAttachments)), nil
+	}
+
+	expectedAttachmentIds := []params.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "volume-1",
+	}}
+
+	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
+		c.Assert(ids, gc.DeepEquals, expectedAttachmentIds)
+		value := life.Alive
+		var lifeErr *params.Error
+		if attached {
+			lifeErr = &params.Error{Code: params.CodeNotFound}
+		}
+		return []params.LifeResult{{Life: value, Error: lifeErr}}, nil
+	}
+
+	s.provider.detachVolumesFunc = func(args []storage.VolumeAttachmentParams) ([]error, error) {
+		c.Fatalf("unexpected call to detachVolumes")
+		return nil, nil
+	}
+	s.provider.destroyVolumesFunc = func(ids []string) ([]error, error) {
+		c.Fatalf("unexpected call to destroyVolumes")
+		return nil, nil
+	}
+
+	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+		c.Fatalf("unexpected call to removeAttachments")
+		return nil, nil
+	}
+
+	// volume-1 and machine-1 are provisioned.
+	volumeAccessor.provisionedVolumes["volume-1"] = params.Volume{
+		VolumeTag: "volume-1",
+		Info: params.VolumeInfo{
+			VolumeId: "vol-123",
+		},
+	}
+	volumeAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
+
+	args := &workerArgs{
+		volumes: volumeAccessor,
+		life: &mockLifecycleManager{
+			attachmentLife:    attachmentLife,
+			removeAttachments: removeAttachments,
+		},
+		registry: s.registry,
+	}
+	worker := newStorageProvisioner(c, args)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+
+	volumeAccessor.attachmentsWatcher.changes <- []watcher.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "volume-1",
+	}}
+	volumeAccessor.volumesWatcher.changes <- []string{"1"}
+	waitChannel(c, volumeAttachmentInfoSet, "waiting for volume attachments to be set")
+
+	// This results in a not found attachment.
+	volumeAccessor.attachmentsWatcher.changes <- []watcher.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "volume-1",
+	}}
+	workertest.CleanKill(c, worker)
 }
 
 func (s *storageProvisionerSuite) TestDetachFilesystemsUnattached(c *gc.C) {
@@ -1542,7 +1621,7 @@ func (s *storageProvisionerSuite) TestDetachFilesystems(c *gc.C) {
 			FilesystemId: "fs-id",
 		},
 	}
-	filesystemAccessor.provisionedMachines["machine-1"] = instance.Id("already-provisioned-1")
+	filesystemAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
 
 	args := &workerArgs{
 		filesystems: filesystemAccessor,
@@ -1566,6 +1645,86 @@ func (s *storageProvisionerSuite) TestDetachFilesystems(c *gc.C) {
 	}}
 	waitChannel(c, detached, "waiting for filesystem to be detached")
 	waitChannel(c, removed, "waiting for attachment to be removed")
+}
+
+func (s *storageProvisionerSuite) TestDetachFilesystemsNotFound(c *gc.C) {
+	// This test just checks that there are no unexpected api calls
+	// if a volume attachment is deleted from state.
+	var attached bool
+	filesystemAttachmentInfoSet := make(chan interface{})
+	filesystemAccessor := newMockFilesystemAccessor()
+	filesystemAccessor.setFilesystemAttachmentInfo = func(filesystemAttachments []params.FilesystemAttachment) ([]params.ErrorResult, error) {
+		close(filesystemAttachmentInfoSet)
+		attached = true
+		for _, a := range filesystemAttachments {
+			id := params.MachineStorageId{
+				MachineTag:    a.MachineTag,
+				AttachmentTag: a.FilesystemTag,
+			}
+			filesystemAccessor.provisionedAttachments[id] = a
+		}
+		return make([]params.ErrorResult, len(filesystemAttachments)), nil
+	}
+
+	expectedAttachmentIds := []params.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "filesystem-1",
+	}}
+
+	attachmentLife := func(ids []params.MachineStorageId) ([]params.LifeResult, error) {
+		c.Assert(ids, gc.DeepEquals, expectedAttachmentIds)
+		value := life.Alive
+		var lifeErr *params.Error
+		if attached {
+			lifeErr = &params.Error{Code: params.CodeNotFound}
+		}
+		return []params.LifeResult{{Life: value, Error: lifeErr}}, nil
+	}
+
+	s.provider.detachFilesystemsFunc = func(args []storage.FilesystemAttachmentParams) ([]error, error) {
+		c.Fatalf("unexpected call to detachFilesystems")
+		return nil, nil
+	}
+	s.provider.destroyFilesystemsFunc = func(ids []string) ([]error, error) {
+		c.Fatalf("unexpected call to destroyFilesystems")
+		return nil, nil
+	}
+
+	removeAttachments := func(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+		c.Fatalf("unexpected call to removeAttachments")
+		return nil, nil
+	}
+
+	// filesystem-1 and machine-1 are provisioned.
+	filesystemAccessor.provisionedFilesystems["filesystem-1"] = params.Filesystem{
+		FilesystemTag: "filesystem-1",
+		Info: params.FilesystemInfo{
+			FilesystemId: "fs-id",
+		},
+	}
+	filesystemAccessor.provisionedMachines["machine-1"] = "already-provisioned-1"
+
+	args := &workerArgs{
+		filesystems: filesystemAccessor,
+		life: &mockLifecycleManager{
+			attachmentLife:    attachmentLife,
+			removeAttachments: removeAttachments,
+		},
+		registry: s.registry,
+	}
+	worker := newStorageProvisioner(c, args)
+	defer func() { c.Assert(worker.Wait(), gc.IsNil) }()
+
+	filesystemAccessor.attachmentsWatcher.changes <- []watcher.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "filesystem-1",
+	}}
+	filesystemAccessor.filesystemsWatcher.changes <- []string{"1"}
+	waitChannel(c, filesystemAttachmentInfoSet, "waiting for filesystem attachments to be set")
+
+	// This results in a not found attachment.
+	filesystemAccessor.attachmentsWatcher.changes <- []watcher.MachineStorageId{{
+		MachineTag: "machine-1", AttachmentTag: "filesystem-1",
+	}}
+	workertest.CleanKill(c, worker)
 }
 
 func (s *storageProvisionerSuite) TestDestroyVolumes(c *gc.C) {

--- a/worker/storageprovisioner/volume_events.go
+++ b/worker/storageprovisioner/volume_events.go
@@ -180,7 +180,7 @@ func volumePlansToMachineIds(plans []params.VolumeAttachmentPlanResult) []params
 // attachments with the provided IDs have been seen to have changed.
 func volumeAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageId) error {
 	ids := copyMachineStorageIds(watcherIds)
-	alive, dying, dead, err := attachmentLife(ctx, ids)
+	alive, dying, dead, gone, err := attachmentLife(ctx, ids)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -189,6 +189,10 @@ func volumeAttachmentsChanged(ctx *context, watcherIds []watcher.MachineStorageI
 		// We should not see dead volume attachments;
 		// attachments go directly from Dying to removed.
 		ctx.config.Logger.Warningf("unexpected dead volume attachments: %v", dead)
+	}
+	// Clean up any attachments which have been removed.
+	for _, id := range gone {
+		delete(ctx.volumeAttachments, id)
 	}
 	if len(alive)+len(dying) == 0 {
 		return nil


### PR DESCRIPTION
There a couple of storage cleanups here.
1. When detaching storage, the attachment entity goes from Dying -> Removed. The storage provisioner workers gets the event for the change to dying, and then interprets the subsequent NotFound error as the attachment being Dead and logs the warning as we don't expect any Dead attachments. The correct thing to do is simply cleanup.
2. When attaching storage to a unit, if it is done twice, the state code was surfacing the internal ErrNoTransactions error - clearly it was attempting to say that the operation is idempotent but was poorly implemented. This is fixed.

Also some drive by lint fixes.

## QA steps
```
juju deploy someapp
# add storage to the first unit
juju add-storage someapp/0 logdata=ebs,1,200M
# remove the disk from the unit
juju detach-storage logdata/0
# add a second unit
juju add-unit someapp
# re-attach the old disk (logdata/0) new unit 
juju attach-storage someapp/1 logdata/0
# and again
juju attach-storage someapp/1 logdata/0

^^^ should be no error
And logs should not have any errors about Dead filesystem attachments
```

## Bug reference

The idempotent attach issue is referenced by this bug (but the bug is for a different issue)
https://bugs.launchpad.net/juju/+bug/1950781
