### PR TITLE
[JUJU-517] Prevent charm revision calling on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build/
+_deps/
 cmd/juju/juju
 cmd/jujud/jujud
 cmd/builddb/builddb

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/juju/pubsub/v2 v2.0.0-20220104155641-7af8a09f58f0
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
 	github.com/juju/replicaset/v2 v2.0.1-0.20211125220232-7967ce535201
-	github.com/juju/retry v0.0.0-20180821225755-9058e192b216
+	github.com/juju/retry v0.0.0-20210818141810-5526f6f6ff07
 	github.com/juju/rfc/v2 v2.0.0-20210319034215-ed820200fad3
 	github.com/juju/romulus v0.0.0-20210309074704-4fa3bbd32568
 	github.com/juju/rpcreflect v0.0.0-20200416001309-bb46e9ba1476

--- a/go.sum
+++ b/go.sum
@@ -522,6 +522,8 @@ github.com/juju/retry v0.0.0-20151029024821-62c620325291/go.mod h1:OohPQGsr4pnxw
 github.com/juju/retry v0.0.0-20160928201858-1998d01ba1c3/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v0.0.0-20180821225755-9058e192b216 h1:/eQL7EJQKFHByJe3DeE8Z36yqManj9UY5zppDoQi4FU=
 github.com/juju/retry v0.0.0-20180821225755-9058e192b216/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
+github.com/juju/retry v0.0.0-20210818141810-5526f6f6ff07 h1:jnxK6Owo8yO92gXRr2AIJ7+CKs/l2dhKx0TqyvwcixI=
+github.com/juju/retry v0.0.0-20210818141810-5526f6f6ff07/go.mod h1:ccbrGJnibS6BJBXpdQl/b4r3MOf6KPrfJweNZplkig0=
 github.com/juju/rfc/v2 v2.0.0-20210319034215-ed820200fad3 h1:xxNLWSJgliRU691OJe2X+iyNgdV6vVOPSdu2blFxJzg=
 github.com/juju/rfc/v2 v2.0.0-20210319034215-ed820200fad3/go.mod h1:5bfynI3ARAqSscuwkXiWxcpZ+8XFlTd5dlUr6WcEerg=
 github.com/juju/romulus v0.0.0-20210309074704-4fa3bbd32568 h1:2somxwwYl73JFvcojV7hmQDFuzj/YH7Uv5uvAPn9afg=


### PR DESCRIPTION
On very large deployments we do not want the charm revision worker
starting up and instantly calling the charmhub/charmstore APIs. In a HA
environment, this is compounded by the fact that it does it for every
controller node. This can happen if you bounce the agents, so jujus
under load or in trouble are not helping themselves out here.

The solution here is half baked, I've left a TODO to state what the
correct solution is, for now, we will just jitter the worker for the
delay so that not every node is smashing the API at the same time.

The real solution is to have a lease for the worker so that it is only
responsible for calling the API. Releasing that lease when it's
terminated. We can not add `ifResponsible` flag in the manifold, because
if the agent is being bounced then there is a chance that this
never runs as the `clock.After` starts again every time.

I think for now, this is a happy medium.

## QA steps

Bootstrap juju and wait for it to run.