### PR TITLE
Added --no-progress argument to juju download.

### DIFF
--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -266,10 +266,6 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	// if err := client.Download(ctx, resourceURL, path, charmhub.WithProgressBar(pb)); err != nil {
-	// 	return errors.Trace(err)
-	// }
-
 	// If we're piping to stdout, then we don't need to mention how to install
 	// and deploy the charm.
 	if c.pipeToStdout {


### PR DESCRIPTION
The current implementation of `juju download` by default displays a progress bar in the stdout. Unfortunately, this makes impossible to redirect the output to a file. Furthermore, in the command help we encourage users to run `juju download postgresql - > x.charm` which cannot work. This PR adds an additional `--no-progress` argument that disables the progress bar to allow users redirecting the command output correctly.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Please replace with how we can verify that the change works.*

```sh
juju download postgresql --no-progress - > x.charm
juju deploy x.charm
```

## Documentation changes
Updated command help.

## Bug reference

[https://bugs.launchpad.net/juju/+bug/1960493](https://bugs.launchpad.net/juju/+bug/1960493)
