### PR TITLE
[JUJU-851] Avoid Running no-op transactions. 

### DIFF
--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -354,7 +354,7 @@ func (m *Model) UpdateModelConfig(updateAttrs map[string]interface{}, removeAttr
 			return errors.Trace(err)
 		}
 		for _, attr := range removeAttrs {
-			// We we are updating an attribute, that takes
+			// We are updating an attribute, that takes
 			// precedence over removing.
 			if _, ok := updateAttrs[attr]; ok {
 				continue
@@ -404,7 +404,10 @@ func (m *Model) UpdateModelConfig(updateAttrs map[string]interface{}, removeAttr
 
 	modelSettings.Update(validAttrs)
 	_, ops := modelSettings.settingsUpdateOps()
-	return modelSettings.write(ops)
+	if len(ops) > 0 {
+		return modelSettings.write(ops)
+	}
+	return nil
 }
 
 type modelConfigSourceFunc func() (attrValues, error)


### PR DESCRIPTION
Check the operations slice length first. Found during qa of #13888. 

machine-0: 17:22:40 WARNING juju.state Running no-op transaction - called by /home/heather/work-test/src/github.com/juju/juju/state/database.go:406 /home/heather/work-test/src/github.com/juju/juju/state/settings.go:193 /home/heather/work-test/src/github.com/juju/juju/state/modelconfig.go:399 /home/heather/work-test/src/github.com/juju/juju/apiserver/facades/client/modelconfig/backend.go:34 ....
