### PR TITLE
[JUJU-467] Fix race in nested deployer report test

### DIFF
--- a/worker/deployer/nested_test.go
+++ b/worker/deployer/nested_test.go
@@ -366,8 +366,12 @@ func (s *NestedContextSuite) deployThreeUnits(c *gc.C, ctx deployer.Context) {
 	for {
 		units := report["units"].(map[string]interface{})
 		workers := units["workers"].(map[string]interface{})
+
+		first := workers["first/0"].(map[string]interface{})
+		second := workers["second/0"].(map[string]interface{})
 		third := workers["third/0"].(map[string]interface{})
-		if third["state"] == "started" {
+
+		if first["state"] == "started" && second["state"] == "started" && third["state"] == "started" {
 			break
 		}
 		select {


### PR DESCRIPTION
The engine report test for the nested deployer worker only waits until the last of the (semantically) started workers is up.

This does not guarantee that they are all up, and the test can fail, as observed in our arm64 unit test job.

Waiting for all of the workers fixes it.

## QA steps

`NestedContextSuite.TestReport` passes under stress conditions.

## Documentation changes

None.

## Bug reference

N/A
