### PR TITLE
Update the model-defaults help text

### DIFF
--- a/cmd/juju/model/defaults.go
+++ b/cmd/juju/model/defaults.go
@@ -60,7 +60,7 @@ Examples:
     juju model-defaults us-east-1 ftp-proxy=10.0.0.1:8000
     juju model-defaults us-east-1 ftp-proxy=10.0.0.1:8000 path/to/file.yaml
     juju model-defaults us-east-1 path/to/file.yaml    
-    juju model-defaults --reset default-series test-mode
+    juju model-defaults --reset default-series,test-mode
     juju model-defaults aws --reset http-proxy
     juju model-defaults aws/us-east-1 --reset http-proxy
     juju model-defaults us-east-1 --reset http-proxy


### PR DESCRIPTION
This just fixes a model default line that wasn't properly formatted. 

What it was actually saying was to reset the model-defaults of `default-series` in the cloud `test-mode`. This changes it to indicate that we want to reset `default-series` and `test-mode` for all clouds.

## Checklist

 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
juju help model-defaults should print out the right help text
```

## Documentation changes

None

## Bug reference

None
