### PR TITLE
[JUJU-1423] Remove SSHAddresses method from networking environ

### DIFF
--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/core/network"
-	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -17,7 +16,6 @@ import (
 // Backend defines the State API used by the sshclient facade.
 type Backend interface {
 	ModelConfig() (*config.Config, error)
-	CloudSpec() (environscloudspec.CloudSpec, error)
 	GetMachineForEntity(tag string) (SSHMachine, error)
 	GetSSHHostKeys(names.MachineTag) (state.SSHHostKeys, error)
 	ModelTag() names.ModelTag

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40434,7 +40434,7 @@
                             "$ref": "#/definitions/SSHAddressesResults"
                         }
                     },
-                    "description": "AllAddresses reports all addresses that might have SSH listening for each given\nentity in args. Machines and units are supported as entity types.\nTODO(wpk): 2017-05-17 This is a temporary solution, we should not fetch environ here\nbut get the addresses from state. We will be changing it since we want to have space-aware\nSSH settings."
+                    "description": "AllAddresses reports all addresses that might have SSH listening for each\nentity in args. The result is sorted with public addresses first.\nMachines and units are supported as entity types."
                 },
                 "Leader": {
                     "type": "object",

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -337,21 +337,6 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).ReleaseContainerAddresses), arg0, arg1)
 }
 
-// SSHAddresses mocks base method.
-func (m *MockNetworkingEnviron) SSHAddresses(arg0 context0.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
-	ret0, _ := ret[0].(network.SpaceAddresses)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SSHAddresses indicates an expected call of SSHAddresses.
-func (mr *MockNetworkingEnvironMockRecorder) SSHAddresses(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSHAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).SSHAddresses), arg0, arg1)
-}
-
 // SetConfig mocks base method.
 func (m *MockNetworkingEnviron) SetConfig(arg0 *config.Config) error {
 	m.ctrl.T.Helper()

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -95,17 +95,6 @@ type Networking interface {
 	// ReleaseContainerAddresses releases the previously allocated
 	// addresses matching the interface details passed in.
 	ReleaseContainerAddresses(ctx context.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error
-
-	// SSHAddresses filters the input addresses to those suitable for SSH use.
-	// Usually we would have the provider deal only with ProviderAddresses.
-	// This method is called from the sshclient API facade to filter addresses
-	// obtained from a `state.Machine` (which are SpaceAddresses).
-	// At the time of writing, each provider generally does one of two things:
-	// - just returns all the addresses back or;
-	// - returns a subset based on public scope matching.
-	// The address `Value` is then returned to the client,
-	// which is just a string, so we do not actually leak a SpaceAddress.
-	SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error)
 }
 
 // NetworkingEnviron combines the standard Environ interface with the

--- a/environs/space/environs_mock_test.go
+++ b/environs/space/environs_mock_test.go
@@ -501,21 +501,6 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).ReleaseContainerAddresses), arg0, arg1)
 }
 
-// SSHAddresses mocks base method.
-func (m *MockNetworkingEnviron) SSHAddresses(arg0 context.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
-	ret0, _ := ret[0].(network.SpaceAddresses)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SSHAddresses indicates an expected call of SSHAddresses.
-func (mr *MockNetworkingEnvironMockRecorder) SSHAddresses(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSHAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).SSHAddresses), arg0, arg1)
-}
-
 // SetConfig mocks base method.
 func (m *MockNetworkingEnviron) SetConfig(arg0 *config.Config) error {
 	m.ctrl.T.Helper()

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -1751,21 +1751,6 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).ReleaseContainerAddresses), arg0, arg1)
 }
 
