### PR TITLE
[JUJU-1263] Updated storage params code start

### DIFF
--- a/caas/kubernetes/metadata.go
+++ b/caas/kubernetes/metadata.go
@@ -4,9 +4,8 @@
 package kubernetes
 
 import (
-	"fmt"
-
 	"github.com/juju/collections/set"
+	storagev1 "k8s.io/api/storage/v1"
 )
 
 const (
@@ -45,30 +44,14 @@ const (
 type ClusterMetadataChecker interface {
 	// GetClusterMetadata returns metadata about host cloud and storage for the cluster.
 	GetClusterMetadata(storageClass string) (result *ClusterMetadata, err error)
-
-	// CheckDefaultWorkloadStorage returns an error if the opinionated storage defined for
-	// the cluster does not match the specified storage.
-	CheckDefaultWorkloadStorage(cluster string, storageProvisioner *StorageProvisioner) error
-
-	// EnsureStorageProvisioner creates a storage provisioner with the specified config, or returns an existing one.
-	EnsureStorageProvisioner(cfg StorageProvisioner) (*StorageProvisioner, bool, error)
 }
 
 // ClusterMetadata defines metadata about a cluster.
 type ClusterMetadata struct {
-	NominatedStorageClass *StorageProvisioner
-	OperatorStorageClass  *StorageProvisioner
-	Cloud                 string
-	Regions               set.Strings
-}
-
-// PreferredStorage defines preferred storage
-// attributes on a given cluster.
-type PreferredStorage struct {
-	Name              string
-	Provisioner       string
-	Parameters        map[string]string
-	VolumeBindingMode string
+	WorkloadStorageClass *storagev1.StorageClass
+	OperatorStorageClass *storagev1.StorageClass
+	Cloud                string
+	Regions              set.Strings
 }
 
 // StorageProvisioner defines the a storage provisioner available on a cluster.
@@ -80,21 +63,4 @@ type StorageProvisioner struct {
 	Model             string
 	ReclaimPolicy     string
 	VolumeBindingMode string
-}
-
-// NonPreferredStorageError is raised when a cluster does not have
-// the opinionated default storage Juju requires.
-type NonPreferredStorageError struct {
-	PreferredStorage
-}
-
-// Error implements error.
-func (e *NonPreferredStorageError) Error() string {
-	return fmt.Sprintf("preferred storage %q not available", e.Provisioner)
-}
-
-// IsNonPreferredStorageError returns true if err is a NonPreferredStorageError.
-func IsNonPreferredStorageError(err error) bool {
-	_, ok := err.(*NonPreferredStorageError)
-	return ok
 }

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -4,8 +4,6 @@
 package provider
 
 import (
-	"fmt"
-
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/utils/v3"
@@ -49,53 +47,16 @@ type KubeCloudStorageParams struct {
 	GetClusterMetadataFunc GetClusterMetadataFunc
 }
 
-func updateK8sCloud(k8sCloud *cloud.Cloud, clusterMetadata *k8s.ClusterMetadata, storageMsg string) string {
-	var workloadSC, operatorSC string
-	// Record the operator storage to use.
-	if clusterMetadata.OperatorStorageClass != nil {
-		operatorSC = clusterMetadata.OperatorStorageClass.Name
-	} else {
-		if storageMsg == "" {
-			storageMsg += "\nwith "
-		} else {
-			storageMsg += "\nand "
-		}
-		storageMsg += "operator storage provisioned by the workload storage class"
-	}
-
-	if clusterMetadata.NominatedStorageClass != nil {
-		workloadSC = clusterMetadata.NominatedStorageClass.Name
-	}
-
-	if k8sCloud.Config == nil {
-		k8sCloud.Config = make(map[string]interface{})
-	}
-	if _, ok := k8sCloud.Config[k8sconstants.WorkloadStorageKey]; !ok {
-		k8sCloud.Config[k8sconstants.WorkloadStorageKey] = workloadSC
-	}
-	if _, ok := k8sCloud.Config[k8sconstants.OperatorStorageKey]; !ok {
-		k8sCloud.Config[k8sconstants.OperatorStorageKey] = operatorSC
-	}
-	return storageMsg
-}
-
-// UpdateKubeCloudWithStorage updates the passed Cloud with storage details retrieved from the clouds' cluster.
-func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudStorageParams) (storageMsg string, err error) {
-	// Get the cluster metadata so we can see if there's suitable storage available.
+// UpdateKubeCloudWithStorage updates the passed Cloud with storage details retrieved from the cloud's cluster.
+func UpdateKubeCloudWithStorage(k8sCloud cloud.Cloud, storageParams KubeCloudStorageParams) (cloud.Cloud, error) {
+	// Get the cluster metadata and see what storage comes back based on the
+	// preffered rules for metadata.
 	clusterMetadata, err := storageParams.GetClusterMetadataFunc(storageParams)
-	defer func() {
-		if err == nil {
-			storageMsg = updateK8sCloud(k8sCloud, clusterMetadata, storageMsg)
-		}
-	}()
-
-	if err != nil || clusterMetadata == nil {
-		// err will be nil if user hit Ctrl+C.
-		msg := "cannot get cluster metadata"
-		if err != nil {
-			msg = err.Error()
-		}
-		return "", ClusterQueryError{Message: msg}
+	if err != nil {
+		return cloud.Cloud{}, ClusterQueryError{Message: err.Error()}
+	}
+	if clusterMetadata == nil {
+		return cloud.Cloud{}, ClusterQueryError{Message: "cannot get cluster metadata"}
 	}
 
 	if storageParams.HostCloudRegion == "" && clusterMetadata.Cloud != "" {
@@ -107,12 +68,11 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 	}
 	k8sCloud.HostCloudRegion = storageParams.HostCloudRegion
 
-	var cloudType, region string
 	if k8sCloud.HostCloudRegion != "" {
-		cloudType, region, err = cloud.SplitHostCloudRegion(k8sCloud.HostCloudRegion)
+		_, region, err := cloud.SplitHostCloudRegion(k8sCloud.HostCloudRegion)
 		if err != nil {
 			// Shouldn't happen as HostCloudRegion is validated earlier.
-			return "", errors.Trace(err)
+			return cloud.Cloud{}, errors.Trace(err)
 		}
 		if region != "" {
 			k8sCloud.Regions = []cloud.Region{{
@@ -121,80 +81,25 @@ func UpdateKubeCloudWithStorage(k8sCloud *cloud.Cloud, storageParams KubeCloudSt
 			}}
 		}
 	}
-	// If the user has not specified storage and cloudType is usable, check Juju's opinionated defaults.
-	err = storageParams.MetadataChecker.CheckDefaultWorkloadStorage(
-		cloudType, clusterMetadata.NominatedStorageClass,
-	)
-	if storageParams.WorkloadStorage == "" {
-		if err == nil {
-			return
-		}
-		if k8s.IsNonPreferredStorageError(err) {
-			npse := err.(*k8s.NonPreferredStorageError)
-			return "", NoRecommendedStorageError{Message: err.Error(), ProviderName: npse.Name}
-		}
-		if errors.IsNotFound(err) {
-			// No juju preferred storage config in jujuPreferredWorkloadStorage, for example, maas.
-			if clusterMetadata.NominatedStorageClass == nil {
-				// And no preferred storage classes with expected annotations found.
-				//  - workloadStorageClassAnnotationKey
-				//  - operatorStorageClassAnnotationKey
-				return "", UnknownClusterError{
-					Message:   "Suitable Kubernetes storage class for workload storage not found in cluster. Consider adding a default storage class to the cluster",
-					CloudName: cloudType,
-				}
-			}
-			// Do further EnsureStorageProvisioner if preferred storage found via juju preferred/default annotations.
-		} else if err != nil {
-			return "", errors.Trace(err)
+
+	// We at least expected operator storage to be available to successfully use
+	// this cloud.
+	if clusterMetadata.OperatorStorageClass == nil {
+		return cloud.Cloud{}, &environs.PreferredStorageNotFound{
+			Message: "no preferred operator storage found in Kubernetes cluster",
 		}
 	}
 
-	// we need to create storage class with the opinionated defaults, or use an existing one if
-	// --storage provided or nominated storage found but Juju does not have preferred storage config to
-	// compare with for the cloudType(like maas for example);
-	var (
-		provisioner       string
-		volumeBindingMode string
-		params            map[string]string
-	)
-	scName := storageParams.WorkloadStorage
-	nonPreferredStorageErr, ok := errors.Cause(err).(*k8s.NonPreferredStorageError)
-	if ok {
-		provisioner = nonPreferredStorageErr.Provisioner
-		volumeBindingMode = nonPreferredStorageErr.VolumeBindingMode
-		params = nonPreferredStorageErr.Parameters
-	} else if clusterMetadata.NominatedStorageClass != nil {
-		if scName == "" {
-			// no preferred storage class config but nominated storage found.
-			scName = clusterMetadata.NominatedStorageClass.Name
-		}
+	if k8sCloud.Config == nil {
+		k8sCloud.Config = make(map[string]interface{})
 	}
-	sp, existing, err := storageParams.MetadataChecker.EnsureStorageProvisioner(k8s.StorageProvisioner{
-		Name:              scName,
-		Provisioner:       provisioner,
-		Parameters:        params,
-		VolumeBindingMode: volumeBindingMode,
-	})
-	if errors.IsNotFound(err) {
-		return "", errors.Wrap(err, errors.NotFoundf("storage class %q", scName))
+
+	k8sCloud.Config[k8sconstants.OperatorStorageKey] = clusterMetadata.OperatorStorageClass.Name
+	k8sCloud.Config[k8sconstants.WorkloadStorageKey] = ""
+	if clusterMetadata.WorkloadStorageClass != nil {
+		k8sCloud.Config[k8sconstants.WorkloadStorageKey] = clusterMetadata.WorkloadStorageClass.Name
 	}
-	if err != nil {
-		return "", errors.Annotatef(err, "creating storage class %q", scName)
-	}
-	if nonPreferredStorageErr != nil && sp.Provisioner == provisioner {
-		storageMsg = fmt.Sprintf(" with %s default storage provisioned", nonPreferredStorageErr.Name)
-	} else {
-		storageMsg = " with storage provisioned"
-	}
-	scExisting := "existing"
-	if !existing {
-		scExisting = "new"
-	}
-	storageMsg += fmt.Sprintf("\nby the %s %q storage class", scExisting, scName)
-	clusterMetadata.NominatedStorageClass = sp
-	clusterMetadata.OperatorStorageClass = sp
-	return storageMsg, nil
+	return k8sCloud, nil
 }
 
 // BaseKubeCloudOpenParams provides a basic OpenParams for a cluster
@@ -294,9 +199,9 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 		},
 	}
 
-	_, err = UpdateKubeCloudWithStorage(&cld, storageUpdateParams)
+	cld, err = UpdateKubeCloudWithStorage(cld, storageUpdateParams)
 	if err != nil {
-		return cloud.Cloud{}, errors.Trace(err)
+		return cld, errors.Trace(err)
 	}
 
 	if cld.HostCloudRegion == "" {

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -42,9 +42,13 @@ var defaultK8sCloud = jujucloud.Cloud{
 }
 
 var defaultClusterMetadata = &k8s.ClusterMetadata{
-	Cloud:                k8s.K8sCloudMicrok8s,
-	Regions:              set.NewStrings(k8s.Microk8sRegion),
-	OperatorStorageClass: &k8s.StorageProvisioner{Name: "operator-sc"},
+	Cloud:   k8s.K8sCloudMicrok8s,
+	Regions: set.NewStrings(k8s.Microk8sRegion),
+	OperatorStorageClass: &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "operator-sc",
+		},
+	},
 }
 
 func getDefaultCredential() jujucloud.Credential {

--- a/caas/kubernetes/provider/errors.go
+++ b/caas/kubernetes/provider/errors.go
@@ -27,22 +27,6 @@ func IsClusterQueryError(err error) bool {
 	return ok
 }
 
-// UnknownClusterError occurs when the provided cluster is not known to Juju.
-type UnknownClusterError struct {
-	Message   string
-	CloudName string
-}
-
-func (e UnknownClusterError) Error() string {
-	return e.Message
-}
-
-// IsUnknownClusterError returns true if err is a UnknownClusterError
-func IsUnknownClusterError(err error) bool {
-	_, ok := err.(UnknownClusterError)
-	return ok
-}
-
 // NoRecommendedStorageError represents when Juju is unable to determine which storage a cluster uses (or should use)
 type NoRecommendedStorageError struct {
 	Message      string

--- a/caas/kubernetes/provider/init.go
+++ b/caas/kubernetes/provider/init.go
@@ -13,12 +13,8 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 )
 
-const volBindModeWaitFirstConsumer = "WaitForFirstConsumer"
-
 var (
-	k8sCloudCheckers             map[string][]k8slabels.Selector
-	jujuPreferredWorkloadStorage map[string]k8s.PreferredStorage
-	jujuPreferredOperatorStorage map[string]k8s.PreferredStorage
+	k8sCloudCheckers map[string][]k8slabels.Selector
 
 	// lifecycleApplicationRemovalSelector is the label selector for removing global resources for application removal.
 	lifecycleApplicationRemovalSelector k8slabels.Selector
@@ -35,45 +31,6 @@ func init() {
 	// k8sCloudCheckers is a collection of k8s node selector requirement definitions
 	// used for detecting cloud provider from node labels.
 	k8sCloudCheckers = compileK8sCloudCheckers()
-
-	// jujuPreferredWorkloadStorage defines the opinionated storage
-	// that Juju requires to be available on supported clusters.
-	jujuPreferredWorkloadStorage = map[string]k8s.PreferredStorage{
-		// WaitForFirstConsumer mode which will delay the binding and provisioning of a PersistentVolume until a
-		// Pod using the PersistentVolumeClaim is created.
-		// https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
-		k8s.K8sCloudMicrok8s: {
-			Name:              "hostpath",
-			Provisioner:       "microk8s.io/hostpath",
-			VolumeBindingMode: volBindModeWaitFirstConsumer,
-		},
-		k8s.K8sCloudGCE: {
-			Name:              "GCE Persistent Disk",
-			Provisioner:       "kubernetes.io/gce-pd",
-			VolumeBindingMode: volBindModeWaitFirstConsumer,
-		},
-		k8s.K8sCloudAzure: {
-			Name:              "Azure Disk",
-			Provisioner:       "kubernetes.io/azure-disk",
-			VolumeBindingMode: volBindModeWaitFirstConsumer,
-		},
-		k8s.K8sCloudEC2: {
-			Name:              "EBS Volume",
-			Provisioner:       "kubernetes.io/aws-ebs",
-			VolumeBindingMode: volBindModeWaitFirstConsumer,
-		},
-		k8s.K8sCloudOpenStack: {
-			Name:              "Cinder Disk",
-			Provisioner:       "csi-cinderplugin",
-			VolumeBindingMode: volBindModeWaitFirstConsumer,
-		},
-	}
-
-	// jujuPreferredOperatorStorage defines the opinionated storage
-	// that Juju requires to be available on supported clusters to
-	// provision storage for operators.
-	// TODO - support regional storage for GCE etc
-	jujuPreferredOperatorStorage = jujuPreferredWorkloadStorage
 
 	lifecycleApplicationRemovalSelector = compileLifecycleApplicationRemovalSelector()
 	lifecycleModelTeardownSelector = compileLifecycleModelTeardownSelector()

--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -8,15 +8,17 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	core "k8s.io/api/core/v1"
-	storage "k8s.io/api/storage/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	core "k8s.io/client-go/kubernetes/typed/core/v1"
+	storage "k8s.io/client-go/kubernetes/typed/storage/v1"
 
-	k8s "github.com/juju/juju/caas/kubernetes"
-	k8sannotations "github.com/juju/juju/core/annotations"
+	"github.com/juju/juju/caas/kubernetes"
+	providerstorage "github.com/juju/juju/caas/kubernetes/provider/storage"
+	"github.com/juju/juju/environs"
 	environscontext "github.com/juju/juju/environs/context"
 )
 
@@ -66,13 +68,13 @@ type requirementParams struct {
 
 const regionLabelName = "failure-domain.beta.kubernetes.io/region"
 
-func getCloudRegionFromNodeMeta(node core.Node) (string, string) {
+func getCloudRegionFromNodeMeta(node corev1.Node) (string, string) {
 	for cloudType, checkers := range k8sCloudCheckers {
 		for _, checker := range checkers {
 			if checker.Matches(k8slabels.Set(node.GetLabels())) {
 				region := node.Labels[regionLabelName]
-				if region == "" && cloudType == k8s.K8sCloudMicrok8s {
-					region = k8s.Microk8sRegion
+				if region == "" && cloudType == kubernetes.K8sCloudMicrok8s {
+					region = kubernetes.Microk8sRegion
 				}
 				return cloudType, region
 			}
@@ -81,23 +83,8 @@ func getCloudRegionFromNodeMeta(node core.Node) (string, string) {
 	return "", ""
 }
 
-func isDefaultStorageClass(sc storage.StorageClass) bool {
-	return k8sannotations.New(sc.GetAnnotations()).HasAny(
-		map[string]string{
-			"storageclass.kubernetes.io/is-default-class": "true",
-			// Older clusters still use the beta annotation.
-			"storageclass.beta.kubernetes.io/is-default-class": "true",
-		},
-	)
-}
-
-const (
-	operatorStorageClassAnnotationKey = "juju.is/operator-storage"
-	workloadStorageClassAnnotationKey = "juju.is/workload-storage"
-)
-
-func toCaaSStorageProvisioner(sc storage.StorageClass) *k8s.StorageProvisioner {
-	caasSc := &k8s.StorageProvisioner{
+func toCaaSStorageProvisioner(sc *storagev1.StorageClass) *kubernetes.StorageProvisioner {
+	caasSc := &kubernetes.StorageProvisioner{
 		Name:        sc.Name,
 		Provisioner: sc.Provisioner,
 		Parameters:  sc.Parameters,
@@ -119,111 +106,97 @@ func (k *kubernetesClient) ValidateCloudEndpoint(_ environscontext.ProviderCallC
 	return errors.Trace(err)
 }
 
-// GetClusterMetadata implements ClusterMetadataChecker.
-func (k *kubernetesClient) GetClusterMetadata(storageClass string) (*k8s.ClusterMetadata, error) {
-	var result k8s.ClusterMetadata
+// GetClusterMetadata implements ClusterMetadataChecker. If a nominated storage
+// class is provided
+func (k *kubernetesClient) GetClusterMetadata(nominatedStorageClass string) (*kubernetes.ClusterMetadata, error) {
+	return GetClusterMetadata(
+		context.TODO(),
+		nominatedStorageClass,
+		k.client().CoreV1().Nodes(),
+		k.client().StorageV1().StorageClasses(),
+	)
+}
+
+// GetClusterMetadata is responsible for gather a Kubernetes cluster metadata
+// for Juju to make decisions. This relates to the cloud the cluster may or may
+// not be running in + storage available. Split out from the main
+// kubernetesClient struct so that it can be tested correctly.
+func GetClusterMetadata(
+	ctx context.Context,
+	nominatedStorageClass string,
+	nodeI core.NodeInterface,
+	storageClassI storage.StorageClassInterface,
+) (*kubernetes.ClusterMetadata, error) {
+	var result kubernetes.ClusterMetadata
 	var err error
-	result.Cloud, result.Regions, err = k.listHostCloudRegions()
+	result.Cloud, result.Regions, err = listHostCloudRegions(ctx, nodeI)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot determine cluster region")
 	}
 
-	if storageClass != "" {
-		sc, err := k.client().StorageV1().StorageClasses().Get(context.TODO(), storageClass, v1.GetOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
-			return nil, errors.Trace(err)
-		}
-		if err == nil {
-			logger.Debugf("use %q for nominated storage class", sc.Name)
-			result.NominatedStorageClass = toCaaSStorageProvisioner(*sc)
-		}
-	}
-
 	// We may have the workload storage but still need to look for operator storage.
-	storageClasses, err := k.client().StorageV1().StorageClasses().List(context.TODO(), v1.ListOptions{})
+	storageClasses, err := storageClassI.List(context.TODO(), v1.ListOptions{})
 	if err != nil {
 		return nil, errors.Annotate(err, "listing storage classes")
 	}
 
-	var possibleWorkloadStorage, possibleOperatorStorage []*k8s.StorageProvisioner
-	preferredOperatorStorage, hasPreferredOperatorStorage := jujuPreferredOperatorStorage[result.Cloud]
+	preferredOperatorStorage := providerstorage.PreferredOperatorStorageForCloud(result.Cloud).Prepend(
+		&providerstorage.PreferredStorageNominated{
+			StorageClassName: nominatedStorageClass,
+		},
+	)
 
-	pickOperatorSC := func(sc storage.StorageClass, maybeStorage *k8s.StorageProvisioner) {
-		if result.OperatorStorageClass != nil {
-			return
+	preferredWorkloadStorage := providerstorage.PreferredWorkloadStorageForCloud(result.Cloud).Prepend(
+		&providerstorage.PreferredStorageNominated{
+			StorageClassName: nominatedStorageClass,
+		},
+	)
+
+	var (
+		selectedOperatorSC *storagev1.StorageClass
+		selectedWorkloadSC *storagev1.StorageClass
+		operatorPriority   int
+		workloadPriority   int
+	)
+	for i, sc := range storageClasses.Items {
+		priority, matches := preferredOperatorStorage.Matches(&sc)
+		if matches && (priority < operatorPriority || selectedOperatorSC == nil) {
+			selectedOperatorSC = &storageClasses.Items[i]
+			operatorPriority = priority
 		}
 
-		if k8sannotations.New(sc.GetAnnotations()).Has(operatorStorageClassAnnotationKey, "true") {
-			logger.Debugf("use %q with annotations %v for operator storage class", sc.Name, sc.GetAnnotations())
-			result.OperatorStorageClass = maybeStorage
-		} else if hasPreferredOperatorStorage {
-			err := storageClassMatches(preferredOperatorStorage, maybeStorage)
-			if err != nil {
-				// not match.
-				return
-			}
-			if isDefaultStorageClass(sc) {
-				// Prefer operator storage from the default storage class.
-				result.OperatorStorageClass = maybeStorage
-				logger.Debugf(
-					"use the default Storage class %q for operator storage class because it also matches Juju preferred config %v",
-					maybeStorage.Name, preferredOperatorStorage,
-				)
-			} else {
-				possibleOperatorStorage = append(possibleOperatorStorage, maybeStorage)
-			}
-		}
-	}
-
-	pickWorkloadSC := func(sc storage.StorageClass, maybeStorage *k8s.StorageProvisioner) {
-		if result.NominatedStorageClass != nil {
-			return
-		}
-
-		if k8sannotations.New(sc.GetAnnotations()).Has(workloadStorageClassAnnotationKey, "true") {
-			logger.Debugf("use %q with annotations %v for nominated storage class", sc.Name, sc.GetAnnotations())
-			result.NominatedStorageClass = maybeStorage
-		} else if isDefaultStorageClass(sc) {
-			// no nominated storage class specified, so use the default one;
-			result.NominatedStorageClass = maybeStorage
-			logger.Debugf("use the default Storage class %q for nominated storage class", maybeStorage.Name)
-		} else {
-			possibleWorkloadStorage = append(possibleWorkloadStorage, maybeStorage)
+		priority, matches = preferredWorkloadStorage.Matches(&sc)
+		if matches && (priority < workloadPriority || selectedWorkloadSC == nil) {
+			selectedWorkloadSC = &storageClasses.Items[i]
+			workloadPriority = priority
 		}
 	}
 
-	for _, sc := range storageClasses.Items {
-		if result.OperatorStorageClass != nil && result.NominatedStorageClass != nil {
-			break
+	if nominatedStorageClass != "" && selectedOperatorSC.Name != nominatedStorageClass {
+		return nil, &environs.NominatedStorageNotFound{
+			StorageName: nominatedStorageClass,
 		}
-		maybeStorage := toCaaSStorageProvisioner(sc)
-		pickOperatorSC(sc, maybeStorage)
-		pickWorkloadSC(sc, maybeStorage)
 	}
 
-	if result.OperatorStorageClass == nil && len(possibleOperatorStorage) > 0 {
-		result.OperatorStorageClass = possibleOperatorStorage[0]
-		logger.Debugf("use %q for operator storage class", possibleOperatorStorage[0].Name)
+	if nominatedStorageClass != "" && selectedWorkloadSC.Name != nominatedStorageClass {
+		return nil, &environs.NominatedStorageNotFound{
+			StorageName: nominatedStorageClass,
+		}
 	}
-	// Even if no storage class was marked as default for the cluster, if there's only
-	// one of them, use it for workload storage.
-	if result.NominatedStorageClass == nil && len(possibleWorkloadStorage) == 1 {
-		result.NominatedStorageClass = possibleWorkloadStorage[0]
-		logger.Debugf("use %q for nominated storage class", possibleWorkloadStorage[0].Name)
-	}
-	if result.OperatorStorageClass == nil && result.NominatedStorageClass != nil {
-		// use workload storage class if no operator storage class preference found.
-		result.OperatorStorageClass = result.NominatedStorageClass
-		logger.Debugf("use nominated storage class %q for operator storage class", result.NominatedStorageClass.Name)
-	}
+
+	result.OperatorStorageClass = selectedOperatorSC
+	result.WorkloadStorageClass = selectedWorkloadSC
 	return &result, nil
 }
 
 // listHostCloudRegions lists all the cloud regions that this cluster has worker nodes/instances running in.
-func (k *kubernetesClient) listHostCloudRegions() (string, set.Strings, error) {
+func listHostCloudRegions(
+	ctx context.Context,
+	nodeI core.NodeInterface,
+) (string, set.Strings, error) {
 	// we only check 5 worker nodes as of now just run in the one region and
 	// we are just looking for a running worker to sniff its region.
-	nodes, err := k.client().CoreV1().Nodes().List(context.TODO(), v1.ListOptions{Limit: 5})
+	nodes, err := nodeI.List(ctx, v1.ListOptions{Limit: 5})
 	if err != nil {
 		return "", nil, errors.Annotate(err, "listing nodes")
 	}
@@ -238,28 +211,4 @@ func (k *kubernetesClient) listHostCloudRegions() (string, set.Strings, error) {
 		result.Add(region)
 	}
 	return cloudResult, result, nil
-}
-
-// CheckDefaultWorkloadStorage implements ClusterMetadataChecker.
-func (k *kubernetesClient) CheckDefaultWorkloadStorage(cloudType string, storageProvisioner *k8s.StorageProvisioner) error {
-	preferredStorage, ok := jujuPreferredWorkloadStorage[cloudType]
-	if !ok {
-		return errors.NotFoundf("preferred workload storage for cloudType %q", cloudType)
-	}
-	return storageClassMatches(preferredStorage, storageProvisioner)
-}
-
-func storageClassMatches(preferredStorage k8s.PreferredStorage, storageProvisioner *k8s.StorageProvisioner) error {
-	if storageProvisioner == nil || preferredStorage.Provisioner != storageProvisioner.Provisioner {
-		return &k8s.NonPreferredStorageError{PreferredStorage: preferredStorage}
-	}
-	for k, v := range preferredStorage.Parameters {
-		param, ok := storageProvisioner.Parameters[k]
-		if !ok || param != v {
-			return errors.Annotatef(
-				&k8s.NonPreferredStorageError{PreferredStorage: preferredStorage},
-				"storage class %q requires parameter %s=%s", preferredStorage.Name, k, v)
-		}
-	}
-	return nil
 }

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -4,20 +4,21 @@
 package provider_test
 
 import (
-	"strings"
+	"context"
+	"errors"
 
-	"github.com/golang/mock/gomock"
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 
-	k8s "github.com/juju/juju/caas/kubernetes"
+	"github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/environs"
 )
 
 type K8sMetadataSuite struct {
@@ -26,10 +27,94 @@ type K8sMetadataSuite struct {
 
 var _ = gc.Suite(&K8sMetadataSuite{})
 
-func newNode(labels map[string]string) core.Node {
+var (
+	annotatedOperatorStorage = &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "operator-storage",
+			Annotations: map[string]string{
+				"juju.is/operator-storage": "true",
+			},
+		},
+	}
+
+	annotatedWorkloadStorage = &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "workload-storage",
+			Annotations: map[string]string{
+				"juju.is/workload-storage": "true",
+			},
+		},
+	}
+
+	azureNode = newNode(map[string]string{
+		"failure-domain.beta.kubernetes.io/region": "wallyworld-region",
+		"kubernetes.azure.com/cluster":             "true",
+	})
+
+	azureStorageClass = &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "mynode",
+		},
+		Provisioner: "kubernetes.io/azure-disk",
+	}
+
+	defaultStorage = &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "default",
+			Annotations: map[string]string{
+				"storageclass.kubernetes.io/is-default-class": "true",
+			},
+		},
+	}
+
+	ec2Node = newNode(map[string]string{
+		"failure-domain.beta.kubernetes.io/region": "wallyworld-region",
+		"manufacturer": "amazon_ec2",
+	})
+
+	ec2StorageClass = &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "mynode",
+		},
+		Provisioner: "kubernetes.io/aws-ebs",
+	}
+
+	gceNode = newNode(map[string]string{
+		"failure-domain.beta.kubernetes.io/region": "wallyworld-region",
+		"cloud.google.com/gke-nodepool":            "true",
+		"cloud.google.com/gke-os-distribution":     "true",
+	})
+
+	gceStorageClass = &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "mynode",
+		},
+		Provisioner: "kubernetes.io/gce-pd",
+	}
+
+	microk8sNode = newNode(map[string]string{
+		"microk8s.io/cluster":                      "true",
+		"failure-domain.beta.kubernetes.io/region": "wallyworld-region",
+	})
+
+	microk8sStorageClass = &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "mynode",
+		},
+		Provisioner: "microk8s.io/hostpath",
+	}
+
+	nominatedStorage = &storagev1.StorageClass{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "nominated",
+		},
+	}
+)
+
+func newNode(labels map[string]string) *core.Node {
 	n := core.Node{}
 	n.SetLabels(labels)
-	return n
+	return &n
 }
 
 func (s *K8sMetadataSuite) TestMicrok8sFromNodeMeta(c *gc.C) {
@@ -68,30 +153,30 @@ func (s *K8sMetadataSuite) TestK8sCloudCheckersValidationPass(c *gc.C) {
 type hostRegionTestcase struct {
 	expectedCloud   string
 	expectedRegions set.Strings
-	nodes           *core.NodeList
+	node            *core.Node
 }
 
 var hostRegionsTestCases = []hostRegionTestcase{
 	{
 		expectedRegions: set.NewStrings(),
-		nodes:           newNodeList(map[string]string{}),
+		node:            newNode(map[string]string{}),
 	},
 	{
 		expectedRegions: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"cloud.google.com/gke-nodepool": "",
 		}),
 	},
 	{
 		expectedRegions: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"cloud.google.com/gke-os-distribution": "",
 		}),
 	},
 	{
 		expectedCloud:   "gce",
 		expectedRegions: set.NewStrings(""),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"cloud.google.com/gke-nodepool":        "",
 			"cloud.google.com/gke-os-distribution": "",
 		}),
@@ -99,61 +184,61 @@ var hostRegionsTestCases = []hostRegionTestcase{
 	{
 		expectedCloud:   "gce",
 		expectedRegions: set.NewStrings(""),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"juju.is/cloud": "gce",
 		}),
 	},
 	{
 		expectedCloud:   "ec2",
 		expectedRegions: set.NewStrings(""),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"juju.is/cloud": "ec2",
 		}),
 	},
 	{
 		expectedCloud:   "azure",
 		expectedRegions: set.NewStrings(""),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"juju.is/cloud": "azure",
 		}),
 	},
 	{
 		expectedCloud:   "azure",
 		expectedRegions: set.NewStrings(""),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"kubernetes.azure.com/cluster": "",
 		}),
 	},
 	{
 		expectedCloud:   "ec2",
 		expectedRegions: set.NewStrings(""),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"manufacturer": "amazon_ec2",
 		}),
 	},
 	{
 		expectedCloud:   "ec2",
 		expectedRegions: set.NewStrings(""),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"eks.amazonaws.com/nodegroup": "any-node-group",
 		}),
 	},
 	{
 		expectedRegions: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
 		}),
 	},
 	{
 		expectedRegions: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
 			"cloud.google.com/gke-nodepool":            "",
 		}),
 	},
 	{
 		expectedRegions: set.NewStrings(),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
 			"cloud.google.com/gke-os-distribution":     "",
 		}),
