### PR TITLE
[JUJU-270] Fix enable ha integration test

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -300,7 +300,7 @@ destroy_model() {
 
 	echo "====> Destroying juju model ${name}"
 	echo "${name}" | xargs -I % juju destroy-model -y % >"${output}" 2>&1 || true
-	CHK=$(cat "${output}" | grep -i "ERROR" || true)
+	CHK=$(cat "${output}" | grep -i "ERROR\|Unable to get the model status from the API" || true)
 	if [[ -n ${CHK} ]]; then
 		printf '\nFound some issues\n'
 		cat "${output}"


### PR DESCRIPTION
Found a bug in ha tear down, #13525 , however the enable-ha integration test failed to catch it multiple times.

1. destroy model can fail without the word error, check for "Unable to get the model status from the API" as well.
2. When verifying machine tear down in ha, once there are no stopped machines and 1 started, verify none are in error state.

## QA steps

```sh
(cd tests ; ./main.sh -v controller test_enable_ha)
```
