### PR TITLE
[JUJU-357] Reorder commands run in run_model_metrics.

### DIFF
--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -12,11 +12,12 @@ run_model_metrics() {
 	juju deploy juju-qa-test
 	juju deploy ntp
 	juju relate ntp focal
-	juju relate ntp:juju-info juju-qa-test:juju-info
 
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 1)"
 	wait_for "focal" "$(idle_condition "focal" 0)"
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "focal" 0)"
+
+	juju relate ntp:juju-info juju-qa-test:juju-info
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test" 1)"
 
 	juju model-config -m controller logging-config="'<root>=INFO;#charmhub=TRACE'"


### PR DESCRIPTION
Improve reliability of model metrics integration test by ensuring which subordinate units go with which principals.

## QA steps

```sh
 (cd tests ; ./main.sh -v model test_model_metrics)
```