### PR TITLE
Cleanup port printing in status tabular to also compact.

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -319,24 +319,141 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 	endSection(tw)
 }
 
+type protocol struct {
+	group      map[string]string
+	groups     map[string][]string
+	grouped    map[string]bool
+	components map[string][]string
+}
+
+type sortablePorts []string
+
+func (s sortablePorts) Len() int {
+	return len(s)
+}
+
+func (s sortablePorts) Less(i, j int) bool {
+	if len(s[i]) < len(s[j]) {
+		return true
+	}
+	if len(s[i]) > len(s[j]) {
+		return false
+	}
+	return s[i] < s[j]
+}
+
+func (s sortablePorts) Swap(i, j int) {
+	t := s[i]
+	s[i] = s[j]
+	s[j] = t
+}
+
 func printPorts(w output.Wrapper, ps []string) {
-	size := len(ps)
-	for i, op := range ps {
-		if strings.Contains(op, "/") { //some port values just contain the protocol name e.g icmp
-			pp := strings.Split(op, "/")
-			w.PrintColorNoTab(output.EmphasisHighlight.BrightMagenta, pp[0]) //port e.g 3306
-			w.PrintNoTab(fmt.Sprintf("/%s", pp[1]))                          //append back the forward slash to the protocol name (3306/tcp)
+	sorted := append([]string(nil), ps...)
+	sort.Strings(sorted)
+
+	protocols := map[string]*protocol{}
+	proto := func(p string) *protocol {
+		v, ok := protocols[p]
+		if !ok {
+			v = &protocol{
+				group:      map[string]string{},
+				groups:     map[string][]string{},
+				grouped:    map[string]bool{},
+				components: map[string][]string{},
+			}
+			protocols[p] = v
+		}
+		return v
+	}
+
+	for _, port := range sorted {
+		split := strings.Split(port, "/")
+		protocolId := ""
+		if len(split) == 1 {
+			protocolId = split[0]
 		} else {
-			if _, err := strconv.Atoi(op); err == nil { //if string is a port number i.e 3306
-				w.PrintColorNoTab(output.EmphasisHighlight.BrightMagenta, op)
-			} else { //the string is a protocol name i.e icmp
-				w.PrintNoTab(op)
+			protocolId = strings.Join(append([]string{""}, split[1:]...), "/")
+		}
+		protocol := proto(protocolId)
+		protocol.components[port] = split
+		if len(split) == 1 {
+			continue
+		}
+		n, err := strconv.Atoi(split[0])
+		if err != nil || n <= 1 {
+			continue
+		}
+		prev := strings.Join(append([]string{strconv.Itoa(n - 1)}, split[1:]...), "/")
+		if _, ok := protocol.components[prev]; !ok {
+			continue
+		}
+		groupName := protocol.group[prev]
+		if groupName == "" {
+			groupName = prev
+		}
+		protocol.group[port] = groupName
+		protocol.groups[groupName] = append(protocol.groups[groupName], port)
+		protocol.grouped[port] = true
+	}
+
+	protocolKeys := []string{}
+	for k := range protocols {
+		protocolKeys = append(protocolKeys, k)
+	}
+	sort.Strings(protocolKeys)
+
+	hasOutput := false
+	for _, pk := range protocolKeys {
+		protocol := protocols[pk]
+
+		portKeys := []string{}
+		for k := range protocol.components {
+			portKeys = append(portKeys, k)
+		}
+		sort.Sort(sortablePorts(portKeys))
+
+		hasPrev := false
+		for _, port := range portKeys {
+			if protocol.grouped[port] {
+				continue
+			}
+			if hasOutput {
+				hasOutput = false
+				w.PrintNoTab(" ")
+			}
+			if hasPrev {
+				w.PrintNoTab(",")
+			}
+			hasPrev = true
+			split := protocol.components[port]
+			group := protocol.groups[port]
+			// Print grouped ports.
+			if len(group) > 0 {
+				last := group[len(group)-1]
+				lastSplit := protocol.components[last]
+				portRange := fmt.Sprintf("%s-%s", split[0], lastSplit[0])
+				w.PrintColorNoTab(output.EmphasisHighlight.BrightMagenta, portRange)
+				continue
+			}
+			// Print single port with protocol.
+			if len(split) > 1 {
+				w.PrintColorNoTab(output.EmphasisHighlight.BrightMagenta, split[0])
+				continue
+			}
+			// Everything else.
+			break
+		}
+		if hasPrev {
+			hasOutput = true
+			if _, err := strconv.Atoi(pk); err == nil {
+				w.PrintColorNoTab(output.EmphasisHighlight.BrightMagenta, pk)
+			} else {
+				w.PrintNoTab(pk)
 			}
 		}
-		if i != size-1 && size > 1 {
-			w.PrintNoTab(", ")
-		}
 	}
+
 	w.Print("") //Print empty tab after the ports
 }
 

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5435,6 +5435,123 @@ foo/0  waiting   allocating  10.0.0.1  80/TCP
 `[1:])
 }
 
+func (s *StatusSuite) TestFormatTabularManyPorts(c *gc.C) {
+	fStatus := formattedStatus{
+		Model: modelStatus{
+			Type: "caas",
+		},
+		Applications: map[string]applicationStatus{
+			"foo": {
+				Scale:   1,
+				Address: "54.32.1.2",
+				Units: map[string]unitStatus{
+					"foo/0": {
+						Address:     "10.0.0.1",
+						OpenedPorts: []string{"1555/TCP", "123/UDP", "ICMP", "80/TCP"},
+						JujuStatusInfo: statusInfoContents{
+							Current: status.Allocating,
+						},
+						WorkloadStatusInfo: statusInfoContents{
+							Current: status.Waiting,
+						},
+					},
+				},
+			},
+		},
+	}
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, false, fStatus)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.String(), gc.Equals, `
+Model  Controller  Cloud/Region  Version
+                                 
+
+App  Version  Status  Scale  Charm  Channel  Rev  Address    Exposed  Message
+foo                     0/1                    0  54.32.1.2  no       
+
+Unit   Workload  Agent       Address   Ports                     Message
+foo/0  waiting   allocating  10.0.0.1  80,1555/TCP 123/UDP ICMP  
+`[1:])
+}
+
+func (s *StatusSuite) TestFormatTabularManyPortsGrouped(c *gc.C) {
+	fStatus := formattedStatus{
+		Model: modelStatus{
+			Type: "caas",
+		},
+		Applications: map[string]applicationStatus{
+			"foo": {
+				Scale:   1,
+				Address: "54.32.1.2",
+				Units: map[string]unitStatus{
+					"foo/0": {
+						Address:     "10.0.0.1",
+						OpenedPorts: []string{"1557/TCP", "1555/TCP", "80/TCP", "ICMP", "1556/TCP"},
+						JujuStatusInfo: statusInfoContents{
+							Current: status.Allocating,
+						},
+						WorkloadStatusInfo: statusInfoContents{
+							Current: status.Waiting,
+						},
+					},
+				},
+			},
+		},
+	}
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, false, fStatus)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.String(), gc.Equals, `
+Model  Controller  Cloud/Region  Version
+                                 
+
+App  Version  Status  Scale  Charm  Channel  Rev  Address    Exposed  Message
+foo                     0/1                    0  54.32.1.2  no       
+
+Unit   Workload  Agent       Address   Ports                  Message
+foo/0  waiting   allocating  10.0.0.1  80,1555-1557/TCP ICMP  
+`[1:])
+}
+
+func (s *StatusSuite) TestFormatTabularManyPortsCommonGrouped(c *gc.C) {
+	fStatus := formattedStatus{
+		Model: modelStatus{
+			Type: "caas",
+		},
+		Applications: map[string]applicationStatus{
+			"foo": {
+				Scale:   1,
+				Address: "54.32.1.2",
+				Units: map[string]unitStatus{
+					"foo/0": {
+						Address:     "10.0.0.1",
+						OpenedPorts: []string{"1557/TCP", "1555/TCP", "1558/TCP", "1559/TCP", "80/TCP", "1556/TCP"},
+						JujuStatusInfo: statusInfoContents{
+							Current: status.Allocating,
+						},
+						WorkloadStatusInfo: statusInfoContents{
+							Current: status.Waiting,
+						},
+					},
+				},
+			},
+		},
+	}
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, false, fStatus)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.String(), gc.Equals, `
+Model  Controller  Cloud/Region  Version
+                                 
+
+App  Version  Status  Scale  Charm  Channel  Rev  Address    Exposed  Message
+foo                     0/1                    0  54.32.1.2  no       
+
+Unit   Workload  Agent       Address   Ports             Message
+foo/0  waiting   allocating  10.0.0.1  80,1555-1559/TCP  
+`[1:])
+}
+
 func (s *StatusSuite) TestStatusWithNilStatusAPI(c *gc.C) {
 	ctx := s.newContext(c)
 	defer s.resetContext(c, ctx)


### PR DESCRIPTION
This PR cleans up port printing when there is a large number of opened ports, pushing the message column to the next line.

### Before
```
Unit                          Workload  Agent  Address      Ports                                                                                                            Message
admission-webhook/0*          active    idle   10.1.75.86   4443/TCP
argo-controller/0*            active    idle   10.1.75.98
dex-auth/0*                   active    idle   10.1.75.97   5556/TCP
envoy/0*                      active    idle   10.1.75.77   9901/TCP, 9090/TCP
istio-ingressgateway/0*       active    idle   10.1.75.90   15020/TCP, 80/TCP, 443/TCP, 15029/TCP, 15030/TCP, 15031/TCP, 15032/TCP, 15443/TCP, 15011/TCP, 8060/TCP, 853/TCP
istio-pilot/0*                active    idle   10.1.75.109  8080/TCP, 15010/TCP, 15012/TCP, 15017/TCP
jupyter-controller/0*         active    idle   10.1.75.81
jupyter-ui/0*                 active    idle   10.1.75.106  5000/TCP
kfp-api/0*                    active    idle   10.1.75.115  8888/TCP, 8887/TCP
kfp-db/0*                     active    idle   10.1.75.82   3306/TCP                                                                                                         ready
kfp-persistence/0*            active    idle   10.1.75.99
kfp-profile-controller/0*     active    idle   10.1.75.96   80/TCP
kfp-schedwf/0*                active    idle   10.1.75.113
kfp-ui/0*                     active    idle   10.1.75.116  3000/TCP
kfp-viewer/0*                 active    idle   10.1.75.78
kfp-viz/0*                    active    idle   10.1.75.95   8888/TCP
kubeflow-dashboard/0*         active    idle   10.1.75.93   8082/TCP
kubeflow-profiles/0*          active    idle   10.1.75.68   8080/TCP, 8081/TCP
kubeflow-roles/0*             active    idle   10.1.75.112
kubeflow-volumes/0*           active    idle   10.1.75.89   5000/TCP
metacontroller-operator/0*    active    idle   10.1.75.117
minio/0*                      active    idle   10.1.75.126  9000/TCP
mlmd/0*                       active    idle   10.1.75.119  8080/TCP
oidc-gatekeeper/0*            active    idle   10.1.75.101  8080/TCP
seldon-controller-manager/0*  active    idle   10.1.75.65   8080/TCP, 4443/TCP
training-operator/0*          active    idle   10.1.75.123
```

### After
```
Unit                          Workload  Agent  Address      Ports                                              Message
admission-webhook/0*          active    idle   10.1.75.86   4443/TCP
argo-controller/0*            active    idle   10.1.75.98
dex-auth/0*                   active    idle   10.1.75.97   5556/TCP
envoy/0*                      active    idle   10.1.75.77   9901,9090/TCP
istio-ingressgateway/0*       active    idle   10.1.75.90   15020,80,443,15029-15032,15443,15011,8060,853/TCP
istio-pilot/0*                active    idle   10.1.75.109  8080,15010,15012,15017/TCP
jupyter-controller/0*         active    idle   10.1.75.81
jupyter-ui/0*                 active    idle   10.1.75.106  5000/TCP
kfp-api/0*                    active    idle   10.1.75.115  8887-8888/TCP
kfp-db/0*                     active    idle   10.1.75.82   3306/TCP                                           ready
kfp-persistence/0*            active    idle   10.1.75.99
kfp-profile-controller/0*     active    idle   10.1.75.96   80/TCP
kfp-schedwf/0*                active    idle   10.1.75.113
kfp-ui/0*                     active    idle   10.1.75.116  3000/TCP
kfp-viewer/0*                 active    idle   10.1.75.78
kfp-viz/0*                    active    idle   10.1.75.95   8888/TCP
kubeflow-dashboard/0*         active    idle   10.1.75.93   8082/TCP
kubeflow-profiles/0*          active    idle   10.1.75.68   8080-8081/TCP
kubeflow-roles/0*             active    idle   10.1.75.112
kubeflow-volumes/0*           active    idle   10.1.75.89   5000/TCP
metacontroller-operator/0*    active    idle   10.1.75.117
minio/0*                      active    idle   10.1.75.126  9000/TCP
mlmd/0*                       active    idle   10.1.75.119  8080/TCP
oidc-gatekeeper/0*            active    idle   10.1.75.101  8080/TCP
seldon-controller-manager/0*  active    idle   10.1.75.65   8080,4443/TCP
training-operator/0*          active    idle   10.1.75.123
```

## QA steps

deploy a large bundle like kubeflow and check `juju status` for correct port grouping.

## Documentation changes

N/A

## Bug reference

N/A