### PR TITLE
[JUJU-464] Implement NetworkInterfaces method for openstack provider

### DIFF
--- a/provider/openstack/network_mock_test.go
+++ b/provider/openstack/network_mock_test.go
@@ -194,30 +194,30 @@ func (mr *MockNetworkingMockRecorder) Subnets(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNetworking)(nil).Subnets), arg0, arg1)
 }
 
-// MockNetworkingBase is a mock of NetworkingBase interface
+// MockNetworkingBase is a mock of NetworkingBase interface.
 type MockNetworkingBase struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetworkingBaseMockRecorder
 }
 
-// MockNetworkingBaseMockRecorder is the mock recorder for MockNetworkingBase
+// MockNetworkingBaseMockRecorder is the mock recorder for MockNetworkingBase.
 type MockNetworkingBaseMockRecorder struct {
 	mock *MockNetworkingBase
 }
 
-// NewMockNetworkingBase creates a new mock instance
+// NewMockNetworkingBase creates a new mock instance.
 func NewMockNetworkingBase(ctrl *gomock.Controller) *MockNetworkingBase {
 	mock := &MockNetworkingBase{ctrl: ctrl}
 	mock.recorder = &MockNetworkingBaseMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetworkingBase) EXPECT() *MockNetworkingBaseMockRecorder {
 	return m.recorder
 }
 
-// client mocks base method
+// client mocks base method.
 func (m *MockNetworkingBase) client() NetworkingAuthenticatingClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "client")
@@ -225,13 +225,13 @@ func (m *MockNetworkingBase) client() NetworkingAuthenticatingClient {
 	return ret0
 }
 
-// client indicates an expected call of client
+// client indicates an expected call of client.
 func (mr *MockNetworkingBaseMockRecorder) client() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "client", reflect.TypeOf((*MockNetworkingBase)(nil).client))
 }
 
-// ecfg mocks base method
+// ecfg mocks base method.
 func (m *MockNetworkingBase) ecfg() NetworkingEnvironConfig {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ecfg")
@@ -239,13 +239,13 @@ func (m *MockNetworkingBase) ecfg() NetworkingEnvironConfig {
 	return ret0
 }
 
-// ecfg indicates an expected call of ecfg
+// ecfg indicates an expected call of ecfg.
 func (mr *MockNetworkingBaseMockRecorder) ecfg() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ecfg", reflect.TypeOf((*MockNetworkingBase)(nil).ecfg))
 }
 
-// neutron mocks base method
+// neutron mocks base method.
 func (m *MockNetworkingBase) neutron() NetworkingNeutron {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "neutron")
@@ -253,13 +253,13 @@ func (m *MockNetworkingBase) neutron() NetworkingNeutron {
 	return ret0
 }
 
-// neutron indicates an expected call of neutron
+// neutron indicates an expected call of neutron.
 func (mr *MockNetworkingBaseMockRecorder) neutron() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "neutron", reflect.TypeOf((*MockNetworkingBase)(nil).neutron))
 }
 
-// nova mocks base method
+// nova mocks base method.
 func (m *MockNetworkingBase) nova() NetworkingNova {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "nova")
@@ -267,36 +267,36 @@ func (m *MockNetworkingBase) nova() NetworkingNova {
 	return ret0
 }
 
-// nova indicates an expected call of nova
+// nova indicates an expected call of nova.
 func (mr *MockNetworkingBaseMockRecorder) nova() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "nova", reflect.TypeOf((*MockNetworkingBase)(nil).nova))
 }
 
-// MockNetworkingNeutron is a mock of NetworkingNeutron interface
+// MockNetworkingNeutron is a mock of NetworkingNeutron interface.
 type MockNetworkingNeutron struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetworkingNeutronMockRecorder
 }
 
-// MockNetworkingNeutronMockRecorder is the mock recorder for MockNetworkingNeutron
+// MockNetworkingNeutronMockRecorder is the mock recorder for MockNetworkingNeutron.
 type MockNetworkingNeutronMockRecorder struct {
 	mock *MockNetworkingNeutron
 }
 
