### PR TITLE
[JUJU-1101] Add --cert option to microk8s refresh-cert

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -157,7 +157,7 @@ jobs:
         sg microk8s "microk8s kubectl create -f .github/reg.yml"
 
         # TODO:(jack-w-shaw) Figure out why we need this and do something nicer
-        sudo microk8s refresh-certs
+        sudo microk8s refresh-certs --cert ca.crt
 
         # Wait for registry
         sg microk8s "microk8s kubectl wait --for condition=available deployment registry -n container-registry --timeout 180s" || true


### PR DESCRIPTION
This fixes a breaking change introduced here:
https://github.com/canonical/microk8s/pull/3029

This change adds a `--cert` flag, which `microk8s refresh-certs` fails without. So add this option

## QA steps

The smoke upgrade action successfully runs to completion