### PR TITLE
[JUJU-714] Pass macaroons from cookiejar for HTTPS requests

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -243,8 +243,6 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		fallback: http.DefaultTransport,
 	}
 
-	// Prefer the SNI hostname or controller name for the cookie URL
-	// so that it is stable when used with a HA controller cluster.
 	host := PerferredHost(info)
 	if host == "" {
 		host = dialResult.addr
@@ -305,8 +303,13 @@ func CookieURLFromHost(host string) *url.URL {
 	}
 }
 
-// PerferredHost returns the perferred host from a Info.
+// PerferredHost returns the SNI hostname or controller name for the cookie URL
+// so that it is stable when used with a HA controller cluster.
 func PerferredHost(info *Info) string {
+	if info == nil {
+		return ""
+	}
+
 	host := info.SNIHostName
 	if host == "" && info.ControllerUUID != "" {
 		host = info.ControllerUUID

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -600,7 +600,7 @@ func OpenAPIFuncWithMacaroons(apiOpen api.OpenFunc, store jujuclient.ClientStore
 		// When attempting to connect to the non websocket fronted HTTPS
 		// endpoints, we need to ensure that we have a series of macaroons
 		// correctly set if there isn't a password.
-		if info.Password == "" && len(info.Macaroons) == 0 {
+		if info != nil && info.Password == "" && len(info.Macaroons) == 0 {
 			cookieJar, err := store.CookieJar(controllerName)
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -589,8 +589,29 @@ func newAPIConnectionParams(
 		AccountDetails: accountDetails,
 		ModelUUID:      modelUUID,
 		DialOpts:       dialOpts,
-		OpenAPI:        apiOpen,
+		OpenAPI:        OpenAPIFuncWithMacaroons(apiOpen, store, controllerName),
 	}, nil
+}
+
+// OpenAPIFuncWithMacaroons is a middleware to ensure that we have a set of
+// macaroons for a given open request.
+func OpenAPIFuncWithMacaroons(apiOpen api.OpenFunc, store jujuclient.ClientStore, controllerName string) api.OpenFunc {
+	return func(info *api.Info, dialOpts api.DialOpts) (api.Connection, error) {
+		// When attempting to connect to the non websocket fronted HTTPS
+		// endpoints, we need to ensure that we have a series of macaroons
+		// correctly set if there isn't a password.
+		if info.Password == "" && len(info.Macaroons) == 0 {
+			cookieJar, err := store.CookieJar(controllerName)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			cookieURL := api.CookieURLFromHost(api.PerferredHost(info))
+			info.Macaroons = httpbakery.MacaroonsForURL(cookieJar, cookieURL)
+		}
+
+		return apiOpen(info, dialOpts)
+	}
 }
 
 // NewGetBootstrapConfigParamsFunc returns a function that, given a controller name,


### PR DESCRIPTION
The following passes the macaroons for all HTTPS requests if you
log out and then login. As we rightly do not store the new password once
you've changed it, we then expect to use the macaroons from the cookie
jar. We do that correctly when passing to log in, but we fail to do it
when calling the HTTPS requests.

The following fix just creates a new openFunc middleware that just adds
the macaroons if the password and the length of macaroons are empty. For
most if not all cases this should not be called, yet for uploading
charms in production environments where the password for the user has
been changed it clearly a benefit.

## QA steps

The following should work without a password prompt.

```sh
$ juju bootstrap lxd test
$ juju change-user-password admin
$ juju logout
$ juju login
$ juju deploy mysql
$ juju download mysql
$ juju deploy ./mysql_*.charm
```

## Bug

https://bugs.launchpad.net/juju/+bug/1960635