### PR TITLE
[JUJU-459] Engine Report: Model Cache

### DIFF
--- a/core/cache/application.go
+++ b/core/cache/application.go
@@ -46,6 +46,21 @@ type Application struct {
 	hashCache  *hashCache
 }
 
+// Report returns information that is used in the dependency engine report.
+func (a *Application) Report() map[string]interface{} {
+	details := a.details
+
+	return map[string]interface{}{
+		"exposed":          details.Exposed,
+		"charm-url":        details.CharmURL,
+		"min-units":        details.MinUnits,
+		"constraints":      details.Constraints.String(),
+		"config":           details.Config,
+		"subordinate":      details.Subordinate,
+		"workload-version": details.WorkloadVersion,
+	}
+}
+
 // Note that these property accessors are not lock-protected.
 // They are intended for calling from external packages that have retrieved a
 // deep copy from the cache.

--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -31,6 +31,11 @@ type Charm struct {
 	details CharmChange
 }
 
+// Report returns information that is used in the dependency engine report.
+func (c *Charm) Report() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
 // LXDProfile returns the lxd profile of this charm.
 func (c *Charm) LXDProfile() lxdprofile.Profile {
 	return c.details.LXDProfile

--- a/core/cache/controller_test.go
+++ b/core/cache/controller_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/cache"
-	"github.com/juju/juju/core/life"
 )
 
 type ControllerSuite struct {
@@ -52,14 +51,14 @@ func (s *ControllerSuite) TestAddModel(c *gc.C) {
 	c.Check(controller.ModelUUIDs(), jc.SameContents, []string{modelChange.ModelUUID})
 	c.Check(controller.Report(), gc.DeepEquals, map[string]interface{}{
 		"model-uuid": map[string]interface{}{
-			"name":              "model-owner/test-model",
-			"life":              life.Value("alive"),
-			"application-count": 0,
-			"charm-count":       0,
-			"machine-count":     0,
-			"unit-count":        0,
-			"relation-count":    0,
-			"branch-count":      0,
+			"name":         "model-owner/test-model",
+			"life":         "alive",
+			"applications": make(map[string]interface{}),
+			"charms":       make(map[string]interface{}),
+			"machines":     make(map[string]interface{}),
+			"units":        make(map[string]interface{}),
+			"relations":    make(map[string]interface{}),
+			"branch-count": 0,
 		}})
 
 	// The model has the first ID and is registered.
@@ -155,7 +154,7 @@ func (s *ControllerSuite) TestAddApplication(c *gc.C) {
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mod.Report()["application-count"], gc.Equals, 1)
+	c.Check(mod.Report()["applications"], gc.HasLen, 1)
 
 	app, err := mod.Application(appChange.Name)
 	c.Assert(err, jc.ErrorIsNil)
@@ -180,7 +179,7 @@ func (s *ControllerSuite) TestRemoveApplication(c *gc.C) {
 	s.ProcessChange(c, remove, events)
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mod.Report()["application-count"], gc.Equals, 0)
+	c.Check(mod.Report()["applications"], gc.HasLen, 0)
 	s.AssertResident(c, app.CacheId(), false)
 }
 
@@ -190,7 +189,7 @@ func (s *ControllerSuite) TestAddCharm(c *gc.C) {
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mod.Report()["charm-count"], gc.Equals, 1)
+	c.Check(mod.Report()["charms"], gc.HasLen, 1)
 
 	ch, err := mod.Charm(charmChange.CharmURL)
 	c.Assert(err, jc.ErrorIsNil)
@@ -213,7 +212,7 @@ func (s *ControllerSuite) TestRemoveCharm(c *gc.C) {
 	}
 	s.ProcessChange(c, remove, events)
 
-	c.Check(mod.Report()["charm-count"], gc.Equals, 0)
+	c.Check(mod.Report()["charms"], gc.HasLen, 0)
 	s.AssertResident(c, ch.CacheId(), false)
 }
 
@@ -223,7 +222,7 @@ func (s *ControllerSuite) TestAddMachine(c *gc.C) {
 
 	mod, err := controller.Model(machineChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mod.Report()["machine-count"], gc.Equals, 1)
+	c.Check(mod.Report()["machines"], gc.HasLen, 1)
 
 	machine, err := mod.Machine(machineChange.Id)
 	c.Assert(err, jc.ErrorIsNil)
@@ -246,7 +245,7 @@ func (s *ControllerSuite) TestRemoveMachine(c *gc.C) {
 	}
 	s.ProcessChange(c, remove, events)
 
-	c.Check(mod.Report()["machine-count"], gc.Equals, 0)
+	c.Check(mod.Report()["machines"], gc.HasLen, 0)
 	s.AssertResident(c, machine.CacheId(), false)
 }
 
