### PR TITLE
[JUJU-1122] Reject if --build-agent was provided for a snap juju;

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -283,7 +283,7 @@ jobs:
       shell: bash
       env:
         UPSTREAM_JUJU_TAG: ${{ steps.vars.outputs.upstream-juju-version }}
-        UPGRADE_PARAMS_localhost: "--build-agent"
+        UPGRADE_PARAMS_localhost: ""
         UPGRADE_PARAMS_microk8s: ""
       run: |
         set -euxo pipefail

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -301,23 +301,43 @@ func packageLocalTools(toolsDir string, buildAgent bool) error {
 type BundleToolsFunc func(build bool, w io.Writer, forceVersion *version.Number) (version.Binary, bool, string, error)
 
 // Override for testing.
-var BundleTools BundleToolsFunc = bundleTools
+var BundleTools BundleToolsFunc = func(
+	build bool, w io.Writer, forceVersion *version.Number,
+) (version.Binary, bool, string, error) {
+	return bundleTools(build, w, forceVersion, JujudVersion)
+}
 
 // bundleTools bundles all the current juju tools in gzipped tar
 // format to the given writer.  If forceVersion is not nil and the
 // file isn't an official build, a FORCE-VERSION file is included in
 // the tools bundle so it will lie about its current version number.
-func bundleTools(build bool, w io.Writer, forceVersion *version.Number) (_ version.Binary, official bool, sha256hash string, _ error) {
+func bundleTools(
+	build bool, w io.Writer, forceVersion *version.Number, jujudVersion func(dir string) (version.Binary, bool, error),
+) (_ version.Binary, official bool, sha256hash string, _ error) {
 	dir, err := ioutil.TempDir("", "juju-tools")
 	if err != nil {
 		return version.Binary{}, false, "", err
 	}
 	defer os.RemoveAll(dir)
+
+	existingJujuLocation, err := ExistingJujuLocation()
+	if err != nil {
+		return version.Binary{}, false, "", errors.Annotate(err, "couldn't find existing jujud")
+	}
+	_, official, err = jujudVersion(existingJujuLocation)
+	if err != nil {
+		return version.Binary{}, official, "", errors.Trace(err)
+	}
+	if official && build {
+		return version.Binary{}, official, "", errors.Errorf("can not build agent for official build")
+	}
+
 	if err := packageLocalTools(dir, build); err != nil {
 		return version.Binary{}, false, "", err
 	}
 
-	tvers, official, err := JujudVersion(dir)
+	// We need to get the version again because the juju binaries at dir might be built from source code.
+	tvers, official, err := jujudVersion(dir)
 	if err != nil {
 		return version.Binary{}, false, "", errors.Trace(err)
 	}

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -357,11 +357,12 @@ func bundleTools(
 	return tvers, official, sha256hash, err
 }
 
-var execCommand = exec.Command
+// Override for testing.
+var ExecCommand = exec.Command
 
 func getVersionFromJujud(dir string) (version.Binary, error) {
 	path := filepath.Join(dir, names.Jujud)
-	cmd := execCommand(path, "version")
+	cmd := ExecCommand(path, "version")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -329,7 +329,7 @@ func bundleTools(
 		return version.Binary{}, official, "", errors.Trace(err)
 	}
 	if official && build {
-		return version.Binary{}, official, "", errors.Errorf("can not build agent for official build")
+		return version.Binary{}, official, "", errors.Errorf("cannot build agent for official build")
 	}
 
 	if err := packageLocalTools(dir, build); err != nil {

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -351,7 +351,7 @@ func (b *buildSuite) TestBundleToolsFailForOfficialBuildWithBuildAgent(c *gc.C) 
 
 	forceVersion := version.MustParse("1.2.3.1")
 	_, official, _, err := tools.BundleToolsForTest(true, bundleFile, &forceVersion, jujudVersion)
-	c.Assert(err, gc.ErrorMatches, `can not build agent for official build`)
+	c.Assert(err, gc.ErrorMatches, `cannot build agent for official build`)
 	c.Assert(official, jc.IsTrue)
 }
 

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -168,7 +168,7 @@ func (b *buildSuite) TestGetVersionFromJujud(c *gc.C) {
 		Args:   argsCh,
 	})
 
-	b.PatchValue(tools.ExecCommand, execCommand)
+	b.PatchValue(&tools.ExecCommand, execCommand)
 
 	v, err := tools.GetVersionFromJujud("foo")
 	c.Assert(err, jc.ErrorIsNil)
@@ -191,7 +191,7 @@ func (b *buildSuite) TestGetVersionFromJujudWithParseError(c *gc.C) {
 		Args:   argsCh,
 	})
 
-	b.PatchValue(tools.ExecCommand, execCommand)
+	b.PatchValue(&tools.ExecCommand, execCommand)
 
 	_, err := tools.GetVersionFromJujud("foo")
 	c.Assert(err, gc.ErrorMatches, `invalid version "oops, not a valid version" printed by jujud`)
@@ -214,7 +214,7 @@ func (b *buildSuite) TestGetVersionFromJujudWithRunError(c *gc.C) {
 		Args:     argsCh,
 	})
 
-	b.PatchValue(tools.ExecCommand, execCommand)
+	b.PatchValue(&tools.ExecCommand, execCommand)
 
 	_, err := tools.GetVersionFromJujud("foo")
 
@@ -316,26 +316,8 @@ func (b *buildSuite) TestBundleToolsMatchesBinaryUsingOsTypeArch(c *gc.C) {
 }
 
 func (b *buildSuite) TestJujudVersion(c *gc.C) {
+	b.patchExecCommand(c)
 	dir := b.setUpFakeBinaries(c, "")
-
-	// Patch so that getting the version from our fake binary in the
-	// absence of a version file works.
-	ver := version.Binary{
-		Number: version.Number{
-			Major: 1,
-			Minor: 2,
-			Patch: 3,
-		},
-		Release: "ubuntu",
-		Arch:    "amd64",
-	}
-
-	execCommand := b.GetExecCommand(exttest.PatchExecConfig{
-		Stdout: ver.String(),
-		Args:   make(chan []string, 1),
-	})
-
-	b.PatchValue(tools.ExecCommand, execCommand)
 
 	resultVersion, official, err := tools.JujudVersion(dir)
 	c.Assert(err, jc.ErrorIsNil)
@@ -343,29 +325,11 @@ func (b *buildSuite) TestJujudVersion(c *gc.C) {
 	c.Assert(official, jc.IsFalse)
 }
 
-func (b *buildSuite) TestBundleToolsWithNoVersion(c *gc.C) {
+func (b *buildSuite) TestBundleToolsWithNoVersionFile(c *gc.C) {
+	b.patchExecCommand(c)
 	dir := b.setUpFakeBinaries(c, "")
 	bundleFile, err := os.Create(filepath.Join(dir, "bundle"))
 	c.Assert(err, jc.ErrorIsNil)
-
-	// Patch so that getting the version from our fake binary in the
-	// absence of a version file works.
-	ver := version.Binary{
-		Number: version.Number{
-			Major: 1,
-			Minor: 2,
-			Patch: 3,
-		},
-		Release: "ubuntu",
-		Arch:    "amd64",
-	}
-
-	execCommand := b.GetExecCommand(exttest.PatchExecConfig{
-		Stdout: ver.String(),
-		Args:   make(chan []string, 1),
-	})
-
-	b.PatchValue(tools.ExecCommand, execCommand)
 
 	forceVersion := version.MustParse("1.2.3.1")
 	resultVersion, official, sha, err := tools.BundleTools(false, bundleFile, &forceVersion)
@@ -376,10 +340,22 @@ func (b *buildSuite) TestBundleToolsWithNoVersion(c *gc.C) {
 }
 
 func (b *buildSuite) TestBundleToolsFailForOfficialBuildWithBuildAgent(c *gc.C) {
+	b.patchExecCommand(c)
 	dir := b.setUpFakeBinaries(c, "")
 	bundleFile, err := os.Create(filepath.Join(dir, "bundle"))
 	c.Assert(err, jc.ErrorIsNil)
 
+	jujudVersion := func(dir string) (version.Binary, bool, error) {
+		return version.Binary{}, true, nil
+	}
+
+	forceVersion := version.MustParse("1.2.3.1")
+	_, official, _, err := tools.BundleToolsForTest(true, bundleFile, &forceVersion, jujudVersion)
+	c.Assert(err, gc.ErrorMatches, `can not build agent for official build`)
+	c.Assert(official, jc.IsTrue)
+}
+
+func (b *buildSuite) patchExecCommand(c *gc.C) {
 	// Patch so that getting the version from our fake binary in the
 	// absence of a version file works.
 	ver := version.Binary{
@@ -391,23 +367,16 @@ func (b *buildSuite) TestBundleToolsFailForOfficialBuildWithBuildAgent(c *gc.C) 
 		Release: "ubuntu",
 		Arch:    "amd64",
 	}
-
 	execCommand := b.GetExecCommand(exttest.PatchExecConfig{
 		Stdout: ver.String(),
-		Args:   make(chan []string, 1),
+		Args:   make(chan []string, 2),
 	})
-	b.PatchValue(tools.ExecCommand, execCommand)
-	jujudVersion := func(dir string) (version.Binary, bool, error) {
-		return version.Binary{}, true, nil
-	}
-
-	forceVersion := version.MustParse("1.2.3.1")
-	_, official, _, err := tools.BundleToolsForTest(true, bundleFile, &forceVersion, jujudVersion)
-	c.Assert(err, gc.ErrorMatches, `can not build agent for official build`)
-	c.Assert(official, jc.IsTrue)
+	b.PatchValue(&tools.ExecCommand, execCommand)
 }
 
 func (b *buildSuite) TestBundleToolsFindsVersionFileInFallbackLocation(c *gc.C) {
+	b.patchExecCommand(c)
+
 	// No version file next to the binary.
 	dir := b.setUpFakeBinaries(c, "")
 	// But one in the fallback location.

--- a/environs/tools/export_test.go
+++ b/environs/tools/export_test.go
@@ -12,6 +12,7 @@ var (
 	MarshalToolsMetadataIndexJSON = marshalToolsMetadataIndexJSON
 	GetVersionFromJujud           = getVersionFromJujud
 	ExecCommand                   = &execCommand
+	BundleToolsForTest            = bundleTools
 )
 
 func VersionsMatchingHash(v *Versions, h string) []string {

--- a/environs/tools/export_test.go
+++ b/environs/tools/export_test.go
@@ -11,7 +11,6 @@ var (
 	CurrentStreamsVersion         = currentStreamsVersion
 	MarshalToolsMetadataIndexJSON = marshalToolsMetadataIndexJSON
 	GetVersionFromJujud           = getVersionFromJujud
-	ExecCommand                   = &execCommand
 	BundleToolsForTest            = bundleTools
 )
 


### PR DESCRIPTION
`--build-agent` is purely for local development purposes, so disallow to use it for snap juju client.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ which juju
/snap/bin/juju

$ juju bootstrap lxd k1 --build-agent
Creating Juju controller "k1" on lxd/localhost
Building local Juju agent binary version 2.9.31 for amd64
ERROR failed to bootstrap model: cannot package bootstrap agent binary: can not build agent for official build

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1812191