### PR TITLE
Update the raftlease mocks

### DIFF
--- a/apiserver/facades/controller/raftlease/raft_mock_test.go
+++ b/apiserver/facades/controller/raftlease/raft_mock_test.go
@@ -530,6 +530,20 @@ func (mr *MockContextMockRecorder) State() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockContext)(nil).State))
 }
 
+// StateManager mocks base method.
+func (m *MockContext) StateManager() facade.StateManager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StateManager")
+	ret0, _ := ret[0].(facade.StateManager)
+	return ret0
+}
+
+// StateManager indicates an expected call of StateManager.
+func (mr *MockContextMockRecorder) StateManager() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateManager", reflect.TypeOf((*MockContext)(nil).StateManager))
+}
+
 // StatePool mocks base method.
 func (m *MockContext) StatePool() *state.StatePool {
 	m.ctrl.T.Helper()

--- a/go.sum
+++ b/go.sum
@@ -636,6 +636,7 @@ github.com/juju/utils v0.0.0-20180619112806-c746c6e86f4f/go.mod h1:6/KLg8Wz/y2KV
 github.com/juju/utils v0.0.0-20180808125547-9dfc6dbfb02b/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20180820210520-bf9cc5bdd62d/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
+github.com/juju/utils v0.0.0-20200423035217-b0a7da72a5fa h1:lv9vemJVV2iGalxqEOqEPw2+bBr0WyZqun7TfguD4fY=
 github.com/juju/utils v0.0.0-20200423035217-b0a7da72a5fa/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=
 github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1/go.mod h1:fdlDtQlzundleLLz/ggoYinEt/LmnrpNKcNTABQATNI=
 github.com/juju/utils/v2 v2.0.0-20210305225158-eedbe7b6b3e2 h1:E7BgV8lczMmMqMtXdOis5BPEDu6bSG1D6K7SHEq7hEw=


### PR DESCRIPTION
When bringing in the 2.9 branch with all the changes, we accidentally
broke the raftlease mocks. It was missing a StateManager method.

## QA steps

juju check job passes.