### PR TITLE
[JUJU-237] Fix the failure to update homebrew on none juju/juju

### DIFF
--- a/.github/workflows/update-brew-formulae.yml
+++ b/.github/workflows/update-brew-formulae.yml
@@ -6,7 +6,7 @@ on:
     - cron:  '0 */12 * * *'
 jobs:
   update-brew-tap:
-    if: ${{ github.repository == "juju/juju" }}
+    if: github.repository_owner == 'juju'
     runs-on: ubuntu-latest
     steps:
       - name: Update Homebrew formulae


### PR DESCRIPTION
The following uses the repository_owner instead of repository to work
out if it's possible to update the homebrew formula. This should prevent
the errors we get occasionally on none juju/juju repos.

## QA steps

Wait for tests to run.
