### PR TITLE
[JUJU-463] Implement NetworkInterfaces method for azure provider

### DIFF
--- a/apiserver/common/networkingcommon/types_test.go
+++ b/apiserver/common/networkingcommon/types_test.go
@@ -442,7 +442,6 @@ func (s *TypesSuite) TestAddressMatchingFromObservedConfig(c *gc.C) {
 		DeviceName:       "br-eno3-8",
 		ConfigMethod:     "static",
 		CIDRAddress:      "10.1.16.3/23",
-		DNSServers:       []string{},
 		IsDefaultGateway: false,
 		Origin:           network.OriginMachine,
 	}})

--- a/apiserver/params/network.go
+++ b/apiserver/params/network.go
@@ -222,18 +222,22 @@ func NetworkConfigFromInterfaceInfo(interfaceInfos network.InterfaceInfos) []Net
 		for _, nameserver := range v.DNSServers {
 			dnsServers = append(dnsServers, nameserver.Value)
 		}
-		routes := make([]NetworkRoute, len(v.Routes))
-		for j, route := range v.Routes {
-			routes[j] = NetworkRoute{
-				DestinationCIDR: route.DestinationCIDR,
-				GatewayIP:       route.GatewayIP,
-				Metric:          route.Metric,
+
+		var routes []NetworkRoute
+		if len(v.Routes) != 0 {
+			routes = make([]NetworkRoute, len(v.Routes))
+			for j, route := range v.Routes {
+				routes[j] = NetworkRoute{
+					DestinationCIDR: route.DestinationCIDR,
+					GatewayIP:       route.GatewayIP,
+					Metric:          route.Metric,
+				}
 			}
 		}
 
 		result[i] = NetworkConfig{
 			DeviceIndex:         v.DeviceIndex,
-			MACAddress:          v.MACAddress,
+			MACAddress:          network.NormalizeMACAddress(v.MACAddress),
 			ConfigType:          string(v.ConfigType),
 			MTU:                 v.MTU,
 			ProviderId:          string(v.ProviderId),
@@ -272,12 +276,15 @@ func NetworkConfigFromInterfaceInfo(interfaceInfos network.InterfaceInfos) []Net
 func InterfaceInfoFromNetworkConfig(configs []NetworkConfig) network.InterfaceInfos {
 	result := make(network.InterfaceInfos, len(configs))
 	for i, v := range configs {
-		routes := make([]network.Route, len(v.Routes))
-		for j, route := range v.Routes {
-			routes[j] = network.Route{
-				DestinationCIDR: route.DestinationCIDR,
-				GatewayIP:       route.GatewayIP,
-				Metric:          route.Metric,
+		var routes []network.Route
+		if len(v.Routes) != 0 {
+			routes = make([]network.Route, len(v.Routes))
+			for j, route := range v.Routes {
+				routes[j] = network.Route{
+					DestinationCIDR: route.DestinationCIDR,
+					GatewayIP:       route.GatewayIP,
+					Metric:          route.Metric,
+				}
 			}
 		}
 
@@ -285,7 +292,7 @@ func InterfaceInfoFromNetworkConfig(configs []NetworkConfig) network.InterfaceIn
 
 		result[i] = network.InterfaceInfo{
 			DeviceIndex:         v.DeviceIndex,
-			MACAddress:          v.MACAddress,
+			MACAddress:          network.NormalizeMACAddress(v.MACAddress),
 			MTU:                 v.MTU,
 			ProviderId:          network.Id(v.ProviderId),
 			ProviderNetworkId:   network.Id(v.ProviderNetworkId),
@@ -497,6 +504,10 @@ func (addr Address) ProviderAddress() network.ProviderAddress {
 // ToProviderAddresses transforms multiple Addresses into a
 // ProviderAddresses collection.
 func ToProviderAddresses(addrs ...Address) network.ProviderAddresses {
+	if len(addrs) == 0 {
+		return nil
+	}
+
 	pAddrs := make([]network.ProviderAddress, len(addrs))
 	for i, addr := range addrs {
 		pAddrs[i] = addr.ProviderAddress()
@@ -507,6 +518,10 @@ func ToProviderAddresses(addrs ...Address) network.ProviderAddresses {
 // FromProviderAddresses transforms multiple ProviderAddresses
 // into a slice of Address.
 func FromProviderAddresses(pAddrs ...network.ProviderAddress) []Address {
+	if len(pAddrs) == 0 {
+		return nil
+	}
+
 	addrs := make([]Address, len(pAddrs))
 	for i, pAddr := range pAddrs {
 		addrs[i] = FromProviderAddress(pAddr)

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -325,6 +325,10 @@ type MachineAddresses []MachineAddress
 // AsProviderAddresses is used to construct ProviderAddresses
 // element-wise from MachineAddresses
 func (as MachineAddresses) AsProviderAddresses(options ...func(mutator ProviderAddressMutator)) ProviderAddresses {
+	if len(as) == 0 {
+		return nil
+	}
+
 	addrs := make(ProviderAddresses, len(as))
 	for i, addr := range as {
 		addrs[i] = addr.AsProviderAddress(options...)
@@ -336,6 +340,10 @@ func (as MachineAddresses) AsProviderAddresses(options ...func(mutator ProviderA
 // from a variable number of string arguments, applying any supplied
 // options to each address
 func NewMachineAddresses(values []string, options ...func(AddressMutator)) MachineAddresses {
+	if len(values) == 0 {
+		return nil
+	}
+
 	addrs := make(MachineAddresses, len(values))
 	for i, value := range values {
 		addrs[i] = NewMachineAddress(value, options...)

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -6,6 +6,7 @@ package network
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/juju/errors"
 )
@@ -307,4 +308,12 @@ type ProviderInterfaceInfo struct {
 	// contents of this field depend on the NIC type (a MAC address for an
 	// ethernet device, a GUID for an infiniband device etc.)
 	HardwareAddress string
+}
+
+// NormalizeMACAddress replaces dashes with colons and lowercases the MAC
+// address provided as input.
+func NormalizeMACAddress(mac string) string {
+	return strings.ToLower(
+		strings.Replace(mac, "-", ":", -1),
+	)
 }

--- a/core/network/nic_test.go
+++ b/core/network/nic_test.go
@@ -135,6 +135,36 @@ func (s *nicSuite) TestInterfaceInfosGetByName(c *gc.C) {
 	c.Assert(devs, gc.HasLen, 1)
 }
 
+func (s *nicSuite) TestNormalizeMACAddress(c *gc.C) {
+	specs := []struct {
+		descr string
+		in    string
+		exp   string
+	}{
+		{
+			descr: "uppercased MAC",
+			in:    "AA:BB:CC:DD:EE:FF",
+			exp:   "aa:bb:cc:dd:ee:ff",
+		},
+		{
+			descr: "MAC with dashes instead of colons",
+			in:    "AA-BB-CC-DD-EE-FF",
+			exp:   "aa:bb:cc:dd:ee:ff",
+		},
+		{
+			descr: "already normalized MAC",
+			in:    "aa:bb:cc:dd:ee:ff",
+			exp:   "aa:bb:cc:dd:ee:ff",
+		},
+	}
+
+	for i, spec := range specs {
+		c.Logf("%d. %s", i, spec.descr)
+		got := network.NormalizeMACAddress(spec.in)
+		c.Assert(got, gc.Equals, spec.exp)
+	}
+}
+
 func getInterFaceInfos() network.InterfaceInfos {
 	return network.InterfaceInfos{
 		{

--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -217,8 +217,7 @@ func mapAzureInterfaceList(in []azurenetwork.Interface, subnetIDToCIDR map[strin
 			// NOTE(achilleasa): azure does not seem to include
 			// shadow IPs (or any public IP for that matter) when
 			// querying network interfaces. If we do encounter a
-			// public IP make sure we include it both as an address
-			// and as a shadow IP.
+			// public IP make sure we include it as a shadow IP.
 			if ipConf.PublicIPAddress != nil && ipConf.PublicIPAddress.PublicIPAddressPropertiesFormat != nil && ipConf.PublicIPAddress.IPAddress != nil {
 				var cfgMethod = network.ConfigDHCP
 				if ipConf.PublicIPAddress.PublicIPAllocationMethod == azurenetwork.Static {
@@ -232,14 +231,12 @@ func mapAzureInterfaceList(in []azurenetwork.Interface, subnetIDToCIDR map[strin
 				).AsProviderAddress()
 
 				// If this a primary address make sure it appears
-				// at the top of the address lists.
+				// at the top of the shadow address list.
 				if isPrimary {
 					ni.ShadowAddresses = append(network.ProviderAddresses{providerAddr}, ni.ShadowAddresses...)
-					ni.Addresses = append(network.ProviderAddresses{providerAddr}, ni.Addresses...)
 					ni.ConfigType = cfgMethod
 				} else {
 					ni.ShadowAddresses = append(ni.ShadowAddresses, providerAddr)
-					ni.Addresses = append(ni.Addresses, providerAddr)
 				}
 			}
 

--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -133,11 +133,163 @@ func (*azureEnviron) SSHAddresses(
 	return addresses, nil
 }
 
-// NetworkInterfaces implements environs.NetworkingEnviron.
-func (env *azureEnviron) NetworkInterfaces(
-	context.ProviderCallContext, []instance.Id,
-) ([]network.InterfaceInfos, error) {
-	return nil, errors.NotSupportedf("network interfaces")
+// NetworkInterfaces implements environs.NetworkingEnviron. It returns back
+// a slice where the i_th element contains the list of network interfaces
+// for the i_th provided instance ID.
+//
+// If none of the provided instance IDs exist, ErrNoInstances will be returned.
+// If only a subset of the instance IDs exist, the result will contain a nil
+// value for the missing instances and a ErrPartialInstances error will be
+// returned.
+func (env *azureEnviron) NetworkInterfaces(ctx context.ProviderCallContext, instanceIDs []instance.Id) ([]network.InterfaceInfos, error) {
+	// Create a subnet (provider) ID to CIDR map so we can identify the
+	// subnet for each NIC address when mapping azure NIC details.
+	allSubnets, err := env.allSubnets(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	subnetIDToCIDR := make(map[string]string)
+	for _, sub := range allSubnets {
+		subnetIDToCIDR[sub.ProviderId.String()] = sub.CIDR
+	}
+
+	nicClient := azurenetwork.InterfacesClient{BaseClient: env.network}
+	instIfaceMap, err := instanceNetworkInterfaces(ctx, env.resourceGroup, nicClient)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var (
+		res        = make([]network.InterfaceInfos, len(instanceIDs))
+		matchCount int
+	)
+
+	for resIdx, instID := range instanceIDs {
+		azInterfaceList, found := instIfaceMap[instID]
+		if !found {
+			continue
+		}
+
+		matchCount++
+		res[resIdx] = mapAzureInterfaceList(azInterfaceList, subnetIDToCIDR)
+	}
+
+	if matchCount == 0 {
+		return nil, environs.ErrNoInstances
+	} else if matchCount < len(instanceIDs) {
+		return res, environs.ErrPartialInstances
+	}
+
+	return res, nil
+}
+
+func mapAzureInterfaceList(in []azurenetwork.Interface, subnetIDToCIDR map[string]string) network.InterfaceInfos {
+	var out = make(network.InterfaceInfos, len(in))
+
+	for idx, azif := range in {
+		ni := network.InterfaceInfo{
+			DeviceIndex:   idx,
+			Disabled:      false,
+			NoAutoStart:   false,
+			InterfaceType: network.EthernetDevice,
+			Origin:        network.OriginProvider,
+		}
+
+		if azif.MacAddress != nil {
+			ni.MACAddress = network.NormalizeMACAddress(*azif.MacAddress)
+		}
+		if azif.ID != nil {
+			ni.ProviderId = network.Id(*azif.ID)
+		}
+
+		if azif.InterfacePropertiesFormat == nil || azif.IPConfigurations == nil {
+			out[idx] = ni
+			continue
+		}
+
+		for _, ipConf := range *azif.IPConfigurations {
+			if ipConf.InterfaceIPConfigurationPropertiesFormat == nil {
+				continue
+			}
+
+			isPrimary := ipConf.Primary != nil && *ipConf.Primary
+
+			// NOTE(achilleasa): azure does not seem to include
+			// shadow IPs (or any public IP for that matter) when
+			// querying network interfaces. If we do encounter a
+			// public IP make sure we include it both as an address
+			// and as a shadow IP.
+			if ipConf.PublicIPAddress != nil && ipConf.PublicIPAddress.PublicIPAddressPropertiesFormat != nil && ipConf.PublicIPAddress.IPAddress != nil {
+				var cfgMethod = network.ConfigDHCP
+				if ipConf.PublicIPAddress.PublicIPAllocationMethod == azurenetwork.Static {
+					cfgMethod = network.ConfigStatic
+				}
+
+				providerAddr := network.NewMachineAddress(
+					*ipConf.PublicIPAddress.IPAddress,
+					network.WithScope(network.ScopePublic),
+					network.WithConfigType(cfgMethod),
+				).AsProviderAddress()
+
+				// If this a primary address make sure it appears
+				// at the top of the address lists.
+				if isPrimary {
+					ni.ShadowAddresses = append(network.ProviderAddresses{providerAddr}, ni.ShadowAddresses...)
+					ni.Addresses = append(network.ProviderAddresses{providerAddr}, ni.Addresses...)
+					ni.ConfigType = cfgMethod
+				} else {
+					ni.ShadowAddresses = append(ni.ShadowAddresses, providerAddr)
+					ni.Addresses = append(ni.Addresses, providerAddr)
+				}
+			}
+
+			// Check if the configuration also includes a private address component.
+			if ipConf.PrivateIPAddress == nil {
+				continue
+			}
+
+			var cfgMethod = network.ConfigDHCP
+			if ipConf.PrivateIPAllocationMethod == azurenetwork.Static {
+				cfgMethod = network.ConfigStatic
+			}
+
+			addrOpts := []func(network.AddressMutator){
+				network.WithScope(network.ScopeCloudLocal),
+				network.WithConfigType(cfgMethod),
+			}
+
+			var subnetID string
+			if ipConf.Subnet != nil && ipConf.Subnet.ID != nil {
+				subnetID = *ipConf.Subnet.ID
+				if subnetCIDR := subnetIDToCIDR[subnetID]; subnetCIDR != "" {
+					addrOpts = append(addrOpts, network.WithCIDR(subnetCIDR))
+				}
+			}
+
+			providerAddr := network.NewMachineAddress(
+				*ipConf.PrivateIPAddress,
+				addrOpts...,
+			).AsProviderAddress()
+
+			// If this is the primary address ensure that it appears
+			// at the top of the address list.
+			if isPrimary {
+				ni.Addresses = append(network.ProviderAddresses{providerAddr}, ni.Addresses...)
+			} else {
+				ni.Addresses = append(ni.Addresses, providerAddr)
+			}
+
+			// Record the subnetID and config mode to the NIC instance
+			if isPrimary && subnetID != "" {
+				ni.ProviderSubnetId = network.Id(subnetID)
+				ni.ConfigType = cfgMethod
+			}
+		}
+
+		out[idx] = ni
+	}
+
+	return out
 }
 
 // defaultControllerSubnet returns the subnet to use for starting a controller

--- a/provider/azure/environ_network_test.go
+++ b/provider/azure/environ_network_test.go
@@ -186,13 +186,7 @@ func (s *environSuite) TestNetworkInterfacesSuccess(c *gc.C) {
 	c.Assert(nic1.InterfaceType, gc.Equals, corenetwork.EthernetDevice)
 	c.Assert(nic1.Origin, gc.Equals, corenetwork.OriginProvider)
 	c.Assert(nic1.MACAddress, gc.Equals, "ba:d0:c0:ff:ee:42")
-	c.Assert(nic1.Addresses, gc.DeepEquals, corenetwork.ProviderAddresses{
-		corenetwork.NewMachineAddress(
-			"1.2.3.4",
-			corenetwork.WithScope(corenetwork.ScopePublic),
-			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
-		).AsProviderAddress(),
-	})
+	c.Assert(nic1.Addresses, gc.HasLen, 0)
 	c.Assert(nic1.ShadowAddresses, gc.DeepEquals, corenetwork.ProviderAddresses{
 		corenetwork.NewMachineAddress(
 			"1.2.3.4",

--- a/provider/azure/environ_network_test.go
+++ b/provider/azure/environ_network_test.go
@@ -59,3 +59,184 @@ func (s *environSuite) TestSubnetsSuccess(c *gc.C) {
 	c.Check(subs[0].ProviderId, gc.Equals, corenetwork.Id("provider-sub-id"))
 	c.Check(subs[0].CIDR, gc.Equals, "10.0.0.0/24")
 }
+
+func (s *environSuite) TestNetworkInterfacesSuccess(c *gc.C) {
+	env := s.openEnviron(c)
+
+	// We wait for common resource creation, then query subnets
+	// in the default virtual network created for every model.
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", network.SubnetListResult{
+			Value: &[]network.Subnet{
+				{
+					ID: to.StringPtr("subnet-42"),
+					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+						AddressPrefix: to.StringPtr("10.0.0.0/24"),
+					},
+				},
+				{
+					ID: to.StringPtr("subnet-665"),
+					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+						AddressPrefix: to.StringPtr("172.0.0.0/24"),
+					},
+				},
+			},
+		}),
+		makeSender(".*/networkInterfaces", network.InterfaceListResult{
+			Value: &[]network.Interface{
+				{
+					ID: to.StringPtr("az-nic-0"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						Primary:    to.BoolPtr(true),
+						MacAddress: to.StringPtr("AA-BB-CC-DD-EE-FF"), // azure reports MACs in this format; they are normalized internally
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          to.StringPtr("10.0.0.42"),
+									PrivateIPAllocationMethod: network.Dynamic,
+									Subnet: &network.Subnet{
+										ID: to.StringPtr("subnet-42"), // should match one of values returned by the Subnets() call
+									},
+									Primary: to.BoolPtr(false),
+								},
+							},
+							{
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          to.StringPtr("172.0.0.99"),
+									PrivateIPAllocationMethod: network.Static,
+									Subnet: &network.Subnet{
+										ID: to.StringPtr("subnet-665"), // should match one of values returned by the Subnets() call
+									},
+									// This is the primary address for the NIC and should appear first in the mapped interface.
+									Primary: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+					Tags: map[string]*string{
+						"juju-machine-name": to.StringPtr("machine-0"),
+					},
+				},
+				// Azure (at least the SDK version that we are using) does not seem to report public addresses.
+				// This response is meant to exercise the pubic address parsing logic.
+				{
+					ID: to.StringPtr("az-nic-1"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						Primary:    to.BoolPtr(true),
+						MacAddress: to.StringPtr("BA-D0-C0-FF-EE-42"), // azure reports MACs in this format; they are normalized internally
+						IPConfigurations: &[]network.InterfaceIPConfiguration{
+							{
+								InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
+									Subnet: &network.Subnet{
+										ID: to.StringPtr("subnet-42"), // should match one of values returned by the Subnets() call
+									},
+									PublicIPAddress: &network.PublicIPAddress{
+										PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+											PublicIPAllocationMethod: network.Dynamic,
+											IPAddress:                to.StringPtr("1.2.3.4"),
+										},
+									},
+									Primary: to.BoolPtr(true),
+								},
+							},
+						},
+					},
+					Tags: map[string]*string{
+						"juju-machine-name": to.StringPtr("machine-0"),
+					},
+				},
+			},
+		}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, jc.IsTrue)
+
+	res, err := netEnv.NetworkInterfaces(s.callCtx, []instance.Id{"machine-0"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(res, gc.HasLen, 1)
+	c.Assert(res[0], gc.HasLen, 2, gc.Commentf("expected to get 2 NICs for machine-0"))
+
+	nic0 := res[0][0]
+	c.Assert(nic0.InterfaceType, gc.Equals, corenetwork.EthernetDevice)
+	c.Assert(nic0.Origin, gc.Equals, corenetwork.OriginProvider)
+	c.Assert(nic0.MACAddress, gc.Equals, "aa:bb:cc:dd:ee:ff")
+	c.Assert(nic0.Addresses, gc.DeepEquals, corenetwork.ProviderAddresses{
+		// The primary IP address for the NIC should appear first.
+		corenetwork.NewMachineAddress(
+			"172.0.0.99",
+			corenetwork.WithCIDR("172.0.0.0/24"),
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithConfigType(corenetwork.ConfigStatic),
+		).AsProviderAddress(),
+		corenetwork.NewMachineAddress(
+			"10.0.0.42",
+			corenetwork.WithCIDR("10.0.0.0/24"),
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
+		).AsProviderAddress(),
+	})
+	c.Assert(nic0.ProviderId, gc.Equals, corenetwork.Id("az-nic-0"))
+	c.Assert(nic0.ProviderSubnetId, gc.Equals, corenetwork.Id("subnet-665"), gc.Commentf("expected NIC to use the provider subnet ID for the primary NIC address"))
+	c.Assert(nic0.ConfigType, gc.Equals, corenetwork.ConfigStatic, gc.Commentf("expected NIC to use the config type for the primary NIC address"))
+
+	nic1 := res[0][1]
+	c.Assert(nic1.InterfaceType, gc.Equals, corenetwork.EthernetDevice)
+	c.Assert(nic1.Origin, gc.Equals, corenetwork.OriginProvider)
+	c.Assert(nic1.MACAddress, gc.Equals, "ba:d0:c0:ff:ee:42")
+	c.Assert(nic1.Addresses, gc.DeepEquals, corenetwork.ProviderAddresses{
+		corenetwork.NewMachineAddress(
+			"1.2.3.4",
+			corenetwork.WithScope(corenetwork.ScopePublic),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
+		).AsProviderAddress(),
+	})
+	c.Assert(nic1.ShadowAddresses, gc.DeepEquals, corenetwork.ProviderAddresses{
+		corenetwork.NewMachineAddress(
+			"1.2.3.4",
+			corenetwork.WithScope(corenetwork.ScopePublic),
+			corenetwork.WithConfigType(corenetwork.ConfigDHCP),
+		).AsProviderAddress(),
+	}, gc.Commentf("expected public address to be also included in the shadow addresses list"))
+	c.Assert(nic1.ProviderId, gc.Equals, corenetwork.Id("az-nic-1"))
+	c.Assert(nic1.ConfigType, gc.Equals, corenetwork.ConfigDHCP, gc.Commentf("expected NIC to use the config type for the primary NIC address"))
+}
+
+func (s *environSuite) TestNetworkInterfacesPartialMatch(c *gc.C) {
+	env := s.openEnviron(c)
+
+	// We wait for common resource creation, then query subnets
+	// in the default virtual network created for every model.
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", network.SubnetListResult{
+			Value: &[]network.Subnet{},
+		}),
+		makeSender(".*/networkInterfaces", network.InterfaceListResult{
+			Value: &[]network.Interface{
+				{
+					ID: to.StringPtr("az-nic-0"),
+					InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+						Primary:    to.BoolPtr(true),
+						MacAddress: to.StringPtr("AA-BB-CC-DD-EE-FF"), // azure reports MACs in this format; they are normalized internally
+					},
+					Tags: map[string]*string{
+						"juju-machine-name": to.StringPtr("machine-0"),
+					},
+				},
+			},
+		}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, jc.IsTrue)
+
+	res, err := netEnv.NetworkInterfaces(s.callCtx, []instance.Id{"machine-0", "bogus-0"})
+	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
+
+	c.Assert(res, gc.HasLen, 2)
+	c.Assert(res[0], gc.HasLen, 1, gc.Commentf("expected to get 1 NIC for machine-0"))
+	c.Assert(res[1], gc.IsNil, gc.Commentf("expected a nil slice for non-matched machines"))
+}


### PR DESCRIPTION
This PR implements the `NetworkInterfaces` call for the azure provider.

The implementation works in batch mode but as the azure SDK (at least the version that Juju is importing) does not support filtering, the provider pulls the NIC details for all devices in the current resource group and filters by instance ID on the client-side.

While the azure API response for listing NICs does include a field for enumerating **public IP** addresses, it always seems to be omitted from the response. I am not sure if this is a limitation of the particular SDK version (we are a few versions behind) we are using but the PR includes logic for parsing public addresses if they are available in the response. As a result, the azure provider is currently unable to detect shadow IP addresses/VIPs.

While working on this PR I realized that we are not normalizing MAC addresses before handling them (store, match against existing devices when merging configurations e.t.c.). Azure reports MAC addresses using an all-caps, hyphenated format. To address this, the `NormalizeMACAddress` method has been added to the `core/network` package and the params serialization logic for NetworkConfig (to/from network.NetworkInterface) has been updated to always normalize MAC addresses.

Once we implement the same call for the openstack provider we will finally be able to remove the fallback fake instance generation logic from the instancepoller worker.

## QA steps

Bootstrap on azure. Wait a few moments for the instancepoller to make its pass and check the logs to ensure that it correctly detects the private IP address for the controller (and other machines).