### PR TITLE
Update run_* tests to test_* so juju-qa-jenkins generator picks them up

### DIFF
--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -1,4 +1,4 @@
-run_controller_model_admission() {
+test_controller_model_admission() {
 	# Echo out to ensure nice output to the test suite.
 	echo
 
@@ -82,7 +82,7 @@ EOF
 	destroy_model "${model_name}"
 }
 
-run_new_model_admission() {
+test_new_model_admission() {
 	# Echo out to ensure nice output to the test suite.
 	echo
 
@@ -167,7 +167,7 @@ EOF
 
 # Tests that after the model operator pod restarts it can come back up without
 # having to be validated by itself.
-run_model_chicken_and_egg() {
+test_model_chicken_and_egg() {
 	# Echo out to ensure nice output to the test suite.
 	echo
 

--- a/tests/suites/caasadmission/task.sh
+++ b/tests/suites/caasadmission/task.sh
@@ -14,9 +14,9 @@ test_caasadmission() {
 		microk8s.config >"${TEST_DIR}"/kube.conf
 		export KUBE_CONFIG="${TEST_DIR}"/kube.conf
 
-		run_controller_model_admission
-		run_new_model_admission
-		run_model_chicken_and_egg
+		test_controller_model_admission
+		test_new_model_admission
+		test_model_chicken_and_egg
 		;;
 	*)
 		echo "==> TEST SKIPPED: caas admission tests, not a k8s provider"

--- a/tests/suites/sidecar/sidecar.sh
+++ b/tests/suites/sidecar/sidecar.sh
@@ -1,4 +1,4 @@
-run_deploy_and_remove_application() {
+test_deploy_and_remove_application() {
 	echo
 
 	# Ensure that a valid Juju controller exists

--- a/tests/suites/sidecar/task.sh
+++ b/tests/suites/sidecar/task.sh
@@ -8,7 +8,7 @@ test_sidecar() {
 
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"k8s")
-        run_deploy_and_remove_application
+        test_deploy_and_remove_application
 		;;
 	*)
 		echo "==> TEST SKIPPED: sidecar charm tests, not a k8s provider"


### PR DESCRIPTION
I've already updated juju-qa-jenkins (https://github.com/canonical/juju-qa-jenkins/pull/732) to make these tests part of the generated tests, but they need to be called `test_*` instead of `run_*` for the generator to automatically pick them up. This PR makes that change to the existing `caasadmission` tests as well as the new `sidecar` tests.