### PR TITLE
[JUJU-169] fix bundle deployment with 2.9 client and older controllers

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -262,6 +262,10 @@ func (h *bundleHandler) makeModel(
 	if err != nil {
 		return errors.Annotate(err, "cannot get model status")
 	}
+	status, err = h.updateChannelsModelStatus(status)
+	if err != nil {
+		return errors.Annotate(err, "updating current application channels")
+	}
 
 	h.model, err = appbundle.BuildModelRepresentation(status, h.deployAPI, useExistingMachines, bundleMachines)
 	if err != nil {
@@ -280,6 +284,38 @@ func (h *bundleHandler) makeModel(
 		return err
 	}
 	return nil
+}
+
+// updateChannelsModelStatus gets the application's channel from a different
+// source when the default charm schema is charmstore.  Required for compatibility
+// between pre 2.9 controllers and newer clients.  The controller has the data,
+// status output does not.
+func (h *bundleHandler) updateChannelsModelStatus(status *params.FullStatus) (*params.FullStatus, error) {
+	if !h.defaultCharmSchema.Matches(charm.CharmStore.String()) || len(status.Applications) <= 0 {
+		return status, nil
+	}
+	var tags []names.ApplicationTag
+	for k := range status.Applications {
+		tags = append(tags, names.NewApplicationTag(k))
+	}
+	infoResults, err := h.deployAPI.ApplicationsInfo(tags)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, result := range infoResults {
+		name := tags[i].Id()
+		if result.Error != nil {
+			return nil, errors.Annotatef(err, "%s", name)
+		}
+		appStatus, ok := status.Applications[name]
+		if !ok {
+			return nil, errors.NotFoundf("programming error: %q application info", name)
+		}
+		appStatus.CharmChannel = result.Result.Channel
+		status.Applications[name] = appStatus
+	}
+	return status, nil
 }
 
 // resolveCharmsAndEndpoints will go through the bundle and

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -816,7 +816,6 @@ func (s *BundleDeployRepositorySuite) TestDryRunExistingModel(c *gc.C) {
 	}
 	s.setupCharmUnits(chUnits)
 	s.expectAddRelation([]string{"wordpress:db", "mysql:db"})
-	s.expectResolveCharm(nil, 2)
 
 	bundleData, err := charm.ReadBundleData(strings.NewReader(wordpressBundleWithStorage))
 	c.Assert(err, jc.ErrorIsNil)
@@ -1325,17 +1324,19 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusWordpressBundle() {
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"mysql": {
-				Charm:  "cs:mysql-42",
-				Scale:  1,
-				Series: "bionic",
+				Charm:        "cs:mysql-42",
+				Scale:        1,
+				Series:       "bionic",
+				CharmChannel: "stable",
 				Units: map[string]params.UnitStatus{
 					"mysql/0": {Machine: "0"},
 				},
 			},
 			"wordpress": {
-				Charm:  "cs:wordpress-47",
-				Scale:  1,
-				Series: "bionic",
+				Charm:        "cs:wordpress-47",
+				Scale:        1,
+				Series:       "bionic",
+				CharmChannel: "stable",
 				Units: map[string]params.UnitStatus{
 					"mysql/0": {Machine: "1"},
 				},
@@ -1383,7 +1384,7 @@ func (s *BundleDeployRepositorySuite) expectResolveCharmWithSeries(series []stri
 		// Ensure the same curl that is provided, is returned.
 		func(curl *charm.URL, origin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error) {
 			return curl, origin, series, err
-		}).Times(times)
+		}).AnyTimes()
 }
 
 func (s *BundleDeployRepositorySuite) expectResolveCharm(err error, times int) {

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/application"
@@ -137,6 +138,8 @@ type ApplicationAPI interface {
 
 	ScaleApplication(application.ScaleApplicationParams) (apiparams.ScaleApplicationResult, error)
 	Consume(arg crossmodel.ConsumeApplicationArgs) (string, error)
+
+	ApplicationsInfo([]names.ApplicationTag) ([]apiparams.ApplicationInfoResult, error)
 }
 
 // Bundle is a local version of the charm.Bundle interface, for test

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -153,6 +153,21 @@ func (mr *MockDeployerAPIMockRecorder) AddUnits(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUnits", reflect.TypeOf((*MockDeployerAPI)(nil).AddUnits), arg0)
 }
 
+// ApplicationsInfo mocks base method.
+func (m *MockDeployerAPI) ApplicationsInfo(arg0 []names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplicationsInfo", arg0)
+	ret0, _ := ret[0].([]params.ApplicationInfoResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplicationsInfo indicates an expected call of ApplicationsInfo.
+func (mr *MockDeployerAPIMockRecorder) ApplicationsInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationsInfo", reflect.TypeOf((*MockDeployerAPI)(nil).ApplicationsInfo), arg0)
+}
+
 // BakeryClient mocks base method.
 func (m *MockDeployerAPI) BakeryClient() base.MacaroonDischarger {
 	m.ctrl.T.Helper()

--- a/core/bundle/changes/changes.go
+++ b/core/bundle/changes/changes.go
@@ -70,6 +70,8 @@ func FromData(config ChangesConfig) ([]Change, error) {
 		model = &Model{
 			logger: config.Logger,
 		}
+	} else if model.logger == nil {
+		model.logger = config.Logger
 	}
 	model.initializeSequence()
 	model.InferMachineMap(config.Bundle)

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -271,7 +271,7 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 		// If the bundle channel is not empty and we're not using force, then
 		// raise an error asking the user to supply force.
 		if !r.force && bundleApp.Channel != "" {
-			return false, errors.Errorf("upgrades not supported when the channel for the deployed application is unknown; use --force to override")
+			return false, errors.Errorf("upgrades not supported when the channel for %q is unknown; use --force to override", existingApp.Name)
 		}
 		return true, nil
 	}

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -305,7 +305,7 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 		if bundleApp.Channel == "" {
 			verb = "resolved"
 		}
-		return false, errors.Errorf("upgrades not supported across channels (existing: %q, %s: %q); use --force to override", existingApp.Channel, verb, resolvedChan)
+		return false, errors.Errorf("application %q: upgrades not supported across channels (existing: %q, %s: %q); use --force to override", existingApp.Name, existingApp.Channel, verb, resolvedChan)
 	}
 
 	// The revision number is in the origin for a charmhub charm and in the url for a charmstore charm.

--- a/core/bundle/changes/handlers_test.go
+++ b/core/bundle/changes/handlers_test.go
@@ -102,6 +102,7 @@ func (s *resolverSuite) TestAllowUpgradeWithSameRevision(c *gc.C) {
 
 func (s *resolverSuite) TestAllowUpgradeWithDifferentChannel(c *gc.C) {
 	existing := &Application{
+		Name:    "ubuntu",
 		Charm:   "ch:ubuntu",
 		Channel: "stable",
 	}
@@ -113,12 +114,13 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannel(c *gc.C) {
 
 	r := resolver{}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, gc.ErrorMatches, `^upgrades not supported across channels \(existing: "stable", requested: "edge"\); use --force to override`)
+	c.Assert(err, gc.ErrorMatches, `^application "ubuntu": upgrades not supported across channels \(existing: "stable", requested: "edge"\); use --force to override`)
 	c.Assert(ok, jc.IsFalse)
 }
 
 func (s *resolverSuite) TestAllowUpgradeWithNoBundleChannel(c *gc.C) {
 	existing := &Application{
+		Name:    "ubuntu",
 		Charm:   "ch:ubuntu",
 		Channel: "stable",
 	}
@@ -129,7 +131,7 @@ func (s *resolverSuite) TestAllowUpgradeWithNoBundleChannel(c *gc.C) {
 
 	r := resolver{}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, gc.ErrorMatches, `^upgrades not supported across channels \(existing: "stable", resolved: ""\); use --force to override`)
+	c.Assert(err, gc.ErrorMatches, `^application "ubuntu": upgrades not supported across channels \(existing: "stable", resolved: ""\); use --force to override`)
 	c.Assert(ok, jc.IsFalse)
 }
 

--- a/core/bundle/changes/handlers_test.go
+++ b/core/bundle/changes/handlers_test.go
@@ -168,7 +168,7 @@ func (s *resolverSuite) TestAllowUpgradeWithNoExistingChannel(c *gc.C) {
 
 	r := resolver{}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, gc.ErrorMatches, `^upgrades not supported when the channel for the deployed application is unknown; use --force to override`)
+	c.Assert(err, gc.ErrorMatches, `^upgrades not supported when the channel for "" is unknown; use --force to override`)
 	c.Assert(ok, jc.IsFalse)
 }
 

--- a/core/bundle/changes/model.go
+++ b/core/bundle/changes/model.go
@@ -443,10 +443,6 @@ type inferenceEngine struct {
 }
 
 func newInference(m *Model, data *charm.BundleData) *inferenceEngine {
-	log := m.logger
-	if log == nil {
-		log = &noOpLogger{}
-	}
 	appUnits := make(map[string][]Unit)
 	// The initialMachines starts by including all the targets defined
 	// by the user for the machine map.
@@ -472,7 +468,7 @@ func newInference(m *Model, data *charm.BundleData) *inferenceEngine {
 		appUnits:        appUnits,
 		appPlacements:   make(map[string][]string),
 		initialMachines: initialMachines,
-		logger:          log,
+		logger:          m.logger,
 	}
 }
 
@@ -584,7 +580,3 @@ mainloop:
 		}
 	}
 }
