### PR TITLE
Use default arch when provisioning a machine

### DIFF
--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/controller/authentication"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
@@ -1475,12 +1476,13 @@ func (task *provisionerTask) setupToStartMachine(machine apiprovisioner.MachineP
 		return environs.StartInstanceParams{}, errors.Annotatef(err, "creating instance config for machine %q", machine)
 	}
 
-	var arch string
+	// We default to amd64 unless otherwise specified.
+	agentArch := arch.DefaultArchitecture
 	if pInfo.Constraints.Arch != nil {
-		arch = *pInfo.Constraints.Arch
+		agentArch = *pInfo.Constraints.Arch
 	}
 
-	possibleTools, err := task.toolsFinder.FindTools(*version, pInfo.Series, arch)
+	possibleTools, err := task.toolsFinder.FindTools(*version, pInfo.Series, agentArch)
 	if err != nil {
 		return environs.StartInstanceParams{}, errors.Annotatef(err, "finding agent binaries for machine %q", machine)
 	}

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -1980,8 +1980,9 @@ func (f mockToolsFinder) FindTools(number version.Number, series string, a strin
 	if err != nil {
 		return nil, err
 	}
-	if a != "" {
-		v.Arch = a
+	if a == "" {
+		return nil, errors.New("missing arch")
 	}
+	v.Arch = a
 	return coretools.List{&coretools.Tools{Version: v}}, nil
 }


### PR DESCRIPTION
Found when doing the 2.9.30 release candidate smoke tests - a 2.8 model does not record machine architecture. In 2.9, we default to amd64, and recent changes have added more strict checks around this. Upgrading from a 2.8 controller, if there is a machine that was not yet provisioned at the time of the upgrade, there would be no arch specified when locating agents to use, and so multiple would be found, one for each arch. This is now an error in 2.9.

The fix is to use the default arch when provisioning in case the model doesn't have one.

## QA steps

bootstrap a 2.8 model and deploy a charm
immediately upgrade before the machine has been provisioned
