### PR TITLE
Fix typos in some bash tests

### DIFF
--- a/tests/suites/expose_ec2/expose_app.sh
+++ b/tests/suites/expose_ec2/expose_app.sh
@@ -29,10 +29,8 @@ assert_opened_ports_output() {
 
 	# Test the backwards-compatible version of opened-ports where the output
 	# includes the unique set of opened ports for all endpoints.
-	# Note that 'juju exec' injects a trailing line-feed tot he command output
-	# so we need to use echo to generate our expectation string.
-	exp=$(echo "1234/tcp 1337-1339/tcp" | tr '\n' ' ')
-	got=$(juju exec --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ')
+	exp="1234/tcp 1337-1339/tcp"
+	got=$(juju exec --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
 	if [ "$got" != "$exp" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected opened-ports output to be:\n${exp}\nGOT:\n${got}")
@@ -40,10 +38,8 @@ assert_opened_ports_output() {
 	fi
 
 	# Try the new version where we group by endpoint.
-	# Note that 'juju exec' injects a trailing line-feed tot he command output
-	# so we need to use echo to generate our expectation string.
-	exp=$(echo "1234/tcp (ubuntu) 1337-1339/tcp (*)" | tr '\n' ' ')
-	got=$(juju exec --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ')
+	exp="1234/tcp (ubuntu) 1337-1339/tcp (*)"
+	got=$(juju exec --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
 	if [ "$got" != "$exp" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected opened-ports output when using --endpoints to be:\n${exp}\nGOT:\n${got}")

--- a/tests/suites/hooks/dispatch.sh
+++ b/tests/suites/hooks/dispatch.sh
@@ -19,7 +19,7 @@ run_hook_dispatching_script() {
 	# awk, change the separator to " and get the 2nd value.
 	# e.g Action queued with id: "2"
 	# yields: 2
-	action_id=$(juju exec-action ubuntu-plus/0 no-dispatch filename=test-dispatch | awk 'BEGIN{FS="\""} {print $2}')
+	action_id=$(juju run-action ubuntu-plus/0 no-dispatch filename=test-dispatch | awk 'BEGIN{FS="\""} {print $2}')
 	juju show-action-status "${action_id}" | grep -q completed || true
 
 	# wait for update-status


### PR DESCRIPTION
A recent update to 2.9 had a sed error, so this fixes that `exec-action` -> `run-action`.
Also align the 2.9 opened-ports tests with 3.0

## QA steps

run affected tests