### PR TITLE
Make .ssh dir for snap testing + avoid printf %%s to fix LXD bug

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -68,4 +68,5 @@ jobs:
       run: |
         set -euxo pipefail
         lxc network set lxdbr0 ipv6.address none
+        mkdir ~/.ssh
         juju bootstrap localhost --debug

--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -270,7 +270,7 @@ var ctests = []struct {
 		},
 		"bootcmd": []string{
 			"install -D -m 644 /dev/null '/some/path'",
-			"printf '%s\\n' 'Explanation: test\n" +
+			"echo 'Explanation: test\n" +
 				"Package: *\n" +
 				"Pin: release n=series\n" +
 				"Pin-Priority: 123\n" +
@@ -382,7 +382,7 @@ var ctests = []struct {
 	map[string]any{
 		"runcmd": []string{
 			"install -D -m 644 /dev/null '/etc/apt/apt.conf.d/99proxy'",
-			"printf '%s\\n' '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
+			"echo '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
 		},
 	},
 	func(cfg cloudinit.CloudConfig) error {
@@ -398,7 +398,7 @@ var ctests = []struct {
 	map[string]any{
 		"runcmd": []string{
 			"install -D -m 644 /dev/null '/dev/nonsense'",
-			"printf %s AAECAw== | base64 -d > '/dev/nonsense'",
+			"echo -n AAECAw== | base64 -d > '/dev/nonsense'",
 		},
 	},
 	func(cfg cloudinit.CloudConfig) error {
@@ -414,7 +414,7 @@ var ctests = []struct {
 	map[string]any{
 		"bootcmd": []string{
 			"install -D -m 644 /dev/null '/etc/apt/apt.conf.d/99proxy'",
-			"printf '%s\\n' '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
+			"echo '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
 		},
 	},
 	func(cfg cloudinit.CloudConfig) error {

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -167,7 +167,7 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 		if !strings.HasPrefix(src.URL, "ppa:") {
 			if src.Key != "" {
 				key := utils.ShQuote(src.Key)
-				cmd := fmt.Sprintf("printf '%%s\\n' %s | apt-key add -", key)
+				cmd := fmt.Sprintf("echo %s | apt-key add -", key)
 				cmds = append(cmds, cmd)
 			}
 		}
@@ -298,7 +298,7 @@ func (cfg *ubuntuCloudConfig) updateProxySettings(proxyCfg PackageManagerProxyCo
 		pkgCmder := cfg.paccmder[jujupackaging.AptPackageManager]
 		filename := config.AptProxyConfigFile
 		cfg.AddBootCmd(fmt.Sprintf(
-			`printf '%%s\n' %s > %s`,
+			`echo %s > %s`,
 			utils.ShQuote(pkgCmder.ProxyConfigContents(aptProxy)),
 			filename))
 	}

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -123,7 +123,7 @@ bootcmd:
 `
 	s.expectedSampleConfigWriting = `- install -D -m 644 /dev/null '%[1]s.templ'
 - |-
-  printf '%%s\n' '
+  echo '
   auto lo {ethaa_bb_cc_dd_ee_f0} {ethaa_bb_cc_dd_ee_f1} {ethaa_bb_cc_dd_ee_f3} {ethaa_bb_cc_dd_ee_f5}
 
   iface lo inet loopback
@@ -186,7 +186,7 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
 
 	s.expectedSampleUserData = `- install -D -m 744 /dev/null '%[2]s'
 - |-
-  printf '%%s\n' '` + networkInterfacesScriptYamled + ` ' > '%[2]s'
+  echo '` + networkInterfacesScriptYamled + ` ' > '%[2]s'
 - |2
 
   if [ ! -f /sbin/ifup ]; then
@@ -217,7 +217,7 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
 	s.expectedFullNetplanYaml = `
 - install -D -m 644 /dev/null '%[1]s'
 - |-
-  printf '%%s\n' 'network:
+  echo 'network:
     version: 2
     ethernets:
       any0:

--- a/cloudconfig/cloudinit/utils.go
+++ b/cloudconfig/cloudinit/utils.go
@@ -51,9 +51,9 @@ func addFileCmds(filename string, data []byte, mode uint, binary bool) []string 
 	// dash. Instead, we use printf (or we could use /bin/echo).
 	if binary {
 		encoded := base64.StdEncoding.EncodeToString(data)
-		cmds = append(cmds, fmt.Sprintf(`printf %%s %s | base64 -d > %s`, encoded, p))
+		cmds = append(cmds, fmt.Sprintf(`echo -n %s | base64 -d > %s`, encoded, p))
 	} else {
-		cmds = append(cmds, fmt.Sprintf(`printf '%%s\n' %s > %s`, utils.ShQuote(string(data)), p))
+		cmds = append(cmds, fmt.Sprintf(`echo %s > %s`, utils.ShQuote(string(data)), p))
 	}
 
 	return cmds

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -223,9 +223,9 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 				"script1", "script2",
 				"set -xe",
 				"install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown.conf'",
-				"printf '%s\\n' '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
+				"echo '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
 				"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
-				"printf '%s\\n' '5432' > '/var/lib/juju/nonce.txt'",
+				"echo '5432' > '/var/lib/juju/nonce.txt'",
 			},
 		}
 		// OSType with old cloudinit versions don't support adding

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -325,12 +325,12 @@ var cloudinitTests = []cloudinitTest{
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
 install -D -m 644 /dev/null '/etc/apt/preferences\.d/50-cloud-tools'
-printf '%s\\n' '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
+echo '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
 set -xe
 install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
-printf '%s\\n' '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
+echo '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
+echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
 \[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
@@ -344,16 +344,16 @@ curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
-printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
+echo '.*' > '/var/lib/juju/bootstrap-params'
 echo 'Installing Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-ubuntu-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 install -D -m 755 /dev/null '/sbin/remove-juju-services'
-printf '%s\\n' '.*' > '/sbin/remove-juju-services'
+echo '.*' > '/sbin/remove-juju-services'
 ln -s 1\.2\.3-ubuntu-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(service jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:adm /var/log/juju/machine-0\.log\\n  chmod 0640 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
@@ -369,12 +369,12 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 		upgradedToVersion: "1.2.3.123",
 		expectScripts: `
 install -D -m 644 /dev/null '/etc/apt/preferences\.d/50-cloud-tools'
-printf '%s\\n' '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
+echo '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
 set -xe
 install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
-printf '%s\\n' '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
+echo '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
+echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
 \[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
@@ -388,16 +388,16 @@ curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3\.123-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3\.123-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3\.123-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3\.123-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+echo -n '{"version":"1\.2\.3\.123-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3\.123-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
-printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
+echo '.*' > '/var/lib/juju/bootstrap-params'
 echo 'Installing Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3\.123-ubuntu-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 install -D -m 755 /dev/null '/sbin/remove-juju-services'
-printf '%s\\n' '.*' > '/sbin/remove-juju-services'
+echo '.*' > '/sbin/remove-juju-services'
 ln -s 1\.2\.3\.123-ubuntu-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(service jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:adm /var/log/juju/machine-0\.log\\n  chmod 0640 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
@@ -417,9 +417,9 @@ bin='/var/lib/juju/tools/1\.2\.3-ubuntu-amd64'
 curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
-printf %s '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
-printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
+echo '.*' > '/var/lib/juju/bootstrap-params'
 /var/lib/juju/tools/1\.2\.3-ubuntu-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 ln -s 1\.2\.3-ubuntu-amd64 '/var/lib/juju/tools/machine-0'
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
@@ -433,9 +433,9 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 		expectScripts: `
 set -xe
 install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
-printf '%s\\n' '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shutdown\.conf'
+echo '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
+echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
 \[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
@@ -449,12 +449,12 @@ curl -sSfw '.*' --connect-timeout 20 --noproxy "\*" --insecure -o \$bin/tools\.t
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3-ubuntu-amd64","url":"https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-ubuntu-amd64","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-ubuntu-amd64","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-99'
 cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
 install -D -m 755 /dev/null '/sbin/remove-juju-services'
-printf '%s\\n' '.*' > '/sbin/remove-juju-services'
+echo '.*' > '/sbin/remove-juju-services'
 ln -s 1\.2\.3-ubuntu-amd64 '/var/lib/juju/tools/machine-99'
 echo 'Starting Juju machine agent \(service jujud-machine-99\)'.*
 cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:adm /var/log/juju/machine-99\.log\\n  chmod 0640 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
@@ -471,7 +471,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 		expectScripts: `
 set -xe
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
+echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 .*
 `,
 	},
@@ -537,7 +537,7 @@ curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.t
 		inexactMatch:      true,
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
-printf '%s\\n' '.*bootstrap-machine-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
+echo '.*bootstrap-machine-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
@@ -550,7 +550,7 @@ printf '%s\\n' '.*bootstrap-machine-constraints: {}.*' > '/var/lib/juju/bootstra
 		inexactMatch:      true,
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
-printf '%s\\n' '.*model-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
+echo '.*model-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
@@ -570,7 +570,7 @@ printf '%s\\n' '.*model-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
 		inexactMatch:      true,
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
-printf '%s\\n' '.*custom-image-metadata:.*us-east1.*.*' > '/var/lib/juju/bootstrap-params'
+echo '.*custom-image-metadata:.*us-east1.*.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
@@ -584,7 +584,7 @@ printf '%s\\n' '.*custom-image-metadata:.*us-east1.*.*' > '/var/lib/juju/bootstr
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
 install -D -m 644 /dev/null '.*publicsimplestreamskey'
-printf '%s\\n' 'publickey' > '.*publicsimplestreamskey'
+echo 'publickey' > '.*publicsimplestreamskey'
 `,
 	},
 
@@ -599,7 +599,7 @@ sha256sum \$bin/tools.tar.gz > \$bin/juju2.8.0-ubuntu-amd64.sha256
 grep '1234' \$bin/juju2.8.0-ubuntu-amd64.sha256 .*
 tar zxf \$bin/tools.tar.gz -C \$bin
 ln -s \$bin /var/lib/juju/tools/2.8.0-bionic-amd64
-printf %s '{"version":"2.8.0-ubuntu-amd64".*
+echo -n '{"version":"2.8.0-ubuntu-amd64".*
 mkdir -p '/var/lib/juju/agents/machine-1'
 `,
 	},
@@ -639,7 +639,7 @@ func checkEnvConfig(c *gc.C, cfg *config.Config, scripts []string) {
 func getStateInitializationParams(c *gc.C, scripts []string) instancecfg.StateInitializationParams {
 	var args instancecfg.StateInitializationParams
 	c.Assert(scripts, gc.Not(gc.HasLen), 0)
-	re := regexp.MustCompile(`printf '%s\\n' '(?s:(.+))' > '/var/lib/juju/bootstrap-params'`)
+	re := regexp.MustCompile(`echo '(?s:(.+))' > '/var/lib/juju/bootstrap-params'`)
 	for _, s := range scripts {
 		m := re.FindStringSubmatch(s)
 		if m == nil {
@@ -754,7 +754,7 @@ func (*cloudinitSuite) TestCloudInitWithLocalControllerCharmDir(c *gc.C) {
 	base64Content := base64.StdEncoding.EncodeToString(content)
 	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`chmod 0600 '/var/lib/juju/agents/machine-0/agent.conf'
 install -D -m 644 /dev/null '/var/lib/juju/charms/controller.charm'
-printf %%s %s | base64 -d > '/var/lib/juju/charms/controller.charm'
+echo -n %s | base64 -d > '/var/lib/juju/charms/controller.charm'
 `, base64Content))
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
@@ -778,7 +778,7 @@ func (*cloudinitSuite) TestCloudInitWithLocalControllerCharmArchive(c *gc.C) {
 	base64Content := base64.StdEncoding.EncodeToString(content)
 	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`chmod 0600 '/var/lib/juju/agents/machine-0/agent.conf'
 install -D -m 644 /dev/null '/var/lib/juju/charms/controller.charm'
-printf %%s %s | base64 -d > '/var/lib/juju/charms/controller.charm'
+echo -n %s | base64 -d > '/var/lib/juju/charms/controller.charm'
 `, base64Content))
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
@@ -1243,7 +1243,7 @@ func (s *cloudinitSuite) TestAptProxyWritten(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmds := cloudcfg.BootCmds()
-	expected := "printf '%s\\n' 'Acquire::http::Proxy \"http://user@10.0.0.1\";' > /etc/apt/apt.conf.d/95-juju-proxy-settings"
+	expected := "echo 'Acquire::http::Proxy \"http://user@10.0.0.1\";' > /etc/apt/apt.conf.d/95-juju-proxy-settings"
 	c.Assert(cmds, jc.DeepEquals, []string{expected})
 }
 
@@ -1270,12 +1270,12 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 		`export no_proxy=0.1.2.3,10.0.3.1,localhost`,
 		`export NO_PROXY=0.1.2.3,10.0.3.1,localhost`,
 		``,
-		`(printf '%s\n' 'export http_proxy=http://user@10.0.0.1
+		`(echo 'export http_proxy=http://user@10.0.0.1
 export HTTP_PROXY=http://user@10.0.0.1
 export no_proxy=0.1.2.3,10.0.3.1,localhost
 export NO_PROXY=0.1.2.3,10.0.3.1,localhost
 ' > /etc/juju-proxy.conf && chmod 0644 /etc/juju-proxy.conf)`,
-		`printf '%s\n' '# To allow juju to control the global systemd proxy settings,
+		`echo '# To allow juju to control the global systemd proxy settings,
 # create symbolic links to this file from within /etc/systemd/system.conf.d/
 # and /etc/systemd/users.conf.d/.
 [Manager]

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -327,11 +327,11 @@ func (w *unixConfigure) ConfigureJuju() error {
 		w.conf.AddScripts(strings.Split(exportedProxyEnv, "\n")...)
 		w.conf.AddScripts(
 			fmt.Sprintf(
-				`(printf '%%s\n' %s > /etc/juju-proxy.conf && chmod 0644 /etc/juju-proxy.conf)`,
+				`(echo %s > /etc/juju-proxy.conf && chmod 0644 /etc/juju-proxy.conf)`,
 				shquote(w.icfg.LegacyProxySettings.AsScriptEnvironment())))
 
 		// Write out systemd proxy settings
-		w.conf.AddScripts(fmt.Sprintf(`printf '%%s\n' %[1]s > /etc/juju-proxy-systemd.conf`,
+		w.conf.AddScripts(fmt.Sprintf(`echo %[1]s > /etc/juju-proxy-systemd.conf`,
 			shquote(w.icfg.LegacyProxySettings.AsSystemdDefaultEnv())))
 	}
 
@@ -636,7 +636,7 @@ func (w *unixConfigure) addDownloadToolsCmds() error {
 		return err
 	}
 	w.conf.AddScripts(
-		fmt.Sprintf("printf %%s %s > $bin/downloaded-tools.txt", shquote(string(toolsJson))),
+		fmt.Sprintf("echo -n %s > $bin/downloaded-tools.txt", shquote(string(toolsJson))),
 	)
 
 	return nil

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -417,7 +417,7 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(userDataMap["runcmd"], jc.DeepEquals, []interface{}{
 		"set -xe",
 		"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
-		"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
+		"echo 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
 	})
 
 	// check that a new instance will be started with a machine agent
@@ -494,9 +494,9 @@ func (t *localServerSuite) TestUpstartBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(userDataMap["runcmd"], jc.DeepEquals, []interface{}{
 		"set -xe",
 		"install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown.conf'",
-		"printf '%s\\n' '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
+		"echo '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
 		"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
-		"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
+		"echo 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
 	})
 
 	// check that a new instance will be started with a machine agent


### PR DESCRIPTION
- This should fix the missing .ssh directory used by the juju snap GitHub action.
- Also fixes bootstrapping LXD due to a buggy version of LXD that interprets %s in cloud-init config.
Future PR will add in better user error messaging asking the user to create the directory.