### PR TITLE
[JUJU-395] Adds support for dashboard proxying on to CAAS.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/utils/v3/shell"
 	"github.com/juju/version/v2"
 
+	"github.com/juju/juju/agent/constants"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/machinelock"
@@ -562,7 +563,7 @@ func Dir(dataDir string, tag names.Tag) string {
 // NOTE: Delete this once all agents accept --config instead
 // of --data-dir - it won't be needed anymore.
 func ConfigPath(dataDir string, tag names.Tag) string {
-	return filepath.Join(Dir(dataDir, tag), AgentConfigFilename)
+	return filepath.Join(Dir(dataDir, tag), constants.AgentConfigFilename)
 }
 
 // ReadConfig reads configuration data from the given location.
@@ -865,7 +866,7 @@ func (c *configInternal) WriteCommands(renderer shell.Renderer) ([]string, error
 		return nil, errors.Trace(err)
 	}
 	commands := renderer.MkdirAll(c.Dir())
-	filename := c.File(AgentConfigFilename)
+	filename := c.File(constants.AgentConfigFilename)
 	commands = append(commands, renderer.WriteFile(filename, data)...)
 	commands = append(commands, renderer.Chmod(filename, 0600)...)
 	return commands, nil

--- a/agent/constants/constants.go
+++ b/agent/constants/constants.go
@@ -1,0 +1,10 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package constants
+
+const (
+	// AgentConfigFilename is the default file name of used for the agent
+	// config.
+	AgentConfigFilename = "agent.conf"
+)

--- a/agent/format-2.0_whitebox_test.go
+++ b/agent/format-2.0_whitebox_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
+	agentconstants "github.com/juju/juju/agent/constants"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/testing"
 )
