### PR TITLE
[JUJU-1355] Add jammy template data for vsphere provider

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -177,6 +177,7 @@ add_model() {
 # add_images_for_vsphere is used to add-image with known vSphere template paths for LTS series
 # and shouldn't be used by any of the tests directly.
 add_images_for_vsphere() {
+	juju metadata add-image juju-ci-root/templates/jammy-test-template --series jammy
 	juju metadata add-image juju-ci-root/templates/focal-test-template --series focal
 	juju metadata add-image juju-ci-root/templates/bionic-test-template --series bionic
 	juju metadata add-image juju-ci-root/templates/xenial-test-template --series xenial


### PR DESCRIPTION
Add a jammy template for use when testing against the Boston vSphere. Use of it for bootstrap is automatic based on how it's done.

## QA steps

While the following test is running, log into the Boston vsphere and verify that no template directory was created under the controller.

```sh
(cd tests ; ./main.sh -v -c boston-vsphere -R Boston -S jammy controller )
```
