### PR TITLE
[JUJU-958] Enable dry-run for deploying charms.

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -651,7 +651,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Set application constraints")
 	f.StringVar(&c.Series, "series", "", "The series on which to deploy")
 	f.IntVar(&c.Revision, "revision", -1, "The revision to deploy")
-	f.BoolVar(&c.DryRun, "dry-run", false, "Just show what the bundle deploy would do")
+	f.BoolVar(&c.DryRun, "dry-run", false, "Just show what the deploy would do")
 	f.BoolVar(&c.Force, "force", false, "Allow a charm/bundle to be deployed which bypasses checks such as supported series or LXD profile allow list")
 	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "Charm storage constraints")
 	f.Var(devicesFlag{&c.Devices, &c.BundleDevices}, "device", "Charm device constraints")

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1418,7 +1418,7 @@ func (s *DeploySuite) TestDeployFlags(c *gc.C) {
 	c.Assert(command.flagSet, jc.DeepEquals, flagSet)
 	// Add to the slice below if a new flag is introduced which is valid for
 	// both charms and bundles.
-	charmAndBundleFlags := []string{"channel", "storage", "device", "force", "trust", "revision"}
+	charmAndBundleFlags := []string{"channel", "storage", "device", "dry-run", "force", "trust", "revision"}
 	var allFlags []string
 	flagSet.VisitAll(func(flag *gnuflag.Flag) {
 		allFlags = append(allFlags, flag.Name)

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testcharms"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type BundleDeployRepositorySuite struct {
@@ -1418,18 +1417,7 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusWordpressBundle() {
 }
 
 func (s *BundleDeployRepositorySuite) expectDeployerAPIModelGet(c *gc.C) {
-	minimal := map[string]interface{}{
-		"name":            "test",
-		"type":            "manual",
-		"uuid":            coretesting.ModelTag.Id(),
-		"controller-uuid": coretesting.ControllerTag.Id(),
-		"firewall-mode":   "instance",
-		// While the ca-cert bits aren't entirely minimal, they avoid the need
-		// to set up a fake home.
-		"ca-cert":        coretesting.CACert,
-		"ca-private-key": coretesting.CAKey,
-	}
-	cfg, err := config.New(true, minimal)
+	cfg, err := config.New(true, minimalModelConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	s.deployerAPI.EXPECT().ModelGet().Return(cfg.AllAttrs(), nil)
 }
@@ -1820,18 +1808,7 @@ func (s *BundleHandlerMakeModelSuite) expectDeployerAPIEmptyStatus() {
 }
 
 func (s *BundleHandlerMakeModelSuite) expectDeployerAPIModelGet(c *gc.C) {
-	minimal := map[string]interface{}{
-		"name":            "test",
-		"type":            "manual",
-		"uuid":            coretesting.ModelTag.Id(),
-		"controller-uuid": coretesting.ControllerTag.Id(),
-		"firewall-mode":   "instance",
-		// While the ca-cert bits aren't entirely minimal, they avoid the need
-		// to set up a fake home.
-		"ca-cert":        coretesting.CACert,
-		"ca-private-key": coretesting.CAKey,
-	}
-	cfg, err := config.New(true, minimal)
+	cfg, err := config.New(true, minimalModelConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	s.deployerAPI.EXPECT().ModelGet().Return(cfg.AllAttrs(), nil)
 }

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -224,6 +224,7 @@ func (d *factory) newDeployCharm() deployCharm {
 		bindings:         d.bindings,
 		configOptions:    &d.configOptions,
 		constraints:      d.constraints,
+		dryRun:           d.dryRun,
 		modelConstraints: d.modelConstraints,
 		devices:          d.devices,
 		deployResources:  d.deployResources,


### PR DESCRIPTION
A long standing todo. It is especially needed with the introduction of charmhub. The expected charm is not always what is deployed for many reasons. This gives the user a chance to find out, before it happens.

This does apply for local charms - to do a proper job with dry run would require uploading the charm, which is not want. As well, doing so would increment the charm's revision needlessly.

## QA steps

```sh
$ juju bootstrap localhost testme
$ juju deploy neutron-api --dry-run
Located charm "neutron-api" in charm-hub, revision 501
Deploying "neutron-api" from charm-hub charm "neutron-api", revision 501 in channel stable on focal

# check that the db has no charms, nor resources
juju:PRIMARY> db.charms.count()
0
juju:PRIMARY> db.resources.count()
0
```

## Documentation changes

Juju deploy help has been updated, online docs may need updating as well.

## Bug reference

Does not fix, but is related to https://bugs.launchpad.net/juju/+bug/1966664
