### PR TITLE
[JUJU-1104]add_no_color_flag

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -69,7 +69,6 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	if fs.Model.SLA != "" {
 		header = append(header, "SLA")
 		values = append(values, fs.Model.SLA)
-
 	}
 	if cs := fs.Controller; cs != nil && cs.Timestamp != "" {
 		header = append(header, "Timestamp")

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -59,7 +59,8 @@ type statusCommand struct {
 	retryCount int
 	retryDelay time.Duration
 
-	color bool
+	color   bool
+	noColor bool
 
 	// relations indicates if 'relations' section is displayed
 	relations bool
@@ -172,6 +173,7 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.isoTime, "utc", false, "Display timestamps in the UTC timezone")
 
 	f.BoolVar(&c.color, "color", false, "Use ANSI color codes in tabular output")
+	f.BoolVar(&c.noColor, "no-color", false, "Disable ANSI color codes in tabular output")
 	f.BoolVar(&c.relations, "relations", false, "Show 'relations' section in tabular output")
 	f.BoolVar(&c.storage, "storage", false, "Show 'storage' section in tabular output")
 
@@ -227,6 +229,11 @@ func (c *statusCommand) Init(args []string) error {
 	if c.clock == nil {
 		c.clock = clock.WallClock
 	}
+
+	if c.color && c.noColor {
+		return errors.Errorf("cannot mix --no-color and --color")
+	}
+
 	return nil
 }
 
@@ -427,5 +434,11 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *statusCommand) FormatTabular(writer io.Writer, value interface{}) error {
-	return FormatTabular(writer, c.color, value)
+
+	if c.noColor {
+		return FormatTabular(writer, false, value)
+	}
+
+	//color mode enabled by default
+	return FormatTabular(writer, true, value)
 }

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4715,7 +4715,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 	for _, format := range statusFormats {
 		c.Logf("format %q", format.name)
 		// Run command with the required format.
-		args := []string{"--format", format.name}
+		args := []string{"--no-color","--format", format.name}
 		if ctx.expectIsoTime {
 			args = append(args, "--utc")
 		}
@@ -4810,7 +4810,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 	}
 
 	for _, format := range statusFormats {
-		code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", format.name)
+		code, stdout, stderr := runStatus(c,"--no-color", "-m", "hosted", "--format", format.name)
 		c.Check(code, gc.Equals, 0)
 		c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
@@ -4839,7 +4839,7 @@ hosted  kontroll    dummy/dummy-region  2.0.0    unsupported  15:04:05+07:00  mi
 
 	st := s.setupMigrationTest(c)
 	defer st.Close()
-	code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", "tabular")
+	code, stdout, stderr := runStatus(c, "--no-color","-m", "hosted", "--format", "tabular")
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
@@ -4863,7 +4863,7 @@ hosted  kontroll    dummy/dummy-region  2.0.0    unsupported  15:04:05+07:00  mi
 	err = model.UpdateLatestToolsVersion(nextVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
-	code, stdout, stderr := runStatus(c, "-m", "hosted", "--format", "tabular")
+	code, stdout, stderr := runStatus(c,"--no-color", "-m", "hosted", "--format", "tabular")
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
@@ -4959,7 +4959,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 	for _, s := range steps {
 		s.step(c, ctx)
 	}
-	code, stdout, stderr := runStatus(c, "--format", "summary")
+	code, stdout, stderr := runStatus(c, "--no-color","--format", "summary")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, `
@@ -5041,19 +5041,19 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 }
 
 func assertOneLineStatus(c *gc.C, expected string) {
-	code, stdout, stderr := runStatus(c, "--format", "oneline")
+	code, stdout, stderr := runStatus(c, "--no-color","--format", "oneline")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, expected)
 
 	c.Log(`Check that "short" is an alias for oneline.`)
-	code, stdout, stderr = runStatus(c, "--format", "short")
+	code, stdout, stderr = runStatus(c, "--no-color","--format", "short")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, expected)
 
 	c.Log(`Check that "line" is an alias for oneline.`)
-	code, stdout, stderr = runStatus(c, "--format", "line")
+	code, stdout, stderr = runStatus(c,"--no-color", "--format", "line")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, expected)
@@ -5182,7 +5182,7 @@ wordpress:logging-dir  logging:logging-directory  logging    subordinate
 func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
-	code, stdout, stderr := runStatus(c, "--format", "tabular", "--relations")
+	code, stdout, stderr := runStatus(c, "--no-color", "--format", "tabular", "--relations")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 
@@ -5195,7 +5195,7 @@ func (s *StatusSuite) TestStatusWithFormatTabularValidModelUUID(c *gc.C) {
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
 
-	code, stdout, stderr := runStatus(c, "--format", "tabular", "--relations", "-m", s.Model.UUID())
+	code, stdout, stderr := runStatus(c, "--no-color", "--format", "tabular", "--relations", "-m", s.Model.UUID())
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 
@@ -5207,7 +5207,7 @@ func (s *StatusSuite) TestStatusWithFormatTabularValidModelUUID(c *gc.C) {
 func (s *StatusSuite) TestStatusWithFormatYaml(c *gc.C) {
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
-	code, stdout, stderr := runStatus(c, "--format", "yaml")
+	code, stdout, stderr := runStatus(c, "--no-color", "--format", "yaml")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), jc.Contains, "display-name: snowflake")
@@ -5216,7 +5216,7 @@ func (s *StatusSuite) TestStatusWithFormatYaml(c *gc.C) {
 func (s *StatusSuite) TestStatusWithFormatJson(c *gc.C) {
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
-	code, stdout, stderr := runStatus(c, "--format", "json")
+	code, stdout, stderr := runStatus(c, "--no-color", "--format", "json")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), jc.Contains, `"display-name":"snowflake"`)
@@ -5455,7 +5455,7 @@ func (s *StatusSuite) TestStatusWithNilStatusAPI(c *gc.C) {
 		return &client, nil
 	})
 
-	code, _, stderr := runStatus(c, "--format", "tabular")
+	code, _, stderr := runStatus(c, "--no-color", "--format", "tabular")
 	c.Check(code, gc.Equals, 1)
 	c.Check(string(stderr), gc.Equals, "ERROR unable to obtain the current status\n")
 }
@@ -5591,7 +5591,7 @@ func (s *StatusSuite) TestFilterToActive(c *gc.C) {
 	// And unit 0 of the "mysql" application has an error
 	setAgentStatus{"mysql/0", status.Error, "mock error", nil}.step(c, ctx)
 	// When I run juju status --format oneline started
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "active")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "active")
 	c.Assert(string(stderr), gc.Equals, "")
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5608,7 +5608,7 @@ func (s *StatusSuite) TestFilterToMachine(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// When I run juju status --format oneline 1
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "1")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "1")
 	c.Assert(string(stderr), gc.Equals, "")
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5625,7 +5625,7 @@ func (s *StatusSuite) TestFilterToMachineShowsContainer(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// When I run juju status --format yaml 0
-	_, stdout, stderr := runStatus(c, "--format", "yaml", "0")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "yaml", "0")
 	c.Assert(string(stderr), gc.Equals, "")
 	// Then I should receive output matching:
 	const expected = "(.|\n)*machines:(.|\n)*\"0\"(.|\n)*0/lxd/0(.|\n)*"
@@ -5638,7 +5638,7 @@ func (s *StatusSuite) TestFilterToContainer(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// When I run juju status --format yaml 0/lxd/0
-	_, stdout, stderr := runStatus(c, "--format", "yaml", "0/lxd/0")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "yaml", "0/lxd/0")
 	c.Assert(string(stderr), gc.Equals, "")
 
 	const expected = "" +
@@ -5708,7 +5708,7 @@ func (s *StatusSuite) TestFilterToErrored(c *gc.C) {
 	// Given unit 1 of the "logging" application has an error
 	setAgentStatus{"logging/1", status.Error, "mock error", nil}.step(c, ctx)
 	// When I run juju status --format oneline error
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "error")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "error")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5725,7 +5725,7 @@ func (s *StatusSuite) TestFilterToApplication(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// When I run juju status --format oneline error
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "mysql")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "mysql")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5749,7 +5749,7 @@ func (s *StatusSuite) TestFilterToExposedApplication(c *gc.C) {
 	// And the wordpress application is not exposed
 	setApplicationExposed{"wordpress", false}.step(c, ctx)
 	// When I run juju status --format oneline exposed
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "exposed")
+	_, stdout, stderr := runStatus(c, "--no-color","--format", "oneline", "exposed")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5767,7 +5767,7 @@ func (s *StatusSuite) TestFilterToNotExposedApplication(c *gc.C) {
 
 	setApplicationExposed{"mysql", true}.step(c, ctx)
 	// When I run juju status --format oneline not exposed
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "not", "exposed")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "not", "exposed")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5788,7 +5788,7 @@ func (s *StatusSuite) TestFilterOnSubnet(c *gc.C) {
 	// And the address for machine "2" is "10.0.2.1"
 	setAddresses{"2", network.NewSpaceAddresses("10.0.2.1")}.step(c, ctx)
 	// When I run juju status --format oneline 127.0.0.1
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "127.0.0.1")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "127.0.0.1")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5810,7 +5810,7 @@ func (s *StatusSuite) TestFilterOnPorts(c *gc.C) {
 	setAddresses{"2", network.NewSpaceAddresses("10.0.2.1")}.step(c, ctx)
 	openUnitPort{"wordpress/0", "tcp", 80}.step(c, ctx)
 	// When I run juju status --format oneline 80/tcp
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "80/tcp")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "80/tcp")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5827,7 +5827,7 @@ func (s *StatusSuite) TestFilterParentButNotSubordinate(c *gc.C) {
 	defer s.resetContext(c, ctx)
 
 	// When I run juju status --format oneline 80/tcp
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "logging")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "logging")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5848,7 +5848,7 @@ func (s *StatusSuite) TestFilterSubordinateButNotParent(c *gc.C) {
 	// Given the wordpress application is exposed
 	setApplicationExposed{"wordpress", true}.step(c, ctx)
 	// When I run juju status --format oneline not exposed
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "not", "exposed")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "not", "exposed")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5863,7 +5863,7 @@ func (s *StatusSuite) TestFilterMultipleHomogenousPatterns(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "wordpress/0", "mysql/0")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "wordpress/0", "mysql/0")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -5880,9 +5880,9 @@ func (s *StatusSuite) TestFilterMultipleHeterogenousPatterns(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--format", "oneline", "wordpress/0", "active")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "wordpress/0", "active")
 	c.Assert(stderr, gc.IsNil)
-	// Then I should receive output prefixed with:
+	// Then I should receive output prefixed with:runStatus
 	const expected = `
 
 - mysql/0: 10.0.2.1 (agent:idle, workload:active)
@@ -6171,7 +6171,7 @@ func (s *StatusSuite) TestTabularNoRelations(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c)
+	_, stdout, stderr := runStatus(c, "--no-color")
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "Relation provider"), jc.IsFalse)
 }
