### PR TITLE
[JUJU-585] Increase SA secret bootstrap time out.

### DIFF
--- a/caas/kubernetes/clientconfig/plugins.go
+++ b/caas/kubernetes/clientconfig/plugins.go
@@ -98,9 +98,13 @@ func ensureJujuAdminServiceAccount(
 	}
 
 	var secret *core.Secret
+	// NOTE (tlm) Increased the max duration here to 120 seconds to deal with
+	// microk8s bootstrapping. Microk8s is taking a significant amoutn of time
+	// to be Kubernetes ready while still reporting that it is ready to go.
+	// See lp:1937282
 	retryCallArgs := retry.CallArgs{
 		Delay:       time.Second,
-		MaxDuration: 5 * time.Second,
+		MaxDuration: 120 * time.Second,
 		Clock:       clock,
 		Func: func() error {
 			secret, err = getServiceAccountSecret(clientset, name, adminNameSpace)


### PR DESCRIPTION
Increased the timeout for service account secret creation when bootstrapping to Microk8s.

## Please provide the following details to expedite review (and delete this heading)

*Replace with a description about why this change is needed, along with a description of what changed.*

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Immediately run microk8s enable storage dns then bootstrap Juju

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1937282
