### PR TITLE
[JUJU-479] Revert "unit charm url"

### DIFF
--- a/api/uniter/unit.go
+++ b/api/uniter/unit.go
@@ -503,6 +503,9 @@ func (u *Unit) ClosePorts(protocol string, fromPort, toPort int) error {
 var ErrNoCharmURLSet = errors.New("unit has no charm url set")
 
 // CharmURL returns the charm URL this unit is currently using.
+//
+// NOTE: This differs from state.Unit.CharmURL() by returning
+// an error instead of a bool, because it needs to make an API call.
 func (u *Unit) CharmURL() (*charm.URL, error) {
 	var results params.StringBoolResults
 	args := params.Entities{

--- a/apiserver/facades/agent/uniter/mocks/lxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/lxdprofile.go
@@ -5,38 +5,37 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	uniter "github.com/juju/juju/apiserver/facades/agent/uniter"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
-// MockLXDProfileBackend is a mock of LXDProfileBackend interface.
+// MockLXDProfileBackend is a mock of LXDProfileBackend interface
 type MockLXDProfileBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileBackendMockRecorder
 }
 
-// MockLXDProfileBackendMockRecorder is the mock recorder for MockLXDProfileBackend.
+// MockLXDProfileBackendMockRecorder is the mock recorder for MockLXDProfileBackend
 type MockLXDProfileBackendMockRecorder struct {
 	mock *MockLXDProfileBackend
 }
 
-// NewMockLXDProfileBackend creates a new mock instance.
+// NewMockLXDProfileBackend creates a new mock instance
 func NewMockLXDProfileBackend(ctrl *gomock.Controller) *MockLXDProfileBackend {
 	mock := &MockLXDProfileBackend{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileBackendMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileBackend) EXPECT() *MockLXDProfileBackendMockRecorder {
 	return m.recorder
 }
 
-// Machine mocks base method.
+// Machine mocks base method
 func (m *MockLXDProfileBackend) Machine(arg0 string) (uniter.LXDProfileMachine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Machine", arg0)
@@ -45,13 +44,13 @@ func (m *MockLXDProfileBackend) Machine(arg0 string) (uniter.LXDProfileMachine, 
 	return ret0, ret1
 }
 
-// Machine indicates an expected call of Machine.
+// Machine indicates an expected call of Machine
 func (mr *MockLXDProfileBackendMockRecorder) Machine(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockLXDProfileBackend)(nil).Machine), arg0)
 }
 
-// Unit mocks base method.
+// Unit mocks base method
 func (m *MockLXDProfileBackend) Unit(arg0 string) (uniter.LXDProfileUnit, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unit", arg0)
@@ -60,36 +59,36 @@ func (m *MockLXDProfileBackend) Unit(arg0 string) (uniter.LXDProfileUnit, error)
 	return ret0, ret1
 }
 
-// Unit indicates an expected call of Unit.
+// Unit indicates an expected call of Unit
 func (mr *MockLXDProfileBackendMockRecorder) Unit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockLXDProfileBackend)(nil).Unit), arg0)
 }
 
-// MockLXDProfileMachine is a mock of LXDProfileMachine interface.
+// MockLXDProfileMachine is a mock of LXDProfileMachine interface
 type MockLXDProfileMachine struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileMachineMockRecorder
 }
 
-// MockLXDProfileMachineMockRecorder is the mock recorder for MockLXDProfileMachine.
+// MockLXDProfileMachineMockRecorder is the mock recorder for MockLXDProfileMachine
 type MockLXDProfileMachineMockRecorder struct {
 	mock *MockLXDProfileMachine
 }
 
-// NewMockLXDProfileMachine creates a new mock instance.
+// NewMockLXDProfileMachine creates a new mock instance
 func NewMockLXDProfileMachine(ctrl *gomock.Controller) *MockLXDProfileMachine {
 	mock := &MockLXDProfileMachine{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileMachineMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileMachine) EXPECT() *MockLXDProfileMachineMockRecorder {
 	return m.recorder
 }
 
-// WatchLXDProfileUpgradeNotifications mocks base method.
+// WatchLXDProfileUpgradeNotifications mocks base method
 func (m *MockLXDProfileMachine) WatchLXDProfileUpgradeNotifications(arg0 string) (state.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchLXDProfileUpgradeNotifications", arg0)
@@ -98,36 +97,36 @@ func (m *MockLXDProfileMachine) WatchLXDProfileUpgradeNotifications(arg0 string)
 	return ret0, ret1
 }
 
-// WatchLXDProfileUpgradeNotifications indicates an expected call of WatchLXDProfileUpgradeNotifications.
+// WatchLXDProfileUpgradeNotifications indicates an expected call of WatchLXDProfileUpgradeNotifications
 func (mr *MockLXDProfileMachineMockRecorder) WatchLXDProfileUpgradeNotifications(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileUpgradeNotifications", reflect.TypeOf((*MockLXDProfileMachine)(nil).WatchLXDProfileUpgradeNotifications), arg0)
 }
 
-// MockLXDProfileUnit is a mock of LXDProfileUnit interface.
+// MockLXDProfileUnit is a mock of LXDProfileUnit interface
 type MockLXDProfileUnit struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileUnitMockRecorder
 }
 
