### PR TITLE
[JUJU-1400] Migrate allocate public ip constraint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/juju/clock v0.0.0-20220203021603-d9deb868a28a
 	github.com/juju/cmd/v3 v3.0.0-20220203030511-039f3566372a
 	github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a
-	github.com/juju/description/v3 v3.0.0-20220207013250-e60bc7b1c242
+	github.com/juju/description/v3 v3.0.0-20220705143837-6a522a3e3bbc
 	github.com/juju/errors v0.0.0-20220622220526-54a94488269b
 	github.com/juju/featureflag v0.0.0-20220207005600-a9676d92ad24
 	github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,8 @@ github.com/juju/cmd/v3 v3.0.0-20220203030511-039f3566372a/go.mod h1:OwsFyKpl9Hz4
 github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71dV1JClcOJE+4dzdn4HrI5LiyKd7PlVG6eZYhY=
 github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a h1:d7eZO8OS/ZXxdP0uq3E8CdoA1qNFaecAv90UxrxaY2k=
 github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
-github.com/juju/description/v3 v3.0.0-20220207013250-e60bc7b1c242 h1:IvXW5q+6BTdZgmlpZin8xyig5qwDk3rkMbRTynoqvR0=
-github.com/juju/description/v3 v3.0.0-20220207013250-e60bc7b1c242/go.mod h1:bT3J/YHYEGVP6i5R52gIX1C8KAfMj0EdxCe2Sv5Tsl4=
+github.com/juju/description/v3 v3.0.0-20220705143837-6a522a3e3bbc h1:tibVTV04TYbe0QfxPWITGp5ZjXRvM+5/1+UCvnHfqrY=
+github.com/juju/description/v3 v3.0.0-20220705143837-6a522a3e3bbc/go.mod h1:i2ZbXp3mj6EnOgexunf9DsnsZuyOB5oT0y0Lek8vBSs=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20220622220526-54a94488269b h1:RDqhIF4b2LKv1CHVw5AKASru2kJ1gnTMJJGhpUNo0LQ=

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -2188,19 +2188,30 @@ func (e *exporter) constraintsArgs(globalKey string) (description.ConstraintsArg
 		}
 		return nil
 	}
+	optionalBool := func(name string) bool {
+		switch value := doc[name].(type) {
+		case nil:
+		case bool:
+			return value
+		default:
+			optionalErr = errors.Errorf("expected bool for %s, got %T", name, value)
+		}
+		return false
+	}
 	result := description.ConstraintsArgs{
-		Architecture:   optionalString("arch"),
-		Container:      optionalString("container"),
-		CpuCores:       optionalInt("cpucores"),
-		CpuPower:       optionalInt("cpupower"),
-		InstanceType:   optionalString("instancetype"),
-		Memory:         optionalInt("mem"),
-		RootDisk:       optionalInt("rootdisk"),
-		RootDiskSource: optionalString("rootdisksource"),
-		Spaces:         optionalStringSlice("spaces"),
-		Tags:           optionalStringSlice("tags"),
-		VirtType:       optionalString("virttype"),
-		Zones:          optionalStringSlice("zones"),
+		AllocatePublicIP: optionalBool("allocatepublicip"),
+		Architecture:     optionalString("arch"),
+		Container:        optionalString("container"),
+		CpuCores:         optionalInt("cpucores"),
+		CpuPower:         optionalInt("cpupower"),
+		InstanceType:     optionalString("instancetype"),
+		Memory:           optionalInt("mem"),
+		RootDisk:         optionalInt("rootdisk"),
+		RootDiskSource:   optionalString("rootdisksource"),
+		Spaces:           optionalStringSlice("spaces"),
+		Tags:             optionalStringSlice("tags"),
+		VirtType:         optionalString("virttype"),
+		Zones:            optionalStringSlice("zones"),
 	}
 	if optionalErr != nil {
 		return description.ConstraintsArgs{}, errors.Trace(optionalErr)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -2284,6 +2284,9 @@ func (i *importer) constraints(cons description.Constraints) constraints.Value {
 		return result
 	}
 
+	if allocate := cons.AllocatePublicIP(); allocate {
+		result.AllocatePublicIP = &allocate
+	}
 	if arch := cons.Architecture(); arch != "" {
 		result.Arch = &arch
 	}


### PR DESCRIPTION
Ensure that the allocate-public-ip constraint is not lost when doing a migration.

## QA steps

```console
$ juju bootstrap localhost --constraints "allocate-public-ip=true" destination
$ juju bootstrap localhost --constraints "allocate-public-ip=true" source
$ juju add-model moveme
$ juju set-model-constraints "allocate-public-ip=true"
$ juju get-model-constraints
allocate-public-ip=true
$ juju migrate moveme destination
Migration started with ID "8fb8b10e-36fe-48e4-8d85-e91360f03eb6:0"
$ juju switch destination:admin/moveme
$ juju get-model-constraints
allocate-public-ip=true
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1980526