### PR TITLE
[JUJU-1107] new color scheme for juju run

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -7,14 +7,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/juju/ansiterm"
-	"github.com/juju/juju/cmd/output"
 	"io"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/juju/ansiterm"
+	"github.com/juju/juju/cmd/output"
 
 	"github.com/juju/juju/rpc/params"
 
@@ -248,7 +249,7 @@ func (c *runCommandBase) processOperationResultsWithColor(ctx *cmd.Context, resu
 			ctx.Infof("Check operation status with 'juju show-operation %s'", opIDColored)
 			ctx.Infof("Check task status with 'juju show-task %s'", actionIdColored)
 		} else {
-			ctx.Infof("Scheduled operation %s with %d tasks", opIDColored, numTasksColored)
+			ctx.Infof("Scheduled operation %s with %v tasks", opIDColored, numTasksColored)
 			_ = output.FormatYamlWithColor(ctx.Stdout, info)
 			ctx.Infof("Check operation status with 'juju show-operation %s'", opIDColored)
 			ctx.Infof("Check task status with 'juju show-task <id>'")

--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -266,7 +266,7 @@ func (c *runCommandBase) processOperationResultsWithColor(ctx *cmd.Context, resu
 		list := make([]string, 0, len(failed))
 		for k, v := range failed {
 
-			list = append(list, fmt.Sprintf(" - id %q with return code %d", k, colorVal(output.EmphasisHighlight.Magenta, v)))
+			list = append(list, fmt.Sprintf(" - id %q with return code %v", k, colorVal(output.EmphasisHighlight.Magenta, v)))
 		}
 		sort.Strings(list)
 

--- a/cmd/juju/action/listoperations.go
+++ b/cmd/juju/action/listoperations.go
@@ -35,6 +35,7 @@ type listOperationsCommand struct {
 	ActionCommandBase
 	out              cmd.Output
 	utc              bool
+	color            bool
 	applicationNames []string
 	unitNames        []string
 	machineNames     []string
@@ -77,12 +78,13 @@ func (c *listOperationsCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ActionCommandBase.SetFlags(f)
 	defaultFormatter := "plain"
 	c.out.AddFlags(f, defaultFormatter, map[string]cmd.Formatter{
-		"yaml":  cmd.FormatYaml,
-		"json":  cmd.FormatJson,
+		"yaml":  c.formatYaml,
+		"json":  c.formatJson,
 		"plain": c.formatTabular,
 	})
 
 	f.BoolVar(&c.utc, "utc", false, "Show times in UTC")
+	f.BoolVar(&c.color, "color", false, "Use ANSI color codes in output")
 	f.Var(cmd.NewStringsValue(nil, &c.applicationNames), "applications", "Comma separated list of applications to filter on")
 	f.Var(cmd.NewStringsValue(nil, &c.applicationNames), "apps", "Comma separated list of applications to filter on")
 	f.Var(cmd.NewStringsValue(nil, &c.unitNames), "units", "Comma separated list of units to filter on")
@@ -237,16 +239,46 @@ func (c *listOperationsCommand) formatTabular(writer io.Writer, value interface{
 			if len(line.tasks) > maxTaskIDs {
 				tasks += "..."
 			}
-			w.Print(line.id, line.status)
-			w.Print(formatTimestamp(line.started, false, c.utc, true))
-			w.Print(formatTimestamp(line.finished, false, c.utc, true))
-			w.Print(tasks)
-			w.Println(line.operation)
+			if c.color {
+				w.PrintColor(output.EmphasisHighlight.Magenta, line.id)
+				w.PrintColor(output.GoodHighlight, line.status)
+				//w.Print(colorVal(output.EmphasisHighlight.BrightMagenta, line.id), colorVal(output.GoodHighlight, line.status))
+				w.PrintColor(output.InfoHighlight, formatTimestamp(line.started, false, c.utc, true))
+				w.PrintColor(output.GoodHighlight, formatTimestamp(line.finished, false, c.utc, true))
+				w.PrintColor(output.EmphasisHighlight.BrightMagenta, tasks)
+				w.PrintColorNoTab(output.EmphasisHighlight.Gray, fmt.Sprintf("%s\n", line.operation))
+			} else {
+				w.Print(line.id, line.status)
+				w.Print(formatTimestamp(line.started, false, c.utc, true))
+				w.Print(formatTimestamp(line.finished, false, c.utc, true))
+				w.Print(tasks)
+				w.Println(line.operation)
+			}
 		}
 	}
-	w.Println("ID", "Status", "Started", "Finished", "Task IDs", "Summary")
+	if c.color {
+		w.PrintHeaders(output.EmphasisHighlight.DefaultBold, "ID", "Status", "Started", "Finished", "Task IDs", "Summary")
+	} else {
+		w.Println("ID", "Status", "Started", "Finished", "Task IDs", "Summary")
+	}
 	printOperations(actionOperationLinesFromResults(results), c.utc)
 	return tw.Flush()
+}
+
+func (c *listOperationsCommand) formatYaml(writer io.Writer, value interface{}) error {
+	if c.color {
+		return output.FormatYamlWithColor(writer, value)
+	}
+
+	return cmd.FormatYaml(writer, value)
+}
+
+func (c *listOperationsCommand) formatJson(writer io.Writer, value interface{}) error {
+	if c.color {
+		return output.FormatJsonWithColor(writer, value)
+	}
+
+	return cmd.FormatJson(writer, value)
 }
 
 func actionOperationLinesFromResults(results []actionapi.Operation) []operationLine {

--- a/cmd/juju/action/run.go
+++ b/cmd/juju/action/run.go
@@ -170,7 +170,7 @@ func (c *runCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return c.processOperationResults(ctx, results)
+	return c.operationResults(ctx, results)
 }
 
 func (c *runCommand) enqueueActions(ctx *cmd.Context) (*actionapi.EnqueuedActions, error) {

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -160,27 +160,29 @@ var InfoHighlight = ansiterm.Foreground(ansiterm.Cyan)
 // EmphasisHighlight is used to show accompanying information, which
 // might be deemed as important by the user.
 var EmphasisHighlight = struct {
-	White         *ansiterm.Context
-	DefaultBold   *ansiterm.Context
-	BoldWhite     *ansiterm.Context
-	Gray          *ansiterm.Context
-	BoldGray      *ansiterm.Context
-	DarkGray      *ansiterm.Context
-	BoldDarkGray  *ansiterm.Context
-	Magenta       *ansiterm.Context
-	BrightMagenta *ansiterm.Context
-	BrightGreen   *ansiterm.Context
+	White             *ansiterm.Context
+	DefaultBold       *ansiterm.Context
+	BoldWhite         *ansiterm.Context
+	Gray              *ansiterm.Context
+	BoldGray          *ansiterm.Context
+	DarkGray          *ansiterm.Context
+	BoldDarkGray      *ansiterm.Context
+	Magenta           *ansiterm.Context
+	BrightMagenta     *ansiterm.Context
+	BoldBrightMagenta *ansiterm.Context
+	BrightGreen       *ansiterm.Context
 }{
-	White:         ansiterm.Foreground(ansiterm.White),
-	DefaultBold:   ansiterm.Foreground(ansiterm.Default).SetStyle(ansiterm.Bold),
-	BoldWhite:     ansiterm.Foreground(ansiterm.White).SetStyle(ansiterm.Bold),
-	Gray:          ansiterm.Foreground(ansiterm.Gray),
-	BoldGray:      ansiterm.Foreground(ansiterm.Gray).SetStyle(ansiterm.Bold),
-	BoldDarkGray:  ansiterm.Foreground(ansiterm.DarkGray).SetStyle(ansiterm.Bold),
-	DarkGray:      ansiterm.Foreground(ansiterm.DarkGray),
-	Magenta:       ansiterm.Foreground(ansiterm.Magenta),
-	BrightMagenta: ansiterm.Foreground(ansiterm.BrightMagenta),
-	BrightGreen:   ansiterm.Foreground(ansiterm.BrightGreen),
+	White:             ansiterm.Foreground(ansiterm.White),
+	DefaultBold:       ansiterm.Foreground(ansiterm.Default).SetStyle(ansiterm.Bold),
+	BoldWhite:         ansiterm.Foreground(ansiterm.White).SetStyle(ansiterm.Bold),
+	Gray:              ansiterm.Foreground(ansiterm.Gray),
+	BoldGray:          ansiterm.Foreground(ansiterm.Gray).SetStyle(ansiterm.Bold),
+	BoldDarkGray:      ansiterm.Foreground(ansiterm.DarkGray).SetStyle(ansiterm.Bold),
+	DarkGray:          ansiterm.Foreground(ansiterm.DarkGray),
+	Magenta:           ansiterm.Foreground(ansiterm.Magenta),
+	BrightMagenta:     ansiterm.Foreground(ansiterm.BrightMagenta),
+	BoldBrightMagenta: ansiterm.Foreground(ansiterm.BrightMagenta).SetStyle(ansiterm.Bold),
+	BrightGreen:       ansiterm.Foreground(ansiterm.BrightGreen),
 }
 
 var statusColors = map[status.Status]*ansiterm.Context{


### PR DESCRIPTION
*Add vim default color scheme for  `juju run` output*

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps

```sh
  juju bootstrap localhost overlord
  juju add-model lxd-model 
  juju deploy postgresql
  juju run postgresql/0 maintenance-mode-start 
  juju run postgresql/0 maintenance-mode-stop
  juju run postgresql/0 maintenance-mode-start --color
  watch --color juju run postgresql/0 maintenance-mode-start --color
  juju run postgresql/0 maintenance-mode-start --format=yaml --color
  juju run postgresql/0 maintenance-mode-start  --format=json --color
```
*The output above should be colored*

```sh
  juju run postgresql/0 maintenance-mode-stop --no-color
  NO_COLOR="" juju run postgresql/0 maintenance-mode-stop 
  watch juju run postgresql/0 maintenance-mode-start 
  juju run postgresql/0 maintenance-mode-start  > output.txt
  juju run postgresql/0 maintenance-mode-start --color | cat
```
*The output above should **not** be colored*