### PR TITLE
[JUJU-1082] Fix inst filtering to avoid arch mismatches

### DIFF
--- a/apiserver/common/instancetypes.go
+++ b/apiserver/common/instancetypes.go
@@ -22,13 +22,15 @@ func toParamsInstanceTypeResult(itypes []instances.InstanceType) []params.Instan
 		}
 		result[i] = params.InstanceType{
 			Name:         t.Name,
-			Arches:       t.Arches,
 			CPUCores:     int(t.CpuCores),
 			Memory:       int(t.Mem),
 			RootDiskSize: int(t.RootDisk),
 			VirtType:     virtType,
 			Deprecated:   t.Deprecated,
 			Cost:         int(t.Cost),
+		}
+		if t.Arch != "" {
+			result[i].Arches = []string{t.Arch}
 		}
 	}
 	return result

--- a/container/broker/broker.go
+++ b/container/broker/broker.go
@@ -159,9 +159,10 @@ func matchHostArchTools(allTools coretools.List) (coretools.List, error) {
 	arch := arch.HostArch()
 	archTools, err := allTools.Match(coretools.Filter{Arch: arch})
 	if err == coretools.ErrNoMatches {
+		agentArch, _ := allTools.OneArch()
 		return nil, errors.Errorf(
 			"need agent binaries for arch %s, only found %s",
-			arch, allTools.Arches(),
+			arch, agentArch,
 		)
 	} else if err != nil {
 		return nil, errors.Trace(err)

--- a/container/broker/lxd-broker_test.go
+++ b/container/broker/lxd-broker_test.go
@@ -103,7 +103,9 @@ func (s *lxdBrokerSuite) TestStartInstanceWithoutHostNetworkChanges(c *gc.C) {
 	c.Assert(call.Args[0], gc.FitsTypeOf, &instancecfg.InstanceConfig{})
 	instanceConfig := call.Args[0].(*instancecfg.InstanceConfig)
 	c.Assert(instanceConfig.ToolsList(), gc.HasLen, 1)
-	c.Assert(instanceConfig.ToolsList().Arches(), jc.DeepEquals, []string{"amd64"})
+	arch, err := instanceConfig.ToolsList().OneArch()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(arch, gc.Equals, "amd64")
 }
 
 func (s *lxdBrokerSuite) TestStartInstancePopulatesFallbackNetworkInfo(c *gc.C) {
@@ -133,7 +135,7 @@ func (s *lxdBrokerSuite) TestStartInstanceNoHostArchTools(c *gc.C) {
 		}},
 		InstanceConfig: makeInstanceConfig(c, s, "1/lxd/0"),
 	})
-	c.Assert(err, gc.ErrorMatches, `need agent binaries for arch amd64, only found \[arm64\]`)
+	c.Assert(err, gc.ErrorMatches, `need agent binaries for arch amd64, only found arm64`)
 }
 
 func (s *lxdBrokerSuite) TestStartInstanceWithCloudInitUserData(c *gc.C) {

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -447,7 +447,7 @@ func bootstrapIAAS(
 	} else {
 		// If no arch is specified as a constraint and we couldn't
 		// auto-discover the arch from the provider, we'll fall back
-		// to bootstrapping on on the same arch as the CLI client.
+		// to bootstrapping on the same arch as the CLI client.
 		bootstrapArch = localToolsArch()
 
 		// We no longer support controllers on i386. If we are

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1646,8 +1646,9 @@ func (e *bootstrapEnviron) Bootstrap(ctx environs.BootstrapContext, callCtx envc
 	if args.BootstrapSeries != "" {
 		series = args.BootstrapSeries
 	}
+	arch, _ := args.AvailableTools.OneArch()
 	return &environs.BootstrapResult{
-		Arch:                    args.AvailableTools.Arches()[0],
+		Arch:                    arch,
 		Series:                  series,
 		CloudBootstrapFinalizer: finalizer,
 	}, nil

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -90,10 +90,10 @@ var jsonImagesContent = `
        }
      }
    },
-   "com.ubuntu.cloud:server:12.04:armhf": {
+   "com.ubuntu.cloud:server:12.04:arm64": {
      "release": "precise",
      "version": "12.04",
-     "arch": "armhf",
+     "arch": "arm64",
      "versions": {
        "20121218": {
          "items": {
@@ -116,7 +116,7 @@ var jsonImagesContent = `
              "id": "ami-00000036"
            }
          },
-         "pubname": "ubuntu-precise-12.04-armhf-server-20121218",
+         "pubname": "ubuntu-precise-12.04-arm64-server-20121218",
          "label": "release"
        }
      }
