### PR TITLE
[JUJU-659] Fix introspection nil pointer on k8s operator charms

### DIFF
--- a/agent/addons/addons.go
+++ b/agent/addons/addons.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,7 +17,6 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/presence"
-	"github.com/juju/juju/core/raftlease"
 	"github.com/juju/juju/worker/introspection"
 )
 
@@ -42,9 +40,9 @@ type IntrospectionConfig struct {
 	PrometheusGatherer prometheus.Gatherer
 	PresenceRecorder   presence.Recorder
 	Clock              clock.Clock
-	LocalHub           *pubsub.SimpleHub
-	CentralHub         *pubsub.StructuredHub
-	LeaseFSM           *raftlease.FSM
+	LocalHub           introspection.SimpleHub
+	CentralHub         introspection.StructuredHub
+	LeaseFSM           introspection.Leases
 
 	NewSocketName func(names.Tag) string
 	WorkerFunc    func(config introspection.Config) (worker.Worker, error)

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -6,10 +6,11 @@ package apiserver
 import (
 	"net/http"
 
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/params"
 	"github.com/juju/juju/core/permission"
-	"github.com/juju/names/v4"
 )
 
 // introspectionHandler is an http.Handler that wraps an http.Handler

--- a/cmd/jujud/agent/caasoperator.go
+++ b/cmd/jujud/agent/caasoperator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	"github.com/juju/pubsub/v2"
 	"github.com/juju/utils/v3/voyeur"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -251,6 +252,9 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		}
 		return nil, err
 	}
+	localHub := pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{
+		Logger: loggo.GetLogger("juju.localhub"),
+	})
 	if err := addons.StartIntrospection(addons.IntrospectionConfig{
 		AgentTag:           op.CurrentConfig().Tag(),
 		Engine:             engine,
@@ -258,6 +262,8 @@ func (op *CaasOperatorAgent) Workers() (worker.Worker, error) {
 		NewSocketName:      addons.DefaultIntrospectionSocketName,
 		PrometheusGatherer: op.prometheusRegistry,
 		WorkerFunc:         introspection.NewWorker,
+		Clock:              clock.WallClock,
+		LocalHub:           localHub,
 		// If the caas operator gains the ability to interact with the
 		// introspection worker, the introspection worker should be configured
 		// with a clock and hub. See the machine agent.

--- a/worker/introspection/worker_test.go
+++ b/worker/introspection/worker_test.go
@@ -45,6 +45,18 @@ func (s *suite) TestConfigValidation(c *gc.C) {
 	w, err := introspection.NewWorker(introspection.Config{})
 	c.Check(w, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "empty SocketName not valid")
+	w, err = introspection.NewWorker(introspection.Config{
+		SocketName: "socket",
+	})
+	c.Check(w, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "nil PrometheusGatherer not valid")
+	w, err = introspection.NewWorker(introspection.Config{
+		SocketName:         "socket",
+		PrometheusGatherer: newPrometheusGatherer(),
+		LocalHub:           pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{}),
+	})
+	c.Check(w, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "nil Clock not valid")
 }
 
 func (s *suite) TestStartStop(c *gc.C) {
@@ -179,13 +191,13 @@ func (s *introspectionSuite) TestMissingDepEngineReporter(c *gc.C) {
 func (s *introspectionSuite) TestMissingStatePoolReporter(c *gc.C) {
 	response := s.call(c, "/statepool")
 	c.Assert(response.StatusCode, gc.Equals, http.StatusNotFound)
-	s.assertBody(c, response, "State Pool Report: missing reporter")
+	s.assertBody(c, response, `"State Pool" introspection not supported`)
 }
 
 func (s *introspectionSuite) TestMissingPubSubReporter(c *gc.C) {
 	response := s.call(c, "/pubsub")
 	c.Assert(response.StatusCode, gc.Equals, http.StatusNotFound)
-	s.assertBody(c, response, "PubSub Report: missing reporter")
+	s.assertBody(c, response, `"PubSub Report" introspection not supported`)
 }
 
 func (s *introspectionSuite) TestMissingMachineLock(c *gc.C) {
@@ -223,7 +235,7 @@ working: true`[1:])
 func (s *introspectionSuite) TestMissingPresenceReporter(c *gc.C) {
 	response := s.call(c, "/presence")
 	c.Assert(response.StatusCode, gc.Equals, http.StatusNotFound)
-	s.assertBody(c, response, "404 page not found")
+	s.assertBody(c, response, `"Presence" introspection not supported`)
 }
 
 func (s *introspectionSuite) TestDisabledPresenceReporter(c *gc.C) {


### PR DESCRIPTION
Running the `juju_leases` introspection on an operator charm agent printed "EOF" and causes a nil pointer deference.
This fixes the npe by avoiding the use of typed nils.

Also improves the error message for introspections not supported by the agent - it prints a message instead of a generic 404.

NB turns out introspections are totally broken on k8s sidecar charms so a separate PR will need to wire all that up.
Plus the units introspections are broken for all k8s charms.

## QA steps

deploy a k8s operator charm
exec into the operator pod
. /etc/profile.d/juju-introspection.sh
juju_leases
juju_engine_report

Do the same for the controller api-server container
juju_leases will print useful info for this case.