### PR TITLE
[JUJU-1003] Add storage to exported bundle yaml

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -701,6 +701,13 @@ func (b *BundleAPI) bundleDataApplications(
 		if result := b.constraints(application.Constraints()); len(result) != 0 {
 			newApplication.Constraints = strings.Join(result, " ")
 		}
+		if len(application.StorageConstraints()) != 0 {
+			newApplication.Storage = make(map[string]string)
+			for name, constr := range application.StorageConstraints() {
+				newApplication.Storage[name] = fmt.Sprintf("%s,%d,%d",
+					constr.Pool(), constr.Count(), constr.Size())
+			}
+		}
 
 		// If this application has been trusted by the operator, set the
 		// Trust field of the ApplicationSpec to true

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -1066,6 +1066,61 @@ applications:
 	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
 }
 
+func (s *bundleSuite) TestExportBundleWithApplicationStorage(c *gc.C) {
+	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
+		Config: map[string]interface{}{
+			"name": "awesome",
+			"uuid": "some-uuid",
+		},
+		CloudRegion: "some-region"})
+
+	args := s.minimalApplicationArgs(description.IAAS)
+	// Add storage constraints to the app
+	args.StorageConstraints = map[string]description.StorageConstraintArgs{
+		"storage1": {
+			Pool:  "pool1",
+			Size:  1024,
+			Count: 3,
+		},
+		"storage2": {
+			Pool:  "pool2",
+			Size:  4096,
+			Count: 1,
+		},
+	}
+	app := s.st.model.AddApplication(args)
+	app.SetStatus(minimalStatusArgs())
+
+	u := app.AddUnit(minimalUnitArgs(app.Type()))
+	u.SetAgentStatus(minimalStatusArgs())
+
+	s.st.model.SetStatus(description.StatusArgs{Value: "available"})
+
+	result, err := s.facade.ExportBundle(params.ExportBundleParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	expectedResult := params.StringResult{Result: `
+series: trusty
+applications:
+  ubuntu:
+    charm: cs:trusty/ubuntu
+    channel: stable
+    num_units: 1
+    to:
+    - "0"
+    options:
+      key: value
+    storage:
+      storage1: pool1,3,1024
+      storage2: pool2,1,4096
+    bindings:
+      another: alpha
+      juju-info: vlan2
+`[1:]}
+
+	c.Assert(result, gc.Equals, expectedResult)
+	s.st.CheckCall(c, 0, "ExportPartial", s.st.GetExportConfig())
+}
+
 func (s *bundleSuite) TestExportBundleWithTrustedApplication(c *gc.C) {
 	s.st.model = description.NewModel(description.ModelArgs{Owner: names.NewUserTag("magic"),
 		Config: map[string]interface{}{


### PR DESCRIPTION
Now, when you `juju export-bundle`, application storage will be added to the yaml output. I've also added a unit test to verify this.

Fixes [lp#1835133](https://bugs.launchpad.net/juju/+bug/1835133).