### PR TITLE
Changes to image-check build subprocess.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,12 +232,15 @@ OPERATOR_IMAGE_PATH=sh -c '. "${PROJECT_DIR}/make_functions.sh"; operator_image_
 OPERATOR_IMAGE_RELEASE_PATH=sh -c '. "${PROJECT_DIR}/make_functions.sh"; operator_image_release_path "$$@"' operator_image_release_path
 UPDATE_MICROK8S_OPERATOR=sh -c '. "${PROJECT_DIR}/make_functions.sh"; microk8s_operator_update "$$@"' microk8s_operator_update
 
-image-check-build:
-ifeq ($(OPERATOR_IMAGE_BUILD_SRC),true)
-	make build
-else
-	@echo "skipping to build jujud bin, use existing one at ${JUJUD_BIN_DIR}/."
+image_check_prereq=build
+ifneq ($(OPERATOR_IMAGE_BUILD_SRC),true)
+	image_check_prereq=image-check-build-skip
 endif
+
+image-check-build: $(image_check_prereq)
+
+image-check-build-skip:
+	@echo "skipping to build jujud bin, use existing one at ${JUJUD_BIN_DIR}/."
 
 operator-image: image-check-build
 ## operator-image: Build operator image via docker


### PR DESCRIPTION
In the previous versions of our make file the operator image building
would determine if it was needed to build the Juju bin's and call a Make
subprocess to do the building.

This has the negative effect where Make options like -j 4 would not get
passed along slowing down the Make build. This change keeps the build in
the same process to maintain the env.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run:

```
make operator-image
```

## Documentation changes

N/A

## Bug reference

N/A