-// SSHAddresses mocks base method.
-func (m *MockNetworkingEnviron) SSHAddresses(arg0 context0.ProviderCallContext, arg1 network.SpaceAddresses) (network.SpaceAddresses, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SSHAddresses", arg0, arg1)
-	ret0, _ := ret[0].(network.SpaceAddresses)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SSHAddresses indicates an expected call of SSHAddresses.
-func (mr *MockNetworkingEnvironMockRecorder) SSHAddresses(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSHAddresses", reflect.TypeOf((*MockNetworkingEnviron)(nil).SSHAddresses), arg0, arg1)
-}
-
 // SetConfig mocks base method.
 func (m *MockNetworkingEnviron) SetConfig(arg0 *config.Config) error {
 	m.ctrl.T.Helper()

--- a/provider/azure/environ_network.go
+++ b/provider/azure/environ_network.go
@@ -168,12 +168,6 @@ func (*azureEnviron) AreSpacesRoutable(_ context.ProviderCallContext, _, _ *envi
 	return false, nil
 }
 
-// SSHAddresses implements environs.NetworkingEnviron.
-func (*azureEnviron) SSHAddresses(
-	_ context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
-	return addresses, nil
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron. It returns back
 // a slice where the i_th element contains the list of network interfaces
 // for the i_th provided instance ID.

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -2031,18 +2031,6 @@ func (*environ) AssignLXDProfiles(instId string, profilesNames []string, profile
 	return profilesNames, nil
 }
 
-// SSHAddresses implements environs.SSHAddresses.
-// For testing we cut "100.100.100.100" out of this list.
-func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
-	var rv network.SpaceAddresses
-	for _, addr := range addresses {
-		if addr.Value != "100.100.100.100" {
-			rv = append(rv, addr)
-		}
-	}
-	return rv, nil
-}
-
 // SuperSubnets implements environs.SuperSubnets
 func (*environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error) {
 	return nil, errors.NotSupportedf("super subnets")

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -2731,11 +2731,6 @@ func (*environ) AreSpacesRoutable(ctx context.ProviderCallContext, space1, space
 	return false, nil
 }
 
-// SSHAddresses implements environs.SSHAddresses.
-func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
-	return addresses, nil
-}
-
 // SuperSubnets implements NetworkingEnviron.SuperSubnets
 func (e *environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error) {
 	vpcId := e.ecfg().vpcID()

--- a/provider/equinix/environ_network.go
+++ b/provider/equinix/environ_network.go
@@ -211,11 +211,6 @@ func (*environ) SupportsContainerAddresses(context.ProviderCallContext) (bool, e
 	return false, nil
 }
 
-// SSHAddresses filters the input addaddresses to those suitable for SSH use.
-func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
-	return addresses, nil
-}
-
 // SupportsSpaceDiscovery returns whether the current environment
 // supports discovering spaces from the provider. The returned error
 // satisfies errors.IsNotSupported(), unless a general API failure occurs.

--- a/provider/gce/environ_network.go
+++ b/provider/gce/environ_network.go
@@ -345,19 +345,6 @@ func (*environ) AreSpacesRoutable(ctx context.ProviderCallContext, space1, space
 	return false, nil
 }
 
-// SSHAddresses implements environs.SSHAddresses.
-// For GCE we want to make sure we're returning only one public address, so that probing won't
-// cause SSHGuard to lock us out
-func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses corenetwork.SpaceAddresses) (corenetwork.SpaceAddresses, error) {
-	bestAddress, ok := addresses.OneMatchingScope(corenetwork.ScopeMatchPublic)
-	if ok {
-		return corenetwork.SpaceAddresses{bestAddress}, nil
-	} else {
-		// fallback
-		return addresses, nil
-	}
-}
-
 // SuperSubnets implements environs.SuperSubnets
 func (e *environ) SuperSubnets(ctx context.ProviderCallContext) ([]string, error) {
 	subnets, err := e.Subnets(ctx, "", nil)

--- a/provider/lxd/environ_network.go
+++ b/provider/lxd/environ_network.go
@@ -442,8 +442,3 @@ func (*environ) AllocateContainerAddresses(context.ProviderCallContext, instance
 func (*environ) ReleaseContainerAddresses(context.ProviderCallContext, []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("container address allocation")
 }
-
-// SSHAddresses filters the input addresses to those suitable for SSH use.
-func (*environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
-	return addresses, nil
-}

--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -2480,11 +2480,6 @@ func (*maasEnviron) AreSpacesRoutable(ctx context.ProviderCallContext, space1, s
 	return false, nil
 }
 
-// SSHAddresses implements environs.SSHAddresses.
-func (*maasEnviron) SSHAddresses(ctx context.ProviderCallContext, addresses corenetwork.SpaceAddresses) (corenetwork.SpaceAddresses, error) {
-	return addresses, nil
-}
-
 // SuperSubnets implements environs.SuperSubnets
 func (*maasEnviron) SuperSubnets(ctx context.ProviderCallContext) ([]string, error) {
 	return nil, errors.NotSupportedf("super subnets")

--- a/provider/manual/environ_network.go
+++ b/provider/manual/environ_network.go
@@ -52,12 +52,6 @@ func (*manualEnviron) AreSpacesRoutable(_ context.ProviderCallContext, _, _ *env
 	return false, nil
 }
 
-// SSHAddresses implements environs.NetworkingEnviron.
-func (*manualEnviron) SSHAddresses(
-	_ context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
-	return addresses, nil
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron.
 func (e *manualEnviron) NetworkInterfaces(
 	context.ProviderCallContext, []instance.Id,

--- a/provider/oci/networking.go
+++ b/provider/oci/networking.go
@@ -1109,7 +1109,3 @@ func (e *Environ) AllocateContainerAddresses(
 func (e *Environ) ReleaseContainerAddresses(ctx envcontext.ProviderCallContext, interfaces []network.ProviderInterfaceInfo) error {
 	return errors.NotSupportedf("ReleaseContainerAddresses")
 }
-
-func (e *Environ) SSHAddresses(ctx envcontext.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
-	return addresses, nil
-}

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -2356,11 +2356,6 @@ func (*Environ) AreSpacesRoutable(ctx context.ProviderCallContext, space1, space
 	return false, nil
 }
 
-// SSHAddresses is specified on environs.SSHAddresses.
-func (*Environ) SSHAddresses(ctx context.ProviderCallContext, addresses network.SpaceAddresses) (network.SpaceAddresses, error) {
-	return addresses, nil
-}
-
 // SupportsRulesWithIPV6CIDRs returns true if the environment supports ingress
 // rules containing IPV6 CIDRs. It is part of the FirewallFeatureQuerier
 // interface.


### PR DESCRIPTION
The `AllAddresses` method on the `sshclient` facade is slow, because we load an environ for each call, in order to call the `SSHAddresses` method.

This method is largely superfluous - each provider except GCE just returns all the addresses that we pass to it. GCE simply filters for the first public address.

Here we remove the `SSHAddresses`, along with implementations from the `Networking` environ, and simply sort the addresses in order of scope, preferring the most public first.

## QA steps

Bootstrap onto each substrate and ensure that you can `juju ssh` to a machine.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1980759
