### PR TITLE
[JUJU-840] instancemutater watch machines and containers individually.

### DIFF
--- a/api/agent/instancemutater/instancemutater.go
+++ b/api/agent/instancemutater/instancemutater.go
@@ -34,10 +34,11 @@ func NewClientFromFacade(facadeCaller base.FacadeCaller) *Client {
 	}
 }
 
-// WatchMachines returns a StringsWatcher reporting changes to machines.
-func (c *Client) WatchMachines() (watcher.StringsWatcher, error) {
+// WatchModelMachines returns a StringsWatcher reporting changes to machines
+// and not containers.
+func (c *Client) WatchModelMachines() (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
-	err := c.facade.FacadeCall("WatchMachines", nil, &result)
+	err := c.facade.FacadeCall("WatchModelMachines", nil, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/agent/instancemutater/instancemutater_test.go
+++ b/api/agent/instancemutater/instancemutater_test.go
@@ -58,10 +58,10 @@ func (s *instanceMutaterSuite) TestWatchMachines(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	api := s.clientForScenario(c,
-		s.expectWatchMachines,
+		s.expectWatchModelMachines,
 		s.expectStringsWatcher,
 	)
-	ch, err := api.WatchMachines()
+	ch, err := api.WatchModelMachines()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// watch for the changes
@@ -78,9 +78,9 @@ func (s *instanceMutaterSuite) TestWatchMachinesServerError(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	api := s.clientForScenario(c,
-		s.expectWatchMachinesWithError,
+		s.expectWatchModelMachinesWithError,
 	)
-	_, err := api.WatchMachines()
+	_, err := api.WatchModelMachines()
 	c.Assert(err, gc.ErrorMatches, "failed")
 }
 
@@ -101,10 +101,10 @@ func (s *instanceMutaterSuite) clientForScenario(c *gc.C, behaviours ...func()) 
 	return instancemutater.NewClient(s.apiCaller)
 }
 
-func (s *instanceMutaterSuite) expectWatchMachines() {
+func (s *instanceMutaterSuite) expectWatchModelMachines() {
 	aExp := s.apiCaller.EXPECT()
 	aExp.BestFacadeVersion("InstanceMutater").Return(1)
-	aExp.APICall("InstanceMutater", 1, "", "WatchMachines", nil, gomock.Any()).Return(nil)
+	aExp.APICall("InstanceMutater", 1, "", "WatchModelMachines", nil, gomock.Any()).Return(nil)
 }
 
 func (s *instanceMutaterSuite) expectStringsWatcher() {
@@ -113,10 +113,10 @@ func (s *instanceMutaterSuite) expectStringsWatcher() {
 	aExp.APICall("StringsWatcher", 1, "", "Next", nil, gomock.Any()).Return(nil).MinTimes(1)
 }
 
-func (s *instanceMutaterSuite) expectWatchMachinesWithError() {
+func (s *instanceMutaterSuite) expectWatchModelMachinesWithError() {
 	aExp := s.apiCaller.EXPECT()
 	aExp.BestFacadeVersion("InstanceMutater").Return(1)
-	aExp.APICall("InstanceMutater", 1, "", "WatchMachines", nil, gomock.Any()).Return(errors.New("failed"))
+	aExp.APICall("InstanceMutater", 1, "", "WatchModelMachines", nil, gomock.Any()).Return(errors.New("failed"))
 }
 
 func (s *instanceMutaterSuite) expectNotifyWatcher() {

--- a/api/agent/instancemutater/machine.go
+++ b/api/agent/instancemutater/machine.go
@@ -20,8 +20,7 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/caller_mock.go github.com/juju/juju/api/base APICaller,FacadeCaller
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/instancemutater MutaterMachine
+// MutatorMachine represents the machine methods required for the instancemutater.
 type MutaterMachine interface {
 
 	// InstanceId returns the provider specific instance id for this machine
@@ -211,6 +210,8 @@ func (m *Machine) WatchContainers() (watcher.StringsWatcher, error) {
 	return apiwatcher.NewStringsWatcher(m.facade.RawAPICaller(), result), nil
 }
 
+// UnitProfileInfo is data required by the instancemutater to determine what
+// any changes are required to a machine's lxd profiles.
 type UnitProfileInfo struct {
 	ModelName       string
 	InstanceId      instance.Id
@@ -218,6 +219,8 @@ type UnitProfileInfo struct {
 	CurrentProfiles []string
 }
 
+// UnitProfileChanges provides the application name, revision and profile of
+// the current charm referenced by this application.
 type UnitProfileChanges struct {
 	ApplicationName string
 	Revision        int

--- a/api/agent/instancemutater/package_test.go
+++ b/api/agent/instancemutater/package_test.go
@@ -9,6 +9,9 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/caller_mock.go github.com/juju/juju/api/base APICaller,FacadeCaller
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/machinemutater_mock.go github.com/juju/juju/api/agent/instancemutater MutaterMachine
+
 func TestAll(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -61,7 +61,7 @@ var facadeVersions = map[string]int{
 	"ImageManager":                 2,
 	"ImageMetadata":                3,
 	"ImageMetadataManager":         1,
-	"InstanceMutater":              2,
+	"InstanceMutater":              3,
 	"InstancePoller":               4,
 	"KeyManager":                   1,
 	"KeyUpdater":                   1,

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -612,6 +612,35 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) setup(c *gc.C) *gomock.Controller
 	return ctrl
 }
 
+func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchModelMachines(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.expectAuthMachineAgent()
+	s.expectAuthController()
+	s.expectWatchModelMachinesWithNotify(1)
+	facade := s.facadeAPIForScenario(c)
+
+	result, err := facade.WatchModelMachines()
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{
+		StringsWatcherId: "1",
+		Changes:          []string{"0"},
+	})
+	s.assertNotifyStop(c)
+}
+
+func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchModelMachinesWithClosedChannel(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.expectAuthMachineAgent()
+	s.expectAuthController()
+	s.expectWatchModelMachinesWithClosedChannel()
+	facade := s.facadeAPIForScenario(c)
+
+	_, err := facade.WatchModelMachines()
+	c.Assert(err, gc.ErrorMatches, "cannot obtain initial model machines")
+}
+
 func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchMachines(c *gc.C) {
 	defer s.setup(c).Finish()
 
@@ -619,8 +648,9 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchMachines(c *gc.C) {
 	s.expectAuthController()
 	s.expectWatchMachinesWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
+	facadev2 := &instancemutater.InstanceMutaterAPIV2{facade}
 
-	result, err := facade.WatchMachines()
+	result, err := facadev2.WatchMachines()
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{
 		StringsWatcherId: "1",
@@ -636,8 +666,9 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchMachinesWithClosedChanne
 	s.expectAuthController()
 	s.expectWatchMachinesWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
+	facadev2 := &instancemutater.InstanceMutaterAPIV2{facade}
 
-	_, err := facade.WatchMachines()
+	_, err := facadev2.WatchMachines()
 	c.Assert(err, gc.ErrorMatches, "cannot obtain initial model machines")
 }
 
@@ -660,11 +691,34 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) expectWatchMachinesWithNotify(tim
 	s.resources.EXPECT().Register(s.watcher).Return("1")
 }
 
+func (s *InstanceMutaterAPIWatchMachinesSuite) expectWatchModelMachinesWithNotify(times int) {
+	ch := make(chan []string)
+
+	go func() {
+		for i := 0; i < times; i++ {
+			ch <- []string{fmt.Sprintf("%d", i)}
+		}
+		close(s.notifyDone)
+	}()
+
+	s.state.EXPECT().WatchModelMachines().Return(s.watcher)
+	s.watcher.EXPECT().Changes().Return(ch)
+	s.resources.EXPECT().Register(s.watcher).Return("1")
+}
+
 func (s *InstanceMutaterAPIWatchMachinesSuite) expectWatchMachinesWithClosedChannel() {
 	ch := make(chan []string)
 	close(ch)
 
 	s.state.EXPECT().WatchMachines().Return(s.watcher)
+	s.watcher.EXPECT().Changes().Return(ch)
+}
+
+func (s *InstanceMutaterAPIWatchMachinesSuite) expectWatchModelMachinesWithClosedChannel() {
+	ch := make(chan []string)
+	close(ch)
+
+	s.state.EXPECT().WatchModelMachines().Return(s.watcher)
 	s.watcher.EXPECT().Changes().Return(ch)
 }
 

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -26,6 +26,7 @@ type InstanceMutaterState interface {
 	ControllerTimestamp() (*time.Time, error)
 
 	WatchMachines() state.StringsWatcher
+	WatchModelMachines() state.StringsWatcher
 	WatchApplicationCharms() state.StringsWatcher
 	WatchCharms() state.StringsWatcher
 	WatchUnits() state.StringsWatcher

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -226,6 +226,20 @@ func (mr *MockInstanceMutaterStateMockRecorder) WatchMachines() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchMachines", reflect.TypeOf((*MockInstanceMutaterState)(nil).WatchMachines))
 }
 
+// WatchModelMachines mocks base method.
+func (m *MockInstanceMutaterState) WatchModelMachines() state.StringsWatcher {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchModelMachines")
+	ret0, _ := ret[0].(state.StringsWatcher)
+	return ret0
+}
+
+// WatchModelMachines indicates an expected call of WatchModelMachines.
+func (mr *MockInstanceMutaterStateMockRecorder) WatchModelMachines() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchModelMachines", reflect.TypeOf((*MockInstanceMutaterState)(nil).WatchModelMachines))
+}
+
 // WatchUnits mocks base method.
 func (m *MockInstanceMutaterState) WatchUnits() state.StringsWatcher {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/agent/instancemutater/register.go
+++ b/apiserver/facades/agent/instancemutater/register.go
@@ -16,15 +16,27 @@ func Register(registry facade.FacadeRegistry) {
 	}, reflect.TypeOf((*InstanceMutaterAPIV1)(nil)))
 	registry.MustRegister("InstanceMutater", 2, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV2(ctx)
+	}, reflect.TypeOf((*InstanceMutaterAPIV2)(nil)))
+	registry.MustRegister("InstanceMutater", 3, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV3(ctx)
 	}, reflect.TypeOf((*InstanceMutaterAPI)(nil)))
 }
 
-// newFacadeV2 is used for API registration.
-func newFacadeV2(ctx facade.Context) (*InstanceMutaterAPI, error) {
+// newFacadeV3 is used for API registration.
+func newFacadeV3(ctx facade.Context) (*InstanceMutaterAPI, error) {
 	st := &instanceMutaterStateShim{State: ctx.State()}
 
 	watcher := &instanceMutatorWatcher{st: st}
 	return NewInstanceMutaterAPI(st, watcher, ctx.Resources(), ctx.Auth())
+}
+
+// newFacadeV2 is used for API registration.
+func newFacadeV2(ctx facade.Context) (*InstanceMutaterAPIV2, error) {
+	v3, err := newFacadeV3(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &InstanceMutaterAPIV2{v3}, nil
 }
 
 // newFacadeV1 is used for API registration.

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -25569,7 +25569,7 @@
     {
         "Name": "InstanceMutater",
         "Description": "",
-        "Version": 2,
+        "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent"
@@ -25661,14 +25661,14 @@
                     },
                     "description": "WatchLXDProfileVerificationNeeded starts a watcher to track Applications with\nLXD Profiles."
                 },
-                "WatchMachines": {
+                "WatchModelMachines": {
                     "type": "object",
                     "properties": {
                         "Result": {
                             "$ref": "#/definitions/StringsWatchResult"
                         }
                     },
-                    "description": "WatchMachines starts a watcher to track machines.\nWatchMachines does not consume the initial event of the watch response, as\nthat returns the initial set of machines that are currently available."
+                    "description": "WatchModelMachines starts a watcher to track machines, but not containers.\nWatchModelMachines does not consume the initial event of the watch response, as\nthat returns the initial set of machines that are currently available."
                 }
             },
             "definitions": {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -1010,7 +1010,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			BrokerName:    brokerTrackerName,
-			Logger:        loggo.GetLogger("juju.worker.instancemutater"),
+			Logger:        loggo.GetLogger("juju.worker.instancemutater.container"),
 			NewClient:     instancemutater.NewClient,
 			NewWorker:     instancemutater.NewContainerWorker,
 		})),

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -452,7 +452,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
 			EnvironName:   environTrackerName,
-			Logger:        config.LoggingContext.GetLogger("juju.worker.instancemutater"),
+			Logger:        config.LoggingContext.GetLogger("juju.worker.instancemutater.environ"),
 			NewClient:     instancemutater.NewClient,
 			NewWorker:     instancemutater.NewEnvironWorker,
 		})),

--- a/worker/instancemutater/export_test.go
+++ b/worker/instancemutater/export_test.go
@@ -5,11 +5,12 @@ package instancemutater
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	worker "github.com/juju/worker/v3"
+
 	"github.com/juju/juju/api/agent/instancemutater"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/environs"
-	"github.com/juju/names/v4"
-	worker "github.com/juju/worker/v3"
 )
 
 func NewMachineContext(
@@ -35,7 +36,7 @@ func NewMachineContext(
 }
 
 func NewEnvironTestWorker(config Config, ctxFn RequiredMutaterContextFunc) (worker.Worker, error) {
-	config.GetMachineWatcher = config.Facade.WatchMachines
+	config.GetMachineWatcher = config.Facade.WatchModelMachines
 	config.GetRequiredLXDProfiles = func(modelName string) []string {
 		return []string{"default", "juju-" + modelName}
 	}

--- a/worker/instancemutater/mocks/instancebroker_mock.go
+++ b/worker/instancemutater/mocks/instancebroker_mock.go
@@ -51,17 +51,17 @@ func (mr *MockInstanceMutaterAPIMockRecorder) Machine(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).Machine), arg0)
 }
 
