### PR TITLE
[JUJU-358] Add explicit owner to params when creating an offer

### DIFF
--- a/api/applicationoffers/client.go
+++ b/api/applicationoffers/client.go
@@ -32,7 +32,7 @@ func NewClient(st base.APICallCloser) *Client {
 }
 
 // Offer prepares application's endpoints for consumption.
-func (c *Client) Offer(modelUUID, application string, endpoints []string, offerName string, desc string) ([]params.ErrorResult, error) {
+func (c *Client) Offer(modelUUID, application string, endpoints []string, owner, offerName, desc string) ([]params.ErrorResult, error) {
 	// TODO(wallyworld) - support endpoint aliases
 	ep := make(map[string]string)
 	for _, name := range endpoints {
@@ -45,6 +45,7 @@ func (c *Client) Offer(modelUUID, application string, endpoints []string, offerN
 			ApplicationDescription: desc,
 			Endpoints:              ep,
 			OfferName:              offerName,
+			OwnerTag:               names.NewUserTag(owner).String(),
 		},
 	}
 	out := params.ErrorResults{}

--- a/api/applicationoffers/client_test.go
+++ b/api/applicationoffers/client_test.go
@@ -33,6 +33,7 @@ func (s *crossmodelMockSuite) TestOffer(c *gc.C) {
 	endPointB := "endPointB"
 	offer := "offer"
 	desc := "desc"
+	owner := "fred"
 
 	msg := "fail"
 	apiCaller := basetesting.APICallerFunc(
@@ -54,6 +55,7 @@ func (s *crossmodelMockSuite) TestOffer(c *gc.C) {
 			c.Assert(offer.ApplicationName, gc.Equals, application)
 			c.Assert(offer.Endpoints, jc.DeepEquals, map[string]string{endPointA: endPointA, endPointB: endPointB})
 			c.Assert(offer.OfferName, gc.Equals, offer.OfferName)
+			c.Assert(offer.OwnerTag, gc.Equals, "user-"+owner)
 			c.Assert(offer.ApplicationDescription, gc.Equals, desc)
 
 			if results, ok := result.(*params.ErrorResults); ok {
@@ -68,7 +70,7 @@ func (s *crossmodelMockSuite) TestOffer(c *gc.C) {
 		})
 
 	client := applicationoffers.NewClient(apiCaller)
-	results, err := client.Offer("uuid", application, []string{endPointA, endPointB}, offer, desc)
+	results, err := client.Offer("uuid", application, []string{endPointA, endPointB}, owner, offer, desc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 2)
 	c.Assert(results, jc.DeepEquals,
@@ -93,7 +95,7 @@ func (s *crossmodelMockSuite) TestOfferFacadeCallError(c *gc.C) {
 			return errors.New(msg)
 		})
 	client := applicationoffers.NewClient(apiCaller)
-	results, err := client.Offer("", "", nil, "", "")
+	results, err := client.Offer("", "", nil, "fred", "", "")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 	c.Assert(results, gc.IsNil)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -19,7 +19,7 @@ var facadeVersions = map[string]int{
 	"AllWatcher":                   1,
 	"Annotations":                  2,
 	"Application":                  13,
-	"ApplicationOffers":            3,
+	"ApplicationOffers":            4,
 	"ApplicationScaler":            1,
 	"Backups":                      2,
 	"Block":                        2,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -167,7 +167,8 @@ func AllFacades() *facade.Registry {
 
 	reg("ApplicationOffers", 1, applicationoffers.NewOffersAPI)
 	reg("ApplicationOffers", 2, applicationoffers.NewOffersAPIV2)
-	reg("ApplicationOffers", 3, applicationoffers.NewOffersAPIV3) // Add user to consume offers details  args.
+	reg("ApplicationOffers", 3, applicationoffers.NewOffersAPIV3) // Add user to consume offers details args.
+	reg("ApplicationOffers", 4, applicationoffers.NewOffersAPIV4) // Add user to add offer args.
 	reg("ApplicationScaler", 1, applicationscaler.NewAPI)
 	reg("Backups", 1, backups.NewFacade)
 	reg("Backups", 2, backups.NewFacadeV2)

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -75,13 +75,14 @@ func (s *applicationOffersSuite) assertOffer(c *gc.C, expectedErr error) {
 		OfferName:       "offer-test",
 		ApplicationName: applicationName,
 		Endpoints:       map[string]string{"db": "db"},
+		OwnerTag:        "user-fred",
 	}
 	all := params.AddApplicationOffers{Offers: []params.AddApplicationOffer{one}}
 	s.applicationOffers.addOffer = func(offer jujucrossmodel.AddApplicationOfferArgs) (*jujucrossmodel.ApplicationOffer, error) {
 		c.Assert(offer.OfferName, gc.Equals, one.OfferName)
 		c.Assert(offer.ApplicationName, gc.Equals, one.ApplicationName)
 		c.Assert(offer.ApplicationDescription, gc.Equals, "A pretty popular blog engine")
-		c.Assert(offer.Owner, gc.Equals, "admin")
+		c.Assert(offer.Owner, gc.Equals, "fred")
 		c.Assert(offer.HasRead, gc.DeepEquals, []string{"everyone@external"})
 		return &jujucrossmodel.ApplicationOffer{}, nil
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -4321,8 +4321,8 @@
     },
     {
         "Name": "ApplicationOffers",
-        "Description": "OffersAPIV3 implements the cross model interface V3.",
-        "Version": 3,
+        "Description": "OffersAPIV4 implements the cross model interface V4.",
+        "Version": 4,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -4451,6 +4451,9 @@
                             "type": "string"
                         },
                         "offer-name": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
                             "type": "string"
                         }
                     },

--- a/apiserver/params/crossmodel.go
+++ b/apiserver/params/crossmodel.go
@@ -124,6 +124,7 @@ type AddApplicationOffer struct {
 	ApplicationName        string            `json:"application-name"`
 	ApplicationDescription string            `json:"application-description"`
 	Endpoints              map[string]string `json:"endpoints"`
+	OwnerTag               string            `json:"owner-tag,omitempty"`
 }
 
 // DestroyApplicationOffers holds parameters for the DestroyOffers call.

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -869,6 +869,7 @@ func (s *DeploySuite) TestDeployBundleWithOffers(c *gc.C) {
 		"deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		"apache2",
 		[]string{"apache-website", "website-cache"},
+		"admin",
 		"my-offer",
 		"",
 	).Returns([]params.ErrorResult{}, nil)
@@ -877,6 +878,7 @@ func (s *DeploySuite) TestDeployBundleWithOffers(c *gc.C) {
 		"deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		"apache2",
 		[]string{"apache-website"},
+		"admin",
 		"my-other-offer",
 		"",
 	).Returns([]params.ErrorResult{}, nil)
@@ -2820,8 +2822,8 @@ func (f *fakeDeployAPI) ScaleApplication(p application.ScaleApplicationParams) (
 	}, nil
 }
 
-func (f *fakeDeployAPI) Offer(modelUUID, application string, endpoints []string, offerName, descr string) ([]params.ErrorResult, error) {
-	results := f.MethodCall(f, "Offer", modelUUID, application, endpoints, offerName, descr)
+func (f *fakeDeployAPI) Offer(modelUUID, application string, endpoints []string, owner, offerName, descr string) ([]params.ErrorResult, error) {
+	results := f.MethodCall(f, "Offer", modelUUID, application, endpoints, owner, offerName, descr)
 	return results[0].([]params.ErrorResult), jujutesting.TypeAssertError(results[1])
 }
 

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1418,7 +1418,7 @@ func (h *bundleHandler) createOffer(change *bundlechanges.CreateOfferChange) err
 	}
 
 	p := change.Params
-	result, err := h.deployAPI.Offer(h.targetModelUUID, p.Application, p.Endpoints, p.OfferName, "")
+	result, err := h.deployAPI.Offer(h.targetModelUUID, p.Application, p.Endpoints, h.accountUser, p.OfferName, "")
 	if err == nil && len(result) > 0 && result[0].Error != nil {
 		err = result[0].Error
 	}

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -87,7 +87,7 @@ type CharmDeployAPI interface {
 // OfferAPI represents the methods of the API the deploy command needs
 // for creating offers.
 type OfferAPI interface {
-	Offer(modelUUID, application string, endpoints []string, offerName, descr string) ([]apiparams.ErrorResult, error)
+	Offer(modelUUID, application string, endpoints []string, owner, offerName, descr string) ([]apiparams.ErrorResult, error)
 	GrantOffer(user, access string, offerURLs ...string) error
 }
 

--- a/cmd/juju/application/deployer/mocks/api_mock.go
+++ b/cmd/juju/application/deployer/mocks/api_mock.go
@@ -5,35 +5,36 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
-	reflect "reflect"
 )
 
-// MockAllWatch is a mock of AllWatch interface
+// MockAllWatch is a mock of AllWatch interface.
 type MockAllWatch struct {
 	ctrl     *gomock.Controller
 	recorder *MockAllWatchMockRecorder
 }
 
-// MockAllWatchMockRecorder is the mock recorder for MockAllWatch
+// MockAllWatchMockRecorder is the mock recorder for MockAllWatch.
 type MockAllWatchMockRecorder struct {
 	mock *MockAllWatch
 }
 
-// NewMockAllWatch creates a new mock instance
+// NewMockAllWatch creates a new mock instance.
 func NewMockAllWatch(ctrl *gomock.Controller) *MockAllWatch {
 	mock := &MockAllWatch{ctrl: ctrl}
 	mock.recorder = &MockAllWatchMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAllWatch) EXPECT() *MockAllWatchMockRecorder {
 	return m.recorder
 }
 
-// Next mocks base method
+// Next mocks base method.
 func (m *MockAllWatch) Next() ([]params.Delta, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Next")
@@ -42,13 +43,13 @@ func (m *MockAllWatch) Next() ([]params.Delta, error) {
 	return ret0, ret1
 }
 
-// Next indicates an expected call of Next
+// Next indicates an expected call of Next.
 func (mr *MockAllWatchMockRecorder) Next() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*MockAllWatch)(nil).Next))
 }
 
-// Stop mocks base method
+// Stop mocks base method.
 func (m *MockAllWatch) Stop() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
@@ -56,7 +57,7 @@ func (m *MockAllWatch) Stop() error {
 	return ret0
 }
 
-// Stop indicates an expected call of Stop
+// Stop indicates an expected call of Stop.
 func (mr *MockAllWatchMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockAllWatch)(nil).Stop))

