### PR TITLE
[JUJU-1186] WIP Remove K8s provider from caasmodel test.

### DIFF
--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -12,8 +12,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/caas"
-	k8sprovider "github.com/juju/juju/caas/kubernetes/provider"
-	k8stesting "github.com/juju/juju/caas/kubernetes/provider/testing"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
@@ -31,7 +29,6 @@ type CAASFixture struct {
 
 func (s *CAASFixture) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	s.PatchValue(&k8sprovider.NewK8sClients, k8stesting.NoopFakeK8sClients)
 }
 
 // createTestModelConfig returns a new model config and its UUID for testing.


### PR DESCRIPTION
Attempts to remove K8s dependencies from state/caasmodel_test.go

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps
NA

## Documentation changes

NA

## Bug reference

NA
