### PR TITLE
[JUJU-1101] make_color_mode_default_juju_status

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -78,10 +78,8 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	w := startSection(tw, true, header...)
 	versionPos := indexOf("Version", header)
 	w.Print(values[:versionPos]...)
-	staleVersion := false
 	modelVersionNum, err := version.Parse(fs.Model.Version)
-	staleVersion = err == nil && jujuversion.Current.Compare(modelVersionNum) > 0
-	if staleVersion {
+	if err == nil && jujuversion.Current.Compare(modelVersionNum) > 0 {
 		w.PrintColor(output.WarningHighlight, fs.Model.Version)
 	} else {
 		w.Print(fs.Model.Version)
@@ -223,13 +221,10 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			w.PrintColor(output.InfoHighlight, app.Address)
 		}
 
-		var exposed string
 		if app.Exposed {
-			exposed = "yes"
-			w.PrintColor(output.GoodHighlight, exposed)
+			w.PrintColor(output.GoodHighlight, "yes")
 		} else {
-			exposed = "no"
-			w.Print(exposed)
+			w.Print("no")
 		}
 
 		w.PrintColor(output.EmphasisHighlight.Gray, app.StatusInfo.Message)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -213,7 +213,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 
 		w.Print(app.CharmName, app.CharmChannel, app.CharmRev)
 		if fs.Model.Type == caasModelType {
-			w.Print(app.Address)
+			w.PrintColor(output.InfoHighlight, app.Address)
 		}
 
 		exposed := "no"
@@ -252,19 +252,15 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		w.PrintStatus(u.WorkloadStatusInfo.Current)
 		w.PrintStatus(u.JujuStatusInfo.Current)
 		if fs.Model.Type == caasModelType {
-			w.Println(
-				u.Address,
-				strings.Join(u.OpenedPorts, ","),
-				message,
-			)
+			w.PrintColor(output.InfoHighlight, u.Address)
+			w.PrintColor(output.EmphasisHighlight, strings.Join(u.OpenedPorts, ","))
+			w.Println(message)
 			return
 		}
-		w.Println(
-			u.Machine,
-			u.PublicAddress,
-			strings.Join(u.OpenedPorts, ","),
-			message,
-		)
+		w.Print(u.Machine)
+		w.PrintColor(output.InfoHighlight, u.PublicAddress)
+		w.PrintColor(output.EmphasisHighlight, strings.Join(u.OpenedPorts, ","))
+		w.Println(message)
 	}
 
 	if len(units) > 0 {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -203,12 +203,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		if len(version) > maxVersionWidth {
 			version = version[:truncatedWidth] + ellipsis
 		}
-		w.Print(appName)
-		if version != app.CharmVersion {
-			w.PrintColor(output.WarningHighlight, version)
-		} else {
-			w.Print(version)
-		}
+		w.Print(appName, version)
 		w.PrintStatus(app.StatusInfo.Current)
 		scale, warn := fs.applicationScale(appName)
 		if warn {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -269,7 +269,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 				w.PrintColorNoTab(output.EmphasisHighlight.BrightMagenta, fmt.Sprintf("%s ", pp[0])) //port e.g 3306
 				w.PrintNoTab(fmt.Sprintf("/%s", pp[1]))                                              //append back the forward slash to the protocol name (3306/tcp)
 
-				if i != size && size > 1 {
+				if i != size-1 && size > 1 {
 					w.PrintNoTab(", ")
 				}
 			}

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -380,11 +380,11 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 
 	for _, r := range relations {
 		provider := strings.Split(r.Provider, ":")
-		w.PrintNoTab(provider[0])
-		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", provider[1]))//the service name (mysql)
+		w.PrintNoTab(provider[0])                                                       //the service name (mysql)
+		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", provider[1])) //the resource type (:cluster)
 		requirer := strings.Split(r.Requirer, ":")
-		w.PrintNoTab(requirer[0])
-		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", requirer[1]))//the resource type (:cluster)
+		w.PrintNoTab(requirer[0])                                                       //the service name (mysql)
+		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", requirer[1])) //the resource type (:cluster)
 		w.Print(r.Interface, r.Type)
 		if r.Status != string(relation.Joined) {
 			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -226,7 +226,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		var exposed string
 		if app.Exposed {
 			exposed = "yes"
-			w.PrintColor(output.EmphasisHighlight.BrightGreen, exposed)
+			w.PrintColor(output.GoodHighlight, exposed)
 		} else {
 			exposed = "no"
 			w.Print(exposed)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -212,7 +212,12 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			w.Print(scale)
 		}
 
-		w.Print(app.CharmName, app.CharmChannel, app.CharmRev)
+		w.Print(app.CharmName, app.CharmChannel)
+		if app.CanUpgradeTo != "" {
+			w.PrintColor(output.WarningHighlight, app.CharmRev)
+		} else {
+			w.Print(app.CharmRev)
+		}
 		if fs.Model.Type == caasModelType {
 			w.PrintColor(output.InfoHighlight, app.Address)
 		}
@@ -376,10 +381,10 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 	for _, r := range relations {
 		provider := strings.Split(r.Provider, ":")
 		w.PrintNoTab(provider[0])
-		w.PrintColor(output.EmphasisHighlight.BrightMagenta, fmt.Sprintf(":%s", provider[1]))
+		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", provider[1]))//the service name (mysql)
 		requirer := strings.Split(r.Requirer, ":")
 		w.PrintNoTab(requirer[0])
-		w.PrintColor(output.EmphasisHighlight.BrightMagenta, fmt.Sprintf(":%s", requirer[1]))
+		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", requirer[1]))//the resource type (:cluster)
 		w.Print(r.Interface, r.Type)
 		if r.Status != string(relation.Joined) {
 			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -389,7 +389,7 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 		if r.Status != string(relation.Joined) {
 			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)
 			if r.Message != "" {
-				w.Print(" - " + r.Message)
+				w.PrintColor(output.EmphasisHighlight.Gray, " - "+r.Message)
 			}
 		}
 		w.Println()

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -488,7 +488,9 @@ func printMachine(w output.Wrapper, m machineStatus) {
 	w.PrintStatus(status)
 	w.PrintColor(output.InfoHighlight, m.DNSName)
 	w.Print(m.machineName(), m.Series, az)
-	w.PrintColor(output.EmphasisHighlight.Gray, message)
+	if message != "" { //some unit tests were failing because of the printed empty string .
+		w.PrintColor(output.EmphasisHighlight.Gray, message)
+	}
 	w.Println()
 
 	for _, name := range naturalsort.Sort(stringKeysFromMap(m.Containers)) {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -421,6 +421,5 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *statusCommand) FormatTabular(writer io.Writer, value interface{}) error {
-	//enable coloring by default
-	return FormatTabular(writer, true, value)
+	return FormatTabular(writer, c.color, value)
 }

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -421,5 +421,6 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *statusCommand) FormatTabular(writer io.Writer, value interface{}) error {
-	return FormatTabular(writer, c.color, value)
+	//enable coloring by default
+	return FormatTabular(writer, true, value)
 }

--- a/cmd/juju/status/utils.go
+++ b/cmd/juju/status/utils.go
@@ -36,3 +36,13 @@ func recurseUnits(u unitStatus, il int, recurseMap func(string, unitStatus, int)
 func indent(prepend string, level int, append string) string {
 	return fmt.Sprintf("%s%*s%s", prepend, level, "", append)
 }
+
+//indexOf returns the position of an element in a slice if it exists otherwise it returns -1.
+func indexOf(element interface{}, data []interface{}) int {
+	for k, v := range data {
+		if element == v {
+			return k
+		}
+	}
+	return -1 //not found.
+}

--- a/cmd/juju/status/utils.go
+++ b/cmd/juju/status/utils.go
@@ -37,7 +37,7 @@ func indent(prepend string, level int, append string) string {
 	return fmt.Sprintf("%s%*s%s", prepend, level, "", append)
 }
 
-//indexOf returns the position of an element in a slice if it exists otherwise it returns -1.
+// indexOf returns the position of an element in a slice if it exists otherwise it returns -1.
 func indexOf(element interface{}, data []interface{}) int {
 	for k, v := range data {
 		if element == v {

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -169,7 +169,8 @@ func FormatStorageListForStatusTabular(writer *ansiterm.TabWriter, s CombinedSto
 			w.Print(getFilesystemAttachment(s, info).MountPoint)
 			w.Print(humanizeStorageSize(storageSize[storageId]))
 			w.PrintStatus(info.status.Current)
-			w.Println(info.status.Message)
+			w.PrintColor(output.EmphasisHighlight.Gray, info.status.Message)
+			w.Println()
 		}
 	}
 	return w.Flush()

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -98,7 +98,27 @@ var InfoHighlight = ansiterm.Foreground(ansiterm.Cyan)
 
 // EmphasisHighlight is used to show accompanying information, which
 // might be deemed as important by the user.
-var EmphasisHighlight = ansiterm.Foreground(ansiterm.BrightMagenta)
+var EmphasisHighlight = struct {
+	White         *ansiterm.Context
+	DefaultBold   *ansiterm.Context
+	BoldWhite     *ansiterm.Context
+	Gray          *ansiterm.Context
+	BoldGray      *ansiterm.Context
+	DarkGray      *ansiterm.Context
+	BoldDarkGray  *ansiterm.Context
+	BrightMagenta *ansiterm.Context
+	BrightGreen   *ansiterm.Context
+}{
+	White:         ansiterm.Foreground(ansiterm.White),
+	DefaultBold:   ansiterm.Foreground(ansiterm.Default).SetStyle(ansiterm.Bold),
+	BoldWhite:     ansiterm.Foreground(ansiterm.White).SetStyle(ansiterm.Bold),
+	Gray:          ansiterm.Foreground(ansiterm.Gray),
+	BoldGray:      ansiterm.Foreground(ansiterm.Gray).SetStyle(ansiterm.Bold),
+	BoldDarkGray:  ansiterm.Foreground(ansiterm.DarkGray).SetStyle(ansiterm.Bold),
+	DarkGray:      ansiterm.Foreground(ansiterm.DarkGray),
+	BrightMagenta: ansiterm.Foreground(ansiterm.BrightMagenta),
+	BrightGreen:   ansiterm.Foreground(ansiterm.BrightGreen),
+}
 
 var statusColors = map[status.Status]*ansiterm.Context{
 	// good

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -91,13 +91,13 @@ var WarningHighlight = ansiterm.Foreground(ansiterm.Yellow)
 // GoodHighlight is used to indicate good or success conditions.
 var GoodHighlight = ansiterm.Foreground(ansiterm.Green)
 
-//InfoHighlight is  the color used to indicate important details.
-//Generally that might be important to a user but not necessarily that
-//obvious.
+// InfoHighlight is  the color used to indicate important details.
+// Generally that might be important to a user but not necessarily that
+// obvious.
 var InfoHighlight = ansiterm.Foreground(ansiterm.Cyan)
 
-//EmphasisHighlight is used to show accompanying information, which
-//might be deemed as important by the user.
+// EmphasisHighlight is used to show accompanying information, which
+// might be deemed as important by the user.
 var EmphasisHighlight = ansiterm.Foreground(ansiterm.BrightMagenta)
 
 var statusColors = map[status.Status]*ansiterm.Context{

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -134,6 +134,7 @@ var EmphasisHighlight = struct {
 	BoldGray      *ansiterm.Context
 	DarkGray      *ansiterm.Context
 	BoldDarkGray  *ansiterm.Context
+	Magenta       *ansiterm.Context
 	BrightMagenta *ansiterm.Context
 	BrightGreen   *ansiterm.Context
 }{
@@ -144,6 +145,7 @@ var EmphasisHighlight = struct {
 	BoldGray:      ansiterm.Foreground(ansiterm.Gray).SetStyle(ansiterm.Bold),
 	BoldDarkGray:  ansiterm.Foreground(ansiterm.DarkGray).SetStyle(ansiterm.Bold),
 	DarkGray:      ansiterm.Foreground(ansiterm.DarkGray),
+	Magenta:       ansiterm.Foreground(ansiterm.Magenta),
 	BrightMagenta: ansiterm.Foreground(ansiterm.BrightMagenta),
 	BrightGreen:   ansiterm.Foreground(ansiterm.BrightGreen),
 }

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -45,6 +45,13 @@ func (w *Wrapper) Print(values ...interface{}) {
 	}
 }
 
+// PrintNoTab writes each value adjacent to each other.
+func (w *Wrapper) PrintNoTab(values ...interface{}) {
+	for _, v := range values {
+		fmt.Fprintf(w, "%v", v)
+	}
+}
+
 // Printf writes the formatted text followed by a tab.
 func (w *Wrapper) Printf(format string, values ...interface{}) {
 	fmt.Fprintf(w, format+"\t", values...)
@@ -69,6 +76,27 @@ func (w *Wrapper) PrintColor(ctx *ansiterm.Context, value interface{}) {
 	} else {
 		fmt.Fprintf(w, "%v\t", value)
 	}
+}
+
+// PrintColorNoTab writes the value out in the color context specified.
+func (w *Wrapper) PrintColorNoTab(ctx *ansiterm.Context, value interface{}) {
+	if ctx != nil {
+		ctx.Fprintf(w.TabWriter, "%v", value)
+	} else {
+		fmt.Fprintf(w, "%v", value)
+	}
+}
+
+// PrintHeaders writes out many tab separated values in the color context specificed.
+func (w *Wrapper) PrintHeaders(ctx *ansiterm.Context, values ...interface{}) {
+	for i, v := range values {
+		if i != len(values)-1 {
+			ctx.Fprintf(w, "%v\t", v)
+		} else {
+			ctx.Fprintf(w, "%v", v)
+		}
+	}
+	fmt.Fprintln(w)
 }
 
 // PrintStatus writes out the status value in the standard color.

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -91,6 +91,15 @@ var WarningHighlight = ansiterm.Foreground(ansiterm.Yellow)
 // GoodHighlight is used to indicate good or success conditions.
 var GoodHighlight = ansiterm.Foreground(ansiterm.Green)
 
+//InfoHighlight is  the color used to indicate important details.
+//Generally that might be important to a user but not necessarily that
+//obvious.
+var InfoHighlight = ansiterm.Foreground(ansiterm.Cyan)
+
+//EmphasisHighlight is used to show accompanying information, which
+//might be deemed as important by the user.
+var EmphasisHighlight = ansiterm.Foreground(ansiterm.BrightMagenta)
+
 var statusColors = map[status.Status]*ansiterm.Context{
 	// good
 	status.Active:    GoodHighlight,


### PR DESCRIPTION
 *Enable color by default for juju status*


## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Please check that the following fields match their corresponding highlight colors in the cli.*
 - version -> yellow highlight, 
 - address -> blue highlight, 
 - ports -> bright magenta highlight


```sh
juju status
```
