### PR TITLE
[JUJU-369] Remove offers when a model is destroyed

### DIFF
--- a/apiserver/common/relationunitswatcher.go
+++ b/apiserver/common/relationunitswatcher.go
@@ -26,7 +26,7 @@ type RelationUnitsWatcher interface {
 	Err() error
 }
 
-// NewRelationUnitsWatcherFromState wraps a state-level
+// RelationUnitsWatcherFromState wraps a state-level
 // RelationUnitsWatcher in an equivalent apiserver-level one, taking
 // responsibility for the source watcher's lifetime.
 func RelationUnitsWatcherFromState(source state.RelationUnitsWatcher) (RelationUnitsWatcher, error) {

--- a/state/offerconnections.go
+++ b/state/offerconnections.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/status"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/mgo/v2/txn"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/core/status"
 )
 
 // OfferConnection represents the state of a relation

--- a/state/offerconnections_test.go
+++ b/state/offerconnections_test.go
@@ -6,10 +6,10 @@ package state_test
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/errors"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"

--- a/worker/remoterelations/remoterelationsworker.go
+++ b/worker/remoterelations/remoterelationsworker.go
@@ -7,12 +7,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/names/v4"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/names/v4"
 )
 
 // remoteRelationsWorker listens for changes to the


### PR DESCRIPTION
When destroying a model, the application cleanup job needs to force remove any active offers so that relevant units can be allowed to leave scope. If this doesn't happen, the offered application cannot be removed and destroy model is blocked.

## QA steps

create a model and deploy mariadb and offer it
create another model and deploy mediawiki and relate to the offer
juju destroy-model -y offering-model

The mariadb app will be removed and the destroy operation will complete.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1954948
