### PR TITLE
[JUJU-706] Allow for the ch schema to be included in a charm name.

### DIFF
--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -115,23 +115,25 @@ func (c *downloadCommand) Init(args []string) error {
 		c.pipeToStdout = true
 	}
 
-	if err := c.validateCharmOrBundle(args[0]); err != nil {
+	curl, err := c.validateCharmOrBundle(args[0])
+	if err != nil {
 		return errors.Trace(err)
 	}
-	c.charmOrBundle = args[0]
+	// Allow for both <charm> and ch:<charm> to download.
+	c.charmOrBundle = curl.Name
 
 	return nil
 }
 
-func (c *downloadCommand) validateCharmOrBundle(charmOrBundle string) error {
+func (c *downloadCommand) validateCharmOrBundle(charmOrBundle string) (*charm.URL, error) {
 	curl, err := charm.ParseURL(charmOrBundle)
 	if err != nil {
-		return errors.Annotatef(err, "unexpected charm or bundle name")
+		return nil, errors.Annotatef(err, "unexpected charm or bundle name")
 	}
 	if !charm.CharmHub.Matches(curl.Schema) {
-		return errors.Errorf("%q is not a Charm Hub charm", charmOrBundle)
+		return nil, errors.Errorf("%q is not a Charmhub charm", charmOrBundle)
 	}
-	return nil
+	return curl, nil
 }
 
 // Run is the business logic of the download command.  It implements the meaty

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -46,11 +46,27 @@ func (s *downloadSuite) TestInitNoArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "expected a charm or bundle name")
 }
 
-func (s *downloadSuite) TestInitSuccess(c *gc.C) {
+func (s *downloadSuite) TestInitErrorCSSchema(c *gc.C) {
 	command := &downloadCommand{
 		charmHubCommand: s.newCharmHubCommand(),
 	}
-	err := command.Init([]string{"test"})
+	err := command.Init([]string{"cs:test"})
+	c.Assert(err, gc.ErrorMatches, ".* is not a Charmhub charm")
+}
+
+func (s *downloadSuite) TestInitSuccess(c *gc.C) {
+	s.testInitSuccess(c, "test")
+}
+
+func (s *downloadSuite) TestInitSuccessWithSchema(c *gc.C) {
+	s.testInitSuccess(c, "ch:test")
+}
+
+func (s *downloadSuite) testInitSuccess(c *gc.C, charmName string) {
+	command := &downloadCommand{
+		charmHubCommand: s.newCharmHubCommand(),
+	}
+	err := command.Init([]string{charmName})
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
It confuses users for "charmname" download to succeed, but "ch:charmname" returns not found.  Parse out the ch schema if used before finding the charm for download.

## QA steps

```console
$ juju download ch:keystone
Fetching charm "keystone" using "stable" channel and base "amd64/ubuntu/20.04"
Install the "keystone" charm with:
    juju deploy ./keystone_67249f4.charm

$ juju download keystone
Fetching charm "keystone" using "stable" channel and base "amd64/ubuntu/20.04"
Install the "keystone" charm with:
    juju deploy ./keystone_67249f4.charm
```
