### PR TITLE
Attempt to fix race condition in worker/caasunitprovisioner

### DIFF
--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -1018,9 +1018,12 @@ func (s *WorkerSuite) TestV2CharmExitsApplicationWorker(c *gc.C) {
 	s.sendApplicationChanges(c, "gitlab")
 	waitCharmGetterCalls("ApplicationCharmInfo")
 
-	// Wait till Life() is called to synchronize (ensure charmInfo is done).
+	// Wait till application worker has started up
+	var appWorker worker.Worker
 	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		if len(s.lifeGetter.Calls()) > 0 {
+		aw, ok := caasunitprovisioner.AppWorker(w, "gitlab")
+		if ok {
+			appWorker = aw
 			break
 		}
 	}
@@ -1036,10 +1039,8 @@ func (s *WorkerSuite) TestV2CharmExitsApplicationWorker(c *gc.C) {
 	}
 	waitCharmGetterCalls("ApplicationCharmInfo")
 
-	// Ensure application worker exited due to charm becoming v2
-	aw, ok := caasunitprovisioner.AppWorker(w, "gitlab")
-	c.Assert(ok, jc.IsTrue)
-	err = workertest.CheckKilled(c, aw)
+	// Ensure application worker exits due to charm becoming v2
+	err = workertest.CheckKilled(c, appWorker)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -1027,6 +1027,7 @@ func (s *WorkerSuite) TestV2CharmExitsApplicationWorker(c *gc.C) {
 			break
 		}
 	}
+	c.Assert(appWorker, gc.NotNil)
 
 	// Make it a v2 charm (will make the application worker exit)
 	s.charmGetter.charmInfo.Manifest = &charm.Manifest{Bases: []charm.Base{{}}}


### PR DESCRIPTION
I think what was happening was occasionally the parent worker was getting another event that would cause it to remove the
applicationWorker before the test expected it, and the `c.Assert(ok, jc.IsTrue)` would fail (or previously panic when the assert
wasn't there).

Now we fetch the applicationWorker earlier in the test when we know it should be active, so the `CheckKilled` argument will never be nil.

This was causing a panic in our race tests ([example](https://jenkins.juju.canonical.com/job/Unit-RunUnitTests-race-amd64/1133/console), also copied below), then @wallyworld changed it to fail instead of panic with the assert. Hopefully this fixes the intermittent failure case.

```
06:31:51 panic: runtime error: invalid memory address or nil pointer dereference
06:31:51 [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x223c44a]
06:31:51 
06:31:51 goroutine 313 [running]:
06:31:51 github.com/juju/juju/worker/caasunitprovisioner.(*applicationWorker).Wait(0x0)
06:31:51 	/home/jenkins/workspace/Unit-RunUnitTests-race-amd64/_build/src/github.com/juju/juju/worker/caasunitprovisioner/application_worker.go:81 +0x2a
06:31:51 github.com/juju/worker/v3/workertest.CheckKilled.func1()
06:31:51 	/home/jenkins/workspace/Unit-RunUnitTests-race-amd64/_build/src/github.com/juju/juju/vendor/github.com/juju/worker/v3/workertest/check.go:52 +0x49
06:31:51 created by github.com/juju/worker/v3/workertest.CheckKilled
06:31:51 	/home/jenkins/workspace/Unit-RunUnitTests-race-amd64/_build/src/github.com/juju/juju/vendor/github.com/juju/worker/v3/workertest/check.go:51 +0x12c
06:31:51 FAIL	github.com/juju/juju/worker/caasunitprovisioner	1.289s
```