### PR TITLE
Fix multiwatcher data race

### DIFF
--- a/core/multiwatcher/store.go
+++ b/core/multiwatcher/store.go
@@ -228,7 +228,13 @@ func (a *store) Get(id EntityID) EntityInfo {
 	if !ok {
 		return nil
 	}
-	return e.Value.(*entityEntry).info
+	ei := e.Value.(*entityEntry).info
+	if ei == nil {
+		return nil
+	}
+	// Always clone to prevent data races/mutating internal store state which will miss
+	// sending changes.
+	return ei.Clone()
 }
 
 // ChangesSince returns any changes that have occurred since

--- a/core/multiwatcher/store_internal_test.go
+++ b/core/multiwatcher/store_internal_test.go
@@ -309,7 +309,7 @@ func (s *storeSuite) TestGet(c *gc.C) {
 	m := &MachineInfo{ModelUUID: "uuid", ID: "0"}
 	a.Update(m)
 
-	c.Assert(a.Get(m.EntityID()), gc.Equals, m)
+	c.Assert(a.Get(m.EntityID()), gc.DeepEquals, m)
 	c.Assert(a.Get(EntityID{"machine", "uuid", "1"}), gc.IsNil)
 }
 

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -368,7 +368,14 @@ func (s *WorkerSuite) TestRemovedModel(c *gc.C) {
 	s.State.StartSync()
 
 	obtained = s.nextChange(c, changes)
+	modelChange2, ok := obtained.(cache.ModelChange)
+	c.Assert(ok, jc.IsTrue)
+	// Check permissions dropped correctly.
+	mc := jc.NewMultiChecker()
+	mc.AddExpr("_.UserPermissions", gc.HasLen, 0)
+	c.Assert(modelChange2, mc, modelChange)
 
+	obtained = s.nextChange(c, changes)
 	change, ok := obtained.(cache.RemoveModel)
 	c.Assert(ok, jc.IsTrue)
 	c.Check(change.ModelUUID, gc.Equals, model.UUID())


### PR DESCRIPTION
Raw updates to UserPermissions on `multiwatcher.ModelInfo` cause a data race. This fixes the issue by cloning the `multiwatcher.ModelInfo` before mutating UserPermissions.

## QA steps

Run race tests on all apiserver packages.

## Documentation changes

N/A

## Bug reference

N/A