### PR TITLE
Fix broken bootstrap on k8s due to misconfigured init container

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -51,7 +51,6 @@ import (
 var logger = loggo.GetLogger("juju.kubernetes.provider.application")
 
 const (
-	unitContainerName            = "charm"
 	charmVolumeName              = "charm-data"
 	agentProbeInitialDelay int32 = 30
 	agentProbePeriod       int32 = 10
@@ -174,7 +173,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 	var handleVolumeMount handleVolumeMountFunc = func(storageName string, m corev1.VolumeMount) error {
 		for i := range podSpec.Containers {
 			name := podSpec.Containers[i].Name
-			if name == unitContainerName {
+			if name == constants.ApplicationCharmContainer {
 				podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, m)
 				continue
 			}
@@ -742,7 +741,7 @@ func (a *app) updateContainerPorts(applier resources.Applier, ports []corev1.Ser
 	updatePodSpec := func(spec *corev1.PodSpec, containerPorts []corev1.ContainerPort) {
 		for i, c := range spec.Containers {
 			ps := containerPorts
-			if c.Name != unitContainerName {
+			if c.Name != constants.ApplicationCharmContainer {
 				spec.Containers[i].Ports = ps
 			}
 		}
@@ -1218,7 +1217,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		})
 	}
 	containerSpecs := []corev1.Container{{
-		Name:            unitContainerName,
+		Name:            constants.ApplicationCharmContainer,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Image:           config.CharmBaseImagePath,
 		WorkingDir:      jujuDataDir,
@@ -1349,7 +1348,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		ServiceAccountName:           a.serviceAccountName(),
 		ImagePullSecrets:             imagePullSecrets,
 		InitContainers: []corev1.Container{{
-			Name:            "charm-init",
+			Name:            constants.ApplicationInitContainer,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Image:           config.AgentImagePath,
 			WorkingDir:      jujuDataDir,

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -893,6 +893,11 @@ JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujud machine --data-dir $
 				MountPath: "/charm/containers",
 				SubPath:   "charm/containers",
 			},
+			{
+				Name:      "juju-controller-test-agent-conf",
+				MountPath: "/var/lib/juju/template-agent.conf",
+				SubPath:   "controller-unit-agent.conf",
+			},
 		},
 	}}
 

--- a/caas/kubernetes/provider/constants/env.go
+++ b/caas/kubernetes/provider/constants/env.go
@@ -9,4 +9,9 @@ const (
 	EnvJujuK8sPodName      = "JUJU_K8S_POD_NAME"
 	EnvJujuK8sPodUUID      = "JUJU_K8S_POD_UUID"
 	EnvJujuK8sUnitPassword = "JUJU_K8S_UNIT_PASSWORD"
+
+	// ApplicationInitContainer is the init container which sets up the charm agent config.
+	ApplicationInitContainer = "charm-init"
+	// ApplicationCharmContainer is the container which runs the unit agent.
+	ApplicationCharmContainer = "charm"
 )


### PR DESCRIPTION
When setting up the controller pod at bootstrap, the `charm-init` container needs to have the agent config file as a volume mount; this was missing.

## QA steps

juju bootstrap microk8s
juju status
