### PR TITLE
[JUJU-592] LP1960235 worker does not stop

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -720,6 +720,7 @@ func (a *MachineAgent) startAPIWorkers(apiConn api.Connection) (_ worker.Worker,
 		IsFatal:       agenterrors.ConnectionIsFatal(logger, apiConn),
 		MoreImportant: agenterrors.MoreImportant,
 		RestartDelay:  jworker.RestartDelay,
+		Logger:        logger.Child("runner"),
 	})
 	defer func() {
 		// If startAPIWorkers exits early with an error, stop the

--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -143,7 +143,7 @@ func (cs *ContainerSetup) initialiseAndStartProvisioner(
 			// We only care about the initial container creation.
 			// This worker has done its job so stop it.
 			// We do not expect there will be an error, and there's not much we can do anyway.
-			if err := cs.runner.StopAndRemoveWorker(cs.workerName, nil); err != nil {
+			if err := cs.runner.StopAndRemoveWorker(cs.workerName, abort); err != nil {
 				cs.logger.Warningf("stopping machine agent container watcher: %v", err)
 			}
 		}


### PR DESCRIPTION
The unconverted-api-workers manifold was failing to quiesce for model migration or for agent upgrades.  The #-container-worker was stopped, but not gone, causing the manifold to stay in "stopping".

Include the abort channel when calling StopAndRemoveWorker for #-container-worker, otherwise it is stopped, but never goes away correctly due to the differences in return errors with StopWorker.  More investigation is needed around this.  As well as finally writing manifolds to move the unconverted-api-workers into their appropriate locations.

## QA steps

The following test is for migration, also a test for upgrade-juju should not require the machine agent to be bounced for success. 
```console
# Setup for model migration
$ juju bootstrap localhost destination
$ juju bootstrap localhost source
$ juju add-model moveme

# setup for the error scenario
$ juju deploy ubuntu
$ juju add-unit ubuntu --to lxd:0
# due to an outside issues, the container won't get to a full juju machine.
$ juju remove-unit ubuntu/1
$ juju remove-machine --force 0/lxd/1

# successful migrate
$ juju migrate moveme destination
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1960235
