### PR TITLE
[JUJU-261] Add index for model and name to units collection

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -275,6 +275,8 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid", "principal"},
 			}, {
 				Key: []string{"model-uuid", "machineid"},
+			}, {
+				Key: []string{"model-uuid", "name"},
 			}},
 		},
 		unitStatesC: {


### PR DESCRIPTION
Accessing a unit by name (and implicitly model UUID) is a hot path due in large part to server-side uniter state settings.

Here we add an index for this access pattern.

Verified efficacy for production deployment via:
```
db.units.find({"model-uuid" : "6259e12b-81c6-4a02-88fb-125bbf648578", "name" : "postgresql/0"}).explain("executionStats")
```
Before:
```
"totalKeysExamined" : 48,
"totalDocsExamined" : 48,
```
After:
```
"totalKeysExamined" : 1,
"totalDocsExamined" : 1,
```