### PR TITLE
[JUJU-1327] dummy locator-add hook tool

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -990,6 +990,15 @@ func (ctx *HookContext) AddMetricLabels(key, value string, created time.Time, la
 	return errors.New("metrics not allowed in this context")
 }
 
+// AddServiceLocator adds service locator to the hook context.
+// Implements jujuc.HookContext.ContextServiceLocators, part of runner.Context.
+func (ctx *HookContext) AddServiceLocator(slId string, slName string, slType string) error {
+	ctx.logger.Infof("Service Locator ID = %s", slId)
+	ctx.logger.Infof("Service Locator Name = %s", slName)
+	ctx.logger.Infof("Service Locator Type = %s", slType)
+	return nil
+}
+
 // ActionData returns the context's internal action data. It's meant to be
 // transitory; it exists to allow uniter and runner code to keep working as
 // it did; it should be considered deprecated, and not used by new clients.

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -50,6 +50,7 @@ type HookContext interface {
 	ContextRelations
 	ContextVersion
 	ContextSecrets
+	ContextServiceLocators
 
 	// GetLogger returns a juju loggo Logger for the supplied module that is
 	// correctly wired up for the given context
@@ -291,6 +292,12 @@ type ContextMetrics interface {
 	AddMetric(string, string, time.Time) error
 	// AddMetricLabels records a metric with tags to return after hook execution.
 	AddMetricLabels(string, string, time.Time, map[string]string) error
+}
+
+// ContextServiceLocators is the part of a hook context related to service locators.
+type ContextServiceLocators interface {
+	// AddServiceLocator records a metric to return after hook execution.
+	AddServiceLocator(string, string, string) error
 }
 
 // ContextStorage is the part of a hook context related to storage

--- a/worker/uniter/runner/jujuc/locator-add.go
+++ b/worker/uniter/runner/jujuc/locator-add.go
@@ -4,13 +4,10 @@
 package jujuc
 
 import (
-	"fmt"
-
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
-	"github.com/juju/utils/v3"
-
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/utils/v3"
 )
 
 // AddServiceLocatorCommand implements the locator-add command.
@@ -47,7 +44,7 @@ func (c *AddServiceLocatorCommand) Init(args []string) error {
 	}
 	c.Name = args[0]
 	if c.Name == "" {
-		return fmt.Errorf("no service locator name specified")
+		return errors.Errorf("no service locator name specified")
 	}
 	return cmd.CheckEmpty(args[1:])
 }
@@ -67,5 +64,5 @@ func (c *AddServiceLocatorCommand) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Annotate(err, "cannot record service locator")
 	}
-	return c.out.Write(ctx, c.Name) // TODO(anvial): think what should be the output
+	return nil
 }

--- a/worker/uniter/runner/jujuc/locator-add.go
+++ b/worker/uniter/runner/jujuc/locator-add.go
@@ -1,0 +1,71 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"fmt"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/utils/v3"
+
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+// AddServiceLocatorCommand implements the locator-add command.
+type AddServiceLocatorCommand struct {
+	cmd.CommandBase
+	ctx    Context
+	Labels string
+
+	Id   string
+	Name string
+	Type string
+
+	out cmd.Output
+}
+
+// NewAddServiceLocatorCommand generates a new AddServiceLocatorCommand.
+func NewAddServiceLocatorCommand(ctx Context) (cmd.Command, error) {
+	return &AddServiceLocatorCommand{ctx: ctx}, nil
+}
+
+// Info returns the command info structure for the locator-add command.
+func (c *AddServiceLocatorCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "locator-add",
+		Args:    "<locator-name>",
+		Purpose: "add service locator",
+	})
+}
+
+// Init parses the command's parameters.
+func (c *AddServiceLocatorCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("no arguments specified")
+	}
+	c.Name = args[0]
+	if c.Name == "" {
+		return fmt.Errorf("no service locator name specified")
+	}
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run adds metrics to the hook context.
+func (c *AddServiceLocatorCommand) Run(ctx *cmd.Context) (err error) {
+	// Generate new UUID for service locator
+	uuid, err := utils.NewUUID()
+	if err != nil {
+		return errors.Annotate(err, "failed to generate new uuid for service locator")
+	}
+	c.Id = uuid.String()
+	c.Type = "l4-service" // TODO(anvial): remove hardcode after locators assertions will be impl
+
+	// Record new service locator
+	err = c.ctx.AddServiceLocator(c.Id, c.Name, c.Type)
+	if err != nil {
+		return errors.Annotate(err, "cannot record service locator")
+	}
+	return c.out.Write(ctx, c.Name) // TODO(anvial): think what should be the output
+}

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -147,6 +147,11 @@ func (*RestrictedContext) AddMetricLabels(string, string, time.Time, map[string]
 	return ErrRestrictedContext
 }
 
+// AddServiceLocator implements hooks.Context.
+func (*RestrictedContext) AddServiceLocator(string, string, string) error {
+	return ErrRestrictedContext
+}
+
 // StorageTags implements hooks.Context.
 func (*RestrictedContext) StorageTags() ([]names.StorageTag, error) { return nil, ErrRestrictedContext }
 

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -54,6 +54,7 @@ var baseCommands = map[string]creator{
 	"relation-set" + cmdSuffix:            NewRelationSetCommand,
 	"unit-get" + cmdSuffix:                NewUnitGetCommand,
 	"add-metric" + cmdSuffix:              NewAddMetricCommand,
+	"locator-add" + cmdSuffix:             NewAddServiceLocatorCommand,
 	"juju-reboot" + cmdSuffix:             NewJujuRebootCommand,
 	"status-get" + cmdSuffix:              NewStatusGetCommand,
 	"status-set" + cmdSuffix:              NewStatusSetCommand,


### PR DESCRIPTION
## Please provide the following details to expedite review (and delete this heading)

This is a dummy version of the new hook tool for Service Locator implementation: `locator-add`


## QA steps


```sh
juju bootstrap localhost lxd
juju deploy tiny-bash
juju exec --unit tiny-bash/0 locator-add awesome-locator
juju debug-log
```
then see the following output: 

```
unit-tiny-bash-0: 13:33:35 INFO juju.worker.uniter.context Service Locator ID = <UUID>
unit-tiny-bash-0: 13:33:35 INFO juju.worker.uniter.context Service Locator Name = awesome-locator
unit-tiny-bash-0: 13:33:35 INFO juju.worker.uniter.context Service Locator Type = l4-service

```

## Documentation changes

None

## Bug reference

None