### PR TITLE
[JUJU-845] Bring in new juju/replicaset to fix member address updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/juju/proxy v0.0.0-20220207021845-4d37a2e6a78f
 	github.com/juju/pubsub/v2 v2.0.0-20220207005728-39d68caef4a7
 	github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441
-	github.com/juju/replicaset/v2 v2.0.1-0.20220207005755-f1b225b4be6e
+	github.com/juju/replicaset/v2 v2.0.1-0.20220330042111-ec94259ca14f
 	github.com/juju/retry v0.0.0-20220204093819-62423bf33287
 	github.com/juju/rfc/v2 v2.0.0-20220207021814-ffb92bc8e9eb
 	github.com/juju/romulus v0.0.0-20220207004956-1a3bcf86b836

--- a/go.sum
+++ b/go.sum
@@ -532,8 +532,8 @@ github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5 h1:+eWzUG6XLDSdcz
 github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5/go.mod h1:F7wHQBX+lEJkv9PhNCgNJgCeI+GISZW2RefLINbmgXU=
 github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441 h1:b5Jqi7ir58EzfeZDyp7OSYQG/IVgyY4JWfHuJUF2AZI=
 github.com/juju/ratelimit v1.0.2-0.20191002062651-f60b32039441/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
-github.com/juju/replicaset/v2 v2.0.1-0.20220207005755-f1b225b4be6e h1:5sdKaq/34vhXlDqHgjo0cw9huX/TLgTjEq/3DvFXTzc=
-github.com/juju/replicaset/v2 v2.0.1-0.20220207005755-f1b225b4be6e/go.mod h1:/PYyLYquusxFcgHA7TE1j+3agse+CIh7DWwiuYyWr5c=
+github.com/juju/replicaset/v2 v2.0.1-0.20220330042111-ec94259ca14f h1:WVVCaXqsfulFhzJNiGiQZ9Og1WwfGYUOUU096CKIlIg=
+github.com/juju/replicaset/v2 v2.0.1-0.20220330042111-ec94259ca14f/go.mod h1:Mje4O+NYfZYzJKPcIVJcHQ62b63Y3T+qNXqocm4gxz0=
 github.com/juju/retry v0.0.0-20151029024821-62c620325291/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v0.0.0-20180821225755-9058e192b216/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v0.0.0-20220204093819-62423bf33287 h1:U+7oMWEglXfiikIppNexButZRwKPlzLBGKYSNCXzXf8=


### PR DESCRIPTION
When updating a replicaset member's address, the member Id needs to stay the same. The upstream `juju/replicaset` had a bug where a new Id was being used for such updates. This broke the scenario in the bug, where a multi-nic controller had a the `juju-ha-space` after bootstrap, causing a replicaset update of a single member. 

## QA steps

Configure lxd to bring up multiple NICs. Bootstrap a lxd controller with "juju.replicaset=DEBUG"
```
juju show-machine 0
...
    network-interfaces:
      eth0:
        ip-addresses:
        - 10.46.214.150
        mac-address: 00:16:3e:c6:92:53
        space: alpha
        is-up: true
      eth1:
        ip-addresses:
        - 10.40.149.66
        mac-address: 00:16:3e:0b:88:9e
        space: alpha
        is-up: true
      eth2:
        ip-addresses:
        - 10.248.35.126
        mac-address: 00:16:3e:e3:fd:d8
        gateway: 10.248.35.1
        space: ha
        is-up: true
    hardware: arch=amd64 cores=0 mem=0M
    controller-member-status: has-vote
```

Set up a new "ha" space for one of the subnets
```
juju add-space ha 10.248.35.126/24
juju spaces
Name   Space ID  Subnets       
alpha  0         10.40.149.0/24
                 10.46.214.0/24
                 172.17.0.0/16 
ha     3         10.248.35.0/24
```

Configure the controller to use the new space for mongo
```
juju controller-config juju-ha-space=ha
juju show-controller
```

Look at the logs to see the mongo replicaset config change

```
DEBUG juju.replicaset current replicaset config: {
  Name: juju,
  Version: 1,
  Term: 2,
  Protocol Version: 1,
  Members: {
    {1 "10.46.214.150:37017" juju-machine-id:0 voting},
  },
}
...
- updated:
"    {1 "10.248.35.126:37017" juju-machine-id:0 voting},"
- added:

- removed: []
...
DEBUG juju.replicaset current replicaset config: {
  Name: juju,
  Version: 2,
  Term: 2,
  Protocol Version: 1,
  Members: {
    {1 "10.248.35.126:37017" juju-machine-id:0 voting},
  },
}

```

Then do `enable-ha -n 5` and check `show-controller` output that all 5 HA nodes are enabled.
Remove one of the nodes and check again that one of the nodes becomes non-voting.
Remove one of the other nodes and check the non-voting node becomes voting for a 3 HA setup.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1966983
