### PR TITLE
[JUJU-960] Fix/init container image pull secret

### DIFF
--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -111,7 +111,6 @@ func (c *Client) Life(appName string) (life.Value, error) {
 
 // ProvisioningInfo holds the info needed to provision an operator.
 type ProvisioningInfo struct {
-	ImagePath            string
 	Version              version.Number
 	APIAddresses         []string
 	CACert               string

--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -120,7 +120,7 @@ type ProvisioningInfo struct {
 	Filesystems          []storage.KubernetesFilesystemParams
 	Devices              []devices.KubernetesDeviceParams
 	Series               string
-	ImageRepo            docker.ImageRepoDetails
+	ImageDetails         resources.DockerImageDetails
 	CharmModifiedVersion int
 	CharmURL             *charm.URL
 	Trust                bool
@@ -146,29 +146,14 @@ func (c *Client) ProvisioningInfo(applicationName string) (ProvisioningInfo, err
 		return ProvisioningInfo{}, errors.Trace(maybeNotFound(err))
 	}
 
-	imageRepo := docker.ImageRepoDetails{
-		Repository:    r.ImageRepo.Repository,
-		ServerAddress: r.ImageRepo.ServerAddress,
-		BasicAuthConfig: docker.BasicAuthConfig{
-			Username: r.ImageRepo.Username,
-			Password: r.ImageRepo.Password,
-			Auth:     docker.NewToken(r.ImageRepo.Auth),
-		},
-		TokenAuthConfig: docker.TokenAuthConfig{
-			Email:         r.ImageRepo.Email,
-			IdentityToken: docker.NewToken(r.ImageRepo.IdentityToken),
-			RegistryToken: docker.NewToken(r.ImageRepo.RegistryToken),
-		},
-	}
 	info := ProvisioningInfo{
-		ImagePath:            r.ImagePath,
 		Version:              r.Version,
 		APIAddresses:         r.APIAddresses,
 		CACert:               r.CACert,
 		Tags:                 r.Tags,
 		Constraints:          r.Constraints,
 		Series:               r.Series,
-		ImageRepo:            imageRepo,
+		ImageDetails:         params.ConvertDockerImageInfo(r.ImageRepo),
 		CharmModifiedVersion: r.CharmModifiedVersion,
 		Trust:                r.Trust,
 		Scale:                r.Scale,

--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -157,7 +157,6 @@ func (c *Client) ProvisioningInfo(applicationName string) (ProvisioningInfo, err
 		Trust:                r.Trust,
 		Scale:                r.Scale,
 	}
-
 	for _, fs := range r.Filesystems {
 		f, err := filesystemFromParams(fs)
 		if err != nil {

--- a/api/controller/caasapplicationprovisioner/client_test.go
+++ b/api/controller/caasapplicationprovisioner/client_test.go
@@ -147,12 +147,14 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.CAASApplicationProvisioningInfoResults{})
 		*(result.(*params.CAASApplicationProvisioningInfoResults)) = params.CAASApplicationProvisioningInfoResults{
 			Results: []params.CAASApplicationProvisioningInfo{{
-				ImagePath:            "juju-operator-image",
-				Version:              vers,
-				APIAddresses:         []string{"10.0.0.1:1"},
-				Tags:                 map[string]string{"foo": "bar"},
-				Series:               "bionic",
-				ImageRepo:            params.DockerImageInfo{Repository: "jujuqa"},
+				Version:      vers,
+				APIAddresses: []string{"10.0.0.1:1"},
+				Tags:         map[string]string{"foo": "bar"},
+				Series:       "bionic",
+				ImageRepo: params.DockerImageInfo{
+					Repository:   "jujuqa",
+					RegistryPath: "juju-operator-image",
+				},
 				CharmModifiedVersion: 1,
 				CharmURL:             "cs:~test/charm-1",
 				Trust:                true,
@@ -163,12 +165,14 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 	info, err := client.ProvisioningInfo("gitlab")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, caasapplicationprovisioner.ProvisioningInfo{
-		ImagePath:            "juju-operator-image",
-		Version:              vers,
-		APIAddresses:         []string{"10.0.0.1:1"},
-		Tags:                 map[string]string{"foo": "bar"},
-		Series:               "bionic",
-		ImageRepo:            docker.ImageRepoDetails{Repository: "jujuqa"},
+		Version:      vers,
+		APIAddresses: []string{"10.0.0.1:1"},
+		Tags:         map[string]string{"foo": "bar"},
+		Series:       "bionic",
+		ImageDetails: params.ConvertDockerImageInfo(params.DockerImageInfo{
+			Repository:   "jujuqa",
+			RegistryPath: "juju-operator-image",
+		}),
 		CharmModifiedVersion: 1,
 		CharmURL:             &charm.URL{Schema: "cs", User: "test", Name: "charm", Revision: 1},
 		Trust:                true,

--- a/api/controller/caasoperatorprovisioner/client.go
+++ b/api/controller/caasoperatorprovisioner/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/docker"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/storage"
 )
@@ -135,25 +134,8 @@ func (c *Client) OperatorProvisioningInfo(applicationName string) (OperatorProvi
 	if err := info.Error; err != nil {
 		return OperatorProvisioningInfo{}, errors.Trace(err)
 	}
-	imageRepo := resources.DockerImageDetails{
-		RegistryPath: info.ImageDetails.RegistryPath,
-		ImageRepoDetails: docker.ImageRepoDetails{
-			Repository:    info.ImageDetails.Repository,
-			ServerAddress: info.ImageDetails.ServerAddress,
-			BasicAuthConfig: docker.BasicAuthConfig{
-				Username: info.ImageDetails.Username,
-				Password: info.ImageDetails.Password,
-				Auth:     docker.NewToken(info.ImageDetails.Auth),
-			},
-			TokenAuthConfig: docker.TokenAuthConfig{
-				IdentityToken: docker.NewToken(info.ImageDetails.IdentityToken),
-				RegistryToken: docker.NewToken(info.ImageDetails.RegistryToken),
-				Email:         info.ImageDetails.Email,
-			},
-		},
-	}
 	return OperatorProvisioningInfo{
-		ImageDetails: imageRepo,
+		ImageDetails: params.ConvertDockerImageInfo(info.ImageDetails),
 		Version:      info.Version,
 		APIAddresses: info.APIAddresses,
 		Tags:         info.Tags,

--- a/api/controller/caasunitprovisioner/client.go
+++ b/api/controller/caasunitprovisioner/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
@@ -232,7 +233,7 @@ type ProvisioningInfo struct {
 	Filesystems          []storage.KubernetesFilesystemParams
 	Devices              []devices.KubernetesDeviceParams
 	Tags                 map[string]string
-	OperatorImagePath    string
+	ImageDetails         resources.DockerImageDetails
 	CharmModifiedVersion int
 }
 
@@ -261,8 +262,8 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 		RawK8sSpec:           result.RawK8sSpec,
 		Constraints:          result.Constraints,
 		Tags:                 result.Tags,
-		OperatorImagePath:    result.OperatorImagePath,
 		CharmModifiedVersion: result.CharmModifiedVersion,
+		ImageDetails:         params.ConvertDockerImageInfo(result.ImageRepo),
 	}
 	if result.DeploymentInfo != nil {
 		info.DeploymentInfo = DeploymentInfo{

--- a/api/controller/caasunitprovisioner/client_test.go
+++ b/api/controller/caasunitprovisioner/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/storage"
@@ -47,10 +48,12 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 		*(result.(*params.KubernetesProvisioningInfoResults)) = params.KubernetesProvisioningInfoResults{
 			Results: []params.KubernetesProvisioningInfoResult{{
 				Result: &params.KubernetesProvisioningInfo{
-					PodSpec:           "foo",
-					Tags:              map[string]string{"foo": "bar"},
-					Constraints:       constraints.MustParse("mem=4G"),
-					OperatorImagePath: "operator/image-path",
+					PodSpec:     "foo",
+					Tags:        map[string]string{"foo": "bar"},
+					Constraints: constraints.MustParse("mem=4G"),
+					ImageRepo: params.DockerImageInfo{
+						RegistryPath: "operator/image-path",
+					},
 					DeploymentInfo: &params.KubernetesDeploymentInfo{
 						DeploymentType: "stateful",
 						ServiceType:    "loadbalancer",
@@ -84,10 +87,12 @@ func (s *unitprovisionerSuite) TestProvisioningInfo(c *gc.C) {
 	info, err := client.ProvisioningInfo("gitlab")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &caasunitprovisioner.ProvisioningInfo{
-		PodSpec:           "foo",
-		Tags:              map[string]string{"foo": "bar"},
-		Constraints:       constraints.MustParse("mem=4G"),
-		OperatorImagePath: "operator/image-path",
+		PodSpec:     "foo",
+		Tags:        map[string]string{"foo": "bar"},
+		Constraints: constraints.MustParse("mem=4G"),
+		ImageDetails: resources.DockerImageDetails{
+			RegistryPath: "operator/image-path",
+		},
 		DeploymentInfo: caasunitprovisioner.DeploymentInfo{
 			DeploymentType: "stateful",
 			ServiceType:    "loadbalancer",

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -362,7 +362,6 @@ func (w *mockStringsWatcher) Changes() <-chan []string {
 
 type mockUnit struct {
 	testing.Stub
-	life                state.Life
 	destroyOp           *state.DestroyUnitOperation
 	containerInfo       *mockCloudContainer
 	status              status.StatusInfo

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -260,17 +260,6 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting juju oci image path")
 	}
-	imageRepo := cfg.CAASImageRepo()
-	imageInfo := params.DockerImageInfo{
-		Username:      imageRepo.Username,
-		Password:      imageRepo.Password,
-		Email:         imageRepo.Email,
-		Repository:    imageRepo.Repository,
-		Auth:          imageRepo.Auth.Content(),
-		IdentityToken: imageRepo.IdentityToken.Content(),
-		RegistryToken: imageRepo.RegistryToken.Content(),
-	}
-
 	apiHostPorts, err := a.ctrlSt.APIHostPortsForAgents()
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting api addresses")
@@ -291,7 +280,6 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		return nil, errors.Annotatef(err, "getting application config")
 	}
 	return &params.CAASApplicationProvisioningInfo{
-		ImagePath:            imagePath,
 		Version:              vers,
 		APIAddresses:         addrs,
 		CACert:               caCert,
@@ -300,7 +288,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		Devices:              devices,
 		Constraints:          mergedCons,
 		Series:               app.Series(),
-		ImageRepo:            imageInfo,
+		ImageRepo:            params.NewDockerImageInfo(cfg.CAASImageRepo(), imagePath),
 		CharmModifiedVersion: app.CharmModifiedVersion(),
 		CharmURL:             charmURL.String(),
 		Trust:                appConfig.GetBool(application.TrustConfigOptionName, false),

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -109,7 +109,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	mc.AddExpr(`_.Results[0].CACert`, jc.Ignore)
 	c.Assert(result, mc, params.CAASApplicationProvisioningInfoResults{
 		Results: []params.CAASApplicationProvisioningInfo{{
-			ImagePath:    "jujusolutions/jujud-operator:2.6-beta3.666",
+			ImageRepo:    params.DockerImageInfo{RegistryPath: "jujusolutions/jujud-operator:2.6-beta3.666"},
 			Version:      version.MustParse("2.6-beta3.666"),
 			APIAddresses: []string{"10.0.0.1:1"},
 			Tags: map[string]string{

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -85,19 +85,11 @@ func (a *API) ModelOperatorProvisioningInfo() (params.ModelOperatorInfo, error) 
 		return result, errors.Annotate(err, "getting api addresses")
 	}
 
-	imageRepo := controllerConf.CAASImageRepo()
-	imageInfo := params.DockerImageInfo{
-		Username:      imageRepo.Username,
-		Password:      imageRepo.Password,
-		Email:         imageRepo.Email,
-		Repository:    imageRepo.Repository,
-		Auth:          imageRepo.Auth.Content(),
-		IdentityToken: imageRepo.IdentityToken.Content(),
-		RegistryToken: imageRepo.RegistryToken.Content(),
-	}
-	if imageInfo.RegistryPath, err = podcfg.GetJujuOCIImagePath(controllerConf, vers); err != nil {
+	registryPath, err := podcfg.GetJujuOCIImagePath(controllerConf, vers)
+	if err != nil {
 		return result, errors.Trace(err)
 	}
+	imageInfo := params.NewDockerImageInfo(controllerConf.CAASImageRepo(), registryPath)
 	logger.Tracef("image info %v", imageInfo)
 
 	result = params.ModelOperatorInfo{

--- a/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasoperatorprovisioner/provisioner.go
@@ -131,20 +131,12 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 		modelConfig,
 	)
 
-	imageRepo := cfg.CAASImageRepo()
-	imageInfo := params.DockerImageInfo{
-		Username:      imageRepo.Username,
-		Password:      imageRepo.Password,
-		Email:         imageRepo.Email,
-		Repository:    imageRepo.Repository,
-		Auth:          imageRepo.Auth.Content(),
-		IdentityToken: imageRepo.IdentityToken.Content(),
-		RegistryToken: imageRepo.RegistryToken.Content(),
-	}
-	if imageInfo.RegistryPath, err = podcfg.GetJujuOCIImagePath(cfg, vers); err != nil {
+	registryPath, err := podcfg.GetJujuOCIImagePath(cfg, vers)
+	if err != nil {
 		return result, errors.Trace(err)
 	}
-	logger.Tracef("imageInfo %v", imageInfo)
+	imageRepo := params.NewDockerImageInfo(cfg.CAASImageRepo(), registryPath)
+	logger.Tracef("imageRepo %v", imageRepo)
 
 	apiAddresses, err := a.APIAddresses()
 	if err == nil && apiAddresses.Error != nil {
@@ -173,7 +165,7 @@ func (a *API) OperatorProvisioningInfo(args params.Entities) (params.OperatorPro
 			}
 		}
 		return params.OperatorProvisioningInfo{
-			ImageDetails: imageInfo,
+			ImageDetails: imageRepo,
 			Version:      vers,
 			APIAddresses: apiAddresses.Result,
 			CharmStorage: charmStorageParams,

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -388,11 +388,12 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 			fmt.Sprintf("agent version is missing in model config %q", modelConfig.Name()),
 		)
 	}
-	operatorImagePath, err := podcfg.GetJujuOCIImagePath(controllerCfg, vers)
+	registryPath, err := podcfg.GetJujuOCIImagePath(controllerCfg, vers)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
+	imageRepo := params.NewDockerImageInfo(controllerCfg.CAASImageRepo(), registryPath)
+	logger.Tracef("imageRepo %v", imageRepo)
 	filesystemParams, err := f.applicationFilesystemParams(app, controllerCfg, modelConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -428,8 +429,8 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		Devices:              devices,
 		Constraints:          mergedCons,
 		Tags:                 resourceTags,
-		OperatorImagePath:    operatorImagePath,
 		CharmModifiedVersion: app.CharmModifiedVersion(),
+		ImageRepo:            imageRepo,
 	}
 	deployInfo := ch.Meta().Deployment
 	if deployInfo != nil {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner_test.go
@@ -236,7 +236,9 @@ func (s *CAASProvisionerSuite) assertProvisioningInfo(c *gc.C, isRawK8sSpec bool
 			DeploymentType: "stateful",
 			ServiceType:    "loadbalancer",
 		},
-		OperatorImagePath: fmt.Sprintf("jujusolutions/jujud-operator:%s", jujuversion.Current.String()+".666"),
+		ImageRepo: params.DockerImageInfo{
+			RegistryPath: fmt.Sprintf("jujusolutions/jujud-operator:%s", jujuversion.Current.String()+".666"),
+		},
 		Devices: []params.KubernetesDeviceParams{
 			{
 				Type:       "nvidia.com/gpu",
@@ -293,7 +295,7 @@ func (s *CAASProvisionerSuite) assertProvisioningInfo(c *gc.C, isRawK8sSpec bool
 	c.Assert(obtained.PodSpec, jc.DeepEquals, expectedResult.PodSpec)
 	c.Assert(obtained.RawK8sSpec, jc.DeepEquals, expectedResult.RawK8sSpec)
 	c.Assert(obtained.DeploymentInfo, jc.DeepEquals, expectedResult.DeploymentInfo)
-	c.Assert(obtained.OperatorImagePath, gc.Equals, expectedResult.OperatorImagePath)
+	c.Assert(obtained.ImageRepo.RegistryPath, gc.Equals, expectedResult.ImageRepo.RegistryPath)
 	c.Assert(obtained.CharmModifiedVersion, jc.DeepEquals, 888)
 	c.Assert(len(obtained.Filesystems), gc.Equals, len(expectedFileSystems))
 	for _, fs := range obtained.Filesystems {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -7011,9 +7011,6 @@
                                 "$ref": "#/definitions/KubernetesFilesystemParams"
                             }
                         },
-                        "image-path": {
-                            "type": "string"
-                        },
                         "image-repo": {
                             "$ref": "#/definitions/DockerImageInfo"
                         },
@@ -7046,7 +7043,6 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "image-path",
                         "version",
                         "api-addresses",
                         "ca-cert",
@@ -13659,6 +13655,42 @@
                         "config"
                     ]
                 },
+                "DockerImageInfo": {
+                    "type": "object",
+                    "properties": {
+                        "auth": {
+                            "type": "string"
+                        },
+                        "email": {
+                            "type": "string"
+                        },
+                        "identitytoken": {
+                            "type": "string"
+                        },
+                        "image-name": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "registrytoken": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "serveraddress": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "image-name"
+                    ]
+                },
                 "Entities": {
                     "type": "object",
                     "properties": {
@@ -14012,8 +14044,8 @@
                                 "$ref": "#/definitions/KubernetesFilesystemParams"
                             }
                         },
-                        "operator-image-path": {
-                            "type": "string"
+                        "image-repo": {
+                            "$ref": "#/definitions/DockerImageInfo"
                         },
                         "pod-spec": {
                             "type": "string"

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -152,11 +152,11 @@ type ServiceParams struct {
 	// Devices is a set of parameters for Devices that is required.
 	Devices []devices.KubernetesDeviceParams
 
-	// OperatorImagePath is the path to the OCI image shared by the operator and pod init.
-	OperatorImagePath string
-
 	// CharmModifiedVersion increases when the charm changes in some way.
 	CharmModifiedVersion int
+
+	// ImageDetails is the docker registry URL and auth details for the juju init container image.
+	ImageDetails resources.DockerImageDetails
 }
 
 // DeploymentState is returned by the OperatorExists call.

--- a/caas/kubernetes/provider/admissionregistration_test.go
+++ b/caas/kubernetes/provider/admissionregistration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/core/config"
+	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
 )
@@ -34,7 +35,9 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 			MutatingWebhookConfigurations: cfgs,
 		},
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -115,8 +118,8 @@ func (s *K8sBrokerSuite) assertMutatingWebhookConfigurations(c *gc.C, cfgs []k8s
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentStateful,
 		},
-		OperatorImagePath: "operator/image-path",
-		ResourceTags:      map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+		ResourceTags: map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, e string, _ map[string]interface{}) error {
 		c.Logf("EnsureService error -> %q", e)
@@ -685,7 +688,9 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 			ValidatingWebhookConfigurations: cfgs,
 		},
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -762,8 +767,8 @@ func (s *K8sBrokerSuite) assertValidatingWebhookConfigurations(c *gc.C, cfgs []k
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentStateful,
 		},
-		OperatorImagePath: "operator/image-path",
-		ResourceTags:      map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+		ResourceTags: map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, e string, _ map[string]interface{}) error {
 		c.Logf("EnsureService error -> %q", e)

--- a/caas/kubernetes/provider/customresourcedefinitions_test.go
+++ b/caas/kubernetes/provider/customresourcedefinitions_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/mocks"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/core/config"
+	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
 )
@@ -38,7 +39,9 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 			CustomResourceDefinitions: crds,
 		},
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -115,8 +118,8 @@ func (s *K8sBrokerSuite) assertCustomerResourceDefinitions(c *gc.C, crds []k8ssp
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentStateful,
 		},
-		OperatorImagePath: "operator/image-path",
-		ResourceTags:      map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+		ResourceTags: map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, e string, _ map[string]interface{}) error {
 		c.Logf("EnsureService error -> %q", e)
@@ -756,7 +759,9 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 			CustomResources: crs,
 		},
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -835,8 +840,8 @@ func (s *K8sBrokerSuite) assertCustomerResources(c *gc.C, crs map[string][]unstr
 			Deployment: caas.DeploymentParams{
 				DeploymentType: caas.DeploymentStateful,
 			},
-			OperatorImagePath: "operator/image-path",
-			ResourceTags:      map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
+			ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+			ResourceTags: map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
 		}
 		errChan <- s.broker.EnsureService("app-name",
 			func(_ string, _ status.Status, e string, _ map[string]interface{}) error {

--- a/caas/kubernetes/provider/ingress_test.go
+++ b/caas/kubernetes/provider/ingress_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/core/config"
+	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/testing"
 )
@@ -35,7 +36,9 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, ingressResources []k8ss
 			IngressResources: ingressResources,
 		},
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -115,8 +118,8 @@ func (s *K8sBrokerSuite) assertIngressResources(c *gc.C, ingressResources []k8ss
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentStateful,
 		},
-		OperatorImagePath: "operator/image-path",
-		ResourceTags:      map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+		ResourceTags: map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, e string, _ map[string]interface{}) error {
 		c.Logf("EnsureService error -> %q", e)

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/docker"
 	"github.com/juju/juju/environs"
@@ -117,7 +118,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecNoConfigConfig(c *gc.C) {
 		},
 	}
 
-	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
+	spec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", &podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
 		Labels:      map[string]string{},
@@ -321,7 +324,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithEnvAndEnvFrom(c *gc.C) {
 		},
 	}
 
-	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
+	spec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", &podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
 		Labels:      map[string]string{},
@@ -445,7 +450,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecWithInitContainers(c *gc.C) {
 		},
 	}
 
-	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
+	spec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", &podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
 		PodSpec: core.PodSpec{
@@ -538,7 +545,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpec(c *gc.C) {
 		},
 	}
 
-	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
+	spec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", &podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
 		Labels:      map[string]string{"foo": "bax"},
@@ -590,7 +599,9 @@ func (s *K8sSuite) TestPrepareWorkloadSpecPrimarySA(c *gc.C) {
 		},
 	}
 
-	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", &podSpec, "operator/image-path")
+	spec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", &podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
 		PodSpec: core.PodSpec{
@@ -713,7 +724,9 @@ func (s *K8sBrokerSuite) getOCIImageSecret(c *gc.C, annotations map[string]strin
 }
 
 func (s *K8sSuite) TestPrepareWorkloadSpecConfigPairs(c *gc.C) {
-	spec, err := provider.PrepareWorkloadSpec("app-name", "app-name", getBasicPodspec(), "operator/image-path")
+	spec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", getBasicPodspec(), resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(provider.Pod(spec), jc.DeepEquals, k8sspecs.PodSpecWithAnnotations{
 		PodSpec: core.PodSpec{
@@ -771,7 +784,9 @@ func (s *K8sBrokerSuite) assertFileSetToVolume(c *gc.C, fs specs.FileSet, result
 
 	cfgMapName := func(n string) string { return n }
 
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", getBasicPodspec(), "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", getBasicPodspec(), resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	workloadSpec.ConfigMaps = map[string]specs.ConfigMap{
 		"log-config": map[string]string{
@@ -1233,7 +1248,9 @@ func (s *K8sBrokerSuite) TestConfigurePodFiles(c *gc.C) {
 			},
 		},
 	}}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	workloadSpec.ConfigMaps = map[string]specs.ConfigMap{
 		"log-config": map[string]string{
@@ -2248,7 +2265,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 			Pod: &k8sspecs.PodSpec{Annotations: map[string]string{"foo": "baz"}},
 		},
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -2329,8 +2348,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
@@ -2362,7 +2381,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 		},
 	}
 
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -2449,8 +2470,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
@@ -2488,8 +2509,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceStatelessWithScalePolicyInvalid(c *gc.
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
@@ -2561,7 +2582,9 @@ password: shhhh`[1:],
 		},
 	}
 
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -2737,8 +2760,8 @@ password: shhhh`[1:],
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
@@ -2810,7 +2833,9 @@ password: shhhh`[1:],
 		},
 	}
 
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -3000,7 +3025,7 @@ password: shhhh`[1:],
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
 		"kubernetes-service-type":            "loadbalancer",
@@ -3182,7 +3207,9 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithStatefulSet(c *gc.C, mode c
 		appName += "-operator"
 	}
 
-	workloadSpec, err := provider.PrepareWorkloadSpec(appName, "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		appName, "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -3273,7 +3300,9 @@ func (s *K8sBrokerSuite) assertGetServiceSvcFoundWithDeployment(c *gc.C, mode ca
 		appName += "-operator"
 	}
 
-	workloadSpec, err := provider.PrepareWorkloadSpec(appName, "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		appName, "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -3353,7 +3382,9 @@ func (s *K8sBrokerSuite) TestGetServiceSvcFoundWithDaemonSet(c *gc.C) {
 	basicPodSpec.Service = &specs.ServiceSpec{
 		ScalePolicy: "serial",
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -3425,7 +3456,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 	basicPodSpec.Service = &specs.ServiceSpec{
 		ScalePolicy: "serial",
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -3494,8 +3527,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorageStateful(c *gc.C) {
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentStateful,
 		},
-		OperatorImagePath: "operator/image-path",
-		ResourceTags:      map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+		ResourceTags: map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
@@ -3509,7 +3542,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 
@@ -3580,8 +3615,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceCustomType(c *gc.C) {
 		Deployment: caas.DeploymentParams{
 			ServiceType: caas.ServiceExternal,
 		},
-		OperatorImagePath: "operator/image-path",
-		ResourceTags:      map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+		ResourceTags: map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
 		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
@@ -3620,8 +3655,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceServiceWithoutPortsNotValid(c *gc.C) {
 			DeploymentType: caas.DeploymentStateful,
 			ServiceType:    caas.ServiceExternal,
 		},
-		OperatorImagePath: "operator/image-path",
-		ResourceTags:      map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+		ResourceTags: map[string]string{"juju-controller-uuid": testing.ControllerTag.Id()},
 	}
 	err := s.broker.EnsureService(
 		"app-name",
@@ -3643,7 +3678,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 	podSpec.ServiceAccount = primeServiceAccount
 
 	numUnits := int32(2)
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	deploymentArg := &appsv1.Deployment{
@@ -3784,7 +3821,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleCreate(c *gc.
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
 		"kubernetes-service-type":            "loadbalancer",
@@ -3803,7 +3840,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 	podSpec.ServiceAccount = primeServiceAccount
 
 	numUnits := int32(2)
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	deploymentArg := &appsv1.Deployment{
@@ -3954,7 +3993,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewRoleUpdate(c *gc.
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 	}
 
 	errChan := make(chan error)
@@ -4001,7 +4040,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 	}
 
 	numUnits := int32(2)
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	deploymentArg := &appsv1.Deployment{
@@ -4148,7 +4189,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleCreate
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
 		"kubernetes-service-type":            "loadbalancer",
@@ -4183,7 +4224,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 	}
 
 	numUnits := int32(2)
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	deploymentArg := &appsv1.Deployment{
@@ -4330,7 +4373,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountNewClusterRoleUpdate
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 	}
 
 	errChan := make(chan error)
@@ -4387,7 +4430,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 	}
 
 	numUnits := int32(2)
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	deploymentArg := &appsv1.Deployment{
@@ -4589,7 +4634,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
 		"kubernetes-service-type":            "loadbalancer",
@@ -4646,7 +4691,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 	}
 
 	numUnits := int32(2)
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	deploymentArg := &appsv1.Deployment{
@@ -4862,7 +4909,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
 		"kubernetes-service-type":            "loadbalancer",
@@ -4927,7 +4974,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 	}
 
 	numUnits := int32(2)
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", podSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", podSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	deploymentArg := &appsv1.Deployment{
@@ -5187,7 +5236,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithServiceAccountAndK8sServiceAccount
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 	}
 	err = s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
 		"kubernetes-service-type":            "loadbalancer",
@@ -5211,7 +5260,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 			},
 		},
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -5262,8 +5313,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithStorage(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 		},
@@ -5309,7 +5360,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 		},
 	}
 
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -5365,8 +5418,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithUpdateStrategy(c *gc
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 		},
@@ -5403,7 +5456,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 
 	numUnits := int32(2)
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.NodeSelector = map[string]string{"accelerator": "nvidia-tesla-p100"}
@@ -5471,8 +5526,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithDevices(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		Devices: []devices.KubernetesDeviceParams{
 			{
 				Type:       "nvidia.com/gpu",
@@ -5498,7 +5553,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 
 	numUnits := int32(2)
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -5608,8 +5665,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageCreate(c *gc.C
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentStateless,
 		},
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 		},
@@ -5646,7 +5703,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 
 	numUnits := int32(2)
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -5758,8 +5817,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithStorageUpdate(c *gc.C
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentStateless,
 		},
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 		},
@@ -5803,7 +5862,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 			},
 		},
 	}
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Affinity = &core.Affinity{
@@ -5966,7 +6027,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageCreate(c *gc.C)
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentDaemon,
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 		},
@@ -6013,7 +6074,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 		},
 	}
 
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Affinity = &core.Affinity{
@@ -6149,7 +6212,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithUpdateStrategy(c *gc.C
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentDaemon,
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 		},
@@ -6186,7 +6249,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Affinity = &core.Affinity{
@@ -6325,7 +6390,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithStorageUpdate(c *gc.C)
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentDaemon,
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 		},
@@ -6362,7 +6427,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.NodeSelector = map[string]string{"accelerator": "nvidia-tesla-p100"}
@@ -6453,7 +6520,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsC
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentDaemon,
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		Devices: []devices.KubernetesDeviceParams{
 			{
 				Type:       "nvidia.com/gpu",
@@ -6479,7 +6546,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.NodeSelector = map[string]string{"accelerator": "nvidia-tesla-p100"}
@@ -6575,7 +6644,7 @@ func (s *K8sBrokerSuite) TestEnsureServiceForDaemonSetWithDevicesAndConstraintsU
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentDaemon,
 		},
-		OperatorImagePath: "operator/image-path",
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		Devices: []devices.KubernetesDeviceParams{
 			{
 				Type:       "nvidia.com/gpu",
@@ -6601,7 +6670,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -6649,8 +6720,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceForStatefulSetWithDevices(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",
 			Size:        100,
@@ -6685,7 +6756,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -6733,8 +6806,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",
 			Size:        100,
@@ -6763,7 +6836,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -6821,8 +6896,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithNodeAffinity(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",
 			Size:        100,
@@ -6851,7 +6926,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithZones(c *gc.C) {
 	defer ctrl.Finish()
 
 	basicPodSpec := getBasicPodspec()
-	workloadSpec, err := provider.PrepareWorkloadSpec("app-name", "app-name", basicPodSpec, "operator/image-path")
+	workloadSpec, err := provider.PrepareWorkloadSpec(
+		"app-name", "app-name", basicPodSpec, resources.DockerImageDetails{RegistryPath: "operator/image-path"},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	podSpec := provider.Pod(workloadSpec).PodSpec
 	podSpec.Containers[0].VolumeMounts = append(dataVolumeMounts(), core.VolumeMount{
@@ -6901,8 +6978,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithZones(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		Filesystems: []storage.KubernetesFilesystemParams{{
 			StorageName: "database",
 			Size:        100,

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -2461,8 +2461,8 @@ func (s *K8sBrokerSuite) TestEnsureServiceInvalidServiceName(c *gc.C) {
 	)
 
 	params := &caas.ServiceParams{
-		PodSpec:           basicPodSpec,
-		OperatorImagePath: "operator/image-path",
+		PodSpec:      basicPodSpec,
+		ImageDetails: resources.DockerImageDetails{RegistryPath: "operator/image-path"},
 		ResourceTags: map[string]string{
 			"juju-controller-uuid": testing.ControllerTag.Id(),
 			"fred":                 "mary",

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -68,6 +68,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"core/os",
 		"core/paths",
 		"core/relation",
+		"core/resources",
 		"core/secrets",
 		"core/series",
 		"core/status",

--- a/rpc/params/caas.go
+++ b/rpc/params/caas.go
@@ -8,6 +8,8 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/resources"
+	"github.com/juju/juju/docker"
 )
 
 // CAASUnitIntroductionArgs is used by sidecar units to introduce
@@ -43,7 +45,6 @@ type CAASUnitTerminationResult struct {
 
 // CAASApplicationProvisioningInfo holds info needed to provision a caas application.
 type CAASApplicationProvisioningInfo struct {
-	ImagePath            string                       `json:"image-path"`
 	Version              version.Number               `json:"version"`
 	APIAddresses         []string                     `json:"api-addresses"`
 	CACert               string                       `json:"ca-cert"`
@@ -105,6 +106,41 @@ type DockerImageInfo struct {
 
 	// Repository is the namespace of the image repo.
 	Repository string `json:"repository,omitempty" yaml:"repository,omitempty"`
+}
+
+// NewDockerImageInfo converts docker.ImageRepoDetails to DockerImageInfo.
+func NewDockerImageInfo(info docker.ImageRepoDetails, registryPath string) DockerImageInfo {
+	return DockerImageInfo{
+		Username:      info.Username,
+		Password:      info.Password,
+		Email:         info.Email,
+		Repository:    info.Repository,
+		Auth:          info.Auth.Content(),
+		IdentityToken: info.IdentityToken.Content(),
+		RegistryToken: info.RegistryToken.Content(),
+		RegistryPath:  registryPath,
+	}
+}
+
+// ConvertDockerImageInfo converts DockerImageInfo to resources.ImageRepoDetails.
+func ConvertDockerImageInfo(info DockerImageInfo) resources.DockerImageDetails {
+	return resources.DockerImageDetails{
+		RegistryPath: info.RegistryPath,
+		ImageRepoDetails: docker.ImageRepoDetails{
+			Repository:    info.Repository,
+			ServerAddress: info.ServerAddress,
+			BasicAuthConfig: docker.BasicAuthConfig{
+				Username: info.Username,
+				Password: info.Password,
+				Auth:     docker.NewToken(info.Auth),
+			},
+			TokenAuthConfig: docker.TokenAuthConfig{
+				IdentityToken: docker.NewToken(info.IdentityToken),
+				RegistryToken: docker.NewToken(info.RegistryToken),
+				Email:         info.Email,
+			},
+		},
+	}
 }
 
 // CAASApplicationOCIResourceResults holds all the image results for queried applications.

--- a/rpc/params/kubernetes.go
+++ b/rpc/params/kubernetes.go
@@ -25,8 +25,8 @@ type KubernetesProvisioningInfo struct {
 	Filesystems          []KubernetesFilesystemParams `json:"filesystems,omitempty"`
 	Volumes              []KubernetesVolumeParams     `json:"volumes,omitempty"`
 	Devices              []KubernetesDeviceParams     `json:"devices,omitempty"`
-	OperatorImagePath    string                       `json:"operator-image-path,omitempty"`
 	CharmModifiedVersion int                          `json:"charm-modified-version,omitempty"`
+	ImageRepo            DockerImageInfo              `json:"image-repo,omitempty"`
 }
 
 // KubernetesProvisioningInfoResult holds unit provisioning info or an error.

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -704,7 +704,7 @@ func (a *appWorker) alive(app caas.Application) error {
 	}
 
 	ch := charmInfo.Charm()
-	charmBaseImage, err := podcfg.ImageForBase(provisionInfo.ImageRepo.Repository, charm.Base{
+	charmBaseImage, err := podcfg.ImageForBase(provisionInfo.ImageDetails.Repository, charm.Base{
 		Name: strings.ToLower(os.String()),
 		Channel: charm.Channel{
 			Track: ver,
@@ -739,10 +739,10 @@ func (a *appWorker) alive(app caas.Application) error {
 
 	// TODO(sidecar): container.Mounts[*].Path <= consolidate? => provisionInfo.Filesystems[*].Attachment.Path
 	config := caas.ApplicationConfig{
-		IsPrivateImageRepo:   provisionInfo.ImageRepo.IsPrivate(),
+		IsPrivateImageRepo:   provisionInfo.ImageDetails.IsPrivate(),
 		IntroductionSecret:   a.password,
 		AgentVersion:         provisionInfo.Version,
-		AgentImagePath:       provisionInfo.ImagePath,
+		AgentImagePath:       provisionInfo.ImageDetails.RegistryPath,
 		ControllerAddresses:  strings.Join(provisionInfo.APIAddresses, ","),
 		ControllerCertBundle: provisionInfo.CACert,
 		ResourceTags:         provisionInfo.Tags,

--- a/worker/caasunitprovisioner/application_worker.go
+++ b/worker/caasunitprovisioner/application_worker.go
@@ -295,7 +295,6 @@ func (aw *applicationWorker) clusterChanged(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	serviceStatus := service.Status
 	var scale *int
 	var generation *int64
 	if service != nil && shouldSetScale {
@@ -306,11 +305,13 @@ func (aw *applicationWorker) clusterChanged(
 		ApplicationTag: names.NewApplicationTag(aw.application).String(),
 		Scale:          scale,
 		Generation:     generation,
-		Status: params.EntityStatus{
-			Status: serviceStatus.Status,
-			Info:   serviceStatus.Message,
-			Data:   serviceStatus.Data,
-		},
+	}
+	if service != nil {
+		args.Status = params.EntityStatus{
+			Status: service.Status.Status,
+			Info:   service.Status.Message,
+			Data:   service.Status.Data,
+		}
 	}
 	for _, u := range units {
 		// For pods managed by the substrate, any marked as dying

--- a/worker/caasunitprovisioner/deployment_worker.go
+++ b/worker/caasunitprovisioner/deployment_worker.go
@@ -225,7 +225,7 @@ func provisionInfoToServiceParams(info *apicaasunitprovisioner.ProvisioningInfo)
 		ResourceTags:         info.Tags,
 		Filesystems:          info.Filesystems,
 		Devices:              info.Devices,
-		OperatorImagePath:    info.OperatorImagePath,
+		ImageDetails:         info.ImageDetails,
 		CharmModifiedVersion: info.CharmModifiedVersion,
 		Deployment: caas.DeploymentParams{
 			DeploymentType: caas.DeploymentType(info.DeploymentInfo.DeploymentType),

--- a/worker/caasunitprovisioner/mock_test.go
+++ b/worker/caasunitprovisioner/mock_test.go
@@ -276,14 +276,6 @@ func (m *mockLifeGetter) setLife(life life.Value) {
 	m.lifeRetrieved = make(chan struct{}, 1)
 }
 
-func (m *mockLifeGetter) assertLifeRetrieved(c *gc.C) {
-	select {
-	case <-m.lifeRetrieved:
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out waiting for life to be retrieved")
-	}
-}
-
 func (m *mockLifeGetter) Life(entityName string) (life.Value, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
 	"github.com/juju/clock"
-	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"

--- a/worker/caasunitprovisioner/worker_test.go
+++ b/worker/caasunitprovisioner/worker_test.go
@@ -61,7 +61,6 @@ type WorkerSuite struct {
 	serviceUpdated          chan struct{}
 	resourcesCleared        chan struct{}
 	appChanges              chan struct{}
-	clock                   *testclock.Clock
 }
 
 var _ = gc.Suite(&WorkerSuite{})


### PR DESCRIPTION
This PR ensures the juju init container has the image pull secret if it's configured in the controller config.

Drive-by: refactored the params for passing image reposiotry details across different layers(apiserver -> api -> worker).

No facade version bumps up because all of them are controller facades.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ cat ecr.json | jq '.username = "foo" | .password = "bar"'
{
  "serveraddress": "689913858002.dkr.ecr.ap-southeast-2.amazonaws.com",
  "repository": "689913858002.dkr.ecr.ap-southeast-2.amazonaws.com/ycliuhw-888",
  "username": "foo",
  "password": "bar",
  "region": "ap-southeast-2"
}

$ juju bootstrap microk8s k1 --config caas-image-repo=./ecr.json --debug --show-log

$ juju add-model t1

$ juju deploy snappass-test

$ juju deploy cs:~juju/mariadb-k8s-3

$ mkubectl -ncontroller-k1 get pod/controller-0 -o json | jq .spec.imagePullSecrets
[
  {
    "name": "juju-image-pull-secret"
  }
]

$ mkubectl -nt1 get pods \
    snappass-test-0 \
    mariadb-k8s-operator-0 \
    mariadb-k8s-0 \
    modeloperator-645d7dfdcd-h6bgp -o json | jq '.items[].spec.imagePullSecrets'
[
  {
    "name": "juju-image-pull-secret"
  }
]
[
  {
    "name": "juju-image-pull-secret"
  }
]
[
  {
    "name": "mariadb-k8s-mariadb-k8s-secret"
  },
  {
    "name": "juju-image-pull-secret"
  }
]
[
  {
    "name": "juju-image-pull-secret"
  }
]

$ mkubectl -nt1 get pod/snappass-test-0 -o json | jq '.spec.containers[].image'
"689913858002.dkr.ecr.ap-southeast-2.amazonaws.com/ycliuhw-888/charm-base:ubuntu-20.04"
"registry.hub.docker.com/library/redis@sha256:27bea08330830c6e5efc456075d66eb1fb4b76e5518947e8c87556adf1df3e51"
"registry.hub.docker.com/benhoyt/snappass-test@sha256:32506b5ac7bde75b7a76bee003cf8c77f30fc936f446c8c52d457b8fe6fce96f"

$ mkubectl -nt1 get pod/mariadb-k8s-operator-0 -o json | jq '.spec.containers[].image'
"689913858002.dkr.ecr.ap-southeast-2.amazonaws.com/ycliuhw-888/jujud-operator:2.9.29"

$ mkubectl -nt1 get pod/modeloperator-76598cd988-pwtzk -o json | jq '.spec.containers[].image'
"689913858002.dkr.ecr.ap-southeast-2.amazonaws.com/ycliuhw-888/jujud-operator:2.9.29"

$ mkubectl -ncontroller-k1 get pod/controller-0  -o json | jq '.spec.containers[].image'
"689913858002.dkr.ecr.ap-southeast-2.amazonaws.com/ycliuhw-888/juju-db:4.4"
"689913858002.dkr.ecr.ap-southeast-2.amazonaws.com/ycliuhw-888/jujud-operator:2.9.29"

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1968527
