### PR TITLE
[JUJU-1409] Stop forcing lxd tests to bionic.

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -232,19 +232,9 @@ juju_bootstrap() {
 		esac
 	fi
 
-	# TODO(walllyworld) - remove when we fix the nested lxd and snap/focal issue
-	# Snap doesn't work in nested focal LXD containers.
-	# So we force the model default series to be bionic.
-	model_default_series=
-	case "${BOOTSTRAP_PROVIDER:-}" in
-	"localhost" | "lxd" | "lxd-remote")
-		model_default_series="--model-default default-series=bionic"
-		;;
-	esac
-
 	pre_bootstrap
 
-	command="juju bootstrap ${series} ${model_default_series} ${cloud_region} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${series} ${cloud_region} ${name} -d ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"


### PR DESCRIPTION
Due to past bugs and CI setup we forced lxd tests to bionic. We can
safely remove this now in favour of focal as bionic is being removed
from supported.

## Checklist

 - [x] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [x] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed
 - [x] Comments answer the question of why design decisions were made

## QA steps

Run lxd tests in /tests.

## Documentation changes

N/A

## Bug reference

N/A
