### PR TITLE
Reduce logging level for link-layer device updates

### DIFF
--- a/apiserver/common/networkingcommon/linklayer.go
+++ b/apiserver/common/networkingcommon/linklayer.go
@@ -170,7 +170,7 @@ type MachineLinkLayerOp struct {
 // NewMachineLinkLayerOp returns a reference that can be embedded in a
 // model operation for updating the input machine's link layer data.
 func NewMachineLinkLayerOp(source string, machine LinkLayerMachine, in network.InterfaceInfos) *MachineLinkLayerOp {
-	logger.Infof(
+	logger.Debugf(
 		"processing %s-sourced link-layer devices for machine %q in model %q",
 		source, machine.Id(), machine.ModelUUID(),
 	)


### PR DESCRIPTION
link-layer updates were spamming logs. Reduce their log level to debug

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/apiserver/common/networkingcommon
```

## Documentation changes

N/A

## Bug reference

N/A