### PR TITLE
[JUJU-1319] Avoid needless JSON encoding and allocation for RPC observer

### DIFF
--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -202,7 +202,9 @@ func (n *rpcObserver) ServerReply(req rpc.Request, hdr *rpc.Header, body interfa
 
 	if req.Type == "Pinger" && req.Action == "Ping" {
 		if tracing {
-			n.pingLogger.Tracef("-> [%X] %s %s", n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
+			n.pingLogger.Tracef(
+				"-> [%X] %s %s %s %s[%q].%s",
+				n.id, n.tag, time.Since(n.requestStart), jsoncodec.DumpRequest(hdr, body), req.Type, req.Id, req.Action)
 		}
 		return
 	}
@@ -211,7 +213,9 @@ func (n *rpcObserver) ServerReply(req rpc.Request, hdr *rpc.Header, body interfa
 	// Until secrets are removed, we only log the body of the requests at trace level
 	// which is below the default level of debug.
 	if tracing {
-		n.logger.Tracef("-> [%X] %s %s", n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
+		n.logger.Tracef(
+			"-> [%X] %s %s %s %s[%q].%s",
+			n.id, n.tag, time.Since(n.requestStart), jsoncodec.DumpRequest(hdr, body), req.Type, req.Id, req.Action)
 	} else {
 		n.logger.Debugf(
 			"-> [%X] %s %s %s %s[%q].%s",

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -161,6 +161,13 @@ type rpcObserver struct {
 
 // ServerRequest implements rpc.Observer.
 func (n *rpcObserver) ServerRequest(hdr *rpc.Header, body interface{}) {
+	// We know that if *at least* debug logging is not enabled, there will be
+	// nothing to do here. Since this is a hot path, we can avoid the call to
+	// DumpRequest below that would otherwise still be paid for every request.
+	if !n.logger.IsDebugEnabled() {
+		return
+	}
+
 	n.requestStart = n.clock.Now()
 
 	if hdr.Request.Type == "Pinger" && hdr.Request.Action == "Ping" {
@@ -180,6 +187,13 @@ func (n *rpcObserver) ServerRequest(hdr *rpc.Header, body interface{}) {
 
 // ServerReply implements rpc.Observer.
 func (n *rpcObserver) ServerReply(req rpc.Request, hdr *rpc.Header, body interface{}) {
+	// We know that if *at least* debug logging is not enabled, there will be
+	// nothing to do here. Since this is a hot path, we can avoid the call to
+	// DumpRequest below that would otherwise still be paid for every reply.
+	if !n.logger.IsDebugEnabled() {
+		return
+	}
+
 	if req.Type == "Pinger" && req.Action == "Ping" {
 		n.logReplyTrace(n.pingLogger, hdr, body)
 		return

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -170,16 +170,20 @@ func (n *rpcObserver) ServerRequest(hdr *rpc.Header, body interface{}) {
 
 	n.requestStart = n.clock.Now()
 
+	tracing := n.logger.IsTraceEnabled()
+
 	if hdr.Request.Type == "Pinger" && hdr.Request.Action == "Ping" {
-		n.logRequestTrace(n.pingLogger, hdr, body)
+		if tracing {
+			n.pingLogger.Tracef("<- [%X] %s %s", n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
+		}
 		return
 	}
 
 	// TODO(rog) 2013-10-11 remove secrets from some requests.
 	// Until secrets are removed, we only log the body of the requests at trace level
 	// which is below the default level of debug.
-	if n.logger.IsTraceEnabled() {
-		n.logRequestTrace(n.logger, hdr, body)
+	if tracing {
+		n.logger.Tracef("<- [%X] %s %s", n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
 	} else {
 		n.logger.Debugf("<- [%X] %s %s", n.id, n.tag, jsoncodec.DumpRequest(hdr, "'params redacted'"))
 	}
@@ -194,16 +198,20 @@ func (n *rpcObserver) ServerReply(req rpc.Request, hdr *rpc.Header, body interfa
 		return
 	}
 
+	tracing := n.logger.IsTraceEnabled()
+
 	if req.Type == "Pinger" && req.Action == "Ping" {
-		n.logReplyTrace(n.pingLogger, hdr, body)
+		if tracing {
+			n.pingLogger.Tracef("-> [%X] %s %s", n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
+		}
 		return
 	}
 
 	// TODO(rog) 2013-10-11 remove secrets from some responses.
 	// Until secrets are removed, we only log the body of the requests at trace level
 	// which is below the default level of debug.
-	if n.logger.IsTraceEnabled() {
-		n.logReplyTrace(n.logger, hdr, body)
+	if tracing {
+		n.logger.Tracef("-> [%X] %s %s", n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
 	} else {
 		n.logger.Debugf(
 			"-> [%X] %s %s %s %s[%q].%s",
@@ -215,19 +223,5 @@ func (n *rpcObserver) ServerReply(req rpc.Request, hdr *rpc.Header, body interfa
 			req.Id,
 			req.Action,
 		)
-	}
-}
-
-func (n *rpcObserver) logRequestTrace(logger loggo.Logger, hdr *rpc.Header, body interface{}) {
-	n.logTrace(logger, "<-", hdr, body)
-}
-
-func (n *rpcObserver) logReplyTrace(logger loggo.Logger, hdr *rpc.Header, body interface{}) {
-	n.logTrace(logger, "->", hdr, body)
-}
-
-func (n *rpcObserver) logTrace(logger loggo.Logger, prefix string, hdr *rpc.Header, body interface{}) {
-	if logger.IsTraceEnabled() {
-		logger.Tracef("%s [%X] %s %s", prefix, n.id, n.tag, jsoncodec.DumpRequest(hdr, body))
 	}
 }


### PR DESCRIPTION
On each RPC call, we use notifiers for logging and metrics. The one used for logging makes a `logger.Debugf` call to which the results of a call to `jsoncodec.DumpRequest` is passed.

Even when we are logging at a less verbose level than debug, this latter call is made, only to then be unused due to the detected logging level.

Here, by exiting early from `rpcObserver.ServerRequest` and `rpcObserver.ServerReply` based on the current log level, we can avoid JSON encoding and slice allocations _twice_ for _every_ RPC call.

## QA steps

For regression, check controller logging with `juju.apiserver` at both DEBUG and TRACE.

I checked performance with A/B testing, deploying 10 units of the Ubuntu charm, then once settled for a while, running `juju_metrics` one the controller. This is a little soft in terms of definitive verification, but there are some plenty of obvious deltas in favour of the change.

Leases:
```
juju_raftlease_request{operation="extend",result="success",quantile="0.5"} 245.498119
juju_raftlease_request{operation="extend",result="success",quantile="0.9"} 2629.337725
juju_raftlease_request{operation="extend",result="success",quantile="0.99"} 4734.541589
```
versus
```
juju_raftlease_request{operation="extend",result="success",quantile="0.5"} 3.890365
juju_raftlease_request{operation="extend",result="success",quantile="0.9"} 13.98624
juju_raftlease_request{operation="extend",result="success",quantile="0.99"} 96.474839
```

Strings watchers:
```
juju_apiserver_request_duration_seconds{error_code="",facade="StringsWatcher",method="Next",version="1",quantile="0.5"} 40.268059188
juju_apiserver_request_duration_seconds{error_code="",facade="StringsWatcher",method="Next",version="1",quantile="0.9"} 167.556930914
juju_apiserver_request_duration_seconds{error_code="",facade="StringsWatcher",method="Next",version="1",quantile="0.99"} 167.55708684
```
versus
```
juju_apiserver_request_duration_seconds{error_code="",facade="StringsWatcher",method="Next",version="1",quantile="0.5"} 38.464108582
juju_apiserver_request_duration_seconds{error_code="",facade="StringsWatcher",method="Next",version="1",quantile="0.9"} 38.464108582
juju_apiserver_request_duration_seconds{error_code="",facade="StringsWatcher",method="Next",version="1",quantile="0.99"} 38.464108582
```
Agent entity requests:
```
juju_apiserver_request_duration_seconds{error_code="",facade="Agent",method="GetEntities",version="3",quantile="0.5"} 0.00073766
juju_apiserver_request_duration_seconds{error_code="",facade="Agent",method="GetEntities",version="3",quantile="0.9"} 0.119557032
juju_apiserver_request_duration_seconds{error_code="",facade="Agent",method="GetEntities",version="3",quantile="0.99"} 0.134508296
```
versus
```
juju_apiserver_request_duration_seconds{error_code="",facade="Agent",method="GetEntities",version="3",quantile="0.5"} 0.000563284
juju_apiserver_request_duration_seconds{error_code="",facade="Agent",method="GetEntities",version="3",quantile="0.9"} 0.000909186
juju_apiserver_request_duration_seconds{error_code="",facade="Agent",method="GetEntities",version="3",quantile="0.99"} 0.009080264
```

## Documentation changes

None.

## Bug reference

N/A
