### PR TITLE
[JUJU-1118] Bug 1970608: should not have a local charm channel

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1445,11 +1445,11 @@ func getApplicationSourceChannel(a description.Application, url *charm.URL) (cor
 	}
 
 	c := a.Channel()
-	if c == "" {
+	if c == "" || source == corecharm.Local {
 		return source, nil
 	}
 
-	if source == corecharm.CharmStore || source == corecharm.Local {
+	if source == corecharm.CharmStore {
 		return source, &Channel{Risk: a.Channel()}
 	}
 

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3687,6 +3687,16 @@ func EnsureCharmOriginRisk(pool *StatePool) error {
 
 		var ops []txn.Op
 		for _, doc := range docs {
+			// It is expected that every application should have a charm URL.
+			charmURL := doc.CharmURL
+			if charmURL == nil {
+				return errors.Errorf("charmurl is empty")
+			}
+
+			if charmURL.Schema == "local" {
+				continue
+			}
+
 			// This should never happen, instead we should always have one.
 			// See: AddCharmOriginToApplications
 			if doc.CharmOrigin == nil {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -4275,3 +4275,45 @@ func UpdateOperationWithEnqueuingErrors(pool *StatePool) error {
 	}
 	return st.runRawTransaction(ops)
 }
+
+// RemoveLocalCharmOriginChannels removes the charm-origin channel from all
+// local charms, it cannot have even an empty risk. See LP1970608.
+func RemoveLocalCharmOriginChannels(pool *StatePool) error {
+	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
+		col, closer := st.db().GetCollection(applicationsC)
+		defer closer()
+
+		var docs []applicationDoc
+		if err := col.Find(nil).All(&docs); err != nil {
+			return errors.Trace(err)
+		}
+
+		var ops []txn.Op
+		for _, doc := range docs {
+			// It is expected that every application should have a charm URL.
+			charmURL := doc.CharmURL
+			if charmURL == nil {
+				return errors.Errorf("charmurl is empty")
+			}
+
+			if charmURL.Schema != "local" {
+				continue
+			}
+
+			if doc.CharmOrigin == nil || doc.CharmOrigin.Channel == nil {
+				continue
+			}
+
+			ops = append(ops, txn.Op{
+				C:      applicationsC,
+				Id:     doc.DocID,
+				Assert: txn.DocExists,
+				Update: bson.D{{"$unset", bson.D{{"charm-origin.channel", nil}}}},
+			})
+		}
+		if len(ops) > 0 {
+			return errors.Trace(st.db().RunTransaction(ops))
+		}
+		return nil
+	}))
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -5434,10 +5434,6 @@ func (s *upgradesSuite) TestEnsureCharmOriginRisk(c *gc.C) {
 			"source":   "local",
 			"type":     "charm",
 			"revision": 12,
-			"channel": bson.M{
-				"track": "latest",
-				"risk":  "edge",
-			},
 			"platform": bson.M{
 				"architecture": "amd64",
 				"series":       "focal",
@@ -5456,10 +5452,6 @@ func (s *upgradesSuite) TestEnsureCharmOriginRisk(c *gc.C) {
 			"id":       "local:test",
 			"hash":     "",
 			"revision": -1,
-			"channel": bson.M{
-				"track": "latest",
-				"risk":  "",
-			},
 			"platform": bson.M{
 				"architecture": "amd64",
 				"series":       "focal",
@@ -5528,10 +5520,6 @@ func (s *upgradesSuite) TestEnsureCharmOriginRisk(c *gc.C) {
 				"source":   "local",
 				"type":     "charm",
 				"revision": 12,
-				"channel": bson.M{
-					"track": "latest",
-					"risk":  "edge",
-				},
 				"platform": bson.M{
 					"architecture": "amd64",
 					"series":       "focal",
@@ -5549,10 +5537,6 @@ func (s *upgradesSuite) TestEnsureCharmOriginRisk(c *gc.C) {
 				"id":       "local:test",
 				"hash":     "",
 				"revision": -1,
-				"channel": bson.M{
-					"track": "latest",
-					"risk":  "stable",
-				},
 				"platform": bson.M{
 					"architecture": "amd64",
 					"series":       "focal",

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -107,6 +107,7 @@ type StateBackend interface {
 	SetContainerAddressOriginToMachine() error
 	UpdateCharmOriginAfterSetSeries() error
 	UpdateOperationWithEnqueuingErrors() error
+	RemoveLocalCharmOriginChannels() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -467,4 +468,8 @@ func (s stateBackend) UpdateCharmOriginAfterSetSeries() error {
 
 func (s stateBackend) UpdateOperationWithEnqueuingErrors() error {
 	return state.UpdateOperationWithEnqueuingErrors(s.pool)
+}
+
+func (s stateBackend) RemoveLocalCharmOriginChannels() error {
+	return state.RemoveLocalCharmOriginChannels(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -59,6 +59,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.24"), stateStepsFor2924()},
 		upgradeToVersion{version.MustParse("2.9.26"), stateStepsFor2926()},
 		upgradeToVersion{version.MustParse("2.9.29"), stateStepsFor2929()},
+		upgradeToVersion{version.MustParse("2.9.30"), stateStepsFor2930()},
 	}
 	return steps
 }

--- a/upgrades/steps_2930.go
+++ b/upgrades/steps_2930.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2930 returns database upgrade steps for Juju 2.9.30
+func stateStepsFor2930() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "remove channels from local charm origins",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveLocalCharmOriginChannels()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2930_test.go
+++ b/upgrades/steps_2930_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2930 = version.MustParse("2.9.30")
+
+type steps2930Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2930Suite{})
+
+func (s *steps2930Suite) TestRemoveLocalCharmOriginChannels(c *gc.C) {
+	step := findStateStep(c, v2930, "remove channels from local charm origins")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -648,6 +648,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.24",
 		"2.9.26",
 		"2.9.29",
+		"2.9.30",
 	})
 }
 


### PR DESCRIPTION
A 2.9.12 upgrade steps introduced a bug where local charms were given a channel in their origins. This causes a failure when running a bundle with local charms more than once as the channels do not match. Fixed the old upgrade step: EnsureCharmOriginRisk. Then added a new upgrade step to remove the channel from the local charm origins, as even an empty risk results in stable being assumed. This was introduced in upgrade step AddCharmOriginToApplications. 

Update migration import to ensure that any models with local charms upgraded from pre 2.9.12 then migrated will not carry over the same problem.

## QA steps

```sh
$ cat ./bundle.yaml
series: focal
applications:
  u:
    charm: ./ubuntu
    num_units: 1
$ charm pull cs:ubuntu
$ snap refresh juju --channel 2.8/stable
$ juju bootstrap localhost testme
$ juju deploy ./bundle.yaml
Executing changes:
- upload charm /home/heather/notes/bug-1970608/ubuntu for series focal
- deploy application u on focal using /home/heather/notes/bug-1970608/ubuntu
- add unit u/0 to new machine 1
Deploy of bundle completed.
$ juju deploy cs:ubuntu
Located charm "cs:ubuntu-18".
Deploying charm "cs:ubuntu-18".
# wait for it to settle

# now using the new juju
$ juju upgrade-controller --build-agent
$ juju upgrade-juju
$ juju deploy ./bundle.yaml
No changes to apply.
$ juju refresh ubuntu
charm "ubuntu": already up-to-date
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1970608