### PR TITLE
Remove unnecessary set of testing state clock

### DIFF
--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -92,7 +92,6 @@ func (s *internalStateSuite) SetUpTest(c *gc.C) {
 	s.pool = ctlr.StatePool()
 	s.state, err = ctlr.SystemState()
 	c.Assert(err, jc.ErrorIsNil)
-	s.state.stateClock = testclock.NewClock(testing.NonZeroTime())
 	s.AddCleanup(func(*gc.C) {
 		// Controller closes pool, pool closes all states.
 		s.controller.Close()


### PR DESCRIPTION
Fixes a test race - setting the state clock is not needed here so remove it.

## QA steps

go test --race