### PR TITLE
Adds support for sidecard charm operator image.

### DIFF
--- a/tests/suites/sidecar/task.sh
+++ b/tests/suites/sidecar/task.sh
@@ -4,6 +4,10 @@ test_sidecar() {
 		return
 	fi
 
+	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
+	fi
+
 	set_verbosity
 
 	case "${BOOTSTRAP_PROVIDER:-}" in


### PR DESCRIPTION
To help aid in testing have introduced the OPERATOR_IMAGE_ACCOUNT ENV
variable to the sidecar charms so they use the correct operator image
during bootstrap.