### PR TITLE
[JUJU-823] Add log label CMR.

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -14,13 +14,14 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/network"
 	"github.com/juju/juju/rpc/params"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.common.crossmodel")
+var logger = loggo.GetLoggerWithLabels("juju.apiserver.common.crossmodel", corelogger.CMR)
 
 // PublishRelationChange applies the relation change event to the specified backend.
 func PublishRelationChange(backend Backend, relationTag names.Tag, change params.RemoteRelationChangeEvent) error {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -22,12 +22,13 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/life"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
 )
 
-var logger = loggo.GetLogger("juju.apiserver.crossmodelrelations")
+var logger = loggo.GetLoggerWithLabels("juju.apiserver.crossmodelrelations", corelogger.CMR)
 
 type egressAddressWatcherFunc func(facade.Resources, firewall.State, params.Entities) (params.StringsWatchResults, error)
 type relationStatusWatcherFunc func(CrossModelRelationsState, names.RelationTag) (state.StringsWatcher, error)

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
 	"github.com/juju/juju/core/life"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/pki"
 	"github.com/juju/juju/rpc/params"
@@ -278,7 +279,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewControllerConnection:  apicaller.NewExternalControllerConnection,
 			NewRemoteRelationsFacade: remoterelations.NewRemoteRelationsFacade,
 			NewWorker:                remoterelations.NewWorker,
-			Logger:                   config.LoggingContext.GetLogger("juju.worker.remoterelations"),
+			Logger:                   config.LoggingContext.GetLogger("juju.worker.remoterelations", corelogger.CMR),
 		})),
 		stateCleanerName: ifNotMigrating(cleaner.Manifold(cleaner.ManifoldConfig{
 			APICallerName: apiCallerName,

--- a/core/logger/labels.go
+++ b/core/logger/labels.go
@@ -17,4 +17,7 @@ const (
 	// CHARMHUB defines a common label for dealing with the charmhub client
 	// and callers.
 	CHARMHUB Label = "charmhub"
+
+	// CMR defines a common label for dealing with cross model relations.
+	CMR Label = "cmr"
 )

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -39,6 +39,7 @@ type Logger interface {
 	IsTraceEnabled() bool
 
 	Child(string) loggo.Logger
+	ChildWithLabels(name string, labels ...string) loggo.Logger
 }
 
 // ManifoldConfig defines the names of the manifolds on which a

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
@@ -475,9 +476,9 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				u.logger.Child("leadership"),
 			),
 			CreatedRelations: relation.NewCreatedRelationResolver(
-				u.relationStateTracker, u.logger.Child("relation")),
+				u.relationStateTracker, u.logger.ChildWithLabels("relation", corelogger.CMR)),
 			Relations: relation.NewRelationResolver(
-				u.relationStateTracker, u.unit, u.logger.Child("relation")),
+				u.relationStateTracker, u.unit, u.logger.ChildWithLabels("relation", corelogger.CMR)),
 			Storage: storage.NewResolver(
 				u.logger.Child("storage"), u.storage, u.modelType),
 			Commands: runcommands.NewCommandsResolver(


### PR DESCRIPTION
Cross model relations is a complex item in juju. Add a log label tohelp simplify the knowledge necessary to debug it.

Other loggers may be added in the future.  Starting with the ones referenced in https://bugs.launchpad.net/juju/+bug/1965590/comments/2. 

## QA steps

```console
$ juju bootstrap localhost testme
$ juju model-config "logging-config=#cmr=TRACE;<root>=INFO" -m controller
$ juju deploy mysql
$ juju offer mysql:db
$ juju add-model one
$ juju deploy wordpress --series bionic --force
$ juju add-relation wordpress admin/default.mysql
$ juju debug-log -m controller --include-label cmr
... 
machine-0: 13:32:55 DEBUG juju.apiserver.common.crossmodel cmr changed unit tag for unit id 0 is unit-remote-068c6055b6ad4a4c8b9fe9e264003c27-0
...
```

