### PR TITLE
[JUJU-795] Consistently use juju/retry for retries for tests in worker dir (1)

### DIFF
--- a/testing/constants.go
+++ b/testing/constants.go
@@ -6,6 +6,8 @@ package testing
 import (
 	"time"
 
+	"github.com/juju/clock"
+	"github.com/juju/retry"
 	"github.com/juju/utils/v3"
 )
 
@@ -25,4 +27,10 @@ const LongWait = 10 * time.Second
 var LongAttempt = &utils.AttemptStrategy{
 	Total: LongWait,
 	Delay: ShortWait,
+}
+
+var LongRetryStrategy = retry.CallArgs{
+	Clock:       clock.WallClock,
+	MaxDuration: LongWait,
+	Delay:       ShortWait,
 }

--- a/worker/caasfirewaller/worker_test.go
+++ b/worker/caasfirewaller/worker_test.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/juju/charm/v8"
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
+	"github.com/juju/retry"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v3"
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
@@ -340,23 +341,30 @@ type waitStub interface {
 }
 
 func waitStubCalls(c *gc.C, stub waitStub, names ...string) {
-	for a := coretesting.LongAttempt.Start(); a.Next(); {
+	retryCallArgs := coretesting.LongRetryStrategy
+	retryCallArgs.Func = func() error {
 		if len(stub.Calls()) >= len(names) {
-			break
+			return nil
 		}
+		return errors.Errorf("Not enough calls yet")
 	}
+	err := retry.Call(retryCallArgs)
+	c.Assert(err, jc.ErrorIsNil)
+
 	stub.CheckCallNames(c, names...)
 	stub.ResetCalls()
 }
 
 func (s *WorkerSuite) expectNoLifeGetterCalls(c *gc.C) {
-	strategy := utils.AttemptStrategy{
-		Total: coretesting.ShortWait,
-		Delay: 10 * time.Millisecond,
-	}
-	for a := strategy.Start(); a.Next(); {
-		if len(s.lifeGetter.Calls()) > 0 {
-			c.Fatalf("unexpected lifegetter call")
+	totalDuration := clock.WallClock.After(coretesting.ShortWait)
+	for {
+		select {
+		case <-clock.WallClock.After(10 * time.Millisecond):
+			if len(s.lifeGetter.Calls()) > 0 {
+				c.Fatalf("unexpected lifegetter call")
+			}
+		case <-totalDuration:
+			return
 		}
 	}
 }


### PR DESCRIPTION
Throughout Juju we have inconsistent ways of performing retries. Standardise all retry code to the repository github.com/juju/retry.

Replace occurrences of this old method of retries from a bunch of tests in the worker directory

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
make static-analysis
go test github.com/juju/juju/worker/...
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1611427
