### PR TITLE
[JUJU-478] Require only a ping for the state pool

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -407,6 +407,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			StateConfigWatcherName: stateConfigWatcherName,
 			OpenStatePool:          config.OpenStatePool,
 			SetStatePool:           config.SetStatePool,
+			Clock:                  config.Clock,
 		}),
 
 		// The multiwatcher manifold watches all the changes in the database

--- a/state/pool.go
+++ b/state/pool.go
@@ -424,7 +424,8 @@ func (p *StatePool) Close() error {
 		p.txnWatcherSession.Close()
 	}
 	p.mu.Unlock()
-	// As with above and the other watchers. Unlock while releas
+	// As with above and the other watchers, unlock while releasing the state
+	// session.
 	if err := p.systemState.Close(); err != nil {
 		lastErr = err
 	}

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"sync"
 	"time"
 
 	"github.com/juju/errors"
@@ -12,11 +11,9 @@ import (
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 	"github.com/juju/worker/v3/dependency"
-	"gopkg.in/tomb.v2"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/wrench"
 )
 
 var logger = loggo.GetLogger("juju.worker.state")
@@ -130,178 +127,4 @@ func outputFunc(in worker.Worker, out interface{}) error {
 		return errors.Errorf("out should be *StateTracker; got %T", out)
 	}
 	return nil
-}
-
-type stateWorker struct {
-	catacomb     catacomb.Catacomb
-	stTracker    StateTracker
-	pingInterval time.Duration
-	setStatePool func(*state.StatePool)
-	cleanupOnce  sync.Once
-}
-
-func (w *stateWorker) loop() error {
-	pool, err := w.stTracker.Use()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer func() { _ = w.stTracker.Done() }()
-
-	systemState := pool.SystemState()
-
-	w.setStatePool(pool)
-	defer w.setStatePool(nil)
-
-	modelWatcher := systemState.WatchModelLives()
-	_ = w.catacomb.Add(modelWatcher)
-
-	wrenchTimer := time.NewTimer(30 * time.Second)
-	defer wrenchTimer.Stop()
-
-	modelStateWorkers := make(map[string]worker.Worker)
-	for {
-		select {
-		case <-w.catacomb.Dying():
-			return w.catacomb.ErrDying()
-
-		case modelUUIDs := <-modelWatcher.Changes():
-			for _, modelUUID := range modelUUIDs {
-				if err := w.processModelLifeChange(
-					modelUUID,
-					modelStateWorkers,
-					pool,
-				); err != nil {
-					return errors.Trace(err)
-				}
-			}
-		// Useful for tracking down some bugs that occur when
-		// mongo is overloaded.
-		case <-wrenchTimer.C:
-			if wrench.IsActive("state-worker", "io-timeout") {
-				return errors.Errorf("wrench simulating i/o timeout!")
-			}
-			wrenchTimer.Reset(30 * time.Second)
-		}
-	}
-}
-
-// Report conforms to the Dependency Engine Report() interface, giving an opportunity to introspect
-// what is going on at runtime.
-func (w *stateWorker) Report() map[string]interface{} {
-	return w.stTracker.Report()
-}
-
-func (w *stateWorker) processModelLifeChange(
-	modelUUID string,
-	modelStateWorkers map[string]worker.Worker,
-	pool *state.StatePool,
-) error {
-	remove := func() {
-		if w, ok := modelStateWorkers[modelUUID]; ok {
-			w.Kill()
-			delete(modelStateWorkers, modelUUID)
-		}
-		_, _ = pool.Remove(modelUUID)
-	}
-
-	model, hp, err := pool.GetModel(modelUUID)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// Model has been removed from state.
-			logger.Debugf("model %q removed from state", modelUUID)
-			remove()
-			return nil
-		}
-		return errors.Trace(err)
-	}
-	defer hp.Release()
-
-	if model.Life() == state.Dead {
-		// Model is Dead, and will soon be removed from state.
-		logger.Debugf("model %q is dead", modelUUID)
-		remove()
-		return nil
-	}
-
-	if modelStateWorkers[modelUUID] == nil {
-		mw := newModelStateWorker(pool, modelUUID, w.pingInterval)
-		modelStateWorkers[modelUUID] = mw
-		_ = w.catacomb.Add(mw)
-	}
-
-	return nil
-}
-
-// Kill is part of the worker.Worker interface.
-func (w *stateWorker) Kill() {
-	w.catacomb.Kill(nil)
-}
-
-// Wait is part of the worker.Worker interface.
-func (w *stateWorker) Wait() error {
-	err := w.catacomb.Wait()
-	w.cleanupOnce.Do(func() {
-		// Make sure the worker has exited before closing state.
-		if err := w.stTracker.Done(); err != nil {
-			logger.Warningf("error releasing state: %v", err)
-		}
-	})
-	return err
-}
-
-type modelStateWorker struct {
-	tomb         tomb.Tomb
-	pool         *state.StatePool
-	modelUUID    string
-	pingInterval time.Duration
-}
-
-func newModelStateWorker(
-	pool *state.StatePool,
-	modelUUID string,
-	pingInterval time.Duration,
-) worker.Worker {
-	w := &modelStateWorker{
-		pool:         pool,
-		modelUUID:    modelUUID,
-		pingInterval: pingInterval,
-	}
-	w.tomb.Go(w.loop)
-	return w
-}
-
-func (w *modelStateWorker) loop() error {
-	st, err := w.pool.Get(w.modelUUID)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// ignore not found error here, because the pooledState has already been removed.
-			return nil
-		}
-		return errors.Trace(err)
-	}
-	defer func() {
-		st.Release()
-		_, _ = w.pool.Remove(w.modelUUID)
-	}()
-
-	for {
-		select {
-		case <-w.tomb.Dying():
-			return tomb.ErrDying
-		case <-time.After(w.pingInterval):
-			if err := st.Ping(); err != nil {
-				return errors.Annotate(err, "state ping failed")
-			}
-		}
-	}
-}
-
-// Kill is part of the worker.Worker interface.
-func (w *modelStateWorker) Kill() {
-	w.tomb.Kill(nil)
-}
-
-// Wait is part of the worker.Worker interface.
-func (w *modelStateWorker) Wait() error {
-	return w.tomb.Wait()
 }

