### PR TITLE
[JUJU-208] juju-mongotop outputs a sorted table of problem queries

### DIFF
--- a/scripts/juju-mongotop/Makefile
+++ b/scripts/juju-mongotop/Makefile
@@ -1,0 +1,14 @@
+PROJECT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+GOOS=$(shell go env GOOS)
+GOARCH=$(shell go env GOARCH)
+
+BUILD_DIR ?= $(abspath $(PROJECT_DIR)/../../_build)
+BIN_DIR = ${BUILD_DIR}/${GOOS}_${GOARCH}/bin
+
+build:
+	echo ${BUILD_DIR}
+	@go build -o ${BIN_DIR}/juju-mongotop
+
+install:
+	@go install

--- a/scripts/juju-mongotop/README.md
+++ b/scripts/juju-mongotop/README.md
@@ -1,0 +1,39 @@
+## juju-mongotop
+
+The following parses a series of mongotop files and outputs a sorted list of
+namespaced collections.
+
+Takes a file containing many of the following:
+
+```
+                                            ns    total    read    write    2022-03-15T08:20:12Z
+                                     juju.txns    319ms     0ms    319ms                        
+                        local.replset.minvalid    241ms     0ms    241ms                        
+                                local.oplog.rs    212ms    95ms    117ms                        
+                               juju.unitstates    127ms     0ms    127ms                        
+                                    juju.units    100ms     0ms    100ms                        
+                                 juju.txns.log     79ms     0ms     79ms                        
+                          juju.statuseshistory     61ms     0ms     61ms                        
+logs.logs.d16df13e-f09d-4b03-816a-193c38b7d38c     58ms     0ms     58ms                        
+logs.logs.4f55c931-cba6-4d18-8620-d72c9053949e     29ms     0ms     29ms                        
+logs.logs.480368cd-73e4-4950-85b5-292c7ee64fe5     26ms     0ms     26ms                        
+```
+
+And outputs the following:
+
+```
++----------------+-----------+-------+-----------+
+|       NS       |   TOTAL   | READ  |   WRITE   |
++----------------+-----------+-------+-----------+
+| local.oplog.rs | 1m20.921s | 965ms | 1m19.955s |
+| local.oplog.rs | 1m5.055s  | 9ms   | 1m5.045s  |
+| local.oplog.rs | 1m5.011s  | 23ms  | 1m4.987s  |
+| local.oplog.rs | 1m4.257s  | 15ms  | 1m4.241s  |
+| local.oplog.rs | 1m3.332s  | 9ms   | 1m3.322s  |
+| local.oplog.rs | 1m2.645s  | 74ms  | 1m2.57s   |
+| local.oplog.rs | 1m2.188s  | 12ms  | 1m2.175s  |
+| local.oplog.rs | 1m1.608s  | 21ms  | 1m1.587s  |
+| local.oplog.rs | 1m1.269s  | 38ms  | 1m1.23s   |
+| local.oplog.rs | 1m1.138s  | 10ms  | 1m1.127s  |
++----------------+-----------+-------+-----------+
+```

--- a/scripts/juju-mongotop/go.mod
+++ b/scripts/juju-mongotop/go.mod
@@ -1,0 +1,8 @@
+module github.com/juju/juju/scripts/juju-mongotop
+
+go 1.17
+
+require (
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+)

--- a/scripts/juju-mongotop/go.sum
+++ b/scripts/juju-mongotop/go.sum
@@ -1,0 +1,4 @@
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=

--- a/scripts/juju-mongotop/main.go
+++ b/scripts/juju-mongotop/main.go
@@ -1,0 +1,125 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+func main() {
+	var viewable int
+	var sortOn string
+	flag.IntVar(&viewable, "viewable", 20, "number of viewable in a table")
+	flag.StringVar(&sortOn, "sort-on", "total", "sort either on total, read or write (default is write)")
+	flag.Parse()
+
+	files := flag.Args()
+	if len(files) == 0 {
+		log.Fatal("expected at least on file")
+	}
+
+	if len(files) == 1 {
+		matches, err := filepath.Glob(files[0])
+		if err == nil && len(matches) > 0 {
+			files = matches
+		}
+	}
+
+	var lines []Line
+	for _, file := range files {
+		f, err := os.Open(file)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		buf := bufio.NewReader(f)
+		for {
+			bytes, _, err := buf.ReadLine()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				log.Fatal(err)
+			}
+			if len(bytes) == 0 {
+				continue
+			}
+			if headerRegex.Match(bytes) {
+				continue
+			}
+			matches := lineRegex.FindSubmatch(bytes)
+
+			total, err := time.ParseDuration(string(matches[2]))
+			if err != nil {
+				log.Fatal(err)
+			}
+			read, err := time.ParseDuration(string(matches[3]))
+			if err != nil {
+				log.Fatal(err)
+			}
+			write, err := time.ParseDuration(string(matches[4]))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			lines = append(lines, Line{
+				Namespace: string(matches[1]),
+				Total:     total,
+				Read:      read,
+				Write:     write,
+			})
+		}
+	}
+
+	sort.Slice(lines, func(i, j int) bool {
+		switch sortOn {
+		case "read":
+			return lines[i].Read > lines[j].Read
+		case "write":
+			return lines[i].Write > lines[j].Write
+		default:
+			return lines[i].Total > lines[j].Total
+		}
+	})
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ns", "total", "read", "write"})
+
+	max := viewable
+	if len(lines) < max {
+		max = len(lines)
+	}
+
+	for i := 0; i < max; i++ {
+		line := lines[i]
+		table.Append([]string{
+			line.Namespace,
+			line.Total.String(),
+			line.Read.String(),
+			line.Write.String(),
+		})
+	}
+
+	table.Render()
+}
+
+var (
+	headerRegex = regexp.MustCompile(`^\s+ns\s+total\s+read\s+write\s+[0-9\-\:TZ]+$`)
+	lineRegex   = regexp.MustCompile(`^^\s*([a-zA-Z0-9\.\-]+)\s+([0-9]+ms)\s+([0-9]+ms)\s+([0-9]+ms)\s+$`)
+)
+
+type Line struct {
+	Namespace          string
+	Total, Read, Write time.Duration
+}


### PR DESCRIPTION
The following is a script to help diagnose problem collections. Either
by trying to understand which collections aren't correctly indexed or if
there is an underlying problem with mongo.

The code can work with glob files, so it can span multiple data points.

## QA steps

Download a lot of mongotop output files and run the following:

```sh
$ cd ./scripts/juju-mongotop
$ go run main.go ./mongotop-2022-03-15-0*
+----------------+-----------+-------+-----------+
|       NS       |   TOTAL   | READ  |   WRITE   |
+----------------+-----------+-------+-----------+
| local.oplog.rs | 1m20.921s | 965ms | 1m19.955s |
| local.oplog.rs | 1m5.055s  | 9ms   | 1m5.045s  |
| local.oplog.rs | 1m5.011s  | 23ms  | 1m4.987s  |
| local.oplog.rs | 1m4.257s  | 15ms  | 1m4.241s  |
| local.oplog.rs | 1m3.332s  | 9ms   | 1m3.322s  |
| local.oplog.rs | 1m2.645s  | 74ms  | 1m2.57s   |
| local.oplog.rs | 1m2.188s  | 12ms  | 1m2.175s  |
| local.oplog.rs | 1m1.608s  | 21ms  | 1m1.587s  |
| local.oplog.rs | 1m1.269s  | 38ms  | 1m1.23s   |
| local.oplog.rs | 1m1.138s  | 10ms  | 1m1.127s  |
+----------------+-----------+-------+-----------+
```
