### PR TITLE
[JUJU-877] Dynamically Reflect Cloud AZ Changes in Provisioner

### DIFF
--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1519,7 +1519,6 @@ func (az azShim) Available() bool {
 
 // AvailabilityZones implements environs.ZonedEnviron.
 func (env *environ) AvailabilityZones(ctx context.ProviderCallContext) (network.AvailabilityZones, error) {
-	// TODO(dimitern): Fix this properly.
 	return network.AvailabilityZones{
 		azShim{"zone1", true},
 		azShim{"zone2", false},
@@ -1544,7 +1543,7 @@ func (env *environ) InstanceAvailabilityZoneNames(ctx context.ProviderCallContex
 		if availabilityZones[azIndex].Available() {
 			returnValue[id] = availabilityZones[azIndex].Name()
 		} else {
-			// Based on knowledge of how the AZs are setup above
+			// Based on knowledge of how the AZs are set up above
 			// in AvailabilityZones()
 			azIndex++
 			returnValue[id] = availabilityZones[azIndex].Name()

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -49,7 +49,7 @@ func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachin
 	task := p.(*provisionerTask)
 	task.machinesMutex.RLock()
 	defer task.machinesMutex.RUnlock()
-	// sort to make comparisons in the tests easier.
+	// Sort to make comparisons in the tests easier.
 	zoneMachines := task.availabilityZoneMachines
 	sort.Slice(task.availabilityZoneMachines, func(i, j int) bool {
 		switch {

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -220,7 +220,7 @@ func (task *provisionerTask) loop() (taskErr error) {
 				return errors.New("machine watcher closed channel")
 			}
 			if err := task.processMachines(ctx, ids); err != nil {
-				return errors.Annotate(err, "failed to process updated machines")
+				return errors.Annotate(err, "processing updated machines")
 			}
 
 			task.notifyEventProcessedCallback(eventTypeProcessedMachines)
@@ -251,13 +251,13 @@ func (task *provisionerTask) loop() (taskErr error) {
 			if harvestMode.HarvestUnknown() {
 				task.logger.Infof("harvesting unknown machines")
 				if err := task.processMachines(ctx, nil); err != nil {
-					return errors.Annotate(err, "failed to process machines after safe mode disabled")
+					return errors.Annotate(err, "processing machines after safe mode disabled")
 				}
 				task.notifyEventProcessedCallback(eventTypeProcessedMachines)
 			}
 		case <-task.retryChanges:
 			if err := task.processMachinesWithTransientErrors(ctx); err != nil {
-				return errors.Annotate(err, "failed to process machines with transient errors")
+				return errors.Annotate(err, "processing machines with transient errors")
 			}
 			task.notifyEventProcessedCallback(eventTypeRetriedMachinesWithErrors)
 		case <-task.wp.Done():
@@ -371,7 +371,7 @@ func instanceIds(instances []instances.Instance) []string {
 func (task *provisionerTask) populateMachineMaps(ctx context.ProviderCallContext, ids []string) error {
 	allInstances, err := task.broker.AllRunningInstances(ctx)
 	if err != nil {
-		return errors.Annotate(err, "failed to get all instances from broker")
+		return errors.Annotate(err, "getting all instances from broker")
 	}
 
 	instances := make(map[instance.Id]instances.Instance)
@@ -390,7 +390,7 @@ func (task *provisionerTask) populateMachineMaps(ctx context.ProviderCallContext
 	}
 	machines, err := task.machineGetter.Machines(machineTags...)
 	if err != nil {
-		return errors.Annotatef(err, "failed to get machines %v", ids)
+		return errors.Annotatef(err, "getting machines %v", ids)
 	}
 	task.machinesMutex.Lock()
 	defer task.machinesMutex.Unlock()
@@ -402,7 +402,7 @@ func (task *provisionerTask) populateMachineMaps(ctx context.ProviderCallContext
 			task.logger.Debugf("machine %q not found in state", ids[i])
 			delete(task.machines, ids[i])
 		default:
-			return errors.Annotatef(result.Err, "failed to get machine %v", ids[i])
+			return errors.Annotatef(result.Err, "getting machine %v", ids[i])
 		}
 	}
 	return nil
@@ -474,11 +474,11 @@ func classifyMachine(logger Logger, machine ClassifiableMachine) (
 		if _, err := machine.InstanceId(); err == nil {
 			return None, nil
 		} else if !params.IsCodeNotProvisioned(err) {
-			return None, errors.Annotatef(err, "failed to load dying machine id:%s, details:%v", machine.Id(), machine)
+			return None, errors.Annotatef(err, "loading dying machine id:%s, details:%v", machine.Id(), machine)
 		}
 		logger.Infof("killing dying, unprovisioned machine %q", machine)
 		if err := machine.EnsureDead(); err != nil {
-			return None, errors.Annotatef(err, "failed to ensure machine dead id:%s, details:%v", machine.Id(), machine)
+			return None, errors.Annotatef(err, "ensuring machine dead id:%s, details:%v", machine.Id(), machine)
 		}
 		fallthrough
 	case life.Dead:
@@ -487,7 +487,7 @@ func classifyMachine(logger Logger, machine ClassifiableMachine) (
 	instId, err := machine.InstanceId()
 	if err != nil {
 		if !params.IsCodeNotProvisioned(err) {
-			return None, errors.Annotatef(err, "failed to load machine id:%s, details:%v", machine.Id(), machine)
+			return None, errors.Annotatef(err, "loading machine id:%s, details:%v", machine.Id(), machine)
 		}
 		machineStatus, _, err := machine.Status()
 		if err != nil {
@@ -745,7 +745,7 @@ func (task *provisionerTask) doStopInstances(ctx context.ProviderCallContext, in
 		ids[i] = inst.Id()
 	}
 	if err := task.broker.StopInstances(ctx, ids...); err != nil {
-		return errors.Annotate(err, "broker failed to stop instances")
+		return errors.Annotate(err, "stopping instances")
 	}
 	return nil
 }
@@ -758,7 +758,7 @@ func (task *provisionerTask) constructInstanceConfig(
 
 	apiInfo, err := auth.SetupAuthentication(machine)
 	if err != nil {
-		return nil, errors.Annotate(err, "failed to setup authentication")
+		return nil, errors.Annotate(err, "setting up authentication")
 	}
 
 	// Generated a nonce for the new instance, with the format: "machine-#:UUID".
@@ -766,7 +766,7 @@ func (task *provisionerTask) constructInstanceConfig(
 	// is running on, while the second part is a random UUID.
 	uuid, err := utils.NewUUID()
 	if err != nil {
-		return nil, errors.Annotate(err, "failed to generate a nonce for machine "+machine.Id())
+		return nil, errors.Annotate(err, "generating nonce for machine "+machine.Id())
 	}
 
 	nonce := fmt.Sprintf("%s:%s", task.hostTag, uuid)
@@ -1197,7 +1197,7 @@ func (task *provisionerTask) setErrorStatus(msg string, machine apiprovisioner.M
 	errForStatus := errors.Cause(err)
 	if err2 := machine.SetInstanceStatus(status.ProvisioningError, errForStatus.Error(), nil); err2 != nil {
 		// Something is wrong with this machine, better report it back.
-		return errors.Annotatef(err2, "cannot set error status for machine %q", machine)
+		return errors.Annotatef(err2, "setting error status for machine %q", machine)
 	}
 	return nil
 }
@@ -1355,12 +1355,12 @@ func (task *provisionerTask) doStartMachine(ctx context.ProviderCallContext, mac
 	); err != nil {
 		// We need to stop the instance right away here, set error status and go on.
 		if err2 := task.setErrorStatus("cannot register instance for machine %v: %v", machine, err); err2 != nil {
-			task.logger.Errorf("%v", errors.Annotate(err2, "cannot set machine's status"))
+			task.logger.Errorf("%v", errors.Annotate(err2, "setting machine status"))
 		}
 		if err2 := task.broker.StopInstances(ctx, instanceID); err2 != nil {
 			task.logger.Errorf("%v", errors.Annotate(err2, "after failing to set instance info"))
 		}
-		return errors.Annotate(err, "cannot set instance info")
+		return errors.Annotate(err, "setting instance info")
 	}
 
 	task.logger.Infof(
@@ -1402,7 +1402,7 @@ func (task *provisionerTask) setupToStartMachine(machine apiprovisioner.MachineP
 
 	possibleTools, err := task.toolsFinder.FindTools(*version, pInfo.Series, arch)
 	if err != nil {
-		return environs.StartInstanceParams{}, errors.Annotatef(err, "cannot find agent binaries for machine %q", machine)
+		return environs.StartInstanceParams{}, errors.Annotatef(err, "finding agent binaries for machine %q", machine)
 	}
 
 	startInstanceParams, err := task.constructStartInstanceParams(
@@ -1413,7 +1413,7 @@ func (task *provisionerTask) setupToStartMachine(machine apiprovisioner.MachineP
 		possibleTools,
 	)
 	if err != nil {
-		return environs.StartInstanceParams{}, errors.Annotatef(err, "cannot construct params for machine %q", machine)
+		return environs.StartInstanceParams{}, errors.Annotatef(err, "constructing params for machine %q", machine)
 	}
 
 	return startInstanceParams, nil

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -802,6 +802,93 @@ func (s *ProvisionerTaskSuite) TestResizeWorkerPool(c *gc.C) {
 	workertest.CleanKill(c, task)
 }
 
+func (s *ProvisionerTaskSuite) TestUpdatedZonesReflectedInAZMachineSlice(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	m0 := &testMachine{id: "0", life: life.Alive}
+	s.setUpMachines(m0)
+
+	broker := mocks.NewMockZonedEnviron(ctrl)
+	exp := broker.EXPECT()
+
+	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil).MinTimes(1)
+	exp.InstanceAvailabilityZoneNames(s.callCtx, []instance.Id{s.instances[0].Id()}).Return(
+		map[instance.Id]string{}, nil).Do(func(_ ...interface{}) { close(s.setupDone) })
+
+	az1 := mocks.NewMockAvailabilityZone(ctrl)
+	az1.EXPECT().Name().Return("az1").MinTimes(1)
+	az1.EXPECT().Available().Return(true).MinTimes(1)
+
+	az2 := mocks.NewMockAvailabilityZone(ctrl)
+	az2.EXPECT().Name().Return("az2").MinTimes(1)
+	az2.EXPECT().Available().Return(true).MinTimes(1)
+
+	az3 := mocks.NewMockAvailabilityZone(ctrl)
+	az3.EXPECT().Name().Return("az3").MinTimes(1)
+	az3.EXPECT().Available().Return(true).MinTimes(1)
+
+	// Return 1 availability zone on the first call, then 3, then 1 again.
+	// See steps below punctuated by sending machine changes.
+	gomock.InOrder(
+		exp.AvailabilityZones(s.callCtx).Return(network.AvailabilityZones{az1}, nil),
+		exp.AvailabilityZones(s.callCtx).Return(network.AvailabilityZones{az1, az2, az3}, nil),
+		exp.AvailabilityZones(s.callCtx).Return(network.AvailabilityZones{az1}, nil),
+	)
+
+	step := make(chan struct{}, 1)
+
+	// We really don't care about these calls.
+	// StartInstance is just a synchronisation point.
+	exp.DeriveAvailabilityZones(s.callCtx, gomock.Any()).Return([]string{}, nil).AnyTimes()
+	exp.StartInstance(s.callCtx, gomock.Any()).Return(&environs.StartInstanceResult{
+		Instance: &testInstance{id: "instance-0"},
+	}, nil).AnyTimes().Do(func(...interface{}) {
+		select {
+		case step <- struct{}{}:
+		case <-time.After(testing.LongWait):
+			c.Fatalf("timed out writing to step channel")
+		}
+	})
+
+	task := s.newProvisionerTaskWithBroker(c, broker, nil, numProvisionWorkersForTesting)
+
+	syncStep := func() {
+		select {
+		case <-step:
+		case <-time.After(testing.LongWait):
+			c.Fatalf("timed out reading from step channel")
+		}
+	}
+
+	s.sendModelMachinesChange(c, "0")
+
+	// After the first change, there is only one AZ in the tracker.
+	syncStep()
+	azm := provisioner.GetCopyAvailabilityZoneMachines(task)
+	c.Assert(azm, gc.HasLen, 1)
+	c.Assert(azm[0].ZoneName, gc.Equals, "az1")
+
+	s.sendModelMachinesChange(c, "0")
+
+	// After the second change, we see all 3 AZs.
+	syncStep()
+	azm = provisioner.GetCopyAvailabilityZoneMachines(task)
+	c.Assert(azm, gc.HasLen, 3)
+	c.Assert([]string{azm[0].ZoneName, azm[1].ZoneName, azm[2].ZoneName}, jc.SameContents, []string{"az1", "az2", "az3"})
+
+	s.sendModelMachinesChange(c, "0")
+
+	// At this point, we will have had a deployment to one of the zones added
+	// in the prior step. This means one will be removed from tracking,
+	// but the one we deployed to will not be deleted.
+	syncStep()
+	azm = provisioner.GetCopyAvailabilityZoneMachines(task)
+	c.Assert(azm, gc.HasLen, 2)
+
+	workertest.CleanKill(c, task)
+}
+
 // setUpZonedEnviron creates a mock environ with instances based on those set
 // on the test suite, and 3 availability zones.
 func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller, machines ...*testMachine) *mocks.MockZonedEnviron {
@@ -809,14 +896,8 @@ func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller, machin
 	if len(machines) == 0 {
 		return broker
 	}
-	for _, m := range machines {
-		inst := &testInstance{id: m.id}
-		s.instances = append(s.instances, inst)
-		s.machinesResults = append(s.machinesResults, apiprovisioner.MachineResult{Machine: m})
-		s.machineStatusResults = append(s.machineStatusResults, apiprovisioner.MachineStatusResult{Machine: m, Status: params.StatusResult{
-			Status: "pending",
-		}})
-	}
+
+	s.setUpMachines(machines...)
 
 	instanceIds := make([]instance.Id, len(s.instances))
 	for i, inst := range s.instances {
@@ -839,6 +920,17 @@ func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller, machin
 	)
 	exp.AvailabilityZones(s.callCtx).Return(zones, nil).MinTimes(1)
 	return broker
+}
+
+func (s *ProvisionerTaskSuite) setUpMachines(machines ...*testMachine) {
+	for _, m := range machines {
+		inst := &testInstance{id: m.id}
+		s.instances = append(s.instances, inst)
+		s.machinesResults = append(s.machinesResults, apiprovisioner.MachineResult{Machine: m})
+		s.machineStatusResults = append(s.machineStatusResults, apiprovisioner.MachineStatusResult{
+			Machine: m, Status: params.StatusResult{Status: "pending"},
+		})
+	}
 }
 
 func (s *ProvisionerTaskSuite) waitForWorkerSetup(c *gc.C, msg string) {
@@ -931,7 +1023,13 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithBroker(c *gc.C, broker envi
 	return s.newProvisionerTaskWithBrokerAndEventCb(c, broker, distributionGroups, numProvisionWorkers, nil)
 }
 
-func (s *ProvisionerTaskSuite) newProvisionerTaskWithBrokerAndEventCb(c *gc.C, broker environs.InstanceBroker, distributionGroups map[names.MachineTag][]string, numProvisionWorkers int, evtCb func(string)) provisioner.ProvisionerTask {
+func (s *ProvisionerTaskSuite) newProvisionerTaskWithBrokerAndEventCb(
+	c *gc.C,
+	broker environs.InstanceBroker,
+	distributionGroups map[names.MachineTag][]string,
+	numProvisionWorkers int,
+	evtCb func(string),
+) provisioner.ProvisionerTask {
 	task, err := provisioner.NewProvisionerTask(
 		coretesting.ControllerTag.Id(),
 		names.NewMachineTag("0"),

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -627,7 +627,7 @@ func (s *ProvisionerTaskSuite) TestPopulateAZMachinesErrorWorkerStopped(c *gc.C)
 	s.waitForWorkerSetup(c, "worker not set up")
 
 	err := workertest.CheckKill(c, task)
-	c.Assert(err, gc.ErrorMatches, "failed to process updated machines: .* boom")
+	c.Assert(err, gc.ErrorMatches, "updating AZ distributions: boom")
 }
 
 func (s *ProvisionerTaskSuite) TestDedupStopRequests(c *gc.C) {
@@ -827,17 +827,17 @@ func (s *ProvisionerTaskSuite) setUpZonedEnviron(ctrl *gomock.Controller, machin
 	zones := make(network.AvailabilityZones, 3)
 	for i := 0; i < 3; i++ {
 		az := mocks.NewMockAvailabilityZone(ctrl)
-		az.EXPECT().Name().Return(fmt.Sprintf("az%d", i+1))
-		az.EXPECT().Available().Return(true)
+		az.EXPECT().Name().Return(fmt.Sprintf("az%d", i+1)).MinTimes(1)
+		az.EXPECT().Available().Return(true).MinTimes(1)
 		zones[i] = az
 	}
 
 	exp := broker.EXPECT()
-	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil).MinTimes(2)
-	exp.InstanceAvailabilityZoneNames(s.callCtx, instanceIds).Return(map[instance.Id]string{}, nil).Do(func(_ ...interface{}) {
-		close(s.setupDone)
-	})
-	exp.AvailabilityZones(s.callCtx).Return(zones, nil)
+	exp.AllRunningInstances(s.callCtx).Return(s.instances, nil).MinTimes(1)
+	exp.InstanceAvailabilityZoneNames(s.callCtx, instanceIds).Return(map[instance.Id]string{}, nil).Do(
+		func(_ ...interface{}) { close(s.setupDone) },
+	)
+	exp.AvailabilityZones(s.callCtx).Return(zones, nil).MinTimes(1)
 	return broker
 }
 

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1269,7 +1269,7 @@ func (s *ProvisionerSuite) TestMachineErrorsRetainInstances(c *gc.C) {
 	)
 	defer func() {
 		err := worker.Stop(task)
-		c.Assert(err, gc.ErrorMatches, ".*failed to get machine.*")
+		c.Assert(err, gc.ErrorMatches, ".*getting machine.*")
 	}()
 	s.checkNoOperations(c)
 }
@@ -1462,7 +1462,9 @@ func assertAvailabilityZoneMachines(c *gc.C,
 			found := 0
 			for _, zoneInfo := range obtained {
 				if zone == zoneInfo.ZoneName {
-					c.Assert(zoneInfo.MachineIds.Contains(m.Id()), gc.Equals, true)
+					c.Assert(zoneInfo.MachineIds.Contains(m.Id()), gc.Equals, true, gc.Commentf(
+						"machine %q not found in list for zone %q; zone list: %#v", m.Id(), zone, zoneInfo,
+					))
 					found += 1
 				}
 			}
@@ -1670,8 +1672,8 @@ func (s *ProvisionerSuite) TestProvisioningMachinesSingleMachineDGFailure(c *gc.
 
 func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStopMachines(c *gc.C) {
 	// Per provider dummy, there will be 3 available availability zones.
-	task := s.newProvisionerTask(c, config.HarvestDestroyed, s.Environ, s.provisioner, &mockDistributionGroupFinder{}, mockToolsFinder{})
-	defer workertest.CleanKill(c, task)
+	task := s.newProvisionerTask(
+		c, config.HarvestDestroyed, s.Environ, s.provisioner, &mockDistributionGroupFinder{}, mockToolsFinder{})
 
 	machines, err := s.addMachines(4)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1674,6 +1674,7 @@ func (s *ProvisionerSuite) TestAvailabilityZoneMachinesStopMachines(c *gc.C) {
 	// Per provider dummy, there will be 3 available availability zones.
 	task := s.newProvisionerTask(
 		c, config.HarvestDestroyed, s.Environ, s.provisioner, &mockDistributionGroupFinder{}, mockToolsFinder{})
+	defer workertest.CleanKill(c, task)
 
 	machines, err := s.addMachines(4)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
If a cloud's availability zones change, the Juju provisioner will not represent the change unless the controller agent is restarted. This is because we only ever load the provisioner's AZ-to-machines tracker upon start-up.

This patch follows #13926, which removes provider zone caching, fetching AZs from the cloud upon every call to `AvailabilityZones`.

Here, we load the distribution info from the provider at start-up as before, but each time we process a batch of machine changes, we re-query the cloud availability zones.
- New zones are added to the tracker.
- Zones no longer available are removed if we have no machines in those zones.
- A warning is logged for zones no longer available if the tracker indicates we have machines provisioned there.

To ease review, discount the first (mechanical) commit.

## QA steps

I used MAAS, where changing AZs is simple. One can use the _finfolk_ MAAS like this:
- Connect to the VPN.
- `sshuttle -r finfolk 10.0.30.0/24`.
- Connect via http://10.0.30.1:5240/MAAS/r/machines using the creds in cloud-city.
- See clouds.yaml and credentials.yaml in cloud-city to source local Juju cloud/cred.

Then:
- Run `juju debug-log` in its own terminal.
- Add a machine and observe the logged AZs:
```
controller-0: 17:23:11 INFO juju.worker.provisioner provisioning in zones: [default]
```
- Use the MAAS UI to add a new zone and then another machine; see the new AZ indicated:
```
controller-0: 17:25:19 INFO juju.worker.provisioner provisioning in zones: [default staging]
```
- Delete the added zone and add another machine to see the added zone above, now deleted:
```
controller-0: 17:29:48 INFO juju.worker.provisioner provisioning in zones: [default]
```

## Documentation changes

None.

## Bug reference

N/A
