### PR TITLE
[JUJU-562] Setup required version of Go in actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,21 @@ jobs:
            - { os: darwin, arch: amd64 }
 
     steps:
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v2.1.4
-      with:
-        go-version: "1.17"
-      id: go
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Find required go version
+      id: go-version
+      run: |
+        set -euxo pipefail
+        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.4
+      with:
+        go-version: ${{ steps.go-version.outputs.version }}
+      id: go
+
     - name: Build
       run: |
         GOOS=${{ matrix.platform.os }} GOARCH=${{ matrix.platform.arch }} make go-install

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,5 +1,5 @@
 name: "Client Tests"
-on: 
+on:
   push:
     paths-ignore:
       - 'acceptancetests/**'
@@ -34,14 +34,20 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v2.1.4
-      with:
-        go-version: 1.17
-      id: go
-
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Find required go version
+      id: go-version
+      run: |
+        set -euxo pipefail
+        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.4
+      with:
+        go-version: ${{ steps.go-version.outputs.version }}
+      id: go
 
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -18,7 +18,7 @@ on:
       - 'testing/**'
       - 'tests/**'
 
-env: 
+env:
   DOCKER_USERNAME: jujuqabot
   JUJU_BUILD_NUMBER: 888
 
@@ -32,20 +32,26 @@ jobs:
         microk8s: [1.21/stable]
 
     steps:
-    - name: Set up Go 1.17 for building juju
+    - name: Checking out repo
+      uses: actions/checkout@v2
+
+    - name: Find required go version
+      id: go-version
+      run: |
+        set -euxo pipefail
+        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+
+    - name: Set up Go
       uses: actions/setup-go@v2.1.4
       with:
-        go-version: "1.17"
+        go-version: ${{ steps.go-version.outputs.version }}
       id: go
-      
+
     - name: setup env
       shell: bash
       run: |
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
-    - name: Checking out repo
-      uses: actions/checkout@v2
 
     - uses: balchua/microk8s-actions@v0.2.2
       with:
@@ -174,7 +180,7 @@ jobs:
             kubectl describe $resource -A > describe/"$resource".describe || true
         done
       if: failure()
-      
+
     - name: Upload kubectl describe
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,6 +24,18 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Find required go version
+      id: go-version
+      run: |
+        set -euxo pipefail
+        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.4
+      with:
+        go-version: ${{ steps.go-version.outputs.version }}
+      id: go
+
     - name: Build snap
       shell: bash
       run: |
@@ -75,6 +87,24 @@ jobs:
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
         echo "/snap/bin" >> $GITHUB_PATH
 
+    - name: Checkout
+      if: env.RUN_TEST == 'RUN'
+      uses: actions/checkout@v2
+
+    - name: Find required go version
+      id: go-version
+      if: env.RUN_TEST == 'RUN'
+      run: |
+        set -euxo pipefail
+        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+
+    - name: Set up Go
+      if: env.RUN_TEST == 'RUN'
+      uses: actions/setup-go@v2.1.4
+      with:
+        go-version: ${{ steps.go-version.outputs.version }}
+      id: go
+
     - name: Bootstrap Juju
       if: env.RUN_TEST == 'RUN'
       shell: bash
@@ -85,10 +115,6 @@ jobs:
         juju bootstrap localhost test
         juju status
         juju version
-
-    - name: Checkout
-      if: env.RUN_TEST == 'RUN'
-      uses: actions/checkout@v2
 
     - name: Deploy some applications
       if: env.RUN_TEST == 'RUN'

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -23,6 +23,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Find required go version
+      id: go-version
+      if: env.RUN_TEST == 'RUN'
+      run: |
+        set -euxo pipefail
+        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+
+    - name: Set up Go
+      if: env.RUN_TEST == 'RUN'
+      uses: actions/setup-go@v2.1.4
+      with:
+        go-version: ${{ steps.go-version.outputs.version }}
+      id: go
+
     - name: Build snap
       shell: bash
       run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,7 +27,7 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.0
 
     - name: Download Dependencies
       run: go mod download

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,10 +7,19 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
 
-    - name: Set up Go 1.17
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Find required go version
+      id: go-version
+      run: |
+        set -euxo pipefail
+        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+
+    - name: Set up Go
       uses: actions/setup-go@v2.1.4
       with:
-        go-version: 1.17
+        go-version: ${{ steps.go-version.outputs.version }}
       id: go
 
     - name: Install Dependencies
@@ -19,9 +28,6 @@ jobs:
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
-
-    - name: Checkout
-      uses: actions/checkout@v2
 
     - name: Download Dependencies
       run: go mod download
@@ -52,17 +58,22 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
 
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v2.1.4
-      with:
-        go-version: 1.17
-      id: go
-
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Find required go version
+      id: go-version
+      run: |
+        set -euxo pipefail
+        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.4
+      with:
+        go-version: ${{ steps.go-version.outputs.version }}
+      id: go
 
     - name: Schema Check
       run: |
         STATIC_ANALYSIS_JOB=test_schema make static-analysis
       shell: bash
