### PR TITLE
[JUJU-1386] Upgrade step to remove use-floating-ip=false from config.

### DIFF
--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -4517,3 +4517,24 @@ func FixCharmhubLastPolltime(pool *StatePool) error {
 		return st.runRawTransaction(ops)
 	}))
 }
+
+// RemoveUseFloatingIPConfigFalse removes any model config key value pair:
+// use-floating-ip=false. It is deprecated, default by false and causing
+// much noise in logs.
+func RemoveUseFloatingIPConfigFalse(pool *StatePool) error {
+	st, err := pool.SystemState()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(applyToAllModelSettings(st, func(doc *settingsDoc) (bool, error) {
+		var changed bool
+		value, ok := doc.Settings["use-floating-ip"]
+		if ok && value != "" {
+			if v, ok := value.(bool); ok && !v {
+				changed = true
+				delete(doc.Settings, "use-floating-ip")
+			}
+		}
+		return changed, nil
+	}))
+}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -6777,6 +6777,42 @@ func (s *upgradesSuite) TestFixCharmhubLastPollTime(c *gc.C) {
 	)
 }
 
+func (s *upgradesSuite) TestRemoveUseFloatingIPConfigFalse(c *gc.C) {
+	model1 := s.makeModel(c, "model-1", coretesting.Attrs{"use-floating-ip": true})
+	model2 := s.makeModel(c, "model-2", coretesting.Attrs{"use-floating-ip": false})
+	model3 := s.makeModel(c, "model-3", coretesting.Attrs{})
+	defer func() {
+		_ = model1.Close()
+		_ = model2.Close()
+		_ = model3.Close()
+	}()
+
+	err := RemoveUseFloatingIPConfigFalse(s.pool)
+	c.Assert(err, jc.ErrorIsNil)
+
+	m1, _, err := s.pool.GetModel(model1.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	cfg1, err := m1.Config()
+	c.Assert(err, jc.ErrorIsNil)
+	m1Val, ok := cfg1.AllAttrs()["use-floating-ip"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(m1Val, jc.IsTrue)
+
+	m2, _, err := s.pool.GetModel(model2.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	cfg2, err := m2.Config()
+	c.Assert(err, jc.ErrorIsNil)
+	_, ok = cfg2.AllAttrs()["use-floating-ip"]
+	c.Assert(ok, jc.IsFalse)
+
+	m3, _, err := s.pool.GetModel(model3.ModelUUID())
+	c.Assert(err, jc.ErrorIsNil)
+	cfg3, err := m3.Config()
+	c.Assert(err, jc.ErrorIsNil)
+	_, ok = cfg3.AllAttrs()["use-floating-ip"]
+	c.Assert(ok, jc.IsFalse)
+}
+
 type docById []bson.M
 
 func (d docById) Len() int           { return len(d) }

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -110,6 +110,7 @@ type StateBackend interface {
 	UpdateOperationWithEnqueuingErrors() error
 	RemoveLocalCharmOriginChannels() error
 	FixCharmhubLastPolltime() error
+	RemoveUseFloatingIPConfigFalse() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -503,4 +504,8 @@ func (s stateBackend) RemoveLocalCharmOriginChannels() error {
 
 func (s stateBackend) FixCharmhubLastPolltime() error {
 	return state.FixCharmhubLastPolltime(s.pool)
+}
+
+func (s stateBackend) RemoveUseFloatingIPConfigFalse() error {
+	return state.RemoveUseFloatingIPConfigFalse(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -61,6 +61,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.29"), stateStepsFor2929()},
 		upgradeToVersion{version.MustParse("2.9.30"), stateStepsFor2930()},
 		upgradeToVersion{version.MustParse("2.9.32"), stateStepsFor2932()},
+		upgradeToVersion{version.MustParse("2.9.33"), stateStepsFor2933()},
 	}
 	return steps
 }

--- a/upgrades/steps_2933.go
+++ b/upgrades/steps_2933.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2933 returns database upgrade steps for Juju 2.9.33
+func stateStepsFor2933() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "remove use-floating-ip=false from model config",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveUseFloatingIPConfigFalse()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2933_test.go
+++ b/upgrades/steps_2933_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2933 = version.MustParse("2.9.33")
+
+type steps2933Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2933Suite{})
+
+func (s *steps2933Suite) TestRemoveUseFloatingIPConfigFalse(c *gc.C) {
+	step := findStateStep(c, v2933, "remove use-floating-ip=false from model config")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -650,6 +650,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.29",
 		"2.9.30",
 		"2.9.32",
+		"2.9.33",
 	})
 }
 


### PR DESCRIPTION
It is an openstack config value which was deprecated a few years ago. The warnings about deprecation cause a lot of log noise, which is especially painful when set to false anyways. Remove from config if false.

## QA steps

```console
$ juju bootstrap <openstack-cloud> --agent-version 2.9.32 --constraints "allocate-public-ip=true" --config use-floating-ip=false
$ juju add-model one --config use-floating-ip=true

$ juju upgrade-controller 
WARNING Config attribute "use-floating-ip" is deprecated.
You can instead use the constraint "allocate-public-ip".
no prepackaged agent binaries available, using local agent binary 2.9.33.1
best version:
    2.9.33.1
started upgrade to 2.9.33.1
$ juju model-config use-floating-ip
true
$ juju switch default
$ juju model-config use-floating-ip

$
```

## Bug reference

Related to https://bugs.launchpad.net/juju/+bug/1897944
