### PR TITLE
[JUJU-691] Raft notifier worker

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -286,6 +286,10 @@ type Config interface {
 	// performed after each write to the raft log.
 	NonSyncedWritesToRaftLog() bool
 
+	// BatchRaftFSM returns true if the raft calls should use the batching
+	// FSM.
+	BatchRaftFSM() bool
+
 	// AgentLogfileMaxSizeMB returns the maximum file size in MB of each
 	// agent/controller log file.
 	AgentLogfileMaxSizeMB() int
@@ -347,6 +351,10 @@ type configSetterOnly interface {
 	// SetNonSyncedWritesToRaftLog selects whether fsync calls are performed
 	// after each write to the raft log.
 	SetNonSyncedWritesToRaftLog(bool)
+
+	// SetBatchRaftFSM select whether raft should use the batching for writing
+	// to the FSM.
+	SetBatchRaftFSM(bool)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -422,6 +430,7 @@ type configInternal struct {
 	mongoMemoryProfile       string
 	jujuDBSnapChannel        string
 	nonSyncedWritesToRaftLog bool
+	batchRaftFSM             bool
 	agentLogfileMaxSizeMB    int
 	agentLogfileMaxBackups   int
 }
@@ -444,6 +453,7 @@ type AgentConfigParams struct {
 	MongoMemoryProfile       mongo.MemoryProfile
 	JujuDBSnapChannel        string
 	NonSyncedWritesToRaftLog bool
+	BatchRaftFSM             bool
 	AgentLogfileMaxSizeMB    int
 	AgentLogfileMaxBackups   int
 }
@@ -509,6 +519,7 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		mongoMemoryProfile:       configParams.MongoMemoryProfile.String(),
 		jujuDBSnapChannel:        configParams.JujuDBSnapChannel,
 		nonSyncedWritesToRaftLog: configParams.NonSyncedWritesToRaftLog,
+		batchRaftFSM:             configParams.BatchRaftFSM,
 		agentLogfileMaxSizeMB:    configParams.AgentLogfileMaxSizeMB,
 		agentLogfileMaxBackups:   configParams.AgentLogfileMaxBackups,
 	}
@@ -845,6 +856,16 @@ func (c *configInternal) NonSyncedWritesToRaftLog() bool {
 // SetNonSyncedWritesToRaftLog implements configSetterOnly.
 func (c *configInternal) SetNonSyncedWritesToRaftLog(nonSyncedWrites bool) {
 	c.nonSyncedWritesToRaftLog = nonSyncedWrites
+}
+
+// BatchRaftFSM implements Config.
+func (c *configInternal) BatchRaftFSM() bool {
+	return c.batchRaftFSM
+}
+
+// SetBatchRaftFSM implements configSetterOnly.
+func (c *configInternal) SetBatchRaftFSM(batchRaftFSM bool) {
+	c.batchRaftFSM = batchRaftFSM
 }
 
 // AgentLogfileMaxSizeMB implements Config.

--- a/cmd/containeragent/initialize/config.go
+++ b/cmd/containeragent/initialize/config.go
@@ -128,6 +128,10 @@ func (c *configFromEnv) NonSyncedWritesToRaftLog() bool {
 	panic("not implemented")
 }
 
+func (c *configFromEnv) BatchRaftFSM() bool {
+	panic("not implemented")
+}
+
 func (c *configFromEnv) AgentLogfileMaxSizeMB() int {
 	panic("not implemented")
 }

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -278,6 +278,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		}
 		agentConfig.SetJujuDBSnapChannel(args.ControllerConfig.JujuDBSnapChannel())
 		agentConfig.SetNonSyncedWritesToRaftLog(args.ControllerConfig.NonSyncedWritesToRaftLog())
+		agentConfig.SetBatchRaftFSM(args.ControllerConfig.BatchRaftFSM())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("cannot write agent config: %v", err)

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -83,6 +83,7 @@ import (
 	"github.com/juju/juju/worker/raft/raftclusterer"
 	"github.com/juju/juju/worker/raft/raftflag"
 	"github.com/juju/juju/worker/raft/raftforwarder"
+	"github.com/juju/juju/worker/raft/raftnotifier"
 	"github.com/juju/juju/worker/raft/rafttransport"
 	"github.com/juju/juju/worker/reboot"
 	"github.com/juju/juju/worker/restorewatcher"
@@ -774,16 +775,23 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Path:              "/raft",
 		})),
 
