### PR TITLE
[JUJU-1106] new json color scheme juju config

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -3,7 +3,6 @@
 package application
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -385,9 +384,7 @@ func (c *configCommand) validateValues(ctx *cmd.Context) (map[string]string, err
 // FormatYaml serializes value into valid yaml string. If color flag is passed it adds ANSI color escape codes to the output.
 func (c *configCommand) FormatYaml(w io.Writer, value interface{}) error {
 	if c.configBase.Color {
-		// use a buffered writer, we need to process(color) data into a buffer before writing to IO
-		colorBufferedWriter := output.Writer(bufio.NewWriter(w))
-		return output.FormatYamlWithColor(colorBufferedWriter, value)
+		return output.FormatYamlWithColor(w, value)
 	}
 	return cmd.FormatYaml(w, value)
 }
@@ -395,9 +392,7 @@ func (c *configCommand) FormatYaml(w io.Writer, value interface{}) error {
 // FormatJson serializes value into valid json string. If color flag is passed it adds ANSI color escape codes to the output.
 func (c *configCommand) FormatJson(w io.Writer, val interface{}) error {
 	if c.configBase.Color {
-		// use a buffered writer, we need to process(color) data into a buffer before writing to IO
-		colorBufferedWriter := output.Writer(bufio.NewWriter(w))
-		return output.FormatJsonWithColor(colorBufferedWriter, val)
+		return output.FormatJsonWithColor(w, val)
 	}
 	return cmd.FormatJson(w, val)
 }

--- a/cmd/juju/config/config.go
+++ b/cmd/juju/config/config.go
@@ -46,6 +46,7 @@ type ConfigCommandBase struct {
 	// Flag values
 	ConfigFile cmd.FileVar
 	reset      []string // Holds the keys to be reset until parsed.
+	Color      bool
 
 	// Fields to be set during initialisation
 	Actions     []Action // The action which we want to handle, set in Init.
@@ -59,10 +60,12 @@ type ConfigCommandBase struct {
 // SetFlags implements cmd.Command.SetFlags.
 func (c *ConfigCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.ConfigFile, "file", "path to yaml-formatted configuration file")
+	f.BoolVar(&c.Color, "color", false, "Use ANSI color codes in output")
 	if c.Resettable {
 		f.Var(cmd.NewAppendStringsValue(&c.reset), "reset",
 			"Reset the provided comma delimited keys")
 	}
+
 }
 
 // Init provides a basic implementation of cmd.Command.Init.

--- a/cmd/juju/config/config_test.go
+++ b/cmd/juju/config/config_test.go
@@ -34,7 +34,7 @@ func (s *suite) TestSetFlags(c *gc.C) {
 		cmd.SetFlags(f)
 
 		// Collect all flags
-		expectedFlags := []string{"file"}
+		expectedFlags := []string{"color", "file"}
 		if resettable {
 			expectedFlags = append(expectedFlags, "reset")
 		}

--- a/cmd/output/colors.go
+++ b/cmd/output/colors.go
@@ -1,0 +1,19 @@
+package output
+
+import "github.com/juju/ansiterm"
+
+// Colors holds Color for each of the JSON and YAML data types.
+type Colors struct {
+	// Null is the Color for JSON nil.
+	Null *ansiterm.Context
+	// Bool is the Color for boolean values.
+	Bool *ansiterm.Context
+	// Number is the Color for number values.
+	Number *ansiterm.Context
+	// String is the Color for string values.
+	String *ansiterm.Context
+	// Key is the Color for JSON keys.
+	Key *ansiterm.Context
+	//KeyValSep separates key from values.
+	KeyValSep *ansiterm.Context
+}

--- a/cmd/output/colors.go
+++ b/cmd/output/colors.go
@@ -1,3 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package output
 
 import "github.com/juju/ansiterm"

--- a/cmd/output/jsonformatter.go
+++ b/cmd/output/jsonformatter.go
@@ -31,7 +31,7 @@ type JSONFormatter struct {
 	writer *ansiterm.Writer
 	// buff is the internal buffer used by writer to write out ansi-color formatted strings.
 	buff *bytes.Buffer
-	//InitialDepth used as multiplier for the number of spaces to be used for indentation.
+	// InitialDepth used as multiplier for the number of spaces to be used for indentation.
 	InitialDepth int
 	// RawStrings enable parsing as json raw strings
 	RawStrings bool

--- a/cmd/output/jsonformatter.go
+++ b/cmd/output/jsonformatter.go
@@ -76,6 +76,8 @@ func (f *JSONFormatter) writeObjSep(buf *bytes.Buffer) {
 	}
 }
 
+// Marshal traverses the value jsonObj recursively, encoding each field and appending it
+// with ansi escape sequence for colored output.
 func (f *JSONFormatter) Marshal(jsonObj interface{}) ([]byte, error) {
 	buffer := bytes.Buffer{}
 	f.marshalValue(jsonObj, &buffer, f.InitialDepth)

--- a/cmd/output/jsonformatter.go
+++ b/cmd/output/jsonformatter.go
@@ -1,0 +1,196 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/juju/ansiterm"
+)
+
+const (
+	valueSep   = ","
+	null       = "null"
+	beginMap   = "{"
+	endMap     = "}"
+	beginArray = "["
+	endArray   = "]"
+	emptyMap   = "{}"
+	emptyArray = "[]"
+)
+
+// Colors holds Color for each of the JSON data types.
+type Colors struct {
+	// Null is the Color for JSON nil.
+	Null *ansiterm.Context
+	// Bool is the Color for boolean values.
+	Bool *ansiterm.Context
+	// Number is the Color for number values.
+	Number *ansiterm.Context
+	// String is the Color for string values.
+	String *ansiterm.Context
+	// Key is the Color for JSON keys.
+	Key *ansiterm.Context
+	//KeyValSep separates key from values.
+	KeyValSep *ansiterm.Context
+	//InitialDepth used as multiplier for the number of spaces to be used for indentation.
+	InitialDepth int
+	// RawStrings enable parsing as json raw strings
+	RawStrings bool
+}
+
+// Formatter is a custom formatter that is used to custom format parsed input.
+type Formatter struct {
+	// Colors a list of colors that the formatter uses for writing output.
+	Colors
+	// Number of spaces before the first string is printed.
+	Indent int
+	// writer writes formatted output to the internal buffer (buff).
+	writer *ansiterm.Writer
+	// buff is the internal buffer used by writer to write out ansi-color formatted strings.
+	buff *bytes.Buffer
+}
+
+// NewFormatter instantiates a new formatter with default options.
+func NewFormatter() *Formatter {
+	buff, writer := bufferedWriter()
+	return &Formatter{
+		Colors: Colors{
+			Null:      ansiterm.Foreground(ansiterm.Magenta),
+			Key:       ansiterm.Foreground(ansiterm.BrightCyan).SetStyle(ansiterm.Bold),
+			Bool:      ansiterm.Foreground(ansiterm.Magenta),
+			Number:    ansiterm.Foreground(ansiterm.Magenta),
+			KeyValSep: ansiterm.Foreground(ansiterm.BrightMagenta),
+			String:    ansiterm.Foreground(ansiterm.Default),
+		},
+		writer: writer,
+		buff:   buff,
+	}
+}
+
+func bufferedWriter() (*bytes.Buffer, *ansiterm.Writer) {
+	buff := &bytes.Buffer{}
+	writer := ansiterm.NewWriter(buff)
+	writer.SetColorCapable(true)
+	return buff, writer
+}
+
+// marshal JSON data with default options
+func marshal(jsonObj interface{}) ([]byte, error) {
+	return NewFormatter().Marshal(jsonObj)
+}
+
+func (f *Formatter) writeIndent(buf *bytes.Buffer, depth int) {
+	buf.WriteString(strings.Repeat(" ", f.Indent*depth))
+}
+
+func (f *Formatter) writeObjSep(buf *bytes.Buffer) {
+	if f.Indent != 0 {
+		buf.WriteByte('\n')
+	}
+}
+
+func (f *Formatter) Marshal(jsonObj interface{}) ([]byte, error) {
+	buffer := bytes.Buffer{}
+	f.marshalValue(jsonObj, &buffer, f.InitialDepth)
+	return buffer.Bytes(), nil
+}
+
+func (f *Formatter) marshalString(str string, buf *bytes.Buffer) {
+	if !f.RawStrings {
+		strBytes, _ := json.Marshal(str)
+		str = string(strBytes)
+	}
+
+	f.Colors.String.Fprint(f.writer, str)
+	buf.WriteString(f.buff.String())
+	f.buff.Reset()
+}
+
+func (f *Formatter) marshalMap(m map[string]interface{}, buf *bytes.Buffer, depth int) {
+	remaining := len(m)
+
+	if remaining == 0 {
+		buf.WriteString(emptyMap)
+		return
+	}
+
+	keys := make([]string, 0)
+	for key := range m {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	buf.WriteString(beginMap)
+	f.writeObjSep(buf)
+
+	f.Colors.KeyValSep.Fprint(f.writer, ":")
+	keyValSep := f.buff.String()
+	f.buff.Reset()
+
+	for _, key := range keys {
+		f.writeIndent(buf, depth+1)
+		f.Colors.Key.Fprintf(f.writer, "\"%s\"%s", key, keyValSep)
+		buf.WriteString(f.buff.String())
+		f.buff.Reset()
+		f.marshalValue(m[key], buf, depth+1)
+		remaining--
+		if remaining != 0 {
+			buf.WriteString(valueSep)
+		}
+		f.writeObjSep(buf)
+	}
+	f.writeIndent(buf, depth)
+	buf.WriteString(endMap)
+}
+
+func (f *Formatter) marshalArray(a []interface{}, buf *bytes.Buffer, depth int) {
+	if len(a) == 0 {
+		buf.WriteString(emptyArray)
+		return
+	}
+
+	buf.WriteString(beginArray)
+	f.writeObjSep(buf)
+
+	for i, v := range a {
+		f.writeIndent(buf, depth+1)
+		f.marshalValue(v, buf, depth+1)
+		if i < len(a)-1 {
+			buf.WriteString(valueSep)
+		}
+		f.writeObjSep(buf)
+	}
+	f.writeIndent(buf, depth)
+	buf.WriteString(endArray)
+}
+
+func (f *Formatter) marshalValue(val interface{}, buf *bytes.Buffer, depth int) {
+	switch v := val.(type) {
+	case map[string]interface{}:
+		f.marshalMap(v, buf, depth)
+	case []interface{}:
+		f.marshalArray(v, buf, depth)
+	case string:
+		f.marshalString(v, buf)
+	case float64:
+		f.Colors.Number.Fprint(f.writer, strconv.FormatFloat(v, 'f', -1, 64))
+		buf.WriteString(f.buff.String())
+		f.buff.Reset()
+	case bool:
+		f.Colors.Bool.Fprint(f.writer, strconv.FormatBool(v))
+		buf.WriteString(f.buff.String())
+		f.buff.Reset()
+	case nil:
+		f.Colors.Null.Fprint(f.writer, null)
+		buf.WriteString(f.buff.String())
+		f.buff.Reset()
+	case json.Number:
+		f.Colors.Number.Fprint(f.writer, v.String())
+		buf.WriteString(f.buff.String())
+		f.buff.Reset()
+	}
+}

--- a/cmd/output/jsonformatter.go
+++ b/cmd/output/jsonformatter.go
@@ -1,3 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package output
 
 import (

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -5,7 +5,6 @@ package output
 
 import (
 	"fmt"
-	goyaml "gopkg.in/yaml.v2"
 	"io"
 
 	"github.com/juju/ansiterm"
@@ -21,26 +20,25 @@ var DefaultFormatters = map[string]cmd.Formatter{
 	"json": cmd.FormatJson,
 }
 
-// FormatYamlWithColor formats yaml output with color. w is a colored Writer. (appends ansi color escape
-// codes) to the output.
+// FormatYamlWithColor formats yaml output with color.
 func FormatYamlWithColor(w io.Writer, value interface{}) error {
-	if value == nil {
+	//TODO:
+	return nil
+}
+
+// FormatJsonWithColor formats json output with color.
+func FormatJsonWithColor(w io.Writer, val interface{}) error {
+	if val == nil {
 		return nil
 	}
-	result, err := goyaml.Marshal(value)
+
+	result, err := marshal(val)
 	if err != nil {
 		return err
 	}
 
-	// Parse the result and color it as we output it token by token.
-	fmt.Printf("%v\n", result)
-	return nil
-}
-
-// FormatJsonWithColor formats json output with color. w is a colored Writer. (appends ansi color escape
-// codes) to the output.
-func FormatJsonWithColor(w io.Writer, val interface{}) error {
-	return nil
+	_, err = fmt.Fprintln(w, string(result))
+	return err
 }
 
 // Writer returns a new writer that appends ansi color codes to the output.

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -5,6 +5,7 @@ package output
 
 import (
 	"fmt"
+	goyaml "gopkg.in/yaml.v2"
 	"io"
 
 	"github.com/juju/ansiterm"
@@ -18,6 +19,33 @@ import (
 var DefaultFormatters = map[string]cmd.Formatter{
 	"yaml": cmd.FormatYaml,
 	"json": cmd.FormatJson,
+}
+
+// FormatYamlWithColor formats yaml output with color. w is a colored Writer. (appends ansi color escape
+// codes) to the output.
+func FormatYamlWithColor(w io.Writer, value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	result, err := goyaml.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	// Parse the result and color it as we output it token by token.
+	fmt.Printf("%v\n", result)
+	return nil
+}
+
+// FormatJsonWithColor formats json output with color. w is a colored Writer. (appends ansi color escape
+// codes) to the output.
+func FormatJsonWithColor(w io.Writer, val interface{}) error {
+	return nil
+}
+
+// Writer returns a new writer that appends ansi color codes to the output.
+func Writer(writer io.Writer) *ansiterm.Writer {
+	return ansiterm.NewWriter(writer)
 }
 
 // TabWriter returns a new tab writer with common layout definition.


### PR DESCRIPTION
*Add vim default color scheme for  juju config json output*

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps

```sh
  juju bootstrap localhost overlord
  juju add-model lxd-model 
  juju deploy mediawiki
  juju deploy mysql --series=trusty
  juju deploy haproxy
  juju add-relation mediawiki:db mysql
  juju add-relation mediawiki haproxy
  juju expose haproxy
  juju add-unit -n 2 mediawiki
  juju config --format=json --color
```
*The json output should be colored and should be valid json*