### PR TITLE
[JUJU-705] Add unit local state data into the introspection report.

### DIFF
--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -176,6 +176,18 @@ func (st State) Validate() (err error) {
 	return nil
 }
 
+func (st State) Report() map[string]interface{} {
+	result := make(map[string]interface{})
+	result["started"] = st.Started
+	result["stopped"] = st.Stopped
+	result["installed"] = st.Installed
+	result["removed"] = st.Removed
+	result["hook-kind"] = st.Kind
+	result["hook-step"] = st.Step
+	result["leader"] = st.Leader
+	return result
+}
+
 func (st State) match(otherState State) bool {
 	stateYaml, _ := yaml.Marshal(st)
 	otherStateYaml, _ := yaml.Marshal(otherState)

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -987,6 +987,9 @@ func (u *Uniter) Report() map[string]interface{} {
 	if u.unit != nil {
 		result["unit"] = u.unit.Name()
 	}
+	if u.operationExecutor != nil {
+		result["local-state"] = u.operationExecutor.State().Report()
+	}
 	if u.relationStateTracker != nil {
 		result["relations"] = u.relationStateTracker.Report()
 	}


### PR DESCRIPTION
With a recent case in the wild, the unit is stuck at "agent initializing". The engine report reports all happy and started, however there are no new unit logs, no errors in the machine log, and it appears the single unit has no connectivity to the controller.

Data formally in /var/lib/juju/agents/unit-*/state/ is not longer viewable.  Correct that here.

## QA steps

```sh
Run the juju_engine_report
                uniter:
                  inputs:
...
                  report:
                    local-state:
                      hook-kind: continue
                      hook-step: pending
                      installed: true
                      leader: true
                      removed: false
                      started: true
                      stopped: false
                    relations: {}
                    unit: ubuntu/0
                  start-count: 1
                  started: "2022-03-04 09:01:59"
                  state: started
```

