### PR TITLE
[JUJU-278] Only the peer grouper on the primary machine should change the replicaset

### DIFF
--- a/state/enableha.go
+++ b/state/enableha.go
@@ -467,7 +467,7 @@ func (st *State) HAPrimaryMachine() (names.MachineTag, error) {
 	}
 	for _, m := range ms {
 		if m.Id == nodeID {
-			if machineID, k := m.Tags["juju-machine-id"]; k {
+			if machineID, ok := m.Tags["juju-machine-id"]; ok {
 				return names.NewMachineTag(machineID), nil
 			}
 		}

--- a/worker/peergrouper/manifold.go
+++ b/worker/peergrouper/manifold.go
@@ -124,7 +124,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		PrometheusRegisterer: config.PrometheusRegisterer,
 		// On machine models, the controller id is the same as the machine/agent id.
 		// TODO(wallyworld) - revisit when we add HA to k8s.
-		ControllerIdGetter: agentConfig.Tag().Id,
+		ControllerId: agentConfig.Tag().Id,
 	})
 	if err != nil {
 		_ = stTracker.Done()

--- a/worker/peergrouper/manifold.go
+++ b/worker/peergrouper/manifold.go
@@ -122,6 +122,9 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		ControllerAPIPort:    stateServingInfo.ControllerAPIPort,
 		SupportsHA:           supportsHA,
 		PrometheusRegisterer: config.PrometheusRegisterer,
+		// On machine models, the controller id is the same as the machine/agent id.
+		// TODO(wallyworld) - revisit when we add HA to k8s.
+		ControllerIdGetter: agentConfig.Tag().Id,
 	})
 	if err != nil {
 		_ = stTracker.Done()

--- a/worker/peergrouper/manifold_test.go
+++ b/worker/peergrouper/manifold_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
@@ -116,6 +117,8 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(args[0], gc.FitsTypeOf, peergrouper.Config{})
 	config := args[0].(peergrouper.Config)
 
+	c.Assert(config.ControllerIdGetter(), gc.Equals, "10")
+	config.ControllerIdGetter = nil
 	c.Assert(config, jc.DeepEquals, peergrouper.Config{
 		State:        peergrouper.StateShim{s.State},
 		MongoSession: peergrouper.MongoSessionShim{s.State.MongoSession()},
@@ -180,6 +183,10 @@ func (ma *mockAgent) CurrentConfig() agent.Config {
 type mockAgentConfig struct {
 	agent.Config
 	info *controller.StateServingInfo
+}
+
+func (c *mockAgentConfig) Tag() names.Tag {
+	return names.NewMachineTag("10")
 }
 
 func (c *mockAgentConfig) StateServingInfo() (controller.StateServingInfo, bool) {

--- a/worker/peergrouper/manifold_test.go
+++ b/worker/peergrouper/manifold_test.go
@@ -117,8 +117,8 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	c.Assert(args[0], gc.FitsTypeOf, peergrouper.Config{})
 	config := args[0].(peergrouper.Config)
 
-	c.Assert(config.ControllerIdGetter(), gc.Equals, "10")
-	config.ControllerIdGetter = nil
+	c.Assert(config.ControllerId(), gc.Equals, "10")
+	config.ControllerId = nil
 	c.Assert(config, jc.DeepEquals, peergrouper.Config{
 		State:        peergrouper.StateShim{s.State},
 		MongoSession: peergrouper.MongoSessionShim{s.State.MongoSession()},

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -166,10 +166,6 @@ func checkInvariants(st *fakeState) error {
 				if m == nil {
 					return fmt.Errorf("voting member with controller id %q has no associated Controller", id)
 				}
-
-				if !m.doc().hasVote {
-					return fmt.Errorf("controller %q should be marked as having the vote, but does not", id)
-				}
 			}
 		}
 	}

--- a/worker/peergrouper/mock_test.go
+++ b/worker/peergrouper/mock_test.go
@@ -502,6 +502,21 @@ func (session *fakeMongoSession) CurrentStatus() (*replicaset.Status, error) {
 	return deepCopy(session.status.Get()).(*replicaset.Status), nil
 }
 
+func (session *fakeMongoSession) currentPrimary() string {
+	members := session.members.Get().([]replicaset.Member)
+	status := session.status.Get().(*replicaset.Status)
+	for _, statusMember := range status.Members {
+		if statusMember.State == replicaset.PrimaryState {
+			for _, member := range members {
+				if member.Id == statusMember.Id {
+					return member.Tags["juju-machine-id"]
+				}
+			}
+		}
+	}
+	return ""
+}
+
 // setStatus sets the status of the current members of the session.
 func (session *fakeMongoSession) setStatus(members []replicaset.MemberStatus) {
 	session.status.Set(deepCopy(&replicaset.Status{


### PR DESCRIPTION
Each controller runs its own peer grouper worker. For mongo 4.0, we could construct the desired replicaset and each worker would splat the same copy onto mongo. Multiple workers doing this wasn't an issue.

For mongo 4.4, we need to apply the changes one at a time, and this is done by calculating a diff. This becomes an issue if multiple workers try and do that at the same time. This PR ensures that only the peer grouper running on the primary changes the replicaset. Small test changes were needed to accommodate this, since we need to change which machine the worker thinks is the primary.

## QA steps

./main.sh controller

Also
```
juju bootstrap 
juju enable-ha
```
juju show-controller
check rs.config()

remove a secondary
`juju remove-machine 1`
check rs.config()

`juju enable-ha`
juju show-controller
check rs.config()

remove the primary
`juju remove-machine 0`
juju show-controller
check rs.config()

`juju enable-ha`
juju show-controller
check rs.config()
