### PR TITLE
[JUJU-1157] Check that an AgentStreamKey value exists.

### DIFF
--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -440,8 +440,8 @@ func (c *upgradeJujuCommand) upgradeModel(ctx *cmd.Context, implicitUploadAllowe
 	}
 	haveControllerModelPermission := err == nil
 	isControllerModel := haveControllerModelPermission && cfg.UUID() == controllerModelConfig[config.UUIDKey]
-	modelStream := controllerModelConfig[config.AgentStreamKey]
-	if modelStream == "" {
+	modelStream, ok := controllerModelConfig[config.AgentStreamKey]
+	if modelStream == "" || !ok {
 		modelStream = tools.ReleasedStream
 	}
 	wantStream := c.AgentStream


### PR DESCRIPTION
LP1973811. The key above doesn't exist in the controller config map, so our agent stream handling wasn't proper, nor was the warning output. Set the modelString value if empty or does not exist.

This is a bandaid and leaves open the question of why the agent-stream was missing from the ControllerConfig. The code change ensures the intent, if the agent-stream config value does not exist or is empty, use a sane default.

## QA steps

I reproduced by adding `delete(controllerModelConfig, config.AgentStreamKey)` to the code right before my change. No idea how this happened in the wild.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1973811