-
-type noOpLogger struct{}
-
-func (*noOpLogger) Tracef(string, ...interface{}) {}

--- a/core/bundle/changes/model_test.go
+++ b/core/bundle/changes/model_test.go
@@ -322,7 +322,7 @@ func (s *inferMachineMapSuite) parseBundle(c *gc.C, bundle string) *charm.Bundle
 }
 
 func (s *inferMachineMapSuite) TestInferMachineMapEmptyModel(c *gc.C) {
-	model := &Model{}
+	model := &Model{logger: loggo.GetLogger("bundlechanges")}
 	model.InferMachineMap(s.data)
 	// MachineMap is empty and not nil.
 	c.Assert(model.MachineMap, gc.HasLen, 0)
@@ -334,6 +334,7 @@ func (s *inferMachineMapSuite) TestInferMachineMapSuppliedMapping(c *gc.C) {
 		"4": "0", "8": "2",
 	}
 	model := &Model{
+		logger:     loggo.GetLogger("bundlechanges"),
 		MachineMap: userSpecifiedMap,
 	}
 	// If the user specified a mapping for those machines, use those.


### PR DESCRIPTION

Fix 1950237 by using ApplicationsInfo to find existing channels, rather than the status output, which doesn't contain the data in pre-2.9 controllers.  This will only be done for pre 2.9 controllers, as is the case when the defaultCharmSchema is charmstore.  Nicely, ApplicationsInfo is a bulk api call.  However this necessitated requiring applications to have a channel from the bundle. To keep compatibility assume stable if channel not specified in the bundle.

Fix 1931739 by updating the error messages to include the application name causing the failure.  Helps finding the problem in the bundle, where multiple applications exist.

Now that ChangeConfig is internal to juju, ensure there is always a logger.

## QA steps

Please try various combinations of juju clients and controllers with deploying bundles and redeploying them with --dry-run to ensure no changes.  Below are reproducers for the bugs resolved.

```console
$ sudo snap refresh juju --channel 2.8/stable
# using the snap juju:
$ juju bootstrap localhost two-eight
$ juju deploy cs:~ubuntu-mirror-charm-maintainers/ubuntu-mirror
Located charm "cs:~ubuntu-mirror-charm-maintainers/ubuntu-mirror-9".
Deploying charm "cs:~ubuntu-mirror-charm-maintainers/ubuntu-mirror-9".
$ juju deploy cs:~ubuntu-mirror-charm-maintainers/ubuntu-mirror --channel candidate ubuntu-mirror-candidate
Located charm "cs:~ubuntu-mirror-charm-maintainers/ubuntu-mirror-9".
Deploying charm "cs:~ubuntu-mirror-charm-maintainers/ubuntu-mirror-9".
$ juju export-bundle > /tmp/bundle.yaml

# edit the bundle to include the candidate channel for ubuntu-mirror-candidate

# with the 2.9 client:
$ juju deploy /tmp/bundle.yaml --dry-run
No changes to apply.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1950237
https://bugs.launchpad.net/juju/+bug/1931739