### PR TITLE
[JUJU-711] Fix upgrade step to correctly set external controller ref counts

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3953,6 +3953,7 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 		return errors.Trace(err)
 	}
 
+	refCountPerController := make(map[string]int)
 	err := errors.Trace(runForAllModelStates(pool, func(st *State) error {
 		remoteApps, rCloser := st.db().GetCollection(remoteApplicationsC)
 		defer rCloser()
@@ -3982,11 +3983,7 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 					"source-controller-uuid", controllerUUID}},
 				}},
 			})
-			incRefOp, err := incExternalControllersRefOp(st, controllerUUID)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			ops = append(ops, incRefOp)
+			refCountPerController[controllerUUID] = refCountPerController[controllerUUID] + 1
 		}
 		if err := iter.Close(); err != nil {
 			return errors.Trace(err)
@@ -4004,6 +4001,21 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 		return errors.Trace(err)
 	}
 
+	var ops []txn.Op
+	for controllerUUID, refCount := range refCountPerController {
+		incRefOp, err := setExternalControllersRefOp(st, controllerUUID, refCount)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		ops = append(ops, incRefOp)
+	}
+	if len(ops) > 0 {
+		err := st.db().RunTransaction(ops)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	if orphanedControllers.Size() > 0 {
 		_, err := extControllers.Writeable().RemoveAll(bson.D{
 			{"_id", bson.D{{"$in", orphanedControllers.Values()}}},
@@ -4013,6 +4025,22 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 		}
 	}
 	return nil
+}
+
+// setExternalControllersRefOp returns a txn.Op that sets the reference
+// count for an external controller, incrementing any existing value as needed.
+// These ref counts are controller wide.
+func setExternalControllersRefOp(mb modelBackend, controllerUUID string, count int) (txn.Op, error) {
+	refcounts, closer := mb.db().GetCollection(globalRefcountsC)
+	defer closer()
+	refCountKey := externalControllerRefCountKey(controllerUUID)
+	existing, err := nsRefcounts.read(refcounts, refCountKey)
+	if err != nil && !errors.IsNotFound(err) {
+		return txn.Op{}, errors.Trace(err)
+	}
+	newCount := count - existing
+	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, refCountKey, newCount)
+	return incRefOp, errors.Trace(err)
 }
 
 // RemoveInvalidCharmPlaceholders removes invalid charms that have invalid charm

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5991,17 +5991,22 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
 		Name:        "remote-application2",
+		SourceModel: names.NewModelTag(modelUUID1),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
+		Name:        "remote-application3",
 		SourceModel: names.NewModelTag(modelUUID2),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
