### PR TITLE
[JUJU-575] Add trust for kubeflow deploy command;

### DIFF
--- a/acceptancetests/assess_caas_deploy_kubeflow.py
+++ b/acceptancetests/assess_caas_deploy_kubeflow.py
@@ -118,6 +118,7 @@ def deploy_kubeflow(caas_client, k8s_model, bundle, build):
                     'deploy',
                     '--bundle', f'{KUBEFLOW_DIR}/{bundle_info[bundle]["file_name"]}',
                     '--build',
+                    '--trust',
                     '--', '-m', k8s_model.model_name,
                 ),
                 # disable `include_e` and pass -m to `juju-bundle`
@@ -127,6 +128,7 @@ def deploy_kubeflow(caas_client, k8s_model, bundle, build):
         k8s_model.deploy(
             charm=bundle_info[bundle]['uri'],
             channel="stable",
+            trust=True,
         )
 
     if application_exists(k8s_model, 'istio-ingressgateway'):
@@ -290,8 +292,8 @@ def get_pub_addr(caas_client, model_name):
         except (KeyError, subprocess.CalledProcessError):
             pass
     log.warn("""
-it is not possible to get the public address from either ambassador or istio-ingressgateway, now fall back to "localhost"
-""")
+it is not possible to get the public address from either ambassador or istio-ingressgateway,
+now fall back to 'localhost'""")
     # If all else fails, just use localhost
     return 'localhost'
 

--- a/acceptancetests/jujupy/__init__.py
+++ b/acceptancetests/jujupy/__init__.py
@@ -13,6 +13,30 @@
 # You should have received a copy of the Lesser GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from jujupy.backend import JUJU_DEV_FEATURE_FLAGS, JujuBackend
+from jujupy.client import (
+    KILL_CONTROLLER,
+    KVM_MACHINE,
+    LXC_MACHINE,
+    LXD_MACHINE,
+    IaasClient,
+    JujuData,
+    Machine,
+    ModelClient,
+    client_for_existing,
+    client_from_config,
+    get_cache_path,
+    get_machine_dns_name,
+    juju_home_path,
+    parse_new_state_server_from_error,
+    temp_bootstrap_env,
+)
+from jujupy.configuration import (
+    NoSuchEnvironment,
+    get_juju_data,
+    get_juju_home,
+)
+from jujupy.controller import Controllers
 from jujupy.exceptions import (
     AgentsNotStarted,
     AuthNotAccepted,
@@ -22,49 +46,10 @@ from jujupy.exceptions import (
     SoftDeadlineExceeded,
     TypeNotAccepted,
 )
-from jujupy.backend import (
-    JUJU_DEV_FEATURE_FLAGS,
-    JujuBackend,
-)
-from jujupy.client import (
-    client_from_config,
-    client_for_existing,
-    get_cache_path,
-    get_machine_dns_name,
-    juju_home_path,
-    JujuData,
-    KILL_CONTROLLER,
-    KVM_MACHINE,
-    LXC_MACHINE,
-    LXD_MACHINE,
-    Machine,
-    ModelClient,
-    IaasClient,
-    parse_new_state_server_from_error,
-    temp_bootstrap_env,
-)
-from jujupy.configuration import (
-    get_juju_data,
-    get_juju_home,
-    NoSuchEnvironment,
-)
-from jujupy.fake import (
-    FakeBackend,
-    FakeControllerState,
-    fake_juju_client,
-)
-from jujupy.status import (
-    Status,
-)
-from jujupy.controller import (
-    Controllers,
-)
-from jujupy.utility import (
-    get_timeout_prefix,
-)
-from jujupy.wait_condition import (
-    ConditionList,
-)
+from jujupy.fake import FakeBackend, FakeControllerState, fake_juju_client
+from jujupy.status import Status
+from jujupy.utility import get_timeout_prefix
+from jujupy.wait_condition import ConditionList
 
 __all__ = [
     'AgentsNotStarted',
@@ -91,7 +76,6 @@ __all__ = [
     'LXD_MACHINE',
     'Machine',
     'ModelClient',
-    'CaasClient',
     'IaasClient',
     'NameNotAccepted',
     'NoProvider',


### PR DESCRIPTION
Enable `--trust` for `kubeflow` deploy command;
Kubeflow has charms require `trust`:
  - dex-auth
  - istio-ingressgateway
  - kubeflow-roles
  - metacontroller-operator
  - training-operator