### PR TITLE
Added two examples to juju status help

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -139,8 +139,14 @@ Examples:
     juju status --format=json
 
     # Watch the status of the mysql application every five seconds
-	# Only available for unix-based systems.
+    # Only available for unix-based systems.
     juju status --watch 5s mysql
+
+    # Show only applications/units in active status
+    juju status active
+
+    # Show only applications/units in error status
+    juju status error
 
 See also:
 


### PR DESCRIPTION
Add two simple examples to the juju status help text that show how to filter by application/unit status. I actually had no idea you could do this...

## Bug reference

https://bugs.launchpad.net/juju/+bug/1727639
