### PR TITLE
[JUJU-447] Process offer permissions when migrating models

### DIFF
--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -97,6 +97,10 @@ func (s *applicationOffersSuite) TestRemove(c *gc.C) {
 
 	_, err = r.GetToken(names.NewApplicationTag(offer.OfferName))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	userPerms, err := s.State.GetOfferUsers(offer.OfferUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(userPerms, gc.HasLen, 0)
 }
 
 func (s *applicationOffersSuite) TestAddApplicationOffer(c *gc.C) {

--- a/state/migration_description_mock_test.go
+++ b/state/migration_description_mock_test.go
@@ -5,37 +5,38 @@
 package state
 
 import (
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description/v3"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
-	time "time"
 )
 
-// MockApplicationOffer is a mock of ApplicationOffer interface
+// MockApplicationOffer is a mock of ApplicationOffer interface.
 type MockApplicationOffer struct {
 	ctrl     *gomock.Controller
 	recorder *MockApplicationOfferMockRecorder
 }
 
-// MockApplicationOfferMockRecorder is the mock recorder for MockApplicationOffer
+// MockApplicationOfferMockRecorder is the mock recorder for MockApplicationOffer.
 type MockApplicationOfferMockRecorder struct {
 	mock *MockApplicationOffer
 }
 
-// NewMockApplicationOffer creates a new mock instance
+// NewMockApplicationOffer creates a new mock instance.
 func NewMockApplicationOffer(ctrl *gomock.Controller) *MockApplicationOffer {
 	mock := &MockApplicationOffer{ctrl: ctrl}
 	mock.recorder = &MockApplicationOfferMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplicationOffer) EXPECT() *MockApplicationOfferMockRecorder {
 	return m.recorder
 }
 
-// ACL mocks base method
+// ACL mocks base method.
 func (m *MockApplicationOffer) ACL() map[string]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ACL")
@@ -43,13 +44,13 @@ func (m *MockApplicationOffer) ACL() map[string]string {
 	return ret0
 }
 
-// ACL indicates an expected call of ACL
+// ACL indicates an expected call of ACL.
 func (mr *MockApplicationOfferMockRecorder) ACL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ACL", reflect.TypeOf((*MockApplicationOffer)(nil).ACL))
 }
 
-// ApplicationDescription mocks base method
+// ApplicationDescription mocks base method.
 func (m *MockApplicationOffer) ApplicationDescription() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationDescription")
@@ -57,13 +58,13 @@ func (m *MockApplicationOffer) ApplicationDescription() string {
 	return ret0
 }
 
-// ApplicationDescription indicates an expected call of ApplicationDescription
+// ApplicationDescription indicates an expected call of ApplicationDescription.
 func (mr *MockApplicationOfferMockRecorder) ApplicationDescription() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationDescription", reflect.TypeOf((*MockApplicationOffer)(nil).ApplicationDescription))
 }
 
-// ApplicationName mocks base method
+// ApplicationName mocks base method.
 func (m *MockApplicationOffer) ApplicationName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationName")
@@ -71,13 +72,13 @@ func (m *MockApplicationOffer) ApplicationName() string {
 	return ret0
 }
 
-// ApplicationName indicates an expected call of ApplicationName
+// ApplicationName indicates an expected call of ApplicationName.
 func (mr *MockApplicationOfferMockRecorder) ApplicationName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationName", reflect.TypeOf((*MockApplicationOffer)(nil).ApplicationName))
 }
 
-// Endpoints mocks base method
+// Endpoints mocks base method.
 func (m *MockApplicationOffer) Endpoints() map[string]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Endpoints")
@@ -85,13 +86,13 @@ func (m *MockApplicationOffer) Endpoints() map[string]string {
 	return ret0
 }
 
-// Endpoints indicates an expected call of Endpoints
+// Endpoints indicates an expected call of Endpoints.
 func (mr *MockApplicationOfferMockRecorder) Endpoints() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Endpoints", reflect.TypeOf((*MockApplicationOffer)(nil).Endpoints))
 }
 
-// OfferName mocks base method
+// OfferName mocks base method.
 func (m *MockApplicationOffer) OfferName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OfferName")
@@ -99,13 +100,13 @@ func (m *MockApplicationOffer) OfferName() string {
 	return ret0
 }
 
-// OfferName indicates an expected call of OfferName
+// OfferName indicates an expected call of OfferName.
 func (mr *MockApplicationOfferMockRecorder) OfferName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfferName", reflect.TypeOf((*MockApplicationOffer)(nil).OfferName))
 }
 
-// OfferUUID mocks base method
+// OfferUUID mocks base method.
 func (m *MockApplicationOffer) OfferUUID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OfferUUID")
@@ -113,36 +114,36 @@ func (m *MockApplicationOffer) OfferUUID() string {
 	return ret0
 }
 
-// OfferUUID indicates an expected call of OfferUUID
+// OfferUUID indicates an expected call of OfferUUID.
 func (mr *MockApplicationOfferMockRecorder) OfferUUID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfferUUID", reflect.TypeOf((*MockApplicationOffer)(nil).OfferUUID))
 }
 
-// MockExternalController is a mock of ExternalController interface
+// MockExternalController is a mock of ExternalController interface.
 type MockExternalController struct {
 	ctrl     *gomock.Controller
 	recorder *MockExternalControllerMockRecorder
 }
 
-// MockExternalControllerMockRecorder is the mock recorder for MockExternalController
+// MockExternalControllerMockRecorder is the mock recorder for MockExternalController.
 type MockExternalControllerMockRecorder struct {
 	mock *MockExternalController
 }
 
-// NewMockExternalController creates a new mock instance
+// NewMockExternalController creates a new mock instance.
 func NewMockExternalController(ctrl *gomock.Controller) *MockExternalController {
 	mock := &MockExternalController{ctrl: ctrl}
 	mock.recorder = &MockExternalControllerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExternalController) EXPECT() *MockExternalControllerMockRecorder {
 	return m.recorder
 }
 
-// Addrs mocks base method
+// Addrs mocks base method.
 func (m *MockExternalController) Addrs() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Addrs")
@@ -150,13 +151,13 @@ func (m *MockExternalController) Addrs() []string {
 	return ret0
 }
 
-// Addrs indicates an expected call of Addrs
+// Addrs indicates an expected call of Addrs.
 func (mr *MockExternalControllerMockRecorder) Addrs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addrs", reflect.TypeOf((*MockExternalController)(nil).Addrs))
 }
 
-// Alias mocks base method
+// Alias mocks base method.
 func (m *MockExternalController) Alias() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Alias")
@@ -164,13 +165,13 @@ func (m *MockExternalController) Alias() string {
 	return ret0
 }
 
-// Alias indicates an expected call of Alias
+// Alias indicates an expected call of Alias.
 func (mr *MockExternalControllerMockRecorder) Alias() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Alias", reflect.TypeOf((*MockExternalController)(nil).Alias))
 }
 
-// CACert mocks base method
+// CACert mocks base method.
 func (m *MockExternalController) CACert() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CACert")
@@ -178,13 +179,13 @@ func (m *MockExternalController) CACert() string {
 	return ret0
 }
 
-// CACert indicates an expected call of CACert
+// CACert indicates an expected call of CACert.
 func (mr *MockExternalControllerMockRecorder) CACert() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockExternalController)(nil).CACert))
 }
 
-// ID mocks base method
+// ID mocks base method.
 func (m *MockExternalController) ID() names.ControllerTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ID")
@@ -192,13 +193,13 @@ func (m *MockExternalController) ID() names.ControllerTag {
 	return ret0
 }
 
-// ID indicates an expected call of ID
+// ID indicates an expected call of ID.
 func (mr *MockExternalControllerMockRecorder) ID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockExternalController)(nil).ID))
 }
 
-// Models mocks base method
+// Models mocks base method.
 func (m *MockExternalController) Models() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Models")
@@ -206,36 +207,36 @@ func (m *MockExternalController) Models() []string {
 	return ret0
 }
 
-// Models indicates an expected call of Models
+// Models indicates an expected call of Models.
 func (mr *MockExternalControllerMockRecorder) Models() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Models", reflect.TypeOf((*MockExternalController)(nil).Models))
 }
 
-// MockFirewallRule is a mock of FirewallRule interface
+// MockFirewallRule is a mock of FirewallRule interface.
 type MockFirewallRule struct {
 	ctrl     *gomock.Controller
 	recorder *MockFirewallRuleMockRecorder
 }
 
-// MockFirewallRuleMockRecorder is the mock recorder for MockFirewallRule
+// MockFirewallRuleMockRecorder is the mock recorder for MockFirewallRule.
 type MockFirewallRuleMockRecorder struct {
 	mock *MockFirewallRule
 }
 
-// NewMockFirewallRule creates a new mock instance
+// NewMockFirewallRule creates a new mock instance.
 func NewMockFirewallRule(ctrl *gomock.Controller) *MockFirewallRule {
 	mock := &MockFirewallRule{ctrl: ctrl}
 	mock.recorder = &MockFirewallRuleMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFirewallRule) EXPECT() *MockFirewallRuleMockRecorder {
 	return m.recorder
 }
 
-// ID mocks base method
+// ID mocks base method.
 func (m *MockFirewallRule) ID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ID")
@@ -243,13 +244,13 @@ func (m *MockFirewallRule) ID() string {
 	return ret0
 }
 
-// ID indicates an expected call of ID
+// ID indicates an expected call of ID.
 func (mr *MockFirewallRuleMockRecorder) ID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockFirewallRule)(nil).ID))
 }
 
-// WellKnownService mocks base method
+// WellKnownService mocks base method.
 func (m *MockFirewallRule) WellKnownService() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WellKnownService")
@@ -257,13 +258,13 @@ func (m *MockFirewallRule) WellKnownService() string {
 	return ret0
 }
 
-// WellKnownService indicates an expected call of WellKnownService
+// WellKnownService indicates an expected call of WellKnownService.
 func (mr *MockFirewallRuleMockRecorder) WellKnownService() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WellKnownService", reflect.TypeOf((*MockFirewallRule)(nil).WellKnownService))
 }
 
-// WhitelistCIDRs mocks base method
+// WhitelistCIDRs mocks base method.
 func (m *MockFirewallRule) WhitelistCIDRs() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WhitelistCIDRs")
@@ -271,36 +272,36 @@ func (m *MockFirewallRule) WhitelistCIDRs() []string {
 	return ret0
 }
 
-// WhitelistCIDRs indicates an expected call of WhitelistCIDRs
+// WhitelistCIDRs indicates an expected call of WhitelistCIDRs.
 func (mr *MockFirewallRuleMockRecorder) WhitelistCIDRs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WhitelistCIDRs", reflect.TypeOf((*MockFirewallRule)(nil).WhitelistCIDRs))
 }
 
-// MockRemoteEntity is a mock of RemoteEntity interface
+// MockRemoteEntity is a mock of RemoteEntity interface.
 type MockRemoteEntity struct {
 	ctrl     *gomock.Controller
 	recorder *MockRemoteEntityMockRecorder
 }
 
-// MockRemoteEntityMockRecorder is the mock recorder for MockRemoteEntity
+// MockRemoteEntityMockRecorder is the mock recorder for MockRemoteEntity.
 type MockRemoteEntityMockRecorder struct {
 	mock *MockRemoteEntity
 }
 
-// NewMockRemoteEntity creates a new mock instance
+// NewMockRemoteEntity creates a new mock instance.
 func NewMockRemoteEntity(ctrl *gomock.Controller) *MockRemoteEntity {
 	mock := &MockRemoteEntity{ctrl: ctrl}
 	mock.recorder = &MockRemoteEntityMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemoteEntity) EXPECT() *MockRemoteEntityMockRecorder {
 	return m.recorder
 }
 
-// ID mocks base method
+// ID mocks base method.
 func (m *MockRemoteEntity) ID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ID")
@@ -308,13 +309,13 @@ func (m *MockRemoteEntity) ID() string {
 	return ret0
 }
 
-// ID indicates an expected call of ID
+// ID indicates an expected call of ID.
 func (mr *MockRemoteEntityMockRecorder) ID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockRemoteEntity)(nil).ID))
 }
 
-// Macaroon mocks base method
+// Macaroon mocks base method.
 func (m *MockRemoteEntity) Macaroon() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Macaroon")
@@ -322,13 +323,13 @@ func (m *MockRemoteEntity) Macaroon() string {
 	return ret0
 }
 
-// Macaroon indicates an expected call of Macaroon
+// Macaroon indicates an expected call of Macaroon.
 func (mr *MockRemoteEntityMockRecorder) Macaroon() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Macaroon", reflect.TypeOf((*MockRemoteEntity)(nil).Macaroon))
 }
 
-// Token mocks base method
+// Token mocks base method.
 func (m *MockRemoteEntity) Token() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Token")
@@ -336,36 +337,36 @@ func (m *MockRemoteEntity) Token() string {
 	return ret0
 }
 
-// Token indicates an expected call of Token
+// Token indicates an expected call of Token.
 func (mr *MockRemoteEntityMockRecorder) Token() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockRemoteEntity)(nil).Token))
 }
 
-// MockRelationNetwork is a mock of RelationNetwork interface
+// MockRelationNetwork is a mock of RelationNetwork interface.
 type MockRelationNetwork struct {
 	ctrl     *gomock.Controller
 	recorder *MockRelationNetworkMockRecorder
 }
 
-// MockRelationNetworkMockRecorder is the mock recorder for MockRelationNetwork
+// MockRelationNetworkMockRecorder is the mock recorder for MockRelationNetwork.
 type MockRelationNetworkMockRecorder struct {
 	mock *MockRelationNetwork
 }
 
-// NewMockRelationNetwork creates a new mock instance
+// NewMockRelationNetwork creates a new mock instance.
 func NewMockRelationNetwork(ctrl *gomock.Controller) *MockRelationNetwork {
 	mock := &MockRelationNetwork{ctrl: ctrl}
 	mock.recorder = &MockRelationNetworkMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRelationNetwork) EXPECT() *MockRelationNetworkMockRecorder {
 	return m.recorder
 }
 
-// CIDRS mocks base method
+// CIDRS mocks base method.
 func (m *MockRelationNetwork) CIDRS() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CIDRS")
@@ -373,13 +374,13 @@ func (m *MockRelationNetwork) CIDRS() []string {
 	return ret0
 }
 
-// CIDRS indicates an expected call of CIDRS
+// CIDRS indicates an expected call of CIDRS.
 func (mr *MockRelationNetworkMockRecorder) CIDRS() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CIDRS", reflect.TypeOf((*MockRelationNetwork)(nil).CIDRS))
 }
 
-// ID mocks base method
+// ID mocks base method.
 func (m *MockRelationNetwork) ID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ID")
@@ -387,13 +388,13 @@ func (m *MockRelationNetwork) ID() string {
 	return ret0
 }
 
-// ID indicates an expected call of ID
+// ID indicates an expected call of ID.
 func (mr *MockRelationNetworkMockRecorder) ID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockRelationNetwork)(nil).ID))
 }
 
-// RelationKey mocks base method
+// RelationKey mocks base method.
 func (m *MockRelationNetwork) RelationKey() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RelationKey")
@@ -401,36 +402,36 @@ func (m *MockRelationNetwork) RelationKey() string {
 	return ret0
 }
 
-// RelationKey indicates an expected call of RelationKey
+// RelationKey indicates an expected call of RelationKey.
 func (mr *MockRelationNetworkMockRecorder) RelationKey() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationKey", reflect.TypeOf((*MockRelationNetwork)(nil).RelationKey))
 }
 
-// MockRemoteApplication is a mock of RemoteApplication interface
+// MockRemoteApplication is a mock of RemoteApplication interface.
 type MockRemoteApplication struct {
 	ctrl     *gomock.Controller
 	recorder *MockRemoteApplicationMockRecorder
 }
 
-// MockRemoteApplicationMockRecorder is the mock recorder for MockRemoteApplication
+// MockRemoteApplicationMockRecorder is the mock recorder for MockRemoteApplication.
 type MockRemoteApplicationMockRecorder struct {
 	mock *MockRemoteApplication
 }
 
-// NewMockRemoteApplication creates a new mock instance
+// NewMockRemoteApplication creates a new mock instance.
 func NewMockRemoteApplication(ctrl *gomock.Controller) *MockRemoteApplication {
 	mock := &MockRemoteApplication{ctrl: ctrl}
 	mock.recorder = &MockRemoteApplicationMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemoteApplication) EXPECT() *MockRemoteApplicationMockRecorder {
 	return m.recorder
 }
 
-// AddEndpoint mocks base method
+// AddEndpoint mocks base method.
 func (m *MockRemoteApplication) AddEndpoint(arg0 description.RemoteEndpointArgs) description.RemoteEndpoint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddEndpoint", arg0)
@@ -438,13 +439,13 @@ func (m *MockRemoteApplication) AddEndpoint(arg0 description.RemoteEndpointArgs)
 	return ret0
 }
 
-// AddEndpoint indicates an expected call of AddEndpoint
+// AddEndpoint indicates an expected call of AddEndpoint.
 func (mr *MockRemoteApplicationMockRecorder) AddEndpoint(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoint", reflect.TypeOf((*MockRemoteApplication)(nil).AddEndpoint), arg0)
 }
 
-// AddSpace mocks base method
+// AddSpace mocks base method.
 func (m *MockRemoteApplication) AddSpace(arg0 description.RemoteSpaceArgs) description.RemoteSpace {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSpace", arg0)
@@ -452,13 +453,13 @@ func (m *MockRemoteApplication) AddSpace(arg0 description.RemoteSpaceArgs) descr
 	return ret0
 }
 
-// AddSpace indicates an expected call of AddSpace
+// AddSpace indicates an expected call of AddSpace.
 func (mr *MockRemoteApplicationMockRecorder) AddSpace(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpace", reflect.TypeOf((*MockRemoteApplication)(nil).AddSpace), arg0)
 }
 
