### PR TITLE
[JUJU-954] Improve juju deploy nameclash error msg

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -258,7 +258,12 @@ func (d *deployCharm) deploy(
 	}
 
 	if errors.IsAlreadyExists(err) {
-		return errors.Wrapf(err, errors.Errorf("\ndeploy application using an alias name, or use remove-application to remove the existing one and try again"), err.Error())
+		// Would be nice to be able to access the app name here
+		return errors.Wrapf(err, errors.Errorf(`
+deploy application using an alias name:
+    juju deploy <application> <alias>
+or use remove-application to remove the existing one and try again.`,
+		), err.Error())
 	}
 	return errors.Trace(err)
 


### PR DESCRIPTION
`juju deploy` gives an error message when you try to deploy an app with the same name as an existing app. However, the message did not make it clear how to solve the problem:

```sh
$ juju deploy foo
...
ERROR cannot add application "foo": application already exists: 
deploy application using an alias name, or use remove-application to
remove the existing one and try again

$ juju deploy --help | grep -i alias
# no output
# should I use an --alias flag? extra argument?
```

I've now improved this to give the user clear instructions:
```
$ juju deploy foo
...
ERROR cannot add application "foo": application already exists: 
deploy application using an alias name:
    juju deploy <application> <alias>
or use remove-application to remove the existing one and try again.
```

## QA steps

```sh
juju deploy hello-juju
juju deploy hello-juju
```