### PR TITLE
[JUJU-686] Clean up error message for raft lease request

### DIFF
--- a/api/controller/raftlease/client.go
+++ b/api/controller/raftlease/client.go
@@ -542,7 +542,7 @@ func (r *remote) SetAddress(addr string) {
 // Request performs a request against a specific api.
 func (r *remote) Request(ctx context.Context, command *raftlease.Command) error {
 	if r.client == nil {
-		r.config.Logger.Errorf("No attached client instance; dropping command: %v", command)
+		r.config.Logger.Warningf("not currently connected to the controller raft engine; dropping lease command: %v", command)
 		return lease.ErrDropped
 	}
 


### PR DESCRIPTION
If we don't have a client yet and is expected to process a raft lease
command, we want the error (now warning) message to be less cryptic.

Dropped to a warning, as operators should be aware of the message, but
don't need to jump onto the error message itself. This should resolve
itself once a client has been connected.

## QA steps

Inorder to trigger the client issue is actually quite difficult but can be done via throttling the API client requests to other controllers. As this is just a change in log levels, it's probably sufficient to just ensure that normal operations are working correctly.

- Bootstrap with `--config features="[raft-api-leases]"`.
- `juju model-config -m controller logging-config="<root>=INFO;juju.worker.lease.raft=TRACE;juju.core.raftlease=TRACE;juju.worker.globalclockupdater.raft=TRACE;juju.worker.raft=TRACE;juju.worker.raft.raftforwarder=TRACE;juju.worker.raft.rafttransport=TRACE"`.
- Watch `debug-log -m controller`.
- `juju enable-ha`.
- `juju deploy ubuntu -n 3`.
- Normal operation will see logging with sections like this:
```
machine-0: 10:32:46 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
machine-0: 10:32:47 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
machine-0: 10:32:48 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
machine-0: 10:32:49 TRACE juju.worker.globalclockupdater.raft incremented lease clock by 1s
machine-0: 10:32:50 TRACE juju.worker.lease.raft [df51a1] machine-0 extending lease df51a145-6b04-434e-8abb-663951fcc757 for 1m0s
machine-0: 10:32:50 TRACE juju.worker.raft Dequeued 1 commands to be applied on the raft log
machine-0: 10:32:50 TRACE juju.worker.raft Applying command 0 version: 1
operation: extend
namespace: singular-controller
model-uuid: 847b5f2d-0dc6-440a-837e-86d7b0bc8ce8
lease: df51a145-6b04-434e-8abb-663951fcc757
holder: machine-0
duration: 1m0s
```

