### PR TITLE
[JUJU-879] Don't validate during migration what isn't validated at deploy.

### DIFF
--- a/apiserver/resources_mig.go
+++ b/apiserver/resources_mig.go
@@ -134,9 +134,6 @@ func queryToResource(query url.Values) (charmresource.Resource, error) {
 	if res.Name == "" {
 		return empty, errors.BadRequestf("missing name")
 	}
-	if res.Description == "" {
-		return empty, errors.BadRequestf("missing description")
-	}
 	res.Type, err = charmresource.ParseType(query.Get("type"))
 	if err != nil {
 		return empty, errors.BadRequestf("invalid type")

--- a/apiserver/resources_mig_test.go
+++ b/apiserver/resources_mig_test.go
@@ -249,10 +249,6 @@ func (s *resourcesUploadSuite) TestArgValidation(c *gc.C) {
 	checkBadRequest(q, "missing path")
 
 	q = s.makeUploadArgs(c)
-	q.Del("description")
-	checkBadRequest(q, "missing description")
-
-	q = s.makeUploadArgs(c)
 	q.Set("type", "fooo")
 	checkBadRequest(q, "invalid type")
 


### PR DESCRIPTION
LP1967958. Validating the description of a resource blocks during migration. Descriptions are not essential to the resource. The time to validate this would be during deploy or charm upload to a repository.

## QA steps

```
$ juju bootstrap localhost dst
$ juju bootstrap localhost src
$ juju add-model move
$ juju deploy ubuntu
$ juju deploy octavia-diskimage-retrofit
$ juju relate ubuntu octavia-diskimage-retrofit

# wait for deploy to finish

$ juju migrate moveme dst
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1967958