@@ -161,7 +246,7 @@ var hostRegionsTestCases = []hostRegionTestcase{
 	{
 		expectedCloud:   "gce",
 		expectedRegions: set.NewStrings("a-fancy-region"),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
 			"cloud.google.com/gke-nodepool":            "",
 			"cloud.google.com/gke-os-distribution":     "",
@@ -170,7 +255,7 @@ var hostRegionsTestCases = []hostRegionTestcase{
 	{
 		expectedCloud:   "azure",
 		expectedRegions: set.NewStrings("a-fancy-region"),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
 			"kubernetes.azure.com/cluster":             "",
 		}),
@@ -178,336 +263,481 @@ var hostRegionsTestCases = []hostRegionTestcase{
 	{
 		expectedCloud:   "ec2",
 		expectedRegions: set.NewStrings("a-fancy-region"),
-		nodes: newNodeList(map[string]string{
+		node: newNode(map[string]string{
 			"failure-domain.beta.kubernetes.io/region": "a-fancy-region",
 			"manufacturer": "amazon_ec2",
 		}),
 	},
 }
 
-func newNodeList(labels map[string]string) *core.NodeList {
-	return &core.NodeList{Items: []core.Node{newNode(labels)}}
-}
-
 func (s *K8sMetadataSuite) TestListHostCloudRegions(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
+	for _, v := range hostRegionsTestCases {
+		clientSet := fake.NewSimpleClientset(v.node)
 
-	for i, v := range hostRegionsTestCases {
-		c.Logf("test %d", i)
-		gomock.InOrder(
-			s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-				Return(v.nodes, nil),
-			s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-				Return(&storagev1.StorageClassList{}, nil),
+		metadata, err := provider.GetClusterMetadata(
+			context.TODO(),
+			"",
+			clientSet.CoreV1().Nodes(),
+			clientSet.StorageV1().StorageClasses(),
 		)
-		metadata, err := s.broker.GetClusterMetadata("")
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(metadata.Cloud, gc.Equals, v.expectedCloud)
 		c.Check(metadata.Regions, jc.DeepEquals, v.expectedRegions)
 	}
 }
 
-func (s *K8sMetadataSuite) TestNoDefaultStorageClasses(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
+func (_ *K8sMetadataSuite) TestGetMetadataVariations(c *gc.C) {
+	tests := []struct {
+		Name             string
+		InitialObjects   []runtime.Object
+		NominatedStorage string
+		Result           kubernetes.ClusterMetadata
+	}{
+		// EC2 tests
+		{
+			Name: "Test ec2 cloud finds provisioner storage",
+			InitialObjects: []runtime.Object{
+				ec2Node,
+				ec2StorageClass,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "ec2",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: ec2StorageClass,
+				OperatorStorageClass: ec2StorageClass,
+			},
+		},
+		{
+			Name: "Test ec2 cloud prefers annotation storage",
+			InitialObjects: []runtime.Object{
+				ec2Node,
+				ec2StorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "ec2",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: annotatedWorkloadStorage,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test ec2 cloud prefers annotation storage without workload",
+			InitialObjects: []runtime.Object{
+				ec2Node,
+				annotatedOperatorStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "ec2",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test ec2 cloud prefers nominated storage as first priority",
+			InitialObjects: []runtime.Object{
+				ec2Node,
+				ec2StorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+				nominatedStorage,
+			},
+			NominatedStorage: "nominated",
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "ec2",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nominatedStorage,
+				OperatorStorageClass: nominatedStorage,
+			},
+		},
+		{
+			Name: "Test ec2 cloud with no found storage",
+			InitialObjects: []runtime.Object{
+				ec2Node,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "ec2",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: nil,
+			},
+		},
+		{
+			Name: "Test ec2 cloud with default storage",
+			InitialObjects: []runtime.Object{
+				ec2Node,
+				defaultStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "ec2",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: defaultStorage,
+				OperatorStorageClass: defaultStorage,
+			},
+		},
 
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
-				Provisioner: "a-provisioner",
-				Parameters:  map[string]string{"foo": "bar"},
-			}}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Provisioner: "a-provisioner",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-}
+		// Microk8s
+		{
+			Name: "Test microk8s cloud finds provisioner storage",
+			InitialObjects: []runtime.Object{
+				microk8sNode,
+				microk8sStorageClass,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "microk8s",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: microk8sStorageClass,
+				OperatorStorageClass: microk8sStorageClass,
+			},
+		},
+		{
+			Name: "Test microk8s cloud prefers annotation storage",
+			InitialObjects: []runtime.Object{
+				microk8sNode,
+				microk8sStorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "microk8s",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: annotatedWorkloadStorage,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test microk8s cloud prefers annotation storage without workload",
+			InitialObjects: []runtime.Object{
+				microk8sNode,
+				annotatedOperatorStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "microk8s",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test microk8s cloud prefers nominated storage as first priority",
+			InitialObjects: []runtime.Object{
+				microk8sNode,
+				microk8sStorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+				nominatedStorage,
+			},
+			NominatedStorage: "nominated",
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "microk8s",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nominatedStorage,
+				OperatorStorageClass: nominatedStorage,
+			},
+		},
+		{
+			Name: "Test microk8s cloud with no found storage",
+			InitialObjects: []runtime.Object{
+				microk8sNode,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "microk8s",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: nil,
+			},
+		},
+		{
+			Name: "Test microk8s cloud doesn't use default storage",
+			InitialObjects: []runtime.Object{
+				microk8sNode,
+				defaultStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "microk8s",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: nil,
+			},
+		},
 
-func (s *K8sMetadataSuite) TestNoDefaultStorageClassesTooMany(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
+		// Azure
+		{
+			Name: "Test azure cloud finds provisioner storage",
+			InitialObjects: []runtime.Object{
+				azureNode,
+				azureStorageClass,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "azure",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: azureStorageClass,
+				OperatorStorageClass: azureStorageClass,
+			},
+		},
+		{
+			Name: "Test azure cloud prefers annotation storage",
+			InitialObjects: []runtime.Object{
+				azureNode,
+				azureStorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "azure",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: annotatedWorkloadStorage,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test azure cloud prefers annotation storage without workload",
+			InitialObjects: []runtime.Object{
+				azureNode,
+				annotatedOperatorStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "azure",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test azure cloud prefers nominated storage as first priority",
+			InitialObjects: []runtime.Object{
+				azureNode,
+				azureStorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+				nominatedStorage,
+			},
+			NominatedStorage: "nominated",
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "azure",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nominatedStorage,
+				OperatorStorageClass: nominatedStorage,
+			},
+		},
+		{
+			Name: "Test azure cloud with no found storage",
+			InitialObjects: []runtime.Object{
+				azureNode,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "azure",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: nil,
+			},
+		},
+		{
+			Name: "Test azure cloud with default storage",
+			InitialObjects: []runtime.Object{
+				azureNode,
+				defaultStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "azure",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: defaultStorage,
+				OperatorStorageClass: defaultStorage,
+			},
+		},
 
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
-				Provisioner: "a-provisioner",
-				Parameters:  map[string]string{"foo": "bar"},
-			}, {
-				Provisioner: "b-provisioner",
-				Parameters:  map[string]string{"foo": "bar"},
-			}}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, gc.IsNil)
-}
+		// GCE
+		{
+			Name: "Test gce cloud finds provisioner storage",
+			InitialObjects: []runtime.Object{
+				gceNode,
+				gceStorageClass,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "gce",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: gceStorageClass,
+				OperatorStorageClass: gceStorageClass,
+			},
+		},
+		{
+			Name: "Test gce cloud prefers annotation storage",
+			InitialObjects: []runtime.Object{
+				gceNode,
+				gceStorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "gce",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: annotatedWorkloadStorage,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test gce cloud prefers annotation storage without workload",
+			InitialObjects: []runtime.Object{
+				gceNode,
+				annotatedOperatorStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "gce",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test gce cloud prefers nominated storage as first priority",
+			InitialObjects: []runtime.Object{
+				gceNode,
+				gceStorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+				nominatedStorage,
+			},
+			NominatedStorage: "nominated",
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "gce",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nominatedStorage,
+				OperatorStorageClass: nominatedStorage,
+			},
+		},
+		{
+			Name: "Test gce cloud with no found storage",
+			InitialObjects: []runtime.Object{
+				gceNode,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "gce",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: nil,
+			},
+		},
+		{
+			Name: "Test gce cloud with default storage",
+			InitialObjects: []runtime.Object{
+				gceNode,
+				defaultStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "gce",
+				Regions:              set.NewStrings("wallyworld-region"),
+				WorkloadStorageClass: defaultStorage,
+				OperatorStorageClass: defaultStorage,
+			},
+		},
 
-func (s *K8sMetadataSuite) TestPreferDefaultStorageClass(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
-				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
-				Provisioner: "a-provisioner",
-				Parameters:  map[string]string{"foo": "bar"},
-			}, {
-				Provisioner: "b-provisioner",
-				Parameters:  map[string]string{"foo": "bar"},
-			}}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Provisioner: "a-provisioner",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-}
-
-func (s *K8sMetadataSuite) TestBetaDefaultStorageClass(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
-				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.beta.kubernetes.io/is-default-class": "true"}},
-				Provisioner: "a-provisioner",
-				Parameters:  map[string]string{"foo": "bar"},
-			}, {
-				Provisioner: "b-provisioner",
-				Parameters:  map[string]string{"foo": "bar"},
-			}}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Provisioner: "a-provisioner",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-}
-
-func (s *K8sMetadataSuite) TestUserSpecifiedStorageClasses(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
-				Labels: map[string]string{"manufacturer": "amazon_ec2"},
-			}}}}, nil),
-		s.mockStorageClass.EXPECT().Get(gomock.Any(), "foo", v1.GetOptions{}).
-			Return(&storagev1.StorageClass{
-				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
-				Provisioner: "a-provisioner",
-				Parameters:  map[string]string{"foo": "bar"},
-			}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
-				Provisioner: "kubernetes.io/aws-ebs",
-			}}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("foo")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Provisioner: "a-provisioner",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Provisioner: "kubernetes.io/aws-ebs",
-	})
-}
-
-func (s *K8sMetadataSuite) TestOperatorStorageClassNoDefault(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
-				Labels: map[string]string{"manufacturer": "amazon_ec2"},
-			}}}}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
-				Provisioner: "kubernetes.io/aws-ebs",
-			}, {
-				Provisioner: "kubernetes.io/aws-ebs",
-				Parameters:  map[string]string{"foo": "bar"},
-			}}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("")
-	c.Check(err, jc.ErrorIsNil)
-	// More than one match so need to be explicit for workload storage.
-	c.Check(metadata.NominatedStorageClass, gc.IsNil)
-	// Take the first match for operator storage.
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Provisioner: "kubernetes.io/aws-ebs",
-	})
-}
-
-func (s *K8sMetadataSuite) TestOperatorStorageClassPrefersDefault(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
-				Labels: map[string]string{"manufacturer": "amazon_ec2"},
-			}}}}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
-				Provisioner: "kubernetes.io/aws-ebs",
-			}, {
-				ObjectMeta:  v1.ObjectMeta{Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"}},
-				Provisioner: "kubernetes.io/aws-ebs",
-				Parameters:  map[string]string{"foo": "bar"},
-			}}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Provisioner: "kubernetes.io/aws-ebs",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Provisioner: "kubernetes.io/aws-ebs",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-}
-
-func (s *K8sMetadataSuite) TestAnnotatedWorkloadStorageClass(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
-				Labels: map[string]string{"manufacturer": "amazon_ec2"},
-			}}}}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "juju-preferred-workload-storage",
-					Annotations: map[string]string{
-						"juju.is/workload-storage": "true",
-					},
-				},
-				Provisioner: "kubernetes.io/aws-ebs",
-				Parameters:  map[string]string{"foo": "bar"},
-			}}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Name:        "juju-preferred-workload-storage",
-		Provisioner: "kubernetes.io/aws-ebs",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Name:        "juju-preferred-workload-storage",
-		Provisioner: "kubernetes.io/aws-ebs",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-}
-
-func (s *K8sMetadataSuite) TestAnnotatedWorkloadAndOperatorStorageClass(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	gomock.InOrder(
-		s.mockNodes.EXPECT().List(gomock.Any(), v1.ListOptions{Limit: 5}).
-			Return(&core.NodeList{Items: []core.Node{{ObjectMeta: v1.ObjectMeta{
-				Labels: map[string]string{"manufacturer": "amazon_ec2"},
-			}}}}, nil),
-		s.mockStorageClass.EXPECT().List(gomock.Any(), v1.ListOptions{}).
-			Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{
-				{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "juju-preferred-workload-storage",
-						Annotations: map[string]string{
-							"juju.is/workload-storage": "true",
-						},
-					},
-					Provisioner: "kubernetes.io/aws-ebs",
-					Parameters:  map[string]string{"foo": "bar"},
-				},
-				{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "juju-preferred-operator-storage",
-						Annotations: map[string]string{
-							"juju.is/operator-storage": "true",
-						},
-					},
-					Provisioner: "kubernetes.io/aws-ebs",
-					Parameters:  map[string]string{"foo": "bar"},
-				},
-			}}, nil),
-	)
-	metadata, err := s.broker.GetClusterMetadata("")
-	c.Check(err, jc.ErrorIsNil)
-	c.Check(metadata.NominatedStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Name:        "juju-preferred-workload-storage",
-		Provisioner: "kubernetes.io/aws-ebs",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-	c.Check(metadata.OperatorStorageClass, jc.DeepEquals, &k8s.StorageProvisioner{
-		Name:        "juju-preferred-operator-storage",
-		Provisioner: "kubernetes.io/aws-ebs",
-		Parameters:  map[string]string{"foo": "bar"},
-	})
-}
-
-func (s *K8sMetadataSuite) TestCheckDefaultWorkloadStorageUnknownCluster(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	err := s.broker.CheckDefaultWorkloadStorage("foo", nil)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-}
-
-func (s *K8sMetadataSuite) TestCheckDefaultWorkloadStorageNonpreferred(c *gc.C) {
-	ctrl := s.setupController(c)
-	defer ctrl.Finish()
-
-	err := s.broker.CheckDefaultWorkloadStorage("microk8s", &k8s.StorageProvisioner{Provisioner: "foo"})
-	c.Assert(err, jc.Satisfies, k8s.IsNonPreferredStorageError)
-	npse, ok := errors.Cause(err).(*k8s.NonPreferredStorageError)
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(npse.Provisioner, gc.Equals, "microk8s.io/hostpath")
-}
-
-func (s *K8sMetadataSuite) TestLabelSetToRequirements(c *gc.C) {
-	labels := map[string]string{
-		"foo":  "bar",
-		"foo1": "bar1",
+		// Other
+		{
+			Name: "Test other cloud prefers annotation storage",
+			InitialObjects: []runtime.Object{
+				newNode(map[string]string{}),
+				gceStorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "",
+				Regions:              set.NewStrings(),
+				WorkloadStorageClass: annotatedWorkloadStorage,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test other cloud prefers annotation storage without workload",
+			InitialObjects: []runtime.Object{
+				newNode(map[string]string{}),
+				annotatedOperatorStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "",
+				Regions:              set.NewStrings(),
+				WorkloadStorageClass: annotatedOperatorStorage,
+				OperatorStorageClass: annotatedOperatorStorage,
+			},
+		},
+		{
+			Name: "Test other cloud prefers nominated storage as first priority",
+			InitialObjects: []runtime.Object{
+				newNode(map[string]string{}),
+				gceStorageClass,
+				annotatedOperatorStorage,
+				annotatedWorkloadStorage,
+				nominatedStorage,
+			},
+			NominatedStorage: "nominated",
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "",
+				Regions:              set.NewStrings(),
+				WorkloadStorageClass: nominatedStorage,
+				OperatorStorageClass: nominatedStorage,
+			},
+		},
+		{
+			Name: "Test other cloud with no found storage",
+			InitialObjects: []runtime.Object{
+				newNode(map[string]string{}),
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "",
+				Regions:              set.NewStrings(),
+				WorkloadStorageClass: nil,
+				OperatorStorageClass: nil,
+			},
+		},
+		{
+			Name: "Test other cloud with default storage",
+			InitialObjects: []runtime.Object{
+				newNode(map[string]string{}),
+				defaultStorage,
+			},
+			Result: kubernetes.ClusterMetadata{
+				Cloud:                "",
+				Regions:              set.NewStrings(),
+				WorkloadStorageClass: defaultStorage,
+				OperatorStorageClass: defaultStorage,
+			},
+		},
 	}
-	var out []string
-	for _, v := range provider.LabelSetToRequirements(labels) {
-		out = append(out, v.String())
+
+	for _, test := range tests {
+		c.Logf("running test %s", test.Name)
+		clientSet := fake.NewSimpleClientset(test.InitialObjects...)
+
+		metadata, err := provider.GetClusterMetadata(
+			context.TODO(),
+			test.NominatedStorage,
+			clientSet.CoreV1().Nodes(),
+			clientSet.StorageV1().StorageClasses(),
+		)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(*metadata, jc.DeepEquals, test.Result)
 	}
-	c.Assert(strings.Join(out, ","), gc.DeepEquals, `foo=bar,foo1=bar1`)
 }
 
-func (s *K8sMetadataSuite) TestMergeSelectors(c *gc.C) {
-	selector1 := k8slabels.SelectorFromSet(map[string]string{"foo": "bar"})
-	selector2 := k8slabels.SelectorFromSet(map[string]string{"foo1": "bar1"})
-	c.Assert(provider.MergeSelectors(selector1, selector2), gc.DeepEquals,
-		k8slabels.SelectorFromSet(map[string]string{
-			"foo":  "bar",
-			"foo1": "bar1",
-		}),
+func (s *K8sMetadataSuite) TestNominatedStorageNotFound(c *gc.C) {
+	clientSet := fake.NewSimpleClientset(
+		newNode(map[string]string{}),
+		gceStorageClass,
+		annotatedOperatorStorage,
+		annotatedWorkloadStorage,
 	)
+
+	_, err := provider.GetClusterMetadata(
+		context.TODO(),
+		"my-nominated-storage",
+		clientSet.CoreV1().Nodes(),
+		clientSet.StorageV1().StorageClasses(),
+	)
+
+	var notFoundError *environs.NominatedStorageNotFound
+	c.Assert(err, gc.NotNil)
+	c.Assert(errors.As(err, &notFoundError), jc.IsTrue)
+	c.Assert(notFoundError.StorageName, gc.Equals, "my-nominated-storage")
 }

--- a/caas/kubernetes/provider/storage/metadata.go
+++ b/caas/kubernetes/provider/storage/metadata.go
@@ -1,0 +1,304 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import (
+	storagev1 "k8s.io/api/storage/v1"
+
+	"github.com/juju/juju/caas/kubernetes"
+	k8sannotations "github.com/juju/juju/core/annotations"
+)
+
+// PreferredStorageAny is an implementation of PreferredStorage that matches
+// any storage class which isn't nil
+type PreferredStorageAny struct{}
+
+// PreferredStorageNominated is an implementation of PreferredStorage that
+// matches based on a nominated storage class name.
+type PreferredStorageNominated struct {
+	// StorageClassName is the name to match to for a Kubernetes storage class.
+	StorageClassName string
+}
+
+// PreferredStorage defines a matcher that can inject it's own logic into the
+// preferred storage choice for a given storage class and decide if it's a match
+// to it's rules.
+type PreferredStorage interface {
+	// Name returns the name used to uniquely identify this preferred storage
+	// matcher.
+	Name() string
+
+	// Matches returns true if this matcher matches the supplied storage class.
+	Matches(*storagev1.StorageClass) bool
+}
+
+// PreferredStorageOperatorAnnotation is an implementation of PreferredStorage
+// that matches based on the operator storage annotation.
+type PreferredStorageOperatorAnnotation struct{}
+
+// PreferredStorageOperatorAnnotation is an implementation of PreferredStorage
+// that matches based on the workload storage annotation.
+type PreferredStorageWorkloadAnnotation struct{}
+
+// PreferredStorageDefault is an implementation of PreferredStorage that returns
+// true if the supplied Kubernetes storage class is considered the default
+// storage class for the cluster.
+type PreferredStorageDefault struct{}
+
+// PreferredStorageProvisioner is an implementation of PreferredStorage that
+// returns true if the supplied Kubernetes storage classes provisioner matches
+// this provisioner.
+type PreferredStorageProvisioner struct {
+	// NameVal defines the value return by this struct's Name() method
+	NameVal string
+
+	// Provisioner is the string to match on the storage classess provisioner
+	// member.
+	Provisioner string
+}
+
+// PreferredStorageList defined an ordered list of PreferredStorage matches to
+// test a given storage class against. The position of PreferredStorage matches
+// matches indicating they're preference.
+type PreferredStorageList []PreferredStorage
+
+const (
+	operatorStorageClassAnnotationKey = "juju.is/operator-storage"
+	workloadStorageClassAnnotationKey = "juju.is/workload-storage"
+)
+
+// PreferredStorageForCloud returns a PreferredStorageList for the supplied
+// cloud. If no cloud is found matching then a default list is provided.
+func PreferredOperatorStorageForCloud(cloud string) PreferredStorageList {
+	switch cloud {
+
+	// Microk8s
+	case kubernetes.K8sCloudMicrok8s:
+		return PreferredStorageList{
+			&PreferredStorageOperatorAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "hostpath",
+				Provisioner: "microk8s.io/hostpath",
+			},
+		}
+
+	// Azure
+	case kubernetes.K8sCloudAzure:
+		return PreferredStorageList{
+			&PreferredStorageOperatorAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "azure-disk",
+				Provisioner: "kubernetes.io/azure-disk",
+			},
+			&PreferredStorageDefault{},
+		}
+
+	// Google Cloud
+	case kubernetes.K8sCloudGCE:
+		return PreferredStorageList{
+			&PreferredStorageOperatorAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "gce-pd",
+				Provisioner: "kubernetes.io/gce-pd",
+			},
+			&PreferredStorageDefault{},
+		}
+
+	// AWS
+	case kubernetes.K8sCloudEC2:
+		return PreferredStorageList{
+			&PreferredStorageOperatorAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "aws-ebs",
+				Provisioner: "kubernetes.io/aws-ebs",
+			},
+			&PreferredStorageDefault{},
+		}
+
+	// Openstack
+	case kubernetes.K8sCloudOpenStack:
+		return PreferredStorageList{
+			&PreferredStorageOperatorAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "csi-cinder",
+				Provisioner: "csi-cinderplugin",
+			},
+			&PreferredStorageDefault{},
+		}
+
+	// Everything else
+	default:
+		return PreferredStorageList{
+			&PreferredStorageOperatorAnnotation{},
+			&PreferredStorageDefault{},
+			&PreferredStorageAny{},
+		}
+	}
+}
+
+// PreferredWorkloadStorageForCloud returns a PreferredStorageList for the
+// supplied cloud. If no cloud is found matching then a default list is
+// provided.
+func PreferredWorkloadStorageForCloud(cloud string) PreferredStorageList {
+	switch cloud {
+
+	// Microk8s
+	case kubernetes.K8sCloudMicrok8s:
+		return PreferredStorageList{
+			&PreferredStorageWorkloadAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "hostpath",
+				Provisioner: "microk8s.io/hostpath",
+			},
+		}
+
+	// Azure
+	case kubernetes.K8sCloudAzure:
+		return PreferredStorageList{
+			&PreferredStorageWorkloadAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "azure-disk",
+				Provisioner: "kubernetes.io/azure-disk",
+			},
+			&PreferredStorageDefault{},
+		}
+
+	// Google Cloud
+	case kubernetes.K8sCloudGCE:
+		return PreferredStorageList{
+			&PreferredStorageWorkloadAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "gce-pd",
+				Provisioner: "kubernetes.io/gce-pd",
+			},
+			&PreferredStorageDefault{},
+		}
+
+	// AWS
+	case kubernetes.K8sCloudEC2:
+		return PreferredStorageList{
+			&PreferredStorageWorkloadAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "aws-ebs",
+				Provisioner: "kubernetes.io/aws-ebs",
+			},
+			&PreferredStorageDefault{},
+		}
+
+	// Openstack
+	case kubernetes.K8sCloudOpenStack:
+		return PreferredStorageList{
+			&PreferredStorageWorkloadAnnotation{},
+			&PreferredStorageProvisioner{
+				NameVal:     "csi-cinder",
+				Provisioner: "csi-cinderplugin",
+			},
+			&PreferredStorageDefault{},
+		}
+
+	// Everything else
+	default:
+		return PreferredStorageList{
+			&PreferredStorageWorkloadAnnotation{},
+			&PreferredStorageDefault{},
+			&PreferredStorageAny{},
+		}
+	}
+}
+
+// Prepend adds the supplied PreferredStorage matcher to the beginning of this
+// list. This makes the PreferredStorage the highest storage matcher and the
+// most preferred. Useful for when a user has nominated their own storage.
+func (p PreferredStorageList) Prepend(ps PreferredStorage) PreferredStorageList {
+	return append(PreferredStorageList{ps}, p...)
+}
+
+// Matches implements PreferredStorage Matches.
+func (_ *PreferredStorageAny) Matches(sc *storagev1.StorageClass) bool {
+	if sc == nil {
+		return false
+	}
+	return true
+}
+
+// Matches is responsible for taking a Kubernetes StorageClass and testing it
+// against each PreferredStorage matcher in this slice. The first match this
+// function returns the preference of this storage class. Lower prefferences
+// are better. If no match is return -1 and false is returned.
+func (p PreferredStorageList) Matches(sc *storagev1.StorageClass) (int, bool) {
+	for i, val := range []PreferredStorage(p) {
+		if val.Matches(sc) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// Matches implements PreferredStorage Matches.
+func (p *PreferredStorageNominated) Matches(sc *storagev1.StorageClass) bool {
+	if p.StorageClassName == "" || sc == nil {
+		return false
+	}
+	return sc.Name == p.StorageClassName
+}
+
+// Matches implements PreferredStorage Matches.
+func (_ *PreferredStorageOperatorAnnotation) Matches(sc *storagev1.StorageClass) bool {
+	return k8sannotations.New(sc.GetAnnotations()).Has(
+		operatorStorageClassAnnotationKey, "true",
+	)
+}
+
+// Matches implements PreferredStorage Matches.
+func (_ *PreferredStorageWorkloadAnnotation) Matches(sc *storagev1.StorageClass) bool {
+	return k8sannotations.New(sc.GetAnnotations()).Has(
+		workloadStorageClassAnnotationKey, "true",
+	)
+}
+
+// Matches implements PreferredStorage Matches.
+func (p *PreferredStorageDefault) Matches(sc *storagev1.StorageClass) bool {
+	return k8sannotations.New(sc.GetAnnotations()).HasAny(
+		map[string]string{
+			"storageclass.kubernetes.io/is-default-class": "true",
+			// Older clusters still use the beta annotation.
+			"storageclass.beta.kubernetes.io/is-default-class": "true",
+		},
+	)
+}
+
+// Matches implements PreferredStorage Matches.
+func (p *PreferredStorageProvisioner) Matches(sc *storagev1.StorageClass) bool {
+	return sc.Provisioner == p.Provisioner
+}
+
+// Name implements PreferredStorage Name.
+func (_ *PreferredStorageAny) Name() string {
+	return "any"
+}
+
+// Name implements PreferredStorage Name.
+func (_ *PreferredStorageNominated) Name() string {
+	return "nominated-storage"
+}
+
+// Name implements PreferredStorage Name.
+func (_ *PreferredStorageOperatorAnnotation) Name() string {
+	return "operator-storage-annotation"
+}
+
+// Name implements PreferredStorage Name.
+func (_ *PreferredStorageWorkloadAnnotation) Name() string {
+	return "workload-storage-annotation"
+}
+
+// Name implements PreferredStorage Name.
+func (p *PreferredStorageDefault) Name() string {
+	return "cluster-default-storage"
+}
+
+// Name implements PreferredStorage Name.
+func (p *PreferredStorageProvisioner) Name() string {
+	return p.NameVal
+}

--- a/caas/kubernetes/provider/storage/metadata_test.go
+++ b/caas/kubernetes/provider/storage/metadata_test.go
@@ -1,0 +1,351 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage_test
+
+import (
+	gc "gopkg.in/check.v1"
+	storagev1 "k8s.io/api/storage/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/caas/kubernetes/provider/storage"
+)
+
+type metadataSuite struct{}
+
+var _ = gc.Suite(&metadataSuite{})
+
+func (*metadataSuite) TestPreferredStorageAny(c *gc.C) {
+	tests := []struct {
+		Name         string
+		StorageClass *storagev1.StorageClass
+		Result       bool
+	}{
+		{
+			Name: "Test Any Storage Class",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+				},
+			},
+			Result: true,
+		},
+		{
+			Name:         "Test Any Storage Class returns false for nil",
+			StorageClass: nil,
+			Result:       false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("running test %s", test.Name)
+		any := storage.PreferredStorageAny{}
+		c.Assert(any.Matches(test.StorageClass), gc.Equals, test.Result)
+	}
+}
+
+func (*metadataSuite) TestPreferredStorageNominated(c *gc.C) {
+	tests := []struct {
+		Name             string
+		StorageClass     *storagev1.StorageClass
+		NominatedStorage string
+		Result           bool
+	}{
+		{
+			Name: "Test match nominated storage",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "Test1",
+				},
+			},
+			NominatedStorage: "Test1",
+			Result:           true,
+		},
+		{
+			Name:             "Test match nominated storage nil class",
+			StorageClass:     nil,
+			NominatedStorage: "test2",
+			Result:           false,
+		},
+		{
+			Name: "Test empty string does not match",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "",
+				},
+			},
+			NominatedStorage: "",
+			Result:           false,
+		},
+		{
+			Name: "Test case sensitive does not match",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "AaBb",
+				},
+			},
+			NominatedStorage: "aabb",
+			Result:           false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("running test %s", test.Name)
+		nominated := storage.PreferredStorageNominated{StorageClassName: test.NominatedStorage}
+		c.Assert(nominated.Matches(test.StorageClass), gc.Equals, test.Result)
+	}
+}
+
+func (*metadataSuite) TestPreferredStorageOperatorAnnotation(c *gc.C) {
+	tests := []struct {
+		Name         string
+		StorageClass *storagev1.StorageClass
+		Result       bool
+	}{
+		{
+			Name: "Test operator storage annotation matches",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"juju.is/operator-storage": "true",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test operator storage doesn't match bad value",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"juju.is/operator-storage": "false",
+					},
+				},
+			},
+			Result: false,
+		},
+		{
+			Name: "Test operator storage doesn't match workload storage",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"juju.is/workload-storage": "true",
+					},
+				},
+			},
+			Result: false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("running test %s", test.Name)
+		annotation := storage.PreferredStorageOperatorAnnotation{}
+		c.Assert(annotation.Matches(test.StorageClass), gc.Equals, test.Result)
+	}
+}
+
+func (*metadataSuite) TestPreferredStorageWorkloadAnnotation(c *gc.C) {
+	tests := []struct {
+		Name         string
+		StorageClass *storagev1.StorageClass
+		Result       bool
+	}{
+		{
+			Name: "Test operator storage annotation matches",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"juju.is/workload-storage": "true",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test operator storage doesn't match bad value",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"juju.is/workload-storage": "false",
+					},
+				},
+			},
+			Result: false,
+		},
+		{
+			Name: "Test operator storage doesn't match operator storage",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"juju.is/operator-storage": "true",
+					},
+				},
+			},
+			Result: false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("running test %s", test.Name)
+		annotation := storage.PreferredStorageWorkloadAnnotation{}
+		c.Assert(annotation.Matches(test.StorageClass), gc.Equals, test.Result)
+	}
+}
+
+func (*metadataSuite) TestPreferredStorageDefault(c *gc.C) {
+	tests := []struct {
+		Name         string
+		StorageClass *storagev1.StorageClass
+		Result       bool
+	}{
+		{
+			Name: "Test default storage matches",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"storageclass.kubernetes.io/is-default-class": "true",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test default storage beta matches",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"storageclass.beta.kubernetes.io/is-default-class": "true",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test default storage both annotations match",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"storageclass.beta.kubernetes.io/is-default-class": "true",
+						"storageclass.kubernetes.io/is-default-class":      "true",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test default storage both annotations different order match",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"storageclass.kubernetes.io/is-default-class":      "true",
+						"storageclass.beta.kubernetes.io/is-default-class": "true",
+					},
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "Test default storage type sensitive annotation",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"Storageclass.kubernetes.io/is-default-class": "true",
+					},
+				},
+			},
+			Result: false,
+		},
+		{
+			Name: "Test default storage doesn't match",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						"junk": "true",
+					},
+				},
+			},
+			Result: false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("running test %s", test.Name)
+		defStorage := storage.PreferredStorageDefault{}
+		c.Assert(defStorage.Matches(test.StorageClass), gc.Equals, test.Result)
+	}
+}
+
+func (*metadataSuite) TestPreferredStorageProvisioner(c *gc.C) {
+	tests := []struct {
+		Name         string
+		StorageClass *storagev1.StorageClass
+		Provisioner  string
+		Result       bool
+	}{
+		{
+			Name: "Test provisioner empty string matches",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+				},
+				Provisioner: "",
+			},
+			Provisioner: "",
+			Result:      true,
+		},
+		{
+			Name: "Test Azure provisioner",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+				},
+				Provisioner: "kubernetes.io/azure-disk",
+			},
+			Provisioner: "kubernetes.io/azure-disk",
+			Result:      true,
+		},
+		{
+			Name: "Test provisioner doesn't match 1",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+				},
+				Provisioner: "kubernetes.io/azure-disk",
+			},
+			Provisioner: "",
+			Result:      false,
+		},
+		{
+			Name: "Test provisioner doesn't match 2",
+			StorageClass: &storagev1.StorageClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test1",
+				},
+				Provisioner: "kubernetes.io/azure-disk",
+			},
+			Provisioner: "junk",
+			Result:      false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("running test %s", test.Name)
+		provisioner := storage.PreferredStorageProvisioner{
+			NameVal:     "test-storage-provisioner",
+			Provisioner: test.Provisioner,
+		}
+		c.Assert(provisioner.Matches(test.StorageClass), gc.Equals, test.Result)
+	}
+}

