### PR TITLE
[JUJU-1066] Improve error message on remove unit subordinate.

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1804,7 +1804,7 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 			return nil, errors.Trace(err)
 		}
 		if !unit.IsPrincipal() {
-			return nil, errors.Errorf("unit %q is a subordinate", name)
+			return nil, errors.Errorf("unit %q is a subordinate, to remove use remove-relation. Note: this will remove all units of %q", name, unit.ApplicationName())
 		}
 		var info params.DestroyUnitInfo
 		unitStorage, err := storagecommon.UnitStorage(api.storageAccess, unit.UnitTag())

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -2945,7 +2945,7 @@ func (s *applicationSuite) TestDestroySubordinateUnits(c *gc.C) {
 	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"logging/0"},
 	})
-	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate`)
+	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate, .*`)
 	assertLife(c, logging0, state.Alive)
 
 	s.assertDestroySubordinateUnits(c, wordpress0, logging0)
@@ -3062,7 +3062,7 @@ func (s *applicationSuite) assertDestroySubordinateUnits(c *gc.C, wordpress0, lo
 	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"wordpress/0", "logging/0"},
 	})
-	c.Assert(err, gc.ErrorMatches, `some units were not destroyed: unit "logging/0" is a subordinate`)
+	c.Assert(err, gc.ErrorMatches, `some units were not destroyed: unit "logging/0" is a subordinate, .*`)
 	assertLife(c, wordpress0, state.Dying)
 	assertLife(c, logging0, state.Alive)
 }
@@ -3158,7 +3158,7 @@ func (s *applicationSuite) TestBlockDestroyDestroySubordinateUnits(c *gc.C) {
 	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
 		UnitNames: []string{"logging/0"},
 	})
-	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate`)
+	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate, .*`)
 	assertLife(c, logging0, state.Alive)
 
 	s.assertDestroySubordinateUnits(c, wordpress0, logging0)


### PR DESCRIPTION
Add text regarding use of remove-relation to remove a subordinate. Will help new users especially know what to do and the limitations.

## QA steps

```sh
$ juju deploy ubuntu -n 3
$ juju deploy ntp
$ juju add-relation ntp ubuntu

# wait to settle
$ juju remove-unit ntp/2
removing unit ntp/2 failed: unit "ntp/2" is a subordinate, to remove use remove-relation. Note: this will remove all units of "ntp"
```

## Bug reference

https://discourse.charmhub.io/t/failed-removing-a-subordinate-unit/6338/3

