### PR TITLE
[JUJU-764] Compute base channel for centos

### DIFF
--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -971,15 +971,49 @@ func (selectReleaseByChannelSuite) TestNoReleases(c *gc.C) {
 }
 
 func (selectReleaseByChannelSuite) TestInvalidChannel(c *gc.C) {
-	_, err := selectReleaseByArchAndChannel([]transport.Release{{
+	release, err := selectReleaseByArchAndChannel([]transport.Release{{
 		Base: transport.Base{
-			Name:         "os",
-			Channel:      "series",
-			Architecture: "arch",
+			Name:         "centos",
+			Channel:      "7",
+			Architecture: "amd64",
 		},
 		Channel: "",
-	}}, corecharm.Origin{})
-	c.Assert(err, gc.ErrorMatches, `unknown series for version: "series"`)
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			Series:       "centos7",
+			OS:           "centos",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "amd64",
+		OS:           "centos",
+		Series:       "7",
+	}})
+}
+
+func (selectReleaseByChannelSuite) TestCentosChannel(c *gc.C) {
+	release, err := selectReleaseByArchAndChannel([]transport.Release{{
+		Base: transport.Base{
+			Name:         "centos",
+			Channel:      "centos7",
+			Architecture: "amd64",
+		},
+		Channel: "",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			Series:       "centos7",
+			OS:           "centos",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "amd64",
+		OS:           "centos",
+		Series:       "centos7",
+	}})
 }
 
 func (selectReleaseByChannelSuite) TestSelection(c *gc.C) {
@@ -1077,6 +1111,53 @@ func (selectReleaseByChannelSuite) TestMultipleSelectionMultipleReturned(c *gc.C
 		Architecture: "h",
 		OS:           "g",
 		Series:       "focal",
+	}})
+}
+
+func (selectReleaseByChannelSuite) TestMultipleSelectionMultipleReturnedWithOS(c *gc.C) {
+	release, err := selectReleaseByArchAndChannel([]transport.Release{{
+		Base: transport.Base{
+			Name:         "centos",
+			Channel:      "7",
+			Architecture: "c",
+		},
+		Channel: "1.0/edge",
+	}, {
+		Base: transport.Base{
+			Name:         "osx",
+			Channel:      "10",
+			Architecture: "all",
+		},
+		Channel: "2.0/stable",
+	}, {
+		Base: transport.Base{
+			Name:         "ubuntu",
+			Channel:      "18.04",
+			Architecture: "h",
+		},
+		Channel: "3.0/stable",
+	}, {
+		Base: transport.Base{
+			Name:         "windows",
+			Channel:      "7",
+			Architecture: "h",
+		},
+		Channel: "3.0/stable",
+	}}, corecharm.Origin{
+		Platform: corecharm.Platform{
+			Architecture: "h",
+			OS:           "ubuntu",
+		},
+		Channel: &charm.Channel{
+			Track: "3.0",
+			Risk:  "stable",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(release, gc.DeepEquals, []corecharm.Platform{{
+		Architecture: "h",
+		OS:           "ubuntu",
+		Series:       "bionic",
 	}})
 }
 


### PR DESCRIPTION
The following allows centos charm authors to use just the series number
for the series instead of centos7. The code is backwards compatible with
older style series naming. Because we pushed this to the edges for
normalisation, the data stored in the database is correct. It
reports it as centos7 and we don't leak the implementation information
outside of the charmhub repository.

## QA steps

```sh
$ juju bootstrap aws test
$ juju deploy slurmdbd --series=centos7
Located charm "slurmdbd" in charm-hub, revision 18
Deploying "slurmdbd" from charm-hub charm "slurmdbd", revision 18 in channel stable
$ juju status
```

Notice: charm URL and origin are stored correctly for what __juju__ needs. 

```sh
$ juju mongo
juju:PRIMARY> db.applications.find().pretty()
{
        "_id" : "74bb1e61-39ef-4604-865c-7a73db2107db:slurmdbd",
        "name" : "slurmdbd",
        "model-uuid" : "74bb1e61-39ef-4604-865c-7a73db2107db",
        "series" : "centos7",
        "subordinate" : false,
        "charmurl" : "ch:amd64/centos7/slurmdbd-18",
        "cs-channel" : "stable",
        "charm-origin" : {
                "source" : "charm-hub",
                "type" : "charm",
                "id" : "4HKauFz7wnQVmpl0Zb8Z6is7JeDlsWvK",
                "hash" : "7d666cd89c9b2cb566caf9e830ab153f86f1edd15389250b99fcb83b36827a08",
                "revision" : 18,
                "channel" : {
                        "risk" : "stable"
                },
                "platform" : {
                        "architecture" : "amd64",
                        "os" : "centos",
                        "series" : "centos7"
                }
        },
        "charmmodifiedversion" : 0,
        "forcecharm" : false,
        "life" : 0,
        "unitcount" : 1,
        "relationcount" : 1,
        "minunits" : 0,
        "txn-revno" : NumberLong(2),
        "metric-credentials" : BinData(0,""),
        "exposed" : false,
        "scale" : 0,
        "passwordhash" : "",
        "txn-queue" : [
                "62331927a08d2f3e1586cd07_6eba802f"
        ]
}
```