--- a/worker/state/manifold.go
+++ b/worker/state/manifold.go
@@ -6,6 +6,7 @@ package state
 import (
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/worker/v3"
@@ -24,6 +25,7 @@ type ManifoldConfig struct {
 	StateConfigWatcherName string
 	OpenStatePool          func(coreagent.Config) (*state.StatePool, error)
 	PingInterval           time.Duration
+	Clock                  clock.Clock
 
 	// SetStatePool is called with the state pool when it is created,
 	// and called again with nil just before the state pool is closed.
@@ -46,6 +48,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.SetStatePool == nil {
 		return errors.NotValidf("nil SetStatePool")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	return nil
 }
@@ -97,6 +102,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				stTracker:    stTracker,
 				pingInterval: pingInterval,
 				setStatePool: config.SetStatePool,
+				clock:        config.Clock,
 			}
 			if err := catacomb.Invoke(catacomb.Plan{
 				Site: &w.catacomb,

--- a/worker/state/manifold_test.go
+++ b/worker/state/manifold_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -28,7 +29,6 @@ type ManifoldSuite struct {
 	openStateCalled   bool
 	openStateErr      error
 	config            workerstate.ManifoldConfig
-	agent             *mockAgent
 	resources         dt.StubResources
 	setStatePoolCalls []*state.StatePool
 }
@@ -50,6 +50,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		SetStatePool: func(pool *state.StatePool) {
 			s.setStatePoolCalls = append(s.setStatePoolCalls, pool)
 		},
+		Clock: clock.WallClock,
 	}
 	s.manifold = workerstate.Manifold(s.config)
 	s.resources = dt.StubResources{
@@ -96,6 +97,11 @@ func (s *ManifoldSuite) TestStartOpenStateNil(c *gc.C) {
 func (s *ManifoldSuite) TestStartSetStatePoolNil(c *gc.C) {
 	s.config.SetStatePool = nil
 	s.startManifoldInvalidConfig(c, s.config, "nil SetStatePool not valid")
+}
+
+func (s *ManifoldSuite) TestStartClockNil(c *gc.C) {
+	s.config.Clock = nil
+	s.startManifoldInvalidConfig(c, s.config, "nil Clock not valid")
 }
 
 func (s *ManifoldSuite) startManifoldInvalidConfig(c *gc.C, config workerstate.ManifoldConfig, expect string) {


### PR DESCRIPTION
Requires #13633 to land first.

--------

The state model worker would force a mongo session ping per model. This
causes a lot of noise for controllers with lots of models. In reality,
all sessions for a given controller are copies of the root session. So
if the root session isn't pingable then it doesn't matter if the model
sessions are reachable, we'll fail at the system state level. We use the
catacomb dying as a way to indicate that all modelStateWorkers should
clean up and release the state.

Originally the premise was to remove the modelStateWorker, but we do
still require the modelStateWorker as that correctly removes the model
from the state pool. I don't believe there is another way around
that, without using finalizers.

As a driveby, I also pushed the clock in through the manifold.

## QA steps

```
$ juju bootstrap lxd test
$ juju enable-ha
$ juju deploy ubuntu 
$ juju deploy mongodb
```

It expects a [juju_mongo](https://discourse.charmhub.io/t/login-into-mongodb/309) on the `$PATH`.

```
$ juju mongo
$ rs.stepDown(10)
```
