### PR TITLE
Add a secrets facade stub to keep older agents happy

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -105,6 +105,8 @@ var facadeVersions = map[string]int{
 	"ResourcesHookContext":         1,
 	"Resumer":                      2,
 	"RetryStrategy":                1,
+	"SecretsRotationWatcher":       1,
+	"SecretsManager":               1,
 	"Singular":                     2,
 	"Spaces":                       6,
 	"SSHClient":                    3,

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/reboot"
 	"github.com/juju/juju/apiserver/facades/agent/resourceshookcontext"
 	"github.com/juju/juju/apiserver/facades/agent/retrystrategy"
+	"github.com/juju/juju/apiserver/facades/agent/secretsmanager"
 	"github.com/juju/juju/apiserver/facades/agent/storageprovisioner"
 	"github.com/juju/juju/apiserver/facades/agent/unitassigner"
 	"github.com/juju/juju/apiserver/facades/agent/uniter"
@@ -198,6 +199,7 @@ func AllFacades() *facade.Registry {
 	resumer.Register(registry)
 	retrystrategy.Register(registry)
 	singular.Register(registry)
+	secretsmanager.Register(registry)
 	sshclient.Register(registry)
 	spaces.Register(registry)
 	statushistory.Register(registry)
@@ -237,6 +239,7 @@ func AllFacades() *facade.Registry {
 	registry.MustRegister("EntityWatcher", 2, newEntitiesWatcher, reflect.TypeOf((*srvEntitiesWatcher)(nil)))
 	registry.MustRegister("MigrationStatusWatcher", 1, newMigrationStatusWatcher, reflect.TypeOf((*srvMigrationStatusWatcher)(nil)))
 	registry.MustRegister("ModelSummaryWatcher", 1, newModelSummaryWatcher, reflect.TypeOf((*SrvModelSummaryWatcher)(nil)))
+	registry.MustRegister("SecretsRotationWatcher", 1, newSecretsRotationWatcher, reflect.TypeOf((*srvSecretRotationWatcher)(nil)))
 
 	return registry
 }

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsmanager
+
+import (
+	"reflect"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/apiserver/facade"
+)
+
+// Register is called to expose a package of facades onto a given registry.
+func Register(registry facade.FacadeRegistry) {
+	registry.MustRegister("SecretsManager", 1, func(ctx facade.Context) (facade.Facade, error) {
+		return newSecretManagerAPI(ctx)
+	}, reflect.TypeOf((*SecretsManagerAPI)(nil)))
+}
+
+// newSecretManagerAPI creates a SecretsManagerAPI.
+func newSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
+	if !context.Auth().AuthUnitAgent() && !context.Auth().AuthApplicationAgent() {
+		return nil, apiservererrors.ErrPerm
+	}
+	return &SecretsManagerAPI{
+		controllerUUID: context.State().ControllerUUID(),
+		modelUUID:      context.State().ModelUUID(),
+		resources:      context.Resources(),
+	}, nil
+}

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -1,0 +1,75 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsmanager
+
+import (
+	"time"
+
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/rpc/params"
+)
+
+// SecretsManagerAPI is the implementation for the SecretsManager facade.
+// This is only a stub implementation to keep older unit agents happy.
+type SecretsManagerAPI struct {
+	controllerUUID string
+	modelUUID      string
+	resources      facade.Resources
+}
+
+type SecretRotationChange struct {
+	ID             int           `json:"secret-id"`
+	URL            string        `json:"url"`
+	RotateInterval time.Duration `json:"rotate-interval"`
+	LastRotateTime time.Time     `json:"last-rotate-time"`
+}
+
+type SecretRotationWatchResult struct {
+	SecretRotationWatcherId string                 `json:"watcher-id"`
+	Changes                 []SecretRotationChange `json:"changes"`
+	Error                   *params.Error          `json:"error,omitempty"`
+}
+
+type SecretRotationWatchResults struct {
+	Results []SecretRotationWatchResult `json:"results"`
+}
+
+type SecretRotationChannel <-chan []SecretRotationChange
+
+type noopSecretsWatcher struct {
+	tomb tomb.Tomb
+}
+
+func (w *noopSecretsWatcher) Changes() SecretRotationChannel {
+	return nil
+}
+
+func (w *noopSecretsWatcher) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+func (w *noopSecretsWatcher) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *noopSecretsWatcher) Err() error {
+	return w.tomb.Err()
+}
+
+func (w *noopSecretsWatcher) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (s *SecretsManagerAPI) WatchSecretsRotationChanges(args params.Entities) (SecretRotationWatchResults, error) {
+	results := SecretRotationWatchResults{
+		Results: make([]SecretRotationWatchResult, len(args.Entities)),
+	}
+	for i := range args.Entities {
+		results.Results[i].SecretRotationWatcherId = s.resources.Register(&noopSecretsWatcher{})
+	}
+	return results, nil
+}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -40668,6 +40668,252 @@
         }
     },
     {
+        "Name": "SecretsManager",
+        "Description": "SecretsManagerAPI is the implementation for the SecretsManager facade.\nThis is only a stub implementation to keep older unit agents happy.",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "WatchSecretsRotationChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretRotationWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "SecretRotationChange": {
+                    "type": "object",
+                    "properties": {
+                        "last-rotate-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "rotate-interval": {
+                            "type": "integer"
+                        },
+                        "secret-id": {
+                            "type": "integer"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "secret-id",
+                        "url",
+                        "rotate-interval",
+                        "last-rotate-time"
+                    ]
+                },
+                "SecretRotationWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRotationChange"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id",
+                        "changes"
+                    ]
+                },
+                "SecretRotationWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRotationWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "SecretsRotationWatcher",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Next": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/SecretRotationWatchResult"
+                        }
+                    },
+                    "description": "Next returns when a change has occurred to an entity of the\ncollection being watched since the most recent call to Next\nor the Watch call that created the srvSecretRotationWatcher."
+                },
+                "Stop": {
+                    "type": "object",
+                    "description": "Stop stops the watcher."
+                }
+            },
+            "definitions": {
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "SecretRotationChange": {
+                    "type": "object",
+                    "properties": {
+                        "last-rotate-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "rotate-interval": {
+                            "type": "integer"
+                        },
+                        "secret-id": {
+                            "type": "integer"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "secret-id",
+                        "url",
+                        "rotate-interval",
+                        "last-rotate-time"
+                    ]
+                },
+                "SecretRotationWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRotationChange"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id",
+                        "changes"
+                    ]
+                }
+            }
+        }
+    },
+    {
         "Name": "Singular",
         "Description": "Facade allows controller machines to request exclusive rights to administer\nsome specific model or controller for a limited time.",
         "Version": 2,


### PR DESCRIPTION
Removing the agent secret facades breaks older agents if just the controller is upgraded.
Here we restore previously removed code and convert the required facades to stubs for the secret rotation watcher and manager to keep the older agents happy.

## QA steps

```
juju bootstrap lxd --agent-version=2.9.28
juju deploy ubuntu
juju upgrade-controller --build-agent
```

check logs for errors

## Bug reference

https://bugs.launchpad.net/juju/+bug/1981324
