### PR TITLE
[JUJU-1357] Rework some of the hosted model verbage in messages

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -71,7 +71,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        snap_version: ["2.8/stable"]
+        snap_version: ["3.0/stable"]
         model_type: ["localhost", "microk8s"]
     env:
       CHARM_localhost: apache2
@@ -88,6 +88,8 @@ jobs:
         OUT=$(snap info juju | grep -E "${{ matrix.snap_version }}:[[:space:]]+\^" || echo "NOT FOUND")
         set -e
         if [ "$OUT" = "NOT FOUND" ]; then
+          echo "RUN_TEST=NO_BASE_VERSION" >> $GITHUB_ENV
+        else
           echo "RUN_TEST=RUN" >> $GITHUB_ENV
         fi
 
@@ -238,6 +240,7 @@ jobs:
     # However we just need to install the `wait-for` binary ourselves,
     # and then Juju 2.8 can use it (amazing!)
     - name: Add `wait-for` plugin
+      if: env.RUN_TEST == 'RUN'
       shell: bash
       run: |
         # Download a stable version of Juju

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -252,8 +252,8 @@ func InitializeState(
 	}
 	c.SetPassword(newPassword)
 
-	if err := ensureHostedModel(cloudSpec, provider, args, st, ctrl, adminUser, cloudCredTag); err != nil {
-		return nil, errors.Annotate(err, "ensuring hosted model")
+	if err := ensureInitialModel(cloudSpec, provider, args, st, ctrl, adminUser, cloudCredTag); err != nil {
+		return nil, errors.Annotate(err, "ensuring initial model")
 	}
 	return ctrl, nil
 }
@@ -299,8 +299,8 @@ func getCloudCredentials(
 	return cloudCredentials, cloudCredentialTag, nil
 }
 
