### PR TITLE
[JUJU-335] Expand functionality of ProviderAddress

### DIFF
--- a/core/network/address.go
+++ b/core/network/address.go
@@ -404,8 +404,24 @@ func isIPv6UniqueLocalAddress(addrType AddressType, ip net.IP) bool {
 // address resides.
 type ProviderAddress struct {
 	MachineAddress
-	SpaceName       SpaceName
+
+	// SpaceName is the space in which this address resides
+	SpaceName SpaceName
+
+	// ProviderSpaceID is the provider's ID for the space this address is in
 	ProviderSpaceID Id
+
+	// ProviderID is the ID of this address's provider
+	ProviderID Id
+
+	// ProviderSubnetID is the provider's ID for the subnet this address is in
+	ProviderSubnetID Id
+
+	// ProviderVLANID is the provider's ID for the VLAN this address is in
+	ProviderVLANID Id
+
+	// VLANTag is the tag associated with this address's VLAN
+	VLANTag int
 }
 
 // GoString implements fmt.GoStringer.

--- a/core/network/address_options.go
+++ b/core/network/address_options.go
@@ -77,7 +77,23 @@ func WithConfigType(configType AddressConfigType) func(AddressMutator) {
 type ProviderAddressMutator interface {
 	AddressMutator
 
+	// SetSpaceName sets the SpaceName property of the provider address
 	SetSpaceName(string)
+
+	// SetProviderSpaceID sets the ProviderSpaceID property of the provider address
+	SetProviderSpaceID(Id)
+
+	// SetProviderID sets the ProviderID property of the provider address
+	SetProviderID(Id)
+
+	// SetProviderSubnetID sets the ProviderSubnetID property of the provider address
+	SetProviderSubnetID(Id)
+
+	// SetProviderVLANID sets the ProviderVLANID property of the provider address
+	SetProviderVLANID(Id)
+
+	// SetVLANTag sets the VLANTag property of the provider address
+	SetVLANTag(int)
 }
 
 // SetSpaceName (ProviderAddressMutator) sets the input
@@ -86,10 +102,80 @@ func (a *ProviderAddress) SetSpaceName(spaceName string) {
 	a.SpaceName = SpaceName(spaceName)
 }
 
+// SetProviderSpaceID (ProviderAddressMutator) sets the input
+// provider space id on the provider address receiver
+func (a *ProviderAddress) SetProviderSpaceID(id Id) {
+	a.ProviderSpaceID = id
+}
+
+// SetProviderID (ProviderAddressMutator) sets the input
+// provider id on the provider address receiver
+func (a *ProviderAddress) SetProviderID(id Id) {
+	a.ProviderID = id
+}
+
+// SetProviderSubnetID (ProviderAddressMutator) sets the input
+// provider subnet id on the provider addrerss reviever
+func (a *ProviderAddress) SetProviderSubnetID(id Id) {
+	a.ProviderSubnetID = id
+}
+
+// SetProviderVLANID (ProviderAddressMutator) sets the input
+// provider VLAN id on the provider addrerss reviever
+func (a *ProviderAddress) SetProviderVLANID(id Id) {
+	a.ProviderVLANID = id
+}
+
+// SetVLANTag (ProviderAddressMutator) sets the input
+// VLAN tag on the provider addrerss reviever
+func (a *ProviderAddress) SetVLANTag(tag int) {
+	a.VLANTag = tag
+}
+
 // WithSpaceName returns a functional option that can
 // be used to set the input space name on a provider address.
 func WithSpaceName(space string) func(ProviderAddressMutator) {
 	return func(a ProviderAddressMutator) {
 		a.SetSpaceName(space)
+	}
+}
+
+// WithProviderSpaceID returns a functional option that can
+// be used to set the input provider space id on a provider address
+func WithProviderSpaceID(id Id) func(ProviderAddressMutator) {
+	return func(a ProviderAddressMutator) {
+		a.SetProviderSpaceID(id)
+	}
+}
+
+// WithProviderID returns a functional option that can
+// be used to set the input provider id on a provider address
+func WithProviderID(id Id) func(ProviderAddressMutator) {
+	return func(a ProviderAddressMutator) {
+		a.SetProviderID(id)
+	}
+}
+
+// WithProviderSubnetID returns a functional option that can
+// be used to set the input provider subnet id on a provider address
+func WithProviderSubnetID(id Id) func(ProviderAddressMutator) {
+	return func(a ProviderAddressMutator) {
+		a.SetProviderSubnetID(id)
+	}
+}
+
+// WithProviderVLANID returns a functional option that can
+// be used to set the input provider VLAN id on a provider address
+func WithProviderVLANID(id Id) func(ProviderAddressMutator) {
+	return func(a ProviderAddressMutator) {
+		a.SetProviderVLANID(id)
+	}
+}
+
+// WithVLANTag returns a functional option that can
+// be used to set the input VLAN tag on a provider address
+func WithVLANTag(tag int) func(ProviderAddressMutator) {
+	return func(a ProviderAddressMutator) {
+		a.SetVLANTag(tag)
 	}
 }

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -122,15 +122,29 @@ func (s *AddressSuite) TestNewScopedAddressIPv6(c *gc.C) {
 }
 
 func (s *AddressSuite) TestAsProviderAddress(c *gc.C) {
-	addr1 := network.NewMachineAddress("0.1.2.3").AsProviderAddress(network.WithSpaceName("foo"))
-	addr2 := network.NewMachineAddress("2001:db8::123").AsProviderAddress(network.WithSpaceName(""))
+	addr1 := network.NewMachineAddress("0.1.2.3").AsProviderAddress(
+		network.WithSpaceName("foo"),
+		network.WithProviderSpaceID("3"),
+		network.WithProviderID("523"),
+		network.WithProviderSubnetID("5"),
+		network.WithProviderVLANID("5001"),
+		network.WithVLANTag(50),
+	)
+	addr2 := network.NewMachineAddress("2001:db8::123").AsProviderAddress(
+		network.WithSpaceName(""),
+	)
 	c.Check(addr1, jc.DeepEquals, network.ProviderAddress{
 		MachineAddress: network.MachineAddress{
 			Value: "0.1.2.3",
 			Type:  "ipv4",
 			Scope: "public",
 		},
-		SpaceName: "foo",
+		SpaceName:        "foo",
+		ProviderSpaceID:  "3",
+		ProviderID:       "523",
+		ProviderSubnetID: "5",
+		ProviderVLANID:   "5001",
+		VLANTag:          50,
 	})
 	c.Check(addr2, jc.DeepEquals, network.ProviderAddress{
 		MachineAddress: network.MachineAddress{
@@ -143,21 +157,35 @@ func (s *AddressSuite) TestAsProviderAddress(c *gc.C) {
 }
 
 func (s *AddressSuite) TestAsProviderAddresses(c *gc.C) {
-	addrs := network.NewMachineAddresses([]string{"0.2.3.4", "fc00::1"}).AsProviderAddresses(network.WithSpaceName("bar"))
+	addrs := network.NewMachineAddresses([]string{"0.2.3.4", "fc00::1"}).AsProviderAddresses(
+		network.WithSpaceName("bar"),
+		network.WithProviderSpaceID("4"),
+		network.WithProviderSubnetID("6"),
+		network.WithProviderVLANID("5002"),
+		network.WithVLANTag(100),
+	)
 	c.Check(addrs, jc.DeepEquals, network.ProviderAddresses{{
 		MachineAddress: network.MachineAddress{
 			Value: "0.2.3.4",
 			Type:  "ipv4",
 			Scope: "public",
 		},
-		SpaceName: "bar",
+		SpaceName:        "bar",
+		ProviderSpaceID:  "4",
+		ProviderSubnetID: "6",
+		ProviderVLANID:   "5002",
+		VLANTag:          100,
 	}, {
 		MachineAddress: network.MachineAddress{
 			Value: "fc00::1",
 			Type:  "ipv6",
 			Scope: "local-cloud",
 		},
-		SpaceName: "bar",
+		SpaceName:        "bar",
+		ProviderSpaceID:  "4",
+		ProviderSubnetID: "6",
+		ProviderVLANID:   "5002",
+		VLANTag:          100,
 	}})
 }
 
@@ -674,6 +702,54 @@ var stringTests = []struct {
 		},
 		SpaceName:       "badlands",
 		ProviderSpaceID: network.Id("3"),
+	},
+	str: "public:foo.com@badlands(id:3)",
+}, {
+	addr: network.ProviderAddress{
+		MachineAddress: network.MachineAddress{
+			Type:  network.HostName,
+			Value: "foo.com",
+			Scope: network.ScopePublic,
+		},
+		SpaceName:       "badlands",
+		ProviderSpaceID: network.Id("3"),
+		ProviderID:      "523",
+	},
+	str: "public:foo.com@badlands(id:3)",
+}, {
+	addr: network.ProviderAddress{
+		MachineAddress: network.MachineAddress{
+			Type:  network.HostName,
+			Value: "foo.com",
+			Scope: network.ScopePublic,
+		},
+		SpaceName:        "badlands",
+		ProviderSpaceID:  network.Id("3"),
+		ProviderSubnetID: "5",
+	},
+	str: "public:foo.com@badlands(id:3)",
+}, {
+	addr: network.ProviderAddress{
+		MachineAddress: network.MachineAddress{
+			Type:  network.HostName,
+			Value: "foo.com",
+			Scope: network.ScopePublic,
+		},
+		SpaceName:       "badlands",
+		ProviderSpaceID: network.Id("3"),
+		ProviderVLANID:  "5001",
+	},
+	str: "public:foo.com@badlands(id:3)",
+}, {
+	addr: network.ProviderAddress{
+		MachineAddress: network.MachineAddress{
+			Type:  network.HostName,
+			Value: "foo.com",
+			Scope: network.ScopePublic,
+		},
+		SpaceName:       "badlands",
+		ProviderSpaceID: network.Id("3"),
+		VLANTag:         50,
 	},
 	str: "public:foo.com@badlands(id:3)",
 }}


### PR DESCRIPTION
This is to setup a later change described in JUJU-335. 

Add some more properties to `ProviderAddress`, particularly `ProviderID`, so they can later be dropped from `InterfaceInfo`

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/core/network
```

## Documentation changes

No documentations changes

## Bug reference

No bug reference
