### PR TITLE
Clarify log message

### DIFF
--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -157,7 +157,7 @@ func (m jujuMain) Run(args []string) int {
 		if _, _, err := cloud.FetchAndMaybeUpdatePublicClouds(cloud.PublicCloudsAccess(), true); err != nil {
 			cmd.WriteError(ctx.Stderr, err)
 		}
-		jujuMsg = fmt.Sprintf("Since Juju %v is being run for the first time, downloaded the latest public cloud information.\n", jujuversion.Current.Major)
+		jujuMsg = fmt.Sprintf("Since Juju %v is being run for the first time, it has downloaded the latest public cloud information.\n", jujuversion.Current.Major)
 	}
 
 	for i := range x {

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -231,7 +231,7 @@ func (s *MainSuite) TestNoWarn2xFirstRun(c *gc.C) {
 
 	assertNoArgs(c, argChan)
 	c.Check(string(stderr), gc.Equals, `
-Since Juju 2 is being run for the first time, downloaded the latest public cloud information.`[1:]+"\n")
+Since Juju 2 is being run for the first time, it has downloaded the latest public cloud information.`[1:]+"\n")
 	checkVersionOutput(c, string(stdout))
 }
 


### PR DESCRIPTION
When Juju is being run for the first time, a message is shown to the
user. The message was not a complete sentence, so it was hard to
understand, especially for non native speakers.

The message has been improved.

## Reproducing the problem

```
$ lxc launch ubuntu:bionic juju-reproducer
$ lxc shell juju-reproducer
root@juju-reproducer:~# snap install juju --classic
root@juju-reproducer:~# juju add-model mojo-how-to
Since Juju 2 is being run for the first time, downloaded the latest public cloud information.
```

## QA steps as requested

```
$ lxc launch ubuntu:bionic juju-reproducer
$ lxc shell juju-reproducer
# git clone --depth 1 https://github.com/juju/juju.git
# cd juju
# git remote add jugmac00 https://github.com/jugmac00/juju.git
# git remote update jugmac00
# git checkout improve-message
# apt install make
# make install-dependencies
# make build
# _build/linux_amd64/bin/juju add-model mojo-how-to
Since Juju 2 is being run for the first time, it has downloaded the latest public cloud information.
...
```