### PR TITLE
[JUJU-1083] Fix upgrade tests on 2.9

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -230,7 +230,7 @@ jobs:
 
         sg microk8s <<EOF
           juju bootstrap microk8s c \
-            --config caas-image-repo="https://${DOCKER_REGISTRY}/test-repo" \
+            --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
             --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
             --config features="[developer-mode]"
         EOF

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -380,3 +380,7 @@ jobs:
 
         sg microk8s "microk8s kubectl get all -A" || true
         lxc ls || true
+
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -240,12 +240,10 @@ jobs:
       run: |
         set -euxo pipefail
 
-        sg microk8s <<EOF
-          juju bootstrap microk8s c \
-            --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
-            --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
-            --config features="[developer-mode]"
-        EOF
+        juju bootstrap microk8s c \
+          --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
+          --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
+          --config features="[developer-mode]"
         juju add-model m
 
         juju status

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -180,7 +180,7 @@ jobs:
         sg microk8s "microk8s kubectl create -f .github/reg.yml"
 
         # TODO:(jack-w-shaw) Figure out why we need this and do something nicer
-        sudo microk8s refresh-certs
+        sudo microk8s refresh-certs --cert ca.crt
 
         # Wait for registry
         sg microk8s "microk8s kubectl wait --for condition=available deployment registry -n container-registry --timeout 180s" || true
@@ -210,13 +210,6 @@ jobs:
         docker tag jujusolutions/juju-db:${JUJU_DB_TAG} ${DOCKER_REGISTRY}/test-repo/juju-db:${JUJU_DB_TAG}
         docker push ${DOCKER_REGISTRY}/test-repo/juju-db:${JUJU_DB_TAG}
 
-    - name: Give microk8s permissions to user
-      shell: bash
-      run: |
-        sudo usermod -a -G microk8s $USER
-        sudo chown -f -R $USER ~/.kube
-        newgrp microk8s
-
     - name: Bootstrap Juju - localhost
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'localhost'
       shell: bash
@@ -240,10 +233,12 @@ jobs:
       run: |
         set -euxo pipefail
 
-        juju bootstrap microk8s c \
-          --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
-          --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
-          --config features="[developer-mode]"
+        sg microk8s <<EOF
+          juju bootstrap microk8s c \
+            --config caas-image-repo='{"repository": "${DOCKER_REGISTRY}/test-repo", "serveraddress": "https://${DOCKER_REGISTRY}/"}' \
+            --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
+            --config features="[developer-mode]"
+        EOF
         juju add-model m
 
         juju status

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -76,6 +76,11 @@ jobs:
 
     steps:
 
+    - run: sudo touch /continue
+
+    - name: Open SSH session
+      uses: mxschmitt/action-tmate@v3
+
     - name: PreCheck
       shell: bash
       run: |
@@ -204,6 +209,13 @@ jobs:
         docker pull jujusolutions/juju-db:${JUJU_DB_TAG}
         docker tag jujusolutions/juju-db:${JUJU_DB_TAG} ${DOCKER_REGISTRY}/test-repo/juju-db:${JUJU_DB_TAG}
         docker push ${DOCKER_REGISTRY}/test-repo/juju-db:${JUJU_DB_TAG}
+
+    - name: Give microk8s permissions to user
+      shell: bash
+      run: |
+        sudo usermod -a -G microk8s $USER
+        sudo chown -f -R $USER ~/.kube
+        newgrp microk8s
 
     - name: Bootstrap Juju - localhost
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'localhost'
@@ -381,6 +393,6 @@ jobs:
         sg microk8s "microk8s kubectl get all -A" || true
         lxc ls || true
 
-    - name: Setup tmate session
+    - name: Block so we can introspect failures
       if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
+      run: sleep infinity

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -393,4 +393,13 @@ jobs:
 
     - name: Block so we can introspect failures
       if: ${{ failure() }}
-      run: sleep infinity
+      run: |
+        echo "To end the workflow, cancel it, or run"
+        echo "    sudo touch /close"
+        echo "in the SSH session."
+        sudo stat /close &> /dev/null
+        while [ $? != 0 ]
+        do
+          sleep 5
+          sudo stat /close &> /dev/null
+        done

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -230,7 +230,7 @@ jobs:
 
         sg microk8s <<EOF
           juju bootstrap microk8s c \
