### PR TITLE
[JUJU-1063] Update CK overlay because latest stable bundle renamed kubernetes-mas…

### DIFF
--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -15,12 +15,12 @@ run_deploy_ck() {
 		sudo snap install kubectl --classic --channel latest/stable
 	fi
 
-	wait_for "active" '.applications["kubernetes-master"] | ."application-status".current'
+	wait_for "active" '.applications["kubernetes-control-plane"] | ."application-status".current'
 	wait_for "active" '.applications["kubernetes-worker"] | ."application-status".current'
 
 	kube_home="${HOME}/.kube"
 	mkdir -p "${kube_home}"
-	juju scp kubernetes-master/0:config "${kube_home}/config"
+	juju scp kubernetes-control-plane/0:config "${kube_home}/config"
 
 	kubectl cluster-info
 	kubectl get ns

--- a/tests/suites/ck/overlay/aws.yaml
+++ b/tests/suites/ck/overlay/aws.yaml
@@ -4,9 +4,9 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/aws-integrator
+    charm: aws-integrator
     num_units: 1
     trust: true
 relations:
-  - ['aws-integrator', 'kubernetes-master']
+  - ['aws-integrator', 'kubernetes-control-plane']
   - ['aws-integrator', 'kubernetes-worker']

--- a/tests/suites/ck/overlay/azure.yaml
+++ b/tests/suites/ck/overlay/azure.yaml
@@ -4,27 +4,29 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/azure-integrator
+    charm: azure-integrator
     num_units: 1
     trust: true
   kubernetes-worker:
-    annotations:
-      gui-x: '90'
-      gui-y: '850'
-    charm: cs:~containers/kubernetes-worker-838
-    constraints: cores=2 mem=4G root-disk=16G
-    expose: true
-    num_units: 3
-    options:
-      channel: 1.23/stable
+    charm: kubernetes-worker
+    channel: stable
+    revision: 27
     resources:
-      cni-amd64: 983
-      cni-arm64: 974
-      cni-s390x: 986
-      core: 0
-      kube-proxy: 0
-      kubectl: 0
-      kubelet: 0
+      cni-amd64: 27
+      cni-arm64: 27
+      cni-s390x: 27
+      core: -1
+      kube-proxy: -1
+      kubectl: -1
+      kubelet: -1
+    num_units: 3
+    expose: true
+    options:
+      channel: 1.24/stable
+    annotations:
+      gui-x: "90"
+      gui-y: "850"
+    constraints: arch=amd64 cpu-cores=2 mem=4G root-disk=16G
 relations:
-  - ['azure-integrator', 'kubernetes-master:azure']
+  - ['azure-integrator', 'kubernetes-control-plane:azure']
   - ['azure-integrator', 'kubernetes-worker:azure']

--- a/tests/suites/ck/overlay/gce.yaml
+++ b/tests/suites/ck/overlay/gce.yaml
@@ -4,27 +4,29 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/gcp-integrator
+    charm: gcp-integrator
     num_units: 1
     trust: true
   kubernetes-worker:
-    annotations:
-      gui-x: '90'
-      gui-y: '850'
-    charm: cs:~containers/kubernetes-worker-838
-    constraints: cores=2 mem=4G root-disk=16G
-    expose: true
-    num_units: 3
-    options:
-      channel: 1.23/stable
+    charm: kubernetes-worker
+    channel: stable
+    revision: 27
     resources:
-      cni-amd64: 983
-      cni-arm64: 974
-      cni-s390x: 986
-      core: 0
-      kube-proxy: 0
-      kubectl: 0
-      kubelet: 0
+      cni-amd64: 27
+      cni-arm64: 27
+      cni-s390x: 27
+      core: -1
+      kube-proxy: -1
+      kubectl: -1
+      kubelet: -1
+    num_units: 3
+    expose: true
+    options:
+      channel: 1.24/stable
+    annotations:
+      gui-x: "90"
+      gui-y: "850"
+    constraints: arch=amd64 cpu-cores=2 mem=4G root-disk=16G
 relations:
-  - ['gcp-integrator', 'kubernetes-master']
+  - ['gcp-integrator', 'kubernetes-control-plane']
   - ['gcp-integrator', 'kubernetes-worker']


### PR DESCRIPTION
Update CK overlay because the latest stable bundle(`stable 1009` - published: 06 May 2022) renamed `kubernetes-master` to `kubernetes-control-plane`;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju deploy charmed-kubernetes --trust --overlay ./tests/suites/ck/overlay/aws.yaml
```

## Documentation changes

No

## Bug reference

No