### PR TITLE
Removed direct uses of pkg/errors

### DIFF
--- a/api/common/leadership_test.go
+++ b/api/common/leadership_test.go
@@ -4,10 +4,11 @@
 package common_test
 
 import (
+	"errors"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/base/mocks"

--- a/cmd/juju/model/diff_test.go
+++ b/cmd/juju/model/diff_test.go
@@ -4,11 +4,12 @@
 package model_test
 
 import (
+	"errors"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	jc "github.com/juju/testing/checkers"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cmd/juju/model"

--- a/cmd/juju/model/listcommits_test.go
+++ b/cmd/juju/model/listcommits_test.go
@@ -4,10 +4,10 @@
 package model_test
 
 import (
+	"errors"
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd/v3"

--- a/cmd/juju/model/showcommit_test.go
+++ b/cmd/juju/model/showcommit_test.go
@@ -4,10 +4,10 @@
 package model_test
 
 import (
+	"errors"
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd/v3"

--- a/cmd/plugins/juju-wait-for/query/errors.go
+++ b/cmd/plugins/juju-wait-for/query/errors.go
@@ -3,7 +3,7 @@
 
 package query
 
-import "github.com/pkg/errors"
+import "github.com/juju/errors"
 
 // InvalidIdentifierError creates an invalid error.
 type InvalidIdentifierError struct {

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -4,6 +4,7 @@
 package kvm_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
 	. "github.com/juju/juju/container/kvm"
@@ -219,7 +219,7 @@ func (commandWrapperSuite) TestDestroyMachineSuccess(c *gc.C) {
 }
 
 func (commandWrapperSuite) TestDestroyMachineFails(c *gc.C) {
-	stub := NewRunStub("", errors.Errorf("Boom"))
+	stub := NewRunStub("", errors.New("Boom"))
 	container := NewTestContainer("aname", stub.Run, nil)
 	err := DestroyMachine(container)
 	c.Check(stub.Calls(), jc.DeepEquals, []string{
@@ -242,7 +242,7 @@ func (commandWrapperSuite) TestAutostartMachineSuccess(c *gc.C) {
 }
 
 func (commandWrapperSuite) TestAutostartMachineFails(c *gc.C) {
-	stub := NewRunStub("", errors.Errorf("Boom"))
+	stub := NewRunStub("", errors.New("Boom"))
 	container := NewTestContainer("aname", stub.Run, nil)
 	err := AutostartMachine(container)
 	c.Assert(stub.Calls(), jc.DeepEquals, []string{" virsh autostart aname"})
@@ -269,7 +269,7 @@ func (commandWrapperSuite) TestListMachinesSuccess(c *gc.C) {
 }
 
 func (commandWrapperSuite) TestListMachinesFails(c *gc.C) {
-	stub := NewRunStub("", errors.Errorf("Boom"))
+	stub := NewRunStub("", errors.New("Boom"))
 	got, err := ListMachines(stub.Run)
 	c.Check(err, gc.ErrorMatches, "Boom")
 	c.Check(stub.Calls(), jc.DeepEquals, []string{" virsh -q list --all"})

--- a/container/lxd/cluster_test.go
+++ b/container/lxd/cluster_test.go
@@ -4,13 +4,14 @@
 package lxd_test
 
 import (
+	"errors"
+
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/container/lxd"
 	lxdtesting "github.com/juju/juju/container/lxd/testing"
-	"github.com/pkg/errors"
 )
 
 type clusterSuite struct {

--- a/core/assumes/error.go
+++ b/core/assumes/error.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
-	"github.com/pkg/errors"
+	"github.com/juju/errors"
 )
 
 var (

--- a/core/charm/downloader/downloader_test.go
+++ b/core/charm/downloader/downloader_test.go
@@ -4,6 +4,7 @@
 package downloader
 
 import (
+	"errors"
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,6 @@ require (
 	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb
 	github.com/oracle/oci-go-sdk/v47 v47.1.0
 	github.com/packethost/packngo v0.14.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
@@ -193,6 +192,7 @@ require (
 	github.com/onsi/gomega v1.10.4 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/prometheus/common v0.10.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/network/debinterfaces/activate.go
+++ b/network/debinterfaces/activate.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/juju/clock"
+	"github.com/juju/errors"
 	"github.com/juju/juju/utils/scriptrunner"
 	"github.com/juju/loggo"
-	"github.com/pkg/errors"
 )
 
 var logger = loggo.GetLogger("juju.network.debinterfaces")
@@ -110,7 +110,7 @@ fi
 // for the new bridges.
 func BridgeAndActivate(params ActivationParams) (*ActivationResult, error) {
 	if len(params.Devices) == 0 {
-		return nil, errors.Errorf("no devices specified")
+		return nil, errors.New("no devices specified")
 	}
 
 	stanzas, err := Parse(params.Filename)
@@ -142,7 +142,7 @@ func BridgeAndActivate(params ActivationParams) (*ActivationResult, error) {
 	}
 
 	if err != nil {
-		return &activationResult, errors.Errorf("bridge activation error: %s", err)
+		return &activationResult, fmt.Errorf("bridge activation error: %w", err)
 	}
 
 	logger.Infof("bridge activation result=%v", result.Code)
@@ -152,9 +152,9 @@ func BridgeAndActivate(params ActivationParams) (*ActivationResult, error) {
 		logger.Errorf("bridge activation stderr\n%s\n", result.Stderr)
 		// We want to suppress long output from ifup, ifdown - it will be shown in status message!
 		if len(result.Stderr) < 40 {
-			return &activationResult, errors.Errorf("bridge activation failed: %s", string(result.Stderr))
+			return &activationResult, fmt.Errorf("bridge activation failed: %s", string(result.Stderr))
 		} else {
-			return &activationResult, errors.Errorf("bridge activation failed, see logs for details")
+			return &activationResult, errors.New("bridge activation failed, see logs for details")
 		}
 	}
 

--- a/network/debinterfaces/parser_test.go
+++ b/network/debinterfaces/parser_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/network/debinterfaces"
@@ -37,7 +36,7 @@ func wordExpanderWithError(errmsg string) debinterfaces.WordExpander {
 }
 
 func (w *wordExpanderErrors) Expand(s string) ([]string, error) {
-	return nil, errors.Errorf("word expansion failed: %s", w.errmsg)
+	return nil, fmt.Errorf("word expansion failed: %s", w.errmsg)
 }
 
 func (s *ParserSuite) SetUpTest(c *gc.C) {

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -40,7 +40,6 @@ import (
 	"github.com/juju/juju/tools"
 
 	"github.com/packethost/packngo"
-	errr "github.com/pkg/errors"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -destination ./mocks/packngo.go -package mocks github.com/packethost/packngo DeviceService,OSService,PlanService,ProjectIPService
@@ -732,12 +731,12 @@ func waitDeviceActive(ctx context.ProviderCallContext, c *packngo.Client, id str
 				return nil
 			}
 			if d.State == "failed" {
-				return errr.Wrap(ErrDeviceProvisioningFailed, fmt.Sprintf("device %s provisioning failed", id))
+				return fmt.Errorf("device %s provisioning failed: %w", id, ErrDeviceProvisioningFailed)
 			}
 			return fmt.Errorf("device in not in active state yet")
 		},
 		IsFatalError: func(err error) bool {
-			if errr.Is(err, ErrDeviceProvisioningFailed) {
+			if errors.Is(err, ErrDeviceProvisioningFailed) {
 				return true
 			}
 			return common.IsCredentialNotValid(err)

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/workertest"
-	"github.com/pkg/errors"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"

--- a/worker/raft/errors.go
+++ b/worker/raft/errors.go
@@ -6,7 +6,7 @@ package raft
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/juju/errors"
 )
 
 // NotLeaderError creates a typed error for when a raft operation is applied,


### PR DESCRIPTION
Developer tools have been bringing in github.com/pkg/errors instead of
github.com/juju/errors. This commit removes those usages in favour of
juju/errors or standard library.

pkg/errors is still an indirect dependency via the LXD provider.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run the unit tests and compile Juju

## Documentation changes

N/A

## Bug reference

N/A
