### PR TITLE
Run pod spec operator container processes under a non-root account

### DIFF
--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -5,6 +5,10 @@ FROM $BASE_IMAGE
 RUN useradd --system -M syslog
 RUN usermod -s /usr/sbin/nologin syslog
 
+# Add a juju user to run the daemon.
+RUN useradd -u 1010 juju
+USER juju
+
 # Some Python dependencies.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Change the CAAS Dockerfile to add a named user account `juju` with uid `1010`
Change the CAAS Dockerfile to run the workload as the user `juju`

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x ] Comments answer the question of why design decisions were made

## QA steps

Verify by deploying and checking a podspec based application such as Charmed Kubeflow with the adapted CAAS image.

## Documentation changes

The intention is that this should not impact user experience nor workflow in any way except to reduce the attack surface area.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1960390
