### PR TITLE
Fix test on centos9

### DIFF
--- a/version/current_test.go
+++ b/version/current_test.go
@@ -39,7 +39,7 @@ func (*CurrentSuite) TestCurrentSeries(c *gc.C) {
 			if s != "n/a" {
 				// There is no lsb_release command on CentOS.
 				if currentOS == os.CentOS {
-					c.Check(s, gc.Matches, `centos7|centos8`)
+					c.Check(s, gc.Matches, `centos\d+`)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes current series silly test for centos9.

## QA steps

Run tests on centos9 stream.

## Documentation changes

N/A

## Bug reference

N/A