### PR TITLE
Fix unmanaged "controller" namespace clash with "controller" model.

### DIFF
--- a/caas/kubernetes/provider/admissionregistration.go
+++ b/caas/kubernetes/provider/admissionregistration.go
@@ -41,6 +41,9 @@ func decideNameForGlobalResource(meta k8sspecs.Meta, namespace string, isLegacy 
 func (k *kubernetesClient) ensureMutatingWebhookConfigurations(
 	appName string, annotations k8sannotations.Annotation, cfgs []k8sspecs.K8sMutatingWebhook,
 ) (cleanUps []func(), err error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	for _, v := range cfgs {
 		obj := metav1.ObjectMeta{
 			Name:        decideNameForGlobalResource(v.Meta, k.namespace, k.IsLegacyLabels()),
@@ -200,6 +203,9 @@ func (k *kubernetesClient) deleteMutatingWebhookConfigurationsForApp(appName str
 func (k *kubernetesClient) ensureValidatingWebhookConfigurations(
 	appName string, annotations k8sannotations.Annotation, cfgs []k8sspecs.K8sValidatingWebhook,
 ) (cleanUps []func(), err error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	for _, v := range cfgs {
 		obj := metav1.ObjectMeta{
 			Name:        decideNameForGlobalResource(v.Meta, k.namespace, k.IsLegacyLabels()),

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -469,5 +469,9 @@ func (k *kubernetesClient) getCustomResourceDefinitionClient(crd *apiextensionsv
 	if !isCRDScopeNamespaced(crd.Spec.Scope) {
 		return client, nil
 	}
+
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	return client.Namespace(k.namespace), nil
 }

--- a/caas/kubernetes/provider/daemonset.go
+++ b/caas/kubernetes/provider/daemonset.go
@@ -41,6 +41,9 @@ func (k *kubernetesClient) ensureDaemonSet(spec *apps.DaemonSet) (func(), error)
 }
 
 func (k *kubernetesClient) createDaemonSet(spec *apps.DaemonSet) (*apps.DaemonSet, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	utils.PurifyResource(spec)
 	out, err := k.client().AppsV1().DaemonSets(k.namespace).Create(context.TODO(), spec, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
@@ -50,6 +53,9 @@ func (k *kubernetesClient) createDaemonSet(spec *apps.DaemonSet) (*apps.DaemonSe
 }
 
 func (k *kubernetesClient) getDaemonSet(name string) (*apps.DaemonSet, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().AppsV1().DaemonSets(k.namespace).Get(context.TODO(), name, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("daemon set %q", name)
@@ -58,6 +64,9 @@ func (k *kubernetesClient) getDaemonSet(name string) (*apps.DaemonSet, error) {
 }
 
 func (k *kubernetesClient) updateDaemonSet(spec *apps.DaemonSet) (*apps.DaemonSet, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().AppsV1().DaemonSets(k.namespace).Update(context.TODO(), spec, v1.UpdateOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("daemon set %q", spec.GetName())
@@ -66,6 +75,9 @@ func (k *kubernetesClient) updateDaemonSet(spec *apps.DaemonSet) (*apps.DaemonSe
 }
 
 func (k *kubernetesClient) deleteDaemonSet(name string, uid types.UID) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().AppsV1().DaemonSets(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -74,6 +86,9 @@ func (k *kubernetesClient) deleteDaemonSet(name string, uid types.UID) error {
 }
 
 func (k *kubernetesClient) listDaemonSets(labels map[string]string) ([]apps.DaemonSet, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	listOps := v1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(labels).String(),
 	}
@@ -88,6 +103,9 @@ func (k *kubernetesClient) listDaemonSets(labels map[string]string) ([]apps.Daem
 }
 
 func (k *kubernetesClient) deleteDaemonSets(appName string) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
 	err := k.client().AppsV1().DaemonSets(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),

--- a/caas/kubernetes/provider/errors.go
+++ b/caas/kubernetes/provider/errors.go
@@ -8,6 +8,10 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
+var (
+	errNoNamespace = errors.NotProvisionedf("bootstrap broker or no namespace")
+)
+
 // ClusterQueryError represents an issue when querying a cluster.
 type ClusterQueryError struct {
 	Message string

--- a/caas/kubernetes/provider/events.go
+++ b/caas/kubernetes/provider/events.go
@@ -45,6 +45,9 @@ const (
 )
 
 func (k *kubernetesClient) getEvents(objName string, objKind string) ([]core.Event, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	selector := fields.AndSelectors(
 		fields.OneTermEqualSelector("involvedObject.name", objName),
 		fields.OneTermEqualSelector("involvedObject.kind", objKind),
@@ -60,6 +63,9 @@ func (k *kubernetesClient) getEvents(objName string, objKind string) ([]core.Eve
 }
 
 func (k *kubernetesClient) watchEvents(objName string, objKind string) (watcher.NotifyWatcher, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	factory := informers.NewSharedInformerFactoryWithOptions(k.client(), 0,
 		informers.WithNamespace(k.namespace),
 		informers.WithTweakListOptions(func(o *v1.ListOptions) {

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -101,6 +101,9 @@ func (k *kubernetesClient) ensureIngressResources(
 
 func (k *kubernetesClient) ensureIngressV1beta1(appName string, spec *networkingv1beta1.Ingress, force bool) (func(), error) {
 	cleanUp := func() {}
+	if k.namespace == "" {
+		return cleanUp, errNoNamespace
+	}
 	api := k.client().NetworkingV1beta1().Ingresses(k.namespace)
 	out, err := api.Create(context.TODO(), spec, metav1.CreateOptions{})
 	if err == nil {
@@ -134,6 +137,9 @@ func (k *kubernetesClient) ensureIngressV1beta1(appName string, spec *networking
 
 func (k *kubernetesClient) ensureIngressV1(appName string, spec *networkingv1.Ingress, force bool) (func(), error) {
 	cleanUp := func() {}
+	if k.namespace == "" {
+		return cleanUp, errNoNamespace
+	}
 	api := k.client().NetworkingV1().Ingresses(k.namespace)
 	out, err := api.Create(context.TODO(), spec, metav1.CreateOptions{})
 	if err == nil {
@@ -166,6 +172,9 @@ func (k *kubernetesClient) ensureIngressV1(appName string, spec *networkingv1.In
 }
 
 func (k *kubernetesClient) deleteIngress(name string, uid k8stypes.UID) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().NetworkingV1().Ingresses(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -174,6 +183,9 @@ func (k *kubernetesClient) deleteIngress(name string, uid k8stypes.UID) error {
 }
 
 func (k *kubernetesClient) deleteIngressResources(appName string) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().NetworkingV1().Ingresses(k.namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, metav1.ListOptions{

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	jujuclock "github.com/juju/clock"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -54,6 +55,7 @@ import (
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type K8sSuite struct {
@@ -63,7 +65,6 @@ type K8sSuite struct {
 var _ = gc.Suite(&K8sSuite{})
 
 func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
-
 	podSpec := specs.PodSpec{
 		ServiceAccount: primeServiceAccount,
 	}
@@ -794,6 +795,49 @@ func (s *K8sBrokerSuite) assertFileSetToVolume(c *gc.C, fs specs.FileSet, result
 		workloadSpec, fs, cfgMapName,
 	)
 	resultChecker(vol, err)
+}
+
+func (s *K8sBrokerSuite) TestNoNamespaceBroker(c *gc.C) {
+	ctrl := gomock.NewController(c)
+
+	s.clock = testclock.NewClock(time.Time{})
+
+	newK8sClientFunc, newK8sRestFunc := s.setupK8sRestClient(c, ctrl, "")
+	randomPrefixFunc := func() (string, error) {
+		return "appuuid", nil
+	}
+	watcherFn := k8swatcher.NewK8sWatcherFunc(func(i cache.SharedIndexInformer, n string, c jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
+		return nil, errors.NewNotFound(nil, "undefined k8sWatcherFn for base test")
+	})
+	stringsWatcherFn := k8swatcher.NewK8sStringsWatcherFunc(func(i cache.SharedIndexInformer, n string, c jujuclock.Clock, e []string,
+		f k8swatcher.K8sStringsWatcherFilterFunc) (k8swatcher.KubernetesStringsWatcher, error) {
+		return nil, errors.NewNotFound(nil, "undefined k8sStringsWatcherFn for base test")
+	})
+
+	var err error
+	s.broker, err = provider.NewK8sBroker(coretesting.ControllerTag.Id(), s.k8sRestConfig, s.cfg, "", newK8sClientFunc, newK8sRestFunc,
+		watcherFn, stringsWatcherFn, randomPrefixFunc, s.clock)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Test namespace is actually empty string and a namespaced method fails.
+	_, err = s.broker.GetPod("test")
+	c.Assert(err, gc.ErrorMatches, `bootstrap broker or no namespace not provisioned`)
+
+	nsInput := s.ensureJujuNamespaceAnnotations(false, &core.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test",
+		},
+	})
+
+	gomock.InOrder(
+		s.mockNamespaces.EXPECT().Get(gomock.Any(), "test", v1.GetOptions{}).Times(2).
+			Return(nsInput, nil),
+	)
+
+	// Check a cluster wide resource is still accessible.
+	ns, err := s.broker.GetNamespace("test")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ns, gc.DeepEquals, nsInput)
 }
 
 func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDMigrated(c *gc.C) {

--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -333,6 +333,9 @@ func (k *kubernetesClient) EnsureModelOperator(
 // ModelOperator return the model operator config used to create the current
 // model operator for this broker
 func (k *kubernetesClient) ModelOperator() (*caas.ModelOperatorConfig, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	operatorName := modelOperatorName
 	exists, err := k.ModelOperatorExists()
 	if err != nil {
@@ -481,6 +484,9 @@ func (k *kubernetesClient) ModelOperatorExists() (bool, error) {
 }
 
 func (k *kubernetesClient) modelOperatorDeploymentExists(operatorName string) (bool, error) {
+	if k.namespace == "" {
+		return false, errNoNamespace
+	}
 	_, err := k.client().AppsV1().Deployments(k.namespace).
 		Get(context.TODO(), operatorName, meta.GetOptions{})
 

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -198,6 +198,9 @@ func (k *kubernetesClient) deleteAllServiceAccountResources(appName string) erro
 }
 
 func (k *kubernetesClient) createServiceAccount(sa *core.ServiceAccount) (*core.ServiceAccount, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	utils.PurifyResource(sa)
 	out, err := k.client().CoreV1().ServiceAccounts(k.namespace).Create(context.TODO(), sa, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
@@ -207,6 +210,9 @@ func (k *kubernetesClient) createServiceAccount(sa *core.ServiceAccount) (*core.
 }
 
 func (k *kubernetesClient) updateServiceAccount(sa *core.ServiceAccount) (*core.ServiceAccount, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().CoreV1().ServiceAccounts(k.namespace).Update(context.TODO(), sa, v1.UpdateOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("service account %q", sa.GetName())
@@ -238,6 +244,9 @@ func (k *kubernetesClient) ensureServiceAccount(sa *core.ServiceAccount) (out *c
 }
 
 func (k *kubernetesClient) getServiceAccount(name string) (*core.ServiceAccount, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().CoreV1().ServiceAccounts(k.namespace).Get(context.TODO(), name, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("service account %q", name)
@@ -246,6 +255,9 @@ func (k *kubernetesClient) getServiceAccount(name string) (*core.ServiceAccount,
 }
 
 func (k *kubernetesClient) deleteServiceAccount(name string, uid types.UID) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().CoreV1().ServiceAccounts(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -270,6 +282,9 @@ func (k *kubernetesClient) deleteServiceAccounts(selectors ...k8slabels.Selector
 }
 
 func (k *kubernetesClient) listServiceAccount(labels map[string]string) ([]core.ServiceAccount, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	listOps := v1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(labels).String(),
 	}
@@ -284,6 +299,9 @@ func (k *kubernetesClient) listServiceAccount(labels map[string]string) ([]core.
 }
 
 func (k *kubernetesClient) createRole(role *rbacv1.Role) (*rbacv1.Role, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	utils.PurifyResource(role)
 	out, err := k.client().RbacV1().Roles(k.namespace).Create(context.TODO(), role, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
@@ -293,6 +311,9 @@ func (k *kubernetesClient) createRole(role *rbacv1.Role) (*rbacv1.Role, error) {
 }
 
 func (k *kubernetesClient) updateRole(role *rbacv1.Role) (*rbacv1.Role, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().RbacV1().Roles(k.namespace).Update(context.TODO(), role, v1.UpdateOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("role %q", role.GetName())
@@ -324,6 +345,9 @@ func (k *kubernetesClient) ensureRole(role *rbacv1.Role) (out *rbacv1.Role, clea
 }
 
 func (k *kubernetesClient) getRole(name string) (*rbacv1.Role, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().RbacV1().Roles(k.namespace).Get(context.TODO(), name, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("role %q", name)
@@ -332,6 +356,9 @@ func (k *kubernetesClient) getRole(name string) (*rbacv1.Role, error) {
 }
 
 func (k *kubernetesClient) deleteRole(name string, uid types.UID) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().RbacV1().Roles(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -340,6 +367,9 @@ func (k *kubernetesClient) deleteRole(name string, uid types.UID) error {
 }
 
 func (k *kubernetesClient) deleteRoles(selectors ...k8slabels.Selector) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	for _, selector := range selectors {
 		err := k.client().RbacV1().Roles(k.namespace).DeleteCollection(
 			context.TODO(),
@@ -356,6 +386,9 @@ func (k *kubernetesClient) deleteRoles(selectors ...k8slabels.Selector) error {
 }
 
 func (k *kubernetesClient) listRoles(selector k8slabels.Selector) ([]rbacv1.Role, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	listOps := v1.ListOptions{
 		LabelSelector: selector.String(),
 	}
@@ -396,6 +429,9 @@ func (k *kubernetesClient) listClusterRoles(selector k8slabels.Selector) ([]rbac
 }
 
 func (k *kubernetesClient) createRoleBinding(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	utils.PurifyResource(rb)
 	out, err := k.client().RbacV1().RoleBindings(k.namespace).Create(context.TODO(), rb, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
@@ -476,6 +512,9 @@ func (k *kubernetesClient) ensureRoleBinding(rb *rbacv1.RoleBinding) (out *rbacv
 }
 
 func (k *kubernetesClient) getRoleBinding(name string) (*rbacv1.RoleBinding, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().RbacV1().RoleBindings(k.namespace).Get(context.TODO(), name, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("role binding %q", name)
@@ -484,6 +523,9 @@ func (k *kubernetesClient) getRoleBinding(name string) (*rbacv1.RoleBinding, err
 }
 
 func (k *kubernetesClient) deleteRoleBinding(name string, uid types.UID) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().RbacV1().RoleBindings(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -492,6 +534,9 @@ func (k *kubernetesClient) deleteRoleBinding(name string, uid types.UID) error {
 }
 
 func (k *kubernetesClient) deleteRoleBindings(selectors ...k8slabels.Selector) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	for _, selector := range selectors {
 		err := k.client().RbacV1().RoleBindings(k.namespace).DeleteCollection(
 			context.TODO(),
@@ -508,6 +553,9 @@ func (k *kubernetesClient) deleteRoleBindings(selectors ...k8slabels.Selector) e
 }
 
 func (k *kubernetesClient) listRoleBindings(selector k8slabels.Selector) ([]rbacv1.RoleBinding, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	listOps := v1.ListOptions{
 		LabelSelector: selector.String(),
 	}

--- a/caas/kubernetes/provider/resources.go
+++ b/caas/kubernetes/provider/resources.go
@@ -18,6 +18,9 @@ import (
 // AdoptResources is called when the model is moved from one
 // controller to another using model migration.
 func (k *kubernetesClient) AdoptResources(ctx jujucontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	modelLabel := fmt.Sprintf("%v==%v", tags.JujuModel, k.modelUUID)
 
 	pods := k.client().CoreV1().Pods(k.namespace)

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -131,6 +131,9 @@ func (k *kubernetesClient) ensureSecret(sec *core.Secret) (func(), error) {
 
 // updateSecret updates a secret resource.
 func (k *kubernetesClient) updateSecret(sec *core.Secret) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	_, err := k.client().CoreV1().Secrets(k.namespace).Update(context.TODO(), sec, v1.UpdateOptions{})
 	if k8serrors.IsNotFound(err) {
 		return errors.NotFoundf("secret %q", sec.GetName())
@@ -140,6 +143,9 @@ func (k *kubernetesClient) updateSecret(sec *core.Secret) error {
 
 // getSecret return a secret resource.
 func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	secret, err := k.client().CoreV1().Secrets(k.namespace).Get(context.TODO(), secretName, v1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -152,6 +158,9 @@ func (k *kubernetesClient) getSecret(secretName string) (*core.Secret, error) {
 
 // createSecret creates a secret resource.
 func (k *kubernetesClient) createSecret(secret *core.Secret) (*core.Secret, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	utils.PurifyResource(secret)
 	out, err := k.client().CoreV1().Secrets(k.namespace).Create(context.TODO(), secret, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
@@ -162,6 +171,9 @@ func (k *kubernetesClient) createSecret(secret *core.Secret) (*core.Secret, erro
 
 // deleteSecret deletes a secret resource.
 func (k *kubernetesClient) deleteSecret(secretName string, uid types.UID) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().CoreV1().Secrets(k.namespace).Delete(context.TODO(), secretName, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -170,6 +182,9 @@ func (k *kubernetesClient) deleteSecret(secretName string, uid types.UID) error 
 }
 
 func (k *kubernetesClient) listSecrets(labels map[string]string) ([]core.Secret, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	listOps := v1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(labels).String(),
 	}
@@ -184,6 +199,9 @@ func (k *kubernetesClient) listSecrets(labels map[string]string) ([]core.Secret,
 }
 
 func (k *kubernetesClient) deleteSecrets(appName string) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().CoreV1().Secrets(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, v1.ListOptions{

--- a/caas/kubernetes/provider/services.go
+++ b/caas/kubernetes/provider/services.go
@@ -44,6 +44,9 @@ func (k *kubernetesClient) ensureServicesForApp(appName string, annotations k8sa
 // ensureK8sService ensures a k8s service resource.
 func (k *kubernetesClient) ensureK8sService(spec *core.Service) (func(), error) {
 	cleanUp := func() {}
+	if k.namespace == "" {
+		return cleanUp, errNoNamespace
+	}
 
 	api := k.client().CoreV1().Services(k.namespace)
 	// Set any immutable fields if the service already exists.
@@ -65,6 +68,9 @@ func (k *kubernetesClient) ensureK8sService(spec *core.Service) (func(), error) 
 
 // deleteService deletes a service resource.
 func (k *kubernetesClient) deleteService(serviceName string) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	services := k.client().CoreV1().Services(k.namespace)
 	err := services.Delete(context.TODO(), serviceName, v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
@@ -76,6 +82,9 @@ func (k *kubernetesClient) deleteService(serviceName string) error {
 }
 
 func (k *kubernetesClient) deleteServices(appName string) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	// Service API does not have `DeleteCollection` implemented, so we have to do it like this.
 	api := k.client().CoreV1().Services(k.namespace)
 	services, err := api.List(context.TODO(),

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -157,6 +157,9 @@ func (k *kubernetesClient) ensureStatefulSet(spec *apps.StatefulSet, existingPod
 }
 
 func (k *kubernetesClient) createStatefulSet(spec *apps.StatefulSet) (*apps.StatefulSet, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().AppsV1().StatefulSets(k.namespace).Create(context.TODO(), spec, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("stateful set %q", spec.GetName())
@@ -168,6 +171,9 @@ func (k *kubernetesClient) createStatefulSet(spec *apps.StatefulSet) (*apps.Stat
 }
 
 func (k *kubernetesClient) updateStatefulSet(spec *apps.StatefulSet) (*apps.StatefulSet, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().AppsV1().StatefulSets(k.namespace).Update(context.TODO(), spec, v1.UpdateOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("stateful set %q", spec.GetName())
@@ -179,6 +185,9 @@ func (k *kubernetesClient) updateStatefulSet(spec *apps.StatefulSet) (*apps.Stat
 }
 
 func (k *kubernetesClient) getStatefulSet(name string) (*apps.StatefulSet, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().AppsV1().StatefulSets(k.namespace).Get(context.TODO(), name, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("stateful set %q", name)
@@ -188,6 +197,9 @@ func (k *kubernetesClient) getStatefulSet(name string) (*apps.StatefulSet, error
 
 // deleteStatefulSet deletes a statefulset resource.
 func (k *kubernetesClient) deleteStatefulSet(name string) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().AppsV1().StatefulSets(k.namespace).Delete(context.TODO(), name, v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	})
@@ -199,6 +211,9 @@ func (k *kubernetesClient) deleteStatefulSet(name string) error {
 
 // deleteStatefulSet deletes all statefulset resources for an application.
 func (k *kubernetesClient) deleteStatefulSets(appName string) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
 	err := k.client().AppsV1().StatefulSets(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),

--- a/caas/kubernetes/provider/volume.go
+++ b/caas/kubernetes/provider/volume.go
@@ -88,6 +88,9 @@ func (k *kubernetesClient) ensurePVC(pvc *core.PersistentVolumeClaim) (*core.Per
 }
 
 func (k *kubernetesClient) createPVC(pvc *core.PersistentVolumeClaim) (*core.PersistentVolumeClaim, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().CoreV1().PersistentVolumeClaims(k.namespace).Create(context.TODO(), pvc, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		return nil, errors.AlreadyExistsf("PVC %q", pvc.GetName())
@@ -96,6 +99,9 @@ func (k *kubernetesClient) createPVC(pvc *core.PersistentVolumeClaim) (*core.Per
 }
 
 func (k *kubernetesClient) updatePVC(pvc *core.PersistentVolumeClaim) (*core.PersistentVolumeClaim, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	out, err := k.client().CoreV1().PersistentVolumeClaims(k.namespace).Update(context.TODO(), pvc, v1.UpdateOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("PVC %q", pvc.GetName())
@@ -104,6 +110,9 @@ func (k *kubernetesClient) updatePVC(pvc *core.PersistentVolumeClaim) (*core.Per
 }
 
 func (k *kubernetesClient) deletePVC(name string, uid types.UID) error {
+	if k.namespace == "" {
+		return errNoNamespace
+	}
 	err := k.client().CoreV1().PersistentVolumeClaims(k.namespace).Delete(context.TODO(), name, utils.NewPreconditionDeleteOptions(uid))
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -112,6 +121,9 @@ func (k *kubernetesClient) deletePVC(name string, uid types.UID) error {
 }
 
 func (k *kubernetesClient) getPVC(name string) (*core.PersistentVolumeClaim, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	pvc, err := k.client().CoreV1().PersistentVolumeClaims(k.namespace).Get(context.TODO(), name, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil, errors.NotFoundf("pvc %q", name)
@@ -309,6 +321,9 @@ func (k *kubernetesClient) volumeInfoForEmptyDir(vol core.Volume, volMount core.
 }
 
 func (k *kubernetesClient) volumeInfoForPVC(vol core.Volume, volMount core.VolumeMount, claimName string, now time.Time) (*caas.FilesystemInfo, error) {
+	if k.namespace == "" {
+		return nil, errNoNamespace
+	}
 	pvClaims := k.client().CoreV1().PersistentVolumeClaims(k.namespace)
 	pvc, err := pvClaims.Get(context.TODO(), claimName, v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {

--- a/core/annotations/annotations.go
+++ b/core/annotations/annotations.go
@@ -54,6 +54,12 @@ func (a Annotation) Add(key, value string) Annotation {
 	return a
 }
 
+// Remove deletes the key and its value from the annotation.
+func (a Annotation) Remove(key string) Annotation {
+	delete(a, key)
+	return a
+}
+
 // Merge merges an annotation with current one.
 func (a Annotation) Merge(as Annotation) Annotation {
 	for k, v := range as {

--- a/core/annotations/annotations_test.go
+++ b/core/annotations/annotations_test.go
@@ -39,6 +39,18 @@ func (s *annotationsSuite) TestExistAndAdd(c *gc.C) {
 	c.Assert(s.annotations.Has(key, "a new value"), jc.IsTrue)
 }
 
+func (s *annotationsSuite) TestRemove(c *gc.C) {
+	key := "annotation-1-key"
+	value := "annotation-1-val"
+	c.Assert(s.annotations.Has(key, value), jc.IsFalse)
+
+	s.annotations.Add(key, value)
+	c.Assert(s.annotations.Has(key, value), jc.IsTrue)
+
+	s.annotations.Remove(key)
+	c.Assert(s.annotations.Has(key, value), jc.IsFalse)
+}
+
 func (s *annotationsSuite) TestCopy(c *gc.C) {
 	annotation1 := map[string]string{
 		"annotation-1-key": "annotation-1-val",


### PR DESCRIPTION
While bootstrapping the namespace of the controller is unknown also during creating of the controller model's broker the namespace is unknown.

Previously the name of the controller model was used ("controller"). But the controller namespace is in the form of controller-<controller-name> (e.g. controller-microk8s-localhost). This means the target k8s cluster could legitimately have a namespace called "controller" that is not managed by juju.

This fixes this clash by using an empty string namespace for controller models when bootstrapping and forcing namespace resolution to always use the slow path for controller broker instances after bootstrap.

## QA steps

Should not see the error `namespace "controller" may already be in use`

```
$ juju bootstrap microk8s
$ juju deploy istio-pilot --trust
# wait for Istio-pilot to be ready
$ juju config istio-pilot trust
true
$ juju destroy-controller microk8s
```

## Documentation changes

N/A

## Bug reference

N/A