### PR TITLE
[JUJU-999] Fix intermittent provisioner test failures

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -220,12 +220,6 @@ func (task *provisionerTask) loop() (taskErr error) {
 				return errors.New("machine watcher closed channel")
 			}
 
-			// Maintain zone-machine distributions.
-			err := task.updateAvailabilityZoneMachines(ctx)
-			if err != nil && !errors.IsNotImplemented(err) {
-				return errors.Annotate(err, "updating AZ distributions")
-			}
-
 			if err := task.processMachines(ctx, ids); err != nil {
 				return errors.Annotate(err, "processing updated machines")
 			}
@@ -340,6 +334,12 @@ func (task *provisionerTask) processMachines(ctx context.ProviderCallContext, id
 	// Populate the tasks maps of current instances and machines.
 	if err := task.populateMachineMaps(ctx, ids); err != nil {
 		return errors.Trace(err)
+	}
+
+	// Maintain zone-machine distributions.
+	err := task.updateAvailabilityZoneMachines(ctx)
+	if err != nil && !errors.IsNotImplemented(err) {
+		return errors.Annotate(err, "updating AZ distributions")
 	}
 
 	// Find machines without an instance ID or that are dead.

--- a/worker/provisioner/provisioner_task_test.go
+++ b/worker/provisioner/provisioner_task_test.go
@@ -627,7 +627,7 @@ func (s *ProvisionerTaskSuite) TestPopulateAZMachinesErrorWorkerStopped(c *gc.C)
 	s.waitForWorkerSetup(c, "worker not set up")
 
 	err := workertest.CheckKill(c, task)
-	c.Assert(err, gc.ErrorMatches, "updating AZ distributions: boom")
+	c.Assert(err, gc.ErrorMatches, "processing updated machines: getting all instances from broker: boom")
 }
 
 func (s *ProvisionerTaskSuite) TestDedupStopRequests(c *gc.C) {


### PR DESCRIPTION
A bug was introduced by #13933 affecting machine provisioning retries, as revealed by intermittent failures in the test `TestProvisioningMachinesClearAZFailures`.

This is because populating the initial machine-AZ distribution information requires the task state being populated with the incoming machine changes first.

Here we relocate the population from the worker loop back to its original location in `processMachines`, which addresses the issue.

Supersedes #13965.

## QA steps

Provisioner tests now pass consistently.

## Documentation changes

None.

## Bug reference

N/A
