### PR TITLE
[JUJU-863] Match with contains, not exact phrase "already exists".

### DIFF
--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -359,7 +359,7 @@ func (s *containerSuite) TestCreateContainerFromSpecAlreadyExists(c *gc.C) {
 	// Container created, started and returned.
 	exp := cSvr.EXPECT()
 	gomock.InOrder(
-		exp.CreateContainerFromImage(cSvr, image, createReq).Return(createOp, errors.Errorf("already exists")),
+		exp.CreateContainerFromImage(cSvr, image, createReq).Return(createOp, errors.Errorf("Container 'juju-5bcbde-5-lxd-6' already exists")),
 		exp.GetContainer(spec.Name).Return(&api.Container{
 			ContainerPut: api.ContainerPut{
 				Profiles: spec.Profiles,
@@ -422,7 +422,7 @@ func (s *containerSuite) TestCreateContainerFromSpecAlreadyExistsNotCorrectSpec(
 	// Container created, started and returned.
 	exp := cSvr.EXPECT()
 	gomock.InOrder(
-		exp.CreateContainerFromImage(cSvr, image, createReq).Return(createOp, errors.Errorf("already exists")),
+		exp.CreateContainerFromImage(cSvr, image, createReq).Return(createOp, errors.Errorf("Container 'juju-5bcbde-5-lxd-6' already exists")),
 		exp.GetContainer(spec.Name).Return(&api.Container{
 			StatusCode: api.Running,
 		}, lxdtesting.ETag, nil),
@@ -432,7 +432,7 @@ func (s *containerSuite) TestCreateContainerFromSpecAlreadyExistsNotCorrectSpec(
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = jujuSvr.CreateContainerFromSpec(spec)
-	c.Assert(err, gc.ErrorMatches, `already exists`)
+	c.Assert(err, gc.ErrorMatches, `Container 'juju-5bcbde-5-lxd-6' already exists`)
 }
 
 func (s *containerSuite) TestCreateContainerFromSpecStartFailed(c *gc.C) {

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -348,7 +348,7 @@ func IsLXDAlreadyExists(err error) bool {
 		return true
 	}
 
-	return strings.ToLower(err.Error()) == "already exists"
+	return strings.Contains(strings.ToLower(err.Error()), "already exists")
 }
 
 // lxdStatusError allows us to check if an error conforms to the lxd status


### PR DESCRIPTION
The full error returned is like "Container 'juju-5bcbde-5-lxd-6' already exists" and won't match an exact match to "already exists".

See also: #13920 and #12848
## QA steps

unit tests - fortunately there is not a reliable reproducer for this issue.  The updated unit tests cause the exact match to fail, the new code does not.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1945813