### PR TITLE
Rename show-controller uuid -> controller-uuid ('uuid' gone in 3.0)

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1683,7 +1683,7 @@ class ModelClient:
             '--format', 'yaml',
             include_e=False)
         output = yaml.safe_load(output_yaml)
-        return output[name]['details']['uuid']
+        return output[name]['details']['controller-uuid']
 
     def get_controller_model_uuid(self):
         output_yaml = self.get_juju_output(

--- a/acceptancetests/jujupy/fake.py
+++ b/acceptancetests/jujupy/fake.py
@@ -798,7 +798,7 @@ class FakeBackend:
             controller_name: {
                 'details': {
                     'api-endpoints': [api_endpoint],
-                    'uuid': uuid,
+                    'controller-uuid': uuid,
                 }
             }
         }


### PR DESCRIPTION
This was breaking the model-migration tests on 3.0, [for example](https://jenkins.juju.canonical.com/job/nw-model-migration-amd64-lxd/107/console) (output below). The `uuid` field was renamed to `controller-uuid` a number of years ago for clarity, and the legacy `uuid` field was only removed in 3.0, hence the failures. But we can update the tests in the 2.9 branch too.

```
2022-07-05 14:01:37 ERROR 'uuid'
Traceback (most recent call last):
  File "/home/jenkins/workspace/nw-model-migration-amd64-lxd/juju-src-functional/acceptancetests/utility.py", line 432, in logged_exception
    yield
  File "/home/jenkins/workspace/nw-model-migration-amd64-lxd/juju-src-functional/acceptancetests/deploy_stack.py", line 1077, in runtime_context
    yield
  File "/home/jenkins/workspace/nw-model-migration-amd64-lxd/juju-src-functional/acceptancetests/deploy_stack.py", line 1229, in existing_booted_context
    yield machines
  File "/home/jenkins/workspace/nw-model-migration-amd64-lxd/juju-src-functional/acceptancetests/assess_model_migration.py", line 58, in assess_model_migration
    ensure_api_login_redirects(source_client, dest_client, model_constraints)
  File "/home/jenkins/workspace/nw-model-migration-amd64-lxd/juju-src-functional/acceptancetests/assess_model_migration.py", line 182, in ensure_api_login_redirects
    assert_model_has_correct_controller_uuid(source_client)
  File "/home/jenkins/workspace/nw-model-migration-amd64-lxd/juju-src-functional/acceptancetests/assess_model_migration.py", line 228, in assert_model_has_correct_controller_uuid
    controller_uuid = client.get_controller_uuid()
  File "/home/jenkins/workspace/nw-model-migration-amd64-lxd/juju-src-functional/acceptancetests/jujupy/client.py", line 1698, in get_controller_uuid
    return output[name]['details']['uuid']
KeyError: 'uuid'
```