### PR TITLE
Use host arch as default arch for testing instance

### DIFF
--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils/v3/arch"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
@@ -171,7 +172,9 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 	if params.Constraints.Arch != nil {
 		filter.Arch = *params.Constraints.Arch
 	} else {
-		filter.Arch = "amd64"
+		// This deviates slightly from standard behaviour when bootstrapping for
+		// convenience so that by default instances start with a compatible arch
+		filter.Arch = arch.HostArch()
 	}
 	streams := tools.PreferredStreams(&agentVersion, env.Config().Development(), env.Config().AgentStream())
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())


### PR DESCRIPTION
A load of unit tests were failing on arm machines with "no matching agent binaries available"

This is because we were defaulting to amd64 in juju/testing/instance if another arch was not provided. Instead, default to the arch of the host machine

This may not resolve all failures, but it resolves at least one
QA Steps

Clone + checkout juju on an arm machine, and run unit tests

For example
```
go test github.com/juju/juju/cmd/jujud/agent
```