### PR TITLE
[JUJU-883] Verify endpoint bindings when deploying bundles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Go can be [installed](https://golang.org/doc/install#install) from the official 
 
 Juju uses Go modules and does not depend on GOPATH, therefore you can check juju out anywhere.
 
-### Change to the Juju source code directory  
+### Change to the Juju source code directory
 
     cd juju
 
@@ -254,7 +254,7 @@ Testing
 -------
 
 Some tests may require local lxd to be installed, see
-[installing lxd via snap](https://stgraber.org/2016/10/17/lxd-snap-available/).  
+[installing lxd via snap](https://stgraber.org/2016/10/17/lxd-snap-available/).
 
 Juju uses the `gocheck` testing framework, which is automatically installed
 as a dependency of `juju`. You can read more about `gocheck` at

--- a/cmd/juju/application/bind.go
+++ b/cmd/juju/application/bind.go
@@ -196,18 +196,18 @@ func (c *bindCommand) parseBindExpression(apiRoot base.APICallCloser) error {
 	}
 
 	// Fetch known spaces from server
-	knownSpaceList, err := c.NewSpacesClient(apiRoot).ListSpaces()
+	knownSpaces, err := c.NewSpacesClient(apiRoot).ListSpaces()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	knownSpaces := make([]string, 0, len(knownSpaceList))
-	for _, sp := range knownSpaceList {
-		knownSpaces = append(knownSpaces, sp.Name)
+	knownSpaceNames := set.NewStrings()
+	for _, space := range knownSpaces {
+		knownSpaceNames.Add(space.Name)
 	}
 
 	// Parse expression
-	bindings, err := parseBindExpr(c.BindExpression, knownSpaces)
+	bindings, err := parseBindExpr(c.BindExpression, knownSpaceNames)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/binding.go
+++ b/cmd/juju/application/binding.go
@@ -20,14 +20,9 @@ const parseBindErrorPrefix = "--bind must be in the form '[<default-space>] [<en
 // * space-name (equivalent to binding all endpoints to the same space, i.e. application-default)
 // * The above in a space separated list to specify multiple bindings,
 //   e.g. "rel1=space1 ext1=space2 space3"
-func parseBindExpr(expr string, knownSpaces []string) (map[string]string, error) {
+func parseBindExpr(expr string, knownSpaceNames set.Strings) (map[string]string, error) {
 	if expr == "" {
 		return nil, nil
-	}
-
-	knownSpaceMap := make(map[string]struct{})
-	for _, spaceName := range knownSpaces {
-		knownSpaceMap[spaceName] = struct{}{}
 	}
 
 	parsedBindings := make(map[string]string)
@@ -54,7 +49,7 @@ func parseBindExpr(expr string, knownSpaces []string) (map[string]string, error)
 		// default spaceName lands.
 		spaceName = strings.Trim(spaceName, `"`)
 
-		if _, exists := knownSpaceMap[spaceName]; !exists {
+		if !knownSpaceNames.Contains(spaceName) {
 			return nil, errors.NotFoundf("space %q", spaceName)
 		}
 

--- a/cmd/juju/application/binding_test.go
+++ b/cmd/juju/application/binding_test.go
@@ -31,38 +31,38 @@ func (s *ParseBindSuite) TestParseSuccessWithEmptyArgs(c *gc.C) {
 }
 
 func (s *ParseBindSuite) TestParseSuccessWithEndpointsOnly(c *gc.C) {
-	knownSpaces := []string{"a", "b"}
-	s.checkParseOKForExpr(c, "foo=a bar=b", knownSpaces, map[string]string{"foo": "a", "bar": "b"})
+	knownSpaceNames := set.NewStrings("a", "b")
+	s.checkParseOKForExpr(c, "foo=a bar=b", knownSpaceNames, map[string]string{"foo": "a", "bar": "b"})
 }
 
 func (s *ParseBindSuite) TestParseSuccessWithApplicationDefaultSpaceOnly(c *gc.C) {
-	knownSpaces := []string{"application-default"}
-	s.checkParseOKForExpr(c, "application-default", knownSpaces, map[string]string{"": "application-default"})
+	knownSpaceNames := set.NewStrings("application-default")
+	s.checkParseOKForExpr(c, "application-default", knownSpaceNames, map[string]string{"": "application-default"})
 }
 
 func (s *ParseBindSuite) TestBindingsOrderForDefaultSpaceAndEndpointsDoesNotMatter(c *gc.C) {
-	knownSpaces := []string{"sp3", "sp1", "sp2"}
+	knownSpaceNames := set.NewStrings("sp3", "sp1", "sp2")
 	expectedBindings := map[string]string{
 		"ep1": "sp1",
 		"ep2": "sp2",
 		"":    "sp3",
 	}
-	s.checkParseOKForExpr(c, "ep1=sp1 ep2=sp2 sp3", knownSpaces, expectedBindings)
-	s.checkParseOKForExpr(c, "ep1=sp1 sp3 ep2=sp2", knownSpaces, expectedBindings)
-	s.checkParseOKForExpr(c, "ep2=sp2 ep1=sp1 sp3", knownSpaces, expectedBindings)
-	s.checkParseOKForExpr(c, "ep2=sp2 sp3 ep1=sp1", knownSpaces, expectedBindings)
-	s.checkParseOKForExpr(c, "sp3 ep1=sp1 ep2=sp2", knownSpaces, expectedBindings)
-	s.checkParseOKForExpr(c, "sp3 ep2=sp2 ep1=sp1", knownSpaces, expectedBindings)
+	s.checkParseOKForExpr(c, "ep1=sp1 ep2=sp2 sp3", knownSpaceNames, expectedBindings)
+	s.checkParseOKForExpr(c, "ep1=sp1 sp3 ep2=sp2", knownSpaceNames, expectedBindings)
+	s.checkParseOKForExpr(c, "ep2=sp2 ep1=sp1 sp3", knownSpaceNames, expectedBindings)
+	s.checkParseOKForExpr(c, "ep2=sp2 sp3 ep1=sp1", knownSpaceNames, expectedBindings)
+	s.checkParseOKForExpr(c, "sp3 ep1=sp1 ep2=sp2", knownSpaceNames, expectedBindings)
+	s.checkParseOKForExpr(c, "sp3 ep2=sp2 ep1=sp1", knownSpaceNames, expectedBindings)
 }
 
 func (s *ParseBindSuite) TestParseWithEmptyQuotedDefaultSpace(c *gc.C) {
-	knownSpaces := []string{"", "sp1"}
+	knownSpaceNames := set.NewStrings("", "sp1")
 	expectedBindings := map[string]string{
 		"ep1": "sp1",
 		"ep2": "",
 		"":    "",
 	}
-	s.checkParseOKForExpr(c, `"" ep2="" ep1=sp1`, knownSpaces, expectedBindings)
+	s.checkParseOKForExpr(c, `"" ep2="" ep1=sp1`, knownSpaceNames, expectedBindings)
 }
 
 func (s *ParseBindSuite) TestParseFailsWithSpaceNameButNoEndpoint(c *gc.C) {
@@ -100,14 +100,14 @@ func (s *ParseBindSuite) TestMergeBindingsNewBindingsInheritDefaultSpace(c *gc.C
 	c.Assert(mergedBindings, gc.DeepEquals, expMergedBindings)
 }
 
-func (s *ParseBindSuite) checkParseOKForExpr(c *gc.C, expr string, knownSpaces []string, expectedBindings map[string]string) {
-	parsedBindings, err := parseBindExpr(expr, knownSpaces)
+func (s *ParseBindSuite) checkParseOKForExpr(c *gc.C, expr string, knownSpaceNames set.Strings, expectedBindings map[string]string) {
+	parsedBindings, err := parseBindExpr(expr, knownSpaceNames)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(parsedBindings, jc.DeepEquals, expectedBindings)
 }
 
-func (s *ParseBindSuite) checkParseFailsForExpr(c *gc.C, expr string, knownSpaces []string, expectedErrorSuffix string) {
-	parsedBindings, err := parseBindExpr(expr, knownSpaces)
+func (s *ParseBindSuite) checkParseFailsForExpr(c *gc.C, expr string, knownSpaceNames set.Strings, expectedErrorSuffix string) {
+	parsedBindings, err := parseBindExpr(expr, knownSpaceNames)
 	c.Check(err.Error(), gc.Equals, expectedErrorSuffix)
 	c.Check(parsedBindings, gc.IsNil)
 }

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/charm/v8"
 	csparams "github.com/juju/charmrepo/v6/csclient/params"
 	"github.com/juju/cmd/v3"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
@@ -866,18 +867,18 @@ func (c *DeployCommand) parseBindFlag(api SpacesAPI) error {
 	}
 
 	// Fetch known spaces from server
-	knownSpaceList, err := api.ListSpaces()
+	knownSpaces, err := api.ListSpaces()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	knownSpaces := make([]string, 0, len(knownSpaceList))
-	for _, sp := range knownSpaceList {
-		knownSpaces = append(knownSpaces, sp.Name)
+	knownSpaceNames := set.NewStrings()
+	for _, space := range knownSpaces {
+		knownSpaceNames.Add(space.Name)
 	}
 
 	// Parse expression
-	bindings, err := parseBindExpr(c.BindToSpaces, knownSpaces)
+	bindings, err := parseBindExpr(c.BindToSpaces, knownSpaceNames)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -50,13 +50,6 @@ type SpacesAPI interface {
 
 var supportedJujuSeries = series.WorkloadSeries
 
-type DeployAPI interface {
-	deployer.DeployerAPI
-	SpacesAPI
-	// PlanURL returns the configured URL prefix for the metering plan API.
-	PlanURL() string
-}
-
 type CharmsAPI interface {
 	store.CharmsAPI
 	BestAPIVersion() int
@@ -211,7 +204,7 @@ func newDeployCommand() *DeployCommand {
 
 		return charmhub.NewClient(cfg)
 	}
-	deployCmd.NewDeployAPI = func() (DeployAPI, error) {
+	deployCmd.NewDeployAPI = func() (deployer.DeployerAPI, error) {
 		apiRoot, err := deployCmd.newAPIRoot()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -344,7 +337,7 @@ type DeployCommand struct {
 	BundleMachines map[string]string
 
 	// NewDeployAPI stores a function which returns a new deploy client.
-	NewDeployAPI func() (DeployAPI, error)
+	NewDeployAPI func() (deployer.DeployerAPI, error)
 
 	// NewCharmRepo stores a function which returns a charm store client.
 	NewCharmRepo func() (*store.CharmStoreAdaptor, error)

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/cmd/v3"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/client/application"
@@ -163,7 +164,10 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 			}
 		}
 	}
-	spec := d.makeBundleDeploySpec(ctx, deployAPI)
+	spec, err := d.makeBundleDeploySpec(ctx, deployAPI)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// TODO(ericsnow) Do something with the CS macaroons that were returned?
 	// Deploying bundles does not allow the use force, it's expected that the
@@ -174,7 +178,7 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 	return nil
 }
 
-func (d *deployBundle) makeBundleDeploySpec(ctx *cmd.Context, apiRoot DeployerAPI) bundleDeploySpec {
+func (d *deployBundle) makeBundleDeploySpec(ctx *cmd.Context, apiRoot DeployerAPI) (bundleDeploySpec, error) {
 	// set the consumer details API factory method on the spec, so it makes it
 	// possible to communicate with other controllers, that are found within
 	// the local cache.
@@ -186,6 +190,16 @@ func (d *deployBundle) makeBundleDeploySpec(ctx *cmd.Context, apiRoot DeployerAP
 			url.Source = d.controllerName
 		}
 		return d.newConsumeDetailsAPI(url)
+	}
+
+	knownSpaces, err := apiRoot.ListSpaces()
+	if err != nil {
+		return bundleDeploySpec{}, errors.Trace(err)
+	}
+
+	knownSpaceNames := set.NewStrings()
+	for _, space := range knownSpaces {
+		knownSpaceNames.Add(space.Name)
 	}
 
 	return bundleDeploySpec{
@@ -213,7 +227,8 @@ func (d *deployBundle) makeBundleDeploySpec(ctx *cmd.Context, apiRoot DeployerAP
 		targetModelUUID:      d.targetModelUUID,
 		controllerName:       d.controllerName,
 		accountUser:          d.accountUser,
-	}
+		knownSpaceNames:      knownSpaceNames,
+	}, nil
 }
 
 type localBundle struct {

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -78,6 +78,8 @@ type bundleDeploySpec struct {
 	targetModelUUID string
 	controllerName  string
 	accountUser     string
+
+	knownSpaceNames set.Strings
 }
 
 // deployBundle deploys the given bundle data using the given API client and
@@ -187,6 +189,10 @@ type bundleHandler struct {
 	// each origin.
 	origins map[charm.URL]map[string]commoncharm.Origin
 
+	// knownSpaceNames is a set of the names of existing spaces an application
+	// can bind to
+	knownSpaceNames set.Strings
+
 	// watcher holds an environment mega-watcher used to keep the environment
 	// status up to date.
 	watcher api.AllWatch
@@ -243,6 +249,7 @@ func makeBundleHandler(defaultCharmSchema charm.Schema, bundleData *charm.Bundle
 		unitStatus:           make(map[string]string),
 		macaroons:            make(map[charm.URL]*macaroon.Macaroon),
 		origins:              make(map[charm.URL]map[string]commoncharm.Origin),
+		knownSpaceNames:      spec.knownSpaceNames,
 
 		targetModelName: spec.targetModelName,
 		targetModelUUID: spec.targetModelUUID,
@@ -799,6 +806,11 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 		return errors.Trace(err)
 	} else if curl == nil {
 		return errors.Errorf("unexpected application charm URL %q", p.Charm)
+	}
+
+	err = verifyEndpointBindings(p.EndpointBindings, h.knownSpaceNames)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	channel, err := constructNormalizedChannel(p.Channel)
@@ -1710,4 +1722,13 @@ func addCharmConstraintsParser(s string) bundlechanges.ArchConstraint {
 	return bundleArchConstraint{
 		constraints: s,
 	}
+}
+
+func verifyEndpointBindings(endpointBindings map[string]string, knownSpaceNames set.Strings) error {
+	for _, spaceName := range endpointBindings {
+		if !knownSpaceNames.Contains(spaceName) {
+			return errors.NotFoundf("space %q", spaceName)
+		}
+	}
+	return nil
 }

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -110,6 +110,10 @@ type DeployerAPI interface {
 	ModelAPI
 	OfferAPI
 
+	// PlanURL returns the configured URL prefix for the metering plan API.
+	PlanURL() string
+
+	ListSpaces() ([]apiparams.Space, error)
 	Deploy(application.DeployArgs) error
 	Status(patterns []string) (*apiparams.FullStatus, error)
 	WatchAll() (api.AllWatch, error)

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -460,6 +460,21 @@ func (mr *MockDeployerAPIMockRecorder) IsMetered(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetered", reflect.TypeOf((*MockDeployerAPI)(nil).IsMetered), arg0)
 }
 
+// ListSpaces mocks base method.
+func (m *MockDeployerAPI) ListSpaces() ([]params.Space, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSpaces")
+	ret0, _ := ret[0].([]params.Space)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSpaces indicates an expected call of ListSpaces.
+func (mr *MockDeployerAPIMockRecorder) ListSpaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSpaces", reflect.TypeOf((*MockDeployerAPI)(nil).ListSpaces))
+}
+
 // ModelGet mocks base method.
 func (m *MockDeployerAPI) ModelGet() (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
@@ -518,6 +533,20 @@ func (m *MockDeployerAPI) Offer(arg0, arg1 string, arg2 []string, arg3, arg4, ar
 func (mr *MockDeployerAPIMockRecorder) Offer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Offer", reflect.TypeOf((*MockDeployerAPI)(nil).Offer), arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// PlanURL mocks base method.
+func (m *MockDeployerAPI) PlanURL() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PlanURL")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// PlanURL indicates an expected call of PlanURL.
+func (mr *MockDeployerAPIMockRecorder) PlanURL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlanURL", reflect.TypeOf((*MockDeployerAPI)(nil).PlanURL))
 }
 
 // ScaleApplication mocks base method.

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -520,18 +520,18 @@ func (c *refreshCommand) parseBindFlag(apiRoot base.APICallCloser) error {
 	}
 
 	// Fetch known spaces from server
-	knownSpaceList, err := c.NewSpacesClient(apiRoot).ListSpaces()
+	knownSpaces, err := c.NewSpacesClient(apiRoot).ListSpaces()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	knownSpaces := make([]string, 0, len(knownSpaceList))
-	for _, sp := range knownSpaceList {
-		knownSpaces = append(knownSpaces, sp.Name)
+	knownSpaceNames := set.NewStrings()
+	for _, space := range knownSpaces {
+		knownSpaceNames.Add(space.Name)
 	}
 
 	// Parse expression
-	bindings, err := parseBindExpr(c.BindToSpaces, knownSpaces)
+	bindings, err := parseBindExpr(c.BindToSpaces, knownSpaceNames)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
Similar to how bindings with --bind are verified here:
https://github.com/juju/juju/blob/5a29872ebdae8b293a77ca33f8b43da01401edbe/cmd/juju/application/binding.go#L57-L59

Verify endpoint bindings when adding handling application deployments inside of bundles

This involved having access to SpaceAPI.ListSpaces inside of deployer package. SpaceAPI has (somewhat unfortunately) been duplicated to resolve a circular dependency. If there is a better way, I'm all ears

This also makes https://github.com/juju/juju/pull/13928 redundant

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

#### Bootstrap to aws and add some spaces
```sh
$ juju spaces
Name   Space ID  Subnets       
alpha  0         172.31.16.0/20
                 252.16.0.0/12 
beta   1         172.31.48.0/24
                 252.48.0.0/16 
gamma  2         172.31.32.0/20
                 252.32.0.0/12 
```

#### Create a basic bundle
```sh
$ cat bundle.yaml
series: focal
applications:
  grafana:
    charm: grafana
    channel: stable
    revision: 51
    num_units: 1
    constraints: arch=amd64
    bindings:
      "": $SPACE_NAME
```
and attempt a deployment for multiple values of $SPACE_NAME

#### $SPACE_NAME = 1
```sh
$ juju deploy ./graf.yaml
Located charm "grafana" in charm-hub, channel stable
Executing changes:
- upload charm grafana from charm-hub for series focal with revision 51 with architecture=amd64
- deploy application grafana from charm-hub on focal with stable
ERROR cannot deploy bundle: space "1" not found
```

#### $SPACE_NAME = beta
```sh
$ juju deploy ./graf.yaml
Located charm "grafana" in charm-hub, channel stable
Executing changes:
- upload charm grafana from charm-hub for series focal with revision 51 with architecture=amd64
- deploy application grafana from charm-hub on focal with stable
- add unit grafana/1 to new machine 1
Deploy of bundle completed.
```

### $SPACE_NAME = delta
```sh
$ juju deploy ./graf.yaml
Located charm "grafana" in charm-hub, channel stable
Executing changes:
- upload charm grafana from charm-hub for series focal with revision 51 with architecture=amd64
- deploy application grafana from charm-hub on focal with stable
ERROR cannot deploy bundle: space "delta" not found
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1967766
Also resolves:
https://bugs.launchpad.net/juju/+bug/1943465
