### PR TITLE
[JUJU-1266] Rename column DNS --> Address in machines tabular output

### DIFF
--- a/cmd/juju/machine/list_test.go
+++ b/cmd/juju/machine/list_test.go
@@ -137,7 +137,7 @@ func (s *MachineListCommandSuite) TestMachine(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, newMachineListCommand())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Machine  State    DNS       Inst id              Series  AZ         Message\n"+
+		"Machine  State    Address   Inst id              Series  AZ         Message\n"+
 		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
 		"1        started  10.0.0.2  juju-badd06-1        trusty             \n"+
 		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty             \n"+

--- a/cmd/juju/machine/show_test.go
+++ b/cmd/juju/machine/show_test.go
@@ -128,7 +128,7 @@ func (s *MachineShowCommandSuite) TestShowTabularMachine(c *gc.C) {
 	context, err := cmdtesting.RunCommand(c, newMachineShowCommand(), "--format", "tabular", "0", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, ""+
-		"Machine  State    DNS       Inst id              Series  AZ         Message\n"+
+		"Machine  State    Address   Inst id              Series  AZ         Message\n"+
 		"0        started  10.0.0.1  juju-badd06-0        trusty  us-east-1  \n"+
 		"1        started  10.0.0.2  juju-badd06-1        trusty             \n"+
 		"1/lxd/0  pending  10.0.0.3  juju-badd06-1-lxd-0  trusty             \n"+

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -422,7 +422,7 @@ func getModelMessage(model modelStatus) string {
 }
 
 func printMachines(tw *ansiterm.TabWriter, standAlone bool, machines map[string]machineStatus) {
-	w := startSection(tw, standAlone, "Machine", "State", "DNS", "Inst id", "Series", "AZ", "Message")
+	w := startSection(tw, standAlone, "Machine", "State", "Address", "Inst id", "Series", "AZ", "Message")
 	for _, name := range naturalsort.Sort(stringKeysFromMap(machines)) {
 		printMachine(w, machines[name])
 	}

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5162,7 +5162,7 @@ mysql/1       terminated   idle   1        10.0.1.1               gooooone
 wordpress/0*  active       idle   1        10.0.1.1               
   logging/0   active       idle            10.0.1.1               
 
-Machine  State    DNS       Inst id       Series   AZ          Message
+Machine  State    Addess    Inst id       Series   AZ          Message
 0        started  10.0.0.1  controller-0  quantal  us-east-1a  
 1        started  10.0.1.1  snowflake     quantal              
 2        started  10.0.2.1  controller-2  quantal              

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5162,7 +5162,7 @@ mysql/1       terminated   idle   1        10.0.1.1               gooooone
 wordpress/0*  active       idle   1        10.0.1.1               
   logging/0   active       idle            10.0.1.1               
 
-Machine  State    Address    Inst id       Series   AZ          Message
+Machine  State    Address   Inst id       Series   AZ          Message
 0        started  10.0.0.1  controller-0  quantal  us-east-1a  
 1        started  10.0.1.1  snowflake     quantal              
 2        started  10.0.2.1  controller-2  quantal              

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5162,7 +5162,7 @@ mysql/1       terminated   idle   1        10.0.1.1               gooooone
 wordpress/0*  active       idle   1        10.0.1.1               
   logging/0   active       idle            10.0.1.1               
 
-Machine  State    Addess    Inst id       Series   AZ          Message
+Machine  State    Address    Inst id       Series   AZ          Message
 0        started  10.0.0.1  controller-0  quantal  us-east-1a  
 1        started  10.0.1.1  snowflake     quantal              
 2        started  10.0.2.1  controller-2  quantal              

--- a/featuretests/cmd_juju_status_test.go
+++ b/featuretests/cmd_juju_status_test.go
@@ -175,9 +175,9 @@ another/0    waiting   allocating  1                               waiting for m
 mysql/0      waiting   allocating  0                               waiting for machine
 wordpress/0  waiting   allocating  0                               waiting for machine
 
-Machine  State    DNS  Inst id  Series   AZ  Message
-0        pending       id0      quantal      
-1        pending       id1      quantal      
+Machine  State    Address  Inst id  Series   AZ  Message
+0        pending           id0      quantal      
+1        pending           id1      quantal      
 `)
 
 	context = s.run(c, "status", "0")
@@ -190,8 +190,8 @@ Unit         Workload  Agent       Machine  Public address  Ports  Message
 mysql/0      waiting   allocating  0                               waiting for machine
 wordpress/0  waiting   allocating  0                               waiting for machine
 
-Machine  State    DNS  Inst id  Series   AZ  Message
-0        pending       id0      quantal      
+Machine  State    Address  Inst id  Series   AZ  Message
+0        pending           id0      quantal      
 `)
 }
 
@@ -240,8 +240,8 @@ func (s *StatusSuite) TestStatusFilteringByMachineIDMatchesExactly(c *gc.C) {
 Unit       Workload  Agent       Machine  Public address  Ports  Message
 another/0  waiting   allocating  1                               waiting for machine
 
-Machine  State    DNS  Inst id  Series   AZ  Message
-1        pending       id1      quantal      
+Machine  State    Address  Inst id  Series   AZ  Message
+1        pending           id1      quantal      
 
 `)
 
@@ -251,8 +251,8 @@ Machine  State    DNS  Inst id  Series   AZ  Message
 Unit       Workload  Agent       Machine  Public address  Ports  Message
 another/1  waiting   allocating  10                              waiting for machine
 
-Machine  State    DNS  Inst id  Series   AZ  Message
-10       pending       id10     quantal      
+Machine  State    Address  Inst id  Series   AZ  Message
+10       pending           id10     quantal      
 
 `)
 }
@@ -278,8 +278,8 @@ func (s *StatusSuite) TestStatusMachineFilteringWithUnassignedUnits(c *gc.C) {
 
 	context := s.run(c, "status", "1")
 	c.Assert(cmdtesting.Stdout(context), jc.Contains, `
-Machine  State    DNS  Inst id  Series   AZ  Message
-1        pending       id1      quantal      
+Machine  State    Address  Inst id  Series   AZ  Message
+1        pending           id1      quantal      
 
 `)
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, ``)


### PR DESCRIPTION
## Please provide the following details to expedite review (and delete this heading)

Rename DNS column (to Address) in machine tabular output. Modify relevant tests.
This field (DNS) is been set as the machine's preferred public address since 2015.

## Checklist

 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
juju bootstrap localhost lxd
juju deploy tiny-bash
juju status
```

## Documentation change

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1940459