### PR TITLE
[JUJU-834] Cloudconfig: Skip IPv6 link-local in Netplan

### DIFF
--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -162,6 +162,11 @@ func GenerateNetplan(interfaces corenetwork.InterfaceInfos) (string, error) {
 		}
 
 		for _, dns := range info.DNSServers {
+			// Netplan doesn't support IPv6 link-local addresses, so skip them.
+			if strings.HasPrefix(dns.Value, "fe80:") {
+				continue
+			}
+
 			iface.Nameservers.Addresses = append(iface.Nameservers.Addresses, dns.Value)
 		}
 		iface.Nameservers.Search = append(iface.Nameservers.Search, info.DNSSearchDomains...)


### PR DESCRIPTION
From @stgraber via superseded #13879 

Netplan doesn't allow IPv6 link-local addresses in its configuration,
specifically, it doesn't seem to support the '%interface' or '%id'
syntax which is required on such addresses.

As far as I can tell, there is no such limitation to ifupdown which will
then pass that value directly to /etc/resolv.conf, so this fix only
applies to the Netplan generator.

## QA steps

TBC

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1883701
