### PR TITLE
Use --client for add-k8s command;

### DIFF
--- a/acceptancetests/assess_caas_deploy_charms.py
+++ b/acceptancetests/assess_caas_deploy_charms.py
@@ -175,7 +175,7 @@ def main(argv=None):
         cluster_name=args.temp_env_name,
         enable_rbac=args.enable_rbac,
     ).substrate_context() as caas_client:
-        # add-k8s --local
+        # add-k8s --client
         is_mk8s = args.caas_provider == K8sProviderType.MICROK8S.name
         if args.k8s_controller and not is_mk8s:
             # microk8s is built-in cloud, no need run add-k8s for bootstrapping

--- a/acceptancetests/assess_caas_deploy_kubeflow.py
+++ b/acceptancetests/assess_caas_deploy_kubeflow.py
@@ -510,7 +510,7 @@ def main(argv=None):
         cluster_name=args.temp_env_name,
         enable_rbac=args.enable_rbac,
     ).substrate_context() as caas_client:
-        # add-k8s --local
+        # add-k8s --client
         if args.k8s_controller and args.caas_provider != K8sProviderType.MICROK8S.name:
             # microk8s is built-in cloud, no need run add-k8s for bootstrapping.
             caas_client.add_k8s(True)

--- a/acceptancetests/jujupy/k8s_provider/aks.py
+++ b/acceptancetests/jujupy/k8s_provider/aks.py
@@ -91,7 +91,7 @@ class AKS(Base):
     def _ensure_cluster_stack(self):
         self.provision_aks()
 
-    def add_k8s(self, is_local=False, juju_home=None, storage=None):
+    def add_k8s(self, is_client=False, juju_home=None, storage=None):
         if storage is None:
             storageclasses = json.loads(self.kubectl('get', 'storageclass', '-o', 'json'))
             for sc in storageclasses.get('items', []):
@@ -101,7 +101,7 @@ class AKS(Base):
                 if annotations.get('storageclass.kubernetes.io/is-default-class') == 'true':
                     storage = sc['metadata']['name']
                     break
-        super().add_k8s(is_local, juju_home, storage)
+        super().add_k8s(is_client, juju_home, storage)
 
     def _tear_down_substrate(self):
         logger.info("Deleting the AKS instance {0}".format(self.cluster_name))

--- a/acceptancetests/jujupy/k8s_provider/base.py
+++ b/acceptancetests/jujupy/k8s_provider/base.py
@@ -168,16 +168,16 @@ class Base(object):
         # returns the newly added CAAS model.
         return self.client.add_model(env=self.client.env.clone(model_name), cloud_region=self.cloud_name)
 
-    def add_k8s(self, is_local=False, juju_home=None, storage=None):
+    def add_k8s(self, is_client=False, juju_home=None, storage=None):
         args = (
             self.cloud_name,
         )
         juju_home = juju_home or self.client.env.juju_home
         if storage is not None:
             args += ('--storage', storage)
-        if is_local:
+        if is_client:
             args += (
-                '--local',
+                '--client',
                 '--cluster-name', self.kubeconfig_cluster_name,
             )
             # use this local cloud to bootstrap later.


### PR DESCRIPTION
Fix for k8s CI tests:
1. use --client for the add-k8s command because --local is deprecated.