### PR TITLE
[JUJU-132] Deploy the controller charm when bootstrapping on k8s

### DIFF
--- a/caas/application.go
+++ b/caas/application.go
@@ -5,6 +5,7 @@ package caas
 
 import (
 	"github.com/juju/version/v2"
+	core "k8s.io/api/core/v1"
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
@@ -22,6 +23,9 @@ type Application interface {
 	Delete() error
 	Watch() (watcher.NotifyWatcher, error)
 	WatchReplicas() (watcher.NotifyWatcher, error)
+
+	// ApplicationPodSpec returns the pod spec needed to run the application workload.
+	ApplicationPodSpec(config ApplicationConfig) (*core.PodSpec, error)
 
 	// Scale scales the Application's unit to the value specified. Scale must
 	// be >= 0. Application units will be removed or added to meet the scale

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -412,7 +412,7 @@ func (s *applicationSuite) assertDelete(c *gc.C, app caas.Application) {
 	c.Assert(statefulSets.Items, gc.IsNil)
 }
 
-func getPodSpec(c *gc.C) corev1.PodSpec {
+func getPodSpec() corev1.PodSpec {
 	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 	return corev1.PodSpec{
 		ServiceAccountName:           "gitlab",
@@ -695,7 +695,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
 							Annotations: map[string]string{"juju.is/version": "1.1.1"},
 						},
-						Spec: getPodSpec(c),
+						Spec: getPodSpec(),
 					},
 					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 						{
@@ -748,7 +748,7 @@ func (s *applicationSuite) TestEnsureUntrusted(c *gc.C) {
 func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 
-	podSpec := getPodSpec(c)
+	podSpec := getPodSpec()
 	podSpec.ImagePullSecrets = append(
 		[]corev1.LocalObjectReference{
 			{Name: constants.CAASImageRepoSecretName},
@@ -874,7 +874,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 				},
 			})
 
-			podSpec := getPodSpec(c)
+			podSpec := getPodSpec()
 			podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 				Name: "gitlab-database-appuuid",
 				VolumeSource: corev1.VolumeSource{
@@ -947,7 +947,7 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 				},
 			})
 
-			podSpec := getPodSpec(c)
+			podSpec := getPodSpec()
 			podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 				Name: "gitlab-database-appuuid",
 				VolumeSource: corev1.VolumeSource{
@@ -1905,7 +1905,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 
 	for i := 0; i < 4; i++ {
-		podSpec := getPodSpec(c)
+		podSpec := getPodSpec()
 		podSpec.Volumes = append(podSpec.Volumes,
 			corev1.Volume{
 				Name: "gitlab-database-appuuid",
@@ -2228,7 +2228,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 				},
 			})
 
-			ps := getPodSpec(c)
+			ps := getPodSpec()
 			ps.NodeSelector = map[string]string{
 				"kubernetes.io/arch": "arm64",
 			}

--- a/caas/kubernetes/provider/application/constraints.go
+++ b/caas/kubernetes/provider/application/constraints.go
@@ -1,0 +1,289 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/v2/arch"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/core/constraints"
+)
+
+// ApplyConstraints applies the specified constraints to the pod.
+func ApplyConstraints(pod *core.PodSpec, appName string, cons constraints.Value) error {
+	// TODO(allow resource limits to be applied to each container).
+	// For now we only do resource requests, one container is sufficient for
+	// scheduling purposes.
+	if mem := cons.Mem; mem != nil {
+		if err := configureConstraint(pod, "memory", fmt.Sprintf("%dMi", *mem)); err != nil {
+			return errors.Annotatef(err, "configuring memory constraint for %s", appName)
+		}
+	}
+	if cpu := cons.CpuPower; cpu != nil {
+		if err := configureConstraint(pod, "cpu", fmt.Sprintf("%dm", *cpu)); err != nil {
+			return errors.Annotatef(err, "configuring cpu constraint for %s", appName)
+		}
+	}
+	nodeSelector := map[string]string(nil)
+	if cons.HasArch() {
+		cpuArch := *cons.Arch
+		cpuArch = arch.NormaliseArch(cpuArch)
+		// Convert to Golang arch string
+		switch cpuArch {
+		case arch.AMD64:
+			cpuArch = "amd64"
+		case arch.ARM64:
+			cpuArch = "arm64"
+		case arch.PPC64EL:
+			cpuArch = "ppc64le"
+		case arch.S390X:
+			cpuArch = "s390x"
+		default:
+			return errors.NotSupportedf("architecture %q", cpuArch)
+		}
+		nodeSelector = map[string]string{"kubernetes.io/arch": cpuArch}
+	}
+	if pod.NodeSelector != nil {
+		for k, v := range nodeSelector {
+			pod.NodeSelector[k] = v
+		}
+	} else if nodeSelector != nil {
+		pod.NodeSelector = nodeSelector
+	}
+
+	// Translate tags to pod or node affinity.
+	// Tag names are prefixed with "pod.", "anti-pod.", or "node."
+	// with the default being "node".
+	// The tag 'topology-key', if set, is used for the affinity topology key value.
+	if cons.Tags != nil {
+		affinityLabels := make(map[string]string)
+		for _, labelPair := range *cons.Tags {
+			parts := strings.Split(labelPair, "=")
+			if len(parts) != 2 {
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
+			}
+			key := strings.Trim(parts[0], " ")
+			value := strings.Trim(parts[1], " ")
+			affinityLabels[key] = value
+		}
+
+		if err := processNodeAffinity(pod, affinityLabels); err != nil {
+			return errors.Annotatef(err, "configuring node affinity for %s", appName)
+		}
+		if err := processPodAffinity(pod, affinityLabels); err != nil {
+			return errors.Annotatef(err, "configuring pod affinity for %s", appName)
+		}
+	}
+	if cons.Zones != nil {
+		zones := *cons.Zones
+		affinity := pod.Affinity
+		if affinity == nil {
+			affinity = &core.Affinity{
+				NodeAffinity: &core.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+						NodeSelectorTerms: []core.NodeSelectorTerm{{}},
+					},
+				},
+			}
+			pod.Affinity = affinity
+		}
+		selector := &affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+		selector.MatchExpressions = append(selector.MatchExpressions,
+			core.NodeSelectorRequirement{
+				Key:      "failure-domain.beta.kubernetes.io/zone",
+				Operator: core.NodeSelectorOpIn,
+				Values:   zones,
+			})
+	}
+	return nil
+}
+
+const (
+	podPrefix      = "pod."
+	antiPodPrefix  = "anti-pod."
+	topologyKeyTag = "topology-key"
+	nodePrefix     = "node."
+)
+
+func processNodeAffinity(pod *core.PodSpec, affinityLabels map[string]string) error {
+	affinityTags := make(map[string]string)
+	for key, value := range affinityLabels {
+		keyVal := key
+		if strings.HasPrefix(key, "^") {
+			if len(key) == 1 {
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
+			}
+			key = key[1:]
+		}
+		if strings.HasPrefix(key, podPrefix) || strings.HasPrefix(key, antiPodPrefix) {
+			continue
+		}
+		key = strings.TrimPrefix(keyVal, nodePrefix)
+		affinityTags[key] = value
+	}
+
+	updateSelectorTerms := func(nodeSelectorTerm *core.NodeSelectorTerm, tags map[string]string) {
+		// Sort for stable ordering.
+		var keys []string
+		for k := range tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, tag := range keys {
+			allValues := strings.Split(tags[tag], "|")
+			for i, v := range allValues {
+				allValues[i] = strings.Trim(v, " ")
+			}
+			op := core.NodeSelectorOpIn
+			if strings.HasPrefix(tag, "^") {
+				tag = tag[1:]
+				op = core.NodeSelectorOpNotIn
+			}
+			nodeSelectorTerm.MatchExpressions = append(nodeSelectorTerm.MatchExpressions, core.NodeSelectorRequirement{
+				Key:      tag,
+				Operator: op,
+				Values:   allValues,
+			})
+		}
+	}
+	var nodeSelectorTerm core.NodeSelectorTerm
+	updateSelectorTerms(&nodeSelectorTerm, affinityTags)
+	if pod.Affinity == nil {
+		pod.Affinity = &core.Affinity{}
+	}
+	pod.Affinity.NodeAffinity = &core.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+			NodeSelectorTerms: []core.NodeSelectorTerm{nodeSelectorTerm},
+		},
+	}
+	return nil
+}
+
+func processPodAffinity(pod *core.PodSpec, affinityLabels map[string]string) error {
+	affinityTags := make(map[string]string)
+	antiAffinityTags := make(map[string]string)
+	for key, value := range affinityLabels {
+		notVal := false
+		if strings.HasPrefix(key, "^") {
+			if len(key) == 1 {
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
+			}
+			notVal = true
+			key = key[1:]
+		}
+		if !strings.HasPrefix(key, podPrefix) && !strings.HasPrefix(key, antiPodPrefix) {
+			continue
+		}
+		if strings.HasPrefix(key, podPrefix) {
+			key = strings.TrimPrefix(key, podPrefix)
+			if notVal {
+				key = "^" + key
+			}
+			affinityTags[key] = value
+		}
+		if strings.HasPrefix(key, antiPodPrefix) {
+			key = strings.TrimPrefix(key, antiPodPrefix)
+			if notVal {
+				key = "^" + key
+			}
+			antiAffinityTags[key] = value
+		}
+	}
+	if len(affinityTags) == 0 && len(antiAffinityTags) == 0 {
+		return nil
+	}
+
+	updateAffinityTerm := func(affinityTerm *core.PodAffinityTerm, tags map[string]string) {
+		// Sort for stable ordering.
+		var keys []string
+		for k := range tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var (
+			labelSelector v1.LabelSelector
+			topologyKey   string
+		)
+		for _, tag := range keys {
+			if tag == topologyKeyTag {
+				topologyKey = tags[tag]
+				continue
+			}
+			allValues := strings.Split(tags[tag], "|")
+			for i, v := range allValues {
+				allValues[i] = strings.Trim(v, " ")
+			}
+			op := v1.LabelSelectorOpIn
+			if strings.HasPrefix(tag, "^") {
+				tag = tag[1:]
+				op = v1.LabelSelectorOpNotIn
+			}
+			labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, v1.LabelSelectorRequirement{
+				Key:      tag,
+				Operator: op,
+				Values:   allValues,
+			})
+		}
+		affinityTerm.LabelSelector = &labelSelector
+		if topologyKey != "" {
+			affinityTerm.TopologyKey = topologyKey
+		}
+	}
+	if pod.Affinity == nil {
+		pod.Affinity = &core.Affinity{}
+	}
+	var affinityTerm core.PodAffinityTerm
+	updateAffinityTerm(&affinityTerm, affinityTags)
+	if len(affinityTerm.LabelSelector.MatchExpressions) > 0 {
+		pod.Affinity.PodAffinity = &core.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{affinityTerm},
+		}
+	}
+
+	var antiAffinityTerm core.PodAffinityTerm
+	updateAffinityTerm(&antiAffinityTerm, antiAffinityTags)
+	if len(antiAffinityTerm.LabelSelector.MatchExpressions) > 0 {
+		pod.Affinity.PodAntiAffinity = &core.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{antiAffinityTerm},
+		}
+	}
+	return nil
+}
+
+func configureConstraint(pod *core.PodSpec, constraint, value string) error {
+	for i := range pod.Containers {
+		resources := pod.Containers[i].Resources
+		err := mergeConstraint(constraint, value, &resources)
+		if err != nil {
+			return errors.Annotatef(err, "merging constraint %q to %#v", constraint, resources)
+		}
+		pod.Containers[i].Resources = resources
+		// Just the first container is enough for scheduling purposes.
+		break
+	}
+	return nil
+}
+
+func mergeConstraint(constraint string, value string, resources *core.ResourceRequirements) error {
+	if resources.Requests == nil {
+		resources.Requests = core.ResourceList{}
+	}
+	resourceName := core.ResourceName(constraint)
+	if v, ok := resources.Requests[resourceName]; ok {
+		return errors.NotValidf("resource limit for %q has already been set to %v!", resourceName, v)
+	}
+	parsedValue, err := resource.ParseQuantity(value)
+	if err != nil {
+		return errors.Annotatef(err, "invalid constraint value %q for %v", value, constraint)
+	}
+	resources.Requests[resourceName] = parsedValue
+	return nil
+}

