### PR TITLE
[JUJU-1058] Close buffered logger upon termination of converged unit agent

### DIFF
--- a/worker/deployer/unit_agent.go
+++ b/worker/deployer/unit_agent.go
@@ -221,6 +221,7 @@ func (a *UnitAgent) start() (worker.Worker, error) {
 		_ = engine.Wait()
 		a.mu.Lock()
 		a.workerRunning = false
+		bufferedLogger.Close()
 		a.mu.Unlock()
 	}()
 	if err := addons.StartIntrospection(addons.IntrospectionConfig{


### PR DESCRIPTION
The installation of a buffered logger, used to ship logs to controllers, spawns a Goroutine that is not managed.

This was not a problem when it was created in the `main` method for jujud, because there was only ever one per agent, and an agent restart would cause termination of the Goroutine.

When unit agents were converged as runners into the machine agent, this changed. Now, a terminated unit agent leaves these Goroutines behind.

Here we call the logger's `Close` method when the unit worker's dependency engine completes. This closure causes the loop running in the Goroutine to terminate.

## QA steps

A test for this would involve repeatedly causing machine agents to soft bounce (restarting their worker graphs). Introspection of the agent's Goroutines would indicate that we are not accumulating them over time.

## Documentation changes

None.

## Bug reference

N/A
