### PR TITLE
[JUJU-1323] a bit of clean up while working on a large pr

### DIFF
--- a/apiserver/common/charms/appcharminfo_test.go
+++ b/apiserver/common/charms/appcharminfo_test.go
@@ -36,7 +36,7 @@ func (s *appCharmInfoSuite) TestBasic(c *gc.C) {
 
 	// The convertCharm logic is tested in the CharmInfo tests, so just test
 	// the minimal set of fields here.
-	ch.EXPECT().URL().Return(&charm.URL{Schema: "ch", Name: "foo", Revision: 1})
+	ch.EXPECT().String().Return("ch:foo-1")
 	ch.EXPECT().Revision().Return(1)
 	ch.EXPECT().Config().Return(&charm.Config{})
 	ch.EXPECT().Meta().Return(&charm.Meta{Name: "foo"})

--- a/apiserver/common/charms/charminfo_test.go
+++ b/apiserver/common/charms/charminfo_test.go
@@ -39,6 +39,7 @@ func (s *charmInfoSuite) TestBasic(c *gc.C) {
 	ch.EXPECT().Metrics().Return(&charm.Metrics{})
 	ch.EXPECT().Manifest().Return(&charm.Manifest{})
 	ch.EXPECT().LXDProfile().Return(&state.LXDProfile{})
+	ch.EXPECT().String().Return("ch:foo-1")
 
 	authorizer := facademocks.NewMockAuthorizer(ctrl)
 	authorizer.EXPECT().AuthController().Return(true)

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -27,7 +27,7 @@ type Application interface {
 }
 
 type Charm interface {
-	URL() *charm.URL
+	String() string
 	Revision() int
 	Meta() *charm.Meta
 	Config() *charm.Config
@@ -89,7 +89,7 @@ func (a *CharmInfoAPI) CharmInfo(args params.CharmURL) (params.Charm, error) {
 	if err != nil {
 		return params.Charm{}, errors.Trace(err)
 	}
-	info := convertCharm(curl, aCharm)
+	info := convertCharm(aCharm)
 	return info, nil
 }
 
@@ -125,13 +125,13 @@ func (a *ApplicationCharmInfoAPI) ApplicationCharmInfo(args params.Entity) (para
 	if err != nil {
 		return params.Charm{}, errors.Trace(err)
 	}
-	return convertCharm(ch.URL(), ch), nil
+	return convertCharm(ch), nil
 }
 
-func convertCharm(curl *charm.URL, ch Charm) params.Charm {
+func convertCharm(ch Charm) params.Charm {
 	charm := params.Charm{
 		Revision: ch.Revision(),
-		URL:      curl.String(),
+		URL:      ch.String(),
 		Config:   params.ToCharmOptionMap(ch.Config()),
 		Meta:     convertCharmMeta(ch.Meta()),
 		Actions:  convertCharmActions(ch.Actions()),

--- a/apiserver/common/charms/mocks/mocks.go
+++ b/apiserver/common/charms/mocks/mocks.go
@@ -242,18 +242,18 @@ func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))
 }
 
-// URL mocks base method.
-func (m *MockCharm) URL() *charm.URL {
+// String mocks base method.
+func (m *MockCharm) String() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URL")
-	ret0, _ := ret[0].(*charm.URL)
+	ret := m.ctrl.Call(m, "String")
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// URL indicates an expected call of URL.
-func (mr *MockCharmMockRecorder) URL() *gomock.Call {
+// String indicates an expected call of String.
+func (mr *MockCharmMockRecorder) String() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockCharm)(nil).URL))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockCharm)(nil).String))
 }
 
 // MockModel is a mock of Model interface.

--- a/apiserver/facades/agent/caasoperator/mock_test.go
+++ b/apiserver/facades/agent/caasoperator/mock_test.go
@@ -239,6 +239,10 @@ func (ch *mockCharm) URL() *charm.URL {
 	return ch.url
 }
 
