### PR TITLE
Use mongo 5 when installing the juju-db snap

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -60,18 +60,18 @@ jobs:
       if: (matrix.os == 'windows-latest')
       uses: crazy-max/ghaction-chocolatey@v1
       with:
-        args: install mongodb.install --version=4.4.11 --allow-downgrade
+        args: install mongodb.install --version=5.0.5 --allow-downgrade
 
     # GitHub runners already have preinstalled version of mongodb, but
-    # we specifically need 4.4.11, otherwise our tests will not pass
+    # we specifically need 5.0.5, otherwise our tests will not pass
     - name: "Install Mongo Dependencies: macOS-latest"
       if: (matrix.os == 'macOS-latest')
       run: |
-        curl -o mongodb-4.4.11.tgz https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.11.tgz
-        tar xzvf mongodb-4.4.11.tgz
+        curl -o mongodb.tgz https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-5.0.5.tgz
+        tar xzvf mongodb.tgz
         sudo rm -rf /usr/local/mongodb
         sudo mkdir -p /usr/local/mongodb
-        sudo mv mongodb-macos-x86_64-4.4.11/bin/* /usr/local/mongodb
+        sudo mv mongodb-macos-x86_64-5.0.5/bin/* /usr/local/mongodb
         sudo mkdir -p /usr/local/bin
         sudo rm /usr/local/bin/mongod
         sudo ln -s /usr/local/mongodb/mongod /usr/local/bin/mongod

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ endif
 
 WAIT_FOR_DPKG=sh -c '. "${PROJECT_DIR}/make_functions.sh"; wait_for_dpkg "$$@"' wait_for_dpkg
 
-JUJU_DB_CHANNEL=4.4/stable
+JUJU_DB_CHANNEL=5.0/stable
 install-mongo-dependencies:
 ## install-mongo-dependencies: Install Mongo and its dependencies
 	@echo Installing ${JUJU_DB_CHANNEL} juju-db snap for mongodb

--- a/acceptancetests/jujupy/controller.py
+++ b/acceptancetests/jujupy/controller.py
@@ -91,4 +91,4 @@ class ControllerConfig:
     def db_snap_channel(self):
         if 'juju-db-snap-channel' in self.cfg:
             return self.cfg["juju-db-snap-channel"]
-        return "4.4/stable"
+        return "5.0/stable"

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -400,7 +400,7 @@ func (*suite) TestAttributes(c *gc.C) {
 	c.Assert(conf.Dir(), gc.Equals, "/data/dir/agents/machine-1")
 	c.Assert(conf.Nonce(), gc.Equals, "a nonce")
 	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, jujuversion.Current)
-	c.Assert(conf.JujuDBSnapChannel(), gc.Equals, "4.4/stable")
+	c.Assert(conf.JujuDBSnapChannel(), gc.Equals, "5.0/stable")
 	c.Assert(conf.NonSyncedWritesToRaftLog(), jc.IsFalse)
 }
 

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -719,7 +719,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "mongodb",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "test-account/juju-db:4.4",
+			Image:           "test-account/juju-db:5.0",
 			Command: []string{
 				"/bin/sh",
 			},

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -58,7 +58,7 @@ func testPodLabels(c *gc.C, cfg *config.Config, jobs []model.MachineJob, expectT
 
 func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 	cfg := testing.FakeControllerConfig()
-	cfg["juju-db-snap-channel"] = "4.4/stable"
+	cfg["juju-db-snap-channel"] = "9.9/stable"
 	podConfig, err := podcfg.NewBootstrapControllerPodConfig(
 		cfg,
 		"controller-1",
@@ -73,13 +73,13 @@ func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 	c.Assert(path, gc.Equals, "jujusolutions/jujud-operator:6.6.6.666")
 	path, err = podConfig.GetJujuDbOCIImagePath()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.Equals, "jujusolutions/juju-db:4.4")
+	c.Assert(path, gc.Equals, "jujusolutions/juju-db:9.9")
 }
 
 func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
 	cfg := testing.FakeControllerConfig()
 	cfg["caas-image-repo"] = "path/to/my/repo"
-	cfg["juju-db-snap-channel"] = "4.4"
+	cfg["juju-db-snap-channel"] = "9.9"
 	podConfig, err := podcfg.NewBootstrapControllerPodConfig(
 		cfg,
 		"controller-1",
@@ -94,7 +94,7 @@ func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
 	c.Assert(path, gc.Equals, "path/to/my/repo/jujud-operator:6.6.6.666")
 	path, err = podConfig.GetJujuDbOCIImagePath()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(path, gc.Equals, "path/to/my/repo/juju-db:4.4")
+	c.Assert(path, gc.Equals, "path/to/my/repo/juju-db:9.9")
 }
 
 func (*podcfgSuite) TestBootstrapConstraints(c *gc.C) {

--- a/controller/config.go
+++ b/controller/config.go
@@ -283,7 +283,7 @@ const (
 
 	// DefaultJujuDBSnapChannel is the default snap channel for installing
 	// mongo in focal or later.
-	DefaultJujuDBSnapChannel = "4.4/stable"
+	DefaultJujuDBSnapChannel = "5.0/stable"
 
 	// DefaultMaxDebugLogDuration is the default duration that debug-log
 	// commands can run before being terminated by the API server.

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -70,7 +70,7 @@ func makeEnsureServerParams(dataDir, configDir string) mongo.EnsureServerParams 
 func (s *MongoSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	testing.PatchExecutable(c, s, "juju-db.mongod", "#!/bin/bash\n\nprintf %s 'db version v4.4.11'\n")
+	testing.PatchExecutable(c, s, "juju-db.mongod", "#!/bin/bash\n\nprintf %s 'db version v6.6.6'\n")
 	jujuMongodPath, err := exec.LookPath("juju-db.mongod")
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&mongo.JujuDbSnapMongodPath, jujuMongodPath)

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -71,7 +71,7 @@ func (s *oplogSuite) TestWithRealOplog(c *gc.C) {
 	// Update foo.bar and see the update reported.
 	err := coll.UpdateId("thing", bson.M{"$set": bson.M{"blah": 42}})
 	c.Assert(err, jc.ErrorIsNil)
-	assertOplog("u", bson.D{{"$set", bson.D{{"blah", 42}}}}, bson.D{{"_id", "thing"}})
+	assertOplog("u", bson.D{{"diff", bson.D{{"i", bson.D{{"blah", 42}}}}}}, bson.D{{"_id", "thing"}})
 
 	// Insert into another collection (shouldn't be reported due to filter).
 	s.insertDoc(c, session, db.C("elsewhere"), bson.M{"_id": "boo"})

--- a/service/snap/snap_test.go
+++ b/service/snap/snap_test.go
@@ -134,14 +134,14 @@ func (*serviceSuite) TestInstallCommands(c *gc.C) {
 			EnableAtStartup: true,
 		},
 	}
-	service, err := NewService("juju-db", "juju-db", conf, Command, "/path/to/config", "4.4/stable", "", backgroundServices, prerequisites)
+	service, err := NewService("juju-db", "juju-db", conf, Command, "/path/to/config", "9.9/stable", "", backgroundServices, prerequisites)
 	c.Assert(err, jc.ErrorIsNil)
 
 	commands, err := service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(commands, gc.DeepEquals, []string{
 		"snap install core",
-		"snap install --channel=4.4/stable juju-db",
+		"snap install --channel=9.9/stable juju-db",
 	})
 }
 
@@ -154,14 +154,14 @@ func (*serviceSuite) TestInstallCommandsWithConfinementPolicy(c *gc.C) {
 			EnableAtStartup: true,
 		},
 	}
-	service, err := NewService("juju-db", "juju-db", conf, Command, "/path/to/config", "4.4/stable", "classic", backgroundServices, prerequisites)
+	service, err := NewService("juju-db", "juju-db", conf, Command, "/path/to/config", "9.9/stable", "classic", backgroundServices, prerequisites)
 	c.Assert(err, jc.ErrorIsNil)
 
 	commands, err := service.InstallCommands()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(commands, gc.DeepEquals, []string{
 		"snap install core",
-		"snap install --channel=4.4/stable --classic juju-db",
+		"snap install --channel=9.9/stable --classic juju-db",
 	})
 }
 
@@ -174,7 +174,7 @@ func (*serviceSuite) TestInstall(c *gc.C) {
 
 	runnable := NewMockRunnable(ctrl)
 	runnable.EXPECT().Execute("snap", []string{"install", "core"}).Return("", nil)
-	runnable.EXPECT().Execute("snap", []string{"install", "--channel=4.4/stable", "juju-db"}).Return("", nil)
+	runnable.EXPECT().Execute("snap", []string{"install", "--channel=9.9/stable", "juju-db"}).Return("", nil)
 
 	conf := common.Conf{}
 	prerequisites := []Installable{NewNamedApp("core")}
@@ -184,7 +184,7 @@ func (*serviceSuite) TestInstall(c *gc.C) {
 			EnableAtStartup: true,
 		},
 	}
-	service, err := NewService("juju-db", "juju-db", conf, Command, "/path/to/config", "4.4/stable", "", backgroundServices, prerequisites)
+	service, err := NewService("juju-db", "juju-db", conf, Command, "/path/to/config", "9.9/stable", "", backgroundServices, prerequisites)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s := &service
@@ -214,7 +214,7 @@ func (*serviceSuite) TestInstallWithRetry(c *gc.C) {
 	runnable := NewMockRunnable(ctrl)
 	runnable.EXPECT().Execute("snap", []string{"install", "core"}).Return("", errors.New("bad"))
 	runnable.EXPECT().Execute("snap", []string{"install", "core"}).Return("", nil)
-	runnable.EXPECT().Execute("snap", []string{"install", "--channel=4.4/stable", "juju-db"}).Return("", nil)
+	runnable.EXPECT().Execute("snap", []string{"install", "--channel=9.9/stable", "juju-db"}).Return("", nil)
 
 	conf := common.Conf{}
 	prerequisites := []Installable{NewNamedApp("core")}
@@ -224,7 +224,7 @@ func (*serviceSuite) TestInstallWithRetry(c *gc.C) {
 			EnableAtStartup: true,
 		},
 	}
-	service, err := NewService("juju-db", "juju-db", conf, Command, "/path/to/config", "4.4/stable", "", backgroundServices, prerequisites)
+	service, err := NewService("juju-db", "juju-db", conf, Command, "/path/to/config", "9.9/stable", "", backgroundServices, prerequisites)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s := &service


### PR DESCRIPTION
The juju-sb snap channel now defaults to `5.0/stable`

An op log test was fixed to suit.
Plus a few unit tests use fake mongo versions to avoid churn when changing the version next time.

## QA steps

juju bootstrap
