### PR TITLE
[JUJU-674] Allow constraints to be passed when adding a model

### DIFF
--- a/api/client/modelmanager/modelmanager.go
+++ b/api/client/modelmanager/modelmanager.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
@@ -48,6 +49,7 @@ func (c *Client) CreateModel(
 	name, owner, cloud, cloudRegion string,
 	cloudCredential names.CloudCredentialTag,
 	config map[string]interface{},
+	cons constraints.Value,
 ) (base.ModelInfo, error) {
 	var result base.ModelInfo
 	if !names.IsValidUser(owner) {
@@ -71,6 +73,7 @@ func (c *Client) CreateModel(
 		CloudTag:           cloudTag,
 		CloudRegion:        cloudRegion,
 		CloudCredentialTag: cloudCredentialTag,
+		Constraints:        cons,
 	}
 	var modelInfo params.ModelInfo
 	err := c.facade.FacadeCall("CreateModel", createArgs, &modelInfo)

--- a/api/client/modelmanager/modelmanager.go
+++ b/api/client/modelmanager/modelmanager.go
@@ -73,7 +73,7 @@ func (c *Client) CreateModel(
 		CloudTag:           cloudTag,
 		CloudRegion:        cloudRegion,
 		CloudCredentialTag: cloudCredentialTag,
-		Constraints:        cons,
+		Constraints:        &cons,
 	}
 	var modelInfo params.ModelInfo
 	err := c.facade.FacadeCall("CreateModel", createArgs, &modelInfo)

--- a/api/client/modelmanager/modelmanager_test.go
+++ b/api/client/modelmanager/modelmanager_test.go
@@ -57,7 +57,7 @@ func (s *modelmanagerSuite) TestCreateModel(c *gc.C) {
 			Config:      map[string]interface{}{"abc": 123},
 			CloudTag:    "cloud-nimbus",
 			CloudRegion: "catbus",
-			Constraints: constraints.Value{
+			Constraints: &constraints.Value{
 				Arch: &a,
 			},
 		})

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -585,6 +585,11 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 		return result, errors.Trace(err)
 	}
 
+	var cons constraints.Value
+	if args.Constraints != nil {
+		cons = *args.Constraints
+	}
+
 	var model common.Model
 	if jujucloud.CloudIsCAAS(cloud) {
 		model, err = m.newCAASModel(
@@ -595,7 +600,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 			cloudRegionName,
 			cloudCredentialTag,
 			ownerTag,
-			args.Constraints)
+			cons)
 	} else {
 		model, err = m.newModel(
 			cloudSpec,
@@ -605,7 +610,7 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 			cloudRegionName,
 			cloudCredentialTag,
 			ownerTag,
-			args.Constraints)
+			cons)
 	}
 	if err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/caas"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller/modelmanager"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs"
@@ -593,7 +594,8 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 			cloudTag,
 			cloudRegionName,
 			cloudCredentialTag,
-			ownerTag)
+			ownerTag,
+			args.Constraints)
 	} else {
 		model, err = m.newModel(
 			cloudSpec,
@@ -602,11 +604,13 @@ func (m *ModelManagerAPI) CreateModel(args params.ModelCreateArgs) (params.Model
 			cloudTag,
 			cloudRegionName,
 			cloudCredentialTag,
-			ownerTag)
+			ownerTag,
+			args.Constraints)
 	}
 	if err != nil {
 		return result, errors.Trace(err)
 	}
+
 	return m.getModelInfo(model.ModelTag())
 }
 
@@ -618,6 +622,7 @@ func (m *ModelManagerAPI) newCAASModel(
 	cloudRegionName string,
 	cloudCredentialTag names.CloudCredentialTag,
 	ownerTag names.UserTag,
+	cons constraints.Value,
 ) (_ common.Model, err error) {
 	newConfig, err := m.newModelConfig(cloudSpec, createArgs, controllerModel)
 	if err != nil {
@@ -667,6 +672,7 @@ Please choose a different model name.
 		Config:                  newConfig,
 		Owner:                   ownerTag,
 		StorageProviderRegistry: storageProviderRegistry,
+		Constraints:             cons,
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to create new model")
@@ -684,6 +690,7 @@ func (m *ModelManagerAPI) newModel(
 	cloudRegionName string,
 	cloudCredentialTag names.CloudCredentialTag,
 	ownerTag names.UserTag,
+	cons constraints.Value,
 ) (common.Model, error) {
 	newConfig, err := m.newModelConfig(cloudSpec, createArgs, controllerModel)
 	if err != nil {
@@ -728,6 +735,7 @@ func (m *ModelManagerAPI) newModel(
 		Owner:                   ownerTag,
 		StorageProviderRegistry: storageProviderRegistry,
 		EnvironVersion:          env.Provider().Version(),
+		Constraints:             cons,
 	})
 	if err != nil {
 		// Clean up the environ.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -33013,6 +33013,9 @@
                                 }
                             }
                         },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
                         "credential": {
                             "type": "string"
                         },
@@ -33831,6 +33834,63 @@
                         "model",
                         "force"
                     ]
