### PR TITLE
[JUJU-792] Ensure model defaults are coerced to the correct type when saving

### DIFF
--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -214,10 +214,18 @@ func (st *State) UpdateModelConfigDefaultValues(updateAttrs map[string]interface
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if _, err := st.buildAndValidateModelConfig(updateAttrs, removeAttrs, oldConfig); err != nil {
+	validCfg, err := st.buildAndValidateModelConfig(updateAttrs, removeAttrs, oldConfig)
+	if err != nil {
 		return errors.Trace(err)
 	}
+	validAttrs := validCfg.AllAttrs()
+	for k := range updateAttrs {
+		if v, ok := validAttrs[k]; ok {
+			updateAttrs[k] = v
+		}
+	}
 
+	updateAttrs = config.CoerceForStorage(updateAttrs)
 	settings.Update(updateAttrs)
 	for _, r := range removeAttrs {
 		settings.Delete(r)

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -457,7 +457,8 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	attrs = map[string]interface{}{
-		"apt-mirror": "http://different-mirror",
+		"apt-mirror":            "http://different-mirror",
+		"num-provision-workers": 666,
 	}
 	err = s.State.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -485,6 +486,10 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaults(c *gc.C) {
 			Name:  "dummy-region",
 			Value: "dummy-proxy",
 		}}}
+	expectedValues["num-provision-workers"] = config.AttributeDefaultValues{
+		Controller: 666,
+		Default:    16,
+	}
 	c.Assert(cfg, jc.DeepEquals, expectedValues)
 }
 


### PR DESCRIPTION
The juju cli used to (in some places) coerce various config name values to the required type. This was removed from the cli but it exposed a latent bug in state where type coercion was not being done for model default values.

## QA steps

juju bootstrap 
juju model-default num-provision-workers=666
juju model-default --format yaml

The "controller" value in the yaml should be `666` not `"666"`

