### PR TITLE
Add debug log for when the unit series-upgrade status is unchanged

### DIFF
--- a/apiserver/common/upgradeseries.go
+++ b/apiserver/common/upgradeseries.go
@@ -247,6 +247,7 @@ func (u *UpgradeSeriesAPI) setUnitStatus(args params.UpgradeSeriesStatusParams) 
 		// This can happen in situations where the upgrade completion hook
 		// fails and requires resolution before re-running.
 		if sts == p.Status {
+			logger.Debugf("unit %s already has upgrade series status %s", tag.Id(), sts)
 			continue
 		}
 


### PR DESCRIPTION
Adds a log line omitted in error from #14163.