### PR TITLE
[JUJU-416] Consistantly use juju/retry to handle retries 4 (worker/apicaller/*)

### DIFF
--- a/worker/apicaller/util_test.go
+++ b/worker/apicaller/util_test.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/juju/names/v4"
+	"github.com/juju/retry"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v2"
 	"github.com/juju/worker/v3"
 	gc "gopkg.in/check.v1"
 
@@ -163,8 +163,7 @@ func lifeTest(c *gc.C, stub *testing.Stub, life apiagent.Life, test func() (api.
 	return test()
 }
 
-// TODO(katco): 2016-08-09: lp:1611427
-func strategyTest(stub *testing.Stub, strategy utils.AttemptStrategy, test func(api.OpenFunc) (api.Connection, error)) (api.Connection, error) {
+func strategyTest(stub *testing.Stub, strategy retry.CallArgs, test func(api.OpenFunc) (api.Connection, error)) (api.Connection, error) {
 	unpatch := testing.PatchValue(apicaller.Strategy, strategy)
 	defer unpatch()
 	return test(func(info *api.Info, opts api.DialOpts) (api.Connection, error) {


### PR DESCRIPTION
Throughout Juju we have inconsistent ways of performing retries. Standardise all retry code to the repository github.com/juju/retry.

Replace occurrences of this old method of retries from the worker/apicaller/ directory

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/worker/apicaller
```

## Documentation changes

No documentation changes required

## Bug reference

https://bugs.launchpad.net/juju/+bug/1611427/
