### PR TITLE
[JUJU-416] Consistantly use juju/retry to handle retries 5 (provider/ec2/*)

### DIFF
--- a/environs/testing/polling.go
+++ b/environs/testing/polling.go
@@ -92,7 +92,7 @@ func PatchAttemptStrategies(strategies ...*utils.AttemptStrategy) func() {
 	return internalPatchAttemptStrategies(combinedStrategies)
 }
 
-// TODO(jack-w-shaw): 2022-01-21: Implemnting funcs for both 'AttemptStrategy'
+// TODO(jack-w-shaw): 2022-01-21: Implementing funcs for both 'AttemptStrategy'
 // patching and 'RetryStrategy' patching whilst lp:1611427 is in progress
 //
 // Remove AttemptStrategy patching when they are no longer in use i.e. when
@@ -130,10 +130,14 @@ func restoreRetryStrategies(strategies []savedRetryStrategy) {
 	}
 }
 
-func PatchRetryStrategies(strategies ...*retry.CallArgs) func() {
+func internalPatchRetryStrategies(strategies []*retry.CallArgs) func() {
 	snapshot := saveRetryStrategies(strategies)
 	for _, strategy := range strategies {
 		*strategy = impatientRetryStrategy
 	}
 	return func() { restoreRetryStrategies(snapshot) }
+}
+
+func PatchRetryStrategies(strategies ...*retry.CallArgs) func() {
+	return internalPatchRetryStrategies(strategies)
 }

--- a/environs/testing/polling_test.go
+++ b/environs/testing/polling_test.go
@@ -7,6 +7,8 @@ import (
 	stdtesting "testing"
 	"time"
 
+	"github.com/juju/clock"
+	"github.com/juju/retry"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
@@ -110,4 +112,88 @@ func (*testingSuite) TestPatchAttemptStrategiesPatchesGivenAttempts(c *gc.C) {
 
 	c.Check(attempt1, gc.DeepEquals, impatientAttempt)
 	c.Check(attempt2, gc.DeepEquals, impatientAttempt)
+}
+
+// TODO(jack-w-shaw): 2022-01-21: Implementing funcs for both 'AttemptStrategy'
+// patching and 'RetryStrategy' patching whilst lp:1611427 is in progress
+//
+// Remove AttemptStrategy patching when they are no longer in use i.e. when
+// lp issue is resolved
+
+func (*testingSuite) TestSaveRetrytrategiesSaves(c *gc.C) {
+	retryStrategy := retry.CallArgs{
+		Clock:       clock.WallClock,
+		MaxDuration: time.Second,
+		Delay:       time.Millisecond,
+	}
+
+	snapshot := saveRetryStrategies([]*retry.CallArgs{&retryStrategy})
+
+	c.Assert(snapshot, gc.HasLen, 1)
+	c.Check(snapshot[0].address, gc.Equals, &retryStrategy)
+	c.Check(snapshot[0].original, gc.DeepEquals, retryStrategy)
+}
+
+func (*testingSuite) TestSaveRetryStrategiesLeavesOriginalsIntact(c *gc.C) {
+	original := retry.CallArgs{
+		Clock:       clock.WallClock,
+		MaxDuration: time.Second,
+		Delay:       time.Millisecond,
+	}
+	retryStrategy := original
+
+	saveRetryStrategies([]*retry.CallArgs{&retryStrategy})
+
+	c.Check(retryStrategy, gc.DeepEquals, original)
+}
+
+func (*testingSuite) TestInternalPatchRetryStrategiesPatches(c *gc.C) {
+	retryStrategy := retry.CallArgs{
+		Clock:       clock.WallClock,
+		MaxDuration: 33 * time.Millisecond,
+		Delay:       99 * time.Microsecond,
+	}
+	c.Assert(retryStrategy, gc.Not(gc.DeepEquals), impatientRetryStrategy)
+
+	internalPatchRetryStrategies([]*retry.CallArgs{&retryStrategy})
+
+	c.Check(retryStrategy, gc.DeepEquals, impatientRetryStrategy)
+}
+
+// internalPatchAttemptStrategies returns a cleanup function that restores
+// the given strategies to their original configurations.  For simplicity,
+// these tests take this as sufficient proof that any strategy that gets
+// patched, also gets restored by the cleanup function.
+func (*testingSuite) TestInternalPatchRetryStrategiesReturnsCleanup(c *gc.C) {
+	original := retry.CallArgs{
+		Clock:       clock.WallClock,
+		MaxDuration: 22 * time.Millisecond,
+		Delay:       77 * time.Microsecond,
+	}
+	c.Assert(original, gc.Not(gc.DeepEquals), impatientRetryStrategy)
+	retryStrategy := original
+
+	cleanup := internalPatchRetryStrategies([]*retry.CallArgs{&retryStrategy})
+	cleanup()
+
+	c.Check(retryStrategy, gc.DeepEquals, original)
+}
+
+func (*testingSuite) TestPatchRetryStrategiesPatchesGivenRetries(c *gc.C) {
+	retryStrategy1 := retry.CallArgs{
+		Clock:       clock.WallClock,
+		MaxDuration: 33 * time.Millisecond,
+		Delay:       99 * time.Microsecond,
+	}
+	retryStrategy2 := retry.CallArgs{
+		Clock:       clock.WallClock,
+		MaxDuration: 82 * time.Microsecond,
+		Delay:       62 * time.Nanosecond,
+	}
+
+	cleanup := PatchRetryStrategies(&retryStrategy1, &retryStrategy2)
+	defer cleanup()
+
+	c.Check(retryStrategy1, gc.DeepEquals, impatientRetryStrategy)
+	c.Check(retryStrategy2, gc.DeepEquals, impatientRetryStrategy)
 }

--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -69,7 +69,7 @@ var (
 	GetBlockDeviceMappings         = getBlockDeviceMappings
 	IsVPCNotUsableError            = isVPCNotUsableError
 	IsVPCNotRecommendedError       = isVPCNotRecommendedError
-	ShortAttempt                   = &shortAttempt
+	ShortRetryStrategy             = &shortRetryStrategy
 	DestroyVolumeAttempt           = &destroyVolumeAttempt
 	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
 	TerminateInstancesById         = &terminateInstancesById

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/os/v2/series"
+	"github.com/juju/retry"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/arch"
@@ -1701,6 +1702,7 @@ func (t *localServerSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 	inst, _ := testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "1")
 
 	infoLists, err := env.NetworkInterfaces(t.callCtx, []instance.Id{inst.Id(), instance.Id("bogus")})
+	c.Log(infoLists)
 	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
 	c.Assert(infoLists, gc.HasLen, 2)
 
@@ -2072,11 +2074,11 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 
 func patchEC2ForTesting(c *gc.C, region types.Region) func() {
 	ec2.UseTestImageData(c, ec2.MakeTestImageStreamsData(region))
-	restoreTimeouts := envtesting.PatchAttemptStrategies(ec2.ShortAttempt)
+	restoreRetryTimeouts := envtesting.PatchRetryStrategies(ec2.ShortRetryStrategy)
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
 	return func() {
 		restoreFinishBootstrap()
-		restoreTimeouts()
+		restoreRetryTimeouts()
 		ec2.UseTestImageData(c, nil)
 	}
 }
@@ -2409,20 +2411,22 @@ func (t *localServerSuite) TestStopInstances(c *gc.C) {
 	// We need the retry logic here because we are waiting
 	// for Instances to return an error, and it will not retry
 	// if it succeeds.
-	gone := false
-	for a := ec2.ShortAttempt.Start(); a.Next(); {
+	retryStrategy := ec2.ShortRetryStrategy
+	retryStrategy.Func = func() error {
 		insts, err = t.Env.Instances(t.callCtx, []instance.Id{inst0.Id(), inst2.Id()})
 		if err == environs.ErrPartialInstances {
 			// instances not gone yet.
-			continue
+			return err
 		}
 		if err == environs.ErrNoInstances {
-			gone = true
-			break
+			return nil
 		}
 		c.Fatalf("error getting instances: %v", err)
+		return errors.New(fmt.Sprintf("error getting instances: %v", err))
 	}
-	if !gone {
+	err = retry.Call(*retryStrategy)
+
+	if err != nil {
 		c.Errorf("after termination, instances remaining: %v", insts)
 	}
 }


### PR DESCRIPTION
Throughout Juju we have inconsistent ways of performing retries. Standardise all retry code to the repository github.com/juju/retry.

Replace occurrences of this old method of retries from the provider/ec2/ directory

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/provider/ec2
go test github.com/juju/juju/environs/testing
```

## Documentation changes

No documentation changes required

## Bug reference

https://bugs.launchpad.net/juju/+bug/1611427/
