### PR TITLE
[JUJU-974] Detect LXD "not found" errors

### DIFF
--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -561,7 +561,7 @@ func (s *containerSuite) TestRemoveContainersSuccessWithNotFound(c *gc.C) {
 	exp.DeleteContainer("c1").Return(deleteOp, nil)
 	exp.GetContainerState("c2").Return(&api.ContainerState{StatusCode: api.Started}, lxdtesting.ETag, nil)
 	exp.UpdateContainerState("c2", stopReq, lxdtesting.ETag).Return(stopOp, nil)
-	exp.DeleteContainer("c2").Return(deleteOp, errors.New("not found"))
+	exp.DeleteContainer("c2").Return(deleteOp, errors.New("container not found"))
 
 	jujuSvr, err := lxd.NewServer(cSvr)
 	c.Assert(err, jc.ErrorIsNil)

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -271,7 +271,7 @@ func (s *networkSuite) TestVerifyNetworkDeviceNotPresentCreated(c *gc.C) {
 		NetworkPut: lxdapi.NetworkPut{Config: netConf},
 	}
 	gomock.InOrder(
-		cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(nil, "", errors.New("not found")),
+		cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(nil, "", errors.New("network not found")),
 		cSvr.EXPECT().CreateNetwork(netCreateReq).Return(nil),
 		cSvr.EXPECT().GetNetwork(network.DefaultLXDBridge).Return(newNet, "", nil),
 		cSvr.EXPECT().UpdateProfile("default", defaultLegacyProfileWithNIC().Writable(), lxdtesting.ETag).Return(nil),

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -332,7 +332,7 @@ func IsLXDNotFound(err error) bool {
 		return true
 	}
 
-	return strings.ToLower(err.Error()) == "not found"
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
 }
 
 // IsLXDAlreadyExists checks if an error from the LXD API indicates that a


### PR DESCRIPTION
LXD 5.0.0 introduced [this change](https://github.com/lxc/lxd/commit/6fee3b624d3adbda4d07c24bd8d143abca2f96c9) which breaks not-found error detection in the LXD container manager.

Here, we change the detection to work on a sub-string instead of verbatim "not found".

## QA steps

See unit tests.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1968849
