### PR TITLE
Fix missing - in juju bootstrap command for bash tests.

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -239,7 +239,7 @@ juju_bootstrap() {
 
 	pre_bootstrap
 
-	command="juju bootstrap ${series} ${cloud_region} ${name} -add-model ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${series} ${cloud_region} ${name} --add-model ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"


### PR DESCRIPTION
Missing `-` in `-add-model`