### PR TITLE
The ModelAccess method of api.Connection is unused - remove it.

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -311,9 +311,6 @@ type Connection interface {
 	// connection.
 	AuthTag() names.Tag
 
-	// ModelAccess returns the access level of authorized user to the model.
-	ModelAccess() string
-
 	// ControllerAccess returns the access level of authorized user to the controller.
 	ControllerAccess() string
 

--- a/api/state.go
+++ b/api/state.go
@@ -242,11 +242,6 @@ func (st *state) AuthTag() names.Tag {
 	return st.authTag
 }
 
-// ModelAccess returns the access level of authorized user to the model.
-func (st *state) ModelAccess() string {
-	return st.modelAccess
-}
-
 // ControllerAccess returns the access level of authorized user to the model.
 func (st *state) ControllerAccess() string {
 	return st.controllerAccess

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -152,24 +152,6 @@ func (s *stateSuite) TestTags(c *gc.C) {
 	c.Check(controllerTag, gc.Equals, coretesting.ControllerTag)
 }
 
-func (s *stateSuite) TestLoginSetsModelAccess(c *gc.C) {
-	// The default user has admin access.
-	c.Assert(s.APIState.ModelAccess(), gc.Equals, "admin")
-
-	manager := usermanager.NewClient(s.OpenControllerAPI(c))
-	defer manager.Close()
-	usertag, _, err := manager.AddUser("ro", "ro", "ro-password")
-	c.Assert(err, jc.ErrorIsNil)
-	mmanager := modelmanager.NewClient(s.OpenControllerAPI(c))
-	defer mmanager.Close()
-	modeltag, ok := s.APIState.ModelTag()
-	c.Assert(ok, jc.IsTrue)
-	err = mmanager.GrantModel(usertag.Id(), "read", modeltag.Id())
-	c.Assert(err, jc.ErrorIsNil)
-	conn := s.OpenAPIAs(c, usertag, "ro-password")
-	c.Assert(conn.ModelAccess(), gc.Equals, "read")
-}
-
 func (s *stateSuite) TestLoginSetsControllerAccess(c *gc.C) {
 	// The default user has admin access.
 	c.Assert(s.APIState.ControllerAccess(), gc.Equals, "superuser")


### PR DESCRIPTION
The ModelAccess method of api.Connection is unused outside tests so should be removed.