### PR TITLE
[JUJU-1038] Update `model-config` to use `ConfigCommandBase`

### DIFF
--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -6,9 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
-	"regexp"
+	"io/ioutil"
 	"sort"
 	"strings"
 
@@ -16,32 +14,34 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/schema"
+	"github.com/juju/utils"
 	"gopkg.in/juju/environschema.v1"
+	"gopkg.in/yaml.v3"
 
 	"github.com/juju/juju/api/client/modelconfig"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/common"
+	"github.com/juju/juju/cmd/juju/config"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/environs/config"
+	envconfig "github.com/juju/juju/environs/config"
 )
 
 const (
 	modelConfigSummary        = "Displays or sets configuration values on a model."
 	modelConfigHelpDocPartOne = `
-By default, all configuration (keys, source, and values) for the current model
-are displayed.
+When called with no arguments, all configuration (keys, source, and values) for
+the current model are displayed.
 
-Supplying one key name returns only the value for the key. Supplying key=value
-will set the supplied key to the supplied value, this can be repeated for
-multiple keys. You can also specify a yaml file containing key values, that can
-be used for the input for the command.
+Supplying one key name returns only the value for the key. You can supply one
+or more key=value arguments to set the supplied keys to the supplied values.
+Alternatively, config values can be set from a yaml file using the --file flag.
 
 Model config yaml can be piped from stdin from the output of the command stdout.
-Some model-config configuration are read-only, to prevent the command exiting on
-read-only fields, setting "ignore-read-only-fields" will cause it to skip over
-the fields when they're encountered.
+Some model-config configuration are read-only; to prevent the command exiting on
+read-only fields, use the --ignore-read-only-fields flag, which will cause it to
+ignore these fields when they're encountered.
 
 The reset flag will set the provided key(s) to the model default for those key(s).
 Any key not in the default model config, will be deleted.
@@ -61,12 +61,8 @@ Print the model config of model mycontroller:mymodel:
 Set the value of ftp-proxy to 10.0.0.1:8000:
     juju model-config ftp-proxy=10.0.0.1:8000
 
-Set the value of ftp-proxy to 10.0.0.1:8000, and set the values defined in
-path/to/file.yaml:
-    juju model-config ftp-proxy=10.0.0.1:8000 path/to/file.yaml
-
-Set the model config key value pairs defined in a file:
-    juju model-config path/to/file.yaml
+Set the model config to key=value pairs defined in a file:
+    juju model-config --file path/to/file.yaml
 
 Set model config values of a specific model:
     juju model-config -m othercontroller:mymodel default-series=yakkety test-mode=false
@@ -82,9 +78,13 @@ See also:
 `
 )
 
+var modelConfigBase = config.ConfigCommandBase{
+	CantReset: []string{envconfig.AgentVersionKey, envconfig.CharmHubURLKey},
+}
+
 // NewConfigCommand wraps configCommand with sane model settings.
 func NewConfigCommand() cmd.Command {
-	return modelcmd.Wrap(&configCommand{})
+	return modelcmd.Wrap(&configCommand{configBase: modelConfigBase})
 }
 
 type configAttrs map[string]interface{}
