### PR TITLE
Add AGPL-3.0 as the licence for the Juju snap.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: juju
 version: 2.9.29
 summary: Juju - a model-driven operator lifecycle manager for K8s and machines
+license: AGPL-3.0
 description: |
   A model-driven **universal operator lifecycle manager** for multi cloud and hybrid cloud application management on K8s and machines.
 


### PR DESCRIPTION
This just sets a licence for the built snap. We already have this set in the website metadata, but without this when you install the snap `snap info juju` doesn't report its license correctly.

## QA steps

```sh
$ snapcraft
$ sudo snap install --dangerous --classic ./juju_2.9.29_amd64.snap
$ snap info juju
...
license:   AGPL-3.0
...
```

## Documentation changes

None

## Bug reference

None