### PR TITLE
[JUJU-631] Fix upgrades when agent-stream is used

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -274,7 +274,7 @@ jobs:
       env:
         UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
         UPGRADE_PARAMS_localhost: "--build-agent"
-        UPGRADE_PARAMS_microk8s: "--agent-stream stable"
+        UPGRADE_PARAMS_microk8s: ""
       run: |
         set -euxo pipefail
 
@@ -309,12 +309,12 @@ jobs:
       env:
         UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
         UPGRADE_PARAMS_localhost: "--build-agent"
-        UPGRADE_PARAMS_microk8s: "--agent-stream stable"
+        UPGRADE_PARAMS_microk8s: ""
       run: |
         set -euxo pipefail
 
         while true; do
-          juju upgrade-model --agent-stream stable 2>&1 | tee output.log || true
+          juju upgrade-model 2>&1 | tee output.log || true
           RES=$(cat output.log | grep "upgrade in progress" || echo "NOT-UPGRADING")
           if [ "$RES" = "NOT-UPGRADING" ]; then
             break

--- a/api/client.go
+++ b/api/client.go
@@ -281,8 +281,12 @@ func (c *Client) Close() error {
 
 // SetModelAgentVersion sets the model agent-version setting
 // to the given value.
-func (c *Client) SetModelAgentVersion(version version.Number, ignoreAgentVersions bool) error {
-	args := params.SetModelAgentVersion{Version: version, IgnoreAgentVersions: ignoreAgentVersions}
+func (c *Client) SetModelAgentVersion(version version.Number, stream string, ignoreAgentVersions bool) error {
+	args := params.SetModelAgentVersion{
+		Version:             version,
+		AgentStream:         stream,
+		IgnoreAgentVersions: ignoreAgentVersions,
+	}
 	return c.facade.FacadeCall("SetModelAgentVersion", args, nil)
 }
 

--- a/api/controller/controller.go
+++ b/api/controller/controller.go
@@ -100,7 +100,7 @@ type HostedConfig struct {
 	Error     error
 }
 
-// HostedModelsConfig returns all model settings for the
+// HostedModelConfigs returns all model settings for the
 // controller model.
 func (c *Client) HostedModelConfigs() ([]HostedConfig, error) {
 	result := params.HostedModelConfigsResults{}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -41,7 +41,7 @@ var facadeVersions = map[string]int{
 	"CharmRevisionUpdater":         2,
 	"Charms":                       4,
 	"Cleaner":                      2,
-	"Client":                       4,
+	"Client":                       5,
 	"Cloud":                        7,
 	"Controller":                   11,
 	"CredentialManager":            1,

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -275,7 +275,7 @@ func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {
 }
 
 func (s *stateSuite) TestBestFacadeVersion(c *gc.C) {
-	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 4)
+	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 5)
 }
 
 func (s *stateSuite) TestAPIHostPortsMovesConnectedValueFirst(c *gc.C) {

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -190,7 +190,8 @@ func AllFacades() *facade.Registry {
 	reg("Client", 1, client.NewFacadeV1)
 	reg("Client", 2, client.NewFacadeV2)
 	reg("Client", 3, client.NewFacadeV3)
-	reg("Client", 4, client.NewFacade)
+	reg("Client", 4, client.NewFacadeV4)
+	reg("Client", 5, client.NewFacade)
 	reg("Cloud", 1, cloud.NewFacadeV1)
 	reg("Cloud", 2, cloud.NewFacadeV2) // adds AddCloud, AddCredentials, CredentialContents, RemoveClouds
 	reg("Cloud", 3, cloud.NewFacadeV3) // changes signature of UpdateCredentials, adds ModifyCloudAccess

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -369,7 +369,7 @@ func (s *upgraderSuite) bumpDesiredAgentVersion(c *gc.C) version.Number {
 	c.Assert(err, jc.ErrorIsNil)
 	newer := current
 	newer.Patch++
-	err = s.State.SetModelAgentVersion(newer.Number, false)
+	err = s.State.SetModelAgentVersion(newer.Number, nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := s.Model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -60,7 +60,7 @@ func (s *baseSuite) toSupportNewActionID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	if !state.IsNewActionIDSupported(ver) {
-		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, true)
+		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, nil, true)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -70,7 +70,7 @@ type Backend interface {
 	RemoteConnectionStatus(string) (*state.RemoteConnectionStatus, error)
 	RemoveUserAccess(names.UserTag, names.Tag) error
 	SetAnnotations(state.GlobalEntity, map[string]string) error
-	SetModelAgentVersion(version.Number, bool) error
+	SetModelAgentVersion(version.Number, *string, bool) error
 	SetModelConstraints(constraints.Value) error
 	Unit(string) (Unit, error)
 	UpdateModelConfig(map[string]interface{}, []string, ...state.ValidateConfigFunc) error

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -97,8 +97,13 @@ type ClientV2 struct {
 	*ClientV3
 }
 
-// ClientV2 serves the (v2) client-specific API methods.
+// ClientV3 serves the (v3) client-specific API methods.
 type ClientV3 struct {
+	*ClientV4
+}
+
+// ClientV4 serves the (v4) client-specific API methods.
+type ClientV4 struct {
 	*Client
 }
 
@@ -170,14 +175,23 @@ func NewFacadeV2(ctx facade.Context) (*ClientV2, error) {
 
 // NewFacadeV3 creates a version 3 Client facade to handle API requests.
 func NewFacadeV3(ctx facade.Context) (*ClientV3, error) {
-	client, err := NewFacade(ctx)
+	client, err := NewFacadeV4(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &ClientV3{client}, nil
 }
 
-// NewFacade creates a version 4 Client facade to handle API requests.
+// NewFacadeV4 creates a version 4 Client facade to handle API requests.
+func NewFacadeV4(ctx facade.Context) (*ClientV4, error) {
+	client, err := NewFacade(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &ClientV4{client}, nil
+}
+
+// NewFacade creates a version 5 Client facade to handle API requests.
 // Changes:
 // - FindTools deals with CAAS models now;
 func NewFacade(ctx facade.Context) (*Client, error) {
@@ -763,7 +777,7 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 		}
 	}
 
-	return c.api.stateAccessor.SetModelAgentVersion(args.Version, args.IgnoreAgentVersions)
+	return c.api.stateAccessor.SetModelAgentVersion(args.Version, &args.AgentStream, args.IgnoreAgentVersions)
 }
 
 // CheckMongoStatusForUpgrade returns an error if the replicaset is not in a good

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -274,27 +274,33 @@ func (s *serverSuite) makeLocalModelUser(c *gc.C, username, displayname string) 
 	return modelUser
 }
 
-func (s *serverSuite) assertModelVersion(c *gc.C, st *state.State, expected string) {
+func (s *serverSuite) assertModelVersion(c *gc.C, st *state.State, expectedVersion, expectedStream string) {
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	modelConfig, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	agentVersion, found := modelConfig.AllAttrs()["agent-version"]
+	agentVersion, found := modelConfig.AllAttrs()["agent-version"].(string)
 	c.Assert(found, jc.IsTrue)
-	c.Assert(agentVersion, gc.Equals, expected)
+	c.Assert(agentVersion, gc.Equals, expectedVersion)
+	var agentStream string
+	agentStream, found = modelConfig.AllAttrs()["agent-stream"].(string)
+	c.Assert(found, jc.IsTrue)
+	c.Assert(agentStream, gc.Equals, expectedStream)
+
 }
 
 func (s *serverSuite) TestSetModelAgentVersion(c *gc.C) {
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse(validVersion.String()),
+		Version:     version.MustParse(validVersion.String()),
+		AgentStream: "proposed",
 	}
 	err := s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertModelVersion(c, s.State, validVersion.String())
+	s.assertModelVersion(c, s.State, validVersion.String(), "proposed")
 }
 
 func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
-	err := s.State.SetModelAgentVersion(version.MustParse("2.8.0"), false)
+	err := s.State.SetModelAgentVersion(version.MustParse("2.8.0"), nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.SetModelAgentVersion{
 		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major+1)),
@@ -333,7 +339,7 @@ func (s *serverSuite) TestSetModelAgentVersionForced(c *gc.C) {
 	err = s.client.SetModelAgentVersion(args)
 	c.Check(err, gc.ErrorMatches, "some agents have not upgraded to the current model version .*: unit-wordpress-0")
 	// Version hasn't changed
-	s.assertModelVersion(c, s.State, currentVersion)
+	s.assertModelVersion(c, s.State, currentVersion, "released")
 	// But we can force it
 	to := validVersion
 	to.Minor++
@@ -343,7 +349,7 @@ func (s *serverSuite) TestSetModelAgentVersionForced(c *gc.C) {
 	}
 	err = s.client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertModelVersion(c, s.State, to.String())
+	s.assertModelVersion(c, s.State, to.String(), "released")
 }
 
 func (s *serverSuite) makeMigratingModel(c *gc.C, name string, mode state.MigrationMode) {
@@ -397,7 +403,7 @@ func (s *serverSuite) TestUserModelSetModelAgentVersionNotAffectedByMigration(c 
 	err := client.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertModelVersion(c, otherSt, "2.0.4")
+	s.assertModelVersion(c, otherSt, "2.0.4", "released")
 }
 
 func (s *serverSuite) TestControllerModelSetModelAgentVersionChecksReplicaset(c *gc.C) {
@@ -434,7 +440,7 @@ func (s *serverSuite) TestUserModelSetModelAgentVersionSkipsMongoCheck(c *gc.C) 
 	err := apiserverClient.SetModelAgentVersion(args)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertModelVersion(c, otherSt, "2.0.4")
+	s.assertModelVersion(c, otherSt, "2.0.4", "released")
 }
 
 type mockEnviron struct {

--- a/apiserver/facades/client/client/mocks/client_mock.go
+++ b/apiserver/facades/client/client/mocks/client_mock.go
@@ -682,17 +682,17 @@ func (mr *MockBackendMockRecorder) SetAnnotations(arg0, arg1 interface{}) *gomoc
 }
 
 // SetModelAgentVersion mocks base method.
-func (m *MockBackend) SetModelAgentVersion(arg0 version.Number, arg1 bool) error {
+func (m *MockBackend) SetModelAgentVersion(arg0 version.Number, arg1 *string, arg2 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetModelAgentVersion", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetModelAgentVersion", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetModelAgentVersion indicates an expected call of SetModelAgentVersion.
-func (mr *MockBackendMockRecorder) SetModelAgentVersion(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBackendMockRecorder) SetModelAgentVersion(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModelAgentVersion", reflect.TypeOf((*MockBackend)(nil).SetModelAgentVersion), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModelAgentVersion", reflect.TypeOf((*MockBackend)(nil).SetModelAgentVersion), arg0, arg1, arg2)
 }
 
 // SetModelConstraints mocks base method.

--- a/apiserver/facades/client/client/perm_test.go
+++ b/apiserver/facades/client/client/perm_test.go
@@ -423,7 +423,7 @@ func opClientSetModelAgentVersion(c *gc.C, st api.Connection, mst *state.State) 
 		return func() {}, err
 	}
 	ver := version.Number{Major: 2, Minor: 0, Patch: 0}
-	err = st.Client().SetModelAgentVersion(ver, false)
+	err = st.Client().SetModelAgentVersion(ver, "released", false)
 	if err != nil {
 		return func() {}, err
 	}
@@ -432,7 +432,7 @@ func opClientSetModelAgentVersion(c *gc.C, st api.Connection, mst *state.State) 
 		oldAgentVersion, found := attrs["agent-version"]
 		if found {
 			versionString := oldAgentVersion.(string)
-			st.Client().SetModelAgentVersion(version.MustParse(versionString), false)
+			st.Client().SetModelAgentVersion(version.MustParse(versionString), "released", false)
 		}
 	}, nil
 }

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -436,9 +436,9 @@ func (s *controllerSuite) TestWatchAllModels(c *gc.C) {
 	defer st.Close()
 
 	// Update the model agent versions to ensure settings changes cause an update.
-	err = s.State.SetModelAgentVersion(version.MustParse("2.6.666"), true)
+	err = s.State.SetModelAgentVersion(version.MustParse("2.6.666"), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.SetModelAgentVersion(version.MustParse("2.6.667"), true)
+	err = st.SetModelAgentVersion(version.MustParse("2.6.667"), nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	expectedVersions := map[string]string{
 		s.State.ModelUUID(): "2.6.666",

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1076,7 +1076,7 @@ func (s *modelManagerStateSuite) TestCreateModelSameAgentVersion(c *gc.C) {
 }
 
 func (s *modelManagerStateSuite) TestCreateModelBadAgentVersion(c *gc.C) {
-	err := s.BackingState.SetModelAgentVersion(coretesting.FakeVersionNumber, false)
+	err := s.BackingState.SetModelAgentVersion(coretesting.FakeVersionNumber, nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	admin := s.AdminUserTag(c)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -16368,7 +16368,7 @@
     {
         "Name": "Client",
         "Description": "Client serves client-specific API methods.",
-        "Version": 4,
+        "Version": 5,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -18560,6 +18560,9 @@
                 "SetModelAgentVersion": {
                     "type": "object",
                     "properties": {
+                        "agent-stream": {
+                            "type": "string"
+                        },
                         "force": {
                             "type": "boolean"
                         },

--- a/apiserver/params/model.go
+++ b/apiserver/params/model.go
@@ -125,6 +125,7 @@ type UnsetModelDefaults struct {
 // SetModelAgentVersion client API call.
 type SetModelAgentVersion struct {
 	Version             version.Number `json:"version"`
+	AgentStream         string         `json:"agent-stream,omitempty"`
 	IgnoreAgentVersions bool           `json:"force,omitempty"`
 }
 

--- a/cmd/juju/commands/mocks/client_mock.go
+++ b/cmd/juju/commands/mocks/client_mock.go
@@ -81,17 +81,17 @@ func (mr *MockClientAPIMockRecorder) FindTools(arg0, arg1, arg2, arg3, arg4 inte
 }
 
 // SetModelAgentVersion mocks base method.
-func (m *MockClientAPI) SetModelAgentVersion(arg0 version.Number, arg1 bool) error {
+func (m *MockClientAPI) SetModelAgentVersion(arg0 version.Number, arg1 string, arg2 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetModelAgentVersion", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetModelAgentVersion", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetModelAgentVersion indicates an expected call of SetModelAgentVersion.
-func (mr *MockClientAPIMockRecorder) SetModelAgentVersion(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientAPIMockRecorder) SetModelAgentVersion(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModelAgentVersion", reflect.TypeOf((*MockClientAPI)(nil).SetModelAgentVersion), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModelAgentVersion", reflect.TypeOf((*MockClientAPI)(nil).SetModelAgentVersion), arg0, arg1, arg2)
 }
 
 // Status mocks base method.

--- a/cmd/juju/commands/package_test.go
+++ b/cmd/juju/commands/package_test.go
@@ -20,8 +20,8 @@ import (
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/statusapi_mock.go github.com/juju/juju/cmd/juju/commands StatusAPI
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/leaderapi_mock.go github.com/juju/juju/cmd/juju/commands LeaderAPI
 // For upgrademodel:
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/controller_mock.go github.com/    juju/juju/cmd/juju/commands ControllerAPI
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/client_mock.go github.com/juju    /juju/cmd/juju/commands ClientAPI
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/controller_mock.go github.com/juju/juju/cmd/juju/commands ControllerAPI
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/client_mock.go github.com/juju/juju/cmd/juju/commands ClientAPI
 
 func init() {
 	if err := all.RegisterForClient(); err != nil {

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -295,8 +295,9 @@ type toolsAPI interface {
 }
 
 type upgradeJujuAPI interface {
+	BestAPIVersion() int
 	AbortCurrentUpgrade() error
-	SetModelAgentVersion(version version.Number, ignoreAgentVersion bool) error
+	SetModelAgentVersion(version version.Number, stream string, ignoreAgentVersion bool) error
 	Close() error
 }
 
@@ -383,6 +384,12 @@ func (c *upgradeJujuCommand) Run(ctx *cmd.Context) (err error) {
 	return c.upgradeModel(ctx, implicitAgentUploadAllowed, c.timeout)
 }
 
+const unsupportedStreamMsg = `
+this version of Juju does not support specifying an agent-stream value
+different to that of the controller model. If you want to use %q agents,
+you must first 'juju model-config -m controller agent-stream=%s'.
+`
+
 func (c *upgradeJujuCommand) upgradeModel(ctx *cmd.Context, implicitUploadAllowed bool, fetchTimeout time.Duration) (err error) {
 	defer func() {
 		if err != nil {
@@ -433,6 +440,15 @@ func (c *upgradeJujuCommand) upgradeModel(ctx *cmd.Context, implicitUploadAllowe
 	}
 	haveControllerModelPermission := err == nil
 	isControllerModel := haveControllerModelPermission && cfg.UUID() == controllerModelConfig[config.UUIDKey]
+	modelStream := controllerModelConfig[config.AgentStreamKey]
+	if modelStream == "" {
+		modelStream = tools.ReleasedStream
+	}
+	wantStream := c.AgentStream
+	if wantStream == "" {
+		wantStream = tools.ReleasedStream
+	}
+
 	if c.BuildAgent {
 		// For UploadTools, model must be the "controller" model,
 		// that is, modelUUID == controllerUUID
@@ -441,6 +457,10 @@ func (c *upgradeJujuCommand) upgradeModel(ctx *cmd.Context, implicitUploadAllowe
 		}
 		if !isControllerModel {
 			return errors.Errorf("--build-agent can only be used with the controller model")
+		}
+	} else if isControllerModel {
+		if modelStream != wantStream && client.BestAPIVersion() < 5 {
+			return errors.Errorf(unsupportedStreamMsg, wantStream, wantStream)
 		}
 	}
 
@@ -527,6 +547,12 @@ func (c *upgradeJujuCommand) upgradeModel(ctx *cmd.Context, implicitUploadAllowe
 	if warnCompat {
 		fmt.Fprintf(ctx.Stderr, "version %s incompatible with this client (%s)\n", upgradeCtx.chosen, jujuversion.Current)
 	}
+
+	// Log rather than Printf so it stands out.
+	if modelStream != wantStream {
+		logger.Warningf("Updating model config to specify agent-stream=%s.\nYou can reset back to %q after the upgrade has finished.", wantStream, modelStream)
+	}
+
 	if c.DryRun {
 		if c.BuildAgent {
 			fmt.Fprintf(ctx.Stderr, "%s --build-agent\n", c.upgradeMessage)
@@ -552,7 +578,7 @@ func (c *baseUpgradeCommand) notifyControllerUpgrade(ctx *cmd.Context, client up
 			return block.ProcessBlockedError(err, block.BlockChange)
 		}
 	}
-	if err := client.SetModelAgentVersion(upgradeCtx.chosen, c.IgnoreAgentVersions); err != nil {
+	if err := client.SetModelAgentVersion(upgradeCtx.chosen, c.AgentStream, c.IgnoreAgentVersions); err != nil {
 		if params.IsCodeUpgradeInProgress(err) {
 			return errors.Errorf("%s\n\n"+
 				"Please wait for the upgrade to complete or if there was a problem with\n"+

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -402,7 +402,7 @@ func (s *MachineSuite) testUpgradeRequest(c *gc.C, agent runner, tag string, cur
 	newVers.Patch++
 	newTools := envtesting.AssertUploadFakeToolsVersions(
 		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), newVers)[0]
-	err := s.State.SetModelAgentVersion(newVers.Number, true)
+	err := s.State.SetModelAgentVersion(newVers.Number, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	err = runWithTimeout(c, agent)
 	envtesting.CheckUpgraderReadyError(c, err, &agenterrors.UpgradeReadyError{

--- a/scripts/juju-force-upgrade/main.go
+++ b/scripts/juju-force-upgrade/main.go
@@ -119,6 +119,5 @@ func main() {
 		modelSt.Release()
 		_, _ = statePool.Remove(modelUUID)
 	}()
-
-	checkErr("set model agent version", modelSt.SetModelAgentVersion(agentVersion, true))
+	checkErr("set model agent version", modelSt.SetModelAgentVersion(agentVersion, nil, true))
 }

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -526,7 +526,7 @@ func (s *ActionSuite) toSupportNewActionID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	if !state.IsNewActionIDSupported(ver) {
-		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, true)
+		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, nil, true)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
@@ -536,7 +536,7 @@ func (s *ActionSuite) toSupportOldActionID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	if state.IsNewActionIDSupported(ver) {
-		err := s.State.SetModelAgentVersion(version.MustParse("2.6.0"), true)
+		err := s.State.SetModelAgentVersion(version.MustParse("2.6.0"), nil, true)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }

--- a/state/operation_test.go
+++ b/state/operation_test.go
@@ -131,7 +131,7 @@ func (s *OperationSuite) setupOperations(c *gc.C) names.Tag {
 	c.Assert(err, jc.ErrorIsNil)
 
 	if !state.IsNewActionIDSupported(ver) {
-		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, true)
+		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, nil, true)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -619,7 +619,7 @@ func (st *State) checkCanUpgradeIAAS(currentVersion, newVersion string) error {
 // given version, only if the model is in a stable state (all agents are
 // running the current version). If this is a hosted model, newVersion
 // cannot be higher than the controller version.
-func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVersions bool) (err error) {
+func (st *State) SetModelAgentVersion(newVersion version.Number, stream *string, ignoreAgentVersions bool) (err error) {
 	if newVersion.Compare(jujuversion.Current) > 0 && !st.IsController() {
 		return errors.Errorf("model cannot be upgraded to %s while the controller is %s: upgrade 'controller' model first",
 			newVersion.String(),
@@ -649,6 +649,14 @@ func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVers
 			// Nothing to do.
 			return nil, jujutxn.ErrNoOperations
 		}
+		agentStream, _ := settings.Get("agent-stream")
+		currentStream, _ := agentStream.(string)
+		newStream := currentStream
+		if stream != nil {
+			if (*stream != "" || currentStream != "released") && (*stream != "released" || currentStream != "") {
+				newStream = *stream
+			}
+		}
 
 		if !ignoreAgentVersions {
 			if isCAAS {
@@ -673,7 +681,10 @@ func (st *State) SetModelAgentVersion(newVersion version.Number, ignoreAgentVers
 				Id:     st.docID(modelGlobalKey),
 				Assert: bson.D{{"version", settings.version}},
 				Update: bson.D{
-					{"$set", bson.D{{"settings.agent-version", newVersion.String()}}},
+					{"$set", bson.D{
+						{"settings.agent-version", newVersion.String()},
+						{"settings.agent-stream", newStream},
+					}},
 				},
 			},
 		}

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -1037,7 +1037,8 @@ func (s *WorkerSuite) TestV2CharmExitsApplicationWorker(c *gc.C) {
 	waitCharmGetterCalls("ApplicationCharmInfo")
 
 	// Ensure application worker exited due to charm becoming v2
-	aw, _ := caasunitprovisioner.AppWorker(w, "gitlab")
+	aw, ok := caasunitprovisioner.AppWorker(w, "gitlab")
+	c.Assert(ok, jc.IsTrue)
 	err = workertest.CheckKilled(c, aw)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -403,7 +403,7 @@ func (s *InterfaceSuite) toSupportNewActionID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	if !state.IsNewActionIDSupported(ver) {
-		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, true)
+		err := s.State.SetModelAgentVersion(state.MinVersionSupportNewActionID, nil, true)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -255,7 +255,7 @@ func (s *UpgradeSuite) TestAbortWhenOtherControllerDoesNotStartUpgrade(c *gc.C) 
 	// This test checks when a controller is upgrading and one of
 	// the other controllers doesn't signal it is ready in time.
 
-	err := s.State.SetModelAgentVersion(jujuversion.Current, false)
+	err := s.State.SetModelAgentVersion(jujuversion.Current, nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.create3Controllers(c)


### PR DESCRIPTION
If we want to upgrade a model to a "proposed" agent, the `--agent-stream` arg is used. And the CLI client will use this to check for available agents. But when the controller is informed about the new agent version, it is usually configured to use "released" agents, and so can't find the proposed one.

It's possible to fix this by first setting the agent-stream on the controller model to "proposed". This PR makes that step a part of the upgrade process, via the `SetModelAgentVersion` API. A warning is printed if the stream for the upgrade does not match that of the controller model so that the user knows they might want to reset it later.

This fixes the CI test which put the newly built agent in the "develop" stream. Until a new version of Juju is released with this patch, the test is also tweaked to manually set the controller model agent version to the right value.

Also, the test is updated to use the preferred `upgrade-controller` and `upgrade-model` commands.

## QA steps

To test without the need to set the agent version manually, I bootstrap using a custom-built agent with the version set to 2.9.22.

```
juju bootstrap --build-agent
juju add-machine
juju status --format yaml -> agents have 2.9.22.1
juju upgrade-controller --agent-stream=proposed --agent-version=2.9.25
juju status -m controller --format yaml -> agents have 2.9.25
juju upgrade-model
juju status --format yaml -> agents have 2.9.25
```