+func (ch *mockCharm) String() string {
+	return ch.url.String()
+}
+
 func (ch *mockCharm) BundleSha256() string {
 	return ch.sha256
 }

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -148,7 +148,7 @@ func (f *Facade) Charm(args params.Entities) (params.ApplicationCharmResults, er
 			continue
 		}
 		results.Results[i].Result = &params.ApplicationCharm{
-			URL:                  ch.URL().String(),
+			URL:                  ch.String(),
 			ForceUpgrade:         force,
 			SHA256:               ch.BundleSha256(),
 			CharmModifiedVersion: application.CharmModifiedVersion(),

--- a/apiserver/facades/agent/caasoperator/state.go
+++ b/apiserver/facades/agent/caasoperator/state.go
@@ -54,7 +54,7 @@ type Application interface {
 // Charm provides the subset of charm state required by the
 // CAAS operator facade.
 type Charm interface {
-	URL() *charm.URL
+	String() string
 	BundleSha256() string
 	Meta() *charm.Meta
 }

--- a/apiserver/facades/agent/metricsadder/metricsadder_test.go
+++ b/apiserver/facades/agent/metricsadder/metricsadder_test.go
@@ -110,7 +110,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatch(c *gc.C) {
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
 				UUID:     uuid,
-				CharmURL: s.meteredCharm.URL().String(),
+				CharmURL: s.meteredCharm.String(),
 				Created:  time.Now(),
 				Metrics:  metrics,
 			}}}},
@@ -125,7 +125,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatch(c *gc.C) {
 	c.Assert(batches, gc.HasLen, 1)
 	batch := batches[0]
 	c.Assert(batch.UUID(), gc.Equals, uuid)
-	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL().String())
+	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.String())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
 	c.Assert(storedMetrics, gc.HasLen, 2)
@@ -146,7 +146,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
 				UUID:     uuid,
-				CharmURL: s.meteredCharm.URL().String(),
+				CharmURL: s.meteredCharm.String(),
 				Created:  time.Now(),
 				Metrics:  metrics,
 			}}}})
@@ -160,7 +160,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 	c.Assert(batches, gc.HasLen, 1)
 	batch := batches[0]
 	c.Assert(batch.UUID(), gc.Equals, uuid)
-	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.URL().String())
+	c.Assert(batch.CharmURL(), gc.Equals, s.meteredCharm.String())
 	c.Assert(batch.Unit(), gc.Equals, s.meteredUnit.Name())
 	storedMetrics := batch.Metrics()
 	c.Assert(storedMetrics, gc.HasLen, 1)
