### PR TITLE
2.9 mongo based leases

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -227,6 +227,18 @@ func allCollections() CollectionSchema {
 			}},
 		},
 
+		// This collection tracks the expiration and pinned status of leases. Note that we access this collection
+		// directly, without mgo/txn.
+		leaseExpiriesC: {
+			rawAccess: true,
+			global:    true,
+			indexes: []mgo.Index{{
+				// We want fast access for finding leases that have expired
+				// TODO: (jam 2022-03-05 Do we want to track if they are pinned in the same index?)
+				Key: []string{"model-uuid", "expiry_timestamp", "pinned"},
+			}},
+		},
+
 		// This collection holds the last time the model user connected
 		// to the model.
 		modelUserLastConnectionC: {
@@ -636,6 +648,7 @@ const (
 	guisettingsC               = "guisettings"
 	instanceDataC              = "instanceData"
 	leaseHoldersC              = "leaseholders"
+	leaseExpiriesC             = "leaseexpiries"
 	machinesC                  = "machines"
 	machineRemovalsC           = "machineremovals"
 	machineUpgradeSeriesLocksC = "machineUpgradeSeriesLocks"

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -236,6 +236,8 @@ func allCollections() CollectionSchema {
 				// We want fast access for finding leases that have expired
 				// TODO: (jam 2022-03-05 Do we want to track if they are pinned in the same index?)
 				Key: []string{"model-uuid", "expiry_timestamp", "pinned"},
+			}, {
+				Key: []string{"model-uuid", "namespace"},
 			}},
 		},
 

