### PR TITLE
[JUJU-795] Consistently use juju/retry for retries - worker/upgradedatabase

### DIFF
--- a/worker/upgradedatabase/manifold.go
+++ b/worker/upgradedatabase/manifold.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/v3"
+	"github.com/juju/retry"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -87,7 +87,7 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 				Logger:          cfg.Logger,
 				OpenState:       openState,
 				PerformUpgrade:  performUpgrade,
-				RetryStrategy:   utils.AttemptStrategy{Delay: 2 * time.Minute, Min: 5},
+				RetryStrategy:   retry.CallArgs{Clock: cfg.Clock, Delay: 2 * time.Minute, Attempts: 5},
 				Clock:           cfg.Clock,
 			}
 			w, err := NewWorker(workerCfg)

--- a/worker/upgradedatabase/mocks/package.go
+++ b/worker/upgradedatabase/mocks/package.go
@@ -285,3 +285,17 @@ func (mr *MockClockMockRecorder) After(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "After", reflect.TypeOf((*MockClock)(nil).After), arg0)
 }
+
+// Now mocks base method.
+func (m *MockClock) Now() time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Now")
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// Now indicates an expected call of Now.
+func (mr *MockClockMockRecorder) Now() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Now", reflect.TypeOf((*MockClock)(nil).Now))
+}

--- a/worker/upgradedatabase/shim.go
+++ b/worker/upgradedatabase/shim.go
@@ -23,6 +23,9 @@ type Logger interface {
 
 // Clock provides an interface for dealing with clocks.
 type Clock interface {
+	// Now returns the current clock time.
+	Now() time.Time
+
 	// After waits for the duration to elapse and then sends the
 	// current time on the returned channel.
 	After(time.Duration) <-chan time.Time

--- a/worker/upgradedatabase/worker_test.go
+++ b/worker/upgradedatabase/worker_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	"github.com/juju/retry"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
@@ -118,7 +118,7 @@ func (s *workerSuite) TestValidateConfig(c *gc.C) {
 	c.Check(cfg.Validate(), jc.Satisfies, errors.IsNotValid)
 
 	cfg = s.getConfig()
-	cfg.RetryStrategy = utils.AttemptStrategy{}
+	cfg.RetryStrategy = retry.CallArgs{}
 	c.Check(cfg.Validate(), jc.Satisfies, errors.IsNotValid)
 
 	cfg = s.getConfig()
@@ -579,7 +579,7 @@ func (s *workerSuite) getConfig() upgradedatabase.Config {
 		Logger:          s.logger,
 		OpenState:       func() (upgradedatabase.Pool, error) { return s.pool, nil },
 		PerformUpgrade:  func(version.Number, []upgrades.Target, func() upgrades.Context) error { return nil },
-		RetryStrategy:   utils.AttemptStrategy{Delay: time.Millisecond, Min: 3},
+		RetryStrategy:   retry.CallArgs{Clock: clock.WallClock, Delay: time.Millisecond, Attempts: 3},
 		Clock:           clock.WallClock,
 	}
 }


### PR DESCRIPTION
Throughout Juju we have inconsistent ways of performing retries. Standardise all retry code to the repository github.com/juju/retry.

Replace occurrences of this old method of retries from the worker/upgradedatabase directory.

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/worker/upgradedatabase
```

### Also

Verify a db upgrade

#### Bootstrap a controller
```sh
juju bootstrap localhost c
```

#### Perform an upgrade
```sh
juju upgrade-controller --build-agent
```

#### Verify upgrade has completed
```sh
$ juju status -m controller
Model       Controller  Cloud/Region         Version   SLA          Timestamp
controller  c           localhost/localhost  2.9.26.1  unsupported  17:01:21Z

Machine  State    DNS           Inst id        Series  AZ  Message
0        started  10.73.49.189  juju-045f65-0  xenial      Running

```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1611427
