### PR TITLE
Fixed broken AKS bootstrap.

### DIFF
--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -44,26 +44,31 @@ func init() {
 		caas.K8sCloudMicrok8s: {
 			Name:              "hostpath",
 			Provisioner:       "microk8s.io/hostpath",
+			SupportsDefault:   false,
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 		caas.K8sCloudGCE: {
 			Name:              "GCE Persistent Disk",
 			Provisioner:       "kubernetes.io/gce-pd",
+			SupportsDefault:   true,
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 		caas.K8sCloudAzure: {
 			Name:              "Azure Disk",
 			Provisioner:       "kubernetes.io/azure-disk",
+			SupportsDefault:   true,
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 		caas.K8sCloudEC2: {
 			Name:              "EBS Volume",
 			Provisioner:       "kubernetes.io/aws-ebs",
+			SupportsDefault:   true,
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 		caas.K8sCloudOpenStack: {
 			Name:              "Cinder Disk",
 			Provisioner:       "csi-cinderplugin",
+			SupportsDefault:   false,
 			VolumeBindingMode: volBindModeWaitFirstConsumer,
 		},
 	}

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -101,6 +101,7 @@ func toCaaSStorageProvisioner(sc storage.StorageClass) *caas.StorageProvisioner 
 		Name:        sc.Name,
 		Provisioner: sc.Provisioner,
 		Parameters:  sc.Parameters,
+		IsDefault:   isDefaultStorageClass(sc),
 	}
 	if sc.VolumeBindingMode != nil {
 		caasSc.VolumeBindingMode = string(*sc.VolumeBindingMode)
@@ -250,6 +251,10 @@ func (k *kubernetesClient) CheckDefaultWorkloadStorage(cloudType string, storage
 }
 
 func storageClassMatches(preferredStorage caas.PreferredStorage, storageProvisioner *caas.StorageProvisioner) error {
+	if preferredStorage.SupportsDefault && storageProvisioner.IsDefault {
+		return nil
+	}
+
 	if storageProvisioner == nil || preferredStorage.Provisioner != storageProvisioner.Provisioner {
 		return &caas.NonPreferredStorageError{PreferredStorage: preferredStorage}
 	}

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -272,6 +272,7 @@ func (s *K8sMetadataSuite) TestPreferDefaultStorageClass(c *gc.C) {
 	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
 		Provisioner: "a-provisioner",
 		Parameters:  map[string]string{"foo": "bar"},
+		IsDefault:   true,
 	})
 }
 
@@ -297,6 +298,7 @@ func (s *K8sMetadataSuite) TestBetaDefaultStorageClass(c *gc.C) {
 	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
 		Provisioner: "a-provisioner",
 		Parameters:  map[string]string{"foo": "bar"},
+		IsDefault:   true,
 	})
 }
 
@@ -325,6 +327,7 @@ func (s *K8sMetadataSuite) TestUserSpecifiedStorageClasses(c *gc.C) {
 	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
 		Provisioner: "a-provisioner",
 		Parameters:  map[string]string{"foo": "bar"},
+		IsDefault:   true,
 	})
 	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
 		Provisioner: "kubernetes.io/aws-ebs",
@@ -381,10 +384,12 @@ func (s *K8sMetadataSuite) TestOperatorStorageClassPrefersDefault(c *gc.C) {
 	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters:  map[string]string{"foo": "bar"},
+		IsDefault:   true,
 	})
 	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &caas.StorageProvisioner{
 		Provisioner: "kubernetes.io/aws-ebs",
 		Parameters:  map[string]string{"foo": "bar"},
+		IsDefault:   true,
 	})
 }
 

--- a/caas/metadata.go
+++ b/caas/metadata.go
@@ -50,6 +50,7 @@ type PreferredStorage struct {
 	Name              string
 	Provisioner       string
 	Parameters        map[string]string
+	SupportsDefault   bool
 	VolumeBindingMode string
 }
 
@@ -62,6 +63,7 @@ type StorageProvisioner struct {
 	Model             string
 	ReclaimPolicy     string
 	VolumeBindingMode string
+	IsDefault         bool
 }
 
 // ClusterMetadata defines metadata about a cluster.


### PR DESCRIPTION
AKS has changed the name of their provisioner used in new clusters.
Because of this Juju is unable to bootstrap to newly created AKS
clusters with the error message 'preferred storage "kubernetes.io/azure-disk" not available'.

What this change does is introduce a quick flag for AKS and the other
cloud clusters telling Juju that it is ok to use the default storage
provider. We have done the fix this way in 2.9 because of several bugs
found in the storage processing logic for Juju.

A proper and greater fix will land in 3.0 to address the short comings
of storage.

Fixes lp1976434

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

1. Create a new AKS cluster in Azure
2. Bootstrap Juju to the newly created cluster and make sure the bootstrap process succeeds.
3. Add a new model
4. Deploy postgres `juju deploy -n3 postgresql-k8s`
5. Check the postgres deployments comes up with attached storage.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1976434