--- a/caas/kubernetes/provider/volume.go
+++ b/caas/kubernetes/provider/volume.go
@@ -161,7 +161,7 @@ func (k *kubernetesClient) EnsureStorageProvisioner(cfg k8s.StorageProvisioner) 
 	// First see if the named storage class exists.
 	sc, err := k.getStorageClass(cfg.Name)
 	if err == nil {
-		return toCaaSStorageProvisioner(*sc), true, nil
+		return toCaaSStorageProvisioner(sc), true, nil
 	}
 	if !k8serrors.IsNotFound(err) {
 		return nil, false, errors.Annotatef(err, "getting storage class %q", cfg.Name)
@@ -197,7 +197,7 @@ func (k *kubernetesClient) EnsureStorageProvisioner(cfg k8s.StorageProvisioner) 
 	if err != nil {
 		return nil, false, errors.Annotatef(err, "creating storage class %q", cfg.Name)
 	}
-	return toCaaSStorageProvisioner(*sc), false, nil
+	return toCaaSStorageProvisioner(sc), false, nil
 }
 
 // maybeGetVolumeClaimSpec returns a persistent volume claim spec for the given

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -23,6 +23,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
+	storagev1 "k8s.io/api/storage/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	k8s "github.com/juju/juju/caas/kubernetes"
@@ -33,6 +35,7 @@ import (
 	"github.com/juju/juju/cmd/juju/caas"
 	"github.com/juju/juju/cmd/juju/caas/mocks"
 	jujucmdcloud "github.com/juju/juju/cmd/juju/cloud"
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc/params"
 )
