### PR TITLE
[JUJU-1276] Charm's url saved as string

### DIFF
--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -371,7 +371,7 @@ func (s *applicationSuite) TestCompatibleSettingsParsing(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	ch, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL().String(), gc.Equals, "local:quantal/dummy-1")
+	c.Assert(ch.String(), gc.Equals, "local:quantal/dummy-1")
 
 	// Empty string will be returned as nil.
 	options := map[string]string{
@@ -643,7 +643,7 @@ func (s *applicationSuite) TestApplicationDeploymentRemovesPendingResourcesOnFai
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "haha/borken",
 			NumUnits:        1,
-			CharmURL:        charm.URL().String(),
+			CharmURL:        charm.String(),
 			CharmOrigin:     createCharmOriginFromURL(c, charm.URL()),
 			Resources:       map[string]string{"dummy": pendingID},
 		}},
@@ -671,7 +671,7 @@ func (s *applicationSuite) TestApplicationDeploymentLeavesResourcesOnSuccess(c *
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "unborken",
 			NumUnits:        1,
-			CharmURL:        charm.URL().String(),
+			CharmURL:        charm.String(),
 			CharmOrigin:     createCharmOriginFromURL(c, charm.URL()),
 			Resources:       map[string]string{"dummy": pendingID},
 		}},
@@ -1063,7 +1063,7 @@ func (s *applicationSuite) TestApplicationSetCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charm.URL().String(), gc.Equals, curl.String())
+	c.Assert(charm.String(), gc.Equals, curl.String())
 	c.Assert(force, jc.IsFalse)
 }
 
@@ -1114,7 +1114,7 @@ func (s *applicationSuite) assertApplicationSetCharm(c *gc.C, forceUnits bool) {
 	c.Assert(err, jc.ErrorIsNil)
 	charm, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charm.URL().String(), gc.Equals, "cs:~who/precise/wordpress-3")
+	c.Assert(charm.String(), gc.Equals, "cs:~who/precise/wordpress-3")
 }
 
 func (s *applicationSuite) assertApplicationSetCharmBlocked(c *gc.C, msg string) {
@@ -1188,7 +1188,7 @@ func (s *applicationSuite) TestApplicationSetCharmForceUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charm.URL().String(), gc.Equals, curl.String())
+	c.Assert(charm.String(), gc.Equals, curl.String())
 	c.Assert(force, jc.IsTrue)
 }
 
@@ -1325,7 +1325,7 @@ func (s *applicationSuite) assertApplicationSetCharmSeries(c *gc.C, upgradeCharm
 	c.Assert(err, jc.ErrorIsNil)
 	ch, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL().String(), gc.Equals, "cs:~who/"+url+"-0")
+	c.Assert(ch.String(), gc.Equals, "cs:~who/"+url+"-0")
 }
 
 func (s *applicationSuite) TestApplicationSetCharmUnsupportedSeriesForce(c *gc.C) {
@@ -2088,7 +2088,7 @@ func (s *applicationSuite) TestApplicationUpdateAllParams(c *gc.C) {
 	// Check the charm.
 	ch, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL().String(), gc.Equals, expectCurl.String())
+	c.Assert(ch.String(), gc.Equals, expectCurl.String())
 	c.Assert(force, gc.Equals, expectForce)
 
 	// Check the minimum number of units.

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1249,7 +1249,7 @@ func (context *statusContext) processApplication(application *state.Application)
 		series = coreseries.Kubernetes.String()
 	}
 	var processedStatus = params.ApplicationStatus{
-		Charm:            applicationCharm.URL().String(),
+		Charm:            applicationCharm.String(),
 		CharmVersion:     applicationCharm.Version(),
 		CharmProfile:     charmProfileName,
 		CharmChannel:     channel,
@@ -1276,7 +1276,7 @@ func (context *statusContext) processApplication(application *state.Application)
 		if err != nil {
 			return params.ApplicationStatus{Err: apiservererrors.ServerError(err)}
 		}
-		processedStatus.Units = context.processUnits(units, applicationCharm.URL().String(), expectWorkload)
+		processedStatus.Units = context.processUnits(units, applicationCharm.String(), expectWorkload)
 	}
 
 	// If for whatever reason the application isn't yet in the cache,

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -792,7 +792,7 @@ func (ch *backingCharm) updated(ctx *allWatcherContext) error {
 	allWatcherLogger.Tracef(`charm "%s:%s" updated`, ctx.modelUUID, ctx.id)
 	info := &multiwatcher.CharmInfo{
 		ModelUUID:    ch.ModelUUID,
-		CharmURL:     ch.URL.String(),
+		CharmURL:     *ch.URL,
 		CharmVersion: ch.CharmVersion,
 		Life:         life.Value(ch.Life.String()),
 	}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2485,12 +2485,12 @@ func testChangeCharms(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, [
 				about: "charm is added if it's in backing but not in Store",
 				change: watcher.Change{
 					C:  "charms",
-					Id: st.docID(ch.URL().String()),
+					Id: st.docID(ch.String()),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.CharmInfo{
 						ModelUUID:     st.ModelUUID(),
-						CharmURL:      ch.URL().String(),
+						CharmURL:      ch.String(),
 						Life:          life.Alive,
 						DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 					}}}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -84,7 +84,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, s.charm.URL())
 	c.Assert(force, jc.IsFalse)
 	url, force := s.mysql.CharmURL()
-	c.Assert(*url, gc.DeepEquals, s.charm.URL().String())
+	c.Assert(*url, gc.DeepEquals, s.charm.String())
 	c.Assert(force, jc.IsFalse)
 
 	// Add a compatible charm and force it.
@@ -101,7 +101,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = s.mysql.CharmURL()
-	c.Assert(*url, gc.DeepEquals, sch.URL().String())
+	c.Assert(*url, gc.DeepEquals, sch.String())
 	c.Assert(force, jc.IsTrue)
 }
 
