### PR TITLE
fixed charm channel issue in test-trusted-bundles-deploy-aws

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -35,7 +35,8 @@ run_deploy_cmr_bundle() {
 
 	ensure "test-cmr-bundles-deploy" "${file}"
 
-	juju deploy mysql
+  # mysql charm does not have stable channel, so we use edge channel
+	juju deploy mysql --channel=edge
 	wait_for "mysql" ".applications | keys[0]"
 
 	juju offer mysql:db


### PR DESCRIPTION
This is the fix for https://jenkins.juju.canonical.com/job/test-deploy-test-deploy-bundles-aws/.
Because the mysql charm does not have a stable channel, that issue broke the CMR test. This patch specifies the edge channel explicitly.

## QA steps
None

## Documentation changes

None
