### PR TITLE
[JUJU-484] Stop polling external cmr controller when it is removed

### DIFF
--- a/api/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/api/externalcontrollerupdater/externalcontrollerupdater.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/watcher"
@@ -39,7 +40,8 @@ func (c *Client) WatchExternalControllers() (watcher.StringsWatcher, error) {
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return nil, result.Error
+		err := apiservererrors.RestoreError(result.Error)
+		return nil, errors.Trace(err)
 	}
 	w := apiwatcher.NewStringsWatcher(c.facade.RawAPICaller(), result)
 	return w, nil
@@ -64,7 +66,8 @@ func (c *Client) ExternalControllerInfo(controllerUUID string) (*crossmodel.Cont
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return nil, result.Error
+		err := apiservererrors.RestoreError(result.Error)
+		return nil, errors.Trace(err)
 	}
 	return &crossmodel.ControllerInfo{
 		ControllerTag: controllerTag,

--- a/api/externalcontrollerupdater/externalcontrollerupdater_test.go
+++ b/api/externalcontrollerupdater/externalcontrollerupdater_test.go
@@ -4,6 +4,7 @@
 package externalcontrollerupdater_test
 
 import (
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -65,14 +66,14 @@ func (s *ExternalControllerUpdaterSuite) TestExternalControllerInfoError(c *gc.C
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.ExternalControllerInfoResults)) = params.ExternalControllerInfoResults{
 			[]params.ExternalControllerInfoResult{{
-				Error: &params.Error{Message: "boom"},
+				Error: &params.Error{Code: params.CodeNotFound},
 			}},
 		}
 		return nil
 	})
 	client := externalcontrollerupdater.New(apiCaller)
 	info, err := client.ExternalControllerInfo(coretesting.ControllerTag.Id())
-	c.Assert(err, gc.ErrorMatches, "boom")
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(info, gc.IsNil)
 }
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2402,6 +2402,7 @@ func (api *APIBase) consumeOne(arg params.ConsumeApplicationArg) error {
 	}
 
 	// Maybe save the details of the controller hosting the offer.
