### PR TITLE
The Ping method of api.Connection is unused - remove it.

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -284,7 +284,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 
 	go (&monitor{
 		clock:       opts.Clock,
-		ping:        st.Ping,
+		ping:        st.ping,
 		pingPeriod:  PingPeriod,
 		pingTimeout: pingTimeout,
 		closed:      st.closed,
@@ -551,8 +551,8 @@ func (st *state) apiEndpoint(path, query string) (*url.URL, error) {
 	}, nil
 }
 
-// Ping implements api.Connection.
-func (s *state) Ping() error {
+// ping implements calls the Pinger.ping facade.
+func (s *state) ping() error {
 	return s.APICall("Pinger", s.pingerFacadeVersion, "", "Ping", nil, nil)
 }
 
@@ -1302,7 +1302,7 @@ func (s *state) IsBroken() bool {
 		return true
 	default:
 	}
-	if err := s.Ping(); err != nil {
+	if err := s.ping(); err != nil {
 		logger.Debugf("connection ping failed: %v", err)
 		return true
 	}

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1127,29 +1127,6 @@ func (s *apiclientSuite) TestAPICallError(c *gc.C) {
 	c.Check(clock.waits, gc.HasLen, 0)
 }
 
-func (s *apiclientSuite) TestPing(c *gc.C) {
-	clock := &fakeClock{}
-	rpcConn := newRPCConnection()
-	conn := api.NewTestingState(api.TestingStateParams{
-		RPCConnection: rpcConn,
-		Clock:         clock,
-	})
-	err := conn.Ping()
-	c.Assert(err, jc.ErrorIsNil)
-	rpcConn.stub.CheckCalls(c, []testing.StubCall{{
-		"Pinger.Ping", []interface{}{0, nil},
-	}})
-}
-
-func (s *apiclientSuite) TestPingBroken(c *gc.C) {
-	conn := api.NewTestingState(api.TestingStateParams{
-		RPCConnection: newRPCConnection(errors.New("no biscuit")),
-		Clock:         &fakeClock{},
-	})
-	err := conn.Ping()
-	c.Assert(err, gc.ErrorMatches, "no biscuit")
-}
-
 func (s *apiclientSuite) TestIsBrokenOk(c *gc.C) {
 	conn := api.NewTestingState(api.TestingStateParams{
 		RPCConnection: newRPCConnection(),

--- a/api/interface.go
+++ b/api/interface.go
@@ -298,11 +298,6 @@ type Connection interface {
 	// All the rest are strange and questionable and deserve extra attention
 	// and/or discussion.
 
-	// Ping makes an API request which checks if the connection is
-	// still functioning.
-	// NOTE: This method is deprecated. Please use IsBroken or Broken instead.
-	Ping() error
-
 	// I think this is actually dead code. It's tested, at least, so I'm
 	// keeping it for now, but it's not apparently used anywhere else.
 	AllFacadeVersions() map[string][]int


### PR DESCRIPTION
The Ping method of api.Connection is unused and marked as deprecated, so it should be removed.