### PR TITLE
[JUJU-1367] Fix client test timeouts

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -74,6 +74,6 @@ jobs:
     - name: "Test client"
       run: |
         # Jenkins can perform the full jujud testing.
-        go test -v ./cmd/juju/... -check.v -coverprofile=coverage.txt -covermode=atomic
+        go test -v ./cmd/juju/... -check.v -coverprofile=coverage.txt -covermode=atomic -timeout=15m
         go test -v ./cmd/plugins/... -check.v
       shell: bash


### PR DESCRIPTION
The Mongo-based client tests are causing more issues, this time with timing out on Ubuntu. As a preventative measure, we should ~~skip these tests for now~~ increase the test timeout - there is ongoing work to rewrite these tests to not use Mongo.