### PR TITLE
[JUJU-871] Fix occasional race condition in worker/upgradedatabase/worker_test.go

### DIFF
--- a/worker/upgradedatabase/worker.go
+++ b/worker/upgradedatabase/worker.go
@@ -301,6 +301,7 @@ func (w *upgradeDB) watchUpgrade() error {
 		for {
 			select {
 			case <-done:
+				return
 			case <-w.clock.After(5 * time.Second):
 				isPrimary, err := w.pool.IsPrimary(w.tag.Id())
 				if isPrimary || err != nil {


### PR DESCRIPTION
Do this by increasing the timeout

Example of a failure is here: https://jenkins.juju.canonical.com/view/ci-run/job/Unit-RunUnitTests-race-amd64/1186/

Also remove a redundant EXPECT from the same test

Include a flyby bugfix as well, resolving a potential memory leak

## QA steps

Run unit tests in Jenkins multiple times to be confident the test now succeeds

## Documentation changes

N/A

## Bug reference

N/A
