### PR TITLE
[JUJU-269] fix nw-deploy-bionic-gke

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/gke.py
+++ b/acceptancetests/jujupy/k8s_provider/gke.py
@@ -178,6 +178,10 @@ class GKE(Base):
                     max_node_count=3,
                 ),
             )],
+            network=f"projects/{self.default_params['project_id']}/global/networks/with-subnets",
+            ip_allocation_policy=dict(
+                use_ip_aliases=True,
+            ),
         )
         logger.info('creating cluster -> %s', cluster)
         r = self.driver.create_cluster(


### PR DESCRIPTION
Use the `with-subnets` network for GKE cluster because the `default` legacy network is not allowed now;
Fix below error:
```log
	debug_error_string = "{"created":"@1638856961.902441815","description":"Error received from peer ipv6:[2404:6800:4006:80f::200a]:443","file":"src/core/lib/surface/call.cc","file_line":1067,"grpc_message":"IP aliases cannot be used with a legacy network.","grpc_status":3}"
```