--- a/state/mongolease/mongolease.go
+++ b/state/mongolease/mongolease.go
@@ -1,0 +1,244 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongolease
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/mgo/v2"
+	"github.com/juju/mgo/v2/bson"
+	"github.com/juju/mgo/v2/txn"
+	jujutxn "github.com/juju/txn/v2"
+
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/mongo"
+)
+
+// leaseHolderDoc is used to serialise lease holder info.
+// This tracks who the current holder of the lease is. This document is updated with a Transaction,
+// while the leaseExpiryDocument is not.
+type leaseHolderDoc struct {
+	Id        string `bson:"_id"`
+	Namespace string `bson:"namespace"`
+	ModelUUID string `bson:"model-uuid"`
+	Lease     string `bson:"lease"`
+	Holder    string `bson:"holder"`
+}
+
+func (lhd leaseHolderDoc) String() string {
+	return fmt.Sprintf("lease [%s] %s %q held by %q",
+		lhd.ModelUUID[:6], lhd.Namespace, lhd.Lease, lhd.Holder)
+}
+
+// leaseExpiryDoc tracks when the current holder of a lease would expire
+type leaseExpiryDoc struct {
+	Id        string `bson:"_id"`
+	Namespace string `bson:"namespace"`
+	ModelUUID string `bson:"model-uuid"`
+	Lease     string `bson:"lease"`
+	Holder    string `bson:"holder"`
+	Expiry    int    `bson:"expiry_timestamp"`
+	Pinned    bool   `bson:"pinned"`
+}
+
+func (led leaseExpiryDoc) String() string {
+	return fmt.Sprintf("lease [%s] %s %q held by %q until %d (pinned: %t)",
+		led.ModelUUID[:6], led.Namespace, led.Lease, led.Holder, led.Expiry, led.Pinned)
+}
+
+const (
+	fieldNamespace = "namespace"
+	fieldHolder    = "holder"
+	fieldExpiry    = "expiry_timestamp"
+)
+
+type RequestOp string
+
+const (
+	Claim  RequestOp = "claim"
+	Extend RequestOp = "extend"
+	Revoke RequestOp = "revoke"
+	Pin    RequestOp = "pin"
+)
+
+var knownRequestOps = map[RequestOp]string{
+	Claim:  string(Claim),
+	Extend: string(Extend),
+	Revoke: string(Revoke),
+	Pin:    string(Pin),
+}
+
+func (rop RequestOp) Validate() error {
+	if _, ok := knownRequestOps[rop]; !ok {
+		return errors.Errorf("unknown lease request operation: %q", string(rop))
+	}
+	return nil
+}
+
+// Mongo exposes MongoDB operations for use by the lease package.
+type Mongo interface {
+
+	// RunTransaction should probably delegate to a jujutxn.Runner's Run method.
+	RunTransaction(jujutxn.TransactionSource) error
+
+	// GetCollection should probably call the mongo.CollectionFromName func.
+	GetCollection(name string) (collection mongo.Collection, closer func())
+}
+
+type logger interface {
+	Debugf(string, ...interface{})
+	Tracef(string, ...interface{})
+}
+
+// DBRequest is a list of requests for claiming/extending a set of leases
+// TODO: (jam 2022-05-05) Future use. do we want to have a way to issue a single DB query
+//  that can claim and extend a bunch of leases? What about at least supporting a batch of leases to extend?
+type DBRequest struct {
+	Op       RequestOp
+	Key      lease.Key
+	Holder   string
+	Duration time.Duration
+}
+
+// mongoLeaseStore conforms to the Lease.Store interface, providing queries against the database to
+// track who currently holds leases, and what leases are ready to expire.
+// For now, we don't track anything in memory, we just use the database as the source of truth.
+type mongoLeaseStore struct {
+	expiryCollection  mongo.Collection
+	holdersCollection mongo.Collection
+	mongo             Mongo
+	globalTimeFunc    func() int // A function to get the 'global' time
+	logger            logger
+}
+
+var _ (lease.Store) = (*mongoLeaseStore)(nil)
+
+func leaseDBId(key lease.Key) string {
+	return key.ModelUUID + "#" + key.Namespace + "#" + key.Namespace
+}
+
+func (mls *mongoLeaseStore) ClaimLease(key lease.Key, request lease.Request, stop <-chan struct{}) error {
+	// When claiming a lease, we can only claim a lease that is not currently held. It is not currently allowed to
+	// *claim* a lease that you currently hold (you must request to Extend the lease)
+	// TODO: (jam 2022-03-05) should we support claiming a lease that has 'expired'?
+	//  for now, the lease must not exist for you to claim it
+	var expiry leaseExpiryDoc
+	// TODO: (jam 2022-03-05) should we just look this up by leaseId?,
+	//  we should probably also check if it does exist that it has the right fields
+	leaseId := leaseDBId(key)
+	mls.logger.Tracef("claiming lease [%v] %v %q for %q duration %s",
+		key.ModelUUID[6:], key.Namespace, key.Lease, request.Holder, request.Duration)
+	err := mls.expiryCollection.FindId(leaseId).One(&expiry)
+	if err == nil {
+		// Lease already held
+		// TODO: (jam 2022-03-05) is it better to explicitly format the error than defer to another string function?
+		// Probably we shouldn't trace here if we are returning an error, as the caller should log
+		mls.logger.Tracef("claiming lease for %q %s failed: held by %v",
+			request.Holder, request.Duration, expiry)
+		return errors.Annotatef(lease.ErrClaimDenied, "unable to claim: %v", expiry.String())
+	} else if errors.Cause(err) != mgo.ErrNotFound {
+		// TODO: (jam 2022-03-05) Are there special errors here that we should treat differently?
+		mls.logger.Tracef("claiming lease [%v] %v %q for %q duration %s failed with: %v",
+			key.ModelUUID[6:], key.Namespace, key.Lease, request.Holder, request.Duration,
+			err)
+		return errors.Trace(err)
+	}
+	// NotFound as expected, so create one
+	// TODO: (jam 2022-03-05) Ensure that if we are creating an object here, it cannot race with someone else
+	//  creating a similar record without them colliding
+	newExpiry := leaseExpiryDoc{
+		// We have to use fixed ids so that 2 processes trying to create the same lease will collide
+		Id:        leaseId,
+		ModelUUID: key.ModelUUID,
+		Namespace: key.Namespace,
+		Lease:     key.Lease,
+		Holder:    request.Holder,
+		Expiry:    mls.getExpiryTime(request.Duration),
+		Pinned:    false,
+	}
+	err = mls.expiryCollection.Writeable().Insert(newExpiry)
+	if err != nil {
+		mls.logger.Tracef("claiming %s failed: %v", newExpiry, err)
+		return errors.Trace(err)
+	}
+	// Now that we have the expiry collection entry, we need to update the holder in a txn
+	err = mls.mongo.RunTransaction(func(attempt int) ([]txn.Op, error) {
+		// the default assumption is that the holder doesn't exist (because we are making a claim)
+		if attempt > 0 {
+			var existing leaseHolderDoc
+			err := mls.holdersCollection.FindId(leaseId).One(&existing)
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					// TODO (jam 2022-03-05): are there specific errors we should be trapping?
+					mls.logger.Tracef("updating holder of %v failed: %v", newExpiry, err)
+					return nil, errors.Trace(err)
+				} else {
+					// Nothing to do because the object doesn't exist, so fall back to the normal creation steps
+				}
+			} else {
+				// Handle the Holder document already existing
+				if existing.Holder == request.Holder {
+					// No-op
+					mls.logger.Tracef("updating holder of %v no-op (already held by %q)", newExpiry, request.Holder)
+					return nil, jujutxn.ErrNoOperations
+				}
+				mls.logger.Tracef("updating holder of %v, new holder %q", existing, request.Holder)
+				return []txn.Op{{
+					C:      mls.holdersCollection.Name(),
+					Id:     leaseId,
+					Assert: txn.DocExists,
+					Update: bson.M{"$set": bson.M{"holder": request.Holder}},
+				}}, nil
+			}
+		}
+		// Assume the case where the document doesn't exist
+		return []txn.Op{{
+			C:      mls.holdersCollection.Name(),
+			Id:     leaseId,
+			Assert: txn.DocMissing,
+			Insert: leaseHolderDoc{
+				Id:        leaseId,
+				ModelUUID: key.ModelUUID,
+				Namespace: key.Namespace,
+				Lease:     key.Lease,
+				Holder:    request.Holder,
+			},
+		}}, nil
+	})
+	if err != nil {
+		mls.logger.Tracef("failed to update holder of %v: %v",
+			newExpiry, err)
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (mls *mongoLeaseStore) getExpiryTime(t time.Duration) int {
+	return mls.globalTimeFunc() + int(t)
+}
+
+func (mls *mongoLeaseStore) ExtendLease(key lease.Key, request lease.Request, stop <-chan struct{}) error {
+	return nil
+}
+func (mls *mongoLeaseStore) RevokeLease(key lease.Key, holder string, stop <-chan struct{}) error {
+	return nil
+}
+
+func (mls *mongoLeaseStore) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
+	return nil
+}
+func (mls *mongoLeaseStore) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease.Info {
+	return nil
+}
+func (mls *mongoLeaseStore) PinLease(key lease.Key, entity string, stop <-chan struct{}) error {
+	return nil
+}
+func (mls *mongoLeaseStore) UnpinLease(key lease.Key, entity string, stop <-chan struct{}) error {
+	return nil
+}
+func (mls *mongoLeaseStore) Pinned() map[lease.Key][]string {
+	return nil
+}