@@ -28,7 +29,7 @@ var _ = gc.Suite(&format_2_0Suite{})
 
 func (s *format_2_0Suite) TestStatePortNotParsedWithoutSecret(c *gc.C) {
 	dataDir := c.MkDir()
-	configPath := filepath.Join(dataDir, AgentConfigFilename)
+	configPath := filepath.Join(dataDir, agentconstants.AgentConfigFilename)
 	err := utils.AtomicWriteFile(configPath, []byte(agentConfig2_0NotStateMachine), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	readConfig, err := ReadConfig(configPath)
@@ -39,7 +40,7 @@ func (s *format_2_0Suite) TestStatePortNotParsedWithoutSecret(c *gc.C) {
 
 func (*format_2_0Suite) TestReadConfWithExisting2_0ConfigFileContents(c *gc.C) {
 	dataDir := c.MkDir()
-	configPath := filepath.Join(dataDir, AgentConfigFilename)
+	configPath := filepath.Join(dataDir, agentconstants.AgentConfigFilename)
 	err := utils.AtomicWriteFile(configPath, []byte(agentConfig2_0Contents), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/agent/format.go
+++ b/agent/format.go
@@ -55,10 +55,6 @@ func registerFormat(format formatter) {
 // currentFormat holds the current agent config version's formatter.
 var currentFormat = format_2_0
 
-// AgentConfigFilename is the default file name of used for the agent
-// config.
-const AgentConfigFilename = "agent.conf"
-
 // formatPrefix is prefix of the first line in an agent config file.
 const formatPrefix = "# format "
 

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -390,22 +390,17 @@ func (c *Client) ControllerVersion() (ControllerVersion, error) {
 	return out, err
 }
 
-// DashboardAddresses returns the address info needed to connect to the dashboard.
-func (c *Client) DashboardAddresses() ([]string, bool, error) {
-	result := params.DashboardInfo{}
-	err := c.facade.FacadeCall("DashboardAddressInfo", nil, &result)
+// DashboardConnectionInfo fetches the connection information needed for
+// connecting to the Juju Dashboard.
+func (c *Client) DashboardConnectionInfo() (params.DashboardConnectionInfo, error) {
+	result := params.DashboardConnectionInfo{}
+	err := c.facade.FacadeCall("DashboardConnectionInfo", nil, &result)
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return result, errors.Trace(err)
 	}
+
 	if result.Error != nil {
-		var apiErr error = result.Error
-		if params.IsCodeNotFound(apiErr) {
-			apiErr = errors.NotFoundf("dashboard")
-		}
-		return nil, false, errors.Trace(apiErr)
+		err = result.Error
 	}
-	if len(result.Addresses) < 1 {
-		return nil, false, errors.NotFoundf("dashboard")
-	}
-	return result.Addresses, result.UseTunnel, nil
+	return result, err
 }

--- a/apiserver/facades/client/controller/backend.go
+++ b/apiserver/facades/client/controller/backend.go
@@ -51,6 +51,7 @@ type Relation interface {
 	Endpoint(applicationname string) (state.Endpoint, error)
 	RelatedEndpoints(applicationname string) ([]state.Endpoint, error)
 	ApplicationSettings(appName string) (map[string]interface{}, error)
+	ModelUUID() string
 }
 
 type stateShim struct {

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/juju/charm/v9"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -30,7 +29,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/client/controller"
-	"github.com/juju/juju/apiserver/facades/client/controller/mocks"
 	"github.com/juju/juju/apiserver/params"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloud"
@@ -1215,38 +1213,4 @@ var _ = gc.Suite(&controllerUnitSuite{})
 func (s *controllerUnitSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	return ctrl
-}
-
-func (s *controllerUnitSuite) TestDashboardAddressInfo(c *gc.C) {
-	ctrl := s.setup(c)
-	defer ctrl.Finish()
-
-	backend := mocks.NewMockBackend(ctrl)
-	controllerApp := mocks.NewMockApplication(ctrl)
-	dashboardApp := mocks.NewMockApplication(ctrl)
-	relation := mocks.NewMockRelation(ctrl)
-
-	backend.EXPECT().Application("controller").Return(controllerApp, nil)
-	controllerApp.EXPECT().Name().Return("controller").AnyTimes()
-	controllerApp.EXPECT().Relations().Return([]controller.Relation{relation}, nil)
-	relation.EXPECT().Endpoint("controller").Return(state.Endpoint{
-		Relation: charm.Relation{Name: "dashboard"},
-	}, nil)
-	relation.EXPECT().RelatedEndpoints("controller").Return([]state.Endpoint{{
-		ApplicationName: "juju-dashboard",
-	}}, nil)
-	relation.EXPECT().ApplicationSettings("juju-dashboard").Return(map[string]interface{}{
-		"dashboard-ingress": "10.6.6.6",
-	}, nil)
-
-	backend.EXPECT().Application("juju-dashboard").Return(dashboardApp, nil)
-	dashboardApp.EXPECT().CharmConfig("master").Return(charm.Settings{"port": 666}, nil)
-
-	api := controller.NewControllerAPIForTest(backend)
-	info, err := api.DashboardAddressInfo()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(info, jc.DeepEquals, params.DashboardInfo{
-		Addresses: []string{"10.6.6.6:666"},
-		UseTunnel: true,
-	})
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -19578,21 +19578,58 @@
                 "DashboardConnectionInfo": {
                     "type": "object",
                     "properties": {
-                        "connection": {
-                            "type": "object",
-                            "additionalProperties": true
-                        },
-                        "connection-type": {
-                            "type": "string"
-                        },
                         "error": {
                             "$ref": "#/definitions/Error"
+                        },
+                        "proxy-connection": {
+                            "$ref": "#/definitions/DashboardConnectionProxy"
+                        },
+                        "ssh-connection": {
+                            "$ref": "#/definitions/DashboardConnectionSSHTunnel"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "connection",
-                        "connection-type"
+                        "proxy-connection",
+                        "ssh-connection"
+                    ]
+                },
+                "DashboardConnectionProxy": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config",
+                        "type"
+                    ]
+                },
+                "DashboardConnectionSSHTunnel": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "host",
+                        "port"
                     ]
                 },
                 "DestroyControllerArgs": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -19191,14 +19191,14 @@
                     },
                     "description": "ControllerVersion returns the version information associated with this\ncontroller binary.\n\nNOTE: the implementation intentionally does not check for SuperuserAccess\nas the Version is known even to users with login access."
                 },
-                "DashboardAddressInfo": {
+                "DashboardConnectionInfo": {
                     "type": "object",
                     "properties": {
                         "Result": {
-                            "$ref": "#/definitions/DashboardInfo"
+                            "$ref": "#/definitions/DashboardConnectionInfo"
                         }
                     },
-                    "description": "DashboardAddressInfo returns the address info needed to connect to the juju dashboard."
+                    "description": "DashboardConnectionInfo returns the connection information for a client to\nconnect to the Juju Dashboard including any proxying information."
                 },
                 "DestroyController": {
                     "type": "object",
@@ -19575,26 +19575,24 @@
                         "git-commit"
                     ]
                 },
-                "DashboardInfo": {
+                "DashboardConnectionInfo": {
                     "type": "object",
                     "properties": {
-                        "addresses": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
+                        "connection": {
+                            "type": "object",
+                            "additionalProperties": true
+                        },
+                        "connection-type": {
+                            "type": "string"
                         },
                         "error": {
                             "$ref": "#/definitions/Error"
-                        },
-                        "use-tunnel": {
-                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "addresses",
-                        "use-tunnel"
+                        "connection",
+                        "connection-type"
                     ]
                 },
                 "DestroyControllerArgs": {

--- a/apiserver/params/controller.go
+++ b/apiserver/params/controller.go
@@ -4,9 +4,13 @@
 package params
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/proxy"
 )
 
 // DestroyControllerArgs holds the arguments for destroying a controller.
@@ -132,10 +136,146 @@ type ControllerVersionResults struct {
 	GitCommit string `json:"git-commit"`
 }
 
+const (
+	// DashboardConnectionTypeProxy is the type key used for proxy connections
+	DashboardConnectionTypeProxy = "proxy"
+
+	// DashboardConnectionTypeSSHTunnel is the type key used for ssh connections
+	DashboardConnectionTypeSSHTunnel = "ssh-tunnel"
+)
+
+// DashboardConnectionProxy represents a proxy connection to the Juju Dashboard
+type DashboardConnectionProxy struct {
+	Proxier       proxy.Proxier   `json:"proxier"`
+	proxierConfig json.RawMessage `json:"-"`
+	ProxierType   string          `json:"type"`
+}
+
+// ProxierFactory is an interface type representing a factory that can make a
+// new juju proxier from the supplied type and JSON config.
+type ProxierFactory interface {
+	ProxierFromJSONDataBag(proxierType string, config json.RawMessage) (proxy.Proxier, error)
+}
+
+// DashboardConnectionSSHTunnel represents an ssh tunnel connection to the Juju
+// Dashboard
+type DashboardConnectionSSHTunnel struct {
+	Host string `json:"host"`
+	Port string `json:"port"`
+}
+
+// DashboardConnection interface represents a generic interface for establishing
+// dashboard connections.
+type DashboardConnection interface {
+	Type() string
+}
+
+// DashboardConnectionInfo holds the information necassery
+type DashboardConnectionInfo struct {
+	Connection     DashboardConnection `json:"connection"`
+	ConnectionType string              `json:"connection-type"`
+	Error          *Error              `json:"error,omitempty"`
+}
+
 // DashboardInfo holds the results from an api call
 // to get address info for the juju dashboard.
 type DashboardInfo struct {
 	Addresses []string `json:"addresses"`
 	UseTunnel bool     `json:"use-tunnel"`
 	Error     *Error   `json:"error,omitempty"`
+}
+
+// NewDashboardConnectionProxy constructs a new DashboardConnectionProxy from
+// the supplied proxier.
+func NewDashboardConnectionProxy(proxier proxy.Proxier) *DashboardConnectionProxy {
+	proxierType := ""
+	if proxier != nil {
+		proxierType = proxier.Type()
+	}
+	return &DashboardConnectionProxy{
+		Proxier:     proxier,
+		ProxierType: proxierType,
+	}
+}
+
+// Type implements the DashboardConnection interface
+func (_ *DashboardConnectionProxy) Type() string {
+	return DashboardConnectionTypeProxy
+}
+
+// Type implements the DashboardConnection interface
+func (_ *DashboardConnectionSSHTunnel) Type() string {
+	return DashboardConnectionTypeSSHTunnel
+}
+
+// UnmarshalJSON implements the encoding/json Unmarshaller interface
+func (d *DashboardConnectionInfo) UnmarshalJSON(data []byte) error {
+	wireFormat := &struct {
+		Connection     json.RawMessage `json:"connection"`
+		ConnectionType string          `json:"connection-type"`
+		Error          *Error          `json:"error,omitempty"`
+	}{}
+	if err := json.Unmarshal(data, wireFormat); err != nil {
+		return errors.Trace(err)
+	}
+	switch ct := wireFormat.ConnectionType; ct {
+	case DashboardConnectionTypeProxy:
+		con := &DashboardConnectionProxy{}
+		if err := json.Unmarshal(wireFormat.Connection, con); err != nil {
+			return errors.Trace(err)
+		}
+		d.Connection = con
+	case DashboardConnectionTypeSSHTunnel:
+		con := &DashboardConnectionSSHTunnel{}
+		if err := json.Unmarshal(wireFormat.Connection, con); err != nil {
+			return errors.Trace(err)
+		}
+		d.Connection = con
+	case "":
+		break
+	default:
+		return fmt.Errorf("Unknown connection type %q", ct)
+	}
+
+	d.ConnectionType = wireFormat.ConnectionType
+	d.Error = wireFormat.Error
+	return nil
+}
+
+// ProxierFromFactory attempts to construct a Juju proxier from the raw JSON
+// configuration in this connection using the supplied proxier factory.
+func (d *DashboardConnectionProxy) ProxierFromFactory(factory ProxierFactory) (proxy.Proxier, error) {
+	if d.Proxier != nil {
+		return d.Proxier, nil
+	}
+
+	if d.ProxierType == "" {
+		return nil, errors.NotValidf("proxier type is empty, unable to construct a proxy from an empty type")
+	}
+
+	proxier, err := factory.ProxierFromJSONDataBag(d.ProxierType, d.proxierConfig)
+	if err != nil {
+		return nil, errors.Annotate(err, "making proxy from configuration")
+	}
+
+	d.Proxier = proxier
+	return proxier, nil
+}
+
+// UnmarshalJSON implements the encoding/json Unmarshaller interface
+func (d *DashboardConnectionProxy) UnmarshalJSON(data []byte) error {
+	wireFormat := &struct {
+		ProxierConfig json.RawMessage `json:"proxier"`
+		ProxierType   string          `json:"type"`
+	}{}
+
+	if err := json.Unmarshal(data, wireFormat); err != nil {
+		return errors.Trace(err)
+	}
+
+	d.ProxierType = wireFormat.ProxierType
+	d.proxierConfig = wireFormat.ProxierConfig
+	d.Proxier = nil
+
+	return nil
 }

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/docker"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/proxy"
 	"github.com/juju/juju/storage"
 )
 
@@ -215,6 +216,9 @@ type Broker interface {
 
 	// EnsureImageRepoSecret ensures the image pull secret gets created.
 	EnsureImageRepoSecret(docker.ImageRepoDetails) error
+
+	// ProxyManager provides methods for managing application proxy connections.
+	ProxyManager
 }
 
 // ApplicationBroker provides an API for accessing the broker interface for
@@ -311,6 +315,11 @@ type CredentialChecker interface {
 	// CheckCloudCredentials verifies that the provided cloud credentials
 	// are still valid for the cloud.
 	CheckCloudCredentials() error
+}
+
+// ProxyManager provides the API to get proxier information for applications
+type ProxyManager interface {
+	ProxyToApplication(appName, remotePort string) (proxy.Proxier, error)
 }
 
 // ServiceManager provides the API to manipulate services.

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -419,7 +419,7 @@ func (c *controllerStack) Deploy() (err error) {
 	}
 
 	// create the proxy resources for services of type cluster ip
-	if err = c.createControllerProxy(); err != nil {
+	if err = c.createControllerProxy(c.ctx.Context()); err != nil {
 		return errors.Annotate(err, "creating controller service proxy for controller")
 	}
 
@@ -538,7 +538,7 @@ func (c *controllerStack) getControllerSvcSpec(cloudType string, cfg *podcfg.Boo
 	return spec, nil
 }
 
-func (c *controllerStack) createControllerProxy() error {
+func (c *controllerStack) createControllerProxy(ctx context.Context) error {
 	if c.pcfg.Bootstrap.IgnoreProxy {
 		return nil
 	}
@@ -568,6 +568,7 @@ func (c *controllerStack) createControllerProxy() error {
 	}
 
 	err = k8sproxy.CreateControllerProxy(
+		ctx,
 		config,
 		c.stackLabels,
 		k8sClient.CoreV1().ConfigMaps(c.broker.GetCurrentNamespace()),

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/agent"
+	agentconstants "github.com/juju/juju/agent/constants"
 	"github.com/juju/juju/caas"
 	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider/application"
@@ -292,7 +293,7 @@ func newcontrollerStack(
 	cs.resourceNameVolSharedSecret = cs.getResourceName(mongo.SharedSecretFile)
 	cs.resourceNameVolSSLKey = cs.getResourceName(mongo.FileNameDBSSLKey)
 	cs.resourceNameVolBootstrapParams = cs.getResourceName(cloudconfig.FileNameBootstrapParams)
-	cs.resourceNameVolAgentConf = cs.getResourceName(agent.AgentConfigFilename)
+	cs.resourceNameVolAgentConf = cs.getResourceName(agentconstants.AgentConfigFilename)
 
 	if cs.dockerAuthSecretData, err = pcfg.Controller.Config.CAASImageRepo().SecretData(); err != nil {
 		return nil, errors.Trace(err)
@@ -1375,7 +1376,7 @@ func (c *controllerStack) buildContainerSpecForController() (*core.PodSpec, erro
 	agentConfigRelativePath := c.pathJoin(
 		"agents",
 		fmt.Sprintf("controller-%s", c.pcfg.ControllerId),
-		agent.AgentConfigFilename,
+		agentconstants.AgentConfigFilename,
 	)
 	var jujudCmds []string
 	pushCmd := func(cmd string) {

--- a/caas/kubernetes/provider/connection.go
+++ b/caas/kubernetes/provider/connection.go
@@ -36,6 +36,15 @@ func (k *kubernetesClient) ProxyToApplication(appName, remotePort string) (proxy
 		return nil, errors.Annotatef(err, "ensuring proxy service for application %s", appName)
 	}
 
+	err = k8sproxy.WaitForProxyService(
+		context.Background(),
+		proxyName,
+		k.client().CoreV1().ServiceAccounts(k.GetCurrentNamespace()),
+	)
+	if err != nil {
+		return nil, errors.Annotatef(err, "waiting for proxy service for application %s", appName)
+	}
+
 	config := k8sproxy.GetProxyConfig{
 		APIHost:    k.k8sCfgUnlocked.Host,
 		Namespace:  k.GetCurrentNamespace(),

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -6,7 +6,7 @@ package constants
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/juju/juju/agent"
+	agentconstants "github.com/juju/juju/agent/constants"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 	JujuExecServerSocketPort = 30666
 
 	// TemplateFileNameAgentConf is the template agent.conf file name.
-	TemplateFileNameAgentConf = "template-" + agent.AgentConfigFilename
+	TemplateFileNameAgentConf = "template-" + agentconstants.AgentConfigFilename
 
 	// ControllerAgentConfigFilename is the agent conf filename
 	// for the controller agent for the api server.

--- a/caas/kubernetes/provider/proxy/info.go
+++ b/caas/kubernetes/provider/proxy/info.go
@@ -19,6 +19,61 @@ const (
 	serviceAccountSecretTokenKey  = "token"
 )
 
+// GetProxyConfig is as config input to the GetProxy function. It describes
+// basic properties to seed the returned Proxier object with.
+type GetProxyConfig struct {
+	// APIHost to expect when performing SNI with the kubernetes API.
+	APIHost string
+
+	// Namespace is the namespace the proxied targets resides in.
+	Namespace string
+
+	// RemotePort to proxy to.
+	RemotePort string
+
+	// The service in the above Namespace to proxy onto.
+	Service string
+}
+
+// GetProxy attempts to create a Proxier from the named resources using the
+// found service account and associated secret.
+func GetProxy(
+	name string,
+	config GetProxyConfig,
+	saI core.ServiceAccountInterface,
+	secretI core.SecretInterface,
+) (*Proxier, error) {
+	sa, err := saI.Get(context.TODO(), name, meta.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil, errors.NotFoundf("proxy service account for %s", name)
+	} else if err != nil {
+		return nil, errors.Annotatef(err, "proxy service account for %s", name)
+	}
+
+	if secLen := len(sa.Secrets); secLen < 1 || secLen > 1 {
+		return nil, fmt.Errorf("unsupported number of service account %q secrets: %d", sa.Name, secLen)
+	}
+
+	sec, err := secretI.Get(context.TODO(), sa.Secrets[0].Name, meta.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil, fmt.Errorf("could not get proxy service account secret: %q", sa.Secrets[0].Name)
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	proxierConfig := ProxierConfig{
+		APIHost:             config.APIHost,
+		CAData:              string(sec.Data[serviceAccountSecretCADataKey]),
+		Namespace:           config.Namespace,
+		RemotePort:          config.RemotePort,
+		Service:             config.Service,
+		ServiceAccountToken: string(sec.Data[serviceAccountSecretTokenKey]),
+	}
+
+	return NewProxier(proxierConfig), nil
+}
+
+// GetControllerProxy returns the proxier for the controller specified by name.
 func GetControllerProxy(
 	name,
 	apiHost string,
@@ -38,36 +93,16 @@ func GetControllerProxy(
 		return nil, errors.Trace(err)
 	}
 
-	sa, err := saI.Get(context.TODO(), config.Name, meta.GetOptions{})
-	if k8serrors.IsNotFound(err) {
-		return nil, errors.NotFoundf("controller proxy service account for %s", name)
-	} else if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if secLen := len(sa.Secrets); secLen < 1 || secLen > 1 {
-		return nil, fmt.Errorf("unsupported number of service account secrets: %d", secLen)
-	}
-
-	sec, err := secretI.Get(context.TODO(), sa.Secrets[0].Name, meta.GetOptions{})
-	if k8serrors.IsNotFound(err) {
-		return nil, fmt.Errorf("could not get proxy service account secret: %s", sa.Secrets[0].Name)
-	} else if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	proxierConfig := ProxierConfig{
-		APIHost:             apiHost,
-		CAData:              string(sec.Data[serviceAccountSecretCADataKey]),
-		Namespace:           config.Namespace,
-		RemotePort:          config.RemotePort,
-		Service:             config.TargetService,
-		ServiceAccountToken: string(sec.Data[serviceAccountSecretTokenKey]),
-	}
-
-	return NewProxier(proxierConfig), nil
+	return GetProxy(config.Name, GetProxyConfig{
+		APIHost:    apiHost,
+		Namespace:  config.Namespace,
+		RemotePort: config.RemotePort,
+		Service:    config.TargetService,
+	}, saI, secretI)
 }
 
+// HasControllerProxy indicates if a controller proxy exists for the supplied
+// name and namespace.
 func HasControllerProxy(
 	name string,
 	configI core.ConfigMapInterface,

--- a/caas/kubernetes/provider/proxy/info_test.go
+++ b/caas/kubernetes/provider/proxy/info_test.go
@@ -52,6 +52,7 @@ func (i *infoSuite) TestHasControllerProxy(c *gc.C) {
 	}
 
 	err := proxy.CreateControllerProxy(
+		context.Background(),
 		config,
 		labels.Set{},
 		i.client.CoreV1().ConfigMaps(testNamespace),
@@ -77,6 +78,7 @@ func (i *infoSuite) TestGetControllerProxier(c *gc.C) {
 	}
 
 	err := proxy.CreateControllerProxy(
+		context.Background(),
 		config,
 		labels.Set{},
 		i.client.CoreV1().ConfigMaps(testNamespace),

--- a/caas/kubernetes/provider/proxy/proxier.go
+++ b/caas/kubernetes/provider/proxy/proxier.go
@@ -4,11 +4,11 @@
 package proxy
 
 import (
-	"encoding/json"
 	"net"
 	"net/url"
 
 	"github.com/juju/errors"
+	"github.com/mitchellh/mapstructure"
 	"k8s.io/client-go/rest"
 
 	"github.com/juju/juju/caas/kubernetes"
@@ -22,12 +22,12 @@ type Proxier struct {
 }
 
 type ProxierConfig struct {
-	APIHost             string `yaml:"api-host"`
-	CAData              string `yaml:"ca-cert"`
-	Namespace           string `yaml:"namespace"`
-	RemotePort          string `yaml:"remote-port"`
-	Service             string `yaml:"service"`
-	ServiceAccountToken string `yaml:"service-account-token"`
+	APIHost             string `yaml:"api-host" mapstructure:"api-host"`
+	CAData              string `yaml:"ca-cert" mapstructure:"ca-cert"`
+	Namespace           string `yaml:"namespace" mapstructure:"namespace"`
+	RemotePort          string `yaml:"remote-port" mapstructure:"remote-port"`
+	Service             string `yaml:"service" mapstructure:"service"`
+	ServiceAccountToken string `yaml:"service-account-token" mapstructure:"service-account-token"`
 }
 
 const (
@@ -70,9 +70,11 @@ func (p *Proxier) SetAPIHost(host string) {
 	p.config.APIHost = host
 }
 
-// MarshalJSON implements encoding/json Marshaler interface
-func (p *Proxier) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.config)
+// RawConfig implements Proxier RawConfig interface.
+func (p *Proxier) RawConfig() (map[string]interface{}, error) {
+	rval := map[string]interface{}{}
+	err := mapstructure.Decode(&p.config, &rval)
+	return rval, errors.Trace(err)
 }
 
 // MarshalYAML implements the yaml Marshaler interface

--- a/caas/kubernetes/provider/proxy/proxier.go
+++ b/caas/kubernetes/provider/proxy/proxier.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"net"
 	"net/url"
 
@@ -69,6 +70,12 @@ func (p *Proxier) SetAPIHost(host string) {
 	p.config.APIHost = host
 }
 
+// MarshalJSON implements encoding/json Marshaler interface
+func (p *Proxier) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.config)
+}
+
+// MarshalYAML implements the yaml Marshaler interface
 func (p *Proxier) MarshalYAML() (interface{}, error) {
 	return &p.config, nil
 }

--- a/caas/kubernetes/provider/proxy/setup.go
+++ b/caas/kubernetes/provider/proxy/setup.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/retry"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -20,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	core "k8s.io/client-go/kubernetes/typed/core/v1"
 	rbac "k8s.io/client-go/kubernetes/typed/rbac/v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
 )
 
 // ControllerProxyConfig is used to configure the kubernetes resources made for
@@ -81,7 +82,7 @@ func proxyRoleForName(name string, lbs labels.Set) *rbacv1.Role {
 	return &role
 }
 
-// EnsureModelProxy ensures there is a proxy service account in existance for
+// EnsureModelProxy ensures there is a proxy service account in existence for
 // the namespace of a Kubernetes model.
 func EnsureProxyService(
 	ctx context.Context,
@@ -99,7 +100,7 @@ func EnsureProxyService(
 		roleRVal, err = roleI.Update(ctx, pr, meta.UpdateOptions{})
 	}
 	if err != nil {
-		return errors.Annotate(err, "creating proxy service account role")
+		return errors.Annotate(err, "cannot create proxy service account role")
 	}
 
 	sa := &corev1.ServiceAccount{

--- a/caas/kubernetes/provider/proxy/setup.go
+++ b/caas/kubernetes/provider/proxy/setup.go
@@ -8,12 +8,16 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/juju/errors"
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	core "k8s.io/client-go/kubernetes/typed/core/v1"
 	rbac "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	//"github.com/juju/juju/caas/kubernetes/provider/utils"
 )
 
 // ControllerProxyConfig is used to configure the kubernetes resources made for
@@ -40,23 +44,8 @@ const (
 	ProxyConfigMapKey = "config"
 )
 
-// CreateControllerProxy establishes the Kubernetes resources needed for
-// proxying to a Juju controller. The end result of this function is a service
-// account with a set of permissions that the Juju client can use for proxying
-// to a controller.
-func CreateControllerProxy(
-	config ControllerProxyConfig,
-	labels labels.Set,
-	configI core.ConfigMapInterface,
-	roleI rbac.RoleInterface,
-	roleBindingI rbac.RoleBindingInterface,
-	saI core.ServiceAccountInterface,
-) error {
-	role := &rbacv1.Role{
-		ObjectMeta: meta.ObjectMeta{
-			Labels: labels,
-			Name:   config.Name,
-		},
+var (
+	proxyRole = rbacv1.Role{
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
@@ -77,48 +66,103 @@ func CreateControllerProxy(
 			},
 		},
 	}
+)
 
-	role, err := roleI.Create(context.TODO(), role, meta.CreateOptions{})
+// proxyRoleForName builds the role needed for proxying to pods within a given
+// namespace.
+func proxyRoleForName(name string, lbs labels.Set) *rbacv1.Role {
+	role := proxyRole
+	role.ObjectMeta = meta.ObjectMeta{
+		Labels: lbs,
+		Name:   name,
+	}
+	return &role
+}
+
+// EnsureModelProxy ensures there is a proxy service account in existance for
+// the namespace of a Kubernetes model.
+func EnsureProxyService(
+	ctx context.Context,
+	lbs labels.Set,
+	name string,
+	roleI rbac.RoleInterface,
+	roleBindingI rbac.RoleBindingInterface,
+	saI core.ServiceAccountInterface,
+) error {
+	lbs = labels.Merge(lbs, utils.LabelsJuju)
+	pr := proxyRoleForName(name, lbs)
+	roleRVal, err := roleI.Create(ctx, pr, meta.CreateOptions{})
+
+	if k8serrors.IsAlreadyExists(err) {
+		roleRVal, err = roleI.Update(ctx, pr, meta.UpdateOptions{})
+	}
 	if err != nil {
-		return fmt.Errorf("creating proxy service account role: %w", err)
+		return errors.Annotate(err, "creating proxy service account role")
 	}
 
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: meta.ObjectMeta{
-			Labels: labels,
-			Name:   config.Name,
+			Labels: lbs,
+			Name:   name,
 		},
 	}
 
-	sa, err = saI.Create(context.TODO(), sa, meta.CreateOptions{})
+	saRVal, err := saI.Create(ctx, sa, meta.CreateOptions{})
+	if k8serrors.IsAlreadyExists(err) {
+		saRVal, err = saI.Get(ctx, sa.Name, meta.GetOptions{})
+	}
 	if err != nil {
-		return fmt.Errorf("creating proxy service account: %w", err)
+		return errors.Annotate(err, "creating proxy service account")
 	}
 
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: meta.ObjectMeta{
-			Labels: labels,
-			Name:   config.Name,
+			Labels: lbs,
+			Name:   name,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      sa.Name,
-				Namespace: sa.Namespace,
+				Name:      saRVal.Name,
+				Namespace: saRVal.Namespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     role.Name,
+			Name:     roleRVal.Name,
 		},
 	}
 
-	_, err = roleBindingI.Create(context.TODO(), roleBinding, meta.CreateOptions{})
+	_, err = roleBindingI.Create(ctx, roleBinding, meta.CreateOptions{})
+	if k8serrors.IsAlreadyExists(err) {
+		_, err = roleBindingI.Update(ctx, roleBinding, meta.UpdateOptions{})
+	}
 	if err != nil {
-		return fmt.Errorf("creating proxy service account role binding: %w", err)
+		return errors.Annotate(err, "creating proxy service account role binding")
 	}
 
+	return nil
+
+}
+
+// CreateControllerProxy establishes the Kubernetes resources needed for
+// proxying to a Juju controller. The end result of this function is a service
+// account with a set of permissions that the Juju client can use for proxying
+// to a controller.
+func CreateControllerProxy(
+	ctx context.Context,
+	config ControllerProxyConfig,
+	labels labels.Set,
+	configI core.ConfigMapInterface,
+	roleI rbac.RoleInterface,
+	roleBindingI rbac.RoleBindingInterface,
+	saI core.ServiceAccountInterface,
+) error {
+	err := EnsureProxyService(ctx, labels, config.Name, roleI, roleBindingI, saI)
+	if err != nil {
+		return errors.Annotate(err, "ensuring proxy service account")
+	}
 	configJSON, err := json.Marshal(config)
 	if err != nil {
 		return fmt.Errorf("marshalling proxy configmap data to json: %w", err)
@@ -134,7 +178,7 @@ func CreateControllerProxy(
 		},
 	}
 
-	_, err = configI.Create(context.TODO(), cm, meta.CreateOptions{})
+	_, err = configI.Create(ctx, cm, meta.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("creating proxy config map: %w", err)
 	}

--- a/caas/kubernetes/provider/proxy/setup_test.go
+++ b/caas/kubernetes/provider/proxy/setup_test.go
@@ -48,6 +48,7 @@ func (s *setupSuite) TestProxyObjCreation(c *gc.C) {
 	}
 
 	err := proxy.CreateControllerProxy(
+		context.Background(),
 		config,
 		labels.Set{},
 		s.client.CoreV1().ConfigMaps(testNamespace),
@@ -105,6 +106,7 @@ func (s *setupSuite) TestProxyConfigMap(c *gc.C) {
 	}
 
 	err := proxy.CreateControllerProxy(
+		context.Background(),
 		config,
 		labels.Set{},
 		s.client.CoreV1().ConfigMaps(testNamespace),

--- a/caas/kubernetes/provider/services.go
+++ b/caas/kubernetes/provider/services.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/errors"
 	core "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
@@ -24,7 +24,7 @@ func getServiceLabels(appName string, legacy bool) map[string]string {
 func (k *kubernetesClient) ensureServicesForApp(appName string, annotations k8sannotations.Annotation, services []k8sspecs.K8sService) (cleanUps []func(), err error) {
 	for _, v := range services {
 		spec := &core.Service{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: meta.ObjectMeta{
 				Name:        v.Name,
 				Namespace:   k.namespace,
 				Labels:      utils.LabelsMerge(v.Labels, getServiceLabels(appName, k.IsLegacyLabels())),
@@ -50,15 +50,15 @@ func (k *kubernetesClient) ensureK8sService(spec *core.Service) (func(), error) 
 
 	api := k.client().CoreV1().Services(k.namespace)
 	// Set any immutable fields if the service already exists.
-	existing, err := api.Get(context.TODO(), spec.Name, v1.GetOptions{})
+	existing, err := api.Get(context.TODO(), spec.Name, meta.GetOptions{})
 	if err == nil {
 		spec.Spec.ClusterIP = existing.Spec.ClusterIP
 		spec.ObjectMeta.ResourceVersion = existing.ObjectMeta.ResourceVersion
 	}
-	_, err = api.Update(context.TODO(), spec, v1.UpdateOptions{})
+	_, err = api.Update(context.TODO(), spec, meta.UpdateOptions{})
 	if k8serrors.IsNotFound(err) {
 		var svcCreated *core.Service
-		svcCreated, err = api.Create(context.TODO(), spec, v1.CreateOptions{})
+		svcCreated, err = api.Create(context.TODO(), spec, meta.CreateOptions{})
 		if err == nil {
 			cleanUp = func() { _ = k.deleteService(svcCreated.GetName()) }
 		}
@@ -72,7 +72,7 @@ func (k *kubernetesClient) deleteService(serviceName string) error {
 		return errNoNamespace
 	}
 	services := k.client().CoreV1().Services(k.namespace)
-	err := services.Delete(context.TODO(), serviceName, v1.DeleteOptions{
+	err := services.Delete(context.TODO(), serviceName, meta.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	})
 	if k8serrors.IsNotFound(err) {
@@ -88,7 +88,7 @@ func (k *kubernetesClient) deleteServices(appName string) error {
 	// Service API does not have `DeleteCollection` implemented, so we have to do it like this.
 	api := k.client().CoreV1().Services(k.namespace)
 	services, err := api.List(context.TODO(),
-		v1.ListOptions{
+		meta.ListOptions{
 			LabelSelector: utils.LabelsToSelector(
 				getServiceLabels(appName, k.IsLegacyLabels())).String(),
 		},
@@ -105,4 +105,23 @@ func (k *kubernetesClient) deleteServices(appName string) error {
 		}
 	}
 	return nil
+}
+
+func (k *kubernetesClient) findServiceForApplication(appName string) (*core.Service, error) {
+	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+	servicesList, err := k.client().CoreV1().Services(k.namespace).List(context.TODO(), meta.ListOptions{
+		LabelSelector: utils.LabelsToSelector(labels).String(),
+	})
+
+	if err != nil {
+		return nil, errors.Annotatef(err, "finding service for application %s", appName)
+	}
+
+	if len(servicesList.Items) == 0 {
+		return nil, errors.NotFoundf("finding service for application %s", appName)
+	} else if len(servicesList.Items) != 1 {
+		return nil, errors.NotValidf("unable to handle mutiple services %d for application %s", len(servicesList.Items), appName)
+	}
+
+	return &servicesList.Items[0], nil
 }

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -16,6 +16,7 @@ import (
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
 	context "github.com/juju/juju/environs/context"
+	proxy "github.com/juju/juju/proxy"
 	storage "github.com/juju/juju/storage"
 	names "github.com/juju/names/v4"
 	version "github.com/juju/version/v2"
@@ -414,6 +415,21 @@ func (m *MockBroker) Provider() caas.ContainerEnvironProvider {
 func (mr *MockBrokerMockRecorder) Provider() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockBroker)(nil).Provider))
+}
+
+// ProxyToApplication mocks base method.
+func (m *MockBroker) ProxyToApplication(arg0, arg1 string) (proxy.Proxier, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProxyToApplication", arg0, arg1)
+	ret0, _ := ret[0].(proxy.Proxier)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ProxyToApplication indicates an expected call of ProxyToApplication.
+func (mr *MockBrokerMockRecorder) ProxyToApplication(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyToApplication", reflect.TypeOf((*MockBroker)(nil).ProxyToApplication), arg0, arg1)
 }
 
 // SetConfig mocks base method.

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -30,6 +30,7 @@ func (*importSuite) TestImports(c *gc.C) {
 
 	expected := set.NewStrings(
 		"agent",
+		"agent/constants",
 		"agent/tools",
 		"api",
 		"api/agent",
@@ -46,11 +47,8 @@ func (*importSuite) TestImports(c *gc.C) {
 		"api/watcher",
 		"apiserver/errors",
 		"apiserver/params",
-		"cmd/containeragent/utils",
-		"caas/kubernetes",
-		"caas/kubernetes/pod",
 		"caas/kubernetes/provider/constants",
-		"caas/kubernetes/provider/proxy",
+		"cmd/containeragent/utils",
 		"charmhub",
 		"charmhub/path",
 		"charmhub/transport",
@@ -102,7 +100,6 @@ func (*importSuite) TestImports(c *gc.C) {
 		"pki",
 		"provider/lxd/lxdnames",
 		"proxy",
-		"proxy/errors",
 		"resource",
 		"rpc",
 		"rpc/jsoncodec",

--- a/cmd/juju/dashboard/export_test.go
+++ b/cmd/juju/dashboard/export_test.go
@@ -4,6 +4,8 @@
 package dashboard
 
 import (
+	"os"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/juju/jujuclient"
 
@@ -14,11 +16,12 @@ var (
 	WebbrowserOpen = &webbrowserOpen
 )
 
-func NewDashboardCommandForTest(store jujuclient.ClientStore, api ControllerAPI) cmd.Command {
+func NewDashboardCommandForTest(store jujuclient.ClientStore, api ControllerAPI, signalCh chan os.Signal) cmd.Command {
 	d := &dashboardCommand{
 		newAPIFunc: func() (ControllerAPI, bool, error) {
 			return api, false, nil
 		},
+		signalCh: signalCh,
 	}
 	d.SetClientStore(store)
 	return modelcmd.Wrap(d)

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/lxc/lxd v0.0.0-20210607205159-a7c206b5233d
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb
+	github.com/mitchellh/mapstructure v1.4.3
 	github.com/oracle/oci-go-sdk/v47 v47.1.0
 	github.com/packethost/packngo v0.19.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -677,6 +677,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb h1:GRiLv4rgyqjqzxbhJke65IYUf4NCOOvrPOJbV/sPxkM=
 github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb/go.mod h1:OaY7UOoTkkrX3wRwjpYRKafIkkyeD0UtweSHAWWiqQM=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
+github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/jujuclient/proxy.go
+++ b/jujuclient/proxy.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/juju/juju/proxy"
+	proxyfactory "github.com/juju/juju/proxy/factory"
 )
 
 const (
@@ -16,7 +17,7 @@ const (
 )
 
 var (
-	NewProxierFactory = proxy.NewDefaultFactory
+	NewProxierFactory = proxyfactory.NewDefaultFactory
 )
 
 // ProxyConfWrapper is wrapper around proxier interfaces so that they can be

--- a/jujuclient/proxy_test.go
+++ b/jujuclient/proxy_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/proxy"
+	"github.com/juju/juju/proxy/factory"
 )
 
 type dummyProxier struct {
@@ -19,7 +20,7 @@ type dummyProxier struct {
 }
 
 type proxyWrapperSuite struct {
-	factory *proxy.Factory
+	factory *factory.Factory
 }
 
 var _ = gc.Suite(&proxyWrapperSuite{})
@@ -31,6 +32,10 @@ func (d *dummyProxier) MarshalYAML() (interface{}, error) {
 	return map[string]string{
 		"conf": d.Conf,
 	}, nil
+}
+
+func (d *dummyProxier) RawConfig() (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
 }
 
 func (d *dummyProxier) Start() error {
@@ -45,7 +50,7 @@ func (d *dummyProxier) Type() string {
 }
 
 func (p *proxyWrapperSuite) SetUpTest(c *gc.C) {
-	p.factory = proxy.NewFactory()
+	p.factory = factory.NewFactory()
 }
 
 func (p *proxyWrapperSuite) TestMarshallingKeys(c *gc.C) {
@@ -72,7 +77,7 @@ func (p *proxyWrapperSuite) TestUnmarshalling(c *gc.C) {
 	y, err := yaml.Marshal(wrapper)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = p.factory.Register(proxier.Type(), proxy.FactoryRegister{
+	err = p.factory.Register(proxier.Type(), factory.FactoryRegister{
 		ConfigFn: func() interface{} {
 			return &dummyProxier{}
 		},
@@ -86,7 +91,7 @@ func (p *proxyWrapperSuite) TestUnmarshalling(c *gc.C) {
 
 	fmt.Println(string(y))
 
-	jujuclient.NewProxierFactory = func() (*proxy.Factory, error) {
+	jujuclient.NewProxierFactory = func() (*factory.Factory, error) {
 		return p.factory, nil
 	}
 

--- a/proxy/factory/factory.go
+++ b/proxy/factory/factory.go
@@ -4,9 +4,8 @@
 package factory
 
 import (
-	"encoding/json"
-
 	"github.com/juju/errors"
+	"github.com/mitchellh/mapstructure"
 
 	k8sproxy "github.com/juju/juju/caas/kubernetes/provider/proxy"
 	"github.com/juju/juju/proxy"
@@ -83,9 +82,10 @@ func NewFactory() *Factory {
 	}
 }
 
-// ProxierFromJSONDataBag is a utility function for making a proxy from this
-// factory using a JSON data bag. The type key cannot be an empty string.
-func (f *Factory) ProxierFromJSONDataBag(typeKey string, rawData json.RawMessage) (proxy.Proxier, error) {
+// ProxierFromConfig is a utility function for making a proxier from this
+// factory using raw config data within in a map[string]interface{}. The type
+// key cannot be an empty string.
+func (f *Factory) ProxierFromConfig(typeKey string, config map[string]interface{}) (proxy.Proxier, error) {
 	if typeKey == "" {
 		return nil, errors.NotValidf("type key for proxier cannot be empty")
 	}
@@ -95,8 +95,8 @@ func (f *Factory) ProxierFromJSONDataBag(typeKey string, rawData json.RawMessage
 		return nil, err
 	}
 
-	if err := json.Unmarshal(rawData, maker.Config()); err != nil {
-		return nil, errors.Annotatef(err, "unmarshalling json config for proxier type %q", typeKey)
+	if err := mapstructure.Decode(config, maker.Config()); err != nil {
+		return nil, errors.Annotatef(err, "decoding config  for proxier type %q", typeKey)
 	}
 
 	return maker.Make()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -17,6 +17,10 @@ type Proxier interface {
 	// considered single use. This call should only ever be made once.
 	Stop()
 
+	// RawConfig is responsible for providing a raw configuration representation
+	// of the proxier for serialising over the wire.
+	RawConfig() (map[string]interface{}, error)
+
 	// Type is the unique key identifying the type of proxying for configuration
 	// purposes.
 	Type() string

--- a/proxy/testing/proxy.go
+++ b/proxy/testing/proxy.go
@@ -5,6 +5,9 @@ package testing
 
 type MockProxier struct {
 	// See Proxier interface
+	RawConfigFn func() (map[string]interface{}, error)
+
+	// See Proxier interface
 	StartFn func() error
 
 	// See Proxier interface
@@ -28,6 +31,13 @@ func NewMockTunnelProxier() *MockTunnelProxier {
 	return &MockTunnelProxier{
 		MockProxier: &MockProxier{},
 	}
+}
+
+func (mp *MockProxier) RawConfig() (map[string]interface{}, error) {
+	if mp.RawConfigFn == nil {
+		return map[string]interface{}{}, nil
+	}
+	return mp.RawConfigFn()
 }
 
 func (mp *MockProxier) Start() error {

--- a/state/relation.go
+++ b/state/relation.go
@@ -677,6 +677,11 @@ func (r *Relation) Endpoint(applicationname string) (Endpoint, error) {
 	return Endpoint{}, errors.NewNotFound(nil, msg)
 }
 
+// ModelUUID returns the model UUID for the relation.
+func (r *Relation) ModelUUID() string {
+	return r.doc.ModelUUID
+}
+
 // Endpoints returns the endpoints for the relation.
 func (r *Relation) Endpoints() []Endpoint {
 	return r.doc.Endpoints


### PR DESCRIPTION
This change allows users to proxy onto the Juju Dashboard in Juju3 for
both CAAS and IAAS models.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

You will need to get the Juju Dashboard charm from here https://github.com/canonical-web-and-design/juju-dashboard-charm

Build the charm for both machine and kubernetes.

Bootstrap to microk8s and lxd and deploy the charm on both controllers. Once this is done relate the juju-dashboard to the controller. NOTE: These must be in the same model.

Run `juju dashboard` for both controllers and make sure you can get to the dashboard with the displayed credentials.

## Documentation changes

N/A

## Bug reference
N/A
