### PR TITLE
[JUJU-1083] Make tests upgrade from 2.8

### DIFF
--- a/.github/reg.yml
+++ b/.github/reg.yml
@@ -80,5 +80,5 @@ spec:
   clusterIP: 10.152.183.69
   ports:
     - name: "registry"
-      port: 5000
+      port: 443
       targetPort: 5000

--- a/.github/verify-elasticsearch-k8s.sh
+++ b/.github/verify-elasticsearch-k8s.sh
@@ -12,7 +12,7 @@ while true; do
   fi
   attempts=$((attempts+1))
 
-  ip=$(juju status --format json | jq -r '.applications."elasticsearch-k8s".units[].address' || echo "")
+  ip=$(juju status --format json | jq -r '.applications."elasticsearch-k8s".address' || echo "")
   app_status=$(curl --silent --max-time 3 "${ip}:9200/_cluster/health" | jq -r ".status" || echo "")
   [ "$app_status" == "green" ] && break
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -64,7 +64,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        snap_version: ["latest/stable", "latest/beta"]
+        snap_version: ["2.8/stable"]
         model_type: ["localhost", "microk8s"]
     env:
       CHARM_localhost: apache2
@@ -209,7 +209,7 @@ jobs:
       # and filter with as standard, instead of skipping over them with this flag
       run: |
         set -euxo pipefail
-
+        sleep 60
         sg microk8s <<EOF
           juju bootstrap microk8s c \
             --config caas-image-repo='{"repository": "${DOCKER_REGISTRY}/test-repo", "serveraddress": "https://${DOCKER_REGISTRY}/"}' \
@@ -220,6 +220,20 @@ jobs:
 
         juju status
         juju version
+
+    # The `wait-for` plugin is used after deploying an application
+    # This was added in Juju 2.9, so it's not installed by the 2.8 snap
+    # However we just need to install the `wait-for` binary ourselves,
+    # and then Juju 2.8 can use it (amazing!)
+    - name: Add `wait-for` plugin
+      shell: bash
+      run: |
+        # Download a stable version of Juju
+        curl -L -O https://github.com/juju/juju/archive/refs/tags/juju-2.9.29.tar.gz
+        tar -xf juju-2.9.29.tar.gz
+        cd juju-juju-2.9.29/
+        go install github.com/juju/juju/cmd/plugins/juju-wait-for
+        cd ..
 
     - name: Deploy some applications
       if: env.RUN_TEST == 'RUN'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -69,7 +69,7 @@ jobs:
     env:
       CHARM_localhost: apache2
       CHARM_microk8s: elasticsearch-k8s
-      DOCKER_REGISTRY: 10.152.183.69:5000
+      DOCKER_REGISTRY: 10.152.183.69
 
     steps:
 
@@ -214,7 +214,7 @@ jobs:
         sg microk8s <<EOF
           juju bootstrap microk8s c \
             --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
-            --config features="[developer-mode]" --debug
+            --config features="[developer-mode]" --debug --keep-broken
         EOF
         juju add-model m
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -92,6 +92,7 @@ jobs:
         sudo apt-get remove lxd lxd-client
         sudo snap install snapcraft --classic
         sudo snap install lxd
+        sudo snap install yq
         sudo snap install juju --classic --channel=${{ matrix.snap_version }}
 
         sudo lxd waitready
@@ -111,7 +112,11 @@ jobs:
 
         echo "::set-output name=go-version::$(grep '^go ' go.mod | awk '{print $2}')"
         echo "::set-output name=base-juju-version::$(juju version | cut -d '-' -f 1)"
