### PR TITLE
[JUJU-1077] Drop ControllerConfigAPI from FirewallerAPI and remote relations API

### DIFF
--- a/apiserver/facades/controller/firewaller/firewaller.go
+++ b/apiserver/facades/controller/firewaller/firewaller.go
@@ -52,7 +52,6 @@ type FirewallerAPIV3 struct {
 // FirewallerAPIV4 provides access to the Firewaller v4 API facade.
 type FirewallerAPIV4 struct {
 	*FirewallerAPIV3
-	*common.ControllerConfigAPI
 }
 
 // FirewallerAPIV5 provides access to the Firewaller v5 API facade.

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	statetesting "github.com/juju/juju/state/testing"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type firewallerSuite struct {
@@ -183,8 +182,7 @@ func (s *firewallerSuite) TestAreManuallyProvisioned(c *gc.C) {
 
 	apiv5 := &firewaller.FirewallerAPIV5{
 		&firewaller.FirewallerAPIV4{
-			FirewallerAPIV3:     s.firewaller,
-			ControllerConfigAPI: common.NewControllerConfig(newMockState(coretesting.ModelTag.Id())),
+			FirewallerAPIV3: s.firewaller,
 		}}
 
 	result, err := apiv5.AreManuallyProvisioned(args)
@@ -210,8 +208,7 @@ func (s *firewallerSuite) TestGetExposeInfo(c *gc.C) {
 	apiv6 := &firewaller.FirewallerAPIV6{
 		&firewaller.FirewallerAPIV5{
 			&firewaller.FirewallerAPIV4{
-				FirewallerAPIV3:     s.firewaller,
-				ControllerConfigAPI: common.NewControllerConfig(newMockState(coretesting.ModelTag.Id())),
+				FirewallerAPIV3: s.firewaller,
 			},
 		},
 	}
@@ -240,8 +237,7 @@ func (s *firewallerSuite) TestWatchSubnets(c *gc.C) {
 	apiv6 := &firewaller.FirewallerAPIV6{
 		&firewaller.FirewallerAPIV5{
 			&firewaller.FirewallerAPIV4{
-				FirewallerAPIV3:     s.firewaller,
-				ControllerConfigAPI: common.NewControllerConfig(newMockState(coretesting.ModelTag.Id())),
+				FirewallerAPIV3: s.firewaller,
 			},
 		},
 	}

--- a/apiserver/facades/controller/firewaller/mock_test.go
+++ b/apiserver/facades/controller/firewaller/mock_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/common/firewall"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	corefirewall "github.com/juju/juju/core/network/firewall"
@@ -38,7 +37,6 @@ type mockState struct {
 	macaroons      map[names.Tag]*macaroon.Macaroon
 	relations      map[string]*mockRelation
 	machines       map[string]*mockMachine
-	controllerInfo map[string]*mockControllerInfo
 	firewallRules  map[corefirewall.WellKnownServiceType]*state.FirewallRule
 	subnetsWatcher *mockStringsWatcher
 	modelWatcher   *mockNotifyWatcher
@@ -55,7 +53,6 @@ func newMockState(modelUUID string) *mockState {
 		machines:       make(map[string]*mockMachine),
 		remoteEntities: make(map[names.Tag]string),
 		macaroons:      make(map[names.Tag]*macaroon.Macaroon),
-		controllerInfo: make(map[string]*mockControllerInfo),
 		firewallRules:  make(map[corefirewall.WellKnownServiceType]*state.FirewallRule),
 		subnetsWatcher: newMockStringsWatcher(),
 		modelWatcher:   newMockNotifyWatcher(),
@@ -71,18 +68,6 @@ func (st *mockState) WatchForModelConfigChanges() state.NotifyWatcher {
 
 func (st *mockState) ModelConfig() (*config.Config, error) {
 	return config.New(config.UseDefaults, st.configAttrs)
-}
-
-func (st *mockState) ControllerConfig() (controller.Config, error) {
-	return nil, errors.NotImplementedf("ControllerConfig")
-}
-
-func (st *mockState) ControllerInfo(modelUUID string) ([]string, string, error) {
-	if info, ok := st.controllerInfo[modelUUID]; !ok {
-		return nil, "", errors.NotFoundf("controller info for %v", modelUUID)
-	} else {
-		return info.ControllerInfo().Addrs, info.ControllerInfo().CACert, nil
-	}
 }
 
 func (st *mockState) GetMacaroon(entity names.Tag) (*macaroon.Macaroon, error) {

--- a/apiserver/facades/controller/firewaller/register.go
+++ b/apiserver/facades/controller/firewaller/register.go
@@ -59,8 +59,7 @@ func newStateFirewallerAPIV4(context facade.Context) (*FirewallerAPIV4, error) {
 		return nil, err
 	}
 	return &FirewallerAPIV4{
-		ControllerConfigAPI: common.NewStateControllerConfig(context.State()),
-		FirewallerAPIV3:     facadev3,
+		FirewallerAPIV3: facadev3,
 	}, nil
 }
 

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -15,7 +15,6 @@ import (
 
 	common "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/controller/remoterelations"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -33,7 +32,6 @@ type mockState struct {
 	remoteRelationsWatcher       *mockStringsWatcher
 	applicationRelationsWatchers map[string]*mockStringsWatcher
 	remoteEntities               map[names.Tag]string
-	controllerInfo               map[string]*mockControllerInfo
 }
 
 func newMockState() *mockState {
@@ -45,19 +43,6 @@ func newMockState() *mockState {
 		remoteRelationsWatcher:       newMockStringsWatcher(),
 		applicationRelationsWatchers: make(map[string]*mockStringsWatcher),
 		remoteEntities:               make(map[names.Tag]string),
-		controllerInfo:               make(map[string]*mockControllerInfo),
-	}
-}
-
-func (st *mockState) ControllerConfig() (controller.Config, error) {
-	return nil, errors.NotImplementedf("ControllerConfig")
-}
-
-func (st *mockState) ControllerInfo(modelUUID string) ([]string, string, error) {
-	if info, ok := st.controllerInfo[modelUUID]; !ok {
-		return nil, "", errors.NotFoundf("controller info for %v", modelUUID)
-	} else {
-		return info.ControllerInfo().Addrs, info.ControllerInfo().CACert, nil
 	}
 }
 

--- a/apiserver/facades/controller/remoterelations/register.go
+++ b/apiserver/facades/controller/remoterelations/register.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/apiserver/common"
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facade"
 )
@@ -36,7 +35,6 @@ func newAPIv1(ctx facade.Context) (*APIv1, error) {
 func newAPI(ctx facade.Context) (*API, error) {
 	return NewRemoteRelationsAPI(
 		stateShim{st: ctx.State(), Backend: commoncrossmodel.GetBackend(ctx.State())},
-		common.NewStateControllerConfig(ctx.StatePool().SystemState()),
 		ctx.Resources(), ctx.Auth(),
 	)
 }

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -25,7 +25,6 @@ type APIv1 struct {
 
 // API provides access to the remote relations API facade.
 type API struct {
-	*common.ControllerConfigAPI
 	st         RemoteRelationsState
 	resources  facade.Resources
 	authorizer facade.Authorizer
@@ -34,7 +33,6 @@ type API struct {
 // NewRemoteRelationsAPI returns a new server-side API facade.
 func NewRemoteRelationsAPI(
 	st RemoteRelationsState,
-	controllerCfgAPI *common.ControllerConfigAPI,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 ) (*API, error) {
@@ -42,10 +40,9 @@ func NewRemoteRelationsAPI(
 		return nil, apiservererrors.ErrPerm
 	}
 	return &API{
-		st:                  st,
-		ControllerConfigAPI: controllerCfgAPI,
-		resources:           resources,
-		authorizer:          authorizer,
+		st:         st,
+		resources:  resources,
+		authorizer: authorizer,
 	}, nil
 }
 

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -48,7 +48,7 @@ func (s *remoteRelationsSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState()
-	api, err := remoterelations.NewRemoteRelationsAPI(s.st, common.NewControllerConfig(s.st), s.resources, s.authorizer)
+	api, err := remoterelations.NewRemoteRelationsAPI(s.st, s.resources, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 	s.api = api
 }
@@ -493,26 +493,6 @@ func (s *remoteRelationsSuite) TestConsumeRemoteRelationChange(c *gc.C) {
 		{"KeyRelation", []interface{}{"db2:db django:db"}},
 		{"GetRemoteEntity", []interface{}{"app-token"}},
 	})
-}
-
-func (s *remoteRelationsSuite) TestControllerAPIInfoForModels(c *gc.C) {
-	controllerInfo := &mockControllerInfo{
-		uuid: "some uuid",
-		info: crossmodel.ControllerInfo{
-			Addrs:  []string{"1.2.3.4/32"},
-			CACert: coretesting.CACert,
-		},
-	}
-	s.st.controllerInfo[coretesting.ModelTag.Id()] = controllerInfo
-	result, err := s.api.ControllerAPIInfoForModels(
-		params.Entities{Entities: []params.Entity{{
-			Tag: coretesting.ModelTag.String(),
-		}}})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Results, gc.HasLen, 1)
-	c.Assert(result.Results[0].Addresses, jc.SameContents, []string{"1.2.3.4/32"})
-	c.Assert(result.Results[0].Error, gc.IsNil)
-	c.Assert(result.Results[0].CACert, gc.Equals, coretesting.CACert)
 }
 
 func (s *remoteRelationsSuite) TestSetRemoteApplicationsStatus(c *gc.C) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -23768,27 +23768,6 @@
                     },
                     "description": "CloudSpec returns the model's cloud spec."
                 },
-                "ControllerAPIInfoForModels": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ControllerAPIInfoResults"
-                        }
-                    },
-                    "description": "ControllerAPIInfoForModels returns the controller api connection details for the specified models."
-                },
-                "ControllerConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/ControllerConfigResult"
-                        }
-                    },
-                    "description": "ControllerConfig returns the controller's configuration."
-                },
                 "FirewallRules": {
                     "type": "object",
                     "properties": {
@@ -24153,61 +24132,6 @@
                         }
                     },
                     "additionalProperties": false
-                },
-                "ControllerAPIInfoResult": {
-                    "type": "object",
-                    "properties": {
-                        "addresses": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "cacert": {
-                            "type": "string"
-                        },
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "addresses",
-                        "cacert"
-                    ]
-                },
-                "ControllerAPIInfoResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ControllerAPIInfoResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
-                    ]
-                },
-                "ControllerConfigResult": {
-                    "type": "object",
-                    "properties": {
-                        "config": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "config"
-                    ]
                 },
                 "Entities": {
                     "type": "object",

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38336,27 +38336,6 @@
                     },
                     "description": "ConsumeRemoteRelationChanges consumes changes to settings originating\nfrom the remote/offering side of relations."
                 },