--- a/cmd/juju/application/deployer/mocks/charm_mock.go
+++ b/cmd/juju/application/deployer/mocks/charm_mock.go
@@ -5,35 +5,36 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
-	reflect "reflect"
 )
 
-// MockCharm is a mock of Charm interface
+// MockCharm is a mock of Charm interface.
 type MockCharm struct {
 	ctrl     *gomock.Controller
 	recorder *MockCharmMockRecorder
 }
 
-// MockCharmMockRecorder is the mock recorder for MockCharm
+// MockCharmMockRecorder is the mock recorder for MockCharm.
 type MockCharmMockRecorder struct {
 	mock *MockCharm
 }
 
-// NewMockCharm creates a new mock instance
+// NewMockCharm creates a new mock instance.
 func NewMockCharm(ctrl *gomock.Controller) *MockCharm {
 	mock := &MockCharm{ctrl: ctrl}
 	mock.recorder = &MockCharmMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 	return m.recorder
 }
 
-// Actions mocks base method
+// Actions mocks base method.
 func (m *MockCharm) Actions() *charm.Actions {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Actions")
@@ -41,13 +42,13 @@ func (m *MockCharm) Actions() *charm.Actions {
 	return ret0
 }
 
-// Actions indicates an expected call of Actions
+// Actions indicates an expected call of Actions.
 func (mr *MockCharmMockRecorder) Actions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Actions", reflect.TypeOf((*MockCharm)(nil).Actions))
 }
 
