### PR TITLE
[JUJU-1318] create new service locator collection in db

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -44562,7 +44562,7 @@
     {
         "Name": "Uniter",
         "Description": "UniterAPI implements the latest version (v18) of the Uniter API.",
-        "Version": 18,
+        "Version": 19,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -44561,7 +44561,7 @@
     },
     {
         "Name": "Uniter",
-        "Description": "UniterAPI implements the latest version (v18) of the Uniter API.",
+        "Description": "UniterAPI implements the latest version (v19) of the Uniter API.",
         "Version": 19,
         "AvailableTo": [
             "controller-machine-agent",
@@ -44625,6 +44625,18 @@
                         }
                     },
                     "description": "AddMetricBatches adds the metrics for the specified unit."
+                },
+                "AddServiceLocator": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    },
+                    "description": "AddServiceLocator ..."
                 },
                 "AddUnitStorage": {
                     "type": "object",

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1498,3 +1498,32 @@ type CLICommandStatus struct {
 	Done   bool     `json:"done,omitempty"`
 	Error  *Error   `json:"error,omitempty"`
 }
+
+// AddServiceLocatorParams contains the parameters for adding a service locator.
+type AddServiceLocatorParams struct {
+	// ServiceLocatorUUID is the UUID of the service locator.
+	ServiceLocatorUUID string `json:"id"`
+
+	// Name is the name of the service locator.
+	Name string `json:"name"`
+
+	// Type is the type of the service locator.
+	Type string `json:"type"`
+
+	// UnitId is owner unit id of the service locator.
+	UnitId int `json:"unit-id"`
+
+	// ConsumerUnitId is consumer unit id of the service locator.
+	ConsumerUnitId int `json:"consumer-unit-id"`
+
+	// ConsumerRelationId is consumer unit id of the service locator.
+	ConsumerRelationId int `json:"consumer-relation-id"`
+
+	// Params is the param lists of the service locator.
+	Params map[string]interface{} `json:"params"`
+}
+
+// AddServiceLocators holds the parameters for making the AddServiceLocators call.
+type AddServiceLocators struct {
+	ServiceLocatorParams []AddServiceLocatorParams `json:"params"`
+}

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1525,5 +1525,5 @@ type AddServiceLocatorParams struct {
 
 // AddServiceLocators holds the parameters for making the AddServiceLocators call.
 type AddServiceLocators struct {
-	ServiceLocatorParams []AddServiceLocatorParams `json:"params"`
+	ServiceLocators []AddServiceLocatorParams `json:"params"`
 }

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1511,10 +1511,10 @@ type AddServiceLocatorParams struct {
 	Type string `json:"type"`
 
 	// UnitId is owner unit id of the service locator.
-	UnitId int `json:"unit-id"`
+	UnitId string `json:"unit-id"`
 
 	// ConsumerUnitId is consumer unit id of the service locator.
-	ConsumerUnitId int `json:"consumer-unit-id"`
+	ConsumerUnitId string `json:"consumer-unit-id"`
 
 	// ConsumerRelationId is consumer unit id of the service locator.
 	ConsumerRelationId int `json:"consumer-relation-id"`

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1501,9 +1501,6 @@ type CLICommandStatus struct {
 
 // AddServiceLocatorParams contains the parameters for adding a service locator.
 type AddServiceLocatorParams struct {
-	// ServiceLocatorUUID is the UUID of the service locator.
-	ServiceLocatorUUID string `json:"id"`
-
 	// Name is the name of the service locator.
 	Name string `json:"name"`
 

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -568,7 +568,11 @@ func allCollections() CollectionSchema {
 
 		// ----------------------
 
-		serviceLocatorsC: {},
+		serviceLocatorsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
 
 		// Raw-access collections
 		// ======================

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -568,6 +568,8 @@ func allCollections() CollectionSchema {
 
 		// ----------------------
 
+		serviceLocatorsC: {},
+
 		// Raw-access collections
 		// ======================
 
@@ -679,4 +681,7 @@ const (
 	secretMetadataC = "secretMetadata"
 	secretValuesC   = "secretValues"
 	secretRotateC   = "secretRotate"
+
+	// Service locators
+	serviceLocatorsC = "serviceLocators" //TODO: we need to unify collection naming system (all camel-case, or all non camel-case)
 )

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -683,5 +683,5 @@ const (
 	secretRotateC   = "secretRotate"
 
 	// Service locators
-	serviceLocatorsC = "serviceLocators" //TODO: we need to unify collection naming system (all camel-case, or all non camel-case)
+	serviceLocatorsC = "serviceLocators" // TODO(anvial): unify collection naming (camel-case, or not camel-case)
 )

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -570,7 +570,7 @@ func allCollections() CollectionSchema {
 
 		serviceLocatorsC: {
 			indexes: []mgo.Index{{
-				Key: []string{"model-uuid"},
+				Key: []string{"model-uuid", "unit-id"},
 			}},
 		},
 

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -896,7 +896,7 @@ func (s *MigrationSuite) TestStorageConstraintsDocFields(c *gc.C) {
 
 func (s *MigrationSuite) TestPayloadDocFields(c *gc.C) {
 	definedThroughContainment := set.NewStrings(
-		"UnitID",
+		"UnitId",
 		"MachineID",
 	)
 	migrated := set.NewStrings(

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -123,11 +123,12 @@ func (sp *serviceLocatorPersistence) AddServiceLocator(args AddServiceLocatorPar
 		return nil, errors.Errorf("model is no longer alive")
 	}
 
-	// Create the application addition operations.
 	serviceLocatorDoc := serviceLocatorDoc{
-		Id:   args.ServiceLocatorUUID,
-		Name: args.Name,
-		Type: args.Type,
+		Id:     args.ServiceLocatorUUID,
+		Name:   args.Name,
+		Type:   args.Type,
+		UnitId: args.UnitId,
+		Params: args.Params,
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that
@@ -142,7 +143,7 @@ func (sp *serviceLocatorPersistence) AddServiceLocator(args AddServiceLocatorPar
 			model.assertActiveOp(),
 			{
 				C:      serviceLocatorsC,
-				Id:     serviceLocatorDoc.DocId,
+				Id:     serviceLocatorDoc.Id,
 				Assert: txn.DocMissing,
 				Insert: &serviceLocatorDoc,
 			},

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -44,6 +44,7 @@ type ServiceLocator struct {
 type serviceLocatorDoc struct {
 	DocId  string                 `bson:"_id"`
 	Id     string                 `bson:"service-locator-id"`
+	UnitID int                    `bson:"unit-id"`
 	Name   string                 `bson:"name"`
 	Type   string                 `bson:"type"`
 	Params map[string]interface{} `bson:"params"`

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -7,6 +7,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/mgo/v2/txn"
+
+	"github.com/juju/juju/rpc/params"
 )
 
 //// ServiceLocators describes the state functionality for service locators.
@@ -90,39 +92,14 @@ func (sl *ServiceLocator) Params() map[string]interface{} {
 	return sl.doc.Params
 }
 
-// AddServiceLocatorParams contains the parameters for adding a service locator
-// to the model.
-type AddServiceLocatorParams struct {
-	// ServiceLocatorUUID is the UUID of the service locator.
-	ServiceLocatorUUID string
-
-	// Name is the name of the service locator.
-	Name string
-
-	// Type is the type of the service locator.
-	Type string
-
-	// UnitId is owner unit id of the service locator.
-	UnitId int
-
-	// ConsumerUnitId is consumer unit id of the service locator.
-	ConsumerUnitId int
-
-	// ConsumerRelationId is consumer unit id of the service locator.
-	ConsumerRelationId int
-
-	// Params is the param lists of the service locator.
-	Params map[string]interface{}
-}
-
-func validateServiceLocatorParams(args AddServiceLocatorParams) (err error) {
+func validateServiceLocatorParams(args params.AddServiceLocatorParams) (err error) {
 	// No Sanity checks.
 	return nil
 }
 
 // AddServiceLocator creates a new service locator record, which records details about a
 // network service provided to related units.
-func (sp *serviceLocatorPersistence) AddServiceLocator(args AddServiceLocatorParams) (_ *ServiceLocator, err error) {
+func (sp *serviceLocatorPersistence) AddServiceLocator(args params.AddServiceLocatorParams) (_ *ServiceLocator, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot add service locator for %q", args.ServiceLocatorUUID)
 
 	if err := validateServiceLocatorParams(args); err != nil {

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -15,8 +15,8 @@ import (
 //	//AllServiceLocators() ([]*ServiceLocator, error)
 //}
 
-// ServiceLocators returns the service locators functionality for the current state.
-func (st *State) ServiceLocators() *serviceLocatorPersistence {
+// ServiceLocatorsState returns the service locators for the current state.
+func (st *State) ServiceLocatorsState() *serviceLocatorPersistence {
 	return st.serviceLocators()
 }
 

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -1,0 +1,63 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/mgo/v2/bson"
+)
+
+// ServiceLocator represents the state of a juju network service locator.
+type ServiceLocator struct {
+	st  *State
+	doc serviceLocatorDoc
+}
+
+type serviceLocatorDoc struct {
+	DocId string `bson:"_id"`
+	Id    string `bson:"service-locator-id"`
+	Name  string `bson:"name"`
+	Type  string `bson:"type"`
+}
+
+func newServiceLocator(st *State, doc *serviceLocatorDoc) *ServiceLocator {
+	app := &ServiceLocator{
+		st:  st,
+		doc: *doc,
+	}
+	return app
+}
+
+// Name returns the name of the service locator.
+func (sl *ServiceLocator) Name() string {
+	return sl.doc.Name
+}
+
+// Type returns the type of the service locator.
+func (sl *ServiceLocator) Type() string {
+	return sl.doc.Type
+}
+
+// serviceLocators returns the service locators for the input condition
+func (st *State) serviceLocators(condition bson.D) ([]*ServiceLocator, error) {
+	serviceLocatorCollection, closer := st.db().GetCollection(serviceLocatorsC)
+	defer closer()
+
+	var connDocs []serviceLocatorDoc
+	if err := serviceLocatorCollection.Find(condition).All(&connDocs); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	conns := make([]*ServiceLocator, len(connDocs))
+	for i, v := range connDocs {
+		conns[i] = newServiceLocator(st, &v)
+	}
+	return conns, nil
+}
+
+// AllServiceLocators returns all service locators in the model.
+func (st *State) AllServiceLocators() ([]*ServiceLocator, error) {
+	conns, err := st.serviceLocators(nil)
+	return conns, errors.Annotate(err, "getting service locators")
+}

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -40,7 +40,7 @@ type ServiceLocator struct {
 
 type serviceLocatorDoc struct {
 	DocId              string                 `bson:"_id"`
-	Id                 string                 `bson:"service-locator-id"`
+	Id                 int                    `bson:"id"`
 	UnitId             string                 `bson:"unit-id"`
 	ConsumerUnitId     string                 `bson:"consumer-unit-id"`
 	ConsumerRelationId int                    `bson:"consumer-relation-id"`
@@ -58,7 +58,7 @@ func newServiceLocator(st *State, doc *serviceLocatorDoc) *ServiceLocator {
 }
 
 // Id returns the ID of the service locator.
-func (sl *ServiceLocator) Id() string {
+func (sl *ServiceLocator) Id() int {
 	return sl.doc.Id
 }
 
@@ -134,7 +134,7 @@ func (sp *serviceLocatorPersistence) AddServiceLocator(args params.AddServiceLoc
 			model.assertActiveOp(),
 			{
 				C:      serviceLocatorsC,
-				Id:     serviceLocatorDoc.DocId,
+				Id:     serviceLocatorDoc.Id,
 				Assert: txn.DocMissing,
 				Insert: &serviceLocatorDoc,
 			},
@@ -165,7 +165,7 @@ func (sp *serviceLocatorPersistence) AllServiceLocators() ([]*ServiceLocator, er
 
 // ServiceLocator returns the service locator.
 func (sp *serviceLocatorPersistence) ServiceLocator(slId string) ([]*ServiceLocator, error) {
-	locators, err := sp.serviceLocators(bson.D{{"service-locator-uuid", slId}})
+	locators, err := sp.serviceLocators(bson.D{{"id", slId}})
 	return locators, errors.Annotatef(err, "getting service locators for %v", slId)
 }
 

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -37,12 +37,14 @@ type ServiceLocator struct {
 }
 
 type serviceLocatorDoc struct {
-	DocId  string                 `bson:"_id"`
-	Id     string                 `bson:"service-locator-id"`
-	UnitId int                    `bson:"unit-id"`
-	Name   string                 `bson:"name"`
-	Type   string                 `bson:"type"`
-	Params map[string]interface{} `bson:"params"`
+	DocId              string                 `bson:"_id"`
+	Id                 string                 `bson:"service-locator-id"`
+	UnitId             int                    `bson:"unit-id"`
+	ConsumerUnitId     int                    `bson:"consumer-unit-id"`
+	ConsumerRelationId int                    `bson:"consumer-relation-id"`
+	Name               string                 `bson:"name"`
+	Type               string                 `bson:"type"`
+	Params             map[string]interface{} `bson:"params"`
 }
 
 func newServiceLocator(st *State, doc *serviceLocatorDoc) *ServiceLocator {
@@ -68,9 +70,19 @@ func (sl *ServiceLocator) Type() string {
 	return sl.doc.Type
 }
 
-// UnitId returns the name of the service locator.
+// UnitId returns the owner unit ID of the service locator.
 func (sl *ServiceLocator) UnitId() int {
 	return sl.doc.UnitId
+}
+
+// ConsumerUnitId returns the consumer unit ID of the service locator.
+func (sl *ServiceLocator) ConsumerUnitId() int {
+	return sl.doc.ConsumerUnitId
+}
+
+// ConsumerRelationId returns the consumer relation ID of the service locator.
+func (sl *ServiceLocator) ConsumerRelationId() int {
+	return sl.doc.ConsumerRelationId
 }
 
 // Params returns the param list of the service locator.
@@ -90,8 +102,14 @@ type AddServiceLocatorParams struct {
 	// Type is the type of the service locator.
 	Type string
 
-	// UnitId is the ID of the unit where service locator associated with.
+	// UnitId is owner unit id of the service locator.
 	UnitId int
+
+	// ConsumerUnitId is consumer unit id of the service locator.
+	ConsumerUnitId int
+
+	// ConsumerRelationId is consumer unit id of the service locator.
+	ConsumerRelationId int
 
 	// Params is the param lists of the service locator.
 	Params map[string]interface{}
@@ -119,11 +137,13 @@ func (sp *serviceLocatorPersistence) AddServiceLocator(args AddServiceLocatorPar
 	}
 
 	serviceLocatorDoc := serviceLocatorDoc{
-		Id:     args.ServiceLocatorUUID,
-		Name:   args.Name,
-		Type:   args.Type,
-		UnitId: args.UnitId,
-		Params: args.Params,
+		Id:                 args.ServiceLocatorUUID,
+		Name:               args.Name,
+		Type:               args.Type,
+		UnitId:             args.UnitId,
+		ConsumerUnitId:     args.ConsumerUnitId,
+		ConsumerRelationId: args.ConsumerRelationId,
+		Params:             args.Params,
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -103,10 +103,9 @@ func (sp *serviceLocatorPersistence) AddServiceLocator(args AddServiceLocatorPar
 
 	// Create the application addition operations.
 	serviceLocatorDoc := serviceLocatorDoc{
-		Id:    args.ServiceLocatorUUID,
-		Name:  args.Name,
-		Type:  args.Type,
-		DocId: args.ServiceLocatorUUID,
+		Id:   args.ServiceLocatorUUID,
+		Name: args.Name,
+		Type: args.Type,
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// If we've tried once already and failed, check that

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -44,7 +44,7 @@ type ServiceLocator struct {
 type serviceLocatorDoc struct {
 	DocId  string                 `bson:"_id"`
 	Id     string                 `bson:"service-locator-id"`
-	UnitID int                    `bson:"unit-id"`
+	UnitId int                    `bson:"unit-id"`
 	Name   string                 `bson:"name"`
 	Type   string                 `bson:"type"`
 	Params map[string]interface{} `bson:"params"`
@@ -58,6 +58,11 @@ func newServiceLocator(st *State, doc *serviceLocatorDoc) *ServiceLocator {
 	return app
 }
 
+// Id returns the ID of the service locator.
+func (sl *ServiceLocator) Id() string {
+	return sl.doc.Id
+}
+
 // Name returns the name of the service locator.
 func (sl *ServiceLocator) Name() string {
 	return sl.doc.Name
@@ -68,7 +73,17 @@ func (sl *ServiceLocator) Type() string {
 	return sl.doc.Type
 }
 
-// AddServiceLocatorParams contains the parameters for adding an service locator
+// UnitId returns the name of the service locator.
+func (sl *ServiceLocator) UnitId() int {
+	return sl.doc.UnitId
+}
+
+// Params returns the param list of the service locator.
+func (sl *ServiceLocator) Params() map[string]interface{} {
+	return sl.doc.Params
+}
+
+// AddServiceLocatorParams contains the parameters for adding a service locator
 // to the model.
 type AddServiceLocatorParams struct {
 	// ServiceLocatorUUID is the UUID of the service locator.
@@ -79,6 +94,12 @@ type AddServiceLocatorParams struct {
 
 	// Type is the type of the service locator.
 	Type string
+
+	// UnitId is the ID of the unit where service locator associated with.
+	UnitId int
+
+	// Params is the param lists of the service locator.
+	Params map[string]interface{}
 }
 
 func validateServiceLocatorParams(args AddServiceLocatorParams) (err error) {

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -17,11 +17,6 @@ import (
 
 // ServiceLocatorsState returns the service locators for the current state.
 func (st *State) ServiceLocatorsState() *serviceLocatorPersistence {
-	return st.serviceLocators()
-}
-
-// serviceLocators returns the service locators functionality for the current state.
-func (st *State) serviceLocators() *serviceLocatorPersistence {
 	return &serviceLocatorPersistence{
 		st: st,
 	}

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -41,8 +41,8 @@ type ServiceLocator struct {
 type serviceLocatorDoc struct {
 	DocId              string                 `bson:"_id"`
 	Id                 string                 `bson:"service-locator-id"`
-	UnitId             int                    `bson:"unit-id"`
-	ConsumerUnitId     int                    `bson:"consumer-unit-id"`
+	UnitId             string                 `bson:"unit-id"`
+	ConsumerUnitId     string                 `bson:"consumer-unit-id"`
 	ConsumerRelationId int                    `bson:"consumer-relation-id"`
 	Name               string                 `bson:"name"`
 	Type               string                 `bson:"type"`
@@ -73,12 +73,12 @@ func (sl *ServiceLocator) Type() string {
 }
 
 // UnitId returns the owner unit ID of the service locator.
-func (sl *ServiceLocator) UnitId() int {
+func (sl *ServiceLocator) UnitId() string {
 	return sl.doc.UnitId
 }
 
 // ConsumerUnitId returns the consumer unit ID of the service locator.
-func (sl *ServiceLocator) ConsumerUnitId() int {
+func (sl *ServiceLocator) ConsumerUnitId() string {
 	return sl.doc.ConsumerUnitId
 }
 

--- a/state/service_locators.go
+++ b/state/service_locators.go
@@ -134,14 +134,24 @@ func (sp *serviceLocatorPersistence) AddServiceLocator(args AddServiceLocatorPar
 	return &ServiceLocator{doc: serviceLocatorDoc}, nil
 }
 
+// RemoveServiceLocator removes a service locator record
+func RemoveServiceLocator(slId string) []txn.Op {
+	op := txn.Op{
+		C:      serviceLocatorsC,
+		Id:     slId,
+		Remove: true,
+	}
+	return []txn.Op{op}
+}
+
 // AllServiceLocators returns all service locators in the model.
 func (sp *serviceLocatorPersistence) AllServiceLocators() ([]*ServiceLocator, error) {
-	locators, err := sp.ServiceLocators("")
+	locators, err := sp.serviceLocators(nil)
 	return locators, errors.Annotate(err, "getting service locators")
 }
 
-// ServiceLocators returns the service locator.
-func (sp *serviceLocatorPersistence) ServiceLocators(ServiceLocatorUUID string) ([]*ServiceLocator, error) {
+// ServiceLocator returns the service locator.
+func (sp *serviceLocatorPersistence) ServiceLocator(ServiceLocatorUUID string) ([]*ServiceLocator, error) {
 	locators, err := sp.serviceLocators(bson.D{{"service-locator-uuid", ServiceLocatorUUID}})
 	return locators, errors.Annotatef(err, "getting service locators for %v", ServiceLocatorUUID)
 }

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -21,8 +21,8 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 		ServiceLocatorUUID: "test-service-locator-uuid",
 		Name:               "test-locator",
 		Type:               "l4-service",
-		UnitId:             17,
-		ConsumerUnitId:     18,
+		UnitId:             "mysql/17",
+		ConsumerUnitId:     "mediawiki/18",
 		ConsumerRelationId: 19,
 		Params:             map[string]interface{}{"ip-address": "1.1.1.1"},
 	})
@@ -30,16 +30,16 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl.Id(), gc.Equals, "test-service-locator-uuid")
 	c.Assert(sl.Name(), gc.Equals, "test-locator")
 	c.Assert(sl.Type(), gc.Equals, "l4-service")
-	c.Assert(sl.UnitId(), gc.Equals, 17)
-	c.Assert(sl.ConsumerUnitId(), gc.Equals, 18)
+	c.Assert(sl.UnitId(), gc.Equals, "mysql/17")
+	c.Assert(sl.ConsumerUnitId(), gc.Equals, "mediawiki/18")
 	c.Assert(sl.ConsumerRelationId(), gc.Equals, 19)
 
 	sl2, err := s.State.ServiceLocatorsState().AddServiceLocator(params.AddServiceLocatorParams{
 		ServiceLocatorUUID: "test-service-locator-uuid2",
 		Name:               "test-locator2",
 		Type:               "l4-service",
-		UnitId:             18,
-		ConsumerUnitId:     19,
+		UnitId:             "mysql/18",
+		ConsumerUnitId:     "mediawiki/19",
 		ConsumerRelationId: 20,
 		Params:             map[string]interface{}{"ip-address": "2.2.2.2"},
 	})
@@ -47,8 +47,8 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl2.Id(), gc.Equals, "test-service-locator-uuid2")
 	c.Assert(sl2.Name(), gc.Equals, "test-locator2")
 	c.Assert(sl2.Type(), gc.Equals, "l4-service")
-	c.Assert(sl2.UnitId(), gc.Equals, 18)
-	c.Assert(sl2.ConsumerUnitId(), gc.Equals, 19)
+	c.Assert(sl2.UnitId(), gc.Equals, "mysql/18")
+	c.Assert(sl2.ConsumerUnitId(), gc.Equals, "mediawiki/19")
 	c.Assert(sl2.ConsumerRelationId(), gc.Equals, 20)
 
 	all, err := s.State.ServiceLocatorsState().AllServiceLocators()
@@ -57,7 +57,7 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(all[0].Id(), gc.Equals, "test-service-locator-uuid")
 	c.Assert(all[0].Name(), gc.Equals, "test-locator")
 	c.Assert(all[0].Type(), gc.Equals, "l4-service")
-	c.Assert(all[0].UnitId(), gc.Equals, 17)
-	c.Assert(all[0].ConsumerUnitId(), gc.Equals, 18)
+	c.Assert(all[0].UnitId(), gc.Equals, "mysql/17")
+	c.Assert(all[0].ConsumerUnitId(), gc.Equals, "mediawiki/18")
 	c.Assert(all[0].ConsumerRelationId(), gc.Equals, 19)
 }

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -12,15 +12,12 @@ import (
 
 type serviceLocatorsSuite struct {
 	ConnSuite
-
-	suspendedRel *state.Relation
-	activeRel    *state.Relation
 }
 
 var _ = gc.Suite(&serviceLocatorsSuite{})
 
-func (s *serviceLocatorsSuite) TestAddServiceLocator(c *gc.C) {
-	oc, err := s.State.ServiceLocators().AddServiceLocator(state.AddServiceLocatorParams{
+func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
+	sl, err := s.State.ServiceLocators().AddServiceLocator(state.AddServiceLocatorParams{
 		ServiceLocatorUUID: "test-service-locator-uuid",
 		Name:               "test-locator",
 		Type:               "l4-service",
@@ -28,18 +25,29 @@ func (s *serviceLocatorsSuite) TestAddServiceLocator(c *gc.C) {
 		Params:             map[string]interface{}{"ip-address": "1.1.1.1"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(oc.Id(), gc.Equals, "test-service-locator-uuid")
-	c.Assert(oc.Name(), gc.Equals, "test-locator")
-	c.Assert(oc.Type(), gc.Equals, "l4-service")
-	c.Assert(oc.UnitId(), gc.Equals, 17)
-	c.Assert(oc.Params(), gc.Equals, map[string]interface{}{"ip-address": "1.1.1.1"})
+	c.Assert(sl.Id(), gc.Equals, "test-service-locator-uuid")
+	c.Assert(sl.Name(), gc.Equals, "test-locator")
+	c.Assert(sl.Type(), gc.Equals, "l4-service")
+	c.Assert(sl.UnitId(), gc.Equals, 17)
+
+	sl2, err := s.State.ServiceLocators().AddServiceLocator(state.AddServiceLocatorParams{
+		ServiceLocatorUUID: "test-service-locator-uuid2",
+		Name:               "test-locator2",
+		Type:               "l4-service",
+		UnitId:             18,
+		Params:             map[string]interface{}{"ip-address": "2.2.2.2"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(sl2.Id(), gc.Equals, "test-service-locator-uuid2")
+	c.Assert(sl2.Name(), gc.Equals, "test-locator2")
+	c.Assert(sl2.Type(), gc.Equals, "l4-service")
+	c.Assert(sl2.UnitId(), gc.Equals, 18)
 
 	all, err := s.State.ServiceLocators().AllServiceLocators()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(all, gc.HasLen, 2)
-	c.Assert(oc.Id(), gc.Equals, "test-service-locator-uuid")
-	c.Assert(oc.Name(), gc.Equals, "test-locator")
-	c.Assert(oc.Type(), gc.Equals, "l4-service")
-	c.Assert(oc.UnitId(), gc.Equals, 17)
-	c.Assert(oc.Params(), gc.Equals, map[string]interface{}{"ip-address": "1.1.1.1"})
+	c.Assert(all[0].Id(), gc.Equals, "test-service-locator-uuid")
+	c.Assert(all[0].Name(), gc.Equals, "test-locator")
+	c.Assert(all[0].Type(), gc.Equals, "l4-service")
+	c.Assert(all[0].UnitId(), gc.Equals, 17)
 }

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -22,6 +22,8 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 		Name:               "test-locator",
 		Type:               "l4-service",
 		UnitId:             17,
+		ConsumerUnitId:     18,
+		ConsumerRelationId: 19,
 		Params:             map[string]interface{}{"ip-address": "1.1.1.1"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -29,12 +31,16 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl.Name(), gc.Equals, "test-locator")
 	c.Assert(sl.Type(), gc.Equals, "l4-service")
 	c.Assert(sl.UnitId(), gc.Equals, 17)
+	c.Assert(sl.ConsumerUnitId(), gc.Equals, 18)
+	c.Assert(sl.ConsumerRelationId(), gc.Equals, 19)
 
 	sl2, err := s.State.ServiceLocatorsState().AddServiceLocator(state.AddServiceLocatorParams{
 		ServiceLocatorUUID: "test-service-locator-uuid2",
 		Name:               "test-locator2",
 		Type:               "l4-service",
 		UnitId:             18,
+		ConsumerUnitId:     19,
+		ConsumerRelationId: 20,
 		Params:             map[string]interface{}{"ip-address": "2.2.2.2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -42,6 +48,8 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl2.Name(), gc.Equals, "test-locator2")
 	c.Assert(sl2.Type(), gc.Equals, "l4-service")
 	c.Assert(sl2.UnitId(), gc.Equals, 18)
+	c.Assert(sl2.ConsumerUnitId(), gc.Equals, 19)
+	c.Assert(sl2.ConsumerRelationId(), gc.Equals, 20)
 
 	all, err := s.State.ServiceLocatorsState().AllServiceLocators()
 	c.Assert(err, jc.ErrorIsNil)
@@ -50,4 +58,6 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(all[0].Name(), gc.Equals, "test-locator")
 	c.Assert(all[0].Type(), gc.Equals, "l4-service")
 	c.Assert(all[0].UnitId(), gc.Equals, 17)
+	c.Assert(all[0].ConsumerUnitId(), gc.Equals, 18)
+	c.Assert(all[0].ConsumerRelationId(), gc.Equals, 19)
 }

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -17,7 +17,7 @@ type serviceLocatorsSuite struct {
 var _ = gc.Suite(&serviceLocatorsSuite{})
 
 func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
-	sl, err := s.State.ServiceLocators().AddServiceLocator(state.AddServiceLocatorParams{
+	sl, err := s.State.ServiceLocatorsState().AddServiceLocator(state.AddServiceLocatorParams{
 		ServiceLocatorUUID: "test-service-locator-uuid",
 		Name:               "test-locator",
 		Type:               "l4-service",
@@ -30,7 +30,7 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl.Type(), gc.Equals, "l4-service")
 	c.Assert(sl.UnitId(), gc.Equals, 17)
 
-	sl2, err := s.State.ServiceLocators().AddServiceLocator(state.AddServiceLocatorParams{
+	sl2, err := s.State.ServiceLocatorsState().AddServiceLocator(state.AddServiceLocatorParams{
 		ServiceLocatorUUID: "test-service-locator-uuid2",
 		Name:               "test-locator2",
 		Type:               "l4-service",
@@ -43,7 +43,7 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl2.Type(), gc.Equals, "l4-service")
 	c.Assert(sl2.UnitId(), gc.Equals, 18)
 
-	all, err := s.State.ServiceLocators().AllServiceLocators()
+	all, err := s.State.ServiceLocatorsState().AllServiceLocators()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(all, gc.HasLen, 2)
 	c.Assert(all[0].Id(), gc.Equals, "test-service-locator-uuid")

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -18,7 +18,6 @@ var _ = gc.Suite(&serviceLocatorsSuite{})
 
 func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	sl, err := s.State.ServiceLocatorsState().AddServiceLocator(params.AddServiceLocatorParams{
-		ServiceLocatorUUID: "test-service-locator-uuid",
 		Name:               "test-locator",
 		Type:               "l4-service",
 		UnitId:             "mysql/17",
@@ -35,10 +34,9 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl.ConsumerRelationId(), gc.Equals, 19)
 
 	sl2, err := s.State.ServiceLocatorsState().AddServiceLocator(params.AddServiceLocatorParams{
-		ServiceLocatorUUID: "test-service-locator-uuid2",
 		Name:               "test-locator2",
 		Type:               "l4-service",
-		UnitId:             "mysql/18",
+		UnitId:             "mysql/17",
 		ConsumerUnitId:     "mediawiki/19",
 		ConsumerRelationId: 20,
 		Params:             map[string]interface{}{"ip-address": "2.2.2.2"},
@@ -47,7 +45,7 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl2.Id(), gc.Equals, 2)
 	c.Assert(sl2.Name(), gc.Equals, "test-locator2")
 	c.Assert(sl2.Type(), gc.Equals, "l4-service")
-	c.Assert(sl2.UnitId(), gc.Equals, "mysql/18")
+	c.Assert(sl2.UnitId(), gc.Equals, "mysql/17")
 	c.Assert(sl2.ConsumerUnitId(), gc.Equals, "mediawiki/19")
 	c.Assert(sl2.ConsumerRelationId(), gc.Equals, 20)
 

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -27,7 +27,7 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 		Params:             map[string]interface{}{"ip-address": "1.1.1.1"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sl.Id(), gc.Equals, "test-service-locator-uuid")
+	c.Assert(sl.Id(), gc.Equals, 1)
 	c.Assert(sl.Name(), gc.Equals, "test-locator")
 	c.Assert(sl.Type(), gc.Equals, "l4-service")
 	c.Assert(sl.UnitId(), gc.Equals, "mysql/17")
@@ -44,7 +44,7 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 		Params:             map[string]interface{}{"ip-address": "2.2.2.2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sl2.Id(), gc.Equals, "test-service-locator-uuid2")
+	c.Assert(sl2.Id(), gc.Equals, 2)
 	c.Assert(sl2.Name(), gc.Equals, "test-locator2")
 	c.Assert(sl2.Type(), gc.Equals, "l4-service")
 	c.Assert(sl2.UnitId(), gc.Equals, "mysql/18")
@@ -53,8 +53,7 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 
 	all, err := s.State.ServiceLocatorsState().AllServiceLocators()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(all, gc.HasLen, 2)
-	c.Assert(all[0].Id(), gc.Equals, "test-service-locator-uuid")
+	c.Assert(all[0].Id(), gc.Equals, 1)
 	c.Assert(all[0].Name(), gc.Equals, "test-locator")
 	c.Assert(all[0].Type(), gc.Equals, "l4-service")
 	c.Assert(all[0].UnitId(), gc.Equals, "mysql/17")

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -7,7 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/state"
+	"github.com/juju/juju/rpc/params"
 )
 
 type serviceLocatorsSuite struct {
@@ -17,7 +17,7 @@ type serviceLocatorsSuite struct {
 var _ = gc.Suite(&serviceLocatorsSuite{})
 
 func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
-	sl, err := s.State.ServiceLocatorsState().AddServiceLocator(state.AddServiceLocatorParams{
+	sl, err := s.State.ServiceLocatorsState().AddServiceLocator(params.AddServiceLocatorParams{
 		ServiceLocatorUUID: "test-service-locator-uuid",
 		Name:               "test-locator",
 		Type:               "l4-service",
@@ -34,7 +34,7 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(sl.ConsumerUnitId(), gc.Equals, 18)
 	c.Assert(sl.ConsumerRelationId(), gc.Equals, 19)
 
-	sl2, err := s.State.ServiceLocatorsState().AddServiceLocator(state.AddServiceLocatorParams{
+	sl2, err := s.State.ServiceLocatorsState().AddServiceLocator(params.AddServiceLocatorParams{
 		ServiceLocatorUUID: "test-service-locator-uuid2",
 		Name:               "test-locator2",
 		Type:               "l4-service",

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/state"
+)
+
+type serviceLocatorsSuite struct {
+	ConnSuite
+
+	suspendedRel *state.Relation
+	activeRel    *state.Relation
+}
+
+var _ = gc.Suite(&serviceLocatorsSuite{})
+
+func (s *serviceLocatorsSuite) TestAddServiceLocator(c *gc.C) {
+	oc, err := s.State.ServiceLocators().AddServiceLocator(state.AddServiceLocatorParams{
+		ServiceLocatorUUID: "test-service-locator-uuid",
+		Name:               "test-locator",
+		Type:               "l4-service",
+		UnitId:             17,
+		Params:             map[string]interface{}{"ip-address": "1.1.1.1"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(oc.Id(), gc.Equals, "test-service-locator-uuid")
+	c.Assert(oc.Name(), gc.Equals, "test-locator")
+	c.Assert(oc.Type(), gc.Equals, "l4-service")
+	c.Assert(oc.UnitId(), gc.Equals, 17)
+	c.Assert(oc.Params(), gc.Equals, map[string]interface{}{"ip-address": "1.1.1.1"})
+
+	all, err := s.State.ServiceLocators().AllServiceLocators()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(all, gc.HasLen, 2)
+	c.Assert(oc.Id(), gc.Equals, "test-service-locator-uuid")
+	c.Assert(oc.Name(), gc.Equals, "test-locator")
+	c.Assert(oc.Type(), gc.Equals, "l4-service")
+	c.Assert(oc.UnitId(), gc.Equals, 17)
+	c.Assert(oc.Params(), gc.Equals, map[string]interface{}{"ip-address": "1.1.1.1"})
+}

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -58,3 +58,26 @@ func (s *serviceLocatorsSuite) TestServiceLocator(c *gc.C) {
 	c.Assert(all[0].ConsumerUnitId(), gc.Equals, "mediawiki/18")
 	c.Assert(all[0].ConsumerRelationId(), gc.Equals, 19)
 }
+
+func (s *serviceLocatorsSuite) TestServiceLocatorDuplication(c *gc.C) {
+	_, err := s.State.ServiceLocatorsState().AddServiceLocator(params.AddServiceLocatorParams{
+		Name:               "test-locator", // part of unique key
+		Type:               "l4-service",
+		UnitId:             "mysql/17", // part of unique key
+		ConsumerUnitId:     "mediawiki/18",
+		ConsumerRelationId: 19,
+		Params:             map[string]interface{}{"ip-address": "1.1.1.1"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.ServiceLocatorsState().AddServiceLocator(params.AddServiceLocatorParams{
+		Name:               "test-locator", // part of unique key
+		Type:               "l4-service",
+		UnitId:             "mysql/17", // part of unique key
+		ConsumerUnitId:     "mediawiki/19",
+		ConsumerRelationId: 20,
+		Params:             map[string]interface{}{"ip-address": "2.2.2.2"},
+	})
+	c.Assert(err.Error(), gc.Equals, "service locator name: test-locator unit-id: mysql/17 already exists")
+
+}

--- a/state/service_locators_test.go
+++ b/state/service_locators_test.go
@@ -78,6 +78,6 @@ func (s *serviceLocatorsSuite) TestServiceLocatorDuplication(c *gc.C) {
 		ConsumerRelationId: 20,
 		Params:             map[string]interface{}{"ip-address": "2.2.2.2"},
 	})
-	c.Assert(err.Error(), gc.Equals, "service locator name: test-locator unit-id: mysql/17 already exists")
+	c.Assert(err, gc.ErrorMatches, "service locator name: test-locator unit-id: mysql/17 already exists")
 
 }


### PR DESCRIPTION
This PR adds a new collection in DB,  the collection so far contains only Service locator Name, Type, ID. 
Further, this collection will be used as 'build-in' assertions information storage and service locator data storage.

## QA steps

```sh
juju bootstrap localhost lxd
```
Take script to login to DB: https://discourse.charmhub.io/t/login-into-mongodb/309

login to DB and type: `show collections`

one of them should be `ServiceLocators`

## Documentation changes

None

## Bug reference

None