### PR TITLE
[JUJU-1260] Remove rackspace cloud registration

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -481,7 +481,6 @@ var defaultCloudDescription = map[string]string{
 	"google":      "Google Cloud Platform",
 	"azure":       "Microsoft Azure",
 	"azure-china": "Microsoft Azure China",
-	"rackspace":   "Rackspace Cloud",
 	"cloudsigma":  "CloudSigma Cloud",
 	"lxd":         "LXD Container Hypervisor",
 	"maas":        "Metal As A Service",

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -4,6 +4,7 @@
 package cloud_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
@@ -23,7 +24,7 @@ type cloudSuite struct {
 var _ = gc.Suite(&cloudSuite{})
 
 var publicCloudNames = []string{
-	"aws", "aws-china", "aws-gov", "equinix", "google", "azure", "azure-china", "rackspace", "cloudsigma", "oracle",
+	"aws", "aws-china", "aws-gov", "equinix", "google", "azure", "azure-china", "cloudsigma", "oracle",
 }
 
 func parsePublicClouds(c *gc.C) map[string]cloud.Cloud {
@@ -51,25 +52,21 @@ func (s *cloudSuite) TestAuthTypesContains(c *gc.C) {
 
 func (s *cloudSuite) TestParseCloudsEndpointDenormalisation(c *gc.C) {
 	clouds := parsePublicClouds(c)
-	rackspace := clouds["rackspace"]
-	c.Assert(rackspace.Type, gc.Equals, "rackspace")
-	c.Assert(rackspace.Endpoint, gc.Equals, "https://identity.api.rackspacecloud.com/v2.0")
+	oracle := clouds["oracle"]
+	c.Assert(oracle.Type, gc.Equals, "oci")
 	var regionNames []string
-	for _, region := range rackspace.Regions {
+	for _, region := range oracle.Regions {
 		regionNames = append(regionNames, region.Name)
-		if region.Name == "lon" {
-			c.Assert(region.Endpoint, gc.Equals, "https://lon.identity.api.rackspacecloud.com/v2.0")
-		} else {
-			c.Assert(region.Endpoint, gc.Equals, "https://identity.api.rackspacecloud.com/v2.0")
-		}
+		endpointURL := fmt.Sprintf("https://iaas.%s.oraclecloud.com", region.Name)
+		c.Assert(region.Endpoint, gc.Equals, endpointURL)
 	}
-	c.Assert(regionNames, jc.SameContents, []string{"dfw", "ord", "iad", "lon", "syd", "hkg"})
+	c.Assert(regionNames, jc.SameContents, []string{"us-phoenix-1", "us-ashburn-1", "eu-frankfurt-1", "uk-london-1"})
 }
 
 func (s *cloudSuite) TestParseCloudsAuthTypes(c *gc.C) {
 	clouds := parsePublicClouds(c)
-	rackspace := clouds["rackspace"]
-	c.Assert(rackspace.AuthTypes, jc.SameContents, cloud.AuthTypes{"userpass"})
+	equinix := clouds["equinix"]
+	c.Assert(equinix.AuthTypes, jc.SameContents, cloud.AuthTypes{"access-key"})
 }
 
 func (s *cloudSuite) TestParseCloudsConfig(c *gc.C) {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -316,24 +316,6 @@ clouds:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
         identity-endpoint: https://graph.chinacloudapi.cn
-  rackspace:
-    type: rackspace
-    description: Rackspace Cloud
-    auth-types: [ userpass ]
-    endpoint: https://identity.api.rackspacecloud.com/v2.0
-    regions:
-      dfw:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
-      ord:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
-      iad:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
-      lon:
-        endpoint: https://lon.identity.api.rackspacecloud.com/v2.0
-      syd:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
-      hkg:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
   cloudsigma:
     type: cloudsigma
     description: CloudSigma Cloud

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -323,24 +323,6 @@ clouds:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
         identity-endpoint: https://graph.chinacloudapi.cn
-  rackspace:
-    type: rackspace
-    description: Rackspace Cloud
-    auth-types: [ userpass ]
-    endpoint: https://identity.api.rackspacecloud.com/v2.0
-    regions:
-      dfw:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
-      ord:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
-      iad:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
-      lon:
-        endpoint: https://lon.identity.api.rackspacecloud.com/v2.0
-      syd:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
-      hkg:
-        endpoint: https://identity.api.rackspacecloud.com/v2.0
   cloudsigma:
     type: cloudsigma
     description: CloudSigma Cloud

--- a/cmd/juju/cloud/removecredential.go
+++ b/cmd/juju/cloud/removecredential.go
@@ -71,10 +71,10 @@ see ' + "'juju set-credential'" + ' for more information.
 Use --client option to remove credentials from the current client.
 
 Examples:
-    juju remove-credential rackspace credential_name
-    juju remove-credential rackspace credential_name --client
-    juju remove-credential rackspace credential_name -c mycontroller
-    juju remove-credential rackspace credential_name -c mycontroller --force
+    juju remove-credential google credential_name
+    juju remove-credential google credential_name --client
+    juju remove-credential google credential_name -c mycontroller
+    juju remove-credential google credential_name -c mycontroller --force
 
 See also: 
     add-credential

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -173,7 +173,7 @@ Examples:
     juju bootstrap aws
     juju bootstrap aws/us-east-1
     juju bootstrap google joe-us-east1
-    juju bootstrap --config=~/config-rs.yaml rackspace joe-syd
+    juju bootstrap --config=~/config-rs.yaml google joe-syd
     juju bootstrap --agent-version=2.2.4 aws joe-us-east-1
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
     juju bootstrap aws --storage-pool name=secret --storage-pool type=ebs --storage-pool encrypted=true

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1997,7 +1997,7 @@ cloudsigma
 equinix                                       
 google                                        
 oracle                                        
-rackspace                                     \n?(localhost\s+)?(microk8s\s+)?
+?(localhost\s+)?(microk8s\s+)?
 dummy-cloud                      joe          home
 dummy-cloud-dummy-region-config               
 dummy-cloud-with-config                       
@@ -2060,7 +2060,7 @@ cloudsigma
 equinix                                       
 google                                        
 oracle                                        
-rackspace                                     \n?(localhost\s+)?(microk8s\s+)?
+?(localhost\s+)?(microk8s\s+)?
 dummy-cloud-dummy-region-config               
 dummy-cloud-with-config                       
 dummy-cloud-with-region-config                


### PR DESCRIPTION
Hide rackspace as a cloud for 2.9. Including tests and help text. It is no longer available as a public cloud.

Full removal of the provider will be done for juju 3.0

## QA steps


```sh
$ juju bootstrap rackspace
ERROR unknown cloud "rackspace", please try "juju update-public-clouds"

# Output from the following commands should not reference rackspace in any way.
$ juju clouds
$ juju help bootstrap
$ juju help remove-credential
```

## Documentation changes

The web docs covering bootstrap and remove-credential requires updates.
