### PR TITLE
Fix display of storage in tabular status

### DIFF
--- a/apiserver/params/storage.go
+++ b/apiserver/params/storage.go
@@ -784,7 +784,7 @@ type FilesystemDetails struct {
 	MachineAttachments map[string]FilesystemAttachmentDetails `json:"machine-attachments,omitempty"`
 
 	// UnitAttachments contains a mapping from
-	// unit tag to filesystem attachment information (CAAS models).
+	// unit tag to filesystem attachment information.
 	UnitAttachments map[string]FilesystemAttachmentDetails `json:"unit-attachments,omitempty"`
 
 	// Storage contains details about the storage instance

--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -7,11 +7,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/cmd/juju/storage"
 	"github.com/juju/juju/core/instance"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/names/v4"
 )
 
 type formattedStatus struct {

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -99,8 +99,8 @@ Storage Unit  Storage id    Type        Pool      Mountpoint  Size    Status    
               persistent/1  filesystem                                detached  
 postgresql/0  db-dir/1100   block                             3.0MiB  attached  
 transcode/0   db-dir/1000   block                                     pending   creating volume
-transcode/0   shared-fs/0   filesystem  radiance              1.0GiB  attached  
-transcode/1   shared-fs/0   filesystem  radiance              1.0GiB  attached  
+transcode/0   shared-fs/0   filesystem  radiance  /mnt/doom   1.0GiB  attached  
+transcode/1   shared-fs/0   filesystem  radiance  /mnt/huang  1.0GiB  attached  
 
 `[1:])
 }


### PR DESCRIPTION
A refactoring of storage in status a while back broke the display of mount point in tabular status with the --storage option.
The `juju storage --filesystem` command worked ok. So this PR extracts the processing logic from the storage command and re-uses that same logic in status --storage, instead of the existing status storage code.

The existing unit test was incorrect, so it was updated to match the new (correct) logic.

## QA steps

On AWS
juju deploy postgresql --storage pgdata=1G
On k8s
juju deploy /my/local/mariadb-k8s --resource mysql_image=mariadb --storage database=20M

For both, run
juju status --storage
juju storage --filesystem

## Bug reference

https://bugs.launchpad.net/juju/+bug/1960184
