### PR TITLE
[JUJU-815] Don't create a mongo transaction when there's nothing to do

### DIFF
--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -89,7 +89,9 @@ func (m *Machine) RemoveAllLinkLayerDevices() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-
+	if len(ops) == 0 {
+		return nil
+	}
 	return m.st.db().RunTransaction(ops)
 }
 


### PR DESCRIPTION
Don't create an empty Mongo transaction when there is nothing to do.

Sometimes when removing (all) link layer devices from a machine on
cleanup, there are none to be removed, leading to a no-op

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
go test github.com/juju/juju/state -test.timeout=1800s
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1962316
