### PR TITLE
[JUJU-806] Remove Uniter() from api.Connection interface

### DIFF
--- a/api/agent/uniter/uniter.go
+++ b/api/agent/uniter/uniter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	apiwatcher "github.com/juju/juju/api/watcher"
@@ -66,6 +67,17 @@ func NewState(
 		ErrIfNotVersionFn(2, state.BestAPIVersion()),
 	)
 	return state
+}
+
+// NewFromConnection returns a version of the Connection that provides
+// functionality required by the uniter worker if possible else a non-nil error.
+func NewFromConnection(c api.Connection) (*State, error) {
+	authTag := c.AuthTag()
+	unitTag, ok := authTag.(names.UnitTag)
+	if !ok {
+		return nil, errors.Errorf("expected UnitTag, got %T %v", authTag, authTag)
+	}
+	return NewState(c, unitTag), nil
 }
 
 // BestAPIVersion returns the API version that we were able to

--- a/api/interface.go
+++ b/api/interface.go
@@ -43,9 +43,10 @@ type Info struct {
 	// ControllerUUID is the UUID of the controller.
 	ControllerUUID string
 
-	// SNIHostName optionally holds the host name to use for server name
-	// indication (SNI) when connecting to the addresses in Addrs above. If
-	// CACert is non-empty, this field is ignored.
+	// SNIHostName optionally holds the host name to use for
+	// server name indication (SNI) when connecting
+	// to the addresses in Addrs above. If CACert is non-empty,
+	// this field is ignored.
 	SNIHostName string
 
 	// CACert holds the CA certificate that will be used

--- a/api/interface.go
+++ b/api/interface.go
@@ -43,10 +43,9 @@ type Info struct {
 	// ControllerUUID is the UUID of the controller.
 	ControllerUUID string
 
-	// SNIHostName optionally holds the host name to use for
-	// server name indication (SNI) when connecting
-	// to the addresses in Addrs above. If CACert is non-empty,
-	// this field is ignored.
+	// SNIHostName optionally holds the host name to use for server name
+	// indication (SNI) when connecting to the addresses in Addrs above. If
+	// CACert is non-empty, this field is ignored.
 	SNIHostName string
 
 	// CACert holds the CA certificate that will be used

--- a/api/interface.go
+++ b/api/interface.go
@@ -332,9 +332,19 @@ type Connection interface {
 	// will be easy to remove, but until we're using them via manifolds it's
 	// prohibitively ugly to do so.
 	Client() *Client
-	Uniter() (*uniter.State, error)
 	Upgrader() *upgrader.State
 	Reboot() (reboot.State, error)
 	InstancePoller() *instancepoller.API
 	UnitAssigner() unitassigner.API
+}
+
+// ConnectionUniter returns a version of the Connection that provides
+// functionality required by the uniter worker if possible else a non-nil error.
+func ConnectionUniter(c Connection) (*uniter.State, error) {
+	authTag := c.AuthTag()
+	unitTag, ok := authTag.(names.UnitTag)
+	if !ok {
+		return nil, errors.Errorf("expected UnitTag, got %T %v", authTag, authTag)
+	}
+	return uniter.NewState(c, unitTag), nil
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/juju/juju/api/agent/reboot"
 	"github.com/juju/juju/api/agent/unitassigner"
-	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/api/agent/upgrader"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller/instancepoller"
@@ -336,15 +335,4 @@ type Connection interface {
 	Reboot() (reboot.State, error)
 	InstancePoller() *instancepoller.API
 	UnitAssigner() unitassigner.API
-}
-
-// ConnectionUniter returns a version of the Connection that provides
-// functionality required by the uniter worker if possible else a non-nil error.
-func ConnectionUniter(c Connection) (*uniter.State, error) {
-	authTag := c.AuthTag()
-	unitTag, ok := authTag.(names.UnitTag)
-	if !ok {
-		return nil, errors.Errorf("expected UnitTag, got %T %v", authTag, authTag)
-	}
-	return uniter.NewState(c, unitTag), nil
 }

--- a/api/state.go
+++ b/api/state.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/api/agent/keyupdater"
 	"github.com/juju/juju/api/agent/reboot"
 	"github.com/juju/juju/api/agent/unitassigner"
-	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/api/agent/upgrader"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller/instancepoller"
@@ -318,16 +317,6 @@ func (st *state) Client() *Client {
 // required by the unitassigner worker.
 func (st *state) UnitAssigner() unitassigner.API {
 	return unitassigner.New(st)
-}
-
-// Uniter returns a version of the state that provides functionality
-// required by the uniter worker.
-func (st *state) Uniter() (*uniter.State, error) {
-	unitTag, ok := st.authTag.(names.UnitTag)
-	if !ok {
-		return nil, errors.Errorf("expected UnitTag, got %T %v", st.authTag, st.authTag)
-	}
-	return uniter.NewState(st, unitTag), nil
 }
 
 // Upgrader returns access to the Upgrader API

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -228,7 +228,7 @@ func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.State, *state.CAAS
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: app.Tag(),
 	}
-	u, err := api.ConnectionUniter(apiState)
+	u, err := apiuniter.NewFromConnection(apiState)
 	c.Assert(err, jc.ErrorIsNil)
 	return u, cm, app, unit
 }
@@ -3329,7 +3329,7 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	st := s.OpenAPIAs(c, unit.Tag(), password)
-	uniter, err := api.ConnectionUniter(st)
+	uniter, err := apiuniter.NewFromConnection(st)
 	c.Assert(err, jc.ErrorIsNil)
 
 	attachments, err := uniter.UnitStorageAttachments(unit.UnitTag())

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -228,7 +228,7 @@ func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.State, *state.CAAS
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: app.Tag(),
 	}
-	u, err := apiState.Uniter()
+	u, err := api.ConnectionUniter(apiState)
 	c.Assert(err, jc.ErrorIsNil)
 	return u, cm, app, unit
 }
