### PR TITLE
[JUJU-763] juju status: remove app Store and OS columns, add Exposed

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -132,7 +132,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	units := make(map[string]unitStatus)
 	var w output.Wrapper
 	if fs.Model.Type == caasModelType {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Channel", "Rev", "Exposed", "Address", "Message")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Channel", "Rev", "Address", "Exposed", "Message")
 	} else {
 		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Channel", "Rev", "Exposed", "Message")
 	}
@@ -201,18 +201,16 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			w.Print(scale)
 		}
 
+		w.Print(app.CharmName, app.CharmChannel, app.CharmRev)
+		if fs.Model.Type == caasModelType {
+			w.Print(app.Address)
+		}
+
 		exposed := "no"
 		if app.Exposed {
 			exposed = "yes"
 		}
-
-		w.Print(app.CharmName,
-			app.CharmChannel,
-			app.CharmRev,
-			exposed)
-		if fs.Model.Type == caasModelType {
-			w.Print(app.Address)
-		}
+		w.Print(exposed)
 
 		w.Println(app.StatusInfo.Message)
 		for un, u := range app.Units {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -132,12 +132,12 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	units := make(map[string]unitStatus)
 	var w output.Wrapper
 	if fs.Model.Type == caasModelType {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Channel", "Rev", "OS", "Address", "Message")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Channel", "Rev", "Exposed", "Address", "Message")
 	} else {
-		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Store", "Channel", "Rev", "OS", "Message")
+		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Channel", "Rev", "Exposed", "Message")
 	}
 	tw.SetColumnAlignRight(3)
-	tw.SetColumnAlignRight(7)
+	tw.SetColumnAlignRight(6)
 	for _, appName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
 		app := fs.Applications[appName]
 		// Workload version might be multi-line; we only want the first line for tabular.
@@ -201,11 +201,15 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			w.Print(scale)
 		}
 
+		exposed := "no"
+		if app.Exposed {
+			exposed = "yes"
+		}
+
 		w.Print(app.CharmName,
-			app.CharmOrigin,
 			app.CharmChannel,
 			app.CharmRev,
-			app.OS)
+			exposed)
 		if fs.Model.Type == caasModelType {
 			w.Print(app.Address)
 		}

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5307,8 +5307,8 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version         Status  Scale  Charm  Channel  Rev  Exposed  Address    Message
-foo  user/image:tag            1/2                    0  no       54.32.1.2  
+App  Version         Status  Scale  Charm  Channel  Rev  Address    Exposed  Message
+foo  user/image:tag            1/2                    0  54.32.1.2  no       
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  active    allocating                    
@@ -5378,10 +5378,10 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version                         Status  Scale  Charm  Channel  Rev  Exposed  Address    Message
-bar  res:image:0.5                             0/1                    0  no       54.32.1.3  
-baz  .../image:0.6                             0/1                    0  no       54.32.1.4  
-foo  .../mysql/mysql_image:tag@3...            0/1                    0  no       54.32.1.2  
+App  Version                         Status  Scale  Charm  Channel  Rev  Address    Exposed  Message
+bar  res:image:0.5                             0/1                    0  54.32.1.3  no       
+baz  .../image:0.6                             0/1                    0  54.32.1.4  no       
+foo  .../mysql/mysql_image:tag@3...            0/1                    0  54.32.1.2  no       
 
 Unit   Workload  Agent       Address  Ports  Message
 bar/0  active    allocating                  
