### PR TITLE
[JUJU-518] Remove CMR reliance on the model cache

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -485,7 +485,7 @@ func (s *watcherSuite) setupOfferStatusWatch(
 	}
 
 	// Initial event.
-	assertChange(status.Unset, "")
+	assertChange(status.Unknown, "")
 	return assertChange, assertNoChange, stop
 }
 

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -485,7 +485,7 @@ func (s *watcherSuite) setupOfferStatusWatch(
 	}
 
 	// Initial event.
-	assertChange(status.Unknown, "")
+	assertChange(status.Unset, "")
 	return assertChange, assertNoChange, stop
 }
 
@@ -496,13 +496,10 @@ func (s *watcherSuite) TestOfferStatusWatcher(c *gc.C) {
 	assertChange, assertNoChange, stop := s.setupOfferStatusWatch(c)
 	defer stop()
 
-	// watcher needs to come from model cache: https://bugs.launchpad.net/juju/+bug/1883625"
-	// Until then, the status checking is bypassed.
-	var err error
-	// err := mysql.SetStatus(status.StatusInfo{Status: status.Unknown, Message: "another message"})
-	// c.Assert(err, jc.ErrorIsNil)
+	err := mysql.SetStatus(status.StatusInfo{Status: status.Unknown, Message: "another message"})
+	c.Assert(err, jc.ErrorIsNil)
 
-	// assertChange(status.Waiting, "another message")
+	assertChange(status.Unknown, "another message")
 
 	// Removing offer and application both trigger events.
 	offers := state.NewApplicationOffers(s.State)

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -220,6 +220,15 @@ type Application interface {
 
 	// Status returns the status of the application.
 	Status() (status.StatusInfo, error)
+
+	// AllUnits returns all units of the application.
+	AllUnits() ([]Unit, error)
+}
+
+// Unit represents the state of a unit hosted in the local model.
+type Unit interface {
+	// Status returns the status of the unit.
+	Status() (status.StatusInfo, error)
 }
 
 // Bindings defines a subset of the functionality provided by the

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -92,6 +92,18 @@ func (a applicationShim) EndpointBindings() (Bindings, error) {
 	return a.Application.EndpointBindings()
 }
 
+func (a applicationShim) AllUnits() ([]Unit, error) {
+	all, err := a.Application.AllUnits()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]Unit, len(all))
+	for i, u := range all {
+		result[i] = u
+	}
+	return result, nil
+}
+
 func (st stateShim) Application(name string) (Application, error) {
 	a, err := st.State.Application(name)
 	if err != nil {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -46,7 +46,6 @@ type crossmodelRelationsSuite struct {
 	mockStatePool *mockStatePool
 	bakery        *mockBakeryService
 	authContext   *commoncrossmodel.AuthContext
-	cachedModel   *fakeCachedModel
 	api           *crossmodelrelations.CrossModelRelationsAPI
 
 	watchedRelations params.Entities
@@ -64,7 +63,6 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 		Tag:        names.NewMachineTag("0"),
 		Controller: true,
 	}
-	s.cachedModel = &fakeCachedModel{}
 
 	s.st = newMockState()
 	s.mockStatePool = &mockStatePool{map[string]commoncrossmodel.Backend{coretesting.ModelTag.Id(): s.st}}
@@ -93,7 +91,7 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	s.authContext, err = commoncrossmodel.NewAuthContext(s.mockStatePool, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := crossmodelrelations.NewCrossModelRelationsAPI(
-		s.st, fw, s.resources, s.authorizer, s.cachedModel,
+		s.st, fw, s.resources, s.authorizer,
 		s.authContext, egressAddressWatcher, relationStatusWatcher,
 		offerStatusWatcher)
 	c.Assert(err, jc.ErrorIsNil)
@@ -589,7 +587,7 @@ func (s *crossmodelRelationsSuite) TestWatchRelationsStatusRelationNotFound(c *g
 func (s *crossmodelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 	s.st.offers["mysql-uuid"] = &crossmodel.ApplicationOffer{
 		OfferName: "hosted-mysql", OfferUUID: "mysql-uuid", ApplicationName: "mysql"}
-	app := &mockApplication{name: "mysql"}
+	app := &mockApplication{name: "mysql", appStatus: status.Waiting}
 	s.st.applications["mysql"] = app
 	s.st.remoteEntities[names.NewApplicationOfferTag("hosted-mysql")] = "token-hosted-mysql"
 	mac, err := s.bakery.NewMacaroon(
@@ -635,7 +633,7 @@ func (s *crossmodelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 		{"Application", []interface{}{"mysql"}},
 	})
 	app.CheckCalls(c, []testing.StubCall{
-		{"Name", nil},
+		{"Status", nil},
 	})
 }
 
@@ -891,20 +889,4 @@ func (s *crossmodelRelationsSuite) TestWatchRelationUnitsOnV1(c *gc.C) {
 			},
 		}},
 	})
-}
-
-type fakeCachedModel struct {
-	err  error
-	info status.StatusInfo
-}
-
-func (f *fakeCachedModel) Application(name string) (commoncrossmodel.CachedApplication, error) {
-	if f.err != nil {
-		return nil, f.err
-	}
-	return f, nil
-}
-
-func (f *fakeCachedModel) Status() status.StatusInfo {
-	return status.StatusInfo{Status: status.Waiting}
 }

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -539,7 +539,8 @@ func (r *mockRemoteApplication) DestroyOperation(force bool) state.ModelOperatio
 
 type mockApplication struct {
 	commoncrossmodel.Application
-	name string
+	name      string
+	appStatus status.Status
 	testing.Stub
 	life state.Life
 	eps  []state.Endpoint
@@ -562,7 +563,11 @@ func (a *mockApplication) Life() state.Life {
 
 func (a *mockApplication) Status() (status.StatusInfo, error) {
 	a.MethodCall(a, "Status")
-	return status.StatusInfo{Status: status.Terminated}, nil
+	s := status.Terminated
+	if a.appStatus != "" {
+		s = a.appStatus
+	}
+	return status.StatusInfo{Status: s}, nil
 }
 
 type mockOfferConnection struct {

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -892,9 +892,8 @@ func newOfferStatusWatcher(context facade.Context) (facade.Facade, error) {
 // or the Watch call that created the srvOfferStatusWatcher.
 func (w *srvOfferStatusWatcher) Next() (params.OfferStatusWatchResult, error) {
 	if _, ok := <-w.watcher.Changes(); ok {
-		shim := crossmodel.CacheShim{w.model}
 		change, err := crossmodel.GetOfferStatusChange(
-			shim, crossmodel.GetBackend(w.st),
+			crossmodel.GetBackend(w.st),
 			w.watcher.OfferUUID(), w.watcher.OfferName())
 		if err != nil {
 			return params.OfferStatusWatchResult{


### PR DESCRIPTION
The following is a start to remove the model cache from various api
calls, so that we can fully understand where the model cache is actually
required.

This looks like an easy one but will require some thought on why it was
placed there in the first place.

The reason for this change is to fully remove the model cache for the new
database work lands.

## QA steps

```
$ juju bootstrap lxd src
$ juju deploy mysql
$ juju offer mysql:db
$ juju status --relations
```

```
$ juju add-model other
$ juju deploy wordpress
$ juju add-relation wordpress:db admin/default.mysql
```