### PR TITLE
[JUJU-778] Remove bash variable expansion.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ image-check-build-skip:
 docker-builder:
 ## docker-builder: Makes sure that there is a buildx context for building the
 ## oci images
-	@docker buildx create --name ${DOCKER_BUILDX_CONTEXT} || true
+	-@docker buildx create --name ${DOCKER_BUILDX_CONTEXT}
 
 .PHONY: image-check
 operator-image: image-check docker-builder

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -97,7 +97,7 @@ build_push_operator_image() {
       output="-o type=docker"
     fi
 
-    build_multi_osarch=${build_multi_osarch// /,}
+    build_multi_osarch=$(echo $build_multi_osarch | sed 's/ /,/g')
 
     WORKDIR=$(_make_docker_staging_dir)
     cp "${PROJECT_DIR}/caas/Dockerfile" "${WORKDIR}/"


### PR DESCRIPTION
In a Bourne shell file using Bash syntax. Removing this as it was failing in strict conformance mode from Bash.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run `make operator-image`

## Documentation changes

N/A

## Bug reference

N/A
