### PR TITLE
Clear GOOS and GOARCH to run schemagen.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,10 +311,11 @@ simplify:
 rebuild-schema:
 ## rebuild-schema: Rebuild the schema for clients with the latest facades
 	@echo "Generating facade schema..."
+# GOOS and GOARCH environment variables are cleared in case the user is trying to cross architecture compilation.
 ifdef SCHEMA_PATH
-	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades "$(SCHEMA_PATH)"
+	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades "$(SCHEMA_PATH)"
 else
-	@go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades \
+	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades \
 		./apiserver/facades/schema.json
 endif
 


### PR DESCRIPTION
Golang is capable of doing cross compilation and to achieve this the
user can set the environment variables GOOS and GOARCH, although the
"rebuild-schema" target compiles and run the schemagen program, which
fails when trying to do a cross compilation.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

*Please replace with how we can verify that the change works.*

```sh
env GOOS=linux GOARCH=s390x make build
```

## Documentation changes

None needed. This change only affects developers trying to do cross compilation.

## Bug reference

N/A.
