### PR TITLE
[JUJU-390] Transfer machine DisplayName through migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,8 @@ require (
 
 replace github.com/altoros/gosigma => github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e
 
+replace github.com/juju/description/v3 => github.com/cderici/description/machine-display-name
+
 replace gopkg.in/yaml.v2 => github.com/juju/yaml v0.0.0-20200420012109-12a32b78de07
 
 replace github.com/dustin/go-humanize v1.0.0 => github.com/dustin/go-humanize v0.0.0-20141228071148-145fabdb1ab7

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c
 	github.com/juju/cmd/v3 v3.0.0-20210809234809-65029dab4cd0
 	github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271
-	github.com/juju/description/v3 v3.0.0-20210709162012-5f861fa82eab
+	github.com/juju/description/v3 v3.0.0-20220125161928-cc5932c29986
 	github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff
 	github.com/juju/featureflag v0.0.0-20200423045028-e2f9e1cb1611
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
@@ -144,8 +144,6 @@ require (
 )
 
 replace github.com/altoros/gosigma => github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e
-
-replace github.com/juju/description/v3 => github.com/cderici/description/v3 v3.0.0-20220124185649-54214b3dc18e
 
 replace gopkg.in/yaml.v2 => github.com/juju/yaml v0.0.0-20200420012109-12a32b78de07
 

--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ require (
 
 replace github.com/altoros/gosigma => github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e
 
-replace github.com/juju/description/v3 => github.com/cderici/description/machine-display-name
+replace github.com/juju/description/v3 => github.com/cderici/description/v3 v3.0.0-20220124185649-54214b3dc18e
 
 replace gopkg.in/yaml.v2 => github.com/juju/yaml v0.0.0-20200420012109-12a32b78de07
 

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajAB
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0 h1:Bzr3QOteZ+bPUxFGjgA3jkYnERpeFfbgGaLsH9g7qm8=
 github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
+github.com/cderici/description/v3 v3.0.0-20220124185649-54214b3dc18e h1:9EImXjK5XtCYBbFRPeOA0OCYwzp0BlPQhfApecY7zjI=
+github.com/cderici/description/v3 v3.0.0-20220124185649-54214b3dc18e/go.mod h1:l94w+OBJ7b3BAfIInxoX6FHxzERxBtLh9FNABsGNO2U=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajAB
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0 h1:Bzr3QOteZ+bPUxFGjgA3jkYnERpeFfbgGaLsH9g7qm8=
 github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
-github.com/cderici/description/v3 v3.0.0-20220124185649-54214b3dc18e h1:9EImXjK5XtCYBbFRPeOA0OCYwzp0BlPQhfApecY7zjI=
-github.com/cderici/description/v3 v3.0.0-20220124185649-54214b3dc18e/go.mod h1:l94w+OBJ7b3BAfIInxoX6FHxzERxBtLh9FNABsGNO2U=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -429,8 +427,8 @@ github.com/juju/collections v0.0.0-20180516022642-90152009b5f3/go.mod h1:Ep+c0vn
 github.com/juju/collections v0.0.0-20180717171555-9be91dc79b7c/go.mod h1:Ep+c0vnxsgmmTtsMibPgEEleZyi0b4uVvyzJ+8ka9EI=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271 h1:4R626WTwa7pRYQFiIRLVPepMhm05eZMEx+wIurRnMLc=
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
-github.com/juju/description/v3 v3.0.0-20210709162012-5f861fa82eab h1:F6p6nvVCiS6V2Lbxg3bneKNmX1VVO0BEF6rnQyTILfI=
-github.com/juju/description/v3 v3.0.0-20210709162012-5f861fa82eab/go.mod h1:l94w+OBJ7b3BAfIInxoX6FHxzERxBtLh9FNABsGNO2U=
+github.com/juju/description/v3 v3.0.0-20220125161928-cc5932c29986 h1:+mBLgv5yMUY6g7rycCf3aPxxl58ohrVU0Fu0VKVd65s=
+github.com/juju/description/v3 v3.0.0-20220125161928-cc5932c29986/go.mod h1:l94w+OBJ7b3BAfIInxoX6FHxzERxBtLh9FNABsGNO2U=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20180726005433-812b06ada177/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20190930114154-d42613fe1ab9/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -322,7 +322,7 @@ func (e *Environ) Create(ctx envcontext.ProviderCallContext, params environs.Cre
 
 // AdoptResources implements environs.Environ.
 func (e *Environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
-	return errors.NotImplementedf("AdoptResources")
+	return nil
 }
 
 // ConstraintsValidator implements environs.Environ.

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -322,7 +322,8 @@ func (e *Environ) Create(ctx envcontext.ProviderCallContext, params environs.Cre
 
 // AdoptResources implements environs.Environ.
 func (e *Environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
-	return nil
+	// TODO(cderici): implement AdoptResources for oci
+	return errors.NotImplementedf("AdoptResources")
 }
 
 // ConstraintsValidator implements environs.Environ.

--- a/state/machine.go
+++ b/state/machine.go
@@ -148,6 +148,10 @@ type machineDoc struct {
 
 	// Hostname records the machine's hostname as reported by the machine agent.
 	Hostname string `bson:"hostname,omitempty"`
+
+	// DisplayName records the machine's display-name (currently
+	// only OCI and MAAS providers use this)
+	DisplayName string `bson:"display-name,omitempty"`
 }
 
 func newMachine(st *State, doc *machineDoc) *Machine {

--- a/state/machine.go
+++ b/state/machine.go
@@ -148,10 +148,6 @@ type machineDoc struct {
 
 	// Hostname records the machine's hostname as reported by the machine agent.
 	Hostname string `bson:"hostname,omitempty"`
-
-	// DisplayName records the machine's display-name (currently
-	// only OCI and MAAS providers use this)
-	DisplayName string `bson:"display-name,omitempty"`
 }
 
 func newMachine(st *State, doc *machineDoc) *Machine {

--- a/state/machine.go
+++ b/state/machine.go
@@ -279,6 +279,14 @@ func (m *Machine) HardwareCharacteristics() (*instance.HardwareCharacteristics, 
 	return hardwareCharacteristics(instData), nil
 }
 
+func (m *Machine) DisplayName() (string, error) {
+	instData, err := getInstanceData(m.st, m.Id())
+	if err != nil {
+		return "", err
+	}
+	return instData.DisplayName, nil
+}
+
 func getInstanceData(st *State, id string) (instanceData, error) {
 	instanceDataCollection, closer := st.db().GetCollection(instanceDataC)
 	defer closer()

--- a/state/machine.go
+++ b/state/machine.go
@@ -279,14 +279,6 @@ func (m *Machine) HardwareCharacteristics() (*instance.HardwareCharacteristics, 
 	return hardwareCharacteristics(instData), nil
 }
 
-func (m *Machine) DisplayName() (string, error) {
-	instData, err := getInstanceData(m.st, m.Id())
-	if err != nil {
-		return "", err
-	}
-	return instData.DisplayName, nil
-}
-
 func getInstanceData(st *State, id string) (instanceData, error) {
 	instanceDataCollection, closer := st.db().GetCollection(instanceDataC)
 	defer closer()

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -454,16 +454,6 @@ func (e *exporter) loadMachineBlockDevices() (map[string][]BlockDeviceInfo, erro
 }
 
 func (e *exporter) newMachine(exParent description.Machine, machine *Machine, instances map[string]instanceData, portsData map[string]*machinePortRanges, blockDevices map[string][]BlockDeviceInfo) (description.Machine, error) {
-	// For machines that are assigned a displayName, we need to
-	// get their displayName from the instance (provisioner keeps
-	// it in db.instanceData (see state.Machine.SetProvisioned)
-	instData, found := instances[machine.doc.Id]
-
-	machineDisplayName := ""
-	if found {
-		machineDisplayName = instData.DisplayName
-	}
-
 	args := description.MachineArgs{
 		Id:            machine.MachineTag(),
 		Nonce:         machine.doc.Nonce,
@@ -471,7 +461,6 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 		Placement:     machine.doc.Placement,
 		Series:        machine.doc.Series,
 		ContainerType: machine.doc.ContainerType,
-		DisplayName:   machineDisplayName,
 	}
 
 	if supported, ok := machine.SupportedContainers(); ok {
@@ -504,6 +493,7 @@ func (e *exporter) newMachine(exParent description.Machine, machine *Machine, in
 	// We fully expect the machine to have tools set, and that there is
 	// some instance data.
 	if !e.cfg.SkipInstanceData {
+		instData, found := instances[machine.doc.Id]
 		if !found && !e.cfg.IgnoreIncompleteModel {
 			return nil, errors.NotValidf("missing instance data for machine %s", machine.Id())
 		}
@@ -627,7 +617,8 @@ func (e *exporter) newAddressArgs(a address) description.AddressArgs {
 
 func (e *exporter) newCloudInstanceArgs(data instanceData) description.CloudInstanceArgs {
 	inst := description.CloudInstanceArgs{
-		InstanceId: string(data.InstanceId),
+		InstanceId:  string(data.InstanceId),
+		DisplayName: data.DisplayName,
 	}
 	if data.Arch != nil {
 		inst.Architecture = *data.Arch

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -304,6 +304,7 @@ func (s *MigrationExportSuite) TestMachinesWithRootDiskSourceConstraint(c *gc.C)
 func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.Value) {
 	// Add a machine with an LXC container.
 	source := "vashti"
+	displayName := "test-display-name"
 
 	addr := network.NewSpaceAddress("1.1.1.1")
 	addr.SpaceID = "0"
@@ -313,7 +314,8 @@ func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.
 		Characteristics: &instance.HardwareCharacteristics{
 			RootDiskSource: &source,
 		},
-		Addresses: network.SpaceAddresses{addr},
+		DisplayName: displayName,
+		Addresses:   network.SpaceAddresses{addr},
 	})
 	nested := s.Factory.MakeMachineNested(c, machine1.Id(), nil)
 
@@ -365,6 +367,7 @@ func (s *MigrationExportSuite) assertMachinesMigrated(c *gc.C, cons constraints.
 	inst := exported.Instance()
 	c.Assert(inst.ModificationStatus().Value(), gc.Equals, "idle")
 	c.Assert(inst.RootDiskSource(), gc.Equals, "vashti")
+	c.Assert(inst.DisplayName(), gc.Equals, displayName)
 
 	c.Assert(exported.ProviderAddresses(), gc.HasLen, 1)
 	exAddr := exported.ProviderAddresses()[0]

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -568,19 +568,16 @@ func (i *importer) machinePortsOp(m description.Machine) txn.Op {
 
 func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudInstance) txn.Op {
 	doc := &instanceData{
-		DocID:      mdoc.DocID,
-		MachineId:  mdoc.Id,
-		InstanceId: instance.Id(inst.InstanceId()),
-		ModelUUID:  mdoc.ModelUUID,
+		DocID:       mdoc.DocID,
+		MachineId:   mdoc.Id,
+		InstanceId:  instance.Id(inst.InstanceId()),
+		DisplayName: inst.DisplayName(),
+		ModelUUID:   mdoc.ModelUUID,
 	}
 
 	if arch := inst.Architecture(); arch != "" {
 		doc.Arch = &arch
 	}
-	if displayName := inst.DisplayName(); displayName != "" {
-		doc.DisplayName = displayName
-	}
-
 	if mem := inst.Memory(); mem != 0 {
 		doc.Mem = &mem
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -568,16 +568,19 @@ func (i *importer) machinePortsOp(m description.Machine) txn.Op {
 
 func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudInstance) txn.Op {
 	doc := &instanceData{
-		DocID:       mdoc.DocID,
-		DisplayName: mdoc.DisplayName,
-		MachineId:   mdoc.Id,
-		InstanceId:  instance.Id(inst.InstanceId()),
-		ModelUUID:   mdoc.ModelUUID,
+		DocID:      mdoc.DocID,
+		MachineId:  mdoc.Id,
+		InstanceId: instance.Id(inst.InstanceId()),
+		ModelUUID:  mdoc.ModelUUID,
 	}
 
 	if arch := inst.Architecture(); arch != "" {
 		doc.Arch = &arch
 	}
+	if displayName := inst.DisplayName(); displayName != "" {
+		doc.DisplayName = displayName
+	}
+
 	if mem := inst.Memory(); mem != 0 {
 		doc.Mem = &mem
 	}
@@ -651,7 +654,6 @@ func (i *importer) makeMachineDoc(m description.Machine) (*machineDoc, error) {
 		SupportedContainersKnown: supportedSet,
 		SupportedContainers:      supportedContainers,
 		Placement:                m.Placement(),
-		DisplayName:              m.DisplayName(),
 	}, nil
 }
 

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -568,10 +568,11 @@ func (i *importer) machinePortsOp(m description.Machine) txn.Op {
 
 func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudInstance) txn.Op {
 	doc := &instanceData{
-		DocID:      mdoc.DocID,
-		MachineId:  mdoc.Id,
-		InstanceId: instance.Id(inst.InstanceId()),
-		ModelUUID:  mdoc.ModelUUID,
+		DocID:       mdoc.DocID,
+		DisplayName: mdoc.DisplayName,
+		MachineId:   mdoc.Id,
+		InstanceId:  instance.Id(inst.InstanceId()),
+		ModelUUID:   mdoc.ModelUUID,
 	}
 
 	if arch := inst.Architecture(); arch != "" {
@@ -650,6 +651,7 @@ func (i *importer) makeMachineDoc(m description.Machine) (*machineDoc, error) {
 		SupportedContainersKnown: supportedSet,
 		SupportedContainers:      supportedContainers,
 		Placement:                m.Placement(),
+		DisplayName:              m.DisplayName(),
 	}, nil
 }
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -340,16 +340,11 @@ func (s *MigrationImportSuite) AssertMachineEqual(c *gc.C, newMachine, oldMachin
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newStatus, jc.DeepEquals, oldStatus)
 
-	oldInstID, err := oldMachine.InstanceId()
+	oldInstID, oldInstDisplayName, err := oldMachine.InstanceNames()
 	c.Assert(err, jc.ErrorIsNil)
-	newInstID, err := newMachine.InstanceId()
+	newInstID, newInstDisplayName, err := newMachine.InstanceNames()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newInstID, gc.Equals, oldInstID)
-
-	oldInstDisplayName, err := oldMachine.DisplayName()
-	c.Assert(err, jc.ErrorIsNil)
-	newInstDisplayName, err := oldMachine.DisplayName()
-	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newInstDisplayName, gc.Equals, oldInstDisplayName)
 
 	oldStatus, err = oldMachine.InstanceStatus()

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -346,6 +346,12 @@ func (s *MigrationImportSuite) AssertMachineEqual(c *gc.C, newMachine, oldMachin
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newInstID, gc.Equals, oldInstID)
 
+	oldInstDisplayName, err := oldMachine.DisplayName()
+	c.Assert(err, jc.ErrorIsNil)
+	newInstDisplayName, err := oldMachine.DisplayName()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(newInstDisplayName, gc.Equals, oldInstDisplayName)
+
 	oldStatus, err = oldMachine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	newStatus, err = newMachine.InstanceStatus()
@@ -357,6 +363,7 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 	// Add a machine with an LXC container.
 	cons := constraints.MustParse("arch=amd64 mem=8G root-disk-source=bunyan")
 	source := "bunyan"
+	displayName := "test-display-name"
 
 	addr := network.NewSpaceAddress("1.1.1.1")
 	addr.SpaceID = "9"
@@ -366,7 +373,8 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 		Characteristics: &instance.HardwareCharacteristics{
 			RootDiskSource: &source,
 		},
-		Addresses: network.SpaceAddresses{addr},
+		DisplayName: displayName,
+		Addresses:   network.SpaceAddresses{addr},
 	})
 	err := s.Model.SetAnnotations(machine1, testAnnotations)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/mocks/description_mock.go
+++ b/state/mocks/description_mock.go
@@ -153,6 +153,14 @@ func (m *MockMachine) Id() string {
 	return ret0
 }
 
+// DisplayName mocks base method.
+func (m *MockMachine) DisplayName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisplayName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
 // Id indicates an expected call of Id.
 func (mr *MockMachineMockRecorder) Id() *gomock.Call {
 	mr.mock.ctrl.T.Helper()


### PR DESCRIPTION
#### Description

This allows the machines (usually provided by OCI or MAAS) to be able to transfer their `DisplayName` fields through a migration. 

Fixes:

 [LP #1954969](https://bugs.launchpad.net/juju/+bug/1954969).

Requires:

- [x] https://github.com/juju/description/pull/102 to land.
- [x] https://github.com/juju/juju/pull/13653 to land.

#### QA Steps

You'll need either Oracle OCI or MAAS controllers for this one. (Other providers don't use display name) 
I tested it with the OCI, like as follows (I used the compartment&tenancy ids from within the cloud-city):

```sh
juju bootstrap --config compartment-id=$OCID_COMPARTMENT oci-canonical oci-test-controller2

juju bootstrap --config compartment-id=$OCID_COMPARTMENT oci-canonical oci-test-controller1

juju add-model --config compartment-id=$OCID_COMPARTMENT test-model1

juju deploy ubuntu
```

Note the machine `Inst Id` in juju status, or do `db.instanceData.find().pretty()` in mongodb and look for the `display-name` field.

```sh
juju migrate test-model1 oci-test-controller2
```

1. Migration should be successful,
2. After the migration is complete you should be able to see the same id in the juju status or the db.


#### Notes & Discussion

This PR also includes temporary code that will be removed before the PR lands:

- go.mod for external changed dependency (description pkg), and
- provider/oci/environ.go for quick fix to allow the PR to run
