### PR TITLE
[JUJU-742] Ensure we fail if a offer is not found for RemoveOfferOperation.

### DIFF
--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -161,7 +161,7 @@ func (s *applicationOffers) RemoveOfferOperation(offerName string, force bool) (
 
 	// Any proxies for applications on the consuming side also need to be removed.
 	offer, err := offerStore.ApplicationOffer(offerName)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	var associatedAppProxies []*DestroyRemoteApplicationOperation


### PR DESCRIPTION
Otherwise we end up panicing later on a nil pointer.

## QA steps

Try to remove an offer that doesn't exist.  It should return a not found, not panic.

```sh
juju remove-offer seven
```

## Bug Reference
https://bugs.launchpad.net/juju/+bug/1964821