--- a/state/mongolease/mongolease_test.go
+++ b/state/mongolease/mongolease_test.go
@@ -1,0 +1,191 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongolease
+
+import (
+	"github.com/juju/loggo"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/mgo/v2"
+	"github.com/juju/mgo/v2/bson"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	jujutxn "github.com/juju/txn/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/mongo"
+)
+
+var _ = gc.Suite(&mongoLeaseSuite{})
+
+type mongoLeaseSuite struct {
+	testing.IsolationSuite
+	testing.MgoSuite
+	db         *mgo.Database
+	leaseStore *mongoLeaseStore
+	// errorLog loggo.Logger
+}
+
+const (
+	leasesC   = "testleaseholders"
+	expiriesC = "testleaseexpiries"
+)
+
+func (s *mongoLeaseSuite) SetUpSuite(c *gc.C) {
+	s.MgoSuite.SetUpSuite(c)
+	s.IsolationSuite.SetUpSuite(c)
+}
+
+func (s *mongoLeaseSuite) TearDownSuite(c *gc.C) {
+	s.IsolationSuite.TearDownSuite(c)
+	s.MgoSuite.TearDownSuite(c)
+}
+
+func (s *mongoLeaseSuite) SetUpTest(c *gc.C) {
+	s.MgoSuite.SetUpTest(c)
+	s.IsolationSuite.SetUpTest(c)
+	s.db = s.Session.DB("juju")
+}
+
+func (s *mongoLeaseSuite) TearDownTest(c *gc.C) {
+	s.IsolationSuite.TearDownTest(c)
+	s.MgoSuite.TearDownTest(c)
+}
+
+// TestMongo exposes database operations. It uses a real database -- we can't mock
+// mongo out, we need to check it really actually works -- but it's good to
+// have the runner accessible for adversarial transaction tests.
+type TestMongo struct {
+	database *mgo.Database
+	runner   jujutxn.Runner
+	txnErr   error
+}
+
+// NewTestMongo returns a *TestMongo backed by the supplied database.
+func NewTestMongo(database *mgo.Database) *TestMongo {
+	return &TestMongo{
+		database: database,
+		runner: jujutxn.NewRunner(jujutxn.RunnerParams{
+			Database: database,
+		}),
+	}
+}
+
+// GetCollection is part of the lease.TestMongo interface.
+func (m *TestMongo) GetCollection(name string) (mongo.Collection, func()) {
+	return mongo.CollectionFromName(m.database, name)
+}
+
+// RunTransaction is part of the lease.TestMongo interface.
+func (m *TestMongo) RunTransaction(getTxn jujutxn.TransactionSource) error {
+	if m.txnErr != nil {
+		return m.txnErr
+	}
+	return m.runner.Run(getTxn)
+}
+
+func (s *mongoLeaseSuite) SetupLeaseStore(c *gc.C, timeFunc func() int) {
+	expiryCollection, close1 := mongo.CollectionFromName(s.db, expiriesC)
+	s.AddCleanup(func(*gc.C) { close1() })
+	holdersCollection, close2 := mongo.CollectionFromName(s.db, leasesC)
+	s.AddCleanup(func(*gc.C) { close2() })
+	s.leaseStore = &mongoLeaseStore{
+		expiryCollection:  expiryCollection,
+		holdersCollection: holdersCollection,
+		mongo:             NewTestMongo(s.db),
+		globalTimeFunc:    timeFunc,
+		logger:            loggo.GetLogger("mongo-leases"),
+	}
+}
+
+func (s *mongoLeaseSuite) getExpiries(c *gc.C) []leaseExpiryDoc {
+	c.Assert(s.leaseStore.expiryCollection, gc.NotNil)
+	var entries []leaseExpiryDoc
+	err := s.leaseStore.expiryCollection.Find(bson.M{}).All(&entries)
+	c.Assert(err, jc.ErrorIsNil)
+	return entries
+}
+
+func (s *mongoLeaseSuite) expectOneExpiry(c *gc.C) leaseExpiryDoc {
+	allExpiries := s.getExpiries(c)
+	c.Assert(allExpiries, gc.HasLen, 1)
+	return allExpiries[0]
+}
+
+func (s *mongoLeaseSuite) getHolders(c *gc.C) []leaseHolderDoc {
+	c.Assert(s.leaseStore.holdersCollection, gc.NotNil)
+	var holders []leaseHolderDoc
+	err := s.leaseStore.holdersCollection.Find(bson.M{}).All(&holders)
+	c.Assert(err, jc.ErrorIsNil)
+	return holders
+}
+
+func (s *mongoLeaseSuite) expectOneHolder(c *gc.C) leaseHolderDoc {
+	allHolders := s.getHolders(c)
+	c.Assert(allHolders, gc.HasLen, 1)
+	return allHolders[0]
+}
+
+func (s *mongoLeaseSuite) TestClaimLease(c *gc.C) {
+	s.SetupLeaseStore(c, func() int { return 12345 })
+	stopChan := make(chan struct{})
+	err := s.leaseStore.ClaimLease(lease.Key{
+		Namespace: "application",
+		ModelUUID: "deadbeef",
+		Lease:     "app",
+	}, lease.Request{
+		Holder:   "mytest",
+		Duration: time.Second,
+	}, stopChan,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	entry := s.expectOneExpiry(c)
+	c.Check(entry.ModelUUID, gc.Equals, "deadbeef")
+	c.Check(entry.Namespace, gc.Equals, "application")
+	c.Check(entry.Lease, gc.Equals, "app")
+	c.Check(entry.Holder, gc.Equals, "mytest")
+	c.Check(entry.Expiry, gc.Equals, 12345+int(time.Second))
+	holder := s.expectOneHolder(c)
+	c.Check(holder.ModelUUID, gc.Equals, "deadbeef")
+	c.Check(holder.Namespace, gc.Equals, "application")
+	c.Check(holder.Lease, gc.Equals, "app")
+	c.Check(holder.Holder, gc.Equals, "mytest")
+}
+
+func (s *mongoLeaseSuite) TestClaimClaimedLease(c *gc.C) {
+	s.SetupLeaseStore(c, func() int { return 12345 })
+	key := lease.Key{
+		Namespace: "application",
+		ModelUUID: "deadbeef",
+		Lease:     "app",
+	}
+	req := lease.Request{
+		Holder:   "mytest",
+		Duration: time.Second,
+	}
+	stopChan := make(chan struct{})
+	err := s.leaseStore.ClaimLease(key, req, stopChan)
+	c.Assert(err, jc.ErrorIsNil)
+	entry := s.expectOneExpiry(c)
+	c.Check(entry.Lease, gc.Equals, "app")
+	c.Check(entry.Holder, gc.Equals, "mytest")
+	holder := s.expectOneHolder(c)
+	c.Check(holder.Lease, gc.Equals, "app")
+	c.Check(holder.Holder, gc.Equals, "mytest")
+	req.Holder = "othertest"
+	err = s.leaseStore.ClaimLease(key, req, stopChan)
+	c.Assert(err, gc.NotNil)
+	c.Check(errors.Cause(err), gc.Equals, lease.ErrClaimDenied)
+	c.Check(err.Error(), gc.Equals,
+		`unable to claim: lease [deadbe] application "app" held by "mytest" until 1000012345 (pinned: false): lease claim denied`)
+	// The lease holder should not have changed
+	entry = s.expectOneExpiry(c)
+	c.Check(entry.Lease, gc.Equals, "app")
+	c.Check(entry.Holder, gc.Equals, "mytest")
+	holder = s.expectOneHolder(c)
+	c.Check(holder.Lease, gc.Equals, "app")
+	c.Check(holder.Holder, gc.Equals, "mytest")
+}

--- a/state/mongolease/package_test.go
+++ b/state/mongolease/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongolease
+
+import (
+	stdtesting "testing"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *stdtesting.T) {
+	coretesting.MgoTestPackage(t)
+}


### PR DESCRIPTION
This is a quick prototype of how we might do Database leases in Mongo, splitting out the logic that extends leases into plain Mongo interactions, but keeping the Transaction table whenever we have a valid Claim.
I don't know where we put in things like "expire all the leases" because that seems to need to be part of a worker, rather than part of the base LeaseStore interaction.

If someone wants to pick it up from here, it should be an interesting starting point at least.

For my vision of it, I would try avoid having a global time ticker, but if we need it, we can see how that would work. I *would* like to change the lookup to just do a db query on "give me everything with an expiry time < now". In theory, we did a bunch of work to track when the next thing *might* expire and sleep until that triggers, etc. But I think we can simplify this code a lot and just wake up every ~1s and do a query. (If we have the right index, and we're updating the leases, that index just always returns nothing to expire.)

The nice thing of this, is that we get mgo to give us all the work around 'must talk to the database primary', and not have to worry about raft redirections, etc.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change (internal change)
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR (integration tests should already be running against leases, though we might need a variant that uses an alternate lease implementation)
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
  (we probably need to document things like 'raft-api-leases' and something along those lines for how we would do it here)
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Still a draft at this point. Will need work to integrate it as an actual raft backend (based on a controller config).

```sh
QA steps here
```

## Documentation changes

*Please replace with any notes about how it affects current user workflow, CLI, or API.*

## Bug reference

*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
