### PR TITLE
[JUJU-1275] Application charmurl string

### DIFF
--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -9,13 +9,14 @@ import (
 	"github.com/juju/charm/v8"
 	"gopkg.in/macaroon.v2"
 
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
-	"github.com/juju/names/v4"
 )
 
 type Backend interface {
@@ -211,9 +212,10 @@ type Application interface {
 	// charm even if they are in an error state.
 	Charm() (ch Charm, force bool, err error)
 
-	// CharmURL returns the application's charm URL, and whether units should upgrade
-	// to the charm with that URL even if they are in an error state.
-	CharmURL() (curl *charm.URL, force bool)
+	// CharmURL returns a string representation the application's charm URL,
+	// and whether units should upgrade to the charm with that URL even if
+	// they are in an error state.
+	CharmURL() (curl *string, force bool)
 
 	// EndpointBindings returns the Bindings object for this application.
 	EndpointBindings() (Bindings, error)

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -7,9 +7,8 @@ import (
 	"time"
 
 	"github.com/juju/charm/v8"
-	"gopkg.in/macaroon.v2"
-
 	"github.com/juju/names/v4"
+	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"

--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -4,6 +4,7 @@
 package instancemutater
 
 import (
+	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -339,7 +340,12 @@ func (api *InstanceMutaterAPI) machineLXDProfileInfo(m Machine) (lxdProfileInfo,
 			changeResults[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		chURL := app.CharmURL()
+		cURL := app.CharmURL()
+		chURL, err := charm.ParseURL(*cURL)
+		if err != nil {
+			changeResults[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
 		ch, err := api.st.Charm(chURL)
 		if err != nil {
 			changeResults[i].Error = apiservererrors.ServerError(err)
@@ -356,7 +362,7 @@ func (api *InstanceMutaterAPI) machineLXDProfileInfo(m Machine) (lxdProfileInfo,
 		}
 		changeResults[i] = params.ProfileInfoResult{
 			ApplicationName: appName,
-			Revision:        chURL.Revision,
+			Revision:        ch.Revision(),
 			Profile:         normalised,
 		}
 	}

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	coretesting "github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -260,7 +259,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfo(c *gc
 	s.expectInstanceId("0")
 	s.expectUnits(1)
 	s.expectCharmProfiles()
-	s.expectProfileExtraction(c)
+	s.expectProfileExtraction()
 	s.expectName()
 	facade := s.facadeAPIForScenario(c)
 
@@ -302,8 +301,8 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithNo
 	s.expectInstanceId("0")
 	s.expectUnits(2)
 	s.expectCharmProfiles()
-	s.expectProfileExtraction(c)
-	s.expectProfileExtractionWithEmpty(c)
+	s.expectProfileExtraction()
+	s.expectProfileExtractionWithEmpty()
 	s.expectName()
 	facade := s.facadeAPIForScenario(c)
 
@@ -393,7 +392,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectCharmProfiles() {
 	machineExp.CharmProfiles().Return([]string{"charm-app-0"}, nil)
 }
 
-func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtraction(c *gc.C) {
+func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtraction() {
 	appExp := s.application.EXPECT()
 	charmExp := s.charm.EXPECT()
 	stateExp := s.state.EXPECT()
@@ -401,10 +400,11 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtraction(c *g
 
 	unitExp.ApplicationName().Return("foo")
 	stateExp.Application("foo").Return(s.application, nil)
-	chURL, err := charm.ParseURL("cs:app-0")
-	c.Assert(err, jc.ErrorIsNil)
-	appExp.CharmURL().Return(chURL)
+	chURLStr := "cs:app-0"
+	appExp.CharmURL().Return(&chURLStr)
+	chURL := charm.MustParseURL(chURLStr)
 	stateExp.Charm(chURL).Return(s.charm, nil)
+	charmExp.Revision().Return(chURL.Revision)
 	charmExp.LXDProfile().Return(lxdprofile.Profile{
 		Config: map[string]string{
 			"security.nesting": "true",
@@ -418,7 +418,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtraction(c *g
 	})
 }
 
-func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtractionWithEmpty(c *gc.C) {
+func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtractionWithEmpty() {
 	appExp := s.application.EXPECT()
 	charmExp := s.charm.EXPECT()
 	stateExp := s.state.EXPECT()
@@ -426,10 +426,11 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectProfileExtractionWithE
 
 	unitExp.ApplicationName().Return("foo")
 	stateExp.Application("foo").Return(s.application, nil)
-	chURL, err := charm.ParseURL("cs:app-0")
-	c.Assert(err, jc.ErrorIsNil)
-	appExp.CharmURL().Return(chURL)
+	chURLStr := "cs:app-0"
+	appExp.CharmURL().Return(&chURLStr)
+	chURL := charm.MustParseURL(chURLStr)
 	stateExp.Charm(chURL).Return(s.charm, nil)
+	charmExp.Revision().Return(chURL.Revision)
 	charmExp.LXDProfile().Return(lxdprofile.Profile{})
 }
 

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -60,9 +60,10 @@ type Unit interface {
 // Charm represents point of use methods from the state Charm object.
 type Charm interface {
 	LXDProfile() lxdprofile.Profile
+	Revision() int
 }
 
 // Application represents point of use methods from the state Application object.
 type Application interface {
-	CharmURL() *charm.URL
+	CharmURL() *string
 }

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
@@ -330,9 +330,9 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherAppChangeCharmURLNo
 	s.wc0.AssertOneChange()
 
 	s.state.EXPECT().Application("foo").Return(s.app, nil)
-	curl := charm.MustParseURL("ch:name-me-3")
-	s.app.EXPECT().CharmURL().Return(curl)
-	s.state.EXPECT().Charm(curl).Return(nil, errors.NotFoundf(""))
+	curl := "ch:name-me-3"
+	s.app.EXPECT().CharmURL().Return(&curl)
+	s.state.EXPECT().Charm(charm.MustParseURL(curl)).Return(nil, errors.NotFoundf(""))
 
 	s.appChanges <- []string{"foo"}
 	s.wc0.AssertNoChange()
@@ -394,9 +394,9 @@ func (s *lxdProfileWatcherSuite) updateCharmForMachineLXDProfileWatcher(rev stri
 	} else {
 		s.charm.EXPECT().LXDProfile().Return(lxdprofile.Profile{})
 	}
-	chURL := charm.MustParseURL(curl)
 	s.state.EXPECT().Application("foo").Return(s.app, nil)
-	s.app.EXPECT().CharmURL().Return(chURL)
+	s.app.EXPECT().CharmURL().Return(&curl)
+	chURL := charm.MustParseURL(curl)
 	s.state.EXPECT().Charm(chURL).Return(s.charm, nil)
 	s.charmChanges <- []string{curl}
 	s.appChanges <- []string{"foo"}
@@ -451,14 +451,15 @@ func (s *lxdProfileWatcherSuite) setupScenario(startEmpty, withProfile bool) {
 	s.unit.EXPECT().ApplicationName().AnyTimes().Return("foo")
 	s.unit.EXPECT().Name().AnyTimes().Return("foo/0")
 
-	curl := charm.MustParseURL("ch:name-me")
+	curlStr := "ch:name-me"
+	curl := charm.MustParseURL(curlStr)
 	s.state.EXPECT().Charm(curl).Return(s.charm, nil)
 	if startEmpty {
 		s.machine0.EXPECT().Units().Return(nil, nil)
 	} else {
 		s.machine0.EXPECT().Units().Return([]instancemutater.Unit{s.unit}, nil)
 		s.unit.EXPECT().Application().Return(s.app, nil)
-		s.app.EXPECT().CharmURL().Return(curl)
+		s.app.EXPECT().CharmURL().Return(&curlStr)
 	}
 
 	if withProfile {

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -570,10 +570,10 @@ func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 }
 
 // CharmURL mocks base method.
-func (m *MockApplication) CharmURL() *charm.URL {
+func (m *MockApplication) CharmURL() *string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
-	ret0, _ := ret[0].(*charm.URL)
+	ret0, _ := ret[0].(*string)
 	return ret0
 }
 
@@ -618,4 +618,18 @@ func (m *MockCharm) LXDProfile() lxdprofile.Profile {
 func (mr *MockCharmMockRecorder) LXDProfile() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfile", reflect.TypeOf((*MockCharm)(nil).LXDProfile))
+}
+
+// Revision mocks base method.
+func (m *MockCharm) Revision() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Revision")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Revision indicates an expected call of Revision.
+func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))
 }

--- a/apiserver/facades/agent/instancemutater/shim.go
+++ b/apiserver/facades/agent/instancemutater/shim.go
@@ -103,7 +103,7 @@ type applicationShim struct {
 	*state.Application
 }
 
-func (a *applicationShim) CharmURL() *charm.URL {
+func (a *applicationShim) CharmURL() *string {
 	curl, _ := a.Application.CharmURL()
 	return curl
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -692,22 +692,28 @@ func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, er
 			var unitOrApplication state.Entity
 			unitOrApplication, err = u.st.FindEntity(tag)
 			if err == nil {
+				// TODO (hmlanigan) 2022-06-08
+				// cURL can be a string pointer once unit.CharmURL()
+				// returns a string pointer as well.
 				var cURL *charm.URL
-				var ok bool
+				var force bool
 
 				switch entity := unitOrApplication.(type) {
 				case *state.Application:
-					cURL, ok = entity.CharmURL()
+					var cURLStr *string
+					cURLStr, force = entity.CharmURL()
+					cURL, err = charm.ParseURL(*cURLStr)
 				case *state.Unit:
 					cURL, err = entity.CharmURL()
+					// The force value is not actually used on the uniter's unit api.
 					if cURL != nil {
-						ok = true
+						force = true
 					}
 				}
 
 				if cURL != nil {
 					result.Results[i].Result = cURL.String()
-					result.Results[i].Ok = ok
+					result.Results[i].Ok = force
 				}
 			}
 		}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -880,8 +880,8 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	c.Assert(curl, gc.DeepEquals, s.wpCharm.URL())
 
 	// Make sure wordpress application's charm is what we expect.
-	curl, force := s.wordpress.CharmURL()
-	c.Assert(curl, gc.DeepEquals, s.wpCharm.URL())
+	curlStr, force := s.wordpress.CharmURL()
+	c.Assert(*curlStr, gc.DeepEquals, s.wpCharm.URL().String())
 	c.Assert(force, jc.IsFalse)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -938,7 +938,7 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 	charmURL, err := s.wordpressUnit.CharmURL()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmURL, gc.NotNil)
-	c.Assert(charmURL.String(), gc.Equals, s.wpCharm.String())
+	c.Assert(*charmURL, gc.Equals, s.wpCharm.String())
 }
 
 func (s *uniterSuite) TestWorkloadVersion(c *gc.C) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -881,7 +881,7 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 
 	// Make sure wordpress application's charm is what we expect.
 	curlStr, force := s.wordpress.CharmURL()
-	c.Assert(*curlStr, gc.DeepEquals, s.wpCharm.URL().String())
+	c.Assert(*curlStr, gc.Equals, s.wpCharm.String())
 	c.Assert(force, jc.IsFalse)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -1364,7 +1364,7 @@ func (s *uniterSuite) TestConfigSettings(c *gc.C) {
 		Entities: []params.EntityCharmURL{
 			{
 				Tag:      s.wordpressUnit.Tag().String(),
-				CharmURL: s.wpCharm.URL().String(),
+				CharmURL: s.wpCharm.String(),
 			},
 		},
 	})
@@ -4071,7 +4071,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatch(c *gc.C) {
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
 				UUID:     uuid,
-				CharmURL: s.meteredCharm.URL().String(),
+				CharmURL: s.meteredCharm.String(),
 				Created:  time.Now(),
 				Metrics:  metrics,
 			}}}},
@@ -4085,7 +4085,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatch(c *gc.C) {
 	batch, err := s.State.MetricBatch(uuid)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(batch.UUID(), gc.Equals, uuid)
-	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL().String())
+	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.String())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
 	c.Assert(storedMetrics, gc.HasLen, 1)
@@ -4102,7 +4102,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
 				UUID:     uuid,
-				CharmURL: s.meteredCharm.URL().String(),
+				CharmURL: s.meteredCharm.String(),
 				Created:  time.Now(),
 				Metrics:  metrics,
 			}}}})
@@ -4115,7 +4115,7 @@ func (s *unitMetricBatchesSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 	batch, err := s.State.MetricBatch(uuid)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(batch.UUID(), gc.Equals, uuid)
-	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL().String())
+	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.String())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
 	c.Assert(storedMetrics, gc.HasLen, 1)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -938,7 +938,7 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 	charmURL, err := s.wordpressUnit.CharmURL()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charmURL, gc.NotNil)