-// Config mocks base method
+// Config mocks base method.
 func (m *MockCharm) Config() *charm.Config {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Config")
@@ -55,13 +56,13 @@ func (m *MockCharm) Config() *charm.Config {
 	return ret0
 }
 
-// Config indicates an expected call of Config
+// Config indicates an expected call of Config.
 func (mr *MockCharmMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockCharm)(nil).Config))
 }
 
-// Manifest mocks base method
+// Manifest mocks base method.
 func (m *MockCharm) Manifest() *charm.Manifest {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Manifest")
@@ -69,13 +70,13 @@ func (m *MockCharm) Manifest() *charm.Manifest {
 	return ret0
 }
 
-// Manifest indicates an expected call of Manifest
+// Manifest indicates an expected call of Manifest.
 func (mr *MockCharmMockRecorder) Manifest() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Manifest", reflect.TypeOf((*MockCharm)(nil).Manifest))
 }
 
-// Meta mocks base method
+// Meta mocks base method.
 func (m *MockCharm) Meta() *charm.Meta {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Meta")
@@ -83,13 +84,13 @@ func (m *MockCharm) Meta() *charm.Meta {
 	return ret0
 }
 
-// Meta indicates an expected call of Meta
+// Meta indicates an expected call of Meta.
 func (mr *MockCharmMockRecorder) Meta() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Meta", reflect.TypeOf((*MockCharm)(nil).Meta))
 }
 
-// Metrics mocks base method
+// Metrics mocks base method.
 func (m *MockCharm) Metrics() *charm.Metrics {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Metrics")
@@ -97,13 +98,13 @@ func (m *MockCharm) Metrics() *charm.Metrics {
 	return ret0
 }
 
-// Metrics indicates an expected call of Metrics
+// Metrics indicates an expected call of Metrics.
 func (mr *MockCharmMockRecorder) Metrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockCharm)(nil).Metrics))
 }
 
-// Revision mocks base method
+// Revision mocks base method.
 func (m *MockCharm) Revision() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revision")
@@ -111,7 +112,7 @@ func (m *MockCharm) Revision() int {
 	return ret0
 }
 
-// Revision indicates an expected call of Revision
+// Revision indicates an expected call of Revision.
 func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -506,18 +506,18 @@ func (mr *MockDeployerAPIMockRecorder) ModelUUID() *gomock.Call {
 }
 
 // Offer mocks base method.
-func (m *MockDeployerAPI) Offer(arg0, arg1 string, arg2 []string, arg3, arg4 string) ([]params.ErrorResult, error) {
+func (m *MockDeployerAPI) Offer(arg0, arg1 string, arg2 []string, arg3, arg4, arg5 string) ([]params.ErrorResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Offer", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Offer", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].([]params.ErrorResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Offer indicates an expected call of Offer.
-func (mr *MockDeployerAPIMockRecorder) Offer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockDeployerAPIMockRecorder) Offer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Offer", reflect.TypeOf((*MockDeployerAPI)(nil).Offer), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Offer", reflect.TypeOf((*MockDeployerAPI)(nil).Offer), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // ScaleApplication mocks base method.

--- a/cmd/juju/application/deployer/mocks/deployer_mock.go
+++ b/cmd/juju/application/deployer/mocks/deployer_mock.go
@@ -5,39 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	httpbakery "github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	gomock "github.com/golang/mock/gomock"
 	params "github.com/juju/juju/apiserver/params"
 	modelcmd "github.com/juju/juju/cmd/modelcmd"
 	model "github.com/juju/juju/core/model"
 	jujuclient "github.com/juju/juju/jujuclient"
-	reflect "reflect"
 )
 
