### PR TITLE
Add basic sidecar deploy and remove-application integration test

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -180,7 +180,7 @@ while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
 			PROVIDER="${CLOUD}"
 		fi
 		export BOOTSTRAP_PROVIDER="${PROVIDER}"
-		export BOOTSTRAP_CLOUD="${PROVIDER}"
+		export BOOTSTRAP_CLOUD="${CLOUD}"
 		;;
 	p)
 		export BOOTSTRAP_PROVIDER="${OPTARG}"

--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -144,7 +144,7 @@ EOF
 	done
 
 	# We still sleep quickly here to let everything settle down. By adding
-	# propper probes we could avoid this.
+	# proper probes we could avoid this.
 	sleep 5
 
 	kubectl --kubeconfig "${TEST_DIR}"/kube-sa.json apply -f - <<EOF

--- a/tests/suites/sidecar/sidecar.sh
+++ b/tests/suites/sidecar/sidecar.sh
@@ -1,0 +1,24 @@
+run_deploy_and_remove_application() {
+	echo
+
+	# Ensure that a valid Juju controller exists
+	model_name="controller-model-sidecar"
+	file="${TEST_DIR}/test-${model_name}.log"
+	ensure "${model_name}" "${file}"
+
+	# Deploy snappass-test application
+	juju deploy snappass-test
+	wait_for "active" '.applications["snappass-test"]["application-status"].current'
+	wait_for "active" '.applications["snappass-test"].units["snappass-test/0"]["workload-status"].current'
+
+	# Check that it's properly responding
+	address=$(juju status --format=json | jq -r '.applications["snappass-test"].units["snappass-test/0"].address')
+	curl "http://${address}:5000" | grep Snappass
+
+	# Remove application
+	juju remove-application snappass-test
+	wait_for "0" '.applications | length'
+
+	# Clean up model
+	destroy_model "${model_name}"
+}

--- a/tests/suites/sidecar/task.sh
+++ b/tests/suites/sidecar/task.sh
@@ -1,0 +1,17 @@
+test_sidecar() {
+	if [ "$(skip 'test_sidecar')" ]; then
+		echo "==> TEST SKIPPED: sidecar charm tests"
+		return
+	fi
+
+	set_verbosity
+
+	case "${BOOTSTRAP_PROVIDER:-}" in
+	"k8s")
+        run_deploy_and_remove_application
+		;;
+	*)
+		echo "==> TEST SKIPPED: sidecar charm tests, not a k8s provider"
+		;;
+	esac
+}


### PR DESCRIPTION
This PR adds a basic `juju deploy` and `juju remove-application` sequence for a sidecar charm (we didn't actually have any bash integration tests for sidecar charms).

## QA steps

First install Microk8s and set up Juju for Microk8s. Then:

```text
juju bootstrap microk8s
cd tests
./main.sh -l microk8s-localhost sidecar
```
