### PR TITLE
[JUJU-422] Remove space.Subnets method

### DIFF
--- a/apiserver/common/networkingcommon/mocks/package_mock.go
+++ b/apiserver/common/networkingcommon/mocks/package_mock.go
@@ -9,7 +9,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	networkingcommon "github.com/juju/juju/apiserver/common/networkingcommon"
-	life "github.com/juju/juju/core/life"
 	network "github.com/juju/juju/core/network"
 	state "github.com/juju/juju/state"
 	txn "github.com/juju/mgo/v2/txn"
@@ -66,6 +65,21 @@ func (mr *MockBackingSpaceMockRecorder) Name() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockBackingSpace)(nil).Name))
 }
 
+// NetworkSpace mocks base method.
+func (m *MockBackingSpace) NetworkSpace() (network.SpaceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NetworkSpace")
+	ret0, _ := ret[0].(network.SpaceInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NetworkSpace indicates an expected call of NetworkSpace.
+func (mr *MockBackingSpaceMockRecorder) NetworkSpace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkSpace", reflect.TypeOf((*MockBackingSpace)(nil).NetworkSpace))
+}
+
 // ProviderId mocks base method.
 func (m *MockBackingSpace) ProviderId() network.Id {
 	m.ctrl.T.Helper()
@@ -78,21 +92,6 @@ func (m *MockBackingSpace) ProviderId() network.Id {
 func (mr *MockBackingSpaceMockRecorder) ProviderId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderId", reflect.TypeOf((*MockBackingSpace)(nil).ProviderId))
-}
-
-// NetworkSpace mocks base method.
-func (m *MockBackingSpace) NetworkSpace() (networkingcommon.BackingSpaceInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkSpace")
-	ret0, _ := ret[0].(networkingcommon.BackingSpaceInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NetworkSpace indicates an expected call of NetworkSpace.
-func (mr *MockBackingSpaceMockRecorder) NetworkSpace() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkSpace", reflect.TypeOf((*MockBackingSpace)(nil).NetworkSpace))
 }
 
 // MockBackingSubnet is a mock of BackingSubnet interface.
@@ -161,10 +160,10 @@ func (mr *MockBackingSubnetMockRecorder) ID() *gomock.Call {
 }
 
 // Life mocks base method.
-func (m *MockBackingSubnet) Life() life.Value {
+func (m *MockBackingSubnet) Life() state.Life {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Life")
-	ret0, _ := ret[0].(life.Value)
+	ret0, _ := ret[0].(state.Life)
 	return ret0
 }
 
@@ -228,20 +227,6 @@ func (m *MockBackingSubnet) SpaceName() string {
 func (mr *MockBackingSubnetMockRecorder) SpaceName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpaceName", reflect.TypeOf((*MockBackingSubnet)(nil).SpaceName))
-}
-
-// Status mocks base method.
-func (m *MockBackingSubnet) Status() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Status indicates an expected call of Status.
-func (mr *MockBackingSubnetMockRecorder) Status() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockBackingSubnet)(nil).Status))
 }
 
 // VLANTag mocks base method.

--- a/apiserver/common/networkingcommon/mocks/package_mock.go
+++ b/apiserver/common/networkingcommon/mocks/package_mock.go
@@ -80,19 +80,19 @@ func (mr *MockBackingSpaceMockRecorder) ProviderId() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderId", reflect.TypeOf((*MockBackingSpace)(nil).ProviderId))
 }
 
-// Subnets mocks base method.
-func (m *MockBackingSpace) Subnets() ([]networkingcommon.BackingSubnet, error) {
+// NetworkSpace mocks base method.
+func (m *MockBackingSpace) NetworkSpace() (networkingcommon.BackingSpaceInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subnets")
-	ret0, _ := ret[0].([]networkingcommon.BackingSubnet)
+	ret := m.ctrl.Call(m, "NetworkSpace")
+	ret0, _ := ret[0].(networkingcommon.BackingSpaceInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Subnets indicates an expected call of Subnets.
-func (mr *MockBackingSpaceMockRecorder) Subnets() *gomock.Call {
+// NetworkSpace indicates an expected call of NetworkSpace.
+func (mr *MockBackingSpaceMockRecorder) NetworkSpace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockBackingSpace)(nil).Subnets))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkSpace", reflect.TypeOf((*MockBackingSpace)(nil).NetworkSpace))
 }
 
 // MockBackingSubnet is a mock of BackingSubnet interface.

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -89,14 +89,20 @@ type spaceShim struct {
 	*state.Space
 }
 
-func (s *spaceShim) Subnets() ([]BackingSubnet, error) {
-	results, err := s.Space.Subnets()
+func (s *spaceShim) NetworkSpace() (BackingSpaceInfo, error) {
+	result, err := s.Space.NetworkSpace()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return BackingSpaceInfo{}, errors.Trace(err)
 	}
-	subnets := make([]BackingSubnet, len(results))
-	for i, result := range results {
-		subnets[i] = &subnetShim{Subnet: result}
+	spaceInfo := BackingSpaceInfo{
+		ID:         result.ID,
+		Name:       result.Name,
+		ProviderId: result.ProviderId,
 	}
-	return subnets, nil
+	subnets := make([]BackingSubnetInfo, len(result.Subnets))
+	for i, subnet := range result.Subnets {
+		subnets[i] = SubnetInfoToBackingSubnetInfo(subnet)
+	}
+	spaceInfo.Subnets = subnets
+	return spaceInfo, nil
 }

--- a/apiserver/common/networkingcommon/shims.go
+++ b/apiserver/common/networkingcommon/shims.go
@@ -5,7 +5,6 @@ package networkingcommon
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/state"
 )
 