-// MockModelCommand is a mock of ModelCommand interface
+// MockModelCommand is a mock of ModelCommand interface.
 type MockModelCommand struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelCommandMockRecorder
 }
 
-// MockModelCommandMockRecorder is the mock recorder for MockModelCommand
+// MockModelCommandMockRecorder is the mock recorder for MockModelCommand.
 type MockModelCommandMockRecorder struct {
 	mock *MockModelCommand
 }
 
-// NewMockModelCommand creates a new mock instance
+// NewMockModelCommand creates a new mock instance.
 func NewMockModelCommand(ctrl *gomock.Controller) *MockModelCommand {
 	mock := &MockModelCommand{ctrl: ctrl}
 	mock.recorder = &MockModelCommandMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModelCommand) EXPECT() *MockModelCommandMockRecorder {
 	return m.recorder
 }
 
-// BakeryClient mocks base method
+// BakeryClient mocks base method.
 func (m *MockModelCommand) BakeryClient() (*httpbakery.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BakeryClient")
@@ -46,13 +47,13 @@ func (m *MockModelCommand) BakeryClient() (*httpbakery.Client, error) {
 	return ret0, ret1
 }
 
-// BakeryClient indicates an expected call of BakeryClient
+// BakeryClient indicates an expected call of BakeryClient.
 func (mr *MockModelCommandMockRecorder) BakeryClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BakeryClient", reflect.TypeOf((*MockModelCommand)(nil).BakeryClient))
 }
 
-// ControllerName mocks base method
+// ControllerName mocks base method.
 func (m *MockModelCommand) ControllerName() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ControllerName")
@@ -61,13 +62,13 @@ func (m *MockModelCommand) ControllerName() (string, error) {
 	return ret0, ret1
 }
 
-// ControllerName indicates an expected call of ControllerName
+// ControllerName indicates an expected call of ControllerName.
 func (mr *MockModelCommandMockRecorder) ControllerName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerName", reflect.TypeOf((*MockModelCommand)(nil).ControllerName))
 }
 
-// CurrentAccountDetails mocks base method
+// CurrentAccountDetails mocks base method.
 func (m *MockModelCommand) CurrentAccountDetails() (*jujuclient.AccountDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CurrentAccountDetails")
@@ -76,13 +77,13 @@ func (m *MockModelCommand) CurrentAccountDetails() (*jujuclient.AccountDetails, 
 	return ret0, ret1
 }
 
-// CurrentAccountDetails indicates an expected call of CurrentAccountDetails
+// CurrentAccountDetails indicates an expected call of CurrentAccountDetails.
 func (mr *MockModelCommandMockRecorder) CurrentAccountDetails() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentAccountDetails", reflect.TypeOf((*MockModelCommand)(nil).CurrentAccountDetails))
 }
 
-// Filesystem mocks base method
+// Filesystem mocks base method.
 func (m *MockModelCommand) Filesystem() modelcmd.Filesystem {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Filesystem")
@@ -90,13 +91,13 @@ func (m *MockModelCommand) Filesystem() modelcmd.Filesystem {
 	return ret0
 }
 
-// Filesystem indicates an expected call of Filesystem
+// Filesystem indicates an expected call of Filesystem.
 func (mr *MockModelCommandMockRecorder) Filesystem() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Filesystem", reflect.TypeOf((*MockModelCommand)(nil).Filesystem))
 }
 
-// ModelDetails mocks base method
+// ModelDetails mocks base method.
 func (m *MockModelCommand) ModelDetails() (string, *jujuclient.ModelDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelDetails")
@@ -106,13 +107,13 @@ func (m *MockModelCommand) ModelDetails() (string, *jujuclient.ModelDetails, err
 	return ret0, ret1, ret2
 }
 
-// ModelDetails indicates an expected call of ModelDetails
+// ModelDetails indicates an expected call of ModelDetails.
 func (mr *MockModelCommandMockRecorder) ModelDetails() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelDetails", reflect.TypeOf((*MockModelCommand)(nil).ModelDetails))
 }
 
-// ModelType mocks base method
+// ModelType mocks base method.
 func (m *MockModelCommand) ModelType() (model.ModelType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelType")
@@ -121,36 +122,36 @@ func (m *MockModelCommand) ModelType() (model.ModelType, error) {
 	return ret0, ret1
 }
 
-// ModelType indicates an expected call of ModelType
+// ModelType indicates an expected call of ModelType.
 func (mr *MockModelCommandMockRecorder) ModelType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelType", reflect.TypeOf((*MockModelCommand)(nil).ModelType))
 }
 
-// MockConsumeDetails is a mock of ConsumeDetails interface
+// MockConsumeDetails is a mock of ConsumeDetails interface.
 type MockConsumeDetails struct {
 	ctrl     *gomock.Controller
 	recorder *MockConsumeDetailsMockRecorder
 }
 
-// MockConsumeDetailsMockRecorder is the mock recorder for MockConsumeDetails
+// MockConsumeDetailsMockRecorder is the mock recorder for MockConsumeDetails.
 type MockConsumeDetailsMockRecorder struct {
 	mock *MockConsumeDetails
 }
 
