### PR TITLE
Add a juju_apiserver_build_info metric

### DIFF
--- a/apiserver/apiservermetrics_test.go
+++ b/apiserver/apiservermetrics_test.go
@@ -4,6 +4,7 @@
 package apiserver_test
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/juju/testing"
@@ -12,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/version"
 )
 
 type apiservermetricsSuite struct {
@@ -36,7 +38,7 @@ func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
 	for desc := range ch {
 		descs = append(descs, desc)
 	}
-	c.Assert(descs, gc.HasLen, 10)
+	c.Assert(descs, gc.HasLen, 11)
 	c.Assert(descs[0].String(), gc.Matches, `.*fqName: "juju_apiserver_connections_total".*`)
 	c.Assert(descs[1].String(), gc.Matches, `.*fqName: "juju_apiserver_connections".*`)
 	c.Assert(descs[2].String(), gc.Matches, `.*fqName: "juju_apiserver_active_login_attempts".*`)
@@ -48,6 +50,13 @@ func (s *apiservermetricsSuite) TestDescribe(c *gc.C) {
 	c.Assert(descs[7].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_requests_total".*`)
 	c.Assert(descs[8].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_request_errors_total".*`)
 	c.Assert(descs[9].String(), gc.Matches, `.*fqName: "juju_apiserver_outbound_request_duration_seconds".*`)
+	build_info_description := descs[10].String()
+	c.Check(build_info_description, gc.Matches, `.*fqName: "juju_apiserver_build_info".*`)
+	// Ensure that the current version of the Juju controller is one of the const labels on the
+	//build_info metric.
+	expectedVersionRe := fmt.Sprintf(`.*constLabels:.*version="%s".*`,
+		regexp.QuoteMeta(version.Current.String()))
+	c.Check(build_info_description, gc.Matches, expectedVersionRe)
 }
 
 func (s *apiservermetricsSuite) TestCollect(c *gc.C) {
@@ -61,7 +70,7 @@ func (s *apiservermetricsSuite) TestCollect(c *gc.C) {
 	for metric := range ch {
 		metrics = append(metrics, metric)
 	}
-	c.Assert(metrics, gc.HasLen, 2)
+	c.Assert(metrics, gc.HasLen, 3)
 }
 
 func (s *apiservermetricsSuite) TestLabelNames(c *gc.C) {


### PR DESCRIPTION
As per guidance from Prometheus, we attach the version of the controller
onto a special metric. This always has a Gauge value of 1.0 and the
labels are used to indicate what version, etc we are running. This is
all known at compile time, so it can be all static info. We add all the
items that we have on the `running jujud` line for now.

## Checklist

 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
$ juju bootstrap lxd lxd
$ juju ssh -m controller 0 -- bash --login -c juju_metrics
# this should include a juju_apiserver_build_info field that can be used to track what versions the controller is running.
...
juju_apiserver_build_info{git_commit="98bb31ed3f4c2bdd3fea65f930984f03878d289c",git_commit_state="clean",go_compiler="gc",go_version="go1.18.3",official_build="0",version="2.9.32.1"} 1
...
```

Even better is to set up a controller with [Prometheus Monitoring](https://discourse.charmhub.io/t/monitoring-juju-controllers/430) and then see that you can add a graph for Juju versions.

Once I got that up and running this is how I configured the graph. It isn't super interesting,  but you get 1 line for each juju version, and the total value is the number of controllers on that version.
![image](https://user-images.githubusercontent.com/202877/172721506-f23edbb7-7a2d-4f7f-8900-3113dddbefe3.png)
(In that particular image you can see that it started with 2.9.32.1 and then I did an upgrade to 2.9.32.2, and you have the 2 different colored bars showing it.

## Documentation changes

We may want to update our Grafana dashboards to include this metric information.

## Bug reference

* https://bugs.launchpad.net/juju/+bug/1978006