### PR TITLE
[JUJU-501] Remove orphaned charm documents

### DIFF
--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -133,7 +133,7 @@ func (c *RefreshClient) RefreshWithMetricsOnly(ctx context.Context, metrics map[
 }
 
 func contextMetrics(metrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string) (transport.RequestMetrics, error) {
-	m := make(transport.RequestMetrics, 0)
+	m := make(transport.RequestMetrics)
 	for k, v := range metrics {
 		// verify top level "model" and "controller" keys
 		if k != charmmetrics.Controller && k != charmmetrics.Model {
@@ -162,9 +162,30 @@ func (c *RefreshClient) refresh(ctx context.Context, ensure func(responses []tra
 	if err := handleBasicAPIErrors(resp.ErrorList, c.logger); err != nil {
 		return nil, errors.Trace(err)
 	}
+	// Ensure that all the results contain the correct instance keys.
+	if err := ensure(resp.Results); err != nil {
+		return nil, errors.Trace(err)
+	}
+	// Exit early.
+	if len(resp.Results) <= 1 {
+		return resp.Results, nil
+	}
 
-	c.logger.Tracef("Refresh() unmarshalled: %s", pretty.Sprint(resp.Results))
-	return resp.Results, ensure(resp.Results)
+	// As the results are not expected to be in the correct order, sort them
+	// to prevent others falling into not RTFM!
+	indexes := make(map[string]int, len(req.Actions))
+	for i, action := range req.Actions {
+		indexes[action.InstanceKey] = i
+	}
+	results := make([]transport.RefreshResponse, len(resp.Results))
+	for _, result := range resp.Results {
+		results[indexes[result.InstanceKey]] = result
+	}
+
+	if c.logger.IsTraceEnabled() {
+		c.logger.Tracef("Refresh() unmarshalled: %s", pretty.Sprint(results))
+	}
+	return results, nil
 }
 
 // RefreshOne creates a request config for requesting only one charm.
@@ -249,7 +270,7 @@ func AddConfigMetrics(config RefreshConfig, metrics map[charmmetrics.MetricKey]s
 	if len(metrics) < 1 {
 		return c, nil
 	}
-	c.metrics = make(transport.ContextMetrics, 0)
+	c.metrics = make(transport.ContextMetrics)
 	for k, v := range metrics {
 		c.metrics[k.String()] = v
 	}

--- a/charmhub/refreshconfig.go
+++ b/charmhub/refreshconfig.go
@@ -91,9 +91,8 @@ type executeOne struct {
 	Base     RefreshBase
 	// instanceKey is a private unique key that we construct for CharmHub API
 	// asynchronous calls.
-	action            Action
-	instanceKey       string
-	resourceRevisions []transport.RefreshResourceRevision
+	action      Action
+	instanceKey string
 }
 
 // InstanceKey returns the underlying instance key.

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -103,6 +103,7 @@ type StateBackend interface {
 	CleanupDeadAssignUnits() error
 	RemoveOrphanedLinkLayerDevices() error
 	UpdateExternalControllerInfo() error
+	RemoveInvalidCharmPlaceholders() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -447,4 +448,8 @@ func (s stateBackend) RemoveOrphanedLinkLayerDevices() error {
 
 func (s stateBackend) UpdateExternalControllerInfo() error {
 	return state.UpdateExternalControllerInfo(s.pool)
+}
+
+func (s stateBackend) RemoveInvalidCharmPlaceholders() error {
+	return state.RemoveInvalidCharmPlaceholders(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -57,6 +57,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.20"), stateStepsFor2920()},
 		upgradeToVersion{version.MustParse("2.9.22"), stateStepsFor2922()},
 		upgradeToVersion{version.MustParse("2.9.24"), stateStepsFor2924()},
+		upgradeToVersion{version.MustParse("2.9.25"), stateStepsFor2925()},
 	}
 	return steps
 }

--- a/upgrades/steps_2925.go
+++ b/upgrades/steps_2925.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2925 returns database upgrade steps for Juju 2.9.25
+func stateStepsFor2925() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "remove invalid charm placeholders",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveInvalidCharmPlaceholders()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2925_test.go
+++ b/upgrades/steps_2925_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2925 = version.MustParse("2.9.25")
+
+type steps2925Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2925Suite{})
+
+func (s *steps2925Suite) TestUpdateExternalControllerInfo(c *gc.C) {
+	step := findStateStep(c, v2925, "remove invalid charm placeholders")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -646,6 +646,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.20",
 		"2.9.22",
 		"2.9.24",
+		"2.9.25",
 	})
 }
 


### PR DESCRIPTION
The following updates the charmhub refresh API clients so that all
results are correctly ordered. This was written in the documentation of
the charmhub client API, but it was not observed when using the client.
This can be seen using the charmrevisionupdater expects all results to
be in order. If the results are out of order we end up creating place
holders with invalid revisions.

These are valid:

```
 - ch:amd64/focal/mongodb-64: {}
 - ch:amd64/focal/ubuntu-19: {}
```

After running they become:

```
 - ch:amd64/focal/mongodb-19: {}
 - ch:amd64/focal/mongodb-64: {}
 - ch:amd64/focal/ubuntu-19: {}
 - ch:amd64/focal/ubuntu-64: {}
```

## QA steps

```sh
$ juju bootstrap lxd test
$ juju enable-ha
$ juju deploy ubuntu
$ juju deploy mongodb
$ juju ssh -m controller 0
$ juju_engine_report | grep "ch:amd64/focal/"
```
Outputs:
```
          ch:amd64/focal/mongodb-64: {}	
          ch:amd64/focal/ubuntu-19: {}
```

Step the mongo primary down:
```sh
$ juju mongo
$ rs.stepDown(10)
```


```sh
$ juju ssh -m controller 0
$ juju_engine_report | grep "ch:amd64/focal/"
```

Invalid output:
```sh
          ch:amd64/focal/mongodb-19: {}
          ch:amd64/focal/mongodb-64: {}
          ch:amd64/focal/ubuntu-19: {}
          ch:amd64/focal/ubuntu-64: {}
```

The solution is to sort all results from the client.

Result should be:
```
          ch:amd64/focal/mongodb-64: {}	
          ch:amd64/focal/ubuntu-19: {}
```
