### PR TITLE
[JUJU-800] correct and update juju bootstrap --help results

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -185,7 +185,8 @@ Examples:
     juju bootstrap --config controller-service-type=external --config controller-service-name=controller.juju.is
 
 See also:
-    add-credentials
+    add-credential
+    autoload-credentials
     add-model
     controller-config
     model-config


### PR DESCRIPTION
The See also section misspelled a command, which has now been corrected. While I was there, added autoload-credentials.

## QA steps

```console
$ juju help bootstrap
Usage: juju bootstrap [options] [<cloud name>[/region] [<controller name>]]
...
See also:
    add-credential
    autoload-credentials
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1966080