### PR TITLE
Fix K8s application removal in pre-initialized error state

### DIFF
--- a/state/application_test.go
+++ b/state/application_test.go
@@ -5071,7 +5071,10 @@ func (s *CAASApplicationSuite) TestDestroyQueuesUnitCleanup(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		units[i] = unit
 		if i%2 != 0 {
-			preventUnitDestroyRemove(c, unit)
+			unitState := state.NewUnitState()
+			unitState.SetUniterState("idle")
+			err := unit.SetState(unitState, state.UnitStateSizeLimits{})
+			c.Assert(err, jc.ErrorIsNil)
 		}
 	}
 

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -736,7 +736,7 @@ func (st *State) removeOffersForDyingModel() (err error) {
 }
 
 // cleanupUnitsForDyingApplication sets all units with the given prefix to Dying,
-// if they are not already Dying or Dead. It's expected to be used when a
+// if they are not already Dying or Dead. It's expected to be used when an
 // application is destroyed.
 func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanupArgs []bson.Raw) (err error) {
 	var destroyStorage bool

--- a/state/unit.go
+++ b/state/unit.go
@@ -739,12 +739,12 @@ func (op *DestroyUnitOperation) destroyOps() ([]txn.Op, error) {
 		Id:     op.unit.st.docID(agentStatusDocId),
 		Assert: bson.D{{"status", agentStatusInfo.Status}},
 	}
-	removeAsserts := append(isAliveDoc, bson.DocElem{
+	removeAsserts := bson.D{{
 		"$and", []bson.D{
 			unitHasNoSubordinates,
 			unitHasNoStorageAttachments,
 		},
-	})
+	}}
 	// If the unit is unassigned, ensure it is not assigned in the interim.
 	if !isAssigned && shouldBeAssigned {
 		removeAsserts = append(removeAsserts, bson.DocElem{"machineid", ""})

--- a/state/unit.go
+++ b/state/unit.go
@@ -1325,14 +1325,14 @@ func (u *Unit) Agent() *UnitAgent {
 }
 
 // AgentHistory returns an StatusHistoryGetter which can
-//be used to query the status history of the unit's agent.
+// be used to query the status history of the unit's agent.
 func (u *Unit) AgentHistory() status.StatusHistoryGetter {
 	return u.Agent()
 }
 
 // SetAgentStatus calls SetStatus for this unit's agent, this call
 // is equivalent to the former call to SetStatus when Agent and Unit
-// where not separate entities.
+// were not separate entities.
 func (u *Unit) SetAgentStatus(agentStatus status.StatusInfo) error {
 	agent := newUnitAgent(u.st, u.Tag(), u.Name())
 	s := status.StatusInfo{
@@ -1346,7 +1346,7 @@ func (u *Unit) SetAgentStatus(agentStatus status.StatusInfo) error {
 
 // AgentStatus calls Status for this unit's agent, this call
 // is equivalent to the former call to Status when Agent and Unit
-// where not separate entities.
+// were not separate entities.
 func (u *Unit) AgentStatus() (status.StatusInfo, error) {
 	agent := newUnitAgent(u.st, u.Tag(), u.Name())
 	return agent.Status()

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -2840,12 +2840,9 @@ func (s *CAASUnitSuite) TestCannotShortCircuitDestroyAllocatedUnit(c *gc.C) {
 	// the unit has been allocated and a pod created.
 	unit, err := s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	now := coretesting.NonZeroTime()
-	err = unit.SetAgentStatus(status.StatusInfo{
-		Status:  status.Error,
-		Message: "some error",
-		Since:   &now,
-	})
+	unitState := state.NewUnitState()
+	unitState.SetUniterState("error")
+	err = unit.SetState(unitState, state.UnitStateSizeLimits{})
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -3054,7 +3051,9 @@ func (s *CAASUnitSuite) TestWatchContainerAddresses(c *gc.C) {
 
 	// Ensure the following operation to set the unit as Dying
 	// is not short circuited to remove the unit.
-	err = unit.SetAgentStatus(status.StatusInfo{Status: status.Idle})
+	unitState := state.NewUnitState()
+	unitState.SetUniterState("idle")
+	err = unit.SetState(unitState, state.UnitStateSizeLimits{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Make it Dying: not reported.
 	err = unit.Destroy()
@@ -3115,7 +3114,9 @@ func (s *CAASUnitSuite) TestWatchServiceAddressesHash(c *gc.C) {
 
 	// Ensure the following operation to set the unit as Dying
 	// is not short circuited to remove the unit.
-	err = unit.SetAgentStatus(status.StatusInfo{Status: status.Idle})
+	unitState := state.NewUnitState()
+	unitState.SetUniterState("idle")
+	err = unit.SetState(unitState, state.UnitStateSizeLimits{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Make it Dying: not reported.
 	err = unit.Destroy()

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -657,7 +657,7 @@ func (a *appWorker) ensureScale(app caas.Application) error {
 
 	a.logger.Debugf("updating application %q scale to %d", a.name, desiredScale)
 	err = app.Scale(desiredScale)
-	if a.life == life.Dead && errors.IsNotFound(err) {
+	if desiredScale == 0 && errors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
 		return errors.Annotatef(err, "scaling application %q to desired scale %d", a.name, desiredScale)


### PR DESCRIPTION
This fixes [LP 9876543](https://bugs.launchpad.net/juju/+bug/9876543), where a K8s application was stuck in an unremoveable state when it had an error before initializing (couldn't find the container image) and then you couldn't remove it, even with `--force`.

See the individual commit messages for the three specific issues.

## QA steps

I've been reproducing this issue with the following sequence:

```sh
# bootstrap and deploy
juju bootstrap microk8s
juju deploy harbor-registry --channel edge  # https://charmhub.io/harbor-registry
juju debug-log
# then, in another terminal:
juju remove-application harbor-registry  # won't remove it
juju remove-application harbor-registry --force  # this previously failed to clean it up, now it works
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/9876543