### PR TITLE
[JUJU-227] Stop the CAAS storage provisioner worker if the application is dead;

### DIFF
--- a/worker/caasfirewaller/worker_test.go
+++ b/worker/caasfirewaller/worker_test.go
@@ -246,7 +246,6 @@ func (s *WorkerSuite) TestRemoveApplicationStopsWorker(c *gc.C) {
 	// Set up the errors before triggering any events to avoid racing
 	// with the worker loop. First time around the loop the
 	// application's alive, then it's gone.
-	//s.lifeGetter.life = life.Dead
 	s.applicationGetter.SetErrors(nil, nil, errors.NotFoundf("application"))
 
 	w, err := caasfirewaller.NewWorker(s.config)

--- a/worker/caasfirewallersidecar/worker.go
+++ b/worker/caasfirewallersidecar/worker.go
@@ -133,7 +133,7 @@ func (p *firewaller) loop() error {
 				}
 
 				appLife, err := p.config.LifeGetter.Life(appName)
-				if errors.IsNotFound(err) {
+				if errors.IsNotFound(err) || appLife == life.Dead {
 					w, ok := p.appWorkers[appName]
 					if ok {
 						if err := worker.Stop(w); err != nil {
@@ -146,9 +146,8 @@ func (p *firewaller) loop() error {
 				if err != nil {
 					return errors.Trace(err)
 				}
-				if _, ok := p.appWorkers[appName]; ok || appLife == life.Dead {
-					// Already watching the application. or we're
-					// not yet watching it and it's dead.
+				if _, ok := p.appWorkers[appName]; ok {
+					// Already watching the application.
 					continue
 				}
 				w, err := p.newApplicationWorker(

--- a/worker/caasfirewallersidecar/worker_test.go
+++ b/worker/caasfirewallersidecar/worker_test.go
@@ -157,13 +157,13 @@ func (s *workerSuite) TestStartStop(c *gc.C) {
 
 	s.firewallerAPI.EXPECT().ApplicationCharmInfo("app1").Return(charmInfo, nil)
 	s.lifeGetter.EXPECT().Life("app1").Return(life.Value(""), errors.NotFoundf("%q", "app1"))
-	// Stopped app1's worker.
+	// Stopped app1's worker because it's removed.
 	app1Worker.EXPECT().Kill()
 	app1Worker.EXPECT().Wait().Return(nil)
 
 	s.firewallerAPI.EXPECT().ApplicationCharmInfo("app2").Return(charmInfo, nil)
-	s.lifeGetter.EXPECT().Life("app2").Return(life.Value(""), errors.NotFoundf("%q", "app2"))
-	// Stopped app2's worker.
+	s.lifeGetter.EXPECT().Life("app2").Return(life.Dead, nil)
+	// Stopped app2's worker because it's dead.
 	app2Worker.EXPECT().Kill()
 	app2Worker.EXPECT().Wait().Return(nil)
 

--- a/worker/storageprovisioner/caasworker.go
+++ b/worker/storageprovisioner/caasworker.go
@@ -125,9 +125,8 @@ func (p *provisioner) loop() error {
 				appLifeResult := appsLife[i]
 				if appLifeResult.Error != nil && params.IsCodeNotFound(appLifeResult.Error) || appLifeResult.Life == life.Dead {
 					p.config.Logger.Debugf("app %v not found", appID)
-					_, ok := p.getApplicationWorker(appID)
-					if ok {
-						if err := worker.Stop(appsWatcher); err != nil {
+					if appWorker, ok := p.getApplicationWorker(appID); ok {
+						if err := worker.Stop(appWorker); err != nil {
 							p.config.Logger.Errorf("stopping application storage worker for %v: %v", appID, err)
 						}
 						p.deleteApplicationWorker(appID)

--- a/worker/storageprovisioner/caasworker_test.go
+++ b/worker/storageprovisioner/caasworker_test.go
@@ -142,7 +142,7 @@ func (s *WorkerSuite) assertStopsWatchingApplication(c *gc.C, lifeGetterInjecter
 	c.Assert(running, jc.IsTrue)
 
 	// Add an additional app worker so we can check that the correct one is accessed.
-	storageprovisioner.NewStorageWorker(w, "postgresql")
+	storageprovisioner.NewStorageWorker(c, w, "postgresql")
 
 	if lifeGetterInjecter != nil {
 		lifeGetterInjecter()

--- a/worker/storageprovisioner/caasworker_test.go
+++ b/worker/storageprovisioner/caasworker_test.go
@@ -7,14 +7,12 @@ import (
 	stdcontext "context"
 	"time"
 
-	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2"
-	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
@@ -33,8 +31,6 @@ type WorkerSuite struct {
 	lifeGetter          *mockLifecycleManager
 
 	applicationChanges chan []string
-
-	clock *testclock.Clock
 }
 
 var _ = gc.Suite(&WorkerSuite{})
@@ -85,18 +81,6 @@ func (s *WorkerSuite) TestStartStop(c *gc.C) {
 	workertest.CleanKill(c, w)
 }
 
-func (s *WorkerSuite) setupNewUnitScenario(c *gc.C) worker.Worker {
-	w, err := storageprovisioner.NewCaasWorker(s.config)
-	c.Assert(err, jc.ErrorIsNil)
-
-	select {
-	case s.applicationChanges <- []string{"mariadb"}:
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out sending applications change")
-	}
-	return w
-}
-
 func (s *WorkerSuite) TestWatchApplicationDead(c *gc.C) {
 	w, err := storageprovisioner.NewCaasWorker(s.config)
 	c.Assert(err, jc.ErrorIsNil)
@@ -125,7 +109,13 @@ func (s *WorkerSuite) TestWatchApplicationDead(c *gc.C) {
 	s.config.Filesystems.(*mockFilesystemAccessor).CheckCall(c, 0, "WatchFilesystems", coretesting.ModelTag)
 }
 
-func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplication(c *gc.C) {
+func (s *WorkerSuite) TestStopsWatchingApplicationBecauseApplicationRemoved(c *gc.C) {
+	s.assertStopsWatchingApplication(c, func() {
+		s.lifeGetter.err = &params.Error{Code: params.CodeNotFound}
+	})
+}
+
+func (s *WorkerSuite) assertStopsWatchingApplication(c *gc.C, lifeGetterInjecter func()) {
 	w, err := storageprovisioner.NewCaasWorker(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -154,7 +144,9 @@ func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplication(c *gc.C) {
 	// Add an additional app worker so we can check that the correct one is accessed.
 	storageprovisioner.NewStorageWorker(w, "postgresql")
 
-	s.lifeGetter.err = &params.Error{Code: params.CodeNotFound}
+	if lifeGetterInjecter != nil {
+		lifeGetterInjecter()
+	}
 	select {
 	case s.applicationChanges <- []string{"postgresql"}:
 	case <-time.After(coretesting.LongWait):
@@ -177,6 +169,10 @@ func (s *WorkerSuite) TestRemoveApplicationStopsWatchingApplication(c *gc.C) {
 	c.Assert(running, jc.IsFalse)
 	workertest.CleanKill(c, w)
 	workertest.CheckKilled(c, s.applicationsWatcher.watcher)
+}
+
+func (s *WorkerSuite) TestStopsWatchingApplicationBecauseApplicationDead(c *gc.C) {
+	s.assertStopsWatchingApplication(c, nil)
 }
 
 func (s *WorkerSuite) TestWatcherErrorStopsWorker(c *gc.C) {

--- a/worker/storageprovisioner/export_test.go
+++ b/worker/storageprovisioner/export_test.go
@@ -3,7 +3,12 @@
 
 package storageprovisioner
 
-import "github.com/juju/worker/v3"
+import (
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3"
+	gc "gopkg.in/check.v1"
+)
 
 var (
 	NewManagedFilesystemSource = &newManagedFilesystemSource
@@ -14,7 +19,12 @@ func StorageWorker(parent worker.Worker, appName string) (worker.Worker, bool) {
 	return p.getApplicationWorker(appName)
 }
 
-func NewStorageWorker(parent worker.Worker, appName string) {
+func NewStorageWorker(c *gc.C, parent worker.Worker, appName string) {
 	p := parent.(*provisioner)
-	p.saveApplicationWorker(appName, &storageProvisioner{})
+	cfg := p.config
+	cfg.Scope = names.NewApplicationTag(appName)
+	w, err := NewStorageProvisioner(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	p.saveApplicationWorker(appName, w)
+	_ = p.catacomb.Add(w)
 }


### PR DESCRIPTION
We should stop the CAAS storage provisioner worker if the application is dead.
Currently, we stop the worker if the application is not found, but we actually could never get an application change event if the application has already been removed.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps
No good way to QA this.
What I did was to add a debug message to log when the worker gets stopped.

```console
$ juju deploy hello-kubecon

$ juju remove-application hello-kubecon --force

```

## Documentation changes

No


## Bug reference

This issue was found when I was investigating the below bug. But this PR is not fixing the below bug yet.
https://bugs.launchpad.net/juju/+bug/1946382
