### PR TITLE
[JUJU-1385] Remove deprecated openstack config: use-floating-ip.

### DIFF
--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -279,11 +279,6 @@ use-default-secgroup:
   type: bool
   description: Whether new machine instances should have the "default" Openstack security
     group assigned in addition to juju defined security groups.
-use-floating-ip:
-  type: bool
-  description: Whether a floating IP address is required to give the nodes a public
-    IP address. Some installations assign public IP addresses by default without requiring
-    a floating IP address.
 use-openstack-gbp:
   type: bool
   description: Whether to use Neutrons Group-Based Policy
@@ -306,7 +301,6 @@ clouds:
     region-config:
       london:
         bootstrap-timeout: 1800
-        use-floating-ip: true
 `[1:]
 	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
@@ -331,7 +325,6 @@ config:
 region-config:
   london:
     bootstrap-timeout: 1800
-    use-floating-ip: true
 `[1:], openstackProviderConfig}, ""))
 }
 

--- a/provider/openstack/config.go
+++ b/provider/openstack/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/utils/v3"
 	"gopkg.in/juju/environschema.v1"
 
-	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -20,14 +19,9 @@ const (
 	PolicyTargetGroupKey  = "policy-target-group"
 	UseDefaultSecgroupKey = "use-default-secgroup"
 	UseOpenstackGBPKey    = "use-openstack-gbp"
-	UseFloatingIPKey      = "use-floating-ip"
 )
 
 var configSchema = environschema.Fields{
-	UseFloatingIPKey: {
-		Description: "Whether a floating IP address is required to give the nodes a public IP address. Some installations assign public IP addresses by default without requiring a floating IP address.",
-		Type:        environschema.Tbool,
-	},
 	UseDefaultSecgroupKey: {
 		Description: `Whether new machine instances should have the "default" Openstack security group assigned in addition to juju defined security groups.`,
 		Type:        environschema.Tbool,
@@ -51,7 +45,6 @@ var configSchema = environschema.Fields{
 }
 
 var configDefaults = schema.Defaults{
-	UseFloatingIPKey:      schema.Omit,
 	UseDefaultSecgroupKey: false,
 	NetworkKey:            "",
 	ExternalNetworkKey:    "",
@@ -70,11 +63,6 @@ var configFields = func() schema.Fields {
 type environConfig struct {
 	*config.Config
 	attrs map[string]interface{}
-}
-
-func (c *environConfig) useFloatingIP() bool {
-	v, ok := c.attrs[UseFloatingIPKey].(bool)
-	return ok && v
 }
 
 func (c *environConfig) useDefaultSecurityGroup() bool {
@@ -170,14 +158,6 @@ func (p EnvironProvider) Validate(cfg, old *config.Config) (valid *config.Config
 				"when an model is bootstrapped, or individually when a charm is deployed.\n"+
 				"See 'juju help bootstrap' or 'juju help deploy'.",
 			"default-instance-type", defaultInstanceType)
-		logger.Warningf(msg)
-	}
-
-	if _, ok := cfgAttrs[UseFloatingIPKey]; ok {
-		msg := fmt.Sprintf(
-			"Config attribute %q is deprecated.\n"+
-				"You can instead use the constraint %q.\n",
-			UseFloatingIPKey, constraints.AllocatePublicIP)
 		logger.Warningf(msg)
 	}
 

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -30,7 +30,6 @@ type configTest struct {
 	change                  map[string]interface{}
 	expect                  map[string]interface{}
 	region                  string
-	useFloatingIP           bool
 	useDefaultSecurityGroup bool
 	network                 string
 	externalNetwork         string
@@ -81,7 +80,6 @@ func (t configTest) check(c *gc.C) {
 	if t.firewallMode != "" {
 		c.Assert(ecfg.FirewallMode(), gc.Equals, t.firewallMode)
 	}
-	c.Assert(ecfg.useFloatingIP(), gc.Equals, t.useFloatingIP)
 	c.Assert(ecfg.useDefaultSecurityGroup(), gc.Equals, t.useDefaultSecurityGroup)
 	c.Assert(ecfg.network(), gc.Equals, t.network)
 	c.Assert(ecfg.externalNetwork(), gc.Equals, t.externalNetwork)
@@ -110,17 +108,6 @@ func (s *ConfigSuite) SetUpTest(c *gc.C) {
 
 var configTests = []configTest{
 	{
-		summary: "default use floating ip",
-		config:  requiredConfig,
-		// Do not use floating IP's by default.
-		useFloatingIP: false,
-	}, {
-		summary: "use floating ip",
-		config: requiredConfig.Merge(testing.Attrs{
-			"use-floating-ip": true,
-		}),
-		useFloatingIP: true,
-	}, {
 		summary: "default use default security group",
 		config:  requiredConfig,
 		// Do not use default security group by default.

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1299,7 +1299,7 @@ func (e *Environ) startInstance(
 		runOpts:      &opts,
 	}
 	logger.Infof("started instance %q", inst.Id())
-	withPublicIP := e.ecfg().useFloatingIP()
+	var withPublicIP bool
 	// Any machine constraint for allocating a public IP address
 	// overrides the (deprecated) model config.
 	if args.Constraints.HasAllocatePublicIP() {
@@ -1307,7 +1307,7 @@ func (e *Environ) startInstance(
 	}
 	if withPublicIP {
 		// If we don't lock here, AllocatePublicIP() can return the same
-		// public IP for 2 different instances.  Only one will successfully
+		// public IP for 2 different instances. Only one will successfully
 		// be assigned the public IP, the other will not have one.
 		e.publicIPMutex.Lock()
 		defer e.publicIPMutex.Unlock()

--- a/provider/openstack/provider_configurator.go
+++ b/provider/openstack/provider_configurator.go
@@ -42,7 +42,6 @@ func (c *defaultConfigurator) GetCloudConfig(args environs.StartInstanceParams) 
 // GetConfigDefaults implements ProviderConfigurator interface.
 func (c *defaultConfigurator) GetConfigDefaults() schema.Defaults {
 	return schema.Defaults{
-		"use-floating-ip":      schema.Omit,
 		"use-default-secgroup": false,
 		"network":              "",
 		"external-network":     "",

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -3,13 +3,13 @@
 # of the juju version. If JUJU_VERSION is defined in CI this value will be used
 # otherwise we interrogate the juju binary on path.
 juju_version() {
-  # Match only major, minor, and patch or tag + build number
-  if [ -n "${JUJU_VERSION:-}" ]; then
-    version=${JUJU_VERSION}
-  else
-    version=$(juju version | grep -oE '^[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+|-\w+){1}(\.[[:digit:]]+)?')
-  fi
-  echo "${version}"
+	# Match only major, minor, and patch or tag + build number
+	if [ -n "${JUJU_VERSION:-}" ]; then
+		version=${JUJU_VERSION}
+	else
+		version=$(juju version | grep -oE '^[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+|-\w+){1}(\.[[:digit:]]+)?')
+	fi
+	echo "${version}"
 }
 
 jujud_version() {


### PR DESCRIPTION
use-floating-ip is a long deprecated model config key specific to openstack clouds. A new major version is a good time to remove it.

The attached bug is about how often the deprecation message is printed and the noise it creates. Removing the config key is one way to handle the messages.

## QA steps

```sh
# Verify the allocate-public-ip constraint still works, where bootstrap will no succeed without one.
$ juju bootstrap <openstack-cloud> --constraints "allocate-public-ip=true"

# Verify unknown config
$ juju bootstrap <openstack-cloud> --config "use-floating-ip=true"
WARNING unknown config field "use-floating-ip"
```

## Documentation changes

Yes, 3.0 openstack docs will need to be updated.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1897944