### PR TITLE
[JUJU-647] improve messaging on deleted users

### DIFF
--- a/cmd/juju/user/add.go
+++ b/cmd/juju/user/add.go
@@ -20,12 +20,13 @@ import (
 var usageSummary = `
 Adds a Juju user to a controller.`[1:]
 
-const usageDetails = `The user's details are stored within the controller and
-will be removed when the controller is destroyed.
+const usageDetails = `
+The user's details are stored within the controller and will be removed when
+the controller is destroyed.
 
 A user unique registration string will be printed. This registration string 
-must be used by the newly added user as supplied to 
-complete the registration process. 
+must be used by the newly added user as supplied to complete the registration
+process.
 
 Some machine providers will require the user to be in possession of certain
 credentials in order to create a model.

--- a/cmd/juju/user/remove.go
+++ b/cmd/juju/user/remove.go
@@ -43,10 +43,10 @@ See also:
 
 var removeUserMsg = `
 WARNING! This command will permanently archive the user %q on the %q
-controller.
+controller. This action is irreversible and you WILL NOT be able to reuse
+username %q.
 
-This action is irreversible. If you wish to temporarily disable the
-user please use the`[1:] + " `juju disable-user` " + `command. See
+If you wish to temporarily disable the user please use the`[1:] + " `juju disable-user`\n" + `command. See
 ` + " `juju help disable-user` " + `for more details.
 
 Continue (y/N)? `
@@ -140,7 +140,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 
 func confirmDelete(ctx *cmd.Context, controller, username string) error {
 	// Get confirmation from the user that they want to continue
-	fmt.Fprintf(ctx.Stdout, removeUserMsg, username, controller)
+	fmt.Fprintf(ctx.Stdout, removeUserMsg, username, controller, username)
 
 	scanner := bufio.NewScanner(ctx.Stdin)
 	scanner.Scan()

--- a/cmd/juju/user/remove_test.go
+++ b/cmd/juju/user/remove_test.go
@@ -73,10 +73,10 @@ func (s *RemoveUserCommandSuite) TestRemove(c *gc.C) {
 func (s *RemoveUserCommandSuite) TestRemovePrompts(c *gc.C) {
 	username := "testing"
 	expected := `WARNING! This command will permanently archive the user "testing" on the "testing"
-controller.
+controller. This action is irreversible and you WILL NOT be able to reuse
+username "testing".
 
-This action is irreversible. If you wish to temporarily disable the
-user please use the` + " `juju disable-user` " + `command. See
+If you wish to temporarily disable the user please use the` + " `juju disable-user`\n" + `command. See
 ` + " `juju help disable-user` " + `for more details.
 
 Continue (y/N)? `

--- a/featuretests/cmd_juju_user_test.go
+++ b/featuretests/cmd_juju_user_test.go
@@ -129,10 +129,10 @@ func (s *UserSuite) TestUserEnable(c *gc.C) {
 func (s *UserSuite) TestRemoveUserPrompt(c *gc.C) {
 	expected := `
 WARNING! This command will permanently archive the user "jjam" on the "kontroll"
-controller.
+controller. This action is irreversible and you WILL NOT be able to reuse
+username "jjam".
 
-This action is irreversible. If you wish to temporarily disable the
-user please use the`[1:] + " `juju disable-user` " + `command. See
+If you wish to temporarily disable the user please use the`[1:] + " `juju disable-user`\n" + `command. See
 ` + " `juju help disable-user` " + `for more details.
 
 Continue (y/N)? `

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -494,6 +494,16 @@ func (s *UserSuite) TestAllUsers(c *gc.C) {
 	c.Check(users[6].Name(), gc.Equals, "test-admin")
 }
 
+func (s *UserSuite) TestAddDeletedUser(c *gc.C) {
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "Bob"})
+
+	_ = s.State.RemoveUser(names.NewUserTag("bob"))
+
+	_, err := s.State.AddUser(
+		"bob", "ignored", "ignored", "ignored")
+	c.Assert(err, jc.Satisfies, state.IsDeletedUserError)
+}
+
 func (s *UserSuite) TestAddUserNoSecretKey(c *gc.C) {
 	u, err := s.State.AddUser("bob", "display", "pass", "admin")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
There are now 3 duplicates to LP 1770370 and continued confusion.  The bug has a plan to improve the user experience at some point in the future.  Until then, improve the error message when trying to add a user already removed.  And enhance the statement on user removal.

## QA steps

```console
$ juju add-user charlie
User "charlie" added
...
$ juju remove-user charlie
WARNING! This command will permanently archive the user "charlie" on the "tuesday"
controller. This action is irreversible and you WILL NOT be able to reuse
username "charlie".

If you wish to temporarily disable the user please use the `juju disable-user`
command. See
 `juju help disable-user` for more details.

Continue (y/N)? y
User "charlie" removed
$ juju add-user charlie
ERROR failed to create user: cannot reuse name: user "charlie" is permanently deleted
```
## Bug reference
This change does not fix the problem below, however it's intended to improve messaging and related errors.
https://bugs.launchpad.net/juju/+bug/1770370