-// Bindings mocks base method
+// Bindings mocks base method.
 func (m *MockRemoteApplication) Bindings() map[string]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Bindings")
@@ -466,13 +467,13 @@ func (m *MockRemoteApplication) Bindings() map[string]string {
 	return ret0
 }
 
-// Bindings indicates an expected call of Bindings
+// Bindings indicates an expected call of Bindings.
 func (mr *MockRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockRemoteApplication)(nil).Bindings))
 }
 
-// Endpoints mocks base method
+// Endpoints mocks base method.
 func (m *MockRemoteApplication) Endpoints() []description.RemoteEndpoint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Endpoints")
@@ -480,13 +481,13 @@ func (m *MockRemoteApplication) Endpoints() []description.RemoteEndpoint {
 	return ret0
 }
 
-// Endpoints indicates an expected call of Endpoints
+// Endpoints indicates an expected call of Endpoints.
 func (mr *MockRemoteApplicationMockRecorder) Endpoints() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Endpoints", reflect.TypeOf((*MockRemoteApplication)(nil).Endpoints))
 }
 
-// IsConsumerProxy mocks base method
+// IsConsumerProxy mocks base method.
 func (m *MockRemoteApplication) IsConsumerProxy() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsConsumerProxy")
@@ -494,13 +495,13 @@ func (m *MockRemoteApplication) IsConsumerProxy() bool {
 	return ret0
 }
 
-// IsConsumerProxy indicates an expected call of IsConsumerProxy
+// IsConsumerProxy indicates an expected call of IsConsumerProxy.
 func (mr *MockRemoteApplicationMockRecorder) IsConsumerProxy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConsumerProxy", reflect.TypeOf((*MockRemoteApplication)(nil).IsConsumerProxy))
 }
 
-// Macaroon mocks base method
+// Macaroon mocks base method.
 func (m *MockRemoteApplication) Macaroon() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Macaroon")
@@ -508,13 +509,13 @@ func (m *MockRemoteApplication) Macaroon() string {
 	return ret0
 }
 
-// Macaroon indicates an expected call of Macaroon
+// Macaroon indicates an expected call of Macaroon.
 func (mr *MockRemoteApplicationMockRecorder) Macaroon() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Macaroon", reflect.TypeOf((*MockRemoteApplication)(nil).Macaroon))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockRemoteApplication) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -522,13 +523,13 @@ func (m *MockRemoteApplication) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockRemoteApplicationMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockRemoteApplication)(nil).Name))
 }
 
-// OfferUUID mocks base method
+// OfferUUID mocks base method.
 func (m *MockRemoteApplication) OfferUUID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OfferUUID")
@@ -536,25 +537,25 @@ func (m *MockRemoteApplication) OfferUUID() string {
 	return ret0
 }
 
-// OfferUUID indicates an expected call of OfferUUID
+// OfferUUID indicates an expected call of OfferUUID.
 func (mr *MockRemoteApplicationMockRecorder) OfferUUID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OfferUUID", reflect.TypeOf((*MockRemoteApplication)(nil).OfferUUID))
 }
 
-// SetStatus mocks base method
+// SetStatus mocks base method.
 func (m *MockRemoteApplication) SetStatus(arg0 description.StatusArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetStatus", arg0)
 }
 
-// SetStatus indicates an expected call of SetStatus
+// SetStatus indicates an expected call of SetStatus.
 func (mr *MockRemoteApplicationMockRecorder) SetStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockRemoteApplication)(nil).SetStatus), arg0)
 }
 
-// SourceModelTag mocks base method
+// SourceModelTag mocks base method.
 func (m *MockRemoteApplication) SourceModelTag() names.ModelTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SourceModelTag")
@@ -562,13 +563,13 @@ func (m *MockRemoteApplication) SourceModelTag() names.ModelTag {
 	return ret0
 }
 
-// SourceModelTag indicates an expected call of SourceModelTag
+// SourceModelTag indicates an expected call of SourceModelTag.
 func (mr *MockRemoteApplicationMockRecorder) SourceModelTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SourceModelTag", reflect.TypeOf((*MockRemoteApplication)(nil).SourceModelTag))
 }
 
-// Spaces mocks base method
+// Spaces mocks base method.
 func (m *MockRemoteApplication) Spaces() []description.RemoteSpace {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Spaces")
@@ -576,13 +577,13 @@ func (m *MockRemoteApplication) Spaces() []description.RemoteSpace {
 	return ret0
 }
 
-// Spaces indicates an expected call of Spaces
+// Spaces indicates an expected call of Spaces.
 func (mr *MockRemoteApplicationMockRecorder) Spaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Spaces", reflect.TypeOf((*MockRemoteApplication)(nil).Spaces))
 }
 
-// Status mocks base method
+// Status mocks base method.
 func (m *MockRemoteApplication) Status() description.Status {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
@@ -590,13 +591,13 @@ func (m *MockRemoteApplication) Status() description.Status {
 	return ret0
 }
 
-// Status indicates an expected call of Status
+// Status indicates an expected call of Status.
 func (mr *MockRemoteApplicationMockRecorder) Status() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockRemoteApplication)(nil).Status))
 }
 
-// Tag mocks base method
+// Tag mocks base method.
 func (m *MockRemoteApplication) Tag() names.ApplicationTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -604,13 +605,13 @@ func (m *MockRemoteApplication) Tag() names.ApplicationTag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag
+// Tag indicates an expected call of Tag.
 func (mr *MockRemoteApplicationMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockRemoteApplication)(nil).Tag))
 }
 
-// URL mocks base method
+// URL mocks base method.
 func (m *MockRemoteApplication) URL() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "URL")
@@ -618,36 +619,36 @@ func (m *MockRemoteApplication) URL() string {
 	return ret0
 }
 
-// URL indicates an expected call of URL
+// URL indicates an expected call of URL.
 func (mr *MockRemoteApplicationMockRecorder) URL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockRemoteApplication)(nil).URL))
 }
 
-// MockRemoteSpace is a mock of RemoteSpace interface
+// MockRemoteSpace is a mock of RemoteSpace interface.
 type MockRemoteSpace struct {
 	ctrl     *gomock.Controller
 	recorder *MockRemoteSpaceMockRecorder
 }
 
-// MockRemoteSpaceMockRecorder is the mock recorder for MockRemoteSpace
+// MockRemoteSpaceMockRecorder is the mock recorder for MockRemoteSpace.
 type MockRemoteSpaceMockRecorder struct {
 	mock *MockRemoteSpace
 }
 
-// NewMockRemoteSpace creates a new mock instance
+// NewMockRemoteSpace creates a new mock instance.
 func NewMockRemoteSpace(ctrl *gomock.Controller) *MockRemoteSpace {
 	mock := &MockRemoteSpace{ctrl: ctrl}
 	mock.recorder = &MockRemoteSpaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemoteSpace) EXPECT() *MockRemoteSpaceMockRecorder {
 	return m.recorder
 }
 
-// AddSubnet mocks base method
+// AddSubnet mocks base method.
 func (m *MockRemoteSpace) AddSubnet(arg0 description.SubnetArgs) description.Subnet {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSubnet", arg0)
@@ -655,13 +656,13 @@ func (m *MockRemoteSpace) AddSubnet(arg0 description.SubnetArgs) description.Sub
 	return ret0
 }
 
-// AddSubnet indicates an expected call of AddSubnet
+// AddSubnet indicates an expected call of AddSubnet.
 func (mr *MockRemoteSpaceMockRecorder) AddSubnet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSubnet", reflect.TypeOf((*MockRemoteSpace)(nil).AddSubnet), arg0)
 }
 
-// CloudType mocks base method
+// CloudType mocks base method.
 func (m *MockRemoteSpace) CloudType() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloudType")
@@ -669,13 +670,13 @@ func (m *MockRemoteSpace) CloudType() string {
 	return ret0
 }
 
-// CloudType indicates an expected call of CloudType
+// CloudType indicates an expected call of CloudType.
 func (mr *MockRemoteSpaceMockRecorder) CloudType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudType", reflect.TypeOf((*MockRemoteSpace)(nil).CloudType))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockRemoteSpace) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -683,13 +684,13 @@ func (m *MockRemoteSpace) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockRemoteSpaceMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockRemoteSpace)(nil).Name))
 }
 
-// ProviderAttributes mocks base method
+// ProviderAttributes mocks base method.
 func (m *MockRemoteSpace) ProviderAttributes() map[string]interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderAttributes")
@@ -697,13 +698,13 @@ func (m *MockRemoteSpace) ProviderAttributes() map[string]interface{} {
 	return ret0
 }
 
-// ProviderAttributes indicates an expected call of ProviderAttributes
+// ProviderAttributes indicates an expected call of ProviderAttributes.
 func (mr *MockRemoteSpaceMockRecorder) ProviderAttributes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderAttributes", reflect.TypeOf((*MockRemoteSpace)(nil).ProviderAttributes))
 }
 
-// ProviderId mocks base method
+// ProviderId mocks base method.
 func (m *MockRemoteSpace) ProviderId() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderId")
@@ -711,13 +712,13 @@ func (m *MockRemoteSpace) ProviderId() string {
 	return ret0
 }
 
-// ProviderId indicates an expected call of ProviderId
+// ProviderId indicates an expected call of ProviderId.
 func (mr *MockRemoteSpaceMockRecorder) ProviderId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderId", reflect.TypeOf((*MockRemoteSpace)(nil).ProviderId))
 }
 
-// Subnets mocks base method
+// Subnets mocks base method.
 func (m *MockRemoteSpace) Subnets() []description.Subnet {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subnets")
@@ -725,36 +726,36 @@ func (m *MockRemoteSpace) Subnets() []description.Subnet {
 	return ret0
 }
 
-// Subnets indicates an expected call of Subnets
+// Subnets indicates an expected call of Subnets.
 func (mr *MockRemoteSpaceMockRecorder) Subnets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockRemoteSpace)(nil).Subnets))
 }
 
-// MockStatus is a mock of Status interface
+// MockStatus is a mock of Status interface.
 type MockStatus struct {
 	ctrl     *gomock.Controller
 	recorder *MockStatusMockRecorder
 }
 
-// MockStatusMockRecorder is the mock recorder for MockStatus
+// MockStatusMockRecorder is the mock recorder for MockStatus.
 type MockStatusMockRecorder struct {
 	mock *MockStatus
 }
 
-// NewMockStatus creates a new mock instance
+// NewMockStatus creates a new mock instance.
 func NewMockStatus(ctrl *gomock.Controller) *MockStatus {
 	mock := &MockStatus{ctrl: ctrl}
 	mock.recorder = &MockStatusMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStatus) EXPECT() *MockStatusMockRecorder {
 	return m.recorder
 }
 
-// Data mocks base method
+// Data mocks base method.
 func (m *MockStatus) Data() map[string]interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Data")
@@ -762,13 +763,13 @@ func (m *MockStatus) Data() map[string]interface{} {
 	return ret0
 }
 
-// Data indicates an expected call of Data
+// Data indicates an expected call of Data.
 func (mr *MockStatusMockRecorder) Data() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Data", reflect.TypeOf((*MockStatus)(nil).Data))
 }
 
-// Message mocks base method
+// Message mocks base method.
 func (m *MockStatus) Message() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Message")
@@ -776,13 +777,13 @@ func (m *MockStatus) Message() string {
 	return ret0
 }
 
-// Message indicates an expected call of Message
+// Message indicates an expected call of Message.
 func (mr *MockStatusMockRecorder) Message() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Message", reflect.TypeOf((*MockStatus)(nil).Message))
 }
 
-// NeverSet mocks base method
+// NeverSet mocks base method.
 func (m *MockStatus) NeverSet() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NeverSet")
@@ -790,13 +791,13 @@ func (m *MockStatus) NeverSet() bool {
 	return ret0
 }
 
-// NeverSet indicates an expected call of NeverSet
+// NeverSet indicates an expected call of NeverSet.
 func (mr *MockStatusMockRecorder) NeverSet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeverSet", reflect.TypeOf((*MockStatus)(nil).NeverSet))
 }
 
-// Updated mocks base method
+// Updated mocks base method.
 func (m *MockStatus) Updated() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Updated")
@@ -804,13 +805,13 @@ func (m *MockStatus) Updated() time.Time {
 	return ret0
 }
 
-// Updated indicates an expected call of Updated
+// Updated indicates an expected call of Updated.
 func (mr *MockStatusMockRecorder) Updated() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Updated", reflect.TypeOf((*MockStatus)(nil).Updated))
 }
 
-// Value mocks base method
+// Value mocks base method.
 func (m *MockStatus) Value() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Value")
@@ -818,7 +819,7 @@ func (m *MockStatus) Value() string {
 	return ret0
 }
 
-// Value indicates an expected call of Value
+// Value indicates an expected call of Value.
 func (mr *MockStatusMockRecorder) Value() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MockStatus)(nil).Value))

--- a/state/migration_import_input_mock_test.go
+++ b/state/migration_import_input_mock_test.go
@@ -5,36 +5,37 @@
 package state
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description/v3"
 	txn "github.com/juju/mgo/v2/txn"
-	reflect "reflect"
 )
 
-// MockRemoteEntitiesInput is a mock of RemoteEntitiesInput interface
+// MockRemoteEntitiesInput is a mock of RemoteEntitiesInput interface.
 type MockRemoteEntitiesInput struct {
 	ctrl     *gomock.Controller
 	recorder *MockRemoteEntitiesInputMockRecorder
 }
 
-// MockRemoteEntitiesInputMockRecorder is the mock recorder for MockRemoteEntitiesInput
+// MockRemoteEntitiesInputMockRecorder is the mock recorder for MockRemoteEntitiesInput.
 type MockRemoteEntitiesInputMockRecorder struct {
 	mock *MockRemoteEntitiesInput
 }
 
-// NewMockRemoteEntitiesInput creates a new mock instance
+// NewMockRemoteEntitiesInput creates a new mock instance.
 func NewMockRemoteEntitiesInput(ctrl *gomock.Controller) *MockRemoteEntitiesInput {
 	mock := &MockRemoteEntitiesInput{ctrl: ctrl}
 	mock.recorder = &MockRemoteEntitiesInputMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemoteEntitiesInput) EXPECT() *MockRemoteEntitiesInputMockRecorder {
 	return m.recorder
 }
 
-// DocID mocks base method
+// DocID mocks base method.
 func (m *MockRemoteEntitiesInput) DocID(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DocID", arg0)
@@ -42,13 +43,13 @@ func (m *MockRemoteEntitiesInput) DocID(arg0 string) string {
 	return ret0
 }
 
-// DocID indicates an expected call of DocID
+// DocID indicates an expected call of DocID.
 func (mr *MockRemoteEntitiesInputMockRecorder) DocID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocID", reflect.TypeOf((*MockRemoteEntitiesInput)(nil).DocID), arg0)
 }
 
-// RemoteEntities mocks base method
+// RemoteEntities mocks base method.
 func (m *MockRemoteEntitiesInput) RemoteEntities() []description.RemoteEntity {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteEntities")
@@ -56,36 +57,36 @@ func (m *MockRemoteEntitiesInput) RemoteEntities() []description.RemoteEntity {
 	return ret0
 }
 
-// RemoteEntities indicates an expected call of RemoteEntities
+// RemoteEntities indicates an expected call of RemoteEntities.
 func (mr *MockRemoteEntitiesInputMockRecorder) RemoteEntities() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteEntities", reflect.TypeOf((*MockRemoteEntitiesInput)(nil).RemoteEntities))
 }
 
-// MockRelationNetworksInput is a mock of RelationNetworksInput interface
+// MockRelationNetworksInput is a mock of RelationNetworksInput interface.
 type MockRelationNetworksInput struct {
 	ctrl     *gomock.Controller
 	recorder *MockRelationNetworksInputMockRecorder
 }
 
-// MockRelationNetworksInputMockRecorder is the mock recorder for MockRelationNetworksInput
+// MockRelationNetworksInputMockRecorder is the mock recorder for MockRelationNetworksInput.
 type MockRelationNetworksInputMockRecorder struct {
 	mock *MockRelationNetworksInput
 }
 
-// NewMockRelationNetworksInput creates a new mock instance
+// NewMockRelationNetworksInput creates a new mock instance.
 func NewMockRelationNetworksInput(ctrl *gomock.Controller) *MockRelationNetworksInput {
 	mock := &MockRelationNetworksInput{ctrl: ctrl}
 	mock.recorder = &MockRelationNetworksInputMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRelationNetworksInput) EXPECT() *MockRelationNetworksInputMockRecorder {
 	return m.recorder
 }
 
-// DocID mocks base method
+// DocID mocks base method.
 func (m *MockRelationNetworksInput) DocID(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DocID", arg0)
@@ -93,13 +94,13 @@ func (m *MockRelationNetworksInput) DocID(arg0 string) string {
 	return ret0
 }
 
-// DocID indicates an expected call of DocID
+// DocID indicates an expected call of DocID.
 func (mr *MockRelationNetworksInputMockRecorder) DocID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocID", reflect.TypeOf((*MockRelationNetworksInput)(nil).DocID), arg0)
 }
 
-// RelationNetworks mocks base method
+// RelationNetworks mocks base method.
 func (m *MockRelationNetworksInput) RelationNetworks() []description.RelationNetwork {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RelationNetworks")
@@ -107,36 +108,36 @@ func (m *MockRelationNetworksInput) RelationNetworks() []description.RelationNet
 	return ret0
 }
 
-// RelationNetworks indicates an expected call of RelationNetworks
+// RelationNetworks indicates an expected call of RelationNetworks.
 func (mr *MockRelationNetworksInputMockRecorder) RelationNetworks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationNetworks", reflect.TypeOf((*MockRelationNetworksInput)(nil).RelationNetworks))
 }
 
