### PR TITLE
[JUJU-674] Always set the application arch

### DIFF
--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -421,7 +421,7 @@ func (s *applicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 	storageConstraintsOut, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
@@ -501,7 +501,7 @@ func (s *applicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 	storageConstraintsOut, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
@@ -537,10 +537,17 @@ func (s *applicationSuite) TestApplicationDeploy(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
+}
+
+func (s *applicationSuite) constraintsWithDefaultArch(c *gc.C) constraints.Value {
+	a := arch.DefaultArchitecture
+	return constraints.Value{
+		Arch: &a,
+	}
 }
 
 func (s *applicationSuite) TestApplicationDeployWithInvalidPlacement(c *gc.C) {
@@ -693,6 +700,7 @@ func (s *applicationSuite) TestApplicationDeploymentWithTrust(c *gc.C) {
 		CharmOrigin:     createCharmOriginFromURL(c, curl),
 		NumUnits:        1,
 		Config:          config,
+		Constraints:     cons,
 		Placement: []*instance.Placement{
 			{Scope: "deadbeef-0bad-400d-8000-4b1d0d06f00d", Directive: "valid"},
 		},
@@ -705,7 +713,7 @@ func (s *applicationSuite) TestApplicationDeploymentWithTrust(c *gc.C) {
 		Results: []params.ErrorResult{{Error: nil}},
 	})
 
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 
 	appConfig, err := app.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -729,6 +737,7 @@ func (s *applicationSuite) TestApplicationDeploymentNoTrust(c *gc.C) {
 		CharmURL:        curl.String(),
 		CharmOrigin:     createCharmOriginFromURL(c, curl),
 		NumUnits:        1,
+		Constraints:     cons,
 		Placement: []*instance.Placement{
 			{Scope: "deadbeef-0bad-400d-8000-4b1d0d06f00d", Directive: "valid"},
 		},
@@ -741,7 +750,7 @@ func (s *applicationSuite) TestApplicationDeploymentNoTrust(c *gc.C) {
 		Results: []params.ErrorResult{{Error: nil}},
 	})
 
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 	appConfig, err := app.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	trust := appConfig.GetBool(application.TrustConfigOptionName, true)

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -62,7 +62,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	s.assertCharm(c, app, s.charm.URL())
 	s.assertSettings(c, app, charm.Settings{})
 	s.assertApplicationConfig(c, app, coreconfig.ConfigAttributes(nil))
-	s.assertConstraints(c, app, constraints.Value{})
+	s.assertConstraints(c, app, constraints.MustParse("arch=amd64"))
 	s.assertMachines(c, app, constraints.Value{})
 }
 
@@ -361,7 +361,7 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 			Constraints:     applicationCons,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, app, applicationCons)
+	s.assertConstraints(c, app, constraints.MustParse("cores=2 arch=amd64"))
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -101,7 +101,8 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 				"value":       "My Title",
 			},
 		},
-		Series: "quantal",
+		Constraints: constraints.MustParse("arch=amd64"),
+		Series:      "quantal",
 	})
 }
 
@@ -138,7 +139,8 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV5(c *gc.C) {
 				"value":       "My Title",
 			},
 		},
-		Series: "quantal",
+		Constraints: constraints.MustParse("arch=amd64"),
+		Series:      "quantal",
 	})
 }
 
@@ -167,7 +169,8 @@ func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {
 				"type":        environschema.Tbool,
 				"value":       false,
 			}},
-		Series: "quantal",
+		Constraints: constraints.MustParse("arch=amd64"),
+		Series:      "quantal",
 		EndpointBindings: map[string]string{
 			"":                network.AlphaSpaceName,
 			"admin-api":       network.AlphaSpaceName,
@@ -283,6 +286,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 			},
 		},
 		ApplicationConfig: expectedAppConfig,