-// NewMockConsumeDetails creates a new mock instance
+// NewMockConsumeDetails creates a new mock instance.
 func NewMockConsumeDetails(ctrl *gomock.Controller) *MockConsumeDetails {
 	mock := &MockConsumeDetails{ctrl: ctrl}
 	mock.recorder = &MockConsumeDetailsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConsumeDetails) EXPECT() *MockConsumeDetailsMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockConsumeDetails) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -158,13 +159,13 @@ func (m *MockConsumeDetails) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockConsumeDetailsMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConsumeDetails)(nil).Close))
 }
 
-// GetConsumeDetails mocks base method
+// GetConsumeDetails mocks base method.
 func (m *MockConsumeDetails) GetConsumeDetails(arg0 string) (params.ConsumeOfferDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConsumeDetails", arg0)
@@ -173,36 +174,36 @@ func (m *MockConsumeDetails) GetConsumeDetails(arg0 string) (params.ConsumeOffer
 	return ret0, ret1
 }
 
-// GetConsumeDetails indicates an expected call of GetConsumeDetails
+// GetConsumeDetails indicates an expected call of GetConsumeDetails.
 func (mr *MockConsumeDetailsMockRecorder) GetConsumeDetails(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumeDetails", reflect.TypeOf((*MockConsumeDetails)(nil).GetConsumeDetails), arg0)
 }
 
-// MockModelConfigGetter is a mock of ModelConfigGetter interface
+// MockModelConfigGetter is a mock of ModelConfigGetter interface.
 type MockModelConfigGetter struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelConfigGetterMockRecorder
 }
 
-// MockModelConfigGetterMockRecorder is the mock recorder for MockModelConfigGetter
+// MockModelConfigGetterMockRecorder is the mock recorder for MockModelConfigGetter.
 type MockModelConfigGetterMockRecorder struct {
 	mock *MockModelConfigGetter
 }
 
-// NewMockModelConfigGetter creates a new mock instance
+// NewMockModelConfigGetter creates a new mock instance.
 func NewMockModelConfigGetter(ctrl *gomock.Controller) *MockModelConfigGetter {
 	mock := &MockModelConfigGetter{ctrl: ctrl}
 	mock.recorder = &MockModelConfigGetterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModelConfigGetter) EXPECT() *MockModelConfigGetterMockRecorder {
 	return m.recorder
 }
 
-// ModelGet mocks base method
+// ModelGet mocks base method.
 func (m *MockModelConfigGetter) ModelGet() (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelGet")
@@ -211,7 +212,7 @@ func (m *MockModelConfigGetter) ModelGet() (map[string]interface{}, error) {
 	return ret0, ret1
 }
 
-// ModelGet indicates an expected call of ModelGet
+// ModelGet indicates an expected call of ModelGet.
 func (mr *MockModelConfigGetterMockRecorder) ModelGet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelGet", reflect.TypeOf((*MockModelConfigGetter)(nil).ModelGet))

--- a/cmd/juju/application/deployer/mocks/modelcmd_mock.go
+++ b/cmd/juju/application/deployer/mocks/modelcmd_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	modelcmd "github.com/juju/juju/cmd/modelcmd"
 	os "os"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	modelcmd "github.com/juju/juju/cmd/modelcmd"
 )
 
-// MockFilesystem is a mock of Filesystem interface
+// MockFilesystem is a mock of Filesystem interface.
 type MockFilesystem struct {
 	ctrl     *gomock.Controller
 	recorder *MockFilesystemMockRecorder
 }
 
-// MockFilesystemMockRecorder is the mock recorder for MockFilesystem
+// MockFilesystemMockRecorder is the mock recorder for MockFilesystem.
 type MockFilesystemMockRecorder struct {
 	mock *MockFilesystem
 }
 
-// NewMockFilesystem creates a new mock instance
+// NewMockFilesystem creates a new mock instance.
 func NewMockFilesystem(ctrl *gomock.Controller) *MockFilesystem {
 	mock := &MockFilesystem{ctrl: ctrl}
 	mock.recorder = &MockFilesystemMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFilesystem) EXPECT() *MockFilesystemMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockFilesystem) Create(arg0 string) (*os.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0)
@@ -43,13 +44,13 @@ func (m *MockFilesystem) Create(arg0 string) (*os.File, error) {
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockFilesystemMockRecorder) Create(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFilesystem)(nil).Create), arg0)
 }
 
-// Open mocks base method
+// Open mocks base method.
 func (m *MockFilesystem) Open(arg0 string) (modelcmd.ReadSeekCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", arg0)
@@ -58,13 +59,13 @@ func (m *MockFilesystem) Open(arg0 string) (modelcmd.ReadSeekCloser, error) {
 	return ret0, ret1
 }
 
-// Open indicates an expected call of Open
+// Open indicates an expected call of Open.
 func (mr *MockFilesystemMockRecorder) Open(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockFilesystem)(nil).Open), arg0)
 }
 
-// OpenFile mocks base method
+// OpenFile mocks base method.
 func (m *MockFilesystem) OpenFile(arg0 string, arg1 int, arg2 os.FileMode) (*os.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenFile", arg0, arg1, arg2)
@@ -73,13 +74,13 @@ func (m *MockFilesystem) OpenFile(arg0 string, arg1 int, arg2 os.FileMode) (*os.
 	return ret0, ret1
 }
 
-// OpenFile indicates an expected call of OpenFile
+// OpenFile indicates an expected call of OpenFile.
 func (mr *MockFilesystemMockRecorder) OpenFile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenFile", reflect.TypeOf((*MockFilesystem)(nil).OpenFile), arg0, arg1, arg2)
 }
 
