### PR TITLE
[JUJU-625] Skip test-kubeflow on draft mode.

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     name: Test Kubeflow
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
By default we disable tests when PRs are in draft mode. Follow the same approach for the Kubeflow test.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps


## Documentation changes

## Bug reference

