### PR TITLE
Extend grace period to 5minutes

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1452,10 +1452,11 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 
 	automountToken := true
 	return &corev1.PodSpec{
-		AutomountServiceAccountToken: &automountToken,
-		ServiceAccountName:           a.serviceAccountName(),
-		NodeSelector:                 nodeSelector,
-		ImagePullSecrets:             imagePullSecrets,
+		AutomountServiceAccountToken:  &automountToken,
+		ServiceAccountName:            a.serviceAccountName(),
+		NodeSelector:                  nodeSelector,
+		ImagePullSecrets:              imagePullSecrets,
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(300),
 		InitContainers: []corev1.Container{{
 			Name:            "charm-init",
 			ImagePullPolicy: corev1.PullIfNotPresent,

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -415,9 +415,10 @@ func (s *applicationSuite) assertDelete(c *gc.C, app caas.Application) {
 func getPodSpec(c *gc.C) corev1.PodSpec {
 	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 	return corev1.PodSpec{
-		ServiceAccountName:           "gitlab",
-		AutomountServiceAccountToken: pointer.BoolPtr(true),
-		ImagePullSecrets:             []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
+		ServiceAccountName:            "gitlab",
+		AutomountServiceAccountToken:  pointer.BoolPtr(true),
+		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(300),
 		InitContainers: []corev1.Container{{
 			Name:            "charm-init",
 			ImagePullPolicy: corev1.PullIfNotPresent,


### PR DESCRIPTION
Temporary mitigation of lp1977582 by extending pod termination grace period. 
A proper fix to lp1951415 will also fix lp1977582.

## QA steps

- bootstrap k8s
- deploy sidecar app
- kubectl describe app-0
- should have grace period of 300seconds

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1977582