### PR TITLE
[JUJU-1006] Remove unused call from state start method.

### DIFF
--- a/state/workers.go
+++ b/state/workers.go
@@ -22,7 +22,6 @@ const txnLogWorker = "txnlog"
 // workers when they fail.
 type workers struct {
 	state *State
-	//	model *Model
 	*worker.Runner
 
 	hub *pubsub.SimpleHub


### PR DESCRIPTION
This just removes a query that was previously used downstream for legacy state-based leases. Since that lease implementation no longer exists, we don't need it.

## QA steps

Just bootstrap, add a model and check for errors.

## Documentation changes

None.

## Bug reference

N/A
