### PR TITLE
[JUJU-587] Tweak cpu power so test passes

### DIFF
--- a/acceptancetests/assess_constraints.py
+++ b/acceptancetests/assess_constraints.py
@@ -363,7 +363,7 @@ def assess_constraints(client, test_kvm=False):
         assess_cores_constraints(client, ['2'])
         assess_cpu_power_constraints(client, ['30'])
         assess_multiple_constraints(client, 'root-disk-and-cpu-power',
-                                    root_disk='15G', cpu_power='40')
+                                    root_disk='15G', cpu_power='4000')
 
 
 def parse_args(argv):


### PR DESCRIPTION
The constraints test was failing intermittently because the instances provisioned with and without the `cpu-power` constraint ended up being the same, since the constraint value was so small.
Tweak the test to use a large value to ensure we get a different type of machine provisioned.

## QA steps

nw-constraints-aws test