### PR TITLE
Juju 1061 add machine private key

### DIFF
--- a/cmd/juju/common/authkeys.go
+++ b/cmd/juju/common/authkeys.go
@@ -19,7 +19,6 @@ import (
 )
 
 var ErrNoAuthorizedKeys = errors.New("no public ssh keys found")
-var ErrNoPrivateKeys = errors.New("no private ssh keys found")
 
 // FinalizeAuthorizedKeys takes a set of configuration attributes and
 // ensures that it has an authorized-keys setting, or returns

--- a/cmd/juju/common/authkeys.go
+++ b/cmd/juju/common/authkeys.go
@@ -19,6 +19,7 @@ import (
 )
 
 var ErrNoAuthorizedKeys = errors.New("no public ssh keys found")
+var ErrNoPrivateKeys = errors.New("no private ssh keys found")
 
 // FinalizeAuthorizedKeys takes a set of configuration attributes and
 // ensures that it has an authorized-keys setting, or returns

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -122,8 +122,12 @@ Examples:
 	# Allocate a machine to the model via SSH
 	juju add-machine ssh:user@10.10.0.3
 
-	# Allocate a machine specifying the private key
+	# Allocate a machine specifying the private key to use during the connection.
 	juju add-machine ssh:user@10.10.0.3 --private-key /tmp/id_rsa
+
+	# Allocate a machine specifying a public key to set in the list of
+	# authorized keys in the machine.
+	juju add-machine ssh:user@10.10.0.3 --public-key /tmp/id_rsa.pub
 
 	# Allocate a machine to the model via WinRM
 	juju add-machine winrm:user@10.10.0.3
