### PR TITLE
[JUJU-483] Ensure that unit public address is acquired as-needed

### DIFF
--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -357,13 +357,6 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 			return errors.Trace(err)
 		}
 
-		// Calling these last, because there's a potential race: they're not guaranteed
-		// to be set in time to be needed for a hook. If they're not, we just leave them
-		// unset as we always have; this isn't great but it's about behaviour preservation.
-		ctx.publicAddress, err = f.unit.PublicAddress()
-		if err != nil && !params.IsCodeNoAddressSet(err) {
-			f.logger.Warningf("cannot get legacy public address for %v: %v", f.unit.Name(), err)
-		}
 		ctx.privateAddress, err = f.unit.PrivateAddress()
 		if err != nil && !params.IsCodeNoAddressSet(err) {
 			f.logger.Warningf("cannot get legacy private address for %v: %v", f.unit.Name(), err)

--- a/worker/uniter/runner/context/mocks/hookunit_mock.go
+++ b/worker/uniter/runner/context/mocks/hookunit_mock.go
@@ -139,6 +139,21 @@ func (mr *MockHookUnitMockRecorder) NetworkInfo(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockHookUnit)(nil).NetworkInfo), arg0, arg1)
 }
 
+// PublicAddress mocks base method.
+func (m *MockHookUnit) PublicAddress() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublicAddress")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PublicAddress indicates an expected call of PublicAddress.
+func (mr *MockHookUnitMockRecorder) PublicAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicAddress", reflect.TypeOf((*MockHookUnit)(nil).PublicAddress))
+}
+
 // RequestReboot mocks base method.
 func (m *MockHookUnit) RequestReboot() error {
 	m.ctrl.T.Helper()

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -255,7 +255,7 @@ type ContextNetworking interface {
 
 	// ClosePortRange ensures the supplied port range is closed even when
 	// the executing unit's application is exposed (unless it is opened
-	// separately by a co- located unit).
+	// separately by a co-located unit).
 	ClosePortRange(endpointName string, portRange network.PortRange) error
 
 	// OpenedPortRanges returns all port ranges currently opened by this


### PR DESCRIPTION
We populate `PublicAddress` for every unit hook context. This has 2 issues:
- It's a wasted API call for cases where the address is not required for the hook.
- We increase the chance that the public address may found for freshly installed units.

Here we acquire the address upon the first call to `PublicAddress` and cache it. This means: 
- We still acquire it only once if it is used, but eschew the wasted call if not.
- We have a better chance of it being set by acquiring it slightly later.

## QA steps

- Bootstrap to AWS and `juju deploy ubuntu`.
- `juju run --unit ubuntu/0 "unit-get public-address"` should return the public address.

## Documentation changes

None.

## Bug reference

N/A
