### PR TITLE
[JUJU-824] Discard syslog for k8s models

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -732,11 +732,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			RaftOpQueue:                       config.RaftOpQueue,
 		})),
 
-		syslogName: syslogger.Manifold(syslogger.ManifoldConfig{
-			NewWorker: syslogger.NewWorker,
-			NewLogger: syslogger.NewSyslog,
-		}),
-
 		modelWorkerManagerName: ifFullyUpgraded(modelworkermanager.Manifold(modelworkermanager.ManifoldConfig{
 			AgentName:      agentName,
 			AuthorityName:  certificateWatcherName,
@@ -1022,6 +1017,11 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewClient:     instancemutater.NewClient,
 			NewWorker:     instancemutater.NewContainerWorker,
 		})),
+
+		syslogName: syslogger.Manifold(syslogger.ManifoldConfig{
+			NewWorker: syslogger.NewWorker,
+			NewLogger: syslogger.NewSyslog,
+		}),
 	}
 
 	return mergeManifolds(config, manifolds)
@@ -1038,6 +1038,11 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			UpgradeStepsGateName: upgradeStepsGateName,
 			UpgradeCheckGateName: upgradeCheckGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
+		}),
+
+		syslogName: syslogger.Manifold(syslogger.ManifoldConfig{
+			NewWorker: syslogger.NewWorker,
+			NewLogger: syslogger.NewDiscard,
 		}),
 	})
 }

--- a/worker/syslogger/syslogger.go
+++ b/worker/syslogger/syslogger.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package syslogger
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+// NewDiscard creates a new WriteCloser that discards all writes and the close
+// is a noop.
+func NewDiscard(priority Priority, tag string) (io.WriteCloser, error) {
+	return nopCloser{
+		Writer: ioutil.Discard,
+	}, nil
+}
+
+// nopCloser is a closer that discards the close request. We can't use the
+// io.NopCloser as that expects a io.Reader.
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error {
+	return nil
+}

--- a/worker/syslogger/syslogger_unix.go
+++ b/worker/syslogger/syslogger_unix.go
@@ -8,9 +8,31 @@ package syslogger
 
 import (
 	"io"
+	"io/ioutil"
 	"log/syslog"
 )
 
+// NewSyslog creates a new instance of a syslog logger, which sends all logs to
+// directly to the _local_ syslog. Returning a io.WriterCloser, so that we
+// can ensure that the underlying logger can be closed when done.
 func NewSyslog(priority Priority, tag string) (io.WriteCloser, error) {
 	return syslog.New(syslog.Priority(priority), tag)
+}
+
+// NewDiscard creates a new WriteCloser that discards all writes and the close
+// is a noop.
+func NewDiscard(priority Priority, tag string) (io.WriteCloser, error) {
+	return nopCloser{
+		Writer: ioutil.Discard,
+	}, nil
+}
+
+// nopCloser is a closer that discards the close request. We can't use the
+// io.NopCloser as that expects a io.Reader.
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error {
+	return nil
 }

--- a/worker/syslogger/syslogger_unix.go
+++ b/worker/syslogger/syslogger_unix.go
@@ -8,7 +8,6 @@ package syslogger
 
 import (
 	"io"
-	"io/ioutil"
 	"log/syslog"
 )
 
@@ -17,22 +16,4 @@ import (
 // can ensure that the underlying logger can be closed when done.
 func NewSyslog(priority Priority, tag string) (io.WriteCloser, error) {
 	return syslog.New(syslog.Priority(priority), tag)
-}
-
-// NewDiscard creates a new WriteCloser that discards all writes and the close
-// is a noop.
-func NewDiscard(priority Priority, tag string) (io.WriteCloser, error) {
-	return nopCloser{
-		Writer: ioutil.Discard,
-	}, nil
-}
-
-// nopCloser is a closer that discards the close request. We can't use the
-// io.NopCloser as that expects a io.Reader.
-type nopCloser struct {
-	io.Writer
-}
-
-func (nopCloser) Close() error {
-	return nil
 }


### PR DESCRIPTION
The following discards the syslog logger for k8s models. The idea is
that syslog isn't always available in every container, so we should
prevent it for now. In the future, it would be better for k8s models to
not speak to a local syslog, but a remote one, like the log forwarder.

Until that's set up just discard any logs for now. As this is a
optimization for production issues we can ignore this for normal use
cases.

---

Notice none of the tests had to change here, so we're still providing
the same manifolds, just with different configs.

## QA steps

See: https://github.com/juju/juju/pull/13888

```sh
$ juju bootstrap microk8s test --config="logging-config=syslog"
```

Nothing should happen.