@@ -313,7 +316,9 @@ func (s *addCAASSuite) SetUpTest(c *gc.C) {
 
 	defaultClusterMetadata := &k8s.ClusterMetadata{
 		Cloud: "gce", Regions: set.NewStrings("us-east1"),
-		OperatorStorageClass: &k8s.StorageProvisioner{Name: "operator-sc"},
+		OperatorStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "operator-sc"},
+		},
 	}
 	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
 		CallMocker: jujutesting.NewCallMocker(logger),
@@ -900,8 +905,15 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRegions(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	var result k8s.ClusterMetadata
-	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(&result, nil)
+	result := &k8s.ClusterMetadata{
+		OperatorStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "mystorage"},
+		},
+		WorkloadStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "mystorage"},
+		},
+	}
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(result, nil)
 
 	err := SetKubeConfigData(kubeConfigStr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -910,10 +922,9 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRegions(c *gc.C) {
 		command := s.makeCommand(c, true, false, true)
 		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--client", "-c", "foo")
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s"
-with operator storage provisioned by the workload storage class.
+		c.Assert(strings.Trim(cmdtesting.Stdout(ctx), "\n"), gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s".
 You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
-	}, "other", "", "", testData{client: true, controller: true})
+	}, "other", "mystorage", "mystorage", testData{client: true, controller: true})
 }
 
 func (s *addCAASSuite) TestGatherClusterMetadataUnknownError(c *gc.C) {
@@ -929,13 +940,10 @@ func (s *addCAASSuite) TestGatherClusterMetadataUnknownError(c *gc.C) {
 
 	command := s.makeCommand(c, true, false, true)
 	_, err = s.runCommand(c, nil, command, "myk8s", "--cluster-name", "myk8s", "-c", "foo")
-	expectedErr := `
-	Juju needs to query the k8s cluster to ensure that the recommended
-	storage defaults are available and to detect the cluster's cloud/region.
-	This was not possible in this case because the cloud "foo" is not known to Juju.
-	Run add-k8s again, using --storage=<name> to specify the storage class to use.
-`[1:]
-	c.Assert(err, gc.ErrorMatches, expectedErr)
+	c.Assert(err, gc.ErrorMatches, `	No recommended storage configuration is defined on this cluster.
+	Run add-k8s again with --storage=<name> and Juju will use the
+	specified storage class.
+`)
 }
 
 func (s *addCAASSuite) TestGatherClusterMetadataNoStorageError(c *gc.C) {
@@ -948,27 +956,25 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoStorageError(c *gc.C) {
 
 	command := s.makeCommand(c, true, false, true)
 	_, err = s.runCommand(c, nil, command, "myk8s", "--cluster-name", "myk8s", "-c", "foo")
-	expectedErr := `
-	Juju needs to know what storage class to use to provision workload storage.
-	Run add-k8s again, using --storage=<name> to specify the storage class to use.
-`[1:]
-	c.Assert(err, gc.ErrorMatches, expectedErr)
+	c.Assert(err, gc.ErrorMatches, `	No recommended storage configuration is defined on this cluster.
+	Run add-k8s again with --storage=<name> and Juju will use the
+	specified storage class.
+`)
 }
 
 func (s *addCAASSuite) TestGatherClusterMetadataUserStorage(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	var result k8s.ClusterMetadata
-	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(&result, nil)
-	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("foo"))
-	storageProvisioner := &k8s.StorageProvisioner{
-		Name:        "mystorage",
-		Provisioner: "kubernetes.io/gce-pd",
+	result := &k8s.ClusterMetadata{
+		OperatorStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "mystorage"},
+		},
+		WorkloadStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "mystorage"},
+		},
 	}
