### PR TITLE
[JUJU-334] Ensure we stop the op queue

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -993,6 +993,8 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 				return errors.Trace(err)
 			}
 
+			queue := queue.NewOpQueue(clock.WallClock)
+
 			estate.apiServer, err = apiserver.NewServer(apiserver.ServerConfig{
 				StatePool:           statePool,
 				Controller:          estate.controller,
@@ -1024,7 +1026,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 					return state.RestoreNotActive
 				},
 				MetricsCollector: apiserver.NewMetricsCollector(),
-				RaftOpQueue:      queue.NewOpQueue(clock.WallClock),
+				RaftOpQueue:      queue,
 			})
 			if err != nil {
 				panic(err)
@@ -1036,7 +1038,14 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			abort := make(chan struct{})
 			go stateAuthenticator.Maintain(abort)
 			go func(apiServer *apiserver.Server) {
-				defer close(abort)
+				defer func() {
+					close(abort)
+
+					// Ensure we correctly kill the raft op queue when the api
+					// server goes down.
+					queue.Kill(nil)
+					_ = queue.Wait()
+				}()
 				_ = apiServer.Wait()
 			}(estate.apiServer)
 		}


### PR DESCRIPTION
The raft op queue in the dummy provider can end up not stopping the op
queue. To fix this, we need to ensure that it goes away when the API
server is stopped.

This should prevent the leaking of goroutines.

## QA steps

Tests pass.