### PR TITLE
[JUJU-474] Create and save a display name for bootstrap machine on oci

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -461,6 +461,7 @@ func initBootstrapMachine(st *state.State, args InitializeStateParams) (bootstra
 		InstanceId:              args.BootstrapMachineInstanceId,
 		HardwareCharacteristics: hardware,
 		Jobs:                    jobs,
+		DisplayName:             args.BootstrapMachineDisplayName,
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create bootstrap machine in state")

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -171,6 +171,7 @@ LXC_BRIDGE="ignored"`[1:])
 		StateInitializationParams: instancecfg.StateInitializationParams{
 			BootstrapMachineConstraints:             expectBootstrapConstraints,
 			BootstrapMachineInstanceId:              "i-bootstrap",
+			BootstrapMachineDisplayName:             "test-display-name",
 			BootstrapMachineHardwareCharacteristics: &expectHW,
 			ControllerCloud: cloud.Cloud{
 				Name:         "dummy",
@@ -435,7 +436,8 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 
 	args := agentbootstrap.InitializeStateParams{
 		StateInitializationParams: instancecfg.StateInitializationParams{
-			BootstrapMachineInstanceId: "i-bootstrap",
+			BootstrapMachineInstanceId:  "i-bootstrap",
+			BootstrapMachineDisplayName: "test-display-name",
 			ControllerCloud: cloud.Cloud{
 				Name:      "dummy",
 				Type:      "dummy",

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -321,6 +321,10 @@ type StateInitializationParams struct {
 	// machine instance being initialized.
 	BootstrapMachineInstanceId instance.Id
 
+	// BootstrapMachineDisplayName is the human readable name for
+	// the bootstrap machine instance being initialized.
+	BootstrapMachineDisplayName string
+
 	// BootstrapMachineConstraints holds the constraints for the bootstrap
 	// machine.
 	BootstrapMachineConstraints constraints.Value
@@ -353,6 +357,7 @@ type stateInitializationParamsInternal struct {
 	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id,omitempty"`
 	BootstrapMachineConstraints             constraints.Value                 `yaml:"bootstrap-machine-constraints"`
 	BootstrapMachineHardwareCharacteristics *instance.HardwareCharacteristics `yaml:"bootstrap-machine-hardware,omitempty"`
+	BootstrapMachineDisplayName             string                            `yaml:"bootstrap-machine-display-name,omitempty"`
 	ModelConstraints                        constraints.Value                 `yaml:"model-constraints"`
 	CustomImageMetadataJSON                 string                            `yaml:"custom-image-metadata,omitempty"`
 	ControllerCloud                         string                            `yaml:"controller-cloud"`
@@ -382,6 +387,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		p.BootstrapMachineInstanceId,
 		p.BootstrapMachineConstraints,
 		p.BootstrapMachineHardwareCharacteristics,
+		p.BootstrapMachineDisplayName,
 		p.ModelConstraints,
 		string(customImageMetadataJSON),
 		string(controllerCloud),
@@ -422,6 +428,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		BootstrapMachineInstanceId:              internal.BootstrapMachineInstanceId,
 		BootstrapMachineConstraints:             internal.BootstrapMachineConstraints,
 		BootstrapMachineHardwareCharacteristics: internal.BootstrapMachineHardwareCharacteristics,
+		BootstrapMachineDisplayName:             internal.BootstrapMachineDisplayName,
 		ModelConstraints:                        internal.ModelConstraints,
 		CustomImageMetadata:                     imageMetadata,
 		ControllerCloud:                         controllerCloud,

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -306,6 +306,7 @@ func BootstrapInstance(
 
 	finalizer := func(ctx environs.BootstrapContext, icfg *instancecfg.InstanceConfig, opts environs.BootstrapDialOpts) error {
 		icfg.Bootstrap.BootstrapMachineInstanceId = result.Instance.Id()
+		icfg.Bootstrap.BootstrapMachineDisplayName = result.DisplayName
 		icfg.Bootstrap.BootstrapMachineHardwareCharacteristics = result.Hardware
 		icfg.Bootstrap.InitialSSHHostKeys = initialSSHHostKeys
 		envConfig := env.Config()

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -458,18 +458,6 @@ func (e *Environ) getCloudInitConfig(series string, apiPort int, statePort int) 
 	return cloudcfg, nil
 }
 
-func shortenMachineId(machineId *string, nRunesShown int) string {
-	var short string
-	if machineId != nil {
-		short = *machineId
-	}
-	offset := len(short) - nRunesShown
-	if offset > 0 {
-		short = "..." + short[offset:]
-	}
-	return short
-}
-
 // StartInstance implements environs.InstanceBroker.
 func (e *Environ) StartInstance(
 	ctx envcontext.ProviderCallContext, args environs.StartInstanceParams,
@@ -652,7 +640,6 @@ func (e *Environ) startInstance(
 		return nil, errors.Trace(err)
 	}
 	logger.Infof("started instance %q", *machineId)
-	displayName := shortenMachineId(machineId, 6)
 
 	if desiredStatus == ociCore.InstanceLifecycleStateRunning && allocatePublicIP {
 		if err := instance.waitForPublicIP(ctx); err != nil {
@@ -661,7 +648,7 @@ func (e *Environ) startInstance(
 	}
 
 	result := &environs.StartInstanceResult{
-		DisplayName: displayName,
+		DisplayName: hostname,
 		Instance:    instance,
 		Hardware:    instance.hardwareCharacteristics(),
 	}

--- a/provider/oci/environ_test.go
+++ b/provider/oci/environ_test.go
@@ -267,26 +267,6 @@ func (s *environSuite) setupListImagesExpectations() {
 	s.compute.EXPECT().ListShapes(context.Background(), gomock.Any(), gomock.Any()).Return(shapesResponse, nil).AnyTimes()
 }
 
-func (s *environSuite) TestMachineIdShortening(c *gc.C) {
-	blank := oci.ShortenMachineId(makeStringPointer(""), 6)
-	c.Check(blank, gc.Equals, "")
-
-	null := oci.ShortenMachineId(nil, 6)
-	c.Check(null, gc.Equals, "")
-
-	ocid := oci.ShortenMachineId(makeStringPointer("ocid"), 6)
-	c.Check(ocid, gc.Equals, "ocid")
-
-	id := oci.ShortenMachineId(makeStringPointer("ocid"), 2)
-	c.Check(id, gc.Equals, "...id")
-
-	short := oci.ShortenMachineId(makeStringPointer("ocid......12345678987654321"), 6)
-	c.Check(short, gc.Equals, "...654321")
-
-	shorter := oci.ShortenMachineId(makeStringPointer("ocid......12345678987654321"), 2)
-	c.Check(shorter, gc.Equals, "...21")
-}
-
 func (s *environSuite) TestAvailabilityZones(c *gc.C) {
 	ctrl := s.patchEnv(c)
 	defer ctrl.Finish()

--- a/provider/oci/export_test.go
+++ b/provider/oci/export_test.go
@@ -21,7 +21,6 @@ var (
 	OciStorageProviderType = ociStorageProviderType
 	OciVolumeType          = ociVolumeType
 	IscsiPool              = iscsiPool
-	ShortenMachineId       = shortenMachineId
 )
 
 func (e *Environ) SetClock(clock clock.Clock) {

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -283,8 +283,15 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+
+	displayName := mdoc.Hostname
+	if ns, err := instance.NewNamespace(mdoc.ModelUUID); err == nil {
+		displayName = ns.Value(mdoc.Id)
+	}
+
 	prereqOps = append(prereqOps, assertModelActiveOp(st.ModelUUID()))
 	prereqOps = append(prereqOps, insertNewContainerRefOp(st, mdoc.Id))
+
 	if template.InstanceId != "" {
 		prereqOps = append(prereqOps, txn.Op{
 			C:      instanceDataC,
@@ -294,6 +301,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 				DocID:          mdoc.DocID,
 				MachineId:      mdoc.Id,
 				InstanceId:     template.InstanceId,
+				DisplayName:    displayName,
 				ModelUUID:      mdoc.ModelUUID,
 				Arch:           template.HardwareCharacteristics.Arch,
 				Mem:            template.HardwareCharacteristics.Mem,

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -47,6 +47,10 @@ type MachineTemplate struct {
 	// fields must be set appropriately.
 	InstanceId instance.Id
 
+	// DisplayName holds the human readable name for the instance
+	// associated with the machine.
+	DisplayName string
+
 	// HardwareCharacteristics holds the h/w characteristics to
 	// be associated with the machine.
 	HardwareCharacteristics instance.HardwareCharacteristics
@@ -284,14 +288,8 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 		return nil, nil, errors.Trace(err)
 	}
 
-	displayName := mdoc.Hostname
-	if ns, err := instance.NewNamespace(mdoc.ModelUUID); err == nil {
-		displayName = ns.Value(mdoc.Id)
-	}
-
 	prereqOps = append(prereqOps, assertModelActiveOp(st.ModelUUID()))
 	prereqOps = append(prereqOps, insertNewContainerRefOp(st, mdoc.Id))
-
 	if template.InstanceId != "" {
 		prereqOps = append(prereqOps, txn.Op{
 			C:      instanceDataC,
@@ -301,7 +299,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 				DocID:          mdoc.DocID,
 				MachineId:      mdoc.Id,
 				InstanceId:     template.InstanceId,
-				DisplayName:    displayName,
+				DisplayName:    template.DisplayName,
 				ModelUUID:      mdoc.ModelUUID,
 				Arch:           template.HardwareCharacteristics.Arch,
 				Mem:            template.HardwareCharacteristics.Mem,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -888,6 +888,7 @@ func (s *StateSuite) TestAddMachines(c *gc.C) {
 		Constraints:             cons,
 		HardwareCharacteristics: hc,
 		InstanceId:              "inst-id",
+		DisplayName:             "test-display-name",
 		Nonce:                   "nonce",
 		Jobs:                    oneJob,
 	}
@@ -896,9 +897,6 @@ func (s *StateSuite) TestAddMachines(c *gc.C) {
 	c.Assert(machines, gc.HasLen, 1)
 	m, err := s.State.Machine(machines[0].Id())
 	c.Assert(err, jc.ErrorIsNil)
-	instId, err := m.InstanceId()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(string(instId), gc.Equals, "inst-id")
 	c.Assert(m.CheckProvisioned("nonce"), jc.IsTrue)
 	c.Assert(m.Series(), gc.Equals, "precise")
 	mcons, err := m.Constraints()
@@ -907,9 +905,10 @@ func (s *StateSuite) TestAddMachines(c *gc.C) {
 	mhc, err := m.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*mhc, gc.DeepEquals, hc)
-	instId, err = m.InstanceId()
+	instId, instDN, err := m.InstanceNames()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(instId), gc.Equals, "inst-id")
+	c.Assert(instDN, gc.Equals, "test-display-name")
 }
 
 func (s *StateSuite) TestAddMachinesModelDying(c *gc.C) {
@@ -945,9 +944,12 @@ func (s *StateSuite) TestAddMachineExtraConstraints(c *gc.C) {
 	oneJob := []state.MachineJob{state.JobHostUnits}
 	extraCons := constraints.MustParse("cores=4")
 	m, err := s.State.AddOneMachine(state.MachineTemplate{
+		DisplayName: "test-display-name",
 		Series:      "quantal",
 		Constraints: extraCons,
 		Jobs:        oneJob,
+		Nonce:       "nonce",
+		InstanceId:  "inst-id",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Id(), gc.Equals, "0")
@@ -957,6 +959,12 @@ func (s *StateSuite) TestAddMachineExtraConstraints(c *gc.C) {
 	mcons, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mcons, gc.DeepEquals, expectedCons)
+	m, err = s.State.Machine(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.CheckProvisioned("nonce"), jc.IsTrue)
+	_, instDN, err := m.InstanceNames()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instDN, gc.Equals, "test-display-name")
 }
 
 func (s *StateSuite) TestAddMachinePlacementIgnoresModelConstraints(c *gc.C) {
@@ -964,9 +972,12 @@ func (s *StateSuite) TestAddMachinePlacementIgnoresModelConstraints(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	oneJob := []state.MachineJob{state.JobHostUnits}
 	m, err := s.State.AddOneMachine(state.MachineTemplate{
-		Series:    "quantal",
-		Jobs:      oneJob,
-		Placement: "theplacement",
+		DisplayName: "test-display-name",
+		Series:      "quantal",
+		Jobs:        oneJob,
+		Placement:   "theplacement",
+		Nonce:       "nonce",
+		InstanceId:  "inst-id",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m.Id(), gc.Equals, "0")
@@ -977,6 +988,12 @@ func (s *StateSuite) TestAddMachinePlacementIgnoresModelConstraints(c *gc.C) {
 	mcons, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mcons, gc.DeepEquals, expectedCons)
+	m, err = s.State.Machine(m.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(m.CheckProvisioned("nonce"), jc.IsTrue)
+	_, instDN, err := m.InstanceNames()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instDN, gc.Equals, "test-display-name")
 }
 
 func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
@@ -1006,6 +1023,7 @@ func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
 		Constraints:             cons,
 		HardwareCharacteristics: hc,
 		InstanceId:              "inst-id",
+		DisplayName:             "test-display-name",
 		Nonce:                   "nonce",
 		Jobs:                    oneJob,
 		Volumes: []state.HostVolumeParams{{
@@ -1047,6 +1065,10 @@ func (s *StateSuite) TestAddMachineWithVolumes(c *gc.C) {
 		c.Assert(ok, jc.IsTrue)
 		c.Check(volumeParams, gc.Equals, machineTemplate.Volumes[i].Volume)
 	}
+	instId, instDN, err := m.InstanceNames()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(instId), gc.Equals, "inst-id")
+	c.Assert(instDN, gc.Equals, "test-display-name")
 }
 
 func (s *StateSuite) assertMachineContainers(c *gc.C, m *state.Machine, containers []string) {


### PR DESCRIPTION
#### Description

For some clouds, the instance id is very long, to simplify the `juju status` output we use a DisplayName. When bootstrapping on oci, a display name is not created for the controller machine. 

This PR has two commits:

* Creates and saves a display name for a bootstrapped controller machine.
* OCI has a custom way of shortening the model id and generate a `...foobar` style display name when provisioning an instance. This makes it use the `instance.Namespace` package to generate a `juju-foobar-0` style display name like the other providers do.

Fixes: [LP #1958423](https://bugs.launchpad.net/juju/+bug/1958423).

#### QA Steps

You need to bootstrap an Oracle OCI and add a model, look at the state of both the controller and the added model machines and you should see short nice `Inst Id`s:

```sh
juju bootstrap --config compartment-id=$OCID_COMPARTMENT oci-canonical oci-test-controller1

juju add-model --config compartment-id=$OCID_COMPARTMENT test-model1
juju deploy ubuntu
```

Now check the `Inst id` in both:

```sh
juju status -m controller

juju status -m test-model1
```