+                },
+                "Value": {
+                    "type": "object",
+                    "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "container": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "instance-role": {
+                            "type": "string"
+                        },
+                        "instance-type": {
+                            "type": "string"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
                 }
             }
         }

--- a/caas/kubernetes/provider/utils/labels.go
+++ b/caas/kubernetes/provider/utils/labels.go
@@ -6,7 +6,9 @@ package utils
 import (
 	"context"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -41,7 +43,9 @@ func HasLabels(src, has labels.Set) bool {
 // IsLegacyModelLabels checks to see if the provided model is running on an older
 // labeling scheme or a newer one.
 func IsLegacyModelLabels(namespace, model string, namespaceI core.NamespaceInterface) (bool, error) {
+	loggo.GetLogger("***").Criticalf("???? %v", spew.Sdump(namespaceI))
 	ns, err := namespaceI.Get(context.TODO(), namespace, meta.GetOptions{})
+	loggo.GetLogger("***").Criticalf("!!!!! %v, %v", ns, err)
 	if k8serrors.IsNotFound(err) {
 		return false, nil
 	}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/cmd/juju/common"
 	"github.com/juju/juju/cmd/juju/controller"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/feature"
@@ -702,6 +703,7 @@ type fakeAddClient struct {
 	cloudRegion     string
 	cloudCredential names.CloudCredentialTag
 	config          map[string]interface{}
+	cons            constraints.Value
 	err             error
 	model           base.ModelInfo
 }
@@ -712,7 +714,7 @@ func (*fakeAddClient) Close() error {
 	return nil
 }
 
-func (f *fakeAddClient) CreateModel(name, owner, cloudName, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}) (base.ModelInfo, error) {
+func (f *fakeAddClient) CreateModel(name, owner, cloudName, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}, cons constraints.Value) (base.ModelInfo, error) {
 	if f.err != nil {
 		return base.ModelInfo{}, f.err
 	}
@@ -721,6 +723,7 @@ func (f *fakeAddClient) CreateModel(name, owner, cloudName, cloudRegion string, 
 	f.cloudName = cloudName
 	f.cloudRegion = cloudRegion
 	f.config = config
+	f.cons = cons
 	return f.model, nil
 }
 

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/modelmanager"
 	"github.com/juju/juju/cmd/juju/commands"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/juju"
@@ -53,7 +54,7 @@ func (s *cmdControllerSuite) createModelAdminUser(c *gc.C, modelname string, isS
 	model, err := modelManager.CreateModel(
 		modelname, s.AdminUserTag(c).Id(), "", "", names.CloudCredentialTag{}, map[string]interface{}{
 			"controller": isServer,
-		},
+		}, constraints.Value{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return model
@@ -67,7 +68,7 @@ func (s *cmdControllerSuite) createModelNormalUser(c *gc.C, modelname string, is
 		modelname, names.NewLocalUserTag("test").Id(), "", "", names.CloudCredentialTag{}, map[string]interface{}{
 			"authorized-keys": "ssh-key",
 			"controller":      isServer,
-		},
+		}, constraints.Value{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -146,7 +146,7 @@ type ModelCreateArgs struct {
 	CloudCredentialTag string `json:"credential,omitempty"`
 
 	// Constraints allows setting the initial model constraints when creating.
-	Constraints constraints.Value `json:"constraints,omitempty"`
+	Constraints *constraints.Value `json:"constraints,omitempty"`
 }
 
 // Model holds the result of an API call returning a name and UUID

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -144,6 +144,9 @@ type ModelCreateArgs struct {
 	// and the owner is the controller owner, the same credential
 	// used for the controller model will be used.
 	CloudCredentialTag string `json:"credential,omitempty"`
+
+	// Constraints allows setting the initial model constraints when creating.
+	Constraints constraints.Value `json:"constraints,omitempty"`
 }
 
 // Model holds the result of an API call returning a name and UUID

--- a/state/model.go
+++ b/state/model.go
@@ -454,6 +454,14 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 		return nil, nil, errors.Annotate(err, "could not start state for new model")
 	}
 
+	// Validate the constraints of a model cam only be done after the state
+	// of the model has been started. This can leave us with a model partially
+	// created, but we can use destroy model to clean it up, before attempting
+	// again.
+	if _, err = newSt.validateConstraints(args.Constraints); err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
 	newModel, err := newSt.Model()
 	if err != nil {
 		return nil, nil, errors.Trace(err)


### PR DESCRIPTION
Architecture is a fundamental key to the deployment of new charms, adding
constraints to `add-model` ensures that users can better control what charm
can land on the correct machine.

The main aim of this PR is to improve the usability of when deploying a
charm the reason fails. If the constraints of a model aren't set and we use the 
default arch constraints, it's better to help the user set valid defaults.

An additional PR will be proposed to improve the error messages of when
an application doesn't meet the constraints.

## QA steps

Invalid arch constraints.

```sh
juju add-model foo --constraints="arch=arm64"
ERROR failed to create new model: invalid constraint value: arch=arm64
valid values are: [amd64 i386]
```

```sh
juju add-model bar --constraints="arch=amd64"
Added 'bar' model on lxd/default with credential 'lxd' for user 'admin'
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1961396
