### PR TITLE
[JUJU-1248] Fix race in state upgrade test TestFixCharmhubLastPollTime

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -117,8 +117,7 @@ func (st *State) ControllerUUID() string {
 	return st.controllerTag.Id()
 }
 
-// ControllerTag returns the tag form of the the return value of
-// ControllerUUID.
+// ControllerTag returns the tag form of the ControllerUUID.
 func (st *State) ControllerTag() names.ControllerTag {
 	return st.controllerTag
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -6698,15 +6698,13 @@ func (s *upgradesSuite) TestRemoveLocalCharmOriginChannels(c *gc.C) {
 	)
 }
 
-func (s *upgradesSuite) TestFixCharmhubLastPolltime(c *gc.C) {
+func (s *upgradesSuite) TestFixCharmhubLastPollTime(c *gc.C) {
 	model1 := s.makeModel(c, "model-1", coretesting.Attrs{})
 	model2 := s.makeModel(c, "model-2", coretesting.Attrs{})
 	defer func() {
 		_ = model1.Close()
 		_ = model2.Close()
 	}()
-	model1.stateClock = s.state.stateClock
-	model2.stateClock = s.state.stateClock
 
 	uuid1 := model1.ModelUUID()
 	uuid2 := model2.ModelUUID()


### PR DESCRIPTION
The race checker is tripped by `TestFixCharmhubLastPollTime`.

This turns out to be needless, as the write statements set the same clock as is used to create the models anyway. Simply removing the assignments fixes the situation.

## QA steps

`(cd state; go test -check.v -race -check.f TestFixCharmhubLastPollTime)`

## Documentation changes

None.

## Bug reference

N/A
