### PR TITLE
[JUJU-697] Verify pointers before using them in Report.

### DIFF
--- a/state/pool.go
+++ b/state/pool.go
@@ -467,8 +467,12 @@ func (p *StatePool) IntrospectionReport() string {
 func (p *StatePool) Report() map[string]interface{} {
 	p.mu.Lock()
 	report := make(map[string]interface{})
-	report["txn-watcher"] = p.watcherRunner.Report()
-	report["system"] = p.systemState.Report()
+	if p.watcherRunner != nil {
+		report["txn-watcher"] = p.watcherRunner.Report()
+	}
+	if p.systemState != nil {
+		report["system"] = p.systemState.Report()
+	}
 	report["pool-size"] = len(p.pool)
 	for uuid, item := range p.pool {
 		modelReport := item.state.Report()

--- a/state/state.go
+++ b/state/state.go
@@ -2339,6 +2339,9 @@ func (st *State) AliveRelationKeys() []string {
 // Report conforms to the Dependency Engine Report() interface, giving an opportunity to introspect
 // what is going on at runtime.
 func (st *State) Report() map[string]interface{} {
+	if st.workers == nil {
+		return nil
+	}
 	return st.workers.Report()
 }
 

--- a/worker/deployer/nested.go
+++ b/worker/deployer/nested.go
@@ -294,14 +294,13 @@ func (c *nestedContext) Wait() error {
 func (c *nestedContext) Report() map[string]interface{} {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	running := c.runner.Report()
 
 	deployed := c.deployedUnits()
-	stopped := c.stoppedUnits()
-
 	result := map[string]interface{}{
 		"deployed": deployed.SortedValues(),
-		"units":    running,
+	}
+	if c.runner != nil {
+		result["units"] = c.runner.Report()
 	}
 	if len(c.errors) > 0 {
 		errors := make(map[string]string)
@@ -310,6 +309,7 @@ func (c *nestedContext) Report() map[string]interface{} {
 		}
 		result["errors"] = errors
 	}
+	stopped := c.stoppedUnits()
 	if len(stopped) > 0 {
 		result["stopped"] = stopped.SortedValues()
 	}

--- a/worker/httpserver/worker.go
+++ b/worker/httpserver/worker.go
@@ -137,7 +137,9 @@ func (w *Worker) Report() map[string]interface{} {
 	result := map[string]interface{}{
 		"api-port": w.config.APIPort,
 		"status":   w.status,
-		"ports":    w.holdable.report(),
+	}
+	if w.holdable != nil {
+		result["ports"] = w.holdable.report()
 	}
 	if w.config.ControllerAPIPort != 0 {
 		result["api-port-open-delay"] = w.config.APIPortOpenDelay

--- a/worker/modelcache/worker.go
+++ b/worker/modelcache/worker.go
@@ -163,6 +163,9 @@ func NewWorker(config Config) (worker.Worker, error) {
 
 // Report returns information that is used in the dependency engine report.
 func (c *cacheWorker) Report() map[string]interface{} {
+	if c.controller == nil {
+		return nil
+	}
 	return c.controller.Report()
 }
 

--- a/worker/modelworkermanager/modelworkermanager.go
+++ b/worker/modelworkermanager/modelworkermanager.go
@@ -283,5 +283,8 @@ func isModelActive(m Model) bool {
 
 // Report shows up in the dependency engine report.
 func (m *modelWorkerManager) Report() map[string]interface{} {
+	if m.runner == nil {
+		return nil
+	}
 	return m.runner.Report()
 }

--- a/worker/multiwatcher/worker.go
+++ b/worker/multiwatcher/worker.go
@@ -158,11 +158,14 @@ func (w *Worker) Report() map[string]interface{} {
 	for _, err := range w.errors {
 		errors = append(errors, err.Error())
 	}
-	queueSize := w.pending.Len()
 	var queueAge float64
-	if front, exists := w.pending.Front(); exists {
-		entry := front.(*queueEntry)
-		queueAge = w.config.Clock.Now().Sub(entry.created).Seconds()
+	var queueSize int
+	if w.pending != nil {
+		queueSize = w.pending.Len()
+		if front, exists := w.pending.Front(); exists {
+			entry := front.(*queueEntry)
+			queueAge = w.config.Clock.Now().Sub(entry.created).Seconds()
+		}
 	}
 	w.mu.Unlock()
 

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -237,6 +237,9 @@ func (w *pgWorker) Wait() error {
 
 // Report is shown in the engine report.
 func (w *pgWorker) Report() map[string]interface{} {
+	if w.metrics == nil {
+		return nil
+	}
 	return w.metrics.report()
 }
 

--- a/worker/pubsub/remoteserver.go
+++ b/worker/pubsub/remoteserver.go
@@ -108,12 +108,17 @@ func (r *remoteServer) Report() map[string]interface{} {
 	} else {
 		status = "connected"
 	}
-	return map[string]interface{}{
-		"status":    status,
-		"addresses": r.info.Addrs,
-		"queue-len": r.pending.Len(),
-		"sent":      r.sent,
+	result := map[string]interface{}{
+		"status": status,
+		"sent":   r.sent,
 	}
+	if r.info != nil {
+		result["addresses"] = r.info.Addrs
+	}
+	if r.pending != nil {
+		result["queue-len"] = r.pending.Len()
+	}
+	return result
 }
 
 // IntrospectionReport is the method called by the subscriber to get

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -689,18 +689,25 @@ func (w *remoteApplicationWorker) Report() map[string]interface{} {
 
 	relationsInfo := make(map[string]interface{})
 	for rel, info := range w.relations {
-		relationsInfo[rel] = map[string]interface{}{
-			"relation-id":        info.relationId,
-			"local-dead":         info.localDead,
-			"suspended":          info.suspended,
-			"application-token":  info.applicationToken,
-			"relation-token":     info.relationToken,
-			"local-endpoint":     info.localEndpoint.Name,
-			"remote-endpoint":    info.remoteEndpointName,
-			"last-status-event":  info.remoteRrw.Report(),
-			"last-local-change":  info.localRuw.Report(),
-			"last-remote-change": info.remoteRuw.Report(),
+		report := map[string]interface{}{
+			"relation-id":       info.relationId,
+			"local-dead":        info.localDead,
+			"suspended":         info.suspended,
+			"application-token": info.applicationToken,
+			"relation-token":    info.relationToken,
+			"local-endpoint":    info.localEndpoint.Name,
+			"remote-endpoint":   info.remoteEndpointName,
 		}
+		if info.remoteRrw != nil {
+			report["last-status-event"] = info.remoteRrw.Report()
+		}
+		if info.localRuw != nil {
+			report["last-local-change"] = info.localRuw.Report()
+		}
+		if info.remoteRuw != nil {
+			report["last-remote-change"] = info.remoteRuw.Report()
+		}
+		relationsInfo[rel] = report
 	}
 	if len(relationsInfo) > 0 {
 		result["relations"] = relationsInfo

--- a/worker/state/statetracker.go
+++ b/worker/state/statetracker.go
@@ -81,5 +81,8 @@ func (c *stateTracker) Done() error {
 func (c *stateTracker) Report() map[string]interface{} {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.pool == nil {
+		return nil
+	}
 	return c.pool.Report()
 }

--- a/worker/uniter/relation/statetracker.go
+++ b/worker/uniter/relation/statetracker.go
@@ -497,7 +497,15 @@ func (r *relationStateTracker) LocalUnitAndApplicationLife() (life.Value, life.V
 func (r *relationStateTracker) Report() map[string]interface{} {
 	result := make(map[string]interface{})
 
-	for id, st := range r.stateMgr.(*stateManager).relationState {
+	stateMgr, ok := r.stateMgr.(*stateManager)
+	if !ok {
+		return nil
+	}
+	stateMgr.mu.Lock()
+	relationState := stateMgr.relationState
+	stateMgr.mu.Unlock()
+
+	for id, st := range relationState {
 		report := map[string]interface{}{
 			"application-members": st.ApplicationMembers,
 			"members":             st.Members,


### PR DESCRIPTION
Follow on to #13789 

If the uniter is coming up or is dead, yet you can report on it at just the right time, it will panic when accessing the fields.  Guard against the potential of this happening in other Report methods.

## QA steps

Bootstrap and run juju_engine_report on the controller and one other juju machine
