### PR TITLE
[JUJU-1174] [config commands] Allow simultaneously setting, resetting, setting from file

### DIFF
--- a/cmd/juju/model/fakeenv_test.go
+++ b/cmd/juju/model/fakeenv_test.go
@@ -63,7 +63,14 @@ func (f *fakeEnvAPI) ModelGetWithMetadata() (config.ConfigValues, error) {
 }
 
 func (f *fakeEnvAPI) ModelSet(config map[string]interface{}) error {
-	f.values = config
+	if f.values == nil {
+		f.values = config
+	} else {
+		// Append values rather than overwriting
+		for key, val := range config {
+			f.values[key] = val
+		}
+	}
 	return f.err
 }
 


### PR DESCRIPTION
Continues work done in #14072. We change `ConfigCommandBase` and its child config commands to support simultaneously setting k=v args, resetting keys, and setting from a file, as per the "spec" [here](https://docs.google.com/document/d/1GK7M-t5pHvtdEI1lTXx4MUwmDnwkfKzx6NdkCQETRXw/edit?usp=sharing).

The rules are:
- Setting k=v args and resetting can be done simultaneously, as long as we are not trying to set/reset the same key. So, this is valid:
`juju X-config key1=val1 --reset key2`
but this is not:
`juju X-config key1=val1 --reset key1`
- Setting from a yaml file can be done simultaneously with resetting/setting from k=v args. In this case, any keys being reset/set from k=v args will **override** the config specified in the yaml file. So the following are all valid:
  ```
  juju X-config --file=cfg.yaml key1=val1
  juju X-config --file=cfg.yaml --reset key1
  juju X-config --file=cfg.yaml key1=val1 --reset key2
  ```