### PR TITLE
[JUJU-648] Allow the ability to specify branch when deploying charms

### DIFF
--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -42,6 +42,8 @@ type Origin struct {
 	Revision *int
 	// Track is a CharmHub channel track.
 	Track *string
+	// Branch is the CharmHub channel branch
+	Branch *string
 	// Architecture describes the architecture intended to be used by the charm.
 	Architecture string
 	// OS describes the OS intended to be used by the charm.
@@ -69,9 +71,14 @@ func (o Origin) CharmChannel() charm.Channel {
 	if o.Track != nil {
 		track = *o.Track
 	}
+	var branch string
+	if o.Branch != nil {
+		branch = *o.Branch
+	}
 	return charm.Channel{
-		Track: track,
-		Risk:  charm.Risk(o.Risk),
+		Track:  track,
+		Risk:   charm.Risk(o.Risk),
+		Branch: branch,
 	}
 }
 
@@ -86,6 +93,7 @@ func (o Origin) ParamsCharmOrigin() params.CharmOrigin {
 		Revision:     o.Revision,
 		Risk:         o.Risk,
 		Track:        o.Track,
+		Branch:       o.Branch,
 		Architecture: o.Architecture,
 		OS:           o.OS,
 		Series:       o.Series,
@@ -99,11 +107,16 @@ func (o Origin) CoreCharmOrigin() corecharm.Origin {
 	if o.Track != nil {
 		track = *o.Track
 	}
+	var branch string
+	if o.Branch != nil {
+		branch = *o.Branch
+	}
 	var channel *charm.Channel
 	if o.Risk != "" {
 		channel = &charm.Channel{
-			Risk:  charm.Risk(o.Risk),
-			Track: track,
+			Risk:   charm.Risk(o.Risk),
+			Track:  track,
+			Branch: branch,
 		}
 	}
 	return corecharm.Origin{
@@ -133,6 +146,7 @@ func APICharmOrigin(origin params.CharmOrigin) Origin {
 		Risk:         origin.Risk,
 		Revision:     origin.Revision,
 		Track:        origin.Track,
+		Branch:       origin.Branch,
 		Architecture: origin.Architecture,
 		OS:           origin.OS,
 		Series:       origin.Series,
@@ -151,6 +165,10 @@ func CoreCharmOrigin(origin corecharm.Origin) Origin {
 	if ch.Track != "" {
 		track = &ch.Track
 	}
+	var branch *string
+	if ch.Branch != "" {
+		branch = &ch.Branch
+	}
 	return Origin{
 		Source:       OriginSource(origin.Source),
 		Type:         origin.Type,
@@ -159,6 +177,7 @@ func CoreCharmOrigin(origin corecharm.Origin) Origin {
 		Revision:     origin.Revision,
 		Risk:         string(ch.Risk),
 		Track:        track,
+		Branch:       branch,
 		Architecture: origin.Platform.Architecture,
 		OS:           origin.Platform.OS,
 		Series:       origin.Platform.Series,

--- a/api/common/charm/charmorigin_test.go
+++ b/api/common/charm/charmorigin_test.go
@@ -16,13 +16,16 @@ var _ = gc.Suite(&originSuite{})
 
 func (originSuite) TestCoreChannel(c *gc.C) {
 	track := "latest"
+	branch := "foo"
 	origin := commoncharm.Origin{
-		Risk:  "edge",
-		Track: &track,
+		Risk:   "edge",
+		Track:  &track,
+		Branch: &branch,
 	}
 	c.Assert(origin.CharmChannel(), gc.DeepEquals, charm.Channel{
-		Risk:  charm.Edge,
-		Track: "latest",
+		Risk:   charm.Edge,
+		Track:  "latest",
+		Branch: "foo",
 	})
 }
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -836,11 +836,15 @@ func convertCharmOrigin(origin *params.CharmOrigin, curl *charm.URL, charmStoreC
 	if origin.Track != nil {
 		track = *origin.Track
 	}
+	var branch string
+	if origin.Branch != nil {
+		branch = *origin.Branch
+	}
 	// We do guarantee that there will be a risk value.
 	// Ignore the error, as only caused by risk as an
 	// empty string.
 	var channel *charm.Channel
-	if ch, err := charm.MakeChannel(track, origin.Risk, ""); err == nil {
+	if ch, err := charm.MakeChannel(track, origin.Risk, branch); err == nil {
 		channel = &ch
 	}
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1536,6 +1536,9 @@ func makeParamsCharmOrigin(origin *state.CharmOrigin) params.CharmOrigin {
 		if origin.Channel.Track != "" {
 			retOrigin.Track = &origin.Channel.Track
 		}
+		if origin.Channel.Branch != "" {
+			retOrigin.Branch = &origin.Channel.Branch
+		}
 	}
 	if origin.Platform != nil {
 		retOrigin.Architecture = origin.Platform.Architecture

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -977,8 +977,9 @@ func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 		Source:   "local",
 		Revision: &rev,
 		Channel: &state.Channel{
-			Track: "latest",
-			Risk:  "stable",
+			Track:  "latest",
+			Risk:   "stable",
+			Branch: "foo",
 		},
 		Platform: &state.Platform{
 			Architecture: "amd64",
@@ -991,13 +992,16 @@ func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
 	c.Assert(result.URL, gc.Equals, "local:quantal/wordpress-3")
+
 	latest := "latest"
+	branch := "foo"
 
 	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
 		Source:       "local",
 		Risk:         "stable",
 		Revision:     &rev,
 		Track:        &latest,
+		Branch:       &branch,
 		Architecture: "amd64",
 		OS:           "ubuntu",
 		Series:       "focal",

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2273,7 +2273,7 @@ func (s *ApplicationSuite) TestApplicationsInfoOne(c *gc.C) {
 		},
 	})
 	app := s.backend.applications["test-app-info"]
-	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Series", "Channel", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
+	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
 }
 
 func (s *ApplicationSuite) TestApplicationsInfoOneWithExposedEndpoints(c *gc.C) {
@@ -2312,7 +2312,7 @@ func (s *ApplicationSuite) TestApplicationsInfoOneWithExposedEndpoints(c *gc.C) 
 			},
 		},
 	})
-	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Series", "Channel", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
+	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
 }
 
 func (s *ApplicationSuite) TestApplicationsInfoDetailsErr(c *gc.C) {
@@ -2363,7 +2363,7 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 	c.Assert(result.Results[1].Error, gc.ErrorMatches, `application "wordpress" not found`)
 	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"unit-postgresql-0" is not a valid application tag`)
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Series", "Channel", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
+	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
 }
 
 func (s *ApplicationSuite) TestApplicationMergeBindingsErr(c *gc.C) {

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/core/network"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing/factory"
 )
 
@@ -299,6 +300,7 @@ var getTests = []struct {
 	about       string
 	charm       string
 	constraints string
+	origin      *state.CharmOrigin
 	config      charm.Settings
 	expect      params.ApplicationGetResults
 }{{
@@ -438,13 +440,43 @@ var getTests = []struct {
 			"logging-directory": network.AlphaSpaceName,
 		},
 	},
+}, {
+	about: "charmhub application",
+	charm: "logging",
+	origin: &state.CharmOrigin{
+		Source: "charm-hub",
+		Channel: &state.Channel{
+			Risk:   "stable",
+			Branch: "foo",
+		},
+	},
+	expect: params.ApplicationGetResults{
+		CharmConfig: map[string]interface{}{},
+		Series:      "quantal",
+		ApplicationConfig: map[string]interface{}{
+			"trust": map[string]interface{}{
+				"value":       false,
+				"default":     false,
+				"description": "Does this application have access to trusted credentials",
+				"source":      "default",
+				"type":        "bool",
+			},
+		},
+		EndpointBindings: map[string]string{
+			"":                  network.AlphaSpaceName,
+			"info":              network.AlphaSpaceName,
+			"logging-client":    network.AlphaSpaceName,
+			"logging-directory": network.AlphaSpaceName,
+		},
+		Channel: "stable/foo",
+	},
 }}
 
 func (s *getSuite) TestApplicationGet(c *gc.C) {
 	for i, t := range getTests {
 		c.Logf("test %d. %s", i, t.about)
 		ch := s.AddTestingCharm(c, t.charm)
-		app := s.AddTestingApplication(c, fmt.Sprintf("test%d", i), ch)
+		app := s.AddTestingApplicationWithOrigin(c, fmt.Sprintf("test%d", i), ch, t.origin)
 
 		var constraintsv constraints.Value
 		if t.constraints != "" {

--- a/apiserver/facades/client/charms/clientnormalize_test.go
+++ b/apiserver/facades/client/charms/clientnormalize_test.go
@@ -19,11 +19,13 @@ var _ = gc.Suite(&clientNormalizeOriginSuite{})
 
 func (s *clientNormalizeOriginSuite) TestNormalizeCharmOriginNoAll(c *gc.C) {
 	track := "1.0"
+	branch := "foo"
 	origin := params.CharmOrigin{
 		Source:       "charm-hub",
 		Type:         "charm",
 		Risk:         "edge",
 		Track:        &track,
+		Branch:       &branch,
 		Architecture: "all",
 		OS:           "all",
 		Series:       "all",

--- a/apiserver/facades/client/charms/conversions.go
+++ b/apiserver/facades/client/charms/conversions.go
@@ -15,6 +15,10 @@ func convertOrigin(origin corecharm.Origin) params.CharmOrigin {
 	if origin.Channel != nil && origin.Channel.Track != "" {
 		track = &origin.Channel.Track
 	}
+	var branch *string
+	if origin.Channel != nil && origin.Channel.Branch != "" {
+		branch = &origin.Channel.Branch
+	}
 	var risk string
 	if origin.Channel != nil {
 		risk = string(origin.Channel.Risk)
@@ -27,6 +31,7 @@ func convertOrigin(origin corecharm.Origin) params.CharmOrigin {
 		Risk:         risk,
 		Revision:     origin.Revision,
 		Track:        track,
+		Branch:       branch,
 		Architecture: origin.Platform.Architecture,
 		OS:           origin.Platform.OS,
 		Series:       origin.Platform.Series,
@@ -39,6 +44,10 @@ func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 	if origin.Track != nil {
 		track = *origin.Track
 	}
+	var branch string
+	if origin.Branch != nil {
+		branch = *origin.Branch
+	}
 	return corecharm.Origin{
 		Source:   corecharm.Source(origin.Source),
 		Type:     origin.Type,
@@ -46,8 +55,9 @@ func convertParamsOrigin(origin params.CharmOrigin) corecharm.Origin {
 		Hash:     origin.Hash,
 		Revision: origin.Revision,
 		Channel: &charm.Channel{
-			Track: track,
-			Risk:  charm.Risk(origin.Risk),
+			Track:  track,
+			Risk:   charm.Risk(origin.Risk),
+			Branch: branch,
 		},
 		Platform: corecharm.Platform{
 			Architecture: origin.Architecture,

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3164,6 +3164,9 @@
                         "architecture": {
                             "type": "string"
                         },
+                        "branch": {
+                            "type": "string"
+                        },
                         "hash": {
                             "type": "string"
                         },
@@ -15730,6 +15733,9 @@
                     "type": "object",
                     "properties": {
                         "architecture": {
+                            "type": "string"
+                        },
+                        "branch": {
                             "type": "string"
                         },
                         "hash": {
@@ -39273,6 +39279,9 @@
                     "type": "object",
                     "properties": {
                         "architecture": {
+                            "type": "string"
+                        },
+                        "branch": {
                             "type": "string"
                         },
                         "hash": {

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -55,6 +55,10 @@ func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Plat
 		if channel.Track != "" {
 			track = &channel.Track
 		}
+		var branch *string
+		if channel.Branch != "" {
+			branch = &channel.Branch
+		}
 		var revision *int
 		if url.Revision != -1 {
 			revision = &url.Revision
@@ -64,6 +68,7 @@ func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Plat
 			Revision:     revision,
 			Risk:         string(channel.Risk),
 			Track:        track,
+			Branch:       branch,
 			Architecture: architecture,
 			OS:           platform.OS,
 			Series:       platform.Series,

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -90,7 +90,7 @@ func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, re
 	case res.Error != nil:
 		retryResult, err := c.retryResolveWithPreferredChannel(charmURL, requestedOrigin, macaroons, res.Error)
 		if err != nil {
-			return nil, corecharm.Origin{}, nil, errors.Annotatef(err, "retry resolving with preferred channel")
+			return nil, corecharm.Origin{}, nil, errors.Trace(err)
 		}
 
 		res = retryResult.refreshResponse
@@ -226,7 +226,7 @@ func (c *CharmHubRepository) retryResolveWithPreferredChannel(charmURL *charm.UR
 	}
 
 	if len(bases) == 0 {
-		return nil, errors.Wrap(resErr, errors.Errorf("no channels available for selection"))
+		return nil, errors.Wrap(resErr, errors.Errorf("no releases found for channel %q", origin.Channel.String()))
 	}
 	base := bases[0]
 
@@ -526,7 +526,7 @@ func (c *CharmHubRepository) selectNextBasesFromReleases(releases []transport.Re
 		// If the user passed in a branch, but not enough information about the
 		// arch and series, then we can help by giving a better error message.
 		if origin.Channel != nil && origin.Channel.Branch != "" {
-			return nil, errors.Errorf("ambiguous arch and series with channel track/risk/branch. specify both arch and series along with channel")
+			return nil, errors.Errorf("ambiguous arch and series with channel %q, specify both arch and series along with channel", origin.Channel.String())
 		}
 		// If the origin is empty, then we want to help the user out
 		// by display a series of suggestions to try.

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -526,7 +526,7 @@ func (c *CharmHubRepository) selectNextBasesFromReleases(releases []transport.Re
 		// If the user passed in a branch, but not enough information about the
 		// arch and series, then we can help by giving a better error message.
 		if origin.Channel != nil && origin.Channel.Branch != "" {
-			return nil, errors.Errorf("ambiguous arch and series with channel track/risk/branch. specify both arch and series along with channel.")
+			return nil, errors.Errorf("ambiguous arch and series with channel track/risk/branch. specify both arch and series along with channel")
 		}
 		// If the origin is empty, then we want to help the user out
 		// by display a series of suggestions to try.

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -523,6 +523,11 @@ func (c *CharmHubRepository) selectNextBasesFromReleases(releases []transport.Re
 		return nil, errors.Errorf("no releases available")
 	}
 	if origin.Platform.Series == "" {
+		// If the user passed in a branch, but not enough information about the
+		// arch and series, then we can help by giving a better error message.
+		if origin.Channel != nil && origin.Channel.Branch != "" {
+			return nil, errors.Errorf("ambiguous arch and series with channel track/risk/branch. specify both arch and series along with channel.")
+		}
 		// If the origin is empty, then we want to help the user out
 		// by display a series of suggestions to try.
 		suggestions := c.composeSuggestions(releases, origin)

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -6,6 +6,7 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 
 	"github.com/golang/mock/gomock"
@@ -248,7 +249,7 @@ func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundErrorWithNoSeries(c
 
 	repo := NewCharmHubRepository(s.logger, s.client)
 	_, _, _, err := repo.ResolveWithPreferredChannel(curl, origin, nil)
-	c.Assert(err, gc.ErrorMatches, `retry resolving with preferred channel: selecting releases: no charm or bundle matching channel or platform; suggestions: stable with focal`)
+	c.Assert(err, gc.ErrorMatches, `selecting releases: no charm or bundle matching channel or platform; suggestions: stable with focal`)
 }
 
 func (s *charmHubRepositorySuite) TestResolveRevisionNotFoundError(c *gc.C) {
@@ -791,7 +792,7 @@ func (selectNextBaseSuite) TestSelectNextBasesFromReleasesAmbiguousMatchError(c 
 	}, corecharm.Origin{
 		Channel: &channel,
 	})
-	c.Assert(err, gc.ErrorMatches, `ambiguous arch and series with channel track/risk/branch. specify both arch and series along with channel`)
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf(`ambiguous arch and series with channel %q. specify both arch and series along with channel`, channel.String()))
 }
 
 func (s *selectNextBaseSuite) TestSelectNextBasesFromReleasesSuggestionError(c *gc.C) {

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -34,6 +34,7 @@ type CharmOrigin struct {
 	// Revision is the charm revision number.
 	Revision *int    `json:"revision,omitempty"`
 	Track    *string `json:"track,omitempty"`
+	Branch   *string `json:"branch,omitempty"`
 
 	Architecture string `json:"architecture,omitempty"`
 	OS           string `json:"os,omitempty"`


### PR DESCRIPTION
The following is the initial work for deploying charms with channel
branches. As channel branches are non-discoverable it means that both
arch and series (platform) are required when using a branch in a
channel.

The code was pretty much wired up for this already, it was just about
exposing this via the api parameters.


## QA steps

The following should fail without knowing the arch and series you want
to target.

```sh
$ juju deploy juju-test-qa --channel=stable/foo
ERROR selecting releases: ambiguous arch and series with channel "stable/foo", specify both arch and series along with channel
```

The following should pass:

```sh
$ juju deploy juju-test-qa --channel=stable/foo --constraints="arch=amd64" --series="focal"
Located charm "juju-test-qa" in charm-hub, revision 2
Deploying "juju-test-qa" from charm-hub charm "juju-test-qa", revision 2 in channel stable/foo
```

Invalid channel:

```sh
$ juju deploy juju-test-qa --channel=stable/bar --constraints="arch=amd64" --series="focal"
ERROR no releases found for channel "stable/bar"
```

## Status

See the channel is now correctly shown.

```sh
$ juju status
Model    Controller  Cloud/Region  Version   SLA          Timestamp
default  test        lxd/default   2.9.26.1  unsupported  10:10:48Z

App           Version  Status  Scale  Charm         Store     Channel     Rev  OS      Message
juju-test-qa           active      1  juju-test-qa  charmhub  stable/foo    2  ubuntu  it is now: 02/23/2022, 10:06:34

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-test-qa/1*  active    idle   5        10.132.183.189         it is now: 02/23/2022, 10:06:34

Machine  State    DNS             Inst id        Series  AZ  Message
5        started  10.132.183.189  juju-81ae99-5  focal       Running
```

### Refresh

Once deployed, push a new charm to the store and then call refresh. A channel
isn't required as the `application.Get` is correctly returned.

```sh
$ juju refresh juju-test-qa
Added charm-hub charm "juju-test-qa", revision 3 in channel stable/foo, to the model
```

```sh
$ juju status
Model    Controller  Cloud/Region  Version   SLA          Timestamp
default  test        lxd/default   2.9.26.1  unsupported  10:10:48Z

App           Version  Status  Scale  Charm         Store     Channel     Rev  OS      Message
juju-test-qa           active      1  juju-test-qa  charmhub  stable/foo    3  ubuntu  it is now: 02/23/2022, 11:26:14

Unit             Workload  Agent  Machine  Public address  Ports  Message
juju-test-qa/1*  active    idle   5        10.132.183.189         it is now: 02/23/2022, 11:26:14

Machine  State    DNS             Inst id        Series  AZ  Message
5        started  10.132.183.189  juju-81ae99-5  focal       Running
```



## Bug reference

https://bugs.launchpad.net/juju/+bug/1961107
