### PR TITLE
[JUJU-1176] Fixes a bug in for icmp rules in openstack.

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2072,9 +2072,11 @@ func rulesToRuleInfo(groupId string, rules firewall.IngressRules) []neutron.Rule
 		ruleInfo := neutron.RuleInfoV2{
 			Direction:     "ingress",
 			ParentGroupId: groupId,
-			PortRangeMin:  r.PortRange.FromPort,
-			PortRangeMax:  r.PortRange.ToPort,
 			IPProtocol:    r.PortRange.Protocol,
+		}
+		if ruleInfo.IPProtocol != "icmp" {
+			ruleInfo.PortRangeMin = r.PortRange.FromPort
+			ruleInfo.PortRangeMax = r.PortRange.ToPort
 		}
 		sourceCIDRs := r.SourceCIDRs.Values()
 		if len(sourceCIDRs) == 0 {


### PR DESCRIPTION
When exposing applications in Openstack with icmp rules the Openstack
provider copies the port values from Juju internal rules to that of the
Openstack rules. However openstack expects port values to be nil when
making ICMP rules.

This change resolves this by not setting port values for ICMP proto's
and also by translating Openstack rules back to Juju rules by setting
the port to -1.

Fixes LP1970295

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

The best way to reproduce and also test the fix is to follow the steps in the bug I have found. See bug link below.

## Bug reference

 https://bugs.launchpad.net/juju/+bug/9876543*](https://bugs.launchpad.net/juju/+bug/1970295