-// MockRemoteApplicationsInput is a mock of RemoteApplicationsInput interface
+// MockRemoteApplicationsInput is a mock of RemoteApplicationsInput interface.
 type MockRemoteApplicationsInput struct {
 	ctrl     *gomock.Controller
 	recorder *MockRemoteApplicationsInputMockRecorder
 }
 
-// MockRemoteApplicationsInputMockRecorder is the mock recorder for MockRemoteApplicationsInput
+// MockRemoteApplicationsInputMockRecorder is the mock recorder for MockRemoteApplicationsInput.
 type MockRemoteApplicationsInputMockRecorder struct {
 	mock *MockRemoteApplicationsInput
 }
 
-// NewMockRemoteApplicationsInput creates a new mock instance
+// NewMockRemoteApplicationsInput creates a new mock instance.
 func NewMockRemoteApplicationsInput(ctrl *gomock.Controller) *MockRemoteApplicationsInput {
 	mock := &MockRemoteApplicationsInput{ctrl: ctrl}
 	mock.recorder = &MockRemoteApplicationsInputMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemoteApplicationsInput) EXPECT() *MockRemoteApplicationsInputMockRecorder {
 	return m.recorder
 }
 
-// DocID mocks base method
+// DocID mocks base method.
 func (m *MockRemoteApplicationsInput) DocID(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DocID", arg0)
@@ -144,13 +145,13 @@ func (m *MockRemoteApplicationsInput) DocID(arg0 string) string {
 	return ret0
 }
 
-// DocID indicates an expected call of DocID
+// DocID indicates an expected call of DocID.
 func (mr *MockRemoteApplicationsInputMockRecorder) DocID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocID", reflect.TypeOf((*MockRemoteApplicationsInput)(nil).DocID), arg0)
 }
 
-// MakeRemoteApplicationDoc mocks base method
+// MakeRemoteApplicationDoc mocks base method.
 func (m *MockRemoteApplicationsInput) MakeRemoteApplicationDoc(arg0 description.RemoteApplication) *remoteApplicationDoc {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeRemoteApplicationDoc", arg0)
@@ -158,13 +159,13 @@ func (m *MockRemoteApplicationsInput) MakeRemoteApplicationDoc(arg0 description.
 	return ret0
 }
 
-// MakeRemoteApplicationDoc indicates an expected call of MakeRemoteApplicationDoc
+// MakeRemoteApplicationDoc indicates an expected call of MakeRemoteApplicationDoc.
 func (mr *MockRemoteApplicationsInputMockRecorder) MakeRemoteApplicationDoc(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRemoteApplicationDoc", reflect.TypeOf((*MockRemoteApplicationsInput)(nil).MakeRemoteApplicationDoc), arg0)
 }
 
-// MakeStatusDoc mocks base method
+// MakeStatusDoc mocks base method.
 func (m *MockRemoteApplicationsInput) MakeStatusDoc(arg0 description.Status) statusDoc {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeStatusDoc", arg0)
@@ -172,13 +173,13 @@ func (m *MockRemoteApplicationsInput) MakeStatusDoc(arg0 description.Status) sta
 	return ret0
 }
 
-// MakeStatusDoc indicates an expected call of MakeStatusDoc
+// MakeStatusDoc indicates an expected call of MakeStatusDoc.
 func (mr *MockRemoteApplicationsInputMockRecorder) MakeStatusDoc(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeStatusDoc", reflect.TypeOf((*MockRemoteApplicationsInput)(nil).MakeStatusDoc), arg0)
 }
 
-// MakeStatusOp mocks base method
+// MakeStatusOp mocks base method.
 func (m *MockRemoteApplicationsInput) MakeStatusOp(arg0 string, arg1 statusDoc) txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeStatusOp", arg0, arg1)
@@ -186,13 +187,13 @@ func (m *MockRemoteApplicationsInput) MakeStatusOp(arg0 string, arg1 statusDoc) 
 	return ret0
 }
 
-// MakeStatusOp indicates an expected call of MakeStatusOp
+// MakeStatusOp indicates an expected call of MakeStatusOp.
 func (mr *MockRemoteApplicationsInputMockRecorder) MakeStatusOp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeStatusOp", reflect.TypeOf((*MockRemoteApplicationsInput)(nil).MakeStatusOp), arg0, arg1)
 }
 
-// NewRemoteApplication mocks base method
+// NewRemoteApplication mocks base method.
 func (m *MockRemoteApplicationsInput) NewRemoteApplication(arg0 *remoteApplicationDoc) *RemoteApplication {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRemoteApplication", arg0)
@@ -200,13 +201,13 @@ func (m *MockRemoteApplicationsInput) NewRemoteApplication(arg0 *remoteApplicati
 	return ret0
 }
 
-// NewRemoteApplication indicates an expected call of NewRemoteApplication
+// NewRemoteApplication indicates an expected call of NewRemoteApplication.
 func (mr *MockRemoteApplicationsInputMockRecorder) NewRemoteApplication(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRemoteApplication", reflect.TypeOf((*MockRemoteApplicationsInput)(nil).NewRemoteApplication), arg0)
 }
 
-// RemoteApplications mocks base method
+// RemoteApplications mocks base method.
 func (m *MockRemoteApplicationsInput) RemoteApplications() []description.RemoteApplication {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoteApplications")
@@ -214,36 +215,36 @@ func (m *MockRemoteApplicationsInput) RemoteApplications() []description.RemoteA
 	return ret0
 }
 
-// RemoteApplications indicates an expected call of RemoteApplications
+// RemoteApplications indicates an expected call of RemoteApplications.
 func (mr *MockRemoteApplicationsInputMockRecorder) RemoteApplications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteApplications", reflect.TypeOf((*MockRemoteApplicationsInput)(nil).RemoteApplications))
 }
 
-// MockApplicationOfferStateDocumentFactory is a mock of ApplicationOfferStateDocumentFactory interface
+// MockApplicationOfferStateDocumentFactory is a mock of ApplicationOfferStateDocumentFactory interface.
 type MockApplicationOfferStateDocumentFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockApplicationOfferStateDocumentFactoryMockRecorder
 }
 
-// MockApplicationOfferStateDocumentFactoryMockRecorder is the mock recorder for MockApplicationOfferStateDocumentFactory
+// MockApplicationOfferStateDocumentFactoryMockRecorder is the mock recorder for MockApplicationOfferStateDocumentFactory.
 type MockApplicationOfferStateDocumentFactoryMockRecorder struct {
 	mock *MockApplicationOfferStateDocumentFactory
 }
 
-// NewMockApplicationOfferStateDocumentFactory creates a new mock instance
+// NewMockApplicationOfferStateDocumentFactory creates a new mock instance.
 func NewMockApplicationOfferStateDocumentFactory(ctrl *gomock.Controller) *MockApplicationOfferStateDocumentFactory {
 	mock := &MockApplicationOfferStateDocumentFactory{ctrl: ctrl}
 	mock.recorder = &MockApplicationOfferStateDocumentFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplicationOfferStateDocumentFactory) EXPECT() *MockApplicationOfferStateDocumentFactoryMockRecorder {
 	return m.recorder
 }
 
-// MakeApplicationOfferDoc mocks base method
+// MakeApplicationOfferDoc mocks base method.
 func (m *MockApplicationOfferStateDocumentFactory) MakeApplicationOfferDoc(arg0 description.ApplicationOffer) (applicationOfferDoc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeApplicationOfferDoc", arg0)
@@ -252,13 +253,13 @@ func (m *MockApplicationOfferStateDocumentFactory) MakeApplicationOfferDoc(arg0 
 	return ret0, ret1
 }
 
-// MakeApplicationOfferDoc indicates an expected call of MakeApplicationOfferDoc
+// MakeApplicationOfferDoc indicates an expected call of MakeApplicationOfferDoc.
 func (mr *MockApplicationOfferStateDocumentFactoryMockRecorder) MakeApplicationOfferDoc(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeApplicationOfferDoc", reflect.TypeOf((*MockApplicationOfferStateDocumentFactory)(nil).MakeApplicationOfferDoc), arg0)
 }
 
-// MakeIncApplicationOffersRefOp mocks base method
+// MakeIncApplicationOffersRefOp mocks base method.
 func (m *MockApplicationOfferStateDocumentFactory) MakeIncApplicationOffersRefOp(arg0 string) (txn.Op, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeIncApplicationOffersRefOp", arg0)
@@ -267,36 +268,36 @@ func (m *MockApplicationOfferStateDocumentFactory) MakeIncApplicationOffersRefOp
 	return ret0, ret1
 }
 
-// MakeIncApplicationOffersRefOp indicates an expected call of MakeIncApplicationOffersRefOp
+// MakeIncApplicationOffersRefOp indicates an expected call of MakeIncApplicationOffersRefOp.
 func (mr *MockApplicationOfferStateDocumentFactoryMockRecorder) MakeIncApplicationOffersRefOp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeIncApplicationOffersRefOp", reflect.TypeOf((*MockApplicationOfferStateDocumentFactory)(nil).MakeIncApplicationOffersRefOp), arg0)
 }
 
-// MockApplicationOfferInput is a mock of ApplicationOfferInput interface
+// MockApplicationOfferInput is a mock of ApplicationOfferInput interface.
 type MockApplicationOfferInput struct {
 	ctrl     *gomock.Controller
 	recorder *MockApplicationOfferInputMockRecorder
 }
 
-// MockApplicationOfferInputMockRecorder is the mock recorder for MockApplicationOfferInput
+// MockApplicationOfferInputMockRecorder is the mock recorder for MockApplicationOfferInput.
 type MockApplicationOfferInputMockRecorder struct {
 	mock *MockApplicationOfferInput
 }
 
-// NewMockApplicationOfferInput creates a new mock instance
+// NewMockApplicationOfferInput creates a new mock instance.
 func NewMockApplicationOfferInput(ctrl *gomock.Controller) *MockApplicationOfferInput {
 	mock := &MockApplicationOfferInput{ctrl: ctrl}
 	mock.recorder = &MockApplicationOfferInputMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplicationOfferInput) EXPECT() *MockApplicationOfferInputMockRecorder {
 	return m.recorder
 }
 
-// DocID mocks base method
+// DocID mocks base method.
 func (m *MockApplicationOfferInput) DocID(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DocID", arg0)
@@ -304,13 +305,13 @@ func (m *MockApplicationOfferInput) DocID(arg0 string) string {
 	return ret0
 }
 
-// DocID indicates an expected call of DocID
+// DocID indicates an expected call of DocID.
 func (mr *MockApplicationOfferInputMockRecorder) DocID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocID", reflect.TypeOf((*MockApplicationOfferInput)(nil).DocID), arg0)
 }
 
-// MakeApplicationOfferDoc mocks base method
+// MakeApplicationOfferDoc mocks base method.
 func (m *MockApplicationOfferInput) MakeApplicationOfferDoc(arg0 description.ApplicationOffer) (applicationOfferDoc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeApplicationOfferDoc", arg0)
@@ -319,13 +320,13 @@ func (m *MockApplicationOfferInput) MakeApplicationOfferDoc(arg0 description.App
 	return ret0, ret1
 }
 
-// MakeApplicationOfferDoc indicates an expected call of MakeApplicationOfferDoc
+// MakeApplicationOfferDoc indicates an expected call of MakeApplicationOfferDoc.
 func (mr *MockApplicationOfferInputMockRecorder) MakeApplicationOfferDoc(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeApplicationOfferDoc", reflect.TypeOf((*MockApplicationOfferInput)(nil).MakeApplicationOfferDoc), arg0)
 }
 
-// MakeIncApplicationOffersRefOp mocks base method
+// MakeIncApplicationOffersRefOp mocks base method.
 func (m *MockApplicationOfferInput) MakeIncApplicationOffersRefOp(arg0 string) (txn.Op, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeIncApplicationOffersRefOp", arg0)
@@ -334,13 +335,13 @@ func (m *MockApplicationOfferInput) MakeIncApplicationOffersRefOp(arg0 string) (
 	return ret0, ret1
 }
 
-// MakeIncApplicationOffersRefOp indicates an expected call of MakeIncApplicationOffersRefOp
+// MakeIncApplicationOffersRefOp indicates an expected call of MakeIncApplicationOffersRefOp.
 func (mr *MockApplicationOfferInputMockRecorder) MakeIncApplicationOffersRefOp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeIncApplicationOffersRefOp", reflect.TypeOf((*MockApplicationOfferInput)(nil).MakeIncApplicationOffersRefOp), arg0)
 }
 
-// Offers mocks base method
+// Offers mocks base method.
 func (m *MockApplicationOfferInput) Offers() []description.ApplicationOffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Offers")
@@ -348,36 +349,36 @@ func (m *MockApplicationOfferInput) Offers() []description.ApplicationOffer {
 	return ret0
 }
 
-// Offers indicates an expected call of Offers
+// Offers indicates an expected call of Offers.
 func (mr *MockApplicationOfferInputMockRecorder) Offers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Offers", reflect.TypeOf((*MockApplicationOfferInput)(nil).Offers))
 }
 
-// MockExternalControllerStateDocumentFactory is a mock of ExternalControllerStateDocumentFactory interface
+// MockExternalControllerStateDocumentFactory is a mock of ExternalControllerStateDocumentFactory interface.
 type MockExternalControllerStateDocumentFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockExternalControllerStateDocumentFactoryMockRecorder
 }
 
-// MockExternalControllerStateDocumentFactoryMockRecorder is the mock recorder for MockExternalControllerStateDocumentFactory
+// MockExternalControllerStateDocumentFactoryMockRecorder is the mock recorder for MockExternalControllerStateDocumentFactory.
 type MockExternalControllerStateDocumentFactoryMockRecorder struct {
 	mock *MockExternalControllerStateDocumentFactory
 }
 
-// NewMockExternalControllerStateDocumentFactory creates a new mock instance
+// NewMockExternalControllerStateDocumentFactory creates a new mock instance.
 func NewMockExternalControllerStateDocumentFactory(ctrl *gomock.Controller) *MockExternalControllerStateDocumentFactory {
 	mock := &MockExternalControllerStateDocumentFactory{ctrl: ctrl}
 	mock.recorder = &MockExternalControllerStateDocumentFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExternalControllerStateDocumentFactory) EXPECT() *MockExternalControllerStateDocumentFactoryMockRecorder {
 	return m.recorder
 }
 
-// ExternalControllerDoc mocks base method
+// ExternalControllerDoc mocks base method.
 func (m *MockExternalControllerStateDocumentFactory) ExternalControllerDoc(arg0 string) (*externalControllerDoc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExternalControllerDoc", arg0)
@@ -386,13 +387,13 @@ func (m *MockExternalControllerStateDocumentFactory) ExternalControllerDoc(arg0 
 	return ret0, ret1
 }
 
-// ExternalControllerDoc indicates an expected call of ExternalControllerDoc
+// ExternalControllerDoc indicates an expected call of ExternalControllerDoc.
 func (mr *MockExternalControllerStateDocumentFactoryMockRecorder) ExternalControllerDoc(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalControllerDoc", reflect.TypeOf((*MockExternalControllerStateDocumentFactory)(nil).ExternalControllerDoc), arg0)
 }
 
-// MakeExternalControllerOp mocks base method
+// MakeExternalControllerOp mocks base method.
 func (m *MockExternalControllerStateDocumentFactory) MakeExternalControllerOp(arg0 externalControllerDoc, arg1 *externalControllerDoc) txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeExternalControllerOp", arg0, arg1)
@@ -400,36 +401,36 @@ func (m *MockExternalControllerStateDocumentFactory) MakeExternalControllerOp(ar
 	return ret0
 }
 
-// MakeExternalControllerOp indicates an expected call of MakeExternalControllerOp
+// MakeExternalControllerOp indicates an expected call of MakeExternalControllerOp.
 func (mr *MockExternalControllerStateDocumentFactoryMockRecorder) MakeExternalControllerOp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeExternalControllerOp", reflect.TypeOf((*MockExternalControllerStateDocumentFactory)(nil).MakeExternalControllerOp), arg0, arg1)
 }
 
-// MockExternalControllersInput is a mock of ExternalControllersInput interface
+// MockExternalControllersInput is a mock of ExternalControllersInput interface.
 type MockExternalControllersInput struct {
 	ctrl     *gomock.Controller
 	recorder *MockExternalControllersInputMockRecorder
 }
 
-// MockExternalControllersInputMockRecorder is the mock recorder for MockExternalControllersInput
+// MockExternalControllersInputMockRecorder is the mock recorder for MockExternalControllersInput.
 type MockExternalControllersInputMockRecorder struct {
 	mock *MockExternalControllersInput
 }
 
-// NewMockExternalControllersInput creates a new mock instance
+// NewMockExternalControllersInput creates a new mock instance.
 func NewMockExternalControllersInput(ctrl *gomock.Controller) *MockExternalControllersInput {
 	mock := &MockExternalControllersInput{ctrl: ctrl}
 	mock.recorder = &MockExternalControllersInputMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExternalControllersInput) EXPECT() *MockExternalControllersInputMockRecorder {
 	return m.recorder
 }
 
