### PR TITLE
[JUJU-736] Fix embedded deploy CLI for external users

### DIFF
--- a/apiserver/embeddedcli.go
+++ b/apiserver/embeddedcli.go
@@ -243,7 +243,7 @@ func runCLICommands(m *state.Model, errCh chan<- error, commands params.CLIComma
 	// Set up a juju client store used to configure the
 	// embedded command to give it the controller, model
 	// and account details to use.
-	store := jujuclient.NewMemStore()
+	store := jujuclient.NewEmbeddedMemStore()
 	cert, _ := cfg.CACert()
 	controllerName := cfg.ControllerName()
 	if controllerName == "" {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -98,7 +98,7 @@ type DeploySuiteBase struct {
 // charm store and the controller deploy API.
 func (s *DeploySuiteBase) deployCommand() *DeployCommand {
 	deploy := s.deployCommandForState()
-	deploy.NewAPIRoot = func() (DeployAPI, error) {
+	deploy.NewDeployAPI = func() (DeployAPI, error) {
 		return s.fakeAPI, nil
 	}
 	return deploy
@@ -1044,7 +1044,7 @@ func (s *CAASDeploySuiteBase) makeCharmDir(c *gc.C, cloneCharm string) *charm.Ch
 
 func (s *CAASDeploySuiteBase) runDeploy(c *gc.C, fakeAPI *fakeDeployAPI, args ...string) (*cmd.Context, error) {
 	deployCmd := &DeployCommand{
-		NewAPIRoot: func() (DeployAPI, error) {
+		NewDeployAPI: func() (DeployAPI, error) {
 			return fakeAPI, nil
 		},
 		DeployResources: s.DeployResources,
@@ -2522,7 +2522,7 @@ func newWrappedDeployCommandForTest(fakeApi *fakeDeployAPI) modelcmd.ModelComman
 // newDeployCommandForTest returns a command to deploy applications.
 func newDeployCommandForTest(fakeAPI *fakeDeployAPI) *DeployCommand {
 	deployCmd := &DeployCommand{
-		NewAPIRoot: func() (DeployAPI, error) {
+		NewDeployAPI: func() (DeployAPI, error) {
 			return fakeAPI, nil
 		},
 		DeployResources: func(
@@ -2541,7 +2541,7 @@ func newDeployCommandForTest(fakeAPI *fakeDeployAPI) *DeployCommand {
 		},
 	}
 	if fakeAPI == nil {
-		deployCmd.NewAPIRoot = func() (DeployAPI, error) {
+		deployCmd.NewDeployAPI = func() (DeployAPI, error) {
 			apiRoot, err := deployCmd.ModelCommandBase.NewAPIRoot()
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -100,7 +100,7 @@ type ConsumeDetails interface {
 var supportedJujuSeries = series.WorkloadSeries
 
 type DeployerAPI interface {
-	// Needed for BestFacadeVersion and for the DeployResourcesFunc.
+	// APICallCloser is needed for BestFacadeVersion and for the DeployResourcesFunc.
 	base.APICallCloser
 
 	ApplicationAPI

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -284,7 +284,7 @@ type AccountRemover interface {
 
 // AccountGetter gets accounts.
 type AccountGetter interface {
-	// AccountByName returns the account associated with the given
+	// AccountDetails returns the account associated with the given
 	// controller name. If no associated account exists, an error
 	// satisfying errors.IsNotFound will be returned.
 	AccountDetails(controllerName string) (*AccountDetails, error)


### PR DESCRIPTION
When using the dashboard CLI widget, the deploy command was failing. The deploy command creates a couple of facades, and calls NewAPIRoot() more than once. Each call does a login and then updates the account details. Because the embedded CLI uses an in memory store for these details, the info was being overwritten and the macaroon was cleared.

This fix does 2 things:
- refactor deploy to only get the api root once
- make the mem store robust to account updates in case it happens again

## QA steps
```
juju bootstrap aws/ap-southeast-2 ian --config identity-url=https://api.jujucharms.com/identity --config identity-public-key=hmHaPgCC1UfuhYHUSX5+aihSAZesqpVdjRv0mgfIwjo=
juju grant wallyworld@external login
juju grant wallyworld@external write default
```

then use the dashboard to deploy a charm
also check deploy from the CLI
