### PR TITLE
Sets explicit support for buildkit

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -87,7 +87,7 @@ build_operator_image() {
     cp "${PROJECT_DIR}/caas/Dockerfile" "${WORKDIR}/"
     cp "${PROJECT_DIR}/caas/requirements.txt" "${WORKDIR}/"
     for build_osarch in ${build_multi_osarch}; do
-      tar cf - -C "${BUILD_DIR}" . | "${DOCKER_BIN}" build \
+      tar cf - -C "${BUILD_DIR}" . | DOCKER_BUILDKIT=1 "${DOCKER_BIN}" build \
           -f "docker-staging/Dockerfile" \
           --platform "$build_osarch" \
           -t "$(operator_image_path)" -


### PR DESCRIPTION
Not all platforms have buildkit enabled by default in Docker. This change set's it explicitly in the make functions. Without this we can't build platform specific Docker images.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Install Docker on Ubuntu from the official Docker deb's and run:

```sh
make operator-image
```

## Bug reference

Reported by @wallyworld 
