### PR TITLE
[JUJU-1315] Fix snapcraft failures in GitHub CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
-        sudo snap install snapcraft --classic
+        sudo snap install snapcraft --classic --channel=5.x/stable
         sudo snap install lxd
         sudo lxd waitready
         sudo lxd init --auto
@@ -90,7 +90,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
-        sudo snap install snapcraft --classic
+        sudo snap install snapcraft --classic --channel=5.x/stable
         sudo snap install lxd
         sudo snap install yq
         sudo snap install juju --classic --channel=${{ matrix.snap_version }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
-        sudo snap install snapcraft --classic
+        sudo snap install snapcraft --classic --channel=5.x/stable
         sudo snap install lxd
         sudo lxd waitready
         sudo lxd init --auto


### PR DESCRIPTION
Snapcraft recently upgraded their `latest/stable` channel from 6.1 to 7.0.4. Now, the Juju snap is failing to build - it can't find the local `juju-go` plugin:
```
Failed to load plugin: unknown plugin: 'juju-go'
```

Until Snapcraft get their shit together, let's continue to use an older Snapcraft version. Unfortunately, Snapcraft doesn't have a `6.x` snap channel, so I'm gonna revert to `5.x` and see if that works.