### PR TITLE
Fix for "juju find-offers" access in tabular format.

### DIFF
--- a/cmd/juju/crossmodel/find.go
+++ b/cmd/juju/crossmodel/find.go
@@ -4,6 +4,8 @@
 package crossmodel
 
 import (
+	"strings"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -191,7 +193,7 @@ type ApplicationOfferResult struct {
 
 func accessForUser(user names.UserTag, users []crossmodel.OfferUserDetails) string {
 	for _, u := range users {
-		if u.UserName == user.Id() {
+		if strings.ToLower(u.UserName) == strings.ToLower(user.Id()) {
 			return string(u.Access)
 		}
 	}


### PR DESCRIPTION
Tabular format was not showing the correct access level in case the logged in user's username contained upper case letters.

In general Juju lower cases usernames, but the logged-in user's username may contain upper case letters as may be the case when Candid uses custom identity providers.

## QA steps

1. deploy LDAP and create a user with a username that contains upper case letters
2. deploy candid and configure it to use the deployed LDAP
3. bootstrap a controller that uses candid deployed in step 2
4. add a model and deploy mysql
5. create an application offer from the deployed mysql application
6.  run "juju find-offfers"
7. the tabular output should show "admin" as access level on the created offer

## Documentation changes

no changes needed

## Bug reference

https://bugs.launchpad.net/juju/+bug/1959584
