### PR TITLE
Handles permission errors for listing instance profiles.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1878,7 +1878,9 @@ func (e *environ) destroyControllerManagedModels(ctx context.ProviderCallContext
 	}
 
 	instanceProfiles, err := listInstanceProfilesForController(ctx, e.iamClient, controllerUUID)
-	if err != nil {
+	if errors.IsUnauthorized(err) {
+		logger.Warningf("unable to list Instance Profiles for deletion, Instance Profiles may have to be manually cleaned up for controller %q", controllerUUID)
+	} else if err != nil {
 		return errors.Annotatef(err, "listing instance profiles for controller uuid %q", controllerUUID)
 	}
 
@@ -1890,7 +1892,9 @@ func (e *environ) destroyControllerManagedModels(ctx context.ProviderCallContext
 	}
 
 	roles, err := listRolesForController(ctx, e.iamClient, controllerUUID)
-	if err != nil {
+	if errors.IsUnauthorized(err) {
+		logger.Warningf("unable to list Roles for deletion, Roles may have to be manually cleaned up for controller %q", controllerUUID)
+	} else if err != nil {
 		return errors.Annotatef(err, "listing roles for controller uuid %q", controllerUUID)
 	}
 

--- a/provider/ec2/internal/testing/iam_server.go
+++ b/provider/ec2/internal/testing/iam_server.go
@@ -18,15 +18,22 @@ type InlinePolicy struct {
 type IAMServer struct {
 	mu sync.Mutex
 
-	instanceProfiles map[string]*types.InstanceProfile
-	roles            map[string]*types.Role
-	roleInlinePolicy map[string]*InlinePolicy
+	instanceProfiles       map[string]*types.InstanceProfile
+	roles                  map[string]*types.Role
+	roleInlinePolicy       map[string]*InlinePolicy
+	producePermissionError bool
 }
 
 func NewIAMServer() (*IAMServer, error) {
 	srv := &IAMServer{}
 	srv.Reset()
 	return srv, nil
+}
+
+func (i *IAMServer) ProducePermissionError(p bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.producePermissionError = p
 }
 
 func (i *IAMServer) Reset() {

--- a/provider/ec2/internal/testing/instanceprofile.go
+++ b/provider/ec2/internal/testing/instanceprofile.go
@@ -125,6 +125,19 @@ func (i *IAMServer) ListInstanceProfiles(
 		InstanceProfiles: []types.InstanceProfile{},
 		IsTruncated:      false,
 	}
+
+	if i.producePermissionError {
+		return rval, &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{
+					&http.Response{
+						StatusCode: http.StatusForbidden,
+					},
+				},
+			},
+		}
+	}
+
 	for _, v := range i.instanceProfiles {
 		rval.InstanceProfiles = append(rval.InstanceProfiles, *v)
 	}

--- a/provider/ec2/internal/testing/roles.go
+++ b/provider/ec2/internal/testing/roles.go
@@ -125,6 +125,18 @@ func (i *IAMServer) ListRoles(
 		IsTruncated: false,
 	}
 
+	if i.producePermissionError {
+		return rval, &awshttp.ResponseError{
+			ResponseError: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{
+					&http.Response{
+						StatusCode: http.StatusForbidden,
+					},
+				},
+			},
+		}
+	}
+
 	for _, role := range i.roles {
 		if strings.HasPrefix(*role.Path, *input.PathPrefix) {
 			rval.Roles = append(rval.Roles, *role)

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -593,6 +593,16 @@ func (t *localServerSuite) TestIAMRoleCleanup(c *gc.C) {
 	c.Assert(len(res1.Roles), gc.Equals, 0)
 }
 
+func (t *localServerSuite) TestIAMRolePermissionProblems(c *gc.C) {
+	t.srv.ec2srv.SetInitialInstanceState(ec2test.Running)
+	t.srv.iamsrv.ProducePermissionError(true)
+	defer t.srv.iamsrv.ProducePermissionError(false)
+	env := t.prepareAndBootstrap(c)
+
+	err := env.DestroyController(t.callCtx, t.ControllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (t *localServerSuite) TestGetTerminatedInstances(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,


### PR DESCRIPTION
With the introduction of instance profile code there is a potentially error for users when destroying controllers that have a very limited permission set in use because 2.9 now requires more permissions then it did previously. This PR introduces the new checks as warning's should this case arise.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Create a aws credential user with the policy found [here](https://discourse.charmhub.io/t/juju-aws-permissions/5307). From this policy remove the `"iam:ListInstanceProfiles"` and `"iam:ListRoles"` actions.

Add the newly created AWS user to your local Juju credentials and bootstrap a controller.

Kill the controller with:
`juju kill-controller -t0 -y`

You should see warnings in the output about the lack of permissions and manual cleanup may be required.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1954915
