### PR TITLE
[JUJU-1285] Remove cloudsigma cloud registration

### DIFF
--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -481,7 +481,6 @@ var defaultCloudDescription = map[string]string{
 	"google":      "Google Cloud Platform",
 	"azure":       "Microsoft Azure",
 	"azure-china": "Microsoft Azure China",
-	"cloudsigma":  "CloudSigma Cloud",
 	"lxd":         "LXD Container Hypervisor",
 	"maas":        "Metal As A Service",
 	"openstack":   "Openstack Cloud",

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -24,7 +24,7 @@ type cloudSuite struct {
 var _ = gc.Suite(&cloudSuite{})
 
 var publicCloudNames = []string{
-	"aws", "aws-china", "aws-gov", "equinix", "google", "azure", "azure-china", "cloudsigma", "oracle",
+	"aws", "aws-china", "aws-gov", "equinix", "google", "azure", "azure-china", "oracle",
 }
 
 func parsePublicClouds(c *gc.C) map[string]cloud.Cloud {

--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -316,35 +316,6 @@ clouds:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
         identity-endpoint: https://graph.chinacloudapi.cn
-  cloudsigma:
-    type: cloudsigma
-    description: CloudSigma Cloud
-    auth-types: [ userpass ]
-    regions:
-      dub:
-        endpoint: https://dub.cloudsigma.com/api/2.0/
-      fra:
-        endpoint: https://fra.cloudsigma.com/api/2.0/
-      hnl:
-        endpoint: https://hnl.cloudsigma.com/api/2.0/
-      mel:
-        endpoint: https://mel.cloudsigma.com/api/2.0/
-      mia:
-        endpoint: https://mia.cloudsigma.com/api/2.0/
-      mnl:
-        endpoint: https://mnl.cloudsigma.com/api/2.0/
-      per:
-        endpoint: https://per.cloudsigma.com/api/2.0/
-      ruh:
-        endpoint: https://ruh.cloudsigma.com/api/2.0/
-      sjc:
-        endpoint: https://sjc.cloudsigma.com/api/2.0/
-      waw:
-        endpoint: https://waw.cloudsigma.com/api/2.0/
-      wdc:
-        endpoint: https://wdc.cloudsigma.com/api/2.0/
-      zrh:
-        endpoint: https://zrh.cloudsigma.com/api/2.0/
   oracle:
     type: oci
     description: Oracle Cloud Infrastructure

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -323,35 +323,6 @@ clouds:
         endpoint: https://management.chinacloudapi.cn
         storage-endpoint: https://core.chinacloudapi.cn
         identity-endpoint: https://graph.chinacloudapi.cn
-  cloudsigma:
-    type: cloudsigma
-    description: CloudSigma Cloud
-    auth-types: [ userpass ]
-    regions:
-      dub:
-        endpoint: https://dub.cloudsigma.com/api/2.0/
-      fra:
-        endpoint: https://fra.cloudsigma.com/api/2.0/
-      hnl:
-        endpoint: https://hnl.cloudsigma.com/api/2.0/
-      mel:
-        endpoint: https://mel.cloudsigma.com/api/2.0/
-      mia:
-        endpoint: https://mia.cloudsigma.com/api/2.0/
-      mnl:
-        endpoint: https://mnl.cloudsigma.com/api/2.0/
-      per:
-        endpoint: https://per.cloudsigma.com/api/2.0/
-      ruh:
-        endpoint: https://ruh.cloudsigma.com/api/2.0/
-      sjc:
-        endpoint: https://sjc.cloudsigma.com/api/2.0/
-      waw:
-        endpoint: https://waw.cloudsigma.com/api/2.0/
-      wdc:
-        endpoint: https://wdc.cloudsigma.com/api/2.0/
-      zrh:
-        endpoint: https://zrh.cloudsigma.com/api/2.0/
   oracle:
     type: oci
     description: Oracle Cloud Infrastructure

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -100,7 +100,6 @@ clouds:                           # mandatory
 
 <cloud types> for public clouds:
  - azure
- - cloudsigma
  - ec2
  - gce
  - oci

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1993,7 +1993,6 @@ aws-china
 aws-gov                                       
 azure                                         
 azure-china                                   
-cloudsigma                                    
 equinix                                       
 google                                        
 oracle                                        
@@ -2056,7 +2055,6 @@ aws-china
 aws-gov                                       
 azure                                         
 azure-china                                   
-cloudsigma                                    
 equinix                                       
 google                                        
 oracle                                        


### PR DESCRIPTION
Hide cloudsigma as a cloud for 2.9. Including tests and help text.

Full removal of the provider will be done for juju 3.0
## QA steps

```sh
$ juju bootstrap cloudsigma
ERROR unknown cloud "cloudsigma", please try "juju update-public-clouds"

# Output from the following commands should not reference cloudsigma in any way.
$ juju clouds
```

## Documentation changes

We need to document the deprecation and subsquient 

## Bug reference

*Please add a link to any bugs that this change is related to, e.g., https://bugs.launchpad.net/juju/+bug/9876543*
