### PR TITLE
Use --client in "juju clouds" test instead of --local (gone in 3.0)

### DIFF
--- a/acceptancetests/assess_cloud_display.py
+++ b/acceptancetests/assess_cloud_display.py
@@ -59,7 +59,7 @@ def remove_display_attributes(cloud):
 
 def get_clouds(client):
     cloud_list = yaml.safe_load(client.get_juju_output(
-        'clouds', '--format', 'yaml', '--local', include_e=False))
+        'clouds', '--format', 'yaml', '--client', include_e=False))
     cloud_list_without_builtins = {
         k: v for (k, v) in iter(cloud_list.items()) if
         v['defined'] != 'built-in'
@@ -94,7 +94,7 @@ def assess_show_cloud(client, expected):
     for cloud_name, expected_cloud in expected.items():
         actual_cloud = yaml.safe_load(client.get_juju_output(
             'show-cloud', cloud_name, '--format', 'yaml',
-            '--local', include_e=False))
+            '--client', include_e=False))
         remove_display_attributes(actual_cloud)
         assert_equal(actual_cloud, expected_cloud)
 


### PR DESCRIPTION
This fixes the `nw-clouds-display` test failures on 3.0, which removes the `--local` (we only accept `--client` now). [Failure example](https://jenkins.juju.canonical.com/job/nw-clouds-display/110/console) was:

```
assess_clouds (no_clouds): FAIL
Traceback (most recent call last):
  File "/home/jenkins/workspace/nw-clouds-display/juju-src-functional/acceptancetests/assess_cloud_display.py", line 149, in <module>
    sys.exit(main())
  File "/home/jenkins/workspace/nw-clouds-display/juju-src-functional/acceptancetests/assess_cloud_display.py", line 136, in main
    assess_clouds(client, {})
  File "/home/jenkins/workspace/nw-clouds-display/juju-src-functional/acceptancetests/assess_cloud_display.py", line 88, in assess_clouds
    cloud_list = get_clouds(client)
  File "/home/jenkins/workspace/nw-clouds-display/juju-src-functional/acceptancetests/assess_cloud_display.py", line 61, in get_clouds
    cloud_list = yaml.safe_load(client.get_juju_output(
  File "/home/jenkins/workspace/nw-clouds-display/juju-src-functional/acceptancetests/jujupy/client.py", line 1153, in get_juju_output
    return self.get_raw_juju_output(command, model, *args, **kwargs)
  File "/home/jenkins/workspace/nw-clouds-display/juju-src-functional/acceptancetests/jujupy/client.py", line 1167, in get_raw_juju_output
    return self._backend.get_juju_output(
  File "/home/jenkins/workspace/nw-clouds-display/juju-src-functional/acceptancetests/jujupy/backend.py", line 280, in get_juju_output
    raise e
subprocess.CalledProcessError: Command '('juju', '--show-log', 'clouds', '--format', 'yaml', '--local')' returned non-zero exit status 2.
```