### PR TITLE
Hard fail on mongo without sstxn and update bash tests to use focal or jammy

### DIFF
--- a/state/database.go
+++ b/state/database.go
@@ -256,10 +256,6 @@ type database struct {
 	// resulting from Copy.
 	ownSession bool
 
-	// serverSideTransactions can be set to request that we use server-side
-	// transactions instead of client-side transactions when applying changes
-	serverSideTransactions bool
-
 	// runTransactionObserver is passed on to txn.TransactionRunner, to be
 	// invoked after calls to Run and RunTransaction.
 	runTransactionObserver RunTransactionObserverFunc
@@ -278,13 +274,12 @@ type RunTransactionObserverFunc func(dbName, modelUUID string, attempt int, dura
 func (db *database) copySession(modelUUID string) (*database, SessionCloser) {
 	session := db.raw.Session.Copy()
 	return &database{
-		raw:                    db.raw.With(session),
-		schema:                 db.schema,
-		modelUUID:              modelUUID,
-		runner:                 db.runner,
-		ownSession:             true,
-		serverSideTransactions: db.serverSideTransactions,
-		clock:                  db.clock,
+		raw:        db.raw.With(session),
+		schema:     db.schema,
+		modelUUID:  modelUUID,
+		runner:     db.runner,
+		ownSession: true,
+		clock:      db.clock,
 	}, session.Close
 }
 
@@ -393,7 +388,7 @@ func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCl
 			Database:               raw,
 			RunTransactionObserver: observer,
 			Clock:                  db.clock,
-			ServerSideTransactions: db.serverSideTransactions,
+			ServerSideTransactions: true,
 			MaxRetryAttempts:       40,
 		}
 		runner = jujutxn.NewRunner(params)

--- a/state/imagestorage/image.go
+++ b/state/imagestorage/image.go
@@ -75,7 +75,7 @@ func (s *imageStorage) txnRunner(session *mgo.Session) jujutxn.Runner {
 var txnRunner = func(db *mgo.Database) jujutxn.Runner {
 	return jujutxn.NewRunner(jujutxn.RunnerParams{
 		Database:               db,
-		ServerSideTransactions: false,
+		ServerSideTransactions: true,
 	})
 }
 

--- a/state/leaseupgrades.go
+++ b/state/leaseupgrades.go
@@ -47,7 +47,7 @@ func migrateModelLeasesToGlobalTime(st *State) error {
 		runner = jujutxn.NewRunner(jujutxn.RunnerParams{
 			Database:               db.raw,
 			Clock:                  db.clock,
-			ServerSideTransactions: db.serverSideTransactions,
+			ServerSideTransactions: true,
 		})
 	}
 	err := runner.Run(func(int) ([]txn.Op, error) {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -184,8 +184,6 @@ add_model() {
 add_images_for_vsphere() {
 	juju metadata add-image juju-ci-root/templates/jammy-test-template --series jammy
 	juju metadata add-image juju-ci-root/templates/focal-test-template --series focal
-	juju metadata add-image juju-ci-root/templates/bionic-test-template --series bionic
-	juju metadata add-image juju-ci-root/templates/xenial-test-template --series xenial
 }
 
 # setup_vsphere_simplestreams generates image metadata for use during vSphere bootstrap.  There is

--- a/tests/suites/appdata/charms/appdata-sink/metadata.yaml
+++ b/tests/suites/appdata/charms/appdata-sink/metadata.yaml
@@ -9,10 +9,5 @@ provides:
 categories:
   - misc
 series:
-  - trusty
-  - xenial
-  - artful
-  - bionic
-  - eoan
+  - jammy
   - focal
-

--- a/tests/suites/appdata/charms/appdata-source/metadata.yaml
+++ b/tests/suites/appdata/charms/appdata-source/metadata.yaml
@@ -9,10 +9,5 @@ requires:
 categories:
   - misc
 series:
-  - trusty
-  - xenial
-  - artful
-  - bionic
-  - eoan
+  - jammy
   - focal
-

--- a/tests/suites/bootstrap/charms/ubuntu/metadata.yaml
+++ b/tests/suites/bootstrap/charms/ubuntu/metadata.yaml
@@ -9,7 +9,5 @@ requires:
   sink:
     interface: dummy-token
 series:
+  - jammy
   - focal
-  - bionic
-  - xenial
-  - trusty

--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -6,7 +6,7 @@ run_charmhub_download() {
 
 	ensure "test-${name}" "${file}"
 
-	output=$(juju download mysql --series xenial --filepath="${TEST_DIR}/mysql.charm" 2>&1 || true)
+	output=$(juju download mysql --series focal --filepath="${TEST_DIR}/mysql.charm" 2>&1 || true)
 	check_contains "${output}" 'Fetching charm "mysql"'
 
 	juju deploy "${TEST_DIR}/mysql.charm" mysql

--- a/tests/suites/deploy/bundles/basic-openstack.yaml
+++ b/tests/suites/deploy/bundles/basic-openstack.yaml
@@ -41,32 +41,32 @@ relations:
     - mysql:shared-db
   - - nova-cloud-controller:neutron-api
     - neutron-api:neutron-api
-series: xenial
+series: focal
 applications:
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:glance
+    charm: glance
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       worker-multiplier: 0.25
   keystone:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:keystone
+    charm: keystone
     num_units: 1
     options:
       admin-password: openstack
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       worker-multiplier: 0.25
   mysql:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:percona-cluster
+    charm: percona-cluster
     num_units: 1
     options:
       max-connections: 20000
@@ -75,52 +75,52 @@ applications:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:neutron-api
+    charm: neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
       overlay-network-type: "gre vxlan"
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       flat-network-providers: physnet1
   neutron-gateway:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:neutron-gateway
+    charm: neutron-gateway
     num_units: 1
     options:
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       worker-multiplier: 0.25
       dns-servers: 10.101.0.1
   neutron-openvswitch:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:neutron-openvswitch
+    charm: neutron-openvswitch
     num_units: 0
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:nova-cloud-controller
+    charm: nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
       worker-multiplier: 0.25
   nova-compute:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:nova-compute
+    charm: nova-compute
     num_units: 1
     options:
       enable-live-migration: False
       enable-resize: False
-      openstack-origin: cloud:xenial-queens
+      openstack-origin: cloud:focal-yoga
   rabbitmq-server:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:rabbitmq-server
+    charm: rabbitmq-server
     num_units: 1

--- a/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
+++ b/tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
@@ -4,7 +4,7 @@ saas:
     url: {{BOOTSTRAPPED_JUJU_CTRL_NAME}}:admin/test-cmr-bundles-deploy.mysql
 applications:
   wordpress:
-    charm: cs:wordpress
+    charm: wordpress
     num_units: 1
 relations:
 - - wordpress:db

--- a/tests/suites/deploy/bundles/lxd-profile-bundle.yaml
+++ b/tests/suites/deploy/bundles/lxd-profile-bundle.yaml
@@ -6,7 +6,8 @@ machines:
   '3': {}
 applications:
   lxd-profile:
-    charm: cs:~juju-qa/bionic/lxd-profile-without-devices-5
+    charm: juju-qa-lxd-profile-without-devices
+    channel: beta
     num_units: 8
     to:
       - lxd:0
@@ -18,7 +19,7 @@ applications:
       - lxd:2
       - lxd:3
   ubuntu:
-    charm: cs:~jameinel/ubuntu-lite
+    charm: jameinel-ubuntu-lite
     num_units: 4
     to:
       - "0"

--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -1,21 +1,19 @@
-series: bionic
+series: focal
 applications:
   influxdb:
-    charm: cs:influxdb
+    charm: influxdb
     channel: stable
-    revision: 22
     num_units: 1
     to:
     - "0"
     constraints: arch=amd64
   telegraf:
-    charm: cs:telegraf
+    charm: telegraf
     channel: stable
-    revision: 29
   ubuntu:
-    charm: cs:ubuntu
+    charm: ubuntu
     channel: stable
-    revision: 12
+    revision: 20
     num_units: 1
     to:
     - "1"

--- a/tests/suites/deploy/bundles/trusted_bundle.yaml
+++ b/tests/suites/deploy/bundles/trusted_bundle.yaml
@@ -1,5 +1,7 @@
 applications:
     trust-checker:
-        charm: cs:~juju-qa/bionic/trust-checker-0
+        charm: juju-qa-trust-checker
+        channel: beta
+        series: bionic
         num_units: 1
         trust: true

--- a/tests/suites/deploy/charms/lxd-profile-alt/metadata.yaml
+++ b/tests/suites/deploy/charms/lxd-profile-alt/metadata.yaml
@@ -13,7 +13,5 @@ tags:
   - application_development
 subordinate: false
 series:
+  - jammy
   - focal
-  - bionic
-  - xenial
-  - quantal

--- a/tests/suites/deploy/charms/lxd-profile-subordinate/metadata.yaml
+++ b/tests/suites/deploy/charms/lxd-profile-subordinate/metadata.yaml
@@ -15,7 +15,5 @@ requires:
     interface: juju-info
     scope: container
 series:
+  - jammy
   - focal
-  - bionic
-  - xenial
-  - quantal

--- a/tests/suites/deploy/charms/lxd-profile/metadata.yaml
+++ b/tests/suites/deploy/charms/lxd-profile/metadata.yaml
@@ -13,7 +13,5 @@ tags:
   - application_development
 subordinate: false
 series:
+  - jammy
   - focal
-  - bionic
-  - xenial
-  - quantal

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -46,6 +46,7 @@ run_deploy_cmr_bundle() {
 
 	bundle=./tests/suites/deploy/bundles/cmr_bundles_test_deploy.yaml
 	sed "s/{{BOOTSTRAPPED_JUJU_CTRL_NAME}}/${BOOTSTRAPPED_JUJU_CTRL_NAME}/g" "${bundle}" >"${TEST_DIR}/cmr_bundles_test_deploy.yaml"
+	# TODO - upgrade the charm to support focal
 	juju deploy "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
 
 	wait_for "wordpress" "$(idle_condition "wordpress")"
@@ -79,6 +80,7 @@ run_deploy_trusted_bundle() {
 
 	ensure "test-trusted-bundles-deploy" "${file}"
 
+	# TODO - upgrade the charm to support focal
 	bundle=./tests/suites/deploy/bundles/trusted_bundle.yaml
 	OUT=$(juju deploy ${bundle} 2>&1 || true)
 	echo "${OUT}" | check "repeat the deploy command with the --trust argument"
@@ -155,6 +157,7 @@ run_deploy_lxd_profile_bundle() {
 	ensure "${model_name}" "${file}"
 
 	bundle=./tests/suites/deploy/bundles/lxd-profile-bundle.yaml
+	# TODO - upgrade the charm to support focal
 	juju deploy "${bundle}"
 
 	# 8 units of lxd-profile

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -18,12 +18,12 @@ run_deploy_specific_series() {
 
 	ensure "test-deploy-specific-series" "${file}"
 
-	juju deploy cs:postgresql --series bionic
+	juju deploy postgresql --series focal
 	series=$(juju status --format=json | jq ".applications.postgresql.series")
 
 	destroy_model "test-deploy-specific-series"
 
-	echo "$series" | check "bionic"
+	echo "$series" | check "focal"
 }
 
 run_deploy_lxd_profile_charm() {
@@ -33,7 +33,8 @@ run_deploy_lxd_profile_charm() {
 
 	ensure "test-deploy-lxd-profile" "${file}"
 
-	juju deploy cs:~juju-qa/bionic/lxd-profile-without-devices-5
+	# TODO - upgrade the charm to support focal
+	juju deploy juju-qa-lxd-profile-without-devices --channel beta
 	wait_for "lxd-profile" "$(idle_condition "lxd-profile")"
 
 	juju status --format=json | jq '.machines | .["0"] | .["lxd-profiles"] | keys[0]' | check "juju-test-deploy-lxd-profile-lxd-profile"
@@ -48,7 +49,8 @@ run_deploy_lxd_profile_charm_container() {
 
 	ensure "test-deploy-lxd-profile-container" "${file}"
 
-	juju deploy cs:~juju-qa/bionic/lxd-profile-without-devices-5 --to lxd --series=bionic
+	# TODO - upgrade the charm to support focal
+	juju deploy juju-qa-lxd-profile-without-devices --channel beta --to lxd
 	wait_for "lxd-profile" "$(idle_condition "lxd-profile")"
 
 	juju status --format=json | jq '.machines | .["0"] | .containers | .["0/lxd/0"] | .["lxd-profiles"] | keys[0]' |
@@ -64,7 +66,7 @@ run_deploy_local_lxd_profile_charm() {
 
 	ensure "test-deploy-local-lxd-profile" "${file}"
 
-	juju deploy ./tests/suites/deploy/charms/lxd-profile --series=bionic
+	juju deploy ./tests/suites/deploy/charms/lxd-profile
 	juju deploy ./tests/suites/deploy/charms/lxd-profile-subordinate
 	juju add-relation lxd-profile-subordinate lxd-profile
 
@@ -108,10 +110,10 @@ run_deploy_lxd_to_machine() {
 
 	ensure "${model_name}" "${file}"
 
-	juju add-machine -n 1 --series=bionic
+	juju add-machine -n 1 --series=jammy
 
 	charm=./tests/suites/deploy/charms/lxd-profile-alt
-	juju deploy "${charm}" --to 0 --series=bionic
+	juju deploy "${charm}" --to 0
 
 	wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 
@@ -169,7 +171,7 @@ run_deploy_lxd_to_container() {
 	ensure "${model_name}" "${file}"
 
 	charm=./tests/suites/deploy/charms/lxd-profile-alt
-	juju deploy "${charm}" --to lxd --series=bionic
+	juju deploy "${charm}" --to lxd
 
 	wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 

--- a/tests/suites/hooks/dispatch.sh
+++ b/tests/suites/hooks/dispatch.sh
@@ -10,17 +10,13 @@ run_hook_dispatching_script() {
 	# log level is WARNING.
 	juju model-config logging-config="<root>=INFO"
 
-	juju deploy cs:~juju-qa/bionic/ubuntu-plus-0
+	# TODO - upgrade the charm to support focal
+	juju deploy juju-qa-ubuntu-plus --channel=beta
 	wait_for "ubuntu-plus" "$(idle_condition "ubuntu-plus")"
 
 	juju debug-log --include unit-ubuntu-plus-0 | grep -q "via hook dispatching script: dispatch" || true
 
-	# run an action and retrieve the id for use in show-task.
-	# awk, change the separator to " and get the 2nd value.
-	# e.g Action queued with id: "2"
-	# yields: 2
-	action_id=$(juju run ubuntu-plus/0 no-dispatch filename=test-dispatch | awk 'BEGIN{FS="\""} {print $2}')
-	juju show-task "${action_id}" | grep -q completed || true
+	juju run ubuntu-plus/0 no-dispatch filename=test-dispatch
 
 	# wait for update-status
 	wait_for "Hello from update-status" "$(workload_status ubuntu-plus 0).message"

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -15,7 +15,7 @@ run_deploy_manual_aws() {
 	add_clean_func "run_cleanup_deploy_manual_aws"
 
 	# Eventually we should use BOOTSTRAP_SERIES
-	series="bionic"
+	series="jammy"
 
 	# This creates a new VPC for this deployment. If one already exists it will
 	# get the existing setup and use that.

--- a/tests/suites/manual/deploy_manual_lxd.sh
+++ b/tests/suites/manual/deploy_manual_lxd.sh
@@ -77,7 +77,7 @@ run_deploy_manual_lxd() {
 	create_privileged_profile
 	create_user_profile "${name}"
 
-	series="bionic"
+	series="jammy"
 
 	controller="${name}-controller"
 	model1="${name}-m1"

--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -39,7 +39,7 @@ run_spaces_manual_aws() {
 	add_clean_func "run_cleanup_deploy_manual_aws"
 
 	# Eventually we should use BOOTSTRAP_SERIES.
-	series="bionic"
+	series="jammy"
 
 	OUT=$(aws ec2 describe-images \
 		--owners 099720109477 \

--- a/tests/suites/model/charms/ubuntu/metadata.yaml
+++ b/tests/suites/model/charms/ubuntu/metadata.yaml
@@ -9,8 +9,5 @@ requires:
   sink:
     interface: dummy-token
 series:
+  - jammy
   - focal
-  - bionic
-  - xenial
-  - trusty
-

--- a/tests/suites/model/config.sh
+++ b/tests/suites/model/config.sh
@@ -6,12 +6,12 @@ run_model_config() {
 	file="${TEST_DIR}/test-model-config.log"
 	ensure "model-config" "${file}"
 
-	juju model-config mode="[strict]"
-	juju model-config mode | grep "strict"
-	juju model-config mode="[]"
-	juju model-config mode | grep "\[\]"
-	juju model-config mode="[boom]" || echo "ERROR" | grep "ERROR"
-	juju model-config --reset mode
+	juju model-config provisioner-harvest-mode="none"
+	juju model-config provisioner-harvest-mode | grep "none"
+	juju model-config provisioner-harvest-mode="destroyed"
+	juju model-config provisioner-harvest-mode | grep "destroyed"
+	juju model-config provisioner-harvest-mode="invalid" || echo "ERROR" | grep "ERROR"
+	juju model-config --reset provisioner-harvest-mode
 
 	destroy_model "model-config"
 }

--- a/tests/suites/model/multi.sh
+++ b/tests/suites/model/multi.sh
@@ -28,8 +28,8 @@ deploy_stack() {
 
 	juju switch "${name}"
 
-	juju deploy "cs:~juju-qa/dummy-source"
-	juju deploy "cs:~juju-qa/dummy-sink"
+	juju deploy "juju-qa-dummy-source"
+	juju deploy "juju-qa-dummy-sink"
 
 	juju add-relation dummy-source dummy-sink
 	juju expose dummy-sink

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -10,8 +10,8 @@ run_network_health() {
 	juju deploy ubuntu ubuntu-jammy --series jammy
 
 	# Now the testing charm for each series.
-	juju deploy 'cs:~juju-qa/network-health' network-health-focal --series focal
-	juju deploy 'cs:~juju-qa/network-health' network-health-jammy --series jammy
+	juju deploy 'juju-qa-network-health' network-health-focal --series focal
+	juju deploy 'juju-qa-network-health' network-health-jammy --series jammy
 
 	juju add-relation network-health-focal ubuntu-focal
 	juju add-relation network-health-jammy ubuntu-jammy

--- a/tests/suites/ovs_maas/ovs_netplan_config.sh
+++ b/tests/suites/ovs_maas/ovs_netplan_config.sh
@@ -7,7 +7,7 @@ run_ovs_netplan_config() {
 	# an address in 'space1'.
 	# - The third NIC is assigned an address in 'space2'.
 	juju switch controller
-	juju deploy cs:~juju-qa/bionic/space-invader --constraints='tags=ovs' --to lxd:0 --bind 'space1 invade-b=space2'
+	juju deploy juju-qa-space-invader --series=focal --constraints='tags=ovs' --to lxd:0 --bind 'space1 invade-b=space2'
 	unit_index=$(get_unit_index "space-invader")
 	wait_for "space-invader" "$(idle_condition "space-invader" 0 "${unit_index}")"
 

--- a/tests/suites/smoke/charms/ubuntu/metadata.yaml
+++ b/tests/suites/smoke/charms/ubuntu/metadata.yaml
@@ -9,7 +9,5 @@ requires:
   sink:
     interface: dummy-token
 series:
+  - jammy
   - focal
-  - bionic
-  - xenial
-  - trusty

--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -16,7 +16,7 @@ run_juju_bind() {
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
 
 	# Deploy test charm to dual-nic machine
-	juju deploy cs:~juju-qa/focal/space-defender-3 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
+	juju deploy juju-qa-space-defender --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}"
 	unit_index=$(get_unit_index "space-defender")
 	wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -17,7 +17,7 @@ run_upgrade_charm_with_bind() {
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
 
 	# Deploy test charm to dual-nic machine
-	juju deploy cs:~juju-qa/focal/space-defender-2 --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}" --force
+	juju deploy juju-qa-space-defender --bind "defend-a=alpha defend-b=isolated" --to "${juju_machine_id}" --force
 	unit_index=$(get_unit_index "space-defender")
 	wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 

--- a/tests/suites/unit/unit_series.sh
+++ b/tests/suites/unit/unit_series.sh
@@ -6,16 +6,16 @@ run_unit_set_series() {
 	file="${TEST_DIR}/test-unit-series.log"
 	ensure "unit-series" "${file}"
 
-	juju deploy cs:ubuntu --series=bionic
+	juju deploy ubuntu --series=focal
 
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
-	juju set-series ubuntu focal
+	juju set-series ubuntu jammy
 	juju add-unit ubuntu
 
 	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 1)"
 
-	juju status --format=json | jq -r '.machines | .["1"] | .series' | grep "focal"
+	juju status --format=json | jq -r '.machines | .["1"] | .series' | grep "jammy"
 
 	destroy_model "unit-series"
 }

--- a/tests/suites/upgrade/charms/ubuntu/metadata.yaml
+++ b/tests/suites/upgrade/charms/ubuntu/metadata.yaml
@@ -9,7 +9,5 @@ requires:
   sink:
     interface: dummy-token
 series:
+  - jammy
   - focal
-  - bionic
-  - xenial
-  - trusty

--- a/tests/suites/upgrade/streams.sh
+++ b/tests/suites/upgrade/streams.sh
@@ -53,19 +53,6 @@ exec_simplestream_metadata() {
 		--prevent-fallback \
 		-d "./tests/suites/upgrade/streams/"
 
-	# 2.8 or older needs series based agent metadata.
-	if [ "${stable_version}" == "2.8" ]; then
-		local focal_version bionic_version
-		focal_version=$(series_version "${version}" "focal")
-		bionic_version=$(series_version "${version}" "bionic")
-		add_upgrade_tools "${focal_version}"
-		add_upgrade_tools "${bionic_version}"
-
-		/snap/bin/juju metadata generate-agents \
-			--clean \
-			-d "./tests/suites/upgrade/streams/"
-	fi
-
 	add_clean_func "kill_server"
 	start_server "./tests/suites/upgrade/streams/tools"
 


### PR DESCRIPTION
Various compatibility changes.
Hard fail if mongo does not support sstxns.
For the bash tests, update local charms to be focal or jammy only.
When deploying, use the juju-qa charms from charmhub, not charm store, and use focal or jammy.
Some charms are not yet updated for focal or jammy, so we need `--force`.

## QA steps

`./main.sh -c aws deploy`
`./main.sh -c aws unit`
`./main.sh -c aws hooks`
`./main.sh -c aws manual`
`./main.sh -c aws model`
`./main.sh -c aws appdata`
`./main.sh -c aws spaces_ec2`
