### PR TITLE
[JUJU-1441]Status_panic_when_status_color_is_unknown

### DIFF
--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -139,7 +139,10 @@ func (w *Wrapper) PrintStatus(status status.Status) {
 
 // StatusColor returns the status's standard color
 func StatusColor(status status.Status) *ansiterm.Context {
-	return statusColors[status]
+	if val, ok := statusColors[status]; ok {
+		return val
+	}
+	return CurrentHighlight
 }
 
 // CurrentHighlight is the color used to show the current

--- a/cmd/output/output_test.go
+++ b/cmd/output/output_test.go
@@ -1,0 +1,28 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package output_test
+
+import (
+	"github.com/juju/ansiterm"
+	"github.com/juju/juju/cmd/output"
+	"github.com/juju/juju/core/status"
+	gc "gopkg.in/check.v1"
+)
+
+type OutputSuite struct{}
+
+var _ = gc.Suite(&OutputSuite{})
+
+func (s *OutputSuite) TestStatusColor(c *gc.C) {
+	var ctx *ansiterm.Context
+
+	unknown := status.Status("notKnown")
+	allocating := status.Allocating
+
+	ctx = output.StatusColor(unknown)
+	c.Assert(ctx, gc.Equals, output.CurrentHighlight)
+
+	ctx = output.StatusColor(allocating)
+	c.Assert(ctx, gc.Equals, output.WarningHighlight)
+}

--- a/cmd/output/package_test.go
+++ b/cmd/output/package_test.go
@@ -1,0 +1,15 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package output_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+// None of the tests in this package require mongo.
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This PR fixes a bug introduced by [PR](https://github.com/juju/juju/pull/14293). for `juju status --format=summary`

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps
In a separate terminal run

```sh
watch --color juju status --format=summary --color
```
In another run
```sh
juju deploy postgresql
```