### PR TITLE
[JUJU-451] Prevent panic during reporting in relation state tracker.

### DIFF
--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -498,15 +498,21 @@ func (r *relationStateTracker) Report() map[string]interface{} {
 	result := make(map[string]interface{})
 
 	for id, st := range r.stateMgr.(*stateManager).relationState {
-		relationer := r.relationers[id]
-		result[strconv.Itoa(id)] = map[string]interface{}{
+		report := map[string]interface{}{
 			"application-members": st.ApplicationMembers,
 			"members":             st.Members,
 			"is-peer":             r.isPeerRelation[id],
-			"dying":               relationer.IsDying(),
-			"endpoint":            relationer.RelationUnit().Endpoint().Name,
-			"relation":            relationer.RelationUnit().Relation().String(),
 		}
+
+		// Ensure that the relationer exists and is alive before reporting
+		// the information.
+		if relationer, ok := r.relationers[id]; ok && relationer != nil {
+			report["dying"] = relationer.IsDying()
+			report["endpoint"] = relationer.RelationUnit().Endpoint().Name
+			report["relation"] = relationer.RelationUnit().Relation().String()
+		}
+
+		result[strconv.Itoa(id)] = report
 	}
 
 	return result


### PR DESCRIPTION
The following prevents the reporting in relation state tracker causing a
panic if the relation doesn't exist. Additionally, we may want to check
if the relationer is dying before inspecting the relation unit.

The panic in question:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x25667a5]

goroutine 527 [running]:
github.com/juju/juju/worker/uniter/relation.(*relationStateTracker).Report(0xc000cc7340, 0xc0004ecea0)
	/build/snapcraft-juju-35d6cf/parts/juju/src/worker/uniter/relation/statetracker.go:506 +0x325
github.com/juju/juju/worker/uniter.(*Uniter).Report(0xc0003ec480, 0x6ec7160)
	/build/snapcraft-juju-35d6cf/parts/juju/src/worker/uniter/uniter.go:986 +0xe4
github.com/juju/worker/v3/dependency.(*Engine).manifoldsReport(0xc000763200, 0xc0004ecab0)
	/build/snapcraft-juju-35d6cf/parts/juju/src/vendor/github.com/juju/worker/v3/dependency/engine.go:314 +0x379
github.com/juju/worker/v3/dependency.(*Engine).liveReport(0xc000763200, 0xc000c29c6c)
	/build/snapcraft-juju-35d6cf/parts/juju/src/vendor/github.com/juju/worker/v3/dependency/engine.go:285 +0xf0
github.com/juju/worker/v3/dependency.(*Engine).loop(0xc000763200, 0x0, 0x0)
	/build/snapcraft-juju-35d6cf/parts/juju/src/vendor/github.com/juju/worker/v3/dependency/engine.go:213 +0x5a7
gopkg.in/tomb%2ev2.(*Tomb).run(0xc000763270, 0xc000c93a60)
	/build/snapcraft-juju-35d6cf/parts/juju/src/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x38
created by gopkg.in/tomb%2ev2.(*Tomb).Go
	/build/snapcraft-juju-35d6cf/parts/juju/src/vendor/gopkg.in/tomb.v2/tomb.go:159 +0xba
```

## QA steps

Trigger the engine report.

## Bug

Relates to https://bugs.launchpad.net/juju/+bug/1957824
