### PR TITLE
[JUJU-570] Allow forced-destruction of storage-linked file systems

### DIFF
--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -867,7 +867,7 @@ func (s *FilesystemStateSuite) TestDestroyFilesystemNotFound(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
-func (s *FilesystemStateSuite) TestDestroyFilesystemStorageAssigned(c *gc.C) {
+func (s *FilesystemStateSuite) TestDestroyFilesystemStorageAssignedNoForce(c *gc.C) {
 	// Create a filesystem-type storage instance, and show that we
 	// cannot destroy the filesystem while there is storage assigned.
 	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "rootfs")
@@ -882,6 +882,17 @@ func (s *FilesystemStateSuite) TestDestroyFilesystemStorageAssigned(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	removeStorageInstance(c, s.storageBackend, storageTag)
 	s.assertDestroyFilesystem(c, filesystem.FilesystemTag(), state.Dying)
+}
+
+func (s *FilesystemStateSuite) TestDestroyFilesystemStorageAssignedWithForce(c *gc.C) {
+	_, u, storageTag := s.setupSingleStorage(c, "filesystem", "rootfs")
+	s.maybeAssignUnit(c, u)
+	filesystem := s.storageInstanceFilesystem(c, storageTag)
+
+	err := s.storageBackend.DestroyFilesystem(filesystem.FilesystemTag(), true)
+	c.Assert(err, jc.ErrorIsNil)
+	filesystem = s.filesystem(c, filesystem.FilesystemTag())
+	c.Assert(filesystem.Life(), gc.Equals, state.Dying)
 }
 
 func (s *FilesystemIAASModelSuite) TestDestroyFilesystemNoAttachments(c *gc.C) {


### PR DESCRIPTION
We've observed a model stuck in its destruction phase on ProdStack, with lines like this repeatedly logged:
```
2022-01-21 17:49:56 WARNING juju.state cleanup.go:1451 could not destroy filesystem 3/0 for machine-3: destroying filesystem 3/0: filesystem is assigned to storage pgdata/0
2022-01-21 17:49:56 WARNING juju.state cleanup.go:1510 could not remove attachment for filesystem 3/0 for machine-3: removing attachment of filesystem 3/0 from machine 3: filesystem attachment is not dying
2022-01-21 17:49:56 WARNING juju.state cleanup.go:1543 could not remove filesystem 3/0 for dying machine-3: removing filesystem 3/0: filesystem is not dead
2022-01-21 17:49:56 WARNING juju.state cleanup.go:213 cleanup failed in model f8bcb962-cb4a-4e98-82d0-e0c883358190 for machine("3"): machine 3 has attachments [volume-0]
```

This indicates that despite supplying the `--force` flag, Juju refuses to progress the life-cycle of a file-system if it  is linked to a storage instance.

Here we allow this operation when the destruction is forced.

## QA steps

I have not been able to replicate the situation that produces the error above, but to ensure against regression:
- Bootstrap to O7k.
- `juju deploy postgresql --storage pgdata=1G`
- `juju remove-machine 0` will fail.
- `juju remove-machine 0 --force` will succeed.

## Documentation changes

None.

## Bug reference

N/A
