### PR TITLE
[JUJU-408] update juju_start_unit

### DIFF
--- a/worker/deployer/nested_test.go
+++ b/worker/deployer/nested_test.go
@@ -205,6 +205,10 @@ func (s *NestedContextSuite) TestRecallUnit(c *gc.C) {
 }
 
 func (s *NestedContextSuite) TestErrTerminateAgentFromAgentWorker(c *gc.C) {
+	_ = s.errTerminateAgentFromAgentWorker(c)
+}
+
+func (s *NestedContextSuite) errTerminateAgentFromAgentWorker(c *gc.C) deployer.Context {
 	s.workers.workerError = jworker.ErrTerminateAgent
 	ctx := s.newContext(c)
 	unitName := "something/0"
@@ -226,6 +230,7 @@ func (s *NestedContextSuite) TestErrTerminateAgentFromAgentWorker(c *gc.C) {
 			"workers": map[string]interface{}{},
 		},
 	})
+	return ctx
 }
 
 func (s *NestedContextSuite) waitForStoppedCount(c *gc.C, ctx deployer.Context, length int) map[string]interface{} {
@@ -307,6 +312,43 @@ func (s *NestedContextSuite) TestStopStartUnits(c *gc.C) {
 
 	report = ctx.Report()
 	c.Assert(report["stopped"], jc.DeepEquals, []string{"second/0"})
+}
+
+func (s *NestedContextSuite) TestStartUnitAgent(c *gc.C) {
+	ctx := s.errTerminateAgentFromAgentWorker(c)
+	s.workers.workerError = nil
+
+	handledBothCalls := make(chan struct{})
+	count := 0
+	unsub := s.hub.Subscribe(message.StartUnitResponseTopic, func(_ string, data interface{}) {
+		c.Check(data, jc.DeepEquals, message.StartStopResponse{
+			"something/0": "started",
+			"unknown/2":   `unit "unknown/2" not found`,
+		})
+		count++
+		if count == 2 {
+			close(handledBothCalls)
+		}
+	})
+
+	// Start one back up again.
+	done := s.hub.Publish(message.StartUnitTopic, message.Units{
+		Names: []string{"something/0", "unknown/2"},
+	})
+	s.waitForEventHandled(c, pubsub.Wait(done))
+	// Wait for unit to start.
+	s.workers.waitForStart(c, "something/0")
+
+	// Called again gets the same results.
+	done = s.hub.Publish(message.StartUnitTopic, message.Units{
+		Names: []string{"something/0", "unknown/2"},
+	})
+	s.waitForEventHandled(c, pubsub.Wait(done))
+	s.waitForEventHandled(c, handledBothCalls)
+	unsub()
+
+	report := ctx.Report()
+	c.Assert(report["stopped"], gc.IsNil)
 }
 
 func (s *NestedContextSuite) TestUnitStatus(c *gc.C) {


### PR DESCRIPTION
In the course of having a resolution to the agent lost issue reported by 1956975, there wasn't a clean way to get back to a happy state.  The work around was to edit the machine's agent.conf file and bounce the machine agent.  

Today juju_start_unit only starts workers for a running agent.  This change has juju_start_unit start a newUnitAgent if it's not running, then starts the workers.  

When this problem is a found by a user, the lost agent, usually it's a month or more since the agent has been running.  Therefore start with a new agent, in case config have changed since it was last created.  This allows a new password to be setup and a new agent.conf to be written. 

juju_start_unit will get the unit started again when unit reports lost after an error such as: 
       Failed to connect to controller: invalid entity name or password (unauthorized access)


## QA steps

```console
$ juju bootstrap localhost testme
$ juju deploy ubuntu
$ juju deploy ntp
$ juju relate ntp ubuntu

# add a wrench and bounce ubuntu/0's machine agent.
$ juju ssh 0
$ sudo mkdir -p /var/lib/juju/wrench/
$ sudo vim /var/lib/juju/wrench/apiserver-admin
unit-ubuntu-0
$ ps axu | grep jujud
... 
$ sudo kill -9 <pid>
$ juju_unit_status
agent: machine-0
units:
  ntp/0: running
  ubuntu/0: stopped
$ exit

# remove the wrench
juju ssh  0  'sudo rm /var/lib/juju/wrench/apiserver-admin'

# go back to the juju machine
$ juju ssh 0
$ juju_start_unit ubuntu/0
ubuntu/0: started
$ juju_unit_status
agent: machine-0
units:
  ntp/0: running
  ubuntu/0: running

```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1956975
