### PR TITLE
[JUJU-1358]Fail more gracefully for negative watch values

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -224,6 +224,11 @@ func (c *statusCommand) Init(args []string) error {
 			}
 		}
 	}
+
+	if c.watch < 0 {
+		return errors.Errorf("invalid value %q, expected a positive value", c.watch)
+	}
+
 	if c.clock == nil {
 		c.clock = clock.WallClock
 	}


### PR DESCRIPTION
This PR fixes panics when `juju status --watch` receives a negative value. 

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps
Provision on any cloud.

```sh
juju status --watch -2s
```

## Bug reference

*https://bugs.launchpad.net/juju/+bug/1979572*
