### PR TITLE
[JUJU-720] remove workaround for LTS series with controller charm

### DIFF
--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -218,15 +218,14 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	})
 
 	curl := charm.MustParseURL(controllerCharmURL)
-	channel := corecharm.MakeRiskOnlyChannel("beta")
+	channel := corecharm.MustParseChannel("beta")
 	origin := corecharm.Origin{
 		Source:  corecharm.CharmHub,
-		Type:    "charm",
 		Channel: &channel,
 		Platform: corecharm.Platform{
 			Architecture: "amd64",
 			OS:           "ubuntu",
-			Series:       "NA",
+			Series:       "focal",
 		},
 	}
 
@@ -235,7 +234,7 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	storeCurl.Series = "focal"
 	storeCurl.Architecture = "amd64"
 	storeOrigin := origin
-	storeOrigin.Platform.Series = "focal"
+	storeOrigin.Type = "charm"
 	repo.EXPECT().ResolveWithPreferredChannel(curl, origin, nil).Return(&storeCurl, storeOrigin, nil, nil)
 
 	origin.Platform.Series = "focal"


### PR DESCRIPTION
Use the origin returned by ResolveWithPreferredChannel which suggests an charm origin to use.  Provide the bootstrap series, if it's available it will be used, otherwise the latest LTS will be provided.

The workaround was due to a bug in charmhub api response where "revision-not-found" returned supported bases in the reverse order as "invalid-base", causing an older LTS to be suggested rather than a newer.  It has been fixed.

Currently the controller charm is series independent.  Who knows what the future holds.  The scenario where a deployed charm is forced to a specific series that the charm does not support is essentially the same as the controller charm when bootstrap-series is not an LTS. However controller application charm origin has slight different data than an application charm origin in this case.  The controller charm origin can be seen below, a different application with a forced series will have a charm url and charm origin indicating the forced series, rather than the actual charm series.  This allows for future calls to refresh to use the requested series and perhaps not be forced in the future.

## QA Steps

```console
$ juju bootstrap aws --bootstrap-series impish
# verify juju db 
juju:PRIMARY> db.applications.find().pretty()
{
	"_id" : "baedf129-1b10-418a-8ce1-040e3eebf3c3:controller",
	"name" : "controller",
	"model-uuid" : "baedf129-1b10-418a-8ce1-040e3eebf3c3",
	"series" : "impish",
	"subordinate" : false,
	"charmurl" : "ch:amd64/focal/juju-controller-7",
	"cs-channel" : "",
	"charm-origin" : {
		"source" : "charm-hub",
		...
		"revision" : 7,
		"channel" : {
			"risk" : "beta"
		},
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"series" : "focal"
		}
	},


$ juju bootstrap localhost --bootstrap-series bionic
juju:PRIMARY> db.applications.find().pretty()
{
	"_id" : "5c639ce8-1367-4fe5-8be1-b46f35692542:controller",
	"name" : "controller",
	"model-uuid" : "5c639ce8-1367-4fe5-8be1-b46f35692542",
	"series" : "bionic",
	"subordinate" : false,
	"charmurl" : "ch:amd64/bionic/juju-controller-7",
	"cs-channel" : "",
	"charm-origin" : {
		"source" : "charm-hub",
		...
		"revision" : 7,
		"channel" : {
			"risk" : "beta"
		},
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"series" : "bionic"
		}
	},
```