### PR TITLE
Move to sstxns.log (non-capped collection) + improvements to sstxn retry/error handling.

### DIFF
--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
@@ -52,7 +52,7 @@ var singletonErrorCodes = map[error]string{
 	stateerrors.ErrCannotEnterScope:    params.CodeCannotEnterScope,
 	stateerrors.ErrUnitHasSubordinates: params.CodeUnitHasSubordinates,
 	stateerrors.ErrDead:                params.CodeDead,
-	txn.ErrExcessiveContention:         params.CodeExcessiveContention,
+	jujutxn.ErrExcessiveContention:     params.CodeExcessiveContention,
 	leadership.ErrClaimDenied:          params.CodeLeadershipClaimDenied,
 	lease.ErrClaimDenied:               params.CodeLeaseClaimDenied,
 	ErrBadId:                           params.CodeNotFound,

--- a/apiserver/errors/errors_test.go
+++ b/apiserver/errors/errors_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 
@@ -69,7 +69,7 @@ var errorTransformTests = []struct {
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeDead,
 }, {
-	err:        txn.ErrExcessiveContention,
+	err:        jujutxn.ErrExcessiveContention,
 	code:       params.CodeExcessiveContention,
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeExcessiveContention,

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 
 	"github.com/juju/juju/apiserver/common"
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
@@ -272,7 +272,7 @@ func (api *OffersAPI) grantOfferAccess(backend Backend, offerTag names.Applicati
 		offerAccess, err := backend.GetOfferAccess(offer.OfferUUID, targetUserTag)
 		if errors.IsNotFound(err) {
 			// Conflicts with prior check, must be inconsistent state.
-			err = txn.ErrExcessiveContention
+			err = jujutxn.ErrExcessiveContention
 		}
 		if err != nil {
 			return errors.Annotate(err, "could not look up offer access for user")

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/credentialcommon"
@@ -1004,7 +1004,7 @@ func grantCloudAccess(backend Backend, cloud string, targetUserTag names.UserTag
 		cloudAccess, err := backend.GetCloudAccess(cloud, targetUserTag)
 		if errors.IsNotFound(err) {
 			// Conflicts with prior check, must be inconsistent state.
-			err = txn.ErrExcessiveContention
+			err = jujutxn.ErrExcessiveContention
 		}
 		if err != nil {
 			return errors.Annotate(err, "could not look up cloud access for user")

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 	"github.com/juju/version/v2"
 	"gopkg.in/macaroon.v2"
 
@@ -952,7 +952,7 @@ func grantControllerAccess(accessor ControllerAccess, targetUserTag, apiUser nam
 		controllerUser, err := accessor.UserAccess(targetUserTag, controllerTag)
 		if errors.IsNotFound(err) {
 			// Conflicts with prior check, must be inconsistent state.
-			err = txn.ErrExcessiveContention
+			err = jujutxn.ErrExcessiveContention
 		}
 		if err != nil {
 			return errors.Annotate(err, "could not look up controller access for user")

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/apiserver/common"
@@ -1090,7 +1090,7 @@ func changeModelAccess(accessor common.ModelManagerBackend, modelTag names.Model
 			modelUser, err := st.UserAccess(targetUserTag, modelTag)
 			if errors.IsNotFound(err) {
 				// Conflicts with prior check, must be inconsistent state.
-				err = txn.ErrExcessiveContention
+				err = jujutxn.ErrExcessiveContention
 			}
 			if err != nil {
 				return errors.Annotate(err, "could not look up model access for user")

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -32474,14 +32474,14 @@
                         "model-tag": {
                             "type": "string"
                         },
-                        "targert-version": {
+                        "target-version": {
                             "$ref": "#/definitions/Number"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
                         "model-tag",
-                        "targert-version"
+                        "target-version"
                     ]
                 },
                 "UpgradeModelResult": {

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/juju/schema v1.0.1
 	github.com/juju/terms-client/v2 v2.0.0
 	github.com/juju/testing v1.0.1
-	github.com/juju/txn/v3 v3.0.0
+	github.com/juju/txn/v3 v3.0.1
 	github.com/juju/utils v0.0.0-20200604140309-9d78121a29e0
 	github.com/juju/utils/v3 v3.0.0
 	github.com/juju/version/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,16 @@ github.com/hashicorp/raft v1.3.2-0.20210825230038-1a621031eb2b h1:/RdcFlfZTf190O
 github.com/hashicorp/raft v1.3.2-0.20210825230038-1a621031eb2b/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/hpidcock/mgo/v2 v2.0.0-20220712061958-48d28efff097 h1:mUlPaEXFTQX1MLYBqozWmxdL9csWtDewGuAbSyvv1Wg=
+github.com/hpidcock/mgo/v2 v2.0.0-20220712061958-48d28efff097/go.mod h1:N614SE0a4e+ih2rg96Vi2PeC3cTpUOWgCTv3Cgk974c=
+github.com/hpidcock/mgo/v2 v2.0.0-20220712063409-dcf0c4875ba8 h1:7XBq/TMjRtuUutQ4qWZLBLFJD2TLEWWHzlACvWHZTcM=
+github.com/hpidcock/mgo/v2 v2.0.0-20220712063409-dcf0c4875ba8/go.mod h1:N614SE0a4e+ih2rg96Vi2PeC3cTpUOWgCTv3Cgk974c=
+github.com/hpidcock/mgo/v2 v2.0.0-20220712064421-1826dea0c381 h1:90Cw/ov56JO3j2NeMCdBXbAbJ2O7Bkhfddu6RfJ0J0s=
+github.com/hpidcock/mgo/v2 v2.0.0-20220712064421-1826dea0c381/go.mod h1:N614SE0a4e+ih2rg96Vi2PeC3cTpUOWgCTv3Cgk974c=
+github.com/hpidcock/txn/v2 v2.0.0-20220712062202-9ff8d89d90a0 h1:U03cpGmT4U1KCmaQAt9ER7dd/grX6fgdzkKeN6UGWo4=
+github.com/hpidcock/txn/v2 v2.0.0-20220712062202-9ff8d89d90a0/go.mod h1:7zgbIJdJPvT///7hsQUavz1RPAllhsfcnc3+3k07rs8=
+github.com/hpidcock/txn/v2 v2.0.0-20220712063826-ba1dc8b74316 h1:eL0sAQORn5gAnkjcJoff7cRzep2fsVWyMArBBuQIwas=
+github.com/hpidcock/txn/v2 v2.0.0-20220712063826-ba1dc8b74316/go.mod h1:G5n9GbftkJP2aO8hDma/VnFIC72fCd4XIKC5obeEuH4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/im7mortal/kmutex v1.0.1 h1:zAACzjwD+OEknDqnLdvRa/BhzFM872EBwKijviGLc9Q=

--- a/go.sum
+++ b/go.sum
@@ -447,16 +447,6 @@ github.com/hashicorp/raft v1.3.2-0.20210825230038-1a621031eb2b h1:/RdcFlfZTf190O
 github.com/hashicorp/raft v1.3.2-0.20210825230038-1a621031eb2b/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hpidcock/mgo/v2 v2.0.0-20220712061958-48d28efff097 h1:mUlPaEXFTQX1MLYBqozWmxdL9csWtDewGuAbSyvv1Wg=
-github.com/hpidcock/mgo/v2 v2.0.0-20220712061958-48d28efff097/go.mod h1:N614SE0a4e+ih2rg96Vi2PeC3cTpUOWgCTv3Cgk974c=
-github.com/hpidcock/mgo/v2 v2.0.0-20220712063409-dcf0c4875ba8 h1:7XBq/TMjRtuUutQ4qWZLBLFJD2TLEWWHzlACvWHZTcM=
-github.com/hpidcock/mgo/v2 v2.0.0-20220712063409-dcf0c4875ba8/go.mod h1:N614SE0a4e+ih2rg96Vi2PeC3cTpUOWgCTv3Cgk974c=
-github.com/hpidcock/mgo/v2 v2.0.0-20220712064421-1826dea0c381 h1:90Cw/ov56JO3j2NeMCdBXbAbJ2O7Bkhfddu6RfJ0J0s=
-github.com/hpidcock/mgo/v2 v2.0.0-20220712064421-1826dea0c381/go.mod h1:N614SE0a4e+ih2rg96Vi2PeC3cTpUOWgCTv3Cgk974c=
-github.com/hpidcock/txn/v2 v2.0.0-20220712062202-9ff8d89d90a0 h1:U03cpGmT4U1KCmaQAt9ER7dd/grX6fgdzkKeN6UGWo4=
-github.com/hpidcock/txn/v2 v2.0.0-20220712062202-9ff8d89d90a0/go.mod h1:7zgbIJdJPvT///7hsQUavz1RPAllhsfcnc3+3k07rs8=
-github.com/hpidcock/txn/v2 v2.0.0-20220712063826-ba1dc8b74316 h1:eL0sAQORn5gAnkjcJoff7cRzep2fsVWyMArBBuQIwas=
-github.com/hpidcock/txn/v2 v2.0.0-20220712063826-ba1dc8b74316/go.mod h1:G5n9GbftkJP2aO8hDma/VnFIC72fCd4XIKC5obeEuH4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/im7mortal/kmutex v1.0.1 h1:zAACzjwD+OEknDqnLdvRa/BhzFM872EBwKijviGLc9Q=
@@ -614,8 +604,8 @@ github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494/go.mod h1:rUquetT0ALL
 github.com/juju/testing v1.0.0/go.mod h1:rUquetT0ALL48LHZhyRGvjjBH8xZaZ8dFClulKK5wK4=
 github.com/juju/testing v1.0.1 h1:Zlg3HKP+wBRpkxCmh+Bsxp3WOmfelcZXuX6Adb7Dvec=
 github.com/juju/testing v1.0.1/go.mod h1:h3Vd2rzB57KrdsBEy6R7bmSKPzP76BnNavt7i8PerwQ=
-github.com/juju/txn/v3 v3.0.0 h1:R3Oth/N+FmoqOUWOKEKihIMnJ8O5JQRlMI9pEMLpoHE=
-github.com/juju/txn/v3 v3.0.0/go.mod h1:DlFlqNZkgzE4NolIxhSvYOok/heIOjhXLx3Z5oUTyy4=
+github.com/juju/txn/v3 v3.0.1 h1:6lz2Oa84RVgfKz8+DMR/3IlwKj/iUBUmrOv40IFSAU0=
+github.com/juju/txn/v3 v3.0.1/go.mod h1:DlFlqNZkgzE4NolIxhSvYOok/heIOjhXLx3Z5oUTyy4=
 github.com/juju/usso v1.0.1 h1:zyQhSUJnhFZdPqVAmPeqXYlnYXv+i0Cp1Ii+aziMXGs=
 github.com/juju/usso v1.0.1/go.mod h1:3cvBcGVmWXyHhrBHBQtpNBzca/JRg4S5XH88Hj/NsYA=
 github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=

--- a/rpc/params/model.go
+++ b/rpc/params/model.go
@@ -491,7 +491,7 @@ type ModelParam struct {
 // UpgradeModel contains the arguments for UpgradeModel API call.
 type UpgradeModelParams struct {
 	ModelTag            string         `json:"model-tag"`
-	TargetVersion       version.Number `json:"targert-version"`
+	TargetVersion       version.Number `json:"target-version"`
 	AgentStream         string         `json:"agent-stream,omitempty"`
 	IgnoreAgentVersions bool           `json:"ignore-agent-versions,omitempty"`
 	DryRun              bool           `json:"dry-run,omitempty"`

--- a/scripts/juju-blobstore-cleanup/main.go
+++ b/scripts/juju-blobstore-cleanup/main.go
@@ -378,7 +378,12 @@ func (b *BlobstoreCleaner) findUnmanagedResources() {
 }
 
 func txnRunner(db *mgo.Database) jujutxn.Runner {
-	return jujutxn.NewRunner(jujutxn.RunnerParams{Database: db})
+	return jujutxn.NewRunner(jujutxn.RunnerParams{
+		Database:                  db,
+		TransactionCollectionName: "txns",
+		ChangeLogName:             "sstxns.log",
+		ServerSideTransactions:    true,
+	})
 }
 
 func removeStoredResourceOps(docID string) []txn.Op {

--- a/scripts/mgo-run-txn/main.go
+++ b/scripts/mgo-run-txn/main.go
@@ -146,7 +146,8 @@ func main() {
 	runner := jujutxn.NewRunner(jujutxn.RunnerParams{
 		Database:                  session.DB(args.Database),
 		TransactionCollectionName: "txns",
-		ChangeLogName:             "txns.log",
+		ChangeLogName:             "sstxns.log",
+		ServerSideTransactions:    true,
 		Clock:                     clock.WallClock,
 	})
 	txnOps := make([]txn.Op, len(ops))

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/actions"
@@ -673,7 +673,7 @@ func (s *ActionSuite) TestAddActionFailsOnDeadUnitInTransaction(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	preventUnitDestroyRemove(c, unit)
 
-	killUnit := txn.TestHook{
+	killUnit := jujutxn.TestHook{
 		Before: func() {
 			c.Assert(unit.Destroy(), gc.IsNil)
 			c.Assert(unit.EnsureDead(), gc.IsNil)

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -654,7 +654,7 @@ const (
 	linkLayerDevicesC          = "linklayerdevices"
 	ipAddressesC               = "ip.addresses"
 	toolsmetadataC             = "toolsmetadata"
-	txnLogC                    = "txns.log"
+	txnLogC                    = "sstxns.log"
 	txnsC                      = "txns"
 	unitsC                     = "units"
 	unitStatesC                = "unitstates"

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -801,6 +801,7 @@ func (s *applicationOffersSuite) TestRemovingApplicationFailsRace(c *gc.C) {
 		}
 	}
 
+	state.SetMaxTxnAttempts(c, s.State, 3)
 	bumpTxnRevno := jujutxn.TestHook{Before: addRelation, After: rmRelations}
 	defer state.SetTestHooks(c, s.State, bumpTxnRevno, bumpTxnRevno, bumpTxnRevno).Check()
 

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/crossmodel"
@@ -801,7 +801,7 @@ func (s *applicationOffersSuite) TestRemovingApplicationFailsRace(c *gc.C) {
 		}
 	}
 
-	bumpTxnRevno := txn.TestHook{Before: addRelation, After: rmRelations}
+	bumpTxnRevno := jujutxn.TestHook{Before: addRelation, After: rmRelations}
 	defer state.SetTestHooks(c, s.State, bumpTxnRevno, bumpTxnRevno, bumpTxnRevno).Check()
 
 	err = s.mysql.Destroy()

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 	"github.com/juju/utils/v3/arch"
 	gc "gopkg.in/check.v1"
 
@@ -485,7 +485,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineBecomesDirty(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	makeDirty := txn.TestHook{
+	makeDirty := jujutxn.TestHook{
 		Before: func() { c.Assert(unit.AssignToMachine(machine), gc.IsNil) },
 	}
 	defer state.SetTestHooks(c, s.State, makeDirty).Check()
@@ -516,7 +516,7 @@ func (s *AssignSuite) TestAssignUnitToNewMachineBecomesHost(c *gc.C) {
 	machine, err := s.State.AddMachine("quantal", state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	addContainer := txn.TestHook{
+	addContainer := jujutxn.TestHook{
 		Before: func() {
 			_, err := s.State.AddMachineInsideMachine(state.MachineTemplate{
 				Series: "quantal",

--- a/state/binarystorage/binarystorage_test.go
+++ b/state/binarystorage/binarystorage_test.go
@@ -57,6 +57,7 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 		TransactionCollectionName: "txns",
 		ChangeLogName:             "sstxns.log",
 		ServerSideTransactions:    true,
+		MaxRetryAttempts:          3,
 	})
 	s.storage = binarystorage.New("my-uuid", s.managedStorage, s.metadataCollection, s.txnRunner)
 }

--- a/state/binarystorage/binarystorage_test.go
+++ b/state/binarystorage/binarystorage_test.go
@@ -52,7 +52,12 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 	s.metadataCollection, closer = mongo.CollectionFromName(catalogue, "binarymetadata")
 	s.addCleanup(func(*gc.C) { closer() })
 	s.managedStorage = blobstore.NewManagedStorage(s.metadataCollection.Writeable().Underlying().Database, rs)
-	s.txnRunner = jujutxn.NewRunner(jujutxn.RunnerParams{Database: catalogue})
+	s.txnRunner = jujutxn.NewRunner(jujutxn.RunnerParams{
+		Database:                  catalogue,
+		TransactionCollectionName: "txns",
+		ChangeLogName:             "sstxns.log",
+		ServerSideTransactions:    true,
+	})
 	s.storage = binarystorage.New("my-uuid", s.managedStorage, s.metadataCollection, s.txnRunner)
 }
 

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/juju/mgo/v3/bson"
 	mgotesting "github.com/juju/mgo/v3/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/txn/v3"
-	txntesting "github.com/juju/txn/v3/testing"
+	jujutxn "github.com/juju/txn/v3"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/mongo"
@@ -635,13 +634,13 @@ func (s *cloudImageMetadataSuite) assertNoMetadata(c *gc.C) {
 
 type TestMongo struct {
 	database *mgo.Database
-	runner   txn.Runner
+	runner   jujutxn.Runner
 }
 
 func NewTestMongo(database *mgo.Database) *TestMongo {
 	return &TestMongo{
 		database: database,
-		runner: txn.NewRunner(txn.RunnerParams{
+		runner: jujutxn.NewRunner(jujutxn.RunnerParams{
 			Database: database,
 		}),
 	}
@@ -651,6 +650,6 @@ func (m *TestMongo) GetCollection(name string) (mongo.Collection, func()) {
 	return mongo.CollectionFromName(m.database, name)
 }
 
-func (m *TestMongo) RunTransaction(getTxn txn.TransactionSource) error {
+func (m *TestMongo) RunTransaction(getTxn jujutxn.TransactionSource) error {
 	return m.runner.Run(getTxn)
 }

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -13,6 +13,7 @@ import (
 	mgotesting "github.com/juju/mgo/v3/testing"
 	jc "github.com/juju/testing/checkers"
 	jujutxn "github.com/juju/txn/v3"
+	txntesting "github.com/juju/txn/v3/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/mongo"

--- a/state/database.go
+++ b/state/database.go
@@ -385,11 +385,13 @@ func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCl
 			}
 		}
 		params := jujutxn.RunnerParams{
-			Database:               raw,
-			RunTransactionObserver: observer,
-			Clock:                  db.clock,
-			ServerSideTransactions: true,
-			MaxRetryAttempts:       40,
+			Database:                  raw,
+			RunTransactionObserver:    observer,
+			Clock:                     db.clock,
+			TransactionCollectionName: "txns",
+			ChangeLogName:             "sstxns.log",
+			ServerSideTransactions:    true,
+			MaxRetryAttempts:          40,
 		}
 		runner = jujutxn.NewRunner(params)
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -134,6 +134,9 @@ func newRunnerForHooks(st *State) jujutxn.Runner {
 	runner := jujutxn.NewRunner(jujutxn.RunnerParams{
 		Database: db.raw,
 		Clock:    st.stateClock,
+		TransactionCollectionName: "txns",
+		ChangeLogName:             "sstxns.log",
+		ServerSideTransactions:    true,
 		RunTransactionObserver: func(t jujutxn.Transaction) {
 			txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
 				t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)

--- a/state/imagestorage/image.go
+++ b/state/imagestorage/image.go
@@ -74,8 +74,10 @@ func (s *imageStorage) txnRunner(session *mgo.Session) jujutxn.Runner {
 // Override for testing.
 var txnRunner = func(db *mgo.Database) jujutxn.Runner {
 	return jujutxn.NewRunner(jujutxn.RunnerParams{
-		Database:               db,
-		ServerSideTransactions: true,
+		Database:                  db,
+		TransactionCollectionName: "txns",
+		ChangeLogName:             "sstxns.log",
+		ServerSideTransactions:    true,
 	})
 }
 

--- a/state/imagestorage/image_test.go
+++ b/state/imagestorage/image_test.go
@@ -46,6 +46,7 @@ func (s *ImageSuite) SetUpTest(c *gc.C) {
 		TransactionCollectionName: "txns",
 		ChangeLogName:             "sstxns.log",
 		ServerSideTransactions:    true,
+		MaxRetryAttempts:          3,
 	})
 	s.patchTransactionRunner()
 }

--- a/state/initialize.go
+++ b/state/initialize.go
@@ -64,6 +64,10 @@ type InitializeParams struct {
 	// for closing this session; Initialize will copy it.
 	MongoSession *mgo.Session
 
+	// MaxTxnAttempts is the number of attempts when running transactions
+	// against mongo. OpenStatePool defaults this if 0.
+	MaxTxnAttempts int
+
 	// AdminPassword holds the password for the initial user.
 	AdminPassword string
 }
@@ -158,6 +162,7 @@ func Initialize(args InitializeParams) (_ *Controller, err error) {
 		ControllerTag:      controllerTag,
 		ControllerModelTag: modelTag,
 		MongoSession:       args.MongoSession,
+		MaxTxnAttempts:     args.MaxTxnAttempts,
 		NewPolicy:          args.NewPolicy,
 		InitDatabaseFunc:   InitDatabase,
 	})

--- a/state/leaseupgrades.go
+++ b/state/leaseupgrades.go
@@ -45,9 +45,11 @@ func migrateModelLeasesToGlobalTime(st *State) error {
 	runner := db.runner
 	if runner == nil {
 		runner = jujutxn.NewRunner(jujutxn.RunnerParams{
-			Database:               db.raw,
-			Clock:                  db.clock,
-			ServerSideTransactions: true,
+			Database:                  db.raw,
+			Clock:                     db.clock,
+			TransactionCollectionName: "txns",
+			ChangeLogName:             "sstxns.log",
+			ServerSideTransactions:    true,
 		})
 	}
 	err := runner.Run(func(int) ([]txn.Op, error) {

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -931,6 +931,7 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithModerateStateChu
 
 func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesWithTooMuchStateChurn(c *gc.C) {
 	childArgs, churnHook := s.prepareSetLinkLayerDevicesWithStateChurn(c)
+	state.SetMaxTxnAttempts(c, s.State, 3)
 	defer state.SetTestHooks(c, s.State, churnHook, churnHook, churnHook).Check()
 	s.assertAllLinkLayerDevicesOnMachineMatchCount(c, s.machine, 1) // parent only
 

--- a/state/machine_ports_test.go
+++ b/state/machine_ports_test.go
@@ -6,7 +6,6 @@ package state_test
 import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/txn/v3"
 	jujutxn "github.com/juju/txn/v3"
 	gc "gopkg.in/check.v1"
 
@@ -523,5 +522,5 @@ func (s *MachinePortsDocSuite) TestChangesForIndividualUnits(c *gc.C) {
 	// Verify that if we call changes on the machine ports instance we
 	// get no ops as everything has been committed.
 	_, err = s.machPortRanges.Changes().Build(0)
-	c.Assert(err, gc.Equals, txn.ErrNoOperations, gc.Commentf("machine port range was not synced correctly after applying changes"))
+	c.Assert(err, gc.Equals, jujutxn.ErrNoOperations, gc.Commentf("machine port range was not synced correctly after applying changes"))
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -538,6 +538,7 @@ func (s *MachineSuite) TestDestroyContention(c *gc.C) {
 		Before: func() { c.Assert(unit.AssignToMachine(s.machine), gc.IsNil) },
 		After:  func() { c.Assert(unit.UnassignFromMachine(), gc.IsNil) },
 	}
+	state.SetMaxTxnAttempts(c, s.State, 3)
 	defer state.SetTestHooks(c, s.State, perturb, perturb, perturb).Check()
 
 	err = s.machine.Destroy()

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -135,6 +135,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// Transaction stuff.
 		"txns",
 		"txns.log",
+		"sstxns.log",
 
 		// We don't import any of the migration collections.
 		migrationsC,

--- a/state/model.go
+++ b/state/model.go
@@ -395,6 +395,7 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 		st.newPolicy,
 		st.clock(),
 		st.runTransactionObserver,
+		st.maxTxnAttempts,
 	)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "could not create state for new model")

--- a/state/pool.go
+++ b/state/pool.go
@@ -130,6 +130,10 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 		return nil, errors.Annotate(err, "validating args")
 	}
 
+	if args.MaxTxnAttempts <= 0 {
+		args.MaxTxnAttempts = 20
+	}
+
 	pool := &StatePool{
 		pool: make(map[string]*PoolItem),
 		hub:  pubsub.NewSimpleHub(nil),
@@ -145,6 +149,7 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 		args.NewPolicy,
 		args.Clock,
 		args.RunTransactionObserver,
+		args.MaxTxnAttempts,
 	)
 	if err != nil {
 		session.Close()
@@ -271,6 +276,7 @@ func (p *StatePool) openState(modelUUID string) (*State, error) {
 		modelTag, p.systemState.controllerModelTag,
 		session, p.systemState.newPolicy, p.systemState.stateClock,
 		p.systemState.runTransactionObserver,
+		p.systemState.maxTxnAttempts,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/raftlease/target_test.go
+++ b/state/raftlease/target_test.go
@@ -536,7 +536,10 @@ func NewMongo(database *mgo.Database) *Mongo {
 	return &Mongo{
 		database: database,
 		runner: jujutxn.NewRunner(jujutxn.RunnerParams{
-			Database: database,
+			Database:                  database,
+			TransactionCollectionName: "txns",
+			ChangeLogName:             "sstxns.log",
+			ServerSideTransactions:    true,
 		}),
 	}
 }

--- a/state/state.go
+++ b/state/state.go
@@ -73,6 +73,7 @@ type State struct {
 	policy                 Policy
 	newPolicy              NewPolicyFunc
 	runTransactionObserver RunTransactionObserverFunc
+	maxTxnAttempts         int
 
 	// workers is responsible for keeping the various sub-workers
 	// available by starting new ones as they fail. It doesn't do
@@ -94,6 +95,7 @@ func (st *State) newStateNoWorkers(modelUUID string) (*State, error) {
 		st.newPolicy,
 		st.stateClock,
 		st.runTransactionObserver,
+		st.maxTxnAttempts,
 	)
 	// We explicitly don't start the workers.
 	if err != nil {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -22,7 +22,7 @@ import (
 	mgotxn "github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/txn/v3"
+	jujutxn "github.com/juju/txn/v3"
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/arch"
 	"github.com/juju/version/v2"
@@ -4272,7 +4272,7 @@ func (s *StateSuite) TestSetModelAgentVersionExcessiveContention(c *gc.C) {
 	}
 	defer state.SetBeforeHooks(c, s.State, changeFuncs...).Check()
 	err := s.State.SetModelAgentVersion(version.MustParse("4.5.6"), nil, false)
-	c.Assert(errors.Cause(err), gc.Equals, txn.ErrExcessiveContention)
+	c.Assert(errors.Cause(err), gc.Equals, jujutxn.ErrExcessiveContention)
 	// Make sure the version remained the same.
 	assertAgentVersion(c, s.State, currentVersion, "released")
 }

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1104,8 +1104,7 @@ func (s *UnitSuite) TestRemoveUnitMachineThrashed(c *gc.C) {
 			s.setControllerVote(c, host.Id(), true)
 		},
 	}
-	// You'll need to adjust the flip-flops to match the number of transaction
-	// retries.
+	state.SetMaxTxnAttempts(c, s.State, 3)
 	defer state.SetTestHooks(c, s.State, flip, flop, flip).Check()
 
 	c.Assert(target.Destroy(), gc.ErrorMatches, `cannot destroy unit "wordpress/1": state changing too quickly; try again soon`)

--- a/state/watcher/logger.go
+++ b/state/watcher/logger.go
@@ -11,6 +11,7 @@ type Logger interface {
 	Infof(format string, values ...interface{})
 	Debugf(format string, values ...interface{})
 	Tracef(format string, values ...interface{})
+	Errorf(format string, values ...interface{})
 	IsTraceEnabled() bool
 }
 
@@ -21,4 +22,5 @@ func (noOpLogger) Warningf(format string, values ...interface{})  {}
 func (noOpLogger) Infof(format string, values ...interface{})     {}
 func (noOpLogger) Debugf(format string, values ...interface{})    {}
 func (noOpLogger) Tracef(format string, values ...interface{})    {}
+func (noOpLogger) Errorf(format string, values ...interface{})    {}
 func (noOpLogger) IsTraceEnabled() bool                           { return false }

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
+	"github.com/juju/mgo/v3/sstxn"
 	"github.com/juju/worker/v3"
 	"gopkg.in/retry.v1"
 	"gopkg.in/tomb.v2"
@@ -88,7 +89,7 @@ func (e outOfSyncError) Error() string {
 		e.lastSeenId)
 }
 
-// A TxnWatcher watches the txns.log collection and publishes all change events
+// A TxnWatcher watches the sstxns.log collection and publishes all change events
 // to the hub.
 type TxnWatcher struct {
 	hub    Hub
@@ -137,7 +138,7 @@ type TxnWatcherConfig struct {
 	Session *mgo.Session
 	// JujuDBName is the Juju database name, usually "juju".
 	JujuDBName string
-	// CollectionName is txn logs collection name, usually "txns.log".
+	// CollectionName is txn logs collection name, usually "sstxns.log".
 	CollectionName string
 	// Hub is where the changes are published to.
 	Hub Hub
@@ -380,18 +381,24 @@ func (w *TxnWatcher) flush() {
 	// doesn't grow to the size of the largest-ever change and never shrink
 }
 
-// initLastId reads the most recent changelog document and initializes
-// lastId with it. This causes all history that precedes the creation
-// of the watcher to be ignored.
+// initLastId writes an empty transaction to the change log and sets
+// lastId to that txnId. This causes all history that precedes the creation
+// of the watcher to be ignored. By writing an empty transaction to the
+// change log collection (usually sstxns.log), it ensures the collection
+// exists.
 func (w *TxnWatcher) initLastId(log *mgo.Collection) error {
-	var entry struct {
-		Id interface{} `bson:"_id"`
+	txnId := bson.NewObjectId()
+
+	// Create an empty txn to ensure the txn log collection exists and
+	// mark our log checkpoint.
+	sstxnRunner := sstxn.NewRunner(log.Database, w.logger)
+	sstxnRunner.ChangeLog(log)
+	err := sstxnRunner.Run(nil, txnId, nil)
+	if err != nil {
+		return errors.Annotatef(err, "failed to create checkpoint txn %s", txnId.String())
 	}
-	err := log.Find(nil).Sort("-$natural").One(&entry)
-	if err != nil && err != mgo.ErrNotFound {
-		return errors.Trace(err)
-	}
-	w.lastId = entry.Id
+
+	w.lastId = txnId
 	return nil
 }
 

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -13,7 +13,7 @@ import (
 	mgotesting "github.com/juju/mgo/v3/testing"
 	"github.com/juju/mgo/v3/txn"
 	jc "github.com/juju/testing/checkers"
-	jujutxn "github.com/juju/txn/v2"
+	jujutxn "github.com/juju/txn/v3"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
@@ -86,6 +86,7 @@ func (s *TxnWatcherSuite) newRunner(c *gc.C) {
 		TransactionCollectionName: "txn",
 		ChangeLogName:             s.log.Name,
 		ServerSideTransactions:    true,
+		MaxRetryAttempts:          3,
 	})
 }
 

--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -13,6 +13,7 @@ import (
 	mgotesting "github.com/juju/mgo/v3/testing"
 	"github.com/juju/mgo/v3/txn"
 	jc "github.com/juju/testing/checkers"
+	jujutxn "github.com/juju/txn/v2"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
@@ -27,7 +28,7 @@ type TxnWatcherSuite struct {
 
 	log          *mgo.Collection
 	stash        *mgo.Collection
-	runner       *txn.Runner
+	runner       jujutxn.Runner
 	w            *watcher.TxnWatcher
 	ch           chan watcher.Change
 	iteratorFunc func(collection *mgo.Collection) mongo.Iterator
@@ -51,14 +52,9 @@ func (s *TxnWatcherSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
 	db := s.MgoSuite.Session.DB("juju")
-	s.log = db.C("txnlog")
-	s.log.Create(&mgo.CollectionInfo{
-		Capped:   true,
-		MaxBytes: 1000000,
-	})
+	s.log = db.C("testingsstxns.log")
+	s.log.Create(&mgo.CollectionInfo{})
 	s.stash = db.C("txn.stash")
-	s.runner = txn.NewRunner(db.C("txn"))
-	s.runner.ChangeLog(s.log)
 	s.clock = testclock.NewClock(time.Now())
 	s.iteratorFunc = nil
 }
@@ -79,12 +75,28 @@ func (s *TxnWatcherSuite) newWatcher(c *gc.C, expect int) (*watcher.TxnWatcher, 
 	return s.newWatcherWithError(c, expect, nil)
 }
 
+func (s *TxnWatcherSuite) newRunner(c *gc.C) {
+	runnerSession := s.MgoSuite.Session.New()
+	s.AddCleanup(func(c *gc.C) {
+		s.runner = nil
+		runnerSession.Close()
+	})
+	s.runner = jujutxn.NewRunner(jujutxn.RunnerParams{
+		Database:                  runnerSession.DB("juju"),
+		TransactionCollectionName: "txn",
+		ChangeLogName:             s.log.Name,
+		ServerSideTransactions:    true,
+	})
+}
+
 func (s *TxnWatcherSuite) newWatcherWithError(c *gc.C, expect int, watcherError error) (*watcher.TxnWatcher, *fakeHub) {
 	hub := newFakeHub(c, expect)
 	logger := loggo.GetLogger("test")
 	logger.SetLogLevel(loggo.TRACE)
+
+	session := s.MgoSuite.Session.New()
 	w, err := watcher.NewTxnWatcher(watcher.TxnWatcherConfig{
-		Session:        s.MgoSuite.Session,
+		Session:        session,
 		JujuDBName:     "juju",
 		CollectionName: s.log.Name,
 		Hub:            hub,
@@ -95,11 +107,15 @@ func (s *TxnWatcherSuite) newWatcherWithError(c *gc.C, expect int, watcherError 
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
 		if watcherError == nil {
-			c.Assert(w.Stop(), jc.ErrorIsNil)
+			c.Check(w.Stop(), jc.ErrorIsNil)
 		} else {
-			c.Assert(w.Stop(), gc.Equals, watcherError)
+			c.Check(w.Stop(), gc.Equals, watcherError)
 		}
+		session.Close()
 	})
+
+	// Synchronize, otherwise the tests will race.
+	w.Report()
 	return w, hub
 }
 
@@ -114,7 +130,9 @@ func (s *TxnWatcherSuite) revno(c *gc.C, coll string, id interface{}) (revno int
 
 func (s *TxnWatcherSuite) insert(c *gc.C, coll string, id interface{}) (revno int64) {
 	ops := []txn.Op{{C: coll, Id: id, Insert: M{"n": 1}}}
-	err := s.runner.Run(ops, "", nil)
+	err := s.runner.Run(func(attempt int) ([]txn.Op, error) {
+		return ops, nil
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	revno = s.revno(c, coll, id)
 	c.Logf("insert(%#v, %#v) => revno %d", coll, id, revno)
@@ -126,7 +144,9 @@ func (s *TxnWatcherSuite) insertAll(c *gc.C, coll string, ids ...interface{}) (r
 	for _, id := range ids {
 		ops = append(ops, txn.Op{C: coll, Id: id, Insert: M{"n": 1}})
 	}
-	err := s.runner.Run(ops, "", nil)
+	err := s.runner.Run(func(attempt int) ([]txn.Op, error) {
+		return ops, nil
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	for _, id := range ids {
 		revnos = append(revnos, s.revno(c, coll, id))
@@ -137,7 +157,9 @@ func (s *TxnWatcherSuite) insertAll(c *gc.C, coll string, ids ...interface{}) (r
 
 func (s *TxnWatcherSuite) update(c *gc.C, coll string, id interface{}) (revno int64) {
 	ops := []txn.Op{{C: coll, Id: id, Update: M{"$inc": M{"n": 1}}}}
-	err := s.runner.Run(ops, "", nil)
+	err := s.runner.Run(func(attempt int) ([]txn.Op, error) {
+		return ops, nil
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	revno = s.revno(c, coll, id)
 	c.Logf("update(%#v, %#v) => revno %d", coll, id, revno)
@@ -146,7 +168,9 @@ func (s *TxnWatcherSuite) update(c *gc.C, coll string, id interface{}) (revno in
 
 func (s *TxnWatcherSuite) remove(c *gc.C, coll string, id interface{}) (revno int64) {
 	ops := []txn.Op{{C: coll, Id: id, Remove: true}}
-	err := s.runner.Run(ops, "", nil)
+	err := s.runner.Run(func(attempt int) ([]txn.Op, error) {
+		return ops, nil
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("remove(%#v, %#v) => revno -1", coll, id)
 	return -1
@@ -170,6 +194,7 @@ func (s *TxnWatcherSuite) TestErrAndDead(c *gc.C) {
 }
 
 func (s *TxnWatcherSuite) TestInsert(c *gc.C) {
+	s.newRunner(c)
 	_, hub := s.newWatcher(c, 1)
 
 	revno := s.insert(c, "test", "a")
@@ -183,6 +208,7 @@ func (s *TxnWatcherSuite) TestInsert(c *gc.C) {
 }
 
 func (s *TxnWatcherSuite) TestUpdate(c *gc.C) {
+	s.newRunner(c)
 	s.insert(c, "test", "a")
 
 	_, hub := s.newWatcher(c, 1)
@@ -197,6 +223,7 @@ func (s *TxnWatcherSuite) TestUpdate(c *gc.C) {
 }
 
 func (s *TxnWatcherSuite) TestRemove(c *gc.C) {
+	s.newRunner(c)
 	s.insert(c, "test", "a")
 
 	_, hub := s.newWatcher(c, 1)
@@ -211,6 +238,28 @@ func (s *TxnWatcherSuite) TestRemove(c *gc.C) {
 }
 
 func (s *TxnWatcherSuite) TestWatchOrder(c *gc.C) {
+	s.newRunner(c)
+	_, hub := s.newWatcher(c, 3)
+
+	revno1 := s.insert(c, "test", "a")
+	revno2 := s.insert(c, "test", "b")
+	revno3 := s.insert(c, "test", "c")
+
+	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
+	hub.waitForExpected(c)
+
+	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
+		{"test", "a", revno1},
+		{"test", "b", revno2},
+		{"test", "c", revno3},
+	})
+}
+
+func (s *TxnWatcherSuite) TestMissingOplogCollection(c *gc.C) {
+	db := s.MgoSuite.Session.DB("juju")
+	s.log = db.C("missingsstxns.log")
+
+	s.newRunner(c)
 	_, hub := s.newWatcher(c, 3)
 
 	revno1 := s.insert(c, "test", "a")
@@ -228,6 +277,7 @@ func (s *TxnWatcherSuite) TestWatchOrder(c *gc.C) {
 }
 
 func (s *TxnWatcherSuite) TestTransactionWithMultiple(c *gc.C) {
+	s.newRunner(c)
 	_, hub := s.newWatcher(c, 3)
 
 	revnos := s.insertAll(c, "test", "a", "b", "c")
@@ -246,6 +296,7 @@ func (s *TxnWatcherSuite) TestScale(c *gc.C) {
 	const N = 500
 	const T = 10
 
+	s.newRunner(c)
 	_, hub := s.newWatcher(c, N)
 
 	c.Logf("Creating %d documents, %d per transaction...", N, T)
@@ -255,7 +306,9 @@ func (s *TxnWatcherSuite) TestScale(c *gc.C) {
 		for j := 0; j < T && i*T+j < N; j++ {
 			ops = append(ops, txn.Op{C: "test", Id: i*T + j, Insert: M{"n": 1}})
 		}
-		err := s.runner.Run(ops, "", nil)
+		err := s.runner.Run(func(attempt int) ([]txn.Op, error) {
+			return ops, nil
+		})
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -273,6 +326,7 @@ func (s *TxnWatcherSuite) TestScale(c *gc.C) {
 }
 
 func (s *TxnWatcherSuite) TestInsertThenRemove(c *gc.C) {
+	s.newRunner(c)
 	_, hub := s.newWatcher(c, 2)
 
 	revno1 := s.insert(c, "test", "a")
@@ -289,6 +343,7 @@ func (s *TxnWatcherSuite) TestInsertThenRemove(c *gc.C) {
 }
 
 func (s *TxnWatcherSuite) TestDoubleUpdate(c *gc.C) {
+	s.newRunner(c)
 	_, hub := s.newWatcher(c, 2)
 
 	revno1 := s.insert(c, "test", "a")
@@ -316,6 +371,7 @@ func (s *TxnWatcherSuite) TestErrorRetry(c *gc.C) {
 		fakeIter.iter = s.log.Find(nil).Batch(10).Sort("-$natural").Iter()
 		return fakeIter
 	}
+	s.newRunner(c)
 	_, hub := s.newWatcher(c, 1)
 	revno := s.insert(c, "test", "a")
 
@@ -340,6 +396,7 @@ func (s *TxnWatcherSuite) TestOutOfSyncError(c *gc.C) {
 		fakeIter.iter = s.log.Find(nil).Batch(10).Sort("-$natural").Iter()
 		return fakeIter
 	}
+	s.newRunner(c)
 	_, hub := s.newWatcherWithError(c, 1, watcher.OutOfSyncError)
 	s.insert(c, "test", "a")
 

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -27,8 +27,7 @@ func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (boo
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
-	// TODO: enable here once we fix the capped txn collection issue in juju3.
-	// 3: version.MustParse("2.9.33"),
+	3: version.MustParse("2.9.33"),
 }
 
 // UpgradeToAllowed returns true if a major version upgrade is allowed

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -46,24 +46,15 @@ func (s *versionSuite) TestUpgradeToAllowed(c *gc.C) {
 			to:      "3.0.0",
 			allowed: true,
 			minVers: "2.9.33",
-			patch:   true,
+			patch:   false,
 		}, {
-			from:    "2.9.34",
-			to:      "3.0.0",
-			allowed: false,
-			minVers: "0.0.0",
-			patch:   false, // We disallow upgrading to 3 for now.
-			err:     `cannot upgrade, "3.0.0" is not a supported version`,
-		},
-		{
 			from:    "2.9.0",
 			to:      "4.0.0",
 			allowed: false,
 			minVers: "0.0.0",
 			patch:   true,
 			err:     `cannot upgrade, "4.0.0" is not a supported version`,
-		},
-		{
+		}, {
 			from:    "3.0.0",
 			to:      "2.0.0",
 			allowed: false,


### PR DESCRIPTION
This changes the txns.log collection to sstxns.log, automatically transitioning at startup of juju 3.0.
In doing so I found some issues with sstxn retry and error handling that will come as updates to juju/txn and juju/mgo modules.

Depends on #14363

## QA steps

- Deploy juju 2.9 with upgrade allowed to 3.0.0
- `juju upgrade-controller --build-agent`
- Controller + controller model should upgrade to 3.0.0

## Documentation changes

N/A

## Bug reference

N/A