### PR TITLE
[JUJU-418] Fix some intermittent unit test failures

### DIFF
--- a/core/raft/queue/opqueue_test.go
+++ b/core/raft/queue/opqueue_test.go
@@ -9,12 +9,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/clock"
-	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
+
+	"github.com/juju/juju/core/raftlease"
 )
 
 type OpQueueSuite struct {
@@ -24,7 +25,7 @@ type OpQueueSuite struct {
 var _ = gc.Suite(&OpQueueSuite{})
 
 func (s *OpQueueSuite) TestEnqueueDequeue(c *gc.C) {
-	queue := NewOpQueue(clock.WallClock)
+	queue := NewOpQueue(testclock.NewClock(time.Now()))
 
 	results := consumeN(c, queue, 1)
 
@@ -56,7 +57,7 @@ func (s *OpQueueSuite) TestEnqueueDequeue(c *gc.C) {
 }
 
 func (s *OpQueueSuite) TestEnqueueWithStopped(c *gc.C) {
-	queue := NewOpQueue(clock.WallClock)
+	queue := NewOpQueue(testclock.NewClock(time.Now()))
 
 	canceled := make(chan struct{}, 1)
 	close(canceled)
@@ -86,7 +87,7 @@ func (s *OpQueueSuite) TestEnqueueWithStopped(c *gc.C) {
 }
 
 func (s *OpQueueSuite) TestEnqueueWithError(c *gc.C) {
-	queue := NewOpQueue(clock.WallClock)
+	queue := NewOpQueue(testclock.NewClock(time.Now()))
 
 	results := consumeNUntilErr(c, queue, 1, errors.New("boom"))
 
@@ -118,7 +119,7 @@ func (s *OpQueueSuite) TestEnqueueWithError(c *gc.C) {
 }
 
 func (s *OpQueueSuite) TestSynchronousEnqueueImmediateDispatch(c *gc.C) {
-	queue := NewOpQueue(clock.WallClock)
+	queue := NewOpQueue(testclock.NewClock(time.Now()))
 
 	toEnqueue := 5
 	go func() {
@@ -150,7 +151,7 @@ func (s *OpQueueSuite) TestSynchronousEnqueueImmediateDispatch(c *gc.C) {
 }
 
 func (s *OpQueueSuite) TestConcurrentEnqueueMultiDispatch(c *gc.C) {
-	queue := NewOpQueue(clock.WallClock)
+	queue := NewOpQueue(testclock.NewClock(time.Now()))
 
 	toEnqueue := EnqueueBatchSize * 3
 	for i := 0; i < toEnqueue; i++ {
@@ -184,7 +185,7 @@ func (s *OpQueueSuite) TestConcurrentEnqueueMultiDispatch(c *gc.C) {
 }
 
 func (s *OpQueueSuite) TestMultipleEnqueueWithErrors(c *gc.C) {
-	queue := NewOpQueue(clock.WallClock)
+	queue := NewOpQueue(testclock.NewClock(time.Now()))
 
 	results := make(chan raftlease.Command, 3)
 	go func() {
@@ -264,7 +265,7 @@ func (s *OpQueueSuite) TestMultipleEnqueueWithErrors(c *gc.C) {
 }
 
 func (s *OpQueueSuite) TestMultipleEnqueueWithStop(c *gc.C) {
-	queue := NewOpQueue(clock.WallClock)
+	queue := NewOpQueue(testclock.NewClock(time.Now()))
 
 	results := make(chan raftlease.Command, 2)
 	go func() {
@@ -348,7 +349,7 @@ func (s *OpQueueSuite) TestMultipleEnqueueWithStop(c *gc.C) {
 }
 
 func (s *OpQueueSuite) TestMultipleEnqueues(c *gc.C) {
-	queue := NewOpQueue(clock.WallClock)
+	queue := NewOpQueue(testclock.NewClock(time.Now()))
 
 	results := consumeN(c, queue, 10)
 

--- a/state/watcher/export_test.go
+++ b/state/watcher/export_test.go
@@ -3,9 +3,15 @@
 
 package watcher
 
+import "time"
+
 const (
-	TxnWatcherShortWait      = txnWatcherShortWait
-	TxnWatcherErrorShortWait = txnWatcherErrorShortWait
+	// Add a small fudge factor to the wait times; if we use exactly the same wait time
+	// for the fake clock, on slow systems the next watcher event can occur before the
+	// watcher sync can run to process the first event.
+
+	TxnWatcherShortWait      = time.Duration(1.1 * float64(txnWatcherShortWait))
+	TxnWatcherErrorShortWait = time.Duration(1.1 * float64(txnWatcherErrorShortWait))
 )
 
 var OutOfSyncError = outOfSyncError{}

--- a/worker/caasfirewaller/worker_test.go
+++ b/worker/caasfirewaller/worker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v2"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
@@ -289,7 +290,7 @@ func (s *WorkerSuite) TestV2CharmSkipProcessing(c *gc.C) {
 
 	workertest.CleanKill(c, w)
 
-	s.lifeGetter.CheckNoCalls(c)
+	s.expectNoLifeGetterCalls(c)
 }
 
 func (s *WorkerSuite) TestCharmNotFound(c *gc.C) {
@@ -303,7 +304,7 @@ func (s *WorkerSuite) TestCharmNotFound(c *gc.C) {
 
 	workertest.CleanKill(c, w)
 
-	s.lifeGetter.CheckNoCalls(c)
+	s.expectNoLifeGetterCalls(c)
 }
 
 func (s *WorkerSuite) TestCharmChangesToV2(c *gc.C) {
@@ -346,4 +347,16 @@ func waitStubCalls(c *gc.C, stub waitStub, names ...string) {
 	}
 	stub.CheckCallNames(c, names...)
 	stub.ResetCalls()
+}
+
+func (s *WorkerSuite) expectNoLifeGetterCalls(c *gc.C) {
+	strategy := utils.AttemptStrategy{
+		Total: coretesting.ShortWait,
+		Delay: 10 * time.Millisecond,
+	}
+	for a := strategy.Start(); a.Next(); {
+		if len(s.lifeGetter.Calls()) > 0 {
+			c.Fatalf("unexpected lifegetter call")
+		}
+	}
 }


### PR DESCRIPTION
Some unit tests we failing on slow hardware. One main root cause was advancing the test clock by exactly the interval used to trigger the next processing step. The test adds a small additional fraction of time to allow the step to always trigger.

In another case, a test clock was used instead of a wall clock to ensure a stable time.Now().

Also, in the firewaller tests, we were testing for something that could pass on slow hardware but fail in real life.

## QA steps

run the unit tests