### PR TITLE
Add support for changing operator image account.

### DIFF
--- a/tests/suites/caasadmission/task.sh
+++ b/tests/suites/caasadmission/task.sh
@@ -4,6 +4,10 @@ test_caasadmission() {
 		return
 	fi
 
+	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
+	fi
+
 	set_verbosity
 
 	case "${BOOTSTRAP_PROVIDER:-}" in


### PR DESCRIPTION
For caas admission tests you can change the operator image account used
now.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run the caas admission tests with OPERATOR_IMAGE_ACCOUNT set

