### PR TITLE
Add support for arch ppc64el.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,13 +132,20 @@ endef
 # juju package. It's expected that the make target using this sequence has a
 # local variable defined for PACKAGE. An example of PACKAGE would be
 # PACKAGE=github.com/juju/juju
+# 
+# This canned commaned also allows building for architectures defined as
+# ppc64el. Because of legacy Juju we use the arch ppc64el over the go defined
+# arch of ppc64le. This canned command will do a last minute transformation of
+# the string we build the "correct" go archiecture. However the build result
+# will still be placed at the expected location with names matching ppc64el.
 define run_go_build
 	$(eval OS = $(word 1,$(subst _, ,$*)))
 	$(eval ARCH = $(word 2,$(subst _, ,$*)))
 	$(eval BBIN_DIR = ${BUILD_DIR}/${OS}_${ARCH}/bin)
+	$(eval BUILD_ARCH = $(subst ppc64el,ppc64le,${ARCh}))
 	@@mkdir -p ${BBIN_DIR}
 	@echo "Building ${PACKAGE} for ${OS}/${ARCH}"
-	@env GOOS=${OS} GOARCH=${ARCH} go build -mod=$(JUJU_GOMOD_MODE) -o ${BBIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v  ${PACKAGE}
+	@env GOOS=${OS} GOARCH=${BUILD_ARCH} go build -mod=$(JUJU_GOMOD_MODE) -o ${BBIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v  ${PACKAGE}
 endef
 
 define run_go_install

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -88,6 +88,17 @@ build_push_operator_image() {
       build_multi_osarch="$(go env GOOS)/$(go env GOARCH)"
     fi
 
+    # We need to find any ppc64el references and move the build artefacts over
+    # to ppc64le so that it works with Docker.
+    for platform in $build_multi_osarch; do
+      if [[ "$platform" == *"ppc64el"* ]]; then
+        new_platform=$(echo "$platform" | sed 's/ppc64el/ppc64le/g')
+        cp -r "${BUILD_DIR}/$(echo "$platform" | sed 's/\//_/g')" \
+          "${BUILD_DIR}/$(echo "$new_platform" | sed 's/\//_/g')"
+      fi
+    done
+    build_multi_osarch=$(echo "$build_multi_osarch" | sed 's/ppc64el/ppc64le/g')
+
     push_image=${2:-"false"}
 
     output="-o type=oci,dest=${BUILD_DIR}/oci.tar.gz"


### PR DESCRIPTION
For legacy reasons Juju uses arch ppc64el instead of ppc64le. This
change allows the makefile to accept both formats and continue working.
This is critical for Juju to function for older versions and to maintain
our CI systems.

In future versions of Juju we can look at dropping this support but it
would require a major version change.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps
Run:

```sh
CLIENT_PACKAGE_PLATFORMS="linux/ppc64el" AGENT_PACKAGE_PLATFORMS="linux/ppc64el" make build
ls -l _build # Make sure there is a directory called linux_ppc64el with Juju binaries

OCI_IMAGE_PLATFORMS="linux/ppc64el" make operator-image #make sure completes successfully.
```

## Documentation changes

N/A

## Bug reference

N/A
