### PR TITLE
[JUJU-1394] Deprecate bionic;

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -171,6 +171,7 @@ func (s *modelManagerUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *
 		// - check if the model has deprecated ubuntu machines;
 		ctrlState.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",
@@ -206,6 +207,7 @@ func (s *modelManagerUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *
 		// - check if the model has deprecated ubuntu machines;
 		state1.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",
@@ -310,6 +312,7 @@ func (s *modelManagerUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed
 		// - check if the model has deprecated ubuntu machines;
 		ctrlState.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",
@@ -347,6 +350,7 @@ func (s *modelManagerUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed
 		// - check if the model has deprecated ubuntu machines;
 		state1.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",
@@ -426,6 +430,7 @@ func (s *modelManagerUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool)
 		// - check if the model has deprecated ubuntu machines;
 		st.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",
@@ -502,6 +507,7 @@ func (s *modelManagerUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 		// - check if the model has deprecated ubuntu machines;
 		st.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",

--- a/core/series/supported.go
+++ b/core/series/supported.go
@@ -309,7 +309,6 @@ var ubuntuSeries = map[SeriesName]seriesVersion{
 		WorkloadType: ControllerWorkloadType,
 		Version:      "18.04",
 		LTS:          true,
-		Supported:    true,
 		ESMSupported: true,
 	},
 	Cosmic: {

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -226,7 +226,6 @@ func (s *SupportedSeriesSuite) TestUbuntuVersions(c *gc.C) {
 			WorkloadType: ControllerWorkloadType,
 			Version:      "18.04",
 			LTS:          true,
-			Supported:    true,
 			ESMSupported: true,
 		},
 		Cosmic: {
@@ -273,7 +272,7 @@ func (s *SupportedSeriesSuite) TestUbuntuVersions(c *gc.C) {
 	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "focal": "20.04", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "jammy": "22.04", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
 
 	result = ubuntuVersions(boolPtr(true), boolPtr(true), ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "focal": "20.04", "jammy": "22.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"focal": "20.04", "jammy": "22.04"})
 
 	result = ubuntuVersions(boolPtr(false), boolPtr(false), ubuntuSeries)
 	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "yakkety": "16.10", "zesty": "17.04"})
@@ -282,13 +281,13 @@ func (s *SupportedSeriesSuite) TestUbuntuVersions(c *gc.C) {
 	c.Check(result, gc.DeepEquals, map[string]string{})
 
 	result = ubuntuVersions(boolPtr(false), boolPtr(true), ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"trusty": "14.04", "xenial": "16.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "trusty": "14.04", "xenial": "16.04"})
 
 	result = ubuntuVersions(boolPtr(true), nil, ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "focal": "20.04", "jammy": "22.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"focal": "20.04", "jammy": "22.04"})
 
 	result = ubuntuVersions(boolPtr(false), nil, ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
 
 	result = ubuntuVersions(nil, boolPtr(true), ubuntuSeries)
 	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "focal": "20.04", "jammy": "22.04", "trusty": "14.04", "xenial": "16.04"})

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -35,6 +35,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelMigrationSourceJuju3(c *g
 		).Return(nil, nil),
 		state.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -68,6 +68,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 		).Return(nil, nil),
 		ctrlState.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",
@@ -99,6 +100,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 		).Return(nil, nil),
 		state1.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",
@@ -220,6 +222,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 		).Return(nil, nil),
 		state.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -143,6 +143,7 @@ func (s *upgradeValidationSuite) TestCheckForDeprecatedUbuntuSeriesForModel(c *g
 	gomock.InOrder(
 		state.EXPECT().MachineCountForSeries(
 			"artful",
+			"bionic",
 			"cosmic",
 			"disco",
 			"eoan",


### PR DESCRIPTION
Deprecate bionic for model migrate upgrade;

## Checklist

 - [ ] ~Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [ ] ~Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - [ ] ~Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [x] ~Comments answer the question of why design decisions were made

## QA steps

```console
$ juju models -c k1 --format json | jq '.models[] | {name,"agent-version"}'
{
  "name": "admin/controller",
  "agent-version": "2.9.33.1"
}
{
  "name": "admin/default",
  "agent-version": "2.9.33.1"
}

$ juju list-machines --format json | jq '.machines[] | .series ' | sort | uniq -c
      3 "bionic"

$ juju upgrade-controller --build-agent -c k1
no prepackaged agent binaries available, using local agent binary 2.9.33.2 (built from source)
best version:
    2.9.33.2
started upgrade to 2.9.33.2

$ juju upgrade-controller --build-agent -c k1
no prepackaged agent binaries available, using local agent binary 3.0-beta2.1 (built from source)
best version:
    3.0-beta2.1
ERROR cannot upgrade to "3.0-beta2.1" due to issues with these models:
"admin/default":
- the model hosts deprecated ubuntu machine(s): bionic(3) (not supported)
```
