### PR TITLE
[JUJU-250] Update juju/replicaset/v2 dependency

### DIFF
--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -49,7 +49,7 @@ func InstallFakeEnsureMongo(suite patchingSuite) *FakeEnsureMongo {
 		ServiceInstalled: true,
 	}
 	suite.PatchValue(&mongo.IsServiceInstalled, f.IsServiceInstalled)
-	suite.PatchValue(&replicaset.CurrentConfig, f.CurrentConfig)
+	suite.PatchValue(&mongo.CurrentReplicasetConfig, f.CurrentConfig)
 	suite.PatchValue(&cmdutil.EnsureMongoServer, f.EnsureMongo)
 	return f
 }

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
 	"github.com/juju/pubsub/v2"
-	"github.com/juju/replicaset/v2"
 	"github.com/juju/utils/v2"
 	"github.com/juju/utils/v2/symlink"
 	"github.com/juju/utils/v2/voyeur"
@@ -125,7 +124,7 @@ func init() {
 		safe := mgo.Safe{}
 		if ProductionMongoWriteConcern {
 			safe.J = true
-			_, err := replicaset.CurrentConfig(session)
+			_, err := mongo.CurrentReplicasetConfig(session)
 			if err == nil {
 				// set mongo to write-majority (writes only returned after
 				// replicated to a majority of replica-set members).

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/juju/proxy v0.0.0-20210817195502-c6015cfe0258
 	github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
-	github.com/juju/replicaset/v2 v2.0.1-0.20210310024806-bbbdc5f31eb3
+	github.com/juju/replicaset/v2 v2.0.1-0.20211125220232-7967ce535201
 	github.com/juju/retry v0.0.0-20180821225755-9058e192b216
 	github.com/juju/rfc/v2 v2.0.0-20210319034215-ed820200fad3
 	github.com/juju/romulus v0.0.0-20210309074704-4fa3bbd32568

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,8 @@ github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5 h1:+eWzUG6XLDSdcz
 github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5/go.mod h1:F7wHQBX+lEJkv9PhNCgNJgCeI+GISZW2RefLINbmgXU=
 github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441 h1:b5Jqi7ir58EzfeZDyp7OSYQG/IVgyY4JWfHuJUF2AZI=
 github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
-github.com/juju/replicaset/v2 v2.0.1-0.20210310024806-bbbdc5f31eb3 h1:PYmT5m/07JtXv8/DfSSw3bwD/1TpA9E83//jZldR8l4=
-github.com/juju/replicaset/v2 v2.0.1-0.20210310024806-bbbdc5f31eb3/go.mod h1:NRTC6FXOBX/+Usgl6GjqU2VUcReSG8Odml56qE4bZ/g=
+github.com/juju/replicaset/v2 v2.0.1-0.20211125220232-7967ce535201 h1:K8kT6VLLEpzdWaFPLL82Mv9weftax63lRa1SsV+ExNg=
+github.com/juju/replicaset/v2 v2.0.1-0.20211125220232-7967ce535201/go.mod h1:NRTC6FXOBX/+Usgl6GjqU2VUcReSG8Odml56qE4bZ/g=
 github.com/juju/retry v0.0.0-20151029024821-62c620325291/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v0.0.0-20160928201858-1998d01ba1c3/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v0.0.0-20180821225755-9058e192b216 h1:/eQL7EJQKFHByJe3DeE8Z36yqManj9UY5zppDoQi4FU=

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -771,3 +771,8 @@ func providesMongoAsSnap(mongoDep packaging.Dependency, series string) bool {
 	}
 	return false
 }
+
+// CurrentReplicasetConfig is overridden in tests.
+var CurrentReplicasetConfig = func(session *mgo.Session) (*replicaset.Config, error) {
+	return replicaset.CurrentConfig(session)
+}


### PR DESCRIPTION
Update the juju/replicaset/v2 dependency to fix an issue updating the mongo replicaset where node addresses change.

Supersedes #13521 

## QA steps

```
# Setup lxd instances and push required keys
$ lxc launch ubuntu:18.04 t1
$ lxc launch ubuntu:18.04 t2
$ lxc launch ubuntu:18.04 t3
$ lxc file push --uid 0 --gid 0 --mode 644  ~/.local/share/juju/ssh/juju_id_rsa.pub t1/root/.ssh/authorized_keys
$ lxc file push --uid 0 --gid 0 --mode 644  ~/.local/share/juju/ssh/juju_id_rsa.pub t2/root/.ssh/authorized_keys
$ lxc file push --uid 0 --gid 0 --mode 644  ~/.local/share/juju/ssh/juju_id_rsa.pub t3/root/.ssh/authorized_keys

# Add manual cloud with the address of `t1` (lxc list t1)
$ juju add-cloud manual-test --client
Cloud Types
  lxd
  maas
  manual
  openstack
  vsphere

Select cloud type: manual

Enter the ssh connection string for controller, username@<hostname or IP> or <hostname or IP>: root@$T1_IP_ADDRESS

Cloud "manual-test" successfully added to your local client.

# Bootstrap cloud with FAN support
FAN_UNDERLAY=`ip addr show dev lxdbr0 | grep /24 | awk '{print $2}' | sed 's/1\/24/0\/24/'`
FAN_OVERLAY='252.0.0.0/16'

$ juju bootstrap manual-test manual-test --model-default container-networking-method=fan --model-default fan-config=${FAN_UNDERLAY}=${FAN_OVERLAY}

$ juju switch controller

$ lxc list | grep RUNNING
$ juju add-machine ssh:root@$T2_IP_ADDRESS
$ juju add-machine ssh:root@$T3_IP_ADDRESS

$ juju enable-ha --to 1,2
$ juju show-controller
# check "ha-enabled" sections

# Also connect to mongo and check 'rs.status()' output
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1951813
