### PR TITLE
[JUJU-854] Removes UpdateNetworkInfo API client method

### DIFF
--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -889,25 +889,6 @@ func (u *Unit) NetworkInfo(bindings []string, relationId *int) (map[string]param
 	return results.Results, nil
 }
 
-// UpdateNetworkInfo updates the network settings for the unit's bound
-// endpoints.
-func (u *Unit) UpdateNetworkInfo() error {
-	args := params.Entities{
-		Entities: []params.Entity{
-			{
-				Tag: u.tag.String(),
-			},
-		},
-	}
-
-	var results params.ErrorResults
-	err := u.st.facade.FacadeCall("UpdateNetworkInfo", args, &results)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return results.OneError()
-}
-
 // State returns the state persisted by the charm running in this unit
 // and the state internal to the uniter for this unit.
 func (u *Unit) State() (params.UnitStateResult, error) {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -159,7 +159,6 @@ type HookUnit interface {
 	State() (params.UnitStateResult, error)
 	Tag() names.UnitTag
 	UnitStatus() (params.StatusResult, error)
-	UpdateNetworkInfo() error
 	CommitHookChanges(params.CommitHookChangesArgs) error
 	PublicAddress() (string, error)
 }

--- a/worker/uniter/runner/context/mocks/hookunit_mock.go
+++ b/worker/uniter/runner/context/mocks/hookunit_mock.go
@@ -239,17 +239,3 @@ func (mr *MockHookUnitMockRecorder) UnitStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStatus", reflect.TypeOf((*MockHookUnit)(nil).UnitStatus))
 }
-
-// UpdateNetworkInfo mocks base method.
-func (m *MockHookUnit) UpdateNetworkInfo() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNetworkInfo")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateNetworkInfo indicates an expected call of UpdateNetworkInfo.
-func (mr *MockHookUnitMockRecorder) UpdateNetworkInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNetworkInfo", reflect.TypeOf((*MockHookUnit)(nil).UpdateNetworkInfo))
-}


### PR DESCRIPTION
This method used to be called by the unit agent during `config-changed` after we detected that endpoint bindings had been changed for an application.

Since we aggregated calls into the flush-upon commit, it hasn't been required. We remove it here.

The server-side method is not required either. A patch will follow to bump the version and mask it. 

## QA steps

Deploy a unit.

## Documentation changes

None.

## Bug reference

N/A
