### PR TITLE
[JUJU-1102]change_juju_status_color_help_string 

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -172,7 +172,7 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.isoTime, "utc", false, "Display timestamps in the UTC timezone")
 
-	f.BoolVar(&c.color, "color", false, "Use ANSI color codes in tabular output")
+	f.BoolVar(&c.color, "color", true, "Use ANSI color codes in tabular output")
 	f.BoolVar(&c.noColor, "no-color", false, "Disable ANSI color codes in tabular output")
 	f.BoolVar(&c.relations, "relations", false, "Show 'relations' section in tabular output")
 	f.BoolVar(&c.storage, "storage", false, "Show 'storage' section in tabular output")
@@ -228,10 +228,6 @@ func (c *statusCommand) Init(args []string) error {
 	}
 	if c.clock == nil {
 		c.clock = clock.WallClock
-	}
-
-	if c.color && c.noColor {
-		return errors.Errorf("cannot mix --no-color and --color")
 	}
 
 	return nil
@@ -439,5 +435,5 @@ func (c *statusCommand) FormatTabular(writer io.Writer, value interface{}) error
 	}
 
 	//color mode enabled by default
-	return FormatTabular(writer, true, value)
+	return FormatTabular(writer, c.color, value)
 }


### PR DESCRIPTION
Update juju status `--color` help string.

*This helps the user know that the color mode in `juju status` is enabled by default`*

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps

```sh
juju status --help
```

*The help string should show you that the default value for `--color` is set to true*
```
--color  (= true)
    Use ANSI color codes in tabular output
```

