### PR TITLE
2.9 Logging level for implied arch in model exports

### DIFF
--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1939,7 +1939,7 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 	}
 	origin := doc.CharmOrigin
 
-	// If the channel is empty, then we fallback to the Revision.
+	// If the channel is empty, then we fall back to the Revision.
 	var revision int
 	if rev := origin.Revision; rev != nil {
 		revision = *rev
@@ -1955,10 +1955,10 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 		// the architecture is set in the platform if it's not set. This
 		// shouldn't happen that often, but handles clients sending bad requests
 		// when deploying.
-		arch := origin.Platform.Architecture
-		if arch == "" {
-			e.logger.Warningf("using default architecture (%q) for doc[%q]", defaultArch, doc.DocID)
-			arch = defaultArch
+		pArch := origin.Platform.Architecture
+		if pArch == "" {
+			e.logger.Debugf("using default architecture (%q) for doc[%q]", defaultArch, doc.DocID)
+			pArch = defaultArch
 		}
 		var os string
 		if origin.Platform.Series != "" {
@@ -1969,7 +1969,7 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 			os = strings.ToLower(sys.String())
 		}
 		platform = corecharm.Platform{
-			Architecture: arch,
+			Architecture: pArch,
 			OS:           os,
 			Series:       origin.Platform.Series,
 		}

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -123,7 +123,7 @@ func Loop(cfg LoopConfig, localState *LocalState) error {
 
 				if errors.Cause(err) == mutex.ErrCancelled {
 					// If the lock acquisition was cancelled (such as when the
-					// migration-inactive flag drops, we do not want the
+					// migration-inactive flag drops) we do not want the
 					// resolver to surface that error. This puts the agent into
 					// the "failed" state, which causes the initial migration
 					// validation phase to fail.


### PR DESCRIPTION
It was observed in Prodstack controller logs that lines like this were frequently present:
```
2021-11-27 14:34:56 WARNING juju.state.export-model migration_export.go:1960 using default architecture ("amd64") for doc["2743e5f9-74f2-492e-89ab-a272135d3328:postgresql"]
```
It turns out that models are frequently dumped from Prodstack by software called `plinth`. 

Here we drop the log level from WARNING to DEBUG to reduce log-sender load.

## QA steps

- Bootstrap a 2.8 controller/model.
- Deploy a charm-store workload.
- Upgrade to this patch.
- `JUJU_DEV_FEATURE_FLAGS=developer-mode juju dump-db`.
- Check that the errors are absent from controller logs.

## Documentation changes

None.

## Bug reference

N/A
