### PR TITLE
[JUJU-459] Sync cache model unit setCharmURL

### DIFF
--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -33,6 +33,7 @@ const (
 )
 
 type modelConfig struct {
+	controller   *Controller
 	initializing func() bool
 	metrics      *ControllerGauges
 	hub          *pubsub.SimpleHub
@@ -46,6 +47,7 @@ func newModel(config modelConfig) *Model {
 		Resident:      config.res,
 		metrics:       config.metrics,
 		hub:           config.hub,
+		controller:    config.controller,
 		controllerHub: config.chub,
 		applications:  make(map[string]*Application),
 		charms:        make(map[string]*Charm),
@@ -67,6 +69,7 @@ type Model struct {
 	initializing  func() bool
 	metrics       *ControllerGauges
 	hub           *pubsub.SimpleHub
+	controller    *Controller
 	controllerHub *pubsub.SimpleHub
 	mu            sync.Mutex
 

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -78,7 +78,7 @@ func (s *BaseSuite) New(c *gc.C) (*Controller, <-chan interface{}) {
 func (s *BaseSuite) CaptureEvents(c *gc.C) <-chan interface{} {
 	events := make(chan interface{})
 	s.Config.Notify = func(change interface{}) {
-		send := false
+		var send bool
 		switch change.(type) {
 		case ControllerConfigChange,
 			ModelChange, RemoveModel,

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -181,6 +181,11 @@ func (u *Unit) WatchConfigSettings() (*CharmConfigWatcher, error) {
 	return w, errors.Trace(err)
 }
 
+// GetDetails returns the current unit details as a change type.
+func (u *Unit) GetDetails() UnitChange {
+	return u.details.copy()
+}
+
 func (u *Unit) setDetails(details UnitChange) {
 	var newSubordinate bool
 

--- a/core/cache/unit_test.go
+++ b/core/cache/unit_test.go
@@ -109,6 +109,18 @@ func (s *UnitSuite) TestConfigSettingsDefaultsOnly(c *gc.C) {
 	c.Assert(cfg, gc.DeepEquals, expected)
 }
 
+func (s *UnitSuite) TestUnitGetDetailsReturnsValidChangeType(c *gc.C) {
+	m := s.NewModel(modelChange)
+	m.UpdateCharm(charmChange, s.Manager)
+	m.UpdateApplication(appChange, s.Manager)
+	m.UpdateUnit(unitChange, s.Manager)
+
+	u, err := m.Unit(unitChange.Name)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(u.GetDetails(), gc.DeepEquals, unitChange)
+}
+
 var unitChange = cache.UnitChange{
 	ModelUUID:                "model-uuid",
 	Name:                     "application-name/0",


### PR DESCRIPTION
The following forces a cache sync change during a SetCharmURL from the
uniter API request. The current implementation waits for the unit in the
model cache to reflect the change. If the change never happens, then a
timeout will be recorded and the process will start again.

The following code says, that if the change was dropped during waiting
for the change, then sync the model change directly. This should then
force the URL to be the correct value and other items can then query the
data in a correct manner.

## QA steps

TBA

## Bug reference

Note: this isn't a full fix, but should ensure that we can set the URL correctly.

https://bugs.launchpad.net/juju/+bug/1957942