-// RemoveAll mocks base method
+// RemoveAll mocks base method.
 func (m *MockFilesystem) RemoveAll(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveAll", arg0)
@@ -87,13 +88,13 @@ func (m *MockFilesystem) RemoveAll(arg0 string) error {
 	return ret0
 }
 
-// RemoveAll indicates an expected call of RemoveAll
+// RemoveAll indicates an expected call of RemoveAll.
 func (mr *MockFilesystemMockRecorder) RemoveAll(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockFilesystem)(nil).RemoveAll), arg0)
 }
 
-// Stat mocks base method
+// Stat mocks base method.
 func (m *MockFilesystem) Stat(arg0 string) (os.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", arg0)
@@ -102,7 +103,7 @@ func (m *MockFilesystem) Stat(arg0 string) (os.FileInfo, error) {
 	return ret0, ret1
 }
 
-// Stat indicates an expected call of Stat
+// Stat indicates an expected call of Stat.
 func (mr *MockFilesystemMockRecorder) Stat(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockFilesystem)(nil).Stat), arg0)

--- a/cmd/juju/application/deployer/mocks/resolver_mock.go
+++ b/cmd/juju/application/deployer/mocks/resolver_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	charm0 "github.com/juju/juju/api/common/charm"
-	reflect "reflect"
 )
 
-// MockResolver is a mock of Resolver interface
+// MockResolver is a mock of Resolver interface.
 type MockResolver struct {
 	ctrl     *gomock.Controller
 	recorder *MockResolverMockRecorder
 }
 
-// MockResolverMockRecorder is the mock recorder for MockResolver
+// MockResolverMockRecorder is the mock recorder for MockResolver.
 type MockResolverMockRecorder struct {
 	mock *MockResolver
 }
 
-// NewMockResolver creates a new mock instance
+// NewMockResolver creates a new mock instance.
 func NewMockResolver(ctrl *gomock.Controller) *MockResolver {
 	mock := &MockResolver{ctrl: ctrl}
 	mock.recorder = &MockResolverMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResolver) EXPECT() *MockResolverMockRecorder {
 	return m.recorder
 }
 
-// GetBundle mocks base method
+// GetBundle mocks base method.
 func (m *MockResolver) GetBundle(arg0 *charm.URL, arg1 charm0.Origin, arg2 string) (charm.Bundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBundle", arg0, arg1, arg2)
@@ -43,13 +44,13 @@ func (m *MockResolver) GetBundle(arg0 *charm.URL, arg1 charm0.Origin, arg2 strin
 	return ret0, ret1
 }
 
-// GetBundle indicates an expected call of GetBundle
+// GetBundle indicates an expected call of GetBundle.
 func (mr *MockResolverMockRecorder) GetBundle(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundle", reflect.TypeOf((*MockResolver)(nil).GetBundle), arg0, arg1, arg2)
 }
 
-// ResolveBundleURL mocks base method
+// ResolveBundleURL mocks base method.
 func (m *MockResolver) ResolveBundleURL(arg0 *charm.URL, arg1 charm0.Origin) (*charm.URL, charm0.Origin, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveBundleURL", arg0, arg1)
@@ -59,13 +60,13 @@ func (m *MockResolver) ResolveBundleURL(arg0 *charm.URL, arg1 charm0.Origin) (*c
 	return ret0, ret1, ret2
 }
 
-// ResolveBundleURL indicates an expected call of ResolveBundleURL
+// ResolveBundleURL indicates an expected call of ResolveBundleURL.
 func (mr *MockResolverMockRecorder) ResolveBundleURL(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBundleURL", reflect.TypeOf((*MockResolver)(nil).ResolveBundleURL), arg0, arg1)
 }
 
-// ResolveCharm mocks base method
+// ResolveCharm mocks base method.
 func (m *MockResolver) ResolveCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bool) (*charm.URL, charm0.Origin, []string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveCharm", arg0, arg1, arg2)
@@ -76,36 +77,36 @@ func (m *MockResolver) ResolveCharm(arg0 *charm.URL, arg1 charm0.Origin, arg2 bo
 	return ret0, ret1, ret2, ret3
 }
 
-// ResolveCharm indicates an expected call of ResolveCharm
+// ResolveCharm indicates an expected call of ResolveCharm.
 func (mr *MockResolverMockRecorder) ResolveCharm(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveCharm", reflect.TypeOf((*MockResolver)(nil).ResolveCharm), arg0, arg1, arg2)
 }
 
-// MockBundle is a mock of Bundle interface
+// MockBundle is a mock of Bundle interface.
 type MockBundle struct {
 	ctrl     *gomock.Controller
 	recorder *MockBundleMockRecorder
 }
 
-// MockBundleMockRecorder is the mock recorder for MockBundle
+// MockBundleMockRecorder is the mock recorder for MockBundle.
 type MockBundleMockRecorder struct {
 	mock *MockBundle
 }
 
-// NewMockBundle creates a new mock instance
+// NewMockBundle creates a new mock instance.
 func NewMockBundle(ctrl *gomock.Controller) *MockBundle {
 	mock := &MockBundle{ctrl: ctrl}
 	mock.recorder = &MockBundleMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBundle) EXPECT() *MockBundleMockRecorder {
 	return m.recorder
 }
 
-// ContainsOverlays mocks base method
+// ContainsOverlays mocks base method.
 func (m *MockBundle) ContainsOverlays() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainsOverlays")
@@ -113,13 +114,13 @@ func (m *MockBundle) ContainsOverlays() bool {
 	return ret0
 }
 
-// ContainsOverlays indicates an expected call of ContainsOverlays
+// ContainsOverlays indicates an expected call of ContainsOverlays.
 func (mr *MockBundleMockRecorder) ContainsOverlays() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsOverlays", reflect.TypeOf((*MockBundle)(nil).ContainsOverlays))
 }
 
-// Data mocks base method
+// Data mocks base method.
 func (m *MockBundle) Data() *charm.BundleData {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Data")
@@ -127,13 +128,13 @@ func (m *MockBundle) Data() *charm.BundleData {
 	return ret0
 }
 
-// Data indicates an expected call of Data
+// Data indicates an expected call of Data.
 func (mr *MockBundleMockRecorder) Data() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Data", reflect.TypeOf((*MockBundle)(nil).Data))
 }
 
-// ReadMe mocks base method
+// ReadMe mocks base method.
 func (m *MockBundle) ReadMe() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadMe")
@@ -141,7 +142,7 @@ func (m *MockBundle) ReadMe() string {
 	return ret0
 }
 
-// ReadMe indicates an expected call of ReadMe
+// ReadMe indicates an expected call of ReadMe.
 func (mr *MockBundleMockRecorder) ReadMe() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadMe", reflect.TypeOf((*MockBundle)(nil).ReadMe))

--- a/cmd/juju/application/deployer/mocks/store_mock.go
+++ b/cmd/juju/application/deployer/mocks/store_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	params "github.com/juju/charmrepo/v6/csclient/params"
-	reflect "reflect"
 )
 
