### PR TITLE
Ensure we check trace enabled before heavy operations

### DIFF
--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -141,7 +141,9 @@ func ServerError(err error) *params.Error {
 	if err == nil {
 		return nil
 	}
-	logger.Tracef("server RPC error %v", errors.Details(err))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("server RPC error %v", errors.Details(err))
+	}
 
 	var (
 		info map[string]interface{}

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -213,5 +213,7 @@ func (n *rpcObserver) logReplyTrace(logger loggo.Logger, hdr *rpc.Header, body i
 }
 
 func (n *rpcObserver) logTrace(logger loggo.Logger, prefix string, hdr *rpc.Header, body interface{}) {
-	logger.Tracef("%s [%X] %s %s", prefix, n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("%s [%X] %s %s", prefix, n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
+	}
 }

--- a/caas/kubernetes/provider/specs/container_env.go
+++ b/caas/kubernetes/provider/specs/container_env.go
@@ -290,7 +290,9 @@ func ContainerConfigToK8sEnvConfig(cc specs.ContainerConfig) (envVars []core.Env
 		case map[string]interface{}:
 			vars, envFroms, err := processMapInterfaceValue(k, envVal)
 			if err != nil {
-				logger.Tracef("processing container config %q, err -> %v", k, errors.ErrorStack(err))
+				if logger.IsTraceEnabled() {
+					logger.Tracef("processing container config %q, err -> %v", k, errors.ErrorStack(err))
+				}
 				return nil, nil, errors.Trace(err)
 			}
 			envVars = append(envVars, vars...)
@@ -308,8 +310,10 @@ func ContainerConfigToK8sEnvConfig(cc specs.ContainerConfig) (envVars []core.Env
 		return getEnvFromSourceName(envFromSources[i]) < getEnvFromSourceName(envFromSources[j])
 	})
 
-	logger.Tracef("envVars -> %s", pretty.Sprint(envVars))
-	logger.Tracef("envFromSources -> %s", pretty.Sprint(envFromSources))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("envVars -> %s", pretty.Sprint(envVars))
+		logger.Tracef("envFromSources -> %s", pretty.Sprint(envFromSources))
+	}
 	return envVars, envFromSources, nil
 }
 

--- a/charmhub/info.go
+++ b/charmhub/info.go
@@ -94,7 +94,9 @@ func (c *InfoClient) Info(ctx context.Context, name string, options ...InfoOptio
 		return resp, errors.Errorf("unexpected response type %q, expected charm or bundle", resp.Type)
 	}
 
-	c.logger.Tracef("Info() unmarshalled: %s", pretty.Sprint(resp))
+	if c.logger.IsTraceEnabled() {
+		c.logger.Tracef("Info() unmarshalled: %s", pretty.Sprint(resp))
+	}
 	return resp, nil
 }
 

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -97,7 +97,9 @@ func NewRefreshClient(path path.Path, client RESTClient, logger Logger) *Refresh
 
 // Refresh is used to refresh installed charms to a more suitable revision.
 func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]transport.RefreshResponse, error) {
-	c.logger.Tracef("Refresh(%s)", pretty.Sprint(config))
+	if c.logger.IsTraceEnabled() {
+		c.logger.Tracef("Refresh(%s)", pretty.Sprint(config))
+	}
 	req, err := config.Build()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -108,7 +110,9 @@ func (c *RefreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 // RefreshWithRequestMetrics is to get refreshed charm data and provide metrics
 // at the same time.  Used as part of the charm revision updater facade.
 func (c *RefreshClient) RefreshWithRequestMetrics(ctx context.Context, config RefreshConfig, metrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string) ([]transport.RefreshResponse, error) {
-	c.logger.Tracef("RefreshWithRequestMetrics(%s, %+v)", pretty.Sprint(config), metrics)
+	if c.logger.IsTraceEnabled() {
+		c.logger.Tracef("RefreshWithRequestMetrics(%s, %+v)", pretty.Sprint(config), metrics)
+	}
 	req, err := config.Build()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/charmhub/resources.go
+++ b/charmhub/resources.go
@@ -46,6 +46,8 @@ func (c *ResourcesClient) ListResourceRevisions(ctx context.Context, charm, reso
 	if restResp.StatusCode == http.StatusNotFound {
 		return nil, errors.NotFoundf("%q for %q", charm, resource)
 	}
-	c.logger.Tracef("ListResourceRevisions(%s, %s) unmarshalled: %s", charm, resource, pretty.Sprint(resp.Revisions))
+	if c.logger.IsTraceEnabled() {
+		c.logger.Tracef("ListResourceRevisions(%s, %s) unmarshalled: %s", charm, resource, pretty.Sprint(resp.Revisions))
+	}
 	return resp.Revisions, nil
 }

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -538,14 +538,18 @@ func (h *bundleHandler) getChanges() error {
 		Logger:           logger,
 		Force:            h.force,
 	}
-	logger.Tracef("bundlechanges.ChangesConfig.Bundle %s", pretty.Sprint(cfg.Bundle))
-	logger.Tracef("bundlechanges.ChangesConfig.BundleURL %s", pretty.Sprint(cfg.BundleURL))
-	logger.Tracef("bundlechanges.ChangesConfig.Model %s", pretty.Sprint(cfg.Model))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("bundlechanges.ChangesConfig.Bundle %s", pretty.Sprint(cfg.Bundle))
+		logger.Tracef("bundlechanges.ChangesConfig.BundleURL %s", pretty.Sprint(cfg.BundleURL))
+		logger.Tracef("bundlechanges.ChangesConfig.Model %s", pretty.Sprint(cfg.Model))
+	}
 	changes, err := bundlechanges.FromData(cfg)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	logger.Tracef("changes %s", pretty.Sprint(changes))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("changes %s", pretty.Sprint(changes))
+	}
 	h.changes = changes
 	return nil
 }
