### PR TITLE
[JUJU-462] Prevent needless link-layer update attempts by instance-poller

### DIFF
--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -850,6 +850,19 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigSuccess(c *gc.C) {
 		makeSpaceAddress("192.168.0.1", network.ScopeCloudLocal, network.AlphaSpaceId),
 		makeSpaceAddress("1.1.1.42", network.ScopePublic, network.AlphaSpaceId),
 	})
+
+	// The addresses were supplied against devices without names or hardware
+	// addresses. This should cause us to update the machine provider addresses
+	// (verified above), but not to attempt to update link-layer device
+	// addresses.
+	var buildCalled bool
+	for _, call := range s.st.Calls() {
+		if call.FuncName == "ApplyOperation.Build" {
+			buildCalled = true
+			break
+		}
+	}
+	c.Assert(buildCalled, jc.IsFalse)
 }
 
 func (s *InstancePollerSuite) TestSetProviderNetworkConfigNoChange(c *gc.C) {


### PR DESCRIPTION
For providers that do not implement `NetworkInterfaces`, the instance-poller worker creates `NetworkConfig` from instance addresses, using dummy devices that have only a `DeviceIndex`.

This is necessary in order that provider-sourced addresses, particularly FIPs and VIPs, are recorded in the `machines` collection. However, we are attempting to update link-layer devices addresses using such configuration, causing low-value log context as described in the linked bug.

Here we prevent the attempt to update link-layer device addresses when we detect such config.

## QA steps

- Bootstrap to OpenStack ensuring that public IPs are allocated to machines.
- Once complete, check the controller logs. There should be no occurrences of "updating provider-sourced link-layer devices...".
- But `juju show-machine -m controller 0 --format yaml` should include the public IP; for example, here we see the public, private and Fan IPs:
```
    ip-addresses:
    - 10.245.164.31
    - 10.5.3.32
    - 252.3.32.1
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1951331
