### PR TITLE
Generate modern ssh host keys for jammy support.

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/packaging/v2"
 	jc "github.com/juju/testing/checkers"
 	sshtesting "github.com/juju/utils/v3/ssh/testing"
+	"golang.org/x/crypto/ssh"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -26,132 +27,177 @@ var _ = gc.Suite(S{})
 
 var ctests = []struct {
 	name      string
-	expect    map[string]interface{}
-	setOption func(cfg cloudinit.CloudConfig)
+	expect    map[string]any
+	setOption func(cfg cloudinit.CloudConfig) error
 }{{
 	"PackageUpgrade",
-	map[string]interface{}{"package_upgrade": true},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"package_upgrade": true,
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetSystemUpgrade(true)
+		return nil
 	},
 }, {
 	"PackageUpdate",
-	map[string]interface{}{"package_update": true},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"package_update": true,
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetSystemUpdate(true)
+		return nil
 	},
 }, {
 	"PackageProxy",
-	map[string]interface{}{"apt_proxy": "http://foo.com"},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"apt_proxy": "http://foo.com",
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetPackageProxy("http://foo.com")
+		return nil
 	},
 }, {
 	"PackageMirror",
-	map[string]interface{}{"apt_mirror": "http://foo.com"},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"apt_mirror": "http://foo.com",
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetPackageMirror("http://foo.com")
+		return nil
 	},
 }, {
 	"DisableEC2Metadata",
-	map[string]interface{}{"disable_ec2_metadata": true},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"disable_ec2_metadata": true,
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetDisableEC2Metadata(true)
+		return nil
 	},
 }, {
 	"FinalMessage",
-	map[string]interface{}{"final_message": "goodbye"},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"final_message": "goodbye",
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetFinalMessage("goodbye")
+		return nil
 	},
 }, {
 	"Locale",
-	map[string]interface{}{"locale": "en_us"},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"locale": "en_us",
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetLocale("en_us")
+		return nil
 	},
 }, {
 	"DisableRoot",
-	map[string]interface{}{"disable_root": false},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"disable_root": false,
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetDisableRoot(false)
+		return nil
 	},
 }, {
 	"SetSSHAuthorizedKeys with two keys",
-	map[string]interface{}{"ssh_authorized_keys": []string{
-		fmt.Sprintf("%s Juju:user@host", sshtesting.ValidKeyOne.Key),
-		fmt.Sprintf("%s Juju:another@host", sshtesting.ValidKeyTwo.Key),
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"ssh_authorized_keys": []string{
+			fmt.Sprintf("%s Juju:user@host", sshtesting.ValidKeyOne.Key),
+			fmt.Sprintf("%s Juju:another@host", sshtesting.ValidKeyTwo.Key),
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetSSHAuthorizedKeys(
 			sshtesting.ValidKeyOne.Key + " Juju:user@host\n" +
 				sshtesting.ValidKeyTwo.Key + " another@host")
+		return nil
 	},
 }, {
 	"SetSSHAuthorizedKeys with comments in keys",
-	map[string]interface{}{"ssh_authorized_keys": []string{
-		fmt.Sprintf("%s Juju:sshkey", sshtesting.ValidKeyOne.Key),
-		fmt.Sprintf("%s Juju:user@host", sshtesting.ValidKeyTwo.Key),
-		fmt.Sprintf("%s Juju:another@host", sshtesting.ValidKeyThree.Key),
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"ssh_authorized_keys": []string{
+			fmt.Sprintf("%s Juju:sshkey", sshtesting.ValidKeyOne.Key),
+			fmt.Sprintf("%s Juju:user@host", sshtesting.ValidKeyTwo.Key),
+			fmt.Sprintf("%s Juju:another@host", sshtesting.ValidKeyThree.Key),
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetSSHAuthorizedKeys(
 			"#command\n" + sshtesting.ValidKeyOne.Key + "\n" +
 				sshtesting.ValidKeyTwo.Key + " user@host\n" +
 				"# comment\n\n" +
 				sshtesting.ValidKeyThree.Key + " another@host")
+		return nil
 	},
 }, {
 	"SetSSHAuthorizedKeys unsets keys",
-	map[string]interface{}{},
-	func(cfg cloudinit.CloudConfig) {
+	nil,
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetSSHAuthorizedKeys(sshtesting.ValidKeyOne.Key)
 		cfg.SetSSHAuthorizedKeys("")
+		return nil
 	},
 }, {
 	"AddUser with keys",
-	map[string]interface{}{"users": []interface{}{map[string]interface{}{
-		"name":        "auser",
-		"lock_passwd": true,
-		"ssh-authorized-keys": []string{
-			fmt.Sprintf("%s Juju:user@host", sshtesting.ValidKeyOne.Key),
-			fmt.Sprintf("%s Juju:another@host", sshtesting.ValidKeyTwo.Key),
+	map[string]any{
+		"users": []any{
+			map[string]any{
+				"name":        "auser",
+				"lock_passwd": true,
+				"ssh-authorized-keys": []string{
+					fmt.Sprintf("%s Juju:user@host", sshtesting.ValidKeyOne.Key),
+					fmt.Sprintf("%s Juju:another@host", sshtesting.ValidKeyTwo.Key),
+				},
+			},
 		},
-	}}},
-	func(cfg cloudinit.CloudConfig) {
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		keys := (sshtesting.ValidKeyOne.Key + " Juju:user@host\n" +
 			sshtesting.ValidKeyTwo.Key + " another@host")
 		cfg.AddUser(&cloudinit.User{
 			Name:              "auser",
 			SSHAuthorizedKeys: keys,
 		})
+		return nil
 	},
 }, {
 	"AddUser with groups",
-	map[string]interface{}{"users": []interface{}{map[string]interface{}{
-		"name":        "auser",
-		"lock_passwd": true,
-		"groups":      []string{"agroup", "bgroup"},
-	}}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"users": []any{
+			map[string]any{
+				"name":        "auser",
+				"lock_passwd": true,
+				"groups":      []string{"agroup", "bgroup"},
+			},
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddUser(&cloudinit.User{
 			Name:   "auser",
 			Groups: []string{"agroup", "bgroup"},
 		})
+		return nil
 	},
 }, {
 	"AddUser with everything",
-	map[string]interface{}{"users": []interface{}{map[string]interface{}{
-		"name":        "auser",
-		"lock_passwd": true,
-		"groups":      []string{"agroup", "bgroup"},
-		"shell":       "/bin/sh",
-		"ssh-authorized-keys": []string{
-			sshtesting.ValidKeyOne.Key + " Juju:sshkey",
+	map[string]any{
+		"users": []any{
+			map[string]any{
+				"name":        "auser",
+				"lock_passwd": true,
+				"groups":      []string{"agroup", "bgroup"},
+				"shell":       "/bin/sh",
+				"ssh-authorized-keys": []string{
+					sshtesting.ValidKeyOne.Key + " Juju:sshkey",
+				},
+				"sudo": []string{"ALL=(ALL) ALL"},
+			},
 		},
-		"sudo": []string{"ALL=(ALL) ALL"},
-	}}},
-	func(cfg cloudinit.CloudConfig) {
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddUser(&cloudinit.User{
 			Name:              "auser",
 			Groups:            []string{"agroup", "bgroup"},
@@ -159,49 +205,64 @@ var ctests = []struct {
 			SSHAuthorizedKeys: sshtesting.ValidKeyOne.Key + "\n",
 			Sudo:              []string{"ALL=(ALL) ALL"},
 		})
+		return nil
 	},
 }, {
 	"AddUser with only name",
-	map[string]interface{}{"users": []interface{}{map[string]interface{}{
-		"name":        "auser",
-		"lock_passwd": true,
-	}}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"users": []any{
+			map[string]any{
+				"name":        "auser",
+				"lock_passwd": true,
+			},
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddUser(&cloudinit.User{
 			Name: "auser",
 		})
+		return nil
 	},
 }, {
 	"Output",
-	map[string]interface{}{"output": map[string]interface{}{
-		"all": []string{">foo", "|bar"},
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"output": map[string]any{
+			"all": []string{">foo", "|bar"},
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetOutput("all", ">foo", "|bar")
+		return nil
 	},
 }, {
 	"Output",
-	map[string]interface{}{"output": map[string]interface{}{
-		"all": ">foo",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"output": map[string]any{
+			"all": ">foo",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetOutput(cloudinit.OutAll, ">foo", "")
+		return nil
 	},
 }, {
 	"PackageSources",
-	map[string]interface{}{"apt_sources": []map[string]interface{}{
-		{
-			"source": "keyName",
-			"key":    "someKey",
+	map[string]any{
+		"apt_sources": []map[string]any{
+			{
+				"source": "keyName",
+				"key":    "someKey",
+			},
 		},
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddPackageSource(packaging.PackageSource{URL: "keyName", Key: "someKey"})
+		return nil
 	},
 }, {
 	"PackageSources with preferences",
-	map[string]interface{}{
-		"apt_sources": []map[string]interface{}{
+	map[string]any{
+		"apt_sources": []map[string]any{
 			{
 				"source": "keyName",
 				"key":    "someKey",
@@ -216,7 +277,7 @@ var ctests = []struct {
 				"' > '/some/path'",
 		},
 	},
-	func(cfg cloudinit.CloudConfig) {
+	func(cfg cloudinit.CloudConfig) error {
 		prefs := packaging.PackagePreferences{
 			Path:        "/some/path",
 			Explanation: "test",
@@ -226,154 +287,222 @@ var ctests = []struct {
 		}
 		cfg.AddPackageSource(packaging.PackageSource{URL: "keyName", Key: "someKey"})
 		cfg.AddPackagePreferences(prefs)
+		return nil
 	},
 }, {
 	"Packages",
-	map[string]interface{}{"packages": []string{
-		"juju",
-		"ubuntu",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"packages": []string{
+			"juju",
+			"ubuntu",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddPackage("juju")
 		cfg.AddPackage("ubuntu")
+		return nil
 	},
 }, {
 	"BootCmd",
-	map[string]interface{}{"bootcmd": []string{
-		"ls > /dev",
-		"ls >with space",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"bootcmd": []string{
+			"ls > /dev",
+			"ls >with space",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddBootCmd("ls > /dev")
 		cfg.AddBootCmd("ls >with space")
+		return nil
 	},
 }, {
 	"Mounts",
-	map[string]interface{}{"mounts": [][]string{
-		{"x", "y"},
-		{"z", "w"},
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"mounts": [][]string{
+			{"x", "y"},
+			{"z", "w"},
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddMount("x", "y")
 		cfg.AddMount("z", "w")
+		return nil
 	},
 }, {
 	"Attr",
-	map[string]interface{}{"arbitraryAttr": "someValue"},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"arbitraryAttr": "someValue"},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.SetAttr("arbitraryAttr", "someValue")
+		return nil
 	},
 }, {
 	"RunCmd",
-	map[string]interface{}{"runcmd": []string{
-		"ifconfig",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"runcmd": []string{
+			"ifconfig",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddRunCmd("ifconfig")
+		return nil
 	},
 }, {
 	"PrependRunCmd",
-	map[string]interface{}{"runcmd": []string{
-		"echo 'Hello World'",
-		"ifconfig",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"runcmd": []string{
+			"echo 'Hello World'",
+			"ifconfig",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddRunCmd("ifconfig")
 		cfg.PrependRunCmd(
 			"echo 'Hello World'",
 		)
+		return nil
 	},
 }, {
 	"AddScripts",
-	map[string]interface{}{"runcmd": []string{
-		"echo 'Hello World'",
-		"ifconfig",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"runcmd": []string{
+			"echo 'Hello World'",
+			"ifconfig",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddScripts(
 			"echo 'Hello World'",
 			"ifconfig",
 		)
+		return nil
 	},
 }, {
 	"AddTextFile",
-	map[string]interface{}{"runcmd": []string{
-		"install -D -m 644 /dev/null '/etc/apt/apt.conf.d/99proxy'",
-		"printf '%s\\n' '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"runcmd": []string{
+			"install -D -m 644 /dev/null '/etc/apt/apt.conf.d/99proxy'",
+			"printf '%s\\n' '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddRunTextFile(
 			"/etc/apt/apt.conf.d/99proxy",
 			`"Acquire::http::Proxy "http://10.0.3.1:3142";`,
 			0644,
 		)
+		return nil
 	},
 }, {
 	"AddBinaryFile",
-	map[string]interface{}{"runcmd": []string{
-		"install -D -m 644 /dev/null '/dev/nonsense'",
-		"printf %s AAECAw== | base64 -d > '/dev/nonsense'",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"runcmd": []string{
+			"install -D -m 644 /dev/null '/dev/nonsense'",
+			"printf %s AAECAw== | base64 -d > '/dev/nonsense'",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddRunBinaryFile(
 			"/dev/nonsense",
 			[]byte{0, 1, 2, 3},
 			0644,
 		)
+		return nil
 	},
 }, {
 	"AddBootTextFile",
-	map[string]interface{}{"bootcmd": []string{
-		"install -D -m 644 /dev/null '/etc/apt/apt.conf.d/99proxy'",
-		"printf '%s\\n' '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
-	}},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"bootcmd": []string{
+			"install -D -m 644 /dev/null '/etc/apt/apt.conf.d/99proxy'",
+			"printf '%s\\n' '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.AddBootTextFile(
 			"/etc/apt/apt.conf.d/99proxy",
 			`"Acquire::http::Proxy "http://10.0.3.1:3142";`,
 			0644,
 		)
+		return nil
 	},
 }, {
 	"ManageEtcHosts",
-	map[string]interface{}{"manage_etc_hosts": true},
-	func(cfg cloudinit.CloudConfig) {
+	map[string]any{
+		"manage_etc_hosts": true},
+	func(cfg cloudinit.CloudConfig) error {
 		cfg.ManageEtcHosts(true)
+		return nil
 	},
 }, {
 	"SetSSHKeys",
-	map[string]interface{}{"ssh_keys": map[string]interface{}{
-		"rsa_private": "private",
-		"rsa_public":  "public",
-	}},
-	func(cfg cloudinit.CloudConfig) {
-		cfg.SetSSHKeys(cloudinit.SSHKeys{
-			RSA: &cloudinit.SSHKey{
-				Private: "private",
-				Public:  "public",
-			},
+	map[string]any{
+		"ssh_keys": map[string]any{
+			"rsa_private": "private",
+			"rsa_public":  "public",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
+		return cfg.SetSSHKeys(cloudinit.SSHKeys{{
+			Private:            "private",
+			Public:             "public",
+			PublicKeyAlgorithm: ssh.KeyAlgoRSA,
+		},
 		})
 	},
 }, {
 	"SetSSHKeys unsets keys",
-	map[string]interface{}{},
-	func(cfg cloudinit.CloudConfig) {
-		cfg.SetSSHKeys(cloudinit.SSHKeys{
-			RSA: &cloudinit.SSHKey{
-				Private: "private",
-				Public:  "public",
+	nil,
+	func(cfg cloudinit.CloudConfig) error {
+		err := cfg.SetSSHKeys(cloudinit.SSHKeys{{
+			Private:            "private",
+			Public:             "public",
+			PublicKeyAlgorithm: ssh.KeyAlgoRSA,
+		},
+		})
+		if err != nil {
+			return err
+		}
+		return cfg.SetSSHKeys(cloudinit.SSHKeys{})
+	},
+}, {
+	"SetSSHKeysMultiple",
+	map[string]any{
+		"ssh_keys": map[string]any{
+			"rsa_private":     "private-rsa",
+			"rsa_public":      "public-rsa",
+			"ecdsa_private":   "private-ecdsa",
+			"ecdsa_public":    "public-ecdsa",
+			"ed25519_private": "private-ed25519",
+			"ed25519_public":  "public-ed25519",
+		},
+	},
+	func(cfg cloudinit.CloudConfig) error {
+		return cfg.SetSSHKeys(cloudinit.SSHKeys{
+			{
+				Private:            "private-rsa",
+				Public:             "public-rsa",
+				PublicKeyAlgorithm: ssh.KeyAlgoRSA,
+			}, {
+				Private:            "private-ecdsa",
+				Public:             "public-ecdsa",
+				PublicKeyAlgorithm: ssh.KeyAlgoECDSA256,
+			}, {
+				Private:            "private-ed25519",
+				Public:             "public-ed25519",
+				PublicKeyAlgorithm: ssh.KeyAlgoED25519,
 			},
 		})
-		cfg.SetSSHKeys(cloudinit.SSHKeys{})
 	},
-}}
+},
+}
 
 func (S) TestOutput(c *gc.C) {
 	for i, t := range ctests {
 		c.Logf("test %d: %s", i, t.name)
 		cfg, err := cloudinit.New("precise")
 		c.Assert(err, jc.ErrorIsNil)
-		t.setOption(cfg)
+		err = t.setOption(cfg)
+		c.Assert(err, jc.ErrorIsNil)
 		data, err := cfg.RenderYAML()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(data, gc.NotNil)
@@ -422,7 +551,8 @@ func (S) TestSetOutput(c *gc.C) {
 		cloudinit.OutAll, "a", "b",
 	}, {
 		cloudinit.OutAll, "", "",
-	}}
+	},
+	}
 
 	cfg, err := cloudinit.New("trusty")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -248,11 +248,7 @@ type BootstrapConfig struct {
 }
 
 // SSHHostKeys contains the SSH host keys to configure for a bootstrap host.
-type SSHHostKeys struct {
-	// RSA, if non-nil, contains the RSA key to configure as the initial
-	// SSH host key.
-	RSA *SSHKeyPair
-}
+type SSHHostKeys []SSHKeyPair
 
 // SSHKeyPair is an SSH host key pair.
 type SSHKeyPair struct {
@@ -261,6 +257,9 @@ type SSHKeyPair struct {
 
 	// Public contains the public key in authorized_keys format.
 	Public string
+
+	// PublicKeyAlgorithm contains the public key algorithm as defined by golang.org/x/crypto/ssh KeyAlgo*
+	PublicKeyAlgorithm string
 }
 
 // StateInitializationParams contains parameters for initializing the

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -200,13 +200,17 @@ func (w *unixConfigure) ConfigureBasic() error {
 		// except when manually provisioning.
 		icfgKeys := w.icfg.Bootstrap.InitialSSHHostKeys
 		var keys cloudinit.SSHKeys
-		if icfgKeys.RSA != nil {
-			keys.RSA = &cloudinit.SSHKey{
-				Private: icfgKeys.RSA.Private,
-				Public:  icfgKeys.RSA.Public,
-			}
+		for _, hostKey := range icfgKeys {
+			keys = append(keys, cloudinit.SSHKey{
+				Private:            hostKey.Private,
+				Public:             hostKey.Public,
+				PublicKeyAlgorithm: hostKey.PublicKeyAlgorithm,
+			})
 		}
-		w.conf.SetSSHKeys(keys)
+		err := w.conf.SetSSHKeys(keys)
+		if err != nil {
+			return errors.Annotate(err, "setting ssh keys")
+		}
 	}
 
 	w.conf.SetOutput(cloudinit.OutAll, "| tee -a "+w.icfg.CloudInitOutputLog, "")
@@ -274,23 +278,19 @@ func (w *unixConfigure) ConfigureJuju() error {
 		w.conf.AddBootCmd(cloudinit.LogProgressCmd("Logging to %s on the bootstrap machine", w.icfg.CloudInitOutputLog))
 	}
 
-	if w.icfg.Bootstrap != nil {
+	if w.icfg.Bootstrap != nil && len(w.icfg.Bootstrap.InitialSSHHostKeys) > 0 {
 		// Before anything else, we must regenerate the SSH host keys.
-		var any bool
-		keys := w.icfg.Bootstrap.InitialSSHHostKeys
-		if keys.RSA != nil {
-			any = true
-			w.conf.AddBootCmd(cloudinit.LogProgressCmd("Regenerating SSH RSA host key"))
-			w.conf.AddBootCmd(`rm /etc/ssh/ssh_host_rsa_key*`)
-			w.conf.AddBootCmd(`ssh-keygen -t rsa -N "" -f /etc/ssh/ssh_host_rsa_key`)
-		}
-		if any {
-			// ssh_keys was specified in cloud-config, which will
-			// disable all key generation. Generate the other keys
-			// that we did not generate previously.
-			w.conf.AddBootCmd(`ssh-keygen -t dsa -N "" -f /etc/ssh/ssh_host_dsa_key`)
-			w.conf.AddBootCmd(`ssh-keygen -t ecdsa -N "" -f /etc/ssh/ssh_host_ecdsa_key`)
-		}
+		// During bootstrap we provide our own keys, but to prevent keys being
+		// sniffed from metadata by user applications that shouldn't have access,
+		// we regenerate them.
+		w.conf.AddBootCmd(cloudinit.LogProgressCmd("Regenerating SSH host keys"))
+		w.conf.AddBootCmd(`rm /etc/ssh/ssh_host_*_key*`)
+		w.conf.AddBootCmd(`ssh-keygen -t rsa -N "" -f /etc/ssh/ssh_host_rsa_key`)
+		w.conf.AddBootCmd(`ssh-keygen -t ecdsa -N "" -f /etc/ssh/ssh_host_ecdsa_key`)
+		// We drop DSA due to it not really being supported by default anymore,
+		// we also softly fail on ed25519 as it may not be supported by the target
+		// machine.
+		w.conf.AddBootCmd(`ssh-keygen -t ed25519 -N "" -f /etc/ssh/ssh_host_ed25519_key || true`)
 	}
 
 	if err := w.conf.AddPackageCommands(

--- a/pki/ssh/format.go
+++ b/pki/ssh/format.go
@@ -1,0 +1,85 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ssh
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/juju/errors"
+	cryptossh "golang.org/x/crypto/ssh"
+)
+
+func encodePrivateKey(pk crypto.PrivateKey) (string, error) {
+	pkcs, err := x509.MarshalPKCS8PrivateKey(pk)
+	if err != nil {
+		return "", err
+	}
+	block := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: pkcs,
+	}
+	return string(pem.EncodeToMemory(block)), nil
+}
+
+func encodePublicKey(pk crypto.PublicKey, comment string) (string, error) {
+	sshPublicKey, err := cryptossh.NewPublicKey(pk)
+	if err != nil {
+		return "", errors.NewNotValid(err, "public key")
+	}
+	encoded := string(cryptossh.MarshalAuthorizedKey(sshPublicKey))
+	if comment != "" {
+		encoded = fmt.Sprintf("%s %s\n", strings.TrimRight(encoded, "\n"), comment)
+	}
+	return encoded, nil
+}
+
+type privateKey interface {
+	Public() crypto.PublicKey
+}
+
+// FormatKey formats the crypto key into PKCS8 encoded private key and openssh public keyline.
+func FormatKey(pk crypto.PrivateKey, comment string) (private string, public string, keyAlgorithm string, err error) {
+	sshPrivateKey, _ := pk.(privateKey)
+	if sshPrivateKey == nil {
+		return "", "", "", errors.NotValidf("private key")
+	}
+	private, err = encodePrivateKey(sshPrivateKey)
+	if err != nil {
+		err = errors.Annotate(err, "cannot encode private key")
+		return
+	}
+	public, err = encodePublicKey(sshPrivateKey.Public(), comment)
+	if err != nil {
+		err = errors.Annotate(err, "cannot encode public key")
+		return
+	}
+	switch k := pk.(type) {
+	case *ecdsa.PrivateKey:
+		switch k.Curve {
+		case elliptic.P256():
+			keyAlgorithm = cryptossh.KeyAlgoECDSA256
+		case elliptic.P384():
+			keyAlgorithm = cryptossh.KeyAlgoECDSA384
+		case elliptic.P521():
+			keyAlgorithm = cryptossh.KeyAlgoECDSA521
+		}
+	case *ed25519.PrivateKey, ed25519.PrivateKey:
+		keyAlgorithm = cryptossh.KeyAlgoED25519
+	case *rsa.PrivateKey:
+		keyAlgorithm = cryptossh.KeyAlgoRSA
+	}
+	if keyAlgorithm == "" {
+		err = errors.Errorf("unknown private key type %v", reflect.TypeOf(pk))
+	}
+	return
+}

--- a/pki/ssh/format_test.go
+++ b/pki/ssh/format_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ssh_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+
+	jc "github.com/juju/testing/checkers"
+	cryptossh "golang.org/x/crypto/ssh"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/pki/ssh"
+)
+
+type FormatSuite struct {
+}
+
+var _ = gc.Suite(&FormatSuite{})
+
+func (s *FormatSuite) TestKeyProfilesFormat(c *gc.C) {
+	tests := []struct {
+		name          string
+		profile       ssh.KeyProfile
+		publicKeyType string
+	}{
+		{name: "ecdsa256", profile: ssh.ECDSAP256, publicKeyType: cryptossh.KeyAlgoECDSA256},
+		{name: "ecdsa384", profile: ssh.ECDSAP384, publicKeyType: cryptossh.KeyAlgoECDSA384},
+		{name: "ecdsa521", profile: ssh.ECDSAP521, publicKeyType: cryptossh.KeyAlgoECDSA521},
+		{name: "rsa2048", profile: ssh.RSA2048, publicKeyType: cryptossh.KeyAlgoRSA},
+		{name: "rsa3072", profile: ssh.RSA3072, publicKeyType: cryptossh.KeyAlgoRSA},
+		{name: "ed25519", profile: ssh.ED25519, publicKeyType: cryptossh.KeyAlgoED25519},
+	}
+	for _, test := range tests {
+		pk, err := test.profile()
+		c.Check(err, jc.ErrorIsNil, gc.Commentf("profile %s", test.name))
+
+		private, public, publicKeyType, err := ssh.FormatKey(pk, "test-comment")
+		c.Check(err, jc.ErrorIsNil, gc.Commentf("profile %s", test.name))
+		c.Check(private, gc.Not(gc.Equals), "")
+		c.Check(public, gc.Not(gc.Equals), "")
+		c.Check(public, gc.Matches, test.publicKeyType+` .* test-comment\n`)
+		c.Check(publicKeyType, gc.Equals, test.publicKeyType)
+	}
+}
+
+func (s *FormatSuite) TestBadKey(c *gc.C) {
+	_, _, _, err := ssh.FormatKey(nil, "nope")
+	c.Assert(err, gc.ErrorMatches, `private key not valid`)
+	_, _, _, err = ssh.FormatKey(&struct{}{}, "nope")
+	c.Assert(err, gc.ErrorMatches, `private key not valid`)
+	_, _, _, err = ssh.FormatKey(&ecdsa.PrivateKey{}, "nope")
+	c.Assert(err, gc.ErrorMatches, `cannot encode private key: x509: unknown curve while marshaling to PKCS#8`)
+
+	pk, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	c.Assert(err, jc.ErrorIsNil)
+	_, _, _, err = ssh.FormatKey(pk, "nope")
+	c.Assert(err, gc.ErrorMatches, `cannot encode public key: public key: ssh: only P-256, P-384 and P-521 EC keys are supported`)
+}

--- a/pki/ssh/keys.go
+++ b/pki/ssh/keys.go
@@ -1,0 +1,68 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ssh
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+
+	"github.com/juju/errors"
+)
+
+type KeyProfile func() (crypto.PrivateKey, error)
+
+// ECDSAP256 returns a ECDSA 256 private key
+func ECDSAP256() (crypto.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
+// ECDSA384 returns a ECDSA 384 private key
+func ECDSAP384() (crypto.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+}
+
+// ECDSAP521 returns a ECDSA 521 private key
+func ECDSAP521() (crypto.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+}
+
+// RSA2048 returns a RSA 2048 private key
+func RSA2048() (crypto.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, 2048)
+}
+
+// RSA3072 returns a RSA 3072 private key
+func RSA3072() (crypto.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, 3072)
+}
+
+// ED25519 returns a ed25519 private key
+func ED25519() (crypto.PrivateKey, error) {
+	_, pk, err := ed25519.GenerateKey(rand.Reader)
+	return pk, err
+}
+
+var hostKeyProfiles = []KeyProfile{
+	RSA2048,
+	ECDSAP256,
+	ED25519,
+}
+
+// GenerateHostKeys returns newly generated keys of various algorithms/curves/parameters
+// to be used as ssh host heys.
+func GenerateHostKeys() ([]crypto.PrivateKey, error) {
+	var res []crypto.PrivateKey
+	for _, f := range hostKeyProfiles {
+		k, err := f()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		res = append(res, k)
+	}
+	return res, nil
+}

--- a/pki/ssh/keys_test.go
+++ b/pki/ssh/keys_test.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ssh_test
+
+import (
+	"crypto"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/pki/ssh"
+)
+
+type KeySuite struct {
+}
+
+var _ = gc.Suite(&KeySuite{})
+
+func (s *KeySuite) TestKeyProfilesForErrors(c *gc.C) {
+	tests := []struct {
+		name    string
+		profile ssh.KeyProfile
+	}{
+		{name: "ecdsa256", profile: ssh.ECDSAP256},
+		{name: "ecdsa384", profile: ssh.ECDSAP384},
+		{name: "ecdsa521", profile: ssh.ECDSAP521},
+		{name: "rsa2048", profile: ssh.RSA2048},
+		{name: "rsa3072", profile: ssh.RSA3072},
+		{name: "ed25519", profile: ssh.ED25519},
+	}
+	for _, test := range tests {
+		_, err := test.profile()
+		c.Check(err, jc.ErrorIsNil, gc.Commentf("profile %s", test.name))
+	}
+}
+
+func (s *KeySuite) TestGenerateHostKeys(c *gc.C) {
+	keys, err := ssh.GenerateHostKeys()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keys, gc.HasLen, 3)
+	keys2, err := ssh.GenerateHostKeys()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(keys2, gc.HasLen, 3)
+	for i, key := range keys {
+		key2 := keys2[i]
+		c.Assert(key, gc.FitsTypeOf, key2)
+		typedKey, ok := key.(interface {
+			Equal(crypto.PrivateKey) bool
+		})
+		c.Assert(ok, jc.IsTrue, gc.Commentf("cast %v", key))
+		c.Assert(typedKey.Equal(key), jc.IsTrue)
+		c.Assert(typedKey.Equal(key2), jc.IsFalse)
+	}
+}

--- a/pki/ssh/package_test.go
+++ b/pki/ssh/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ssh_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestSuite(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
Jammy ships with modern OpenSSH that restricts supported keys, to support bootstrapping jammy, juju needs to generate modern host keys other than rsa 2048.

This PR adds ECDSA256 and ED25519 host keys.

## QA steps

```
juju bootstrap aws --series jammy
juju add-machine --series jammy
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1971616