### PR TITLE
[JUJU-1373] Fixes caasadmission tests for kubernetes 1.24+

### DIFF
--- a/tests/suites/caasadmission/task.sh
+++ b/tests/suites/caasadmission/task.sh
@@ -15,7 +15,7 @@ test_caasadmission() {
 		echo "==> Checking for dependencies"
 		check_dependencies petname
 
-		microk8s.config >"${TEST_DIR}"/kube.conf
+		microk8s config >"${TEST_DIR}"/kube.conf
 		export KUBE_CONFIG="${TEST_DIR}"/kube.conf
 
 		test_controller_model_admission


### PR DESCRIPTION
As per title updates tests to work with latest Kubernetes.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run the tests.

## Documentation changes

N/A

## Bug reference

N/A
