### PR TITLE
[JUJU-526] Fix comment about disabled os

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -26,11 +26,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS-latest is disabled because there is an issue of the tests timing
-        # out. No effort has been done to work out why they currently timeout
-        # on macOS, but we should investigate that to improve our coverage on
-        # other clients.
-        # To turn on macOS, just update the os to include it.
+        # windows tests is disabled because we require a certain version of
+        # mongo (that's actually going away now though), and choclately was
+        # failing to install it correctly.
         # os: [ubuntu-latest, macOS-latest, windows-latest]
         os: [ubuntu-latest, macOS-latest]
 


### PR DESCRIPTION
The client-tests.yml file in juju/juju explains why macOS builds are disabled when they are not.  Instead Windows builds are disabled but the reason is not given

## Checklist

No check list?

## QA steps

There is no QA, it's only a comment

## Documentation changes

None

## Bug reference

No bug reference