-// MockLXDProfileUnitMockRecorder is the mock recorder for MockLXDProfileUnit.
+// MockLXDProfileUnitMockRecorder is the mock recorder for MockLXDProfileUnit
 type MockLXDProfileUnitMockRecorder struct {
 	mock *MockLXDProfileUnit
 }
 
-// NewMockLXDProfileUnit creates a new mock instance.
+// NewMockLXDProfileUnit creates a new mock instance
 func NewMockLXDProfileUnit(ctrl *gomock.Controller) *MockLXDProfileUnit {
 	mock := &MockLXDProfileUnit{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileUnitMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileUnit) EXPECT() *MockLXDProfileUnitMockRecorder {
 	return m.recorder
 }
 
-// AssignedMachineId mocks base method.
+// AssignedMachineId mocks base method
 func (m *MockLXDProfileUnit) AssignedMachineId() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignedMachineId")
@@ -136,13 +135,13 @@ func (m *MockLXDProfileUnit) AssignedMachineId() (string, error) {
 	return ret0, ret1
 }
 
-// AssignedMachineId indicates an expected call of AssignedMachineId.
+// AssignedMachineId indicates an expected call of AssignedMachineId
 func (mr *MockLXDProfileUnitMockRecorder) AssignedMachineId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedMachineId", reflect.TypeOf((*MockLXDProfileUnit)(nil).AssignedMachineId))
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockLXDProfileUnit) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -150,13 +149,13 @@ func (m *MockLXDProfileUnit) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockLXDProfileUnitMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLXDProfileUnit)(nil).Name))
 }
 
-// Tag mocks base method.
+// Tag mocks base method
 func (m *MockLXDProfileUnit) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -164,13 +163,13 @@ func (m *MockLXDProfileUnit) Tag() names.Tag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag.
+// Tag indicates an expected call of Tag
 func (mr *MockLXDProfileUnitMockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockLXDProfileUnit)(nil).Tag))
 }
 
-// WatchLXDProfileUpgradeNotifications mocks base method.
+// WatchLXDProfileUpgradeNotifications mocks base method
 func (m *MockLXDProfileUnit) WatchLXDProfileUpgradeNotifications() (state.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchLXDProfileUpgradeNotifications")
@@ -179,7 +178,7 @@ func (m *MockLXDProfileUnit) WatchLXDProfileUpgradeNotifications() (state.String
 	return ret0, ret1
 }
 
-// WatchLXDProfileUpgradeNotifications indicates an expected call of WatchLXDProfileUpgradeNotifications.
+// WatchLXDProfileUpgradeNotifications indicates an expected call of WatchLXDProfileUpgradeNotifications
 func (mr *MockLXDProfileUnitMockRecorder) WatchLXDProfileUpgradeNotifications() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileUpgradeNotifications", reflect.TypeOf((*MockLXDProfileUnit)(nil).WatchLXDProfileUpgradeNotifications))

--- a/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v8"
 	uniter "github.com/juju/juju/apiserver/facades/agent/uniter"
@@ -15,32 +13,33 @@ import (
 	config "github.com/juju/juju/environs/config"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v4"
+	reflect "reflect"
 )
 
-// MockLXDProfileBackendV2 is a mock of LXDProfileBackendV2 interface.
+// MockLXDProfileBackendV2 is a mock of LXDProfileBackendV2 interface
 type MockLXDProfileBackendV2 struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileBackendV2MockRecorder
 }
 
-// MockLXDProfileBackendV2MockRecorder is the mock recorder for MockLXDProfileBackendV2.
+// MockLXDProfileBackendV2MockRecorder is the mock recorder for MockLXDProfileBackendV2
 type MockLXDProfileBackendV2MockRecorder struct {
 	mock *MockLXDProfileBackendV2
 }
 
-// NewMockLXDProfileBackendV2 creates a new mock instance.
+// NewMockLXDProfileBackendV2 creates a new mock instance
 func NewMockLXDProfileBackendV2(ctrl *gomock.Controller) *MockLXDProfileBackendV2 {
 	mock := &MockLXDProfileBackendV2{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileBackendV2MockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileBackendV2) EXPECT() *MockLXDProfileBackendV2MockRecorder {
 	return m.recorder
 }
 
-// Charm mocks base method.
+// Charm mocks base method
 func (m *MockLXDProfileBackendV2) Charm(arg0 *charm.URL) (uniter.LXDProfileCharmV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Charm", arg0)
@@ -49,13 +48,13 @@ func (m *MockLXDProfileBackendV2) Charm(arg0 *charm.URL) (uniter.LXDProfileCharm
 	return ret0, ret1
 }
 
-// Charm indicates an expected call of Charm.
+// Charm indicates an expected call of Charm
 func (mr *MockLXDProfileBackendV2MockRecorder) Charm(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockLXDProfileBackendV2)(nil).Charm), arg0)
 }
 
