### PR TITLE
Enable async charm downloads and remove feature flag

### DIFF
--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	apitesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/controller"
-	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -582,14 +580,6 @@ func (s *charmsSuite) TestGetReturnsNotFoundWhenMissing(c *gc.C) {
 }
 
 func (s *charmsSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *gc.C) {
-	// Required to allow charm lookups to return pending charms.
-	err := s.State.UpdateControllerConfig(
-		map[string]interface{}{
-			controller.Features: []interface{}{feature.AsynchronousCharmDownloads},
-		}, nil,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
 	// Add a charm in pending mode.
 	chInfo := state.CharmInfo{
 		ID:          charm.MustParseURL("cs:focal/dummy-1"),
@@ -598,7 +588,7 @@ func (s *charmsSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *gc.C) {
 		SHA256:      "", // indicates that we don't have the data in the blobstore yet.
 		Version:     "42",
 	}
-	_, err = s.State.AddCharmMetadata(chInfo)
+	_, err := s.State.AddCharmMetadata(chInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure a 490 is returned if the charm is pending to be downloaded.

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -488,10 +488,10 @@ func (a *API) getCharmRepository(src corecharm.Source) (corecharm.Repository, er
 
 	httpTransport := charmhub.RequestHTTPTransport(a.requestRecorder, charmhub.DefaultRetryPolicy())
 	repoFactory := a.newRepoFactory(services.CharmRepoFactoryConfig{
-		Logger:       logger,
-		Transport:    httpTransport(logger),
-		StateBackend: a.backendState,
-		ModelBackend: a.backendModel,
+		Logger:            logger,
+		CharmhubTransport: httpTransport(logger),
+		StateBackend:      a.backendState,
+		ModelBackend:      a.backendModel,
 	})
 
 	return repoFactory.GetCharmRepository(src)

--- a/apiserver/facades/client/charms/register.go
+++ b/apiserver/facades/client/charms/register.go
@@ -11,7 +11,6 @@ import (
 	charmscommon "github.com/juju/juju/apiserver/common/charms"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	charmsinterfaces "github.com/juju/juju/apiserver/facades/client/charms/interfaces"
 	"github.com/juju/juju/apiserver/facades/client/charms/services"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/state/storage"
@@ -53,9 +52,6 @@ func newFacadeV4(ctx facade.Context) (*API, error) {
 		},
 		newRepoFactory: func(cfg services.CharmRepoFactoryConfig) corecharm.RepositoryFactory {
 			return services.NewCharmRepoFactory(cfg)
-		},
-		newDownloader: func(cfg services.CharmDownloaderConfig) (charmsinterfaces.Downloader, error) {
-			return services.NewCharmDownloader(cfg)
 		},
 		tag:             m.ModelTag(),
 		requestRecorder: ctx.RequestRecorder(),

--- a/apiserver/facades/client/charms/services/downloader.go
+++ b/apiserver/facades/client/charms/services/downloader.go
@@ -40,10 +40,10 @@ func NewCharmDownloader(cfg CharmDownloaderConfig) (*charmdownloader.Downloader,
 
 	repoFactory := repoFactoryShim{
 		factory: NewCharmRepoFactory(CharmRepoFactoryConfig{
-			Logger:       cfg.Logger.Child("charmrepofactory"),
-			Transport:    cfg.Transport,
-			StateBackend: cfg.StateBackend,
-			ModelBackend: cfg.ModelBackend,
+			Logger:            cfg.Logger.Child("charmrepofactory"),
+			CharmhubTransport: cfg.Transport,
+			StateBackend:      cfg.StateBackend,
+			ModelBackend:      cfg.ModelBackend,
 		}),
 	}
 

--- a/apiserver/facades/client/charms/services/repofactory.go
+++ b/apiserver/facades/client/charms/services/repofactory.go
@@ -22,7 +22,7 @@ type CharmRepoFactoryConfig struct {
 	Logger loggo.Logger
 
 	// A transport that is injected when making charmhub API calls.
-	Transport charmhub.Transport
+	CharmhubTransport charmhub.Transport
 
 	StateBackend StateBackend
 	ModelBackend ModelBackend
@@ -45,7 +45,7 @@ type CharmRepoFactory struct {
 func NewCharmRepoFactory(cfg CharmRepoFactoryConfig) *CharmRepoFactory {
 	return &CharmRepoFactory{
 		logger:            cfg.Logger,
-		charmhubTransport: cfg.Transport,
+		charmhubTransport: cfg.CharmhubTransport,
 		stateBackend:      cfg.StateBackend,
 		modelBackend:      cfg.ModelBackend,
 		memoizedRepos:     make(map[corecharm.Source]corecharm.Repository),

--- a/apiserver/facades/client/charms/services/repofactory_test.go
+++ b/apiserver/facades/client/charms/services/repofactory_test.go
@@ -90,10 +90,10 @@ func (s *repoFactoryTestSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.modelBackend = NewMockModelBackend(ctrl)
 
 	s.repoFactory = NewCharmRepoFactory(CharmRepoFactoryConfig{
-		Logger:       loggo.GetLogger("test"),
-		StateBackend: s.stateBackend,
-		ModelBackend: s.modelBackend,
-		Transport:    http.DefaultClient,
+		Logger:            loggo.GetLogger("test"),
+		StateBackend:      s.stateBackend,
+		ModelBackend:      s.modelBackend,
+		CharmhubTransport: http.DefaultClient,
 	})
 	return ctrl
 }

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -137,10 +137,10 @@ func populateStoreControllerCharm(st *state.State, charmRisk, series, arch strin
 
 	stateBackend := &stateShim{st}
 	charmRepo, err := newCharmRepo(services.CharmRepoFactoryConfig{
-		Logger:       logger,
-		Transport:    charmhub.DefaultHTTPTransport(logger),
-		StateBackend: stateBackend,
-		ModelBackend: model,
+		Logger:            logger,
+		CharmhubTransport: charmhub.DefaultHTTPTransport(logger),
+		StateBackend:      stateBackend,
+		ModelBackend:      model,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -50,8 +50,5 @@ const Secrets = "secrets"
 // handled by Pubsub to facade API interaction.
 const RaftAPILeases = "raft-api-leases"
 
-// AsynchronousCharmDownloads enables support for asynchronous charm downloads.
-const AsynchronousCharmDownloads = "async-charm-downloads"
-
 // LoggingOutput enables the ability to configure different logging backends.
 const LoggingOutput = "logging-output"

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -22,7 +22,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
 
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
@@ -32,7 +31,6 @@ import (
 	resourcetesting "github.com/juju/juju/core/resources/testing"
 	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/state/testing"
@@ -5230,14 +5228,6 @@ deployment:
 }
 
 func (s *ApplicationSuite) TestWatchApplicationsWithPendingCharms(c *gc.C) {
-	// Required to allow charm lookups to return pending charms.
-	err := s.State.UpdateControllerConfig(
-		map[string]interface{}{
-			controller.Features: []interface{}{feature.AsynchronousCharmDownloads},
-		}, nil,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
 	s.State.StartSync()
 	w := s.State.WatchApplicationsWithPendingCharms()
 	defer func() { _ = w.Stop() }()

--- a/state/charm.go
+++ b/state/charm.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/macaroon.v2"
 
 	corecharm "github.com/juju/juju/core/charm"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/mongo"
 	mongoutils "github.com/juju/juju/mongo/utils"
 	stateerrors "github.com/juju/juju/state/errors"
@@ -774,16 +773,9 @@ func (st *State) AllCharms() ([]*Charm, error) {
 }
 
 // Charm returns the charm with the given URL. Charm placeholders are never
-// returned. Charms pending to be uploaded are only returned if the
-// async charm download feature flag is set.
-//
-// TODO(achilleasa) remove the feature flag check once the server-side bundle
-// expansion work lands.
+// returned.
 func (st *State) Charm(curl *charm.URL) (*Charm, error) {
-	var (
-		cdoc    charmDoc
-		charmID = curl.String()
-	)
+	var cdoc charmDoc
 
 	charms, closer := st.db().GetCollection(charmsC)
 	defer closer()
@@ -799,17 +791,6 @@ func (st *State) Charm(curl *charm.URL) (*Charm, error) {
 	}
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get charm %q", curl)
-	}
-
-	// This check ensures that we don't break the existing deploy logic
-	// until the server-side bundle expansion work lands.
-	cfg, err := st.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	returnPendingCharms := cfg.Features().Contains(feature.AsynchronousCharmDownloads)
-	if cdoc.PendingUpload && !returnPendingCharms {
-		return nil, errors.NotFoundf("charm %q", charmID)
 	}
 
 	return newCharm(st, &cdoc), nil

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -17,8 +17,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 
-	"github.com/juju/juju/controller"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/testcharms"
@@ -705,14 +703,6 @@ func (s *CharmSuite) TestAllCharms(c *gc.C) {
 }
 
 func (s *CharmSuite) TestAddCharmMetadata(c *gc.C) {
-	// Required to allow charm lookups to return pending charms.
-	err := s.State.UpdateControllerConfig(
-		map[string]interface{}{
-			controller.Features: []interface{}{feature.AsynchronousCharmDownloads},
-		}, nil,
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
 	// Check that a charm with missing sha/storage path is flagged as pending
 	// to be uploaded.
 	dummy1 := s.dummyCharm(c, "cs:quantal/dummy-1")


### PR DESCRIPTION
This enables async charm downloads by default, and removes the corresponding feature flag. This works with charm and bundle deploys in my initial tests, but I'm doing further tests now.

## QA Steps

```
$ juju bootstrap microk8s
$ juju deploy snappass-test
$ juju deploy postgresql-k8s

$ juju bootstrap lxd
$ juju deploy postgresql
$ juju deploy charmed-kubernetes

# Charmstore "cs:" charm (currently fails)
$ juju deploy cs:mysql-55
```