### PR TITLE
[JUJU-740] Update run_charmstore_download checkout_output.

### DIFF
--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -22,7 +22,7 @@ run_charmstore_download() {
 	ensure "test-${name}" "${file}"
 
 	output=$(juju download cs:meshuggah 2>&1 || echo "not found")
-	check_contains "${output}" '"cs:meshuggah" is not a Charm Hub charm'
+	check_contains "${output}" '"cs:meshuggah" is not a Charmhub charm'
 }
 
 run_unknown_download() {
@@ -39,7 +39,7 @@ run_unknown_download() {
 
 test_charmhub_download() {
 	if [ "$(skip 'test_charmhub_download')" ]; then
-		echo "==> TEST SKIPPED: Charm Hub download"
+		echo "==> TEST SKIPPED: Charmhub download"
 		return
 	fi
 


### PR DESCRIPTION
Match the new wording introduced fixing a bug where specifying ch:charm failed to download.  See #13808.

## QA steps

```console
(cd tests ; ./main.sh -v charmhub test_charmhub_download )
```

