### PR TITLE
[JUJU-1179] Adds dual stack support for aws firewall rules.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1976,6 +1976,7 @@ func rulesToIPPerms(rules firewall.IngressRules) []types.IpPermission {
 		}
 		if len(r.SourceCIDRs) == 0 {
 			ipPerms[i].IpRanges = []types.IpRange{{CidrIp: aws.String(defaultRouteCIDRBlock)}}
+			ipPerms[i].Ipv6Ranges = []types.Ipv6Range{{CidrIpv6: aws.String(defaultRouteIPv6CIDRBlock)}}
 		} else {
 			for _, cidr := range r.SourceCIDRs.SortedValues() {
 				// CIDRs are pre-validated; if an invalid CIDR
@@ -2067,6 +2068,7 @@ func (e *environ) ingressRulesInGroup(ctx context.ProviderCallContext, name stri
 		}
 		if len(sourceCIDRs) == 0 {
 			sourceCIDRs = append(sourceCIDRs, defaultRouteCIDRBlock)
+			sourceCIDRs = append(sourceCIDRs, defaultRouteIPv6CIDRBlock)
 		}
 		portRange := network.PortRange{
 			Protocol: aws.ToString(p.IpProtocol),

--- a/provider/ec2/environ_test.go
+++ b/provider/ec2/environ_test.go
@@ -185,38 +185,48 @@ func (*Suite) TestPortsToIPPerms(c *gc.C) {
 	}{{
 		about: "single port",
 		rules: firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("80/tcp"))},
-		expected: []types.IpPermission{{
-			IpProtocol: aws.String("tcp"),
-			FromPort:   aws.Int32(80),
-			ToPort:     aws.Int32(80),
-			IpRanges:   []types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
-		}},
+		expected: []types.IpPermission{
+			{
+				IpProtocol: aws.String("tcp"),
+				FromPort:   aws.Int32(80),
+				ToPort:     aws.Int32(80),
+				IpRanges:   []types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+				Ipv6Ranges: []types.Ipv6Range{{CidrIpv6: aws.String("::/0")}},
+			},
+		},
 	}, {
 		about: "multiple ports",
 		rules: firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("80-82/tcp"))},
-		expected: []types.IpPermission{{
-			IpProtocol: aws.String("tcp"),
-			FromPort:   aws.Int32(80),
-			ToPort:     aws.Int32(82),
-			IpRanges:   []types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
-		}},
+		expected: []types.IpPermission{
+			{
+				IpProtocol: aws.String("tcp"),
+				FromPort:   aws.Int32(80),
+				ToPort:     aws.Int32(82),
+				IpRanges:   []types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+				Ipv6Ranges: []types.Ipv6Range{{CidrIpv6: aws.String("::/0")}},
+			},
+		},
 	}, {
 		about: "multiple port ranges",
 		rules: firewall.IngressRules{
 			firewall.NewIngressRule(network.MustParsePortRange("80-82/tcp")),
 			firewall.NewIngressRule(network.MustParsePortRange("100-120/tcp")),
 		},
-		expected: []types.IpPermission{{
-			IpProtocol: aws.String("tcp"),
-			FromPort:   aws.Int32(80),
-			ToPort:     aws.Int32(82),
-			IpRanges:   []types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
-		}, {
-			IpProtocol: aws.String("tcp"),
-			FromPort:   aws.Int32(100),
-			ToPort:     aws.Int32(120),
-			IpRanges:   []types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
-		}},
+		expected: []types.IpPermission{
+			{
+				IpProtocol: aws.String("tcp"),
+				FromPort:   aws.Int32(80),
+				ToPort:     aws.Int32(82),
+				IpRanges:   []types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+				Ipv6Ranges: []types.Ipv6Range{{CidrIpv6: aws.String("::/0")}},
+			}, {
+				IpProtocol: aws.String("tcp"),
+				FromPort:   aws.Int32(100),
+				ToPort:     aws.Int32(120),
+				IpRanges:   []types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+				Ipv6Ranges: []types.Ipv6Range{{CidrIpv6: aws.String("::/0")}},
+			},
+		},
 	}, {
 		about: "source ranges",
 		rules: firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("80-82/tcp"), "192.168.1.0/24", "0.0.0.0/0")},

--- a/provider/ec2/environ_vpc.go
+++ b/provider/ec2/environ_vpc.go
@@ -20,11 +20,12 @@ import (
 )
 
 const (
-	activeState           = "active"
-	availableState        = "available"
-	localRouteGatewayID   = "local"
-	defaultRouteCIDRBlock = "0.0.0.0/0"
-	vpcIDNone             = "none"
+	activeState               = "active"
+	availableState            = "available"
+	localRouteGatewayID       = "local"
+	defaultRouteCIDRBlock     = "0.0.0.0/0"
+	defaultRouteIPv6CIDRBlock = "::/0"
+	vpcIDNone                 = "none"
 )
 
 var (


### PR DESCRIPTION
When exposing an application in Juju with know cidr ranges the aws
provider defaults to just v4 0.0.0.0/0 cidr. This change now adds v6
cidr's to the list of allowed ingress.

When operating in a vpc with only v4 rules the v6 rules do not affect
operation.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

See bug description for best QA steps and also unit test changes.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1709312