@@ -256,7 +255,7 @@ func (s *ControllerSuite) TestAddUnit(c *gc.C) {
 
 	mod, err := controller.Model(modelChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mod.Report()["unit-count"], gc.Equals, 1)
+	c.Check(mod.Report()["units"], gc.HasLen, 1)
 
 	unit, err := mod.Unit(unitChange.Name)
 	c.Assert(err, jc.ErrorIsNil)
@@ -278,7 +277,7 @@ func (s *ControllerSuite) TestRemoveUnit(c *gc.C) {
 	}
 	s.ProcessChange(c, remove, events)
 
-	c.Check(mod.Report()["unit-count"], gc.Equals, 0)
+	c.Check(mod.Report()["units"], gc.HasLen, 0)
 	s.AssertResident(c, unit.CacheId(), false)
 }
 
@@ -288,7 +287,7 @@ func (s *ControllerSuite) TestAddRelation(c *gc.C) {
 
 	mod, err := controller.Model(relationChange.ModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(mod.Report()["relation-count"], gc.Equals, 1)
+	c.Check(mod.Report()["relations"], gc.HasLen, 1)
 
 	relation, err := mod.Relation(relationChange.Key)
 	c.Assert(err, jc.ErrorIsNil)
@@ -310,7 +309,7 @@ func (s *ControllerSuite) TestRemoveRelation(c *gc.C) {
 	}
 	s.ProcessChange(c, remove, events)
 
-	c.Check(mod.Report()["relation-count"], gc.Equals, 0)
+	c.Check(mod.Report()["relations"], gc.HasLen, 0)
 	s.AssertResident(c, relation.CacheId(), false)
 }
 
@@ -342,7 +341,7 @@ func (s *ControllerSuite) TestRemoveBranch(c *gc.C) {
 	}
 	s.ProcessChange(c, remove, events)
 
-	c.Check(mod.Report()["unit-count"], gc.Equals, 0)
+	c.Check(mod.Report()["units"], gc.HasLen, 0)
 	s.AssertResident(c, branch.CacheId(), false)
 }
 

--- a/core/cache/machine.go
+++ b/core/cache/machine.go
@@ -37,6 +37,26 @@ type Machine struct {
 	configHash string
 }
 
+// Report returns information that is used in the dependency engine report.
+func (m *Machine) Report() map[string]interface{} {
+	details := m.details
+
+	addresses := make([]string, len(details.Addresses))
+	for k, address := range details.Addresses {
+		addresses[k] = address.String()
+	}
+
+	return map[string]interface{}{
+		"instance-id":        details.InstanceId,
+		"config":             details.Config,
+		"series":             details.Series,
+		"is-manual":          details.IsManual,
+		"hw-characteristics": details.HardwareCharacteristics,
+		"charm-profiles":     details.CharmProfiles,
+		"addresses":          addresses,
+	}
+}
+
 // Note that these property accessors are not lock-protected.
 // They are intended for calling from external packages that have retrieved a
 // deep copy from the cache.

