### PR TITLE
[JUJU-106] Add support for mgo scram-sha256 auth; default to mongo 4.4 on bootstrap

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -385,7 +385,7 @@ var attributeParams = agent.AgentConfigParams{
 	Nonce:                    "a nonce",
 	Controller:               testing.ControllerTag,
 	Model:                    testing.ModelTag,
-	JujuDBSnapChannel:        "4.0/stable",
+	JujuDBSnapChannel:        "4.4/stable",
 	NonSyncedWritesToRaftLog: false,
 }
 
@@ -400,7 +400,7 @@ func (*suite) TestAttributes(c *gc.C) {
 	c.Assert(conf.Dir(), gc.Equals, "/data/dir/agents/machine-1")
 	c.Assert(conf.Nonce(), gc.Equals, "a nonce")
 	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, jujuversion.Current)
-	c.Assert(conf.JujuDBSnapChannel(), gc.Equals, "4.0/stable")
+	c.Assert(conf.JujuDBSnapChannel(), gc.Equals, "4.4/stable")
 	c.Assert(conf.NonSyncedWritesToRaftLog(), jc.IsFalse)
 }
 

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -80,7 +80,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.cfg = cfg
 
 	s.controllerCfg = coretesting.FakeControllerConfig()
-	s.controllerCfg["juju-db-snap-channel"] = "4.0/stable"
+	s.controllerCfg["juju-db-snap-channel"] = "4.4/stable"
 	s.controllerCfg[controller.CAASImageRepo] = `
 {
     "serveraddress": "quay.io",
@@ -615,7 +615,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "mongodb",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "test-account/juju-db:4.0",
+			Image:           "test-account/juju-db:4.4",
 			Command: []string{
 				"/bin/sh",
 			},

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -57,7 +57,7 @@ func testPodLabels(c *gc.C, cfg *config.Config, jobs []model.MachineJob, expectT
 
 func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 	cfg := testing.FakeControllerConfig()
-	cfg["juju-db-snap-channel"] = "4.0/stable"
+	cfg["juju-db-snap-channel"] = "4.4/stable"
 	podConfig, err := podcfg.NewBootstrapControllerPodConfig(
 		cfg,
 		"controller-1",
@@ -72,7 +72,7 @@ func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 	c.Assert(path, gc.Equals, "jujusolutions/jujud-operator:6.6.6.666")
 	path, err = podConfig.GetJujuDbOCIImagePath()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.Equals, "jujusolutions/juju-db:4.0")
+	c.Assert(path, gc.Equals, "jujusolutions/juju-db:4.4")
 }
 
 func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -45,7 +45,6 @@ Examples:
     juju create-backup --no-download
 
 See also:
-    backups
     download-backup
 `
 