-	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", k8s.StorageProvisioner{
-		Name: "mystorage",
-	}).Returns(storageProvisioner, nil)
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(result, nil)
 
 	err := SetKubeConfigData(kubeConfigStr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -984,8 +990,8 @@ You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
 }
 
 func (s *addCAASSuite) TestGatherClusterMetadataNoRecommendedStorageError(c *gc.C) {
-	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(
-		&k8s.NonPreferredStorageError{PreferredStorage: k8s.PreferredStorage{Name: "disk"}})
+	result := k8s.ClusterMetadata{}
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(&result, nil)
 
 	err := SetKubeConfigData(kubeConfigStr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -995,8 +1001,7 @@ func (s *addCAASSuite) TestGatherClusterMetadataNoRecommendedStorageError(c *gc.
 	expectedErr := `
 	No recommended storage configuration is defined on this cluster.
 	Run add-k8s again with --storage=<name> and Juju will use the
-	specified storage class or create a storage-class using the recommended
-	"disk" provisioner.
+	specified storage class.
 `[1:]
 	c.Assert(err, gc.ErrorMatches, expectedErr)
 }
@@ -1008,14 +1013,16 @@ func (s *addCAASSuite) TestUnknownClusterExistingStorageClass(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("cluster"))
-	storageProvisioner := &k8s.StorageProvisioner{
-		Name:        "mystorage",
-		Provisioner: "kubernetes.io/gce-pd",
+	defaultClusterMetadata := &k8s.ClusterMetadata{
+		Cloud: cloudRegion,
+		OperatorStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "mystorage"},
+		},
+		WorkloadStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "mystorage"},
+		},
 	}
