### PR TITLE
[JUJU-1238] Fix microk8s addons check for strictly confined microk8s;

### DIFF
--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -10,7 +10,6 @@ import (
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	jujuos "github.com/juju/os/v2"
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/exec"
 	"gopkg.in/yaml.v2"
@@ -307,43 +306,7 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 	return cld, nil
 }
 
-func checkMicrok8sUserGroupSetup(cmdRunner CommandRunner) error {
-	if jujuos.HostOS() == jujuos.Windows || jujuos.HostOS() == jujuos.OSX {
-		// The microk8s on windows and macOS is running on a vm managed by multipass.
-		// Even the vm does not have the user group properly configured but it is not
-		// a problem because microk8s CLI uses `multipass exec` with sudo to run the commands.
-		// https://github.com/ubuntu/microk8s/blob/master/installer/vm_providers/_multipass/_multipass.py#L50
-		return nil
-	}
-	resp, err := cmdRunner.RunCommands(exec.RunParams{
-		Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`,
-	})
-	if err != nil {
-		return errors.Annotate(err, "checking microk8s setup")
-	}
-	if resp.Code != 0 {
-		user, _ := utils.OSUsername()
-		if user == "" {
-			user = "<username>"
-		}
-		return errors.Errorf(`
-The microk8s user group is created during the microk8s snap installation.
-Users in that group are granted access to microk8s commands and this
-is needed for Juju to be able to interact with microk8s.
-
-Add yourself to that group before trying again:
-	sudo usermod -a -G microk8s %s  # classic confined microk8s.
-	sudo usermod -a -G snap_microk8s %s  # strictly confined microk8s.
-`[1:], user)
-	}
-	return nil
-}
-
 func ensureMicroK8sSuitable(cmdRunner CommandRunner) error {
-	if err := checkMicrok8sUserGroupSetup(cmdRunner); err != nil {
-		return errors.Trace(err)
-	}
-
 	status, err := microK8sStatus(cmdRunner)
 	if err != nil {
 		return errors.Trace(err)

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	jujuclock "github.com/juju/clock"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jujuos "github.com/juju/os/v2"
 	"github.com/juju/utils/v3"
@@ -315,7 +316,7 @@ func checkMicrok8sUserGroupSetup(cmdRunner CommandRunner) error {
 		return nil
 	}
 	resp, err := cmdRunner.RunCommands(exec.RunParams{
-		Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`,
+		Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`,
 	})
 	if err != nil {
 		return errors.Annotate(err, "checking microk8s setup")
@@ -331,7 +332,8 @@ Users in that group are granted access to microk8s commands and this
 is needed for Juju to be able to interact with microk8s.
 
 Add yourself to that group before trying again:
-	sudo usermod -a -G microk8s %s
+	sudo usermod -a -G microk8s %s  # classic confined microk8s.
+	sudo usermod -a -G snap_microk8s %s  # strictly confined microk8s.
 `[1:], user)
 	}
 	return nil
@@ -346,19 +348,20 @@ func ensureMicroK8sSuitable(cmdRunner CommandRunner) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	var requiredAddons []string
-	if storageStatus, ok := status.Addons["storage"]; ok {
-		if storageStatus != "enabled" {
-			requiredAddons = append(requiredAddons, "storage")
+	requiredAddons := set.NewStrings("dns", "storage")
+	for _, addon := range status.Addons {
+		if addon.Name == "dns" && addon.Status == "enabled" {
+			requiredAddons.Remove("dns")
+		}
+		if (addon.Name == "storage" || addon.Name == "hostpath-storage") && addon.Status == "enabled" {
+			requiredAddons.Remove("storage")
 		}
 	}
-	if dns, ok := status.Addons["dns"]; ok {
-		if dns != "enabled" {
-			requiredAddons = append(requiredAddons, "dns")
-		}
-	}
-	if len(requiredAddons) > 0 {
-		return errors.Errorf("required addons not enabled for microk8s, run 'microk8s enable %s'", strings.Join(requiredAddons, " "))
+
+	if requiredAddons.Size() > 0 {
+		return errors.Errorf("required addons not enabled for microk8s, run 'microk8s enable %s'",
+			strings.Join(requiredAddons.SortedValues(), " "),
+		)
 	}
 	return nil
 }
@@ -366,7 +369,7 @@ func ensureMicroK8sSuitable(cmdRunner CommandRunner) error {
 func microK8sStatus(cmdRunner CommandRunner) (microk8sStatus, error) {
 	var status microk8sStatus
 	result, err := cmdRunner.RunCommands(exec.RunParams{
-		Commands: "microk8s status --wait-ready --timeout 15 --yaml",
+		Commands: "microk8s status --wait-ready --timeout 15 --format yaml",
 	})
 	if err != nil {
 		return status, errors.Trace(err)
@@ -394,5 +397,10 @@ func microK8sStatus(cmdRunner CommandRunner) (microk8sStatus, error) {
 }
 
 type microk8sStatus struct {
-	Addons map[string]string `yaml:"addons"`
+	Addons []microk8sAddon `yaml:"addons"`
+}
+
+type microk8sAddon struct {
+	Name   string `yaml:"name"`
+	Status string `yaml:"status"`
 }

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -5,8 +5,6 @@ package provider_test
 
 import (
 	"fmt"
-	"runtime"
-	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
@@ -111,12 +109,6 @@ func (s *cloudSuite) SetUpTest(c *gc.C) {
 func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	p := s.getProvider()
 	cloudFinalizer := p.(environs.CloudFinalizer)
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
@@ -153,12 +145,6 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 	p := s.getProvider()
 	cloudFinalizer := p.(environs.CloudFinalizer)
 
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
@@ -192,12 +178,6 @@ func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
@@ -206,12 +186,6 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccessNew(c *gc.C) {
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
@@ -220,12 +194,6 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccessNew(c *gc.C) {
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
@@ -234,12 +202,6 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageNewDisabled(c *gc.C) {
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
@@ -248,31 +210,11 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageNewDisabled(c *gc.C) {
 }
 
 func (s *cloudSuite) TestEnsureMicroK8sSuitableDNSDisabled(c *gc.C) {
-	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
-		s.runner.Call(
-			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
-			&exec.ExecResponse{Code: 0}, nil)
-	}
 	s.runner.Call(
 		"RunCommands",
 		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusDNSDisabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable dns'`)
-}
-
-func (s *cloudSuite) TestEnsureMicroK8sSuitableNotInGroup(c *gc.C) {
-	if runtime.GOOS == "windows" {
-		c.Skip("no need to check user group setup for windows")
-	}
-	s.runner.Call(
-		"RunCommands",
-		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
-		&exec.ExecResponse{Code: 1}, nil)
-	err := provider.EnsureMicroK8sSuitable(s.runner)
-	c.Assert(err, gc.NotNil)
-	c.Assert(strings.Replace(err.Error(), "\n", "", -1),
-		gc.Matches, `The microk8s user group is created during the microk8s snap installation.*`)
 }
 
 type mockContext struct {

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/caas"
 	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	"github.com/juju/juju/caas/kubernetes/provider"
-	"github.com/juju/juju/cloud"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 )
@@ -31,50 +30,50 @@ var microk8sStatusEnabled = `
 microk8s:
   running: true
 addons:
-  jaeger: disabled
-  fluentd: disabled
-  gpu: disabled
-  storage: enabled
-  registry: disabled
-  ingress: disabled
-  dns: enabled
-  metrics-server: disabled
-  prometheus: disabled
-  istio: disabled
-  dashboard: disabled
+  - name: storage
+    status: enabled
+  - name: dns
+    status: enabled
+`
+
+var microk8sStatusNewEnabled = `
+microk8s:
+  running: true
+addons:
+  - name: hostpath-storage
+    status: enabled
+  - name: dns
+    status: enabled
 `
 
 var microk8sStatusStorageDisabled = `
 microk8s:
   running: true
 addons:
-  jaeger: disabled
-  fluentd: disabled
-  gpu: disabled
-  storage: disabled
-  registry: disabled
-  ingress: disabled
-  dns: enabled
-  metrics-server: disabled
-  prometheus: disabled
-  istio: disabled
-  dashboard: disabled
+  - name: storage
+    status: disabled
+  - name: dns
+    status: enabled
 `
+
+var microk8sStatusStorageNewDisabled = `
+microk8s:
+  running: true
+addons:
+  - name: hostpath-storage
+    status: disabled
+  - name: dns
+    status: enabled
+`
+
 var microk8sStatusDNSDisabled = `
 microk8s:
   running: true
 addons:
-  jaeger: disabled
-  fluentd: disabled
-  gpu: disabled
-  storage: enabled
-  registry: disabled
-  ingress: disabled
-  dns: disabled
-  metrics-server: disabled
-  prometheus: disabled
-  istio: disabled
-  dashboard: disabled
+  - name: storage
+    status: enabled
+  - name: dns
+    status: disabled
 `
 
 type cloudSuite struct {
@@ -85,8 +84,8 @@ type cloudSuite struct {
 var defaultK8sCloud = jujucloud.Cloud{
 	Name:           caas.K8sCloudMicrok8s,
 	Endpoint:       "http://1.1.1.1:8080",
-	Type:           cloud.CloudTypeCAAS,
-	AuthTypes:      []cloud.AuthType{cloud.UserPassAuthType},
+	Type:           jujucloud.CloudTypeCAAS,
+	AuthTypes:      []jujucloud.AuthType{jujucloud.UserPassAuthType},
 	CACertificates: []string{""},
 	SkipTLSVerify:  true,
 }
@@ -97,8 +96,8 @@ var defaultClusterMetadata = &caas.ClusterMetadata{
 	OperatorStorageClass: &caas.StorageProvisioner{Name: "operator-sc"},
 }
 
-func getDefaultCredential() cloud.Credential {
-	defaultCredential := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"username": "admin", "password": ""})
+func getDefaultCredential() jujucloud.Credential {
+	defaultCredential := jujucloud.NewCredential(jujucloud.UserPassAuthType, map[string]string{"username": "admin", "password": ""})
 	defaultCredential.Label = "kubernetes credential \"admin\""
 	return defaultCredential
 }
@@ -115,12 +114,12 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8s(c *gc.C) {
 	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 		s.runner.Call(
 			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
 			&exec.ExecResponse{Code: 0}, nil)
 	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 
 	var ctx mockContext
@@ -157,12 +156,12 @@ func (s *cloudSuite) TestFinalizeCloudMicrok8sAlreadyStorage(c *gc.C) {
 	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 		s.runner.Call(
 			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
 			&exec.ExecResponse{Code: 0}, nil)
 	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
 
 	var ctx mockContext
@@ -196,13 +195,27 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccess(c *gc.C) {
 	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 		s.runner.Call(
 			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
 			&exec.ExecResponse{Code: 0}, nil)
 	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusEnabled)}, nil)
+	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), jc.ErrorIsNil)
+}
+
+func (s *cloudSuite) TestEnsureMicroK8sSuitableSuccessNew(c *gc.C) {
+	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
+		s.runner.Call(
+			"RunCommands",
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
+			&exec.ExecResponse{Code: 0}, nil)
+	}
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
+		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusNewEnabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), jc.ErrorIsNil)
 }
 
@@ -210,13 +223,27 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageDisabled(c *gc.C) {
 	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 		s.runner.Call(
 			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
 			&exec.ExecResponse{Code: 0}, nil)
 	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusStorageDisabled)}, nil)
+	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable storage'`)
+}
+
+func (s *cloudSuite) TestEnsureMicroK8sSuitableStorageNewDisabled(c *gc.C) {
+	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
+		s.runner.Call(
+			"RunCommands",
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
+			&exec.ExecResponse{Code: 0}, nil)
+	}
+	s.runner.Call(
+		"RunCommands",
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
+		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusStorageNewDisabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable storage'`)
 }
 
@@ -224,12 +251,12 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableDNSDisabled(c *gc.C) {
 	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
 		s.runner.Call(
 			"RunCommands",
-			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+			exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
 			&exec.ExecResponse{Code: 0}, nil)
 	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --yaml"}).Returns(
+		exec.RunParams{Commands: "microk8s status --wait-ready --timeout 15 --format yaml"}).Returns(
 		&exec.ExecResponse{Code: 0, Stdout: []byte(microk8sStatusDNSDisabled)}, nil)
 	c.Assert(provider.EnsureMicroK8sSuitable(s.runner), gc.ErrorMatches, `required addons not enabled for microk8s, run 'microk8s enable dns'`)
 }
@@ -240,7 +267,7 @@ func (s *cloudSuite) TestEnsureMicroK8sSuitableNotInGroup(c *gc.C) {
 	}
 	s.runner.Call(
 		"RunCommands",
-		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s"`}).Returns(
+		exec.RunParams{Commands: `id -nG "$(whoami)" | grep -qw "root\|microk8s\|snap_microk8s"`}).Returns(
 		&exec.ExecResponse{Code: 1}, nil)
 	err := provider.EnsureMicroK8sSuitable(s.runner)
 	c.Assert(err, gc.NotNil)

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -212,7 +212,6 @@ func (p kubernetesEnvironProvider) DetectRegions() ([]cloud.Region, error) {
 }
 
 func (p kubernetesEnvironProvider) validateCloudSpec(spec environscloudspec.CloudSpec) error {
-
 	if err := spec.Validate(); err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
The new strictly confined microk8s made two changes that break the juju bootstrap process.

1. the output format of `microk8s status --yaml` changed(so now we use `--format yaml`);

```
$ sudo snap install microk8s --classic --channel latest/stable

$ microk8s status --wait-ready --timeout 15 --yaml
microk8s:
  running: True
addons:
  ha-cluster: enabled
  ambassador: disabled
  dashboard: disabled
  dns: disabled
  storage: disabled

$ sudo snap install microk8s --channel=latest/edge/MK-530

$ microk8s status --wait-ready --timeout 15 --yaml
microk8s:
  running: True
addons:
  core/ha-cluster: enabled
  core/community: disabled
  core/dashboard: disabled
  core/dns: disabled
  core/storage: disabled

```

2. the user group changed from `microk8s` to `snap-microk8s`(Juju doesn't know which one is required, so just leave it to microk8s to check);

This PR fixes above issues.



## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ sudo snap install microk8s --channel=latest/edge/MK-530

$ juju bootstrap microk8s k1 --debug

$ microk8s.enable storage dns

$ juju bootstrap microk8s k1 --debug

```

## Documentation changes

No


## Bug reference

https://bugs.launchpad.net/juju/+bug/1977488
