### PR TITLE
[JUJU-1396] Added v2 module to go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/juju
+module github.com/juju/juju/v2
 
 go 1.18
 


### PR DESCRIPTION
Juju will have to be consumed by third-party clients. In the current scenario Juju has to be imported by setting the commit hash. This is a minor change to include the `/v2` to the module path. For next releases we can start setting labels with semantic versions.

## Checklist

 - [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [ ] Comments answer the question of why design decisions were made

## QA steps

NA

## Documentation changes

NA

## Bug reference

NA
