### PR TITLE
[JUJU-712] Add the snapcraft plugs needed for strictly confining the juju snap

### DIFF
--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -78,7 +78,8 @@ func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
 	}
 	if result.Code != 0 {
 		// TODO - confined snaps can't execute other commands.
-		if strings.HasSuffix(strings.ToLower(string(result.Stderr)), "permission denied") {
+		errMessage := strings.ReplaceAll(string(result.Stderr), "\n", "")
+		if strings.HasSuffix(strings.ToLower(errMessage), "permission denied") {
 			return []byte{}, errors.NotFoundf("microk8s")
 		}
 		return []byte{}, errors.New(string(result.Stderr))

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -676,6 +676,7 @@ func configDirs() []string {
 	}
 	dirs = append(dirs, filepath.Join(utils.Home(), ".config", "lxc"))
 	if runtime.GOOS == "linux" {
+		// TODO(juju3) - remove "~/snap/lxd/current/.config/lxc"
 		dirs = append(dirs, filepath.Join(utils.Home(), "snap", "lxd", "current", ".config", "lxc"))
 		dirs = append(dirs, filepath.Join(utils.Home(), "snap", "lxd", "common", "config"))
 	}

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -221,7 +222,9 @@ func (p *environProvider) DetectClouds() ([]cloud.Cloud, error) {
 		configPath := filepath.Join(dir, "config.yml")
 		config, err := p.lxcConfigReader.ReadConfig(configPath)
 		if err != nil {
-			logger.Warningf("unable to read/parse LXC config file (%s): %s", configPath, err)
+			if !strings.HasSuffix(err.Error(), "permission denied") {
+				logger.Warningf("unable to read/parse LXC config file (%s): %s", configPath, err)
+			}
 		}
 		for name, remote := range config.Remotes {
 			if remote.Protocol != lxdnames.ProviderType {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,9 @@ description: |
    - https://discourse.charmhub.io/
    - https://github.com/juju/juju
 
+  ** Note **
+  This snap needs to read any relevant locally stored cloud credentials in order to manage resources on your behalf in a specified cloud. 
+
 confinement: classic
 grade: devel
 base: core18
@@ -29,27 +32,32 @@ apps:
       # Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
       PATH: "$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH"
     command: bin/juju
-    # Even though the snap is being build as classic, the store still places the
-    # snap in a review queue despite these not being needed in classic.
-    # plugs:
-      # - network
-      # - ssh-keys
-      # - lxd
+    plugs:
+      - network
+      - network-bind
+      - ssh-public-keys
+      - lxd
       # Needed so that juju can still use the real ~/.local/share/juju.
-      # - config-juju
+      - dot-local-share-juju
       # Needed to read lxd config.
-      # - config-lxd
+      - config-lxd
       # Needed to read ~/.kube, ~/.novarc, ~/.aws etc.
-      # - cloud-credentials-juju
-      # Needed so that arbitrary cloud/credential yaml files can be read.
-      # - home
+      - dot-aws
+      - dot-azure
+      - dot-google
+      - dot-kubernetes
+      - dot-maas
+      - dot-openstack
+      - dot-oracle
+      # Needed so that arbitrary cloud/credential yaml files can be read and backups written.
+      - home
   fetch-oci:
     daemon: oneshot
     command: wrappers/fetch-oci
     start-timeout: 3m
     stop-timeout: 35s
-#    plugs:
-#      - network
+    plugs:
+      - network
 
 parts:
   wrappers:
@@ -120,26 +128,47 @@ plugs:
     content: microk8s
     target: $SNAP_COMMON/.peers
 
-# Even though the snap is being build as classic, the store still places the
-# snap in a review queue despite these not being needed in classic.
-#  config-juju:
-#    interface: personal-files
-#    write:
-#      - $HOME/.local/share/juju
-#
-#  config-lxd:
-#    interface: personal-files
-#    read:
-#      - $HOME/snap/lxd/current/.config/lxc
-#      - $HOME/snap/lxd/common/config
-#
-#  cloud-credentials-juju:
-#    interface: personal-files
-#    read:
-#      - $HOME/.aws
-#      - $HOME/.azure
-#      - $HOME/.config
-#      - $HOME/.kube
-#      - $HOME/.maasrc
-#      - $HOME/.oci
-#      - $HOME/.novarc
+  dot-local-share-juju:
+    interface: personal-files
+    write:
+      - $HOME/.local/share/juju
+
+  config-lxd:
+    interface: personal-files
+    read:
+      - $HOME/snap/lxd/common/config
+
+  dot-aws:
+    interface: personal-files
+    read:
+      - $HOME/.aws
+
+  dot-azure:
+    interface: personal-files
+    read:
+      - $HOME/.azure
+
+  dot-google:
+    interface: personal-files
+    read:
+      - $HOME/.config/gcloud
+
+  dot-kubernetes:
+    interface: personal-files
+    read:
+      - $HOME/.kube
+
+  dot-maas:
+    interface: personal-files
+    read:
+      - $HOME/.maasrc
+
+  dot-oracle:
+    interface: personal-files
+    read:
+      - $HOME/.oci
+
+  dot-openstack:
+    interface: personal-files
+    read:
+      - $HOME/.novarc


### PR DESCRIPTION
Add changes to `snapcraft.yaml` to enable a strictly confined snap to be built.

## QA steps

`snapcraft remote-build --launchpad-accept-public-upload --build-on amd64`

