### PR TITLE
[JUJU-1002] Fix machine manifolds tests for db-accessor

### DIFF
--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -884,7 +884,7 @@ func (s *RefreshConfigSuite) TestDownloadOneFromChannelBuildK8s(c *gc.C) {
 			Channel:     &channel,
 			Base: &transport.Base{
 				Name:         "ubuntu",
-				Channel:      "20.04",
+				Channel:      "22.04",
 				Architecture: arch.DefaultArchitecture,
 			},
 		}},

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -71,6 +71,7 @@ func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *gc.C) {
 			"certificate-watcher",
 			"clock",
 			"controller-port",
+			"db-accessor",
 			"deployer",
 			"disk-manager",
 			"external-controller-updater",
@@ -147,6 +148,7 @@ func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *gc.C) {
 			"certificate-watcher",
 			"clock",
 			"controller-port",
+			"db-accessor",
 			"external-controller-updater",
 			"http-server",
 			"http-server-args",
@@ -227,6 +229,7 @@ func (s *ManifoldsSuite) TestMigrationGuardsUsed(c *gc.C) {
 		"central-hub",
 		"clock",
 		"controller-port",
+		"db-accessor",
 		"deployer",
 		"global-clock-updater",
 		"http-server",
@@ -300,6 +303,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 		"upgrade-database-runner",
+		"db-accessor",
 	)
 
 	// Explicitly guarded by ifPrimaryController.
@@ -516,6 +520,12 @@ var expectedMachineManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"central-hub",
 		"state",
+		"state-config-watcher",
+	},
+
+	"db-accessor": {
+		"agent",
+		"is-controller-flag",
 		"state-config-watcher",
 	},
 


### PR DESCRIPTION
The introduction of the new `db-accessor` controller worker needs to be accommodated in the machine manifolds test suites.

Those tests should now pass.