### PR TITLE
[JUJU-1320] Don't require region when running `main.sh -c`

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -189,14 +189,7 @@ while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
 	c)
 		PROVIDER=$(juju clouds --client --all --format=json 2>/dev/null | jq -r ".[\"${OPTARG}\"] | .type")
 		export BOOTSTRAP_PROVIDER="${PROVIDER}"
-		num_regions=$(juju clouds --client --all --format=json 2>/dev/null | jq -r ".[\"${OPTARG}\"] | .regions | length")
-		if [[ ${num_regions} -gt 1 ]]; then
-			echo "more than 1 region, must specify"
-			exit 1
-		fi
 		CLOUD="${OPTARG}"
-		REGION=$(juju clouds --client --all --format=json 2>/dev/null | jq -r ".[\"${CLOUD}\"] | .regions | keys[0]")
-		export BOOTSTRAP_REGION="${REGION}"
 		export BOOTSTRAP_CLOUD="${CLOUD}"
 		;;
 	R)


### PR DESCRIPTION
Throughout (most of) the testing framework it is assumed that BOOTSTRAP_REGION
can be absent. This should be the aim since most clouds are happy  So drop this requirement

This code is also broken, making it impossible to run `main.sh -c aws`,
for instance, or any cloud that has multiple regions.

## QA steps

```sh
./main.sh -c localhost network
./main.sh -c aws network
./main.sh -c aws -R eu-west-2 network
```
