### PR TITLE
Pass macaroons from cookiejar

### DIFF
--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -244,6 +245,20 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 					Macaroons: accountDetails.Macaroons,
 				}
 			}
+		} else if len(accountDetails.Macaroons) == 0 {
+			jar, err := store.CookieJar(controllerName)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			controllerDetails, err := store.ControllerByName(controllerName)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			accountDetails.Macaroons = httpbakery.MacaroonsForURL(jar, &url.URL{
+				Scheme: "https",
+				Host:   controllerDetails.ControllerUUID,
+				Path:   "/",
+			})
 		}
 	}
 


### PR DESCRIPTION
The following passes the macaroons for all http(s) requests if you
logout and then login. Unfortunately, it looks like we don't use the
cookie jar when opening up the API for normal HTTP requests.

The change is flawed. It prevents the locating of macaroons by
only using the controller UUID and we fail to correctly use 
`SNIHostName` or the `dialResult.addr` as a fallback if we don't
have a controller UUID.

The api.state/Open has the cookie URL, but doesn't have access to
the store which has the cookie jar. It might be worth thinking about
passing the store through api.Info, although that feels dangerous
and causes a leaky abstraction. 

## QA steps

The following should work without a password.

```sh
$ juju bootstrap lxd test
$ juju change-user-password admin
$ juju logout
$ juju login
$ juju deploy mysql
$ juju download mysql
$ juju deploy ./mysql_*.charm
```

## Bug reference

N/A
