### PR TITLE
[JUJU-1007] Add a new logging-output feature flag to force the beta syslog feature to be opt in

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -45,6 +45,7 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/pubsub/apiserver"
 	controllermsg "github.com/juju/juju/pubsub/controller"
 	"github.com/juju/juju/resource"
@@ -321,6 +322,9 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 		return nil, errors.Trace(err)
 	}
 	loggingOutputs, _ := modelConfig.LoggingOutput()
+	if !controllerConfig.Features().Contains(feature.LoggingOutput) {
+		loggingOutputs = []string{}
+	}
 
 	srv := &Server{
 		clock:                         cfg.Clock,

--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
@@ -23,6 +24,7 @@ type Backend interface {
 	SetSLA(level, owner string, credentials []byte) error
 	SLALevel() (string, error)
 	SpaceByName(string) error
+	ControllerConfig() (controller.Config, error)
 }
 
 type stateShim struct {

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -136,9 +137,13 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 	// Make sure DefaultSpace exists.
 	checkDefaultSpace := c.checkDefaultSpace()
 
+	// To use the logging-output feature, the feature flag needs to be set.
+	checkLoggingConfig := c.checkLoggingOutput()
+
 	// Replace any deprecated attributes with their new values.
 	attrs := config.ProcessDeprecatedAttributes(args.Config)
-	return c.backend.UpdateModelConfig(attrs, nil, checkAgentVersion, checkLogTrace, checkDefaultSpace, checkCharmhubURL)
+	return c.backend.UpdateModelConfig(attrs, nil,
+		checkAgentVersion, checkLogTrace, checkDefaultSpace, checkCharmhubURL, checkLoggingConfig)
 }
 
 func (c *ModelConfigAPI) checkLogTrace() state.ValidateConfigFunc {
@@ -215,6 +220,23 @@ func (c *ModelConfigAPI) checkCharmhubURL() state.ValidateConfigFunc {
 			if v != oldURL {
 				return errors.New("charmhub-url cannot be changed")
 			}
+		}
+		return nil
+	}
+}
+
+func (c *ModelConfigAPI) checkLoggingOutput() state.ValidateConfigFunc {
+	return func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
+		v, ok := updateAttrs[config.LoggingOutputKey]
+		if !ok || v == "" {
+			return nil
+		}
+		cfg, err := c.backend.ControllerConfig()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !cfg.Features().Contains(feature.LoggingOutput) {
+			return errors.Errorf("cannot set %q without setting the %q feature flag", config.LoggingOutputKey, feature.LoggingOutput)
 		}
 		return nil
 	}

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/space"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -589,6 +590,11 @@ func (m *ModelManagerAPI) newModel(
 	controllerCfg, err := m.state.ControllerConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+
+	_, ok := newConfig.LoggingOutput()
+	if ok && !controllerCfg.Features().Contains(feature.LoggingOutput) {
+		return nil, errors.Errorf("cannot set %q without setting the %q feature flag", config.LoggingOutputKey, feature.LoggingOutput)
 	}
 
 	// Create the Environ.

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -1512,6 +1512,11 @@ func (c *bootstrapCommand) bootstrapConfigs(
 		return bootstrapConfigs{}, errors.Annotate(err, "finalizing authorized-keys")
 	}
 
+	v, ok := bootstrapModelConfig[config.LoggingOutputKey]
+	if ok && v != "" && !controllerConfig.Features().Contains(feature.LoggingOutput) {
+		return bootstrapConfigs{}, errors.Errorf("cannot set %q without setting the %q feature flag", config.LoggingOutputKey, feature.LoggingOutput)
+	}
+
 	// We need to do an Azure specific check here.
 	// This won't be needed once the "default" model is banished.
 	// Until it is, we need to ensure that if a resource-group-name is specified,

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -482,6 +482,11 @@ var bootstrapTests = []bootstrapTest{{
 	err:  `storage pool requires a type`,
 }}
 
+func (s *BootstrapSuite) TestRunModelLoggingOutputChecksFlag(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "my-controller", "--config", "logging-output=syslog")
+	c.Check(err, gc.ErrorMatches, `cannot set "logging-output" without setting the "logging-output" feature flag`)
+}
+
 func (s *BootstrapSuite) TestRunCloudNameUnknown(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "unknown", "my-controller")
 	c.Check(err, gc.ErrorMatches, `unknown cloud "unknown", please try "juju update-public-clouds"`)

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -60,3 +60,6 @@ const RaftAPILeases = "raft-api-leases"
 
 // AsynchronousCharmDownloads enables support for asynchronous charm downloads.
 const AsynchronousCharmDownloads = "async-charm-downloads"
+
+// LoggingOutput enables the ability to configure different logging backends.
+const LoggingOutput = "logging-output"

--- a/worker/modelworkermanager/shim.go
+++ b/worker/modelworkermanager/shim.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/juju/juju/controller"
 	corelogger "github.com/juju/juju/core/logger"
+	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 )
 
@@ -42,6 +43,13 @@ func (g StatePoolController) RecordLogger(modelUUID string) (RecordLogger, error
 		return nil, errors.Trace(err)
 	}
 	loggingOutputs, _ := config.LoggingOutput()
+	controllerConfig, err := ps.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !controllerConfig.Features().Contains(feature.LoggingOutput) {
+		loggingOutputs = []string{}
+	}
 	return g.getLoggers(loggingOutputs, ps), nil
 }
 


### PR DESCRIPTION
A new model config `logging-output` was just added. This is not yet ready for general use and is not something we want to be forced to support in its current form long term. So add a feature flag called `logging-output` which must be enabled if you want to set the `logging-output` model config.

## QA steps

```
$ juju bootstrap aws/ap-southeast-2 test --config "logging-output=syslog"
ERROR cannot set "logging-output" without setting the "logging-output" feature flag
```

```
$ juju bootstrap aws test --config "logging-output=syslog,database" --config "features=[logging-output] --no-default-model"
$ juju controller-config features=[]
$ juju add-model foo --config logging-output=syslog
ERROR cannot set "logging-output" without setting the "logging-output" feature flag
$ juju model-config logging-output=syslog
ERROR cannot set "logging-output" without setting the "logging-output" feature flag
```

