### PR TITLE
[JUJU-593] make verification of cloud connectivity at upgrade less intense.

### DIFF
--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/client/application"
 	"github.com/juju/juju/apiserver/facades/client/modelconfig"
-	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/instance"
@@ -719,18 +718,10 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// Check IAAS clouds.
-	if env, ok := envOrBroker.(environs.InstanceBroker); ok {
-		if err := environs.CheckProviderAPI(env, c.callContext); err != nil {
-			return err
-		}
+	if err := environs.CheckProviderAPI(envOrBroker, c.callContext); err != nil {
+		return err
 	}
-	// Check k8s clusters.
-	if env, ok := envOrBroker.(caas.ClusterMetadataChecker); ok {
-		if _, err := env.GetClusterMetadata(""); err != nil {
-			return errors.Annotate(err, "cannot make API call to provider")
-		}
-	}
+
 	// If this is the controller model, also check to make sure that there are
 	// no running migrations.  All models should have migration mode of None.
 	// For major version upgrades, also check that all models are at a version high

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -116,7 +116,7 @@ func toCaaSStorageProvisioner(sc storage.StorageClass) *caas.StorageProvisioner 
 // Implements environs.CloudEndpointChecker
 func (k *kubernetesClient) ValidateCloudEndpoint(_ environscontext.ProviderCallContext) error {
 	_, err := k.GetClusterMetadata("")
-	return err
+	return errors.Trace(err)
 }
 
 // GetClusterMetadata implements ClusterMetadataChecker.

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	k8sannotations "github.com/juju/juju/core/annotations"
+	environscontext "github.com/juju/juju/environs/context"
 )
 
 // newLabelRequirements creates a list of k8s node label requirements.
@@ -108,6 +109,14 @@ func toCaaSStorageProvisioner(sc storage.StorageClass) *caas.StorageProvisioner 
 		caasSc.ReclaimPolicy = string(*sc.ReclaimPolicy)
 	}
 	return caasSc
+}
+
+// ValidateCloudEndpoint returns nil if the current model can talk to the kubernetes
+// endpoint.  Used as validation during model upgrades.
+// Implements environs.CloudEndpointChecker
+func (k *kubernetesClient) ValidateCloudEndpoint(_ environscontext.ProviderCallContext) error {
+	_, err := k.GetClusterMetadata("")
+	return err
 }
 
 // GetClusterMetadata implements ClusterMetadataChecker.

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -638,3 +638,24 @@ type HardwareCharacteristicsDetector interface {
 type SupportedFeatureEnumerator interface {
 	SupportedFeatures() (assumes.FeatureSet, error)
 }
+
+// CheckProvider defines the old and/or public cloud style of cloud
+// endpoint validation.  This check is a heavy weight method to
+// verify the current cloud connectivity.
+// Typically used with public clouds which have not implemented the
+// CloudEndpointChecker.
+type CheckProvider interface {
+	// AllInstances returns all instances currently known to the broker.
+	AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error)
+}
+
+// CloudEndpointChecker defines a method for cloud endpoint validation.
+//
+// TODO: hml 09-Feb-22
+// Implement this interface for all providers, including the public
+// clouds.
+type CloudEndpointChecker interface {
+	// ValidateCloudEndpoint validates connectivity with the cloud's
+	// endpoint and returns nil if no problems.
+	ValidateCloudEndpoint(ctx context.ProviderCallContext) error
+}

