### PR TITLE
[JUJU-1424] Adjustments to Mongo Logging Config

### DIFF
--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -51,6 +51,7 @@ func (s *serviceSuite) TestNewConf24(c *gc.C) {
 		"--sslPEMKeyPassword=ignored",
 		"--port",
 		"--syslog",
+		"--slowms",
 		"--journal",
 		"--port",
 		"--quiet",
@@ -70,9 +71,10 @@ func (s *serviceSuite) TestNewConf24(c *gc.C) {
 		"--dbpath":        "'/var/lib/juju/db'",
 		"--sslPEMKeyFile": "'/var/lib/juju/server.pem'",
 		"--port":          "12345",
-		" --keyFile":      "'/var/lib/juju/shared-secret'",
-		" --oplogSize":    "10",
-		" --replSet":      "juju",
+		"--keyFile":       "'/var/lib/juju/shared-secret'",
+		"--oplogSize":     "10",
+		"--replSet":       "juju",
+		"--slowms":        "1000",
 	}
 
 	c.Assert(conf.Desc, gc.Not(gc.Equals), "")
@@ -162,6 +164,7 @@ func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
 		"--sslPEMKeyPassword=ignored",
 		"--port",
 		"--syslog",
+		"--slowms",
 		"--journal",
 		"--port",
 		"--quiet",
@@ -187,6 +190,7 @@ func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
 		"--storageEngine":         "wiredTiger",
 		"--wiredTigerCacheSizeGB": "1",
 		"--sslMode":               "requireSSL",
+		"--slowms":                "1000",
 	}
 
 	c.Assert(conf.Desc, gc.Not(gc.Equals), "")
@@ -195,8 +199,7 @@ func (s *serviceSuite) TestNewConf32LowMem(c *gc.C) {
 		if !strings.HasPrefix(field, "-") {
 			continue
 		}
-		logger.Debugf("checking argument %v", field)
-		c.Assert(expectedArgs.Contains(field), gc.Equals, true)
+		c.Assert(expectedArgs.Contains(field), gc.Equals, true, gc.Commentf("expected arg %q not found", field))
 		expectedArgs.Remove(field)
 
 		expectedVal, ok := expectedKwArgs[field]


### PR DESCRIPTION
To-date we have not specified a configuration value for `slowms`, which is the threshold at which Mongo considers an operation to be slow and writes it to the log. The default value is 100, which appears in some cases to cause excessive logging. On older installations using apt-installed Mongo (logging to syslog) we have observed flooding of the serial console, leading to soft lock-ups.

For Snap-installed Mongo, we have been using the `logappend` option, which causes the same file to be written to in perpetuity. On one of the PS5-beta controllers, this was larger than 30GiB.

This patch does 2 things:
- Adds the `slowms` item with a value of 1000.
- Removes the `logappend` option for the snap, which archives the old log file and starts a new one with each Mongo restart. This will make management easier.

## QA steps

- Bootstrap a controller and SSH to it.
- Check that the contents of _/var/snap/juju-db/common/juju-db.config_ look like this:
```
dbpath = /var/snap/juju-db/common/db
sslPEMKeyFile = /var/snap/juju-db/common/server.pem
oplogSize = 1024
replSet = juju
sslPEMKeyPassword=ignored
keyFile = /var/snap/juju-db/common/shared-secret
slowms = 1000
logpath = /var/snap/juju-db/common/logs/mongodb.log
journal = true
quiet = true
port = 37017
ipv6 = true
bind_ip_all = true
sslMode = requireSSL
auth = true
```
- Find the juju-db process with `ps aux|grep juju-db`.
- Send a SIGUSR1 to it with `kill -SIGUSR1 <PID>`.
- Check the contents of _/var/snap/juju-db/common/logs/_. You should see the current file and archives something like:
```
-rw------- 1 root root  2757 Jul  8 11:19 mongodb.log
-rw-r--r-- 1 root root  5813 Jul  8 11:09 mongodb.log.2022-07-08T11-09-05
-rw------- 1 root root  6360 Jul  8 11:09 mongodb.log.2022-07-08T11-09-22
-rw------- 1 root root 32345 Jul  8 11:19 mongodb.log.2022-07-08T11-19-04
```

## Documentation changes

None.

## Bug reference

N/A