-// ensureHostedModel ensures hosted model.
-func ensureHostedModel(
+// ensureInitialModel ensures the initial model.
+func ensureInitialModel(
 	cloudSpec environscloudspec.CloudSpec,
 	provider environs.EnvironProvider,
 	args InitializeStateParams,
@@ -309,41 +309,41 @@ func ensureHostedModel(
 	adminUser names.UserTag,
 	cloudCredentialTag names.CloudCredentialTag,
 ) error {
-	if len(args.HostedModelConfig) == 0 {
-		logger.Debugf("no hosted model configured")
+	if len(args.InitialModelConfig) == 0 {
+		logger.Debugf("no initial model configured")
 		return nil
 	}
 
 	// Create the initial hosted model, with the model config passed to
-	// bootstrap, which contains the UUID, name for the hosted model,
+	// bootstrap, which contains the UUID, name for the model,
 	// and any user supplied config. We also copy the authorized-keys
 	// from the controller model.
 	attrs := make(map[string]interface{})
-	for k, v := range args.HostedModelConfig {
+	for k, v := range args.InitialModelConfig {
 		attrs[k] = v
 	}
 	attrs[config.AuthorizedKeysKey] = args.ControllerModelConfig.AuthorizedKeys()
 
 	creator := modelmanager.ModelConfigCreator{Provider: args.Provider}
-	hostedModelConfig, err := creator.NewModelConfig(
+	InitialModelConfig, err := creator.NewModelConfig(
 		cloudSpec, args.ControllerModelConfig, attrs,
 	)
 	if err != nil {
-		return errors.Annotate(err, "creating hosted model config")
+		return errors.Annotate(err, "creating initial model config")
 	}
 	controllerUUID := args.ControllerConfig.ControllerUUID()
 
-	hostedModelEnv, err := getEnviron(controllerUUID, cloudSpec, hostedModelConfig, provider)
+	initialModelEnv, err := getEnviron(controllerUUID, cloudSpec, InitialModelConfig, provider)
 	if err != nil {
-		return errors.Annotate(err, "opening hosted model environment")
+		return errors.Annotate(err, "opening initial model environment")
 	}
 
-	if err := hostedModelEnv.Create(
+	if err := initialModelEnv.Create(
 		context.CallContext(st),
 		environs.CreateParams{
 			ControllerUUID: controllerUUID,
 		}); err != nil {
-		return errors.Annotate(err, "creating hosted model environment")
+		return errors.Annotate(err, "creating initial model environment")
 	}
 
 	ctrlModel, err := st.Model()
@@ -351,10 +351,10 @@ func ensureHostedModel(
 		return errors.Trace(err)
 	}
 
-	model, hostedModelState, err := ctrl.NewModel(state.ModelArgs{
+	model, initialModelState, err := ctrl.NewModel(state.ModelArgs{
 		Type:                    ctrlModel.Type(),
 		Owner:                   adminUser,
-		Config:                  hostedModelConfig,
+		Config:                  InitialModelConfig,
 		Constraints:             args.ModelConstraints,
 		CloudName:               args.ControllerCloud.Name,
 		CloudRegion:             args.ControllerCloudRegion,
@@ -363,21 +363,21 @@ func ensureHostedModel(
 		EnvironVersion:          provider.Version(),
 	})
 	if err != nil {
-		return errors.Annotate(err, "creating hosted model")
+		return errors.Annotate(err, "creating initial model")
 	}
-	defer func() { _ = hostedModelState.Close() }()
+	defer func() { _ = initialModelState.Close() }()
 
-	if err := model.AutoConfigureContainerNetworking(hostedModelEnv); err != nil {
+	if err := model.AutoConfigureContainerNetworking(initialModelEnv); err != nil {
 		return errors.Annotate(err, "autoconfiguring container networking")
 	}
 
 	// TODO(wpk) 2017-05-24 Copy subnets/spaces from controller model
-	ctx := context.CallContext(hostedModelState)
-	if err = space.ReloadSpaces(ctx, space.NewState(hostedModelState), hostedModelEnv); err != nil {
+	ctx := context.CallContext(initialModelState)
+	if err = space.ReloadSpaces(ctx, space.NewState(initialModelState), initialModelEnv); err != nil {
 		if errors.IsNotSupported(err) {
 			logger.Debugf("Not performing spaces load on a non-networking environment")
 		} else {
-			return errors.Annotate(err, "fetching hosted model spaces")
+			return errors.Annotate(err, "fetching initial model spaces")
 		}
 	}
 	return nil

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -152,10 +152,10 @@ LXC_BRIDGE="ignored"`[1:])
 	c.Assert(err, jc.ErrorIsNil)
 	controllerCfg := testing.FakeControllerConfig()
 
-	hostedModelUUID := utils.MustNewUUID().String()
-	hostedModelConfigAttrs := map[string]interface{}{
+	initialModelUUID := utils.MustNewUUID().String()
+	InitialModelConfigAttrs := map[string]interface{}{
 		"name": "hosted",
-		"uuid": hostedModelUUID,
+		"uuid": initialModelUUID,
 	}
 	controllerInheritedConfig := map[string]interface{}{
 		"apt-mirror": "http://mirror",
@@ -187,7 +187,7 @@ LXC_BRIDGE="ignored"`[1:])
 			ControllerModelEnvironVersion: 666,
 			ModelConstraints:              expectModelConstraints,
 			ControllerInheritedConfig:     controllerInheritedConfig,
-			HostedModelConfig:             hostedModelConfigAttrs,
+			InitialModelConfig:            InitialModelConfigAttrs,
 			StoragePools: map[string]storage.Attrs{
 				"spool": {
 					"type": "loop",
@@ -273,18 +273,18 @@ LXC_BRIDGE="ignored"`[1:])
 	// Check that the hosted model has been added, model constraints
 	// set, and its config contains the same authorized-keys as the
 	// controller model.
-	hostedModelSt, err := ctlr.StatePool().Get(hostedModelUUID)
+	initialModelSt, err := ctlr.StatePool().Get(initialModelUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	defer hostedModelSt.Release()
-	gotModelConstraints, err = hostedModelSt.ModelConstraints()
+	defer initialModelSt.Release()
+	gotModelConstraints, err = initialModelSt.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
-	hostedModel, err := hostedModelSt.Model()
+	initialModel, err := initialModelSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(hostedModel.Name(), gc.Equals, "hosted")
-	c.Assert(hostedModel.CloudRegion(), gc.Equals, "dummy-region")
-	c.Assert(hostedModel.EnvironVersion(), gc.Equals, 123)
-	hostedCfg, err := hostedModel.ModelConfig()
+	c.Assert(initialModel.Name(), gc.Equals, "hosted")
+	c.Assert(initialModel.CloudRegion(), gc.Equals, "dummy-region")
+	c.Assert(initialModel.EnvironVersion(), gc.Equals, 123)
+	hostedCfg, err := initialModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	_, hasUnexpected := hostedCfg.AllAttrs()["not-for-hosted"]
 	c.Assert(hasUnexpected, jc.IsFalse)
@@ -431,7 +431,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	modelCfg, err := config.New(config.NoDefaults, modelAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 
-	hostedModelConfigAttrs := map[string]interface{}{
+	InitialModelConfigAttrs := map[string]interface{}{
 		"name": "hosted",
 		"uuid": utils.MustNewUUID().String(),
 	}
@@ -447,7 +447,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 			},
 			ControllerConfig:      testing.FakeControllerConfig(),
 			ControllerModelConfig: modelCfg,
-			HostedModelConfig:     hostedModelConfigAttrs,
+			InitialModelConfig:    InitialModelConfigAttrs,
 		},
 		BootstrapMachineJobs: []model.MachineJob{model.JobManageModel},
 		SharedSecret:         "abc123",

--- a/api/controller/controller/controller.go
+++ b/api/controller/controller/controller.go
@@ -102,7 +102,7 @@ type HostedConfig struct {
 }
 
 // HostedModelConfigs returns all model settings for the
-// controller model.
+// models hosted on the controller.
 func (c *Client) HostedModelConfigs() ([]HostedConfig, error) {
 	result := params.HostedModelConfigsResults{}
 	err := c.facade.FacadeCall("HostedModelConfigs", nil, &result)

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -73,7 +73,7 @@ func (api *HighAvailabilityAPI) enableHASingle(st *state.State, spec params.Cont
 	params.ControllersChanges, error,
 ) {
 	if !st.IsController() {
-		return params.ControllersChanges{}, errors.New("unsupported with hosted models")
+		return params.ControllersChanges{}, errors.New("unsupported with workload models")
 	}
 	// Check if changes are allowed and the command may proceed.
 	blockChecker := common.NewBlockChecker(st)

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -555,7 +555,7 @@ func (s *clientSuite) TestEnableHAHostedModelErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	enableHAResult, err := enableHA(c, haServer, 3, constraints.MustParse("mem=4G"), defaultSeries, nil)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, "unsupported with hosted models")
+	c.Assert(errors.Cause(err), gc.ErrorMatches, "unsupported with workload models")
 
 	c.Assert(enableHAResult.Maintained, gc.HasLen, 0)
 	c.Assert(enableHAResult.Added, gc.HasLen, 0)

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -98,8 +98,8 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	}
 	pcfg.Bootstrap.ControllerModelConfig = s.cfg
 	pcfg.Bootstrap.BootstrapMachineInstanceId = "instance-id"
-	pcfg.Bootstrap.HostedModelConfig = map[string]interface{}{
-		"name": "hosted-model",
+	pcfg.Bootstrap.InitialModelConfig = map[string]interface{}{
+		"name": "my-model",
 	}
 	pcfg.Bootstrap.StateServingInfo = controller.StateServingInfo{
 		Cert:         coretesting.ServerCert,

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -16,7 +16,6 @@ import (
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 	"github.com/juju/utils/v3/arch"
@@ -39,6 +38,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
+
+	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 
 	"github.com/juju/juju/caas"
 	k8sapplication "github.com/juju/juju/caas/kubernetes/provider/application"
@@ -470,14 +471,14 @@ func (k *kubernetesClient) Bootstrap(
 
 		logger.Debugf("controller pod config: \n%+v", pcfg)
 
-		// validate hosted model name if we need to create it.
-		if hostedModelName, has := pcfg.GetHostedModel(); has {
-			_, err := k.getNamespaceByName(hostedModelName)
+		// validate initial model name if we need to create it.
+		if initialModelName, has := pcfg.GetInitialModel(); has {
+			_, err := k.getNamespaceByName(initialModelName)
 			if err == nil {
 				return errors.NewAlreadyExists(nil,
 					fmt.Sprintf(`
 namespace %q already exists in the cluster,
-please choose a different hosted model name then try again.`, hostedModelName),
+please choose a different initial model name then try again.`, initialModelName),
 				)
 			}
 			if !errors.IsNotFound(err) {

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -71,8 +71,8 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 		}
 		icfg.Bootstrap.ControllerModelConfig = modelConfig
 		icfg.Bootstrap.BootstrapMachineInstanceId = "instance-id"
-		icfg.Bootstrap.HostedModelConfig = map[string]interface{}{
-			"name": "hosted-model",
+		icfg.Bootstrap.InitialModelConfig = map[string]interface{}{
+			"name": "my-model",
 		}
 		icfg.Bootstrap.StateServingInfo = jujucontroller.StateServingInfo{
 			Cert:         coretesting.ServerCert,

--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -307,10 +307,10 @@ type StateInitializationParams struct {
 	// cloud.
 	RegionInheritedConfig cloud.RegionConfig
 
-	// HostedModelConfig is a set of config attributes to be overlaid
+	// InitialModelConfig is a set of config attributes to be overlaid
 	// on the controller model config (Config, above) to construct the
 	// initial hosted model config.
-	HostedModelConfig map[string]interface{}
+	InitialModelConfig map[string]interface{}
 
 	// BootstrapMachineInstanceId is the instance ID of the bootstrap
 	// machine instance being initialized.
@@ -347,7 +347,7 @@ type stateInitializationParamsInternal struct {
 	ControllerModelEnvironVersion           int                               `yaml:"controller-model-version"`
 	ControllerInheritedConfig               map[string]interface{}            `yaml:"controller-config-defaults,omitempty"`
 	RegionInheritedConfig                   cloud.RegionConfig                `yaml:"region-inherited-config,omitempty"`
-	HostedModelConfig                       map[string]interface{}            `yaml:"hosted-model-config,omitempty"`
+	InitialModelConfig                      map[string]interface{}            `yaml:"initial-model-config,omitempty"`
 	StoragePools                            map[string]storage.Attrs          `yaml:"storage-pools,omitempty"`
 	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id,omitempty"`
 	BootstrapMachineConstraints             constraints.Value                 `yaml:"bootstrap-machine-constraints"`
@@ -378,7 +378,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		ControllerModelEnvironVersion:           p.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               p.ControllerInheritedConfig,
 		RegionInheritedConfig:                   p.RegionInheritedConfig,
-		HostedModelConfig:                       p.HostedModelConfig,
+		InitialModelConfig:                      p.InitialModelConfig,
 		StoragePools:                            p.StoragePools,
 		BootstrapMachineInstanceId:              p.BootstrapMachineInstanceId,
 		BootstrapMachineConstraints:             p.BootstrapMachineConstraints,
@@ -420,7 +420,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		ControllerModelEnvironVersion:           internal.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               internal.ControllerInheritedConfig,
 		RegionInheritedConfig:                   internal.RegionInheritedConfig,
-		HostedModelConfig:                       internal.HostedModelConfig,
+		InitialModelConfig:                      internal.InitialModelConfig,
 		StoragePools:                            internal.StoragePools,
 		BootstrapMachineInstanceId:              internal.BootstrapMachineInstanceId,
 		BootstrapMachineConstraints:             internal.BootstrapMachineConstraints,

--- a/cloudconfig/podcfg/podcfg.go
+++ b/cloudconfig/podcfg/podcfg.go
@@ -235,12 +235,12 @@ func (cfg *ControllerPodConfig) GetPodName() string {
 	return "controller-" + cfg.ControllerId
 }
 
-// GetHostedModel checks if hosted model was requested to create.
-func (cfg *ControllerPodConfig) GetHostedModel() (string, bool) {
-	hasHostedModel := len(cfg.Bootstrap.HostedModelConfig) > 0
-	if hasHostedModel {
-		modelName := cfg.Bootstrap.HostedModelConfig[config.NameKey].(string)
-		logger.Debugf("configured hosted model %q for bootstrapping", modelName)
+// GetInitialModel checks if hosted model was requested to create.
+func (cfg *ControllerPodConfig) GetInitialModel() (string, bool) {
+	hasInitialModel := len(cfg.Bootstrap.InitialModelConfig) > 0
+	if hasInitialModel {
+		modelName := cfg.Bootstrap.InitialModelConfig[config.NameKey].(string)
+		logger.Debugf("configured initial model %q for bootstrapping", modelName)
 		return modelName, true
 	}
 	return "", false

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -180,7 +180,7 @@ func (cfg *testInstanceConfig) setControllerCharm(path string) *testInstanceConf
 func (cfg *testInstanceConfig) maybeSetModelConfig(envConfig *config.Config) *testInstanceConfig {
 	if envConfig != nil && cfg.Bootstrap != nil {
 		cfg.Bootstrap.ControllerModelConfig = envConfig
-		cfg.Bootstrap.HostedModelConfig = map[string]interface{}{"name": "hosted-model"}
+		cfg.Bootstrap.InitialModelConfig = map[string]interface{}{"name": "my-model"}
 	}
 	return cfg
 }
@@ -1140,7 +1140,7 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 				StateInitializationParams: instancecfg.StateInitializationParams{
 					BootstrapMachineInstanceId: "i-bootstrap",
 					ControllerModelConfig:      minimalModelConfig(c),
-					HostedModelConfig:          map[string]interface{}{"name": "hosted-model"},
+					InitialModelConfig:         map[string]interface{}{"name": "my-model"},
 				},
 				StateServingInfo: stateServingInfo,
 			},

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -453,8 +453,8 @@ var bootstrapTests = []bootstrapTest{{
 	args: []string{"--config", "controller-name=test"},
 	err:  `controller name cannot be set via config, please use cmd args`,
 }, {
-	info: "resource-group-name does not support workload-model",
-	args: []string{"--config", "resource-group-name=foo", "--workload-model", "foo"},
+	info: "resource-group-name does not support create-model",
+	args: []string{"--config", "resource-group-name=foo", "--create-model", "foo"},
 	err:  `if using resource-group-name "foo" then a workload model cannot be specified as well`,
 }, {
 	info: "missing storage pool name",
@@ -550,7 +550,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultControllerNameNoRegions(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModelWithCaps(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "xenial")
 
-	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "DevController", "--auto-upgrade", "--workload-model", "workload")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "DevController", "--auto-upgrade", "--create-model", "workload")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
 	c.Assert(currentController, gc.Equals, "devcontroller")
@@ -565,7 +565,7 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModelWithCaps(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "xenial")
 
-	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade", "--workload-model", "workload")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade", "--create-model", "workload")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
 	c.Assert(currentController, gc.Equals, "devcontroller")
@@ -639,12 +639,12 @@ func (s *BootstrapSuite) TestBootstrapWithWorkloadModel(c *gc.C) {
 		c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 		"--auto-upgrade",
-		"--workload-model", "mymodel",
+		"--create-model", "mymodel",
 		"--config", "foo=bar",
 	)
 	c.Assert(utils.IsValidUUIDString(bootstrapFuncs.args.ControllerConfig.ControllerUUID()), jc.IsTrue)
-	c.Assert(bootstrapFuncs.args.HostedModelConfig["name"], gc.Equals, "mymodel")
-	c.Assert(bootstrapFuncs.args.HostedModelConfig["foo"], gc.Equals, "bar")
+	c.Assert(bootstrapFuncs.args.InitialModelConfig["name"], gc.Equals, "mymodel")
+	c.Assert(bootstrapFuncs.args.InitialModelConfig["foo"], gc.Equals, "bar")
 }
 
 func (s *BootstrapSuite) TestBootstrapNoWorkloadModel(c *gc.C) {
@@ -662,7 +662,7 @@ func (s *BootstrapSuite) TestBootstrapNoWorkloadModel(c *gc.C) {
 		"--config", "foo=bar",
 	)
 	c.Assert(utils.IsValidUUIDString(bootstrapFuncs.args.ControllerConfig.ControllerUUID()), jc.IsTrue)
-	c.Assert(bootstrapFuncs.args.HostedModelConfig, gc.HasLen, 0)
+	c.Assert(bootstrapFuncs.args.InitialModelConfig, gc.HasLen, 0)
 }
 
 func (s *BootstrapSuite) TestBootstrapTimeout(c *gc.C) {
@@ -713,7 +713,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsProcessedAttributes(c *
 		"--auto-upgrade",
 		"--config", "authorized-keys-path="+fakeSSHFile,
 	)
-	_, ok := bootstrapFuncs.args.HostedModelConfig["authorized-keys-path"]
+	_, ok := bootstrapFuncs.args.InitialModelConfig["authorized-keys-path"]
 	c.Assert(ok, jc.IsFalse)
 }
 
@@ -728,16 +728,16 @@ func (s *BootstrapSuite) TestBootstrapModelDefaultConfig(c *gc.C) {
 	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
-		"--workload-model", "workload",
+		"--create-model", "workload",
 		"--model-default", "network=foo",
 		"--model-default", "ftp-proxy=model-proxy",
 		"--config", "ftp-proxy=controller-proxy",
 	)
 
-	c.Check(bootstrapFuncs.args.HostedModelConfig["network"], gc.Equals, "foo")
+	c.Check(bootstrapFuncs.args.InitialModelConfig["network"], gc.Equals, "foo")
 	c.Check(bootstrapFuncs.args.ControllerInheritedConfig["network"], gc.Equals, "foo")
 
-	c.Check(bootstrapFuncs.args.HostedModelConfig["ftp-proxy"], gc.Equals, "controller-proxy")
+	c.Check(bootstrapFuncs.args.InitialModelConfig["ftp-proxy"], gc.Equals, "controller-proxy")
 	c.Check(bootstrapFuncs.args.ControllerInheritedConfig["ftp-proxy"], gc.Equals, "model-proxy")
 }
 
@@ -759,9 +759,9 @@ func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsInheritedAttributes(c *
 		"--config", "authorized-keys=ssh-key",
 		"--config", "agent-version=1.19.0",
 	)
-	_, ok := bootstrapFuncs.args.HostedModelConfig["authorized-keys"]
+	_, ok := bootstrapFuncs.args.InitialModelConfig["authorized-keys"]
 	c.Assert(ok, jc.IsFalse)
-	_, ok = bootstrapFuncs.args.HostedModelConfig["agent-version"]
+	_, ok = bootstrapFuncs.args.InitialModelConfig["agent-version"]
 	c.Assert(ok, jc.IsFalse)
 }
 

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -80,7 +80,7 @@ See https://juju.is for getting started tutorials and additional documentation.
 Starter commands:
 
     bootstrap           Initializes a cloud environment.
-    add-model           Adds a hosted model.
+    add-model           Adds a workload model.
     deploy              Deploys a new application.
     status              Displays the current status of Juju, applications, and units.
     add-unit            Adds extra units of a deployed application.

--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -67,7 +67,7 @@ Juju version. Once complete, the model's machine and and unit agents
 will be connected to the new controller. The model will no longer be
 available at the source controller.
 
-Note that only hosted models can be migrated. Controller models can
+Note that only workload models can be migrated. Controller models can
 not be migrated.
 
 If the migration fails for some reason, the model be returned to its
@@ -93,7 +93,7 @@ func (c *migrateCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "migrate",
 		Args:    "<model-name> <target-controller-name>",
-		Purpose: "Migrate a hosted model to another controller.",
+		Purpose: "Migrate a workload model to another controller.",
 		Doc:     migrateDoc,
 	})
 }

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -109,7 +109,7 @@ func (c *addModelCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "add-model",
 		Args:    "<model name> [cloud|region|(cloud/region)]",
-		Purpose: "Adds a hosted model.",
+		Purpose: "Adds a workload model.",
 		Doc:     strings.TrimSpace(addModelHelpDoc),
 	})
 }

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -70,15 +70,15 @@ type destroyCommand struct {
 // TODO(cheryl): Do we want the usage, options, examples, and see also text in
 // backticks for markdown?
 var usageDetails = `
-All models (initial model plus all workload/hosted) associated with the
-controller will first need to be destroyed, either in advance, or by
+All workload models running on the controller will first
+need to be destroyed, either in advance, or by
 specifying `[1:] + "`--destroy-all-models`." + `
 
 If there is persistent storage in any of the models managed by the
 controller, then you must choose to either destroy or release the
 storage, using ` + "`--destroy-storage` or `--release-storage` respectively." + `
 
-Sometimes, the destruction of a hosted model may fail as Juju encounters errors
+Sometimes, the destruction of a model may fail as Juju encounters errors
 that need to be dealt with before that model can be destroyed.
 However, at times, there is a need to destroy a controller ignoring
 such model errors. In these rare cases, use --force option but note 
@@ -91,21 +91,21 @@ However, when using --force, users can also specify --no-wait to progress throug
 without delay waiting for each step to complete.
 
 Examples:
-    # Destroy the controller and all hosted models. If there is
+    # Destroy the controller and all models. If there is
     # persistent storage remaining in any of the models, then
     # this will prompt you to choose to either destroy or release
     # the storage.
     juju destroy-controller --destroy-all-models mycontroller
 
-    # Destroy the controller and all hosted models, destroying
+    # Destroy the controller and all models, destroying
     # any remaining persistent storage.
     juju destroy-controller --destroy-all-models --destroy-storage
 
-    # Destroy the controller and all hosted models, releasing
+    # Destroy the controller and all models, releasing
     # any remaining persistent storage from Juju's control.
     juju destroy-controller --destroy-all-models --release-storage
 
-    # Destroy the controller and all hosted models, continuing
+    # Destroy the controller and all models, continuing
     # even if there are operational errors.
     juju destroy-controller --destroy-all-models --force
     juju destroy-controller --destroy-all-models --force --no-wait
@@ -165,12 +165,12 @@ const defaultTimeout = 30 * time.Minute
 // SetFlags implements Command.SetFlags.
 func (c *destroyCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.destroyCommandBase.SetFlags(f)
-	f.BoolVar(&c.destroyModels, "destroy-all-models", false, "Destroy all hosted models in the controller")
+	f.BoolVar(&c.destroyModels, "destroy-all-models", false, "Destroy all models in the controller")
 	f.BoolVar(&c.destroyStorage, "destroy-storage", false, "Destroy all storage instances managed by the controller")
 	f.BoolVar(&c.releaseStorage, "release-storage", false, "Release all storage instances from management of the controller, without destroying them")
-	f.DurationVar(&c.modelTimeout, "model-timeout", defaultTimeout, "Timeout before each individual hosted model destruction is aborted")
-	f.BoolVar(&c.force, "force", false, "Force destroy hosted models ignoring any errors")
-	f.BoolVar(&c.noWait, "no-wait", false, "Rush through hosted model destruction without waiting for each individual step to complete")
+	f.DurationVar(&c.modelTimeout, "model-timeout", defaultTimeout, "Timeout before each individual model destruction is aborted")
+	f.BoolVar(&c.force, "force", false, "Force destroy models ignoring any errors")
+	f.BoolVar(&c.noWait, "no-wait", false, "Rush through model destruction without waiting for each individual step to complete")
 }
 
 // Init implements Command.Init.
@@ -283,14 +283,14 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 		// there may be some being destroyed already. We need to wait for them.
 		// Check for both undead models and live machines, as machines may be
 		// in the controller model.
-		ctx.Infof("Waiting for hosted model resources to be reclaimed")
+		ctx.Infof("Waiting for model resources to be reclaimed")
 		for ; hasUnreclaimedResources(modelStatus); modelStatus = updateStatus(2 * time.Second) {
 			ctx.Infof(fmtCtrStatus(modelStatus.controller))
 			for _, model := range modelStatus.models {
 				ctx.Verbosef(fmtModelStatus(model))
 			}
 		}
-		ctx.Infof("All hosted models reclaimed, cleaning up controller machines")
+		ctx.Infof("All models reclaimed, cleaning up controller machines")
 		return c.environsDestroy(controllerName, controllerEnviron, cloudCallCtx, store)
 	}
 }
@@ -332,8 +332,8 @@ func (c *destroyCommand) checkNoAliveHostedModels(ctx *cmd.Context, models []mod
 	}
 	return errors.Errorf(`cannot destroy controller %q
 
-The controller has live hosted models. If you want
-to destroy all hosted models in the controller,
+The controller has live models. If you want
+to destroy all models in the controller,
 run this command again with the --destroy-all-models
 option.
 

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -428,8 +428,8 @@ func (s *DestroySuite) TestDestroyControllerAliveModels(c *gc.C) {
 	_, err := s.runDestroyCommand(c, "test1", "-y")
 	c.Assert(err.Error(), gc.Equals, `cannot destroy controller "test1"
 
-The controller has live hosted models. If you want
-to destroy all hosted models in the controller,
+The controller has live models. If you want
+to destroy all models in the controller,
 run this command again with the --destroy-all-models
 option.
 

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -27,15 +27,15 @@ import (
 
 const killDoc = `
 Forcibly destroy the specified controller.  If the API server is accessible,
-this command will attempt to destroy the controller model and all hosted models
+this command will attempt to destroy the controller model and all models
 and their resources.
 
 If the API server is unreachable, the machines of the controller model will be
 destroyed through the cloud provisioner.  If there are additional machines,
-including machines within hosted models, these machines will not be destroyed
+including machines within models, these machines will not be destroyed
 and will never be reconnected to the Juju controller being destroyed.
 
-The normal process of killing the controller will involve watching the hosted
+The normal process of killing the controller will involve watching the
 models as they are brought down in a controlled manner. If for some reason the
 models do not stop cleanly, there is a default five minute timeout. If no change
 in the model state occurs for the duration of this timeout, the command will
@@ -197,7 +197,7 @@ func (c *killCommand) DirectDestroyRemaining(
 	hostedConfig, err := api.HostedModelConfigs()
 	if err != nil {
 		hasErrors = true
-		logger.Errorf("unable to retrieve hosted model config: %v", err)
+		logger.Errorf("unable to retrieve model config: %v", err)
 	}
 	ctrlUUID := ""
 	// try to get controller UUID or just ignore.
@@ -266,7 +266,7 @@ func (c *killCommand) DirectDestroyRemaining(
 	if hasErrors {
 		logger.Errorf("there were problems destroying some models, manual intervention may be necessary to ensure resources are released")
 	} else {
-		ctx.Infof("All hosted models destroyed, cleaning up controller machines")
+		ctx.Infof("All models destroyed, cleaning up controller machines")
 	}
 }
 
@@ -338,7 +338,7 @@ func (c *killCommand) WaitForModels(ctx *cmd.Context, api destroyControllerAPI, 
 	if hasUnreclaimedResources(envStatus) {
 		return errors.New("timed out")
 	} else {
-		ctx.Infof("All hosted models reclaimed, cleaning up controller machines")
+		ctx.Infof("All models reclaimed, cleaning up controller machines")
 	}
 	return nil
 }

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -108,7 +108,7 @@ func (s *KillSuite) TestKillWaitForModels_AllGood(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	err = controller.KillWaitForModels(wrapped, ctx, s.api, test1UUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "All hosted models reclaimed, cleaning up controller machines\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "All models reclaimed, cleaning up controller machines\n")
 }
 
 func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
@@ -153,7 +153,7 @@ func (s *KillSuite) TestKillWaitForModels_ActuallyWaits(c *gc.C) {
 	expect := "" +
 		"Waiting for 1 model, 2 machines, 2 applications\n" +
 		"Waiting for 1 model, 1 machine\n" +
-		"All hosted models reclaimed, cleaning up controller machines\n"
+		"All models reclaimed, cleaning up controller machines\n"
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
 }
@@ -208,7 +208,7 @@ func (s *KillSuite) TestKillWaitForModels_WaitsForControllerMachines(c *gc.C) {
 	expect := "" +
 		"Waiting for 0 model, 2 machines\n" +
 		"Waiting for 0 model, 1 machine\n" +
-		"All hosted models reclaimed, cleaning up controller machines\n"
+		"All models reclaimed, cleaning up controller machines\n"
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
 }
@@ -259,7 +259,7 @@ func (s *KillSuite) TestKillWaitForModels_TimeoutResetsWithChange(c *gc.C) {
 		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 20s\n" +
 		"Waiting for 1 model, 2 machines, 2 applications, will kill machines directly in 15s\n" +
 		"Waiting for 1 model, 1 machine, will kill machines directly in 20s\n" +
-		"All hosted models reclaimed, cleaning up controller machines\n"
+		"All models reclaimed, cleaning up controller machines\n"
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expect)
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -112,10 +112,10 @@ type BootstrapParams struct {
 	// cloud.
 	RegionInheritedConfig cloud.RegionConfig
 
-	// HostedModelConfig is the set of config attributes to be overlaid
+	// InitialModelConfig is the set of config attributes to be overlaid
 	// on the controller config to construct the initial hosted model
 	// config.
-	HostedModelConfig map[string]interface{}
+	InitialModelConfig map[string]interface{}
 
 	// Placement, if non-empty, holds an environment-specific placement
 	// directive used to choose the initial instance.
@@ -770,7 +770,7 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.ControllerConfig = args.ControllerConfig
 	icfg.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
 	icfg.Bootstrap.RegionInheritedConfig = args.Cloud.RegionConfig
-	icfg.Bootstrap.HostedModelConfig = args.HostedModelConfig
+	icfg.Bootstrap.InitialModelConfig = args.InitialModelConfig
 	icfg.Bootstrap.StoragePools = args.StoragePools
 	icfg.Bootstrap.Timeout = args.DialOpts.Timeout
 	icfg.Bootstrap.JujuDbSnapPath = args.JujuDbSnapPath
@@ -846,7 +846,7 @@ func finalizePodBootstrapConfig(
 	pcfg.Bootstrap.ControllerCloudCredentialName = args.CloudCredentialName
 	pcfg.Bootstrap.ControllerConfig = args.ControllerConfig
 	pcfg.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
-	pcfg.Bootstrap.HostedModelConfig = args.HostedModelConfig
+	pcfg.Bootstrap.InitialModelConfig = args.InitialModelConfig
 	pcfg.Bootstrap.StoragePools = args.StoragePools
 	pcfg.Bootstrap.Timeout = args.DialOpts.Timeout
 	pcfg.Bootstrap.ControllerServiceType = args.ControllerServiceType

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -317,7 +317,7 @@ func (s *cmdControllerSuite) TestControllerDestroyUsingAPI(c *gc.C) {
 
 func (s *cmdControllerSuite) testControllerDestroy(c *gc.C, forceAPI bool) {
 	st := s.Factory.MakeModel(c, &factory.ModelParams{
-		Name:        "just-a-hosted-model",
+		Name:        "just-a-model",
 		ConfigAttrs: testing.Attrs{"controller": true},
 		CloudRegion: "dummy-region",
 	})

--- a/state/model.go
+++ b/state/model.go
@@ -1426,8 +1426,8 @@ func (m *Model) destroyOps(
 		// We only need to destroy resources if the model is non-empty.
 		// It wouldn't normally be harmful to enqueue the cleanups
 		// otherwise, except for when we're destroying an empty
-		// hosted model in the course of destroying the controller. In
-		// that case we'll get errors if we try to enqueue hosted-model
+		// model in the course of destroying the controller. In
+		// that case we'll get errors if we try to enqueue model
 		// cleanups, because the cleanups collection is non-global.
 		ops = append(ops, newCleanupOp(cleanupApplicationsForDyingModel, modelUUID, args))
 		if m.Type() == ModelTypeIAAS {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -244,7 +244,7 @@ juju_bootstrap() {
 
 	pre_bootstrap
 
-	command="juju bootstrap ${series} ${model_default_series} ${cloud_region} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${series} ${model_default_series} ${cloud_region} ${name} --create-model ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"

--- a/tests/suites/smoke/task.sh
+++ b/tests/suites/smoke/task.sh
@@ -9,10 +9,10 @@ test_smoke() {
 	echo "==> Checking for dependencies"
 	check_dependencies juju
 
-	file="${TEST_DIR}/test-smoke.log"
-
 	test_build
 
+	file="${TEST_DIR}/test-smoke.log"
+	echo "====> Logging to ${file}"
 	bootstrap "test-smoke" "${file}"
 
 	test_deploy "${file}"


### PR DESCRIPTION
Change the bootstrap `--workload-model` param to `--create-model`.
Remove "hosted" from various user facing messages as it's not needed.

## QA steps

juju bootstrap lxd test --create-model mine --config logging-config="<root>=INFO;<unit>=WARNING"
juju model config
juju models
juju status

