### PR TITLE
Allow upgrading from 2.9.x to 3.0.0 by dropping capped txns.log collection.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/juju/schema v1.0.1-0.20190814234152-1f8aaeef0989
 	github.com/juju/terms-client/v2 v2.0.0-20220207005045-25aa57bf93cd
 	github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494
-	github.com/juju/txn/v2 v2.0.0-20220204100656-93c9d8a9b89f
+	github.com/juju/txn/v2 v2.0.0-20220708051510-a47ef96b6543
 	github.com/juju/utils v0.0.0-20200604140309-9d78121a29e0
 	github.com/juju/utils/v3 v3.0.0-20220203023959-c3fbc78a33b0
 	github.com/juju/version/v2 v2.0.0-20220204124744-fc9915e3d935

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/juju/testing v0.0.0-20210302031854-2c7ee8570c07/go.mod h1:7lxZW0B50+x
 github.com/juju/testing v0.0.0-20210324180055-18c50b0c2098/go.mod h1:7lxZW0B50+xdGFkvhAb8bwAGt6IU87JB1H9w4t8MNVM=
 github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494 h1:XEDzpuZb8Ma7vLja3+5hzUqVTvAqm5Y+ygvnDs5iTMM=
 github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494/go.mod h1:rUquetT0ALL48LHZhyRGvjjBH8xZaZ8dFClulKK5wK4=
-github.com/juju/txn/v2 v2.0.0-20220204100656-93c9d8a9b89f h1:IMKfv0HgEfQNwWiWkPYNUJ0nI2yZ3JWety0+yQWf9eQ=
-github.com/juju/txn/v2 v2.0.0-20220204100656-93c9d8a9b89f/go.mod h1:Sh0uxANJLqw/GccwAhz4qIn+eWFVbAlQSBynFR4luY8=
+github.com/juju/txn/v2 v2.0.0-20220708051510-a47ef96b6543 h1:NT1obdBzRv8WgamyEIROtYStggIVgD5FkgJvatnhHKQ=
+github.com/juju/txn/v2 v2.0.0-20220708051510-a47ef96b6543/go.mod h1:Sh0uxANJLqw/GccwAhz4qIn+eWFVbAlQSBynFR4luY8=
 github.com/juju/usso v1.0.1 h1:zyQhSUJnhFZdPqVAmPeqXYlnYXv+i0Cp1Ii+aziMXGs=
 github.com/juju/usso v1.0.1/go.mod h1:3cvBcGVmWXyHhrBHBQtpNBzca/JRg4S5XH88Hj/NsYA=
 github.com/juju/utils v0.0.0-20160526025251-ffea6ead0c37/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=

--- a/state/mocks/database_mock.go
+++ b/state/mocks/database_mock.go
@@ -113,6 +113,20 @@ func (mr *MockDatabaseMockRecorder) GetRawCollection(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawCollection", reflect.TypeOf((*MockDatabase)(nil).GetRawCollection), arg0)
 }
 