-// NewMockNetworkingNeutron creates a new mock instance
+// NewMockNetworkingNeutron creates a new mock instance.
 func NewMockNetworkingNeutron(ctrl *gomock.Controller) *MockNetworkingNeutron {
 	mock := &MockNetworkingNeutron{ctrl: ctrl}
 	mock.recorder = &MockNetworkingNeutronMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetworkingNeutron) EXPECT() *MockNetworkingNeutronMockRecorder {
 	return m.recorder
 }
 
-// AllocateFloatingIPV2 mocks base method
+// AllocateFloatingIPV2 mocks base method.
 func (m *MockNetworkingNeutron) AllocateFloatingIPV2(arg0 string) (*neutron.FloatingIPV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateFloatingIPV2", arg0)
@@ -305,13 +305,13 @@ func (m *MockNetworkingNeutron) AllocateFloatingIPV2(arg0 string) (*neutron.Floa
 	return ret0, ret1
 }
 
-// AllocateFloatingIPV2 indicates an expected call of AllocateFloatingIPV2
+// AllocateFloatingIPV2 indicates an expected call of AllocateFloatingIPV2.
 func (mr *MockNetworkingNeutronMockRecorder) AllocateFloatingIPV2(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateFloatingIPV2", reflect.TypeOf((*MockNetworkingNeutron)(nil).AllocateFloatingIPV2), arg0)
 }
 
-// CreatePortV2 mocks base method
+// CreatePortV2 mocks base method.
 func (m *MockNetworkingNeutron) CreatePortV2(arg0 neutron.PortV2) (*neutron.PortV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePortV2", arg0)
@@ -320,13 +320,13 @@ func (m *MockNetworkingNeutron) CreatePortV2(arg0 neutron.PortV2) (*neutron.Port
 	return ret0, ret1
 }
 
-// CreatePortV2 indicates an expected call of CreatePortV2
+// CreatePortV2 indicates an expected call of CreatePortV2.
 func (mr *MockNetworkingNeutronMockRecorder) CreatePortV2(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePortV2", reflect.TypeOf((*MockNetworkingNeutron)(nil).CreatePortV2), arg0)
 }
 
-// DeletePortV2 mocks base method
+// DeletePortV2 mocks base method.
 func (m *MockNetworkingNeutron) DeletePortV2(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePortV2", arg0)
@@ -334,13 +334,13 @@ func (m *MockNetworkingNeutron) DeletePortV2(arg0 string) error {
 	return ret0
 }
 
-// DeletePortV2 indicates an expected call of DeletePortV2
+// DeletePortV2 indicates an expected call of DeletePortV2.
 func (mr *MockNetworkingNeutronMockRecorder) DeletePortV2(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePortV2", reflect.TypeOf((*MockNetworkingNeutron)(nil).DeletePortV2), arg0)
 }
 
-// GetNetworkV2 mocks base method
+// GetNetworkV2 mocks base method.
 func (m *MockNetworkingNeutron) GetNetworkV2(arg0 string) (*neutron.NetworkV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetworkV2", arg0)
@@ -349,13 +349,13 @@ func (m *MockNetworkingNeutron) GetNetworkV2(arg0 string) (*neutron.NetworkV2, e
 	return ret0, ret1
 }
 
-// GetNetworkV2 indicates an expected call of GetNetworkV2
+// GetNetworkV2 indicates an expected call of GetNetworkV2.
 func (mr *MockNetworkingNeutronMockRecorder) GetNetworkV2(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkV2", reflect.TypeOf((*MockNetworkingNeutron)(nil).GetNetworkV2), arg0)
 }
 
-// ListFloatingIPsV2 mocks base method
+// ListFloatingIPsV2 mocks base method.
 func (m *MockNetworkingNeutron) ListFloatingIPsV2(arg0 ...*neutron.Filter) ([]neutron.FloatingIPV2, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -368,13 +368,13 @@ func (m *MockNetworkingNeutron) ListFloatingIPsV2(arg0 ...*neutron.Filter) ([]ne
 	return ret0, ret1
 }
 
-// ListFloatingIPsV2 indicates an expected call of ListFloatingIPsV2
+// ListFloatingIPsV2 indicates an expected call of ListFloatingIPsV2.
 func (mr *MockNetworkingNeutronMockRecorder) ListFloatingIPsV2(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFloatingIPsV2", reflect.TypeOf((*MockNetworkingNeutron)(nil).ListFloatingIPsV2), arg0...)
 }
 
-// ListNetworksV2 mocks base method
+// ListNetworksV2 mocks base method.
 func (m *MockNetworkingNeutron) ListNetworksV2(arg0 ...*neutron.Filter) ([]neutron.NetworkV2, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -387,13 +387,32 @@ func (m *MockNetworkingNeutron) ListNetworksV2(arg0 ...*neutron.Filter) ([]neutr
 	return ret0, ret1
 }
 
-// ListNetworksV2 indicates an expected call of ListNetworksV2
+// ListNetworksV2 indicates an expected call of ListNetworksV2.
 func (mr *MockNetworkingNeutronMockRecorder) ListNetworksV2(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNetworksV2", reflect.TypeOf((*MockNetworkingNeutron)(nil).ListNetworksV2), arg0...)
 }
 
-// ListSubnetsV2 mocks base method
+// ListPortsV2 mocks base method.
+func (m *MockNetworkingNeutron) ListPortsV2(arg0 ...*neutron.Filter) ([]neutron.PortV2, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListPortsV2", varargs...)
+	ret0, _ := ret[0].([]neutron.PortV2)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPortsV2 indicates an expected call of ListPortsV2.
+func (mr *MockNetworkingNeutronMockRecorder) ListPortsV2(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPortsV2", reflect.TypeOf((*MockNetworkingNeutron)(nil).ListPortsV2), arg0...)
+}
+
+// ListSubnetsV2 mocks base method.
 func (m *MockNetworkingNeutron) ListSubnetsV2() ([]neutron.SubnetV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSubnetsV2")
@@ -402,36 +421,36 @@ func (m *MockNetworkingNeutron) ListSubnetsV2() ([]neutron.SubnetV2, error) {
 	return ret0, ret1
 }
 
-// ListSubnetsV2 indicates an expected call of ListSubnetsV2
+// ListSubnetsV2 indicates an expected call of ListSubnetsV2.
 func (mr *MockNetworkingNeutronMockRecorder) ListSubnetsV2() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubnetsV2", reflect.TypeOf((*MockNetworkingNeutron)(nil).ListSubnetsV2))
 }
 
-// MockNetworkingAuthenticatingClient is a mock of NetworkingAuthenticatingClient interface
+// MockNetworkingAuthenticatingClient is a mock of NetworkingAuthenticatingClient interface.
 type MockNetworkingAuthenticatingClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetworkingAuthenticatingClientMockRecorder
 }
 
-// MockNetworkingAuthenticatingClientMockRecorder is the mock recorder for MockNetworkingAuthenticatingClient
+// MockNetworkingAuthenticatingClientMockRecorder is the mock recorder for MockNetworkingAuthenticatingClient.
 type MockNetworkingAuthenticatingClientMockRecorder struct {
 	mock *MockNetworkingAuthenticatingClient
 }
 
-// NewMockNetworkingAuthenticatingClient creates a new mock instance
+// NewMockNetworkingAuthenticatingClient creates a new mock instance.
 func NewMockNetworkingAuthenticatingClient(ctrl *gomock.Controller) *MockNetworkingAuthenticatingClient {
 	mock := &MockNetworkingAuthenticatingClient{ctrl: ctrl}
 	mock.recorder = &MockNetworkingAuthenticatingClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetworkingAuthenticatingClient) EXPECT() *MockNetworkingAuthenticatingClientMockRecorder {
 	return m.recorder
 }
 
-// TenantId mocks base method
+// TenantId mocks base method.
 func (m *MockNetworkingAuthenticatingClient) TenantId() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TenantId")
@@ -439,36 +458,36 @@ func (m *MockNetworkingAuthenticatingClient) TenantId() string {
 	return ret0
 }
 
-// TenantId indicates an expected call of TenantId
+// TenantId indicates an expected call of TenantId.
 func (mr *MockNetworkingAuthenticatingClientMockRecorder) TenantId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantId", reflect.TypeOf((*MockNetworkingAuthenticatingClient)(nil).TenantId))
 }
 
-// MockNetworkingNova is a mock of NetworkingNova interface
+// MockNetworkingNova is a mock of NetworkingNova interface.
 type MockNetworkingNova struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetworkingNovaMockRecorder
 }
 
-// MockNetworkingNovaMockRecorder is the mock recorder for MockNetworkingNova
+// MockNetworkingNovaMockRecorder is the mock recorder for MockNetworkingNova.
 type MockNetworkingNovaMockRecorder struct {
 	mock *MockNetworkingNova
 }
 
-// NewMockNetworkingNova creates a new mock instance
+// NewMockNetworkingNova creates a new mock instance.
 func NewMockNetworkingNova(ctrl *gomock.Controller) *MockNetworkingNova {
 	mock := &MockNetworkingNova{ctrl: ctrl}
 	mock.recorder = &MockNetworkingNovaMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetworkingNova) EXPECT() *MockNetworkingNovaMockRecorder {
 	return m.recorder
 }
 
-// GetServer mocks base method
+// GetServer mocks base method.
 func (m *MockNetworkingNova) GetServer(arg0 string) (*nova.ServerDetail, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServer", arg0)
@@ -477,36 +496,36 @@ func (m *MockNetworkingNova) GetServer(arg0 string) (*nova.ServerDetail, error) 
 	return ret0, ret1
 }
 
-// GetServer indicates an expected call of GetServer
+// GetServer indicates an expected call of GetServer.
 func (mr *MockNetworkingNovaMockRecorder) GetServer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServer", reflect.TypeOf((*MockNetworkingNova)(nil).GetServer), arg0)
 }
 
-// MockNetworkingEnvironConfig is a mock of NetworkingEnvironConfig interface
+// MockNetworkingEnvironConfig is a mock of NetworkingEnvironConfig interface.
 type MockNetworkingEnvironConfig struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetworkingEnvironConfigMockRecorder
 }
 
-// MockNetworkingEnvironConfigMockRecorder is the mock recorder for MockNetworkingEnvironConfig
+// MockNetworkingEnvironConfigMockRecorder is the mock recorder for MockNetworkingEnvironConfig.
 type MockNetworkingEnvironConfigMockRecorder struct {
 	mock *MockNetworkingEnvironConfig
 }
 
-// NewMockNetworkingEnvironConfig creates a new mock instance
+// NewMockNetworkingEnvironConfig creates a new mock instance.
 func NewMockNetworkingEnvironConfig(ctrl *gomock.Controller) *MockNetworkingEnvironConfig {
 	mock := &MockNetworkingEnvironConfig{ctrl: ctrl}
 	mock.recorder = &MockNetworkingEnvironConfigMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNetworkingEnvironConfig) EXPECT() *MockNetworkingEnvironConfigMockRecorder {
 	return m.recorder
 }
 
-// externalNetwork mocks base method
+// externalNetwork mocks base method.
 func (m *MockNetworkingEnvironConfig) externalNetwork() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "externalNetwork")
@@ -514,13 +533,13 @@ func (m *MockNetworkingEnvironConfig) externalNetwork() string {
 	return ret0
 }
 
-// externalNetwork indicates an expected call of externalNetwork
+// externalNetwork indicates an expected call of externalNetwork.
 func (mr *MockNetworkingEnvironConfigMockRecorder) externalNetwork() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "externalNetwork", reflect.TypeOf((*MockNetworkingEnvironConfig)(nil).externalNetwork))
 }
 
