### PR TITLE
[JUJU-691] Raft notify proxy worker

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -84,6 +84,7 @@ import (
 	"github.com/juju/juju/worker/raft/raftclusterer"
 	"github.com/juju/juju/worker/raft/raftflag"
 	"github.com/juju/juju/worker/raft/raftforwarder"
+	"github.com/juju/juju/worker/raft/raftnotifier"
 	"github.com/juju/juju/worker/raft/rafttransport"
 	"github.com/juju/juju/worker/reboot"
 	"github.com/juju/juju/worker/restorewatcher"
@@ -774,16 +775,23 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Path:              "/raft",
 		})),
 
+		raftNotifyProxy: ifController(raftnotifier.Manifold(raftnotifier.ManifoldConfig{
+			StateName: stateName,
+			RaftName:  raftName,
+			Logger:    loggo.GetLogger("juju.worker.raft.raftnotifier"),
+			NewTarget: raftnotifier.NewTarget,
+			NewWorker: raftnotifier.NewWorker,
+		})),
+
 		raftName: ifFullyUpgraded(raft.Manifold(raft.ManifoldConfig{
 			ClockName:            clockName,
 			AgentName:            agentName,
 			TransportName:        raftTransportName,
-			StateName:            stateName,
 			FSM:                  config.LeaseFSM,
 			Logger:               loggo.GetLogger("juju.worker.raft"),
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            raft.NewWorker,
-			NewTarget:            raft.NewTarget,
+			NewNotifyTarget:      raft.NewTarget,
 			Queue:                config.RaftOpQueue,
 			NewApplier:           raft.NewApplier,
 		})),
