### PR TITLE
[JUJU-336] DQLite API scaffolding

### DIFF
--- a/apiserver/db.go
+++ b/apiserver/db.go
@@ -1,0 +1,39 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+)
+
+// dbMediator encapsulates DB related capabilities to the facades.
+type dbMediator struct {
+	db     *sql.DB
+	logger Logger
+	clock  clock.Clock
+}
+
+// Txn defines a method for running transactions, dealing with retries,
+// commit and rollback semantics.
+func (m *dbMediator) Txn(fn func(*sql.Tx) error) error {
+	// TODO (stickupkid): Implement retries.
+	tx, err := m.db.BeginTx(context.TODO(), nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := fn(tx); err != nil {
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			m.logger.Errorf("unable to rollback transaction %v", rollbackErr)
+		}
+		return errors.Trace(err)
+	}
+
+	return errors.Trace(tx.Commit())
+}

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -4,6 +4,7 @@
 package apiserver
 
 import (
+	"database/sql"
 	"sync"
 
 	"github.com/juju/clock"
@@ -46,6 +47,10 @@ func (testingAPIRootHandler) State() *state.State {
 	return nil
 }
 
+func (testingAPIRootHandler) DB() *sql.DB {
+	return nil
+}
+
 func (testingAPIRootHandler) SharedContext() *sharedServerContext {
 	return nil
 }
@@ -84,7 +89,7 @@ func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHan
 		shared:        &sharedServerContext{statePool: pool},
 		tag:           names.NewMachineTag("0"),
 	}
-	h, err := newAPIHandler(srv, st, nil, st.ModelUUID(), 6543, "testing.invalid:1234")
+	h, err := newAPIHandler(srv, st, nil, nil, st.ModelUUID(), 6543, "testing.invalid:1234")
 	c.Assert(err, jc.ErrorIsNil)
 	return h, h.Resources()
 }

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -5,6 +5,7 @@ package facade
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"net/url"
 	"time"
@@ -67,6 +68,13 @@ type RaftContext interface {
 	// It's up to the caller to retry or drop depending on how the retry
 	// algorithm is implemented.
 	ApplyLease(context.Context, []byte) error
+}
+
+// SQLDatabase represents a database for the associated model.
+type SQLDatabase interface {
+	// Txn defines a method for running transactions, dealing with retries,
+	// commit and rollback semantics.
+	Txn(func(*sql.Tx) error) error
 }
 
 // Context exposes useful capabilities to a Facade.
@@ -159,6 +167,8 @@ type Context interface {
 
 	// Raft returns a lease context for managing raft.
 	Raft() RaftContext
+
+	DB() SQLDatabase
 }
 
 // RequestRecorder is implemented by types that can record information about

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -4,6 +4,7 @@
 package charms
 
 import (
+	"database/sql"
 	"strings"
 
 	"github.com/juju/charm/v8"
@@ -31,11 +32,18 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.charms")
 
+type Database interface {
+	// Txn defines a method for running transactions, dealing with retries,
+	// commit and rollback semantics.
+	Txn(func(*sql.Tx) error) error
+}
+
 // API implements the charms interface and is the concrete
 // implementation of the API end point.
 type API struct {
 	charmInfoAPI *charmscommon.CharmInfoAPI
 	authorizer   facade.Authorizer
+	db           Database
 	backendState charmsinterfaces.BackendState
 	backendModel charmsinterfaces.BackendModel
 
@@ -135,6 +143,7 @@ func NewFacadeV4(ctx facade.Context) (*API, error) {
 	return &API{
 		charmInfoAPI: charmInfoAPI,
 		authorizer:   authorizer,
+		db:           ctx.DB(),
 		backendState: newStateShim(st),
 		backendModel: m,
 		newStorage: func(modelUUID string) services.Storage {
@@ -157,6 +166,7 @@ func NewFacadeV4(ctx facade.Context) (*API, error) {
 func NewCharmsAPI(
 	authorizer facade.Authorizer,
 	st charmsinterfaces.BackendState,
+	db Database,
 	m charmsinterfaces.BackendModel,
 	newStorage func(modelUUID string) services.Storage,
 	repoFactory corecharm.RepositoryFactory,

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -43,6 +43,7 @@ type sharedServerContext struct {
 	presence            presence.Recorder
 	leaseManager        lease.Manager
 	raftOpQueue         Queue
+	sqlDBGetter         SQLDBGetter
 	logger              loggo.Logger
 	cancel              <-chan struct{}
 
@@ -62,6 +63,7 @@ type sharedServerConfig struct {
 	leaseManager        lease.Manager
 	controllerConfig    jujucontroller.Config
 	raftOpQueue         Queue
+	sqlDBGetter         SQLDBGetter
 	logger              loggo.Logger
 }
 
@@ -90,6 +92,9 @@ func (c *sharedServerConfig) validate() error {
 	if c.raftOpQueue == nil {
 		return errors.NotValidf("nil raftOpQueue")
 	}
+	if c.sqlDBGetter == nil {
+		return errors.NotValidf("nil sqlDBGetter")
+	}
 	return nil
 }
 
@@ -107,6 +112,7 @@ func newSharedServerContext(config sharedServerConfig) (*sharedServerContext, er
 		logger:              config.logger,
 		controllerConfig:    config.controllerConfig,
 		raftOpQueue:         config.raftOpQueue,
+		sqlDBGetter:         config.sqlDBGetter,
 	}
 	ctx.features = config.controllerConfig.Features()
 	// We are able to get the current controller config before subscribing to changes


### PR DESCRIPTION
It should be now possible to pick up the database within the facade
calls. From here we should look into wiring up the new overlord package
to manage state.

We should swap out the *sql.Tx for a interface at this level, so we can
use both unit and integration tests.
