### PR TITLE
[JUJU-1338] Uniter charmurl string

### DIFF
--- a/api/agent/uniter/application.go
+++ b/api/agent/uniter/application.go
@@ -6,7 +6,6 @@ package uniter
 import (
 	"fmt"
 
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -92,30 +91,26 @@ func (s *Application) CharmModifiedVersion() (int, error) {
 //
 // NOTE: This differs from state.Application.CharmURL() by returning
 // an error instead as well, because it needs to make an API call.
-func (s *Application) CharmURL() (*charm.URL, bool, error) {
+func (s *Application) CharmURL() (string, bool, error) {
 	var results params.StringBoolResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.tag.String()}},
 	}
 	err := s.st.facade.FacadeCall("CharmURL", args, &results)
 	if err != nil {
-		return nil, false, err
+		return "", false, err
 	}
 	if len(results.Results) != 1 {
-		return nil, false, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+		return "", false, fmt.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return nil, false, result.Error
+		return "", false, result.Error
 	}
 	if result.Result != "" {
-		curl, err := charm.ParseURL(result.Result)
-		if err != nil {
-			return nil, false, err
-		}
-		return curl, result.Ok, nil
+		return result.Result, result.Ok, nil
 	}
-	return nil, false, fmt.Errorf("%q has no charm url set", s.tag)
+	return "", false, fmt.Errorf("%q has no charm url set", s.tag)
 }
 
 // SetStatus sets the status of the application if the passed unitName,

--- a/api/agent/uniter/application_test.go
+++ b/api/agent/uniter/application_test.go
@@ -159,7 +159,7 @@ func (s *applicationSuite) TestCharmURL(c *gc.C) {
 
 	curl, force, err := app.CharmURL()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(curl.String(), gc.Equals, "cs:mysql")
+	c.Assert(curl, gc.Equals, "cs:mysql")
 	c.Assert(force, jc.IsTrue)
 }
 

