### PR TITLE
[JUJU-386] Improve yaml parsing for yaml files without 'clouds:' keyword ...

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/schema"
 	"github.com/juju/utils/v2"
 	"gopkg.in/yaml.v2"
 
@@ -397,19 +398,57 @@ func ParseOneCloud(data []byte) (Cloud, error) {
 }
 
 // ParseCloudMetadata parses the given yaml bytes into Clouds metadata.
+//
+// The expected regular yaml formal is:
+//
+// clouds:
+//   garage-maas:
+//     type: maas
+//     auth-types: [oauth1]
+//     endpoint: "http://garagemaas"
+//     skip-tls-verify: true`
+//   ...
+//
+// It also accepts a yaml format without the 'clouds' key at the top,
+// e.g.
+//
+// garage-maas:
+//   type: maas
+//   auth-types: [oauth1]
+//   endpoint: "http://garagemaas"
+//   skip-tls-verify: true`
+// ...
+//
 func ParseCloudMetadata(data []byte) (map[string]Cloud, error) {
 	var metadata cloudSet
-	if err := yaml.Unmarshal(data, &metadata); err != nil {
+
+	// Unmarshal with a generic type first
+	yaml_map := make(map[string]interface{})
+	if err := yaml.Unmarshal(data, &yaml_map); err != nil {
 		return nil, errors.Annotate(err, "cannot unmarshal yaml cloud metadata")
 	}
-	// If we have a yaml that starts without a 'clouds:' key at
-	// top (e.g. list-clouds output), then try to accommodate
-	if len(metadata.Clouds) == 0 && string(data[:7]) != "clouds:" {
-		var metadataClouds map[string]*cloud
-		if errSecTry := yaml.Unmarshal(data, &metadataClouds); errSecTry != nil {
-			return nil, errors.Annotate(errSecTry, "cannot unmarshal yaml cloud metadata")
+
+	cloudSet_schema := schema.FieldMap(schema.Fields{
+		"clouds": schema.Map(schema.String(), schema.Any()),
+	}, nil)
+
+	// Try to coerce the schema with the 'clouds' keyword, if so,
+	// read directly into a cloudSet, otherwise read it as a map
+	// and construct the cloudSet manually
+	regular_map, _ := cloudSet_schema.Coerce(yaml_map, []string{})
+
+	if regular_map != nil {
+		// Able to coerce, so read directly into the cloudSet
+		if err_cloudSet := yaml.Unmarshal(data, &metadata); err_cloudSet != nil {
+			return nil, errors.Errorf("Invalid cloud metadata %s", yaml_map)
 		}
-		metadata.Clouds = metadataClouds
+	} else {
+		// Unable to coerce cloudSet, try to unmarshal into a map[string]*cloud
+		cloudMap := make(map[string]*cloud)
+		if err_cloudMap := yaml.Unmarshal(data, &cloudMap); err_cloudMap != nil {
+			return nil, errors.Errorf("Invalid cloud metadata %s", yaml_map)
+		}
+		metadata.Clouds = cloudMap
 	}
 
 	// Translate to the exported type. For each cloud, we store

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -423,30 +423,30 @@ func ParseCloudMetadata(data []byte) (map[string]Cloud, error) {
 	var metadata cloudSet
 
 	// Unmarshal with a generic type first
-	yaml_map := make(map[string]interface{})
-	if err := yaml.Unmarshal(data, &yaml_map); err != nil {
+	yamlMap := make(map[string]interface{})
+	if err := yaml.Unmarshal(data, &yamlMap); err != nil {
 		return nil, errors.Annotate(err, "cannot unmarshal yaml cloud metadata")
 	}
 
-	cloudSet_schema := schema.FieldMap(schema.Fields{
+	cloudsetSchema := schema.FieldMap(schema.Fields{
 		"clouds": schema.Map(schema.String(), schema.Any()),
 	}, nil)
 
 	// Try to coerce the schema with the 'clouds' keyword, if so,
 	// read directly into a cloudSet, otherwise read it as a map
 	// and construct the cloudSet manually
-	regular_map, _ := cloudSet_schema.Coerce(yaml_map, []string{})
+	regularMap, _ := cloudsetSchema.Coerce(yamlMap, []string{})
 
-	if regular_map != nil {
+	if regularMap != nil {
 		// Able to coerce, so read directly into the cloudSet
-		if err_cloudSet := yaml.Unmarshal(data, &metadata); err_cloudSet != nil {
-			return nil, errors.Errorf("Invalid cloud metadata %s", yaml_map)
+		if errCloudSet := yaml.Unmarshal(data, &metadata); errCloudSet != nil {
+			return nil, errors.Errorf("Invalid cloud metadata %s", yamlMap)
 		}
 	} else {
 		// Unable to coerce cloudSet, try to unmarshal into a map[string]*cloud
 		cloudMap := make(map[string]*cloud)
-		if err_cloudMap := yaml.Unmarshal(data, &cloudMap); err_cloudMap != nil {
-			return nil, errors.Errorf("Invalid cloud metadata %s", yaml_map)
+		if errCloudMap := yaml.Unmarshal(data, &cloudMap); errCloudMap != nil {
+			return nil, errors.Errorf("Invalid cloud metadata %s", yamlMap)
 		}
 		metadata.Clouds = cloudMap
 	}

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -150,6 +150,13 @@ var (
             endpoint: "http://garagemaas"
             skip-tls-verify: true`
 
+	garageMaasYamlFileListCloudOutput = `
+        garage-maas:
+          type: maas
+          auth-types: [oauth1]
+          endpoint: "http://garagemaas"
+          skip-tls-verify: true`
+
 	manyCloudsYamlFile = `
         clouds:
           garage-maas:


### PR DESCRIPTION
#### Description

This improves the `ParseCloudMetadata` to be able to parse yaml files for the cloudset that doesn't have the keyword `clouds:` at the top level.

The change is requested in the [LP Bug #1826957](https://bugs.launchpad.net/juju/+bug/1826957)

#### QA Steps

```sh
juju list-clouds -c <controller> --format yaml > /tmp/clouds.yaml
```

```sh
juju update-cloud -f /tmp/clouds.yaml localhost
```


#### Notes & Discussion

It is also discussed in the LP bug as another solution to put `clouds:` keyword into the `list-cloud`, but that'd break backwards compatibility. 
