### PR TITLE
[JUJU-1232] Backport actions facade v7 support

### DIFF
--- a/api/client/action/client.go
+++ b/api/client/action/client.go
@@ -137,6 +137,16 @@ func (c *Client) EnqueueOperation(actions []Action) (EnqueuedActions, error) {
 			Parameters: a.Parameters,
 		}
 	}
+
+	if c.BestAPIVersion() > 6 {
+		var results params.EnqueuedActionsV2
+		err := c.facade.FacadeCall("EnqueueOperation", arg, &results)
+		if err != nil {
+			return EnqueuedActions{}, errors.Trace(err)
+		}
+		return unmarshallEnqueuedActionsV2(results)
+	}
+
 	results := params.EnqueuedActions{}
 	err := c.facade.FacadeCall("EnqueueOperation", arg, &results)
 	if err != nil {

--- a/api/client/action/run.go
+++ b/api/client/action/run.go
@@ -14,8 +14,18 @@ import (
 // RunOnAllMachines runs the command on all the machines with the specified
 // timeout.
 func (c *Client) RunOnAllMachines(commands string, timeout time.Duration) (EnqueuedActions, error) {
-	var results params.ActionResults
 	args := params.RunParams{Commands: commands, Timeout: timeout}
+
+	if c.BestAPIVersion() > 6 {
+		var results params.EnqueuedActionsV2
+		err := c.facade.FacadeCall("RunOnAllMachines", args, &results)
+		if err != nil {
+			return EnqueuedActions{}, errors.Trace(err)
+		}
+		return unmarshallEnqueuedActionsV2(results)
+	}
+
+	var results params.ActionResults
 	err := c.facade.FacadeCall("RunOnAllMachines", args, &results)
 	if err != nil {
 		return EnqueuedActions{}, errors.Trace(err)
@@ -34,6 +44,16 @@ func (c *Client) Run(run RunParams) (EnqueuedActions, error) {
 		Units:           run.Units,
 		WorkloadContext: run.WorkloadContext,
 	}
+
+	if c.BestAPIVersion() > 6 {
+		var results params.EnqueuedActionsV2
+		err := c.facade.FacadeCall("Run", args, &results)
+		if err != nil {
+			return EnqueuedActions{}, errors.Trace(err)
+		}
+		return unmarshallEnqueuedActionsV2(results)
+	}
+
 	var results params.ActionResults
 	err := c.facade.FacadeCall("Run", args, &results)
 	if err != nil {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -11,7 +11,7 @@ package api
 // New facades should start at 1.
 // Facades that existed before versioning start at 0.
 var facadeVersions = map[string]int{
-	"Action":                       6,
+	"Action":                       7,
 	"ActionPruner":                 1,
 	"Agent":                        3,
 	"AgentTools":                   1,

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -51,6 +51,11 @@ type APIv5 struct {
 
 // APIv6 provides the Action API facade for version 6.
 type APIv6 struct {
+	*APIv7
+}
+
+// APIv7 provides the Action API facade for version 7.
+type APIv7 struct {
 	*ActionAPI
 }
 

--- a/apiserver/facades/client/action/export_test.go
+++ b/apiserver/facades/client/action/export_test.go
@@ -10,7 +10,6 @@ import (
 
 var (
 	GetAllUnitNames = getAllUnitNames
-	QueueActions    = &queueActions
 )
 
 func NewActionAPI(st *state.State, resources facade.Resources, authorizer facade.Authorizer) (*ActionAPI, error) {

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -23,7 +23,22 @@ func (*APIv5) EnqueueOperation(_, _ struct{}) {}
 // EnqueueOperation takes a list of Actions and queues them up to be executed as
 // an operation, each action running as a task on the designated ActionReceiver.
 // We return the ID of the overall operation and each individual task.
-func (a *ActionAPI) EnqueueOperation(arg params.Actions) (params.EnqueuedActions, error) {
+func (a *ActionAPI) EnqueueOperation(arg params.Actions) (params.EnqueuedActionsV2, error) {
+	operationId, actionResults, err := a.enqueue(arg)
+	if err != nil {
+		return params.EnqueuedActionsV2{}, err
+	}
+	results := params.EnqueuedActionsV2{
+		OperationTag: names.NewOperationTag(operationId).String(),
+		Actions:      actionResults.Results,
+	}
+	return results, nil
+}
+
+// EnqueueOperation takes a list of Actions and queues them up to be executed as
+// an operation, each action running as a task on the designated ActionReceiver.
+// We return the ID of the overall operation and each individual task.
+func (a *APIv6) EnqueueOperation(arg params.Actions) (params.EnqueuedActions, error) {
 	operationId, actionResults, err := a.enqueue(arg)
 	if err != nil {
 		return params.EnqueuedActions{}, err

--- a/apiserver/facades/client/action/register.go
+++ b/apiserver/facades/client/action/register.go
@@ -28,6 +28,9 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Action", 6, func(ctx facade.Context) (facade.Facade, error) {
 		return newActionAPIV6(ctx)
 	}, reflect.TypeOf((*APIv6)(nil)))
+	registry.MustRegister("Action", 7, func(ctx facade.Context) (facade.Facade, error) {
+		return newActionAPIV7(ctx)
+	}, reflect.TypeOf((*APIv7)(nil)))
 }
 
 // newActionAPIV2 returns an initialized ActionAPI for version 2.
@@ -68,10 +71,19 @@ func newActionAPIV5(ctx facade.Context) (*APIv5, error) {
 
 // newActionAPIV6 returns an initialized ActionAPI for version 6.
 func newActionAPIV6(ctx facade.Context) (*APIv6, error) {
+	api, err := newActionAPIV7(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv6{api}, nil
+}
+
+// newActionAPIV7 returns an initialized ActionAPI for version 7.
+func newActionAPIV7(ctx facade.Context) (*APIv7, error) {
 	st := ctx.State()
 	api, err := newActionAPI(&stateShim{st: st}, ctx.Resources(), ctx.Auth())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &APIv6{api}, nil
+	return &APIv7{api}, nil
 }

--- a/apiserver/facades/client/action/run_test.go
+++ b/apiserver/facades/client/action/run_test.go
@@ -198,20 +198,13 @@ func (s *runSuite) TestRunMachineAndApplication(c *gc.C) {
 		"timeout":          int64(0),
 		"workload-context": false,
 	}
-	expectedArgs := params.Actions{
+	arg := params.Actions{
 		Actions: []params.Action{
 			{Receiver: "unit-magic-0", Name: "juju-run", Parameters: expectedPayload},
 			{Receiver: "unit-magic-1", Name: "juju-run", Parameters: expectedPayload},
 			{Receiver: "machine-0", Name: "juju-run", Parameters: expectedPayload},
 		},
 	}
-	called := false
-	s.PatchValue(action.QueueActions, func(client *action.ActionAPI, args params.Actions) (params.ActionResults, error) {
-		called = true
-		c.Assert(args, jc.DeepEquals, expectedArgs)
-		return params.ActionResults{}, nil
-	})
-
 	s.addMachine(c)
 
 	charm := s.AddTestingCharm(c, "dummy")
@@ -226,7 +219,18 @@ func (s *runSuite) TestRunMachineAndApplication(c *gc.C) {
 			Machines:     []string{"0"},
 			Applications: []string{"magic"},
 		})
-	c.Assert(called, jc.IsTrue)
+	op, err := s.client.EnqueueOperation(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Actions, gc.HasLen, 3)
+
+	emptyActionTag := names.ActionTag{}
+	for i, r := range op.Actions {
+		c.Assert(r.Action, gc.NotNil)
+		c.Assert(r.Action.Tag, gc.Not(gc.Equals), emptyActionTag)
+		c.Assert(r.Action.Name, gc.Equals, "juju-run")
+		c.Assert(r.Action.Receiver, gc.Equals, arg.Actions[i].Receiver)
+		c.Assert(r.Action.Parameters, jc.DeepEquals, expectedPayload)
+	}
 }
 
 func (s *runSuite) TestRunApplicationWorkload(c *gc.C) {
@@ -237,19 +241,12 @@ func (s *runSuite) TestRunApplicationWorkload(c *gc.C) {
 		"timeout":          int64(0),
 		"workload-context": true,
 	}
-	expectedArgs := params.Actions{
+	arg := params.Actions{
 		Actions: []params.Action{
 			{Receiver: "unit-magic-0", Name: "juju-run", Parameters: expectedPayload},
 			{Receiver: "unit-magic-1", Name: "juju-run", Parameters: expectedPayload},
 		},
 	}
-	called := false
-	s.PatchValue(action.QueueActions, func(client *action.ActionAPI, args params.Actions) (params.ActionResults, error) {
-		called = true
-		c.Assert(args, jc.DeepEquals, expectedArgs)
-		return params.ActionResults{}, nil
-	})
-
 	s.addMachine(c)
 
 	charm := s.AddTestingCharm(c, "dummy")
@@ -264,7 +261,18 @@ func (s *runSuite) TestRunApplicationWorkload(c *gc.C) {
 			Applications:    []string{"magic"},
 			WorkloadContext: true,
 		})
-	c.Assert(called, jc.IsTrue)
+	op, err := s.client.EnqueueOperation(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Actions, gc.HasLen, 2)
+
+	emptyActionTag := names.ActionTag{}
+	for i, r := range op.Actions {
+		c.Assert(r.Action, gc.NotNil)
+		c.Assert(r.Action.Tag, gc.Not(gc.Equals), emptyActionTag)
+		c.Assert(r.Action.Name, gc.Equals, "juju-run")
+		c.Assert(r.Action.Receiver, gc.Equals, arg.Actions[i].Receiver)
+		c.Assert(r.Action.Parameters, jc.DeepEquals, expectedPayload)
+	}
 }
 
 func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
@@ -275,19 +283,13 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 		"timeout":          testing.LongWait.Nanoseconds(),
 		"workload-context": false,
 	}
-	expectedArgs := params.Actions{
+	arg := params.Actions{
 		Actions: []params.Action{
 			{Receiver: "machine-0", Name: "juju-run", Parameters: expectedPayload},
 			{Receiver: "machine-1", Name: "juju-run", Parameters: expectedPayload},
 			{Receiver: "machine-2", Name: "juju-run", Parameters: expectedPayload},
 		},
 	}
-	called := false
-	s.PatchValue(action.QueueActions, func(client *action.ActionAPI, args params.Actions) (params.ActionResults, error) {
-		called = true
-		c.Assert(args, jc.DeepEquals, expectedArgs)
-		return params.ActionResults{}, nil
-	})
 	// Make three machines.
 	s.addMachine(c)
 	s.addMachine(c)
@@ -298,7 +300,19 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 			Commands: "hostname",
 			Timeout:  testing.LongWait,
 		})
-	c.Assert(called, jc.IsTrue)
+	op, err := s.client.EnqueueOperation(arg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.Actions, gc.HasLen, 3)
+
+	emptyActionTag := names.ActionTag{}
+	for i, r := range op.Actions {
+		c.Assert(r.Action, gc.NotNil)
+		c.Assert(r.Action.Tag, gc.Not(gc.Equals), emptyActionTag)
+		c.Assert(r.Action.Name, gc.Equals, "juju-run")
+		c.Assert(r.Action.Receiver, gc.Equals, arg.Actions[i].Receiver)
+		c.Assert(r.Action.Parameters, jc.DeepEquals, expectedPayload)
+	}
+
 }
 
 func (s *runSuite) TestRunRequiresAdmin(c *gc.C) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1,8 +1,8 @@
 [
     {
         "Name": "Action",
-        "Description": "APIv6 provides the Action API facade for version 6.",
-        "Version": 6,
+        "Description": "APIv7 provides the Action API facade for version 7.",
+        "Version": 7,
         "AvailableTo": [
             "model-user"
         ],
@@ -64,7 +64,7 @@
                             "$ref": "#/definitions/Actions"
                         },
                         "Result": {
-                            "$ref": "#/definitions/EnqueuedActions"
+                            "$ref": "#/definitions/EnqueuedActionsV2"
                         }
                     },
                     "description": "EnqueueOperation takes a list of Actions and queues them up to be executed as\nan operation, each action running as a task on the designated ActionReceiver.\nWe return the ID of the overall operation and each individual task."
@@ -171,7 +171,7 @@
                             "$ref": "#/definitions/RunParams"
                         },
                         "Result": {
-                            "$ref": "#/definitions/ActionResults"
+                            "$ref": "#/definitions/EnqueuedActionsV2"
                         }
                     },
                     "description": "Run the commands specified on the machines identified through the\nlist of machines, units and services."
@@ -183,7 +183,7 @@
                             "$ref": "#/definitions/RunParams"
                         },
                         "Result": {
-                            "$ref": "#/definitions/ActionResults"
+                            "$ref": "#/definitions/EnqueuedActionsV2"
                         }
                     },
                     "description": "RunOnAllMachines attempts to run the specified command on all the machines."
@@ -431,13 +431,13 @@
                     },
                     "additionalProperties": false
                 },
-                "EnqueuedActions": {
+                "EnqueuedActionsV2": {
                     "type": "object",
                     "properties": {
                         "actions": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/StringResult"
+                                "$ref": "#/definitions/ActionResult"
                             }
                         },
                         "operation": {
@@ -683,21 +683,6 @@
                     "required": [
                         "commands",
                         "timeout"
-                    ]
-                },
-                "StringResult": {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "result": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "result"
                     ]
                 },
                 "StringsWatchResult": {

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -6,6 +6,7 @@ package action
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -24,6 +25,12 @@ var logger = loggo.GetLogger("juju.cmd.juju.action")
 func getActionTagsByPrefix(api APIClient, prefix string) ([]names.ActionTag, error) {
 	results := []names.ActionTag{}
 
+	if api.BestAPIVersion() > 6 {
+		if _, err := strconv.Atoi(prefix); err != nil {
+			return nil, errors.NotValidf("task id %q", prefix)
+		}
+		return []names.ActionTag{names.NewActionTag(prefix)}, nil
+	}
 	tags, err := api.FindActionTagsByPrefix(params.FindTags{Prefixes: []string{prefix}})
 	if err != nil {
 		return results, err

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -178,13 +178,15 @@ func (c *fakeAPIClient) Enqueue(actions []actionapi.Action) ([]actionapi.ActionR
 
 func (c *fakeAPIClient) EnqueueOperation(args []actionapi.Action) (actionapi.EnqueuedActions, error) {
 	c.enqueuedActions = args
-	actions := make([]actionapi.ActionReference, len(c.actionResults))
+	actions := make([]actionapi.ActionResult, len(c.actionResults))
 	for i, a := range c.actionResults {
-		actions[i] = actionapi.ActionReference{
+		actions[i] = actionapi.ActionResult{
 			Error: a.Error,
 		}
 		if a.Action != nil {
-			actions[i].ID = a.Action.ID
+			actions[i].Action = &actionapi.Action{
+				ID: a.Action.ID,
+			}
 		}
 	}
 	return actionapi.EnqueuedActions{

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -384,12 +384,13 @@ func (c *runCommand) enqueueActions(ctx *cmd.Context) (string, []enqueuedAction,
 	}
 	tasks := make([]enqueuedAction, len(results.Actions))
 	for i, a := range results.Actions {
-		tasks[i] = enqueuedAction{
-			task:     a.ID,
-			receiver: c.unitReceivers[i],
-		}
 		if a.Error != nil {
 			tasks[i].err = a.Error
+			continue
+		}
+		tasks[i] = enqueuedAction{
+			task:     a.Action.ID,
+			receiver: c.unitReceivers[i],
 		}
 	}
 	return results.OperationID, tasks, nil

--- a/cmd/juju/commands/exec.go
+++ b/cmd/juju/commands/exec.go
@@ -323,9 +323,9 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 			fmt.Fprintf(ctx.GetStderr(), "couldn't queue one action: %v\n", result.Error)
 			continue
 		}
-		receiverTag, err := names.ActionReceiverFromTag(result.Receiver)
+		receiverTag, err := names.ActionReceiverFromTag(result.Action.Receiver)
 		if err != nil {
-			fmt.Fprintf(ctx.GetStderr(), "got invalid action receiver tag %q for action %v\n", result.Receiver, result.ID)
+			fmt.Fprintf(ctx.GetStderr(), "got invalid action receiver tag %q for action %v\n", result.Action.Receiver, result.Action.ID)
 			continue
 		}
 		var receiverType string
@@ -338,7 +338,7 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 			receiverType = "ReceiverId"
 		}
 		actionsToQuery = append(actionsToQuery, actionQuery{
-			actionID: result.ID,
+			actionID: result.Action.ID,
 			receiver: actionReceiver{
 				receiverType: receiverType,
 				tag:          receiverTag,

--- a/cmd/juju/commands/exec_test.go
+++ b/cmd/juju/commands/exec_test.go
@@ -822,10 +822,12 @@ func (m *mockExecAPI) RunOnAllMachines(commands string, timeout time.Duration) (
 				Error: exec.ErrCancelled,
 			}
 		}
-		result.Actions = append(result.Actions, actionapi.ActionReference{
-			ID:       response.Action.ID,
-			Receiver: response.Action.Receiver,
-			Error:    response.Error,
+		result.Actions = append(result.Actions, actionapi.ActionResult{
+			Action: &actionapi.Action{
+				ID:       response.Action.ID,
+				Receiver: response.Action.Receiver,
+			},
+			Error: response.Error,
 		})
 	}
 
@@ -844,10 +846,12 @@ func (m *mockExecAPI) Run(runParams actionapi.RunParams) (actionapi.EnqueuedActi
 	for _, id := range runParams.Machines {
 		response, found := m.execResponses[id]
 		if found {
-			result.Actions = append(result.Actions, actionapi.ActionReference{
-				ID:       response.Action.ID,
-				Receiver: response.Action.Receiver,
-				Error:    response.Error,
+			result.Actions = append(result.Actions, actionapi.ActionResult{
+				Action: &actionapi.Action{
+					ID:       response.Action.ID,
+					Receiver: response.Action.Receiver,
+				},
+				Error: response.Error,
 			})
 		}
 	}
@@ -855,10 +859,12 @@ func (m *mockExecAPI) Run(runParams actionapi.RunParams) (actionapi.EnqueuedActi
 	for _, id := range runParams.Units {
 		response, found := m.execResponses[id]
 		if found {
-			result.Actions = append(result.Actions, actionapi.ActionReference{
-				ID:       response.Action.ID,
-				Receiver: response.Action.Receiver,
-				Error:    response.Error,
+			result.Actions = append(result.Actions, actionapi.ActionResult{
+				Action: &actionapi.Action{
+					ID:       response.Action.ID,
+					Receiver: response.Action.Receiver,
+				},
+				Error: response.Error,
 			})
 		}
 	}

--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -169,7 +169,7 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 			wg.Done()
 			continue
 		}
-		actionResult, err := getActionResult(runnerClient, r.ID, wait)
+		actionResult, err := getActionResult(runnerClient, r.Action.ID, wait)
 		if err != nil {
 			_, _ = fmt.Fprintf(ctx.Stderr, "failed to collect metrics: %v\n", err)
 			wg.Done()
@@ -201,7 +201,7 @@ func (c *collectMetricsCommand) Run(ctx *cmd.Context) error {
 				_, _ = fmt.Fprintf(ctx.Stderr, "failed to send metrics for unit %v: %v\n", unitId, sendResults.Actions[0].Error)
 				return
 			}
-			actionResult, err := getActionResult(runnerClient, sendResults.Actions[0].ID, wait)
+			actionResult, err := getActionResult(runnerClient, sendResults.Actions[0].Action.ID, wait)
 			if err != nil {
 				_, _ = fmt.Fprintf(ctx.Stderr, "failed to send metrics for unit %v: %v\n", unitId, err)
 				return

--- a/cmd/juju/metricsdebug/collectmetrics_test.go
+++ b/cmd/juju/metricsdebug/collectmetrics_test.go
@@ -351,14 +351,18 @@ func (t *testRunClient) Run(run actionapi.RunParams) (actionapi.EnqueuedActions,
 	}
 	r := t.results[0]
 	t.results = t.results[1:]
-	result := actionapi.EnqueuedActions{Actions: make([]actionapi.ActionReference, len(r))}
+	result := actionapi.EnqueuedActions{Actions: make([]actionapi.ActionResult, len(r))}
 	for i, a := range r {
-		result.Actions[i] = actionapi.ActionReference{
+		result.Actions[i] = actionapi.ActionResult{
 			Error: a.Error,
 		}
 		if a.Action != nil {
-			result.Actions[i].ID = a.Action.ID
-			result.Actions[i].Receiver = a.Action.Receiver
+			result.Actions[i] = actionapi.ActionResult{
+				Action: &actionapi.Action{
+					ID:       a.Action.ID,
+					Receiver: a.Action.Receiver,
+				},
+			}
 		}
 	}
 	return result, nil

--- a/core/actions/actions.go
+++ b/core/actions/actions.go
@@ -5,11 +5,22 @@
 package actions
 
 import (
+	"strings"
+
 	"github.com/juju/charm/v8"
 )
 
 // JujuRunActionName defines the action name used by juju-run.
 const JujuRunActionName = "juju-run"
+
+// JujuExecActionName defines the action name used by juju-exec.
+const JujuExecActionName = "juju-exec"
+
+// HasJujuExecAction returns true if the "juju-exec" binary name appears
+// anywhere in the specified commands.
+func HasJujuExecAction(commands string) bool {
+	return strings.Contains(commands, JujuExecActionName) || strings.Contains(commands, JujuRunActionName)
+}
 
 // PredefinedActionsSpec defines a spec for each predefined action.
 var PredefinedActionsSpec = map[string]charm.ActionSpec{

--- a/rpc/params/actions.go
+++ b/rpc/params/actions.go
@@ -58,6 +58,11 @@ type EnqueuedActions struct {
 	Actions      []StringResult `json:"actions,omitempty"`
 }
 
+type EnqueuedActionsV2 struct {
+	OperationTag string         `json:"operation"`
+	Actions      []ActionResult `json:"actions,omitempty"`
+}
+
 // ActionResults is a slice of ActionResult for bulk requests.
 type ActionResults struct {
 	Results []ActionResult `json:"results,omitempty"`


### PR DESCRIPTION
Juju 2.9 needs to support the v7 actions facade so that the 2.9 client can talk to a 3.0 controller. There's a few api calls on the actions facade that differ for v7 - EnqueueOperation, Run, RunOnAllMachines. These were left as is on v6 and v7 compatibility was added. The api client was updated to account for both v6 and v7 facades.

## QA steps

There's several combinations to test:

juju 2.9.31 client with this controller (with and without actions-v2 flag)
this client with juju 2.9.31 controller  (with and without actions-v2 flag)
this client with juju 3.0 controller  (with and without actions-v2 flag)

deploy a charm with an action

without actions-v2 flag
juju exec pwd --machine 0
juju exec pwd --all
juju run pwd --machine 0
juju run pwd --all
juju run-action charm/0 actionname
juju run-action charm/0 actionname --wait
juju show-action-output ...
juju show-action-status ...

with actions-v2 flag
juju exec pwd --machine 0
juju exec pwd --all
juju run charm/0 actionname
juju run charm/0 actionname --background
juju show-task ...
juju show-operation ...
