### PR TITLE
Fix `test_basic_backup` to read lxd container status with `lxc list`.

### DIFF
--- a/tests/suites/backup/backup.sh
+++ b/tests/suites/backup/backup.sh
@@ -61,8 +61,8 @@ run_basic_backup_restore() {
 	# Only do this check if provider is LXD (too hard to do for all providers)
 	if [ "${BOOTSTRAP_PROVIDER}" == "lxd" ] || [ "${BOOTSTRAP_PROVIDER}" == "localhost" ]; then
 		echo "Ensure that both instances are running (restore shouldn't terminate machines)"
-		lxc info "${id0}" | grep Status | check Running
-		lxc info "${id1}" | grep Status | check Running
+		lxc list --format json | jq --arg name "${id0}" -r '.[] | select(.name==$name) | .state.status' | check Running
+		lxc list --format json | jq --arg name "${id1}" -r '.[] | select(.name==$name) | .state.status' | check Running
 	fi
 
 	destroy_model "test-basic-backup-restore"


### PR DESCRIPTION
Shell test test_basic_backup didn't read container status reliably between versions,
use `lxc list` with jq filtering instead.