### PR TITLE
[JUJU-1162] allow charm refresh to just update resources

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -2751,6 +2751,10 @@ func (f *fakeDeployAPI) CharmInfo(url string) (*apicommoncharms.CharmInfo, error
 	return results[0].(*apicommoncharms.CharmInfo), jujutesting.TypeAssertError(results[1])
 }
 
+func (f *fakeDeployAPI) Get(endpoint string, extra interface{}) error {
+	return nil
+}
+
 func (f *fakeDeployAPI) Deploy(args application.DeployArgs) error {
 	results := f.MethodCall(f, "Deploy", args)
 	if len(results) != 1 {

--- a/cmd/juju/application/refresher/refresher_test.go
+++ b/cmd/juju/application/refresher/refresher_test.go
@@ -351,6 +351,8 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithNoUpdates(c *gc.C) {
 	}
 
 	authorizer := NewMockMacaroonGetter(ctrl)
+	authorizer.EXPECT().Get("/delegatable-macaroon?id=cs%3Ameshuggah", gomock.Any()).Return(errors.New("404 NOT FOUND"))
+
 	charmAdder := NewMockCharmAdder(ctrl)
 
 	charmResolver := NewMockCharmResolver(ctrl)
@@ -378,6 +380,7 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithARevision(c *gc.C) {
 	}
 
 	authorizer := NewMockMacaroonGetter(ctrl)
+	authorizer.EXPECT().Get("/delegatable-macaroon?id=cs%3Ameshuggah-1", gomock.Any()).Return(errors.New("404 NOT FOUND"))
 	charmAdder := NewMockCharmAdder(ctrl)
 
 	charmResolver := NewMockCharmResolver(ctrl)
@@ -405,6 +408,7 @@ func (s *charmStoreCharmRefresherSuite) TestRefreshWithCharmSwitch(c *gc.C) {
 	}
 
 	authorizer := NewMockMacaroonGetter(ctrl)
+	authorizer.EXPECT().Get("/delegatable-macaroon?id=cs%3Aaloupi-1", gomock.Any()).Return(errors.New("404 NOT FOUND"))
 	charmAdder := NewMockCharmAdder(ctrl)
 
 	charmResolver := NewMockCharmResolver(ctrl)

--- a/cmd/juju/application/store/store.go
+++ b/cmd/juju/application/store/store.go
@@ -43,7 +43,7 @@ func AddCharmWithAuthorizationFromURL(client CharmAdder, cs MacaroonGetter, curl
 		if !params.IsCodeUnauthorized(err) {
 			return nil, nil, commoncharm.Origin{}, errors.Trace(err)
 		}
-		m, err := authorizeCharmStoreEntity(cs, curl)
+		m, err := AuthorizeCharmStoreEntity(cs, curl)
 		if err != nil {
 			return nil, nil, commoncharm.Origin{}, common.MaybeTermsAgreementError(err)
 		}
@@ -65,11 +65,11 @@ var NewCharmStoreClient = func(client *httpbakery.Client, csURL string) *csclien
 	})
 }
 
-// authorizeCharmStoreEntity acquires and return the charm store
+// AuthorizeCharmStoreEntity acquires and return the charm store
 // delegatable macaroon to be used to add the charm corresponding
 // to the given URL. The macaroon is properly attenuated so that
 // it can only be used to deploy the given charm URL.
-func authorizeCharmStoreEntity(csClient MacaroonGetter, curl *charm.URL) (*macaroon.Macaroon, error) {
+func AuthorizeCharmStoreEntity(csClient MacaroonGetter, curl *charm.URL) (*macaroon.Macaroon, error) {
 	endpoint := "/delegatable-macaroon?id=" + url.QueryEscape(curl.String())
 	var m *macaroon.Macaroon
 	if err := csClient.Get(endpoint, &m); err != nil {


### PR DESCRIPTION
When running juju refresh, even if the charm itself is not updated, we need to still allow new resources to be refreshed.
This tweaks the logic used in the refresh CLI to allow just resources to be updated.

## QA steps

deploy a charm with a resource, eg `ch:prometheus-k8s` from beta
`juju refresh prometheus-k8s --resource=--resource prometheus-image=prom/prometheus`

Do the same with a cs charm, eg `cs:~juju/mariadb-k8s`

## Bug reference

https://bugs.launchpad.net/juju/+bug/1954462
