### PR TITLE
[JUJU-1041] Direct controller-worker to controller API proof-of-concept

### DIFF
--- a/api/controller/controllerapi/controllerapi.go
+++ b/api/controller/controllerapi/controllerapi.go
@@ -1,0 +1,106 @@
+package controllerapi
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
+
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker/common"
+	workerstate "github.com/juju/juju/worker/state"
+)
+
+type Logger interface {
+	Debugf(string, ...interface{})
+}
+
+type ManifoldConfig struct {
+	StateName string
+	Logger    Logger
+}
+
+func (config ManifoldConfig) Validate() error {
+	if config.StateName == "" {
+		return errors.NotValidf("empty StateName")
+	}
+	return nil
+}
+
+func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var stTracker workerstate.StateTracker
+	if err := context.Get(config.StateName, &stTracker); err != nil {
+		return nil, errors.Trace(err)
+	}
+	statePool, err := stTracker.Use()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w := &Worker{
+		state:  statePool.SystemState(),
+		logger: config.Logger,
+	}
+	config.Logger.Debugf("controllerapi worker initialized")
+	return common.NewCleanupWorker(w, func() {
+		_ = stTracker.Done()
+	}), nil
+}
+
+func (config ManifoldConfig) output(in worker.Worker, out interface{}) error {
+	inWorker, ok := in.(*Worker)
+	if !ok {
+		return errors.Errorf("expected *Worker, got %T", in)
+	}
+	switch result := out.(type) {
+	case **Worker:
+		*result = inWorker
+	default:
+		return errors.Errorf("expected **Worker, got %T", out)
+	}
+	return nil
+}
+
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.StateName,
+		},
+		Start:  config.start,
+		Output: config.output,
+	}
+}
+
+type State interface {
+	FindEntity(tag names.Tag) (state.Entity, error)
+}
+
+type Worker struct {
+	state  State
+	logger Logger
+}
+
+func (w *Worker) Life(tag names.Tag) (v life.Value, err error) {
+	w.logger.Debugf("controllerapi.Worker.Life start")
+	defer func() {
+		w.logger.Debugf("controllerapi.Worker.Life finish v=%v, err=%v", v, err)
+	}()
+	entity, err := w.state.FindEntity(tag)
+	if err != nil {
+		return "", err
+	}
+	lifer, ok := entity.(state.Lifer)
+	if !ok {
+		return "", errors.NotSupportedf("entity %q does not support life cycles", tag)
+	}
+	return life.Value(lifer.Life().String()), nil
+}
+
+func (w *Worker) Kill() {} // TODO
+
+func (w *Worker) Wait() error { return nil } // TODO

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1140,6 +1140,8 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewEnvironFunc:              newEnvirons,
 		NewContainerBrokerFunc:      newCAASBroker,
 		NewMigrationMaster:          migrationmaster.NewWorker,
+		OpenStatePool:               a.initState,
+		SetStatePool:                func(pool *state.StatePool) {}, // TODO?
 	}
 	if wrench.IsActive("charmrevision", "shortinterval") {
 		interval := 10 * time.Second


### PR DESCRIPTION
This adds a new controllerapi package (name not final) which is
intended for use in controller workers like caasapplicationprovisioner.
In this proof-of-concept I've only used it for the Life function, but
obviously other functions could be added in a similar way.

Note that all details, including package location and naming, are open
to debate. The important thing is the concept: being able to call
controller functions from controller workers directly, with these
advantages:

* No need to write client or server (facade) boilerplate functions.
* Function name and args are properly type checked by the Go compiler.
* No need for these controller-to-controller calls in the same process
  to be going over the network.

Also note that while this compiles, it doesn't work yet! I spent a
small amount of time debugging it, but didn't finish as I'm time-boxing
this PoC. I'm not sure why it's not working -- something's not getting
wired up correctly. But hopefully it shows the intent.
