### PR TITLE
[JUJU-743] Fixes a bug for zero credentials in finalise.

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -246,7 +246,12 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 			return cld, err
 		}
 
-		credentials = creds[cld.Name].AuthCredentials[creds[cld.Name].DefaultCredential]
+		cloudCred, exists := creds[cld.Name]
+		if !exists {
+			return cld, nil
+		}
+
+		credentials = cloudCred.AuthCredentials[creds[cld.Name].DefaultCredential]
 	} else {
 		if err := ensureMicroK8sSuitable(p.cmdRunner); err != nil {
 			return cld, errors.Trace(err)


### PR DESCRIPTION
When finalising a k8s clouds we try and find credentials for clouds that
we have auto filled so that we may check the storage of the cluster. For
clouds added by the user we can't do these checks nor do we have to.
This adds a check to see if we can find credentials and if not we don't
perform any finalise actions on k8s clouds.

Side note this code is become horrible to test and needs to be broken
out away from the main provider so that it can be sanity tested.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Please see bug report below for best repo case. This can be done for minikube or microk8s locally.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1964533
