### PR TITLE
[JUJU-796] Drop add-relation in favour of relate

### DIFF
--- a/acceptancetests/assess_block.py
+++ b/acceptancetests/assess_block.py
@@ -101,7 +101,7 @@ def assess_block_all_changes(client, charm_series):
     block_list = client.list_disabled_commands()
     if block_list != make_block_list(client, [client.command_set_all]):
         raise JujuAssertionError(block_list)
-    test_disabled(client, 'add-relation', ('dummy-source', 'dummy-sink'))
+    test_disabled(client, 'relate', ('dummy-source', 'dummy-sink'))
     test_disabled(client, 'unexpose', ('dummy-sink',))
     test_disabled(client, 'remove-application', 'dummy-sink')
     client.enable_command(client.command_set_all)

--- a/acceptancetests/assess_heterogeneous_control.py
+++ b/acceptancetests/assess_heterogeneous_control.py
@@ -37,7 +37,7 @@ def prepare_dummy_env(client):
     client.deploy(charm_sink)
     token = get_random_string()
     client.set_config('dummy-source', {'token': token})
-    client.juju('add-relation', ('dummy-source', 'dummy-sink'))
+    client.juju('relate', ('dummy-source', 'dummy-sink'))
     client.juju('expose', ('dummy-sink',))
     return token
 
@@ -123,7 +123,7 @@ def test_control_heterogeneous(bs_manager, other, upload_tools):
         juju_with_fallback(other, released, 'deploy',
                            (charm_path, 'sink2'))
         other.wait_for_started()
-        other.juju('add-relation', ('dummy-source', 'sink2'))
+        other.juju('relate', ('dummy-source', 'sink2'))
         status = other.get_status()
         other.juju('expose', ('sink2',))
         status = other.get_status()
@@ -136,7 +136,7 @@ def test_control_heterogeneous(bs_manager, other, upload_tools):
                 break
         else:
             raise AssertionError('Sink2 not destroyed')
-        other.juju('add-relation', ('dummy-source', 'dummy-sink'))
+        other.juju('relate', ('dummy-source', 'dummy-sink'))
         status = other.get_status()
         relations = status.get_applications()['dummy-sink']['relations']
         if not relations['source'] == ['dummy-source']:

--- a/acceptancetests/assess_juju_output.py
+++ b/acceptancetests/assess_juju_output.py
@@ -95,7 +95,7 @@ def deploy_charm_with_subordinate_charm(client, series):
     client.deploy(charm_subordinate)
     client.wait_for_started()
     client.set_config('dummy-subordinate', {'token': token})
-    client.juju('add-relation', ('dummy-subordinate', 'dummy-sink'))
+    client.juju('relate', ('dummy-subordinate', 'dummy-sink'))
     client.juju('expose', ('dummy-sink',))
     client.wait_for_workloads()
 

--- a/acceptancetests/assess_mixed_images.py
+++ b/acceptancetests/assess_mixed_images.py
@@ -33,7 +33,7 @@ def assess_mixed_images(client):
     charm_path = local_charm_path(charm='dummy-source',
                                   juju_ver=client.version, series='trusty')
     client.deploy(charm_path)
-    client.juju('add-relation', ('dummy-source', 'dummy-sink'))
+    client.juju('relate', ('dummy-source', 'dummy-sink'))
     # Wait for the deployment to finish.
     client.wait_for_started()
     assess_juju_relations(client)

--- a/acceptancetests/assess_network_health.py
+++ b/acceptancetests/assess_network_health.py
@@ -157,7 +157,7 @@ class AssessNetworkHealth:
 
             app_series = info['series']
             try:
