### PR TITLE
[JUJU-388] Ensure 'hostname -f' returns juju-assigned hostname on equinix metal …

### DIFF
--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -311,6 +311,16 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		)
 	}
 
+	// NOTE(achilleasa): ensure that /etc/hosts entry for the loopback dev
+	// references the juju-assigned hostname before localhost. Otherwise,
+	// running 'hostname -f' would return localhost whereas 'hostname'
+	// returns the juju-assigned host (see LP1956538).
+	if _, err := series.UbuntuSeriesVersion(args.InstanceConfig.Series); err == nil {
+		cloudCfg.AddScripts(
+			`sed -i -e "/127\.0\.0\.1/c\127\.0\.0\.1 $(hostname) localhost" /etc/hosts`,
+		)
+	}
+
 	// NOTE(achilleasa): The following script applies a set of equinix-specific
 	// networking fixes:
 	//


### PR DESCRIPTION
This PR ensures that running `hostname -f` on nodes that juju provisions on equinix metal always yields the juju-assigned hostname instead of localhost.

## QA steps

```sh
$ juju bootstrap equinix/da test-equinix-am --no-gui --bootstrap-constraints instance-type=c3.small.x86
$ juju switch controller
$ juju ssh 0

# Ensure that hostname and hostname -f always returns the juju-assigned hostname instead of localhost
$ hostname
juju-....
$ hostname -f
juju-...
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1956538