### PR TITLE
Faster bootstrap when using local agent.

### DIFF
--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -31,6 +31,10 @@ type cloudConfig struct {
 	// renderer is the shell Renderer for this cloudConfig.
 	renderer shell.Renderer
 
+	// fileTransporter allows the cloud config to optionally emit files that it
+	// wants to be planted on the target machine.
+	fileTransporter FileTransporter
+
 	// attrs is the map of options set on this cloudConfig.
 	// main attributes used in the options map and their corresponding types:
 	//
@@ -103,6 +107,10 @@ func (cfg *cloudConfig) SetAttr(name string, value interface{}) {
 // UnsetAttr is defined on the CloudConfig interface.
 func (cfg *cloudConfig) UnsetAttr(name string) {
 	delete(cfg.attrs, name)
+}
+
+func (cfg *cloudConfig) SetFileTransporter(ft FileTransporter) {
+	cfg.fileTransporter = ft
 }
 
 func annotateKeys(rawKeys string) []string {
@@ -390,6 +398,11 @@ func (cfg *cloudConfig) AddBootTextFile(filename, contents string, perm uint) {
 
 // AddRunBinaryFile is defined on the WrittenFilesConfig interface.
 func (cfg *cloudConfig) AddRunBinaryFile(filename string, data []byte, mode uint) {
+	if cfg.fileTransporter != nil {
+		source := cfg.fileTransporter.SendBytes(filename, data)
+		cfg.AddScripts(addFileCopyCmds(source, filename, mode)...)
+		return
+	}
 	cfg.AddScripts(addFileCmds(filename, data, mode, true)...)
 }
 

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -319,6 +319,10 @@ type WrittenFilesConfig interface {
 	// of a given file with the specified file permissions on *first* boot.
 	// NOTE: if the file already exists, it will be truncated.
 	AddRunBinaryFile(string, []byte, uint)
+
+	// SetFileTransporter sets an alternative transporter for files added currently
+	// with AddRunBinaryFile.
+	SetFileTransporter(FileTransporter)
 }
 
 // RenderConfig provides various ways to render a CloudConfig.
@@ -417,6 +421,12 @@ type HostnameConfig interface {
 type NetworkingConfig interface {
 	// AddNetworkConfig adds network config from interfaces to the container.
 	AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error
+}
+
+// FileTransporter is the interface set on CloudConfig when it wants to optionally
+// deliver files by its own means.
+type FileTransporter interface {
+	SendBytes(hint string, payload []byte) string
 }
 
 // New returns a new Config with no options set.

--- a/cloudconfig/cloudinit/utils.go
+++ b/cloudconfig/cloudinit/utils.go
@@ -59,6 +59,24 @@ func addFileCmds(filename string, data []byte, mode uint, binary bool) []string 
 	return cmds
 }
 
+// addFileCopyCmds is a helper function returns all the required shell commands to copy
+// a file (be it text or binary) with regards to the given parameters
+// NOTE: if the file already exists, it will be overwritten.
+func addFileCopyCmds(source string, filename string, mode uint) []string {
+	// Note: recent versions of cloud-init have the "write_files"
+	// module, which can write arbitrary files. We currently support
+	// 12.04 LTS, which uses an older version of cloud-init without
+	// this module.
+	// TODO (aznashwan): eagerly await 2017 and to do the right thing here
+	s := utils.ShQuote(source)
+	p := utils.ShQuote(filename)
+
+	cmds := []string{fmt.Sprintf("install -D -m %o /dev/null %s", mode, p)}
+	cmds = append(cmds, fmt.Sprintf(`cat %s > %s`, s, p))
+
+	return cmds
+}
+
 // removeStringFromSlice is a helper function which removes a given string from
 // the given slice, if it exists it returns the slice, be it modified or unmodified
 func removeStringFromSlice(slice []string, val string) []string {


### PR DESCRIPTION
Instead of making a 55mb shell script, scp the juju binaries over. About 22s faster on my local machine.

#### Before

```
$ time juju bootstrap localhost
Creating Juju controller "localhost-localhost" on localhost/localhost
Looking for packaged Juju agent version 3.0-beta2 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md
Launching controller instance(s) on localhost/localhost...
 - juju-87bed7-0 (arch=amd64)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.75.71.165:22
Connected to 10.75.71.165
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.75.71.165 to verify accessibility...

Bootstrap complete, controller "localhost-localhost" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.
juju bootstrap localhost  7.14s user 1.84s system 7% cpu 1:52.42 total
```

#### After

```
$ time juju bootstrap localhost
Creating Juju controller "localhost-localhost" on localhost/localhost
Looking for packaged Juju agent version 3.0-beta2 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md
Launching controller instance(s) on localhost/localhost...
 - juju-f2cb23-0 (arch=amd64)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.75.71.50:22
Connected to 10.75.71.50
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.75.71.50 to verify accessibility...

Bootstrap complete, controller "localhost-localhost" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.
juju bootstrap localhost  5.04s user 1.07s system 6% cpu 1:30.33 total
```

## QA steps

bootstrap lxd/aws/etc.. (not k8s)

## Documentation changes

N/A

## Bug reference

N/A