### PR TITLE
Start child worker if app is dead so it goes through the dead() routine

### DIFF
--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -165,13 +165,12 @@ func (p *provisioner) loop() error {
 				return errors.New("app watcher closed channel")
 			}
 			for _, appName := range apps {
-				appLife, err := p.facade.Life(appName)
+				_, err := p.facade.Life(appName)
 				if err != nil && !errors.IsNotFound(err) {
 					return errors.Trace(err)
 				}
-				if errors.IsNotFound(err) || appLife == life.Dead {
-					// Application worker will shut itself down in these cases.
-					p.logger.Debugf("application %q not found or dead, ignoring", appName)
+				if errors.IsNotFound(err) {
+					p.logger.Debugf("application %q not found, ignoring", appName)
 					continue
 				}
 


### PR DESCRIPTION
Currently if for some reason the system gets into a funny state and
the child application worker dies before it's had a chance to go
through the a.dead() routine the application will never be deleted
from state.

Instead, only ignore if the application is not found (has already gone
away), but if it still exists and is dead, start the worker, which will
then go through the dying+dead sequence.

See also https://github.com/juju/juju/pull/13973