### PR TITLE
[JUJU-1099] Restore "Store unit CharmURL as a string reference"

### DIFF
--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -503,9 +503,6 @@ func (u *Unit) ClosePorts(protocol string, fromPort, toPort int) error {
 var ErrNoCharmURLSet = errors.New("unit has no charm url set")
 
 // CharmURL returns the charm URL this unit is currently using.
-//
-// NOTE: This differs from state.Unit.CharmURL() by returning
-// an error instead of a bool, because it needs to make an API call.
 func (u *Unit) CharmURL() (*charm.URL, error) {
 	var results params.StringBoolResults
 	args := params.Entities{

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -54,7 +54,7 @@ type Unit interface {
 	Application() (Application, error)
 	PrincipalName() (string, bool)
 	AssignedMachineId() (string, error)
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*charm.URL, error)
 }
 
 // Charm represents point of use methods from the state Charm object.

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
@@ -440,8 +440,12 @@ func (w *machineLXDProfileWatcher) add(unit Unit) (bool, error) {
 
 	_, ok := w.applications[appName]
 	if !ok {
-		curl, ok := unit.CharmURL()
-		if !ok {
+		curl, err := unit.CharmURL()
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+
+		if curl == nil {
 			// this happens for new units to existing machines.
 			app, err := unit.Application()
 			if errors.IsNotFound(err) {
@@ -452,6 +456,7 @@ func (w *machineLXDProfileWatcher) add(unit Unit) (bool, error) {
 			}
 			curl = app.CharmURL()
 		}
+
 		ch, err := w.backend.Charm(curl)
 		if errors.IsNotFound(err) {
 			logger.Debugf("charm %s removed for %s on machine-%s", curl, unitName, w.machine.Id())

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
@@ -92,7 +92,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherProfile(c *gc.C) {
 
 	s.setupPrincipalUnit()
 	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, true)
+	s.unit.EXPECT().CharmURL().Return(curl, nil)
 	s.unitChanges <- []string{"foo/0"}
 	s.wc0.AssertOneChange()
 }
@@ -152,7 +152,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherAddUnit(c *gc.C) {
 	s.unit.EXPECT().PrincipalName().Return("", false)
 	s.unit.EXPECT().AssignedMachineId().Return("0", nil)
 	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, true)
+	s.unit.EXPECT().CharmURL().Return(curl, nil)
 	s.unitChanges <- []string{"bar/0"}
 	s.wc0.AssertOneChange()
 }
@@ -195,7 +195,7 @@ func (s *lxdProfileWatcherSuite) assertAddSubordinate() {
 	s.unit.EXPECT().AssignedMachineId().Return("0", nil)
 
 	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, true)
+	s.unit.EXPECT().CharmURL().Return(curl, nil)
 	s.unitChanges <- []string{"foo/0"}
 }
 
@@ -291,7 +291,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherRemoveOnlyUnit(c *g
 
 	s.setupPrincipalUnit()
 	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, true)
+	s.unit.EXPECT().CharmURL().Return(curl, nil)
 	s.unitChanges <- []string{"foo/0"}
 	s.wc0.AssertOneChange()
 
@@ -346,8 +346,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherUnitChangeAppNotFou
 	s.machine0.EXPECT().Units().Return(nil, nil)
 
 	s.setupPrincipalUnit()
-	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, false)
+	s.unit.EXPECT().CharmURL().Return(nil, nil)
 	s.unit.EXPECT().Application().Return(nil, errors.NotFoundf(""))
 
 	defer workertest.CleanKill(c, s.assertStartLxdProfileWatcher(c))
@@ -365,7 +364,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherUnitChangeCharmURLN
 
 	s.setupPrincipalUnit()
 	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, true)
+	s.unit.EXPECT().CharmURL().Return(curl, nil)
 	s.state.EXPECT().Charm(curl).Return(nil, errors.NotFoundf(""))
 
 	defer workertest.CleanKill(c, s.assertStartLxdProfileWatcher(c))

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -489,11 +489,11 @@ func (mr *MockUnitMockRecorder) AssignedMachineId() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockUnit) CharmURL() (*charm.URL, bool) {
+func (m *MockUnit) CharmURL() (*charm.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
 	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 

--- a/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
@@ -234,11 +234,11 @@ func (mr *MockLXDProfileUnitV2MockRecorder) AssignedMachineId() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockLXDProfileUnitV2) CharmURL() (*charm.URL, bool) {
+func (m *MockLXDProfileUnitV2) CharmURL() (*charm.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
 	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -47,7 +47,7 @@ type LXDProfileMachineV2 interface {
 type LXDProfileUnitV2 interface {
 	ApplicationName() string
 	AssignedMachineId() (string, error)
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*charm.URL, error)
 	Name() string
 	Tag() names.Tag
 }
@@ -66,7 +66,7 @@ type LXDProfileAPIv2 struct {
 	accessUnit common.GetAuthFunc
 }
 
-// LXDProfileAPIv2 returns a new LXDProfileAPIv2. Currently both
+// NewLXDProfileAPIv2 returns a new LXDProfileAPIv2. Currently both
 // GetAuthFuncs can used to determine current permissions.
 func NewLXDProfileAPIv2(
 	backend LXDProfileBackendV2,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -692,12 +692,21 @@ func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, er
 			var unitOrApplication state.Entity
 			unitOrApplication, err = u.st.FindEntity(tag)
 			if err == nil {
-				charmURLer := unitOrApplication.(interface {
-					CharmURL() (*charm.URL, bool)
-				})
-				curl, ok := charmURLer.CharmURL()
-				if curl != nil {
-					result.Results[i].Result = curl.String()
+				var cURL *charm.URL
+				var ok bool
+
+				switch entity := unitOrApplication.(type) {
+				case *state.Application:
+					cURL, ok = entity.CharmURL()
+				case *state.Unit:
+					cURL, err = entity.CharmURL()
+					if cURL != nil {
+						ok = true
+					}
+				}
+
+				if cURL != nil {
+					result.Results[i].Result = cURL.String()
 					result.Results[i].Ok = ok
 				}
 			}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -875,9 +875,9 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	// Set wordpressUnit's charm URL first.
 	err := s.wordpressUnit.SetCharmURL(s.wpCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	curl, ok := s.wordpressUnit.CharmURL()
+	curl, err := s.wordpressUnit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, s.wpCharm.URL())
-	c.Assert(ok, jc.IsTrue)
 
 	// Make sure wordpress application's charm is what we expect.
 	curl, force := s.wordpress.CharmURL()
@@ -901,7 +901,7 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, params.StringBoolResults{
 		Results: []params.StringBoolResult{
 			{Error: apiservertesting.ErrUnauthorized},
-			{Result: s.wpCharm.String(), Ok: ok},
+			{Result: s.wpCharm.String(), Ok: true},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Result: s.wpCharm.String(), Ok: force},
@@ -934,10 +934,11 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 	// Verify the charm URL was set.
 	err = s.wordpressUnit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	charmURL, needsUpgrade := s.wordpressUnit.CharmURL()
+
+	charmURL, err := s.wordpressUnit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmURL, gc.NotNil)
 	c.Assert(charmURL.String(), gc.Equals, s.wpCharm.String())
-	c.Assert(needsUpgrade, jc.IsTrue)
 }
 
 func (s *uniterSuite) TestWorkloadVersion(c *gc.C) {

--- a/apiserver/facades/client/metricsdebug/metricsdebug.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug.go
@@ -180,8 +180,11 @@ func (api *MetricsDebugAPI) setEntityMeterStatus(entity names.Tag, status state.
 		if err != nil {
 			return errors.Trace(err)
 		}
-		chURL, found := unit.CharmURL()
-		if !found {
+		chURL, err := unit.CharmURL()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if chURL == nil {
 			return errors.New("no charm url")
 		}
 		if chURL.Schema != "local" {

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -165,9 +165,9 @@ func UnitChange(c *gc.C, modelUUID string, unit *state.Unit) cache.UnitChange {
 	}
 
 	var charmURL string
-	if cURL, ok := unit.CharmURL(); ok {
-		charmURL = cURL.String()
-	}
+	cURL, err := unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
+	charmURL = cURL.String()
 
 	pr, err := unit.OpenedPortRanges()
 	if !errors.IsNotAssigned(err) {

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -83,7 +83,7 @@ type PrecheckUnit interface {
 	Name() string
 	AgentTools() (*tools.Tools, error)
 	Life() state.Life
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*charm.URL, error)
 	AgentStatus() (status.StatusInfo, error)
 	Status() (status.StatusInfo, error)
 	ShouldBeAssigned() bool

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -798,7 +798,7 @@ func (b *fakeBackend) IsMigrationActive(string) (bool, error) {
 	return b.migrationActive, b.migrationActiveErr
 }
 
-func (b *fakeBackend) CloudCredential(tag names.CloudCredentialTag) (state.Credential, error) {
+func (b *fakeBackend) CloudCredential(_ names.CloudCredentialTag) (state.Credential, error) {
 	return b.credentials, b.credentialsErr
 }
 
@@ -814,7 +814,7 @@ func (b *fakeBackend) AllRelations() ([]migration.PrecheckRelation, error) {
 	return b.relations, b.allRelsErr
 }
 
-func (b *fakeBackend) ListPendingResources(app string) ([]resource.Resource, error) {
+func (b *fakeBackend) ListPendingResources(_ string) ([]resource.Resource, error) {
 	return b.pendingResources, b.pendingResourcesErr
 }
 
@@ -1009,12 +1009,12 @@ func (u *fakeUnit) ShouldBeAssigned() bool {
 	return true
 }
 
-func (u *fakeUnit) CharmURL() (*charm.URL, bool) {
+func (u *fakeUnit) CharmURL() (*charm.URL, error) {
 	url := u.charmURL
 	if url == "" {
 		url = "cs:foo-1"
 	}
-	return charm.MustParseURL(url), false
+	return charm.MustParseURL(url), nil
 }
 
 func (u *fakeUnit) AgentStatus() (status.StatusInfo, error) {

--- a/resource/resourceadapters/mocks/opener_mock.go
+++ b/resource/resourceadapters/mocks/opener_mock.go
@@ -278,11 +278,11 @@ func (mr *MockUnitMockRecorder) ApplicationName() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockUnit) CharmURL() (*charm.URL, bool) {
+func (m *MockUnit) CharmURL() (*charm.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
 	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 

--- a/resource/resourceadapters/opener_test.go
+++ b/resource/resourceadapters/opener_test.go
@@ -172,7 +172,7 @@ func (s *OpenerSuite) setupMocks(c *gc.C, includeUnit bool) *gomock.Controller {
 	if s.unit != nil {
 		s.unit.EXPECT().ApplicationName().Return("postgresql").AnyTimes()
 		s.unit.EXPECT().Application().Return(s.app, nil).AnyTimes()
-		s.unit.EXPECT().CharmURL().Return(curl, false).AnyTimes()
+		s.unit.EXPECT().CharmURL().Return(curl, nil).AnyTimes()
 	} else {
 		s.app.EXPECT().CharmURL().Return(curl, false).AnyTimes()
 	}

--- a/resource/unit.go
+++ b/resource/unit.go
@@ -18,5 +18,5 @@ type Unit interface {
 	ApplicationName() string
 
 	// CharmURL returns the unit's charm URL.
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*charm.URL, error)
 }

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -627,8 +627,9 @@ func (checker *ModelChecker) readApplicationsAndUnits() {
 		units, err := app.AllUnits()
 		checkErr(err, "AllUnits")
 		for _, unit := range units {
-			unitCharmURL, found := unit.CharmURL()
-			if !found {
+			unitCharmURL, err := unit.CharmURL()
+			checkErr(err, "unit CharmURL")
+			if unitCharmURL == nil {
 				continue
 			}
 			unitString := unitCharmURL.String()

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -524,7 +524,7 @@ func (u *backingUnit) updated(ctx *allWatcherContext) error {
 		Subordinate: u.Principal != "",
 	}
 	if u.CharmURL != nil {
-		info.CharmURL = u.CharmURL.String()
+		info.CharmURL = *u.CharmURL
 	}
 
 	// Construct a unit for the purpose of retrieving other fields as necessary.

--- a/state/application.go
+++ b/state/application.go
@@ -2652,11 +2652,17 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	if u.doc.CharmURL != nil {
 		// If the unit has a different URL to the application, allow any final
 		// cleanup to happen; otherwise we just do it when the app itself is removed.
-		maybeDoFinal := u.doc.CharmURL != a.doc.CharmURL
+		maybeDoFinal := *u.doc.CharmURL != a.doc.CharmURL.String()
+
+		cURL, err := u.CharmURL()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
 		// When 'force' is set, this call will return both needed operations
 		// as well as all operational errors encountered.
 		// If the 'force' is not set, any error will be fatal and no operations will be returned.
-		decOps, err := appCharmDecRefOps(a.st, a.doc.Name, u.doc.CharmURL, maybeDoFinal, op)
+		decOps, err := appCharmDecRefOps(a.st, a.doc.Name, cURL, maybeDoFinal, op)
 		if errors.IsNotFound(err) {
 			return nil, errRefresh
 		} else if op.FatalError(err) {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1984,8 +1984,8 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	// used by app as well, hence 2.
 	err = u.SetCharmURL(oldCh.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	curl, ok := u.CharmURL()
-	c.Assert(ok, jc.IsTrue)
+	curl, err := u.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, oldCh.URL())
 	assertSettingsRef(c, s.State, appName, oldCh, 2)
 	assertNoSettingsRef(c, s.State, appName, newCh)

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -551,9 +551,9 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 	}}
 	for i, t := range tests {
 		c.Logf("test %d: %s", i, t.about)
-		chURL, ok := t.unit.CharmURL()
-		c.Assert(ok, jc.IsTrue)
-		_, err := s.State.AddMetrics(
+		chURL, err := t.unit.CharmURL()
+		c.Assert(err, jc.ErrorIsNil)
+		_, err = s.State.AddMetrics(
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  now,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1561,10 +1561,7 @@ func (i *importer) makeUnitDoc(s description.Application, u description.Unit) (*
 	// the charm url for each unit rather than grabbing the applications charm url.
 	// Currently the units charm url matching the application is a precondiation
 	// to migration.
-	charmURL, err := charm.ParseURL(s.CharmURL())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	charmURL := s.CharmURL()
 
 	var subordinates []string
 	if subs := u.Subordinates(); len(subs) > 0 {
@@ -1589,7 +1586,7 @@ func (i *importer) makeUnitDoc(s description.Application, u description.Unit) (*
 		Name:                   u.Name(),
 		Application:            s.Name(),
 		Series:                 s.Series(),
-		CharmURL:               charmURL,
+		CharmURL:               &charmURL,
 		Principal:              u.Principal().Id(),
 		Subordinates:           subordinates,
 		StorageAttachmentCount: i.unitStorageAttachmentCount(u.Tag()),

--- a/state/state.go
+++ b/state/state.go
@@ -1627,7 +1627,7 @@ func (st *State) AssignStagedUnits(ids []string) ([]UnitAssignmentResult, error)
 	return results, nil
 }
 
-// UnitAssignments returns all staged unit assignments in the model.
+// AllUnitAssignments returns all staged unit assignments in the model.
 func (st *State) AllUnitAssignments() ([]UnitAssignment, error) {
 	return st.unitAssignments(nil)
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -77,7 +77,7 @@ type unitDoc struct {
 	ModelUUID              string `bson:"model-uuid"`
 	Application            string
 	Series                 string
-	CharmURL               *charm.URL
+	CharmURL               *string
 	Principal              string
 	Subordinates           []string
 	StorageAttachmentCount int `bson:"storageattachmentcount"`
@@ -146,8 +146,15 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 		return nil, fmt.Errorf("unit's charm URL must be set before retrieving config")
 	}
 
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// TODO (manadart 2019-02-21) Factor the current generation into this call.
-	s, err := charmSettingsWithDefaults(u.st, u.doc.CharmURL, u.doc.Application, model.GenerationMaster)
+	// TODO (manadart 2021-12-03) Most places where we are passing a charm URL
+	// could just use its string form.
+	s, err := charmSettingsWithDefaults(u.st, cURL, u.doc.Application, model.GenerationMaster)
 	if err != nil {
 		return nil, errors.Annotatef(err, "charm config for unit %q", u.Name())
 	}
@@ -363,7 +370,7 @@ type UpdateUnitOperation struct {
 }
 
 // Build is part of the ModelOperation interface.
-func (op *UpdateUnitOperation) Build(attempt int) ([]txn.Op, error) {
+func (op *UpdateUnitOperation) Build(_ int) ([]txn.Op, error) {
 	op.setStatusDocs = make(map[string]statusDoc)
 
 	containerInfo, err := op.unit.cloudContainer()
@@ -1459,11 +1466,13 @@ func (u *Unit) OpenedPortRanges() (UnitPortRanges, error) {
 }
 
 // CharmURL returns the charm URL this unit is currently using.
-func (u *Unit) CharmURL() (*charm.URL, bool) {
+func (u *Unit) CharmURL() (*charm.URL, error) {
 	if u.doc.CharmURL == nil {
-		return nil, false
+		return nil, nil
 	}
-	return u.doc.CharmURL, true
+
+	cURL, err := charm.ParseURL(*u.doc.CharmURL)
+	return cURL, errors.Trace(err)
 }
 
 // SetCharmURL marks the unit as currently using the supplied charm URL.
@@ -1521,17 +1530,22 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 				Assert: append(notDeadDoc, differentCharm...),
 				Update: bson.D{{"$set", bson.D{{"charmurl", curl}}}},
 			})
-		if u.doc.CharmURL != nil {
+
+		cURL, err := u.CharmURL()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if cURL != nil {
 			// Drop the reference to the old charm.
 			// Since we can force this now, let's.. There is no point hanging on to the old charm.
 			op := &ForcedOperation{Force: true}
-			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, u.doc.CharmURL, true, op)
+			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, cURL, true, op)
 			if err != nil {
 				// No need to stop further processing if the old key could not be removed.
-				logger.Errorf("could not remove old charm references for %v:%v", u.doc.CharmURL, err)
+				logger.Errorf("could not remove old charm references for %s: %v", cURL, err)
 			}
 			if len(op.Errors) != 0 {
-				logger.Errorf("could not remove old charm references for %v:%v", u.doc.CharmURL, op.Errors)
+				logger.Errorf("could not remove old charm references for %s: %v", cURL, op.Errors)
 			}
 			ops = append(ops, decOps...)
 		}
@@ -1539,7 +1553,8 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 	}
 	err := u.st.db().Run(buildTxn)
 	if err == nil {
-		u.doc.CharmURL = curl
+		curlStr := curl.String()
+		u.doc.CharmURL = &curlStr
 	}
 	return err
 }
@@ -1547,15 +1562,20 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 // charm returns the charm for the unit, or the application if the unit's charm
 // has not been set yet.
 func (u *Unit) charm() (*Charm, error) {
-	curl, ok := u.CharmURL()
-	if !ok {
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if cURL == nil {
 		app, err := u.Application()
 		if err != nil {
 			return nil, err
 		}
-		curl = app.doc.CharmURL
+		cURL = app.doc.CharmURL
 	}
-	ch, err := u.st.Charm(curl)
+
+	ch, err := u.st.Charm(cURL)
 	return ch, errors.Annotatef(err, "getting charm for %s", u)
 }
 
@@ -1568,7 +1588,7 @@ func (u *Unit) assertCharmOps(ch *Charm) []txn.Op {
 		Id:     u.doc.Name,
 		Assert: bson.D{{"charmurl", u.doc.CharmURL}},
 	}}
-	if _, ok := u.CharmURL(); !ok {
+	if u.doc.CharmURL != nil {
 		appName := u.ApplicationName()
 		ops = append(ops, txn.Op{
 			C:      applicationsC,
@@ -2889,7 +2909,13 @@ func (u *Unit) StorageConstraints() (map[string]StorageConstraints, error) {
 		}
 		return app.StorageConstraints()
 	}
-	key := applicationStorageConstraintsKey(u.doc.Application, u.doc.CharmURL)
+
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	key := applicationStorageConstraintsKey(u.doc.Application, cURL)
 	cons, err := readStorageConstraints(u.st, key)
 	if errors.IsNotFound(err) {
 		return nil, nil
@@ -2939,9 +2965,14 @@ func addUnitOps(st *State, args addUnitOpsArgs) ([]txn.Op, error) {
 	// relax the restrictions on migrating apps mid-upgrade, this
 	// will need to be more sophisticated, because it might need to
 	// create the settings doc.
-	if curl := args.unitDoc.CharmURL; curl != nil {
+	if charmURL := args.unitDoc.CharmURL; charmURL != nil {
+		cURL, err := charm.ParseURL(*charmURL)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
 		appName := args.unitDoc.Application
-		charmRefOps, err := appCharmIncRefOps(st, appName, curl, false)
+		charmRefOps, err := appCharmIncRefOps(st, appName, cURL, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1269,8 +1269,8 @@ func (s *UnitSuite) TestSetCharmURLSuccess(c *gc.C) {
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, ok = s.unit.CharmURL()
-	c.Assert(ok, jc.IsTrue)
+	curl, err = s.unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, s.charm.URL())
 }
 
@@ -1310,8 +1310,8 @@ func (s *UnitSuite) TestSetCharmURLWithDyingUnit(c *gc.C) {
 	err = s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, ok := s.unit.CharmURL()
-	c.Assert(ok, jc.IsTrue)
+	curl, err := s.unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, s.charm.URL())
 }
 
@@ -1359,9 +1359,9 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 				// Verify it worked after the second attempt.
 				err := s.unit.Refresh()
 				c.Assert(err, jc.ErrorIsNil)
-				currentURL, hasURL := s.unit.CharmURL()
+				currentURL, err := s.unit.CharmURL()
+				c.Assert(err, jc.ErrorIsNil)
 				c.Assert(currentURL, jc.DeepEquals, s.charm.URL())
-				c.Assert(hasURL, jc.IsTrue)
 			},
 		},
 	).Check()
@@ -2649,7 +2649,8 @@ func (s *UnitSuite) TestWorkloadVersion(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(version, gc.Equals, "")
 
-	unit.SetWorkloadVersion("3.combined")
+	err = unit.SetWorkloadVersion("3.combined")
+	c.Assert(err, jc.ErrorIsNil)
 	version, err = unit.WorkloadVersion()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(version, gc.Equals, "3.combined")

--- a/state/upgrade/types.go
+++ b/state/upgrade/types.go
@@ -78,7 +78,7 @@ type OldPortsDoc28 struct {
 	TxnRevno  int64               `bson:"txn-revno"`
 }
 
-// OldPortsDoc28 represents a port range entry document prior to the 2.9 schema changes.
+// OldPortRangeDoc28 represents a port range entry document prior to the 2.9 schema changes.
 type OldPortRangeDoc28 struct {
 	UnitName string `bson:"unitname"`
 	FromPort int    `bson:"fromport"`

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/mongo/utils"
 	"github.com/juju/juju/state/upgrade"
 	"github.com/juju/juju/storage/provider"
+	"github.com/juju/juju/tools"
 )
 
 var upgradesLogger = loggo.GetLogger("juju.state.upgrade")
@@ -1327,7 +1328,7 @@ func collectRelationInfo(coll *mgo.Collection) (map[string]*relationUnitCountInf
 	return relations, nil
 }
 
-// unitAppName returns the name of the Application, given a Units name.
+// unitAppName returns the name of the Application, given a Unit's name.
 func unitAppName(unitName string) string {
 	unitParts := strings.Split(unitName, "/")
 	return unitParts[0]
@@ -2897,13 +2898,34 @@ func AddMachineIDToSubordinates(pool *StatePool) error {
 	coll, closer := st.db().GetRawCollection(unitsC)
 	defer closer()
 
-	// Load all the units into a map by full ID.
-	units := make(map[string]*unitDoc)
+	// unitDoc28 represents the unit document as at Juju version 2.8,
+	// to which this upgrade step applies.
+	// Later, in version 2.9.23, CharmURL was stored as *string
+	// instead of *charm.URL.
+	type unitDoc28 struct {
+		DocID                  string `bson:"_id"`
+		Name                   string `bson:"name"`
+		ModelUUID              string `bson:"model-uuid"`
+		Application            string
+		Series                 string
+		CharmURL               *charm.URL
+		Principal              string
+		Subordinates           []string
+		StorageAttachmentCount int `bson:"storageattachmentcount"`
+		MachineId              string
+		Resolved               ResolvedMode
+		Tools                  *tools.Tools `bson:",omitempty"`
+		Life                   Life
+		PasswordHash           string
+	}
 
-	var doc unitDoc
+	// Load all the units into a map by full ID.
+	units := make(map[string]*unitDoc28)
+
+	var doc unitDoc28
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
-		// Make a copy of the unitDoc and put the copy
+		// Make a copy of the doc and put the copy
 		// into the map.
 		unit := doc
 		units[unit.DocID] = &unit

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2064,7 +2064,13 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
+
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, cURL)
 	return newEntityWatcher(u.st, settingsC, u.st.docID(charmConfigKey)), nil
 }
 
@@ -2083,7 +2089,13 @@ func (u *Unit) WatchConfigSettingsHash() (StringsWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
+
+	cURL, err := u.CharmURL()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, cURL)
 	return newSettingsHashWatcher(u.st, charmConfigKey), nil
 }
 

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -678,8 +678,8 @@ func (factory *Factory) MakeMetric(c *gc.C, params *MetricParams) *state.MetricB
 		}}
 	}
 
-	chURL, ok := params.Unit.CharmURL()
-	c.Assert(ok, gc.Equals, true)
+	chURL, err := params.Unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 
 	metric, err := factory.st.AddMetrics(
 		state.BatchParam{

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -795,13 +795,16 @@ func (s waitUnitAgent) step(c *gc.C, ctx *testContext) {
 				c.Logf("want resolved mode %q, got %q; still waiting", s.resolved, resolved)
 				continue
 			}
-			url, ok := ctx.unit.CharmURL()
-			if !ok || *url != *curl(s.charm) {
-				var got string
-				if ok {
-					got = url.String()
-				}
-				c.Logf("want unit charm %q, got %q; still waiting", curl(s.charm), got)
+			url, err := ctx.unit.CharmURL()
+			if err != nil {
+				c.Fatalf("cannot refresh unit: %v", err)
+			}
+			if url == nil {
+				c.Logf("want unit charm %q, got nil; still waiting", curl(s.charm))
+				continue
+			}
+			if *url != *curl(s.charm) {
+				c.Logf("want unit charm %q, got %q; still waiting", curl(s.charm), url.String())
 				continue
 			}
 			statusInfo, err := s.statusGetter(ctx)()
@@ -1026,8 +1029,9 @@ func (s verifyCharm) step(c *gc.C, ctx *testContext) {
 	}
 	err = ctx.unit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	url, ok := ctx.unit.CharmURL()
-	c.Assert(ok, jc.IsTrue)
+
+	url, err := ctx.unit.CharmURL()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.DeepEquals, curl(checkRevision))
 }
 


### PR DESCRIPTION
This is an effective reapplication of #13546. See that patch for the full description.

That patch was reverted under #13636, which this in-turn reverts.

## QA steps

See #13546.

## Documentation changes

None.

## Bug reference

N/A