--- a/api/agent/uniter/unit_test.go
+++ b/api/agent/uniter/unit_test.go
@@ -496,7 +496,7 @@ func (s *unitSuite) TestCharmURL(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	curl, err := unit.CharmURL()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(curl, jc.DeepEquals, charm.MustParseURL("cs:mysql"))
+	c.Assert(curl, gc.Equals, "cs:mysql")
 }
 
 func (s *unitSuite) TestSetCharmURL(c *gc.C) {
@@ -517,7 +517,7 @@ func (s *unitSuite) TestSetCharmURL(c *gc.C) {
 	client := uniter.NewState(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.SetCharmURL(charm.MustParseURL("cs:mysql"))
+	err := unit.SetCharmURL("cs:mysql")
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -123,7 +123,11 @@ func (opc *operationCallbacks) ActionStatus(actionId string) (string, error) {
 }
 
 // GetArchiveInfo is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) GetArchiveInfo(charmURL *corecharm.URL) (charm.BundleInfo, error) {
+func (opc *operationCallbacks) GetArchiveInfo(url string) (charm.BundleInfo, error) {
+	charmURL, err := corecharm.ParseURL(url)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	ch, err := opc.u.st.Charm(charmURL)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -132,7 +136,7 @@ func (opc *operationCallbacks) GetArchiveInfo(charmURL *corecharm.URL) (charm.Bu
 }
 
 // SetCurrentCharm is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) SetCurrentCharm(charmURL *corecharm.URL) error {
+func (opc *operationCallbacks) SetCurrentCharm(charmURL string) error {
 	return opc.u.unit.SetCharmURL(charmURL)
 }
 

--- a/worker/uniter/operation/deploy.go
+++ b/worker/uniter/operation/deploy.go
@@ -6,7 +6,6 @@ package operation
 import (
 	"fmt"
 
-	corecharm "github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 
@@ -20,7 +19,7 @@ type deploy struct {
 	DoesNotRequireMachineLock
 
 	kind     Kind
-	charmURL *corecharm.URL
+	charmURL string
 	revert   bool
 	resolved bool
 
@@ -109,7 +108,7 @@ func (d *deploy) checkAlreadyDone(state State) error {
 	if state.Kind != d.kind {
 		return nil
 	}
-	if *state.CharmURL != *d.charmURL {
+	if state.CharmURL != d.charmURL {
 		return nil
 	}
 	if state.Step == Done {

--- a/worker/uniter/operation/deploy_test.go
+++ b/worker/uniter/operation/deploy_test.go
@@ -4,7 +4,6 @@
 package operation_test
 
 import (
-	corecharm "github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -22,7 +21,7 @@ type DeploySuite struct {
 
 var _ = gc.Suite(&DeploySuite{})
 
-type newDeploy func(operation.Factory, *corecharm.URL) (operation.Operation, error)
+type newDeploy func(operation.Factory, string) (operation.Operation, error)
 
 func (s *DeploySuite) testPrepareAlreadyDone(
 	c *gc.C, newDeploy newDeploy, kind operation.Kind,
@@ -37,12 +36,12 @@ func (s *DeploySuite) testPrepareAlreadyDone(
 		Callbacks: callbacks,
 		Logger:    loggo.GetLogger("test"),
 	})
-	op, err := newDeploy(factory, curl("cs:quantal/hive-23"))
+	op, err := newDeploy(factory, "cs:quantal/hive-23")
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Prepare(operation.State{
 		Kind:     kind,
 		Step:     operation.Done,
-		CharmURL: curl("cs:quantal/hive-23"),
+		CharmURL: "cs:quantal/hive-23",
 	})
 	c.Check(newState, gc.IsNil)
 	c.Check(errors.Cause(err), gc.Equals, operation.ErrSkipExecute)
@@ -89,13 +88,13 @@ func (s *DeploySuite) testPrepareArchiveInfoError(c *gc.C, newDeploy newDeploy) 
 		Callbacks: callbacks,
 		Logger:    loggo.GetLogger("test"),
 	})
-	op, err := newDeploy(factory, curl("cs:quantal/hive-23"))
+	op, err := newDeploy(factory, "cs:quantal/hive-23")
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "pew")
-	c.Check(callbacks.MockGetArchiveInfo.gotCharmURL, gc.DeepEquals, curl("cs:quantal/hive-23"))
+	c.Check(callbacks.MockGetArchiveInfo.gotCharmURL, gc.Equals, "cs:quantal/hive-23")
 }
 
 func (s *DeploySuite) TestPrepareArchiveInfoError_Install(c *gc.C) {
@@ -130,7 +129,7 @@ func (s *DeploySuite) testPrepareStageError(c *gc.C, newDeploy newDeploy) {
 		Abort:     abort,
 		Logger:    loggo.GetLogger("test"),
 	})
-	op, err := newDeploy(factory, curl("cs:quantal/hive-23"))
+	op, err := newDeploy(factory, "cs:quantal/hive-23")
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(operation.State{})
@@ -172,13 +171,13 @@ func (s *DeploySuite) testPrepareSetCharmError(c *gc.C, newDeploy newDeploy) {
 		Logger:    loggo.GetLogger("test"),
 	})
 
-	op, err := newDeploy(factory, curl("cs:quantal/hive-23"))
+	op, err := newDeploy(factory, "cs:quantal/hive-23")
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(operation.State{})
 	c.Check(newState, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "blargh")
-	c.Check(callbacks.MockSetCurrentCharm.gotCharmURL, gc.DeepEquals, curl("cs:quantal/hive-23"))
+	c.Check(callbacks.MockSetCurrentCharm.gotCharmURL, gc.Equals, "cs:quantal/hive-23")
 }
 
 func (s *DeploySuite) TestPrepareSetCharmError_Install(c *gc.C) {
@@ -209,13 +208,13 @@ func (s *DeploySuite) testPrepareSuccess(c *gc.C, newDeploy newDeploy, before, a
 		Callbacks: callbacks,
 		Logger:    loggo.GetLogger("test"),
 	})
-	op, err := newDeploy(factory, curl("cs:quantal/nyancat-4"))
+	op, err := newDeploy(factory, "cs:quantal/nyancat-4")
 	c.Assert(err, jc.ErrorIsNil)
 
 	newState, err := op.Prepare(before)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(newState, gc.DeepEquals, &after)
-	c.Check(callbacks.MockSetCurrentCharm.gotCharmURL, gc.DeepEquals, curl("cs:quantal/nyancat-4"))
+	c.Check(callbacks.MockSetCurrentCharm.gotCharmURL, gc.Equals, "cs:quantal/nyancat-4")
 }
 
 func (s *DeploySuite) TestPrepareSuccess_Install_BlankSlate(c *gc.C) {
@@ -225,7 +224,7 @@ func (s *DeploySuite) TestPrepareSuccess_Install_BlankSlate(c *gc.C) {
 		operation.State{
 			Kind:     operation.Install,
 			Step:     operation.Pending,
-			CharmURL: curl("cs:quantal/nyancat-4"),
+			CharmURL: "cs:quantal/nyancat-4",
 		},
 	)
 }
@@ -236,12 +235,12 @@ func (s *DeploySuite) TestPrepareSuccess_Install_Queued(c *gc.C) {
 		operation.State{
 			Kind:     operation.Install,
 			Step:     operation.Queued,
-			CharmURL: curl("cs:quantal/nyancat-4"),
+			CharmURL: "cs:quantal/nyancat-4",
 		},
 		operation.State{
 			Kind:     operation.Install,
 			Step:     operation.Pending,
-			CharmURL: curl("cs:quantal/nyancat-4"),
+			CharmURL: "cs:quantal/nyancat-4",
 		},
 	)
 }
@@ -263,7 +262,7 @@ func (s *DeploySuite) TestPrepareSuccess_Upgrade_PreservePendingHook(c *gc.C) {
 			operation.State{
 				Kind:     operation.Upgrade,
 				Step:     operation.Pending,
-				CharmURL: curl("cs:quantal/nyancat-4"),
+				CharmURL: "cs:quantal/nyancat-4",
 				Hook:     &hook.Info{Kind: hooks.ConfigChanged},
 			},
 		)
@@ -282,13 +281,13 @@ func (s *DeploySuite) TestPrepareSuccess_Upgrade_PreserveOriginalPendingHook(c *
 			operation.State{
 				Kind:     operation.Upgrade,
 				Step:     operation.Pending,
-				CharmURL: curl("cs:quantal/random-23"),
+				CharmURL: "cs:quantal/random-23",
 				Hook:     &hook.Info{Kind: hooks.ConfigChanged},
 			},
 			operation.State{
 				Kind:     operation.Upgrade,
 				Step:     operation.Pending,
-				CharmURL: curl("cs:quantal/nyancat-4"),
+				CharmURL: "cs:quantal/nyancat-4",
 				Hook:     &hook.Info{Kind: hooks.ConfigChanged},
 			},
 		)
@@ -308,7 +307,7 @@ func (s *DeploySuite) TestPrepareSuccess_Upgrade_PreserveNoHook(c *gc.C) {
 			operation.State{
 				Kind:     operation.Upgrade,
 				Step:     operation.Pending,
-				CharmURL: curl("cs:quantal/nyancat-4"),
+				CharmURL: "cs:quantal/nyancat-4",
 				Started:  true,
 			},
 		)
@@ -344,7 +343,7 @@ func (s *DeploySuite) testExecuteError(c *gc.C, newDeploy newDeploy) {
 		Callbacks: callbacks,
 		Logger:    loggo.GetLogger("test"),
 	})
-	op, err := newDeploy(factory, curl("cs:quantal/nyancat-4"))
+	op, err := newDeploy(factory, "cs:quantal/nyancat-4")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = op.Prepare(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -381,7 +380,7 @@ func (s *DeploySuite) testExecuteSuccess(
 		Callbacks: callbacks,
 		Logger:    loggo.GetLogger("test"),
 	})
-	op, err := newDeploy(factory, curl("cs:quantal/lol-1"))
+	op, err := newDeploy(factory, "cs:quantal/lol-1")
 	c.Assert(err, jc.ErrorIsNil)
 
 	midState, err := op.Prepare(before)
@@ -401,7 +400,7 @@ func (s *DeploySuite) TestExecuteSuccess_Install_BlankSlate(c *gc.C) {
 		operation.State{
 			Kind:     operation.Install,
 			Step:     operation.Done,
-			CharmURL: curl("cs:quantal/lol-1"),
+			CharmURL: "cs:quantal/lol-1",
 		},
 	)
 }
@@ -412,12 +411,12 @@ func (s *DeploySuite) TestExecuteSuccess_Install_Queued(c *gc.C) {
 		operation.State{
 			Kind:     operation.Install,
 			Step:     operation.Queued,
-			CharmURL: curl("cs:quantal/lol-1"),
+			CharmURL: "cs:quantal/lol-1",
 		},
 		operation.State{
 			Kind:     operation.Install,
 			Step:     operation.Done,
-			CharmURL: curl("cs:quantal/lol-1"),
+			CharmURL: "cs:quantal/lol-1",
 		},
 	)
 }
@@ -439,7 +438,7 @@ func (s *DeploySuite) TestExecuteSuccess_Upgrade_PreservePendingHook(c *gc.C) {
 			operation.State{
 				Kind:     operation.Upgrade,
 				Step:     operation.Done,
-				CharmURL: curl("cs:quantal/lol-1"),
+				CharmURL: "cs:quantal/lol-1",
 				Hook:     &hook.Info{Kind: hooks.ConfigChanged},
 			},
 		)
@@ -458,13 +457,13 @@ func (s *DeploySuite) TestExecuteSuccess_Upgrade_PreserveOriginalPendingHook(c *
 			operation.State{
 				Kind:     operation.Upgrade,
 				Step:     operation.Pending,
-				CharmURL: curl("cs:quantal/wild-9"),
+				CharmURL: "cs:quantal/wild-9",
 				Hook:     &hook.Info{Kind: hooks.ConfigChanged},
 			},
 			operation.State{
 				Kind:     operation.Upgrade,
 				Step:     operation.Done,
-				CharmURL: curl("cs:quantal/lol-1"),
+				CharmURL: "cs:quantal/lol-1",
 				Hook:     &hook.Info{Kind: hooks.ConfigChanged},
 			},
 		)
