### PR TITLE
[JUJU-1422] Skip provider link-layer device update when machine not alive

### DIFF
--- a/apiserver/facades/controller/instancepoller/instancepoller.go
+++ b/apiserver/facades/controller/instancepoller/instancepoller.go
@@ -137,6 +137,14 @@ func (a *InstancePollerAPI) SetProviderNetworkConfig(
 			continue
 		}
 
+		// We assert in transactions that the machine is alive.
+		// If it is not, we assume that it will be removed from the
+		// instance-poller worker subsequently.
+		if machine.Life() != state.Alive {
+			logger.Debugf("machine %q is not alive; skipping provider network config update", machine.Id())
+			continue
+		}
+
 		configs := arg.Configs
 		logger.Tracef("provider network config for machine %q: %+v", machine.Id(), configs)
 


### PR DESCRIPTION
When updating provider-sourced link-layer device information, we assert in transactions that the machine is alive, but we do not check it outside of the transaction.

Here we simply skip the update if the machine is not alive, assuming that we will soon cease getting calls to update its network config.

## QA steps

This is hard to replicate, because we need: 
- A dying machine that is not being progressed.
- The instance-poller updating the machine's network config.

It is a trivial enough change to be verified by the accompanying unit test.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1948824
