### PR TITLE
[JUJU-1236] Get kubeconfig from content interface file

### DIFF
--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -17,11 +17,12 @@ import (
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
 	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	jujucloud "github.com/juju/juju/cloud"
+	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/version"
 )
 
-func attemptMicroK8sCloud(cmdRunner CommandRunner) (jujucloud.Cloud, error) {
-	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner)
+func attemptMicroK8sCloud(cmdRunner CommandRunner, getKubeConfigDir func() (string, error)) (jujucloud.Cloud, error) {
+	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner, getKubeConfigDir)
 	if err != nil {
 		return jujucloud.Cloud{}, err
 	}
@@ -41,8 +42,8 @@ func attemptMicroK8sCloud(cmdRunner CommandRunner) (jujucloud.Cloud, error) {
 	return k8sCloud, err
 }
 
-func attemptMicroK8sCredential(cmdRunner CommandRunner) (jujucloud.Credential, error) {
-	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner)
+func attemptMicroK8sCredential(cmdRunner CommandRunner, getKubeConfigDir func() (string, error)) (jujucloud.Credential, error) {
+	microk8sConfig, err := getLocalMicroK8sConfig(cmdRunner, getKubeConfigDir)
 	if err != nil {
 		return jujucloud.Credential{}, err
 	}
@@ -67,17 +68,35 @@ func attemptMicroK8sCredential(cmdRunner CommandRunner) (jujucloud.Credential, e
 	return k8scloud.CredentialFromKubeConfig(context.AuthInfo, conf)
 }
 
-func getLocalMicroK8sConfig(cmdRunner CommandRunner) ([]byte, error) {
+// For testing.
+var CheckJujuOfficial = envtools.JujudVersion
+
+func decideKubeConfigDir() (string, error) {
+	jujuDir, err := envtools.ExistingJujuLocation()
+	if err != nil {
+		return "", errors.Annotate(err, "cannot find juju binary")
+	}
+	_, isOffical, err := CheckJujuOfficial(jujuDir)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if isOffical {
+		return filepath.Join(os.Getenv("SNAP_DATA"), "microk8s", "credentials", "client.config"), nil
+	}
+	return filepath.Join("/var/snap/microk8s/current/", "credentials", "client.config"), nil
+}
+
+func getLocalMicroK8sConfig(cmdRunner CommandRunner, getKubeConfigDir func() (string, error)) ([]byte, error) {
+	// TODO: fix OSX and Windows - probably still use `microk8s config (need to test)`.
 	_, err := cmdRunner.LookPath("microk8s")
 	if err != nil {
 		return []byte{}, errors.NotFoundf("microk8s")
 	}
-	notSupportErr := errors.NewNotSupported(nil, fmt.Sprintf("juju %q can only work with strict confined microk8s", version.Current))
-	snapDataPath := os.Getenv("SNAP_DATA")
-	if snapDataPath == "" {
-		return nil, errors.Annotate(notSupportErr, "SNAP_DATA is empty")
+	notSupportErr := errors.NewNotSupported(nil, fmt.Sprintf("juju %q can only work with strictly confined microk8s", version.Current))
+	clientConfigPath, err := getKubeConfigDir()
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	clientConfigPath := filepath.Join(snapDataPath, "credentials", "client.config")
 	content, err := ioutil.ReadFile(clientConfigPath)
 	if os.IsNotExist(err) {
 		return nil, errors.Annotatef(notSupportErr, "%q does not exist", clientConfigPath)

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -6,7 +6,6 @@ package provider_test
 import (
 	"fmt"
 	"runtime"
-	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
@@ -205,48 +204,6 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
 		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), jc.ErrorIsNil)
-}
-
-func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
-		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusStorageDisabled)}, nil)
-	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable storage'`)
-}
-
-func (s *cloudSuite) TestEnsureMicroK8sSuitableDNSDisabled(c *gc.C) {
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
-		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusDNSDisabled)}, nil)
-	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable dns'`)
-}
-
-func (s *cloudSuite) TestEnsureMicroK8sSuitableNotInGroup(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("no need to check user group setup for windows")
-	}
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-		&exec.ExecResponse{Code: 1}, nil)
-	err := provider.EnsureMicroK8sSuitable(s.runner)
-	c.Assert(err, gc.NotNil)
-	c.Assert(strings.Replace(err.Error(), "\n", "", -1),
-		gc.Matches, `The microk8s user group is created during the microk8s snap installation.*`)
 }
 
 type mockContext struct {

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -5,77 +5,27 @@ package provider_test
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v3/exec"
 	gc "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 
 	"github.com/juju/juju/caas"
 	k8s "github.com/juju/juju/caas/kubernetes"
 	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	"github.com/juju/juju/caas/kubernetes/provider"
-	"github.com/juju/juju/cloud"
+	k8sutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )
 
