### PR TITLE
Increase the number of open file descriptors.

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -89,10 +89,12 @@ jobs:
     - name: "Test client: macOS-latest"
       if: (matrix.os == 'macOS-latest')
       run: |
-        # There is a concurrency issue with macos setup for the "./cmd/juju/..." packages.
-        # So we have to limit amount of used CPUs and therefore parallelization
-        go test -v -p 1 ./cmd/juju/... -check.v
-        go test -v  ./cmd/plugins/... -check.v
+        # We increase the number of file descriptors that processes can have 
+        # open so mongo doesn't fail. Client tests still rely on mongo and as
+        # such we have a high request count for FD's
+        ulimit -n 8192
+        go test -v ./cmd/juju/... -check.v
+        go test -v ./cmd/plugins/... -check.v
       shell: bash
 
     - name: "Test client: ubuntu-latest"


### PR DESCRIPTION
macos tests require more file descriptors then the default for mongo to
behave.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Watch the github actions run successfully. They will more then likely fail in this PR as new action changes aren't picked up till after the merge. You can see a test result here https://github.com/tlm/juju/runs/6517961435?check_suite_focus=true
