### PR TITLE
[JUJU-896] Keep original origin when refreshing local charm

### DIFF
--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -111,6 +111,7 @@ func (d *factory) maybeReadLocal(charmAdder store.CharmAdder, charmRepo CharmRep
 	return func(cfg RefresherConfig) (Refresher, error) {
 		return &localCharmRefresher{
 			charmAdder:     charmAdder,
+			charmOrigin:    cfg.CharmOrigin,
 			charmRepo:      charmRepo,
 			charmURL:       cfg.CharmURL,
 			charmRef:       cfg.CharmRef,
@@ -174,6 +175,7 @@ func (d *factory) maybeCharmHub(charmAdder store.CharmAdder, charmResolver Charm
 type localCharmRefresher struct {
 	charmAdder     store.CharmAdder
 	charmRepo      CharmRepository
+	charmOrigin    corecharm.Origin
 	charmURL       *charm.URL
 	charmRef       string
 	deployedSeries string
@@ -201,12 +203,12 @@ func (d *localCharmRefresher) Refresh() (*CharmID, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+
+		newOrigin := d.charmOrigin
+		newOrigin.Source = corecharm.Local
 		return &CharmID{
-			URL: addedURL,
-			Origin: corecharm.Origin{
-				Source: corecharm.Local,
-				Type:   "charm",
-			},
+			URL:    addedURL,
+			Origin: newOrigin,
 		}, nil
 	}
 	if _, ok := err.(*charmrepo.NotFoundError); ok {

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -46,9 +46,9 @@ func (s *refresherFactorySuite) TestRefresh(c *gc.C) {
 		},
 	}
 
-	charmID, err := f.Run(cfg)
+	charmID2, err := f.Run(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charmID, gc.DeepEquals, charmID)
+	c.Assert(charmID2, gc.DeepEquals, charmID)
 }
 
 func (s *refresherFactorySuite) TestRefreshNotAllowed(c *gc.C) {
@@ -104,9 +104,9 @@ func (s *refresherFactorySuite) TestRefreshCallsAllRefreshers(c *gc.C) {
 		},
 	}
 
-	charmID, err := f.Run(cfg)
+	charmID2, err := f.Run(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charmID, gc.DeepEquals, charmID)
+	c.Assert(charmID2, gc.DeepEquals, charmID)
 }
 
 func (s *refresherFactorySuite) TestRefreshCallsRefreshersEvenAfterExhaustedError(c *gc.C) {
@@ -145,9 +145,9 @@ func (s *refresherFactorySuite) TestRefreshCallsRefreshersEvenAfterExhaustedErro
 		},
 	}
 
-	charmID, err := f.Run(cfg)
+	charmID2, err := f.Run(cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charmID, gc.DeepEquals, charmID)
+	c.Assert(charmID2, gc.DeepEquals, charmID)
 }
 
 type baseRefresherSuite struct{}
@@ -255,13 +255,8 @@ func (s *localCharmRefresherSuite) TestRefresh(c *gc.C) {
 
 	charmID, err := task.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charmID, gc.DeepEquals, &CharmID{
-		URL: curl,
-		Origin: corecharm.Origin{
-			Source: corecharm.Local,
-			Type:   "charm",
-		},
-	})
+	c.Assert(charmID.URL, gc.Equals, curl)
+	c.Assert(charmID.Origin.Source, gc.Equals, corecharm.Local)
 }
 
 func (s *localCharmRefresherSuite) TestRefreshBecomesExhausted(c *gc.C) {


### PR DESCRIPTION
Per @hmlanigan's comment [here](https://github.com/juju/juju/pull/13881#discussion_r842871836), we fix #13881 so that the `Origin` of the original charm is preserved. However, we do need to change the `Origin.Source` to "local" so that it prints properly on refresh:
```
Added local charm ...
```

## QA steps

```sh
juju deploy ch:hello-juju --revision=3 --channel=stable
charm pull hello-juju-4
juju refresh hello-juju --path ./hello-juju
# Cleanup
juju remove-application hello-juju
rm -r ./hello-juju
```