-var (
-	_ = gc.Suite(&cloudSuite{})
-)
-
-var microk8sStatusEnabled = `
-microk8s:
-  running: true
-addons:
-  jaeger: disabled
-  fluentd: disabled
-  gpu: disabled
-  storage: enabled
-  registry: disabled
-  ingress: disabled
-  dns: enabled
-  metrics-server: disabled
-  prometheus: disabled
-  istio: disabled
-  dashboard: disabled
-`
-
-var microk8sStatusStorageDisabled = `
-microk8s:
-  running: true
-addons:
-  jaeger: disabled
-  fluentd: disabled
-  gpu: disabled
-  storage: disabled
-  registry: disabled
-  ingress: disabled
-  dns: enabled
-  metrics-server: disabled
-  prometheus: disabled
-  istio: disabled
-  dashboard: disabled
-`
-var microk8sStatusDNSDisabled = `
-microk8s:
-  running: true
-addons:
-  jaeger: disabled
-  fluentd: disabled
-  gpu: disabled
-  storage: enabled
-  registry: disabled
-  ingress: disabled
-  dns: disabled
-  metrics-server: disabled
-  prometheus: disabled
-  istio: disabled
-  dashboard: disabled
-`
+var _ = gc.Suite(&cloudSuite{})
 
 type cloudSuite struct {
 	fakeBroker fakeK8sClusterMetadataChecker
@@ -85,8 +35,8 @@ type cloudSuite struct {
 var defaultK8sCloud = jujucloud.Cloud{
 	Name:           k8s.K8sCloudMicrok8s,
 	Endpoint:       "http://1.1.1.1:8080",
-	Type:           cloud.CloudTypeKubernetes,
-	AuthTypes:      []cloud.AuthType{cloud.UserPassAuthType},
+	Type:           jujucloud.CloudTypeKubernetes,
+	AuthTypes:      []jujucloud.AuthType{jujucloud.UserPassAuthType},
 	CACertificates: []string{""},
 	SkipTLSVerify:  true,
 }
@@ -97,8 +47,8 @@ var defaultClusterMetadata = &k8s.ClusterMetadata{
 	OperatorStorageClass: &k8s.StorageProvisioner{Name: "operator-sc"},
 }
 
-func getDefaultCredential() cloud.Credential {
-	defaultCredential := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"username": "admin", "password": ""})
+func getDefaultCredential() jujucloud.Credential {
+	defaultCredential := jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{"username": "admin", "password": ""})
 	defaultCredential.Label = "kubernetes credential \"admin\""
 	return defaultCredential
 }
@@ -112,16 +62,31 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	p := s.getProvider()
 	cloudFinalizer := p.(environs.CloudFinalizer)
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
-		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
+	s.fakeBroker.Call("ListStorageClasses", k8slabels.NewSelector()).Returns(
+		[]storagev1.StorageClass{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "microk8s-hostpath",
+					Annotations: map[string]string{
+						"storageclass.kubernetes.io/is-default-class": "true",
+					},
+				},
+			},
+		}, nil,
+	)
+	s.fakeBroker.Call(
+		"ListPods", "kube-system",
+		k8sutils.LabelsToSelector(map[string]string{"k8s-app": "kube-dns"}),
+	).Returns([]corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "coredns-xx",
+				Labels: map[string]string{
+					"k8s-app": "kube-dns",
+				},
+			},
+		},
+	}, nil)
 
 	var ctx mockContext
 	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, defaultK8sCloud)
