### PR TITLE
[JUJU-240] Use the storage prefix when selecting pvcs for sidecar charms

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1581,7 +1581,7 @@ func (a *app) volumeName(storageName string) string {
 }
 
 // pvcNames returns a mapping of volume name to PVC name for this app's PVCs.
-func (a *app) pvcNames() (map[string]string, error) {
+func (a *app) pvcNames(storagePrefix string) (map[string]string, error) {
 	// Fetch all Juju PVCs associated with this app
 	labelSelectors := map[string]string{
 		"app.kubernetes.io/managed-by": "juju",
@@ -1604,11 +1604,12 @@ func (a *app) pvcNames() (map[string]string, error) {
 		}
 
 		// Try to match different PVC name formats that have evolved over time
+		storagePart := s + "-" + storagePrefix
 		regexes := []string{
 			// Sidecar "{appName}-{storageName}-{uniqueId}", e.g., "dex-auth-test-0837847d-dex-auth-0"
-			"^" + regexp.QuoteMeta(a.name+"-"+s) + `-[0-9a-f]{8}`,
+			"^" + regexp.QuoteMeta(a.name+"-"+storagePart),
 			// Pod-spec "{storageName}-{uniqueId}", e.g., "test-0837847d-dex-auth-0"
-			"^" + regexp.QuoteMeta(s) + `-[0-9a-f]{8}`,
+			"^" + regexp.QuoteMeta(storagePart),
 			// Legacy "juju-{storageName}-{n}", e.g., "juju-test-1-dex-auth-0"
 			"^juju-" + regexp.QuoteMeta(s) + `-[0-9]+`,
 		}
@@ -1641,7 +1642,7 @@ func (a *app) configureStorage(
 		storageClassMap[v.Name] = v
 	}
 
-	pvcNames, err := a.pvcNames()
+	pvcNames, err := a.pvcNames(storageUniqueID)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -2371,12 +2371,23 @@ func (s *applicationSuite) TestPVCNames(c *gc.C) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gitlab-storage_b-abcd1235-gitlab-0",
+				Name:      "gitlab-storage_b-abcd1234-gitlab-0",
 				Namespace: "test",
 				Labels: map[string]string{
 					"app.kubernetes.io/managed-by": "juju",
 					"app.kubernetes.io/name":       "gitlab",
 					"storage.juju.is/name":         "storage_b",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gitlab-storage_g-abcd666-gitlab-0",
+				Namespace: "test",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "juju",
+					"app.kubernetes.io/name":       "gitlab",
+					"storage.juju.is/name":         "storage_g",
 				},
 			},
 		},
@@ -2419,11 +2430,11 @@ func (s *applicationSuite) TestPVCNames(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	names, err := application.PVCNames(s.client, "test", "gitlab")
+	names, err := application.PVCNames(s.client, "test", "gitlab", "abcd1234")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(names, gc.DeepEquals, map[string]string{
 		"gitlab-storage_a": "storage_a-abcd1234",
-		"gitlab-storage_b": "gitlab-storage_b-abcd1235",
+		"gitlab-storage_b": "gitlab-storage_b-abcd1234",
 		"gitlab-storage_c": "juju-storage_c-42",
 	})
 }

--- a/caas/kubernetes/provider/application/package_test.go
+++ b/caas/kubernetes/provider/application/package_test.go
@@ -52,11 +52,11 @@ func NewApplicationForTest(
 	)
 }
 
-func PVCNames(client kubernetes.Interface, namespace, appName string) (map[string]string, error) {
+func PVCNames(client kubernetes.Interface, namespace, appName, storagePrefix string) (map[string]string, error) {
 	a := &app{
 		name:      appName,
 		namespace: namespace,
 		client:    client,
 	}
-	return a.pvcNames()
+	return a.pvcNames(storagePrefix)
 }

--- a/state/application.go
+++ b/state/application.go
@@ -3372,8 +3372,8 @@ func (op *UpdateUnitsOperation) Build(attempt int) ([]txn.Op, error) {
 	var ops []txn.Op
 
 	all := op.allOps()
-	for _, op := range all {
-		switch nextOps, err := op.Build(attempt); err {
+	for _, txnOp := range all {
+		switch nextOps, err := txnOp.Build(attempt); err {
 		case jujutxn.ErrNoOperations:
 			continue
 		case nil:


### PR DESCRIPTION
When a k8s application with storage is removed, and the storage is to be retained, we keep the PVCs and PVs.
When a new application but with the same name is deployed, we use a unique storage prefix to filter out any previously created PVCs. Except we weren't doing it for sidecar charms. Hence storage for the new app with the reused name was picking up the old PVCs and things got confused.

This PR ensure the storage prefix is used to filter PVC selection for sidecar charms.
Also a small driveby lint fix.

## QA steps

deploy hello-kubecon
kubectl get pvc
juju status --storage

juju remove-application kubecon
wait for it to be removed

deploy hello-kubecon
kubectl get pvc
juju status --storage

New PVCs should be created and the old ones left alone.

NB - there's a different bug which means that we end up with ghost PVCs when the app is redeployed with the same name. This is being fixed separately.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1946382