### PR TITLE
Fix/nw deploy kubeflow

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -105,6 +105,9 @@ jobs:
         EOF
 
     - name: Test kubeflow
+      # TODO: disable test for now because some files required by kubeflow tests are not accessible now.
+      # URL fetch failure on https://people.canonical.com/~knkski/train-images-idx3-ubyte.gz: 404 -- Not Found
+      if: ${{ false }}
       run: |
         sg microk8s <<EOF
           set -eux
@@ -114,35 +117,35 @@ jobs:
 
     - name: Juju status
       run: juju status --relations --color --storage
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Juju status (YAML)
       run: juju status --relations --color --storage --format=yaml
-      if: failure()
+      if: ${{ failure() }}
 
     - name: MicroK8s status
       run: sudo microk8s status
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Get MicroK8s pods
       run: |
         sudo microk8s kubectl get pods -A -o wide
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Describe MicroK8s pods
       run: sudo microk8s kubectl describe pods -nkubeflow
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Generate debug log
       run: juju debug-log --replay --no-tail > juju-debug.log
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Upload debug log
       uses: actions/upload-artifact@v2
       with:
         name: juju-debug-actions
         path: juju-debug.log
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Get pipeline logs
       run: |
@@ -156,21 +159,21 @@ jobs:
           done
           printf '\n\n'
         done
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Generate inspect tarball
       run: >
         sudo microk8s inspect |
         grep -Po "Report tarball is at \K.+" |
         sudo xargs -I {} mv {} inspection-report-${{ strategy.job-index }}.tar.gz
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Upload inspect tarball
       uses: actions/upload-artifact@v2
       with:
         name: inspection-report-actions
         path: ./inspection-report-${{ strategy.job-index }}.tar.gz
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Generate kubectl describe
       run: |
