### PR TITLE
[JUJU-1410] Make CMR robust to consume side relation removal

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -21,11 +21,14 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
-var logger = loggo.GetLoggerWithLabels("juju.apiserver.common.crossmodel", corelogger.CMR)
+var (
+	logger     = loggo.GetLoggerWithLabels("juju.apiserver.common.crossmodel", corelogger.CMR)
+	authlogger = loggo.GetLoggerWithLabels("juju.apiserver.common.crossmodelauth", corelogger.CMR_AUTH)
+)
 
 // PublishRelationChange applies the relation change event to the specified backend.
 func PublishRelationChange(backend Backend, relationTag names.Tag, change params.RemoteRelationChangeEvent) error {
-	logger.Debugf("publish into model %v change for %v: %+v", backend.ModelUUID(), relationTag, change)
+	logger.Debugf("publish into model %v change for %v: %#v", backend.ModelUUID(), relationTag, &change)
 
 	dyingOrDead := change.Life != "" && change.Life != life.Alive
 	// Ensure the relation exists.
@@ -49,7 +52,7 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 	if err != nil && !errors.IsNotFound(err) {
 		return errors.Trace(err)
 	}
-	logger.Debugf("application tag for token %+v is %v in model %v", change.ApplicationToken, applicationTag, backend.ModelUUID())
+	logger.Debugf("application tag for token %v is %v in model %v", change.ApplicationToken, applicationTag, backend.ModelUUID())
 
 	// If the remote model has destroyed the relation, do it here also.
 	forceCleanUp := change.ForceCleanup != nil && *change.ForceCleanup
@@ -395,7 +398,7 @@ func RelationUnitSettings(backend Backend, ru params.RelationUnit) (params.Setti
 
 // PublishIngressNetworkChange saves the specified ingress networks for a relation.
 func PublishIngressNetworkChange(backend Backend, relationTag names.Tag, change params.IngressNetworksChangeEvent) error {
-	logger.Debugf("publish into model %v network change for %v: %+v", backend.ModelUUID(), relationTag, change)
+	logger.Debugf("publish into model %v network change for %v: %#v", backend.ModelUUID(), relationTag, &change)
 
 	// Ensure the relation exists.
 	rel, err := backend.KeyRelation(relationTag.Id())

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -193,6 +193,7 @@ func (api *API) remoteRelation(entity params.Entity) (*params.RemoteRelation, er
 		Life:      life.Value(rel.Life().String()),
 		Suspended: rel.Suspended(),
 		Key:       tag.Id(),
+		UnitCount: rel.UnitCount(),
 	}
 	for _, ep := range rel.Endpoints() {
 		// Try looking up the info for the remote application.

--- a/apiserver/facades/controller/remoterelations/remoterelations_test.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations_test.go
@@ -443,6 +443,7 @@ func (s *remoteRelationsSuite) TestRelations(c *gc.C) {
 			Life:                  "alive",
 			Suspended:             true,
 			Key:                   "db2:db django:db",
+			UnitCount:             666,
 			RemoteApplicationName: "db2",
 			RemoteEndpointName:    "data",
 			ApplicationName:       "django",

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -22189,7 +22189,8 @@
                     "required": [
                         "relation-token",
                         "application-token",
-                        "life"
+                        "life",
+                        "unit-count"
                     ]
                 },
                 "RemoteRelationDetails": {
@@ -38645,7 +38646,8 @@
                     "required": [
                         "relation-token",
                         "application-token",
-                        "life"
+                        "life",
+                        "unit-count"
                     ]
                 },
                 "RemoteRelationUnitChange": {
@@ -39270,6 +39272,9 @@
                         },
                         "suspended": {
                             "type": "boolean"
+                        },
+                        "unit-count": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,
@@ -39280,6 +39285,7 @@
                         "key",
                         "application-name",
                         "endpoint",
+                        "unit-count",
                         "remote-application-name",
                         "remote-endpoint-name",
                         "source-model-uuid"
@@ -39344,7 +39350,8 @@
                     "required": [
                         "relation-token",
                         "application-token",
-                        "life"
+                        "life",
+                        "unit-count"
                     ]
                 },
                 "RemoteRelationResult": {

--- a/core/logger/labels.go
+++ b/core/logger/labels.go
@@ -20,4 +20,7 @@ const (
 
 	// CMR defines a common label for dealing with cross model relations.
 	CMR Label = "cmr"
+
+	// CMR_AUTH defines a common label for dealing with cross model relations auth.
+	CMR_AUTH Label = "cmr-auth"
 )

--- a/rpc/params/crossmodel.go
+++ b/rpc/params/crossmodel.go
@@ -6,6 +6,7 @@ package params
 import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/charm/v8"
+	"github.com/kr/pretty"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/core/life"
@@ -216,6 +217,7 @@ type RemoteRelation struct {
 	Key                   string         `json:"key"`
 	ApplicationName       string         `json:"application-name"`
 	Endpoint              RemoteEndpoint `json:"endpoint"`
+	UnitCount             int            `json:"unit-count"`
 	RemoteApplicationName string         `json:"remote-application-name"`
 	RemoteEndpointName    string         `json:"remote-endpoint-name"`
 	SourceModelUUID       string         `json:"source-model-uuid"`
@@ -374,7 +376,7 @@ type RemoteRelationChangeEvent struct {
 	ForceCleanup *bool `json:"force-cleanup,omitempty"`
 
 	// UnitCount is the number of units still in relation scope.
-	UnitCount *int `json:"unit-count,omitempty"`
+	UnitCount *int `json:"unit-count"`
 
 	// Suspended is the current suspended status of the relation.
 	Suspended *bool `json:"suspended,omitempty"`
@@ -397,6 +399,15 @@ type RemoteRelationChangeEvent struct {
 
 	// BakeryVersion is the version of the bakery used to mint macaroons.
 	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
+}
+
+func (e *RemoteRelationChangeEvent) GoString() string {
+	if e == nil {
+		return "<nil>"
+	}
+	eCopy := *e
+	eCopy.Macaroons = nil
+	return pretty.Sprint(eCopy)
 }
 
 // RemoteRelationWatchResult holds a RemoteRelationWatcher id, initial
@@ -490,6 +501,15 @@ type IngressNetworksChangeEvent struct {
 
 	// BakeryVersion is the version of the bakery used to mint macaroons.
 	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
+}
+
+func (e *IngressNetworksChangeEvent) GoString() string {
+	if e == nil {
+		return "<nil>"
+	}
+	eCopy := *e
+	eCopy.Macaroons = nil
+	return pretty.Sprint(eCopy)
 }
 
 // RegisterRemoteRelationArg holds attributes used to register a remote relation.

--- a/worker/remoterelations/relationunitsworker.go
+++ b/worker/remoterelations/relationunitsworker.go
@@ -98,7 +98,7 @@ func (w *relationUnitsWorker) loop() error {
 				// We are dying.
 				return w.catacomb.ErrDying()
 			}
-			w.logger.Debugf("%v relation units changed for %v: %#v", w.mode, w.relationTag, change)
+			w.logger.Debugf("%v relation units changed for %v: %#v", w.mode, w.relationTag, &change)
 			if isEmpty(change) {
 				continue
 			}

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -64,12 +64,13 @@ type remoteApplicationWorker struct {
 // relation holds attributes relevant to a particular
 // relation between a local app and a remote offer.
 type relation struct {
-	relationId int
-	localDead  bool
-	suspended  bool
-	localRuw   *relationUnitsWorker
-	remoteRuw  *relationUnitsWorker
-	remoteRrw  *remoteRelationsWorker
+	relationId     int
+	localDead      bool
+	suspended      bool
+	localUnitCount int
+	localRuw       *relationUnitsWorker
+	remoteRuw      *relationUnitsWorker
+	remoteRrw      *remoteRelationsWorker
 
 	applicationToken   string // token for app in local model
 	relationToken      string // token for relation in local model
@@ -137,7 +138,7 @@ func isNotFound(err error) bool {
 }
 
 func (w *remoteApplicationWorker) loop() (err error) {
-	// Watch for changes to any remote relations to this application.
+	// Watch for changes to any local relations to the remote application.
 	relationsWatcher, err := w.localModelFacade.WatchRemoteApplicationRelations(w.applicationName)
 	if err != nil && isNotFound(err) {
 		return nil
@@ -193,7 +194,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
 		case change, ok := <-relationsWatcher.Changes():
-			w.logger.Debugf("relations changed: %#v, %v", change, ok)
+			w.logger.Debugf("relations changed: %#v, %v", &change, ok)
 			if !ok {
 				// We are dying.
 				return w.catacomb.ErrDying()
@@ -218,7 +219,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 				}
 			}
 		case change := <-w.localRelationUnitChanges:
-			w.logger.Debugf("local relation units changed -> publishing: %#v", change)
+			w.logger.Debugf("local relation units changed -> publishing: %#v", &change)
 			// TODO(babbageclunk): add macaroons to event here instead
 			// of in the relation units worker.
 			if err := w.remoteModelFacade.PublishRelationChange(change.RemoteRelationChangeEvent); err != nil {
@@ -227,19 +228,28 @@ func (w *remoteApplicationWorker) loop() (err error) {
 					w.logger.Debugf("relation %v changed but remote side already removed", change.Tag.Id())
 					continue
 				}
-				return errors.Annotatef(err, "publishing relation change %+v to remote model %v", change, w.remoteModelUUID)
+				return errors.Annotatef(err, "publishing relation change %#v to remote model %v", &change, w.remoteModelUUID)
 			}
-			if err := w.localRelationChanged(change.Tag.Id(), change.UnitCount); err != nil {
+
+			// TODO(juju4) - remove
+			// UnitCount has had omitempty removed, but we need to account for older controllers.
+			zero := 0
+			unitCount := change.UnitCount
+			if unitCount == nil {
+				unitCount = &zero
+			}
+
+			if err := w.localRelationChanged(change.Tag.Id(), unitCount); err != nil {
 				return errors.Annotatef(err, "processing local relation change for %v", change.Tag.Id())
 			}
 		case change := <-w.remoteRelationUnitChanges:
-			w.logger.Debugf("remote relation units changed -> consuming: %#v", change)
+			w.logger.Debugf("remote relation units changed -> consuming: %#v", &change)
 			if err := w.localModelFacade.ConsumeRemoteRelationChange(change.RemoteRelationChangeEvent); err != nil {
 				if isNotFound(err) || params.IsCodeCannotEnterScope(err) {
 					w.logger.Debugf("relation %v changed but local side already removed", change.Tag.Id())
 					continue
 				}
-				return errors.Annotatef(err, "consuming relation change %+v from remote model %v", change, w.remoteModelUUID)
+				return errors.Annotatef(err, "consuming relation change %#v from remote model %v", &change, w.remoteModelUUID)
 			}
 		case changes := <-offerStatusChanges:
 			w.logger.Debugf("offer status changed: %#v", changes)
@@ -324,7 +334,7 @@ func (w *remoteApplicationWorker) processRelationDying(key string, r *relation, 
 				w.logger.Debugf("relation %v dying but remote side already removed", key)
 				return nil
 			}
-			return errors.Annotatef(err, "publishing relation dying %+v to remote model %v", change, w.remoteModelUUID)
+			return errors.Annotatef(err, "publishing relation dying %#v to remote model %v", &change, w.remoteModelUUID)
 		}
 	}
 	return nil
@@ -384,31 +394,49 @@ func (w *remoteApplicationWorker) processLocalRelationRemoved(key string, relati
 		relations[key] = relation
 	}
 
-	w.logger.Debugf("remote relation %v removed from remote model", key)
+	w.logger.Debugf("remote relation %v removed from local model", key)
 	return nil
 }
 
 // localRelationChanged processes changes to the relation
 // as recorded in the local model; the primary function
 // is to shut down workers when the relation is dead.
-func (w *remoteApplicationWorker) localRelationChanged(key string, unitCount *int) error {
-	w.logger.Debugf("local relation %v changed", key)
+func (w *remoteApplicationWorker) localRelationChanged(key string, unitCountPtr *int) error {
+	unitCountMsg := " (removed)"
+	if unitCountPtr != nil {
+		unitCountMsg = fmt.Sprintf(", still has %d unit(s) in scope", *unitCountPtr)
+	}
+	w.logger.Debugf("local relation %v changed%s", key, unitCountMsg)
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
 	relation, ok := w.relations[key]
 	if !ok {
+		w.logger.Debugf("local relation %v already gone", key)
 		return nil
 	}
-	if !relation.localDead && unitCount != nil {
+	w.logger.Debugf("relation %v in mem unit count is %d", key, relation.localUnitCount)
+	if unitCountPtr != nil {
+		relation.localUnitCount = *unitCountPtr
+	}
+	if !relation.localDead {
+		w.logger.Debugf("local relation %v not dead yet", key)
 		return nil
 	}
-	if unitCount != nil && *unitCount > 1 {
-		w.logger.Debugf("relation dead but still has %d units in scope", *unitCount)
+	if relation.localUnitCount > 0 {
+		w.logger.Debugf("relation dead but still has %d units in scope", relation.localUnitCount)
+		return nil
+	}
+	return w.terminateLocalRelation(key)
+}
+
+func (w *remoteApplicationWorker) terminateLocalRelation(key string) error {
+	relation, ok := w.relations[key]
+	if !ok {
 		return nil
 	}
 	delete(w.relations, key)
-	w.logger.Debugf("local relation %v is dead", key)
+	w.logger.Debugf("local relation %v is terminated", key)
 
 	// For the unit watchers, check to see if these are nil before stopping.
 	// They will be nil if the relation was suspended and then we kill it for real.
@@ -425,7 +453,7 @@ func (w *remoteApplicationWorker) localRelationChanged(key string, unitCount *in
 		relation.remoteRuw = nil
 	}
 
-	w.logger.Debugf("remote relation %v removed from local model", key)
+	w.logger.Debugf("local relation %v removed from local model", key)
 	return nil
 }
 
@@ -462,9 +490,19 @@ func (w *remoteApplicationWorker) relationChanged(key string, localRelation para
 		if localRelationInfo.Suspended {
 			return w.processRelationSuspended(key, localRelationInfo.Life, w.relations)
 		}
-		if !wasSuspended && localRelationInfo.Life == life.Alive {
-			// Nothing to do, we have previously started the watcher.
-			return nil
+		if localRelationInfo.Life == life.Alive {
+			if r.localDead {
+				// A previous relation with the same name was removed but
+				// not cleaned up properly so do it now before starting up
+				// workers again.
+				w.logger.Debugf("still have zombie local relation %v", key)
+				if err := w.terminateLocalRelation(key); err != nil {
+					return errors.Annotatef(err, "terminating zombie local relation %v", key)
+				}
+			} else if !wasSuspended {
+				// Nothing to do, we have previously started the watcher.
+				return nil
+			}
 		}
 	}
 
@@ -586,6 +624,7 @@ func (w *remoteApplicationWorker) processConsumingRelation(
 		r = &relation{
 			relationId:         remoteRelation.Id,
 			suspended:          remoteRelation.Suspended,
+			localUnitCount:     remoteRelation.UnitCount,
 			remoteRrw:          remoteRelationsWorker,
 			macaroon:           mac,
 			localEndpoint:      remoteRelation.Endpoint,


### PR DESCRIPTION
There's an issue when removing a cmr relation in the consuming model, where the local app has more than one unit.
The end result is that on the offering side, the relation is stuck and not removed because all the unit departed events are not delivered. This can happen if the relation removal event is received on the consuming side before all the unit departed events - the relation removal event shuts down the workers and any remaining unit departed events are not published.

The core fix is in `worker/remoterelations/remoteapplicationworker.go`. The other changes are tweaks to logging which are useful anyway so they have been kept.

We now track the count of units still in scope on the relation. This must get to zero before the relation workers are shutdown, allowing all unit departed events to be published.

## QA steps

Bootstrap lxd and add microk8s as a cloud. Add a k8s model and deploy coredns and export
```
juju deploy coredns --channel=latest/stable --trust
juju offer coredns:dns-provider
```
In a lxd model, deploy kubernets-control-plane and relate
```
juju deploy kubernetes-control-plane -n 2
juju config kubernetes-control-plane dns-provider=none
juju consume k8s-test.coredns
juju relate coredns kubernetes-control-plane
```
After things settle, the k8s control plane units will be blocked because not everything is set up but that's fine.
Remove the relation
```
juju remove-relation coredns kubernetes-control-plane
```
On the consuming side, the relation will be removed. On the offering side, the offer will show 0 connections and the offer can be removed.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1976311