-	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", k8s.StorageProvisioner{
-		Name: "mystorage",
-	}).Returns(storageProvisioner, nil)
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(defaultClusterMetadata, nil)
 
 	err := SetKubeConfigData(kubeConfigStr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1055,9 +1062,7 @@ func (s *addCAASSuite) assertCreateDefaultStorageProvisioner(c *gc.C, expectedMs
 	defer ctrl.Finish()
 
 	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(
-		&k8s.NonPreferredStorageError{PreferredStorage: k8s.PreferredStorage{
-			Name:        "gce disk",
-			Provisioner: "kubernetes.io/gce-pd"}})
+		&environs.PreferredStorageNotFound{"error"})
 	storageProvisioner := &k8s.StorageProvisioner{
 		Name:        "mystorage",
 		Provisioner: "kubernetes.io/gce-pd",
@@ -1090,72 +1095,19 @@ func (s *addCAASSuite) assertCreateDefaultStorageProvisioner(c *gc.C, expectedMs
 	}, cloudRegion, "mystorage", "mystorage", t)
 }
 
-func (s *addCAASSuite) TestCreateDefaultStorageProvisionerBoth(c *gc.C) {
-	s.assertCreateDefaultStorageProvisioner(c,
-		`k8s substrate "myk8s" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`,
-		testData{client: true, controller: true})
-}
-
-func (s *addCAASSuite) TestCreateDefaultStorageProvisionerClientOnly(c *gc.C) {
-	s.assertCreateDefaultStorageProvisioner(c,
-		`k8s substrate "myk8s" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`,
-		testData{client: true})
-}
-
-func (s *addCAASSuite) TestCreateDefaultStorageProvisionerControllerOnly(c *gc.C) {
-	s.assertCreateDefaultStorageProvisioner(c,
-		`k8s substrate "myk8s" added as cloud "myk8s" with gce disk default storage provisioned by the existing "mystorage" storage class on controller foo.`,
-		testData{controller: true})
-}
-
-func (s *addCAASSuite) TestCreateCustomStorageProvisioner(c *gc.C) {
-	s.fakeCloudAPI.isCloudRegionRequired = true
-	s.fakeK8sClusterMetadataChecker.existingSC = false
-	cloudRegion := "gce/us-east1"
-
-	ctrl := s.setupBroker(c)
-	defer ctrl.Finish()
-
-	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(
-		&k8s.NonPreferredStorageError{PreferredStorage: k8s.PreferredStorage{Name: "gce disk"}})
-	storageProvisioner := &k8s.StorageProvisioner{
-		Name:        "mystorage",
-		Provisioner: "my disk provisioner",
-	}
-	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", k8s.StorageProvisioner{
-		Name: "mystorage",
-	}).Returns(storageProvisioner, nil)
-
-	err := SetKubeConfigData(kubeConfigStr)
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertAddCloudResult(c, func() {
-		command := s.makeCommand(c, true, false, true)
-		ctx, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--cluster-name", "myk8s", "--storage", "mystorage", "--client")
-		c.Assert(err, jc.ErrorIsNil)
-		result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
-		result = strings.Replace(result, "\n", " ", -1)
-		c.Assert(result, gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s" with storage provisioned by the new "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
-	}, cloudRegion, "mystorage", "mystorage", testData{client: true, controller: true})
-}
-
 func (s *addCAASSuite) TestFoundStorageProvisionerViaAnnationForMAASWIthoutStorageOptionProvided(c *gc.C) {
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
-	storageProvisioner := &k8s.StorageProvisioner{
-		Name:        "mystorage",
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  meta.ObjectMeta{Name: "mystorage"},
 		Provisioner: "my disk provisioner",
 	}
 	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(&k8s.ClusterMetadata{
-		Cloud:                 "maas",
-		OperatorStorageClass:  storageProvisioner,
-		NominatedStorageClass: storageProvisioner,
+		Cloud:                "maas",
+		OperatorStorageClass: sc,
+		WorkloadStorageClass: sc,
 	}, nil)
-	s.fakeK8sClusterMetadataChecker.Call("CheckDefaultWorkloadStorage").Returns(errors.NotFoundf("no sc config for this cloud type"))
-	s.fakeK8sClusterMetadataChecker.Call("EnsureStorageProvisioner", k8s.StorageProvisioner{
-		Name: "mystorage",
-	}).Returns(storageProvisioner, nil)
 
 	err := SetKubeConfigData(kubeConfigStr)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1166,7 +1118,7 @@ func (s *addCAASSuite) TestFoundStorageProvisionerViaAnnationForMAASWIthoutStora
 		c.Assert(err, jc.ErrorIsNil)
 		result := strings.Trim(cmdtesting.Stdout(ctx), "\n")
 		result = strings.Replace(result, "\n", " ", -1)
-		c.Assert(result, gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s" with storage provisioned by the existing "mystorage" storage class. You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
+		c.Assert(result, gc.Equals, `k8s substrate "myk8s" added as cloud "myk8s". You can now bootstrap to this cloud by running 'juju bootstrap myk8s'.`)
 	}, "maas", "mystorage", "mystorage", testData{client: true, controller: true})
 }
 
