### PR TITLE
[JUJU-976] Fix/lp 1968745

### DIFF
--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -34,8 +34,7 @@ var (
 	ErrActionNotAvailable = errors.New("action no longer available")
 )
 
-// ErrTryAgain reports whether the cause
-// of the error is an ErrTryAgain.
+// IsErrTryAgain reports whether the cause of the error is an ErrTryAgain.
 func IsErrTryAgain(err error) bool {
 	return errors.Cause(err) == ErrTryAgain
 }

--- a/worker/migrationminion/worker.go
+++ b/worker/migrationminion/worker.go
@@ -196,7 +196,7 @@ func (w *Worker) doVALIDATION(status watcher.MigrationStatus) error {
 	}
 	if apiservererrors.IsErrTryAgain(err) || params.IsCodeTryAgain(err) {
 		// We treat TryAgainError as a retriable error,
-		// so ingore it and don't report to the migrationmaster.
+		// so ingore it and don't report to the migration master.
 		w.config.Logger.Errorf("validation failed due to rate limit reached: %v", err)
 		return nil
 	}

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -235,8 +235,7 @@ func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Durat
 				return rval
 			},
 			func(k string) string {
-				v, _ := env[k]
-				return v
+				return env[k]
 			},
 			func(k string) (string, bool) {
 				v, t := env[k]
@@ -420,8 +419,7 @@ func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, r
 				return rval
 			},
 			func(k string) string {
-				v, _ := env[k]
-				return v
+				return env[k]
 			},
 			func(k string) (string, bool) {
 				v, t := env[k]
@@ -745,7 +743,10 @@ func (runner *runner) getRemoteEnviron(abort <-chan struct{}) (map[string]string
 		Stderr:   &stderr,
 	})
 	if err != nil {
-		return nil, errors.Annotatef(err, "stdout: %q stderr: %q", string(res.Stdout), string(res.Stderr))
+		if res != nil {
+			err = errors.Annotatef(err, "stdout: %q stderr: %q", string(res.Stdout), string(res.Stderr))
+		}
+		return nil, errors.Trace(err)
 	}
 	matches := exportLineRegexp.FindAllStringSubmatch(string(res.Stdout), -1)
 	env := map[string]string{}


### PR DESCRIPTION
Fix below panic(the exec response could be nil if the target pod does not exist or is not running):

```log
application-minio: 13:42:38 ERROR juju.worker.caasoperator.runner exited "minio/8": panic resulted in: runtime error: invalid memory address or nil pointer dereference
panic resulted in: runtime error: invalid memory address or nil pointer dereference
stacktrace:
goroutine 299 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/juju/worker/v3/catacomb.runSafely.func1()
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/vendor/github.com/juju/worker/v3/catacomb/catacomb.go:292 +0x8f
panic({0x52bac00, 0x9b6fda0})
        /usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/juju/juju/worker/uniter/runner.(*runner).getRemoteEnviron(0xc000d9a210, 0xc0005bb1a0)
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/runner/runner.go:748 +0x215
github.com/juju/juju/worker/uniter/runner.(*runner).runCommandsWithTimeout(0xc000d9a210, {0xc00014ef00, 0xd}, 0x45d964b800, {0x673f260, 0x9bfb4f0}, 0x2, 0xc0006b6520)
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/runner/runner.go:225 +0x185
github.com/juju/juju/worker/uniter/runner.(*runner).runJujuRunAction(0xc000d9a210)
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/runner/runner.go:311 +0x205
github.com/juju/juju/worker/uniter/runner.(*runner).RunAction(0xc000d9a210, {0xc00014eef0, 0xc0007f4830})
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/runner/runner.go:370 +0x85
github.com/juju/juju/worker/uniter/operation.(*runAction).Execute(0xc000fc7180, {0x1, 0x1, 0x0, 0x1, 0x0, 0x1, {0x5d3bbbb, 0xa}, {0x5d31bea, ...}, ...})
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/operation/runaction.go:107 +0x166
github.com/juju/juju/worker/uniter/operation.(*executor).do(0xc00006eb40, {0x6769668, 0xc0008c4378}, {{0x5d37064, 0x203000}, 0x5f6caa0})
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/operation/executor.go:133 +0x1f4
github.com/juju/juju/worker/uniter/operation.(*executor).Run(0xc00006eb40, {0x6769668, 0xc0008c4378}, 0xc0005baa80)
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/operation/executor.go:113 +0x505
github.com/juju/juju/worker/uniter/resolver.Loop({{0x6667160, 0xc0008c66c0}, {0x673e0a8, 0xc0002ec600}, {0x66c1cc8, 0xc00006eb40}, {0x67f6c40, 0xc00080e600}, 0xc00032cf60, 0xc00046b250, ...}, ...)
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/resolver/loop.go:121 +0x845
github.com/juju/juju/worker/uniter.(*Uniter).loop(0xc000507680, {{0xc00045c3b5, 0x7}})
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/uniter.go:519 +0x20a5
github.com/juju/juju/worker/uniter.newUniter.func2.1()
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/worker/uniter/uniter.go:283 +0x29
github.com/juju/worker/v3/catacomb.runSafely(0xc00067c070)
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/vendor/github.com/juju/worker/v3/catacomb/catacomb.go:295 +0x62
github.com/juju/worker/v3/catacomb.Invoke.func3()
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/vendor/github.com/juju/worker/v3/catacomb/catacomb.go:116 +0x6d
gopkg.in/tomb%2ev2.(*Tomb).run(0xc000507680, 0xc00067c070)
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/vendor/gopkg.in/tomb.v2/tomb.go:163 +0x36
created by gopkg.in/tomb%2ev2.(*Tomb).Go
        /home/jenkins/workspace/build-juju-amd64/_build/src/github.com/juju/juju/vendor/gopkg.in/tomb.v2/tomb.go:159 +0xf3

application-minio: 13:42:41 ERROR juju.worker.caasoperator could not get pod "unit-minio-8" "minio-0" pod "minio-0" not found
application-minio: 13:56:51 WARNING juju.worker.caasoperator.uniter.minio/8.operation we should run a leader-deposed hook here, but we can't yet
application-minio: 13:56:59 WARNING juju.worker.caasoperator stopping uniter for dead unit "minio/8": worker "minio/8" not found
application-minio: 13:58:02 WARNING juju.worker.proxyupdater unable to set snap core settings [proxy.http= proxy.https= proxy.store=]: exec: "snap": executable file not found in $PATH, output: ""
application-minio: 14:02:24 ERROR juju.worker.caasoperator.uniter.minio/9 resolver loop error: executing operation "remote init" for minio/9: attempt count exceeded: container not running not found
application-minio: 14:02:24 ERROR juju.worker.caasoperator.runner exited "minio/9": executing operation "remote init" for minio/9: attempt count exceeded: container not running not found
```

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
# need microk8s 1.21
$ git clone https://github.com/jardon/minio-operator.git
$ git checkout b2a04cb63ec319b96b7e8861a9d1f2c38c2c23ae
$ charmcraft pack
$ juju deploy ./minio_ubuntu-20.04-amd64.charm --resource oci-image=minio/minio:RELEASE.2021-09-03T03-56-13Z
$ juju config minio ssl-key=key
$ juju config minio ssl-cert=cert
$ juju config minio ssl-root-ca=root-ca
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1968745
