### PR TITLE
Remove links to jaas.ai docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Quick links
 Issue tracker: https://bugs.launchpad.net/juju/+bugs
 
 Documentation:
-* https://jaas.ai/docs
+* https://juju.is/docs
 * [source tree docs](doc/)
 
 Community:

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -556,7 +556,7 @@ for security purposes by allowing only certain configurations and devices. Use
 the '--force' option to bypass this check. Doing so is not recommended as it
 can lead to unexpected behaviour.
 
-Further reading: https://jaas.ai/docs/deploying-applications
+Further reading: https://juju.is/docs/olm/manage-applications
 
 Examples:
 

--- a/cmd/juju/cloud/list.go
+++ b/cmd/juju/cloud/list.go
@@ -63,7 +63,7 @@ var listCloudsDoc = "" +
 	"\n" +
 	"Further reading:\n " +
 	"\n" +
-	"    Documentation:   https://jaas.ai/docs/clouds\n" +
+	"    Documentation:   https://juju.is/docs/olm/manage-clouds\n" +
 	"    microk8s:        https://microk8s.io/\n" +
 	"    LXD hypervisor:  https://linuxcontainers.org/lxd/\n" +
 	listCloudsDocExamples

--- a/doc/logging.txt
+++ b/doc/logging.txt
@@ -9,7 +9,7 @@ Accessing logs as a user
 Please consult the available user documentation for details of how to
 access Juju's logs. Specifically:
 
-  * https://jaas.ai/docs/logs
+  * https://juju.is/docs/olm/juju-logs
   * juju help logging
   * juju help debug-log
   * juju-dumplogs --help

--- a/scripts/jujuman.py
+++ b/scripts/jujuman.py
@@ -175,7 +175,7 @@ Records the UUIDs of all models known to Juju.
 .I "~/.local/share/juju/ssh/"
 A directory containing the SSH credentials for the Juju client.
 .SH "SEE ALSO"
-.UR https://jaas.ai/docs
-.BR https://jaas.ai/docs
+.UR https://juju.is/docs/olm
+.BR https://juju.is/docs/olm
 """
 

--- a/scripts/win-installer/README.txt
+++ b/scripts/win-installer/README.txt
@@ -13,8 +13,8 @@ Amazon EC2, Google Compute Engine, or an OpenStack installation.
 in a directory called '.ssh' in your home directory. There are instructions on
 how to generate these keys at:
 
-    https://jaas.ai/docs/creating-ssh-keypairs-on-windows
+    https://ubuntu.com/tutorials/ssh-keygen-on-windows
 
 To continue, please follow the online documentation at:
 
-    https://jaas.ai/docs/getting-started-with-juju
+    https://juju.is/docs/olm


### PR DESCRIPTION
Removes links to Juju docs on jaas.ai in various places after a dead link was noticed by @pietropasotti

## Checklist 

 - ~~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~~
 - ~~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~~
 - ~~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~~
 - ~~[ ] Comments answer the question of why design decisions were made~~
