### PR TITLE
[JUJU-245] Do not error with permission denied if a controller tries to access removed storage

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -117,7 +117,9 @@ func NewStorageProvisionerAPIv3(
 				return authorizer.AuthController()
 			}
 			f, err := sb.Filesystem(tag)
-			if err != nil {
+			if errors.IsNotFound(err) {
+				return authorizer.AuthController()
+			} else if err != nil {
 				return false
 			}
 			volumeTag, err := f.Volume()
@@ -127,7 +129,7 @@ func NewStorageProvisionerAPIv3(
 				// machines that the volume is attached to, then
 				// it may access the filesystem too.
 				volumeAttachments, err := sb.VolumeAttachments(volumeTag)
-				if err != nil {
+				if err != nil && !errors.IsNotFound(err) {
 					return false
 				}
 				for _, a := range volumeAttachments {
@@ -135,7 +137,7 @@ func NewStorageProvisionerAPIv3(
 						return true
 					}
 				}
-			} else if err != state.ErrNoBackingVolume {
+			} else if !errors.IsNotFound(err) && err != state.ErrNoBackingVolume {
 				return false
 			}
 			return authorizer.AuthController()

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -1490,7 +1490,7 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemsController(c *gc.C) {
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 			{Error: nil},
 			{Error: &params.Error{Message: "removing filesystem 2: filesystem is not dead"}},
-			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
+			{Error: nil},
 			{Error: &params.Error{Message: `"filesystem-invalid" is not a valid filesystem tag`}},
 			{Error: &params.Error{Message: "permission denied", Code: "unauthorized access"}},
 		},
@@ -1753,7 +1753,10 @@ func (s *caasProvisionerSuite) TestFilesystemLife(c *gc.C) {
 		Results: []params.LifeResult{
 			{Life: life.Alive},
 			{Life: life.Alive},
-			{Error: apiservertesting.ErrUnauthorized},
+			{Error: &params.Error{
+				Code:    params.CodeNotFound,
+				Message: `filesystem "42" not found`,
+			}},
 		},
 	})
 }

--- a/apiserver/testing/errors.go
+++ b/apiserver/testing/errors.go
@@ -5,10 +5,6 @@ package testing
 
 import (
 	"fmt"
-	"reflect"
-
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/params"
 )
@@ -62,13 +58,4 @@ func ServerError(message string) *params.Error {
 
 func PrefixedError(prefix, message string) *params.Error {
 	return ServerError(prefix + message)
-}
-
-func AssertNotImplemented(c *gc.C, apiFacade interface{}, methodName string) {
-	val := reflect.ValueOf(apiFacade)
-	c.Assert(val.IsValid(), jc.IsTrue)
-	indir := reflect.Indirect(val)
-	c.Assert(indir.IsValid(), jc.IsTrue)
-	method := indir.MethodByName(methodName)
-	c.Assert(method.IsValid(), jc.IsFalse)
 }


### PR DESCRIPTION
If a controller agent tries to access storage (fs or vol) and that storage has been removed, access should be allowed and not permission denied, otherwise you get errors in the storage provisioner worker trying to cleanup storage that is not fully provisioned.

## QA steps

juju deploy hello-kubecon
then immediately
juju remove-application hello-kubecon --force

check logs for errors, app should eventually go away

## Bug reference

https://bugs.launchpad.net/juju/+bug/1950781
