### PR TITLE
Record the error if an external cmr controller goes bad

### DIFF
--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -4,6 +4,7 @@
 package remoterelations
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
@@ -154,6 +155,10 @@ func (w *remoteApplicationWorker) loop() (err error) {
 	)
 	if !w.isConsumerProxy {
 		if err := w.newRemoteRelationsFacadeWithRedirect(); err != nil {
+			msg := fmt.Sprintf("cannot connect to external controller: %v", err.Error())
+			if err := w.localModelFacade.SetRemoteApplicationStatus(w.applicationName, status.Error, msg); err != nil {
+				return errors.Annotatef(err, "updating remote application %v status from remote model %v", w.applicationName, w.remoteModelUUID)
+			}
 			return errors.Trace(err)
 		}
 		defer func() { _ = w.remoteModelFacade.Close() }()

--- a/worker/remoterelations/remoterelations_test.go
+++ b/worker/remoterelations/remoterelations_test.go
@@ -89,7 +89,7 @@ func waitForStubCalls(c *gc.C, stub *jujutesting.Stub, expected []jujutesting.St
 			return
 		}
 	}
-	c.Fatalf("failed to see expected calls.\nexpected: %#v\nobserved: %#v", expected, calls)
+	c.Assert(expected, jc.DeepEquals, calls)
 }
 
 func (s *remoteRelationsSuite) assertRemoteApplicationWorkers(c *gc.C) worker.Worker {
@@ -151,6 +151,31 @@ func (s *remoteRelationsSuite) TestRemoteApplicationWorkers(c *gc.C) {
 		c.Check(ok, jc.IsTrue)
 		c.Check(w.killed(), jc.IsTrue)
 	}
+}
+
+func (s *remoteRelationsSuite) TestExternalControllerError(c *gc.C) {
+	s.config.NewRemoteModelFacadeFunc = func(info *api.Info) (remoterelations.RemoteModelRelationsFacadeCloser, error) {
+		return nil, errors.New("boom")
+	}
+
+	s.relationsFacade.remoteApplications["mysql"] = newMockRemoteApplication("mysql", "mysqlurl")
+	s.relationsFacade.controllerInfo["remote-model-uuid"] = s.remoteControllerInfo
+
+	w, err := remoterelations.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	s.relationsFacade.remoteApplicationsWatcher.changes <- []string{"mysql"}
+	expected := []jujutesting.StubCall{
+		{"WatchRemoteApplications", nil},
+		{"RemoteApplications", []interface{}{[]string{"mysql"}}},
+		{"WatchRemoteApplicationRelations", []interface{}{"mysql"}},
+		{"ControllerAPIInfoForModel", []interface{}{"remote-model-uuid"}},
+		{"SetRemoteApplicationStatus", []interface{}{
+			"mysql", "error", "cannot connect to external controller: opening facade to remote model: boom",
+		}},
+	}
+	s.waitForWorkerStubCalls(c, expected)
 }
 
 func (s *remoteRelationsSuite) TestRemoteApplicationWorkersRedirect(c *gc.C) {


### PR DESCRIPTION
Fixes one of the issues in the linked bug.
For a cross controller CMR, we poll the other controller. If that connection fails, we should update the SAAS status to reflect the error. Currently it stays "active".
There's still the issue where we never stop polling the other controller - we need to add ref counting for that, but not here.

## QA steps

I tested with LXD.
Deploy 2 controllers, create an offer in one and consume in the other.
lxc stop the offering controller.
juju status on the consuming model will show error (after  a few seconds).
And yaml status will show the error message.
lxc start the controller again and status will go back to active.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1958372
