### PR TITLE
[JUJU-668] Add partial support for centos 9 stream

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -33,10 +33,9 @@ type centOSHelper struct {
 func (helper centOSHelper) getRequiredPackages() []string {
 	return []string{
 		"curl",
-		"bridge-utils",
-		"cloud-utils",
 		"nmap-ncat",
 		"tmux",
+		"tar",
 	}
 }
 

--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -120,6 +120,14 @@ var CloudImagesDailyRemote = ServerSpec{
 	Protocol: SimpleStreamsProtocol,
 }
 
+// CloudImagesLinuxContainersRemote hosts images for other distributions.
+// These will be used for pulling CentOS images.
+var CloudImagesLinuxContainersRemote = ServerSpec{
+	Name:     "images.linuxcontainers.org",
+	Host:     "https://images.linuxcontainers.org",
+	Protocol: SimpleStreamsProtocol,
+}
+
 // ConnectImageRemote connects to a remote ImageServer using specified protocol.
 var ConnectImageRemote = connectImageRemote
 

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -190,9 +190,11 @@ func seriesRemoteAliases(series, arch string) ([]string, error) {
 		if arch == jujuarch.AMD64 {
 			switch series {
 			case "centos7":
-				return []string{"centos/7/amd64"}, nil
+				return []string{"centos/7/cloud/amd64"}, nil
 			case "centos8":
-				return []string{"centos/8/amd64"}, nil
+				return []string{"centos/8/cloud/amd64"}, nil
+			case "centos9":
+				return []string{"centos/9-Stream/cloud/amd64"}, nil
 			default:
 				return nil, errors.NotSupportedf("series %q", series)
 			}

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -249,11 +249,11 @@ func (m *containerManager) getImageSources() ([]ServerSpec, error) {
 	// an empty image metadata URL results in a search of the default sources.
 	if imURL == "" && m.imageStream != "daily" {
 		logger.Debugf("checking default image metadata sources")
-		return []ServerSpec{CloudImagesRemote, CloudImagesDailyRemote}, nil
+		return []ServerSpec{CloudImagesRemote, CloudImagesDailyRemote, CloudImagesLinuxContainersRemote}, nil
 	}
 	// Otherwise only check the daily stream.
 	if imURL == "" {
-		return []ServerSpec{CloudImagesDailyRemote}, nil
+		return []ServerSpec{CloudImagesDailyRemote, CloudImagesLinuxContainersRemote}, nil
 	}
 
 	imURL, err := imagemetadata.ImageMetadataURL(imURL, m.imageStream)
@@ -270,9 +270,9 @@ func (m *containerManager) getImageSources() ([]ServerSpec, error) {
 	// If the daily stream was configured with custom image metadata URL,
 	// only use the Ubuntu daily as a fallback.
 	if m.imageStream == "daily" {
-		return []ServerSpec{remote, CloudImagesDailyRemote}, nil
+		return []ServerSpec{remote, CloudImagesDailyRemote, CloudImagesLinuxContainersRemote}, nil
 	}
-	return []ServerSpec{remote, CloudImagesRemote, CloudImagesDailyRemote}, nil
+	return []ServerSpec{remote, CloudImagesRemote, CloudImagesDailyRemote, CloudImagesLinuxContainersRemote}, nil
 }
 
 // networkDevicesFromConfig uses the input container network configuration to

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -444,7 +444,7 @@ func (s *managerSuite) TestGetImageSourcesDefaultConfig(c *gc.C) {
 
 	sources, err := lxd.GetImageSources(s.manager)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesRemote, lxd.CloudImagesDailyRemote})
+	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesRemote, lxd.CloudImagesDailyRemote, lxd.CloudImagesLinuxContainersRemote})
 }
 
 func (s *managerSuite) TestGetImageSourcesNonStandardStreamDefaultConfig(c *gc.C) {
@@ -456,7 +456,7 @@ func (s *managerSuite) TestGetImageSourcesNonStandardStreamDefaultConfig(c *gc.C
 
 	sources, err := lxd.GetImageSources(s.manager)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesRemote, lxd.CloudImagesDailyRemote})
+	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesRemote, lxd.CloudImagesDailyRemote, lxd.CloudImagesLinuxContainersRemote})
 }
 
 func (s *managerSuite) TestGetImageSourcesDailyOnly(c *gc.C) {
@@ -467,7 +467,7 @@ func (s *managerSuite) TestGetImageSourcesDailyOnly(c *gc.C) {
 	s.makeManagerForConfig(c, cfg)
 	sources, err := lxd.GetImageSources(s.manager)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesDailyRemote})
