### PR TITLE
add message query to juju wait-for

### DIFF
--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -205,8 +205,8 @@ func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
 		return query.NewBool(m.UnitInfo.Subordinate), nil
 	case "workload-status":
 		return query.NewString(string(m.UnitInfo.WorkloadStatus.Current)), nil
-        case "workload-message":
-                return query.NewString(m.UnitInfo.WorkloadStatus.Message), nil
+	case "workload-message":
+		return query.NewString(m.UnitInfo.WorkloadStatus.Message), nil
 	case "agent-status":
 		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
 	}

--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -205,6 +205,8 @@ func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
 		return query.NewBool(m.UnitInfo.Subordinate), nil
 	case "workload-status":
 		return query.NewString(string(m.UnitInfo.WorkloadStatus.Current)), nil
+        case "workload-message":
+                return query.NewString(string(m.UnitInfo.WorkloadStatus.Message)), nil
 	case "agent-status":
 		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
 	}

--- a/cmd/plugins/juju-wait-for/unit.go
+++ b/cmd/plugins/juju-wait-for/unit.go
@@ -206,7 +206,7 @@ func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
 	case "workload-status":
 		return query.NewString(string(m.UnitInfo.WorkloadStatus.Current)), nil
         case "workload-message":
-                return query.NewString(string(m.UnitInfo.WorkloadStatus.Message)), nil
+                return query.NewString(m.UnitInfo.WorkloadStatus.Message), nil
 	case "agent-status":
 		return query.NewString(string(m.UnitInfo.AgentStatus.Current)), nil
 	}

--- a/cmd/plugins/juju-wait-for/unit_test.go
+++ b/cmd/plugins/juju-wait-for/unit_test.go
@@ -71,12 +71,12 @@ func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
 			Current: status.Active,
 		}},
 		Expected: query.NewString("active"),
-        }, {
-                Field: "workload-message",
-                UnitInfo: &params.UnitInfo{WorkloadStatus: params.StatusInfo{
-                        Message: "unit is ready",
-                }},
-                Expected: query.NewString("unit is ready"),
+	}, {
+		Field: "workload-message",
+		UnitInfo: &params.UnitInfo{WorkloadStatus: params.StatusInfo{
+			Message: "unit is ready",
+		}},
+		Expected: query.NewString("unit is ready"),
 	}, {
 		Field: "agent-status",
 		UnitInfo: &params.UnitInfo{AgentStatus: params.StatusInfo{

--- a/cmd/plugins/juju-wait-for/unit_test.go
+++ b/cmd/plugins/juju-wait-for/unit_test.go
@@ -71,6 +71,12 @@ func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
 			Current: status.Active,
 		}},
 		Expected: query.NewString("active"),
+        }, {
+                Field: "workload-message",
+                UnitInfo: &params.UnitInfo{WorkloadStatus: params.StatusInfo{
+                        Message: "unit is ready",
+                }},
+                Expected: query.NewString("unit is ready"),
 	}, {
 		Field: "agent-status",
 		UnitInfo: &params.UnitInfo{AgentStatus: params.StatusInfo{


### PR DESCRIPTION
## Add options to query workload-message for unit in juju-wait

Related bug: https://bugs.launchpad.net/juju/+bug/1958568

Currently, juju wait-for can only query the workload-status of a unit, and not also the workload message. In the SQA team, we use a similar script that waits for a unit to show a message like:
```
octavia - Awaiting end-user execution of configure-resources action to create required resources
ceilometer - Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi
```
It would be useful if juju wait-for can halt a script until the unit shows a certain message to indicate that it is ready for an action, before the script attempts to run that action against a unit.

## QA Steps

I rebuilt the snap and verified that juju wait-for can wait for a unit message. That is, it does nothing when the the unit shows a different message and it exits if the unit does show the message.