### PR TITLE
[JUJU-1253] Restore stdin support for config commands

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -215,7 +215,7 @@ func (c *configCommand) Run(ctx *cmd.Context) error {
 		switch action {
 		case config.GetOne:
 			err = c.getConfig(client, ctx)
-		case config.Set:
+		case config.SetArgs:
 			err = c.setConfig(client, ctx)
 		case config.SetFile:
 			err = c.setConfigFile(client, ctx)
@@ -350,20 +350,21 @@ func (c *configCommand) getAllConfig(client ApplicationAPI, ctx *cmd.Context) er
 func (c *configCommand) validateValues(ctx *cmd.Context) (map[string]string, error) {
 	settings := map[string]string{}
 	for k, v := range c.configBase.ValsToSet {
+		vStr := fmt.Sprint(v) // `v` is generally a string
 		//empty string is also valid as a setting value
-		if v == "" {
-			settings[k] = v
+		if vStr == "" {
+			settings[k] = vStr
 			continue
 		}
 
-		if v[0] != '@' {
-			if !utf8.ValidString(v) {
+		if vStr[0] != '@' {
+			if !utf8.ValidString(vStr) {
 				return nil, errors.Errorf("value for option %q contains non-UTF-8 sequences", k)
 			}
-			settings[k] = v
+			settings[k] = vStr
 			continue
 		}
-		nv, err := utils.ReadValue(ctx, c.Filesystem(), v[1:])
+		nv, err := utils.ReadValue(ctx, c.Filesystem(), vStr[1:])
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/cmd/juju/controller/config_test.go
+++ b/cmd/juju/controller/config_test.go
@@ -202,6 +202,21 @@ func (s *ConfigSuite) TestSettingFromFile(c *gc.C) {
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{"juju-ha-space": "value"})
 }
 
+func (s *ConfigSuite) TestSettingFromStdin(c *gc.C) {
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = strings.NewReader("juju-ha-space: value\n")
+	var api fakeControllerAPI
+	code := cmd.Main(controller.NewConfigCommandForTest(&api, s.store), ctx,
+		[]string{"--file", "-"})
+
+	c.Assert(code, gc.Equals, 0)
+	output := strings.TrimSpace(cmdtesting.Stdout(ctx))
+	c.Assert(output, gc.Equals, "")
+	stderr := strings.TrimSpace(cmdtesting.Stderr(ctx))
+	c.Assert(stderr, gc.Equals, "")
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{"juju-ha-space": "value"})
+}
+
 func (s *ConfigSuite) TestOverrideFileFromArgs(c *gc.C) {
 	path := writeFile(c, "yaml", "juju-ha-space: value\naudit-log-max-backups: 2\n")
 	var api fakeControllerAPI

--- a/cmd/juju/model/config_test.go
+++ b/cmd/juju/model/config_test.go
@@ -5,6 +5,7 @@ package model_test
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -214,6 +215,26 @@ func (s *ConfigCommandSuite) TestSetFromFile(c *gc.C) {
 
 	_, err = s.run(c, "--file", configFile)
 	c.Assert(err, jc.ErrorIsNil)
+	expected := map[string]interface{}{
+		"special": "extra",
+		"name":    "test-model",
+		"running": true,
+	}
+	c.Assert(s.fake.values, jc.DeepEquals, expected)
+}
+
+func (s *ConfigCommandSuite) TestSetFromStdin(c *gc.C) {
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = strings.NewReader("special: extra\n")
+	code := cmd.Main(model.NewConfigCommandForTest(s.fake), ctx,
+		[]string{"--file", "-"})
+
+	c.Assert(code, gc.Equals, 0)
+	output := strings.TrimSpace(cmdtesting.Stdout(ctx))
+	c.Assert(output, gc.Equals, "")
+	stderr := strings.TrimSpace(cmdtesting.Stderr(ctx))
+	c.Assert(stderr, gc.Equals, "")
+
 	expected := map[string]interface{}{
 		"special": "extra",
 		"name":    "test-model",


### PR DESCRIPTION
In some previous refactoring of the config commands, I had inadvertently removed stdin support. This PR restores it and adds some unit tests.

All config commands now support reading from stdin using the option `--file -`. Concretely, this looks like
```
juju config app1 | juju config app2 --file -

juju model-config -m m1 --format=yaml | juju model-config -m m2 --file - --ignore-read-only-fields

juju model-defaults -c c1 --format=yaml | juju model-defaults -c c2 --file -

juju controller-config -c c1 --format=yaml | juju controller-config -c c2 --file - --ignore-read-only-fields
```

Behind the scenes, there have been some changes. The main one is adding a `ReadFile` method to `ConfigCommandBase`, which child commands can use to process files. This allows us to combine the `setConfig` and `setConfigFile` methods in the child commands, removing a lot of duplicate/similar code.