### PR TITLE
Fix type in add-cloud help doc

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -63,7 +63,7 @@ When invoked without arguments, add-cloud begins an interactive session
 designed for working with private clouds.  The session will enable you 
 to instruct Juju how to connect to your private cloud.
 
-A cloud definition can be provided in a file either as an option --f or as a 
+A cloud definition can be provided in a file either as an option -f or as a 
 positional argument:
 
     juju add-cloud mycloud ~/mycloud.yaml


### PR DESCRIPTION
Fix type in juju add cloud doc

### QA Steps

```sh
juju add-cloud -h
```