### PR TITLE
[JUJU-1328] Set snapcraft version to 6.x

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
-        sudo snap install snapcraft --classic --channel=5.x/stable
+        sudo snap install snapcraft --classic --channel=6.x/stable
         sudo snap install lxd
         sudo lxd waitready
         sudo lxd init --auto

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
-        sudo snap install snapcraft --classic --channel=5.x/stable
+        sudo snap install snapcraft --classic --channel=6.x/stable
         sudo snap install lxd
         sudo lxd waitready
         sudo lxd init --auto


### PR DESCRIPTION
Set snapcraft version to 6.x in GitHub actions. This has to be maintained until existing problems in the latest snapcraft version are fixed.

## QA steps
NA

## Documentation changes
NA

## Bug reference
NA