### PR TITLE
[JUJU-423] State package closure of collections and iterators

### DIFF
--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1811,33 +1811,39 @@ func loadAllWatcherEntities(st *State, loadOrder []string, collectionByName map[
 		if c.subsidiary {
 			continue
 		}
-		col, closer := db.GetCollection(c.name)
-		defer closer()
-		infoSlicePtr := reflect.New(reflect.SliceOf(c.docType))
 
-		// models is a global collection so need to filter on UUID.
-		var filter bson.M
-		if c.name == modelsC {
-			filter = bson.M{"_id": st.ModelUUID()}
-		}
-		query := col.Find(filter)
-		// Units are ordered so we load the subordinates first.
-		if c.name == unitsC {
-			// Subordinates have a principal, so will sort after the
-			// empty string, which is what principal units have.
-			query = query.Sort("principal")
-		}
-		if err := query.All(infoSlicePtr.Interface()); err != nil {
-			return errors.Errorf("cannot get all %s: %v", c.name, err)
-		}
-		infos := infoSlicePtr.Elem()
-		for i := 0; i < infos.Len(); i++ {
-			info := infos.Index(i).Addr().Interface().(backingEntityDoc)
-			ctx.id = info.mongoID()
-			err := info.updated(ctx)
-			if err != nil {
-				return errors.Annotatef(err, "failed to initialise backing for %s:%v", c.name, ctx.id)
+		if err := func(name string) error {
+			col, closer := db.GetCollection(name)
+			defer closer()
+			infoSlicePtr := reflect.New(reflect.SliceOf(c.docType))
+
+			// models is a global collection so need to filter on UUID.
+			var filter bson.M
+			if name == modelsC {
+				filter = bson.M{"_id": st.ModelUUID()}
 			}
+			query := col.Find(filter)
+			// Units are ordered so we load the subordinates first.
+			if name == unitsC {
+				// Subordinates have a principal, so will sort after the
+				// empty string, which is what principal units have.
+				query = query.Sort("principal")
+			}
+			if err := query.All(infoSlicePtr.Interface()); err != nil {
+				return errors.Errorf("cannot get all %s: %v", name, err)
+			}
+			infos := infoSlicePtr.Elem()
+			for i := 0; i < infos.Len(); i++ {
+				info := infos.Index(i).Addr().Interface().(backingEntityDoc)
+				ctx.id = info.mongoID()
+				err := info.updated(ctx)
+				if err != nil {
+					return errors.Annotatef(err, "failed to initialise backing for %s:%v", name, ctx.id)
+				}
+			}
+			return nil
+		}(c.name); err != nil {
+			return errors.Trace(err)
 		}
 	}
 

--- a/state/charm.go
+++ b/state/charm.go
@@ -268,8 +268,8 @@ func insertPendingCharmOps(mb modelBackend, curl *charm.URL) ([]txn.Op, error) {
 // insertAnyCharmOps returns the txn operations necessary to insert the supplied
 // charm document.
 func insertAnyCharmOps(mb modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
-	charms, closer := mb.db().GetCollection(charmsC)
-	defer closer()
+	charms, cCloser := mb.db().GetCollection(charmsC)
+	defer cCloser()
 
 	life, err := nsLife.read(charms, cdoc.DocID)
 	if errors.IsNotFound(err) {
@@ -288,8 +288,8 @@ func insertAnyCharmOps(mb modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
 		Insert: cdoc,
 	}
 
-	refcounts, closer := mb.db().GetCollection(refcountsC)
-	defer closer()
+	refcounts, rCloser := mb.db().GetCollection(refcountsC)
+	defer rCloser()
 
 	charmKey := charmGlobalKey(cdoc.URL)
 	refOp, required, err := nsRefcounts.LazyCreateOp(refcounts, charmKey)

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -15,8 +15,8 @@ var errCharmInUse = errors.New("charm in use")
 // to a charm and its per-application settings and storage constraints
 // documents. It will fail if the charm is not Alive.
 func appCharmIncRefOps(mb modelBackend, appName string, curl *charm.URL, canCreate bool) ([]txn.Op, error) {
-	charms, closer := mb.db().GetCollection(charmsC)
-	defer closer()
+	charms, cCloser := mb.db().GetCollection(charmsC)
+	defer cCloser()
 
 	// If we're migrating. charm document will not be present. But
 	// if we're not migrating, we need to check the charm is alive.
@@ -32,8 +32,8 @@ func appCharmIncRefOps(mb modelBackend, appName string, curl *charm.URL, canCrea
 		checkOps = []txn.Op{checkOp}
 	}
 
-	refcounts, closer := mb.db().GetCollection(refcountsC)
-	defer closer()
+	refcounts, rCloser := mb.db().GetCollection(refcountsC)
+	defer rCloser()
 
 	getIncRefOp := nsRefcounts.CreateOrIncRefOp
 	if !canCreate {
@@ -138,8 +138,8 @@ func finalAppCharmRemoveOps(appName string, curl *charm.URL) []txn.Op {
 // charmDestroyOps implements the logic of charm.Destroy.
 func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
 	db := st.db()
-	charms, closer := db.GetCollection(charmsC)
-	defer closer()
+	charms, cCloser := db.GetCollection(charmsC)
+	defer cCloser()
 
 	charmKey := curl.String()
 	charmOp, err := nsLife.destroyOp(charms, charmKey, nil)
@@ -147,8 +147,8 @@ func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
 		return nil, errors.Annotate(err, "charm")
 	}
 
-	refcounts, closer := db.GetCollection(refcountsC)
-	defer closer()
+	refcounts, rCloser := db.GetCollection(refcountsC)
+	defer rCloser()
 
 	refcountKey := charmGlobalKey(curl)
 	refcountOp, err := nsRefcounts.RemoveOp(refcounts, refcountKey, 0)

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -120,21 +120,23 @@ func (st *State) modelsToRevert(tag names.CloudCredentialTag) (map[*Model]func()
 	for _, m := range credentialModels {
 		one, closer, err := st.model(m.UUID)
 		if err != nil {
-			// Something has gone wrong with this model... keep going.
+			_ = closer()
 			logger.Warningf("model %v error: %v", m.UUID, err)
 			continue
 		}
 		modelStatus, err := one.Status()
 		if err != nil {
+			_ = closer()
 			return revert, errors.Trace(err)
 		}
-		// We only interested if the models are currently suspended.
+		// We're only interested if the models are currently suspended.
 		if modelStatus.Status == status.Suspended {
 			revert[one] = closer
 			continue
 		}
-		// We still need to close models that did not make the cut.
-		defer func() { _ = closer() }()
+
+		// We're not interested in this model; close its session now.
+		_ = closer()
 	}
 	return revert, nil
 }

--- a/state/database.go
+++ b/state/database.go
@@ -121,8 +121,8 @@ var ErrChangeComplete = errors.New("change complete")
 // Apply runs the supplied Change against the supplied Database. If it
 // returns no error, the change succeeded.
 func Apply(db Database, change Change) error {
-	db, closer := db.Copy()
-	defer closer()
+	db, dbCloser := db.Copy()
+	defer dbCloser()
 
 	buildTxn := func(int) ([]txn.Op, error) {
 		ops, err := change.Prepare(db)
@@ -135,8 +135,8 @@ func Apply(db Database, change Change) error {
 		return ops, nil
 	}
 
-	runner, closer := db.TransactionRunner()
-	defer closer()
+	runner, tCloser := db.TransactionRunner()
+	defer tCloser()
 	if err := runner.Run(buildTxn); err != nil {
 		return errors.Trace(err)
 	}

--- a/state/docker_resource.go
+++ b/state/docker_resource.go
@@ -50,7 +50,7 @@ func NewDockerMetadataStorage(st *State) DockerMetadataStorage {
 	}
 }
 
-// Save creates a new record the a Docker resource.
+// Save creates a new record for a Docker resource.
 func (dr *dockerMetadataStorage) Save(resourceID string, drInfo resources.DockerImageDetails) error {
 	doc := dockerMetadataDoc{
 		Id:           resourceID,

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -53,27 +53,30 @@ func (st *State) suspendCredentialModels(tag names.CloudCredentialTag, reason st
 	logger.Warningf("suspending these models:\n%s\n because their credential has become invalid:\n%s",
 		strings.Join(infos, " - "),
 		reason)
-	status := modelStatusInvalidCredential(reason)
+	sts := modelStatusInvalidCredential(reason)
 	doc := statusDoc{
-		Status:     status.Status,
-		StatusInfo: status.Message,
-		StatusData: status.Data,
+		Status:     sts.Status,
+		StatusInfo: sts.Message,
+		StatusData: sts.Data,
 		Updated:    timeOrNow(nil, st.clock()).UnixNano(),
 	}
 	for _, m := range models {
-		one, closer, err := st.model(m.UUID)
-		if err != nil {
-			// Something has gone wrong with this model... keep going.
-			logger.Warningf("model %v error: %v", m.UUID, err)
-			continue
-		}
-		defer func() { _ = closer() }()
-		if _, err = probablyUpdateStatusHistory(one.st.db(), one.globalKey(), doc); err != nil {
-			// We do not want to stop processing the rest of the models.
-			logger.Warningf("%v", err)
-		}
+		st.maybeSetModelStatusHistoryDoc(m.UUID, doc)
 	}
 	return nil
+}
+
+func (st *State) maybeSetModelStatusHistoryDoc(modelUUID string, doc statusDoc) {
+	one, closer, err := st.model(modelUUID)
+	defer func() { _ = closer() }()
+	if err != nil {
+		logger.Warningf("model %v error: %v", modelUUID, err)
+		return
+	}
+
+	if _, err = probablyUpdateStatusHistory(one.st.db(), one.globalKey(), doc); err != nil {
+		logger.Warningf("%v", err)
+	}
 }
 
 // ValidateCloudCredential validates new cloud credential for this model.

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -722,7 +722,7 @@ func (st *State) Branches() ([]*Generation, error) {
 	return branches, nil
 }
 
-// Generations returns all committed branches.
+// CommittedBranches returns all committed branches.
 func (st *State) CommittedBranches() ([]*Generation, error) {
 	col, closer := st.db().GetCollection(generationsC)
 	defer closer()

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -867,7 +867,7 @@ func (st *State) CompletedMigration() (ModelMigration, error) {
 	return mig, errors.Trace(err)
 }
 
-// CompletedMigration returns the most recent migration for the
+// CompletedMigrationForModel returns the most recent migration for the
 // input model UUID if it reached the DONE phase and caused the model
 // to be relocated.
 func (st *State) CompletedMigrationForModel(modelUUID string) (ModelMigration, error) {

--- a/state/operation.go
+++ b/state/operation.go
@@ -278,8 +278,8 @@ func (m *Model) Operation(id string) (Operation, error) {
 // OperationWithActions returns an OperationInfo by Id.
 func (m *Model) OperationWithActions(id string) (*OperationInfo, error) {
 	// First gather the matching actions and record the parent operation ids we need.
-	actionsCollection, closer := m.st.db().GetCollection(actionsC)
-	defer closer()
+	actionsCollection, aCloser := m.st.db().GetCollection(actionsC)
+	defer aCloser()
 
 	var actions []actionDoc
 	err := actionsCollection.Find(bson.D{{"operation", id}}).
@@ -288,8 +288,8 @@ func (m *Model) OperationWithActions(id string) (*OperationInfo, error) {
 		return nil, errors.Trace(err)
 	}
 
-	operationCollection, closer := m.st.db().GetCollection(operationsC)
-	defer closer()
+	operationCollection, oCloser := m.st.db().GetCollection(operationsC)
+	defer oCloser()
 
 	var docs []operationDoc
 	err = operationCollection.FindId(id).All(&docs)

--- a/state/payloads.go
+++ b/state/payloads.go
@@ -167,10 +167,9 @@ type payloadTrackChange struct {
 
 // Prepare is part of the Change interface.
 func (change payloadTrackChange) Prepare(db Database) ([]txn.Op, error) {
-
 	unit := change.Doc.UnitID
-	units, closer := db.GetCollection(unitsC)
-	defer closer()
+	units, uCloser := db.GetCollection(unitsC)
+	defer uCloser()
 	unitOp, err := nsLife.notDeadOp(units, unit)
 	if errors.Cause(err) == errDeadOrGone {
 		return nil, errors.Errorf("unit %q no longer available", unit)
@@ -178,8 +177,8 @@ func (change payloadTrackChange) Prepare(db Database) ([]txn.Op, error) {
 		return nil, errors.Trace(err)
 	}
 
-	payloads, closer := db.GetCollection(payloadsC)
-	defer closer()
+	payloads, pCloser := db.GetCollection(payloadsC)
+	defer pCloser()
 	payloadOp, err := nsPayloads.trackOp(payloads, change.Doc)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -69,10 +69,10 @@ func (ru *RelationUnit) UnitName() string {
 // intervention; the relation will not be able to become Dead until all units
 // have departed its scopes.
 func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
-	db, closer := ru.st.newDB()
-	defer closer()
-	relationScopes, closer := db.GetCollection(relationScopesC)
-	defer closer()
+	db, dbCloser := ru.st.newDB()
+	defer dbCloser()
+	relationScopes, rsCloser := db.GetCollection(relationScopesC)
+	defer rsCloser()
 
 	// Verify that the unit is not already in scope, and abort without error
 	// if it is.
@@ -109,8 +109,8 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	//   before we create the scope doc, because the existence of a scope doc
 	//   is considered to be a guarantee of the existence of a settings doc.
 	settingsChanged := func() (bool, error) { return false, nil }
-	settingsColl, closer := db.GetCollection(settingsC)
-	defer closer()
+	settingsColl, sCloser := db.GetCollection(settingsC)
+	defer sCloser()
 	if count, err := settingsColl.FindId(ruKey).Count(); err != nil {
 		return err
 	} else if count == 0 {
@@ -159,16 +159,16 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 	// unit: this could fail due to the subordinate applications not being Alive,
 	// but this case will always be caught by the check for the relation's
 	// life (because a relation cannot be Alive if its applications are not).)
-	relations, closer := db.GetCollection(relationsC)
-	defer closer()
+	relations, rCloser := db.GetCollection(relationsC)
+	defer rCloser()
 	if alive, err := isAliveWithSession(relations, relationDocID); err != nil {
 		return err
 	} else if !alive {
 		return stateerrors.ErrCannotEnterScope
 	}
 	if ru.isLocalUnit {
-		units, closer := db.GetCollection(unitsC)
-		defer closer()
+		units, uCloser := db.GetCollection(unitsC)
+		defer uCloser()
 		if alive, err := isAliveWithSession(units, ru.unitName); err != nil {
 			return err
 		} else if !alive {

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -525,10 +525,12 @@ func (w *secretsRotationWatcher) initial() ([]corewatcher.SecretRotationChange, 
 	for iter.Next(&doc) {
 		id, err := secretIDFromGlobalKey(doc.DocID)
 		if err != nil {
+			_ = iter.Close()
 			return nil, errors.Annotatef(err, "invalid secret key %q", doc.DocID)
 		}
 		url, err := secrets.ParseURL(doc.URL)
 		if err != nil {
+			_ = iter.Close()
 			return nil, errors.Annotatef(err, "invalid secret URL %q", doc.URL)
 		}
 		w.known[doc.DocID] = rotateWatcherDetails{
@@ -542,7 +544,7 @@ func (w *secretsRotationWatcher) initial() ([]corewatcher.SecretRotationChange, 
 			LastRotateTime: doc.LastRotateTime.UTC(),
 		})
 	}
-	return details, iter.Close()
+	return details, errors.Trace(iter.Close())
 }
 
 func (w *secretsRotationWatcher) merge(details []corewatcher.SecretRotationChange, change watcher.Change) ([]corewatcher.SecretRotationChange, error) {

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -90,6 +90,9 @@ func (s *Space) Subnets() ([]*Subnet, error) {
 			subnet := &Subnet{s.st, doc, id}
 			results = append(results, subnet)
 		}
+		if err := childIter.Close(); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	if err := iter.Close(); err != nil {
 		return nil, errors.Annotatef(err, "cannot fetch subnets")

--- a/state/unit.go
+++ b/state/unit.go
@@ -1456,12 +1456,12 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 		return errors.Errorf("cannot set nil charm url")
 	}
 
-	db, closer := u.st.newDB()
-	defer closer()
-	units, closer := db.GetCollection(unitsC)
-	defer closer()
-	charms, closer := db.GetCollection(charmsC)
-	defer closer()
+	db, dbCloser := u.st.newDB()
+	defer dbCloser()
+	units, uCloser := db.GetCollection(unitsC)
+	defer uCloser()
+	charms, cCloser := db.GetCollection(charmsC)
+	defer cCloser()
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		if attempt > 0 {
@@ -2410,16 +2410,16 @@ var hasNoContainersTerm = bson.DocElem{
 // findCleanMachineQuery returns a Mongo query to find clean (and maybe empty)
 // machines with characteristics matching the specified constraints.
 func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value) (bson.D, error) {
-	db, closer := u.st.newDB()
-	defer closer()
+	db, dbCloser := u.st.newDB()
+	defer dbCloser()
 
 	// Select all machines that can accept principal units and are clean.
 	var containerRefs []machineContainers
 	// If we need empty machines, first build up a list of machine ids which
 	// have containers so we can exclude those.
 	if requireEmpty {
-		containerRefsCollection, closer := db.GetCollection(containerRefsC)
-		defer closer()
+		containerRefsCollection, cCloser := db.GetCollection(containerRefsC)
+		defer cCloser()
 
 		err := containerRefsCollection.Find(bson.D{hasContainerTerm}).All(&containerRefs)
 		if err != nil {
@@ -2502,8 +2502,8 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 		suitableTerms = append(suitableTerms, bson.DocElem{"availzone", bson.D{{"$in", *cons.Zones}}})
 	}
 	if len(suitableTerms) > 0 {
-		instanceDataCollection, closer := db.GetCollection(instanceDataC)
-		defer closer()
+		instanceDataCollection, iCloser := db.GetCollection(instanceDataC)
+		defer iCloser()
 
 		var suitableInstanceData []instanceData
 		err := instanceDataCollection.Find(suitableTerms).Select(bson.M{"_id": 1}).All(&suitableInstanceData)

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3123,6 +3123,7 @@ func ReplaceNeverSetWithUnset(pool *StatePool) (err error) {
 				upgradesLogger.Infof("updating %d statuses (%d total)", len(ops), totalOps)
 				err = st.db().RunTransaction(ops)
 				if err != nil {
+					_ = iter.Close()
 					return errors.Trace(err)
 				}
 				ops = ops[:0]
@@ -3483,6 +3484,9 @@ func RemoveUnusedLinkLayerDeviceProviderIDs(pool *StatePool) error {
 	iter := lldCol.Find(bson.M{"providerid": bson.M{"$exists": true}}).Iter()
 	for iter.Next(&doc) {
 		used.Add(strings.Join([]string{doc.ModelUUID, idType, doc.ProviderID}, ":"))
+	}
+	if err := iter.Close(); err != nil {
+		return errors.Trace(err)
 	}
 
 	pidCol, pidCloser := st.db().GetRawCollection(providerIDsC)


### PR DESCRIPTION
These changes follow an audit ensuring we close all collections and iterators that we open in the state package.

- Some larger loops now have closures ensuring sooner execution of deferred close calls.
- Where we open multiple collections in a method, closers are disambiguated with different variables.
- Some missing calls to close iterators are added.

## QA steps

Non-functional changes, verified by our test suite.

## Documentation changes

None.

## Bug reference

N/A