@@ -573,7 +577,9 @@ func (h *bundleHandler) handleChanges() error {
 	// Deploy the bundle.
 	for i, change := range h.changes {
 		fmt.Fprint(h.ctx.Stdout, fmtChange(change))
-		logger.Tracef("%d: change %s", i, pretty.Sprint(change))
+		if logger.IsTraceEnabled() {
+			logger.Tracef("%d: change %s", i, pretty.Sprint(change))
+		}
 		switch change := change.(type) {
 		case *bundlechanges.AddCharmChange:
 			err = h.addCharm(change)

--- a/docker/registry/internal/transports.go
+++ b/docker/registry/internal/transports.go
@@ -260,7 +260,9 @@ func handleErrorResponse(resp *http.Response) (*http.Response, error) {
 		return nil, errors.Annotatef(err, "reading bad response body with status code %d", resp.StatusCode)
 	}
 	errMsg := fmt.Sprintf("non-successful response status=%d", resp.StatusCode)
-	logger.Tracef("%s, url %q, body=%q", errMsg, resp.Request.URL.String(), body)
+	if logger.IsTraceEnabled() {
+		logger.Tracef("%s, url %q, body=%q", errMsg, resp.Request.URL.String(), body)
+	}
 	errNew := errors.Errorf
 	switch resp.StatusCode {
 	case http.StatusForbidden:

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -5,7 +5,6 @@ package cloudsigma
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/loggo"
 
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
@@ -120,7 +119,7 @@ func (env *environ) instancesForMethod(ctx context.ProviderCallContext, method s
 		instances = append(instances, instance)
 	}
 
-	if logger.LogLevel() <= loggo.TRACE {
+	if logger.IsTraceEnabled() {
 		logger.Tracef("%v, len = %d:", method, len(instances))
 		for _, instance := range instances {
 			logger.Tracef("... id: %q, status: %q", instance.Id(), instance.Status(ctx))

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1507,7 +1507,9 @@ func (e *environ) networkInterfacesForInstance(ctx context.ProviderCallContext, 
 			logger.Tracef("%s", msg)
 			return errors.New(msg)
 		}
-		logger.Tracef("found instance %q NICs: %s", instId, pretty.Sprint(resp.NetworkInterfaces))
+		if logger.IsTraceEnabled() {
+			logger.Tracef("found instance %q NICs: %s", instId, pretty.Sprint(resp.NetworkInterfaces))
+		}
 		return nil
 	}
 	err := retry.Call(retryStrategy)

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -341,7 +341,9 @@ func getVPCRouteTables(apiClient vpcAPIClient, ctx context.ProviderCallContext, 
 	if len(resp.RouteTables) == 0 {
 		return nil, vpcNotRecommendedf("VPC has no route tables")
 	}
-	logger.Tracef("RouteTables() returned %s", pretty.Sprint(resp))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("RouteTables() returned %s", pretty.Sprint(resp))
+	}
 
 	return resp.RouteTables, nil
 }
@@ -396,7 +398,9 @@ func checkVPCRouteTableRoutes(vpc *types.Vpc, routeTable *types.RouteTable, gate
 	vpcCIDRBlock := aws.ToString(vpc.CidrBlock)
 	for _, route := range routeTable.Routes {
 		if route.State != activeState {
-			logger.Tracef("skipping inactive route %s", pretty.Sprint(route))
+			if logger.IsTraceEnabled() {
+				logger.Tracef("skipping inactive route %s", pretty.Sprint(route))
+			}
 			continue
 		}
 
@@ -413,7 +417,9 @@ func checkVPCRouteTableRoutes(vpc *types.Vpc, routeTable *types.RouteTable, gate
 				hasLocalRoute = true
 			}
 		default:
-			logger.Tracef("route %s is neither local nor default (skipping)", pretty.Sprint(route))
+			if logger.IsTraceEnabled() {
+				logger.Tracef("route %s is neither local nor default (skipping)", pretty.Sprint(route))
+			}
 		}
 	}
 

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -496,7 +496,9 @@ func (e *Environ) startInstance(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Tracef("Image cache contains: %# v", pretty.Formatter(imgCache))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("Image cache contains: %# v", pretty.Formatter(imgCache))
+	}
 
 	series := args.InstanceConfig.Series
 	arches := args.Tools.Arches()

--- a/state/database.go
+++ b/state/database.go
@@ -367,13 +367,17 @@ func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCl
 			closer = session.Close
 		}
 		observer := func(t jujutxn.Transaction) {
-			txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
-				t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
+			if txnLogger.IsTraceEnabled() {
+				txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
+					t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
+			}
 		}
 		if db.runTransactionObserver != nil {
 			observer = func(t jujutxn.Transaction) {
-				txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
-					t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
+				if txnLogger.IsTraceEnabled() {
+					txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
+						t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
+				}
 				db.runTransactionObserver(
 					db.raw.Name, db.modelUUID,
 					t.Ops, t.Error,

--- a/state/resources_mongo.go
+++ b/state/resources_mongo.go
@@ -165,7 +165,9 @@ func newInsertCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 func newUpdateCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 	doc := newCharmStoreResourceDoc(res)
 
-	logger.Tracef("updating charm store resource %s to %# v", res.id, pretty.Formatter(doc))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("updating charm store resource %s to %# v", res.id, pretty.Formatter(doc))
+	}
 	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,
@@ -190,7 +192,9 @@ func newUpdateUnitResourceOps(unitID string, stored storedResource, progress *in
 	doc := newUnitResourceDoc(unitID, stored)
 	doc.DownloadProgress = progress
 
-	logger.Tracef("updating unit resource %s to %# v", unitID, pretty.Formatter(doc))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("updating unit resource %s to %# v", unitID, pretty.Formatter(doc))
+	}
 	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,

--- a/state/resources_persistence.go
+++ b/state/resources_persistence.go
@@ -110,7 +110,9 @@ func (p ResourcePersistence) ListResources(applicationID string) (resource.Appli
 			DownloadProgress: downloadProgress[tag],
 		})
 	}
-	rpLogger.Tracef("found %d docs: %q", len(docs), pretty.Sprint(results))
+	if rpLogger.IsTraceEnabled() {
+		rpLogger.Tracef("found %d docs: %q", len(docs), pretty.Sprint(results))
+	}
 	return results, nil
 }
 

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -784,7 +784,9 @@ func (w *pgWorker) peerGroupInfo() (*peerGroupInfo, error) {
 		return nil, err
 	}
 
-	logger.Tracef("read peer group info: %# v\n%# v", pretty.Formatter(sts), pretty.Formatter(members))
+	if logger.IsTraceEnabled() {
+		logger.Tracef("read peer group info: %# v\n%# v", pretty.Formatter(sts), pretty.Formatter(members))
+	}
 	return newPeerGroupInfo(w.controllerTrackers, sts.Members, members, w.config.MongoPort, haSpace)
 }
 


### PR DESCRIPTION
Whilst investigating timeouts from mongo pings, I noticed that we have
traces happening for potential expensive operations. The following just
goes through the code base and wraps most of the Tracef with expensive
outputs (prettier, spew) to ensure that we don't waste CPU cycles on
logging stuff that will never be stored/logged.

## QA steps

We should still see the traces if we enable trace.

```sh
$ juju bootstrap lxd test
$ juju debug-log -m controller
$ juju model-config -m controller logging-config="<root>INFO;juju.state.txn=TRACE"
$ juju debug-log -m controller
```
