### PR TITLE
Remove txn watcher wrench

### DIFF
--- a/state/watcher/logger.go
+++ b/state/watcher/logger.go
@@ -11,6 +11,7 @@ type Logger interface {
 	Infof(format string, values ...interface{})
 	Debugf(format string, values ...interface{})
 	Tracef(format string, values ...interface{})
+	IsTraceEnabled() bool
 }
 
 type noOpLogger struct{}
@@ -20,3 +21,4 @@ func (noOpLogger) Warningf(format string, values ...interface{})  {}
 func (noOpLogger) Infof(format string, values ...interface{})     {}
 func (noOpLogger) Debugf(format string, values ...interface{})    {}
 func (noOpLogger) Tracef(format string, values ...interface{})    {}
+func (noOpLogger) IsTraceEnabled() bool                           { return false }

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -327,11 +327,10 @@ func (w *TxnWatcher) loop() error {
 			logCollection = w.getTxnLogCollection()
 		}
 		added, err := w.sync(logCollection)
-		if wrench.IsActive("txnwatcher", "sync-error") {
+		if w.logger.IsTraceEnabled() && wrench.IsActive("txnwatcher", "sync-error") {
 			added = false
 			err = errors.New("test sync watcher error")
 		}
-
 		if err == nil {
 			if syncRetryCount > 0 {
 				w.logger.Infof("txn sync watcher recovered after %d retries", syncRetryCount)


### PR DESCRIPTION
The following removes the txn watcher wrench. It calls too frequently in
production applications. This removes it completely, but I'm not averse
to either creating a controller/model config for enabling wrenches
(calling wrench.SetEnable method), similar to the setup for logging
config. Alternatively, just throttling the existence of the wench every
minute or so.

Either way, we just need to back off calling this.

@wallyworld thoughts?

## QA steps

Test pass.