### PR TITLE
[JUJU-826] fix lxd profile watcher regression

### DIFF
--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/charm/v8"
 
-	"github.com/juju/juju/core/cache"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/status"
@@ -65,12 +64,4 @@ type Charm interface {
 // Application represents point of use methods from the state Application object.
 type Application interface {
 	CharmURL() *charm.URL
-}
-
-// ModelCacheMachine represents a point of use Machine from the cache package.
-type ModelCacheMachine interface {
-	ContainerType() instance.ContainerType
-	IsManual() bool
-	WatchLXDProfileVerificationNeeded() (cache.NotifyWatcher, error)
-	WatchContainers() (cache.StringsWatcher, error)
 }

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
@@ -187,8 +187,11 @@ func (w *machineLXDProfileWatcher) loop() error {
 				}
 			}
 		case <-instanceWatcher.Changes():
-			logger.Tracef("instance changes")
-			w.provisionedChange()
+			id := w.machine.Id()
+			logger.Tracef("instance changes machine-%s", id)
+			if err := w.provisionedChange(); err != nil {
+				return errors.Annotatef(err, "processing change for machine-%s", id)
+			}
 		}
 	}
 }
@@ -534,18 +537,31 @@ func (w *machineLXDProfileWatcher) removeUnit(unitName string) error {
 
 // provisionedChanged notifies when called.  Topic subscribed to is specific to
 // this machine.
-func (w *machineLXDProfileWatcher) provisionedChange() {
+func (w *machineLXDProfileWatcher) provisionedChange() error {
 	// We don't want to respond to any events until we have been fully initialized.
 	select {
 	case <-w.initialized:
 	case <-w.catacomb.Dying():
-		return
+		return nil
 	}
 
 	if w.provisioned {
-		return
+		return nil
 	}
-	w.provisioned = true
+
+	m, err := w.backend.Machine(w.machine.Id())
+	if err != nil {
+		return err
+	}
+	instanceID, err := m.InstanceId()
+	if err != nil {
+		return err
+	}
+	if w.machine.Id() == string(instanceID) {
+		w.provisioned = true
+	}
+
 	logger.Debugf("notifying due to machine-%s now provisioned", w.machine.Id())
 	w.notify()
+	return nil
 }

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/apiserver/facades/agent/instancemutater"
 	"github.com/juju/juju/apiserver/facades/agent/instancemutater/mocks"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
@@ -377,6 +378,8 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherMachineProvisioned(
 	defer s.setup(c).Finish()
 
 	s.setupScenarioWithProfile()
+	s.machine0.EXPECT().InstanceId().Return(instance.Id("0"), nil)
+	s.state.EXPECT().Machine("0").Return(s.machine0, nil)
 	defer workertest.CleanKill(c, s.assertStartLxdProfileWatcher(c))
 
 	s.instanceChanges <- struct{}{}


### PR DESCRIPTION
Creation of an InstanceData doc is not an indication that a machine has been provisioned, instead you must wait for the InstanceID to be specified in the doc.  This different was lost when the lxd profile watcher moved from a model cache watcher to a state watcher.  See bug for details.

## QA steps

Deploy the bundle here: https://people.canonical.com/~heather/1966129-bundle.yaml. Not agents should get stuck waiting for "required charm profile not yet applied to machine".

## Bug reference

https://bugs.launchpad.net/juju/+bug/1966129