### PR TITLE
Small tweak to git local repo init for ci test

### DIFF
--- a/tests/suites/cli/local_charms.sh
+++ b/tests/suites/cli/local_charms.sh
@@ -163,7 +163,10 @@ run_deploy_local_charm_revision_invalid_git() {
 
 create_local_git_folder() {
 	git init .
-	git config user.email "me@example.com"
+	if [ -z "$(git config --global user.email)" ]; then
+		git config --global user.email "john@doe.com"
+		git config --global user.name "John Doe"
+	fi
 	touch rand_file
 	git add rand_file
 	git commit -am "rand_file"


### PR DESCRIPTION
The CI test which uses a git repo should only set the user info if not already set.

## QA steps

./main.sh -v cli
