### PR TITLE
[JUJU-685] Prevent a panic in the uniter report

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -982,8 +982,14 @@ func (u *Uniter) Terminate() error {
 func (u *Uniter) Report() map[string]interface{} {
 	result := make(map[string]interface{})
 
-	result["unit"] = u.unit.Name()
-	result["relations"] = u.relationStateTracker.Report()
+	// We need to guard against attempting to report when setting up or dying,
+	// so we don't end up panic'ing with missing information.
+	if u.unit != nil {
+		result["unit"] = u.unit.Name()
+	}
+	if u.relationStateTracker != nil {
+		result["relations"] = u.relationStateTracker.Report()
+	}
 
 	return result
 }


### PR DESCRIPTION
If the uniter is coming up or is dead, yet you can report on it at just
the right time, it will panic when accessing the fields.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu
$ juju ssh 0
$ juju_engine_report
```
