### PR TITLE
Run pod spec operator container processes under a non-root account

### DIFF
--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -5,6 +5,9 @@ FROM $BASE_IMAGE
 RUN useradd --system -M syslog
 RUN usermod -s /usr/sbin/nologin syslog
 
+# Add a juju user to run the daemon.
+RUN useradd -u 1010 juju
+
 # Some Python dependencies.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -33,5 +36,13 @@ COPY jujud /opt/
 COPY jujuc /opt/
 COPY containeragent /opt/
 COPY pebble /opt/
+
+RUN chown -R juju /var/lib/juju
+RUN chown juju /opt/jujud
+RUN chown juju /opt/jujuc
+RUN chown juju /opt/containeragent
+RUN chown juju /opt/pebble
+
+USER juju
 
 ENTRYPOINT ["sh", "-c"]

--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -42,6 +42,9 @@ RUN chown juju /opt/jujud
 RUN chown juju /opt/jujuc
 RUN chown juju /opt/containeragent
 RUN chown juju /opt/pebble
+RUN chown -R juju /root
+RUN chown -R juju /usr/bin
+RUN chown -R juju /etc/profile.d
 
 USER juju
 


### PR DESCRIPTION
Adapted CAAS Dockerfile to add `juju` user with uid `1010`
Changed ownerhip of relevant paths to `juju` user in CAAS Dockerfile
Introduce `USER` parameter to specify container should be run as `juju` user

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Please validate the modified CAAS backing image generated by this PR against an application using pod spec operators, eg. Charmed Kubeflow; eg. publish a build to a charmhub "unstable" channel or similar, so that CKF and OSM teams can validate.

## Documentation changes

the intention is that this PR should not break any aspect of the user experience / workflow, just reduce the attack surface area.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1960390
