### PR TITLE
Merge 2.9

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -881,7 +881,7 @@ class ModelClient:
 
         args += [
             '--constraints', self._get_substrate_constraints(arch),
-            '--create-model', self.env.environment
+            '--add-model', self.env.environment
         ]
         if force:
             args.extend(['--force'])

--- a/acceptancetests/jujupy/fake.py
+++ b/acceptancetests/jujupy/fake.py
@@ -726,7 +726,7 @@ class FakeBackend:
         parser.add_argument('controller_name')
         parser.add_argument('--constraints')
         parser.add_argument('--config')
-        parser.add_argument('--create-model=default')
+        parser.add_argument('--add-model=default')
         parser.add_argument('--agent-version')
         parser.add_argument('--bootstrap-series')
         parser.add_argument('--upload-tools', action='store_true')

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -357,7 +357,7 @@ class TestModelClient(ClientTest):
                     '--constraints', 'mem=2G spaces=^endpoint-bindings-data,'
                     '^endpoint-bindings-public',
                     'foo/asdf', 'maas',
-                    '--config', config_file.name, '--create-model', 'maas',
+                    '--config', config_file.name, '--add-model', 'maas',
                     '--agent-version', '2.0'),
                 include_e=False)
 
@@ -374,7 +374,7 @@ class TestModelClient(ClientTest):
                 'bootstrap', (
                     '--constraints', 'mem=2G',
                     'foo/asdf', 'maas',
-                    '--config', config_file.name, '--create-model', 'maas',
+                    '--config', config_file.name, '--add-model', 'maas',
                     '--agent-version', '2.0'),
                 include_e=False)
 
@@ -388,7 +388,7 @@ class TestModelClient(ClientTest):
                     'bootstrap', ('--constraints', 'mem=2G',
                                   'bar/baz', 'foo',
                                   '--config', config_file.name,
-                                  '--create-model', 'foo',
+                                  '--add-model', 'foo',
                                   '--agent-version', '2.0'), include_e=False)
                 config_file.seek(0)
                 config = yaml.safe_load(config_file)
@@ -405,7 +405,7 @@ class TestModelClient(ClientTest):
                 '--upload-tools', '--constraints', 'mem=2G',
                 'foo/baz', 'foo',
                 '--config', config_file.name,
-                '--create-model', 'foo'), include_e=False)
+                '--add-model', 'foo'), include_e=False)
 
     def test_bootstrap_credential(self):
         env = JujuData('foo', {'type': 'foo', 'region': 'baz'})
@@ -418,7 +418,7 @@ class TestModelClient(ClientTest):
                 '--constraints', 'mem=2G',
                 'foo/baz', 'foo',
                 '--config', config_file.name,
-                '--create-model', 'foo', '--agent-version', '2.0',
+                '--add-model', 'foo', '--agent-version', '2.0',
                 '--credential', 'credential_name'), include_e=False)
 
     def test_bootstrap_bootstrap_series(self):
@@ -431,7 +431,7 @@ class TestModelClient(ClientTest):
             'bootstrap', (
                 '--constraints', 'mem=2G',
                 'bar/baz', 'foo',
-                '--config', config_file.name, '--create-model', 'foo',
+                '--config', config_file.name, '--add-model', 'foo',
                 '--agent-version', '2.0',
                 '--bootstrap-series', 'angsty'), include_e=False)
 
@@ -445,7 +445,7 @@ class TestModelClient(ClientTest):
             'bootstrap', (
                 '--constraints', 'mem=2G',
                 'bar/baz', 'foo',
-                '--config', config_file.name, '--create-model', 'foo',
+                '--config', config_file.name, '--add-model', 'foo',
                 '--agent-version', '2.0', '--auto-upgrade'), include_e=False)
 
     def test_bootstrap_metadata(self):
@@ -458,7 +458,7 @@ class TestModelClient(ClientTest):
             'bootstrap', (
                 '--constraints', 'mem=2G',
                 'bar/baz', 'foo',
-                '--config', config_file.name, '--create-model', 'foo',
+                '--config', config_file.name, '--add-model', 'foo',
                 '--agent-version', '2.0',
                 '--metadata-source', '/var/test-source'), include_e=False)
 
@@ -470,7 +470,7 @@ class TestModelClient(ClientTest):
             upload_tools=False, config_filename='config')
         self.assertEqual(
             ('--constraints', 'mem=2G', 'bar/baz', 'foo',
-             '--config', 'config', '--create-model', 'foo',
+             '--config', 'config', '--add-model', 'foo',
              '--agent-version', '2.0', '--to', 'zone=fnord'),
             args)
 
@@ -486,7 +486,7 @@ class TestModelClient(ClientTest):
                             '--constraints', 'mem=2G',
                             'bar/baz', 'foo',
                             '--config', config_file.name,
-                            '--create-model', 'foo',
+                            '--add-model', 'foo',
                             '--agent-version', '2.0'), include_e=False)
 
     def test_bootstrap_async_upload_tools(self):
@@ -500,7 +500,7 @@ class TestModelClient(ClientTest):
                             '--upload-tools', '--constraints', 'mem=2G',
                             'bar/baz', 'foo',
                             '--config', config_file.name,
-                            '--create-model', 'foo',
+                            '--add-model', 'foo',
                             ),
                         include_e=False)
 
@@ -513,7 +513,7 @@ class TestModelClient(ClientTest):
         self.assertEqual(args, (
             '--upload-tools', '--constraints', 'mem=2G',
             'bar/baz', 'foo',
-            '--config', 'config', '--create-model', 'foo',
+            '--config', 'config', '--add-model', 'foo',
             '--bootstrap-series', 'angsty'))
 
     def test_get_bootstrap_args_agent_version(self):
@@ -524,7 +524,7 @@ class TestModelClient(ClientTest):
                                          agent_version='2.0-lambda1')
         self.assertEqual(('--constraints', 'mem=2G',
                           'bar/baz', 'foo',
-                          '--config', 'config', '--create-model', 'foo',
+                          '--config', 'config', '--add-model', 'foo',
                           '--agent-version', '2.0-lambda1'), args)
 
     def test_get_bootstrap_args_upload_tools_and_agent_version(self):

--- a/acceptancetests/tests/test_deploy_stack.py
+++ b/acceptancetests/tests/test_deploy_stack.py
@@ -2026,7 +2026,7 @@ class TestBootContext(FakeHomeTestCase):
         assert_juju_call(self, cc_mock, client, (
             'path', '--show-log', 'bootstrap', '--constraints',
             'mem=2G', 'paas/qux', 'bar', '--config', config_file.name,
-            '--create-model', 'bar', '--agent-version', '1.23'), 0)
+            '--add-model', 'bar', '--agent-version', '1.23'), 0)
         assert_juju_call(self, cc_mock, client, (
             'path', '--show-log', 'list-controllers'), 1)
         assert_juju_call(self, cc_mock, client, (
@@ -2050,7 +2050,7 @@ class TestBootContext(FakeHomeTestCase):
         assert_juju_call(self, cc_mock, client, (
             'path', '--show-log', 'bootstrap', '--constraints',
             'mem=2G', 'paas/qux', 'bar', '--config', config_file.name,
-            '--create-model', 'bar', '--agent-version', '1.23'), 0)
+            '--add-model', 'bar', '--agent-version', '1.23'), 0)
         assert_juju_call(self, cc_mock, client, (
             'path', '--show-log', 'list-controllers'), 1)
         assert_juju_call(self, cc_mock, client, (
@@ -2074,7 +2074,7 @@ class TestBootContext(FakeHomeTestCase):
         assert_juju_call(self, cc_mock, client, (
             'path', '--show-log', 'bootstrap', '--upload-tools',
             '--constraints', 'mem=2G', 'paas/qux', 'bar', '--config',
-            config_file.name, '--create-model', 'bar'), 0)
+            config_file.name, '--add-model', 'bar'), 0)
 
     def test_calls_update_env(self):
         cc_mock = self.addContext(patch('subprocess.check_call'))
