### PR TITLE
[JUJU-732] Fix external user login errors on single controller

### DIFF
--- a/api/client_macaroon_test.go
+++ b/api/client_macaroon_test.go
@@ -75,15 +75,3 @@ func (s *clientMacaroonSuite) TestAddLocalCharmSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.String())
 }
-
-func (s *clientMacaroonSuite) TestAddLocalCharmUnauthorized(c *gc.C) {
-	client := s.createTestClient(c)
-	s.DischargerLogin = func() string { return "baduser" }
-	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	curl := charm.MustParseURL(
-		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),
-	)
-	// Upload an archive with its original revision.
-	_, err := client.AddLocalCharm(curl, charmArchive, false)
-	c.Assert(err, gc.ErrorMatches, `.*invalid entity name or password$`)
-}

--- a/api/state_macaroon_test.go
+++ b/api/state_macaroon_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
@@ -16,7 +15,6 @@ import (
 	"github.com/juju/juju/api"
 	apitesting "github.com/juju/juju/api/testing"
 	"github.com/juju/juju/core/permission"
-	"github.com/juju/juju/rpc"
 )
 
 var _ = gc.Suite(&macaroonLoginSuite{})
@@ -56,17 +54,6 @@ func (s *macaroonLoginSuite) TestSuccessfulLogin(c *gc.C) {
 func (s *macaroonLoginSuite) TestFailedToObtainDischargeLogin(c *gc.C) {
 	err := s.client.Login(nil, "", "", s.macSlice)
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
-}
-
-func (s *macaroonLoginSuite) TestUnknownUserLogin(c *gc.C) {
-	s.DischargerLogin = func() string {
-		return "testUnknown"
-	}
-	err := s.client.Login(nil, "", "", s.macSlice)
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: "invalid entity name or password",
-		Code:    "unauthorized access",
-	})
 }
 
 func (s *macaroonLoginSuite) TestConnectStream(c *gc.C) {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1206,25 +1206,6 @@ func (s *macaroonLoginSuite) TestPublicKeyLocatorErrorIsNotPersistent(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *macaroonLoginSuite) TestLoginToController(c *gc.C) {
-	// Note that currently we cannot use macaroon auth
-	// to log into the controller rather than a model
-	// because there's no place to store the fact that
-	// a given external user is allowed access to the controller.
-	s.DischargerLogin = func() string {
-		return "test@somewhere"
-	}
-	info := s.APIInfo(c)
-
-	// Zero the model tag so that we log into the controller
-	// not the model.
-	info.ModelTag = names.ModelTag{}
-
-	client, err := api.Open(info, api.DialOpts{})
-	assertInvalidEntityPassword(c, err)
-	c.Assert(client, gc.Equals, nil)
-}
-
 func (s *macaroonLoginSuite) login(c *gc.C, info *api.Info) (params.LoginResult, error) {
 	cookieJar := apitesting.NewClearableCookieJar()
 
@@ -1282,7 +1263,7 @@ func (s *macaroonLoginSuite) TestRemoteUserLoginToControllerNoAccess(c *gc.C) {
 	info.ModelTag = names.ModelTag{}
 
 	_, err := s.login(c, info)
-	assertInvalidEntityPassword(c, err)
+	assertPermissionDenied(c, err)
 }
 
 func (s *macaroonLoginSuite) TestRemoteUserLoginToControllerLoginAccess(c *gc.C) {
@@ -1431,15 +1412,6 @@ func (s *macaroonLoginSuite) TestFailedToObtainDischargeLogin(c *gc.C) {
 	}
 	client, err := api.Open(s.APIInfo(c), api.DialOpts{})
 	c.Assert(err, gc.ErrorMatches, `cannot get discharge from "https://.*": third party refused discharge: cannot discharge: login denied by discharger`)
-	c.Assert(client, gc.Equals, nil)
-}
-
-func (s *macaroonLoginSuite) TestUnknownUserLogin(c *gc.C) {
-	s.DischargerLogin = func() string {
-		return "testUnknown@somewhere"
-	}
-	client, err := api.Open(s.APIInfo(c), api.DialOpts{})
-	assertInvalidEntityPassword(c, err)
 	c.Assert(client, gc.Equals, nil)
 }
 

--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -14,10 +14,10 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// AgentAuthenticator performs authentication for machine and unit agents.
-type AgentAuthenticator struct{}
+// EntityAuthenticator performs authentication for juju entities.
+type EntityAuthenticator struct{}
 
-var _ EntityAuthenticator = (*AgentAuthenticator)(nil)
+var _ Authenticator = (*EntityAuthenticator)(nil)
 
 type taggedAuthenticator interface {
 	state.Entity
@@ -26,9 +26,10 @@ type taggedAuthenticator interface {
 
 // Authenticate authenticates the provided entity.
 // It takes an entityfinder and the tag used to find the entity that requires authentication.
-func (*AgentAuthenticator) Authenticate(ctx context.Context, entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
+func (*EntityAuthenticator) Authenticate(ctx context.Context, entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
 	entity, err := entityFinder.FindEntity(tag)
 	if errors.IsNotFound(err) {
+		logger.Debugf("cannot authenticate unknown agent: %v", tag)
 		return nil, errors.Trace(apiservererrors.ErrBadCreds)
 	}
 	if err != nil {

--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -29,7 +29,7 @@ type taggedAuthenticator interface {
 func (*EntityAuthenticator) Authenticate(ctx context.Context, entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error) {
 	entity, err := entityFinder.FindEntity(tag)
 	if errors.IsNotFound(err) {
-		logger.Debugf("cannot authenticate unknown agent: %v", tag)
+		logger.Debugf("cannot authenticate unknown entity: %v", tag)
 		return nil, errors.Trace(apiservererrors.ErrBadCreds)
 	}
 	if err != nil {

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -103,7 +103,7 @@ func (s *agentAuthenticatorSuite) TestValidLogins(c *gc.C) {
 
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
-		var authenticator authentication.AgentAuthenticator
+		var authenticator authentication.EntityAuthenticator
 		entity, err := authenticator.Authenticate(context.TODO(), s.State, t.entity.Tag(), params.LoginRequest{
 			Credentials: t.credentials,
 			Nonce:       t.nonce,
@@ -139,7 +139,7 @@ func (s *agentAuthenticatorSuite) TestInvalidLogins(c *gc.C) {
 
 	for i, t := range testCases {
 		c.Logf("test %d: %s", i, t.about)
-		var authenticator authentication.AgentAuthenticator
+		var authenticator authentication.EntityAuthenticator
 		entity, err := authenticator.Authenticate(context.TODO(), s.State, t.entity.Tag(), params.LoginRequest{
 			Credentials: t.credentials,
 			Nonce:       t.nonce,

--- a/apiserver/authentication/interfaces.go
+++ b/apiserver/authentication/interfaces.go
@@ -6,15 +6,16 @@ package authentication
 import (
 	"context"
 
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/names/v4"
 )
 
-// EntityAuthenticator is the interface all entity authenticators need to implement
+// Authenticator is the interface all entity authenticators need to implement
 // to authenticate juju entities.
-type EntityAuthenticator interface {
-	// Authenticate authenticates the given entity
+type Authenticator interface {
+	// Authenticate authenticates the given entity.
 	Authenticate(ctx context.Context, entityFinder EntityFinder, tag names.Tag, req params.LoginRequest) (state.Entity, error)
 }
 

--- a/apiserver/httpcontext/auth.go
+++ b/apiserver/httpcontext/auth.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/errors"
@@ -86,11 +85,6 @@ type Entity interface {
 type AuthInfo struct {
 	// Entity is the user/machine/unit/etc that has authenticated.
 	Entity Entity
-
-	// LastConnection returns the time of the last connection for
-	// the authenticated entity. If it's the zero value, then the
-	// entity has not previously logged in.
-	LastConnection time.Time
 
 	// Controller reports whether or not the authenticated
 	// entity is a controller agent.

--- a/apiserver/stateauthenticator/authenticator_test.go
+++ b/apiserver/stateauthenticator/authenticator_test.go
@@ -54,21 +54,21 @@ func (s *agentAuthenticatorSuite) TestAuthenticatorForTag(c *gc.C) {
 func (s *agentAuthenticatorSuite) TestMachineGetsAgentAuthenticator(c *gc.C) {
 	authenticator, err := stateauthenticator.EntityAuthenticator(s.authenticator, names.NewMachineTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
-	_, ok := authenticator.(*authentication.AgentAuthenticator)
+	_, ok := authenticator.(*authentication.EntityAuthenticator)
 	c.Assert(ok, jc.IsTrue)
 }
 
 func (s *agentAuthenticatorSuite) TestModelGetsAgentAuthenticator(c *gc.C) {
 	authenticator, err := stateauthenticator.EntityAuthenticator(s.authenticator, names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d"))
 	c.Assert(err, jc.ErrorIsNil)
-	_, ok := authenticator.(*authentication.AgentAuthenticator)
+	_, ok := authenticator.(*authentication.EntityAuthenticator)
 	c.Assert(ok, jc.IsTrue)
 }
 
 func (s *agentAuthenticatorSuite) TestUnitGetsAgentAuthenticator(c *gc.C) {
 	authenticator, err := stateauthenticator.EntityAuthenticator(s.authenticator, names.NewUnitTag("wordpress/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	_, ok := authenticator.(*authentication.AgentAuthenticator)
+	_, ok := authenticator.(*authentication.EntityAuthenticator)
 	c.Assert(ok, jc.IsTrue)
 }
 

--- a/apiserver/stateauthenticator/export_test.go
+++ b/apiserver/stateauthenticator/export_test.go
@@ -6,13 +6,14 @@ package stateauthenticator
 import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/identchecker"
 
-	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/names/v4"
+
+	"github.com/juju/juju/apiserver/authentication"
 )
 
 // TODO update the tests moved from apiserver to test via the public
 // interface, and then get rid of these.
-func EntityAuthenticator(authenticator *Authenticator, tag names.Tag) (authentication.EntityAuthenticator, error) {
+func EntityAuthenticator(authenticator *Authenticator, tag names.Tag) (authentication.Authenticator, error) {
 	return authenticator.authContext.authenticator("testing.invalid:1234").authenticatorForTag(tag)
 }
 

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -541,14 +541,3 @@ func (s *macaroonLoginSuite) TestsFailToObtainDischargeLogin(c *gc.C) {
 	_, err := cmd.NewAPIRoot()
 	c.Assert(err, gc.ErrorMatches, "cannot get discharge.*", gc.Commentf("%s", errors.Details(err)))
 }
-
-func (s *macaroonLoginSuite) TestsUnknownUserLogin(c *gc.C) {
-	s.DischargerLogin = func() string {
-		return "testUnknown@nowhere"
-	}
-
-	cmd := s.newModelCommandBase()
-	cmd.SetAPIOpen(s.apiOpen)
-	_, err := cmd.NewAPIRoot()
-	c.Assert(err, gc.ErrorMatches, "invalid entity name or password \\(unauthorized access\\)", gc.Commentf("details: %s", errors.Details(err)))
-}


### PR DESCRIPTION
When trying to login as an external user, the controller was attempting to find this user in state and returning a not found error. This is wrong because external users do not exist in the model, only their permissions.

Also, some structs and interfaces associated with entity auth were poorly named, eg `AgentAuthenticator` is actually also used for users.
And the AuthInfo struct has an obsolete LastConnection field that was unused.

## QA steps

```
juju bootstrap --config identity-url=https://api.jujucharms.com/identity --config identity-public-key=hmHaPgCC1UfuhYHUSX5+aihSAZesqpVdjRv0mgfIwjo=
juju grant wallyworld@external login
juju grant wallyworld@external write default

export JUJU_DATA=/path
cd $JUJU_DATA
cp ~/.local/share/juju/controllers.yaml $JUJU_DATA
juju login
juju deploy ubuntu
juju status
```
Also check local users using juju add-user, juju grant, and juju register.