-// ExternalControllerDoc mocks base method
+// ExternalControllerDoc mocks base method.
 func (m *MockExternalControllersInput) ExternalControllerDoc(arg0 string) (*externalControllerDoc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExternalControllerDoc", arg0)
@@ -438,13 +439,13 @@ func (m *MockExternalControllersInput) ExternalControllerDoc(arg0 string) (*exte
 	return ret0, ret1
 }
 
-// ExternalControllerDoc indicates an expected call of ExternalControllerDoc
+// ExternalControllerDoc indicates an expected call of ExternalControllerDoc.
 func (mr *MockExternalControllersInputMockRecorder) ExternalControllerDoc(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalControllerDoc", reflect.TypeOf((*MockExternalControllersInput)(nil).ExternalControllerDoc), arg0)
 }
 
-// ExternalControllers mocks base method
+// ExternalControllers mocks base method.
 func (m *MockExternalControllersInput) ExternalControllers() []description.ExternalController {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExternalControllers")
@@ -452,13 +453,13 @@ func (m *MockExternalControllersInput) ExternalControllers() []description.Exter
 	return ret0
 }
 
-// ExternalControllers indicates an expected call of ExternalControllers
+// ExternalControllers indicates an expected call of ExternalControllers.
 func (mr *MockExternalControllersInputMockRecorder) ExternalControllers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalControllers", reflect.TypeOf((*MockExternalControllersInput)(nil).ExternalControllers))
 }
 
-// MakeExternalControllerOp mocks base method
+// MakeExternalControllerOp mocks base method.
 func (m *MockExternalControllersInput) MakeExternalControllerOp(arg0 externalControllerDoc, arg1 *externalControllerDoc) txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeExternalControllerOp", arg0, arg1)
@@ -466,36 +467,36 @@ func (m *MockExternalControllersInput) MakeExternalControllerOp(arg0 externalCon
 	return ret0
 }
 
-// MakeExternalControllerOp indicates an expected call of MakeExternalControllerOp
+// MakeExternalControllerOp indicates an expected call of MakeExternalControllerOp.
 func (mr *MockExternalControllersInputMockRecorder) MakeExternalControllerOp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeExternalControllerOp", reflect.TypeOf((*MockExternalControllersInput)(nil).MakeExternalControllerOp), arg0, arg1)
 }
 
-// MockFirewallRulesInput is a mock of FirewallRulesInput interface
+// MockFirewallRulesInput is a mock of FirewallRulesInput interface.
 type MockFirewallRulesInput struct {
 	ctrl     *gomock.Controller
 	recorder *MockFirewallRulesInputMockRecorder
 }
 
-// MockFirewallRulesInputMockRecorder is the mock recorder for MockFirewallRulesInput
+// MockFirewallRulesInputMockRecorder is the mock recorder for MockFirewallRulesInput.
 type MockFirewallRulesInputMockRecorder struct {
 	mock *MockFirewallRulesInput
 }
 
-// NewMockFirewallRulesInput creates a new mock instance
+// NewMockFirewallRulesInput creates a new mock instance.
 func NewMockFirewallRulesInput(ctrl *gomock.Controller) *MockFirewallRulesInput {
 	mock := &MockFirewallRulesInput{ctrl: ctrl}
 	mock.recorder = &MockFirewallRulesInputMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFirewallRulesInput) EXPECT() *MockFirewallRulesInputMockRecorder {
 	return m.recorder
 }
 
-// FirewallRules mocks base method
+// FirewallRules mocks base method.
 func (m *MockFirewallRulesInput) FirewallRules() []description.FirewallRule {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FirewallRules")
@@ -503,7 +504,7 @@ func (m *MockFirewallRulesInput) FirewallRules() []description.FirewallRule {
 	return ret0
 }
 
-// FirewallRules indicates an expected call of FirewallRules
+// FirewallRules indicates an expected call of FirewallRules.
 func (mr *MockFirewallRulesInputMockRecorder) FirewallRules() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FirewallRules", reflect.TypeOf((*MockFirewallRulesInput)(nil).FirewallRules))

--- a/state/migration_import_mock_test.go
+++ b/state/migration_import_mock_test.go
@@ -5,36 +5,37 @@
 package state
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description/v3"
 	txn "github.com/juju/mgo/v2/txn"
-	reflect "reflect"
 )
 
-// MockTransactionRunner is a mock of TransactionRunner interface
+// MockTransactionRunner is a mock of TransactionRunner interface.
 type MockTransactionRunner struct {
 	ctrl     *gomock.Controller
 	recorder *MockTransactionRunnerMockRecorder
 }
 
-// MockTransactionRunnerMockRecorder is the mock recorder for MockTransactionRunner
+// MockTransactionRunnerMockRecorder is the mock recorder for MockTransactionRunner.
 type MockTransactionRunnerMockRecorder struct {
 	mock *MockTransactionRunner
 }
 
-// NewMockTransactionRunner creates a new mock instance
+// NewMockTransactionRunner creates a new mock instance.
 func NewMockTransactionRunner(ctrl *gomock.Controller) *MockTransactionRunner {
 	mock := &MockTransactionRunner{ctrl: ctrl}
 	mock.recorder = &MockTransactionRunnerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTransactionRunner) EXPECT() *MockTransactionRunnerMockRecorder {
 	return m.recorder
 }
 
-// RunTransaction mocks base method
+// RunTransaction mocks base method.
 func (m *MockTransactionRunner) RunTransaction(arg0 []txn.Op) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTransaction", arg0)
@@ -42,36 +43,36 @@ func (m *MockTransactionRunner) RunTransaction(arg0 []txn.Op) error {
 	return ret0
 }
 
-// RunTransaction indicates an expected call of RunTransaction
+// RunTransaction indicates an expected call of RunTransaction.
 func (mr *MockTransactionRunnerMockRecorder) RunTransaction(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTransaction", reflect.TypeOf((*MockTransactionRunner)(nil).RunTransaction), arg0)
 }
 
-// MockStateDocumentFactory is a mock of StateDocumentFactory interface
+// MockStateDocumentFactory is a mock of StateDocumentFactory interface.
 type MockStateDocumentFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateDocumentFactoryMockRecorder
 }
 
-// MockStateDocumentFactoryMockRecorder is the mock recorder for MockStateDocumentFactory
+// MockStateDocumentFactoryMockRecorder is the mock recorder for MockStateDocumentFactory.
 type MockStateDocumentFactoryMockRecorder struct {
 	mock *MockStateDocumentFactory
 }
 
-// NewMockStateDocumentFactory creates a new mock instance
+// NewMockStateDocumentFactory creates a new mock instance.
 func NewMockStateDocumentFactory(ctrl *gomock.Controller) *MockStateDocumentFactory {
 	mock := &MockStateDocumentFactory{ctrl: ctrl}
 	mock.recorder = &MockStateDocumentFactoryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStateDocumentFactory) EXPECT() *MockStateDocumentFactoryMockRecorder {
 	return m.recorder
 }
 
-// MakeRemoteApplicationDoc mocks base method
+// MakeRemoteApplicationDoc mocks base method.
 func (m *MockStateDocumentFactory) MakeRemoteApplicationDoc(arg0 description.RemoteApplication) *remoteApplicationDoc {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeRemoteApplicationDoc", arg0)
@@ -79,13 +80,13 @@ func (m *MockStateDocumentFactory) MakeRemoteApplicationDoc(arg0 description.Rem
 	return ret0
 }
 
-// MakeRemoteApplicationDoc indicates an expected call of MakeRemoteApplicationDoc
+// MakeRemoteApplicationDoc indicates an expected call of MakeRemoteApplicationDoc.
 func (mr *MockStateDocumentFactoryMockRecorder) MakeRemoteApplicationDoc(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRemoteApplicationDoc", reflect.TypeOf((*MockStateDocumentFactory)(nil).MakeRemoteApplicationDoc), arg0)
 }
 
-// MakeStatusDoc mocks base method
+// MakeStatusDoc mocks base method.
 func (m *MockStateDocumentFactory) MakeStatusDoc(arg0 description.Status) statusDoc {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeStatusDoc", arg0)
@@ -93,13 +94,13 @@ func (m *MockStateDocumentFactory) MakeStatusDoc(arg0 description.Status) status
 	return ret0
 }
 
-// MakeStatusDoc indicates an expected call of MakeStatusDoc
+// MakeStatusDoc indicates an expected call of MakeStatusDoc.
 func (mr *MockStateDocumentFactoryMockRecorder) MakeStatusDoc(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeStatusDoc", reflect.TypeOf((*MockStateDocumentFactory)(nil).MakeStatusDoc), arg0)
 }
 
-// MakeStatusOp mocks base method
+// MakeStatusOp mocks base method.
 func (m *MockStateDocumentFactory) MakeStatusOp(arg0 string, arg1 statusDoc) txn.Op {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeStatusOp", arg0, arg1)
@@ -107,13 +108,13 @@ func (m *MockStateDocumentFactory) MakeStatusOp(arg0 string, arg1 statusDoc) txn
 	return ret0
 }
 
-// MakeStatusOp indicates an expected call of MakeStatusOp
+// MakeStatusOp indicates an expected call of MakeStatusOp.
 func (mr *MockStateDocumentFactoryMockRecorder) MakeStatusOp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeStatusOp", reflect.TypeOf((*MockStateDocumentFactory)(nil).MakeStatusOp), arg0, arg1)
 }
 
-// NewRemoteApplication mocks base method
+// NewRemoteApplication mocks base method.
 func (m *MockStateDocumentFactory) NewRemoteApplication(arg0 *remoteApplicationDoc) *RemoteApplication {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRemoteApplication", arg0)
@@ -121,36 +122,36 @@ func (m *MockStateDocumentFactory) NewRemoteApplication(arg0 *remoteApplicationD
 	return ret0
 }
 
-// NewRemoteApplication indicates an expected call of NewRemoteApplication
+// NewRemoteApplication indicates an expected call of NewRemoteApplication.
 func (mr *MockStateDocumentFactoryMockRecorder) NewRemoteApplication(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRemoteApplication", reflect.TypeOf((*MockStateDocumentFactory)(nil).NewRemoteApplication), arg0)
 }
 
-// MockDocModelNamespace is a mock of DocModelNamespace interface
+// MockDocModelNamespace is a mock of DocModelNamespace interface.
 type MockDocModelNamespace struct {
 	ctrl     *gomock.Controller
 	recorder *MockDocModelNamespaceMockRecorder
 }
 
-// MockDocModelNamespaceMockRecorder is the mock recorder for MockDocModelNamespace
+// MockDocModelNamespaceMockRecorder is the mock recorder for MockDocModelNamespace.
 type MockDocModelNamespaceMockRecorder struct {
 	mock *MockDocModelNamespace
 }
 
-// NewMockDocModelNamespace creates a new mock instance
+// NewMockDocModelNamespace creates a new mock instance.
 func NewMockDocModelNamespace(ctrl *gomock.Controller) *MockDocModelNamespace {
 	mock := &MockDocModelNamespace{ctrl: ctrl}
 	mock.recorder = &MockDocModelNamespaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDocModelNamespace) EXPECT() *MockDocModelNamespaceMockRecorder {
 	return m.recorder
 }
 
-// DocID mocks base method
+// DocID mocks base method.
 func (m *MockDocModelNamespace) DocID(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DocID", arg0)
@@ -158,7 +159,7 @@ func (m *MockDocModelNamespace) DocID(arg0 string) string {
 	return ret0
 }
 
-// DocID indicates an expected call of DocID
+// DocID indicates an expected call of DocID.
 func (mr *MockDocModelNamespaceMockRecorder) DocID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocID", reflect.TypeOf((*MockDocModelNamespace)(nil).DocID), arg0)

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -920,9 +920,10 @@ func (s *MigrationImportSuite) TestApplicationsWithExposedOffers(c *gc.C) {
 	stOffers := state.NewApplicationOffers(s.State)
 	stOffer, err := stOffers.AddOffer(
 		crossmodel.AddApplicationOfferArgs{
-			OfferName:       "my-offer",
-			Owner:           "admin",
-			ApplicationName: application.Name(),
+			OfferName:              "my-offer",
+			Owner:                  "admin",
+			ApplicationDescription: "my app",
+			ApplicationName:        application.Name(),
 			Endpoints: map[string]string{
 				"server": serverSpace.Name(),
 			},

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -944,7 +944,22 @@ func (s *MigrationImportSuite) TestApplicationsWithExposedOffers(c *gc.C) {
 	c.Assert(exportedOffers, gc.HasLen, 1)
 	exported := exportedOffers[0]
 
-	_, newSt := s.importModel(c, s.State)
+	_, newSt := s.importModel(c, s.State, func(_ map[string]interface{}) {
+		// Application offer permissions are keyed on the offer uuid
+		// rather than a model uuid.
+		// If we import and the permissions still exist, the txn will fail
+		// as imports all assume any records do not already exist.
+		err = s.State.RemoveOfferAccess(
+			names.NewApplicationOfferTag("my-offer"),
+			fooUser.UserTag(),
+		)
+		c.Assert(err, jc.ErrorIsNil)
+		err = s.State.RemoveOfferAccess(
+			names.NewApplicationOfferTag("my-offer"),
+			names.NewUserTag("admin"),
+		)
+		c.Assert(err, jc.ErrorIsNil)
+	})
 
 	// The following is required because we don't add charms during an import,
 	// these are added at a later date. When constructing an application offer,

--- a/state/mocks/clock_mock.go
+++ b/state/mocks/clock_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	clock "github.com/juju/clock"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	clock "github.com/juju/clock"
 )
 
-// MockClock is a mock of Clock interface
+// MockClock is a mock of Clock interface.
 type MockClock struct {
 	ctrl     *gomock.Controller
 	recorder *MockClockMockRecorder
 }
 
-// MockClockMockRecorder is the mock recorder for MockClock
+// MockClockMockRecorder is the mock recorder for MockClock.
 type MockClockMockRecorder struct {
 	mock *MockClock
 }
 
-// NewMockClock creates a new mock instance
+// NewMockClock creates a new mock instance.
 func NewMockClock(ctrl *gomock.Controller) *MockClock {
 	mock := &MockClock{ctrl: ctrl}
 	mock.recorder = &MockClockMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClock) EXPECT() *MockClockMockRecorder {
 	return m.recorder
 }
 
-// After mocks base method
+// After mocks base method.
 func (m *MockClock) After(arg0 time.Duration) <-chan time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "After", arg0)
@@ -42,13 +43,13 @@ func (m *MockClock) After(arg0 time.Duration) <-chan time.Time {
 	return ret0
 }
 
-// After indicates an expected call of After
+// After indicates an expected call of After.
 func (mr *MockClockMockRecorder) After(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "After", reflect.TypeOf((*MockClock)(nil).After), arg0)
 }
 
-// AfterFunc mocks base method
+// AfterFunc mocks base method.
 func (m *MockClock) AfterFunc(arg0 time.Duration, arg1 func()) clock.Timer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AfterFunc", arg0, arg1)
@@ -56,13 +57,13 @@ func (m *MockClock) AfterFunc(arg0 time.Duration, arg1 func()) clock.Timer {
 	return ret0
 }
 
-// AfterFunc indicates an expected call of AfterFunc
+// AfterFunc indicates an expected call of AfterFunc.
 func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
-// NewTimer mocks base method
+// NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewTimer", arg0)
@@ -70,13 +71,13 @@ func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	return ret0
 }
 
-// NewTimer indicates an expected call of NewTimer
+// NewTimer indicates an expected call of NewTimer.
 func (mr *MockClockMockRecorder) NewTimer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewTimer", reflect.TypeOf((*MockClock)(nil).NewTimer), arg0)
 }
 
-// Now mocks base method
+// Now mocks base method.
 func (m *MockClock) Now() time.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Now")
@@ -84,7 +85,7 @@ func (m *MockClock) Now() time.Time {
 	return ret0
 }
 
-// Now indicates an expected call of Now
+// Now indicates an expected call of Now.
 func (mr *MockClockMockRecorder) Now() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Now", reflect.TypeOf((*MockClock)(nil).Now))

--- a/state/mocks/database_mock.go
+++ b/state/mocks/database_mock.go
@@ -5,39 +5,40 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	mongo "github.com/juju/juju/mongo"
 	state "github.com/juju/juju/state"
 	mgo "github.com/juju/mgo/v2"
 	txn "github.com/juju/mgo/v2/txn"
 	txn0 "github.com/juju/txn"
-	reflect "reflect"
 )
 
-// MockDatabase is a mock of Database interface
+// MockDatabase is a mock of Database interface.
 type MockDatabase struct {
 	ctrl     *gomock.Controller
 	recorder *MockDatabaseMockRecorder
 }
 
-// MockDatabaseMockRecorder is the mock recorder for MockDatabase
+// MockDatabaseMockRecorder is the mock recorder for MockDatabase.
 type MockDatabaseMockRecorder struct {
 	mock *MockDatabase
 }
 
-// NewMockDatabase creates a new mock instance
+// NewMockDatabase creates a new mock instance.
 func NewMockDatabase(ctrl *gomock.Controller) *MockDatabase {
 	mock := &MockDatabase{ctrl: ctrl}
 	mock.recorder = &MockDatabaseMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDatabase) EXPECT() *MockDatabaseMockRecorder {
 	return m.recorder
 }
 
-// Copy mocks base method
+// Copy mocks base method.
 func (m *MockDatabase) Copy() (state.Database, state.SessionCloser) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Copy")
@@ -46,13 +47,13 @@ func (m *MockDatabase) Copy() (state.Database, state.SessionCloser) {
 	return ret0, ret1
 }
 
-// Copy indicates an expected call of Copy
+// Copy indicates an expected call of Copy.
 func (mr *MockDatabaseMockRecorder) Copy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockDatabase)(nil).Copy))
 }
 
-// CopyForModel mocks base method
+// CopyForModel mocks base method.
 func (m *MockDatabase) CopyForModel(arg0 string) (state.Database, state.SessionCloser) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyForModel", arg0)
@@ -61,13 +62,13 @@ func (m *MockDatabase) CopyForModel(arg0 string) (state.Database, state.SessionC
 	return ret0, ret1
 }
 
-// CopyForModel indicates an expected call of CopyForModel
+// CopyForModel indicates an expected call of CopyForModel.
 func (mr *MockDatabaseMockRecorder) CopyForModel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyForModel", reflect.TypeOf((*MockDatabase)(nil).CopyForModel), arg0)
 }
 
