### PR TITLE
[JUJU-1218] Make output of `juju exec` less verbose

### DIFF
--- a/cmd/juju/action/exec.go
+++ b/cmd/juju/action/exec.go
@@ -37,6 +37,7 @@ func newExecCommand(store jujuclient.ClientStore, logMessageHandler func(*cmd.Co
 			defaultWait:       5 * time.Minute,
 			logMessageHandler: logMessageHandler,
 			clock:             clock,
+			hideProgress:      true,
 		},
 	})
 	cmd.SetClientStore(store)

--- a/cmd/juju/action/export_test.go
+++ b/cmd/juju/action/export_test.go
@@ -163,6 +163,7 @@ func NewExecCommandForTest(store jujuclient.ClientStore, clock clock.Clock, logM
 			defaultWait:       5 * time.Minute,
 			logMessageHandler: logMessageHandler,
 			clock:             clock,
+			hideProgress:      true,
 		},
 	}
 	c.SetClientStore(store)


### PR DESCRIPTION
Fixes [lp:1946530](https://bugs.launchpad.net/juju/+bug/1946530).

`juju exec` was printing meta-info such as
```
Running operation 1 with 2 tasks
Waiting for task 3...
```
We want this to be hidden by default, and allow the user to opt into it with the `--verbose` flag. However, we don't want to change the behaviour of other action commands such as `juju run` - these should still print the meta-info by default (can be hidden with `--quiet`).

So, my changes are:
- introduce a new field `hideMetaInfo bool` in `runCommandBase`, which signals whether or not these messages should be hidden by default.
- introduce a function 
  ```go
  func (c *runCommandBase) metaf(ctx *cmd.Context, args...)
  ```
  which redirects its arguments to `ctx.Verbosef` or `ctx.Infof`, depending on the value of `c.hideMetaInfo`
- set `hideMetaInfo = true` for `execCommand`.

I also added unit tests for `juju exec` and `juju run` to check that the verbosity behaviour is correct.

## Output

```
$ juju exec --machine 0 'echo hi'
hi

$ juju exec --machine 0 'echo hi' --quiet
hi

$ juju exec --machine 0 'echo hi' --verbose
Running operation 31 with 1 task
  - task 32 on machine-0

Waiting for task 32...
hi

$ juju exec --machine 0 'echo hi' --background
Scheduled operation 29 with task 30
Check operation status with 'juju show-operation 29'
Check task status with 'juju show-task 30'
$ juju exec --machine 0 'stat foo'
stat: cannot stat 'foo': No such file or directory

ERROR the following task failed:
 - id "38" with return code 1

use 'juju show-task' to inspect the failure

$
```