@@ -413,9 +417,6 @@ func (c *addCommand) tryManualProvision(client AddMachineAPI, config *config.Con
 	if err != nil {
 		return errors.Annotatef(err, "cannot reading authorized-keys")
 	}
-
-	fmt.Printf("public keys: [[%v]]", authKeys)
-	fmt.Printf("private keys: [[%v]]", c.PrivateKey)
 
 	user, host := splitUserHost(c.Placement.Directive)
 	args := manual.ProvisionMachineArgs{

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -122,6 +122,9 @@ Examples:
 	# Allocate a machine to the model via SSH
 	juju add-machine ssh:user@10.10.0.3
 
+	# Allocate a machine specifying the private key
+	juju add-machine ssh:user@10.10.0.3 --private-key /tmp/id_rsa
+
 	# Allocate a machine to the model via WinRM
 	juju add-machine winrm:user@10.10.0.3
 
@@ -162,12 +165,18 @@ type addCommand struct {
 	NumMachines int
 	// Disks describes disks that are to be attached to the machine.
 	Disks []storage.Constraints
+	// PrivateKey is the path for a file containing the private key required
+	// by the server
+	PrivateKey string
+	// PublicKey is the path for a file containing a public key required
+	// by the server
+	PublicKey string
 }
 
 func (c *addCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "add-machine",
-		Args:    "[<container-type>[:<machine-id>] | (ssh|winrm):[<user>@]<host> | <placement>]",
+		Args:    "[<container-type>[:<machine-id>] | (ssh|winrm):[<user>@]<host> | <placement>] | <privateKey>",
 		Purpose: "Provision a new machine or assign one to the model.",
 		Doc:     addMachineDoc,
 	})
@@ -179,6 +188,8 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Machine constraints that overwrite those available from 'juju get-model-constraints' and provider's defaults")
 	f.Var(disksFlag{&c.Disks}, "disks", "Storage constraints for disks to attach to the machine(s)")
+	f.StringVar(&c.PrivateKey, "private-key", "", "Path to the private key to use")
+	f.StringVar(&c.PublicKey, "public-key", "", "Path to the public key to use")
 }
 
 func (c *addCommand) Init(args []string) error {
@@ -398,10 +409,13 @@ func (c *addCommand) tryManualProvision(client AddMachineAPI, config *config.Con
 		return errNonManualScope
 	}
 
-	authKeys, err := common.ReadAuthorizedKeys(ctx, "")
+	authKeys, err := common.ReadAuthorizedKeys(ctx, c.PublicKey)
 	if err != nil {
 		return errors.Annotatef(err, "cannot reading authorized-keys")
 	}
+
+	fmt.Printf("public keys: [[%v]]", authKeys)
+	fmt.Printf("private keys: [[%v]]", c.PrivateKey)
 
 	user, host := splitUserHost(c.Placement.Directive)
 	args := manual.ProvisionMachineArgs{
@@ -412,6 +426,7 @@ func (c *addCommand) tryManualProvision(client AddMachineAPI, config *config.Con
 		Stdout:         ctx.Stdout,
 		Stderr:         ctx.Stderr,
 		AuthorizedKeys: authKeys,
+		PrivateKey:     c.PrivateKey,
 		UpdateBehavior: &params.UpdateBehavior{
 			EnableOSRefreshUpdate: config.EnableOSRefreshUpdate(),
 			EnableOSUpgrade:       config.EnableOSUpgrade(),

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -129,6 +129,11 @@ Examples:
 	# authorized keys in the machine.
 	juju add-machine ssh:user@10.10.0.3 --public-key /tmp/id_rsa.pub
 
+	# Allocate a machine specifying a public key to set in the list of
+	# authorized keys and the private key to used during the 
+	# connection
+	juju add-machine ssh:user@10.10.0.3 --public-key /tmp/id_rsa.pub --private-key /tmp/id_rsa
+
 	# Allocate a machine to the model via WinRM
 	juju add-machine winrm:user@10.10.0.3
 
@@ -180,7 +185,7 @@ type addCommand struct {
 func (c *addCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "add-machine",
-		Args:    "[<container-type>[:<machine-id>] | (ssh|winrm):[<user>@]<host> | <placement>] | <privateKey>",
+		Args:    "[<container-type>[:<machine-id>] | (ssh|winrm):[<user>@]<host> | <placement>] | <private-key> | <public-key>",
 		Purpose: "Provision a new machine or assign one to the model.",
 		Doc:     addMachineDoc,
 	})
@@ -192,8 +197,8 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Machine constraints that overwrite those available from 'juju get-model-constraints' and provider's defaults")
 	f.Var(disksFlag{&c.Disks}, "disks", "Storage constraints for disks to attach to the machine(s)")
-	f.StringVar(&c.PrivateKey, "private-key", "", "Path to the private key to use")
-	f.StringVar(&c.PublicKey, "public-key", "", "Path to the public key to use")
+	f.StringVar(&c.PrivateKey, "private-key", "", "Path to the private key to use during the connection")
+	f.StringVar(&c.PublicKey, "public-key", "", "Path to the public key to add to the remote authorized keys")
 }
 
 func (c *addCommand) Init(args []string) error {

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -77,15 +77,15 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 			placement: "winrm:user@10.10.0.3",
 		}, {
 			args:      []string{"ssh:user@10.10.0.3", "--private-key", "pv"},
-			count:     2,
+			count:     1,
 			placement: "ssh:user@10.10.0.3",
 		}, {
 			args:      []string{"ssh:user@10.10.0.3", "--public-key", "pb"},
-			count:     2,
+			count:     1,
 			placement: "ssh:user@10.10.0.3",
 		}, {
 			args:      []string{"ssh:user@10.10.0.3", "--private-key", "pv", "--public-key", "pb"},
-			count:     3,
+			count:     1,
 			placement: "ssh:user@10.10.0.3",
 		}, {
 			args:      []string{"zone=us-east-1a"},
@@ -171,6 +171,7 @@ func (s *AddMachineSuite) TestParamsPassedOn(c *gc.C) {
 	c.Assert(s.fakeMachineManager.args, gc.HasLen, 1)
 
 	param := s.fakeMachineManager.args[0]
+
 	c.Assert(param.Placement.String(), gc.Equals, "fake-uuid:zone=nz")
 	c.Assert(param.Series, gc.Equals, "special")
 	c.Assert(param.Constraints.String(), gc.Equals, "mem=8192M")

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -76,6 +76,18 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 			count:     1,
 			placement: "winrm:user@10.10.0.3",
 		}, {
+			args:      []string{"ssh:user@10.10.0.3", "--private-key", "pv"},
+			count:     2,
+			placement: "ssh:user@10.10.0.3",
+		}, {
+			args:      []string{"ssh:user@10.10.0.3", "--public-key", "pb"},
+			count:     2,
+			placement: "ssh:user@10.10.0.3",
+		}, {
+			args:      []string{"ssh:user@10.10.0.3", "--private-key", "pv", "--public-key", "pb"},
+			count:     3,
+			placement: "ssh:user@10.10.0.3",
+		}, {
 			args:      []string{"zone=us-east-1a"},
 			count:     1,
 			placement: "model-uuid:zone=us-east-1a",

--- a/environs/manual/provisioner.go
+++ b/environs/manual/provisioner.go
@@ -49,6 +49,11 @@ type ProvisionMachineArgs struct {
 	// ubuntu user's ~/.ssh/authorized_keys.
 	AuthorizedKeys string
 
+	// PrivateKey contains the path of the identify file containing the
+	// private key to be used during the ssh connection with a target
+	// machine.
+	PrivateKey string
+
 	// WinRM contains keys and client interface api with the remote windows machine
 	WinRM WinRMArgs
 

--- a/environs/manual/sshprovisioner/init_test.go
+++ b/environs/manual/sshprovisioner/init_test.go
@@ -159,18 +159,18 @@ func (s *initialisationSuite) TestCheckProvisioned(c *gc.C) {
 func (s *initialisationSuite) TestInitUbuntuUserNonExisting(c *gc.C) {
 	defer installFakeSSH(c, "", "", 0)() // successful creation of ubuntu user
 	defer installFakeSSH(c, "", "", 1)() // simulate failure of ubuntu@ login
-	err := sshprovisioner.InitUbuntuUser("testhost", "testuser", "", nil, nil)
+	err := sshprovisioner.InitUbuntuUser("testhost", "testuser", "", "", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *initialisationSuite) TestInitUbuntuUserExisting(c *gc.C) {
 	defer installFakeSSH(c, "", nil, 0)()
-	sshprovisioner.InitUbuntuUser("testhost", "testuser", "", nil, nil)
+	sshprovisioner.InitUbuntuUser("testhost", "testuser", "", "", nil, nil)
 }
 
 func (s *initialisationSuite) TestInitUbuntuUserError(c *gc.C) {
 	defer installFakeSSH(c, "", []string{"", "failed to create ubuntu user"}, 123)()
 	defer installFakeSSH(c, "", "", 1)() // simulate failure of ubuntu@ login
-	err := sshprovisioner.InitUbuntuUser("testhost", "testuser", "", nil, nil)
+	err := sshprovisioner.InitUbuntuUser("testhost", "testuser", "", "", nil, nil)
 	c.Assert(err, gc.ErrorMatches, "subprocess encountered error code 123 \\(failed to create ubuntu user\\)")
 }

--- a/environs/manual/sshprovisioner/provisioner.go
+++ b/environs/manual/sshprovisioner/provisioner.go
@@ -33,7 +33,7 @@ func ProvisionMachine(args manual.ProvisionMachineArgs) (machineId string, err e
 	// user's ~/.ssh directory. The authenticationworker will later update the
 	// ubuntu user's authorized_keys.
 	if err = InitUbuntuUser(args.Host, args.User,
-		args.AuthorizedKeys, args.Stdin, args.Stdout); err != nil {
+		args.AuthorizedKeys, args.PrivateKey, args.Stdin, args.Stdout); err != nil {
 		return "", err
 	}
 

--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -39,7 +39,7 @@ import (
 //
 // authorizedKeys may be empty, in which case the file
 // will be created and left empty.
-func InitUbuntuUser(host, login, authorizedKeys string, read io.Reader, write io.Writer) error {
+func InitUbuntuUser(host, login, authorizedKeys string, privateKeys string, read io.Reader, write io.Writer) error {
 	logger.Infof("initialising %q, user %q", host, login)
 
 	// To avoid unnecessary prompting for the specified login,
@@ -64,6 +64,11 @@ func InitUbuntuUser(host, login, authorizedKeys string, read io.Reader, write io
 	var options ssh.Options
 	options.AllowPasswordAuthentication()
 	options.EnablePTY()
+	// private Keys were set
+	if privateKeys != "" && len(privateKeys) > 0 {
+		options.SetIdentities(privateKeys)
+	}
+
 	cmd = ssh.Command(host, []string{"sudo", "/bin/bash -c " + utils.ShQuote(script)}, &options)
 	var stderr bytes.Buffer
 	cmd.Stdin = read

--- a/provider/manual/provider.go
+++ b/provider/manual/provider.go
@@ -34,7 +34,7 @@ var _ environs.EnvironProvider = (*ManualProvider)(nil)
 var initUbuntuUser = sshprovisioner.InitUbuntuUser
 
 func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, host, user string, cfg *environConfig) error {
-	err := initUbuntuUser(host, user, cfg.AuthorizedKeys(), ctx.GetStdin(), ctx.GetStdout())
+	err := initUbuntuUser(host, user, cfg.AuthorizedKeys(), "", ctx.GetStdin(), ctx.GetStdout())
 	if err != nil {
 		logger.Errorf("initializing ubuntu user: %v", err)
 		return err

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -40,13 +40,13 @@ func (s *providerSuite) SetUpTest(c *gc.C) {
 func (s *providerSuite) TestPrepareForBootstrapCloudEndpointAndRegion(c *gc.C) {
 	ctx, err := s.testPrepareForBootstrap(c, "endpoint", "region")
 	c.Assert(err, jc.ErrorIsNil)
-	s.CheckCall(c, 0, "InitUbuntuUser", "endpoint", "", "", ctx.GetStdin(), ctx.GetStdout())
+	s.CheckCall(c, 0, "InitUbuntuUser", "endpoint", "", "", "", ctx.GetStdin(), ctx.GetStdout())
 }
 
 func (s *providerSuite) TestPrepareForBootstrapUserHost(c *gc.C) {
 	ctx, err := s.testPrepareForBootstrap(c, "user@host", "")
 	c.Assert(err, jc.ErrorIsNil)
-	s.CheckCall(c, 0, "InitUbuntuUser", "host", "user", "", ctx.GetStdin(), ctx.GetStdout())
+	s.CheckCall(c, 0, "InitUbuntuUser", "host", "user", "", "", ctx.GetStdin(), ctx.GetStdout())
 }
 
 func (s *providerSuite) TestPrepareForBootstrapNoCloudEndpoint(c *gc.C) {

--- a/provider/manual/provider_test.go
+++ b/provider/manual/provider_test.go
@@ -31,8 +31,8 @@ var _ = gc.Suite(&providerSuite{})
 func (s *providerSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.Stub.ResetCalls()
-	s.PatchValue(manual.InitUbuntuUser, func(host, user, keys string, stdin io.Reader, stdout io.Writer) error {
-		s.AddCall("InitUbuntuUser", host, user, keys, stdin, stdout)
+	s.PatchValue(manual.InitUbuntuUser, func(host, user, keys string, privateKey string, stdin io.Reader, stdout io.Writer) error {
+		s.AddCall("InitUbuntuUser", host, user, keys, privateKey, stdin, stdout)
 		return s.NextErr()
 	})
 }


### PR DESCRIPTION
During the manual provision Juju only considers the keys in folder `~/.ssh` and `~/.local/share/juju` to connect/configure the new machine. As required in the bug mentioned below, it would be good to extend the `add-machine` command to use a different private key to establish an ssh session with the new machine. Additionally, this PR extends the list of authorized keys to be set in the new machine by mentioning a public key stored in a file.

## Checklist
NA

## QA steps
For QA bootstrap a new controller on lxd, launch a new lxd machine, config the authorized ssh keys for the machine and try to add this new machine. This QA requires some manual checking...

```bash
# new controller
juju bootstrap lxd deleteme

# new machine
lxc launch ubuntu new-machine

# copy and paste the IP for the machine
lxc list new-machine

+-------------+---------+--------------------+------+-----------+-----------+
|    NAME     |  STATE  |        IPV4        | IPV6 |   TYPE    | SNAPSHOTS |
+-------------+---------+--------------------+------+-----------+-----------+
| new-machine | RUNNING | 10.73.25.18 (eth0) |      | CONTAINER | 0         |
+-------------+---------+--------------------+------+-----------+-----------+

# or if you feel jq-ish ;)
# lxc list new-machine --columns 4 -f json | jq '.[] | select(.name=="new-machine") | .state.network.eth0.addresses[0].address'

# create your pair of keys
mkdir -p /tmp/testkey
ssh-keygen -f /tmp/testkey/testkey

# add the public key to the list of authorized entries into the new machine
publickey=$(cat testkey.pub)
lxc file push testkey.pub new-machine/home/ubuntu/.ssh/authorized_keys

# check we can ssh with no password
ssh -i testkey ubuntu@10.73.25.18

# Test we cannot access using the standard method
juju add-machine ssh:ubuntu@10.73.25.18 --debug

# Test we can access with the private key
juju add-machine ssh:ubuntu@10.73.25.18 --private-key /tmp/testkey/testkey --public-key /tmp/testkey/testkey.pub --debug

# The new machine should be there!
juju list-machines

```

## Documentation changes

This usecase must be mentioned in the docs.

## Bug reference

[https://bugs.launchpad.net/juju/+bug/1971962](https://bugs.launchpad.net/juju/+bug/1971962)