@@ -3329,7 +3329,7 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	st := s.OpenAPIAs(c, unit.Tag(), password)
-	uniter, err := st.Uniter()
+	uniter, err := api.ConnectionUniter(st)
 	c.Assert(err, jc.ErrorIsNil)
 
 	attachments, err := uniter.UnitStorageAttachments(unit.UnitTag())

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -57,7 +57,6 @@ func (*importSuite) TestImports(c *gc.C) {
 		"cloud",
 		"cmd",
 		"controller",
-		"core/application",
 		"core/charm/metrics",
 		"core/constraints",
 		"core/devices",

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -41,7 +41,6 @@ func (*importSuite) TestImports(c *gc.C) {
 		"api/agent/keyupdater",
 		"api/agent/reboot",
 		"api/agent/unitassigner",
-		"api/agent/uniter",
 		"api/agent/upgrader",
 		"api/watcher",
 		"apiserver/errors",

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -15,7 +15,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/cmd/juju/application"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -71,7 +70,7 @@ func (s *ApplicationConfigSuite) assertApplicationDeployed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := s.OpenAPIAs(c, unit.Tag(), password)
-	uniter, err := api.ConnectionUniter(st)
+	uniter, err := uniter.NewFromConnection(st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uniter, gc.NotNil)
 

--- a/featuretests/application_config_test.go
+++ b/featuretests/application_config_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/cmd/juju/application"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -70,7 +71,7 @@ func (s *ApplicationConfigSuite) assertApplicationDeployed(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := s.OpenAPIAs(c, unit.Tag(), password)
-	uniter, err := st.Uniter()
+	uniter, err := api.ConnectionUniter(st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uniter, gc.NotNil)
 

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -57,7 +57,7 @@ func (s *BundlesDirSuite) SetUpTest(c *gc.C) {
 
 	s.st = s.OpenAPIAs(c, unit.Tag(), password)
 	c.Assert(s.st, gc.NotNil)
-	s.uniter, err = api.ConnectionUniter(s.st)
+	s.uniter, err = uniter.NewFromConnection(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 }

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -57,7 +57,7 @@ func (s *BundlesDirSuite) SetUpTest(c *gc.C) {
 
 	s.st = s.OpenAPIAs(c, unit.Tag(), password)
 	c.Assert(s.st, gc.NotNil)
-	s.uniter, err = s.st.Uniter()
+	s.uniter, err = api.ConnectionUniter(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 }

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -263,7 +263,7 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	st := s.OpenAPIAs(c, unit.Tag(), password)
-	uniter, err := st.Uniter()
+	uniter, err := api.ConnectionUniter(st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uniter, gc.NotNil)
 	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))
@@ -352,7 +352,7 @@ func (s *ContextFactorySuite) setupPodSpec(c *gc.C) (*state.State, context.Conte
 	apiInfo.Password = password
 	apiState, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
-	uniter, err := apiState.Uniter()
+	uniter, err := api.ConnectionUniter(apiState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uniter, gc.NotNil)
 	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))
@@ -560,7 +560,7 @@ func (s *ContextFactorySuite) TestNewHookContextCAASModel(c *gc.C) {
 	apiInfo.Password = password
 	apiState, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
-	uniter, err := apiState.Uniter()
+	uniter, err := api.ConnectionUniter(apiState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uniter, gc.NotNil)
 	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -19,6 +19,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8stesting "github.com/juju/juju/caas/kubernetes/provider/testing"
 	"github.com/juju/juju/controller"
@@ -263,7 +264,7 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	st := s.OpenAPIAs(c, unit.Tag(), password)
-	uniter, err := api.ConnectionUniter(st)
+	uniter, err := uniter.NewFromConnection(st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uniter, gc.NotNil)
 	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))