-// Machine mocks base method.
+// Machine mocks base method
 func (m *MockLXDProfileBackendV2) Machine(arg0 string) (uniter.LXDProfileMachineV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Machine", arg0)
@@ -64,13 +63,13 @@ func (m *MockLXDProfileBackendV2) Machine(arg0 string) (uniter.LXDProfileMachine
 	return ret0, ret1
 }
 
-// Machine indicates an expected call of Machine.
+// Machine indicates an expected call of Machine
 func (mr *MockLXDProfileBackendV2MockRecorder) Machine(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockLXDProfileBackendV2)(nil).Machine), arg0)
 }
 
-// Model mocks base method.
+// Model mocks base method
 func (m *MockLXDProfileBackendV2) Model() (uniter.LXDProfileModelV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model")
@@ -79,13 +78,13 @@ func (m *MockLXDProfileBackendV2) Model() (uniter.LXDProfileModelV2, error) {
 	return ret0, ret1
 }
 
-// Model indicates an expected call of Model.
+// Model indicates an expected call of Model
 func (mr *MockLXDProfileBackendV2MockRecorder) Model() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Model", reflect.TypeOf((*MockLXDProfileBackendV2)(nil).Model))
 }
 
-// Unit mocks base method.
+// Unit mocks base method
 func (m *MockLXDProfileBackendV2) Unit(arg0 string) (uniter.LXDProfileUnitV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unit", arg0)
@@ -94,36 +93,36 @@ func (m *MockLXDProfileBackendV2) Unit(arg0 string) (uniter.LXDProfileUnitV2, er
 	return ret0, ret1
 }
 
-// Unit indicates an expected call of Unit.
+// Unit indicates an expected call of Unit
 func (mr *MockLXDProfileBackendV2MockRecorder) Unit(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockLXDProfileBackendV2)(nil).Unit), arg0)
 }
 
-// MockLXDProfileMachineV2 is a mock of LXDProfileMachineV2 interface.
+// MockLXDProfileMachineV2 is a mock of LXDProfileMachineV2 interface
 type MockLXDProfileMachineV2 struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileMachineV2MockRecorder
 }
 
-// MockLXDProfileMachineV2MockRecorder is the mock recorder for MockLXDProfileMachineV2.
+// MockLXDProfileMachineV2MockRecorder is the mock recorder for MockLXDProfileMachineV2
 type MockLXDProfileMachineV2MockRecorder struct {
 	mock *MockLXDProfileMachineV2
 }
 
-// NewMockLXDProfileMachineV2 creates a new mock instance.
+// NewMockLXDProfileMachineV2 creates a new mock instance
 func NewMockLXDProfileMachineV2(ctrl *gomock.Controller) *MockLXDProfileMachineV2 {
 	mock := &MockLXDProfileMachineV2{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileMachineV2MockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileMachineV2) EXPECT() *MockLXDProfileMachineV2MockRecorder {
 	return m.recorder
 }
 
-// CharmProfiles mocks base method.
+// CharmProfiles mocks base method
 func (m *MockLXDProfileMachineV2) CharmProfiles() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmProfiles")
@@ -132,13 +131,13 @@ func (m *MockLXDProfileMachineV2) CharmProfiles() ([]string, error) {
 	return ret0, ret1
 }
 
-// CharmProfiles indicates an expected call of CharmProfiles.
+// CharmProfiles indicates an expected call of CharmProfiles
 func (mr *MockLXDProfileMachineV2MockRecorder) CharmProfiles() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfiles", reflect.TypeOf((*MockLXDProfileMachineV2)(nil).CharmProfiles))
 }
 
-// ContainerType mocks base method.
+// ContainerType mocks base method
 func (m *MockLXDProfileMachineV2) ContainerType() instance.ContainerType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerType")
@@ -146,13 +145,13 @@ func (m *MockLXDProfileMachineV2) ContainerType() instance.ContainerType {
 	return ret0
 }
 
-// ContainerType indicates an expected call of ContainerType.
+// ContainerType indicates an expected call of ContainerType
 func (mr *MockLXDProfileMachineV2MockRecorder) ContainerType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerType", reflect.TypeOf((*MockLXDProfileMachineV2)(nil).ContainerType))
 }
 
-// IsManual mocks base method.
+// IsManual mocks base method
 func (m *MockLXDProfileMachineV2) IsManual() (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsManual")
@@ -161,13 +160,13 @@ func (m *MockLXDProfileMachineV2) IsManual() (bool, error) {
 	return ret0, ret1
 }
 
-// IsManual indicates an expected call of IsManual.
+// IsManual indicates an expected call of IsManual
 func (mr *MockLXDProfileMachineV2MockRecorder) IsManual() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManual", reflect.TypeOf((*MockLXDProfileMachineV2)(nil).IsManual))
 }
 
-// WatchInstanceData mocks base method.
+// WatchInstanceData mocks base method
 func (m *MockLXDProfileMachineV2) WatchInstanceData() state.NotifyWatcher {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchInstanceData")
@@ -175,36 +174,36 @@ func (m *MockLXDProfileMachineV2) WatchInstanceData() state.NotifyWatcher {
 	return ret0
 }
 
-// WatchInstanceData indicates an expected call of WatchInstanceData.
+// WatchInstanceData indicates an expected call of WatchInstanceData
 func (mr *MockLXDProfileMachineV2MockRecorder) WatchInstanceData() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchInstanceData", reflect.TypeOf((*MockLXDProfileMachineV2)(nil).WatchInstanceData))
 }
 
