### PR TITLE
[JUJU-741] Fix typo: rename removeValidator to remoteValidator

### DIFF
--- a/apiserver/facades/client/machinemanager/upgradeseries.go
+++ b/apiserver/facades/client/machinemanager/upgradeseries.go
@@ -284,13 +284,13 @@ func (s upgradeSeriesState) ApplicationsFromMachine(machine Machine) ([]Applicat
 
 type upgradeSeriesValidator struct {
 	localValidator  ApplicationValidator
-	removeValidator ApplicationValidator
+	remoteValidator ApplicationValidator
 }
 
 func makeUpgradeSeriesValidator(client CharmhubClient) upgradeSeriesValidator {
 	return upgradeSeriesValidator{
 		localValidator: stateSeriesValidator{},
-		removeValidator: charmhubSeriesValidator{
+		remoteValidator: charmhubSeriesValidator{
 			client: client,
 		},
 	}
@@ -367,7 +367,7 @@ func (s upgradeSeriesValidator) ValidateApplications(applications []Application,
 		return errors.Trace(err)
 	}
 
-	return s.removeValidator.ValidateApplications(requestApps, series, force)
+	return s.remoteValidator.ValidateApplications(requestApps, series, force)
 }
 
 // ValidateMachine validates a given machine for ensuring it meets a given

--- a/apiserver/facades/client/machinemanager/upgradeseries_test.go
+++ b/apiserver/facades/client/machinemanager/upgradeseries_test.go
@@ -277,12 +277,12 @@ func (s ValidatorSuite) TestValidateApplications(c *gc.C) {
 
 	localValidator := NewMockUpgradeSeriesValidator(ctrl)
 	localValidator.EXPECT().ValidateApplications([]Application{localApp, storeApp}, "focal", false)
-	removeValidator := NewMockUpgradeSeriesValidator(ctrl)
-	removeValidator.EXPECT().ValidateApplications([]Application{charmhubApp}, "focal", false)
+	remoteValidator := NewMockUpgradeSeriesValidator(ctrl)
+	remoteValidator.EXPECT().ValidateApplications([]Application{charmhubApp}, "focal", false)
 
 	validator := upgradeSeriesValidator{
 		localValidator:  localValidator,
-		removeValidator: removeValidator,
+		remoteValidator: remoteValidator,
 	}
 
 	err := validator.ValidateApplications(applications, "focal", false)
@@ -299,12 +299,12 @@ func (s ValidatorSuite) TestValidateApplicationsWithNoOrigin(c *gc.C) {
 
 	localValidator := NewMockUpgradeSeriesValidator(ctrl)
 	localValidator.EXPECT().ValidateApplications(applications, "focal", false)
-	removeValidator := NewMockUpgradeSeriesValidator(ctrl)
-	removeValidator.EXPECT().ValidateApplications([]Application(nil), "focal", false)
+	remoteValidator := NewMockUpgradeSeriesValidator(ctrl)
+	remoteValidator.EXPECT().ValidateApplications([]Application(nil), "focal", false)
 
 	validator := upgradeSeriesValidator{
 		localValidator:  localValidator,
-		removeValidator: removeValidator,
+		remoteValidator: remoteValidator,
 	}
 
 	err := validator.ValidateApplications(applications, "focal", false)


### PR DESCRIPTION
While investigating other work, I noticed this typo, removeValidator.  Renaming to remoteValidator.

## QA steps

This is a mechanical change, with no impact to current behavior.  Unit tests should succeed.