### PR TITLE
[JUJU-1376] Close remote model connection when controller info update fails

### DIFF
--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -241,6 +241,9 @@ func (m *mockRelationsFacade) SetRemoteApplicationStatus(applicationName string,
 
 func (m *mockRelationsFacade) UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error {
 	m.stub.MethodCall(m, "UpdateControllerForModel", controller, modelUUID)
+	if err := m.stub.NextErr(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -290,8 +290,10 @@ func (w *remoteApplicationWorker) newRemoteRelationsFacadeWithRedirect() error {
 				CACert:        apiInfo.CACert,
 			}
 
-			err = errors.Annotate(w.localModelFacade.UpdateControllerForModel(controllerInfo, w.remoteModelUUID),
-				"updating external controller info")
+			if err = w.localModelFacade.UpdateControllerForModel(controllerInfo, w.remoteModelUUID); err != nil {
+				_ = w.remoteModelFacade.Close()
+				err = errors.Annotate(err, "updating external controller info")
+			}
 		}
 	}
 


### PR DESCRIPTION
When we get a redirect error from a connection to a remote controller, we use the redirection info for a new connection and then update our information for the remote model.

If this last step fails, we return an error, but do not close the connection we just established.

Here we change the connection logic to ensure that we do close it if an error results from the last step.

## QA steps

Very hard to reproduce. This was observed by interrogation rather than a specific occurrence. Unit test verifies closure upon error.

## Documentation changes

None.

## Bug reference

Peripherally related to https://bugs.launchpad.net/juju/+bug/1979957