-// MockLXDProfileUnitV2 is a mock of LXDProfileUnitV2 interface.
+// MockLXDProfileUnitV2 is a mock of LXDProfileUnitV2 interface
 type MockLXDProfileUnitV2 struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileUnitV2MockRecorder
 }
 
-// MockLXDProfileUnitV2MockRecorder is the mock recorder for MockLXDProfileUnitV2.
+// MockLXDProfileUnitV2MockRecorder is the mock recorder for MockLXDProfileUnitV2
 type MockLXDProfileUnitV2MockRecorder struct {
 	mock *MockLXDProfileUnitV2
 }
 
-// NewMockLXDProfileUnitV2 creates a new mock instance.
+// NewMockLXDProfileUnitV2 creates a new mock instance
 func NewMockLXDProfileUnitV2(ctrl *gomock.Controller) *MockLXDProfileUnitV2 {
 	mock := &MockLXDProfileUnitV2{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileUnitV2MockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileUnitV2) EXPECT() *MockLXDProfileUnitV2MockRecorder {
 	return m.recorder
 }
 
-// ApplicationName mocks base method.
+// ApplicationName mocks base method
 func (m *MockLXDProfileUnitV2) ApplicationName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplicationName")
@@ -212,13 +211,13 @@ func (m *MockLXDProfileUnitV2) ApplicationName() string {
 	return ret0
 }
 
-// ApplicationName indicates an expected call of ApplicationName.
+// ApplicationName indicates an expected call of ApplicationName
 func (mr *MockLXDProfileUnitV2MockRecorder) ApplicationName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationName", reflect.TypeOf((*MockLXDProfileUnitV2)(nil).ApplicationName))
 }
 
-// AssignedMachineId mocks base method.
+// AssignedMachineId mocks base method
 func (m *MockLXDProfileUnitV2) AssignedMachineId() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignedMachineId")
@@ -227,28 +226,28 @@ func (m *MockLXDProfileUnitV2) AssignedMachineId() (string, error) {
 	return ret0, ret1
 }
 
-// AssignedMachineId indicates an expected call of AssignedMachineId.
+// AssignedMachineId indicates an expected call of AssignedMachineId
 func (mr *MockLXDProfileUnitV2MockRecorder) AssignedMachineId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedMachineId", reflect.TypeOf((*MockLXDProfileUnitV2)(nil).AssignedMachineId))
 }
 
-// CharmURL mocks base method.
-func (m *MockLXDProfileUnitV2) CharmURL() (*charm.URL, error) {
+// CharmURL mocks base method
+func (m *MockLXDProfileUnitV2) CharmURL() (*charm.URL, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
 	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(error)
+	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
-// CharmURL indicates an expected call of CharmURL.
+// CharmURL indicates an expected call of CharmURL
 func (mr *MockLXDProfileUnitV2MockRecorder) CharmURL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockLXDProfileUnitV2)(nil).CharmURL))
 }
 
-// Name mocks base method.
+// Name mocks base method
 func (m *MockLXDProfileUnitV2) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -256,13 +255,13 @@ func (m *MockLXDProfileUnitV2) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockLXDProfileUnitV2MockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLXDProfileUnitV2)(nil).Name))
 }
 
-// Tag mocks base method.
+// Tag mocks base method
 func (m *MockLXDProfileUnitV2) Tag() names.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tag")
@@ -270,36 +269,36 @@ func (m *MockLXDProfileUnitV2) Tag() names.Tag {
 	return ret0
 }
 
-// Tag indicates an expected call of Tag.
+// Tag indicates an expected call of Tag
 func (mr *MockLXDProfileUnitV2MockRecorder) Tag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tag", reflect.TypeOf((*MockLXDProfileUnitV2)(nil).Tag))
 }
 
-// MockLXDProfileCharmV2 is a mock of LXDProfileCharmV2 interface.
+// MockLXDProfileCharmV2 is a mock of LXDProfileCharmV2 interface
 type MockLXDProfileCharmV2 struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileCharmV2MockRecorder
 }
 
-// MockLXDProfileCharmV2MockRecorder is the mock recorder for MockLXDProfileCharmV2.
+// MockLXDProfileCharmV2MockRecorder is the mock recorder for MockLXDProfileCharmV2
 type MockLXDProfileCharmV2MockRecorder struct {
 	mock *MockLXDProfileCharmV2
 }
 
