### PR TITLE
add message query to juju wait-for

### DIFF
--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -205,6 +205,8 @@ func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
 		return query.NewBool(m.UnitInfo.Subordinate), nil
 	case "workload-status":
 		return query.NewString(string(m.UnitInfo.WorkloadStatus.Current)), nil
+        case "workload-message":
+                return query.NewString(string(m.UnitInfo.WorkloadStatus.Message)), nil
 	case "agent-status":
 		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
 	}

--- a/cmd/plugins/juju-wait-for/unit_test.go
+++ b/cmd/plugins/juju-wait-for/unit_test.go
@@ -71,6 +71,12 @@ func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
 			Current: status.Active,
 		}},
 		Expected: query.NewString("active"),
+        }, {
+                Field: "workload-message",
+                UnitInfo: &params.UnitInfo{WorkloadStatus: params.StatusInfo{
+                        Message: "unit is ready",
+                }},
+                Expected: query.NewString("unit is ready"),
 	}, {
 		Field: "agent-status",
 		UnitInfo: &params.UnitInfo{AgentStatus: params.StatusInfo{


### PR DESCRIPTION
To fix https://bugs.launchpad.net/juju/+bug/1958568

juju wait-for would be useful to use to wait for a unit before performing an action, for example:
octavia - Awaiting end-user execution of `configure-resources` action to create required resources
ceilometer - Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi