### PR TITLE
[JUJU-1215] Fix timestamp when updating charmhub resources

### DIFF
--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/juju/clock"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -835,7 +836,7 @@ func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 	}
 
 	var err error
-	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, newCharmstoreClient, newCharmhubClient)
+	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, clock.WallClock, newCharmstoreClient, newCharmhubClient)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/controller/charmrevisionupdater/register.go
+++ b/apiserver/facades/controller/charmrevisionupdater/register.go
@@ -6,6 +6,7 @@ package charmrevisionupdater
 import (
 	"reflect"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/common"
@@ -42,6 +43,7 @@ func newCharmRevisionUpdaterAPI(ctx facade.Context) (*CharmRevisionUpdaterAPI, e
 	}
 	return NewCharmRevisionUpdaterAPIState(
 		StateShim{State: ctx.State()},
+		clock.WallClock,
 		newCharmstoreClient,
 		newCharmhubClient,
 	)

--- a/charmstore/latest.go
+++ b/charmstore/latest.go
@@ -4,8 +4,7 @@
 package charmstore
 
 import (
-	"time"
-
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 )
 
@@ -17,9 +16,9 @@ const jujuMetadataHTTPHeader = "Juju-Metadata"
 // the macaroon has been updated. This updated macaroon should be stored for
 // use in any further requests.  Note that this map may be non-empty even if
 // this method returns an error (and the macaroons should be stored).
-func LatestCharmInfo(client Client, charms []CharmID, metadata map[string]string) ([]CharmInfoResult, error) {
+func LatestCharmInfo(client Client, charms []CharmID, metadata map[string]string, clock clock.Clock) ([]CharmInfoResult, error) {
 	// TODO(perrito666) 2016-05-02 lp:1558657
-	now := time.Now().UTC()
+	now := clock.Now().UTC()
 	// Do a bulk call to get the revision info for all charms.
 	logger.Infof("retrieving revision information for %d charms", len(charms))
 	revResults, err := client.LatestRevisions(charms, metadata)

--- a/charmstore/latest_test.go
+++ b/charmstore/latest_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/resource"
 	"github.com/juju/charmrepo/v6/csclient/params"
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -79,7 +80,7 @@ func (s *LatestCharmInfoSuite) TestSuccess(c *gc.C) {
 		"controller_version": version.Current.String(),
 		"is_controller":      "false",
 	}
-	results, err := LatestCharmInfo(client, charms, metadata)
+	results, err := LatestCharmInfo(client, charms, metadata, clock.WallClock)
 	c.Assert(err, jc.ErrorIsNil)
 
 	header := []string{

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -648,6 +648,7 @@ const (
 	settingsC                  = "settings"
 	generationsC               = "generations"
 	refcountsC                 = "refcounts"
+	resourcesC                 = "resources"
 	sshHostKeysC               = "sshhostkeys"
 	spacesC                    = "spaces"
 	statusesC                  = "statuses"
@@ -671,8 +672,6 @@ const (
 	volumeAttachmentsC         = "volumeattachments"
 	volumeAttachmentPlanC      = "volumeattachmentplan"
 	volumesC                   = "volumes"
-
-	// "resources" (see state/resources_mongo.go)
 
 	// Cross model relations
 	applicationOffersC   = "applicationOffers"

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -92,6 +92,7 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 	s.pool = ctlr.StatePool()
 	s.state, err = ctlr.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
+	s.state.stateClock = testclock.NewClock(testing.NonZeroTime())
 	s.AddCleanup(func(*gc.C) {
 		// Controller closes pool, pool closes all states.
 		s.controller.Close()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1062,10 +1062,7 @@ func (i *importer) appResourceOps(app description.Application) []txn.Op {
 		}
 		if storeRev := r.CharmStoreRevision(); storeRev.Timestamp().IsZero() {
 			doc := makeResourceDoc(resID, resName, storeRev)
-			// Now the resource code is particularly stupid and instead of using
-			// the ID, or encoding the type somewhere, it uses the fact that the
-			// LastPolled time to indicate it is the charm store version.
-			doc.LastPolled = time.Now()
+			doc.LastPolled = i.st.nowToTheSecond()
 			result = append(result, txn.Op{
 				C:      resourcesC,
 				Id:     charmStoreResourceID(resID),

--- a/state/resources.go
+++ b/state/resources.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"strings"
 	"time"
 
 	charmresource "github.com/juju/charm/v8/resource"
@@ -88,8 +89,6 @@ func (st *State) resources() *resourcePersistence {
 var rLogger = logger.Child("resource")
 
 const (
-	resourcesC = "resources"
-
 	resourcesStagedIDSuffix     = "#staged"
 	resourcesCharmstoreIDSuffix = "#charmstore"
 )
@@ -458,7 +457,7 @@ func (p *resourcePersistence) listResources(applicationID string, pending bool) 
 		if err != nil {
 			return resources.ApplicationResources{}, errors.Trace(err)
 		}
-		if !doc.LastPolled.IsZero() {
+		if strings.HasSuffix(doc.DocID, resourcesCharmstoreIDSuffix) {
 			store[res.Name] = res.Resource
 			continue
 		}
@@ -1259,7 +1258,7 @@ func resourceDocToUpdateOp(doc *resourceDoc) bson.M {
 		"timestamp-when-added":       doc.Timestamp,
 		"storage-path":               doc.StoragePath,
 		"download-progress":          doc.DownloadProgress,
-		"timestamp-when-last-polled": doc.LastPolled,
+		"timestamp-when-last-polled": doc.LastPolled.Round(time.Second).UTC(),
 	}}
 }
 

--- a/state/resources.go
+++ b/state/resources.go
@@ -655,6 +655,9 @@ func (p *resourcePersistence) setCharmStoreResource(id, applicationID string, re
 	if err := res.Validate(); err != nil {
 		return errors.Annotate(err, "bad resource")
 	}
+	if lastPolled.IsZero() {
+		return errors.NotValidf("empty last polled timestamp for charm resource %s/%s", applicationID, id)
+	}
 
 	csRes := charmStoreResource{
 		Resource:      res,

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -109,6 +109,7 @@ type StateBackend interface {
 	UpdateCharmOriginAfterSetSeries() error
 	UpdateOperationWithEnqueuingErrors() error
 	RemoveLocalCharmOriginChannels() error
+	FixCharmhubLastPolltime() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -498,4 +499,8 @@ func (s stateBackend) UpdateOperationWithEnqueuingErrors() error {
 
 func (s stateBackend) RemoveLocalCharmOriginChannels() error {
 	return state.RemoveLocalCharmOriginChannels(s.pool)
+}
+
+func (s stateBackend) FixCharmhubLastPolltime() error {
+	return state.FixCharmhubLastPolltime(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -60,6 +60,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.26"), stateStepsFor2926()},
 		upgradeToVersion{version.MustParse("2.9.29"), stateStepsFor2929()},
 		upgradeToVersion{version.MustParse("2.9.30"), stateStepsFor2930()},
+		upgradeToVersion{version.MustParse("2.9.32"), stateStepsFor2932()},
 	}
 	return steps
 }

--- a/upgrades/steps_2932.go
+++ b/upgrades/steps_2932.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2932 returns database upgrade steps for Juju 2.9.32
+func stateStepsFor2932() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add last poll time to charmhub resources",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().FixCharmhubLastPolltime()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2932_test.go
+++ b/upgrades/steps_2932_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2932 = version.MustParse("2.9.32")
+
+type steps2932Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2932Suite{})
+
+func (s *steps2932Suite) TestFixCharmhubLastPolltime(c *gc.C) {
+	step := findStateStep(c, v2932, "add last poll time to charmhub resources")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -649,6 +649,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.26",
 		"2.9.29",
 		"2.9.30",
+		"2.9.32",
 	})
 }
 


### PR DESCRIPTION
The charm revision update worker polls the store for latest charm info and records that in the juju model, with a timestamp. For charmhub, the timestamp used was the entity created timestamp, which was always zero, and recording a zero timestamp messes up the resource model. What it should have been using is `time.Now()` like is done for the old charmstore.

## QA steps

bootstrap microk8s

Use a wrench to set the charm revision updater poll time to 1 minute or shorter

juju deploy charmed-osm-lcm --channel=edge
after the poll time has elapsed, run
juju resources lcm

previously this would fail with the error seen in the bug

## Bug reference

https://bugs.launchpad.net/juju/+bug/1975726
