### PR TITLE
[JUJU-416] Consistantly use juju/retry to handle retries 1 (juju/juju/cmd/*)

### DIFF
--- a/cmd/juju/commands/debugcode.go
+++ b/cmd/juju/commands/debugcode.go
@@ -6,15 +6,17 @@ package commands
 import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
+	"github.com/juju/retry"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/network/ssh"
 )
 
-func newDebugCodeCommand(hostChecker ssh.ReachableChecker) cmd.Command {
+func newDebugCodeCommand(hostChecker ssh.ReachableChecker, retryStrategy retry.CallArgs) cmd.Command {
 	c := new(debugCodeCommand)
 	c.hostChecker = hostChecker
+	c.retryStrategy = defaultSSHRetryStrategy
 	return modelcmd.Wrap(c)
 }
 

--- a/cmd/juju/commands/debugcode_test.go
+++ b/cmd/juju/commands/debugcode_test.go
@@ -27,7 +27,7 @@ func (s *DebugCodeSuite) TestArgFormatting(c *gc.C) {
 	}
 	s.setupModel(c)
 	s.setHostChecker(validAddresses("0.public"))
-	ctx, err := cmdtesting.RunCommand(c, newDebugCodeCommand(s.hostChecker),
+	ctx, err := cmdtesting.RunCommand(c, newDebugCodeCommand(s.hostChecker, baseTestingRetryStrategy),
 		"--at=foo,bar", "mysql/0", "install", "start")
 	c.Assert(err, jc.ErrorIsNil)
 	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")

--- a/cmd/juju/commands/debughooks.go
+++ b/cmd/juju/commands/debughooks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
+	"github.com/juju/retry"
 
 	"github.com/juju/juju/api/application"
 	"github.com/juju/juju/api/charms"
@@ -25,9 +26,10 @@ import (
 	unitdebug "github.com/juju/juju/worker/uniter/runner/debug"
 )
 
-func newDebugHooksCommand(hostChecker ssh.ReachableChecker) cmd.Command {
+func newDebugHooksCommand(hostChecker ssh.ReachableChecker, retryStrategy retry.CallArgs) cmd.Command {
 	c := new(debugHooksCommand)
 	c.hostChecker = hostChecker
+	c.retryStrategy = retryStrategy
 	return modelcmd.Wrap(c)
 }
 

--- a/cmd/juju/commands/debughooks_test.go
+++ b/cmd/juju/commands/debughooks_test.go
@@ -8,8 +8,11 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/retry"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
@@ -21,6 +24,12 @@ var _ = gc.Suite(&DebugHooksSuite{})
 
 type DebugHooksSuite struct {
 	SSHMachineSuite
+}
+
+var baseTestingRetryStrategy = retry.CallArgs{
+	Clock:    clock.WallClock,
+	Attempts: 5,
+	Delay:    time.Millisecond,
 }
 
 var debugHooksTests = []struct {
@@ -145,7 +154,7 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 		s.setHostChecker(t.hostChecker)
 		s.setForceAPIv1(t.forceAPIv1)
 
-		ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker), t.args...)
+		ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker, baseTestingRetryStrategy), t.args...)
 		if t.error != "" {
 			c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(t.error))
 		} else {
@@ -163,7 +172,7 @@ func (s *DebugHooksSuite) TestDebugHooksArgFormatting(c *gc.C) {
 	}
 	s.setupModel(c)
 	s.setHostChecker(validAddresses("0.public"))
-	ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker),
+	ctx, err := cmdtesting.RunCommand(c, newDebugHooksCommand(s.hostChecker, baseTestingRetryStrategy),
 		"mysql/0", "install", "start")
 	c.Check(err, jc.ErrorIsNil)
 	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -376,12 +376,12 @@ func registerCommands(r commandRegistry) {
 		r.Register(newDefaultRunCommand(nil))
 	}
 	r.Register(newDefaultExecCommand(nil))
-	r.Register(newSCPCommand(nil))
-	r.Register(newSSHCommand(nil, nil))
+	r.Register(newSCPCommand(nil, defaultSSHRetryStrategy))
+	r.Register(newSSHCommand(nil, nil, defaultSSHRetryStrategy))
 	r.Register(application.NewResolvedCommand())
 	r.Register(newDebugLogCommand(nil))
-	r.Register(newDebugHooksCommand(nil))
-	r.Register(newDebugCodeCommand(nil))
+	r.Register(newDebugHooksCommand(nil, defaultSSHRetryStrategy))
+	r.Register(newDebugCodeCommand(nil, defaultSSHRetryStrategy))
 
 	// Configuration commands.
 	r.Register(model.NewModelGetConstraintsCommand())

--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/retry"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -108,9 +109,10 @@ See also:
 	ssh
 `
 
-func newSCPCommand(hostChecker jujussh.ReachableChecker) cmd.Command {
+func newSCPCommand(hostChecker jujussh.ReachableChecker, retryStrategy retry.CallArgs) cmd.Command {
 	c := new(scpCommand)
 	c.hostChecker = hostChecker
+	c.retryStrategy = retryStrategy
 	return modelcmd.Wrap(c)
 }
 
@@ -126,6 +128,8 @@ type scpCommand struct {
 	provider sshProvider
 
 	hostChecker jujussh.ReachableChecker
+
+	retryStrategy retry.CallArgs
 }
 
 func (c *scpCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -157,6 +161,7 @@ func (c *scpCommand) Init(args []string) (err error) {
 
 	c.provider.setArgs(args)
 	c.provider.setHostChecker(c.hostChecker)
+	c.provider.setRetryStrategy(c.retryStrategy)
 	return nil
 }
 

--- a/cmd/juju/commands/scp_unix_test.go
+++ b/cmd/juju/commands/scp_unix_test.go
@@ -221,7 +221,7 @@ func (s *SCPSuiteLegacy) TestSCPCommand(c *gc.C) {
 		s.setHostChecker(t.hostChecker)
 		s.setForceAPIv1(t.forceAPIv1)
 
-		ctx, err := cmdtesting.RunCommand(c, newSCPCommand(s.hostChecker), t.args...)
+		ctx, err := cmdtesting.RunCommand(c, newSCPCommand(s.hostChecker, baseTestingRetryStrategy), t.args...)
 		if t.error != "" {
 			c.Check(err, gc.ErrorMatches, t.error)
 		} else {

--- a/cmd/juju/commands/ssh.go
+++ b/cmd/juju/commands/ssh.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/retry"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/apiserver/params"
@@ -120,15 +123,33 @@ For k8s controller:
 See also: 
     scp`
 
+const (
+	// SSHRetryDelay is the time to wait for an SSH connection to be established
+	// to a single endpoint of a target.
+	SSHRetryDelay = 500 * time.Millisecond
+
+	// SSHTimeout is the time to wait for before giving up trying to establish
+	// an SSH connection to a target, after retrying.
+	SSHTimeout = 5 * time.Second
+)
+
 func newSSHCommand(
 	hostChecker jujussh.ReachableChecker,
 	isTerminal func(interface{}) bool,
+	retryStrategy retry.CallArgs,
 ) cmd.Command {
 	c := &sshCommand{
-		hostChecker: hostChecker,
-		isTerminal:  isTerminal,
+		hostChecker:   hostChecker,
+		isTerminal:    isTerminal,
+		retryStrategy: retryStrategy,
 	}
 	return modelcmd.Wrap(c)
+}
+
+var defaultSSHRetryStrategy = retry.CallArgs{
+	Clock:       clock.WallClock,
+	MaxDuration: SSHTimeout,
+	Delay:       SSHRetryDelay,
 }
 
 // sshCommand is responsible for launching a ssh shell on a given unit or machine.
@@ -144,6 +165,8 @@ type sshCommand struct {
 	hostChecker jujussh.ReachableChecker
 	isTerminal  func(interface{}) bool
 	pty         autoBoolValue
+
+	retryStrategy retry.CallArgs
 }
 
 func (c *sshCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -176,6 +199,7 @@ func (c *sshCommand) Init(args []string) (err error) {
 	c.provider.setTarget(args[0])
 	c.provider.setArgs(args[1:])
 	c.provider.setHostChecker(c.hostChecker)
+	c.provider.setRetryStrategy(c.retryStrategy)
 	return nil
 }
 
@@ -203,6 +227,8 @@ type sshProvider interface {
 
 	getArgs() []string
 	setArgs(Args []string)
+
+	setRetryStrategy(retry.CallArgs)
 }
 
 // Run resolves c.Target to a machine, to the address of a i

--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
+	"github.com/juju/retry"
 
 	"github.com/juju/juju/api/application"
 	apicharms "github.com/juju/juju/api/charms"
@@ -104,6 +105,8 @@ func (c *sshContainer) getArgs() []string {
 func (c *sshContainer) setArgs(args []string) {
 	c.args = args
 }
+
+func (c *sshContainer) setRetryStrategy(_ retry.CallArgs) {}
 
 // initRun initializes the API connection if required. It must be called
 // at the top of the command's Run method.

--- a/cmd/juju/commands/ssh_unix_test.go
+++ b/cmd/juju/commands/ssh_unix_test.go
@@ -13,7 +13,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	"github.com/juju/cmd/v3/cmdtesting"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -200,7 +199,7 @@ func (s *SSHSuite) TestSSHCommand(c *gc.C) {
 		isTerminal := func(stdin interface{}) bool {
 			return t.isTerminal
 		}
-		cmd := newSSHCommand(t.hostChecker, isTerminal)
+		cmd := newSSHCommand(t.hostChecker, isTerminal, baseTestingRetryStrategy)
 
 		ctx, err := cmdtesting.RunCommand(c, cmd, t.args...)
 		if t.expectedErr != "" {
@@ -222,8 +221,7 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.setForceAPIv1(true)
-
-	ctx, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil), "0")
+	ctx, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil, baseTestingRetryStrategy), "0")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	expectedArgs := argsSpec{
@@ -235,7 +233,7 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *gc.C) {
 	expectedArgs.check(c, cmdtesting.Stdout(ctx))
 
 	s.setForceAPIv1(false)
-	ctx, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil), "0")
+	ctx, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil, baseTestingRetryStrategy), "0")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 	expectedArgs.argsMatch = `ubuntu@0.(public|private|1\.2\.3)` // can be any of the 3 with api v2.
@@ -298,20 +296,11 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 	m := s.Factory.MakeMachine(c, nil)
 	s.setKeys(c, m)
 
-	called := 0
-	attemptStarter := &callbackAttemptStarter{next: func() bool {
-		called++
-		return called < 2
-	}}
-	restorer := testing.PatchValue(&sshHostFromTargetAttemptStrategy, attemptStarter)
-	defer restorer.Restore()
-
 	// Ensure that the ssh command waits for a public (private with proxy=true)
 	// address, or the attempt strategy's Done method returns false.
 	args := []string{"--proxy=" + fmt.Sprint(proxy), "0"}
-	_, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil), args...)
+	_, err := cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil, baseTestingRetryStrategy), args...)
 	c.Assert(err, gc.ErrorMatches, `no .+ address\(es\)`)
-	c.Assert(called, gc.Equals, 2)
 
 	if proxy {
 		s.setHostChecker(nil) // not used when proxy=true
@@ -319,18 +308,15 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *gc.C, proxy bool) {
 		s.setHostChecker(validAddresses("0.private", "0.public"))
 	}
 
-	called = 0
-	attemptStarter.next = func() bool {
-		called++
-		if called > 1 {
+	retryStrategy := baseTestingRetryStrategy
+	retryStrategy.NotifyFunc = func(lastError error, attempt int) {
+		if attempt > 1 {
 			s.setAddresses(c, m)
 		}
-		return true
 	}
 
-	_, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil), args...)
+	_, err = cmdtesting.RunCommand(c, newSSHCommand(s.hostChecker, nil, retryStrategy), args...)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, gc.Equals, 2)
 }
 
 func (s *SSHSuite) TestMaybeResolveLeaderUnit(c *gc.C) {
@@ -372,20 +358,4 @@ func (s *SSHSuite) TestMaybeResolveLeaderUnit(c *gc.C) {
 	}, "wormhole/leader")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resolvedUnit, gc.Equals, "wormhole/1", gc.Commentf("expected leader to resolve to wormhole/1 for subordinate application"))
-}
-
-type callbackAttemptStarter struct {
-	next func() bool
-}
-
-func (s *callbackAttemptStarter) Start() attempt {
-	return callbackAttempt{next: s.next}
-}
-
-type callbackAttempt struct {
-	next func() bool
-}
-
-func (a callbackAttempt) Next() bool {
-	return a.next()
 }

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -141,7 +141,7 @@ func (s *controllerSuite) TestWaitForAgentCancelled(c *gc.C) {
 		cancel()
 		bootstrapCtx := modelcmd.BootstrapContext(stdCtx, ctx)
 		err := WaitForAgentInitialisation(bootstrapCtx, base, false, "controller")
-		c.Check(err, gc.ErrorMatches, `contacting controller \(cancelled\): .*`)
+		c.Check(err, gc.ErrorMatches, `unable to contact api server after \d+ attempts: contacting controller \(cancelled\): .*`)
 	})
 }
 


### PR DESCRIPTION
Throughout Juju we have inconsistent ways of performing retries. Standardise all retry code to the repository github.com/juju/retry.

Replace occurrences of this old method of retries from the cmd directory

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/cmd/juju/common
go test github.com/juju/juju/cmd/juju/commands
```

## Documentation changes

No documentation changes required

## Bug reference

https://bugs.launchpad.net/juju/+bug/1611427/
