### PR TITLE
[JUJU-1382] Improve formatting of machine errors in state

### DIFF
--- a/state/errors/machine.go
+++ b/state/errors/machine.go
@@ -24,7 +24,11 @@ func NewHasAssignedUnitsError(machineId string, unitNames []string) error {
 }
 
 func (e *hasAssignedUnitsError) Error() string {
-	return fmt.Sprintf("machine %s has unit %q assigned", e.machineId, e.unitNames[0])
+	unitNames := make([]string, len(e.unitNames))
+	for i, unitName := range e.unitNames {
+		unitNames[i] = fmt.Sprintf("%q", unitName)
+	}
+	return fmt.Sprintf("machine %s has unit(s) %s assigned", e.machineId, strings.Join(unitNames, ", "))
 }
 
 func IsHasAssignedUnitsError(err error) bool {
@@ -45,7 +49,11 @@ func NewHasContainersError(machineId string, containerIds []string) error {
 }
 
 func (e *hasContainersError) Error() string {
-	return fmt.Sprintf("machine %s is hosting containers %q", e.machineId, strings.Join(e.containerIds, ","))
+	containerIds := make([]string, len(e.containerIds))
+	for i, containerId := range e.containerIds {
+		containerIds[i] = fmt.Sprintf("%q", containerId)
+	}
+	return fmt.Sprintf("machine %s is hosting container(s) %s", e.machineId, strings.Join(containerIds, ", "))
 }
 
 // IshasContainersError reports whether or not the error is a

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -345,11 +345,11 @@ func (s *MachineSuite) TestLifeMachineWithContainer(c *gc.C) {
 
 	err = s.machine.Destroy()
 	c.Assert(errors.Cause(err), jc.Satisfies, state.IsHasContainersError)
-	c.Assert(err, gc.ErrorMatches, `machine 1 is hosting containers "1/lxd/0"`)
+	c.Assert(err, gc.ErrorMatches, `machine 1 is hosting container\(s\) "1/lxd/0"`)
 
 	err = s.machine.EnsureDead()
 	c.Assert(errors.Cause(err), jc.Satisfies, state.IsHasContainersError)
-	c.Assert(err, gc.ErrorMatches, `machine 1 is hosting containers "1/lxd/0"`)
+	c.Assert(err, gc.ErrorMatches, `machine 1 is hosting container\(s\) "1/lxd/0"`)
 
 	c.Assert(s.machine.Life(), gc.Equals, state.Alive)
 }
@@ -375,11 +375,11 @@ func (s *MachineSuite) TestLifeJobHostUnits(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.machine.Destroy()
 	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
-	c.Assert(err, gc.ErrorMatches, `machine 1 has unit "wordpress/0" assigned`)
+	c.Assert(err, gc.ErrorMatches, `machine 1 has unit\(s\) "wordpress/0" assigned`)
 
 	err = s.machine.EnsureDead()
 	c.Assert(err, jc.Satisfies, state.IsHasAssignedUnitsError)
-	c.Assert(err, gc.ErrorMatches, `machine 1 has unit "wordpress/0" assigned`)
+	c.Assert(err, gc.ErrorMatches, `machine 1 has unit\(s\) "wordpress/0" assigned`)
 
 	c.Assert(s.machine.Life(), gc.Equals, state.Alive)
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2725,7 +2725,7 @@ func (s *StateSuite) TestWatchContainerLifecycle(c *gc.C) {
 
 	// Make the container Dying: cannot because of nested container.
 	err = m.Destroy()
-	c.Assert(err, gc.ErrorMatches, `machine .* is hosting containers ".*"`)
+	c.Assert(err, gc.ErrorMatches, `machine .* is hosting container\(s\) ".*"`)
 
 	err = mchild.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
`juju remove-machine` was returning incomplete, badly formatted errors. Improve the information content, and fix the formatting of the two relevant error types

## QA steps

Bootstrap a controller and deploy some machine/containers/units to it

```
$ juju status
Model    Controller  Cloud/Region   Version   SLA          Timestamp
default  aws-test    aws/eu-west-2  2.9.33.1  unsupported  11:13:33+01:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu           active      3  ubuntu  stable    19  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        13.41.185.218          
ubuntu/1   active    idle   0/lxd/0  252.37.226.54          
ubuntu/2   active    idle   0/lxd/0  252.37.226.54          

Machine  State    Address        Inst id              Series  AZ          Message
0        started  13.41.185.218  i-0a015a30c53d221b9  focal   eu-west-2b  running
0/lxd/0  started  252.37.226.54  juju-2fa5cc-0-lxd-0  focal   eu-west-2b  Container started
0/lxd/1  started  252.37.226.41  juju-2fa5cc-0-lxd-1  focal   eu-west-2b  Container started
```

Then try:
```
$ juju remove-machine 0/lxd/0
removing machine failed: machine 0/lxd/0 has unit(s) "ubuntu/1", "ubuntu/2" assigned

$ juju remove-machine 0
removing machine failed: machine 0 is hosting container(s) "0/lxd/0", "0/lxd/1"
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1980216