+	var externalControllerUUID string
 	if arg.ControllerInfo != nil {
 		controllerTag, err := names.ParseControllerTag(arg.ControllerInfo.ControllerTag)
 		if err != nil {
@@ -2410,6 +2411,7 @@ func (api *APIBase) consumeOne(arg params.ConsumeApplicationArg) error {
 		// Only save controller details if the offer comes from
 		// a different controller.
 		if controllerTag.Id() != api.backend.ControllerTag().Id() {
+			externalControllerUUID = controllerTag.Id()
 			if _, err = api.backend.SaveController(crossmodel.ControllerInfo{
 				ControllerTag: controllerTag,
 				Alias:         arg.ControllerInfo.Alias,
@@ -2425,7 +2427,7 @@ func (api *APIBase) consumeOne(arg params.ConsumeApplicationArg) error {
 	if appName == "" {
 		appName = arg.OfferName
 	}
-	_, err = api.saveRemoteApplication(sourceModelTag, appName, arg.ApplicationOfferDetails, arg.Macaroon)
+	_, err = api.saveRemoteApplication(sourceModelTag, appName, externalControllerUUID, arg.ApplicationOfferDetails, arg.Macaroon)
 	return err
 }
 
@@ -2434,6 +2436,7 @@ func (api *APIBase) consumeOne(arg params.ConsumeApplicationArg) error {
 func (api *APIBase) saveRemoteApplication(
 	sourceModelTag names.ModelTag,
 	applicationName string,
+	externalControllerUUID string,
 	offer params.ApplicationOfferDetails,
 	mac *macaroon.Macaroon,
 ) (RemoteApplication, error) {
@@ -2473,14 +2476,15 @@ func (api *APIBase) saveRemoteApplication(
 	}
 
 	return api.backend.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:        applicationName,
-		OfferUUID:   offer.OfferUUID,
-		URL:         offer.OfferURL,
-		SourceModel: sourceModelTag,
-		Endpoints:   remoteEps,
-		Spaces:      remoteSpaces,
-		Bindings:    offer.Bindings,
-		Macaroon:    mac,
+		Name:                   applicationName,
+		OfferUUID:              offer.OfferUUID,
+		URL:                    offer.OfferURL,
+		ExternalControllerUUID: externalControllerUUID,
+		SourceModel:            sourceModelTag,
+		Endpoints:              remoteEps,
+		Spaces:                 remoteSpaces,
+		Bindings:               offer.Bindings,
+		Macaroon:               mac,
 	})
 }
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1644,11 +1644,12 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 	obtained, ok := s.backend.remoteApplications["hosted-mysql"]
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(obtained, jc.DeepEquals, &mockRemoteApplication{
-		name:           "hosted-mysql",
-		sourceModelTag: coretesting.ModelTag,
-		status:         status.Active,
-		offerUUID:      "hosted-mysql-uuid",
-		offerURL:       "othermodel.hosted-mysql",
+		name:                 "hosted-mysql",
+		sourceControllerUUID: controllerUUID,
+		sourceModelTag:       coretesting.ModelTag,
+		status:               status.Active,
+		offerUUID:            "hosted-mysql-uuid",
+		offerURL:             "othermodel.hosted-mysql",
 		endpoints: []state.Endpoint{
 			{ApplicationName: "hosted-mysql", Relation: charm.Relation{Name: "database", Interface: "mysql", Role: "provider"}}},
 		mac: mac,

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -314,16 +314,17 @@ func (m *mockApplication) MergeBindings(bindings *state.Bindings, force bool) er
 
 type mockRemoteApplication struct {
 	jtesting.Stub
-	name           string
-	life           state.Life
-	sourceModelTag names.ModelTag
-	endpoints      []state.Endpoint
-	bindings       map[string]string
-	spaces         []state.RemoteSpace
-	offerUUID      string
-	offerURL       string
-	status         status.Status
-	mac            *macaroon.Macaroon
+	name                 string
+	life                 state.Life
+	sourceControllerUUID string
+	sourceModelTag       names.ModelTag
+	endpoints            []state.Endpoint
+	bindings             map[string]string
+	spaces               []state.RemoteSpace
+	offerUUID            string
+	offerURL             string
+	status               status.Status
+	mac                  *macaroon.Macaroon
 }
 
 func (m *mockRemoteApplication) Name() string {
@@ -734,13 +735,14 @@ func (m *mockBackend) AddRemoteApplication(args state.AddRemoteApplicationParams
 		return nil, err
 	}
 	app := &mockRemoteApplication{
-		name:           args.Name,
-		sourceModelTag: args.SourceModel,
-		offerUUID:      args.OfferUUID,
-		offerURL:       args.URL,
-		bindings:       args.Bindings,
-		mac:            args.Macaroon,
-		status:         status.Active,
+		name:                 args.Name,
+		sourceControllerUUID: args.ExternalControllerUUID,
+		sourceModelTag:       args.SourceModel,
+		offerUUID:            args.OfferUUID,
+		offerURL:             args.URL,
+		bindings:             args.Bindings,
+		mac:                  args.Macaroon,
+		status:               status.Active,
 	}
 	for _, ep := range args.Endpoints {
 		app.endpoints = append(app.endpoints, state.Endpoint{

--- a/apiserver/facades/controller/crosscontroller/crosscontroller.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller.go
@@ -91,7 +91,11 @@ func (api *CrossControllerAPI) ControllerInfo() (params.ControllerAPIInfoResults
 		results.Results[0].Error = apiservererrors.ServerError(err)
 		return results, nil
 	}
-	results.Results[0].Addresses = append([]string{publicDNSAddress}, addrs...)
+	if publicDNSAddress == "" {
+		results.Results[0].Addresses = addrs
+	} else {
+		results.Results[0].Addresses = append([]string{publicDNSAddress}, addrs...)
+	}
 	results.Results[0].CACert = caCert
 	return results, nil
 }

--- a/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
@@ -26,6 +26,8 @@ type CrossControllerSuite struct {
 	localControllerInfo      func() ([]string, string, error)
 	watchLocalControllerInfo func() state.NotifyWatcher
 	api                      *crosscontroller.CrossControllerAPI
+
+	publicDnsAddress string
 }
 
 func (s *CrossControllerSuite) SetUpTest(c *gc.C) {
@@ -41,7 +43,7 @@ func (s *CrossControllerSuite) SetUpTest(c *gc.C) {
 	api, err := crosscontroller.NewCrossControllerAPI(
 		s.resources,
 		func() ([]string, string, error) { return s.localControllerInfo() },
-		func() (string, error) { return "publicDNSaddr", nil },
+		func() (string, error) { return s.publicDnsAddress, nil },
 		func() state.NotifyWatcher { return s.watchLocalControllerInfo() },
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -51,6 +53,18 @@ func (s *CrossControllerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CrossControllerSuite) TestControllerInfo(c *gc.C) {
+	results, err := s.api.ControllerInfo()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ControllerAPIInfoResults{
+		[]params.ControllerAPIInfoResult{{
+			Addresses: []string{"addr1", "addr2"},
+			CACert:    "ca-cert",
+		}},
+	})
+}
+
+func (s *CrossControllerSuite) TestControllerInfoWithDNSAddress(c *gc.C) {
+	s.publicDnsAddress = "publicDNSaddr"
 	results, err := s.api.ControllerInfo()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ControllerAPIInfoResults{

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -175,6 +175,14 @@ func ApplicationOffersRefCount(st *State, appName string) (int, error) {
 	return nsRefcounts.read(refcounts, key)
 }
 
+func ControllerRefCount(st *State, controllerUUID string) (int, error) {
+	refcounts, closer := st.db().GetCollection(globalRefcountsC)
+	defer closer()
+
+	key := externalControllerRefCountKey(controllerUUID)
+	return nsRefcounts.read(refcounts, key)
+}
+
 func AddTestingCharm(c *gc.C, st *State, name string) *Charm {
 	return addCharm(c, st, "quantal", testcharms.Repo.CharmDir(name))
 }

--- a/state/refcounts_ns.go
+++ b/state/refcounts_ns.go
@@ -69,7 +69,7 @@ func (ns nsRefcounts_) StrictCreateOp(coll mongo.Collection, key string, value i
 	return ns.JustCreateOp(coll.Name(), key, value), nil
 }
 
-// CreateOrIncrefOp returns a txn.Op that creates a refcount document as
+// CreateOrIncRefOp returns a txn.Op that creates a refcount document as
 // configured with a specified value; or increments any such refcount doc
 // that already exists.
 func (ns nsRefcounts_) CreateOrIncRefOp(coll mongo.Collection, key string, n int) (txn.Op, error) {

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -456,9 +456,10 @@ func (s *RelationSuite) TestDestroyCrossModelRelationAppTerminated(c *gc.C) {
 
 func (s *RelationSuite) TestForceDestroyCrossModelRelationOfferSide(c *gc.C) {
 	rwordpress, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:        "remote-wordpress",
-		SourceModel: names.NewModelTag("source-model"),
-		OfferUUID:   "offer-uuid",
+		Name:                   "remote-wordpress",
+		ExternalControllerUUID: "controller-uuid",
+		SourceModel:            names.NewModelTag("source-model"),
+		OfferUUID:              "offer-uuid",
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Limit:     1,
@@ -469,6 +470,9 @@ func (s *RelationSuite) TestForceDestroyCrossModelRelationOfferSide(c *gc.C) {
 		IsConsumerProxy: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	rc, err := state.ControllerRefCount(s.State, "controller-uuid")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rc, gc.Equals, 1)
 	wordpressEP, err := rwordpress.Endpoint("db")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -500,6 +504,8 @@ func (s *RelationSuite) TestForceDestroyCrossModelRelationOfferSide(c *gc.C) {
 	err = rel.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	err = rwordpress.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = state.ControllerRefCount(s.State, "controller-uuid")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	s.assertInScope(c, wpru, false)

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -33,19 +33,20 @@ type RemoteApplication struct {
 
 // remoteApplicationDoc represents the internal state of a remote application in MongoDB.
 type remoteApplicationDoc struct {
-	DocID           string              `bson:"_id"`
-	Name            string              `bson:"name"`
-	OfferUUID       string              `bson:"offer-uuid"`
-	URL             string              `bson:"url,omitempty"`
-	SourceModelUUID string              `bson:"source-model-uuid"`
-	Endpoints       []remoteEndpointDoc `bson:"endpoints"`
-	Spaces          []remoteSpaceDoc    `bson:"spaces"`
-	Bindings        map[string]string   `bson:"bindings"`
-	Life            Life                `bson:"life"`
-	RelationCount   int                 `bson:"relationcount"`
-	IsConsumerProxy bool                `bson:"is-consumer-proxy"`
-	Version         int                 `bson:"version"`
-	Macaroon        string              `bson:"macaroon,omitempty"`
+	DocID                string              `bson:"_id"`
+	Name                 string              `bson:"name"`
+	OfferUUID            string              `bson:"offer-uuid"`
+	URL                  string              `bson:"url,omitempty"`
+	SourceControllerUUID string              `bson:"source-controller-uuid"`
+	SourceModelUUID      string              `bson:"source-model-uuid"`
+	Endpoints            []remoteEndpointDoc `bson:"endpoints"`
+	Spaces               []remoteSpaceDoc    `bson:"spaces"`
+	Bindings             map[string]string   `bson:"bindings"`
+	Life                 Life                `bson:"life"`
+	RelationCount        int                 `bson:"relationcount"`
+	IsConsumerProxy      bool                `bson:"is-consumer-proxy"`
+	Version              int                 `bson:"version"`
+	Macaroon             string              `bson:"macaroon,omitempty"`
 }
 
 // remoteEndpointDoc represents the internal state of a remote application endpoint in MongoDB.
@@ -448,7 +449,10 @@ func (op *DestroyRemoteApplicationOperation) destroyOps() (ops []txn.Op, err err
 		if !forceTerminate {
 			hasLastRefs = bson.D{{"life", Alive}, {"relationcount", removeCount}}
 		}
-		removeOps := op.app.removeOps(hasLastRefs)
+		removeOps, err := op.app.removeOps(hasLastRefs)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		ops = append(ops, removeOps...)
 		return ops, nil
 	}
@@ -480,7 +484,7 @@ func (op *DestroyRemoteApplicationOperation) destroyOps() (ops []txn.Op, err err
 
 // removeOps returns the operations required to remove the application. Supplied
 // asserts will be included in the operation on the application document.
-func (s *RemoteApplication) removeOps(asserts bson.D) []txn.Op {
+func (s *RemoteApplication) removeOps(asserts bson.D) ([]txn.Op, error) {
 	r := s.st.RemoteEntities()
 	ops := []txn.Op{
 		{
@@ -493,7 +497,24 @@ func (s *RemoteApplication) removeOps(asserts bson.D) []txn.Op {
 	}
 	tokenOps := r.removeRemoteEntityOps(s.Tag())
 	ops = append(ops, tokenOps...)
-	return ops
+
+	// If this is the last consumed app off an external controller,
+	// also remove the external controller record.
+	if s.doc.SourceControllerUUID != "" {
+		decRefOp, isFinal, err := decExternalControllersRefOp(s.st, s.doc.SourceControllerUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops = append(ops, decRefOp)
+		if isFinal {
+			ops = append(ops, txn.Op{
+				C:      externalControllersC,
+				Id:     s.doc.SourceControllerUUID,
+				Remove: true,
+			})
+		}
+	}
+	return ops, nil
 }
 
 // Status returns the status of the remote application.
@@ -776,6 +797,10 @@ type AddRemoteApplicationParams struct {
 	// with on the hosting model.
 	URL string
 
+	// ExternalControllerUUID, if set, is the UUID of the controller other
+	// than this one, which is hosting the offer.
+	ExternalControllerUUID string
+
 	// SourceModel is the tag of the model to which the remote application belongs.
 	SourceModel names.ModelTag
 
@@ -867,16 +892,17 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 	}
 	// Create the application addition operations.
 	appDoc := &remoteApplicationDoc{
-		DocID:           applicationID,
-		Name:            args.Name,
-		OfferUUID:       args.OfferUUID,
-		SourceModelUUID: args.SourceModel.Id(),
-		URL:             args.URL,
-		Bindings:        args.Bindings,
-		Life:            Alive,
-		IsConsumerProxy: args.IsConsumerProxy,
-		Version:         version,
-		Macaroon:        macJSON,
+		DocID:                applicationID,
+		Name:                 args.Name,
+		OfferUUID:            args.OfferUUID,
+		SourceControllerUUID: args.ExternalControllerUUID,
+		SourceModelUUID:      args.SourceModel.Id(),
+		URL:                  args.URL,
+		Bindings:             args.Bindings,
+		Life:                 Alive,
+		IsConsumerProxy:      args.IsConsumerProxy,
+		Version:              version,
+		Macaroon:             macJSON,
 	}
 	eps := make([]remoteEndpointDoc, len(args.Endpoints))
 	for i, ep := range args.Endpoints {
@@ -958,6 +984,14 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		if args.Token != "" {
 			importRemoteEntityOps := st.RemoteEntities().importRemoteEntityOps(app.Tag(), args.Token)
 			ops = append(ops, importRemoteEntityOps...)
+		}
+
+		if args.ExternalControllerUUID != "" {
+			incRefOp, err := incExternalControllersRefOp(st, args.ExternalControllerUUID)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, incRefOp)
 		}
 		return ops, nil
 	}

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v2"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
@@ -22,13 +25,22 @@ import (
 
 type remoteApplicationSuite struct {
 	ConnSuite
-	application *state.RemoteApplication
+	application            *state.RemoteApplication
+	externalControllerUUID string
 }
 
 var _ = gc.Suite(&remoteApplicationSuite{})
 
 func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
+	s.externalControllerUUID = utils.MustNewUUID().String()
+	s.makeRemoteApplication(c, "mysql", "me/model.mysql")
+	rc, err := state.ControllerRefCount(s.State, s.externalControllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rc, gc.Equals, 1)
+}
+
+func (s *remoteApplicationSuite) makeRemoteApplication(c *gc.C, name, url string) {
 	eps := []charm.Relation{
 		{
 			Interface: "mysql",
@@ -95,14 +107,15 @@ func (s *remoteApplicationSuite) SetUpTest(c *gc.C) {
 	mac, err := newMacaroon("test")
 	c.Assert(err, jc.ErrorIsNil)
 	s.application, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:        "mysql",
-		URL:         "me/model.mysql",
-		SourceModel: s.Model.ModelTag(),
-		Token:       "app-token",
-		Endpoints:   eps,
-		Spaces:      spaces,
-		Bindings:    bindings,
-		Macaroon:    mac,
+		Name:                   name,
+		URL:                    url,
+		ExternalControllerUUID: s.externalControllerUUID,
+		SourceModel:            s.Model.ModelTag(),
+		Token:                  "app-token",
+		Endpoints:              eps,
+		Spaces:                 spaces,
+		Bindings:               bindings,
+		Macaroon:               mac,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -747,6 +760,51 @@ func (s *remoteApplicationSuite) TestDestroySimple(c *gc.C) {
 	c.Assert(s.application.Life(), gc.Equals, state.Dying)
 	err = s.application.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = state.ControllerRefCount(s.State, s.externalControllerUUID)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+}
+
+func (s *remoteApplicationSuite) TestDestroyRemovesExternalController(c *gc.C) {
+	ec := state.NewExternalControllers(s.State)
+	_, err := ec.Save(crossmodel.ControllerInfo{
+		ControllerTag: names.NewControllerTag(s.externalControllerUUID),
+		Addrs:         []string{"10.0.0.1:17070"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.application.Life(), gc.Equals, state.Dying)
+	err = s.application.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = state.ControllerRefCount(s.State, s.externalControllerUUID)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = ec.Controller(s.externalControllerUUID)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *remoteApplicationSuite) TestDestroyDoesNotRemoveExternalController(c *gc.C) {
+	s.makeRemoteApplication(c, "mariadb", "user/model.mariadb")
+	rc, err := state.ControllerRefCount(s.State, s.externalControllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rc, gc.Equals, 2)
+
+	ec := state.NewExternalControllers(s.State)
+	_, err = ec.Save(crossmodel.ControllerInfo{
+		ControllerTag: names.NewControllerTag(s.externalControllerUUID),
+		Addrs:         []string{"10.0.0.1:17070"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.application.Life(), gc.Equals, state.Dying)
+	err = s.application.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = ec.Controller(s.externalControllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	rc, err = state.ControllerRefCount(s.State, s.externalControllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rc, gc.Equals, 1)
 }
 
 func (s *remoteApplicationSuite) TestDestroyWithRemovableRelation(c *gc.C) {

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -102,6 +102,7 @@ type StateBackend interface {
 	MigrateLegacyCrossModelTokens() error
 	CleanupDeadAssignUnits() error
 	RemoveOrphanedLinkLayerDevices() error
+	UpdateExternalControllerInfo() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -442,4 +443,8 @@ func (s stateBackend) CleanupDeadAssignUnits() error {
 
 func (s stateBackend) RemoveOrphanedLinkLayerDevices() error {
 	return state.RemoveOrphanedLinkLayerDevices(s.pool)
+}
+
+func (s stateBackend) UpdateExternalControllerInfo() error {
+	return state.UpdateExternalControllerInfo(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -56,6 +56,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.19"), stateStepsFor2919()},
 		upgradeToVersion{version.MustParse("2.9.20"), stateStepsFor2920()},
 		upgradeToVersion{version.MustParse("2.9.22"), stateStepsFor2922()},
+		upgradeToVersion{version.MustParse("2.9.24"), stateStepsFor2924()},
 	}
 	return steps
 }

--- a/upgrades/steps_2924.go
+++ b/upgrades/steps_2924.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2924 returns database upgrade steps for Juju 2.9.24
+func stateStepsFor2924() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "update remote application external controller info",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().UpdateExternalControllerInfo()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2924_test.go
+++ b/upgrades/steps_2924_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2924 = version.MustParse("2.9.24")
+
+type steps2924Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2924Suite{})
+
+func (s *steps2924Suite) TestUpdateExternalControllerInfo(c *gc.C) {
+	step := findStateStep(c, v2924, "update remote application external controller info")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -645,6 +645,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.19",
 		"2.9.20",
 		"2.9.22",
+		"2.9.24",
 	})
 }
 


### PR DESCRIPTION
For offers host on a different controller, the consuming side needs to poll the controller to keep up to date with any API address changes. However, we weren't stopping the poll operation when all consuming apps were removed. And if the external controller was killed, the polling would fill the logs with errors.

This PR adds ref counting so that we track if an external controller record is still needed. Once all SAAS applications are removed, the external controller record is also deleted. A watcher in the polling worker causes the worker stop. To enabled the ref counting, the SAAS application gets a new attribute set to the external controller UUID. 

An upgrade step is added to set the new external controller UUID attribute on any relevant SAAS applications, and also remove any orphaned external controller records.

In the polling worker, the external controller connection is now done asynchronously to avoid blocking the worker from shutting down if the external controller is removed while the connection is being made. Error handling is also fixed to properly account for not found etc.

Another fix is that getting the api addresses for the external controller was incorrectly including an empty address if there was no public DNS name recorded.

## QA steps

bootstrap two earlier 2.9 controllers with logging for `juju.worker.externalcontrollerupdater` set to DEBUG
create a cross controller relation
upgrade the controllers
use mongo shell to check that the `source-countroller-uuid` is set for the remote application record on the consuming side
on the consuming side, run `juju remove-saas` to delete the consuming application
check log for `stopping watcher for external controller ...`
run `juju consume` to consume the offer again
check log for `starting watcher for external controller ...`

## Bug reference

https://bugs.launchpad.net/juju/+bug/1958446
