### PR TITLE
[JUJU-762] Fix the premature closing of the model config client during deploy

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -56,6 +56,11 @@ type DeployAPI interface {
 	PlanURL() string
 }
 
+type CharmsAPI interface {
+	store.CharmsAPI
+	BestAPIVersion() int
+}
+
 // The following structs exist purely because Go cannot create a
 // struct with a field named the same as a method name. The DeployAPI
 // needs to both embed a *<package>.Client and provide the
@@ -181,16 +186,19 @@ func newDeployCommand() *DeployCommand {
 		}
 		return store.NewCharmStoreAdaptor(bakeryClient, url), nil
 	}
-	deployCmd.NewModelConfigClient = func(api base.APICallCloser) ModelConfigClient {
+	deployCmd.NewModelConfigAPI = func(api base.APICallCloser) ModelConfigGetter {
 		return modelconfig.NewClient(api)
+	}
+	deployCmd.NewCharmsAPI = func(api base.APICallCloser) CharmsAPI {
+		return apicharms.NewClient(api)
 	}
 	deployCmd.NewDownloadClient = func() (store.DownloadBundleClient, error) {
 		apiRoot, err := deployCmd.newAPIRoot()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-
-		charmHubURL, err := deployCmd.getCharmHubURL(apiRoot)
+		modelConfigClient := deployCmd.NewModelConfigAPI(apiRoot)
+		charmHubURL, err := deployCmd.getCharmHubURL(modelConfigClient)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -343,9 +351,12 @@ type DeployCommand struct {
 	// NewDownloadClient stores a function for getting a charm/bundle.
 	NewDownloadClient func() (store.DownloadBundleClient, error)
 
-	// NewModelConfigClient stores a function which returns a new model config
+	// NewModelConfigAPI stores a function which returns a new model config
 	// client. This is used to get the model config.
-	NewModelConfigClient func(base.APICallCloser) ModelConfigClient
+	NewModelConfigAPI func(base.APICallCloser) ModelConfigGetter
+
+	// NewCharmsAPI stores a function for getting info about charms.
+	NewCharmsAPI func(caller base.APICallCloser) CharmsAPI
 
 	// NewResolver stores a function which returns a charm adaptor.
 	NewResolver func(store.CharmsAPI, store.CharmStoreRepoFunc, store.DownloadBundleClientFunc) deployer.Resolver
@@ -798,7 +809,14 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	defer func() { _ = deployAPI.Close() }()
+	defer func() {
+		if c.apiRoot != nil {
+			_ = c.apiRoot.Close()
+		}
+		if c.controllerAPIRoot != nil {
+			_ = c.controllerAPIRoot.Close()
+		}
+	}()
 
 	if c.ModelConstraints, err = deployAPI.GetModelConstraints(); err != nil {
 		return errors.Trace(err)
@@ -819,7 +837,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		return c.NewDownloadClient()
 	}
 
-	charmAPIClient := apicharms.NewClient(deployAPI)
+	charmAPIClient := c.NewCharmsAPI(c.apiRoot)
 	charmAdapter := c.NewResolver(charmAPIClient, csRepoFn, downloadClientFn)
 
 	// Check whether the controller includes charmhub support. If not,
@@ -916,10 +934,7 @@ func (c *DeployCommand) getDeployerFactory(defaultCharmSchema charm.Schema) (dep
 	return c.NewDeployerFactory(dep), cfg
 }
 
-func (c *DeployCommand) getCharmHubURL(apiRoot base.APICallCloser) (string, error) {
-	modelConfigClient := c.NewModelConfigClient(apiRoot)
-	defer func() { _ = modelConfigClient.Close() }()
-
+func (c *DeployCommand) getCharmHubURL(modelConfigClient ModelConfigGetter) (string, error) {
 	attrs, err := modelConfigClient.ModelGet()
 	if err != nil {
 		return "", errors.Trace(err)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -101,6 +101,12 @@ func (s *DeploySuiteBase) deployCommand() *DeployCommand {
 	deploy.NewDeployAPI = func() (DeployAPI, error) {
 		return s.fakeAPI, nil
 	}
+	deploy.NewModelConfigAPI = func(api base.APICallCloser) ModelConfigGetter {
+		return s.fakeAPI
+	}
+	deploy.NewCharmsAPI = func(api base.APICallCloser) CharmsAPI {
+		return apicharms.NewClient(s.fakeAPI)
+	}
 	return deploy
 }
 
@@ -1055,6 +1061,12 @@ func (s *CAASDeploySuiteBase) runDeploy(c *gc.C, fakeAPI *fakeDeployAPI, args ..
 			return fakeAPI
 		},
 		NewDeployerFactory: fakeAPI.deployerFactoryFunc,
+		NewModelConfigAPI: func(api base.APICallCloser) ModelConfigGetter {
+			return fakeAPI
+		},
+		NewCharmsAPI: func(api base.APICallCloser) CharmsAPI {
+			return apicharms.NewClient(fakeAPI)
+		},
 	}
 	deployCmd.SetClientStore(s.Store)
 	return cmdtesting.RunCommand(c, modelcmd.Wrap(deployCmd), args...)
@@ -2594,6 +2606,12 @@ func newDeployCommandForTest(fakeAPI *fakeDeployAPI) *DeployCommand {
 		deployCmd.NewCharmRepo = fakeAPI.charmRepoFunc
 		deployCmd.NewResolver = func(charmsAPI store.CharmsAPI, charmRepoFn store.CharmStoreRepoFunc, downloadClientFn store.DownloadBundleClientFunc) deployer.Resolver {
 			return fakeAPI
+		}
+		deployCmd.NewModelConfigAPI = func(api base.APICallCloser) ModelConfigGetter {
+			return fakeAPI
+		}
+		deployCmd.NewCharmsAPI = func(api base.APICallCloser) CharmsAPI {
+			return apicharms.NewClient(fakeAPI)
 		}
 	}
 	return deployCmd

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -91,7 +91,7 @@ type OfferAPI interface {
 	GrantOffer(user, access string, offerURLs ...string) error
 }
 
-// ConsumeDetails
+// ConsumeDetails represents methods needed to consume an offer.
 type ConsumeDetails interface {
 	GetConsumeDetails(url string) (apiparams.ConsumeOfferDetails, error)
 	Close() error


### PR DESCRIPTION
When deploying certain bundles, the api connection could get closed early. This is because we now share a single api connection to the controller across all clients, and the model config client was calling Close() when it should not have.

## QA steps

juju bootstrap microk8s
juju deploy magma-orc8r --channel=edge --trust
