### PR TITLE
Increase the number of ec2 client retries

### DIFF
--- a/tests/suites/cli/local_charms.sh
+++ b/tests/suites/cli/local_charms.sh
@@ -163,6 +163,7 @@ run_deploy_local_charm_revision_invalid_git() {
 
 create_local_git_folder() {
 	git init .
+	git config user.email "me@example.com"
 	touch rand_file
 	git add rand_file
 	git commit -am "rand_file"


### PR DESCRIPTION
The default ec2 client retry strategy retries up to 3 times with a max backoff of 20s.
This is not enough when running CI tests, and we occasionally have seen release failures as well.

This PR increases the retry count to 10 with a max backoff of 1 minute.

Also, fix an integration test which was not correctly setting up git on a virgin machine.

## QA steps

juju bootstrap aws

