### PR TITLE
[JUJU-305] new block cmd integration test

### DIFF
--- a/cmd/juju/application/removesaas.go
+++ b/cmd/juju/application/removesaas.go
@@ -84,8 +84,8 @@ func (c *removeSaasCommand) Init(args []string) error {
 
 func (c *removeSaasCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.Force, "force", false, "Completely remove an application and all its dependencies")
-	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through application removal without waiting for each individual step to complete")
+	f.BoolVar(&c.Force, "force", false, "Completely remove a SAAS and all its dependencies")
+	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through SAAS removal without waiting for each individual step to complete")
 	c.fs = f
 }
 

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -108,8 +108,8 @@ func (c *removeUnitCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.IntVar(&c.NumUnits, "num-units", 0, "Number of units to remove (k8s models only)")
 	f.BoolVar(&c.DestroyStorage, "destroy-storage", false, "Destroy storage attached to the unit")
-	f.BoolVar(&c.Force, "force", false, "Completely remove an application and all its dependencies")
-	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through application removal without waiting for each individual step to complete")
+	f.BoolVar(&c.Force, "force", false, "Completely remove an unit and all its dependencies")
+	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through unit removal without waiting for each individual step to complete")
 	c.fs = f
 }
 

--- a/tests/suites/cli/block.sh
+++ b/tests/suites/cli/block.sh
@@ -1,0 +1,102 @@
+run_block_destroy_model() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	model_name="test-block-destroy-model"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju disable-command destroy-model
+	juju destroy-model -y ${model_name} | grep -q 'the operation has been blocked' || true
+
+	juju enable-command destroy-model
+	destroy_model "${model_name}"
+}
+
+run_block_remove_object() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	model_name="test-block-remove-object"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy ubuntu
+	juju deploy ntp
+	juju add-relation ntp ubuntu
+
+	juju disable-command remove-object
+
+	# juju status should still work when 'remove-object' commands
+	# are disabled.
+	wait_for "ntp" "$(idle_subordinate_condition "ntp" "ubuntu" 0)"
+
+	juju destroy-model -y ${model_name} | grep -q 'the operation has been blocked' || true
+	juju remove-application ntp | grep -q 'the operation has been blocked' || true
+	juju remove-relation ntp ubuntu | grep -q 'the operation has been blocked' || true
+	juju remove-unit ubuntu/0 | grep -q 'the operation has been blocked' || true
+
+	juju enable-command remove-object
+
+	juju remove-relation ntp ubuntu
+	juju remove-application ntp
+	juju remove-unit ubuntu/0
+
+	destroy_model "${model_name}"
+}
+
+run_block_all() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	model_name="test-block-all"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy ubuntu
+	juju expose ubuntu
+
+	juju disable-command all
+
+	# juju status and offers should still work when 'all' commands
+	# are disabled.
+	juju status --format json | jq '.applications | .["ubuntu"] | .exposed' | check true
+	juju offers | grep -q 'Offer' || true
+
+	juju enable-ha | grep -q 'the operation has been blocked' || true
+	juju deploy ntp | grep -q 'the operation has been blocked' || true
+	juju add-relation ntp ubuntu | grep -q 'the operation has been blocked' || true
+	juju unexpose ubuntu | grep -q 'the operation has been blocked' || true
+
+	juju enable-command all
+
+	juju deploy ntp
+	juju add-relation ntp ubuntu
+
+	wait_for "ntp" "$(idle_subordinate_condition "ntp" "ubuntu" 0)"
+
+	juju unexpose ubuntu
+	juju status --format json | jq '.applications | .["ubuntu"] | .exposed' | check false
+
+	destroy_model "${model_name}"
+}
+
+test_block_commands() {
+	if [ "$(skip 'test_block_commands')" ]; then
+		echo "==> TEST SKIPPED: block commands"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_block_destroy_model"
+		run "run_block_remove_object"
+		run "run_block_all"
+	)
+}

--- a/tests/suites/cli/task.sh
+++ b/tests/suites/cli/task.sh
@@ -17,6 +17,7 @@ test_cli() {
 	test_local_charms
 	test_model_config
 	test_model_defaults
+	test_block_commands
 
 	destroy_controller "test-cli"
 }


### PR DESCRIPTION
Replacement for old python nw-block-commands test.  Test all three options for `juju disable-command`: all, remote-object and destroy-model.  As well as `juju enable-command`.  

Includes fixes for 2 copy/paste errors in command flag descriptions, found while looked at `juju disable-command` and `juju enable-command.

## QA

```console
(cd tests ; ./main.sh -v cli test_block_commands)
```

