### PR TITLE
Fixes lp bug 1976620 to allow lxd pem certs inline.

### DIFF
--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -4,6 +4,7 @@
 package cloud
 
 import (
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -258,6 +259,13 @@ func ExpandFilePathsOfCredential(
 
 		val, exists := attributes[credAttr.Name]
 		if !exists || val == "" {
+			continue
+		}
+
+		// NOTE: tlm dirty fix for lp1976620. This will be removed in Juju 3.0
+		// when we stop overloading the keys in cloud credentials with different
+		// values.
+		if block, _ := pem.Decode([]byte(val)); block != nil {
 			continue
 		}
 


### PR DESCRIPTION
With the fix for #14040 we changed Juju
to start properly treating lxd credential files as file paths to pem
encoded certificates.

Previously no checking had been performed so the key's were being
overloaded for dual purpose. Do strict expansion on the key value has
introduced a bug where previous users had in lined certificates.

It's expected that this work around will be removed in Juju 3.0.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Follow steps in bug to replicate and test fix.


## Bug reference

https://bugs.launchpad.net/juju/+bug/9876543*](https://bugs.launchpad.net/juju/+bug/1976620/
