### PR TITLE
[JUJU-1352] No default model on bootstrap unless asked

### DIFF
--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -77,7 +77,7 @@ func decideKubeConfigDir() (string, error) {
 		return "", errors.Annotate(err, "cannot find juju binary")
 	}
 	_, isOffical, err := CheckJujuOfficial(jujuDir)
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		return "", errors.Trace(err)
 	}
 	if isOffical {

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -176,3 +176,13 @@ func (s *builtinSuite) TestDecideKubeConfigDirOfficial(c *gc.C) {
 func (s *builtinSuite) TestDecideKubeConfigDirLocalBuild(c *gc.C) {
 	s.assertDecideKubeConfigDir(c, false, `/var/snap/microk8s/current/credentials/client.config`)
 }
+
+func (s *builtinSuite) TestDecideKubeConfigDirNoJujud(c *gc.C) {
+	s.PatchValue(&provider.CheckJujuOfficial, func(string) (version.Binary, bool, error) {
+		return version.Binary{}, false, errors.NotFoundf("jujud")
+	})
+	s.PatchEnvironment("SNAP_DATA", "snap-data-dir")
+	p, err := provider.DecideKubeConfigDir()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(p, gc.DeepEquals, `/var/snap/microk8s/current/credentials/client.config`)
+}

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -43,9 +43,6 @@ var (
 	CompileLifecycleApplicationRemovalSelector = compileLifecycleApplicationRemovalSelector
 	CompileLifecycleModelTeardownSelector      = compileLifecycleModelTeardownSelector
 
-	LabelSetToRequirements = labelSetToRequirements
-	MergeSelectors         = mergeSelectors
-
 	UpdateStrategyForDeployment  = updateStrategyForDeployment
 	UpdateStrategyForStatefulSet = updateStrategyForStatefulSet
 	UpdateStrategyForDaemonSet   = updateStrategyForDaemonSet

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -165,9 +165,12 @@ func copyFileWithMode(from, to string, mode os.FileMode) error {
 	return nil
 }
 
+// Override for testing.
+var ExistingJujuLocation = existingJujuLocation
+
 // ExistingJujuLocation returns the directory where 'juju' is running, and where
 // we expect to find 'jujuc' and 'jujud'.
-func ExistingJujuLocation() (string, error) {
+func existingJujuLocation() (string, error) {
 	jujuLocation, err := findExecutable(os.Args[0])
 	if err != nil {
 		logger.Infof("%v", err)
@@ -328,7 +331,7 @@ func bundleTools(
 		return version.Binary{}, false, "", errors.Annotate(err, "couldn't find existing jujud")
 	}
 	_, official, err = jujudVersion(existingJujuLocation)
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		return version.Binary{}, official, "", errors.Trace(err)
 	}
 	if official && build {
@@ -366,7 +369,14 @@ func bundleTools(
 var ExecCommand = exec.Command
 
 func getVersionFromJujud(dir string) (version.Binary, error) {
+	// If there's no jujud, return a NotFound error.
 	path := filepath.Join(dir, names.Jujud)
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return version.Binary{}, errors.NotFoundf(path)
+		}
+		return version.Binary{}, errors.Trace(err)
+	}
 	cmd := ExecCommand(path, "version")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -6,7 +6,7 @@ package testing
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/ssh"
@@ -115,7 +115,7 @@ const DefaultMongoPassword = "conn-from-name-secret"
 // sets up a Juju home with a sample environment and certificate.
 type FakeJujuXDGDataHomeSuite struct {
 	JujuOSEnvSuite
-	gitjujutesting.FakeHomeSuite
+	testing.FakeHomeSuite
 }
 
 func (s *FakeJujuXDGDataHomeSuite) SetUpTest(c *gc.C) {


### PR DESCRIPTION
Machine and k8s bootstrap is now the same - an out of the box workload model is not created unless the user specifies one with the `--workload-model` argument. The `--no-default-model` option is removed.

Some tests were failing due to `~/.kube` existing and so extra testing code was needed to keep the tests happy when run on a non-clean environment. This included returning a not found error when sniffing the official juju version if jujud does not exist, rather than an os.Exec error.

## QA steps

juju bootstrap aws
-> no default model and no current model

juju bootstrap aws --workload-model=foo
-> model foo created and becomes the current model

Repeat the above on microk8s.