### PR TITLE
[JUJU-503] Reimplement essential metadata for charmhub using refresh API

### DIFF
--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -37,6 +38,15 @@ const (
 
 	// RefreshAction defines a refresh action.
 	RefreshAction Action = "refresh"
+)
+
+var (
+	// A set of fields that are always requested when performing refresh calls
+	requiredRefreshFields = set.NewStrings(
+		"download", "id", "license", "name", "publisher", "resources",
+		"revision", "summary", "type", "version", "bases", "config-yaml",
+		"metadata-yaml",
+	).SortedValues()
 )
 
 const (
@@ -212,6 +222,7 @@ func RefreshOne(key, id string, revision int, channel string, base RefreshBase) 
 		Revision:    revision,
 		Channel:     channel,
 		Base:        base,
+		fields:      requiredRefreshFields,
 	}, nil
 }
 
@@ -239,6 +250,7 @@ func InstallOneFromRevision(name string, revision int) (RefreshConfig, error) {
 		instanceKey: uuid.String(),
 		Name:        name,
 		Revision:    &revision,
+		fields:      requiredRefreshFields,
 	}, nil
 }
 
@@ -296,6 +308,7 @@ func InstallOneFromChannel(name string, channel string, base RefreshBase) (Refre
 		Name:        name,
 		Channel:     &channel,
 		Base:        base,
+		fields:      requiredRefreshFields,
 	}, nil
 }
 
@@ -314,6 +327,7 @@ func DownloadOneFromRevision(id string, revision int) (RefreshConfig, error) {
 		instanceKey: uuid.String(),
 		ID:          id,
 		Revision:    &revision,
+		fields:      requiredRefreshFields,
 	}, nil
 }
 
@@ -332,6 +346,7 @@ func DownloadOneFromRevisionByName(name string, revision int) (RefreshConfig, er
 		instanceKey: uuid.String(),
 		Name:        name,
 		Revision:    &revision,
+		fields:      requiredRefreshFields,
 	}, nil
 }
 
@@ -354,6 +369,7 @@ func DownloadOneFromChannel(id string, channel string, base RefreshBase) (Refres
 		ID:          id,
 		Channel:     &channel,
 		Base:        base,
+		fields:      requiredRefreshFields,
 	}, nil
 }
 
@@ -376,6 +392,7 @@ func DownloadOneFromChannelByName(name string, channel string, base RefreshBase)
 		Name:        name,
 		Channel:     &channel,
 		Base:        base,
+		fields:      requiredRefreshFields,
 	}, nil
 }
 

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -26,7 +27,15 @@ type RefreshSuite struct {
 	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&RefreshSuite{})
+var (
+	_ = gc.Suite(&RefreshSuite{})
+
+	expRefreshFields = set.NewStrings(
+		"download", "id", "license", "name", "publisher", "resources",
+		"revision", "summary", "type", "version", "bases", "config-yaml",
+		"metadata-yaml",
+	).SortedValues()
+)
 
 func (s *RefreshSuite) TestRefresh(c *gc.C) {
 	ctrl := gomock.NewController(c)
@@ -53,6 +62,7 @@ func (s *RefreshSuite) TestRefresh(c *gc.C) {
 			InstanceKey: "instance-key",
 			ID:          &id,
 		}},
