### PR TITLE
[JUJU-691] Raft batching FSM feature flag to agent config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -286,6 +286,10 @@ type Config interface {
 	// performed after each write to the raft log.
 	NonSyncedWritesToRaftLog() bool
 
+	// BatchRaftFSM returns true if the raft calls should use the batching
+	// FSM.
+	BatchRaftFSM() bool
+
 	// AgentLogfileMaxSizeMB returns the maximum file size in MB of each
 	// agent/controller log file.
 	AgentLogfileMaxSizeMB() int
@@ -347,6 +351,10 @@ type configSetterOnly interface {
 	// SetNonSyncedWritesToRaftLog selects whether fsync calls are performed
 	// after each write to the raft log.
 	SetNonSyncedWritesToRaftLog(bool)
+
+	// SetBatchRaftFSM select whether raft should use the batching for writing
+	// to the FSM.
+	SetBatchRaftFSM(bool)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -422,6 +430,7 @@ type configInternal struct {
 	mongoMemoryProfile       string
 	jujuDBSnapChannel        string
 	nonSyncedWritesToRaftLog bool
+	batchRaftFSM             bool
 	agentLogfileMaxSizeMB    int
 	agentLogfileMaxBackups   int
 }
@@ -444,6 +453,7 @@ type AgentConfigParams struct {
 	MongoMemoryProfile       mongo.MemoryProfile
 	JujuDBSnapChannel        string
 	NonSyncedWritesToRaftLog bool
+	BatchRaftFSM             bool
 	AgentLogfileMaxSizeMB    int
 	AgentLogfileMaxBackups   int
 }
@@ -509,6 +519,7 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		mongoMemoryProfile:       configParams.MongoMemoryProfile.String(),
 		jujuDBSnapChannel:        configParams.JujuDBSnapChannel,
 		nonSyncedWritesToRaftLog: configParams.NonSyncedWritesToRaftLog,
+		batchRaftFSM:             configParams.BatchRaftFSM,
 		agentLogfileMaxSizeMB:    configParams.AgentLogfileMaxSizeMB,
 		agentLogfileMaxBackups:   configParams.AgentLogfileMaxBackups,
 	}
@@ -845,6 +856,16 @@ func (c *configInternal) NonSyncedWritesToRaftLog() bool {
 // SetNonSyncedWritesToRaftLog implements configSetterOnly.
 func (c *configInternal) SetNonSyncedWritesToRaftLog(nonSyncedWrites bool) {
 	c.nonSyncedWritesToRaftLog = nonSyncedWrites
+}
+
+// BatchRaftFSM implements Config.
+func (c *configInternal) BatchRaftFSM() bool {
+	return c.batchRaftFSM
+}
+
+// SetBatchRaftFSM implements configSetterOnly.
+func (c *configInternal) SetBatchRaftFSM(batchRaftFSM bool) {
+	c.batchRaftFSM = batchRaftFSM
 }
 
 // AgentLogfileMaxSizeMB implements Config.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -387,6 +387,7 @@ var attributeParams = agent.AgentConfigParams{
 	Model:                    testing.ModelTag,
 	JujuDBSnapChannel:        "4.4/stable",
 	NonSyncedWritesToRaftLog: false,
+	BatchRaftFSM:             false,
 	AgentLogfileMaxSizeMB:    150,
 	AgentLogfileMaxBackups:   4,
 }
@@ -404,6 +405,7 @@ func (*suite) TestAttributes(c *gc.C) {
 	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, jujuversion.Current)
 	c.Assert(conf.JujuDBSnapChannel(), gc.Equals, "4.4/stable")
 	c.Assert(conf.NonSyncedWritesToRaftLog(), jc.IsFalse)
+	c.Assert(conf.BatchRaftFSM(), jc.IsFalse)
 	c.Assert(conf.AgentLogfileMaxSizeMB(), gc.Equals, 150)
 	c.Assert(conf.AgentLogfileMaxBackups(), gc.Equals, 4)
 }
