### PR TITLE
[JUJU-211] Remove Provider AZ Caching

### DIFF
--- a/cmd/juju/subnet/package_test.go
+++ b/cmd/juju/subnet/package_test.go
@@ -168,22 +168,6 @@ func (sa *StubAPI) Close() error {
 	return sa.NextErr()
 }
 
-func (sa *StubAPI) AllZones() ([]string, error) {
-	sa.MethodCall(sa, "AllZones")
-	if err := sa.NextErr(); err != nil {
-		return nil, err
-	}
-	return sa.Zones, nil
-}
-
-func (sa *StubAPI) AllSpaces() ([]names.Tag, error) {
-	sa.MethodCall(sa, "AllSpaces")
-	if err := sa.NextErr(); err != nil {
-		return nil, err
-	}
-	return sa.Spaces, nil
-}
-
 func (sa *StubAPI) AddSubnet(cidr string, id network.Id, spaceTag names.SpaceTag, zones []string) error {
 	sa.MethodCall(sa, "AddSubnet", cidr, id, spaceTag, zones)
 	return sa.NextErr()

--- a/cmd/juju/subnet/subnet.go
+++ b/cmd/juju/subnet/subnet.go
@@ -30,12 +30,6 @@ type SubnetAPI interface {
 	// ListSubnets returns information about subnets known to Juju,
 	// optionally filtered by space and/or zone (both can be empty).
 	ListSubnets(withSpace *names.SpaceTag, withZone string) ([]params.Subnet, error)
-
-	// AllZones returns all availability zones known to Juju.
-	AllZones() ([]string, error)
-
-	// AllSpaces returns all Juju network spaces.
-	AllSpaces() ([]names.Tag, error)
 }
 
 // mvpAPIShim forwards SubnetAPI methods to the real API facade for

--- a/provider/common/availabilityzones.go
+++ b/provider/common/availabilityzones.go
@@ -154,7 +154,7 @@ func DistributeInstances(
 		return nil, err
 	}
 
-	// If there any zones supplied for limitation,
+	// If there are any zones supplied for limitation,
 	// filter to distribution data so that only those zones are considered.
 	filteredZoneInstances := zoneInstances[:0]
 	if len(limitZones) > 0 {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -982,16 +982,6 @@ func (t *localServerSuite) TestGetAvailabilityZones(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(zones, gc.HasLen, 1)
 	c.Assert(zones[0].Name(), gc.Equals, "whatever")
-
-	// A successful result is cached, currently for the lifetime
-	// of the Environ. This will change if/when we have long-lived
-	// Environs to cut down repeated IaaS requests.
-	resultErr = fmt.Errorf("failed to get availability zones")
-	resultZones[0].ZoneName = aws.String("andever")
-	zones, err = env.AvailabilityZones(t.callCtx)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(zones, gc.HasLen, 1)
-	c.Assert(zones[0].Name(), gc.Equals, "whatever")
 }
 
 func (t *localServerSuite) TestGetAvailabilityZonesCommon(c *gc.C) {

--- a/provider/gce/environ_availzones.go
+++ b/provider/gce/environ_availzones.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/provider/common"
 	"github.com/juju/juju/provider/gce/google"
 	"github.com/juju/juju/storage"
 )
@@ -88,8 +87,6 @@ func (env *environ) availZoneUp(ctx context.ProviderCallContext, name string) (*
 	}
 	return zone, nil
 }
-
-var availabilityZoneAllocations = common.AvailabilityZoneAllocations
 
 // volumeAttachmentsZone determines the availability zone for each volume
 // identified in the volume attachment parameters, checking that they are

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -334,7 +334,6 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	})
 	s.PatchValue(&bootstrap, s.FakeCommon.Bootstrap)
 	s.PatchValue(&destroyEnv, s.FakeCommon.Destroy)
-	s.PatchValue(&availabilityZoneAllocations, s.FakeCommon.AvailabilityZoneAllocations)
 	s.PatchValue(&buildInstanceSpec, s.FakeEnviron.BuildInstanceSpec)
 	s.PatchValue(&getHardwareCharacteristics, s.FakeEnviron.GetHardwareCharacteristics)
 	s.PatchValue(&newRawInstance, s.FakeEnviron.NewRawInstance)
@@ -421,14 +420,6 @@ func (fc *fakeCommon) Destroy(env environs.Environ, ctx context.ProviderCallCont
 		"switch": env,
 	})
 	return fc.err()