@@ -54,55 +53,4 @@ type linkLayerState struct {
 func (s *linkLayerState) Machine(id string) (LinkLayerMachine, error) {
 	m, err := s.State.Machine(id)
 	return &linkLayerMachine{m}, errors.Trace(err)
-}
-
-// NOTE: All of the following code is only tested with a feature test.
-
-// NewSubnetShim creates new subnet shim to be used by subnets and spaces Facades.
-func NewSubnetShim(sub *state.Subnet) *subnetShim {
-	return &subnetShim{Subnet: sub}
-}
-
-// subnetShim forwards and adapts state.Subnets methods to BackingSubnet.
-type subnetShim struct {
-	*state.Subnet
-}
-
-func (s *subnetShim) Life() life.Value {
-	return life.Value(s.Subnet.Life().String())
-}
-
-func (s *subnetShim) Status() string {
-	if life.IsNotAlive(s.Life()) {
-		return "terminating"
-	}
-	return "in-use"
-}
-
-// NewSpaceShim creates new subnet shim to be used by subnets and spaces Facades.
-func NewSpaceShim(sp *state.Space) *spaceShim {
-	return &spaceShim{Space: sp}
-}
-
-// spaceShim forwards and adapts state.Space methods to BackingSpace.
-type spaceShim struct {
-	*state.Space
-}
-
-func (s *spaceShim) NetworkSpace() (BackingSpaceInfo, error) {
-	result, err := s.Space.NetworkSpace()
-	if err != nil {
-		return BackingSpaceInfo{}, errors.Trace(err)
-	}
-	spaceInfo := BackingSpaceInfo{
-		ID:         result.ID,
-		Name:       result.Name,
-		ProviderId: result.ProviderId,
-	}
-	subnets := make([]BackingSubnetInfo, len(result.Subnets))
-	for i, subnet := range result.Subnets {
-		subnets[i] = SubnetInfoToBackingSubnetInfo(subnet)
-	}
-	spaceInfo.Subnets = subnets
-	return spaceInfo, nil
 }

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -28,10 +28,9 @@ type BackingSubnet interface {
 	ProviderId() network.Id
 	ProviderNetworkId() network.Id
 	AvailabilityZones() []string
-	Status() string
 	SpaceName() string
 	SpaceID() string
-	Life() life.Value
+	Life() state.Life
 }
 
 // BackingSubnetInfo describes a single subnet to be added in the
@@ -70,10 +69,6 @@ type BackingSubnetInfo struct {
 	SpaceName string
 	SpaceID   string
 
-	// Status holds the status of the subnet. Normally this will be
-	// calculated from the reference count and Life of a subnet.
-	Status string
-
 	// Live holds the life of the subnet
 	Life life.Value
 }
@@ -88,25 +83,10 @@ type BackingSpace interface {
 	Name() string
 
 	// NetworkSpace maps the space into network.SpaceInfo
-	NetworkSpace() (BackingSpaceInfo, error)
+	NetworkSpace() (network.SpaceInfo, error)
 
 	// ProviderId returns the network ID of the provider
 	ProviderId() network.Id
-}
-
-type BackingSpaceInfo struct {
-	// ID is the unique identifier for the space.
-	ID string
-
-	// Name is the name of the space.
-	Name network.SpaceName
-
-	// ProviderId is the provider's unique identifier for the space,
-	// such as used by MAAS.
-	ProviderId network.Id
-
-	// Subnets are the subnets that have been grouped into this network space.
-	Subnets []BackingSubnetInfo
 }
 
 // NetworkBacking defines the methods needed by the API facade to store and
@@ -157,34 +137,20 @@ func BackingSubnetToParamsSubnet(subnet BackingSubnet) params.Subnet {
 		ProviderId:        subnet.ProviderId().String(),
 		ProviderNetworkId: subnet.ProviderNetworkId().String(),
 		Zones:             subnet.AvailabilityZones(),
-		Status:            subnet.Status(),
 		SpaceTag:          names.NewSpaceTag(subnet.SpaceName()).String(),
-		Life:              subnet.Life(),
+		Life:              subnet.Life().Value(),
 	}
 }
 