--- a/controller/config.go
+++ b/controller/config.go
@@ -46,7 +46,7 @@ const (
 	// properly.
 	ControllerAPIPort = "controller-api-port"
 
-	// Canonical name for the controller
+	// ControllerName is the canonical name for the controller
 	ControllerName = "controller-name"
 
 	// AgentRateLimitMax is the maximum size of the token bucket used to
@@ -283,7 +283,7 @@ const (
 
 	// DefaultJujuDBSnapChannel is the default snap channel for installing
 	// mongo in focal or later.
-	DefaultJujuDBSnapChannel = "4.0/stable"
+	DefaultJujuDBSnapChannel = "4.4/stable"
 
 	// DefaultMaxDebugLogDuration is the default duration that debug-log
 	// commands can run before being terminated by the API server.
@@ -337,7 +337,7 @@ const (
 	// non-synced-writes-to-raft-log value. It is set to false by default.
 	DefaultNonSyncedWritesToRaftLog = false
 
-	// DefaultMigrationMinionMaxWait is the default value for
+	// DefaultMigrationMinionWaitMax is the default value for
 	DefaultMigrationMinionWaitMax = "15m"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/juju/jsonschema v0.0.0-20210422141032-b0ff291abe9c
 	github.com/juju/jsonschema-gen v0.0.0-20200416014454-d924343d72b2
 	github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4
-	github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f
+	github.com/juju/mgo/v2 v2.0.0-20220111072304-f200228f1090
 	github.com/juju/mutex v0.0.0-20180619145857-d21b13acf4bf
 	github.com/juju/names/v4 v4.0.0-20200929085019-be23e191fee0
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,8 @@ github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible h1:7L
 github.com/juju/lumberjack v2.0.0-20200420012306-ddfd864a6ade+incompatible/go.mod h1:YQBneJkXlAAye6yHFYH8CabVID+0Oq2by8DDKGj5OIU=
 github.com/juju/mempool v0.0.0-20160205104927-24974d6c264f/go.mod h1:+7K7MqWi5xWI+s1LyB2g0Di71jZo27y+XOlmhNtV1Y0=
 github.com/juju/mgo/v2 v2.0.0-20210302023703-70d5d206e208/go.mod h1:0OChplkvPTZ174D2FYZXg4IB9hbEwyHkD+zT+/eK+Fg=
-github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f h1:/Wj+9vztEkhkudRz596GbOu3x6FmftHk2vurf4yaaxw=
-github.com/juju/mgo/v2 v2.0.0-20210414025616-e854c672032f/go.mod h1:0OChplkvPTZ174D2FYZXg4IB9hbEwyHkD+zT+/eK+Fg=
+github.com/juju/mgo/v2 v2.0.0-20220111072304-f200228f1090 h1:zX5GoH3Jp8k1EjUFkApu/YZAYEn0PYQfg/U6IDyNyYs=
+github.com/juju/mgo/v2 v2.0.0-20220111072304-f200228f1090/go.mod h1:N614SE0a4e+ih2rg96Vi2PeC3cTpUOWgCTv3Cgk974c=
 github.com/juju/mgomonitor v0.0.0-20181029151116-52206bb0cd31/go.mod h1:m6E+J+I+cE+6rcaVxSI4HwGLIEOCSOBMYedt3Sewh+U=
 github.com/juju/mgotest v1.0.1/go.mod h1:vTaDufYul+Ps8D7bgseHjq87X8eu0ivlKLp9mVc/Bfc=
 github.com/juju/mgotest v1.0.2 h1:rgeY0zbfWvxsuCz9m13VAGPFQVzQJeSZOnJ/AzkrkRQ=
@@ -807,6 +807,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45 h1:zpQBW+l4uPQTfTOxedN5GEcSONhabbCf3X+5+P/H4Jk=
 github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
+github.com/xdg-go/stringprep v1.0.2 h1:6iq84/ryjjeRmMJwxutI51F2GIPlP5BfTvXHeYjyhBc=
+github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
@@ -1009,6 +1011,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/mongo/mongodfinder_test.go
+++ b/mongo/mongodfinder_test.go
@@ -219,8 +219,8 @@ func (s *MongodFinderSuite) TestFindJujuMongodbFromSnap(c *gc.C) {
 	c.Check(path, gc.Equals, "/snap/bin/juju-db.mongod")
 	c.Check(version, gc.Equals, mongo.Version{
 		Major:         4,
-		Minor:         0,
-		Point:         9,
+		Minor:         4,
+		Point:         10,
 		StorageEngine: mongo.WiredTiger,
 	})
 }
@@ -298,9 +298,9 @@ build environment:
     target_arch: x86_64
 `
 
-// mongodb409Version is the output of 'mongodb --version' from the 4.0/stable snap.
+// mongodb409Version is the output of 'mongodb --version' from the 4.4/stable snap.
 const mongodb409Version = `EXTRA CONTENT
-db version v4.0.9
+db version v4.4.10
 git version: fc525e2d9b0e4bceff5c2201457e564362909765
 OpenSSL version: OpenSSL 1.1.0g  2 Nov 2017
 allocator: tcmalloc

--- a/service/snap/snap_test.go
+++ b/service/snap/snap_test.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	time "time"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/testing"
@@ -134,14 +134,14 @@ func (*serviceSuite) TestInstallCommands(c *gc.C) {
 			EnableAtStartup: true,
 		},
 	}
-	service, err := NewService("juju-db", "juju-db", conf, Command, "4.0/stable", "", backgroundServices, prerequisites)
+	service, err := NewService("juju-db", "juju-db", conf, Command, "4.4/stable", "", backgroundServices, prerequisites)
 	c.Assert(err, jc.ErrorIsNil)
 
 	commands, err := service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(commands, gc.DeepEquals, []string{
 		"snap install core",
-		"snap install --channel=4.0/stable juju-db",
+		"snap install --channel=4.4/stable juju-db",
 	})
 }
 
@@ -154,14 +154,14 @@ func (*serviceSuite) TestInstallCommandsWithConfinementPolicy(c *gc.C) {
 			EnableAtStartup: true,
 		},
 	}