@@ -204,7 +204,7 @@ var jsonImagesContent = `
 type instanceSpecTestParams struct {
 	desc             string
 	region           string
-	arches           []string
+	arch             string
 	stream           string
 	constraints      string
 	instanceTypes    []InstanceType
@@ -215,11 +215,11 @@ type instanceSpecTestParams struct {
 }
 
 func (p *instanceSpecTestParams) init() {
-	if p.arches == nil {
-		p.arches = []string{"amd64", "armhf"}
+	if p.arch == "" {
+		p.arch = "amd64"
 	}
 	if p.instanceTypes == nil {
-		p.instanceTypes = []InstanceType{{Id: "1", Name: "it-1", Arches: []string{"amd64", "armhf"}}}
+		p.instanceTypes = []InstanceType{{Id: "1", Name: "it-1", Arch: "amd64"}}
 		p.instanceTypeId = "1"
 		p.instanceTypeName = "it-1"
 	}
@@ -232,43 +232,7 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 		region:  "test",
 		imageId: "ami-00000033",
 		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, VirtType: &pv, Mem: 512},
-		},
-	},
-	{
-		desc:    "prefer amd64 over i386",
-		region:  "test",
-		imageId: "ami-00000033",
-		arches:  []string{"amd64", "i386"},
-		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"i386", "amd64"}, VirtType: &pv, Mem: 512},
-		},
-	},
-	{
-		desc:    "prefer armhf over i386 (first alphabetical wins)",
-		region:  "test",
-		imageId: "ami-00000034",
-		arches:  []string{"armhf", "i386"},
-		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"armhf", "i386"}, VirtType: &pv, Mem: 512},
-		},
-	},
-	{
-		desc:    "prefer ppc64el over i386 (64-bit trumps 32-bit, regardless of alphabetical order)",
-		region:  "test",
-		imageId: "ami-b79b09b9",
-		arches:  []string{"ppc64el", "i386"},
-		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"i386", "ppc64el"}, VirtType: &pv, Mem: 512},
-		},
-	},
-	{
-		desc:    "prefer amd64 over arm64 (first 64-bit alphabetical wins)",
-		region:  "test",
-		imageId: "ami-00000033",
-		arches:  []string{"arm64", "amd64"},
-		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"arm64", "amd64"}, VirtType: &pv, Mem: 512},
+			{Id: "1", Name: "it-1", Arch: "amd64", VirtType: &pv, Mem: 512},
 		},
 	},
 	{
@@ -277,7 +241,7 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 		stream:  "released",
 		imageId: "ami-00000035",
 		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, VirtType: &hvm, Mem: 512, CpuCores: 2},
+			{Id: "1", Name: "it-1", Arch: "amd64", VirtType: &hvm, Mem: 512, CpuCores: 2},
 		},
 	},
 	{
@@ -286,7 +250,7 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 		stream:  "daily",
 		imageId: "ami-10000035",
 		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, VirtType: &hvm, Mem: 512, CpuCores: 2},
+			{Id: "1", Name: "it-1", Arch: "amd64", VirtType: &hvm, Mem: 512, CpuCores: 2},
 		},
 	},
 	{
@@ -294,7 +258,7 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 		region:  "test",
 		imageId: "ami-00000035",
 		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, VirtType: &hvm, Mem: 512, CpuCores: 2},
+			{Id: "1", Name: "it-1", Arch: "amd64", VirtType: &hvm, Mem: 512, CpuCores: 2},
 		},
 	},
 	{
@@ -303,7 +267,7 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 		constraints: "instance-type=",
 		imageId:     "ami-00000033",
 		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, VirtType: &pv, Mem: 512},
+			{Id: "1", Name: "it-1", Arch: "amd64", VirtType: &pv, Mem: 512},
 		},
 	},
 	{
@@ -312,8 +276,18 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 		constraints: "instance-type=it-1",
 		imageId:     "ami-00000035",
 		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, VirtType: &hvm, Mem: 512, CpuCores: 2},
-			{Id: "2", Name: "it-2", Arches: []string{"amd64"}, VirtType: &hvm, Mem: 1024, CpuCores: 2},
+			{Id: "1", Name: "it-1", Arch: "amd64", VirtType: &hvm, Mem: 512, CpuCores: 2},
+			{Id: "2", Name: "it-2", Arch: "amd64", VirtType: &hvm, Mem: 1024, CpuCores: 2},
+		},
+	},
+	{
+		desc:    "use instance type non amd64 constraint",
+		region:  "test",
+		arch:    "ppc64el",
+		imageId: "ami-b79b09b9",
+		instanceTypes: []InstanceType{
+			{Id: "1", Name: "it-1", Arch: "amd64", VirtType: &pv, Mem: 4096, CpuCores: 2, Cost: 1},
+			{Id: "2", Name: "it-2", Arch: "ppc64el", VirtType: &pv, Mem: 4096, CpuCores: 2, Cost: 2},
 		},
 	},
 	{
@@ -321,25 +295,25 @@ var findInstanceSpecTests = []instanceSpecTestParams{
 		region:      "test",
 		constraints: "instance-type=it-10",
 		instanceTypes: []InstanceType{
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, VirtType: &hvm, Mem: 512, CpuCores: 2},
+			{Id: "1", Name: "it-1", Arch: "amd64", VirtType: &hvm, Mem: 512, CpuCores: 2},
 		},
-		err: `no instance types in test matching constraints "instance-type=it-10"`,
+		err: `no instance types in test matching constraints "arch=amd64 instance-type=it-10"`,
 	},
 	{
 		desc:   "no image exists in metadata",
 		region: "invalid-region",
-		err:    `no metadata for "precise" images in invalid-region with arches \[amd64 armhf\]`,
+		err:    `no metadata for "precise" images in invalid-region with arch amd64`,
 	},
 	{
 		desc:          "no valid instance types",
 		region:        "test",
 		instanceTypes: []InstanceType{},
-		err:           `no instance types in test matching constraints ""`,
+		err:           `no instance types in test matching constraints "arch=amd64"`,
 	},
 	{
 		desc:          "no compatible instance types",
 		region:        "arm-only",
-		instanceTypes: []InstanceType{{Id: "1", Name: "it-1", Arches: []string{"amd64"}, Mem: 2048}},
+		instanceTypes: []InstanceType{{Id: "1", Name: "it-1", Arch: "amd64", Mem: 2048}},
 		err:           `no "precise" images in arm-only matching instance types \[it-1\]`,
 	},
 }
@@ -351,7 +325,6 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 		cons, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 			CloudSpec: simplestreams.CloudSpec{t.region, "ep"},
 			Releases:  []string{"precise"},
-			Arches:    t.arches,
 			Stream:    t.stream,
 		})
 		c.Assert(err, jc.ErrorIsNil)
@@ -376,7 +349,7 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 		spec, err := FindInstanceSpec(images, &InstanceConstraint{
 			Series:      "precise",
 			Region:      t.region,
-			Arches:      t.arches,
+			Arch:        t.arch,
 			Constraints: imageCons,
 		}, t.instanceTypes)
 		if t.err != "" {
@@ -404,30 +377,30 @@ var imageMatchtests = []struct {
 }{
 	{
 		image: Image{Arch: "amd64"},
-		itype: InstanceType{Arches: []string{"amd64"}},
+		itype: InstanceType{Arch: "amd64"},
 		match: exactMatch,
 	}, {
 		image: Image{Arch: "amd64"},
-		itype: InstanceType{Arches: []string{"amd64", "armhf"}},
+		itype: InstanceType{Arch: "amd64"},
 		match: exactMatch,
 	}, {
 		image: Image{Arch: "amd64", VirtType: hvm},
-		itype: InstanceType{Arches: []string{"amd64"}, VirtType: &hvm},
+		itype: InstanceType{Arch: "amd64", VirtType: &hvm},
 		match: exactMatch,
 	}, {
-		image: Image{Arch: "armhf"},
-		itype: InstanceType{Arches: []string{"amd64"}},
+		image: Image{Arch: "arm64"},
+		itype: InstanceType{Arch: "amd64"},
 	}, {
 		image: Image{Arch: "amd64", VirtType: hvm},
-		itype: InstanceType{Arches: []string{"amd64"}},
+		itype: InstanceType{Arch: "amd64"},
 		match: exactMatch,
 	}, {
 		image: Image{Arch: "amd64"}, // no known virt type
-		itype: InstanceType{Arches: []string{"amd64"}, VirtType: &hvm},
+		itype: InstanceType{Arch: "amd64", VirtType: &hvm},
 		match: partialMatch,
 	}, {
 		image: Image{Arch: "amd64", VirtType: "pv"},
-		itype: InstanceType{Arches: []string{"amd64"}, VirtType: &hvm},
+		itype: InstanceType{Arch: "amd64", VirtType: &hvm},
 		match: nonMatch,
 	},
 }
@@ -484,15 +457,15 @@ func (*imageSuite) TestInstanceConstraintString(c *gc.C) {
 	ic := &InstanceConstraint{
 		Series:      "precise",
 		Region:      "region",
-		Arches:      []string{"amd64", "arm64"},
+		Arch:        "amd64",
 		Constraints: imageCons,
 	}
 	c.Assert(
 		ic.String(), gc.Equals,
-		"{region: region, series: precise, arches: [amd64 arm64], constraints: mem=4096M, storage: []}")
+		"{region: region, series: precise, arch: amd64, constraints: mem=4096M, storage: []}")
 
 	ic.Storage = []string{"ebs", "ssd"}
 	c.Assert(
 		ic.String(), gc.Equals,
-		"{region: region, series: precise, arches: [amd64 arm64], constraints: mem=4096M, storage: [ebs ssd]}")
+		"{region: region, series: precise, arch: amd64, constraints: mem=4096M, storage: [ebs ssd]}")
 }

--- a/environs/instances/instancetype.go
+++ b/environs/instances/instancetype.go
@@ -15,7 +15,7 @@ import (
 type InstanceType struct {
 	Id       string
 	Name     string
-	Arches   []string
+	Arch     string
 	CpuCores uint64
 	Mem      uint64
 	Cost     uint64
@@ -51,16 +51,13 @@ func CpuPower(power uint64) *uint64 {
 // constraints filtered out.
 func (itype InstanceType) match(cons constraints.Value) (InstanceType, bool) {
 	nothing := InstanceType{}
-	if cons.Arch != nil {
-		itype.Arches = filterArches(itype.Arches, []string{*cons.Arch})
+	if cons.HasArch() && *cons.Arch != itype.Arch {
+		return nothing, false
 	}
 	if itype.Deprecated && !cons.HasInstanceType() {
 		return nothing, false
 	}
 	if cons.HasInstanceType() && itype.Name != *cons.InstanceType {
-		return nothing, false
-	}
-	if len(itype.Arches) == 0 {
 		return nothing, false
 	}
 	if cons.CpuCores != nil && itype.CpuCores < *cons.CpuCores {
@@ -82,19 +79,6 @@ func (itype InstanceType) match(cons constraints.Value) (InstanceType, bool) {
 		return nothing, false
 	}
 	return itype, true
-}
-
-// filterArches returns every element of src that also exists in filter.
-func filterArches(src, filter []string) (dst []string) {
-	for _, arch := range src {
-		for _, match := range filter {
-			if arch == match {
-				dst = append(dst, arch)
-				break
-			}
-		}
-	}
-	return dst
 }
 
 // minMemoryHeuristic is the assumed minimum amount of memory (in MB) we prefer in order to run a server (1GB)

--- a/environs/instances/instancetype_test.go
+++ b/environs/instances/instancetype_test.go
@@ -26,7 +26,7 @@ var hvm = "hvm"
 var instanceTypes = []InstanceType{
 	{
 		Name:     "m1.small",
-		Arches:   []string{"amd64", "armhf"},
+		Arch:     "amd64",
 		CpuCores: 1,
 		CpuPower: CpuPower(100),
 		Mem:      1740,
@@ -34,7 +34,7 @@ var instanceTypes = []InstanceType{
 		RootDisk: 8192,
 	}, {
 		Name:     "m1.medium",
-		Arches:   []string{"amd64", "armhf"},
+		Arch:     "amd64",
 		CpuCores: 1,
 		CpuPower: CpuPower(200),
 		Mem:      3840,
@@ -42,7 +42,7 @@ var instanceTypes = []InstanceType{
 		RootDisk: 16384,
 	}, {
 		Name:     "m1.large",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		CpuCores: 2,
 		CpuPower: CpuPower(400),
 		Mem:      7680,
@@ -50,40 +50,45 @@ var instanceTypes = []InstanceType{
 		RootDisk: 32768,
 	}, {
 		Name:     "m1.xlarge",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		CpuCores: 4,
 		CpuPower: CpuPower(800),
 		Mem:      15360,
 		Cost:     480,
-	},
-	{
+	}, {
 		Name:     "t1.micro",
-		Arches:   []string{"amd64", "armhf"},
+		Arch:     "amd64",
 		CpuCores: 1,
 		CpuPower: CpuPower(20),
 		Mem:      613,
 		Cost:     20,
 		RootDisk: 4096,
-	},
-	{
+	}, {
 		Name:     "c1.medium",
-		Arches:   []string{"amd64", "armhf"},
+		Arch:     "amd64",
 		CpuCores: 2,
 		CpuPower: CpuPower(500),
 		Mem:      1740,
 		Cost:     145,
 		RootDisk: 8192,
 	}, {
+		Name:     "c1.large",
+		Arch:     "arm64",
+		CpuCores: 2,
+		CpuPower: CpuPower(500),
+		Mem:      3264,
+		Cost:     520,
+		RootDisk: 8192,
+	}, {
 		Name:     "c1.xlarge",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		CpuCores: 8,
 		CpuPower: CpuPower(2000),
 		Mem:      7168,
 		Cost:     580,
-	},
-	{
+	}, {
 		Name:     "cc1.4xlarge",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		CpuCores: 8,
 		CpuPower: CpuPower(3350),
 		Mem:      23552,
@@ -91,7 +96,7 @@ var instanceTypes = []InstanceType{
 		VirtType: &hvm,
 	}, {
 		Name:     "cc2.8xlarge",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		CpuCores: 16,
 		CpuPower: CpuPower(8800),
 		Mem:      61952,
@@ -99,7 +104,7 @@ var instanceTypes = []InstanceType{
 		VirtType: &hvm,
 	}, {
 		Name:       "dep.small",
-		Arches:     []string{"amd64"},
+		Arch:       "amd64",
 		CpuCores:   1,
 		CpuPower:   CpuPower(100),
 		Mem:        1740,
@@ -107,7 +112,7 @@ var instanceTypes = []InstanceType{
 		Deprecated: true,
 	}, {
 		Name:       "dep.medium",
-		Arches:     []string{"amd64"},
+		Arch:       "amd64",
 		CpuCores:   2,
 		CpuPower:   CpuPower(200),
 		Mem:        4096,
@@ -121,13 +126,13 @@ var getInstanceTypesTest = []struct {
 	cons           string
 	itypesToUse    []InstanceType
 	expectedItypes []string
-	arches         []string
+	arch           string
 }{
 	{
 		about: "cores",
 		cons:  "cores=2",
 		expectedItypes: []string{
-			"c1.medium", "m1.large", "m1.xlarge", "c1.xlarge", "cc1.4xlarge",
+			"c1.medium", "m1.large", "m1.xlarge", "c1.large", "c1.xlarge", "cc1.4xlarge",
 			"cc2.8xlarge",
 		},
 	}, {
@@ -148,19 +153,19 @@ var getInstanceTypesTest = []struct {
 		},
 	}, {
 		about:          "arches filtered by constraint",
-		cons:           "cpu-power=100 arch=armhf",
-		expectedItypes: []string{"m1.small", "m1.medium", "c1.medium"},
-		arches:         []string{"armhf"},
+		cons:           "cpu-power=100 arch=arm64",
+		expectedItypes: []string{"c1.large"},
+		arch:           "arm64",
 	},
 	{
 		about: "enough memory for mongodb if mem not specified",
 		cons:  "cores=4",
 		itypesToUse: []InstanceType{
-			{Id: "5", Name: "it-5", Arches: []string{"amd64"}, Mem: 1024, CpuCores: 2},
-			{Id: "4", Name: "it-4", Arches: []string{"amd64"}, Mem: 2048, CpuCores: 4},
-			{Id: "3", Name: "it-3", Arches: []string{"amd64"}, Mem: 1024, CpuCores: 4},
-			{Id: "2", Name: "it-2", Arches: []string{"amd64"}, Mem: 256, CpuCores: 4},
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, Mem: 512, CpuCores: 4},
+			{Id: "5", Name: "it-5", Arch: "amd64", Mem: 1024, CpuCores: 2},
+			{Id: "4", Name: "it-4", Arch: "amd64", Mem: 2048, CpuCores: 4},
+			{Id: "3", Name: "it-3", Arch: "amd64", Mem: 1024, CpuCores: 4},
+			{Id: "2", Name: "it-2", Arch: "amd64", Mem: 256, CpuCores: 4},
+			{Id: "1", Name: "it-1", Arch: "amd64", Mem: 512, CpuCores: 4},
 		},
 		expectedItypes: []string{"it-3", "it-4"},
 	},
@@ -168,9 +173,9 @@ var getInstanceTypesTest = []struct {
 		about: "small mem specified, use that even though less than needed for mongodb",
 		cons:  "mem=300M",
 		itypesToUse: []InstanceType{
-			{Id: "3", Name: "it-3", Arches: []string{"amd64"}, Mem: 2048},
-			{Id: "2", Name: "it-2", Arches: []string{"amd64"}, Mem: 256},
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, Mem: 512},
+			{Id: "3", Name: "it-3", Arch: "amd64", Mem: 2048},
+			{Id: "2", Name: "it-2", Arch: "amd64", Mem: 256},
+			{Id: "1", Name: "it-1", Arch: "amd64", Mem: 512},
 		},
 		expectedItypes: []string{"it-1", "it-3"},
 	},
@@ -178,10 +183,10 @@ var getInstanceTypesTest = []struct {
 		about: "mem specified and match found",
 		cons:  "mem=4G arch=amd64",
 		itypesToUse: []InstanceType{
-			{Id: "4", Name: "it-4", Arches: []string{"armhf"}, Mem: 8096},
-			{Id: "3", Name: "it-3", Arches: []string{"amd64"}, Mem: 4096},
-			{Id: "2", Name: "it-2", Arches: []string{"amd64"}, Mem: 2048},
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, Mem: 512},
+			{Id: "4", Name: "it-4", Arch: "arm64", Mem: 8096},
+			{Id: "3", Name: "it-3", Arch: "amd64", Mem: 4096},
+			{Id: "2", Name: "it-2", Arch: "amd64", Mem: 2048},
+			{Id: "1", Name: "it-1", Arch: "amd64", Mem: 512},
 		},
 		expectedItypes: []string{"it-3"},
 	},
@@ -189,10 +194,10 @@ var getInstanceTypesTest = []struct {
 		about: "instance-type specified and match found",
 		cons:  "instance-type=it-3",
 		itypesToUse: []InstanceType{
-			{Id: "4", Name: "it-4", Arches: []string{"amd64"}, Mem: 8096},
-			{Id: "3", Name: "it-3", Arches: []string{"amd64"}, Mem: 4096},
-			{Id: "2", Name: "it-2", Arches: []string{"amd64"}, Mem: 2048},
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, Mem: 512},
+			{Id: "4", Name: "it-4", Arch: "amd64", Mem: 8096},
+			{Id: "3", Name: "it-3", Arch: "amd64", Mem: 4096},
+			{Id: "2", Name: "it-2", Arch: "amd64", Mem: 2048},
+			{Id: "1", Name: "it-1", Arch: "amd64", Mem: 512},
 		},
 		expectedItypes: []string{"it-3"},
 	},
@@ -200,9 +205,9 @@ var getInstanceTypesTest = []struct {
 		about: "largest mem available matching other constraints if mem not specified",
 		cons:  "cores=4",
 		itypesToUse: []InstanceType{
-			{Id: "3", Name: "it-3", Arches: []string{"amd64"}, Mem: 1024, CpuCores: 2},
-			{Id: "2", Name: "it-2", Arches: []string{"amd64"}, Mem: 256, CpuCores: 4},
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, Mem: 512, CpuCores: 4},
+			{Id: "3", Name: "it-3", Arch: "amd64", Mem: 1024, CpuCores: 2},
+			{Id: "2", Name: "it-2", Arch: "amd64", Mem: 256, CpuCores: 4},
+			{Id: "1", Name: "it-1", Arch: "amd64", Mem: 512, CpuCores: 4},
 		},
 		expectedItypes: []string{"it-1"},
 	},
@@ -210,10 +215,10 @@ var getInstanceTypesTest = []struct {
 		about: "largest mem available matching other constraints if mem not specified, cost is tie breaker",
 		cons:  "cores=4",
 		itypesToUse: []InstanceType{
-			{Id: "4", Name: "it-4", Arches: []string{"amd64"}, Mem: 1024, CpuCores: 2},
-			{Id: "3", Name: "it-3", Arches: []string{"amd64"}, Mem: 256, CpuCores: 4},
-			{Id: "2", Name: "it-2", Arches: []string{"amd64"}, Mem: 512, CpuCores: 4, Cost: 50},
-			{Id: "1", Name: "it-1", Arches: []string{"amd64"}, Mem: 512, CpuCores: 4, Cost: 100},
+			{Id: "4", Name: "it-4", Arch: "amd64", Mem: 1024, CpuCores: 2},
+			{Id: "3", Name: "it-3", Arch: "amd64", Mem: 256, CpuCores: 4},
+			{Id: "2", Name: "it-2", Arch: "amd64", Mem: 512, CpuCores: 4, Cost: 50},
+			{Id: "1", Name: "it-1", Arch: "amd64", Mem: 512, CpuCores: 4, Cost: 100},
 		},
 		expectedItypes: []string{"it-2"},
 	}, {
@@ -243,10 +248,10 @@ func (s *instanceTypeSuite) TestGetMatchingInstanceTypes(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		names := make([]string, len(itypes))
 		for i, itype := range itypes {
-			if len(t.arches) > 0 {
-				c.Check(itype.Arches, gc.DeepEquals, filterArches(itype.Arches, t.arches))
+			if t.arch != "" {
+				c.Check(itype.Arch, gc.Equals, t.arch)
 			} else {
-				c.Check(len(itype.Arches) > 0, jc.IsTrue)
+				c.Check(itype.Arch, gc.Not(gc.Equals), "")
 			}
 			names[i] = itype.Name
 		}
@@ -272,26 +277,26 @@ func (s *instanceTypeSuite) TestGetMatchingInstanceTypesErrors(c *gc.C) {
 }
 
 var instanceTypeMatchTests = []struct {
-	cons   string
-	itype  string
-	arches []string
+	cons  string
+	itype string
+	arch  string
 }{
-	{"", "m1.small", []string{"amd64", "armhf"}},
-	{"", "m1.large", []string{"amd64"}},
-	{"cpu-power=100", "m1.small", []string{"amd64", "armhf"}},
-	{"arch=amd64", "m1.small", []string{"amd64"}},
-	{"cores=3", "m1.xlarge", []string{"amd64"}},
-	{"cpu-power=", "t1.micro", []string{"amd64", "armhf"}},
-	{"cpu-power=500", "c1.medium", []string{"amd64", "armhf"}},
-	{"cpu-power=2000", "c1.xlarge", []string{"amd64"}},
-	{"cpu-power=2001", "cc1.4xlarge", []string{"amd64"}},
-	{"mem=2G", "m1.medium", []string{"amd64", "armhf"}},
+	{"", "m1.small", "amd64"},
+	{"", "m1.large", "amd64"},
+	{"cpu-power=100", "m1.small", "amd64"},
+	{"arch=amd64", "m1.small", "amd64"},
+	{"cores=3", "m1.xlarge", "amd64"},
+	{"cpu-power=", "t1.micro", "amd64"},
+	{"cpu-power=500", "c1.medium", "amd64"},
+	{"cpu-power=2000", "c1.xlarge", "amd64"},
+	{"cpu-power=2001", "cc1.4xlarge", "amd64"},
+	{"mem=2G", "m1.medium", "amd64"},
 
-	{"arch=i386", "m1.small", nil},
-	{"cpu-power=100", "t1.micro", nil},
-	{"cpu-power=9001", "cc2.8xlarge", nil},
-	{"mem=1G", "t1.micro", nil},
-	{"arch=armhf", "c1.xlarge", nil},
+	{"arch=i386", "m1.small", ""},
+	{"cpu-power=100", "t1.micro", ""},
+	{"cpu-power=9001", "cc2.8xlarge", ""},
+	{"mem=1G", "t1.micro", ""},
+	{"arch=arm64", "c1.xlarge", ""},
 }
 
 func (s *instanceTypeSuite) TestMatch(c *gc.C) {
@@ -306,11 +311,9 @@ func (s *instanceTypeSuite) TestMatch(c *gc.C) {
 		}
 		c.Assert(itype.Name, gc.Not(gc.Equals), "")
 		itype, match := itype.match(cons)
-		if len(t.arches) > 0 {
+		if t.arch != "" {
 			c.Check(match, jc.IsTrue)
-			expect := itype
-			expect.Arches = t.arches
-			c.Check(itype, gc.DeepEquals, expect)
+			c.Check(itype, gc.DeepEquals, itype)
 		} else {
 			c.Check(match, jc.IsFalse)
 			c.Check(itype, gc.DeepEquals, InstanceType{})

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -943,7 +943,7 @@ func (t *LiveTests) TestStartInstanceWithEmptyNonceFails(c *gc.C) {
 		t.Env,
 		simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory()),
 		[]string{"trusty"},
-		possibleTools.Arches(),
+		[]string{"amd64"},
 		&params.ImageMetadata,
 	)
 	c.Check(err, jc.ErrorIsNil)

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -170,6 +170,8 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 	}
 	if params.Constraints.Arch != nil {
 		filter.Arch = *params.Constraints.Arch
+	} else {
+		filter.Arch = "amd64"
 	}
 	streams := tools.PreferredStreams(&agentVersion, env.Config().Development(), env.Config().AgentStream())
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())
@@ -183,7 +185,7 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 			env,
 			ss,
 			[]string{preferredSeries},
-			possibleTools.Arches(),
+			[]string{filter.Arch},
 			&params.ImageMetadata,
 		); err != nil {
 			return errors.Trace(err)

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -534,6 +534,10 @@ func (env *azureEnviron) StartInstance(ctx context.ProviderCallContext, args env
 	}
 	// Start the instance - if we get a quota error, that instance type is ignored
 	// and we'll try the next most expensive one, up to a reasonable number of attempts.
+	arch, err := args.Tools.OneArch()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	for i := 0; i < 15; i++ {
 		// Identify the instance type and image to provision.
 		instanceSpec, err := findInstanceSpec(
@@ -543,7 +547,7 @@ func (env *azureEnviron) StartInstance(ctx context.ProviderCallContext, args env
 			&instances.InstanceConstraint{
 				Region:      env.location,
 				Series:      args.InstanceConfig.Series,
-				Arches:      args.Tools.Arches(),
+				Arch:        arch,
 				Constraints: args.Constraints,
 			},
 			imageStream,

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -485,9 +485,10 @@ func newInstanceType(size compute.VirtualMachineSize) instances.InstanceType {
 
 	vtype := "Hyper-V"
 	return instances.InstanceType{
-		Id:       sizeName,
-		Name:     sizeName,
-		Arches:   []string{arch.AMD64},
+		Id:   sizeName,
+		Name: sizeName,
+		// TODO(wallyworld) - add arm64 once supported
+		Arch:     arch.AMD64,
 		CpuCores: uint64(to.Int32(size.NumberOfCores)),
 		Mem:      uint64(to.Int32(size.MemoryInMB)),
 		// NOTE(axw) size.OsDiskSizeInMB is the *maximum*
@@ -528,7 +529,7 @@ func findInstanceSpec(
 	imageStream string,
 ) (*instances.InstanceSpec, error) {
 
-	if !constraintHasArch(constraint, arch.AMD64) {
+	if constraint.Arch != arch.AMD64 {
 		// Azure only supports AMD64.
 		return nil, errors.NotFoundf("%s in arch constraints", arch.AMD64)
 	}
@@ -545,15 +546,6 @@ func findInstanceSpec(
 	}
 	constraint.Constraints = defaultToBaselineSpec(constraint.Constraints)
 	return instances.FindInstanceSpec(images, constraint, instanceTypes)
-}
-
-func constraintHasArch(constraint *instances.InstanceConstraint, arch string) bool {
-	for _, constraintArch := range constraint.Arches {
-		if constraintArch == arch {
-			return true
-		}
-	}
-	return false
 }
 
 // If you specify no constraints at all, you're going to get the smallest

--- a/provider/azure/instancetype_test.go
+++ b/provider/azure/instancetype_test.go
@@ -41,7 +41,7 @@ func (s *InstanceTypeSuite) TestStandard(c *gc.C) {
 	c.Assert(inst, jc.DeepEquals, instances.InstanceType{
 		Id:       "Standard_A2",
 		Name:     "Standard_A2",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		VirtType: to.StringPtr("Hyper-V"),
 		CpuCores: 2,
 		Mem:      100,
@@ -61,7 +61,7 @@ func (s *InstanceTypeSuite) TestStandardVersioned(c *gc.C) {
 	c.Assert(inst, jc.DeepEquals, instances.InstanceType{
 		Id:       "Standard_A2_v4",
 		Name:     "Standard_A2_v4",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		VirtType: to.StringPtr("Hyper-V"),
 		CpuCores: 2,
 		Mem:      100,
@@ -81,7 +81,7 @@ func (s *InstanceTypeSuite) TestStandardPromo(c *gc.C) {
 	c.Assert(inst, jc.DeepEquals, instances.InstanceType{
 		Id:       "Standard_A2_v4_Promo",
 		Name:     "Standard_A2_v4_Promo",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		VirtType: to.StringPtr("Hyper-V"),
 		CpuCores: 2,
 		Mem:      100,
@@ -101,7 +101,7 @@ func (s *InstanceTypeSuite) TestBasic(c *gc.C) {
 	c.Assert(inst, jc.DeepEquals, instances.InstanceType{
 		Id:       "Basic_A2",
 		Name:     "Basic_A2",
-		Arches:   []string{"amd64"},
+		Arch:     "amd64",
 		VirtType: to.StringPtr("Hyper-V"),
 		CpuCores: 2,
 		Mem:      100,

--- a/provider/cloudsigma/environinstance.go
+++ b/provider/cloudsigma/environinstance.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
-	"github.com/juju/juju/tools"
 )
 
 //
@@ -50,12 +49,7 @@ func (env *environ) StartInstance(ctx context.ProviderCallContext, args environs
 		return nil, err
 	}
 
-	tools, err := args.Tools.Match(tools.Filter{Arch: img.Arch})
-	if err != nil {
-		return nil, errors.Errorf("chosen architecture %v not present in %v", img.Arch, args.Tools.Arches())
-	}
-
-	if err := args.InstanceConfig.SetTools(tools); err != nil {
+	if err := args.InstanceConfig.SetTools(args.Tools); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config()); err != nil {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -812,7 +812,10 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 	if err != nil {
 		return nil, err
 	}
-	arch := availableTools.Arches()[0]
+	arch, err := availableTools.OneArch()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	defer delay()
 	if err := e.checkBroken("Bootstrap"); err != nil {

--- a/provider/ec2/image.go
+++ b/provider/ec2/image.go
@@ -4,6 +4,8 @@
 package ec2
 
 import (
+	"github.com/kr/pretty"
+
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
@@ -47,7 +49,7 @@ func findInstanceSpec(
 		ic.Constraints = withDefaultNonControllerConstraints(ic.Constraints)
 	}
 	suitableImages := filterImages(allImageMetadata, ic)
-	logger.Debugf("found %d suitable image(s)", len(suitableImages))
+	logger.Debugf("found %d suitable image(s): %s", len(suitableImages), pretty.Sprint(suitableImages))
 	images := instances.ImageMetadataToImages(suitableImages)
 	return instances.FindInstanceSpec(images, ic, instanceTypes)
 }

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -30,41 +30,41 @@ var testInstanceTypes = []instances.InstanceType{{
 	CpuCores: 4,
 	CpuPower: instances.CpuPower(1400),
 	Mem:      16384,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     172,
 }, {
 	Name:     "t3a.nano",
 	CpuCores: 2,
 	CpuPower: instances.CpuPower(700),
 	Mem:      512,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     5,
 }, {
 	Name:     "t3a.micro",
 	CpuCores: 2,
 	CpuPower: instances.CpuPower(700),
 	Mem:      1024,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     10,
 }, {
 	Name:     "t3a.small",
 	CpuCores: 2,
 	CpuPower: instances.CpuPower(700),
 	Mem:      2048,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     21,
 }, {
 	Name:     "t3a.medium",
 	CpuPower: instances.CpuPower(700),
 	Mem:      4096,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     43,
 }, {
 	Name:     "m1.medium",
 	CpuCores: 1,
 	CpuPower: instances.CpuPower(100),
 	Mem:      3840,
-	Arches:   []string{"amd64", "i386"},
+	Arch:     "amd64",
 	VirtType: &paravirtual,
 	Cost:     117,
 }, {
@@ -72,48 +72,48 @@ var testInstanceTypes = []instances.InstanceType{{
 	CpuCores: 4,
 	CpuPower: instances.CpuPower(1288),
 	Mem:      8192,
-	Arches:   []string{"arm64"},
+	Arch:     "arm64",
 }, {
 	Name:     "c4.large",
 	CpuCores: 2,
 	CpuPower: instances.CpuPower(811),
 	Mem:      3840,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     114,
 }, {
 	Name:     "t2.medium",
 	CpuCores: 2,
 	CpuPower: instances.CpuPower(40),
 	Mem:      4096,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     46,
 }, {
 	Name:     "c1.medium",
 	CpuCores: 2,
 	CpuPower: instances.CpuPower(200),
 	Mem:      1741,
-	Arches:   []string{"amd64", "i386"},
+	Arch:     "amd64",
 	Cost:     164,
 }, {
 	Name:     "cc2.8xlarge",
 	CpuCores: 32,
 	CpuPower: instances.CpuPower(11647),
 	Mem:      61952,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     2250,
 }, {
 	Name:     "r5a.large",
 	CpuCores: 2,
 	CpuPower: instances.CpuPower(700),
 	Mem:      16384,
-	Arches:   []string{"amd64"},
+	Arch:     "amd64",
 	Cost:     137,
 }}
 
 var findInstanceSpecTests = []struct {
 	// LTS-dependent requires new or updated entries upon a new LTS release.
 	series  string
-	arches  []string
+	arch    string
 	cons    string
 	itype   string
 	image   string
@@ -121,103 +121,97 @@ var findInstanceSpecTests = []struct {
 }{
 	{
 		series: "xenial",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		itype:  "t3a.micro",
 		image:  "ami-00000133",
 	}, {
 		series: "quantal",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		itype:  "t3a.micro",
 		image:  "ami-01000035",
 	}, {
 		series: "xenial",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		cons:   "cores=4",
 		itype:  "t3a.xlarge",
 		image:  "ami-00000133",
 	}, {
 		series: "bionic",
-		arches: []string{"arm64"},
+		arch:   "arm64",
 		cons:   "cores=4",
 		itype:  "a1.xlarge",
 		image:  "ami-00002133",
 	}, {
 		series: "xenial",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		cons:   "mem=10G",
 		itype:  "r5a.large",
 		image:  "ami-00000133",
 	}, {
 		series: "xenial",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		cons:   "mem=",
 		itype:  "t3a.nano",
 		image:  "ami-00000133",
 	}, {
 		series: "xenial",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		cons:   "cpu-power=",
 		itype:  "t3a.micro",
 		image:  "ami-00000133",
 	}, {
 		series: "xenial",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		cons:   "cpu-power=800",
 		itype:  "c4.large",
 		image:  "ami-00000133",
 	}, {
 		series: "xenial",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		cons:   "instance-type=m1.medium cpu-power=100",
 		itype:  "m1.medium",
 		image:  "ami-00000135",
 	}, {
 		series: "xenial",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		cons:   "mem=2G root-disk=16384M",
 		itype:  "t3a.small",
 		image:  "ami-00000133",
 	}, {
 		series:  "xenial",
-		arches:  []string{"amd64"},
+		arch:    "amd64",
 		cons:    "mem=4G root-disk=16384M",
 		itype:   "t3a.medium",
 		storage: []string{"ssd", "ebs"},
 		image:   "ami-00000133",
 	}, {
 		series:  "xenial",
-		arches:  []string{"amd64"},
+		arch:    "amd64",
 		cons:    "mem=4G root-disk=16384M",
 		itype:   "t3a.medium",
 		storage: []string{"ebs", "ssd"},
 		image:   "ami-00000139",
 	}, {
 		series:  "xenial",
-		arches:  []string{"amd64"},
+		arch:    "amd64",
 		cons:    "mem=4G root-disk=16384M",
 		itype:   "t3a.medium",
 		storage: []string{"ebs"},
 		image:   "ami-00000139",
 	}, {
 		series: "trusty",
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		itype:  "t3a.micro",
 		image:  "ami-00000033",
 	}, {
-		series: "trusty",
-		arches: []string{"i386"},
-		cons:   "instance-type=c1.medium",
-		itype:  "c1.medium",
-		image:  "ami-00000034",
-	}, {
 		series: "bionic",
-		arches: []string{"amd64", "i386"},
+		arch:   "amd64",
 		cons:   "arch=amd64",
 		itype:  "t3a.micro",
 		image:  "ami-00001133",
 	}, {
 		series: "bionic",
-		arches: []string{"amd64", "i386"},
+		arch:   "amd64",
 		cons:   "instance-type=cc2.8xlarge",
 		itype:  "cc2.8xlarge",
 		image:  "ami-00001133",
@@ -228,7 +222,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 	size := len(findInstanceSpecTests)
 	for i, test := range findInstanceSpecTests {
 		c.Logf("\ntest %d of %d: %q; %q; %q; %q; %q; %v", i+1, size,
-			test.series, test.arches, test.cons, test.itype, test.image,
+			test.series, test.arch, test.cons, test.itype, test.image,
 			test.storage)
 		stor := test.storage
 		if len(stor) == 0 {
@@ -238,7 +232,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 		// arches and series; the provisioner and bootstrap
 		// code will do this.
 		imageMetadata := filterImageMetadata(
-			c, TestImageMetadata, test.series, test.arches,
+			c, TestImageMetadata, test.series, test.arch,
 		)
 		spec, err := findInstanceSpec(
 			false, // non-controller
@@ -247,7 +241,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 			&instances.InstanceConstraint{
 				Region:      "test",
 				Series:      test.series,
-				Arches:      test.arches,
+				Arch:        test.arch,
 				Constraints: constraints.MustParse(test.cons),
 				Storage:     stor,
 			})
@@ -278,24 +272,24 @@ func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.
 
 var findInstanceSpecErrorTests = []struct {
 	series string
-	arches []string
+	arch   string
 	cons   string
 	err    string
 }{
 	{
 		series: version.DefaultSupportedLTS(),
-		arches: []string{"arm"},
-		err:    fmt.Sprintf(`no metadata for "%s" images in test with arches \[arm\]`, version.DefaultSupportedLTS()),
+		arch:   "arm",
+		err:    fmt.Sprintf(`no metadata for "%s" images in test with arch arm`, version.DefaultSupportedLTS()),
 	}, {
 		series: "raring",
-		arches: []string{"amd64", "i386"},
+		arch:   "amd64",
 		cons:   "mem=4G",
-		err:    `no "raring" images in test matching instance types \[.*\]`,
+		err:    `no metadata for \"raring\" images in test with arch amd64`,
 	}, {
 		series: version.DefaultSupportedLTS(),
-		arches: []string{"amd64"},
+		arch:   "amd64",
 		cons:   "instance-type=m1.small mem=4G",
-		err:    `no instance types in test matching constraints "instance-type=m1.small mem=4096M"`,
+		err:    `no instance types in test matching constraints "arch=amd64 instance-type=m1.small mem=4096M"`,
 	},
 }
 
