### PR TITLE
terminate nova instance if allocating floating ip fails

### DIFF
--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -509,6 +509,50 @@ func (s *localServerSuite) TestStartInstanceWithoutPublicIP(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+// If we fail to allocate a floating IP when starting an instance, the nova instance
+// should be terminated.
+func (s *localServerSuite) TestStartInstanceWhenPublicIPError(c *gc.C) {
+	var (
+		addServerID        string
+		removeServerID     string
+		removeServerCalled bool
+	)
+
+	cleanup := s.srv.Neutron.RegisterControlPoint(
+		"addFloatingIP",
+		func(sc hook.ServiceControl, args ...interface{}) error {
+			return fmt.Errorf("fail on purpose")
+		},
+	)
+	defer cleanup()
+	cleanup = s.srv.Nova.RegisterControlPoint(
+		"addServer",
+		func(sc hook.ServiceControl, args ...interface{}) error {
+			addServerID = args[0].(*nova.ServerDetail).Id
+			return nil
+		},
+	)
+	defer cleanup()
+	cleanup = s.srv.Nova.RegisterControlPoint(
+		"removeServer",
+		func(sc hook.ServiceControl, args ...interface{}) error {
+			removeServerCalled = true
+			removeServerID = args[0].(string)
+			return nil
+		},
+	)
+	defer cleanup()
+	_, _, _, err := testing.StartInstanceWithConstraints(s.env, s.callCtx, s.ControllerUUID, "100", constraints.MustParse("allocate-public-ip=true"))
+	c.Assert(err, gc.ErrorMatches, "(.|\n)*cannot allocate a public IP as needed(.|\n)*")
+
+	if !removeServerCalled {
+		c.Fatal("removeServer should have been called")
+	}
+	if removeServerID != addServerID {
+		c.Fatalf("server IDs of addServer (%q) and removeServer (%q) do not match", addServerID, removeServerID)
+	}
+}
+
 func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {
 	// Ensure amd64 tools are available, to ensure an amd64 image.
 	env := s.ensureAMDImages(c)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -544,13 +544,8 @@ func (s *localServerSuite) TestStartInstanceWhenPublicIPError(c *gc.C) {
 	defer cleanup()
 	_, _, _, err := testing.StartInstanceWithConstraints(s.env, s.callCtx, s.ControllerUUID, "100", constraints.MustParse("allocate-public-ip=true"))
 	c.Assert(err, gc.ErrorMatches, "(.|\n)*cannot allocate a public IP as needed(.|\n)*")
-
-	if !removeServerCalled {
-		c.Fatal("removeServer should have been called")
-	}
-	if removeServerID != addServerID {
-		c.Fatalf("server IDs of addServer (%q) and removeServer (%q) do not match", addServerID, removeServerID)
-	}
+	c.Assert(removeServerCalled, jc.IsTrue)
+	c.Assert(removeServerID, gc.Equals, addServerID)
 }
 
 func (s *localServerSuite) TestStartInstanceHardwareCharacteristics(c *gc.C) {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1333,6 +1333,10 @@ func (e *Environ) startInstance(
 		var publicIP *string
 		logger.Debugf("allocating public IP address for openstack node")
 		if fip, err := e.networking.AllocatePublicIP(inst.Id()); err != nil {
+			if err := e.terminateInstances(ctx, []instance.Id{inst.Id()}); err != nil {
+				// ignore the failure at this stage, just log it
+				logger.Debugf("failed to terminate instance %q: %v", inst.Id(), err)
+			}
 			return nil, common.ZoneIndependentError(errors.Annotate(err, "cannot allocate a public IP as needed"))
 		} else {
 			publicIP = fip


### PR DESCRIPTION
If allocating a floating IP fails, then terminate the created instance before returning from `startInstance`

I am not sure if the Juju team wants to come up with a different fix.

## QA steps

```sh
# for a controller on an openstack cloud, after exhausting the floating ip quotas
juju add-machine --constraints 'allocate-public-ip=true'
```

I am not sure how to spin up a Juju controller from a development branch, but I am confident the proposed change should work, since it is also used directly below in case the floating IP attach fails.

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1969309