-	service, err := NewService("juju-db", "juju-db", conf, Command, "4.0/stable", "classic", backgroundServices, prerequisites)
+	service, err := NewService("juju-db", "juju-db", conf, Command, "4.4/stable", "classic", backgroundServices, prerequisites)
 	c.Assert(err, jc.ErrorIsNil)
 
 	commands, err := service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(commands, gc.DeepEquals, []string{
 		"snap install core",
-		"snap install --channel=4.0/stable --classic juju-db",
+		"snap install --channel=4.4/stable --classic juju-db",
 	})
 }
 
@@ -174,7 +174,7 @@ func (*serviceSuite) TestInstall(c *gc.C) {
 
 	runnable := NewMockRunnable(ctrl)
 	runnable.EXPECT().Execute("snap", []string{"install", "core"}).Return("", nil)
-	runnable.EXPECT().Execute("snap", []string{"install", "--channel=4.0/stable", "juju-db"}).Return("", nil)
+	runnable.EXPECT().Execute("snap", []string{"install", "--channel=4.4/stable", "juju-db"}).Return("", nil)
 
 	conf := common.Conf{}
 	prerequisites := []Installable{NewNamedApp("core")}
@@ -184,7 +184,7 @@ func (*serviceSuite) TestInstall(c *gc.C) {
 			EnableAtStartup: true,
 		},
 	}
-	service, err := NewService("juju-db", "juju-db", conf, Command, "4.0/stable", "", backgroundServices, prerequisites)
+	service, err := NewService("juju-db", "juju-db", conf, Command, "4.4/stable", "", backgroundServices, prerequisites)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s := &service
@@ -214,7 +214,7 @@ func (*serviceSuite) TestInstallWithRetry(c *gc.C) {
 	runnable := NewMockRunnable(ctrl)
 	runnable.EXPECT().Execute("snap", []string{"install", "core"}).Return("", errors.New("bad"))
 	runnable.EXPECT().Execute("snap", []string{"install", "core"}).Return("", nil)
-	runnable.EXPECT().Execute("snap", []string{"install", "--channel=4.0/stable", "juju-db"}).Return("", nil)
+	runnable.EXPECT().Execute("snap", []string{"install", "--channel=4.4/stable", "juju-db"}).Return("", nil)
 
 	conf := common.Conf{}
 	prerequisites := []Installable{NewNamedApp("core")}
@@ -224,7 +224,7 @@ func (*serviceSuite) TestInstallWithRetry(c *gc.C) {
 			EnableAtStartup: true,
 		},
 	}
-	service, err := NewService("juju-db", "juju-db", conf, Command, "4.0/stable", "", backgroundServices, prerequisites)
+	service, err := NewService("juju-db", "juju-db", conf, Command, "4.4/stable", "", backgroundServices, prerequisites)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s := &service

--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -32,7 +32,7 @@ echo "Wait for microk8s to be ready if needed."
 microk8s.status --wait-ready --timeout 30 2>&1
 juju_version=\$(/snap/bin/juju version | rev | cut -d- -f3- | rev)
 oci_image="docker.io/jujusolutions/jujud-operator:\$juju_version"
-mongo_image="docker.io/jujusolutions/juju-db:4.0"
+mongo_image="docker.io/jujusolutions/juju-db:4.4"
 
 echo "Going to cache images: \$oci_image and \$mongo_image."
 echo "Pulling: \$oci_image."


### PR DESCRIPTION
Update to use a newer upstream juju/mgo/v2 which adds support for scram-sha256 authentication.
This enables auth against newer mongos.

When bootstrapping on focal or later, we now default to juju-db from the 4.4/stable channel. This gets rid of significant log spam due to apparmor issues and also uses a version of mongo that is still under support (4.0 reaches EOL April 2022).

A couple of small drive by cleanups as well.

## QA steps

juju bootstrap lxd --bootstrap-series=focal
juju bootstrap lxd --bootstrap-series=bionic
juju bootstrap microk8s
juju bootstrap lxd --bootstrap-series=focal --config juju-db-snap-channel=5.0/stable
juju bootstrap microk8s --config juju-db-snap-channel=5.0/stable

Once bootstrapped
juju enable-ha
juju deploy ubuntu

Bootstrap with juju 2.9.22 and upgrade to using this PR.
juju enable-ha
The installed mongo version should remain as 4.0.
