### PR TITLE
add user-agent to Equinix provider

### DIFF
--- a/provider/equinix/provider.go
+++ b/provider/equinix/provider.go
@@ -7,6 +7,7 @@ import (
 	stdcontext "context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
@@ -15,6 +16,7 @@ import (
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/version"
 	"github.com/juju/schema"
 
 	"github.com/packethost/packngo"
@@ -123,6 +125,8 @@ var equinixClient = func(spec environscloudspec.CloudSpec) *packngo.Client {
 	httpClient := http.DefaultClient
 
 	c := packngo.NewClientWithAuth("juju", apiToken, httpClient)
+	userAgent := fmt.Sprintf("Juju/%s %s", version.Current.String(), c.UserAgent)
+	c.UserAgent = strings.TrimSpace(userAgent)
 
 	return c
 }


### PR DESCRIPTION
Adds a user-agent to API requests to Equinix.  This user-agent follows
the prefix [format in-use by the Azure provider](https://github.com/juju/juju/compare/develop...displague:equinix-user-agent).  The suffix of the
user-agent is the default packngo user-agent (expressing the version of
packngo in use).

From an Equinix Metal perspective, this will help gauge Juju consumption
of the Equinix Metal API.  The existing `"juju"` string in the client constructor is a "Consumer-Token" which produces an "X-Consumer-Token" HTTP Header.  User-Agents are more common and detailed than the Equinix Metal specific Consumer-Token.
