### PR TITLE
[JUJU-1182] Remove k8s provider state storage

### DIFF
--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/storage"
 	jujucontext "github.com/juju/juju/environs/context"
 	jujustorage "github.com/juju/juju/storage"
-	storageprovider "github.com/juju/juju/storage/provider"
 )
 
 func validateStorageAttributes(attributes map[string]interface{}) error {
@@ -38,14 +37,10 @@ var _ jujustorage.Provider = (*storageProvider)(nil)
 
 //ValidateStorageProvider returns an error if the storage type and config is not valid
 // for a Kubernetes deployment.
-func (g *storageProvider) ValidateStorageProvider(providerType jujustorage.ProviderType, attributes map[string]any) error {
+func (g *storageProvider) ValidateStorageProvider(isCaas bool, attributes map[string]any) error {
 
-	switch providerType {
-	case constants.StorageProviderType:
-	case storageprovider.RootfsProviderType:
-	case storageprovider.TmpfsProviderType:
-	default:
-		return errors.NotValidf("storage provider type %q", providerType)
+	if !isCaas {
+		return errors.NotValidf("storage provider type %q", constants.StorageProviderType)
 	}
 
 	if attributes == nil {
@@ -58,11 +53,11 @@ func (g *storageProvider) ValidateStorageProvider(providerType jujustorage.Provi
 			return errors.NotValidf("storage medium %q", mediumValue)
 		}
 	}
-	if providerType == constants.StorageProviderType {
-		if err := validateStorageAttributes(attributes); err != nil {
-			return errors.Trace(err)
-		}
+
+	if err := validateStorageAttributes(attributes); err != nil {
+		return errors.Trace(err)
 	}
+
 	return nil
 }
 

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -20,33 +20,6 @@ import (
 	storageprovider "github.com/juju/juju/storage/provider"
 )
 
-//ValidateStorageProvider returns an error if the storage type and config is not valid
-// for a Kubernetes deployment.
-func ValidateStorageProvider(providerType jujustorage.ProviderType, attributes map[string]interface{}) error {
-	switch providerType {
-	case constants.StorageProviderType:
-	case storageprovider.RootfsProviderType:
-	case storageprovider.TmpfsProviderType:
-	default:
-		return errors.NotValidf("storage provider type %q", providerType)
-	}
-	if attributes == nil {
-		return nil
-	}
-	if mediumValue, ok := attributes[constants.StorageMedium]; ok {
-		medium := core.StorageMedium(fmt.Sprintf("%v", mediumValue))
-		if medium != core.StorageMediumMemory && medium != core.StorageMediumHugePages {
-			return errors.NotValidf("storage medium %q", mediumValue)
-		}
-	}
-	if providerType == constants.StorageProviderType {
-		if err := validateStorageAttributes(attributes); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
 func validateStorageAttributes(attributes map[string]interface{}) error {
 	if _, err := storage.ParseStorageConfig(attributes); err != nil {
 		return errors.Trace(err)
@@ -62,6 +35,39 @@ type storageProvider struct {
 }
 
 var _ jujustorage.Provider = (*storageProvider)(nil)
+
+//ValidateStorageProvider returns an error if the storage type and config is not valid
+// for a Kubernetes deployment.
+func (g *storageProvider) ValidateStorageProvider(providerType jujustorage.ProviderType, attributes map[string]any) error {
+
+	fmt.Println("---------------------")
+	fmt.Printf("%v ::: %v\n", providerType, attributes)
+	fmt.Println("---------------------")
+
+	switch providerType {
+	case constants.StorageProviderType:
+	case storageprovider.RootfsProviderType:
+	case storageprovider.TmpfsProviderType:
+	default:
+		return errors.NotValidf("storage provider type %q", providerType)
+	}
+	if attributes == nil {
+		return nil
+	}
+
+	if mediumValue, ok := attributes[constants.StorageMedium]; ok {
+		medium := core.StorageMedium(fmt.Sprintf("%v", mediumValue))
+		if medium != core.StorageMediumMemory && medium != core.StorageMediumHugePages {
+			return errors.NotValidf("storage medium %q", mediumValue)
+		}
+	}
+	if providerType == constants.StorageProviderType {
+		if err := validateStorageAttributes(attributes); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
 
 // ValidateConfig is defined on the jujustorage.Provider interface.
 func (g *storageProvider) ValidateConfig(cfg *jujustorage.Config) error {

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -37,11 +37,7 @@ var _ jujustorage.Provider = (*storageProvider)(nil)
 
 //ValidateStorageProvider returns an error if the storage type and config is not valid
 // for a Kubernetes deployment.
-func (g *storageProvider) ValidateStorageProvider(isCaas bool, attributes map[string]any) error {
-
-	if !isCaas {
-		return errors.NotValidf("storage provider type %q", constants.StorageProviderType)
-	}
+func (g *storageProvider) ValidateForK8s(attributes map[string]any) error {
 
 	if attributes == nil {
 		return nil

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -40,10 +40,9 @@ var _ jujustorage.Provider = (*storageProvider)(nil)
 // for a Kubernetes deployment.
 func (g *storageProvider) ValidateStorageProvider(providerType jujustorage.ProviderType, attributes map[string]any) error {
 
-	fmt.Println("---------------------")
+	fmt.Println("--------ValidateStorageProvider-------------")
 	fmt.Printf("%v ::: %v\n", providerType, attributes)
-	fmt.Println("---------------------")
-
+	fmt.Println("--------EndValidateStorageProvider-------------")
 	switch providerType {
 	case constants.StorageProviderType:
 	case storageprovider.RootfsProviderType:

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -40,9 +40,6 @@ var _ jujustorage.Provider = (*storageProvider)(nil)
 // for a Kubernetes deployment.
 func (g *storageProvider) ValidateStorageProvider(providerType jujustorage.ProviderType, attributes map[string]any) error {
 
-	fmt.Println("--------ValidateStorageProvider-------------")
-	fmt.Printf("%v ::: %v\n", providerType, attributes)
-	fmt.Println("--------EndValidateStorageProvider-------------")
 	switch providerType {
 	case constants.StorageProviderType:
 	case storageprovider.RootfsProviderType:
@@ -50,6 +47,7 @@ func (g *storageProvider) ValidateStorageProvider(providerType jujustorage.Provi
 	default:
 		return errors.NotValidf("storage provider type %q", providerType)
 	}
+
 	if attributes == nil {
 		return nil
 	}

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -174,6 +174,11 @@ func (s *storageSuite) TestDescribeVolumes(c *gc.C) {
 }
 
 func (s *storageSuite) TestValidateStorageProvider(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	prov := s.k8sProvider(c, ctrl)
+
 	for _, t := range []struct {
 		providerType storage.ProviderType
 		attrs        map[string]interface{}
@@ -192,7 +197,8 @@ func (s *storageSuite) TestValidateStorageProvider(c *gc.C) {
 			err:          `storage medium "foo" not valid`,
 		},
 	} {
-		err := provider.ValidateStorageProvider(t.providerType, t.attrs)
+		err := prov.ValidateStorageProvider(t.providerType, t.attrs)
+		// err := provider.ValidateStorageProvider(t.providerType, t.attrs)
 		if t.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/caas/kubernetes/provider/storage_test.go
+++ b/caas/kubernetes/provider/storage_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/storage"
-	storageprovider "github.com/juju/juju/storage/provider"
 )
 
 var _ = gc.Suite(&storageSuite{})
@@ -180,25 +179,18 @@ func (s *storageSuite) TestValidateStorageProvider(c *gc.C) {
 	prov := s.k8sProvider(c, ctrl)
 
 	for _, t := range []struct {
-		providerType storage.ProviderType
-		attrs        map[string]interface{}
-		err          string
+		attrs map[string]interface{}
+		err   string
 	}{
 		{
-			providerType: storageprovider.RootfsProviderType,
-		}, {
-			providerType: storageprovider.TmpfsProviderType,
-		}, {
-			providerType: storageprovider.LoopProviderType,
-			err:          `storage provider type "loop" not valid`,
-		}, {
-			providerType: storageprovider.TmpfsProviderType,
-			attrs:        map[string]interface{}{"storage-medium": "foo"},
-			err:          `storage medium "foo" not valid`,
+			attrs: map[string]interface{}{"storage-medium": "foo"},
+			err:   `storage medium "foo" not valid`,
+		},
+		{
+			attrs: nil,
 		},
 	} {
-		err := prov.ValidateStorageProvider(t.providerType, t.attrs)
-		// err := provider.ValidateStorageProvider(t.providerType, t.attrs)
+		err := prov.ValidateForK8s(t.attrs)
 		if t.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -83,8 +83,8 @@ func newAzureStorageConfig(attrs map[string]interface{}) (*azureStorageConfig, e
 	return azureStorageConfig, nil
 }
 
-func (e *azureStorageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
-	// No validation required
+func (e *azureStorageProvider) ValidateStorageProvider(bool, map[string]any) error {
+	// no validation required
 	return nil
 }
 

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -83,7 +83,7 @@ func newAzureStorageConfig(attrs map[string]interface{}) (*azureStorageConfig, e
 	return azureStorageConfig, nil
 }
 
-func (e *azureStorageProvider) ValidateStorageProvider(bool, map[string]any) error {
+func (e *azureStorageProvider) ValidateForK8s(map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -83,6 +83,11 @@ func newAzureStorageConfig(attrs map[string]interface{}) (*azureStorageConfig, e
 	return azureStorageConfig, nil
 }
 
+func (e *azureStorageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// No validation required
+	return nil
+}
+
 // ValidateConfig is part of the Provider interface.
 func (e *azureStorageProvider) ValidateConfig(cfg *storage.Config) error {
 	_, err := newAzureStorageConfig(cfg.Attrs())

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -271,7 +271,7 @@ func newEbsConfig(attrs map[string]interface{}) (*ebsConfig, error) {
 	return ebsConfig, nil
 }
 
-func (e *ebsProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+func (e *ebsProvider) ValidateStorageProvider(bool, map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -271,7 +271,7 @@ func newEbsConfig(attrs map[string]interface{}) (*ebsConfig, error) {
 	return ebsConfig, nil
 }
 
-func (e *ebsProvider) ValidateStorageProvider(bool, map[string]any) error {
+func (e *ebsProvider) ValidateForK8s(map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/ec2/ebs.go
+++ b/provider/ec2/ebs.go
@@ -271,6 +271,11 @@ func newEbsConfig(attrs map[string]interface{}) (*ebsConfig, error) {
 	return ebsConfig, nil
 }
 
+func (e *ebsProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 // ValidateConfig is defined on the Provider interface.
 func (e *ebsProvider) ValidateConfig(cfg *storage.Config) error {
 	_, err := newEbsConfig(cfg.Attrs())

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -41,6 +41,11 @@ type storageProvider struct {
 
 var _ storage.Provider = (*storageProvider)(nil)
 
+func (g *storageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 func (g *storageProvider) ValidateConfig(cfg *storage.Config) error {
 	return nil
 }

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -41,7 +41,7 @@ type storageProvider struct {
 
 var _ storage.Provider = (*storageProvider)(nil)
 
-func (g *storageProvider) ValidateStorageProvider(bool, map[string]any) error {
+func (g *storageProvider) ValidateForK8s(map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/gce/disks.go
+++ b/provider/gce/disks.go
@@ -41,7 +41,7 @@ type storageProvider struct {
 
 var _ storage.Provider = (*storageProvider)(nil)
 
-func (g *storageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+func (g *storageProvider) ValidateStorageProvider(bool, map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -130,6 +130,11 @@ func newLXDStorageConfig(attrs map[string]interface{}) (*lxdStorageConfig, error
 	return lxdStorageConfig, nil
 }
 
+func (e *lxdStorageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 // ValidateConfig is part of the Provider interface.
 func (e *lxdStorageProvider) ValidateConfig(cfg *storage.Config) error {
 	lxdStorageConfig, err := newLXDStorageConfig(cfg.Attrs())

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -130,7 +130,7 @@ func newLXDStorageConfig(attrs map[string]interface{}) (*lxdStorageConfig, error
 	return lxdStorageConfig, nil
 }
 
-func (e *lxdStorageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+func (e *lxdStorageProvider) ValidateStorageProvider(bool, map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/lxd/storage.go
+++ b/provider/lxd/storage.go
@@ -130,9 +130,8 @@ func newLXDStorageConfig(attrs map[string]interface{}) (*lxdStorageConfig, error
 	return lxdStorageConfig, nil
 }
 
-func (e *lxdStorageProvider) ValidateStorageProvider(bool, map[string]any) error {
-	// no validation required
-	return nil
+func (e *lxdStorageProvider) ValidateForK8s(map[string]any) error {
+	return errors.NotValidf("storage provider type %q", lxdStorageProviderType)
 }
 
 // ValidateConfig is part of the Provider interface.

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -93,7 +93,7 @@ func newStorageConfig(attrs map[string]interface{}) (*storageConfig, error) {
 	return &storageConfig{tags: tags}, nil
 }
 
-func (maasStorageProvider) ValidateStorageProvider(bool, map[string]any) error {
+func (maasStorageProvider) ValidateForK8s(map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -93,7 +93,7 @@ func newStorageConfig(attrs map[string]interface{}) (*storageConfig, error) {
 	return &storageConfig{tags: tags}, nil
 }
 
-func (maasStorageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+func (maasStorageProvider) ValidateStorageProvider(bool, map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/maas/volumes.go
+++ b/provider/maas/volumes.go
@@ -93,6 +93,11 @@ func newStorageConfig(attrs map[string]interface{}) (*storageConfig, error) {
 	return &storageConfig{tags: tags}, nil
 }
 
+func (maasStorageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 // ValidateConfig is defined on the Provider interface.
 func (maasStorageProvider) ValidateConfig(cfg *storage.Config) error {
 	_, err := newStorageConfig(cfg.Attrs())

--- a/provider/oci/storage.go
+++ b/provider/oci/storage.go
@@ -83,6 +83,11 @@ func (s *storageProvider) DefaultPools() []*storage.Config {
 	return []*storage.Config{pool}
 }
 
+func (s *storageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 func (s *storageProvider) ValidateConfig(cfg *storage.Config) error {
 	attrs := cfg.Attrs()
 	var pool string

--- a/provider/oci/storage.go
+++ b/provider/oci/storage.go
@@ -83,7 +83,7 @@ func (s *storageProvider) DefaultPools() []*storage.Config {
 	return []*storage.Config{pool}
 }
 
-func (s *storageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+func (s *storageProvider) ValidateStorageProvider(bool, map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/oci/storage.go
+++ b/provider/oci/storage.go
@@ -83,9 +83,8 @@ func (s *storageProvider) DefaultPools() []*storage.Config {
 	return []*storage.Config{pool}
 }
 
-func (s *storageProvider) ValidateStorageProvider(bool, map[string]any) error {
-	// no validation required
-	return nil
+func (s *storageProvider) ValidateForK8s(map[string]any) error {
+	return errors.NotValidf("storage provider type %q", ociStorageProviderType)
 }
 
 func (s *storageProvider) ValidateConfig(cfg *storage.Config) error {

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -188,9 +188,8 @@ func (s *cinderProvider) Scope() storage.Scope {
 	return storage.ScopeEnviron
 }
 
-func (p *cinderProvider) ValidateStorageProvider(bool, map[string]any) error {
-	// no validation required
-	return nil
+func (p *cinderProvider) ValidateForK8s(map[string]any) error {
+	return errors.NotValidf("storage provider type %q", CinderProviderType)
 }
 
 // ValidateConfig implements storage.Provider.

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -188,7 +188,7 @@ func (s *cinderProvider) Scope() storage.Scope {
 	return storage.ScopeEnviron
 }
 
-func (p *cinderProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+func (p *cinderProvider) ValidateStorageProvider(bool, map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -188,6 +188,11 @@ func (s *cinderProvider) Scope() storage.Scope {
 	return storage.ScopeEnviron
 }
 
+func (p *cinderProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 // ValidateConfig implements storage.Provider.
 func (p *cinderProvider) ValidateConfig(cfg *storage.Config) error {
 	// TODO(axw) 2015-05-01 #1450737

--- a/state/storage.go
+++ b/state/storage.go
@@ -1875,9 +1875,11 @@ func validateStoragePool(
 			*machineId = ""
 		}
 	}
-	isCaas := sb.modelType == ModelTypeCAAS
-	if err := aProvider.ValidateStorageProvider(isCaas, poolConfig); err != nil {
-		return errors.Annotatef(err, "invalid storage config")
+	//
+	if sb.modelType == ModelTypeCAAS {
+		if err := aProvider.ValidateForK8s(poolConfig); err != nil {
+			return errors.Annotatef(err, "invalid storage config")
+		}
 	}
 
 	return nil

--- a/state/storage.go
+++ b/state/storage.go
@@ -1875,28 +1875,10 @@ func validateStoragePool(
 			*machineId = ""
 		}
 	}
-
-	// Validate any config.
-
-	returned := aProvider.ValidateStorageProvider(providerType, poolConfig)
-
-	fmt.Printf("ValidateStorageProvider with %v ::: %v ::: %v returns %s\n", providerType, aProvider, poolConfig, returned)
-
-	if returned != nil {
-		return errors.Annotatef(returned, "invalid storage config")
+	isCaas := sb.modelType == ModelTypeCAAS
+	if err := aProvider.ValidateStorageProvider(isCaas, poolConfig); err != nil {
+		return errors.Annotatef(err, "invalid storage config")
 	}
-
-	// if err := aProvider.ValidateStorageProvider(providerType, poolConfig); err != nil {
-	// 	return errors.Annotatef(err, "invalid storage config")
-	// }
-
-	/*
-		if sb.modelType == ModelTypeCAAS {
-			if err := k8sprovider.ValidateStorageProvider(providerType, poolConfig); err != nil {
-				return errors.Annotatef(err, "invalid storage config")
-			}
-		}
-	*/
 
 	return nil
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/names/v4"
 	jujutxn "github.com/juju/txn/v2"
 
-	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/storage"
@@ -1879,10 +1878,18 @@ func validateStoragePool(
 
 	// Validate any k8s config.
 	if sb.modelType == ModelTypeCAAS {
-		if err := k8sprovider.ValidateStorageProvider(providerType, poolConfig); err != nil {
+		if err := aProvider.ValidateStorageProvider(providerType, poolConfig); err != nil {
 			return errors.Annotatef(err, "invalid storage config")
 		}
 	}
+
+	/*
+		if sb.modelType == ModelTypeCAAS {
+			if err := k8sprovider.ValidateStorageProvider(providerType, poolConfig); err != nil {
+				return errors.Annotatef(err, "invalid storage config")
+			}
+		}
+	*/
 
 	return nil
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -1849,6 +1849,10 @@ func validateStoragePool(
 		return errors.Trace(err)
 	}
 
+	fmt.Println("---------------------")
+	fmt.Printf("%v ::: %v ::: %v\n", providerType, aProvider, poolConfig)
+	fmt.Println("---------------------")
+
 	// Ensure the storage provider supports the specified kind.
 	kindSupported := aProvider.Supports(kind)
 	if !kindSupported && kind == storage.StorageKindFilesystem {

--- a/state/storage.go
+++ b/state/storage.go
@@ -1849,10 +1849,6 @@ func validateStoragePool(
 		return errors.Trace(err)
 	}
 
-	fmt.Println("---------------------")
-	fmt.Printf("%v ::: %v ::: %v\n", providerType, aProvider, poolConfig)
-	fmt.Println("---------------------")
-
 	// Ensure the storage provider supports the specified kind.
 	kindSupported := aProvider.Supports(kind)
 	if !kindSupported && kind == storage.StorageKindFilesystem {
@@ -1880,12 +1876,19 @@ func validateStoragePool(
 		}
 	}
 
-	// Validate any k8s config.
-	if sb.modelType == ModelTypeCAAS {
-		if err := aProvider.ValidateStorageProvider(providerType, poolConfig); err != nil {
-			return errors.Annotatef(err, "invalid storage config")
-		}
+	// Validate any config.
+
+	returned := aProvider.ValidateStorageProvider(providerType, poolConfig)
+
+	fmt.Printf("ValidateStorageProvider with %v ::: %v ::: %v returns %s\n", providerType, aProvider, poolConfig, returned)
+
+	if returned != nil {
+		return errors.Annotatef(returned, "invalid storage config")
 	}
+
+	// if err := aProvider.ValidateStorageProvider(providerType, poolConfig); err != nil {
+	// 	return errors.Annotatef(err, "invalid storage config")
+	// }
 
 	/*
 		if sb.modelType == ModelTypeCAAS {

--- a/storage/constants.go
+++ b/storage/constants.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+const (
+	// K8sStorageMediumConst is the constant key
+	K8sStorageMediumConst = "storage-medium"
+	// K8sStorageMediumMemory is the value use tmpfs in K8s
+	K8sStorageMediumMemory = "Memory"
+	// K8sStorageMediumHugePages is a K8s storage for volumes
+	K8sStorageMediumHugePages = "HugePages"
+)
+
+const (
+	// StorageClass is the name of a storage class resource.
+	K8sStorageClass       = "storage-class"
+	K8sStorageProvisioner = "storage-provisioner"
+	K8sStorageMedium      = "storage-medium"
+	K8sStorageMode        = "storage-mode"
+)

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -85,9 +85,9 @@ type Provider interface {
 	// returning an error if it is invalid.
 	ValidateConfig(*Config) error
 
-	// ValidateStorageProvider validates if for a CaaS model the
-	// current provider is valid with the given attributes.
-	ValidateStorageProvider(bool, map[string]any) error
+	// ValidateForkK8s validates if a storage provider can be set for
+	// a given K8s configuration.
+	ValidateForK8s(map[string]any) error
 }
 
 // VolumeSource provides an interface for creating, destroying, describing,

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -85,10 +85,9 @@ type Provider interface {
 	// returning an error if it is invalid.
 	ValidateConfig(*Config) error
 
-	// ValidateStorageProvider validates that a configuration is valid
-	// for a given provider type. This is specially useful for K8s
-	// deployments where we have to validate K8s configurations.
-	ValidateStorageProvider(ProviderType, map[string]any) error
+	// ValidateStorageProvider validates if for a CaaS model the
+	// current provider is valid with the given attributes.
+	ValidateStorageProvider(bool, map[string]any) error
 }
 
 // VolumeSource provides an interface for creating, destroying, describing,

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -84,6 +84,11 @@ type Provider interface {
 	// ValidateConfig validates the provided storage provider config,
 	// returning an error if it is invalid.
 	ValidateConfig(*Config) error
+
+	// ValidateStorageProvider validates that a configuration is valid
+	// for a given provider type. This is specially useful for K8s
+	// deployments where we have to validate K8s configurations.
+	ValidateStorageProvider(ProviderType, map[string]any) error
 }
 
 // VolumeSource provides an interface for creating, destroying, describing,

--- a/storage/provider/dummy/provider.go
+++ b/storage/provider/dummy/provider.go
@@ -76,6 +76,11 @@ func (p *StorageProvider) ValidateConfig(providerConfig *storage.Config) error {
 	return nil
 }
 
+func (p *StorageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 // Supports is defined on storage.Provider.
 func (p *StorageProvider) Supports(kind storage.StorageKind) bool {
 	p.MethodCall(p, "Supports", kind)

--- a/storage/provider/dummy/provider.go
+++ b/storage/provider/dummy/provider.go
@@ -44,6 +44,10 @@ type StorageProvider struct {
 	// otherwise ValidateConfig returns nil.
 	ValidateConfigFunc func(*storage.Config) error
 
+	// ValidateForK8sFunc will be called by ValidateForK8s, if non-nil;
+	// otherwise ValidateForK8s returns nil.
+	ValidateForK8sFunc func(map[string]any) error
+
 	// SupportsFunc will be called by Supports, if non-nil; otherwise,
 	// Supports returns true.
 	SupportsFunc func(kind storage.StorageKind) bool
@@ -76,9 +80,9 @@ func (p *StorageProvider) ValidateConfig(providerConfig *storage.Config) error {
 	return nil
 }
 
-func (p *StorageProvider) ValidateStorageProvider(bool, map[string]any) error {
-	// no validation required
-	return nil
+func (p *StorageProvider) ValidateForK8s(attributes map[string]any) error {
+	p.MethodCall(p, "ValidateForK8s", attributes)
+	return p.ValidateForK8sFunc(attributes)
 }
 
 // Supports is defined on storage.Provider.

--- a/storage/provider/dummy/provider.go
+++ b/storage/provider/dummy/provider.go
@@ -76,7 +76,7 @@ func (p *StorageProvider) ValidateConfig(providerConfig *storage.Config) error {
 	return nil
 }
 
-func (p *StorageProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+func (p *StorageProvider) ValidateStorageProvider(bool, map[string]any) error {
 	// no validation required
 	return nil
 }

--- a/storage/provider/k8s_validation.go
+++ b/storage/provider/k8s_validation.go
@@ -1,0 +1,98 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/juju/storage"
+	"github.com/juju/schema"
+)
+
+// checkK8sConfig checks that the attributes in a configuration
+// are valid for a K8s deployment.
+func checkK8sConfig(attributes map[string]any) error {
+	if mediumValue, ok := attributes[storage.K8sStorageMediumConst]; ok {
+		medium := fmt.Sprintf("%v", mediumValue)
+		if medium != storage.K8sStorageMediumMemory && medium != storage.K8sStorageMediumHugePages {
+			return errors.NotValidf("storage medium %q", mediumValue)
+		}
+	}
+
+	if err := validateStorageAttributes(attributes); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+func validateStorageAttributes(attributes map[string]any) error {
+	if err := validateStorageConfig(attributes); err != nil {
+		return errors.Trace(err)
+	}
+	if err := validateStorageMode(attributes); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+var storageConfigFields = schema.Fields{
+	storage.K8sStorageClass:       schema.String(),
+	storage.K8sStorageProvisioner: schema.String(),
+}
+
+var storageConfigChecker = schema.FieldMap(
+	storageConfigFields,
+	schema.Defaults{
+		storage.K8sStorageClass:       schema.Omit,
+		storage.K8sStorageProvisioner: schema.Omit,
+	},
+)
+
+// validateStorageConfig returns issues in the configuration if any.
+func validateStorageConfig(attrs map[string]any) error {
+	out, err := storageConfigChecker.Coerce(attrs, nil)
+	if err != nil {
+		return errors.Annotate(err, "validating storage config")
+	}
+	coerced := out.(map[string]any)
+
+	if coerced[storage.K8sStorageProvisioner] != "" && coerced[storage.K8sStorageClass] == "" {
+		return errors.New("storage-class must be specified if storage-provisioner is specified")
+	}
+
+	return nil
+}
+
+var storageModeFields = schema.Fields{
+	storage.K8sStorageMode: schema.String(),
+}
+
+var storageModeChecker = schema.FieldMap(
+	storageModeFields,
+	schema.Defaults{
+		storage.K8sStorageMode: "ReadWriteOnce",
+	},
+)
+
+// validateStorageMode returns an error if the K8s persistent
+// volume is not configured correctly.
+func validateStorageMode(attrs map[string]any) error {
+	out, err := storageModeChecker.Coerce(attrs, nil)
+	if err != nil {
+		return errors.Annotate(err, "validating storage mode")
+	}
+	coerced := out.(map[string]any)
+	mode := coerced[storage.K8sStorageMode]
+	switch coerced[storage.K8sStorageMode] {
+	case "ReadOnlyMany", "ROX":
+	case "ReadWriteMany", "RWX":
+	case "ReadWriteOnce", "RWO":
+	default:
+		return errors.NotSupportedf("storage mode %q", mode)
+	}
+
+	return nil
+}

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -31,8 +31,11 @@ type loopProvider struct {
 
 var _ storage.Provider = (*loopProvider)(nil)
 
-func (*loopProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
-	// no validation required
+func (*loopProvider) ValidateStorageProvider(isCaas bool, _ map[string]any) error {
+	// loop does not work with CaaS
+	if isCaas {
+		return errors.NotValidf("storage provider type %q", LoopProviderType)
+	}
 	return nil
 }
 

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -31,6 +31,11 @@ type loopProvider struct {
 
 var _ storage.Provider = (*loopProvider)(nil)
 
+func (*loopProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 // ValidateConfig is defined on the Provider interface.
 func (*loopProvider) ValidateConfig(*storage.Config) error {
 	// Loop provider has no configuration.

--- a/storage/provider/loop.go
+++ b/storage/provider/loop.go
@@ -31,12 +31,8 @@ type loopProvider struct {
 
 var _ storage.Provider = (*loopProvider)(nil)
 
-func (*loopProvider) ValidateStorageProvider(isCaas bool, _ map[string]any) error {
-	// loop does not work with CaaS
-	if isCaas {
-		return errors.NotValidf("storage provider type %q", LoopProviderType)
-	}
-	return nil
+func (*loopProvider) ValidateForK8s(map[string]any) error {
+	return errors.NotValidf("storage provider type %q", LoopProviderType)
 }
 
 // ValidateConfig is defined on the Provider interface.

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -28,8 +28,11 @@ var (
 	_ storage.Provider = (*rootfsProvider)(nil)
 )
 
-func (p *rootfsProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
-	// no validation required
+func (p *rootfsProvider) ValidateStorageProvider(isCaas bool, config map[string]any) error {
+	if isCaas {
+		return errors.NotValidf("storage provider type %q", RootfsProviderType)
+	}
+
 	return nil
 }
 

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -28,12 +28,12 @@ var (
 	_ storage.Provider = (*rootfsProvider)(nil)
 )
 
-func (p *rootfsProvider) ValidateStorageProvider(isCaas bool, config map[string]any) error {
-	if isCaas {
-		return errors.NotValidf("storage provider type %q", RootfsProviderType)
+func (p *rootfsProvider) ValidateForK8s(attributes map[string]any) error {
+	if attributes == nil {
+		return nil
 	}
-
-	return nil
+	// check the configuration
+	return checkK8sConfig(attributes)
 }
 
 // ValidateConfig is defined on the Provider interface.

--- a/storage/provider/rootfs.go
+++ b/storage/provider/rootfs.go
@@ -28,6 +28,11 @@ var (
 	_ storage.Provider = (*rootfsProvider)(nil)
 )
 
+func (p *rootfsProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 // ValidateConfig is defined on the Provider interface.
 func (p *rootfsProvider) ValidateConfig(cfg *storage.Config) error {
 	// Rootfs provider has no configuration.

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -30,12 +30,13 @@ var (
 	_ storage.Provider = (*tmpfsProvider)(nil)
 )
 
-func (p *tmpfsProvider) ValidateStorageProvider(isCaas bool, config map[string]any) error {
-	if !isCaas {
-		return errors.NotValidf("storage provider type %q", TmpfsProviderType)
+func (p *tmpfsProvider) ValidateForK8s(attributes map[string]any) error {
+	if attributes == nil {
+		return nil
 	}
 
-	return nil
+	// check the configuration
+	return checkK8sConfig(attributes)
 }
 
 // ValidateConfig is defined on the Provider interface.

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -30,8 +30,11 @@ var (
 	_ storage.Provider = (*tmpfsProvider)(nil)
 )
 
-func (p *tmpfsProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
-	// no validation required
+func (p *tmpfsProvider) ValidateStorageProvider(isCaas bool, config map[string]any) error {
+	if !isCaas {
+		return errors.NotValidf("storage provider type %q", TmpfsProviderType)
+	}
+
 	return nil
 }
 

--- a/storage/provider/tmpfs.go
+++ b/storage/provider/tmpfs.go
@@ -30,6 +30,11 @@ var (
 	_ storage.Provider = (*tmpfsProvider)(nil)
 )
 
+func (p *tmpfsProvider) ValidateStorageProvider(storage.ProviderType, map[string]any) error {
+	// no validation required
+	return nil
+}
+
 // ValidateConfig is defined on the Provider interface.
 func (p *tmpfsProvider) ValidateConfig(cfg *storage.Config) error {
 	// Tmpfs provider has no configuration.


### PR DESCRIPTION
Some refactoring to remove dependencies from the k8s package from `state/storage`. I extended the provider interface to include some additional checking methods . In theory, the working logic should now be distributed among the different providers instead of being centralized in `state/storage.go`.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

Rely on CI and run some basic QA

```bash
juju bootstrap microk8s deleteme --verbose
juju deploy charmed-osm-mariadb-k8s mariadb
juju deploy wordpress-k8s
juju relate wordpress-k8s mariadb:mysql
juju expose wordpress-k8s
...
juju destroy-controller deleteme --destroy-storage
```

and an IaaS deployment

```bash
juju bootstrap lxd deleteme --verbose
juju deploy wordpress --series=jammy --force
juju deploy mysql --channel=edge --series=trusty
juju relate wordpress postgresql
juju expose wordpress
...
juju destroy-controller deleteme --destroy-storage
```

## Documentation changes

NA

## Bug reference

NA