### PR TITLE
Fixes Juju to handle microk8s not running.

### DIFF
--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -82,6 +82,10 @@ func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
 			return []byte{}, errors.NotFoundf("microk8s")
 		}
 		return []byte{}, errors.New(string(result.Stderr))
+	} else {
+		if strings.HasPrefix(strings.ToLower(string(result.Stdout)), "microk8s is not running") {
+			return []byte{}, errors.NotFoundf("microk8s is not running")
+		}
 	}
 	return result.Stdout, nil
 }

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -117,6 +117,17 @@ func (s *builtinSuite) TestGetLocalMicroK8sConfigCallFails(c *gc.C) {
 	c.Assert(result, gc.HasLen, 0)
 }
 
+func (s *builtinSuite) TestGetLocalMicroK8sConfigNotRunning(c *gc.C) {
+	s.runner.Call("LookPath", "microk8s").Returns("", nil)
+	s.runner.Call("LookPath", "microk8s").Returns("", nil)
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s config"}).Returns(&exec.ExecResponse{Code: 0, Stdout: []byte("microk8s is not running")}, nil)
+	result, err := provider.GetLocalMicroK8sConfig(s.runner)
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+	c.Assert(string(result), gc.Equals, "")
+}
+
 func (s *builtinSuite) TestGetLocalMicroK8sConfig(c *gc.C) {
 	s.runner.Call("LookPath", "microk8s").Returns("", nil)
 	s.runner.Call(

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -375,6 +375,10 @@ func microK8sStatus(cmdRunner CommandRunner) (microk8sStatus, error) {
 			msg = "unknown error running microk8s status"
 		}
 		return status, errors.New(msg)
+	} else {
+		if strings.HasPrefix(strings.ToLower(string(result.Stdout)), "microk8s is not running") {
+			return status, errors.NotProvisionedf("microk8s is not running")
+		}
 	}
 
 	err = yaml.Unmarshal(result.Stdout, &status)


### PR DESCRIPTION
When microk8s is stopped Juju chokes as it reports an exit code of 0.
Because of this we try and parse text output as yaml and Juju chokes.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

1. Install micirok8s then stop it with `microk8s stop`. Bootstrap Juju to microk8s and see that it reports microk8s is stopped.

2. With microk8s stopped attempt to bootstrap to another Kubernetes cluster in your kubeconfig.

## Documentation changes

N/A

## Bug reference

Not reported found during testing.