-}
-
-func (fc *fakeCommon) AvailabilityZoneAllocations(env common.ZonedEnviron, ctx context.ProviderCallContext, group []instance.Id) ([]common.AvailabilityZoneInstances, error) {
-	fc.addCall("AvailabilityZoneAllocations", FakeCallArgs{
-		"switch": env,
-		"group":  group,
-	})
-	return fc.AZInstances, fc.err()
 }
 
 type fakeEnviron struct {

--- a/provider/maas/environ_whitebox_test.go
+++ b/provider/maas/environ_whitebox_test.go
@@ -959,15 +959,6 @@ func (s *environSuite) TestGetAvailabilityZones(c *gc.C) {
 	c.Assert(zones, gc.HasLen, 1)
 	c.Assert(zones[0].Name(), gc.Equals, "whatever")
 	c.Assert(zones[0].Available(), jc.IsTrue)
-
-	// A successful result is cached, currently for the lifetime
-	// of the Environ. This will change if/when we have long-lived
-	// Environs to cut down repeated IaaS requests.
-	s.testMAASObject.TestServer.AddZone("somewhere", "outthere")
-	zones, err = env.AvailabilityZones(s.callCtx)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(zones, gc.HasLen, 1)
-	c.Assert(zones[0].Name(), gc.Equals, "whatever")
 }
 
 func (s *environSuite) newNode(c *gc.C, nodename, hostname string, attrs map[string]interface{}) {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -2457,16 +2457,6 @@ func (s *localServerSuite) TestGetAvailabilityZones(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(zones, gc.HasLen, 1)
 	c.Assert(zones[0].Name(), gc.Equals, "whatever")
-
-	// A successful result is cached, currently for the lifetime
-	// of the Environ. This will change if/when we have long-lived
-	// Environs to cut down repeated IaaS requests.
-	resultErr = fmt.Errorf("failed to get availability zones")
-	resultZones[0].Name = "andever"
-	zones, err = env.AvailabilityZones(s.callCtx)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(zones, gc.HasLen, 1)
-	c.Assert(zones[0].Name(), gc.Equals, "whatever")
 }
 
 func (s *localServerSuite) TestGetAvailabilityZonesCommon(c *gc.C) {

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -115,9 +115,9 @@ func CloudSpec(
 	return environscloudspec.MakeCloudSpec(modelCloud, regionName, cloudCredential)
 }
 
-// NewEnvironFunc defines the type of a function that, given a Model,
+// NewEnvironFunc aliases a function that, given a Model,
 // returns a new Environ.
-type NewEnvironFunc func(Model) (environs.Environ, error)
+type NewEnvironFunc = func(Model) (environs.Environ, error)
 
 // GetNewEnvironFunc returns a NewEnvironFunc, that constructs Environs
 // using the given environs.NewEnvironFunc.
@@ -128,9 +128,9 @@ func GetNewEnvironFunc(newEnviron environs.NewEnvironFunc) NewEnvironFunc {
 	}
 }
 
-// NewCAASBrokerFunc defines the type of a function that, given a state.State,
+// NewCAASBrokerFunc aliases a function that, given a state.State,
 // returns a new CAAS broker.
-type NewCAASBrokerFunc func(Model) (caas.Broker, error)
+type NewCAASBrokerFunc = func(Model) (caas.Broker, error)
 
 // GetNewCAASBrokerFunc returns a NewCAASBrokerFunc, that constructs CAAS brokers
 // using the given caas.NewContainerBrokerFunc.


### PR DESCRIPTION
Some providers, upon a first call to `AvailabilityZones` cache the retrieved zones and thereafter return the cached values for future calls to that method.

Most of the time, this has no adverse effects, but if existing AZs change for a Juju cloud, the provisioner will never factor in this change in AZ topology - the controllers need to be bounced in order to pick up the changes.

Caching doesn't provide great value anyway, because we only call `AvailabilityZones` when:
- We add subnets.
- We process a batch of machines in the provisioner loop.
- We are determining unit distribution in the case of having empty machines.

Here we remove provider AZ caching, instead fetching them for each call. The vSphere provider caches AZs on the _session_ (a better approach to limiting calls), but not the environ, so no change is required there.

Other sundry cleanups include:
- Comment fixes.
- Unused method removal.
- Type aliases over new declarations.

## QA steps

Deploy something on providers:
- EC2
- MAAS
- OpenStack

## Documentation changes

None.

## Bug reference

N/A
