### PR TITLE
[JUJU-982] Not all clouds support spaces.

### DIFF
--- a/cmd/juju/application/bind.go
+++ b/cmd/juju/application/bind.go
@@ -118,7 +118,10 @@ func (c *bindCommand) Run(ctx *cmd.Context) error {
 		return err
 	}
 
-	if err = c.parseBindExpression(apiRoot); err != nil {
+	if err = c.parseBindExpression(apiRoot); err != nil && errors.IsNotSupported(err) {
+		ctx.Infof("Spaces not supported by this model's cloud, nothing to do.")
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -193,7 +193,7 @@ func (d *deployBundle) makeBundleDeploySpec(ctx *cmd.Context, apiRoot DeployerAP
 	}
 
 	knownSpaces, err := apiRoot.ListSpaces()
-	if err != nil {
+	if err != nil && !errors.IsNotSupported(err) {
 		return bundleDeploySpec{}, errors.Trace(err)
 	}
 

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -359,7 +359,9 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 			return err
 		}
 
-		if err := c.parseBindFlag(apiRoot); err != nil {
+		if err := c.parseBindFlag(apiRoot); err != nil && errors.IsNotSupported(err) {
+			ctx.Infof("Spaces not supported by this model's cloud, ignoring bindings.")
+		} else if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Do not fail deploying, refreshing nor bind due to lack of space support by the model's cloud. The user may not be attempting to use anyways. For bind, return an information message and exit.

## QA steps

All QA steps in #13934 

and

```console
# for deploy
# please use your personal credentials on the Boston vsphere.
# overlay can be found: https://ubuntu.com/kubernetes/docs/charm-vsphere-integrator 
$ juju bootstrap Boston-vsphere --config datastore=vsanDatastore --config primary-network=VLAN_2765
$ juju deploy charmed-kubernetes --trust --overlay ./vsphere-overlay.yaml

# test juju refresh with --bind, should continue but include the message: "Spaces not supported by this model's cloud, ignoring bindings."

# test juju bind, should return an info message "Spaces not supported by this model's cloud, nothing to do." and exit.
 
```
