### PR TITLE
[JUJU-969] Validate service names

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -1165,7 +1165,7 @@ func (k *kubernetesClient) ensureService(
 
 	// ensure services.
 	if len(workloadSpec.Services) > 0 {
-		servicesCleanUps, err := k.ensureServicesForApp(appName, annotations, workloadSpec.Services)
+		servicesCleanUps, err := k.ensureServicesForApp(appName, deploymentName, annotations, workloadSpec.Services)
 		cleanups = append(cleanups, servicesCleanUps...)
 		if err != nil {
 			return errors.Annotate(err, "creating or updating services")

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -2345,6 +2345,59 @@ func (s *K8sBrokerSuite) TestEnsureServiceNoStorage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *K8sBrokerSuite) TestEnsureServiceInvalidServiceName(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	basicPodSpec := getBasicPodspec()
+	basicPodSpec.ProviderPod = &k8sspecs.K8sPodSpec{
+		KubernetesResources: &k8sspecs.KubernetesResources{
+			Pod: &k8sspecs.PodSpec{Annotations: map[string]string{"foo": "baz"}},
+			Services: []k8sspecs.K8sService{
+				{
+					Meta: k8sspecs.Meta{
+						Name:        "app-name",
+						Labels:      map[string]string{"foo": "bar"},
+						Annotations: map[string]string{"cloud.google.com/load-balancer-type": "Internal"},
+					},
+					Spec: core.ServiceSpec{
+						Selector: map[string]string{"app": "MyApp"},
+						Ports: []core.ServicePort{
+							{
+								Protocol:   core.ProtocolTCP,
+								Port:       80,
+								TargetPort: intstr.IntOrString{IntVal: 9376},
+							},
+						},
+						Type: core.ServiceTypeLoadBalancer,
+					},
+				},
+			},
+		},
+	}
+
+	gomock.InOrder(
+		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "juju-operator-app-name", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+	)
+
+	params := &caas.ServiceParams{
+		PodSpec:           basicPodSpec,
+		OperatorImagePath: "operator/image-path",
+		ResourceTags: map[string]string{
+			"juju-controller-uuid": testing.ControllerTag.Id(),
+			"fred":                 "mary",
+		},
+	}
+	err := s.broker.EnsureService("app-name", func(_ string, _ status.Status, _ string, _ map[string]interface{}) error { return nil }, params, 2, config.ConfigAttributes{
+		"kubernetes-service-type":            "loadbalancer",
+		"kubernetes-service-loadbalancer-ip": "10.0.0.1",
+		"kubernetes-service-externalname":    "ext-name",
+		"kubernetes-service-annotations":     map[string]interface{}{"a": "b"},
+	})
+	c.Assert(err, gc.ErrorMatches, `creating or updating services: "app-name" is a reserved service name`)
+}
+
 func (s *K8sBrokerSuite) TestEnsureServiceForDeploymentWithUpdateStrategy(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()

--- a/caas/kubernetes/provider/services.go
+++ b/caas/kubernetes/provider/services.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/juju/errors"
 	core "k8s.io/api/core/v1"
@@ -21,8 +22,11 @@ func getServiceLabels(appName string, legacy bool) map[string]string {
 	return utils.LabelsForApp(appName, legacy)
 }
 
-func (k *kubernetesClient) ensureServicesForApp(appName string, annotations k8sannotations.Annotation, services []k8sspecs.K8sService) (cleanUps []func(), err error) {
+func (k *kubernetesClient) ensureServicesForApp(appName, deploymentName string, annotations k8sannotations.Annotation, services []k8sspecs.K8sService) (cleanUps []func(), err error) {
 	for _, v := range services {
+		if v.Name == deploymentName {
+			return cleanUps, errors.NewNotValid(nil, fmt.Sprintf("%q is a reserved service name", deploymentName))
+		}
 		spec := &core.Service{
 			ObjectMeta: v1.ObjectMeta{
 				Name:        v.Name,


### PR DESCRIPTION
This PR adds validattion for service names under `.kubernetesResources.services` in podsepc.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
# deploy a charm has service name using app name;
$ juju deploy ./minio_ubuntu-20.04-amd64.charm --resource oci-image=minio/minio:latest
Located local charm "minio", revision 0
Deploying "minio" from local charm "minio", revision 0

$ juju status --relations --color --storage -m k1:t1
Model  Controller  Cloud/Region        Version     SLA          Timestamp
t1     k1          microk8s/localhost  2.9.29.888  unsupported  17:26:58+10:00

App    Version             Status  Scale  Charm  Channel  Rev  Address  Exposed  Message
minio  minio/minio:latest  error       1  minio             0           no       "minio" is a reserved service name

Unit      Workload  Agent      Address  Ports  Message
minio/0*  waiting   executing                  (leader-elected) waiting for container

Storage Unit  Storage id    Type        Mountpoint  Size  Status   Message
minio/0       minio-data/0  filesystem                    pending
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1968634