### PR TITLE
[JUJU-1105] new_color_scheme_for_juju_status

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -85,9 +85,9 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	w.Print(values[:versionPos]...)
 	modelVersionNum, err := version.Parse(fs.Model.Version)
 	if err == nil && jujuversion.Current.Compare(modelVersionNum) > 0 {
-		w.PrintColorNoTab(output.WarningHighlight, fs.Model.Version)
+		w.PrintColor(output.WarningHighlight, fs.Model.Version)
 	} else {
-		w.PrintNoTab(fs.Model.Version)
+		w.Print(fs.Model.Version)
 	}
 	w.Println(values[versionPos:]...)
 	if len(fs.Branches) > 0 {
@@ -232,7 +232,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			w.Print("no")
 		}
 
-		w.PrintColor(output.EmphasisHighlight.Gray, app.StatusInfo.Message)
+		w.PrintColorNoTab(output.EmphasisHighlight.Gray, app.StatusInfo.Message)
 		w.Println()
 		for un, u := range app.Units {
 			units[un] = u
@@ -266,14 +266,14 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		if fs.Model.Type == caasModelType {
 			w.PrintColor(output.InfoHighlight, u.Address)
 			printPorts(w, u.OpenedPorts)
-			w.PrintColor(output.EmphasisHighlight.Gray, message)
+			w.PrintColorNoTab(output.EmphasisHighlight.Gray, message)
 			w.Println()
 			return
 		}
 		w.Print(u.Machine)
 		w.PrintColor(output.InfoHighlight, u.PublicAddress)
 		printPorts(w, u.OpenedPorts)
-		w.PrintColor(output.EmphasisHighlight.Gray, message)
+		w.PrintColorNoTab(output.EmphasisHighlight.Gray, message)
 		w.Println()
 	}
 
@@ -396,9 +396,7 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 		w.Print(r.Interface, r.Type)
 		if r.Status != string(relation.Joined) {
 			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)
-			if r.Message != "" {
-				w.PrintColor(output.EmphasisHighlight.Gray, " - "+r.Message)
-			}
+			w.PrintColorNoTab(output.EmphasisHighlight.Gray, " - "+r.Message)
 		}
 		w.Println()
 	}

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -83,12 +83,15 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	w := startSection(tw, true, header...)
 	versionPos := indexOf("Version", header)
 	w.Print(values[:versionPos]...)
-	modelVersionNum, err := version.Parse(fs.Model.Version)
-	if err == nil && jujuversion.Current.Compare(modelVersionNum) > 0 {
-		w.PrintColor(output.WarningHighlight, fs.Model.Version)
-	} else {
-		w.Print(fs.Model.Version)
+	if fs.Model.Version != "" {
+		modelVersionNum, err := version.Parse(fs.Model.Version)
+		if err == nil && jujuversion.Current.Compare(modelVersionNum) > 0 {
+			w.PrintColor(output.WarningHighlight, fs.Model.Version)
+		} else {
+			w.Print(fs.Model.Version)
+		}
 	}
+
 	w.Println(values[versionPos:]...)
 	if len(fs.Branches) > 0 {
 		printBranches(tw, fs.Branches)
@@ -396,7 +399,7 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 		w.Print(r.Interface, r.Type)
 		if r.Status != string(relation.Joined) {
 			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)
-			w.PrintColorNoTab(output.EmphasisHighlight.Gray, " - "+r.Message)
+			w.PrintColorNoTab(output.EmphasisHighlight.Gray, r.Message)
 		}
 		w.Println()
 	}
