### PR TITLE
[JUJU-1430] CMR connection closure error logging and simplification

### DIFF
--- a/worker/firewaller/manifold.go
+++ b/worker/firewaller/manifold.go
@@ -43,7 +43,7 @@ type ManifoldConfig struct {
 	Logger        Logger
 
 	NewControllerConnection      apicaller.NewExternalControllerConnectionFunc
-	NewRemoteRelationsFacade     func(base.APICaller) (*remoterelations.Client, error)
+	NewRemoteRelationsFacade     func(base.APICaller) *remoterelations.Client
 	NewFirewallerFacade          func(base.APICaller) (FirewallerAPI, error)
 	NewFirewallerWorker          func(Config) (worker.Worker, error)
 	NewCredentialValidatorFacade func(base.APICaller) (common.CredentialAPI, error)
@@ -133,10 +133,6 @@ func (cfg ManifoldConfig) start(context dependency.Context) (worker.Worker, erro
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	remoteRelationsAPI, err := cfg.NewRemoteRelationsFacade(apiConn)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 
 	credentialAPI, err := cfg.NewCredentialValidatorFacade(apiConn)
 	if err != nil {
@@ -155,7 +151,7 @@ func (cfg ManifoldConfig) start(context dependency.Context) (worker.Worker, erro
 
 	w, err := cfg.NewFirewallerWorker(Config{
 		ModelUUID:               agent.CurrentConfig().Model().Id(),
-		RemoteRelationsApi:      remoteRelationsAPI,
+		RemoteRelationsApi:      cfg.NewRemoteRelationsFacade(apiConn),
 		FirewallerAPI:           firewallerAPI,
 		EnvironFirewaller:       fwEnv,
 		EnvironInstances:        environ,

--- a/worker/firewaller/manifold_test.go
+++ b/worker/firewaller/manifold_test.go
@@ -84,7 +84,7 @@ func validConfig() firewaller.ManifoldConfig {
 		NewControllerConnection:      func(*api.Info) (api.Connection, error) { return nil, nil },
 		NewFirewallerFacade:          func(base.APICaller) (firewaller.FirewallerAPI, error) { return nil, nil },
 		NewFirewallerWorker:          func(firewaller.Config) (worker.Worker, error) { return nil, nil },
-		NewRemoteRelationsFacade:     func(base.APICaller) (*remoterelations.Client, error) { return nil, nil },
+		NewRemoteRelationsFacade:     func(base.APICaller) *remoterelations.Client { return nil },
 		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) { return nil, nil },
 	}
 }

--- a/worker/firewaller/shim.go
+++ b/worker/firewaller/shim.go
@@ -4,8 +4,6 @@
 package firewaller
 
 import (
-	"io"
-
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/worker/v3"
@@ -56,16 +54,6 @@ func crossmodelFirewallerFacadeFunc(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		facade := crossmodelrelations.NewClient(conn)
-		return &crossModelFirewallerFacadeCloser{facade, conn}, nil
+		return crossmodelrelations.NewClient(conn), nil
 	}
-}
-
-type crossModelFirewallerFacadeCloser struct {
-	CrossModelFirewallerFacade
-	conn io.Closer
-}
-
-func (p *crossModelFirewallerFacadeCloser) Close() error {
-	return p.conn.Close()
 }

--- a/worker/firewaller/shim.go
+++ b/worker/firewaller/shim.go
@@ -17,9 +17,8 @@ import (
 )
 
 // NewRemoteRelationsFacade creates a remote relations API facade.
-func NewRemoteRelationsFacade(apiCaller base.APICaller) (*remoterelations.Client, error) {
-	facade := remoterelations.NewClient(apiCaller)
-	return facade, nil
+func NewRemoteRelationsFacade(apiCaller base.APICaller) *remoterelations.Client {
+	return remoterelations.NewClient(apiCaller)
 }
 
 // NewFirewallerFacade creates a firewaller API facade.

--- a/worker/remoterelations/manifold.go
+++ b/worker/remoterelations/manifold.go
@@ -31,7 +31,7 @@ type ManifoldConfig struct {
 	APICallerName string
 
 	NewControllerConnection  apicaller.NewExternalControllerConnectionFunc
-	NewRemoteRelationsFacade func(base.APICaller) (RemoteRelationsFacade, error)
+	NewRemoteRelationsFacade func(base.APICaller) RemoteRelationsFacade
 	NewWorker                func(Config) (worker.Worker, error)
 	Logger                   Logger
 }
@@ -73,14 +73,10 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 	if err := context.Get(config.APICallerName, &apiConn); err != nil {
 		return nil, errors.Trace(err)
 	}
-	facade, err := config.NewRemoteRelationsFacade(apiConn)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 
 	w, err := config.NewWorker(Config{
 		ModelUUID:                agent.CurrentConfig().Model().Id(),
-		RelationsFacade:          facade,
+		RelationsFacade:          config.NewRemoteRelationsFacade(apiConn),
 		NewRemoteModelFacadeFunc: remoteRelationsFacadeForModelFunc(config.NewControllerConnection),
 		Clock:                    clock.WallClock,
 		Logger:                   config.Logger,

--- a/worker/remoterelations/manifold_test.go
+++ b/worker/remoterelations/manifold_test.go
@@ -33,7 +33,7 @@ func (s *ManifoldConfigSuite) validConfig() remoterelations.ManifoldConfig {
 		AgentName:                "agent",
 		APICallerName:            "api-caller",
 		NewControllerConnection:  func(*api.Info) (api.Connection, error) { return nil, nil },
-		NewRemoteRelationsFacade: func(base.APICaller) (remoterelations.RemoteRelationsFacade, error) { return nil, nil },
+		NewRemoteRelationsFacade: func(base.APICaller) remoterelations.RemoteRelationsFacade { return nil },
 		NewWorker:                func(remoterelations.Config) (worker.Worker, error) { return nil, nil },
 		Logger:                   loggo.GetLogger("test"),
 	}

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -162,7 +162,11 @@ func (w *remoteApplicationWorker) loop() (err error) {
 			}
 			return errors.Trace(err)
 		}
-		defer func() { _ = w.remoteModelFacade.Close() }()
+		defer func() {
+			if err := w.remoteModelFacade.Close(); err != nil {
+				w.logger.Errorf("error closing remote-relations facade: %s", err)
+			}
+		}()
 
 		arg := params.OfferArg{
 			OfferUUID: w.offerUUID,

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -17,14 +17,8 @@ import (
 	"github.com/juju/juju/worker/apicaller"
 )
 
-func NewRemoteRelationsFacade(apiCaller base.APICaller) (RemoteRelationsFacade, error) {
-	facade := remoterelations.NewClient(apiCaller)
-	return facade, nil
-}
-
-func NewRemoteModelRelationsFacade(apiCaller base.APICallCloser) (RemoteModelRelationsFacade, error) {
-	facade := crossmodelrelations.NewClient(apiCaller)
-	return facade, nil
+func NewRemoteRelationsFacade(apiCaller base.APICaller) RemoteRelationsFacade {
+	return remoterelations.NewClient(apiCaller)
 }
 
 func NewWorker(config Config) (worker.Worker, error) {
@@ -49,11 +43,7 @@ func remoteRelationsFacadeForModelFunc(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		facade, err := NewRemoteModelRelationsFacade(conn)
-		if err != nil {
-			conn.Close()
-			return nil, errors.Trace(err)
-		}
+		facade := crossmodelrelations.NewClient(conn)
 		return &remoteModelRelationsFacadeCloser{facade, conn}, nil
 	}
 }

--- a/worker/remoterelations/shim.go
+++ b/worker/remoterelations/shim.go
@@ -4,8 +4,6 @@
 package remoterelations
 
 import (
-	"io"
-
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/worker/v3"
@@ -43,16 +41,6 @@ func remoteRelationsFacadeForModelFunc(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		facade := crossmodelrelations.NewClient(conn)
-		return &remoteModelRelationsFacadeCloser{facade, conn}, nil
+		return crossmodelrelations.NewClient(conn), nil
 	}
-}
-
-type remoteModelRelationsFacadeCloser struct {
-	RemoteModelRelationsFacade
-	conn io.Closer
-}
-
-func (p *remoteModelRelationsFacadeCloser) Close() error {
-	return p.conn.Close()
 }


### PR DESCRIPTION
We do not log errors that occur when closing the remote relations facade in the remote application worker. Here we address that, ensuring that errors closing the connection are written to the log.

In addition, the following mechanical simplifications are included:
- Function signatures for acquiring remote relations clients have their error returns removed. They are always nil, and so superfluous.
- Wrapping and embedding of clients in order to implement the `Close` method against the underlying facade-caller is removed. The embedding used here is confusing and opaque. The underlying client ensures that calling `Close` closes the facade-caller anyway, so the jumping through hoops to do this explicitly is not even necessary.

## QA steps

Ensure that cross-model relations continue to work:
- `juju bootstrap lxd src --debug --no-gui && juju deploy mysql --edge && juju offer mysql:db`.
- `juju bootstrap lxd dst --debug --no-gui && juju consume src:default.mysql && juju deploy wordpress && juju relate mysql wordpress`.
- The wordpress install hook fails, but the CMR should be established correctly, with the log showing no CMR errors.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1979957
