### PR TITLE
Fix Juju version checking regex.

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -1,11 +1,15 @@
 #!/bin/bash -e
 # juju_version will return only the version and not the architecture/substrate
-# of the juju version.
-# This will use any juju on $PATH
+# of the juju version. If JUJU_VERSION is defined in CI this value will be used
+# otherwise we interrogate the juju binary on path.
 juju_version() {
-	# Match only major, minor, and patch or tag
-	version=$(juju version | grep -oP '^\d+\.\d+(\.\d+|-\w+)')
-	echo "${version}"
+  # Match only major, minor, and patch or tag + build number
+  if [ -n "${JUJU_VERSION:-}" ]; then
+    version=${JUJU_VERSION}
+  else
+    version=$(juju version | grep -oE '^[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+|-\w+){1}(\.[[:digit:]]+)?')
+  fi
+  echo "${version}"
 }
 
 jujud_version() {


### PR DESCRIPTION
Fixed Juju version check regex to also match build number and the
correct number of patch repeats. Also removed the check off of Perl
regex to extended regex.

Added a short circuit that can use JUJU_VERSION from the CI env.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run tests in CI