-// MockCharmrepoForDeploy is a mock of CharmrepoForDeploy interface
+// MockCharmrepoForDeploy is a mock of CharmrepoForDeploy interface.
 type MockCharmrepoForDeploy struct {
 	ctrl     *gomock.Controller
 	recorder *MockCharmrepoForDeployMockRecorder
 }
 
-// MockCharmrepoForDeployMockRecorder is the mock recorder for MockCharmrepoForDeploy
+// MockCharmrepoForDeployMockRecorder is the mock recorder for MockCharmrepoForDeploy.
 type MockCharmrepoForDeployMockRecorder struct {
 	mock *MockCharmrepoForDeploy
 }
 
-// NewMockCharmrepoForDeploy creates a new mock instance
+// NewMockCharmrepoForDeploy creates a new mock instance.
 func NewMockCharmrepoForDeploy(ctrl *gomock.Controller) *MockCharmrepoForDeploy {
 	mock := &MockCharmrepoForDeploy{ctrl: ctrl}
 	mock.recorder = &MockCharmrepoForDeployMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCharmrepoForDeploy) EXPECT() *MockCharmrepoForDeployMockRecorder {
 	return m.recorder
 }
 
-// GetBundle mocks base method
+// GetBundle mocks base method.
 func (m *MockCharmrepoForDeploy) GetBundle(arg0 *charm.URL, arg1 string) (charm.Bundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBundle", arg0, arg1)
@@ -43,13 +44,13 @@ func (m *MockCharmrepoForDeploy) GetBundle(arg0 *charm.URL, arg1 string) (charm.
 	return ret0, ret1
 }
 
-// GetBundle indicates an expected call of GetBundle
+// GetBundle indicates an expected call of GetBundle.
 func (mr *MockCharmrepoForDeployMockRecorder) GetBundle(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundle", reflect.TypeOf((*MockCharmrepoForDeploy)(nil).GetBundle), arg0, arg1)
 }
 
-// ResolveWithPreferredChannel mocks base method
+// ResolveWithPreferredChannel mocks base method.
 func (m *MockCharmrepoForDeploy) ResolveWithPreferredChannel(arg0 *charm.URL, arg1 params.Channel) (*charm.URL, params.Channel, []string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveWithPreferredChannel", arg0, arg1)
@@ -60,36 +61,36 @@ func (m *MockCharmrepoForDeploy) ResolveWithPreferredChannel(arg0 *charm.URL, ar
 	return ret0, ret1, ret2, ret3
 }
 
-// ResolveWithPreferredChannel indicates an expected call of ResolveWithPreferredChannel
+// ResolveWithPreferredChannel indicates an expected call of ResolveWithPreferredChannel.
 func (mr *MockCharmrepoForDeployMockRecorder) ResolveWithPreferredChannel(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveWithPreferredChannel", reflect.TypeOf((*MockCharmrepoForDeploy)(nil).ResolveWithPreferredChannel), arg0, arg1)
 }
 
-// MockMacaroonGetter is a mock of MacaroonGetter interface
+// MockMacaroonGetter is a mock of MacaroonGetter interface.
 type MockMacaroonGetter struct {
 	ctrl     *gomock.Controller
 	recorder *MockMacaroonGetterMockRecorder
 }
 
-// MockMacaroonGetterMockRecorder is the mock recorder for MockMacaroonGetter
+// MockMacaroonGetterMockRecorder is the mock recorder for MockMacaroonGetter.
 type MockMacaroonGetterMockRecorder struct {
 	mock *MockMacaroonGetter
 }
 
-// NewMockMacaroonGetter creates a new mock instance
+// NewMockMacaroonGetter creates a new mock instance.
 func NewMockMacaroonGetter(ctrl *gomock.Controller) *MockMacaroonGetter {
 	mock := &MockMacaroonGetter{ctrl: ctrl}
 	mock.recorder = &MockMacaroonGetterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMacaroonGetter) EXPECT() *MockMacaroonGetterMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockMacaroonGetter) Get(arg0 string, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
@@ -97,7 +98,7 @@ func (m *MockMacaroonGetter) Get(arg0 string, arg1 interface{}) error {
 	return ret0
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockMacaroonGetterMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockMacaroonGetter)(nil).Get), arg0, arg1)

