### PR TITLE
[JUJU-416] Consistantly use juju/retry to handle retries 3 (state/*)

### DIFF
--- a/state/backups/restore_test.go
+++ b/state/backups/restore_test.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/clock/testclock"
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset/v2"
@@ -25,9 +24,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/mongo/mongotest"
-	"github.com/juju/juju/state"
-	statetesting "github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -201,25 +197,6 @@ func (r *RestoreSuite) TestUpdateMongoEntries(c *gc.C) {
 	n, err = query.Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
-}
-
-func (r *RestoreSuite) TestNewConnection(c *gc.C) {
-	ctlr := statetesting.InitializeWithArgs(c,
-		statetesting.InitializeArgs{
-			Owner: names.NewLocalUserTag("test-admin"),
-			Clock: testclock.NewClock(coretesting.NonZeroTime()),
-		})
-	st := ctlr.SystemState()
-	c.Assert(ctlr.Close(), jc.ErrorIsNil)
-
-	r.PatchValue(&mongoDefaultDialOpts, mongotest.DialOpts)
-	r.PatchValue(&environsGetNewPolicyFunc, func() state.NewPolicyFunc {
-		return nil
-	})
-
-	newConnection, err := connectToDB(st.ControllerTag(), names.NewModelTag(st.ModelUUID()), statetesting.NewMongoInfo())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newConnection.Close(), jc.ErrorIsNil)
 }
 
 func (r *RestoreSuite) TestRunViaSSH(c *gc.C) {


### PR DESCRIPTION
Throughout Juju we have inconsistent ways of performing retries. Standardise all retry code to the repository github.com/juju/retry.

Completely drop the function where this old retries strategy was used. Can do this since it wasn't in use anymore

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run on a linux and windows machine:
```sh
make static-analysis
go test github.com/juju/juju/state/
```

## Documentation changes

No documentation changes required

## Bug reference

https://bugs.launchpad.net/juju/+bug/1611427/
