### PR TITLE
Stop reporting pebble startup errors.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.9.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20220220221114-a922aaf20c76
+	github.com/canonical/pebble v0.0.0-20220316083406-c50b1edca41f
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.7.1+incompatible
@@ -48,7 +48,7 @@ require (
 	github.com/juju/cmd/v3 v3.0.0-20220203030511-039f3566372a
 	github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a
 	github.com/juju/description/v3 v3.0.0-20220207013250-e60bc7b1c242
-	github.com/juju/errors v0.0.0-20220203013757-bd733f3c86b9
+	github.com/juju/errors v0.0.0-20220316043928-e10eb17a9eeb
 	github.com/juju/featureflag v0.0.0-20220207005600-a9676d92ad24
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d
 	github.com/juju/gojsonschema v0.0.0-20150312170016-e1ad140384f2

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20220220221114-a922aaf20c76 h1:N1s6Fhblu52wgT8+FU5DUxAXW+jQlW+Cl4TJieITAws=
-github.com/canonical/pebble v0.0.0-20220220221114-a922aaf20c76/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
+github.com/canonical/pebble v0.0.0-20220316083406-c50b1edca41f h1:V+86qthBBFMClDqgvGbTZm6+mOf6/j7ttfg7BaqlIK0=
+github.com/canonical/pebble v0.0.0-20220316083406-c50b1edca41f/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -452,8 +452,9 @@ github.com/juju/description/v3 v3.0.0-20220207013250-e60bc7b1c242/go.mod h1:bT3J
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=
-github.com/juju/errors v0.0.0-20220203013757-bd733f3c86b9 h1:EJHbsNpQyupmMeWTq7inn+5L/WZ7JfzCVPJ+DP9McCQ=
 github.com/juju/errors v0.0.0-20220203013757-bd733f3c86b9/go.mod h1:TRm7EVGA3mQOqSVcBySRY7a9Y1/gyVhh/WTCnc5sD4U=
+github.com/juju/errors v0.0.0-20220316043928-e10eb17a9eeb h1:4e8FtfnfajZwu+aKGeDH1I1IRs/NsDlbvBPuu61gZNE=
+github.com/juju/errors v0.0.0-20220316043928-e10eb17a9eeb/go.mod h1:jMGj9DWF/qbo91ODcfJq6z/RYc3FX3taCBZMCcpI4Ls=
 github.com/juju/featureflag v0.0.0-20220207005600-a9676d92ad24 h1:MmwFTLD6youIUvG5FWjx3pAtEDdQO+PaxGcL6PGooSE=
 github.com/juju/featureflag v0.0.0-20220207005600-a9676d92ad24/go.mod h1:g6bvykW7D6L/R2iZgiWatlCz9RadldeybAte71GgFg8=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d h1:c93kUJDtVAXFEhsCh5jSxyOJmFHuzcihnslQiX8Urwo=

--- a/worker/uniter/pebblepoller.go
+++ b/worker/uniter/pebblepoller.go
@@ -95,7 +95,10 @@ func (p *pebblePoller) run(containerName string) error {
 		case <-timer.Chan():
 			timer.Reset(pebblePollInterval)
 			err := p.poll(containerName)
-			if err != nil && err != tomb.ErrDying {
+			var socketNotFound *client.SocketNotFoundError
+			if errors.As(err, &socketNotFound) {
+				p.logger.Debugf("pebble still starting up on container %q: %v", containerName, socketNotFound)
+			} else if err != nil && err != tomb.ErrDying {
 				p.logger.Errorf("pebble poll failed for container %q: %v", containerName, err)
 			}
 		}


### PR DESCRIPTION
- When charms are being deployed and the process is slow the uniter
  starts a pebble poller that looks for the pebble unix sockets then
  proceeds to poll pebbles status. When this socket is not on disk as of
  yet due to the docker image still being created it creates a lot of
  false errors in the Juju output. We stop reporting these errors now
  and instead send this to the debug log where it will provide more
  value.

- Upgrade the pebble version in use to support the new error type used.

- Updated juju/errors for As support.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run:

```sh
juju deploy magma-orc8r --channel=edge --trust
```

Watch the `juju debug-log` for pebble startup errors or lack there of.

## Documentation changes

N/A

## Bug reference

N/A
