### PR TITLE
[JUJU-478] Retry ping before failing

### DIFF
--- a/state/pool.go
+++ b/state/pool.go
@@ -424,7 +424,8 @@ func (p *StatePool) Close() error {
 		p.txnWatcherSession.Close()
 	}
 	p.mu.Unlock()
-	// As with above and the other watchers. Unlock while releas
+	// As with above and the other watchers, unlock while releasing the state
+	// session.
 	if err := p.systemState.Close(); err != nil {
 		lastErr = err
 	}

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"sync"
 	"time"
 
 	"github.com/juju/errors"
@@ -12,11 +11,9 @@ import (
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 	"github.com/juju/worker/v3/dependency"
-	"gopkg.in/tomb.v2"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/wrench"
 )
 
 var logger = loggo.GetLogger("juju.worker.state")
@@ -130,178 +127,4 @@ func outputFunc(in worker.Worker, out interface{}) error {
 		return errors.Errorf("out should be *StateTracker; got %T", out)
 	}
 	return nil
-}
-
-type stateWorker struct {
-	catacomb     catacomb.Catacomb
-	stTracker    StateTracker
-	pingInterval time.Duration
-	setStatePool func(*state.StatePool)
-	cleanupOnce  sync.Once
-}
-
-func (w *stateWorker) loop() error {
-	pool, err := w.stTracker.Use()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer func() { _ = w.stTracker.Done() }()
-
-	systemState := pool.SystemState()
-
-	w.setStatePool(pool)
-	defer w.setStatePool(nil)
-
-	modelWatcher := systemState.WatchModelLives()
-	_ = w.catacomb.Add(modelWatcher)
-
-	wrenchTimer := time.NewTimer(30 * time.Second)
-	defer wrenchTimer.Stop()
-
-	modelStateWorkers := make(map[string]worker.Worker)
-	for {
-		select {
-		case <-w.catacomb.Dying():
-			return w.catacomb.ErrDying()
-
-		case modelUUIDs := <-modelWatcher.Changes():
-			for _, modelUUID := range modelUUIDs {
-				if err := w.processModelLifeChange(
-					modelUUID,
-					modelStateWorkers,
-					pool,
-				); err != nil {
-					return errors.Trace(err)
-				}
-			}
-		// Useful for tracking down some bugs that occur when
-		// mongo is overloaded.
-		case <-wrenchTimer.C:
-			if wrench.IsActive("state-worker", "io-timeout") {
-				return errors.Errorf("wrench simulating i/o timeout!")
-			}
-			wrenchTimer.Reset(30 * time.Second)
-		}
-	}
-}
-
-// Report conforms to the Dependency Engine Report() interface, giving an opportunity to introspect
-// what is going on at runtime.
-func (w *stateWorker) Report() map[string]interface{} {
-	return w.stTracker.Report()
-}
-
-func (w *stateWorker) processModelLifeChange(
-	modelUUID string,
-	modelStateWorkers map[string]worker.Worker,
-	pool *state.StatePool,
-) error {
-	remove := func() {
-		if w, ok := modelStateWorkers[modelUUID]; ok {
-			w.Kill()
-			delete(modelStateWorkers, modelUUID)
-		}
-		_, _ = pool.Remove(modelUUID)
-	}
-
-	model, hp, err := pool.GetModel(modelUUID)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// Model has been removed from state.
-			logger.Debugf("model %q removed from state", modelUUID)
-			remove()
-			return nil
-		}
-		return errors.Trace(err)
-	}
-	defer hp.Release()
-
-	if model.Life() == state.Dead {
-		// Model is Dead, and will soon be removed from state.
-		logger.Debugf("model %q is dead", modelUUID)
-		remove()
-		return nil
-	}
-
-	if modelStateWorkers[modelUUID] == nil {
-		mw := newModelStateWorker(pool, modelUUID, w.pingInterval)
-		modelStateWorkers[modelUUID] = mw
-		_ = w.catacomb.Add(mw)
-	}
-
-	return nil
-}
-
-// Kill is part of the worker.Worker interface.
-func (w *stateWorker) Kill() {
-	w.catacomb.Kill(nil)
-}
-
-// Wait is part of the worker.Worker interface.
-func (w *stateWorker) Wait() error {
-	err := w.catacomb.Wait()
-	w.cleanupOnce.Do(func() {
-		// Make sure the worker has exited before closing state.
-		if err := w.stTracker.Done(); err != nil {
-			logger.Warningf("error releasing state: %v", err)
-		}
-	})
-	return err
-}
-
-type modelStateWorker struct {
-	tomb         tomb.Tomb
-	pool         *state.StatePool
-	modelUUID    string
-	pingInterval time.Duration
-}
-
-func newModelStateWorker(
-	pool *state.StatePool,
-	modelUUID string,
-	pingInterval time.Duration,
-) worker.Worker {
-	w := &modelStateWorker{
-		pool:         pool,
-		modelUUID:    modelUUID,
-		pingInterval: pingInterval,
-	}
-	w.tomb.Go(w.loop)
-	return w
-}
-
-func (w *modelStateWorker) loop() error {
-	st, err := w.pool.Get(w.modelUUID)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// ignore not found error here, because the pooledState has already been removed.
-			return nil
-		}
-		return errors.Trace(err)
-	}
-	defer func() {
-		st.Release()
-		_, _ = w.pool.Remove(w.modelUUID)
-	}()
-
-	for {
-		select {
-		case <-w.tomb.Dying():
-			return tomb.ErrDying
-		case <-time.After(w.pingInterval):
-			if err := st.Ping(); err != nil {
-				return errors.Annotate(err, "state ping failed")
-			}
-		}
-	}
-}
-
-// Kill is part of the worker.Worker interface.
-func (w *modelStateWorker) Kill() {
-	w.tomb.Kill(nil)
-}
-
-// Wait is part of the worker.Worker interface.
-func (w *modelStateWorker) Wait() error {
-	return w.tomb.Wait()
 }


### PR DESCRIPTION
This PR is for discussion and not a final PR.

The following attempts to retry a ping before failing. This should
improve the transient errors we can get if a ping on a session fails.
Failure of a ping causes a restart of the API server. The interesting
part is that we know the session to mongo is ok, as mongo cursor
iterators will fail immediately in `.Next()` calls and the `.Close()` will
return the error. The latter should cause the apiserver to restart.

The latter case can be replicated easily by putting juju into HA mode
and then calling rs.stepDown(10) from the mongo shell. At no point will
the `.Ping()` fail, instead other session requests will fail.

Additionally, a modelStateWorker is only required on a controller NOT
for every model. The mongo is the same mongo for the whole controller,
so the worker is doing busy work for no reason.

## QA steps

```
$ juju bootstrap lxd test
$ juju enable-ha
$ juju deploy ubuntu 
$ juju deploy mongodb
```

It expects a [juju_mongo](https://discourse.charmhub.io/t/login-into-mongodb/309) on the `$PATH`.

```
$ juju mongo
$ rs.stepDown(10)
```