### PR TITLE
[JUJU-1067] prevent panic in show controller

### DIFF
--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -37,7 +37,9 @@ func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus
 	if err := c.facade.FacadeCall("ModelStatus", req, &result); err != nil {
 		return nil, err
 	}
-
+	if len(result.Results) != len(tags) {
+		return nil, errors.Errorf("%d results, expected %d", len(result.Results), len(tags))
+	}
 	return c.processModelStatusResults(result.Results)
 }
 

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -475,7 +475,13 @@ func (c *showControllerCommand) convertModelsForShow(
 	modelStatus []base.ModelStatus,
 ) {
 	controller.Models = make(map[string]ModelDetails)
+	if len(models) != len(modelStatus) {
+		controller.Errors = append(controller.Errors, "model status incomplete")
+	}
 	for i, m := range models {
+		if i >= len(modelStatus) {
+			continue
+		}
 		modelDetails := ModelDetails{ModelUUID: m.UUID, OldModelUUID: m.UUID}
 		result := modelStatus[i]
 		if result.Error != nil {


### PR DESCRIPTION

Prevent panic seen while doing trying to reproduce an issue seen:

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/juju/juju/cmd/juju/controller.(*showControllerCommand).convertModelsForShow(0xc000219440, {0xc000143390, 0x9\}
, 0xc000aadb48, \{0xc000c08cf0, 0x2, 0x16\}, \{0x0, 0x0, 0x0\})
        /home/heather/work/src/github.com/juju/juju/cmd/juju/controller/showcontroller.go:480 +0x659
```
## QA steps

Not entirely sure how to reproduce, seen a few times only.

```sh
$ juju show-controller
```