@@ -1179,6 +1131,14 @@ func (s *addCAASSuite) TestLocalOnly(c *gc.C) {
 
 	err := SetKubeConfigData(kubeConfigStr)
 	c.Assert(err, jc.ErrorIsNil)
+
+	defaultClusterMetadata := &k8s.ClusterMetadata{
+		Cloud: cloudRegion,
+		OperatorStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "operator-sc"},
+		},
+	}
+	s.fakeK8sClusterMetadataChecker.Call("GetClusterMetadata").Returns(defaultClusterMetadata, nil)
 
 	s.assertAddCloudResult(c, func() {
 		command := s.makeCommand(c, true, false, true)

--- a/cmd/juju/caas/update_test.go
+++ b/cmd/juju/caas/update_test.go
@@ -16,6 +16,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
+	storagev1 "k8s.io/api/storage/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	k8s "github.com/juju/juju/caas/kubernetes"
 	"github.com/juju/juju/caas/kubernetes/clientconfig"
@@ -117,7 +119,9 @@ func (s *updateCAASSuite) SetUpTest(c *gc.C) {
 
 	defaultClusterMetadata := &k8s.ClusterMetadata{
 		Cloud: "gce", Regions: set.NewStrings("us-east1"),
-		OperatorStorageClass: &k8s.StorageProvisioner{Name: "operator-sc"},
+		OperatorStorageClass: &storagev1.StorageClass{
+			ObjectMeta: meta.ObjectMeta{Name: "operator-sc"},
+		},
 	}
 	s.fakeK8sClusterMetadataChecker = &fakeK8sClusterMetadataChecker{
 		CallMocker: jujutesting.NewCallMocker(logger),

--- a/environs/errors.go
+++ b/environs/errors.go
@@ -4,6 +4,8 @@
 package environs
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 )
 
@@ -40,4 +42,29 @@ func IsAvailabilityZoneIndependent(err error) bool {
 		return err.AvailabilityZoneIndependent()
 	}
 	return false
+}
+
+// PreferredStorageNotFound is an error that indicates to the caller the environ
+// was unable to completes it's operation because it could not find the storage
+// it prefers for the operation. i.e aws block storage or Kubernetes cluster
+// storage.
+type PreferredStorageNotFound struct {
+	Message string
+}
+
+// NominatedStorageNotFound is an error that indicates the storage the user
+// nominated to use for a specific operation was not found and needs to be
+// checked for existence or typo's.
+type NominatedStorageNotFound struct {
+	StorageName string
+}
+
+// Error implements the error interface
+func (p *PreferredStorageNotFound) Error() string {
+	return p.Message
+}
+
+// Error implements the error interface
+func (n *NominatedStorageNotFound) Error() string {
+	return fmt.Sprintf("nominated storage %q not found", n.StorageName)
 }

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -2088,10 +2088,10 @@ func updateKubernetesStorageConfig(st *State) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if metadata.NominatedStorageClass == nil {
+		if metadata.WorkloadStorageClass == nil {
 			return nil
 		}
-		operatorStorage = metadata.NominatedStorageClass.Name
+		operatorStorage = metadata.WorkloadStorageClass.Name
 		err = st.updateConfigDefaults(model.CloudName(), cloud.Attrs{
 			k8sconstants.OperatorStorageKey: operatorStorage,
 			k8sconstants.WorkloadStorageKey: operatorStorage, // use same storage for both

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/juju/juju/caas"
 	k8s "github.com/juju/juju/caas/kubernetes"
@@ -2770,8 +2772,15 @@ type fakeBroker struct {
 
 func (f *fakeBroker) GetClusterMetadata(storageClass string) (result *k8s.ClusterMetadata, err error) {
 	return &k8s.ClusterMetadata{
-		NominatedStorageClass: &k8s.StorageProvisioner{
-			Name: "storage-provisioner",
+		OperatorStorageClass: &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "storage-provisioner",
+			},
+		},
+		WorkloadStorageClass: &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "storage-provisioner",
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
# Introduction

What kicked off this change was the Juju was know longer able to
bootstrap to Azure clusters because the predefined notion Juju had about
what storage to use by default was know longer correct because Azure had
changed the naming of their provisioner's.

Upon closer inspection of the logic the code had a number of short
comings and bugs that did not allow it operate in the manner it was
originally intended to do.

This change is big but simplifies the logic used for finding storage in
Kubernetes now. Specifically cluster storage is now laid out
in provider preferences where the provider can find the best matching
storage class based on it's list. This allows the underlying cloud code
to be more agile and tolerate change from the underlying cloud and also
enshrines the logic used previously into a more robust readable
solution.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

This is a pretty substantial change and manual testing is fine but we really want to check the unit tests here because they setup a fake Kubernetes with the different pre states we are expecting to encounter. What we want to do is check that these pre-state's are matched to post states from GetClusterMetadata that we expect to see.

If a manual test is required then you may bootstrap against a fresh Azure Kubernetes cluster to check that bootstrapping is successful as this was the original problem that inspired this work.

## Documentation changes

Currently investigating. Will update PR once I have looked.

## Bug reference

Original bug as been fixed on the 2.9 branch. This was work to make the overall fix better but not introduce to much churn on the 2.9 stream.
