### PR TITLE
[JUJU-820] Improve error message for unspec'd channel

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -720,16 +720,15 @@ func (c *DeployCommand) Init(args []string) error {
 		// do a late validation at Run().
 		c.unknownModel = true
 	}
-	if c.channelStr == "" {
-		if c.Revision != -1 {
-			// Tell the user they need to specify a channel
-			return errors.BadRequestf(
-				"If a revision is specified, a channel must also be specified for store\n" +
-					"charms and bundles. Do this using the --channel option, e.g.\n" +
-					"    juju deploy <charm> --revision=5 --channel=stable",
-			)
-		}
-	} else {
+	if c.channelStr == "" && c.Revision != -1 {
+		// Tell the user they need to specify a channel
+		return errors.New(
+			`If a revision is specified, a channel must also be specified for store
+charms and bundles. Do this using the --channel option, e.g.
+    juju deploy <charm> --revision=5 --channel=stable`,
+		)
+	}
+	if c.channelStr != "" {
 		c.Channel, err = charm.ParseChannelNormalize(c.channelStr)
 		if err != nil {
 			return errors.Annotate(err, "error in --channel")

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -720,7 +720,16 @@ func (c *DeployCommand) Init(args []string) error {
 		// do a late validation at Run().
 		c.unknownModel = true
 	}
-	if c.channelStr != "" {
+	if c.channelStr == "" {
+		if c.Revision != -1 {
+			// Tell the user they need to specify a channel
+			return errors.BadRequestf(
+				"If a revision is specified, a channel must also be specified for store\n" +
+					"charms and bundles. Do this using the --channel option, e.g.\n" +
+					"    juju deploy <charm> --revision=5 --channel=stable",
+			)
+		}
+	} else {
 		c.Channel, err = charm.ParseChannelNormalize(c.channelStr)
 		if err != nil {
 			return errors.Annotate(err, "error in --channel")

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -723,9 +723,7 @@ func (c *DeployCommand) Init(args []string) error {
 	if c.channelStr == "" && c.Revision != -1 {
 		// Tell the user they need to specify a channel
 		return errors.New(
-			`If a revision is specified, a channel must also be specified for store
-charms and bundles. Do this using the --channel option, e.g.
-    juju deploy <charm> --revision=5 --channel=stable`,
+			`when using --revision option, you must also use --channel option`,
 		)
 	}
 	if c.channelStr != "" {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -294,6 +294,9 @@ var initErrorTests = []struct {
 	}, {
 		args: []string{"bundle", "--map-machines", "foo"},
 		err:  `error in --map-machines: expected "existing" or "<bundle-id>=<machine-id>", got "foo"`,
+	}, {
+		args: []string{"charm-name", "--revision", "3"},
+		err:  `when using --revision option, you must also use --channel option`,
 	},
 }
 


### PR DESCRIPTION
When deploying a Charmhub charm with specified revision but unspecified channel, Juju was giving a cryptic error message:
```
$ juju deploy ch:hello-juju --revision=3
ERROR invalid channel for "ch:hello-juju": channel cannot be empty
```
I made this message more clear, so the user can tell what to do:
```
$ juju deploy ch:hello-juju --revision=3
ERROR If a revision is specified, a channel must also be specified for Charmhub
charms and bundles. Do this using the --channel option, e.g.
    juju deploy <charm> --revision=5 --channel=stable
```

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
make go-install
juju destroy-controller overlord --destroy-all-models
juju bootstrap localhost overlord
juju deploy ch:hello-juju --revision=3
```