### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ on:
       - 'testing/**'
       - 'tests/**'
 
+permissions:
+  contents: read
+
 jobs:
   Build:
     name: Build

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,7 +1,12 @@
 name: "CLA check"
 on: [pull_request]
+permissions:
+  contents: read
+
 jobs:
   cla-check:
+    permissions:
+      pull-requests: write  # for canonical/has-signed-canonical-cla to create & update comments
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -17,6 +17,9 @@ on:
       - 'testing/**'
       - 'tests/**'
 
+permissions:
+  contents: read
+
 jobs:
 
   test-client-ubuntu:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,5 +1,8 @@
 name: "Snapcraft"
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
 
   snap:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,5 +1,8 @@
 name: "Static Analysis"
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/update-brew-formulae.yml
+++ b/.github/workflows/update-brew-formulae.yml
@@ -4,8 +4,13 @@ on:
     types: [published]
   schedule:
     - cron:  '0 */12 * * *'
+permissions:
+  contents: read
+
 jobs:
   update-brew-tap:
+    permissions:
+      contents: none
     if: github.repository_owner == 'juju'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