-func BackingSubnetInfoToParamsSubnet(subnet BackingSubnetInfo) params.Subnet {
+func SubnetInfoToParamsSubnet(subnet network.SubnetInfo) params.Subnet {
 	return params.Subnet{
 		CIDR:              subnet.CIDR,
 		VLANTag:           subnet.VLANTag,
 		ProviderId:        subnet.ProviderId.String(),
 		ProviderNetworkId: subnet.ProviderNetworkId.String(),
 		Zones:             subnet.AvailabilityZones,
-		Status:            subnet.Status,
 		SpaceTag:          names.NewSpaceTag(subnet.SpaceName).String(),
 		Life:              subnet.Life,
-	}
-}
-
-func SubnetInfoToBackingSubnetInfo(subnet network.SubnetInfo) BackingSubnetInfo {
-	return BackingSubnetInfo{
-		ProviderId:        subnet.ProviderId,
-		ProviderNetworkId: subnet.ProviderNetworkId,
-		CIDR:              subnet.CIDR,
-		VLANTag:           subnet.VLANTag,
-		AvailabilityZones: subnet.AvailabilityZones,
-		SpaceName:         subnet.SpaceName,
-		SpaceID:           subnet.SpaceID,
 	}
 }
 

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -87,11 +87,26 @@ type BackingSpace interface {
 	// Name returns the space name.
 	Name() string
 
-	// Subnets returns the subnets in the space
-	Subnets() ([]BackingSubnet, error)
+	// NetworkSpace maps the space into network.SpaceInfo
+	NetworkSpace() (BackingSpaceInfo, error)
 
 	// ProviderId returns the network ID of the provider
 	ProviderId() network.Id
+}
+
+type BackingSpaceInfo struct {
+	// ID is the unique identifier for the space.
+	ID string
+
+	// Name is the name of the space.
+	Name network.SpaceName
+
+	// ProviderId is the provider's unique identifier for the space,
+	// such as used by MAAS.
+	ProviderId network.Id
+
+	// Subnets are the subnets that have been grouped into this network space.
+	Subnets []BackingSubnetInfo
 }
 
 // NetworkBacking defines the methods needed by the API facade to store and
@@ -145,6 +160,31 @@ func BackingSubnetToParamsSubnet(subnet BackingSubnet) params.Subnet {
 		Status:            subnet.Status(),
 		SpaceTag:          names.NewSpaceTag(subnet.SpaceName()).String(),
 		Life:              subnet.Life(),
+	}
+}
+
+func BackingSubnetInfoToParamsSubnet(subnet BackingSubnetInfo) params.Subnet {
+	return params.Subnet{
+		CIDR:              subnet.CIDR,
+		VLANTag:           subnet.VLANTag,
+		ProviderId:        subnet.ProviderId.String(),
+		ProviderNetworkId: subnet.ProviderNetworkId.String(),
+		Zones:             subnet.AvailabilityZones,
+		Status:            subnet.Status,
+		SpaceTag:          names.NewSpaceTag(subnet.SpaceName).String(),
+		Life:              subnet.Life,
+	}
+}
+
+func SubnetInfoToBackingSubnetInfo(subnet network.SubnetInfo) BackingSubnetInfo {
+	return BackingSubnetInfo{
+		ProviderId:        subnet.ProviderId,
+		ProviderNetworkId: subnet.ProviderNetworkId,
+		CIDR:              subnet.CIDR,
+		VLANTag:           subnet.VLANTag,
+		AvailabilityZones: subnet.AvailabilityZones,
+		SpaceName:         subnet.SpaceName,
+		SpaceID:           subnet.SpaceID,
 	}
 }
 

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -93,8 +93,8 @@ func (s *applicationOffersSuite) assertOffer(c *gc.C, expectedErr error) {
 	s.mockState.spaces["myspace"] = &mockSpace{
 		name:       "myspace",
 		providerId: "juju-space-myspace",
-		subnets: []applicationoffers.Subnet{
-			&mockSubnet{cidr: "4.3.2.0/24", providerId: "juju-subnet-1", zones: []string{"az1"}},
+		subnets: network.SubnetInfos{
+			{CIDR: "4.3.2.0/24", ProviderId: "juju-subnet-1", AvailabilityZones: []string{"az1"}},
 		},
 	}
 	s.env.spaceInfo = &environs.ProviderSpaceInfo{
@@ -623,8 +623,8 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 	s.mockState.spaces["myspace"] = &mockSpace{
 		name:       "myspace",
 		providerId: "juju-space-myspace",
-		subnets: []applicationoffers.Subnet{
-			&mockSubnet{cidr: "4.3.2.0/24", providerId: "juju-subnet-1", zones: []string{"az1"}},
+		subnets: network.SubnetInfos{
+			{CIDR: "4.3.2.0/24", ProviderId: "juju-subnet-1", AvailabilityZones: []string{"az1"}},
 		},
 	}
 	s.env.spaceInfo = &environs.ProviderSpaceInfo{
@@ -659,8 +659,8 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 	anotherState.spaces["anotherspace"] = &mockSpace{
 		name:       "anotherspace",
 		providerId: "juju-space-myspace",
-		subnets: []applicationoffers.Subnet{
-			&mockSubnet{cidr: "4.3.2.0/24", providerId: "juju-subnet-1", zones: []string{"az1"}},
+		subnets: network.SubnetInfos{
+			{CIDR: "4.3.2.0/24", ProviderId: "juju-subnet-1", AvailabilityZones: []string{"az1"}},
 		},
 	}
 	anotherState.users[user.Name()] = &mockUser{user.Name()}
@@ -909,12 +909,8 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 	s.mockState.spaces["myspace"] = &mockSpace{
 		name:       "myspace",
 		providerId: "juju-space-myspace",
-		subnets: []applicationoffers.Subnet{
-			&mockSubnet{
-				cidr:       "4.3.2.0/24",
-				providerId: "juju-subnet-1",
-				zones:      []string{"az1"},
-			},
+		subnets: network.SubnetInfos{
+			{CIDR: "4.3.2.0/24", ProviderId: "juju-subnet-1", AvailabilityZones: []string{"az1"}},
 		},
 	}
 	s.env.spaceInfo = &environs.ProviderSpaceInfo{
@@ -962,12 +958,8 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 	anotherState.spaces["anotherspace"] = &mockSpace{
 		name:       "anotherspace",
 		providerId: "juju-space-anotherspace",
-		subnets: []applicationoffers.Subnet{
-			&mockSubnet{
-				cidr:       "4.3.2.0/24",
-				providerId: "juju-subnet-1",
-				zones:      []string{"az1"},
-			},
+		subnets: network.SubnetInfos{
+			{CIDR: "4.3.2.0/24", ProviderId: "juju-subnet-1", AvailabilityZones: []string{"az1"}},
 		},
 	}
 	anotherState.model = &mockModel{
@@ -1365,8 +1357,8 @@ func (s *consumeSuite) setupOffer() {
 	st.spaces["myspace"] = &mockSpace{
 		name:       "myspace",
 		providerId: "juju-space-myspace",
-		subnets: []applicationoffers.Subnet{
-			&mockSubnet{cidr: "4.3.2.0/24", providerId: "juju-subnet-1", zones: []string{"az1"}},
+		subnets: network.SubnetInfos{
+			{CIDR: "4.3.2.0/24", ProviderId: "juju-subnet-1", AvailabilityZones: []string{"az1"}},
 		},
 	}
 	s.env.spaceInfo = &environs.ProviderSpaceInfo{

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -580,10 +580,11 @@ func (api *BaseAPI) collectRemoteSpaces(backend Backend, spaceNames []string) (m
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			space, err = spaceInfoFromState(dbSpace)
+			dbSpaceInfo, err := dbSpace.NetworkSpace()
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
+			space = &dbSpaceInfo
 		}
 		providerSpace, err := netEnv.ProviderSpaceInfo(backend.GetModelCallContext(), space)
 		if err != nil && !errors.IsNotFound(err) {

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -144,12 +144,8 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string, filterWithEndpoin
 	s.mockState.spaces["myspace"] = &mockSpace{
 		name:       "myspace",
 		providerId: "juju-space-myspace",
-		subnets: []applicationoffers.Subnet{
-			&mockSubnet{
-				cidr:       "4.3.2.0/24",
-				providerId: "juju-subnet-1",
-				zones:      []string{"az1"},
-			},
+		subnets: network.SubnetInfos{
+			{CIDR: "4.3.2.0/24", ProviderId: "juju-subnet-1", AvailabilityZones: []string{"az1"}},
 		},
 	}
 	s.env.spaceInfo = &environs.ProviderSpaceInfo{

--- a/apiserver/facades/client/applicationoffers/conversions.go
+++ b/apiserver/facades/client/applicationoffers/conversions.go
@@ -4,9 +4,6 @@
 package applicationoffers
 
 import (
-	"github.com/juju/errors"
-
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/rpc/params"
 )
@@ -32,28 +29,4 @@ func paramsFromProviderSpaceInfo(info *environs.ProviderSpaceInfo) params.Remote
 		result.Subnets = append(result.Subnets, resultSubnet)
 	}
 	return result
-}
-
-// spaceInfoFromState converts a state.Space into the equivalent
-// network.SpaceInfo.
-func spaceInfoFromState(space Space) (*network.SpaceInfo, error) {
-	result := &network.SpaceInfo{
-		Name:       network.SpaceName(space.Name()),
-		ProviderId: space.ProviderId(),
-	}
-	subnets, err := space.Subnets()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	for _, subnet := range subnets {
-		resultSubnet := network.SubnetInfo{
-			CIDR:              subnet.CIDR(),
-			ProviderId:        subnet.ProviderId(),
-			ProviderNetworkId: subnet.ProviderNetworkId(),
-			VLANTag:           subnet.VLANTag(),
-			AvailabilityZones: subnet.AvailabilityZones(),
-		}
-		result.Subnets = append(result.Subnets, resultSubnet)
-	}
-	return result, nil
 }

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -181,47 +181,23 @@ func (b *mockBindings) MapWithSpaceNames(network.SpaceInfos) (map[string]string,
 type mockSpace struct {
 	name       string
 	providerId network.Id
-	subnets    []applicationoffers.Subnet
+	subnets    network.SubnetInfos
 }
 
 func (m *mockSpace) Name() string {
 	return m.name
 }
 
-func (m *mockSpace) Subnets() ([]applicationoffers.Subnet, error) {
-	return m.subnets, nil
+func (m *mockSpace) NetworkSpace() (network.SpaceInfo, error) {
+	return corenetwork.SpaceInfo{
+		Name:       corenetwork.SpaceName(m.name),
+		ProviderId: m.providerId,
+		Subnets:    m.subnets,
+	}, nil
 }
 
 func (m *mockSpace) ProviderId() network.Id {
 	return m.providerId
-}
-
-type mockSubnet struct {
-	cidr              string
-	vlantag           int
-	providerId        network.Id
-	providerNetworkId network.Id
-	zones             []string
-}
-
-func (m *mockSubnet) CIDR() string {
-	return m.cidr
-}
-
-func (m *mockSubnet) VLANTag() int {
-	return m.vlantag
-}
-
-func (m *mockSubnet) ProviderId() network.Id {
-	return m.providerId
-}
-
-func (m *mockSubnet) ProviderNetworkId() network.Id {
-	return m.providerNetworkId
-}
-
-func (m *mockSubnet) AvailabilityZones() []string {
-	return m.zones
 }
 
 type mockRelation struct {

--- a/apiserver/facades/client/applicationoffers/state.go
+++ b/apiserver/facades/client/applicationoffers/state.go
@@ -107,8 +107,7 @@ func (s stateShim) GetOfferUsers(offerUUID string) (map[string]permission.Access
 }
 
 func (s *stateShim) SpaceByName(name string) (Space, error) {
-	sp, err := s.st.SpaceByName(name)
-	return &spaceShim{sp}, err
+	return s.st.SpaceByName(name)
 }
 
 func (s *stateShim) Model() (Model, error) {
@@ -151,38 +150,10 @@ var GetApplicationOffers = func(backend interface{}) crossmodel.ApplicationOffer
 	return nil
 }
 
-type Subnet interface {
-	CIDR() string
-	VLANTag() int
-	ProviderId() network.Id
-	ProviderNetworkId() network.Id
-	AvailabilityZones() []string
-}
-
-type subnetShim struct {
-	*state.Subnet
-}
-
 type Space interface {
 	Name() string
-	Subnets() ([]Subnet, error)
+	NetworkSpace() (network.SpaceInfo, error)
 	ProviderId() network.Id
-}
-
-type spaceShim struct {
-	*state.Space
-}
-
-func (s *spaceShim) Subnets() ([]Subnet, error) {
-	subnets, err := s.Space.Subnets()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	result := make([]Subnet, len(subnets))
-	for i, subnet := range subnets {
-		result[i] = &subnetShim{subnet}
-	}
-	return result, nil
 }
 
 type Model interface {

--- a/apiserver/facades/client/spaces/shims.go
+++ b/apiserver/facades/client/spaces/shims.go
@@ -79,8 +79,7 @@ func (s *stateShim) AddSpace(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	space := networkingcommon.NewSpaceShim(result)
-	return space, nil
+	return result, nil
 }
 
 func (s *stateShim) SpaceByName(name string) (networkingcommon.BackingSpace, error) {
@@ -88,8 +87,7 @@ func (s *stateShim) SpaceByName(name string) (networkingcommon.BackingSpace, err
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	space := networkingcommon.NewSpaceShim(result)
-	return space, nil
+	return result, nil
 }
 
 // AllEndpointBindings returns all endpoint bindings,
@@ -127,7 +125,7 @@ func (s *stateShim) AllSpaces() ([]networkingcommon.BackingSpace, error) {
 	}
 	spaces := make([]networkingcommon.BackingSpace, len(results))
 	for i, result := range results {
-		spaces[i] = networkingcommon.NewSpaceShim(result)
+		spaces[i] = result
 	}
 	return spaces, nil
 }
@@ -137,7 +135,7 @@ func (s *stateShim) SubnetByCIDR(cidr string) (networkingcommon.BackingSubnet, e
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return networkingcommon.NewSubnetShim(result), nil
+	return result, nil
 }
 
 // MovingSubnet wraps state.Subnet so that it

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -313,7 +313,7 @@ func (api *API) ListSpaces() (results params.ListSpacesResults, err error) {
 
 		result.Subnets = make([]params.Subnet, len(subnets))
 		for i, subnet := range subnets {
-			result.Subnets[i] = networkingcommon.BackingSubnetInfoToParamsSubnet(subnet)
+			result.Subnets[i] = networkingcommon.SubnetInfoToParamsSubnet(subnet)
 		}
 		results.Results[i] = result
 	}
@@ -362,7 +362,7 @@ func (api *API) ShowSpace(entities params.Entities) (params.ShowSpaceResults, er
 
 		result.Space.Subnets = make([]params.Subnet, len(subnets))
 		for i, subnet := range subnets {
-			result.Space.Subnets[i] = networkingcommon.BackingSubnetInfoToParamsSubnet(subnet)
+			result.Space.Subnets[i] = networkingcommon.SubnetInfoToParamsSubnet(subnet)
 		}
 
 		applications, err := api.applicationsBoundToSpace(space.Id())

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -302,17 +302,18 @@ func (api *API) ListSpaces() (results params.ListSpacesResults, err error) {
 		result.Id = space.Id()
 		result.Name = space.Name()
 
-		subnets, err := space.Subnets()
+		spaceInfo, err := space.NetworkSpace()
 		if err != nil {
 			err = errors.Annotatef(err, "fetching subnets")
 			result.Error = apiservererrors.ServerError(err)
 			results.Results[i] = result
 			continue
 		}
+		subnets := spaceInfo.Subnets
 
 		result.Subnets = make([]params.Subnet, len(subnets))
 		for i, subnet := range subnets {
-			result.Subnets[i] = networkingcommon.BackingSubnetToParamsSubnet(subnet)
+			result.Subnets[i] = networkingcommon.BackingSubnetInfoToParamsSubnet(subnet)
 		}
 		results.Results[i] = result
 	}
@@ -351,16 +352,17 @@ func (api *API) ShowSpace(entities params.Entities) (params.ShowSpaceResults, er
 		}
 		result.Space.Name = space.Name()
 		result.Space.Id = space.Id()
-		subnets, err := space.Subnets()
+		spaceInfo, err := space.NetworkSpace()
 		if err != nil {
 			newErr := errors.Annotatef(err, "fetching subnets")
 			results[i].Error = apiservererrors.ServerError(newErr)
 			continue
 		}
+		subnets := spaceInfo.Subnets
 
 		result.Space.Subnets = make([]params.Subnet, len(subnets))
 		for i, subnet := range subnets {
-			result.Space.Subnets[i] = networkingcommon.BackingSubnetToParamsSubnet(subnet)
+			result.Space.Subnets[i] = networkingcommon.BackingSubnetInfoToParamsSubnet(subnet)
 		}
 
 		applications, err := api.applicationsBoundToSpace(space.Id())

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -66,7 +66,6 @@ func (s *APISuite) TestShowSpaceDefault(c *gc.C) {
 				Life:              "alive",
 				SpaceTag:          args.Entities[0].Tag,
 				Zones:             []string{"bar", "bam"},
-				Status:            "in-use",
 			}}},
 			Error: nil,
 			// Applications = 2, as 2 applications are having a bind on that space.
@@ -519,7 +518,7 @@ func (s *APISuite) expectEndpointBindings(ctrl *gomock.Controller, spaceID strin
 
 // expectDefaultSpace configures a default space mock with default subnet settings
 func (s *APISuite) expectDefaultSpace(ctrl *gomock.Controller, name string, spacesErr, subnetErr error) {
-	backingSubnets := []networkingcommon.BackingSubnetInfo{{
+	backingSubnets := network.SubnetInfos{{
 		ProviderId:        network.Id("0"),
 		ProviderNetworkId: network.Id("1"),
 		CIDR:              "192.168.0.0/24",
@@ -527,10 +526,9 @@ func (s *APISuite) expectDefaultSpace(ctrl *gomock.Controller, name string, spac
 		AvailabilityZones: []string{"bar", "bam"},
 		SpaceName:         name,
 		SpaceID:           "1",
-		Status:            "in-use",
 		Life:              life.Value("alive"),
 	}}
-	backingSpaceInfo := networkingcommon.BackingSpaceInfo{
+	backingSpaceInfo := network.SpaceInfo{
 		ID:      "1",
 		Name:    network.SpaceName(name),
 		Subnets: backingSubnets,
@@ -951,7 +949,6 @@ func (s *LegacySuite) TestListSpacesDefault(c *gc.C) {
 			CIDR:       "192.168.0.0/24",
 			ProviderId: "provider-192.168.0.0/24",
 			Zones:      []string{"foo"},
-			Status:     "in-use",
 			SpaceTag:   "space-default",
 		}, {
 			CIDR:       "192.168.3.0/24",
@@ -977,7 +974,6 @@ func (s *LegacySuite) TestListSpacesDefault(c *gc.C) {
 			CIDR:       "192.168.2.0/24",
 			ProviderId: "provider-192.168.2.0/24",
 			Zones:      []string{"foo"},
-			Status:     "in-use",
 			SpaceTag:   "space-private",
 		}},
 	}}

--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -519,22 +519,27 @@ func (s *APISuite) expectEndpointBindings(ctrl *gomock.Controller, spaceID strin
 
 // expectDefaultSpace configures a default space mock with default subnet settings
 func (s *APISuite) expectDefaultSpace(ctrl *gomock.Controller, name string, spacesErr, subnetErr error) {
-	subnetMock := netmocks.NewMockBackingSubnet(ctrl)
-	subnetMock.EXPECT().CIDR().Return("192.168.0.0/24").AnyTimes()
-	subnetMock.EXPECT().SpaceID().Return("1").AnyTimes()
-	subnetMock.EXPECT().SpaceName().Return(name).AnyTimes()
-	subnetMock.EXPECT().VLANTag().Return(0).AnyTimes()
-	subnetMock.EXPECT().ProviderId().Return(network.Id("0")).AnyTimes()
-	subnetMock.EXPECT().ProviderNetworkId().Return(network.Id("1")).AnyTimes()
-	subnetMock.EXPECT().AvailabilityZones().Return([]string{"bar", "bam"}).AnyTimes()
-	subnetMock.EXPECT().Status().Return("in-use").AnyTimes()
-	subnetMock.EXPECT().Life().Return(life.Value("alive")).AnyTimes()
-	subnetMock.EXPECT().ID().Return("111").AnyTimes()
+	backingSubnets := []networkingcommon.BackingSubnetInfo{{
+		ProviderId:        network.Id("0"),
+		ProviderNetworkId: network.Id("1"),
+		CIDR:              "192.168.0.0/24",
+		VLANTag:           0,
+		AvailabilityZones: []string{"bar", "bam"},
+		SpaceName:         name,
+		SpaceID:           "1",
+		Status:            "in-use",
+		Life:              life.Value("alive"),
+	}}
+	backingSpaceInfo := networkingcommon.BackingSpaceInfo{
+		ID:      "1",
+		Name:    network.SpaceName(name),
+		Subnets: backingSubnets,
+	}
 
 	spacesMock := netmocks.NewMockBackingSpace(ctrl)
 	spacesMock.EXPECT().Id().Return("1").AnyTimes()
 	spacesMock.EXPECT().Name().Return(name).AnyTimes()
-	spacesMock.EXPECT().Subnets().Return([]networkingcommon.BackingSubnet{subnetMock}, subnetErr).AnyTimes()
+	spacesMock.EXPECT().NetworkSpace().Return(backingSpaceInfo, subnetErr).AnyTimes()
 	if spacesErr != nil {
 		s.Backing.EXPECT().SpaceByName(name).Return(nil, spacesErr)
 	} else {

--- a/apiserver/facades/client/subnets/shims.go
+++ b/apiserver/facades/client/subnets/shims.go
@@ -53,7 +53,7 @@ func (s *stateShim) AllSubnets() ([]networkingcommon.BackingSubnet, error) {
 	}
 	subnets := make([]networkingcommon.BackingSubnet, len(results))
 	for i, result := range results {
-		subnets[i] = networkingcommon.NewSubnetShim(result)
+		subnets[i] = result
 	}
 	return subnets, nil
 }
@@ -63,7 +63,7 @@ func (s *stateShim) SubnetByCIDR(cidr string) (networkingcommon.BackingSubnet, e
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return networkingcommon.NewSubnetShim(result), nil
+	return result, nil
 }
 
 // SubnetsByCIDR wraps each result of a call to state.SubnetsByCIDR
@@ -79,7 +79,7 @@ func (s *stateShim) SubnetsByCIDR(cidr string) ([]networkingcommon.BackingSubnet
 
 	result := make([]networkingcommon.BackingSubnet, len(subnets))
 	for i, subnet := range subnets {
-		result[i] = networkingcommon.NewSubnetShim(subnet)
+		result[i] = subnet
 	}
 	return result, nil
 }
@@ -102,7 +102,7 @@ func (s *stateShim) AllSpaces() ([]networkingcommon.BackingSpace, error) {
 	}
 	spaces := make([]networkingcommon.BackingSpace, len(results))
 	for i, result := range results {
-		spaces[i] = networkingcommon.NewSpaceShim(result)
+		spaces[i] = result
 	}
 	return spaces, nil
 }

--- a/apiserver/facades/client/subnets/subnets_test.go
+++ b/apiserver/facades/client/subnets/subnets_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -59,8 +60,7 @@ func (s *SubnetSuite) TestSubnetsByCIDR(c *gc.C) {
 	sExp.ProviderId().Return(network.Id("0"))
 	sExp.ProviderNetworkId().Return(network.Id("1"))
 	sExp.AvailabilityZones().Return([]string{"bar", "bam"})
-	sExp.Status().Return("in-use")
-	sExp.Life().Return(life.Value("alive"))
+	sExp.Life().Return(state.Alive)
 
 	bExp := s.mockBacking.EXPECT()
 	gomock.InOrder(
@@ -626,19 +626,17 @@ func (s *SubnetsSuite) TestListSubnetsAndFiltering(c *gc.C) {
 		ProviderId:        "sn-zadf00d",
 		ProviderNetworkId: "godspeed",
 		VLANTag:           0,
-		Life:              "",
+		Life:              life.Alive,
 		SpaceTag:          "space-private",
 		Zones:             []string{"zone1"},
-		Status:            "",
 	}, {
 		CIDR:              "2001:db8::/32",
 		ProviderId:        "sn-ipv6",
 		ProviderNetworkId: "",
 		VLANTag:           0,
-		Life:              "",
+		Life:              life.Alive,
 		SpaceTag:          "space-dmz",
 		Zones:             []string{"zone1", "zone3"},
-		Status:            "",
 	}}
 	// No filtering.
 	args := params.SubnetsFilters{}

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -155,13 +155,17 @@ func (f *FakeSpace) Name() string {
 	return f.SpaceName
 }
 
-func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
-	outputSubnets := []networkingcommon.BackingSubnet{}
-
-	if err = f.NextErr(); err != nil {
-		return outputSubnets, err
+func (f *FakeSpace) NetworkSpace() (networkingcommon.BackingSpaceInfo, error) {
+	if err := f.NextErr(); err != nil {
+		return networkingcommon.BackingSpaceInfo{}, err
 	}
 
+	outputSpaceInfo := networkingcommon.BackingSpaceInfo{
+		ID:   f.SpaceId,
+		Name: network.SpaceName(f.SpaceName),
+	}
+
+	outputSpaceInfo.Subnets = make([]networkingcommon.BackingSubnetInfo, len(f.SubnetIds))
 	for i, subnetId := range f.SubnetIds {
 		providerId := network.Id("provider-" + subnetId)
 
@@ -170,7 +174,7 @@ func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
 		// test data.
 		first, err := strconv.Atoi(strings.Split(subnetId, ".")[2])
 		if err != nil {
-			return outputSubnets, err
+			return outputSpaceInfo, err
 		}
 		vlantag := 0
 		zones := []string{"foo"}
@@ -190,10 +194,10 @@ func (f *FakeSpace) Subnets() (bs []networkingcommon.BackingSubnet, err error) {
 			AvailabilityZones: zones,
 			Status:            status,
 		}
-		outputSubnets = append(outputSubnets, &FakeSubnet{Info: backing, id: f.SpaceId + strconv.Itoa(i)})
+		outputSpaceInfo.Subnets[i] = backing
 	}
 
-	return outputSubnets, nil
+	return outputSpaceInfo, nil
 }
 
 func (f *FakeSpace) ProviderId() (netID network.Id) {

--- a/core/network/import_test.go
+++ b/core/network/import_test.go
@@ -4,6 +4,7 @@
 package network_test
 
 import (
+	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,8 +15,11 @@ type ImportSuite struct{}
 
 var _ = gc.Suite(&ImportSuite{})
 
+var allowedCoreImports = set.NewStrings("core/life")
+
 func (*ImportSuite) TestImports(c *gc.C) {
 	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/network")
-	// This package only brings in other core packages.
-	c.Assert(found, jc.SameContents, []string{})
+	for _, packageImport := range found {
+		c.Assert(allowedCoreImports.Contains(packageImport), jc.IsTrue)
+	}
 }

--- a/core/network/subnet.go
+++ b/core/network/subnet.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/life"
 )
 
 // FanCIDRs describes the subnets relevant to a fan network.
@@ -82,6 +84,9 @@ type SubnetInfo struct {
 
 	// IsPublic describes whether a subnet is public or not.
 	IsPublic bool
+
+	// Life represents the current life-cycle status of the subnets.
+	Life life.Value
 }
 
 // SetFan sets the fan networking information for the subnet.

--- a/rpc/params/network.go
+++ b/rpc/params/network.go
@@ -44,6 +44,8 @@ type Subnet struct {
 	// associated with.
 	Zones []string `json:"zones"`
 
+	// TODO (jack-w-shaw 2022-02-22): Remove this. It is unused
+	//
 	// Status returns the status of the subnet, whether it is in use, not
 	// in use or terminating.
 	Status string `json:"status,omitempty"`

--- a/state/life.go
+++ b/state/life.go
@@ -49,6 +49,12 @@ func (l Life) Value() life.Value {
 	}
 }
 
+// LifeFromValue converts a life.Value into it's corresponding
+// state.Life
+func LifeFromValue(value life.Value) Life {
+	return valueMap[value]
+}
+
 var (
 	isAliveDoc = bson.D{{"life", Alive}}
 	isDyingDoc = bson.D{{"life", Dying}}
@@ -61,6 +67,12 @@ var (
 	errAlreadyRemoved = errors.New("already removed")
 	errNotDying       = errors.New("not dying")
 )
+
+var valueMap = map[life.Value]Life{
+	life.Alive: Alive,
+	life.Dying: Dying,
+	life.Dead:  Dead,
+}
 
 // Living describes state entities with a lifecycle.
 type Living interface {

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 )
@@ -655,6 +656,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 				VLANTag:           79,
 				AvailabilityZones: []string{"AvailabilityZone"},
 				ProviderSpaceId:   "some id 2",
+				Life:              life.Alive,
 			},
 			{
 				ID:                "2",
@@ -668,6 +670,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 					FanOverlay:       "253.0.0.0/8",
 				},
 				ProviderSpaceId: "some id 2",
+				Life:            life.Alive,
 			},
 			{
 				ID:                "1",
@@ -677,6 +680,7 @@ func (s *SpacesSuite) TestSpaceToNetworkSpace(c *gc.C) {
 				VLANTag:           79,
 				AvailabilityZones: []string{"AvailabilityZone"},
 				ProviderSpaceId:   "some id 2",
+				Life:              life.Alive,
 			},
 		},
 	}

--- a/state/spaces_test.go
+++ b/state/spaces_test.go
@@ -446,25 +446,6 @@ func (s *SpacesSuite) TestAddSpaceWithEmptyNameAndNonEmptyProviderIdFails(c *gc.
 	s.assertInvalidSpaceNameErrorAndWasNotAdded(c, err, args.Name)
 }
 
-func (s *SpacesSuite) TestSubnetsReturnsExpectedSubnets(c *gc.C) {
-	args := addSpaceArgs{
-		Name:        "my-space",
-		SubnetCIDRs: []string{"1.1.1.0/24", "2.1.1.0/24", "3.1.1.0/24", "4.1.1.0/24", "5.1.1.0/24"},
-	}
-	space, err := s.addSpaceWithSubnets(c, args)
-	c.Assert(err, jc.ErrorIsNil)
-
-	var expected []*state.Subnet
-	for _, cidr := range args.SubnetCIDRs {
-		subnet, err := s.State.SubnetByCIDR(cidr)
-		c.Assert(err, jc.ErrorIsNil)
-		expected = append(expected, subnet)
-	}
-	actual, err := space.Subnets()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actual, jc.DeepEquals, expected)
-}
-
 func (s *SpacesSuite) TestAllSpaces(c *gc.C) {
 	alphaSpace, err := s.State.SpaceByName(network.AlphaSpaceName)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -361,6 +361,7 @@ func (s *Subnet) networkSubnet() network.SubnetInfo {
 		FanInfo:           fanInfo,
 		IsPublic:          s.doc.IsPublic,
 		SpaceID:           s.spaceID,
+		Life:              s.Life().Value(),
 		// SpaceName and ProviderSpaceID are populated by Space.NetworkSpace().
 		// For now, we do not look them up here.
 	}


### PR DESCRIPTION
As stated [here](https://github.com/juju/juju/blob/207cf067e2ee4727fb072288cb4cd6af47729c2f/state/spaces.go#L70-L71), the method space.Subnets should be phased out.

Remove all remaining invocations of space.Subnets, and finally remove the method itself

This has also opened the possibility for some pretty large reductions in complexity and the removal of redundancies. A couple of shims and the like have been removed

## Checklist

 - [?] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [?] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/apiserver/common/networkingcommon
go test github.com/juju/juju/apiserver/facades/client/...
go test github.com/juju/juju/apiserver/testing/
go test github.com/juju/juju/rpc/params/
go test github.com/juju/juju/core/network/
go test github.com/juju/juju/state/ --test.timeout=1800s
```

### Also

Bootstrap a controller into aws

#### List spaces
```sh
$ juju spaces
Name   Space ID  Subnets       
alpha  0         172.31.0.0/20 
                 172.31.16.0/20
                 172.31.32.0/20
                 252.0.0.0/12  
                 252.16.0.0/12 
                 252.32.0.0/12 
```

#### List subnets
```sh
$ juju subnets
subnets:
  172.31.0.0/20:
    type: ipv4
    provider-id: subnet-0815d22b08e3d82d1
    provider-network-id: vpc-0d3a33e664f1a5715
    status: in-use
    space: alpha
    zones:
    - eu-west-2c
...
  252.32.0.0/12:
    type: ipv4
    provider-id: subnet-039d317932e61e450-INFAN-172-31-32-0-20
    provider-network-id: vpc-0d3a33e664f1a5715
    status: in-use
    space: alpha
    zones:
    - eu-west-2b
```

#### Add subnet

```sh
$ juju add-subnet 172.31.48.0/24 alpha
added subnet with CIDR "172.31.48.0/24" in space "alpha"

$ juju subnets
subnets:
  172.31.0.0/20:
    type: ipv4
    provider-id: subnet-0815d22b08e3d82d1
    provider-network-id: vpc-0d3a33e664f1a5715
    status: in-use
    space: alpha
    zones:
    - eu-west-2c
...
  172.31.48.0/24:
    type: ipv4
    provider-id: subnet-03d148ead6fa5625a
    provider-network-id: vpc-0d3a33e664f1a5715
    status: in-use
    space: alpha
    zones:
    - eu-west-2b
...
  252.32.0.0/12:
    type: ipv4
    provider-id: subnet-039d317932e61e450-INFAN-172-31-32-0-20
    provider-network-id: vpc-0d3a33e664f1a5715
    status: in-use
    space: alpha
    zones:
    - eu-west-2

$ juju spaces
Name   Space ID  Subnets       
alpha  0         172.31.0.0/20 
                 172.31.16.0/20
                 172.31.32.0/20
                 172.31.48.0/24
                 252.0.0.0/12  
                 252.16.0.0/12 
                 252.32.0.0/12 
```

#### Add space

```sh
$ juju add-space beta
added space "beta" with no subnets

$ juju spaces
Name   Space ID  Subnets       
alpha  0         172.31.0.0/20 
                 172.31.16.0/20
                 172.31.32.0/20
                 172.31.48.0/24
                 252.0.0.0/12  
                 252.16.0.0/12 
                 252.32.0.0/12 
beta   1                       
```

#### Move subnet

```sh
$ juju move-to-space beta 172.31.48.0/24
Subnet 172.31.48.0/24 moved from alpha to beta

$ juju spaces
Name   Space ID  Subnets       
alpha  0         172.31.0.0/20 
                 172.31.16.0/20
                 172.31.32.0/20
                 252.0.0.0/12  
                 252.16.0.0/12 
                 252.32.0.0/12 
beta   1         172.31.48.0/24
```



## Documentation changes

N/A

## Bug reference

N/A