@@ -492,7 +495,7 @@ func printMachine(w output.Wrapper, m machineStatus) {
 	w.PrintColor(output.InfoHighlight, m.DNSName)
 	w.Print(m.machineName(), m.Series, az)
 	if message != "" { //some unit tests were failing because of the printed empty string .
-		w.PrintColor(output.EmphasisHighlight.Gray, message)
+		w.PrintColorNoTab(output.EmphasisHighlight.Gray, message)
 	}
 	w.Println()
 

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -85,9 +85,9 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	w.Print(values[:versionPos]...)
 	modelVersionNum, err := version.Parse(fs.Model.Version)
 	if err == nil && jujuversion.Current.Compare(modelVersionNum) > 0 {
-		w.PrintColor(output.WarningHighlight, fs.Model.Version)
+		w.PrintColorNoTab(output.WarningHighlight, fs.Model.Version)
 	} else {
-		w.Print(fs.Model.Version)
+		w.PrintNoTab(fs.Model.Version)
 	}
 	w.Println(values[versionPos:]...)
 	if len(fs.Branches) > 0 {

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -6,8 +6,10 @@ package status
 import (
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -16,6 +18,7 @@ import (
 	"github.com/juju/charm/v9/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"
+	"github.com/juju/version/v2"
 
 	cmdcrossmodel "github.com/juju/juju/cmd/juju/crossmodel"
 	"github.com/juju/juju/cmd/juju/storage"
@@ -24,6 +27,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/status"
+	jujuversion "github.com/juju/juju/version"
 )
 
 const (
@@ -42,6 +46,10 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		return errors.Errorf("expected value of type %T, got %T", fs, value)
 	}
 
+	// NO_COLOR; regardless of its value,is required by ansiterm to enable
+	// toggling color capability on or off
+	os.Setenv("NO_COLOR", "")
+
 	// To format things into columns.
 	tw := output.TabWriter(writer)
 	if forceColor {
@@ -55,13 +63,13 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 
 	// Default table output
 	header := []interface{}{"Model", "Controller", "Cloud/Region", "Version"}
-	values := []interface{}{fs.Model.Name, fs.Model.Controller, cloudRegion, fs.Model.Version}
-
+	values := []interface{}{fs.Model.Name, fs.Model.Controller, cloudRegion}
 	// Optional table output if values exist
 	message := getModelMessage(fs.Model)
 	if fs.Model.SLA != "" {
 		header = append(header, "SLA")
 		values = append(values, fs.Model.SLA)
+
 	}
 	if cs := fs.Controller; cs != nil && cs.Timestamp != "" {
 		header = append(header, "Timestamp")
@@ -71,11 +79,17 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		header = append(header, "Notes")
 		values = append(values, message)
 	}
-
 	// The first set of headers don't use outputHeaders because it adds the blank line.
 	w := startSection(tw, true, header...)
-	w.Println(values...)
-
+	versionPos := indexOf("Version", header)
+	w.Print(values[:versionPos]...)
+	modelVersionNum, err := version.Parse(fs.Model.Version)
+	if err == nil && jujuversion.Current.Compare(modelVersionNum) > 0 {
+		w.PrintColor(output.WarningHighlight, fs.Model.Version)
+	} else {
+		w.Print(fs.Model.Version)
+	}
+	w.Println(values[versionPos:]...)
 	if len(fs.Branches) > 0 {
 		printBranches(tw, fs.Branches)
 	}
@@ -113,7 +127,8 @@ func startSection(tw *ansiterm.TabWriter, top bool, headers ...interface{}) outp
 	if !top {
 		w.Println()
 	}
-	w.Println(headers...)
+	w.PrintHeaders(output.EmphasisHighlight.DefaultBold, headers...)
+
 	return w
 }
 
@@ -201,18 +216,24 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 			w.Print(scale)
 		}
 
-		w.Print(app.CharmName, app.CharmChannel, app.CharmRev)
+		w.Print(app.CharmName, app.CharmChannel)
+		if app.CanUpgradeTo != "" {
+			w.PrintColor(output.WarningHighlight, app.CharmRev)
+		} else {
+			w.Print(app.CharmRev)
+		}
 		if fs.Model.Type == caasModelType {
-			w.Print(app.Address)
+			w.PrintColor(output.InfoHighlight, app.Address)
 		}
 
-		exposed := "no"
 		if app.Exposed {
-			exposed = "yes"
+			w.PrintColor(output.GoodHighlight, "yes")
+		} else {
+			w.Print("no")
 		}
-		w.Print(exposed)
 
-		w.Println(app.StatusInfo.Message)
+		w.PrintColor(output.EmphasisHighlight.Gray, app.StatusInfo.Message)
+		w.Println()
 		for un, u := range app.Units {
 			units[un] = u
 			if u.MeterStatus != nil {
@@ -241,20 +262,19 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		w.Print(indent("", level*2, name))
 		w.PrintStatus(u.WorkloadStatusInfo.Current)
 		w.PrintStatus(u.JujuStatusInfo.Current)
+
 		if fs.Model.Type == caasModelType {
-			w.Println(
-				u.Address,
-				strings.Join(u.OpenedPorts, ","),
-				message,
-			)
+			w.PrintColor(output.InfoHighlight, u.Address)
+			printPorts(w, u.OpenedPorts)
+			w.PrintColor(output.EmphasisHighlight.Gray, message)
+			w.Println()
 			return
 		}
-		w.Println(
-			u.Machine,
-			u.PublicAddress,
-			strings.Join(u.OpenedPorts, ","),
-			message,
-		)
+		w.Print(u.Machine)
+		w.PrintColor(output.InfoHighlight, u.PublicAddress)
+		printPorts(w, u.OpenedPorts)
+		w.PrintColor(output.EmphasisHighlight.Gray, message)
+		w.Println()
 	}
 
 	if len(units) > 0 {
@@ -295,6 +315,27 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 		}
 	}
 	endSection(tw)
+}
+
+func printPorts(w output.Wrapper, ps []string) {
+	size := len(ps)
+	for i, op := range ps {
+		if strings.Contains(op, "/") { //some port values just contain the protocol name e.g icmp
+			pp := strings.Split(op, "/")
+			w.PrintColorNoTab(output.EmphasisHighlight.BrightMagenta, pp[0]) //port e.g 3306
+			w.PrintNoTab(fmt.Sprintf("/%s", pp[1]))                          //append back the forward slash to the protocol name (3306/tcp)
+		} else {
+			if _, err := strconv.Atoi(op); err == nil { //if string is a port number i.e 3306
+				w.PrintColorNoTab(output.EmphasisHighlight.BrightMagenta, op)
+			} else { //the string is a protocol name i.e icmp
+				w.PrintNoTab(op)
+			}
+		}
+		if i != size-1 && size > 1 {
+			w.PrintNoTab(", ")
+		}
+	}
+	w.Print("") //Print empty tab after the ports
 }
 
 func printBranches(tw *ansiterm.TabWriter, branches map[string]branchStatus) {
@@ -346,11 +387,17 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 	w := startSection(tw, false, "Relation provider", "Requirer", "Interface", "Type", "Message")
 
 	for _, r := range relations {
-		w.Print(r.Provider, r.Requirer, r.Interface, r.Type)
+		provider := strings.Split(r.Provider, ":")
+		w.PrintNoTab(provider[0])                                                       //the service name (mysql)
+		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", provider[1])) //the resource type (:cluster)
+		requirer := strings.Split(r.Requirer, ":")
+		w.PrintNoTab(requirer[0])                                                       //the service name (mysql)
+		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", requirer[1])) //the resource type (:cluster)
+		w.Print(r.Interface, r.Type)
 		if r.Status != string(relation.Joined) {
 			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)
 			if r.Message != "" {
-				w.Print(" - " + r.Message)
+				w.PrintColor(output.EmphasisHighlight.Gray, " - "+r.Message)
 			}
 		}
 		w.Println()
@@ -444,7 +491,12 @@ func printMachine(w output.Wrapper, m machineStatus) {
 
 	w.Print(m.Id)
 	w.PrintStatus(status)
-	w.Println(m.DNSName, m.machineName(), m.Series, az, message)
+	w.PrintColor(output.InfoHighlight, m.DNSName)
+	w.Print(m.machineName(), m.Series, az)
+	if message != "" { //some unit tests were failing because of the printed empty string .
+		w.PrintColor(output.EmphasisHighlight.Gray, message)
+	}
+	w.Println()
 
 	for _, name := range naturalsort.Sort(stringKeysFromMap(m.Containers)) {
 		printMachine(w, m.Containers[name])

--- a/cmd/juju/status/utils.go
+++ b/cmd/juju/status/utils.go
@@ -36,3 +36,13 @@ func recurseUnits(u unitStatus, il int, recurseMap func(string, unitStatus, int)
 func indent(prepend string, level int, append string) string {
 	return fmt.Sprintf("%s%*s%s", prepend, level, "", append)
 }
+
+// indexOf returns the position of an element in a slice if it exists otherwise it returns -1.
+func indexOf(element interface{}, data []interface{}) int {
+	for k, v := range data {
+		if element == v {
+			return k
+		}
+	}
+	return -1 //not found.
+}

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -169,7 +169,7 @@ func FormatStorageListForStatusTabular(writer *ansiterm.TabWriter, s CombinedSto
 			w.Print(getFilesystemAttachment(s, info).MountPoint)
 			w.Print(humanizeStorageSize(storageSize[storageId]))
 			w.PrintStatus(info.status.Current)
-			w.PrintColor(output.EmphasisHighlight.Gray, info.status.Message)
+			w.PrintColorNoTab(output.EmphasisHighlight.Gray, info.status.Message)
 			w.Println()
 		}
 	}

--- a/cmd/juju/storage/listformatters.go
+++ b/cmd/juju/storage/listformatters.go
@@ -169,7 +169,8 @@ func FormatStorageListForStatusTabular(writer *ansiterm.TabWriter, s CombinedSto
 			w.Print(getFilesystemAttachment(s, info).MountPoint)
 			w.Print(humanizeStorageSize(storageSize[storageId]))
 			w.PrintStatus(info.status.Current)
-			w.Println(info.status.Message)
+			w.PrintColor(output.EmphasisHighlight.Gray, info.status.Message)
+			w.Println()
 		}
 	}
 	return w.Flush()

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -91,6 +91,37 @@ var WarningHighlight = ansiterm.Foreground(ansiterm.Yellow)
 // GoodHighlight is used to indicate good or success conditions.
 var GoodHighlight = ansiterm.Foreground(ansiterm.Green)
 
+// InfoHighlight is  the color used to indicate important details.
+// Generally that might be important to a user but not necessarily that
+// obvious.
+var InfoHighlight = ansiterm.Foreground(ansiterm.Cyan)
+
+// EmphasisHighlight is used to show accompanying information, which
+// might be deemed as important by the user.
+var EmphasisHighlight = struct {
+	White         *ansiterm.Context
+	DefaultBold   *ansiterm.Context
+	BoldWhite     *ansiterm.Context
+	Gray          *ansiterm.Context
+	BoldGray      *ansiterm.Context
+	DarkGray      *ansiterm.Context
+	BoldDarkGray  *ansiterm.Context
+	Magenta       *ansiterm.Context
+	BrightMagenta *ansiterm.Context
+	BrightGreen   *ansiterm.Context
+}{
+	White:         ansiterm.Foreground(ansiterm.White),
+	DefaultBold:   ansiterm.Foreground(ansiterm.Default).SetStyle(ansiterm.Bold),
+	BoldWhite:     ansiterm.Foreground(ansiterm.White).SetStyle(ansiterm.Bold),
+	Gray:          ansiterm.Foreground(ansiterm.Gray),
+	BoldGray:      ansiterm.Foreground(ansiterm.Gray).SetStyle(ansiterm.Bold),
+	BoldDarkGray:  ansiterm.Foreground(ansiterm.DarkGray).SetStyle(ansiterm.Bold),
+	DarkGray:      ansiterm.Foreground(ansiterm.DarkGray),
+	Magenta:       ansiterm.Foreground(ansiterm.Magenta),
+	BrightMagenta: ansiterm.Foreground(ansiterm.BrightMagenta),
+	BrightGreen:   ansiterm.Foreground(ansiterm.BrightGreen),
+}
+
 var statusColors = map[status.Status]*ansiterm.Context{
 	// good
 	status.Active:    GoodHighlight,

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -45,6 +45,13 @@ func (w *Wrapper) Print(values ...interface{}) {
 	}
 }
 
+// PrintNoTab writes each value adjacent to each other.
+func (w *Wrapper) PrintNoTab(values ...interface{}) {
+	for _, v := range values {
+		fmt.Fprintf(w, "%v", v)
+	}
+}
+
 // Printf writes the formatted text followed by a tab.
 func (w *Wrapper) Printf(format string, values ...interface{}) {
 	fmt.Fprintf(w, format+"\t", values...)
@@ -69,6 +76,27 @@ func (w *Wrapper) PrintColor(ctx *ansiterm.Context, value interface{}) {
 	} else {
 		fmt.Fprintf(w, "%v\t", value)
 	}
+}
+
+// PrintColorNoTab writes the value out in the color context specified.
+func (w *Wrapper) PrintColorNoTab(ctx *ansiterm.Context, value interface{}) {
+	if ctx != nil {
+		ctx.Fprintf(w.TabWriter, "%v", value)
+	} else {
+		fmt.Fprintf(w, "%v", value)
+	}
+}
+
+// PrintHeaders writes out many tab separated values in the color context specificed.
+func (w *Wrapper) PrintHeaders(ctx *ansiterm.Context, values ...interface{}) {
+	for i, v := range values {
+		if i != len(values)-1 {
+			ctx.Fprintf(w, "%v\t", v)
+		} else {
+			ctx.Fprintf(w, "%v", v)
+		}
+	}
+	fmt.Fprintln(w)
 }
 
 // PrintStatus writes out the status value in the standard color.


### PR DESCRIPTION
Add color to juju status
 
## Checklist

 - ~~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~~
 - ~~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~~
 - ~~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~~
 - ~~[ ] Comments answer the question of why design decisions were made~~

## QA steps
 ```sh
   juju bootstrap localhost overlord
   juju add-model lxd-model 
   juju deploy mediawiki
   juju deploy mysql --series=trusty
   juju deploy haproxy
   juju add-relation mediawiki:db mysql
   juju add-relation mediawiki haproxy
   juju expose haproxy
   juju add-unit -n 2 mediawiki
   juju status --color
   juju status --color --relations
   
```

*Please check that the following fields match their corresponding highlight colors in the cli.*
```
version -> yellow highlight,
address -> blue highlight,
ports -> bright magenta highlight
```

*Use this reference  [doc](https://docs.google.com/document/d/1F8BhZmIG4w_SJfztIexiBOEikXmSz9d3Ju1zoqkNdbQ/edit)*
**Note** the section header colors vary based on your default terminal's color scheme.

