### PR TITLE
[JUJU-1084] Rewrite client tests not to use `JujuConnSuite` / Mongo

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -66,21 +66,6 @@ jobs:
       with:
         args: install mongodb.install --version=4.4.11 --allow-downgrade
 
-    # GitHub runners already have preinstalled version of mongodb, but
-    # we specifically need 4.4.11, otherwise our tests will not pass
-    - name: "Install Mongo Dependencies: macOS-latest"
-      if: (matrix.os == 'macOS-latest')
-      run: |
-        curl -o mongodb-4.4.11.tgz https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.11.tgz
-        tar xzvf mongodb-4.4.11.tgz
-        sudo rm -rf /usr/local/mongodb
-        sudo mkdir -p /usr/local/mongodb
-        sudo mv mongodb-macos-x86_64-4.4.11/bin/* /usr/local/mongodb
-        sudo mkdir -p /usr/local/bin
-        sudo rm /usr/local/bin/mongod
-        sudo ln -s /usr/local/mongodb/mongod /usr/local/bin/mongod
-      shell: bash
-
     - name: "Test client: macOS-latest"
       if: (matrix.os == 'macOS-latest')
       run: |


### PR DESCRIPTION
Several of the (older) Juju client tests use `JujuConnSuite`, which sets up a full database, fake apiserver and dummy provider. On macOS, these tests are sporadically failing due to a Mongo issue.

As @wallyworld pointed out, all the client unit tests should run without Mongo - we should mock the backend instead of setting up a "real" backend with fake apiserver, etc.

The work here is to rewrite those tests so that they don't use `JujuConnSuite` / Mongo.
- [ ] application/package_test.go
- [ ] commands/enableha_test.go
- [ ] commands/machine_test.go
- [ ] commands/ssh_machine_test.go
- [ ] commands/sshkeys_test.go
- [ ] commands/upgradecontroller_test.go
- [ ] commands/upgrademodel_test.go
- [ ] gui/gui_test.go
- [ ] gui/upgradegui_test.go
- [ ] romulus/setplan/set_plan_test.go
- [ ] setmeterstatus/setmeterstatus_test.go
- [ ] status/status_internal_test.go

We also have to rewrite the following tests to not use `RepoSuite`, which calls `JujuConnSuite`:
- [ ] application/addremoterelation_test.go
- [ ] application/deploy_test.go
- [ ] application/export_test.go
- [ ] application/expose_test.go
- [ ] application/refresh_resources_test.go
- [ ] application/refresh_test.go
- [ ] application/removeapplication_test.go (needs to be ported to remove_application_test.go)
- [ ] application/unexpose_test.go