-// GetCollection mocks base method
+// GetCollection mocks base method.
 func (m *MockDatabase) GetCollection(arg0 string) (mongo.Collection, state.SessionCloser) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCollection", arg0)
@@ -76,13 +77,13 @@ func (m *MockDatabase) GetCollection(arg0 string) (mongo.Collection, state.Sessi
 	return ret0, ret1
 }
 
-// GetCollection indicates an expected call of GetCollection
+// GetCollection indicates an expected call of GetCollection.
 func (mr *MockDatabaseMockRecorder) GetCollection(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCollection", reflect.TypeOf((*MockDatabase)(nil).GetCollection), arg0)
 }
 
-// GetCollectionFor mocks base method
+// GetCollectionFor mocks base method.
 func (m *MockDatabase) GetCollectionFor(arg0, arg1 string) (mongo.Collection, state.SessionCloser) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCollectionFor", arg0, arg1)
@@ -91,13 +92,13 @@ func (m *MockDatabase) GetCollectionFor(arg0, arg1 string) (mongo.Collection, st
 	return ret0, ret1
 }
 
-// GetCollectionFor indicates an expected call of GetCollectionFor
+// GetCollectionFor indicates an expected call of GetCollectionFor.
 func (mr *MockDatabaseMockRecorder) GetCollectionFor(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCollectionFor", reflect.TypeOf((*MockDatabase)(nil).GetCollectionFor), arg0, arg1)
 }
 
-// GetRawCollection mocks base method
+// GetRawCollection mocks base method.
 func (m *MockDatabase) GetRawCollection(arg0 string) (*mgo.Collection, state.SessionCloser) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRawCollection", arg0)
@@ -106,13 +107,13 @@ func (m *MockDatabase) GetRawCollection(arg0 string) (*mgo.Collection, state.Ses
 	return ret0, ret1
 }
 
-// GetRawCollection indicates an expected call of GetRawCollection
+// GetRawCollection indicates an expected call of GetRawCollection.
 func (mr *MockDatabaseMockRecorder) GetRawCollection(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawCollection", reflect.TypeOf((*MockDatabase)(nil).GetRawCollection), arg0)
 }
 
-// Run mocks base method
+// Run mocks base method.
 func (m *MockDatabase) Run(arg0 txn0.TransactionSource) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Run", arg0)
@@ -120,13 +121,13 @@ func (m *MockDatabase) Run(arg0 txn0.TransactionSource) error {
 	return ret0
 }
 
-// Run indicates an expected call of Run
+// Run indicates an expected call of Run.
 func (mr *MockDatabaseMockRecorder) Run(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockDatabase)(nil).Run), arg0)
 }
 
-// RunRawTransaction mocks base method
+// RunRawTransaction mocks base method.
 func (m *MockDatabase) RunRawTransaction(arg0 []txn.Op) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunRawTransaction", arg0)
@@ -134,13 +135,13 @@ func (m *MockDatabase) RunRawTransaction(arg0 []txn.Op) error {
 	return ret0
 }
 
-// RunRawTransaction indicates an expected call of RunRawTransaction
+// RunRawTransaction indicates an expected call of RunRawTransaction.
 func (mr *MockDatabaseMockRecorder) RunRawTransaction(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunRawTransaction", reflect.TypeOf((*MockDatabase)(nil).RunRawTransaction), arg0)
 }
 
-// RunTransaction mocks base method
+// RunTransaction mocks base method.
 func (m *MockDatabase) RunTransaction(arg0 []txn.Op) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTransaction", arg0)
@@ -148,13 +149,13 @@ func (m *MockDatabase) RunTransaction(arg0 []txn.Op) error {
 	return ret0
 }
 
-// RunTransaction indicates an expected call of RunTransaction
+// RunTransaction indicates an expected call of RunTransaction.
 func (mr *MockDatabaseMockRecorder) RunTransaction(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTransaction", reflect.TypeOf((*MockDatabase)(nil).RunTransaction), arg0)
 }
 
-// RunTransactionFor mocks base method
+// RunTransactionFor mocks base method.
 func (m *MockDatabase) RunTransactionFor(arg0 string, arg1 []txn.Op) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTransactionFor", arg0, arg1)
@@ -162,13 +163,13 @@ func (m *MockDatabase) RunTransactionFor(arg0 string, arg1 []txn.Op) error {
 	return ret0
 }
 
-// RunTransactionFor indicates an expected call of RunTransactionFor
+// RunTransactionFor indicates an expected call of RunTransactionFor.
 func (mr *MockDatabaseMockRecorder) RunTransactionFor(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTransactionFor", reflect.TypeOf((*MockDatabase)(nil).RunTransactionFor), arg0, arg1)
 }
 
-// Schema mocks base method
+// Schema mocks base method.
 func (m *MockDatabase) Schema() state.CollectionSchema {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Schema")
@@ -176,13 +177,13 @@ func (m *MockDatabase) Schema() state.CollectionSchema {
 	return ret0
 }
 
-// Schema indicates an expected call of Schema
+// Schema indicates an expected call of Schema.
 func (mr *MockDatabaseMockRecorder) Schema() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Schema", reflect.TypeOf((*MockDatabase)(nil).Schema))
 }
 
-// TransactionRunner mocks base method
+// TransactionRunner mocks base method.
 func (m *MockDatabase) TransactionRunner() (txn0.Runner, state.SessionCloser) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransactionRunner")
@@ -191,7 +192,7 @@ func (m *MockDatabase) TransactionRunner() (txn0.Runner, state.SessionCloser) {
 	return ret0, ret1
 }
 
-// TransactionRunner indicates an expected call of TransactionRunner
+// TransactionRunner indicates an expected call of TransactionRunner.
 func (mr *MockDatabaseMockRecorder) TransactionRunner() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionRunner", reflect.TypeOf((*MockDatabase)(nil).TransactionRunner))

--- a/state/mocks/description_mock.go
+++ b/state/mocks/description_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	description "github.com/juju/description/v3"
 	names "github.com/juju/names/v4"
-	reflect "reflect"
 )
 
-// MockMachine is a mock of Machine interface
+// MockMachine is a mock of Machine interface.
 type MockMachine struct {
 	ctrl     *gomock.Controller
 	recorder *MockMachineMockRecorder
 }
 
-// MockMachineMockRecorder is the mock recorder for MockMachine
+// MockMachineMockRecorder is the mock recorder for MockMachine.
 type MockMachineMockRecorder struct {
 	mock *MockMachine
 }
 
-// NewMockMachine creates a new mock instance
+// NewMockMachine creates a new mock instance.
 func NewMockMachine(ctrl *gomock.Controller) *MockMachine {
 	mock := &MockMachine{ctrl: ctrl}
 	mock.recorder = &MockMachineMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 	return m.recorder
 }
 
-// AddBlockDevice mocks base method
+// AddBlockDevice mocks base method.
 func (m *MockMachine) AddBlockDevice(arg0 description.BlockDeviceArgs) description.BlockDevice {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddBlockDevice", arg0)
@@ -42,13 +43,13 @@ func (m *MockMachine) AddBlockDevice(arg0 description.BlockDeviceArgs) descripti
 	return ret0
 }
 
-// AddBlockDevice indicates an expected call of AddBlockDevice
+// AddBlockDevice indicates an expected call of AddBlockDevice.
 func (mr *MockMachineMockRecorder) AddBlockDevice(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBlockDevice", reflect.TypeOf((*MockMachine)(nil).AddBlockDevice), arg0)
 }
 
-// AddContainer mocks base method
+// AddContainer mocks base method.
 func (m *MockMachine) AddContainer(arg0 description.MachineArgs) description.Machine {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddContainer", arg0)
@@ -56,25 +57,25 @@ func (m *MockMachine) AddContainer(arg0 description.MachineArgs) description.Mac
 	return ret0
 }
 
-// AddContainer indicates an expected call of AddContainer
+// AddContainer indicates an expected call of AddContainer.
 func (mr *MockMachineMockRecorder) AddContainer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddContainer", reflect.TypeOf((*MockMachine)(nil).AddContainer), arg0)
 }
 
-// AddOpenedPortRange mocks base method
+// AddOpenedPortRange mocks base method.
 func (m *MockMachine) AddOpenedPortRange(arg0 description.OpenedPortRangeArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddOpenedPortRange", arg0)
 }
 
-// AddOpenedPortRange indicates an expected call of AddOpenedPortRange
+// AddOpenedPortRange indicates an expected call of AddOpenedPortRange.
 func (mr *MockMachineMockRecorder) AddOpenedPortRange(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOpenedPortRange", reflect.TypeOf((*MockMachine)(nil).AddOpenedPortRange), arg0)
 }
 
-// Annotations mocks base method
+// Annotations mocks base method.
 func (m *MockMachine) Annotations() map[string]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Annotations")
@@ -82,13 +83,13 @@ func (m *MockMachine) Annotations() map[string]string {
 	return ret0
 }
 
-// Annotations indicates an expected call of Annotations
+// Annotations indicates an expected call of Annotations.
 func (mr *MockMachineMockRecorder) Annotations() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Annotations", reflect.TypeOf((*MockMachine)(nil).Annotations))
 }
 
-// BlockDevices mocks base method
+// BlockDevices mocks base method.
 func (m *MockMachine) BlockDevices() []description.BlockDevice {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockDevices")
@@ -96,13 +97,13 @@ func (m *MockMachine) BlockDevices() []description.BlockDevice {
 	return ret0
 }
 
-// BlockDevices indicates an expected call of BlockDevices
+// BlockDevices indicates an expected call of BlockDevices.
 func (mr *MockMachineMockRecorder) BlockDevices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockDevices", reflect.TypeOf((*MockMachine)(nil).BlockDevices))
 }
 
-// Constraints mocks base method
+// Constraints mocks base method.
 func (m *MockMachine) Constraints() description.Constraints {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Constraints")
@@ -110,13 +111,13 @@ func (m *MockMachine) Constraints() description.Constraints {
 	return ret0
 }
 
-// Constraints indicates an expected call of Constraints
+// Constraints indicates an expected call of Constraints.
 func (mr *MockMachineMockRecorder) Constraints() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockMachine)(nil).Constraints))
 }
 
-// ContainerType mocks base method
+// ContainerType mocks base method.
 func (m *MockMachine) ContainerType() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
@@ -124,13 +125,13 @@ func (m *MockMachine) ContainerType() string {
 	return ret0
 }
 
-// ContainerType indicates an expected call of ContainerType
+// ContainerType indicates an expected call of ContainerType.
 func (mr *MockMachineMockRecorder) ContainerType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockMachine)(nil).ContainerType))
 }
 
-// Containers mocks base method
+// Containers mocks base method.
 func (m *MockMachine) Containers() []description.Machine {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Containers")
@@ -138,13 +139,13 @@ func (m *MockMachine) Containers() []description.Machine {
 	return ret0
 }
 
-// Containers indicates an expected call of Containers
+// Containers indicates an expected call of Containers.
 func (mr *MockMachineMockRecorder) Containers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Containers", reflect.TypeOf((*MockMachine)(nil).Containers))
 }
 
-// Id mocks base method
+// Id mocks base method.
 func (m *MockMachine) Id() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Id")
@@ -152,13 +153,13 @@ func (m *MockMachine) Id() string {
 	return ret0
 }
 
-// Id indicates an expected call of Id
+// Id indicates an expected call of Id.
 func (mr *MockMachineMockRecorder) Id() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
 }
 
-// Instance mocks base method
+// Instance mocks base method.
 func (m *MockMachine) Instance() description.CloudInstance {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Instance")
@@ -166,13 +167,13 @@ func (m *MockMachine) Instance() description.CloudInstance {
 	return ret0
 }
 
-// Instance indicates an expected call of Instance
+// Instance indicates an expected call of Instance.
 func (mr *MockMachineMockRecorder) Instance() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Instance", reflect.TypeOf((*MockMachine)(nil).Instance))
 }
 
-// Jobs mocks base method
+// Jobs mocks base method.
 func (m *MockMachine) Jobs() []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
@@ -180,13 +181,13 @@ func (m *MockMachine) Jobs() []string {
 	return ret0
 }
 
-// Jobs indicates an expected call of Jobs
+// Jobs indicates an expected call of Jobs.
 func (mr *MockMachineMockRecorder) Jobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockMachine)(nil).Jobs))
 }
 
-// MachineAddresses mocks base method
+// MachineAddresses mocks base method.
 func (m *MockMachine) MachineAddresses() []description.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachineAddresses")
@@ -194,13 +195,13 @@ func (m *MockMachine) MachineAddresses() []description.Address {
 	return ret0
 }
 
-// MachineAddresses indicates an expected call of MachineAddresses
+// MachineAddresses indicates an expected call of MachineAddresses.
 func (mr *MockMachineMockRecorder) MachineAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineAddresses", reflect.TypeOf((*MockMachine)(nil).MachineAddresses))
 }
 
-// Nonce mocks base method
+// Nonce mocks base method.
 func (m *MockMachine) Nonce() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce")
@@ -208,13 +209,13 @@ func (m *MockMachine) Nonce() string {
 	return ret0
 }
 
-// Nonce indicates an expected call of Nonce
+// Nonce indicates an expected call of Nonce.
 func (mr *MockMachineMockRecorder) Nonce() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockMachine)(nil).Nonce))
 }
 
-// OpenedPortRanges mocks base method
+// OpenedPortRanges mocks base method.
 func (m *MockMachine) OpenedPortRanges() description.MachinePortRanges {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenedPortRanges")
@@ -222,13 +223,13 @@ func (m *MockMachine) OpenedPortRanges() description.MachinePortRanges {
 	return ret0
 }
 
-// OpenedPortRanges indicates an expected call of OpenedPortRanges
+// OpenedPortRanges indicates an expected call of OpenedPortRanges.
 func (mr *MockMachineMockRecorder) OpenedPortRanges() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenedPortRanges", reflect.TypeOf((*MockMachine)(nil).OpenedPortRanges))
 }
 
-// PasswordHash mocks base method
+// PasswordHash mocks base method.
 func (m *MockMachine) PasswordHash() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PasswordHash")
@@ -236,13 +237,13 @@ func (m *MockMachine) PasswordHash() string {
 	return ret0
 }
 
-// PasswordHash indicates an expected call of PasswordHash
+// PasswordHash indicates an expected call of PasswordHash.
 func (mr *MockMachineMockRecorder) PasswordHash() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PasswordHash", reflect.TypeOf((*MockMachine)(nil).PasswordHash))
 }
 
-// Placement mocks base method
+// Placement mocks base method.
 func (m *MockMachine) Placement() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Placement")
@@ -250,13 +251,13 @@ func (m *MockMachine) Placement() string {
 	return ret0
 }
 
-// Placement indicates an expected call of Placement
+// Placement indicates an expected call of Placement.
 func (mr *MockMachineMockRecorder) Placement() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Placement", reflect.TypeOf((*MockMachine)(nil).Placement))
 }
 
-// PreferredPrivateAddress mocks base method
+// PreferredPrivateAddress mocks base method.
 func (m *MockMachine) PreferredPrivateAddress() description.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreferredPrivateAddress")
@@ -264,13 +265,13 @@ func (m *MockMachine) PreferredPrivateAddress() description.Address {
 	return ret0
 }
 
-// PreferredPrivateAddress indicates an expected call of PreferredPrivateAddress
+// PreferredPrivateAddress indicates an expected call of PreferredPrivateAddress.
 func (mr *MockMachineMockRecorder) PreferredPrivateAddress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreferredPrivateAddress", reflect.TypeOf((*MockMachine)(nil).PreferredPrivateAddress))
 }
 
-// PreferredPublicAddress mocks base method
+// PreferredPublicAddress mocks base method.
 func (m *MockMachine) PreferredPublicAddress() description.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreferredPublicAddress")
@@ -278,13 +279,13 @@ func (m *MockMachine) PreferredPublicAddress() description.Address {
 	return ret0
 }
 
-// PreferredPublicAddress indicates an expected call of PreferredPublicAddress
+// PreferredPublicAddress indicates an expected call of PreferredPublicAddress.
 func (mr *MockMachineMockRecorder) PreferredPublicAddress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreferredPublicAddress", reflect.TypeOf((*MockMachine)(nil).PreferredPublicAddress))
 }
 
-// ProviderAddresses mocks base method
+// ProviderAddresses mocks base method.
 func (m *MockMachine) ProviderAddresses() []description.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderAddresses")
@@ -292,13 +293,13 @@ func (m *MockMachine) ProviderAddresses() []description.Address {
 	return ret0
 }
 
-// ProviderAddresses indicates an expected call of ProviderAddresses
+// ProviderAddresses indicates an expected call of ProviderAddresses.
 func (mr *MockMachineMockRecorder) ProviderAddresses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderAddresses", reflect.TypeOf((*MockMachine)(nil).ProviderAddresses))
 }
 
-// Series mocks base method
+// Series mocks base method.
 func (m *MockMachine) Series() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Series")
@@ -306,109 +307,109 @@ func (m *MockMachine) Series() string {
 	return ret0
 }
 
-// Series indicates an expected call of Series
+// Series indicates an expected call of Series.
 func (mr *MockMachineMockRecorder) Series() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockMachine)(nil).Series))
 }
 
-// SetAddresses mocks base method
+// SetAddresses mocks base method.
 func (m *MockMachine) SetAddresses(arg0, arg1 []description.AddressArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAddresses", arg0, arg1)
 }
 
-// SetAddresses indicates an expected call of SetAddresses
+// SetAddresses indicates an expected call of SetAddresses.
 func (mr *MockMachineMockRecorder) SetAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAddresses", reflect.TypeOf((*MockMachine)(nil).SetAddresses), arg0, arg1)
 }
 
