### PR TITLE
[JUJU-700] Setup CI test for deploying CK

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -129,8 +129,14 @@ bootstrap() {
 		add_model "${model}" "${cloud}" "${bootstrapped_name}" "${output}"
 		name="${bootstrapped_name}"
 	else
-		echo "====> Bootstrapping juju ($(green "${version}:${cloud}"))"
-		juju_bootstrap "${cloud}" "${name}" "${model}" "${output}"
+		local cloud_region
+		if [[ -n ${BOOTSTRAP_REGION:-} ]]; then
+			cloud_region="${cloud}/${BOOTSTRAP_REGION}"
+		else
+			cloud_region="${cloud}"
+		fi
+		echo "====> Bootstrapping juju ($(green "${version}:${cloud_region}"))"
+		juju_bootstrap "${cloud_region}" "${name}" "${model}" "${output}"
 	fi
 
 	END_TIME=$(date +%s)
@@ -191,9 +197,9 @@ setup_vsphere_simplestreams() {
 # juju_bootstrap is used to bootstrap a model for tracking. This is for internal
 # use only and shouldn't be used by any of the tests directly.
 juju_bootstrap() {
-	local cloud name model output
+	local cloud_region name model output
 
-	cloud=${1}
+	cloud_region=${1}
 	shift
 
 	name=${1}
@@ -231,7 +237,7 @@ juju_bootstrap() {
 
 	pre_bootstrap
 
-	command="juju bootstrap ${series} ${model_default_series} --build-agent=${BUILD_AGENT} ${cloud} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${series} ${model_default_series} --build-agent=${BUILD_AGENT} ${cloud_region} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -58,6 +58,12 @@ bootstrap() {
 	"aws" | "ec2")
 		cloud="aws"
 		;;
+	"google" | "gce")
+		cloud="google"
+		;;
+	"azure")
+		cloud="azure"
+		;;
 	"localhost" | "lxd")
 		cloud="lxd"
 		;;

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -299,7 +299,7 @@ destroy_model() {
 	output="${TEST_DIR}/${name}-destroy.log"
 
 	echo "====> Destroying juju model ${name}"
-	echo "${name}" | xargs -I % juju destroy-model -y % >"${output}" 2>&1 || true
+	echo "${name}" | xargs -I % juju destroy-model -y --destroy-storage % >"${output}" 2>&1 || true
 	CHK=$(cat "${output}" | grep -i "ERROR\|Unable to get the model status from the API" || true)
 	if [[ -n ${CHK} ]]; then
 		printf '\nFound some issues\n'

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -152,9 +152,9 @@ add_model() {
 
 	OUT=$(juju controllers --format=json | jq '.controllers | .["${bootstrapped_name}"] | .cloud' | grep "${cloud}" || true)
 	if [[ -n ${OUT} ]]; then
-		juju add-model -c "${controller}" "${model}" "${cloud}" 2>&1 | OUTPUT "${output}"
-	else
 		juju add-model -c "${controller}" "${model}" 2>&1 | OUTPUT "${output}"
+	else
+		juju add-model -c "${controller}" "${model}" "${cloud}" 2>&1 | OUTPUT "${output}"
 	fi
 
 	post_add_model

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -65,7 +65,7 @@ bootstrap() {
 		cloud="azure"
 		;;
 	"localhost" | "lxd")
-		cloud="lxd"
+		cloud="localhost"
 		;;
 	"lxd-remote" | "vsphere" | "openstack" | "k8s" | "maas")
 		cloud="${BOOTSTRAP_CLOUD}"

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -18,7 +18,7 @@ wait_for() {
 	attempt=0
 	# shellcheck disable=SC2046,SC2143
 	until [[ "$(juju status --format=json 2>/dev/null | jq -S "${query}" | grep "${name}")" ]]; do
-		echo "[+] (attempt ${attempt}) polling status for" "${name}"
+		echo "[+] (attempt ${attempt}) polling status for" "${query} => ${name}"
 		juju status --relations 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
 		attempt=$((attempt + 1))

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -312,6 +312,7 @@ trap cleanup EXIT HUP INT TERM
 
 # Setup test directory
 TEST_DIR=$(mktemp -d tmp.XXX | xargs -I % echo "$(pwd)/%")
+export TEST_DIR
 
 run_test() {
 	TEST_CURRENT=${1}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -312,7 +312,6 @@ trap cleanup EXIT HUP INT TERM
 
 # Setup test directory
 TEST_DIR=$(mktemp -d tmp.XXX | xargs -I % echo "$(pwd)/%")
-export TEST_DIR
 
 run_test() {
 	TEST_CURRENT=${1}

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -45,6 +45,7 @@ TEST_NAMES="agents \
             charmhub \
             cli \
             controller \
+            ck \
             deploy \
             expose_ec2 \
             hooks \
@@ -92,7 +93,7 @@ show_help() {
 	echo "¯¯¯¯¯¯"
 	echo "Flags should appear $(red 'before') arguments."
 	echo ""
-	echo "cmd [-h] [-v] [-A] [-s test] [-a file] [-x file] [-r] [-l controller] [-p provider type <lxd|aws|manual|microk8s|vsphere|maas>]"
+	echo "cmd [-h] [-v] [-A] [-s test] [-a file] [-x file] [-r] [-l controller] [-p provider type <lxd|aws|google|azure|manual|microk8s|vsphere|maas>]"
 	echo ""
 	echo "    $(green './main.sh -h')        Display this help message"
 	echo "    $(green './main.sh -v')        Verbose and debug messages"
@@ -102,7 +103,7 @@ show_help() {
 	echo "    $(green './main.sh -x')        Output file from streaming the output"
 	echo "    $(green './main.sh -r')        Reuse bootstrapped controller between testing suites"
 	echo "    $(green './main.sh -l')        Local bootstrapped controller name to reuse"
-	echo "    $(green './main.sh -p')        Bootstrap provider to use when bootstrapping <lxd|aws|manual|k8s|openstack|vsphere|maas>"
+	echo "    $(green './main.sh -p')        Bootstrap provider to use when bootstrapping <lxd|aws|google|azure|manual|k8s|openstack|vsphere|maas>"
 	echo "                                     vsphere assumes juju boston vsphere for image metadata generation"
 	echo "                                     openstack assumes providing image data directly is not required"
 	echo "    $(green './main.sh -c')        Cloud name to use when bootstrapping, must be one of provider types listed above"

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -2,13 +2,12 @@ run_deploy_ck() {
 	echo
 
 	local name model_name file overlay_path storage_path
-	name="deploy-ck"
-	model_name="test-${name}"
+	name="${2}"
+	model_name="${name}"
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
 	
-	echo "BOOTSTRAP_PROVIDER => $BOOTSTRAP_PROVIDER"
 	overlay_path="./tests/suites/ck/overlay/${BOOTSTRAP_PROVIDER}.yaml"
 	juju deploy charmed-kubernetes  --overlay "${overlay_path}" --trust
 	
@@ -65,8 +64,11 @@ test_deploy_ck() {
 		set_verbosity
 
 		cd .. || exit
+		local run_deploy_ck_name="deploy-ck"
+		run "run_deploy_ck" "${run_deploy_ck_name}"
 
-		run "run_deploy_ck"
 		run "run_deploy_caas_workload"
+
+		destroy_model "${run_deploy_ck_name}"
 	)
 }

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -1,0 +1,73 @@
+run_deploy_ck() {
+	echo
+
+	local name model_name file overlay_path storage_path
+	name="deploy-ck"
+	model_name="test-${name}"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+	
+	echo "BOOTSTRAP_PROVIDER => $BOOTSTRAP_PROVIDER"
+	# echo "BOOTSTRAP_CLOUD => $BOOTSTRAP_CLOUD"
+	overlay_path="./tests/suites/ck/overlay/${BOOTSTRAP_PROVIDER}.yaml"
+	juju deploy charmed-kubernetes  --overlay "${overlay_path}" --trust
+	
+	if ! which "kubectl" >/dev/null 2>&1; then
+		sudo snap install kubectl --classic --channel latest/stable
+	fi
+
+	wait_for "active" '.applications["kubernetes-master"] | ."application-status".current'
+
+	juju scp kubernetes-master/0:config ~/.kube/config
+	
+	kubectl cluster-info
+	kubectl get ns
+	storage_path="./tests/suites/ck/storage/${BOOTSTRAP_PROVIDER}.yaml"
+	kubectl create -f "${storage_path}"
+	kubectl get sc -o yaml
+	# destroy_model "${model_name}"
+}
+
+run_deploy_caas_workload() {
+	echo
+	
+	local name k8s_cloud_name model_name file storage controller_name
+	
+	name="deploy-caas-workload"
+	k8s_cloud_name="k8s-cloud"
+	model_name="test-${name}"
+	file="${TEST_DIR}/${model_name}.log"
+	
+	storage=$(kubectl get sc -o json | jq -r '.items[] | select(.metadata.annotations."storageclass.kubernetes.io/is-default-class"=="true") | .metadata.name')
+
+	controller_name=$(juju controllers --format json | jq -r '.controllers | keys[0]')
+	juju add-k8s "${k8s_cloud_name}" --storage "${storage}" --controller "${controller_name}" 2>&1 | OUTPUT "${file}"
+	
+	add_model "${model_name}" "${k8s_cloud_name}" "${controller_name}" "${file}"
+
+	juju deploy cs:~juju/mariadb-k8s-3
+	juju deploy cs:~juju/mediawiki-k8s-4 --config kubernetes-service-type=loadbalancer
+	juju relate mediawiki-k8s:db mariadb-k8s:server
+
+	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current'
+	wait_for "active" '.applications["mediawiki-k8s"] | ."application-status".current'
+
+	destroy_model "${model_name}"
+}
+
+test_deploy_ck() {
+	if [ "$(skip 'test_deploy_ck')" ]; then
+		echo "==> TEST SKIPPED: Test Deploy CK"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_deploy_ck"
+		run "run_deploy_caas_workload"
+	)
+}

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -18,6 +18,7 @@ run_deploy_ck() {
 	fi
 
 	wait_for "active" '.applications["kubernetes-master"] | ."application-status".current'
+	wait_for "active" '.applications["kubernetes-worker"] | ."application-status".current'
 
 	juju scp kubernetes-master/0:config ~/.kube/config
 	
@@ -26,7 +27,6 @@ run_deploy_ck() {
 	storage_path="./tests/suites/ck/storage/${BOOTSTRAP_PROVIDER}.yaml"
 	kubectl create -f "${storage_path}"
 	kubectl get sc -o yaml
-	# destroy_model "${model_name}"
 }
 
 run_deploy_caas_workload() {

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -9,7 +9,6 @@ run_deploy_ck() {
 	ensure "${model_name}" "${file}"
 	
 	echo "BOOTSTRAP_PROVIDER => $BOOTSTRAP_PROVIDER"
-	# echo "BOOTSTRAP_CLOUD => $BOOTSTRAP_CLOUD"
 	overlay_path="./tests/suites/ck/overlay/${BOOTSTRAP_PROVIDER}.yaml"
 	juju deploy charmed-kubernetes  --overlay "${overlay_path}" --trust
 	

--- a/tests/suites/ck/overlay/aws.yaml
+++ b/tests/suites/ck/overlay/aws.yaml
@@ -1,0 +1,12 @@
+description: Charmed Kubernetes overlay to add native AWS support.
+applications:
+  aws-integrator:
+    annotations:
+      gui-x: "600"
+      gui-y: "300"
+    charm: cs:~containers/aws-integrator
+    num_units: 1
+    trust: true
+relations:
+  - ['aws-integrator', 'kubernetes-master']
+  - ['aws-integrator', 'kubernetes-worker']

--- a/tests/suites/ck/overlay/azure.yaml
+++ b/tests/suites/ck/overlay/azure.yaml
@@ -7,6 +7,24 @@ applications:
     charm: cs:~containers/azure-integrator
     num_units: 1
     trust: true
+  kubernetes-worker:
+    annotations:
+      gui-x: '90'
+      gui-y: '850'
+    charm: cs:~containers/kubernetes-worker-838
+    constraints: cores=2 mem=4G root-disk=16G
+    expose: true
+    num_units: 3
+    options:
+      channel: 1.23/stable
+    resources:
+      cni-amd64: 983
+      cni-arm64: 974
+      cni-s390x: 986
+      core: 0
+      kube-proxy: 0
+      kubectl: 0
+      kubelet: 0
 relations:
   - ['azure-integrator', 'kubernetes-master:azure']
   - ['azure-integrator', 'kubernetes-worker:azure']

--- a/tests/suites/ck/overlay/azure.yaml
+++ b/tests/suites/ck/overlay/azure.yaml
@@ -1,0 +1,12 @@
+description: Charmed Kubernetes overlay to add native Azure support.
+applications:
+  azure-integrator:
+    annotations:
+      gui-x: "600"
+      gui-y: "300"
+    charm: cs:~containers/azure-integrator
+    num_units: 1
+    trust: true
+relations:
+  - ['azure-integrator', 'kubernetes-master:azure']
+  - ['azure-integrator', 'kubernetes-worker:azure']

--- a/tests/suites/ck/overlay/gce.yaml
+++ b/tests/suites/ck/overlay/gce.yaml
@@ -7,6 +7,24 @@ applications:
     charm: cs:~containers/gcp-integrator
     num_units: 1
     trust: true
+  kubernetes-worker:
+    annotations:
+      gui-x: '90'
+      gui-y: '850'
+    charm: cs:~containers/kubernetes-worker-838
+    constraints: cores=2 mem=4G root-disk=16G
+    expose: true
+    num_units: 3
+    options:
+      channel: 1.23/stable
+    resources:
+      cni-amd64: 983
+      cni-arm64: 974
+      cni-s390x: 986
+      core: 0
+      kube-proxy: 0
+      kubectl: 0
+      kubelet: 0
 relations:
   - ['gcp-integrator', 'kubernetes-master']
   - ['gcp-integrator', 'kubernetes-worker']

--- a/tests/suites/ck/overlay/gce.yaml
+++ b/tests/suites/ck/overlay/gce.yaml
@@ -1,0 +1,12 @@
+description: Charmed Kubernetes overlay to add native GCP support.
+applications:
+  gcp-integrator:
+    annotations:
+      gui-x: "600"
+      gui-y: "300"
+    charm: cs:~containers/gcp-integrator
+    num_units: 1
+    trust: true
+relations:
+  - ['gcp-integrator', 'kubernetes-master']
+  - ['gcp-integrator', 'kubernetes-worker']

--- a/tests/suites/ck/storage/aws.yaml
+++ b/tests/suites/ck/storage/aws.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-gp2
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2

--- a/tests/suites/ck/storage/azure.yaml
+++ b/tests/suites/ck/storage/azure.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: azure-standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/azure-disk
+parameters:
+  storageaccounttype: Standard_LRS
+  kind: managed

--- a/tests/suites/ck/storage/gce.yaml
+++ b/tests/suites/ck/storage/gce.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gcp-standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -1,0 +1,19 @@
+test_ck() {
+	if [ "$(skip 'test_ck')" ]; then
+		echo "==> TEST SKIPPED: CK tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-ck.log"
+
+	bootstrap "test-ck" "${file}"
+
+	test_deploy_ck
+
+	destroy_controller "test-ck"
+}


### PR DESCRIPTION
Setup CI test for deploying CK;

Also a few bug fixes:
- fixed wrong cloud_name logic in add_model();
- destroy_model with --destroy-storage;
-  bootstrap() now uses the region from `-R`;
- cloud name of `lxd` should be `localhost` rather than `lxd`;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] ~Comments answer the question of why design decisions were made~

## QA steps

```console
$ ./tests/main.sh -v -p aws ck

# this is not working due to https://bugs.launchpad.net/charm-gcp-integrator/+bug/1964063
$ ./tests/main.sh -v -p google ck

# this is not working due to https://bugs.launchpad.net/charm-azure-integrator/+bug/1964067
$ ./tests/main.sh -v -p azure ck
```

## Documentation changes

No

## Bug reference

No
