### PR TITLE
Fixed typo in Makefile for build arch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ define run_go_build
 	$(eval OS = $(word 1,$(subst _, ,$*)))
 	$(eval ARCH = $(word 2,$(subst _, ,$*)))
 	$(eval BBIN_DIR = ${BUILD_DIR}/${OS}_${ARCH}/bin)
-	$(eval BUILD_ARCH = $(subst ppc64el,ppc64le,${ARCh}))
+	$(eval BUILD_ARCH = $(subst ppc64el,ppc64le,${ARCH}))
 	@@mkdir -p ${BBIN_DIR}
 	@echo "Building ${PACKAGE} for ${OS}/${ARCH}"
 	@env GOOS=${OS} GOARCH=${BUILD_ARCH} go build -mod=$(JUJU_GOMOD_MODE) -o ${BBIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v  ${PACKAGE}


### PR DESCRIPTION
With a recent change to handle the conversion of ppc64el to ppc64le a
typo was made in the arch passed to the go tools for building binaries.
This resulted in an empty string that caused the juju binaries to be
built for the local arch.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Build a foreign arch to your local machine and check the resultant output.

```sh
CLIENT_PACKAGE_PLATFORMS=linux/arm64 AGENT_PACKAGE_PLATFORMS=linux/arm64 make build
file _build/linux_arm64/bin/*
# Check that the output of file depicts the right architecture
```

## Documentation changes

N/A

## Bug reference

[Bug #1971183 “unable to bootstrap arm64 controller” : Bugs : juju](https://bugs.launchpad.net/juju/+bug/1971183)
