### PR TITLE
[JUJU-485] Add per controller and per app limits for downloading resources

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -108,6 +108,10 @@ type Server struct {
 	agentRateLimitRate time.Duration
 	agentRateLimit     *ratelimit.Bucket
 
+	// resourceLock is used to limit the number of
+	// concurrent resource downloads to units.
+	resourceLock resourceadapters.ResourceDownloadLock
+
 	// registerIntrospectionHandlers is a function that will
 	// call a function with (path, http.Handler) tuples. This
 	// is to support registering the handlers underneath the
@@ -331,6 +335,7 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 		healthStatus: "starting",
 	}
 	srv.updateAgentRateLimiter(controllerConfig)
+	srv.updateResourceDownloadLimiters(controllerConfig)
 
 	// We are able to get the current controller config before subscribing to changes
 	// because the changes are only ever published in response to an API call,
@@ -343,6 +348,7 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 				return
 			}
 			srv.updateAgentRateLimiter(data.Config)
+			srv.updateResourceDownloadLimiters(data.Config)
 		})
 	if err != nil {
 		logger.Criticalf("programming error in subscribe function: %v", err)
@@ -469,6 +475,20 @@ func (srv *Server) updateAgentRateLimiter(cfg controller.Config) {
 	} else {
 		srv.agentRateLimit = nil
 	}
+}
+
+func (srv *Server) updateResourceDownloadLimiters(cfg controller.Config) {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	globalLimit := cfg.ControllerResourceDownloadLimit()
+	appLimit := cfg.ApplicationResourceDownloadLimit()
+	srv.resourceLock = resourceadapters.NewResourceDownloadLimiter(globalLimit, appLimit)
+}
+
+func (srv *Server) getResourceDownloadLimiter() resourceadapters.ResourceDownloadLock {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	return srv.resourceLock
 }
 
 type rateClock struct {
@@ -712,7 +732,8 @@ func (srv *Server) endpoints() []apihttp.Endpoint {
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
-			opener, err := resourceadapters.NewResourceOpener(resourceadapters.NewResourceOpenerState(st.State), tag.Id())
+			opener, err := resourceadapters.NewResourceOpener(
+				resourceadapters.NewResourceOpenerState(st.State), srv.getResourceDownloadLimiter, tag.Id())
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}

--- a/controller/config.go
+++ b/controller/config.go
@@ -49,6 +49,17 @@ const (
 	// ControllerName is the canonical name for the controller
 	ControllerName = "controller-name"
 
+	// ApplicationResourceDownloadLimit limits the number of concurrent resource download
+	// requests from unit agents which will be served. The limit is per application.
+	// Use a value of 0 to disable the limit.
+	ApplicationResourceDownloadLimit = "application-resource-download-limit"
+
+	// ControllerResourceDownloadLimit limits the number of concurrent resource download
+	// requests from unit agents which will be served. The limit is for the combined total
+	// of all applications on the controller.
+	// Use a value of 0 to disable the limit.
+	ControllerResourceDownloadLimit = "controller-resource-download-limit"
+
 	// AgentRateLimitMax is the maximum size of the token bucket used to
 	// ratelimit the agent connections.
 	AgentRateLimitMax = "agent-ratelimit-max"
@@ -248,6 +259,14 @@ const (
 
 	// Attribute Defaults
 
+	// DefaultApplicationResourceDownloadLimit allows unlimited
+	// resource download requests initiated by a unit agent per application.
+	DefaultApplicationResourceDownloadLimit = 0
+
+	// DefaultControllerResourceDownloadLimit allows unlimited concurrent resource
+	// download requests initiated by unit agents for any application on the controller.
+	DefaultControllerResourceDownloadLimit = 0
+
 	// DefaultAgentRateLimitMax allows the first 10 agents to connect without
 	// any issue. After that the rate limiting kicks in.
 	DefaultAgentRateLimitMax = 10
@@ -406,6 +425,8 @@ var (
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
 		MigrationMinionWaitMax,
+		ApplicationResourceDownloadLimit,
+		ControllerResourceDownloadLimit,
 	}
 
 	// For backwards compatibility, we must include "anything", "juju-apiserver"
@@ -451,6 +472,8 @@ var (
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
 		MigrationMinionWaitMax,
+		ApplicationResourceDownloadLimit,
+		ControllerResourceDownloadLimit,
 	)
 
 	// DefaultAuditLogExcludeMethods is the default list of methods to
@@ -599,6 +622,35 @@ func (c Config) ControllerAPIPort() int {
 	// will be 0, which is what we want here.
 	value, _ := c[ControllerAPIPort].(int)
 	return value
+}
+
+// ApplicationResourceDownloadLimit limits the number of concurrent resource download
+// requests from unit agents which will be served. The limit is per application.
+func (c Config) ApplicationResourceDownloadLimit() int {
+	switch v := c[ApplicationResourceDownloadLimit].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		// nil type shows up here
+	}
+	return DefaultApplicationResourceDownloadLimit
+}
+
+// ControllerResourceDownloadLimit limits the number of concurrent resource download
+// requests from unit agents which will be served. The limit is for the combined total
+// of all applications on the controller.
+func (c Config) ControllerResourceDownloadLimit() int {
+	switch v := c[ControllerResourceDownloadLimit].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		// nil type shows up here
+	}
+	return DefaultControllerResourceDownloadLimit
 }
 
 // AgentRateLimitMax is the initial size of the token bucket that is used to
@@ -995,6 +1047,16 @@ func Validate(c Config) error {
 		return errors.Errorf("controller-uuid: expected UUID, got string(%q)", uuid)
 	}
 
+	if v, ok := c[ApplicationResourceDownloadLimit].(int); ok {
+		if v < 0 {
+			return errors.Errorf("negative %s (%d) not valid, use 0 to disable the limit", ApplicationResourceDownloadLimit, v)
+		}
+	}
+	if v, ok := c[ControllerResourceDownloadLimit].(int); ok {
+		if v < 0 {
+			return errors.Errorf("negative %s (%d) not valid, use 0 to disable the limit", ControllerResourceDownloadLimit, v)
+		}
+	}
 	if v, ok := c[AgentRateLimitMax].(int); ok {
 		if v < 0 {
 			return errors.NotValidf("negative %s (%d)", AgentRateLimitMax, v)
@@ -1237,98 +1299,110 @@ func (c Config) AsSpaceConstraints(spaces *[]string) *[]string {
 }
 
 var configChecker = schema.FieldMap(schema.Fields{
-	AgentRateLimitMax:        schema.ForceInt(),
-	AgentRateLimitRate:       schema.TimeDuration(),
-	AuditingEnabled:          schema.Bool(),
-	AuditLogCaptureArgs:      schema.Bool(),
-	AuditLogMaxSize:          schema.String(),
-	AuditLogMaxBackups:       schema.ForceInt(),
-	AuditLogExcludeMethods:   schema.List(schema.String()),
-	APIPort:                  schema.ForceInt(),
-	APIPortOpenDelay:         schema.String(),
-	ControllerAPIPort:        schema.ForceInt(),
-	ControllerName:           schema.String(),
-	StatePort:                schema.ForceInt(),
-	IdentityURL:              schema.String(),
-	IdentityPublicKey:        schema.String(),
-	SetNUMAControlPolicyKey:  schema.Bool(),
-	AutocertURLKey:           schema.String(),
-	AutocertDNSNameKey:       schema.String(),
-	AllowModelAccessKey:      schema.Bool(),
-	MongoMemoryProfile:       schema.String(),
-	JujuDBSnapChannel:        schema.String(),
-	MaxDebugLogDuration:      schema.TimeDuration(),
-	MaxTxnLogSize:            schema.String(),
-	MaxPruneTxnBatchSize:     schema.ForceInt(),
-	MaxPruneTxnPasses:        schema.ForceInt(),
-	AgentLogfileMaxBackups:   schema.ForceInt(),
-	AgentLogfileMaxSize:      schema.String(),
-	ModelLogfileMaxBackups:   schema.ForceInt(),
-	ModelLogfileMaxSize:      schema.String(),
-	ModelLogsSize:            schema.String(),
-	PruneTxnQueryCount:       schema.ForceInt(),
-	PruneTxnSleepTime:        schema.String(),
-	PublicDNSAddress:         schema.String(),
-	JujuHASpace:              schema.String(),
-	JujuManagementSpace:      schema.String(),
-	CAASOperatorImagePath:    schema.String(),
-	CAASImageRepo:            schema.String(),
-	Features:                 schema.List(schema.String()),
-	CharmStoreURL:            schema.String(),
-	MeteringURL:              schema.String(),
-	MaxCharmStateSize:        schema.ForceInt(),
-	MaxAgentStateSize:        schema.ForceInt(),
-	NonSyncedWritesToRaftLog: schema.Bool(),
-	MigrationMinionWaitMax:   schema.String(),
+	AgentRateLimitMax:                schema.ForceInt(),
+	AgentRateLimitRate:               schema.TimeDuration(),
+	AuditingEnabled:                  schema.Bool(),
+	AuditLogCaptureArgs:              schema.Bool(),
+	AuditLogMaxSize:                  schema.String(),
+	AuditLogMaxBackups:               schema.ForceInt(),
+	AuditLogExcludeMethods:           schema.List(schema.String()),
+	APIPort:                          schema.ForceInt(),
+	APIPortOpenDelay:                 schema.String(),
+	ControllerAPIPort:                schema.ForceInt(),
+	ControllerName:                   schema.String(),
+	StatePort:                        schema.ForceInt(),
+	IdentityURL:                      schema.String(),
+	IdentityPublicKey:                schema.String(),
+	SetNUMAControlPolicyKey:          schema.Bool(),
+	AutocertURLKey:                   schema.String(),
+	AutocertDNSNameKey:               schema.String(),
+	AllowModelAccessKey:              schema.Bool(),
+	MongoMemoryProfile:               schema.String(),
+	JujuDBSnapChannel:                schema.String(),
+	MaxDebugLogDuration:              schema.TimeDuration(),
+	MaxTxnLogSize:                    schema.String(),
+	MaxPruneTxnBatchSize:             schema.ForceInt(),
+	MaxPruneTxnPasses:                schema.ForceInt(),
+	AgentLogfileMaxBackups:           schema.ForceInt(),
+	AgentLogfileMaxSize:              schema.String(),
+	ModelLogfileMaxBackups:           schema.ForceInt(),
+	ModelLogfileMaxSize:              schema.String(),
+	ModelLogsSize:                    schema.String(),
+	PruneTxnQueryCount:               schema.ForceInt(),
+	PruneTxnSleepTime:                schema.String(),
+	PublicDNSAddress:                 schema.String(),
+	JujuHASpace:                      schema.String(),
+	JujuManagementSpace:              schema.String(),
+	CAASOperatorImagePath:            schema.String(),
+	CAASImageRepo:                    schema.String(),
+	Features:                         schema.List(schema.String()),
+	CharmStoreURL:                    schema.String(),
+	MeteringURL:                      schema.String(),
+	MaxCharmStateSize:                schema.ForceInt(),
+	MaxAgentStateSize:                schema.ForceInt(),
+	NonSyncedWritesToRaftLog:         schema.Bool(),
+	MigrationMinionWaitMax:           schema.String(),
+	ApplicationResourceDownloadLimit: schema.ForceInt(),
+	ControllerResourceDownloadLimit:  schema.ForceInt(),
 }, schema.Defaults{
-	AgentRateLimitMax:        schema.Omit,
-	AgentRateLimitRate:       schema.Omit,
-	APIPort:                  DefaultAPIPort,
-	APIPortOpenDelay:         DefaultAPIPortOpenDelay,
-	ControllerAPIPort:        schema.Omit,
-	ControllerName:           schema.Omit,
-	AuditingEnabled:          DefaultAuditingEnabled,
-	AuditLogCaptureArgs:      DefaultAuditLogCaptureArgs,
-	AuditLogMaxSize:          fmt.Sprintf("%vM", DefaultAuditLogMaxSizeMB),
-	AuditLogMaxBackups:       DefaultAuditLogMaxBackups,
-	AuditLogExcludeMethods:   DefaultAuditLogExcludeMethods,
-	StatePort:                DefaultStatePort,
-	IdentityURL:              schema.Omit,
-	IdentityPublicKey:        schema.Omit,
-	SetNUMAControlPolicyKey:  DefaultNUMAControlPolicy,
-	AutocertURLKey:           schema.Omit,
-	AutocertDNSNameKey:       schema.Omit,
-	AllowModelAccessKey:      schema.Omit,
-	MongoMemoryProfile:       DefaultMongoMemoryProfile,
-	JujuDBSnapChannel:        DefaultJujuDBSnapChannel,
-	MaxDebugLogDuration:      DefaultMaxDebugLogDuration,
-	MaxTxnLogSize:            fmt.Sprintf("%vM", DefaultMaxTxnLogCollectionMB),
-	MaxPruneTxnBatchSize:     DefaultMaxPruneTxnBatchSize,
-	MaxPruneTxnPasses:        DefaultMaxPruneTxnPasses,
-	AgentLogfileMaxBackups:   DefaultAgentLogfileMaxBackups,
-	AgentLogfileMaxSize:      fmt.Sprintf("%vM", DefaultAgentLogfileMaxSize),
-	ModelLogfileMaxBackups:   DefaultModelLogfileMaxBackups,
-	ModelLogfileMaxSize:      fmt.Sprintf("%vM", DefaultModelLogfileMaxSize),
-	ModelLogsSize:            fmt.Sprintf("%vM", DefaultModelLogsSizeMB),
-	PruneTxnQueryCount:       DefaultPruneTxnQueryCount,
-	PruneTxnSleepTime:        DefaultPruneTxnSleepTime,
-	PublicDNSAddress:         schema.Omit,
-	JujuHASpace:              schema.Omit,
-	JujuManagementSpace:      schema.Omit,
-	CAASOperatorImagePath:    schema.Omit,
-	CAASImageRepo:            schema.Omit,
-	Features:                 schema.Omit,
-	CharmStoreURL:            csclient.ServerURL,
-	MeteringURL:              romulus.DefaultAPIRoot,
-	MaxCharmStateSize:        DefaultMaxCharmStateSize,
-	MaxAgentStateSize:        DefaultMaxAgentStateSize,
-	NonSyncedWritesToRaftLog: DefaultNonSyncedWritesToRaftLog,
-	MigrationMinionWaitMax:   DefaultMigrationMinionWaitMax,
+	AgentRateLimitMax:                schema.Omit,
+	AgentRateLimitRate:               schema.Omit,
+	APIPort:                          DefaultAPIPort,
+	APIPortOpenDelay:                 DefaultAPIPortOpenDelay,
+	ControllerAPIPort:                schema.Omit,
+	ControllerName:                   schema.Omit,
+	AuditingEnabled:                  DefaultAuditingEnabled,
+	AuditLogCaptureArgs:              DefaultAuditLogCaptureArgs,
+	AuditLogMaxSize:                  fmt.Sprintf("%vM", DefaultAuditLogMaxSizeMB),
+	AuditLogMaxBackups:               DefaultAuditLogMaxBackups,
+	AuditLogExcludeMethods:           DefaultAuditLogExcludeMethods,
+	StatePort:                        DefaultStatePort,
+	IdentityURL:                      schema.Omit,
+	IdentityPublicKey:                schema.Omit,
+	SetNUMAControlPolicyKey:          DefaultNUMAControlPolicy,
+	AutocertURLKey:                   schema.Omit,
+	AutocertDNSNameKey:               schema.Omit,
+	AllowModelAccessKey:              schema.Omit,
+	MongoMemoryProfile:               DefaultMongoMemoryProfile,
+	JujuDBSnapChannel:                DefaultJujuDBSnapChannel,
+	MaxDebugLogDuration:              DefaultMaxDebugLogDuration,
+	MaxTxnLogSize:                    fmt.Sprintf("%vM", DefaultMaxTxnLogCollectionMB),
+	MaxPruneTxnBatchSize:             DefaultMaxPruneTxnBatchSize,
+	MaxPruneTxnPasses:                DefaultMaxPruneTxnPasses,
+	AgentLogfileMaxBackups:           DefaultAgentLogfileMaxBackups,
+	AgentLogfileMaxSize:              fmt.Sprintf("%vM", DefaultAgentLogfileMaxSize),
+	ModelLogfileMaxBackups:           DefaultModelLogfileMaxBackups,
+	ModelLogfileMaxSize:              fmt.Sprintf("%vM", DefaultModelLogfileMaxSize),
+	ModelLogsSize:                    fmt.Sprintf("%vM", DefaultModelLogsSizeMB),
+	PruneTxnQueryCount:               DefaultPruneTxnQueryCount,
+	PruneTxnSleepTime:                DefaultPruneTxnSleepTime,
+	PublicDNSAddress:                 schema.Omit,
+	JujuHASpace:                      schema.Omit,
+	JujuManagementSpace:              schema.Omit,
+	CAASOperatorImagePath:            schema.Omit,
+	CAASImageRepo:                    schema.Omit,
+	Features:                         schema.Omit,
+	CharmStoreURL:                    csclient.ServerURL,
+	MeteringURL:                      romulus.DefaultAPIRoot,
+	MaxCharmStateSize:                DefaultMaxCharmStateSize,
+	MaxAgentStateSize:                DefaultMaxAgentStateSize,
+	NonSyncedWritesToRaftLog:         DefaultNonSyncedWritesToRaftLog,
+	MigrationMinionWaitMax:           DefaultMigrationMinionWaitMax,
+	ApplicationResourceDownloadLimit: schema.Omit,
+	ControllerResourceDownloadLimit:  schema.Omit,
 })
 
 // ConfigSchema holds information on all the fields defined by
 // the config package.
 var ConfigSchema = environschema.Fields{
+	ApplicationResourceDownloadLimit: {
+		Description: "The maximum number of concurrent resources downloads per application",
+		Type:        environschema.Tint,
+	},
+	ControllerResourceDownloadLimit: {
+		Description: "The maximum number of concurrent resources downloads across all the applications on the controller",
+		Type:        environschema.Tint,
+	},
 	AgentRateLimitMax: {
 		Description: "The maximum size of the token bucket used to ratelimit agent connections",
 		Type:        environschema.Tint,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -376,6 +376,18 @@ var newConfigTests = []struct {
 			controller.MigrationMinionWaitMax: "15",
 		},
 		expectError: `migration-agent-wait-time value "15" must be a valid duration`,
+	}, {
+		about: "application-resource-download-limit cannot be negative",
+		config: controller.Config{
+			controller.ApplicationResourceDownloadLimit: "-42",
+		},
+		expectError: `negative application-resource-download-limit \(-42\) not valid, use 0 to disable the limit`,
+	}, {
+		about: "controller-resource-download-limit cannot be negative",
+		config: controller.Config{
+			controller.ControllerResourceDownloadLimit: "-42",
+		},
+		expectError: `negative controller-resource-download-limit \(-42\) not valid, use 0 to disable the limit`,
 	}, {}}
 
 func (s *ConfigSuite) TestNewConfig(c *gc.C) {
@@ -400,6 +412,20 @@ func (s *ConfigSuite) TestLogConfigDefaults(c *gc.C) {
 	cfg, err := controller.NewConfig(testing.ControllerTag.Id(), testing.CACert, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.ModelLogsSizeMB(), gc.Equals, 20)
+}
+
+func (s *ConfigSuite) TestResourceDownloadLimits(c *gc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]interface{}{
+			"application-resource-download-limit": "42",
+			"controller-resource-download-limit":  "666",
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.ApplicationResourceDownloadLimit(), gc.Equals, 42)
+	c.Assert(cfg.ControllerResourceDownloadLimit(), gc.Equals, 666)
 }
 
 func (s *ConfigSuite) TestLogConfigValues(c *gc.C) {
@@ -793,6 +819,8 @@ func (s *ConfigSuite) TestDefaults(c *gc.C) {
 	c.Assert(cfg.AgentLogfileMaxSizeMB(), gc.Equals, controller.DefaultAgentLogfileMaxSize)
 	c.Assert(cfg.ModelLogfileMaxBackups(), gc.Equals, controller.DefaultModelLogfileMaxBackups)
 	c.Assert(cfg.ModelLogfileMaxSizeMB(), gc.Equals, controller.DefaultModelLogfileMaxSize)
+	c.Assert(cfg.ApplicationResourceDownloadLimit(), gc.Equals, controller.DefaultApplicationResourceDownloadLimit)
+	c.Assert(cfg.ControllerResourceDownloadLimit(), gc.Equals, controller.DefaultControllerResourceDownloadLimit)
 }
 
 func (s *ConfigSuite) TestAgentLogfile(c *gc.C) {

--- a/resource/repositories/operations_test.go
+++ b/resource/repositories/operations_test.go
@@ -13,10 +13,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
 	charmresource "github.com/juju/charm/v8/resource"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/charmstore"
 	"github.com/juju/juju/resource"
@@ -117,9 +116,7 @@ func (s *OperationsSuite) TestConcurrentGetResource(c *gc.C) {
 		Repository: er,
 		Name:       "company-icon",
 		CharmID:    repositories.CharmID{URL: charm.MustParseURL("cs:gitlab")},
-		Done: func() {
-			done.Done()
-		},
+		Done:       done.Done,
 	}
 
 	start := sync.WaitGroup{}

--- a/resource/resourceadapters/export_test.go
+++ b/resource/resourceadapters/export_test.go
@@ -36,6 +36,7 @@ func NewResourceOpenerForTest(
 	unit Unit,
 	application Application,
 	fn func(st ResourceOpenerState) ResourceRetryClientGetter,
+	maxRequests int,
 ) *ResourceOpener {
 	return &ResourceOpener{
 		st:                st,
@@ -44,5 +45,8 @@ func NewResourceOpenerForTest(
 		unit:              unit,
 		application:       application,
 		newResourceOpener: fn,
+		resourceDownloadLimiterFunc: func() ResourceDownloadLock {
+			return NewResourceDownloadLimiter(maxRequests, 0)
+		},
 	}
 }

--- a/resource/resourceadapters/limiter.go
+++ b/resource/resourceadapters/limiter.go
@@ -1,0 +1,85 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resourceadapters
+
+import (
+	"sync"
+)
+
+// ResourceDownloadLock is used to limit the number of concurrent
+// resource downloads and per application. The total number of
+// downloads across all applications cannot exceed the global limit.
+type ResourceDownloadLock interface {
+	// Acquire grabs the lock for a given application so long as the
+	// per application limit is not exceeded and total across all
+	// applications does not exceed the global limit.
+	Acquire(appName string)
+
+	// Release releases the lock for the given application.
+	Release(appName string)
+}
+
+// NewResourceDownloadLimiter creates a new resource download limiter.
+func NewResourceDownloadLimiter(globalLimit, applicationLimit int) *resourceDownloadLimiter {
+	limiter := &resourceDownloadLimiter{
+		applicationLimit: applicationLimit,
+		applicationLocks: make(map[string]chan struct{}),
+	}
+	if globalLimit > 0 {
+		limiter.globalLock = make(chan struct{}, globalLimit)
+	}
+	return limiter
+}
+
+type resourceDownloadLimiter struct {
+	globalLock chan struct{}
+
+	mu               sync.Mutex
+	applicationLimit int
+	applicationLocks map[string]chan struct{}
+}
+
+// Acquire implements ResourceDownloadLock.
+func (r *resourceDownloadLimiter) Acquire(appName string) {
+	if r.globalLock != nil {
+		logger.Debugf("acquire global resource download lock, current downloads = %d", len(r.globalLock))
+		r.globalLock <- struct{}{}
+	}
+	if r.applicationLimit <= 0 {
+		return
+	}
+
+	r.mu.Lock()
+	lock, ok := r.applicationLocks[appName]
+	if !ok {
+		lock = make(chan struct{}, r.applicationLimit)
+		r.applicationLocks[appName] = lock
+	}
+	r.mu.Unlock()
+	logger.Debugf("acquire application resource download lock, current downloads = %d", len(lock))
+	lock <- struct{}{}
+}
+
+// Release implements ResourceDownloadLock.
+func (r *resourceDownloadLimiter) Release(appName string) {
+	if r.globalLock != nil {
+		<-r.globalLock
+		logger.Debugf("release global resource download lock, current downloads = %d", len(r.globalLock))
+	}
+	if r.applicationLimit <= 0 {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lock, ok := r.applicationLocks[appName]
+	if !ok {
+		return
+	}
+	logger.Debugf("release global resource download lock, current downloads = %d", len(lock))
+	<-lock
+	if len(lock) == 0 {
+		delete(r.applicationLocks, appName)
+	}
+}

--- a/resource/resourceadapters/limiter_test.go
+++ b/resource/resourceadapters/limiter_test.go
@@ -33,17 +33,21 @@ func (s *LimiterSuite) TestNoLimits(c *gc.C) {
 
 	totalAcquiredCount := int32(0)
 	trigger := make(chan struct{})
+	started := sync.WaitGroup{}
 	finished := sync.WaitGroup{}
 	for i := 0; i < totalToAcquire; i++ {
+		started.Add(1)
 		finished.Add(1)
 		go func() {
 			defer finished.Done()
+			started.Done()
 			limiter.Acquire("app1")
 			atomic.AddInt32(&totalAcquiredCount, 1)
 			<-trigger
 			limiter.Release("app1")
 		}()
 	}
+	started.Wait()
 
 	done := make(chan bool)
 	go func() {
@@ -88,17 +92,21 @@ func (s *LimiterSuite) TestGlobalLimit(c *gc.C) {
 
 	totalAcquiredCount := int32(0)
 	trigger := make(chan struct{})
+	started := sync.WaitGroup{}
 	finished := sync.WaitGroup{}
 	for i := 0; i < totalToAcquire; i++ {
+		started.Add(1)
 		finished.Add(1)
 		go func() {
 			defer finished.Done()
+			started.Done()
 			limiter.Acquire("app1")
 			atomic.AddInt32(&totalAcquiredCount, 1)
 			<-trigger
 			limiter.Release("app1")
 		}()
 	}
+	started.Wait()
 
 	done := make(chan bool)
 	go func() {
@@ -152,8 +160,10 @@ func (s *LimiterSuite) TestApplicationLimit(c *gc.C) {
 
 	totalAcquiredCount := int32(0)
 	trigger := make(chan struct{})
+	started := sync.WaitGroup{}
 	finished := sync.WaitGroup{}
 	for i := 0; i < numApplications*totalToAcquirePerApplication; i++ {
+		started.Add(1)
 		finished.Add(1)
 		uuid := "app1"
 		if i >= totalToAcquirePerApplication {
@@ -161,12 +171,14 @@ func (s *LimiterSuite) TestApplicationLimit(c *gc.C) {
 		}
 		go func(uui string) {
 			defer finished.Done()
+			started.Done()
 			limiter.Acquire(uuid)
 			atomic.AddInt32(&totalAcquiredCount, 1)
 			<-trigger
 			limiter.Release(uuid)
 		}(uuid)
 	}
+	started.Wait()
 
 	done := make(chan bool)
 	go func() {
@@ -222,8 +234,10 @@ func (s *LimiterSuite) TestGlobalAndApplicationLimit(c *gc.C) {
 
 	totalAcquiredCount := int32(0)
 	trigger := make(chan struct{})
+	started := sync.WaitGroup{}
 	finished := sync.WaitGroup{}
 	for i := 0; i < numApplications*totalToAcquirePerApplication; i++ {
+		started.Add(1)
 		finished.Add(1)
 		uuid := "app1"
 		if i >= 2*totalToAcquirePerApplication {
@@ -233,12 +247,14 @@ func (s *LimiterSuite) TestGlobalAndApplicationLimit(c *gc.C) {
 		}
 		go func(uui string) {
 			defer finished.Done()
+			started.Done()
 			limiter.Acquire(uuid)
 			atomic.AddInt32(&totalAcquiredCount, 1)
 			<-trigger
 			limiter.Release(uuid)
 		}(uuid)
 	}
+	started.Wait()
 
 	done := make(chan bool)
 	go func() {

--- a/resource/resourceadapters/limiter_test.go
+++ b/resource/resourceadapters/limiter_test.go
@@ -1,0 +1,283 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package resourceadapters_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/resource/resourceadapters"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type LimiterSuite struct {
+}
+
+var _ = gc.Suite(&LimiterSuite{})
+
+var shortAttempt = &utils.AttemptStrategy{
+	Total: coretesting.ShortWait,
+	Delay: 10 * time.Millisecond,
+}
+
+func (s *LimiterSuite) TestNoLimits(c *gc.C) {
+
+	const totalToAcquire = 10
+	limiter := resourceadapters.NewResourceDownloadLimiter(0, 0)
+
+	totalAcquiredCount := int32(0)
+	trigger := make(chan struct{})
+	finished := sync.WaitGroup{}
+	for i := 0; i < totalToAcquire; i++ {
+		finished.Add(1)
+		go func() {
+			defer finished.Done()
+			limiter.Acquire("app1")
+			atomic.AddInt32(&totalAcquiredCount, 1)
+			<-trigger
+			limiter.Release("app1")
+		}()
+	}
+
+	done := make(chan bool)
+	go func() {
+		finished.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		c.Fatal("finished too soon")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// All locks can be acquired.
+	allLocksAcquired := false
+	for a := coretesting.LongAttempt.Start(); a.Next(); a.HasNext() {
+		if allLocksAcquired = atomic.LoadInt32(&totalAcquiredCount) == totalToAcquire; allLocksAcquired {
+			break
+		}
+	}
+	c.Assert(allLocksAcquired, jc.IsTrue)
+
+	for i := 0; i < totalToAcquire; i++ {
+		trigger <- struct{}{}
+	}
+	c.Assert(atomic.LoadInt32(&totalAcquiredCount), gc.Equals, int32(totalToAcquire))
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timeout waiting for finish")
+	}
+}
+
+func (s *LimiterSuite) TestGlobalLimit(c *gc.C) {
+
+	const (
+		globalLimit    = 5
+		totalToAcquire = 10
+	)
+	limiter := resourceadapters.NewResourceDownloadLimiter(globalLimit, 0)
+
+	totalAcquiredCount := int32(0)
+	trigger := make(chan struct{})
+	finished := sync.WaitGroup{}
+	for i := 0; i < totalToAcquire; i++ {
+		finished.Add(1)
+		go func() {
+			defer finished.Done()
+			limiter.Acquire("app1")
+			atomic.AddInt32(&totalAcquiredCount, 1)
+			<-trigger
+			limiter.Release("app1")
+		}()
+	}
+
+	done := make(chan bool)
+	go func() {
+		finished.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		c.Fatal("finished too soon")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// We should acquire "globalLimit" locks.
+	limitReached := false
+	for a := coretesting.LongAttempt.Start(); a.Next(); a.HasNext() {
+		if limitReached = atomic.LoadInt32(&totalAcquiredCount) == globalLimit; limitReached {
+			break
+		}
+	}
+	c.Assert(limitReached, jc.IsTrue)
+
+	// Ensure we don't acquire more than allowed.
+	for a := shortAttempt.Start(); a.Next(); a.HasNext() {
+		if atomic.LoadInt32(&totalAcquiredCount) > globalLimit {
+			c.Fatal("too many concurrent threads")
+		}
+	}
+
+	// Allow all the locks to be acquired.
+	for i := 0; i < totalToAcquire; i++ {
+		trigger <- struct{}{}
+	}
+	c.Assert(atomic.LoadInt32(&totalAcquiredCount), gc.Equals, int32(totalToAcquire))
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timeout waiting for finish")
+	}
+}
+
+func (s *LimiterSuite) TestApplicationLimit(c *gc.C) {
+
+	const (
+		applicationLimit             = 5
+		numApplications              = 2
+		totalToAcquirePerApplication = 10
+	)
+	limiter := resourceadapters.NewResourceDownloadLimiter(0, applicationLimit)
+
+	totalAcquiredCount := int32(0)
+	trigger := make(chan struct{})
+	finished := sync.WaitGroup{}
+	for i := 0; i < numApplications*totalToAcquirePerApplication; i++ {
+		finished.Add(1)
+		uuid := "app1"
+		if i >= totalToAcquirePerApplication {
+			uuid = "app2"
+		}
+		go func(uui string) {
+			defer finished.Done()
+			limiter.Acquire(uuid)
+			atomic.AddInt32(&totalAcquiredCount, 1)
+			<-trigger
+			limiter.Release(uuid)
+		}(uuid)
+	}
+
+	done := make(chan bool)
+	go func() {
+		finished.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		c.Fatal("finished too soon")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// We should acquire 2 * "applicationLimit" locks.
+	limitReached := false
+	for a := coretesting.LongAttempt.Start(); a.Next(); a.HasNext() {
+		if limitReached = atomic.LoadInt32(&totalAcquiredCount) == numApplications*applicationLimit; limitReached {
+			break
+		}
+	}
+	c.Logf("got %d", totalAcquiredCount)
+	c.Assert(limitReached, jc.IsTrue)
+
+	// Ensure we don't acquire more than allowed.
+	for a := shortAttempt.Start(); a.Next(); a.HasNext() {
+		if atomic.LoadInt32(&totalAcquiredCount) > numApplications*applicationLimit {
+			c.Fatal("too many concurrent threads")
+		}
+	}
+
+	// Allow all the locks to be acquired.
+	for i := 0; i < numApplications*totalToAcquirePerApplication; i++ {
+		trigger <- struct{}{}
+	}
+	c.Assert(atomic.LoadInt32(&totalAcquiredCount), gc.Equals, int32(numApplications*totalToAcquirePerApplication))
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timeout waiting for finish")
+	}
+}
+
+func (s *LimiterSuite) TestGlobalAndApplicationLimit(c *gc.C) {
+
+	const (
+		globalLimit                  = 5
+		applicationLimit             = 3
+		numApplications              = 3
+		totalToAcquirePerApplication = 2
+	)
+	limiter := resourceadapters.NewResourceDownloadLimiter(globalLimit, applicationLimit)
+
+	totalAcquiredCount := int32(0)
+	trigger := make(chan struct{})
+	finished := sync.WaitGroup{}
+	for i := 0; i < numApplications*totalToAcquirePerApplication; i++ {
+		finished.Add(1)
+		uuid := "app1"
+		if i >= 2*totalToAcquirePerApplication {
+			uuid = "app3"
+		} else if i >= totalToAcquirePerApplication {
+			uuid = "app2"
+		}
+		go func(uui string) {
+			defer finished.Done()
+			limiter.Acquire(uuid)
+			atomic.AddInt32(&totalAcquiredCount, 1)
+			<-trigger
+			limiter.Release(uuid)
+		}(uuid)
+	}
+
+	done := make(chan bool)
+	go func() {
+		finished.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		c.Fatal("finished too soon")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// We should acquire "globalLimit" locks as that is less
+	// than the total number of application locks.
+	limitReached := false
+	for a := coretesting.LongAttempt.Start(); a.Next(); a.HasNext() {
+		if limitReached = atomic.LoadInt32(&totalAcquiredCount) == globalLimit; limitReached {
+			break
+		}
+	}
+	c.Assert(limitReached, jc.IsTrue)
+
+	// Ensure we don't acquire more than allowed.
+	for a := shortAttempt.Start(); a.Next(); a.HasNext() {
+		if atomic.LoadInt32(&totalAcquiredCount) > globalLimit {
+			c.Fatal("too many concurrent threads")
+		}
+	}
+
+	// Allow all the locks to be acquired.
+	for i := 0; i < numApplications*totalToAcquirePerApplication; i++ {
+		trigger <- struct{}{}
+	}
+	c.Assert(atomic.LoadInt32(&totalAcquiredCount), gc.Equals, int32(numApplications*totalToAcquirePerApplication))
+
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timeout waiting for finish")
+	}
+}

--- a/resource/resourceadapters/opener_test.go
+++ b/resource/resourceadapters/opener_test.go
@@ -5,7 +5,10 @@ package resourceadapters_test
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
+	"sync"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
@@ -20,6 +23,7 @@ import (
 	"github.com/juju/juju/resource/resourceadapters"
 	"github.com/juju/juju/resource/resourceadapters/mocks"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type OpenerSuite struct {
@@ -28,6 +32,8 @@ type OpenerSuite struct {
 	resources           *mocks.MockResources
 	resourceGetter      *mocks.MockResourceGetter
 	resourceOpenerState *mocks.MockResourceOpenerState
+
+	unleash sync.Mutex
 }
 
 var _ = gc.Suite(&OpenerSuite{})
@@ -48,15 +54,75 @@ func (s *OpenerSuite) TestOpenResource(c *gc.C) {
 		},
 		ApplicationID: "postgreql",
 	}
-	s.expectCacheMethods(res)
+	s.expectCharmOrigin(1)
+	s.expectCacheMethods(res, 1)
 	s.resourceGetter.EXPECT().GetResource(gomock.Any()).Return(charmstore.ResourceData{
 		ReadCloser: nil,
 		Resource:   res.Resource,
 	}, nil)
 
-	opened, err := s.newOpener().OpenResource("wal-e")
+	opened, err := s.newOpener(0).OpenResource("wal-e")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(opened.Resource, gc.DeepEquals, res)
+	c.Check(opened.Resource, gc.DeepEquals, res)
+	c.Assert(opened.Close(), jc.ErrorIsNil)
+}
+
+func (s *OpenerSuite) TestOpenResourceThrottle(c *gc.C) {
+	defer s.setupMocks(c, true).Finish()
+	fp, _ := charmresource.ParseFingerprint("38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b")
+	res := resource.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: "wal-e",
+				Type: 1,
+			},
+			Origin:      2,
+			Revision:    0,
+			Fingerprint: fp,
+			Size:        0,
+		},
+		ApplicationID: "postgreql",
+	}
+	const (
+		numConcurrentRequests = 10
+		maxConcurrentRequests = 5
+	)
+	s.expectCharmOrigin(numConcurrentRequests)
+	s.expectCacheMethods(res, numConcurrentRequests)
+	s.resourceGetter.EXPECT().GetResource(gomock.Any()).Return(charmstore.ResourceData{
+		ReadCloser: nil,
+		Resource:   res.Resource,
+	}, nil)
+
+	s.unleash.Lock()
+	start := sync.WaitGroup{}
+	finished := sync.WaitGroup{}
+	for i := 0; i < numConcurrentRequests; i++ {
+		start.Add(1)
+		finished.Add(1)
+		go func() {
+			defer finished.Done()
+			start.Done()
+			opened, err := s.newOpener(maxConcurrentRequests).OpenResource("wal-e")
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(opened.Resource, gc.DeepEquals, res)
+			c.Assert(opened.Close(), jc.ErrorIsNil)
+		}()
+	}
+	// Let all the test routines queue up then unleash.
+	start.Wait()
+	s.unleash.Unlock()
+
+	done := make(chan bool)
+	go func() {
+		finished.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timeout waiting for resources to be fetched")
+	}
 }
 
 func (s *OpenerSuite) TestOpenResourceApplication(c *gc.C) {
@@ -75,15 +141,18 @@ func (s *OpenerSuite) TestOpenResourceApplication(c *gc.C) {
 		},
 		ApplicationID: "postgreql",
 	}
-	s.expectCacheMethods(res)
+	s.expectCharmOrigin(1)
+	s.expectCacheMethods(res, 1)
 	s.resourceGetter.EXPECT().GetResource(gomock.Any()).Return(charmstore.ResourceData{
 		ReadCloser: nil,
 		Resource:   res.Resource,
 	}, nil)
 
-	opened, err := s.newOpener().OpenResource("wal-e")
+	opened, err := s.newOpener(0).OpenResource("wal-e")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(opened.Resource, gc.DeepEquals, res)
+	err = opened.Close()
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *OpenerSuite) setupMocks(c *gc.C, includeUnit bool) *gomock.Controller {
@@ -108,12 +177,11 @@ func (s *OpenerSuite) setupMocks(c *gc.C, includeUnit bool) *gomock.Controller {
 		s.app.EXPECT().CharmURL().Return(curl, false).AnyTimes()
 	}
 	s.app.EXPECT().Name().Return("postgresql").AnyTimes()
-	s.expectCharmOrigin()
 
 	return ctrl
 }
 
-func (s *OpenerSuite) expectCharmOrigin() {
+func (s *OpenerSuite) expectCharmOrigin(numConcurrentRequests int) {
 	rev := 0
 	s.app.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
 		Source:   "charm-hub",
@@ -125,12 +193,16 @@ func (s *OpenerSuite) expectCharmOrigin() {
 			OS:           "ubuntu",
 			Series:       "focal",
 		},
-	})
+	}).Times(numConcurrentRequests)
 }
 
-func (s *OpenerSuite) expectCacheMethods(res resource.Resource) {
+func (s *OpenerSuite) expectCacheMethods(res resource.Resource, numConcurrentRequests int) {
 	if s.unit != nil {
-		s.resources.EXPECT().OpenResourceForUniter(gomock.Any(), gomock.Any()).Return(resource.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e"))
+		s.resources.EXPECT().OpenResourceForUniter(gomock.Any(), gomock.Any()).DoAndReturn(func(unit resource.Unit, name string) (resource.Resource, io.ReadCloser, error) {
+			s.unleash.Lock()
+			defer s.unleash.Unlock()
+			return resource.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e")
+		})
 	} else {
 		s.resources.EXPECT().OpenResource(gomock.Any(), gomock.Any()).Return(resource.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e"))
 	}
@@ -140,13 +212,13 @@ func (s *OpenerSuite) expectCacheMethods(res resource.Resource) {
 	other := res
 	other.ApplicationID = "postgreql"
 	if s.unit != nil {
-		s.resources.EXPECT().OpenResourceForUniter(gomock.Any(), gomock.Any()).Return(other, ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil)
+		s.resources.EXPECT().OpenResourceForUniter(gomock.Any(), gomock.Any()).Return(other, ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil).Times(numConcurrentRequests)
 	} else {
 		s.resources.EXPECT().OpenResource(gomock.Any(), gomock.Any()).Return(other, ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil)
 	}
 }
 
-func (s *OpenerSuite) newOpener() *resourceadapters.ResourceOpener {
+func (s *OpenerSuite) newOpener(maxRequests int) *resourceadapters.ResourceOpener {
 	tag, _ := names.ParseUnitTag("postgresql/0")
 	// preserve nil
 	unit := resourceadapters.Unit(nil)
@@ -164,6 +236,7 @@ func (s *OpenerSuite) newOpener() *resourceadapters.ResourceOpener {
 				resourceGetter: s.resourceGetter,
 			}
 		},
+		maxRequests,
 	)
 }
 

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -63,6 +63,8 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MigrationMinionWaitMax,
 		controller.AgentLogfileMaxBackups,
 		controller.AgentLogfileMaxSize,
+		controller.ControllerResourceDownloadLimit,
+		controller.ApplicationResourceDownloadLimit,
 	)
 	for _, controllerAttr := range controller.ControllerOnlyConfigAttributes {
 		v, ok := controllerSettings.Get(controllerAttr)


### PR DESCRIPTION
This follows on from the work done in #13215 which throttled resource downloads from the store.
Here we introduce limits to resource downloads from the controller to the workload nodes (initiated by the unit agents calling `resource-get`).

There are 2 new controller config attributes:
- controller-resource-download-limit
- application-resource-download-limit

The first limits the number of total downloads for any app hosted in any model on the controller.
The latter limits the number of downloads per application per model.
The default values for these limits are 0, meaning no throttling; the new behaviour is opt in.

## QA steps

I deployed the `dummy-resource` charm with slightly modified hooks; the line
`status-set maintenance $(cat $RES_PATH)`
was commented out.

First create a number of machines to run the charm
juju bootstrap 
juju controller-config controller-resource-download-limit=5
juju add-machine -n 20

Optionally turn on debug logging for `juju.resource.resourceadapters`
juju model-config logging-config="juju.resource.resourceadapters=DEBUG"

Let the machines start.
watch -c juju status --color

Then deploy the charm twice with different app name, using a large zip file
juju deploy /path/to/dummy-resource -n 10 --resource dummy=./dummy-resource.zip --to 1,2,3,4,5,6,7,8,9,10
juju deploy /path/to/dummy-resource -n 10 app2 --resource dummy=./dummy-resource.zip --to 11,12,13,14,15,16,17,18,19,20

status will show the message for each unit change to indicate the resource is delivered. Typically a few change at once.
debug-log will show the resource download lock being acquired in batches.

ssh into the machines and check the zip file is present in the unit resources directory.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1940219
