### PR TITLE
[JUJU-497] Avoid breaking migration because of NYI

### DIFF
--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -248,7 +248,11 @@ func (api *API) AdoptResources(args params.AdoptResourcesArgs) error {
 		return errors.Trace(err)
 	}
 
-	return errors.Trace(ra.AdoptResources(context.CallContext(m.State()), st.ControllerUUID(), args.SourceControllerVersion))
+	err = ra.AdoptResources(context.CallContext(m.State()), st.ControllerUUID(), args.SourceControllerVersion)
+	if errors.IsNotImplemented(err) {
+		return nil
+	}
+	return errors.Trace(err)
 }
 
 // CheckMachines compares the machines in state with the ones reported


### PR DESCRIPTION
#### Description

Migration fails on some providers (e.g. oci) because of some not yet
implemented/optional features. This unblocks it by returning nil
whenever it sees an nyi. All the other errors are raised as usual.

Fixes: https://bugs.launchpad.net/juju/+bug/1958459

#### QA steps

Migration on oci should succeed. (use the compartment&tenancy ids from within the cloud-city)

```sh
juju bootstrap --config compartment-id=$OCID_COMPARTMENT oci-canonical oci-test-controller2

juju bootstrap --config compartment-id=$OCID_COMPARTMENT oci-canonical oci-test-controller1

juju add-model --config compartment-id=$OCID_COMPARTMENT test-model1

juju deploy ubuntu

juju migrate test-model1 oci-test-controller2
```

#### Notes & Discussion

This is sort of a requirement for #13645, as we need the migration to be working for that to take effect.