### PR TITLE
Fix/crd upgrade

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -96,7 +96,7 @@ jobs:
           sleep 10
           microk8s kubectl patch role -n kubeflow istio-ingressgateway-operator -p '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"istio-ingressgateway-operator"},"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]}'
           sleep 6m
-          juju --debug wait -wv -m kubeflow -t 300
+          juju --debug wait -wv -m kubeflow -t 1200
 
           microk8s kubectl get pods -l 'juju-operator' -A -o custom-columns='Name:metadata.name,Image:spec.containers[0].image'
         EOF

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -65,19 +65,19 @@ func (k *kubernetesClient) ensureCustomResourceDefinitions(
 			Labels:      k8slabels.Merge(v.Labels, k.getAPIExtensionLabelsGlobal(appName)),
 			Annotations: k8sannotations.New(v.Annotations).Merge(annotations),
 		}
-		logger.Infof("ensuring custom resource definition %q with version %q", obj.GetName(), v.Spec.Version)
+		logger.Infof("ensuring custom resource definition %q with version %q on k8s %q", obj.GetName(), v.Spec.Version, k8sVersion.String())
 		var out metav1.Object
 		var crdCleanUps []func()
 		var err error
 		switch v.Spec.Version {
 		case k8sspecs.K8sCustomResourceDefinitionV1:
 			if k8sVersion.Major == 1 && k8sVersion.Minor < 16 {
-				return cleanUps, errors.NotSupportedf("custom resource definition version %q", v.Spec.Version)
+				return cleanUps, errors.NotSupportedf("custom resource definition version %q for k8s %q", v.Spec.Version, k8sVersion.String())
 			} else {
 				out, crdCleanUps, err = k.ensureCustomResourceDefinitionV1(obj, v.Spec.SpecV1)
 			}
 		case k8sspecs.K8sCustomResourceDefinitionV1Beta1:
-			if k8sVersion.Major == 1 && k8sVersion.Minor < 16 {
+			if k8sVersion.Major == 1 && k8sVersion.Minor < 22 {
 				out, crdCleanUps, err = k.ensureCustomResourceDefinitionV1beta1(obj, v.Spec.SpecV1Beta1)
 			} else {
 				var newSpec apiextensionsv1.CustomResourceDefinitionSpec

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -133,7 +133,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1beta1
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "15",
+		Major: "1", Minor: "21",
 	}, nil)
 
 	crds := []k8sspecs.K8sCustomResourceDefinition{
@@ -252,7 +252,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1beta1
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "16",
+		Major: "1", Minor: "22",
 	}, nil)
 
 	crds := []k8sspecs.K8sCustomResourceDefinition{
@@ -269,6 +269,13 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1beta1
 					Version: "v1alpha2",
 					Group:   "kubeflow.org",
 					Scope:   "Namespaced",
+					Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha2",
+							Served:  true,
+							Storage: true,
+						},
+					},
 					Validation: &apiextensionsv1beta1.CustomResourceValidation{
 						OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
 							Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
@@ -381,7 +388,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdateV1beta1
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "15",
+		Major: "1", Minor: "21",
 	}, nil)
 
 	crds := []k8sspecs.K8sCustomResourceDefinition{
@@ -502,7 +509,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsCreateV1(c *g
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "16",
+		Major: "1", Minor: "22",
 	}, nil)
 
 	crds := []k8sspecs.K8sCustomResourceDefinition{
@@ -623,7 +630,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourceDefinitionsUpdateV1(c *g
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "16",
+		Major: "1", Minor: "22",
 	}, nil)
 
 	crds := []k8sspecs.K8sCustomResourceDefinition{
@@ -946,7 +953,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesCreate(c *gc.C) {
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "16",
+		Major: "1", Minor: "22",
 	}, nil)
 
 	crRaw1 := getCR1()
@@ -1072,7 +1079,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomResourcesUpdate(c *gc.C) {
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "16",
+		Major: "1", Minor: "22",
 	}, nil)
 
 	crRaw1 := getCR1()
@@ -1230,7 +1237,7 @@ func (s *K8sBrokerSuite) TestCRDGetter(c *gc.C) {
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "16",
+		Major: "1", Minor: "22",
 	}, nil)
 
 	crdGetter := provider.CRDGetter{s.broker}
@@ -1404,7 +1411,7 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsAllGood(c *gc.C) {
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "16",
+		Major: "1", Minor: "22",
 	}, nil)
 
 	crd1 := &apiextensionsv1.CustomResourceDefinition{
@@ -1543,7 +1550,7 @@ func (s *K8sBrokerSuite) TestGetCRDsForCRsFailEarly(c *gc.C) {
 	defer ctrl.Finish()
 
 	s.mockDiscovery.EXPECT().ServerVersion().AnyTimes().Return(&k8sversion.Info{
-		Major: "1", Minor: "16",
+		Major: "1", Minor: "22",
 	}, nil)
 
 	mockCRDGetter := mocks.NewMockCRDGetterInterface(ctrl)

--- a/caas/kubernetes/provider/specs/customresourcedefinition.go
+++ b/caas/kubernetes/provider/specs/customresourcedefinition.go
@@ -41,6 +41,9 @@ func UpgradeCustomResourceDefinitionSpecV1Beta1(spec apiextensionsv1beta1.Custom
 			Categories: spec.Names.Categories,
 		},
 	}
+	if spec.Version != "" && len(spec.Versions) == 0 {
+		return apiextensionsv1.CustomResourceDefinitionSpec{}, errors.NotValidf("custom resource definition group %q", spec.Group)
+	}
 	if spec.Versions != nil {
 		for _, v := range spec.Versions {
 			crd := apiextensionsv1.CustomResourceDefinitionVersion{
@@ -88,12 +91,6 @@ func UpgradeCustomResourceDefinitionSpecV1Beta1(spec apiextensionsv1beta1.Custom
 			}
 			out.Versions = append(out.Versions, crd)
 		}
-	} else if spec.Version != "" {
-		out.Versions = append(out.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
-			Name:    spec.Version,
-			Served:  true,
-			Storage: true,
-		})
 	}
 	if spec.PreserveUnknownFields != nil {
 		out.PreserveUnknownFields = *spec.PreserveUnknownFields


### PR DESCRIPTION
This PR fixes some CRD upgrade issues:

- do not create a CustomResourceDefinitionVersion if no version is defined in the v1beta1 because the `Schema` is required for v1;
- upgrade v1beta1 CRDs if k8s version > 1.21;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ sudo snap install microk8s --classic --channel 1.21/stable

$ juju bootstrap microk8s k1

$ juju add-model kubeflow

$ microk8s.enable storage dns rbac

$ juju deploy kubeflow-lite --trust

$ mkubectl patch role -n kubeflow istio-ingressgateway-operator -p '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"istio-ingressgateway-operator"},"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]}'

$ juju status --relations --color --storage -m k1:kubeflow
```

## Documentation changes

No

## Bug reference

No
