### PR TITLE
Remove Connection Upgrader() method

### DIFF
--- a/api/agent/upgrader/unitupgrader_test.go
+++ b/api/agent/upgrader/unitupgrader_test.go
@@ -48,7 +48,7 @@ func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 	s.stateAPI = s.OpenAPIAs(c, s.rawUnit.Tag(), password)
 
 	// Create the upgrader facade.
-	s.st = s.stateAPI.Upgrader()
+	s.st = upgrader.NewState(s.stateAPI)
 	c.Assert(s.st, gc.NotNil)
 
 	s.WaitForModelWatchersIdle(c, s.State.ModelUUID())

--- a/api/agent/upgrader/upgrader_test.go
+++ b/api/agent/upgrader/upgrader_test.go
@@ -39,7 +39,7 @@ func (s *machineUpgraderSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	s.stateAPI, s.rawMachine = s.OpenAPIAsNewMachine(c)
 	// Create the upgrader facade.
-	s.st = s.stateAPI.Upgrader()
+	s.st = upgrader.NewState(s.stateAPI)
 	c.Assert(s.st, gc.NotNil)
 }
 

--- a/api/interface.go
+++ b/api/interface.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/juju/api/agent/reboot"
 	"github.com/juju/juju/api/agent/unitassigner"
 	"github.com/juju/juju/api/agent/uniter"
-	"github.com/juju/juju/api/agent/upgrader"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller/instancepoller"
 	"github.com/juju/juju/core/network"
@@ -333,7 +332,6 @@ type Connection interface {
 	// prohibitively ugly to do so.
 	Client() *Client
 	Uniter() (*uniter.State, error)
-	Upgrader() *upgrader.State
 	Reboot() (reboot.State, error)
 	InstancePoller() *instancepoller.API
 	UnitAssigner() unitassigner.API

--- a/api/state.go
+++ b/api/state.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/api/agent/reboot"
 	"github.com/juju/juju/api/agent/unitassigner"
 	"github.com/juju/juju/api/agent/uniter"
-	"github.com/juju/juju/api/agent/upgrader"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller/instancepoller"
 	"github.com/juju/juju/core/network"
@@ -328,11 +327,6 @@ func (st *state) Uniter() (*uniter.State, error) {
 		return nil, errors.Errorf("expected UnitTag, got %T %v", st.authTag, st.authTag)
 	}
 	return uniter.NewState(st, unitTag), nil
-}
-
-// Upgrader returns access to the Upgrader API
-func (st *state) Upgrader() *upgrader.State {
-	return upgrader.NewState(st)
 }
 
 // Reboot returns access to the Reboot API

--- a/worker/upgrader/upgrader_test.go
+++ b/worker/upgrader/upgrader_test.go
@@ -113,7 +113,7 @@ func (s *UpgraderSuite) makeUpgrader(c *gc.C) *upgrader.Upgrader {
 	w, err := upgrader.NewAgentUpgrader(upgrader.Config{
 		Clock:                       s.clock,
 		Logger:                      loggo.GetLogger("test"),
-		State:                       s.state.Upgrader(),
+		State:                       upgrader.NewState(s.state),
 		AgentConfig:                 agentConfig(s.machine.Tag(), s.DataDir()),
 		OrigAgentVersion:            s.confVersion,
 		UpgradeStepsWaiter:          s.upgradeStepsComplete,
@@ -489,7 +489,7 @@ func (s *UpgraderSuite) TestChecksSpaceBeforeDownloading(c *gc.C) {
 	u, err := upgrader.NewAgentUpgrader(upgrader.Config{
 		Clock:                       s.clock,
 		Logger:                      loggo.GetLogger("test"),
-		State:                       s.state.Upgrader(),
+		State:                       upgrader.NewState(s.state),
 		AgentConfig:                 agentConfig(s.machine.Tag(), s.DataDir()),
 		OrigAgentVersion:            s.confVersion,
 		UpgradeStepsWaiter:          s.upgradeStepsComplete,


### PR DESCRIPTION
The api.Connection interface declares an `Upgrader()` method.  It is only used in tests and a comment says it should not exist.  Its only implementation in api.state is trivial.

This PR removes it.