-// WatchMachines mocks base method.
-func (m *MockInstanceMutaterAPI) WatchMachines() (watcher.StringsWatcher, error) {
+// WatchModelMachines mocks base method.
+func (m *MockInstanceMutaterAPI) WatchModelMachines() (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchMachines")
+	ret := m.ctrl.Call(m, "WatchModelMachines")
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchMachines indicates an expected call of WatchMachines.
-func (mr *MockInstanceMutaterAPIMockRecorder) WatchMachines() *gomock.Call {
+// WatchModelMachines indicates an expected call of WatchModelMachines.
+func (mr *MockInstanceMutaterAPIMockRecorder) WatchModelMachines() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchMachines", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).WatchMachines))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchModelMachines", reflect.TypeOf((*MockInstanceMutaterAPI)(nil).WatchModelMachines))
 }

--- a/worker/instancemutater/worker.go
+++ b/worker/instancemutater/worker.go
@@ -19,7 +19,7 @@ import (
 )
 
 type InstanceMutaterAPI interface {
-	WatchMachines() (watcher.StringsWatcher, error)
+	WatchModelMachines() (watcher.StringsWatcher, error)
 	Machine(tag names.MachineTag) (instancemutater.MutaterMachine, error)
 }
 
@@ -110,7 +110,7 @@ func (config Config) Validate() error {
 // the machines in the state and polls their instance
 // for addition or removal changes.
 func NewEnvironWorker(config Config) (worker.Worker, error) {
-	config.GetMachineWatcher = config.Facade.WatchMachines
+	config.GetMachineWatcher = config.Facade.WatchModelMachines
 	config.GetRequiredLXDProfiles = func(modelName string) []string {
 		return []string{"default", "juju-" + modelName}
 	}

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -527,7 +527,7 @@ func (s *workerSuite) notifyMachines(values [][]string) {
 	s.machinesWorker.EXPECT().Kill().AnyTimes()
 	s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
 
-	s.facade.EXPECT().WatchMachines().Return(
+	s.facade.EXPECT().WatchModelMachines().Return(
 		&fakeStringsWatcher{
 			Worker: s.machinesWorker,
 			ch:     ch,
@@ -548,7 +548,7 @@ func (s *workerSuite) notifyMachinesWaitGroup(values [][]string, group *sync.Wai
 	s.machinesWorker.EXPECT().Kill().AnyTimes()
 	s.machinesWorker.EXPECT().Wait().Return(nil).AnyTimes()
 
-	s.facade.EXPECT().WatchMachines().Return(
+	s.facade.EXPECT().WatchModelMachines().Return(
 		&fakeStringsWatcher{
 			Worker: s.machinesWorker,
 			ch:     ch,


### PR DESCRIPTION
instancemutater.NewEnvironWorker works with LXD environ machines on per model basis. It should only watch machines not containers, switch from WatchMachines to WatchModelMachines.

instancemutater.NewContainerWorker works with LXD containers on a per machine basis, where the machine supports LXD.

Previously, both the container and environ workers were watching 0/lxd/0, depending on timing, the environ worker would try to apply an empty profile, as the function to find the data returned not found.  It would then set the machine's modification status to Error, causing the entire machine to go into an error.

## QA steps

```console
$ juju bootstrap localhost
$ juju deploy kubernetes-core
# Watch the model as it provisions.  0/lxd/ should not fail with:  cannot upgrade machine's lxd profile: 0/lxd/0: Not Found

Run the test with a upgraded controller and older model to ensure compatibility.
```