@@ -166,15 +166,12 @@ func coerceResourceTags(resourceTags interface{}) (string, error) {
 // configCommand is the simplified command for accessing and setting
 // attributes related to model configuration.
 type configCommand struct {
-	api configCommandAPI
 	modelcmd.ModelCommandBase
-	out cmd.Output
+	configBase config.ConfigCommandBase
+	api        configCommandAPI
+	out        cmd.Output
 
-	action               func(configCommandAPI, *cmd.Context) error // The action which we want to handle, set in cmd.Init.
-	keys                 []string
-	reset                []string // Holds the keys to be reset until parsed.
-	resetKeys            []string // Holds the keys to be reset once parsed.
-	setOptions           common.ConfigFlag
+	// Extra `model-config`-specific fields
 	ignoreReadOnlyFields bool
 }
 
@@ -182,7 +179,7 @@ type configCommand struct {
 type configCommandAPI interface {
 	Close() error
 	ModelGet() (map[string]interface{}, error)
-	ModelGetWithMetadata() (config.ConfigValues, error)
+	ModelGetWithMetadata() (envconfig.ConfigValues, error)
 	ModelSet(config map[string]interface{}) error
 	ModelUnset(keys ...string) error
 }
@@ -213,147 +210,19 @@ func (c *configCommand) Info() *cmd.Info {
 // SetFlags implements part of the cmd.Command interface.
 func (c *configCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
+	c.configBase.SetFlags(f)
 
 	c.out.AddFlags(f, "tabular", map[string]cmd.Formatter{
 		"json":    cmd.FormatJson,
 		"tabular": formatConfigTabular,
 		"yaml":    cmd.FormatYaml,
 	})
-	f.Var(cmd.NewAppendStringsValue(&c.reset), "reset", "Reset the provided comma delimited keys, deletes keys not in the model config")
 	f.BoolVar(&c.ignoreReadOnlyFields, "ignore-read-only-fields", false, "Ignore read only fields that might cause errors to be emitted while processing yaml documents")
 }
 
 // Init implements part of the cmd.Command interface.
 func (c *configCommand) Init(args []string) error {
-	// If there are arguments provided to reset, we turn it into a slice of
-	// strings and verify them. If there is one or more valid keys to reset and
-	// no other errors initializing the command, c.resetDefaults will be called
-	// in c.Run.
-	if err := c.parseResetKeys(); err != nil {
-		return errors.Trace(err)
-	}
-
-	switch len(args) {
-	case 0:
-		return c.handleZeroArgs()
-	case 1:
-		return c.handleOneArg(args[0])
-	default:
-		return c.handleArgs(args)
-	}
-}
-
-// handleZeroArgs handles the case where there are no positional args.
-func (c *configCommand) handleZeroArgs() error {
-	// If reset is empty we're getting configuration
-	if len(c.reset) == 0 {
-		c.action = c.getConfig
-	}
-	// Otherwise we're going to reset args.
-	return nil
-}
-
-// handleOneArg handles the case where there is one positional arg.
-func (c *configCommand) handleOneArg(arg string) error {
-	if arg == "-" {
-		// If we can't read the stdin, then continue onwards to fall back to the
-		// previous logic.
-		if err := c.parseStdin(); err == nil {
-			return nil
-		}
-	}
-
-	// We may have a single config.yaml file
-	if isFileName(arg) {
-		return c.parseYAMLFile(arg)
-	} else if strings.Contains(arg, "=") {
-		return c.parseSetKeys([]string{arg})
-	}
-	// If we are not setting a value, then we are retrieving one so we need to
-	// make sure that we are not resetting because it is not valid to get and
-	// reset simultaneously.
-	if len(c.reset) > 0 {
-		return errors.New("cannot set and retrieve model values simultaneously")
-	}
-	c.keys = []string{arg}
-	c.action = c.getConfig
-	return ParseCert(arg)
-}
-
-// handleArgs handles the case where there's more than one positional arg.
-func (c *configCommand) handleArgs(args []string) error {
-	// Check all arguments are valid first
-	for _, arg := range args {
-		if !isFileName(arg) && !strings.Contains(arg, "=") {
-			return errors.Errorf("arg %q is not a key-value pair or a filename", arg)
-		}
-	}
-	if err := c.parseSetKeys(args); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}
-
-// parseStdin ensures that we handle stdin correctly.
-func (c *configCommand) parseStdin() error {
-	if err := c.setOptions.SetAttrsFromReader(os.Stdin); err != nil {
-		return errors.Trace(err)
-	}
-	c.action = c.setConfig
-	return nil
-}
-
-// isFileName tests if its argument `s` explicitly specifies a file (i.e. `s`
-// contains the path-separator character for this OS).
-func isFileName(s string) bool {
-	return strings.HasPrefix(s, ".") || filepath.IsAbs(s)
-}
-
-// parseYAMLFile ensures that we handle the YAML file passed in.
-func (c *configCommand) parseYAMLFile(file string) error {
-	if err := c.setOptions.Set(file); err != nil {
-		return errors.Trace(err)
-	}
-	c.action = c.setConfig
-	return nil
-}
-
-// parseSetKeys iterates over the args and make sure that the key=value pairs
-// are valid.
-func (c *configCommand) parseSetKeys(args []string) error {
-	for _, arg := range args {
-		if err := c.setOptions.Set(arg); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	c.action = c.setConfig
-	return nil
-}
-
-// parseResetKeys splits the keys provided to --reset after trimming any
-// leading or trailing comma. It then verifies that we haven't incorrectly
-// received any key=value pairs and finally sets the value(s) on c.resetKeys.
-func (c *configCommand) parseResetKeys() error {
-	if len(c.reset) == 0 {
-		return nil
-	}
-	var resetKeys []string
-	for _, value := range c.reset {
-		keys := strings.Split(strings.Trim(value, ","), ",")
-		resetKeys = append(resetKeys, keys...)
-	}
-
-	for _, k := range resetKeys {
-		if k == config.AgentVersionKey || k == config.CharmHubURLKey {
-			return errors.Errorf("%q cannot be reset", k)
-		}
-		if strings.Contains(k, "=") {
-			return errors.Errorf(
-				`--reset accepts a comma delimited set of keys "a,b,c", received: %q`, k)
-		}
-	}
-	c.resetKeys = resetKeys
-	return nil
+	return c.configBase.Init(args)
 }
 
 // getAPI returns the API. This allows passing in a test configCommandAPI
@@ -378,51 +247,82 @@ func (c *configCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	if len(c.resetKeys) > 0 {
-		err := c.resetConfig(client, ctx)
-		if err != nil {
-			// We return this error naked as it is almost certainly going to be
-			// cmd.ErrSilent and the cmd.Command framework expects that back
-			// from cmd.Run if the process is blocked.
-			return err
-		}
+	switch c.configBase.Actions[0] {
+	case config.GetOne:
+		return c.getConfig(client, ctx)
+	case config.Set:
+		return c.setConfig(client, ctx)
+	case config.SetFile:
+		return c.setConfigFile(client, ctx)
+	case config.Reset:
+		return c.resetConfig(client, ctx)
+	default:
+		return c.getAllConfig(client, ctx)
 	}
-	if c.action == nil {
-		// If we are reset only we end up here, only we've already done that.
-		return nil
-	}
-	return c.action(client, ctx)
 }
 
 // resetConfig unsets the keys provided to the command.
 func (c *configCommand) resetConfig(client configCommandAPI, ctx *cmd.Context) error {
 	// ctx unused in this method
-	if err := c.verifyKnownKeys(client, c.resetKeys); err != nil {
+	if err := c.verifyKnownKeys(client, c.configBase.KeysToReset); err != nil {
 		return errors.Trace(err)
 	}
 
-	return block.ProcessBlockedError(client.ModelUnset(c.resetKeys...), block.BlockChange)
+	return block.ProcessBlockedError(client.ModelUnset(c.configBase.KeysToReset...), block.BlockChange)
 }
 
 // setConfig sets the provided key/value pairs on the model.
 func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) error {
-	attrs, err := c.setOptions.ReadAttrs(ctx)
+	// Have to convert c.configBase.ValsToSet to a map[string]interface{}
+	// This could probably be done better with generics: we could change
+	// c.validateValues to accept a `map[string]V` for `V any`
+	attrs := make(map[string]interface{})
+	for key, value := range c.configBase.ValsToSet {
+		attrs[key] = value
+	}
+
+	return c.validateSet(client, attrs)
+}
+
+// setConfigFile sets the model configuration from the provided file.
+func (c *configCommand) setConfigFile(client configCommandAPI, ctx *cmd.Context) error {
+	// Read file & unmarshal into yaml
+	attrs := make(map[string]interface{})
+	path, err := utils.NormalizePath(c.configBase.ConfigFile.Path)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	var keys []string
+	data, err := ioutil.ReadFile(ctx.AbsPath(path))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := yaml.Unmarshal(data, &attrs); err != nil {
+		return errors.Trace(err)
+	}
+
+	return c.validateSet(client, attrs)
+}
+
+// validateSet checks the provided map for read-only keys, coerces the keys,
+// and then sets the model config.
+func (c *configCommand) validateSet(client configCommandAPI, rawAttrs map[string]interface{}) error {
+	var keys []string // collect and validate
+
+	// Sort through to catch read-only keys
 	values := make(configAttrs)
-	for k, v := range attrs {
-		if k == config.AgentVersionKey {
+	for k, v := range rawAttrs {
+		if k == envconfig.AgentVersionKey {
 			if c.ignoreReadOnlyFields {
 				continue
 			}
-			return errors.Errorf(`"agent-version" must be set via "upgrade-model"`)
-		} else if k == config.CharmHubURLKey {
+			return errors.Errorf(`%q must be set via "upgrade-model"`,
+				envconfig.AgentVersionKey)
+		} else if k == envconfig.CharmHubURLKey {
 			if c.ignoreReadOnlyFields {
 				continue
 			}
-			return errors.Errorf(`"charmhub-url" must be set via "add-model"`)
+			return errors.Errorf(`%q must be set via "add-model"`,
+				envconfig.CharmHubURLKey)
 		}
 
 		values[k] = v
@@ -434,13 +334,6 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 		return errors.Trace(err)
 	}
 
-	for _, k := range c.resetKeys {
-		if _, ok := coerced[k]; ok {
-			return errors.Errorf(
-				"key %q cannot be both set and reset in the same command", k)
-		}
-	}
-
 	if err := c.verifyKnownKeys(client, keys); err != nil {
 		return errors.Trace(err)
 	}
@@ -448,34 +341,60 @@ func (c *configCommand) setConfig(client configCommandAPI, ctx *cmd.Context) err
 	return block.ProcessBlockedError(client.ModelSet(coerced), block.BlockChange)
 }
 
-// get writes the value of a single key or the full output for the model to the cmd.Context.
+// getConfig writes the value of a single model config key to the cmd.Context.
 func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) error {
-	if len(c.keys) == 1 && certBytes != nil {
-		_, _ = ctx.Stdout.Write(certBytes)
-		return nil
-	}
+	// if certBytes != nil {
+	// 	_, _ = ctx.Stdout.Write(certBytes)
+	// 	return nil
+	// }
+
 	attrs, err := c.getFilteredModel(client)
 	if err != nil {
 		return err
 	}
-	attrs, err, finished := c.handleIsKeyOfModel(attrs, ctx)
-	if err != nil {
-		return err
-	} else if attrs != nil && finished {
-		return c.out.Write(ctx, attrs)
-	} else if len(c.keys) > 0 && !finished {
-		if isFileLike(c.keys[0]) {
-			return errors.Errorf("%q seems to be a file but not found", c.keys[0])
-		}
 
-		mod, _ := c.ModelIdentifier()
-		return errors.Errorf("%q seems to be neither a file nor a key of the currently targeted model: %q",
-			c.keys[0], mod)
+	if value, found := attrs[c.configBase.KeyToGet]; found {
+		if c.out.Name() == "tabular" {
+			// The user has not specified that they want
+			// YAML or JSON formatting, so we print out
+			// the value unadorned.
+			return c.out.WriteFormatter(ctx, cmd.FormatSmart, value.Value)
+		}
+		// Return value in JSON / YAML format
+		return c.out.Write(ctx, envconfig.ConfigValues{
+			c.configBase.KeyToGet: envconfig.ConfigValue{Source: value.Source, Value: value.Value},
+		})
 	}
-	return nil
+
+	// Key not found - error
+	mod, _ := c.ModelIdentifier()
+	return errors.Errorf("%q is not a key of the currently targeted model: %q",
+		c.configBase.KeyToGet, mod)
 }
 
-func (c *configCommand) getFilteredModel(client configCommandAPI) (config.ConfigValues, error) {
+// getAllConfig writes the full model config to the cmd.Context.
+func (c *configCommand) getAllConfig(client configCommandAPI, ctx *cmd.Context) error {
+	attrs, err := c.getFilteredModel(client)
+	if err != nil {
+		return err
+	}
+
+	// In tabular format, don't print "cloudinit-userdata" it can be very long,
+	// instead give instructions on how to print specifically.
+	if c.out.Name() == "tabular" {
+		if value, ok := attrs[envconfig.CloudInitUserDataKey]; ok {
+			if value.Value.(string) != "" {
+				value.Value = "<value set, see juju model-config cloudinit-userdata>"
+				attrs["cloudinit-userdata"] = value
+			}
+		}
+	}
+
+	return c.out.Write(ctx, attrs)
+}
+
+// getFilteredModel returns the model config with model attributes filtered out.
+func (c *configCommand) getFilteredModel(client configCommandAPI) (envconfig.ConfigValues, error) {
 	attrs, err := client.ModelGetWithMetadata()
 	if err != nil {
 		return nil, err
@@ -487,47 +406,6 @@ func (c *configCommand) getFilteredModel(client configCommandAPI) (config.Config
 		}
 	}
 	return attrs, nil
-}
-
-func isFileLike(fileLike string) bool {
-	r, _ := regexp.Compile("\\.[a-zA-Z]{0,4}$")
-	match := r.FindString(fileLike)
-	if strings.HasSuffix(match, ".") {
-		return false
-	}
-	if match == "" || match == " " {
-		return false
-	}
-	return true
-}
-
-func (c *configCommand) handleIsKeyOfModel(attrs config.ConfigValues, ctx *cmd.Context) (config.ConfigValues, error, bool) {
-	if len(c.keys) == 1 {
-		key := c.keys[0]
-		if value, found := attrs[key]; found {
-			if c.out.Name() == "tabular" {
-				// The user has not specified that they want
-				// YAML or JSON formatting, so we print out
-				// the value unadorned.
-				return nil, c.out.WriteFormatter(ctx, cmd.FormatSmart, value.Value), true
-			}
-			return config.ConfigValues{key: config.ConfigValue{Source: value.Source, Value: value.Value}}, nil, true
-		}
-
-		return attrs, nil, false
-	}
-
-	// In tabular format, don't print "cloudinit-userdata" it can be very long,
-	// instead give instructions on how to print specifically.
-	if value, ok := attrs[config.CloudInitUserDataKey]; ok && c.out.Name() == "tabular" {
-		if value.Value.(string) != "" {
-			value.Value = "<value set, see juju model-config cloudinit-userdata>"
-			attrs["cloudinit-userdata"] = value
-		}
-		return attrs, nil, true
-	}
-
-	return attrs, nil, true
 }
 
 // verifyKnownKeys is a helper to validate the keys we are operating with
@@ -554,7 +432,7 @@ func (c *configCommand) verifyKnownKeys(client configCommandAPI, keys []string) 
 // attribute.
 func isModelAttribute(attr string) bool {
 	switch attr {
-	case config.NameKey, config.TypeKey, config.UUIDKey:
+	case envconfig.NameKey, envconfig.TypeKey, envconfig.UUIDKey:
 		return true
 	}
 	return false
@@ -562,7 +440,7 @@ func isModelAttribute(attr string) bool {
 
 // formatConfigTabular writes a tabular summary of config information.
 func formatConfigTabular(writer io.Writer, value interface{}) error {
-	configValues, ok := value.(config.ConfigValues)
+	configValues, ok := value.(envconfig.ConfigValues)
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", configValues, value)
 	}
@@ -599,7 +477,7 @@ func formatConfigTabular(writer io.Writer, value interface{}) error {
 // ConfigDetails gets ModelDetails when a model is not available
 // to use.
 func ConfigDetails() (map[string]interface{}, error) {
-	defaultSchema, err := config.Schema(nil)
+	defaultSchema, err := envconfig.Schema(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +489,7 @@ func ConfigDetails() (map[string]interface{}, error) {
 		}
 		specifics[key] = common.PrintConfigSchema{
 			Description: attr.Description,
-			Type:        fmt.Sprintf("%s", attr.Type),
+			Type:        string(attr.Type),
 		}
 	}
 	return specifics, nil

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -18,7 +18,8 @@ import (
 // provided as specified.
 func NewConfigCommandForTest(api configCommandAPI) cmd.Command {
 	cmd := &configCommand{
-		api: api,
+		configBase: modelConfigBase,
+		api:        api,
 	}
 	cmd.SetClientStore(jujuclienttesting.MinimalStore())
 	return modelcmd.Wrap(cmd)


### PR DESCRIPTION
Continues work done in #13983.

There will be some behaviour changes:
- now you must specify a `--file` flag in order to set config from a file
- cannot perform multiple actions simultaneously

I've made a note [here](https://discourse.charmhub.io/t/how-to-configure-a-model/1151/5).