@@ -6180,7 +6180,7 @@ func (s *StatusSuite) TestTabularDisplayRelations(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--relations")
+	_, stdout, stderr := runStatus(c, "--no-color", "--relations")
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "Relation provider"), jc.IsTrue)
 }
@@ -6189,7 +6189,7 @@ func (s *StatusSuite) TestNonTabularDisplayRelations(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--format=yaml", "--relations")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml", "--relations")
 	c.Assert(string(stderr), gc.Equals, "provided relations option is always enabled in non tabular formats\n")
 	logger.Debugf("stdout -> \n%q", stdout)
 	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
@@ -6200,7 +6200,7 @@ func (s *StatusSuite) TestNonTabularDisplayStorage(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--format=yaml", "--storage")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml", "--storage")
 	c.Assert(string(stderr), gc.Equals, "provided storage option is always enabled in non tabular formats\n")
 	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
 	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
@@ -6210,7 +6210,7 @@ func (s *StatusSuite) TestNonTabularDisplayRelationsAndStorage(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--format=yaml", "--relations", "--storage")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml", "--relations", "--storage")
 	c.Assert(string(stderr), gc.Equals, "provided relations, storage options are always enabled in non tabular formats\n")
 	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
 	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
@@ -6220,7 +6220,7 @@ func (s *StatusSuite) TestNonTabularRelations(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--format=yaml")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml")
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
 	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