-		Name:            "remote-application3",
+		Name:            "remote-application4",
 		SourceModel:     names.NewModelTag(modelUUID1),
 		IsConsumerProxy: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = model1.AddRemoteApplication(AddRemoteApplicationParams{
-		Name:        "remote-application4",
+		Name:        "remote-application5",
 		SourceModel: names.NewModelTag(modelUUID1),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -6031,18 +6036,32 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"name":                   "remote-application2",
 			"offer-uuid":             "",
 			"relationcount":          0,
-			"source-controller-uuid": "",
-			"source-model-uuid":      modelUUID2,
+			"source-controller-uuid": extControllerUUID,
+			"source-model-uuid":      modelUUID1,
 			"spaces":                 []interface{}{},
 		},
 		{
 			"_id":                    model0.docID("remote-application3"),
 			"bindings":               bson.M{},
 			"endpoints":              []interface{}{},
-			"is-consumer-proxy":      true,
+			"is-consumer-proxy":      false,
 			"life":                   0,
 			"model-uuid":             model0.modelUUID(),
 			"name":                   "remote-application3",
+			"offer-uuid":             "",
+			"relationcount":          0,
+			"source-controller-uuid": "",
+			"source-model-uuid":      modelUUID2,
+			"spaces":                 []interface{}{},
+		},
+		{
+			"_id":                    model0.docID("remote-application4"),
+			"bindings":               bson.M{},
+			"endpoints":              []interface{}{},
+			"is-consumer-proxy":      true,
+			"life":                   0,
+			"model-uuid":             model0.modelUUID(),
+			"name":                   "remote-application4",
 			"offer-uuid":             "",
 			"relationcount":          0,
 			"source-controller-uuid": "",
@@ -6050,13 +6069,13 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"spaces":                 []interface{}{},
 		},
 		{
-			"_id":                    model1.docID("remote-application4"),
+			"_id":                    model1.docID("remote-application5"),
 			"bindings":               bson.M{},
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      false,
 			"life":                   0,
 			"model-uuid":             model1.modelUUID(),
-			"name":                   "remote-application4",
+			"name":                   "remote-application5",
 			"offer-uuid":             "",
 			"relationcount":          0,
 			"source-controller-uuid": extControllerUUID,
@@ -6072,6 +6091,14 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 		upgradedData(appColl, expectedApps),
 	)
 
+	// Check the ref counts.
+	refcounts, closer := s.state.db().GetCollection(globalRefcountsC)
+	defer closer()
+	key := externalControllerRefCountKey(extControllerUUID)
+	count, err := nsRefcounts.read(refcounts, key)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(count, gc.Equals, 3)
+
 	// Check the orphaned controller is removed and we still have
 	// the in use controller.
 	ec = NewExternalControllers(s.state)
@@ -6079,6 +6106,91 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	_, err = ec.Controller(extControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradesSuite) TestUpdateExternalControllerInfoFixRefCount(c *gc.C) {
+	model0 := s.makeModel(c, "model-0", coretesting.Attrs{})
+	defer func() {
+		_ = model0.Close()
+	}()
+
+	extControllerUUID := utils.MustNewUUID().String()
+	modelUUID1 := utils.MustNewUUID().String()
+
+	ec := NewExternalControllers(s.state)
+	_, err := ec.Save(crossmodel.ControllerInfo{
+		ControllerTag: names.NewControllerTag(extControllerUUID),
+		Addrs:         []string{"10.0.0.1:17070"},
+	}, modelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = ec.Save(crossmodel.ControllerInfo{
+		ControllerTag: coretesting.ControllerTag,
+		Addrs:         []string{"10.0.0.2:17070"},
+	}, coretesting.ModelTag.Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
+		Name:        "remote-application",
+		SourceModel: names.NewModelTag(modelUUID1),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
+		Name:        "remote-application2",
+		SourceModel: names.NewModelTag(modelUUID1),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add a bad ref count.
+	refcounts, closer := s.state.db().GetCollection(globalRefcountsC)
+	defer closer()
+	key := externalControllerRefCountKey(extControllerUUID)
+	op, err := nsRefcounts.CreateOrIncRefOp(refcounts, key, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.state.db().RunTransaction([]txn.Op{op})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedApps := bsonMById{
+		{
+			"_id":                    model0.docID("remote-application"),
+			"bindings":               bson.M{},
+			"endpoints":              []interface{}{},
+			"is-consumer-proxy":      false,
+			"life":                   0,
+			"model-uuid":             model0.modelUUID(),
+			"name":                   "remote-application",
+			"offer-uuid":             "",
+			"relationcount":          0,
+			"source-controller-uuid": extControllerUUID,
+			"source-model-uuid":      modelUUID1,
+			"spaces":                 []interface{}{},
+		},
+		{
+			"_id":                    model0.docID("remote-application2"),
+			"bindings":               bson.M{},
+			"endpoints":              []interface{}{},
+			"is-consumer-proxy":      false,
+			"life":                   0,
+			"model-uuid":             model0.modelUUID(),
+			"name":                   "remote-application2",
+			"offer-uuid":             "",
+			"relationcount":          0,
+			"source-controller-uuid": extControllerUUID,
+			"source-model-uuid":      modelUUID1,
+			"spaces":                 []interface{}{},
+		},
+	}
+	sort.Sort(expectedApps)
+
+	appColl, aCloser := s.state.db().GetRawCollection(remoteApplicationsC)
+	defer aCloser()
+	s.assertUpgradedData(c, UpdateExternalControllerInfo,
+		upgradedData(appColl, expectedApps),
+	)
+
+	// Check the ref counts.
+	count, err := nsRefcounts.read(refcounts, key)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(count, gc.Equals, 2)
 }
 
 func (s *upgradesSuite) TestRemoveInvalidCharmPlaceholders(c *gc.C) {

--- a/upgrades/steps_2924.go
+++ b/upgrades/steps_2924.go
@@ -7,13 +7,6 @@ package upgrades
 func stateStepsFor2924() []Step {
 	return []Step{
 		&upgradeStep{
-			description: "update remote application external controller info",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return context.State().UpdateExternalControllerInfo()
-			},
-		},
-		&upgradeStep{
 			description: "remove invalid charm placeholders",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps_2924_test.go
+++ b/upgrades/steps_2924_test.go
@@ -20,11 +20,6 @@ type steps2924Suite struct {
 
 var _ = gc.Suite(&steps2924Suite{})
 
-func (s *steps2924Suite) TestUpdateExternalControllerInfo(c *gc.C) {
-	step := findStateStep(c, v2924, "update remote application external controller info")
-	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
-}
-
 func (s *steps2924Suite) TestRemoveInvalidCharmPlaceholders(c *gc.C) {
 	step := findStateStep(c, v2924, "remove invalid charm placeholders")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})

--- a/upgrades/steps_2926.go
+++ b/upgrades/steps_2926.go
@@ -20,5 +20,12 @@ func stateStepsFor2926() []Step {
 				return context.State().UpdateCharmOriginAfterSetSeries()
 			},
 		},
+		&upgradeStep{
+			description: "update remote application external controller info",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().UpdateExternalControllerInfo()
+			},
+		},
 	}
 }

--- a/upgrades/steps_2926_test.go
+++ b/upgrades/steps_2926_test.go
@@ -29,3 +29,8 @@ func (s *steps2926Suite) TestUpdateCharmOriginAfterSetSeries(c *gc.C) {
 	step := findStateStep(c, v2926, "update charm origin to facilitate charm refresh after set-series")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps2926Suite) TestUpdateExternalControllerInfo(c *gc.C) {
+	step := findStateStep(c, v2926, "update remote application external controller info")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}


### PR DESCRIPTION
We now track whether an external controller has references to it from remote applications records for CMR. An upgrade step set up the ref count based on what was in the model, but there was an error resulting in setting the ref count to 1 always.

This PR fixes the upgrade step.

## QA steps

In juju 2.9.22
create a cross controller cmr scenario where a consuming model uses more than one offer from the other controller

```
juju bootstrap aws c1 --agent-version=2.9.22
juju bootstrap aws c2 --agent-version=2.9.22
juju deploy mariadb && juju offer mariadb:db
juju deploy postgresql && juju offer postgresql:db

juju switch c1
juju consume c2:default.mariadb
juju consume c2:default.postgresql
```

Upgrade to this PR
check the ref count for the external controller uuid - it should match the number of consumed applications

```
juju upgrade-controller --build-agent

log into mongo shell
juju:PRIMARY> db.globalRefcounts.find().pretty()
...
{
        "_id" : "controller#875d1b2a-cf9a-43b7-8c07-cd85ca536321",
        "refcount" : 2,
        "txn-revno" : NumberLong(2),
        "txn-queue" : [
                "6220be2f5feaa63dad806f88_8459323c"
        ]
}

```