### PR TITLE
[JUJU-600] Bump GCE default constraints;

### DIFF
--- a/provider/gce/environ_instance_test.go
+++ b/provider/gce/environ_instance_test.go
@@ -181,7 +181,7 @@ func (s *environInstSuite) TestParsePlacementUnknownDirective(c *gc.C) {
 }
 
 func (s *environInstSuite) TestPrecheckInstanceWithValidInstanceType(c *gc.C) {
-	typ := "n1-standard-1"
+	typ := "n1-standard-2"
 	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{
 		Constraints: constraints.Value{
 			InstanceType: &typ,
@@ -216,7 +216,7 @@ func (s *environInstSuite) TestListMachineTypes(c *gc.C) {
 	// If no zone is specified, no machine types will be pulled.
 	s.FakeConn.Zones = nil
 	_, err := s.Env.InstanceTypes(s.CallCtx, constraints.Value{})
-	c.Assert(err, gc.ErrorMatches, "no instance types in  matching constraints \"\"")
+	c.Assert(err, gc.ErrorMatches, "no instance types in  matching constraints \"cores=2 mem=2048M\"")
 
 	// If a non-empty list of zones is specified , we will make an API call
 	// to fetch the available machine types.

--- a/provider/gce/environ_policy_test.go
+++ b/provider/gce/environ_policy_test.go
@@ -44,7 +44,7 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 		google.NewZone("home-zone", google.StatusUp, "", ""),
 	}
 
-	cons := constraints.MustParse("instance-type=n1-standard-1 arch=amd64 root-disk=1G")
+	cons := constraints.MustParse("instance-type=n1-standard-2 arch=amd64 root-disk=1G")
 	placement := "zone=home-zone"
 	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: version.DefaultSupportedLTS(), Constraints: cons, Placement: placement})
 	c.Assert(err, jc.ErrorIsNil)
@@ -62,7 +62,7 @@ func (s *environPolSuite) TestPrecheckInstanceFullAPI(c *gc.C) {
 }
 
 func (s *environPolSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
-	cons := constraints.MustParse("instance-type=n1-standard-1")
+	cons := constraints.MustParse("instance-type=n1-standard-2")
 	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: version.DefaultSupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
@@ -76,7 +76,7 @@ func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 }
 
 func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
-	cons := constraints.MustParse("instance-type=n1-standard-1 root-disk=1G")
+	cons := constraints.MustParse("instance-type=n1-standard-2 root-disk=1G")
 	placement := ""
 	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: version.DefaultSupportedLTS(), Constraints: cons, Placement: placement})
 
@@ -84,7 +84,7 @@ func (s *environPolSuite) TestPrecheckInstanceDiskSize(c *gc.C) {
 }
 
 func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
-	cons := constraints.MustParse("instance-type=n1-standard-1 arch=i386")
+	cons := constraints.MustParse("instance-type=n1-standard-2 arch=i386")
 	err := s.Env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{Series: version.DefaultSupportedLTS(), Constraints: cons})
 
 	c.Check(err, jc.ErrorIsNil)
@@ -217,7 +217,7 @@ func (s *environPolSuite) TestConstraintsValidatorConflicts(c *gc.C) {
 	validator, err := s.Env.ConstraintsValidator(s.CallCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
-	cons := constraints.MustParse("instance-type=n1-standard-1")
+	cons := constraints.MustParse("instance-type=n1-standard-2")
 	// We do not check arch or container since there is only one valid
 	// value for each and will always match.
 	consFallback := constraints.MustParse("cores=2 cpu-power=1000 mem=10000 tags=bar")
@@ -225,7 +225,7 @@ func (s *environPolSuite) TestConstraintsValidatorConflicts(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// tags is not supported, but we're not validating here...
-	expected := constraints.MustParse("instance-type=n1-standard-1 tags=bar")
+	expected := constraints.MustParse("instance-type=n1-standard-2 tags=bar")
 	c.Check(merged, jc.DeepEquals, expected)
 }
 

--- a/provider/gce/instance_information.go
+++ b/provider/gce/instance_information.go
@@ -27,6 +27,12 @@ var (
 	// provides amd64 machine types. For more information see:
 	// https://cloud.google.com/compute/docs/cpu-platforms.
 	machArches = []string{arch.AMD64}
+
+	// minCpuCores is the assumed minimum CPU cores we prefer in order to run a server.
+	minCpuCores uint64 = 2
+
+	// minMemoryHeuristic is the assumed minimum amount of memory (in MB) we prefer in order to run a server (2GB)
+	minMemoryHeuristic uint64 = 2048
 )
 
 // InstanceTypes implements InstanceTypesFetcher
@@ -35,7 +41,12 @@ func (env *environ) InstanceTypes(ctx context.ProviderCallContext, c constraints
 	if err != nil {
 		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
 	}
-
+	if c.CpuCores == nil {
+		c.CpuCores = &minCpuCores
+	}
+	if c.Mem == nil {
+		c.Mem = &minMemoryHeuristic
+	}
 	matches, err := instances.MatchingInstanceTypes(allInstanceTypes, "", c)
 	if err != nil {
 		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)

--- a/provider/gce/instance_information.go
+++ b/provider/gce/instance_information.go
@@ -35,19 +35,22 @@ var (
 	minMemoryHeuristic uint64 = 2048
 )
 
+func ensureDefaultConstraints(c constraints.Value) constraints.Value {
+	if c.HasInstanceType() || c.HasCpuCores() || c.HasMem() {
+		return c
+	}
+	c.CpuCores = &minCpuCores
+	c.Mem = &minMemoryHeuristic
+	return c
+}
+
 // InstanceTypes implements InstanceTypesFetcher
 func (env *environ) InstanceTypes(ctx context.ProviderCallContext, c constraints.Value) (instances.InstanceTypesWithCostMetadata, error) {
 	allInstanceTypes, err := env.getAllInstanceTypes(ctx, clock.WallClock)
 	if err != nil {
 		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
 	}
-	if c.CpuCores == nil {
-		c.CpuCores = &minCpuCores
-	}
-	if c.Mem == nil {
-		c.Mem = &minMemoryHeuristic
-	}
-	matches, err := instances.MatchingInstanceTypes(allInstanceTypes, "", c)
+	matches, err := instances.MatchingInstanceTypes(allInstanceTypes, "", ensureDefaultConstraints(c))
 	if err != nil {
 		return instances.InstanceTypesWithCostMetadata{}, errors.Trace(err)
 	}


### PR DESCRIPTION
The current default constraint is `mem=1G`. For the GCE cloud, we will get `e2-micro` which only has `0.25` vCPUs.
It takes 5+mins(sometimes 10+mins) to run the cloud-init script on `e2-micro`.
So this PR bumps GCE default constraints to `cores=2 mem=2048M`, then we will get an `e2-small` which has `0.5 vCPUs`.

```log
2022-02-23 23:38:59,427 - util.py[DEBUG]: cloud-init mode 'modules' took 525.388 seconds (525.39)
```


```
{1969-12-31T16:00:00.000-08:00 false Efficient Instance, 2 vCPU (1/8 shared physical core) and 1 GB RAM 2 334002 0 compute#machineType 16 3072 1024 e2-micro}

{1969-12-31T16:00:00.000-08:00 false Efficient Instance, 2 vCPU (1/4 shared physical core) and 2 GB RAM 2 334003 0 compute#machineType 16 3072 2048 e2-small}
```

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju bootstrap google/us-west1 k1

$ juju --show-log deploy  cs:ubuntu

$ juju add-unit ubuntu
```

## Documentation changes

No

## Bug reference

None
