### PR TITLE
[JUJU-381] Fix test race in RaftLeaseRemoteSuite.TestSetAddress

### DIFF
--- a/api/raftlease/client.go
+++ b/api/raftlease/client.go
@@ -608,9 +608,8 @@ func (r *remote) loop() error {
 func (r *remote) connect() bool {
 	stop := make(chan struct{})
 
-	var info *api.Info
 	r.mutex.Lock()
-	info = r.config.APIInfo
+	info := *r.config.APIInfo
 	r.stopConnecting = stop
 	r.mutex.Unlock()
 
@@ -621,7 +620,7 @@ func (r *remote) connect() bool {
 	_ = retry.Call(retry.CallArgs{
 		Func: func() error {
 			r.config.Logger.Debugf("open api to %v", address)
-			conn, err := api.Open(info, api.DialOpts{
+			conn, err := api.Open(&info, api.DialOpts{
 				DialAddressInterval: 50 * time.Millisecond,
 				Timeout:             10 * time.Minute,
 				RetryDelay:          2 * time.Second,


### PR DESCRIPTION
Fixes a testing race in `github.com/juju/juju/api/raftlease.(*RaftLeaseRemoteSuite).TestSetAddress()`.

See: https://jenkins.juju.canonical.com/job/Unit-RunUnitTests-race-amd64/1050

The logic copies a reference under lock protection and uses it outside of the lock. To fix this we copy the value into a new reference that does not need lock protection.

## QA steps

Run `RaftLeaseRemoteSuite.TestSetAddress` in a loop with the `-race` flag.

## Documentation changes

None.

## Bug reference

N/A
