### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@3eb79ef290553f0de096b3948a6770c15171fb15 # v1
         with:
           accept-existing-contributors: true

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
 
     - name: Find required go version
       id: go-version
@@ -44,7 +44,7 @@ jobs:
         echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3
       with:
         go-version: ${{ steps.go-version.outputs.version }}
       id: go
@@ -56,13 +56,13 @@ jobs:
 
     - name: "Remove Mongo Dependencies: windows-latest"
       if: (matrix.os == 'windows-latest')
-      uses: crazy-max/ghaction-chocolatey@v1
+      uses: crazy-max/ghaction-chocolatey@87d06bbbd2cfb1835f1820042d356aef4875fb5f # v1
       with:
         args: uninstall mongodb mongodb.install -y --all-versions
 
     - name: "Install Mongo Dependencies: windows-latest"
       if: (matrix.os == 'windows-latest')
-      uses: crazy-max/ghaction-chocolatey@v1
+      uses: crazy-max/ghaction-chocolatey@87d06bbbd2cfb1835f1820042d356aef4875fb5f # v1
       with:
         args: install mongodb.install --version=4.4.11 --allow-downgrade
 

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
 
     - name: Find required go version
       id: go-version

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checking out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
 
     - name: Find required go version
       id: go-version
@@ -29,7 +29,7 @@ jobs:
         echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3
       with:
         go-version: ${{ steps.go-version.outputs.version }}
       id: go
@@ -40,7 +40,7 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-    - uses: balchua/microk8s-actions@v0.2.2
+    - uses: balchua/microk8s-actions@98f481ca6bad1cdca5185008b9572a3102d46af3 # v0.2.2
       with:
         channel: '${{ matrix.microk8s }}'
         # enable now to give microk8s more time to settle down.
@@ -125,7 +125,7 @@ jobs:
       if: ${{ failure() }}
 
     - name: Upload debug log
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: juju-debug-actions
         path: juju-debug.log
@@ -153,7 +153,7 @@ jobs:
       if: ${{ failure() }}
 
     - name: Upload inspect tarball
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: inspection-report-actions
         path: ./inspection-report-${{ strategy.job-index }}.tar.gz
@@ -169,7 +169,7 @@ jobs:
       if: ${{ failure() }}
 
     - name: Upload kubectl describe
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: kubectl-describe-actions
         path: describe/*.describe
@@ -187,7 +187,7 @@ jobs:
       if: ${{ failure() }}
 
     - name: Upload kubeflow pod logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: kubectl-stdout-actions
         path: stdout/*.log

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checking out repo
-      uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
 
     - name: Find required go version
       id: go-version

--- a/.github/workflows/update-brew-formulae.yml
+++ b/.github/workflows/update-brew-formulae.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Homebrew formulae
-        uses: dawidd6/action-homebrew-bump-formula@master
+        uses: dawidd6/action-homebrew-bump-formula@b1f4659559bcc32ab942f0b0f851e3c856d05253 # master
         with:
           token: "${{ secrets.TOKEN }}"
           formula: juju


### PR DESCRIPTION
## Pin actions to a full length commit SHA

- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>