### PR TITLE
[JUJU-1001] Include relation ID in show-units

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -1215,6 +1215,7 @@ type RelationData struct {
 
 // EndpointRelationData holds information about a relation to a given endpoint.
 type EndpointRelationData struct {
+	RelationId       int
 	Endpoint         string
 	CrossModel       bool
 	RelatedEndpoint  string
@@ -1266,6 +1267,7 @@ func unitInfoFromParams(in params.UnitInfoResult) UnitInfo {
 	}
 	for _, inRd := range in.Result.RelationData {
 		erd := EndpointRelationData{
+			RelationId:      inRd.RelationId,
 			Endpoint:        inRd.Endpoint,
 			CrossModel:      inRd.CrossModel,
 			RelatedEndpoint: inRd.RelatedEndpoint,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -3154,6 +3154,7 @@ func (api *APIBase) relationData(app Application, myUnit Unit) ([]params.Endpoin
 			return nil, errors.Trace(err)
 		}
 		erd := params.EndpointRelationData{
+			RelationId:       rel.Id(),
 			Endpoint:         ep.Name,
 			ApplicationData:  make(map[string]interface{}),
 			UnitRelationData: make(map[string]params.RelationData),

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2403,6 +2403,7 @@ func (s *ApplicationSuite) TestUnitsInfo(c *gc.C) {
 		Charm:           "cs:postgresql-42",
 		Leader:          true,
 		RelationData: []params.EndpointRelationData{{
+			RelationId:      101,
 			Endpoint:        "db",
 			CrossModel:      true,
 			RelatedEndpoint: "server",
@@ -2440,6 +2441,7 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 		Charm:           "cs:postgresql-42",
 		Leader:          true,
 		RelationData: []params.EndpointRelationData{{
+			RelationId:      101,
 			Endpoint:        "db",
 			CrossModel:      true,
 			RelatedEndpoint: "server",
@@ -2463,6 +2465,7 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 		Charm:           "cs:postgresql-42",
 		Leader:          false,
 		RelationData: []params.EndpointRelationData{{
+			RelationId:      101,
 			Endpoint:        "db",
 			CrossModel:      true,
 			RelatedEndpoint: "server",

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -149,6 +149,7 @@ type Relation interface {
 	Tag() names.Tag
 	Destroy() error
 	DestroyWithForce(bool, time.Duration) ([]error, error)
+	Id() int
 	Endpoints() []state.Endpoint
 	RelatedEndpoints(applicationname string) ([]state.Endpoint, error)
 	ApplicationSettings(appName string) (map[string]interface{}, error)

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -862,6 +862,11 @@ func (r *mockRelation) Tag() names.Tag {
 	return r.tag
 }
 
+func (r *mockRelation) Id() int {
+	r.MethodCall(r, "Id")
+	return 101
+}
+
 func (r *mockRelation) Endpoints() []state.Endpoint {
 	r.MethodCall(r, "Endpoints")
 	return []state.Endpoint{{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3677,6 +3677,9 @@
                         "related-endpoint": {
                             "type": "string"
                         },
+                        "relation-id": {
+                            "type": "integer"
+                        },
                         "unit-relation-data": {
                             "type": "object",
                             "patternProperties": {
@@ -3688,6 +3691,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
+                        "relation-id",
                         "endpoint",
                         "cross-model",
                         "related-endpoint",

--- a/cmd/juju/application/showunit.go
+++ b/cmd/juju/application/showunit.go
@@ -185,6 +185,7 @@ type UnitRelationData struct {
 }
 
 type RelationData struct {
+	RelationId              int                         `yaml:"relation-id" json:"relation-id"`
 	Endpoint                string                      `yaml:"endpoint" json:"endpoint"`
 	CrossModel              bool                        `yaml:"cross-model,omitempty" json:"cross-model,omitempty"`
 	RelatedEndpoint         string                      `yaml:"related-endpoint" json:"related-endpoint"`
@@ -229,6 +230,7 @@ func (c *showUnitCommand) createUnitInfo(details application.UnitInfo) (names.Un
 			continue
 		}
 		rd := RelationData{
+			RelationId:              rdparams.RelationId,
 			Endpoint:                rdparams.Endpoint,
 			RelatedEndpoint:         rdparams.RelatedEndpoint,
 			CrossModel:              rdparams.CrossModel,

--- a/cmd/juju/application/showunit_test.go
+++ b/cmd/juju/application/showunit_test.go
@@ -193,7 +193,8 @@ wordpress/0:
   charm: charm-wordpress
   leader: true
   relation-info:
-  - endpoint: db
+  - relation-id: 0
+    endpoint: db
     cross-model: true
     related-endpoint: server
     application-data:
@@ -227,7 +228,8 @@ wordpress/0:
   charm: charm-wordpress
   leader: true
   relation-info:
-  - endpoint: db
+  - relation-id: 0
+    endpoint: db
     cross-model: true
     related-endpoint: server
     application-data:
@@ -256,7 +258,8 @@ wordpress/0:
   charm: charm-wordpress
   leader: true
   relation-info:
-  - endpoint: db-shared
+  - relation-id: 0
+    endpoint: db-shared
     related-endpoint: common
     application-data: {}
   provider-id: provider-id
@@ -283,7 +286,8 @@ wordpress/0:
   charm: charm-wordpress
   leader: true
   relation-info:
-  - endpoint: db
+  - relation-id: 0
+    endpoint: db
     cross-model: true
     related-endpoint: server
     application-data:
@@ -307,7 +311,7 @@ func (s *ShowUnitSuite) TestShowJSON(c *gc.C) {
 	}
 	s.assertRunShow(c, showUnitTest{
 		args:   []string{"wordpress/0", "--format", "json"},
-		stdout: `{"wordpress/0":{"workload-version":"666","machine":"0","opened-ports":["100-102/ip"],"public-address":"10.0.0.1","charm":"charm-wordpress","leader":true,"relation-info":[{"endpoint":"db","cross-model":true,"related-endpoint":"server","application-data":{"wordpress":"setting"},"local-unit":{"in-scope":false,"data":null},"related-units":{"mariadb/2":{"in-scope":true,"data":{"mariadb/2":"mariadb/2-setting"}}}}],"provider-id":"provider-id","address":"192.168.1.1"}}` + "\n",
+		stdout: `{"wordpress/0":{"workload-version":"666","machine":"0","opened-ports":["100-102/ip"],"public-address":"10.0.0.1","charm":"charm-wordpress","leader":true,"relation-info":[{"relation-id":0,"endpoint":"db","cross-model":true,"related-endpoint":"server","application-data":{"wordpress":"setting"},"local-unit":{"in-scope":false,"data":null},"related-units":{"mariadb/2":{"in-scope":true,"data":{"mariadb/2":"mariadb/2-setting"}}}}],"provider-id":"provider-id","address":"192.168.1.1"}}` + "\n",
 	})
 }
 
@@ -343,7 +347,8 @@ logging/0:
   charm: charm-logging
   leader: true
   relation-info:
-  - endpoint: db
+  - relation-id: 0
+    endpoint: db
     cross-model: true
     related-endpoint: server
     application-data:
@@ -364,7 +369,8 @@ wordpress/0:
   charm: charm-wordpress
   leader: true
   relation-info:
-  - endpoint: db
+  - relation-id: 0
+    endpoint: db
     cross-model: true
     related-endpoint: server
     application-data:

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -608,6 +608,7 @@ type RelationData struct {
 
 // EndpointRelationData holds information about a relation to a given endpoint.
 type EndpointRelationData struct {
+	RelationId       int                     `json:"relation-id"`
 	Endpoint         string                  `json:"endpoint"`
 	CrossModel       bool                    `json:"cross-model"`
 	RelatedEndpoint  string                  `json:"related-endpoint"`


### PR DESCRIPTION
Implement ID method from state.Relation to Relation facade, then transmit Id through to relations in show-unit

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

#### Setup
```sh
juju bootstrap lxd c
juju deploy wordpress
juju deploy mysql
juju relate wordpress mysql
```

#### QA
```sh
$ juju show-unit mysql/0
mysql/0:
  workload-version: 5.7.33
  machine: "1"
  opened-ports:
  - 3306/tcp
  public-address: 10.142.118.87
  charm: ch:amd64/xenial/mysql-58
  leader: true
  relation-info:
  - relation-id: 1
    endpoint: cluster
    related-endpoint: cluster
    application-data: {}
    local-unit:
      in-scope: true
      data:
        egress-subnets: 10.142.118.87/32
        ingress-address: 10.142.118.87
        private-address: 10.142.118.87
  - relation-id: 2
    endpoint: db
    related-endpoint: db
    application-data: {}
    related-units:
      wordpress/0:
        in-scope: true
        data:
          egress-subnets: 10.142.118.131/32
          ingress-address: 10.142.118.131
          private-address: 10.142.118.131
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1967143