### PR TITLE
Update Pebble to latest (including health checks and API)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.9.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0
+	github.com/canonical/pebble v0.0.0-20220220221114-a922aaf20c76
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.0.0-20200316104309-cb8b64719ae3
 	github.com/docker/distribution v2.8.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0 h1:Bzr3QOteZ+bPUxFGjgA3jkYnERpeFfbgGaLsH9g7qm8=
-github.com/canonical/pebble v0.0.0-20220105032148-3a48156fcbf0/go.mod h1:+0rQ57rhB9pciKKaE/QlwPL4R8mujv+24D81KGYRlV0=
+github.com/canonical/pebble v0.0.0-20220220221114-a922aaf20c76 h1:N1s6Fhblu52wgT8+FU5DUxAXW+jQlW+Cl4TJieITAws=
+github.com/canonical/pebble v0.0.0-20220220221114-a922aaf20c76/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
Includes the health checks and API/CLI PRs:

* https://github.com/canonical/pebble/pull/85
* https://github.com/canonical/pebble/pull/86

## QA steps

TODO

## Documentation changes

Documentation link: https://github.com/benhoyt/juju-docs/pull/1