@@ -1199,6 +1207,7 @@ const (
 	raftFlagName      = "raft-leader-flag"
 	raftBackstopName  = "raft-backstop"
 	raftForwarderName = "raft-forwarder"
+	raftNotifyProxy   = "raft-notifier"
 
 	validCredentialFlagName = "valid-credential-flag"
 

--- a/core/raft/notifyproxy/notifyproxy.go
+++ b/core/raft/notifyproxy/notifyproxy.go
@@ -29,17 +29,6 @@ const (
 	ExpirationsTimeout = time.Second * 30
 )
 
-// NotifyType defines a notification type.
-type NotifyType string
-
-const (
-	// Claimed defines the claimed notification type.
-	Claimed NotifyType = "claimed"
-
-	// Expirations defines the expirations notification type.
-	Expirations NotifyType = "expirations"
-)
-
 // NotificationProxy allows notifications to be sent via a proxy, rather than
 // directly to state, allowing the decoupling of state to a given worker.
 type NotificationProxy interface {
@@ -50,9 +39,6 @@ type NotificationProxy interface {
 
 // Notification defines a typed notification sent from the proxy.
 type Notification interface {
-	// Type returns the notification type.
-	Type() NotifyType
-
 	// ErrorResponse is used to notify the proxy call of any potential errors
 	// when sending.
 	ErrorResponse(error)
@@ -63,11 +49,6 @@ type ClaimedNote struct {
 	Key      lease.Key
 	Holder   string
 	response func(error)
-}
-
-// Type returns the notification type.
-func (ClaimedNote) Type() NotifyType {
-	return Claimed
 }
 
 // ErrorResponse is used to notify the proxy call of any potential errors
@@ -83,10 +64,6 @@ func (n ClaimedNote) ErrorResponse(err error) {
 type ExpirationsNote struct {
 	Expirations []raftlease.Expired
 	response    func(error)
-}
-
-func (ExpirationsNote) Type() NotifyType {
-	return Expirations
 }
 
 // ErrorResponse is used to notify the proxy call of any potential errors

--- a/core/raft/notifyproxy/notifyproxy.go
+++ b/core/raft/notifyproxy/notifyproxy.go
@@ -1,0 +1,197 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package notifyproxy
+
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+	"gopkg.in/tomb.v2"
+)
+
+const (
+	// BufferSize is the amount of notifications to enqueue before dropping the
+	// oldest.
+	BufferSize int = 512
+)
+
+// NotifyType defines a notification type.
+type NotifyType string
+
+const (
+	// Claimed defines the claimed notification type.
+	Claimed NotifyType = "claimed"
+
+	// Expiries defines the expiries notification type.
+	Expiries NotifyType = "expiries"
+)
+
+// NotificationProxy allows notifications to be sent via a proxy, rather than
+// directly to state, allowing the decoupling of state to a given worker.
+type NotificationProxy interface {
+	// Notifications returns a channel of notifications from a given notify
+	// target.
+	Notifications() <-chan []Notification
+}
+
+// Notification defines a typed notification sent from the proxy.
+type Notification interface {
+	// Type returns the notification type.
+	Type() NotifyType
+
+	// ErrorResponse is used to notify the proxy call of any potential errors
+	// when sending.
+	ErrorResponse(error)
+}
+
+// ClaimedNote returns the information associated with a claimed request.
+type ClaimedNote struct {
+	Key      lease.Key
+	Holder   string
+	response func(error)
+}
+
+// Type returns the notification type.
+func (ClaimedNote) Type() NotifyType {
+	return Claimed
+}
+
+// ErrorResponse is used to notify the proxy call of any potential errors
+// when sending.
+func (n ClaimedNote) ErrorResponse(err error) {
+	if n.response != nil {
+		n.response(err)
+	}
+}
+
+// ExpiriesNote returns the information associated with a expiries request.
+type ExpiriesNote struct {
+	Expiries []raftlease.Expired
+	response func(error)
+}
+
+func (ExpiriesNote) Type() NotifyType {
+	return Expiries
+}
+
+// ErrorResponse is used to notify the proxy call of any potential errors
+// when sending.
+func (n ExpiriesNote) ErrorResponse(err error) {
+	if n.response != nil {
+		n.response(err)
+	}
+}
+
+type NotifyProxy struct {
+	tomb *tomb.Tomb
+	in   chan Notification
+	out  chan []Notification
+}
+
+// New creates a new NotifyProxy.
+func New() *NotifyProxy {
+	proxy := &NotifyProxy{
+		tomb: new(tomb.Tomb),
+		in:   make(chan Notification),
+		out:  make(chan []Notification),
+	}
+	proxy.tomb.Go(proxy.loop)
+	return proxy
+}
+
+// Claimed will be called when a new lease has been claimed.
+func (p *NotifyProxy) Claimed(key lease.Key, holder string) error {
+	var err error
+	select {
+	case <-p.tomb.Dying():
+		return tomb.ErrDying
+	case <-p.tomb.Dead():
+		return p.tomb.Err()
+	case p.in <- ClaimedNote{
+		Key:    key,
+		Holder: holder,
+		response: func(e error) {
+			err = e
+		},
+	}:
+	}
+	return errors.Trace(err)
+}
+
+// Expiries will be called when a set of existing leases have expired.
+func (p *NotifyProxy) Expiries(expiries []raftlease.Expired) error {
+	var err error
+	select {
+	case <-p.tomb.Dying():
+		return tomb.ErrDying
+	case <-p.tomb.Dead():
+		return p.tomb.Err()
+	case p.in <- ExpiriesNote{
+		Expiries: expiries,
+		response: func(e error) {
+			err = e
+		},
+	}:
+	}
+	return errors.Trace(err)
+}
+
+// Notifications returns a channel of notifications from a given notify
+// target.
+func (p *NotifyProxy) Notifications() <-chan []Notification {
+	return p.out
+}
+
+// Close the NotifyProxy.
+func (p *NotifyProxy) Close() error {
+	p.Kill(nil)
+	return p.Wait()
+}
+
+// Kill puts the tomb in a dying state for the given reason,
+// closes the Dying channel, and sets Alive to false.
+func (p *NotifyProxy) Kill(reason error) {
+	p.tomb.Kill(reason)
+}
+
+// Wait blocks until all goroutines have finished running, and
+// then returns the reason for their death.
+func (p *NotifyProxy) Wait() error {
+	return p.tomb.Wait()
+}
+
+func (p *NotifyProxy) loop() error {
+	defer close(p.out)
+
+	out := p.out
+
+	var buffer []Notification
+	for {
+		select {
+		case <-p.tomb.Dying():
+			return tomb.ErrDying
+		case <-p.tomb.Dead():
+			return p.tomb.Err()
+		case note := <-p.in:
+			// This would be better a linked list, so that we can just grab
+			// the tail and drop the head.
+			if len(buffer) == BufferSize {
+				buffer = buffer[1:]
+			}
+			buffer = append(buffer, note)
+			out = p.out
+
+		case out <- buffer:
+			buffer = make([]Notification, 0)
+			out = nil
+
+		default:
+			// If there is no work to do, pause briefly
+			// so that this loop is not thrashing CPU.
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}

--- a/core/raft/notifyproxy/notifyproxy_test.go
+++ b/core/raft/notifyproxy/notifyproxy_test.go
@@ -120,19 +120,19 @@ func (s *NotifyProxySuite) TestExpiries(c *gc.C) {
 		Key:    lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"},
 		Holder: "meshuggah",
 	}}
-	err := proxy.Expiries(expected)
+	err := proxy.Expirations(expected)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 
 	for _, note := range results {
-		c.Assert(note.Type(), gc.Equals, Expiries)
-		expiry, ok := note.(ExpiriesNote)
+		c.Assert(note.Type(), gc.Equals, Expirations)
+		expiry, ok := note.(ExpirationsNote)
 		c.Assert(ok, jc.IsTrue)
-		c.Assert(expiry.Expiries, jc.DeepEquals, expected)
+		c.Assert(expiry.Expirations, jc.DeepEquals, expected)
 	}
 }
 
-func (s *NotifyProxySuite) TestExpiriesWithBatch(c *gc.C) {
+func (s *NotifyProxySuite) TestExpirationsWithBatch(c *gc.C) {
 	proxy := NewBlocking(clock.WallClock)
 	defer proxy.Close()
 
@@ -153,15 +153,15 @@ func (s *NotifyProxySuite) TestExpiriesWithBatch(c *gc.C) {
 		Key:    lease.Key{Namespace: "ns", ModelUUID: "model2", Lease: "lease2"},
 		Holder: "nadir",
 	}}
-	err := proxy.Expiries(expected)
+	err := proxy.Expirations(expected)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 
 	for _, note := range results {
-		c.Assert(note.Type(), gc.Equals, Expiries)
-		expiry, ok := note.(ExpiriesNote)
+		c.Assert(note.Type(), gc.Equals, Expirations)
+		expiry, ok := note.(ExpirationsNote)
 		c.Assert(ok, jc.IsTrue)
-		c.Assert(expiry.Expiries, jc.DeepEquals, expected)
+		c.Assert(expiry.Expirations, jc.DeepEquals, expected)
 	}
 }
 

--- a/core/raft/notifyproxy/notifyproxy_test.go
+++ b/core/raft/notifyproxy/notifyproxy_test.go
@@ -1,0 +1,172 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package notifyproxy
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raftlease"
+)
+
+type NotifyProxySuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&NotifyProxySuite{})
+
+func (s *NotifyProxySuite) TestSendingWithNoWaiting(c *gc.C) {
+	proxy := NewNonBlocking(clock.WallClock)
+	defer proxy.Close()
+
+	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
+	err := proxy.Claimed(key, "meshuggah")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *NotifyProxySuite) TestSendingWithNoWaitingOverflowsBuffer(c *gc.C) {
+	proxy := NewNonBlocking(clock.WallClock)
+	defer proxy.Close()
+
+	// Issue the claimed commands,
+	for i := 0; i < BufferSize+2; i++ {
+		key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
+		err := proxy.Claimed(key, fmt.Sprintf("meshuggah%d", i))
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	// Once all claimed commands have been issued, then start to consume them.
+	done := make(chan struct{})
+	results := make([]Notification, 0)
+	go func() {
+		defer close(done)
+
+		for notes := range proxy.Notifications() {
+			for _, note := range notes {
+				note.ErrorResponse(nil)
+				results = append(results, note)
+			}
+			if len(results) >= BufferSize {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting")
+	}
+
+	// As we overflowed the buffer, we should only get the buffered amount, not
+	// all of them.
+	for k, note := range results {
+		c.Assert(note.Type(), gc.Equals, Claimed)
+		expiry, ok := note.(ClaimedNote)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(expiry.Holder, gc.Equals, fmt.Sprintf("meshuggah%d", k+2))
+	}
+}
+
+func (s *NotifyProxySuite) TestClaimed(c *gc.C) {
+	proxy := NewBlocking(clock.WallClock)
+	defer proxy.Close()
+
+	results := make([]Notification, 0)
+	go func() {
+		for notes := range proxy.Notifications() {
+			for _, note := range notes {
+				note.ErrorResponse(nil)
+				results = append(results, note)
+			}
+		}
+	}()
+
+	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
+	err := proxy.Claimed(key, "meshuggah")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+
+	for _, note := range results {
+		c.Assert(note.Type(), gc.Equals, Claimed)
+		expiry, ok := note.(ClaimedNote)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(expiry.Holder, gc.Equals, "meshuggah")
+	}
+}
+
+func (s *NotifyProxySuite) TestExpiries(c *gc.C) {
+	proxy := NewBlocking(clock.WallClock)
+	defer proxy.Close()
+
+	results := make([]Notification, 0)
+	go func() {
+		for notes := range proxy.Notifications() {
+			for _, note := range notes {
+				note.ErrorResponse(nil)
+				results = append(results, note)
+			}
+		}
+	}()
+
+	expected := []raftlease.Expired{{
+		Key:    lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"},
+		Holder: "meshuggah",
+	}}
+	err := proxy.Expiries(expected)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+
+	for _, note := range results {
+		c.Assert(note.Type(), gc.Equals, Expiries)
+		expiry, ok := note.(ExpiriesNote)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(expiry.Expiries, jc.DeepEquals, expected)
+	}
+}
+
+func (s *NotifyProxySuite) TestExpiriesWithBatch(c *gc.C) {
+	proxy := NewBlocking(clock.WallClock)
+	defer proxy.Close()
+
+	results := make([]Notification, 0)
+	go func() {
+		for notes := range proxy.Notifications() {
+			for _, note := range notes {
+				note.ErrorResponse(nil)
+				results = append(results, note)
+			}
+		}
+	}()
+
+	expected := []raftlease.Expired{{
+		Key:    lease.Key{Namespace: "ns", ModelUUID: "model1", Lease: "lease1"},
+		Holder: "meshuggah",
+	}, {
+		Key:    lease.Key{Namespace: "ns", ModelUUID: "model2", Lease: "lease2"},
+		Holder: "nadir",
+	}}
+	err := proxy.Expiries(expected)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+
+	for _, note := range results {
+		c.Assert(note.Type(), gc.Equals, Expiries)
+		expiry, ok := note.(ExpiriesNote)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(expiry.Expiries, jc.DeepEquals, expected)
+	}
+}
+
+func (s *NotifyProxySuite) TestClose(c *gc.C) {
+	proxy := NewBlocking(clock.WallClock)
+	err := proxy.Close()
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/core/raft/notifyproxy/notifyproxy_test.go
+++ b/core/raft/notifyproxy/notifyproxy_test.go
@@ -71,7 +71,6 @@ func (s *NotifyProxySuite) TestSendingWithNoWaitingOverflowsBuffer(c *gc.C) {
 	// As we overflowed the buffer, we should only get the buffered amount, not
 	// all of them.
 	for k, note := range results {
-		c.Assert(note.Type(), gc.Equals, Claimed)
 		expiry, ok := note.(ClaimedNote)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(expiry.Holder, gc.Equals, fmt.Sprintf("meshuggah%d", k+2))
@@ -105,7 +104,6 @@ func (s *NotifyProxySuite) TestClaimed(c *gc.C) {
 	c.Assert(results, gc.HasLen, 1)
 
 	for _, note := range results {
-		c.Assert(note.Type(), gc.Equals, Claimed)
 		expiry, ok := note.(ClaimedNote)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(expiry.Holder, gc.Equals, "meshuggah")
@@ -142,7 +140,6 @@ func (s *NotifyProxySuite) TestExpirations(c *gc.C) {
 	c.Assert(results, gc.HasLen, 1)
 
 	for _, note := range results {
-		c.Assert(note.Type(), gc.Equals, Expirations)
 		expiry, ok := note.(ExpirationsNote)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(expiry.Expirations, jc.DeepEquals, expected)
@@ -182,7 +179,6 @@ func (s *NotifyProxySuite) TestExpirationsWithBatch(c *gc.C) {
 	c.Assert(results, gc.HasLen, 1)
 
 	for _, note := range results {
-		c.Assert(note.Type(), gc.Equals, Expirations)
 		expiry, ok := note.(ExpirationsNote)
 		c.Assert(ok, jc.IsTrue)
 		c.Assert(expiry.Expirations, jc.DeepEquals, expected)

--- a/core/raft/notifyproxy/package_test.go
+++ b/core/raft/notifyproxy/package_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package notifyproxy
+
+import (
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coretesting "github.com/juju/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type ImportTest struct{}
+
+var _ = gc.Suite(&ImportTest{})
+
+func (*ImportTest) TestImports(c *gc.C) {
+	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/raft/notifyproxy")
+
+	// This package brings in nothing else from outside juju/juju/core
+	c.Assert(found, jc.SameContents, []string{
+		"core/globalclock",
+		"core/lease",
+		"core/raftlease",
+	})
+
+}

--- a/core/raftlease/fsm.go
+++ b/core/raftlease/fsm.go
@@ -403,7 +403,7 @@ func (r *response) Notify(target NotifyTarget) error {
 	}
 	// One call expiries when we have some expired keys.
 	if len(r.expired) > 0 {
-		if err := target.Expiries(r.expired); err != nil {
+		if err := target.Expirations(r.expired); err != nil {
 			errs = append(errs, errors.Annotatef(err, "expirying leases"))
 		}
 	}

--- a/core/raftlease/fsm_test.go
+++ b/core/raftlease/fsm_test.go
@@ -1026,12 +1026,12 @@ func assertExpired(c *gc.C, resp raftlease.FSMResponse, keys ...lease.Key) {
 	var target fakeTarget
 	resp.Notify(&target)
 	for _, call := range target.Calls() {
-		c.Assert(call.FuncName, gc.Equals, "Expiries")
+		c.Assert(call.FuncName, gc.Equals, "Expirations")
 		c.Assert(call.Args, gc.HasLen, 1)
 
-		paramExpiries, ok := call.Args[0].([]raftlease.Expired)
+		paramExpirations, ok := call.Args[0].([]raftlease.Expired)
 		c.Assert(ok, gc.Equals, true)
-		for _, expired := range paramExpiries {
+		for _, expired := range paramExpirations {
 			_, found := keySet[expired.Key]
 			c.Assert(found, gc.Equals, true)
 			delete(keySet, expired.Key)
@@ -1054,8 +1054,8 @@ func (t *fakeTarget) Claimed(key lease.Key, holder string) error {
 	return t.NextErr()
 }
 
-func (t *fakeTarget) Expiries(expiries []raftlease.Expired) error {
-	t.AddCall("Expiries", expiries)
+func (t *fakeTarget) Expirations(expirations []raftlease.Expired) error {
+	t.AddCall("Expirations", expirations)
 	return t.NextErr()
 }
 

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -40,8 +40,8 @@ type NotifyTarget interface {
 	// Claimed will be called when a new lease has been claimed.
 	Claimed(lease.Key, string) error
 
-	// Expiries will be called when a set of existing leases have expired.
-	Expiries([]Expired) error
+	// Expirations will be called when a set of existing leases have expired.
+	Expirations([]Expired) error
 }
 
 // TrapdoorFunc returns a trapdoor to be attached to lease details for

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -96,7 +96,7 @@ func (s *leaseStore) RevokeLease(key lease.Key, holder string, stop <-chan struc
 		return lease.ErrInvalid
 	}
 	delete(s.entries, key)
-	_ = s.target.Expiries([]raftlease.Expired{{
+	_ = s.target.Expirations([]raftlease.Expired{{
 		Key:    key,
 		Holder: holder,
 	}})

--- a/state/raftlease/target.go
+++ b/state/raftlease/target.go
@@ -183,9 +183,9 @@ type leaseDoc struct {
 	Holder string
 }
 
-// Expiries is part of raftlease.NotifyTarget.
-func (t *notifyTarget) Expiries(expiries []raftlease.Expired) error {
-	if len(expiries) == 0 {
+// Expirations is part of raftlease.NotifyTarget.
+func (t *notifyTarget) Expirations(expirations []raftlease.Expired) error {
+	if len(expirations) == 0 {
 		return nil
 	}
 
@@ -195,7 +195,7 @@ func (t *notifyTarget) Expiries(expiries []raftlease.Expired) error {
 	// Cache all the document idents up front, incase we have to retry the
 	// transaction again. Also this serves as a de-duping process.
 	leaseDocs := make(map[string]leaseDoc)
-	for _, expired := range expiries {
+	for _, expired := range expirations {
 		key := expired.Key
 		docId := leaseHolderDocId(key.Namespace, key.ModelUUID, key.Lease)
 
@@ -265,7 +265,7 @@ func (t *notifyTarget) Expiries(expiries []raftlease.Expired) error {
 				Id: doc.Id,
 				Assert: bson.M{
 					// Ensure that the lease holder is the same holder as the
-					// one we where told to expire. This should prevent the
+					// one we were told to expire. This should prevent the
 					// race of removing a lease that might have been changed to
 					// another holder, before the batch remove.
 					fieldHolder: leaseDoc.Holder,

--- a/state/raftlease/target_test.go
+++ b/state/raftlease/target_test.go
@@ -194,7 +194,7 @@ func (s *targetSuite) TestExpired(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+	err = s.newTarget().Expirations([]coreraftlease.Expired{{
 		Key:    lease.Key{"leadership", "model", "twin"},
 		Holder: "kitamura",
 	}})
@@ -221,7 +221,7 @@ func (s *targetSuite) TestExpires(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+	err = s.newTarget().Expirations([]coreraftlease.Expired{{
 		Key:    lease.Key{"leadership", "model", "twin1"},
 		Holder: "kitamura1",
 	}, {
@@ -253,7 +253,7 @@ func (s *targetSuite) TestExpiresWithDifferentHolder(c *gc.C) {
 
 	// Attempt to expire this one, but it won't match. We should still expire
 	// the second lease.
-	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+	err = s.newTarget().Expirations([]coreraftlease.Expired{{
 		Key:    lease.Key{"leadership", "model", "twin1"},
 		Holder: "kitamura1",
 	}, {
@@ -292,7 +292,7 @@ func (s *targetSuite) TestExpiresWithDuplicateEntries(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+	err = s.newTarget().Expirations([]coreraftlease.Expired{{
 		Key:    lease.Key{"leadership", "model", "twin1"},
 		Holder: "kitamura1",
 	}, {
@@ -318,7 +318,7 @@ func (s *targetSuite) TestExpiresWithMissingRecord(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+	err = s.newTarget().Expirations([]coreraftlease.Expired{{
 		Key:    lease.Key{"leadership", "model", "twin1"},
 		Holder: "kitamura1",
 	}, {
@@ -330,7 +330,7 @@ func (s *targetSuite) TestExpiresWithMissingRecord(c *gc.C) {
 }
 
 func (s *targetSuite) TestExpiredNoRecord(c *gc.C) {
-	err := s.newTarget().Expiries([]coreraftlease.Expired{{
+	err := s.newTarget().Expirations([]coreraftlease.Expired{{
 		Key:    lease.Key{"leadership", "model", "twin"},
 		Holder: "kitamura",
 	}})
@@ -355,7 +355,7 @@ func (s *targetSuite) TestExpiredRemovedWhileRunning(c *gc.C) {
 		c.Assert(coll.Remove(nil), jc.ErrorIsNil)
 	}).Check()
 
-	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+	err = s.newTarget().Expirations([]coreraftlease.Expired{{
 		Key:    lease.Key{"leadership", "model", "twin"},
 		Holder: "kitamura",
 	}})
@@ -380,7 +380,7 @@ func (s *targetSuite) TestExpiredError(c *gc.C) {
 
 	s.mongo.txnErr = errors.Errorf("oops!")
 
-	err = s.newTarget().Expiries([]coreraftlease.Expired{{
+	err = s.newTarget().Expirations([]coreraftlease.Expired{{
 		Key:    lease.Key{"leadership", "model", "twin"},
 		Holder: "kitamura",
 	}})

--- a/worker/globalclockupdater/manifold_test.go
+++ b/worker/globalclockupdater/manifold_test.go
@@ -268,7 +268,7 @@ func (noopTarget) Claimed(lease.Key, string) error {
 	return nil
 }
 
-// Expired will be called when a set if existing leases have expired.
-func (noopTarget) Expiries([]raftlease.Expired) error {
+// Expirations will be called when a set if existing leases have expired.
+func (noopTarget) Expirations([]raftlease.Expired) error {
 	return nil
 }

--- a/worker/globalclockupdater/raftlease_test.go
+++ b/worker/globalclockupdater/raftlease_test.go
@@ -50,18 +50,18 @@ func (mr *MockNotifyTargetMockRecorder) Claimed(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Claimed", reflect.TypeOf((*MockNotifyTarget)(nil).Claimed), arg0, arg1)
 }
 
-// Expiries mocks base method.
-func (m *MockNotifyTarget) Expiries(arg0 []raftlease.Expired) error {
+// Expirations mocks base method.
+func (m *MockNotifyTarget) Expirations(arg0 []raftlease.Expired) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Expiries", arg0)
+	ret := m.ctrl.Call(m, "Expirations", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Expiries indicates an expected call of Expiries.
-func (mr *MockNotifyTargetMockRecorder) Expiries(arg0 interface{}) *gomock.Call {
+// Expirations indicates an expected call of Expirations.
+func (mr *MockNotifyTargetMockRecorder) Expirations(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expiries", reflect.TypeOf((*MockNotifyTarget)(nil).Expiries), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expirations", reflect.TypeOf((*MockNotifyTarget)(nil).Expirations), arg0)
 }
 
 // MockReadOnlyClock is a mock of ReadOnlyClock interface.

--- a/worker/raft/manifold.go
+++ b/worker/raft/manifold.go
@@ -179,5 +179,5 @@ type withRaftOutputs interface {
 // NewTarget creates a new lease notify proxy target using the dependencies in
 // a late fashion.
 func NewTarget() NotifyProxy {
-	return notifyproxy.New()
+	return notifyproxy.NewNonBlocking(clock.WallClock)
 }

--- a/worker/raft/manifold_test.go
+++ b/worker/raft/manifold_test.go
@@ -56,7 +56,7 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 			dataDir: filepath.Join("data", "dir"),
 		},
 	}
-	s.target = notifyproxy.New()
+	s.target = notifyproxy.NewNonBlocking(clock.WallClock)
 	s.fsm = &raft.SimpleFSM{}
 	s.logger = loggo.GetLogger("juju.worker.raft_test")
 	s.worker = &mockRaftWorker{

--- a/worker/raft/mock_test.go
+++ b/worker/raft/mock_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/worker/v3"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/raft/notifyproxy"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 )
@@ -50,6 +51,7 @@ type mockRaftWorker struct {
 	testing.Stub
 	r  *raft.Raft
 	ls raft.LogStore
+	np notifyproxy.NotificationProxy
 }
 
 func (r *mockRaftWorker) Raft() (*raft.Raft, error) {
@@ -60,6 +62,11 @@ func (r *mockRaftWorker) Raft() (*raft.Raft, error) {
 func (r *mockRaftWorker) LogStore() (raft.LogStore, error) {
 	r.MethodCall(r, "LogStore")
 	return r.ls, r.NextErr()
+}
+
+func (r *mockRaftWorker) NotifyProxy() (notifyproxy.NotificationProxy, error) {
+	r.MethodCall(r, "NotifyProxy")
+	return r.np, r.NextErr()
 }
 
 func (r *mockRaftWorker) Kill() {

--- a/worker/raft/raftlease_mock_test.go
+++ b/worker/raft/raftlease_mock_test.go
@@ -49,18 +49,18 @@ func (mr *MockNotifyTargetMockRecorder) Claimed(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Claimed", reflect.TypeOf((*MockNotifyTarget)(nil).Claimed), arg0, arg1)
 }
 
-// Expiries mocks base method.
-func (m *MockNotifyTarget) Expiries(arg0 []raftlease.Expired) error {
+// Expirations mocks base method.
+func (m *MockNotifyTarget) Expirations(arg0 []raftlease.Expired) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Expiries", arg0)
+	ret := m.ctrl.Call(m, "Expirations", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Expiries indicates an expected call of Expiries.
-func (mr *MockNotifyTargetMockRecorder) Expiries(arg0 interface{}) *gomock.Call {
+// Expirations indicates an expected call of Expirations.
+func (mr *MockNotifyTargetMockRecorder) Expirations(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expiries", reflect.TypeOf((*MockNotifyTarget)(nil).Expiries), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expirations", reflect.TypeOf((*MockNotifyTarget)(nil).Expirations), arg0)
 }
 
 // MockFSMResponse is a mock of FSMResponse interface.

--- a/worker/raft/raftnotifier/manifold.go
+++ b/worker/raft/raftnotifier/manifold.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftnotifier
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
+
+	"github.com/juju/juju/core/raft/notifyproxy"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/state"
+	raftleasestore "github.com/juju/juju/state/raftlease"
+	"github.com/juju/juju/worker/common"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+// ManifoldConfig holds the information necessary to run a raft
+// worker in a dependency.Engine.
+type ManifoldConfig struct {
+	StateName string
+	RaftName  string
+
+	Logger    Logger
+	NewWorker func(Config) (worker.Worker, error)
+	NewTarget func(*state.State, raftleasestore.Logger) raftlease.NotifyTarget
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	if config.RaftName == "" {
+		return errors.NotValidf("error RaftName")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	if config.NewTarget == nil {
+		return errors.NotValidf("nil NewTarget")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run a raft worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.StateName,
+		},
+		Start: config.start,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var notifyProxy notifyproxy.NotificationProxy
+	if err := context.Get(config.RaftName, &notifyProxy); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker workerstate.StateTracker
+	if err := context.Get(config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	notifyTarget := config.NewTarget(statePool.SystemState(), config.Logger)
+
+	w, err := config.NewWorker(Config{
+		Logger:       config.Logger,
+		NotifyTarget: notifyTarget,
+	})
+	if err != nil {
+		_ = stTracker.Done()
+		return nil, errors.Trace(err)
+	}
+	return common.NewCleanupWorker(w, func() { _ = stTracker.Done() }), nil
+}
+
+// NewTarget creates a new lease notify target using the dependencies in a late
+// fashion.
+func NewTarget(st *state.State, logger raftleasestore.Logger) raftlease.NotifyTarget {
+	return st.LeaseNotifyTarget(logger)
+}

--- a/worker/raft/raftnotifier/manifold.go
+++ b/worker/raft/raftnotifier/manifold.go
@@ -78,7 +78,13 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		return nil, errors.Trace(err)
 	}
 
-	notifyTarget := config.NewTarget(statePool.SystemState(), config.Logger)
+	sysState, err := statePool.SystemState()
+	if err != nil {
+		_ = stTracker.Done()
+		return nil, errors.Trace(err)
+	}
+
+	notifyTarget := config.NewTarget(sysState, config.Logger)
 
 	w, err := config.NewWorker(Config{
 		NotifyProxy:  notifyProxy,

--- a/worker/raft/raftnotifier/manifold.go
+++ b/worker/raft/raftnotifier/manifold.go
@@ -51,6 +51,7 @@ func (config ManifoldConfig) Validate() error {
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
+			config.RaftName,
 			config.StateName,
 		},
 		Start: config.start,
@@ -80,8 +81,9 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	notifyTarget := config.NewTarget(statePool.SystemState(), config.Logger)
 
 	w, err := config.NewWorker(Config{
-		Logger:       config.Logger,
+		NotifyProxy:  notifyProxy,
 		NotifyTarget: notifyTarget,
+		Logger:       config.Logger,
 	})
 	if err != nil {
 		_ = stTracker.Done()

--- a/worker/raft/raftnotifier/manifold_test.go
+++ b/worker/raft/raftnotifier/manifold_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -55,7 +56,7 @@ func (s *manifoldSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.raft = &raft.Raft{}
-	s.raftNotifyProxy = notifyproxy.New()
+	s.raftNotifyProxy = notifyproxy.NewNonBlocking(clock.WallClock)
 
 	s.worker = &mockWorker{}
 	s.logger = loggo.GetLogger("juju.worker.raftnotifier_test")

--- a/worker/raft/raftnotifier/manifold_test.go
+++ b/worker/raft/raftnotifier/manifold_test.go
@@ -1,0 +1,226 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftnotifier_test
+
+import (
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
+	dt "github.com/juju/worker/v3/dependency/testing"
+	"github.com/juju/worker/v3/workertest"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/raft/notifyproxy"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/state"
+	raftleasestore "github.com/juju/juju/state/raftlease"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/common"
+	"github.com/juju/juju/worker/raft/raftnotifier"
+)
+
+type manifoldSuite struct {
+	testing.IsolationSuite
+
+	context  dependency.Context
+	manifold dependency.Manifold
+	config   raftnotifier.ManifoldConfig
+
+	raft            *raft.Raft
+	raftNotifyProxy notifyproxy.NotificationProxy
+	stateTracker    *stubStateTracker
+	logger          loggo.Logger
+	worker          worker.Worker
+	target          raftlease.NotifyTarget
+
+	stub testing.Stub
+}
+
+var _ = gc.Suite(&manifoldSuite{})
+
+func (s *manifoldSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	s.stub.ResetCalls()
+
+	s.stateTracker = &stubStateTracker{
+		done: make(chan struct{}),
+	}
+
+	s.raft = &raft.Raft{}
+	s.raftNotifyProxy = notifyproxy.New()
+
+	s.worker = &mockWorker{}
+	s.logger = loggo.GetLogger("juju.worker.raftnotifier_test")
+	s.target = &struct{ raftlease.NotifyTarget }{}
+
+	s.context = s.newContext(nil)
+	s.config = raftnotifier.ManifoldConfig{
+		RaftName:  "raft",
+		StateName: "state",
+		Logger:    &s.logger,
+		NewWorker: s.newWorker,
+		NewTarget: s.newTarget,
+	}
+	s.manifold = raftnotifier.Manifold(s.config)
+}
+
+func (s *manifoldSuite) newContext(overlay map[string]interface{}) dependency.Context {
+	resources := map[string]interface{}{
+		"raft":  s.raftNotifyProxy,
+		"state": s.stateTracker,
+	}
+	for k, v := range overlay {
+		resources[k] = v
+	}
+	return dt.StubContext(nil, resources)
+}
+
+func (s *manifoldSuite) newWorker(config raftnotifier.Config) (worker.Worker, error) {
+	s.stub.MethodCall(s, "NewWorker", config)
+	if err := s.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	return s.worker, nil
+}
+
+func (s *manifoldSuite) newTarget(st *state.State, logger raftleasestore.Logger) raftlease.NotifyTarget {
+	s.stub.MethodCall(s, "NewTarget", st, logger)
+	return s.target
+}
+
+func (s *manifoldSuite) TestValidate(c *gc.C) {
+	c.Assert(s.config.Validate(), jc.ErrorIsNil)
+	type test struct {
+		f      func(cfg *raftnotifier.ManifoldConfig)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *raftnotifier.ManifoldConfig) { cfg.StateName = "" },
+		"empty StateName not valid",
+	}, {
+		func(cfg *raftnotifier.ManifoldConfig) { cfg.Logger = nil },
+		"nil Logger not valid",
+	}, {
+		func(cfg *raftnotifier.ManifoldConfig) { cfg.NewWorker = nil },
+		"nil NewWorker not valid",
+	}, {
+		func(cfg *raftnotifier.ManifoldConfig) { cfg.NewTarget = nil },
+		"nil NewTarget not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		// Local copy before mutating.
+		cfg := s.config
+		test.f(&cfg)
+		c.Assert(cfg.Validate(), gc.ErrorMatches, test.expect)
+	}
+}
+
+var expectedInputs = []string{
+	"raft", "state",
+}
+
+func (s *manifoldSuite) TestInputs(c *gc.C) {
+	c.Assert(s.manifold.Inputs, jc.SameContents, expectedInputs)
+}
+
+func (s *manifoldSuite) TestMissingInputs(c *gc.C) {
+	for _, input := range expectedInputs {
+		context := s.newContext(map[string]interface{}{
+			input: dependency.ErrMissing,
+		})
+		_, err := s.manifold.Start(context)
+		c.Assert(errors.Cause(err), gc.Equals, dependency.ErrMissing)
+	}
+}
+
+func (s *manifoldSuite) TestStart(c *gc.C) {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+	cleanupW, ok := w.(*common.CleanupWorker)
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(cleanupW.Worker, gc.Equals, s.worker)
+
+	s.stub.CheckCallNames(c, "NewTarget", "NewWorker")
+
+	args := s.stub.Calls()[0].Args
+	c.Assert(args, gc.HasLen, 2)
+	c.Assert(args[0], gc.Equals, s.stateTracker.pool.SystemState())
+	var logWriter raftleasestore.Logger
+	c.Assert(args[1], gc.Implements, &logWriter)
+
+	args = s.stub.Calls()[1].Args
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0], gc.FitsTypeOf, raftnotifier.Config{})
+	config := args[0].(raftnotifier.Config)
+
+	c.Assert(config, jc.DeepEquals, raftnotifier.Config{
+		NotifyProxy:  s.raftNotifyProxy,
+		NotifyTarget: s.target,
+		Logger:       &s.logger,
+	})
+}
+
+func (s *manifoldSuite) TestStoppingWorkerReleasesState(c *gc.C) {
+	w, err := s.manifold.Start(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.stateTracker.CheckCallNames(c, "Use")
+	select {
+	case <-s.stateTracker.done:
+		c.Fatal("unexpected state release")
+	case <-time.After(coretesting.ShortWait):
+	}
+
+	// Stopping the worker should cause the state to
+	// eventually be released.
+	workertest.CleanKill(c, w)
+
+	s.stateTracker.waitDone(c)
+	s.stateTracker.CheckCallNames(c, "Use", "Done")
+}
+
+type stubStateTracker struct {
+	testing.Stub
+	pool state.StatePool
+	done chan struct{}
+}
+
+func (s *stubStateTracker) Use() (*state.StatePool, error) {
+	s.MethodCall(s, "Use")
+	return &s.pool, s.NextErr()
+}
+
+func (s *stubStateTracker) Done() error {
+	s.MethodCall(s, "Done")
+	err := s.NextErr()
+	close(s.done)
+	return err
+}
+
+func (s *stubStateTracker) Report() map[string]interface{} {
+	return map[string]interface{}{"hey": "mum"}
+}
+
+func (s *stubStateTracker) waitDone(c *gc.C) {
+	select {
+	case <-s.done:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for state to be released")
+	}
+}
+
+type mockWorker struct{}
+
+func (w *mockWorker) Kill() {}
+func (w *mockWorker) Wait() error {
+	return nil
+}

--- a/worker/raft/raftnotifier/manifold_test.go
+++ b/worker/raft/raftnotifier/manifold_test.go
@@ -154,7 +154,11 @@ func (s *manifoldSuite) TestStart(c *gc.C) {
 
 	args := s.stub.Calls()[0].Args
 	c.Assert(args, gc.HasLen, 2)
-	c.Assert(args[0], gc.Equals, s.stateTracker.pool.SystemState())
+
+	sysState, err := s.stateTracker.pool.SystemState()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(args[0], gc.Equals, sysState)
+
 	var logWriter raftleasestore.Logger
 	c.Assert(args[1], gc.Implements, &logWriter)
 

--- a/worker/raft/raftnotifier/package_test.go
+++ b/worker/raft/raftnotifier/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftnotifier_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/raft/raftnotifier/worker.go
+++ b/worker/raft/raftnotifier/worker.go
@@ -1,0 +1,138 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftnotifier
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/catacomb"
+
+	"github.com/juju/juju/core/raft/notifyproxy"
+	"github.com/juju/juju/core/raftlease"
+)
+
+// Logger represents the logging methods called.
+type Logger interface {
+	Criticalf(message string, args ...interface{})
+	Warningf(message string, args ...interface{})
+	Errorf(message string, args ...interface{})
+	Infof(message string, args ...interface{})
+	Debugf(message string, args ...interface{})
+	Tracef(message string, args ...interface{})
+	Logf(level loggo.Level, message string, args ...interface{})
+	IsTraceEnabled() bool
+}
+
+// Config is the configuration required for running a raft worker.
+type Config struct {
+	// Logger is the logger for this worker.
+	Logger Logger
+
+	// NotifyProxy is a proxy for notifications for the notify target.
+	NotifyProxy notifyproxy.NotificationProxy
+
+	// NotifyTarget is used to notify the changes from the raft operation
+	// applications.
+	NotifyTarget raftlease.NotifyTarget
+}
+
+// Validate validates the raft worker configuration.
+func (config Config) Validate() error {
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if config.NotifyProxy == nil {
+		return errors.NotValidf("nil NotifyProxy")
+	}
+	if config.NotifyTarget == nil {
+		return errors.NotValidf("nil NotifyTarget")
+	}
+	return nil
+}
+
+// NewWorker returns a new raft worker, with the given configuration.
+func NewWorker(config Config) (worker.Worker, error) {
+	return newWorker(config)
+}
+
+func newWorker(config Config) (*Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &Worker{
+		config: config,
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: func() error {
+			return w.loop()
+		},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// Worker is a worker that manages a raft.Raft instance.
+type Worker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *Worker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *Worker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *Worker) loop() error {
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+
+		case changes := <-w.config.NotifyProxy.Notifications():
+			// TODO: (stickupkid): We should push these as a batch through
+			// the notify target.
+			for _, change := range changes {
+				switch change.Type() {
+				case notifyproxy.Claimed:
+					note := change.(notifyproxy.ClaimedNote)
+					err := w.config.NotifyTarget.Claimed(note.Key, note.Holder)
+
+					// We always want to sent the error response, so that the other
+					// end of the proxy can be notified if there was an error or
+					// not.
+					note.ErrorResponse(err)
+
+					// If there was an error, return out, so we get a fresh proxy
+					// state.
+					if err != nil {
+						return errors.Trace(err)
+					}
+
+				case notifyproxy.Expiries:
+					note := change.(notifyproxy.ExpiriesNote)
+					err := w.config.NotifyTarget.Expiries(note.Expiries)
+
+					// We always want to sent the error response, so that the other
+					// end of the proxy can be notified if there was an error or
+					// not.
+					note.ErrorResponse(err)
+
+					// If there was an error, return out, so we get a fresh proxy
+					// state.
+					if err != nil {
+						return errors.Trace(err)
+					}
+				}
+			}
+		}
+	}
+}

--- a/worker/raft/raftnotifier/worker.go
+++ b/worker/raft/raftnotifier/worker.go
@@ -117,9 +117,9 @@ func (w *Worker) loop() error {
 						return errors.Trace(err)
 					}
 
-				case notifyproxy.Expiries:
-					note := change.(notifyproxy.ExpiriesNote)
-					err := w.config.NotifyTarget.Expiries(note.Expiries)
+				case notifyproxy.Expirations:
+					note := change.(notifyproxy.ExpirationsNote)
+					err := w.config.NotifyTarget.Expirations(note.Expirations)
 
 					// We always want to sent the error response, so that the other
 					// end of the proxy can be notified if there was an error or

--- a/worker/raft/raftnotifier/worker_test.go
+++ b/worker/raft/raftnotifier/worker_test.go
@@ -4,6 +4,7 @@
 package raftnotifier_test
 
 import (
+	"github.com/juju/clock"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -32,7 +33,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.target = &fakeTarget{}
-	s.notifyProxy = notifyproxy.New()
+	s.notifyProxy = notifyproxy.NewBlocking(clock.WallClock)
 
 	s.config = raftnotifier.Config{
 		Logger:       loggo.GetLogger("raftnotifier_test"),

--- a/worker/raft/raftnotifier/worker_test.go
+++ b/worker/raft/raftnotifier/worker_test.go
@@ -111,14 +111,14 @@ func (s *workerSuite) TestClaimedSuccess(c *gc.C) {
 	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
 	err := s.notifyProxy.Claimed(key, "meshuggah")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.target.Claims, gc.DeepEquals, []Claimed{{
+	c.Assert(s.target.claims, gc.DeepEquals, []Claimed{{
 		Key:    key,
 		Holder: "meshuggah",
 	}})
 }
 
 func (s *workerSuite) TestClaimedError(c *gc.C) {
-	s.target.Err = errors.Errorf("boom")
+	s.target.err = errors.Errorf("boom")
 
 	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
 	err := s.notifyProxy.Claimed(key, "meshuggah")
@@ -130,13 +130,13 @@ func (s *workerSuite) TestClaimedError(c *gc.C) {
 
 func (s *workerSuite) TestExpiriesSuccess(c *gc.C) {
 	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
-	err := s.notifyProxy.Expiries([]raftlease.Expired{{
+	err := s.notifyProxy.Expirations([]raftlease.Expired{{
 		Key:    key,
 		Holder: "meshuggah",
 	}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.target.Expires, gc.DeepEquals, []Expiries{{
-		Expiries: []raftlease.Expired{{
+	c.Assert(s.target.expirations, gc.DeepEquals, []Expirations{{
+		Expirations: []raftlease.Expired{{
 			Key:    key,
 			Holder: "meshuggah",
 		}},
@@ -144,10 +144,10 @@ func (s *workerSuite) TestExpiriesSuccess(c *gc.C) {
 }
 
 func (s *workerSuite) TestExpiriesError(c *gc.C) {
-	s.target.Err = errors.Errorf("boom")
+	s.target.err = errors.Errorf("boom")
 
 	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
-	err := s.notifyProxy.Expiries([]raftlease.Expired{{
+	err := s.notifyProxy.Expirations([]raftlease.Expired{{
 		Key:    key,
 		Holder: "meshuggah",
 	}})
@@ -162,29 +162,29 @@ type Claimed struct {
 	Holder string
 }
 
-type Expiries struct {
-	Expiries []raftlease.Expired
+type Expirations struct {
+	Expirations []raftlease.Expired
 }
 
 type fakeTarget struct {
-	Claims  []Claimed
-	Expires []Expiries
-	Err     error
+	claims      []Claimed
+	expirations []Expirations
+	err         error
 }
 
 // Claimed will be called when a new lease has been claimed.
 func (t *fakeTarget) Claimed(key lease.Key, holder string) error {
-	t.Claims = append(t.Claims, Claimed{
+	t.claims = append(t.claims, Claimed{
 		Key:    key,
 		Holder: holder,
 	})
-	return t.Err
+	return t.err
 }
 
-// Expiries will be called when a set of existing leases have expired.
-func (t *fakeTarget) Expiries(expires []raftlease.Expired) error {
-	t.Expires = append(t.Expires, Expiries{
-		Expiries: expires,
+// Expirations will be called when a set of existing leases have expired.
+func (t *fakeTarget) Expirations(expires []raftlease.Expired) error {
+	t.expirations = append(t.expirations, Expirations{
+		Expirations: expires,
 	})
-	return t.Err
+	return t.err
 }

--- a/worker/raft/raftnotifier/worker_test.go
+++ b/worker/raft/raftnotifier/worker_test.go
@@ -1,0 +1,189 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package raftnotifier_test
+
+import (
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/workertest"
+	"github.com/pkg/errors"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/raft/notifyproxy"
+	"github.com/juju/juju/core/raftlease"
+	"github.com/juju/juju/worker/raft/raftnotifier"
+)
+
+type workerFixture struct {
+	testing.IsolationSuite
+
+	notifyProxy *notifyproxy.NotifyProxy
+	target      *fakeTarget
+	config      raftnotifier.Config
+}
+
+func (s *workerFixture) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	err := loggo.ConfigureLoggers("TRACE")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.target = &fakeTarget{}
+	s.notifyProxy = notifyproxy.New()
+
+	s.config = raftnotifier.Config{
+		Logger:       loggo.GetLogger("raftnotifier_test"),
+		NotifyTarget: s.target,
+		NotifyProxy:  s.notifyProxy,
+	}
+
+	s.AddCleanup(func(c *gc.C) {
+		s.notifyProxy.Close()
+	})
+}
+
+type workerValidationSuite struct {
+	workerFixture
+}
+
+var _ = gc.Suite(&workerValidationSuite{})
+
+func (s *workerValidationSuite) TestValidateErrors(c *gc.C) {
+	type test struct {
+		f      func(*raftnotifier.Config)
+		expect string
+	}
+	tests := []test{{
+		func(cfg *raftnotifier.Config) { cfg.Logger = nil },
+		"nil Logger not valid",
+	}, {
+		func(cfg *raftnotifier.Config) { cfg.NotifyProxy = nil },
+		"nil NotifyProxy not valid",
+	}, {
+		func(cfg *raftnotifier.Config) { cfg.NotifyTarget = nil },
+		"nil NotifyTarget not valid",
+	}}
+	for i, test := range tests {
+		c.Logf("test #%d (%s)", i, test.expect)
+		s.testValidateError(c, test.f, test.expect)
+	}
+}
+
+func (s *workerValidationSuite) testValidateError(c *gc.C, f func(*raftnotifier.Config), expect string) {
+	config := s.config
+	f(&config)
+	w, err := raftnotifier.NewWorker(config)
+	if !c.Check(err, gc.NotNil) {
+		workertest.DirtyKill(c, w)
+		return
+	}
+	c.Check(w, gc.IsNil)
+	c.Check(err, gc.ErrorMatches, expect)
+}
+
+type workerSuite struct {
+	workerFixture
+	worker worker.Worker
+}
+
+var _ = gc.Suite(&workerSuite{})
+
+func (s *workerSuite) SetUpTest(c *gc.C) {
+	s.workerFixture.SetUpTest(c)
+
+	worker, err := raftnotifier.NewWorker(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, worker)
+	})
+	s.worker = worker
+}
+
+func (s *workerSuite) TestCleanKill(c *gc.C) {
+	workertest.CleanKill(c, s.worker)
+}
+
+func (s *workerSuite) TestClaimedSuccess(c *gc.C) {
+	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
+	err := s.notifyProxy.Claimed(key, "meshuggah")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.target.Claims, gc.DeepEquals, []Claimed{{
+		Key:    key,
+		Holder: "meshuggah",
+	}})
+}
+
+func (s *workerSuite) TestClaimedError(c *gc.C) {
+	s.target.Err = errors.Errorf("boom")
+
+	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
+	err := s.notifyProxy.Claimed(key, "meshuggah")
+	c.Assert(err, gc.ErrorMatches, "boom")
+
+	err = workertest.CheckKilled(c, s.worker)
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *workerSuite) TestExpiriesSuccess(c *gc.C) {
+	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
+	err := s.notifyProxy.Expiries([]raftlease.Expired{{
+		Key:    key,
+		Holder: "meshuggah",
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.target.Expires, gc.DeepEquals, []Expiries{{
+		Expiries: []raftlease.Expired{{
+			Key:    key,
+			Holder: "meshuggah",
+		}},
+	}})
+}
+
+func (s *workerSuite) TestExpiriesError(c *gc.C) {
+	s.target.Err = errors.Errorf("boom")
+
+	key := lease.Key{Namespace: "ns", ModelUUID: "model", Lease: "lease"}
+	err := s.notifyProxy.Expiries([]raftlease.Expired{{
+		Key:    key,
+		Holder: "meshuggah",
+	}})
+	c.Assert(err, gc.ErrorMatches, "boom")
+
+	err = workertest.CheckKilled(c, s.worker)
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+type Claimed struct {
+	Key    lease.Key
+	Holder string
+}
+
+type Expiries struct {
+	Expiries []raftlease.Expired
+}
+
+type fakeTarget struct {
+	Claims  []Claimed
+	Expires []Expiries
+	Err     error
+}
+
+// Claimed will be called when a new lease has been claimed.
+func (t *fakeTarget) Claimed(key lease.Key, holder string) error {
+	t.Claims = append(t.Claims, Claimed{
+		Key:    key,
+		Holder: holder,
+	})
+	return t.Err
+}
+
+// Expiries will be called when a set of existing leases have expired.
+func (t *fakeTarget) Expiries(expires []raftlease.Expired) error {
+	t.Expires = append(t.Expires, Expiries{
+		Expiries: expires,
+	})
+	return t.Err
+}

--- a/worker/raft/worker.go
+++ b/worker/raft/worker.go
@@ -113,8 +113,8 @@ type NotifyProxy interface {
 	// Claimed will be called when a new lease has been claimed.
 	Claimed(key lease.Key, holder string) error
 
-	// Expiries will be called when a set of existing leases have expired.
-	Expiries(expiries []raftlease.Expired) error
+	// Expirations will be called when a set of existing leases have expired.
+	Expirations(expirations []raftlease.Expired) error
 
 	// Notifications returns a channel of notifications from a given notify
 	// target.

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
 
+	"github.com/juju/juju/core/raft/notifyproxy"
 	"github.com/juju/juju/core/raft/queue"
 	"github.com/juju/juju/core/raftlease"
 	coretesting "github.com/juju/juju/testing"
@@ -30,6 +31,7 @@ type workerFixture struct {
 	config     raft.Config
 	queue      *queue.OpQueue
 	operations chan []queue.OutOperation
+	target     *notifyproxy.NotifyProxy
 }
 
 func (s *workerFixture) SetUpTest(c *gc.C) {
@@ -38,16 +40,19 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.fsm = &raft.SimpleFSM{}
 	s.queue = queue.NewOpQueue(clock.WallClock)
 	s.operations = make(chan []queue.OutOperation)
+	s.target = notifyproxy.New()
 
 	s.config = raft.Config{
-		FSM:          s.fsm,
-		Logger:       loggo.GetLogger("juju.worker.raft_test"),
-		StorageDir:   c.MkDir(),
-		LocalID:      "123",
-		Transport:    s.newTransport("123"),
-		Clock:        testclock.NewClock(time.Time{}),
-		Queue:        s.queue,
-		NotifyTarget: &struct{ raftlease.NotifyTarget }{},
+		FSM:        s.fsm,
+		Logger:     loggo.GetLogger("juju.worker.raft_test"),
+		StorageDir: c.MkDir(),
+		LocalID:    "123",
+		Transport:  s.newTransport("123"),
+		Clock:      testclock.NewClock(time.Time{}),
+		Queue:      s.queue,
+		NewNotifyTarget: func() raft.NotifyProxy {
+			return s.target
+		},
 		NewApplier: func(raft.Raft, raftlease.NotifyTarget, raft.ApplierMetrics, clock.Clock, raft.Logger) raft.LeaseApplier {
 			return testLeaseApplier{operations: s.operations}
 		},
@@ -111,8 +116,8 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 		func(cfg *raft.Config) { cfg.Queue = nil },
 		"nil Queue not valid",
 	}, {
-		func(cfg *raft.Config) { cfg.NotifyTarget = nil },
-		"nil NotifyTarget not valid",
+		func(cfg *raft.Config) { cfg.NewNotifyTarget = nil },
+		"nil NewNotifyTarget not valid",
 	}, {
 		func(cfg *raft.Config) { cfg.NewApplier = nil },
 		"nil NewApplier not valid",
@@ -147,17 +152,17 @@ func (s *WorkerValidationSuite) TestBootstrapTransport(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "non-nil Transport during Bootstrap not valid")
 }
 
-func (s *WorkerValidationSuite) TestBootstrapNotifyTarget(c *gc.C) {
+func (s *WorkerValidationSuite) TestBootstrapNewNotifyTarget(c *gc.C) {
 	s.config.Transport = nil
 	s.config.FSM = nil
 	err := raft.Bootstrap(s.config)
-	c.Assert(err, gc.ErrorMatches, "non-nil NotifyTarget during Bootstrap not valid")
+	c.Assert(err, gc.ErrorMatches, "non-nil NewNotifyTarget during Bootstrap not valid")
 }
 
 func (s *WorkerValidationSuite) TestBootstrapNewApplier(c *gc.C) {
 	s.config.Transport = nil
 	s.config.FSM = nil
-	s.config.NotifyTarget = nil
+	s.config.NewNotifyTarget = nil
 	err := raft.Bootstrap(s.config)
 	c.Assert(err, gc.ErrorMatches, "non-nil NewApplier during Bootstrap not valid")
 }
@@ -181,12 +186,12 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	// Bootstrap before starting the worker.
 	transport := s.config.Transport
 	fsm := s.config.FSM
-	notifyTarget := s.config.NotifyTarget
+	notifyTarget := s.config.NewNotifyTarget
 	applyOp := s.config.NewApplier
 
 	s.config.Transport = nil
 	s.config.FSM = nil
-	s.config.NotifyTarget = nil
+	s.config.NewNotifyTarget = nil
 	s.config.NewApplier = nil
 
 	err := raft.Bootstrap(s.config)
@@ -194,7 +199,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 
 	s.config.Transport = transport
 	s.config.FSM = fsm
-	s.config.NotifyTarget = notifyTarget
+	s.config.NewNotifyTarget = notifyTarget
 	s.config.NewApplier = applyOp
 
 	// Make a new clock so the waits from the bootstrap aren't hanging
@@ -487,12 +492,12 @@ func (s *WorkerTimeoutSuite) SetUpTest(c *gc.C) {
 	// Bootstrap before starting the worker.
 	transport := s.config.Transport
 	fsm := s.config.FSM
-	notifyTarget := s.config.NotifyTarget
+	notifyTarget := s.config.NewNotifyTarget
 	applyOp := s.config.NewApplier
 
 	s.config.Transport = nil
 	s.config.FSM = nil
-	s.config.NotifyTarget = nil
+	s.config.NewNotifyTarget = nil
 	s.config.NewApplier = nil
 
 	err := raft.Bootstrap(s.config)
@@ -500,7 +505,7 @@ func (s *WorkerTimeoutSuite) SetUpTest(c *gc.C) {
 
 	s.config.Transport = transport
 	s.config.FSM = fsm
-	s.config.NotifyTarget = notifyTarget
+	s.config.NewNotifyTarget = notifyTarget
 	s.config.NewApplier = applyOp
 }
 

--- a/worker/raft/worker_test.go
+++ b/worker/raft/worker_test.go
@@ -40,7 +40,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.fsm = &raft.SimpleFSM{}
 	s.queue = queue.NewOpQueue(clock.WallClock)
 	s.operations = make(chan []queue.OutOperation)
-	s.target = notifyproxy.New()
+	s.target = notifyproxy.NewNonBlocking(clock.WallClock)
 
 	s.config = raft.Config{
 		FSM:        s.fsm,


### PR DESCRIPTION
~~Requires https://github.com/juju/juju/pull/13795 to land first.~~

The following updates raft worker to use a notify proxy so itself
doesn't have to depend on state. The idea behind this is to keep raft
and other workers up if state is bouncing. Although this is a tough
challenge, it's something that will be worthwhile.

The concept is simple, provide a worker that just depends on both state
and raft, if state goes down then only bounce the new worker and state,
not raft.

The conduit between these two workers is a notifier proxy. It consumes
messages from the raft work and places them on a channel. If the
notifications aren't consumed then the notifications are left in a
poor man's LRU buffer, until the consumer starts to consume.

That way we have a better uptime strategy without the downsides.

## QA steps

TBA

## Bug reference

TBA