### PR TITLE
Update to latest version of Pebble

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.9.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20211208232418-4d9bc7c18005
+	github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.0.0-20200316104309-cb8b64719ae3
 	github.com/dnaeon/go-vcr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20211208232418-4d9bc7c18005 h1:gb+1Krh3y40cJdrzzi2WJKuHgIr/q3CGBbGXIEJuQ3g=
-github.com/canonical/pebble v0.0.0-20211208232418-4d9bc7c18005/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
+github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0 h1:Bzr3QOteZ+bPUxFGjgA3jkYnERpeFfbgGaLsH9g7qm8=
+github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
This includes:

* Show process's last output in error msg when service exits quickly:
  https://github.com/canonical/pebble/pull/69
* Fix subtle Service merging issues:
  https://github.com/canonical/pebble/pull/98
* Fix bug with replan/start/restart not updating internal config:
  https://github.com/canonical/pebble/pull/96
