### PR TITLE
[JUJU-1087] Keep state worker alive for model life watcher failures

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -286,6 +286,7 @@ func MachineAgentFactoryFn(
 				IsFatal:       agenterrors.IsFatal,
 				MoreImportant: agenterrors.MoreImportant,
 				RestartDelay:  jworker.RestartDelay,
+				Logger:        logger,
 			}),
 			looputil.NewLoopDeviceManager(),
 			newIntrospectionSocketName,

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -940,19 +940,11 @@ func (s *MachineSuite) TestCertificateDNSUpdatedInvalidPrivateKey(c *gc.C) {
 }
 
 func (s *MachineSuite) testCertificateDNSUpdated(c *gc.C, a *MachineAgent) {
-	// Set up a channel which fires when State is opened.
-	started := make(chan struct{}, 16)
-	s.PatchValue(&reportOpenedState, func(*state.State) {
-		started <- struct{}{}
-	})
-
 	// Start the agent.
 	go func() { c.Check(a.Run(cmdtesting.Context(c)), jc.ErrorIsNil) }()
 	defer func() { c.Check(a.Stop(), jc.ErrorIsNil) }()
 
-	// Wait for State to be opened. Once this occurs we know that the
-	// agent's initial startup has happened.
-	s.assertChannelActive(c, started, "agent to start up")
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
 	// Check that certificate was updated when the agent started.
 	stateInfo, _ := a.CurrentConfig().StateServingInfo()

--- a/state/state.go
+++ b/state/state.go
@@ -117,7 +117,7 @@ func (st *State) ControllerUUID() string {
 	return st.controllerTag.Id()
 }
 
-// ControllerTag returns the tag form of the the return value of
+// ControllerTag returns the tag form of the return value of
 // ControllerUUID.
 func (st *State) ControllerTag() names.ControllerTag {
 	return st.controllerTag

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -284,7 +284,7 @@ func (w *pgWorker) loop() error {
 			idle.Reset(IdleTime)
 			continue
 		case <-controllerChanges:
-			// A controller controller was added or removed.
+			// A controller was added or removed.
 			logger.Tracef("<-controllerChanges")
 			changed, err := w.updateControllerNodes()
 			if err != nil {

--- a/worker/state/export_test.go
+++ b/worker/state/export_test.go
@@ -1,6 +1,0 @@
-// Copyright 2016 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
-package state
-
-var NewStateTracker = newStateTracker

--- a/worker/state/manifold_test.go
+++ b/worker/state/manifold_test.go
@@ -84,6 +84,7 @@ func (s *ManifoldSuite) TestOutputBadWorker(c *gc.C) {
 
 func (s *ManifoldSuite) TestOutputWrongType(c *gc.C) {
 	w := s.MustStartManifold(c)
+	defer workertest.DirtyKill(c, w)
 
 	var wrong int
 	err := s.Manifold.Output(w, &wrong)

--- a/worker/state/manifold_test.go
+++ b/worker/state/manifold_test.go
@@ -4,10 +4,7 @@
 package state_test
 
 import (
-	"time"
-
 	"github.com/juju/errors"
-	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -15,149 +12,90 @@ import (
 	"github.com/juju/worker/v3/workertest"
 	gc "gopkg.in/check.v1"
 
-	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/state"
-	statetesting "github.com/juju/juju/state/testing"
-	coretesting "github.com/juju/juju/testing"
 	workerstate "github.com/juju/juju/worker/state"
 )
 
 type ManifoldSuite struct {
-	statetesting.StateSuite
-	manifold          dependency.Manifold
-	openStateCalled   bool
-	openStateErr      error
-	config            workerstate.ManifoldConfig
-	agent             *mockAgent
-	resources         dt.StubResources
-	setStatePoolCalls []*state.StatePool
+	workerstate.BaseSuite
 }
 
 var _ = gc.Suite(&ManifoldSuite{})
 
-func (s *ManifoldSuite) SetUpTest(c *gc.C) {
-	s.StateSuite.SetUpTest(c)
-
-	s.openStateCalled = false
-	s.openStateErr = nil
-	s.setStatePoolCalls = nil
-
-	s.config = workerstate.ManifoldConfig{
-		AgentName:              "agent",
-		StateConfigWatcherName: "state-config-watcher",
-		OpenStatePool:          s.fakeOpenState,
-		PingInterval:           10 * time.Millisecond,
-		SetStatePool: func(pool *state.StatePool) {
-			s.setStatePoolCalls = append(s.setStatePoolCalls, pool)
-		},
-	}
-	s.manifold = workerstate.Manifold(s.config)
-	s.resources = dt.StubResources{
-		"agent":                dt.NewStubResource(new(mockAgent)),
-		"state-config-watcher": dt.NewStubResource(true),
-	}
-}
-
-func (s *ManifoldSuite) fakeOpenState(coreagent.Config) (*state.StatePool, error) {
-	s.openStateCalled = true
-	if s.openStateErr != nil {
-		return nil, s.openStateErr
-	}
-	// Here's one we prepared earlier...
-	return s.StatePool, nil
-}
-
 func (s *ManifoldSuite) TestInputs(c *gc.C) {
-	c.Assert(s.manifold.Inputs, jc.SameContents, []string{
+	c.Assert(s.Manifold.Inputs, jc.SameContents, []string{
 		"agent",
 		"state-config-watcher",
 	})
 }
 
 func (s *ManifoldSuite) TestStartAgentMissing(c *gc.C) {
-	s.resources["agent"] = dt.StubResource{Error: dependency.ErrMissing}
-	w, err := s.startManifold(c)
+	s.Resources["agent"] = dt.StubResource{Error: dependency.ErrMissing}
+	w, err := s.StartManifold(c)
 	c.Check(w, gc.IsNil)
 	c.Check(err, gc.Equals, dependency.ErrMissing)
 }
 
 func (s *ManifoldSuite) TestStateConfigWatcherMissing(c *gc.C) {
-	s.resources["state-config-watcher"] = dt.StubResource{Error: dependency.ErrMissing}
-	w, err := s.startManifold(c)
+	s.Resources["state-config-watcher"] = dt.StubResource{Error: dependency.ErrMissing}
+	w, err := s.StartManifold(c)
 	c.Check(w, gc.IsNil)
 	c.Check(err, gc.Equals, dependency.ErrMissing)
 }
 
 func (s *ManifoldSuite) TestStartOpenStateNil(c *gc.C) {
-	s.config.OpenStatePool = nil
-	s.startManifoldInvalidConfig(c, s.config, "nil OpenStatePool not valid")
+	s.Config.OpenStatePool = nil
+	s.startManifoldInvalidConfig(c, s.Config, "nil OpenStatePool not valid")
 }
 
 func (s *ManifoldSuite) TestStartSetStatePoolNil(c *gc.C) {
-	s.config.SetStatePool = nil
-	s.startManifoldInvalidConfig(c, s.config, "nil SetStatePool not valid")
+	s.Config.SetStatePool = nil
+	s.startManifoldInvalidConfig(c, s.Config, "nil SetStatePool not valid")
 }
 
 func (s *ManifoldSuite) startManifoldInvalidConfig(c *gc.C, config workerstate.ManifoldConfig, expect string) {
 	manifold := workerstate.Manifold(config)
-	w, err := manifold.Start(s.resources.Context())
+	w, err := manifold.Start(s.Resources.Context())
 	c.Check(w, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, expect)
 }
 
 func (s *ManifoldSuite) TestStartNotStateServer(c *gc.C) {
-	s.resources["state-config-watcher"] = dt.NewStubResource(false)
-	w, err := s.startManifold(c)
+	s.Resources["state-config-watcher"] = dt.NewStubResource(false)
+	w, err := s.StartManifold(c)
 	c.Check(w, gc.IsNil)
 	c.Check(errors.Cause(err), gc.Equals, dependency.ErrMissing)
 	c.Check(err, gc.ErrorMatches, "no StateServingInfo in config: dependency not available")
 }
 
 func (s *ManifoldSuite) TestStartOpenStateFails(c *gc.C) {
-	s.openStateErr = errors.New("boom")
-	w, err := s.startManifold(c)
+	s.OpenStateErr = errors.New("boom")
+	w, err := s.StartManifold(c)
 	c.Check(w, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "boom")
 }
 
-func (s *ManifoldSuite) TestStartSuccess(c *gc.C) {
-	w := s.mustStartManifold(c)
-	c.Check(s.openStateCalled, jc.IsTrue)
-	checkNotExiting(c, w)
-	workertest.CleanKill(c, w)
-}
-
-func (s *ManifoldSuite) TestStatePinging(c *gc.C) {
-	w := s.mustStartManifold(c)
-	checkNotExiting(c, w)
-
-	// Kill the mongod to cause pings to fail.
-	jujutesting.MgoServer.Destroy()
-
-	checkExitsWithError(c, w, "state ping failed: .+")
-}
-
 func (s *ManifoldSuite) TestOutputBadWorker(c *gc.C) {
 	var st *state.State
-	err := s.manifold.Output(dummyWorker{}, &st)
+	err := s.Manifold.Output(dummyWorker{}, &st)
 	c.Check(st, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, `in should be a \*state.stateWorker; .+`)
 }
 
 func (s *ManifoldSuite) TestOutputWrongType(c *gc.C) {
-	w := s.mustStartManifold(c)
+	w := s.MustStartManifold(c)
 
 	var wrong int
-	err := s.manifold.Output(w, &wrong)
+	err := s.Manifold.Output(w, &wrong)
 	c.Check(wrong, gc.Equals, 0)
 	c.Check(err, gc.ErrorMatches, `out should be \*StateTracker; got .+`)
 }
 
 func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
-	w := s.mustStartManifold(c)
+	w := s.MustStartManifold(c)
 
 	var stTracker workerstate.StateTracker
-	err := s.manifold.Output(w, &stTracker)
+	err := s.Manifold.Output(w, &stTracker)
 	c.Assert(err, jc.ErrorIsNil)
 
 	pool, err := stTracker.Use()
@@ -171,10 +109,10 @@ func (s *ManifoldSuite) TestOutputSuccess(c *gc.C) {
 }
 
 func (s *ManifoldSuite) TestStateStillInUse(c *gc.C) {
-	w := s.mustStartManifold(c)
+	w := s.MustStartManifold(c)
 
 	var stTracker workerstate.StateTracker
-	err := s.manifold.Output(w, &stTracker)
+	err := s.Manifold.Output(w, &stTracker)
 	c.Assert(err, jc.ErrorIsNil)
 
 	pool, err := stTracker.Use()
@@ -187,106 +125,6 @@ func (s *ManifoldSuite) TestStateStillInUse(c *gc.C) {
 	// Now signal that the State is no longer needed.
 	c.Assert(stTracker.Done(), jc.ErrorIsNil)
 	assertStatePoolClosed(c, pool)
-}
-
-func (s *ManifoldSuite) TestDeadStateRemoved(c *gc.C) {
-	// Create an additional state *before* we start
-	// the worker, so the worker's lifecycle watcher
-	// is guaranteed to observe it in both the Alive
-	// state and the Dead state.
-	newSt := s.Factory.MakeModel(c, nil)
-	defer newSt.Close()
-	model, err := newSt.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	w := s.mustStartManifold(c)
-	defer workertest.CleanKill(c, w)
-
-	var stTracker workerstate.StateTracker
-	err = s.manifold.Output(w, &stTracker)
-	c.Assert(err, jc.ErrorIsNil)
-	pool, err := stTracker.Use()
-	c.Assert(err, jc.ErrorIsNil)
-	defer stTracker.Done()
-
-	// Get a reference to the state pool entry, so we can
-	// prevent it from being fully removed from the pool.
-	st, err := pool.Get(newSt.ModelUUID())
-	c.Assert(err, jc.ErrorIsNil)
-	defer st.Release()
-
-	// Progress the model to Dead.
-	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
-	c.Assert(model.Refresh(), jc.ErrorIsNil)
-	c.Assert(model.Life(), gc.Equals, state.Dying)
-	c.Assert(newSt.RemoveDyingModel(), jc.ErrorIsNil)
-	c.Assert(model.Refresh(), jc.Satisfies, errors.IsNotFound)
-	s.State.StartSync()
-
-	for a := coretesting.LongAttempt.Start(); a.Next(); {
-		st, err := pool.Get(newSt.ModelUUID())
-		if errors.IsNotFound(err) {
-			c.Assert(err, gc.ErrorMatches, "model .* has been removed")
-			return
-		}
-		c.Assert(err, jc.ErrorIsNil)
-		st.Release()
-	}
-	c.Fatal("timed out waiting for model state to be removed from pool")
-}
-
-func (s *ManifoldSuite) mustStartManifold(c *gc.C) worker.Worker {
-	w, err := s.startManifold(c)
-	c.Assert(err, jc.ErrorIsNil)
-	return w
-}
-
-func (s *ManifoldSuite) startManifold(c *gc.C) (worker.Worker, error) {
-	w, err := s.manifold.Start(s.resources.Context())
-	if w != nil {
-		s.AddCleanup(func(*gc.C) { worker.Stop(w) })
-	}
-	return w, err
-}
-
-func checkNotExiting(c *gc.C, w worker.Worker) {
-	exited := make(chan bool)
-	go func() {
-		w.Wait()
-		close(exited)
-	}()
-
-	select {
-	case <-exited:
-		c.Fatal("worker exited unexpectedly")
-	case <-time.After(coretesting.ShortWait):
-		// Worker didn't exit (good)
-	}
-}
-
-func checkExitsWithError(c *gc.C, w worker.Worker, expectedErr string) {
-	errCh := make(chan error)
-	go func() {
-		errCh <- w.Wait()
-	}()
-	select {
-	case err := <-errCh:
-		c.Check(err, gc.ErrorMatches, expectedErr)
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out waiting for worker to exit")
-	}
-}
-
-type mockAgent struct {
-	coreagent.Agent
-}
-
-func (ma *mockAgent) CurrentConfig() coreagent.Config {
-	return new(mockConfig)
-}
-
-type mockConfig struct {
-	coreagent.Config
 }
 
 type dummyWorker struct {

--- a/worker/state/package_test.go
+++ b/worker/state/package_test.go
@@ -6,6 +6,16 @@ package state
 import (
 	stdtesting "testing"
 
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3"
+
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/state"
+	statetesting "github.com/juju/juju/state/testing"
+	"github.com/juju/worker/v3/dependency"
+	dt "github.com/juju/worker/v3/dependency/testing"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/testing"
 )
 
@@ -13,4 +23,74 @@ var NewStateTracker = newStateTracker
 
 func TestPackage(t *stdtesting.T) {
 	testing.MgoTestPackage(t)
+}
+
+type BaseSuite struct {
+	statetesting.StateSuite
+
+	Manifold        dependency.Manifold
+	Resources       dt.StubResources
+	Config          ManifoldConfig
+	OpenStateErr    error
+	OpenStateCalled bool
+
+	agent             *mockAgent
+	setStatePoolCalls []*state.StatePool
+}
+
+func (s *BaseSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+
+	s.OpenStateCalled = false
+	s.OpenStateErr = nil
+	s.setStatePoolCalls = nil
+
+	s.Config = ManifoldConfig{
+		AgentName:              "agent",
+		StateConfigWatcherName: "state-config-watcher",
+		OpenStatePool:          s.fakeOpenState,
+		SetStatePool: func(pool *state.StatePool) {
+			s.setStatePoolCalls = append(s.setStatePoolCalls, pool)
+		},
+	}
+	s.Manifold = Manifold(s.Config)
+	s.Resources = dt.StubResources{
+		"agent":                dt.NewStubResource(new(mockAgent)),
+		"state-config-watcher": dt.NewStubResource(true),
+	}
+}
+
+func (s *BaseSuite) MustStartManifold(c *gc.C) worker.Worker {
+	w, err := s.StartManifold(c)
+	c.Assert(err, jc.ErrorIsNil)
+	return w
+}
+
+func (s *BaseSuite) StartManifold(_ *gc.C) (worker.Worker, error) {
+	w, err := s.Manifold.Start(s.Resources.Context())
+	if w != nil {
+		s.AddCleanup(func(*gc.C) { _ = worker.Stop(w) })
+	}
+	return w, err
+}
+
+func (s *BaseSuite) fakeOpenState(coreagent.Config) (*state.StatePool, error) {
+	s.OpenStateCalled = true
+	if s.OpenStateErr != nil {
+		return nil, s.OpenStateErr
+	}
+	// Here's one we prepared earlier...
+	return s.StatePool, nil
+}
+
+type mockAgent struct {
+	coreagent.Agent
+}
+
+func (ma *mockAgent) CurrentConfig() coreagent.Config {
+	return new(mockConfig)
+}
+
+type mockConfig struct {
+	coreagent.Config
 }

--- a/worker/state/package_test.go
+++ b/worker/state/package_test.go
@@ -1,13 +1,15 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package state_test
+package state
 
 import (
 	stdtesting "testing"
 
 	"github.com/juju/juju/testing"
 )
+
+var NewStateTracker = newStateTracker
 
 func TestPackage(t *stdtesting.T) {
 	testing.MgoTestPackage(t)

--- a/worker/state/worker_test.go
+++ b/worker/state/worker_test.go
@@ -1,0 +1,108 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"time"
+
+	"github.com/juju/worker/v3"
+
+	jujutesting "github.com/juju/testing"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3/workertest"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
+)
+
+type WorkerSuite struct {
+	BaseSuite
+}
+
+var _ = gc.Suite(&WorkerSuite{})
+
+func (s *WorkerSuite) TestStartSuccess(c *gc.C) {
+	w := s.MustStartManifold(c)
+	c.Check(s.OpenStateCalled, jc.IsTrue)
+	checkNotExiting(c, w)
+	workertest.CleanKill(c, w)
+}
+
+func (s *WorkerSuite) TestStatePinging(c *gc.C) {
+	// Exhaust the retries ASAP.
+	s.Config.PingInterval = time.Millisecond
+	s.Manifold = Manifold(s.Config)
+
+	w := s.MustStartManifold(c)
+	checkNotExiting(c, w)
+
+	jujutesting.MgoServer.Destroy()
+
+	err := workertest.CheckKilled(c, w)
+	c.Check(err, gc.ErrorMatches, "state ping failed: .+")
+}
+
+func (s *WorkerSuite) TestDeadStateRemoved(c *gc.C) {
+	// Create an additional state *before* we start
+	// the worker, so the worker's lifecycle watcher
+	// is guaranteed to observe it in both the Alive
+	// state and the Dead state.
+	newSt := s.Factory.MakeModel(c, nil)
+	defer func() { _ = newSt.Close() }()
+	model, err := newSt.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	w := s.MustStartManifold(c)
+	defer workertest.CleanKill(c, w)
+
+	var stTracker StateTracker
+	err = s.Manifold.Output(w, &stTracker)
+	c.Assert(err, jc.ErrorIsNil)
+	pool, err := stTracker.Use()
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() { _ = stTracker.Done() }()
+
+	// Get a reference to the state pool entry, so we can
+	// prevent it from being fully removed from the pool.
+	st, err := pool.Get(newSt.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	defer st.Release()
+
+	// Progress the model to Dead.
+	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
+	c.Assert(model.Refresh(), jc.ErrorIsNil)
+	c.Assert(model.Life(), gc.Equals, state.Dying)
+	c.Assert(newSt.RemoveDyingModel(), jc.ErrorIsNil)
+	c.Assert(model.Refresh(), jc.Satisfies, errors.IsNotFound)
+	s.State.StartSync()
+
+	for a := coretesting.LongAttempt.Start(); a.Next(); {
+		st, err := pool.Get(newSt.ModelUUID())
+		if errors.IsNotFound(err) {
+			c.Assert(err, gc.ErrorMatches, "model .* has been removed")
+			return
+		}
+		c.Assert(err, jc.ErrorIsNil)
+		st.Release()
+	}
+	c.Fatal("timed out waiting for model state to be removed from pool")
+}
+
+func checkNotExiting(c *gc.C, w worker.Worker) {
+	exited := make(chan bool)
+	go func() {
+		_ = w.Wait()
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
+		c.Fatal("worker exited unexpectedly")
+	case <-time.After(coretesting.ShortWait):
+		// Worker didn't exit (good)
+	}
+}


### PR DESCRIPTION
Under #13633 we gave some leeway in the state worker for individual model workers that fail their pings to state.

Unfortunately this change was immaterial to the worker resiliency because the top level model life worker, which is added to the worker's catacomb, will kill the worker if it's session closes anyway.

Here we decouple it so that it is restarted whenever it completes. This is safe, because we can rely on the model sub-workers to kill the worker when failure to access Mongo causes repeated ping failures. Even if there are no workload models, there is still a controller model.

There is some test suite rearrangement in the second-to-last commit. The main change here is represented in the last one.

This is hard to unit test using the package's test infrastructure because destroying or resetting the test Mongo, causes a new one to come up on a different port and we can't cause the watcher to restart (it attempts to dial the old port). However, the tests do verify that ping failures bounce the worker in this case.

## QA steps

- Bootstrap and `juju enable-ha`, waiting for quiescence.
- Ensure that controller model logging config includes `juju.worker.state=DEBUG`.
- Connect to the Mongo primary and run `rs.stepDown()`.
- Run `juju debug-log -m controller` and look for something like:
```
machine-0: 16:29:01 INFO juju.worker.state restarting model watcher for error: state has been closed
```
- Now add and destroy a model. The logs should show that the life watcher is still working, indicated by entries such as:
```
machine-0: 16:29:43 DEBUG juju.worker.state model "54e659c1-ad2d-4f86-88fe-e63b1e7152b1" is dead
```

## Documentation changes

None.

## Bug reference

N/A
