### PR TITLE
[JUJU-360] Reduce API server metric cardinality

### DIFF
--- a/apiserver/observer/metricobserver/observer_test.go
+++ b/apiserver/observer/metricobserver/observer_test.go
@@ -67,7 +67,7 @@ func (s *observerSuite) createFactory(c *gc.C) (observer.ObserverFactory, func()
 		metricobserver.MetricLabelFacade:    "api-facade",
 		metricobserver.MetricLabelVersion:   strconv.Itoa(42),
 		metricobserver.MetricLabelMethod:    "api-method",
-		metricobserver.MetricLabelErrorCode: "badness",
+		metricobserver.MetricLabelErrorCode: "error",
 	})
 
 	factory, err := metricobserver.NewObserverFactory(metricobserver.Config{


### PR DESCRIPTION
The number of API server metric quantile permutations are growing
because the rpc.ErrorCode can lead to too many deviations. The fix for
now is to reduce this and only compute success or errors. This way we
can be sure that the cardinality can be finite.

This should reduce the total number of memory used for every API server
instance.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-user prometheus
$ juju change-user-password prometheus
$ juju grant prometheus read controller
$ juju show-controller test1 --format=json | jq '.test1.details."api-endpoints"[0]' | xargs -I % echo "https://%/introspection/metrics" | xargs curl -k -s -u user-prometheus:$PASSWORD
```

The output should now be more standardized... see full output https://paste.ubuntu.com/p/rRMJPPGfDk/

```sh
juju_apiserver_request_duration_seconds{error_code="",facade="UserManager",method="SetPassword",version="2",quantile="0.9"} 0.024054679
juju_apiserver_request_duration_seconds{error_code="",facade="UserManager",method="SetPassword",version="2",quantile="0.99"} 0.024054679
juju_apiserver_request_duration_seconds_sum{error_code="",facade="UserManager",method="SetPassword",version="2"} 0.024054679
juju_apiserver_request_duration_seconds_count{error_code="",facade="UserManager",method="SetPassword",version="2"} 1
juju_apiserver_request_duration_seconds{error_code="error",facade="MigrationMaster",method="MigrationStatus",version="3",quantile="0.5"} 0.000436942
juju_apiserver_request_duration_seconds{error_code="error",facade="MigrationMaster",method="MigrationStatus",version="3",quantile="0.9"} 0.001692763
juju_apiserver_request_duration_seconds{error_code="error",facade="MigrationMaster",method="MigrationStatus",version="3",quantile="0.99"} 0.001692763
juju_apiserver_request_duration_seconds_sum{error_code="error",facade="MigrationMaster",method="MigrationStatus",version="3"} 0.002129705
juju_apiserver_request_duration_seconds_count{error_code="error",facade="MigrationMaster",method="MigrationStatus",version="3"} 2
juju_apiserver_request_duration_seconds{error_code="error",facade="MigrationStatusWatcher",method="Next",version="1",quantile="0.5"} 0.209688904
juju_apiserver_request_duration_seconds{error_code="error",facade="MigrationStatusWatcher",method="Next",version="1",quantile="0.9"} 0.209688904
juju_apiserver_request_duration_seconds{error_code="error",facade="MigrationStatusWatcher",method="Next",version="1",quantile="0.99"} 0.209688904
juju_apiserver_request_duration_seconds_sum{error_code="error",facade="MigrationStatusWatcher",method="Next",version="1"} 0.209688904
juju_apiserver_request_duration_seconds_count{error_code="error",facade="MigrationStatusWatcher",method="Next",version="1"} 1
juju_apiserver_request_duration_seconds{error_code="error",facade="NotifyWatcher",method="Next",version="1",quantile="0.5"} 0.010861041
juju_apiserver_request_duration_seconds{error_code="error",facade="NotifyWatcher",method="Next",version="1",quantile="0.9"} 0.265503743
juju_apiserver_request_duration_seconds{error_code="error",facade="NotifyWatcher",method="Next",version="1",quantile="0.99"} 0.265503743
juju_apiserver_request_duration_seconds_sum{error_code="error",facade="NotifyWatcher",method="Next",version="1"} 1.056411186
juju_apiserver_request_duration_seconds_count{error_code="error",facade="NotifyWatcher",method="Next",version="1"} 8
juju_apiserver_request_duration_seconds{error_code="error",facade="StringsWatcher",method="Next",version="1",quantile="0.5"} 0.228891151
juju_apiserver_request_duration_seconds{error_code="error",facade="StringsWatcher",method="Next",version="1",quantile="0.9"} 0.228891151
juju_apiserver_request_duration_seconds{error_code="error",facade="StringsWatcher",method="Next",version="1",quantile="0.99"} 0.228891151
juju_apiserver_request_duration_seconds_sum{error_code="error",facade="StringsWatcher",method="Next",version="1"} 0.228891151
juju_apiserver_request_duration_seconds_count{error_code="error",facade="StringsWatcher",method="Next",version="1"} 1
```



