### PR TITLE
[JUJU-256] MVP verify app health after controller/model upgrade

### DIFF
--- a/.github/verify-apache2.sh
+++ b/.github/verify-apache2.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+set -euxo pipefail
+
+ip=$(juju status --format json | jq -r '.applications.apache2.units[]."public-address"')
+
+curl --silent --output /dev/null --max-time 3 "$ip"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -75,7 +75,7 @@ jobs:
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
         echo "/snap/bin" >> $GITHUB_PATH
 
-    - name: Bootstrap Juju latest/stable
+    - name: Bootstrap Juju
       if: env.RUN_TEST == 'RUN'
       shell: bash
       run: |
@@ -90,6 +90,26 @@ jobs:
       if: env.RUN_TEST == 'RUN'
       uses: actions/checkout@v2
 
+    - name: Deploy some applications
+      if: env.RUN_TEST == 'RUN'
+      shell: bash
+      run: |
+        set -euxo pipefail
+
+        juju deploy apache2 --series focal
+
+        juju wait-for application apache2
+
+        attempts=0
+        while ! ./.github/verify-apache2.sh; do
+          sleep 10
+          attempts=$((attempts+1))
+          if [ "$attempts" -eq 5 ]; then
+            echo "Apache health check timed out"
+            exit 0
+          fi
+        done
+
     - name: Build snap
       if: env.RUN_TEST == 'RUN'
       shell: bash
@@ -102,7 +122,7 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
-        sudo snap install *.snap --dangerous --classic
+        sudo snap install juju*.snap --dangerous --classic
 
     - name: Preflight
       if: env.RUN_TEST == 'RUN'
@@ -141,6 +161,8 @@ jobs:
             juju debug-log --replay --no-tail -m controller
             exit 1
         fi
+
+        ./.github/verify-apache2.sh
 
     - name: Test upgrade model
       if: env.RUN_TEST == 'RUN'
@@ -192,3 +214,5 @@ jobs:
             juju debug-log --replay --no-tail
             exit 1
         fi
+
+        ./.github/verify-apache2.sh


### PR DESCRIPTION
Sometimes after a new release users can have issues with deployed
applications during an upgrade. Add some CI to verify that
existing applications remain healthy after a controller and model
upgrade

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Execute smoke.yml GitHub Action

## Documentation changes

No doc change required

## Bug reference

No bug reference
