### PR TITLE
[JUJU-700] Ci ck

### DIFF
--- a/acceptancetests/assess_model_migration.py
+++ b/acceptancetests/assess_model_migration.py
@@ -405,7 +405,7 @@ def assert_logs_appear_in_client_model(client, expected_logs, timeout):
         expected_logs.splitlines(keepends=True),
         current_logs.splitlines(keepends=True),
     )
-    log.error(f'log migration failed, diff of the logs: \n{"".join(diff)}')
+    log.error('log migration failed, diff of the logs: \n%s', "".join(diff))
     raise JujuAssertionError(
         'Logs failed to be migrated after {}'.format(timeout))
 

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -1,7 +1,7 @@
 run_deploy_ck() {
 	echo
 
-	local name model_name file overlay_path storage_path
+	local name model_name file overlay_path kube_home storage_path
 	name="${2}"
 	model_name="${name}"
 	file="${TEST_DIR}/${model_name}.log"
@@ -18,7 +18,9 @@ run_deploy_ck() {
 	wait_for "active" '.applications["kubernetes-master"] | ."application-status".current'
 	wait_for "active" '.applications["kubernetes-worker"] | ."application-status".current'
 
-	juju scp kubernetes-master/0:config ~/.kube/config
+	kube_home="${HOME}/.kube"
+	mkdir -p "${kube_home}"
+	juju scp kubernetes-master/0:config "${kube_home}/config"
 	
 	kubectl cluster-info
 	kubectl get ns

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -11,6 +11,9 @@ test_ck() {
 
 	file="${TEST_DIR}/test-ck.log"
 
+	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
+	fi
 	bootstrap "test-ck" "${file}"
 
 	test_deploy_ck


### PR DESCRIPTION
A few CI tests fixes:
- ensure kube home dir;
- remove f-string in assess_model_migration.py because the vsphere runs on old machine having python < 3.6;
- add --config caas-image-repo for bootstrapping if  OPERATOR_IMAGE_ACCOUNT was provided;