### PR TITLE
`model-config` filepaths must be explicit

### DIFF
--- a/cmd/juju/model/config_test.go
+++ b/cmd/juju/model/config_test.go
@@ -63,7 +63,7 @@ func (s *ConfigCommandSuite) TestInit(c *gc.C) {
 		}, {
 			desc:       "get multiple fails",
 			args:       []string{"one", "two"},
-			errorMatch: "can only retrieve a single value, or all values",
+			errorMatch: `arg "one" is not a key-value pair or a filename`,
 		}, {
 			// test variations
 			desc:   "test reset interspersed",


### PR DESCRIPTION
This is a remedial fix to [bug/1946043](https://bugs.launchpad.net/juju/+bug/1946043), so that `model-config` will now only accept an argument as a filepath if it is prefixed by `/`, `./`, `../` or `~/`.

In 3.0, `model-config` will no longer accept a yaml file as a primary argument - they will need to be specified using the `--file` flag, as is currently the case with `juju config`.

## QA steps

```sh
mkdir elmo
juju model-config elmo=test
juju model-config elmo
```

should give `test` rather than `ERROR read $CWD/elmo: is a directory`