### PR TITLE
Change docker staging to build dir.

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -15,11 +15,13 @@ DOCKER_USERNAME=${DOCKER_USERNAME:-jujusolutions}
 DOCKER_STAGING_DIR="${BUILD_DIR}/docker-staging"
 DOCKER_BIN=${DOCKER_BIN:-$(which docker || true)}
 
+readonly docker_staging_dir="docker-staging"
+
 # _make_docker_staging_dir is responsible for ensuring that there exists a
 # Docker staging directory under the build path. The staging directory's path
 # is returned as the output of this function.
 _make_docker_staging_dir() {
-  dir="${PROJECT_DIR}/_build/docker-staging"
+  dir="${BUILD_DIR}/${docker_staging_dir}"
   rm -rf "$dir"
   mkdir -p "$dir"
   echo "$dir"
@@ -52,7 +54,7 @@ microk8s_operator_update() {
 }
 
 juju_version() {
-    echo $(go run ${PROJECT_DIR}/version/helper/main.go)
+  (cd "${PROJECT_DIR}" && go run version/helper/main.go)
 }
 
 operator_image_release_path() {
@@ -88,7 +90,7 @@ build_operator_image() {
     cp "${PROJECT_DIR}/caas/requirements.txt" "${WORKDIR}/"
     for build_osarch in ${build_multi_osarch}; do
       tar cf - -C "${BUILD_DIR}" . | DOCKER_BUILDKIT=1 "${DOCKER_BIN}" build \
-          -f "docker-staging/Dockerfile" \
+          -f "${docker_staging_dir}/Dockerfile" \
           --platform "$build_osarch" \
           -t "$(operator_image_path)" -
     done


### PR DESCRIPTION
- Made a small error when calculating the location of the docker-staging
  directory. Was pinning it at the project root instead of at the build
  context. This doesn't work for Jenkins where these two concepts
  differ.

- Have also made the name of the docker-staging dir a const for sanity.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

```bash
mkdir -p /tmp/build
export BUILD_DIR=/tmp/build
make operator-image
```

## Documentation changes

N/A

## Bug reference

N/A
