### PR TITLE
[JUJU-1371] Remove unnecessary function from state package

### DIFF
--- a/rpc/params/params_test.go
+++ b/rpc/params/params_test.go
@@ -52,7 +52,7 @@ var marshalTestCases = []struct {
 			Life:                    life.Alive,
 			Series:                  "trusty",
 			SupportedContainers:     []instance.ContainerType{instance.LXD},
-			Jobs:                    []model.MachineJob{"JobManageModel"},
+			Jobs:                    []model.MachineJob{model.JobManageModel},
 			Addresses:               []params.Address{},
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
 		},

--- a/rpc/params/params_test.go
+++ b/rpc/params/params_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
 )
 
@@ -53,7 +52,7 @@ var marshalTestCases = []struct {
 			Life:                    life.Alive,
 			Series:                  "trusty",
 			SupportedContainers:     []instance.ContainerType{instance.LXD},
-			Jobs:                    []model.MachineJob{state.JobManageModel.ToParams()},
+			Jobs:                    []model.MachineJob{"JobManageModel"},
 			Addresses:               []params.Address{},
 			HardwareCharacteristics: &instance.HardwareCharacteristics{},
 		},

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -458,7 +458,6 @@ var _ = gc.Suite(&StorageStateSuite{})
 
 func (s *StorageStateSuite) TestBlockStorageNotSupportedOnCAAS(c *gc.C) {
 	st := s.Factory.MakeCAASModel(c, nil)
-	st.Close()
 	defer st.Close()
 	ch := state.AddTestingCharmForSeries(c, st, "kubernetes", "storage-block")
 	_, err := st.AddApplication(state.AddApplicationArgs{

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -458,6 +458,7 @@ var _ = gc.Suite(&StorageStateSuite{})
 
 func (s *StorageStateSuite) TestBlockStorageNotSupportedOnCAAS(c *gc.C) {
 	st := s.Factory.MakeCAASModel(c, nil)
+	st.Close()
 	defer st.Close()
 	ch := state.AddTestingCharmForSeries(c, st, "kubernetes", "storage-block")
 	_, err := st.AddApplication(state.AddApplicationArgs{


### PR DESCRIPTION
Remove a trivial function from the `state` package required in one test the `rpc` package.

## Checklist

NA

## QA steps

NA

## Documentation changes

NA

## Bug reference

NA