@@ -306,7 +300,7 @@ func (s *specSuite) TestFindInstanceSpecErrors(c *gc.C) {
 		// arches and series; the provisioner and bootstrap
 		// code will do this.
 		imageMetadata := filterImageMetadata(
-			c, TestImageMetadata, t.series, t.arches,
+			c, TestImageMetadata, t.series, t.arch,
 		)
 		_, err := findInstanceSpec(
 			false, // non-controller
@@ -315,7 +309,7 @@ func (s *specSuite) TestFindInstanceSpecErrors(c *gc.C) {
 			&instances.InstanceConstraint{
 				Region:      "test",
 				Series:      t.series,
-				Arches:      t.arches,
+				Arch:        t.arch,
 				Constraints: constraints.MustParse(t.cons),
 			})
 		c.Check(err, gc.ErrorMatches, t.err)
@@ -325,7 +319,7 @@ func (s *specSuite) TestFindInstanceSpecErrors(c *gc.C) {
 func filterImageMetadata(
 	c *gc.C,
 	in []*imagemetadata.ImageMetadata,
-	filterSeries string, filterArches []string,
+	filterSeries string, filterArch string,
 ) []*imagemetadata.ImageMetadata {
 	var imageMetadata []*imagemetadata.ImageMetadata
 	for _, im := range in {
@@ -334,11 +328,7 @@ func filterImageMetadata(
 		if im.Version != version {
 			continue
 		}
-		match := false
-		for _, arch := range filterArches {
-			match = match || im.Arch == arch
-		}
-		if match {
+		if im.Arch == filterArch {
 			imageMetadata = append(imageMetadata, im)
 		}
 	}

--- a/provider/ec2/instancetypes.go
+++ b/provider/ec2/instancetypes.go
@@ -301,7 +301,12 @@ func convertEC2InstanceType(
 			if instArch == "" {
 				continue
 			}
-			instType.Arches = append(instType.Arches, archName(instArch))
+			// We no longer support i386
+			if instArch == arch.I386 {
+				continue
+			}
+			instType.Arch = archName(instArch)
+			break
 		}
 	}
 	instZones, ok := instanceTypeZones[types.InstanceType(instType.Name)]

--- a/provider/ec2/internal/testing/instances.go
+++ b/provider/ec2/internal/testing/instances.go
@@ -409,7 +409,7 @@ func (inst *Instance) matchAttr(attr, value string) (ok bool, err error) {
 	}
 	switch attr {
 	case "architecture":
-		return value == "i386", nil
+		return value == "amd64", nil
 	case "availability-zone":
 		return value == inst.availZone, nil
 	case "instance-id":

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -233,7 +233,7 @@ func (t *localServerSuite) SetUpSuite(c *gc.C) {
 
 	// Upload arches that ec2 supports; add to this
 	// as ec2 coverage expands.
-	t.UploadArches = []string{arch.AMD64, arch.I386}
+	t.UploadArches = []string{arch.AMD64}
 	t.TestConfig = localConfigAttrs
 	imagetesting.PatchOfficialDataSources(&t.BaseSuite.CleanupSuite, "test:")
 	t.BaseSuite.PatchValue(&imagemetadata.SimplestreamsImagesPublicKey, sstesting.SignedMetadataPublicKey)
@@ -1475,10 +1475,10 @@ func (t *localServerSuite) TestConstraintsMerge(c *gc.C) {
 	validator, err := env.ConstraintsValidator(t.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 	consA := constraints.MustParse("arch=amd64 mem=1G cpu-power=10 cores=2 tags=bar")
-	consB := constraints.MustParse("arch=i386 instance-type=m1.small")
+	consB := constraints.MustParse("arch=arm64 instance-type=m1.small")
 	cons, err := validator.Merge(consA, consB)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons, gc.DeepEquals, constraints.MustParse("arch=i386 instance-type=m1.small tags=bar"))
+	c.Assert(cons, gc.DeepEquals, constraints.MustParse("arch=arm64 instance-type=m1.small tags=bar"))
 }
 
 func (t *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {
@@ -1503,12 +1503,12 @@ func (t *localServerSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 
 func (t *localServerSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	env := t.Prepare(c)
-	cons := constraints.MustParse("instance-type=cc1.4xlarge arch=i386")
+	cons := constraints.MustParse("instance-type=cc1.4xlarge arch=arm64")
 	err := env.PrecheckInstance(t.callCtx, environs.PrecheckInstanceParams{
 		Series:      jujuversion.DefaultSupportedLTS(),
 		Constraints: cons,
 	})
-	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "cc1.4xlarge" and arch "i386" specified`)
+	c.Assert(err, gc.ErrorMatches, `invalid AWS instance type "cc1.4xlarge" and arch "arm64" specified`)
 }
 
 func (t *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
@@ -2774,7 +2774,7 @@ func (t *localServerSuite) TestStartInstanceWithEmptyNonceFails(c *gc.C) {
 		t.Env,
 		simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory()),
 		[]string{"trusty"},
-		possibleTools.Arches(),
+		[]string{"amd64"},
 		&params.ImageMetadata,
 	)
 	c.Check(err, jc.ErrorIsNil)

--- a/provider/ec2/series_test.go
+++ b/provider/ec2/series_test.go
@@ -80,18 +80,8 @@ var TestImageMetadata = []*imagemetadata.ImageMetadata{
 	// 14.04:amd64
 	makeImage("ami-00000033", "ssd", "hvm", "amd64", "14.04", "test"),
 
-	// 14.04:i386
-	makeImage("ami-00000034", "ssd", "pv", "i386", "14.04", "test"),
-
 	// 12.10:amd64
 	makeImage("ami-01000035", "ssd", "hvm", "amd64", "12.10", "test"),
-
-	// 12.10:i386
-	makeImage("ami-01000034", "ssd", "hvm", "i386", "12.10", "test"),
-
-	// 13.04:i386
-	makeImage("ami-02000034", "ssd", "hvm", "i386", "13.04", "test"),
-	makeImage("ami-02000035", "ssd", "pv", "i386", "13.04", "test"),
 }
 
 func MakeTestImageStreamsData(region types.Region) map[string]string {
@@ -122,10 +112,7 @@ const testImageMetadataIndex = `
     "com.ubuntu.cloud:server:20.04:amd64",
     "com.ubuntu.cloud:server:18.04:amd64",
     "com.ubuntu.cloud:server:16.04:amd64",
-    "com.ubuntu.cloud:server:14.04:amd64",
-    "com.ubuntu.cloud:server:14.04:i386",
-    "com.ubuntu.cloud:server:12.10:i386",
-    "com.ubuntu.cloud:server:13.04:i386"
+    "com.ubuntu.cloud:server:14.04:amd64"
    ],
    "path": "streams/v1/com.ubuntu.cloud:released:aws.json"
   }
@@ -322,25 +309,6 @@ const testImageMetadataProduct = `
        }
      }
    },
-   "com.ubuntu.cloud:server:14.04:i386": {
-     "release": "trusty",
-     "version": "14.04",
-     "arch": "i386",
-     "versions": {
-       "20121218": {
-         "items": {
-           "test1pe": {
-             "root_store": "ssd",
-             "virt": "pv",
-             "region": "test",
-             "id": "ami-00000034"
-           }
-         },
-         "pubname": "ubuntu-trusty-14.04-i386-server-20121218",
-         "label": "release"
-       }
-     }
-   },
    "com.ubuntu.cloud:server:12.10:amd64": {
      "release": "quantal",
      "version": "12.10",
@@ -380,50 +348,6 @@ const testImageMetadataProduct = `
            }
          },
          "pubname": "ubuntu-quantal-12.10-amd64-server-20121218",
-         "label": "release"
-       }
-     }
-   },
-   "com.ubuntu.cloud:server:12.10:i386": {
-     "release": "quantal",
-     "version": "12.10",
-     "arch": "i386",
-     "versions": {
-       "20121218": {
-         "items": {
-           "test1pe": {
-             "root_store": "ssd",
-             "virt": "pv",
-             "region": "test",
-             "id": "ami-01000034"
-           },
-           "apne1pe": {
-             "root_store": "ssd",
-             "virt": "pv",
-             "region": "ap-northeast-1",
-             "id": "ami-01000023"
-           }
-         },
-         "pubname": "ubuntu-quantal-12.10-i386-server-20121218",
-         "label": "release"
-       }
-     }
-   },
-   "com.ubuntu.cloud:server:13.04:i386": {
-     "release": "raring",
-     "version": "13.04",
-     "arch": "i386",
-     "versions": {
-       "20121218": {
-         "items": {
-           "test1pe": {
-             "root_store": "ssd",
-             "virt": "pv",
-             "region": "test",
-             "id": "ami-02000034"
-           }
-         },
-         "pubname": "ubuntu-raring-13.04-i386-server-20121218",
          "label": "release"
        }
      }

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -64,7 +64,7 @@ func (s *environBrokerSuite) SetUpTest(c *gc.C) {
 	s.ic = &instances.InstanceConstraint{
 		Region:      "home",
 		Series:      "trusty",
-		Arches:      []string{amd64},
+		Arch:        amd64,
 		Constraints: s.StartInstArgs.Constraints,
 	}
 	s.imageMetadata = []*imagemetadata.ImageMetadata{{

--- a/provider/gce/instance_information.go
+++ b/provider/gce/instance_information.go
@@ -23,11 +23,6 @@ var (
 
 	virtType = "kvm"
 
-	// NOTE(achilleasa/20210310): At this point in time, google cloud only
-	// provides amd64 machine types. For more information see:
-	// https://cloud.google.com/compute/docs/cpu-platforms.
-	machArches = []string{arch.AMD64}
-
 	// minCpuCores is the assumed minimum CPU cores we prefer in order to run a server.
 	minCpuCores uint64 = 2
 
@@ -91,7 +86,7 @@ func (env *environ) getAllInstanceTypes(ctx context.ProviderCallContext, clock c
 				Name:     m.Name,
 				CpuCores: uint64(m.GuestCpus),
 				Mem:      uint64(m.MemoryMb),
-				Arches:   machArches,
+				Arch:     arch.AMD64,
 				VirtType: &virtType,
 			}
 			resultUnique[m.Name] = i

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -205,7 +205,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 
 	s.InstanceType = instances.InstanceType{
 		Name:     instType,
-		Arches:   machArches,
+		Arch:     arch.AMD64,
 		CpuCores: 1,
 		CpuPower: instances.CpuPower(275),
 		Mem:      3750,

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -501,7 +501,10 @@ func (e *Environ) startInstance(
 	}
 
 	series := args.InstanceConfig.Series
-	arches := args.Tools.Arches()
+	arch, err := args.Tools.OneArch()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	types := imgCache.SupportedShapes(series)
 
@@ -519,7 +522,7 @@ func (e *Environ) startInstance(
 		types,
 		&instances.InstanceConstraint{
 			Series:      series,
-			Arches:      arches,
+			Arch:        arch,
 			Constraints: args.Constraints,
 		},
 	)

--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/v3/arch"
 
 	ociCore "github.com/oracle/oci-go-sdk/v47/core"
 
@@ -303,7 +304,6 @@ func instanceTypes(cli ComputeClient, compartmentID, imageID *string) ([]instanc
 	}
 
 	// convert shapes to InstanceType
-	arch := []string{"amd64"}
 	types := []instances.InstanceType{}
 	for _, val := range shapes {
 		spec, ok := shapeSpecs[*val.Shape]
@@ -314,7 +314,7 @@ func instanceTypes(cli ComputeClient, compartmentID, imageID *string) ([]instanc
 		instanceType := string(spec.Type)
 		newType := instances.InstanceType{
 			Name:     *val.Shape,
-			Arches:   arch,
+			Arch:     arch.AMD64,
 			Mem:      uint64(spec.Memory),
 			CpuCores: uint64(spec.Cpus),
 			// it's not really virtualization type. We have just 3 types of images:

--- a/provider/openstack/image.go
+++ b/provider/openstack/image.go
@@ -67,7 +67,7 @@ func findInstanceSpec(
 		instanceType := instances.InstanceType{
 			Id:       flavor.Id,
 			Name:     flavor.Name,
-			Arches:   ic.Arches,
+			Arch:     ic.Arch,
 			Mem:      uint64(flavor.RAM),
 			CpuCores: uint64(flavor.VCPUs),
 			RootDisk: uint64(flavor.Disk * 1024),

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1559,7 +1559,7 @@ func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 
 	// An error occurs if no suitable image is found.
 	_, err := openstack.FindInstanceSpec(env, "saucy", "amd64", "mem=1G", nil)
-	c.Assert(err, gc.ErrorMatches, `no metadata for "saucy" images in some-region with arches \[amd64\]`)
+	c.Assert(err, gc.ErrorMatches, `no metadata for "saucy" images in some-region with arch amd64`)
 }
 
 func (s *localServerSuite) TestConstraintsValidator(c *gc.C) {
@@ -1677,7 +1677,7 @@ func (s *localServerSuite) TestFindImageInvalidInstanceConstraint(c *gc.C) {
 		env, jujuversion.DefaultSupportedLTS(), "amd64", "instance-type=m1.large",
 		imageMetadata,
 	)
-	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "instance-type=m1.large"`)
+	c.Assert(err, gc.ErrorMatches, `no instance types in some-region matching constraints "arch=amd64 instance-type=m1.large"`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceValidInstanceType(c *gc.C) {

--- a/provider/openstack/series_test.go
+++ b/provider/openstack/series_test.go
@@ -596,7 +596,7 @@ func FindInstanceSpec(
 	env := e.(*Environ)
 	return findInstanceSpec(env, instances.InstanceConstraint{
 		Series:      series,
-		Arches:      []string{arch},
+		Arch:        arch,
 		Region:      env.cloud().Region,
 		Constraints: constraints.MustParse(cons),
 	}, imageMetadata)

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -168,7 +168,11 @@ func (env *sessionEnviron) newRawInstance(
 		statusUpdateArgs: statusUpdateArgs,
 	}
 
-	vmTemplate, arch, err := tplManager.EnsureTemplate(env.ctx, args.InstanceConfig.Series, args.Tools.Arches())
+	arch, err := args.Tools.OneArch()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	vmTemplate, arch, err := tplManager.EnsureTemplate(env.ctx, args.InstanceConfig.Series, arch)
 	if err != nil {
 		return nil, nil, common.ZoneIndependentError(err)
 	}

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -341,31 +341,6 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceWithUnsupportedConstraints(c
 	c.Assert(err, jc.Satisfies, environs.IsAvailabilityZoneIndependent)
 }
 
-// if tools for multiple architectures are available, provider should filter tools by arch of the selected image
-func (s *legacyEnvironBrokerSuite) TestStartInstanceFilterToolByArch(c *gc.C) {
-	startInstArgs := s.createStartInstanceArgs(c)
-	tools := []*coretools.Tools{{
-		Version: version.Binary{Arch: arch.I386, Release: "ubuntu"},
-		URL:     "https://example.org",
-	}, {
-		Version: version.Binary{Arch: arch.AMD64, Release: "ubuntu"},
-		URL:     "https://example.org",
-	}}
-
-	// Setting tools to I386, but provider should update them to AMD64,
-	// because our fake simplestream server returns only an AMD64 image.
-	startInstArgs.Tools = tools
-	err := startInstArgs.InstanceConfig.SetTools(coretools.List{
-		tools[0],
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	res, err := s.env.StartInstance(s.callCtx, startInstArgs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*res.Hardware.Arch, gc.Equals, arch.AMD64)
-	c.Assert(startInstArgs.InstanceConfig.AgentVersion().Arch, gc.Equals, arch.AMD64)
-}
-
 func (s *legacyEnvironBrokerSuite) TestStartInstanceDefaultConstraintsApplied(c *gc.C) {
 	cfg := s.env.Config()
 	cfg, err := cfg.Apply(map[string]interface{}{

--- a/provider/vsphere/image_metadata.go
+++ b/provider/vsphere/image_metadata.go
@@ -31,11 +31,11 @@ func init() {
 	simplestreams.RegisterStructTags(OvaFileMetadata{})
 }
 
-func findImageMetadata(env environs.Environ, arches []string, series string) (*OvaFileMetadata, error) {
+func findImageMetadata(env environs.Environ, arch string, series string) (*OvaFileMetadata, error) {
 	ic := &imagemetadata.ImageConstraint{
 		LookupParams: simplestreams.LookupParams{
 			Releases: []string{series},
-			Arches:   arches,
+			Arches:   []string{arch},
 			Stream:   env.Config().ImageStream(),
 		},
 	}

--- a/tools/list.go
+++ b/tools/list.go
@@ -46,11 +46,19 @@ func (src List) OneRelease() string {
 	return release[0]
 }
 
-// Arches returns all architectures for which some tools in src were built.
-func (src List) Arches() []string {
-	return src.collect(func(tools *Tools) string {
+// OneArch returns a single architecture for all tools in src,
+// or an error if there's more than one arch (or none) present.
+func (src List) OneArch() (string, error) {
+	allArches := src.collect(func(tools *Tools) string {
 		return tools.Version.Arch
 	})
+	if len(allArches) == 0 {
+		return "", errors.New("tools list is empty")
+	}
+	if len(allArches) != 1 {
+		return "", errors.Errorf("more than one agent arch present: %v", allArches)
+	}
+	return allArches[0], nil
 }
 
 // collect calls f on all values in src and returns an alphabetically

--- a/tools/list_test.go
+++ b/tools/list_test.go
@@ -60,12 +60,12 @@ var (
 	t210all       = tools.List{t210ubuntu, t211ubuntu, t215ubuntu, t2152ubuntu}
 )
 
-type stringsTest struct {
+type releaseTest struct {
 	src    tools.List
 	expect []string
 }
 
-var releaseTests = []stringsTest{{
+var releaseTests = []releaseTest{{
 	src:    tools.List{t100ubuntu},
 	expect: []string{"ubuntu"},
 }, {
@@ -86,21 +86,36 @@ func (s *ListSuite) TestReleases(c *gc.C) {
 	}
 }
 
-var archesTests = []stringsTest{{
+type archTest struct {
+	src    tools.List
+	expect string
+	err    string
+}
+
+var archesTests = []archTest{{
 	src:    tools.List{t100ubuntu},
-	expect: []string{"amd64"},
+	expect: "amd64",
 }, {
 	src:    tools.List{t100ubuntu, t100windows, t200ubuntu},
-	expect: []string{"amd64"},
+	expect: "amd64",
 }, {
-	src:    tAllBefore210,
-	expect: []string{"amd64", "i386"},
+	src: tAllBefore210,
+	err: "more than one agent arch present: \\[amd64 i386\\]",
+}, {
+	src: tools.List{},
+	err: "tools list is empty",
 }}
 
-func (s *ListSuite) TestArches(c *gc.C) {
+func (s *ListSuite) TestOneArch(c *gc.C) {
 	for i, test := range archesTests {
 		c.Logf("test %d", i)
-		c.Check(test.src.Arches(), gc.DeepEquals, test.expect)
+		arch, err := test.src.OneArch()
+		if test.err != "" {
+			c.Check(err, gc.ErrorMatches, test.err)
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(arch, gc.Equals, test.expect)
+		}
 	}
 }
 


### PR DESCRIPTION
When bootstrapping, if no arch constraint is specified, the arch of the host machine is used to find the agent binaries. However, instance selection is not filtered by arch, meaning we could get an amd64 instance with arm64 binaries.

As part of the fix, we also refactor various instance structs to use a single arch rather than slice of arches; the only reason we had more than one was because ec2 supported i386 and amd64, but that's no longer relevant as i386 was dropped a while back. And we can remove some now unnecessary checks when finalising instance config.

## QA steps

```
GOARCH=arm64 juju bootstrap aws --agent-version=2.9.29
juju add-machine
juju add-machine --constraints "arch=amd64"
juju add-machine --constraints "arch=arm64"
```

## Bug reference

https://bugs.launchpad.net/bugs/1972103