### PR TITLE
[Juju-542] Add ap-southeast-3 aws region

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -37,6 +37,8 @@ clouds:
         endpoint: https://ec2.ap-southeast-1.amazonaws.com
       ap-southeast-2:
         endpoint: https://ec2.ap-southeast-2.amazonaws.com
+      ap-southeast-3:
+        endpoint: https://ec2.ap-southeast-3.amazonaws.com
       ap-northeast-1:
         endpoint: https://ec2.ap-northeast-1.amazonaws.com
       ap-northeast-2:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -44,6 +44,8 @@ clouds:
         endpoint: https://ec2.ap-southeast-1.amazonaws.com
       ap-southeast-2:
         endpoint: https://ec2.ap-southeast-2.amazonaws.com
+      ap-southeast-3:
+        endpoint: https://ec2.ap-southeast-3.amazonaws.com
       ap-northeast-1:
         endpoint: https://ec2.ap-northeast-1.amazonaws.com
       ap-northeast-2:

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2097,6 +2097,7 @@ ap-east-1
 ap-south-1
 ap-southeast-1
 ap-southeast-2
+ap-southeast-3
 ap-northeast-1
 ap-northeast-2
 ap-northeast-3
@@ -2109,7 +2110,7 @@ func (s *BootstrapSuite) TestBootstrapInvalidRegion(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "aws/eu-west")
 	c.Assert(err, gc.ErrorMatches, `region "eu-west" for cloud "aws" not valid`)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-north-1, eu-south-1, eu-west-1, eu-west-2, eu-west-3, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ap-southeast-3, ca-central-1, eu-central-1, eu-north-1, eu-south-1, eu-west-1, eu-west-2, eu-west-3, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 }
 


### PR DESCRIPTION
Add ap-southeast-3 aws region. It is an opt in region.

## QA Steps
``` console
$ juju regions aws

Client Cloud Regions
...
ap-southeast-3
...

```