### PR TITLE
Update references to jujucharms.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,8 @@ Documentation:
 * [source tree docs](doc/)
 
 Community:
-* https://jujucharms.com/community/
-* https://discourse.jujucharms.com/
-* [#juju on freenode](http://webchat.freenode.net/?channels=juju)
+* https://chat.charmhub.io
+* https://discourse.charmhub.io/
 
 Building Juju
 =============
@@ -408,6 +407,5 @@ beyond the workflow and the [issue tracker](https://bugs.launchpad.net/juju/+bug
 
 Use the following links to contact the community:
 
- - Community page: https://jujucharms.com/community/
- - IRC channel on freenode: `#juju`
- - Discourse forum: [https://discourse.jujucharms.com/](https://discourse.jujucharms.com/)
+ - Mattermost chat: [https://chat.charmhub.io/](https://chat.charmhub.io/)
+ - Discourse forum: [https://discourse.charmhub.io/](https://discourse.charmhub.io/)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
  - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
  - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
- - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
+ - [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
  - [ ] Comments answer the question of why design decisions were made
 
 ## QA steps

--- a/acceptancetests/README.md
+++ b/acceptancetests/README.md
@@ -55,8 +55,8 @@ The script is parameter-rich and should be able to accept any tweaks that you wa
 
 Further description can be found here in discourse:
 
-here: [discourse-link](https://discourse.jujucharms.com/t/call-for-testing-running-acceptance-tests-locally-and-easily/1449)
-and here: [discourse-link](https://discourse.jujucharms.com/t/wip-juju-acceptance-testing-primer/1482)
+here: [discourse-link](https://discourse.charmhub.io/t/call-for-testing-running-acceptance-tests-locally-and-easily/1449)
+and here: [discourse-link](https://discourse.charmhub.io/t/wip-juju-acceptance-testing-primer/1482)
 
 ### Quick run using LXD
 To run a test locally with lxd and locally complied juju:

--- a/acceptancetests/repository/charms/mediawiki/README.md
+++ b/acceptancetests/repository/charms/mediawiki/README.md
@@ -118,7 +118,7 @@ When set to true this option will enable the following MediaWiki options: `$wgDe
 
 [1]: https://juju.ubuntu.com/docs/getting-started.html
 [2]: https://juju.ubuntu.com/docs/getting-started.html#installation
-[3]: http://jujucharms.com/charms/precise/mysql
+[3]: http://charmhub.io/mysql
 [4]: http://www.mediawiki.org/wiki/Manual:$wgDefaultSkin
 [5]: http://packages.ubuntu.com/precise/mediawiki
 [6]: http://www.mediawiki.org/wiki/Download_from_Git

--- a/acceptancetests/repository/charms/mysql/README.md
+++ b/acceptancetests/repository/charms/mysql/README.md
@@ -45,7 +45,7 @@ You can add further slaves with:
 
 ## Monitoring
 
-This charm provides relations that support monitoring via either [Nagios](https://jujucharms.com/precise/nagios) or [Munin](https://jujucharms.com/precise/munin/). Refer to the appropriate charm for usage.
+This charm provides relations that support monitoring via either [Nagios](https://charmhub.io/nagios) or [Munin](https://charmhub.io/munin/). Refer to the appropriate charm for usage.
 
 # Configuration
 

--- a/acceptancetests/repository/charms/statusstresser/README.md
+++ b/acceptancetests/repository/charms/statusstresser/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/acceptancetests/repository/charms/ubuntu/README.md
+++ b/acceptancetests/repository/charms/ubuntu/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/acceptancetests/repository/trusty/mysql/README.md
+++ b/acceptancetests/repository/trusty/mysql/README.md
@@ -45,7 +45,7 @@ You can add further slaves with:
 
 ## Monitoring
 
-This charm provides relations that support monitoring via either [Nagios](https://jujucharms.com/precise/nagios) or [Munin](https://jujucharms.com/precise/munin/). Refer to the appropriate charm for usage.
+This charm provides relations that support monitoring via either [Nagios](https://charmhub.io/nagios) or [Munin](https://charmhub.io/munin/). Refer to the appropriate charm for usage.
 
 # Configuration
 

--- a/acceptancetests/repository/trusty/statusstresser/README.md
+++ b/acceptancetests/repository/trusty/statusstresser/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/acceptancetests/repository/trusty/ubuntu/README.md
+++ b/acceptancetests/repository/trusty/ubuntu/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/acceptancetests/repository/xenial/mysql/README.md
+++ b/acceptancetests/repository/xenial/mysql/README.md
@@ -45,7 +45,7 @@ You can add further slaves with:
 
 ## Monitoring
 
-This charm provides relations that support monitoring via either [Nagios](https://jujucharms.com/precise/nagios) or [Munin](https://jujucharms.com/precise/munin/). Refer to the appropriate charm for usage.
+This charm provides relations that support monitoring via either [Nagios](https://charmhub.io/nagios) or [Munin](https://charmhub.io/munin/). Refer to the appropriate charm for usage.
 
 # Configuration
 

--- a/acceptancetests/repository/xenial/ubuntu/README.md
+++ b/acceptancetests/repository/xenial/ubuntu/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -656,7 +656,7 @@ func caasPrecheck(
 				"deploying this Kubernetes application requires a suitable storage class.\n" +
 					"None have been configured. Set the operator-storage model config to " +
 					"specify which storage class should be used to allocate operator storage.\n" +
-					"See https://discourse.jujucharms.com/t/getting-started/152.",
+					"See https://discourse.charmhub.io/t/getting-started/152.",
 			)
 		}
 		sp, err := caasoperatorprovisioner.CharmStorageParams("", storageClassName, cfg, "", storagePoolManager, registry)

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -95,7 +95,7 @@ Use --controller option to upload a credential to a controller.
 Use --client option to add a credential to the current client.
 
 Further help:
-Please visit https://discourse.jujucharms.com/t/1508 for cloud-specific
+Please visit https://discourse.charmhub.io/t/1508 for cloud-specific
 instructions.
 
 See also: 

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -891,7 +891,7 @@ Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.jujucharms.com/t/1508).
+(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 `[1:]
 	stderr := `
@@ -947,7 +947,7 @@ Enter your choice, or type Q|q to quit: Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.jujucharms.com/t/1508).
+(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 Credential "blah" added locally for cloud "remote".
 
@@ -976,7 +976,7 @@ Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.jujucharms.com/t/1508).
+(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 `[1:]
 	stderr := `

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -2055,7 +2055,7 @@ global or per instance security groups.`,
 	},
 	ProvisionerHarvestModeKey: {
 		// default: destroyed, but also depends on current setting of ProvisionerSafeModeKey
-		Description: "What to do with unknown machines. See https://jujucharms.com/stable/config-general#juju-lifecycle-and-harvesting (default destroyed)",
+		Description: "What to do with unknown machines (default destroyed)",
 		Type:        environschema.Tstring,
 		Values:      []interface{}{"all", "none", "unknown", "destroyed"},
 		Group:       environschema.EnvironGroup,

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -52,7 +52,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 		cloud.JSONFileAuthType: {{
 			Name: credAttrFile,
 			CredentialAttr: cloud.CredentialAttr{
-				Description: "path to the .json file containing a service account key for your project\n(detailed instructions available at https://discourse.jujucharms.com/t/1508).\nPath",
+				Description: "path to the .json file containing a service account key for your project\n(detailed instructions available at https://discourse.charmhub.io/t/1508).\nPath",
 				FilePath:    true,
 			},
 		}},

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -4,7 +4,7 @@
 #define MyAppName "Juju"
 #define MyAppVersion "2.9.22"
 #define MyAppPublisher "Canonical, Ltd"
-#define MyAppURL "http://jujucharms.com/"
+#define MyAppURL "http://juju.is/"
 #define MyAppExeName "juju.exe"
 
 [Setup]

--- a/tests/suites/bootstrap/charms/ubuntu/README.md
+++ b/tests/suites/bootstrap/charms/ubuntu/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/tests/suites/model/charms/ubuntu/README.md
+++ b/tests/suites/model/charms/ubuntu/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/tests/suites/smoke/charms/ubuntu/README.md
+++ b/tests/suites/smoke/charms/ubuntu/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/tests/suites/upgrade/charms/ubuntu/README.md
+++ b/tests/suites/upgrade/charms/ubuntu/README.md
@@ -48,5 +48,5 @@ This charm has no configuration options.
 
 - Author: Juju Charm Community
 - Report bugs at: [http://bugs.launchpad.net/charms/+source/ubuntu](http://bugs.launchpad.net/charms/+source/ubuntu)
-- Location: [http://jujucharms.com/charms/precise/ubuntu](http://jujucharms.com/charms/precise/ubuntu)
+- Location: [http://charmhub.io/ubuntu](http://charmhub.io/ubuntu)
 

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -206,7 +206,7 @@ tmux kill-session -t $JUJU_UNIT_NAME # or, equivalently, CTRL+a d
 4. CTRL+a is tmux prefix.
 
 More help and info is available in the online documentation:
-https://discourse.jujucharms.com/t/debugging-charm-hooks
+https://discourse.charmhub.io/t/debugging-charm-hooks
 
 `
 


### PR DESCRIPTION
I was reading through some of the bitesize bugs, and [LP#1836818](https://bugs.launchpad.net/juju/+bug/1836818) caught my eye. The issue in question is actually no longer an issue, but there were several references to URLs that either don't exist, or should probably just refer to `charmhub.io` or `juju.is`. This PR is purely presentational and just updates those links.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.jujucharms.com/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## Documentation changes

There are multiple READMEs that are affected here, mostly in the test suite. There is one item that changes a CLI help page, where the link previously returned a 404. I was unable to locate the original document on charmhub.io.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1836818