### PR TITLE
[JUJU-1219] Make "juju clouds" show (client) clouds it can even if controller has an error

### DIFF
--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -141,7 +141,7 @@ func (c *listCloudsCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 }
 
-func (c *listCloudsCommand) getCloudList(ctxt *cmd.Context) (*cloudList, error) {
+func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 	var returnErr error
 	accumulateErrors := func(err error) {
 		if returnErr != nil {
@@ -200,10 +200,7 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	details, err := c.getCloudList(ctxt)
-	if err != nil {
-		return errors.Trace(err)
-	}
+	details, listErr := c.getCloudList() // error checked below, after printing out best-effort results
 	if c.showAllMessage {
 		if details.len() != 0 {
 			ctxt.Infof("Only clouds with registered credentials are shown.")
@@ -223,7 +220,11 @@ func (c *listCloudsCommand) Run(ctxt *cmd.Context) error {
 	default:
 		result = details
 	}
-	return c.out.Write(ctxt, result)
+	err := c.out.Write(ctxt, result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return listErr
 }
 
 type cloudList struct {

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -154,7 +154,7 @@ func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 	details := newCloudList()
 	if c.Client {
 		if d, err := listLocalCloudDetails(c.Store); err != nil {
-			accumulateErrors(errors.Annotate(err, "getting local clouds"))
+			accumulateErrors(errors.Annotate(err, "could not get local clouds"))
 		} else {
 			details = d
 		}
@@ -188,7 +188,7 @@ func (c *listCloudsCommand) getCloudList() (*cloudList, error) {
 			return nil
 		}
 		if err := remotes(); err != nil {
-			accumulateErrors(errors.Annotate(err, "getting controller clouds"))
+			accumulateErrors(errors.Annotatef(err, "could not get clouds from controller %q", c.ControllerName))
 		}
 	}
 	c.showAllMessage = !c.Embedded && details.filter(c.all)

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -4,6 +4,7 @@
 package cloud_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"strings"
 
@@ -112,6 +113,23 @@ beehive:
       display-name: Fred
       access: admin
 `[1:])
+}
+
+func (s *listSuite) TestListControllerError(c *gc.C) {
+	cmd := cloud.NewListCloudCommandForTest(
+		s.store,
+		func() (cloud.ListCloudsAPI, error) {
+			return nil, errors.New("bad problem")
+		},
+	)
+
+	// Command should return an error
+	ctx, err := cmdtesting.RunCommand(c, cmd, "--all")
+	c.Assert(err, gc.ErrorMatches, `getting controller clouds: bad problem`)
+	c.Assert(cmd.ControllerName, gc.Equals, "mycontroller")
+
+	// But also print out what it can (the client clouds)
+	s.assertCloudsOutput(c, cmdtesting.Stdout(ctx))
 }
 
 func (s *listSuite) TestListClientAndController(c *gc.C) {

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -125,7 +125,7 @@ func (s *listSuite) TestListControllerError(c *gc.C) {
 
 	// Command should return an error
 	ctx, err := cmdtesting.RunCommand(c, cmd, "--all")
-	c.Assert(err, gc.ErrorMatches, `getting controller clouds: bad problem`)
+	c.Assert(err, gc.ErrorMatches, `could not get clouds from controller "mycontroller": bad problem`)
 	c.Assert(cmd.ControllerName, gc.Equals, "mycontroller")
 
 	// But also print out what it can (the client clouds)


### PR DESCRIPTION
This happens when we can't contact the controller, for example due to
https://bugs.launchpad.net/bugs/1967491

It should at least print the local clouds in cases like this.

## QA steps

I've been repro-ing by adding an explicit error return inside the `remotes` closure in `listCloudsCommand.getCloudList` and then running `juju clouds`. You could also repro by following the steps in the LP bug and switching your WiFi underneath microk8s so its IP address changes.

Here's example output:

```
$ juju clouds
Only clouds with registered credentials are shown.
There are more clouds, use --all to see them.
You can bootstrap a new controller using one of these clouds...

Clouds available on the client:
Cloud      Regions  Default    Type  Credentials  Source    Description
aws        22       us-east-1  ec2   1            public    Amazon Web Services
localhost  1        localhost  lxd   1            built-in  LXD Container Hypervisor
microk8s   1        localhost  k8s   1            built-in  A Kubernetes Cluster

ERROR could not get clouds from controller "microk8s-localhost": test error message!!!
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1967491
