### PR TITLE
[JUJU-961] Annotate environ tracker errors to indicate the relevant model

### DIFF
--- a/apiserver/facades/client/spaces/spaces_test.go
+++ b/apiserver/facades/client/spaces/spaces_test.go
@@ -903,7 +903,7 @@ func (s *LegacySuite) TestShowSpaceError(c *gc.C) {
 
 	entities := params.Entities{}
 	_, err := s.facade.ShowSpace(entities)
-	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: retrieving model config: boom")
 }
 
 func (s *LegacySuite) TestCreateSpacesModelConfigError(c *gc.C) {
@@ -913,7 +913,7 @@ func (s *LegacySuite) TestCreateSpacesModelConfigError(c *gc.C) {
 
 	args := params.CreateSpacesParams{}
 	_, err := s.facade.CreateSpaces(args)
-	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: retrieving model config: boom")
 }
 
 func (s *LegacySuite) TestCreateSpacesProviderOpenError(c *gc.C) {
@@ -925,7 +925,8 @@ func (s *LegacySuite) TestCreateSpacesProviderOpenError(c *gc.C) {
 
 	args := params.CreateSpacesParams{}
 	_, err := s.facade.CreateSpaces(args)
-	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
+	c.Assert(err, gc.ErrorMatches,
+		`getting environ: creating environ for model \"stub-zoned-networking-environ\" \(.*\): boom`)
 }
 
 func (s *LegacySuite) TestCreateSpacesNotSupportedError(c *gc.C) {
@@ -987,7 +988,7 @@ func (s *LegacySuite) TestListSpacesAllSpacesError(c *gc.C) {
 	boom := errors.New("backing boom")
 	apiservertesting.BackingInstance.SetErrors(boom)
 	_, err := s.facade.ListSpaces()
-	c.Assert(err, gc.ErrorMatches, "getting environ: backing boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: retrieving model config: backing boom")
 }
 
 func (s *LegacySuite) TestListSpacesSubnetsError(c *gc.C) {
@@ -1103,7 +1104,7 @@ func (s *LegacySuite) TestSupportsSpacesModelConfigError(c *gc.C) {
 	)
 
 	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewEmptyCloudCallContext())
-	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
+	c.Assert(err, gc.ErrorMatches, "getting environ: retrieving model config: boom")
 }
 
 func (s *LegacySuite) TestSupportsSpacesEnvironNewError(c *gc.C) {
@@ -1114,7 +1115,8 @@ func (s *LegacySuite) TestSupportsSpacesEnvironNewError(c *gc.C) {
 	)
 
 	err := spaces.SupportsSpaces(&stubBacking{apiservertesting.BackingInstance}, context.NewEmptyCloudCallContext())
-	c.Assert(err, gc.ErrorMatches, "getting environ: boom")
+	c.Assert(err, gc.ErrorMatches,
+		`getting environ: creating environ for model \"stub-zoned-networking-environ\" \(.*\): boom`)
 }
 
 func (s *LegacySuite) TestSupportsSpacesWithoutNetworking(c *gc.C) {

--- a/apiserver/facades/client/subnets/subnets_test.go
+++ b/apiserver/facades/client/subnets/subnets_test.go
@@ -319,7 +319,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndModelConfigFails(c *gc.C
 
 	results, err := s.facade.AllZones()
 	c.Assert(err, gc.ErrorMatches,
-		`cannot update known zones: opening environment: config not found`,
+		`cannot update known zones: opening environment: retrieving model config: config not found`,
 	)
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -342,7 +342,7 @@ func (s *SubnetsSuite) TestAllZonesWithNoBackingZonesAndOpenFails(c *gc.C) {
 
 	results, err := s.facade.AllZones()
 	c.Assert(err, gc.ErrorMatches,
-		`cannot update known zones: opening environment: config not valid`,
+		`cannot update known zones: opening environment: creating environ for model \"stub-zoned-environ\" \(.*\): config not valid`,
 	)
 	// Verify the cause is not obscured.
 	c.Assert(err, jc.Satisfies, errors.IsNotValid)
@@ -865,8 +865,8 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 		{"either CIDR or SubnetProviderId is required", nil},
 		{"either CIDR or SubnetProviderId is required", nil},
 		{"CIDR and SubnetProviderId cannot be both set", nil},
-		{"opening environment: config not found", params.IsCodeNotFound},
-		{"opening environment: provider not found", params.IsCodeNotFound},
+		{"opening environment: retrieving model config: config not found", params.IsCodeNotFound},
+		{`opening environment: creating environ for model \"stub-networking-environ\" \(.*\): provider not found`, params.IsCodeNotFound},
 		{"cannot get provider subnets: subnets not found", params.IsCodeNotFound},
 		{`subnet with CIDR "" and ProviderId "missing" not found`, params.IsCodeNotFound},
 		{`subnet with CIDR "" and ProviderId "void" not found`, params.IsCodeNotFound},
@@ -940,7 +940,7 @@ func (s *SubnetsSuite) TestAddSubnetsParamsCombinations(c *gc.C) {
 			c.Logf("unexpected success; args: %#v", args.Subnets[i])
 			continue
 		}
-		c.Check(result.Error.Message, gc.Equals, expectedErrors[i].message)
+		c.Check(result.Error, gc.ErrorMatches, expectedErrors[i].message)
 		if expectedErrors[i].satisfier != nil {
 			c.Check(result.Error, jc.Satisfies, expectedErrors[i].satisfier)
 		} else {

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -34,18 +34,22 @@ func GetEnviron(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, err
 func GetEnvironAndCloud(st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, *environscloudspec.CloudSpec, error) {
 	modelConfig, err := st.ModelConfig()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Annotate(err, "retrieving model config")
 	}
+
 	cloudSpec, err := st.CloudSpec()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Annotatef(
+			err, "retrieving cloud spec for model %q (%s)", modelConfig.Name(), modelConfig.UUID())
 	}
+
 	env, err := newEnviron(context.TODO(), OpenParams{
 		Cloud:  cloudSpec,
 		Config: modelConfig,
 	})
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Annotatef(
+			err, "creating environ for model %q (%s)", modelConfig.Name(), modelConfig.UUID())
 	}
 	return env, &cloudSpec, nil
 }

--- a/worker/environ/environ.go
+++ b/worker/environ/environ.go
@@ -75,7 +75,7 @@ func NewTracker(config Config) (*Tracker, error) {
 
 	environ, spec, err := environs.GetEnvironAndCloud(config.Observer, config.NewEnvironFunc)
 	if err != nil {
-		return nil, errors.Annotate(err, "creating environ")
+		return nil, errors.Trace(err)
 	}
 
 	t := &Tracker{

--- a/worker/environ/environ_test.go
+++ b/worker/environ/environ_test.go
@@ -82,7 +82,7 @@ func (s *TrackerSuite) TestModelConfigFails(c *gc.C) {
 	}
 	fix.Run(c, func(context *runContext) {
 		tracker, err := environ.NewTracker(s.validConfig(context))
-		c.Check(err, gc.ErrorMatches, "creating environ: no you")
+		c.Check(err, gc.ErrorMatches, "retrieving model config: no you")
 		c.Check(tracker, gc.IsNil)
 		context.CheckCallNames(c, "ModelConfig")
 	})
@@ -96,7 +96,8 @@ func (s *TrackerSuite) TestModelConfigInvalid(c *gc.C) {
 			return nil, errors.NotValidf("config")
 		}
 		tracker, err := environ.NewTracker(config)
-		c.Check(err, gc.ErrorMatches, `creating environ: config not valid`)
+		c.Check(err, gc.ErrorMatches,
+			`creating environ for model \"testmodel\" \(deadbeef-0bad-400d-8000-4b1d0d06f00d\): config not valid`)
 		c.Check(tracker, gc.IsNil)
 		runContext.CheckCallNames(c, "ModelConfig", "CloudSpec")
 	})
@@ -133,7 +134,8 @@ func (s *TrackerSuite) TestCloudSpec(c *gc.C) {
 			return nil, errors.NotValidf("cloud spec")
 		}
 		tracker, err := environ.NewTracker(config)
-		c.Check(err, gc.ErrorMatches, `creating environ: cloud spec not valid`)
+		c.Check(err, gc.ErrorMatches,
+			`creating environ for model \"testmodel\" \(deadbeef-0bad-400d-8000-4b1d0d06f00d\): cloud spec not valid`)
 		c.Check(tracker, gc.IsNil)
 		runContext.CheckCallNames(c, "ModelConfig", "CloudSpec")
 	})

--- a/worker/environ/environ_test.go
+++ b/worker/environ/environ_test.go
@@ -82,7 +82,7 @@ func (s *TrackerSuite) TestModelConfigFails(c *gc.C) {
 	}
 	fix.Run(c, func(context *runContext) {
 		tracker, err := environ.NewTracker(s.validConfig(context))
-		c.Check(err, gc.ErrorMatches, "cannot create environ: no you")
+		c.Check(err, gc.ErrorMatches, "creating environ: no you")
 		c.Check(tracker, gc.IsNil)
 		context.CheckCallNames(c, "ModelConfig")
 	})
@@ -96,7 +96,7 @@ func (s *TrackerSuite) TestModelConfigInvalid(c *gc.C) {
 			return nil, errors.NotValidf("config")
 		}
 		tracker, err := environ.NewTracker(config)
-		c.Check(err, gc.ErrorMatches, `cannot create environ: config not valid`)
+		c.Check(err, gc.ErrorMatches, `creating environ: config not valid`)
 		c.Check(tracker, gc.IsNil)
 		runContext.CheckCallNames(c, "ModelConfig", "CloudSpec")
 	})