@@ -180,7 +180,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, charm.URL().String())
+	c.Assert(*url, gc.DeepEquals, charm.String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile", lxdProfileMetaBase, 2)
@@ -196,7 +196,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, sch.URL().String())
+	c.Assert(*url, gc.DeepEquals, sch.String())
 	c.Assert(force, jc.IsTrue)
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 }
@@ -214,7 +214,7 @@ func (s *ApplicationSuite) TestLXDProfileFailSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, charm.URL().String())
+	c.Assert(*url, gc.DeepEquals, charm.String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile-fail", lxdProfileMetaBase, 2)
@@ -240,7 +240,7 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, charm.URL().String())
+	c.Assert(*url, gc.DeepEquals, charm.String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile-fail", lxdProfileMetaBase, 2)
@@ -257,7 +257,7 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, sch.URL().String())
+	c.Assert(*url, gc.DeepEquals, sch.String())
 	c.Assert(force, jc.IsTrue)
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 }
@@ -674,7 +674,7 @@ func (s *ApplicationSuite) TestClientApplicationSetCharmUnsupportedSeriesForce(c
 	c.Assert(err, jc.ErrorIsNil)
 	ch, _, err = app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL().String(), gc.Equals, "cs:multi-series2-8")
+	c.Assert(ch.String(), gc.Equals, "cs:multi-series2-8")
 }
 
 func (s *ApplicationSuite) TestClientApplicationSetCharmWrongOS(c *gc.C) {
@@ -1921,13 +1921,13 @@ func (s *ApplicationSuite) TestUpdateApplicationSeriesSecondSubordinateIncompati
 }
 
 func assertNoSettingsRef(c *gc.C, st *state.State, appName string, sch *state.Charm) {
-	cURL := sch.URL().String()
+	cURL := sch.String()
 	_, err := state.ApplicationSettingsRefCount(st, appName, &cURL)
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
 }
 
 func assertSettingsRef(c *gc.C, st *state.State, appName string, sch *state.Charm, refcount int) {
-	cURL := sch.URL().String()
+	cURL := sch.String()
 	rc, err := state.ApplicationSettingsRefCount(st, appName, &cURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc, gc.Equals, refcount)

--- a/state/charm.go
+++ b/state/charm.go
@@ -244,8 +244,11 @@ func insertCharmOps(mb modelBackend, info CharmInfo) ([]txn.Op, error) {
 
 // insertPlaceholderCharmOps returns the txn operations necessary to insert a
 // charm document referencing a store charm that is not yet directly accessible
-// within the model. If curl is nil, an error will be returned.
+// within the model. If curl is empty, an error will be returned.
 func insertPlaceholderCharmOps(mb modelBackend, curl string) ([]txn.Op, error) {
+	if curl == "" {
+		return nil, errors.BadRequestf("charm URL is empty")
+	}
 	return insertAnyCharmOps(mb, &charmDoc{
 		DocID:       curl,
 		URL:         &curl,
@@ -255,8 +258,11 @@ func insertPlaceholderCharmOps(mb modelBackend, curl string) ([]txn.Op, error) {
 
 // insertPendingCharmOps returns the txn operations necessary to insert a charm
 // document referencing a charm that has yet to be uploaded to the model.
-// If curl is nil, an error will be returned.
+// If curl is empty, an error will be returned.
 func insertPendingCharmOps(mb modelBackend, curl string) ([]txn.Op, error) {
+	if curl == "" {
+		return nil, errors.BadRequestf("charm URL is empty")
+	}
 	return insertAnyCharmOps(mb, &charmDoc{
 		DocID:         curl,
 		URL:           &curl,
@@ -548,7 +554,7 @@ func (c *Charm) Refresh() error {
 // the charm is not referenced by any application.
 func (c *Charm) Destroy() error {
 	buildTxn := func(_ int) ([]txn.Op, error) {
-		ops, err := charmDestroyOps(c.st, c.doc.URL)
+		ops, err := charmDestroyOps(c.st, c.String())
 		if IsNotAlive(err) {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -456,9 +456,8 @@ func (s *CharmSuite) TestPrepareCharmUpload(c *gc.C) {
 	// Try adding it again with the same revision and ensure we get the same document.
 	schCopy, err := s.State.PrepareCharmUpload(testCurl)
 	c.Assert(err, jc.ErrorIsNil)
-	// Refresh is required to set the charmURL, so the test will succeed.
-	err = schCopy.Refresh()
-	c.Assert(err, jc.ErrorIsNil)
+	// URL is required to set the charmURL, so the test will succeed.
+	_ = schCopy.URL()
 	c.Assert(sch, jc.DeepEquals, schCopy)
 
 	// Now add a charm and try again - we should get the same result

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -78,7 +78,7 @@ func (s *CharmSuite) TestDyingCharm(c *gc.C) {
 func (s *CharmSuite) testCharm(c *gc.C) {
 	dummy, err := s.State.Charm(s.curl)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.URL().String(), gc.Equals, s.curl.String())
+	c.Assert(dummy.String(), gc.Equals, s.curl.String())
 	c.Assert(dummy.Revision(), gc.Equals, 1)
 	c.Assert(dummy.StoragePath(), gc.Equals, "dummy-path")
 	c.Assert(dummy.BundleSha256(), gc.Equals, "quantal-dummy-1-sha256")
@@ -295,13 +295,13 @@ func (s *CharmSuite) TestAddCharm(c *gc.C) {
 	info := s.dummyCharm(c, "")
 	dummy, err := s.State.AddCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.URL().String(), gc.Equals, info.ID.String())
+	c.Assert(dummy.String(), gc.Equals, info.ID.String())
 
 	doc := state.CharmDoc{}
 	err = s.charms.FindId(state.DocID(s.State, info.ID.String())).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("%#v", doc)
-	c.Assert(doc.URL, gc.DeepEquals, info.ID)
+	c.Assert(*doc.URL, gc.DeepEquals, info.ID.String())
 
 	expVersion := "dummy-146-g725cfd3-dirty"
 	c.Assert(doc.CharmVersion, gc.Equals, expVersion)
@@ -339,14 +339,14 @@ func (s *CharmSuite) TestAddCharmUpdatesPlaceholder(c *gc.C) {
 	}
 	dummy, err := s.State.AddCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.URL().String(), gc.Equals, curl.String())
+	c.Assert(dummy.String(), gc.Equals, curl.String())
 
 	// Charm doc has been updated.
 	var docs []state.CharmDoc
 	err = s.charms.FindId(state.DocID(s.State, curl.String())).All(&docs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(docs, gc.HasLen, 1)
-	c.Assert(docs[0].URL, gc.DeepEquals, curl)
+	c.Assert(*docs[0].URL, gc.DeepEquals, curl.String())
 	c.Assert(docs[0].StoragePath, gc.DeepEquals, info.StoragePath)
 
 	// No more placeholder charm.
@@ -361,7 +361,7 @@ func (s *CharmSuite) assertPendingCharmExists(c *gc.C, curl *charm.URL) {
 	err := s.charms.FindId(state.DocID(s.State, curl.String())).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("%#v", doc)
-	c.Assert(doc.URL, gc.DeepEquals, curl)
+	c.Assert(*doc.URL, gc.DeepEquals, curl.String())
 	c.Assert(doc.PendingUpload, jc.IsTrue)
 	c.Assert(doc.Placeholder, jc.IsFalse)
 	c.Assert(doc.Meta, gc.IsNil)
@@ -455,6 +455,9 @@ func (s *CharmSuite) TestPrepareCharmUpload(c *gc.C) {
 
 	// Try adding it again with the same revision and ensure we get the same document.
 	schCopy, err := s.State.PrepareCharmUpload(testCurl)
+	c.Assert(err, jc.ErrorIsNil)
+	// Refresh is required to set the charmURL, so the test will succeed.
+	err = schCopy.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch, jc.DeepEquals, schCopy)
 
@@ -561,7 +564,7 @@ func (s *CharmSuite) assertPlaceholderCharmExists(c *gc.C, curl *charm.URL) {
 	doc := state.CharmDoc{}
 	err := s.charms.FindId(state.DocID(s.State, curl.String())).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(doc.URL, gc.DeepEquals, curl)
+	c.Assert(*doc.URL, gc.DeepEquals, curl.String())
 	c.Assert(doc.PendingUpload, jc.IsFalse)
 	c.Assert(doc.Placeholder, jc.IsTrue)
 	c.Assert(doc.Meta, gc.IsNil)
@@ -699,7 +702,7 @@ func (s *CharmSuite) TestAllCharms(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charms, gc.HasLen, 3)
 
-	c.Assert(charms[0].URL().String(), gc.Equals, "local:quantal/quantal-dummy-1")
+	c.Assert(charms[0].String(), gc.Equals, "local:quantal/quantal-dummy-1")
 	c.Assert(charms[1], gc.DeepEquals, sch)
 	c.Assert(charms[2].URL(), gc.DeepEquals, curl2)
 }

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2/txn"
 )
@@ -49,11 +48,7 @@ func appCharmIncRefOps(mb modelBackend, appName string, cURL *string, canCreate 
 	if err != nil {
 		return nil, errors.Annotate(err, "storage constraints reference")
 	}
-	curl, err := charm.ParseURL(*cURL)
-	if err != nil {
-		return nil, errors.Annotate(err, "parsing charm url")
-	}
-	charmKey := charmGlobalKey(curl)
+	charmKey := charmGlobalKey(cURL)
 	charmOp, err := getIncRefOp(refcounts, charmKey, 1)
 	if err != nil {
 		return nil, errors.Annotate(err, "charm reference")
@@ -81,11 +76,7 @@ func appCharmDecRefOps(st modelBackend, appName string, cURL *string, maybeDoFin
 		return nil, errors.Trace(e)
 	}
 	ops := []txn.Op{}
-	curl, err := charm.ParseURL(*cURL)
-	if op.FatalError(err) {
-		return fail(errors.Annotate(err, "charm url parsing"))
-	}
-	charmKey := charmGlobalKey(curl)
+	charmKey := charmGlobalKey(cURL)
 	charmOp, err := nsRefcounts.AliveDecRefOp(refcounts, charmKey)
 	if op.FatalError(err) {
 		return fail(errors.Annotate(err, "charm reference"))
@@ -144,13 +135,12 @@ func finalAppCharmRemoveOps(appName string, curl *string) []txn.Op {
 }
 
 // charmDestroyOps implements the logic of charm.Destroy.
-func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
+func charmDestroyOps(st modelBackend, curl *string) ([]txn.Op, error) {
 	db := st.db()
 	charms, cCloser := db.GetCollection(charmsC)
 	defer cCloser()
 
-	charmKey := curl.String()
-	charmOp, err := nsLife.destroyOp(charms, charmKey, nil)
+	charmOp, err := nsLife.destroyOp(charms, *curl, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "charm")
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -2159,7 +2159,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 				ops = append(ops, txn.Op{
 					C:      applicationsC,
 					Id:     st.docID(ep.ApplicationName),
-					Assert: bson.D{{"life", Alive}, {"charmurl", ch.URL()}},
+					Assert: bson.D{{"life", Alive}, {"charmurl", ch.String()}},
 					Update: bson.D{{"$inc", bson.D{{"relationcount", 1}}}},
 				})
 			}

--- a/state/state.go
+++ b/state/state.go
@@ -1239,7 +1239,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 
 	// The doc defaults to CharmModifiedVersion = 0, which is correct, since it
 	// has, by definition, at its initial state.
-	cURL := args.Charm.URL().String()
+	cURL := args.Charm.String()
 	appDoc := &applicationDoc{
 		DocID:         applicationID,
 		Name:          args.Name,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3349,6 +3349,9 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 	charm1 := s.AddTestingCharm(c, "wordpress")
 	charm2, err := s.State.Charm(charm1.URL())
 	c.Assert(err, jc.ErrorIsNil)
+	// Refresh is required to set the charmURL, so the test will succeed.
+	err = charm2.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charm1, jc.DeepEquals, charm2)
 
 	wordpress1 := s.AddTestingApplication(c, "wordpress", charm1)

--- a/state/unit.go
+++ b/state/unit.go
@@ -1587,7 +1587,7 @@ func (u *Unit) assertCharmOps(ch *Charm) []txn.Op {
 		ops = append(ops, txn.Op{
 			C:      applicationsC,
 			Id:     appName,
-			Assert: bson.D{{"charmurl", ch.URL()}},
+			Assert: bson.D{{"charmurl", ch.String()}},
 		})
 	}
 	return ops

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -4244,7 +4244,7 @@ func RemoveInvalidCharmPlaceholders(pool *StatePool) error {
 		iter := charms.Find(stillPlaceholder).Iter()
 		var cDoc charmDoc
 		for iter.Next(&cDoc) {
-			docs[cDoc.URL.String()] = cDoc.DocID
+			docs[*cDoc.URL] = cDoc.DocID
 		}
 
 		if err := iter.Close(); err != nil {

--- a/worker/caasoperator/download.go
+++ b/worker/caasoperator/download.go
@@ -28,6 +28,10 @@ func (c *charmInfo) URL() *charm.URL {
 	return c.curl
 }
 
+func (c *charmInfo) String() string {
+	return c.curl.String()
+}
+
 func (c *charmInfo) ArchiveSha256() (string, error) {
 	return c.sha256, nil
 }

--- a/worker/metrics/collect/handler_test.go
+++ b/worker/metrics/collect/handler_test.go
@@ -232,9 +232,9 @@ type mockReadCharm struct {
 	testing.Stub
 }
 
-func (m *mockReadCharm) ReadCharm(unitTag names.UnitTag, paths context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
+func (m *mockReadCharm) ReadCharm(unitTag names.UnitTag, paths context.Paths) (string, map[string]corecharm.Metric, error) {
 	m.MethodCall(m, "ReadCharm", unitTag, paths)
-	return corecharm.MustParseURL("local:trusty/metered-1"),
+	return "local:trusty/metered-1",
 		map[string]corecharm.Metric{
 			"pings":      {Description: "test metric", Type: corecharm.MetricTypeAbsolute},
 			"juju-units": {},

--- a/worker/metrics/collect/manifold.go
+++ b/worker/metrics/collect/manifold.go
@@ -47,18 +47,18 @@ var (
 	defaultPeriod = 5 * time.Minute
 
 	// errMetricsNotDefined is returned when the charm the uniter is running does
-	// not declared any metrics.
+	// not declare any metrics.
 	errMetricsNotDefined = errors.New("no metrics defined")
 
 	// readCharm function reads the charm directory and extracts declared metrics and the charm url.
-	readCharm = func(unitTag names.UnitTag, paths context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
+	readCharm = func(unitTag names.UnitTag, paths context.Paths) (string, map[string]corecharm.Metric, error) {
 		ch, err := corecharm.ReadCharm(paths.GetCharmDir())
 		if err != nil {
-			return nil, nil, errors.Annotatef(err, "failed to read charm from: %v", paths.GetCharmDir())
+			return "", nil, errors.Annotatef(err, "failed to read charm from: %v", paths.GetCharmDir())
 		}
 		chURL, err := charm.ReadCharmURL(path.Join(paths.GetCharmDir(), charm.CharmURLPath))
 		if err != nil {
-			return nil, nil, errors.Trace(err)
+			return "", nil, errors.Trace(err)
 		}
 		charmMetrics := map[string]corecharm.Metric{}
 		if ch.Metrics() != nil {
@@ -77,7 +77,7 @@ var (
 		if len(charmMetrics) == 0 {
 			return nil, errMetricsNotDefined
 		}
-		return metricFactory.Recorder(charmMetrics, chURL.String(), unitTag.String())
+		return metricFactory.Recorder(charmMetrics, chURL, unitTag.String())
 	}
 
 	newSocketListener = func(path string, handler spool.ConnectionHandler) (stopper, error) {
@@ -188,7 +188,11 @@ func newCollect(config ManifoldConfig, context dependency.Context) (*collect, er
 		return nil, errors.Trace(err)
 	}
 
-	if len(validMetrics) > 0 && charmURL.Schema == "local" {
+	curl, err := corecharm.ParseURL(charmURL)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(validMetrics) > 0 && curl.Schema == "local" {
 		h := newHandler(handlerConfig{
 			charmdir:       charmdir,
 			agent:          agent,

--- a/worker/metrics/collect/manifold_test.go
+++ b/worker/metrics/collect/manifold_test.go
@@ -106,8 +106,8 @@ func (s *ManifoldSuite) TestCollectWorkerStarts(c *gc.C) {
 			}, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:ubuntu-1"), map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:ubuntu-1", map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
 		})
 	worker, err := s.manifold.Start(s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)
@@ -125,8 +125,8 @@ func (s *ManifoldSuite) TestCollectWorkerErrorStopsListener(c *gc.C) {
 	listener := &mockListener{}
 	s.PatchValue(collect.NewSocketListener, collect.NewSocketListenerFnc(listener))
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("local:ubuntu-1"), map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "local:ubuntu-1", map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
 		})
 	worker, err := s.manifold.Start(s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)
@@ -163,8 +163,8 @@ func (s *ManifoldSuite) TestRecordMetricsError(c *gc.C) {
 			return &errorRecorder{recorder}, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:wordpress-37"), nil, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:wordpress-37", nil, nil
 		})
 	collectEntity, err := collect.NewCollect(s.manifoldConfig, s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)
@@ -185,8 +185,8 @@ func (s *ManifoldSuite) TestJujuUnitsBuiltinMetric(c *gc.C) {
 			return recorder, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:wordpress-37"), map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:wordpress-37", map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
 		})
 	collectEntity, err := collect.NewCollect(s.manifoldConfig, s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)
@@ -213,8 +213,8 @@ func (s *ManifoldSuite) TestAvailability(c *gc.C) {
 			return recorder, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:wordpress-37"), map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:wordpress-37", map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
 		})
 	charmdir := &dummyCharmdir{}
 	s.resources["charmdir-name"] = dt.NewStubResource(charmdir)
@@ -248,8 +248,8 @@ func (s *ManifoldSuite) TestNoMetricsDeclared(c *gc.C) {
 			return recorder, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:wordpress-37"), map[string]corecharm.Metric{}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:wordpress-37", map[string]corecharm.Metric{}, nil
 		})
 	collectEntity, err := collect.NewCollect(s.manifoldConfig, s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -64,7 +64,7 @@ func (d *BundlesDir) Read(info BundleInfo, abort <-chan struct{}) (Bundle, error
 // download will be stopped.
 func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struct{}) (err error) {
 	// First download...
-	curl, err := url.Parse(info.URL().String())
+	curl, err := url.Parse(info.String())
 	if err != nil {
 		return errors.Annotate(err, "could not parse charm URL")
 	}
@@ -75,10 +75,10 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 		Verify:    downloader.NewSha256Verifier(expectedSha256),
 		Abort:     abort,
 	}
-	d.logger.Infof("downloading %s from API server", info.URL())
+	d.logger.Infof("downloading %s from API server", info.String())
 	filename, err := d.downloader.Download(req)
 	if err != nil {
-		return errors.Annotatef(err, "failed to download charm %q from API server", info.URL())
+		return errors.Annotatef(err, "failed to download charm %q from API server", info.String())
 	}
 	defer errors.DeferredAnnotatef(&err, "downloaded but failed to copy charm to %q from %q", target, filename)
 
@@ -95,13 +95,13 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 // bundlePath returns the path to the location where the verified charm
 // bundle identified by info will be, or has been, saved.
 func (d *BundlesDir) bundlePath(info BundleInfo) string {
-	return d.bundleURLPath(info.URL())
+	return d.bundleURLPath(info.String())
 }
 
 // bundleURLPath returns the path to the location where the verified charm
 // bundle identified by url will be, or has been, saved.
-func (d *BundlesDir) bundleURLPath(url *charm.URL) string {
-	return path.Join(d.path, charm.Quote(url.String()))
+func (d *BundlesDir) bundleURLPath(url string) string {
+	return path.Join(d.path, charm.Quote(url))
 }
 
 // ClearDownloads removes any entries in the temporary bundle download

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -83,13 +83,13 @@ func (s *BundlesDirSuite) AddCharm(c *gc.C) (charm.BundleInfo, *state.Charm) {
 
 type fakeBundleInfo struct {
 	charm.BundleInfo
-	curl   *corecharm.URL
+	curl   string
 	sha256 string
 }
 
-func (f fakeBundleInfo) URL() *corecharm.URL {
-	if f.curl == nil {
-		return f.BundleInfo.URL()
+func (f fakeBundleInfo) String() string {
+	if f.curl == "" {
+		return f.BundleInfo.String()
 	}
 	return f.curl
 }
@@ -121,13 +121,12 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 	apiCharm, sch := s.AddCharm(c)
 
 	// Try to get the charm when the content doesn't match.
-	_, err = d.Read(&fakeBundleInfo{apiCharm, nil, "..."}, nil)
+	_, err = d.Read(&fakeBundleInfo{apiCharm, "", "..."}, nil)
 	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/dummy-1" from API server: `)+`expected sha256 "...", got ".*"`)
 	checkDownloadsEmpty()
 
 	// Try to get a charm whose bundle doesn't exist.
-	otherURL := corecharm.MustParseURL("cs:quantal/spam-1")
-	_, err = d.Read(&fakeBundleInfo{apiCharm, otherURL, ""}, nil)
+	_, err = d.Read(&fakeBundleInfo{apiCharm, "cs:quantal/spam-1", ""}, nil)
 	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/spam-1" from API server: `)+`.* not found`)
 	checkDownloadsEmpty()
 

--- a/worker/uniter/charm/charm.go
+++ b/worker/uniter/charm/charm.go
@@ -6,7 +6,6 @@ package charm
 import (
 	"errors"
 
-	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/utils/v3"
 )
@@ -39,7 +38,10 @@ type Bundle interface {
 type BundleInfo interface {
 
 	// URL returns the charm URL identifying the bundle.
-	URL() *charm.URL
+	//URL() *charm.URL
+
+	// String return the charm URL as a string.
+	String() string
 
 	// ArchiveSha256 returns the hex-encoded SHA-256 digest of the bundle data.
 	ArchiveSha256() (string, error)
@@ -84,15 +86,15 @@ type Logger interface {
 var ErrConflict = errors.New("charm upgrade has conflicts")
 
 // ReadCharmURL reads a charm identity file from the supplied path.
-func ReadCharmURL(path string) (*charm.URL, error) {
+func ReadCharmURL(path string) (string, error) {
 	surl := ""
 	if err := utils.ReadYaml(path, &surl); err != nil {
-		return nil, err
+		return "", err
 	}
-	return charm.ParseURL(surl)
+	return surl, nil
 }
 
 // WriteCharmURL writes a charm identity file into the supplied path.
-func WriteCharmURL(path string, url *charm.URL) error {
-	return utils.WriteYaml(path, url.String())
+func WriteCharmURL(path string, url string) error {
+	return utils.WriteYaml(path, url)
 }

--- a/worker/uniter/charm/charm.go
+++ b/worker/uniter/charm/charm.go
@@ -37,9 +37,6 @@ type Bundle interface {
 // BundleInfo describes a Bundle.
 type BundleInfo interface {
 
-	// URL returns the charm URL identifying the bundle.
-	//URL() *charm.URL
-
 	// String return the charm URL as a string.
 	String() string
 

--- a/worker/uniter/charm/manifest_deployer.go
+++ b/worker/uniter/charm/manifest_deployer.go
@@ -51,7 +51,7 @@ type manifestDeployer struct {
 	bundles   BundleReader
 	logger    Logger
 	staged    struct {
-		url      *charm.URL
+		url      string
 		bundle   Bundle
 		manifest set.Strings
 	}
@@ -71,7 +71,7 @@ func (d *manifestDeployer) Stage(info BundleInfo, abort <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	url := info.URL()
+	url := info.String()
 	if err := d.storeManifest(url, manifest); err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (d *manifestDeployer) Stage(info BundleInfo, abort <-chan struct{}) error {
 }
 
 func (d *manifestDeployer) Deploy() (err error) {
-	if d.staged.url == nil {
+	if d.staged.url == "" {
 		return fmt.Errorf("charm deployment failed: no charm set")
 	}
 
@@ -91,7 +91,7 @@ func (d *manifestDeployer) Deploy() (err error) {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	upgrading := baseURL != nil
+	upgrading := baseURL != ""
 	defer func(err *error) {
 		if *err != nil {
 			if upgrading {
@@ -180,7 +180,7 @@ func (d *manifestDeployer) ensureBaseFiles(baseManifest set.Strings) error {
 	deployingURL, deployingManifest, err := d.loadManifest(deployingURLPath)
 	if err == nil {
 		d.logger.Infof("detected interrupted deploy of charm %q", deployingURL)
-		if *deployingURL != *d.staged.url {
+		if deployingURL != d.staged.url {
 			d.logger.Infof("removing files from charm %q", deployingURL)
 			if err := d.removeDiff(deployingManifest, baseManifest); err != nil {
 				return err
@@ -194,23 +194,23 @@ func (d *manifestDeployer) ensureBaseFiles(baseManifest set.Strings) error {
 }
 
 // storeManifest stores, into dataPath, the supplied manifest for the supplied charm.
-func (d *manifestDeployer) storeManifest(url *charm.URL, manifest set.Strings) error {
+func (d *manifestDeployer) storeManifest(url string, manifest set.Strings) error {
 	if err := os.MkdirAll(d.DataPath(manifestsDataPath), 0755); err != nil {
 		return err
 	}
-	name := charm.Quote(url.String())
+	name := charm.Quote(url)
 	path := filepath.Join(d.DataPath(manifestsDataPath), name)
 	return utils.WriteYaml(path, manifest.SortedValues())
 }
 
 // loadManifest loads, from dataPath, the manifest for the charm identified by the
 // identity file at the supplied path within the charm directory.
-func (d *manifestDeployer) loadManifest(urlFilePath string) (*charm.URL, set.Strings, error) {
+func (d *manifestDeployer) loadManifest(urlFilePath string) (string, set.Strings, error) {
 	url, err := ReadCharmURL(d.CharmPath(urlFilePath))
 	if err != nil {
-		return nil, nil, err
+		return "", nil, err
 	}
-	name := charm.Quote(url.String())
+	name := charm.Quote(url)
 	path := filepath.Join(d.DataPath(manifestsDataPath), name)
 	manifest := []string{}
 	err = utils.ReadYaml(path, &manifest)
@@ -267,8 +267,8 @@ func (rbr RetryingBundleReader) Read(bi BundleInfo, abort <-chan struct{}) (Bund
 		// If the charm is still not available something went wrong.
 		// Report a NotFound error instead
 		if errors.IsNotYetAvailable(fetchErr) {
-			rbr.Logger.Errorf("exceeded max retry attempts while waiting for blob data for %q to become available", bi.URL().String())
-			fetchErr = errors.NotFoundf("blob data for %q", bi.URL().String())
+			rbr.Logger.Errorf("exceeded max retry attempts while waiting for blob data for %q to become available", bi.String())
+			fetchErr = errors.NotFoundf("blob data for %q", bi.String())
 		}
 		return nil, errors.Trace(fetchErr)
 	}

--- a/worker/uniter/charm/manifest_deployer_test.go
+++ b/worker/uniter/charm/manifest_deployer_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	ch "github.com/juju/charm/v8"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -45,8 +44,8 @@ func (s *ManifestDeployerSuite) SetUpTest(c *gc.C) {
 	s.deployer = charm.NewManifestDeployer(s.targetPath, deployerPath, s.bundles, loggo.GetLogger("test"))
 }
 
-func (s *ManifestDeployerSuite) addMockCharm(c *gc.C, revision int, bundle charm.Bundle) charm.BundleInfo {
-	return s.bundles.AddBundle(c, charmURL(revision), bundle)
+func (s *ManifestDeployerSuite) addMockCharm(revision int, bundle charm.Bundle) charm.BundleInfo {
+	return s.bundles.AddBundle(charmURL(revision), bundle)
 }
 
 func (s *ManifestDeployerSuite) addCharm(c *gc.C, revision int, content ...ft.Entry) charm.BundleInfo {
@@ -68,12 +67,12 @@ func (s *ManifestDeployerSuite) deployCharm(c *gc.C, revision int, content ...ft
 func (s *ManifestDeployerSuite) assertCharm(c *gc.C, revision int, content ...ft.Entry) {
 	url, err := charm.ReadCharmURL(filepath.Join(s.targetPath, ".juju-charm"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(url, gc.DeepEquals, charmURL(revision))
+	c.Assert(url, gc.Equals, charmURL(revision).String())
 	ft.Entries(content).Check(c, s.targetPath)
 }
 
 func (s *ManifestDeployerSuite) TestAbortStageWhenClosed(c *gc.C) {
-	info := s.addMockCharm(c, 1, mockBundle{})
+	info := s.addMockCharm(1, mockBundle{})
 	abort := make(chan struct{})
 	errors := make(chan error)
 	s.bundles.EnableWaitForAbort()
@@ -86,7 +85,7 @@ func (s *ManifestDeployerSuite) TestAbortStageWhenClosed(c *gc.C) {
 }
 
 func (s *ManifestDeployerSuite) TestDontAbortStageWhenNotClosed(c *gc.C) {
-	info := s.addMockCharm(c, 1, mockBundle{})
+	info := s.addMockCharm(1, mockBundle{})
 	abort := make(chan struct{})
 	errors := make(chan error)
 	stopWaiting := s.bundles.EnableWaitForAbort()
@@ -204,7 +203,7 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictResolveRetrySameCharm(c *gc.C
 			return nil
 		},
 	}
-	info := s.addMockCharm(c, 2, mockCharm)
+	info := s.addMockCharm(2, mockCharm)
 	err := s.deployer.Stage(info, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -247,7 +246,7 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictRevertRetryDifferentCharm(c *
 			return fmt.Errorf("oh noes")
 		},
 	}
-	badInfo := s.addMockCharm(c, 2, badCharm)
+	badInfo := s.addMockCharm(2, badCharm)
 	err := s.deployer.Stage(badInfo, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.deployer.Deploy()
@@ -278,8 +277,7 @@ type RetryingBundleReaderSuite struct {
 func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	charmURL := ch.MustParseURL("ch:focal/dummy-1")
-	s.bundleInfo.EXPECT().URL().Return(charmURL).AnyTimes()
+	s.bundleInfo.EXPECT().String().Return("ch:focal/dummy-1").AnyTimes()
 	s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")).AnyTimes()
 
 	go func() {
@@ -298,8 +296,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 func (s *RetryingBundleReaderSuite) TestReadBundleEventuallySucceeds(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	charmURL := ch.MustParseURL("ch:focal/dummy-1")
-	s.bundleInfo.EXPECT().URL().Return(charmURL).AnyTimes()
+	s.bundleInfo.EXPECT().String().Return("ch:focal/dummy-1").AnyTimes()
 	gomock.InOrder(
 		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")),
 		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(s.bundle, nil),

--- a/worker/uniter/charm/mocks/mocks.go
+++ b/worker/uniter/charm/mocks/mocks.go
@@ -8,9 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	charm "github.com/juju/charm/v8"
 	set "github.com/juju/collections/set"
-	charm0 "github.com/juju/juju/worker/uniter/charm"
+	charm "github.com/juju/juju/worker/uniter/charm"
 )
 
 // MockBundleReader is a mock of BundleReader interface.
@@ -37,10 +36,10 @@ func (m *MockBundleReader) EXPECT() *MockBundleReaderMockRecorder {
 }
 
 // Read mocks base method.
-func (m *MockBundleReader) Read(arg0 charm0.BundleInfo, arg1 <-chan struct{}) (charm0.Bundle, error) {
+func (m *MockBundleReader) Read(arg0 charm.BundleInfo, arg1 <-chan struct{}) (charm.Bundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", arg0, arg1)
-	ret0, _ := ret[0].(charm0.Bundle)
+	ret0, _ := ret[0].(charm.Bundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -89,18 +88,18 @@ func (mr *MockBundleInfoMockRecorder) ArchiveSha256() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveSha256", reflect.TypeOf((*MockBundleInfo)(nil).ArchiveSha256))
 }
 
-// URL mocks base method.
-func (m *MockBundleInfo) URL() *charm.URL {
+// String mocks base method.
+func (m *MockBundleInfo) String() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URL")
-	ret0, _ := ret[0].(*charm.URL)
+	ret := m.ctrl.Call(m, "String")
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// URL indicates an expected call of URL.
-func (mr *MockBundleInfoMockRecorder) URL() *gomock.Call {
+// String indicates an expected call of String.
+func (mr *MockBundleInfoMockRecorder) String() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockBundleInfo)(nil).URL))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockBundleInfo)(nil).String))
 }
 
 // MockBundle is a mock of Bundle interface.

--- a/worker/uniter/mockdeployer_test.go
+++ b/worker/uniter/mockdeployer_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	jujucharm "github.com/juju/charm/v8"
-
 	"github.com/juju/juju/worker/uniter/charm"
 )
 
@@ -19,14 +17,13 @@ type mockDeployer struct {
 	bundles   charm.BundleReader
 
 	bundle   charm.Bundle
-	staged   *jujucharm.URL
-	curl     *jujucharm.URL
+	staged   string
 	deployed bool
 	err      error
 }
 
 func (m *mockDeployer) Stage(info charm.BundleInfo, abort <-chan struct{}) error {
-	m.staged = info.URL()
+	m.staged = info.String()
 	var err error
 	m.bundle, err = m.bundles.Read(info, abort)
 	return err
@@ -46,6 +43,5 @@ func (m *mockDeployer) Deploy() error {
 		return err
 	}
 	m.deployed = true
-	m.curl = m.staged
 	return nil
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -706,7 +706,7 @@ func (s startupError) step(c *gc.C, ctx *testContext) {
 type verifyDeployed struct{}
 
 func (s verifyDeployed) step(c *gc.C, ctx *testContext) {
-	c.Assert(ctx.deployer.curl, jc.DeepEquals, curl(0))
+	c.Assert(ctx.deployer.staged, jc.DeepEquals, curl(0).String())
 	c.Assert(ctx.deployer.deployed, jc.IsTrue)
 }
 


### PR DESCRIPTION
Follow on to #14140.

Like with the unit doc, we have ended up in a situation where we are paying a small overhead to parse the charm's charm URL upon every access, even when we might not use the field.

Here we update the document to store a string, and only parse the URL at need. The patch is scoped to what is necessary to change the one field in the charm document.


## QA steps

There should be no impact to normal juju use, including upgrade and migrations