### PR TITLE
[JUJU-520] Remove redundant dependency from the presence manifold

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -391,12 +391,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// forwarding connections and api connection and disconnections to
 		// establish a view on which agents are "alive".
 		presenceName: prworker.Manifold(prworker.ManifoldConfig{
-			AgentName:              agentName,
-			CentralHubName:         centralHubName,
-			StateConfigWatcherName: stateConfigWatcherName,
-			Recorder:               config.PresenceRecorder,
-			Logger:                 loggo.GetLogger("juju.worker.presence"),
-			NewWorker:              prworker.NewWorker,
+			AgentName: agentName,
+			// CentralHubName depends on StateConfigWatcherName,
+			// which implies this can only run on controllers.
+			CentralHubName: centralHubName,
+			Recorder:       config.PresenceRecorder,
+			Logger:         loggo.GetLogger("juju.worker.presence"),
+			NewWorker:      prworker.NewWorker,
 		}),
 
 		// The state manifold creates a *state.State and makes it

--- a/worker/stateconfigwatcher/manifold.go
+++ b/worker/stateconfigwatcher/manifold.go
@@ -23,12 +23,12 @@ type ManifoldConfig struct {
 }
 
 // Manifold returns a dependency.Manifold which wraps the machine
-// agent's voyeur.Value which gets set whenever it the machine agent's
+// agent's voyeur.Value which gets set whenever the machine agent's
 // config is changed. Whenever the config is updated the presence of
 // state serving info is checked and if state serving info was added
 // or removed the manifold worker will bounce itself.
 //
-// The manifold offes a single boolean output which will be true if
+// The manifold offers a single boolean output which will be true if
 // state serving info is available (i.e. the machine agent should be a
 // state server) and false otherwise.
 //


### PR DESCRIPTION
The presence worker manifold depends on the state serving info worker to ensure that it runs on controllers. This is not required, because it is already implied by the dependency on the central hub.

Here, we remove the dependency.

## QA steps

- Bootstrap and `juju enable-ha`.
- Ensure via the engine report that the presence worker is running on each machine.

## Documentation changes

None.

## Bug reference

N/A
