### PR TITLE
[JUJU-1326] Allow series upgrade state to be set by the agent to the same status

### DIFF
--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -212,7 +212,6 @@ func (u *UpgradeSeriesAPI) setUnitStatus(args params.UpgradeSeriesStatusParams) 
 		return params.ErrorResults{}, err
 	}
 	for i, p := range args.Params {
-		//TODO[externalreality] refactor all of this, its being copied often.
 		tag, err := names.ParseUnitTag(p.Entity.Tag)
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -244,6 +243,13 @@ func (u *UpgradeSeriesAPI) setUnitStatus(args params.UpgradeSeriesStatusParams) 
 			continue
 		}
 
+		// If attempting to set the same status, we're done.
+		// This can happen in situations where the upgrade completion hook
+		// fails and requires resolution before re-running.
+		if sts == p.Status {
+			continue
+		}
+
 		fsm, err := model.NewUpgradeSeriesFSM(graph, sts)
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
@@ -254,10 +260,8 @@ func (u *UpgradeSeriesAPI) setUnitStatus(args params.UpgradeSeriesStatusParams) 
 			continue
 		}
 
-		err = unit.SetUpgradeSeriesStatus(p.Status, p.Message)
-		if err != nil {
+		if err = unit.SetUpgradeSeriesStatus(p.Status, p.Message); err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
 		}
 	}
 	return result, nil

--- a/apiserver/common/upgradeseries_test.go
+++ b/apiserver/common/upgradeseries_test.go
@@ -183,6 +183,30 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTagWithInvalidStatus(
 	})
 }
 
+func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusUnitTagWithSameStatus(c *gc.C) {
+	api, ctrl, mockBackend := s.assertBackendApi(c, s.unitTag1)
+	defer ctrl.Finish()
+
+	mockUnit := mocks.NewMockUpgradeSeriesUnit(ctrl)
+
+	mockBackend.EXPECT().Unit(s.unitTag1.Id()).Return(mockUnit, nil)
+	mockUnit.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesCompleteRunning, "", nil)
+
+	args := params.UpgradeSeriesStatusParams{
+		Params: []params.UpgradeSeriesStatusParam{
+			{
+				Entity: params.Entity{Tag: s.unitTag1.String()},
+				Status: model.UpgradeSeriesCompleteRunning,
+			},
+		},
+	}
+	watches, err := api.SetUpgradeSeriesUnitStatus(args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(watches, gc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	})
+}
+
 func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusUnitTag(c *gc.C) {
 	api, ctrl, mockBackend := s.assertBackendApi(c, s.unitTag1)
 	defer ctrl.Finish()


### PR DESCRIPTION
The linked bug describes a situation where a unit encounters an error during the upgrade series completion hook. When this hook is resolved, the completion cannot continue because setting the status to "complete running" returns an error due to not transitioning from a state allowed by the FSM.

Here we simply treat setting the status to the same as it currently is, as a no-op.

## QA steps
- `juju deploy aodh --series bionic`.
- `juju upgrade-series 0 prepare focal -y`
- `juju ssh 0` then /var/lib/juju/agents/unit-aodh-0/charm/hooks/post-series-upgrade to `exit(1)` instead of `main()`
- `juju upgrade-series 0 complete`
- Logs will show:
```
unit-aodh-0: 16:52:49 ERROR juju.worker.uniter.operation hook "post-series-upgrade" (via explicit, bespoke hook script) failed: exit status 1
unit-aodh-0: 16:52:49 INFO juju.worker.uniter awaiting error resolution for "post-series-upgrade" hook
```
- `juju status` will show:
```
Machine  State    DNS            Inst id        Series  AZ  Message
0        started  10.161.87.153  juju-145328-0  bionic      series upgrade complete started: waiting for units
```
- Revert the edit to the hook.
- Logs will progress to:
```
unit-aodh-0: 16:54:49 INFO juju.worker.uniter.operation ran "update-status" hook (via explicit, bespoke hook script)
```
- The upgrade will complete and status will show the machine as:
```
Machine  State    DNS            Inst id        Series  AZ  Message
0        started  10.161.87.153  juju-145328-0  bionic      series upgrade completed: success
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1948906