### PR TITLE
[JUJU-1125] Improve error message for local OCI image resource

### DIFF
--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"strings"
 
@@ -123,11 +124,11 @@ func (d deployUploader) upload(resourceValues map[string]string, revisions map[s
 	for name, resValue := range resourceValues {
 		r, err := OpenResource(resValue, d.resources[name].Type, d.filesystem.Open)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "resource %q", name)
 		}
 		id, err := d.uploadPendingResource(name, resValue, r)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "resource %q", name)
 		}
 		pending[name] = id
 	}
@@ -145,7 +146,7 @@ func (d deployUploader) validateResourceDetails(res map[string]string) error {
 			var dockerDetails resources.DockerImageDetails
 			dockerDetails, err = getDockerDetailsData(value, d.filesystem.Open)
 			if err != nil {
-				return err
+				return errors.Annotatef(err, "resource %q", name)
 			}
 			// At the moment this is the same validation that occurs in getDockerDetailsData
 			err = resources.CheckDockerDetails(name, dockerDetails)
@@ -273,9 +274,17 @@ func unMarshalDockerDetails(data io.Reader) (resources.DockerImageDetails, error
 		return details, errors.Trace(err)
 	}
 
-	if err := json.Unmarshal(contents, &details); err != nil {
-		if err := yaml.Unmarshal(contents, &details); err != nil {
-			return details, errors.Annotate(err, "file neither valid json or yaml")
+	if errJ := json.Unmarshal(contents, &details); errJ != nil {
+		if errY := yaml.Unmarshal(contents, &details); errY != nil {
+			contentType := http.DetectContentType(contents)
+			if strings.Contains(contentType, "text/plain") {
+				// Check first character - `{` means probably JSON
+				if strings.TrimSpace(string(contents))[0] == '{' {
+					return details, errors.Annotate(errJ, "json parsing")
+				}
+				return details, errY
+			}
+			return details, errors.New("expected json or yaml file containing oci-image registry details")
 		}
 	}
 	if err := resources.ValidateDockerRegistryPath(details.RegistryPath); err != nil {

--- a/invalid.json
+++ b/invalid.json
@@ -1,0 +1,6 @@
+
+{
+  "ImageName": "registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image",
+  "Username": "docker-registry",,
+  "Password": "hunter2"
+}

--- a/invalid.yaml
+++ b/invalid.yaml
@@ -1,0 +1,4 @@
+
+registrypath: registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image
+username: docker-registry
+password: 'hunter2',,


### PR DESCRIPTION
Fixes [lp#1958253](https://bugs.launchpad.net/juju/+bug/1958253). We now check whether the file provided to `XXXXXX-image` is json, yaml or binary, and return the corresponding error.

I've also rewritten the `TestDeployDockerResource*` tests to be table-driven, which made it easy to add new tests covering my changes.

### QA steps

```sh
$ juju deploy kubernetes-dashboard --resource dashboard-image=./invalid.json
ERROR resource "dashboard-image": json parsing: ...
$ juju deploy kubernetes-dashboard --resource dashboard-image=./invalid.yaml
ERROR resource "dashboard-image": yaml: ...
$ juju deploy kubernetes-dashboard --resource dashboard-image=./dashboard.tar
ERROR resource "dashboard-image": expected json or yaml file
```