### PR TITLE
[JUJU-1325] Deprecate PodSpec charms;

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -93,6 +93,10 @@ func DeployApplication(st ApplicationDeployer, model Model, args DeployApplicati
 		logger.Warningf("proceeding with deployment of application %q even though the charm feature requirements could not be met as --force was specified", args.ApplicationName)
 	}
 
+	if corecharm.IsKubernetes(args.Charm) && charm.MetaFormat(args.Charm) == charm.FormatV1 {
+		logger.Debugf("DEPRECATED: %q is a podspec charm, which will be removed in a future release", args.Charm.URL())
+	}
+
 	// TODO(fwereade): transactional State.AddApplication including settings, constraints
 	// (minimumUnitCount, initialMachineIds?).
 


### PR DESCRIPTION
Deprecate PodSpec charms;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```console
$ juju deploy minio
$ juju deploy kubeflow-lite --trust
$ juju deploy snappass-test

$ juju debug-log --color --replay -m k1:controller | grep -o 'DEPRECATED.*' | sort | uniq -c
      1 DEPRECATED: "ch:amd64/focal/admission-webhook-12" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/argo-controller-55" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/charmed-osm-mariadb-k8s-35" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/dex-auth-78" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/envoy-6" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/istio-gateway-40" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/istio-pilot-61" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/jupyter-controller-61" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/jupyter-ui-21" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kfp-api-33" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kfp-persistence-29" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kfp-profile-controller-16" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kfp-schedwf-32" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kfp-ui-32" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kfp-viewer-31" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kfp-viz-28" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kubeflow-dashboard-64" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kubeflow-profiles-57" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/kubeflow-volumes-11" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/minio-57" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/mlmd-10" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/oidc-gatekeeper-57" is a podspec charm, which will be removed in a future release
      1 DEPRECATED: "ch:amd64/focal/seldon-core-52" is a podspec charm, which will be removed in a future release

```

## Documentation changes

None

## Bug reference

None
