### PR TITLE
When upgrading, use --default-model on 2.x and --add-model on 3.x

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -879,10 +879,11 @@ class ModelClient:
         if self.env.provider == 'kubernetes':
             return tuple(args)
 
-        args += [
-            '--constraints', self._get_substrate_constraints(arch),
-            '--add-model', self.env.environment
-        ]
+        args += ['--constraints', self._get_substrate_constraints(arch)]
+        if self.is_juju2x():
+            args += ['--default-model', self.env.environment]
+        else:
+            args += ['--add-model', self.env.environment]
         if force:
             args.extend(['--force'])
         if config_options:
@@ -1964,6 +1965,9 @@ class ModelClient:
 
     def is_juju1x(self):
         return self.version.startswith('1.')
+
+    def is_juju2x(self):
+        return self.version.startswith('2.')
 
     def _get_register_command(self, output):
         """Return register token from add-user output.


### PR DESCRIPTION
This should fix the error with nw-model-migration-versions ([for example](https://jenkins.juju.canonical.com/job/nw-model-migration-versions-aws/115/console)) due to trying to use `--add-model` when bootstrapping on 2.9. But that's called `--default-model` on 2.9.

```
00:19:46 INFO  juju.cmd supercommand.go:56 running juju [2.9.32 917a8f1033561ce28a73ff81d71da75aec6e0785 gc go1.18.3]
ERROR controller nw-model-migration-versions-aws-stable not found
2022-07-07 00:19:46 INFO juju --show-log bootstrap aws/eu-central-1 nw-model-migration-versions-aws-stable --config /tmp/tmpf5bym9r_.yaml --constraints  --add-model nw-model-migration-versions-aws-stable --agent-version 2.9.32
ERROR option provided but not defined: --add-model
2022-07-07 00:19:46 ERROR Command '('juju', '--show-log', 'bootstrap', 'aws/eu-central-1', 'nw-model-migration-versions-aws-stable', '--config', '/tmp/tmpf5bym9r_.yaml', '--constraints', '', '--add-model', 'nw-model-migration-versions-aws-stable', '--agent-version', '2.9.32')' returned non-zero exit status 2.
```

I haven't actually tested this code as it's hard to test locally, but we'll see when it's pushed to CI.