### PR TITLE
[JUJU-1109] Fix encoding for interfaceAddressDisplay, used by the network-get hook tool

### DIFF
--- a/worker/uniter/runner/jujuc/network-get.go
+++ b/worker/uniter/runner/jujuc/network-get.go
@@ -169,8 +169,12 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 // interfaceAddressDisplay mirrors params.InterfaceAddress.
 type interfaceAddressDisplay struct {
 	Hostname string `json:"hostname" yaml:"hostname"`
-	Address  string `json:"value" yaml:"address"`
+	Address  string `json:"value" yaml:"value"`
 	CIDR     string `json:"cidr" yaml:"cidr"`
+
+	// This copy is used to preserve YAML serialisation that older agents
+	// may be expecting. Delete them for Juju 3/4.
+	AddressX string `json:"-" yaml:"address"`
 }
 
 // networkInfoDisplay mirrors params.NetworkInfo.
@@ -214,7 +218,13 @@ func resultToDisplay(result params.NetworkInfoResult) networkInfoResultDisplay {
 		}
 
 		for j, addr := range rInfo.Addresses {
-			dInfo.Addresses[j] = interfaceAddressDisplay(addr)
+			dInfo.Addresses[j] = interfaceAddressDisplay{
+				Hostname: addr.Hostname,
+				Address:  addr.Address,
+				CIDR:     addr.CIDR,
+
+				AddressX: addr.Address,
+			}
 		}
 
 		display.Info[i] = dInfo

--- a/worker/uniter/runner/jujuc/network-get_test.go
+++ b/worker/uniter/runner/jujuc/network-get_test.go
@@ -175,11 +175,13 @@ bind-addresses:
   interface-name: eth2
   addresses:
   - hostname: ""
-    address: 10.20.1.42
+    value: 10.20.1.42
     cidr: 10.20.1.42/24
+    address: 10.20.1.42
   - hostname: ""
-    address: fc00::1
+    value: fc00::1
     cidr: fc00::/64
+    address: fc00::1
   macaddress: "00:11:22:33:44:22"
   interfacename: eth2`[1:],
 	}, {
@@ -195,22 +197,26 @@ bind-addresses:
   interface-name: eth0
   addresses:
   - hostname: ""
-    address: 10.10.0.23
+    value: 10.10.0.23
     cidr: 10.10.0.0/24
+    address: 10.10.0.23
   - hostname: ""
-    address: 192.168.1.111
+    value: 192.168.1.111
     cidr: 192.168.1.0/24
+    address: 192.168.1.111
   macaddress: "00:11:22:33:44:00"
   interfacename: eth0
 - mac-address: "00:11:22:33:44:11"
   interface-name: eth1
   addresses:
   - hostname: ""
-    address: 10.10.1.23
+    value: 10.10.1.23
     cidr: 10.10.1.0/24
+    address: 10.10.1.23
   - hostname: ""
-    address: 192.168.2.111
+    value: 192.168.2.111
     cidr: 192.168.2.0/24
+    address: 192.168.2.111
   macaddress: "00:11:22:33:44:11"
   interfacename: eth1`[1:],
 	}, {
@@ -226,8 +232,9 @@ bind-addresses:
   interface-name: eth3
   addresses:
   - hostname: ""
-    address: 10.33.1.8
+    value: 10.33.1.8
     cidr: 10.33.1.8/24
+    address: 10.33.1.8
   macaddress: "00:11:22:33:44:33"
   interfacename: eth3`[1:],
 	}, {
@@ -248,8 +255,9 @@ bind-addresses:
   interface-name: eth3
   addresses:
   - hostname: ""
-    address: 10.33.1.8
+    value: 10.33.1.8
     cidr: 10.33.1.8/24
+    address: 10.33.1.8
   macaddress: "00:11:22:33:44:33"
   interfacename: eth3
 egress-subnets:


### PR DESCRIPTION
This patch is a follow-up on #12853.

There, we added a work-around for the fact that types used to display `network-get` results had tags for JSON, but not YAML. We added new display types with YAML tags, but also preserved the legacy field names in the event that charm logic still relied upon them.

This does the same for the `interfaceAddressDisplay` type, where the `Address` field was either `value` (JSON) or `address` (YAML).

## QA steps

- Bootstrap to LXD.
- `juju deploy ubuntu`
- `juju run --unit ubuntu/0 "network-get juju-info --format json"|jq .` should render as before:
```json
{
  "bind-addresses": [
    {
      "mac-address": "00:16:3e:95:00:2d",
      "interface-name": "eth0",
      "addresses": [
        {
          "hostname": "",
          "value": "10.161.87.143",
          "cidr": "10.161.87.0/24"
        }
      ]
    }
  ],
  "egress-subnets": [
    "10.161.87.143/32"
  ],
  "ingress-addresses": [
    "10.161.87.143"
  ]
}
```
- `juju run --unit ubuntu/0 "network-get juju-info --format yaml"` will include both `address` and `value`:
```yaml
bind-addresses:
- mac-address: 00:16:3e:95:00:2d
  interface-name: eth0
  addresses:
  - hostname: ""
    value: 10.161.87.143
    cidr: 10.161.87.0/24
    address: 10.161.87.143
  macaddress: 00:16:3e:95:00:2d
  interfacename: eth0
egress-subnets:
- 10.161.87.143/32
ingress-addresses:
- 10.161.87.143
```

## Documentation changes

None.

## Bug reference

N/A