-// SetAnnotations mocks base method
+// SetAnnotations mocks base method.
 func (m *MockMachine) SetAnnotations(arg0 map[string]string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAnnotations", arg0)
 }
 
-// SetAnnotations indicates an expected call of SetAnnotations
+// SetAnnotations indicates an expected call of SetAnnotations.
 func (mr *MockMachineMockRecorder) SetAnnotations(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAnnotations", reflect.TypeOf((*MockMachine)(nil).SetAnnotations), arg0)
 }
 
-// SetConstraints mocks base method
+// SetConstraints mocks base method.
 func (m *MockMachine) SetConstraints(arg0 description.ConstraintsArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetConstraints", arg0)
 }
 
-// SetConstraints indicates an expected call of SetConstraints
+// SetConstraints indicates an expected call of SetConstraints.
 func (mr *MockMachineMockRecorder) SetConstraints(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConstraints", reflect.TypeOf((*MockMachine)(nil).SetConstraints), arg0)
 }
 
-// SetInstance mocks base method
+// SetInstance mocks base method.
 func (m *MockMachine) SetInstance(arg0 description.CloudInstanceArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetInstance", arg0)
 }
 
-// SetInstance indicates an expected call of SetInstance
+// SetInstance indicates an expected call of SetInstance.
 func (mr *MockMachineMockRecorder) SetInstance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstance", reflect.TypeOf((*MockMachine)(nil).SetInstance), arg0)
 }
 
-// SetPreferredAddresses mocks base method
+// SetPreferredAddresses mocks base method.
 func (m *MockMachine) SetPreferredAddresses(arg0, arg1 description.AddressArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetPreferredAddresses", arg0, arg1)
 }
 
-// SetPreferredAddresses indicates an expected call of SetPreferredAddresses
+// SetPreferredAddresses indicates an expected call of SetPreferredAddresses.
 func (mr *MockMachineMockRecorder) SetPreferredAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPreferredAddresses", reflect.TypeOf((*MockMachine)(nil).SetPreferredAddresses), arg0, arg1)
 }
 
-// SetStatus mocks base method
+// SetStatus mocks base method.
 func (m *MockMachine) SetStatus(arg0 description.StatusArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetStatus", arg0)
 }
 
-// SetStatus indicates an expected call of SetStatus
+// SetStatus indicates an expected call of SetStatus.
 func (mr *MockMachineMockRecorder) SetStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachine)(nil).SetStatus), arg0)
 }
 
-// SetStatusHistory mocks base method
+// SetStatusHistory mocks base method.
 func (m *MockMachine) SetStatusHistory(arg0 []description.StatusArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetStatusHistory", arg0)
 }
 
-// SetStatusHistory indicates an expected call of SetStatusHistory
+// SetStatusHistory indicates an expected call of SetStatusHistory.
 func (mr *MockMachineMockRecorder) SetStatusHistory(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatusHistory", reflect.TypeOf((*MockMachine)(nil).SetStatusHistory), arg0)
 }
 
-// SetTools mocks base method
+// SetTools mocks base method.
 func (m *MockMachine) SetTools(arg0 description.AgentToolsArgs) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetTools", arg0)
 }
 
-// SetTools indicates an expected call of SetTools
+// SetTools indicates an expected call of SetTools.
 func (mr *MockMachineMockRecorder) SetTools(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTools", reflect.TypeOf((*MockMachine)(nil).SetTools), arg0)
 }
 
-// Status mocks base method
+// Status mocks base method.
 func (m *MockMachine) Status() description.Status {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
@@ -416,13 +417,13 @@ func (m *MockMachine) Status() description.Status {
 	return ret0
 }
 
-// Status indicates an expected call of Status
+// Status indicates an expected call of Status.
 func (mr *MockMachineMockRecorder) Status() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachine)(nil).Status))
 }
 
-// StatusHistory mocks base method
+// StatusHistory mocks base method.
 func (m *MockMachine) StatusHistory() []description.Status {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StatusHistory")
@@ -430,13 +431,13 @@ func (m *MockMachine) StatusHistory() []description.Status {
 	return ret0
 }
 
-// StatusHistory indicates an expected call of StatusHistory
+// StatusHistory indicates an expected call of StatusHistory.
 func (mr *MockMachineMockRecorder) StatusHistory() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusHistory", reflect.TypeOf((*MockMachine)(nil).StatusHistory))
 }
 
-// SupportedContainers mocks base method
+// SupportedContainers mocks base method.
 func (m *MockMachine) SupportedContainers() ([]string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportedContainers")
@@ -445,13 +446,13 @@ func (m *MockMachine) SupportedContainers() ([]string, bool) {
 	return ret0, ret1
 }
 
-// SupportedContainers indicates an expected call of SupportedContainers
+// SupportedContainers indicates an expected call of SupportedContainers.
 func (mr *MockMachineMockRecorder) SupportedContainers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachine)(nil).SupportedContainers))
 }
 
-// Tag mocks base method
+// Tag mocks base method.
 func (m *MockMachine) Tag() names.MachineTag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -459,13 +460,13 @@ func (m *MockMachine) Tag() names.MachineTag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag
+// Tag indicates an expected call of Tag.
 func (mr *MockMachineMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockMachine)(nil).Tag))
 }
 
-// Tools mocks base method
+// Tools mocks base method.
 func (m *MockMachine) Tools() description.AgentTools {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tools")
@@ -473,13 +474,13 @@ func (m *MockMachine) Tools() description.AgentTools {
 	return ret0
 }
 
-// Tools indicates an expected call of Tools
+// Tools indicates an expected call of Tools.
 func (mr *MockMachineMockRecorder) Tools() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tools", reflect.TypeOf((*MockMachine)(nil).Tools))
 }
 
-// Validate mocks base method
+// Validate mocks base method.
 func (m *MockMachine) Validate() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate")
@@ -487,36 +488,36 @@ func (m *MockMachine) Validate() error {
 	return ret0
 }
 
-// Validate indicates an expected call of Validate
+// Validate indicates an expected call of Validate.
 func (mr *MockMachineMockRecorder) Validate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockMachine)(nil).Validate))
 }
 
-// MockMachinePortRanges is a mock of MachinePortRanges interface
+// MockMachinePortRanges is a mock of MachinePortRanges interface.
 type MockMachinePortRanges struct {
 	ctrl     *gomock.Controller
 	recorder *MockMachinePortRangesMockRecorder
 }
 
-// MockMachinePortRangesMockRecorder is the mock recorder for MockMachinePortRanges
+// MockMachinePortRangesMockRecorder is the mock recorder for MockMachinePortRanges.
 type MockMachinePortRangesMockRecorder struct {
 	mock *MockMachinePortRanges
 }
 
-// NewMockMachinePortRanges creates a new mock instance
+// NewMockMachinePortRanges creates a new mock instance.
 func NewMockMachinePortRanges(ctrl *gomock.Controller) *MockMachinePortRanges {
 	mock := &MockMachinePortRanges{ctrl: ctrl}
 	mock.recorder = &MockMachinePortRangesMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMachinePortRanges) EXPECT() *MockMachinePortRangesMockRecorder {
 	return m.recorder
 }
 
-// ByUnit mocks base method
+// ByUnit mocks base method.
 func (m *MockMachinePortRanges) ByUnit() map[string]description.UnitPortRanges {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ByUnit")
@@ -524,36 +525,36 @@ func (m *MockMachinePortRanges) ByUnit() map[string]description.UnitPortRanges {
 	return ret0
 }
 
-// ByUnit indicates an expected call of ByUnit
+// ByUnit indicates an expected call of ByUnit.
 func (mr *MockMachinePortRangesMockRecorder) ByUnit() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByUnit", reflect.TypeOf((*MockMachinePortRanges)(nil).ByUnit))
 }
 
-// MockUnitPortRanges is a mock of UnitPortRanges interface
+// MockUnitPortRanges is a mock of UnitPortRanges interface.
 type MockUnitPortRanges struct {
 	ctrl     *gomock.Controller
 	recorder *MockUnitPortRangesMockRecorder
 }
 
-// MockUnitPortRangesMockRecorder is the mock recorder for MockUnitPortRanges
+// MockUnitPortRangesMockRecorder is the mock recorder for MockUnitPortRanges.
 type MockUnitPortRangesMockRecorder struct {
 	mock *MockUnitPortRanges
 }
 
-// NewMockUnitPortRanges creates a new mock instance
+// NewMockUnitPortRanges creates a new mock instance.
 func NewMockUnitPortRanges(ctrl *gomock.Controller) *MockUnitPortRanges {
 	mock := &MockUnitPortRanges{ctrl: ctrl}
 	mock.recorder = &MockUnitPortRangesMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUnitPortRanges) EXPECT() *MockUnitPortRangesMockRecorder {
 	return m.recorder
 }
 
-// ByEndpoint mocks base method
+// ByEndpoint mocks base method.
 func (m *MockUnitPortRanges) ByEndpoint() map[string][]description.UnitPortRange {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ByEndpoint")
@@ -561,7 +562,7 @@ func (m *MockUnitPortRanges) ByEndpoint() map[string][]description.UnitPortRange
 	return ret0
 }
 
-// ByEndpoint indicates an expected call of ByEndpoint
+// ByEndpoint indicates an expected call of ByEndpoint.
 func (mr *MockUnitPortRangesMockRecorder) ByEndpoint() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByEndpoint", reflect.TypeOf((*MockUnitPortRanges)(nil).ByEndpoint))

--- a/state/mocks/endpointbinding_mock.go
+++ b/state/mocks/endpointbinding_mock.go
@@ -5,36 +5,37 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
-	reflect "reflect"
 )
 
-// MockEndpointBinding is a mock of EndpointBinding interface
+// MockEndpointBinding is a mock of EndpointBinding interface.
 type MockEndpointBinding struct {
 	ctrl     *gomock.Controller
 	recorder *MockEndpointBindingMockRecorder
 }
 
-// MockEndpointBindingMockRecorder is the mock recorder for MockEndpointBinding
+// MockEndpointBindingMockRecorder is the mock recorder for MockEndpointBinding.
 type MockEndpointBindingMockRecorder struct {
 	mock *MockEndpointBinding
 }
 
-// NewMockEndpointBinding creates a new mock instance
+// NewMockEndpointBinding creates a new mock instance.
 func NewMockEndpointBinding(ctrl *gomock.Controller) *MockEndpointBinding {
 	mock := &MockEndpointBinding{ctrl: ctrl}
 	mock.recorder = &MockEndpointBindingMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEndpointBinding) EXPECT() *MockEndpointBindingMockRecorder {
 	return m.recorder
 }
 
-// AllSpaceInfos mocks base method
+// AllSpaceInfos mocks base method.
 func (m *MockEndpointBinding) AllSpaceInfos() (network.SpaceInfos, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllSpaceInfos")
@@ -43,13 +44,13 @@ func (m *MockEndpointBinding) AllSpaceInfos() (network.SpaceInfos, error) {
 	return ret0, ret1
 }
 
-// AllSpaceInfos indicates an expected call of AllSpaceInfos
+// AllSpaceInfos indicates an expected call of AllSpaceInfos.
 func (mr *MockEndpointBindingMockRecorder) AllSpaceInfos() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSpaceInfos", reflect.TypeOf((*MockEndpointBinding)(nil).AllSpaceInfos))
 }
 
-// DefaultEndpointBindingSpace mocks base method
+// DefaultEndpointBindingSpace mocks base method.
 func (m *MockEndpointBinding) DefaultEndpointBindingSpace() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultEndpointBindingSpace")
@@ -58,13 +59,13 @@ func (m *MockEndpointBinding) DefaultEndpointBindingSpace() (string, error) {
 	return ret0, ret1
 }
 
-// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace
+// DefaultEndpointBindingSpace indicates an expected call of DefaultEndpointBindingSpace.
 func (mr *MockEndpointBindingMockRecorder) DefaultEndpointBindingSpace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultEndpointBindingSpace", reflect.TypeOf((*MockEndpointBinding)(nil).DefaultEndpointBindingSpace))
 }
 
-// Space mocks base method
+// Space mocks base method.
 func (m *MockEndpointBinding) Space(arg0 string) (*state.Space, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Space", arg0)
@@ -73,7 +74,7 @@ func (m *MockEndpointBinding) Space(arg0 string) (*state.Space, error) {
 	return ret0, ret1
 }
 
-// Space indicates an expected call of Space
+// Space indicates an expected call of Space.
 func (mr *MockEndpointBindingMockRecorder) Space(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Space", reflect.TypeOf((*MockEndpointBinding)(nil).Space), arg0)

--- a/state/mocks/mongo_mock.go
+++ b/state/mocks/mongo_mock.go
@@ -5,37 +5,38 @@
 package mocks
 
 import (
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	mongo "github.com/juju/juju/mongo"
 	mgo "github.com/juju/mgo/v2"
-	reflect "reflect"
-	time "time"
 )
 
-// MockCollection is a mock of Collection interface
+// MockCollection is a mock of Collection interface.
 type MockCollection struct {
 	ctrl     *gomock.Controller
 	recorder *MockCollectionMockRecorder
 }
 
-// MockCollectionMockRecorder is the mock recorder for MockCollection
+// MockCollectionMockRecorder is the mock recorder for MockCollection.
 type MockCollectionMockRecorder struct {
 	mock *MockCollection
 }
 
-// NewMockCollection creates a new mock instance
+// NewMockCollection creates a new mock instance.
 func NewMockCollection(ctrl *gomock.Controller) *MockCollection {
 	mock := &MockCollection{ctrl: ctrl}
 	mock.recorder = &MockCollectionMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCollection) EXPECT() *MockCollectionMockRecorder {
 	return m.recorder
 }
 
-// Count mocks base method
+// Count mocks base method.
 func (m *MockCollection) Count() (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Count")
@@ -44,13 +45,13 @@ func (m *MockCollection) Count() (int, error) {
 	return ret0, ret1
 }
 
-// Count indicates an expected call of Count
+// Count indicates an expected call of Count.
 func (mr *MockCollectionMockRecorder) Count() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockCollection)(nil).Count))
 }
 
-// Find mocks base method
+// Find mocks base method.
 func (m *MockCollection) Find(arg0 interface{}) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Find", arg0)
@@ -58,13 +59,13 @@ func (m *MockCollection) Find(arg0 interface{}) mongo.Query {
 	return ret0
 }
 
-// Find indicates an expected call of Find
+// Find indicates an expected call of Find.
 func (mr *MockCollectionMockRecorder) Find(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockCollection)(nil).Find), arg0)
 }
 
-// FindId mocks base method
+// FindId mocks base method.
 func (m *MockCollection) FindId(arg0 interface{}) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindId", arg0)
@@ -72,13 +73,13 @@ func (m *MockCollection) FindId(arg0 interface{}) mongo.Query {
 	return ret0
 }
 
-// FindId indicates an expected call of FindId
+// FindId indicates an expected call of FindId.
 func (mr *MockCollectionMockRecorder) FindId(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindId", reflect.TypeOf((*MockCollection)(nil).FindId), arg0)
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockCollection) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -86,13 +87,13 @@ func (m *MockCollection) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockCollectionMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockCollection)(nil).Name))
 }
 
-// Pipe mocks base method
+// Pipe mocks base method.
 func (m *MockCollection) Pipe(arg0 interface{}) *mgo.Pipe {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Pipe", arg0)
@@ -100,13 +101,13 @@ func (m *MockCollection) Pipe(arg0 interface{}) *mgo.Pipe {
 	return ret0
 }
 
-// Pipe indicates an expected call of Pipe
+// Pipe indicates an expected call of Pipe.
 func (mr *MockCollectionMockRecorder) Pipe(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pipe", reflect.TypeOf((*MockCollection)(nil).Pipe), arg0)
 }
 
-// Writeable mocks base method
+// Writeable mocks base method.
 func (m *MockCollection) Writeable() mongo.WriteCollection {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Writeable")
@@ -114,36 +115,36 @@ func (m *MockCollection) Writeable() mongo.WriteCollection {
 	return ret0
 }
 
-// Writeable indicates an expected call of Writeable
+// Writeable indicates an expected call of Writeable.
 func (mr *MockCollectionMockRecorder) Writeable() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Writeable", reflect.TypeOf((*MockCollection)(nil).Writeable))
 }
 
-// MockQuery is a mock of Query interface
+// MockQuery is a mock of Query interface.
 type MockQuery struct {
 	ctrl     *gomock.Controller
 	recorder *MockQueryMockRecorder
 }
 
-// MockQueryMockRecorder is the mock recorder for MockQuery
+// MockQueryMockRecorder is the mock recorder for MockQuery.
 type MockQueryMockRecorder struct {
 	mock *MockQuery
 }
 
-// NewMockQuery creates a new mock instance
+// NewMockQuery creates a new mock instance.
 func NewMockQuery(ctrl *gomock.Controller) *MockQuery {
 	mock := &MockQuery{ctrl: ctrl}
 	mock.recorder = &MockQueryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockQuery) EXPECT() *MockQueryMockRecorder {
 	return m.recorder
 }
 
-// All mocks base method
+// All mocks base method.
 func (m *MockQuery) All(arg0 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "All", arg0)
@@ -151,13 +152,13 @@ func (m *MockQuery) All(arg0 interface{}) error {
 	return ret0
 }
 
-// All indicates an expected call of All
+// All indicates an expected call of All.
 func (mr *MockQueryMockRecorder) All(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "All", reflect.TypeOf((*MockQuery)(nil).All), arg0)
 }
 
-// Apply mocks base method
+// Apply mocks base method.
 func (m *MockQuery) Apply(arg0 mgo.Change, arg1 interface{}) (*mgo.ChangeInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", arg0, arg1)
@@ -166,13 +167,13 @@ func (m *MockQuery) Apply(arg0 mgo.Change, arg1 interface{}) (*mgo.ChangeInfo, e
 	return ret0, ret1
 }
 
-// Apply indicates an expected call of Apply
+// Apply indicates an expected call of Apply.
 func (mr *MockQueryMockRecorder) Apply(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockQuery)(nil).Apply), arg0, arg1)
 }
 
