### PR TITLE
[JUJU-480] Use default storage class for AKS CI tests;

### DIFF
--- a/acceptancetests/jujupy/k8s_provider/aks.py
+++ b/acceptancetests/jujupy/k8s_provider/aks.py
@@ -19,6 +19,7 @@
 
 from __future__ import print_function
 
+import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -89,6 +90,18 @@ class AKS(Base):
 
     def _ensure_cluster_stack(self):
         self.provision_aks()
+
+    def add_k8s(self, is_local=False, juju_home=None, storage=None):
+        if storage is None:
+            storageclasses = json.loads(self.kubectl('get', 'storageclass', '-o', 'json'))
+            for sc in storageclasses.get('items', []):
+                annotations = sc['metadata'].get('annotations', None)
+                if annotations is None:
+                    continue
+                if annotations.get('storageclass.kubernetes.io/is-default-class') == 'true':
+                    storage = sc['metadata']['name']
+                    break
+        super().add_k8s(is_local, juju_home, storage)
 
     def _tear_down_substrate(self):
         logger.info("Deleting the AKS instance {0}".format(self.cluster_name))

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -168,11 +168,13 @@ class Base(object):
         # returns the newly added CAAS model.
         return self.client.add_model(env=self.client.env.clone(model_name), cloud_region=self.cloud_name)
 
-    def add_k8s(self, is_local=False, juju_home=None):
+    def add_k8s(self, is_local=False, juju_home=None, storage=None):
         args = (
             self.cloud_name,
         )
         juju_home = juju_home or self.client.env.juju_home
+        if storage is not None:
+            args += ('--storage', storage)
         if is_local:
             args += (
                 '--local',


### PR DESCRIPTION
Fix nw-deploy-bionic-aks.

```log

16:55:19 CRITC juju.kubernetes.provider metadata.go:245 storageProvisioner &caas.StorageProvisioner{Name:"managed-premium", Provisioner:"disk.csi.azure.com", Parameters:map[string]string{"cachingmode":"ReadOnly", "kind":"Managed", "storageaccounttype":"Premium_LRS"}, Namespace:"", Model:"", ReclaimPolicy:"Delete", VolumeBindingMode:"WaitForFirstConsumer"}

16:55:19 CRITC juju.kubernetes.provider metadata.go:237 preferredStorage caas.PreferredStorage{Name:"Azure Disk", Provisioner:"kubernetes.io/azure-disk", Parameters:map[string]string(nil), VolumeBindingMode:"WaitForFirstConsumer"}
```

AKS clusters support two different default storage classes:

1. [kubernetes.io/azure-disk](https://docs.microsoft.com/en-us/azure/aks/azure-disks-dynamic-pv);
2. [disk.csi.azure.com](https://docs.microsoft.com/en-us/azure/aks/azure-disk-csi) (AKS recently switched to this one as the default storage class);

Juju currently only recognizes the 1st one. This PR makes the aks CI code to find the default sc then specify the storage with the `--storage` option in the `add-k8s` command.

TODO: make Juju recognize both the two default sc (add it to `jujuPreferredWorkloadStorage`).

