### PR TITLE
[JUJU-768] LXD Container already exists

### DIFF
--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -270,21 +270,14 @@ func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error)
 	op, err := s.CreateContainerFromImage(spec.Image.LXDServer, *spec.Image.Image, req)
 	if err != nil {
 		if IsLXDAlreadyExists(err) {
-			container, _, conErr := s.GetContainer(spec.Name)
-			if conErr != nil {
-				return nil, errors.Trace(conErr)
-			}
-
-			// If we don't match the spec from the container, then we're not
-			// sure what we've got here. Return the original error message.
-			if container.Architecture != spec.Architecture ||
-				container.Ephemeral != ephemeral ||
-				!reflect.DeepEqual(container.Profiles, spec.Profiles) ||
-				!reflect.DeepEqual(container.Devices, spec.Devices) ||
-				!reflect.DeepEqual(container.Config, spec.Config) {
+			container, runningErr := s.waitForContainerToRunningState(spec, ephemeral)
+			if runningErr != nil {
+				// It's actually more helpful to display the original error
+				// message, but we'll also log out what the new error message
+				// was, when attempting to wait for it.
+				logger.Debugf("waiting for container to be running: %v", runningErr)
 				return nil, errors.Trace(err)
 			}
-
 			c := Container{*container}
 			return &c, nil
 		}
@@ -317,6 +310,50 @@ func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error)
 	}
 	c := Container{*container}
 	return &c, nil
+}
+
+func (s *Server) waitForContainerToRunningState(spec ContainerSpec, ephemeral bool) (*api.Container, error) {
+	var container *api.Container
+	err := retry.Call(retry.CallArgs{
+		Func: func() error {
+			var err error
+			container, _, err = s.GetContainer(spec.Name)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			switch container.StatusCode {
+			case api.Running:
+				return nil
+			case api.Started, api.Starting, api.Success:
+				return errors.Errorf("waiting for container to be running")
+			default:
+				return errors.Errorf("waiting for container")
+			}
+		},
+		Attempts:    60,
+		MaxDuration: time.Minute * 5,
+		Delay:       time.Second * 10,
+		Clock:       s.clock,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// Ensure that the container matches the spec we launched it with.
+	if matchesContainerSpec(container, spec, ephemeral) {
+		return container, nil
+	}
+	return nil, errors.Errorf("container %q does not match container spec", spec.Name)
+}
+
+func matchesContainerSpec(container *api.Container, spec ContainerSpec, ephemeral bool) bool {
+	// If we don't match the spec from the container, then we're not
+	// sure what we've got here. Return the original error message.
+	return container.Architecture == spec.Architecture &&
+		container.Ephemeral == ephemeral &&
+		reflect.DeepEqual(container.Profiles, spec.Profiles) &&
+		reflect.DeepEqual(container.Devices, spec.Devices) &&
+		reflect.DeepEqual(container.Config, spec.Config)
 }
 
 // StartContainer starts the extant container identified by the input name.

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -270,7 +270,7 @@ func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error)
 	op, err := s.CreateContainerFromImage(spec.Image.LXDServer, *spec.Image.Image, req)
 	if err != nil {
 		if IsLXDAlreadyExists(err) {
-			container, runningErr := s.waitForContainerToRunningState(spec, ephemeral)
+			container, runningErr := s.waitForRunningContainer(spec, ephemeral)
 			if runningErr != nil {
 				// It's actually more helpful to display the original error
 				// message, but we'll also log out what the new error message
@@ -312,7 +312,7 @@ func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error)
 	return &c, nil
 }
 
-func (s *Server) waitForContainerToRunningState(spec ContainerSpec, ephemeral bool) (*api.Container, error) {
+func (s *Server) waitForRunningContainer(spec ContainerSpec, ephemeral bool) (*api.Container, error) {
 	var container *api.Container
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -335,6 +335,22 @@ func IsLXDNotFound(err error) bool {
 	return strings.ToLower(err.Error()) == "not found"
 }
 
+// IsLXDAlreadyExists checks if an error from the LXD API indicates that a
+// requested entity already exists.
+func IsLXDAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// TODO (stickupkid): This is a hack until we can correctly upstream the
+	// lxd project.
+	if statusErr, ok := errors.Cause(err).(lxdStatusError); ok && statusErr.Status() == http.StatusConflict {
+		return true
+	}
+
+	return strings.ToLower(err.Error()) == "already exists"
+}
+
 // lxdStatusError allows us to check if an error conforms to the lxd status
 // error type.
 type lxdStatusError interface {


### PR DESCRIPTION
If the container already exists when attempting to create a new
container, check that it matches the existing specs (profiles, devices
and config), if it does, return that container. Otherwise, return the
original error message.

## QA steps

See: https://bugs.launchpad.net/juju/+bug/1945813

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --to lxd
$ juju add-unit ubuntu -n 5
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1945813