### PR TITLE
Fix unsupported series error message in `juju download`

### DIFF
--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -310,7 +310,14 @@ func (c *downloadCommand) suggested(ser string, channel string, releases []trans
 			}
 		}
 	}
-	return errors.Errorf("%s does not support series %s in channel %s.  Supported series are %s.",
+	if series.IsEmpty() {
+		// No releases in this channel
+		return errors.Errorf(`%q has no releases in channel %q. Type
+    juju info %s
+for a list of supported channels.`,
+			c.charmOrBundle, channel, c.charmOrBundle)
+	}
+	return errors.Errorf("%q does not support series %q in channel %q.  Supported series are: %s.",
 		c.charmOrBundle, ser, channel, strings.Join(series.SortedValues(), ", "))
 }
 

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -145,7 +145,26 @@ func (s *downloadSuite) TestRunWithUnsupportedSeries(c *gc.C) {
 
 	ctx := commandContextForTest(c)
 	err = command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, "test does not support series focal in channel stable.  Supported series are bionic, trusty, xenial.")
+	c.Assert(err, gc.ErrorMatches, `"test" does not support series "focal" in channel "stable".  Supported series are: bionic, trusty, xenial.`)
+}
+
+func (s *downloadSuite) TestRunWithNoStableRelease(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	s.expectRefreshUnsupportedSeries()
+
+	command := &downloadCommand{
+		charmHubCommand: s.newCharmHubCommand(),
+	}
+	command.SetFilesystem(s.filesystem)
+	err := cmdtesting.InitCommand(command, []string{"test", "--channel", "foo/stable"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := commandContextForTest(c)
+	err = command.Run(ctx)
+	c.Assert(err, gc.ErrorMatches, `"test" has no releases in channel "foo/stable". Type
+    juju info test
+for a list of supported channels.`)
 }
 
 func (s *downloadSuite) TestRunWithCustomInvalidCharmHubURL(c *gc.C) {


### PR DESCRIPTION
Fixes [bug/1960443](https://bugs.launchpad.net/juju/+bug/1960443). When you try to `juju download` and there are no supported series, it will now tell you that directly, instead of giving an empty list. I also added quotes around relevant objects.

### Before

```
$ juju download kubernetes-worker
ERROR kubernetes-worker does not support series focal in channel stable. Supported series are .
```

### After

```
$ juju download kubernetes-worker
ERROR "kubernetes-worker" has no releases in channel "stable". Type
    juju info kubernetes-worker
for a list of supported channels.
```