### PR TITLE
[JUJU-208] Hide debug.Stack calls behind a feature flag

### DIFF
--- a/state/querytracker.go
+++ b/state/querytracker.go
@@ -105,7 +105,7 @@ func (q *queryTracker) TrackRead(collectionName string, query interface{}) {
 			Type:           "read",
 			CollectionName: collectionName,
 			Query:          query,
-			Traceback:      string(debug.Stack()),
+			Traceback:      traceback,
 		})
 	}
 }

--- a/state/watcher/hubwatcher_test.go
+++ b/state/watcher/hubwatcher_test.go
@@ -4,10 +4,12 @@
 package watcher_test
 
 import (
+	"os"
 	"time"
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/pubsub/v2"
 	jc "github.com/juju/testing/checkers"
@@ -15,6 +17,8 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/feature"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/testing"
 )
@@ -33,6 +37,10 @@ var _ = gc.Suite(&HubWatcherSuite{})
 
 func (s *HubWatcherSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
+
+	err := os.Setenv(osenv.JujuFeatureFlagEnvKey, feature.DeveloperMode)
+	c.Assert(err, jc.ErrorIsNil)
+	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 
 	logger := loggo.GetLogger("HubWatcherSuite")
 	logger.SetLogLevel(loggo.TRACE)


### PR DESCRIPTION
We really don't want to be calling debug.Stack for every call to
everything. It might be negligible from a small model point of view, but
for HUGE models we REALLY don't want to be doing this busywork.

For every call, it makes a [minimum 1024 byte slice,](https://cs.opensource.google/go/go/+/refs/tags/go1.18:src/runtime/debug/stack.go;l=24) if it overflows it
will grow larger and larger. As juju is doing this all the time, this
will add up.

I've not removed this, just hidden it behind either a feature flag or a
trace enable call.

I suspect we should get a speed up here.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju enable-ha
$ juju deploy ubuntu -n 3
$ juju ssh -m controller 0
$ systemctl restart jujud-machine-0
```
Ensure that we come back up correcty.
