### PR TITLE
[JUJU-316] Detect dqlite cluster peers from the API endpoints in the agent's config

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -748,10 +748,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			AgentName:      agentName,
-			CentralHubName: centralHubName,
-			Clock:          config.Clock,
-			Logger:         loggo.GetLogger("juju.worker.dbaccessor"),
+			AgentName: agentName,
+			Clock:     config.Clock,
+			Logger:    loggo.GetLogger("juju.worker.dbaccessor"),
 		})),
 
 		restoreWatcherName: restorewatcher.Manifold(restorewatcher.ManifoldConfig{

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -243,7 +243,6 @@ func buildJujus(dir string) error {
 
 	// Determine if we are in tree of juju and if to prefer
 	// vendor or readonly mod deps.
-	var modArg string
 	var lastErr error
 	for _, m := range []string{"-mod=vendor", "-mod=readonly"} {
 		cmd := exec.Command("go", "list", m, "github.com/juju/juju")
@@ -256,7 +255,6 @@ func buildJujus(dir string) error {
 			lastErr = errors.Annotatef(err, info, jujuversion.Current.String(), jujuversion.GitCommit, out)
 			continue
 		}
-		modArg = m
 		lastErr = nil
 		break
 	}
@@ -266,14 +264,12 @@ func buildJujus(dir string) error {
 
 	// Build binaries.
 	cmds := [][]string{
-		// TODO: jam 2020-03-12 do we want to also default to stripping the binary?
-		//       -ldflags "-s -w"
-		{"go", "build", modArg, "-ldflags", "-extldflags \"-static\"", "-o", filepath.Join(dir, names.Jujud), "github.com/juju/juju/cmd/jujud"},
-		{"go", "build", modArg, "-ldflags", "-extldflags \"-static\"", "-o", filepath.Join(dir, names.Jujuc), "github.com/juju/juju/cmd/jujuc"},
+		{"make", "go-build"},
 	}
 	for _, args := range cmds {
 		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+		cmd.Env = append(os.Environ(), "BIN_DIR="+dir, "CC=/usr/local/musl/bin/musl-gcc")
+		cmd.Dir = filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "juju", "juju")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("build command %q failed: %v; %s", args[0], err, out)

--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbaccessor
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbaccessor
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&detectLocalAddressSuite{})
+
+type detectLocalAddressSuite struct{}
+
+func (s *detectLocalAddressSuite) TestDetectLocalDQliteAddr(c *gc.C) {
+	addrList := []string{
+		"localhost:9999",
+		"10.0.0.1:9999",
+		"10.0.0.2:9999",
+	}
+
+	localAddr, peerAddrs, err := detectLocalDQliteAddr(addrList)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(localAddr, gc.Equals, "localhost:9999")
+	c.Assert(peerAddrs, gc.DeepEquals, addrList[1:])
+}


### PR DESCRIPTION
This change makes the db-accessor worker detect the potential dqlite cluster peers by analyzing the API endpoints present in the controller agent's configuration.

## QA steps

Same as https://github.com/juju/juju/pull/13530