### PR TITLE
[JUJU-227] Cancel the scheduled(1min delayed) forceDestroyUnit cleanups

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -117,6 +117,39 @@ func newCleanupAtOp(when time.Time, kind cleanupKind, prefix string, args ...int
 	}
 }
 
+func (st *State) cancelCleanupOps(kind cleanupKind, prefix string) ([]txn.Op, error) {
+	if prefix == "" {
+		return nil, nil
+	}
+	col, closer := st.db().GetCollection(cleanupsC)
+	defer closer()
+	var docs []cleanupDoc
+	err := col.Find(
+		bson.D{
+			{
+				Name: "prefix", Value: bson.D{
+					{Name: "$regex", Value: fmt.Sprintf("^%s", prefix)},
+				},
+			},
+			{
+				Name: "kind", Value: kind,
+			},
+		},
+	).All(&docs)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get %q cleanups docs with prefix %q", kind, prefix)
+	}
+	var ops []txn.Op
+	for _, doc := range docs {
+		ops = append(ops, txn.Op{
+			C:      cleanupsC,
+			Id:     doc.DocID,
+			Remove: true,
+		})
+	}
+	return ops, nil
+}
+
 // NeedsCleanup returns true if documents previously marked for removal exist.
 func (st *State) NeedsCleanup() (bool, error) {
 	cleanups, closer := st.db().GetCollection(cleanupsC)
@@ -163,7 +196,7 @@ func (st *State) Cleanup() (err error) {
 		case cleanupForceDestroyedRelation:
 			err = st.cleanupForceDestroyedRelation(doc.Prefix)
 		case cleanupCharm:
-			err = st.cleanupCharm(doc.Prefix)
+			err = st.cleanupCharm(doc.Prefix, args)
 		case cleanupApplication:
 			err = st.cleanupApplication(doc.Prefix, args)
 		case cleanupForceApplication:
@@ -752,10 +785,64 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanup
 	return nil
 }
 
+func (st *State) cancelCleanupForceDestroyedUnit(appName string) error {
+	if appName == "" {
+		return nil
+	}
+	shouldCancel := func() (bool, error) {
+		app, err := st.Application(appName)
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+		units, err := app.AllUnits()
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+		return len(units) == 0, nil
+	}
+	if should, err := shouldCancel(); err != nil {
+		return errors.Trace(err)
+	} else if !should {
+		// We probably should not return an error to fail current main cleanup.
+		return nil
+	}
+	// Cancel unit cleanups.
+	ops, err := st.cancelCleanupOps(cleanupForceDestroyedUnit, appName)
+	if err != nil {
+		return errors.Annotatef(err, "can not get %q cancelCleanupOps for %q", cleanupForceDestroyedUnit, appName)
+	}
+	if len(ops) == 0 {
+		return nil
+	}
+	if err := st.db().RunTransaction(ops); err != nil {
+		return errors.Annotatef(err, "cannot cancel %q cleanup for %q", cleanupForceDestroyedUnit, appName)
+	}
+	return nil
+}
+
 // cleanupCharm is speculative: it can abort without error for many
 // reasons, because it's triggered somewhat over-enthusiastically for
 // simplicity's sake.
-func (st *State) cleanupCharm(charmURL string) error {
+func (st *State) cleanupCharm(charmURL string, cleanupArgs []bson.Raw) (err error) {
+	switch n := len(cleanupArgs); n {
+	case 0:
+	// It's valid to have no args: old cleanups have no args, so follow the old behaviour.
+	case 1:
+		// We do this here in the very last step of app removal process.
+		var appName string
+		if err := cleanupArgs[0].Unmarshal(&appName); err != nil {
+			return errors.Annotate(err, "unmarshalling cleanup arg 'appName'")
+		}
+		if err := st.cancelCleanupForceDestroyedUnit(appName); err != nil {
+			return errors.Annotatef(err, "can not cancel %q for %q", cleanupForceDestroyedUnit, appName)
+		}
+	default:
+		return errors.Errorf("expected 0 or 1 argument, got %d", n)
+	}
+
 	curl, err := charm.ParseURL(charmURL)
 	if err != nil {
 		return errors.Annotatef(err, "invalid charm URL %v", charmURL)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1101,3 +1101,15 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 	}
 	return nil
 }
+
+func (st *State) CleanupForceApplication(applicationName string, cleanupArgs []bson.Raw) error {
+	return st.cleanupForceApplication(applicationName, cleanupArgs)
+}
+
+var (
+	CleanupForceDestroyedUnit = cleanupForceDestroyedUnit
+)
+
+func (st *State) ScheduleForceCleanup(kind cleanupKind, name string, maxWait time.Duration) {
+	st.scheduleForceCleanup(kind, name, maxWait)
+}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1102,12 +1102,10 @@ func (st *State) SetClockForTesting(clock clock.Clock) error {
 	return nil
 }
 
-func (st *State) CleanupForceApplication(applicationName string, cleanupArgs []bson.Raw) error {
-	return st.cleanupForceApplication(applicationName, cleanupArgs)
-}
-
 var (
 	CleanupForceDestroyedUnit = cleanupForceDestroyedUnit
+	CleanupForceRemoveUnit    = cleanupForceRemoveUnit
+	CleanupForceApplication   = cleanupForceApplication
 )
 
 func (st *State) ScheduleForceCleanup(kind cleanupKind, name string, maxWait time.Duration) {


### PR DESCRIPTION
We have a `foo` sidecar CAAS application containing storage and resources deployed in a model, now we remove this application with `--force` then re-deploy it again using the same application name `foo`. In `2.9`, the new units sometimes will get terminated. 
The root cause is Juju will schedule (will be processed 1 min later) a `forceDestroyUnit` doc for each unit when we remove the application with `--force` and the application has `storage` and `resources`. 
If we deploy the application `foo` again immediately after the 1st `foo` app gets removed, those new units will be removed by the previously scheduled `forceDestroyUnit` cleanup steps.
So this PR ensures we cancel those scheduled `forceDestroyUnit` cleanup docs in the very last step of the application removal process if the application has already gone or there is no units to remove anymore.
 
## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju add-model t1 microk8s

$ juju deploy hello-kubecon

$ juju remove-application hello-kubecon --force

$ juju deploy hello-kubecon

# now the application and units should be settled correctly.
```

## Documentation changes

No


## Bug reference


https://bugs.launchpad.net/juju/+bug/1946382
