### PR TITLE
[JUJU-880] Pick right channel from CharmHub info response based on release date

### DIFF
--- a/cmd/juju/charmhub/convert.go
+++ b/cmd/juju/charmhub/convert.go
@@ -6,6 +6,7 @@ package charmhub
 import (
 	"bytes"
 	"strings"
+	"time"
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
@@ -322,7 +323,7 @@ func filterChannels(channelMap []transport.InfoChannelMap, isKub bool, arch, ser
 			continue
 		}
 
-		channel := Channel{
+		currentCh := Channel{
 			Revision:   cm.Revision.Revision,
 			ReleasedAt: ch.ReleasedAt,
 			Risk:       ch.Risk,
@@ -334,7 +335,16 @@ func filterChannels(channelMap []transport.InfoChannelMap, isKub bool, arch, ser
 		}
 
 		chName := ch.Track + "/" + ch.Risk
-		channels[chName] = channel
+		if existingCh, ok := channels[chName]; ok {
+			currentChReleasedAt, _ := time.Parse(time.RFC3339, currentCh.ReleasedAt)
+			existingChReleasedAt, _ := time.Parse(time.RFC3339, existingCh.ReleasedAt)
+			if currentChReleasedAt.After(existingChReleasedAt) {
+				channels[chName] = currentCh
+			}
+		} else {
+			channels[chName] = currentCh
+		}
+
 	}
 	return trackList, channels
 }

--- a/cmd/juju/charmhub/convert_test.go
+++ b/cmd/juju/charmhub/convert_test.go
@@ -258,7 +258,8 @@ func (filterSuite) TestFilterChannels(c *gc.C) {
 	}}
 	for k, v := range tests {
 		c.Logf("Test %d %s", k, v.Name)
-		_, got := filterChannels(v.Input, false, v.Arch, v.Series)
+		_, got, err := filterChannels(v.Input, false, v.Arch, v.Series)
+		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(got, jc.DeepEquals, v.Expected)
 	}
 }

--- a/cmd/juju/charmhub/convert_test.go
+++ b/cmd/juju/charmhub/convert_test.go
@@ -216,6 +216,45 @@ func (filterSuite) TestFilterChannels(c *gc.C) {
 			},
 		}},
 		Expected: map[string]Channel{},
+	}, {
+		Name:   "exact match finds no valid channels",
+		Arch:   "amd64",
+		Series: "focal",
+		Input: []transport.InfoChannelMap{{
+			Channel: transport.Channel{
+				Name:       "xena/edge",
+				Base:       transport.Base{Architecture: "amd64", Name: "ubuntu", Channel: "20.04"},
+				ReleasedAt: "2022-04-01T02:41:31.140463+00:00",
+				Risk:       "edge",
+				Track:      "xena",
+			},
+			Revision: transport.InfoRevision{
+				Bases:    []transport.Base{{Channel: "20.04", Name: "ubuntu", Architecture: "amd64"}},
+				Revision: 522,
+			},
+		}, { // the 16.04 channel is intentionally the last one in the map
+			Channel: transport.Channel{
+				Name:       "xena/edge",
+				Base:       transport.Base{Architecture: "amd64", Name: "ubuntu", Channel: "16.04"},
+				ReleasedAt: "2022-03-04T10:38:13.959649+00:00",
+				Risk:       "edge",
+				Track:      "xena",
+			},
+			Revision: transport.InfoRevision{
+				Bases:    []transport.Base{{Channel: "16.04", Name: "ubuntu", Architecture: "all"}},
+				Revision: 501,
+			},
+		}},
+		Expected: map[string]Channel{
+			"xena/edge": {
+				ReleasedAt: "2022-04-01T02:41:31.140463+00:00",
+				Risk:       "edge",
+				Track:      "xena",
+				Revision:   522,
+				Arches:     []string{"amd64"},
+				Series:     []string{"focal"},
+			},
+		},
 	}}
 	for k, v := range tests {
 		c.Logf("Test %d %s", k, v.Name)


### PR DESCRIPTION
When picking the latest channel info for each `track/risk`, `juju info` picks the last element from the channel map (that we're getting from the CharmHub's `info` endpoint). This PR patches that picking process, by picking the one with the latest release date.

## QA steps

QA'ing this particular PR can be done by checking the revision number, so for

`juju info neutron-api --channel xena/edge --series focal` should look like 

```channels: |
  xena/stable:     –
  xena/candidate:  –
  xena/beta:       –
  xena/edge:       522  2022-04-01  (522)  794kB
```

(that revision # was incorrectly 501 before this change, as it is reported in the LP bug referenced below)

and 

`juju info neutron-api --channel xena/edge --series bionic` should look like

```channels: |
  xena/stable:     –
  xena/candidate:  –
  xena/beta:       –
  xena/edge:       501  2022-03-04  (501)  483kB
```

Also a unit test is added for this as well, so 

```sh
cd juju/cmd/juju/charmhub && go test -gocheck.vv -gocheck.f TestFilterChannels
```
should pass.

Properly testing this (and keep testing it as a part of integration tests) requires either using a mock charm, or `juju-qa-test`. Deferring to the further discussions here to iterate over.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1967850
