### PR TITLE
[JUJU-313] fixes a timeout config not long enough issue for upgrade commands

### DIFF
--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -53,7 +53,6 @@ type upgradeControllerCommand struct {
 	modelcmd.ControllerCommandBase
 	baseUpgradeCommand
 
-	rawArgs       []string
 	jujuClientAPI ClientAPI
 }
 
@@ -128,6 +127,7 @@ func (c *upgradeControllerCommand) upgradeController(ctx *cmd.Context, controlle
 	if c.AssumeYes {
 		args = append(args, "--yes")
 	}
+	args = append(args, "--timeout", c.timeout.String())
 	code := cmd.Main(wrapped, ctx, args)
 	if code == 0 {
 		return nil

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -114,7 +114,7 @@ type baseUpgradeCommand struct {
 	ResetPrevious bool
 	AssumeYes     bool
 	AgentStream   string
-
+	timeout       time.Duration
 	// IgnoreAgentVersions is used to allow an admin to request an agent version without waiting for all agents to be at the right
 	// version.
 	IgnoreAgentVersions bool
@@ -137,6 +137,7 @@ func (c *baseUpgradeCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.AssumeYes, "yes", false, "")
 	f.BoolVar(&c.IgnoreAgentVersions, "ignore-agent-versions", false,
 		"Don't check if all agents have already reached the current version")
+	f.DurationVar(&c.timeout, "timeout", 10*time.Minute, "Timeout before upgrade is aborted")
 }
 
 func (c *baseUpgradeCommand) Init(args []string) error {
@@ -375,14 +376,13 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 		return errors.Trace(err)
 	}
 	implicitAgentUploadAllowed := true
-	fetchToolsTimeout := 10 * time.Minute
 	if modelType == model.CAAS {
 		if c.BuildAgent {
 			return errors.NotSupportedf("--build-agent for k8s model upgrades")
 		}
 		implicitAgentUploadAllowed = false
 	}
-	return c.upgradeModel(ctx, implicitAgentUploadAllowed, fetchToolsTimeout)
+	return c.upgradeModel(ctx, implicitAgentUploadAllowed, c.timeout)
 }
 
 func (c *upgradeJujuCommand) upgradeModel(ctx *cmd.Context, implicitUploadAllowed bool, fetchTimeout time.Duration) (err error) {
@@ -829,7 +829,6 @@ func fetchStreamsVersions(
 			result <- findResult.List
 		}
 	}()
-
 	select {
 	case <-time.After(timeout):
 		return nil, errors.NewTimeout(nil, fmt.Sprintf("can not fetch available versions in %s", timeout.String()))

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -368,8 +368,6 @@ func (c *upgradeJujuCommand) getControllerAPI() (ControllerAPI, error) {
 	return apicontroller.NewClient(api), nil
 }
 
-const caasStreamsTimeout = 20 * time.Second
-
 // Run changes the version proposed for the juju envtools.
 func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	modelType, err := c.ModelType()
@@ -383,7 +381,6 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 			return errors.NotSupportedf("--build-agent for k8s model upgrades")
 		}
 		implicitAgentUploadAllowed = false
-		fetchToolsTimeout = caasStreamsTimeout
 	}
 	return c.upgradeModel(ctx, implicitAgentUploadAllowed, fetchToolsTimeout)
 }
@@ -835,7 +832,7 @@ func fetchStreamsVersions(
 
 	select {
 	case <-time.After(timeout):
-		return nil, nil
+		return nil, errors.NewTimeout(nil, fmt.Sprintf("can not fetch available versions in %s", timeout.String()))
 	case err := <-errChan:
 		return nil, err
 	case resultList := <-result:


### PR DESCRIPTION
This PR includes changes:
- Extended the timeout for fetching available versions for CAAS model from 20s to 10min(value is used for IAAS currently);
- Added a timeout option for upgrade-model, upgrade-controller and upgrade-juju commands;


## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju version
2.8.14-focal-amd64

$ juju bootstrap microk8s k1

$ juju add-model t1

$ juju upgrade-controller --timeout 1s --debug
ERROR can not fetch available versions in 1s

$ juju upgrade-controller --timeout 30s --debug
best version:
    2.9.21
started upgrade to 2.9.21

$ juju upgrade-juju -m t1  --timeout 1s
ERROR can not fetch available versions in 1s

$ juju upgrade-model -m t1 --dry-run --timeout 30s
best version:
    2.9.21
upgrade to this version by running
    juju upgrade-model

$ juju upgrade-model -m t1 --dry-run
best version:
    2.9.21
upgrade to this version by running
    juju upgrade-model

$ juju upgrade-model -m t1  --timeout 30s
best version:
    2.9.21
started upgrade to 2.9.21
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1953556
