### PR TITLE
Add CharmDownloader to allowed caas facades

### DIFF
--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -22,6 +22,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"Block",
 	"CharmRevisionUpdater",
 	"Charms",
+	"CharmDownloader",
 	"CharmHub",
 	"Cleaner",
 	"Client",


### PR DESCRIPTION
Quick fix - I noticed when testing on k8s that there was log spam saying that "CharmDownloader" facade was not allowed on CAAS models. So we add it to the whitelist. It might be easier switch the config to define the excluded facades instead.

## QA steps

deploy a k8s charm and check logs