@@ -484,7 +483,7 @@ func (s *DeploySuite) TestExecuteSuccess_Upgrade_PreserveNoHook(c *gc.C) {
 			operation.State{
 				Kind:     operation.Upgrade,
 				Step:     operation.Done,
-				CharmURL: curl("cs:quantal/lol-1"),
+				CharmURL: "cs:quantal/lol-1",
 				Started:  true,
 			},
 		)
@@ -502,12 +501,12 @@ func (s *DeploySuite) TestCommitQueueInstallHook(c *gc.C) {
 		Callbacks: callbacks,
 		Logger:    loggo.GetLogger("test"),
 	})
-	op, err := factory.NewInstall(curl("cs:quantal/x-0"))
+	op, err := factory.NewInstall("cs:quantal/x-0")
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Commit(operation.State{
 		Kind:     operation.Install,
 		Step:     operation.Done,
-		CharmURL: nil, // doesn't actually matter here
+		CharmURL: "", // doesn't actually matter here
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(newState, gc.DeepEquals, &operation.State{
@@ -529,12 +528,12 @@ func (s *DeploySuite) testCommitQueueUpgradeHook(c *gc.C, newDeploy newDeploy) {
 		Logger:    loggo.GetLogger("test"),
 	})
 
-	op, err := newDeploy(factory, curl("cs:quantal/x-0"))
+	op, err := newDeploy(factory, "cs:quantal/x-0")
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Commit(operation.State{
 		Kind:     operation.Upgrade,
 		Step:     operation.Done,
-		CharmURL: nil, // doesn't actually matter here
+		CharmURL: "", // doesn't actually matter here
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(newState, gc.DeepEquals, &operation.State{
@@ -568,12 +567,12 @@ func (s *DeploySuite) testCommitInterruptedHook(c *gc.C, newDeploy newDeploy) {
 		Logger:    loggo.GetLogger("test"),
 	})
 
-	op, err := newDeploy(factory, curl("cs:quantal/x-0"))
+	op, err := newDeploy(factory, "cs:quantal/x-0")
 	c.Assert(err, jc.ErrorIsNil)
 	newState, err := op.Commit(operation.State{
 		Kind:     operation.Upgrade,
 		Step:     operation.Done,
-		CharmURL: nil, // doesn't actually matter here
+		CharmURL: "", // doesn't actually matter here
 		Hook:     &hook.Info{Kind: hooks.ConfigChanged},
 	})
 	c.Check(err, jc.ErrorIsNil)
@@ -605,7 +604,7 @@ func (s *DeploySuite) testDoesNotNeedGlobalMachineLock(c *gc.C, newDeploy newDep
 		Deployer: deployer,
 		Logger:   loggo.GetLogger("test"),
 	})
-	op, err := newDeploy(factory, curl("cs:quantal/x-0"))
+	op, err := newDeploy(factory, "cs:quantal/x-0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.NeedsGlobalMachineLock(), jc.IsFalse)
 }

--- a/worker/uniter/operation/errors.go
+++ b/worker/uniter/operation/errors.go
@@ -6,7 +6,6 @@ package operation
 import (
 	"fmt"
 
-	corecharm "github.com/juju/charm/v8"
 	"github.com/juju/errors"
 )
 
@@ -21,7 +20,7 @@ var (
 )
 
 type deployConflictError struct {
-	charmURL *corecharm.URL
+	charmURL string
 }
 
 func (err *deployConflictError) Error() string {
@@ -30,7 +29,7 @@ func (err *deployConflictError) Error() string {
 
 // NewDeployConflictError returns an error indicating that the charm with
 // the supplied URL failed to deploy.
-func NewDeployConflictError(charmURL *corecharm.URL) error {
+func NewDeployConflictError(charmURL string) error {
 	return &deployConflictError{charmURL}
 }
 

--- a/worker/uniter/operation/factory.go
+++ b/worker/uniter/operation/factory.go
@@ -4,7 +4,6 @@
 package operation
 
 import (
-	corecharm "github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -37,11 +36,11 @@ type factory struct {
 }
 
 // newDeploy is the common code for creating arbitrary deploy operations.
-func (f *factory) newDeploy(kind Kind, charmURL *corecharm.URL, revert, resolved bool) (Operation, error) {
+func (f *factory) newDeploy(kind Kind, charmURL string, revert, resolved bool) (Operation, error) {
 	if f.config.Deployer == nil {
 		return nil, errors.New("deployer required")
 	}
-	if charmURL == nil {
+	if charmURL == "" {
 		return nil, errors.New("charm url required")
 	} else if kind != Install && kind != Upgrade {
 		return nil, errors.Errorf("unknown deploy kind: %s", kind)
@@ -59,12 +58,12 @@ func (f *factory) newDeploy(kind Kind, charmURL *corecharm.URL, revert, resolved
 }
 
 // NewInstall is part of the Factory interface.
-func (f *factory) NewInstall(charmURL *corecharm.URL) (Operation, error) {
+func (f *factory) NewInstall(charmURL string) (Operation, error) {
 	return f.newDeploy(Install, charmURL, false, false)
 }
 
 // NewUpgrade is part of the Factory interface.
-func (f *factory) NewUpgrade(charmURL *corecharm.URL) (Operation, error) {
+func (f *factory) NewUpgrade(charmURL string) (Operation, error) {
 	return f.newDeploy(Upgrade, charmURL, false, false)
 }
 
@@ -86,12 +85,12 @@ func (f *factory) NewNoOpFinishUpgradeSeries() (Operation, error) {
 }
 
 // NewRevertUpgrade is part of the Factory interface.
-func (f *factory) NewRevertUpgrade(charmURL *corecharm.URL) (Operation, error) {
+func (f *factory) NewRevertUpgrade(charmURL string) (Operation, error) {
 	return f.newDeploy(Upgrade, charmURL, true, false)
 }
 
 // NewResolvedUpgrade is part of the Factory interface.
-func (f *factory) NewResolvedUpgrade(charmURL *corecharm.URL) (Operation, error) {
+func (f *factory) NewResolvedUpgrade(charmURL string) (Operation, error) {
 	return f.newDeploy(Upgrade, charmURL, false, true)
 }
 

--- a/worker/uniter/operation/factory_test.go
+++ b/worker/uniter/operation/factory_test.go
@@ -4,7 +4,6 @@
 package operation_test
 
 import (
-	corecharm "github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
@@ -40,7 +39,7 @@ func (s *FactorySuite) SetUpTest(c *gc.C) {
 }
 
 func (s *FactorySuite) testNewDeployError(c *gc.C, newDeploy newDeploy) {
-	op, err := newDeploy(s.factory, nil)
+	op, err := newDeploy(s.factory, "")
 	c.Check(op, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "charm url required")
 }
@@ -62,7 +61,7 @@ func (s *FactorySuite) TestNewResolvedUpgradeError(c *gc.C) {
 }
 
 func (s *FactorySuite) testNewDeployString(c *gc.C, newDeploy newDeploy, expectPrefix string) {
-	op, err := newDeploy(s.factory, corecharm.MustParseURL("cs:quantal/wordpress-1"))
+	op, err := newDeploy(s.factory, "cs:quantal/wordpress-1")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(op.String(), gc.Equals, expectPrefix+" cs:quantal/wordpress-1")
 }

--- a/worker/uniter/operation/failaction_test.go
+++ b/worker/uniter/operation/failaction_test.go
@@ -111,7 +111,7 @@ func (s *FailActionSuite) TestCommit(c *gc.C) {
 			Kind:     operation.Continue,
 			Step:     operation.Pending,
 			Started:  true,
-			CharmURL: curl("cs:quantal/wordpress-2"),
+			CharmURL: "cs:quantal/wordpress-2",
 			ActionId: &randomActionId,
 		},
 		after: operation.State{
@@ -125,7 +125,7 @@ func (s *FailActionSuite) TestCommit(c *gc.C) {
 			Kind:     operation.Continue,
 			Step:     operation.Pending,
 			Started:  true,
-			CharmURL: curl("cs:quantal/wordpress-2"),
+			CharmURL: "cs:quantal/wordpress-2",
 			ActionId: &randomActionId,
 			Hook:     &hook.Info{Kind: hooks.Install},
 		},

--- a/worker/uniter/operation/interface.go
+++ b/worker/uniter/operation/interface.go
@@ -4,7 +4,6 @@
 package operation
 
 import (
-	corecharm "github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	utilexec "github.com/juju/utils/v3/exec"
@@ -107,10 +106,10 @@ type Executor interface {
 type Factory interface {
 
 	// NewInstall creates an install operation for the supplied charm.
-	NewInstall(charmURL *corecharm.URL) (Operation, error)
+	NewInstall(charmURL string) (Operation, error)
 
 	// NewUpgrade creates an upgrade operation for the supplied charm.
-	NewUpgrade(charmURL *corecharm.URL) (Operation, error)
+	NewUpgrade(charmURL string) (Operation, error)
 
 	// NewRemoteInit inits the remote charm on CAAS pod.
 	NewRemoteInit(runningStatus remotestate.ContainerRunningStatus) (Operation, error)
@@ -125,12 +124,12 @@ type Factory interface {
 	// NewRevertUpgrade creates an operation to clear the unit's resolved flag,
 	// and execute an upgrade to the supplied charm that is careful to excise
 	// remnants of a previously failed upgrade to a different charm.
-	NewRevertUpgrade(charmURL *corecharm.URL) (Operation, error)
+	NewRevertUpgrade(charmURL string) (Operation, error)
 
 	// NewResolvedUpgrade creates an operation to clear the unit's resolved flag,
 	// and execute an upgrade to the supplied charm that is careful to preserve
 	// non-overlapping remnants of a previously failed upgrade to the same charm.
-	NewResolvedUpgrade(charmURL *corecharm.URL) (Operation, error)
+	NewResolvedUpgrade(charmURL string) (Operation, error)
 
 	// NewRunHook creates an operation to execute the supplied hook.
 	NewRunHook(hookInfo hook.Info) (Operation, error)
@@ -225,13 +224,13 @@ type Callbacks interface {
 
 	// GetArchiveInfo is used to find out how to download a charm archive. It's
 	// only used by Deploy operations.
-	GetArchiveInfo(charmURL *corecharm.URL) (charm.BundleInfo, error)
+	GetArchiveInfo(charmURL string) (charm.BundleInfo, error)
 
 	// SetCurrentCharm records intent to deploy a given charm. It must be called
 	// *before* recording local state referencing that charm, to ensure there's
 	// no path by which the controller can legitimately garbage collect that
 	// charm or the application's settings for it. It's only used by Deploy operations.
-	SetCurrentCharm(charmURL *corecharm.URL) error
+	SetCurrentCharm(charmURL string) error
 
 	// SetUpgradeSeriesStatus is intended to give the uniter a chance to
 	// upgrade the status of a running series upgrade before or after

--- a/worker/uniter/operation/mocks/interface_mock.go
+++ b/worker/uniter/operation/mocks/interface_mock.go
@@ -8,9 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	charm "github.com/juju/charm/v8"
 	model "github.com/juju/juju/core/model"
-	charm0 "github.com/juju/juju/worker/uniter/charm"
+	charm "github.com/juju/juju/worker/uniter/charm"
 	hook "github.com/juju/juju/worker/uniter/hook"
 	operation "github.com/juju/juju/worker/uniter/operation"
 	remotestate "github.com/juju/juju/worker/uniter/remotestate"
@@ -209,7 +208,7 @@ func (mr *MockFactoryMockRecorder) NewFailAction(arg0 interface{}) *gomock.Call 
 }
 
 // NewInstall mocks base method.
-func (m *MockFactory) NewInstall(arg0 *charm.URL) (operation.Operation, error) {
+func (m *MockFactory) NewInstall(arg0 string) (operation.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewInstall", arg0)
 	ret0, _ := ret[0].(operation.Operation)
@@ -269,7 +268,7 @@ func (mr *MockFactoryMockRecorder) NewResignLeadership() *gomock.Call {
 }
 
 // NewResolvedUpgrade mocks base method.
-func (m *MockFactory) NewResolvedUpgrade(arg0 *charm.URL) (operation.Operation, error) {
+func (m *MockFactory) NewResolvedUpgrade(arg0 string) (operation.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewResolvedUpgrade", arg0)
 	ret0, _ := ret[0].(operation.Operation)
@@ -284,7 +283,7 @@ func (mr *MockFactoryMockRecorder) NewResolvedUpgrade(arg0 interface{}) *gomock.
 }
 
 // NewRevertUpgrade mocks base method.
-func (m *MockFactory) NewRevertUpgrade(arg0 *charm.URL) (operation.Operation, error) {
+func (m *MockFactory) NewRevertUpgrade(arg0 string) (operation.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRevertUpgrade", arg0)
 	ret0, _ := ret[0].(operation.Operation)
@@ -344,7 +343,7 @@ func (mr *MockFactoryMockRecorder) NewSkipRemoteInit(arg0 interface{}) *gomock.C
 }
 
 // NewUpgrade mocks base method.
-func (m *MockFactory) NewUpgrade(arg0 *charm.URL) (operation.Operation, error) {
+func (m *MockFactory) NewUpgrade(arg0 string) (operation.Operation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewUpgrade", arg0)
 	ret0, _ := ret[0].(operation.Operation)
@@ -425,10 +424,10 @@ func (mr *MockCallbacksMockRecorder) FailAction(arg0, arg1 interface{}) *gomock.
 }
 
 // GetArchiveInfo mocks base method.
-func (m *MockCallbacks) GetArchiveInfo(arg0 *charm.URL) (charm0.BundleInfo, error) {
+func (m *MockCallbacks) GetArchiveInfo(arg0 string) (charm.BundleInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetArchiveInfo", arg0)
-	ret0, _ := ret[0].(charm0.BundleInfo)
+	ret0, _ := ret[0].(charm.BundleInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -493,7 +492,7 @@ func (mr *MockCallbacksMockRecorder) RemoteInit(arg0, arg1 interface{}) *gomock.
 }
 
 // SetCurrentCharm mocks base method.
-func (m *MockCallbacks) SetCurrentCharm(arg0 *charm.URL) error {
+func (m *MockCallbacks) SetCurrentCharm(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetCurrentCharm", arg0)
 	ret0, _ := ret[0].(error)

--- a/worker/uniter/operation/runaction_test.go
+++ b/worker/uniter/operation/runaction_test.go
@@ -302,7 +302,7 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 			Kind:     operation.Continue,
 			Step:     operation.Pending,
 			Started:  true,
-			CharmURL: curl("cs:quantal/wordpress-2"),
+			CharmURL: "cs:quantal/wordpress-2",
 			ActionId: &randomActionId,
 		},
 		after: operation.State{
@@ -316,7 +316,7 @@ func (s *RunActionSuite) TestCommit(c *gc.C) {
 			Kind:     operation.Continue,
 			Step:     operation.Pending,
 			Started:  true,
-			CharmURL: curl("cs:quantal/wordpress-2"),
+			CharmURL: "cs:quantal/wordpress-2",
 			ActionId: &randomActionId,
 			Hook:     &hook.Info{Kind: hooks.Install},
 		},

--- a/worker/uniter/operation/state.go
+++ b/worker/uniter/operation/state.go
@@ -4,7 +4,6 @@
 package operation
 
 import (
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 
@@ -98,7 +97,7 @@ type State struct {
 
 	// Charm describes the charm being deployed by an Install or Upgrade
 	// operation, and is otherwise blank.
-	CharmURL *charm.URL `yaml:"charm,omitempty"`
+	CharmURL string `yaml:"charm,omitempty"`
 
 	// ConfigHash stores a hash of the latest known charm
 	// configuration settings - it's used to determine whether we need
@@ -121,7 +120,7 @@ func (st State) Validate() (err error) {
 	defer errors.DeferredAnnotatef(&err, "invalid operation state")
 	hasHook := st.Hook != nil
 	hasActionId := st.ActionId != nil
-	hasCharm := st.CharmURL != nil
+	hasCharm := st.CharmURL != ""
 	switch st.Kind {
 	case Install:
 		if st.Installed {
@@ -200,7 +199,7 @@ type stateChange struct {
 	Step            Step
 	Hook            *hook.Info
 	ActionId        *string
-	CharmURL        *charm.URL
+	CharmURL        string
 	HasRunStatusSet bool
 }
 

--- a/worker/uniter/operation/state_test.go
+++ b/worker/uniter/operation/state_test.go
@@ -5,7 +5,6 @@ package operation_test
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -24,7 +23,7 @@ type StateOpsSuite struct {
 
 var _ = gc.Suite(&StateOpsSuite{})
 
-var stcurl = charm.MustParseURL("cs:quantal/application-name-123")
+var stcurl = "cs:quantal/application-name-123"
 var relhook = &hook.Info{
 	Kind:              hooks.RelationJoined,
 	RemoteUnit:        "some-thing/123",

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -6,7 +6,6 @@ package operation_test
 import (
 	"sync"
 
-	corecharm "github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/testing"
@@ -24,22 +23,22 @@ import (
 )
 
 type MockGetArchiveInfo struct {
-	gotCharmURL *corecharm.URL
+	gotCharmURL string
 	info        charm.BundleInfo
 	err         error
 }
 
-func (mock *MockGetArchiveInfo) Call(charmURL *corecharm.URL) (charm.BundleInfo, error) {
+func (mock *MockGetArchiveInfo) Call(charmURL string) (charm.BundleInfo, error) {
 	mock.gotCharmURL = charmURL
 	return mock.info, mock.err
 }
 
 type MockSetCurrentCharm struct {
-	gotCharmURL *corecharm.URL
+	gotCharmURL string
 	err         error
 }
 
-func (mock *MockSetCurrentCharm) Call(charmURL *corecharm.URL) error {
+func (mock *MockSetCurrentCharm) Call(charmURL string) error {
 	mock.gotCharmURL = charmURL
 	return mock.err
 }
@@ -51,11 +50,11 @@ type DeployCallbacks struct {
 	MockInitializeMetricsTimers *MockNoArgs
 }
 
-func (cb *DeployCallbacks) GetArchiveInfo(charmURL *corecharm.URL) (charm.BundleInfo, error) {
+func (cb *DeployCallbacks) GetArchiveInfo(charmURL string) (charm.BundleInfo, error) {
 	return cb.MockGetArchiveInfo.Call(charmURL)
 }
 
-func (cb *DeployCallbacks) SetCurrentCharm(charmURL *corecharm.URL) error {
+func (cb *DeployCallbacks) SetCurrentCharm(charmURL string) error {
 	return cb.MockSetCurrentCharm.Call(charmURL)
 }
 
@@ -546,14 +545,13 @@ func (mock *MockSendResponse) Call(response *utilexec.ExecResponse, err error) b
 	return mock.eatError
 }
 
-var curl = corecharm.MustParseURL
 var someActionId = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 var randomActionId = "9f484882-2f18-4fd2-967d-db9663db7bea"
 var overwriteState = operation.State{
 	Kind:     operation.Continue,
 	Step:     operation.Pending,
 	Started:  true,
-	CharmURL: curl("cs:quantal/wordpress-2"),
+	CharmURL: "cs:quantal/wordpress-2",
 	ActionId: &randomActionId,
 	Hook:     &hook.Info{Kind: hooks.Install},
 }

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -306,7 +306,7 @@ func (u *mockUnit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus) erro
 type mockApplication struct {
 	tag                   names.ApplicationTag
 	life                  life.Value
-	curl                  *charm.URL
+	curl                  string
 	charmModifiedVersion  int
 	forceUpgrade          bool
 	applicationWatcher    *mockNotifyWatcher
@@ -317,7 +317,7 @@ func (s *mockApplication) CharmModifiedVersion() (int, error) {
 	return s.charmModifiedVersion, nil
 }
 
-func (s *mockApplication) CharmURL() (*charm.URL, bool, error) {
+func (s *mockApplication) CharmURL() (string, bool, error) {
 	return s.curl, s.forceUpgrade, nil
 }
 

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -4,8 +4,6 @@
 package remotestate
 
 import (
-	"github.com/juju/charm/v8"
-
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/core/life"
@@ -31,9 +29,9 @@ type Snapshot struct {
 	// changed in some way.
 	CharmModifiedVersion int
 
-	// CharmURL is the charm URL that the unit is
+	// CharmURL is the string representation of charm URL that the unit is
 	// expected to run.
-	CharmURL *charm.URL
+	CharmURL string
 
 	// ForceCharmUpgrade reports whether the unit
 	// should upgrade even in an error state.

--- a/worker/uniter/remotestate/state.go
+++ b/worker/uniter/remotestate/state.go
@@ -61,7 +61,7 @@ type Application interface {
 	// increments whenever the charm or a resource for the charm changes.
 	CharmModifiedVersion() (int, error)
 	// CharmURL returns the url for the charm for this application.
-	CharmURL() (*charm.URL, bool, error)
+	CharmURL() (string, bool, error)
 	// Life returns whether the application is alive.
 	Life() life.Value
 	// Refresh syncs this value with the api server.

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/worker/v3"
@@ -800,7 +801,11 @@ func (w *RemoteStateWatcher) applicationChanged() error {
 	}
 	required := false
 	if w.canApplyCharmProfile {
-		ch, err := w.st.Charm(url)
+		curl, err := charm.ParseURL(url)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		ch, err := w.st.Charm(curl)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -6,7 +6,6 @@ package remotestate_test
 import (
 	"time"
 
-	"github.com/juju/charm/v8"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -93,7 +92,7 @@ func (s *WatcherSuite) SetUpTest(c *gc.C) {
 			application: mockApplication{
 				tag:                   names.NewApplicationTag("mysql"),
 				life:                  life.Alive,
-				curl:                  charm.MustParseURL("cs:trusty/mysql"),
+				curl:                  "cs:trusty/mysql",
 				charmModifiedVersion:  5,
 				leaderSettingsWatcher: newMockNotifyWatcher(),
 			},
@@ -1028,7 +1027,7 @@ func (s *WatcherSuiteSidecarCharmModVer) TestRemoteStateChanged(c *gc.C) {
 	// EnforcedCharmModifiedVersion prevents the charm upgrading if it isn't the right version.
 	snapshot := s.watcher.Snapshot()
 	c.Assert(snapshot.CharmModifiedVersion, gc.Equals, 0)
-	c.Assert(snapshot.CharmURL, gc.IsNil)
+	c.Assert(snapshot.CharmURL, gc.Equals, "")
 	c.Assert(snapshot.ForceCharmUpgrade, gc.Equals, false)
 
 	s.clock.Advance(5 * time.Minute)
@@ -1046,7 +1045,7 @@ func (s *WatcherSuiteSidecarCharmModVer) TestSnapshot(c *gc.C) {
 		Storage:               map[names.StorageTag]remotestate.StorageSnapshot{},
 		ActionChanged:         map[string]int{},
 		CharmModifiedVersion:  0,
-		CharmURL:              nil,
+		CharmURL:              "",
 		ForceCharmUpgrade:     false,
 		ResolvedMode:          s.st.unit.resolved,
 		ConfigHash:            "confighash",
@@ -1092,10 +1091,10 @@ func (s *WatcherSuite) TestInitialWorkloadEventIDs(c *gc.C) {
 		InitialWorkloadEventIDs: []string{"a", "b", "c"},
 		Logger:                  loggo.GetLogger("test"),
 	}
-	watcher, err := remotestate.NewWatcher(config)
+	w, err := remotestate.NewWatcher(config)
 	c.Assert(err, jc.ErrorIsNil)
 
-	snapshot := watcher.Snapshot()
+	snapshot := w.Snapshot()
 	c.Assert(snapshot.WorkloadEvents, gc.DeepEquals, []string{"a", "b", "c"})
 }
 

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -4,8 +4,6 @@
 package uniter
 
 import (
-	"fmt"
-
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 
@@ -17,7 +15,6 @@ import (
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/resolver"
-	"github.com/juju/juju/wrench"
 )
 
 // ResolverConfig defines configuration for the uniter resolver.
@@ -154,11 +151,13 @@ func (s *uniterResolver) NextOp(
 			return opFactory.NewRunHook(*localState.Hook)
 
 		case operation.Done:
-			curl := localState.CharmURL
-			if curl != nil && wrench.IsActive("hooks", fmt.Sprintf("%s-%s-error", curl.Name, localState.Hook.Kind)) {
-				s.config.Logger.Errorf("commit hook %q failed due to a wrench in the works", localState.Hook.Kind)
-				return nil, errors.Errorf("commit hook %q failed due to a wrench in the works", localState.Hook.Kind)
-			}
+			// TODO hmlanigan 17-06-2002
+			// Resolve the wrench
+			//curl := localState.CharmURL
+			//if curl != "" && wrench.IsActive("hooks", fmt.Sprintf("%s-%s-error", curl.Name, localState.Hook.Kind)) {
+			//	s.config.Logger.Errorf("commit hook %q failed due to a wrench in the works", localState.Hook.Kind)
+			//	return nil, errors.Errorf("commit hook %q failed due to a wrench in the works", localState.Hook.Kind)
+			//}
 
 			logger.Infof("committing %q hook", localState.Hook.Kind)
 			return opFactory.NewSkipHook(*localState.Hook)
@@ -283,10 +282,10 @@ func (s *uniterResolver) nextOpHookError(
 
 func (s *uniterResolver) charmModified(local resolver.LocalState, remote remotestate.Snapshot) bool {
 	// CAAS models may not yet have read the charm url from state.
-	if remote.CharmURL == nil {
+	if remote.CharmURL == "" {
 		return false
 	}
-	if *local.CharmURL != *remote.CharmURL {
+	if local.CharmURL != remote.CharmURL {
 		s.config.Logger.Debugf("upgrade from %v to %v", local.CharmURL, remote.CharmURL)
 		return true
 	}

--- a/worker/uniter/resolver/interface.go
+++ b/worker/uniter/resolver/interface.go
@@ -4,7 +4,6 @@
 package resolver
 
 import (
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/model"
@@ -62,9 +61,9 @@ type LocalState struct {
 	// or any part of it, is changed in some way.
 	CharmModifiedVersion int
 
-	// CharmURL reports the currently installed charm URL. This is set
-	// by the committing of deploy (install/upgrade) ops.
-	CharmURL *charm.URL
+	// CharmURL reports the currently installed charm URL as a string.
+	// This is set by the committing of deploy (install/upgrade) ops.
+	CharmURL string
 
 	// Conflicted indicates that the uniter is in a conflicted state,
 	// and needs either resolution or a forced upgrade to continue.

--- a/worker/uniter/resolver/loop.go
+++ b/worker/uniter/resolver/loop.go
@@ -208,7 +208,7 @@ func checkCharmUpgrade(logger Logger, charmDir string, remote remotestate.Snapsh
 	local.State = ex.State()
 
 	// If the unit isn't installed, no need to start an upgrade.
-	if !local.State.Installed || remote.CharmURL == nil {
+	if !local.State.Installed || remote.CharmURL == "" {
 		return nil
 	}
 
@@ -230,15 +230,17 @@ func checkCharmUpgrade(logger Logger, charmDir string, remote remotestate.Snapsh
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if rev != remote.CharmURL.Revision {
-			logger.Tracef("Charm profile required: current revision %d does not match new revision %d", rev, remote.CharmURL.Revision)
+		curl, err := corecharm.ParseURL(remote.CharmURL)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if rev != curl.Revision {
+			logger.Tracef("Charm profile required: current revision %d does not match new revision %d", rev, curl.Revision)
 			return nil
 		}
 	}
 
-	// TODO (hmlanigan) 2022-06-08
-	// Is there any reason for the local and remote CharmURL to not be string pointers?
-	sameCharm := *local.CharmURL == *remote.CharmURL
+	sameCharm := local.CharmURL == remote.CharmURL
 	if haveCharmDir && (!local.State.Started || sameCharm) {
 		return nil
 	}

--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/loggo"
 	"github.com/juju/mutex/v2"
@@ -31,7 +30,7 @@ type LoopSuite struct {
 	watcher   *mockRemoteStateWatcher
 	opFactory *mockOpFactory
 	executor  *mockOpExecutor
-	charmURL  *charm.URL
+	charmURL  string
 	charmDir  string
 	abort     chan struct{}
 	onIdle    func() error
@@ -49,7 +48,7 @@ func (s *LoopSuite) SetUpTest(c *gc.C) {
 	}
 	s.opFactory = &mockOpFactory{}
 	s.executor = &mockOpExecutor{}
-	s.charmURL = charm.MustParseURL("cs:trusty/mysql-1")
+	s.charmURL = "cs:trusty/mysql-1"
 	s.abort = make(chan struct{})
 }
 
@@ -330,7 +329,7 @@ func (s *LoopSuite) TestCheckCharmUpgradeNotInstalled(c *gc.C) {
 	}
 	s.watcher = &mockRemoteStateWatcher{
 		snapshot: remotestate.Snapshot{
-			CharmURL: charm.MustParseURL("cs:trusty/mysql-2"),
+			CharmURL: "cs:trusty/mysql-2",
 		},
 	}
 	s.charmDir = testcharms.Repo.CharmDirPath("mysql")
@@ -350,7 +349,7 @@ func (s *LoopSuite) TestCheckCharmUpgradeIncorrectLXDProfile(c *gc.C) {
 	}
 	s.watcher = &mockRemoteStateWatcher{
 		snapshot: remotestate.Snapshot{
-			CharmURL:             charm.MustParseURL("cs:trusty/mysql-2"),
+			CharmURL:             "cs:trusty/mysql-2",
 			CharmProfileRequired: true,
 			LXDProfileName:       "juju-test-mysql-1",
 		},
@@ -387,7 +386,7 @@ func (s *LoopSuite) TestCheckCharmUpgrade(c *gc.C) {
 	}
 	s.watcher = &mockRemoteStateWatcher{
 		snapshot: remotestate.Snapshot{
-			CharmURL: charm.MustParseURL("cs:trusty/mysql-2"),
+			CharmURL: "cs:trusty/mysql-2",
 		},
 	}
 	s.testCheckCharmUpgradeCallsRun(c)
@@ -424,7 +423,7 @@ func (s *LoopSuite) TestCheckCharmUpgradeLXDProfile(c *gc.C) {
 	}
 	s.watcher = &mockRemoteStateWatcher{
 		snapshot: remotestate.Snapshot{
-			CharmURL:             charm.MustParseURL("cs:trusty/mysql-2"),
+			CharmURL:             "cs:trusty/mysql-2",
 			CharmProfileRequired: true,
 			LXDProfileName:       "juju-test-mysql-2",
 		},

--- a/worker/uniter/resolver/mock_test.go
+++ b/worker/uniter/resolver/mock_test.go
@@ -4,7 +4,6 @@
 package resolver_test
 
 import (
-	"github.com/juju/charm/v8"
 	"github.com/juju/testing"
 
 	"github.com/juju/juju/worker/fortress"
@@ -33,17 +32,17 @@ type mockOpFactory struct {
 	op mockOp
 }
 
-func (f *mockOpFactory) NewUpgrade(charmURL *charm.URL) (operation.Operation, error) {
+func (f *mockOpFactory) NewUpgrade(charmURL string) (operation.Operation, error) {
 	f.MethodCall(f, "NewUpgrade", charmURL)
 	return f.op, f.NextErr()
 }
 
-func (f *mockOpFactory) NewRevertUpgrade(charmURL *charm.URL) (operation.Operation, error) {
+func (f *mockOpFactory) NewRevertUpgrade(charmURL string) (operation.Operation, error) {
 	f.MethodCall(f, "NewRevertUpgrade", charmURL)
 	return f.op, f.NextErr()
 }
 
-func (f *mockOpFactory) NewResolvedUpgrade(charmURL *charm.URL) (operation.Operation, error) {
+func (f *mockOpFactory) NewResolvedUpgrade(charmURL string) (operation.Operation, error) {
 	f.MethodCall(f, "NewResolvedUpgrade", charmURL)
 	return f.op, f.NextErr()
 }

--- a/worker/uniter/resolver/opfactory.go
+++ b/worker/uniter/resolver/opfactory.go
@@ -4,7 +4,6 @@
 package resolver
 
 import (
-	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 
@@ -58,7 +57,7 @@ func (s *resolverOpFactory) NewNoOpFinishUpgradeSeries() (operation.Operation, e
 	return op, nil
 }
 
-func (s *resolverOpFactory) NewUpgrade(charmURL *charm.URL) (operation.Operation, error) {
+func (s *resolverOpFactory) NewUpgrade(charmURL string) (operation.Operation, error) {
 	op, err := s.Factory.NewUpgrade(charmURL)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -85,7 +84,7 @@ func (s *resolverOpFactory) NewSkipRemoteInit(retry bool) (operation.Operation, 
 	return op, nil
 }
 
-func (s *resolverOpFactory) NewRevertUpgrade(charmURL *charm.URL) (operation.Operation, error) {
+func (s *resolverOpFactory) NewRevertUpgrade(charmURL string) (operation.Operation, error) {
 	op, err := s.Factory.NewRevertUpgrade(charmURL)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -93,7 +92,7 @@ func (s *resolverOpFactory) NewRevertUpgrade(charmURL *charm.URL) (operation.Ope
 	return s.wrapUpgradeOp(op, charmURL), nil
 }
 
-func (s *resolverOpFactory) NewResolvedUpgrade(charmURL *charm.URL) (operation.Operation, error) {
+func (s *resolverOpFactory) NewResolvedUpgrade(charmURL string) (operation.Operation, error) {
 	op, err := s.Factory.NewResolvedUpgrade(charmURL)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -127,7 +126,7 @@ func trimCompletedActions(pendingActions []string, completedActions map[string]s
 	return newCompletedActions
 }
 
-func (s *resolverOpFactory) wrapUpgradeOp(op operation.Operation, charmURL *charm.URL) operation.Operation {
+func (s *resolverOpFactory) wrapUpgradeOp(op operation.Operation, charmURL string) operation.Operation {
 	charmModifiedVersion := s.RemoteState.CharmModifiedVersion
 	return onCommitWrapper{op, func(*operation.State) {
 		s.LocalState.CharmURL = charmURL

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -6,7 +6,6 @@ package uniter_test
 import (
 	"fmt"
 
-	"github.com/juju/charm/v8"
 	"github.com/juju/charm/v8/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -34,7 +33,7 @@ import (
 
 type baseResolverSuite struct {
 	stub           testing.Stub
-	charmURL       *charm.URL
+	charmURL       string
 	remoteState    remotestate.Snapshot
 	opFactory      operation.Factory
 	resolver       resolver.Resolver
@@ -126,7 +125,7 @@ func (s *baseResolverSuite) SetUpTest(c *gc.C, modelType model.ModelType, reboot
 	}
 
 	s.stub = testing.Stub{}
-	s.charmURL = charm.MustParseURL("cs:precise/mysql-2")
+	s.charmURL = "cs:precise/mysql-2"
 	s.remoteState = remotestate.Snapshot{
 		CharmURL: s.charmURL,
 	}

--- a/worker/uniter/runcommands/runcommands_test.go
+++ b/worker/uniter/runcommands/runcommands_test.go
@@ -4,7 +4,6 @@
 package runcommands_test
 
 import (
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
@@ -20,7 +19,7 @@ import (
 )
 
 type runcommandsSuite struct {
-	charmURL         *charm.URL
+	charmURL         string
 	remoteState      remotestate.Snapshot
 	mockRunner       mockRunner
 	callbacks        *mockCallbacks
@@ -34,7 +33,7 @@ type runcommandsSuite struct {
 var _ = gc.Suite(&runcommandsSuite{})
 
 func (s *runcommandsSuite) SetUpTest(c *gc.C) {
-	s.charmURL = charm.MustParseURL("cs:precise/mysql-2")
+	s.charmURL = "cs:precise/mysql-2"
 	s.remoteState = remotestate.Snapshot{
 		CharmURL: s.charmURL,
 	}

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -101,9 +101,9 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 	// The API is used instead of direct state access, because the API call
 	// handles synchronisation with the cache where the data must reside for
 	// config watching and retrieval to work.
-	err = s.apiUnit.SetCharmURL(sch.URL())
+	err = s.apiUnit.SetCharmURL(sch.String())
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.meteredAPIUnit.SetCharmURL(s.meteredCharm.URL())
+	err = s.meteredAPIUnit.SetCharmURL(s.meteredCharm.String())
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.relch = s.AddTestingCharm(c, "mysql")

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -564,7 +564,11 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 	return err
 }
 
-func (u *Uniter) verifyCharmProfile(curl *corecharm.URL) error {
+func (u *Uniter) verifyCharmProfile(url string) error {
+	curl, err := corecharm.ParseURL(url)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	// NOTE: this is very similar code to verifyCharmProfile.NextOp,
 	// if you make changes here, check to see if they are needed there.
 	ch, err := u.st.Charm(curl)
@@ -613,11 +617,11 @@ func (u *Uniter) verifyCharmProfile(curl *corecharm.URL) error {
 // charmState returns data for the local state setup.
 // While gathering the data, look for interrupted Install or pending
 // charm upgrade, execute if found.
-func (u *Uniter) charmState() (bool, *corecharm.URL, int, error) {
+func (u *Uniter) charmState() (bool, string, int, error) {
 	// Install is a special case, as it must run before there
 	// is any remote state, and before the remote state watcher
 	// is started.
-	var charmURL *corecharm.URL
+	var charmURL string
 	var charmModifiedVersion int
 
 	canApplyCharmProfile, err := u.unit.CanApplyLXDProfile()
@@ -900,11 +904,11 @@ func (u *Uniter) Wait() error {
 	return u.catacomb.Wait()
 }
 
-func (u *Uniter) getApplicationCharmURL() (*corecharm.URL, error) {
+func (u *Uniter) getApplicationCharmURL() (string, error) {
 	// TODO(fwereade): pretty sure there's no reason to make 2 API calls here.
 	app, err := u.st.Application(u.unit.ApplicationTag())
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	charmURL, _, err := app.CharmURL()
 	return charmURL, err

--- a/worker/uniter/verifycharmprofile/verifycharmprofile.go
+++ b/worker/uniter/verifycharmprofile/verifycharmprofile.go
@@ -4,6 +4,8 @@
 package verifycharmprofile
 
 import (
+	corecharm "github.com/juju/charm/v8"
+
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/worker/uniter/operation"
@@ -48,8 +50,12 @@ func (r *verifyCharmProfileResolver) NextOp(
 	if err != nil {
 		return nil, err
 	}
-	if rev != remoteState.CharmURL.Revision {
-		r.logger.Tracef("Charm profile required: current revision %d does not match new revision %d", rev, remoteState.CharmURL.Revision)
+	curl, err := corecharm.ParseURL(remoteState.CharmURL)
+	if err != nil {
+		return nil, err
+	}
+	if rev != curl.Revision {
+		r.logger.Tracef("Charm profile required: current revision %d does not match new revision %d", rev, curl.Revision)
 		return nil, resolver.ErrDoNotProceed
 	}
 	r.logger.Tracef("Charm profile correct for charm revision")

--- a/worker/uniter/verifycharmprofile/verifycharmprofile_test.go
+++ b/worker/uniter/verifycharmprofile/verifycharmprofile_test.go
@@ -4,7 +4,6 @@
 package verifycharmprofile_test
 
 import (
-	"github.com/juju/charm/v8"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -63,12 +62,10 @@ func (s *verifySuite) TestNextOpMisMatchCharmRevisions(c *gc.C) {
 	local := resolver.LocalState{
 		State: operation.State{Kind: operation.Upgrade},
 	}
-	curl, err := charm.ParseURL("cs:wordpress-75")
-	c.Assert(err, jc.ErrorIsNil)
 	remote := remotestate.Snapshot{
 		CharmProfileRequired: true,
 		LXDProfileName:       "juju-wordpress-74",
-		CharmURL:             curl,
+		CharmURL:             "cs:wordpress-75",
 	}
 	res := newVerifyCharmProfileResolver()
 
@@ -81,12 +78,10 @@ func (s *verifySuite) TestNextOpMatchingCharmRevisions(c *gc.C) {
 	local := resolver.LocalState{
 		State: operation.State{Kind: operation.Upgrade},
 	}
-	curl, err := charm.ParseURL("cs:wordpress-75")
-	c.Assert(err, jc.ErrorIsNil)
 	remote := remotestate.Snapshot{
 		CharmProfileRequired: true,
 		LXDProfileName:       "juju-wordpress-75",
-		CharmURL:             curl,
+		CharmURL:             "cs:wordpress-75",
 	}
 	res := newVerifyCharmProfileResolver()
 


### PR DESCRIPTION
Changes to not part a charm url coming from state inside of state and the apiserver unless strickly necessary have been made. Now update the uniter to not parse a charm url unless strictly necessary as well. 

## QA steps

To test, run charm refresh, juju upgrade-controller, as well as upgrade of a charm with an lxd profile.

