### PR TITLE
[JUJU-1317] Fix smoke test failures on 2.9

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -253,7 +253,7 @@ jobs:
 
         juju wait-for application ${CHARM_${{ matrix.model_type }}}
 
-        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 10
+        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
 
     - name: Build snap
       if: env.RUN_TEST == 'RUN'
@@ -360,7 +360,7 @@ jobs:
             exit 1
         fi
 
-        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 5
+        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
 
     - name: Test upgrade model
       if: env.RUN_TEST == 'RUN'
@@ -399,7 +399,7 @@ jobs:
           exit 1
         fi
 
-        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 5
+        .github/verify-${CHARM_${{ matrix.model_type }}}.sh 30
 
     - name: Wrap up
       if: env.RUN_TEST == 'RUN'


### PR DESCRIPTION
The smoke and upgrade tests are intermittently failing because the `elasticsearch` charm is failing its health check. At present, the timeout is 50 seconds, which may not be enough for the charm to be in the right state. Hence, I've increased the timeout to 5 minutes.