### PR TITLE
[JUJU-744] Do not run leader-settings-changed on dying unit

### DIFF
--- a/worker/uniter/leadership/package_test.go
+++ b/worker/uniter/leadership/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/uniter/leadership/resolver_test.go
+++ b/worker/uniter/leadership/resolver_test.go
@@ -1,0 +1,131 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leadership_test
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/juju/charm/v8/hooks"
+	"github.com/juju/loggo"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/life"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/uniter/hook"
+	"github.com/juju/juju/worker/uniter/leadership"
+	"github.com/juju/juju/worker/uniter/operation"
+	"github.com/juju/juju/worker/uniter/operation/mocks"
+	"github.com/juju/juju/worker/uniter/remotestate"
+	"github.com/juju/juju/worker/uniter/resolver"
+)
+
+var _ = gc.Suite(&resolverSuite{})
+
+type resolverSuite struct {
+	coretesting.BaseSuite
+}
+
+func (s *resolverSuite) TestNextOpNotInstalled(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	f := mocks.NewMockFactory(ctrl)
+	logger := loggo.GetLogger("test")
+
+	r := leadership.NewResolver(logger)
+	_, err := r.NextOp(resolver.LocalState{}, remotestate.Snapshot{}, f)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+}
+
+func (s *resolverSuite) TestNextOpAcceptLeader(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	f := mocks.NewMockFactory(ctrl)
+	op := mocks.NewMockOperation(ctrl)
+	logger := loggo.GetLogger("test")
+
+	f.EXPECT().NewAcceptLeadership().Return(op, nil)
+
+	r := leadership.NewResolver(logger)
+	result, err := r.NextOp(resolver.LocalState{
+		State: operation.State{Installed: true, Kind: operation.Continue},
+	}, remotestate.Snapshot{
+		Leader: true,
+	}, f)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, op)
+}
+
+func (s *resolverSuite) TestNextOpResignLeader(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	f := mocks.NewMockFactory(ctrl)
+	op := mocks.NewMockOperation(ctrl)
+	logger := loggo.GetLogger("test")
+
+	f.EXPECT().NewResignLeadership().Return(op, nil)
+
+	r := leadership.NewResolver(logger)
+	result, err := r.NextOp(resolver.LocalState{
+		State: operation.State{Installed: true, Leader: true, Kind: operation.Continue},
+	}, remotestate.Snapshot{}, f)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, op)
+}
+
+func (s *resolverSuite) TestNextOpResignLeaderDying(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	f := mocks.NewMockFactory(ctrl)
+	op := mocks.NewMockOperation(ctrl)
+	logger := loggo.GetLogger("test")
+
+	f.EXPECT().NewResignLeadership().Return(op, nil)
+
+	r := leadership.NewResolver(logger)
+	result, err := r.NextOp(resolver.LocalState{
+		State: operation.State{Installed: true, Leader: true, Kind: operation.Continue},
+	}, remotestate.Snapshot{
+		Leader: true, Life: life.Dying,
+	}, f)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, op)
+}
+
+func (s *resolverSuite) TestNextOpLeaderSettings(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	f := mocks.NewMockFactory(ctrl)
+	op := mocks.NewMockOperation(ctrl)
+	logger := loggo.GetLogger("test")
+
+	f.EXPECT().NewRunHook(hook.Info{Kind: hooks.LeaderSettingsChanged}).Return(op, nil)
+
+	r := leadership.NewResolver(logger)
+	result, err := r.NextOp(resolver.LocalState{
+		State:                 operation.State{Installed: true, Kind: operation.Continue},
+		LeaderSettingsVersion: 1,
+	}, remotestate.Snapshot{LeaderSettingsVersion: 2}, f)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.Equals, op)
+}
+
+func (s *resolverSuite) TestNextOpNoLeaderSettingsWhenDying(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	f := mocks.NewMockFactory(ctrl)
+	logger := loggo.GetLogger("test")
+
+	r := leadership.NewResolver(logger)
+	_, err := r.NextOp(resolver.LocalState{
+		State:                 operation.State{Installed: true, Kind: operation.Continue},
+		LeaderSettingsVersion: 1,
+	}, remotestate.Snapshot{Life: life.Dying, LeaderSettingsVersion: 2}, f)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+}

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -621,7 +621,7 @@ func (s *UniterSuite) TestUniterDyingReaction(c *gc.C) {
 			"steady state unit dying",
 			quickStart{},
 			unitDying,
-			waitHooks{"leader-settings-changed", "stop"},
+			waitHooks{"stop"},
 			waitUniterDead{},
 		), ut(
 			"steady state unit dead",
@@ -636,7 +636,7 @@ func (s *UniterSuite) TestUniterDyingReaction(c *gc.C) {
 			verifyWaiting{},
 			fixHook{"start"},
 			resolveError{state.ResolvedRetryHooks},
-			waitHooks{"start", "leader-settings-changed", "stop"},
+			waitHooks{"start", "stop"},
 			waitUniterDead{},
 		), ut(
 			"hook error unit dead",
@@ -944,7 +944,7 @@ func (s *UniterSuite) TestUniterUpgradeConflicts(c *gc.C) {
 			verifyWaitingUpgradeError{revision: 1},
 			fixUpgradeError{},
 			resolveError{state.ResolvedNoHooks},
-			waitHooks{"upgrade-charm", "config-changed", "leader-settings-changed", "stop"},
+			waitHooks{"upgrade-charm", "config-changed", "stop"},
 			waitUniterDead{},
 		), ut(
 			"upgrade conflict unit dead",
@@ -1289,7 +1289,7 @@ func (s *UniterSuite) TestUniterSubordinates(c *gc.C) {
 			waitSubordinateExists{"logging/0"},
 			unitDying,
 			waitSubordinateDying{},
-			waitHooks{"leader-settings-changed", "stop"},
+			waitHooks{"stop"},
 			verifyWaiting{},
 			removeSubordinate{},
 			waitUniterDead{},
@@ -1455,7 +1455,6 @@ storage:
 			waitHooks{"wp-content-storage-attached"},
 			waitHooks(startupHooks(false)),
 			unitDying,
-			waitHooks{"leader-settings-changed"},
 			// "stop" hook is not called until storage is detached
 			waitHooks{"wp-content-storage-detaching", "stop"},
 			verifyStorageDetached{},
@@ -1474,7 +1473,7 @@ storage:
 			waitHooks(startupHooks(false)),
 			unitDying,
 			// storage-detaching is not called because it was never attached
-			waitHooks{"leader-settings-changed", "stop"},
+			waitHooks{"stop"},
 			verifyStorageDetached{},
 			waitUniterDead{},
 		), ut(


### PR DESCRIPTION
When a unit is dying, we do not want to run the leader-settings-changed hook.
The logic for the leadership operation resolver needed tweaking.
Also add unit tests which were never done.

## QA steps

See bug for QA.
Essentially deploy 3 units and remove the leader and ensure leader-settings-changed does not run.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1964582
