### PR TITLE
[JUJU-764] Compute base channel for centos

### DIFF
--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -622,24 +622,14 @@ func refreshConfig(charmURL *charm.URL, origin corecharm.Origin) (charmhub.Refre
 		method = MethodID
 	}
 
-	// origin.Platform.Series could be a series or a version. In reality it will
-	// be a series (focal, groovy), but to be on the safe side we should
-	// validate and fallback if it really isn't a version.
-	// The refresh will fail if it's wrong with a revision not found, which
-	// will be fine for now.
-	track, _ := channelTrack(origin.Platform.Series)
-	baseChannel, err := coreseries.VersionSeries(track)
-	if err != nil {
-		baseChannel = origin.Platform.Series
-	}
-
 	var (
 		cfg charmhub.RefreshConfig
+		err error
 
 		base = charmhub.RefreshBase{
 			Architecture: origin.Platform.Architecture,
 			Name:         origin.Platform.OS,
-			Channel:      baseChannel,
+			Channel:      computeBaseChannel(origin.Platform),
 		}
 	)
 	switch method {
@@ -660,6 +650,25 @@ func refreshConfig(charmURL *charm.URL, origin corecharm.Origin) (charmhub.Refre
 		return nil, errors.NotValidf("origin %v", origin)
 	}
 	return cfg, err
+}
+
+// origin.Platform.Series could be a series or a version. In reality it will
+// be a series (focal, groovy), but to be on the safe side we should
+// validate and fallback if it really isn't a version.
+// The refresh will fail if it's wrong with a revision not found, which
+// will be fine for now.
+func computeBaseChannel(platform corecharm.Platform) string {
+	track, _ := channelTrack(platform.Series)
+	switch strings.ToLower(platform.OS) {
+	case "centos":
+		return strings.TrimPrefix(track, "centos")
+	}
+
+	baseChannel, err := coreseries.SeriesVersion(track)
+	if err != nil {
+		baseChannel = platform.Series
+	}
+	return baseChannel
 }
 
 func (c *CharmHubRepository) composeSuggestions(releases []transport.Release, origin corecharm.Origin) []string {

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -1125,7 +1125,7 @@ type channelTrackSuite struct {
 
 var _ = gc.Suite(&channelTrackSuite{})
 
-func (*channelTrackSuite) ChannelTrack(c *gc.C) {
+func (*channelTrackSuite) TestChannelTrack(c *gc.C) {
 	tests := []struct {
 		channel string
 		result  string
@@ -1141,15 +1141,43 @@ func (*channelTrackSuite) ChannelTrack(c *gc.C) {
 	}, {
 		channel: "focal/stable",
 		result:  "focal",
-	}, {
-		channel: "so/many/forward/slashes/here",
-		result:  "so",
 	}}
 
 	for i, test := range tests {
 		c.Logf("test %d - %s", i, test.channel)
 		got, err := channelTrack(test.channel)
 		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(got, gc.Equals, test.result)
+	}
+}
+
+type computeBaseChannelSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&computeBaseChannelSuite{})
+
+func (*computeBaseChannelSuite) TestComputeBaseChannel(c *gc.C) {
+	tests := []struct {
+		platform corecharm.Platform
+		result   string
+	}{{
+		platform: corecharm.Platform{OS: "centos", Series: "centos7"},
+		result:   "7",
+	}, {
+		platform: corecharm.Platform{OS: "centos", Series: "centos8"},
+		result:   "8",
+	}, {
+		platform: corecharm.Platform{OS: "ubuntu", Series: "20.04"},
+		result:   "20.04",
+	}, {
+		platform: corecharm.Platform{OS: "ubuntu", Series: "focal"},
+		result:   "20.04",
+	}}
+
+	for i, test := range tests {
+		c.Logf("test %d - %s", i, test.platform)
+		got := computeBaseChannel(test.platform)
 		c.Assert(got, gc.Equals, test.result)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/juju/mutex/v2 v2.0.0-20220203023141-11eeddb42c6c
 	github.com/juju/names/v4 v4.0.0-20220207005702-9c6532a52823
 	github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b
-	github.com/juju/os/v2 v2.2.2
+	github.com/juju/os/v2 v2.2.3
 	github.com/juju/packaging/v2 v2.0.0-20220207023655-2ed4de2dc5b4
 	github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93
 	github.com/juju/proxy v0.0.0-20220207021845-4d37a2e6a78f

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/juju/names/v4 v4.0.0-20220207005702-9c6532a52823/go.mod h1:xpkrQpHbz1
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b h1:Ow9ltIspVQvDdGAmZRkbL8q62jqOo3MOLtWASCFc//4=
 github.com/juju/naturalsort v0.0.0-20180423034842-5b81707e882b/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os/v2 v2.2.1/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=
-github.com/juju/os/v2 v2.2.2 h1:h2WYDtC4Ch8OM83kNrca485hq9BYGtNkz6VSzTGlHCI=
-github.com/juju/os/v2 v2.2.2/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=
+github.com/juju/os/v2 v2.2.3 h1:5SnGWfzFTXcFwu/sd9qEEf/No3UZxivOjJuWmsHI4N4=
+github.com/juju/os/v2 v2.2.3/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=
 github.com/juju/packaging/v2 v2.0.0-20220207023655-2ed4de2dc5b4 h1:9iFFR02tVnFJGrAneWZ/UbpgBiXAINJ+46HRJSRvfEI=
 github.com/juju/packaging/v2 v2.0.0-20220207023655-2ed4de2dc5b4/go.mod h1:JC+FIRTJXGLt9wA+iP3ltkzv+aWVMMojB/R47uIAK0Y=
 github.com/juju/persistent-cookiejar v0.0.0-20170428161559-d67418f14c93 h1:nlmpG1/Pv5elsi69wXhLkBhefGPE19bOCJ/xVwovl7A=


### PR DESCRIPTION
The following allows centos charm authors to use just the series number
for the series instead of centos7. The code is backwards compatible with
older style series naming. Because we pushed this to the edges for
normalisation, the data stored in the database is correct. It reports it
as centos7 and we don't leak the implementation information outside of
the charmhub repository.

## QA steps

```sh
$ juju bootstrap aws test
$ juju deploy slurmdbd --series=centos7
Located charm "slurmdbd" in charm-hub, revision 18
Deploying "slurmdbd" from charm-hub charm "slurmdbd", revision 18 in channel stable
$ juju status
```

Notice: charm URL and origin are stored correctly for what __juju__ needs. 

```sh
$ juju mongo
juju:PRIMARY> db.applications.find().pretty()
{
        "_id" : "74bb1e61-39ef-4604-865c-7a73db2107db:slurmdbd",
        "name" : "slurmdbd",
        "model-uuid" : "74bb1e61-39ef-4604-865c-7a73db2107db",
        "series" : "centos7",
        "subordinate" : false,
        "charmurl" : "ch:amd64/centos7/slurmdbd-18",
        "cs-channel" : "stable",
        "charm-origin" : {
                "source" : "charm-hub",
                "type" : "charm",
                "id" : "4HKauFz7wnQVmpl0Zb8Z6is7JeDlsWvK",
                "hash" : "7d666cd89c9b2cb566caf9e830ab153f86f1edd15389250b99fcb83b36827a08",
                "revision" : 18,
                "channel" : {
                        "risk" : "stable"
                },
                "platform" : {
                        "architecture" : "amd64",
                        "os" : "centos",
                        "series" : "centos7"
                }
        },
        "charmmodifiedversion" : 0,
        "forcecharm" : false,
        "life" : 0,
        "unitcount" : 1,
        "relationcount" : 1,
        "minunits" : 0,
        "txn-revno" : NumberLong(2),
        "metric-credentials" : BinData(0,""),
        "exposed" : false,
        "scale" : 0,
        "passwordhash" : "",
        "txn-queue" : [
                "62331927a08d2f3e1586cd07_6eba802f"
        ]
}
```