### PR TITLE
[JUJU-828] Make `juju refresh` idempotent

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -412,6 +412,12 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	}
 	charmID, err := factory.Run(cfg)
 	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			// Charm already up-to-date - success
+			ctx.Infof("Charm %q (revision %d, channel %s) already up-to-date",
+				c.ApplicationName, c.Revision, c.Channel)
+			return nil
+		}
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 			return errors.Trace(termErr.UserErr())
 		}

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -412,10 +412,9 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	}
 	charmID, err := factory.Run(cfg)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if errors.Is(err, refresher.ErrAlreadyUpToDate) {
 			// Charm already up-to-date - success
-			ctx.Infof("Charm %q (revision %d, channel %s) already up-to-date",
-				c.ApplicationName, c.Revision, c.Channel)
+			ctx.Infof(err.Error())
 			return nil
 		}
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -655,7 +655,8 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 func (s *RefreshSuite) TestSwitchSameURL(c *gc.C) {
 	s.charmAPIClient.charmURL = s.resolvedCharmURL
 	_, err := s.runRefresh(c, "foo", "--switch="+s.resolvedCharmURL.String())
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "foo", revision 2`)
+	// Should not get error since charm already up-to-date
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *RefreshSuite) TestSwitchDifferentRevision(c *gc.C) {

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -22,6 +22,9 @@ import (
 // it is expected to attempt another refresher.
 var ErrExhausted = errors.Errorf("exhausted")
 
+// ErrAlreadyUpToDate indicates a charm is already up-to-date.
+var ErrAlreadyUpToDate = errors.Errorf("already up-to-date")
+
 // RefresherDependencies are required for any deployer to be run.
 type RefresherDependencies struct {
 	Authorizer    store.MacaroonGetter
@@ -288,12 +291,14 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 	}
 	if *newURL == *r.charmURL {
 		if refURL.Revision != -1 {
-			return nil, commoncharm.Origin{}, errors.AlreadyExistsf("already running specified charm %q, revision %d", newURL.Name, newURL.Revision)
+			return nil, commoncharm.Origin{}, errors.Annotatef(ErrAlreadyUpToDate,
+				"charm %q, revision %d", newURL.Name, newURL.Revision)
 		}
 		// No point in trying to upgrade a charm store charm when
 		// we just determined that's the latest revision
 		// available.
-		return nil, commoncharm.Origin{}, errors.AlreadyExistsf("already running latest charm %q", newURL.Name)
+		return nil, commoncharm.Origin{}, errors.Annotatef(ErrAlreadyUpToDate,
+			"charm %q", newURL.Name)
 	}
 	r.logger.Verbosef("Using channel %q", origin.CharmChannel().String())
 	return newURL, origin, nil

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -288,12 +288,12 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 	}
 	if *newURL == *r.charmURL {
 		if refURL.Revision != -1 {
-			return nil, commoncharm.Origin{}, errors.Errorf("already running specified charm %q, revision %d", newURL.Name, newURL.Revision)
+			return nil, commoncharm.Origin{}, errors.AlreadyExistsf("already running specified charm %q, revision %d", newURL.Name, newURL.Revision)
 		}
 		// No point in trying to upgrade a charm store charm when
 		// we just determined that's the latest revision
 		// available.
-		return nil, commoncharm.Origin{}, errors.Errorf("already running latest charm %q", newURL.Name)
+		return nil, commoncharm.Origin{}, errors.AlreadyExistsf("already running latest charm %q", newURL.Name)
 	}
 	r.logger.Verbosef("Using channel %q", origin.CharmChannel().String())
 	return newURL, origin, nil

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -368,7 +368,7 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithNoUpdates(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running latest charm "meshuggah"`)
+	c.Assert(err, gc.ErrorMatches, `charm "meshuggah": already up-to-date`)
 }
 
 func (s *charmStoreCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
@@ -395,7 +395,7 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "meshuggah", revision 1`)
+	c.Assert(err, gc.ErrorMatches, `charm "meshuggah", revision 1: already up-to-date`)
 }
 
 func (s *charmStoreCharmRefresherSuite) TestRefreshWithCharmSwitch(c *gc.C) {
@@ -423,7 +423,7 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithCharmSwitch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "aloupi", revision 1`)
+	c.Assert(err, gc.ErrorMatches, `charm "aloupi", revision 1: already up-to-date`)
 }
 
 type charmHubCharmRefresherSuite struct{}
@@ -520,7 +520,7 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithNoUpdates(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running latest charm "meshuggah"`)
+	c.Assert(err, gc.ErrorMatches, `charm "meshuggah": already up-to-date`)
 }
 
 func (s *charmHubCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
@@ -545,7 +545,7 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "meshuggah", revision 1`)
+	c.Assert(err, gc.ErrorMatches, `charm "meshuggah", revision 1: already up-to-date`)
 }
 
 func (s *charmHubCharmRefresherSuite) TestRefreshWithOriginChannel(c *gc.C) {
@@ -580,7 +580,7 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithOriginChannel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "meshuggah", revision 1`)
+	c.Assert(err, gc.ErrorMatches, `charm "meshuggah", revision 1: already up-to-date`)
 }
 
 func (s *charmHubCharmRefresherSuite) TestRefreshWithCharmSwitch(c *gc.C) {
@@ -618,7 +618,7 @@ func (s *charmHubCharmRefresherSuite) TestRefreshWithCharmSwitch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = task.Refresh()
-	c.Assert(err, gc.ErrorMatches, `already running specified charm "aloupi", revision 1`)
+	c.Assert(err, gc.ErrorMatches, `charm "aloupi", revision 1: already up-to-date`)
 }
 
 func (s *charmHubCharmRefresherSuite) TestAllowed(c *gc.C) {


### PR DESCRIPTION
This PR makes `juju refresh` idempotent - see https://bugs.launchpad.net/juju/+bug/1965902.

We add a new error type `refresher.ErrAlreadyUpToDate`, which indicates a charm is already up-to-date. When the refresh command receives this error, it simply logs it to stdout and continues. The tests have been updated to match.

## QA steps

```sh
# Assuming an existing Juju controller
juju deploy hello-juju
juju refresh hello-juju
```