-                client.juju('add-relation',
+                client.juju('relate',
                             (app, 'network-health-{}'.format(app_series)))
             except subprocess.CalledProcessError as e:
                 log.error('Could not relate {0} & network-health due '
@@ -393,7 +393,7 @@ class AssessNetworkHealth:
                 client.deploy('cs:~juju-qa/network-health', alias=alias,
                               series=info['series'])
                 try:
-                    client.juju('add-relation', (app, alias))
+                    client.juju('relate', (app, alias))
                     self.expose_test_charms.add(alias)
                 except subprocess.CalledProcessError as e:
                     log.warning('Could not relate {}, {} due to '

--- a/acceptancetests/assess_upgrade_series.py
+++ b/acceptancetests/assess_upgrade_series.py
@@ -108,7 +108,7 @@ def setup(client, series):
         repository=os.environ['JUJU_REPOSITORY'])
     _, complete_primary = client.deploy(dummy_sink, series=series)
     _, complete_subordinate = client.deploy(dummy_subordinate, series=series)
-    client.juju('add-relation', ('dummy-sink', 'dummy-subordinate'))
+    client.juju('relate', ('dummy-sink', 'dummy-subordinate'))
     client.set_config('dummy-subordinate', {'token': 'Canonical'})
     client.wait_for(complete_primary)
     client.wait_for(complete_subordinate)

--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -109,7 +109,7 @@ def deploy_dummy_stack(client, charm_series, use_charmstore=False):
             platform=platform)
     client.deploy(dummy_source, series=charm_series)
     client.deploy(dummy_sink, series=charm_series)
-    client.juju('add-relation', ('dummy-source', 'dummy-sink'))
+    client.juju('relate', ('dummy-source', 'dummy-sink'))
     client.juju('expose', ('dummy-sink',))
     if client.env.kvm or client.env.maas:
         # A single virtual machine may need up to 30 minutes before

--- a/acceptancetests/jujupy/fake.py
+++ b/acceptancetests/jujupy/fake.py
@@ -908,7 +908,7 @@ class FakeBackend:
                 return (0, CommandTime(command, args))
             if command == 'remove-application':
                 model_state.destroy_service(*args)
-            if command == 'add-relation':
+            if command == 'relate':
                 if args[0] == 'dummy-source':
                     model_state.relations[args[1]] = {'source': [args[0]]}
             if command == 'expose':

--- a/acceptancetests/jujupy/workloads.py
+++ b/acceptancetests/jujupy/workloads.py
@@ -119,15 +119,15 @@ def deploy_simple_server_to_new_model(
         new_model.set_model_constraints(constraints)
     new_model.deploy('cs:nrpe', series=series)
     new_model.deploy('cs:nagios', series=series)
-    new_model.juju('add-relation', ('nrpe:monitors', 'nagios:monitors'))
+    new_model.juju('relate', ('nrpe:monitors', 'nagios:monitors'))
 
     application = deploy_simple_resource_server(
         new_model, resource_contents, series,
     )
     _, deploy_complete = new_model.deploy('cs:ubuntu', series=series)
     new_model.wait_for(deploy_complete)
-    new_model.juju('add-relation', ('nrpe', application))
-    new_model.juju('add-relation', ('nrpe', 'ubuntu'))
+    new_model.juju('relate', ('nrpe', application))
+    new_model.juju('relate', ('nrpe', 'ubuntu'))
     # Need to wait for the subordinate charms too.
     new_model.wait_for(AllApplicationActive(timeout=600))
     new_model.wait_for(AllApplicationWorkloads())

--- a/acceptancetests/repository/charms-centos/dummy-subordinate/README
+++ b/acceptancetests/repository/charms-centos/dummy-subordinate/README
@@ -6,5 +6,5 @@ Deploy dummy-subordinate charm:
 
 juju deploy dummy-sink
 juju deploy dummy-subordinate
-juju add-relation dummy-sink dummy-subordinate
+juju relate dummy-sink dummy-subordinate
 juju config dummy-subordinate token="Canonical"

--- a/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-subordinate/README
+++ b/acceptancetests/repository/charms-centos/dummy-subordinate/dummy-subordinate/README
@@ -6,5 +6,5 @@ Deploy dummy-subordinate charm:
 
 juju deploy dummy-sink
 juju deploy dummy-subordinate
-juju add-relation dummy-sink dummy-subordinate
+juju relate dummy-sink dummy-subordinate
 juju config dummy-subordinate token="Canonical"

--- a/acceptancetests/repository/charms/dummy-sink/README
+++ b/acceptancetests/repository/charms/dummy-sink/README
@@ -1,3 +1,3 @@
 This is a simple workaround to allow jenkins-slave to use a Jenkins in another
 environment.  Typically, you deploy this charm to the same machine as
-jenkins-slave, set master_url to the URL of the actual master and add-relation.
+jenkins-slave, set master_url to the URL of the actual master and relate.

--- a/acceptancetests/repository/charms/dummy-source/README
+++ b/acceptancetests/repository/charms/dummy-source/README
@@ -1,3 +1,3 @@
 This is a simple workaround to allow jenkins-slave to use a Jenkins in another
 environment.  Typically, you deploy this charm to the same machine as
-jenkins-slave, set master_url to the URL of the actual master and add-relation.
+jenkins-slave, set master_url to the URL of the actual master and relate.

--- a/acceptancetests/repository/charms/dummy-subordinate/README
+++ b/acceptancetests/repository/charms/dummy-subordinate/README
@@ -6,5 +6,5 @@ Deploy dummy-subordinate charm:
 
 juju deploy dummy-sink
 juju deploy dummy-subordinate
-juju add-relation dummy-sink dummy-subordinate
+juju relate dummy-sink dummy-subordinate
 juju config dummy-subordinate token="Canonical"

--- a/acceptancetests/repository/charms/jenkins-juju-ci/README.md
+++ b/acceptancetests/repository/charms/jenkins-juju-ci/README.md
@@ -12,5 +12,5 @@ charm. This can be done as follows:
     juju deploy jenkins
     juju deploy jenkins-slave
     juju deploy jenkins-juju-ci
-    juju add-relation jenkins jenkins-slave
-    juju add-relation jenkins-juju-ci jenkins-slave
+    juju relate jenkins jenkins-slave
+    juju relate jenkins-juju-ci jenkins-slave

--- a/acceptancetests/repository/charms/jenkins-slave/README.md
+++ b/acceptancetests/repository/charms/jenkins-slave/README.md
@@ -12,7 +12,7 @@ charm. This can be done as follows:
 
     juju deploy jenkins
     juju deploy -n 5 jenkins-slave
-    juju add-relation jenkins jenkins-slave
+    juju relate jenkins jenkins-slave
 
 There are cases where you want to provision a specific machine that
 provides specific resources for tests, such as CPU architecture or

--- a/acceptancetests/repository/charms/lxd-profile-subordinate/README
+++ b/acceptancetests/repository/charms/lxd-profile-subordinate/README
@@ -6,7 +6,7 @@ Defines a subordinate for the LXD profile.
 
 juju deploy lxd-profile
 juju deploy lxd-profile-subordinate
-juju add-relation lxd-profile-subordinate lxd-profile
+juju relate lxd-profile-subordinate lxd-profile
 
 ## Known Limitations and Issues
 

--- a/acceptancetests/repository/charms/mediawiki/README.md
+++ b/acceptancetests/repository/charms/mediawiki/README.md
@@ -19,7 +19,7 @@ Once bootstrapped, deploy the [MySQL][3] and MediaWiki charm:
 
 Add a relation between the two. Note: To avoid recieving "ambiguous relation" error, specify the "db" relation:
 
-    juju add-relation mysql mediawiki:db
+    juju relate mysql mediawiki:db
 
 Expose the MediaWiki service
 
@@ -34,7 +34,7 @@ deploy memcached:
 
 then relate it to the mediawiki service
 
-    juju add-relation memcached mediawiki
+    juju relate memcached mediawiki
 
 Memcached is recommended for environments with more than one unit deployed. Otherwise there is very little advantage gained by using memcached since 
 MediaWiki will already use whatever byte-code cache is specified in the charm's configuration.
@@ -45,13 +45,13 @@ If you're running MySQL with a slave set up you can attach MediaWiki to those sl
 do this first set up a slave relation with MySQL (If you've already done so skip to the next set of commands):
 
     juju deploy mysql mysql-slave
-    juju add-relation mysql mysql-slave
+    juju relate mysql mysql-slave
 
 Going forward you can scale out MySQL by adding slaves via `juju add-unit mysql-slave`.
 
 Create a relation between the new slave services and MediaWiki:
 
-    juju add-relation mediawiki:slave mysql-slave
+    juju relate mediawiki:slave mysql-slave
 
 ## Known Limitations and Issues
 

--- a/acceptancetests/repository/charms/mysql/README.md
+++ b/acceptancetests/repository/charms/mysql/README.md
@@ -32,7 +32,7 @@ To deploy a slave:
     juju deploy mysql mysql-slave
 
     # add master to slave relation
-    juju add-relation mysql:master mysql-slave:slave
+    juju relate mysql:master mysql-slave:slave
 
 Any changes to the master are reflected on the slave.
 

--- a/acceptancetests/repository/charms/wordpress/README.md
+++ b/acceptancetests/repository/charms/wordpress/README.md
@@ -15,7 +15,7 @@ Once bootstrapped, deploy the MySQL charm then this WordPress charm:
 
 Add a relation between the two of them
 
-    juju add-relation wordpress mysql
+    juju relate wordpress mysql
 
 Expose the WordPress installation
 
@@ -28,7 +28,7 @@ If you're just looking to run a personal blog and want to save money you can run
     juju bootstrap
     juju deploy --to 0 wordpress
     juju deploy --to 0 mysql
-    juju add-relation wordpress mysql 
+    juju relate wordpress mysql 
     juju expose wordpress
 
 This will run everything on one node, however we still have the flexibility to grow horizontally. If your blog gets more traffic and you need to scale:
@@ -46,7 +46,7 @@ You could theoretically then turn off php5-fpm on all of your servers and just h
 wouldn't be able to access the admin panel or any uncached pages - it's just a potential scenario).
 
     juju deploy memcached
-    juju add-relation memcached wordpress
+    juju relate memcached wordpress
     
 This setup will also synchronize the flushing of cache across all WordPress nodes, making it ideal to avoid stale caches.
 
@@ -178,7 +178,7 @@ this writing only the NFS charm will work, but as more shared-fs charms come out
 interface those should all work as well. In this example we'll use NFS:
 
     juju deploy nfs
-    juju add-relation nfs wordpress:nfs
+    juju relate nfs wordpress:nfs
 
 By doing so, everything in the wp-contents directory is moved to this NFS mount and then shared to all future WordPress units. It's strongly
 recommended that you first deploy the nfs mount, _then_ scale WordPress out. Failure to do so may result in data loss. Once nfs is deployed, 

--- a/acceptancetests/repository/trusty/dummy-sink/README
+++ b/acceptancetests/repository/trusty/dummy-sink/README
@@ -1,3 +1,3 @@
 This is a simple workaround to allow jenkins-slave to use a Jenkins in another
 environment.  Typically, you deploy this charm to the same machine as
-jenkins-slave, set master_url to the URL of the actual master and add-relation.
+jenkins-slave, set master_url to the URL of the actual master and relate.

--- a/acceptancetests/repository/trusty/dummy-source/README
+++ b/acceptancetests/repository/trusty/dummy-source/README
@@ -1,3 +1,3 @@
 This is a simple workaround to allow jenkins-slave to use a Jenkins in another
 environment.  Typically, you deploy this charm to the same machine as
-jenkins-slave, set master_url to the URL of the actual master and add-relation.
+jenkins-slave, set master_url to the URL of the actual master and relate.

--- a/acceptancetests/repository/trusty/dummy-subordinate/README
+++ b/acceptancetests/repository/trusty/dummy-subordinate/README
@@ -6,5 +6,5 @@ Deploy dummy-subordinate charm:
 
 juju deploy dummy-sink
 juju deploy dummy-subordinate
-juju add-relation dummy-sink dummy-subordinate
+juju relate dummy-sink dummy-subordinate
 juju config dummy-subordinate token="Canonical"

--- a/acceptancetests/repository/trusty/haproxy/README.md
+++ b/acceptancetests/repository/trusty/haproxy/README.md
@@ -6,7 +6,7 @@ This charm deploys a reverse proxy in front of other servies. You can use this t
 
     juju deploy haproxy
     juju deploy my-web-app
-    juju add-relation my-web-app:website haproxy:reverseproxy
+    juju relate my-web-app:website haproxy:reverseproxy
     juju add-unit my-web-app
     ...
 

--- a/acceptancetests/repository/trusty/jenkins-slave/README.md
+++ b/acceptancetests/repository/trusty/jenkins-slave/README.md
@@ -11,7 +11,7 @@ charm. This can be done as follows:
 
     juju deploy jenkins
     juju deploy -n 5 jenkins-slave
-    juju add-relation jenkins jenkins-slave
+    juju relate jenkins jenkins-slave
 
 There are cases where you want to provision a specific machine that
 provides specific resources for tests, such as CPU architecture or

--- a/acceptancetests/repository/trusty/mysql/README.md
+++ b/acceptancetests/repository/trusty/mysql/README.md
@@ -32,7 +32,7 @@ To deploy a slave:
     juju deploy mysql mysql-slave
 
     # add master to slave relation
-    juju add-relation mysql:master mysql-slave:slave
+    juju relate mysql:master mysql-slave:slave
 
 Any changes to the master are reflected on the slave.
 

--- a/acceptancetests/repository/trusty/wordpress/README.md
+++ b/acceptancetests/repository/trusty/wordpress/README.md
@@ -15,7 +15,7 @@ Once bootstrapped, deploy the MySQL charm then this WordPress charm:
 
 Add a relation between the two of them
 
-    juju add-relation wordpress mysql
+    juju relate wordpress mysql
 
 Expose the WordPress installation
 
@@ -28,7 +28,7 @@ If you're just looking to run a personal blog and want to save money you can run
     juju bootstrap
     juju deploy --to 0 wordpress
     juju deploy --to 0 mysql
-    juju add-relation wordpress mysql 
+    juju relate wordpress mysql 
     juju expose wordpress
 
 This will run everything on one node, however we still have the flexibility to grow horizontally. If your blog gets more traffic and you need to scale:
@@ -46,7 +46,7 @@ You could theoretically then turn off php5-fpm on all of your servers and just h
 wouldn't be able to access the admin panel or any uncached pages - it's just a potential scenario).
 
     juju deploy memcached
-    juju add-relation memcached wordpress
+    juju relate memcached wordpress
     
 This setup will also synchronize the flushing of cache across all WordPress nodes, making it ideal to avoid stale caches.
 
@@ -178,7 +178,7 @@ this writing only the NFS charm will work, but as more shared-fs charms come out
 interface those should all work as well. In this example we'll use NFS:
 
     juju deploy nfs
-    juju add-relation nfs wordpress:nfs
+    juju relate nfs wordpress:nfs
 
 By doing so, everything in the wp-contents directory is moved to this NFS mount and then shared to all future WordPress units. It's strongly
 recommended that you first deploy the nfs mount, _then_ scale WordPress out. Failure to do so may result in data loss. Once nfs is deployed, 

--- a/acceptancetests/repository/xenial/dummy-sink/README
+++ b/acceptancetests/repository/xenial/dummy-sink/README
@@ -1,3 +1,3 @@
 This is a simple workaround to allow jenkins-slave to use a Jenkins in another
 environment.  Typically, you deploy this charm to the same machine as
-jenkins-slave, set master_url to the URL of the actual master and add-relation.
+jenkins-slave, set master_url to the URL of the actual master and relate.

--- a/acceptancetests/repository/xenial/dummy-source/README
+++ b/acceptancetests/repository/xenial/dummy-source/README
@@ -1,3 +1,3 @@
 This is a simple workaround to allow jenkins-slave to use a Jenkins in another
 environment.  Typically, you deploy this charm to the same machine as
-jenkins-slave, set master_url to the URL of the actual master and add-relation.
+jenkins-slave, set master_url to the URL of the actual master and relate.

--- a/acceptancetests/repository/xenial/dummy-subordinate/README
+++ b/acceptancetests/repository/xenial/dummy-subordinate/README
@@ -6,5 +6,5 @@ Deploy dummy-subordinate charm:
 
 juju deploy dummy-sink
 juju deploy dummy-subordinate
-juju add-relation dummy-sink dummy-subordinate
+juju relate dummy-sink dummy-subordinate
 juju config dummy-subordinate token="Canonical"

--- a/acceptancetests/repository/xenial/jenkins-slave/README.md
+++ b/acceptancetests/repository/xenial/jenkins-slave/README.md
@@ -11,7 +11,7 @@ charm. This can be done as follows:
 
     juju deploy jenkins
     juju deploy -n 5 jenkins-slave
-    juju add-relation jenkins jenkins-slave
+    juju relate jenkins jenkins-slave
 
 There are cases where you want to provision a specific machine that
 provides specific resources for tests, such as CPU architecture or

--- a/acceptancetests/repository/xenial/mysql/README.md
+++ b/acceptancetests/repository/xenial/mysql/README.md
@@ -32,7 +32,7 @@ To deploy a slave:
     juju deploy mysql mysql-slave
 
     # add master to slave relation
-    juju add-relation mysql:master mysql-slave:slave
+    juju relate mysql:master mysql-slave:slave
 
 Any changes to the master are reflected on the slave.
 

--- a/acceptancetests/repository/xenial/wordpress/README.md
+++ b/acceptancetests/repository/xenial/wordpress/README.md
@@ -15,7 +15,7 @@ Once bootstrapped, deploy the MySQL charm then this WordPress charm:
 
 Add a relation between the two of them
 
-    juju add-relation wordpress mysql
+    juju relate wordpress mysql
 
 Expose the WordPress installation
 
@@ -28,7 +28,7 @@ If you're just looking to run a personal blog and want to save money you can run
     juju bootstrap
     juju deploy --to 0 wordpress
     juju deploy --to 0 mysql
-    juju add-relation wordpress mysql 
+    juju relate wordpress mysql 
     juju expose wordpress
 
 This will run everything on one node, however we still have the flexibility to grow horizontally. If your blog gets more traffic and you need to scale:
@@ -46,7 +46,7 @@ You could theoretically then turn off php5-fpm on all of your servers and just h
 wouldn't be able to access the admin panel or any uncached pages - it's just a potential scenario).
 
     juju deploy memcached
