### PR TITLE
[JUJU-416] Consistantly use juju/retry to handle retries 2 (service/*)

### DIFF
--- a/service/testing_test.go
+++ b/service/testing_test.go
@@ -4,10 +4,13 @@
 package service
 
 import (
+	"time"
+
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/os/v2/series"
+	"github.com/juju/retry"
 	"github.com/juju/testing"
-	"github.com/juju/utils/v2"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
@@ -71,8 +74,10 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *BaseSuite) PatchAttempts(retries int) {
-	s.PatchValue(&installStartRetryAttempts, utils.AttemptStrategy{
-		Min: retries,
+	s.PatchValue(&installStartRetryStrategy, retry.CallArgs{
+		Clock:    clock.WallClock,
+		Delay:    time.Millisecond,
+		Attempts: retries,
 	})
 }
 

--- a/service/windows/password_windows.go
+++ b/service/windows/password_windows.go
@@ -12,8 +12,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/utils/v2"
+	"github.com/juju/retry"
+	"github.com/juju/utils"
 )
 
 // netUserSetInfo is used to change the password on a user.
@@ -46,7 +48,7 @@ var resetJujudPassword = func() (string, error) {
 		return "", errors.Annotate(err, "could not start service manager")
 	}
 
-	err = ensureJujudPasswordHelper("jujud", newPassword, mgr, &PasswordChanger{})
+	err = ensureJujudPasswordHelper("jujud", newPassword, mgr, &PasswordChanger{RetryStrategy: changeServicePasswordRetryStrategy})
 	if err != nil {
 		return "", errors.Annotate(err, "could not change password")
 	}
@@ -69,10 +71,10 @@ func ensureJujudPasswordHelper(username, newPassword string, mgr ServiceManager,
 	return nil
 }
 
-// TODO(katco): 2016-08-09: lp:1611427
-var changeServicePasswordAttempts = utils.AttemptStrategy{
-	Total: 5 * time.Second,
-	Delay: 6 * time.Second,
+var changeServicePasswordRetryStrategy = retry.CallArgs{
+	Clock:       clock.WallClock,
+	MaxDuration: 5 * time.Second,
+	Delay:       6 * time.Second,
 }
 
 // passwordChangerHelpers exists only for making the testing of the ensureJujudPasswordHelper function easier
@@ -85,7 +87,9 @@ type PasswordChangerHelpers interface {
 }
 
 // passwordChanger implements passwordChangerHelpers
-type PasswordChanger struct{}
+type PasswordChanger struct {
+	RetryStrategy retry.CallArgs
+}
 
 // changeUserPasswordLocalhost changes the password for username on localhost
 func (c *PasswordChanger) ChangeUserPasswordLocalhost(newPassword string) error {
@@ -105,7 +109,6 @@ func (c *PasswordChanger) ChangeUserPasswordLocalhost(newPassword string) error 
 	}
 
 	info := netUserSetPassword{passp}
-
 	err = netUserSetInfo(serverp, userp, changePasswordLevel, &info, nil)
 	if err != nil {
 		return errors.Trace(err)
@@ -132,19 +135,15 @@ func (c *PasswordChanger) ChangeJujudServicesPassword(newPassword string, mgr Se
 			continue
 		}
 		logger.Warningf("resetting password on %s", svc)
-		modifiedService := false
-		var err error
-		for attempt := changeServicePasswordAttempts.Start(); attempt.Next(); {
-			err = mgr.ChangeServicePassword(svc, newPassword)
-			if err != nil {
-				logger.Errorf("retrying to change password on service %v; error: %v", svc, err)
-			}
-			if err == nil {
-				modifiedService = true
-				break
-			}
+
+		retryStrategy := c.RetryStrategy
+		retryStrategy.Func = func() error { return mgr.ChangeServicePassword(svc, newPassword) }
+		retryStrategy.NotifyFunc = func(lastError error, attempt int) {
+			logger.Errorf("retrying to change password on service %v; error: %v", svc, lastError)
 		}
-		if !modifiedService {
+		err := retry.Call(retryStrategy)
+		if err != nil {
+			err = retry.LastError(err)
 			return errors.Trace(err)
 		}
 	}

--- a/service/windows/password_windows_test.go
+++ b/service/windows/password_windows_test.go
@@ -8,7 +8,11 @@
 package windows_test
 
 import (
+	"time"
+
+	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/retry"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -44,7 +48,11 @@ type ServicePasswordChangerSuite struct {
 
 func (s *ServicePasswordChangerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
-	s.c = &windows.PasswordChanger{}
+	s.c = &windows.PasswordChanger{RetryStrategy: retry.CallArgs{
+		Clock:    clock.WallClock,
+		Delay:    time.Second,
+		Attempts: 1,
+	}}
 	s.mgr = &myAmazingServiceManager{}
 }
 


### PR DESCRIPTION
Throughout Juju we have inconsistent ways of performing retries. Standardise all retry code to the repository github.com/juju/retry.

Replace occurrences of this old method of retries from the service directory

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run on a linux and windows machine:
```sh
make static-analysis
go test github.com/juju/juju/service/...
```

## Documentation changes

No documentation changes required

## Bug reference

https://bugs.launchpad.net/juju/+bug/1611427/