-// Batch mocks base method
+// Batch mocks base method.
 func (m *MockQuery) Batch(arg0 int) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Batch", arg0)
@@ -180,13 +181,13 @@ func (m *MockQuery) Batch(arg0 int) mongo.Query {
 	return ret0
 }
 
-// Batch indicates an expected call of Batch
+// Batch indicates an expected call of Batch.
 func (mr *MockQueryMockRecorder) Batch(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Batch", reflect.TypeOf((*MockQuery)(nil).Batch), arg0)
 }
 
-// Comment mocks base method
+// Comment mocks base method.
 func (m *MockQuery) Comment(arg0 string) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Comment", arg0)
@@ -194,13 +195,13 @@ func (m *MockQuery) Comment(arg0 string) mongo.Query {
 	return ret0
 }
 
-// Comment indicates an expected call of Comment
+// Comment indicates an expected call of Comment.
 func (mr *MockQueryMockRecorder) Comment(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Comment", reflect.TypeOf((*MockQuery)(nil).Comment), arg0)
 }
 
-// Count mocks base method
+// Count mocks base method.
 func (m *MockQuery) Count() (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Count")
@@ -209,13 +210,13 @@ func (m *MockQuery) Count() (int, error) {
 	return ret0, ret1
 }
 
-// Count indicates an expected call of Count
+// Count indicates an expected call of Count.
 func (mr *MockQueryMockRecorder) Count() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockQuery)(nil).Count))
 }
 
-// Distinct mocks base method
+// Distinct mocks base method.
 func (m *MockQuery) Distinct(arg0 string, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Distinct", arg0, arg1)
@@ -223,13 +224,13 @@ func (m *MockQuery) Distinct(arg0 string, arg1 interface{}) error {
 	return ret0
 }
 
-// Distinct indicates an expected call of Distinct
+// Distinct indicates an expected call of Distinct.
 func (mr *MockQueryMockRecorder) Distinct(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Distinct", reflect.TypeOf((*MockQuery)(nil).Distinct), arg0, arg1)
 }
 
-// Explain mocks base method
+// Explain mocks base method.
 func (m *MockQuery) Explain(arg0 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Explain", arg0)
@@ -237,13 +238,13 @@ func (m *MockQuery) Explain(arg0 interface{}) error {
 	return ret0
 }
 
-// Explain indicates an expected call of Explain
+// Explain indicates an expected call of Explain.
 func (mr *MockQueryMockRecorder) Explain(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Explain", reflect.TypeOf((*MockQuery)(nil).Explain), arg0)
 }
 
-// For mocks base method
+// For mocks base method.
 func (m *MockQuery) For(arg0 interface{}, arg1 func() error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "For", arg0, arg1)
@@ -251,13 +252,13 @@ func (m *MockQuery) For(arg0 interface{}, arg1 func() error) error {
 	return ret0
 }
 
-// For indicates an expected call of For
+// For indicates an expected call of For.
 func (mr *MockQueryMockRecorder) For(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "For", reflect.TypeOf((*MockQuery)(nil).For), arg0, arg1)
 }
 
-// Hint mocks base method
+// Hint mocks base method.
 func (m *MockQuery) Hint(arg0 ...string) mongo.Query {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -269,13 +270,13 @@ func (m *MockQuery) Hint(arg0 ...string) mongo.Query {
 	return ret0
 }
 
-// Hint indicates an expected call of Hint
+// Hint indicates an expected call of Hint.
 func (mr *MockQueryMockRecorder) Hint(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hint", reflect.TypeOf((*MockQuery)(nil).Hint), arg0...)
 }
 
-// Iter mocks base method
+// Iter mocks base method.
 func (m *MockQuery) Iter() mongo.Iterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Iter")
@@ -283,13 +284,13 @@ func (m *MockQuery) Iter() mongo.Iterator {
 	return ret0
 }
 
-// Iter indicates an expected call of Iter
+// Iter indicates an expected call of Iter.
 func (mr *MockQueryMockRecorder) Iter() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Iter", reflect.TypeOf((*MockQuery)(nil).Iter))
 }
 
-// Limit mocks base method
+// Limit mocks base method.
 func (m *MockQuery) Limit(arg0 int) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Limit", arg0)
@@ -297,13 +298,13 @@ func (m *MockQuery) Limit(arg0 int) mongo.Query {
 	return ret0
 }
 
-// Limit indicates an expected call of Limit
+// Limit indicates an expected call of Limit.
 func (mr *MockQueryMockRecorder) Limit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Limit", reflect.TypeOf((*MockQuery)(nil).Limit), arg0)
 }
 
-// LogReplay mocks base method
+// LogReplay mocks base method.
 func (m *MockQuery) LogReplay() mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogReplay")
@@ -311,13 +312,13 @@ func (m *MockQuery) LogReplay() mongo.Query {
 	return ret0
 }
 
-// LogReplay indicates an expected call of LogReplay
+// LogReplay indicates an expected call of LogReplay.
 func (mr *MockQueryMockRecorder) LogReplay() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogReplay", reflect.TypeOf((*MockQuery)(nil).LogReplay))
 }
 
-// MapReduce mocks base method
+// MapReduce mocks base method.
 func (m *MockQuery) MapReduce(arg0 *mgo.MapReduce, arg1 interface{}) (*mgo.MapReduceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MapReduce", arg0, arg1)
@@ -326,13 +327,13 @@ func (m *MockQuery) MapReduce(arg0 *mgo.MapReduce, arg1 interface{}) (*mgo.MapRe
 	return ret0, ret1
 }
 
-// MapReduce indicates an expected call of MapReduce
+// MapReduce indicates an expected call of MapReduce.
 func (mr *MockQueryMockRecorder) MapReduce(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MapReduce", reflect.TypeOf((*MockQuery)(nil).MapReduce), arg0, arg1)
 }
 
-// One mocks base method
+// One mocks base method.
 func (m *MockQuery) One(arg0 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "One", arg0)
@@ -340,13 +341,13 @@ func (m *MockQuery) One(arg0 interface{}) error {
 	return ret0
 }
 
-// One indicates an expected call of One
+// One indicates an expected call of One.
 func (mr *MockQueryMockRecorder) One(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockQuery)(nil).One), arg0)
 }
 
-// Prefetch mocks base method
+// Prefetch mocks base method.
 func (m *MockQuery) Prefetch(arg0 float64) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Prefetch", arg0)
@@ -354,13 +355,13 @@ func (m *MockQuery) Prefetch(arg0 float64) mongo.Query {
 	return ret0
 }
 
-// Prefetch indicates an expected call of Prefetch
+// Prefetch indicates an expected call of Prefetch.
 func (mr *MockQueryMockRecorder) Prefetch(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prefetch", reflect.TypeOf((*MockQuery)(nil).Prefetch), arg0)
 }
 
-// Select mocks base method
+// Select mocks base method.
 func (m *MockQuery) Select(arg0 interface{}) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Select", arg0)
@@ -368,13 +369,13 @@ func (m *MockQuery) Select(arg0 interface{}) mongo.Query {
 	return ret0
 }
 
-// Select indicates an expected call of Select
+// Select indicates an expected call of Select.
 func (mr *MockQueryMockRecorder) Select(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Select", reflect.TypeOf((*MockQuery)(nil).Select), arg0)
 }
 
-// SetMaxScan mocks base method
+// SetMaxScan mocks base method.
 func (m *MockQuery) SetMaxScan(arg0 int) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMaxScan", arg0)
@@ -382,13 +383,13 @@ func (m *MockQuery) SetMaxScan(arg0 int) mongo.Query {
 	return ret0
 }
 
-// SetMaxScan indicates an expected call of SetMaxScan
+// SetMaxScan indicates an expected call of SetMaxScan.
 func (mr *MockQueryMockRecorder) SetMaxScan(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxScan", reflect.TypeOf((*MockQuery)(nil).SetMaxScan), arg0)
 }
 
-// SetMaxTime mocks base method
+// SetMaxTime mocks base method.
 func (m *MockQuery) SetMaxTime(arg0 time.Duration) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMaxTime", arg0)
@@ -396,13 +397,13 @@ func (m *MockQuery) SetMaxTime(arg0 time.Duration) mongo.Query {
 	return ret0
 }
 
-// SetMaxTime indicates an expected call of SetMaxTime
+// SetMaxTime indicates an expected call of SetMaxTime.
 func (mr *MockQueryMockRecorder) SetMaxTime(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxTime", reflect.TypeOf((*MockQuery)(nil).SetMaxTime), arg0)
 }
 
-// Skip mocks base method
+// Skip mocks base method.
 func (m *MockQuery) Skip(arg0 int) mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Skip", arg0)
@@ -410,13 +411,13 @@ func (m *MockQuery) Skip(arg0 int) mongo.Query {
 	return ret0
 }
 
-// Skip indicates an expected call of Skip
+// Skip indicates an expected call of Skip.
 func (mr *MockQueryMockRecorder) Skip(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Skip", reflect.TypeOf((*MockQuery)(nil).Skip), arg0)
 }
 
-// Snapshot mocks base method
+// Snapshot mocks base method.
 func (m *MockQuery) Snapshot() mongo.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Snapshot")
@@ -424,13 +425,13 @@ func (m *MockQuery) Snapshot() mongo.Query {
 	return ret0
 }
 
-// Snapshot indicates an expected call of Snapshot
+// Snapshot indicates an expected call of Snapshot.
 func (mr *MockQueryMockRecorder) Snapshot() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockQuery)(nil).Snapshot))
 }
 
-// Sort mocks base method
+// Sort mocks base method.
 func (m *MockQuery) Sort(arg0 ...string) mongo.Query {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -442,13 +443,13 @@ func (m *MockQuery) Sort(arg0 ...string) mongo.Query {
 	return ret0
 }
 
-// Sort indicates an expected call of Sort
+// Sort indicates an expected call of Sort.
 func (mr *MockQueryMockRecorder) Sort(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sort", reflect.TypeOf((*MockQuery)(nil).Sort), arg0...)
 }
 
-// Tail mocks base method
+// Tail mocks base method.
 func (m *MockQuery) Tail(arg0 time.Duration) *mgo.Iter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tail", arg0)
@@ -456,7 +457,7 @@ func (m *MockQuery) Tail(arg0 time.Duration) *mgo.Iter {
 	return ret0
 }
 
-// Tail indicates an expected call of Tail
+// Tail indicates an expected call of Tail.
 func (mr *MockQueryMockRecorder) Tail(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tail", reflect.TypeOf((*MockQuery)(nil).Tail), arg0)

--- a/state/mocks/operation_mock.go
+++ b/state/mocks/operation_mock.go
@@ -5,35 +5,36 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	txn "github.com/juju/mgo/v2/txn"
-	reflect "reflect"
 )
 
-// MockModelOperation is a mock of ModelOperation interface
+// MockModelOperation is a mock of ModelOperation interface.
 type MockModelOperation struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelOperationMockRecorder
 }
 
-// MockModelOperationMockRecorder is the mock recorder for MockModelOperation
+// MockModelOperationMockRecorder is the mock recorder for MockModelOperation.
 type MockModelOperationMockRecorder struct {
 	mock *MockModelOperation
 }
 
-// NewMockModelOperation creates a new mock instance
+// NewMockModelOperation creates a new mock instance.
 func NewMockModelOperation(ctrl *gomock.Controller) *MockModelOperation {
 	mock := &MockModelOperation{ctrl: ctrl}
 	mock.recorder = &MockModelOperationMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModelOperation) EXPECT() *MockModelOperationMockRecorder {
 	return m.recorder
 }
 
-// Build mocks base method
+// Build mocks base method.
 func (m *MockModelOperation) Build(arg0 int) ([]txn.Op, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Build", arg0)
@@ -42,13 +43,13 @@ func (m *MockModelOperation) Build(arg0 int) ([]txn.Op, error) {
 	return ret0, ret1
 }
 
-// Build indicates an expected call of Build
+// Build indicates an expected call of Build.
 func (mr *MockModelOperationMockRecorder) Build(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockModelOperation)(nil).Build), arg0)
 }
 
-// Done mocks base method
+// Done mocks base method.
 func (m *MockModelOperation) Done(arg0 error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Done", arg0)
@@ -56,7 +57,7 @@ func (m *MockModelOperation) Done(arg0 error) error {
 	return ret0
 }
 
-// Done indicates an expected call of Done
+// Done indicates an expected call of Done.
 func (mr *MockModelOperationMockRecorder) Done(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockModelOperation)(nil).Done), arg0)

--- a/state/mocks/resources_mock.go
+++ b/state/mocks/resources_mock.go
@@ -5,40 +5,41 @@
 package mocks
 
 import (
+	io "io"
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	resource "github.com/juju/charm/v8/resource"
 	resource0 "github.com/juju/juju/resource"
 	state "github.com/juju/juju/state"
 	txn "github.com/juju/mgo/v2/txn"
-	io "io"
-	reflect "reflect"
-	time "time"
 )
 
-// MockResources is a mock of Resources interface
+// MockResources is a mock of Resources interface.
 type MockResources struct {
 	ctrl     *gomock.Controller
 	recorder *MockResourcesMockRecorder
 }
 
-// MockResourcesMockRecorder is the mock recorder for MockResources
+// MockResourcesMockRecorder is the mock recorder for MockResources.
 type MockResourcesMockRecorder struct {
 	mock *MockResources
 }
 
-// NewMockResources creates a new mock instance
+// NewMockResources creates a new mock instance.
 func NewMockResources(ctrl *gomock.Controller) *MockResources {
 	mock := &MockResources{ctrl: ctrl}
 	mock.recorder = &MockResourcesMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResources) EXPECT() *MockResourcesMockRecorder {
 	return m.recorder
 }
 
-// AddPendingResource mocks base method
+// AddPendingResource mocks base method.
 func (m *MockResources) AddPendingResource(arg0, arg1 string, arg2 resource.Resource) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddPendingResource", arg0, arg1, arg2)
@@ -47,13 +48,13 @@ func (m *MockResources) AddPendingResource(arg0, arg1 string, arg2 resource.Reso
 	return ret0, ret1
 }
 
-// AddPendingResource indicates an expected call of AddPendingResource
+// AddPendingResource indicates an expected call of AddPendingResource.
 func (mr *MockResourcesMockRecorder) AddPendingResource(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPendingResource", reflect.TypeOf((*MockResources)(nil).AddPendingResource), arg0, arg1, arg2)
 }
 
