### PR TITLE
[JUJU-268] Add support for tear down of instance roles.

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -590,6 +590,21 @@ func (c *destroyCommandBase) getControllerEnviron(
 	return env, nil
 }
 
+func (c *destroyCommandBase) getControllerCloudSpecFromStore(
+	ctx *cmd.Context,
+	store jujuclient.ClientStore,
+	controllerName string,
+) (environscloudspec.CloudSpec, error) {
+	_, params, err := modelcmd.NewGetBootstrapConfigParamsFunc(
+		ctx, store, environs.GlobalProviderRegistry(),
+	)(controllerName)
+	if err != nil {
+		return environscloudspec.CloudSpec{}, errors.Trace(err)
+	}
+
+	return params.Cloud, nil
+}
+
 func (c *destroyCommandBase) getControllerEnvironFromStore(
 	ctx *cmd.Context,
 	store jujuclient.ClientStore,

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -288,6 +288,20 @@ type ConfigSetter interface {
 	SetConfig(cfg *config.Config) error
 }
 
+// CloudSpecGetter implents access to retrieving an environment's cloud spec
+type CloudSpecGetter interface {
+	// GetCloudSpec returns the current cloud spec in use by the Environ
+	GetCloudSpec(stdcontext.Context) (environscloudspec.CloudSpec, error)
+}
+
+// CloudSpecGetterFn provides a function type that implements CloudSpecGetter
+type CloudSpecGetterFn func(stdcontext.Context) (environscloudspec.CloudSpec, error)
+
+// GetCloudSpec implements CloudSpecGetter interface
+func (c CloudSpecGetterFn) GetCloudSpec(ctx stdcontext.Context) (environscloudspec.CloudSpec, error) {
+	return c(ctx)
+}
+
 // CloudSpecSetter implements access to an environment's cloud spec.
 type CloudSpecSetter interface {
 	// SetCloudSpec updates the Environ's configuration.

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -288,20 +288,6 @@ type ConfigSetter interface {
 	SetConfig(cfg *config.Config) error
 }
 
-// CloudSpecGetter implents access to retrieving an environment's cloud spec
-type CloudSpecGetter interface {
-	// GetCloudSpec returns the current cloud spec in use by the Environ
-	GetCloudSpec(stdcontext.Context) (environscloudspec.CloudSpec, error)
-}
-
-// CloudSpecGetterFn provides a function type that implements CloudSpecGetter
-type CloudSpecGetterFn func(stdcontext.Context) (environscloudspec.CloudSpec, error)
-
-// GetCloudSpec implements CloudSpecGetter interface
-func (c CloudSpecGetterFn) GetCloudSpec(ctx stdcontext.Context) (environscloudspec.CloudSpec, error) {
-	return c(ctx)
-}
-
 // CloudSpecSetter implements access to an environment's cloud spec.
 type CloudSpecSetter interface {
 	// SetCloudSpec updates the Environ's configuration.

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -2651,6 +2651,13 @@ func (e *environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error
 	return []string{cidr}, nil
 }
 
+// GetCloudSpec is specificed in the CloudSpecGetter interface
+func (e *environ) GetCloudSpec(ctx stdcontext.Context) (environscloudspec.CloudSpec, error) {
+	e.ecfgMutex.Lock()
+	defer e.ecfgMutex.Unlock()
+	return e.cloud, nil
+}
+
 // SetCloudSpec is specified in the environs.Environ interface.
 func (e *environ) SetCloudSpec(ctx stdcontext.Context, spec environscloudspec.CloudSpec) error {
 	if err := validateCloudSpec(spec); err != nil {

--- a/provider/ec2/iam.go
+++ b/provider/ec2/iam.go
@@ -56,6 +56,9 @@ type IAMClient interface {
 	DeleteRolePolicy(stdcontext.Context, *iam.DeleteRolePolicyInput, ...func(*iam.Options)) (*iam.DeleteRolePolicyOutput, error)
 	GetInstanceProfile(stdcontext.Context, *iam.GetInstanceProfileInput, ...func(*iam.Options)) (*iam.GetInstanceProfileOutput, error)
 	GetRole(stdcontext.Context, *iam.GetRoleInput, ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	ListInstanceProfiles(stdcontext.Context, *iam.ListInstanceProfilesInput, ...func(*iam.Options)) (*iam.ListInstanceProfilesOutput, error)
+	ListRolePolicies(stdcontext.Context, *iam.ListRolePoliciesInput, ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error)
+	ListRoles(stdcontext.Context, *iam.ListRolesInput, ...func(*iam.Options)) (*iam.ListRolesOutput, error)
 	PutRolePolicy(stdcontext.Context, *iam.PutRolePolicyInput, ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
 	RemoveRoleFromInstanceProfile(stdcontext.Context, *iam.RemoveRoleFromInstanceProfileInput, ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error)
 }
@@ -95,6 +98,83 @@ func iamClientFunc(
 	return iam.NewFromConfig(cfg), nil
 }
 
+// controllerPath returns an AWS path to use for IAM resources based on the
+// controller UUID
+func controllerPath(controllerUUID string) string {
+	return fmt.Sprintf("/juju/controller/%s/", controllerUUID)
+}
+
+// deleteInstanceProfile is a convience method for removing instance profile by
+// first detaching all roles from the profile then deleting.
+func deleteInstanceProfile(
+	ctx stdcontext.Context,
+	client IAMClient,
+	instanceProfile iamtypes.InstanceProfile,
+) error {
+	for _, role := range instanceProfile.Roles {
+		_, err := client.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+			InstanceProfileName: instanceProfile.InstanceProfileName,
+			RoleName:            role.RoleName,
+		})
+
+		if err != nil {
+			return errors.Annotatef(err, "removing role %q from instance profile", *role.RoleName)
+		}
+	}
+
+	_, err := client.DeleteInstanceProfile(ctx, &iam.DeleteInstanceProfileInput{
+		InstanceProfileName: instanceProfile.InstanceProfileName,
+	})
+
+	return errors.Trace(err)
+}
+
+// deleteRole is a convience method for delete a role and it's associated
+// inline policies.
+func deleteRole(
+	ctx stdcontext.Context,
+	client IAMClient,
+	roleName string,
+) error {
+
+	var (
+		inlinePolicyNames = []string{}
+		marker            *string
+	)
+	for {
+		res, err := client.ListRolePolicies(ctx, &iam.ListRolePoliciesInput{
+			Marker:   marker,
+			RoleName: aws.String(roleName),
+		})
+
+		if err != nil {
+			return errors.Annotatef(err, "listing inline policies for role %q", roleName)
+		}
+
+		inlinePolicyNames = append(inlinePolicyNames, res.PolicyNames...)
+		if !res.IsTruncated {
+			break
+		}
+		marker = res.Marker
+	}
+
+	for _, policyName := range inlinePolicyNames {
+		_, err := client.DeleteRolePolicy(ctx, &iam.DeleteRolePolicyInput{
+			PolicyName: aws.String(policyName),
+			RoleName:   aws.String(roleName),
+		})
+		if err != nil {
+			return errors.Annotatef(err, "delete inline policy %q", policyName)
+		}
+	}
+
+	_, err := client.DeleteRole(ctx, &iam.DeleteRoleInput{
+		RoleName: aws.String(roleName),
+	})
+
+	return errors.Trace(err)
+}
+
 // ensureControllerInstanceProfile ensures that a controller Instance Profile
 // has been created for the supplied controller name in the specified AWS cloud.
 func ensureControllerInstanceProfile(
@@ -117,6 +197,7 @@ func ensureControllerInstanceProfile(
 				Value: aws.String(controllerUUID),
 			},
 		},
+		Path: aws.String(controllerPath(controllerUUID)),
 	})
 	if err != nil {
 		var alreadyExistsErr *iamtypes.EntityAlreadyExistsException
@@ -182,6 +263,7 @@ func ensureControllerInstanceRole(
 		AssumeRolePolicyDocument: aws.String(controllerRoleAssumePolicy),
 		RoleName:                 aws.String(roleName),
 		Description:              aws.String(fmt.Sprintf("juju role for controller %s", controllerName)),
+		Path:                     aws.String(controllerPath(controllerUUID)),
 		Tags: []iamtypes.Tag{
 			{
 				Key:   aws.String(tags.JujuController),
@@ -259,6 +341,68 @@ func findInstanceProfileFromName(
 	}
 
 	return res.InstanceProfile, nil
+}
+
+func listInstanceProfilesForController(
+	ctx stdcontext.Context,
+	client IAMClient,
+	controllerUUID string,
+) ([]iamtypes.InstanceProfile, error) {
+	var (
+		marker *string
+		rval   = []iamtypes.InstanceProfile{}
+	)
+	for {
+		res, err := client.ListInstanceProfiles(ctx, &iam.ListInstanceProfilesInput{
+			Marker:     marker,
+			PathPrefix: aws.String(controllerPath(controllerUUID)),
+		})
+
+		if err != nil {
+			return nil, errors.Annotatef(
+				err,
+				"listing roles with controller prefix %q",
+				controllerPath(controllerUUID))
+		}
+
+		rval = append(rval, res.InstanceProfiles...)
+		if !res.IsTruncated {
+			break
+		}
+		marker = res.Marker
+	}
+	return rval, nil
+}
+
+func listRolesForController(
+	ctx stdcontext.Context,
+	client IAMClient,
+	controllerUUID string,
+) ([]iamtypes.Role, error) {
+	var (
+		marker *string
+		rval   = []iamtypes.Role{}
+	)
+	for {
+		res, err := client.ListRoles(ctx, &iam.ListRolesInput{
+			Marker:     marker,
+			PathPrefix: aws.String(controllerPath(controllerUUID)),
+		})
+
+		if err != nil {
+			return nil, errors.Annotatef(
+				err,
+				"listing roles with controller prefix %q",
+				controllerPath(controllerUUID))
+		}
+
+		rval = append(rval, res.Roles...)
+		if !res.IsTruncated {
+			break
+		}
+		marker = res.Marker
+	}
+	return rval, nil
 }
 
 func findRoleFromName(

--- a/provider/ec2/iam_docs.go
+++ b/provider/ec2/iam_docs.go
@@ -63,6 +63,7 @@ const (
       "Sid": "JujuIAMActions",
       "Effect": "Allow",
       "Action": [
+	    "iam:AddRoleToInstanceProfile",
         "iam:CreateInstanceProfile",
 		"iam:CreateRole",
 		"iam:DeleteInstanceProfile",
@@ -70,6 +71,9 @@ const (
 		"iam:DeleteRolePolicy",
         "iam:GetInstanceProfile",
 		"iam:GetRole",
+		"iam:ListInstanceProfiles",
+		"iam:ListRolePolicies",
+		"iam:ListRoles",
 		"iam:PassRole",
 		"iam:PutRolePolicy",
 		"iam:RemoveRoleFromInstanceProfile"

--- a/provider/ec2/iam_test.go
+++ b/provider/ec2/iam_test.go
@@ -31,7 +31,7 @@ func (i *IAMSuite) TestEnsureControllerInstanceProfileFromScratch(c *gc.C) {
 	ip, _, err := ensureControllerInstanceProfile(context.Background(), i.server, "test", "AABBCC")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*ip.InstanceProfileName, gc.Equals, "juju-controller-test")
-	c.Assert(ip.Path, gc.IsNil)
+	c.Assert(*ip.Path, gc.Equals, "/juju/controller/AABBCC/")
 
 	roleOutput, err := i.server.GetRole(context.Background(), &iam.GetRoleInput{
 		RoleName: aws.String("juju-controller-test"),

--- a/provider/ec2/internal/testing/instanceprofile.go
+++ b/provider/ec2/internal/testing/instanceprofile.go
@@ -113,6 +113,25 @@ func (i *IAMServer) GetInstanceProfile(
 	}, nil
 }
 
+func (i *IAMServer) ListInstanceProfiles(
+	ctx context.Context,
+	input *iam.ListInstanceProfilesInput,
+	opts ...func(*iam.Options),
+) (*iam.ListInstanceProfilesOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	rval := &iam.ListInstanceProfilesOutput{
+		InstanceProfiles: []types.InstanceProfile{},
+		IsTruncated:      false,
+	}
+	for _, v := range i.instanceProfiles {
+		rval.InstanceProfiles = append(rval.InstanceProfiles, *v)
+	}
+
+	return rval, nil
+}
+
 func (i *IAMServer) RemoveRoleFromInstanceProfile(
 	ctx context.Context,
 	input *iam.RemoveRoleFromInstanceProfileInput,
@@ -132,7 +151,7 @@ func (i *IAMServer) RemoveRoleFromInstanceProfile(
 		return nil, apiError("InvalidInstanceProfile.NoRole", "Instance profile has no role attached")
 	}
 
-	if *ip.Roles[1].RoleName != *input.RoleName {
+	if *ip.Roles[0].RoleName != *input.RoleName {
 		return nil, apiError(
 			"InvalidInstanceProfile.Role",
 			"role %s is not attached to instance profile", *ip.Roles[1].RoleName)

--- a/provider/ec2/internal/testing/roles.go
+++ b/provider/ec2/internal/testing/roles.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -109,6 +110,52 @@ func (i *IAMServer) GetRole(
 	return &iam.GetRoleOutput{
 		Role: role,
 	}, nil
+}
+
+func (i *IAMServer) ListRoles(
+	ctx context.Context,
+	input *iam.ListRolesInput,
+	opts ...func(*iam.Options),
+) (*iam.ListRolesOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	rval := &iam.ListRolesOutput{
+		Roles:       []types.Role{},
+		IsTruncated: false,
+	}
+
+	for _, role := range i.roles {
+		if strings.HasPrefix(*role.Path, *input.PathPrefix) {
+			rval.Roles = append(rval.Roles, *role)
+		}
+	}
+
+	return rval, nil
+}
+
+func (i *IAMServer) ListRolePolicies(
+	ctx context.Context,
+	input *iam.ListRolePoliciesInput,
+	opts ...func(*iam.Options),
+) (*iam.ListRolePoliciesOutput, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	_, exists := i.roles[*input.RoleName]
+	if !exists {
+		return nil, apiError("InvalidRole.NotFound", "role not found")
+	}
+
+	rval := &iam.ListRolePoliciesOutput{
+		PolicyNames: []string{},
+		IsTruncated: false,
+	}
+	if policy, exists := i.roleInlinePolicy[*input.RoleName]; exists {
+		rval.PolicyNames = []string{*policy.PolicyName}
+	}
+
+	return rval, nil
 }
 
 func (i *IAMServer) PutRolePolicy(

--- a/provider/ec2/internal/testing/server.go
+++ b/provider/ec2/internal/testing/server.go
@@ -49,7 +49,6 @@ type Server struct {
 func NewServer() (*Server, error) {
 	srv := &Server{}
 	srv.Reset(false)
-
 	return srv, nil
 }
 
@@ -99,6 +98,8 @@ func (srv *Server) Reset(withoutZonesOrGroups bool) {
 	srv.volumes = make(map[string]*volume)
 	srv.volumeAttachments = make(map[string]*volumeAttachment)
 	srv.reservations = make(map[string]*reservation)
+
+	srv.instanceProfileAssociations = make(map[string]types.IamInstanceProfileAssociation)
 
 	if !withoutZonesOrGroups {
 		srv.addDefaultZonesAndGroups()


### PR DESCRIPTION
With instance role credentials the controller cannot use the model credentials to assist in tear down. This introduces a change where if this is detected we swap to using the controller credentials. This is a best effort approach at the moment

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Bootstrap to AWS using:

```sh
juju bootstrap --bootstrap-constraints="instance-role=auto" aws/ap-southeast-2 tlm-test-1
```

Then kill the newly created controller with:
```bash
juju kill-controller -t 0 -y tlm-test-1
```

## Documentation changes

N/A

## Bug reference

N/A
