### PR TITLE
[JUJU-523] Ensure a robust isController wrapper for machine manifolds

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -411,6 +411,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// The multiwatcher manifold watches all the changes in the database
 		// through the AllWatcherBacking and manages notifying the multiwatchers.
+		// Note: ifDatabaseUpgradeComplete implies running on a controller.
 		multiwatcherName: ifDatabaseUpgradeComplete(multiwatcher.Manifold(multiwatcher.ManifoldConfig{
 			StateName:            stateName,
 			Clock:                config.Clock,
@@ -432,6 +433,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The modelcache manifold creates a cache.Controller and keeps
 		// it up to date using an all model watcher. The controller is then
 		// used by the apiserver.
+		// Note: ifDatabaseUpgradeComplete implies running on a controller.
 		modelCacheName: ifDatabaseUpgradeComplete(modelcache.Manifold(modelcache.ManifoldConfig{
 			StateName:            stateName,
 			CentralHubName:       centralHubName,

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -274,11 +274,11 @@ type ManifoldsConfig struct {
 	LeaseFSM *raftlease.FSM
 
 	// RaftOpQueue represents a way to apply operations on to the raft
-	// instance from the API. The RaftQueue exists outside of the dependency
+	// instance from the API. The RaftQueue exists outside the dependency
 	// engine to prevent a circular dependency that can not be solved. By
 	// allowing back pressure on a client callee, we can allow for serialized
 	// operations upon the raft leader.
-	// If the queue becomes stalled there is now way to bounce this without
+	// If the queue becomes stalled there is no way to bounce this without
 	// restarting the agent itself. The same architecture is also applied to
 	// pubsub. Monitoring might be useful to detect this in the future.
 	RaftOpQueue *queue.OpQueue
@@ -298,7 +298,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 	//  1) to let us retry api connections immediately on password change,
 	//     rather than causing the dependency engine to wait for a while;
 	//  2) to decide how to deal with fatal, non-recoverable errors
-	//     e.g apicaller.ErrConnectImpossible.
+	//     e.g. apicaller.ErrConnectImpossible.
 	connectFilter := func(err error) error {
 		cause := errors.Cause(err)
 		if cause == apicaller.ErrConnectImpossible {
@@ -411,14 +411,14 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// The multiwatcher manifold watches all the changes in the database
 		// through the AllWatcherBacking and manages notifying the multiwatchers.
-		multiwatcherName: ifDatabaseUpgradeComplete(ifController(multiwatcher.Manifold(multiwatcher.ManifoldConfig{
+		multiwatcherName: ifDatabaseUpgradeComplete(multiwatcher.Manifold(multiwatcher.ManifoldConfig{
 			StateName:            stateName,
 			Clock:                config.Clock,
 			Logger:               loggo.GetLogger("juju.worker.multiwatcher"),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            multiwatcher.NewWorkerShim,
 			NewAllWatcher:        state.NewAllWatcherBacking,
-		}))),
+		})),
 
 		// The model cache initialized gate is used to make sure the api server
 		// isn't created before the model cache has been initialized with the
@@ -432,7 +432,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The modelcache manifold creates a cache.Controller and keeps
 		// it up to date using an all model watcher. The controller is then
 		// used by the apiserver.
-		modelCacheName: ifDatabaseUpgradeComplete(ifController(modelcache.Manifold(modelcache.ManifoldConfig{
+		modelCacheName: ifDatabaseUpgradeComplete(modelcache.Manifold(modelcache.ManifoldConfig{
 			StateName:            stateName,
 			CentralHubName:       centralHubName,
 			MultiwatcherName:     multiwatcherName,
@@ -440,7 +440,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:               loggo.GetLogger("juju.worker.modelcache"),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            modelcache.NewWorker,
-		}))),
+		})),
 
 		// The api-config-watcher manifold monitors the API server
 		// addresses in the agent config and bounces when they

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -33,14 +33,14 @@ func (s *ManifoldsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 }
 
-func (ms *ManifoldsSuite) TestStartFuncsIAAS(c *gc.C) {
-	ms.assertStartFuncs(c, machine.IAASManifolds(machine.ManifoldsConfig{
+func (s *ManifoldsSuite) TestStartFuncsIAAS(c *gc.C) {
+	s.assertStartFuncs(c, machine.IAASManifolds(machine.ManifoldsConfig{
 		Agent: &mockAgent{},
 	}))
 }
 
-func (ms *ManifoldsSuite) TestStartFuncsCAAS(c *gc.C) {
-	ms.assertStartFuncs(c, machine.CAASManifolds(machine.ManifoldsConfig{
+func (s *ManifoldsSuite) TestStartFuncsCAAS(c *gc.C) {
+	s.assertStartFuncs(c, machine.CAASManifolds(machine.ManifoldsConfig{
 		Agent: &mockAgent{},
 	}))
 }
@@ -52,8 +52,8 @@ func (*ManifoldsSuite) assertStartFuncs(c *gc.C, manifolds dependency.Manifolds)
 	}
 }
 
-func (ms *ManifoldsSuite) TestManifoldNamesIAAS(c *gc.C) {
-	ms.assertManifoldNames(c,
+func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *gc.C) {
+	s.assertManifoldNames(c,
 		machine.IAASManifolds(machine.ManifoldsConfig{
 			Agent: &mockAgent{},
 		}),
@@ -132,8 +132,8 @@ func (ms *ManifoldsSuite) TestManifoldNamesIAAS(c *gc.C) {
 	)
 }
 
-func (ms *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
-	ms.assertManifoldNames(c,
+func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
+	s.assertManifoldNames(c,
 		machine.CAASManifolds(machine.ManifoldsConfig{
 			Agent: &mockAgent{},
 		}),
@@ -217,7 +217,7 @@ func (*ManifoldsSuite) TestUpgradesBlockMigration(c *gc.C) {
 	checkContains(c, manifold.Inputs, "upgrade-steps-flag")
 }
 
-func (ms *ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
+func (s *ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 	exempt := set.NewStrings(
 		"agent",
 		"api-caller",
@@ -289,14 +289,14 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 	manifolds := machine.IAASManifolds(machine.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
+
+	// Explicitly guarded by ifController.
 	controllerWorkers := set.NewStrings(
 		"certificate-watcher",
 		"audit-config-updater",
 		"is-primary-controller-flag",
-		"model-cache",
 		"model-cache-initialized-flag",
 		"model-cache-initialized-gate",
-		"multiwatcher",
 		"lease-manager",
 		"legacy-leases-flag",
 		"raft-transport",
@@ -304,10 +304,20 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"upgrade-database-gate",
 		"upgrade-database-runner",
 	)
+
+	// Explicitly guarded by ifPrimaryController.
 	primaryControllerWorkers := set.NewStrings(
 		"external-controller-updater",
 		"transaction-pruner",
 	)
+
+	// Guarded by ifDatabaseUpgradeComplete,
+	// which implies running on a controller.
+	dbUpgradedWorkers := set.NewStrings(
+		"model-cache",
+		"multiwatcher",
+	)
+
 	for name, manifold := range manifolds {
 		c.Logf(name)
 		switch {
@@ -317,6 +327,10 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		case primaryControllerWorkers.Contains(name):
 			checkNotContains(c, manifold.Inputs, "is-controller-flag")
 			checkContains(c, manifold.Inputs, "is-primary-controller-flag")
+		case dbUpgradedWorkers.Contains(name):
+			checkNotContains(c, manifold.Inputs, "is-controller-flag")
+			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
+			checkContains(c, manifold.Inputs, "upgrade-database-flag")
 		default:
 			checkNotContains(c, manifold.Inputs, "is-controller-flag")
 			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
@@ -396,7 +410,7 @@ func assertGate(c *gc.C, manifold dependency.Manifold, unlocker gate.Unlocker) {
 	}
 }
 
-func (ms *ManifoldsSuite) TestManifoldsDependencies(c *gc.C) {
+func (s *ManifoldsSuite) TestManifoldsDependencies(c *gc.C) {
 	agenttest.AssertManifoldsDependencies(c,
 		machine.IAASManifolds(machine.ManifoldsConfig{
 			Agent: &mockAgent{},
@@ -497,7 +511,6 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 	"certificate-watcher": {
 		"agent",
 		"is-controller-flag",
-		"state",
 		"state-config-watcher",
 	},
 
@@ -540,7 +553,6 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"is-primary-controller-flag",
 		"migration-fortress",
 		"migration-inactive-flag",
-		"state",
 		"state-config-watcher",
 		"upgrade-check-flag",
 		"upgrade-check-gate",
@@ -618,14 +630,13 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"upgrade-steps-gate",
 	},
 
-	"is-controller-flag": {"agent", "state", "state-config-watcher"},
+	"is-controller-flag": {"agent", "state-config-watcher"},
 
 	"is-primary-controller-flag": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
 		"is-controller-flag",
-		"state",
 		"state-config-watcher",
 	},
 
@@ -757,14 +768,12 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"is-controller-flag",
 		"model-cache-initialized-gate",
-		"state",
 		"state-config-watcher",
 	},
 
 	"model-cache-initialized-gate": {
 		"agent",
 		"is-controller-flag",
-		"state",
 		"state-config-watcher",
 	},
 
@@ -1032,7 +1041,6 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 	"upgrade-database-flag": {
 		"agent",
 		"is-controller-flag",
-		"state",
 		"state-config-watcher",
 		"upgrade-database-gate",
 	},
@@ -1040,14 +1048,12 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 	"upgrade-database-gate": {
 		"agent",
 		"is-controller-flag",
-		"state",
 		"state-config-watcher",
 	},
 
 	"upgrade-database-runner": {
 		"agent",
 		"is-controller-flag",
-		"state",
 		"state-config-watcher",
 		"upgrade-database-gate",
 	},

--- a/cmd/jujud/agent/machine/stateflag.go
+++ b/cmd/jujud/agent/machine/stateflag.go
@@ -4,23 +4,28 @@
 package machine
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 )
 
-// isControllerFlagManifold returns a dependency.Manifold which requires
-// State, and returns a worker implementing engine.Flag, whose Check method
-// always returns true. This is used for flagging that the machine is a
-// controller/model manager.
+// isControllerFlagManifold returns a dependency.Manifold that requires state
+// config.
+// It returns a worker implementing engine.Flag, whose Check method returns
+// whether state config is present on the machine.
 func isControllerFlagManifold() dependency.Manifold {
 	return dependency.Manifold{
-		Inputs: []string{stateName},
+		Inputs: []string{stateConfigWatcherName},
 		Output: engine.FlagOutput,
 		Start: func(context dependency.Context) (worker.Worker, error) {
-			if err := context.Get(stateName, nil); err != nil {
+			var haveStateConfig bool
+			if err := context.Get(stateConfigWatcherName, &haveStateConfig); err != nil {
 				return nil, err
+			}
+			if !haveStateConfig {
+				return nil, errors.Annotate(dependency.ErrMissing, "no state config detected")
 			}
 			return engine.NewStaticFlagWorker(true), nil
 		},


### PR DESCRIPTION
Some manifolds in the machine dependency engine are wrapped with `isController` to ensure they only run on controllers. This wrapper in turn has the state worker as a dependency.

Depending on state in this case is problematic, because if the state fails to ping Mongo, all such workers will bounce whether or not they depend on state.

Instead we use the state config watcher, which determines whether we are a controller based on the presence of state serving info. This will remain static when we change the Mongo primary (and bounce the state worker), leaving fewer workers to restart in such an event.

In addition, some redundant usage of `isController` is removed where it is already implied by other dependencies.

## QA steps

- Bootstrap and `juju enable-ha`.
- `juju deploy ubuntu`.
- Observe error free operation in the quiesced state.
- `juju ssh 0` and run `juju_engine_report`.
- Ensure that controller-only workers are not being run.
- `juju ssh -m controller 0` and run `juju_engine_report`.
- Ensure that controller-only workers are being run.
- Connect to the Mongo primary and run `rs.stepDown()`
- Observe the controller and workloads return to an error-free state.

In my simple A/B test, these workers did not bounce for a Mongo primary switch:
- agent-config-updater
- certificate-watcher
- fan-configurer (probably incidental)
- is-controller-flag
- model-cache-initialized-flag
- upgrade-database-flag
- upgrade-database-gate
- upgrade-database-runner

## Documentation changes

None.

## Bug reference

N/A
