### PR TITLE
Fix running individual subtests in bash tests

### DIFF
--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -6,7 +6,7 @@ run() {
 		# shellcheck disable=SC2143
 		if [[ ! "$(echo "${RUN_SUBTEST}" | grep -E "^${CMD}$")" ]]; then
 			echo "SKIPPING: ${RUN_SUBTEST} ${CMD}"
-			exit 0
+			return 0
 		fi
 	fi
 


### PR DESCRIPTION
There was an issue in `run.sh`, best illustrated with an example. Say we want to run the `run_deploy_cmr_bundle` subtest in the `deploy_bundles` suite. Following the README, we would execute
```
./main.sh deploy run_deploy_cmr_bundle
```

However, `test_deploy_bundles()` calls
```
run "run_deploy_bundle"
```
first, which is skipped because it's not the right subtest. However, when the `run` subroutine does `exit 0`, this seems to exit `test_deploy_bundles()` as well. As a result, the subtest we want to run (`run_deploy_cmr_bundle`) doesn't even get a chance.

Replacing `exit 0` with `return 0` seems to fix this.

## QA steps

From the Juju source tree root:
```sh
cd tests
./main.sh deploy run_deploy_cmr_bundle
```

Before, it would attempt to run the first subtest (`run_deploy_bundle`), but since this was not the right test, it would exit the whole test suite.

Now, it will skip all the irrelevant tests and simply run the one we want.