### PR TITLE
Fix MyAppVersion strings for win installer.

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -4,11 +4,10 @@
 #if GetEnv('JUJU_VERSION') != ""
 #define MyAppVersion=GetEnv('JUJU_VERSION')
 #else
-#define MyAppVersion="2.9.33"
+#define MyAppVersion="3.0-beta1"
 #endif
 
 #define MyAppName "Juju"
-#define MyAppVersion "3.0-beta1"
 #define MyAppPublisher "Canonical, Ltd"
 #define MyAppURL "http://juju.is/"
 #define MyAppExeName "juju.exe"


### PR DESCRIPTION
Windows version for installer had been incorrectly defined and hence
breaking CI.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

N/A

## Documentation changes

N/A

## Bug reference

N/A
