### PR TITLE
[JUJU-1270] Fix export of storage in bundles

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -701,11 +701,16 @@ func (b *BundleAPI) bundleDataApplications(
 		if result := b.constraints(application.Constraints()); len(result) != 0 {
 			newApplication.Constraints = strings.Join(result, " ")
 		}
-		if len(application.StorageConstraints()) != 0 {
+		if cons := application.StorageConstraints(); len(cons) != 0 {
 			newApplication.Storage = make(map[string]string)
-			for name, constr := range application.StorageConstraints() {
-				newApplication.Storage[name] = fmt.Sprintf("%s,%d,%d",
-					constr.Pool(), constr.Count(), constr.Size())
+			for name, constr := range cons {
+				if newApplication.Storage[name], err = storage.ToString(storage.Constraints{
+					Pool:  constr.Pool(),
+					Size:  constr.Size(),
+					Count: constr.Count(),
+				}); err != nil {
+					return nil, nil, nil, errors.NotValidf("storage %q for %q", name, application.Name())
+				}
 			}
 		}
 

--- a/apiserver/facades/client/bundle/bundle_test.go
+++ b/apiserver/facades/client/bundle/bundle_test.go
@@ -1083,9 +1083,11 @@ func (s *bundleSuite) TestExportBundleWithApplicationStorage(c *gc.C) {
 			Count: 3,
 		},
 		"storage2": {
-			Pool:  "pool2",
-			Size:  4096,
-			Count: 1,
+			Pool: "pool2",
+			Size: 4096,
+		},
+		"storage3": {
+			Size: 2048,
 		},
 	}
 	app := s.st.model.AddApplication(args)
@@ -1110,8 +1112,9 @@ applications:
     options:
       key: value
     storage:
-      storage1: pool1,3,1024
-      storage2: pool2,1,4096
+      storage1: pool1,3,1024M
+      storage2: pool2,4096M
+      storage3: 2048M
     bindings:
       another: alpha
       juju-info: vlan2

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -166,4 +167,23 @@ func parseSize(s string) (uint64, bool, error) {
 		return 0, true, err
 	}
 	return size, true, nil
+}
+
+// ToString returns a parsable string representation of the storage constraints.
+func ToString(c Constraints) (string, error) {
+	if c.Pool == "" && c.Size <= 0 && c.Count <= 0 {
+		return "", errors.Errorf("must provide one of pool or size or count")
+	}
+
+	var parts []string
+	if c.Pool != "" {
+		parts = append(parts, c.Pool)
+	}
+	if c.Count > 0 {
+		parts = append(parts, fmt.Sprintf("%d", c.Count))
+	}
+	if c.Size > 0 {
+		parts = append(parts, fmt.Sprintf("%dM", c.Size))
+	}
+	return strings.Join(parts, ","), nil
 }


### PR DESCRIPTION
https://github.com/juju/juju/pull/13972 fixed [bug 1835133](https://bugs.launchpad.net/bugs/1835133) but the fix wasn't quite right. The generated storage constraints string was wrong except when all 3 fields were set.

This PR fixes that issue.

## QA steps

The unit tests include a round trip of the generated constraints string.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1977902
