### PR TITLE
[JUJU-553] Add tool to infer entity schemas and render a ER-like diagram using graphviz

### DIFF
--- a/scripts/dqlite/cmd/infer_schema.go
+++ b/scripts/dqlite/cmd/infer_schema.go
@@ -1,0 +1,241 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/juju/loggo"
+)
+
+var (
+	jujuStatePkg  = flag.String("juju-pkg-name", "github.com/juju/juju/state", "the pkg name to scan for mongo doc structs")
+	erdOutputFile = flag.String("output", "-", "the file (or - for STDOUT) to write the generated ER diagram")
+
+	logger = loggo.GetLogger("infer_schema")
+)
+
+// structAST represents a parsed struct representing a mongo document.
+type structAST struct {
+	// The name of the struct identifier.
+	Name string
+
+	// The file where the struct was defined.
+	SrcFile string
+
+	// The AST for the struct.
+	Decl *ast.StructType
+}
+
+func main() {
+	flag.Parse()
+
+	if err := inferSchema(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func inferSchema() error {
+	structASTs, fset, err := extractMongoDocStructASTs()
+	if err != nil {
+		return err
+	}
+
+	// Cluster structs by type
+	clusters := clusterASTS(structASTs)
+
+	// Render ERD
+	var w io.Writer
+	if *erdOutputFile == "-" {
+		w = os.Stdout
+	} else {
+		of, err := os.Open(*erdOutputFile)
+		if err != nil {
+			return fmt.Errorf("unable to open %q for writing: %v", *erdOutputFile, err)
+		}
+		w = of
+		defer func() { _ = of.Close() }()
+	}
+	renderERD(w, clusters, fset)
+
+	return nil
+}
+
+func extractMongoDocStructASTs() ([]structAST, *token.FileSet, error) {
+	logger.Infof("parsing files in package %q", *jujuStatePkg)
+	fset, pkgInfo, err := loadPkg(*jujuStatePkg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to resolve type information from package %q: %w", *jujuStatePkg, err)
+	}
+
+	logger.Infof("extracting mongo doc mapping structs")
+	structASTs, fset := extractStructASTs(fset, pkgInfo.Files, isMongoDocMapping)
+	logger.Infof("extracted %d mongo doc mapping structs", len(structASTs))
+
+	return structASTs, fset, nil
+}
+
+// loadPkg uses go/loader to compile pkgName (including any of its
+// direct and indirect dependencies) and returns back the obtained ASTs and type
+// information.
+func loadPkg(pkgName string) (*token.FileSet, *ast.Package, error) {
+	pathToPkg := filepath.Join(os.Getenv("GOPATH"), "src", pkgName)
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, pathToPkg, func(fi os.FileInfo) bool {
+		// Ignore test files
+		return !strings.Contains(fi.Name(), "_test")
+	}, parser.ParseComments)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkg, found := pkgs[filepath.Base(pkgName)]
+	if !found {
+		for k := range pkgs {
+			fmt.Printf("pkg: %q\n", k)
+		}
+		return nil, nil, fmt.Errorf("unable to identify package %q contents", pkgName)
+	}
+
+	return fset, pkg, nil
+}
+
+// extractASTs returns a list of struct ASTs within a package that satisfy the
+// provided selectFn func.
+func extractStructASTs(fset *token.FileSet, fileASTs map[string]*ast.File, selectFn func(*ast.TypeSpec) bool) ([]structAST, *token.FileSet) {
+	stripPrefix := filepath.Join(os.Getenv("GOPATH"), "src") + string(filepath.Separator)
+
+	var structASTs []structAST
+	for _, fileAST := range fileASTs {
+		for _, decl := range fileAST.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+
+			for _, spec := range genDecl.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+
+				structType, ok := typeSpec.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+
+				if !selectFn(typeSpec) {
+					continue
+				}
+
+				structPos := fset.Position(fileAST.Pos())
+				structASTs = append(structASTs,
+					structAST{
+						Name:    normalizeName(typeSpec.Name.Name),
+						SrcFile: strings.TrimPrefix(structPos.Filename, stripPrefix),
+						Decl:    structType,
+					},
+				)
+			}
+		}
+	}
+
+	return structASTs, fset
+}
+
+func isMongoDocMapping(tspec *ast.TypeSpec) bool {
+	name := tspec.Name.Name
+	lcIdent := name[0] >= 'a' && name[0] <= 'z'
+	return lcIdent && strings.HasSuffix(name, "Doc")
+}
+
+func clusterASTS(structASTs []structAST) map[string][]structAST {
+	// TODO:
+	return map[string][]structAST{
+		"": structASTs,
+	}
+}
+
+func renderERD(w io.Writer, clusters map[string][]structAST, fset *token.FileSet) {
+	braceEscaper := strings.NewReplacer(
+		"{", "\\{",
+		"}", "\\}",
+	)
+
+	fmt.Fprintln(w, "graph {")
+	for clusterName, structASTs := range clusters {
+		if clusterName == "" {
+			fmt.Fprintln(w, "  subgraph {")
+		} else {
+			fmt.Fprintf(w, "  subgraph cluster_%s {\n", clusterName)
+		}
+
+		prefix := strings.Repeat(" ", 4)
+		for _, str := range structASTs {
+			fmt.Fprintf(w, "%s# %s\n", prefix, str.SrcFile)
+			fmt.Fprintf(w, "%s%s [shape=record, label=<{<b>%s</b><br/>%s", prefix, str.Name, str.Name, str.SrcFile)
+			for _, field := range str.Decl.Fields.List {
+				if ignoreField(field.Names[0].Name) {
+					continue // not needed
+				}
+				fieldName := normalizeName(field.Names[0].Name)
+				fmt.Fprintf(w, ` | %s (%s)`, fieldName, braceEscaper.Replace(fmtType(field.Type, fset)))
+			}
+			fmt.Fprintf(w, "}>];\n")
+		}
+
+		fmt.Fprintln(w, "  }")
+	}
+	fmt.Fprintln(w, "}")
+}
+
+func fmtType(typ interface{}, fset *token.FileSet) string {
+	var buf bytes.Buffer
+	_ = printer.Fprint(&buf, fset, typ)
+	return buf.String()
+}
+
+var skipFieldList = []string{
+	"modeluuid",
+	"revno",
+}
+
+func ignoreField(name string) bool {
+	name = strings.ToLower(name)
+
+	for _, skipField := range skipFieldList {
+		if strings.Contains(name, strings.ToLower(skipField)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalizeName(name string) string {
+	var buf bytes.Buffer
+
+	in := strings.TrimSuffix(name, "Doc")
+	for i, r := range in {
+		if i > 0 && unicode.IsUpper(r) && !unicode.IsUpper(rune(in[i-1])) {
+			buf.WriteRune('_')
+		}
+		buf.WriteRune(unicode.ToLower(r))
+	}
+
+	return buf.String()
+}


### PR DESCRIPTION
This PR contributes a CLI tool that analyzes the set of structs defined in Juju's `state` package and attempts to generate an ER-like diagram to aid with the data modeling work which is part of the transition from mongo to sqlite. 

The actual diagram looks more like a UML class diagram as the number of entities (tables) and attributes makes it more difficult for graphviz to figure out a suitable layout for the graph nodes.

The tool automatically normalizes both table and field names to the underscore-cased format that folks are more familiar with when working with SQL databases. In addition, the tool will attempt to cluster together tables that share a common name prefix.

Future work ideas/suggestions:
- Infer relations between tables by analyzing the names of fields that serve as foreign keys (this can also yield a more accurate clustering result). Alternatively, the tool could be seeded with an external (JSON/YAML etc.) file to provide hints as to which tables should be grouped together.
- The tool currently lists the Go type for each attribute. However, for attributes that are nested objects or collections of objects we could automatically generate auxiliary tables for storing them and also annotate the graph with edges that will help identify the relationships between fields.

## QA steps

```sh
$ cd scripts/dqlite/cmd

# NOTE 1: use 'open' instead of xdg-open if running on OSX
# NOTE 2: you must use `fdp` as your layout engine to get nice, rectangular output for the graph!
$ go run infer_schema.go | fdp -o erd.svg -Tsvg && xdg-open erd.svg
```

Yields something like this:

![erd](https://user-images.githubusercontent.com/616049/152198939-ea93a03b-1112-4777-9558-72652129315d.svg)