@@ -179,14 +182,14 @@ jobs:
         for resource in $(kubectl api-resources -o name | sort); do
             kubectl describe $resource -A > describe/"$resource".describe || true
         done
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Upload kubectl describe
       uses: actions/upload-artifact@v2
       with:
         name: kubectl-describe-actions
         path: describe/*.describe
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Generate kubeflow pod logs
       run: |
@@ -197,11 +200,11 @@ jobs:
               kubectl logs -nkubeflow --timestamps $pod -c $container > stdout/$pod-$container.log
             done
         done
-      if: failure()
+      if: ${{ failure() }}
 
     - name: Upload kubeflow pod logs
       uses: actions/upload-artifact@v2
       with:
         name: kubectl-stdout-actions
         path: stdout/*.log
-      if: failure()
+      if: ${{ failure() }}

--- a/acceptancetests/assess_caas_deploy_kubeflow.py
+++ b/acceptancetests/assess_caas_deploy_kubeflow.py
@@ -324,6 +324,9 @@ def prepare(caas_client, caas_provider, build):
 
     caas_client.sh('rm', '-rf', f'{KUBEFLOW_DIR}')
     caas_client.sh('git', 'clone', KUBEFLOW_REPO_URI, KUBEFLOW_DIR)
+    # TODO: pin to this sha for now, update if we want to test newer Kubeflow.
+    caas_client.sh('git', 'reset', '--hard', 'a96fa2d')
+
     caas_client.sh('pip3', 'install', 'tox')
     caas_client.sh(
         'pip3', 'install',
@@ -425,7 +428,10 @@ def assess_caas_kubeflow_deployment(caas_client, caas_provider, bundle, build=Fa
         log.info("sleeping for 30 seconds to let everything start up")
         sleep(30)
 
-        run_test(caas_provider, caas_client, k8s_model, bundle, build)
+        # TODO: disable test for now because some files required by kubeflow tests are not accessible now.
+        # URL fetch failure on https://people.canonical.com/~knkski/train-images-idx3-ubyte.gz: 404 -- Not Found
+        # run_test(caas_provider, caas_client, k8s_model, bundle, build)
+
         k8s_model.juju(k8s_model._show_status, ('--format', 'tabular'))
         success_hook()
     except:  # noqa: E722

--- a/acceptancetests/assess_caas_deploy_kubeflow.py
+++ b/acceptancetests/assess_caas_deploy_kubeflow.py
@@ -118,7 +118,7 @@ def deploy_kubeflow(caas_client, k8s_model, bundle, build):
                     'deploy',
                     '--bundle', f'{KUBEFLOW_DIR}/{bundle_info[bundle]["file_name"]}',
                     '--build',
-                    '--', '-m', k8s_model.model_name, '--trust',
+                    '--', '-m', k8s_model.model_name,
                 ),
                 # disable `include_e` and pass -m to `juju-bundle`
                 include_e=False,
@@ -127,7 +127,6 @@ def deploy_kubeflow(caas_client, k8s_model, bundle, build):
         k8s_model.deploy(
             charm=bundle_info[bundle]['uri'],
             channel="stable",
-            trust='true',
         )
 
     if application_exists(k8s_model, 'istio-ingressgateway'):


### PR DESCRIPTION
1. disable Kubeflow built-in tests because 

```log
2022-02-07T23:05:54.811672956Z Downloading data from https://people.canonical.com/~knkski/train-images-idx3-ubyte.gz
2022-02-07T23:05:55.330408501Z Traceback (most recent call last):
2022-02-07T23:05:55.330436904Z   File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/utils/data_utils.py", line 251, in get_file
2022-02-07T23:05:55.330737434Z     urlretrieve(origin, fpath, dl_progress)
2022-02-07T23:05:55.330746735Z   File "/usr/lib/python3.6/urllib/request.py", line 248, in urlretrieve
2022-02-07T23:05:55.330917953Z     with contextlib.closing(urlopen(url, data)) as fp:
2022-02-07T23:05:55.330935955Z   File "/usr/lib/python3.6/urllib/request.py", line 223, in urlopen
2022-02-07T23:05:55.331131075Z     return opener.open(url, data, timeout)
+ printf '\n'
2022-02-07T23:05:55.331141476Z   File "/usr/lib/python3.6/urllib/request.py", line 532, in open
+ printf '\n\n'
2022-02-07T23:05:55.331384400Z     response = meth(req, response)
+ for pod in $pods
2022-02-07T23:05:55.331392501Z   File "/usr/lib/python3.6/urllib/request.py", line 642, in http_response
2022-02-07T23:05:55.331638626Z     'http', request, response, code, msg, hdrs)
2022-02-07T23:05:55.331646227Z   File "/usr/lib/python3.6/urllib/request.py", line 570, in error
2022-02-07T23:05:55.331867050Z     return self._call_chain(*args)
2022-02-07T23:05:55.331874250Z   File "/usr/lib/python3.6/urllib/request.py", line 504, in _call_chain
2022-02-07T23:05:55.332092373Z     result = func(*args)
2022-02-07T23:05:55.332099974Z   File "/usr/lib/python3.6/urllib/request.py", line 650, in http_error_default
2022-02-07T23:05:55.332329497Z     raise HTTPError(req.full_url, code, msg, hdrs, fp)
2022-02-07T23:05:55.332396204Z urllib.error.HTTPError: HTTP Error 404: Not Found
2022-02-07T23:05:55.332402604Z 
2022-02-07T23:05:55.332408705Z During handling of the above exception, another exception occurred:
2022-02-07T23:05:55.332412505Z 
2022-02-07T23:05:55.332415906Z Traceback (most recent call last):
2022-02-07T23:05:55.332422606Z   File "/tmp/tmp.0Kt12KqPAk", line 79, in <module>
2022-02-07T23:05:55.332557020Z     _outputs = load_task(**_parsed_args)
2022-02-07T23:05:55.332564721Z   File "/tmp/tmp.0Kt12KqPAk", line 44, in load_task
2022-02-07T23:05:55.332674132Z     train_x = parse_images(load(train_images))
2022-02-07T23:05:55.332681333Z   File "/tmp/tmp.0Kt12KqPAk", line 27, in load
2022-02-07T23:05:55.332776243Z     return GzipFile(get_file(Path(path).name, path)).read()
2022-02-07T23:05:55.332785544Z   File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/keras/utils/data_utils.py", line 253, in get_file
2022-02-07T23:05:55.332930258Z     raise Exception(error_msg.format(origin, e.code, e.msg))
2022-02-07T23:05:55.332937759Z Exception: URL fetch failure on https://people.canonical.com/~knkski/train-images-idx3-ubyte.gz: 404 -- Not Found

```

2. pin kubeflow CI runs to a stable SHA: `a96fa2d`;