@@ -713,4 +715,16 @@ func (*suite) TestSetSyncWritesToRaftLog(c *gc.C) {
 	conf.SetNonSyncedWritesToRaftLog(true)
 	nonSyncedWritesToRaftLog = conf.NonSyncedWritesToRaftLog()
 	c.Assert(nonSyncedWritesToRaftLog, jc.IsTrue, gc.Commentf("sync writes to raft log settings not updated"))
+}
+
+func (*suite) TestSetBatchRaftFSM(c *gc.C) {
+	conf, err := agent.NewAgentConfig(attributeParams)
+	c.Assert(err, jc.ErrorIsNil)
+
+	nonSyncedWritesToRaftLog := conf.BatchRaftFSM()
+	c.Assert(nonSyncedWritesToRaftLog, jc.IsFalse)
+
+	conf.SetBatchRaftFSM(true)
+	nonSyncedWritesToRaftLog = conf.BatchRaftFSM()
+	c.Assert(nonSyncedWritesToRaftLog, jc.IsTrue, gc.Commentf("batch raft FSM settings not updated"))
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -65,6 +65,7 @@ type format_2_0Serialization struct {
 	MongoMemoryProfile       string `yaml:"mongomemoryprofile,omitempty"`
 	JujuDBSnapChannel        string `yaml:"juju-db-snap-channel,omitempty"`
 	NonSyncedWritesToRaftLog bool   `yaml:"no-sync-writes-to-raft-log,omitempty"`
+	BatchRaftFSM             bool   `yaml:"batch-raft-fsm,omitempty"`
 }
 
 func init() {
@@ -117,6 +118,7 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 		agentLogfileMaxBackups: format.AgentLogfileMaxBackups,
 
 		nonSyncedWritesToRaftLog: format.NonSyncedWritesToRaftLog,
+		batchRaftFSM:             format.BatchRaftFSM,
 	}
 	if len(format.APIAddresses) > 0 {
 		config.apiDetails = &apiDetails{
@@ -195,6 +197,7 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		AgentLogfileMaxBackups: config.agentLogfileMaxBackups,
 
 		NonSyncedWritesToRaftLog: config.nonSyncedWritesToRaftLog,
+		BatchRaftFSM:             config.batchRaftFSM,
 	}
 	if config.servingInfo != nil {
 		format.ControllerCert = config.servingInfo.Cert

--- a/cmd/containeragent/initialize/config.go
+++ b/cmd/containeragent/initialize/config.go
@@ -128,6 +128,10 @@ func (c *configFromEnv) NonSyncedWritesToRaftLog() bool {
 	panic("not implemented")
 }
 
+func (c *configFromEnv) BatchRaftFSM() bool {
+	panic("not implemented")
+}
+
 func (c *configFromEnv) AgentLogfileMaxSizeMB() int {
 	panic("not implemented")
 }

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -278,6 +278,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		}
 		agentConfig.SetJujuDBSnapChannel(args.ControllerConfig.JujuDBSnapChannel())
 		agentConfig.SetNonSyncedWritesToRaftLog(args.ControllerConfig.NonSyncedWritesToRaftLog())
+		agentConfig.SetBatchRaftFSM(args.ControllerConfig.BatchRaftFSM())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("cannot write agent config: %v", err)

--- a/controller/config.go
+++ b/controller/config.go
@@ -227,6 +227,9 @@ const (
 	// when writing to the raft log by setting this value to true.
 	NonSyncedWritesToRaftLog = "non-synced-writes-to-raft-log"
 
+	// BatchRaftFSM allows the operator to batch raft FSM calls.
+	BatchRaftFSM = "batch-raft-fsm"
+
 	// MigrationMinionWaitMax is the maximum time that the migration-master
 	// worker will wait for agents to report for a migration phase when
 	// executing a model migration.
@@ -373,6 +376,10 @@ const (
 	// non-synced-writes-to-raft-log value. It is set to false by default.
 	DefaultNonSyncedWritesToRaftLog = false
 
+	// DefaultBatchRaftFSM is the default value for batch-raft-fsm value.
+	// It is set to false by default.
+	DefaultBatchRaftFSM = false
+
 	// DefaultMigrationMinionWaitMax is the default value for
 	DefaultMigrationMinionWaitMax = "15m"
 )
@@ -425,6 +432,7 @@ var (
 		MaxCharmStateSize,
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
+		BatchRaftFSM,
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
@@ -476,6 +484,7 @@ var (
 		MaxCharmStateSize,
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
+		BatchRaftFSM,
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
@@ -1016,6 +1025,14 @@ func (c Config) NonSyncedWritesToRaftLog() bool {
 	return DefaultNonSyncedWritesToRaftLog
 }
 
+// BatchRaftFSM returns true if raft should use batch writing to the FSM.
+func (c Config) BatchRaftFSM() bool {
+	if v, ok := c[BatchRaftFSM]; ok {
+		return v.(bool)
+	}
+	return DefaultBatchRaftFSM
+}
+
 // MigrationMinionWaitMax returns a duration for the maximum time that the
 // migration-master worker should wait for migration-minion reports during
 // phases of a model migration.
@@ -1363,6 +1380,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxCharmStateSize:                schema.ForceInt(),
 	MaxAgentStateSize:                schema.ForceInt(),
 	NonSyncedWritesToRaftLog:         schema.Bool(),
+	BatchRaftFSM:                     schema.Bool(),
 	MigrationMinionWaitMax:           schema.String(),
 	ApplicationResourceDownloadLimit: schema.ForceInt(),
 	ControllerResourceDownloadLimit:  schema.ForceInt(),
@@ -1409,6 +1427,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxCharmStateSize:                DefaultMaxCharmStateSize,
 	MaxAgentStateSize:                DefaultMaxAgentStateSize,
 	NonSyncedWritesToRaftLog:         DefaultNonSyncedWritesToRaftLog,
+	BatchRaftFSM:                     DefaultBatchRaftFSM,
 	MigrationMinionWaitMax:           DefaultMigrationMinionWaitMax,
 	ApplicationResourceDownloadLimit: schema.Omit,
 	ControllerResourceDownloadLimit:  schema.Omit,
@@ -1598,6 +1617,10 @@ Use "caas-image-repo" instead.`,
 	NonSyncedWritesToRaftLog: {
 		Type:        environschema.Tbool,
 		Description: `Do not perform fsync calls after appending entries to the raft log. Disabling sync improves performance at the cost of reliability`,
+	},
+	BatchRaftFSM: {
+		Type:        environschema.Tbool,
+		Description: `Allow raft to use batch writing to the FSM.`,
 	},
 	MigrationMinionWaitMax: {
 		Type:        environschema.Tstring,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -371,6 +371,12 @@ var newConfigTests = []struct {
 		},
 		expectError: `non-synced-writes-to-raft-log: expected bool, got string\("I live dangerously"\)`,
 	}, {
+		about: "invalid batch-raft-fsm - string",
+		config: controller.Config{
+			controller.BatchRaftFSM: "I live dangerously",
+		},
+		expectError: `batch-raft-fsm: expected bool, got string\("I live dangerously"\)`,
+	}, {
 		about: "public-dns-address: expect string, got number",
 		config: controller.Config{
 			controller.PublicDNSAddress: 42,

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -54,10 +54,6 @@ const ActionsV2 = "actions-v2"
 // Secrets enables the secrets feature.
 const Secrets = "secrets"
 
-// RaftBatchFSM will use the batching FSM instead of the singular FSM to attempt
-// to commit logs.
-const RaftBatchFSM = "raft-batch-fsm"
-
 // RaftAPILeases will switch all lease store management transport, currently
 // handled by Pubsub to facade API interaction.
 const RaftAPILeases = "raft-api-leases"

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -60,6 +60,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MaxCharmStateSize,
 		controller.MaxAgentStateSize,
 		controller.NonSyncedWritesToRaftLog,
+		controller.BatchRaftFSM,
 		controller.MigrationMinionWaitMax,
 		controller.AgentLogfileMaxBackups,
 		controller.AgentLogfileMaxSize,

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -103,6 +103,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			configNonSyncedWritesToRaftLog := controllerConfig.NonSyncedWritesToRaftLog()
 			nonSyncedWritesToRaftLogChanged := agentsNonSyncedWritesToRaftLog != configNonSyncedWritesToRaftLog
 
+			agentsBatchRaftFSM := agent.CurrentConfig().BatchRaftFSM()
+			configBatchRaftFSM := controllerConfig.BatchRaftFSM()
+			batchRaftFSMChanged := agentsBatchRaftFSM != configBatchRaftFSM
+
 			info, err := apiState.StateServingInfo()
 			if err != nil {
 				return nil, errors.Annotate(err, "getting state serving info")
@@ -133,6 +137,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 					logger.Debugf("setting non synced writes to raft log: %t => %t", agentsNonSyncedWritesToRaftLog, configNonSyncedWritesToRaftLog)
 					config.SetNonSyncedWritesToRaftLog(configNonSyncedWritesToRaftLog)
 				}
+				if batchRaftFSMChanged {
+					logger.Debugf("setting batch raft fsm: %t => %t", agentsBatchRaftFSM, configBatchRaftFSM)
+					config.SetBatchRaftFSM(configBatchRaftFSM)
+				}
 				return nil
 			})
 			if err != nil {
@@ -161,6 +169,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				MongoProfile:             configMongoMemoryProfile,
 				JujuDBSnapChannel:        configJujuDBSnapChannel,
 				NonSyncedWritesToRaftLog: configNonSyncedWritesToRaftLog,
+				BatchRaftFSM:             configBatchRaftFSM,
 				Logger:                   config.Logger,
 			})
 		},

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -357,6 +357,9 @@ type mockConfig struct {
 
 	nonSyncedWritesToRaftLog    bool
 	nonSyncedWritesToRaftLogSet bool
+
+	batchRaftFSM    bool
+	batchRaftFSMSet bool
 }
 
 func (mc *mockConfig) Tag() names.Tag {
@@ -410,6 +413,15 @@ func (mc *mockConfig) NonSyncedWritesToRaftLog() bool {
 func (mc *mockConfig) SetNonSyncedWritesToRaftLog(nonSynced bool) {
 	mc.nonSyncedWritesToRaftLog = nonSynced
 	mc.nonSyncedWritesToRaftLogSet = true
+}
+
+func (mc *mockConfig) BatchRaftFSM() bool {
+	return mc.batchRaftFSM
+}
+
+func (mc *mockConfig) SetBatchRaftFSM(batchRaftFSM bool) {
+	mc.batchRaftFSM = batchRaftFSM
+	mc.batchRaftFSMSet = true
 }
 
 func (mc *mockConfig) LogDir() string {

--- a/worker/containerbroker/manifold.go
+++ b/worker/containerbroker/manifold.go
@@ -15,13 +15,6 @@ import (
 	"github.com/juju/juju/environs"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/worker_mock.go github.com/juju/worker/v3 Worker
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/dependency_mock.go github.com/juju/worker/v3/dependency Context
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/environs_mock.go github.com/juju/juju/environs LXDProfiler,InstanceBroker
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machine_lock_mock.go github.com/juju/juju/core/machinelock Lock
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/base_mock.go github.com/juju/juju/api/base APICaller
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/agent_mock.go github.com/juju/juju/agent Agent,Config
-
 // ManifoldConfig describes the resources used by a Tracker.
 type ManifoldConfig struct {
 	AgentName     string

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -150,6 +150,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/containerbroker/package_test.go
+++ b/worker/containerbroker/package_test.go
@@ -9,6 +9,13 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/worker_mock.go github.com/juju/worker/v3 Worker
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/dependency_mock.go github.com/juju/worker/v3/dependency Context
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/environs_mock.go github.com/juju/juju/environs LXDProfiler,InstanceBroker
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machine_lock_mock.go github.com/juju/juju/core/machinelock Lock
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/base_mock.go github.com/juju/juju/api/base APICaller
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/agent_mock.go github.com/juju/juju/agent Agent,Config
+
 func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -150,6 +150,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/instancemutater/package_test.go
+++ b/worker/instancemutater/package_test.go
@@ -9,6 +9,11 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/instancebroker_mock.go github.com/juju/juju/worker/instancemutater InstanceMutaterAPI
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/logger_mock.go github.com/juju/juju/worker/instancemutater Logger
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/namestag_mock.go github.com/juju/names/v4 Tag
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/instancemutater MutaterMachine
+
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -18,11 +18,6 @@ import (
 	"github.com/juju/juju/environs"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/instancebroker_mock.go github.com/juju/juju/worker/instancemutater InstanceMutaterAPI
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/logger_mock.go github.com/juju/juju/worker/instancemutater Logger
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/namestag_mock.go github.com/juju/names/v4 Tag
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/instancemutater MutaterMachine
-
 type InstanceMutaterAPI interface {
 	WatchMachines() (watcher.StringsWatcher, error)
 	Machine(tag names.MachineTag) (instancemutater.MutaterMachine, error)

--- a/worker/raft/mock_test.go
+++ b/worker/raft/mock_test.go
@@ -26,6 +26,7 @@ type mockAgentConfig struct {
 	dataDir                  string
 	tag                      names.Tag
 	nonSyncedWritesToRaftLog bool
+	batchRaftFSM             bool
 }
 
 func (c *mockAgentConfig) Tag() names.Tag {
@@ -38,6 +39,10 @@ func (c *mockAgentConfig) DataDir() string {
 
 func (c *mockAgentConfig) NonSyncedWritesToRaftLog() bool {
 	return c.nonSyncedWritesToRaftLog
+}
+
+func (c *mockAgentConfig) BatchRaftFSM() bool {
+	return c.batchRaftFSM
 }
 
 type mockRaftWorker struct {

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -151,6 +151,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()
@@ -557,6 +571,20 @@ func (mr *MockConfigSetterMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfigSetter)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfigSetter) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigSetterMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfigSetter)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfigSetter) CACert() string {
 	m.ctrl.T.Helper()
@@ -808,6 +836,18 @@ func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) error {
 func (mr *MockConfigSetterMockRecorder) SetAPIHostPorts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIHostPorts", reflect.TypeOf((*MockConfigSetter)(nil).SetAPIHostPorts), arg0)
+}
+
+// SetBatchRaftFSM mocks base method.
+func (m *MockConfigSetter) SetBatchRaftFSM(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetBatchRaftFSM", arg0)
+}
+
+// SetBatchRaftFSM indicates an expected call of SetBatchRaftFSM.
+func (mr *MockConfigSetterMockRecorder) SetBatchRaftFSM(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBatchRaftFSM", reflect.TypeOf((*MockConfigSetter)(nil).SetBatchRaftFSM), arg0)
 }
 
 // SetCACert mocks base method.


### PR DESCRIPTION
The following moves the batching FSM from the controller config feature
flag to the agent config. This removes one of the dependencies from the
state dependencies from raft worker.

If raft doesn't depend on state, then if state restarts, raft stays up. This
will then prevent churn in the application leases.

## QA steps


```sh
$ juju bootstrap lxd test
$ juju controller-config batch-raft-fsm
false

$ juju controller-config batch-raft-fsm=true
$ juju controller-config batch-raft-fsm
true
$ juju debug-log -m controller --replay | grep "Using batching FSM for processing leases"

$ juju controller-config batch-raft-fsm=false
```