+// NoChangeLog mocks base method.
+func (m *MockDatabase) NoChangeLog() state.Database {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NoChangeLog")
+	ret0, _ := ret[0].(state.Database)
+	return ret0
+}
+
+// NoChangeLog indicates an expected call of NoChangeLog.
+func (mr *MockDatabaseMockRecorder) NoChangeLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoChangeLog", reflect.TypeOf((*MockDatabase)(nil).NoChangeLog))
+}
+
 // Run mocks base method.
 func (m *MockDatabase) Run(arg0 txn0.TransactionSource) error {
 	m.ctrl.T.Helper()

--- a/state/mocks/resources_mock.go
+++ b/state/mocks/resources_mock.go
@@ -13,7 +13,6 @@ import (
 	resource "github.com/juju/charm/v9/resource"
 	resources "github.com/juju/juju/core/resources"
 	state "github.com/juju/juju/state"
-	txn "github.com/juju/mgo/v2/txn"
 )
 
 // MockResources is a mock of Resources interface.
@@ -112,21 +111,6 @@ func (m *MockResources) ListResources(arg0 string) (resources.ApplicationResourc
 func (mr *MockResourcesMockRecorder) ListResources(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResources", reflect.TypeOf((*MockResources)(nil).ListResources), arg0)
-}
-
-// NewResolvePendingResourcesOps mocks base method.
-func (m *MockResources) NewResolvePendingResourcesOps(arg0 string, arg1 map[string]string) ([]txn.Op, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewResolvePendingResourcesOps", arg0, arg1)
-	ret0, _ := ret[0].([]txn.Op)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewResolvePendingResourcesOps indicates an expected call of NewResolvePendingResourcesOps.
-func (mr *MockResourcesMockRecorder) NewResolvePendingResourcesOps(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewResolvePendingResourcesOps", reflect.TypeOf((*MockResources)(nil).NewResolvePendingResourcesOps), arg0, arg1)
 }
 
 // OpenResource mocks base method.

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -330,7 +330,7 @@ func (st *State) EnsureUpgradeInfo(
 			Assert: txn.DocExists,
 		})
 	}
-	if err := st.runRawTransaction(ops); err == nil {
+	if err := st.db().NoChangeLog().RunRawTransaction(ops); err == nil {
 		return &UpgradeInfo{st: st, doc: doc}, nil
 	} else if err != txn.ErrAborted {
 		return nil, errors.Annotate(err, "cannot create upgrade info")
@@ -360,7 +360,7 @@ func (st *State) EnsureUpgradeInfo(
 			"$addToSet", bson.D{{"controllersReady", controllerId}},
 		}},
 	}}
-	switch err := st.db().RunTransaction(ops); err {
+	switch err := st.db().NoChangeLog().RunTransaction(ops); err {
 	case nil:
 		return ensureUpgradeInfoUpdated(st, controllerId, previousVersion, targetVersion)
 	case txn.ErrAborted:

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -49,6 +49,9 @@ type StateBackend interface {
 	RemoveLocalCharmOriginChannels() error
 	FixCharmhubLastPolltime() error
 	RemoveUseFloatingIPConfigFalse() error
+
+	// 3.0.x related functions
+	MigrateCappedTxnsLogCollection() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -227,4 +230,8 @@ func (s stateBackend) FixCharmhubLastPolltime() error {
 
 func (s stateBackend) RemoveUseFloatingIPConfigFalse() error {
 	return state.RemoveUseFloatingIPConfigFalse(s.pool)
+}
+
+func (s stateBackend) MigrateCappedTxnsLogCollection() error {
+	return state.MigrateCappedTxnsLogCollection(s.pool)
 }

--- a/upgrades/steps_30.go
+++ b/upgrades/steps_30.go
@@ -10,3 +10,15 @@ func stepsFor30() []Step {
 func stateStepsFor30() []Step {
 	return []Step{}
 }
+
+func stateStepsForSSTXN() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "migrate txns.log from capped collection",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().MigrateCappedTxnsLogCollection()
+			},
+		},
+	}
+}

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -27,8 +27,7 @@ func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (boo
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
-	// TODO: enable here once we fix the capped txn collection issue in juju3.
-	// 3: version.MustParse("2.9.33"),
+	3: version.MustParse("2.9.33"),
 }
 
 // UpgradeToAllowed returns true if a major version upgrade is allowed

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -48,14 +48,6 @@ func (s *versionSuite) TestUpgradeToAllowed(c *gc.C) {
 			minVers: "2.9.33",
 			patch:   true,
 		}, {
-			from:    "2.9.34",
-			to:      "3.0.0",
-			allowed: false,
-			minVers: "0.0.0",
-			patch:   false, // We disallow upgrading to 3 for now.
-			err:     `cannot upgrade, "3.0.0" is not a supported version`,
-		},
-		{
 			from:    "2.9.0",
 			to:      "4.0.0",
 			allowed: false,


### PR DESCRIPTION
This fix drops `txns.log` if it's a capped collection during upgrade.
It then recreates it as a non-capped collection before continuing with the actual upgrades.

## QA steps

- Deploy juju 2.9 with upgrade allowed to 3.0.0
- `juju upgrade-controller --build-agent`
- Controller + controller model should upgrade to 3.0.0

## Documentation changes

N/A

## Bug reference

N/A