### PR TITLE
[JUJU-416] Consistantly use juju/retry to handle retries 5 (provider/ec2/*) (lazy)

### DIFF
--- a/provider/ec2/export_test.go
+++ b/provider/ec2/export_test.go
@@ -69,7 +69,7 @@ var (
 	GetBlockDeviceMappings         = getBlockDeviceMappings
 	IsVPCNotUsableError            = isVPCNotUsableError
 	IsVPCNotRecommendedError       = isVPCNotRecommendedError
-	ShortAttempt                   = &shortAttempt
+	ShortRetryStrategy             = &shortRetryStrategy
 	DestroyVolumeAttempt           = &destroyVolumeAttempt
 	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
 	TerminateInstancesById         = &terminateInstancesById

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/os/v2/series"
+	"github.com/juju/retry"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/arch"
@@ -1701,6 +1702,7 @@ func (t *localServerSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 	inst, _ := testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "1")
 
 	infoLists, err := env.NetworkInterfaces(t.callCtx, []instance.Id{inst.Id(), instance.Id("bogus")})
+	c.Log(infoLists)
 	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
 	c.Assert(infoLists, gc.HasLen, 2)
 
@@ -2072,11 +2074,9 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 
 func patchEC2ForTesting(c *gc.C, region types.Region) func() {
 	ec2.UseTestImageData(c, ec2.MakeTestImageStreamsData(region))
-	restoreTimeouts := envtesting.PatchAttemptStrategies(ec2.ShortAttempt)
 	restoreFinishBootstrap := envtesting.DisableFinishBootstrap()
 	return func() {
 		restoreFinishBootstrap()
-		restoreTimeouts()
 		ec2.UseTestImageData(c, nil)
 	}
 }
@@ -2409,20 +2409,22 @@ func (t *localServerSuite) TestStopInstances(c *gc.C) {
 	// We need the retry logic here because we are waiting
 	// for Instances to return an error, and it will not retry
 	// if it succeeds.
-	gone := false
-	for a := ec2.ShortAttempt.Start(); a.Next(); {
+	retryStrategy := ec2.ShortRetryStrategy
+	retryStrategy.Func = func() error {
 		insts, err = t.Env.Instances(t.callCtx, []instance.Id{inst0.Id(), inst2.Id()})
 		if err == environs.ErrPartialInstances {
 			// instances not gone yet.
-			continue
+			return err
 		}
 		if err == environs.ErrNoInstances {
-			gone = true
-			break
+			return nil
 		}
 		c.Fatalf("error getting instances: %v", err)
+		return errors.New(fmt.Sprintf("error getting instances: %v", err))
 	}
-	if !gone {
+	err = retry.Call(*retryStrategy)
+
+	if err != nil {
 		c.Errorf("after termination, instances remaining: %v", insts)
 	}
 }


### PR DESCRIPTION
Throughout Juju we have inconsistent ways of performing retries. Standardise all retry code to the repository github.com/juju/retry.

Replace occurrences of this old method of retries from the provider/ec2/ directory

This is an alternative to https://github.com/juju/juju/pull/13647, fixing some problems that were raised in review the, inefficient easy way.

Instead of nasty patching the values of `shortRetryAttempt`, do nothing. This means tests go from approx 15s on my machine to 60s

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/provider/ec2
```

## Documentation changes

No documentation changes required

## Bug reference

https://bugs.launchpad.net/juju/+bug/1611427/
