### PR TITLE
Address consistency in use of id/Id/ID in command line output

### DIFF
--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -244,7 +244,7 @@ func (c *listOperationsCommand) formatTabular(writer io.Writer, value interface{
 			w.Println(line.operation)
 		}
 	}
-	w.Println("Id", "Status", "Started", "Finished", "Task IDs", "Summary")
+	w.Println("ID", "Status", "Started", "Finished", "Task IDs", "Summary")
 	printOperations(actionOperationLinesFromResults(results), c.utc)
 	return tw.Flush()
 }

--- a/cmd/juju/action/listoperations_test.go
+++ b/cmd/juju/action/listoperations_test.go
@@ -188,7 +188,7 @@ func (s *ListOperationsSuite) TestRunPlain(c *gc.C) {
 		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin", "--utc")
 		c.Assert(err, jc.ErrorIsNil)
 		expected := `
-Id  Status   Started  Finished             Task IDs  Summary
+ID  Status   Started  Finished             Task IDs  Summary
  1  error                                  2         operation 1
  3  running           2014-02-14T06:06:06  4         operation 3
  5  pending                                6         operation 5
@@ -216,7 +216,7 @@ func (s *ListOperationsSuite) TestRunPlainTruncated(c *gc.C) {
 Displaying operation results 13 to 16.
 Run the command again with --offset=16 --limit=4 to see the next batch.
 
-Id  Status   Started  Finished             Task IDs  Summary
+ID  Status   Started  Finished             Task IDs  Summary
  1  error                                  2         operation 1
  3  running           2014-02-14T06:06:06  4         operation 3
  5  pending                                6         operation 5
@@ -284,7 +284,7 @@ func (s *ListOperationsSuite) TestRunPlainManyTasks(c *gc.C) {
 		ctx, err := cmdtesting.RunCommand(c, s.wrappedCommand, modelFlag, "admin", "--utc")
 		c.Assert(err, jc.ErrorIsNil)
 		expected := `
-Id  Status     Started              Finished  Task IDs      Summary
+ID  Status     Started              Finished  Task IDs      Summary
  1  completed  2015-02-14T06:06:06            2,3,4,5,6...  operation 1
 
 `[1:]

--- a/cmd/juju/crossmodel/list_test.go
+++ b/cmd/juju/crossmodel/list_test.go
@@ -132,7 +132,7 @@ func (s *ListSuite) TestListTabularNoConnections(c *gc.C) {
 		c,
 		[]string{"--format", "tabular"},
 		`
-Offer       User  Relation id  Status  Endpoint  Interface  Role  Ingress subnets
+Offer       User  Relation ID  Status  Endpoint  Interface  Role  Ingress subnets
 hosted-db2  -                                                     
 
 `[1:],
@@ -191,7 +191,7 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 		c,
 		[]string{"--format", "tabular"},
 		`
-Offer       User  Relation id  Status  Endpoint  Interface  Role      Ingress subnets
+Offer       User  Relation ID  Status  Endpoint  Interface  Role      Ingress subnets
 adiff-db2   mary  3            joined  db        db2        provider  
 hosted-db2  -                                                         
 zdiff-db2   fred  1            joined  server    mysql      provider  
@@ -209,7 +209,7 @@ func (s *ListSuite) TestListTabularActiveOnly(c *gc.C) {
 		c,
 		[]string{"--format", "tabular", "--active-only"},
 		`
-Offer      User  Relation id  Status  Endpoint  Interface  Role      Ingress subnets
+Offer      User  Relation ID  Status  Endpoint  Interface  Role      Ingress subnets
 adiff-db2  mary  3            joined  db        db2        provider  
 zdiff-db2  fred  1            joined  server    mysql      provider  
            mary  1            joined  server    mysql      provider  192.168.0.1/32,10.0.0.0/8

--- a/cmd/juju/crossmodel/listformatter.go
+++ b/cmd/juju/crossmodel/listformatter.go
@@ -101,7 +101,7 @@ func formatListEndpointsTabular(writer io.Writer, offers offeredApplications) er
 	}
 	sort.Sort(allOffers)
 
-	w.Println("Offer", "User", "Relation id", "Status", "Endpoint", "Interface", "Role", "Ingress subnets")
+	w.Println("Offer", "User", "Relation ID", "Status", "Endpoint", "Interface", "Role", "Ingress subnets")
 	for _, offer := range allOffers {
 		// Sort endpoints alphabetically.
 		endpoints := []string{}

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -515,7 +515,7 @@ func (s modelResourceErrorStatusSummary) PrettyPrint(writer io.Writer) error {
 The following errors were encountered during destroying the model.
 You can fix the problem causing the errors and run destroy-model again.
 `)
-	w.Println("Resource", "Id", "Message")
+	w.Println("Resource", "ID", "Message")
 	for _, resources := range []map[string][]modelResourceErrorStatus{
 		{"Machine": s.Machines},
 		{"Filesystem": s.Filesystems},

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -480,7 +480,7 @@ even with potentially orphaned cloud resources.
 The following errors were encountered during destroying the model.
 You can fix the problem causing the errors and run destroy-model again.
 
-Resource    Id  Message
+Resource    ID  Message
 Filesystem  0   failed to destroy filesystem 0
             1   failed to destroy filesystem 1
 Volume      0   failed to destroy volume 0

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -95,7 +95,7 @@ func (s *MinimalStatusSuite) TestGoodCallWithStorage(c *gc.C) {
 Model  Controller  Cloud/Region  Version
 test   test        foo           
 
-Storage Unit  Storage id    Type        Pool      Mountpoint  Size    Status    Message
+Storage Unit  Storage ID    Type        Pool      Mountpoint  Size    Status    Message
               persistent/1  filesystem                                detached  
 postgresql/0  db-dir/1100   block                             3.0MiB  attached  
 transcode/0   db-dir/1000   block                                     pending   creating volume

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -89,7 +89,7 @@ func (s *ListSuite) TestFilesystemListWithErrorResults(c *gc.C) {
 }
 
 var expectedFilesystemListTabular = `
-Machine  Unit         Storage id   Id   Volume  Provider id                       Mountpoint  Size    State      Message
+Machine  Unit         Storage ID   ID   Volume  Provider ID                       Mountpoint  Size    State      Message
 0        abc/0        db-dir/1001  0/0  0/1     provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached   
 0        transcode/0  shared-fs/0  4            provider-supplied-filesystem-4    /mnt/doom   1.0GiB  attached   
 0                                  1            provider-supplied-filesystem-1                2.0GiB  attaching  failed to attach, will retry
@@ -116,7 +116,7 @@ func (s *ListSuite) TestFilesystemListTabular(c *gc.C) {
 }
 
 var expectedCAASFilesystemListTabular = `
-Unit     Storage id   Id   Provider id                       Mountpoint  Size    State     Message
+Unit     Storage ID   ID   Provider ID                       Mountpoint  Size    State     Message
 mysql/0  db-dir/1001  0/0  provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached  
 
 `[1:]

--- a/cmd/juju/storage/filesystemlistformatters.go
+++ b/cmd/juju/storage/filesystemlistformatters.go
@@ -69,9 +69,9 @@ func formatFilesystemListTabular(writer io.Writer, infos map[string]FilesystemIn
 	sort.Sort(filesystemAttachmentInfos)
 
 	if haveMachines {
-		print("Machine", "Unit", "Storage id", "Id", "Volume", "Provider id", "Mountpoint", "Size", "State", "Message")
+		print("Machine", "Unit", "Storage ID", "ID", "Volume", "Provider ID", "Mountpoint", "Size", "State", "Message")
 	} else {
-		print("Unit", "Storage id", "Id", "Provider id", "Mountpoint", "Size", "State", "Message")
+		print("Unit", "Storage ID", "ID", "Provider ID", "Mountpoint", "Size", "State", "Message")
 	}
 
 	for _, info := range filesystemAttachmentInfos {

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -43,7 +43,7 @@ func (s *ListSuite) TestList(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-Unit          Storage id    Type        Pool      Size    Status    Message
+Unit          Storage ID    Type        Pool      Size    Status    Message
               persistent/1  filesystem                    detached  
 postgresql/0  db-dir/1100   block                 3.0MiB  attached  
 transcode/0   db-dir/1000   block                         pending   creating volume
@@ -60,7 +60,7 @@ func (s *ListSuite) TestListNoPool(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-Unit          Storage id    Type        Size    Status    Message
+Unit          Storage ID    Type        Size    Status    Message
               persistent/1  filesystem          detached  
 postgresql/0  db-dir/1100   block       3.0MiB  attached  
 transcode/0   db-dir/1000   block               pending   creating volume

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -23,7 +23,7 @@ func formatStorageInstancesListTabular(writer io.Writer, s CombinedStorage) erro
 	storagePool, storageSize := getStoragePoolAndSize(s)
 	units, byUnit := sortStorageInstancesByUnitId(s)
 
-	w.Print("Unit", "Storage id", "Type")
+	w.Print("Unit", "Storage ID", "Type")
 	if len(storagePool) > 0 {
 		// Older versions of Juju do not include
 		// the pool name in the storage details.
@@ -33,7 +33,7 @@ func formatStorageInstancesListTabular(writer io.Writer, s CombinedStorage) erro
 	w.Println("Size", "Status", "Message")
 
 	for _, unit := range units {
-		// Then sort by storage ids
+		// Then sort by storage IDs
 		byStorage := byUnit[unit]
 		storageIds := make([]string, 0, len(byStorage))
 		for storageId := range byStorage {
@@ -158,7 +158,7 @@ func FormatStorageListForStatusTabular(writer *ansiterm.TabWriter, s CombinedSto
 	units, byUnit := sortStorageInstancesByUnitId(s)
 
 	w.Println()
-	w.Print("Storage Unit", "Storage id", "Type")
+	w.Print("Storage Unit", "Storage ID", "Type")
 	if len(storagePool) > 0 {
 		w.Print("Pool")
 	}

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -27,9 +27,9 @@ func NewShowCommand() cmd.Command {
 
 const showCommandDoc = `
 Show extended information about storage instances.
-Storage instances to display are specified by storage ids. 
-Storage ids are positional arguments to the command and do not need to be comma
-separated when more than one id is desired.
+Storage instances to display are specified by storage IDs. 
+Storage IDs are positional arguments to the command and do not need to be comma
+separated when more than one ID is desired.
 
 `
 
@@ -44,7 +44,7 @@ type showCommand struct {
 // Init implements Command.Init.
 func (c *showCommand) Init(args []string) (err error) {
 	if len(args) < 1 {
-		return errors.New("must specify storage id(s)")
+		return errors.New("must specify storage ID(s)")
 	}
 	c.ids = args
 	return nil
@@ -108,7 +108,7 @@ func (c *showCommand) getStorageTags() ([]names.StorageTag, error) {
 	tags := make([]names.StorageTag, len(c.ids))
 	for i, id := range c.ids {
 		if !names.IsValidStorage(id) {
-			return nil, errors.Errorf("invalid storage id %v", id)
+			return nil, errors.Errorf("invalid storage ID %v", id)
 		}
 		tags[i] = names.NewStorageTag(id)
 	}

--- a/cmd/juju/storage/show_test.go
+++ b/cmd/juju/storage/show_test.go
@@ -76,7 +76,7 @@ shared-fs/0:
 
 func (s *ShowSuite) TestShowInvalidId(c *gc.C) {
 	_, err := s.runShow(c, []string{"foo"})
-	c.Assert(err, gc.ErrorMatches, ".*invalid storage id foo.*")
+	c.Assert(err, gc.ErrorMatches, ".*invalid storage ID foo.*")
 }
 
 func (s *ShowSuite) TestShowJSON(c *gc.C) {

--- a/cmd/juju/storage/volume.go
+++ b/cmd/juju/storage/volume.go
@@ -17,7 +17,7 @@ import (
 
 // VolumeInfo defines the serialization behaviour for storage volume.
 type VolumeInfo struct {
-	// from params.Volume. This is provider-supplied unique volume id.
+	// from params.Volume. This is provider-supplied unique volume ID.
 	ProviderVolumeId string `yaml:"provider-id,omitempty" json:"provider-id,omitempty"`
 
 	// Storage is the ID of the storage instance that the volume is

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -90,7 +90,7 @@ func (s *ListSuite) TestVolumeListWithErrorResults(c *gc.C) {
 }
 
 var expectedVolumeListTabular = `
-Machine  Unit         Storage id   Volume id  Provider Id                   Device  Size    State      Message
+Machine  Unit         Storage ID   Volume ID  Provider ID                   Device  Size    State      Message
 0        abc/0        db-dir/1001  0/0        provider-supplied-volume-0-0  loop0   512MiB  attached   
 0        transcode/0  shared-fs/0  4          provider-supplied-volume-4    xvdf2   1.0GiB  attached   
 0                                  1          provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry
@@ -118,7 +118,7 @@ func (s *ListSuite) TestVolumeListTabular(c *gc.C) {
 }
 
 var expectedCAASVolumeListTabular = `
-Unit     Storage id   Volume id  Provider Id                 Size    State     Message
+Unit     Storage ID   Volume ID  Provider ID                 Size    State     Message
 mysql/0  db-dir/1001  0          provider-supplied-volume-0  512MiB  attached  
 
 `[1:]

--- a/cmd/juju/storage/volumelistformatters.go
+++ b/cmd/juju/storage/volumelistformatters.go
@@ -69,9 +69,9 @@ func formatVolumeListTabular(writer io.Writer, infos map[string]VolumeInfo) erro
 	sort.Sort(volumeAttachmentInfos)
 
 	if haveMachines {
-		print("Machine", "Unit", "Storage id", "Volume id", "Provider Id", "Device", "Size", "State", "Message")
+		print("Machine", "Unit", "Storage ID", "Volume ID", "Provider ID", "Device", "Size", "State", "Message")
 	} else {
-		print("Unit", "Storage id", "Volume id", "Provider Id", "Size", "State", "Message")
+		print("Unit", "Storage ID", "Volume ID", "Provider ID", "Size", "State", "Message")
 	}
 
 	for _, info := range volumeAttachmentInfos {

--- a/cmd/plugins/juju-metadata/listformatter.go
+++ b/cmd/plugins/juju-metadata/listformatter.go
@@ -28,7 +28,7 @@ func formatMetadataTabular(writer io.Writer, metadata []MetadataInfo) {
 	print := func(values ...string) {
 		fmt.Fprintln(tw, strings.Join(values, "\t"))
 	}
-	print("Source", "Series", "Arch", "Region", "Image id", "Stream", "Virt Type", "Storage Type")
+	print("Source", "Series", "Arch", "Region", "Image ID", "Stream", "Virt Type", "Storage Type")
 
 	for _, m := range metadata {
 		print(m.Source, m.Series, m.Arch, m.Region, m.ImageId, m.Stream, m.VirtType, m.RootStorageType)

--- a/cmd/plugins/juju-metadata/listimages_test.go
+++ b/cmd/plugins/juju-metadata/listimages_test.go
@@ -77,7 +77,7 @@ func runList(c *gc.C, args []string) (*cmd.Context, error) {
 func (s *ListSuite) TestListDefault(c *gc.C) {
 	// Default format is tabular
 	s.assertValidList(c, `
-Source  Series  Arch   Region  Image id  Stream    Virt Type  Storage Type
+Source  Series  Arch   Region  Image ID  Stream    Virt Type  Storage Type
 custom  vivid   amd64  asia    im-21     released  kvm        ebs
 custom  vivid   amd64  europe  im-21     released  kvm        ebs
 custom  vivid   amd64  us      im-21     released  kvm        ebs

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -131,7 +131,7 @@ func (s *cmdStorageSuite) TestStorageList(c *gc.C) {
 	createUnitWithStorage(c, &s.JujuConnSuite, testPool)
 
 	expected := `
-Unit             Storage id  Type   Size  Status   Message
+Unit             Storage ID  Type   Size  Status   Message
 storage-block/0  data/0      block        pending  
 
 `[1:]
@@ -144,7 +144,7 @@ func (s *cmdStorageSuite) TestStorageListPersistent(c *gc.C) {
 	// There are currently no guarantees about whether storage
 	// will be persistent until it has been provisioned.
 	expected := `
-Unit             Storage id  Type   Size  Status   Message
+Unit             Storage ID  Type   Size  Status   Message
 storage-block/0  data/0      block        pending  
 
 `[1:]
@@ -455,7 +455,7 @@ func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	stdout, _, err := runVolumeList(c, "0")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
-Machine  Unit             Storage id  Volume id  Provider Id  Device  Size  State    Message
+Machine  Unit             Storage ID  Volume id  Provider Id  Device  Size  State    Message
 0        storage-block/0  data/0      0/0                                   pending  
 
 `[1:]
@@ -575,7 +575,7 @@ func (s *cmdStorageSuite) TestStorageAddToUnitHasVolumes(c *gc.C) {
 	context, err := runCommand(c, "storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
-Unit                  Storage id  Type        Size  Status   Message
+Unit                  Storage ID  Type        Size  Status   Message
 storage-filesystem/0  data/0      filesystem        pending  
 
 `[1:])
@@ -596,7 +596,7 @@ storage-filesystem/0  data/0      filesystem        pending
 	context, err = runCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, `
-Unit                  Storage id  Type        Size  Status   Message
+Unit                  Storage ID  Type        Size  Status   Message
 storage-filesystem/0  data/0      filesystem        pending  
 storage-filesystem/0  data/1      filesystem        pending  
 
@@ -648,7 +648,7 @@ func (s *cmdStorageSuite) TestStorageDetachAttach(c *gc.C) {
 	ctx, err := runCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-Unit             Storage id  Type   Pool         Size    Status     Message
+Unit             Storage ID  Type   Pool         Size    Status     Message
                  allecto/2   block  modelscoped  1.0GiB  detaching  
 storage-block/0  data/0      block                       pending    
 storage-block/1  data/1      block                       pending    
@@ -676,7 +676,7 @@ storage-block/1  data/1      block                       pending
 	ctx, err = runCommand(c, "list-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-Unit             Storage id  Type   Pool         Size    Status     Message
+Unit             Storage ID  Type   Pool         Size    Status     Message
 storage-block/0  data/0      block                       pending    
 storage-block/1  allecto/2   block  modelscoped  1.0GiB  attaching  
 storage-block/1  data/1      block                       pending    

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -76,11 +76,11 @@ func runShow(c *gc.C, expectedError string, args ...string) {
 }
 
 func (s *cmdStorageSuite) TestStorageShowEmpty(c *gc.C) {
-	runShow(c, "must specify storage id")
+	runShow(c, "must specify storage ID")
 }
 
 func (s *cmdStorageSuite) TestStorageShowInvalidId(c *gc.C) {
-	runShow(c, "invalid storage id", "fluff")
+	runShow(c, "invalid storage ID", "fluff")
 }
 
 func (s *cmdStorageSuite) TestStorageShow(c *gc.C) {
@@ -455,7 +455,7 @@ func (s *cmdStorageSuite) TestListVolumeTabularFilterMatch(c *gc.C) {
 	stdout, _, err := runVolumeList(c, "0")
 	c.Assert(err, jc.ErrorIsNil)
 	expected := `
-Machine  Unit             Storage ID  Volume id  Provider Id  Device  Size  State    Message
+Machine  Unit             Storage ID  Volume ID  Provider ID  Device  Size  State    Message
 0        storage-block/0  data/0      0/0                                   pending  
 
 `[1:]


### PR DESCRIPTION
We are very using `id`/`ID`/`Id` very inconsistently in command line output - this [bug](https://bugs.launchpad.net/juju/+bug/1884151) highlights it specifically in the storage module, so I've started there and cleaned up some of the output to use `ID` consistently.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## Bug reference

https://bugs.launchpad.net/juju/+bug/1884151