--- a/caas/kubernetes/provider/application/trust.go
+++ b/caas/kubernetes/provider/application/trust.go
@@ -7,8 +7,9 @@ import (
 	"context"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	rbacv1 "k8s.io/api/rbac/v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider/resources"
 )
 
 var defaultApplicationNamespaceRules = []rbacv1.PolicyRule{

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -37,6 +37,14 @@ const (
 	// TemplateFileNameAgentConf is the template agent.conf file name.
 	TemplateFileNameAgentConf = "template-" + agent.AgentConfigFilename
 
+	// ControllerAgentConfigFilename is the agent conf filename
+	// for the controller agent for the api server.
+	ControllerAgentConfigFilename = "controller-agent.conf"
+
+	// ControllerUnitAgentConfigFilename is the agent conf filename
+	// for the controller unit agent which runs the charm.
+	ControllerUnitAgentConfigFilename = "controller-unit-agent.conf"
+
 	// CAASProviderType is the provider type for k8s.
 	CAASProviderType = "kubernetes"
 

--- a/caas/kubernetes/provider/constants/env.go
+++ b/caas/kubernetes/provider/constants/env.go
@@ -4,5 +4,9 @@
 package constants
 
 const (
-	EnvAgentHTTPProbePort = "HTTP_PROBE_PORT"
+	EnvAgentHTTPProbePort  = "HTTP_PROBE_PORT"
+	EnvJujuContainerNames  = "JUJU_CONTAINER_NAMES"
+	EnvJujuK8sPodName      = "JUJU_K8S_POD_NAME"
+	EnvJujuK8sPodUUID      = "JUJU_K8S_POD_UUID"
+	EnvJujuK8sUnitPassword = "JUJU_K8S_UNIT_PASSWORD"
 )

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -60,17 +60,29 @@ type (
 
 type ControllerStackerForTest interface {
 	controllerStacker
-	GetAgentConfigContent(*gc.C) string
+	GetControllerAgentConfigContent(*gc.C) string
+	GetControllerUnitAgentConfigContent(*gc.C) string
+	GetControllerUnitAgentPassword() string
 	GetSharedSecretAndSSLKey(*gc.C) (string, string)
 	GetStorageSize() resource.Quantity
 	GetControllerSvcSpec(string, *podcfg.BootstrapConfig) (*controllerServiceSpec, error)
 	SetContext(ctx environs.BootstrapContext)
 }
 
-func (cs *controllerStack) GetAgentConfigContent(c *gc.C) string {
+func (cs *controllerStack) GetControllerAgentConfigContent(c *gc.C) string {
 	agentCfg, err := cs.agentConfig.Render()
 	c.Assert(err, jc.ErrorIsNil)
 	return string(agentCfg)
+}
+
+func (cs *controllerStack) GetControllerUnitAgentConfigContent(c *gc.C) string {
+	agentCfg, err := cs.unitAgentConfig.Render()
+	c.Assert(err, jc.ErrorIsNil)
+	return string(agentCfg)
+}
+
+func (cs *controllerStack) GetControllerUnitAgentPassword() string {
+	return cs.unitAgentConfig.OldPassword()
 }
 
 func (cs *controllerStack) GetSharedSecretAndSSLKey(c *gc.C) (string, string) {

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -6752,11 +6752,12 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 	}
 	for i := range podSpec.Containers {
 		podSpec.Containers[i].Resources = core.ResourceRequirements{
-			Limits: core.ResourceList{
+			Requests: core.ResourceList{
 				"memory": resource.MustParse("64Mi"),
 				"cpu":    resource.MustParse("500m"),
 			},
 		}
+		break
 	}
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	ociImageSecret := s.getOCIImageSecret(c, nil)

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -11,6 +11,7 @@ import (
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
 	version "github.com/juju/version/v2"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockApplication is a mock of Application interface.
@@ -34,6 +35,21 @@ func NewMockApplication(ctrl *gomock.Controller) *MockApplication {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 	return m.recorder
+}
+
+// ApplicationPodSpec mocks base method.
+func (m *MockApplication) ApplicationPodSpec(arg0 caas.ApplicationConfig) (*v1.PodSpec, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplicationPodSpec", arg0)
+	ret0, _ := ret[0].(*v1.PodSpec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplicationPodSpec indicates an expected call of ApplicationPodSpec.
+func (mr *MockApplicationMockRecorder) ApplicationPodSpec(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationPodSpec", reflect.TypeOf((*MockApplication)(nil).ApplicationPodSpec), arg0)
 }
 
 // Delete mocks base method.

--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -6,6 +6,7 @@ package initialize
 import (
 	"context"
 	"io"
+	"os"
 	"path"
 
 	"github.com/juju/cmd/v3"
@@ -88,8 +89,22 @@ func (c *initCommand) Init(args []string) error {
 	return c.CommandBase.Init(args)
 }
 
-func (c *initCommand) Run(ctx *cmd.Context) error {
+func (c *initCommand) Run(ctx *cmd.Context) (err error) {
 	ctx.Infof("starting containeragent init command")
+
+	defer func() {
+		if err == nil {
+			err = c.copyBinaries()
+		}
+	}()
+
+	// If the agent conf already exists, no need to do the unit introduction.
+	// TODO(wallyworld) - we may need to revisit this when we support stateless workloads.
+	templateConfigPath := path.Join(c.dataDir, k8sconstants.TemplateFileNameAgentConf)
+	_, err = c.fileReaderWriter.Stat(templateConfigPath)
+	if err == nil || !os.IsNotExist(err) {
+		return errors.Trace(err)
+	}
 
 	applicationAPI, err := c.getApplicationAPI()
 	if err != nil {
@@ -110,7 +125,6 @@ func (c *initCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	templateConfigPath := path.Join(c.dataDir, k8sconstants.TemplateFileNameAgentConf)
 	if err = c.fileReaderWriter.WriteFile(templateConfigPath, unitConfig.AgentConf, 0644); err != nil {
 		return errors.Trace(err)
 	}
@@ -118,7 +132,10 @@ func (c *initCommand) Run(ctx *cmd.Context) error {
 	if err = c.fileReaderWriter.MkdirAll(c.binDir, 0755); err != nil {
 		return errors.Trace(err)
 	}
+	return nil
+}
 
+func (c *initCommand) copyBinaries() error {
 	eg, _ := errgroup.WithContext(context.Background())
 	doCopy := func(src string, dst string) {
 		eg.Go(func() error {

--- a/cmd/containeragent/initialize/command_test.go
+++ b/cmd/containeragent/initialize/command_test.go
@@ -103,6 +103,7 @@ apiport: 17070`[1:])
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/jujuc", os.FileMode(0755)).Return(NopWriteCloser(jujucWritten), nil)
 
 	gomock.InOrder(
+		s.fileReaderWriter.EXPECT().Stat("/var/lib/juju/template-agent.conf").Return(nil, os.ErrNotExist),
 		s.applicationAPI.EXPECT().UnitIntroduction(`gitlab-0`, `gitlab-uuid`).Times(1).Return(&caasapplication.UnitConfig{
 			UnitTag:   names.NewUnitTag("gitlab/0"),
 			AgentConf: data,
@@ -114,6 +115,37 @@ apiport: 17070`[1:])
 
 		s.applicationAPI.EXPECT().Close().Times(1).Return(nil),
 	)
+
+	_, err := cmdtesting.RunCommand(c, s.cmd,
+		"--data-dir", "/var/lib/juju",
+		"--bin-dir", "/charm/bin",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(pebbleWritten.Bytes(), jc.SameContents, expectedPebble)
+	c.Assert(containerAgentWritten.Bytes(), jc.SameContents, expectedContainerAgent)
+	c.Assert(jujucWritten.Bytes(), jc.SameContents, expectedJujuc)
+}
+
+func (s *initCommandSuit) TestRunConfExists(c *gc.C) {
+	ctrl := s.setupCommand(c)
+	defer ctrl.Finish()
+
+	expectedPebble := []byte(`PEBBLE`)
+	expectedContainerAgent := []byte(`CONTAINERAGENT`)
+	expectedJujuc := []byte(`JUJUC`)
+
+	pebbleWritten := bytes.NewBuffer(nil)
+	containerAgentWritten := bytes.NewBuffer(nil)
+	jujucWritten := bytes.NewBuffer(nil)
+
+	s.fileReaderWriter.EXPECT().Reader("/opt/pebble").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedPebble)), nil)
+	s.fileReaderWriter.EXPECT().Writer("/charm/bin/pebble", os.FileMode(0755)).Return(NopWriteCloser(pebbleWritten), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/containeragent").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedContainerAgent)), nil)
+	s.fileReaderWriter.EXPECT().Writer("/charm/bin/containeragent", os.FileMode(0755)).Return(NopWriteCloser(containerAgentWritten), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/jujuc").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedJujuc)), nil)
+	s.fileReaderWriter.EXPECT().Writer("/charm/bin/jujuc", os.FileMode(0755)).Return(NopWriteCloser(jujucWritten), nil)
+	s.fileReaderWriter.EXPECT().Stat("/var/lib/juju/template-agent.conf").Return(nil, nil)
 
 	_, err := cmdtesting.RunCommand(c, s.cmd,
 		"--data-dir", "/var/lib/juju",

--- a/cmd/containeragent/initialize/config.go
+++ b/cmd/containeragent/initialize/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/mongo"
@@ -134,8 +135,8 @@ func defaultConfig() agent.Config {
 type identityFunc func() (identity, error)
 
 func identityFromK8sMetadata() (identity, error) {
-	podName := os.Getenv("JUJU_K8S_POD_NAME")
-	podUUID := os.Getenv("JUJU_K8S_POD_UUID")
+	podName := os.Getenv(k8sconstants.EnvJujuK8sPodName)
+	podUUID := os.Getenv(k8sconstants.EnvJujuK8sPodUUID)
 	if podName == "" || podUUID == "" {
 		return identity{}, errors.New("unable to extract pod name and UUID from environment")
 	}

--- a/cmd/containeragent/initialize/mocks/application_mock.go
+++ b/cmd/containeragent/initialize/mocks/application_mock.go
@@ -11,30 +11,30 @@ import (
 	caasapplication "github.com/juju/juju/api/caasapplication"
 )
 
-// MockApplicationAPI is a mock of ApplicationAPI interface
+// MockApplicationAPI is a mock of ApplicationAPI interface.
 type MockApplicationAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockApplicationAPIMockRecorder
 }
 
-// MockApplicationAPIMockRecorder is the mock recorder for MockApplicationAPI
+// MockApplicationAPIMockRecorder is the mock recorder for MockApplicationAPI.
 type MockApplicationAPIMockRecorder struct {
 	mock *MockApplicationAPI
 }
 
-// NewMockApplicationAPI creates a new mock instance
+// NewMockApplicationAPI creates a new mock instance.
 func NewMockApplicationAPI(ctrl *gomock.Controller) *MockApplicationAPI {
 	mock := &MockApplicationAPI{ctrl: ctrl}
 	mock.recorder = &MockApplicationAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplicationAPI) EXPECT() *MockApplicationAPIMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockApplicationAPI) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -42,13 +42,13 @@ func (m *MockApplicationAPI) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockApplicationAPIMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockApplicationAPI)(nil).Close))
 }
 
-// UnitIntroduction mocks base method
+// UnitIntroduction mocks base method.
 func (m *MockApplicationAPI) UnitIntroduction(arg0, arg1 string) (*caasapplication.UnitConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnitIntroduction", arg0, arg1)
@@ -57,7 +57,7 @@ func (m *MockApplicationAPI) UnitIntroduction(arg0, arg1 string) (*caasapplicati
 	return ret0, ret1
 }
 
-// UnitIntroduction indicates an expected call of UnitIntroduction
+// UnitIntroduction indicates an expected call of UnitIntroduction.
 func (mr *MockApplicationAPIMockRecorder) UnitIntroduction(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitIntroduction", reflect.TypeOf((*MockApplicationAPI)(nil).UnitIntroduction), arg0, arg1)

--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -189,7 +189,7 @@ func (c *containerUnitAgent) Init(args []string) error {
 	if err := c.ensureToolSymlinks(srcDir, dataDir, unitTag); err != nil {
 		return errors.Annotate(err, "ensuring agent tool symlinks")
 	}
-	containerNames := c.environment.Getenv("JUJU_CONTAINER_NAMES")
+	containerNames := c.environment.Getenv(k8sconstants.EnvJujuContainerNames)
 	if len(containerNames) > 0 {
 		c.containerNames = strings.Split(containerNames, ",")
 	}

--- a/cmd/containeragent/utils/filesystem.go
+++ b/cmd/containeragent/utils/filesystem.go
@@ -13,6 +13,7 @@ import (
 
 // FileReaderWriter provides methods for reading a file or writing to a file.
 type FileReaderWriter interface {
+	Stat(filename string) (os.FileInfo, error)
 	ReadFile(filename string) ([]byte, error)
 	WriteFile(filename string, data []byte, perm os.FileMode) error
 
@@ -32,6 +33,10 @@ func NewFileReaderWriter() FileReaderWriter {
 type fileReaderWriter struct{}
 
 var _ FileReaderWriter = (*fileReaderWriter)(nil)
+
+func (fileReaderWriter) Stat(filename string) (os.FileInfo, error) {
+	return os.Stat(filename)
+}
 
 func (fileReaderWriter) ReadFile(filename string) ([]byte, error) {
 	return ioutil.ReadFile(filename)

--- a/cmd/containeragent/utils/mocks/environment_mock.go
+++ b/cmd/containeragent/utils/mocks/environment_mock.go
@@ -10,30 +10,30 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockEnvironment is a mock of Environment interface
+// MockEnvironment is a mock of Environment interface.
 type MockEnvironment struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnvironmentMockRecorder
 }
 
-// MockEnvironmentMockRecorder is the mock recorder for MockEnvironment
+// MockEnvironmentMockRecorder is the mock recorder for MockEnvironment.
 type MockEnvironmentMockRecorder struct {
 	mock *MockEnvironment
 }
 
-// NewMockEnvironment creates a new mock instance
+// NewMockEnvironment creates a new mock instance.
 func NewMockEnvironment(ctrl *gomock.Controller) *MockEnvironment {
 	mock := &MockEnvironment{ctrl: ctrl}
 	mock.recorder = &MockEnvironmentMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEnvironment) EXPECT() *MockEnvironmentMockRecorder {
 	return m.recorder
 }
 
-// ExpandEnv mocks base method
+// ExpandEnv mocks base method.
 func (m *MockEnvironment) ExpandEnv(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExpandEnv", arg0)
@@ -41,13 +41,13 @@ func (m *MockEnvironment) ExpandEnv(arg0 string) string {
 	return ret0
 }
 
-// ExpandEnv indicates an expected call of ExpandEnv
+// ExpandEnv indicates an expected call of ExpandEnv.
 func (mr *MockEnvironmentMockRecorder) ExpandEnv(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpandEnv", reflect.TypeOf((*MockEnvironment)(nil).ExpandEnv), arg0)
 }
 
-// Getenv mocks base method
+// Getenv mocks base method.
 func (m *MockEnvironment) Getenv(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Getenv", arg0)
@@ -55,13 +55,13 @@ func (m *MockEnvironment) Getenv(arg0 string) string {
 	return ret0
 }
 
-// Getenv indicates an expected call of Getenv
+// Getenv indicates an expected call of Getenv.
 func (mr *MockEnvironmentMockRecorder) Getenv(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Getenv", reflect.TypeOf((*MockEnvironment)(nil).Getenv), arg0)
 }
 
-// Setenv mocks base method
+// Setenv mocks base method.
 func (m *MockEnvironment) Setenv(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Setenv", arg0, arg1)
@@ -69,13 +69,13 @@ func (m *MockEnvironment) Setenv(arg0, arg1 string) error {
 	return ret0
 }
 
-// Setenv indicates an expected call of Setenv
+// Setenv indicates an expected call of Setenv.
 func (mr *MockEnvironmentMockRecorder) Setenv(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setenv", reflect.TypeOf((*MockEnvironment)(nil).Setenv), arg0, arg1)
 }
 
-// Unsetenv mocks base method
+// Unsetenv mocks base method.
 func (m *MockEnvironment) Unsetenv(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unsetenv", arg0)
@@ -83,7 +83,7 @@ func (m *MockEnvironment) Unsetenv(arg0 string) error {
 	return ret0
 }
 
-// Unsetenv indicates an expected call of Unsetenv
+// Unsetenv indicates an expected call of Unsetenv.
 func (mr *MockEnvironmentMockRecorder) Unsetenv(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unsetenv", reflect.TypeOf((*MockEnvironment)(nil).Unsetenv), arg0)

--- a/cmd/containeragent/utils/mocks/file_mock.go
+++ b/cmd/containeragent/utils/mocks/file_mock.go
@@ -6,50 +6,50 @@ package mocks
 
 import (
 	io "io"
-	os "os"
+	fs "io/fs"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockFileReaderWriter is a mock of FileReaderWriter interface
+// MockFileReaderWriter is a mock of FileReaderWriter interface.
 type MockFileReaderWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileReaderWriterMockRecorder
 }
 
-// MockFileReaderWriterMockRecorder is the mock recorder for MockFileReaderWriter
+// MockFileReaderWriterMockRecorder is the mock recorder for MockFileReaderWriter.
 type MockFileReaderWriterMockRecorder struct {
 	mock *MockFileReaderWriter
 }
 
-// NewMockFileReaderWriter creates a new mock instance
+// NewMockFileReaderWriter creates a new mock instance.
 func NewMockFileReaderWriter(ctrl *gomock.Controller) *MockFileReaderWriter {
 	mock := &MockFileReaderWriter{ctrl: ctrl}
 	mock.recorder = &MockFileReaderWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFileReaderWriter) EXPECT() *MockFileReaderWriterMockRecorder {
 	return m.recorder
 }
 
-// MkdirAll mocks base method
-func (m *MockFileReaderWriter) MkdirAll(arg0 string, arg1 os.FileMode) error {
+// MkdirAll mocks base method.
+func (m *MockFileReaderWriter) MkdirAll(arg0 string, arg1 fs.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// MkdirAll indicates an expected call of MkdirAll
+// MkdirAll indicates an expected call of MkdirAll.
 func (mr *MockFileReaderWriterMockRecorder) MkdirAll(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MkdirAll", reflect.TypeOf((*MockFileReaderWriter)(nil).MkdirAll), arg0, arg1)
 }
 
-// ReadFile mocks base method
+// ReadFile mocks base method.
 func (m *MockFileReaderWriter) ReadFile(arg0 string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadFile", arg0)
@@ -58,13 +58,13 @@ func (m *MockFileReaderWriter) ReadFile(arg0 string) ([]byte, error) {
 	return ret0, ret1
 }
 
-// ReadFile indicates an expected call of ReadFile
+// ReadFile indicates an expected call of ReadFile.
 func (mr *MockFileReaderWriterMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockFileReaderWriter)(nil).ReadFile), arg0)
 }
 
-// Reader mocks base method
+// Reader mocks base method.
 func (m *MockFileReaderWriter) Reader(arg0 string) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reader", arg0)
@@ -73,13 +73,13 @@ func (m *MockFileReaderWriter) Reader(arg0 string) (io.ReadCloser, error) {
 	return ret0, ret1
 }
 
-// Reader indicates an expected call of Reader
+// Reader indicates an expected call of Reader.
 func (mr *MockFileReaderWriterMockRecorder) Reader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reader", reflect.TypeOf((*MockFileReaderWriter)(nil).Reader), arg0)
 }
 
-// RemoveAll mocks base method
+// RemoveAll mocks base method.
 func (m *MockFileReaderWriter) RemoveAll(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAll", arg0)
@@ -87,13 +87,28 @@ func (m *MockFileReaderWriter) RemoveAll(arg0 string) error {
 	return ret0
 }
 
-// RemoveAll indicates an expected call of RemoveAll
+// RemoveAll indicates an expected call of RemoveAll.
 func (mr *MockFileReaderWriterMockRecorder) RemoveAll(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockFileReaderWriter)(nil).RemoveAll), arg0)
 }
 
-// Symlink mocks base method
+// Stat mocks base method.
+func (m *MockFileReaderWriter) Stat(arg0 string) (fs.FileInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stat", arg0)
+	ret0, _ := ret[0].(fs.FileInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Stat indicates an expected call of Stat.
+func (mr *MockFileReaderWriterMockRecorder) Stat(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockFileReaderWriter)(nil).Stat), arg0)
+}
+
+// Symlink mocks base method.
 func (m *MockFileReaderWriter) Symlink(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Symlink", arg0, arg1)
@@ -101,28 +116,28 @@ func (m *MockFileReaderWriter) Symlink(arg0, arg1 string) error {
 	return ret0
 }
 
-// Symlink indicates an expected call of Symlink
+// Symlink indicates an expected call of Symlink.
 func (mr *MockFileReaderWriterMockRecorder) Symlink(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Symlink", reflect.TypeOf((*MockFileReaderWriter)(nil).Symlink), arg0, arg1)
 }
 
-// WriteFile mocks base method
-func (m *MockFileReaderWriter) WriteFile(arg0 string, arg1 []byte, arg2 os.FileMode) error {
+// WriteFile mocks base method.
+func (m *MockFileReaderWriter) WriteFile(arg0 string, arg1 []byte, arg2 fs.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WriteFile indicates an expected call of WriteFile
+// WriteFile indicates an expected call of WriteFile.
 func (mr *MockFileReaderWriterMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockFileReaderWriter)(nil).WriteFile), arg0, arg1, arg2)
 }
 
-// Writer mocks base method
-func (m *MockFileReaderWriter) Writer(arg0 string, arg1 os.FileMode) (io.WriteCloser, error) {
+// Writer mocks base method.
+func (m *MockFileReaderWriter) Writer(arg0 string, arg1 fs.FileMode) (io.WriteCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Writer", arg0, arg1)
 	ret0, _ := ret[0].(io.WriteCloser)
@@ -130,7 +145,7 @@ func (m *MockFileReaderWriter) Writer(arg0 string, arg1 os.FileMode) (io.WriteCl
 	return ret0, ret1
 }
 
-// Writer indicates an expected call of Writer
+// Writer indicates an expected call of Writer.
 func (mr *MockFileReaderWriterMockRecorder) Writer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Writer", reflect.TypeOf((*MockFileReaderWriter)(nil).Writer), arg0, arg1)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -705,6 +705,9 @@ to create a new model to deploy %sworkloads.
 	}
 
 	isCAASController = jujucloud.CloudIsCAAS(cloud)
+	if isCAASController && c.ControllerCharmPath != "" {
+		return errors.NotSupportedf("deploying a local controller charm on a k8s controller")
+	}
 	if !isCAASController {
 		if bootstrapCfg.bootstrap.ControllerServiceType != "" ||
 			bootstrapCfg.bootstrap.ControllerExternalName != "" ||

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -160,10 +160,12 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 
 	isCAAS := args.ControllerCloud.Type == k8sconstants.CAASProviderType
 
+	var controllerUnitPassword string
 	if isCAAS {
 		if err := c.ensureConfigFilesForCaas(); err != nil {
 			return errors.Trace(err)
 		}
+		controllerUnitPassword = os.Getenv(k8sconstants.EnvJujuK8sUnitPassword)
 	}
 
 	// Get the bootstrap machine's addresses from the provider.
@@ -368,7 +370,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	// Deploy and set up the controller charm and application.
-	if err := c.deployControllerCharm(st, args.ControllerCharmRisk); err != nil {
+	if err := c.deployControllerCharm(st, args.BootstrapMachineConstraints, args.ControllerCharmRisk, isCAAS, controllerUnitPassword); err != nil {
 		return errors.Annotate(err, "cannot deploy controller application")
 	}
 

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -72,7 +72,7 @@ var allowedCalls = map[string]set.Strings{
 	// signmetadata is not a whitelisted embedded CLI command.
 	"plugins/juju-metadata/signmetadata.go": set.NewStrings("os.Open"),
 	// containeragent needs to ensure jujud symlinks.
-	"containeragent/utils/filesystem.go": set.NewStrings("os.Symlink", "os.OpenFile", "os.RemoveAll"),
+	"containeragent/utils/filesystem.go": set.NewStrings("os.Stat", "os.Symlink", "os.OpenFile", "os.RemoveAll"),
 }
 
 var ignoredPackages = set.NewStrings(

--- a/core/application/config.go
+++ b/core/application/config.go
@@ -94,7 +94,7 @@ func (c ConfigAttributes) Get(attrName string, defaultValue interface{}) interfa
 	return defaultValue
 }
 
-// GetInt gets the specified bool attribute.
+// GetBool gets the specified bool attribute.
 func (c ConfigAttributes) GetBool(attrName string, defaultValue bool) bool {
 	if val, ok := c[attrName]; ok {
 		return val.(bool)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -175,6 +175,7 @@ type BootstrapParams struct {
 	// ControllerCharmPath is a local controller charm archive.
 	ControllerCharmPath string
 
+	// ControllerCharmRisk is used when fetching the charmhub controller charm.
 	ControllerCharmRisk string
 
 	// ExtraAgentValuesForTesting are testing only values written to the agent config file.
@@ -852,6 +853,7 @@ func finalizePodBootstrapConfig(
 	pcfg.Bootstrap.ControllerServiceType = args.ControllerServiceType
 	pcfg.Bootstrap.ControllerExternalName = args.ControllerExternalName
 	pcfg.Bootstrap.ControllerExternalIPs = append([]string(nil), args.ControllerExternalIPs...)
+	pcfg.Bootstrap.ControllerCharmRisk = args.ControllerCharmRisk
 	return nil
 }
 

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/environs/bootstrap"
 )
 
 type appNotifyWorker interface {
@@ -187,13 +188,20 @@ func (a *appWorker) loop() error {
 		return errors.Annotatef(err, "failed to watch for application %q scale changes", a.name)
 	}
 
-	appTrustWatcher, err := a.unitFacade.WatchApplicationTrustHash(a.name)
-	if err != nil {
-		return errors.Annotatef(err, "creating application %q trust watcher", a.name)
-	}
+	var trustChanges watcher.StringsChannel
+	// The out of the box "controller" application is set up at bootstrap and does
+	// not use the same roles and cluster roles as "normal" applications.
+	// So we don't want to process trust changes.
+	if a.name != bootstrap.ControllerApplicationName {
+		appTrustWatcher, err := a.unitFacade.WatchApplicationTrustHash(a.name)
+		if err != nil {
+			return errors.Annotatef(err, "creating application %q trust watcher", a.name)
+		}
 
-	if err := a.catacomb.Add(appTrustWatcher); err != nil {
-		return errors.Annotatef(err, "failed to watch for application %q trust changes", a.name)
+		if err := a.catacomb.Add(appTrustWatcher); err != nil {
+			return errors.Annotatef(err, "failed to watch for application %q trust changes", a.name)
+		}
+		trustChanges = appTrustWatcher.Changes()
 	}
 
 	done := false
@@ -290,7 +298,7 @@ func (a *appWorker) loop() error {
 			} else {
 				scaleChan = nil
 			}
-		case _, ok := <-appTrustWatcher.Changes():
+		case _, ok := <-trustChanges:
 			if !ok {
 				return fmt.Errorf("application %q trust watcher closed channel", a.name)
 			}
@@ -722,6 +730,12 @@ func (a *appWorker) alive(app caas.Application) error {
 		CharmModifiedVersion: provisionInfo.CharmModifiedVersion,
 		Trust:                provisionInfo.Trust,
 		InitialScale:         provisionInfo.Scale,
+	}
+	// The out of the box "controller" application is set up at bootstrap and does
+	// not use the same provisioning config as "normal" applications.
+	if a.name == bootstrap.ControllerApplicationName && a.lastApplied.AgentImagePath == "" {
+		a.lastApplied = config
+		return nil
 	}
 	reason := "unchanged"
 	// TODO(sidecar): implement Equals method for caas.ApplicationConfig


### PR DESCRIPTION
When bootstrapping on k8s, we now deploy the [juju controller](https://charmhub.io/juju-controller) charm automatically. As with IAAS, we need to seed the Juju model at bootstrap time to have the "controller" application in state, plus a single unit. For k8s, we also need to add the charm container to the controller pod; there are now 3 containers - api-server, mongodb, charm. 

Still TODO:
 - wire up the controller api-server and mongodb containers to use pebble.
 - model controller storage so it can be set up as part of the app config ad not done by hand

The unit introduction workflow to set up the unit agent password is not needed, since the password is generated as part of the bootstrap process, and it's a chicken/egg scenario. But we still need to copy the various binaries to the right place, so the init container command was modified to behave correctly in both scenarios.

Some refactoring was necessary. For sidecar charms, we introduced an application entity, which renders a suitable podspec to add to the cluster. This was reused so that we render the controller podspec using common code. It was discovered that sidecar apps were not properly applying affinity constraints, so the code there was pulled out and used for both types of charm. The use of constraints memory and cpu values is now also unified.

General housekeeping was also done - some large methods were broken up, constants used, and struct attributes which were just set to constant values were removed to aid in reading the code.

## QA steps

Build a local copy of the [juju-dashboard charm](https://github.com/canonical-web-and-design/juju-dashboard-charm)

juju bootstrap microk8s
juju deploy ./juju-dashboard.charm
juju relate juju-dashboard controller
juju status --relations
```
Model       Controller  Cloud/Region        Version    SLA          Timestamp
controller  test        microk8s/localhost  3.0-beta1  unsupported  12:29:59+10:00

App             Version                    Status  Scale  Charm            Store     Channel  Rev  OS          Address         Message
controller                                 active      1  juju-controller  charmhub  beta       7  ubuntu                      
juju-dashboard  .../jaas-dashboard:latest  active      1  juju-dashboard   local                0  kubernetes  10.152.183.186  

Unit               Workload  Agent  Address      Ports   Message
controller/0*      active    idle                        
juju-dashboard/0*  active    idle   10.1.78.102  80/TCP  

Relation provider     Requirer                   Interface       Type     Message
controller:dashboard  juju-dashboard:controller  juju-dashboard  regular  
```
$ juju show-status-log controller/0
```
Time                        Type       Status       Message
15 Dec 2021 12:25:03+10:00  juju-unit  allocating   
15 Dec 2021 12:25:03+10:00  workload   waiting      installing agent
15 Dec 2021 12:25:25+10:00  workload   waiting      agent initializing
15 Dec 2021 12:25:33+10:00  workload   maintenance  installing charm software
15 Dec 2021 12:25:33+10:00  juju-unit  executing    running install hook
15 Dec 2021 12:25:34+10:00  juju-unit  executing    running leader-elected hook
15 Dec 2021 12:25:34+10:00  juju-unit  executing    running config-changed hook
15 Dec 2021 12:25:35+10:00  juju-unit  executing    running start hook
15 Dec 2021 12:25:35+10:00  workload   active       
15 Dec 2021 12:25:35+10:00  juju-unit  idle         
15 Dec 2021 12:29:44+10:00  juju-unit  executing    running dashboard-relation-created hook
15 Dec 2021 12:29:44+10:00  juju-unit  idle         
15 Dec 2021 12:29:45+10:00  juju-unit  executing    running dashboard-relation-joined hook for juju-dashboard/0
15 Dec 2021 12:29:45+10:00  juju-unit  executing    running dashboard-relation-changed hook for juju-dashboard/0
15 Dec 2021 12:29:45+10:00  juju-unit  idle         
```