### PR TITLE
Fix `test-deploy-test-deploy-revision-lxd`

### DIFF
--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -11,7 +11,7 @@ run_deploy_revision() {
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
 
 	# check resource revision per channel specified.
-	juju resources juju-qa-test --format json | jq -S '.resources[0] | .[ "revision"] == "3"'
+	juju resources juju-qa-test --format json | jq -S '.resources[0] | .[ "revision"] == "1"'
 
 	destroy_model "${model_name}"
 }
@@ -44,7 +44,7 @@ run_deploy_revision_fail() {
 
 	got=$(juju deploy juju-qa-test --revision 9 2>&1 || true)
 	# bad request should be caught by client
-	check_contains "${got}" 'ERROR when using --revision option, you must also use --channel option'
+	check_contains "${got}" 'ERROR specifying a revision requires a channel for future upgrades. Please use --channel'
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
In #13996, the error message was changed, but we forgot to update this test accordingly.

## QA steps

```sh
./main.sh -v -s '"test_cmr_bundles_export_overlay,test_deploy_bundles,test_deploy_charms,test_deploy_os"' deploy test_deploy_revision
```