### PR TITLE
Destroy controller unit on controller machine destroy.

### DIFF
--- a/state/conn_test.go
+++ b/state/conn_test.go
@@ -67,8 +67,16 @@ func (s *ConnSuite) AddTestingCharm(c *gc.C, name string) *state.Charm {
 	return state.AddTestingCharm(c, s.State, name)
 }
 
+func (s *ConnSuite) AddTestingCharmWithSeries(c *gc.C, name string, series string) *state.Charm {
+	return state.AddTestingCharmWithSeries(c, s.State, name, series)
+}
+
 func (s *ConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Charm) *state.Application {
 	return state.AddTestingApplication(c, s.State, name, ch)
+}
+
+func (s *ConnSuite) AddTestingApplicationForSeries(c *gc.C, series string, name string, ch *state.Charm) *state.Application {
+	return state.AddTestingApplicationForSeries(c, s.State, series, name, ch)
 }
 
 func (s *ConnSuite) AddTestingApplicationWithNumUnits(c *gc.C, numUnits int, name string, ch *state.Charm) *state.Application {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -187,6 +187,10 @@ func AddTestingCharm(c *gc.C, st *State, name string) *Charm {
 	return addCharm(c, st, "quantal", testcharms.Repo.CharmDir(name))
 }
 
+func AddTestingCharmWithSeries(c *gc.C, st *State, name string, series string) *Charm {
+	return addCharm(c, st, series, testcharms.Repo.CharmDir(name))
+}
+
 func getCharmRepo(series string) *charmrepotesting.Repo {
 	// ALl testing charms for state are under `quantal` except `kubernetes`.
 	if series == "kubernetes" {

--- a/state/machine.go
+++ b/state/machine.go
@@ -602,7 +602,72 @@ func (m *Machine) PasswordValid(password string) bool {
 // a HasAssignedUnitsError.  If the machine has containers, Destroy
 // will return HasContainersError.
 func (m *Machine) Destroy() error {
+	if m.IsManager() && len(m.doc.Principals) > 0 {
+		return errors.Trace(m.destroyControllerWithPrincipals())
+	}
 	return errors.Trace(m.advanceLifecycle(Dying, false, false, 0))
+}
+
+// destroyControllerWithPrincipals is called if the controller has
+// principal units and they are juju- system charms, then gracefully
+// remove them before destroying the machine.
+func (m *Machine) destroyControllerWithPrincipals() error {
+	units, err := m.Units()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	unitsMap := make(map[string]*Unit)
+	for _, unit := range units {
+		unitsMap[unit.String()] = unit
+	}
+	var evacuablePrincipals []string
+	for _, principalUnit := range m.doc.Principals {
+		unit, ok := unitsMap[principalUnit]
+		if !ok {
+			continue
+		}
+		curl, err := unit.CharmURL()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if curl != nil && strings.HasPrefix(curl.Name, "juju-") {
+			evacuablePrincipals = append(evacuablePrincipals, principalUnit)
+		}
+	}
+	if len(m.doc.Principals) != len(evacuablePrincipals) {
+		return stateerrors.NewHasAssignedUnitsError(m.doc.Id, m.doc.Principals)
+	}
+	ops := []txn.Op{
+		{
+			C:  machinesC,
+			Id: m.doc.DocID,
+			Assert: bson.D{
+				{"life", Alive},
+				advanceLifecycleUnitAsserts(evacuablePrincipals),
+			},
+			// To prevent race conditions, we remove the ability for new
+			// units to be deployed to the machine.
+			Update: bson.D{{"$pull", bson.D{{"jobs", JobHostUnits}}}},
+		},
+		newCleanupOp(cleanupEvacuateMachine, m.doc.Id),
+	}
+	if err := m.st.db().RunTransaction(ops); err != nil {
+		return errors.Annotatef(err, "failed to run transaction: %s", pretty.Sprint(ops))
+	}
+	for i, v := range m.doc.Jobs {
+		if v == JobHostUnits {
+			m.doc.Jobs = append(m.doc.Jobs[:i], m.doc.Jobs[i+1:]...)
+			break
+		}
+	}
+	err = m.SetStatus(status.StatusInfo{
+		Status:  status.Stopped,
+		Message: fmt.Sprintf("waiting on dying units %s", strings.Join(evacuablePrincipals, ", ")),
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // DestroyWithContainers sets the machine lifecycle to Dying if it is Alive.


### PR DESCRIPTION
When removing a controller machine, automatically destroy the controller unit.

## QA steps

- bootstrap
- enable-ha
- remove a controller machine

## Documentation changes

N/A

## Bug reference

N/A