### PR TITLE
Trigger discussions about current PR template.

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Checklist
 
-*To be filled only if you know what is all this about.*
+*A list of items to check. If you do not need this, delete it.*
 
  - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
  - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
@@ -12,7 +12,7 @@
 
 ## QA steps
 
-*Please replace with how we can verify that the change works.*
+*Please replace with how we can verify that the change works. If this is not required (which is particularly weird, but it may happen) indicate it using NA.*
 
 ```sh
 QA steps here
@@ -20,11 +20,11 @@ QA steps here
 
 ## Documentation changes
 
-*Please replace with any notes about how it affects current user workflow, CLI, or API.*
+*Please replace with any notes about how it affects current user workflow, CLI, or API. If this is not required, indicate it using NA.*
 
 ## Bug reference
 
-*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
+*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543 If not bug is related, indicate it using NA.*
 
 ## Additional notes
-*Please use this section if you consider that the reviewer will need additional information to understand the ongoing changes.*
+*Please use this section if you consider that the reviewer will need additional information to understand the ongoing changes. If no additional notes are required, indicate it with NA.*

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Checklist
 
-*A list of items to check. If you do not need this, delete it.*
+*A list of items to check. Only let those checks that are required. If no checks are required, indicate it with NA.*
 
  - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
  - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,14 @@
-## Please provide the following details to expedite review (and delete this heading)
+## Description
 
 *Replace with a description about why this change is needed, along with a description of what changed.*
 
 ## Checklist
 
+*To be filled only if you know what is all this about.*
+
  - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
  - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
- - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
- - [ ] Comments answer the question of why design decisions were made
+ - [ ] Others...
 
 ## QA steps
 
@@ -24,3 +25,6 @@ QA steps here
 ## Bug reference
 
 *Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
+
+## Additional notes
+*Please use this section if you consider that the reviewer will need additional information to understand the ongoing changes.*


### PR DESCRIPTION
This is an initial attempt to update our current PR template or at least trigger some discussions about it. Something I have observed is that external contributors get particularly confused when filling the template. So this are the main changes I have proposed.
- Remove go.doc comments from the checklist
- Add instructions for collaborators to indicate with NA when a section is not required
- "Additional notes" section for collaborators to provide additional context.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Please replace with how we can verify that the change works.*

```sh
QA steps here
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow, CLI, or API.*

## Bug reference

*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
