### PR TITLE
[JUJU-301] Ensure state pool release upon worker start errors

### DIFF
--- a/worker/apiserver/manifold.go
+++ b/worker/apiserver/manifold.go
@@ -211,13 +211,6 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
-	// Get the state pool after grabbing dependencies so we don't need
-	// to remember to call Done on it if they're not running yet.
-	statePool, err := stTracker.Use()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	// Register the metrics collector against the prometheus register.
 	metricsCollector := config.NewMetricsCollector()
 	if err := config.PrometheusRegisterer.Register(metricsCollector); err != nil {
@@ -227,6 +220,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	execEmbeddedCommand := func(ctx *cmd.Context, store jujuclient.ClientStore, whitelist []string, cmdPlusARgs string) int {
 		jujuCmd := commands.NewJujuCommandWithStore(ctx, store, nil, "", `Type "help" to see a list of commands`, whitelist, true)
 		return cmd.Main(jujuCmd, ctx, strings.Split(cmdPlusARgs, " "))
+	}
+
+	// Get the state pool after grabbing dependencies so we don't need
+	// to remember to call Done on it if they're not running yet.
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	w, err := config.NewWorker(Config{

--- a/worker/certupdater/manifold.go
+++ b/worker/certupdater/manifold.go
@@ -87,6 +87,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	st := statePool.SystemState()
 	addressWatcher, err := config.NewMachineAddressWatcher(st, agentConfig.Tag().Id())
 	if err != nil {
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 

--- a/worker/certupdater/manifold_test.go
+++ b/worker/certupdater/manifold_test.go
@@ -124,6 +124,15 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	})
 }
 
+func (s *ManifoldSuite) TestStartErrorClosesState(c *gc.C) {
+	s.stub.SetErrors(errors.New("boom"))
+
+	_, err := s.manifold.Start(s.context)
+	c.Assert(err, gc.ErrorMatches, "boom")
+
+	s.stateTracker.CheckCallNames(c, "Use", "Done")
+}
+
 func (s *ManifoldSuite) TestStopWorkerClosesState(c *gc.C) {
 	w, err := s.manifold.Start(s.context)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/peergrouper/manifold.go
+++ b/worker/peergrouper/manifold.go
@@ -103,10 +103,12 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	agentConfig := agent.CurrentConfig()
 	stateServingInfo, ok := agentConfig.StateServingInfo()
 	if !ok {
+		_ = stTracker.Done()
 		return nil, errors.New("state serving info missing from agent config")
 	}
 	model, err := st.Model()
 	if err != nil {
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 	supportsHA := model.Type() != state.ModelTypeCAAS


### PR DESCRIPTION
We must ensure that after acquiring a state pool reference from the state tracker, we always release it via the `Done` method both in worker clean-up and upon any subsequent start-up errors.

Here we fix a few places where exiting with errors did not adhere to this requirement.

## QA steps

Unit tests verify the change.

Bootstrap and check for errors to test regression.

## Documentation changes

None.

## Bug reference

N/A
