### PR TITLE
[JUJU-394] Improve enable-ha error message

### DIFF
--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -535,7 +535,7 @@ func (s *clientSuite) TestEnableHAErrors(c *gc.C) {
 	s.setMachineAddresses(c, "2")
 
 	_, err = s.enableHA(c, 1, emptyCons, defaultSeries, nil)
-	c.Assert(err, gc.ErrorMatches, "failed to create new controller machines: cannot reduce controller count")
+	c.Assert(err, gc.ErrorMatches, "failed to enable HA with 1 controllers: cannot remove controllers with enable-ha, use remove-machine and chose the controller\\(s\\) to remove")
 }
 
 func (s *clientSuite) TestEnableHAHostedModelErrors(c *gc.C) {

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -113,7 +113,7 @@ func (st *State) EnableHA(
 			}
 		}
 		if votingCount > desiredControllerCount {
-			return nil, errors.New("cannot reduce controller count")
+			return nil, errors.New("cannot remove controllers with enable-ha, use remove-machine and chose the controller(s) to remove")
 		}
 
 		controllerIds, err := st.ControllerIds()
@@ -148,7 +148,7 @@ func (st *State) EnableHA(
 		return ops, err
 	}
 	if err := st.db().Run(buildTxn); err != nil {
-		err = errors.Annotate(err, "failed to create new controller machines")
+		err = errors.Annotatef(err, "failed to enable HA with %d controllers", numControllers)
 		return ControllersChanges{}, err
 	}
 	return change, nil

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -403,7 +403,7 @@ func (s *EnableHASuite) TestEnableHAConcurrentMore(c *gc.C) {
 	// find that the number of voting machines in state is greater than
 	// what we're attempting to ensure, and fail.
 	changes, err := s.State.EnableHA(3, constraints.Value{}, "bionic", nil)
-	c.Assert(err, gc.ErrorMatches, "failed to create new controller machines: cannot reduce controller count")
+	c.Assert(err, gc.ErrorMatches, "failed to enable HA with 3 controllers: cannot remove controllers with enable-ha, use remove-machine and chose the controller\\(s\\) to remove")
 	c.Assert(changes.Added, gc.HasLen, 0)
 
 	// Machine 0 should never have been created.


### PR DESCRIPTION
When reducing the number of controllers. This is still not supported by
enable-ha, but as of recently can be done using remove-machine

Improve the error message to reflect this

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/state
go test github.com/juju/juju/apiserver/facades/client/highavailability
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1951435
