### PR TITLE
[JUJU-752] Ensure the actual charm origin is saved with juju refresh --switch

### DIFF
--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/charmrepo/v6"
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
+
 	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
@@ -428,14 +429,14 @@ func (r *charmHubRefresher) Refresh() (*CharmID, error) {
 		origin.Series = r.deployedSeries
 	}
 
-	curl, _, err := store.AddCharmFromURL(r.charmAdder, newURL, origin, r.force)
+	curl, actualOrigin, err := store.AddCharmFromURL(r.charmAdder, newURL, origin, r.force)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	return &CharmID{
 		URL:    curl,
-		Origin: origin.CoreCharmOrigin(),
+		Origin: actualOrigin.CoreCharmOrigin(),
 	}, nil
 }
 

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -437,9 +437,11 @@ func (s *charmHubCharmRefresherSuite) TestRefresh(c *gc.C) {
 		Source: commoncharm.OriginCharmHub,
 		Series: "bionic",
 	}
+	actualOrigin := origin
+	actualOrigin.ID = "charmid"
 
 	charmAdder := NewMockCharmAdder(ctrl)
-	charmAdder.EXPECT().AddCharm(newCurl, origin, false).Return(origin, nil)
+	charmAdder.EXPECT().AddCharm(newCurl, origin, false).Return(actualOrigin, nil)
 
 	charmResolver := NewMockCharmResolver(ctrl)
 	charmResolver.EXPECT().ResolveCharm(curl, origin, false).Return(newCurl, origin, []string{}, nil)
@@ -455,7 +457,7 @@ func (s *charmHubCharmRefresherSuite) TestRefresh(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmID, gc.DeepEquals, &CharmID{
 		URL:    newCurl,
-		Origin: origin.CoreCharmOrigin(),
+		Origin: actualOrigin.CoreCharmOrigin(),
 	})
 }
 


### PR DESCRIPTION
Usually the initial and actual charm origin will be the same.  However in the case of refresh with --switch, from a local or charmstore charm to a charmhub charm, the ID and hash will be missing.  The ID is essential for when a charm might be renamed in the store.  It allows for juju to have a method to identify a charm independent of the name and refresh to the correct thing when a name changes.

Found while looking at a different refresh --switch bug.

```console
$ juju deploy cs:ubuntu
Located charm "ubuntu" in charm-store, revision 18
Deploying "ubuntu" from charm-store charm "ubuntu", revision 18 in channel stable
$ juju refresh ubuntu --switch ubuntu
Added charm-hub charm "ubuntu", revision 19 in channel stable, to the model

# verify the ID and hash are saved in the juju db.
juju:PRIMARY> db.applications.find().pretty()
{
...
	"name" : "ubuntu",
...
	"charmurl" : "ch:amd64/focal/ubuntu-19",
	"cs-channel" : "stable",
	"charm-origin" : {
		"source" : "charm-hub",
		"type" : "charm",
		"id" : "9NT4sM1gdNLkBPuXbxNu2IusUosDcmR9",
		"hash" : "6bf4a85e0a92b6f4a5f58706c0f288c7657abda776c759da13d0409ed6656cae",
		"revision" : 19,
		"channel" : {
			"risk" : "stable"
		},
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"series" : "focal"
		}
	},
...
}
```