-	c.Assert(*charmURL, gc.Equals, s.wpCharm.String())
+	c.Assert(charmURL.String(), gc.Equals, s.wpCharm.String())
 }
 
 func (s *uniterSuite) TestWorkloadVersion(c *gc.C) {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1420,10 +1420,6 @@ func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmU
 		return params.CharmURLOriginResult{Error: apiservererrors.ServerError(err)}, nil
 	}
 	charmURL, _ := oneApplication.CharmURL()
-	if charmURL == nil {
-		err := errors.NotValidf("application charm url")
-		return params.CharmURLOriginResult{Error: apiservererrors.ServerError(err)}, nil
-	}
 	result := params.CharmURLOriginResult{URL: *charmURL}
 	chOrigin := oneApplication.CharmOrigin()
 	if chOrigin == nil {

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -76,7 +76,7 @@ type Application interface {
 	ApplicationConfig() (coreconfig.ConfigAttributes, error)
 	ApplicationTag() names.ApplicationTag
 	Charm() (Charm, bool, error)
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*string, bool)
 	Channel() csparams.Channel
 	CharmOrigin() *state.CharmOrigin
 	ClearExposed() error

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -539,7 +539,7 @@ func (s *DeployLocalSuite) TestDeployWithFewerPlacement(c *gc.C) {
 
 func (s *DeployLocalSuite) assertCharm(c *gc.C, app application.Application, expect *charm.URL) {
 	curl, force := app.CharmURL()
-	c.Assert(curl, gc.DeepEquals, expect)
+	c.Assert(*curl, gc.Equals, expect.String())
 	c.Assert(force, jc.IsFalse)
 }
 

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -137,9 +137,10 @@ func (m *mockApplication) Charm() (application.Charm, bool, error) {
 	return m.charm, true, nil
 }
 
-func (m *mockApplication) CharmURL() (curl *charm.URL, force bool) {
+func (m *mockApplication) CharmURL() (curl *string, force bool) {
 	m.MethodCall(m, "CharmURL")
-	return m.curl, true
+	str := m.curl.String()
+	return &str, true
 }
 
 func (m *mockApplication) CharmConfig(branchName string) (charm.Settings, error) {

--- a/apiserver/facades/client/application/updateseries_mocks_test.go
+++ b/apiserver/facades/client/application/updateseries_mocks_test.go
@@ -194,10 +194,10 @@ func (mr *MockApplicationMockRecorder) CharmOrigin() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockApplication) CharmURL() (*v8.URL, bool) {
+func (m *MockApplication) CharmURL() (*string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
-	ret0, _ := ret[0].(*v8.URL)
+	ret0, _ := ret[0].(*string)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -612,7 +612,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 	ch := &mockCharm{meta: &charm.Meta{Description: "A pretty popular blog engine"}}
 	s.mockState.applications = map[string]crossmodel.Application{
 		"test": &mockApplication{
-			charm: ch, curl: charm.MustParseURL("db2-2"), bindings: map[string]string{"db": "myspace"}},
+			charm: ch, curl: "ch:db2-2", bindings: map[string]string{"db": "myspace"}},
 	}
 
 	model := &mockModel{uuid: testing.ModelTag.Id(), name: "prod", owner: "fred@external", modelType: state.ModelTypeIAAS}
@@ -654,7 +654,7 @@ func (s *applicationOffersSuite) TestShowFoundMultiple(c *gc.C) {
 	}
 	anotherState.applications = map[string]crossmodel.Application{
 		"testagain": &mockApplication{
-			charm: ch, curl: charm.MustParseURL("mysql-2"), bindings: map[string]string{"db2": "anotherspace"}},
+			charm: ch, curl: "ch:mysql-2", bindings: map[string]string{"db2": "anotherspace"}},
 	}
 	anotherState.spaces["anotherspace"] = &mockSpace{
 		name:       "anotherspace",
@@ -894,7 +894,7 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 		"db2": &mockApplication{
 			name:  "db2",
 			charm: ch,
-			curl:  charm.MustParseURL("cs:db2-2"),
+			curl:  "cs:db2-2",
 			bindings: map[string]string{
 				"db2": "myspace",
 			},
@@ -942,14 +942,14 @@ func (s *applicationOffersSuite) TestFindMulti(c *gc.C) {
 		"mysql": &mockApplication{
 			name:  "mysql",
 			charm: ch,
-			curl:  charm.MustParseURL("cs:mysql-2"),
+			curl:  "cs:mysql-2",
 			bindings: map[string]string{
 				"mysql": "anotherspace",
 			},
 		},
 		"postgresql": &mockApplication{
 			charm: ch,
-			curl:  charm.MustParseURL("cs:postgresql-2"),
+			curl:  "cs:postgresql-2",
 			bindings: map[string]string{
 				"postgresql": "anotherspace",
 			},

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -185,12 +185,15 @@ func (api *BaseAPI) applicationOffersFromModel(
 
 func (api *BaseAPI) getOfferAdminDetails(user names.UserTag, backend Backend, app crossmodel.Application, offer *params.ApplicationOfferAdminDetails) error {
 	curl, _ := app.CharmURL()
+	if curl == nil {
+		return errors.NotValidf("application charm url")
+	}
 	conns, err := backend.OfferConnections(offer.OfferUUID)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	offer.ApplicationName = app.Name()
-	offer.CharmURL = curl.String()
+	offer.CharmURL = *curl
 	for _, oc := range conns {
 		connDetails := params.OfferConnection{
 			SourceModelTag: names.NewModelTag(oc.SourceModelUUID()).String(),

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -185,9 +185,6 @@ func (api *BaseAPI) applicationOffersFromModel(
 
 func (api *BaseAPI) getOfferAdminDetails(user names.UserTag, backend Backend, app crossmodel.Application, offer *params.ApplicationOfferAdminDetails) error {
 	curl, _ := app.CharmURL()
-	if curl == nil {
-		return errors.NotValidf("application charm url")
-	}
 	conns, err := backend.OfferConnections(offer.OfferUUID)
 	if err != nil {
 		return errors.Trace(err)

--- a/apiserver/facades/client/applicationoffers/base_test.go
+++ b/apiserver/facades/client/applicationoffers/base_test.go
@@ -112,7 +112,7 @@ func (s *baseSuite) setupOffers(c *gc.C, filterAppName string, filterWithEndpoin
 		"test": &mockApplication{
 			name:     "test",
 			charm:    ch,
-			curl:     charm.MustParseURL("cs:db2-2"),
+			curl:     "cs:db2-2",
 			bindings: map[string]string{"db2": "myspace"}, // myspace
 		},
 	}

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -143,7 +143,7 @@ type mockApplication struct {
 	crossmodel.Application
 	name      string
 	charm     *mockCharm
-	curl      *charm.URL
+	curl      string
 	endpoints []state.Endpoint
 	bindings  map[string]string
 }
@@ -156,8 +156,8 @@ func (m *mockApplication) Charm() (crossmodel.Charm, bool, error) {
 	return m.charm, true, nil
 }
 
-func (m *mockApplication) CharmURL() (curl *charm.URL, force bool) {
-	return m.curl, true
+func (m *mockApplication) CharmURL() (curl *string, force bool) {
+	return &m.curl, true
 }
 
 func (m *mockApplication) Endpoints() ([]state.Endpoint, error) {

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -811,8 +811,11 @@ func fetchAllApplicationsAndUnits(st Backend, model *state.Model, spaceInfos net
 	for _, app := range applications {
 		appMap[app.Name()] = app
 		appUnits := allUnitsByApp[app.Name()]
-		charmURL, _ := app.CharmURL()
-
+		cURL, _ := app.CharmURL()
+		charmURL, err := charm.ParseURL(*cURL)
+		if err != nil {
+			continue
+		}
 		if len(appUnits) > 0 {
 			unitMap[app.Name()] = appUnits
 			// Record the base URL for the application's charm so that
@@ -896,7 +899,11 @@ func fetchOffers(st Backend, applications map[string]*state.Application) (map[st
 			continue
 		}
 		curl, _ := app.CharmURL()
-		offerInfo.charmURL = curl.String()
+		if curl == nil {
+			offerInfo.err = errors.NotValidf("application charm url nil")
+			continue
+		}
+		offerInfo.charmURL = *curl
 		rc, err := st.RemoteConnectionStatus(offer.OfferUUID)
 		if err != nil && !errors.IsNotFound(err) {
 			offerInfo.err = err

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -1020,7 +1020,7 @@ func (s *CAASStatusSuite) assertUnitStatus(c *gc.C, appStatus params.Application
 		workloadVersion = "gitlab/latest"
 	}
 	c.Assert(appStatus, jc.DeepEquals, params.ApplicationStatus{
-		Charm:           curl.String(),
+		Charm:           *curl,
 		Series:          "kubernetes",
 		WorkloadVersion: workloadVersion,
 		Relations:       map[string][]string{},

--- a/apiserver/facades/client/metricsdebug/metricsdebug.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -187,7 +188,7 @@ func (api *MetricsDebugAPI) setEntityMeterStatus(entity names.Tag, status state.
 		if chURL == nil {
 			return errors.New("no charm url")
 		}
-		if chURL.Schema != "local" {
+		if !charm.Local.Matches(chURL.Schema) {
 			return errors.New("not a local charm")
 		}
 		err = unit.SetMeterStatus(status.Code.String(), status.Info)
@@ -199,8 +200,12 @@ func (api *MetricsDebugAPI) setEntityMeterStatus(entity names.Tag, status state.
 		if err != nil {
 			return errors.Trace(err)
 		}
-		chURL, _ := application.CharmURL()
-		if chURL.Schema != "local" {
+		cURL, _ := application.CharmURL()
+		curl, err := charm.ParseURL(*cURL)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !charm.Local.Matches(curl.Schema) {
 			return errors.New("not a local charm")
 		}
 		units, err := application.AllUnits()

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -291,9 +291,10 @@ func (a *mockApplication) CharmModifiedVersion() int {
 	return a.charmModifiedVersion
 }
 
-func (a *mockApplication) CharmURL() (curl *charm.URL, force bool) {
+func (a *mockApplication) CharmURL() (curl *string, force bool) {
 	a.MethodCall(a, "CharmURL")
-	return a.charm.URL(), false
+	cURL := a.charm.URL().String()
+	return &cURL, false
 }
 
 func (a *mockApplication) ApplicationConfig() (coreconfig.ConfigAttributes, error) {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -288,6 +288,9 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 	}
 	caCert, _ := cfg.CACert()
 	charmURL, _ := app.CharmURL()
+	if charmURL == nil {
+		return nil, errors.NotValidf("application charm url nil")
+	}
 	appConfig, err := app.ApplicationConfig()
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting application config")
@@ -303,7 +306,7 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		Series:               app.Series(),
 		ImageRepo:            params.NewDockerImageInfo(cfg.CAASImageRepo(), imagePath),
 		CharmModifiedVersion: app.CharmModifiedVersion(),
-		CharmURL:             charmURL.String(),
+		CharmURL:             *charmURL,
 		Trust:                appConfig.GetBool(application.TrustConfigOptionName, false),
 		Scale:                app.GetScale(),
 	}, nil

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -59,7 +59,7 @@ type Application interface {
 	Series() string
 	SetStatus(statusInfo status.StatusInfo) error
 	CharmModifiedVersion() int
-	CharmURL() (curl *charm.URL, force bool)
+	CharmURL() (curl *string, force bool)
 	ApplicationConfig() (coreconfig.ConfigAttributes, error)
 	GetScale() int
 	ClearResources() error

--- a/apiserver/facades/controller/charmrevisionupdater/interface.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface.go
@@ -31,7 +31,7 @@ type State interface {
 
 // Application is the subset of *state.Application that we need.
 type Application interface {
-	CharmURL() (curl *charm.URL, force bool)
+	CharmURL() (curl *string, force bool)
 	CharmOrigin() *state.CharmOrigin
 	Channel() csparams.Channel
 	ApplicationTag() names.ApplicationTag

--- a/apiserver/facades/controller/charmrevisionupdater/interface_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface_test.go
@@ -35,11 +35,13 @@ func makeApplication(ctrl *gomock.Controller, schema, charmName, charmID, appID 
 		source = "charm-store"
 	}
 
-	app.EXPECT().CharmURL().Return(&charm.URL{
+	curl := &charm.URL{
 		Schema:   schema,
 		Name:     charmName,
 		Revision: revision,
-	}, false).AnyTimes()
+	}
+	str := curl.String()
+	app.EXPECT().CharmURL().Return(&str, false).AnyTimes()
 	app.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
 		Source:   source,
 		Type:     "charm",

--- a/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
+++ b/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
@@ -88,10 +88,10 @@ func (mr *MockApplicationMockRecorder) CharmOrigin() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockApplication) CharmURL() (*charm.URL, bool) {
+func (m *MockApplication) CharmURL() (*string, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
-	ret0, _ := ret[0].(*charm.URL)
+	ret0, _ := ret[0].(*string)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -145,7 +145,11 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 		charmhubApps   []appInfo
 	)
 	for _, application := range applications {
-		curl, _ := application.CharmURL()
+		cURL, _ := application.CharmURL()
+		curl, err := charm.ParseURL(*cURL)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		switch {
 		case charm.Local.Matches(curl.Schema):
 			continue

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -2134,7 +2134,7 @@ func (s *FakeStoreStateSuite) assertApplicationsDeployed(c *gc.C, info map[strin
 			deviceConstraints = nil
 		}
 		deployed[app.Name()] = applicationInfo{
-			charm:       curl.String(),
+			charm:       *curl,
 			config:      config,
 			constraints: constr,
 			exposed:     app.IsExposed(),

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -94,7 +94,7 @@ func ApplicationChange(c *gc.C, modelUUID string, app *state.Application) cache.
 		ModelUUID:   modelUUID,
 		Name:        app.Name(),
 		Exposed:     app.IsExposed(),
-		CharmURL:    cURL.Path(),
+		CharmURL:    *cURL,
 		Life:        life.Value(app.Life().String()),
 		MinUnits:    app.MinUnits(),
 		Constraints: cons,

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -70,7 +70,7 @@ type PrecheckMachine interface {
 type PrecheckApplication interface {
 	Name() string
 	Life() state.Life
-	CharmURL() (*charm.URL, bool)
+	CharmURL() (*string, bool)
 	AllUnits() ([]PrecheckUnit, error)
 	MinUnits() int
 }
@@ -374,6 +374,9 @@ func (ctx *precheckContext) checkUnits(app PrecheckApplication, units []Precheck
 	}
 
 	appCharmURL, _ := app.CharmURL()
+	if appCharmURL == nil {
+		return errors.Errorf("application charm url is nil")
+	}
 
 	for _, unit := range units {
 		if unit.Life() != state.Alive {
@@ -391,7 +394,7 @@ func (ctx *precheckContext) checkUnits(app PrecheckApplication, units []Precheck
 		}
 
 		unitCharmURL, _ := unit.CharmURL()
-		if appCharmURL.String() != unitCharmURL.String() {
+		if *appCharmURL != unitCharmURL.String() {
 			return errors.Errorf("unit %s is upgrading", unit.Name())
 		}
 	}

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -933,12 +933,12 @@ func (a *fakeApp) Life() state.Life {
 	return a.life
 }
 
-func (a *fakeApp) CharmURL() (*charm.URL, bool) {
+func (a *fakeApp) CharmURL() (*string, bool) {
 	url := a.charmURL
 	if url == "" {
 		url = "cs:foo-1"
 	}
-	return charm.MustParseURL(url), false
+	return &url, false
 }
 
 func (a *fakeApp) AllUnits() ([]migration.PrecheckUnit, error) {

--- a/resource/opener.go
+++ b/resource/opener.go
@@ -78,7 +78,11 @@ func newInternalResourceOpener(
 	if unit != nil {
 		charmURL, _ = unit.CharmURL()
 	} else {
-		charmURL, _ = application.CharmURL()
+		cURL, _ := application.CharmURL()
+		charmURL, err = charm.ParseURL(*cURL)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	switch {
 	case charm.CharmHub.Matches(charmURL.Schema):

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -623,8 +623,7 @@ func (checker *ModelChecker) readApplicationsAndUnits() {
 	checkErr(err, "AllApplications")
 	for _, app := range apps {
 		charmURL, _ := app.CharmURL()
-		appCharmURLStr := charmURL.String()
-		checker.appReferencedCharms.Add(appCharmURLStr, app.Name())
+		checker.appReferencedCharms.Add(*charmURL, app.Name())
 		units, err := app.AllUnits()
 		checkErr(err, "AllUnits")
 		for _, unit := range units {
@@ -634,7 +633,7 @@ func (checker *ModelChecker) readApplicationsAndUnits() {
 				continue
 			}
 			unitString := unitCharmURL.String()
-			if unitString != appCharmURLStr {
+			if unitString != *charmURL {
 				checker.unitReferencedCharms.Add(unitString, unit.Name())
 			}
 			tools, err := unit.AgentTools()

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/juju/charm/v8"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -67,14 +68,14 @@ func (s *ActionSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit.Series(), gc.Equals, "quantal")
 
-	err = s.unit.SetCharmURL(sURL)
+	err = s.unit.SetCharmURL(charm.MustParseURL(*sURL))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.unit2, err = s.application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.unit2.Series(), gc.Equals, "quantal")
 
-	err = s.unit2.SetCharmURL(sURL)
+	err = s.unit2.SetCharmURL(charm.MustParseURL(*sURL))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmlessUnit, err = s.application.AddUnit(state.AddUnitParams{})
@@ -85,7 +86,7 @@ func (s *ActionSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.actionlessUnit.Series(), gc.Equals, "quantal")
 
-	err = s.actionlessUnit.SetCharmURL(actionlessSURL)
+	err = s.actionlessUnit.SetCharmURL(charm.MustParseURL(*actionlessSURL))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.model, err = s.State.Model()
@@ -591,7 +592,7 @@ func makeUnits(c *gc.C, s *ActionSuite, units map[string]*state.Unit, schemas ma
 		u, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(u.Series(), gc.Equals, "quantal")
-		err = u.SetCharmURL(sURL)
+		err = u.SetCharmURL(charm.MustParseURL(*sURL))
 		c.Assert(err, jc.ErrorIsNil)
 
 		units[name] = u

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -949,9 +949,12 @@ func (b *backingApplicationOffer) updated(ctx *allWatcherContext) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	curl, _ := localApp.CharmURL()
+	ch, _, err := localApp.Charm()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	info.ApplicationName = offer.ApplicationName
-	info.CharmName = curl.Name
+	info.CharmName = ch.Tag().Id()
 
 	remoteConnection, err := ctx.state.RemoteConnectionStatus(info.OfferUUID)
 	if err != nil {

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -649,7 +649,7 @@ func (app *backingApplication) updated(ctx *allWatcherContext) error {
 		ModelUUID:   app.ModelUUID,
 		Name:        app.Name,
 		Exposed:     app.Exposed,
-		CharmURL:    app.CharmURL.String(),
+		CharmURL:    *app.CharmURL,
 		Life:        life.Value(app.Life.String()),
 		MinUnits:    app.MinUnits,
 		Subordinate: app.Subordinate,

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -949,12 +949,13 @@ func (b *backingApplicationOffer) updated(ctx *allWatcherContext) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	ch, _, err := localApp.Charm()
+	info.ApplicationName = offer.ApplicationName
+	cURL, _ := localApp.CharmURL()
+	curl, err := charm.ParseURL(*cURL)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	info.ApplicationName = offer.ApplicationName
-	info.CharmName = ch.Tag().Id()
+	info.CharmName = curl.Name
 
 	remoteConnection, err := ctx.state.RemoteConnectionStatus(info.OfferUUID)
 	if err != nil {

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -577,7 +577,8 @@ func (s *allWatcherStateSuite) checkGetAll(c *gc.C, expectEntities entityInfoSli
 }
 
 func applicationCharmURL(app *Application) *charm.URL {
-	url, _ := app.CharmURL()
+	urlStr, _ := app.CharmURL()
+	url := charm.MustParseURL(*urlStr)
 	return url
 }
 
@@ -3539,7 +3540,8 @@ func testChangeApplicationOffers(c *gc.C, runChangeTests func(*gc.C, []changeTes
 			applicationOfferInfo, owner, _ := addOffer(c, st)
 			app, err := st.Application("mysql")
 			c.Assert(err, jc.ErrorIsNil)
-			curl, _ := app.CharmURL()
+			curlStr, _ := app.CharmURL()
+			curl := charm.MustParseURL(*curlStr)
 			ch, err := st.Charm(curl)
 			c.Assert(err, jc.ErrorIsNil)
 			AddTestingApplication(c, st, "another-mysql", ch)

--- a/state/application.go
+++ b/state/application.go
@@ -899,12 +899,15 @@ func (a *Application) setExposed(exposed bool, exposedEndpoints map[string]Expos
 func (a *Application) Charm() (*Charm, bool, error) {
 	// We don't worry about the channel since we aren't interacting
 	// with the charm store here.
-	cURL, force := a.CharmURL()
-	ch, err := a.st.Charm(cURL)
+	curl, err := charm.ParseURL(*a.doc.CharmURL)
 	if err != nil {
 		return nil, false, err
 	}
-	return ch, force, nil
+	ch, err := a.st.Charm(curl)
+	if err != nil {
+		return nil, false, err
+	}
+	return ch, a.doc.ForceCharm, nil
 }
 
 // CharmOrigin returns the origin of a charm associated with a application.
@@ -924,15 +927,11 @@ func (a *Application) CharmModifiedVersion() int {
 	return a.doc.CharmModifiedVersion
 }
 
-// CharmURL returns the application's charm URL, and whether units should upgrade
-// to the charm with that URL even if they are in an error state.
-func (a *Application) CharmURL() (*charm.URL, bool) {
-	cURL, err := charm.ParseURL(*a.doc.CharmURL)
-	if err != nil {
-		// TODO: (hml) change method signature
-		return nil, false
-	}
-	return cURL, a.doc.ForceCharm
+// CharmURL returns a string version of the application's charm URL, and
+// whether units should upgrade to the charm with that URL even if they are
+// in an error state.
+func (a *Application) CharmURL() (*string, bool) {
+	return a.doc.CharmURL, a.doc.ForceCharm
 }
 
 // Channel identifies the charm store channel from which the application's

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -84,7 +84,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, s.charm.URL())
 	c.Assert(force, jc.IsFalse)
 	url, force := s.mysql.CharmURL()
-	c.Assert(url, gc.DeepEquals, s.charm.URL())
+	c.Assert(*url, gc.DeepEquals, s.charm.URL().String())
 	c.Assert(force, jc.IsFalse)
 
 	// Add a compatible charm and force it.
@@ -101,7 +101,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = s.mysql.CharmURL()
-	c.Assert(url, gc.DeepEquals, sch.URL())
+	c.Assert(*url, gc.DeepEquals, sch.URL().String())
 	c.Assert(force, jc.IsTrue)
 }
 
@@ -180,7 +180,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(url, gc.DeepEquals, charm.URL())
+	c.Assert(*url, gc.DeepEquals, charm.URL().String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile", lxdProfileMetaBase, 2)
@@ -196,7 +196,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = app.CharmURL()
-	c.Assert(url, gc.DeepEquals, sch.URL())
+	c.Assert(*url, gc.DeepEquals, sch.URL().String())
 	c.Assert(force, jc.IsTrue)
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 }
@@ -214,7 +214,7 @@ func (s *ApplicationSuite) TestLXDProfileFailSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(url, gc.DeepEquals, charm.URL())
+	c.Assert(*url, gc.DeepEquals, charm.URL().String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile-fail", lxdProfileMetaBase, 2)
@@ -240,7 +240,7 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(url, gc.DeepEquals, charm.URL())
+	c.Assert(*url, gc.DeepEquals, charm.URL().String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile-fail", lxdProfileMetaBase, 2)
@@ -257,7 +257,7 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = app.CharmURL()
-	c.Assert(url, gc.DeepEquals, sch.URL())
+	c.Assert(*url, gc.DeepEquals, sch.URL().String())
 	c.Assert(force, jc.IsTrue)
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1921,12 +1921,14 @@ func (s *ApplicationSuite) TestUpdateApplicationSeriesSecondSubordinateIncompati
 }
 
 func assertNoSettingsRef(c *gc.C, st *state.State, appName string, sch *state.Charm) {
-	_, err := state.ApplicationSettingsRefCount(st, appName, sch.URL())
+	cURL := sch.URL().String()
+	_, err := state.ApplicationSettingsRefCount(st, appName, &cURL)
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
 }
 
 func assertSettingsRef(c *gc.C, st *state.State, appName string, sch *state.Charm, refcount int) {
-	rc, err := state.ApplicationSettingsRefCount(st, appName, sch.URL())
+	cURL := sch.URL().String()
+	rc, err := state.ApplicationSettingsRefCount(st, appName, &cURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc, gc.Equals, refcount)
 }

--- a/state/bench_test.go
+++ b/state/bench_test.go
@@ -6,6 +6,7 @@ package state_test
 import (
 	"time"
 
+	"github.com/juju/charm/v8"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
@@ -78,12 +79,12 @@ func benchmarkAddMetrics(metricsPerBatch, batches int, c *gc.C) {
 			Time:  now,
 		}
 	}
-	charm := s.AddTestingCharm(c, "wordpress")
-	app := s.AddTestingApplication(c, "wordpress", charm)
+	ch := s.AddTestingCharm(c, "wordpress")
+	app := s.AddTestingApplication(c, "wordpress", ch)
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	applicationCharmURL, _ := app.CharmURL()
-	err = unit.SetCharmURL(applicationCharmURL)
+	err = unit.SetCharmURL(charm.MustParseURL(*applicationCharmURL))
 	c.Assert(err, jc.ErrorIsNil)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
@@ -92,7 +93,7 @@ func benchmarkAddMetrics(metricsPerBatch, batches int, c *gc.C) {
 				state.BatchParam{
 					UUID:     utils.MustNewUUID().String(),
 					Created:  now,
-					CharmURL: applicationCharmURL.String(),
+					CharmURL: *applicationCharmURL,
 					Metrics:  metrics,
 					Unit:     unit.UnitTag(),
 				},
@@ -112,12 +113,12 @@ func (*BenchmarkSuite) BenchmarkCleanupMetrics(c *gc.C) {
 	s.SetUpTest(c)
 	defer s.TearDownTest(c)
 	oldTime := time.Now().Add(-(state.CleanupAge))
-	charm := s.AddTestingCharm(c, "wordpress")
-	app := s.AddTestingApplication(c, "wordpress", charm)
+	ch := s.AddTestingCharm(c, "wordpress")
+	app := s.AddTestingApplication(c, "wordpress", ch)
 	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	applicationCharmURL, _ := app.CharmURL()
-	err = unit.SetCharmURL(applicationCharmURL)
+	err = unit.SetCharmURL(charm.MustParseURL(*applicationCharmURL))
 	c.Assert(err, jc.ErrorIsNil)
 	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
@@ -126,7 +127,7 @@ func (*BenchmarkSuite) BenchmarkCleanupMetrics(c *gc.C) {
 				state.BatchParam{
 					UUID:     utils.MustNewUUID().String(),
 					Created:  oldTime,
-					CharmURL: applicationCharmURL.String(),
+					CharmURL: *applicationCharmURL,
 					Metrics:  []state.Metric{{}},
 					Unit:     unit.UnitTag(),
 				},

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -14,18 +14,18 @@ var errCharmInUse = errors.New("charm in use")
 // appCharmIncRefOps returns the operations necessary to record a reference
 // to a charm and its per-application settings and storage constraints
 // documents. It will fail if the charm is not Alive.
-func appCharmIncRefOps(mb modelBackend, appName string, curl *charm.URL, canCreate bool) ([]txn.Op, error) {
+func appCharmIncRefOps(mb modelBackend, appName string, cURL *string, canCreate bool) ([]txn.Op, error) {
 	charms, cCloser := mb.db().GetCollection(charmsC)
 	defer cCloser()
 
 	// If we're migrating. charm document will not be present. But
 	// if we're not migrating, we need to check the charm is alive.
 	var checkOps []txn.Op
-	count, err := charms.FindId(curl.String()).Count()
+	count, err := charms.FindId(*cURL).Count()
 	if err != nil {
 		return nil, errors.Annotate(err, "charm")
 	} else if count != 0 {
-		checkOp, err := nsLife.aliveOp(charms, curl.String())
+		checkOp, err := nsLife.aliveOp(charms, *cURL)
 		if err != nil {
 			return nil, errors.Annotate(err, "charm")
 		}
@@ -39,15 +39,19 @@ func appCharmIncRefOps(mb modelBackend, appName string, curl *charm.URL, canCrea
 	if !canCreate {
 		getIncRefOp = nsRefcounts.StrictIncRefOp
 	}
-	settingsKey := applicationCharmConfigKey(appName, curl)
+	settingsKey := applicationCharmConfigKey(appName, cURL)
 	settingsOp, err := getIncRefOp(refcounts, settingsKey, 1)
 	if err != nil {
 		return nil, errors.Annotate(err, "settings reference")
 	}
-	storageConstraintsKey := applicationStorageConstraintsKey(appName, curl)
+	storageConstraintsKey := applicationStorageConstraintsKey(appName, cURL)
 	storageConstraintsOp, err := getIncRefOp(refcounts, storageConstraintsKey, 1)
 	if err != nil {
 		return nil, errors.Annotate(err, "storage constraints reference")
+	}
+	curl, err := charm.ParseURL(*cURL)
+	if err != nil {
+		return nil, errors.Annotate(err, "charm url parsing")
 	}
 	charmKey := charmGlobalKey(curl)
 	charmOp, err := getIncRefOp(refcounts, charmKey, 1)
@@ -69,7 +73,7 @@ func appCharmIncRefOps(mb modelBackend, appName string, curl *charm.URL, canCrea
 // When 'force' is set, this call will return some, if not all, needed operations
 // and will accumulate operational errors encountered in the operation.
 // If the 'force' is not set, any error will be fatal and no operations will be returned.
-func appCharmDecRefOps(st modelBackend, appName string, curl *charm.URL, maybeDoFinal bool, op *ForcedOperation) ([]txn.Op, error) {
+func appCharmDecRefOps(st modelBackend, appName string, cURL *string, maybeDoFinal bool, op *ForcedOperation) ([]txn.Op, error) {
 	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()
 
@@ -77,6 +81,10 @@ func appCharmDecRefOps(st modelBackend, appName string, curl *charm.URL, maybeDo
 		return nil, errors.Trace(e)
 	}
 	ops := []txn.Op{}
+	curl, err := charm.ParseURL(*cURL)
+	if op.FatalError(err) {
+		return fail(errors.Annotate(err, "charm url parsing"))
+	}
 	charmKey := charmGlobalKey(curl)
 	charmOp, err := nsRefcounts.AliveDecRefOp(refcounts, charmKey)
 	if op.FatalError(err) {
@@ -86,7 +94,7 @@ func appCharmDecRefOps(st modelBackend, appName string, curl *charm.URL, maybeDo
 		ops = append(ops, charmOp)
 	}
 
-	settingsKey := applicationCharmConfigKey(appName, curl)
+	settingsKey := applicationCharmConfigKey(appName, cURL)
 	settingsOp, isFinal, err := nsRefcounts.DyingDecRefOp(refcounts, settingsKey)
 	if op.FatalError(err) {
 		return fail(errors.Annotatef(err, "settings reference %s", settingsKey))
@@ -95,7 +103,7 @@ func appCharmDecRefOps(st modelBackend, appName string, curl *charm.URL, maybeDo
 		ops = append(ops, settingsOp)
 	}
 
-	storageConstraintsKey := applicationStorageConstraintsKey(appName, curl)
+	storageConstraintsKey := applicationStorageConstraintsKey(appName, cURL)
 	storageConstraintsOp, _, err := nsRefcounts.DyingDecRefOp(refcounts, storageConstraintsKey)
 	if op.FatalError(err) {
 		return fail(errors.Annotatef(err, "storage constraints reference %s", storageConstraintsKey))
@@ -110,14 +118,14 @@ func appCharmDecRefOps(st modelBackend, appName string, curl *charm.URL, maybeDo
 		// serial. If this logic is used twice while composing a
 		// single transaction, the removal won't be triggered.
 		// see `Application.removeOps` for the workaround.
-		ops = append(ops, finalAppCharmRemoveOps(appName, curl)...)
+		ops = append(ops, finalAppCharmRemoveOps(appName, cURL)...)
 	}
 	return ops, nil
 }
 
 // finalAppCharmRemoveOps returns operations to delete the settings
 // and storage, device constraints documents and queue a charm cleanup.
-func finalAppCharmRemoveOps(appName string, curl *charm.URL) []txn.Op {
+func finalAppCharmRemoveOps(appName string, curl *string) []txn.Op {
 	settingsKey := applicationCharmConfigKey(appName, curl)
 	removeSettingsOp := txn.Op{
 		C:      settingsC,
@@ -131,7 +139,7 @@ func finalAppCharmRemoveOps(appName string, curl *charm.URL) []txn.Op {
 	deviceConstraintsKey := applicationDeviceConstraintsKey(appName, curl)
 	removeDeviceConstraintsOp := removeDeviceConstraintsOp(deviceConstraintsKey)
 
-	cleanupOp := newCleanupOp(cleanupCharm, curl.String())
+	cleanupOp := newCleanupOp(cleanupCharm, *curl)
 	return []txn.Op{removeSettingsOp, removeStorageConstraintsOp, removeDeviceConstraintsOp, cleanupOp}
 }
 

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -51,7 +51,7 @@ func appCharmIncRefOps(mb modelBackend, appName string, cURL *string, canCreate 
 	}
 	curl, err := charm.ParseURL(*cURL)
 	if err != nil {
-		return nil, errors.Annotate(err, "charm url parsing")
+		return nil, errors.Annotate(err, "parsing charm url")
 	}
 	charmKey := charmGlobalKey(curl)
 	charmOp, err := getIncRefOp(refcounts, charmKey, 1)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -160,7 +160,7 @@ func CloudModelRefCount(st *State, cloudName string) (int, error) {
 	return nsRefcounts.read(refcounts, key)
 }
 
-func ApplicationSettingsRefCount(st *State, appName string, curl *charm.URL) (int, error) {
+func ApplicationSettingsRefCount(st *State, appName string, curl *string) (int, error) {
 	refcounts, closer := st.db().GetCollection(refcountsC)
 	defer closer()
 

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -839,7 +839,7 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		Type:                 e.model.Type(),
 		Series:               application.doc.Series,
 		Subordinate:          application.doc.Subordinate,
-		CharmURL:             application.doc.CharmURL.String(),
+		CharmURL:             *application.doc.CharmURL,
 		Channel:              application.doc.Channel,
 		CharmModifiedVersion: application.doc.CharmModifiedVersion,
 		ForceCharm:           application.doc.ForceCharm,
@@ -1983,9 +1983,10 @@ func (e *exporter) getCharmOrigin(doc applicationDoc, defaultArch string) (descr
 	}, nil
 }
 
-func deduceOrigin(url *charm.URL) (description.CharmOriginArgs, error) {
-	if url == nil {
-		return description.CharmOriginArgs{}, errors.NotValidf("charm url")
+func deduceOrigin(cURL *string) (description.CharmOriginArgs, error) {
+	url, err := charm.ParseURL(*cURL)
+	if err != nil {
+		return description.CharmOriginArgs{}, errors.NewNotValid(err, "charm url")
 	}
 
 	switch url.Schema {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1266,12 +1266,7 @@ func (i *importer) importUnitPayloads(unit *Unit, payloadInfo []description.Payl
 func (i *importer) makeApplicationDoc(a description.Application) (*applicationDoc, error) {
 	units := a.Units()
 
-	charmURL, err := charm.ParseURL(a.CharmURL())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	origin, err := i.makeCharmOrigin(a, charmURL, units)
+	origin, err := i.makeCharmOrigin(a, units)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1291,11 +1286,12 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	cURL := a.CharmURL()
 	return &applicationDoc{
 		Name:                 a.Name(),
 		Series:               a.Series(),
 		Subordinate:          a.Subordinate(),
-		CharmURL:             charmURL,
+		CharmURL:             &cURL,
 		Channel:              a.Channel(),
 		CharmModifiedVersion: a.CharmModifiedVersion(),
 		CharmOrigin:          origin,
@@ -1350,7 +1346,12 @@ func (i *importer) loadInstanceHardwareFromUnits(units []description.Unit) ([]in
 	return hwChars, nil
 }
 
-func (i *importer) makeCharmOrigin(a description.Application, curl *charm.URL, units []description.Unit) (*CharmOrigin, error) {
+func (i *importer) makeCharmOrigin(a description.Application, units []description.Unit) (*CharmOrigin, error) {
+	curl, err := charm.ParseURL(a.CharmURL())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	co := a.CharmOrigin()
 	if co == nil {
 		return i.deduceCharmOrigin(a, curl, units)

--- a/state/state.go
+++ b/state/state.go
@@ -1239,13 +1239,14 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 
 	// The doc defaults to CharmModifiedVersion = 0, which is correct, since it
 	// has, by definition, at its initial state.
+	cURL := args.Charm.URL().String()
 	appDoc := &applicationDoc{
 		DocID:         applicationID,
 		Name:          args.Name,
 		ModelUUID:     st.ModelUUID(),
 		Series:        args.Series,
 		Subordinate:   subordinate,
-		CharmURL:      args.Charm.URL(),
+		CharmURL:      &cURL,
 		CharmOrigin:   args.CharmOrigin,
 		Channel:       string(args.Channel),
 		RelationCount: len(peers),

--- a/state/unit.go
+++ b/state/unit.go
@@ -1562,8 +1562,9 @@ func (u *Unit) charm() (*Charm, error) {
 		if err != nil {
 			return nil, err
 		}
-		cURL, _ = app.CharmURL()
-		if cURL == nil {
+		appCURLStr, _ := app.CharmURL()
+		cURL, err = charm.ParseURL(*appCURLStr)
+		if err != nil {
 			return nil, errors.NotValidf("application charm url")
 		}
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -146,15 +146,8 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 		return nil, fmt.Errorf("unit's charm URL must be set before retrieving config")
 	}
 
-	cURL, err := u.CharmURL()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	// TODO (manadart 2019-02-21) Factor the current generation into this call.
-	// TODO (manadart 2021-12-03) Most places where we are passing a charm URL
-	// could just use its string form.
-	s, err := charmSettingsWithDefaults(u.st, cURL, u.doc.Application, model.GenerationMaster)
+	s, err := charmSettingsWithDefaults(u.st, u.doc.CharmURL, u.doc.Application, model.GenerationMaster)
 	if err != nil {
 		return nil, errors.Annotatef(err, "charm config for unit %q", u.Name())
 	}
@@ -1515,7 +1508,8 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 		}
 
 		// Add a reference to the application settings for the new charm.
-		incOps, err := appCharmIncRefOps(u.st, u.doc.Application, curl, false)
+		cURL := curl.String()
+		incOps, err := appCharmIncRefOps(u.st, u.doc.Application, &cURL, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1530,21 +1524,18 @@ func (u *Unit) SetCharmURL(curl *charm.URL) error {
 				Update: bson.D{{"$set", bson.D{{"charmurl", curl}}}},
 			})
 
-		cURL, err := u.CharmURL()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if cURL != nil {
+		unitCURL := u.doc.CharmURL
+		if unitCURL != nil {
 			// Drop the reference to the old charm.
 			// Since we can force this now, let's.. There is no point hanging on to the old charm.
 			op := &ForcedOperation{Force: true}
-			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, cURL, true, op)
+			decOps, err := appCharmDecRefOps(u.st, u.doc.Application, unitCURL, true, op)
 			if err != nil {
 				// No need to stop further processing if the old key could not be removed.
-				logger.Errorf("could not remove old charm references for %s: %v", cURL, err)
+				logger.Errorf("could not remove old charm references for %s: %v", unitCURL, err)
 			}
 			if len(op.Errors) != 0 {
-				logger.Errorf("could not remove old charm references for %s: %v", cURL, op.Errors)
+				logger.Errorf("could not remove old charm references for %s: %v", unitCURL, op.Errors)
 			}
 			ops = append(ops, decOps...)
 		}
@@ -1571,7 +1562,10 @@ func (u *Unit) charm() (*Charm, error) {
 		if err != nil {
 			return nil, err
 		}
-		cURL = app.doc.CharmURL
+		cURL, _ = app.CharmURL()
+		if cURL == nil {
+			return nil, errors.NotValidf("application charm url")
+		}
 	}
 
 	ch, err := u.st.Charm(cURL)
@@ -2908,13 +2902,7 @@ func (u *Unit) StorageConstraints() (map[string]StorageConstraints, error) {
 		}
 		return app.StorageConstraints()
 	}
-
-	cURL, err := u.CharmURL()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	key := applicationStorageConstraintsKey(u.doc.Application, cURL)
+	key := applicationStorageConstraintsKey(u.doc.Application, u.doc.CharmURL)
 	cons, err := readStorageConstraints(u.st, key)
 	if errors.IsNotFound(err) {
 		return nil, nil
@@ -2965,13 +2953,8 @@ func addUnitOps(st *State, args addUnitOpsArgs) ([]txn.Op, error) {
 	// will need to be more sophisticated, because it might need to
 	// create the settings doc.
 	if charmURL := args.unitDoc.CharmURL; charmURL != nil {
-		cURL, err := charm.ParseURL(*charmURL)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
 		appName := args.unitDoc.Application
-		charmRefOps, err := appCharmIncRefOps(st, appName, cURL, false)
+		charmRefOps, err := appCharmIncRefOps(st, appName, charmURL, false)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -3481,9 +3481,9 @@ func AddCharmOriginToApplications(pool *StatePool) error {
 			}
 
 			// It is expected that every application should have a charm URL.
-			charmURL := application.CharmURL
-			if charmURL == nil {
-				return errors.Errorf("charmurl is empty")
+			charmURL, err := charm.ParseURL(*application.CharmURL)
+			if err != nil {
+				return errors.Annotatef(err, "parsing charm url")
 			}
 
 			var arch string
@@ -3837,9 +3837,9 @@ func EnsureCharmOriginRisk(pool *StatePool) error {
 		var ops []txn.Op
 		for _, doc := range docs {
 			// It is expected that every application should have a charm URL.
-			charmURL := doc.CharmURL
-			if charmURL == nil {
-				return errors.Errorf("charmurl is empty")
+			charmURL, err := charm.ParseURL(*doc.CharmURL)
+			if err != nil {
+				return errors.Annotatef(err, "parsing charm url")
 			}
 
 			if charmURL.Schema == "local" {
@@ -4449,9 +4449,9 @@ func RemoveLocalCharmOriginChannels(pool *StatePool) error {
 		var ops []txn.Op
 		for _, doc := range docs {
 			// It is expected that every application should have a charm URL.
-			charmURL := doc.CharmURL
-			if charmURL == nil {
-				return errors.Errorf("charmurl is empty")
+			charmURL, err := charm.ParseURL(*doc.CharmURL)
+			if err != nil {
+				return errors.Annotatef(err, "parsing charm url")
 			}
 
 			if charmURL.Schema != "local" {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -2947,12 +2947,12 @@ func (s *upgradesSuite) makeApplication(c *gc.C, uuid, name string, life Life) {
 	coll, closer := s.state.db().GetRawCollection(applicationsC)
 	defer closer()
 
-	curl := charm.MustParseURL("cs:test-charm")
+	curl := "cs:test-charm"
 	err := coll.Insert(applicationDoc{
 		DocID:     ensureModelUUID(uuid, name),
 		Name:      name,
 		ModelUUID: uuid,
-		CharmURL:  curl,
+		CharmURL:  &curl,
 		Life:      life,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2064,13 +2064,7 @@ func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
-
-	cURL, err := u.CharmURL()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, cURL)
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
 	return newEntityWatcher(u.st, settingsC, u.st.docID(charmConfigKey)), nil
 }
 
@@ -2089,13 +2083,7 @@ func (u *Unit) WatchConfigSettingsHash() (StringsWatcher, error) {
 	if u.doc.CharmURL == nil {
 		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
 	}
-
-	cURL, err := u.CharmURL()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, cURL)
+	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
 	return newSettingsHashWatcher(u.st, charmConfigKey), nil
 }
 
@@ -2159,7 +2147,7 @@ func watchInstanceCharmProfileCompatibilityData(backend modelBackend, watchDocId
 		if err := query.One(&doc); err != nil {
 			return "", err
 		}
-		return doc.CharmURL.String(), nil
+		return *doc.CharmURL, nil
 	}
 	transform := func(value string) string {
 		return lxdprofile.NotRequiredStatus

--- a/state/watcher_profilecharm_test.go
+++ b/state/watcher_profilecharm_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/juju/charm/v8"
 	"github.com/juju/mgo/v2/bson"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
@@ -193,7 +192,7 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) expectInitialCollectionI
 		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop)
 		s.collection.EXPECT().Find(bson.D{{"_id", "1"}}).Return(s.query)
 		s.query.EXPECT().One(gomock.Any()).SetArg(0, state.ApplicationDoc{
-			CharmURL: charm.MustParseURL(url),
+			CharmURL: &url,
 		}).Return(nil)
 	}
 }
@@ -218,7 +217,7 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) expectMergeCollectionIns
 		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop)
 		s.collection.EXPECT().Find(bson.D{{"_id", "1"}}).Return(s.query)
 		s.query.EXPECT().One(gomock.Any()).SetArg(0, state.ApplicationDoc{
-			CharmURL: charm.MustParseURL(url),
+			CharmURL: &url,
 		}).Return(nil)
 	}
 }

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -630,7 +630,8 @@ func (factory *Factory) MakeUnitReturningPassword(c *gc.C, params *UnitParams) (
 	}
 
 	if params.SetCharmURL {
-		applicationCharmURL, _ := params.Application.CharmURL()
+		applicationCharmURLStr, _ := params.Application.CharmURL()
+		applicationCharmURL, _ := charm.ParseURL(*applicationCharmURLStr)
 		err = unit.SetCharmURL(applicationCharmURL)
 		c.Assert(err, jc.ErrorIsNil)
 	}

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -359,7 +359,7 @@ func (s *factorySuite) TestMakeApplication(c *gc.C) {
 
 	c.Assert(application.Name(), gc.Equals, "wordpress")
 	curl, _ := application.CharmURL()
-	c.Assert(curl, gc.DeepEquals, charm.URL())
+	c.Assert(*curl, gc.Equals, charm.String())
 
 	saved, err := s.State.Application(application.Name())
 	c.Assert(err, jc.ErrorIsNil)
@@ -402,7 +402,7 @@ func (s *factorySuite) TestMakeUnit(c *gc.C) {
 
 	applicationCharmURL, _ := application.CharmURL()
 	unitCharmURL, _ := saved.CharmURL()
-	c.Assert(unitCharmURL, gc.DeepEquals, applicationCharmURL)
+	c.Assert(unitCharmURL.String(), gc.Equals, *applicationCharmURL)
 }
 
 func (s *factorySuite) TestMakeRelationNil(c *gc.C) {

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -236,6 +236,8 @@ func checkCharmUpgrade(logger Logger, charmDir string, remote remotestate.Snapsh
 		}
 	}
 
+	// TODO (hmlanigan) 2022-06-08
+	// Is there any reason for the local and remote CharmURL to not be string pointers?
 	sameCharm := *local.CharmURL == *remote.CharmURL
 	if haveCharmDir && (!local.State.Started || sameCharm) {
 		return nil


### PR DESCRIPTION
Follow on to #14030 

Like with the unit doc, we have ended up in a situation where we are paying a small overhead to parse the application's charm URL upon every access, even when we might not use the field.

Here we update the document to store a string, and only parse the URL at need. The patch is scoped to what is necessary to change the one field in the application document, as well as changing the signature of the CharmURL method. The CharmURL method change for an application allows code on the apiserver side to only part the URL if it's absolutely necessary. 

Once the state Charm method takes a string, rather than a charm.URL, some of the conversions made in the apiserver will no longer be necessary.

## QA steps

Test upgrade from 2.8, deploy, migration, etc. Watch for application doc errors.
