### PR TITLE
We were not recording when a log read successfully completed.

### DIFF
--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -29,6 +29,7 @@ const (
 )
 
 const (
+	metricLogReadLabelSuccess    = "success"
 	metricLogReadLabelError      = "error"
 	metricLogReadLabelDisconnect = "disconnect"
 )
@@ -332,6 +333,7 @@ func (h *logSinkHandler) receiveLogs(socket *websocket.Conn,
 				_ = socket.WriteMessage(gorillaws.CloseMessage, []byte{})
 				return
 			}
+			h.metrics.LogReadCount(resolvedModelUUID, metricLogReadLabelSuccess).Inc()
 
 			// Rate-limit receipt of log messages. We rate-limit
 			// each connection individually to prevent one noisy


### PR DESCRIPTION
## Please provide the following details to expedite review (and delete this heading)

While digging through some information, I noted that the metrics around reading logs only contained errors. Digging into the code, I can see that we very much only update the metric on failures. The descriptions around the metrics appear to say that we would record success as well as failure. The metric is multiplied by the number of models and the types of read (success,failure), but otherwise bounded. (Also, we are already tracking this for 'log_write_count' we just weren't tracking it on the read side.)

If it was intentional to not track reads, we should update the docstrings to indicate that we only track errors.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Bootstrap a juju controller, deploy an application, and then look at:

```sh
$ juju ssh -m controller 0
$$ juju_metrics
```

There should be metrics like:
```
juju_apiserver_log_read_count{model_uuid="ffaf8edc-1e06-490e-8991-1700fd83af10",state="success"} 3
```

## Documentation changes

None

## Bug reference

None