-    juju add-relation memcached wordpress
+    juju relate memcached wordpress
     
 This setup will also synchronize the flushing of cache across all WordPress nodes, making it ideal to avoid stale caches.
 
@@ -178,7 +178,7 @@ this writing only the NFS charm will work, but as more shared-fs charms come out
 interface those should all work as well. In this example we'll use NFS:
 
     juju deploy nfs
-    juju add-relation nfs wordpress:nfs
+    juju relate nfs wordpress:nfs
 
 By doing so, everything in the wp-contents directory is moved to this NFS mount and then shared to all future WordPress units. It's strongly
 recommended that you first deploy the nfs mount, _then_ scale WordPress out. Failure to do so may result in data loss. Once nfs is deployed, 

--- a/acceptancetests/tests/test_deploy_stack.py
+++ b/acceptancetests/tests/test_deploy_stack.py
@@ -875,7 +875,7 @@ class TestDeployDummyStack(FakeHomeTestCase):
             'juju', '--show-log', 'deploy', '-m', 'foo:foo',
             '/tmp/repo/charms/dummy-sink', '--series', 'bar-'), 1)
         assert_juju_call(self, cc_mock, client, (
-            'juju', '--show-log', 'add-relation', '-m', 'foo:foo',
+            'juju', '--show-log', 'relate', '-m', 'foo:foo',
             'dummy-source', 'dummy-sink'), 2)
         assert_juju_call(self, cc_mock, client, (
             'juju', '--show-log', 'expose', '-m', 'foo:foo', 'dummy-sink'), 3)

