### PR TITLE
[JUJU-1220] Add tests to cover GetManifests not found case;

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -2140,6 +2140,7 @@ func (s *findToolsSuite) TestFindToolsCAASNonReleased(c *gc.C) {
 			{Version: version.MustParseBinary("2.9.9-ubuntu-amd64")},
 			{Version: version.MustParseBinary("2.9.10-ubuntu-amd64")},
 			{Version: version.MustParseBinary("2.9.11-ubuntu-amd64")},
+			{Version: version.MustParseBinary("2.9.12-ubuntu-amd64")},
 		},
 	}
 	s.PatchValue(&coreos.HostOS, func() coreos.OSType { return coreos.Ubuntu })
@@ -2173,11 +2174,13 @@ func (s *findToolsSuite) TestFindToolsCAASNonReleased(c *gc.C) {
 			image.NewImageInfo(version.MustParse("2.9.10.1")),
 			image.NewImageInfo(version.MustParse("2.9.10")),
 			image.NewImageInfo(version.MustParse("2.9.11")),
-			image.NewImageInfo(version.MustParse("2.9.12")), // skip: it's not released in simplestream yet.
+			image.NewImageInfo(version.MustParse("2.9.12")),
+			image.NewImageInfo(version.MustParse("2.9.13")), // skip: it's not released in simplestream yet.
 		}, nil),
 		registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10.1").Return("amd64", nil),
 		registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10").Return("amd64", nil),
 		registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.11").Return("amd64", nil),
+		registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.12").Return("", errors.NotFoundf("2.9.12")), // This can only happen on a non-official registry account.
 		registryProvider.EXPECT().Close().Return(nil),
 	)
 


### PR DESCRIPTION
Add tests to cover GetManifests not found case;

## QA steps

```console
$ go test -race -v ./docker/registry/internal/... -test.timeout=300s -check.v -count=1 -check.f=baseSuite
$ go test -race -v ./apiserver/facades/client/client/... -test.timeout=300s -check.v -count=1 -check.f=findToolsSuite.TestFindToolsCAASNonReleased
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1976278
