### PR TITLE
Fix controller charm on caas/k8s

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1507,6 +1507,10 @@ func (c *controllerStack) buildContainerSpecForCommands(jujudCmds []string) (*co
 			continue
 		}
 		ct.VolumeMounts = append(ct.VolumeMounts, agentConfigMount)
+		ct.Args = append(ct.Args, "--controller")
+		ct.LivenessProbe = nil
+		ct.ReadinessProbe = nil
+		ct.StartupProbe = nil
 		spec.Containers[i] = ct
 	}
 	return spec, nil

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -633,6 +633,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 				"--charm-modified-version", "0",
 				"--append-env", "PATH=$PATH:/charm/bin",
 				"--show-log",
+				"--controller",
 			},
 			Resources: core.ResourceRequirements{
 				Requests: core.ResourceList{
@@ -656,42 +657,6 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			SecurityContext: &core.SecurityContext{
 				RunAsUser:  int64Ptr(0),
 				RunAsGroup: int64Ptr(0),
-			},
-			LivenessProbe: &core.Probe{
-				ProbeHandler: core.ProbeHandler{
-					HTTPGet: &core.HTTPGetAction{
-						Path: "/liveness",
-						Port: intstr.Parse("3856"),
-					},
-				},
-				InitialDelaySeconds: 30,
-				PeriodSeconds:       10,
-				SuccessThreshold:    1,
-				FailureThreshold:    2,
-			},
-			ReadinessProbe: &core.Probe{
-				ProbeHandler: core.ProbeHandler{
-					HTTPGet: &core.HTTPGetAction{
-						Path: "/readiness",
-						Port: intstr.Parse("3856"),
-					},
-				},
-				InitialDelaySeconds: 30,
-				PeriodSeconds:       10,
-				SuccessThreshold:    1,
-				FailureThreshold:    2,
-			},
-			StartupProbe: &core.Probe{
-				ProbeHandler: core.ProbeHandler{
-					HTTPGet: &core.HTTPGetAction{
-						Path: "/startup",
-						Port: intstr.Parse("3856"),
-					},
-				},
-				InitialDelaySeconds: 30,
-				PeriodSeconds:       10,
-				SuccessThreshold:    1,
-				FailureThreshold:    2,
 			},
 			VolumeMounts: []core.VolumeMount{
 				{

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -135,11 +135,14 @@ func (cfg *ControllerPodConfig) UnitAgentConfig() (agent.ConfigSetterWriter, err
 		Tag:               names.NewUnitTag("controller/" + cfg.ControllerId),
 		UpgradedToVersion: cfg.JujuVersion,
 		Password:          password,
-		APIAddresses:      cfg.APIHostAddrs(),
-		CACert:            cfg.APIInfo.CACert,
-		Values:            cfg.AgentEnvironment,
-		Controller:        cfg.ControllerTag,
-		Model:             cfg.APIInfo.ModelTag,
+		// Unit agent should always connect to the local controller.
+		APIAddresses: []string{net.JoinHostPort(
+			"localhost", strconv.Itoa(cfg.Bootstrap.StateServingInfo.APIPort),
+		)},
+		CACert:     cfg.APIInfo.CACert,
+		Values:     cfg.AgentEnvironment,
+		Controller: cfg.ControllerTag,
+		Model:      cfg.APIInfo.ModelTag,
 	}
 	conf, err := agent.NewAgentConfig(configParams)
 	if err != nil {

--- a/cloudconfig/podcfg/podcfg_test.go
+++ b/cloudconfig/podcfg/podcfg_test.go
@@ -147,6 +147,7 @@ func (*podcfgSuite) TestUnitAgentConfig(c *gc.C) {
 		ModelTag: testing.ModelTag,
 		CACert:   testing.CACert,
 	}
+	podConfig.Bootstrap.StateServingInfo.APIPort = 1234
 	podConfig.JujuVersion = version.MustParse("6.6.6")
 	c.Assert(err, jc.ErrorIsNil)
 	agentCfg, err := podConfig.UnitAgentConfig()
@@ -154,4 +155,5 @@ func (*podcfgSuite) TestUnitAgentConfig(c *gc.C) {
 	apiInfo, ok := agentCfg.APIInfo()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(agentCfg.OldPassword(), gc.Equals, apiInfo.Password)
+	c.Assert(apiInfo.Addrs, gc.DeepEquals, []string{"localhost:1234"})
 }

--- a/cmd/containeragent/unit/manifolds_test.go
+++ b/cmd/containeragent/unit/manifolds_test.go
@@ -74,6 +74,44 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	c.Assert(keys, jc.SameContents, expectedKeys)
 }
 
+func (s *ManifoldsSuite) TestManifoldNamesColocatedController(c *gc.C) {
+	config := unit.ManifoldsConfig{
+		ColocatedWithController: true,
+	}
+	manifolds := unit.Manifolds(config)
+	expectedKeys := []string{
+		"agent",
+		"api-config-watcher",
+		"api-caller",
+		"uniter",
+		"log-sender",
+
+		"charm-dir",
+		"leadership-tracker",
+		"hook-retry-strategy",
+
+		"migration-fortress",
+		"migration-inactive-flag",
+		"migration-minion",
+
+		"proxy-config-updater",
+		"logging-config-updater",
+
+		"upgrader",
+		"upgrade-steps-runner",
+		"upgrade-steps-gate",
+		"upgrade-steps-flag",
+
+		"caas-unit-termination-worker",
+		"caas-units-manager",
+	}
+	keys := make([]string, 0, len(manifolds))
+	for k := range manifolds {
+		keys = append(keys, k)
+	}
+	c.Assert(keys, jc.SameContents, expectedKeys)
+}
+
 func (*ManifoldsSuite) TestMigrationGuards(c *gc.C) {
 	exempt := set.NewStrings(
 		"agent",


### PR DESCRIPTION
Fixes how the controller charm is deployed in Kubernetes and how it dials the Juju controller.
- The controller charm unit agent now connects directly to the local controller over localhost.
- The charm container also now has no impact on pod readiness.

This also fixes the agent bootstrap tests to work on series other than focal.

## QA steps

Bootstrap microk8s.

## Documentation changes

N/A

## Bug reference

N/A