### PR TITLE
Fix az handling in the machine provisioner

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/juju/environs/context"
 	"github.com/juju/names/v4"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
@@ -36,6 +35,7 @@ import (
 	"github.com/juju/juju/core/workerpool"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	"github.com/juju/juju/environs/simplestreams"
@@ -220,14 +220,14 @@ func (task *provisionerTask) loop() (taskErr error) {
 				return errors.New("machine watcher closed channel")
 			}
 
+			if err := task.processMachines(ctx, ids); err != nil {
+				return errors.Annotate(err, "processing updated machines")
+			}
+
 			// Maintain zone-machine distributions.
 			err := task.updateAvailabilityZoneMachines(ctx)
 			if err != nil && !errors.IsNotImplemented(err) {
 				return errors.Annotate(err, "updating AZ distributions")
-			}
-
-			if err := task.processMachines(ctx, ids); err != nil {
-				return errors.Annotate(err, "processing updated machines")
 			}
 
 			task.notifyEventProcessedCallback(eventTypeProcessedMachines)


### PR DESCRIPTION
A recent logic change to the machine provisioner introduced code to query the AZ info each time.
However, this was done too early, before the querying of the provisioned machines. Hence the AZ distribution was constructed on the basis of an empty list of machines, not what was actually provisioned.

The error was surfaced because test TestProvisioningMachinesClearAZFailures started failing. It was intermittent but regular because the zone is randomly selected and the list from which to select is wrong because of the issue fixed here. So it failed 1/3 of the time because there were 3 zone instead of the correct 2.

## QA steps

TestProvisioningMachinesClearAZFailures now passes every time.

