### PR TITLE
[JUJU-256] Fix smoke race condition

### DIFF
--- a/.github/verify-apache2.sh
+++ b/.github/verify-apache2.sh
@@ -2,6 +2,18 @@
 
 set -euxo pipefail
 
-ip=$(juju status --format json | jq -r '.applications.apache2.units[]."public-address"')
+retries=$1
 
-curl --silent --output /dev/null --max-time 3 "$ip"
+attempts=0
+while true; do
+  if [ "$attempts" -eq "$retries" ]; then
+    echo "Apache health check timed out"
+    exit 1
+  fi
+  attempts=$((attempts+1))
+
+  ip=$(juju status --format json | jq -r '.applications.apache2.units[]."public-address"' || echo "")
+  curl --silent --output /dev/null --max-time 3 "$ip" && break
+
+  sleep 10
+done

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -100,15 +100,7 @@ jobs:
 
         juju wait-for application apache2
 
-        attempts=0
-        while ! ./.github/verify-apache2.sh; do
-          sleep 10
-          attempts=$((attempts+1))
-          if [ "$attempts" -eq 5 ]; then
-            echo "Apache health check timed out"
-            exit 0
-          fi
-        done
+        ./.github/verify-apache2.sh 5
 
     - name: Build snap
       if: env.RUN_TEST == 'RUN'
@@ -162,7 +154,7 @@ jobs:
             exit 1
         fi
 
-        ./.github/verify-apache2.sh
+        ./.github/verify-apache2.sh 3
 
     - name: Test upgrade model
       if: env.RUN_TEST == 'RUN'
@@ -215,4 +207,4 @@ jobs:
             exit 1
         fi
 
-        ./.github/verify-apache2.sh
+        ./.github/verify-apache2.sh 3


### PR DESCRIPTION
There is a rare race condition where this job will poll for juju status before an upgrade has completed, leading to an error.
    
Resolve this by retrying a small number of times


## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run the smoke GitHub action

## Documentation changes

No documentation changes

## Bug reference

No bug reference