### PR TITLE
[JUJU-808] Allow OfficialBuild and Build coexist

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -64,10 +64,8 @@ var GitTreeState string = TreeStateDirty
 
 func init() {
 	defer func() {
-		if Current.Build != 0 && OfficialBuild != 0 {
-			panic(fmt.Sprintf("unexpected Build %d and OfficialBuild %d", Current.Build, OfficialBuild))
-		}
 		if Current.Build == 0 {
+			// We set the Build to OfficialBuild if no build number provided in the FORCE-VERSION file.
 			Current.Build = OfficialBuild
 		}
 	}()


### PR DESCRIPTION
Allow OfficialBuild and Build coexist because CI tests use local tarballed binaries having OfficialBuild set;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ JUJU_BUILD_NUMBER=888 make install

$ juju bootstrap aws/ap-southeast-2 k1

$ juju status --relations --color --storage -m k1:controller

Model       Controller  Cloud/Region        Version     SLA          Timestamp
controller  k1          aws/ap-southeast-2  2.9.27.889  unsupported  16:45:40+11:00

Machine  State    DNS            Inst id              Series  AZ               Message
0        started  13.239.114.40  i-0c82886be5b2095d8  focal   ap-southeast-2a  running

$ juju upgrade-controller --agent-stream=develop --build-agent --debug

$ juju status --relations --color --storage -m k1:controller

Model       Controller  Cloud/Region        Version     SLA          Timestamp
controller  k1          aws/ap-southeast-2  2.9.27.890  unsupported  16:46:47+11:00

Machine  State    DNS            Inst id              Series  AZ               Message
0        started  13.239.114.40  i-0c82886be5b2095d8  focal   ap-southeast-2a  running
```

## Documentation changes

None

## Bug reference

None