-

--- a/caas/kubernetes/provider/resources/claim_test.go
+++ b/caas/kubernetes/provider/resources/claim_test.go
@@ -66,7 +66,7 @@ func TestClaimHasJujuLabel(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			r, err := claimHasJujuLabel(test.Obj)
 			if err != nil {
-				t.Errorf("unexpected error testing claim has juju label %w", err)
+				t.Errorf("unexpected error testing claim has juju label %v", err)
 			}
 			if r != test.Result {
 				t.Errorf("unexpected result for claim has juju label, weanted %t got %t",
@@ -172,7 +172,7 @@ func TestClaimIsManagedByJuju(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			r, err := claimIsManagedByJuju(test.Obj)
 			if err != nil {
-				t.Errorf("unexpected error testing is managed by juju %w", err)
+				t.Errorf("unexpected error testing is managed by juju %v", err)
 			}
 			if r != test.Result {
 				t.Errorf("unexpected result for claim is managed by juju, weanted %t got %t",
@@ -207,7 +207,7 @@ func TestClaimIsManagedByJujuNilData(t *testing.T) {
 func TestClaimOrAggregateWithEmptyClaimsReturnsFalse(t *testing.T) {
 	r, err := ClaimAggregateOr().Assert(nil)
 	if err != nil {
-		t.Errorf("unexpected error for empty claim aggregate or %w", err)
+		t.Errorf("unexpected error for empty claim aggregate or %v", err)
 	}
 	if r {
 		t.Errorf("expected empty claim aggregate or to return false")
@@ -224,7 +224,7 @@ func TestClaimAggregateOrReturnsTrue(t *testing.T) {
 		}),
 	).Assert(nil)
 	if err != nil {
-		t.Errorf("unexpected error for claim aggregate or %w", err)
+		t.Errorf("unexpected error for claim aggregate or %v", err)
 	}
 	if !r {
 		t.Errorf("expected claim aggregate or to return true")
@@ -241,7 +241,7 @@ func TestClaimAggregateOrReturnsFalse(t *testing.T) {
 		}),
 	).Assert(nil)
 	if err != nil {
-		t.Errorf("unexpected error for claim aggregate or %w", err)
+		t.Errorf("unexpected error for claim aggregate or %v", err)
 	}
 	if r {
 		t.Errorf("expected claim aggregate or to return false")
@@ -370,7 +370,7 @@ func TestClaimJujuOwnership(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			r, err := ClaimJujuOwnership.Assert(test.Obj)
 			if err != nil {
-				t.Errorf("unexpected error testing claim juju ownership %w", err)
+				t.Errorf("unexpected error testing claim juju ownership %v", err)
 			}
 			if r != test.Result {
 				t.Errorf("unexpected result for claim juju ownership, weanted %t got %t",

--- a/cmd/juju-bridge/main.go
+++ b/cmd/juju-bridge/main.go
@@ -26,6 +26,7 @@ Options:
 Example:
 
   $ juju-bridge /etc/network/interfaces ens3=br-ens3 bond0.150=br-bond0.150
+
 `
 
 func printParseError(err error) {
@@ -43,7 +44,7 @@ func main() {
 	args := flag.Args()
 
 	if len(args) < 2 {
-		fmt.Fprintln(os.Stderr, usage)
+		fmt.Fprint(os.Stderr, usage)
 		os.Exit(1)
 	}
 
@@ -63,7 +64,7 @@ func main() {
 	for _, v := range args[1:] {
 		arg := strings.Split(v, "=")
 		if len(arg) != 2 {
-			fmt.Fprintln(os.Stderr, usage)
+			fmt.Fprint(os.Stderr, usage)
 			os.Exit(1)
 		}
 		devices[arg[0]] = arg[1]

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,7 +1,7 @@
 run_go() {
 	VER=$(golangci-lint --version | tr -s ' ' | cut -d ' ' -f 4 | cut -d '.' -f 1,2)
-	if [[ ${VER} != "1.36" ]] && [[ ${VER} != "v1.36" ]]; then
-		(echo >&2 -e '\nError: golangci-lint version does not match 1.36. Please upgrade/downgrade to the right version.')
+	if [[ ${VER} != "1.44" ]] && [[ ${VER} != "v1.44" ]]; then
+		(echo >&2 -e '\nError: golangci-lint version does not match 1.44. Please upgrade/downgrade to the right version.')
 		exit 1
 	fi
 	OUT=$(golangci-lint run -c .github/golangci-lint.config.yaml 2>&1)


### PR DESCRIPTION
use go.mod to figure out which version is required. Then install that version of Go when running GitHub actions

GitHub runners have go1.15 installed by default. This is no longer recent enough to run all CI jobs. So add a setup-go action to jobs missing it

Also, whilst I'm here, decide which version of Go to install by looking in go.mod

This also required an upgrade to golanci-lint v1.44. Make that change and adjust fix a few failing lint cases

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Run all Github actions

## Documentation changes

No documentation changes

## Bug reference

No bug reference
