### PR TITLE
Use mongo 4.4 for client tests

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -48,14 +48,6 @@ jobs:
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')
       run: |
-        # Remove the default mongo
-        for version in "4.2" "4.4"; do
-          sudo rm "/etc/apt/sources.list.d/mongodb-org-${version}.list" || true
-        done
-        sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y mongodb-org
-        sudo DEBIAN_FRONTEND=noninteractive apt autoremove
-        sudo rm -rf /usr/bin/mongo* || true
-
         make install-mongo-dependencies
 
     - name: "Remove Mongo Dependencies: windows-latest"
@@ -68,18 +60,18 @@ jobs:
       if: (matrix.os == 'windows-latest')
       uses: crazy-max/ghaction-chocolatey@v1
       with:
-        args: install mongodb.install --version=4.0.21 --allow-downgrade
+        args: install mongodb.install --version=4.4.11 --allow-downgrade
 
     # GitHub runners already have preinstalled version of mongodb, but
-    # we specifically need 4.0.21, otherwise our tests will not pass
+    # we specifically need 4.4.11, otherwise our tests will not pass
     - name: "Install Mongo Dependencies: macOS-latest"
       if: (matrix.os == 'macOS-latest')
       run: |
-        curl -o mongodb-4.0.21.tgz https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.21.tgz
-        tar xzvf mongodb-4.0.21.tgz
+        curl -o mongodb-4.4.11.tgz https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.11.tgz
+        tar xzvf mongodb-4.4.11.tgz
         sudo rm -rf /usr/local/mongodb
         sudo mkdir -p /usr/local/mongodb
-        sudo mv mongodb-osx-x86_64-4.0.21/bin/* /usr/local/mongodb
+        sudo mv mongodb-macos-x86_64-4.4.11/bin/* /usr/local/mongodb
         sudo mkdir -p /usr/local/bin
         sudo rm /usr/local/bin/mongod
         sudo ln -s /usr/local/mongodb/mongod /usr/local/bin/mongod

--- a/Makefile
+++ b/Makefile
@@ -180,15 +180,10 @@ else
 	@sudo snap install go --channel=1.14/stable --classic
 endif
 
+JUJU_DB_CHANNEL=4.4/stable
 install-mongo-dependencies:
-## install-mongo-dependencies: Install Mongo and its dependencies
-	@echo Adding juju PPA for mongodb
-	@sudo apt-add-repository --yes ppa:juju/stable
-	@sudo apt-get update
-	@echo Installing dependencies
-	@sudo apt-get --yes install  \
-	$(strip $(DEPENDENCIES)) \
-	$(shell apt-cache madison mongodb-server-core juju-mongodb3.2 juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
+## install-mongo-dependencies: Install the juju-db snap
+	@sudo snap refresh juju-db --channel=${JUJU_DB_CHANNEL} 2> /dev/null; sudo snap install juju-db --channel=${JUJU_DB_CHANNEL} 2> /dev/null
 
 install-dependencies: install-snap-dependencies install-mongo-dependencies
 ## install-dependencies: Install all the dependencies


### PR DESCRIPTION
Juju 2.9 now needs to run tests using mongo 4.4
Update the ubuntu and macos tests to pull the 4.4 version of mongo.

