### PR TITLE
Unit machine test fixes for fire-walled env (s390x)

### DIFF
--- a/worker/charmrevision/manifold.go
+++ b/worker/charmrevision/manifold.go
@@ -68,7 +68,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 }
 
 // NewAPIFacade returns a Facade backed by the supplied APICaller.
-func NewAPIFacade(apiCaller base.APICaller) (Facade, error) {
+var NewAPIFacade = newAPIFacade
+
+func newAPIFacade(apiCaller base.APICaller) (Facade, error) {
 	return charmrevisionupdater.NewClient(apiCaller), nil
 }
 


### PR DESCRIPTION
The following patches the charmrevision Facade to prevent outbound API
requests to external services. This isn't ideal, as I don't really want
to patch a function call in a unit tests, but this is an integration
masking as a unit test.

## QA steps

```sh
$ go test -v ./cmd/jujud/agent -check.v -check.f=TestControllerModelWorkers
$ go test -v ./cmd/jujud/agent -check.v -check.f=TestHostedModelWorkers
```
