### PR TITLE
[JUJU-246] Revert "Move to replicaset/v2 supporting mongo 4.4"

### DIFF
--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -5,7 +5,7 @@ package backups
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/mongo"

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/controller"

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/apiserver/common"

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	jtesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
 	"github.com/juju/pubsub/v2"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/symlink"
 	"github.com/juju/utils/v2/voyeur"

--- a/core/controller/ha.go
+++ b/core/controller/ha.go
@@ -1,7 +1,0 @@
-// Copyright 2021 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package controller
-
-// MaxPeers defines the maximum number of peers that mongo supports.
-const MaxPeers = 7

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/juju/proxy v0.0.0-20210817195502-c6015cfe0258
 	github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
-	github.com/juju/replicaset/v2 v2.0.1-0.20210310024806-bbbdc5f31eb3
+	github.com/juju/replicaset v0.0.0-20210302050932-0303c8575745
 	github.com/juju/retry v0.0.0-20180821225755-9058e192b216
 	github.com/juju/rfc/v2 v2.0.0-20210319034215-ed820200fad3
 	github.com/juju/romulus v0.0.0-20210309074704-4fa3bbd32568

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,8 @@ github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5 h1:+eWzUG6XLDSdcz
 github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5/go.mod h1:F7wHQBX+lEJkv9PhNCgNJgCeI+GISZW2RefLINbmgXU=
 github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441 h1:b5Jqi7ir58EzfeZDyp7OSYQG/IVgyY4JWfHuJUF2AZI=
 github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
-github.com/juju/replicaset/v2 v2.0.1-0.20210310024806-bbbdc5f31eb3 h1:PYmT5m/07JtXv8/DfSSw3bwD/1TpA9E83//jZldR8l4=
-github.com/juju/replicaset/v2 v2.0.1-0.20210310024806-bbbdc5f31eb3/go.mod h1:NRTC6FXOBX/+Usgl6GjqU2VUcReSG8Odml56qE4bZ/g=
+github.com/juju/replicaset v0.0.0-20210302050932-0303c8575745 h1:3vZtSiDNo99/leCQugDbFAWUIzBuC85rLvzSx2huGfY=
+github.com/juju/replicaset v0.0.0-20210302050932-0303c8575745/go.mod h1:V7wyjD9vFrprVDmycd6g0Lb+Pl5s+WM95bthwLrA1pA=
 github.com/juju/retry v0.0.0-20151029024821-62c620325291/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v0.0.0-20160928201858-1998d01ba1c3/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v0.0.0-20180821225755-9058e192b216 h1:/eQL7EJQKFHByJe3DeE8Z36yqManj9UY5zppDoQi4FU=

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/os/v2/series"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/utils/v2"
 
 	"github.com/juju/juju/core/network"

--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/names/v4"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/ssh"

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -14,13 +14,12 @@ import (
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/mgo/v2/txn"
 	"github.com/juju/names/v4"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	jujutxn "github.com/juju/txn"
 	"github.com/juju/utils/v2"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/controller"
 	"github.com/juju/juju/core/instance"
 	stateerrors "github.com/juju/juju/state/errors"
 )