@@ -352,7 +353,7 @@ func (s *ContextFactorySuite) setupPodSpec(c *gc.C) (*state.State, context.Conte
 	apiInfo.Password = password
 	apiState, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
-	uniter, err := api.ConnectionUniter(apiState)
+	uniter, err := uniter.NewFromConnection(apiState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uniter, gc.NotNil)
 	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))
@@ -560,7 +561,7 @@ func (s *ContextFactorySuite) TestNewHookContextCAASModel(c *gc.C) {
 	apiInfo.Password = password
 	apiState, err := api.Open(apiInfo, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
-	uniter, err := api.ConnectionUniter(apiState)
+	uniter, err := uniter.NewFromConnection(apiState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uniter, gc.NotNil)
 	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/agent/uniter"
 	apiuniter "github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/status"
@@ -65,7 +66,7 @@ func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAs(c, unit.Tag(), password)
-	s.uniter, err = api.ConnectionUniter(s.st)
+	s.uniter, err = uniter.NewFromConnection(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -65,7 +65,7 @@ func (s *ContextRelationSuite) SetUpTest(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAs(c, unit.Tag(), password)
-	s.uniter, err = s.st.Uniter()
+	s.uniter, err = api.ConnectionUniter(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 

--- a/worker/uniter/runner/context/unitStorage_test.go
+++ b/worker/uniter/runner/context/unitStorage_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -199,7 +200,7 @@ func (s *unitStorageSuite) createHookSupport(c *gc.C) {
 	err = s.unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAs(c, s.unit.Tag(), password)
-	s.uniter, err = s.st.Uniter()
+	s.uniter, err = api.ConnectionUniter(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))

--- a/worker/uniter/runner/context/unitStorage_test.go
+++ b/worker/uniter/runner/context/unitStorage_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -200,7 +200,7 @@ func (s *unitStorageSuite) createHookSupport(c *gc.C) {
 	err = s.unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAs(c, s.unit.Tag(), password)
-	s.uniter, err = api.ConnectionUniter(s.st)
+	s.uniter, err = uniter.NewFromConnection(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -78,7 +78,7 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	err = s.unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAs(c, s.unit.Tag(), password)
-	s.uniter, err = api.ConnectionUniter(s.st)
+	s.uniter, err = uniter.NewFromConnection(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))
@@ -87,7 +87,7 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	err = meteredUnit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	meteredState := s.OpenAPIAs(c, meteredUnit.Tag(), password)
-	meteredUniter, err := api.ConnectionUniter(meteredState)
+	meteredUniter, err := uniter.NewFromConnection(meteredState)
 	c.Assert(err, jc.ErrorIsNil)
 	s.meteredAPIUnit, err = meteredUniter.Unit(meteredUnit.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
@@ -187,7 +187,7 @@ func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int, remot
 		_, found := s.apiRelunits[relid]
 		c.Assert(found, jc.IsTrue)
 	}
-	facade, err := api.ConnectionUniter(s.st)
+	facade, err := uniter.NewFromConnection(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 
 	relctxs := map[int]*runnercontext.ContextRelation{}
@@ -231,7 +231,7 @@ func (s *HookContextSuite) getMeteredHookContext(c *gc.C, uuid string, relid int
 		_, found := s.apiRelunits[relid]
 		c.Assert(found, jc.IsTrue)
 	}
-	facade, err := api.ConnectionUniter(s.st)
+	facade, err := uniter.NewFromConnection(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 
 	relctxs := map[int]*runnercontext.ContextRelation{}

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -78,7 +78,7 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	err = s.unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAs(c, s.unit.Tag(), password)
-	s.uniter, err = s.st.Uniter()
+	s.uniter, err = api.ConnectionUniter(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))
@@ -87,7 +87,7 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	err = meteredUnit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	meteredState := s.OpenAPIAs(c, meteredUnit.Tag(), password)
-	meteredUniter, err := meteredState.Uniter()
+	meteredUniter, err := api.ConnectionUniter(meteredState)
 	c.Assert(err, jc.ErrorIsNil)
 	s.meteredAPIUnit, err = meteredUniter.Unit(meteredUnit.Tag().(names.UnitTag))
 	c.Assert(err, jc.ErrorIsNil)
@@ -187,7 +187,7 @@ func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int, remot
 		_, found := s.apiRelunits[relid]
 		c.Assert(found, jc.IsTrue)
 	}
-	facade, err := s.st.Uniter()
+	facade, err := api.ConnectionUniter(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 
 	relctxs := map[int]*runnercontext.ContextRelation{}
@@ -231,7 +231,7 @@ func (s *HookContextSuite) getMeteredHookContext(c *gc.C, uuid string, relid int
 		_, found := s.apiRelunits[relid]
 		c.Assert(found, jc.IsTrue)
 	}
-	facade, err := s.st.Uniter()
+	facade, err := api.ConnectionUniter(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 
 	relctxs := map[int]*runnercontext.ContextRelation{}

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/common/charmrunner"
 	"github.com/juju/juju/worker/uniter/hook"
@@ -162,7 +163,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	st := s.OpenAPIAs(c, unit.Tag(), password)
-	uniter, err := st.Uniter()
+	uniter, err := api.ConnectionUniter(st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/worker/common/charmrunner"
 	"github.com/juju/juju/worker/uniter/hook"
@@ -163,7 +163,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	err = unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	st := s.OpenAPIAs(c, unit.Tag(), password)
-	uniter, err := api.ConnectionUniter(st)
+	uniter, err := uniter.NewFromConnection(st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 	apiUnit, err := uniter.Unit(unit.Tag().(names.UnitTag))

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -81,7 +81,7 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 	err = s.unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAs(c, s.unit.Tag(), password)
-	s.uniter, err = s.st.Uniter()
+	s.uniter, err = api.ConnectionUniter(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -81,7 +81,7 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 	err = s.unit.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 	s.st = s.OpenAPIAs(c, s.unit.Tag(), password)
-	s.uniter, err = api.ConnectionUniter(s.st)
+	s.uniter, err = uniter.NewFromConnection(s.st)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.uniter, gc.NotNil)
 	s.apiUnit, err = s.uniter.Unit(s.unit.Tag().(names.UnitTag))

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -202,7 +202,7 @@ func (ctx *testContext) apiLogin(c *gc.C) {
 	apiConn := ctx.s.OpenAPIAs(c, ctx.unit.Tag(), password)
 	c.Assert(apiConn, gc.NotNil)
 	c.Logf("API: login as %q successful", ctx.unit.Tag())
-	testApi, err := apiConn.Uniter()
+	testApi, err := api.ConnectionUniter(apiConn)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testApi, gc.NotNil)
 	ctx.api = testApi

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -202,7 +202,7 @@ func (ctx *testContext) apiLogin(c *gc.C) {
 	apiConn := ctx.s.OpenAPIAs(c, ctx.unit.Tag(), password)
 	c.Assert(apiConn, gc.NotNil)
 	c.Logf("API: login as %q successful", ctx.unit.Tag())
-	testApi, err := api.ConnectionUniter(apiConn)
+	testApi, err := apiuniter.NewFromConnection(apiConn)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(testApi, gc.NotNil)
 	ctx.api = testApi


### PR DESCRIPTION
It has been noted that there are a bunch of methods at the bottom of the `api.Connection` interface which do not belong there.  They are prefaced by this comment, slightly cryptic for me:
```
	// These methods expose a bunch of worker-specific facades, and basically
	// just should not exist; but removing them is too noisy for a single CL.
	// Client in particular is intimately coupled with State -- and the others
	// will be easy to remove, but until we're using them via manifolds it's
	// prohibitively ugly to do so.
```

As an experiment this PR removes the Uniter() method from the `Connection` interface.  A new `ConnectionUniter` function is created to provide the same functionality on a Connection instance and all method calls are replaced with calls to this function.

I have naively located the new `ConnectionUniter` function in the `api` package, which introduce a new dependency on the `api` package in one test file - I don't think it matters but still I wonder where is a good home for it.

It looks like this method is *only used in tests*, which is suspicious.
