### PR TITLE
[JUJU-722] K8s introspection

### DIFF
--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/pubsub/v2"
 	"github.com/juju/utils/v3/voyeur"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -312,10 +311,6 @@ func (c *containerUnitAgent) workers() (worker.Worker, error) {
 		}
 		return nil, err
 	}
-	localHub := pubsub.NewSimpleHub(&pubsub.SimpleHubConfig{
-		Logger: logger.Child("juju.localhub"),
-		Clock:  c.clk,
-	})
 	if err := addons.StartIntrospection(addons.IntrospectionConfig{
 		AgentTag:           c.CurrentConfig().Tag(),
 		Engine:             eng,
@@ -323,8 +318,6 @@ func (c *containerUnitAgent) workers() (worker.Worker, error) {
 		NewSocketName:      addons.DefaultIntrospectionSocketName,
 		PrometheusGatherer: c.prometheusRegistry,
 		WorkerFunc:         introspection.NewWorker,
-		Clock:              c.clk,
-		LocalHub:           localHub,
 	}); err != nil {
 		// If the introspection worker failed to start, we just log error
 		// but continue. It is very unlikely to happen in the real world

--- a/cmd/containeragent/unit/agent_test.go
+++ b/cmd/containeragent/unit/agent_test.go
@@ -104,8 +104,8 @@ func (s *containerUnitAgentSuite) TestParseSuccess(c *gc.C) {
 		s.fileReaderWriter.EXPECT().RemoveAll(toolsDir).Return(nil),
 		s.fileReaderWriter.EXPECT().MkdirAll(toolsDir, os.FileMode(0755)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.ContainerAgent)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuRun)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuIntrospect)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), "/usr/bin/juju-run").Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), "/usr/bin/juju-introspect").Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.Jujuc)).Return(nil),
 		s.environment.EXPECT().Getenv("JUJU_CONTAINER_NAMES").Return("a,b,c"),
 	)
@@ -140,8 +140,8 @@ func (s *containerUnitAgentSuite) TestParseSuccessNoContainer(c *gc.C) {
 		s.fileReaderWriter.EXPECT().RemoveAll(toolsDir).Return(nil),
 		s.fileReaderWriter.EXPECT().MkdirAll(toolsDir, os.FileMode(0755)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.ContainerAgent)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuRun)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuIntrospect)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), "/usr/bin/juju-run").Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), "/usr/bin/juju-introspect").Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.Jujuc)).Return(nil),
 		s.environment.EXPECT().Getenv("JUJU_CONTAINER_NAMES").Return(""),
 	)

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.51.0
 	gopkg.in/juju/environschema.v1 v1.0.1-0.20201027142642-c89a4490670a
+	gopkg.in/macaroon-bakery.v2 v2.3.0
 	gopkg.in/macaroon.v2 v2.1.0
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 	gopkg.in/retry.v1 v1.0.3
@@ -217,7 +218,6 @@ require (
 	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/gobwas/glob.v0 v0.2.3 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/macaroon-bakery.v2 v2.3.0 // indirect
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -60,6 +60,11 @@ juju_application_agent_name () {
   echo $application
 }
 
+juju_unit_agent_name () {
+  local unit=$(find /var/lib/juju/agents -type d -name 'unit*' -printf %f)
+  echo $unit
+}
+
 juju_agent () {
   local agent=$(juju_machine_agent_name)
   if [ -z "$agent" ]; then
@@ -67,6 +72,9 @@ juju_agent () {
   fi
   if [ -z "$agent" ]; then
     agent=$(juju_application_agent_name)
+  fi
+  if [ -z "$agent" ]; then
+    agent=$(juju_unit_agent_name)
   fi
   juju_agent_call $agent $@
 }

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -89,7 +89,10 @@ func (c *Config) Validate() error {
 	if c.PrometheusGatherer == nil {
 		return errors.NotValidf("nil PrometheusGatherer")
 	}
-	if c.LocalHub != nil && c.Clock == nil {
+	if c.LocalHub == nil {
+		return errors.NotValidf("nil LocalHub")
+	}
+	if c.Clock == nil {
 		return errors.NotValidf("nil Clock")
 	}
 	return nil

--- a/worker/introspection/worker.go
+++ b/worker/introspection/worker.go
@@ -89,10 +89,7 @@ func (c *Config) Validate() error {
 	if c.PrometheusGatherer == nil {
 		return errors.NotValidf("nil PrometheusGatherer")
 	}
-	if c.LocalHub == nil {
-		return errors.NotValidf("nil LocalHub")
-	}
-	if c.Clock == nil {
+	if c.LocalHub != nil && c.Clock == nil {
 		return errors.NotValidf("nil Clock")
 	}
 	return nil


### PR DESCRIPTION
Enable `juju_engine_report` etc. commands for sidecar applications;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju add-model t1

$ juju deploy snappass-test

$ juju run -m k1:t1 --unit snappass-test/0 '. /etc/profile.d/juju-introspection.sh && juju_engine_report'
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1958542