### PR TITLE
[JUJU-1050] Output life in `juju show-unit` and `juju show-application`

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -1200,6 +1200,7 @@ type UnitInfo struct {
 	PublicAddress   string
 	Charm           string
 	Leader          bool
+	Life            string
 	RelationData    []EndpointRelationData
 
 	// The following are for CAAS models.
@@ -1259,6 +1260,7 @@ func unitInfoFromParams(in params.UnitInfoResult) UnitInfo {
 		PublicAddress:   in.Result.PublicAddress,
 		Charm:           in.Result.Charm,
 		Leader:          in.Result.Leader,
+		Life:            in.Result.Life,
 		ProviderId:      in.Result.ProviderId,
 		Address:         in.Result.Address,
 	}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -3085,6 +3085,7 @@ func (api *APIBase) unitResultForUnit(unit Unit) (*params.UnitResult, error) {
 		WorkloadVersion: workloadVersion,
 		Machine:         machineId,
 		Charm:           curl.String(),
+		Life:            unit.Life().String(),
 	}
 	if machineId != "" {
 		machine, err := api.backend.Machine(machineId)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2832,6 +2832,7 @@ func (api *APIBase) ApplicationsInfo(in params.Entities) (params.ApplicationInfo
 			Principal:        app.IsPrincipal(),
 			Exposed:          app.IsExposed(),
 			Remote:           app.IsRemote(),
+			Life:             app.Life().String(),
 			EndpointBindings: bindingsMap,
 			ExposedEndpoints: exposedEndpoints,
 		}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2268,12 +2268,13 @@ func (s *ApplicationSuite) TestApplicationsInfoOne(c *gc.C) {
 		Channel:     "2.0/candidate",
 		Constraints: constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
 		Principal:   true,
+		Life:        state.Alive.String(),
 		EndpointBindings: map[string]string{
 			"juju-info": "myspace",
 		},
 	})
 	app := s.backend.applications["test-app-info"]
-	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
+	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote", "Life")
 }
 
 func (s *ApplicationSuite) TestApplicationsInfoOneWithExposedEndpoints(c *gc.C) {
@@ -2302,6 +2303,7 @@ func (s *ApplicationSuite) TestApplicationsInfoOneWithExposedEndpoints(c *gc.C) 
 		Channel:     "development",
 		Constraints: constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
 		Principal:   true,
+		Life:        state.Alive.String(),
 		EndpointBindings: map[string]string{
 			"juju-info": "myspace",
 		},
@@ -2312,7 +2314,7 @@ func (s *ApplicationSuite) TestApplicationsInfoOneWithExposedEndpoints(c *gc.C) 
 			},
 		},
 	})
