### PR TITLE
Allow conflicting constraints for arch+instance-type until arch issues can be resolved.

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -467,7 +467,8 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (
 		[]string{
 			constraints.Mem,
 			constraints.Cores,
-			constraints.Arch,
+			// TODO: move to a dynamic conflict for arch when azure supports more than amd64
+			//constraints.Arch,
 		},
 	)
 	return validator, nil

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -2183,7 +2183,8 @@ func (s *environSuite) TestConstraintsValidatorMerge(c *gc.C) {
 		constraints.MustParse("instance-type=D1"),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cons.String(), gc.Equals, "instance-type=D1")
+	// For now we can have a compatible arch and instance-type due to charmhub arch workarounds.
+	c.Assert(cons.String(), gc.Equals, "arch=amd64 instance-type=D1")
 }
 
 func (s *environSuite) constraintsValidator(c *gc.C) constraints.Validator {

--- a/provider/ec2/instancetypes.go
+++ b/provider/ec2/instancetypes.go
@@ -118,10 +118,9 @@ func supportsClassic(instanceType string) bool {
 }
 
 var archNames = map[types.ArchitectureType]string{
-	"x86":     arch.I386,
-	"x86_64":  arch.AMD64,
-	"arm":     arch.ARM,
-	"aarch64": arch.ARM64,
+	types.ArchitectureTypeI386:  arch.I386,
+	types.ArchitectureTypeX8664: arch.AMD64,
+	types.ArchitectureTypeArm64: arch.ARM64,
 }
 
 func archName(in types.ArchitectureType) string {

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -39,7 +39,8 @@ var unsupportedConstraints = []string{
 // instanceTypeConstraints defines the fields defined on each of the
 // instance types. See instancetypes.go.
 var instanceTypeConstraints = []string{
-	constraints.Arch, // Arches
+	// TODO: move to a dynamic conflict for arch when gce supports more than amd64
+	//constraints.Arch, // Arches
 	constraints.Cores,
 	constraints.CpuPower,
 	constraints.Mem,

--- a/provider/gce/instance_information.go
+++ b/provider/gce/instance_information.go
@@ -86,6 +86,7 @@ func (env *environ) getAllInstanceTypes(ctx context.ProviderCallContext, clock c
 				Name:     m.Name,
 				CpuCores: uint64(m.GuestCpus),
 				Mem:      uint64(m.MemoryMb),
+				// TODO: support arm64 once the API can report arch.
 				Arch:     arch.AMD64,
 				VirtType: &virtType,
 			}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -591,6 +591,7 @@ func (e *Environ) ConstraintsValidator(ctx context.ProviderCallContext) (constra
 	validator := constraints.NewValidator()
 	validator.RegisterConflicts(
 		[]string{constraints.InstanceType},
+		// TODO: move to a dynamic conflict for arch when openstack supports defining arch in flavors
 		[]string{constraints.Mem, constraints.Cores})
 	// NOTE: RootDiskSource and RootDisk constraints are validated in PrecheckInstance.
 	validator.RegisterUnsupported(unsupportedConstraints)


### PR DESCRIPTION
- Remove conflicts for arch for GCE, Azure and OpenStack.
- Dynamically resolve conflict on AWS using instance type information where `arch` constraint matches instance type architecture info.

## QA steps

```
juju bootstrap aws
juju deploy ubuntu --constraints="arch=arm64 instance-type=c6g.large"
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1970462