### PR TITLE
[juju-977] fix state changing too quickly, newer charm revision adds a resource

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -1301,16 +1301,17 @@ func (a *Application) changeCharmOps(
 		ops = append(ops, resOps...)
 	}
 
-	// Make sure the relation count does not change.
-	sameRelCount := bson.D{{"relationcount", len(relations)}}
-
 	// Update the relation count as well.
-	ops = append(ops, txn.Op{
-		C:      applicationsC,
-		Id:     a.doc.DocID,
-		Assert: append(notDeadDoc, sameRelCount...),
-		Update: bson.D{{"$inc", bson.D{{"relationcount", len(newPeers)}}}},
-	})
+	if len(newPeers) > 0 {
+		// Make sure the relation count does not change.
+		sameRelCount := bson.D{{"relationcount", len(relations)}}
+		ops = append(ops, txn.Op{
+			C:      applicationsC,
+			Id:     a.doc.DocID,
+			Assert: append(notDeadDoc, sameRelCount...),
+			Update: bson.D{{"$inc", bson.D{{"relationcount", len(newPeers)}}}},
+		})
+	}
 	// Check relations to ensure no active relations are removed.
 	relOps, err := a.checkRelationsOps(ch, relations)
 	if err != nil {

--- a/state/resources_mongo.go
+++ b/state/resources_mongo.go
@@ -224,7 +224,7 @@ func newRemoveResourcesOps(docs []resourceDoc) []txn.Op {
 //
 // We trust that the provided resource really is pending
 // and that it matches the existing doc with the same ID.
-func newResolvePendingResourceOps(pending storedResource, exists bool) []txn.Op {
+func newResolvePendingResourceOps(pending storedResource, exists, csExists bool) []txn.Op {
 	oldID := pendingResourceID(pending.ID, pending.PendingID)
 	newRes := pending
 	newRes.PendingID = ""
@@ -250,9 +250,13 @@ func newResolvePendingResourceOps(pending storedResource, exists bool) []txn.Op 
 
 	if exists {
 		ops = append(ops, newUpdateResourceOps(newRes)...)
-		return append(ops, newUpdateCharmStoreResourceOps(csRes)...)
+
 	} else {
 		ops = append(ops, newInsertResourceOps(newRes)...)
+	}
+	if csExists {
+		return append(ops, newUpdateCharmStoreResourceOps(csRes)...)
+	} else {
 		return append(ops, newInsertCharmStoreResourceOps(csRes)...)
 	}
 }
@@ -308,8 +312,8 @@ func (p ResourcePersistence) unitResources(unitID string) ([]resourceDoc, error)
 
 // getOne returns the resource that matches the provided model ID.
 func (p ResourcePersistence) getOne(resID string) (resourceDoc, error) {
-	logger.Tracef("querying db for resource %q", resID)
 	id := applicationResourceID(resID)
+	logger.Tracef("querying db for resource %q as %q", resID, id)
 	var doc resourceDoc
 	if err := p.base.One(resourcesC, id, &doc); err != nil {
 		return doc, errors.Trace(err)
@@ -319,8 +323,8 @@ func (p ResourcePersistence) getOne(resID string) (resourceDoc, error) {
 
 // getOnePending returns the resource that matches the provided model ID.
 func (p ResourcePersistence) getOnePending(resID, pendingID string) (resourceDoc, error) {
-	logger.Tracef("querying db for resource %q (pending %q)", resID, pendingID)
 	id := pendingResourceID(resID, pendingID)
+	logger.Tracef("querying db for resource %q (pending %q) as %q", resID, pendingID, id)
 	var doc resourceDoc
 	if err := p.base.One(resourcesC, id, &doc); err != nil {
 		return doc, errors.Trace(err)

--- a/state/resources_mongo.go
+++ b/state/resources_mongo.go
@@ -142,7 +142,7 @@ func resourceDocToUpdateOp(doc *resourceDoc) bson.M {
 func newUpdateResourceOps(stored storedResource) []txn.Op {
 	doc := newResourceDoc(stored)
 
-	logger.Tracef("updating resource %s to %# v", stored.ID, pretty.Formatter(doc))
+	rpLogger.Tracef("updating resource %s to %# v", stored.ID, pretty.Formatter(doc))
 	return []txn.Op{{
 		C:      resourcesC,
 		Id:     doc.DocID,
@@ -165,8 +165,8 @@ func newInsertCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 func newUpdateCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 	doc := newCharmStoreResourceDoc(res)
 
-	if logger.IsTraceEnabled() {
-		logger.Tracef("updating charm store resource %s to %# v", res.id, pretty.Formatter(doc))
+	if rpLogger.IsTraceEnabled() {
+		rpLogger.Tracef("updating charm store resource %s to %# v", res.id, pretty.Formatter(doc))
 	}
 	return []txn.Op{{
 		C:      resourcesC,
@@ -192,8 +192,8 @@ func newUpdateUnitResourceOps(unitID string, stored storedResource, progress *in
 	doc := newUnitResourceDoc(unitID, stored)
 	doc.DownloadProgress = progress
 
-	if logger.IsTraceEnabled() {
-		logger.Tracef("updating unit resource %s to %# v", unitID, pretty.Formatter(doc))
+	if rpLogger.IsTraceEnabled() {
+		rpLogger.Tracef("updating unit resource %s to %# v", unitID, pretty.Formatter(doc))
 	}
 	return []txn.Op{{
 		C:      resourcesC,
@@ -291,13 +291,13 @@ func newStagedResourceDoc(stored storedResource) *resourceDoc {
 
 // resources returns the resource docs for the given application.
 func (p ResourcePersistence) resources(applicationID string) ([]resourceDoc, error) {
-	logger.Tracef("querying db for resources for %q", applicationID)
+	rpLogger.Tracef("querying db for resources for %q", applicationID)
 	var docs []resourceDoc
 	query := bson.D{{"application-id", applicationID}}
 	if err := p.base.All(resourcesC, query, &docs); err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Tracef("found %d resources", len(docs))
+	rpLogger.Tracef("found %d resources", len(docs))
 	return docs, nil
 }
 
@@ -313,7 +313,7 @@ func (p ResourcePersistence) unitResources(unitID string) ([]resourceDoc, error)
 // getOne returns the resource that matches the provided model ID.
 func (p ResourcePersistence) getOne(resID string) (resourceDoc, error) {
 	id := applicationResourceID(resID)
-	logger.Tracef("querying db for resource %q as %q", resID, id)
+	rpLogger.Tracef("querying db for resource %q as %q", resID, id)
 	var doc resourceDoc
 	if err := p.base.One(resourcesC, id, &doc); err != nil {
 		return doc, errors.Trace(err)
@@ -324,7 +324,7 @@ func (p ResourcePersistence) getOne(resID string) (resourceDoc, error) {
 // getOnePending returns the resource that matches the provided model ID.
 func (p ResourcePersistence) getOnePending(resID, pendingID string) (resourceDoc, error) {
 	id := pendingResourceID(resID, pendingID)
-	logger.Tracef("querying db for resource %q (pending %q) as %q", resID, pendingID, id)
+	rpLogger.Tracef("querying db for resource %q (pending %q) as %q", resID, pendingID, id)
 	var doc resourceDoc
 	if err := p.base.One(resourcesC, id, &doc); err != nil {
 		return doc, errors.Trace(err)

--- a/state/resources_persistence.go
+++ b/state/resources_persistence.go
@@ -380,7 +380,15 @@ func (p ResourcePersistence) NewResolvePendingResourceOps(resID, pendingID strin
 		return nil, errors.Trace(err)
 	}
 
-	ops := newResolvePendingResourceOps(pending, exists)
+	csExists := true
+	csResID := resID + resourcesCharmstoreIDSuffix
+	if _, err := p.getOne(csResID); errors.IsNotFound(err) {
+		csExists = false
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ops := newResolvePendingResourceOps(pending, exists, csExists)
 	return ops, nil
 }
 

--- a/state/resources_persistence.go
+++ b/state/resources_persistence.go
@@ -399,7 +399,7 @@ func (p ResourcePersistence) NewRemoveUnitResourcesOps(unitID string) ([]txn.Op,
 }
 
 // NewRemoveResourcesOps returns mgo transaction operations that
-// remove all the applications's resources from state.
+// remove all the application's resources from state.
 func (p ResourcePersistence) NewRemoveResourcesOps(applicationID string) ([]txn.Op, error) {
 	docs, err := p.resources(applicationID)
 	if err != nil {

--- a/state/statetest/persistence_stubs.go
+++ b/state/statetest/persistence_stubs.go
@@ -5,7 +5,6 @@ package statetest
 
 import (
 	"reflect"
-	"sync"
 
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2/txn"
@@ -23,8 +22,6 @@ type StubPersistence struct {
 
 	ReturnApplicationExistsOps       []txn.Op
 	ReturnIncCharmModifiedVersionOps []txn.Op
-
-	mu sync.Mutex
 }
 
 func NewStubPersistence(stub *testing.Stub) *StubPersistence {

--- a/state/statetest/persistence_stubs.go
+++ b/state/statetest/persistence_stubs.go
@@ -5,6 +5,7 @@ package statetest
 
 import (
 	"reflect"
+	"sync"
 
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2/txn"
@@ -22,6 +23,8 @@ type StubPersistence struct {
 
 	ReturnApplicationExistsOps       []txn.Op
 	ReturnIncCharmModifiedVersionOps []txn.Op
+
+	mu sync.Mutex
 }
 
 func NewStubPersistence(stub *testing.Stub) *StubPersistence {


### PR DESCRIPTION
The charm revision updater inserts or updates a #charmhub doc to the resources collection if a new resource revision is found. The problem is the the NewResolvePendingResourceOps called by SetCharm, assumed that if the non #charmhub doc did not exist, neither did the #charmhub doc. 

This assumption failed once a charm was deployed without a resource but later revisions of the charm added one.

While debugging this problem, I noticed that we had an op in the SetCharm transactions that incremented the relations by the number of new peer relations every time.  Even in there are no new peer relations. Fixing that too. 

## QA steps

```console
$ juju bootstrap localhost
$ juju deploy cs:aodh-37

# setup charm revision updater wrench
$ juju ssh -m controller 0
# add /var/lib/juju/wrench/charmrevision file with "shortinterval" contents
$ sudo systemctl restart jujud-machine-0.service

# in the juju db verify
juju:PRIMARY> db.resources.count()
1

# upgrade the charm
$ juju refresh aodh
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1968931
