### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -493,9 +493,6 @@ func (u *Unit) ClosePorts(protocol string, fromPort, toPort int) error {
 var ErrNoCharmURLSet = errors.New("unit has no charm url set")
 
 // CharmURL returns the charm URL this unit is currently using.
-//
-// NOTE: This differs from state.Unit.CharmURL() by returning
-// an error instead of a bool, because it needs to make an API call.
 func (u *Unit) CharmURL() (*charm.URL, error) {
 	var results params.StringBoolResults
 	args := params.Entities{

--- a/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
@@ -234,11 +234,11 @@ func (mr *MockLXDProfileUnitV2MockRecorder) AssignedMachineId() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockLXDProfileUnitV2) CharmURL() (*charm.URL, bool) {
+func (m *MockLXDProfileUnitV2) CharmURL() (*charm.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
 	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -47,7 +47,7 @@ type LXDProfileMachineV2 interface {
 type LXDProfileUnitV2 interface {
 	ApplicationName() string
 	AssignedMachineId() (string, error)
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*charm.URL, error)
 	Name() string
 	Tag() names.Tag
 }
@@ -66,7 +66,7 @@ type LXDProfileAPIv2 struct {
 	accessUnit common.GetAuthFunc
 }
 
-// LXDProfileAPIv2 returns a new LXDProfileAPIv2. Currently both
+// NewLXDProfileAPIv2 returns a new LXDProfileAPIv2. Currently both
 // GetAuthFuncs can used to determine current permissions.
 func NewLXDProfileAPIv2(
 	backend LXDProfileBackendV2,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -632,12 +632,21 @@ func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, er
 			var unitOrApplication state.Entity
 			unitOrApplication, err = u.st.FindEntity(tag)
 			if err == nil {
-				charmURLer := unitOrApplication.(interface {
-					CharmURL() (*charm.URL, bool)
-				})
-				curl, ok := charmURLer.CharmURL()
-				if curl != nil {
-					result.Results[i].Result = curl.String()
+				var cURL *charm.URL
+				var ok bool
+
+				switch entity := unitOrApplication.(type) {
+				case *state.Application:
+					cURL, ok = entity.CharmURL()
+				case *state.Unit:
+					cURL, err = entity.CharmURL()
+					if cURL != nil {
+						ok = true
+					}
+				}
+
+				if cURL != nil {
+					result.Results[i].Result = cURL.String()
 					result.Results[i].Ok = ok
 				}
 			}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -875,9 +875,9 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	// Set wordpressUnit's charm URL first.
 	err := s.wordpressUnit.SetCharmURL(s.wpCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	curl, ok := s.wordpressUnit.CharmURL()
+	curl, err := s.wordpressUnit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, s.wpCharm.URL())
-	c.Assert(ok, jc.IsTrue)
 
 	// Make sure wordpress application's charm is what we expect.
 	curl, force := s.wordpress.CharmURL()
@@ -901,7 +901,7 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StringBoolResults{
 		Results: []params.StringBoolResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Result: s.wpCharm.String(), Ok: ok},
+			{Result: s.wpCharm.String(), Ok: true},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Result: s.wpCharm.String(), Ok: force},
@@ -941,10 +941,11 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 	// Verify the charm URL was set.
 	err = s.wordpressUnit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	charmURL, needsUpgrade := s.wordpressUnit.CharmURL()
+
+	charmURL, err := s.wordpressUnit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmURL, gc.NotNil)
 	c.Assert(charmURL.String(), gc.Equals, s.wpCharm.String())
-	c.Assert(needsUpgrade, jc.IsTrue)
 }
 
 func (s *uniterSuite) TestWorkloadVersion(c *gc.C) {

--- a/apiserver/facades/client/metricsdebug/metricsdebug.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug.go
@@ -196,8 +196,11 @@ func (api *MetricsDebugAPI) setEntityMeterStatus(entity names.Tag, status state.
 		if err != nil {
 			return errors.Trace(err)
 		}
-		chURL, found := unit.CharmURL()
-		if !found {
+		chURL, err := unit.CharmURL()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if chURL == nil {
 			return errors.New("no charm url")
 		}
 		if chURL.Schema != "local" {

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -265,6 +265,10 @@ func (h *bundleHandler) makeModel(
 	if err != nil {
 		return errors.Annotate(err, "cannot get model status")
 	}
+	status, err = h.updateChannelsModelStatus(status)
+	if err != nil {
+		return errors.Annotate(err, "updating current application channels")
+	}
 
 	h.model, err = appbundle.BuildModelRepresentation(status, h.deployAPI, useExistingMachines, bundleMachines)
 	if err != nil {
@@ -283,6 +287,38 @@ func (h *bundleHandler) makeModel(
 		return err
 	}
 	return nil
+}
+
+// updateChannelsModelStatus gets the application's channel from a different
+// source when the default charm schema is charmstore.  Required for compatibility
+// between pre 2.9 controllers and newer clients.  The controller has the data,
+// status output does not.
+func (h *bundleHandler) updateChannelsModelStatus(status *params.FullStatus) (*params.FullStatus, error) {
+	if !h.defaultCharmSchema.Matches(charm.CharmStore.String()) || len(status.Applications) <= 0 {
+		return status, nil
+	}
+	var tags []names.ApplicationTag
+	for k := range status.Applications {
+		tags = append(tags, names.NewApplicationTag(k))
+	}
+	infoResults, err := h.deployAPI.ApplicationsInfo(tags)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, result := range infoResults {
+		name := tags[i].Id()
+		if result.Error != nil {
+			return nil, errors.Annotatef(err, "%s", name)
+		}
+		appStatus, ok := status.Applications[name]
+		if !ok {
+			return nil, errors.NotFoundf("programming error: %q application info", name)
+		}
+		appStatus.CharmChannel = result.Result.Channel
+		status.Applications[name] = appStatus
+	}
+	return status, nil
 }
 
 // resolveCharmsAndEndpoints will go through the bundle and

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -2206,17 +2206,19 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjangoMemBundle() {
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"django": {
-				Charm:  "cs:django",
-				Scale:  1,
-				Series: "bionic",
+				Charm:        "cs:django",
+				Scale:        1,
+				Series:       "bionic",
+				CharmChannel: "stable",
 				Units: map[string]params.UnitStatus{
 					"django/0": {Machine: "1"},
 				},
 			},
 			"mem": {
-				Charm:  "cs:mem-47",
-				Scale:  1,
-				Series: "bionic",
+				Charm:        "cs:mem-47",
+				Scale:        1,
+				Series:       "bionic",
+				CharmChannel: "stable",
 				Units: map[string]params.UnitStatus{
 					"mem/0": {Machine: "0"},
 				},
@@ -2240,9 +2242,10 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjango2Units() {
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"django": {
-				Charm:  "cs:django-42",
-				Scale:  1,
-				Series: "xenial",
+				Charm:        "cs:django-42",
+				Scale:        1,
+				Series:       "xenial",
+				CharmChannel: "stable",
 				Units: map[string]params.UnitStatus{
 					"django/0": {Machine: "0"},
 					"django/1": {Machine: "1"},

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -2137,17 +2138,19 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusWordpressBundle() {
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"mysql": {
-				Charm:  "cs:mysql-42",
-				Scale:  1,
-				Series: "bionic",
+				Charm:        "cs:mysql-42",
+				Scale:        1,
+				Series:       "bionic",
+				CharmChannel: "stable",
 				Units: map[string]params.UnitStatus{
 					"mysql/0": {Machine: "0"},
 				},
 			},
 			"wordpress": {
-				Charm:  "cs:wordpress-47",
-				Scale:  1,
-				Series: "bionic",
+				Charm:        "cs:wordpress-47",
+				Scale:        1,
+				Series:       "bionic",
+				CharmChannel: "stable",
 				Units: map[string]params.UnitStatus{
 					"mysql/0": {Machine: "1"},
 				},
@@ -2604,4 +2607,182 @@ func (s *BundleHandlerResolverSuite) TestResolveLocalCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(channel, gc.DeepEquals, "stable")
 	c.Assert(rev, gc.Equals, -1)
+}
+
+type BundleHandlerMakeModelSuite struct {
+	testing.IsolationSuite
+
+	deployerAPI *mocks.MockDeployerAPI
+}
+
+var _ = gc.Suite(&BundleHandlerMakeModelSuite{})
+
+func (s *BundleHandlerMakeModelSuite) TestEmptyModel(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectEmptyModelToStart(c)
+
+	handler := &bundleHandler{
+		deployAPI:          s.deployerAPI,
+		defaultCharmSchema: charm.CharmHub,
+	}
+
+	err := handler.makeModel(false, nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BundleHandlerMakeModelSuite) TestEmptyModelOldController(c *gc.C) {
+	// An old controller is pre juju 2.9
+	defer s.setupMocks(c).Finish()
+	s.expectEmptyModelToStart(c)
+
+	handler := &bundleHandler{
+		deployAPI:          s.deployerAPI,
+		defaultCharmSchema: charm.CharmStore,
+	}
+
+	err := handler.makeModel(false, nil)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *BundleHandlerMakeModelSuite) TestModelOldController(c *gc.C) {
+	// An old controller is pre juju 2.9
+	defer s.setupMocks(c).Finish()
+	s.expectDeployerAPIStatusWordpressBundle()
+	s.expectApplicationInfo(c)
+	s.expectEmptyModelRepresentation()
+	s.expectDeployerAPIModelGet(c)
+
+	handler := &bundleHandler{
+		deployAPI:          s.deployerAPI,
+		defaultCharmSchema: charm.CharmStore,
+		unitStatus:         make(map[string]string),
+	}
+
+	err := handler.makeModel(false, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	app := handler.model.GetApplication("mysql")
+	c.Assert(app.Channel, gc.Equals, "stable")
+	app = handler.model.GetApplication("wordpress")
+	c.Assert(app.Channel, gc.Equals, "candidate")
+}
+
+func (s *BundleHandlerMakeModelSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.deployerAPI = mocks.NewMockDeployerAPI(ctrl)
+	return ctrl
+}
+
+func (s *BundleHandlerMakeModelSuite) expectEmptyModelToStart(c *gc.C) {
+	// setup for empty current model
+	// bundleHandler.makeModel()
+	s.expectDeployerAPIEmptyStatus()
+	s.expectEmptyModelRepresentation()
+	s.expectDeployerAPIModelGet(c)
+}
+
+func (s *BundleHandlerMakeModelSuite) expectEmptyModelRepresentation() {
+	// BuildModelRepresentation is tested in bundle pkg.
+	// Setup as if an empty model
+	s.deployerAPI.EXPECT().GetAnnotations(gomock.Any()).Return(nil, nil)
+	s.deployerAPI.EXPECT().GetConstraints(gomock.Any()).Return(nil, nil)
+	s.deployerAPI.EXPECT().GetConfig(gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.deployerAPI.EXPECT().Sequences().Return(nil, errors.NotSupportedf("sequences for test"))
+}
+
+func (s *BundleHandlerMakeModelSuite) expectDeployerAPIEmptyStatus() {
+	status := &params.FullStatus{}
+	s.deployerAPI.EXPECT().Status(gomock.Any()).Return(status, nil)
+}
+
+func (s *BundleHandlerMakeModelSuite) expectDeployerAPIModelGet(c *gc.C) {
+	minimal := map[string]interface{}{
+		"name":            "test",
+		"type":            "manual",
+		"uuid":            coretesting.ModelTag.Id(),
+		"controller-uuid": coretesting.ControllerTag.Id(),
+		"firewall-mode":   "instance",
+		// While the ca-cert bits aren't entirely minimal, they avoid the need
+		// to set up a fake home.
+		"ca-cert":        coretesting.CACert,
+		"ca-private-key": coretesting.CAKey,
+	}
+	cfg, err := config.New(true, minimal)
+	c.Assert(err, jc.ErrorIsNil)
+	s.deployerAPI.EXPECT().ModelGet().Return(cfg.AllAttrs(), nil)
+}
+
+func (s *BundleHandlerMakeModelSuite) expectDeployerAPIStatusWordpressBundle() {
+	status := &params.FullStatus{
+		Model: params.ModelStatusInfo{},
+		Machines: map[string]params.MachineStatus{
+			"0": {Series: "bionic"},
+			"1": {Series: "bionic"},
+		},
+		Applications: map[string]params.ApplicationStatus{
+			"mysql": {
+				Charm:  "cs:mysql-42",
+				Scale:  1,
+				Series: "bionic",
+				Units: map[string]params.UnitStatus{
+					"mysql/0": {Machine: "0"},
+				},
+			},
+			"wordpress": {
+				Charm:  "cs:wordpress-47",
+				Scale:  1,
+				Series: "bionic",
+				Units: map[string]params.UnitStatus{
+					"mysql/0": {Machine: "1"},
+				},
+			},
+		},
+		RemoteApplications: nil,
+		Offers:             nil,
+		Relations: []params.RelationStatus{
+			{
+				Endpoints: []params.EndpointStatus{
+					{ApplicationName: "wordpress", Name: "db", Role: "requirer"},
+					{ApplicationName: "mysql", Name: "db", Role: "provider"},
+				},
+			},
+		},
+		ControllerTimestamp: nil,
+		Branches:            nil,
+	}
+	s.deployerAPI.EXPECT().Status(gomock.Any()).Return(status, nil)
+}
+
+func (s *BundleHandlerMakeModelSuite) expectApplicationInfo(c *gc.C) {
+	s.deployerAPI.EXPECT().ApplicationsInfo(applicationInfoMatcher{c: c}).DoAndReturn(
+		func(args []names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+			// args content ensured by applicationInfoMatcher
+			info := make([]params.ApplicationInfoResult, 2)
+			for i, arg := range args {
+				if arg == names.NewApplicationTag("mysql") {
+					info[i] = params.ApplicationInfoResult{Result: &params.ApplicationResult{Channel: "stable"}}
+				}
+				if arg == names.NewApplicationTag("wordpress") {
+					info[i] = params.ApplicationInfoResult{Result: &params.ApplicationResult{Channel: "candidate"}}
+				}
+			}
+			return info, nil
+		})
+}
+
+type applicationInfoMatcher struct {
+	c *gc.C
+}
+
+func (m applicationInfoMatcher) Matches(x interface{}) bool {
+	obtained, ok := x.([]names.ApplicationTag)
+	m.c.Assert(ok, jc.IsTrue)
+	m.c.Assert(obtained, jc.SameContents, []names.ApplicationTag{
+		names.NewApplicationTag("mysql"),
+		names.NewApplicationTag("wordpress"),
+	})
+	return true
+}
+
+func (m applicationInfoMatcher) String() string {
+	return "Match ApplicationInfo args"
 }

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/charm/v9"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/application"
@@ -134,6 +135,8 @@ type ApplicationAPI interface {
 
 	ScaleApplication(application.ScaleApplicationParams) (apiparams.ScaleApplicationResult, error)
 	Consume(arg crossmodel.ConsumeApplicationArgs) (string, error)
+
+	ApplicationsInfo([]names.ApplicationTag) ([]apiparams.ApplicationInfoResult, error)
 }
 
 // Bundle is a local version of the charm.Bundle interface, for test

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -153,6 +153,21 @@ func (mr *MockDeployerAPIMockRecorder) AddUnits(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUnits", reflect.TypeOf((*MockDeployerAPI)(nil).AddUnits), arg0)
 }
 
+// ApplicationsInfo mocks base method.
+func (m *MockDeployerAPI) ApplicationsInfo(arg0 []names.ApplicationTag) ([]params.ApplicationInfoResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplicationsInfo", arg0)
+	ret0, _ := ret[0].([]params.ApplicationInfoResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplicationsInfo indicates an expected call of ApplicationsInfo.
+func (mr *MockDeployerAPIMockRecorder) ApplicationsInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationsInfo", reflect.TypeOf((*MockDeployerAPI)(nil).ApplicationsInfo), arg0)
+}
+
 // BakeryClient mocks base method.
 func (m *MockDeployerAPI) BakeryClient() base.MacaroonDischarger {
 	m.ctrl.T.Helper()

--- a/core/bundle/changes/changes.go
+++ b/core/bundle/changes/changes.go
@@ -70,6 +70,8 @@ func FromData(config ChangesConfig) ([]Change, error) {
 		model = &Model{
 			logger: config.Logger,
 		}
+	} else if model.logger == nil {
+		model.logger = config.Logger
 	}
 	model.initializeSequence()
 	model.InferMachineMap(config.Bundle)

--- a/core/bundle/changes/changes_test.go
+++ b/core/bundle/changes/changes_test.go
@@ -4070,7 +4070,9 @@ func (s *changesSuite) TestExistingAppsWithArchConstraints(c *gc.C) {
 		"deploy application django-two from charm-store using django",
 		`set constraints for django-one to "arch=amd64 cpu-cores=4 cpu-power=42"`,
 	}
-	s.checkBundleExistingModelWithConstraintsParser(c, bundleContent, existingModel, expectedChanges, constraintParser)
+	s.checkBundleImpl(c, bundleContent, existingModel, expectedChanges, "", constraintParser, func(string, string, string, string, int) (string, int, error) {
+		return "stable", 4, nil
+	})
 }
 
 func (s *changesSuite) TestExistingAppsWithoutArchConstraints(c *gc.C) {
@@ -4110,7 +4112,9 @@ func (s *changesSuite) TestExistingAppsWithoutArchConstraints(c *gc.C) {
 		`set constraints for django-one to "arch=amd64 cpu-cores=4 cpu-power=42"`,
 		"upload charm django from charm-store with architecture=amd64",
 	}
-	s.checkBundleExistingModelWithConstraintsParser(c, bundleContent, existingModel, expectedChanges, constraintParser)
+	s.checkBundleImpl(c, bundleContent, existingModel, expectedChanges, "", constraintParser, func(string, string, string, string, int) (string, int, error) {
+		return "stable", 4, nil
+	})
 }
 
 func (s *changesSuite) TestAppsWithSeriesAndArchConstraints(c *gc.C) {

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -64,6 +64,15 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 			}
 		}
 
+		// For compatibility with pre juju 2.9 controllers, and to facilitate
+		// matching existing charms in this method, assume a channel of stable
+		// if not specified.  Required because another change ensures that the
+		// cs applications have a channel provided an old controller.
+		channel := application.Channel
+		if channel == "" {
+			channel = "stable"
+		}
+
 		revision := -1
 		if application.Revision != nil {
 			revision = *application.Revision
@@ -71,7 +80,7 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 			// The case of upgrade charmhub charm with by channel... need the correct revision,
 			// or we will not have an addCharmChange corresponding to the upgradeCharmChange.
 			if r.charmResolver != nil {
-				_, rev, err := r.charmResolver(application.Charm, application.Series, application.Channel, arch, revision)
+				_, rev, err := r.charmResolver(application.Charm, application.Series, channel, arch, revision)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -82,8 +91,8 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 		// Add the addCharm record if one hasn't been added yet, this means
 		// if the arch and series differ from an existing charm, then we create
 		// a new charm.
-		key := applicationKey(application.Charm, arch, series, application.Channel, revision)
-		if charms[key] == "" && !existing.matchesCharmPermutation(application.Charm, arch, series, application.Channel, revision, r.constraintGetter) {
+		key := applicationKey(application.Charm, arch, series, channel, revision)
+		if charms[key] == "" && !existing.matchesCharmPermutation(application.Charm, arch, series, channel, revision, r.constraintGetter) {
 			change = newAddCharmChange(AddCharmParams{
 				Charm:        application.Charm,
 				Revision:     application.Revision,
@@ -273,7 +282,7 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 		// If the bundle channel is not empty and we're not using force, then
 		// raise an error asking the user to supply force.
 		if !r.force && bundleApp.Channel != "" {
-			return false, errors.Errorf("upgrades not supported when the channel for the deployed application is unknown; use --force to override")
+			return false, errors.Errorf("upgrades not supported when the channel for %q is unknown; use --force to override", existingApp.Name)
 		}
 		return true, nil
 	}
@@ -298,7 +307,7 @@ func (r *resolver) allowCharmUpgrade(existingApp *Application, bundleApp *charm.
 		if bundleApp.Channel == "" {
 			verb = "resolved"
 		}
-		return false, errors.Errorf("upgrades not supported across channels (existing: %q, %s: %q); use --force to override", existingApp.Channel, verb, resolvedChan)
+		return false, errors.Errorf("application %q: upgrades not supported across channels (existing: %q, %s: %q); use --force to override", existingApp.Name, existingApp.Channel, verb, resolvedChan)
 	}
 
 	// The revision number is in the origin for a charmhub charm and in the url for a charmstore charm.

--- a/core/bundle/changes/handlers_test.go
+++ b/core/bundle/changes/handlers_test.go
@@ -102,6 +102,7 @@ func (s *resolverSuite) TestAllowUpgradeWithSameRevision(c *gc.C) {
 
 func (s *resolverSuite) TestAllowUpgradeWithDifferentChannel(c *gc.C) {
 	existing := &Application{
+		Name:    "ubuntu",
 		Charm:   "ch:ubuntu",
 		Channel: "stable",
 	}
@@ -113,12 +114,13 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannel(c *gc.C) {
 
 	r := resolver{}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, gc.ErrorMatches, `^upgrades not supported across channels \(existing: "stable", requested: "edge"\); use --force to override`)
+	c.Assert(err, gc.ErrorMatches, `^application "ubuntu": upgrades not supported across channels \(existing: "stable", requested: "edge"\); use --force to override`)
 	c.Assert(ok, jc.IsFalse)
 }
 
 func (s *resolverSuite) TestAllowUpgradeWithNoBundleChannel(c *gc.C) {
 	existing := &Application{
+		Name:    "ubuntu",
 		Charm:   "ch:ubuntu",
 		Channel: "stable",
 	}
@@ -129,7 +131,7 @@ func (s *resolverSuite) TestAllowUpgradeWithNoBundleChannel(c *gc.C) {
 
 	r := resolver{}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, gc.ErrorMatches, `^upgrades not supported across channels \(existing: "stable", resolved: ""\); use --force to override`)
+	c.Assert(err, gc.ErrorMatches, `^application "ubuntu": upgrades not supported across channels \(existing: "stable", resolved: ""\); use --force to override`)
 	c.Assert(ok, jc.IsFalse)
 }
 
@@ -168,7 +170,7 @@ func (s *resolverSuite) TestAllowUpgradeWithNoExistingChannel(c *gc.C) {
 
 	r := resolver{}
 	ok, err := r.allowCharmUpgrade(existing, requested, requestedArch)
-	c.Assert(err, gc.ErrorMatches, `^upgrades not supported when the channel for the deployed application is unknown; use --force to override`)
+	c.Assert(err, gc.ErrorMatches, `^upgrades not supported when the channel for "" is unknown; use --force to override`)
 	c.Assert(ok, jc.IsFalse)
 }
 

--- a/core/bundle/changes/model.go
+++ b/core/bundle/changes/model.go
@@ -443,10 +443,6 @@ type inferenceEngine struct {
 }
 
 func newInference(m *Model, data *charm.BundleData) *inferenceEngine {
-	log := m.logger
-	if log == nil {
-		log = &noOpLogger{}
-	}
 	appUnits := make(map[string][]Unit)
 	// The initialMachines starts by including all the targets defined
 	// by the user for the machine map.
@@ -472,7 +468,7 @@ func newInference(m *Model, data *charm.BundleData) *inferenceEngine {
 		appUnits:        appUnits,
 		appPlacements:   make(map[string][]string),
 		initialMachines: initialMachines,
-		logger:          log,
+		logger:          m.logger,
 	}
 }
 
@@ -584,7 +580,3 @@ mainloop:
 		}
 	}
 }
-
-type noOpLogger struct{}
-
-func (*noOpLogger) Tracef(string, ...interface{}) {}

--- a/core/bundle/changes/model_test.go
+++ b/core/bundle/changes/model_test.go
@@ -322,7 +322,7 @@ func (s *inferMachineMapSuite) parseBundle(c *gc.C, bundle string) *charm.Bundle
 }
 
 func (s *inferMachineMapSuite) TestInferMachineMapEmptyModel(c *gc.C) {
-	model := &Model{}
+	model := &Model{logger: loggo.GetLogger("bundlechanges")}
 	model.InferMachineMap(s.data)
 	// MachineMap is empty and not nil.
 	c.Assert(model.MachineMap, gc.HasLen, 0)
@@ -334,6 +334,7 @@ func (s *inferMachineMapSuite) TestInferMachineMapSuppliedMapping(c *gc.C) {
 		"4": "0", "8": "2",
 	}
 	model := &Model{
+		logger:     loggo.GetLogger("bundlechanges"),
 		MachineMap: userSpecifiedMap,
 	}
 	// If the user specified a mapping for those machines, use those.

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -165,9 +165,9 @@ func UnitChange(c *gc.C, modelUUID string, unit *state.Unit) cache.UnitChange {
 	}
 
 	var charmURL string
-	if cURL, ok := unit.CharmURL(); ok {
-		charmURL = cURL.String()
-	}
+	cURL, err := unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	charmURL = cURL.String()
 
 	pr, err := unit.OpenedPortRanges()
 	if !errors.IsNotAssigned(err) {

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -83,7 +83,7 @@ type PrecheckUnit interface {
 	Name() string
 	AgentTools() (*tools.Tools, error)
 	Life() state.Life
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*charm.URL, error)
 	AgentStatus() (status.StatusInfo, error)
 	Status() (status.StatusInfo, error)
 	ShouldBeAssigned() bool

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -798,7 +798,7 @@ func (b *fakeBackend) IsMigrationActive(string) (bool, error) {
 	return b.migrationActive, b.migrationActiveErr
 }
 
-func (b *fakeBackend) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
+func (b *fakeBackend) CloudCredential(_ names.CloudCredentialTag) (state.Credential, error) {
 	return b.credentials, b.credentialsErr
 }
 
@@ -814,7 +814,7 @@ func (b *fakeBackend) AllRelations() ([]migration.PrecheckRelation, error) {
 	return b.relations, b.allRelsErr
 }
 
-func (b *fakeBackend) ListPendingResources(app string) ([]resource.Resource, error) {
+func (b *fakeBackend) ListPendingResources(_ string) ([]resource.Resource, error) {
 	return b.pendingResources, b.pendingResourcesErr
 }
 
@@ -1009,12 +1009,12 @@ func (u *fakeUnit) ShouldBeAssigned() bool {
 	return true
 }
 
-func (u *fakeUnit) CharmURL() (*charm.URL, bool) {
+func (u *fakeUnit) CharmURL() (*charm.URL, error) {
 	url := u.charmURL
 	if url == "" {
 		url = "cs:foo-1"
 	}
-	return charm.MustParseURL(url), false
+	return charm.MustParseURL(url), nil
 }
 
 func (u *fakeUnit) AgentStatus() (status.StatusInfo, error) {

--- a/resource/resourceadapters/mocks/opener_mock.go
+++ b/resource/resourceadapters/mocks/opener_mock.go
@@ -278,11 +278,11 @@ func (mr *MockUnitMockRecorder) ApplicationName() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockUnit) CharmURL() (*charm.URL, bool) {
+func (m *MockUnit) CharmURL() (*charm.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
 	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 

--- a/resource/resourceadapters/opener_test.go
+++ b/resource/resourceadapters/opener_test.go
@@ -103,7 +103,7 @@ func (s *OpenerSuite) setupMocks(c *gc.C, includeUnit bool) *gomock.Controller {
 	if s.unit != nil {
 		s.unit.EXPECT().ApplicationName().Return("postgresql").AnyTimes()
 		s.unit.EXPECT().Application().Return(s.app, nil).AnyTimes()
-		s.unit.EXPECT().CharmURL().Return(curl, false).AnyTimes()
+		s.unit.EXPECT().CharmURL().Return(curl, nil).AnyTimes()
 	} else {
 		s.app.EXPECT().CharmURL().Return(curl, false).AnyTimes()
 	}

--- a/resource/unit.go
+++ b/resource/unit.go
@@ -18,5 +18,5 @@ type Unit interface {
 	ApplicationName() string
 
 	// CharmURL returns the unit's charm URL.
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*charm.URL, error)
 }

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -627,8 +627,9 @@ func (checker *ModelChecker) readApplicationsAndUnits() {
 		units, err := app.AllUnits()
 		checkErr(err, "AllUnits")
 		for _, unit := range units {
-			unitCharmURL, found := unit.CharmURL()
-			if !found {
+			unitCharmURL, err := unit.CharmURL()
+			checkErr(err, "unit CharmURL")
+			if unitCharmURL == nil {
 				continue
 			}
 			unitString := unitCharmURL.String()

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -524,7 +524,7 @@ func (u *backingUnit) updated(ctx *allWatcherContext) error {
 		Subordinate: u.Principal != "",
 	}
 	if u.CharmURL != nil {
-		info.CharmURL = u.CharmURL.String()
+		info.CharmURL = *u.CharmURL
 	}
 
 	// Construct a unit for the purpose of retrieving other fields as necessary.

--- a/state/application.go
+++ b/state/application.go
@@ -2650,11 +2650,17 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	if u.doc.CharmURL != nil {
 		// If the unit has a different URL to the application, allow any final
 		// cleanup to happen; otherwise we just do it when the app itself is removed.
-		maybeDoFinal := u.doc.CharmURL != a.doc.CharmURL
+		maybeDoFinal := *u.doc.CharmURL != a.doc.CharmURL.String()
+
+		cURL, err := u.CharmURL()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
 		// When 'force' is set, this call will return both needed operations
 		// as well as all operational errors encountered.
 		// If the 'force' is not set, any error will be fatal and no operations will be returned.
-		decOps, err := appCharmDecRefOps(a.st, a.doc.Name, u.doc.CharmURL, maybeDoFinal, op)
+		decOps, err := appCharmDecRefOps(a.st, a.doc.Name, cURL, maybeDoFinal, op)
 		if errors.IsNotFound(err) {
 			return nil, errRefresh
 		} else if op.FatalError(err) {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -2002,8 +2002,8 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	// used by app as well, hence 2.
 	err = u.SetCharmURL(oldCh.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	curl, ok := u.CharmURL()
-	c.Assert(ok, jc.IsTrue)
+	curl, err := u.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, oldCh.URL())
 	assertSettingsRef(c, s.State, appName, oldCh, 2)
 	assertNoSettingsRef(c, s.State, appName, newCh)

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -551,9 +551,9 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 	}}
 	for i, t := range tests {
 		c.Logf("test %d: %s", i, t.about)
-		chURL, ok := t.unit.CharmURL()
-		c.Assert(ok, jc.IsTrue)
-		_, err := s.State.AddMetrics(
+		chURL, err := t.unit.CharmURL()
+		c.Assert(err, jc.ErrorIsNil)
+		_, err = s.State.AddMetrics(
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  now,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1553,10 +1553,7 @@ func (i *importer) makeUnitDoc(s description.Application, u description.Unit) (*
 	// the charm url for each unit rather than grabbing the applications charm url.
 	// Currently the units charm url matching the application is a precondiation
 	// to migration.
-	charmURL, err := charm.ParseURL(s.CharmURL())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	charmURL := s.CharmURL()
 
 	var subordinates []string
 	if subs := u.Subordinates(); len(subs) > 0 {
@@ -1581,7 +1578,7 @@ func (i *importer) makeUnitDoc(s description.Application, u description.Unit) (*
 		Name:                   u.Name(),
 		Application:            s.Name(),
 		Series:                 s.Series(),
-		CharmURL:               charmURL,
+		CharmURL:               &charmURL,
 		Principal:              u.Principal().Id(),
 		Subordinates:           subordinates,
 		StorageAttachmentCount: i.unitStorageAttachmentCount(u.Tag()),

--- a/state/state.go
+++ b/state/state.go
@@ -1559,7 +1559,7 @@ func (st *State) AssignStagedUnits(ids []string) ([]UnitAssignmentResult, error)
 	return results, nil
 }
 
-// UnitAssignments returns all staged unit assignments in the model.
+// AllUnitAssignments returns all staged unit assignments in the model.
 func (st *State) AllUnitAssignments() ([]UnitAssignment, error) {
 	return st.unitAssignments(nil)
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -77,7 +77,7 @@ type unitDoc struct {
 	ModelUUID              string `bson:"model-uuid"`
 	Application            string
 	Series                 string
-	CharmURL               *charm.URL
+	CharmURL               *string
 	Principal              string
 	Subordinates           []string
 	StorageAttachmentCount int `bson:"storageattachmentcount"`
@@ -146,8 +146,15 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 		return nil, fmt.Errorf("unit's charm URL must be set before retrieving config")
 	}
 
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// TODO (manadart 2019-02-21) Factor the current generation into this call.
-	s, err := charmSettingsWithDefaults(u.st, u.doc.CharmURL, u.doc.Application, model.GenerationMaster)
+	// TODO (manadart 2021-12-03) Most places where we are passing a charm URL
+	// could just use its string form.
+	s, err := charmSettingsWithDefaults(u.st, cURL, u.doc.Application, model.GenerationMaster)
 	if err != nil {
 		return nil, errors.Annotatef(err, "charm config for unit %q", u.Name())
 	}
@@ -337,7 +344,7 @@ type UpdateUnitOperation struct {
 }
 
 // Build is part of the ModelOperation interface.
-func (op *UpdateUnitOperation) Build(attempt int) ([]txn.Op, error) {
+func (op *UpdateUnitOperation) Build(_ int) ([]txn.Op, error) {
 	op.setStatusDocs = make(map[string]statusDoc)
 
 	containerInfo, err := op.unit.cloudContainer()
@@ -1434,11 +1441,13 @@ func (u *Unit) OpenedPortRanges() (UnitPortRanges, error) {
 }
 
 // CharmURL returns the charm URL this unit is currently using.
-func (u *Unit) CharmURL() (*charm.URL, bool) {
+func (u *Unit) CharmURL() (*charm.URL, error) {
 	if u.doc.CharmURL == nil {
-		return nil, false
+		return nil, nil
 	}
-	return u.doc.CharmURL, true
+
+	cURL, err := charm.ParseURL(*u.doc.CharmURL)
+	return cURL, errors.Trace(err)
 }
 
 // SetCharmURL marks the unit as currently using the supplied charm URL.
@@ -1496,17 +1505,22 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 				Assert: append(notDeadDoc, differentCharm...),
 				Update: bson.D{{"$set", bson.D{{"charmurl", curl}}}},
 			})
-		if u.doc.CharmURL != nil {
+
+		cURL, err := u.CharmURL()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if cURL != nil {
 			// Drop the reference to the old charm.
 			// Since we can force this now, let's.. There is no point hanging on to the old charm.
 			op := &ForcedOperation{Force: true}
-			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, u.doc.CharmURL, true, op)
+			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, cURL, true, op)
 			if err != nil {
 				// No need to stop further processing if the old key could not be removed.
-				logger.Errorf("could not remove old charm references for %v:%v", u.doc.CharmURL, err)
+				logger.Errorf("could not remove old charm references for %s: %v", cURL, err)
 			}
 			if len(op.Errors) != 0 {
-				logger.Errorf("could not remove old charm references for %v:%v", u.doc.CharmURL, op.Errors)
+				logger.Errorf("could not remove old charm references for %s: %v", cURL, op.Errors)
 			}
 			ops = append(ops, decOps...)
 		}
@@ -1514,7 +1528,8 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 	}
 	err := u.st.db().Run(buildTxn)
 	if err == nil {
-		u.doc.CharmURL = curl
+		curlStr := curl.String()
+		u.doc.CharmURL = &curlStr
 	}
 	return err
 }
@@ -1522,15 +1537,20 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 // charm returns the charm for the unit, or the application if the unit's charm
 // has not been set yet.
 func (u *Unit) charm() (*Charm, error) {
-	curl, ok := u.CharmURL()
-	if !ok {
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if cURL == nil {
 		app, err := u.Application()
 		if err != nil {
 			return nil, err
 		}
-		curl = app.doc.CharmURL
+		cURL = app.doc.CharmURL
 	}
-	ch, err := u.st.Charm(curl)
+
+	ch, err := u.st.Charm(cURL)
 	return ch, errors.Annotatef(err, "getting charm for %s", u)
 }
 
@@ -1543,7 +1563,7 @@ func (u *Unit) assertCharmOps(ch *Charm) []txn.Op {
 		Id:     u.doc.Name,
 		Assert: bson.D{{"charmurl", u.doc.CharmURL}},
 	}}
-	if _, ok := u.CharmURL(); !ok {
+	if u.doc.CharmURL != nil {
 		appName := u.ApplicationName()
 		ops = append(ops, txn.Op{
 			C:      applicationsC,
@@ -2873,7 +2893,13 @@ func (u *Unit) StorageConstraints() (map[string]StorageConstraints, error) {
 		}
 		return app.StorageConstraints()
 	}
-	key := applicationStorageConstraintsKey(u.doc.Application, u.doc.CharmURL)
+
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	key := applicationStorageConstraintsKey(u.doc.Application, cURL)
 	cons, err := readStorageConstraints(u.st, key)
 	if errors.IsNotFound(err) {
 		return nil, nil
@@ -2923,9 +2949,14 @@ func addUnitOps(st *State, args addUnitOpsArgs) ([]txn.Op, error) {
 	// relax the restrictions on migrating apps mid-upgrade, this
 	// will need to be more sophisticated, because it might need to
 	// create the settings doc.
-	if curl := args.unitDoc.CharmURL; curl != nil {
+	if charmURL := args.unitDoc.CharmURL; charmURL != nil {
+		cURL, err := charm.ParseURL(*charmURL)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
 		appName := args.unitDoc.Application
-		charmRefOps, err := appCharmIncRefOps(st, appName, curl, false)
+		charmRefOps, err := appCharmIncRefOps(st, appName, cURL, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1269,8 +1269,8 @@ func (s *UnitSuite) TestSetCharmURLSuccess(c *gc.C) {
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, ok = s.unit.CharmURL()
-	c.Assert(ok, jc.IsTrue)
+	curl, err = s.unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, s.charm.URL())
 }
 
@@ -1310,8 +1310,8 @@ func (s *UnitSuite) TestSetCharmURLWithDyingUnit(c *gc.C) {
 	err = s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, ok := s.unit.CharmURL()
-	c.Assert(ok, jc.IsTrue)
+	curl, err := s.unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, s.charm.URL())
 }
 
@@ -1359,9 +1359,9 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 				// Verify it worked after the second attempt.
 				err := s.unit.Refresh()
 				c.Assert(err, jc.ErrorIsNil)
-				currentURL, hasURL := s.unit.CharmURL()
+				currentURL, err := s.unit.CharmURL()
+				c.Assert(err, jc.ErrorIsNil)
 				c.Assert(currentURL, jc.DeepEquals, s.charm.URL())
-				c.Assert(hasURL, jc.IsTrue)
 			},
 		},
 	).Check()
@@ -2649,7 +2649,8 @@ func (s *UnitSuite) TestWorkloadVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(version, gc.Equals, "")
 
-	unit.SetWorkloadVersion("3.combined")
+	err = unit.SetWorkloadVersion("3.combined")
+	c.Assert(err, jc.ErrorIsNil)
 	version, err = unit.WorkloadVersion()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(version, gc.Equals, "3.combined")

--- a/state/upgrade/types.go
+++ b/state/upgrade/types.go
@@ -78,7 +78,7 @@ type OldPortsDoc28 struct {
 	TxnRevno  int64               `bson:"txn-revno"`
 }
 
-// OldPortsDoc28 represents a port range entry document prior to the 2.9 schema changes.
+// OldPortRangeDoc28 represents a port range entry document prior to the 2.9 schema changes.
 type OldPortRangeDoc28 struct {
 	UnitName string `bson:"unitname"`
 	FromPort int    `bson:"fromport"`

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -41,6 +41,7 @@ import (
 	"github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/state/upgrade"
 	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/tools"
 )
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
@@ -1328,7 +1329,7 @@ func collectRelationInfo(coll *mgo.Collection) (map[string]*relationUnitCountInf
 	return relations, nil
 }
 
-// unitAppName returns the name of the Application, given a Units name.
+// unitAppName returns the name of the Application, given a Unit's name.
 func unitAppName(unitName string) string {
 	unitParts := strings.Split(unitName, "/")
 	return unitParts[0]
@@ -2915,13 +2916,34 @@ func AddMachineIDToSubordinates(pool *StatePool) error {
 	coll, closer := st.db().GetRawCollection(unitsC)
 	defer closer()
 
-	// Load all the units into a map by full ID.
-	units := make(map[string]*unitDoc)
+	// unitDoc28 represents the unit document as at Juju version 2.8,
+	// to which this upgrade step applies.
+	// Later, in version 2.9.23, CharmURL was stored as *string
+	// instead of *charm.URL.
+	type unitDoc28 struct {
+		DocID                  string `bson:"_id"`
+		Name                   string `bson:"name"`
+		ModelUUID              string `bson:"model-uuid"`
+		Application            string
+		Series                 string
+		CharmURL               *charm.URL
+		Principal              string
+		Subordinates           []string
+		StorageAttachmentCount int `bson:"storageattachmentcount"`
+		MachineId              string
+		Resolved               ResolvedMode
+		Tools                  *tools.Tools `bson:",omitempty"`
+		Life                   Life
+		PasswordHash           string
+	}
 
-	var doc unitDoc
+	// Load all the units into a map by full ID.
+	units := make(map[string]*unitDoc28)
+
+	var doc unitDoc28
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
-		// Make a copy of the unitDoc and put the copy
+		// Make a copy of the doc and put the copy
 		// into the map.
 		unit := doc
 		units[unit.DocID] = &unit

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2037,7 +2037,13 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
+
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, cURL)
 	return newEntityWatcher(u.st, settingsC, u.st.docID(charmConfigKey)), nil
 }
 
@@ -2056,7 +2062,13 @@ func (u *Unit) WatchConfigSettingsHash() (StringsWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
+
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, cURL)
 	return newSettingsHashWatcher(u.st, charmConfigKey), nil
 }
 

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -679,8 +679,8 @@ func (factory *Factory) MakeMetric(c *gc.C, params *MetricParams) *state.MetricB
 		}}
 	}
 
-	chURL, ok := params.Unit.CharmURL()
-	c.Assert(ok, gc.Equals, true)
+	chURL, err := params.Unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 
 	metric, err := factory.st.AddMetrics(
 		state.BatchParam{

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -794,13 +794,16 @@ func (s waitUnitAgent) step(c *gc.C, ctx *testContext) {
 				c.Logf("want resolved mode %q, got %q; still waiting", s.resolved, resolved)
 				continue
 			}
-			url, ok := ctx.unit.CharmURL()
-			if !ok || *url != *curl(s.charm) {
-				var got string
-				if ok {
-					got = url.String()
-				}
-				c.Logf("want unit charm %q, got %q; still waiting", curl(s.charm), got)
+			url, err := ctx.unit.CharmURL()
+			if err != nil {
+				c.Fatalf("cannot refresh unit: %v", err)
+			}
+			if url == nil {
+				c.Logf("want unit charm %q, got nil; still waiting", curl(s.charm))
+				continue
+			}
+			if *url != *curl(s.charm) {
+				c.Logf("want unit charm %q, got %q; still waiting", curl(s.charm), url.String())
 				continue
 			}
 			statusInfo, err := s.statusGetter(ctx)()
@@ -1025,8 +1028,9 @@ func (s verifyCharm) step(c *gc.C, ctx *testContext) {
 	}
 	err = ctx.unit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	url, ok := ctx.unit.CharmURL()
-	c.Assert(ok, jc.IsTrue)
+
+	url, err := ctx.unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.DeepEquals, curl(checkRevision))
 }
 


### PR DESCRIPTION
Merge from 2.9 bringing forward:
- #13546 from manadart/2.9-unit-charm-url
- #13564 from jujubot/increment-to-2.9.23
- #13556 from hmlanigan/deploy-bundle-2-8-controller

Minor conflicts including those typical to version bumps:
- apiserver/facades/agent/uniter/mocks/newlxdprofile.go
- cmd/juju/application/deployer/bundlehandler_test.go
- scripts/win-installer/setup.iss
- snap/snapcraft.yaml
- version/version.go