### PR TITLE
[JUJU-1342] Update juju go snap plugin to work with snapcraft 7

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
-        sudo snap install snapcraft --classic --channel=6.x/stable
+        sudo snap install snapcraft --classic
         sudo snap install lxd
         sudo lxd waitready
         sudo lxd init --auto
@@ -90,7 +90,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
-        sudo snap install snapcraft --classic --channel=5.x/stable
+        sudo snap install snapcraft --classic
         sudo snap install lxd
         sudo snap install yq
         sudo snap install juju --classic --channel=${{ matrix.snap_version }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
-        sudo snap install snapcraft --classic --channel=6.x/stable
+        sudo snap install snapcraft --classic
         sudo snap install lxd
         sudo lxd waitready
         sudo lxd init --auto

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ description: |
 
 confinement: classic
 grade: devel
-base: core18
+base: core20
 
 apps:
   juju:
@@ -111,7 +111,7 @@ parts:
       # If needed, grab the agent from streams
       # curl http://streams.canonical.com/juju/tools/agent/$SNAPCRAFT_PROJECT_VERSION/juju-$SNAPCRAFT_PROJECT_VERSION-ubuntu-amd64.tgz | tar xz -C $SNAPCRAFT_PART_INSTALL/bin/
       jujud=$SNAPCRAFT_PART_INSTALL/bin/jujud
-      version=$(jujud version)
+      version=$($jujud version)
       hash=$(sha256sum $jujud | cut -d " " -f 1)
       cat > jujud-versions.yaml <<EOF
       versions:


### PR DESCRIPTION
This updates the snap install instructions for juju to work with snapcraft 7.
The `juju-go` plugin is migrated to v2 and an existing typo in snapcraft is fixed - how this ever work I'm not sure.
Note also the changes require the use of core20 instead of core18.

Note: the when `go-static` is set to false (we set it to true for juju builds currently), the CGO link flags are not set in this version since the Python doesn't have access to the snapcraft env vars that I can see. 
However, these like flags would never have been set anyway because the include paths was always empty. In the original juju plugin code:
```
            include_paths = []
            for root in [self.installdir, self.project.stage_dir]:
                include_paths.extend(
                    common.get_library_paths(root, self.project.arch_triplet)
                )
```
The paths passed to `get_library_paths` above do not exist so were never added to `include_paths`.

So if we want to use CGO, some enablement work is needed.

## QA steps

Run snapcraft and build the juju snap and install it.