### PR TITLE
Add `Origin` to local charms when refreshing

### DIFF
--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -200,6 +200,10 @@ func (d *localCharmRefresher) Refresh() (*CharmID, error) {
 		}
 		return &CharmID{
 			URL: addedURL,
+			Origin: corecharm.Origin{
+				Source: corecharm.Local,
+				Type:   "charm",
+			},
 		}, nil
 	}
 	if _, ok := err.(*charmrepo.NotFoundError); ok {

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -257,6 +257,10 @@ func (s *localCharmRefresherSuite) TestRefresh(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmID, gc.DeepEquals, &CharmID{
 		URL: curl,
+		Origin: corecharm.Origin{
+			Source: corecharm.Local,
+			Type:   "charm",
+		},
 	})
 }
 


### PR DESCRIPTION
When refreshing a charm locally, the charm source (`local`) is not printed:
```sh
$ juju refresh hello-juju --path=./hello-juju
Added  charm "hello-juju", revision 9, to the model
```
instead of
```sh
Added local charm ...
```
This PR sets the `Origin` in `localCharmRefresher.Refresh()` to ensure it prints correctly. I have also changed the unit tests to match.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Please replace with how we can verify that the change works.*

```sh
# Starting with existing Juju controller
# Deploy old charm
juju deploy hello-juju --revision=6 --channel=stable
# Download new version
charm pull hello-juju-7
# Deploy locally from new version
juju refresh hello-juju --path=./hello-juju
# Cleanup
juju remove-application hello-juju --force
rm -r ./hello-juju
```