### PR TITLE
[JUJU-329] fix intermittent failures in provisioner tests

### DIFF
--- a/worker/provisioner/manifold_test.go
+++ b/worker/provisioner/manifold_test.go
@@ -49,6 +49,10 @@ func (s *ManifoldSuite) makeManifold() dependency.Manifold {
 	})
 }
 
+func (s *ManifoldSuite) SetUpTest(c *gc.C) {
+	s.stub.ResetCalls()
+}
+
 func (s *ManifoldSuite) TestManifold(c *gc.C) {
 	manifold := s.makeManifold()
 	c.Check(manifold.Inputs, jc.SameContents, []string{"agent", "api-caller", "environ"})

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -439,9 +439,9 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsNoDistributionGroupRetry(c *gc
 	// Use satisfaction of this call as the synchronisation point.
 	started := make(chan struct{})
 	gomock.InOrder(
-		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil),
+		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil).AnyTimes(), // may be called multiple times due to the changes in the provisioner task main logic.
 		broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(nil, failedErr),
-		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil),
+		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil).AnyTimes(), // may be called multiple times due to the changes in the provisioner task main logic.
 		broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(&environs.StartInstanceResult{
 			Instance: &testInstance{id: "instance-1"},
 		}, nil).Do(func(_ ...interface{}) {
@@ -525,9 +525,9 @@ func (s *ProvisionerTaskSuite) TestZoneConstraintsWithDistributionGroupRetry(c *
 	failedErr := errors.Errorf("oh no")
 	started := make(chan struct{})
 	gomock.InOrder(
-		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil),
+		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil).AnyTimes(), // may be called multiple times due to the changes in the provisioner task main logic.
 		broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(nil, failedErr),
-		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil),
+		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil).AnyTimes(), // may be called multiple times due to the changes in the provisioner task main logic.
 		broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(&environs.StartInstanceResult{
 			Instance: &testInstance{id: "instance-1"},
 		}, nil).Do(func(_ ...interface{}) {
@@ -569,9 +569,9 @@ func (s *ProvisionerTaskSuite) TestZoneRestrictiveConstraintsWithDistributionGro
 	failedErr := errors.Errorf("oh no")
 	started := make(chan struct{})
 	gomock.InOrder(
-		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil),
+		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil).AnyTimes(), // may be called multiple times due to the changes in the provisioner task main logic.
 		broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(nil, failedErr),
-		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil),
+		broker.EXPECT().DeriveAvailabilityZones(s.callCtx, azConstraints).Return([]string{}, nil).AnyTimes(), // may be called multiple times due to the changes in the provisioner task main logic.
 		broker.EXPECT().StartInstance(s.callCtx, azConstraints).Return(&environs.StartInstanceResult{
 			Instance: &testInstance{id: "instance-2"},
 		}, nil).Do(func(_ ...interface{}) {


### PR DESCRIPTION
This PR makes the provisioner-task test suites more robust.

## QA steps

```sh
cd worker/provisioner
go test -race -count 50
```