-// GetPendingResource mocks base method
+// GetPendingResource mocks base method.
 func (m *MockResources) GetPendingResource(arg0, arg1, arg2 string) (resource0.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPendingResource", arg0, arg1, arg2)
@@ -62,13 +63,13 @@ func (m *MockResources) GetPendingResource(arg0, arg1, arg2 string) (resource0.R
 	return ret0, ret1
 }
 
-// GetPendingResource indicates an expected call of GetPendingResource
+// GetPendingResource indicates an expected call of GetPendingResource.
 func (mr *MockResourcesMockRecorder) GetPendingResource(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingResource", reflect.TypeOf((*MockResources)(nil).GetPendingResource), arg0, arg1, arg2)
 }
 
-// GetResource mocks base method
+// GetResource mocks base method.
 func (m *MockResources) GetResource(arg0, arg1 string) (resource0.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResource", arg0, arg1)
@@ -77,13 +78,13 @@ func (m *MockResources) GetResource(arg0, arg1 string) (resource0.Resource, erro
 	return ret0, ret1
 }
 
-// GetResource indicates an expected call of GetResource
+// GetResource indicates an expected call of GetResource.
 func (mr *MockResourcesMockRecorder) GetResource(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResource", reflect.TypeOf((*MockResources)(nil).GetResource), arg0, arg1)
 }
 
-// ListPendingResources mocks base method
+// ListPendingResources mocks base method.
 func (m *MockResources) ListPendingResources(arg0 string) ([]resource0.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPendingResources", arg0)
@@ -92,13 +93,13 @@ func (m *MockResources) ListPendingResources(arg0 string) ([]resource0.Resource,
 	return ret0, ret1
 }
 
-// ListPendingResources indicates an expected call of ListPendingResources
+// ListPendingResources indicates an expected call of ListPendingResources.
 func (mr *MockResourcesMockRecorder) ListPendingResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPendingResources", reflect.TypeOf((*MockResources)(nil).ListPendingResources), arg0)
 }
 
-// ListResources mocks base method
+// ListResources mocks base method.
 func (m *MockResources) ListResources(arg0 string) (resource0.ApplicationResources, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResources", arg0)
@@ -107,13 +108,13 @@ func (m *MockResources) ListResources(arg0 string) (resource0.ApplicationResourc
 	return ret0, ret1
 }
 
-// ListResources indicates an expected call of ListResources
+// ListResources indicates an expected call of ListResources.
 func (mr *MockResourcesMockRecorder) ListResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResources", reflect.TypeOf((*MockResources)(nil).ListResources), arg0)
 }
 
-// NewResolvePendingResourcesOps mocks base method
+// NewResolvePendingResourcesOps mocks base method.
 func (m *MockResources) NewResolvePendingResourcesOps(arg0 string, arg1 map[string]string) ([]txn.Op, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewResolvePendingResourcesOps", arg0, arg1)
@@ -122,13 +123,13 @@ func (m *MockResources) NewResolvePendingResourcesOps(arg0 string, arg1 map[stri
 	return ret0, ret1
 }
 
-// NewResolvePendingResourcesOps indicates an expected call of NewResolvePendingResourcesOps
+// NewResolvePendingResourcesOps indicates an expected call of NewResolvePendingResourcesOps.
 func (mr *MockResourcesMockRecorder) NewResolvePendingResourcesOps(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewResolvePendingResourcesOps", reflect.TypeOf((*MockResources)(nil).NewResolvePendingResourcesOps), arg0, arg1)
 }
 
-// OpenResource mocks base method
+// OpenResource mocks base method.
 func (m *MockResources) OpenResource(arg0, arg1 string) (resource0.Resource, io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenResource", arg0, arg1)
@@ -138,13 +139,13 @@ func (m *MockResources) OpenResource(arg0, arg1 string) (resource0.Resource, io.
 	return ret0, ret1, ret2
 }
 
-// OpenResource indicates an expected call of OpenResource
+// OpenResource indicates an expected call of OpenResource.
 func (mr *MockResourcesMockRecorder) OpenResource(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenResource", reflect.TypeOf((*MockResources)(nil).OpenResource), arg0, arg1)
 }
 
-// OpenResourceForUniter mocks base method
+// OpenResourceForUniter mocks base method.
 func (m *MockResources) OpenResourceForUniter(arg0 resource0.Unit, arg1 string) (resource0.Resource, io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenResourceForUniter", arg0, arg1)
@@ -154,13 +155,13 @@ func (m *MockResources) OpenResourceForUniter(arg0 resource0.Unit, arg1 string) 
 	return ret0, ret1, ret2
 }
 
-// OpenResourceForUniter indicates an expected call of OpenResourceForUniter
+// OpenResourceForUniter indicates an expected call of OpenResourceForUniter.
 func (mr *MockResourcesMockRecorder) OpenResourceForUniter(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenResourceForUniter", reflect.TypeOf((*MockResources)(nil).OpenResourceForUniter), arg0, arg1)
 }
 
-// RemovePendingAppResources mocks base method
+// RemovePendingAppResources mocks base method.
 func (m *MockResources) RemovePendingAppResources(arg0 string, arg1 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemovePendingAppResources", arg0, arg1)
@@ -168,13 +169,13 @@ func (m *MockResources) RemovePendingAppResources(arg0 string, arg1 map[string]s
 	return ret0
 }
 
-// RemovePendingAppResources indicates an expected call of RemovePendingAppResources
+// RemovePendingAppResources indicates an expected call of RemovePendingAppResources.
 func (mr *MockResourcesMockRecorder) RemovePendingAppResources(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePendingAppResources", reflect.TypeOf((*MockResources)(nil).RemovePendingAppResources), arg0, arg1)
 }
 
-// SetCharmStoreResources mocks base method
+// SetCharmStoreResources mocks base method.
 func (m *MockResources) SetCharmStoreResources(arg0 string, arg1 []resource.Resource, arg2 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCharmStoreResources", arg0, arg1, arg2)
@@ -182,13 +183,13 @@ func (m *MockResources) SetCharmStoreResources(arg0 string, arg1 []resource.Reso
 	return ret0
 }
 
-// SetCharmStoreResources indicates an expected call of SetCharmStoreResources
+// SetCharmStoreResources indicates an expected call of SetCharmStoreResources.
 func (mr *MockResourcesMockRecorder) SetCharmStoreResources(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmStoreResources", reflect.TypeOf((*MockResources)(nil).SetCharmStoreResources), arg0, arg1, arg2)
 }
 
-// SetResource mocks base method
+// SetResource mocks base method.
 func (m *MockResources) SetResource(arg0, arg1 string, arg2 resource.Resource, arg3 io.Reader, arg4 state.IncrementCharmModifiedVersionType) (resource0.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetResource", arg0, arg1, arg2, arg3, arg4)
@@ -197,13 +198,13 @@ func (m *MockResources) SetResource(arg0, arg1 string, arg2 resource.Resource, a
 	return ret0, ret1
 }
 
-// SetResource indicates an expected call of SetResource
+// SetResource indicates an expected call of SetResource.
 func (mr *MockResourcesMockRecorder) SetResource(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetResource", reflect.TypeOf((*MockResources)(nil).SetResource), arg0, arg1, arg2, arg3, arg4)
 }
 
-// SetUnitResource mocks base method
+// SetUnitResource mocks base method.
 func (m *MockResources) SetUnitResource(arg0, arg1 string, arg2 resource.Resource) (resource0.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUnitResource", arg0, arg1, arg2)
@@ -212,13 +213,13 @@ func (m *MockResources) SetUnitResource(arg0, arg1 string, arg2 resource.Resourc
 	return ret0, ret1
 }
 
-// SetUnitResource indicates an expected call of SetUnitResource
+// SetUnitResource indicates an expected call of SetUnitResource.
 func (mr *MockResourcesMockRecorder) SetUnitResource(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUnitResource", reflect.TypeOf((*MockResources)(nil).SetUnitResource), arg0, arg1, arg2)
 }
 
-// UpdatePendingResource mocks base method
+// UpdatePendingResource mocks base method.
 func (m *MockResources) UpdatePendingResource(arg0, arg1, arg2 string, arg3 resource.Resource, arg4 io.Reader) (resource0.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePendingResource", arg0, arg1, arg2, arg3, arg4)
@@ -227,7 +228,7 @@ func (m *MockResources) UpdatePendingResource(arg0, arg1, arg2 string, arg3 reso
 	return ret0, ret1
 }
 
-// UpdatePendingResource indicates an expected call of UpdatePendingResource
+// UpdatePendingResource indicates an expected call of UpdatePendingResource.
 func (mr *MockResourcesMockRecorder) UpdatePendingResource(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePendingResource", reflect.TypeOf((*MockResources)(nil).UpdatePendingResource), arg0, arg1, arg2, arg3, arg4)

--- a/state/mocks/txn_mock.go
+++ b/state/mocks/txn_mock.go
@@ -5,35 +5,36 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	txn "github.com/juju/txn"
-	reflect "reflect"
 )
 
-// MockRunner is a mock of Runner interface
+// MockRunner is a mock of Runner interface.
 type MockRunner struct {
 	ctrl     *gomock.Controller
 	recorder *MockRunnerMockRecorder
 }
 
-// MockRunnerMockRecorder is the mock recorder for MockRunner
+// MockRunnerMockRecorder is the mock recorder for MockRunner.
 type MockRunnerMockRecorder struct {
 	mock *MockRunner
 }
 
-// NewMockRunner creates a new mock instance
+// NewMockRunner creates a new mock instance.
 func NewMockRunner(ctrl *gomock.Controller) *MockRunner {
 	mock := &MockRunner{ctrl: ctrl}
 	mock.recorder = &MockRunnerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRunner) EXPECT() *MockRunnerMockRecorder {
 	return m.recorder
 }
 
-// MaybePruneTransactions mocks base method
+// MaybePruneTransactions mocks base method.
 func (m *MockRunner) MaybePruneTransactions(arg0 txn.PruneOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybePruneTransactions", arg0)
@@ -41,13 +42,13 @@ func (m *MockRunner) MaybePruneTransactions(arg0 txn.PruneOptions) error {
 	return ret0
 }
 
-// MaybePruneTransactions indicates an expected call of MaybePruneTransactions
+// MaybePruneTransactions indicates an expected call of MaybePruneTransactions.
 func (mr *MockRunnerMockRecorder) MaybePruneTransactions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePruneTransactions", reflect.TypeOf((*MockRunner)(nil).MaybePruneTransactions), arg0)
 }
 
-// ResumeTransactions mocks base method
+// ResumeTransactions mocks base method.
 func (m *MockRunner) ResumeTransactions() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResumeTransactions")
@@ -55,13 +56,13 @@ func (m *MockRunner) ResumeTransactions() error {
 	return ret0
 }
 
-// ResumeTransactions indicates an expected call of ResumeTransactions
+// ResumeTransactions indicates an expected call of ResumeTransactions.
 func (mr *MockRunnerMockRecorder) ResumeTransactions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeTransactions", reflect.TypeOf((*MockRunner)(nil).ResumeTransactions))
 }
 
-// Run mocks base method
+// Run mocks base method.
 func (m *MockRunner) Run(arg0 txn.TransactionSource) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Run", arg0)
@@ -69,13 +70,13 @@ func (m *MockRunner) Run(arg0 txn.TransactionSource) error {
 	return ret0
 }
 
-// Run indicates an expected call of Run
+// Run indicates an expected call of Run.
 func (mr *MockRunnerMockRecorder) Run(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockRunner)(nil).Run), arg0)
 }
 
-// RunTransaction mocks base method
+// RunTransaction mocks base method.
 func (m *MockRunner) RunTransaction(arg0 *txn.Transaction) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTransaction", arg0)
@@ -83,7 +84,7 @@ func (m *MockRunner) RunTransaction(arg0 *txn.Transaction) error {
 	return ret0
 }
 
-// RunTransaction indicates an expected call of RunTransaction
+// RunTransaction indicates an expected call of RunTransaction.
 func (mr *MockRunnerMockRecorder) RunTransaction(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTransaction", reflect.TypeOf((*MockRunner)(nil).RunTransaction), arg0)

--- a/state/mocks/watcher_mock.go
+++ b/state/mocks/watcher_mock.go
@@ -5,35 +5,36 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	watcher "github.com/juju/juju/state/watcher"
-	reflect "reflect"
 )
 
-// MockBaseWatcher is a mock of BaseWatcher interface
+// MockBaseWatcher is a mock of BaseWatcher interface.
 type MockBaseWatcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockBaseWatcherMockRecorder
 }
 
-// MockBaseWatcherMockRecorder is the mock recorder for MockBaseWatcher
+// MockBaseWatcherMockRecorder is the mock recorder for MockBaseWatcher.
 type MockBaseWatcherMockRecorder struct {
 	mock *MockBaseWatcher
 }
 
-// NewMockBaseWatcher creates a new mock instance
+// NewMockBaseWatcher creates a new mock instance.
 func NewMockBaseWatcher(ctrl *gomock.Controller) *MockBaseWatcher {
 	mock := &MockBaseWatcher{ctrl: ctrl}
 	mock.recorder = &MockBaseWatcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBaseWatcher) EXPECT() *MockBaseWatcherMockRecorder {
 	return m.recorder
 }
 
-// Dead mocks base method
+// Dead mocks base method.
 func (m *MockBaseWatcher) Dead() <-chan struct{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Dead")
@@ -41,13 +42,13 @@ func (m *MockBaseWatcher) Dead() <-chan struct{} {
 	return ret0
 }
 
-// Dead indicates an expected call of Dead
+// Dead indicates an expected call of Dead.
 func (mr *MockBaseWatcherMockRecorder) Dead() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dead", reflect.TypeOf((*MockBaseWatcher)(nil).Dead))
 }
 
-// Err mocks base method
+// Err mocks base method.
 func (m *MockBaseWatcher) Err() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Err")
@@ -55,49 +56,49 @@ func (m *MockBaseWatcher) Err() error {
 	return ret0
 }
 
-// Err indicates an expected call of Err
+// Err indicates an expected call of Err.
 func (mr *MockBaseWatcherMockRecorder) Err() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Err", reflect.TypeOf((*MockBaseWatcher)(nil).Err))
 }
 
-// Kill mocks base method
+// Kill mocks base method.
 func (m *MockBaseWatcher) Kill() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Kill")
 }
 
-// Kill indicates an expected call of Kill
+// Kill indicates an expected call of Kill.
 func (mr *MockBaseWatcherMockRecorder) Kill() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockBaseWatcher)(nil).Kill))
 }
 
-// Unwatch mocks base method
+// Unwatch mocks base method.
 func (m *MockBaseWatcher) Unwatch(arg0 string, arg1 interface{}, arg2 chan<- watcher.Change) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Unwatch", arg0, arg1, arg2)
 }
 
-// Unwatch indicates an expected call of Unwatch
+// Unwatch indicates an expected call of Unwatch.
 func (mr *MockBaseWatcherMockRecorder) Unwatch(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unwatch", reflect.TypeOf((*MockBaseWatcher)(nil).Unwatch), arg0, arg1, arg2)
 }
 
-// UnwatchCollection mocks base method
+// UnwatchCollection mocks base method.
 func (m *MockBaseWatcher) UnwatchCollection(arg0 string, arg1 chan<- watcher.Change) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UnwatchCollection", arg0, arg1)
 }
 
-// UnwatchCollection indicates an expected call of UnwatchCollection
+// UnwatchCollection indicates an expected call of UnwatchCollection.
 func (mr *MockBaseWatcherMockRecorder) UnwatchCollection(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnwatchCollection", reflect.TypeOf((*MockBaseWatcher)(nil).UnwatchCollection), arg0, arg1)
 }
 
-// Wait mocks base method
+// Wait mocks base method.
 func (m *MockBaseWatcher) Wait() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Wait")
@@ -105,49 +106,49 @@ func (m *MockBaseWatcher) Wait() error {
 	return ret0
 }
 
-// Wait indicates an expected call of Wait
+// Wait indicates an expected call of Wait.
 func (mr *MockBaseWatcherMockRecorder) Wait() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockBaseWatcher)(nil).Wait))
 }
 
-// Watch mocks base method
+// Watch mocks base method.
 func (m *MockBaseWatcher) Watch(arg0 string, arg1 interface{}, arg2 chan<- watcher.Change) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Watch", arg0, arg1, arg2)
 }
 
-// Watch indicates an expected call of Watch
+// Watch indicates an expected call of Watch.
 func (mr *MockBaseWatcherMockRecorder) Watch(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockBaseWatcher)(nil).Watch), arg0, arg1, arg2)
 }
 
-// WatchCollection mocks base method
+// WatchCollection mocks base method.
 func (m *MockBaseWatcher) WatchCollection(arg0 string, arg1 chan<- watcher.Change) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "WatchCollection", arg0, arg1)
 }
 
-// WatchCollection indicates an expected call of WatchCollection
+// WatchCollection indicates an expected call of WatchCollection.
 func (mr *MockBaseWatcherMockRecorder) WatchCollection(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCollection", reflect.TypeOf((*MockBaseWatcher)(nil).WatchCollection), arg0, arg1)
 }
 
-// WatchCollectionWithFilter mocks base method
+// WatchCollectionWithFilter mocks base method.
 func (m *MockBaseWatcher) WatchCollectionWithFilter(arg0 string, arg1 chan<- watcher.Change, arg2 func(interface{}) bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "WatchCollectionWithFilter", arg0, arg1, arg2)
 }
 
-// WatchCollectionWithFilter indicates an expected call of WatchCollectionWithFilter
+// WatchCollectionWithFilter indicates an expected call of WatchCollectionWithFilter.
 func (mr *MockBaseWatcherMockRecorder) WatchCollectionWithFilter(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCollectionWithFilter", reflect.TypeOf((*MockBaseWatcher)(nil).WatchCollectionWithFilter), arg0, arg1, arg2)
 }
 
-// WatchMulti mocks base method
+// WatchMulti mocks base method.
 func (m *MockBaseWatcher) WatchMulti(arg0 string, arg1 []interface{}, arg2 chan<- watcher.Change) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchMulti", arg0, arg1, arg2)
@@ -155,7 +156,7 @@ func (m *MockBaseWatcher) WatchMulti(arg0 string, arg1 []interface{}, arg2 chan<
 	return ret0
 }
 
-// WatchMulti indicates an expected call of WatchMulti
+// WatchMulti indicates an expected call of WatchMulti.
 func (mr *MockBaseWatcherMockRecorder) WatchMulti(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchMulti", reflect.TypeOf((*MockBaseWatcher)(nil).WatchMulti), arg0, arg1, arg2)

--- a/state/state.go
+++ b/state/state.go
@@ -245,6 +245,38 @@ func (st *State) RemoveExportingModelDocs() error {
 func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	modelUUID := st.ModelUUID()
 
+	// Gather all user permissions for the model.
+	// Do this first because we remove some parent docs below.
+	var permOps []txn.Op
+	permPattern := bson.M{
+		"_id": bson.M{"$regex": "^" + permissionID(modelKey(modelUUID), "")},
+	}
+	ops, err := st.removeInCollectionOps(permissionsC, permPattern)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	permOps = append(permOps, ops...)
+	// Gather all offer permissions for the model.
+	ao := NewApplicationOffers(st)
+	allOffers, err := ao.AllApplicationOffers()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, offer := range allOffers {
+		permPattern = bson.M{
+			"_id": bson.M{"$regex": "^" + permissionID(applicationOfferKey(offer.OfferUUID), "")},
+		}
+		ops, err = st.removeInCollectionOps(permissionsC, permPattern)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		permOps = append(permOps, ops...)
+	}
+	err = st.db().RunTransaction(permOps)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// Remove each collection in its own transaction.
 	for name, info := range st.database.Schema() {
 		if info.global || info.rawAccess {
@@ -282,19 +314,6 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 
 	// Logs are in a separate database so don't get caught by that loop.
 	_ = removeModelLogs(st.MongoSession(), modelUUID)
-
-	// Remove all user permissions for the model.
-	permPattern := bson.M{
-		"_id": bson.M{"$regex": "^" + permissionID(modelKey(modelUUID), "")},
-	}
-	ops, err := st.removeInCollectionOps(permissionsC, permPattern)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = st.db().RunTransaction(ops)
-	if err != nil {
-		return errors.Trace(err)
-	}
 
 	// Now remove the model.
 	model, err := st.Model()


### PR DESCRIPTION
When migrating a model, the offer permissions we not being copied across.
The PR fixes that, and also ensures the permissions are removed from the source model.

## QA steps

```
juju bootstrap lxd c1
juju add-model foo
juju deploy mariadb && juju offer mariadb:db

juju bootstrap lxd c2
juju switch c1
juju migrate foo c2
juju switch c2

juju show-offer mariadb
```

(check that there are 2 permissions)
migrate model back to c1
```
juju migrate foo c1
juju switch c2
juju show-offer mariadb
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1957745
