### PR TITLE
Fix mongo memory profile test on focal

### DIFF
--- a/tests/suites/controller/mongo_memory_profile.sh
+++ b/tests/suites/controller/mongo_memory_profile.sh
@@ -1,12 +1,6 @@
 cat_mongo_service() {
-	if juju run -m controller --machine 0 'cat /etc/systemd/system/juju-db.service'; then
-		# shellcheck disable=SC2046
-		echo $(juju run -m controller --machine 0 'cat /etc/systemd/system/juju-db.service' | grep "^ExecStart")
-	else
-		# On focal and beyond we install Mongo via a snap
-		# shellcheck disable=SC2046
-		echo $(juju run -m controller --machine 0 'sudo cat /var/snap/juju-db/common/juju-db.config' | grep "wiredTigerCacheSizeGB")
-	fi
+	# shellcheck disable=SC2046
+	echo $(juju exec -m controller --machine 0 'sudo cat /var/snap/juju-db/common/juju-db.config' | grep "wiredTigerCacheSizeGB")
 }
 
 run_mongo_memory_profile() {

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -173,7 +173,7 @@ run_deploy_lxd_to_container() {
 
 	wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 
-	OUT=$(juju run --machine 0 -- sh -c 'sudo lxc profile show "juju-test-deploy-lxd-container-lxd-profile-alt-0"')
+	OUT=$(juju exec --machine 0 -- sh -c 'sudo lxc profile show "juju-test-deploy-lxd-container-lxd-profile-alt-0"')
 	echo "${OUT}" | grep -E "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"
 
 	juju upgrade-charm "lxd-profile-alt" --path "${charm}"
@@ -185,7 +185,7 @@ run_deploy_lxd_to_container() {
 
 	attempt=0
 	while true; do
-		OUT=$(juju run --machine 0 -- sh -c 'sudo lxc profile show "juju-test-deploy-lxd-container-lxd-profile-alt-1"' || echo 'NOT FOUND')
+		OUT=$(juju exec --machine 0 -- sh -c 'sudo lxc profile show "juju-test-deploy-lxd-container-lxd-profile-alt-1"' || echo 'NOT FOUND')
 		if echo "${OUT}" | grep -E -q "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"; then
 			break
 		fi
@@ -201,7 +201,7 @@ run_deploy_lxd_to_container() {
 	# Ensure that the old one is removed
 	attempt=0
 	while true; do
-		OUT=$(juju run --machine 0 -- sh -c "sudo lxc profile list" || echo 'NOT FOUND')
+		OUT=$(juju exec --machine 0 -- sh -c "sudo lxc profile list" || echo 'NOT FOUND')
 		if echo "${OUT}" | grep -v "juju-test-deploy-lxd-container-lxd-profile-alt-0"; then
 			break
 		fi

--- a/tests/suites/expose_ec2/expose_app.sh
+++ b/tests/suites/expose_ec2/expose_app.sh
@@ -24,15 +24,15 @@ run_expose_app_ec2() {
 assert_opened_ports_output() {
 	echo "==> Checking open/opened-ports hook tools work as expected"
 
-	juju run --unit ubuntu-lite/0 "open-port 1337-1339/tcp"
-	juju run --unit ubuntu-lite/0 "open-port 1234/tcp --endpoints ubuntu"
+	juju exec --unit ubuntu-lite/0 "open-port 1337-1339/tcp"
+	juju exec --unit ubuntu-lite/0 "open-port 1234/tcp --endpoints ubuntu"
 
 	# Test the backwards-compatible version of opened-ports where the output
 	# includes the unique set of opened ports for all endpoints.
-	# Note that 'juju run' injects a trailing line-feed tot he command output
+	# Note that 'juju exec' injects a trailing line-feed tot he command output
 	# so we need to use echo to generate our expectation string.
 	exp=$(echo "1234/tcp 1337-1339/tcp" | tr '\n' ' ')
-	got=$(juju run --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ')
+	got=$(juju exec --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ')
 	if [ "$got" != "$exp" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected opened-ports output to be:\n${exp}\nGOT:\n${got}")
@@ -40,10 +40,10 @@ assert_opened_ports_output() {
 	fi
 
 	# Try the new version where we group by endpoint.
-	# Note that 'juju run' injects a trailing line-feed tot he command output
+	# Note that 'juju exec' injects a trailing line-feed tot he command output
 	# so we need to use echo to generate our expectation string.
 	exp=$(echo "1234/tcp (ubuntu) 1337-1339/tcp (*)" | tr '\n' ' ')
-	got=$(juju run --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ')
+	got=$(juju exec --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ')
 	if [ "$got" != "$exp" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected opened-ports output when using --endpoints to be:\n${exp}\nGOT:\n${got}")

--- a/tests/suites/hooks/dispatch.sh
+++ b/tests/suites/hooks/dispatch.sh
@@ -19,7 +19,7 @@ run_hook_dispatching_script() {
 	# awk, change the separator to " and get the 2nd value.
 	# e.g Action queued with id: "2"
 	# yields: 2
-	action_id=$(juju run-action ubuntu-plus/0 no-dispatch filename=test-dispatch | awk 'BEGIN{FS="\""} {print $2}')
+	action_id=$(juju exec-action ubuntu-plus/0 no-dispatch filename=test-dispatch | awk 'BEGIN{FS="\""} {print $2}')
 	juju show-action-status "${action_id}" | grep -q completed || true
 
 	# wait for update-status

--- a/tests/suites/hooktools/state_tools.sh
+++ b/tests/suites/hooktools/state_tools.sh
@@ -9,15 +9,15 @@ run_state_delete_get_set() {
 	juju deploy cs:~jameinel/ubuntu-lite-7
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
-	juju run --unit ubuntu-lite/0 'state-get | grep -q "{}"'
-	juju run --unit ubuntu-lite/0 'state-set one=two'
-	juju run --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
-	juju run --unit ubuntu-lite/0 'state-set three=four'
-	juju run --unit ubuntu-lite/0 'state-get three | grep -q "four"'
-	juju run --unit ubuntu-lite/0 'state-delete one'
-	juju run --unit ubuntu-lite/0 'state-get | grep -q "three: four"'
-	juju run --unit ubuntu-lite/0 'state-get one --strict | grep -q "ERROR \"one\" not found" || true'
-	juju run --unit ubuntu-lite/0 'state-get one'
+	juju exec --unit ubuntu-lite/0 'state-get | grep -q "{}"'
+	juju exec --unit ubuntu-lite/0 'state-set one=two'
+	juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
+	juju exec --unit ubuntu-lite/0 'state-set three=four'
+	juju exec --unit ubuntu-lite/0 'state-get three | grep -q "four"'
+	juju exec --unit ubuntu-lite/0 'state-delete one'
+	juju exec --unit ubuntu-lite/0 'state-get | grep -q "three: four"'
+	juju exec --unit ubuntu-lite/0 'state-get one --strict | grep -q "ERROR \"one\" not found" || true'
+	juju exec --unit ubuntu-lite/0 'state-get one'
 
 	destroy_model "${model_name}"
 }
@@ -37,15 +37,15 @@ run_state_set_clash_uniter_state() {
 	juju deploy cs:~jameinel/ubuntu-lite-7
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
-	juju run --unit ubuntu-lite/0 'state-get | grep -q "{}"'
-	juju run --unit ubuntu-lite/0 'state-set one=two'
-	juju run --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
+	juju exec --unit ubuntu-lite/0 'state-get | grep -q "{}"'
+	juju exec --unit ubuntu-lite/0 'state-set one=two'
+	juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
 
 	# force a hook
-	juju run --unit ubuntu-lite/0 hooks/update-status
+	juju exec --unit ubuntu-lite/0 hooks/update-status
 
 	# verify charm set values
-	juju run --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
+	juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -40,7 +40,7 @@ check_default_routes() {
 	echo "[+] checking default routes"
 
 	for machine in $(juju machines --format=json | jq -r ".machines | keys | .[]"); do
-		default=$(juju run --machine "$machine" -- ip route show | grep default)
+		default=$(juju exec --machine "$machine" -- ip route show | grep default)
 		if [ -z "$default" ]; then
 			echo "No default route detected for machine ${machine}"
 			exit 1
@@ -58,7 +58,7 @@ check_accessibility() {
 
 		# Check that each of the principles can access the subordinate.
 		for principle_unit in "ubuntu-focal/0" "ubuntu-jammy/0" "ubuntu-bionic/0"; do
-			check_contains "$(juju run --unit $principle_unit "$curl_cmd")" "pass"
+			check_contains "$(juju exec --unit $principle_unit "$curl_cmd")" "pass"
 		done
 
 		# Check that the exposed subordinate is accessible externally.

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -21,7 +21,7 @@ run_relation_data_exchange() {
 	# below will fail
 	attempt=0
 	while true; do
-		got=$(juju run --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress' || echo 'NOT FOUND')
+		got=$(juju exec --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress' || echo 'NOT FOUND')
 		if [ "${got}" != "NOT FOUND" ]; then
 			break
 		fi
@@ -35,7 +35,7 @@ run_relation_data_exchange() {
 	done
 	attempt=0
 	while true; do
-		got=$(juju run --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql' || echo 'NOT FOUND')
+		got=$(juju exec --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql' || echo 'NOT FOUND')
 		if [ "${got}" != "NOT FOUND" ]; then
 			break
 		fi
@@ -48,25 +48,25 @@ run_relation_data_exchange() {
 		sleep 1
 	done
 
-	juju run --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
+	juju exec --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
 
 	# As the leader units, set some *application* data for both sides of a
 	# non-peer relation
-	juju run --unit 'wordpress/0' 'relation-set --app -r db:2 origin=wordpress'
-	juju run --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
+	juju exec --unit 'wordpress/0' 'relation-set --app -r db:2 origin=wordpress'
+	juju exec --unit 'mysql/0' 'relation-set --app -r db:2 origin=mysql'
 
 	# As the leader wordpress unit, also set *application* data for a peer relation
-	juju run --unit 'wordpress/0' 'relation-set --app -r loadbalancer:0 visible=to-peers'
+	juju exec --unit 'wordpress/0' 'relation-set --app -r loadbalancer:0 visible=to-peers'
 
 	# Check 1: ensure that leaders can read the application databag for their
 	# own application (LP1854348)
-	got=$(juju run --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress')
+	got=$(juju exec --unit 'wordpress/0' 'relation-get --app -r db:2 origin wordpress')
 	if [ "${got}" != "wordpress" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected wordpress leader to read its own databag for non-peer relation")
 		exit 1
 	fi
-	got=$(juju run --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql')
+	got=$(juju exec --unit 'mysql/0' 'relation-get --app -r db:2 origin mysql')
 	if [ "${got}" != "mysql" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected mysql leader to read its own databag for non-peer relation")
@@ -75,13 +75,13 @@ run_relation_data_exchange() {
 
 	# Check 2: ensure that any unit can read its own application databag for
 	# *peer* relations LP1865229)
-	got=$(juju run --unit 'wordpress/0' 'relation-get --app -r loadbalancer:0 visible wordpress')
+	got=$(juju exec --unit 'wordpress/0' 'relation-get --app -r loadbalancer:0 visible wordpress')
 	if [ "${got}" != "to-peers" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected wordpress leader to read its own databag for a peer relation")
 		exit 1
 	fi
-	got=$(juju run --unit 'wordpress/1' 'relation-get --app -r loadbalancer:0 visible wordpress')
+	got=$(juju exec --unit 'wordpress/1' 'relation-get --app -r loadbalancer:0 visible wordpress')
 	if [ "${got}" != "to-peers" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected wordpress non-leader to read its own databag for a peer relation")
@@ -90,7 +90,7 @@ run_relation_data_exchange() {
 
 	# Check 3: ensure that non-leader units are not allowed to read their own
 	# application databag for non-peer relations
-	got=$(juju run --unit 'wordpress/1' 'relation-get --app -r db:2 origin wordpress' || echo 'PERMISSION DENIED')
+	got=$(juju exec --unit 'wordpress/1' 'relation-get --app -r db:2 origin wordpress' || echo 'PERMISSION DENIED')
 	if [ "${got}" != "PERMISSION DENIED" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected wordpress non-leader not to be allowed to read the databag for a non-peer relation")

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -15,22 +15,22 @@ run_relation_list_app() {
 	wait_for "mysql" "$(idle_condition "mysql" 0 0)"
 
 	# Figure out the right relation IDs to use for our hook tool invocations
-	db_rel_id=$(juju run --unit mysql/0 "relation-ids db" | cut -d':' -f2)
-	peer_rel_id=$(juju run --unit mysql/0 "relation-ids cluster" | cut -d':' -f2)
+	db_rel_id=$(juju exec --unit mysql/0 "relation-ids db" | cut -d':' -f2)
+	peer_rel_id=$(juju exec --unit mysql/0 "relation-ids cluster" | cut -d':' -f2)
 
 	# Remove wordpress unit; the wordpress-mysql relation is still established
 	# but there are no units present in the wordpress side
 	juju remove-unit wordpress/0
 	sleep 5
 
-	got=$(juju run --unit mysql/0 "relation-list --app -r ${db_rel_id}")
+	got=$(juju exec --unit mysql/0 "relation-list --app -r ${db_rel_id}")
 	if [ "${got}" != "wordpress" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected running 'relation-list --app' on mysql unit for non-peer relation to return 'wordpress'; got ${got}")
 		exit 1
 	fi
 
-	got=$(juju run --unit mysql/0 "relation-list --app -r ${peer_rel_id}")
+	got=$(juju exec --unit mysql/0 "relation-list --app -r ${peer_rel_id}")
 	if [ "${got}" != "mysql" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected running 'relation-list --app' on mysql unit for peer relation to return 'mysql'; got ${got}")

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -50,7 +50,7 @@ assert_net_iface_for_endpoint_matches() {
 	exp_if_name=${3}
 
 	# shellcheck disable=SC2086,SC2016
-	got_if=$(juju run -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}')
+	got_if=$(juju exec -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: ens" | awk '{print $2}')
 	if [ "$got_if" != "$exp_if_name" ]; then
 		# shellcheck disable=SC2086,SC2016,SC2046
 		echo $(red "Expected network interface for ${app_name}:${endpoint_name} to be ${exp_if_name}; got ${got_if}")


### PR DESCRIPTION
The mongo memory profile test was attempting to deal with mongo from deb (on bionic) and from snap, but this was not working properly and the test failed on focal. We bootstrap to focal or later by default now and so only need the snap version of the test.

Also, change `juju run` to `juju exec` so that the tests pass regardless of whether the new actions UX is enabled, which also makes the tests the same as for 3.0

## QA steps

`main.sh controller`