--- a/core/cache/model.go
+++ b/core/cache/model.go
@@ -165,15 +165,40 @@ func (m *Model) WatchConfig(keys ...string) *ConfigWatcher {
 func (m *Model) Report() map[string]interface{} {
 	defer m.doLocked()()
 
+	applications := make(map[string]interface{}, len(m.applications))
+	for name, app := range m.applications {
+		applications[name] = app.Report()
+	}
+
+	charms := make(map[string]interface{}, len(m.charms))
+	for name, charm := range m.charms {
+		charms[name] = charm.Report()
+	}
+
+	machines := make(map[string]interface{}, len(m.machines))
+	for id, machine := range m.machines {
+		machines[id] = machine.Report()
+	}
+
+	units := make(map[string]interface{}, len(m.units))
+	for name, unit := range m.units {
+		units[name] = unit.Report()
+	}
+
+	relations := make(map[string]interface{}, len(m.relations))
+	for id, relation := range m.relations {
+		relations[id] = relation.Report()
+	}
+
 	return map[string]interface{}{
-		"name":              m.details.Owner + "/" + m.details.Name,
-		"life":              m.details.Life,
-		"application-count": len(m.applications),
-		"charm-count":       len(m.charms),
-		"machine-count":     len(m.machines),
-		"unit-count":        len(m.units),
-		"relation-count":    len(m.relations),
-		"branch-count":      len(m.branches),
+		"name":         m.details.Owner + "/" + m.details.Name,
+		"life":         string(m.details.Life),
+		"applications": applications,
+		"charms":       charms,
+		"machines":     machines,
+		"units":        units,
+		"relations":    relations,
+		"branch-count": len(m.branches),
 	}
 }
 

--- a/core/cache/model_test.go
+++ b/core/cache/model_test.go
@@ -28,17 +28,57 @@ type ModelSuite struct {
 
 var _ = gc.Suite(&ModelSuite{})
 
-func (s *ModelSuite) TestReport(c *gc.C) {
+func (s *ModelSuite) TestEmptyReport(c *gc.C) {
 	m := s.NewModel(modelChange)
 	c.Assert(m.Report(), jc.DeepEquals, map[string]interface{}{
-		"name":              "model-owner/test-model",
-		"life":              life.Value("alive"),
-		"application-count": 0,
-		"charm-count":       0,
-		"machine-count":     0,
-		"unit-count":        0,
-		"relation-count":    0,
-		"branch-count":      0,
+		"name":         "model-owner/test-model",
+		"life":         "alive",
+		"applications": make(map[string]interface{}),
+		"charms":       make(map[string]interface{}),
+		"machines":     make(map[string]interface{}),
+		"units":        make(map[string]interface{}),
+		"relations":    make(map[string]interface{}),
+		"branch-count": 0,
+	})
+}
+
+func (s *ModelSuite) TestReport(c *gc.C) {
+	m := s.NewModel(modelChange)
+	m.UpdateCharm(charmChange, s.Manager)
+	m.UpdateApplication(appChange, s.Manager)
+	m.UpdateUnit(unitChange, s.Manager)
+
+	c.Assert(m.Report(), jc.DeepEquals, map[string]interface{}{
+		"name": "model-owner/test-model",
+		"life": "alive",
+		"applications": map[string]interface{}{
+			"application-name": map[string]interface{}{
+				"charm-url": "www.charm-url.com-1",
+				"config": map[string]interface{}{
+					"another": "foo", "key": "value",
+				},
+				"constraints":      "",
+				"exposed":          false,
+				"min-units":        0,
+				"subordinate":      false,
+				"workload-version": "666"},
+		},
+		"charms": map[string]interface{}{
+			"www.charm-url.com-1": map[string]interface{}{},
+		},
+		"machines": map[string]interface{}{},
+		"units": map[string]interface{}{
+			"application-name/0": map[string]interface{}{
+				"charm-url":       "www.charm-url.com-1",
+				"name":            "application-name/0",
+				"private-address": "",
+				"public-address":  "",
+				"series":          "bionic",
+				"subordinate":     false,
+			},
+		},
+		"relations":    map[string]interface{}{},
+		"branch-count": 0,
 	})
 }
 

--- a/core/cache/relation.go
+++ b/core/cache/relation.go
@@ -3,6 +3,8 @@
 
 package cache
 
+import "fmt"
+
 // Relation represents a relation in a cached model.
 type Relation struct {
 	// Resident identifies the relation as a type-agnostic cached entity
@@ -17,6 +19,21 @@ func newRelation(model *Model, res *Resident) *Relation {
 	return &Relation{
 		Resident: res,
 		model:    model,
+	}
+}
+
+// Report returns information that is used in the dependency engine report.
+func (r *Relation) Report() map[string]interface{} {
+	details := r.details
+
+	endpoints := make([]string, len(details.Endpoints))
+	for k, ep := range details.Endpoints {
+		endpoints[k] = fmt.Sprintf("%s:%s", ep.Application, ep.Name)
+	}
+
+	return map[string]interface{}{
+		"key":       details.Key,
+		"endpoints": endpoints,
 	}
 }
 

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -34,6 +34,19 @@ func newUnit(model *Model, res *Resident) *Unit {
 	}
 }
 
+// Report returns information that is used in the dependency engine report.
+func (u *Unit) Report() map[string]interface{} {
+	details := u.details
+	return map[string]interface{}{
+		"name":            details.Name,
+		"series":          details.Series,
+		"charm-url":       details.CharmURL,
+		"public-address":  details.PublicAddress,
+		"private-address": details.PrivateAddress,
+		"subordinate":     details.Subordinate,
+	}
+}
+
 // Note that these property accessors are not lock-protected.
 // They are intended for calling from external packages that have retrieved a
 // deep copy from the cache.


### PR DESCRIPTION
The following improves the reporting for the model cache. Currently,
it's not possible to know what the current state of the model cache is
for a given controller.

In an ideal world, we would have an API to dump the model cache, except
that falls down for HA environments. The correct way would be to query
every controller in the fleet to report back their current information.
That's a bit of work and something that can be done in the future, but
for now, we can piggyback off the juju_engine_report to dump out more
information.

We don't dump all the information, just enough to help diagnose
potential problems within the eventual consistent cache.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju enable-ha
$ juju deploy ubuntu
$ juju deploy nrpe
$ juju add-relation ubuntu nrpe
```

```sh
$ juju ssh -m controller <MACHINE ID>
$ juju_engine_report
```

## Bug reference

Note: this doesn't fix the following bug, but it does help try and diagnose the failure
in the future.

https://bugs.launchpad.net/juju/+bug/1957942