### PR TITLE
[JUJU-813] Remove unused InstancePoller()method from Connection interface

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/api/agent/upgrader"
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/controller/instancepoller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/proxy"
 	"github.com/juju/juju/rpc/jsoncodec"
@@ -335,6 +334,5 @@ type Connection interface {
 	Uniter() (*uniter.State, error)
 	Upgrader() *upgrader.State
 	Reboot() (reboot.State, error)
-	InstancePoller() *instancepoller.API
 	UnitAssigner() unitassigner.API
 }

--- a/api/state.go
+++ b/api/state.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/api/agent/upgrader"
 	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/controller/instancepoller"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc"
@@ -348,11 +347,6 @@ func (st *state) Reboot() (reboot.State, error) {
 // KeyUpdater returns access to the KeyUpdater API
 func (st *state) KeyUpdater() *keyupdater.State {
 	return keyupdater.NewState(st)
-}
-
-// InstancePoller returns access to the InstancePoller API
-func (st *state) InstancePoller() *instancepoller.API {
-	return instancepoller.NewAPI(st)
 }
 
 // ServerVersion holds the version of the API server that we are connected to.

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -37,7 +37,6 @@ func (*importSuite) TestImports(c *gc.C) {
 		"api/agent/caasapplication",
 		"api/common",
 		"api/common/cloudspec",
-		"api/controller/instancepoller",
 		"api/agent/keyupdater",
 		"api/agent/reboot",
 		"api/agent/unitassigner",


### PR DESCRIPTION
The `api.Connection` interface declares an `InstancePoller()` method. A comment says it should not exist and it is unused.

This PR removes it and its implementation in state.