### PR TITLE
[JUJU-1161] Deploy cmd panic when invalid placements

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -869,6 +869,9 @@ func checkMachinePlacement(backend Backend, args params.ApplicationDeploy) error
 	app := args.ApplicationName
 
 	for _, p := range args.Placement {
+		if p == nil {
+			continue
+		}
 		dir := p.Directive
 
 		toProvisionedMachine := p.Scope == instance.MachineScope

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -127,13 +127,18 @@ func (c *UnitCommandBase) Init(args []string) error {
 	}
 	if c.PlacementSpec != "" {
 		placementSpecs := strings.Split(c.PlacementSpec, ",")
-		c.Placement = make([]*instance.Placement, len(placementSpecs))
-		for i, spec := range placementSpecs {
+		// Ensure that Placement length is accurate, wait for valid placements
+		// to add.
+		c.Placement = make([]*instance.Placement, 0)
+		for _, spec := range placementSpecs {
+			if spec == "" {
+				continue
+			}
 			placement, err := utils.ParsePlacement(spec)
 			if err != nil {
 				return errors.Errorf("invalid --to parameter %q", spec)
 			}
-			c.Placement[i] = placement
+			c.Placement = append(c.Placement, placement)
 		}
 	}
 	if len(c.Placement) > c.NumUnits {

--- a/cmd/juju/application/addunit.go
+++ b/cmd/juju/application/addunit.go
@@ -132,7 +132,7 @@ func (c *UnitCommandBase) Init(args []string) error {
 		c.Placement = make([]*instance.Placement, 0)
 		for _, spec := range placementSpecs {
 			if spec == "" {
-				continue
+				return errors.Errorf("invalid --to parameter %q", c.PlacementSpec)
 			}
 			placement, err := utils.ParsePlacement(spec)
 			if err != nil {

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -129,6 +129,11 @@ func (s *AddUnitSuite) TestInitErrors(c *gc.C) {
 	}
 }
 
+func (s *AddUnitSuite) TestInitPlacement(c *gc.C) {
+	err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake, s.store), []string{"some-application-name", "--to", "4,5,,"})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 // Must error at init when the model type is known (and args are invalid)
 func (s *AddUnitSuite) TestInitErrorsForCAAS(c *gc.C) {
 	m := s.store.Models["arthur"].Models["king/sword"]

--- a/cmd/juju/application/addunit_test.go
+++ b/cmd/juju/application/addunit_test.go
@@ -118,6 +118,9 @@ var initAddUnitErrorTests = []struct {
 	}, {
 		args: []string{"some-application-name", "--attach-storage", "foo/0", "-n", "2"},
 		err:  `--attach-storage cannot be used with -n`,
+	}, {
+		args: []string{"some-application-name", "--to", "4,5,,"},
+		err:  `invalid --to parameter "4,5,,"`,
 	},
 }
 
@@ -127,11 +130,6 @@ func (s *AddUnitSuite) TestInitErrors(c *gc.C) {
 		err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake, s.store), t.args)
 		c.Check(err, gc.ErrorMatches, t.err)
 	}
-}
-
-func (s *AddUnitSuite) TestInitPlacement(c *gc.C) {
-	err := cmdtesting.InitCommand(application.NewAddUnitCommandForTest(s.fake, s.store), []string{"some-application-name", "--to", "4,5,,"})
-	c.Assert(err, jc.ErrorIsNil)
 }
 
 // Must error at init when the model type is known (and args are invalid)


### PR DESCRIPTION
Ensure that the slice of Placements only holds valid pointers. Otherwise you see panics in both the client and server side of the deploy code.

## QA steps

```console
# should not panic, though won't succeed in a new model.
juju deploy -n 3 --to 0,1,2, --config vip=10.0.0.101 keystone
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1935726