@@ -197,7 +197,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
 				Tag: test.tag,
 				Batch: params.MetricBatch{
 					UUID:     uuid,
-					CharmURL: s.meteredCharm.URL().String(),
+					CharmURL: s.meteredCharm.String(),
 					Created:  time.Now(),
 					Metrics:  metrics,
 				}}}})

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -122,7 +122,9 @@ type Bindings interface {
 // details on the methods, see the methods on state.Charm with
 // the same names.
 type Charm interface {
-	charm.Charm
+	Config() *charm.Config
+	Manifest() *charm.Manifest
+	Meta() *charm.Meta
 	URL() *charm.URL
 	String() string
 }

--- a/apiserver/facades/client/application/charmstore.go
+++ b/apiserver/facades/client/application/charmstore.go
@@ -271,7 +271,7 @@ func (c *charmRepoShim) Resolve(ref *charm.URL) (*charm.URL, []string, error) {
 	return c.charmStore.Resolve(ref)
 }
 
-func checkCAASMinVersion(ch charm.Charm, caasVersion *version.Number) (err error) {
+func checkCAASMinVersion(ch Charm, caasVersion *version.Number) (err error) {
 	// check caas min version.
 	charmDeployment := ch.Meta().Deployment
 	if caasVersion == nil || charmDeployment == nil || charmDeployment.MinVersion == "" {

--- a/apiserver/facades/client/application/updateseries_mocks_test.go
+++ b/apiserver/facades/client/application/updateseries_mocks_test.go
@@ -585,20 +585,6 @@ func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 	return m.recorder
 }
 
-// Actions mocks base method.
-func (m *MockCharm) Actions() *v8.Actions {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Actions")
-	ret0, _ := ret[0].(*v8.Actions)
-	return ret0
-}
-
-// Actions indicates an expected call of Actions.
-func (mr *MockCharmMockRecorder) Actions() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Actions", reflect.TypeOf((*MockCharm)(nil).Actions))
-}
-
 // Config mocks base method.
 func (m *MockCharm) Config() *v8.Config {
 	m.ctrl.T.Helper()
@@ -639,34 +625,6 @@ func (m *MockCharm) Meta() *v8.Meta {
 func (mr *MockCharmMockRecorder) Meta() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Meta", reflect.TypeOf((*MockCharm)(nil).Meta))
-}
-
-// Metrics mocks base method.
-func (m *MockCharm) Metrics() *v8.Metrics {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Metrics")
-	ret0, _ := ret[0].(*v8.Metrics)
-	return ret0
-}
-
-// Metrics indicates an expected call of Metrics.
-func (mr *MockCharmMockRecorder) Metrics() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockCharm)(nil).Metrics))
-}
-
-// Revision mocks base method.
-func (m *MockCharm) Revision() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Revision")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// Revision indicates an expected call of Revision.
-func (mr *MockCharmMockRecorder) Revision() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revision", reflect.TypeOf((*MockCharm)(nil).Revision))
 }
 
 // String mocks base method.

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -94,7 +94,7 @@ func (s *charmsSuite) TestMeteredCharmInfo(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(
 		c, &factory.CharmParams{Name: "metered", URL: "cs:xenial/metered"})
 	info, err := s.api.CharmInfo(params.CharmURL{
-		URL: meteredCharm.URL().String(),
+		URL: meteredCharm.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	expected := &params.CharmMetrics{
@@ -139,7 +139,7 @@ func (s *charmsSuite) assertListCharms(c *gc.C, someCharms, args, expected []str
 func (s *charmsSuite) TestIsMeteredFalse(c *gc.C) {
 	charm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
 	metered, err := s.api.IsMetered(params.CharmURL{
-		URL: charm.URL().String(),
+		URL: charm.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metered.Metered, jc.IsFalse)
@@ -148,7 +148,7 @@ func (s *charmsSuite) TestIsMeteredFalse(c *gc.C) {
 func (s *charmsSuite) TestIsMeteredTrue(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
 	metered, err := s.api.IsMetered(params.CharmURL{
-		URL: meteredCharm.URL().String(),
+		URL: meteredCharm.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metered.Metered, jc.IsTrue)

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -767,7 +767,7 @@ func (s *RefreshSuccessStateSuite) TestForcedSeriesUpgrade(c *gc.C) {
 	}
 
 	s.charmClient.charmInfo = &apicommoncharms.CharmInfo{
-		URL:      ch.URL().String(),
+		URL:      ch.String(),
 		Meta:     ch.Meta(),
 		Revision: ch.Revision(),
 	}

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -37,7 +37,7 @@ func (s *MetricSuite) TestAddNoMetrics(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
 	_, err := s.State.AddMetrics(state.BatchParam{
 		UUID:     utils.MustNewUUID().String(),
-		CharmURL: s.meteredCharm.URL().String(),
+		CharmURL: s.meteredCharm.String(),
 		Created:  now,
 		Metrics:  []state.Metric{},
 		Unit:     s.unit.UnitTag(),
@@ -68,7 +68,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  m,
 			Unit:     s.unit.UnitTag(),
 		},
@@ -124,7 +124,7 @@ func (s *MetricSuite) TestAddMetricOrderedLabels(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  m,
 			Unit:     s.unit.UnitTag(),
 		},
@@ -209,7 +209,7 @@ func (s *MetricSuite) TestAddMetricNonExistentUnit(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     unitTag,
 		},
@@ -225,7 +225,7 @@ func (s *MetricSuite) TestAddMetricDeadUnit(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -240,7 +240,7 @@ func (s *MetricSuite) TestSetMetricSent(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -264,7 +264,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -276,7 +276,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -289,7 +289,7 @@ func (s *MetricSuite) TestCleanupMetrics(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -321,7 +321,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  oldTime,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -334,7 +334,7 @@ func (s *MetricSuite) TestCleanupMetricsIgnoreNotSent(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -358,7 +358,7 @@ func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -407,7 +407,7 @@ func (s *MetricSuite) TestMetricCredentials(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -577,7 +577,7 @@ func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
 		state.BatchParam{
 			UUID:     mUUID,
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{{Key: "pings", Value: "5", Time: now}},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -588,7 +588,7 @@ func (s *MetricSuite) TestAddMetricDuplicateUUID(c *gc.C) {
 		state.BatchParam{
 			UUID:     mUUID,
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{{Key: "pings", Value: "10", Time: now}},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -627,7 +627,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  now,
-				CharmURL: s.meteredCharm.URL().String(),
+				CharmURL: s.meteredCharm.String(),
 				Metrics:  []state.Metric{m},
 				Unit:     s.unit.UnitTag(),
 			},
@@ -669,7 +669,7 @@ func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -682,7 +682,7 @@ func (s *MetricSuite) TestUnitMetricBatchesMatchesAllCharms(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: localMeteredCharm.URL().String(),
+			CharmURL: localMeteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     unit.UnitTag(),
 		},
@@ -731,7 +731,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -743,7 +743,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m2},
 			Unit:     newUnit.UnitTag(),
 		},
@@ -777,7 +777,7 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -789,7 +789,7 @@ func (s *MetricLocalCharmSuite) TestApplicationMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m2},
 			Unit:     newUnit.UnitTag(),
 		},
@@ -822,7 +822,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -834,7 +834,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now.Add(time.Second),
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m2},
 			Unit:     newUnit.UnitTag(),
 		},
@@ -852,7 +852,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: meteredCharm.URL().String(),
+			CharmURL: meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     unit.UnitTag(),
 		},
@@ -911,7 +911,7 @@ func (s *MetricLocalCharmSuite) TestMetricsSorted(c *gc.C) {
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  t,
-				CharmURL: s.meteredCharm.URL().String(),
+				CharmURL: s.meteredCharm.String(),
 				Metrics:  []state.Metric{{Key: "pings", Value: "5", Time: t}},
 				Unit:     s.unit.UnitTag(),
 			},
@@ -922,7 +922,7 @@ func (s *MetricLocalCharmSuite) TestMetricsSorted(c *gc.C) {
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  t,
-				CharmURL: s.meteredCharm.URL().String(),
+				CharmURL: s.meteredCharm.String(),
 				Metrics:  []state.Metric{{Key: "pings", Value: "10", Time: t}},
 				Unit:     newUnit.UnitTag(),
 			},
@@ -972,7 +972,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.unit.UnitTag(),
 		},
@@ -985,7 +985,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: csMeteredCharm.URL().String(),
+			CharmURL: csMeteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     unit.UnitTag(),
 		},
@@ -1007,7 +1007,7 @@ func (s *MetricLocalCharmSuite) TestUnique(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  t0,
-			CharmURL: s.meteredCharm.URL().String(),
+			CharmURL: s.meteredCharm.String(),
 			Metrics: []state.Metric{{
 				Key:   "pings",
 				Value: "1",
@@ -1088,7 +1088,7 @@ func (s *CrossModelMetricSuite) TestMetricsAcrossmodels(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.models[0].meteredCharm.URL().String(),
+			CharmURL: s.models[0].meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.models[0].unit.UnitTag(),
 		},
@@ -1099,7 +1099,7 @@ func (s *CrossModelMetricSuite) TestMetricsAcrossmodels(c *gc.C) {
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  now,
-			CharmURL: s.models[1].meteredCharm.URL().String(),
+			CharmURL: s.models[1].meteredCharm.String(),
 			Metrics:  []state.Metric{m},
 			Unit:     s.models[1].unit.UnitTag(),
 		},

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -670,7 +670,7 @@ func (s *MigrationImportSuite) TestApplications(c *gc.C) {
 	f := factory.NewFactory(newSt, s.StatePool)
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
-		URL:      testCharm.URL().String(),
+		URL:      testCharm.String(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 	s.assertImportedApplication(c, application, pwd, cons, exported, newModel, newSt, true)
@@ -722,7 +722,7 @@ func (s *MigrationImportSuite) TestApplicationsWithMissingPlatform(c *gc.C) {
 	f := factory.NewFactory(newSt, s.StatePool)
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
-		URL:      testCharm.URL().String(),
+		URL:      testCharm.String(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 
@@ -755,7 +755,7 @@ func (s *MigrationImportSuite) TestApplicationsWithMissingPlatformWithoutConstra
 	f := factory.NewFactory(newSt, s.StatePool)
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
-		URL:      testCharm.URL().String(),
+		URL:      testCharm.String(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 
@@ -797,7 +797,7 @@ func (s *MigrationImportSuite) TestApplicationStatus(c *gc.C) {
 	f := factory.NewFactory(newSt, s.StatePool)
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
-		URL:      testCharm.URL().String(),
+		URL:      testCharm.String(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 	s.assertImportedApplication(c, application, pwd, cons, exported, newModel, newSt, false)
@@ -841,7 +841,7 @@ func (s *MigrationImportSuite) TestCAASApplications(c *gc.C) {
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
 		Series:   "kubernetes",
-		URL:      charm.URL().String(),
+		URL:      charm.String(),
 		Revision: strconv.Itoa(charm.Revision()),
 	})
 	s.assertImportedApplication(c, application, pwd, cons, exported, newModel, newSt, true)
@@ -916,7 +916,7 @@ func (s *MigrationImportSuite) TestCAASApplicationStatus(c *gc.C) {
 	f.MakeCharm(c, &factory.CharmParams{
 		Name:     "starsay", // it has resources
 		Series:   "kubernetes",
-		URL:      testCharm.URL().String(),
+		URL:      testCharm.String(),
 		Revision: strconv.Itoa(testCharm.Revision()),
 	})
 	newApp, err := newSt.Application(application.Name())

--- a/worker/modelcache/worker_test.go
+++ b/worker/modelcache/worker_test.go
@@ -510,7 +510,7 @@ func (s *WorkerSuite) TestAddCharm(c *gc.C) {
 	change := s.nextChange(c, changes)
 	obtained, ok := change.(cache.CharmChange)
 	c.Assert(ok, jc.IsTrue)
-	c.Check(obtained.CharmURL, gc.Equals, charm.URL().String())
+	c.Check(obtained.CharmURL, gc.Equals, charm.String())
 
 	controller := s.getController(c, w)
 	modUUIDs := controller.ModelUUIDs()
@@ -519,7 +519,7 @@ func (s *WorkerSuite) TestAddCharm(c *gc.C) {
 	mod, err := controller.Model(modUUIDs[0])
 	c.Assert(err, jc.ErrorIsNil)
 
-	cachedCharm, err := mod.Charm(charm.URL().String())
+	cachedCharm, err := mod.Charm(charm.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cachedCharm, gc.NotNil)
 }
@@ -549,7 +549,7 @@ func (s *WorkerSuite) TestRemoveCharm(c *gc.C) {
 			mod, err := controller.Model(modUUID)
 			c.Assert(err, jc.ErrorIsNil)
 
-			_, err = mod.Charm(charm.URL().String())
+			_, err = mod.Charm(charm.String())
 			c.Check(errors.IsNotFound(err), jc.IsTrue)
 			return
 		}


### PR DESCRIPTION
There is no need it call URL().String() for a state charm, a helper method already exists: String(). They return the same result, so skip a method call.

Refactor an interface to only use the parts of state Charm needed by the package, rather than everything it can do.

## QA steps

no change to unit test results.
