### PR TITLE
Fix typo in output of juju bootstrap --help

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -183,7 +183,7 @@ Examples:
     juju bootstrap --config controller-service-type=loadbalancer
 
     # For a bootstrap on k8s, setting the service type of the Juju controller service to External
-    juju bootstrap --config controller-service-type=external --config controller-service-name=controller.juju.is
+    juju bootstrap --config controller-service-type=external --config controller-external-name=controller.juju.is
 
 See also:
     add-credential


### PR DESCRIPTION

Fix typo in output of `juju bootstrap --help`. The config option `controller-service-name` should be `controller-external-name` instead.

## QA steps

```sh
juju bootstrap --help
```

## Documentation changes

I am not sure if `controller-service-name` is also mentioned anywhere in juju.is/docs

## Bug reference

I did not create a bug for this typo.