### PR TITLE
[JUJU-560] Turns Jammy off as a supported series.

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -353,7 +353,7 @@ func (b *BundleAPI) fillBundleData(model description.Model, includeCharmDefaults
 	cfg := model.Config()
 	value, ok := cfg["default-series"]
 	if !ok {
-		value = series.LatestLts()
+		value = series.LatestLTS()
 	}
 	defaultSeries := fmt.Sprintf("%v", value)
 

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -43,6 +43,7 @@ import (
 	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/version"
 )
 
 const (
@@ -1441,7 +1442,7 @@ func (c *controllerStack) buildContainerSpecForCommands(jujudCmds []string) (*co
 		c.broker.randomPrefix,
 	)
 
-	chSeries := series.LatestLts()
+	chSeries := version.DefaultSupportedLTS()
 	os, err := series.GetOSFromSeries(chSeries)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -507,7 +507,7 @@ please choose a different hosted model name then try again.`, hostedModelName),
 	return &environs.BootstrapResult{
 		Arch: podArch,
 		// TODO(wallyworld) - use actual series of controller pod image
-		Series:                 series.LatestLts(),
+		Series:                 series.LatestLTS(),
 		CaasBootstrapFinalizer: finalizer,
 	}, nil
 }

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -379,7 +379,7 @@ func constructRefreshBase(base RefreshBase) (transport.Base, error) {
 		// Kubernetes is not a valid channel for a base.
 		// Instead use the latest LTS version of ubuntu.
 		name = "ubuntu"
-		channel, err = coreseries.SeriesVersion(coreseries.LatestLts())
+		channel, err = coreseries.SeriesVersion(coreseries.LatestLTS())
 		if err != nil {
 			return transport.Base{}, errors.NotValidf("invalid latest version")
 		}

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -37,7 +37,7 @@ const controllerCharmURL = "ch:juju-controller"
 
 func (c *BootstrapCommand) deployControllerCharm(st *state.State, cons constraints.Value, charmRisk string, isCAAS bool, unitPassword string) (resultErr error) {
 	arch := corearch.DefaultArchitecture
-	series := coreseries.LatestLts()
+	series := coreseries.LatestLTS()
 	if cons.HasArch() {
 		arch = *cons.Arch
 	}
@@ -154,8 +154,8 @@ func populateStoreControllerCharm(st *state.State, charmRisk, series, arch strin
 	// any series specific code.
 	if charmSeries := set.NewStrings(supportedSeries...); charmSeries.Contains(series) {
 		curl = curl.WithSeries(series)
-	} else if charmSeries.Contains(coreseries.LatestLts()) {
-		curl = curl.WithSeries(coreseries.LatestLts())
+	} else if charmSeries.Contains(coreseries.LatestLTS()) {
+		curl = curl.WithSeries(coreseries.LatestLTS())
 	} else {
 		// Fallback in case controller charm is out of date.
 		curl = curl.WithSeries("focal")

--- a/core/series/supported.go
+++ b/core/series/supported.go
@@ -348,7 +348,7 @@ var ubuntuSeries = map[SeriesName]seriesVersion{
 		WorkloadType: ControllerWorkloadType,
 		Version:      "22.04",
 		LTS:          true,
-		Supported:    true,
+		Supported:    false,
 		ESMSupported: true,
 	},
 }

--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -68,8 +68,8 @@ func AllWorkloadOSTypes(requestedSeries, imageStream string) (set.Strings, error
 		return nil, errors.Trace(err)
 	}
 	result := set.NewStrings()
-	for _, series := range supported.workloadSeries(true) {
-		result.Add(DefaultOSTypeNameFromSeries(series))
+	for _, wSeries := range supported.workloadSeries(true) {
+		result.Add(DefaultOSTypeNameFromSeries(wSeries))
 	}
 	return result, nil
 }
@@ -371,8 +371,8 @@ var (
 // the work to determine the latest lts series once.
 var latestLtsSeries string
 
-// LatestLts returns the Latest LTS Release found in distro-info
-func LatestLts() string {
+// LatestLTS returns the Latest LTS Release found in distro-info
+func LatestLTS() string {
 	if latestLtsSeries != "" {
 		return latestLtsSeries
 	}
@@ -382,11 +382,11 @@ func LatestLts() string {
 	updateSeriesVersionsOnce()
 
 	var latest SeriesName
-	for k, version := range ubuntuSeries {
-		if !version.LTS || !version.Supported {
+	for k, seriesVersion := range ubuntuSeries {
+		if !seriesVersion.LTS || !seriesVersion.Supported {
 			continue
 		}
-		if version.Version > ubuntuSeries[latest].Version {
+		if seriesVersion.Version > ubuntuSeries[latest].Version {
 			latest = k
 		}
 	}

--- a/core/series/supportedseries_linux_test.go
+++ b/core/series/supportedseries_linux_test.go
@@ -33,11 +33,11 @@ func (s *SupportedSeriesLinuxSuite) TestLatestLts(c *gc.C) {
 		latest, want string
 	}{
 		{"testseries", "testseries"},
-		{"", "jammy"},
+		{"", "focal"},
 	}
 	for _, test := range table {
 		SetLatestLtsForTesting(test.latest)
-		got := LatestLts()
+		got := LatestLTS()
 		c.Assert(got, gc.Equals, test.want)
 	}
 }


### PR DESCRIPTION
Jammy has not been released yet and using Juju on any other platform
besides Linux will try and deploy Jammy.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

N/A

## Documentation changes

N/A

## Bug reference

N/A