@@ -2094,7 +2094,7 @@ class TestBootContext(FakeHomeTestCase):
         assert_juju_call(self, cc_mock, client, (
             'path', '--show-log', 'bootstrap', '--constraints', 'mem=2G',
             'paas/qux', 'bar', '--config', config_file.name,
-            '--create-model', 'bar', '--agent-version', '2.3',
+            '--add-model', 'bar', '--agent-version', '2.3',
             '--bootstrap-series', 'wacky'), 0)
 
     def test_with_bootstrap_failure(self):
@@ -2166,7 +2166,7 @@ class TestBootContext(FakeHomeTestCase):
         assert_juju_call(self, cc_mock, client, (
             'path', '--show-log', 'bootstrap', '--constraints',
             'mem=2G', 'paas/qux', 'bar', '--config', config_file.name,
-            '--create-model', 'bar', '--agent-version', '1.23'), 0)
+            '--add-model', 'bar', '--agent-version', '1.23'), 0)
         assert_juju_call(self, cc_mock, client, (
             'path', '--show-log', 'list-controllers'), 1)
         assert_juju_call(self, cc_mock, client, (

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -294,7 +294,7 @@ func (s *applicationSuite) TestCompatibleSettingsParsing(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	ch, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL().String(), gc.Equals, "local:quantal/dummy-1")
+	c.Assert(ch.String(), gc.Equals, "local:quantal/dummy-1")
 
 	// Empty string will be returned as nil.
 	options := map[string]string{
@@ -531,7 +531,7 @@ func (s *applicationSuite) TestApplicationDeploymentRemovesPendingResourcesOnFai
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "haha/borken",
 			NumUnits:        1,
-			CharmURL:        charm.URL().String(),
+			CharmURL:        charm.String(),
 			CharmOrigin:     createCharmOriginFromURL(c, charm.URL()),
 			Resources:       map[string]string{"dummy": pendingID},
 		}},
@@ -559,7 +559,7 @@ func (s *applicationSuite) TestApplicationDeploymentLeavesResourcesOnSuccess(c *
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "unborken",
 			NumUnits:        1,
-			CharmURL:        charm.URL().String(),
+			CharmURL:        charm.String(),
 			CharmOrigin:     createCharmOriginFromURL(c, charm.URL()),
 			Resources:       map[string]string{"dummy": pendingID},
 		}},
@@ -784,7 +784,7 @@ func (s *applicationSuite) TestApplicationSetCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charm.URL().String(), gc.Equals, curl.String())
+	c.Assert(charm.String(), gc.Equals, curl.String())
 	c.Assert(force, jc.IsFalse)
 }
 
@@ -827,7 +827,7 @@ func (s *applicationSuite) assertApplicationSetCharm(c *gc.C, forceUnits bool) {
 	c.Assert(err, jc.ErrorIsNil)
 	charm, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charm.URL().String(), gc.Equals, "cs:~who/precise/wordpress-3")
+	c.Assert(charm.String(), gc.Equals, "cs:~who/precise/wordpress-3")
 }
 
 func (s *applicationSuite) assertApplicationSetCharmBlocked(c *gc.C, msg string) {
@@ -893,7 +893,7 @@ func (s *applicationSuite) TestApplicationSetCharmForceUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	charm, force, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(charm.URL().String(), gc.Equals, curl.String())
+	c.Assert(charm.String(), gc.Equals, curl.String())
 	c.Assert(force, jc.IsTrue)
 }
 
@@ -991,7 +991,7 @@ func (s *applicationSuite) assertApplicationSetCharmSeries(c *gc.C, upgradeCharm
 	c.Assert(err, jc.ErrorIsNil)
 	ch, _, err := app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL().String(), gc.Equals, "cs:~who/"+url+"-0")
+	c.Assert(ch.String(), gc.Equals, "cs:~who/"+url+"-0")
 }
 
 func (s *applicationSuite) TestApplicationSetCharmUnsupportedSeriesForce(c *gc.C) {

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1249,7 +1249,7 @@ func (context *statusContext) processApplication(application *state.Application)
 		series = coreseries.Kubernetes.String()
 	}
 	var processedStatus = params.ApplicationStatus{
-		Charm:            applicationCharm.URL().String(),
+		Charm:            applicationCharm.String(),
 		CharmVersion:     applicationCharm.Version(),
 		CharmProfile:     charmProfileName,
 		CharmChannel:     channel,
@@ -1276,7 +1276,7 @@ func (context *statusContext) processApplication(application *state.Application)
 		if err != nil {
 			return params.ApplicationStatus{Err: apiservererrors.ServerError(err)}
 		}
-		processedStatus.Units = context.processUnits(units, applicationCharm.URL().String(), expectWorkload)
+		processedStatus.Units = context.processUnits(units, applicationCharm.String(), expectWorkload)
 	}
 
 	// If for whatever reason the application isn't yet in the cache,

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -83,6 +83,7 @@ type Machine interface {
 	Destroy() error
 	ForceDestroy(time.Duration) error
 	Series() string
+	Containers() ([]string, error)
 	Units() ([]Unit, error)
 	SetKeepInstance(keepInstance bool) error
 	CreateUpgradeSeriesLock([]string, string) error

--- a/apiserver/facades/client/machinemanager/types_mock_test.go
+++ b/apiserver/facades/client/machinemanager/types_mock_test.go
@@ -72,6 +72,21 @@ func (mr *MockMachineMockRecorder) CompleteUpgradeSeries() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteUpgradeSeries", reflect.TypeOf((*MockMachine)(nil).CompleteUpgradeSeries))
 }
 
