### PR TITLE
docs(README): Remove copy-pasted link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ management to allow much more agile operations for complex cloud workloads.
 Shared, open source operators **take infrastructure as code to the next level**
 with community-driven ops and integration code. Reuse of ops code improves
 quality and encourages wider [community engagement and contribution](
-https://juju.is/about#collaboration). Operators also improve security
-throughchat.charmhub.io/ consistent automation. Juju operators are a
-[community-driven devsecops](https://juju.is/about#automate-everything)
-approach to open source operations.
+https://juju.is/about#collaboration). Operators also improve security through
+consistent automation. Juju operators are a [community-driven
+devsecops](https://juju.is/about#automate-everything) approach to open source
+operations.
 
 Juju implements the Kubernetes operator pattern, but is also a **universal
 OLM** that extends the operator pattern to traditional applications (without


### PR DESCRIPTION
With 353bfd7 a link creeps into a paragraph that has been overlooked.
This PR removes the parasite link and again reformats to 80 chars a
line.

## Documentation changes

Improves readability.