-        echo "::set-output name=upstream-juju-version::$(grep -r "const version =" version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')"
+        upstreamJujuVersion=$(grep -r "const version =" version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')
+        echo "::set-output name=upstream-juju-version::${upstreamJujuVersion}"
+        currentStableChannel="$(echo $upstreamJujuVersion | cut -d'.' -f1,2)/stable"
+        currentStableVersion=$(snap info juju | yq ".channels[\"$currentStableChannel\"]" | cut -d' ' -f1)
+        echo "::set-output name=current-stable-juju-version::$currentStableVersion"
         echo "::set-output name=juju-db-version::4.0"
       id: vars
 
@@ -268,6 +273,7 @@ jobs:
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
       env:
         UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
+        CURRENT_STABLE_JUJU_TAG: ${{ steps.vars.outputs.current-stable-juju-version }}
       run: |
         set -euxo pipefail
 
@@ -283,6 +289,16 @@ jobs:
         EOL
         docker build ~ -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${UPSTREAM_JUJU_TAG}
         docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${UPSTREAM_JUJU_TAG}
+        
+        cat >~/Dockerfile <<EOL
+          FROM jujusolutions/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
+
+          COPY certs/ca.crt /usr/local/share/ca-certificates/ca.crt
+
+          RUN update-ca-certificates
+        EOL
+        docker build ~ -t ${DOCKER_REGISTRY}/test-repo/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
+        docker push ${DOCKER_REGISTRY}/test-repo/jujud-operator:${CURRENT_STABLE_JUJU_TAG}
 
     - name: Preflight
       if: env.RUN_TEST == 'RUN'
@@ -304,7 +320,7 @@ jobs:
 
         # upgrade to the latest stable.
         juju upgrade-controller --debug
-
+        sleep 20
         juju upgrade-controller ${UPGRADE_PARAMS_${{ matrix.model_type }}}
 
         attempt=0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -125,7 +125,7 @@ jobs:
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
       uses: balchua/microk8s-actions@v0.2.2
       with:
-        channel: "latest/stable"
+        channel: "1.23/stable"
         addons: '["dns", "storage"]'
 
     - name: Setup local caas registry

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -376,3 +376,7 @@ jobs:
 
         sg microk8s "microk8s kubectl get all -A" || true
         lxc ls || true
+
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -302,6 +302,9 @@ jobs:
       run: |
         set -euxo pipefail
 
+        # upgrade to the latest stable.
+        juju upgrade-controller --debug
+
         juju upgrade-controller ${UPGRADE_PARAMS_${{ matrix.model_type }}}
 
         attempt=0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -130,7 +130,7 @@ jobs:
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
       uses: balchua/microk8s-actions@v0.2.2
       with:
-        channel: "1.23/stable"
+        channel: "latest/stable"
         addons: '["dns", "storage"]'
 
     - name: Setup local caas registry
@@ -219,7 +219,7 @@ jobs:
         sg microk8s <<EOF
           juju bootstrap microk8s c \
             --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
-            --config features="[developer-mode]" --debug --keep-broken
+            --config features="[developer-mode]"
         EOF
         juju add-model m
 
@@ -319,7 +319,7 @@ jobs:
       run: |
         set -euxo pipefail
 
-        # upgrade to the latest stable.
+        # Upgrade to the latest stable.
         juju upgrade-controller --debug
         
         attempt=0
@@ -336,6 +336,7 @@ jobs:
           fi
         done
         
+        # Upgrade to local built version.
         juju upgrade-controller ${UPGRADE_PARAMS_${{ matrix.model_type }}}
 
         attempt=0
@@ -398,7 +399,7 @@ jobs:
           exit 1
         fi
 
-        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 3
+        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 5
 
     - name: Wrap up
       if: env.RUN_TEST == 'RUN'
@@ -410,7 +411,3 @@ jobs:
 
         sg microk8s "microk8s kubectl get all -A" || true
         lxc ls || true
-
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -112,7 +112,7 @@ jobs:
         echo "::set-output name=go-version::$(grep '^go ' go.mod | awk '{print $2}')"
         echo "::set-output name=base-juju-version::$(juju version | cut -d '-' -f 1)"
         echo "::set-output name=upstream-juju-version::$(grep -r "const version =" version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')"
-        echo "::set-output name=juju-db-version::4.0/stable"
+        echo "::set-output name=juju-db-version::4.0"
       id: vars
 
     - name: Set up Go
@@ -214,7 +214,6 @@ jobs:
         sg microk8s <<EOF
           juju bootstrap microk8s c \
             --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
-            --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
             --config features="[developer-mode]" --debug
         EOF
         juju add-model m

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -313,6 +313,7 @@ jobs:
       shell: bash
       env:
         UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
+        CURRENT_STABLE_JUJU_TAG: ${{ steps.vars.outputs.current-stable-juju-version }}
         UPGRADE_PARAMS_localhost: ""
         UPGRADE_PARAMS_microk8s: "--agent-stream=develop --debug"
       run: |
@@ -320,7 +321,21 @@ jobs:
 
         # upgrade to the latest stable.
         juju upgrade-controller --debug
-        sleep 20
+        
+        attempt=0
+        while true; do
+          UPDATED=$((juju show-controller --format=json || echo "") | jq -r '.c.details."agent-version"')
+          if [[ $UPDATED == $CURRENT_STABLE_JUJU_TAG* ]]; then
+              break
+          fi
+          sleep 10
+          attempt=$((attempt+1))
+          if [ "$attempt" -eq 48 ]; then
+              echo "Upgrade controller timed out"
+              exit 1
+          fi
+        done
+        
         juju upgrade-controller ${UPGRADE_PARAMS_${{ matrix.model_type }}}
 
         attempt=0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -359,7 +359,7 @@ jobs:
             exit 1
         fi
 
-        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 3
+        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 5
 
     - name: Test upgrade model
       if: env.RUN_TEST == 'RUN'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -210,18 +210,13 @@ jobs:
       # and filter with as standard, instead of skipping over them with this flag
       run: |
         set -euxo pipefail
-        
-        while true
-        do
-          sg microk8s <<EOF
-            juju bootstrap microk8s c \
-              --config caas-image-repo='{"repository": "${DOCKER_REGISTRY}/test-repo", "serveraddress": "https://${DOCKER_REGISTRY}/"}' \
-              --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
-              --config features="[developer-mode]" || true
+
+        sg microk8s <<EOF
+          juju bootstrap microk8s c \
+            --config caas-image-repo="${DOCKER_REGISTRY}/test-repo" \
+            --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
+            --config features="[developer-mode]" --debug
         EOF
-          sleep 30
-        done
-        
         juju add-model m
 
         juju status

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -112,7 +112,7 @@ jobs:
         echo "::set-output name=go-version::$(grep '^go ' go.mod | awk '{print $2}')"
         echo "::set-output name=base-juju-version::$(juju version | cut -d '-' -f 1)"
         echo "::set-output name=upstream-juju-version::$(grep -r "const version =" version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')"
-        echo "::set-output name=juju-db-version::$(grep -r 'DefaultJujuDBSnapChannel =' controller/config.go | sed -r 's/^\s*DefaultJujuDBSnapChannel = \"([[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+){0,1})\/.*\"$/\1/')"
+        echo "::set-output name=juju-db-version::4.0/stable"
       id: vars
 
     - name: Set up Go

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -158,6 +158,7 @@ jobs:
 
         # TODO:(jack-w-shaw) Figure out why we need this and do something nicer
         sudo microk8s refresh-certs --cert ca.crt
+        sudo microk8s refresh-certs --cert server.crt
 
         # Wait for registry
         sg microk8s "microk8s kubectl wait --for condition=available deployment registry -n container-registry --timeout 180s" || true
@@ -209,13 +210,18 @@ jobs:
       # and filter with as standard, instead of skipping over them with this flag
       run: |
         set -euxo pipefail
-        sleep 60
-        sg microk8s <<EOF
-          juju bootstrap microk8s c \
-            --config caas-image-repo='{"repository": "${DOCKER_REGISTRY}/test-repo", "serveraddress": "https://${DOCKER_REGISTRY}/"}' \
-            --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
-            --config features="[developer-mode]"
+        
+        while true
+        do
+          sg microk8s <<EOF
+            juju bootstrap microk8s c \
+              --config caas-image-repo='{"repository": "${DOCKER_REGISTRY}/test-repo", "serveraddress": "https://${DOCKER_REGISTRY}/"}' \
+              --config juju-db-snap-channel="${JUJU_DB_TAG}/stable" \
+              --config features="[developer-mode]" || true
         EOF
+          sleep 30
+        done
+        
         juju add-model m
 
         juju status

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -130,7 +130,7 @@ jobs:
       if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
       uses: balchua/microk8s-actions@v0.2.2
       with:
-        channel: "latest/stable"
+        channel: "1.23/stable"
         addons: '["dns", "storage"]'
 
     - name: Setup local caas registry

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -298,7 +298,7 @@ jobs:
       env:
         UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
         UPGRADE_PARAMS_localhost: ""
-        UPGRADE_PARAMS_microk8s: ""
+        UPGRADE_PARAMS_microk8s: "--agent-stream=develop --debug"
       run: |
         set -euxo pipefail
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -244,7 +244,7 @@ jobs:
         # Required for elasticsearch
         sudo sysctl -w vm.max_map_count=262144
 
-        juju deploy ${CHARM_${{ matrix.model_type }}} --series focal
+        juju deploy ${CHARM_${{ matrix.model_type }}}
 
         juju wait-for application ${CHARM_${{ matrix.model_type }}}
 

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -881,7 +881,7 @@ func (c *Client) toolVersionsForCAAS(args params.FindToolsParams, streamsVersion
 			}
 		}
 		arch, err := reg.GetArchitecture(imageName, number.String())
-		if errors.IsNotFound(errors.Cause(err)) {
+		if errors.IsNotFound(err) {
 			continue
 		}
 		if err != nil {

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -881,7 +881,7 @@ func (c *Client) toolVersionsForCAAS(args params.FindToolsParams, streamsVersion
 			}
 		}
 		arch, err := reg.GetArchitecture(imageName, number.String())
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(errors.Cause(err)) {
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
A re-pull of #14015 which I accidentally closed.

The Upgrade tests should be trying to upgrade from the last minor version - i.e. for 2.9, we should try to upgrade from 2.8.