### PR TITLE
The interactive version command doesn't need a controller

### DIFF
--- a/cmd/juju/commands/repl.go
+++ b/cmd/juju/commands/repl.go
@@ -46,7 +46,7 @@ Type "q" or ^D or ^C to quit.
 
 var (
 	quitCommands         = set.NewStrings("q", "quit", "exit")
-	noControllerCommands = set.NewStrings("help", "bootstrap", "register")
+	noControllerCommands = set.NewStrings("help", "bootstrap", "register", "version")
 )
 
 const (


### PR DESCRIPTION
When using juju interactively, the version command should not require a controller.

## QA steps

Start the repl by running "juju".
Then type "version".

## Bug reference

https://bugs.launchpad.net/juju/+bug/1951119
