### PR TITLE
add firewaller support to Equinix Metal provider

### DIFF
--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -50,6 +50,8 @@ type environConfig struct {
 }
 
 type environ struct {
+	equinixFirewaller
+
 	ecfgMutex     sync.Mutex
 	ecfg          *environConfig
 	name          string
@@ -57,6 +59,11 @@ type environ struct {
 	equinixClient *packngo.Client
 	namespace     instance.Namespace
 }
+
+var _ environs.Environ = (*environ)(nil)
+var _ environs.Firewaller = (*environ)(nil)
+var _ environs.NetworkingEnviron = (*environ)(nil)
+var _ environs.InstanceTagger = (*environ)(nil)
 
 var providerInstance environProvider
 
@@ -70,6 +77,11 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 
 func (e *environ) AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
 	return e.getPacketInstancesByTag(map[string]string{"juju-model-uuid": e.Config().UUID()})
+}
+
+// TagInstance implements environs.InstanceTagger.
+func (e *environ) TagInstance(ctx context.ProviderCallContext, id instance.Id, tags map[string]string) error {
+	return e.setTagsForDevice(string(id), tags)
 }
 
 func (e *environ) AllRunningInstances(ctx context.ProviderCallContext) ([]instances.Instance, error) {
@@ -543,7 +555,7 @@ func (e *environ) getPacketInstancesByTag(tags map[string]string) ([]instances.I
 
 	projectID, ok := e.cloud.Credential.Attributes()["project-id"]
 	if !ok {
-		return nil, fmt.Errorf("project-id not fond as attribute")
+		return nil, fmt.Errorf("project-id not found as attribute")
 	}
 
 	devices, _, err := e.equinixClient.Devices.List(projectID, nil)
@@ -561,6 +573,21 @@ func (e *environ) getPacketInstancesByTag(tags map[string]string) ([]instances.I
 	}
 
 	return toReturn, nil
+}
+
+// setTagsForDevice sets the tags for a device.
+func (e *environ) setTagsForDevice(id string, tags map[string]string) error {
+	deviceTags := []string{}
+	for k, v := range tags {
+		deviceTags = append(deviceTags, fmt.Sprintf("%s=%s", k, v))
+	}
+	req := &packngo.DeviceUpdateRequest{
+		Tags: &deviceTags,
+	}
+
+	_, _, err := e.equinixClient.Devices.Update(id, req)
+
+	return errors.Trace(err)
 }
 
 func mapJujuSubnetsToReservationIDs(subnetsToZoneMap []map[network.Id][]string) []string {

--- a/provider/equinix/environ_network.go
+++ b/provider/equinix/environ_network.go
@@ -69,7 +69,7 @@ func (e *environ) Subnets(ctx context.ProviderCallContext, inst instance.Id, sub
 	}
 
 	var instanceSubnets []network.SubnetInfo
-nextSubnet: //API client limitation since we can't get the actual blocks for individual instance we have to do this
+nextSubnet: // API client limitation since we can't get the actual blocks for individual instance we have to do this
 	for _, psub := range projectSubnets {
 		_, ipnet, err := net.ParseCIDR(psub.CIDR)
 		if err != nil {
@@ -121,7 +121,7 @@ func (e *environ) NetworkInterfaces(ctx context.ProviderCallContext, ids []insta
 			return nil, err
 		}
 
-		dev := &equinixDevice{e, device}
+		dev := newInstance(device, e)
 
 		subnets, err := e.Subnets(ctx, id, nil)
 		if err != nil {
@@ -184,7 +184,6 @@ func (e *environ) SuperSubnets(context.ProviderCallContext) ([]string, error) {
 	attrs := e.cloud.Credential.Attributes()
 	if attrs == nil {
 		return nil, errors.Trace(fmt.Errorf("empty attribute credentials"))
-
 	}
 	// We checked the presence of project-id when we were verifying the credentials.
 	projectID := attrs["project-id"]

--- a/provider/equinix/errors.go
+++ b/provider/equinix/errors.go
@@ -1,0 +1,20 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package equinix
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// IsAuthorisationFailure determines if the given error has an authorisation failure.
+func IsAuthorisationFailure(err error) bool {
+	if err == nil {
+		return false
+	} else if strings.Contains(errors.Cause(err).Error(), "not authorized") {
+		return true
+	}
+	return false
+}

--- a/provider/equinix/firewaller.go
+++ b/provider/equinix/firewaller.go
@@ -1,0 +1,123 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package equinix
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network/firewall"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/provider/common"
+)
+
+type equinixFirewaller struct{}
+
+var _ environs.Firewaller = (*equinixFirewaller)(nil)
+
+// OpenPorts is not supported.
+func (c *equinixFirewaller) OpenPorts(ctx context.ProviderCallContext, rules firewall.IngressRules) error {
+	return errors.NotSupportedf("OpenPorts")
+}
+
+// ClosePorts is not supported.
+func (c *equinixFirewaller) ClosePorts(ctx context.ProviderCallContext, rules firewall.IngressRules) error {
+	return errors.NotSupportedf("ClosePorts")
+}
+
+// IngressRules returns the port ranges opened for the whole environment.
+// Must only be used if the environment was setup with the
+// FwGlobal firewall mode.
+func (c *equinixFirewaller) IngressRules(ctx context.ProviderCallContext) (firewall.IngressRules, error) {
+	return nil, errors.NotSupportedf("Ports")
+}
+
+// DeleteGroups implements OpenstackFirewaller interface.
+func (c *equinixFirewaller) DeleteGroups(ctx context.ProviderCallContext, names ...string) error {
+	return nil
+}
+
+// DeleteAllModelGroups implements OpenstackFirewaller interface.
+func (c *equinixFirewaller) DeleteAllModelGroups(ctx context.ProviderCallContext) error {
+	return nil
+}
+
+// DeleteAllControllerGroups implements OpenstackFirewaller interface.
+func (c *equinixFirewaller) DeleteAllControllerGroups(ctx context.ProviderCallContext, controllerUUID string) error {
+	return nil
+}
+
+func (c *equinixFirewaller) UpdateGroupController(ctx context.ProviderCallContext, controllerUUID string) error {
+	return nil
+}
+
+// GetSecurityGroups implements OpenstackFirewaller interface.
+func (c *equinixFirewaller) GetSecurityGroups(ctx context.ProviderCallContext, ids ...instance.Id) ([]string, error) {
+	return nil, nil
+}
+
+// SetUpGroups implements OpenstackFirewaller interface.
+func (c *equinixFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineId string, apiPort int) ([]string, error) {
+	return nil, nil
+}
+
+// OpenInstancePorts implements Firewaller interface.
+func (c *equinixFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, rules firewall.IngressRules) error {
+	return c.changeIngressRules(ctx, inst, true, rules)
+}
+
+// CloseInstancePorts implements Firewaller interface.
+func (c *equinixFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, rules firewall.IngressRules) error {
+	return c.changeIngressRules(ctx, inst, false, rules)
+}
+
+// InstanceIngressRules implements Firewaller interface.
+func (c *equinixFirewaller) InstanceIngressRules(ctx context.ProviderCallContext, inst instances.Instance, machineId string) (firewall.IngressRules, error) {
+	_, configurator, err := c.getInstanceConfigurator(ctx, inst)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	rules, err := configurator.FindIngressRules()
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+	}
+	return rules, err
+}
+
+func (c *equinixFirewaller) changeIngressRules(ctx context.ProviderCallContext, inst instances.Instance, insert bool, rules firewall.IngressRules) error {
+	addresses, sshClient, err := c.getInstanceConfigurator(ctx, inst)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for _, addr := range addresses {
+		if addr.Scope == network.ScopePublic {
+			err = sshClient.ChangeIngressRules(addr.Value, insert, rules)
+			if err != nil {
+				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+				return errors.Trace(err)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *equinixFirewaller) getInstanceConfigurator(
+	ctx context.ProviderCallContext, inst instances.Instance,
+) ([]network.ProviderAddress, common.InstanceConfigurator, error) {
+	addresses, err := inst.Addresses(ctx)
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return nil, nil, errors.Trace(err)
+	}
+	if len(addresses) == 0 {
+		return addresses, nil, errors.New("No addresses found")
+	}
+
+	client := common.NewSshInstanceConfigurator(addresses[0].Value)
+	return addresses, client, err
+}

--- a/provider/equinix/firewaller.go
+++ b/provider/equinix/firewaller.go
@@ -6,13 +6,9 @@ package equinix
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/provider/common"
 )
 
 type equinixFirewaller struct{}
@@ -34,90 +30,4 @@ func (c *equinixFirewaller) ClosePorts(ctx context.ProviderCallContext, rules fi
 // FwGlobal firewall mode.
 func (c *equinixFirewaller) IngressRules(ctx context.ProviderCallContext) (firewall.IngressRules, error) {
 	return nil, errors.NotSupportedf("Ports")
-}
-
-// DeleteGroups implements OpenstackFirewaller interface.
-func (c *equinixFirewaller) DeleteGroups(ctx context.ProviderCallContext, names ...string) error {
-	return nil
-}
-
-// DeleteAllModelGroups implements OpenstackFirewaller interface.
-func (c *equinixFirewaller) DeleteAllModelGroups(ctx context.ProviderCallContext) error {
-	return nil
-}
-
-// DeleteAllControllerGroups implements OpenstackFirewaller interface.
-func (c *equinixFirewaller) DeleteAllControllerGroups(ctx context.ProviderCallContext, controllerUUID string) error {
-	return nil
-}
-
-func (c *equinixFirewaller) UpdateGroupController(ctx context.ProviderCallContext, controllerUUID string) error {
-	return nil
-}
-
-// GetSecurityGroups implements OpenstackFirewaller interface.
-func (c *equinixFirewaller) GetSecurityGroups(ctx context.ProviderCallContext, ids ...instance.Id) ([]string, error) {
-	return nil, nil
-}
-
-// SetUpGroups implements OpenstackFirewaller interface.
-func (c *equinixFirewaller) SetUpGroups(ctx context.ProviderCallContext, controllerUUID, machineId string, apiPort int) ([]string, error) {
-	return nil, nil
-}
-
-// OpenInstancePorts implements Firewaller interface.
-func (c *equinixFirewaller) OpenInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, rules firewall.IngressRules) error {
-	return c.changeIngressRules(ctx, inst, true, rules)
-}
-
-// CloseInstancePorts implements Firewaller interface.
-func (c *equinixFirewaller) CloseInstancePorts(ctx context.ProviderCallContext, inst instances.Instance, machineId string, rules firewall.IngressRules) error {
-	return c.changeIngressRules(ctx, inst, false, rules)
-}
-
-// InstanceIngressRules implements Firewaller interface.
-func (c *equinixFirewaller) InstanceIngressRules(ctx context.ProviderCallContext, inst instances.Instance, machineId string) (firewall.IngressRules, error) {
-	_, configurator, err := c.getInstanceConfigurator(ctx, inst)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	rules, err := configurator.FindIngressRules()
-	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
-	}
-	return rules, err
-}
-
-func (c *equinixFirewaller) changeIngressRules(ctx context.ProviderCallContext, inst instances.Instance, insert bool, rules firewall.IngressRules) error {
-	addresses, sshClient, err := c.getInstanceConfigurator(ctx, inst)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	for _, addr := range addresses {
-		if addr.Scope == network.ScopePublic {
-			err = sshClient.ChangeIngressRules(addr.Value, insert, rules)
-			if err != nil {
-				common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
-				return errors.Trace(err)
-			}
-		}
-	}
-	return nil
-}
-
-func (c *equinixFirewaller) getInstanceConfigurator(
-	ctx context.ProviderCallContext, inst instances.Instance,
-) ([]network.ProviderAddress, common.InstanceConfigurator, error) {
-	addresses, err := inst.Addresses(ctx)
-	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
-		return nil, nil, errors.Trace(err)
-	}
-	if len(addresses) == 0 {
-		return addresses, nil, errors.New("No addresses found")
-	}
-
-	client := common.NewSshInstanceConfigurator(addresses[0].Value)
-	return addresses, client, err
 }

--- a/provider/equinix/provider.go
+++ b/provider/equinix/provider.go
@@ -22,6 +22,8 @@ import (
 	"github.com/packethost/packngo"
 )
 
+var _ environs.CloudEnvironProvider = (*environProvider)(nil)
+
 type environProvider struct {
 	environProviderCredentials
 }
@@ -70,7 +72,13 @@ func validateCloudSpec(spec environscloudspec.CloudSpec) error {
 	return nil
 }
 
-// Open is specified in the EnvironProvider interface.
+// Open opens the environment and returns it. The configuration must
+// have passed through PrepareConfig at some point in its lifecycle.
+//
+// Open should not perform any expensive operations, such as querying
+// the cloud API, as it will be called frequently.
+//
+// Open is part of the CloudEnvironProvider interface.
 func (p environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	logger.Debugf("opening model %q", args.Config.Name())
 


### PR DESCRIPTION
Updates the Equinix Metal provider to support Firewaller via SSH+IPTables (for `juju export` / `juju unexport`)
* implements `environs.Firewaller` 
* implements `instances.InstanceFirewaller`

Also:
* implements `environs.InstanceTagger`

Continues #13552 

## QA steps

```sh
git clone https://github.com/juju/juju/
cd juju
git fetch origin pulls/13695/head:equinixmetal-firewaller
git checkout equinixmetal-firewaller
go install ./cmd/juju
which juju # should be the one installed in the GOBIN path

YOUR_IP=$(curl -4 icanhazip.com)
YOUR_IPV6=$(curl -6 icanhazip.com)
INSTANCE_TYPE=c3.medium.x86 # pick the smallest plan available to you in Dallas

juju add-credential equinix
juju bootstrap equinix/da equinix-controller \
  --bootstrap-image=ubuntu_20_04 \
  --bootstrap-series=focal \
  --bootstrap-constraints="arch=amd64 instance-type=$INSTANCE_TYPE" \
  --build-agent # to use the local linux environment development build remotely

juju set-model-constraints arch=amd64 instance-type=$INSTANCE_TYPE

juju deploy mysql --channel=edge --series=bionic && \
juju deploy wordpress --channel=edge --series=bionic --to=0 && \
juju add-relation wordpress mysql && \
juju expose wordpress --to-cidrs=${YOUR_IP}/32 # your ipv4, add ",${YOUR_IPV6}/128" if also available
# ^ it should now be accessible
# juju status to get the IP and load it in your browser

juju unexpose wordpress
# ^ it should no longer be accessible. verify in your browser.

# debug: if the page loads when it is not exposed, report the following log:
# TODO: how to log helpful debuggin
```

```
# cleanup
juju destroy-controller equinix-controller  --destroy-all-models
```


Next: TODO


## Bug reference
https://bugs.launchpad.net/juju/+bug/1940520