### PR TITLE
[JUJU-793] Add support for delegated subscriptions to Azure provider

### DIFF
--- a/provider/azure/config_test.go
+++ b/provider/azure/config_test.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	fakeApplicationId     = "60a04dc9-1857-425f-8076-5ba81ca53d66"
-	fakeSubscriptionId    = "22222222-2222-2222-2222-222222222222"
-	fakeStorageAccountKey = "quay"
+	fakeApplicationId         = "60a04dc9-1857-425f-8076-5ba81ca53d66"
+	fakeSubscriptionId        = "22222222-2222-2222-2222-222222222222"
+	fakeManagedSubscriptionId = "33333333-3333-3333-3333-333333333333"
+	fakeStorageAccountKey     = "quay"
 )
 
 type configSuite struct {

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -187,7 +187,10 @@ func (env *azureEnviron) SetCloudSpec(_ stdcontext.Context, cloud environsclouds
 
 func (env *azureEnviron) initEnviron() error {
 	credAttrs := env.cloud.Credential.Attributes()
-	env.subscriptionId = credAttrs[credAttrSubscriptionId]
+	env.subscriptionId = credAttrs[credAttrManagedSubscriptionId]
+	if env.subscriptionId == "" {
+		env.subscriptionId = credAttrs[credAttrSubscriptionId]
+	}
 	env.authorizer = &cloudSpecAuth{
 		cloud:  env.cloud,
 		sender: env.provider.config.Sender,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1978,7 +1978,7 @@ func (s *environSuite) TestStopInstancesNoSecurityGroup(c *gc.C) {
 	nic0IPConfiguration := makeIPConfiguration("192.168.0.4")
 	nic0IPConfiguration.Primary = to.BoolPtr(true)
 	internalSubnetId := path.Join(
-		"/subscriptions", fakeSubscriptionId,
+		"/subscriptions", fakeManagedSubscriptionId,
 		"resourceGroups/juju-testmodel-model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		"providers/Microsoft.Network/virtualNetworks/juju-internal-network/subnets/juju-internal-subnet",
 	)

--- a/provider/azure/environprovider_test.go
+++ b/provider/azure/environprovider_test.go
@@ -55,9 +55,10 @@ func fakeServicePrincipalCredential() *cloud.Credential {
 	cred := cloud.NewCredential(
 		"service-principal-secret",
 		map[string]string{
-			"application-id":       fakeApplicationId,
-			"subscription-id":      fakeSubscriptionId,
-			"application-password": "opensezme",
+			"application-id":          fakeApplicationId,
+			"subscription-id":         fakeSubscriptionId,
+			"managed-subscription-id": fakeManagedSubscriptionId,
+			"application-password":    "opensezme",
 		},
 	)
 	return &cred

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -659,13 +659,13 @@ func (s *instanceSuite) TestControllerInstances(c *gc.C) {
 }
 
 var internalSecurityGroupPath = path.Join(
-	"/subscriptions", fakeSubscriptionId,
+	"/subscriptions", fakeManagedSubscriptionId,
 	"resourceGroups", "juju-testmodel-"+testing.ModelTag.Id()[:8],
 	"providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg",
 )
 
 var internalSubnetPath = path.Join(
-	"/subscriptions", fakeSubscriptionId,
+	"/subscriptions", fakeManagedSubscriptionId,
 	"resourceGroups/juju-testmodel-model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
 	"providers/Microsoft.Network/virtualNetworks/juju-internal-network/subnets/juju-internal-subnet",
 )

--- a/provider/azure/instancetype_test.go
+++ b/provider/azure/instancetype_test.go
@@ -69,3 +69,23 @@ func (s *InstanceTypeSuite) TestStandardVersioned(c *gc.C) {
 		RootDisk: 1000 * 1000,
 	})
 }
+
+func (s *InstanceTypeSuite) TestStandardPromo(c *gc.C) {
+	vm := compute.VirtualMachineSize{
+		Name:           to.StringPtr("Standard_A2_v4_Promo"),
+		MemoryInMB:     to.Int32Ptr(100),
+		NumberOfCores:  to.Int32Ptr(2),
+		OsDiskSizeInMB: to.Int32Ptr(1024 * 1024),
+	}
+	inst := newInstanceType(vm)
+	c.Assert(inst, jc.DeepEquals, instances.InstanceType{
+		Id:       "Standard_A2_v4_Promo",
+		Name:     "Standard_A2_v4_Promo",
+		Arches:   []string{"amd64"},
+		VirtType: to.StringPtr("Hyper-V"),
+		CpuCores: 2,
+		Mem:      100,
+		Cost:     39400, // len(costs),
+		RootDisk: 1000 * 1000,
+	})
+}

--- a/provider/azure/internal/azureauth/discovery.go
+++ b/provider/azure/internal/azureauth/discovery.go
@@ -19,7 +19,7 @@ const authenticateHeaderKey = "WWW-Authenticate"
 
 var authorizationUriRegexp = regexp.MustCompile(`authorization_uri="([^"]*)"`)
 
-// DiscoverAuthorizationID returns the OAuth authorization URI for the given
+// DiscoverAuthorizationURI returns the OAuth authorization URI for the given
 // subscription ID. This can be used to determine the AD tenant ID.
 func DiscoverAuthorizationURI(sdkCtx context.Context, client subscriptions.Client, subscriptionID string) (*url.URL, error) {
 	// We make an unauthenticated request to the Azure API, which

--- a/provider/azure/storage_test.go
+++ b/provider/azure/storage_test.go
@@ -885,7 +885,7 @@ func (s *storageSuite) testAttachVolumes(c *gc.C, legacy bool) {
 			return nil
 		}
 		return &compute.ManagedDiskParameters{
-			ID: to.StringPtr("/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/juju-testmodel-deadbeef/providers/Microsoft.Compute/disks/" + volumeName),
+			ID: to.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/juju-testmodel-deadbeef/providers/Microsoft.Compute/disks/%s", fakeManagedSubscriptionId, volumeName)),
 		}
 	}
 


### PR DESCRIPTION
There's 2 key changes here to support delegated subscriptions for Azure.

1. use the homeTenantId from the account info
2. get the API access token based on tenant, not subscription

When setting up an Azure credential for Juju, we query the account info

```
az account list
  {
    "cloudName": "AzureCloud",
    "homeTenantId": "xxxxxxx",
    "id": "yyyyyyyyyyyyy",
    "isDefault": true,
    "managedByTenants": [],
    "name": "Juju",
    "state": "Enabled",
    "tenantId": "zzzzzzzz",
    "user": {
      "name": "foo@canonical.com",
      "type": "user"
    }
  }
```

We now use the `homeTenantId` instead of tenant id in the next steps.

When getting the API access token, we were filtering on subscription, we now use the home tenant
```
az account get-access-token --tenant xxxxxxx
{
  "accessToken": "zzzzzzzz",
  "expiresOn": "2022-03-23 16:34:34.000000",
  "tenant": "xxxxxxx",
  "tokenType": "Bearer"
}
```
instead of
```
az account get-access-token --subscription yyyyyyyy
{
  "accessToken": "zzzzzzzz",
  "expiresOn": "2022-03-23 16:34:34.000000",
  "subscription": "yyyyyyyy",
  "tokenType": "Bearer"
}
```

## QA steps

I tested bootstrapping using a normal subscription.
I also followed the steps in the doc attached to the bug report.
Also verified by field engineer who reported the issue.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1965454