--- a/cmd/juju/application/deployer/mocks/write_mock.go
+++ b/cmd/juju/application/deployer/mocks/write_mock.go
@@ -5,34 +5,35 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockWriter is a mock of Writer interface
+// MockWriter is a mock of Writer interface.
 type MockWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockWriterMockRecorder
 }
 
-// MockWriterMockRecorder is the mock recorder for MockWriter
+// MockWriterMockRecorder is the mock recorder for MockWriter.
 type MockWriterMockRecorder struct {
 	mock *MockWriter
 }
 
-// NewMockWriter creates a new mock instance
+// NewMockWriter creates a new mock instance.
 func NewMockWriter(ctrl *gomock.Controller) *MockWriter {
 	mock := &MockWriter{ctrl: ctrl}
 	mock.recorder = &MockWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWriter) EXPECT() *MockWriterMockRecorder {
 	return m.recorder
 }
 
-// Write mocks base method
+// Write mocks base method.
 func (m *MockWriter) Write(arg0 []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0)
@@ -41,7 +42,7 @@ func (m *MockWriter) Write(arg0 []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Write indicates an expected call of Write
+// Write indicates an expected call of Write.
 func (mr *MockWriterMockRecorder) Write(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockWriter)(nil).Write), arg0)

--- a/cmd/juju/crossmodel/offer.go
+++ b/cmd/juju/crossmodel/offer.go
@@ -151,8 +151,13 @@ func (c *offerCommand) Run(ctx *cmd.Context) error {
 	if c.OfferName == "" {
 		c.OfferName = c.Application
 	}
+	accountDetails, err := c.CurrentAccountDetails()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	loggedInUser := accountDetails.User
 	// TODO (anastasiamac 2015-11-16) Add a sensible way for user to specify long-ish (at times) description when offering
-	results, err := api.Offer(modelDetails.ModelUUID, c.Application, c.Endpoints, c.OfferName, "")
+	results, err := api.Offer(modelDetails.ModelUUID, c.Application, c.Endpoints, loggedInUser, c.OfferName, "")
 	if err != nil {
 		return err
 	}
@@ -173,7 +178,7 @@ func (c *offerCommand) Run(ctx *cmd.Context) error {
 // OfferAPI defines the API methods that the offer command uses.
 type OfferAPI interface {
 	Close() error
-	Offer(modelUUID, application string, endpoints []string, offerName string, desc string) ([]params.ErrorResult, error)
+	Offer(modelUUID, application string, endpoints []string, owner, offerName, desc string) ([]params.ErrorResult, error)
 }
 
 // applicationParse is used to split an application string

--- a/cmd/juju/crossmodel/offer_test.go
+++ b/cmd/juju/crossmodel/offer_test.go
@@ -133,7 +133,7 @@ func (s *mockOfferAPI) Close() error {
 	return nil
 }
 
-func (s *mockOfferAPI) Offer(modelUUID, application string, endpoints []string, offerName, desc string) ([]params.ErrorResult, error) {
+func (s *mockOfferAPI) Offer(modelUUID, application string, endpoints []string, owner, offerName, desc string) ([]params.ErrorResult, error) {
 	if s.errCall {
 		return nil, errors.New("aborted")
 	}
@@ -141,6 +141,9 @@ func (s *mockOfferAPI) Offer(modelUUID, application string, endpoints []string, 
 	if s.errData {
 		result[0].Error = apiservererrors.ServerError(errors.New("failed"))
 		return result, nil
+	}
+	if owner != "bob" {
+		return nil, errors.Errorf("unexpected offer owner %q", owner)
 	}
 	s.modelUUID = modelUUID
 	if offerName == "" {


### PR DESCRIPTION
The add offer api was using the authenticated user as the owner of the offer. However, this breaks on JAAS where the add api is always called as the admin user, and the offer owner needs to be passed in as a parameter. This PR adds the owner to the add offer params. The Juju client sets the value to the logged in user; JAAS is now able to set the owner to the relevant value also.

## QA steps

bootstrap a 2.9.22 controller
create an offer
consume the offer
repeat with a controller bootstrapped off this PR

## Bug reference

https://bugs.launchpad.net/juju/+bug/1952757