-            --config caas-image-repo='{"repository": "${DOCKER_REGISTRY}/test-repo", "serveraddress": "https://${DOCKER_REGISTRY}/"}' \
+            --config caas-image-repo="'{\"repository\": \"${DOCKER_REGISTRY}/test-repo\", \"serveraddress\": \"https://${DOCKER_REGISTRY}/\"}'" \
             --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
             --config features="[developer-mode]"
         EOF

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -230,7 +230,7 @@ jobs:
 
         sg microk8s <<EOF
           juju bootstrap microk8s c \
-            --config caas-image-repo="'{\"repository\": \"${DOCKER_REGISTRY}/test-repo\", \"serveraddress\": \"https://${DOCKER_REGISTRY}/\"}'" \
+            --config caas-image-repo="https://${DOCKER_REGISTRY}/test-repo" \
             --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
             --config features="[developer-mode]"
         EOF

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -143,7 +143,7 @@ jobs:
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
       uses: balchua/microk8s-actions@v0.2.2
       with:
-        channel: "latest/stable"
+        channel: "1.23/stable"
         addons: '["dns", "storage"]'
 
     - name: Setup local caas registry
@@ -175,7 +175,7 @@ jobs:
         sg microk8s "microk8s kubectl create -f .github/reg.yml"
 
         # TODO:(jack-w-shaw) Figure out why we need this and do something nicer
-        sudo microk8s refresh-certs --cert ca.crt
+        sudo microk8s refresh-certs
 
         # Wait for registry
         sg microk8s "microk8s kubectl wait --for condition=available deployment registry -n container-registry --timeout 180s" || true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -64,12 +64,15 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        snap_version: ["latest/stable", "latest/beta"]
         model_type: ["localhost", "microk8s"]
     env:
       CHARM_localhost: apache2
       CHARM_microk8s: elasticsearch-k8s
       DOCKER_REGISTRY: 10.152.183.69:5000
+      # The old version of Juju we are testing upgrade from
+      # e.g. for 2.9 this is 2.8, for 3.0 this is 2.9
+      # Remember to change this when we increment the Juju version
+      JUJU_OLDV: 2.8/stable
 
     steps:
 
@@ -78,7 +81,7 @@ jobs:
       run: |
         set -ux
         set +e
-        OUT=$(snap info juju | grep -E "${{ matrix.snap_version }}:[[:space:]]+\^" || echo "NOT FOUND")
+        OUT=$(snap info juju | grep -E "$JUJU_OLDV:[[:space:]]+\^" || echo "NOT FOUND")
         set -e
         if [ "$OUT" = "NOT FOUND" ]; then
           echo "RUN_TEST=RUN" >> $GITHUB_ENV
@@ -92,7 +95,7 @@ jobs:
         sudo apt-get remove lxd lxd-client
         sudo snap install snapcraft --classic
         sudo snap install lxd
-        sudo snap install juju --classic --channel=${{ matrix.snap_version }}
+        sudo snap install juju --classic --channel=$JUJU_OLDV
 
         sudo lxd waitready
         sudo lxd init --auto
@@ -120,6 +123,21 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ steps.vars.outputs.go-version }}
+
+    # The `wait-for` plugin is used after deploying an application
+    # This was added in Juju 2.9, so it's not installed by the 2.8 snap
+    # However we just need to install the `wait-for` binary ourselves,
+    # and then Juju 2.8 can use it (amazing!)
+    - name: Add `wait-for` plugin
+      if: env.JUJU_OLDV == '2.8/stable'
+      shell: bash
+      run: |
+        # Download a stable version of Juju
+        curl -L -O https://github.com/juju/juju/archive/refs/tags/juju-2.9.29.tar.gz
+        tar -xf juju-2.9.29.tar.gz
+        cd juju-juju-2.9.29/
+        go install github.com/juju/juju/cmd/plugins/juju-wait-for
+        cd ..
 
     - name: Setup k8s
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'


### PR DESCRIPTION
After discussion with @wallyworld, we decided that it doesn't make sense for the Upgrade tests to run on latest/stable and latest/beta. We will now change these tests so that we try to upgrade from 2.8/stable (for 2.9).

Once this merges through to develop, I will change it there so that we try to upgrade from 2.9/stable.