@@ -133,7 +133,7 @@ func (s *TrackerSuite) TestCloudSpec(c *gc.C) {
 			return nil, errors.NotValidf("cloud spec")
 		}
 		tracker, err := environ.NewTracker(config)
-		c.Check(err, gc.ErrorMatches, `cannot create environ: cloud spec not valid`)
+		c.Check(err, gc.ErrorMatches, `creating environ: cloud spec not valid`)
 		c.Check(tracker, gc.IsNil)
 		runContext.CheckCallNames(c, "ModelConfig", "CloudSpec")
 	})
@@ -151,7 +151,8 @@ func (s *TrackerSuite) TestWatchFails(c *gc.C) {
 		defer workertest.DirtyKill(c, tracker)
 
 		err = workertest.CheckKilled(c, tracker)
-		c.Check(err, gc.ErrorMatches, "cannot watch environ config: grrk splat")
+		c.Check(err, gc.ErrorMatches,
+			`model \"testmodel\" \(deadbeef-0bad-400d-8000-4b1d0d06f00d\): watching environ config: grrk splat`)
 		context.CheckCallNames(c, "ModelConfig", "CloudSpec", "WatchForModelConfigChanges")
 	})
 }
@@ -165,7 +166,8 @@ func (s *TrackerSuite) TestModelConfigWatchCloses(c *gc.C) {
 
 		context.CloseModelConfigNotify()
 		err = workertest.CheckKilled(c, tracker)
-		c.Check(err, gc.ErrorMatches, "environ config watch closed")
+		c.Check(err, gc.ErrorMatches,
+			`model \"testmodel\" \(deadbeef-0bad-400d-8000-4b1d0d06f00d\): environ config watch closed`)
 		context.CheckCallNames(c, "ModelConfig", "CloudSpec", "WatchForModelConfigChanges", "WatchCloudSpecChanges")
 	})
 }
