### PR TITLE
[JUJU-772] fix charm-resources regression

### DIFF
--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -822,8 +822,7 @@ func (a *API) listOneCharmResources(arg params.CharmURLAndOrigin) ([]params.Char
 	if err != nil {
 		return nil, apiservererrors.ServerError(err)
 	}
-
-	repo, err := a.getCharmRepository(corecharm.Source(curl.Schema))
+	repo, err := a.getCharmRepository(corecharm.CharmHub)
 	if err != nil {
 		return nil, apiservererrors.ServerError(err)
 	}

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -822,7 +822,7 @@ func (a *API) listOneCharmResources(arg params.CharmURLAndOrigin) ([]params.Char
 	if err != nil {
 		return nil, apiservererrors.ServerError(err)
 	}
-	repo, err := a.getCharmRepository(corecharm.CharmHub)
+	repo, err := a.getCharmRepository(corecharm.Source(charmOrigin.Source))
 	if err != nil {
 		return nil, apiservererrors.ServerError(err)
 	}

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -90,9 +90,9 @@ func (f *CharmRepoFactory) GetCharmRepository(src corecharm.Source) (corecharm.R
 		var chCfg charmhub.Config
 		chURL, ok := cfg.CharmHubURL()
 		if ok {
-			chCfg, err = charmhub.CharmHubConfigFromURL(chURL, f.logger, options...)
+			chCfg, err = charmhub.CharmHubConfigFromURL(chURL, f.logger.Child("charmhubrepo"), options...)
 		} else {
-			chCfg, err = charmhub.CharmHubConfig(f.logger, options...)
+			chCfg, err = charmhub.CharmHubConfig(f.logger.Child("charmhubrepo"), options...)
 		}
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/charmhub"
 	corecharm "github.com/juju/juju/core/charm"
 	charmrepo "github.com/juju/juju/core/charm/repository"
+	corelogger "github.com/juju/juju/core/logger"
 )
 
 // CharmRepoFactoryConfig encapsulates the information required for creating a
@@ -103,7 +104,7 @@ func (f *CharmRepoFactory) GetCharmRepository(src corecharm.Source) (corecharm.R
 		}
 
 		repo = charmrepo.NewCharmHubRepository(
-			f.logger.Child("charmhubrepo"),
+			f.logger.ChildWithLabels("charmhubrepo", corelogger.CHARMHUB),
 			chClient,
 		)
 	default:

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -323,6 +323,12 @@ func (c *CharmHubRepository) ListResources(charmURL *charm.URL, origin corecharm
 		return nil, errors.Trace(err)
 	}
 
+	// If a revision is included with an install action, no resources will be
+	// returned. Resources are dependent on a channel, a specific revision can
+	// be in multiple channels.  refreshOne gives priority to a revision if
+	// specified.  ListResources is used by the "charm-resources" cli cmd,
+	// therefore specific charm revisions are less important.
+	resOrigin.Revision = nil
 	resp, err := c.refreshOne(resCurl, resOrigin, macaroons)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
One was a mismatch between "ch" and "charm-hub".  While conceptually the same, a string match will fail.  The other was using an Install action with a revision included, it will not return the resources as they are synced to a channel.  Must have been broken when deploy by revision implementation changed refreshConfig.  

## QA steps


```console
$  juju charm-resources etcd
Resource  Revision
core      0
etcd      3
snapshot  0

$ juju charm-resources cs:etcd
Resource  Revision
core      0
etcd      3
snapshot  0
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1965305
