### PR TITLE
2.9 into develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,13 @@ define run_go_build
 	$(eval ARCH = $(word 2,$(subst _, ,$*)))
 	$(eval BBIN_DIR = ${BUILD_DIR}/${OS}_${ARCH}/bin)
 	@@mkdir -p ${BBIN_DIR}
-	env GOOS=${OS} GOARCH=${ARCH} go build -mod=$(JUJU_GOMOD_MODE) -o ${BBIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v  ${PACKAGE}
+	@echo "Building ${PACKAGE} for ${OS}/${ARCH}"
+	@env GOOS=${OS} GOARCH=${ARCH} go build -mod=$(JUJU_GOMOD_MODE) -o ${BBIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v  ${PACKAGE}
 endef
 
 define run_go_install
-	go install -mod=$(JUJU_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v ${PACKAGE}
+	@echo "Installing ${PACKAGE}"
+	@go install -mod=$(JUJU_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v ${PACKAGE}
 endef
 
 default: build

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -283,6 +283,10 @@ type Config interface {
 	// performed after each write to the raft log.
 	NonSyncedWritesToRaftLog() bool
 
+	// BatchRaftFSM returns true if the raft calls should use the batching
+	// FSM.
+	BatchRaftFSM() bool
+
 	// AgentLogfileMaxSizeMB returns the maximum file size in MB of each
 	// agent/controller log file.
 	AgentLogfileMaxSizeMB() int
@@ -341,6 +345,10 @@ type configSetterOnly interface {
 	// SetNonSyncedWritesToRaftLog selects whether fsync calls are performed
 	// after each write to the raft log.
 	SetNonSyncedWritesToRaftLog(bool)
+
+	// SetBatchRaftFSM select whether raft should use the batching for writing
+	// to the FSM.
+	SetBatchRaftFSM(bool)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -415,6 +423,7 @@ type configInternal struct {
 	mongoMemoryProfile       string
 	jujuDBSnapChannel        string
 	nonSyncedWritesToRaftLog bool
+	batchRaftFSM             bool
 	agentLogfileMaxSizeMB    int
 	agentLogfileMaxBackups   int
 }
@@ -436,6 +445,7 @@ type AgentConfigParams struct {
 	MongoMemoryProfile       mongo.MemoryProfile
 	JujuDBSnapChannel        string
 	NonSyncedWritesToRaftLog bool
+	BatchRaftFSM             bool
 	AgentLogfileMaxSizeMB    int
 	AgentLogfileMaxBackups   int
 }
@@ -500,6 +510,7 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		mongoMemoryProfile:       configParams.MongoMemoryProfile.String(),
 		jujuDBSnapChannel:        configParams.JujuDBSnapChannel,
 		nonSyncedWritesToRaftLog: configParams.NonSyncedWritesToRaftLog,
+		batchRaftFSM:             configParams.BatchRaftFSM,
 		agentLogfileMaxSizeMB:    configParams.AgentLogfileMaxSizeMB,
 		agentLogfileMaxBackups:   configParams.AgentLogfileMaxBackups,
 	}
@@ -822,6 +833,16 @@ func (c *configInternal) NonSyncedWritesToRaftLog() bool {
 // SetNonSyncedWritesToRaftLog implements configSetterOnly.
 func (c *configInternal) SetNonSyncedWritesToRaftLog(nonSyncedWrites bool) {
 	c.nonSyncedWritesToRaftLog = nonSyncedWrites
+}
+
+// BatchRaftFSM implements Config.
+func (c *configInternal) BatchRaftFSM() bool {
+	return c.batchRaftFSM
+}
+
+// SetBatchRaftFSM implements configSetterOnly.
+func (c *configInternal) SetBatchRaftFSM(batchRaftFSM bool) {
+	c.batchRaftFSM = batchRaftFSM
 }
 
 // AgentLogfileMaxSizeMB implements Config.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -387,6 +387,7 @@ var attributeParams = agent.AgentConfigParams{
 	Model:                    testing.ModelTag,
 	JujuDBSnapChannel:        controller.DefaultJujuDBSnapChannel,
 	NonSyncedWritesToRaftLog: false,
+	BatchRaftFSM:             false,
 	AgentLogfileMaxSizeMB:    150,
 	AgentLogfileMaxBackups:   4,
 }
@@ -404,6 +405,7 @@ func (*suite) TestAttributes(c *gc.C) {
 	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, jujuversion.Current)
 	c.Assert(conf.JujuDBSnapChannel(), gc.Equals, "5.0/stable")
 	c.Assert(conf.NonSyncedWritesToRaftLog(), jc.IsFalse)
+	c.Assert(conf.BatchRaftFSM(), jc.IsFalse)
 	c.Assert(conf.AgentLogfileMaxSizeMB(), gc.Equals, 150)
 	c.Assert(conf.AgentLogfileMaxBackups(), gc.Equals, 4)
 }
@@ -713,4 +715,16 @@ func (*suite) TestSetSyncWritesToRaftLog(c *gc.C) {
 	conf.SetNonSyncedWritesToRaftLog(true)
 	nonSyncedWritesToRaftLog = conf.NonSyncedWritesToRaftLog()
 	c.Assert(nonSyncedWritesToRaftLog, jc.IsTrue, gc.Commentf("sync writes to raft log settings not updated"))
+}
+
+func (*suite) TestSetBatchRaftFSM(c *gc.C) {
+	conf, err := agent.NewAgentConfig(attributeParams)
+	c.Assert(err, jc.ErrorIsNil)
+
+	nonSyncedWritesToRaftLog := conf.BatchRaftFSM()
+	c.Assert(nonSyncedWritesToRaftLog, jc.IsFalse)
+
+	conf.SetBatchRaftFSM(true)
+	nonSyncedWritesToRaftLog = conf.BatchRaftFSM()
+	c.Assert(nonSyncedWritesToRaftLog, jc.IsTrue, gc.Commentf("batch raft FSM settings not updated"))
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -64,6 +64,7 @@ type format_2_0Serialization struct {
 	MongoMemoryProfile       string `yaml:"mongomemoryprofile,omitempty"`
 	JujuDBSnapChannel        string `yaml:"juju-db-snap-channel,omitempty"`
 	NonSyncedWritesToRaftLog bool   `yaml:"no-sync-writes-to-raft-log,omitempty"`
+	BatchRaftFSM             bool   `yaml:"batch-raft-fsm,omitempty"`
 }
 
 func init() {
@@ -116,6 +117,7 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 		agentLogfileMaxBackups: format.AgentLogfileMaxBackups,
 
 		nonSyncedWritesToRaftLog: format.NonSyncedWritesToRaftLog,
+		batchRaftFSM:             format.BatchRaftFSM,
 	}
 	if len(format.APIAddresses) > 0 {
 		config.apiDetails = &apiDetails{
@@ -185,6 +187,7 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		AgentLogfileMaxBackups: config.agentLogfileMaxBackups,
 
 		NonSyncedWritesToRaftLog: config.nonSyncedWritesToRaftLog,
+		BatchRaftFSM:             config.batchRaftFSM,
 	}
 	if config.servingInfo != nil {
 		format.ControllerCert = config.servingInfo.Cert

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -244,27 +244,19 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		fallback: http.DefaultTransport,
 	}
 
-	// Prefer the SNI hostname or controller name for the cookie URL
-	// so that it is stable when used with a HA controller cluster.
-	host := info.SNIHostName
-	if host == "" && info.ControllerUUID != "" {
-		host = info.ControllerUUID
-	}
+	host := PerferredHost(info)
 	if host == "" {
 		host = dialResult.addr
 	}
+
 	st := &state{
-		ctx:    context.Background(),
-		client: client,
-		conn:   dialResult.conn,
-		clock:  opts.Clock,
-		addr:   dialResult.addr,
-		ipAddr: dialResult.ipAddr,
-		cookieURL: &url.URL{
-			Scheme: "https",
-			Host:   host,
-			Path:   "/",
-		},
+		ctx:                 context.Background(),
+		client:              client,
+		conn:                dialResult.conn,
+		clock:               opts.Clock,
+		addr:                dialResult.addr,
+		ipAddr:              dialResult.ipAddr,
+		cookieURL:           CookieURLFromHost(host),
 		pingerFacadeVersion: facadeVersions["Pinger"],
 		serverScheme:        "https",
 		serverRootAddress:   dialResult.addr,
@@ -301,6 +293,29 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		broken:      st.broken,
 	}).run()
 	return st, nil
+}
+
+// CookieURLFromHost creates a url.URL from a given host.
+func CookieURLFromHost(host string) *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   host,
+		Path:   "/",
+	}
+}
+
+// PerferredHost returns the SNI hostname or controller name for the cookie URL
+// so that it is stable when used with a HA controller cluster.
+func PerferredHost(info *Info) string {
+	if info == nil {
+		return ""
+	}
+
+	host := info.SNIHostName
+	if host == "" && info.ControllerUUID != "" {
+		host = info.ControllerUUID
+	}
+	return host
 }
 
 // loginWithContext wraps st.Login with code that terminates

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -341,7 +341,7 @@ func (s *applicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 	storageConstraintsOut, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
@@ -402,7 +402,7 @@ func (s *applicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 	storageConstraintsOut, err := app.StorageConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageConstraintsOut, gc.DeepEquals, map[string]state.StorageConstraints{
@@ -434,10 +434,17 @@ func (s *applicationSuite) TestApplicationDeploy(c *gc.C) {
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{Error: nil}},
 	})
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 1)
+}
+
+func (s *applicationSuite) constraintsWithDefaultArch(c *gc.C) constraints.Value {
+	a := arch.DefaultArchitecture
+	return constraints.Value{
+		Arch: &a,
+	}
 }
 
 func (s *applicationSuite) TestApplicationDeployWithInvalidPlacement(c *gc.C) {
@@ -578,6 +585,7 @@ func (s *applicationSuite) TestApplicationDeploymentWithTrust(c *gc.C) {
 		CharmOrigin:     createCharmOriginFromURL(c, curl),
 		NumUnits:        1,
 		Config:          config,
+		Constraints:     cons,
 		Placement: []*instance.Placement{
 			{Scope: "deadbeef-0bad-400d-8000-4b1d0d06f00d", Directive: "valid"},
 		},
@@ -590,7 +598,7 @@ func (s *applicationSuite) TestApplicationDeploymentWithTrust(c *gc.C) {
 		Results: []params.ErrorResult{{Error: nil}},
 	})
 
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 
 	appConfig, err := app.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
@@ -610,6 +618,7 @@ func (s *applicationSuite) TestApplicationDeploymentNoTrust(c *gc.C) {
 		CharmURL:        curl.String(),
 		CharmOrigin:     createCharmOriginFromURL(c, curl),
 		NumUnits:        1,
+		Constraints:     cons,
 		Placement: []*instance.Placement{
 			{Scope: "deadbeef-0bad-400d-8000-4b1d0d06f00d", Directive: "valid"},
 		},
@@ -622,7 +631,7 @@ func (s *applicationSuite) TestApplicationDeploymentNoTrust(c *gc.C) {
 		Results: []params.ErrorResult{{Error: nil}},
 	})
 
-	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, cons)
+	app := apiservertesting.AssertPrincipalApplicationDeployed(c, s.State, "application", curl, false, ch, s.constraintsWithDefaultArch(c))
 	appConfig, err := app.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	trust := appConfig.GetBool(application.TrustConfigOptionName, true)

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -75,7 +75,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 	s.assertCharm(c, app, s.charm.URL())
 	s.assertSettings(c, app, charm.Settings{})
 	s.assertApplicationConfig(c, app, coreconfig.ConfigAttributes(nil))
-	s.assertConstraints(c, app, constraints.Value{})
+	s.assertConstraints(c, app, constraints.MustParse("arch=amd64"))
 	s.assertMachines(c, app, constraints.Value{})
 }
 
