### PR TITLE
Let application UnitsInfo accept application tags

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -3103,92 +3103,116 @@ func validateAgentVersions(application Application, versioner AgentVersioner) er
 // UnitsInfo isn't on the v11 API.
 func (u *APIv11) UnitsInfo(_, _ struct{}) {}
 
-// UnitsInfo returns unit information.
+// UnitsInfo returns unit information for the given entities (units or
+// applications).
 func (api *APIBase) UnitsInfo(in params.Entities) (params.UnitInfoResults, error) {
-	out := make([]params.UnitInfoResult, len(in.Entities))
+	var results []params.UnitInfoResult
 	leaders, err := api.leadershipReader.Leaders()
 	if err != nil {
 		return params.UnitInfoResults{}, errors.Trace(err)
 	}
-	for i, one := range in.Entities {
-		tag, err := names.ParseUnitTag(one.Tag)
+	for _, one := range in.Entities {
+		units, err := api.unitsFromTag(one.Tag)
 		if err != nil {
-			out[i].Error = apiservererrors.ServerError(err)
+			results = append(results, params.UnitInfoResult{Error: apiservererrors.ServerError(err)})
 			continue
 		}
-		unit, err := api.backend.Unit(tag.Id())
-		if err != nil {
-			out[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-		app, err := api.backend.Application(unit.ApplicationName())
-		if err != nil {
-			out[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-		curl, _ := app.CharmURL()
-		machineId, _ := unit.AssignedMachineId()
-		workloadVersion, err := unit.WorkloadVersion()
-		if err != nil {
-			out[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-
-		result := &params.UnitResult{
-			Tag:             tag.String(),
-			WorkloadVersion: workloadVersion,
-			Machine:         machineId,
-			Charm:           curl.String(),
-		}
-		if leader := leaders[unit.ApplicationName()]; leader == unit.Name() {
-			result.Leader = true
-		}
-		if machineId != "" {
-			machine, err := api.backend.Machine(machineId)
+		for _, unit := range units {
+			result, err := api.unitResultForUnit(unit)
 			if err != nil {
-				out[i].Error = apiservererrors.ServerError(err)
+				results = append(results, params.UnitInfoResult{Error: apiservererrors.ServerError(err)})
 				continue
 			}
-			publicAddress, err := machine.PublicAddress()
-			if err == nil {
-				result.PublicAddress = publicAddress.Value
+			if leader := leaders[unit.ApplicationName()]; leader == unit.Name() {
+				result.Leader = true
 			}
-			// NOTE(achilleasa): this call completely ignores
-			// subnets and lumps all port ranges together in a
-			// single group. This works fine for pre 2.9 agents
-			// as ports where always opened across all subnets.
-			openPorts, err := api.openPortsOnMachineForUnit(unit.Name(), machineId)
-			if err != nil {
-				out[i].Error = apiservererrors.ServerError(err)
-				continue
-			}
-			result.OpenedPorts = openPorts
+			results = append(results, params.UnitInfoResult{Result: result})
 		}
-		container, err := unit.ContainerInfo()
-		if err != nil && !errors.IsNotFound(err) {
-			out[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-		if err == nil {
-			if addr := container.Address(); addr != nil {
-				result.Address = addr.Value
-			}
-			result.ProviderId = container.ProviderId()
-			if len(result.OpenedPorts) == 0 {
-				result.OpenedPorts = container.Ports()
-			}
-		}
-		result.RelationData, err = api.relationData(app, unit)
-		if err != nil {
-			out[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-
-		out[i].Result = result
 	}
 	return params.UnitInfoResults{
-		Results: out,
+		Results: results,
 	}, nil
+}
+
+// Returns the units referred to by the tag argument.  If the tag refers to a
+// unit, a slice with a single unit is returned.  If the tag refers to an
+// application, all the units in the application are returned.
+func (api *APIBase) unitsFromTag(tag string) ([]Unit, error) {
+	unitTag, err := names.ParseUnitTag(tag)
+	if err == nil {
+		unit, err := api.backend.Unit(unitTag.Id())
+		if err != nil {
+			return nil, err
+		}
+		return []Unit{unit}, nil
+	}
+	appTag, err := names.ParseApplicationTag(tag)
+	if err == nil {
+		app, err := api.backend.Application(appTag.Id())
+		if err != nil {
+			return nil, err
+		}
+		return app.AllUnits()
+	}
+	return nil, fmt.Errorf("tag %q is neither unit nor application tag", tag)
+}
+
+// Builds a *params.UnitResult describing the unit argument.
+func (api *APIBase) unitResultForUnit(unit Unit) (*params.UnitResult, error) {
+	app, err := api.backend.Application(unit.ApplicationName())
+	if err != nil {
+		return nil, err
+	}
+	curl, _ := app.CharmURL()
+	machineId, _ := unit.AssignedMachineId()
+	workloadVersion, err := unit.WorkloadVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	result := &params.UnitResult{
+		Tag:             unit.Tag().String(),
+		WorkloadVersion: workloadVersion,
+		Machine:         machineId,
+		Charm:           curl.String(),
+	}
+	if machineId != "" {
+		machine, err := api.backend.Machine(machineId)
+		if err != nil {
+			return nil, err
+		}
+		publicAddress, err := machine.PublicAddress()
+		if err == nil {
+			result.PublicAddress = publicAddress.Value
+		}
+		// NOTE(achilleasa): this call completely ignores
+		// subnets and lumps all port ranges together in a
+		// single group. This works fine for pre 2.9 agents
+		// as ports where always opened across all subnets.
+		openPorts, err := api.openPortsOnMachineForUnit(unit.Name(), machineId)
+		if err != nil {
+			return nil, err
+		}
+		result.OpenedPorts = openPorts
+	}
+	container, err := unit.ContainerInfo()
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	if err == nil {
+		if addr := container.Address(); addr != nil {
+			result.Address = addr.Value
+		}
+		result.ProviderId = container.ProviderId()
+		if len(result.OpenedPorts) == 0 {
+			result.OpenedPorts = container.Ports()
+		}
+	}
+	result.RelationData, err = api.relationData(app, unit)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // openPortsOnMachineForUnit returns the unique set of opened ports for the

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2423,6 +2423,62 @@ func (s *ApplicationSuite) TestUnitsInfo(c *gc.C) {
 	})
 }
 
+func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
+	s.backend.machines = map[string]*mockMachine{"0": {}, "1": {}}
+
+	entities := []params.Entity{{Tag: "application-postgresql"}}
+	result, err := s.api.UnitsInfo(params.Entities{Entities: entities})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results, gc.HasLen, 2)
+	c.Assert(result.Results[0].Error, gc.IsNil)
+	c.Assert(*result.Results[0].Result, gc.DeepEquals, params.UnitResult{
+		Tag:             "unit-postgresql-0",
+		WorkloadVersion: "666",
+		Machine:         "0",
+		OpenedPorts:     []string{"100-102/tcp"},
+		PublicAddress:   "10.0.0.1",
+		Charm:           "cs:postgresql-42",
+		Leader:          true,
+		RelationData: []params.EndpointRelationData{{
+			Endpoint:        "db",
+			CrossModel:      true,
+			RelatedEndpoint: "server",
+			ApplicationData: map[string]interface{}{"app-gitlab": "setting"},
+			UnitRelationData: map[string]params.RelationData{
+				"gitlab/2": {
+					InScope:  true,
+					UnitData: map[string]interface{}{"gitlab/2": "gitlab/2-setting"},
+				},
+			},
+		}},
+		ProviderId: "provider-id",
+		Address:    "192.168.1.1",
+	})
+	c.Assert(*result.Results[1].Result, gc.DeepEquals, params.UnitResult{
+		Tag:             "unit-postgresql-1",
+		WorkloadVersion: "666",
+		Machine:         "1",
+		OpenedPorts:     []string{"100-102/tcp"},
+		PublicAddress:   "10.0.0.1",
+		Charm:           "cs:postgresql-42",
+		Leader:          false,
+		RelationData: []params.EndpointRelationData{{
+			Endpoint:        "db",
+			CrossModel:      true,
+			RelatedEndpoint: "server",
+			ApplicationData: map[string]interface{}{"app-gitlab": "setting"},
+			UnitRelationData: map[string]params.RelationData{
+				"gitlab/2": {
+					InScope:  true,
+					UnitData: map[string]interface{}{"gitlab/2": "gitlab/2-setting"},
+				},
+			},
+		}},
+		ProviderId: "provider-id",
+		Address:    "192.168.1.1",
+	})
+}
+
 func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfied(c *gc.C) {
 	// Define an assumes expression that cannot be satisfied
 	s.backend.charm.meta.Assumes = &assumes.ExpressionTree{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2370,7 +2370,7 @@
                             "$ref": "#/definitions/UnitInfoResults"
                         }
                     },
-                    "description": "UnitsInfo returns unit information."
+                    "description": "UnitsInfo returns unit information for the given entities (units or\napplications)."
                 },
                 "Unset": {
                     "type": "object",


### PR DESCRIPTION
The `UnitsInfo` endpoint of the Application facade currently takes in a list of tags and returns info for the units referred to by these tags.  If a tag does no refer to a unit then this causes an error.  This change extends the set of accepted tags to application tags.  It then returns info for all units in the application.  The idea is that it will allow easy retrieval of all units in an application (or even more than one application).  I am not sure about this approach and the aim of this PR is to get some feedback.

It is a proposed solution to the problem that currently there is no API to find all the units associated with an application.

## Documentation changes

This extends the functionality of the `Application.UnitsInfo` endpoint.  Previously it only accepted unit tags, this change lets it accept application tags.  Given an application tag, it will return all units belonging to the application.