@@ -5424,8 +5424,8 @@ func (s *StatusSuite) TestFormatTabularStatusMessage(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Channel  Rev  Exposed  Address    Message
-foo                     0/1                    0  no       54.32.1.2  Error: ImagePullBackOff
+App  Version  Status  Scale  Charm  Channel  Rev  Address    Exposed  Message
+foo                     0/1                    0  54.32.1.2  no       Error: ImagePullBackOff
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  waiting   allocating  10.0.0.1  80/TCP  

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5150,10 +5150,10 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 SAAS         Status   Store  URL
 hosted-riak  unknown  local  me/model.riak
 
-App        Version          Status       Scale  Charm      Store       Channel  Rev  OS      Message
-logging    a bit too lo...  error            2  logging    charmstore             1  ubuntu  somehow lost in all those logs
-mysql      5.7.13           maintenance    1/2  mysql      charmstore             1  ubuntu  installing all the things
-wordpress  4.5.3            active           1  wordpress  charmhub               3  ubuntu  
+App        Version          Status       Scale  Charm      Channel  Rev  Exposed  Message
+logging    a bit too lo...  error            2  logging               1  yes      somehow lost in all those logs
+mysql      5.7.13           maintenance    1/2  mysql                 1  yes      installing all the things
+wordpress  4.5.3            active           1  wordpress             3  yes      
 
 Unit          Workload     Agent  Machine  Public address  Ports  Message
 mysql/0*      maintenance  idle   2        10.0.2.1               installing all the things
@@ -5258,8 +5258,8 @@ func (s *StatusSuite) TestFormatTabularHookActionName(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Message
-foo                       2                           0      
+App  Version  Status  Scale  Charm  Channel  Rev  Exposed  Message
+foo                       2                    0  no       
 
 Unit   Workload     Agent      Machine  Public address  Ports  Message
 foo/0  maintenance  executing                                  (config-changed) doing some work
@@ -5307,8 +5307,8 @@ func (s *StatusSuite) TestFormatTabularCAASModel(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version         Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
-foo  user/image:tag            1/2                           0      54.32.1.2  
+App  Version         Status  Scale  Charm  Channel  Rev  Exposed  Address    Message
+foo  user/image:tag            1/2                    0  no       54.32.1.2  
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  active    allocating                    
@@ -5378,10 +5378,10 @@ func (s *StatusSuite) TestFormatTabularCAASModelTruncatedVersion(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version                         Status  Scale  Charm  Store     Channel  Rev  OS  Address    Message
-bar  res:image:0.5                             0/1         charmhub             0      54.32.1.3  
-baz  .../image:0.6                             0/1                              0      54.32.1.4  
-foo  .../mysql/mysql_image:tag@3...            0/1                              0      54.32.1.2  
+App  Version                         Status  Scale  Charm  Channel  Rev  Exposed  Address    Message
+bar  res:image:0.5                             0/1                    0  no       54.32.1.3  
+baz  .../image:0.6                             0/1                    0  no       54.32.1.4  
+foo  .../mysql/mysql_image:tag@3...            0/1                    0  no       54.32.1.2  
 
 Unit   Workload  Agent       Address  Ports  Message
 bar/0  active    allocating                  
@@ -5424,8 +5424,8 @@ func (s *StatusSuite) TestFormatTabularStatusMessage(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Address    Message
-foo                     0/1                           0      54.32.1.2  Error: ImagePullBackOff
+App  Version  Status  Scale  Charm  Channel  Rev  Exposed  Address    Message
+foo                     0/1                    0  no       54.32.1.2  Error: ImagePullBackOff
 
 Unit   Workload  Agent       Address   Ports   Message
 foo/0  waiting   allocating  10.0.0.1  80/TCP  
@@ -5488,8 +5488,8 @@ func (s *StatusSuite) TestFormatTabularMetering(c *gc.C) {
 Model  Controller  Cloud/Region  Version
                                  
 
-App  Version  Status  Scale  Charm  Store  Channel  Rev  OS  Message
-foo                     0/2                           0      
+App  Version  Status  Scale  Charm  Channel  Rev  Exposed  Message
+foo                     0/2                    0  no       
 
 Unit   Workload  Agent  Machine  Public address  Ports  Message
 foo/0                                                   

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -165,10 +165,10 @@ func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {
 
 	context := s.run(c, "status")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Channel  Rev  OS      Message
-another             waiting    0/1  mysql      charmstore             5  ubuntu  waiting for machine
-mysql               waiting    0/1  mysql      charmstore             1  ubuntu  waiting for machine
-wordpress           waiting    0/1  wordpress  charmstore             3  ubuntu  waiting for machine
+App        Version  Status   Scale  Charm      Channel  Rev  Exposed  Message
+another             waiting    0/1  mysql                 5  no       waiting for machine
+mysql               waiting    0/1  mysql                 1  no       waiting for machine
+wordpress           waiting    0/1  wordpress             3  no       waiting for machine
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 another/0    waiting   allocating  1                               waiting for machine
@@ -182,9 +182,9 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 
 	context = s.run(c, "status", "0")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-App        Version  Status   Scale  Charm      Store       Channel  Rev  OS      Message
-mysql               waiting    0/1  mysql      charmstore             1  ubuntu  waiting for machine
-wordpress           waiting    0/1  wordpress  charmstore             3  ubuntu  waiting for machine
+App        Version  Status   Scale  Charm      Channel  Rev  Exposed  Message
+mysql               waiting    0/1  mysql                 1  no       waiting for machine
+wordpress           waiting    0/1  wordpress             3  no       waiting for machine
 
 Unit         Workload  Agent       Machine  Public address  Ports  Message
 mysql/0      waiting   allocating  0                               waiting for machine


### PR DESCRIPTION
Per discussion, we want to remove the "Store" and "OS" columns from the tabular `juju status` output, and add `Exposed` instead. This PR makes both those changes.

## QA steps

Bootstrap, deploy any charm (eg, `juju deploy mysql`), then check `juju status` output. "Store" and "OS" should be missing, and "Exposed" should be present, saying `no` by default. Running `juju expose mysql` should change that to `yes`, and `juju unexpose mysql` should change it back to `no`.

Example output:

```
Model    Controller           Cloud/Region         Version   SLA          Timestamp
default  localhost-localhost  localhost/localhost  2.9.27.1  unsupported  12:34:38+13:00

App    Version  Status   Scale  Charm  Channel  Rev  Exposed  Message
mysql           waiting    0/1  mysql  stable    58  no       waiting for machine

Unit     Workload  Agent       Machine  Public address  Ports  Message
mysql/0  waiting   allocating  0                               waiting for machine

Machine  State    DNS  Inst id        Series  AZ  Message
0        pending       juju-13dc7c-0  xenial      Running
```

## Documentation changes

TODO: Should we scan around the docs and make these updates to example `juju status` output?
