### PR TITLE
Fix polarity of keep_env flag: keep_env == not teardown

### DIFF
--- a/acceptancetests/assess_caas_deploy_kubeflow.py
+++ b/acceptancetests/assess_caas_deploy_kubeflow.py
@@ -503,7 +503,7 @@ def main(argv=None):
     # testing here anyway.
     #
     # [1] https://github.com/canonical/metacontroller-operator/issues/5
-    bs_manager.keep_env = False
+    bs_manager.keep_env = True
 
     with k8s_provider(
         bs_manager,


### PR DESCRIPTION
In [#14084](https://github.com/juju/juju/pull/14084) I accidentally got the value of `keep_env` incorrect. It should be True, meaning don't tear down. I've tested this code path locally this time. :-)