### PR TITLE
Block upgrading cloud-init deb during cloud-init.

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -193,7 +193,9 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 	}
 	if cfg.SystemUpgrade() {
 		cmds = append(cmds, LogProgressCmd("Running apt-get upgrade"))
+		cmds = append(cmds, looper+"apt-mark hold cloud-init")
 		cmds = append(cmds, looper+pkgCmder.UpgradeCmd())
+		cmds = append(cmds, looper+"apt-mark unhold cloud-init")
 	}
 
 	var pkgCmds []string


### PR DESCRIPTION
At some point upgrading cloud-init deb would bork the active cloud-init,
so this PR blocks upgrading cloud-init via apt-mark hold.

## QA steps

```
make install
cd tests
BOOTSTRAP_SERIES=bionic ./main.sh -v -s '""' appdata ''
```

## Documentation changes

N/A

## Bug reference

N/A