@@ -374,7 +374,7 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 			Constraints:     applicationCons,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertConstraints(c, app, applicationCons)
+	s.assertConstraints(c, app, constraints.MustParse("cores=2 arch=amd64"))
 }
 
 func (s *DeployLocalSuite) TestDeployNumUnits(c *gc.C) {

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -92,7 +92,8 @@ func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {
 				"type":        environschema.Tbool,
 				"value":       false,
 			}},
-		Series: "quantal",
+		Constraints: constraints.MustParse("arch=amd64"),
+		Series:      "quantal",
 		EndpointBindings: map[string]string{
 			"":                network.AlphaSpaceName,
 			"admin-api":       network.AlphaSpaceName,
@@ -195,6 +196,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 			},
 		},
 		ApplicationConfig: expectedAppConfig,
+		Constraints:       constraints.MustParse("arch=amd64"),
 		Series:            "kubernetes",
 		EndpointBindings: map[string]string{
 			"":      network.AlphaSpaceName,
@@ -218,7 +220,7 @@ var getTests = []struct {
 }{{
 	about:       "deployed application",
 	charm:       "dummy",
-	constraints: "mem=2G cpu-power=400",
+	constraints: "arch=amd64 mem=2G cpu-power=400",
 	config: charm.Settings{
 		// Different from default.
 		"title": "Look To Windward",
@@ -270,8 +272,9 @@ var getTests = []struct {
 		},
 	},
 }, {
-	about: "deployed application  #2",
-	charm: "dummy",
+	about:       "deployed application  #2",
+	charm:       "dummy",
+	constraints: "arch=amd64",
 	config: charm.Settings{
 		// Set title to default.
 		"title": nil,
@@ -353,7 +356,7 @@ var getTests = []struct {
 		},
 	},
 }, {
-	about: "charmhub application",
+	about: "charmhub subordinate application",
 	charm: "logging",
 	origin: &state.CharmOrigin{
 		Source: "charm-hub",

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -19,7 +19,6 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facades/client/modelconfig"
-	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/instance"
@@ -656,18 +655,10 @@ func (c *Client) SetModelAgentVersion(args params.SetModelAgentVersion) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// Check IAAS clouds.
-	if env, ok := envOrBroker.(environs.InstanceBroker); ok {
-		if err := environs.CheckProviderAPI(env, c.callContext); err != nil {
-			return err
-		}
+	if err := environs.CheckProviderAPI(envOrBroker, c.callContext); err != nil {
+		return err
 	}
-	// Check credentials against the container broker
-	if env, ok := envOrBroker.(caas.CredentialChecker); ok {
-		if err := env.CheckCloudCredentials(); err != nil {
-			return errors.Annotate(err, "cannot make API call to provider")
-		}
-	}
+
 	// If this is the controller model, also check to make sure that there are
 	// no running migrations.  All models should have migration mode of None.
 	// For major version upgrades, also check that all models are at a version high

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/client"
 	"github.com/juju/juju/apiserver/facades/client/client/mocks"
 	"github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/caas"
-	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -48,7 +46,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
@@ -443,13 +440,13 @@ func (s *serverSuite) TestUserModelSetModelAgentVersionSkipsMongoCheck(c *gc.C) 
 
 type mockEnviron struct {
 	environs.Environ
-	allInstancesCalled bool
-	err                error
+	validateCloudEndpointCalled bool
+	err                         error
 }
 
-func (m *mockEnviron) AllInstances(context.ProviderCallContext) ([]instances.Instance, error) {
-	m.allInstancesCalled = true
-	return nil, m.err
+func (m *mockEnviron) ValidateCloudEndpoint(context.ProviderCallContext) error {
+	m.validateCloudEndpointCalled = true
+	return m.err
 }
 
 func (s *serverSuite) assertCheckProviderAPI(c *gc.C, envError error, expectErr string) {
@@ -461,7 +458,7 @@ func (s *serverSuite) assertCheckProviderAPI(c *gc.C, envError error, expectErr 
 		Version: version.MustParse(validVersion.String()),
 	}
 	err := s.client.SetModelAgentVersion(args)
-	c.Assert(env.allInstancesCalled, jc.IsTrue)
+	c.Assert(env.validateCloudEndpointCalled, jc.IsTrue)
 	if expectErr != "" {
 		c.Assert(err, gc.ErrorMatches, expectErr)
 	} else {
@@ -471,53 +468,10 @@ func (s *serverSuite) assertCheckProviderAPI(c *gc.C, envError error, expectErr 
 
 func (s *serverSuite) TestCheckProviderAPISuccess(c *gc.C) {
 	s.assertCheckProviderAPI(c, nil, "")
-	s.assertCheckProviderAPI(c, environs.ErrPartialInstances, "")
-	s.assertCheckProviderAPI(c, environs.ErrNoInstances, "")
 }
 
 func (s *serverSuite) TestCheckProviderAPIFail(c *gc.C) {
-	s.assertCheckProviderAPI(c, errors.New("instances error"), "cannot make API call to provider: instances error")
-}
-
-type mockBroker struct {
-	caas.Broker
-	getMetadataCalled bool
-	err               error
-}
-
-func (m *mockBroker) GetClusterMetadata(storageClass string) (result *k8s.ClusterMetadata, err error) {
-	m.getMetadataCalled = true
-	return nil, m.err
-}
-
-func (m *mockBroker) CheckCloudCredentials() error {
-	m.getMetadataCalled = true
-	return m.err
-}
-
-func (s *serverSuite) assertCheckCAASProviderAPI(c *gc.C, envError error, expectErr string) {
-	env := &mockBroker{err: envError}
-	s.newEnviron = func() (environs.BootstrapEnviron, error) {
-		return env, nil
-	}
-	args := params.SetModelAgentVersion{
-		Version: version.MustParse(validVersion.String()),
-	}
-	err := s.client.SetModelAgentVersion(args)
-	c.Assert(env.getMetadataCalled, jc.IsTrue)
-	if expectErr != "" {
-		c.Assert(err, gc.ErrorMatches, expectErr)
-	} else {
-		c.Assert(err, jc.ErrorIsNil)
-	}
-}
-
-func (s *serverSuite) TestCheckCAASProviderAPISuccess(c *gc.C) {
-	s.assertCheckCAASProviderAPI(c, nil, "")
-}
-
-func (s *serverSuite) TestCheckCAASProviderAPIFail(c *gc.C) {
-	s.assertCheckCAASProviderAPI(c, errors.New("metadata error"), "cannot make API call to provider: metadata error")
+	s.assertCheckProviderAPI(c, errors.New("failme"), "cannot make API call to provider: failme")
 }
 
 func (s *serverSuite) assertSetModelAgentVersion(c *gc.C) {

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -78,7 +78,8 @@ func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
 	}
 	if result.Code != 0 {
 		// TODO - confined snaps can't execute other commands.
-		if strings.HasSuffix(strings.ToLower(string(result.Stderr)), "permission denied") {
+		errMessage := strings.ReplaceAll(string(result.Stderr), "\n", "")
+		if strings.HasSuffix(strings.ToLower(errMessage), "permission denied") {
 			return []byte{}, errors.NotFoundf("microk8s")
 		}
 		return []byte{}, errors.New(string(result.Stderr))

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -17,6 +17,7 @@ import (
 
 	k8s "github.com/juju/juju/caas/kubernetes"
 	k8sannotations "github.com/juju/juju/core/annotations"
+	environscontext "github.com/juju/juju/environs/context"
 )
 
 // newLabelRequirements creates a list of k8s node label requirements.
@@ -108,6 +109,14 @@ func toCaaSStorageProvisioner(sc storage.StorageClass) *k8s.StorageProvisioner {
 		caasSc.ReclaimPolicy = string(*sc.ReclaimPolicy)
 	}
 	return caasSc
+}
+
+// ValidateCloudEndpoint returns nil if the current model can talk to the kubernetes
+// endpoint.  Used as validation during model upgrades.
+// Implements environs.CloudEndpointChecker
+func (k *kubernetesClient) ValidateCloudEndpoint(_ environscontext.ProviderCallContext) error {
+	_, err := k.GetClusterMetadata("")
+	return errors.Trace(err)
 }
 
 // GetClusterMetadata implements ClusterMetadataChecker.

--- a/cmd/containeragent/initialize/config.go
+++ b/cmd/containeragent/initialize/config.go
@@ -126,6 +126,10 @@ func (c *configFromEnv) NonSyncedWritesToRaftLog() bool {
 	panic("not implemented")
 }
 
+func (c *configFromEnv) BatchRaftFSM() bool {
+	panic("not implemented")
+}
+
 func (c *configFromEnv) AgentLogfileMaxSizeMB() int {
 	panic("not implemented")
 }

--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	agenterrors "github.com/juju/juju/cmd/jujud/agent/errors"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/paths"
 	jnames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/upgrades"
 	jujuversion "github.com/juju/juju/version"
@@ -44,7 +45,12 @@ import (
 	"github.com/juju/juju/worker/upgradesteps"
 )
 
-var logger = loggo.GetLogger("juju.cmd.containeragent.unit")
+var (
+	logger = loggo.GetLogger("juju.cmd.containeragent.unit")
+
+	jujuRun        = paths.JujuExec(paths.CurrentOS())
+	jujuIntrospect = paths.JujuIntrospect(paths.CurrentOS())
+)
 
 type containerUnitAgent struct {
 	cmd.CommandBase
@@ -193,6 +199,11 @@ func (c *containerUnitAgent) Init(args []string) error {
 	if len(containerNames) > 0 {
 		c.containerNames = strings.Split(containerNames, ",")
 	}
+
+	if err := introspection.WriteProfileFunctions(introspection.ProfileDir); err != nil {
+		// This isn't fatal, just annoying.
+		logger.Errorf("failed to write profile funcs: %v", err)
+	}
 	return nil
 }
 
@@ -210,12 +221,10 @@ func (c *containerUnitAgent) ensureToolSymlinks(srcPath, dataDir string, unitTag
 	}
 
 	for _, link := range []string{
-		jnames.ContainerAgent,
-		jnames.JujuExec,
-		jnames.JujuIntrospect,
+		path.Join(toolsDir, jnames.ContainerAgent),
+		jujuRun, jujuIntrospect,
 	} {
-		newName := path.Join(toolsDir, link)
-		if err = c.fileReaderWriter.Symlink(path.Join(srcPath, jnames.ContainerAgent), newName); err != nil {
+		if err = c.fileReaderWriter.Symlink(path.Join(srcPath, jnames.ContainerAgent), link); err != nil {
 			return errors.Annotatef(err, "ensuring symlink %q", link)
 		}
 	}

--- a/cmd/containeragent/unit/agent_test.go
+++ b/cmd/containeragent/unit/agent_test.go
@@ -104,8 +104,8 @@ func (s *containerUnitAgentSuite) TestParseSuccess(c *gc.C) {
 		s.fileReaderWriter.EXPECT().RemoveAll(toolsDir).Return(nil),
 		s.fileReaderWriter.EXPECT().MkdirAll(toolsDir, os.FileMode(0755)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.ContainerAgent)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuExec)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuIntrospect)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join("/usr/bin", jnames.JujuExec)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join("/usr/bin", jnames.JujuIntrospect)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.Jujuc)).Return(nil),
 		s.environment.EXPECT().Getenv("JUJU_CONTAINER_NAMES").Return("a,b,c"),
 	)
@@ -140,8 +140,8 @@ func (s *containerUnitAgentSuite) TestParseSuccessNoContainer(c *gc.C) {
 		s.fileReaderWriter.EXPECT().RemoveAll(toolsDir).Return(nil),
 		s.fileReaderWriter.EXPECT().MkdirAll(toolsDir, os.FileMode(0755)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.ContainerAgent)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuExec)).Return(nil),
-		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.JujuIntrospect)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join("/usr/bin", jnames.JujuExec)).Return(nil),
+		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join("/usr/bin", jnames.JujuIntrospect)).Return(nil),
 		s.fileReaderWriter.EXPECT().Symlink(gomock.Any(), filepath.Join(toolsDir, jnames.Jujuc)).Return(nil),
 		s.environment.EXPECT().Getenv("JUJU_CONTAINER_NAMES").Return(""),
 	)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -619,7 +619,7 @@ func (s *DeploySuite) TestConstraints(c *gc.C) {
 	app, _ := s.AssertApplication(c, "multi-series", curl, 1, 0)
 	cons, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2"))
+	c.Assert(cons, jc.DeepEquals, constraints.MustParse("mem=2G cores=2 arch=amd64"))
 }
 
 func (s *DeploySuite) TestResources(c *gc.C) {

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -115,23 +115,25 @@ func (c *downloadCommand) Init(args []string) error {
 		c.pipeToStdout = true
 	}
 
-	if err := c.validateCharmOrBundle(args[0]); err != nil {
+	curl, err := c.validateCharmOrBundle(args[0])
+	if err != nil {
 		return errors.Trace(err)
 	}
-	c.charmOrBundle = args[0]
+	// Allow for both <charm> and ch:<charm> to download.
+	c.charmOrBundle = curl.Name
 
 	return nil
 }
 
-func (c *downloadCommand) validateCharmOrBundle(charmOrBundle string) error {
+func (c *downloadCommand) validateCharmOrBundle(charmOrBundle string) (*charm.URL, error) {
 	curl, err := charm.ParseURL(charmOrBundle)
 	if err != nil {
-		return errors.Annotatef(err, "unexpected charm or bundle name")
+		return nil, errors.Annotatef(err, "unexpected charm or bundle name")
 	}
 	if !charm.CharmHub.Matches(curl.Schema) {
-		return errors.Errorf("%q is not a Charm Hub charm", charmOrBundle)
+		return nil, errors.Errorf("%q is not a Charmhub charm", charmOrBundle)
 	}
-	return nil
+	return curl, nil
 }
 
 // Run is the business logic of the download command.  It implements the meaty

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -46,11 +46,27 @@ func (s *downloadSuite) TestInitNoArgs(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "expected a charm or bundle name")
 }
 
-func (s *downloadSuite) TestInitSuccess(c *gc.C) {
+func (s *downloadSuite) TestInitErrorCSSchema(c *gc.C) {
 	command := &downloadCommand{
 		charmHubCommand: s.newCharmHubCommand(),
 	}
-	err := command.Init([]string{"test"})
+	err := command.Init([]string{"cs:test"})
+	c.Assert(err, gc.ErrorMatches, ".* is not a Charmhub charm")
+}
+
+func (s *downloadSuite) TestInitSuccess(c *gc.C) {
+	s.testInitSuccess(c, "test")
+}
+
+func (s *downloadSuite) TestInitSuccessWithSchema(c *gc.C) {
+	s.testInitSuccess(c, "ch:test")
+}
+
+func (s *downloadSuite) testInitSuccess(c *gc.C, charmName string) {
+	command := &downloadCommand{
+		charmHubCommand: s.newCharmHubCommand(),
+	}
+	err := command.Init([]string{charmName})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -280,6 +280,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		}
 		agentConfig.SetJujuDBSnapChannel(args.ControllerConfig.JujuDBSnapChannel())
 		agentConfig.SetNonSyncedWritesToRaftLog(args.ControllerConfig.NonSyncedWritesToRaftLog())
+		agentConfig.SetBatchRaftFSM(args.ControllerConfig.BatchRaftFSM())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("cannot write agent config: %v", err)

--- a/controller/config.go
+++ b/controller/config.go
@@ -227,6 +227,9 @@ const (
 	// when writing to the raft log by setting this value to true.
 	NonSyncedWritesToRaftLog = "non-synced-writes-to-raft-log"
 
+	// BatchRaftFSM allows the operator to batch raft FSM calls.
+	BatchRaftFSM = "batch-raft-fsm"
+
 	// MigrationMinionWaitMax is the maximum time that the migration-master
 	// worker will wait for agents to report for a migration phase when
 	// executing a model migration.
@@ -373,6 +376,10 @@ const (
 	// non-synced-writes-to-raft-log value. It is set to false by default.
 	DefaultNonSyncedWritesToRaftLog = false
 
+	// DefaultBatchRaftFSM is the default value for batch-raft-fsm value.
+	// It is set to false by default.
+	DefaultBatchRaftFSM = false
+
 	// DefaultMigrationMinionWaitMax is the default value for
 	DefaultMigrationMinionWaitMax = "15m"
 )
@@ -425,6 +432,7 @@ var (
 		MaxCharmStateSize,
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
+		BatchRaftFSM,
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
@@ -476,6 +484,7 @@ var (
 		MaxCharmStateSize,
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
+		BatchRaftFSM,
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
@@ -1016,6 +1025,14 @@ func (c Config) NonSyncedWritesToRaftLog() bool {
 	return DefaultNonSyncedWritesToRaftLog
 }
 
+// BatchRaftFSM returns true if raft should use batch writing to the FSM.
+func (c Config) BatchRaftFSM() bool {
+	if v, ok := c[BatchRaftFSM]; ok {
+		return v.(bool)
+	}
+	return DefaultBatchRaftFSM
+}
+
 // MigrationMinionWaitMax returns a duration for the maximum time that the
 // migration-master worker should wait for migration-minion reports during
 // phases of a model migration.
@@ -1363,6 +1380,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxCharmStateSize:                schema.ForceInt(),
 	MaxAgentStateSize:                schema.ForceInt(),
 	NonSyncedWritesToRaftLog:         schema.Bool(),
+	BatchRaftFSM:                     schema.Bool(),
 	MigrationMinionWaitMax:           schema.String(),
 	ApplicationResourceDownloadLimit: schema.ForceInt(),
 	ControllerResourceDownloadLimit:  schema.ForceInt(),
@@ -1409,6 +1427,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxCharmStateSize:                DefaultMaxCharmStateSize,
 	MaxAgentStateSize:                DefaultMaxAgentStateSize,
 	NonSyncedWritesToRaftLog:         DefaultNonSyncedWritesToRaftLog,
+	BatchRaftFSM:                     DefaultBatchRaftFSM,
 	MigrationMinionWaitMax:           DefaultMigrationMinionWaitMax,
 	ApplicationResourceDownloadLimit: schema.Omit,
 	ControllerResourceDownloadLimit:  schema.Omit,
@@ -1598,6 +1617,10 @@ Use "caas-image-repo" instead.`,
 	NonSyncedWritesToRaftLog: {
 		Type:        environschema.Tbool,
 		Description: `Do not perform fsync calls after appending entries to the raft log. Disabling sync improves performance at the cost of reliability`,
+	},
+	BatchRaftFSM: {
+		Type:        environschema.Tbool,
+		Description: `Allow raft to use batch writing to the FSM.`,
 	},
 	MigrationMinionWaitMax: {
 		Type:        environschema.Tstring,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -371,6 +371,12 @@ var newConfigTests = []struct {
 		},
 		expectError: `non-synced-writes-to-raft-log: expected bool, got string\("I live dangerously"\)`,
 	}, {
+		about: "invalid batch-raft-fsm - string",
+		config: controller.Config{
+			controller.BatchRaftFSM: "I live dangerously",
+		},
+		expectError: `batch-raft-fsm: expected bool, got string\("I live dangerously"\)`,
+	}, {
 		about: "public-dns-address: expect string, got number",
 		config: controller.Config{
 			controller.PublicDNSAddress: 42,

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -638,3 +638,24 @@ type HardwareCharacteristicsDetector interface {
 type SupportedFeatureEnumerator interface {
 	SupportedFeatures() (assumes.FeatureSet, error)
 }
+
+// CheckProvider defines the old and/or public cloud style of cloud
+// endpoint validation.  This check is a heavy weight method to
+// verify the current cloud connectivity.
+// Typically used with public clouds which have not implemented the
+// CloudEndpointChecker.
+type CheckProvider interface {
+	// AllInstances returns all instances currently known to the broker.
+	AllInstances(ctx context.ProviderCallContext) ([]instances.Instance, error)
+}
+
+// CloudEndpointChecker defines a method for cloud endpoint validation.
+//
+// TODO: hml 09-Feb-22
+// Implement this interface for all providers, including the public
+// clouds.
+type CloudEndpointChecker interface {
+	// ValidateCloudEndpoint validates connectivity with the cloud's
+	// endpoint and returns nil if no problems.
+	ValidateCloudEndpoint(ctx context.ProviderCallContext) error
+}

--- a/environs/utils.go
+++ b/environs/utils.go
@@ -95,13 +95,18 @@ func APIInfo(
 
 // CheckProviderAPI returns an error if a simple API call
 // to check a basic response from the specified environ fails.
-func CheckProviderAPI(env InstanceBroker, ctx context.ProviderCallContext) error {
-	// We will make a simple API call to the provider
-	// to ensure the underlying substrate is ok.
-	_, err := env.AllInstances(ctx)
-	switch err {
-	case nil, ErrPartialInstances, ErrNoInstances:
-		return nil
+func CheckProviderAPI(envOrBroker BootstrapEnviron, ctx context.ProviderCallContext) error {
+	var err error
+	if checker, ok := envOrBroker.(CloudEndpointChecker); ok {
+		err = checker.ValidateCloudEndpoint(ctx)
+	} else if env, ok := envOrBroker.(CheckProvider); ok {
+		// We will make a simple API call to the provider
+		// to ensure the underlying substrate is ok.
+		_, err = env.AllInstances(ctx)
+		switch err {
+		case nil, ErrPartialInstances, ErrNoInstances:
+			return nil
+		}
 	}
 	return errors.Annotate(err, "cannot make API call to provider")
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -46,13 +46,9 @@ const ActionsV2 = "actions-v2"
 // Secrets enables the secrets feature.
 const Secrets = "secrets"
 
-// AsynchronousCharmDownloads enables support for asynchronous charm downloads.
-const AsynchronousCharmDownloads = "async-charm-downloads"
-
-// RaftBatchFSM will use the batching FSM instead of the singular FSM to attempt
-// to commit logs.
-const RaftBatchFSM = "raft-batch-fsm"
-
 // RaftAPILeases will switch all lease store management transport, currently
 // handled by Pubsub to facade API interaction.
 const RaftAPILeases = "raft-api-leases"
+
+// AsynchronousCharmDownloads enables support for asynchronous charm downloads.
+const AsynchronousCharmDownloads = "async-charm-downloads"

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -69,6 +69,8 @@ func (s *cmdApplicationSuite) TestShowApplicationOne(c *gc.C) {
 wordpress:
   charm: wordpress
   series: quantal
+  constraints:
+    arch: amd64
   principal: true
   exposed: false
   remote: false
@@ -106,6 +108,8 @@ logging:
 wordpress:
   charm: wordpress
   series: quantal
+  constraints:
+    arch: amd64
   principal: true
   exposed: false
   remote: false

--- a/featuretests/cmd_juju_bundle_test.go
+++ b/featuretests/cmd_juju_bundle_test.go
@@ -80,6 +80,7 @@ applications:
   wordpress:
     charm: cs:quantal/wordpress
     revision: 23
+    constraints: arch=amd64
     bindings:
       "": alpha
       admin-api: alpha

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/juju/featureflag v0.0.0-20220207005600-a9676d92ad24
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2
-	github.com/juju/gomaasapi/v2 v2.0.0-20220207023642-10dd7f190313
+	github.com/juju/gomaasapi/v2 v2.0.0-20220215192228-f1f389204471
 	github.com/juju/http/v2 v2.0.0-20220207005632-792b5de45d16
 	github.com/juju/idmclient/v2 v2.0.0-20220207024613-525e1ac3a890
 	github.com/juju/jsonschema v0.0.0-20220207021905-6f321f9146b3
@@ -106,6 +106,7 @@ require (
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.51.0
 	gopkg.in/juju/environschema.v1 v1.0.1-0.20201027142642-c89a4490670a
+	gopkg.in/macaroon-bakery.v2 v2.3.0
 	gopkg.in/macaroon.v2 v2.1.0
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 	gopkg.in/retry.v1 v1.0.3
@@ -216,7 +217,6 @@ require (
 	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/gobwas/glob.v0 v0.2.3 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/macaroon-bakery.v2 v2.3.0 // indirect
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 h1:huRsqE0iXm
 github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33/go.mod h1:UxUZdlQkjnbl3YoCZT1y5uxmvG2KMwqgffBFccD7qHI=
 github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2 h1:VqIDC6dRE0C7wEtTdT6zx2zP5omaoJiZXp2g/dBHRcE=
 github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2/go.mod h1:w3BDUH3gGgrcrAyvEbBy3lNb1vmdqG31UMn3njL8oGc=
-github.com/juju/gomaasapi/v2 v2.0.0-20220207023642-10dd7f190313 h1:O2isK2YQ3wS90SMVpsXKVKX/Xa7psqkL/GeFIkYqrNM=
-github.com/juju/gomaasapi/v2 v2.0.0-20220207023642-10dd7f190313/go.mod h1:ZsohFbU4xShV1aSQYQ21hR1lKj7naNGY0SPuyelcUmk=
+github.com/juju/gomaasapi/v2 v2.0.0-20220215192228-f1f389204471 h1:9QpnrjtVMMzjghavLeUrx3NxwwscXj+jDzTKEnPEGGQ=
+github.com/juju/gomaasapi/v2 v2.0.0-20220215192228-f1f389204471/go.mod h1:ZsohFbU4xShV1aSQYQ21hR1lKj7naNGY0SPuyelcUmk=
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e h1:JoXBbhRrYNw6EIPGcMb4iW4LzsVKNvDKSVvPf4A89mY=
 github.com/juju/gosigma v0.0.0-20200420012028-063911838a9e/go.mod h1:OPBu48GcIJ30kNTA1cm+VbZb6GkQ6vthnr5v6NJ49eM=
 github.com/juju/http/v2 v2.0.0-20220207005632-792b5de45d16 h1:RRZLXCtXZozxgk2ZPQpnyNSzfEf5IoOWYO6jQ3nG3X8=

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -676,6 +676,7 @@ func configDirs() []string {
 	}
 	dirs = append(dirs, filepath.Join(utils.Home(), ".config", "lxc"))
 	if runtime.GOOS == "linux" {
+		// TODO(juju3) - remove "~/snap/lxd/current/.config/lxc"
 		dirs = append(dirs, filepath.Join(utils.Home(), "snap", "lxd", "current", ".config", "lxc"))
 		dirs = append(dirs, filepath.Join(utils.Home(), "snap", "lxd", "common", "config"))
 	}

--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -185,6 +185,18 @@ func (env *environ) Config() *config.Config {
 	return cfg
 }
 
+// ValidateCloudEndpoint returns nil if the current model can talk to the lxd
+// server endpoint.  Used as validation during model upgrades.
+// Implements environs.CloudEndpointChecker
+func (env *environ) ValidateCloudEndpoint(ctx context.ProviderCallContext) error {
+	info, err := env.server().GetConnectionInfo()
+	if err != nil {
+		return err
+	}
+	err = env.provider.Ping(ctx, info.URL)
+	return errors.Trace(err)
+}
+
 // PrepareForBootstrap implements environs.Environ.
 func (env *environ) PrepareForBootstrap(_ environs.BootstrapContext, _ string) error {
 	return nil

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -221,7 +222,9 @@ func (p *environProvider) DetectClouds() ([]cloud.Cloud, error) {
 		configPath := filepath.Join(dir, "config.yml")
 		config, err := p.lxcConfigReader.ReadConfig(configPath)
 		if err != nil {
-			logger.Warningf("unable to read/parse LXC config file (%s): %s", configPath, err)
+			if !strings.HasSuffix(err.Error(), "permission denied") {
+				logger.Warningf("unable to read/parse LXC config file (%s): %s", configPath, err)
+			}
 		}
 		for name, remote := range config.Remotes {
 			if remote.Protocol != lxdnames.ProviderType {

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -278,6 +278,14 @@ func (env *maasEnviron) SetCloudSpec(_ stdcontext.Context, spec environscloudspe
 	return nil
 }
 
+// ValidateCloudEndpoint returns nil if the current model can talk to the maas
+// endpoint.  Used as validation during model upgrades.
+// Implements environs.CloudEndpointChecker
+func (env *maasEnviron) ValidateCloudEndpoint(ctx context.ProviderCallContext) error {
+	_, _, err := env.maasController.APIVersionInfo()
+	return errors.Trace(err)
+}
+
 func (env *maasEnviron) getSupportedArchitectures(ctx context.ProviderCallContext) ([]string, error) {
 	env.archMutex.Lock()
 	defer env.archMutex.Unlock()

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2370,3 +2370,11 @@ func (*Environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.
 func (e *Environ) SupportsRulesWithIPV6CIDRs(ctx context.ProviderCallContext) (bool, error) {
 	return true, nil
 }
+
+// ValidateCloudEndpoint returns nil if the current model can talk to the openstack
+// endpoint. Used as validation during model upgrades.
+// Implements environs.CloudEndpointChecker
+func (env *Environ) ValidateCloudEndpoint(ctx context.ProviderCallContext) error {
+	err := env.Provider().Ping(ctx, env.cloud().Endpoint)
+	return errors.Trace(err)
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,9 @@ description: |
    - https://discourse.charmhub.io/
    - https://github.com/juju/juju
 
+  ** Note **
+  This snap needs to read any relevant locally stored cloud credentials in order to manage resources on your behalf in a specified cloud. 
+
 confinement: classic
 grade: devel
 base: core18
@@ -29,27 +32,32 @@ apps:
       # Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
       PATH: "$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH"
     command: bin/juju
-    # Even though the snap is being build as classic, the store still places the
-    # snap in a review queue despite these not being needed in classic.
-    # plugs:
-      # - network
-      # - ssh-keys
-      # - lxd
+    plugs:
+      - network
+      - network-bind
+      - ssh-public-keys
+      - lxd
       # Needed so that juju can still use the real ~/.local/share/juju.
-      # - config-juju
+      - dot-local-share-juju
       # Needed to read lxd config.
-      # - config-lxd
+      - config-lxd
       # Needed to read ~/.kube, ~/.novarc, ~/.aws etc.
-      # - cloud-credentials-juju
-      # Needed so that arbitrary cloud/credential yaml files can be read.
-      # - home
+      - dot-aws
+      - dot-azure
+      - dot-google
+      - dot-kubernetes
+      - dot-maas
+      - dot-openstack
+      - dot-oracle
+      # Needed so that arbitrary cloud/credential yaml files can be read and backups written.
+      - home
   fetch-oci:
     daemon: oneshot
     command: wrappers/fetch-oci
     start-timeout: 1m
     stop-timeout: 35s
-#    plugs:
-#      - network
+    plugs:
+      - network
 
 parts:
   wrappers:
@@ -120,26 +128,47 @@ plugs:
     content: microk8s
     target: $SNAP_COMMON/.peers
 
-# Even though the snap is being build as classic, the store still places the
-# snap in a review queue despite these not being needed in classic.
-#  config-juju:
-#    interface: personal-files
-#    write:
-#      - $HOME/.local/share/juju
-#
-#  config-lxd:
-#    interface: personal-files
-#    read:
-#      - $HOME/snap/lxd/current/.config/lxc
-#      - $HOME/snap/lxd/common/config
-#
-#  cloud-credentials-juju:
-#    interface: personal-files
-#    read:
-#      - $HOME/.aws
-#      - $HOME/.azure
-#      - $HOME/.config
-#      - $HOME/.kube
-#      - $HOME/.maasrc
-#      - $HOME/.oci
-#      - $HOME/.novarc
+  dot-local-share-juju:
+    interface: personal-files
+    write:
+      - $HOME/.local/share/juju
+
+  config-lxd:
+    interface: personal-files
+    read:
+      - $HOME/snap/lxd/common/config
+
+  dot-aws:
+    interface: personal-files
+    read:
+      - $HOME/.aws
+
+  dot-azure:
+    interface: personal-files
+    read:
+      - $HOME/.azure
+
+  dot-google:
+    interface: personal-files
+    read:
+      - $HOME/.config/gcloud
+
+  dot-kubernetes:
+    interface: personal-files
+    read:
+      - $HOME/.kube
+
+  dot-maas:
+    interface: personal-files
+    read:
+      - $HOME/.maasrc
+
+  dot-oracle:
+    interface: personal-files
+    read:
+      - $HOME/.oci
+
+  dot-openstack:
+    interface: personal-files
+    read:
+      - $HOME/.novarc

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -382,11 +382,12 @@ func (s *allWatcherBaseSuite) setUpScenario(c *gc.C, st *State, units int) (enti
 	mysql := AddTestingApplication(c, st, "mysql", AddTestingCharm(c, st, "mysql"))
 	curl := applicationCharmURL(mysql)
 	add(&multiwatcher.ApplicationInfo{
-		ModelUUID: modelUUID,
-		Name:      "mysql",
-		CharmURL:  curl.String(),
-		Life:      life.Alive,
-		Config:    charm.Settings{},
+		ModelUUID:   modelUUID,
+		Name:        "mysql",
+		CharmURL:    curl.String(),
+		Life:        life.Alive,
+		Config:      charm.Settings{},
+		Constraints: constraints.MustParse("arch=amd64"),
 		Status: multiwatcher.StatusInfo{
 			Current: "unset",
 			Message: "",
@@ -688,11 +689,12 @@ func (s *allWatcherStateSuite) TestChangeCAASApplications(c *gc.C) {
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ApplicationInfo{
-						ModelUUID: caasSt.ModelUUID(),
-						Name:      "mysql",
-						CharmURL:  "local:kubernetes/kubernetes-mysql-0",
-						Life:      "alive",
-						Config:    map[string]interface{}{},
+						ModelUUID:   caasSt.ModelUUID(),
+						Name:        "mysql",
+						CharmURL:    "local:kubernetes/kubernetes-mysql-0",
+						Life:        "alive",
+						Config:      map[string]interface{}{},
+						Constraints: constraints.MustParse("arch=amd64"),
 						Status: multiwatcher.StatusInfo{
 							Current: "unset",
 							Data:    map[string]interface{}{},
@@ -2116,13 +2118,14 @@ func testChangeApplications(c *gc.C, owner names.UserTag, runChangeTests func(*g
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.ApplicationInfo{
-						ModelUUID: st.ModelUUID(),
-						Name:      "wordpress",
-						Exposed:   true,
-						CharmURL:  "local:quantal/quantal-wordpress-3",
-						Life:      life.Alive,
-						MinUnits:  42,
-						Config:    charm.Settings{},
+						ModelUUID:   st.ModelUUID(),
+						Name:        "wordpress",
+						Exposed:     true,
+						CharmURL:    "local:quantal/quantal-wordpress-3",
+						Life:        life.Alive,
+						MinUnits:    42,
+						Config:      charm.Settings{},
+						Constraints: constraints.MustParse("arch=amd64"),
 						Status: multiwatcher.StatusInfo{
 							Current: "unset",
 							Message: "",

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3308,7 +3308,8 @@ func (s *ApplicationSuite) TestConstraints(c *gc.C) {
 	// Constraints are initially empty (for now).
 	cons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&cons, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(&cons, gc.Not(jc.Satisfies), constraints.IsEmpty)
+	c.Assert(cons, gc.DeepEquals, constraints.MustParse("arch=amd64"))
 
 	// Constraints can be set.
 	cons2 := constraints.Value{Mem: uint64p(4096)}
@@ -3339,7 +3340,8 @@ func (s *ApplicationSuite) TestConstraints(c *gc.C) {
 	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
 	cons6, err := mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&cons6, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(&cons6, gc.Not(jc.Satisfies), constraints.IsEmpty)
+	c.Assert(cons6, gc.DeepEquals, constraints.MustParse("arch=amd64"))
 }
 
 func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
@@ -3371,7 +3373,8 @@ func (s *ApplicationSuite) TestArchConstraints(c *gc.C) {
 	mysql := s.AddTestingApplication(c, s.mysql.Name(), ch)
 	cons6, err := mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(constraints.IsEmpty(&cons6), jc.IsTrue)
+	c.Assert(constraints.IsEmpty(&cons6), jc.IsFalse)
+	c.Assert(cons6, jc.DeepEquals, cons2)
 }
 
 func (s *ApplicationSuite) TestSetInvalidConstraints(c *gc.C) {
@@ -3413,7 +3416,8 @@ func (s *ApplicationSuite) TestConstraintsLifecycle(c *gc.C) {
 
 	scons, err := s.mysql.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(&scons, jc.Satisfies, constraints.IsEmpty)
+	c.Assert(&scons, gc.Not(jc.Satisfies), constraints.IsEmpty)
+	c.Assert(scons, gc.DeepEquals, constraints.MustParse("arch=amd64"))
 
 	// Removed (== Dead, for a application).
 	c.Assert(unit.EnsureDead(), jc.ErrorIsNil)

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -62,6 +62,7 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MaxCharmStateSize,
 		controller.MaxAgentStateSize,
 		controller.NonSyncedWritesToRaftLog,
+		controller.BatchRaftFSM,
 		controller.MigrationMinionWaitMax,
 		controller.AgentLogfileMaxBackups,
 		controller.AgentLogfileMaxSize,

--- a/state/prechecker_test.go
+++ b/state/prechecker_test.go
@@ -261,7 +261,7 @@ func (s *PrecheckerSuite) TestPrecheckAddApplicationNoPlacement(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": failed for some reason`)
 	c.Assert(s.prechecker.precheckInstanceArgs, jc.DeepEquals, environs.PrecheckInstanceParams{
 		Series:      "quantal",
-		Constraints: constraints.MustParse("root-disk=20G"),
+		Constraints: constraints.MustParse("arch=amd64 root-disk=20G"),
 	})
 }
 
@@ -310,7 +310,8 @@ func (s *PrecheckerSuite) TestPrecheckAddApplicationMixedPlacement(c *gc.C) {
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot add application "wordpress": hey now`)
 	c.Assert(s.prechecker.precheckInstanceArgs, jc.DeepEquals, environs.PrecheckInstanceParams{
-		Series:    "precise",
-		Placement: "somewhere",
+		Series:      "precise",
+		Placement:   "somewhere",
+		Constraints: constraints.MustParse("arch=amd64"),
 	})
 }

--- a/state/state.go
+++ b/state/state.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
 
+	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
@@ -1173,6 +1174,24 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return nil, errors.Trace(err)
 	}
 
+	// Always ensure that we snapshot the application architecture when adding
+	// the application. If no architecture in the constraints, then look at
+	// the model constraints. If no architecture is found in the model, use the
+	// default architecture (amd64).
+	var (
+		cons        = args.Constraints
+		subordinate = args.Charm.Meta().Subordinate
+	)
+	if !subordinate && !cons.HasArch() {
+		modelConstraints, err := st.ModelConstraints()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		a := arch.ConstraintArch(cons, &modelConstraints)
+		cons.Arch = &a
+		args.Constraints = cons
+	}
+
 	// Perform model specific arg processing.
 	var (
 		scale             int
@@ -1215,7 +1234,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		Name:          args.Name,
 		ModelUUID:     st.ModelUUID(),
 		Series:        args.Series,
-		Subordinate:   args.Charm.Meta().Subordinate,
+		Subordinate:   subordinate,
 		CharmURL:      args.Charm.URL(),
 		CharmOrigin:   args.CharmOrigin,
 		Channel:       string(args.Channel),

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1609,14 +1609,26 @@ func (s *StateSuite) TestAddApplication(c *gc.C) {
 	outconfig, err := wordpress.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outconfig, gc.DeepEquals, inconfig.Attributes())
+	cons, err := wordpress.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	a := corearch.DefaultArchitecture
+	c.Assert(cons, jc.DeepEquals, constraints.Value{
+		Arch: &a,
+	})
 
-	mysql, err := s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Charm: ch})
+	mysqlArch := arch.ARM64
+	mysql, err := s.State.AddApplication(state.AddApplicationArgs{Name: "mysql", Charm: ch, Constraints: constraints.Value{Arch: &mysqlArch}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mysql.Name(), gc.Equals, "mysql")
 	sInfo, err := mysql.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sInfo.Status, gc.Equals, status.Unset)
 	c.Assert(sInfo.Message, gc.Equals, "")
+	cons, err = mysql.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cons, jc.DeepEquals, constraints.Value{
+		Arch: &mysqlArch,
+	})
 
 	// Check that retrieving the new created applications works correctly.
 	wordpress, err = s.State.Application("wordpress")
@@ -1661,6 +1673,13 @@ func (s *StateSuite) TestAddCAASApplication(c *gc.C) {
 	outconfig, err := gitlab.ApplicationConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(outconfig, gc.DeepEquals, inconfig.Attributes())
+
+	cons, err := gitlab.Constraints()
+	c.Assert(err, jc.ErrorIsNil)
+	a := corearch.DefaultArchitecture
+	c.Assert(cons, jc.DeepEquals, constraints.Value{
+		Arch: &a,
+	})
 
 	sInfo, err := gitlab.Status()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/unit.go
+++ b/state/unit.go
@@ -2018,7 +2018,7 @@ func (u *Unit) Constraints() (*constraints.Value, error) {
 			}
 		}
 		if !cons.HasArch() {
-			a := arch.DefaultArchitecture
+			a := arch.ConstraintArch(cons, nil)
 			cons.Arch = &a
 		}
 	}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3971,6 +3971,7 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 		return errors.Trace(err)
 	}
 
+	refCountPerController := make(map[string]int)
 	err := errors.Trace(runForAllModelStates(pool, func(st *State) error {
 		remoteApps, rCloser := st.db().GetCollection(remoteApplicationsC)
 		defer rCloser()
@@ -3986,6 +3987,7 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 		for iter.Next(&appDoc) {
 			if appDoc.SourceControllerUUID != "" {
 				orphanedControllers.Remove(appDoc.SourceControllerUUID)
+				refCountPerController[appDoc.SourceControllerUUID] = refCountPerController[appDoc.SourceControllerUUID] + 1
 				continue
 			}
 			controllerUUID, ok := modelControllers[appDoc.SourceModelUUID]
@@ -4000,11 +4002,7 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 					"source-controller-uuid", controllerUUID}},
 				}},
 			})
-			incRefOp, err := incExternalControllersRefOp(st, controllerUUID)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			ops = append(ops, incRefOp)
+			refCountPerController[controllerUUID] = refCountPerController[controllerUUID] + 1
 		}
 		if err := iter.Close(); err != nil {
 			return errors.Trace(err)
@@ -4022,6 +4020,21 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 		return errors.Trace(err)
 	}
 
+	var ops []txn.Op
+	for controllerUUID, refCount := range refCountPerController {
+		incRefOp, err := setExternalControllersRefOp(st, controllerUUID, refCount)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		ops = append(ops, incRefOp...)
+	}
+	if len(ops) > 0 {
+		err := st.db().RunTransaction(ops)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	if orphanedControllers.Size() > 0 {
 		_, err := extControllers.Writeable().RemoveAll(bson.D{
 			{"_id", bson.D{{"$in", orphanedControllers.Values()}}},
@@ -4031,6 +4044,25 @@ func UpdateExternalControllerInfo(pool *StatePool) error {
 		}
 	}
 	return nil
+}
+
+// setExternalControllersRefOp returns a txn.Op that sets the reference
+// count for an external controller, incrementing any existing value as needed.
+// These ref counts are controller wide.
+func setExternalControllersRefOp(mb modelBackend, controllerUUID string, count int) ([]txn.Op, error) {
+	refcounts, closer := mb.db().GetCollection(globalRefcountsC)
+	defer closer()
+	refCountKey := externalControllerRefCountKey(controllerUUID)
+	existing, err := nsRefcounts.read(refcounts, refCountKey)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, errors.Trace(err)
+	}
+	if count == existing {
+		return nil, nil
+	}
+	newCount := count - existing
+	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, refCountKey, newCount)
+	return []txn.Op{incRefOp}, errors.Trace(err)
 }
 
 // RemoveInvalidCharmPlaceholders removes invalid charms that have invalid charm

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5992,17 +5992,22 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
 		Name:        "remote-application2",
+		SourceModel: names.NewModelTag(modelUUID1),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
+		Name:        "remote-application3",
 		SourceModel: names.NewModelTag(modelUUID2),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
-		Name:            "remote-application3",
+		Name:            "remote-application4",
 		SourceModel:     names.NewModelTag(modelUUID1),
 		IsConsumerProxy: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = model1.AddRemoteApplication(AddRemoteApplicationParams{
-		Name:        "remote-application4",
+		Name:        "remote-application5",
 		SourceModel: names.NewModelTag(modelUUID1),
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -6032,18 +6037,32 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"name":                   "remote-application2",
 			"offer-uuid":             "",
 			"relationcount":          0,
-			"source-controller-uuid": "",
-			"source-model-uuid":      modelUUID2,
+			"source-controller-uuid": extControllerUUID,
+			"source-model-uuid":      modelUUID1,
 			"spaces":                 []interface{}{},
 		},
 		{
 			"_id":                    model0.docID("remote-application3"),
 			"bindings":               bson.M{},
 			"endpoints":              []interface{}{},
-			"is-consumer-proxy":      true,
+			"is-consumer-proxy":      false,
 			"life":                   0,
 			"model-uuid":             model0.modelUUID(),
 			"name":                   "remote-application3",
+			"offer-uuid":             "",
+			"relationcount":          0,
+			"source-controller-uuid": "",
+			"source-model-uuid":      modelUUID2,
+			"spaces":                 []interface{}{},
+		},
+		{
+			"_id":                    model0.docID("remote-application4"),
+			"bindings":               bson.M{},
+			"endpoints":              []interface{}{},
+			"is-consumer-proxy":      true,
+			"life":                   0,
+			"model-uuid":             model0.modelUUID(),
+			"name":                   "remote-application4",
 			"offer-uuid":             "",
 			"relationcount":          0,
 			"source-controller-uuid": "",
@@ -6051,13 +6070,13 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"spaces":                 []interface{}{},
 		},
 		{
-			"_id":                    model1.docID("remote-application4"),
+			"_id":                    model1.docID("remote-application5"),
 			"bindings":               bson.M{},
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      false,
 			"life":                   0,
 			"model-uuid":             model1.modelUUID(),
-			"name":                   "remote-application4",
+			"name":                   "remote-application5",
 			"offer-uuid":             "",
 			"relationcount":          0,
 			"source-controller-uuid": extControllerUUID,
@@ -6073,6 +6092,14 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 		upgradedData(appColl, expectedApps),
 	)
 
+	// Check the ref counts.
+	refcounts, closer := s.state.db().GetCollection(globalRefcountsC)
+	defer closer()
+	key := externalControllerRefCountKey(extControllerUUID)
+	count, err := nsRefcounts.read(refcounts, key)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(count, gc.Equals, 3)
+
 	// Check the orphaned controller is removed and we still have
 	// the in use controller.
 	ec = NewExternalControllers(s.state)
@@ -6080,6 +6107,91 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	_, err = ec.Controller(extControllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradesSuite) TestUpdateExternalControllerInfoFixRefCount(c *gc.C) {
+	model0 := s.makeModel(c, "model-0", coretesting.Attrs{})
+	defer func() {
+		_ = model0.Close()
+	}()
+
+	extControllerUUID := utils.MustNewUUID().String()
+	modelUUID1 := utils.MustNewUUID().String()
+
+	ec := NewExternalControllers(s.state)
+	_, err := ec.Save(crossmodel.ControllerInfo{
+		ControllerTag: names.NewControllerTag(extControllerUUID),
+		Addrs:         []string{"10.0.0.1:17070"},
+	}, modelUUID1)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = ec.Save(crossmodel.ControllerInfo{
+		ControllerTag: coretesting.ControllerTag,
+		Addrs:         []string{"10.0.0.2:17070"},
+	}, coretesting.ModelTag.Id())
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
+		Name:        "remote-application",
+		SourceModel: names.NewModelTag(modelUUID1),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = model0.AddRemoteApplication(AddRemoteApplicationParams{
+		Name:        "remote-application2",
+		SourceModel: names.NewModelTag(modelUUID1),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add a bad ref count.
+	refcounts, closer := s.state.db().GetCollection(globalRefcountsC)
+	defer closer()
+	key := externalControllerRefCountKey(extControllerUUID)
+	op, err := nsRefcounts.CreateOrIncRefOp(refcounts, key, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.state.db().RunTransaction([]txn.Op{op})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedApps := bsonMById{
+		{
+			"_id":                    model0.docID("remote-application"),
+			"bindings":               bson.M{},
+			"endpoints":              []interface{}{},
+			"is-consumer-proxy":      false,
+			"life":                   0,
+			"model-uuid":             model0.modelUUID(),
+			"name":                   "remote-application",
+			"offer-uuid":             "",
+			"relationcount":          0,
+			"source-controller-uuid": extControllerUUID,
+			"source-model-uuid":      modelUUID1,
+			"spaces":                 []interface{}{},
+		},
+		{
+			"_id":                    model0.docID("remote-application2"),
+			"bindings":               bson.M{},
+			"endpoints":              []interface{}{},
+			"is-consumer-proxy":      false,
+			"life":                   0,
+			"model-uuid":             model0.modelUUID(),
+			"name":                   "remote-application2",
+			"offer-uuid":             "",
+			"relationcount":          0,
+			"source-controller-uuid": extControllerUUID,
+			"source-model-uuid":      modelUUID1,
+			"spaces":                 []interface{}{},
+		},
+	}
+	sort.Sort(expectedApps)
+
+	appColl, aCloser := s.state.db().GetRawCollection(remoteApplicationsC)
+	defer aCloser()
+	s.assertUpgradedData(c, UpdateExternalControllerInfo,
+		upgradedData(appColl, expectedApps),
+	)
+
+	// Check the ref counts.
+	count, err := nsRefcounts.read(refcounts, key)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(count, gc.Equals, 2)
 }
 
 func (s *upgradesSuite) TestRemoveInvalidCharmPlaceholders(c *gc.C) {

--- a/upgrades/steps_2924.go
+++ b/upgrades/steps_2924.go
@@ -7,13 +7,6 @@ package upgrades
 func stateStepsFor2924() []Step {
 	return []Step{
 		&upgradeStep{
-			description: "update remote application external controller info",
-			targets:     []Target{DatabaseMaster},
-			run: func(context Context) error {
-				return context.State().UpdateExternalControllerInfo()
-			},
-		},
-		&upgradeStep{
 			description: "remove invalid charm placeholders",
 			targets:     []Target{DatabaseMaster},
 			run: func(context Context) error {

--- a/upgrades/steps_2924_test.go
+++ b/upgrades/steps_2924_test.go
@@ -20,11 +20,6 @@ type steps2924Suite struct {
 
 var _ = gc.Suite(&steps2924Suite{})
 
-func (s *steps2924Suite) TestUpdateExternalControllerInfo(c *gc.C) {
-	step := findStateStep(c, v2924, "update remote application external controller info")
-	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
-}
-
 func (s *steps2924Suite) TestRemoveInvalidCharmPlaceholders(c *gc.C) {
 	step := findStateStep(c, v2924, "remove invalid charm placeholders")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})

--- a/upgrades/steps_2926.go
+++ b/upgrades/steps_2926.go
@@ -20,5 +20,12 @@ func stateStepsFor2926() []Step {
 				return context.State().UpdateCharmOriginAfterSetSeries()
 			},
 		},
+		&upgradeStep{
+			description: "update remote application external controller info",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().UpdateExternalControllerInfo()
+			},
+		},
 	}
 }

--- a/upgrades/steps_2926_test.go
+++ b/upgrades/steps_2926_test.go
@@ -29,3 +29,8 @@ func (s *steps2926Suite) TestUpdateCharmOriginAfterSetSeries(c *gc.C) {
 	step := findStateStep(c, v2926, "update charm origin to facilitate charm refresh after set-series")
 	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
 }
+
+func (s *steps2926Suite) TestUpdateExternalControllerInfo(c *gc.C) {
+	step := findStateStep(c, v2926, "update remote application external controller info")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -103,6 +103,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			configNonSyncedWritesToRaftLog := controllerConfig.NonSyncedWritesToRaftLog()
 			nonSyncedWritesToRaftLogChanged := agentsNonSyncedWritesToRaftLog != configNonSyncedWritesToRaftLog
 
+			agentsBatchRaftFSM := agent.CurrentConfig().BatchRaftFSM()
+			configBatchRaftFSM := controllerConfig.BatchRaftFSM()
+			batchRaftFSMChanged := agentsBatchRaftFSM != configBatchRaftFSM
+
 			info, err := apiState.StateServingInfo()
 			if err != nil {
 				return nil, errors.Annotate(err, "getting state serving info")
@@ -133,6 +137,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 					logger.Debugf("setting non synced writes to raft log: %t => %t", agentsNonSyncedWritesToRaftLog, configNonSyncedWritesToRaftLog)
 					config.SetNonSyncedWritesToRaftLog(configNonSyncedWritesToRaftLog)
 				}
+				if batchRaftFSMChanged {
+					logger.Debugf("setting batch raft fsm: %t => %t", agentsBatchRaftFSM, configBatchRaftFSM)
+					config.SetBatchRaftFSM(configBatchRaftFSM)
+				}
 				return nil
 			})
 			if err != nil {
@@ -161,6 +169,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				MongoProfile:             configMongoMemoryProfile,
 				JujuDBSnapChannel:        configJujuDBSnapChannel,
 				NonSyncedWritesToRaftLog: configNonSyncedWritesToRaftLog,
+				BatchRaftFSM:             configBatchRaftFSM,
 				Logger:                   config.Logger,
 			})
 		},

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -357,6 +357,9 @@ type mockConfig struct {
 
 	nonSyncedWritesToRaftLog    bool
 	nonSyncedWritesToRaftLogSet bool
+
+	batchRaftFSM    bool
+	batchRaftFSMSet bool
 }
 
 func (mc *mockConfig) Tag() names.Tag {
@@ -410,6 +413,15 @@ func (mc *mockConfig) NonSyncedWritesToRaftLog() bool {
 func (mc *mockConfig) SetNonSyncedWritesToRaftLog(nonSynced bool) {
 	mc.nonSyncedWritesToRaftLog = nonSynced
 	mc.nonSyncedWritesToRaftLogSet = true
+}
+
+func (mc *mockConfig) BatchRaftFSM() bool {
+	return mc.batchRaftFSM
+}
+
+func (mc *mockConfig) SetBatchRaftFSM(batchRaftFSM bool) {
+	mc.batchRaftFSM = batchRaftFSM
+	mc.batchRaftFSMSet = true
 }
 
 func (mc *mockConfig) LogDir() string {

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -46,6 +46,7 @@ type appWorker struct {
 	changes     chan struct{}
 	password    string
 	lastApplied caas.ApplicationConfig
+	life        life.Value
 }
 
 type AppWorkerConfig struct {
@@ -216,6 +217,7 @@ func (a *appWorker) loop() error {
 		} else if err != nil {
 			return errors.Trace(err)
 		}
+		a.life = appLife
 		switch appLife {
 		case life.Alive:
 			if appStateChanges == nil {
@@ -264,6 +266,8 @@ func (a *appWorker) loop() error {
 			}
 			done = true
 			return nil
+		default:
+			return errors.NotImplementedf("unknown life %d", a.life)
 		}
 		return nil
 	}
@@ -603,14 +607,25 @@ func (a *appWorker) refreshApplicationStatus(app caas.Application, appLife life.
 }
 
 func (a *appWorker) ensureScale(app caas.Application) error {
-	desiredScale, err := a.unitFacade.ApplicationScale(a.name)
-	if err != nil {
-		return errors.Annotatef(err, "fetching application %q desired scale", a.name)
+	var err error
+	var desiredScale int
+	switch a.life {
+	case life.Alive:
+		desiredScale, err = a.unitFacade.ApplicationScale(a.name)
+		if err != nil {
+			return errors.Annotatef(err, "fetching application %q desired scale", a.name)
+		}
+	case life.Dying, life.Dead:
+		desiredScale = 0
+	default:
+		return errors.NotImplementedf("unknown life %d", a.life)
 	}
 
 	a.logger.Debugf("updating application %q scale to %d", a.name, desiredScale)
 	err = app.Scale(desiredScale)
-	if err != nil {
+	if a.life == life.Dead && errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
 		return errors.Annotatef(
 			err,
 			"scaling application %q to desired scale %d",
@@ -764,9 +779,9 @@ func (a *appWorker) setApplicationStatus(s status.Status, reason string, data ma
 
 func (a *appWorker) dying(app caas.Application) error {
 	a.logger.Debugf("application %q dying", a.name)
-	err := app.Delete()
+	err := a.ensureScale(app)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "cannot scale dying application to 0")
 	}
 	return nil
 }
@@ -774,6 +789,10 @@ func (a *appWorker) dying(app caas.Application) error {
 func (a *appWorker) dead(app caas.Application) error {
 	a.logger.Debugf("application %q dead", a.name)
 	err := a.dying(app)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = app.Delete()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -431,7 +431,7 @@ func (s *ApplicationWorkerSuite) assertWorker(c *gc.C, name string) {
 		tc.facade.EXPECT().Life(name).DoAndReturn(func(string) (life.Value, error) {
 			return life.Dying, nil
 		}),
-		tc.brokerApp.EXPECT().Delete().DoAndReturn(func() error {
+		tc.brokerApp.EXPECT().Scale(0).DoAndReturn(func(int) error {
 			tc.notifyReady <- struct{}{}
 			return nil
 		}),
@@ -439,6 +439,9 @@ func (s *ApplicationWorkerSuite) assertWorker(c *gc.C, name string) {
 		// 2nd Notify() - dead.
 		tc.facade.EXPECT().Life(name).DoAndReturn(func(string) (life.Value, error) {
 			return life.Dead, nil
+		}),
+		tc.brokerApp.EXPECT().Scale(0).DoAndReturn(func(int) error {
+			return nil
 		}),
 		tc.brokerApp.EXPECT().Delete().DoAndReturn(func() error {
 			return nil
@@ -770,7 +773,7 @@ func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusNoOpsForDyingApplic
 		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
 			return life.Dying, nil
 		}),
-		tc.brokerApp.EXPECT().Delete().DoAndReturn(func() error {
+		tc.brokerApp.EXPECT().Scale(0).DoAndReturn(func(int) error {
 			close(done)
 			return nil
 		}),
@@ -787,6 +790,9 @@ func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusNoOpsForDeadApplica
 	s.assertRefreshApplicationStatus(c, tc, newAppWorker,
 		tc.facade.EXPECT().Life("test").DoAndReturn(func(string) (life.Value, error) {
 			return life.Dead, nil
+		}),
+		tc.brokerApp.EXPECT().Scale(0).DoAndReturn(func(int) error {
+			return nil
 		}),
 		tc.brokerApp.EXPECT().Delete().DoAndReturn(func() error {
 			return nil

--- a/worker/containerbroker/manifold.go
+++ b/worker/containerbroker/manifold.go
@@ -15,13 +15,6 @@ import (
 	"github.com/juju/juju/environs"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/worker_mock.go github.com/juju/worker/v3 Worker
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/dependency_mock.go github.com/juju/worker/v3/dependency Context
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/environs_mock.go github.com/juju/juju/environs LXDProfiler,InstanceBroker
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machine_lock_mock.go github.com/juju/juju/core/machinelock Lock
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/base_mock.go github.com/juju/juju/api/base APICaller
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/agent_mock.go github.com/juju/juju/agent Agent,Config
-
 // ManifoldConfig describes the resources used by a Tracker.
 type ManifoldConfig struct {
 	AgentName     string

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -150,6 +150,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/containerbroker/package_test.go
+++ b/worker/containerbroker/package_test.go
@@ -9,6 +9,13 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/worker_mock.go github.com/juju/worker/v3 Worker
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/dependency_mock.go github.com/juju/worker/v3/dependency Context
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/environs_mock.go github.com/juju/juju/environs LXDProfiler,InstanceBroker
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machine_lock_mock.go github.com/juju/juju/core/machinelock Lock
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/base_mock.go github.com/juju/juju/api/base APICaller
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/agent_mock.go github.com/juju/juju/agent Agent,Config
+
 func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -150,6 +150,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/instancemutater/package_test.go
+++ b/worker/instancemutater/package_test.go
@@ -9,6 +9,11 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/instancebroker_mock.go github.com/juju/juju/worker/instancemutater InstanceMutaterAPI
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/logger_mock.go github.com/juju/juju/worker/instancemutater Logger
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/namestag_mock.go github.com/juju/names/v4 Tag
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/instancemutater MutaterMachine
+
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -18,11 +18,6 @@ import (
 	"github.com/juju/juju/environs"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/instancebroker_mock.go github.com/juju/juju/worker/instancemutater InstanceMutaterAPI
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/logger_mock.go github.com/juju/juju/worker/instancemutater Logger
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/namestag_mock.go github.com/juju/names/v4 Tag
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/instancemutater MutaterMachine
-
 type InstanceMutaterAPI interface {
 	WatchMachines() (watcher.StringsWatcher, error)
 	Machine(tag names.MachineTag) (instancemutater.MutaterMachine, error)

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -60,6 +60,11 @@ juju_application_agent_name () {
   echo $application
 }
 
+juju_unit_agent_name () {
+  local unit=$(find /var/lib/juju/agents -type d -name 'unit*' -printf %f)
+  echo $unit
+}
+
 juju_agent () {
   local agent=$(juju_machine_agent_name)
   if [ -z "$agent" ]; then
@@ -67,6 +72,9 @@ juju_agent () {
   fi
   if [ -z "$agent" ]; then
     agent=$(juju_application_agent_name)
+  fi
+  if [ -z "$agent" ]; then
+    agent=$(juju_unit_agent_name)
   fi
   juju_agent_call $agent $@
 }

--- a/worker/raft/mock_test.go
+++ b/worker/raft/mock_test.go
@@ -26,6 +26,7 @@ type mockAgentConfig struct {
 	dataDir                  string
 	tag                      names.Tag
 	nonSyncedWritesToRaftLog bool
+	batchRaftFSM             bool
 }
 
 func (c *mockAgentConfig) Tag() names.Tag {
@@ -38,6 +39,10 @@ func (c *mockAgentConfig) DataDir() string {
 
 func (c *mockAgentConfig) NonSyncedWritesToRaftLog() bool {
 	return c.nonSyncedWritesToRaftLog
+}
+
+func (c *mockAgentConfig) BatchRaftFSM() bool {
+	return c.batchRaftFSM
 }
 
 type mockRaftWorker struct {

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -176,6 +176,18 @@ func (st State) Validate() (err error) {
 	return nil
 }
 
+func (st State) Report() map[string]interface{} {
+	result := make(map[string]interface{})
+	result["started"] = st.Started
+	result["stopped"] = st.Stopped
+	result["installed"] = st.Installed
+	result["removed"] = st.Removed
+	result["hook-kind"] = st.Kind
+	result["hook-step"] = st.Step
+	result["leader"] = st.Leader
+	return result
+}
+
 func (st State) match(otherState State) bool {
 	stateYaml, _ := yaml.Marshal(st)
 	otherStateYaml, _ := yaml.Marshal(otherState)

--- a/worker/uniter/runner/jujuc/action-set_test.go
+++ b/worker/uniter/runner/jujuc/action-set_test.go
@@ -73,6 +73,11 @@ func (s *ActionSetSuite) TestActionSet(c *gc.C) {
 		errMsg:  "ERROR key \"result-Value\" must start and end with lowercase alphanumeric, and contain only lowercase alphanumeric, hyphens and periods\n",
 		code:    2,
 	}, {
+		summary: "reserved key is an error",
+		command: []string{"stdout=foo"},
+		errMsg:  "ERROR cannot set reserved action key \"stdout\"\n",
+		code:    2,
+	}, {
 		summary: "empty values are not an error",
 		command: []string{"result="},
 		expected: [][]string{
@@ -153,7 +158,8 @@ Details:
 action-set adds the given values to the results map of the Action. This map
 is returned to the user after the completion of the Action. Keys must start
 and end with lowercase alphanumeric, and contain only lowercase alphanumeric,
-hyphens and periods.
+hyphens and periods.  The following special keys are reserved for internal use: 
+"stdout", "stdout-encoding", "stderr", "stderr-encoding".
 
 Example usage:
  action-set outfile.size=10G

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -989,6 +989,9 @@ func (u *Uniter) Report() map[string]interface{} {
 	if u.unit != nil {
 		result["unit"] = u.unit.Name()
 	}
+	if u.operationExecutor != nil {
+		result["local-state"] = u.operationExecutor.State().Report()
+	}
 	if u.relationStateTracker != nil {
 		result["relations"] = u.relationStateTracker.Report()
 	}

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -151,6 +151,20 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfig) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()
@@ -543,6 +557,20 @@ func (mr *MockConfigSetterMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfigSetter)(nil).AgentLogfileMaxSizeMB))
 }
 
+// BatchRaftFSM mocks base method.
+func (m *MockConfigSetter) BatchRaftFSM() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BatchRaftFSM")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BatchRaftFSM indicates an expected call of BatchRaftFSM.
+func (mr *MockConfigSetterMockRecorder) BatchRaftFSM() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfigSetter)(nil).BatchRaftFSM))
+}
+
 // CACert mocks base method.
 func (m *MockConfigSetter) CACert() string {
 	m.ctrl.T.Helper()
@@ -780,6 +808,18 @@ func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) error {
 func (mr *MockConfigSetterMockRecorder) SetAPIHostPorts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIHostPorts", reflect.TypeOf((*MockConfigSetter)(nil).SetAPIHostPorts), arg0)
+}
+
+// SetBatchRaftFSM mocks base method.
+func (m *MockConfigSetter) SetBatchRaftFSM(arg0 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetBatchRaftFSM", arg0)
+}
+
+// SetBatchRaftFSM indicates an expected call of SetBatchRaftFSM.
+func (mr *MockConfigSetterMockRecorder) SetBatchRaftFSM(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBatchRaftFSM", reflect.TypeOf((*MockConfigSetter)(nil).SetBatchRaftFSM), arg0)
 }
 
 // SetCACert mocks base method.


### PR DESCRIPTION
Merge of 2.9 into develop. Includes:

- #13821 from tlm/makefile-output
- #13748 from rwcarlsen/action-key-guard
- #13818 from ycliuhw/k8s-introspection
- #13816 from hpidcock/scale-sidecar-on-delete
- #13817 from tlm/darwin-arm64-support
- #13815 from tlm/darwin-arm64-support
- #13749 from hmlanigan/lp1960276-use-ping-instead
- #13814 from SimonRichardson/pass-macaroons-with-api-root
- #13795 from SimonRichardson/config-raft-batch-fsm
- #13813 from wallyworld/strict-snap-plugs
- #13812 from tlm/darwin-arm64-support
- #13805 from wallyworld/remote-controller-ref-count
- #13806 from SimonRichardson/set-application-arch-constraint
- #13808 from hmlanigan/download-ch-schema
- #13807 from hmlanigan/report-unit-state

Conflicts:
```
          apiserver/facades/client/application/get_test.go
          apiserver/facades/client/client/client.go
          apiserver/facades/client/client/client_test.go
          cmd/containeragent/unit/agent.go
          cmd/containeragent/unit/agent_test.go
          feature/flags.go
          scripts/win-installer/setup.iss
          snap/snapcraft.yaml
          version/version.go
```
