### PR TITLE
Fix shellcheck

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -2,7 +2,7 @@
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
-export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005"
+export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005 -e SC2001 -e SC2263"
 export BOOTSTRAP_REUSE_LOCAL="${BOOTSTRAP_REUSE_LOCAL:-}"
 export BOOTSTRAP_REUSE="${BOOTSTRAP_REUSE:-false}"
 export BOOTSTRAP_PROVIDER="${BOOTSTRAP_PROVIDER:-lxd}"
@@ -152,6 +152,7 @@ while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
 		;;
 	v)
 		VERBOSE=2
+		# shellcheck disable=SC2262
 		alias juju="juju --debug"
 		;;
 	A)

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -1,5 +1,5 @@
 run_shellcheck() {
-	OUT=$(shellcheck --shell sh tests/main.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
+	OUT=$(shellcheck --shell=bash tests/main.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
 	if [ -n "${OUT}" ]; then
 		echo ""
 		echo "$(red 'Found some issues:')"


### PR DESCRIPTION
As shellcheck is updating we should ensure that we can still work with
the bleeding edge. This fixes some warnings that weren't flagged
previously.


## QA steps

```sh
make static-analysis
```
