### PR TITLE
[JUJU-1069] CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
       - 'testing/**'
       - 'tests/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'acceptancetests/**'
       - 'doc/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
       - 'testcharms/**'
       - 'testing/**'
       - 'tests/**'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,5 @@
 name: "CLA check"
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 permissions:
   contents: read
 

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -9,6 +9,7 @@ on:
       - 'testing/**'
       - 'tests/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'acceptancetests/**'
       - 'doc/**'

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -17,6 +17,7 @@ on:
       - 'testcharms/**'
       - 'testing/**'
       - 'tests/**'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -2,7 +2,7 @@ name: Test Kubeflow
 
 # The small `edge` bundle has been deprecated, `lite` bundle takes 40mins to run which is too slow for gh action.
 # Disable this one for now, please check `nw-deploy-kubeflow` on Jenkins.
-on: {}
+on: workflow_dispatch
 
 env:
   DOCKER_USERNAME: jujuqabot

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,6 +3,7 @@ on:
   push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,5 +1,9 @@
 name: "Smoke"
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
 jobs:
 
   smoke:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,5 +1,8 @@
 name: "Snapcraft"
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   contents: read
 

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -3,6 +3,7 @@ on:
   push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 permissions:
   contents: read
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,6 +3,7 @@ on:
   push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 permissions:
   contents: read
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,5 +1,8 @@
 name: "Static Analysis"
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   contents: read
 

--- a/.github/workflows/update-brew-formulae.yml
+++ b/.github/workflows/update-brew-formulae.yml
@@ -4,6 +4,7 @@ on:
     types: [published]
   schedule:
     - cron:  '0 */12 * * *'
+  workflow_dispatch:
 permissions:
   contents: read
 


### PR DESCRIPTION
Some small improvements to the CI:
- Added the `workflow_dispatch` event, so that all jobs can be triggered manually (see [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)).
- Many jobs are not running on a draft pull request (fair enough). However, when you mark the draft PR as "ready for review", these jobs should be run. Hence, I changed the config for several actions to 
  ```
  on:
    pull_request:
      types: [opened, synchronize, reopened, ready_for_review]
  ```
  so that it would be run (see [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)). The other `types` are the default ones.