### PR TITLE
[JUJU-1037] Fix intermittent failure in TestEnqueueOperation.

### DIFF
--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -120,17 +120,17 @@ func (a *ActionAPI) enqueue(arg params.Actions) (string, params.ActionResults, e
 }
 
 func (a *ActionAPI) handleFailedActionEnqueuing(operationID string, response params.ActionResults, argCount int) error {
-	failMessages := set.NewStrings()
+	failMessages := make([]string, 0)
 	for _, res := range response.Results {
 		if res.Error != nil {
-			failMessages.Add(res.Error.Error())
+			failMessages = append(failMessages, res.Error.Error())
 		}
 	}
-	if failMessages.IsEmpty() {
+	if len(failMessages) == 0 {
 		return nil
 	}
-	startedCount := argCount - failMessages.Size()
-	failMessage := fmt.Sprintf("error(s) enqueueing action(s): %s", strings.Join(failMessages.Values(), ", "))
+	startedCount := argCount - len(failMessages)
+	failMessage := fmt.Sprintf("error(s) enqueueing action(s): %s", strings.Join(failMessages, ", "))
 	return a.model.FailOperationEnqueuing(operationID, failMessage, startedCount)
 }
 


### PR DESCRIPTION
Using a string set causes the error messages to be returned in different orders periodically. Ensure the order stays the same as they occurredin.

## QA steps

Run the stress-race script in apiserver/facades/client/action, no failures.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1970709