### PR TITLE
Fix tests of model-config and model-default from file.

### DIFF
--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -6,7 +6,7 @@ run_model_config_isomorphic() {
 
 	FILE=$(mktemp)
 
-	juju model-config --format=yaml | juju model-config --ignore-read-only-fields -
+	juju model-config --format=yaml | juju model-config --ignore-read-only-fields --file -
 
 	destroy_model "model-config-isomorphic"
 }

--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -26,7 +26,7 @@ cloudinit-userdata: |
     - shellcheck
 EOF
 
-	juju model-config "${FILE}"
+	juju model-config --file "${FILE}"
 	OUT=$(juju model-config cloudinit-userdata)
 	echo "${OUT}" | grep -q "shellcheck"
 

--- a/tests/suites/cli/model_defaults.sh
+++ b/tests/suites/cli/model_defaults.sh
@@ -17,7 +17,7 @@ cloudinit-userdata: |
     - shellcheck
 EOF
 
-	juju model-defaults "${FILE}"
+	juju model-defaults --file "${FILE}"
 	juju model-defaults cloudinit-userdata --format=yaml | grep -q 'default: ""'
 	juju model-defaults cloudinit-userdata --format=yaml | grep -q "shellcheck"
 }

--- a/tests/suites/cli/model_defaults.sh
+++ b/tests/suites/cli/model_defaults.sh
@@ -3,7 +3,7 @@ run_model_defaults_isomorphic() {
 
 	FILE=$(mktemp)
 
-	juju model-defaults --format=yaml | juju model-defaults --ignore-read-only-fields -
+	juju model-defaults --format=yaml | juju model-defaults --ignore-read-only-fields --file -
 }
 
 run_model_defaults_cloudinit_userdata() {


### PR DESCRIPTION
Fixes test_model_config and test_model_defaults where config was sourced from a file without the new `--file` argument.