-                "ControllerAPIInfoForModels": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ControllerAPIInfoResults"
-                        }
-                    },
-                    "description": "ControllerAPIInfoForModels returns the controller api connection details for the specified models."
-                },
-                "ControllerConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/ControllerConfigResult"
-                        }
-                    },
-                    "description": "ControllerConfig returns the controller's configuration."
-                },
                 "ExportEntities": {
                     "type": "object",
                     "properties": {
@@ -38497,61 +38476,6 @@
                 }
             },
             "definitions": {
-                "ControllerAPIInfoResult": {
-                    "type": "object",
-                    "properties": {
-                        "addresses": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "cacert": {
-                            "type": "string"
-                        },
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "addresses",
-                        "cacert"
-                    ]
-                },
-                "ControllerAPIInfoResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ControllerAPIInfoResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
-                    ]
-                },
-                "ControllerConfigResult": {
-                    "type": "object",
-                    "properties": {
-                        "config": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "config"
-                    ]
-                },
                 "Entities": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
It turns out this API is not used, so can safely be removed

Do-not-merge has been set until I am confident this doesn't lead to any regressions

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Uncertain how this can be QAed other than
```
make static-analysis
go test github.com/juju/juju/apiserver/facades/controller/firewaller
```

## Documentation changes

N/A

## Bug reference

In a round-about way, this PR is connected to:
https://bugs.launchpad.net/juju/+bug/1971600
