### PR TITLE
[JUJU-315] resolve missing back port - remove revision check from ResolveWithPreferredChannel

### DIFF
--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -65,10 +65,6 @@ func NewCharmHubRepository(logger Logger, chClient CharmHubClient) *CharmHubRepo
 // When charmstore goes, we could potentially rework how the client requests
 // the store.
 func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, requestedOrigin corecharm.Origin, macaroons macaroon.Slice) (*charm.URL, corecharm.Origin, []string, error) {
-	if charmURL.Revision != -1 {
-		return nil, corecharm.Origin{}, nil, errors.Errorf("specifying a revision is not supported, please use a channel.")
-	}
-
 	c.logger.Tracef("Resolving CharmHub charm %q with origin %v", charmURL, requestedOrigin)
 
 	// First attempt to find the charm based on the only input provided.


### PR DESCRIPTION
While working on other bundle deployment issues, found that Achilleasa's commit was missing from the back port of deploy by revision with charmhub charms.  It's unexpected that this only happens with deploying a bundle a 2nd time, or to an existing model with the same config.

## QA steps

```sh
$ juju deploy juju-qa-test --revision 8 --channel stable
Located charm "juju-qa-test" in charm-hub, revision 8
Deploying "juju-qa-test" from charm-hub charm "juju-qa-test", revision 8 in channel stable
$ juju export-bundle > /tmp/exported.yaml
$ juju deploy --dry-run /tmp/exported.yaml
No changes to apply.
```