+	c.Check(sources, gc.DeepEquals, []lxd.ServerSpec{lxd.CloudImagesDailyRemote, lxd.CloudImagesLinuxContainersRemote})
 }
 
 func (s *managerSuite) TestGetImageSourcesImageMetadataURLExpectedHTTPSSources(c *gc.C) {
@@ -488,6 +488,7 @@ func (s *managerSuite) TestGetImageSourcesImageMetadataURLExpectedHTTPSSources(c
 		},
 		lxd.CloudImagesRemote,
 		lxd.CloudImagesDailyRemote,
+		lxd.CloudImagesLinuxContainersRemote,
 	}
 	c.Check(sources, gc.DeepEquals, expectedSources)
 }
@@ -510,6 +511,7 @@ func (s *managerSuite) TestGetImageSourcesImageMetadataURLDailyStream(c *gc.C) {
 			Protocol: lxd.SimpleStreamsProtocol,
 		},
 		lxd.CloudImagesDailyRemote,
+		lxd.CloudImagesLinuxContainersRemote,
 	}
 	c.Check(sources, gc.DeepEquals, expectedSources)
 }

--- a/core/series/supported.go
+++ b/core/series/supported.go
@@ -356,6 +356,7 @@ var ubuntuSeries = map[SeriesName]seriesVersion{
 const (
 	Centos7      SeriesName = "centos7"
 	Centos8      SeriesName = "centos8"
+	Centos9      SeriesName = "centos9"
 	OpenSUSELeap SeriesName = "opensuseleap"
 	Kubernetes   SeriesName = "kubernetes"
 )
@@ -460,6 +461,11 @@ var centosSeries = map[SeriesName]seriesVersion{
 	Centos8: {
 		WorkloadType: OtherWorkloadType,
 		Version:      "centos8",
+		Supported:    true,
+	},
+	Centos9: {
+		WorkloadType: OtherWorkloadType,
+		Version:      "centos9",
 		Supported:    true,
 	},
 }

--- a/core/series/supportedseries_linux_test.go
+++ b/core/series/supportedseries_linux_test.go
@@ -80,7 +80,7 @@ func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
 	series, err := WorkloadSeries(time.Time{}, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
-		"bionic", "centos7", "centos8", "focal", "genericlinux", "jammy", "kubernetes",
+		"bionic", "centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kubernetes",
 		"opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv",
 		"win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019",
 		"win7", "win8", "win81", "xenial"})

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -40,7 +40,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -56,7 +56,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -72,7 +72,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -88,7 +88,7 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 var getOSFromSeriesTests = []struct {

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/juju/mutex/v2 v2.0.0-20220203023141-11eeddb42c6c
 	github.com/juju/names/v4 v4.0.0-20220207005702-9c6532a52823
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os/v2 v2.2.1
+	github.com/juju/os/v2 v2.2.2
 	github.com/juju/packaging/v2 v2.0.0-20220207023655-2ed4de2dc5b4
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20220207021845-4d37a2e6a78f

--- a/go.sum
+++ b/go.sum
@@ -497,6 +497,8 @@ github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b h1:Ow9ltIspVQvDdG
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os/v2 v2.2.1 h1:6FrLTloQMA25q65t7qlDBLdwjLe33i0xLyGhM47yclk=
 github.com/juju/os/v2 v2.2.1/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=
+github.com/juju/os/v2 v2.2.2 h1:h2WYDtC4Ch8OM83kNrca485hq9BYGtNkz6VSzTGlHCI=
+github.com/juju/os/v2 v2.2.2/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=
 github.com/juju/packaging/v2 v2.0.0-20220207023655-2ed4de2dc5b4 h1:9iFFR02tVnFJGrAneWZ/UbpgBiXAINJ+46HRJSRvfEI=
 github.com/juju/packaging/v2 v2.0.0-20220207023655-2ed4de2dc5b4/go.mod h1:JC+FIRTJXGLt9wA+iP3ltkzv+aWVMMojB/R47uIAK0Y=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=

--- a/go.sum
+++ b/go.sum
@@ -495,7 +495,6 @@ github.com/juju/names/v4 v4.0.0-20220207005702-9c6532a52823 h1:Sv0+v4107/GHA0S25
 github.com/juju/names/v4 v4.0.0-20220207005702-9c6532a52823/go.mod h1:xpkrQpHbz1DGY+0Geo32ZnyognGA/2vSB++rpu/Z+Lc=
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b h1:Ow9ltIspVQvDdGAmZRkbL8q62jqOo3MOLtWASCFc//4=
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
-github.com/juju/os/v2 v2.2.1 h1:6FrLTloQMA25q65t7qlDBLdwjLe33i0xLyGhM47yclk=
 github.com/juju/os/v2 v2.2.1/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=
 github.com/juju/os/v2 v2.2.2 h1:h2WYDtC4Ch8OM83kNrca485hq9BYGtNkz6VSzTGlHCI=
 github.com/juju/os/v2 v2.2.2/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=

--- a/packaging/dependency/kvm.go
+++ b/packaging/dependency/kvm.go
@@ -20,7 +20,7 @@ type kvmDependency struct {
 
 // PackageList implements packaging.Dependency.
 func (dep kvmDependency) PackageList(series string) ([]packaging.Package, error) {
-	if series == "centos7" || series == "centos8" || series == "opensuseleap" {
+	if series == "centos7" || series == "centos8" || series == "centos9" || series == "opensuseleap" {
 		return nil, errors.NotSupportedf("installing kvm on series %q", series)
 	}
 

--- a/packaging/dependency/lxd.go
+++ b/packaging/dependency/lxd.go
@@ -29,7 +29,7 @@ func (dep lxdDependency) PackageList(series string) ([]packaging.Package, error)
 	var pkg packaging.Package
 
 	switch series {
-	case "centos7", "centos8", "opensuseleap", "precise":
+	case "centos7", "centos8", "centos9", "opensuseleap", "precise":
 		return nil, errors.NotSupportedf("LXD containers on series %q", series)
 	case "trusty", "xenial", "bionic", blankSeries:
 		pkg.Name = "lxd"

--- a/packaging/dependency/mongo.go
+++ b/packaging/dependency/mongo.go
@@ -38,7 +38,7 @@ func (dep mongoDependency) PackageList(series string) ([]packaging.Package, erro
 	}
 
 	switch series {
-	case "centos7", "centos8", "opensuseleap", "precise":
+	case "centos7", "centos8", "centos9", "opensuseleap", "precise":
 		return nil, errors.NotSupportedf("installing mongo on series %q", series)
 	case "trusty":
 		aptPkgList = append(aptPkgList, "juju-mongodb")

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -94,7 +94,7 @@ func SeriesImage(
 		publisher = centOSPublisher
 		offering = centOSOffering
 		switch series {
-		case "centos7", "centos8":
+		case "centos7", "centos8": // TODO: this doesn't look right. Add support for centos 9 stream.
 			sku = "7.3"
 		default:
 			return nil, errors.NotSupportedf("deploying %s", series)

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -159,6 +159,8 @@ func (env *environ) getImageSources() ([]lxd.ServerSpec, error) {
 		// https://github.com/lxc/lxd/issues/1763
 		remotes = append(remotes, lxd.MakeSimpleStreamsServerSpec(source.Description(), url))
 	}
+	// Required for CentOS images.
+	remotes = append(remotes, lxd.CloudImagesLinuxContainersRemote)
 	return remotes, nil
 }
 

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -513,6 +513,7 @@ func (s *environBrokerSuite) TestImageSourcesDefault(c *gc.C) {
 
 	s.checkSources(c, sources, []string{
 		"https://cloud-images.ubuntu.com/releases/",
+		"https://images.linuxcontainers.org",
 	})
 }
 
@@ -531,6 +532,7 @@ func (s *environBrokerSuite) TestImageMetadataURL(c *gc.C) {
 	s.checkSources(c, sources, []string{
 		"https://my-test.com/images/",
 		"https://cloud-images.ubuntu.com/releases/",
+		"https://images.linuxcontainers.org",
 	})
 }
 
@@ -550,6 +552,7 @@ func (s *environBrokerSuite) TestImageMetadataURLEnsuresHTTPS(c *gc.C) {
 	s.checkSources(c, sources, []string{
 		"https://my-test.com/images/",
 		"https://cloud-images.ubuntu.com/releases/",
+		"https://images.linuxcontainers.org",
 	})
 }
 
@@ -567,6 +570,7 @@ func (s *environBrokerSuite) TestImageStreamReleased(c *gc.C) {
 
 	s.checkSources(c, sources, []string{
 		"https://cloud-images.ubuntu.com/releases/",
+		"https://images.linuxcontainers.org",
 	})
 }
 
@@ -584,6 +588,7 @@ func (s *environBrokerSuite) TestImageStreamDaily(c *gc.C) {
 
 	s.checkSources(c, sources, []string{
 		"https://cloud-images.ubuntu.com/daily/",
+		"https://images.linuxcontainers.org",
 	})
 }
 


### PR DESCRIPTION
Updates the os dependency, adds support for centos 9 stream via lxd, fixing support for centos 7/8 on lxd.

## QA steps

- Build juju for centos, package it to simplestreams.
- Bootstrap lxd.
- `juju deploy erik-lonroth-tiny-bash-centos centos7-test`
- `juju deploy erik-lonroth-tiny-bash-centos centos8-test --series centos8 --force`
- `juju deploy erik-lonroth-tiny-bash-centos centos9-test --series centos9 --force`

## Documentation changes

N/A

## Bug reference

N/A