### PR TITLE
[JUJU-897] Don't use coerced values when sending over the wire.

### DIFF
--- a/cmd/juju/controller/configcommand.go
+++ b/cmd/juju/controller/configcommand.go
@@ -234,7 +234,7 @@ func (c *configCommand) setConfig(client controllerAPI, ctx *cmd.Context) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	coerced, err := controller.NewConfig(ctrl.ControllerUUID, ctrl.CACert, attrs)
+	_, err = controller.NewConfig(ctrl.ControllerUUID, ctrl.CACert, attrs)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -243,7 +243,7 @@ func (c *configCommand) setConfig(client controllerAPI, ctx *cmd.Context) error 
 	values := make(map[string]interface{})
 	for k := range attrs {
 		if controller.AllowedUpdateConfigAttributes.Contains(k) {
-			values[k] = coerced[k]
+			values[k] = attrs[k]
 		} else {
 			extraValues.Add(k)
 		}

--- a/cmd/juju/controller/configcommand_test.go
+++ b/cmd/juju/controller/configcommand_test.go
@@ -214,7 +214,7 @@ func (s *ConfigSuite) TestSettingFromBothNoOverlap(c *gc.C) {
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
 		"juju-ha-space":         "value",
-		"audit-log-max-backups": 123,
+		"audit-log-max-backups": "123",
 	})
 }
 
@@ -232,7 +232,7 @@ func (s *ConfigSuite) TestSettingFromBothArgFirst(c *gc.C) {
 	// probably not worth fixing - I don't think people will try to
 	// set an option from a file and then override it from an arg.
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": 123,
+		"audit-log-max-backups": "123",
 	})
 }
 
@@ -246,7 +246,7 @@ func (s *ConfigSuite) TestSettingFromBothFileFirst(c *gc.C) {
 	c.Assert(output, gc.Equals, "")
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": 123,
+		"audit-log-max-backups": "123",
 	})
 }
 


### PR DESCRIPTION
`juju controller-config` has duration values that were not being sent over the wire as a duration string
because the values were being coerced into a time.Duration which has a int64 underlying type.

Since config is sent as a map[string]interface{}, the receiving end doesn't interpret it as a time.Duration, instead as a float64, because json.

## QA steps

`juju controller-config agent-ratelimit-rate=200ms`

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1967975