### PR TITLE
[JUJU-214] Fixes re-downloading of caas charm on restart.

### DIFF
--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -469,9 +469,6 @@ func (op *caasOperator) loop() (err error) {
 		return errors.Trace(err)
 	}
 
-	// Keep a record of the alive units and a channel used to notify
-	// their uniter workers when the charm version has changed.
-	aliveUnits := make(map[string]chan struct{})
 	// Channels used to notify uniter worker that the workload container
 	// is running.
 	unitRunningChannels := make(map[string]chan struct{})
@@ -506,15 +503,6 @@ func (op *caasOperator) loop() (err error) {
 				if err := op.setStatus(status.Active, ""); err != nil {
 					return errors.Trace(err)
 				}
-				// Notify all uniters of the change so they run the upgrade-charm hook.
-				for unitID, changedChan := range aliveUnits {
-					logger.Debugf("trigger upgrade charm for caas unit %v", unitID)
-					select {
-					case <-op.catacomb.Dying():
-						return op.catacomb.ErrDying()
-					case changedChan <- struct{}{}:
-					}
-				}
 			}
 		case units, ok := <-containerStartChan:
 			if !ok {
@@ -548,7 +536,6 @@ func (op *caasOperator) loop() (err error) {
 				logger.Debugf("got unit change %q (%s)", unitID, unitLife)
 				unitTag := names.NewUnitTag(unitID)
 				if errors.IsNotFound(err) || unitLife == life.Dead {
-					delete(aliveUnits, unitID)
 					delete(unitRunningChannels, unitID)
 					logger.Debugf("stopping uniter for dead unit %q", unitID)
 					if err := op.runner.StopAndRemoveWorker(unitID, op.catacomb.Dying()); err != nil {
@@ -567,9 +554,6 @@ func (op *caasOperator) loop() (err error) {
 					// Nothing to do for a dead unit further.
 					continue
 				} else {
-					if _, ok := aliveUnits[unitID]; !ok {
-						aliveUnits[unitID] = make(chan struct{})
-					}
 					if _, ok := unitRunningChannels[unitID]; !ok && op.deploymentMode != caas.ModeOperator {
 						// We make a buffered channel here so that we don't
 						// block the operator while the uniter may not be ready
@@ -593,7 +577,6 @@ func (op *caasOperator) loop() (err error) {
 				params.Downloader = op.config.Downloader // TODO(caas): write a cache downloader
 				params.UniterFacade = op.config.UniterFacadeFunc(unitTag)
 				params.LeadershipTrackerFunc = op.config.LeadershipTrackerFunc
-				params.ApplicationChannel = aliveUnits[unitID]
 				params.Logger = params.Logger.Child(unitID)
 				if op.deploymentMode != caas.ModeOperator {
 					params.IsRemoteUnit = true

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -57,7 +57,6 @@ type RemoteStateWatcher struct {
 	updateStatusChannel           UpdateStatusTimerFunc
 	commandChannel                <-chan string
 	retryHookChannel              watcher.NotifyChannel
-	applicationChannel            watcher.NotifyChannel
 	containerRunningStatusChannel watcher.NotifyChannel
 	containerRunningStatusFunc    ContainerRunningStatusFunc
 	canApplyCharmProfile          bool
@@ -96,7 +95,6 @@ type WatcherConfig struct {
 	UpdateStatusChannel           UpdateStatusTimerFunc
 	CommandChannel                <-chan string
 	RetryHookChannel              watcher.NotifyChannel
-	ApplicationChannel            watcher.NotifyChannel
 	ContainerRunningStatusChannel watcher.NotifyChannel
 	ContainerRunningStatusFunc    ContainerRunningStatusFunc
 	UnitTag                       names.UnitTag
@@ -116,9 +114,6 @@ func (w WatcherConfig) validate() error {
 	}
 
 	if w.ModelType == model.CAAS && !w.Sidecar {
-		if w.ApplicationChannel == nil {
-			return errors.NotValidf("watcher config for CAAS model with nil application channel")
-		}
 		if w.ContainerRunningStatusChannel != nil &&
 			w.ContainerRunningStatusFunc == nil {
 			return errors.NotValidf("watcher config for CAAS model with nil container running status func")
@@ -147,7 +142,6 @@ func NewWatcher(config WatcherConfig) (*RemoteStateWatcher, error) {
 		updateStatusChannel:           config.UpdateStatusChannel,
 		commandChannel:                config.CommandChannel,
 		retryHookChannel:              config.RetryHookChannel,
-		applicationChannel:            config.ApplicationChannel,
 		containerRunningStatusChannel: config.ContainerRunningStatusChannel,
 		containerRunningStatusFunc:    config.ContainerRunningStatusFunc,
 		modelType:                     config.ModelType,
@@ -389,25 +383,14 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 		instanceDataChannel     watcher.NotifyChannel
 	)
 
-	// CAAS models don't use an application watcher
-	// which fires an initial event.
-	if w.modelType == model.CAAS && !w.sidecar {
-		seenApplicationChange = true
+	applicationw, err := w.application.Watch()
+	if err != nil {
+		return errors.Trace(err)
 	}
-
-	if w.modelType == model.IAAS || w.sidecar {
-		// For IAAS model and sidecar CAAS model, we need to watch state for
-		// application charm changes instead of being informed by the operator.
-		applicationw, err := w.application.Watch()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if err := w.catacomb.Add(applicationw); err != nil {
-			return errors.Trace(err)
-		}
-		w.applicationChannel = applicationw.Changes()
-		requiredEvents++
+	if err := w.catacomb.Add(applicationw); err != nil {
+		return errors.Trace(err)
 	}
+	requiredEvents++
 
 	if w.modelType == model.IAAS {
 		// Only IAAS models support upgrading the machine series.
@@ -542,7 +525,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			}
 			observedEvent(&seenUnitChange)
 
-		case _, ok := <-w.applicationChannel:
+		case _, ok := <-applicationw.Changes():
 			w.logger.Debugf("got application change for %s", w.unit.Tag().Id())
 			if !ok {
 				return errors.New("application watcher closed")

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -132,10 +132,6 @@ type Uniter struct {
 	// the update-status hook
 	updateStatusAt remotestate.UpdateStatusTimerFunc
 
-	// applicationChannel, if set, is used to signal a change in the
-	// application's charm. It is passed to the remote state watcher.
-	applicationChannel watcher.NotifyChannel
-
 	// containerRunningStatusChannel, if set, is used to signal a change in the
 	// unit's status. It is passed to the remote state watcher.
 	containerRunningStatusChannel watcher.NotifyChannel
@@ -197,7 +193,6 @@ type UniterParams struct {
 	RunListener                   *RunListener
 	TranslateResolverErr          func(error) error
 	Clock                         clock.Clock
-	ApplicationChannel            watcher.NotifyChannel
 	ContainerRunningStatusChannel watcher.NotifyChannel
 	ContainerRunningStatusFunc    remotestate.ContainerRunningStatusFunc
 	IsRemoteUnit                  bool
@@ -270,7 +265,6 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 			observer:                      uniterParams.Observer,
 			clock:                         uniterParams.Clock,
 			downloader:                    uniterParams.Downloader,
-			applicationChannel:            uniterParams.ApplicationChannel,
 			containerRunningStatusChannel: uniterParams.ContainerRunningStatusChannel,
 			containerRunningStatusFunc:    uniterParams.ContainerRunningStatusFunc,
 			isRemoteUnit:                  uniterParams.IsRemoteUnit,
@@ -394,7 +388,6 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				UpdateStatusChannel:           u.updateStatusAt,
 				CommandChannel:                u.commandChannel,
 				RetryHookChannel:              retryHookChan,
-				ApplicationChannel:            u.applicationChannel,
 				ContainerRunningStatusChannel: u.containerRunningStatusChannel,
 				ContainerRunningStatusFunc:    u.containerRunningStatusFunc,
 				ModelType:                     u.modelType,
@@ -900,6 +893,7 @@ func (u *Uniter) init(unitTag names.UnitTag) (err error) {
 			return errors.Trace(err)
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
When a podspec operator restarts it fails to re download the charm when it sits in volatile storage. This is because the caasoperator controls the application update channel to the uniter. This change removes this control from the caasoperator and resolves the same way as IAAS and sidecar charms by watching application state from the controller.

Please double check this work carefully as we are removing the application watcher channel supplied by the CAAS operator and using the standard approach taken by IAAS and side car charms.

## QA steps

The simplest way to test this pre fix was to bootstrap to Microk8s and run:

```bash
juju deploy cs:~containers/coredns-10
juju config coredns forward=8.8.8.8
```

Then find the operator pod for coredns and delete it. This will cause a restart of the pod and if you watch the logs you will see the uniter failing because he can't find the hook on disk.

However this should also be tested with Kubeflow as well (as per bug report below).


## Bug reference
https://bugs.launchpad.net/juju/+bug/1951123