-// network mocks base method
+// network mocks base method.
 func (m *MockNetworkingEnvironConfig) network() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "network")
@@ -528,7 +547,7 @@ func (m *MockNetworkingEnvironConfig) network() string {
 	return ret0
 }
 
-// network indicates an expected call of network
+// network indicates an expected call of network.
 func (mr *MockNetworkingEnvironConfigMockRecorder) network() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "network", reflect.TypeOf((*MockNetworkingEnvironConfig)(nil).network))

--- a/provider/openstack/networking_interfaces.go
+++ b/provider/openstack/networking_interfaces.go
@@ -76,6 +76,7 @@ type NetworkingNeutron interface {
 	AllocateFloatingIPV2(string) (*neutron.FloatingIPV2, error)
 	CreatePortV2(neutron.PortV2) (*neutron.PortV2, error)
 	DeletePortV2(string) error
+	ListPortsV2(filter ...*neutron.Filter) ([]neutron.PortV2, error)
 	GetNetworkV2(string) (*neutron.NetworkV2, error)
 	ListFloatingIPsV2(...*neutron.Filter) ([]neutron.FloatingIPV2, error)
 	ListNetworksV2(...*neutron.Filter) ([]neutron.NetworkV2, error)


### PR DESCRIPTION
This PR implements the NetworkInterfaces call for the openstack provider.

The implementation works in batch mode but as goose (at least the version that Juju is importing) does not support filtering by device ID, the provider pulls the NIC details for all devices and filters by instance ID on the client-side.

Once this PR and #13634 land, we will finally be able to remove the fallback fake instance generation logic from the instancepoller worker.

NOTE: this PR is based on top of #13634 and will be rebased/re-targeted once that one lands.

## QA steps

```console
$ sudo snap install microstack --edge
$ sudo microstack init --auto --control

$ OS_SERIES=bionic
$ IMAGE_ID=$(curl \
   http://cloud-images.ubuntu.com/$OS_SERIES/current/$OS_SERIES-server-cloudimg-amd64.img | \
   microstack.openstack image create \
   --public --container-format=bare --disk-format=qcow2 \
   -f value -c id $OS_SERIES)

$ mkdir -p ~/simplestreams
$ OS_REGION=microstack
$ KEYSTONE_URL=$(cat /var/snap/microstack/common/etc/microstack.rc| grep OS_AUTH_URL | cut -d'=' -f2)
$ juju metadata generate-image -d ~/simplestreams -i $IMAGE_ID -s $OS_SERIES -r $OS_REGION -u $KEYSTONE_URL

$ cat > microstack-cloud.yaml << EOF
clouds:
    microstack:
      type: openstack
      auth-types: [access-key,userpass]
      regions:
        microstack:
           endpoint: ${KEYSTONE_URL}
      ca-certificates:
      - |
$(cat /var/snap/microstack/common/etc/ssl/certs/cacert.pem | sed -e 's/^/        /g')
EOF

$ juju add-cloud --client -f microstack-cloud.yaml

$ source /var/snap/microstack/common/etc/microstack.rc

$ juju autoload-credentials --client openstack

Looking for cloud and credential information on local client...

1. openstack region "<unspecified>" project "admin" user "admin" (existing, will overwrite)
Select a credential to save by number, or type Q to quit: 1

Select the cloud it belongs to, or type Q to quit [microstack]: Q

$ juju bootstrap --bootstrap-series=$OS_SERIES \
  --metadata-source=~/simplestreams \
  --model-default network=test \
  --model-default external-network=external \
  --model-default use-floating-ip=true \
  microstack microstack
```

Wait a few moments for the instancepoller to make its pass and check the logs to ensure that it correctly detects the private IP address for the controller (and other machines).