### PR TITLE
[JUJU-1393] Do not set application status in charmdownloader;

### DIFF
--- a/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/charms/services"
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
-	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -78,7 +77,6 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharms(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	now := s.clk.Now()
 	charmURL := charm.MustParseURL("cs:focal/dummy-1")
 	resolvedOrigin := corecharm.Origin{
 		Source: "charm-hub",
@@ -99,23 +97,6 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharms(c *gc.C) {
 	app.EXPECT().CharmPendingToBeDownloaded().Return(true)
 	app.EXPECT().Charm().Return(pendingCharm, false, nil)
 	app.EXPECT().CharmOrigin().Return(&resolvedOrigin)
-	gomock.InOrder(
-		app.EXPECT().SetStatus(status.StatusInfo{
-			Status:  status.Maintenance,
-			Message: "downloading charm",
-			Data: map[string]interface{}{
-				"origin":    resolvedOrigin,
-				"charm-url": charmURL,
-				"force":     false,
-			},
-			Since: &now,
-		}),
-		app.EXPECT().SetStatus(status.StatusInfo{
-			Status:  status.Unknown,
-			Message: "",
-			Since:   &now,
-		}),
-	)
 
 	s.authChecker.EXPECT().AuthController().Return(true)
 	s.stateBackend.EXPECT().Application("ufo").Return(app, nil)
@@ -136,7 +117,6 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsSetStatusIfDownloadF
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	now := s.clk.Now()
 	charmURL := charm.MustParseURL("cs:focal/dummy-1")
 	resolvedOrigin := corecharm.Origin{
 		Source: "charm-hub",
@@ -157,23 +137,6 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsSetStatusIfDownloadF
 	app.EXPECT().CharmPendingToBeDownloaded().Return(true)
 	app.EXPECT().Charm().Return(pendingCharm, false, nil)
 	app.EXPECT().CharmOrigin().Return(&resolvedOrigin)
-	gomock.InOrder(
-		app.EXPECT().SetStatus(status.StatusInfo{
-			Status:  status.Maintenance,
-			Message: "downloading charm",
-			Data: map[string]interface{}{
-				"origin":    resolvedOrigin,
-				"charm-url": charmURL,
-				"force":     false,
-			},
-			Since: &now,
-		}),
-		app.EXPECT().SetStatus(status.StatusInfo{
-			Status:  status.Blocked,
-			Message: "unable to download charm",
-			Since:   &now,
-		}),
-	)
 
 	s.authChecker.EXPECT().AuthController().Return(true)
 	s.stateBackend.EXPECT().Application("ufo").Return(app, nil)


### PR DESCRIPTION
Juju should not set application status, so remove the app status set code from charm downloader.

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