+		Constraints:       constraints.MustParse("arch=amd64"),
 		Series:            "kubernetes",
 		EndpointBindings: map[string]string{
 			"":      network.AlphaSpaceName,
@@ -306,7 +310,7 @@ var getTests = []struct {
 }{{
 	about:       "deployed application",
 	charm:       "dummy",
-	constraints: "mem=2G cpu-power=400",
+	constraints: "arch=amd64 mem=2G cpu-power=400",
 	config: charm.Settings{
 		// Different from default.
 		"title": "Look To Windward",
@@ -358,8 +362,9 @@ var getTests = []struct {
 		},
 	},
 }, {
-	about: "deployed application  #2",
-	charm: "dummy",
+	about:       "deployed application  #2",
+	charm:       "dummy",
+	constraints: "arch=amd64",
 	config: charm.Settings{
 		// Set title to default.
 		"title": nil,
@@ -441,7 +446,7 @@ var getTests = []struct {
 		},
 	},
 }, {
-	about: "charmhub application",
+	about: "charmhub subordinate application",
 	charm: "logging",
 	origin: &state.CharmOrigin{
 		Source: "charm-hub",

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -619,7 +619,7 @@ func (s *DeploySuite) TestConstraints(c *gc.C) {
 	app, _ := s.AssertApplication(c, "multi-series", curl, 1, 0)
 	cons, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2"))
+	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2 arch=amd64"))
 }
 
 func (s *DeploySuite) TestResources(c *gc.C) {

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -69,6 +69,8 @@ func (s *cmdApplicationSuite) TestShowApplicationOne(c *gc.C) {
 wordpress:
   charm: wordpress
   series: quantal
+  constraints:
+    arch: amd64
   principal: true
   exposed: false
   remote: false
@@ -106,6 +108,8 @@ logging:
 wordpress:
   charm: wordpress
   series: quantal
+  constraints:
+    arch: amd64
   principal: true
   exposed: false
   remote: false

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -72,6 +72,7 @@ applications:
     revision: 43
     options:
       foo: bar
+    constraints: arch=amd64
     bindings:
       "": alpha
       info: vlan2
@@ -80,6 +81,7 @@ applications:
   wordpress:
     charm: cs:quantal/wordpress
     revision: 23
+    constraints: arch=amd64
     bindings:
       "": alpha
       admin-api: alpha

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -72,7 +72,6 @@ applications:
     revision: 43
     options:
       foo: bar
-    constraints: arch=amd64
     bindings:
       "": alpha
       info: vlan2

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -688,11 +688,12 @@ func (s *allWatcherStateSuite) TestChangeCAASApplications(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ApplicationInfo{
-						ModelUUID: caasSt.ModelUUID(),
-						Name:      "mysql",
-						CharmURL:  "local:kubernetes/kubernetes-mysql-0",
-						Life:      "alive",
-						Config:    map[string]interface{}{},
+						ModelUUID:   caasSt.ModelUUID(),
+						Name:        "mysql",
+						CharmURL:    "local:kubernetes/kubernetes-mysql-0",
+						Life:        "alive",
+						Config:      map[string]interface{}{},
+						Constraints: constraints.MustParse("arch=amd64"),
 						Status: multiwatcher.StatusInfo{
 							Current: "unset",
 							Data:    map[string]interface{}{},
@@ -2116,13 +2117,14 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ApplicationInfo{
-						ModelUUID: st.ModelUUID(),
-						Name:      "wordpress",
-						Exposed:   true,
-						CharmURL:  "local:quantal/quantal-wordpress-3",
-						Life:      life.Alive,
-						MinUnits:  42,
-						Config:    charm.Settings{},
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress",
+						Exposed:     true,
+						CharmURL:    "local:quantal/quantal-wordpress-3",
+						Life:        life.Alive,
+						MinUnits:    42,
+						Config:      charm.Settings{},
+						Constraints: constraints.MustParse("arch=amd64"),
 						Status: multiwatcher.StatusInfo{
 							Current: "unset",
 							Message: "",

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -382,11 +382,12 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	mysql := AddTestingApplication(c, st, "mysql", AddTestingCharm(c, st, "mysql"))
 	curl := applicationCharmURL(mysql)
 	add(&multiwatcher.ApplicationInfo{
-		ModelUUID: modelUUID,
-		Name:      "mysql",
-		CharmURL:  curl.String(),
-		Life:      life.Alive,
-		Config:    charm.Settings{},
+		ModelUUID:   modelUUID,
+		Name:        "mysql",
+		CharmURL:    curl.String(),
+		Life:        life.Alive,
+		Config:      charm.Settings{},
+		Constraints: constraints.MustParse("arch=amd64"),
 		Status: multiwatcher.StatusInfo{
 			Current: "unset",
 			Message: "",

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3308,7 +3308,8 @@ func (s *ApplicationSuite) TestConstraints(c *gc.C) {
 	// Constraints are initially empty (for now).
 	cons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(&cons, gc.Not(jc.Satisfies), constraints.IsEmpty)
+	c.Assert(cons, gc.DeepEquals, constraints.MustParse("arch=amd64"))
 
 	// Constraints can be set.
 	cons2 := constraints.Value{Mem: uint64p(4096)}
@@ -3339,7 +3340,8 @@ func (s *ApplicationSuite) TestConstraints(c *gc.C) {
 	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
 	cons6, err := mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&cons6, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(&cons6, gc.Not(jc.Satisfies), constraints.IsEmpty)
+	c.Assert(cons6, gc.DeepEquals, constraints.MustParse("arch=amd64"))
 }
 
 func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
@@ -3371,7 +3373,8 @@ func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
 	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
 	cons6, err := mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(constraints.IsEmpty(&cons6), jc.IsTrue)
+	c.Assert(constraints.IsEmpty(&cons6), jc.IsFalse)
+	c.Assert(cons6, jc.DeepEquals, cons2)
 }
 
 func (s *ApplicationSuite) TestSetInvalidConstraints(c *gc.C) {
@@ -3413,7 +3416,8 @@ func (s *ApplicationSuite) TestConstraintsLifecycle(c *gc.C) {
 
 	scons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&scons, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(&scons, gc.Not(jc.Satisfies), constraints.IsEmpty)
+	c.Assert(scons, gc.DeepEquals, constraints.MustParse("arch=amd64"))
 
 	// Removed (== Dead, for a application).
 	c.Assert(unit.EnsureDead(), jc.ErrorIsNil)

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -261,7 +261,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplicationNoPlacement(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": failed for some reason`)
 	c.Assert(s.prechecker.precheckInstanceArgs, jc.DeepEquals, environs.PrecheckInstanceParams{
 		Series:      "quantal",
-		Constraints: constraints.MustParse("root-disk=20G"),
+		Constraints: constraints.MustParse("arch=amd64 root-disk=20G"),
 	})
 }
 
@@ -310,7 +310,8 @@ func (s *PrecheckerSuite) TestPrecheckAddApplicationMixedPlacement(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": hey now`)
 	c.Assert(s.prechecker.precheckInstanceArgs, jc.DeepEquals, environs.PrecheckInstanceParams{
-		Series:    "precise",
-		Placement: "somewhere",
+		Series:      "precise",
+		Placement:   "somewhere",
+		Constraints: constraints.MustParse("arch=amd64"),
 	})
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1207,8 +1207,11 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	// the application. If no architecture in the constraints, then look at
 	// the model constraints. If no architecture is found in the model, use the
 	// default architecture (amd64).
-	cons := args.Constraints
-	if !cons.HasArch() {
+	var (
+		cons        = args.Constraints
+		subordinate = args.Charm.Meta().Subordinate
+	)
+	if !subordinate && !cons.HasArch() {
 		modelConstraints, err := st.ModelConstraints()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -1260,7 +1263,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		Name:          args.Name,
 		ModelUUID:     st.ModelUUID(),
 		Series:        args.Series,
-		Subordinate:   args.Charm.Meta().Subordinate,
+		Subordinate:   subordinate,
 		CharmURL:      args.Charm.URL(),
 		CharmOrigin:   args.CharmOrigin,
 		Channel:       string(args.Channel),

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1609,14 +1609,26 @@ func (s *StateSuite) TestAddApplication(c *gc.C) {
 	outconfig, err := wordpress.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outconfig, gc.DeepEquals, inconfig.Attributes())
+	cons, err := wordpress.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	a := corearch.DefaultArchitecture
+	c.Assert(cons, jc.DeepEquals, constraints.Value{
+		Arch: &a,
+	})
 
-	mysql, err := s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Charm: ch})
+	mysqlArch := arch.ARM64
+	mysql, err := s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Charm: ch, Constraints: constraints.Value{Arch: &mysqlArch}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 	sInfo, err := mysql.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sInfo.Status, gc.Equals, status.Unset)
 	c.Assert(sInfo.Message, gc.Equals, "")
+	cons, err = mysql.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, jc.DeepEquals, constraints.Value{
+		Arch: &mysqlArch,
+	})
 
 	// Check that retrieving the new created applications works correctly.
 	wordpress, err = s.State.Application("wordpress")
@@ -1661,6 +1673,13 @@ func (s *StateSuite) TestAddCAASApplication(c *gc.C) {
 	outconfig, err := gitlab.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outconfig, gc.DeepEquals, inconfig.Attributes())
+
+	cons, err := gitlab.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	a := corearch.DefaultArchitecture
+	c.Assert(cons, jc.DeepEquals, constraints.Value{
+		Arch: &a,
+	})
 
 	sInfo, err := gitlab.Status()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit.go
+++ b/state/unit.go
@@ -2017,7 +2017,7 @@ func (u *Unit) Constraints() (*constraints.Value, error) {
 			}
 		}
 		if !cons.HasArch() {
-			a := arch.DefaultArchitecture
+			a := arch.ConstraintArch(cons, nil)
 			cons.Arch = &a
 		}
 	}


### PR DESCRIPTION
The application arch should always be set so when in a non-default
architecture environment we can always add a new unit without setting
the model constraints.

The hierarchy of needs for adding an application and therefore a unit
will first check the user passed constraints arch arguments, before
then checking the model constraints arch value. In reality, we would want to
move constraints into config, but that's an exercise for later.

The code is simple, when we create a new application, just ensure we
always have a default arch.

## QA steps

```sh
$ juju bootstrap lxd test --constraints="arch=arm64"
$ juju deploy ubuntu
$ juju add-unit ubuntu -n 1
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1961396
