### PR TITLE
[JUJU-672] Retry more classes of Raft leader errors

### DIFF
--- a/apiserver/raft.go
+++ b/apiserver/raft.go
@@ -51,7 +51,7 @@ type raftMediator struct {
 
 // ApplyLease attempts to apply the command on to the raft FSM. It only takes a
 // command and enqueues that against the raft instance. If the raft instance is
-// already processing a application, then back pressure is applied to the
+// already processing an operation, then back pressure is applied to the
 // caller and a ErrEnqueueDeadlineExceeded will be sent. It's up to the caller
 // to retry or drop depending on how the retry algorithm is implemented.
 func (m *raftMediator) ApplyLease(ctx context.Context, cmd raftlease.Command) error {
@@ -95,8 +95,8 @@ func (m *raftMediator) ApplyLease(ctx context.Context, cmd raftlease.Command) er
 		return nil
 
 	case raft.IsNotLeaderError(err):
-		// Lift the worker NotLeaderError into the apiserver NotLeaderError. Ensure
-		// the correct boundaries.
+		// Lift the worker NotLeaderError into the apiserver NotLeaderError.
+		// Ensure the correct boundaries.
 		leaderErr := errors.Cause(err).(*raft.NotLeaderError)
 		m.logger.Tracef("Not currently the leader, go to %v %v", leaderErr.ServerAddress(), leaderErr.ServerID())
 		return apiservererrors.NewNotLeaderError(leaderErr.ServerAddress(), leaderErr.ServerID())
@@ -107,8 +107,8 @@ func (m *raftMediator) ApplyLease(ctx context.Context, cmd raftlease.Command) er
 		return apiservererrors.NewDeadlineExceededError(err.Error())
 
 	case queue.IsCanceled(err):
-		// If the apply lease is canceled from the context (facade), then let
-		// the original caller handle it correctly.
+		// If the operation is canceled from the context (facade),
+		// then let the original caller handle it correctly.
 		return apiservererrors.NewDeadlineExceededError(err.Error())
 
 	}

--- a/core/raft/queue/opqueue.go
+++ b/core/raft/queue/opqueue.go
@@ -16,13 +16,13 @@ const (
 	// EnqueueDefaultTimeout is the timeout for enqueueing an operation. If an
 	// operation can't be processed in the time, a ErrDeadlineExceeded is
 	// returned.
-	EnqueueDefaultTimeout time.Duration = time.Second * 3
+	EnqueueDefaultTimeout = time.Second * 3
 
 	// EnqueueExtendTimeout is the timeout for enqueueing an extended operation.
 	// We want a different timeout for extensions as we want to reduce the
 	// amount of application leadership churning. To give the operation a better
 	// chance of succeeding.
-	EnqueueExtendTimeout time.Duration = time.Second * 5
+	EnqueueExtendTimeout = time.Second * 5
 
 	// EnqueueBatchSize dictates how many operations can be processed at any
 	// one time.
@@ -127,7 +127,7 @@ func (q *OpQueue) Enqueue(op InOperation) error {
 }
 
 // Queue returns the queue of operations. Removing an item from the channel
-// will unblock to allow another to take it's place.
+// will unblock to allow another to take its place.
 func (q *OpQueue) Queue() <-chan []OutOperation {
 	return q.out
 }
@@ -244,7 +244,7 @@ type ringOp struct {
 }
 
 func makeRingOp(leaseType string, cmd []byte, stop func() <-chan struct{}, done func(error), now time.Time) ringOp {
-	// If we locate a extension in the queue, give it a larger timeout to prevent
+	// If we locate an extension in the queue, give it a larger timeout to prevent
 	// excessive lease churning.
 	timeout := EnqueueDefaultTimeout
 	if leaseType == "extend" {

--- a/worker/raft/metrics.go
+++ b/worker/raft/metrics.go
@@ -111,15 +111,6 @@ func (a *applierMetrics) Record(start time.Time, result string) {
 	}).Observe(elapsedMS)
 }
 
-// RecordLeaderError calls out that there was a leader error, so didn't
-// follow the usual flow.
-func (a *applierMetrics) RecordLeaderError(start time.Time) {
-	elapsedMS := float64(a.clock.Now().Sub(start)) / float64(time.Millisecond)
-	a.applications.With(prometheus.Labels{
-		"result": "leader-error",
-	}).Observe(elapsedMS)
-}
-
 // Describe is part of the prometheus.Collector interface.
 func (a *applierMetrics) Describe(ch chan<- *prometheus.Desc) {
 	a.applications.Describe(ch)

--- a/worker/raft/raft_mock_test.go
+++ b/worker/raft/raft_mock_test.go
@@ -125,15 +125,3 @@ func (mr *MockApplierMetricsMockRecorder) Record(arg0, arg1 interface{}) *gomock
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Record", reflect.TypeOf((*MockApplierMetrics)(nil).Record), arg0, arg1)
 }
-
-// RecordLeaderError mocks base method.
-func (m *MockApplierMetrics) RecordLeaderError(arg0 time.Time) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RecordLeaderError", arg0)
-}
-
-// RecordLeaderError indicates an expected call of RecordLeaderError.
-func (mr *MockApplierMetricsMockRecorder) RecordLeaderError(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordLeaderError", reflect.TypeOf((*MockApplierMetrics)(nil).RecordLeaderError), arg0)
-}


### PR DESCRIPTION
For API-based leases, the behaviour has been to pre-emptively check the Raft state prior to applying each operation, and if we are not running on the leader, return a `NotLeaderError`, which is interpreted downstream as being retry-able. 

However it is possible after checking state and verifying leadership, that we can get an error such as `raft.ErrLeadershipLost` while applying the log, which flows up and is not recognised as retry-able, causing the lease manager to bounce.

Here we remove the pre-emptive check along with its local dedicated metric and time tracking. Instead we check the Raft state *after* getting leadership-based errors, with the following benefits:
- The increased efficiency of not checking Raft state for *every* log application.
- We represent more of the leadership error types as `NotLeaderError`, meaning retry instead of lease manager crash and restart.

## QA steps

- Bootstrap with `--config features="[raft-api-leases]"`.
- `juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE;juju.worker.raft=TRACE;juju.worker.raft.raftforwarder=TRACE;juju.worker.raft.rafttransport=TRACE"`.
- Watch `debug-log -m controller`.
- `juju enable-ha`.
- `juju deploy ubuntu -n 3`.
- Normal operation will see logging with sections like this:
```
machine-0: 10:32:46 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
machine-0: 10:32:47 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
machine-0: 10:32:48 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
machine-0: 10:32:49 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
machine-0: 10:32:50 TRACE juju.worker.lease.raft [df51a1] machine-0 extending lease df51a145-6b04-434e-8abb-663951fcc757 for 1m0s
machine-0: 10:32:50 TRACE juju.worker.raft Dequeued 1 commands to be applied on the raft log
machine-0: 10:32:50 TRACE juju.worker.raft Applying command 0 version: 1
operation: extend
namespace: singular-controller
model-uuid: 847b5f2d-0dc6-440a-837e-86d7b0bc8ce8
lease: df51a145-6b04-434e-8abb-663951fcc757
holder: machine-0
duration: 1m0s
```
- Note that the lease clock updater runs on the Raft leader, in the case above, machine-0.
- Restart the leader node: `juju ssh -m controller 0 -- sudo reboot now`. You will probably have to reconnect your debug-log session.
- Observe a period of churn where you may see lines like this:
```
machine-2: 10:33:49 ERROR juju.worker.raft Raft future error: node is not the leader
machine-2: 10:33:49 INFO juju.worker.raft Attempt to apply the lease failed, we're not the leader. State: Follower, Leader: 10.161.87.110:17070
```
- Control plane should quiesce quite quickly, and normal lease operation will resume.
- (BONUS) Step down the Mongo primary and observe relatively quick resumption of quiesced state. 

## Documentation changes

None.

## Bug reference

N/A
