### PR TITLE
[JUJU-867] Add `ConfigCommandBase` and refactor `juju config` to use it

### DIFF
--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -251,7 +251,7 @@ var setCommandInitErrorTests = []struct {
 }, {
 	about:       "--file and options specified",
 	args:        []string{"application", "--file", "testconfig.yaml", "bees="},
-	expectError: "cannot specify --file and key=value arguments simultaneously",
+	expectError: "cannot use --file flag and set key=value pairs simultaneously",
 }, {
 	about:       "--reset and no config name provided",
 	args:        []string{"application", "--reset"},
@@ -259,11 +259,11 @@ var setCommandInitErrorTests = []struct {
 }, {
 	about:       "cannot set and retrieve simultaneously",
 	args:        []string{"application", "get", "set=value"},
-	expectError: "cannot set and retrieve values simultaneously",
+	expectError: "cannot get value and set key=value pairs simultaneously",
 }, {
 	about:       "cannot reset and get simultaneously",
 	args:        []string{"application", "--reset", "reset", "get"},
-	expectError: "cannot reset and retrieve values simultaneously",
+	expectError: "cannot use --reset flag and get value simultaneously",
 }, {
 	about:       "invalid reset keys",
 	args:        []string{"application", "--reset", "reset,bad=key"},
@@ -271,7 +271,7 @@ var setCommandInitErrorTests = []struct {
 }, {
 	about:       "init too many args fails",
 	args:        []string{"application", "key", "another"},
-	expectError: "can only retrieve a single value, or all values",
+	expectError: "cannot specify multiple keys to get",
 }, {
 	about:       "--branch with no value",
 	args:        []string{"application", "key", "--branch"},
@@ -285,7 +285,7 @@ func (s *configCommandSuite) TestSetCommandInitError(c *gc.C) {
 		cmd := application.NewConfigCommandForTest(s.fake, s.store)
 		cmd.SetClientStore(testStore)
 		err := cmdtesting.InitCommand(cmd, test.args)
-		c.Assert(err, gc.ErrorMatches, test.expectError)
+		c.Check(err, gc.ErrorMatches, test.expectError)
 	}
 }
 
@@ -369,7 +369,7 @@ func (s *configCommandSuite) TestSetSameValue(c *gc.C) {
 
 func (s *configCommandSuite) TestSetConfigFail(c *gc.C) {
 	s.assertSetFail(c, s.dir, []string{"foo", "bar"},
-		"can only retrieve a single value, or all values")
+		"cannot specify multiple keys to get")
 	s.assertSetFail(c, s.dir, []string{"=bar"}, "expected \"key=value\", got \"=bar\"")
 	s.assertSetFail(c, s.dir, []string{
 		"username=@missing.txt",

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -244,6 +244,13 @@ func NewShowUnitCommandForTest(api UnitsInfoAPI, store jujuclient.ClientStore) c
 	return modelcmd.Wrap(cmd)
 }
 
+// NewConfigCommandForTest returns a SetCommand with the api provided as specified.
+func NewConfigCommandForTest(api ApplicationAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
+	c := modelcmd.Wrap(&configCommand{api: api})
+	c.SetClientStore(store)
+	return c
+}
+
 // RepoSuiteBaseSuite allows the patching of the supported juju suite for
 // each test.
 type RepoSuiteBaseSuite struct {

--- a/cmd/juju/application/trust_test.go
+++ b/cmd/juju/application/trust_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
-	"github.com/juju/juju/rpc/params"
 )
 
 type TrustSuite struct {
@@ -35,9 +34,8 @@ func (s *TrustSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *TrustSuite) runTrust(c *gc.C, args ...string) error {
-	configCmd := configCommand{api: s.applicationAPI}
-	configCmd.SetClientStore(s.store)
-	trustCmd := modelcmd.Wrap(&trustCommand{configCommand: configCmd})
+	trustCmd := modelcmd.Wrap(&trustCommand{api: s.applicationAPI})
+	trustCmd.SetClientStore(s.store)
 	_, err := cmdtesting.RunCommand(c, trustCmd, args...)
 	return err
 }
@@ -45,7 +43,6 @@ func (s *TrustSuite) runTrust(c *gc.C, args ...string) error {
 func (s *TrustSuite) TestTrust(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.applicationAPI.EXPECT().Get("", "gitlab").Return(&params.ApplicationGetResults{}, nil)
 	s.applicationAPI.EXPECT().SetConfig("", "gitlab", "", map[string]string{"trust": "true"})
 	s.applicationAPI.EXPECT().Close()
 
@@ -63,7 +60,6 @@ func (s *TrustSuite) TestTrustCAAS(c *gc.C) {
 		}},
 	}
 
-	s.applicationAPI.EXPECT().Get("", "gitlab").Return(&params.ApplicationGetResults{}, nil)
 	s.applicationAPI.EXPECT().SetConfig("", "gitlab", "", map[string]string{"trust": "true"})
 	s.applicationAPI.EXPECT().Close()
 
@@ -81,7 +77,6 @@ func (s *TrustSuite) TestTrustCAASRemove(c *gc.C) {
 		}},
 	}
 
-	s.applicationAPI.EXPECT().Get("", "gitlab").Return(&params.ApplicationGetResults{}, nil)
 	s.applicationAPI.EXPECT().SetConfig("", "gitlab", "", map[string]string{"trust": "false"})
 	s.applicationAPI.EXPECT().Close()
 

--- a/cmd/juju/config/config.go
+++ b/cmd/juju/config/config.go
@@ -1,0 +1,191 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package config
+
+import (
+	"strings"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/utils/keyvalues"
+)
+
+// ConfigAction represents the action we want to perform here.
+// The action will be set in Init, and then accessed by the child command's
+// Run method to decide what to do.
+type ConfigAction string
+
+// The strings here are descriptions which will be used in the error message:
+// "cannot X and Y simultaneously"
+const (
+	GetOne  ConfigAction = "get value"
+	GetAll  ConfigAction = "get all values"
+	Set     ConfigAction = "set key=value pairs"
+	SetFile ConfigAction = "use --file flag"
+	Reset   ConfigAction = "use --reset flag"
+)
+
+// ConfigCommandBase provides a common interface/functionality for configuration
+// commands (such as config and model-config). It defines SetFlags and Init
+// methods, while the individual command needs to define its own Run and Info
+// methods.
+type ConfigCommandBase struct {
+	// Fields to be set by child
+	CantReset []string // keys which can't be reset
+
+	// Flag values
+	ConfigFile cmd.FileVar
+	reset      []string // Holds the keys to be reset until parsed.
+
+	// Fields to be set during initialisation
+	Actions     []ConfigAction // The action which we want to handle, set in Init.
+	KeyToGet    string
+	KeysToReset []string // Holds keys to be reset after parsing.
+	ValsToSet   map[string]string
+}
+
+// Info - to be implemented by child command
+
+// SetFlags implements cmd.Command.SetFlags.
+func (c *ConfigCommandBase) SetFlags(f *gnuflag.FlagSet) {
+	f.Var(&c.ConfigFile, "file", "path to yaml-formatted configuration file")
+	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset",
+		"Reset the provided comma delimited keys, deletes keys not in the model config")
+}
+
+// Init provides a basic implementation of cmd.Command.Init.
+// This only parses the actual key/value arguments in the command. Some child
+// commands will also need to specify what is being configured (e.g. the app
+// name in the case of `juju config`). In this case, the child should define
+// its own Init command, where it strips the required arguments and passes the
+// rest to the parent.
+func (c *ConfigCommandBase) Init(args []string) error {
+	// Check if --file has been specified
+	if c.ConfigFile.Path != "" {
+		c.Actions = append(c.Actions, SetFile)
+	}
+
+	// Check if --reset has been specified
+	if len(c.reset) != 0 {
+		c.Actions = append(c.Actions, Reset)
+		err := c.parseResetKeys()
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	// The remaining arguments are divided into setKeys (args containing `=`)
+	// and getKeys, so we can work out what the user is trying to do.
+	var setKeys, getKeys []string
+	for _, arg := range args {
+		splitArg := strings.Split(arg, "=")
+		if len(splitArg) > 1 {
+			setKeys = append(setKeys, splitArg[0])
+		} else {
+			getKeys = append(getKeys, arg)
+		}
+	}
+
+	if len(setKeys) == 0 && len(getKeys) == 0 && len(c.Actions) == 0 {
+		// Nothing specified - get full config
+		c.Actions = append(c.Actions, GetAll)
+	}
+
+	if len(setKeys) == 0 && len(getKeys) == 1 {
+		// Get the single key specified
+		c.Actions = append(c.Actions, GetOne)
+		c.KeyToGet = args[0]
+	}
+
+	if len(setKeys) == 0 && len(getKeys) > 1 {
+		// Trying to get multiple keys - error
+		return errors.New("cannot specify multiple keys to get")
+	}
+
+	if len(setKeys) > 0 && len(getKeys) == 0 {
+		// Set specified keys to given values
+		c.Actions = append(c.Actions, Set)
+		var err error
+		c.ValsToSet, err = keyvalues.Parse(args, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(setKeys) > 0 && len(getKeys) > 0 {
+		// Looks like user is trying to get & set simultaneously
+		c.Actions = append(c.Actions, GetOne, Set)
+		// Error will be return in next step
+	}
+
+	// Check that we haven't tried to set/get as well as reset/set from file.
+	return c.checkSingleAction()
+}
+
+// parseResetKeys splits the keys provided to --reset after trimming any
+// leading or trailing comma. It then verifies that we haven't incorrectly
+// received any key=value pairs.
+func (c *ConfigCommandBase) parseResetKeys() error {
+	for _, value := range c.reset {
+		keys := strings.Split(strings.Trim(value, ","), ",")
+		c.KeysToReset = append(c.KeysToReset, keys...)
+	}
+
+	for _, k := range c.KeysToReset {
+		if sliceContains(c.CantReset, k) {
+			return errors.Errorf("%q cannot be reset", k)
+		}
+		if strings.Contains(k, "=") {
+			return errors.Errorf(
+				`--reset accepts a comma delimited set of keys "a,b,c", received: %q`, k)
+		}
+	}
+	return nil
+}
+
+// sliceContains is a utility method to check if the given (string) slice
+// contains a given value.
+func sliceContains(slice []string, val string) bool {
+	for _, s := range slice {
+		if s == val {
+			return true
+		}
+	}
+	return false
+}
+
+// checkSingleAction checks that exactly one action has been specified.
+func (c *ConfigCommandBase) checkSingleAction() error {
+	switch len(c.Actions) {
+	case 0:
+		return errors.New("no action specified")
+	case 1:
+		return nil
+	default:
+		return multiActionError(c.Actions)
+	}
+}
+
+// multiActionError returns an error saying that the provided actions
+// cannot be done simultaneously.
+func multiActionError(actions []ConfigAction) error {
+	actionList := ""
+	for i, descr := range actions {
+		// put in the right (grammatical) list separator
+		switch i {
+		case 0:
+			// no separator before list
+		case len(actions) - 1:
+			actionList += " and "
+		default:
+			actionList += ", "
+		}
+
+		actionList += string(descr)
+	}
+	return errors.Errorf("cannot %s simultaneously", actionList)
+}
+
+// Run - to be implemented by child command

--- a/cmd/juju/config/config_test.go
+++ b/cmd/juju/config/config_test.go
@@ -1,0 +1,313 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package config
+
+import (
+	"bytes"
+	stdtesting "testing"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type suite struct{}
+
+var _ = gc.Suite(&suite{})
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}
+
+func (s *suite) TestSetFlags(c *gc.C) {
+	cmd := ConfigCommandBase{}
+	f := flagSetForTest(c)
+	cmd.SetFlags(f)
+
+	// Collect all flags
+	expectedFlags := []string{"file", "reset"}
+	flags := []string{}
+
+	f.VisitAll(
+		func(f *gnuflag.Flag) { flags = append(flags, f.Name) },
+	)
+	c.Assert(flags, gc.DeepEquals, expectedFlags)
+}
+
+// parseFailTest holds args for which we expect parsing to fail.
+type parseFailTest struct {
+	about  string
+	args   []string
+	errMsg string
+}
+
+// testParse checks that parsing of the given args fails or succeeds
+// (depending on the value of `fail`).
+func testParse(c *gc.C, test parseFailTest, fail bool) {
+	cmd := ConfigCommandBase{}
+	parseFail := false
+	var errWriter bytes.Buffer
+
+	f := &gnuflag.FlagSet{
+		Usage: func() { parseFail = true },
+	}
+	f.SetOutput(&errWriter)
+
+	cmd.SetFlags(f)
+	f.Parse(true, test.args)
+	c.Assert(parseFail, gc.Equals, fail)
+	if fail {
+		c.Assert(errWriter.String(), gc.Equals, test.errMsg)
+	}
+}
+
+// initFailTest represents a test for which we expect parsing to succeed, but
+// initialisation to fail.
+type initFailTest struct {
+	about     string
+	args      []string
+	cantReset []string
+	errMsg    string
+}
+
+// initTest represents a test for which we expect parsing and initialisation
+// to succeed.
+type initTest struct {
+	about       string
+	args        []string
+	cantReset   []string
+	action      ConfigAction
+	configFile  cmd.FileVar
+	keyToGet    string
+	keysToReset []string
+	valsToSet   map[string]string
+}
+
+// setupInitTest sets up the ConfigCommandBase and error for TestInitFail and
+// TestInitSucceed.
+func setupInitTest(c *gc.C, args []string, cantReset []string) (ConfigCommandBase, error) {
+	cmd := ConfigCommandBase{
+		CantReset: cantReset,
+	}
+	f := flagSetForTest(c)
+	cmd.SetFlags(f)
+	f.Parse(true, args)
+	err := cmd.Init(f.Args())
+
+	return cmd, err
+}
+
+func (s *suite) TestParseFail(c *gc.C) {
+	for i, test := range parseTests {
+		c.Logf("test %d: %s", i, test.about)
+		testParse(c, test, true)
+	}
+}
+
+func (s *suite) TestInitFail(c *gc.C) {
+	for i, test := range initFailTests {
+		c.Logf("test %d: %s", i, test.about)
+		// Check parsing succeeds
+		testParse(c, parseFailTest{args: test.args}, false)
+
+		_, err := setupInitTest(c, test.args, test.cantReset)
+		c.Check(err, gc.ErrorMatches, test.errMsg)
+	}
+}
+
+func (s *suite) TestInitSuccess(c *gc.C) {
+	for i, test := range initTests {
+		c.Logf("test %d: %s", i, test.about)
+		// Check parsing succeeds
+		testParse(c, parseFailTest{args: test.args}, false)
+
+		cmd, err := setupInitTest(c, test.args, test.cantReset)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(len(cmd.Actions), gc.Equals, 1)
+		c.Check(cmd.Actions[0], gc.Equals, test.action)
+		c.Check(cmd.ConfigFile, gc.DeepEquals, test.configFile)
+		c.Check(cmd.KeyToGet, gc.DeepEquals, test.keyToGet)
+		c.Check(cmd.KeysToReset, gc.DeepEquals, test.keysToReset)
+		c.Check(cmd.ValsToSet, gc.DeepEquals, test.valsToSet)
+	}
+}
+
+// flagSetForTest returns a flag set for running the parse/init tests.
+func flagSetForTest(c *gc.C) *gnuflag.FlagSet {
+	f := &gnuflag.FlagSet{
+		Usage: func() { c.Fatalf("error occurred while parsing flags") },
+	}
+	return f
+}
+
+var parseTests = []parseFailTest{
+	{
+		about:  "no argument provided to --file",
+		args:   []string{"--file"},
+		errMsg: " needs an argument: --file\n",
+	},
+	{
+		about:  "no argument provided to --reset",
+		args:   []string{"--reset"},
+		errMsg: " needs an argument: --reset\n",
+	},
+	{
+		about:  "undefined flag --foo",
+		args:   []string{"--foo"},
+		errMsg: " provided but not defined: --foo\n",
+	},
+}
+
+var initFailTests = []initFailTest{
+	{
+		about:  "get multiple keys",
+		args:   []string{"key1", "key2"},
+		errMsg: "cannot specify multiple keys to get",
+	},
+	{
+		about:  "get and set",
+		args:   []string{"key1", "key2=val2"},
+		errMsg: "cannot get value and set key=value pairs simultaneously",
+	},
+	{
+		about:  "set and get",
+		args:   []string{"key1=val1", "key2"},
+		errMsg: "cannot get value and set key=value pairs simultaneously",
+	},
+	{
+		about:  "set and get multiple",
+		args:   []string{"key1=val1", "key2", "key3", "key4=val4", "key5"},
+		errMsg: "cannot get value and set key=value pairs simultaneously",
+	},
+	{
+		about:  "get and reset",
+		args:   []string{"key1", "--reset", "key2"},
+		errMsg: "cannot use --reset flag and get value simultaneously",
+	},
+	{
+		about:  "set and reset",
+		args:   []string{"key1=val1", "--reset", "key2"},
+		errMsg: "cannot use --reset flag and set key=value pairs simultaneously",
+	},
+	{
+		about:  "set and reset same key",
+		args:   []string{"key1=val1", "--reset", "key1"},
+		errMsg: "cannot use --reset flag and set key=value pairs simultaneously",
+	},
+	{
+		about:  "get and set from file",
+		args:   []string{"key1", "--file", "path"},
+		errMsg: "cannot use --file flag and get value simultaneously",
+	},
+	{
+		about:  "set and set from file",
+		args:   []string{"key1=val1", "--file", "path"},
+		errMsg: "cannot use --file flag and set key=value pairs simultaneously",
+	},
+	{
+		about:  "set from file and reset",
+		args:   []string{"--file", "path", "--reset", "key1,key2"},
+		errMsg: "cannot use --file flag and use --reset flag simultaneously",
+	},
+	{
+		about:  "get, set from file & reset",
+		args:   []string{"key1", "--file", "path", "--reset", "key1,key2"},
+		errMsg: "cannot use --file flag, use --reset flag and get value simultaneously",
+	},
+	{
+		about:  "set, set from file and reset",
+		args:   []string{"key1=val1", "--file", "path", "--reset", "key1,key2"},
+		errMsg: "cannot use --file flag, use --reset flag and set key=value pairs simultaneously",
+	},
+	{
+		about:  "get, set, set from file and reset",
+		args:   []string{"key1", "key2=val2", "--file", "path", "--reset", "key3,key4"},
+		errMsg: "cannot use --file flag, use --reset flag, get value and set key=value pairs simultaneously",
+	},
+	{
+		about:     "reset unresettable key",
+		args:      []string{"--reset", "key1"},
+		cantReset: []string{"key1"},
+		errMsg:    `"key1" cannot be reset`,
+	},
+	{
+		about:     "reset some unresettable keys",
+		args:      []string{"--reset", "key1,key2,key3"},
+		cantReset: []string{"key2", "key3"},
+		errMsg:    `"key2" cannot be reset`,
+	},
+	{
+		about:  "--reset with key=val",
+		args:   []string{"--reset", "key1=val1"},
+		errMsg: `--reset accepts a comma delimited set of keys "a,b,c", received: "key1=val1"`,
+	},
+	{
+		about:  "--reset with some key=val",
+		args:   []string{"--reset", "key1,key2=val2,key3"},
+		errMsg: `--reset accepts a comma delimited set of keys "a,b,c", received: "key2=val2"`,
+	},
+}
+
+var initTests = []initTest{
+	{
+		about:  "no args",
+		args:   []string{},
+		action: GetAll,
+	},
+	{
+		about:    "get single key",
+		args:     []string{"key1"},
+		action:   GetOne,
+		keyToGet: "key1",
+	},
+	{
+		about:     "set key",
+		args:      []string{"key1=val1"},
+		action:    Set,
+		valsToSet: map[string]string{"key1": "val1"},
+	},
+	{
+		about:  "set multiple keys",
+		args:   []string{"key1=val1", "key2=val2", "key3=val3"},
+		action: Set,
+		valsToSet: map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+			"key3": "val3",
+		},
+	},
+	{
+		about:       "reset key",
+		args:        []string{"--reset", "key1"},
+		action:      Reset,
+		keysToReset: []string{"key1"},
+	},
+	{
+		about:       "reset multiple keys",
+		args:        []string{"--reset", "key1,key2,key3"},
+		action:      Reset,
+		keysToReset: []string{"key1", "key2", "key3"},
+	},
+	{
+		about:      "set from file",
+		args:       []string{"--file", "path"},
+		action:     SetFile,
+		configFile: cmd.FileVar{Path: "path"},
+	},
+	{
+		about:       "reset resettable key",
+		args:        []string{"--reset", "key1"},
+		cantReset:   []string{"key2"},
+		action:      Reset,
+		keysToReset: []string{"key1"},
+	},
+	{
+		about:       "reset resettable keys",
+		args:        []string{"--reset", "key1,key2,key3"},
+		cantReset:   []string{"key4", "key5"},
+		action:      Reset,
+		keysToReset: []string{"key1", "key2", "key3"},
+	},
+}


### PR DESCRIPTION
*NB: here, "config commands" refers to `juju config`, `model-config`, `controller-config`, and possibly `model-defaults`, `constraints`, `model-constraints`. This is currently a **proof of concept** of what I intend to do with the other config commands.*

This PR creates a new module `cmd/juju/config`. Inside this module, we define a new type `ConfigCommandBase`, which is intended to abstract a common interface/functionality shared between the different config commands. `ConfigCommandBase` defines a `SetFlags` method (since most/all the flags are shared between the config commands). A child command `X-config` should call this method, and then optionally set additional flags which are specific to `X-config`.

`ConfigCommandBase` also defines an `Init` method, which parses the command line args and sets an `Action` field. `X-config` has the option of stripping the first argument (e.g. for `config` this is the app name) before passing the remaining args to the parent. `Run` has to be defined by the child (the logic/APIs here differ too much between commands), but it can read the `Action` field to determine what it should do.

This forces all the different config commands to have the same command syntax/interface, reducing user confusion. (e.g. currently some commands have a `--file` flag while others don't). The idea is to prevent issues like [this](https://bugs.launchpad.net/juju/+bug/1946043) from ever happening again.

Any and all feedback appreciated.