@@ -6258,7 +6258,7 @@ func (s *StatusSuite) TestBranchesOutputTabular(c *gc.C) {
 		c.Fatalf(`Expected "bla" got %q. This test failed because the file store did not save the value in time of access`, m.ActiveBranch)
 	}
 
-	_, stdout, stderr := runStatus(c)
+	_, stdout, stderr := runStatus(c, "--no-color")
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "bla*"), jc.IsTrue)
 	c.Assert(strings.Contains(string(stdout), "test*"), jc.IsFalse)
@@ -6279,13 +6279,13 @@ func (s *StatusSuite) TestBranchesOutputNonTabular(c *gc.C) {
 	if m.ActiveBranch != "bla" {
 		c.Fatalf(`Expected "bla" got %q. This test failed because the file store did not save the value in time of access`, m.ActiveBranch)
 	}
-	_, stdout, stderr := runStatus(c, "--format=yaml")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml")
 	c.Assert(stderr, gc.IsNil)
 	c.Assert(strings.Contains(string(stdout), "active: true"), jc.IsTrue)
 }
 
 func (s *StatusSuite) TestStatusFormatTabularEmptyModel(c *gc.C) {
-	code, stdout, stderr := runStatus(c)
+	code, stdout, stderr := runStatus(c, "--no-color")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "Model \"controller\" is empty.\n")
 	expected := `
@@ -6298,7 +6298,7 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 }
 
 func (s *StatusSuite) TestStatusFormatTabularForUnmatchedFilter(c *gc.C) {
-	code, stdout, stderr := runStatus(c, "unmatched")
+	code, stdout, stderr := runStatus(c, "--no-color","unmatched")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "Nothing matched specified filter.\n")
 	expected := `
