### PR TITLE
[JUJU-808] Fix build official build

### DIFF
--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -889,15 +889,16 @@ func (c *Client) toolVersionsForCAAS(args params.FindToolsParams, streamsVersion
 		if number.Compare(current) <= 0 {
 			continue
 		}
-		if jujuversion.OfficialBuild == 0 && number.Build > 0 {
+		if current.Build == 0 && number.Build > 0 {
 			continue
 		}
 		if args.MajorVersion != -1 && number.Major != args.MajorVersion {
 			continue
 		}
-		number.Build = 0
 		if !controllerCfg.Features().Contains(feature.DeveloperMode) && streamsVersions.Size() > 0 {
-			if !streamsVersions.Contains(number.String()) {
+			numberCopy := number
+			numberCopy.Build = 0
+			if !streamsVersions.Contains(numberCopy.String()) {
 				continue
 			}
 		} else {
@@ -908,8 +909,11 @@ func (c *Client) toolVersionsForCAAS(args params.FindToolsParams, streamsVersion
 			}
 		}
 		arch, err := reg.GetArchitecture(imageName, number.String())
+		if errors.IsNotFound(err) {
+			continue
+		}
 		if err != nil {
-			return result, errors.Annotatef(err, "cannot get architecture for %q:%q", imageName, number.String())
+			return result, errors.Annotatef(err, "cannot get architecture for %s:%s", imageName, number.String())
 		}
 		if args.Arch != "" && arch != args.Arch {
 			continue

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/manual/sshprovisioner"
+	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -2037,7 +2038,7 @@ func (s *findToolsSuite) getModelConfig(c *gc.C, agentVersion string) *config.Co
 	return mCfg
 }
 
-func (s *findToolsSuite) TestFindToolsCAAS(c *gc.C) {
+func (s *findToolsSuite) TestFindToolsCAASReleased(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -2113,6 +2114,90 @@ func (s *findToolsSuite) TestFindToolsCAAS(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.FindToolsResult{
 		List: []*tools.Tools{
+			{Version: version.MustParseBinary("2.9.10-ubuntu-amd64")},
+			{Version: version.MustParseBinary("2.9.11-ubuntu-amd64")},
+		},
+	})
+}
+
+func (s *findToolsSuite) TestFindToolsCAASNonReleased(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	backend := mocks.NewMockBackend(ctrl)
+	model := mocks.NewMockModel(ctrl)
+	authorizer := mocks.NewMockAuthorizer(ctrl)
+	registryProvider := registrymocks.NewMockRegistry(ctrl)
+	toolsFinder := mocks.NewMockToolsFinder(ctrl)
+
+	simpleStreams := params.FindToolsResult{
+		List: []*tools.Tools{
+			{Version: version.MustParseBinary("2.9.9-ubuntu-amd64")},
+			{Version: version.MustParseBinary("2.9.10-ubuntu-amd64")},
+			{Version: version.MustParseBinary("2.9.11-ubuntu-amd64")},
+		},
+	}
+	s.PatchValue(&coreos.HostOS, func() coreos.OSType { return coreos.Ubuntu })
+
+	gomock.InOrder(
+		authorizer.EXPECT().AuthClient().Return(true),
+		backend.EXPECT().ControllerTag().Return(coretesting.ControllerTag),
+		authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(true, nil),
+		backend.EXPECT().ModelTag().Return(coretesting.ModelTag),
+		authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(true, nil),
+
+		backend.EXPECT().Model().Return(model, nil),
+		toolsFinder.EXPECT().FindTools(params.FindToolsParams{MajorVersion: 2, AgentStream: envtools.DevelStream}).
+			Return(simpleStreams, nil),
+		model.EXPECT().Type().Return(state.ModelTypeCAAS),
+		model.EXPECT().Config().Return(s.getModelConfig(c, "2.9.9.1"), nil),
+
+		backend.EXPECT().ControllerConfig().Return(controller.Config{
+			controller.ControllerUUIDKey: coretesting.ControllerTag.Id(),
+			controller.CAASImageRepo: `
+{
+    "serveraddress": "quay.io",
+    "auth": "xxxxx==",
+    "repository": "test-account"
+}
+`[1:],
+		}, nil),
+		registryProvider.EXPECT().Tags("jujud-operator").Return(tools.Versions{
+			image.NewImageInfo(version.MustParse("2.9.8")), // skip: older than current version.
+			image.NewImageInfo(version.MustParse("2.9.9")), // skip: older than current version.
+			image.NewImageInfo(version.MustParse("2.9.10.1")),
+			image.NewImageInfo(version.MustParse("2.9.10")),
+			image.NewImageInfo(version.MustParse("2.9.11")),
+			image.NewImageInfo(version.MustParse("2.9.12")), // skip: it's not released in simplestream yet.
+		}, nil),
+		registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10.1").Return("amd64", nil),
+		registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10").Return("amd64", nil),
+		registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.11").Return("amd64", nil),
+		registryProvider.EXPECT().Close().Return(nil),
+	)
+
+	api, err := client.NewClient(
+		backend,
+		nil, nil, nil,
+		authorizer, nil, toolsFinder,
+		nil, nil, nil, nil, nil, nil, nil,
+		func(repo docker.ImageRepoDetails) (registry.Registry, error) {
+			c.Assert(repo, gc.DeepEquals, docker.ImageRepoDetails{
+				Repository:    "test-account",
+				ServerAddress: "quay.io",
+				BasicAuthConfig: docker.BasicAuthConfig{
+					Auth: docker.NewToken("xxxxx=="),
+				},
+			})
+			return registryProvider, nil
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	result, err := api.FindTools(params.FindToolsParams{MajorVersion: 2, AgentStream: envtools.DevelStream})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, gc.DeepEquals, params.FindToolsResult{
+		List: []*tools.Tools{
+			{Version: version.MustParseBinary("2.9.10.1-ubuntu-amd64")},
 			{Version: version.MustParseBinary("2.9.10-ubuntu-amd64")},
 			{Version: version.MustParseBinary("2.9.11-ubuntu-amd64")},
 		},

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -150,7 +150,7 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
 	attrs := coretesting.FakeConfig()
 	attrs["operator-storage"] = "k8s-storage"
-	attrs["agent-version"] = "2.6-beta3"
+	attrs["agent-version"] = "2.6-beta3.666"
 	return config.New(config.UseDefaults, attrs)
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -43,7 +43,6 @@ import (
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
-	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.caasapplicationprovisioner")
@@ -257,7 +256,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, vers.ToPatch(), version.OfficialBuild)
+	imagePath, err := podcfg.GetJujuOCIImagePath(cfg, vers)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting juju oci image path")
 	}

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -50,7 +50,7 @@ func (s *CAASApplicationProvisionerSuite) SetUpTest(c *gc.C) {
 
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
-	s.PatchValue(&jujuversion.OfficialBuild, 666)
+	s.PatchValue(&jujuversion.OfficialBuild, 0)
 
 	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag:        names.NewMachineTag("0"),
@@ -110,7 +110,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	c.Assert(result, mc, params.CAASApplicationProvisioningInfoResults{
 		Results: []params.CAASApplicationProvisioningInfo{{
 			ImagePath:    "jujusolutions/jujud-operator:2.6-beta3.666",
-			Version:      version.MustParse("2.6-beta3"),
+			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -14,8 +15,9 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/version"
 )
+
+var logger = loggo.GetLogger("juju.apiserver.caasmodeloperator")
 
 // TODO (manadart 2020-10-21): Remove the ModelUUID method
 // from the next version of this facade.
@@ -103,10 +105,10 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 		IdentityToken: imageRepo.IdentityToken.Content(),
 		RegistryToken: imageRepo.RegistryToken.Content(),
 	}
-	if imageInfo.RegistryPath, err = podcfg.GetJujuOCIImagePath(controllerConf,
-		vers.ToPatch(), version.OfficialBuild); err != nil {
+	if imageInfo.RegistryPath, err = podcfg.GetJujuOCIImagePath(controllerConf, vers); err != nil {
 		return result, errors.Trace(err)
 	}
+	logger.Tracef("image info %v", imageInfo)
 
 	result = params.ModelOperatorInfo{
 		APIAddresses: apiAddresses.Result,

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -13,7 +13,6 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	coretesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/version"
 )
 
 type ModelOperatorSuite struct {
@@ -60,7 +59,7 @@ func (m *ModelOperatorSuite) TestProvisioningInfo(c *gc.C) {
 	controllerConf, err := m.state.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
-	imagePath, err := podcfg.GetJujuOCIImagePath(controllerConf, info.Version, version.OfficialBuild)
+	imagePath, err := podcfg.GetJujuOCIImagePath(controllerConf, info.Version)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(imagePath, gc.Equals, info.ImageDetails.RegistryPath)
 

--- a/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/mock_test.go
@@ -121,7 +121,7 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
 	attrs := coretesting.FakeConfig()
 	attrs["operator-storage"] = "k8s-storage"
-	attrs["agent-version"] = "2.6-beta3"
+	attrs["agent-version"] = "2.6-beta3.666"
 	return config.New(config.UseDefaults, attrs)
 }
 

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
-	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.caasoperatorprovisioner")
@@ -187,11 +186,10 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 		IdentityToken: imageRepo.IdentityToken.Content(),
 		RegistryToken: imageRepo.RegistryToken.Content(),
 	}
-	if imageInfo.RegistryPath, err = podcfg.GetJujuOCIImagePath(
-		cfg, vers.ToPatch(), version.OfficialBuild,
-	); err != nil {
+	if imageInfo.RegistryPath, err = podcfg.GetJujuOCIImagePath(cfg, vers); err != nil {
 		return result, errors.Trace(err)
 	}
+	logger.Tracef("imageInfo %v", imageInfo)
 
 	apiAddresses, err := a.APIAddresses()
 	if err == nil && apiAddresses.Error != nil {

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner_test.go
@@ -42,7 +42,7 @@ func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
 
 	s.resources = common.NewResources()
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
-	s.PatchValue(&jujuversion.OfficialBuild, 666)
+	s.PatchValue(&jujuversion.OfficialBuild, 0)
 
 	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag:        names.NewMachineTag("0"),
@@ -139,7 +139,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoDefault(c *gc.C) {
 			ImageDetails: params.DockerImageInfo{
 				RegistryPath: "jujusolutions/jujud-operator:2.6-beta3.666",
 			},
-			Version:      version.MustParse("2.6-beta3"),
+			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),
@@ -173,7 +173,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfo(c *gc.C) {
 				RegistryPath: s.st.operatorRepo + "/jujud-operator:" + "2.6-beta3.666",
 				Repository:   s.st.operatorRepo,
 			},
-			Version:      version.MustParse("2.6-beta3"),
+			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),
@@ -208,7 +208,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStorage(c *gc.C) {
 				RegistryPath: s.st.operatorRepo + "/jujud-operator:" + "2.6-beta3.666",
 				Repository:   s.st.operatorRepo,
 			},
-			Version:      version.MustParse("2.6-beta3"),
+			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),
@@ -232,7 +232,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoSidecarNoStorage(c *g
 				RegistryPath: s.st.operatorRepo + "/jujud-operator:" + "2.6-beta3.666",
 				Repository:   s.st.operatorRepo,
 			},
-			Version:      version.MustParse("2.6-beta3"),
+			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),
@@ -256,7 +256,7 @@ func (s *CAASProvisionerSuite) TestOperatorProvisioningInfoNoStoragePool(c *gc.C
 				RegistryPath: s.st.operatorRepo + "/jujud-operator:" + "2.6-beta3.666",
 				Repository:   s.st.operatorRepo,
 			},
-			Version:      version.MustParse("2.6-beta3"),
+			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{
 				"juju-model-uuid":      coretesting.ModelTag.Id(),

--- a/apiserver/facades/controller/caasunitprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/mock_test.go
@@ -102,7 +102,9 @@ func (m *mockModel) ModelConfig() (*config.Config, error) {
 	m.MethodCall(m, "ModelConfig")
 	attrs := coretesting.FakeConfig()
 	attrs["workload-storage"] = "k8s-storage"
-	attrs["agent-version"] = jujuversion.Current.String()
+	ver := jujuversion.Current
+	ver.Build = 666
+	attrs["agent-version"] = ver.String()
 	return config.New(config.UseDefaults, attrs)
 }
 

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -36,7 +36,6 @@ import (
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/storage/poolmanager"
-	"github.com/juju/juju/version"
 )
 
 var logger = loggo.GetLogger("juju.apiserver.controller.caasunitprovisioner")
@@ -439,10 +438,11 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	operatorImagePath, err := podcfg.GetJujuOCIImagePath(controllerCfg, vers.ToPatch(), version.OfficialBuild)
+	operatorImagePath, err := podcfg.GetJujuOCIImagePath(controllerCfg, vers)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	logger.Criticalf("provisioningInfo operatorImagePath => %#v", operatorImagePath)
 
 	filesystemParams, err := f.applicationFilesystemParams(app, controllerCfg, modelConfig)
 	if err != nil {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -442,7 +442,6 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Criticalf("provisioningInfo operatorImagePath => %#v", operatorImagePath)
 
 	filesystemParams, err := f.applicationFilesystemParams(app, controllerCfg, modelConfig)
 	if err != nil {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -102,7 +102,7 @@ func (s *CAASProvisionerSuite) SetUpTest(c *gc.C) {
 		Controller: true,
 	}
 	s.clock = testclock.NewClock(time.Now())
-	s.PatchValue(&jujuversion.OfficialBuild, 666)
+	s.PatchValue(&jujuversion.OfficialBuild, 0)
 
 	facade, err := caasunitprovisioner.NewFacade(
 		s.resources, s.authorizer, s.st, s.storage, s.devices,

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 )
 
 type bootstrapSuite struct {
@@ -91,8 +90,7 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 		s.controllerCfg, controllerName, "bionic", constraints.MustParse("root-disk=10000M mem=4000M"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	pcfg.JujuVersion = jujuversion.Current
-	pcfg.OfficialBuild = 666
+	pcfg.JujuVersion = version.MustParse("2.6.6.888")
 	pcfg.APIInfo = &api.Info{
 		Password: "password",
 		CACert:   coretesting.CACert,
@@ -682,7 +680,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		{
 			Name:            "api-server",
 			ImagePullPolicy: core.PullIfNotPresent,
-			Image:           "test-account/jujud-operator:" + jujuversion.Current.String() + ".666",
+			Image:           "test-account/jujud-operator:" + "2.6.6.888",
 			Env: []core.EnvVar{{
 				Name:  osenv.JujuFeatureFlagEnvKey,
 				Value: "developer-mode",

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -61,7 +61,7 @@ func IsJujuOCIImage(imagePath string) bool {
 }
 
 // GetJujuOCIImagePath returns the jujud oci image path.
-func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) (o string, err error) {
+func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) (string, error) {
 	// First check the deprecated "caas-operator-image-path" config.
 	imagePath, err := RebuildOldOperatorImagePath(
 		controllerCfg.CAASOperatorImagePath().Repository, ver,

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -24,7 +24,7 @@ const (
 
 // GetControllerImagePath returns oci image path of jujud for a controller.
 func (cfg *ControllerPodConfig) GetControllerImagePath() (string, error) {
-	return GetJujuOCIImagePath(cfg.Controller.Config, cfg.JujuVersion, cfg.OfficialBuild)
+	return GetJujuOCIImagePath(cfg.Controller.Config, cfg.JujuVersion)
 }
 
 func (cfg *ControllerPodConfig) mongoVersion() (*mongo.Version, error) {
@@ -61,9 +61,8 @@ func IsJujuOCIImage(imagePath string) bool {
 }
 
 // GetJujuOCIImagePath returns the jujud oci image path.
-func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number, build int) (string, error) {
+func GetJujuOCIImagePath(controllerCfg controller.Config, ver version.Number) (o string, err error) {
 	// First check the deprecated "caas-operator-image-path" config.
-	ver.Build = build
 	imagePath, err := RebuildOldOperatorImagePath(
 		controllerCfg.CAASOperatorImagePath().Repository, ver,
 	)

--- a/cloudconfig/podcfg/image_test.go
+++ b/cloudconfig/podcfg/image_test.go
@@ -24,19 +24,20 @@ func (*imageSuite) TestGetJujuOCIImagePath(c *gc.C) {
 	cfg := testing.FakeControllerConfig()
 
 	cfg[controller.CAASImageRepo] = "testing-repo"
-	ver := version.MustParse("2.6-beta3")
-	path, err := podcfg.GetJujuOCIImagePath(cfg, ver, 666)
+	ver := version.MustParse("2.6-beta3.666")
+	path, err := podcfg.GetJujuOCIImagePath(cfg, ver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, jc.DeepEquals, "testing-repo/jujud-operator:2.6-beta3.666")
 
 	cfg[controller.CAASImageRepo] = "testing-repo:8080"
-	ver = version.MustParse("2.6-beta3")
-	path, err = podcfg.GetJujuOCIImagePath(cfg, ver, 666)
+	ver = version.MustParse("2.6-beta3.666")
+	path, err = podcfg.GetJujuOCIImagePath(cfg, ver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, jc.DeepEquals, "testing-repo:8080/jujud-operator:2.6-beta3.666")
 
 	cfg[controller.CAASOperatorImagePath] = "testing-old-repo/jujud-old-operator:1.6"
-	path, err = podcfg.GetJujuOCIImagePath(cfg, ver, 0)
+	ver = version.MustParse("2.6-beta3")
+	path, err = podcfg.GetJujuOCIImagePath(cfg, ver)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, jc.DeepEquals, "testing-old-repo/jujud-old-operator:2.6-beta3")
 }

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -66,9 +66,6 @@ type ControllerPodConfig struct {
 	// JujuVersion is the juju version.
 	JujuVersion version.Number
 
-	// OfficialBuild is the build number to use when pulling the juju oci image.
-	OfficialBuild int
-
 	// DataDir holds the directory that juju state will be put in the new
 	// instance.
 	DataDir string

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -65,8 +65,7 @@ func (*podcfgSuite) TestOperatorImagesDefaultRepo(c *gc.C) {
 		constraints.Value{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	podConfig.JujuVersion = version.MustParse("6.6.6")
-	podConfig.OfficialBuild = 666
+	podConfig.JujuVersion = version.MustParse("6.6.6.666")
 	path, err := podConfig.GetControllerImagePath()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(path, gc.Equals, "jujusolutions/jujud-operator:6.6.6.666")
@@ -86,8 +85,7 @@ func (*podcfgSuite) TestOperatorImagesCustomRepo(c *gc.C) {
 		constraints.Value{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	podConfig.JujuVersion = version.MustParse("6.6.6")
-	podConfig.OfficialBuild = 666
+	podConfig.JujuVersion = version.MustParse("6.6.6.666")
 	c.Assert(err, jc.ErrorIsNil)
 	path, err := podConfig.GetControllerImagePath()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/commands/version.go
+++ b/cmd/juju/commands/version.go
@@ -80,11 +80,10 @@ func (v *versionCommand) Init(args []string) error {
 		Release: coreos.HostOSTypeName(),
 	}
 	detail := versionDetail{
-		Version:       current,
-		GitCommit:     jujuversion.GitCommit,
-		GitTreeState:  jujuversion.GitTreeState,
-		Compiler:      jujuversion.Compiler,
-		OfficialBuild: jujuversion.OfficialBuild,
+		Version:      current,
+		GitCommit:    jujuversion.GitCommit,
+		GitTreeState: jujuversion.GitTreeState,
+		Compiler:     jujuversion.Compiler,
 	}
 
 	v.version = detail.Version

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -238,11 +238,10 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 		Release: coreos.HostOSTypeName(),
 	}
 	detail := versionDetail{
-		Version:       current.String(),
-		GitCommit:     jujuversion.GitCommit,
-		GitTreeState:  jujuversion.GitTreeState,
-		Compiler:      jujuversion.Compiler,
-		OfficialBuild: jujuversion.OfficialBuild,
+		Version:      current.String(),
+		GitCommit:    jujuversion.GitCommit,
+		GitTreeState: jujuversion.GitTreeState,
+		Compiler:     jujuversion.Compiler,
 	}
 
 	jujud := jujucmd.NewSuperCommand(cmd.SuperCommandParams{

--- a/cmd/supercommand.go
+++ b/cmd/supercommand.go
@@ -53,7 +53,7 @@ func NewSuperCommand(p cmd.SuperCommandParams) *cmd.SuperCommand {
 }
 
 func runNotifier(name string) {
-	logger.Infof("running %s [%s %d %s %s %s]", name, jujuversion.Current, jujuversion.OfficialBuild, jujuversion.GitCommit, runtime.Compiler, runtime.Version())
+	logger.Infof("running %s [%s %s %s %s]", name, jujuversion.Current, jujuversion.GitCommit, runtime.Compiler, runtime.Version())
 	logger.Debugf("  args: %#v", os.Args)
 }
 

--- a/docker/registry/internal/base_client.go
+++ b/docker/registry/internal/base_client.go
@@ -195,7 +195,7 @@ func (c baseClient) Ping() error {
 	if resp != nil {
 		defer resp.Body.Close()
 	}
-	return errors.Trace(err)
+	return errors.Trace(unwrapNetError(err))
 }
 
 func (c baseClient) ImageRepoDetails() (o docker.ImageRepoDetails) {
@@ -217,7 +217,7 @@ func (c baseClient) getPaginatedJSON(url string, response interface{}) (string, 
 	resp, err := c.client.Get(url)
 	logger.Tracef("getPaginatedJSON for %q, err %v", url, err)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Trace(unwrapNetError(err))
 	}
 	defer resp.Body.Close()
 

--- a/docker/registry/internal/base_manifests.go
+++ b/docker/registry/internal/base_manifests.go
@@ -53,7 +53,7 @@ func (c baseClient) GetArchitecture(imageName, tag string) (string, error) {
 func getArchitecture(imageName, tag string, client ArchitectureGetter) (string, error) {
 	manifests, err := client.GetManifests(imageName, tag)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Annotatef(err, "can not get manifests for %s:%s", imageName, tag)
 	}
 	if manifests.Architecture == "" && manifests.Digest == "" {
 		return "", errors.New(fmt.Sprintf("faild to get manifests for %q %q", imageName, tag))
@@ -78,9 +78,8 @@ func (c baseClient) GetManifests(imageName, tag string) (*ManifestsResult, error
 // GetManifestsCommon returns manifests result for the provided url.
 func (c baseClient) GetManifestsCommon(url string) (*ManifestsResult, error) {
 	resp, err := c.client.Get(url)
-	logger.Tracef("getting manifests for %q, err %v", url, err)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(unwrapNetError(err))
 	}
 	defer resp.Body.Close()
 	return processManifestsResponse(resp)
@@ -132,7 +131,7 @@ func (c baseClient) GetBlobsCommon(url string) (*BlobsResponse, error) {
 	resp, err := c.client.Get(url)
 	logger.Tracef("getting blobs for %q, err %v", url, err)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(unwrapNetError(err))
 	}
 	defer resp.Body.Close()
 	var result BlobsResponse

--- a/docker/registry/internal/gcr.go
+++ b/docker/registry/internal/gcr.go
@@ -99,5 +99,5 @@ func (c googleContainerRegistry) Ping() error {
 	if resp != nil {
 		defer resp.Body.Close()
 	}
-	return errors.Trace(err)
+	return errors.Trace(unwrapNetError(err))
 }

--- a/docker/registry/internal/github.go
+++ b/docker/registry/internal/github.go
@@ -80,5 +80,5 @@ func (c githubContainerRegistry) Ping() error {
 	if resp != nil {
 		defer resp.Body.Close()
 	}
-	return err
+	return unwrapNetError(err)
 }

--- a/docker/registry/internal/package_test.go
+++ b/docker/registry/internal/package_test.go
@@ -34,6 +34,7 @@ var (
 	NewElasticContainerRegistryForTest = newElasticContainerRegistryForTest
 	NewAzureContainerRegistry          = newAzureContainerRegistry
 	GetArchitecture                    = getArchitecture
+	UnwrapNetError                     = unwrapNetError
 )
 
 func (c *BaseClient) SetImageRepoDetails(i docker.ImageRepoDetails) {

--- a/docker/registry/internal/quay.go
+++ b/docker/registry/internal/quay.go
@@ -39,5 +39,5 @@ func (c quayContainerRegistry) Ping() error {
 	if resp != nil {
 		defer resp.Body.Close()
 	}
-	return errors.Trace(err)
+	return errors.Trace(unwrapNetError(err))
 }

--- a/docker/registry/internal/transports.go
+++ b/docker/registry/internal/transports.go
@@ -269,6 +269,18 @@ func handleErrorResponse(resp *http.Response) (*http.Response, error) {
 		errNew = errors.Forbiddenf
 	case http.StatusUnauthorized:
 		errNew = errors.Unauthorizedf
+	case http.StatusNotFound:
+		errNew = errors.NotFoundf
 	}
 	return nil, errNew(errMsg)
+}
+
+func unwrapNetError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if neturlErr, ok := err.(*url.Error); ok {
+		return errors.Annotatef(neturlErr.Unwrap(), "%s %q", neturlErr.Op, neturlErr.URL)
+	}
+	return err
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -290,7 +290,6 @@ func bootstrapCAAS(
 		return errors.Trace(err)
 	}
 	podConfig.JujuVersion = jujuVersion
-	podConfig.OfficialBuild = jujuversion.OfficialBuild
 	if err := finalizePodBootstrapConfig(ctx, podConfig, args, environ.Config()); err != nil {
 		return errors.Annotate(err, "finalizing bootstrap instance config")
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -63,6 +63,15 @@ var GitCommit string
 var GitTreeState string = TreeStateDirty
 
 func init() {
+	defer func() {
+		if Current.Build != 0 && OfficialBuild != 0 {
+			panic(fmt.Sprintf("unexpected Build %d and OfficialBuild %d", Current.Build, OfficialBuild))
+		}
+		if Current.Build == 0 {
+			Current.Build = OfficialBuild
+		}
+	}()
+
 	toolsDir := filepath.Dir(os.Args[0])
 	v, err := ioutil.ReadFile(filepath.Join(toolsDir, "FORCE-VERSION"))
 	if err != nil {

--- a/worker/caasupgrader/upgrader.go
+++ b/worker/caasupgrader/upgrader.go
@@ -149,20 +149,10 @@ func (u *Upgrader) loop() error {
 			return err
 		}
 
-		haveVersion := jujuversion.Current
-		if wantVersion.Build == 0 {
-			haveVersion.Build = 0
-		} else {
-			haveVersion.Build = jujuversion.OfficialBuild
-		}
-
-		if wantVersion == haveVersion {
+		if wantVersion == jujuversion.Current {
 			u.config.InitialUpgradeCheckComplete.Unlock()
 			continue
-		} else if !upgrader.AllowedTargetVersion(
-			jujuversion.Current,
-			wantVersion,
-		) {
+		} else if !upgrader.AllowedTargetVersion(jujuversion.Current, wantVersion) {
 			logger.Warningf("desired agent binary version: %s is older than current %s, refusing to downgrade",
 				wantVersion, jujuversion.Current)
 			u.config.InitialUpgradeCheckComplete.Unlock()


### PR DESCRIPTION
The Current.Build and OfficialBuild numbers are confusing and break CaaS models running on an IaaS on our CI tests.
This PR ensures 
1. we can only set either Current.Build or OfficialBuild;
2. Current.Build is the build number we need to check(OfficialBuild is only used for version.go internally);
3. We set the version with build number for CaaS models now which fixes a bug that facades and workers running on controller for CaaS models wrongly use the controller's builder number;

TODO:
I will need to change our CaaS CI tests and edge build Jenkins jobs for this build number logic change.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ JUJU_BUILD_NUMBER=889 make install

$ JUJU_BUILD_NUMBER=889 DOCKER_USERNAME=ycliuhw make push-release-operator-image

$ juju bootstrap microk8s k1

$ juju add-model t1

$ juju deploy hello-kubecon

$ juju deploy cs:~juju/mariadb-k8s-3

$ JUJU_BUILD_NUMBER=999 DOCKER_USERNAME=ycliuhw make push-release-operator-image

$ juju upgrade-controller --agent-stream=develop

$ juju upgrade-model --agent-stream=develop


# gcloud create a gke cluster

$ JUJU_BUILD_NUMBER=1 DOCKER_USERNAME=ycliuhw make push-release-operator-image

$ juju bootstrap aws/ap-southeast-2 k2 --show-log

$ juju add-k8s --gke gke --debug -c k2

$ juju add-model t1 gke

$ juju deploy hello-kubecon

$ juju deploy cs:~juju/mariadb-k8s-3

$ juju upgrade-controller --agent-stream=develop --build-agent

$ JUJU_BUILD_NUMBER=2 DOCKER_USERNAME=ycliuhw make push-release-operator-image

$ juju upgrade-model --agent-stream=develop

```

## Documentation changes

No

## Bug reference

No