### PR TITLE
[JUJU-959] Fix/lp 1968058

### DIFF
--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -34,6 +34,12 @@ var (
 	ErrActionNotAvailable = errors.New("action no longer available")
 )
 
+// ErrTryAgain reports whether the cause
+// of the error is an ErrTryAgain.
+func IsErrTryAgain(err error) bool {
+	return errors.Cause(err) == ErrTryAgain
+}
+
 // OperationBlockedError returns an error which signifies that
 // an operation has been blocked; the message should describe
 // what has been blocked.
@@ -233,6 +239,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeQuotaLimitExceeded
 	case errors.IsNotYetAvailable(err):
 		code = params.CodeNotYetAvailable
+	case IsErrTryAgain(err):
+		code = params.CodeTryAgain
 	case params.IsIncompatibleClientError(err):
 		code = params.CodeIncompatibleClient
 		rawErr := errors.Cause(err).(*params.IncompatibleClientError)
@@ -358,6 +366,8 @@ func RestoreError(err error) error {
 		return rehydrateLeaseError(err)
 	case params.IsCodeNotYetAvailable(err):
 		return errors.NewNotYetAvailable(nil, msg)
+	case params.IsCodeTryAgain(err):
+		return ErrTryAgain
 	default:
 		return err
 	}

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -15,9 +15,11 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/worker/fortress"
 )
 
@@ -192,6 +194,12 @@ func (w *Worker) doVALIDATION(status watcher.MigrationStatus) error {
 			w.config.Logger.Debugf("validation failed (retrying): %v", err)
 		}
 	}
+	if apiservererrors.IsErrTryAgain(err) || params.IsCodeTryAgain(err) {
+		// We treat TryAgainError as a retriable error,
+		// so ingore it and don't report to the migrationmaster.
+		w.config.Logger.Errorf("validation failed due to reach rate limit: %v", err)
+		return nil
+	}
 	if err != nil {
 		// Don't return this error just log it and report to the
 		// migrationmaster that things didn't work out.
@@ -218,8 +226,6 @@ func (w *Worker) validate(status watcher.MigrationStatus) error {
 	// a long set of retry attempts.
 	conn, err := w.config.APIOpen(apiInfo, api.DialOpts{})
 	if err != nil {
-		// Don't return this error just log it and report to the
-		// migrationmaster that things didn't work out.
 		return errors.Annotate(err, "failed to open API to target controller")
 	}
 	defer func() { _ = conn.Close() }()

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -197,7 +197,7 @@ func (w *Worker) doVALIDATION(status watcher.MigrationStatus) error {
 	if apiservererrors.IsErrTryAgain(err) || params.IsCodeTryAgain(err) {
 		// We treat TryAgainError as a retriable error,
 		// so ingore it and don't report to the migrationmaster.
-		w.config.Logger.Errorf("validation failed due to reach rate limit: %v", err)
+		w.config.Logger.Errorf("validation failed due to rate limit reached: %v", err)
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
Do not report error back from migrationminion worker if it got a rate limit error because we think it should be retriable error but not a fatal error.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju bootstrap microk8s k1

$ juju add-model t1

$ juju deploy minio

$ juju bootstrap microk8s k2

$ juju migrate k1:t1 k2

$ juju debug-log --color --replay -m k1:t1
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: QUIESCE
application-minio: 15:21:33 INFO juju.worker.caasoperator.runner stopped "minio/0", err: <nil>
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: QUIESCE
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: QUIESCE
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: QUIESCE
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: QUIESCE
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: QUIESCE
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: QUIESCE
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: IMPORT
application-minio: 15:21:33 INFO juju.worker.migrationminion migration phase is now: IMPORT
application-minio: 15:21:34 INFO juju.worker.migrationminion migration phase is now: IMPORT
application-minio: 15:21:38 INFO juju.worker.migrationminion migration phase is now: VALIDATION
application-minio: 15:21:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:39 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:40 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:42 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:45 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:21:45 ERROR juju.worker.migrationminion validation failed due to reach rate limit: failed to open API to target controller: try again (try again)
application-minio: 15:22:09 INFO juju.worker.migrationminion migration phase is now: VALIDATION
application-minio: 15:22:09 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:09 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:09 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:10 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:10 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:10 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:10 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:12 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:13 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:14 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:14 ERROR juju.worker.migrationminion validation failed due to reach rate limit: failed to open API to target controller: try again (try again)


application-minio: 15:22:38 INFO juju.worker.migrationminion migration phase is now: VALIDATION
application-minio: 15:22:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:38 INFO juju.worker.migrationminion migration phase is now: VALIDATION
application-minio: 15:22:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:38 INFO juju.worker.migrationminion migration phase is now: VALIDATION
application-minio: 15:22:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:38 INFO juju.worker.migrationminion migration phase is now: VALIDATION
application-minio: 15:22:38 INFO juju.api connection established to "wss://10.152.183.132:17070/model/64c16235-56d8-4359-8729-e92dc1e0fcaa/api"
application-minio: 15:22:38 INFO juju.worker.migrationminion migration phase is now: SUCCESS
application-minio: 15:22:38 INFO juju.worker.migrationminion migration phase is now: SUCCESS
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1968058