@@ -179,7 +181,8 @@ func (s *TrackerSuite) TestCloudSpecWatchCloses(c *gc.C) {
 
 		context.CloseCloudSpecNotify()
 		err = workertest.CheckKilled(c, tracker)
-		c.Check(err, gc.ErrorMatches, "cloud watch closed")
+		c.Check(err, gc.ErrorMatches,
+			`model \"testmodel\" \(deadbeef-0bad-400d-8000-4b1d0d06f00d\): cloud watch closed`)
 		context.CheckCallNames(c, "ModelConfig", "CloudSpec", "WatchForModelConfigChanges", "WatchCloudSpecChanges")
 	})
 }
@@ -187,7 +190,7 @@ func (s *TrackerSuite) TestCloudSpecWatchCloses(c *gc.C) {
 func (s *TrackerSuite) TestWatchedModelConfigFails(c *gc.C) {
 	fix := &fixture{
 		observerErrs: []error{
-			nil, nil, nil, nil, nil, errors.New("blam ouch"),
+			nil, nil, nil, nil, errors.New("blam ouch"),
 		},
 	}
 	fix.Run(c, func(context *runContext) {
@@ -196,9 +199,9 @@ func (s *TrackerSuite) TestWatchedModelConfigFails(c *gc.C) {
 		defer workertest.DirtyKill(c, tracker)
 
 		context.SendModelConfigNotify()
-		context.SendCloudSpecNotify()
 		err = workertest.CheckKilled(c, tracker)
-		c.Check(err, gc.ErrorMatches, "cannot read environ config: blam ouch")
+		c.Check(err, gc.ErrorMatches,
+			`model \"testmodel\" \(deadbeef-0bad-400d-8000-4b1d0d06f00d\): reading model config: blam ouch`)
 	})
 }
 
@@ -206,9 +209,9 @@ func (s *TrackerSuite) TestWatchedModelConfigIncompatible(c *gc.C) {
 	fix := &fixture{}
 	fix.Run(c, func(runContext *runContext) {
 		config := s.validConfig(runContext)
-		config.NewEnvironFunc = func(context.Context, environs.OpenParams) (environs.Environ, error) {
-			env := &mockEnviron{}
-			env.SetErrors(errors.New("SetConfig is broken"))
+		config.NewEnvironFunc = func(_ context.Context, args environs.OpenParams) (environs.Environ, error) {
+			env := &mockEnviron{cfg: args.Config}
+			env.SetErrors(nil, errors.New("SetConfig is broken"))
 			return env, nil
 		}
 		tracker, err := environ.NewTracker(config)
@@ -217,8 +220,10 @@ func (s *TrackerSuite) TestWatchedModelConfigIncompatible(c *gc.C) {
 
 		runContext.SendModelConfigNotify()
 		err = workertest.CheckKilled(c, tracker)
-		c.Check(err, gc.ErrorMatches, "cannot update environ config: SetConfig is broken")
-		runContext.CheckCallNames(c, "ModelConfig", "CloudSpec", "WatchForModelConfigChanges", "WatchCloudSpecChanges", "ModelConfig")
+		c.Check(err, gc.ErrorMatches,
+			`model \"testmodel\" \(deadbeef-0bad-400d-8000-4b1d0d06f00d\): updating environ config: SetConfig is broken`)
+		runContext.CheckCallNames(c,
+			"ModelConfig", "CloudSpec", "WatchForModelConfigChanges", "WatchCloudSpecChanges", "ModelConfig")
 	})
 }
 


### PR DESCRIPTION
When we get errors in the environ tracker worker, the logged messages do not indicate the relevant model, which can be janky for multi-model controllers.

Here we ensure that such errors are annotated with the model name and UUID where they are available.

## QA steps

No functional changes and no new error paths introduced. Unit tests verify the message annotations.

## Documentation changes

None.

## Bug reference

N/A
