### PR TITLE
Update pubsub library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/juju/packaging/v2 v2.0.0-20210628104420-5487e24f1350
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20210817195502-c6015cfe0258
-	github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b
+	github.com/juju/pubsub/v2 v2.0.0-20220104155641-7af8a09f58f0
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 	github.com/juju/replicaset/v2 v2.0.1-0.20211125220232-7967ce535201
 	github.com/juju/retry v0.0.0-20180821225755-9058e192b216

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSw
 github.com/juju/proxy v0.0.0-20180516023828-df38202e4713/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
 github.com/juju/proxy v0.0.0-20210817195502-c6015cfe0258 h1:oQ4i531nGh54FPEkAA5j1rbXPANQjUw84FM9O7EsNOo=
 github.com/juju/proxy v0.0.0-20210817195502-c6015cfe0258/go.mod h1:8eZt3fxDIlRXkEkf4N4PCNSZzryF6NxULBg07OjDofA=
-github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b h1:EwjCZIeRDkUzIM7hFFmq339tBZA5NBXIzOUXM6KR3U8=
-github.com/juju/pubsub/v2 v2.0.0-20210804115646-050d38a80f5b/go.mod h1:+fw+MJGVa006M85prHvwS9pQrCjkkaaH8Ds1wvEMpXQ=
+github.com/juju/pubsub/v2 v2.0.0-20220104155641-7af8a09f58f0 h1:Nfb7iOD5//l9mHDNy+lCwk7cxpGCI59/5vrnzUj13UE=
+github.com/juju/pubsub/v2 v2.0.0-20220104155641-7af8a09f58f0/go.mod h1:oT9CqPokoWAc+VUWl9/hGlsSTg51P7+I4tQL4M8zCRI=
 github.com/juju/qthttptest v0.0.1/go.mod h1://LCf/Ls22/rPw2u1yWukUJvYtfPY4nYpWUl2uZhryo=
 github.com/juju/qthttptest v0.1.1 h1:JPju5P5CDMCy8jmBJV2wGLjDItUsx2KKL514EfOYueM=
 github.com/juju/qthttptest v0.1.1/go.mod h1:aTlAv8TYaflIiTDIQYzxnl1QdPjAg8Q8qJMErpKy6A4=


### PR DESCRIPTION
The pubsub library updates to clean up potential runtime errors. Every
so often we can end up with a nil message. Which either means we
dropped a message or we're attempting to process a message that isn't
there. This can lead to issues in people attempting to use the library.

Removing the complexity of knowing when to request the next message. It
removes the ambiguity of knowing if you have a next message or not. The
trick of knowing when next is blocking or not is also gone, as we can
use the existing data channel. If that's already full (it's a buffered
channel of 1), then just offer a default case in the select to allow the
bypassing of the blocking operation.

Message pointers in the implementation is gone, you either have a
message or you don't. We no longer need to check for empty. And in
doing so, the implementation iterates all the pending handlers at once,
without checking for data or next each iteration.

The interface is exactly the same, just the underlying queue
implementation.

## QA steps

The tests pass.