### PR TITLE
[JUJU-656] Fix microk8s gh actions

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -60,8 +60,7 @@ jobs:
     strategy:
       matrix:
         snap_version: ["latest/stable", "latest/beta"]
-        # TODO - microk8s upgrade test is broken
-        model_type: ["localhost"] #, "microk8s"]
+        model_type: ["localhost", "microk8s"]
     env:
       CHARM_localhost: apache2
       CHARM_microk8s: elasticsearch-k8s
@@ -199,13 +198,18 @@ jobs:
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
       env:
         JUJU_DB_TAG: ${{ steps.vars.outputs.juju-db-version }}
+
+      # TODO: Enabling developer-mode is a bit of a hack to get this working for now.
+      # Ideally, we would mock our own simplestream, similar to Jenkins, to select
+      # and filter with as standard, instead of skipping over them with this flag
       run: |
         set -euxo pipefail
 
         sg microk8s <<EOF
           juju bootstrap microk8s c \
-            --config caas-image-repo="'{\"repository\": \"${DOCKER_REGISTRY}/test-repo\", \"serveraddress\": \"https://${DOCKER_REGISTRY}/\"}'" \
-            --config juju-db-snap-channel="${JUJU_DB_TAG}/stable"
+            --config caas-image-repo='{"repository": "${DOCKER_REGISTRY}/test-repo", "serveraddress": "https://${DOCKER_REGISTRY}/"}' \
+            --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
+            --config features="[developer-mode]"
         EOF
         juju add-model m
 
@@ -283,7 +287,7 @@ jobs:
 
         attempt=0
         while true; do
-          UPDATED=$(juju show-controller --format=json | jq -r '.c.details."agent-version"')
+          UPDATED=$((juju show-controller --format=json || echo "") | jq -r '.c.details."agent-version"')
           if [[ $UPDATED == $UPSTREAM_JUJU_TAG* ]]; then
               break
           fi
@@ -309,8 +313,6 @@ jobs:
       shell: bash
       env:
         UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
-        UPGRADE_PARAMS_localhost: "--build-agent"
-        UPGRADE_PARAMS_microk8s: ""
       run: |
         set -euxo pipefail
 
@@ -324,7 +326,7 @@ jobs:
 
         attempt=0
         while true; do
-          UPDATED=$(juju show-model m --format=json | jq -r '.m."agent-version"')
+          UPDATED=$((juju show-model m --format=json || echo "") | jq -r '.m."agent-version"')
           if [[ $UPDATED == $UPSTREAM_JUJU_TAG* ]]; then
             break
           fi


### PR DESCRIPTION
As stated in https://bugs.launchpad.net/juju/+bug/1961614, juju has some weird behaviour when upgrading a controller outside of the default settings. The previous method of performing this action relied on this, which has been determined to be a bug

So instead, use developer-mode feature flag to ignore agent-stream filtering altogether

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Run microk8s upgrade action to completion. Checking the test result is valid as well

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1961614
