### PR TITLE
Removed type of juju version for oci.

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -65,7 +65,7 @@ operator_image_release_path() {
 operator_image_path() {
     juju_version=$(juju_version)
     if [ -z "${JUJU_BUILD_NUMBER}" ] || [ ${JUJU_BUILD_NUMBER} -eq 0 ]; then
-        operator_image_release_path "$juju_version"
+        operator_image_release_path
     else
         echo "${DOCKER_USERNAME}/jujud-operator:$(_image_version "$juju_version").${JUJU_BUILD_NUMBER}"
     fi
@@ -95,7 +95,7 @@ build_operator_image() {
           -t "$(operator_image_path)" -
     done
     if [ "$(operator_image_path)" != "$(operator_image_release_path)" ]; then
-        "${DOCKER_BIN}" tag "$(operator_image_path)" "$(operator_image_release_path $juju_version)"
+        "${DOCKER_BIN}" tag "$(operator_image_path)" "$(operator_image_release_path)"
     fi
 }
 


### PR DESCRIPTION
When building multi arch builds in jenkins we re-tag the resultant image under juju solutions without a build number for the rest of the ci run. Before this we had left a superfluous juju_version for a function call.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
export JUJU_BUILD_NUMBER=12
make operator-image
docker images
# Check  that two versions exists. One with a tag and one without.
```

## Documentation changes

N/A

## Bug reference

N/A