+// Containers mocks base method.
+func (m *MockMachine) Containers() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Containers")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Containers indicates an expected call of Containers.
+func (mr *MockMachineMockRecorder) Containers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Containers", reflect.TypeOf((*MockMachine)(nil).Containers))
+}
+
 // CreateUpgradeSeriesLock mocks base method.
 func (m *MockMachine) CreateUpgradeSeriesLock(arg0 []string, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -26434,6 +26434,12 @@
                 "DestroyMachineInfo": {
                     "type": "object",
                     "properties": {
+                        "destroyed-containers": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyMachineResult"
+                            }
+                        },
                         "destroyed-storage": {
                             "type": "array",
                             "items": {
@@ -26451,9 +26457,15 @@
                             "items": {
                                 "$ref": "#/definitions/Entity"
                             }
+                        },
+                        "machine-id": {
+                            "type": "string"
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-id"
+                    ]
                 },
                 "DestroyMachineResult": {
                     "type": "object",

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -316,7 +316,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.config, "config", "Specify a controller configuration file, or one or more configuration\n    options\n    (--config config.yaml [--config key=value ...])")
 	f.Var(&c.modelDefaults, "model-default", "Specify a configuration file, or one or more configuration\n    options to be set for all models, unless otherwise specified\n    (--model-default config.yaml [--model-default key=value ...])")
 	f.Var(&c.storagePool, "storage-pool", "Specify options for an initial storage pool\n    'name' and 'type' are required, plus any additional attributes\n    (--storage-pool pool-config.yaml [--storage-pool key=value ...])")
-	f.StringVar(&c.initialModelName, "create-model", "", "Name of an initial model to create on the new controller")
+	f.StringVar(&c.initialModelName, "add-model", "", "Name of an initial model to create on the new controller")
 	f.BoolVar(&c.showClouds, "clouds", false, "Print the available clouds which can be used to bootstrap a Juju environment")
 	f.StringVar(&c.showRegionsForCloud, "regions", "", "Print the available regions for the specified cloud")
 	f.BoolVar(&c.noSwitch, "no-switch", false, "Do not switch to the newly created controller")

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -453,8 +453,8 @@ var bootstrapTests = []bootstrapTest{{
 	args: []string{"--config", "controller-name=test"},
 	err:  `controller name cannot be set via config, please use cmd args`,
 }, {
-	info: "resource-group-name does not support create-model",
-	args: []string{"--config", "resource-group-name=foo", "--create-model", "foo"},
+	info: "resource-group-name does not support add-model",
+	args: []string{"--config", "resource-group-name=foo", "--add-model", "foo"},
 	err:  `if using resource-group-name "foo" then a workload model cannot be specified as well`,
 }, {
 	info: "missing storage pool name",
@@ -550,7 +550,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultControllerNameNoRegions(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModelWithCaps(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "xenial")
 
-	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "DevController", "--auto-upgrade", "--create-model", "workload")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "DevController", "--auto-upgrade", "--add-model", "workload")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
 	c.Assert(currentController, gc.Equals, "devcontroller")
@@ -565,7 +565,7 @@ func (s *BootstrapSuite) TestBootstrapSetsCurrentModelWithCaps(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapSetsCurrentModel(c *gc.C) {
 	s.setupAutoUploadTest(c, "1.8.3", "xenial")
 
-	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade", "--create-model", "workload")
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "devcontroller", "--auto-upgrade", "--add-model", "workload")
 	c.Assert(err, jc.ErrorIsNil)
 	currentController := s.store.CurrentControllerName
 	c.Assert(currentController, gc.Equals, "devcontroller")
@@ -639,7 +639,7 @@ func (s *BootstrapSuite) TestBootstrapWithWorkloadModel(c *gc.C) {
 		c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 		"--auto-upgrade",
-		"--create-model", "mymodel",
+		"--add-model", "mymodel",
 		"--config", "foo=bar",
 	)
 	c.Assert(utils.IsValidUUIDString(bootstrapFuncs.args.ControllerConfig.ControllerUUID()), jc.IsTrue)
@@ -728,7 +728,7 @@ func (s *BootstrapSuite) TestBootstrapModelDefaultConfig(c *gc.C) {
 	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
-		"--create-model", "workload",
+		"--add-model", "workload",
 		"--model-default", "network=foo",
 		"--model-default", "ftp-proxy=model-proxy",
 		"--config", "ftp-proxy=controller-proxy",

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -102,10 +102,11 @@ func (s *RemoveMachineSuite) TestRemoveNoWaitWithoutForce(c *gc.C) {
 func (s *RemoveMachineSuite) TestRemoveOutput(c *gc.C) {
 	s.fake.results = []params.DestroyMachineResult{{
 		Error: &params.Error{
-			Message: "oy vey",
+			Message: "oy vey machine 1",
 		},
 	}, {
 		Info: &params.DestroyMachineInfo{
+			MachineId:        "2/lxd/1",
 			DestroyedUnits:   []params.Entity{{"unit-foo-0"}},
 			DestroyedStorage: []params.Entity{{"storage-bar-1"}},
 			DetachedStorage:  []params.Entity{{"storage-baz-2"}},
@@ -115,7 +116,7 @@ func (s *RemoveMachineSuite) TestRemoveOutput(c *gc.C) {
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-removing machine 1 failed: oy vey
+removing machine failed: oy vey machine 1
 removing machine 2/lxd/1
 - will remove unit foo/0
 - will remove storage bar/1
@@ -147,6 +148,40 @@ func (s *RemoveMachineSuite) TestRemoveKeep(c *gc.C) {
 	c.Assert(s.fake.forced, jc.IsFalse)
 	c.Assert(s.fake.keep, jc.IsTrue)
 	c.Assert(s.fake.machines, jc.DeepEquals, []string{"1", "2"})
+}
+
+func (s *RemoveMachineSuite) TestRemoveWithContainers(c *gc.C) {
+	s.fake.results = []params.DestroyMachineResult{{
+		Info: &params.DestroyMachineInfo{
+			MachineId:        "1",
+			DestroyedUnits:   []params.Entity{{"unit-foo-0"}},
+			DestroyedStorage: []params.Entity{{"storage-bar-1"}},
+			DetachedStorage:  []params.Entity{{"storage-baz-2"}},
+			DestroyedContainers: []params.DestroyMachineResult{{
+				Info: &params.DestroyMachineInfo{
+					MachineId:        "1/lxd/2",
+					DestroyedUnits:   []params.Entity{{"unit-foo-1"}},
+					DestroyedStorage: []params.Entity{{"storage-bar-2"}},
+					DetachedStorage:  []params.Entity{{"storage-baz-3"}},
+				},
+			}},
+		},
+	}}
+
+	ctx, err := s.run(c, "--force", "1")
+	c.Assert(err, jc.ErrorIsNil)
+	stderr := cmdtesting.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `
+removing machine 1/lxd/2
+- will remove unit foo/1
+- will remove storage bar/2
+- will detach storage baz/3
+
+removing machine 1
+- will remove unit foo/0
+- will remove storage bar/1
+- will detach storage baz/2
+`[1:])
 }
 
 func (s *RemoveMachineSuite) TestBlockedError(c *gc.C) {
@@ -184,7 +219,7 @@ func (f *fakeRemoveMachineAPI) DestroyMachinesWithParams(force, keep bool, maxWa
 	}
 	results := make([]params.DestroyMachineResult, len(machines))
 	for i := range results {
-		results[i].Info = &params.DestroyMachineInfo{}
+		results[i].Info = &params.DestroyMachineInfo{MachineId: machines[i]}
 	}
 	return results, nil
 }

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1205,6 +1205,9 @@ type DestroyMachineResult struct {
 // DestroyMachineInfo contains information related to the removal of
 // a machine.
 type DestroyMachineInfo struct {
+	// MachineId is the ID if the machine that will be destroyed
+	MachineId string `json:"machine-id"`
+
 	// DetachedStorage is the tags of storage instances that will be
 	// detached from the machine (assigned units) as a result of
 	// destroying the machine, and will remain in the model after
@@ -1215,9 +1218,13 @@ type DestroyMachineInfo struct {
 	// destroyed as a result of destroying the machine.
 	DestroyedStorage []Entity `json:"destroyed-storage,omitempty"`
 
-	// DestroyedStorage is the tags of units that will be destroyed
+	// DestroyedUnits are the tags of units that will be destroyed
 	// as a result of destroying the machine.
 	DestroyedUnits []Entity `json:"destroyed-units,omitempty"`
+
+	// DestroyedContainers are the results of the destroyed containers hosted
+	// on a machine, destroyed as a result of destroying the machine
+	DestroyedContainers []DestroyMachineResult `json:"destroyed-containers,omitempty"`
 }
 
 // DestroyUnitResults contains the results of a DestroyUnit API request.

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -792,7 +792,7 @@ func (ch *backingCharm) updated(ctx *allWatcherContext) error {
 	allWatcherLogger.Tracef(`charm "%s:%s" updated`, ctx.modelUUID, ctx.id)
 	info := &multiwatcher.CharmInfo{
 		ModelUUID:    ch.ModelUUID,
-		CharmURL:     ch.URL.String(),
+		CharmURL:     *ch.URL,
 		CharmVersion: ch.CharmVersion,
 		Life:         life.Value(ch.Life.String()),
 	}

--- a/state/allwatcher_internal_test.go
+++ b/state/allwatcher_internal_test.go
@@ -2485,12 +2485,12 @@ func testChangeCharms(c *gc.C, owner names.UserTag, runChangeTests func(*gc.C, [
 				about: "charm is added if it's in backing but not in Store",
 				change: watcher.Change{
 					C:  "charms",
-					Id: st.docID(ch.URL().String()),
+					Id: st.docID(ch.String()),
 				},
 				expectContents: []multiwatcher.EntityInfo{
 					&multiwatcher.CharmInfo{
 						ModelUUID:     st.ModelUUID(),
-						CharmURL:      ch.URL().String(),
+						CharmURL:      ch.String(),
 						Life:          life.Alive,
 						DefaultConfig: map[string]interface{}{"blog-title": "My Title"},
 					}}}

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -84,7 +84,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, s.charm.URL())
 	c.Assert(force, jc.IsFalse)
 	url, force := s.mysql.CharmURL()
-	c.Assert(*url, gc.DeepEquals, s.charm.URL().String())
+	c.Assert(*url, gc.DeepEquals, s.charm.String())
 	c.Assert(force, jc.IsFalse)
 
 	// Add a compatible charm and force it.
@@ -101,7 +101,7 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = s.mysql.CharmURL()
-	c.Assert(*url, gc.DeepEquals, sch.URL().String())
+	c.Assert(*url, gc.DeepEquals, sch.String())
 	c.Assert(force, jc.IsTrue)
 }
 
@@ -180,7 +180,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, charm.URL().String())
+	c.Assert(*url, gc.DeepEquals, charm.String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile", lxdProfileMetaBase, 2)
@@ -196,7 +196,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, sch.URL().String())
+	c.Assert(*url, gc.DeepEquals, sch.String())
 	c.Assert(force, jc.IsTrue)
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 }
@@ -214,7 +214,7 @@ func (s *ApplicationSuite) TestLXDProfileFailSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, charm.URL().String())
+	c.Assert(*url, gc.DeepEquals, charm.String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile-fail", lxdProfileMetaBase, 2)
@@ -240,7 +240,7 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 
 	url, force := app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, charm.URL().String())
+	c.Assert(*url, gc.DeepEquals, charm.String())
 	c.Assert(force, jc.IsFalse)
 
 	sch := s.AddMetaCharm(c, "lxd-profile-fail", lxdProfileMetaBase, 2)
@@ -257,7 +257,7 @@ func (s *ApplicationSuite) TestLXDProfileFailWithForceSetCharm(c *gc.C) {
 	c.Assert(ch.URL(), gc.DeepEquals, sch.URL())
 	c.Assert(force, jc.IsTrue)
 	url, force = app.CharmURL()
-	c.Assert(*url, gc.DeepEquals, sch.URL().String())
+	c.Assert(*url, gc.DeepEquals, sch.String())
 	c.Assert(force, jc.IsTrue)
 	c.Assert(charm.LXDProfile(), gc.DeepEquals, ch.LXDProfile())
 }
@@ -674,7 +674,7 @@ func (s *ApplicationSuite) TestClientApplicationSetCharmUnsupportedSeriesForce(c
 	c.Assert(err, jc.ErrorIsNil)
 	ch, _, err = app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.URL().String(), gc.Equals, "cs:multi-series2-8")
+	c.Assert(ch.String(), gc.Equals, "cs:multi-series2-8")
 }
 
 func (s *ApplicationSuite) TestClientApplicationSetCharmWrongOS(c *gc.C) {
@@ -1921,13 +1921,13 @@ func (s *ApplicationSuite) TestUpdateApplicationSeriesSecondSubordinateIncompati
 }
 
 func assertNoSettingsRef(c *gc.C, st *state.State, appName string, sch *state.Charm) {
-	cURL := sch.URL().String()
+	cURL := sch.String()
 	_, err := state.ApplicationSettingsRefCount(st, appName, &cURL)
 	c.Assert(errors.Cause(err), jc.Satisfies, errors.IsNotFound)
 }
 
 func assertSettingsRef(c *gc.C, st *state.State, appName string, sch *state.Charm, refcount int) {
-	cURL := sch.URL().String()
+	cURL := sch.String()
 	rc, err := state.ApplicationSettingsRefCount(st, appName, &cURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rc, gc.Equals, refcount)

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -78,7 +78,7 @@ func (s *CharmSuite) TestDyingCharm(c *gc.C) {
 func (s *CharmSuite) testCharm(c *gc.C) {
 	dummy, err := s.State.Charm(s.curl)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.URL().String(), gc.Equals, s.curl.String())
+	c.Assert(dummy.String(), gc.Equals, s.curl.String())
 	c.Assert(dummy.Revision(), gc.Equals, 1)
 	c.Assert(dummy.StoragePath(), gc.Equals, "dummy-path")
 	c.Assert(dummy.BundleSha256(), gc.Equals, "quantal-dummy-1-sha256")
@@ -295,13 +295,13 @@ func (s *CharmSuite) TestAddCharm(c *gc.C) {
 	info := s.dummyCharm(c, "")
 	dummy, err := s.State.AddCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.URL().String(), gc.Equals, info.ID.String())
+	c.Assert(dummy.String(), gc.Equals, info.ID.String())
 
 	doc := state.CharmDoc{}
 	err = s.charms.FindId(state.DocID(s.State, info.ID.String())).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("%#v", doc)
-	c.Assert(doc.URL, gc.DeepEquals, info.ID)
+	c.Assert(*doc.URL, gc.DeepEquals, info.ID.String())
 
 	expVersion := "dummy-146-g725cfd3-dirty"
 	c.Assert(doc.CharmVersion, gc.Equals, expVersion)
@@ -339,14 +339,14 @@ func (s *CharmSuite) TestAddCharmUpdatesPlaceholder(c *gc.C) {
 	}
 	dummy, err := s.State.AddCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dummy.URL().String(), gc.Equals, curl.String())
+	c.Assert(dummy.String(), gc.Equals, curl.String())
 
 	// Charm doc has been updated.
 	var docs []state.CharmDoc
 	err = s.charms.FindId(state.DocID(s.State, curl.String())).All(&docs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(docs, gc.HasLen, 1)
-	c.Assert(docs[0].URL, gc.DeepEquals, curl)
+	c.Assert(*docs[0].URL, gc.DeepEquals, curl.String())
 	c.Assert(docs[0].StoragePath, gc.DeepEquals, info.StoragePath)
 
 	// No more placeholder charm.
@@ -361,7 +361,7 @@ func (s *CharmSuite) assertPendingCharmExists(c *gc.C, curl *charm.URL) {
 	err := s.charms.FindId(state.DocID(s.State, curl.String())).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("%#v", doc)
-	c.Assert(doc.URL, gc.DeepEquals, curl)
+	c.Assert(*doc.URL, gc.DeepEquals, curl.String())
 	c.Assert(doc.PendingUpload, jc.IsTrue)
 	c.Assert(doc.Placeholder, jc.IsFalse)
 	c.Assert(doc.Meta, gc.IsNil)
@@ -456,6 +456,8 @@ func (s *CharmSuite) TestPrepareCharmUpload(c *gc.C) {
 	// Try adding it again with the same revision and ensure we get the same document.
 	schCopy, err := s.State.PrepareCharmUpload(testCurl)
 	c.Assert(err, jc.ErrorIsNil)
+	// URL is required to set the charmURL, so the test will succeed.
+	_ = schCopy.URL()
 	c.Assert(sch, jc.DeepEquals, schCopy)
 
 	// Now add a charm and try again - we should get the same result
@@ -561,7 +563,7 @@ func (s *CharmSuite) assertPlaceholderCharmExists(c *gc.C, curl *charm.URL) {
 	doc := state.CharmDoc{}
 	err := s.charms.FindId(state.DocID(s.State, curl.String())).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(doc.URL, gc.DeepEquals, curl)
+	c.Assert(*doc.URL, gc.DeepEquals, curl.String())
 	c.Assert(doc.PendingUpload, jc.IsFalse)
 	c.Assert(doc.Placeholder, jc.IsTrue)
 	c.Assert(doc.Meta, gc.IsNil)
@@ -699,7 +701,7 @@ func (s *CharmSuite) TestAllCharms(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charms, gc.HasLen, 3)
 
-	c.Assert(charms[0].URL().String(), gc.Equals, "local:quantal/quantal-dummy-1")
+	c.Assert(charms[0].String(), gc.Equals, "local:quantal/quantal-dummy-1")
 	c.Assert(charms[1], gc.DeepEquals, sch)
 	c.Assert(charms[2].URL(), gc.DeepEquals, curl2)
 }

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"github.com/juju/charm/v9"
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2/txn"
 )
@@ -49,11 +48,7 @@ func appCharmIncRefOps(mb modelBackend, appName string, cURL *string, canCreate 
 	if err != nil {
 		return nil, errors.Annotate(err, "storage constraints reference")
 	}
-	curl, err := charm.ParseURL(*cURL)
-	if err != nil {
-		return nil, errors.Annotate(err, "parsing charm url")
-	}
-	charmKey := charmGlobalKey(curl)
+	charmKey := charmGlobalKey(cURL)
 	charmOp, err := getIncRefOp(refcounts, charmKey, 1)
 	if err != nil {
 		return nil, errors.Annotate(err, "charm reference")
@@ -81,11 +76,7 @@ func appCharmDecRefOps(st modelBackend, appName string, cURL *string, maybeDoFin
 		return nil, errors.Trace(e)
 	}
 	ops := []txn.Op{}
-	curl, err := charm.ParseURL(*cURL)
-	if op.FatalError(err) {
-		return fail(errors.Annotate(err, "charm url parsing"))
-	}
-	charmKey := charmGlobalKey(curl)
+	charmKey := charmGlobalKey(cURL)
 	charmOp, err := nsRefcounts.AliveDecRefOp(refcounts, charmKey)
 	if op.FatalError(err) {
 		return fail(errors.Annotate(err, "charm reference"))
@@ -144,13 +135,15 @@ func finalAppCharmRemoveOps(appName string, curl *string) []txn.Op {
 }
 
 // charmDestroyOps implements the logic of charm.Destroy.
-func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
+func charmDestroyOps(st modelBackend, curl string) ([]txn.Op, error) {
+	if curl == "" {
+		return nil, errors.BadRequestf("curl is empty")
+	}
 	db := st.db()
 	charms, cCloser := db.GetCollection(charmsC)
 	defer cCloser()
 
-	charmKey := curl.String()
-	charmOp, err := nsLife.destroyOp(charms, charmKey, nil)
+	charmOp, err := nsLife.destroyOp(charms, curl, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "charm")
 	}
@@ -158,7 +151,7 @@ func charmDestroyOps(st modelBackend, curl *charm.URL) ([]txn.Op, error) {
 	refcounts, rCloser := db.GetCollection(refcountsC)
 	defer rCloser()
 
-	refcountKey := charmGlobalKey(curl)
+	refcountKey := charmGlobalKey(&curl)
 	refcountOp, err := nsRefcounts.RemoveOp(refcounts, refcountKey, 0)
 	switch errors.Cause(err) {
 	case nil:

--- a/state/state.go
+++ b/state/state.go
@@ -1228,7 +1228,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 
 	// The doc defaults to CharmModifiedVersion = 0, which is correct, since it
 	// has, by definition, at its initial state.
-	cURL := args.Charm.URL().String()
+	cURL := args.Charm.String()
 	appDoc := &applicationDoc{
 		DocID:         applicationID,
 		Name:          args.Name,
@@ -2148,7 +2148,7 @@ func (st *State) AddRelation(eps ...Endpoint) (r *Relation, err error) {
 				ops = append(ops, txn.Op{
 					C:      applicationsC,
 					Id:     st.docID(ep.ApplicationName),
-					Assert: bson.D{{"life", Alive}, {"charmurl", ch.URL()}},
+					Assert: bson.D{{"life", Alive}, {"charmurl", ch.String()}},
 					Update: bson.D{{"$inc", bson.D{{"relationcount", 1}}}},
 				})
 			}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -3349,6 +3349,9 @@ func (s *StateSuite) TestAddAndGetEquivalence(c *gc.C) {
 	charm1 := s.AddTestingCharm(c, "wordpress")
 	charm2, err := s.State.Charm(charm1.URL())
 	c.Assert(err, jc.ErrorIsNil)
+	// Refresh is required to set the charmURL, so the test will succeed.
+	err = charm2.Refresh()
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(charm1, jc.DeepEquals, charm2)
 
 	wordpress1 := s.AddTestingApplication(c, "wordpress", charm1)

--- a/state/unit.go
+++ b/state/unit.go
@@ -1588,7 +1588,7 @@ func (u *Unit) assertCharmOps(ch *Charm) []txn.Op {
 		ops = append(ops, txn.Op{
 			C:      applicationsC,
 			Id:     appName,
-			Assert: bson.D{{"charmurl", ch.URL()}},
+			Assert: bson.D{{"charmurl", ch.String()}},
 		})
 	}
 	return ops

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1489,7 +1489,7 @@ func RemoveInvalidCharmPlaceholders(pool *StatePool) error {
 		iter := charms.Find(stillPlaceholder).Iter()
 		var cDoc charmDoc
 		for iter.Next(&cDoc) {
-			docs[cDoc.URL.String()] = cDoc.DocID
+			docs[*cDoc.URL] = cDoc.DocID
 		}
 
 		if err := iter.Close(); err != nil {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -249,7 +249,7 @@ juju_bootstrap() {
 
 	pre_bootstrap
 
-	command="juju bootstrap ${series} ${model_default_series} ${cloud_region} ${name} --create-model ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${series} ${model_default_series} ${cloud_region} ${name} --add-model ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"

--- a/tests/suites/bootstrap/streams.sh
+++ b/tests/suites/bootstrap/streams.sh
@@ -32,7 +32,7 @@ run_simplestream_metadata() {
 		--show-log \
 		--config agent-metadata-url="http://${server_address}:8666/" \
 		--config test-mode=true \
-		--create-model=default \
+		--add-model=default \
 		--bootstrap-series="${BOOTSTRAP_SERIES}" \
 		--agent-version="${JUJUD_VERSION}" 2>&1 | OUTPUT "${file}"
 	echo "${name}" >>"${TEST_DIR}/jujus"

--- a/worker/caasoperator/download.go
+++ b/worker/caasoperator/download.go
@@ -28,6 +28,10 @@ func (c *charmInfo) URL() *charm.URL {
 	return c.curl
 }
 
+func (c *charmInfo) String() string {
+	return c.curl.String()
+}
+
 func (c *charmInfo) ArchiveSha256() (string, error) {
 	return c.sha256, nil
 }

--- a/worker/metrics/collect/handler_test.go
+++ b/worker/metrics/collect/handler_test.go
@@ -232,9 +232,9 @@ type mockReadCharm struct {
 	testing.Stub
 }
 
-func (m *mockReadCharm) ReadCharm(unitTag names.UnitTag, paths context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
+func (m *mockReadCharm) ReadCharm(unitTag names.UnitTag, paths context.Paths) (string, map[string]corecharm.Metric, error) {
 	m.MethodCall(m, "ReadCharm", unitTag, paths)
-	return corecharm.MustParseURL("local:trusty/metered-1"),
+	return "local:trusty/metered-1",
 		map[string]corecharm.Metric{
 			"pings":      {Description: "test metric", Type: corecharm.MetricTypeAbsolute},
 			"juju-units": {},

--- a/worker/metrics/collect/manifold_test.go
+++ b/worker/metrics/collect/manifold_test.go
@@ -106,8 +106,8 @@ func (s *ManifoldSuite) TestCollectWorkerStarts(c *gc.C) {
 			}, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:ubuntu-1"), map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:ubuntu-1", map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
 		})
 	worker, err := s.manifold.Start(s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)
@@ -125,8 +125,8 @@ func (s *ManifoldSuite) TestCollectWorkerErrorStopsListener(c *gc.C) {
 	listener := &mockListener{}
 	s.PatchValue(collect.NewSocketListener, collect.NewSocketListenerFnc(listener))
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("local:ubuntu-1"), map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "local:ubuntu-1", map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
 		})
 	worker, err := s.manifold.Start(s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)
@@ -163,8 +163,8 @@ func (s *ManifoldSuite) TestRecordMetricsError(c *gc.C) {
 			return &errorRecorder{recorder}, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:wordpress-37"), nil, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:wordpress-37", nil, nil
 		})
 	collectEntity, err := collect.NewCollect(s.manifoldConfig, s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)
@@ -185,8 +185,8 @@ func (s *ManifoldSuite) TestJujuUnitsBuiltinMetric(c *gc.C) {
 			return recorder, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:wordpress-37"), map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:wordpress-37", map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
 		})
 	collectEntity, err := collect.NewCollect(s.manifoldConfig, s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)
@@ -213,8 +213,8 @@ func (s *ManifoldSuite) TestAvailability(c *gc.C) {
 			return recorder, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:wordpress-37"), map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:wordpress-37", map[string]corecharm.Metric{"pings": {Description: "test metric", Type: corecharm.MetricTypeAbsolute}}, nil
 		})
 	charmdir := &dummyCharmdir{}
 	s.resources["charmdir-name"] = dt.NewStubResource(charmdir)
@@ -248,8 +248,8 @@ func (s *ManifoldSuite) TestNoMetricsDeclared(c *gc.C) {
 			return recorder, nil
 		})
 	s.PatchValue(collect.ReadCharm,
-		func(_ names.UnitTag, _ context.Paths) (*corecharm.URL, map[string]corecharm.Metric, error) {
-			return corecharm.MustParseURL("cs:wordpress-37"), map[string]corecharm.Metric{}, nil
+		func(_ names.UnitTag, _ context.Paths) (string, map[string]corecharm.Metric, error) {
+			return "cs:wordpress-37", map[string]corecharm.Metric{}, nil
 		})
 	collectEntity, err := collect.NewCollect(s.manifoldConfig, s.resources.Context())
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -241,6 +241,9 @@ func (m *mockRelationsFacade) SetRemoteApplicationStatus(applicationName string,
 
 func (m *mockRelationsFacade) UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error {
 	m.stub.MethodCall(m, "UpdateControllerForModel", controller, modelUUID)
+	if err := m.stub.NextErr(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -290,8 +290,10 @@ func (w *remoteApplicationWorker) newRemoteRelationsFacadeWithRedirect() error {
 				CACert:        apiInfo.CACert,
 			}
 
-			err = errors.Annotate(w.localModelFacade.UpdateControllerForModel(controllerInfo, w.remoteModelUUID),
-				"updating external controller info")
+			if err = w.localModelFacade.UpdateControllerForModel(controllerInfo, w.remoteModelUUID); err != nil {
+				_ = w.remoteModelFacade.Close()
+				err = errors.Annotate(err, "updating external controller info")
+			}
 		}
 	}
 

--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -64,7 +64,7 @@ func (d *BundlesDir) Read(info BundleInfo, abort <-chan struct{}) (Bundle, error
 // download will be stopped.
 func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struct{}) (err error) {
 	// First download...
-	curl, err := url.Parse(info.URL().String())
+	curl, err := url.Parse(info.String())
 	if err != nil {
 		return errors.Annotate(err, "could not parse charm URL")
 	}
@@ -75,10 +75,10 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 		Verify:    downloader.NewSha256Verifier(expectedSha256),
 		Abort:     abort,
 	}
-	d.logger.Infof("downloading %s from API server", info.URL())
+	d.logger.Infof("downloading %s from API server", info.String())
 	filename, err := d.downloader.Download(req)
 	if err != nil {
-		return errors.Annotatef(err, "failed to download charm %q from API server", info.URL())
+		return errors.Annotatef(err, "failed to download charm %q from API server", info.String())
 	}
 	defer errors.DeferredAnnotatef(&err, "downloaded but failed to copy charm to %q from %q", target, filename)
 
@@ -95,13 +95,13 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 // bundlePath returns the path to the location where the verified charm
 // bundle identified by info will be, or has been, saved.
 func (d *BundlesDir) bundlePath(info BundleInfo) string {
-	return d.bundleURLPath(info.URL())
+	return d.bundleURLPath(info.String())
 }
 
 // bundleURLPath returns the path to the location where the verified charm
 // bundle identified by url will be, or has been, saved.
-func (d *BundlesDir) bundleURLPath(url *charm.URL) string {
-	return path.Join(d.path, charm.Quote(url.String()))
+func (d *BundlesDir) bundleURLPath(url string) string {
+	return path.Join(d.path, charm.Quote(url))
 }
 
 // ClearDownloads removes any entries in the temporary bundle download

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -83,13 +83,13 @@ func (s *BundlesDirSuite) AddCharm(c *gc.C) (charm.BundleInfo, *state.Charm) {
 
 type fakeBundleInfo struct {
 	charm.BundleInfo
-	curl   *corecharm.URL
+	curl   string
 	sha256 string
 }
 
-func (f fakeBundleInfo) URL() *corecharm.URL {
-	if f.curl == nil {
-		return f.BundleInfo.URL()
+func (f fakeBundleInfo) String() string {
+	if f.curl == "" {
+		return f.BundleInfo.String()
 	}
 	return f.curl
 }
@@ -121,13 +121,12 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 	apiCharm, sch := s.AddCharm(c)
 
 	// Try to get the charm when the content doesn't match.
-	_, err = d.Read(&fakeBundleInfo{apiCharm, nil, "..."}, nil)
+	_, err = d.Read(&fakeBundleInfo{apiCharm, "", "..."}, nil)
 	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/dummy-1" from API server: `)+`expected sha256 "...", got ".*"`)
 	checkDownloadsEmpty()
 
 	// Try to get a charm whose bundle doesn't exist.
-	otherURL := corecharm.MustParseURL("cs:quantal/spam-1")
-	_, err = d.Read(&fakeBundleInfo{apiCharm, otherURL, ""}, nil)
+	_, err = d.Read(&fakeBundleInfo{apiCharm, "cs:quantal/spam-1", ""}, nil)
 	c.Check(err, gc.ErrorMatches, regexp.QuoteMeta(`failed to download charm "cs:quantal/spam-1" from API server: `)+`.* not found`)
 	checkDownloadsEmpty()
 

--- a/worker/uniter/charm/charm.go
+++ b/worker/uniter/charm/charm.go
@@ -6,7 +6,6 @@ package charm
 import (
 	"errors"
 
-	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/utils/v3"
 )
@@ -38,8 +37,8 @@ type Bundle interface {
 // BundleInfo describes a Bundle.
 type BundleInfo interface {
 
-	// URL returns the charm URL identifying the bundle.
-	URL() *charm.URL
+	// String return the charm URL as a string.
+	String() string
 
 	// ArchiveSha256 returns the hex-encoded SHA-256 digest of the bundle data.
 	ArchiveSha256() (string, error)
@@ -84,15 +83,15 @@ type Logger interface {
 var ErrConflict = errors.New("charm upgrade has conflicts")
 
 // ReadCharmURL reads a charm identity file from the supplied path.
-func ReadCharmURL(path string) (*charm.URL, error) {
+func ReadCharmURL(path string) (string, error) {
 	surl := ""
 	if err := utils.ReadYaml(path, &surl); err != nil {
-		return nil, err
+		return "", err
 	}
-	return charm.ParseURL(surl)
+	return surl, nil
 }
 
 // WriteCharmURL writes a charm identity file into the supplied path.
-func WriteCharmURL(path string, url *charm.URL) error {
-	return utils.WriteYaml(path, url.String())
+func WriteCharmURL(path string, url string) error {
+	return utils.WriteYaml(path, url)
 }

--- a/worker/uniter/charm/manifest_deployer.go
+++ b/worker/uniter/charm/manifest_deployer.go
@@ -51,7 +51,7 @@ type manifestDeployer struct {
 	bundles   BundleReader
 	logger    Logger
 	staged    struct {
-		url      *charm.URL
+		url      string
 		bundle   Bundle
 		manifest set.Strings
 	}
@@ -71,7 +71,7 @@ func (d *manifestDeployer) Stage(info BundleInfo, abort <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	url := info.URL()
+	url := info.String()
 	if err := d.storeManifest(url, manifest); err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (d *manifestDeployer) Stage(info BundleInfo, abort <-chan struct{}) error {
 }
 
 func (d *manifestDeployer) Deploy() (err error) {
-	if d.staged.url == nil {
+	if d.staged.url == "" {
 		return fmt.Errorf("charm deployment failed: no charm set")
 	}
 
@@ -91,7 +91,7 @@ func (d *manifestDeployer) Deploy() (err error) {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	upgrading := baseURL != nil
+	upgrading := baseURL != ""
 	defer func(err *error) {
 		if *err != nil {
 			if upgrading {
@@ -180,7 +180,7 @@ func (d *manifestDeployer) ensureBaseFiles(baseManifest set.Strings) error {
 	deployingURL, deployingManifest, err := d.loadManifest(deployingURLPath)
 	if err == nil {
 		d.logger.Infof("detected interrupted deploy of charm %q", deployingURL)
-		if *deployingURL != *d.staged.url {
+		if deployingURL != d.staged.url {
 			d.logger.Infof("removing files from charm %q", deployingURL)
 			if err := d.removeDiff(deployingManifest, baseManifest); err != nil {
 				return err
@@ -194,23 +194,23 @@ func (d *manifestDeployer) ensureBaseFiles(baseManifest set.Strings) error {
 }
 
 // storeManifest stores, into dataPath, the supplied manifest for the supplied charm.
-func (d *manifestDeployer) storeManifest(url *charm.URL, manifest set.Strings) error {
+func (d *manifestDeployer) storeManifest(url string, manifest set.Strings) error {
 	if err := os.MkdirAll(d.DataPath(manifestsDataPath), 0755); err != nil {
 		return err
 	}
-	name := charm.Quote(url.String())
+	name := charm.Quote(url)
 	path := filepath.Join(d.DataPath(manifestsDataPath), name)
 	return utils.WriteYaml(path, manifest.SortedValues())
 }
 
 // loadManifest loads, from dataPath, the manifest for the charm identified by the
 // identity file at the supplied path within the charm directory.
-func (d *manifestDeployer) loadManifest(urlFilePath string) (*charm.URL, set.Strings, error) {
+func (d *manifestDeployer) loadManifest(urlFilePath string) (string, set.Strings, error) {
 	url, err := ReadCharmURL(d.CharmPath(urlFilePath))
 	if err != nil {
-		return nil, nil, err
+		return "", nil, err
 	}
-	name := charm.Quote(url.String())
+	name := charm.Quote(url)
 	path := filepath.Join(d.DataPath(manifestsDataPath), name)
 	manifest := []string{}
 	err = utils.ReadYaml(path, &manifest)
@@ -267,8 +267,8 @@ func (rbr RetryingBundleReader) Read(bi BundleInfo, abort <-chan struct{}) (Bund
 		// If the charm is still not available something went wrong.
 		// Report a NotFound error instead
 		if errors.IsNotYetAvailable(fetchErr) {
-			rbr.Logger.Errorf("exceeded max retry attempts while waiting for blob data for %q to become available", bi.URL().String())
-			fetchErr = errors.NotFoundf("blob data for %q", bi.URL().String())
+			rbr.Logger.Errorf("exceeded max retry attempts while waiting for blob data for %q to become available", bi.String())
+			fetchErr = errors.NotFoundf("blob data for %q", bi.String())
 		}
 		return nil, errors.Trace(fetchErr)
 	}

--- a/worker/uniter/charm/manifest_deployer_test.go
+++ b/worker/uniter/charm/manifest_deployer_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	ch "github.com/juju/charm/v9"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -44,8 +43,8 @@ func (s *ManifestDeployerSuite) SetUpTest(c *gc.C) {
 	s.deployer = charm.NewManifestDeployer(s.targetPath, deployerPath, s.bundles, loggo.GetLogger("test"))
 }
 
-func (s *ManifestDeployerSuite) addMockCharm(c *gc.C, revision int, bundle charm.Bundle) charm.BundleInfo {
-	return s.bundles.AddBundle(c, charmURL(revision), bundle)
+func (s *ManifestDeployerSuite) addMockCharm(revision int, bundle charm.Bundle) charm.BundleInfo {
+	return s.bundles.AddBundle(charmURL(revision), bundle)
 }
 
 func (s *ManifestDeployerSuite) addCharm(c *gc.C, revision int, content ...ft.Entry) charm.BundleInfo {
@@ -67,12 +66,12 @@ func (s *ManifestDeployerSuite) deployCharm(c *gc.C, revision int, content ...ft
 func (s *ManifestDeployerSuite) assertCharm(c *gc.C, revision int, content ...ft.Entry) {
 	url, err := charm.ReadCharmURL(filepath.Join(s.targetPath, ".juju-charm"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(url, gc.DeepEquals, charmURL(revision))
+	c.Assert(url, gc.Equals, charmURL(revision).String())
 	ft.Entries(content).Check(c, s.targetPath)
 }
 
 func (s *ManifestDeployerSuite) TestAbortStageWhenClosed(c *gc.C) {
-	info := s.addMockCharm(c, 1, mockBundle{})
+	info := s.addMockCharm(1, mockBundle{})
 	abort := make(chan struct{})
 	errors := make(chan error)
 	s.bundles.EnableWaitForAbort()
@@ -85,7 +84,7 @@ func (s *ManifestDeployerSuite) TestAbortStageWhenClosed(c *gc.C) {
 }
 
 func (s *ManifestDeployerSuite) TestDontAbortStageWhenNotClosed(c *gc.C) {
-	info := s.addMockCharm(c, 1, mockBundle{})
+	info := s.addMockCharm(1, mockBundle{})
 	abort := make(chan struct{})
 	errors := make(chan error)
 	stopWaiting := s.bundles.EnableWaitForAbort()
@@ -191,7 +190,7 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictResolveRetrySameCharm(c *gc.C
 			return nil
 		},
 	}
-	info := s.addMockCharm(c, 2, mockCharm)
+	info := s.addMockCharm(2, mockCharm)
 	err := s.deployer.Stage(info, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -234,7 +233,7 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictRevertRetryDifferentCharm(c *
 			return fmt.Errorf("oh noes")
 		},
 	}
-	badInfo := s.addMockCharm(c, 2, badCharm)
+	badInfo := s.addMockCharm(2, badCharm)
 	err := s.deployer.Stage(badInfo, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.deployer.Deploy()
@@ -265,8 +264,7 @@ type RetryingBundleReaderSuite struct {
 func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	charmURL := ch.MustParseURL("ch:focal/dummy-1")
-	s.bundleInfo.EXPECT().URL().Return(charmURL).AnyTimes()
+	s.bundleInfo.EXPECT().String().Return("ch:focal/dummy-1").AnyTimes()
 	s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")).AnyTimes()
 
 	go func() {
@@ -285,8 +283,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 func (s *RetryingBundleReaderSuite) TestReadBundleEventuallySucceeds(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	charmURL := ch.MustParseURL("ch:focal/dummy-1")
-	s.bundleInfo.EXPECT().URL().Return(charmURL).AnyTimes()
+	s.bundleInfo.EXPECT().String().Return("ch:focal/dummy-1").AnyTimes()
 	gomock.InOrder(
 		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")),
 		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(s.bundle, nil),

--- a/worker/uniter/charm/mocks/mocks.go
+++ b/worker/uniter/charm/mocks/mocks.go
@@ -8,9 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	charm "github.com/juju/charm/v9"
 	set "github.com/juju/collections/set"
-	charm0 "github.com/juju/juju/worker/uniter/charm"
+	charm "github.com/juju/juju/worker/uniter/charm"
 )
 
 // MockBundleReader is a mock of BundleReader interface.
@@ -37,10 +36,10 @@ func (m *MockBundleReader) EXPECT() *MockBundleReaderMockRecorder {
 }
 
 // Read mocks base method.
-func (m *MockBundleReader) Read(arg0 charm0.BundleInfo, arg1 <-chan struct{}) (charm0.Bundle, error) {
+func (m *MockBundleReader) Read(arg0 charm.BundleInfo, arg1 <-chan struct{}) (charm.Bundle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", arg0, arg1)
-	ret0, _ := ret[0].(charm0.Bundle)
+	ret0, _ := ret[0].(charm.Bundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -89,18 +88,18 @@ func (mr *MockBundleInfoMockRecorder) ArchiveSha256() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveSha256", reflect.TypeOf((*MockBundleInfo)(nil).ArchiveSha256))
 }
 
-// URL mocks base method.
-func (m *MockBundleInfo) URL() *charm.URL {
+// String mocks base method.
+func (m *MockBundleInfo) String() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URL")
-	ret0, _ := ret[0].(*charm.URL)
+	ret := m.ctrl.Call(m, "String")
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// URL indicates an expected call of URL.
-func (mr *MockBundleInfoMockRecorder) URL() *gomock.Call {
+// String indicates an expected call of String.
+func (mr *MockBundleInfoMockRecorder) String() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URL", reflect.TypeOf((*MockBundleInfo)(nil).URL))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockBundleInfo)(nil).String))
 }
 
 // MockBundle is a mock of Bundle interface.

--- a/worker/uniter/mockdeployer_test.go
+++ b/worker/uniter/mockdeployer_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	jujucharm "github.com/juju/charm/v9"
-
 	"github.com/juju/juju/worker/uniter/charm"
 )
 
@@ -19,14 +17,13 @@ type mockDeployer struct {
 	bundles   charm.BundleReader
 
 	bundle   charm.Bundle
-	staged   *jujucharm.URL
-	curl     *jujucharm.URL
+	staged   string
 	deployed bool
 	err      error
 }
 
 func (m *mockDeployer) Stage(info charm.BundleInfo, abort <-chan struct{}) error {
-	m.staged = info.URL()
+	m.staged = info.String()
 	var err error
 	m.bundle, err = m.bundles.Read(info, abort)
 	return err
@@ -46,6 +43,5 @@ func (m *mockDeployer) Deploy() error {
 		return err
 	}
 	m.deployed = true
-	m.curl = m.staged
 	return nil
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -718,7 +718,7 @@ func (s startupError) step(c *gc.C, ctx *testContext) {
 type verifyDeployed struct{}
 
 func (s verifyDeployed) step(c *gc.C, ctx *testContext) {
-	c.Assert(ctx.deployer.curl, jc.DeepEquals, curl(0))
+	c.Assert(ctx.deployer.staged, jc.DeepEquals, curl(0).String())
 	c.Assert(ctx.deployer.deployed, jc.IsTrue)
 }
 


### PR DESCRIPTION
Merge 2.9

#14185 [JUJU-1336] Display containers when force removing machines
#14215 [JUJU-1376] Close remote model connection when controller info update fails
#14174 [JUJU-1276] Charm's url saved as string

Drive by - rename bootstrap arg `--create-model` to `--add-model`

```
# Conflicts:
#       apiserver/facades/client/application/application_test.go
#       apiserver/facades/client/machinemanager/machinemanager_test.go
#       state/charmref.go
#       worker/uniter/charm/charm.go
#       worker/uniter/charm/manifest_deployer_test.go
#       worker/uniter/charm/mocks/mocks.go
#       worker/uniter/mockdeployer_test.go
```

## QA steps

See PRs


[JUJU-1336]: https://warthogs.atlassian.net/browse/JUJU-1336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JUJU-1376]: https://warthogs.atlassian.net/browse/JUJU-1376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JUJU-1276]: https://warthogs.atlassian.net/browse/JUJU-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