@@ -154,17 +119,6 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 	p := s.getProvider()
 	cloudFinalizer := p.(environs.CloudFinalizer)
 
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
-		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
-
 	var ctx mockContext
 	cloud, err := cloudFinalizer.FinalizeCloud(&ctx, preparedCloud)
 	c.Assert(err, jc.ErrorIsNil)
@@ -188,22 +142,37 @@ func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 		s.runner,
 		credentialGetterFunc(ret),
 		cloudGetterFunc(ret),
-		func(environs.OpenParams) (k8s.ClusterMetadataChecker, error) { return &s.fakeBroker, nil },
+		func(environs.OpenParams) (provider.ClusterMetadataStorageChecker, error) { return &s.fakeBroker, nil },
 	)
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
-		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
-	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), jc.ErrorIsNil)
+	s.fakeBroker.Call("ListStorageClasses", k8slabels.NewSelector()).Returns(
+		[]storagev1.StorageClass{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "microk8s-hostpath",
+					Annotations: map[string]string{
+						"storageclass.kubernetes.io/is-default-class": "true",
+					},
+				},
+			},
+		}, nil,
+	)
+	s.fakeBroker.Call(
+		"ListPods", "kube-system",
+		k8sutils.LabelsToSelector(map[string]string{"k8s-app": "kube-dns"}),
+	).Returns([]corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "coredns-xx",
+				Labels: map[string]string{
+					"k8s-app": "kube-dns",
+				},
+			},
+		},
+	}, nil)
+	c.Assert(provider.EnsureMicroK8sSuitable(&s.fakeBroker), jc.ErrorIsNil)
 }
 
 type mockContext struct {
@@ -232,4 +201,14 @@ func (api *fakeK8sClusterMetadataChecker) CheckDefaultWorkloadStorage(cluster st
 func (api *fakeK8sClusterMetadataChecker) EnsureStorageProvisioner(cfg k8s.StorageProvisioner) (*k8s.StorageProvisioner, bool, error) {
 	results := api.MethodCall(api, "EnsureStorageProvisioner")
 	return results[0].(*k8s.StorageProvisioner), false, testing.TypeAssertError(results[1])
+}
+
+func (api *fakeK8sClusterMetadataChecker) ListPods(namespace string, selector k8slabels.Selector) ([]corev1.Pod, error) {
+	results := api.MethodCall(api, "ListPods", namespace, selector)
+	return results[0].([]corev1.Pod), nil
+}
+
+func (api *fakeK8sClusterMetadataChecker) ListStorageClasses(selector k8slabels.Selector) ([]storagev1.StorageClass, error) {
+	results := api.MethodCall(api, "ListStorageClasses", selector)
+	return results[0].([]storagev1.StorageClass), nil
 }

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -14,7 +14,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/caas"
-	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
@@ -63,7 +62,7 @@ func (s *detectCloudSuite) getProvider(builtin builtinCloudRet) caas.ContainerEn
 		dummyRunner{},
 		credentialGetterFunc(builtin),
 		cloudGetterFunc(builtin),
-		func(environs.OpenParams) (k8s.ClusterMetadataChecker, error) {
+		func(environs.OpenParams) (provider.ClusterMetadataStorageChecker, error) {
 			return &fakeK8sClusterMetadataChecker{}, nil
 		},
 	)

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -49,6 +49,7 @@ var (
 	UpdateStrategyForDeployment  = updateStrategyForDeployment
 	UpdateStrategyForStatefulSet = updateStrategyForStatefulSet
 	UpdateStrategyForDaemonSet   = updateStrategyForDaemonSet
+	DecideKubeConfigDir          = decideKubeConfigDir
 )
 
 type (

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
-	k8s "github.com/juju/juju/caas/kubernetes"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
 	"github.com/juju/juju/caas/specs"
 	jujucloud "github.com/juju/juju/cloud"
@@ -126,7 +125,7 @@ func NewProviderWithFakes(
 	runner CommandRunner,
 	credentialGetter func(CommandRunner) (jujucloud.Credential, error),
 	getter func(CommandRunner) (jujucloud.Cloud, error),
-	brokerGetter func(environs.OpenParams) (k8s.ClusterMetadataChecker, error)) caas.ContainerEnvironProvider {
+	brokerGetter func(environs.OpenParams) (ClusterMetadataStorageChecker, error)) caas.ContainerEnvironProvider {
 	return kubernetesEnvironProvider{
 		environProviderCredentials: environProviderCredentials{
 			cmdRunner:               runner,

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -2262,6 +2262,21 @@ func (k *kubernetesClient) Units(appName string, mode caas.DeploymentMode) ([]ca
 	return units, nil
 }
 
+// ListPods filters a list of pods for the provided namespace and labels.
+func (k *kubernetesClient) ListPods(namespace string, selector k8slabels.Selector) ([]core.Pod, error) {
+	listOps := v1.ListOptions{
+		LabelSelector: selector.String(),
+	}
+	list, err := k.client().CoreV1().Pods(namespace).List(context.TODO(), listOps)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(list.Items) == 0 {
+		return nil, errors.NotFoundf("pods with selector %q", selector)
+	}
+	return list.Items, nil
+}
+
 func (k *kubernetesClient) getPod(podName string) (*core.Pod, error) {
 	if k.namespace == "" {
 		return nil, errNoNamespace

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -12,7 +12,10 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/jsonschema"
 	"github.com/juju/utils/v3/exec"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -31,11 +34,17 @@ import (
 	"github.com/juju/juju/environs/context"
 )
 
+type ClusterMetadataStorageChecker interface {
+	k8s.ClusterMetadataChecker
+	ListStorageClasses(selector k8slabels.Selector) ([]storagev1.StorageClass, error)
+	ListPods(namespace string, selector k8slabels.Selector) ([]corev1.Pod, error)
+}
+
 type kubernetesEnvironProvider struct {
 	environProviderCredentials
 	cmdRunner          CommandRunner
 	builtinCloudGetter func(CommandRunner) (cloud.Cloud, error)
-	brokerGetter       func(environs.OpenParams) (k8s.ClusterMetadataChecker, error)
+	brokerGetter       func(environs.OpenParams) (ClusterMetadataStorageChecker, error)
 }
 
 var _ environs.EnvironProvider = (*kubernetesEnvironProvider)(nil)
@@ -46,13 +55,13 @@ var providerInstance = kubernetesEnvironProvider{
 	},
 	cmdRunner:          defaultRunner{},
 	builtinCloudGetter: attemptMicroK8sCloud,
-	brokerGetter: func(args environs.OpenParams) (k8s.ClusterMetadataChecker, error) {
+	brokerGetter: func(args environs.OpenParams) (ClusterMetadataStorageChecker, error) {
 		broker, err := caas.New(stdcontext.TODO(), args)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 
-		metaChecker, supported := broker.(k8s.ClusterMetadataChecker)
+		metaChecker, supported := broker.(ClusterMetadataStorageChecker)
 		if !supported {
 			return nil, errors.NotSupportedf("cluster metadata ")
 		}

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/environs/context"
 )
 
+// ClusterMetadataStorageChecker provides functionalities for checking k8s cluster storage and pods details.
 type ClusterMetadataStorageChecker interface {
 	k8s.ClusterMetadataChecker
 	ListStorageClasses(selector k8slabels.Selector) ([]storagev1.StorageClass, error)

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -51,11 +51,15 @@ type kubernetesEnvironProvider struct {
 var _ environs.EnvironProvider = (*kubernetesEnvironProvider)(nil)
 var providerInstance = kubernetesEnvironProvider{
 	environProviderCredentials: environProviderCredentials{
-		cmdRunner:               defaultRunner{},
-		builtinCredentialGetter: attemptMicroK8sCredential,
+		cmdRunner: defaultRunner{},
+		builtinCredentialGetter: func(cmdRunner CommandRunner) (cloud.Credential, error) {
+			return attemptMicroK8sCredential(cmdRunner, decideKubeConfigDir)
+		},
 	},
-	cmdRunner:          defaultRunner{},
-	builtinCloudGetter: attemptMicroK8sCloud,
+	cmdRunner: defaultRunner{},
+	builtinCloudGetter: func(cmdRunner CommandRunner) (cloud.Cloud, error) {
+		return attemptMicroK8sCloud(cmdRunner, decideKubeConfigDir)
+	},
 	brokerGetter: func(args environs.OpenParams) (ClusterMetadataStorageChecker, error) {
 		broker, err := caas.New(stdcontext.TODO(), args)
 		if err != nil {

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -178,7 +178,7 @@ func (k *kubernetesClient) deleteStorageClassesModelTeardown(
 ) {
 	ensureResourcesDeletedFunc(ctx, selector, clk, wg, errChan,
 		k.deleteStorageClasses, func(selector k8slabels.Selector) error {
-			_, err := k.listStorageClasses(selector)
+			_, err := k.ListStorageClasses(selector)
 			return err
 		},
 	)

--- a/caas/kubernetes/provider/volume.go
+++ b/caas/kubernetes/provider/volume.go
@@ -52,7 +52,7 @@ func (k *kubernetesClient) deleteStorageClasses(selector k8slabels.Selector) err
 	return errors.Annotate(err, "deleting model storage classes")
 }
 
-// ListStorageClasses retuns a list of storage classes for the provided labels.
+// ListStorageClasses returns a list of storage classes for the provided labels.
 func (k *kubernetesClient) ListStorageClasses(selector k8slabels.Selector) ([]storagev1.StorageClass, error) {
 	listOps := v1.ListOptions{
 		LabelSelector: selector.String(),

--- a/caas/kubernetes/provider/volume.go
+++ b/caas/kubernetes/provider/volume.go
@@ -52,7 +52,8 @@ func (k *kubernetesClient) deleteStorageClasses(selector k8slabels.Selector) err
 	return errors.Annotate(err, "deleting model storage classes")
 }
 
-func (k *kubernetesClient) listStorageClasses(selector k8slabels.Selector) ([]storagev1.StorageClass, error) {
+// ListStorageClasses retuns a list of storage classes for the provided labels.
+func (k *kubernetesClient) ListStorageClasses(selector k8slabels.Selector) ([]storagev1.StorageClass, error) {
 	listOps := v1.ListOptions{
 		LabelSelector: selector.String(),
 	}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,7 +129,7 @@ plugs:
   peers:
     interface: content
     content: microk8s
-    target: $SNAP_COMMON/.peers
+    target: $SNAP_DATA
 
   dot-local-share-juju:
     interface: personal-files

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,7 +129,7 @@ plugs:
   peers:
     interface: content
     content: microk8s
-    target: $SNAP_DATA
+    target: $SNAP_DATA/microk8s
 
   dot-local-share-juju:
     interface: personal-files


### PR DESCRIPTION
This PR includes changes:

- try to read microk8s `kubeconfig` file from the content interface file first;
- update microk8s content interface target;
- check microk8s addons via k8s API;

Notes: depends on https://github.com/canonical/microk8s/pull/3193

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ sudo snap install microk8s --channel=latest/edge/MK-530

$ sudo snap install juju_3.0-beta1_amd64.snap --dangerous

$ sudo snap connect juju:dot-local-share-juju

$ sudo snap connect juju:peers microk8s:microk8s

$ juju bootstrap microk8s k1 --debug
```

## Documentation changes

No

## Bug reference

No