--- a/apiserver/embeddedcli_whitelist.go
+++ b/apiserver/embeddedcli_whitelist.go
@@ -8,7 +8,6 @@ package apiserver
 var allowedEmbeddedCommands = []string{
 	"actions",
 	"add-machine",
-	"add-relation",
 	"add-space",
 	"add-storage",
 	"add-subnet",

--- a/cmd/juju/application/addrelation.go
+++ b/cmd/juju/application/addrelation.go
@@ -166,7 +166,7 @@ Examples:
     # Relate a wordpress application with a mysql application hosted within the 
     # "prod" model, using the "automation" user. Facilitate firewall management
     # by specifying the routes used for relation data.
-    juju add-relation wordpress automation/prod.mysql --via 192.168.0.0/16,10.0.0.0/8
+    juju relate wordpress automation/prod.mysql --via 192.168.0.0/16,10.0.0.0/8
 
 
 See also:
@@ -197,8 +197,7 @@ type addRelationCommand struct {
 
 func (c *addRelationCommand) Info() *cmd.Info {
 	addCmd := &cmd.Info{
-		Name:    "add-relation",
-		Aliases: []string{"relate"},
+		Name:    "relate",
 		Args:    "<application>[:<relation>] <application>[:<relation>]",
 		Purpose: "Relate two applications.",
 		Doc:     addRelationDoc,

--- a/cmd/juju/application/addrelation_test.go
+++ b/cmd/juju/application/addrelation_test.go
@@ -66,7 +66,7 @@ func (s *AddRelationSuite) TestAddRelationSuccess(c *gc.C) {
 }
 
 func (s *AddRelationSuite) TestAddRelationFail(c *gc.C) {
-	msg := "fail add-relation call at API"
+	msg := "fail relate call at API"
 	s.mockAPI.SetErrors(errors.New(msg))
 	err := s.runAddRelation(c, "application1", "application2")
 	c.Assert(err, gc.ErrorMatches, msg)

--- a/cmd/juju/application/addremoterelation_test.go
+++ b/cmd/juju/application/addremoterelation_test.go
@@ -167,7 +167,7 @@ func (s *AddRelationValidationSuite) assertInvalidEndpoint(c *gc.C, endpoint, ms
 	c.Assert(err, gc.ErrorMatches, msg)
 }
 
-// baseAddRemoteRelationSuite contains common functionality for add-relation cmd tests
+// baseAddRemoteRelationSuite contains common functionality for relate cmd tests
 // that mock out api client.
 type baseAddRemoteRelationSuite struct {
 	jujutesting.RepoSuite
@@ -206,11 +206,11 @@ func (s *baseAddRemoteRelationSuite) assertFailAddRelationTwoRemoteApplications(
 	c.Assert(err, gc.ErrorMatches, "providing more than one remote endpoints not supported")
 }
 
-// mockAddRelationAPI contains a stub api used for add-relation cmd tests.
+// mockAddRelationAPI contains a stub api used for relate cmd tests.
 type mockAddRelationAPI struct {
 	jtesting.Stub
 
-	// addRelation can be defined by tests to test different add-relation outcomes.
+	// addRelation can be defined by tests to test different relate outcomes.
 	addRelation func(endpoints, viaCidrs []string) (*params.AddRelationResults, error)
 
 	mac *macaroon.Macaroon

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -36,7 +36,7 @@ Examples:
     $ juju consume anothercontroller:owner/othermodel.mysql
 
 See also:
-    add-relation
+    relate
     offer
     remove-saas`[1:]
 

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -613,7 +613,7 @@ attribute of 'gpu=nvidia-tesla-p100':
        twingpu=2,nvidia.com/gpu,gpu=nvidia-tesla-p100
 
 See also:
-    add-relation
+    relate
     add-unit
     config
     expose

--- a/cmd/juju/application/removerelation.go
+++ b/cmd/juju/application/removerelation.go
@@ -54,7 +54,7 @@ at least once - the following examples will all have the same effect:
     juju remove-relation mediawiki:db mariadb
  
 See also: 
-    add-relation
+    relate
     remove-application`
 
 // NewRemoveRelationCommand returns a command to remove a relation between 2 applications.

--- a/cmd/juju/application/resumerelation.go
+++ b/cmd/juju/application/resumerelation.go
@@ -29,7 +29,7 @@ Examples:
     juju resume-relation 123 456
 
 See also: 
-    add-relation
+    relate
     offers
     remove-relation
     suspend-relation`

--- a/cmd/juju/application/suspendrelation.go
+++ b/cmd/juju/application/suspendrelation.go
@@ -31,7 +31,7 @@ Examples:
     juju suspend-relation 123 456 --message "reason for suspending"
 
 See also: 
-    add-relation
+    relate
     offers
     remove-relation
     resume-relation`

--- a/cmd/juju/block/doc.go
+++ b/cmd/juju/block/doc.go
@@ -23,7 +23,6 @@ Commands that can be disabled are grouped based on logical operations as follows
 
 "all" prevents:
     add-machine
-    add-relation
     add-unit
     add-ssh-key
     add-user
@@ -43,6 +42,7 @@ Commands that can be disabled are grouped based on logical operations as follows
     import-ssh-key
     model-defaults
     model-config
+    relate
     reload-spaces
     remove-application
     remove-machine

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -291,7 +291,6 @@ var commandNames = []string{
 	"add-k8s",
 	"add-machine",
 	"add-model",
-	"add-relation",
 	"add-space",
 	"add-ssh-key",
 	"add-storage",
@@ -402,7 +401,7 @@ var commandNames = []string{
 	"refresh",
 	"regions",
 	"register",
-	"relate", //alias for add-relation
+	"relate",
 	"reload-spaces",
 	"remove-application",
 	"remove-cached-images",

--- a/doc/entity-creation.md
+++ b/doc/entity-creation.md
@@ -34,10 +34,10 @@ existing machine without assigned units.
   * New units can only be added to Alive services.
 
 
-juju add-relation
+juju relate
 -----------------
 
-The `juju add-relation` command creates relations, and may -- if the relation
+The `juju relate` command creates relations, and may -- if the relation
 has container scope, by virtue of one or more endpoints having container scope
 -- indirectly cause the creation of subordinate units. Subordinate units are in
 fact created by principal unit agents, at the point when they enter scope of a

--- a/doc/lifecycles.md
+++ b/doc/lifecycles.md
@@ -71,7 +71,7 @@ Units
   * While a principal unit is Alive, it can be assigned to a machine.
   * While a principal unit is Alive, it can enter the scopes of Alive
     relations, which may cause the creation of subordinate units; so,
-    indirectly, `juju add-relation` can also cause the creation of units.
+    indirectly, `juju relate` can also cause the creation of units.
   * A unit can become Dying at any time, but may not become Dead while any unit
     subordinate to it exists, or while the unit is in scope for any relation.
   * A principal unit can become Dying in one of two ways:
@@ -124,7 +124,7 @@ Applications
 Relations
 ---------
 
-  * A relation is created with `juju add-relation`. No two relations with the
+  * A relation is created with `juju relate`. No two relations with the
     same canonical name can exist. (The canonical relation name form is
     "<requirer-endpoint> <provider-endpoint>", where each endpoint takes the
     form "<application-name>:<charm-relation-name>".)

--- a/featuretests/charm_upgrade_test.go
+++ b/featuretests/charm_upgrade_test.go
@@ -49,7 +49,7 @@ func (s *CharmUpgradeSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	unitTwo.SetCharmURL(charmTwo.URL())
 
-	runCommandExpectSuccess(c, "add-relation", s.appOneName, s.appTwoName)
+	runCommandExpectSuccess(c, "relate", s.appOneName, s.appTwoName)
 }
 
 // This test deploys 2 applications with 1 unit each and relates units to each other.

--- a/featuretests/cmd_juju_crossmodel_test.go
+++ b/featuretests/cmd_juju_crossmodel_test.go
@@ -314,7 +314,7 @@ func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, crossmodel.NewOfferCommand(),
 		"mysql:server", "hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = runCommand(c, "add-relation", "wordpress", "admin/controller.hosted-mysql")
+	_, err = runCommand(c, "relate", "wordpress", "admin/controller.hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	svc, err := s.State.RemoteApplication("hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -341,7 +341,7 @@ func (s *crossmodelSuite) TestAddRelationFromURL(c *gc.C) {
 }
 
 func (s *crossmodelSuite) assertAddRelationSameControllerSuccess(c *gc.C, otherModeluser string) {
-	_, err := runCommand(c, "add-relation", "-m", "admin/controller", "wordpress", otherModeluser+"/othermodel.hosted-mysql")
+	_, err := runCommand(c, "relate", "-m", "admin/controller", "wordpress", otherModeluser+"/othermodel.hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := s.State.RemoteApplication("hosted-mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -464,7 +464,7 @@ func (s *crossmodelSuite) TestAddRelationSameControllerPermissionDenied(c *gc.C)
 
 	s.createTestUser(c)
 	s.loginTestUser(c)
-	context, err := runCommand(c, "add-relation", "-m", "admin/controller", "wordpress", "otheruser/othermodel.hosted-mysql")
+	context, err := runCommand(c, "relate", "-m", "admin/controller", "wordpress", "otheruser/othermodel.hosted-mysql")
 	c.Assert(err, gc.NotNil)
 	c.Assert(cmdtesting.Stderr(context), jc.Contains, `application offer "otheruser/othermodel.hosted-mysql" not found`)
 }

--- a/featuretests/cmd_juju_relation_test.go
+++ b/featuretests/cmd_juju_relation_test.go
@@ -31,12 +31,12 @@ func (s *CmdRelationSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CmdRelationSuite) TestAddRelationSuccess(c *gc.C) {
-	runCommandExpectSuccess(c, "add-relation", s.apps...)
+	runCommandExpectSuccess(c, "relate", s.apps...)
 }
 
 func (s *CmdRelationSuite) TestAddRelationSuccessOnAlreadyExists(c *gc.C) {
-	runCommandExpectSuccess(c, "add-relation", s.apps...)
-	context, err := runCommand(c, append([]string{"add-relation"}, s.apps...)...)
+	runCommandExpectSuccess(c, "relate", s.apps...)
+	context, err := runCommand(c, append([]string{"relate"}, s.apps...)...)
 	c.Assert(err, gc.NotNil)
 	c.Check(cmdtesting.Stderr(context), jc.Contains, `ERROR cannot add relation "wordpress:db mysql:server"
 relation wordpress:db mysql:server (already exists): 
@@ -46,7 +46,7 @@ Use 'juju status --relations' to view the current relations.
 }
 
 func (s *CmdRelationSuite) TestRemoveRelationSuccess(c *gc.C) {
-	runCommandExpectSuccess(c, "add-relation", s.apps...)
+	runCommandExpectSuccess(c, "relate", s.apps...)
 	runCommandExpectSuccess(c, "remove-relation", s.apps...)
 }
 

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -105,7 +105,7 @@ func (s *StateSuite) TestAddRelationWithMaxLimit(c *gc.C) {
 	eps, err = s.State.InferEndpoints("wordpress", "mariadb")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.State.AddRelation(eps...)
-	c.Assert(err, jc.Satisfies, errors.IsQuotaLimitExceeded, gc.Commentf("expected second add-relation attempt to fail due to the limit:1 entry in the wordpress charm's metadata.yaml"))
+	c.Assert(err, jc.Satisfies, errors.IsQuotaLimitExceeded, gc.Commentf("expected second relate attempt to fail due to the limit:1 entry in the wordpress charm's metadata.yaml"))
 }
 
 func (s *RelationSuite) TestRetrieveSuccess(c *gc.C) {

--- a/testcharms/charm-repo/quantal/lxd-profile-subordinate-fail/README
+++ b/testcharms/charm-repo/quantal/lxd-profile-subordinate-fail/README
@@ -6,7 +6,7 @@ Defines a invalid subordinate for the LXD profile.
 
 juju deploy lxd-profile
 juju deploy lxd-profile-subordinate-fail
-juju add-relation lxd-profile-subordinate lxd-profile
+juju relate lxd-profile-subordinate lxd-profile
 
 ## Known Limitations and Issues
 

--- a/testcharms/charm-repo/quantal/lxd-profile-subordinate/README
+++ b/testcharms/charm-repo/quantal/lxd-profile-subordinate/README
@@ -6,7 +6,7 @@ Defines a subordinate for the LXD profile.
 
 juju deploy lxd-profile
 juju deploy lxd-profile-subordinate
-juju add-relation lxd-profile-subordinate lxd-profile
+juju relate lxd-profile-subordinate lxd-profile
 
 ## Known Limitations and Issues
 

--- a/tests/suites/cli/block.sh
+++ b/tests/suites/cli/block.sh
@@ -25,7 +25,7 @@ run_block_remove_object() {
 
 	juju deploy ubuntu
 	juju deploy ntp
-	juju add-relation ntp ubuntu
+	juju relate ntp ubuntu
 
 	juju disable-command remove-object
 
@@ -68,13 +68,13 @@ run_block_all() {
 
 	juju enable-ha | grep -q 'the operation has been blocked' || true
 	juju deploy ntp | grep -q 'the operation has been blocked' || true
-	juju add-relation ntp ubuntu | grep -q 'the operation has been blocked' || true
+	juju relate ntp ubuntu | grep -q 'the operation has been blocked' || true
 	juju unexpose ubuntu | grep -q 'the operation has been blocked' || true
 
 	juju enable-command all
 
 	juju deploy ntp
-	juju add-relation ntp ubuntu
+	juju relate ntp ubuntu
 
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "ubuntu" 0)"
 

--- a/tests/suites/deploy/charms/lxd-profile-subordinate/README
+++ b/tests/suites/deploy/charms/lxd-profile-subordinate/README
@@ -6,7 +6,7 @@ Defines a subordinate for the LXD profile.
 
 juju deploy lxd-profile
 juju deploy lxd-profile-subordinate
-juju add-relation lxd-profile-subordinate lxd-profile
+juju relate lxd-profile-subordinate lxd-profile
 
 ## Known Limitations and Issues
 

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -66,7 +66,7 @@ run_deploy_local_lxd_profile_charm() {
 
 	juju deploy ./tests/suites/deploy/charms/lxd-profile --series=bionic
 	juju deploy ./tests/suites/deploy/charms/lxd-profile-subordinate
-	juju add-relation lxd-profile-subordinate lxd-profile
+	juju relate lxd-profile-subordinate lxd-profile
 
 	wait_for "lxd-profile" "$(idle_condition "lxd-profile")"
 	wait_for "lxd-profile-subordinate" ".applications | keys[1]"

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -85,7 +85,7 @@ run_reboot_monitor_state_cleanup() {
 	# Deploy mysql/rsyslog-forwarder-ha. The latter is a subordinate
 	juju deploy mysql
 	juju deploy rsyslog-forwarder-ha
-	juju add-relation rsyslog-forwarder-ha mysql
+	juju relate rsyslog-forwarder-ha mysql
 	wait_for "mysql" "$(idle_condition "mysql")"
 	wait_for "rsyslog-forwarder-ha" "$(idle_subordinate_condition "rsyslog-forwarder-ha" "mysql")"
 

--- a/tests/suites/model/multi.sh
+++ b/tests/suites/model/multi.sh
@@ -31,7 +31,7 @@ deploy_stack() {
 	juju deploy "cs:~juju-qa/dummy-source"
 	juju deploy "cs:~juju-qa/dummy-sink"
 
-	juju add-relation dummy-source dummy-sink
+	juju relate dummy-source dummy-sink
 	juju expose dummy-sink
 
 	wait_for_machine_agent_status 0 "started"

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -15,9 +15,9 @@ run_network_health() {
 	juju deploy 'cs:~juju-qa/network-health' network-health-bionic --series bionic
 	juju deploy 'cs:~juju-qa/network-health' network-health-focal --series focal
 
-	juju add-relation network-health-focal ubuntu-focal
-	juju add-relation network-health-xenial ubuntu-xenial
-	juju add-relation network-health-bionic ubuntu-bionic
+	juju relate network-health-focal ubuntu-focal
+	juju relate network-health-xenial ubuntu-xenial
+	juju relate network-health-bionic ubuntu-bionic
 
 	juju expose network-health-xenial
 	juju expose network-health-bionic


### PR DESCRIPTION
`relate` was originally an alias for `add-relation`. However, we prefer the cleaner `relate` command. Set this to be primary, and drop the `add-relation` command

Also replace `add-relation` with `relate` wherever else it may be found. Keep files and structs named `addRelation` or `AddRelation` for the time being however.

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
$ juju help commands | grep rela
relate                       Relate two applications.
remove-relation              Removes an existing relation between two applications.
resume-relation              Resumes a suspended relation to an application offer.
suspend-relation             Suspends a relation to an application offer.
```

(And all unit tests pass)

## Documentation changes

Adjusting documentation will need to be an ongoing process

## Bug reference

N/A