### PR TITLE
[JUJU-878] Return an error with more detail when an NewBindings fails

### DIFF
--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -242,7 +242,7 @@ func (s *DeployLocalSuite) TestDeployWithInvalidSpace(c *gc.C) {
 				"db": "42", //unknown space id
 			},
 		})
-	c.Assert(err, gc.ErrorMatches, `cannot add application "bob": space not found`)
+	c.Assert(err, gc.ErrorMatches, `cannot add application "bob": space with name/id "42" (endpoint "db") not found`)
 	c.Check(app, gc.IsNil)
 	// The application should not have been added
 	_, err = s.State.Application("bob")

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -536,7 +536,7 @@ func NewBindings(st EndpointBinding, givenMap map[string]string) (*Bindings, err
 	default:
 		logger.Errorf("%s", namesErr)
 		logger.Errorf("%s", idErr)
-		return nil, errors.NotFoundf("space")
+		return nil, namesErr
 	}
 
 	return &Bindings{st: st, bindingsMap: newMap}, err
@@ -545,7 +545,7 @@ func NewBindings(st EndpointBinding, givenMap map[string]string) (*Bindings, err
 func allOfOne(foundValue func(string) bool, givenMap map[string]string, allowEmptyValues bool) error {
 	for k, v := range givenMap {
 		if !foundValue(v) && (v != "" || (v == "" && !allowEmptyValues)) {
-			return errors.NotFoundf("endpoint %q, value %q, space name or id", k, v)
+			return errors.NotFoundf("space with name/id %q (endpoint %q)", v, k)
 		}
 	}
 	return nil

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1972,7 +1972,7 @@ func (s *StateSuite) TestAddApplicationWithInvalidBindings(c *gc.C) {
 	}{{ // 0
 		about:         "extra endpoint bound to unknown space",
 		bindings:      map[string]string{"extra": "4"},
-		expectedError: `space not found`,
+		expectedError: `space with name/id "4" (endpoint "extra") not found`,
 		errorType:     errors.IsNotFound,
 	}, { // 1
 		about:         "extra endpoint not bound to a space",
@@ -1987,17 +1987,17 @@ func (s *StateSuite) TestAddApplicationWithInvalidBindings(c *gc.C) {
 	}, { // 3
 		about:         "empty endpoint bound to unknown space",
 		bindings:      map[string]string{"": "anything"},
-		expectedError: `space not found`,
+		expectedError: `space with name/id "anything" (endpoint "") not found`,
 		errorType:     errors.IsNotFound,
 	}, { // 4
 		about:         "known endpoint bound to unknown space",
 		bindings:      map[string]string{"server": "invalid"},
-		expectedError: `space not found`,
+		expectedError: `space with name/id "invalid" (endpoint "server") not found`,
 		errorType:     errors.IsNotFound,
 	}, { // 5
 		about:         "known endpoint bound correctly and an extra endpoint",
 		bindings:      map[string]string{"server": dbSpace.Id(), "foo": "public"},
-		expectedError: `space not found`,
+		expectedError: `space with name/id "\d+" (endpoint "server") not found`,
 		errorType:     errors.IsNotFound,
 	}} {
 		c.Logf("test #%d: %s", i, test.about)


### PR DESCRIPTION
Previously, a very vague 'space not found' error is returned. Now
return a more verbose error that reports the space name or id, and the
endpoint

## QA steps

#### Bootstrap a controller that supports spaces
I chose aws

```sh
$ juju bootstrap aws/eu-west-2 c --build-agent
```

#### Configure spaces
```sh
$ juju add-space beta
$ juju spaces
Name   Space ID  Subnets       
alpha  0         172.31.16.0/20
                 172.31.32.0/20
                 172.31.48.0/24
                 252.16.0.0/12 
                 252.32.0.0/12 
                 252.48.0.0/16 
beta   1  
```

#### Attempt to deploy some bundles
I used the following simple bundle
```yaml
series: focal
applications:
  grafana:
    charm: grafana
    channel: stable
    revision: 51
    num_units: 1
    constraints: arch=amd64
    bindings:
      "": $SPACE
```
For different values of $SPACE

#### $SPACE = gamma
```sh
$ juju deploy ./bundle.yaml
Located charm "grafana" in charm-hub, channel stable
Executing changes:
- upload charm grafana from charm-hub for series focal with revision 51 with architecture=amd64
- deploy application grafana from charm-hub on focal with stable
ERROR cannot deploy bundle: cannot deploy application "grafana": endpoint "", value "gamma", space name or id not found
```

#### $SPACE = 2
```sh
$ juju deploy ./bundle.yaml
Located charm "grafana" in charm-hub, channel stable
Executing changes:
- upload charm grafana from charm-hub for series focal with revision 51 with architecture=amd64
- deploy application grafana from charm-hub on focal with stable
ERROR cannot deploy bundle: cannot deploy application "grafana": endpoint "", value "2", space name or id not found
```

#### $SPACE = beta
```sh
$ juju deploy ./graf.yaml
Located charm "grafana" in charm-hub, channel stable
Executing changes:
- upload charm grafana from charm-hub for series focal with revision 51 with architecture=amd64
- deploy application grafana from charm-hub on focal with stable
- add unit grafana/0 to new machine 0
Deploy of bundle completed.
```

#### $SPACE = 1
```sh
$ juju deploy ./graf.yaml
Located charm "grafana" in charm-hub, channel stable
Executing changes:
- upload charm grafana from charm-hub for series focal with revision 51 with architecture=amd64
- deploy application grafana from charm-hub on focal with stable
- add unit grafana/0 to new machine 0
Deploy of bundle completed.
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1943465
