### PR TITLE
[JUJU-641] Charm revision updater prevent terminal failure

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1143,7 +1143,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 	}
 	if wrench.IsActive("charmrevision", "shortinterval") {
 		interval := 10 * time.Second
-		logger.Infof("setting short charmrevision worker interval: %v", interval)
+		logger.Debugf("setting short charmrevision worker interval: %v", interval)
 		manifoldsCfg.CharmRevisionUpdateInterval = interval
 	}
 

--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -1,8 +1,8 @@
-run_charmrevisionupdater() {
+run_charmstore_charmrevisionupdater() {
 	# Echo out to ensure nice output to the test suite.
 	echo
 
-	model_name="test-charmrevisionupdater"
+	model_name="test-cs-charmrevisionupdater"
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
@@ -13,6 +13,25 @@ run_charmrevisionupdater() {
 	# Wait for revision update worker to update the available revision.
 	# eg can-upgrade-to: cs:mysql-58
 	wait_for "cs:mysql-" '.applications["mysql"] | ."can-upgrade-to"'
+
+	destroy_model "${model_name}"
+}
+
+run_charmhub_charmrevisionupdater() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	model_name="test-ch-charmrevisionupdater"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	# Deploy an old revision of ubuntu
+	juju deploy ubuntu --channel=stable --revision=18
+
+	# Wait for revision update worker to update the available revision.
+	# eg can-upgrade-to: ch:ubuntu-18
+	wait_for "ubuntu-" '.applications["ubuntu"] | ."can-upgrade-to"'
 
 	destroy_model "${model_name}"
 }
@@ -28,6 +47,7 @@ test_charmrevisionupdater() {
 
 		cd .. || exit
 
-		run "run_charmrevisionupdater"
+		run "run_charmhub_charmrevisionupdater"
+		run "run_charmstore_charmrevisionupdater"
 	)
 }


### PR DESCRIPTION
If either charmhub or charmstore goes away or starts serving bad
content, like in the charmstore case, we shouldn't die on the hill.
Instead, we should do our best effort to at least return some content.
This sort of async job can be thought of as a tier 2 part of juju, it's
not massively critical, but very useful UX feedback. This may change in
the future, but as it stands this shouldn't just flatout fail.

The following just changes how the errors are handled, whilst trying the
best to return the correct values and errors accordingly.

The integration test still fails for charmstore as they're serving bad
content, but it works nicely for charmhub, as the new test identifies.

## QA steps

The charmstore test will fail because of https://warthogs.atlassian.net/browse/SN-490

```sh
$ (cd tests && ./main.sh -v agents)
```