--- a/environs/utils.go
+++ b/environs/utils.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/utils/v3"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/context"
@@ -97,22 +96,17 @@ func APIInfo(
 // CheckProviderAPI returns an error if a simple API call
 // to check a basic response from the specified environ fails.
 func CheckProviderAPI(envOrBroker BootstrapEnviron, ctx context.ProviderCallContext) error {
-	// Check IAAS clouds.
-	if env, ok := envOrBroker.(InstanceBroker); ok {
+	var err error
+	if checker, ok := envOrBroker.(CloudEndpointChecker); ok {
+		err = checker.ValidateCloudEndpoint(ctx)
+	} else if env, ok := envOrBroker.(CheckProvider); ok {
 		// We will make a simple API call to the provider
 		// to ensure the underlying substrate is ok.
-		_, err := env.AllInstances(ctx)
+		_, err = env.AllInstances(ctx)
 		switch err {
 		case nil, ErrPartialInstances, ErrNoInstances:
 			return nil
 		}
-		return errors.Annotate(err, "cannot make API call to provider")
 	}
-	// Check k8s clusters.
-	if env, ok := envOrBroker.(caas.ClusterMetadataChecker); ok {
-		if _, err := env.GetClusterMetadata(""); err != nil {
-			return errors.Annotate(err, "cannot make API call to provider")
-		}
-	}
-	return errors.Errorf("Not known provider type")
+	return errors.Annotate(err, "cannot make API call to provider")
 }

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/juju/featureflag v0.0.0-20220207005600-a9676d92ad24
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2
-	github.com/juju/gomaasapi/v2 v2.0.0-20220207023642-10dd7f190313
+	github.com/juju/gomaasapi/v2 v2.0.0-20220215192228-f1f389204471
 	github.com/juju/http/v2 v2.0.0-20220207005632-792b5de45d16
 	github.com/juju/idmclient/v2 v2.0.0-20220207024613-525e1ac3a890
 	github.com/juju/jsonschema v0.0.0-20220207021905-6f321f9146b3

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,8 @@ github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 h1:huRsqE0iXm
 github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33/go.mod h1:UxUZdlQkjnbl3YoCZT1y5uxmvG2KMwqgffBFccD7qHI=
 github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2 h1:VqIDC6dRE0C7wEtTdT6zx2zP5omaoJiZXp2g/dBHRcE=
 github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2/go.mod h1:w3BDUH3gGgrcrAyvEbBy3lNb1vmdqG31UMn3njL8oGc=
-github.com/juju/gomaasapi/v2 v2.0.0-20220207023642-10dd7f190313 h1:O2isK2YQ3wS90SMVpsXKVKX/Xa7psqkL/GeFIkYqrNM=
-github.com/juju/gomaasapi/v2 v2.0.0-20220207023642-10dd7f190313/go.mod h1:ZsohFbU4xShV1aSQYQ21hR1lKj7naNGY0SPuyelcUmk=
+github.com/juju/gomaasapi/v2 v2.0.0-20220215192228-f1f389204471 h1:9QpnrjtVMMzjghavLeUrx3NxwwscXj+jDzTKEnPEGGQ=
+github.com/juju/gomaasapi/v2 v2.0.0-20220215192228-f1f389204471/go.mod h1:ZsohFbU4xShV1aSQYQ21hR1lKj7naNGY0SPuyelcUmk=
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e h1:JoXBbhRrYNw6EIPGcMb4iW4LzsVKNvDKSVvPf4A89mY=
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e/go.mod h1:OPBu48GcIJ30kNTA1cm+VbZb6GkQ6vthnr5v6NJ49eM=
 github.com/juju/http/v2 v2.0.0-20220207005632-792b5de45d16 h1:RRZLXCtXZozxgk2ZPQpnyNSzfEf5IoOWYO6jQ3nG3X8=

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -185,6 +185,17 @@ func (env *environ) Config() *config.Config {
 	return cfg
 }
 
+// ValidateCloudEndpoint returns nil if the current model can talk to the lxd
+// server endpoint.  Used as validation during model upgrades.
+// Implements environs.CloudEndpointChecker
+func (env *environ) ValidateCloudEndpoint(ctx context.ProviderCallContext) error {
+	info, err := env.server().GetConnectionInfo()
+	if err != nil {
+		return err
+	}
+	return env.provider.Ping(ctx, info.URL)
+}
+
 // PrepareForBootstrap implements environs.Environ.
 func (env *environ) PrepareForBootstrap(_ environs.BootstrapContext, _ string) error {
 	return nil

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -193,7 +193,8 @@ func (env *environ) ValidateCloudEndpoint(ctx context.ProviderCallContext) error
 	if err != nil {
 		return err
 	}
-	return env.provider.Ping(ctx, info.URL)
+	err = env.provider.Ping(ctx, info.URL)
+	return errors.Trace(err)
 }
 
 // PrepareForBootstrap implements environs.Environ.

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -334,6 +334,14 @@ func (env *maasEnviron) SetCloudSpec(_ stdcontext.Context, spec environscloudspe
 	return nil
 }
 
+// ValidateCloudEndpoint returns nil if the current model can talk to the maas
+// endpoint.  Used as validation during model upgrades.
+// Implements environs.CloudEndpointChecker
+func (env *maasEnviron) ValidateCloudEndpoint(ctx context.ProviderCallContext) error {
+	_, _, err := env.maasController.APIVersionInfo()
+	return err
+}
+
 func (env *maasEnviron) getSupportedArchitectures(ctx context.ProviderCallContext) ([]string, error) {
 	env.archMutex.Lock()
 	defer env.archMutex.Unlock()

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -339,7 +339,7 @@ func (env *maasEnviron) SetCloudSpec(_ stdcontext.Context, spec environscloudspe
 // Implements environs.CloudEndpointChecker
 func (env *maasEnviron) ValidateCloudEndpoint(ctx context.ProviderCallContext) error {
 	_, _, err := env.maasController.APIVersionInfo()
-	return err
+	return errors.Trace(err)
 }
 
 func (env *maasEnviron) getSupportedArchitectures(ctx context.ProviderCallContext) ([]string, error) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2375,5 +2375,6 @@ func (e *Environ) SupportsRulesWithIPV6CIDRs(ctx context.ProviderCallContext) (b
 // endpoint. Used as validation during model upgrades.
 // Implements environs.CloudEndpointChecker
 func (env *Environ) ValidateCloudEndpoint(ctx context.ProviderCallContext) error {
-	return env.Provider().Ping(ctx, env.cloud().Endpoint)
+	err := env.Provider().Ping(ctx, env.cloud().Endpoint)
+	return errors.Trace(err)
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2370,3 +2370,10 @@ func (*Environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.
 func (e *Environ) SupportsRulesWithIPV6CIDRs(ctx context.ProviderCallContext) (bool, error) {
 	return true, nil
 }
+
+// ValidateCloudEndpoint returns nil if the current model can talk to the openstack
+// endpoint. Used as validation during model upgrades.
+// Implements environs.CloudEndpointChecker
+func (env *Environ) ValidateCloudEndpoint(ctx context.ProviderCallContext) error {
+	return env.Provider().Ping(ctx, env.cloud().Endpoint)
+}


### PR DESCRIPTION
Update how juju verifies connectivity to the model's cloud before doing an upgrade of the model. Previously juju called AllInstances on the cloud, which can be intensive depending on how many instances are in the model.  In situations where there is limited connectivity, this could mean that an upgrade fails, such as in the bug.  

Originally the idea was to call Ping instead of AllInstances.  However only the private clouds implement Ping and the CAAS provider was doing its own thing entirely.  Using Ping also requires fetching the endpoint url from the cloud spec.  Having an interface with the new ValidateCloudEndpoint, allows the environ to do what it wants for verification.  Fall back to the original AllInstances if ValidateCloudEndpoint is not implemented, though this should be phased out and additional providers should implement ValidateCloudEndpoint.

Includes a refactor of SetModelAgentVersion to call CheckProviderAPI for all providers.  Then allow a provider to choose whether the call to ValidateCloudEndpoint is implemented.  No need to check the model type here for CAAS or IAAS.

## QA steps

Bootstrap and upgrade-model for the following clouds:
* lxd
* maas
* kubernetes
* openstack
* aws

## Bug reference

https://bugs.launchpad.net/juju/+bug/1960276
