### PR TITLE
Fix type with Darwin test microk8s

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -37,7 +37,7 @@ microk8s_operator_update() {
   echo "Uploading image $(operator_image_path) to microk8s"
   # For macos we have to push the image into the microk8s multipass vm because
   # we can't use the ctr to stream off the local machine.
-  if [ $(uname) == "Darwin" ]; then
+  if [ $(uname) = "Darwin" ]; then
     tmp_docker_image="/tmp/juju-operator-image-${RANDOM}.image"
     docker save $(operator_image_path) | multipass transfer - microk8s-vm:${tmp_docker_image}
     microk8s ctr --namespace k8s.io image import ${tmp_docker_image}


### PR DESCRIPTION
In the bash functions for testing if microk8s image uploading is
happening on Darwin or not we use '==' to compare two strings with test.
This should be a single '='

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run microk8s operator update on darwin with no custom Bash installed.

```sh
make microk8s-operator-update
```

## Documentation changes

N/A

## Bug reference

N/A
