### PR TITLE
The AllFacadeVersions method of api.Connection is unused - remove it.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1366,15 +1366,6 @@ func (s *state) PublicDNSName() string {
 	return s.publicDNSName
 }
 
-// AllFacadeVersions returns what versions we know about for all facades
-func (s *state) AllFacadeVersions() map[string][]int {
-	facades := make(map[string][]int, len(s.facadeVersions))
-	for name, versions := range s.facadeVersions {
-		facades[name] = append([]int{}, versions...)
-	}
-	return facades
-}
-
 // BestFacadeVersion compares the versions of facades that we know about, and
 // the versions available from the server, and reports back what version is the
 // 'best available' to use.

--- a/api/interface.go
+++ b/api/interface.go
@@ -303,10 +303,6 @@ type Connection interface {
 	// NOTE: This method is deprecated. Please use IsBroken or Broken instead.
 	Ping() error
 
-	// I think this is actually dead code. It's tested, at least, so I'm
-	// keeping it for now, but it's not apparently used anywhere else.
-	AllFacadeVersions() map[string][]int
-
 	// AuthTag returns the tag of the authorized user of the state API
 	// connection.
 	AuthTag() names.Tag

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -246,34 +246,6 @@ func (s *stateSuite) TestLoginMacaroonInvalidId(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "interaction required but not possible")
 }
 
-func (s *stateSuite) TestLoginTracksFacadeVersions(c *gc.C) {
-	apistate, tag, password := s.OpenAPIWithoutLogin(c)
-	defer apistate.Close()
-	// We haven't called Login yet, so the Facade Versions should be empty
-	c.Check(apistate.AllFacadeVersions(), gc.HasLen, 0)
-	err := apistate.Login(tag, password, "", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	// Now that we've logged in, AllFacadeVersions should be updated.
-	allVersions := apistate.AllFacadeVersions()
-	c.Check(allVersions, gc.Not(gc.HasLen), 0)
-	// For sanity checking, ensure that we have a v2 of the Client facade
-	c.Assert(allVersions["Client"], gc.Not(gc.HasLen), 0)
-	c.Check(allVersions["Client"][0], gc.Equals, 1)
-}
-
-func (s *stateSuite) TestAllFacadeVersionsSafeFromMutation(c *gc.C) {
-	allVersions := s.APIState.AllFacadeVersions()
-	clients := allVersions["Client"]
-	origClients := make([]int, len(clients))
-	copy(origClients, clients)
-	// Mutating the dict should not affect the cached versions
-	allVersions["Client"] = append(allVersions["Client"], 2597)
-	newVersions := s.APIState.AllFacadeVersions()
-	newClientVers := newVersions["Client"]
-	c.Check(newClientVers, gc.DeepEquals, origClients)
-	c.Check(newClientVers[len(newClientVers)-1], gc.Not(gc.Equals), 2597)
-}
-
 func (s *stateSuite) TestBestFacadeVersion(c *gc.C) {
 	c.Check(s.APIState.BestFacadeVersion("Client"), gc.Equals, 5)
 }


### PR DESCRIPTION
The AllFacadeVersions method of api.Connection is unused and there is a comment stating it is dead code so it should be removed.