### PR TITLE
[JUJU-1243] Fix method to see if InstanceConfg is controller

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -216,13 +216,15 @@ func (api *ProvisionerAPI) getProvisioningInfoBase(m *state.Machine,
 		return result, errors.Annotate(err, "cannot get controller configuration")
 	}
 
+	isController := false
 	jobs := m.Jobs()
 	result.Jobs = make([]model.MachineJob, len(jobs))
 	for i, job := range jobs {
 		result.Jobs[i] = job.ToParams()
+		isController = isController || result.Jobs[i].NeedsState()
 	}
 
-	if result.Tags, err = api.machineTags(m, result.Jobs); err != nil {
+	if result.Tags, err = api.machineTags(m, isController); err != nil {
 		return result, errors.Trace(err)
 	}
 
@@ -322,7 +324,7 @@ func (api *ProvisionerAPI) machineVolumeParams(
 }
 
 // machineTags returns machine-specific tags to set on the instance.
-func (api *ProvisionerAPI) machineTags(m *state.Machine, jobs []model.MachineJob) (map[string]string, error) {
+func (api *ProvisionerAPI) machineTags(m *state.Machine, isController bool) (map[string]string, error) {
 	// Names of all units deployed to the machine.
 	//
 	// TODO(axw) 2015-06-02 #1461358
@@ -351,7 +353,7 @@ func (api *ProvisionerAPI) machineTags(m *state.Machine, jobs []model.MachineJob
 		return nil, errors.Trace(err)
 	}
 
-	machineTags := instancecfg.InstanceTags(cfg.UUID(), controllerCfg.ControllerUUID(), cfg, jobs)
+	machineTags := instancecfg.InstanceTags(cfg.UUID(), controllerCfg.ControllerUUID(), cfg, isController)
 	if len(unitNames) > 0 {
 		machineTags[tags.JujuUnitsDeployed] = strings.Join(unitNames, " ")
 	}

--- a/apiserver/facades/client/client/instanceconfig.go
+++ b/apiserver/facades/client/client/instanceconfig.go
@@ -111,10 +111,9 @@ func InstanceConfig(ctrlSt *state.State, st *state.State, machineId, nonce, data
 		return nil, errors.Annotate(err, "initializing instance config")
 	}
 
-	icfg.Controller = &instancecfg.ControllerConfig{}
-	icfg.Controller.Config = make(map[string]interface{})
+	icfg.ControllerConfig = make(map[string]interface{})
 	for k, v := range controllerConfig {
-		icfg.Controller.Config[k] = v
+		icfg.ControllerConfig[k] = v
 	}
 
 	if dataDir != "" {

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -300,7 +300,7 @@ func newcontrollerStack(
 
 	cs.pvcNameControllerPodStorage = "storage"
 
-	if cs.dockerAuthSecretData, err = pcfg.Controller.Config.CAASImageRepo().SecretData(); err != nil {
+	if cs.dockerAuthSecretData, err = pcfg.Controller.CAASImageRepo().SecretData(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return cs, nil
@@ -1159,7 +1159,7 @@ func (c *controllerStack) buildStorageSpecForController(statefulset *apps.Statef
 
 func (c *controllerStack) buildContainerSpecForController(statefulset *apps.StatefulSet) error {
 	var wiredTigerCacheSize float32
-	if c.pcfg.Controller.Config.MongoMemoryProfile() == string(mongo.MemoryProfileLow) {
+	if c.pcfg.Controller.MongoMemoryProfile() == string(mongo.MemoryProfileLow) {
 		wiredTigerCacheSize = mongo.Mongo34LowCacheSize
 	}
 	generateContainerSpecs := func(jujudCmd string) ([]core.Container, error) {

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -55,7 +55,10 @@ type InstanceConfig struct {
 
 	// Controller contains configuration for the controller
 	// used to manage this new instance.
-	Controller *ControllerConfig
+	ControllerConfig controller.Config
+
+	// The public key used to sign Juju simplestreams image metadata.
+	PublicImageSigningKey string
 
 	// APIInfo holds the means for the new instance to communicate with the
 	// juju state API. Unless the new instance is running a controller (Controller is
@@ -191,16 +194,6 @@ type InstanceConfig struct {
 
 	// Profiles is a slice of (lxd) profile names to be used by a container
 	Profiles []string
-}
-
-// ControllerConfig represents controller-specific initialization information
-// for a new juju instance. This is only relevant for controller machines.
-type ControllerConfig struct {
-	// Config contains controller config attributes.
-	Config controller.Config
-
-	// The public key used to sign Juju simplestreams image metadata.
-	PublicImageSigningKey string
 }
 
 // BootstrapConfig represents bootstrap-specific initialization information
@@ -489,9 +482,9 @@ func (cfg *InstanceConfig) AgentConfig(
 		Controller:        cfg.ControllerTag,
 		Model:             cfg.APIInfo.ModelTag,
 	}
-	if cfg.Controller != nil {
-		configParams.AgentLogfileMaxBackups = cfg.Controller.Config.AgentLogfileMaxBackups()
-		configParams.AgentLogfileMaxSizeMB = cfg.Controller.Config.AgentLogfileMaxSizeMB()
+	if cfg.ControllerConfig != nil {
+		configParams.AgentLogfileMaxBackups = cfg.ControllerConfig.AgentLogfileMaxBackups()
+		configParams.AgentLogfileMaxSizeMB = cfg.ControllerConfig.AgentLogfileMaxSizeMB()
 	}
 	if cfg.Bootstrap == nil {
 		return agent.NewAgentConfig(configParams)
@@ -691,7 +684,7 @@ func (cfg *InstanceConfig) VerifyConfig() (err error) {
 
 func (cfg *InstanceConfig) verifyBootstrapConfig() (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid bootstrap configuration")
-	if cfg.Controller == nil {
+	if cfg.ControllerConfig == nil {
 		return errors.New("bootstrap config supplied without controller config")
 	}
 	if err := cfg.Bootstrap.VerifyConfig(); err != nil {
@@ -784,12 +777,10 @@ func NewBootstrapInstanceConfig(
 	if err != nil {
 		return nil, err
 	}
-	icfg.Controller = &ControllerConfig{
-		PublicImageSigningKey: publicImageSigningKey,
-	}
-	icfg.Controller.Config = make(map[string]interface{})
+	icfg.PublicImageSigningKey = publicImageSigningKey
+	icfg.ControllerConfig = make(map[string]interface{})
 	for k, v := range config {
-		icfg.Controller.Config[k] = v
+		icfg.ControllerConfig[k] = v
 	}
 	icfg.Bootstrap = &BootstrapConfig{
 		StateInitializationParams: StateInitializationParams{
@@ -926,9 +917,9 @@ func FinishInstanceConfig(icfg *InstanceConfig, cfg *config.Config) (err error) 
 	if icfg.IsController() {
 		// Add NUMACTL preference. Needed to work for both bootstrap and high availability
 		// Only makes sense for controller,
-		logger.Debugf("Setting numa ctl preference to %v", icfg.Controller.Config.NUMACtlPreference())
+		logger.Debugf("Setting numa ctl preference to %v", icfg.ControllerConfig.NUMACtlPreference())
 		// Unfortunately, AgentEnvironment can only take strings as values
-		icfg.AgentEnvironment[agent.NUMACtlPreference] = fmt.Sprintf("%v", icfg.Controller.Config.NUMACtlPreference())
+		icfg.AgentEnvironment[agent.NUMACtlPreference] = fmt.Sprintf("%v", icfg.ControllerConfig.NUMACtlPreference())
 	}
 	return nil
 }

--- a/cloudconfig/instancecfg/instancecfg_test.go
+++ b/cloudconfig/instancecfg/instancecfg_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
@@ -22,6 +23,13 @@ type instancecfgSuite struct {
 }
 
 var _ = gc.Suite(&instancecfgSuite{})
+
+func (*instancecfgSuite) TestIsController(c *gc.C) {
+	cfg := instancecfg.InstanceConfig{}
+	c.Assert(cfg.IsController(), jc.IsFalse)
+	cfg.Jobs = []model.MachineJob{model.JobManageModel}
+	c.Assert(cfg.IsController(), jc.IsTrue)
+}
 
 func (*instancecfgSuite) TestInstanceTagsController(c *gc.C) {
 	cfg := testing.CustomModelConfig(c, testing.Attrs{})
@@ -120,11 +128,9 @@ func (*instancecfgSuite) TestAgentConfigLogParams(c *gc.C) {
 			ModelTag: names.NewModelTag(testing.ModelTag.Id()),
 			Password: "secret123",
 		},
-		Controller: &instancecfg.ControllerConfig{
-			Config: controller.Config{
-				"agent-logfile-max-size":    "123MB",
-				"agent-logfile-max-backups": 7,
-			},
+		ControllerConfig: controller.Config{
+			"agent-logfile-max-size":    "123MB",
+			"agent-logfile-max-backups": 7,
 		},
 		ControllerTag: names.NewControllerTag(testing.ControllerTag.Id()),
 		DataDir:       "/path/to/datadir/",

--- a/cloudconfig/instancecfg/instancecfg_test.go
+++ b/cloudconfig/instancecfg/instancecfg_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
@@ -26,14 +25,12 @@ var _ = gc.Suite(&instancecfgSuite{})
 
 func (*instancecfgSuite) TestInstanceTagsController(c *gc.C) {
 	cfg := testing.CustomModelConfig(c, testing.Attrs{})
-	controllerJobs := []model.MachineJob{model.JobManageModel}
-	nonControllerJobs := []model.MachineJob{model.JobHostUnits}
-	testInstanceTags(c, cfg, controllerJobs, map[string]string{
+	testInstanceTags(c, cfg, true, map[string]string{
 		"juju-model-uuid":      testing.ModelTag.Id(),
 		"juju-controller-uuid": testing.ControllerTag.Id(),
 		"juju-is-controller":   "true",
 	})
-	testInstanceTags(c, cfg, nonControllerJobs, map[string]string{
+	testInstanceTags(c, cfg, false, map[string]string{
 		"juju-model-uuid":      testing.ModelTag.Id(),
 		"juju-controller-uuid": testing.ControllerTag.Id(),
 	})
@@ -43,7 +40,7 @@ func (*instancecfgSuite) TestInstanceTagsUserSpecified(c *gc.C) {
 	cfg := testing.CustomModelConfig(c, testing.Attrs{
 		"resource-tags": "a=b c=",
 	})
-	testInstanceTags(c, cfg, nil, map[string]string{
+	testInstanceTags(c, cfg, false, map[string]string{
 		"juju-model-uuid":      testing.ModelTag.Id(),
 		"juju-controller-uuid": testing.ControllerTag.Id(),
 		"a":                    "b",
@@ -51,8 +48,8 @@ func (*instancecfgSuite) TestInstanceTagsUserSpecified(c *gc.C) {
 	})
 }
 
-func testInstanceTags(c *gc.C, cfg *config.Config, jobs []model.MachineJob, expectTags map[string]string) {
-	tags := instancecfg.InstanceTags(testing.ModelTag.Id(), testing.ControllerTag.Id(), cfg, jobs)
+func testInstanceTags(c *gc.C, cfg *config.Config, isController bool, expectTags map[string]string) {
+	tags := instancecfg.InstanceTags(testing.ModelTag.Id(), testing.ControllerTag.Id(), cfg, isController)
 	c.Assert(tags, jc.DeepEquals, expectTags)
 }
 

--- a/cloudconfig/podcfg/image.go
+++ b/cloudconfig/podcfg/image.go
@@ -24,11 +24,11 @@ const (
 
 // GetControllerImagePath returns oci image path of jujud for a controller.
 func (cfg *ControllerPodConfig) GetControllerImagePath() (string, error) {
-	return GetJujuOCIImagePath(cfg.Controller.Config, cfg.JujuVersion)
+	return GetJujuOCIImagePath(cfg.Controller, cfg.JujuVersion)
 }
 
 func (cfg *ControllerPodConfig) mongoVersion() (*mongo.Version, error) {
-	snapChannel := cfg.Controller.Config.JujuDBSnapChannel()
+	snapChannel := cfg.Controller.JujuDBSnapChannel()
 	vers := strings.Split(snapChannel, "/")[0] + ".0"
 	versionNum, err := version.Parse(vers)
 	if err != nil {
@@ -42,7 +42,7 @@ func (cfg *ControllerPodConfig) mongoVersion() (*mongo.Version, error) {
 
 // GetJujuDbOCIImagePath returns the juju-db oci image path.
 func (cfg *ControllerPodConfig) GetJujuDbOCIImagePath() (string, error) {
-	imageRepo := cfg.Controller.Config.CAASImageRepo().Repository
+	imageRepo := cfg.Controller.CAASImageRepo().Repository
 	if imageRepo == "" {
 		imageRepo = JujudOCINamespace
 	}

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -48,7 +48,7 @@ type ControllerPodConfig struct {
 
 	// Controller contains controller-specific configuration. If this is
 	// set, then the instance will be configured as a controller pod.
-	Controller *ControllerConfig
+	Controller controller.Config
 
 	// APIInfo holds the means for the new pod to communicate with the
 	// juju state API. Unless the new pod is running a controller (Controller is
@@ -91,12 +91,6 @@ type BootstrapConfig struct {
 	instancecfg.BootstrapConfig
 }
 
-// ControllerConfig represents controller-specific initialization information
-// for a new juju caas pod. This is only relevant for controller pod.
-type ControllerConfig struct {
-	instancecfg.ControllerConfig
-}
-
 // AgentConfig returns an agent config.
 func (cfg *ControllerPodConfig) AgentConfig(tag names.Tag) (agent.ConfigSetterWriter, error) {
 	mongoVers, err := cfg.mongoVersion()
@@ -118,7 +112,7 @@ func (cfg *ControllerPodConfig) AgentConfig(tag names.Tag) (agent.ConfigSetterWr
 		Controller:         cfg.ControllerTag,
 		Model:              cfg.APIInfo.ModelTag,
 		MongoVersion:       *mongoVers,
-		MongoMemoryProfile: mongo.MemoryProfile(cfg.Controller.Config.MongoMemoryProfile()),
+		MongoMemoryProfile: mongo.MemoryProfile(cfg.Controller.MongoMemoryProfile()),
 	}
 	return agent.NewStateMachineConfig(configParams, cfg.Bootstrap.StateServingInfo)
 }
@@ -289,10 +283,9 @@ func NewBootstrapControllerPodConfig(
 	if err != nil {
 		return nil, err
 	}
-	pcfg.Controller = &ControllerConfig{}
-	pcfg.Controller.Config = make(map[string]interface{})
+	pcfg.Controller = make(map[string]interface{})
 	for k, v := range config {
-		pcfg.Controller.Config[k] = v
+		pcfg.Controller[k] = v
 	}
 	pcfg.Bootstrap = &BootstrapConfig{
 		BootstrapConfig: instancecfg.BootstrapConfig{

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/juju/collections/set"
-	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	"github.com/juju/os/v2/series"
 	pacconf "github.com/juju/packaging/v2/config"
 	"github.com/juju/proxy"
 	jc "github.com/juju/testing/checkers"
@@ -35,12 +35,12 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/paths"
+	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
-	"github.com/juju/os/v2/series"
 )
 
 type cloudinitSuite struct {
@@ -223,7 +223,7 @@ func (cfg *testInstanceConfig) setSeries(series string, vers version.Number, bui
 // a controller instance.
 func (cfg *testInstanceConfig) setController() *testInstanceConfig {
 	cfg.setMachineID("0")
-	cfg.Controller = &instancecfg.ControllerConfig{}
+	cfg.ControllerConfig = controller.Config{}
 	cfg.Bootstrap = &instancecfg.BootstrapConfig{
 		StateInitializationParams: instancecfg.StateInitializationParams{
 			BootstrapMachineInstanceId:  "i-bootstrap",
@@ -579,7 +579,7 @@ printf '%s\\n' '.*custom-image-metadata:.*us-east1.*.*' > '/var/lib/juju/bootstr
 	// custom image metadata signing key.
 	{
 		cfg: makeBootstrapConfig("trusty", 0).mutate(func(cfg *testInstanceConfig) {
-			cfg.Controller.PublicImageSigningKey = "publickey"
+			cfg.PublicImageSigningKey = "publickey"
 		}),
 		setEnvConfig:      true,
 		inexactMatch:      true,
@@ -1150,7 +1150,7 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 				},
 				StateServingInfo: stateServingInfo,
 			},
-			Controller:       &instancecfg.ControllerConfig{},
+			ControllerConfig: controller.Config{},
 			ControllerTag:    testing.ControllerTag,
 			MachineId:        "99",
 			AuthorizedKeys:   "sshkey1",

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -22,6 +22,8 @@ import (
 	"github.com/juju/proxy"
 	"github.com/juju/version/v2"
 
+	"github.com/juju/os/v2/series"
+
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -30,7 +32,6 @@ import (
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/service"
 	"github.com/juju/juju/service/upstart"
-	"github.com/juju/os/v2/series"
 )
 
 var logger = loggo.GetLogger("juju.cloudconfig")

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -19,10 +19,9 @@ import (
 	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
+	"github.com/juju/os/v2/series"
 	"github.com/juju/proxy"
 	"github.com/juju/version/v2"
-
-	"github.com/juju/os/v2/series"
 
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
@@ -335,9 +334,9 @@ func (w *unixConfigure) ConfigureJuju() error {
 			shquote(w.icfg.LegacyProxySettings.AsSystemdDefaultEnv())))
 	}
 
-	if w.icfg.Controller != nil && w.icfg.Controller.PublicImageSigningKey != "" {
+	if w.icfg.PublicImageSigningKey != "" {
 		keyFile := filepath.Join(agent.DefaultPaths.ConfDir, simplestreams.SimplestreamsPublicKeyFile)
-		w.conf.AddRunTextFile(keyFile, w.icfg.Controller.PublicImageSigningKey, 0644)
+		w.conf.AddRunTextFile(keyFile, w.icfg.PublicImageSigningKey, 0644)
 	}
 
 	// Make the lock dir and change the ownership of the lock dir itself to

--- a/cloudconfig/userdatacfg_win.go
+++ b/cloudconfig/userdatacfg_win.go
@@ -98,7 +98,7 @@ func (w *windowsConfigure) ConfigureJuju() error {
 	if err := w.icfg.VerifyConfig(); err != nil {
 		return errors.Trace(err)
 	}
-	if w.icfg.Controller != nil {
+	if w.icfg.IsController() {
 		return errors.Errorf("controllers not supported on windows")
 	}
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -720,7 +720,7 @@ func finalizeInstanceBootstrapConfig(
 	if icfg.APIInfo != nil {
 		return errors.New("machine configuration already has api info")
 	}
-	controllerCfg := icfg.Controller.Config
+	controllerCfg := icfg.ControllerConfig
 	caCert, hasCACert := controllerCfg.CACert()
 	if !hasCACert {
 		return errors.New("controller configuration has no ca-cert")
@@ -793,7 +793,7 @@ func finalizePodBootstrapConfig(
 		return errors.New("machine configuration already has api info")
 	}
 
-	controllerCfg := pcfg.Controller.Config
+	controllerCfg := pcfg.Controller
 	caCert, hasCACert := controllerCfg.CACert()
 	if !hasCACert {
 		return errors.New("controller configuration has no ca-cert")

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1300,7 +1300,7 @@ func (s *bootstrapSuite) TestPublicKeyEnvVar(c *gc.C) {
 			SupportedBootstrapSeries: supportedJujuSeries,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.instanceConfig.Controller.PublicImageSigningKey, gc.Equals, "publickey")
+	c.Assert(env.instanceConfig.PublicImageSigningKey, gc.Equals, "publickey")
 }
 
 func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
@@ -1349,7 +1349,7 @@ func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 			"b-key": "b-value",
 		},
 	})
-	controllerCfg := icfg.Controller.Config
+	controllerCfg := icfg.ControllerConfig
 	c.Check(controllerCfg["ca-private-key"], gc.IsNil)
 	c.Check(icfg.Bootstrap.StateServingInfo.StatePort, gc.Equals, controllerCfg.StatePort())
 	c.Check(icfg.Bootstrap.StateServingInfo.APIPort, gc.Equals, controllerCfg.APIPort())

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -212,7 +212,7 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 		instanceConfig.Jobs = []model.MachineJob{model.JobHostUnits, model.JobManageModel}
 	}
 	cfg := env.Config()
-	instanceConfig.Tags = instancecfg.InstanceTags(env.Config().UUID(), params.ControllerUUID, cfg, nil)
+	instanceConfig.Tags = instancecfg.InstanceTags(env.Config().UUID(), params.ControllerUUID, cfg, false)
 	params.Tools = possibleTools
 	params.InstanceConfig = instanceConfig
 	if params.StatusCallback == nil {

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -206,9 +206,7 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 		return errors.Trace(err)
 	}
 	if isController {
-		instanceConfig.Controller = &instancecfg.ControllerConfig{
-			Config: testing.FakeControllerConfig(),
-		}
+		instanceConfig.ControllerConfig = testing.FakeControllerConfig()
 		instanceConfig.Jobs = []model.MachineJob{model.JobHostUnits, model.JobManageModel}
 	}
 	cfg := env.Config()

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -688,8 +688,8 @@ func (env *azureEnviron) createVirtualMachine(
 	instanceConfig := args.InstanceConfig
 	apiPorts := make([]int, 0, 2)
 	if instanceConfig.IsController() {
-		apiPorts = append(apiPorts, instanceConfig.Controller.Config.APIPort())
-		if instanceConfig.Controller.Config.AutocertDNSName() != "" {
+		apiPorts = append(apiPorts, instanceConfig.ControllerConfig.APIPort())
+		if instanceConfig.ControllerConfig.AutocertDNSName() != "" {
 			// Open port 80 as well as it handles Let's Encrypt HTTP challenge.
 			apiPorts = append(apiPorts, 80)
 		}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -686,9 +686,8 @@ func (env *azureEnviron) createVirtualMachine(
 		BaseClient: env.resources,
 	}
 	instanceConfig := args.InstanceConfig
-	controller := instanceConfig.Controller != nil
 	apiPorts := make([]int, 0, 2)
-	if controller {
+	if instanceConfig.IsController() {
 		apiPorts = append(apiPorts, instanceConfig.Controller.Config.APIPort())
 		if instanceConfig.Controller.Config.AutocertDNSName() != "" {
 			// Open port 80 as well as it handles Let's Encrypt HTTP challenge.
@@ -763,7 +762,7 @@ func (env *azureEnviron) createVirtualMachine(
 
 	var availabilitySetSubResource *compute.SubResource
 	availabilitySetName, err := availabilitySetName(
-		vmName, vmTags, instanceConfig.Controller != nil,
+		vmName, vmTags, instanceConfig.IsController(),
 	)
 	if err != nil {
 		return errors.Annotate(err, "getting availability set name")
@@ -811,7 +810,7 @@ func (env *azureEnviron) createVirtualMachine(
 	if err != nil {
 		return common.ZoneIndependentError(err)
 	}
-	vnetId, subnetIds, err := env.networkInfoForInstance(ctx, args, bootstrapping, controller, placementSubnetID)
+	vnetId, subnetIds, err := env.networkInfoForInstance(ctx, args, bootstrapping, instanceConfig.IsController(), placementSubnetID)
 	if err != nil {
 		return common.ZoneIndependentError(err)
 	}

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/controller"
 	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/juju/provider/azure/internal/errorutils"
 
@@ -592,6 +593,7 @@ func makeStartInstanceParams(c *gc.C, controllerUUID, series string) environs.St
 		series, apiInfo,
 	)
 	c.Assert(err, jc.ErrorIsNil)
+	icfg.ControllerConfig = controller.Config{}
 	icfg.Tags = map[string]string{
 		tags.JujuModel:      testing.ModelTag.Id(),
 		tags.JujuController: controllerUUID,

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -150,7 +150,7 @@ func BootstrapInstance(
 	instanceConfig.EnableOSUpgrade = env.Config().EnableOSUpgrade()
 	instanceConfig.NetBondReconfigureDelay = env.Config().NetBondReconfigureDelay()
 
-	instanceConfig.Tags = instancecfg.InstanceTags(envCfg.UUID(), args.ControllerConfig.ControllerUUID(), envCfg, instanceConfig.Jobs)
+	instanceConfig.Tags = instancecfg.InstanceTags(envCfg.UUID(), args.ControllerConfig.ControllerUUID(), envCfg, true)
 
 	// We're creating a new instance; inject host keys so that we can then
 	// make an SSH connection with known keys.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -892,7 +892,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			// It is set just below.
 			controller, err := state.Initialize(state.InitializeParams{
 				Clock:            clock.WallClock,
-				ControllerConfig: icfg.Controller.Config,
+				ControllerConfig: icfg.ControllerConfig,
 				ControllerModelArgs: state.ModelArgs{
 					Type:                    state.ModelTypeIAAS,
 					Owner:                   adminUser,
@@ -959,7 +959,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 			estate.hub = centralhub.New(machineTag, centralhub.PubsubNoOpMetrics{})
 
 			estate.leaseManager, err = leaseManager(
-				icfg.Controller.Config.ControllerUUID(),
+				icfg.ControllerConfig.ControllerUUID(),
 				st,
 			)
 			if err != nil {
@@ -1032,7 +1032,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 					}
 					return observer.NewRequestObserver(ctx)
 				},
-				PublicDNSName: icfg.Controller.Config.AutocertDNSName(),
+				PublicDNSName: icfg.ControllerConfig.AutocertDNSName(),
 				UpgradeComplete: func() bool {
 					return true
 				},

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1222,7 +1222,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	if args.InstanceConfig.MachineNonce == "" {
 		return nil, errors.New("cannot start instance: missing machine nonce")
 	}
-	if args.InstanceConfig.Controller != nil {
+	if args.InstanceConfig.IsController() {
 		if args.InstanceConfig.APIInfo.Tag != names.NewMachineTag(machineId) {
 			return nil, errors.New("entity tag must match started machine")
 		}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -623,8 +623,8 @@ func (e *environ) StartInstance(
 	logger.Debugf("ec2 user data; %d bytes", len(userData))
 	apiPorts := make([]int, 0, 2)
 	if args.InstanceConfig.IsController() {
-		apiPorts = append(apiPorts, args.InstanceConfig.Controller.Config.APIPort())
-		if args.InstanceConfig.Controller.Config.AutocertDNSName() != "" {
+		apiPorts = append(apiPorts, args.InstanceConfig.ControllerConfig.APIPort())
+		if args.InstanceConfig.ControllerConfig.AutocertDNSName() != "" {
 			// Open port 80 as well as it handles Let's Encrypt HTTP challenge.
 			apiPorts = append(apiPorts, 80)
 		}

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -595,7 +595,7 @@ func (e *environ) StartInstance(
 		return nil, errors.Trace(err)
 	}
 	spec, err := findInstanceSpec(
-		args.InstanceConfig.Controller != nil,
+		args.InstanceConfig.IsController(),
 		args.ImageMetadata,
 		instanceTypes,
 		&instances.InstanceConstraint{
@@ -622,7 +622,7 @@ func (e *environ) StartInstance(
 
 	logger.Debugf("ec2 user data; %d bytes", len(userData))
 	apiPorts := make([]int, 0, 2)
-	if args.InstanceConfig.Controller != nil {
+	if args.InstanceConfig.IsController() {
 		apiPorts = append(apiPorts, args.InstanceConfig.Controller.Config.APIPort())
 		if args.InstanceConfig.Controller.Config.AutocertDNSName() != "" {
 			// Open port 80 as well as it handles Let's Encrypt HTTP challenge.
@@ -641,7 +641,7 @@ func (e *environ) StartInstance(
 	blockDeviceMappings, err := getBlockDeviceMappings(
 		args.Constraints,
 		args.InstanceConfig.Series,
-		args.InstanceConfig.Controller != nil,
+		args.InstanceConfig.IsController(),
 		args.RootDisk,
 	)
 	if err != nil {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -2345,9 +2345,8 @@ func (t *localServerSuite) TestInstanceGroupsWithAutocert(c *gc.C) {
 	}
 	err := testing.FillInStartInstanceParams(t.Env, "42", true, &params)
 	c.Assert(err, jc.ErrorIsNil)
-	config := params.InstanceConfig.Controller.Config
-	config["api-port"] = 443
-	config["autocert-dns-name"] = "example.com"
+	params.InstanceConfig.ControllerConfig["api-port"] = 443
+	params.InstanceConfig.ControllerConfig["autocert-dns-name"] = "example.com"
 
 	// Bootstrap the controller.
 	result, err := t.Env.StartInstance(t.callCtx, params)

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -271,7 +271,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		return nil, errors.Trace(err)
 	}
 	spec, err := e.findInstanceSpec(
-		args.InstanceConfig.Controller != nil,
+		args.InstanceConfig.IsController(),
 		args.ImageMetadata,
 		instanceTypes.InstanceTypes,
 		&instances.InstanceConstraint{

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -193,7 +193,7 @@ func (s *BaseSuiteUnpatched) initInst(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.StartInstArgs = environs.StartInstanceParams{
-		ControllerUUID: instanceConfig.Controller.Config.ControllerUUID(),
+		ControllerUUID: instanceConfig.ControllerConfig.ControllerUUID(),
 		InstanceConfig: instanceConfig,
 		Tools:          tools,
 		Constraints:    cons,
@@ -804,7 +804,7 @@ func (s *EnvironSuite) GetStartInstanceArgs(c *gc.C, series string) environs.Sta
 	c.Assert(err, jc.ErrorIsNil)
 
 	return environs.StartInstanceParams{
-		ControllerUUID: iConfig.Controller.Config.ControllerUUID(),
+		ControllerUUID: iConfig.ControllerConfig.ControllerUUID(),
 		InstanceConfig: iConfig,
 		Tools:          tools,
 		Constraints:    cons,

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/cloudconfig/providerinit"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/series"
@@ -1199,7 +1198,7 @@ func (env *maasEnviron) StartInstance(
 }
 
 func (env *maasEnviron) tagInstance1(inst *maas1Instance, instanceConfig *instancecfg.InstanceConfig) {
-	if !model.AnyJobNeedsState(instanceConfig.Jobs...) {
+	if !instanceConfig.IsController() {
 		return
 	}
 	err := common.AddStateInstance(env.Storage(), inst.Id())

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -558,8 +558,8 @@ func (e *Environ) startInstance(
 	// will take care of it's initial setup, and waiting for a running
 	// status is not necessary
 	if args.InstanceConfig.IsController() {
-		apiPort = args.InstanceConfig.Controller.Config.APIPort()
-		statePort = args.InstanceConfig.Controller.Config.StatePort()
+		apiPort = args.InstanceConfig.ControllerConfig.APIPort()
+		statePort = args.InstanceConfig.ControllerConfig.StatePort()
 		desiredStatus = ociCore.InstanceLifecycleStateRunning
 	} else {
 		desiredStatus = ociCore.InstanceLifecycleStateProvisioning

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -557,7 +557,7 @@ func (e *Environ) startInstance(
 	// If the machine that is spawning is not a controller, then userdata
 	// will take care of it's initial setup, and waiting for a running
 	// status is not necessary
-	if args.InstanceConfig.Controller != nil {
+	if args.InstanceConfig.IsController() {
 		apiPort = args.InstanceConfig.Controller.Config.APIPort()
 		statePort = args.InstanceConfig.Controller.Config.StatePort()
 		desiredStatus = ociCore.InstanceLifecycleStateRunning

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1169,7 +1169,7 @@ func (e *Environ) startInstance(
 	var novaGroupNames []nova.SecurityGroupName
 	if createSecurityGroups {
 		var apiPort int
-		if args.InstanceConfig.Controller != nil {
+		if args.InstanceConfig.IsController() {
 			apiPort = args.InstanceConfig.Controller.Config.APIPort()
 		} else {
 			// All ports are the same so pick the first.

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1170,7 +1170,7 @@ func (e *Environ) startInstance(
 	if createSecurityGroups {
 		var apiPort int
 		if args.InstanceConfig.IsController() {
-			apiPort = args.InstanceConfig.Controller.Config.APIPort()
+			apiPort = args.InstanceConfig.ControllerConfig.APIPort()
 		} else {
 			// All ports are the same so pick the first.
 			apiPort = args.InstanceConfig.APIInfo.Ports()[0]

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -66,7 +66,7 @@ func (e environ) StartInstance(ctx envcontext.ProviderCallContext, args environs
 		}
 		client := newInstanceConfigurator(addr)
 		apiPort := 0
-		if args.InstanceConfig.Controller != nil {
+		if args.InstanceConfig.IsController() {
 			apiPort = args.InstanceConfig.Controller.Config.APIPort()
 		}
 		err = client.DropAllPorts([]int{apiPort, 22}, addr)

--- a/provider/rackspace/environ.go
+++ b/provider/rackspace/environ.go
@@ -67,7 +67,7 @@ func (e environ) StartInstance(ctx envcontext.ProviderCallContext, args environs
 		client := newInstanceConfigurator(addr)
 		apiPort := 0
 		if args.InstanceConfig.IsController() {
-			apiPort = args.InstanceConfig.Controller.Config.APIPort()
+			apiPort = args.InstanceConfig.ControllerConfig.APIPort()
 		}
 		err = client.DropAllPorts([]int{apiPort, 22}, addr)
 		if err != nil {

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -78,7 +78,7 @@ func (s *legacyEnvironBrokerSuite) createStartInstanceArgs(c *gc.C) environs.Sta
 
 	return environs.StartInstanceParams{
 		AvailabilityZone: "z1",
-		ControllerUUID:   instanceConfig.Controller.Config.ControllerUUID(),
+		ControllerUUID:   instanceConfig.ControllerConfig.ControllerUUID(),
 		InstanceConfig:   instanceConfig,
 		Tools:            tools,
 		Constraints:      cons,

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -782,10 +782,9 @@ func (task *provisionerTask) constructInstanceConfig(
 		return nil, errors.Trace(err)
 	}
 
-	instanceConfig.Controller = &instancecfg.ControllerConfig{}
-	instanceConfig.Controller.Config = make(map[string]interface{})
+	instanceConfig.ControllerConfig = make(map[string]interface{})
 	for k, v := range pInfo.ControllerConfig {
-		instanceConfig.Controller.Config[k] = v
+		instanceConfig.ControllerConfig[k] = v
 	}
 
 	instanceConfig.Tags = pInfo.Tags
@@ -798,7 +797,7 @@ func (task *provisionerTask) constructInstanceConfig(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		instanceConfig.Controller.PublicImageSigningKey = publicKey
+		instanceConfig.PublicImageSigningKey = publicKey
 	}
 
 	instanceConfig.CloudInitUserData = pInfo.CloudInitUserData

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/lxdprofile"
-	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -794,7 +793,7 @@ func (task *provisionerTask) constructInstanceConfig(
 		instanceConfig.Jobs = pInfo.Jobs
 	}
 
-	if model.AnyJobNeedsState(instanceConfig.Jobs...) {
+	if instanceConfig.IsController() {
 		publicKey, err := simplestreams.UserPublicSigningKey()
 		if err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
A previous PR https://github.com/juju/juju/pull/13598 added controller config to all InstanceConfig structs. The presence of this controller config was used to determine if the cfg was for a controller. Hence all machines are mistaken as controllers. It affects all providers; the effect on the azure provider is to create all machines under the "juju-controller" availability set instead of the expected one. For other providers, it affects things like constraints used.

This PR adds an explicit `IsController()` method based on the Jobs the machine is configured to run.

## QA steps

bootstrap azure
juju switch controller
juju deploy -n 5 ubuntu

log into azure portal
check that there are 2 availability sets , "juju-controller" and "ubuntu" and that the relevant machines belong to the correct availability set

## Bug reference

https://bugs.launchpad.net/juju/+bug/1973829
