### PR TITLE
[JUJU-1089] Deprecated note for --no-download flag in create-backup

### DIFF
--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -77,7 +77,7 @@ func (c *createCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *createCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.NoDownload, "no-download", false, "Do not download the archive, implies keep-copy")
+	f.BoolVar(&c.NoDownload, "no-download", false, "Do not download the archive, DEPRECATED.")
 	f.StringVar(&c.Filename, "filename", notset, "Download to this file")
 	c.fs = f
 }

--- a/cmd/juju/backups/create.go
+++ b/cmd/juju/backups/create.go
@@ -20,8 +20,7 @@ import (
 
 const (
 	notset          = backups.FilenamePrefix + "<date>-<time>.tar.gz"
-	downloadWarning = "downloading backup archives is recommended; " +
-		"backups stored remotely are not guaranteed to be available."
+	downloadWarning = "--no-download flag is DEPRECATED."
 )
 
 const createDoc = `
@@ -77,7 +76,7 @@ func (c *createCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *createCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.CommandBase.SetFlags(f)
-	f.BoolVar(&c.NoDownload, "no-download", false, "Do not download the archive, DEPRECATED.")
+	f.BoolVar(&c.NoDownload, "no-download", false, "Do not download the archive. DEPRECATED.")
 	f.StringVar(&c.Filename, "filename", notset, "Download to this file")
 	c.fs = f
 }


### PR DESCRIPTION
#### Description

This changes the `juju create-backup --help` text to notify that the `--no-downlad` flag is being deprecated.

Fixes https://bugs.launchpad.net/juju/+bug/1957174

#### QA Steps

This is only a text edit, i.e. here's no semantic change.