+		raftNotifyProxy: ifController(raftnotifier.Manifold(raftnotifier.ManifoldConfig{
+			StateName: stateName,
+			RaftName:  raftName,
+			Logger:    loggo.GetLogger("juju.worker.raft.raftnotifier"),
+			NewTarget: raftnotifier.NewTarget,
+			NewWorker: raftnotifier.NewWorker,
+		})),
+
 		raftName: ifFullyUpgraded(raft.Manifold(raft.ManifoldConfig{
 			ClockName:            clockName,
 			AgentName:            agentName,
 			TransportName:        raftTransportName,
-			StateName:            stateName,
 			FSM:                  config.LeaseFSM,
 			Logger:               loggo.GetLogger("juju.worker.raft"),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            raft.NewWorker,
-			NewTarget:            raft.NewTarget,
+			NewNotifyTarget:      raft.NewTarget,
 			Queue:                config.RaftOpQueue,
 			NewApplier:           raft.NewApplier,
 		})),
@@ -1177,6 +1185,7 @@ const (
 	raftFlagName      = "raft-leader-flag"
 	raftBackstopName  = "raft-backstop"
 	raftForwarderName = "raft-forwarder"
+	raftNotifyProxy   = "raft-notifier"
 
 	validCredentialFlagName = "valid-credential-flag"
 

--- a/controller/config.go
+++ b/controller/config.go
@@ -227,6 +227,9 @@ const (
 	// when writing to the raft log by setting this value to true.
 	NonSyncedWritesToRaftLog = "non-synced-writes-to-raft-log"
 
+	// BatchRaftFSM allows the operator to batch raft FSM calls.
+	BatchRaftFSM = "batch-raft-fsm"
+
 	// MigrationMinionWaitMax is the maximum time that the migration-master
 	// worker will wait for agents to report for a migration phase when
 	// executing a model migration.
@@ -373,6 +376,10 @@ const (
 	// non-synced-writes-to-raft-log value. It is set to false by default.
 	DefaultNonSyncedWritesToRaftLog = false
 
+	// DefaultBatchRaftFSM is the default value for batch-raft-fsm value.
+	// It is set to false by default.
+	DefaultBatchRaftFSM = false
+
 	// DefaultMigrationMinionWaitMax is the default value for
 	DefaultMigrationMinionWaitMax = "15m"
 )
@@ -425,6 +432,7 @@ var (
 		MaxCharmStateSize,
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
+		BatchRaftFSM,
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
@@ -476,6 +484,7 @@ var (
 		MaxCharmStateSize,
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
+		BatchRaftFSM,
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
@@ -1016,6 +1025,14 @@ func (c Config) NonSyncedWritesToRaftLog() bool {
 	return DefaultNonSyncedWritesToRaftLog
 }
 
+// BatchRaftFSM returns true if raft should use batch writing to the FSM.
+func (c Config) BatchRaftFSM() bool {
+	if v, ok := c[BatchRaftFSM]; ok {
+		return v.(bool)
+	}
+	return DefaultBatchRaftFSM
+}
+
 // MigrationMinionWaitMax returns a duration for the maximum time that the
 // migration-master worker should wait for migration-minion reports during
 // phases of a model migration.
@@ -1363,6 +1380,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxCharmStateSize:                schema.ForceInt(),
 	MaxAgentStateSize:                schema.ForceInt(),
 	NonSyncedWritesToRaftLog:         schema.Bool(),
+	BatchRaftFSM:                     schema.Bool(),
 	MigrationMinionWaitMax:           schema.String(),
 	ApplicationResourceDownloadLimit: schema.ForceInt(),
 	ControllerResourceDownloadLimit:  schema.ForceInt(),
@@ -1409,6 +1427,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxCharmStateSize:                DefaultMaxCharmStateSize,
 	MaxAgentStateSize:                DefaultMaxAgentStateSize,
 	NonSyncedWritesToRaftLog:         DefaultNonSyncedWritesToRaftLog,
+	BatchRaftFSM:                     DefaultBatchRaftFSM,
 	MigrationMinionWaitMax:           DefaultMigrationMinionWaitMax,
 	ApplicationResourceDownloadLimit: schema.Omit,
 	ControllerResourceDownloadLimit:  schema.Omit,
@@ -1598,6 +1617,10 @@ Use "caas-image-repo" instead.`,
 	NonSyncedWritesToRaftLog: {
 		Type:        environschema.Tbool,
 		Description: `Do not perform fsync calls after appending entries to the raft log. Disabling sync improves performance at the cost of reliability`,
+	},
+	BatchRaftFSM: {
+		Type:        environschema.Tbool,
+		Description: `Allow raft to use batch writing to the FSM.`,
 	},
 	MigrationMinionWaitMax: {
 		Type:        environschema.Tstring,

--- a/core/raft/notifyproxy/notifyproxy.go
+++ b/core/raft/notifyproxy/notifyproxy.go
@@ -1,0 +1,196 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package notifyproxy
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+	"gopkg.in/tomb.v2"
+)
+
+const (
+	// BufferSize is the amount of notifications to enqueue before dropping the
+	// oldest.
+	BufferSize int = 512
+)
+
+// NotifyType defines a notification type.
+type NotifyType string
+
+const (
+	// Claimed defines the claimed notification type.
+	Claimed NotifyType = "claimed"
+
+	// Expiries defines the expiries notification type.
+	Expiries NotifyType = "expiries"
+)
+
+// NotificationProxy allows notifications to be sent via a proxy, rather than
+// directly to state, allowing the decoupling of state to a given worker.
+type NotificationProxy interface {
+	// Notifications returns a channel of notifications from a given notify
+	// target.
+	Notifications() <-chan []Notification
+}
+
+// Notification defines a typed notification sent from the proxy.
+type Notification interface {
+	// Type returns the notification type.
+	Type() NotifyType
+
+	// ErrorResponse is used to notify the proxy call of any potential errors
+	// when sending.
+	ErrorResponse(error)
+}
+
+// ClaimedNote returns the information associated with a claimed request.
+type ClaimedNote struct {
+	Key      lease.Key
+	Holder   string
+	response func(error)
+}
+
+// Type returns the notification type.
+func (ClaimedNote) Type() NotifyType {
+	return Claimed
+}
+
+// ErrorResponse is used to notify the proxy call of any potential errors
+// when sending.
+func (n ClaimedNote) ErrorResponse(err error) {
+	if n.response != nil {
+		n.response(err)
+	}
+}
+
+// ExpiriesNote returns the information associated with a expiries request.
+type ExpiriesNote struct {
+	Expiries []raftlease.Expired
+	response func(error)
+}
+
+func (ExpiriesNote) Type() NotifyType {
+	return Expiries
+}
+
+// ErrorResponse is used to notify the proxy call of any potential errors
+// when sending.
+func (n ExpiriesNote) ErrorResponse(err error) {
+	if n.response != nil {
+		n.response(err)
+	}
+}
+
+type NotifyProxy struct {
+	tomb *tomb.Tomb
+	in   chan Notification
+	out  chan []Notification
+}
+
+// New creates a new NotifyProxy.
+func New() *NotifyProxy {
+	proxy := &NotifyProxy{
+		in:  make(chan Notification),
+		out: make(chan []Notification),
+	}
+	proxy.tomb.Go(proxy.loop)
+	return proxy
+}
+
+// Claimed will be called when a new lease has been claimed.
+func (p *NotifyProxy) Claimed(key lease.Key, holder string) error {
+	var err error
+	select {
+	case <-p.tomb.Dying():
+		return tomb.ErrDying
+	case <-p.tomb.Dead():
+		return p.tomb.Err()
+	case p.in <- ClaimedNote{
+		Key:    key,
+		Holder: holder,
+		response: func(e error) {
+			err = e
+		},
+	}:
+	}
+	return errors.Trace(err)
+}
+
+// Expiries will be called when a set of existing leases have expired.
+func (p *NotifyProxy) Expiries(expiries []raftlease.Expired) error {
+	var err error
+	select {
+	case <-p.tomb.Dying():
+		return tomb.ErrDying
+	case <-p.tomb.Dead():
+		return p.tomb.Err()
+	case p.in <- ExpiriesNote{
+		Expiries: expiries,
+		response: func(e error) {
+			err = e
+		},
+	}:
+	}
+	return errors.Trace(err)
+}
+
+// Notifications returns a channel of notifications from a given notify
+// target.
+func (p *NotifyProxy) Notifications() <-chan []Notification {
+	return p.out
+}
+
+// Close the NotifyProxy.
+func (p *NotifyProxy) Close() error {
+	p.Kill(nil)
+	return p.Wait()
+}
+
+// Kill puts the tomb in a dying state for the given reason,
+// closes the Dying channel, and sets Alive to false.
+func (p *NotifyProxy) Kill(reason error) {
+	p.tomb.Kill(reason)
+}
+
+// Wait blocks until all goroutines have finished running, and
+// then returns the reason for their death.
+func (p *NotifyProxy) Wait() error {
+	return p.tomb.Wait()
+}
+
+func (p *NotifyProxy) loop() error {
+	defer close(p.out)
+
+	out := p.out
+
+	var buffer []Notification
+	for {
+		select {
+		case <-p.tomb.Dying():
+			return tomb.ErrDying
+		case <-p.tomb.Dead():
+			return p.tomb.Err()
+		case note := <-p.in:
+			// This would be better a linked list, so that we can just grab
+			// the tail and drop the head.
+			if len(buffer) == BufferSize {
+				buffer = buffer[1:]
+			}
+			buffer = append(buffer, note)
+			out = p.out
+
+		case out <- buffer:
+			buffer = make([]Notification, 0)
+			out = nil
+
+		default:
+			// If there is no work to do, pause briefly
+			// so that this loop is not thrashing CPU.
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -103,6 +103,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			configNonSyncedWritesToRaftLog := controllerConfig.NonSyncedWritesToRaftLog()
 			nonSyncedWritesToRaftLogChanged := agentsNonSyncedWritesToRaftLog != configNonSyncedWritesToRaftLog
 
+			agentsBatchRaftFSM := agent.CurrentConfig().BatchRaftFSM()
+			configBatchRaftFSM := controllerConfig.BatchRaftFSM()
+			batchRaftFSMChanged := agentsBatchRaftFSM != configBatchRaftFSM
+
 			info, err := apiState.StateServingInfo()
 			if err != nil {
 				return nil, errors.Annotate(err, "getting state serving info")
@@ -133,6 +137,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 					logger.Debugf("setting non synced writes to raft log: %t => %t", agentsNonSyncedWritesToRaftLog, configNonSyncedWritesToRaftLog)
 					config.SetNonSyncedWritesToRaftLog(configNonSyncedWritesToRaftLog)
 				}
+				if batchRaftFSMChanged {
+					logger.Debugf("setting batch raft fsm: %t => %t", agentsBatchRaftFSM, configBatchRaftFSM)
+					config.SetBatchRaftFSM(configBatchRaftFSM)
+				}
 				return nil
 			})
 			if err != nil {
@@ -161,6 +169,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				MongoProfile:             configMongoMemoryProfile,
 				JujuDBSnapChannel:        configJujuDBSnapChannel,
 				NonSyncedWritesToRaftLog: configNonSyncedWritesToRaftLog,
+				BatchRaftFSM:             configBatchRaftFSM,
 				Logger:                   config.Logger,
 			})
 		},

--- a/worker/containerbroker/manifold.go
+++ b/worker/containerbroker/manifold.go
@@ -15,13 +15,6 @@ import (
 	"github.com/juju/juju/environs"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/worker_mock.go github.com/juju/worker/v3 Worker
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/dependency_mock.go github.com/juju/worker/v3/dependency Context
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/environs_mock.go github.com/juju/juju/environs LXDProfiler,InstanceBroker
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machine_lock_mock.go github.com/juju/juju/core/machinelock Lock
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/base_mock.go github.com/juju/juju/api/base APICaller
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/agent_mock.go github.com/juju/juju/agent Agent,Config
-
 // ManifoldConfig describes the resources used by a Tracker.
 type ManifoldConfig struct {
 	AgentName     string

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -150,6 +150,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/containerbroker/package_test.go
+++ b/worker/containerbroker/package_test.go
@@ -9,6 +9,13 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/worker_mock.go github.com/juju/worker/v3 Worker
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/dependency_mock.go github.com/juju/worker/v3/dependency Context
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/environs_mock.go github.com/juju/juju/environs LXDProfiler,InstanceBroker
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machine_lock_mock.go github.com/juju/juju/core/machinelock Lock
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/base_mock.go github.com/juju/juju/api/base APICaller
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/agent_mock.go github.com/juju/juju/agent Agent,Config
+
 func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -150,6 +150,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/instancemutater/package_test.go
+++ b/worker/instancemutater/package_test.go
@@ -9,6 +9,11 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/instancebroker_mock.go github.com/juju/juju/worker/instancemutater InstanceMutaterAPI
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/logger_mock.go github.com/juju/juju/worker/instancemutater Logger
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/namestag_mock.go github.com/juju/names/v4 Tag
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/instancemutater MutaterMachine
+
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -18,11 +18,6 @@ import (
 	"github.com/juju/juju/environs"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/instancebroker_mock.go github.com/juju/juju/worker/instancemutater InstanceMutaterAPI
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/logger_mock.go github.com/juju/juju/worker/instancemutater Logger
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/namestag_mock.go github.com/juju/names/v4 Tag
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/instancemutater MutaterMachine
-
 type InstanceMutaterAPI interface {
 	WatchMachines() (watcher.StringsWatcher, error)
 	Machine(tag names.MachineTag) (instancemutater.MutaterMachine, error)

--- a/worker/raft/manifold_test.go
+++ b/worker/raft/manifold_test.go
@@ -18,15 +18,12 @@ import (
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 	dt "github.com/juju/worker/v3/dependency/testing"
-	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/raft/notifyproxy"
 	"github.com/juju/juju/core/raft/queue"
 	"github.com/juju/juju/core/raftlease"
-	"github.com/juju/juju/state"
-	raftleasestore "github.com/juju/juju/state/raftlease"
 	statetesting "github.com/juju/juju/state/testing"
-	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/raft"
 )
@@ -34,19 +31,18 @@ import (
 type ManifoldSuite struct {
 	statetesting.StateSuite
 
-	manifold     dependency.Manifold
-	context      dependency.Context
-	agent        *mockAgent
-	transport    *coreraft.InmemTransport
-	clock        *testclock.Clock
-	fsm          *raft.SimpleFSM
-	logger       loggo.Logger
-	worker       *mockRaftWorker
-	stateTracker *stubStateTracker
-	target       raftlease.NotifyTarget
-	queue        *queue.OpQueue
-	apply        func(raft.Raft, raftlease.NotifyTarget, raft.ApplierMetrics, clock.Clock, raft.Logger) raft.LeaseApplier
-	stub         testing.Stub
+	manifold  dependency.Manifold
+	context   dependency.Context
+	agent     *mockAgent
+	transport *coreraft.InmemTransport
+	clock     *testclock.Clock
+	fsm       *raft.SimpleFSM
+	logger    loggo.Logger
+	worker    *mockRaftWorker
+	target    *notifyproxy.NotifyProxy
+	queue     *queue.OpQueue
+	apply     func(raft.Raft, raftlease.NotifyTarget, raft.ApplierMetrics, clock.Clock, raft.Logger) raft.LeaseApplier
+	stub      testing.Stub
 }
 
 var _ = gc.Suite(&ManifoldSuite{})
@@ -67,12 +63,8 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		r:  &coreraft.Raft{},
 		ls: &mockLogStore{},
 	}
-	s.target = &struct{ raftlease.NotifyTarget }{}
+	s.target = notifyproxy.New()
 	s.queue = queue.NewOpQueue(s.clock)
-	s.stateTracker = &stubStateTracker{
-		pool: s.StatePool,
-		done: make(chan struct{}),
-	}
 	s.apply = func(raft.Raft, raftlease.NotifyTarget, raft.ApplierMetrics, clock.Clock, raft.Logger) raft.LeaseApplier {
 		return nil
 	}
@@ -91,11 +83,9 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 		ClockName:     "clock",
 		AgentName:     "agent",
 		TransportName: "transport",
-		StateName:     "state",
 		FSM:           s.fsm,
 		Logger:        s.logger,
 		NewWorker:     s.newWorker,
-		NewTarget:     s.newTarget,
 		Queue:         s.queue,
 		NewApplier:    s.apply,
 	})
@@ -106,7 +96,6 @@ func (s *ManifoldSuite) newContext(overlay map[string]interface{}) dependency.Co
 		"agent":     s.agent,
 		"transport": s.transport,
 		"clock":     s.clock,
-		"state":     s.stateTracker,
 	}
 	for k, v := range overlay {
 		resources[k] = v
@@ -122,13 +111,8 @@ func (s *ManifoldSuite) newWorker(config raft.Config) (worker.Worker, error) {
 	return s.worker, nil
 }
 
-func (s *ManifoldSuite) newTarget(st *state.State, logger raftleasestore.Logger) raftlease.NotifyTarget {
-	s.stub.MethodCall(s, "NewTarget", st, logger)
-	return s.target
-}
-
 var expectedInputs = []string{
-	"clock", "agent", "transport", "state",
+	"clock", "agent", "transport",
 }
 
 func (s *ManifoldSuite) TestInputs(c *gc.C) {
@@ -159,33 +143,17 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.NewApplier = nil
 
 	c.Assert(config, jc.DeepEquals, raft.Config{
-		FSM:          s.fsm,
-		Logger:       s.logger,
-		StorageDir:   filepath.Join(s.agent.conf.dataDir, "raft"),
-		LocalID:      "99",
-		Transport:    s.transport,
-		Clock:        s.clock,
-		Queue:        s.queue,
-		NotifyTarget: s.target,
+		FSM:        s.fsm,
+		Logger:     s.logger,
+		StorageDir: filepath.Join(s.agent.conf.dataDir, "raft"),
+		LocalID:    "99",
+		Transport:  s.transport,
+		Clock:      s.clock,
+		Queue:      s.queue,
+		NewNotifyTarget: func() *notifyproxy.NotifyProxy {
+			return s.target
+		},
 	})
-}
-
-func (s *ManifoldSuite) TestStoppingWorkerReleasesState(c *gc.C) {
-	w := s.startWorkerClean(c)
-
-	s.stateTracker.CheckCallNames(c, "Use")
-	select {
-	case <-s.stateTracker.done:
-		c.Fatal("unexpected state release")
-	case <-time.After(coretesting.ShortWait):
-	}
-
-	// Stopping the worker should cause the state to
-	// eventually be released.
-	workertest.CleanKill(c, w)
-
-	s.stateTracker.waitDone(c)
-	s.stateTracker.CheckCallNames(c, "Use", "Done")
 }
 
 func (s *ManifoldSuite) TestOutput(c *gc.C) {
@@ -227,34 +195,4 @@ func (s *ManifoldSuite) startWorkerClean(c *gc.C) worker.Worker {
 	c.Assert(ok, gc.Equals, true)
 	c.Assert(cleanupW.Worker, gc.Equals, s.worker)
 	return w
-}
-
-type stubStateTracker struct {
-	testing.Stub
-	pool *state.StatePool
-	done chan struct{}
-}
-
-func (s *stubStateTracker) Use() (*state.StatePool, error) {
-	s.MethodCall(s, "Use")
-	return s.pool, s.NextErr()
-}
-
-func (s *stubStateTracker) Done() error {
-	s.MethodCall(s, "Done")
-	err := s.NextErr()
-	close(s.done)
-	return err
-}
-
-func (s *stubStateTracker) Report() map[string]interface{} {
-	return map[string]interface{}{"hey": "mum"}
-}
-
-func (s *stubStateTracker) waitDone(c *gc.C) {
-	select {
-	case <-s.done:
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out waiting for state to be released")
-	}
 }

--- a/worker/raft/raftnotifier/manifold.go
+++ b/worker/raft/raftnotifier/manifold.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftnotifier
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
+
+	"github.com/juju/juju/core/raft/notifyproxy"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/state"
+	raftleasestore "github.com/juju/juju/state/raftlease"
+	"github.com/juju/juju/worker/common"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+// ManifoldConfig holds the information necessary to run a raft
+// worker in a dependency.Engine.
+type ManifoldConfig struct {
+	StateName string
+	RaftName  string
+
+	Logger    Logger
+	NewWorker func(Config) (worker.Worker, error)
+	NewTarget func(*state.State, raftleasestore.Logger) raftlease.NotifyTarget
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if config.RaftName == "" {
+		return errors.NotValidf("error RaftName")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	if config.NewTarget == nil {
+		return errors.NotValidf("nil NewTarget")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run a raft worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.StateName,
+		},
+		Start: config.start,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var notifyProxy notifyproxy.NotificationProxy
+	if err := context.Get(config.RaftName, &notifyProxy); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker workerstate.StateTracker
+	if err := context.Get(config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	notifyTarget := config.NewTarget(statePool.SystemState(), config.Logger)
+
+	w, err := config.NewWorker(Config{
+		Logger:       config.Logger,
+		NotifyTarget: notifyTarget,
+	})
+	if err != nil {
+		_ = stTracker.Done()
+		return nil, errors.Trace(err)
+	}
+	return common.NewCleanupWorker(w, func() { _ = stTracker.Done() }), nil
+}
+
+// NewTarget creates a new lease notify target using the dependencies in a late
+// fashion.
+func NewTarget(st *state.State, logger raftleasestore.Logger) raftlease.NotifyTarget {
+	return st.LeaseNotifyTarget(logger)
+}

--- a/worker/raft/raftnotifier/worker.go
+++ b/worker/raft/raftnotifier/worker.go
@@ -1,0 +1,138 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftnotifier
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/catacomb"
+
+	"github.com/juju/juju/core/raft/notifyproxy"
+	"github.com/juju/juju/core/raftlease"
+)
+
+// Logger represents the logging methods called.
+type Logger interface {
+	Criticalf(message string, args ...interface{})
+	Warningf(message string, args ...interface{})
+	Errorf(message string, args ...interface{})
+	Infof(message string, args ...interface{})
+	Debugf(message string, args ...interface{})
+	Tracef(message string, args ...interface{})
+	Logf(level loggo.Level, message string, args ...interface{})
+	IsTraceEnabled() bool
+}
+
+// Config is the configuration required for running a raft worker.
+type Config struct {
+	// Logger is the logger for this worker.
+	Logger Logger
+
+	// NotifyProxy is a proxy for notifications for the notify target.
+	NotifyProxy notifyproxy.NotificationProxy
+
+	// NotifyTarget is used to notify the changes from the raft operation
+	// applications.
+	NotifyTarget raftlease.NotifyTarget
+}
+
+// Validate validates the raft worker configuration.
+func (config Config) Validate() error {
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.NotifyProxy == nil {
+		return errors.NotValidf("nil NotifyProxy")
+	}
+	if config.NotifyTarget == nil {
+		return errors.NotValidf("nil NotifyTarget")
+	}
+	return nil
+}
+
+// NewWorker returns a new raft worker, with the given configuration.
+func NewWorker(config Config) (worker.Worker, error) {
+	return newWorker(config)
+}
+
+func newWorker(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &Worker{
+		config: config,
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: func() error {
+			return w.loop()
+		},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Worker is a worker that manages a raft.Raft instance.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *Worker) loop() error {
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+
+		case changes := <-w.config.NotifyProxy.Notifications():
+			// TODO: (stickupkid): We should push these as a batch through
+			// the notify target.
+			for _, change := range changes {
+				switch change.Type() {
+				case notifyproxy.Claimed:
+					note := change.(notifyproxy.ClaimedNote)
+					err := w.config.NotifyTarget.Claimed(note.Key, note.Holder)
+
+					// We always want to sent the error response, so that the other
+					// end of the proxy can be notified if there was an error or
+					// not.
+					note.ErrorResponse(err)
+
+					// If there was an error, return out, so we get a fresh proxy
+					// state.
+					if err != nil {
+						return errors.Trace(err)
+					}
+
+				case notifyproxy.Expiries:
+					note := change.(notifyproxy.ExpiriesNote)
+					err := w.config.NotifyTarget.Expiries(note.Expiries)
+
+					// We always want to sent the error response, so that the other
+					// end of the proxy can be notified if there was an error or
+					// not.
+					note.ErrorResponse(err)
+
+					// If there was an error, return out, so we get a fresh proxy
+					// state.
+					if err != nil {
+						return errors.Trace(err)
+					}
+				}
+			}
+		}
+	}
+}

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -151,6 +151,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()
@@ -557,6 +571,20 @@ func (mr *MockConfigSetterMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfigSetter)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfigSetter) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigSetterMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfigSetter)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfigSetter) CACert() string {
 	m.ctrl.T.Helper()
@@ -808,6 +836,18 @@ func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) error {
 func (mr *MockConfigSetterMockRecorder) SetAPIHostPorts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIHostPorts", reflect.TypeOf((*MockConfigSetter)(nil).SetAPIHostPorts), arg0)
+}
+
+// SetBatchRaftFSM mocks base method.
+func (m *MockConfigSetter) SetBatchRaftFSM(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetBatchRaftFSM", arg0)
+}
+
+// SetBatchRaftFSM indicates an expected call of SetBatchRaftFSM.
+func (mr *MockConfigSetterMockRecorder) SetBatchRaftFSM(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBatchRaftFSM", reflect.TypeOf((*MockConfigSetter)(nil).SetBatchRaftFSM), arg0)
 }
 
 // SetCACert mocks base method.


### PR DESCRIPTION
The raft notifier worker isolates state away from the raft
implementation. The basic premise is that if state is bouncing, we don't
want raft bouncing. Keeping raft up prevents a lot of churn in
application leases.

The new notify proxy consumes notifications from raft and writes them to
a buffer. If a consumer to the proxy isn't listening, we just populate
the buffer. Then when the consumer is ready, it can consume the buffer.

## QA steps

*Please replace with how we can verify that the change works.*

```sh
QA steps here
```