-	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
+	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote", "Life")
 }
 
 func (s *ApplicationSuite) TestApplicationsInfoDetailsErr(c *gc.C) {
@@ -2356,6 +2358,7 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 		Channel:     "development",
 		Constraints: constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
 		Principal:   true,
+		Life:        state.Alive.String(),
 		EndpointBindings: map[string]string{
 			"juju-info": "myspace",
 		},
@@ -2363,7 +2366,7 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 	c.Assert(result.Results[1].Error, gc.ErrorMatches, `application "wordpress" not found`)
 	c.Assert(result.Results[2].Error, gc.ErrorMatches, `"unit-postgresql-0" is not a valid application tag`)
 	app := s.backend.applications["postgresql"]
-	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote")
+	app.CheckCallNames(c, "CharmConfig", "Charm", "ApplicationConfig", "IsPrincipal", "Constraints", "EndpointBindings", "Channel", "CharmOrigin", "Series", "EndpointBindings", "ExposedEndpoints", "CharmOrigin", "IsPrincipal", "IsExposed", "IsRemote", "Life")
 }
 
 func (s *ApplicationSuite) TestApplicationMergeBindingsErr(c *gc.C) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2402,6 +2402,7 @@ func (s *ApplicationSuite) TestUnitsInfo(c *gc.C) {
 		PublicAddress:   "10.0.0.1",
 		Charm:           "cs:postgresql-42",
 		Leader:          true,
+		Life:            state.Alive.String(),
 		RelationData: []params.EndpointRelationData{{
 			RelationId:      101,
 			Endpoint:        "db",
@@ -2440,6 +2441,7 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 		PublicAddress:   "10.0.0.1",
 		Charm:           "cs:postgresql-42",
 		Leader:          true,
+		Life:            state.Alive.String(),
 		RelationData: []params.EndpointRelationData{{
 			RelationId:      101,
 			Endpoint:        "db",
@@ -2464,6 +2466,7 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 		PublicAddress:   "10.0.0.1",
 		Charm:           "cs:postgresql-42",
 		Leader:          false,
+		Life:            state.Alive.String(),
 		RelationData: []params.EndpointRelationData{{
 			RelationId:      101,
 			Endpoint:        "db",

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -90,6 +90,7 @@ type Application interface {
 	IsExposed() bool
 	IsPrincipal() bool
 	IsRemote() bool
+	Life() state.Life
 	Series() string
 	SetCharm(state.SetCharmConfig) error
 	SetConstraints(constraints.Value) error

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -275,6 +275,11 @@ func (a *mockApplication) IsRemote() bool {
 	return a.remote
 }
 
+func (a *mockApplication) Life() state.Life {
+	a.MethodCall(a, "Life")
+	return state.Alive
+}
+
 func (a *mockApplication) AgentTools() (*tools.Tools, error) {
 	a.MethodCall(a, "AgentTools")
 	return a.agentTools, a.NextErr()

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -988,6 +988,10 @@ func (u *mockUnit) IsPrincipal() bool {
 	return true
 }
 
+func (u *mockUnit) Life() state.Life {
+	return state.Alive
+}
+
 func (u *mockUnit) DestroyOperation() *state.DestroyUnitOperation {
 	u.MethodCall(u, "DestroyOperation")
 	return &state.DestroyUnitOperation{}

--- a/apiserver/facades/client/application/updateseries_mocks_test.go
+++ b/apiserver/facades/client/application/updateseries_mocks_test.go
@@ -351,6 +351,20 @@ func (mr *MockApplicationMockRecorder) IsRemote() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRemote", reflect.TypeOf((*MockApplication)(nil).IsRemote))
 }
 
+// Life mocks base method.
+func (m *MockApplication) Life() state.Life {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Life")
+	ret0, _ := ret[0].(state.Life)
+	return ret0
+}
+
+// Life indicates an expected call of Life.
+func (mr *MockApplicationMockRecorder) Life() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Life", reflect.TypeOf((*MockApplication)(nil).Life))
+}
+
 // MergeBindings mocks base method.
 func (m *MockApplication) MergeBindings(arg0 *state.Bindings, arg1 bool) error {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -4180,6 +4180,9 @@
                         "leader": {
                             "type": "boolean"
                         },
+                        "life": {
+                            "type": "string"
+                        },
                         "machine": {
                             "type": "string"
                         },

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2981,6 +2981,9 @@
                                 }
                             }
                         },
+                        "life": {
+                            "type": "string"
+                        },
                         "principal": {
                             "type": "boolean"
                         },
@@ -2999,7 +3002,8 @@
                         "tag",
                         "principal",
                         "exposed",
-                        "remote"
+                        "remote",
+                        "life"
                     ]
                 },
                 "ApplicationSet": {

--- a/cmd/juju/application/show.go
+++ b/cmd/juju/application/show.go
@@ -184,6 +184,7 @@ type ApplicationInfo struct {
 	Exposed          bool                       `yaml:"exposed" json:"exposed"`
 	ExposedEndpoints map[string]ExposedEndpoint `yaml:"exposed-endpoints,omitempty" json:"exposed-endpoints,omitempty"`
 	Remote           bool                       `yaml:"remote" json:"remote"`
+	Life             string                     `yaml:"life,omitempty" json:"life,omitempty"`
 	EndpointBindings map[string]string          `yaml:"endpoint-bindings,omitempty" json:"endpoint-bindings,omitempty"`
 }
 
@@ -221,6 +222,7 @@ func createApplicationInfo(details params.ApplicationResult) (names.ApplicationT
 		Exposed:          details.Exposed,
 		ExposedEndpoints: exposedEndpoints,
 		Remote:           details.Remote,
+		Life:             details.Life,
 		EndpointBindings: details.EndpointBindings,
 	}
 	return tag, info, nil

--- a/cmd/juju/application/show_test.go
+++ b/cmd/juju/application/show_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
 	jujutesting "github.com/juju/juju/testing"
 )
 
@@ -147,6 +148,7 @@ func (s *ShowSuite) createTestApplicationInfo(name string, suffix string) *param
 		Channel:     "development",
 		Constraints: constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
 		Principal:   true,
+		Life:        state.Alive.String(),
 		EndpointBindings: map[string]string{
 			"juju-info": "myspace",
 		},
@@ -195,6 +197,7 @@ wordpress:
       expose-to-spaces:
       - non-euclidean-geometry
   remote: false
+  life: alive
   endpoint-bindings:
     juju-info: myspace
 `[1:],
@@ -209,7 +212,7 @@ func (s *ShowSuite) TestShowJSON(c *gc.C) {
 	}
 	s.assertRunShow(c, showTest{
 		args:   []string{"wordpress", "--format", "json"},
-		stdout: "{\"wordpress\":{\"charm\":\"charm-wordpress\",\"series\":\"quantal\",\"channel\":\"development\",\"constraints\":{\"arch\":\"amd64\",\"cores\":1,\"mem\":4096,\"root-disk\":8192},\"principal\":true,\"exposed\":false,\"exposed-endpoints\":{\"\":{\"expose-to-cidrs\":[\"192.168.0.0/24\"]},\"website\":{\"expose-to-spaces\":[\"non-euclidean-geometry\"]}},\"remote\":false,\"endpoint-bindings\":{\"juju-info\":\"myspace\"}}}\n",
+		stdout: "{\"wordpress\":{\"charm\":\"charm-wordpress\",\"series\":\"quantal\",\"channel\":\"development\",\"constraints\":{\"arch\":\"amd64\",\"cores\":1,\"mem\":4096,\"root-disk\":8192},\"principal\":true,\"exposed\":false,\"exposed-endpoints\":{\"\":{\"expose-to-cidrs\":[\"192.168.0.0/24\"]},\"website\":{\"expose-to-spaces\":[\"non-euclidean-geometry\"]}},\"remote\":false,\"life\":\"alive\",\"endpoint-bindings\":{\"juju-info\":\"myspace\"}}}\n",
 	})
 }
 
@@ -248,6 +251,7 @@ logging:
   principal: true
   exposed: false
   remote: false
+  life: alive
   endpoint-bindings:
     juju-info: myspace
 wordpress:
@@ -262,6 +266,7 @@ wordpress:
   principal: true
   exposed: false
   remote: false
+  life: alive
   endpoint-bindings:
     juju-info: myspace
 `[1:],

--- a/cmd/juju/application/showunit.go
+++ b/cmd/juju/application/showunit.go
@@ -202,6 +202,7 @@ type UnitInfo struct {
 	PublicAddress   string         `yaml:"public-address,omitempty" json:"public-address,omitempty"`
 	Charm           string         `yaml:"charm" json:"charm"`
 	Leader          bool           `yaml:"leader" json:"leader"`
+	Life            string         `yaml:"life,omitempty" json:"life,omitempty"`
 	RelationData    []RelationData `yaml:"relation-info,omitempty" json:"relation-info,omitempty"`
 
 	// The following are for CAAS models.
@@ -222,6 +223,7 @@ func (c *showUnitCommand) createUnitInfo(details application.UnitInfo) (names.Un
 		PublicAddress:   details.PublicAddress,
 		Charm:           details.Charm,
 		Leader:          details.Leader,
+		Life:            details.Life,
 		ProviderId:      details.ProviderId,
 		Address:         details.Address,
 	}

--- a/cmd/juju/application/showunit_test.go
+++ b/cmd/juju/application/showunit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
+	"github.com/juju/juju/state"
 	jujutesting "github.com/juju/juju/testing"
 )
 
@@ -147,6 +148,7 @@ func (s *ShowUnitSuite) createTestUnitInfo(app string, otherEndpoint string) api
 		PublicAddress:   "10.0.0.1",
 		Charm:           fmt.Sprintf("charm-%v", app),
 		Leader:          true,
+		Life:            state.Alive.String(),
 		RelationData: []apiapplication.EndpointRelationData{{
 			Endpoint:        "db",
 			CrossModel:      true,
@@ -192,6 +194,7 @@ wordpress/0:
   public-address: 10.0.0.1
   charm: charm-wordpress
   leader: true
+  life: alive
   relation-info:
   - relation-id: 0
     endpoint: db
@@ -227,6 +230,7 @@ wordpress/0:
   public-address: 10.0.0.1
   charm: charm-wordpress
   leader: true
+  life: alive
   relation-info:
   - relation-id: 0
     endpoint: db
@@ -257,6 +261,7 @@ wordpress/0:
   public-address: 10.0.0.1
   charm: charm-wordpress
   leader: true
+  life: alive
   relation-info:
   - relation-id: 0
     endpoint: db-shared
@@ -285,6 +290,7 @@ wordpress/0:
   public-address: 10.0.0.1
   charm: charm-wordpress
   leader: true
+  life: alive
   relation-info:
   - relation-id: 0
     endpoint: db
@@ -311,7 +317,7 @@ func (s *ShowUnitSuite) TestShowJSON(c *gc.C) {
 	}
 	s.assertRunShow(c, showUnitTest{
 		args:   []string{"wordpress/0", "--format", "json"},
-		stdout: `{"wordpress/0":{"workload-version":"666","machine":"0","opened-ports":["100-102/ip"],"public-address":"10.0.0.1","charm":"charm-wordpress","leader":true,"relation-info":[{"relation-id":0,"endpoint":"db","cross-model":true,"related-endpoint":"server","application-data":{"wordpress":"setting"},"local-unit":{"in-scope":false,"data":null},"related-units":{"mariadb/2":{"in-scope":true,"data":{"mariadb/2":"mariadb/2-setting"}}}}],"provider-id":"provider-id","address":"192.168.1.1"}}` + "\n",
+		stdout: `{"wordpress/0":{"workload-version":"666","machine":"0","opened-ports":["100-102/ip"],"public-address":"10.0.0.1","charm":"charm-wordpress","leader":true,"life":"alive","relation-info":[{"relation-id":0,"endpoint":"db","cross-model":true,"related-endpoint":"server","application-data":{"wordpress":"setting"},"local-unit":{"in-scope":false,"data":null},"related-units":{"mariadb/2":{"in-scope":true,"data":{"mariadb/2":"mariadb/2-setting"}}}}],"provider-id":"provider-id","address":"192.168.1.1"}}` + "\n",
 	})
 }
 
@@ -346,6 +352,7 @@ logging/0:
   public-address: 10.0.0.1
   charm: charm-logging
   leader: true
+  life: alive
   relation-info:
   - relation-id: 0
     endpoint: db
@@ -368,6 +375,7 @@ wordpress/0:
   public-address: 10.0.0.1
   charm: charm-wordpress
   leader: true
+  life: alive
   relation-info:
   - relation-id: 0
     endpoint: db

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -74,6 +74,7 @@ wordpress:
   principal: true
   exposed: false
   remote: false
+  life: alive
   endpoint-bindings:
     "": alpha
     admin-api: alpha
@@ -100,6 +101,7 @@ logging:
   principal: false
   exposed: false
   remote: false
+  life: alive
   endpoint-bindings:
     "": alpha
     info: vlan2
@@ -113,6 +115,7 @@ wordpress:
   principal: true
   exposed: false
   remote: false
+  life: alive
   endpoint-bindings:
     "": alpha
     admin-api: alpha

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -585,6 +585,7 @@ type ApplicationResult struct {
 	Principal        bool                       `json:"principal"`
 	Exposed          bool                       `json:"exposed"`
 	Remote           bool                       `json:"remote"`
+	Life             string                     `json:"life"`
 	EndpointBindings map[string]string          `json:"endpoint-bindings,omitempty"`
 	ExposedEndpoints map[string]ExposedEndpoint `json:"exposed-endpoints,omitempty"`
 }

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -625,6 +625,7 @@ type UnitResult struct {
 	PublicAddress   string                 `json:"public-address,omitempty"`
 	Charm           string                 `json:"charm"`
 	Leader          bool                   `json:"leader,omitempty"`
+	Life            string                 `json:"life,omitempty"`
 	RelationData    []EndpointRelationData `json:"relation-data,omitempty"`
 
 	// The following are for CAAS models.


### PR DESCRIPTION
Juju only inconsistently outputs the `life` status of entities when running `juju show-`. This PR is the first step in making this consistent

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

#### Deploy something big and complex
```
$ juju deploy charmed-kubernetes
```
And wait for it to be fully deployed

#### Test show-unit with alive unit
```
$ juju show-unit easyrsa/0
easyrsa/0:
  machine: "0"
  opened-ports: []
  public-address: 18.169.166.26
  charm: cs:~containers/easyrsa-441
  leader: true
  life: alive
...
```

#### Test show-application with alive application
```
$ juju show-application flannel
flannel:
  charm: flannel
  series: focal
  channel: stable
  principal: false
  exposed: false
  remote: false
  life: alive
...
```

This is not sufficient QA, however, since `alive` corresponds to the integer 0, so this value could just be uninitialised under the hood

#### Destroy the model, and quickly whilst units are dying, check `show-x`
Unit
```
$ juju destroy-model k8s
$ juju show-unit etcd/1
etcd/1:
  workload-version: 3.4.5
  machine: "2"
  opened-ports:
  - 2379/tcp
  public-address: 13.41.65.66
  charm: cs:~containers/etcd-655
  leader: false
  life: dying
...
```
and application
```
$ juju show-application containerd
containerd:
  charm: containerd
  series: focal
  channel: stable
  principal: false
  exposed: false
  remote: false
  life: dying
...
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1968092
