### PR TITLE
[JUJU-227] Sidecar application sequence number fix

### DIFF
--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -264,7 +264,7 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 		if err != nil {
 			return errResp(err)
 		}
-		logger.Debugf("created new unit %q for pod %q", unit.Tag().String(), args.PodName)
+		logger.Debugf("created new unit %q for pod %s/%s", unit.Tag().String(), args.PodName, containerID)
 	}
 
 	password, err := utils.RandomPassword()

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -635,7 +635,6 @@ var getCAASBroker = func(getter environs.EnvironConfigGetter) (caas.Broker, erro
 		Config: modelConfig,
 	})
 	if err != nil {
-		logger.Warningf("getCAASBroker err %#v", errors.Cause(err))
 		return nil, errors.Trace(err)
 	}
 	return env, nil

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -387,7 +387,8 @@ func (st *State) addMachineInsideMachineOps(template MachineTemplate, parentId s
 // newContainerId returns a new id for a machine within the machine
 // with id parentId and the given container type.
 func (st *State) newContainerId(parentId string, containerType instance.ContainerType) (string, error) {
-	seq, err := sequence(st, fmt.Sprintf("machine%s%sContainer", parentId, containerType))
+	name := fmt.Sprintf("machine%s%sContainer", parentId, containerType)
+	seq, err := sequence(st, name)
 	if err != nil {
 		return "", err
 	}

--- a/state/address.go
+++ b/state/address.go
@@ -126,7 +126,7 @@ func (st *State) SetAPIHostPorts(newHostPorts []network.SpaceHostPorts) error {
 		}
 		ops = append(ops, agentAddrOps...)
 
-		if ops == nil || len(ops) == 0 {
+		if len(ops) == 0 {
 			return nil, jujutxn.ErrNoOperations
 		}
 		return ops, nil
@@ -489,9 +489,7 @@ func dupeAndSort(a []network.SpaceHostPorts) []network.SpaceHostPorts {
 
 	for _, val := range a {
 		var inner network.SpaceHostPorts
-		for _, hp := range val {
-			inner = append(inner, hp)
-		}
+		inner = append(inner, val...)
 		sort.Sort(inner)
 		result = append(result, inner)
 	}

--- a/state/application.go
+++ b/state/application.go
@@ -444,6 +444,12 @@ func (op *DestroyApplicationOperation) destroyOps() ([]txn.Op, error) {
 	}
 	ops = append(ops, resOps...)
 
+	removeUnitAssignmentOps, err := op.app.removeUnitAssignmentsOps()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, removeUnitAssignmentOps...)
+
 	// We can't delete an application if it is being offered,
 	// unless those offers have no relations.
 	if !op.RemoveOffers {
@@ -624,6 +630,24 @@ func removeResourcesOps(st *State, applicationID string) ([]txn.Op, error) {
 	ops, err := persist.NewRemoveResourcesOps(applicationID)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+	return ops, nil
+}
+
+func (a *Application) removeUnitAssignmentsOps() (ops []txn.Op, err error) {
+	pattern := fmt.Sprintf("^%s:%s/[0-9]+$", a.st.ModelUUID(), a.Name())
+	unitAssignments, err := a.st.unitAssignments(bson.D{
+		{
+			Name: "_id", Value: bson.D{
+				{Name: "$regex", Value: pattern},
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, unitAssignment := range unitAssignments {
+		ops = append(ops, removeStagedAssignmentOp(a.st.docID(unitAssignment.Unit)))
 	}
 	return ops, nil
 }
@@ -1500,7 +1524,7 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 		return errors.Trace(err)
 	}
 	if cfg.Charm.Meta().Deployment != currentCharm.Meta().Deployment {
-		if currentCharm.Meta().Deployment == nil || currentCharm.Meta().Deployment == nil {
+		if cfg.Charm.Meta().Deployment == nil || currentCharm.Meta().Deployment == nil {
 			return errors.New("cannot change a charm's deployment info")
 		}
 		if cfg.Charm.Meta().Deployment.DeploymentType != currentCharm.Meta().Deployment.DeploymentType {
@@ -2106,7 +2130,7 @@ func (a *Application) ClearResources() error {
 				{"has-resources", true}},
 			Update: bson.D{{"$set", bson.D{{"has-resources", false}}}},
 		}}
-		logger.Debugf("aaplication %q still has cluster resources, scheduling cleanup", a.doc.Name)
+		logger.Debugf("application %q still has cluster resources, scheduling cleanup", a.doc.Name)
 		cleanupOp := newCleanupOp(
 			cleanupApplication,
 			a.doc.Name,
@@ -2328,7 +2352,6 @@ func (a *Application) addUnitStorageOps(
 	unitTag names.UnitTag,
 	charm *Charm,
 ) ([]txn.Op, int, error) {
-
 	sb, err := NewStorageBackend(a.st)
 	if err != nil {
 		return nil, -1, errors.Trace(err)
@@ -3322,10 +3345,7 @@ func (a *Application) SetPassword(password string) error {
 // for the given application.
 func (a *Application) PasswordValid(password string) bool {
 	agentHash := utils.AgentPasswordHash(password)
-	if agentHash == a.doc.PasswordHash {
-		return true
-	}
-	return false
+	return agentHash == a.doc.PasswordHash
 }
 
 // UnitUpdateProperties holds information used to update

--- a/state/application_ops.go
+++ b/state/application_ops.go
@@ -17,7 +17,6 @@ type updateLeaderSettingsOperation struct {
 	sets   bson.M
 	unsets bson.M
 
-	appName   string
 	key       string
 	updateDoc bson.D
 

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -68,15 +68,6 @@ func (s *ApplicationSuite) assertNeedsCleanup(c *gc.C) {
 	c.Assert(dirty, jc.IsTrue)
 }
 
-func (s *ApplicationSuite) removeOfferConnections(c *gc.C, offer crossmodel.ApplicationOffer) {
-	jujudb := s.MgoSuite.Session.DB("juju")
-	offerConnectionsCollection := jujudb.C(state.OfferConnectionsC)
-
-	info, err := offerConnectionsCollection.RemoveAll(bson.M{"offer-uuid": offer.OfferUUID})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info.Matched, gc.Equals, info.Removed)
-}
-
 func (s *ApplicationSuite) assertNoCleanup(c *gc.C) {
 	dirty, err := s.State.NeedsCleanup()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1116,6 +1107,75 @@ func (s *ApplicationSuite) TestSequenceUnitIdsAfterDestroy(c *gc.C) {
 	unit, err = s.mysql.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unit.Name(), gc.Equals, "mysql/1")
+}
+
+func (s *ApplicationSuite) TestAssignUnitsRemovedAfterAppDestroy(c *gc.C) {
+	mariadb := s.AddTestingApplicationWithNumUnits(c, 1, "mariadb", s.charm)
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+
+	units, err := mariadb.AllUnits()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(units), gc.Equals, 1)
+	unit := units[0]
+	c.Assert(unit.Name(), gc.Equals, "mariadb/0")
+	unitAssignments, err := s.State.AllUnitAssignments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(unitAssignments), gc.Equals, 1)
+
+	err = unit.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = mariadb.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	assertRemoved(c, mariadb)
+
+	unitAssignments, err = s.State.AllUnitAssignments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(unitAssignments), gc.Equals, 0)
+}
+
+func (s *ApplicationSuite) TestSequenceUnitIdsAfterDestroyForSidecarApplication(c *gc.C) {
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "caas-model",
+		Type: state.ModelTypeCAAS,
+	})
+	s.AddCleanup(func(*gc.C) { _ = st.Close() })
+	f := factory.NewFactory(st, s.StatePool)
+	charmDef := `
+name: cockroachdb
+description: foo
+summary: foo
+containers:
+  redis:
+    resource: redis-container-resource
+resources:
+  redis-container-resource:
+    name: redis-container
+    type: oci-image
+`
+	ch := state.AddCustomCharmWithManifest(c, st, "cockroach", "metadata.yaml", charmDef, "focal", 1)
+	app := f.MakeApplication(c, &factory.ApplicationParams{Name: "cockroachdb", Charm: ch})
+	unit, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.Name(), gc.Equals, "cockroachdb/0")
+	err = unit.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = unit.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	err = app.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	err = app.ClearResources()
+	c.Assert(err, jc.ErrorIsNil)
+	s.WaitForModelWatchersIdle(c, st.ModelUUID())
+	assertCleanupCount(c, st, 2)
+	unitAssignments, err := st.AllUnitAssignments()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(unitAssignments), gc.Equals, 0)
+
+	ch = state.AddCustomCharmWithManifest(c, st, "cockroach", "metadata.yaml", charmDef, "focal", 1)
+	app = f.MakeApplication(c, &factory.ApplicationParams{Name: "cockroachdb", Charm: ch})
+	unit, err = app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unit.Name(), gc.Equals, "cockroachdb/0")
 }
 
 func (s *ApplicationSuite) TestSequenceUnitIds(c *gc.C) {

--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -71,6 +71,10 @@ func (s *ConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Charm)
 	return state.AddTestingApplication(c, s.State, name, ch)
 }
 
+func (s *ConnSuite) AddTestingApplicationWithNumUnits(c *gc.C, numUnits int, name string, ch *state.Charm) *state.Application {
+	return state.AddTestingApplicationWithNumUnits(c, s.State, numUnits, name, ch)
+}
+
 func (s *ConnSuite) AddTestingApplicationWithStorage(c *gc.C, name string, ch *state.Charm, storage map[string]state.StorageConstraints) *state.Application {
 	return state.AddTestingApplicationWithStorage(c, s.State, name, ch, storage)
 }

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -555,10 +555,7 @@ func (c *controllerNode) SetPassword(password string) error {
 // PasswordValid implements Authenticator.
 func (c *controllerNode) PasswordValid(password string) bool {
 	agentHash := utils.AgentPasswordHash(password)
-	if agentHash == c.doc.PasswordHash {
-		return true
-	}
-	return false
+	return agentHash == c.doc.PasswordHash
 }
 
 func (c *controllerNode) AgentTools() (*tools.Tools, error) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -240,6 +240,15 @@ func AddTestingApplicationForSeries(c *gc.C, st *State, series, name string, ch 
 	})
 }
 
+func AddTestingApplicationWithNumUnits(c *gc.C, st *State, numUnits int, name string, ch *Charm) *Application {
+	return addTestingApplication(c, addTestingApplicationParams{
+		st:       st,
+		numUnits: numUnits,
+		name:     name,
+		ch:       ch,
+	})
+}
+
 func AddTestingApplicationWithStorage(c *gc.C, st *State, name string, ch *Charm, storage map[string]StorageConstraints) *Application {
 	return addTestingApplication(c, addTestingApplicationParams{
 		st:      st,
@@ -275,6 +284,7 @@ type addTestingApplicationParams struct {
 	bindings     map[string]string
 	storage      map[string]StorageConstraints
 	devices      map[string]DeviceConstraints
+	numUnits     int
 }
 
 func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Application {
@@ -287,6 +297,7 @@ func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Applica
 		EndpointBindings: params.bindings,
 		Storage:          params.storage,
 		Devices:          params.devices,
+		NumUnits:         params.numUnits,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	return app
@@ -484,6 +495,10 @@ func MultiModelCollections() []string {
 
 func Sequence(st *State, name string) (int, error) {
 	return sequence(st, name)
+}
+
+func ResetSequence(mb modelBackend, name string) error {
+	return resetSequence(mb, name)
 }
 
 func SequenceWithMin(st *State, name string, minVal int) (int, error) {

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -809,14 +809,13 @@ func (s *ModelSuite) TestDestroyControllerAndHostedModelsWithResources(c *gc.C) 
 	_, err = otherSt.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	application := s.Factory.MakeApplication(c, nil)
-	ch, _, err := application.Charm()
-	c.Assert(err, jc.ErrorIsNil)
 
+	ch := state.AddTestingCharm(c, otherSt, "dummy")
 	args := state.AddApplicationArgs{
 		Name:  application.Name(),
 		Charm: ch,
 	}
-	application, err = otherSt.AddApplication(args)
+	_, err = otherSt.AddApplication(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerModel, err := s.State.Model()
@@ -1285,13 +1284,13 @@ func (s *ModelSuite) TestProcessDyingModelWithMachinesAndApplicationsNoOp(c *gc.
 	_, err = st.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	application := s.Factory.MakeApplication(c, nil)
-	ch, _, err := application.Charm()
-	c.Assert(err, jc.ErrorIsNil)
+
+	ch := state.AddTestingCharm(c, st, "dummy")
 	args := state.AddApplicationArgs{
 		Name:  application.Name(),
 		Charm: ch,
 	}
-	application, err = st.AddApplication(args)
+	_, err = st.AddApplication(args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertModel := func(life state.Life, expectedMachines, expectedApplications int) {

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -42,6 +42,16 @@ func sequence(mb modelBackend, name string) (int, error) {
 	return result.Counter, nil
 }
 
+func resetSequence(mb modelBackend, name string) error {
+	sequences, closer := mb.db().GetCollection(sequenceC)
+	defer closer()
+	err := sequences.Writeable().RemoveId(name)
+	if err != nil && errors.Cause(err) != mgo.ErrNotFound {
+		return errors.Annotatef(err, "can not reset sequence for %q", name)
+	}
+	return nil
+}
+
 // sequenceWithMin safely increments a database backed sequence,
 // allowing for a minimum value for the sequence to be specified. The
 // minimum value is used as an initial value for the first use of a

--- a/state/sequence_test.go
+++ b/state/sequence_test.go
@@ -197,6 +197,16 @@ func (s *sequenceSuite) TestEnsureBackwards(c *gc.C) {
 	s.incAndCheck(c, s.State, "foo", 3)
 }
 
+func (s *sequenceSuite) TestResetSequence(c *gc.C) {
+	err := state.SequenceEnsure(s.State, "foo", 3)
+	c.Assert(err, jc.ErrorIsNil)
+	s.incAndCheck(c, s.State, "foo", 3)
+
+	err = state.ResetSequence(s.State, "foo")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.incAndCheck(c, s.State, "foo", 0)
+}
 func (s *sequenceSuite) incAndCheck(c *gc.C, st *state.State, name string, expectedCount int) {
 	value, err := state.Sequence(st, name)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/state.go
+++ b/state/state.go
@@ -1316,6 +1316,15 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 			ops = append(ops, resOps...)
 		}
 
+		isSidecar, err := app.IsSidecar()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if isSidecar {
+			if err := resetSequence(st, app.Tag().String()); err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
 		// Collect unit-adding operations.
 		for x := 0; x < args.NumUnits; x++ {
 			unitName, unitOps, err := app.addUnitOpsWithCons(applicationAddUnitOpsArgs{
@@ -1327,11 +1336,13 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 				return nil, errors.Trace(err)
 			}
 			ops = append(ops, unitOps...)
-			placement := instance.Placement{}
-			if x < len(args.Placement) {
-				placement = *args.Placement[x]
+			if model.Type() != ModelTypeCAAS {
+				placement := instance.Placement{}
+				if x < len(args.Placement) {
+					placement = *args.Placement[x]
+				}
+				ops = append(ops, assignUnitOps(unitName, placement)...)
 			}
-			ops = append(ops, assignUnitOps(unitName, placement)...)
 		}
 		return ops, nil
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -1325,6 +1325,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 				return nil, errors.Trace(err)
 			}
 		}
+
 		// Collect unit-adding operations.
 		for x := 0; x < args.NumUnits; x++ {
 			unitName, unitOps, err := app.addUnitOpsWithCons(applicationAddUnitOpsArgs{

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5856,19 +5856,19 @@ func (s *upgradesSuite) TestCleanupDeadAssignUnits(c *gc.C) {
 
 	s.assertUpgradedData(c, CleanupDeadAssignUnits,
 		upgradedData(assignUnitColl, []bson.M{
-			bson.M{
+			{
 				"_id":        model0.docID("app01/0"),
 				"model-uuid": model0.ModelUUID(),
 			},
-			bson.M{
+			{
 				"_id":        model0.docID("app02/0"),
 				"model-uuid": model0.ModelUUID(),
 			},
-			bson.M{
+			{
 				"_id":        model1.docID("app11/0"),
 				"model-uuid": model1.ModelUUID(),
 			},
-			bson.M{
+			{
 				"_id":        model1.docID("app12/0"),
 				"model-uuid": model1.ModelUUID(),
 			},

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -100,6 +100,7 @@ type StateBackend interface {
 	RemoveOrphanedCrossModelProxies() error
 	DropLegacyAssumesSectionsFromCharmMetadata() error
 	MigrateLegacyCrossModelTokens() error
+	CleanupDeadAssignUnits() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -432,4 +433,8 @@ func (s stateBackend) DropLegacyAssumesSectionsFromCharmMetadata() error {
 
 func (s stateBackend) MigrateLegacyCrossModelTokens() error {
 	return state.MigrateLegacyCrossModelTokens(s.pool)
+}
+
+func (s stateBackend) CleanupDeadAssignUnits() error {
+	return state.CleanupDeadAssignUnits(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -54,6 +54,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.15"), stateStepsFor2915()},
 		upgradeToVersion{version.MustParse("2.9.17"), stateStepsFor2917()},
 		upgradeToVersion{version.MustParse("2.9.19"), stateStepsFor2919()},
+		upgradeToVersion{version.MustParse("2.9.20"), stateStepsFor2920()},
 	}
 	return steps
 }

--- a/upgrades/steps_2920.go
+++ b/upgrades/steps_2920.go
@@ -1,0 +1,17 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2920 returns upgrade steps for juju 2.9.20.
+func stateStepsFor2920() []Step {
+	return []Step{
+		&upgradeStep{
+			description: `clean up assignUnits for dead and removed applications`,
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().CleanupDeadAssignUnits()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2920_test.go
+++ b/upgrades/steps_2920_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Canonical Ltd.
+// Copyright 2021 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package upgrades_test
@@ -12,16 +12,15 @@ import (
 	"github.com/juju/juju/upgrades"
 )
 
-var v222 = version.MustParse("2.2.2")
+var v2920 = version.MustParse("2.9.20")
 
-type steps222Suite struct {
+type steps2920Suite struct {
 	testing.BaseSuite
 }
 
-var _ = gc.Suite(&steps222Suite{})
+var _ = gc.Suite(&steps2920Suite{})
 
-func (s *steps222Suite) TestAddModelEnvironVersionStep(c *gc.C) {
-	step := findStateStep(c, v222, "add environ-version to model docs")
-	// Logic for step itself is tested in state package.
+func (s *steps2920Suite) TestCleanupDeadAssignUnits(c *gc.C) {
+	step := findStateStep(c, v2920, `clean up assignUnits for dead and removed applications`)
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }

--- a/upgrades/steps_29_test.go
+++ b/upgrades/steps_29_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
-	apicallermocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/common"
 	servicemocks "github.com/juju/juju/service/mocks"
@@ -82,7 +81,6 @@ type mergeAgents29Suite struct {
 	mockCtx         *mocks.MockContext
 	mockClient      *mocks.MockUpgradeStepsClient
 	mockAgentConfig *configsettermocks.MockConfigSetter
-	mockAPICaller   *apicallermocks.MockAPICaller
 }
 
 var _ = gc.Suite(&mergeAgents29Suite{})

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -205,7 +205,6 @@ func (mock *mockAgentConfig) Model() names.ModelTag {
 type mockStateBackend struct {
 	upgrades.StateBackend
 	testing.Stub
-	models []upgrades.Model
 }
 
 func (mock *mockStateBackend) ControllerUUID() string {
@@ -644,6 +643,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.15",
 		"2.9.17",
 		"2.9.19",
+		"2.9.20",
 	})
 }
 

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -91,7 +91,7 @@ func (u *Upgrader) loop() error {
 	hostOSType := coreos.HostOSTypeName()
 	if agent.IsAllowedControllerTag(u.tag.Kind()) || u.tag.Kind() == names.UnitTagKind {
 		if err := u.upgraderClient.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current, hostOSType)); err != nil {
-			return errors.Annotate(err, "cannot set agent version")
+			return errors.Annotatef(err, "cannot set agent version for %q", u.tag.String())
 		}
 	}
 

--- a/worker/upgrader/upgrader.go
+++ b/worker/upgrader/upgrader.go
@@ -187,7 +187,7 @@ func (u *Upgrader) loop() error {
 	// used by the controller in communicating the desired version below).
 	hostOSType := coreos.HostOSTypeName()
 	if err := u.st.SetVersion(u.tag.String(), toBinaryVersion(jujuversion.Current, hostOSType)); err != nil {
-		return errors.Annotate(err, "cannot set agent version")
+		return errors.Annotatef(err, "cannot set agent version for %q", u.tag.String())
 	}
 
 	// We do not commence any actions until the upgrade-steps worker has


### PR DESCRIPTION
We have a `foo` sidecar CAAS application with scale `1` deployed in a model, now we remove this application then re-deploy it again.
Currently, Juju will create an `unit-1` for the new `foo` application, then Juju will add another `unit-0` when Juju get notified by k8s when the pod-0 has been scheduled. Now Juju gets confused because the app scale == 1 but we have two units. So Juju will remove the `unit-1` but the storage attachments are totally disordered. 
This PR ensures we create a `unit-0` when the application was deployed instead of `unit-1`.

Additionally, this includes a few drive-by fixes:

- ensured the assignUnit docs are removed when the application gets removed;
- ensured we only create assignUnit doc for non-CAAS applications;
- added an upgrade step for `2.9.20` to remove any assignUnit docs of removed/dead applications;
- fixed a type in `application.SetCharm ` which might cause a panic;


## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju add-model t1 microk8s

$ juju deploy hello-kubecon

$ juju remove-application hello-kubecon --force

$ juju deploy hello-kubecon

```

## Documentation changes

No UX changes

## Bug reference

https://bugs.launchpad.net/juju/+bug/1952014