### PR TITLE
[JUJU-362] Do not force channel for local charms

### DIFF
--- a/core/bundle/changes/changes_test.go
+++ b/core/bundle/changes/changes_test.go
@@ -5628,6 +5628,29 @@ func (s *changesSuite) TestNoPossibleTargets(c *gc.C) {
 	})
 }
 
+func (s *changesSuite) TestRedeploymentOfBundleWithLocalCharms(c *gc.C) {
+	bundleContent := `
+        applications:
+          haproxy:
+            charm: "local:haproxy-0"
+        `
+	existingModel := &bundlechanges.Model{
+		Applications: map[string]*bundlechanges.Application{
+			"haproxy": {
+				Name:     "haproxy",
+				Charm:    "local:haproxy-0",
+				Revision: 42,
+				// NOTE: local charms are not associated with a
+				// channel as this information is not available
+				// at deploy time.
+			},
+		},
+	}
+
+	// No changes expected.
+	s.checkBundleExistingModel(c, bundleContent, existingModel, nil)
+}
+
 func (s *changesSuite) checkBundle(c *gc.C, bundleContent string, expectedChanges []string) {
 	s.checkBundleImpl(c, bundleContent, nil, expectedChanges, "", nil, nil)
 }

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -68,9 +68,16 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 		// matching existing charms in this method, assume a channel of stable
 		// if not specified.  Required because another change ensures that the
 		// cs applications have a channel provided an old controller.
+		//
+		// However, if we are deploying a bundle with local charms they
+		// will always get an empty channel. For such cases, we should
+		// never force a "stable" channel as deploying the bundle more
+		// than once will fail (see LP1954933).
 		channel := application.Channel
-		if channel == "" {
-			channel = "stable"
+		if existingApp == nil || !strings.HasPrefix(existingApp.Charm, "local:") {
+			if channel == "" {
+				channel = "stable"
+			}
 		}
 
 		revision := -1


### PR DESCRIPTION
When deploying local charms, they do not get associated with a
particular channel as this information is not available at deploy time.

When deploying a bundle containing local charms multiple times, we
should never force the channel for local charms as this prevents Juju
from locating the already-existing local charm causing the error
described in LP1954933.

## QA steps

```sh
$ juju bootstrap lxd test --no-gui
$ juju download ha-proxy
Fetching charm "haproxy" using "stable" channel and base "amd64/ubuntu/20.04"
Install the "haproxy" charm with:
    juju deploy ./haproxy_1795a3c.charm

$ cat >bundle.yaml <<EOF
series: bionic
applications:
  haproxy:
    charm: $(pwd)/haproxy_1795a3c.charm
EOF

# Deploy bundle twice. The second attempt should report "No changes to apply"
$ juju deploy ./bundle.yaml
$ juju deploy ./bundle.yaml
No changes to apply.
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1954933