### PR TITLE
[JUJU-481] Remove fake NIC generation fallback logic from instancepoller worker

### DIFF
--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -174,19 +174,6 @@ func (a *InstancePollerAPI) SetProviderNetworkConfig(
 		result.Results[i].Modified = modified
 		result.Results[i].Addresses = params.FromProviderAddresses(newProviderAddrs...)
 
-		// If the input network configuration has addresses on devices without
-		// names or hardware addresses, it ws probably created by the
-		// instance-poller worker using fakeInterfacesFromInstanceAddrs.
-		// If this is the case we don't want to attempt an update of link-layer
-		// devices - we've done what we need to do above by updating addresses
-		// in the machines collection.
-		// TODO (manadart 2022-01-17): If we implement NetworkInterfaces for
-		// all providers, we can remove the fallback method in the worker,
-		// and this contingency.
-		if !containsDeviceConfig(configs) {
-			continue
-		}
-
 		// Treat errors as transient; the purpose of this API
 		// method is to simply update the provider addresses.
 		if err := a.mergeLinkLayer(machine, params.InterfaceInfoFromNetworkConfig(configs)); err != nil {
@@ -205,17 +192,6 @@ func maybeUpdateMachineProviderAddresses(m StateMachine, newSpaceAddrs network.S
 	}
 
 	return true, m.SetProviderAddresses(newSpaceAddrs...)
-}
-
-// containsDeviceConfig returns true if the incoming configuration has devices
-// with names or hardware addresses.
-func containsDeviceConfig(configs []params.NetworkConfig) bool {
-	for _, cfg := range configs {
-		if !(cfg.InterfaceName == "" && cfg.MACAddress == "") {
-			return true
-		}
-	}
-	return false
 }
 
 func (a *InstancePollerAPI) mergeLinkLayer(m StateMachine, devs network.InterfaceInfos) error {

--- a/apiserver/facades/controller/instancepoller/instancepoller_test.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller_test.go
@@ -850,19 +850,6 @@ func (s *InstancePollerSuite) TestSetProviderNetworkConfigSuccess(c *gc.C) {
 		makeSpaceAddress("192.168.0.1", network.ScopeCloudLocal, network.AlphaSpaceId),
 		makeSpaceAddress("1.1.1.42", network.ScopePublic, network.AlphaSpaceId),
 	})
-
-	// The addresses were supplied against devices without names or hardware
-	// addresses. This should cause us to update the machine provider addresses
-	// (verified above), but not to attempt to update link-layer device
-	// addresses.
-	var buildCalled bool
-	for _, call := range s.st.Calls() {
-		if call.FuncName == "ApplyOperation.Build" {
-			buildCalled = true
-			break
-		}
-	}
-	c.Assert(buildCalled, jc.IsFalse)
 }
 
 func (s *InstancePollerSuite) TestSetProviderNetworkConfigNoChange(c *gc.C) {

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -368,11 +368,11 @@ func (u *updaterWorker) pollGroupMembers(groupType pollGroupType) error {
 		// the exception of "manual" which we don't care about in this
 		// context) implement the NetworkInterfaces method.
 		//
-		// This check is left in as a warning for folks working on new
-		// providers in the future to make sure this feature is implemented.
+		// This error is meant as a hint to folks working on new
+		// providers in the future to ensure that they implement this
+		// method.
 		if errors.IsNotSupported(errors.Cause(err)) {
-			u.config.Logger.Warningf("substrate does not implement the required NetworkInterfaces method")
-			return nil
+			return errors.Errorf("BUG: substrate does not implement required NetworkInterfaces method")
 		}
 
 		return errors.Annotate(err, "enumerating network interface list for instances")


### PR DESCRIPTION
Now that all Juju providers (except manual) implement the
NetworkInterfaces method we can finally remove the fallback logic within
the instancepoller worker that would otherwise generate a list of fake
NICs to emulate the output of NetworkInterfaces.

The prior logic has been replaced with a check that outputs a warning to
the logs if the instancepoller ever encounters a provider that does not
implement this method. This is meant as a hint to folks working on
adding support for new providers in the future that they must implement
the method.

Note that the instancepoller ignores manual machines so this particular
call does not need to be implemented for that provider.

NOTE: this PR should not be merged until #13648 merges.
