### PR TITLE
[JUJU-1381]remove color codes from juju status redirect

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -46,15 +46,14 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		return errors.Errorf("expected value of type %T, got %T", fs, value)
 	}
 
-	// NO_COLOR; regardless of its value,is required by ansiterm to enable
-	// toggling color capability on or off
-	os.Setenv("NO_COLOR", "")
+	// overrides the --color=true
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		forceColor = false
+	}
 
 	// To format things into columns.
 	tw := output.TabWriter(writer)
-	if forceColor {
-		tw.SetColorCapable(forceColor)
-	}
+	tw.SetColorCapable(forceColor)
 
 	cloudRegion := fs.Model.Cloud
 	if fs.Model.CloudRegion != "" {

--- a/cmd/juju/status/utils.go
+++ b/cmd/juju/status/utils.go
@@ -5,9 +5,12 @@ package status
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"reflect"
 
 	"github.com/juju/naturalsort"
+	"github.com/mattn/go-isatty"
 )
 
 // stringKeysFromMap takes a map with keys which are strings and returns
@@ -45,4 +48,14 @@ func indexOf(element interface{}, data []interface{}) int {
 		}
 	}
 	return -1 //not found.
+}
+
+// isTerminal checks if the file descriptor is a terminal.
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	return isatty.IsTerminal(f.Fd())
 }


### PR DESCRIPTION
- Remove ansi color codes from redirects. (Maintain the same behaviour as in `2.9`)
- Enforce coloring by default on tty.

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps
*Provision on any cloud*

```sh
  juju bootstrap localhost overlord
  juju add-model lxd-model 
  juju deploy mediawiki
  juju deploy mysql --series=trusty
  juju deploy haproxy
  juju add-relation mediawiki:db mysql
  juju add-relation mediawiki haproxy
  juju expose haproxy
  juju add-unit -n 2 mediawiki
  juju status
  juju status > snapshot.txt
  watch juju status
  watch --color juju status --color
```
* While in `watch` or any other redirect there should be no color codes appended in the output *
