### PR TITLE
[JUJU-516] Enhanced error message for cache timeout upon setting unit charm URL

### DIFF
--- a/core/cache/branch.go
+++ b/core/cache/branch.go
@@ -75,7 +75,7 @@ func (b *Branch) Completed() int64 {
 	return b.details.Completed
 }
 
-// CreatedBy returns user who committed the branch.
+// CompletedBy returns user who committed the branch.
 func (b *Branch) CompletedBy() string {
 	return b.details.CompletedBy
 }

--- a/core/cache/controller.go
+++ b/core/cache/controller.go
@@ -229,7 +229,7 @@ func (c *Controller) Sweep() {
 	// When this call to `Sweep` is the first after a `Mark`, we will have been
 	// in initialization mode, and updates to cached models will not have
 	// caused summaries to be published.
-	// Now that the we are primed, publish all the summary data.
+	// Now that we are primed, publish all the summary data.
 	c.modelsMu.Lock()
 	for _, model := range c.models {
 		model.mu.Lock()

--- a/core/cache/resident.go
+++ b/core/cache/resident.go
@@ -59,7 +59,7 @@ type residentManager struct {
 	marked bool
 
 	// removals is the channel on which remove messages are sent.
-	// It will generally be the the cached controller's "changes" channel.
+	// It will generally be the cached controller's "changes" channel.
 	removals chan<- interface{}
 
 	// dying tells us that the manager's owner is going away.
@@ -111,7 +111,7 @@ func (m *residentManager) mark() {
 }
 
 // sweep removes stale cache residents in descending order of ID.
-// Lock protection of the resident map is done in "evictions" and in the
+// Lock protection of the resident map is done in "evictions" and in
 // the ultimate "evict" invocations.
 func (m *residentManager) sweep() <-chan struct{} {
 	finished := make(chan struct{})
@@ -252,7 +252,7 @@ func (r *Resident) cleanup() error {
 }
 
 // cleanupWorkers calls "Stop" on all registered workers.
-// Note that the deregistration method should have been added the the worker's
+// Note that the deregistration method should have been added to the worker's
 // tomb cleanup method - stopping the worker cleanly is enough to deregister.
 func (r *Resident) cleanupWorkers() error {
 	var errs []string
@@ -296,7 +296,7 @@ func (r *Resident) setRemovalMessage(msg interface{}) bool {
 	return wasNil
 }
 
-// unint64Reverse facilitates sorting of a slice in *descending* order.
+// uint64Reverse facilitates sorting of a slice in *descending* order.
 type uint64Reverse []uint64
 
 func (p uint64Reverse) Len() int           { return len(p) }

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -86,7 +86,7 @@ func (u *Unit) CharmURL() string {
 	return u.details.CharmURL
 }
 
-// OpenbPortRangesByEndpoint returns a map where keys are endpoint names and values
+// OpenPortRangesByEndpoint returns a map where keys are endpoint names and values
 // are the port ranges opened by the unit for each endpoint.
 func (u *Unit) OpenPortRangesByEndpoint() network.GroupedPortRanges {
 	return u.details.OpenPortRangesByEndpoint

--- a/core/multiwatcher/types.go
+++ b/core/multiwatcher/types.go
@@ -404,7 +404,7 @@ func (i *UnitInfo) Clone() EntityInfo {
 	return &clone
 }
 
-// ActionInfo holds the information about a action that is tracked by
+// ActionInfo holds the information about an action that is tracked by
 // multiwatcherStore.
 type ActionInfo struct {
 	ModelUUID  string

--- a/core/settings/settings.go
+++ b/core/settings/settings.go
@@ -40,7 +40,7 @@ func (c *ItemChange) IsModification() bool {
 	return c.Type == modified
 }
 
-// Is deletion returns true if this change indicates the removal of a
+// IsDeletion returns true if this change indicates the removal of a
 // previously operator-defined setting.
 func (c *ItemChange) IsDeletion() bool {
 	return c.Type == deleted

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -2180,8 +2180,8 @@ func (ctx *allWatcherContext) entityIDForGlobalKey(key string) (multiwatcher.Ent
 	} else if len(key) < 3 || key[1] != '#' {
 		return multiwatcher.EntityID{}, "", false
 	}
-	// NOTE: we should probably have a single place where we have all the global key functions
-	// so we can check coverage both ways.
+	// NOTE: we should probably have a single place where we have all the
+	// global key functions, so we can check coverage both ways.
 	parts := strings.Split(key, "#")
 	id := parts[1]
 	suffix := strings.Join(parts[2:], "#")

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -86,7 +86,7 @@ func (c Config) WithDefaultRestartStrategy() Config {
 	return c
 }
 
-// Validate ensures all the necessary values are specified
+// Validate ensures all the necessary values are specified.
 func (c *Config) Validate() error {
 	if c.StatePool == nil {
 		return errors.NotValidf("missing state pool")


### PR DESCRIPTION
When we get a cache time-out for setting the charm URL, we return an error indicating the unit and what we were trying to set it to, but not whether the unit was in the cache, or if it is, what it's charm URL is currently.

Here we provider that extra information.

The first commit is sundry spelling/grammar fixes made during analysis. It can be disregarded to ease review.

## QA steps

- Bootstrap and deploy an application successfully.
- Apply this patch:
```diff
diff --git a/apiserver/facades/agent/uniter/uniter.go b/apiserver/facades/agent/uniter/uniter.go
index cee013dccd..2ae632687a 100644
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -990,15 +990,15 @@ func (u *UniterAPI) SetCharmURL(args params.EntitiesCharmURL) (params.ErrorResul
 			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
-		err = apiservererrors.ErrPerm
+		//err = apiservererrors.ErrPerm
 		if canAccess(tag) {
-			var unit *state.Unit
-			unit, err = u.getUnit(tag)
+			//var unit *state.Unit
+			//unit, err = u.getUnit(tag)
 			if err == nil {
 				var curl *charm.URL
 				curl, err = charm.ParseURL(entity.CharmURL)
 				if err == nil {
-					err = unit.SetCharmURL(curl)
+					//err = unit.SetCharmURL(curl)
 				}
 				if err == nil {
 					// Wait for the change to propagate to the cache controller.
```
- Try to deploy another application/unit and note a logged error message like this:
```
unit-ubuntu-0: 16:05:24 ERROR juju.worker.dependency "uniter" manifold worker returned unexpected error: preparing operation "install ch:amd64/focal/ubuntu-19" for ubuntu/0: ubuntu/0.CharmURL is "", change to "ch:amd64/focal/ubuntu-19" timeout
```

## Documentation changes

None.

## Bug reference

N/A
