### PR TITLE
[JUJU-1421] prioritize cliflags over global envs

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -108,13 +108,12 @@ func (c *runCommandBase) ensureAPI() (err error) {
 }
 
 func (c *runCommandBase) operationResults(ctx *cmd.Context, results *actionapi.EnqueuedActions) error {
-	var noColor bool
-	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color {
-		noColor = true
+
+	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
 		return c.processOperationResults(ctx, results)
 	}
 
-	if noColor && c.color {
+	if c.color {
 		return c.processOperationResultsWithColor(ctx, results)
 	}
 
@@ -428,18 +427,15 @@ func (c *runCommandBase) progressf(ctx *cmd.Context, format string, params ...in
 }
 
 func (c *runCommandBase) printOutput(writer io.Writer, value interface{}) error {
-	var noColor bool
-
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		noColor = true
 		return printPlainOutput(writer, value)
 	}
 
-	if noColor && c.color {
+	if c.color {
 		return printColoredOutput(writer, value)
 	}
 
-	if isTerminal(writer) && !noColor {
+	if isTerminal(writer) && !c.noColor {
 		return printColoredOutput(writer, value)
 	}
 
@@ -451,18 +447,16 @@ func (c *runCommandBase) printOutput(writer io.Writer, value interface{}) error 
 }
 
 func (c *runCommandBase) formatYaml(writer io.Writer, value interface{}) error {
-	var noColor bool
 
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		noColor = true
 		return cmd.FormatYaml(writer, value)
 	}
 
-	if noColor && c.color {
+	if c.color {
 		return output.FormatYamlWithColor(writer, value)
 	}
 
-	if isTerminal(writer) && !noColor {
+	if isTerminal(writer) && !c.noColor {
 		return output.FormatYamlWithColor(writer, value)
 	}
 
@@ -474,13 +468,12 @@ func (c *runCommandBase) formatYaml(writer io.Writer, value interface{}) error {
 }
 
 func (c *runCommandBase) formatJson(writer io.Writer, value interface{}) error {
-	var noColor bool
+
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		noColor = true
 		return cmd.FormatJson(writer, value)
 	}
 
-	if noColor && c.color {
+	if c.color {
 		return output.FormatJsonWithColor(writer, value)
 	}
 

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -362,16 +363,42 @@ func (c *configCommand) validateValues(ctx *cmd.Context) (map[string]string, err
 
 // FormatYaml serializes value into valid yaml string. If color flag is passed it adds ANSI color escape codes to the output.
 func (c *configCommand) FormatYaml(w io.Writer, value interface{}) error {
+	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.configBase.Color || c.configBase.NoColor {
+		return cmd.FormatYaml(w, value)
+	}
+
 	if c.configBase.Color {
 		return output.FormatYamlWithColor(w, value)
 	}
+
+	if utils.IsTerminal(w) && !c.configBase.NoColor {
+		return output.FormatYamlWithColor(w, value)
+	}
+
+	if !utils.IsTerminal(w) && c.configBase.Color {
+		return output.FormatYamlWithColor(w, value)
+	}
+
 	return cmd.FormatYaml(w, value)
 }
 
 // FormatJson serializes value into valid json string. If color flag is passed it adds ANSI color escape codes to the output.
 func (c *configCommand) FormatJson(w io.Writer, val interface{}) error {
+	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.configBase.Color || c.configBase.NoColor {
+		return cmd.FormatJson(w, val)
+	}
+
 	if c.configBase.Color {
 		return output.FormatJsonWithColor(w, val)
 	}
+
+	if utils.IsTerminal(w) && !c.configBase.NoColor {
+		return output.FormatJsonWithColor(w, val)
+	}
+
+	if !utils.IsTerminal(w) && c.configBase.Color {
+		return output.FormatJsonWithColor(w, val)
+	}
+
 	return cmd.FormatJson(w, val)
 }

--- a/cmd/juju/application/utils/utils.go
+++ b/cmd/juju/application/utils/utils.go
@@ -5,7 +5,11 @@ package utils
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
+
+	"github.com/mattn/go-isatty"
 
 	"github.com/juju/charm/v9"
 	charmresource "github.com/juju/charm/v9/resource"
@@ -169,4 +173,14 @@ func ReadValue(ctx *cmd.Context, filesystem modelcmd.Filesystem, filename string
 		return "", errors.Errorf("cannot read option from file %q: %v", filename, err)
 	}
 	return string(content), nil
+}
+
+// isTerminal checks if the file descriptor is a terminal.
+func IsTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	return isatty.IsTerminal(f.Fd())
 }

--- a/cmd/juju/config/config.go
+++ b/cmd/juju/config/config.go
@@ -47,6 +47,7 @@ type ConfigCommandBase struct {
 	ConfigFile cmd.FileVar
 	reset      []string // Holds the keys to be reset until parsed.
 	Color      bool
+	NoColor    bool
 
 	// Fields to be set during initialisation
 	Actions     []Action // The action which we want to handle, set in Init.
@@ -61,6 +62,7 @@ type ConfigCommandBase struct {
 func (c *ConfigCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.ConfigFile, "file", "path to yaml-formatted configuration file")
 	f.BoolVar(&c.Color, "color", false, "Use ANSI color codes in output")
+	f.BoolVar(&c.NoColor, "no-color", false, "Disable ANSI color codes in tabular output")
 	if c.Resettable {
 		f.Var(cmd.NewAppendStringsValue(&c.reset), "reset",
 			"Reset the provided comma delimited keys")

--- a/cmd/juju/config/config_test.go
+++ b/cmd/juju/config/config_test.go
@@ -34,7 +34,7 @@ func (s *suite) TestSetFlags(c *gc.C) {
 		cmd.SetFlags(f)
 
 		// Collect all flags
-		expectedFlags := []string{"color", "file"}
+		expectedFlags := []string{"color", "file", "no-color"}
 		if resettable {
 			expectedFlags = append(expectedFlags, "reset")
 		}

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -6,13 +6,14 @@ package status
 import (
 	"bytes"
 	"fmt"
-	"github.com/juju/ansiterm"
-	"github.com/juju/juju/cmd/output"
-	"github.com/juju/juju/core/status"
 	"io"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/juju/ansiterm"
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/status"
 
 	"github.com/juju/errors"
 	"github.com/juju/naturalsort"

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -4,8 +4,14 @@
 package status
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/juju/ansiterm"
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/status"
 	"io"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/juju/errors"
@@ -25,6 +31,26 @@ func FormatOneline(writer io.Writer, value interface{}) error {
 		fmt.Fprintf(out, format,
 			uName,
 			u.PublicAddress,
+			status,
+		)
+	})
+}
+
+// FormatOnelineWithColor appends ansi color codes to a brief list of units and their subordinates.
+// Subordinates will be indented 2 spaces and listed under their
+// superiors. This format works with version 2 of the CLI.
+func FormatOnelineWithColor(writer io.Writer, value interface{}) error {
+	return formatOnelineWithColor(writer, value, func(out io.Writer, format, uName string, u unitStatus, level int) {
+		status := fmt.Sprintf(
+			"%s:%s, %s:%s",
+			colorVal(output.EmphasisHighlight.DefaultBold, "agent"),
+			colorStatus(u.JujuStatusInfo.Current),
+			colorVal(output.EmphasisHighlight.DefaultBold, "workload"),
+			colorStatus(u.WorkloadStatusInfo.Current),
+		)
+		fmt.Fprintf(out, format,
+			uName,
+			colorVal(output.InfoHighlight, u.PublicAddress),
 			status,
 		)
 	})
@@ -57,4 +83,158 @@ func formatOneline(writer io.Writer, value interface{}, printf onelinePrintf) er
 	}
 
 	return nil
+}
+
+func formatOnelineWithColor(writer io.Writer, value interface{}, printf onelinePrintf) error {
+	fs, valueConverted := value.(formattedStatus)
+	if !valueConverted {
+		return errors.Errorf("expected value of type %T, got %T", fs, value)
+	}
+
+	pprint := func(uName string, u unitStatus, level int) {
+		var fmtPorts string
+		if len(u.OpenedPorts) > 0 {
+			fmtPorts = fmt.Sprintf(" %s", colorPorts(u.OpenedPorts))
+		}
+		format := indent("\n", level*2, "- %s: %s (%v)"+fmtPorts)
+		printf(writer, format, colorVal(output.GoodHighlight, uName), u, level)
+	}
+
+	for _, svcName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
+		svc := fs.Applications[svcName]
+		for _, uName := range naturalsort.Sort(stringKeysFromMap(svc.Units)) {
+			unit := svc.Units[uName]
+			pprint(uName, unit, 0)
+			recurseUnits(unit, 1, pprint)
+		}
+	}
+
+	return nil
+}
+
+func colorStatus(stat status.Status) string {
+	return colorVal(output.StatusColor(stat), stat)
+}
+
+func colorPorts(ps []string) string {
+	buff := &bytes.Buffer{}
+	sorted := append([]string(nil), ps...)
+	sort.Strings(sorted)
+
+	protocols := map[string]*protocol{}
+	proto := func(p string) *protocol {
+		v, ok := protocols[p]
+		if !ok {
+			v = &protocol{
+				group:      map[string]string{},
+				groups:     map[string][]string{},
+				grouped:    map[string]bool{},
+				components: map[string][]string{},
+			}
+			protocols[p] = v
+		}
+		return v
+	}
+
+	for _, port := range sorted {
+		split := strings.Split(port, "/")
+		protocolId := ""
+		if len(split) == 1 {
+			protocolId = split[0]
+		} else {
+			protocolId = strings.Join(append([]string{""}, split[1:]...), "/")
+		}
+		protocol := proto(protocolId)
+		protocol.components[port] = split
+		if len(split) == 1 {
+			continue
+		}
+		n, err := strconv.Atoi(split[0])
+		if err != nil || n <= 1 {
+			continue
+		}
+		prev := strings.Join(append([]string{strconv.Itoa(n - 1)}, split[1:]...), "/")
+		if _, ok := protocol.components[prev]; !ok {
+			continue
+		}
+		groupName := protocol.group[prev]
+		if groupName == "" {
+			groupName = prev
+		}
+		protocol.group[port] = groupName
+		protocol.groups[groupName] = append(protocol.groups[groupName], port)
+		protocol.grouped[port] = true
+	}
+
+	protocolKeys := []string{}
+	for k := range protocols {
+		protocolKeys = append(protocolKeys, k)
+	}
+	sort.Strings(protocolKeys)
+
+	hasOutput := false
+	for _, pk := range protocolKeys {
+		protocol := protocols[pk]
+
+		portKeys := []string{}
+		for k := range protocol.components {
+			portKeys = append(portKeys, k)
+		}
+		sort.Sort(sortablePorts(portKeys))
+
+		hasPrev := false
+		for _, port := range portKeys {
+			if protocol.grouped[port] {
+				continue
+			}
+			if hasOutput {
+				hasOutput = false
+				buff.WriteString(" ")
+			}
+			if hasPrev {
+				buff.WriteString(",")
+			}
+			hasPrev = true
+			split := protocol.components[port]
+			group := protocol.groups[port]
+			// color grouped ports.
+			if len(group) > 0 {
+				last := group[len(group)-1]
+				lastSplit := protocol.components[last]
+				portRange := fmt.Sprintf("%s-%s", split[0], lastSplit[0])
+				buff.WriteString(colorVal(output.EmphasisHighlight.BrightMagenta, portRange))
+				continue
+			}
+			// color single port with protocol.
+			if len(split) > 1 {
+				buff.WriteString(colorVal(output.EmphasisHighlight.BrightMagenta, split[0]))
+				continue
+			}
+			// Everything else.
+			break
+		}
+		if hasPrev {
+			hasOutput = true
+			if _, err := strconv.Atoi(pk); err == nil {
+				buff.WriteString(colorVal(output.EmphasisHighlight.BrightMagenta, pk))
+			} else {
+				buff.WriteString(pk)
+			}
+		}
+	}
+
+	buff.WriteString("")
+	return buff.String()
+}
+
+//colorVal appends ansi color codes to the given value
+func colorVal(ctx *ansiterm.Context, val interface{}) string {
+	buff := &bytes.Buffer{}
+	coloredWriter := ansiterm.NewWriter(buff)
+	coloredWriter.SetColorCapable(true)
+
+	ctx.Fprintf(coloredWriter, "%v", val)
+	str := buff.String()
+	buff.Reset()
+	return str
 }

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -6,11 +6,12 @@ package status
 import (
 	"bytes"
 	"fmt"
+	"github.com/juju/ansiterm"
 	"io"
 	"net"
+	"os"
 	"strings"
 
-	"github.com/juju/ansiterm"
 	"github.com/juju/ansiterm/tabwriter"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -19,6 +20,19 @@ import (
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/core/status"
 )
+
+func (c *statusCommand) formatSummary(writer io.Writer, value interface{}) error {
+
+	if c.noColor {
+		if _, ok := os.LookupEnv("NO_COLOR"); !ok {
+			defer os.Unsetenv("NO_COLOR")
+			os.Setenv("NO_COLOR", "")
+		}
+
+	}
+
+	return FormatSummary(writer, c.color, value)
+}
 
 // FormatSummary writes a summary of the current environment
 // including the following information:
@@ -31,57 +45,76 @@ import (
 //   - Applications: Displays total #, their names, and how many of each
 //     are exposed.
 //   - RemoteApplications: Displays total #, their names and URLs.
-func FormatSummary(writer io.Writer, value interface{}) error {
+func FormatSummary(writer io.Writer, forceColor bool, value interface{}) error {
 	fs, valueConverted := value.(formattedStatus)
 	if !valueConverted {
 		return errors.Errorf("expected value of type %T, got %T", fs, value)
 	}
 
-	f := newSummaryFormatter(writer)
+	f := newSummaryFormatter(writer, forceColor)
 	stateToMachine := f.aggregateMachineStates(fs.Machines)
 	appExposure := f.aggregateApplicationAndUnitStates(fs.Applications)
+	kColor := ansiterm.Foreground(ansiterm.BrightCyan).SetStyle(ansiterm.Bold)
+	k := f.delimitKeysWithTabs
 	p := f.delimitValuesWithTabs
 
 	// Print everything out
-	p("Running on subnets:", strings.Join(f.netStrings, ", "))
-	p(" Utilizing ports:", f.portsInColumnsOf(3))
+	k(kColor, "Running on subnets:")
+	p(output.InfoHighlight, strings.Join(f.netStrings, ", "))
+	k(kColor, " Utilizing ports:")
+	printPorts(f.tw, strings.Split(f.portsInColumnsOf(3), ", "))
+	f.tw.Println()
 	f.tw.Flush()
 
 	// Right align summary information
 	f.tw.Init(writer, 0, 1, 2, ' ', tabwriter.AlignRight)
-	p("# Machines:", fmt.Sprintf("(%d)", len(fs.Machines)))
+	if forceColor {
+		f.tw.SetColorCapable(forceColor)
+	}
+	k(kColor, "# Machines:")
+	p(output.EmphasisHighlight.Magenta, fmt.Sprintf("(%d)", len(fs.Machines)))
 	f.printStateToCount(stateToMachine)
-	p(" ")
+	p(output.CurrentHighlight, " ")
 
-	p("# Units:", fmt.Sprintf("(%d)", f.numUnits))
+	k(kColor, "# Units:")
+	p(output.EmphasisHighlight.Magenta, fmt.Sprintf("(%d)", f.numUnits))
 	f.printStateToCount(f.stateToUnit)
-	p(" ")
+	p(output.CurrentHighlight, " ")
 
-	p("# Applications:", fmt.Sprintf("(%d)", len(fs.Applications)))
+	k(kColor, "# Applications:")
+	p(output.EmphasisHighlight.Magenta, fmt.Sprintf("(%d)", len(fs.Applications)))
 	for _, appName := range naturalsort.Sort(stringKeysFromMap(appExposure)) {
 		s := appExposure[appName]
-		p(appName, fmt.Sprintf("%d/%d\texposed", s[true], s[true]+s[false]))
+		k(output.EmphasisHighlight.BrightGreen, appName)
+		p(output.CurrentHighlight, fmt.Sprintf("%d/%d\texposed", s[true], s[true]+s[false]))
 	}
-	p(" ")
+	p(output.CurrentHighlight, " ")
 
-	p("# Remote:", fmt.Sprintf("(%d)", len(fs.RemoteApplications)))
+	k(kColor, "# Remote:")
+	p(output.EmphasisHighlight.Magenta, fmt.Sprintf("(%d)", len(fs.RemoteApplications)))
 	for _, svcName := range naturalsort.Sort(stringKeysFromMap(fs.RemoteApplications)) {
 		s := fs.RemoteApplications[svcName]
-		p(svcName, "", s.OfferURL)
+		k(output.InfoHighlight, svcName)
+		p(output.GoodHighlight, "", s.OfferURL)
 	}
 	f.tw.Flush()
 
 	return nil
 }
 
-func newSummaryFormatter(writer io.Writer) *summaryFormatter {
+func newSummaryFormatter(writer io.Writer, forceColor bool) *summaryFormatter {
+	w := output.TabWriter(writer)
+	if forceColor {
+		w.SetColorCapable(forceColor)
+	}
+
 	f := &summaryFormatter{
 		ipAddrs:     make([]net.IPNet, 0),
 		netStrings:  make([]string, 0),
 		openPorts:   set.NewStrings(),
 		stateToUnit: make(map[status.Status]int),
 	}
-	f.tw = output.TabWriter(writer)
+	f.tw = output.Wrapper{TabWriter: w}
 	return f
 }
 
@@ -92,12 +125,37 @@ type summaryFormatter struct {
 	openPorts  set.Strings
 	// status -> count
 	stateToUnit map[status.Status]int
-	tw          *ansiterm.TabWriter
+	tw          output.Wrapper
 }
 
-func (f *summaryFormatter) delimitValuesWithTabs(values ...string) {
+func (f *summaryFormatter) delimitKeysWithTabs(ctx *ansiterm.Context, values ...string) {
+	splitted := make([]string, 0)
+	cCtx := output.EmphasisHighlight.BoldBrightMagenta
+
+	for i, v := range values {
+		if strings.Contains(v, ":") {
+			splitted = strings.Split(v, ":")
+			str := splitted[i]
+			ctx.Fprintf(f.tw, "%s", str)
+			cCtx.Fprintf(f.tw, "%s\t", ":")
+		} else {
+			ctx.Fprintf(f.tw, "%s\t", v)
+		}
+	}
+	fmt.Fprint(f.tw)
+}
+
+func (f *summaryFormatter) delimitValuesWithTabs(ctx *ansiterm.Context, values ...string) {
 	for _, v := range values {
-		fmt.Fprintf(f.tw, "%s\t", v)
+		val := strings.TrimSpace(v)
+		if strings.HasPrefix(val, "(") && strings.HasSuffix(val, ")") {
+			val = strings.Split(strings.Split(val, "(")[1], ")")[0]
+			fmt.Fprint(f.tw, "(")
+			ctx.Fprintf(f.tw, "%s", val)
+			fmt.Fprint(f.tw, ")\t")
+		} else {
+			ctx.Fprintf(f.tw, "%s\t", v)
+		}
 	}
 	fmt.Fprintln(f.tw)
 }
@@ -134,7 +192,8 @@ func (f *summaryFormatter) trackUnit(name string, status unitStatus, indentLevel
 func (f *summaryFormatter) printStateToCount(m map[status.Status]int) {
 	for _, stateToCount := range naturalsort.Sort(stringKeysFromMap(m)) {
 		numInStatus := m[status.Status(stateToCount)]
-		f.delimitValuesWithTabs(stateToCount+":", fmt.Sprintf(" %d ", numInStatus))
+		f.delimitKeysWithTabs(output.StatusColor(status.Status(stateToCount)), stateToCount+":")
+		f.delimitValuesWithTabs(output.EmphasisHighlight.Magenta, fmt.Sprintf(" %d ", numInStatus))
 	}
 }
 

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -6,11 +6,12 @@ package status
 import (
 	"bytes"
 	"fmt"
-	"github.com/juju/ansiterm"
 	"io"
 	"net"
 	"os"
 	"strings"
+
+	"github.com/juju/ansiterm"
 
 	"github.com/juju/ansiterm/tabwriter"
 	"github.com/juju/collections/set"
@@ -129,12 +130,10 @@ type summaryFormatter struct {
 }
 
 func (f *summaryFormatter) delimitKeysWithTabs(ctx *ansiterm.Context, values ...string) {
-	splitted := make([]string, 0)
 	cCtx := output.EmphasisHighlight.BoldBrightMagenta
-
 	for i, v := range values {
 		if strings.Contains(v, ":") {
-			splitted = strings.Split(v, ":")
+			splitted := strings.Split(v, ":")
 			str := splitted[i]
 			ctx.Fprintf(f.tw, "%s", str)
 			cCtx.Fprintf(f.tw, "%s\t", ":")

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -6,7 +6,6 @@ package status
 import (
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -46,14 +45,11 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		return errors.Errorf("expected value of type %T, got %T", fs, value)
 	}
 
-	// overrides the --color=true
-	if _, ok := os.LookupEnv("NO_COLOR"); ok {
-		forceColor = false
-	}
-
 	// To format things into columns.
 	tw := output.TabWriter(writer)
-	tw.SetColorCapable(forceColor)
+	if forceColor {
+		tw.SetColorCapable(forceColor)
+	}
 
 	cloudRegion := fs.Model.Cloud
 	if fs.Model.CloudRegion != "" {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -5,13 +5,14 @@ package status
 
 import (
 	"fmt"
-	"github.com/juju/juju/cmd/output"
 	"io"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/juju/juju/cmd/output"
 
 	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
@@ -438,7 +439,6 @@ func (c *statusCommand) formatYaml(writer io.Writer, value interface{}) error {
 	var noColor bool
 
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		noColor = true
 		return cmd.FormatYaml(writer, value)
 	}
 
@@ -460,7 +460,6 @@ func (c *statusCommand) formatYaml(writer io.Writer, value interface{}) error {
 func (c *statusCommand) formatOneline(writer io.Writer, value interface{}) error {
 	var noColor bool
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		noColor = true
 		return FormatOneline(writer, value)
 	}
 	// NO_COLOR="" and --color=true
@@ -482,7 +481,6 @@ func (c *statusCommand) formatOneline(writer io.Writer, value interface{}) error
 func (c *statusCommand) formatJson(writer io.Writer, value interface{}) error {
 	var noColor bool
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		noColor = true
 		return cmd.FormatJson(writer, value)
 	}
 	// NO_COLOR="" and --color=true

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -438,10 +438,5 @@ func (c *statusCommand) FormatTabular(writer io.Writer, value interface{}) error
 		return FormatTabular(writer, !c.noColor, value)
 	}
 
-	// color mode enabled by default if on tty, overrides --color=false
-	if isTerminal(writer) {
-		c.color = true
-	}
-
 	return FormatTabular(writer, c.color, value)
 }

--- a/cmd/output/jsonformatter.go
+++ b/cmd/output/jsonformatter.go
@@ -52,7 +52,6 @@ func NewFormatter() *JSONFormatter {
 			KeyValSep: ansiterm.Foreground(ansiterm.BrightMagenta),
 			String:    ansiterm.Foreground(ansiterm.Default),
 		},
-		Indent: 1,
 		writer: writer,
 		buff:   buff,
 	}
@@ -185,8 +184,8 @@ func (f *JSONFormatter) marshalValue(val interface{}, buf *bytes.Buffer, depth i
 		f.buff.Reset()
 	default:
 		b, _ := json.Marshal(val)
-		m := map[string]interface{}{}
-		json.Unmarshal(b, &m)
-		f.marshalMap(m, buf, depth)
+		var m interface{}
+		_ = json.Unmarshal(b, &m)
+		f.marshalValue(m, buf, depth)
 	}
 }

--- a/cmd/output/jsonformatter.go
+++ b/cmd/output/jsonformatter.go
@@ -52,6 +52,7 @@ func NewFormatter() *JSONFormatter {
 			KeyValSep: ansiterm.Foreground(ansiterm.BrightMagenta),
 			String:    ansiterm.Foreground(ansiterm.Default),
 		},
+		Indent: 1,
 		writer: writer,
 		buff:   buff,
 	}
@@ -158,6 +159,7 @@ func (f *JSONFormatter) marshalArray(a []interface{}, buf *bytes.Buffer, depth i
 }
 
 func (f *JSONFormatter) marshalValue(val interface{}, buf *bytes.Buffer, depth int) {
+
 	switch v := val.(type) {
 	case map[string]interface{}:
 		f.marshalMap(v, buf, depth)
@@ -181,5 +183,10 @@ func (f *JSONFormatter) marshalValue(val interface{}, buf *bytes.Buffer, depth i
 		f.Colors.Number.Fprint(f.writer, v.String())
 		buf.WriteString(f.buff.String())
 		f.buff.Reset()
+	default:
+		b, _ := json.Marshal(val)
+		m := map[string]interface{}{}
+		json.Unmarshal(b, &m)
+		f.marshalMap(m, buf, depth)
 	}
 }

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -137,6 +137,11 @@ func (w *Wrapper) PrintStatus(status status.Status) {
 	w.PrintColor(statusColors[status], status)
 }
 
+// StatusColor returns the status's standard color
+func StatusColor(status status.Status) *ansiterm.Context {
+	return statusColors[status]
+}
+
 // CurrentHighlight is the color used to show the current
 // controller, user or model in tabular
 var CurrentHighlight = ansiterm.Foreground(ansiterm.Green)

--- a/status.txt
+++ b/status.txt
@@ -1,0 +1,21 @@
+Model        Controller        Cloud/Region         Version    SLA          Timestamp
+local-model  local-controller  localhost/localhost  3.0-beta1  unsupported  22:41:07+03:00
+
+App         Version  Status   Scale  Charm       Channel  Rev  Exposed  Message
+haproxy              unknown    0/1  haproxy     stable    66  no       
+mediawiki   1.19.14  unknown    0/1  mediawiki   stable    28  no       
+mysql       5.5.62   unknown    0/1  mysql       stable    58  no       
+postgresql  12.11    unknown    0/1  postgresql  stable   239  no       
+
+Unit          Workload  Agent  Machine  Public address  Ports     Message
+haproxy/0     unknown   lost   2        10.117.119.67   80/tcp    agent lost, see 'juju show-status-log haproxy/0'
+mediawiki/0   unknown   lost   3        10.117.119.101  80/tcp    agent lost, see 'juju show-status-log mediawiki/0'
+mysql/0       unknown   lost   1        10.117.119.31   3306/tcp  agent lost, see 'juju show-status-log mysql/0'
+postgresql/0  unknown   lost   0        10.117.119.126  5432/tcp  agent lost, see 'juju show-status-log postgresql/0'
+
+Machine  State  Address         Inst id        Series  AZ  Message
+0        down   10.117.119.126  juju-9ee80e-0  focal       Running
+1        down   10.117.119.31   juju-9ee80e-1  trusty      Running
+2        down   10.117.119.67   juju-9ee80e-2  xenial      Running
+3        down   10.117.119.101  juju-9ee80e-3  trusty      Running
+


### PR DESCRIPTION
In my previous implementation of coloring output for the commands `juju status`, `juju config` and `juju run`  prioritized the global environment variables `NO_COLOR=""` and `TERM="dumb"` over explicit cli flags. i.e `NO_COLOR="" juju status --color` would not output color while the general premise and expectation was to override the NO_COLOR="" env hence output color since that is what the user wants by explicitly passing the cli color flag.
This PR also colors some subcommands of status which were initially left out i.e `--format=summary` , `--format=oneline` , `--format=line` and `--format=short`

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps

*Bootstrap on any cloud*

1. Juju status
```sh
NO_COLOR="" juju status --format=short --color
TERM="dumb" juju status --format=short --color
watch --color juju status --format=short  --color
juju status --format=short --color | cat
juju status --format=short --color > status.txt
juju status --format=short 
juju status --format=short --color
```
*The output from the above commands should contain ansi color codes and styles. Accepted formats are `short`,`oneline`, `line`, `tabular` , `yaml`, `json` and `summary`*

2. Juju config

```sh
NO_COLOR="" juju config mediawiki --format=json --color
watch --color juju config mediawiki --format=json --color
juju config mediawiki --format=json --color
juju config mediawiki --format=json 
```
*The output from the above commands should contain ansi color codes and styles. Accepted formats are `yaml` and  `json`*

4. Juju  run
```sh
NO_COLOR="" juju run postgresql/0 maintenance-mode-stop --format=json --color
watch --color juju run postgresql/0 maintenance-mode-stop --format=json --color
```
*The output from the above commands should contain ansi color codes and styles. Accepted formats are `yaml` and  `json`*