### PR TITLE
[JUJU-837] Check for NotProvisioned error instead

### DIFF
--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
@@ -553,13 +553,15 @@ func (w *machineLXDProfileWatcher) provisionedChange() error {
 	if err != nil {
 		return err
 	}
-	instanceID, err := m.InstanceId()
-	if err != nil {
+	_, err = m.InstanceId()
+	if errors.IsNotProvisioned(err) {
+		logger.Debugf("machine-%s not provisioned yet", w.machine.Id())
+		return nil
+	} else if err != nil {
+		logger.Criticalf("%q.provisionedChange error getting instanceID: %s", w.machine.Id(), err)
 		return err
 	}
-	if w.machine.Id() == string(instanceID) {
-		w.provisioned = true
-	}
+	w.provisioned = true
 
 	logger.Debugf("notifying due to machine-%s now provisioned", w.machine.Id())
 	w.notify()


### PR DESCRIPTION
Turns out sneaking in an if err != nil { return err }, lack of caught the static analysis, isn't always a good idea. See #13891.

Returning any error from InstanceId is a bad idea, as the intention is to understand when a machine has been provisioned. If there is not InstanceID, a not provisioned error is returned, which is what provisionedChange cares able. Allow watcher to ignore NotProvisioned errors here.

The PR change needed to be fixed anyway, id will never equal instanceId. This allowed the needed notification to happen, but more notifications about a single machine being provisioned happened than were required.

## QA steps

```console
Deploy the bundle here: https://people.canonical.com/~heather/1966129-bundle.yaml. Not agents should get stuck waiting for "required charm profile not yet applied to machine".
```

## Bug

https://bugs.launchpad.net/juju/+bug/1966129