-// NewMockLXDProfileCharmV2 creates a new mock instance.
+// NewMockLXDProfileCharmV2 creates a new mock instance
 func NewMockLXDProfileCharmV2(ctrl *gomock.Controller) *MockLXDProfileCharmV2 {
 	mock := &MockLXDProfileCharmV2{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileCharmV2MockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileCharmV2) EXPECT() *MockLXDProfileCharmV2MockRecorder {
 	return m.recorder
 }
 
-// LXDProfile mocks base method.
+// LXDProfile mocks base method
 func (m *MockLXDProfileCharmV2) LXDProfile() lxdprofile.Profile {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfile")
@@ -307,36 +306,36 @@ func (m *MockLXDProfileCharmV2) LXDProfile() lxdprofile.Profile {
 	return ret0
 }
 
-// LXDProfile indicates an expected call of LXDProfile.
+// LXDProfile indicates an expected call of LXDProfile
 func (mr *MockLXDProfileCharmV2MockRecorder) LXDProfile() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfile", reflect.TypeOf((*MockLXDProfileCharmV2)(nil).LXDProfile))
 }
 
-// MockLXDProfileModelV2 is a mock of LXDProfileModelV2 interface.
+// MockLXDProfileModelV2 is a mock of LXDProfileModelV2 interface
 type MockLXDProfileModelV2 struct {
 	ctrl     *gomock.Controller
 	recorder *MockLXDProfileModelV2MockRecorder
 }
 
-// MockLXDProfileModelV2MockRecorder is the mock recorder for MockLXDProfileModelV2.
+// MockLXDProfileModelV2MockRecorder is the mock recorder for MockLXDProfileModelV2
 type MockLXDProfileModelV2MockRecorder struct {
 	mock *MockLXDProfileModelV2
 }
 
-// NewMockLXDProfileModelV2 creates a new mock instance.
+// NewMockLXDProfileModelV2 creates a new mock instance
 func NewMockLXDProfileModelV2(ctrl *gomock.Controller) *MockLXDProfileModelV2 {
 	mock := &MockLXDProfileModelV2{ctrl: ctrl}
 	mock.recorder = &MockLXDProfileModelV2MockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLXDProfileModelV2) EXPECT() *MockLXDProfileModelV2MockRecorder {
 	return m.recorder
 }
 
-// ModelConfig mocks base method.
+// ModelConfig mocks base method
 func (m *MockLXDProfileModelV2) ModelConfig() (*config.Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModelConfig")
@@ -345,13 +344,13 @@ func (m *MockLXDProfileModelV2) ModelConfig() (*config.Config, error) {
 	return ret0, ret1
 }
 
-// ModelConfig indicates an expected call of ModelConfig.
+// ModelConfig indicates an expected call of ModelConfig
 func (mr *MockLXDProfileModelV2MockRecorder) ModelConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelConfig", reflect.TypeOf((*MockLXDProfileModelV2)(nil).ModelConfig))
 }
 
-// Type mocks base method.
+// Type mocks base method
 func (m *MockLXDProfileModelV2) Type() state.ModelType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Type")
@@ -359,7 +358,7 @@ func (m *MockLXDProfileModelV2) Type() state.ModelType {
 	return ret0
 }
 
-// Type indicates an expected call of Type.
+// Type indicates an expected call of Type
 func (mr *MockLXDProfileModelV2MockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockLXDProfileModelV2)(nil).Type))

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -47,7 +47,7 @@ type LXDProfileMachineV2 interface {
 type LXDProfileUnitV2 interface {
 	ApplicationName() string
 	AssignedMachineId() (string, error)
-	CharmURL() (*charm.URL, error)
+	CharmURL() (*charm.URL, bool)
 	Name() string
 	Tag() names.Tag
 }
@@ -66,7 +66,7 @@ type LXDProfileAPIv2 struct {
 	accessUnit common.GetAuthFunc
 }
 
-// NewLXDProfileAPIv2 returns a new LXDProfileAPIv2. Currently both
+// LXDProfileAPIv2 returns a new LXDProfileAPIv2. Currently both
 // GetAuthFuncs can used to determine current permissions.
 func NewLXDProfileAPIv2(
 	backend LXDProfileBackendV2,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -959,21 +959,12 @@ func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, er
 			var unitOrApplication state.Entity
 			unitOrApplication, err = u.st.FindEntity(tag)
 			if err == nil {
-				var cURL *charm.URL
-				var ok bool
-
-				switch entity := unitOrApplication.(type) {
-				case *state.Application:
-					cURL, ok = entity.CharmURL()
-				case *state.Unit:
-					cURL, err = entity.CharmURL()
-					if cURL != nil {
-						ok = true
-					}
-				}
-
-				if cURL != nil {
-					result.Results[i].Result = cURL.String()
+				charmURLer := unitOrApplication.(interface {
+					CharmURL() (*charm.URL, bool)
+				})
+				curl, ok := charmURLer.CharmURL()
+				if curl != nil {
+					result.Results[i].Result = curl.String()
 					result.Results[i].Ok = ok
 				}
 			}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -875,9 +875,9 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	// Set wordpressUnit's charm URL first.
 	err := s.wordpressUnit.SetCharmURL(s.wpCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	curl, err := s.wordpressUnit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	curl, ok := s.wordpressUnit.CharmURL()
 	c.Assert(curl, gc.DeepEquals, s.wpCharm.URL())
+	c.Assert(ok, jc.IsTrue)
 
 	// Make sure wordpress application's charm is what we expect.
 	curl, force := s.wordpress.CharmURL()
@@ -901,7 +901,7 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StringBoolResults{
 		Results: []params.StringBoolResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Result: s.wpCharm.String(), Ok: true},
+			{Result: s.wpCharm.String(), Ok: ok},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Result: s.wpCharm.String(), Ok: force},
@@ -941,11 +941,10 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 	// Verify the charm URL was set.
 	err = s.wordpressUnit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-
-	charmURL, err := s.wordpressUnit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	charmURL, needsUpgrade := s.wordpressUnit.CharmURL()
 	c.Assert(charmURL, gc.NotNil)
 	c.Assert(charmURL.String(), gc.Equals, s.wpCharm.String())
+	c.Assert(needsUpgrade, jc.IsTrue)
 }
 
 func (s *uniterSuite) TestWorkloadVersion(c *gc.C) {

--- a/apiserver/facades/client/metricsdebug/metricsdebug.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug.go
@@ -196,11 +196,8 @@ func (api *MetricsDebugAPI) setEntityMeterStatus(entity names.Tag, status state.
 		if err != nil {
 			return errors.Trace(err)
 		}
-		chURL, err := unit.CharmURL()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if chURL == nil {
+		chURL, found := unit.CharmURL()
+		if !found {
 			return errors.New("no charm url")
 		}
 		if chURL.Schema != "local" {

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -165,9 +165,9 @@ func UnitChange(c *gc.C, modelUUID string, unit *state.Unit) cache.UnitChange {
 	}
 
 	var charmURL string
-	cURL, err := unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
-	charmURL = cURL.String()
+	if cURL, ok := unit.CharmURL(); ok {
+		charmURL = cURL.String()
+	}
 
 	pr, err := unit.OpenedPortRanges()
 	if !errors.IsNotAssigned(err) {

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -83,7 +83,7 @@ type PrecheckUnit interface {
 	Name() string
 	AgentTools() (*tools.Tools, error)
 	Life() state.Life
-	CharmURL() (*charm.URL, error)
+	CharmURL() (*charm.URL, bool)
 	AgentStatus() (status.StatusInfo, error)
 	Status() (status.StatusInfo, error)
 	ShouldBeAssigned() bool

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -798,7 +798,7 @@ func (b *fakeBackend) IsMigrationActive(string) (bool, error) {
 	return b.migrationActive, b.migrationActiveErr
 }
 
-func (b *fakeBackend) CloudCredential(_ names.CloudCredentialTag) (state.Credential, error) {
+func (b *fakeBackend) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
 	return b.credentials, b.credentialsErr
 }
 
@@ -814,7 +814,7 @@ func (b *fakeBackend) AllRelations() ([]migration.PrecheckRelation, error) {
 	return b.relations, b.allRelsErr
 }
 
-func (b *fakeBackend) ListPendingResources(_ string) ([]resource.Resource, error) {
+func (b *fakeBackend) ListPendingResources(app string) ([]resource.Resource, error) {
 	return b.pendingResources, b.pendingResourcesErr
 }
 
@@ -1009,12 +1009,12 @@ func (u *fakeUnit) ShouldBeAssigned() bool {
 	return true
 }
 
-func (u *fakeUnit) CharmURL() (*charm.URL, error) {
+func (u *fakeUnit) CharmURL() (*charm.URL, bool) {
 	url := u.charmURL
 	if url == "" {
 		url = "cs:foo-1"
 	}
-	return charm.MustParseURL(url), nil
+	return charm.MustParseURL(url), false
 }
 
 func (u *fakeUnit) AgentStatus() (status.StatusInfo, error) {

--- a/resource/resourceadapters/mocks/opener_mock.go
+++ b/resource/resourceadapters/mocks/opener_mock.go
@@ -278,11 +278,11 @@ func (mr *MockUnitMockRecorder) ApplicationName() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockUnit) CharmURL() (*charm.URL, error) {
+func (m *MockUnit) CharmURL() (*charm.URL, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
 	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(error)
+	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 

--- a/resource/resourceadapters/opener_test.go
+++ b/resource/resourceadapters/opener_test.go
@@ -103,7 +103,7 @@ func (s *OpenerSuite) setupMocks(c *gc.C, includeUnit bool) *gomock.Controller {
 	if s.unit != nil {
 		s.unit.EXPECT().ApplicationName().Return("postgresql").AnyTimes()
 		s.unit.EXPECT().Application().Return(s.app, nil).AnyTimes()
-		s.unit.EXPECT().CharmURL().Return(curl, nil).AnyTimes()
+		s.unit.EXPECT().CharmURL().Return(curl, false).AnyTimes()
 	} else {
 		s.app.EXPECT().CharmURL().Return(curl, false).AnyTimes()
 	}

--- a/resource/unit.go
+++ b/resource/unit.go
@@ -18,5 +18,5 @@ type Unit interface {
 	ApplicationName() string
 
 	// CharmURL returns the unit's charm URL.
-	CharmURL() (*charm.URL, error)
+	CharmURL() (*charm.URL, bool)
 }

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -627,9 +627,8 @@ func (checker *ModelChecker) readApplicationsAndUnits() {
 		units, err := app.AllUnits()
 		checkErr(err, "AllUnits")
 		for _, unit := range units {
-			unitCharmURL, err := unit.CharmURL()
-			checkErr(err, "unit CharmURL")
-			if unitCharmURL == nil {
+			unitCharmURL, found := unit.CharmURL()
+			if !found {
 				continue
 			}
 			unitString := unitCharmURL.String()

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -524,7 +524,7 @@ func (u *backingUnit) updated(ctx *allWatcherContext) error {
 		Subordinate: u.Principal != "",
 	}
 	if u.CharmURL != nil {
-		info.CharmURL = *u.CharmURL
+		info.CharmURL = u.CharmURL.String()
 	}
 
 	// Construct a unit for the purpose of retrieving other fields as necessary.

--- a/state/application.go
+++ b/state/application.go
@@ -2649,17 +2649,11 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	if u.doc.CharmURL != nil {
 		// If the unit has a different URL to the application, allow any final
 		// cleanup to happen; otherwise we just do it when the app itself is removed.
-		maybeDoFinal := *u.doc.CharmURL != a.doc.CharmURL.String()
-
-		cURL, err := u.CharmURL()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
+		maybeDoFinal := u.doc.CharmURL != a.doc.CharmURL
 		// When 'force' is set, this call will return both needed operations
 		// as well as all operational errors encountered.
 		// If the 'force' is not set, any error will be fatal and no operations will be returned.
-		decOps, err := appCharmDecRefOps(a.st, a.doc.Name, cURL, maybeDoFinal, op)
+		decOps, err := appCharmDecRefOps(a.st, a.doc.Name, u.doc.CharmURL, maybeDoFinal, op)
 		if errors.IsNotFound(err) {
 			return nil, errRefresh
 		} else if op.FatalError(err) {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1998,8 +1998,8 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	// used by app as well, hence 2.
 	err = u.SetCharmURL(oldCh.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	curl, err := u.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	curl, ok := u.CharmURL()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(curl, gc.DeepEquals, oldCh.URL())
 	assertSettingsRef(c, s.State, appName, oldCh, 2)
 	assertNoSettingsRef(c, s.State, appName, newCh)

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -551,9 +551,9 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 	}}
 	for i, t := range tests {
 		c.Logf("test %d: %s", i, t.about)
-		chURL, err := t.unit.CharmURL()
-		c.Assert(err, jc.ErrorIsNil)
-		_, err = s.State.AddMetrics(
+		chURL, ok := t.unit.CharmURL()
+		c.Assert(ok, jc.IsTrue)
+		_, err := s.State.AddMetrics(
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  now,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1553,7 +1553,10 @@ func (i *importer) makeUnitDoc(s description.Application, u description.Unit) (*
 	// the charm url for each unit rather than grabbing the applications charm url.
 	// Currently the units charm url matching the application is a precondiation
 	// to migration.
-	charmURL := s.CharmURL()
+	charmURL, err := charm.ParseURL(s.CharmURL())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	var subordinates []string
 	if subs := u.Subordinates(); len(subs) > 0 {
@@ -1578,7 +1581,7 @@ func (i *importer) makeUnitDoc(s description.Application, u description.Unit) (*
 		Name:                   u.Name(),
 		Application:            s.Name(),
 		Series:                 s.Series(),
-		CharmURL:               &charmURL,
+		CharmURL:               charmURL,
 		Principal:              u.Principal().Id(),
 		Subordinates:           subordinates,
 		StorageAttachmentCount: i.unitStorageAttachmentCount(u.Tag()),

--- a/state/state.go
+++ b/state/state.go
@@ -1615,7 +1615,7 @@ func (st *State) AssignStagedUnits(ids []string) ([]UnitAssignmentResult, error)
 	return results, nil
 }
 
-// AllUnitAssignments returns all staged unit assignments in the model.
+// UnitAssignments returns all staged unit assignments in the model.
 func (st *State) AllUnitAssignments() ([]UnitAssignment, error) {
 	return st.unitAssignments(nil)
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1269,8 +1269,8 @@ func (s *UnitSuite) TestSetCharmURLSuccess(c *gc.C) {
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, err = s.unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	curl, ok = s.unit.CharmURL()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(curl, gc.DeepEquals, s.charm.URL())
 }
 
@@ -1310,8 +1310,8 @@ func (s *UnitSuite) TestSetCharmURLWithDyingUnit(c *gc.C) {
 	err = s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, err := s.unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	curl, ok := s.unit.CharmURL()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(curl, gc.DeepEquals, s.charm.URL())
 }
 
@@ -1359,9 +1359,9 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 				// Verify it worked after the second attempt.
 				err := s.unit.Refresh()
 				c.Assert(err, jc.ErrorIsNil)
-				currentURL, err := s.unit.CharmURL()
-				c.Assert(err, jc.ErrorIsNil)
+				currentURL, hasURL := s.unit.CharmURL()
 				c.Assert(currentURL, jc.DeepEquals, s.charm.URL())
+				c.Assert(hasURL, jc.IsTrue)
 			},
 		},
 	).Check()
@@ -2649,8 +2649,7 @@ func (s *UnitSuite) TestWorkloadVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(version, gc.Equals, "")
 
-	err = unit.SetWorkloadVersion("3.combined")
-	c.Assert(err, jc.ErrorIsNil)
+	unit.SetWorkloadVersion("3.combined")
 	version, err = unit.WorkloadVersion()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(version, gc.Equals, "3.combined")

--- a/state/upgrade/types.go
+++ b/state/upgrade/types.go
@@ -78,7 +78,7 @@ type OldPortsDoc28 struct {
 	TxnRevno  int64               `bson:"txn-revno"`
 }
 
-// OldPortRangeDoc28 represents a port range entry document prior to the 2.9 schema changes.
+// OldPortsDoc28 represents a port range entry document prior to the 2.9 schema changes.
 type OldPortRangeDoc28 struct {
 	UnitName string `bson:"unitname"`
 	FromPort int    `bson:"fromport"`

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -40,7 +40,6 @@ import (
 	"github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/state/upgrade"
 	"github.com/juju/juju/storage/provider"
-	"github.com/juju/juju/tools"
 )
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
@@ -1328,7 +1327,7 @@ func collectRelationInfo(coll *mgo.Collection) (map[string]*relationUnitCountInf
 	return relations, nil
 }
 
-// unitAppName returns the name of the Application, given a Unit's name.
+// unitAppName returns the name of the Application, given a Units name.
 func unitAppName(unitName string) string {
 	unitParts := strings.Split(unitName, "/")
 	return unitParts[0]
@@ -2898,34 +2897,13 @@ func AddMachineIDToSubordinates(pool *StatePool) error {
 	coll, closer := st.db().GetRawCollection(unitsC)
 	defer closer()
 
-	// unitDoc28 represents the unit document as at Juju version 2.8,
-	// to which this upgrade step applies.
-	// Later, in version 2.9.23, CharmURL was stored as *string
-	// instead of *charm.URL.
-	type unitDoc28 struct {
-		DocID                  string `bson:"_id"`
-		Name                   string `bson:"name"`
-		ModelUUID              string `bson:"model-uuid"`
-		Application            string
-		Series                 string
-		CharmURL               *charm.URL
-		Principal              string
-		Subordinates           []string
-		StorageAttachmentCount int `bson:"storageattachmentcount"`
-		MachineId              string
-		Resolved               ResolvedMode
-		Tools                  *tools.Tools `bson:",omitempty"`
-		Life                   Life
-		PasswordHash           string
-	}
-
 	// Load all the units into a map by full ID.
-	units := make(map[string]*unitDoc28)
+	units := make(map[string]*unitDoc)
 
-	var doc unitDoc28
+	var doc unitDoc
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
-		// Make a copy of the doc and put the copy
+		// Make a copy of the unitDoc and put the copy
 		// into the map.
 		unit := doc
 		units[unit.DocID] = &unit

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2032,13 +2032,7 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
-
-	cURL, err := u.CharmURL()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, cURL)
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
 	return newEntityWatcher(u.st, settingsC, u.st.docID(charmConfigKey)), nil
 }
 
@@ -2057,13 +2051,7 @@ func (u *Unit) WatchConfigSettingsHash() (StringsWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
-
-	cURL, err := u.CharmURL()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, cURL)
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
 	return newSettingsHashWatcher(u.st, charmConfigKey), nil
 }
 

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -678,8 +678,8 @@ func (factory *Factory) MakeMetric(c *gc.C, params *MetricParams) *state.MetricB
 		}}
 	}
 
-	chURL, err := params.Unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	chURL, ok := params.Unit.CharmURL()
+	c.Assert(ok, gc.Equals, true)
 
 	metric, err := factory.st.AddMetrics(
 		state.BatchParam{

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -794,16 +794,13 @@ func (s waitUnitAgent) step(c *gc.C, ctx *testContext) {
 				c.Logf("want resolved mode %q, got %q; still waiting", s.resolved, resolved)
 				continue
 			}
-			url, err := ctx.unit.CharmURL()
-			if err != nil {
-				c.Fatalf("cannot refresh unit: %v", err)
-			}
-			if url == nil {
-				c.Logf("want unit charm %q, got nil; still waiting", curl(s.charm))
-				continue
-			}
-			if *url != *curl(s.charm) {
-				c.Logf("want unit charm %q, got %q; still waiting", curl(s.charm), url.String())
+			url, ok := ctx.unit.CharmURL()
+			if !ok || *url != *curl(s.charm) {
+				var got string
+				if ok {
+					got = url.String()
+				}
+				c.Logf("want unit charm %q, got %q; still waiting", curl(s.charm), got)
 				continue
 			}
 			statusInfo, err := s.statusGetter(ctx)()
@@ -1028,9 +1025,8 @@ func (s verifyCharm) step(c *gc.C, ctx *testContext) {
 	}
 	err = ctx.unit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-
-	url, err := ctx.unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	url, ok := ctx.unit.CharmURL()
+	c.Assert(ok, jc.IsTrue)
 	c.Assert(url, gc.DeepEquals, curl(checkRevision))
 }
 


### PR DESCRIPTION
This reverts commit c5e5548f80d97a9fadcff484350634e6f71ca883, reversing
changes made to 878fc7cf6dc02f20493bcc46ea9cda74d8e0df40.

## QA steps

TBA

## Bug reference

https://bugs.launchpad.net/juju/+bug/1957824
