### PR TITLE
[JUJU-1102]deprecate_juju_status_color

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -172,7 +172,7 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.isoTime, "utc", false, "Display timestamps in the UTC timezone")
 
-	f.BoolVar(&c.color, "color", false, "Use ANSI color codes in tabular output")
+	f.BoolVar(&c.color, "color", true, "Use ANSI color codes in tabular output")
 	f.BoolVar(&c.noColor, "no-color", false, "Disable ANSI color codes in tabular output")
 	f.BoolVar(&c.relations, "relations", false, "Show 'relations' section in tabular output")
 	f.BoolVar(&c.storage, "storage", false, "Show 'storage' section in tabular output")


### PR DESCRIPTION
Add deprecation warning for `--color` flag.

- ~~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~~
 - ~~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~~
 - ~~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~~
 - ~~[ ] Comments answer the question of why design decisions were made~~

## QA steps
 ```sh
   juju bootstrap localhost overlord
   juju add-model lxd-model 
   juju deploy mediawiki
   juju deploy mysql --series=trusty
   juju deploy haproxy
   juju add-relation mediawiki:db mysql
   juju add-relation mediawiki haproxy
   juju expose haproxy
   juju status --color
   ```