### PR TITLE
[JUJU-852] Add assumes to kubernetes test charm metadata.yaml

### DIFF
--- a/apiserver/common/charms/charminfo_test.go
+++ b/apiserver/common/charms/charminfo_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/charm/v8"
+	"github.com/juju/charm/v8/assumes"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -109,6 +110,14 @@ func (s *charmInfoSuite) TestClientCharmInfoCAAS(c *gc.C) {
 						},
 					},
 					MinJujuVersion: "0.0.0",
+					AssumesExpr: &assumes.ExpressionTree{
+						Expression: assumes.CompositeExpression{
+							ExprType: assumes.AllOfExpression,
+							SubExpressions: []assumes.Expression{
+								assumes.FeatureExpression{Name: "k8s-api"},
+							},
+						},
+					},
 				},
 				Actions: &params.CharmActions{},
 			},
@@ -394,13 +403,6 @@ func (s *charmInfoSuite) TestClientCharmInfo(c *gc.C) {
 							Role:      "provider",
 							Interface: "roach",
 							Scope:     "global",
-						},
-					},
-					Resources: map[string]params.CharmResourceMeta{
-						"cockroachdb-image": {
-							Name:        "cockroachdb-image",
-							Type:        "oci-image",
-							Description: "OCI image used for cockroachdb",
 						},
 					},
 					MinJujuVersion: "0.0.0",

--- a/testcharms/charm-repo/focal/cockroach-container-less/README.md
+++ b/testcharms/charm-repo/focal/cockroach-container-less/README.md
@@ -2,16 +2,12 @@
 
 ## Description
 
-A non-container-based V2 metadata kubernetes charm to use in testing juju.
+A non-container-based V2 metadata charm to use in testing juju.
 
 ## Deployment
-
-Pull a cockroachdb image to be used from https://hub.docker.com/r/cockroachdb/cockroach/tags:
-
-<code>docker pull cockroachdb/cockroach:v21.2.7</code>
 
 Deploy the local charm
 
 <code>
-juju deploy ./testcharms/charm-repo/focal/cockroach-container-less --resource cockroachdb-image=cockroachdb/cockroach:v21.2.7
+juju deploy ./testcharms/charm-repo/focal/cockroach-container-less
 </code>

--- a/testcharms/charm-repo/focal/cockroach-container-less/README.md
+++ b/testcharms/charm-repo/focal/cockroach-container-less/README.md
@@ -1,0 +1,17 @@
+# cockroachdb
+
+## Description
+
+A non-container-based V2 metadata kubernetes charm to use in testing juju.
+
+## Deployment
+
+Pull a cockroachdb image to be used from https://hub.docker.com/r/cockroachdb/cockroach/tags:
+
+<code>docker pull cockroachdb/cockroach:v21.2.7</code>
+
+Deploy the local charm
+
+<code>
+juju deploy ./testcharms/charm-repo/focal/cockroach-container-less --resource cockroachdb-image=cockroachdb/cockroach:v21.2.7
+</code>

--- a/testcharms/charm-repo/focal/cockroach-container-less/hooks/start
+++ b/testcharms/charm-repo/focal/cockroach-container-less/hooks/start
@@ -2,13 +2,6 @@
 set -v
 juju-log -l WARN "Running start hook script"
 
-while ! curl -f http://localhost:4321/ ; do
-    juju-log -l WARN "Waiting for workload container"
-    sleep 1
-done
-
-curl -f -d 'cockroach start --insecure --listen-addr=0.0.0.0:26257 --http-addr=0.0.0.0:8080 --store /cockroach/cockroach-data' http://127.0.0.1:4321/
-
 sleep 5
 
 if is-leader; then
@@ -16,8 +9,6 @@ if is-leader; then
         juju-log -l WARN "Database already initialized"
     else
         juju-log -l WARN "Initializing database"
-        #cockroach init --insecure"
-        ssh 127.0.0.1 -p 4322 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no cockroach sql --insecure '--execute="CREATE DATABASE database;"'
         leader-set init="true"
     fi
 else

--- a/testcharms/charm-repo/focal/cockroach-container-less/hooks/stop
+++ b/testcharms/charm-repo/focal/cockroach-container-less/hooks/stop
@@ -1,4 +1,3 @@
 #!/bin/bash
 juju-log -l WARN "Running stop hook script"
-kill $(cat /run/roach.pid)
 exit 0

--- a/testcharms/charm-repo/focal/cockroach-container-less/metadata.yaml
+++ b/testcharms/charm-repo/focal/cockroach-container-less/metadata.yaml
@@ -8,9 +8,3 @@ storage:
 provides:
   db:
     interface: roach
-resources:
-  cockroachdb-image:
-    type: oci-image
-    description: OCI image used for cockroachdb
-assumes:
-  - k8s-api

--- a/testcharms/charm-repo/focal/cockroach-container-less/metadata.yaml
+++ b/testcharms/charm-repo/focal/cockroach-container-less/metadata.yaml
@@ -12,3 +12,5 @@ resources:
   cockroachdb-image:
     type: oci-image
     description: OCI image used for cockroachdb
+assumes:
+  - k8s-api

--- a/testcharms/charm-repo/focal/cockroach/README.md
+++ b/testcharms/charm-repo/focal/cockroach/README.md
@@ -1,0 +1,17 @@
+# cockroachdb
+
+## Description
+
+A container-based V2 metadata kubernetes charm to use in testing juju.
+
+## Deployment
+
+Pull a cockroachdb image to be used from https://hub.docker.com/r/cockroachdb/cockroach/tags:
+
+<code>docker pull cockroachdb/cockroach:v21.2.7</code>
+
+Deploy the local charm
+
+<code>
+juju deploy ./testcharms/charm-repo/focal/cockroach --resource cockroachdb-image=cockroachdb/cockroach:v21.2.7
+</code>

--- a/testcharms/charm-repo/focal/cockroach/metadata.yaml
+++ b/testcharms/charm-repo/focal/cockroach/metadata.yaml
@@ -18,3 +18,5 @@ resources:
   cockroachdb-image:
     type: oci-image
     description: OCI image used for cockroachdb
+assumes:
+  - k8s-api


### PR DESCRIPTION
Ensures that these kubernetes metadata v2 charms will deploy only on kubernetes models.

Add README.md files to help with deployment, including where to find oci-images for the charms.

## QA steps

```console
$ docker pull cockroachdb/cockroach:v21.2.7
$ juju bootstrap localhost test
$ juju deploy ./testcharms/charm-repo/focal/cockroach --resource cockroachdb-image=cockroachdb/cockroach:v21.2.7
Located local charm "cockroachdb", revision 1
Deploying "cockroachdb" from local charm "cockroachdb", revision 1
ERROR Charm feature requirements cannot be met:
  - charm requires feature "k8s-api" but model does not support it

Feature descriptions:
  - "k8s-api": the Kubernetes API lets charms query and manipulate the state of API objects in a Kubernetes cluster

For additional information please see: https://juju.is/docs/olm/supported-features

$ juju bootstrap microk8s
$ juju deploy ./testcharms/charm-repo/focal/cockroach --resource cockroachdb-image=cockroachdb/cockroach:v21.2.7
Located local charm "cockroachdb", revision 0
Deploying "cockroachdb" from local charm "cockroachdb", revision 0
```
