### PR TITLE
[JUJU-807] Update the openstack base bundle used in the deploy test.

### DIFF
--- a/tests/suites/deploy/bundles/basic-openstack.yaml
+++ b/tests/suites/deploy/bundles/basic-openstack.yaml
@@ -1,0 +1,126 @@
+relations:
+  - - nova-compute:amqp
+    - rabbitmq-server:amqp
+  - - neutron-gateway:amqp
+    - rabbitmq-server:amqp
+  - - keystone:shared-db
+    - mysql:shared-db
+  - - nova-cloud-controller:identity-service
+    - keystone:identity-service
+  - - glance:identity-service
+    - keystone:identity-service
+  - - neutron-api:identity-service
+    - keystone:identity-service
+  - - neutron-openvswitch:neutron-plugin-api
+    - neutron-api:neutron-plugin-api
+  - - neutron-api:shared-db
+    - mysql:shared-db
+  - - neutron-api:amqp
+    - rabbitmq-server:amqp
+  - - neutron-gateway:neutron-plugin-api
+    - neutron-api:neutron-plugin-api
+  - - glance:shared-db
+    - mysql:shared-db
+  - - glance:amqp
+    - rabbitmq-server:amqp
+  - - nova-cloud-controller:image-service
+    - glance:image-service
+  - - nova-compute:image-service
+    - glance:image-service
+  - - nova-cloud-controller:cloud-compute
+    - nova-compute:cloud-compute
+  - - nova-cloud-controller:amqp
+    - rabbitmq-server:amqp
+  - - nova-cloud-controller:quantum-network-service
+    - neutron-gateway:quantum-network-service
+  - - nova-compute:neutron-plugin
+    - neutron-openvswitch:neutron-plugin
+  - - neutron-openvswitch:amqp
+    - rabbitmq-server:amqp
+  - - nova-cloud-controller:shared-db
+    - mysql:shared-db
+  - - nova-cloud-controller:neutron-api
+    - neutron-api:neutron-api
+series: xenial
+applications:
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: cs:glance
+    num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
+      worker-multiplier: 0.25
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: cs:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: cloud:xenial-queens
+      worker-multiplier: 0.25
+  mysql:
+    annotations:
+      gui-x: '0'
+      gui-y: '250'
+    charm: cs:percona-cluster
+    num_units: 1
+    options:
+      max-connections: 20000
+      innodb-buffer-pool-size: 50%
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: cs:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      overlay-network-type: "gre vxlan"
+      openstack-origin: cloud:xenial-queens
+      flat-network-providers: physnet1
+  neutron-gateway:
+    annotations:
+      gui-x: '0'
+      gui-y: '0'
+    charm: cs:neutron-gateway
+    num_units: 1
+    options:
+      openstack-origin: cloud:xenial-queens
+      worker-multiplier: 0.25
+      dns-servers: 10.101.0.1
+  neutron-openvswitch:
+    annotations:
+      gui-x: '250'
+      gui-y: '500'
+    charm: cs:neutron-openvswitch
+    num_units: 0
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: cs:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: cloud:xenial-queens
+      worker-multiplier: 0.25
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: cs:nova-compute
+    num_units: 1
+    options:
+      enable-live-migration: False
+      enable-resize: False
+      openstack-origin: cloud:xenial-queens
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: cs:rabbitmq-server
+    num_units: 1

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -121,19 +121,18 @@ run_deploy_lxd_profile_bundle_openstack() {
 
 	ensure "${model_name}" "${file}"
 
-	bundle=cs:~juju-qa/bundle/basic-openstack-lxd-0
+	bundle=./tests/suites/deploy/bundles/basic-openstack.yaml
 	juju deploy "${bundle}"
 
-	wait_for "mysql" "$(idle_condition "mysql" 3)"
-	wait_for "rabbitmq-server" "$(idle_condition "rabbitmq-server" 9)"
+	wait_for "mysql" "$(idle_condition "mysql" 2)"
+	wait_for "rabbitmq-server" "$(idle_condition "rabbitmq-server" 8)"
 	wait_for "glance" "$(idle_condition "glance" 0)"
 	wait_for "keystone" "$(idle_condition "keystone" 1)"
-	wait_for "neutron-api" "$(idle_condition "neutron-api" 4)"
-	wait_for "neutron-gateway" "$(idle_condition "neutron-gateway" 5)"
-	wait_for "nova-compute" "$(idle_condition "nova-compute" 8)"
-	wait_for "lxd" "$(idle_subordinate_condition "lxd" "nova-compute")"
+	wait_for "neutron-api" "$(idle_condition "neutron-api" 3)"
+	wait_for "neutron-gateway" "$(idle_condition "neutron-gateway" 4)"
+	wait_for "nova-compute" "$(idle_condition "nova-compute" 7)"
 	wait_for "neutron-openvswitch" "$(idle_subordinate_condition "neutron-openvswitch" "nova-compute")"
-	wait_for "nova-cloud-controller" "$(idle_condition "nova-cloud-controller" 7)"
+	wait_for "nova-cloud-controller" "$(idle_condition "nova-cloud-controller" 6)"
 
 	lxd_profile_name="juju-${model_name}-neutron-openvswitch"
 	machine_6="$(machine_path 6)"


### PR DESCRIPTION
The current bundle use the lxd charm. With the change from charmstore to charmhub, compatibility was broken for the lxd charm. It changed from a subordinate to a principle charm. Adding a new version of the bundle and update the test to wait for idle appropriately.

This bundle should be replaced for good moving forward as it usesXenial. There is a core kubernetes bundle, however kubernetes's models do not cleaning tear down today.


## QA steps

```console 
$ (cd tests ; ./main.shdeploy test_deploy_bundles)
```
