### PR TITLE
[JUJU-272] Add model UUID indexes

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -262,7 +262,11 @@ func allCollections() CollectionSchema {
 		// -----
 
 		// These collections hold information associated with applications.
-		charmsC: {},
+		charmsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 		applicationsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "name"},
@@ -344,7 +348,7 @@ func allCollections() CollectionSchema {
 		// that a particular machine in the process of performing a series upgrade.
 		machineUpgradeSeriesLocksC: {
 			indexes: []mgo.Index{{
-				Key: []string{"machineid"},
+				Key: []string{"model-uuid", "machineid"},
 			}},
 		},
 
@@ -383,7 +387,13 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid", "machineid"},
 			}},
 		},
-		volumeAttachmentsC:    {},
+		volumeAttachmentsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid", "hostid"},
+			}, {
+				Key: []string{"model-uuid", "volumeid"},
+			}},
+		},
 		volumeAttachmentPlanC: {},
 
 		// -----
@@ -406,8 +416,16 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid", "machine-id", "device-name"},
 			}},
 		},
-		endpointBindingsC: {},
-		openedPortsC:      {},
+		endpointBindingsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
+		openedPortsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// -----
 
@@ -471,7 +489,11 @@ func allCollections() CollectionSchema {
 			}},
 		},
 
-		constraintsC:        {},
+		constraintsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 		storageConstraintsC: {},
 		deviceConstraintsC:  {},
 		statusesC: {
@@ -527,7 +549,11 @@ func allCollections() CollectionSchema {
 		relationNetworksC: {},
 
 		// firewallRulesC holds firewall rules for defined service types.
-		firewallRulesC: {},
+		firewallRulesC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// podSpecsC holds the CAAS pod specifications,
 		// for applications.

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -384,7 +384,7 @@ func allCollections() CollectionSchema {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "storageid"},
 			}, {
-				Key: []string{"model-uuid", "machineid"},
+				Key: []string{"model-uuid", "hostid"},
 			}},
 		},
 		volumeAttachmentsC: {

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -215,7 +215,7 @@ func (m *Model) AllConstraints() (*ModelConstraints, error) {
 	return all, nil
 }
 
-// ModelConstraints represents all the contraints in  a model
+// ModelConstraints represents all the constraints in  a model
 // keyed on global key.
 type ModelConstraints struct {
 	data map[string]constraintsDoc

--- a/state/multienv.go
+++ b/state/multienv.go
@@ -46,7 +46,7 @@ func splitDocID(id string) (string, string, bool) {
 const modelUUIDRequired = 1
 const noModelUUIDInInput = 2
 
-// mungeDocForMultiModel takes the value of an txn.Op Insert or $set
+// mungeDocForMultiModel takes the value of a txn.Op Insert or $set
 // Update and modifies it to be multi-model safe, returning the
 // modified document.
 func mungeDocForMultiModel(doc interface{}, modelUUID string, modelUUIDFlags int) (bson.D, error) {


### PR DESCRIPTION
There are a few collections for which we create no indexes.

Non-global collections always ensure a `model-uuid` clause if required, so it should be a general policy to include this index. This is particularly important in Prodstack 4.5, which hosts many large models and does frequent model exports via `dump-db`.

Here we add such an index to some of the hotter/larger collections.

There is also a fix for the `volumes` collection, which had a composite key including `machineid` instead of `hostid`.

## QA steps

Bootstrap without error.

## Documentation changes

None.

## Bug reference

N/A
