### PR TITLE
Updating fallback clouds for Google.

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -104,6 +104,8 @@ clouds:
         endpoint: https://www.googleapis.com
       australia-southeast1:
         endpoint: https://www.googleapis.com
+      europe-central2:
+        endpoint: https://www.googleapis.com
       europe-north1:
         endpoint: https://www.googleapis.com
       europe-west1:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -111,6 +111,8 @@ clouds:
         endpoint: https://www.googleapis.com
       australia-southeast1:
         endpoint: https://www.googleapis.com
+      europe-central2:
+        endpoint: https://www.googleapis.com
       europe-north1:
         endpoint: https://www.googleapis.com
       europe-west1:


### PR DESCRIPTION
Adding support for missing Google Cloud Region europe-central2. This
was reported as missing at the Frankfurt sprint and is stopping people
from using this region for GKE deployments.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Easiest way to do this is to add a gke cluster in the europe-central2 region and check that it succeeds.

## Documentation changes

N/A

## Bug reference

N/A
