### PR TITLE
Suppresses lost connect to pod error

### DIFF
--- a/caas/kubernetes/provider/klog.go
+++ b/caas/kubernetes/provider/klog.go
@@ -14,6 +14,7 @@ type KlogMessagePrefixes []string
 
 var (
 	klogIgnorePrefixes = KlogMessagePrefixes{
+		"lost connection to pod",
 		"an error occurred forwarding",
 		"error copying from remote stream to local connection",
 		"error copying from local connection to remote stream",


### PR DESCRIPTION
Due to the way Kubernetes port forwarding works in the client api we are
forced to deal with klog errors that arise. A lot of these errors we
don't care about because our code retries gracefully. This change
introduces another error message to suppress from klog for Kubernetes
port forwarding.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

This has been a hard one to repo as it's very system dependent. As of writing we have been able to successfully replicate this on @wallyworld computer and will confirm fixed.

## Bug reference

Reported by @wallyworld 