+		Fields: expRefreshFields,
 	}
 
 	config, err := RefreshOne("instance-key", id, 1, "latest/stable", RefreshBase{
@@ -91,7 +101,7 @@ func (s *RefreshSuite) TestRefeshConfigValidateSeries(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "Channel.*")
 }
 
-func (s *RefreshSuite) TestRefeshConfigValidateName(c *gc.C) {
+func (s *RefreshSuite) TestRefeshConfigVali914dateName(c *gc.C) {
 	err := s.testRefeshConfigValidate(c, RefreshBase{
 		Name:         "all",
 		Channel:      "20.04",
@@ -318,6 +328,7 @@ func (s *RefreshSuite) TestRefreshWithRequestMetrics(c *gc.C) {
 			InstanceKey: "instance-key-bar",
 			ID:          &id,
 		}},
+		Fields: expRefreshFields,
 		Metrics: map[string]map[string]string{
 			"controller": {"uuid": "controller-uuid"},
 			"model":      {"units": "3", "controller": "controller-uuid", "uuid": "model-uuid"},
@@ -457,6 +468,7 @@ func (s *RefreshConfigSuite) TestRefreshOneBuild(c *gc.C) {
 			InstanceKey: "instance-key",
 			ID:          &id,
 		}},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -511,6 +523,7 @@ func (s *RefreshConfigSuite) TestRefreshOneWithMetricsBuild(c *gc.C) {
 			InstanceKey: "instance-key",
 			ID:          &id,
 		}},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -556,7 +569,7 @@ func (s *RefreshConfigSuite) TestInstallOneFromRevisionBuild(c *gc.C) {
 			Name:        &name,
 			Revision:    &revision,
 		}},
-		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -590,7 +603,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevisionResources(c *gc.C) {
 				{Name: "testme", Revision: 3},
 			},
 		}},
-		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -633,6 +646,7 @@ func (s *RefreshConfigSuite) TestInstallOneBuildChannel(c *gc.C) {
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -671,6 +685,7 @@ func (s *RefreshConfigSuite) TestInstallOneWithPartialPlatform(c *gc.C) {
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -730,7 +745,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromRevisionBuild(c *gc.C) {
 			ID:          &id,
 			Revision:    &rev,
 		}},
-		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -757,7 +772,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromRevisionByNameBuild(c *gc.C) {
 			Name:        &name,
 			Revision:    &rev,
 		}},
-		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -793,6 +808,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuild(c *gc.C) {
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -832,6 +848,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelByNameBuild(c *gc.C) {
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -871,6 +888,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuildK8s(c *gc.C) {
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},
+		Fields: expRefreshFields,
 	})
 }
 
@@ -997,7 +1015,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 			Name:        &name4,
 			Revision:    &rev4,
 		}},
-		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
+		Fields: expRefreshFields,
 	})
 }
 

--- a/charmhub/refreshconfig.go
+++ b/charmhub/refreshconfig.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/charmhub/transport"
@@ -34,6 +35,7 @@ type refreshOne struct {
 	// asynchronous calls.
 	instanceKey string
 	metrics     transport.ContextMetrics
+	fields      []string
 }
 
 // InstanceKey returns the underlying instance key.
@@ -70,6 +72,7 @@ func (c refreshOne) Build() (transport.RefreshRequest, error) {
 			InstanceKey: c.instanceKey,
 			ID:          &c.ID,
 		}},
+		Fields: c.fields,
 	}, nil
 }
 
@@ -91,8 +94,10 @@ type executeOne struct {
 	Base     RefreshBase
 	// instanceKey is a private unique key that we construct for CharmHub API
 	// asynchronous calls.
-	action      Action
-	instanceKey string
+	action            Action
+	instanceKey       string
+	resourceRevisions []transport.RefreshResourceRevision
+	fields            []string
 }
 
 // InstanceKey returns the underlying instance key.
@@ -128,6 +133,7 @@ func (c executeOne) Build() (transport.RefreshRequest, error) {
 			Channel:     c.Channel,
 			Base:        &base,
 		}},
+		Fields: c.fields,
 	}
 	return req, nil
 }
@@ -171,6 +177,7 @@ type executeOneByRevision struct {
 	// asynchronous calls.
 	instanceKey string
 	action      Action
+	fields      []string
 }
 
 // InstanceKey returns the underlying instance key.
@@ -202,6 +209,15 @@ func (c executeOneByRevision) Build() (transport.RefreshRequest, error) {
 		}},
 		Fields: []string{"bases", "download", "id", "revision", "version", "resources", "type"},
 	}
+
+	if len(c.fields) != 0 {
+		fieldSet := set.NewStrings(req.Fields...)
+		for _, field := range c.fields {
+			fieldSet.Add(field)
+		}
+		req.Fields = fieldSet.SortedValues()
+	}
+
 	return req, nil
 }
 
@@ -253,6 +269,12 @@ func (c refreshMany) Build() (transport.RefreshRequest, error) {
 		result.Actions = append(result.Actions, req.Actions...)
 		result.Fields = append(result.Fields, req.Fields...)
 	}
