### PR TITLE
[JUJU-1041]: Fix type of MetadataYAML and ConfigYAML fields in Charmhub struct

### DIFF
--- a/charmhub/transport/refresh.go
+++ b/charmhub/transport/refresh.go
@@ -4,7 +4,6 @@
 package transport
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -97,8 +96,8 @@ type RefreshEntity struct {
 	CreatedAt time.Time          `json:"created-at"`
 
 	// The minimum set of metadata required for deploying a charm.
-	MetadataYAML json.RawMessage `json:"metadata-yaml,omitempty"`
-	ConfigYAML   json.RawMessage `json:"config-yaml,omitempty"`
+	MetadataYAML string `json:"metadata-yaml,omitempty"`
+	ConfigYAML   string `json:"config-yaml,omitempty"`
 }
 
 // RefreshResourceRevision represents a resource name revision pair for

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -4,7 +4,6 @@
 package repository
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -428,7 +427,7 @@ func (c *CharmHubRepository) getEssentialMetadataForBatch(reqs []corecharm.Metad
 		if len(refreshResult.Entity.MetadataYAML) == 0 {
 			return nil, errors.Errorf("charmhub refresh response for %q does not include the contents of metadata.yaml", reqs[resIdx].CharmURL)
 		}
-		chMeta, err := charm.ReadMeta(bytes.NewReader(refreshResult.Entity.MetadataYAML))
+		chMeta, err := charm.ReadMeta(strings.NewReader(refreshResult.Entity.MetadataYAML))
 		if err != nil {
 			return nil, errors.Annotatef(err, "parsing metadata.yaml for %q", reqs[resIdx].CharmURL)
 		}
@@ -436,7 +435,7 @@ func (c *CharmHubRepository) getEssentialMetadataForBatch(reqs []corecharm.Metad
 		if len(refreshResult.Entity.ConfigYAML) == 0 {
 			return nil, errors.Errorf("charmhub refresh response for %q does not include the contents of config.yaml", reqs[resIdx].CharmURL)
 		}
-		chConfig, err := charm.ReadConfig(bytes.NewReader(refreshResult.Entity.ConfigYAML))
+		chConfig, err := charm.ReadConfig(strings.NewReader(refreshResult.Entity.ConfigYAML))
 		if err != nil {
 			return nil, errors.Annotatef(err, "parsing config.yaml for %q", reqs[resIdx].CharmURL)
 		}

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -5,7 +5,6 @@ package repository
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -449,15 +448,15 @@ func (s *charmHubRepositorySuite) expectCharmRefresh(c *gc.C, cfg charmhub.Refre
 						Channel:      "20.04",
 					},
 				},
-				MetadataYAML: json.RawMessage([]byte(`
+				MetadataYAML: `
 name: wordpress
 summary: Blog engine
 description: Blog engine
-`[1:])),
-				ConfigYAML: json.RawMessage([]byte(`
+`[1:],
+				ConfigYAML: `
 options:
   blog-title: {default: My Title, description: A descriptive title used for the blog., type: string}
-`[1:])),
+`[1:],
 			},
 			EffectiveChannel: "latest/stable",
 		}}, nil


### PR DESCRIPTION
Currently these are json.RawMessage, but then they come through to the YAML parser as `"description: ..."` (including the quotes) and Juju gives an error parsing the YAML during deploy (when `async-charm-downloads` is on), for example:

```
$ juju bootstrap lxd test
$ juju add-model lightspeed
$ juju controller-config 'features=[async-charm-downloads]'
$ juju deploy calico
ERROR storing charm "calico": retrieving essential metadata for charm "ch:amd64/focal/calico-24": parsing metadata.yaml for "ch:amd64/focal/calico-24": yaml: unmarshal errors:
  line 1: cannot unmarshal !!str `descrip...` into map[interface {}]interface {}
```

However, these fields are regular JSON string fields (with YAML inside them), so change the type to a simple string. I'm not actually sure how this ever worked!

For reference, here's what the Charmhub API returns (you can see the `metadata-yaml` field is a regular string):

```
$ curl -XPOST -s https://api.charmhub.io/v2/charms/refresh  -H 'Content-type: application/json'   -d '{"context":[], "actions": [
        {
      "name": "calico",
      "base": {"name": "ubuntu", "channel": "20.04", "architecture": "amd64"},
      "channel":"beta",
      "action": "download",
      "instance-key": "a-test"
    }], "fields":["metadata-yaml"]}'|jq
{
  "error-list": [],
  "results": [
    {
      "charm": {
        "metadata-yaml": "description: 'Deploys Calico as a background service and configures CNI for use with\n\n  calico on any principal charm that implements the kubernetes-cni interface.\n\n  '\ndocs: https://discourse.charmhub.io/t/calico-docs-index/6167\nmaintainers:\n- Tim Van Steenburgh <tim.van.steenburgh@canonical.com>\n- George Kraft <george.kraft@canonical.com>\n- Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>\n- Mike Wilson <mike.wilson@canonical.com>\n- Kevin Monroe <kevin.monroe@canonical.com>\n- Joe Borg <joseph.borg@canonical.com>\nname: calico\nrequires:\n  cni:\n    interface: kubernetes-cni\n    scope: container\n  etcd:\n    interface: etcd\nresources:\n  calico:\n    description: Calico resource tarball for amd64\n    filename: calico.tar.gz\n    type: file\n  calico-arm64:\n    description: Calico resource tarball for arm64\n    filename: calico.tar.gz\n    type: file\n  calico-node-image:\n    description: calico-node container image\n    filename: calico-node-image.tar.gz\n    type: file\nseries:\n- focal\n- bionic\n- xenial\nsubordinate: true\nsummary: A robust Software Defined Network from Project Calico\ntags:\n- networking\n"
      },
      "effective-channel": "beta",
      "id": "sE5vgx5GS6Kt7iPAn8SrUSfAtKgs6ZBj",
      "instance-key": "a-test",
      "name": "calico",
      "released-at": "2022-04-26T07:55:30.414862+00:00",
      "result": "download"
    }
  ]
}
```