@@ -95,8 +94,8 @@ func (st *State) EnableHA(
 	if numControllers < 0 || (numControllers != 0 && numControllers%2 != 1) {
 		return ControllersChanges{}, errors.New("number of controllers must be odd and non-negative")
 	}
-	if numControllers > controller.MaxPeers {
-		return ControllersChanges{}, errors.Errorf("controller count is too large (allowed %d)", controller.MaxPeers)
+	if numControllers > replicaset.MaxPeers {
+		return ControllersChanges{}, errors.Errorf("controller count is too large (allowed %d)", replicaset.MaxPeers)
 	}
 	var change ControllersChanges
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -8,11 +8,11 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+	"github.com/juju/replicaset"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/constraints"
-	"github.com/juju/juju/core/controller"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
 )
@@ -64,7 +64,7 @@ func (s *EnableHASuite) TestEnableHAFailsWithBadCount(c *gc.C) {
 		c.Assert(err, gc.ErrorMatches, "number of controllers must be odd and non-negative")
 		c.Assert(changes.Added, gc.HasLen, 0)
 	}
-	_, err := s.State.EnableHA(controller.MaxPeers+2, constraints.Value{}, "", nil)
+	_, err := s.State.EnableHA(replicaset.MaxPeers+2, constraints.Value{}, "", nil)
 	c.Assert(err, gc.ErrorMatches, `controller count is too large \(allowed \d+\)`)
 }
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/mgo/v2/txn"
 	"github.com/juju/names/v4"
 	"github.com/juju/os/v2/series"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/kr/pretty"
 	core "k8s.io/api/core/v1"
 

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -6,7 +6,7 @@ package upgrades
 import (
 	"time"
 
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"

--- a/upgrades/raft.go
+++ b/upgrades/raft.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb"
 	"github.com/juju/errors"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/raftlease"

--- a/upgrades/raft_test.go
+++ b/upgrades/raft_test.go
@@ -14,7 +14,7 @@ import (
 	raftboltdb "github.com/hashicorp/raft-boltdb"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"

--- a/worker/peergrouper/desired_test.go
+++ b/worker/peergrouper/desired_test.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/worker/peergrouper/initiate.go
+++ b/worker/peergrouper/initiate.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/utils/v2"
 
 	"github.com/juju/juju/agent"

--- a/worker/peergrouper/metrics.go
+++ b/worker/peergrouper/metrics.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 
 	"github.com/juju/errors"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/utils/v2/voyeur"
 	"github.com/juju/worker/v3"
 	"gopkg.in/tomb.v2"

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -6,7 +6,7 @@ package peergrouper
 import (
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 	"github.com/kr/pretty"

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub/v2"
-	"github.com/juju/replicaset/v2"
+	"github.com/juju/replicaset"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v2/voyeur"
 	"github.com/juju/worker/v3"

--- a/worker/raft/rafttransport/worker.go
+++ b/worker/raft/rafttransport/worker.go
@@ -15,13 +15,13 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub/v2"
+	"github.com/juju/replicaset"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
-	"github.com/juju/juju/core/controller"
 	"github.com/juju/juju/worker/raft/raftutil"
 )
 
@@ -30,7 +30,7 @@ var (
 )
 
 const (
-	maxPoolSize = controller.MaxPeers
+	maxPoolSize = replicaset.MaxPeers
 )
 
 // Config is the configuration required for running an apiserver-based


### PR DESCRIPTION
The following reverts the change from `replicaset/v2`. 

The problem is that if you have multiple addresses or have a fan address 
for the same container then you can't update the address in a non-atomic 
operation. 

The replicaset attempts to add and remove the same machine. This causes
an integrity failure from mongo. The previous code called the `replSetReconfig`
with every member and didn't attempt to perform the additions, updates, and
removals itself, so mongo handled the addition and removal correctly.

There are a couple of bugs in both `juju/juju` and `juju/replicaset` that need
fixing:

 - The double [appends](https://github.com/juju/replicaset/blob/master/replicaset.go#L403-L405)
 - The `Set` should look for added, removals AND updates
 - When we replace the member with a different address, we reuse the same member Id, which isn't allowed. 

## QA steps

```console
# Setup lxd instances and push required keys
$ lxc launch ubuntu:18.04 t1
$ lxc launch ubuntu:18.04 t2
$ lxc launch ubuntu:18.04 t3
$ lxc file push --uid 0 --gid 0 --mode 644  ~/.local/share/juju/ssh/juju_id_rsa.pub t1/root/.ssh/authorized_keys
$ lxc file push --uid 0 --gid 0 --mode 644  ~/.local/share/juju/ssh/juju_id_rsa.pub t2/root/.ssh/authorized_keys
$ lxc file push --uid 0 --gid 0 --mode 644  ~/.local/share/juju/ssh/juju_id_rsa.pub t3/root/.ssh/authorized_keys

# Add manual cloud with the address of `t1` (lxc list t1)
$ juju add-cloud manual-test --client
Cloud Types
  lxd
  maas
  manual
  openstack
  vsphere

Select cloud type: manual

Enter the ssh connection string for controller, username@<hostname or IP> or <hostname or IP>: root@$T1_IP_ADDRESS

Cloud "manual-test" successfully added to your local client.

# Bootstrap cloud with FAN support
FAN_UNDERLAY=`ip addr show dev lxdbr0 | grep /24 | awk '{print $2}' | sed 's/1\/24/0\/24/'`
FAN_OVERLAY='252.0.0.0/16'

$ juju bootstrap manual-test manual-test --model-default container-networking-method=fan --model-default fan-config=${FAN_UNDERLAY}=${FAN_OVERLAY}

$ juju switch controller

$ lxc list | grep RUNNING
$ juju add-machine ssh:root@$T2_IP_ADDRESS
$ juju add-machine ssh:root@$T3_IP_ADDRESS

$ juju enable-ha --to 1,2
$ juju show-controller
# check "ha-enabled" sections

# Also connect to mongo and check 'rs.status()' output
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1951813