+
+	// Ensure that the required field list contains no duplicates
+	if len(result.Fields) != 0 {
+		result.Fields = set.NewStrings(result.Fields...).SortedValues()
+	}
+
 	return result, nil
 }
 

--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -3,7 +3,10 @@
 
 package transport
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // RefreshRequest defines a typed request for making refresh queries, containing
 // both a series of context and actions, this powerful setup should allow for
@@ -92,6 +95,10 @@ type RefreshEntity struct {
 	Summary   string             `json:"summary"`
 	Version   string             `json:"version"`
 	CreatedAt time.Time          `json:"created-at"`
+
+	// The minimum set of metadata required for deploying a charm.
+	MetadataYAML json.RawMessage `json:"metadata-yaml,omitempty"`
+	ConfigYAML   json.RawMessage `json:"config-yaml,omitempty"`
 }
 
 // RefreshResourceRevision represents a resource name revision pair for

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
+	"github.com/juju/collections/set"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -19,6 +20,14 @@ import (
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/charm/repository/mocks"
 	"github.com/juju/juju/testcharms"
+)
+
+var (
+	expRefreshFields = set.NewStrings(
+		"download", "id", "license", "name", "publisher", "resources",
+		"revision", "summary", "type", "version", "bases", "config-yaml",
+		"metadata-yaml",
+	).SortedValues()
 )
 
 type charmHubRepositorySuite struct {
@@ -603,6 +612,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 			},
 		}},
 		Context: []transport.RefreshRequestContext{},
+		Fields:  expRefreshFields,
 	})
 }
 
@@ -636,6 +646,7 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 			},
 		}},
 		Context: []transport.RefreshRequestContext{},
+		Fields:  expRefreshFields,
 	})
 }
 
@@ -663,7 +674,7 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 			Revision:    &revision,
 		}},
 		Context: []transport.RefreshRequestContext{},
-		Fields:  []string{"bases", "download", "id", "revision", "version", "resources", "type"},
+		Fields:  expRefreshFields,
 	})
 }
 
@@ -705,6 +716,7 @@ func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 			},
 			TrackingChannel: channel.String(),
 		}},
+		Fields: expRefreshFields,
 	})
 }
 


### PR DESCRIPTION
This PR provides a real (non-emulated) implementation for the `GetEssentialMetadata` method for the charmhub repository implementation. This will allow us to also leverage  (if the relevant feature flag is enabled) the support for asynchronous charm downloads  when deploying charmhub charms.

To obtain the essential metadata (metadata.yaml, config.yaml and manifest.yaml) we invoke the refresh API in batch mode. The API provides the contents of metadata and config YAML files when instructed to do so at request time. However, we need to map the "bases" field from the response into a manifest instance manually.

The new implementation is not as efficient as it should be as we need to resolve the origin of every charm via a separate call (`ResolveWithPreferredChannel` repository method).

We should provide a batch-aware implementation of the above method so we can resolve all origins via a single call.

Alternatively, we could opt to reconstruct the resolved origin from the refresh API response (the one containing the metadata we need). However, the logic for doing so is *very* convoluted so the decision was made to make an extra call as opposed to duplicating the logic.

NOTE: This PR relies on functionality (return `config.yaml` contents) that is available on `api.staging.charmhub.io`. It can be safely merged as the charmhub refresh API ignores fields that it does not recognize. However, the feature flag needs to stau in place until those changes make it into `api.charmhub.io`.

## QA steps

```console
$ juju bootstrap lxd test --no-gui
$ juju add-model lightspeed --config charmhub-url="https://api.staging.snapcraft.io"
$ juju controller-config 'features=[async-charm-downloads]'

$ time juju deploy charmed-kubernetes 
...
Deploy of bundle completed.
juju deploy charmed-kubernetes  0.14s user 0.04s system 2% cpu 6.832 total
```

Now try the same without the flag and observe the difference in deploy times:

```
$ juju controller-config 'features=[]'
$ juju add-model snailspeed
$ time juju deploy charmed-kubernetes
```