### PR TITLE
Add Darwin support for uploading Microk8s images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,10 @@ host-install:
 ## install juju for host os/architecture
 	GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) make install
 
+minikube-operator-update: host-install operator-image
+## minikube-operator-update: Push up the newly built operator image for use with minikube
+	docker save "$(shell ${OPERATOR_IMAGE_PATH})" | minikube image load --overwrite=true -
+
 microk8s-operator-update: host-install operator-image
 ## microk8s-operator-update: Push up the newly built operator image for use with microk8s
 	@${UPDATE_MICROK8S_OPERATOR}

--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ OPERATOR_IMAGE_BUILD_SRC   ?= true
 BUILD_OPERATOR_IMAGE=sh -c '. "${PROJECT_DIR}/make_functions.sh"; build_operator_image "$$@"' build_operator_image
 OPERATOR_IMAGE_PATH=sh -c '. "${PROJECT_DIR}/make_functions.sh"; operator_image_path "$$@"' operator_image_path
 OPERATOR_IMAGE_RELEASE_PATH=sh -c '. "${PROJECT_DIR}/make_functions.sh"; operator_image_release_path "$$@"' operator_image_release_path
+UPDATE_MICROK8S_OPERATOR=sh -c '. "${PROJECT_DIR}/make_functions.sh"; microk8s_operator_update "$$@"' microk8s_operator_update
 
 image-check-build:
 ifeq ($(OPERATOR_IMAGE_BUILD_SRC),true)
@@ -257,7 +258,7 @@ host-install:
 
 microk8s-operator-update: host-install operator-image
 ## microk8s-operator-update: Push up the newly built operator image for use with microk8s
-	docker save "$(shell ${OPERATOR_IMAGE_PATH})" | microk8s.ctr --namespace k8s.io image import -
+	@${UPDATE_MICROK8S_OPERATOR}
 
 check-k8s-model:
 ## check-k8s-model: Check if k8s model is present in show-model

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -33,9 +33,26 @@ _image_version() {
     _strip_build_version "$(_juju_version)"
 }
 
+microk8s_operator_update() {
+  echo "Uploading image $(operator_image_path) to microk8s"
+  # For macos we have to push the image into the microk8s multipass vm because
+  # we can't use the ctr to stream off the local machine.
+  if [ $(uname) == "Darwin" ]; then
+    tmp_docker_image="/tmp/juju-operator-image-${RANDOM}.image"
+    docker save $(operator_image_path) | multipass transfer - microk8s-vm:${tmp_docker_image}
+    microk8s ctr --namespace k8s.io image import ${tmp_docker_image}
+    multipass exec microk8s-vm rm "${tmp_docker_image}"
+    return
+  fi
+
+  # Linux we can stream the file like normal.
+  docker save "$(operator_image_path)" | microk8s.ctr --namespace k8s.io image import -
+}
+
 operator_image_release_path() {
     echo "${DOCKER_USERNAME}/jujud-operator:$(_image_version)"
 }
+
 operator_image_path() {
     if [ -z "${JUJU_BUILD_NUMBER}" ] || [ ${JUJU_BUILD_NUMBER} -eq 0 ]; then
         operator_image_release_path


### PR DESCRIPTION
Add support for uploading microk8s images from Makefile on Darwin hosts.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run `make microk8s-operator-update` on Linux and Macos to make sure the images get uploaded to the local Microk8s repo.

## Documentation changes

N/A

## Bug reference

N/A