@@ -6309,6 +6309,6 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 	output := substituteFakeTimestamp(c, stdout, false)
 	c.Assert(string(output), gc.Equals, expected)
 
-	_, _, stderr = runStatus(c, "cannot", "match", "me")
+	_, _, stderr = runStatus(c, "--no-color", "cannot", "match", "me")
 	c.Check(string(stderr), gc.Equals, "Nothing matched specified filters.\n")
 }

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -4715,7 +4715,7 @@ func (e scopedExpect) step(c *gc.C, ctx *context) {
 	for _, format := range statusFormats {
 		c.Logf("format %q", format.name)
 		// Run command with the required format.
-		args := []string{"--no-color","--format", format.name}
+		args := []string{"--no-color", "--format", format.name}
 		if ctx.expectIsoTime {
 			args = append(args, "--utc")
 		}
@@ -4810,7 +4810,7 @@ func (s *StatusSuite) TestMigrationInProgress(c *gc.C) {
 	}
 
 	for _, format := range statusFormats {
-		code, stdout, stderr := runStatus(c,"--no-color", "-m", "hosted", "--format", format.name)
+		code, stdout, stderr := runStatus(c, "--no-color", "-m", "hosted", "--format", format.name)
 		c.Check(code, gc.Equals, 0)
 		c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
@@ -4839,7 +4839,7 @@ hosted  kontroll    dummy/dummy-region  2.0.0    unsupported  15:04:05+07:00  mi
 
 	st := s.setupMigrationTest(c)
 	defer st.Close()
-	code, stdout, stderr := runStatus(c, "--no-color","-m", "hosted", "--format", "tabular")
+	code, stdout, stderr := runStatus(c, "--no-color", "-m", "hosted", "--format", "tabular")
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
@@ -4863,7 +4863,7 @@ hosted  kontroll    dummy/dummy-region  2.0.0    unsupported  15:04:05+07:00  mi
 	err = model.UpdateLatestToolsVersion(nextVersion)
 	c.Assert(err, jc.ErrorIsNil)
 
-	code, stdout, stderr := runStatus(c,"--no-color", "-m", "hosted", "--format", "tabular")
+	code, stdout, stderr := runStatus(c, "--no-color", "-m", "hosted", "--format", "tabular")
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(string(stderr), gc.Equals, "Model \"hosted\" is empty.\n")
 
@@ -4959,7 +4959,7 @@ func (s *StatusSuite) TestStatusWithFormatSummary(c *gc.C) {
 	for _, s := range steps {
 		s.step(c, ctx)
 	}
-	code, stdout, stderr := runStatus(c, "--no-color","--format", "summary")
+	code, stdout, stderr := runStatus(c, "--no-color", "--format", "summary")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, `
@@ -5041,19 +5041,19 @@ func (s *StatusSuite) TestStatusWithFormatOneline(c *gc.C) {
 }
 
 func assertOneLineStatus(c *gc.C, expected string) {
-	code, stdout, stderr := runStatus(c, "--no-color","--format", "oneline")
+	code, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, expected)
 
 	c.Log(`Check that "short" is an alias for oneline.`)
-	code, stdout, stderr = runStatus(c, "--no-color","--format", "short")
+	code, stdout, stderr = runStatus(c, "--no-color", "--format", "short")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, expected)
 
 	c.Log(`Check that "line" is an alias for oneline.`)
-	code, stdout, stderr = runStatus(c,"--no-color", "--format", "line")
+	code, stdout, stderr = runStatus(c, "--no-color", "--format", "line")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 	c.Assert(string(stdout), gc.Equals, expected)
@@ -5749,7 +5749,7 @@ func (s *StatusSuite) TestFilterToExposedApplication(c *gc.C) {
 	// And the wordpress application is not exposed
 	setApplicationExposed{"wordpress", false}.step(c, ctx)
 	// When I run juju status --format oneline exposed
-	_, stdout, stderr := runStatus(c, "--no-color","--format", "oneline", "exposed")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format", "oneline", "exposed")
 	c.Assert(stderr, gc.IsNil)
 	// Then I should receive output prefixed with:
 	const expected = `
@@ -6298,7 +6298,7 @@ controller  kontroll    dummy/dummy-region  1.2.3    unsupported  15:04:05+07:00
 }
 
 func (s *StatusSuite) TestStatusFormatTabularForUnmatchedFilter(c *gc.C) {
-	code, stdout, stderr := runStatus(c, "--no-color","unmatched")
+	code, stdout, stderr := runStatus(c, "--no-color", "unmatched")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "Nothing matched specified filter.\n")
 	expected := `

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -73,13 +73,13 @@ func (s *MinimalStatusSuite) TestWatchUntilError(c *gc.C) {
 	// We expect the correct output for the first 3 nil errors before termination.
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 Model  Controller  Cloud/Region  Version
-test   test        foo            
+test   test        foo           
 
 Model  Controller  Cloud/Region  Version
-test   test        foo            
+test   test        foo           
 
 Model  Controller  Cloud/Region  Version
-test   test        foo            
+test   test        foo           
 
 `[1:])
 
@@ -93,7 +93,7 @@ func (s *MinimalStatusSuite) TestGoodCallWithStorage(c *gc.C) {
 	obtainedValid := cmdtesting.Stdout(context)
 	c.Assert(obtainedValid, gc.Equals, `
 Model  Controller  Cloud/Region  Version
-test   test        foo            
+test   test        foo           
 
 Storage Unit  Storage ID    Type        Pool      Mountpoint  Size    Status    Message
               persistent/1  filesystem                                detached  
@@ -111,7 +111,7 @@ func (s *MinimalStatusSuite) TestRetryOnError(c *gc.C) {
 		errors.New("splat"),
 	}
 
-	_, err := s.runStatus(c)
+	_, err := s.runStatus(c, "--no-color")
 	c.Assert(err, jc.ErrorIsNil)
 	delay := 100 * time.Millisecond
 	// Two delays of the default time.
@@ -124,7 +124,7 @@ func (s *MinimalStatusSuite) TestRetryDelays(c *gc.C) {
 		errors.New("splat"),
 	}
 
-	_, err := s.runStatus(c, "--retry-delay", "250ms")
+	_, err := s.runStatus(c, "--no-color", "--retry-delay", "250ms")
 	c.Assert(err, jc.ErrorIsNil)
 	delay := 250 * time.Millisecond
 	c.Assert(s.clock.waits, jc.DeepEquals, []time.Duration{delay, delay})
@@ -141,7 +141,7 @@ func (s *MinimalStatusSuite) TestRetryCount(c *gc.C) {
 		errors.New("error 7"),
 	}
 
-	_, err := s.runStatus(c, "--retry-count", "5")
+	_, err := s.runStatus(c, "--no-color", "--retry-count", "5")
 	c.Assert(err.Error(), gc.Equals, "error 6")
 	// We expect five waits of the default duration.
 	delay := 100 * time.Millisecond
@@ -155,7 +155,7 @@ func (s *MinimalStatusSuite) TestRetryCountOfZero(c *gc.C) {
 		errors.New("error 3"),
 	}
 
-	_, err := s.runStatus(c, "--retry-count", "0")
+	_, err := s.runStatus(c, "--no-color", "--retry-count", "0")
 	c.Assert(err.Error(), gc.Equals, "error 1")
 	// No delays.
 	c.Assert(s.clock.waits, gc.HasLen, 0)

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -67,7 +67,7 @@ func (s *MinimalStatusSuite) TestWatchUntilError(c *gc.C) {
 		errors.New("boom"),
 	}
 
-	ctx, err := s.runStatus(c, "--watch", "1ms", "--retry-count", "0")
+	ctx, err := s.runStatus(c, "--no-color", "--watch", "1ms", "--retry-count", "0")
 	c.Assert(err, gc.ErrorMatches, "boom")
 
 	// We expect the correct output for the first 3 nil errors before termination.
@@ -86,7 +86,7 @@ test   test        foo
 }
 
 func (s *MinimalStatusSuite) TestGoodCallWithStorage(c *gc.C) {
-	context, err := s.runStatus(c, "--storage")
+	context, err := s.runStatus(c, "--no-color", "--storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.clock.waits, gc.HasLen, 0)
 

--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -73,13 +73,13 @@ func (s *MinimalStatusSuite) TestWatchUntilError(c *gc.C) {
 	// We expect the correct output for the first 3 nil errors before termination.
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 Model  Controller  Cloud/Region  Version
-test   test        foo           
+test   test        foo            
 
 Model  Controller  Cloud/Region  Version
-test   test        foo           
+test   test        foo            
 
 Model  Controller  Cloud/Region  Version
-test   test        foo           
+test   test        foo            
 
 `[1:])
 
@@ -93,7 +93,7 @@ func (s *MinimalStatusSuite) TestGoodCallWithStorage(c *gc.C) {
 	obtainedValid := cmdtesting.Stdout(context)
 	c.Assert(obtainedValid, gc.Equals, `
 Model  Controller  Cloud/Region  Version
-test   test        foo           
+test   test        foo            
 
 Storage Unit  Storage ID    Type        Pool      Mountpoint  Size    Status    Message
               persistent/1  filesystem                                detached  

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -68,7 +68,7 @@ func (s *StatusSuite) run(c *gc.C, args ...string) *cmd.Context {
 
 func (s *StatusSuite) TestMultipleRelationsInYamlFormat(c *gc.C) {
 	s.setupMultipleRelationsBetweenApplications(c)
-	context := s.run(c, "status", "--format=yaml")
+	context := s.run(c, "status", "--no-color", "--format=yaml")
 	out := cmdtesting.Stdout(context)
 
 	// expected relations for 'logging'
@@ -93,7 +93,7 @@ func (s *StatusSuite) TestMultipleRelationsInYamlFormat(c *gc.C) {
 
 func (s *StatusSuite) TestMultipleRelationsInTabularFormat(c *gc.C) {
 	s.setupMultipleRelationsBetweenApplications(c)
-	context := s.run(c, "status", "--relations")
+	context := s.run(c, "status", "--no-color", "--relations")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
 Relation provider      Requirer                   Interface  Type         Message
 wordpress:juju-info    logging:info               juju-info  subordinate  joining  
@@ -107,10 +107,10 @@ func (s *StatusSuite) TestMachineDisplayNameIsDisplayed(c *gc.C) {
 		InstanceId:  instance.Id("id1"),
 		DisplayName: "eye-dee-one",
 	})
-	context := s.run(c, "status")
+	context := s.run(c, "status", "--no-color")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, "eye-dee-one")
 
-	context2 := s.run(c, "status", "--format=yaml")
+	context2 := s.run(c, "status", "--no-color", "--format=yaml")
 	c.Assert(cmdtesting.Stdout(context2), jc.Contains, "eye-dee-one")
 }
 
@@ -163,7 +163,7 @@ func (s *StatusSuite) TestStatusWhenFilteringByMachine(c *gc.C) {
 		Machine:     machine,
 	})
 
-	context := s.run(c, "status")
+	context := s.run(c, "status", "--no-color")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
 App        Version  Status   Scale  Charm      Channel  Rev  Exposed  Message
 another             waiting    0/1  mysql                 5  no       waiting for machine
@@ -180,7 +180,7 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 1        pending       id1      quantal      
 `)
 
-	context = s.run(c, "status", "0")
+	context = s.run(c, "status", "--no-color", "0")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
 App        Version  Status   Scale  Charm      Channel  Rev  Exposed  Message
 mysql               waiting    0/1  mysql                 1  no       waiting for machine
@@ -234,7 +234,7 @@ func (s *StatusSuite) TestStatusFilteringByMachineIDMatchesExactly(c *gc.C) {
 		Machine:     machine10,
 	})
 
-	context := s.run(c, "status", "1")
+	context := s.run(c, "status", "--no-color", "1")
 	// Should not have matched anything from machine 10.
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
 Unit       Workload  Agent       Machine  Public address  Ports  Message
@@ -245,7 +245,7 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 
 `)
 
-	context = s.run(c, "status", "10")
+	context = s.run(c, "status", "--no-color", "10")
 	// Should not have matched anything from machine 1.
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
 Unit       Workload  Agent       Machine  Public address  Ports  Message
@@ -276,7 +276,7 @@ func (s *StatusSuite) TestStatusMachineFilteringWithUnassignedUnits(c *gc.C) {
 		InstanceId: instance.Id("id1"),
 	})
 
-	context := s.run(c, "status", "1")
+	context := s.run(c, "status", "--no-color", "1")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
 Machine  State    DNS  Inst id  Series   AZ  Message
 1        pending       id1      quantal      


### PR DESCRIPTION
Add `--no-color` to remove ansicolor codes from juju status output.

- ~~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~~
 - ~~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~~
 - ~~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~~
 - ~~[ ] Comments answer the question of why design decisions were made~~

## QA steps
 ```sh
   juju bootstrap localhost overlord
   juju add-model lxd-model 
   juju deploy mediawiki
   juju deploy mysql --series=trusty
   juju deploy haproxy
   juju add-relation mediawiki:db mysql
   juju add-relation mediawiki haproxy
   juju expose haproxy
   juju add-unit -n 2 mediawiki
   juju status --no-color
   juju status --no-color --relations
   
```
*The output should not contain colored text*