### PR TITLE
[JUJU-1173] Drop JujuConnSuite from apiserver/common/charms

### DIFF
--- a/apiserver/common/charms/charminfo_test.go
+++ b/apiserver/common/charms/charminfo_test.go
@@ -4,447 +4,73 @@
 package charms_test
 
 import (
-	"fmt"
-
+	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v8"
-	"github.com/juju/charm/v8/assumes"
-	jc "github.com/juju/testing/checkers"
+	"github.com/juju/names/v4"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common/charms"
-	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/apiserver/testing"
-	jujutesting "github.com/juju/juju/juju/testing"
+	"github.com/juju/juju/apiserver/common/charms/mocks"
+	facademocks "github.com/juju/juju/apiserver/facade/mocks"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/testcharms"
-	jtesting "github.com/juju/juju/testing"
-	"github.com/juju/juju/testing/factory"
+	"github.com/juju/juju/state"
 )
 
-type charmInfoSuite struct {
-	// TODO(anastasiamac) mock to remove JujuConnSuite
-	jujutesting.JujuConnSuite
-	api  *charms.CharmInfoAPI
-	auth facade.Authorizer
-}
+type charmInfoSuite struct{}
 
 var _ = gc.Suite(&charmInfoSuite{})
 
-func (s *charmInfoSuite) SetUpTest(c *gc.C) {
-	s.JujuConnSuite.SetUpTest(c)
+func (s *charmInfoSuite) TestBasic(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	s.auth = testing.FakeAuthorizer{
-		Tag:        s.AdminUserTag(c),
-		Controller: true,
-	}
+	st := mocks.NewMockState(ctrl)
+	st.EXPECT().Model().Return(nil, nil)
+	ch := mocks.NewMockCharm(ctrl)
+	st.EXPECT().Charm(&charm.URL{Schema: "ch", Name: "foo", Revision: 1}).Return(ch, nil)
 
-	var err error
-	s.api, err = charms.NewCharmInfoAPI(&charms.StateShim{s.State}, s.auth)
-	c.Assert(err, jc.ErrorIsNil)
+	// The convertCharm logic is tested in the CharmInfo tests, so just test
+	// the minimal set of fields here.
+	ch.EXPECT().Revision().Return(1)
+	ch.EXPECT().Config().Return(&charm.Config{})
+	ch.EXPECT().Meta().Return(&charm.Meta{Name: "foo"})
+	ch.EXPECT().Actions().Return(&charm.Actions{})
+	ch.EXPECT().Metrics().Return(&charm.Metrics{})
+	ch.EXPECT().Manifest().Return(&charm.Manifest{})
+	ch.EXPECT().LXDProfile().Return(&state.LXDProfile{})
+
+	authorizer := facademocks.NewMockAuthorizer(ctrl)
+	authorizer.EXPECT().AuthController().Return(true)
+
+	// Make the CharmInfo call
+	api, err := charms.NewCharmInfoAPI(st, authorizer)
+	c.Assert(err, gc.IsNil)
+	charmInfo, err := api.CharmInfo(params.CharmURL{URL: "foo-1"})
+	c.Assert(err, gc.IsNil)
+
+	c.Check(charmInfo.URL, gc.Equals, "ch:foo-1")
+	c.Check(charmInfo.Meta.Name, gc.Equals, "foo")
 }
 
-func (s *charmInfoSuite) TestClientCharmInfoCAAS(c *gc.C) {
-	var clientCharmInfoTests = []struct {
-		about    string
-		series   string
-		charm    string
-		url      string
-		expected params.Charm
-		err      string
-	}{
-		{
-			about:  "charm info for meta format v2 with containers on a CAAS model",
-			series: "focal",
-			// Use cockroach for tests so that we can compare Provides and Requires.
-			charm: "cockroach",
-			url:   "local:focal/cockroachdb-0",
-			expected: params.Charm{
-				Revision: 0,
-				URL:      "local:focal/cockroachdb-0",
-				Config:   map[string]params.CharmOption{},
-				Manifest: &params.CharmManifest{
-					Bases: []params.CharmBase{
-						{
-							Name:          "ubuntu",
-							Channel:       "20.04/stable",
-							Architectures: []string{"amd64"},
-						},
-					},
-				},
-				Meta: &params.CharmMeta{
-					Name:        "cockroachdb",
-					Summary:     "cockroachdb",
-					Description: "cockroachdb",
-					Storage: map[string]params.CharmStorage{
-						"database": {
-							Name:     "database",
-							Type:     "filesystem",
-							CountMin: 1,
-							CountMax: 1,
-						},
-					},
-					Containers: map[string]params.CharmContainer{
-						"cockroachdb": {
-							Resource: "cockroachdb-image",
-							Mounts: []params.CharmMount{
-								{
-									Storage:  "database",
-									Location: "/cockroach/cockroach-data",
-								},
-							},
-						},
-					},
-					Provides: map[string]params.CharmRelation{
-						"db": {
-							Name:      "db",
-							Role:      "provider",
-							Interface: "roach",
-							Scope:     "global",
-						},
-					},
-					Resources: map[string]params.CharmResourceMeta{
-						"cockroachdb-image": {
-							Name:        "cockroachdb-image",
-							Type:        "oci-image",
-							Description: "OCI image used for cockroachdb",
-						},
-					},
-					MinJujuVersion: "0.0.0",
-					AssumesExpr: &assumes.ExpressionTree{
-						Expression: assumes.CompositeExpression{
-							ExprType: assumes.AllOfExpression,
-							SubExpressions: []assumes.Expression{
-								assumes.FeatureExpression{Name: "k8s-api"},
-							},
-						},
-					},
-				},
-				Actions: &params.CharmActions{},
-			},
-		},
-	}
+func (s *charmInfoSuite) TestPermissionDenied(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	for i, t := range clientCharmInfoTests {
-		c.Logf("test %d. %s", i, t.about)
+	st := mocks.NewMockState(ctrl)
+	model := mocks.NewMockModel(ctrl)
+	st.EXPECT().Model().Return(model, nil)
 
-		otherModelOwner := s.Factory.MakeModelUser(c, nil)
-		otherSt := s.Factory.MakeCAASModel(c, &factory.ModelParams{
-			Owner: otherModelOwner.UserTag,
-			ConfigAttrs: jtesting.Attrs{
-				"controller": false,
-			},
-		})
-		defer otherSt.Close()
+	modelTag := names.NewModelTag("1")
+	model.EXPECT().ModelTag().Return(modelTag)
 
-		otherModel, err := otherSt.Model()
-		c.Assert(err, jc.ErrorIsNil)
+	authorizer := facademocks.NewMockAuthorizer(ctrl)
+	authorizer.EXPECT().AuthController().Return(false)
+	authorizer.EXPECT().HasPermission(permission.ReadAccess, modelTag).Return(false, nil)
 
-		repo := testcharms.RepoForSeries(t.series)
-		ch := repo.CharmDir(t.charm)
-		ident := fmt.Sprintf("%s-%d", ch.Meta().Name, ch.Revision())
-		curl := charm.MustParseURL(fmt.Sprintf("local:%s/%s", t.series, ident))
-
-		_, err = jujutesting.AddCharm(otherModel.State(), curl, ch, false)
-
-		c.Assert(err, jc.ErrorIsNil)
-
-		s.api, err = charms.NewCharmInfoAPI(&charms.StateShim{otherModel.State()}, s.auth)
-		c.Assert(err, jc.ErrorIsNil)
-
-		info, err := s.api.CharmInfo(params.CharmURL{URL: t.url})
-		if t.err != "" {
-			c.Check(err, gc.ErrorMatches, t.err)
-			continue
-		}
-		if c.Check(err, jc.ErrorIsNil) == false {
-			continue
-		}
-		c.Check(info, jc.DeepEquals, t.expected)
-	}
-}
-
-func (s *charmInfoSuite) TestClientCharmInfo(c *gc.C) {
-	var clientCharmInfoTests = []struct {
-		about    string
-		charm    string
-		series   string
-		url      string
-		expected params.Charm
-		err      string
-	}{
-		{
-			about: "dummy charm which contains an expectedActions spec",
-			charm: "dummy",
-			url:   "local:quantal/dummy-1",
-			expected: params.Charm{
-				Revision: 1,
-				URL:      "local:quantal/dummy-1",
-				Config: map[string]params.CharmOption{
-					"skill-level": {
-						Type:        "int",
-						Description: "A number indicating skill."},
-					"title": {
-						Type:        "string",
-						Description: "A descriptive title used for the application.",
-						Default:     "My Title"},
-					"outlook": {
-						Type:        "string",
-						Description: "No default outlook."},
-					"username": {
-						Type:        "string",
-						Description: "The name of the initial account (given admin permissions).",
-						Default:     "admin001"},
-				},
-				Meta: &params.CharmMeta{
-					Name:           "dummy",
-					Summary:        "That's a dummy charm.",
-					Description:    "This is a longer description which\npotentially contains multiple lines.\n",
-					Subordinate:    false,
-					MinJujuVersion: "0.0.0",
-				},
-				Actions: &params.CharmActions{
-					ActionSpecs: map[string]params.CharmActionSpec{
-						"snapshot": {
-							Description: "Take a snapshot of the database.",
-							Params: map[string]interface{}{
-								"title":       "snapshot",
-								"description": "Take a snapshot of the database.",
-								"type":        "object",
-								"properties": map[string]interface{}{
-									"outfile": map[string]interface{}{
-										"type":        "string",
-										"description": "The file to write out to.",
-										"default":     "foo.bz2",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			about: "dummy charm which contains lxd profile spec",
-			charm: "lxd-profile",
-			url:   "local:quantal/lxd-profile-0",
-			expected: params.Charm{
-				Revision: 0,
-				URL:      "local:quantal/lxd-profile-0",
-				Config:   map[string]params.CharmOption{},
-				Meta: &params.CharmMeta{
-					Name:           "lxd-profile",
-					Summary:        "start a juju machine with a lxd profile",
-					Description:    "Run an Ubuntu system, with the given lxd-profile\n",
-					Subordinate:    false,
-					MinJujuVersion: "0.0.0",
-					Provides: map[string]params.CharmRelation{
-						"ubuntu": {
-							Name:      "ubuntu",
-							Interface: "ubuntu",
-							Role:      "provider",
-							Scope:     "global",
-						},
-					},
-					ExtraBindings: map[string]string{
-						"another": "another",
-					},
-					Tags: []string{
-						"misc",
-						"application_development",
-					},
-					Series: []string{
-						"bionic",
-						"xenial",
-						"quantal",
-					},
-				},
-				Actions: &params.CharmActions{},
-				LXDProfile: &params.CharmLXDProfile{
-					Description: "lxd profile for testing, will pass validation",
-					Config: map[string]string{
-						"security.nesting":       "true",
-						"security.privileged":    "true",
-						"linux.kernel_modules":   "openvswitch,nbd,ip_tables,ip6_tables",
-						"environment.http_proxy": "",
-					},
-					Devices: map[string]map[string]string{
-						"tun": {
-							"path": "/dev/net/tun",
-							"type": "unix-char",
-						},
-						"sony": {
-							"type":      "usb",
-							"vendorid":  "0fce",
-							"productid": "51da",
-						},
-						"bdisk": {
-							"source": "/dev/loop0",
-							"type":   "unix-block",
-						},
-						"gpu": {
-							"type": "gpu",
-						},
-					},
-				},
-			},
-		},
-		{
-			about: "retrieves charm info",
-			// Use wordpress for tests so that we can compare Provides and Requires.
-			charm: "wordpress",
-			url:   "local:quantal/wordpress-3",
-			expected: params.Charm{
-				Revision: 3,
-				URL:      "local:quantal/wordpress-3",
-				Config: map[string]params.CharmOption{
-					"blog-title": {
-						Type:        "string",
-						Description: "A descriptive title used for the blog.",
-						Default:     "My Title",
-					},
-				},
-				Meta: &params.CharmMeta{
-					Name:        "wordpress",
-					Summary:     "Blog engine",
-					Description: "A pretty popular blog engine",
-					Subordinate: false,
-					Provides: map[string]params.CharmRelation{
-						"logging-dir": {
-							Name:      "logging-dir",
-							Role:      "provider",
-							Interface: "logging",
-							Scope:     "container",
-						},
-						"monitoring-port": {
-							Name:      "monitoring-port",
-							Role:      "provider",
-							Interface: "monitoring",
-							Scope:     "container",
-						},
-						"url": {
-							Name:      "url",
-							Role:      "provider",
-							Interface: "http",
-							Scope:     "global",
-						},
-					},
-					Requires: map[string]params.CharmRelation{
-						"cache": {
-							Name:      "cache",
-							Role:      "requirer",
-							Interface: "varnish",
-							Optional:  true,
-							Limit:     2,
-							Scope:     "global",
-						},
-						"db": {
-							Name:      "db",
-							Role:      "requirer",
-							Interface: "mysql",
-							Limit:     1,
-							Scope:     "global",
-						},
-					},
-					ExtraBindings: map[string]string{
-						"admin-api": "admin-api",
-						"foo-bar":   "foo-bar",
-						"db-client": "db-client",
-					},
-					MinJujuVersion: "0.0.0",
-				},
-				Actions: &params.CharmActions{
-					ActionSpecs: map[string]params.CharmActionSpec{
-						"fakeaction": {
-							Description: "No description",
-							Params: map[string]interface{}{
-								"properties":  map[string]interface{}{},
-								"description": "No description",
-								"type":        "object",
-								"title":       "fakeaction"},
-						},
-					},
-				},
-			},
-		},
-		{
-			about: "charm info for meta format v2 without containers on a IAAS model",
-			// Use cockroach for tests so that we can compare Provides and Requires.
-			charm:  "cockroach-container-less",
-			series: "focal",
-			url:    "local:focal/cockroachdb-0",
-			expected: params.Charm{
-				Revision: 0,
-				URL:      "local:focal/cockroachdb-0",
-				Config:   map[string]params.CharmOption{},
-				Manifest: &params.CharmManifest{
-					Bases: []params.CharmBase{
-						{
-							Name:          "ubuntu",
-							Channel:       "20.04/stable",
-							Architectures: []string{"amd64"},
-						},
-					},
-				},
-				Meta: &params.CharmMeta{
-					Name:        "cockroachdb",
-					Summary:     "cockroachdb",
-					Description: "cockroachdb",
-					Storage: map[string]params.CharmStorage{
-						"database": {
-							Name:     "database",
-							Type:     "filesystem",
-							CountMin: 1,
-							CountMax: 1,
-						},
-					},
-					Provides: map[string]params.CharmRelation{
-						"db": {
-							Name:      "db",
-							Role:      "provider",
-							Interface: "roach",
-							Scope:     "global",
-						},
-					},
-					MinJujuVersion: "0.0.0",
-				},
-				Actions: &params.CharmActions{},
-			},
-		},
-		{
-			about: "invalid URL",
-			charm: "wordpress",
-			url:   "not-valid!",
-			err:   `cannot parse name and/or revision in URL "not-valid!": name "not-valid!" not valid`,
-		},
-		{
-			about: "invalid schema",
-			charm: "wordpress",
-			url:   "not-valid:your-arguments",
-			err:   `cannot parse URL "not-valid:your-arguments": schema "not-valid" not valid`,
-		},
-		{
-			about: "unknown charm",
-			charm: "wordpress",
-			url:   "cs:missing/one-1",
-			err:   `charm "cs:missing/one-1" not found`,
-		},
-	}
-
-	for i, t := range clientCharmInfoTests {
-		c.Logf("test %d. %s", i, t.about)
-		if t.series != "" {
-			s.AddTestingCharmForSeries(c, t.charm, t.series)
-		} else {
-			s.AddTestingCharm(c, t.charm)
-		}
-		info, err := s.api.CharmInfo(params.CharmURL{URL: t.url})
-		if t.err != "" {
-			c.Check(err, gc.ErrorMatches, t.err)
-			continue
-		}
-		if c.Check(err, jc.ErrorIsNil) == false {
-			continue
-		}
-		c.Check(info, jc.DeepEquals, t.expected)
-	}
+	// Make the CharmInfo call
+	api, err := charms.NewCharmInfoAPI(st, authorizer)
+	c.Assert(err, gc.IsNil)
+	_, err = api.CharmInfo(params.CharmURL{URL: "foo"})
+	c.Assert(err, gc.ErrorMatches, "permission denied")
 }

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -16,8 +16,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks.go github.com/juju/juju/apiserver/common/charms State,Application,Charm,Model
-
 type State interface {
 	Model() (Model, error)
 	Charm(curl *charm.URL) (Charm, error)

--- a/apiserver/common/charms/package_test.go
+++ b/apiserver/common/charms/package_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks.go github.com/juju/juju/apiserver/common/charms State,Application,Charm,Model
+
 func TestAll(t *stdtesting.T) {
 	testing.MgoTestPackage(t)
 }


### PR DESCRIPTION
appcharminfo_test.go tests some very similar code, so re-writing these
tests was mostly a case of copying over and adjusting these tests for
this slightly different use case

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps


```sh
go test github.com/juju/juju/apiserver/common/charms
```
