### PR TITLE
[JUJU-1039] Rewrite `controller-config` to use `ConfigCommandBase`

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -99,10 +99,14 @@ See also:
 `
 )
 
+var appConfigBase = config.ConfigCommandBase{
+	Resettable: true,
+}
+
 // NewConfigCommand returns a command used to get, reset, and set application
 // charm attributes.
 func NewConfigCommand() cmd.Command {
-	return modelcmd.Wrap(&configCommand{})
+	return modelcmd.Wrap(&configCommand{configBase: appConfigBase})
 }
 
 // configCommand get, sets, and resets configuration values of an application' charm.

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -246,7 +246,7 @@ func NewShowUnitCommandForTest(api UnitsInfoAPI, store jujuclient.ClientStore) c
 
 // NewConfigCommandForTest returns a SetCommand with the api provided as specified.
 func NewConfigCommandForTest(api ApplicationAPI, store jujuclient.ClientStore) modelcmd.ModelCommand {
-	c := modelcmd.Wrap(&configCommand{api: api})
+	c := modelcmd.Wrap(&configCommand{configBase: appConfigBase, api: api})
 	c.SetClientStore(store)
 	return c
 }

--- a/cmd/juju/controller/configcommand_test.go
+++ b/cmd/juju/controller/configcommand_test.go
@@ -53,7 +53,7 @@ func (s *ConfigSuite) TestInit(c *gc.C) {
 	}, {
 		desc: "can't get two keys",
 		args: []string{"one", "two"},
-		err:  "can only retrieve a single value, or all values",
+		err:  "cannot specify multiple keys to get",
 	}, {
 		desc: "set one key",
 		args: []string{"juju-ha-space=value"},
@@ -63,10 +63,15 @@ func (s *ConfigSuite) TestInit(c *gc.C) {
 	}, {
 		desc: "can't mix setting and getting",
 		args: []string{"juju-ha-space=value", "hey2"},
-		err:  "can only retrieve a single value, or all values",
+		err:  "cannot get value and set key=value pairs simultaneously",
 	}, {
-		desc: "can mix setting with files",
-		args: []string{"juju-ha-space=value", path},
+		desc: "can't mix setting with files",
+		args: []string{"juju-ha-space=value", "--file", path},
+		err:  "cannot use --file flag and set key=value pairs simultaneously",
+	}, {
+		desc: "can't reset",
+		args: []string{"--reset", "key1,key2"},
+		err:  "option provided but not defined: --reset",
 	}}
 	for i, test := range tests {
 		c.Logf("%d - %s", i, test.desc)
@@ -139,7 +144,7 @@ func (s *ConfigSuite) TestAllValuesJSON(c *gc.C) {
 
 func (s *ConfigSuite) TestNonexistentValue(c *gc.C) {
 	context, err := s.run(c, "courtney-barnett")
-	c.Assert(err, gc.ErrorMatches, `key "courtney-barnett" not found in "mallards" controller`)
+	c.Assert(err, gc.ErrorMatches, `key "courtney-barnett" not found in controller "mallards"`)
 
 	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(output, gc.Equals, "")
@@ -194,76 +199,13 @@ func (s *ConfigSuite) TestSettingComplexKey(c *gc.C) {
 func (s *ConfigSuite) TestSettingFromFile(c *gc.C) {
 	path := writeFile(c, "yaml", "juju-ha-space: value\n")
 	var api fakeControllerAPI
-	context, err := s.runWithAPI(c, &api, path)
+	context, err := s.runWithAPI(c, &api, "--file", path)
 	c.Assert(err, jc.ErrorIsNil)
 
 	output := strings.TrimSpace(cmdtesting.Stdout(context))
 	c.Assert(output, gc.Equals, "")
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{"juju-ha-space": "value"})
-}
-
-func (s *ConfigSuite) TestSettingFromBothNoOverlap(c *gc.C) {
-	path := writeFile(c, "yaml", "juju-ha-space: value\n")
-	var api fakeControllerAPI
-	context, err := s.runWithAPI(c, &api, path, "audit-log-max-backups=123")
-	c.Assert(err, jc.ErrorIsNil)
-
-	output := strings.TrimSpace(cmdtesting.Stdout(context))
-	c.Assert(output, gc.Equals, "")
-
-	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"juju-ha-space":         "value",
-		"audit-log-max-backups": "123",
-	})
-}
-
-func (s *ConfigSuite) TestSettingFromBothArgFirst(c *gc.C) {
-	path := writeFile(c, "yaml", "audit-log-max-backups: value\n")
-	var api fakeControllerAPI
-	context, err := s.runWithAPI(c, &api, "audit-log-max-backups=123", path)
-	c.Assert(err, jc.ErrorIsNil)
-
-	output := strings.TrimSpace(cmdtesting.Stdout(context))
-	c.Assert(output, gc.Equals, "")
-
-	// This is a consequence of ConfigFlag reading input files first
-	// and then overlaying with values from args. It's surprising but
-	// probably not worth fixing - I don't think people will try to
-	// set an option from a file and then override it from an arg.
-	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": "123",
-	})
-}
-
-func (s *ConfigSuite) TestSettingFromBothFileFirst(c *gc.C) {
-	path := writeFile(c, "yaml", "audit-log-max-backups: value\n")
-	var api fakeControllerAPI
-	context, err := s.runWithAPI(c, &api, path, "audit-log-max-backups=123")
-	c.Assert(err, jc.ErrorIsNil)
-
-	output := strings.TrimSpace(cmdtesting.Stdout(context))
-	c.Assert(output, gc.Equals, "")
-
-	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": "123",
-	})
-}
-
-func (s *ConfigSuite) TestSettingMultipleFiles(c *gc.C) {
-	path1 := writeFile(c, "yaml1", "audit-log-max-backups: value\n")
-	path2 := writeFile(c, "yaml2", "audit-log-max-backups: 123\n")
-
-	var api fakeControllerAPI
-	context, err := s.runWithAPI(c, &api, path1, path2)
-	c.Assert(err, jc.ErrorIsNil)
-
-	output := strings.TrimSpace(cmdtesting.Stdout(context))
-	c.Assert(output, gc.Equals, "")
-
-	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": 123,
-	})
 }
 
 func (s *ConfigSuite) TestErrorOnSetting(c *gc.C) {

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -166,7 +166,7 @@ func KillWaitForModels(command cmd.Command, ctx *cmd.Context, api destroyControl
 // NewConfigCommandForTest returns a ConfigCommand with
 // the api provided as specified.
 func NewConfigCommandForTest(api controllerAPI, store jujuclient.ClientStore) cmd.Command {
-	c := &configCommand{api: api}
+	c := &configCommand{configBase: ctrConfigBase, api: api}
 	c.SetClientStore(store)
 	return modelcmd.WrapController(c)
 }

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -79,7 +79,8 @@ See also:
 )
 
 var modelConfigBase = config.ConfigCommandBase{
-	CantReset: []string{envconfig.AgentVersionKey, envconfig.CharmHubURLKey},
+	Resettable: true,
+	CantReset:  []string{envconfig.AgentVersionKey, envconfig.CharmHubURLKey},
 }
 
 // NewConfigCommand wraps configCommand with sane model settings.


### PR DESCRIPTION
Continues work done in #13983 and #14014. I had to make a small retroactive change to ConfigCommandBase (allowing child commands to disable --reset flag), since the controller config API doesn't support resetting values. **Reviewers:** it will make more sense looking at the commits individually.

Again, there will be slight behaviour changes to the `controller-config` CLI:
- Config yaml files must now be specified using the --file flag.
- We no longer allow multiple actions to be done simultaneously (e.g. setting from key=value args & setting from file), as this creates ambiguity as to which should be done first. As a result, I removed several unit tests in `configcommand_test.go` which didn't make sense anymore.