### PR TITLE
[JUJU-1442] Fix debug-hooks unit/leader on k8s

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -126,6 +126,20 @@ type DeployArgs struct {
 	Force bool
 }
 
+// Leader returns the unit name for the leader of the provided application.
+func (c *Client) Leader(app string) (string, error) {
+	var result params.StringResult
+	p := params.Entity{Tag: names.NewApplicationTag(app).String()}
+
+	if err := c.facade.FacadeCall("Leader", p, &result); err != nil {
+		return "", errors.Trace(err)
+	}
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return result.Result, nil
+}
+
 // Deploy obtains the charm, either locally or from the charm store, and deploys
 // it. Placement directives, if provided, specify the machine on which the charm
 // is deployed.

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -1992,3 +1992,19 @@ func (s *applicationSuite) TestUnexposeVersionChecks(c *gc.C) {
 		}
 	}
 }
+
+func (s *applicationSuite) TestLeader(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Application")
+		c.Check(request, gc.Equals, "Leader")
+		c.Assert(arg, gc.Equals, params.Entity{Tag: names.NewApplicationTag("ubuntu").String()})
+		c.Assert(result, gc.FitsTypeOf, &params.StringResult{})
+		*(result.(*params.StringResult)) = params.StringResult{Result: "ubuntu/42"}
+		return nil
+	})
+
+	facade := application.NewClient(apiCaller)
+	obtainedUnit, err := facade.Leader("ubuntu")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtainedUnit, gc.Equals, "ubuntu/42")
+}

--- a/api/client/sshclient/facade.go
+++ b/api/client/sshclient/facade.go
@@ -101,6 +101,7 @@ func (facade *Facade) PublicKeys(target string) ([]string, error) {
 }
 
 // Leader returns the unit name for the leader of the provided application.
+// TODO(juju3) - remove
 func (facade *Facade) Leader(app string) (string, error) {
 	var result params.StringResult
 	p := params.Entity{Tag: names.NewApplicationTag(app).String()}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -18,7 +18,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              3,
 	"AllWatcher":                   2,
 	"Annotations":                  2,
-	"Application":                  13,
+	"Application":                  14,
 	"ApplicationOffers":            4,
 	"ApplicationScaler":            1,
 	"Backups":                      3,

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -53,7 +53,7 @@ type applicationSuite struct {
 	jujutesting.JujuConnSuite
 	commontesting.BlockHelper
 
-	applicationAPI *application.APIv13
+	applicationAPI *application.APIv14
 	application    *state.Application
 	authorizer     *apiservertesting.FakeAuthorizer
 	repo           *mockRepo
@@ -117,7 +117,7 @@ func (s *applicationSuite) UploadCharmMultiSeries(c *gc.C, url, name string) (*c
 	return s.UploadCharm(c, url, name)
 }
 
-func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv13 {
+func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv14 {
 	resources := common.NewResources()
 	c.Assert(resources.RegisterNamed("dataDir", common.StringResource(c.MkDir())), jc.ErrorIsNil)
 	storageAccess, err := application.GetStorageState(s.State)
@@ -143,7 +143,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv13 {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	return &application.APIv13{api}
+	return &application.APIv14{api}
 }
 
 func (s *applicationSuite) TestCharmConfig(c *gc.C) {
@@ -169,7 +169,9 @@ func (s *applicationSuite) TestCharmConfigV8(c *gc.C) {
 			APIv10: &application.APIv10{
 				APIv11: &application.APIv11{
 					APIv12: &application.APIv12{
-						s.applicationAPI,
+						APIv13: &application.APIv13{
+							s.applicationAPI,
+						},
 					},
 				},
 			},
@@ -1747,7 +1749,7 @@ func (s *applicationSuite) checkClientApplicationUpdateSetCharm(c *gc.C, forceCh
 		MinUnits:        &minUnits,
 		ForceCharmURL:   forceCharmURL,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err = api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1790,7 +1792,7 @@ func (s *applicationSuite) TestBlockChangeApplicationUpdate(c *gc.C) {
 		CharmURL:        curl,
 		ForceCharmURL:   false,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	s.AssertBlocked(c, err, "TestBlockChangeApplicationUpdate")
 }
@@ -1804,7 +1806,7 @@ func (s *applicationSuite) TestApplicationUpdateSetMinUnits(c *gc.C) {
 		ApplicationName: "dummy",
 		MinUnits:        &minUnits,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1822,7 +1824,7 @@ func (s *applicationSuite) TestApplicationUpdateSetMinUnitsWithLXDProfile(c *gc.
 		ApplicationName: "lxd-profile",
 		MinUnits:        &minUnits,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1850,7 +1852,7 @@ func (s *applicationSuite) TestApplicationUpdateSetMinUnitsError(c *gc.C) {
 		ApplicationName: "dummy",
 		MinUnits:        &minUnits,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, gc.ErrorMatches,
 		`cannot set minimum units for application "dummy": cannot set a negative minimum number of units`)
@@ -1878,7 +1880,7 @@ func (s *applicationSuite) testApplicationUpdateSetSettingsStrings(c *gc.C, bran
 		SettingsStrings: map[string]string{"title": "s-title", "username": "s-user"},
 		Generation:      branchName,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1902,7 +1904,7 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsStringsBranch(c *gc.C
 		SettingsStrings: map[string]string{"title": "s-title", "username": "s-user"},
 		Generation:      newBranch,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1936,7 +1938,7 @@ func (s *applicationSuite) testApplicationUpdateSetSettingsYAML(c *gc.C, branchN
 		SettingsYAML:    "dummy:\n  title: y-title\n  username: y-user",
 		Generation:      branchName,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1960,7 +1962,7 @@ func (s *applicationSuite) TestApplicationUpdateSetSettingsYAMLBranch(c *gc.C) {
 		SettingsYAML:    "dummy:\n  title: y-title\n  username: y-user",
 		Generation:      newBranch,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1986,7 +1988,7 @@ func (s *applicationSuite) TestClientApplicationUpdateSetSettingsGetYAML(c *gc.C
 		SettingsYAML:    "charm: dummy\napplication: dummy\nsettings:\n  title:\n    value: y-title\n    type: string\n  username:\n    value: y-user\n  ignore:\n    blah: true",
 		Generation:      model.GenerationMaster,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2013,7 +2015,7 @@ func (s *applicationSuite) TestApplicationUpdateCombinedStringAndYAMLSettings(c 
 		SettingsYAML: "dummy:\n  title: s-title",
 		Generation:   newBranch,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2039,7 +2041,7 @@ func (s *applicationSuite) TestApplicationUpdateSetConstraints(c *gc.C) {
 		ApplicationName: "dummy",
 		Constraints:     &cons,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err = api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -2077,7 +2079,7 @@ func (s *applicationSuite) TestApplicationUpdateAllParams(c *gc.C) {
 		Constraints:     &cons,
 		Generation:      model.GenerationMaster,
 	}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err = api.Update(args)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 
@@ -2100,20 +2102,20 @@ func (s *applicationSuite) TestApplicationUpdateNoParams(c *gc.C) {
 
 	// Calling Update with no parameters set is a no-op.
 	args := params.ApplicationUpdate{ApplicationName: "wordpress"}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *applicationSuite) TestApplicationUpdateNoApplication(c *gc.C) {
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(params.ApplicationUpdate{})
 	c.Assert(err, gc.ErrorMatches, `"" is not a valid application name`)
 }
 
 func (s *applicationSuite) TestApplicationUpdateInvalidApplication(c *gc.C) {
 	args := params.ApplicationUpdate{ApplicationName: "no-such-application"}
-	api := &application.APIv12{s.applicationAPI}
+	api := &application.APIv12{&application.APIv13{s.applicationAPI}}
 	err := api.Update(args)
 	c.Assert(err, gc.ErrorMatches, `application "no-such-application" not found`)
 }

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -24,7 +24,7 @@ func GetModel(m *state.Model) Model {
 	return modelShim{m}
 }
 
-func SetModelType(api *APIv13, modelType state.ModelType) {
+func SetModelType(api *APIv14, modelType state.ModelType) {
 	api.modelType = modelType
 }
 

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -31,7 +31,7 @@ import (
 type getSuite struct {
 	jujutesting.JujuConnSuite
 
-	applicationAPI *application.APIv13
+	applicationAPI *application.APIv14
 	authorizer     apiservertesting.FakeAuthorizer
 }
 
@@ -64,7 +64,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.applicationAPI = &application.APIv13{api}
+	s.applicationAPI = &application.APIv14{api}
 }
 
 func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
@@ -77,8 +77,10 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV4(c *gc.C) {
 						&application.APIv9{
 							&application.APIv10{
 								&application.APIv11{
-									&application.APIv12{
-										s.applicationAPI,
+									APIv12: &application.APIv12{
+										APIv13: &application.APIv13{
+											s.applicationAPI,
+										},
 									},
 								},
 							},
@@ -115,8 +117,10 @@ func (s *getSuite) TestClientApplicationGetSmokeTestV5(c *gc.C) {
 					&application.APIv9{
 						&application.APIv10{
 							&application.APIv11{
-								&application.APIv12{
-									s.applicationAPI,
+								APIv12: &application.APIv12{
+									APIv13: &application.APIv13{
+										s.applicationAPI,
+									},
 								},
 							},
 						},
@@ -261,9 +265,11 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 		&application.APIv9{
 			&application.APIv10{
 				&application.APIv11{
-					&application.APIv12{
-						&application.APIv13{
-							api,
+					APIv12: &application.APIv12{
+						APIv13: &application.APIv13{
+							APIv14: &application.APIv14{
+								api,
+							},
 						},
 					},
 				},

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 
@@ -53,7 +54,10 @@ func Register(registry facade.FacadeRegistry) {
 	}, reflect.TypeOf((*APIv12)(nil))) // Adds UnitsInfo()
 	registry.MustRegister("Application", 13, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV13(ctx)
-	}, reflect.TypeOf((*APIv13)(nil))) // Adds CharmOrigin to Deploy
+	}, reflect.TypeOf((*APIv13)(nil))) // Adds Leader
+	registry.MustRegister("Application", 14, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV14(ctx)
+	}, reflect.TypeOf((*APIv14)(nil)))
 }
 
 // newFacadeV4 provides the signature required for facade registration
@@ -139,9 +143,17 @@ func newFacadeV12(ctx facade.Context) (*APIv12, error) {
 }
 
 func newFacadeV13(ctx facade.Context) (*APIv13, error) {
-	api, err := newFacadeBase(ctx)
+	api, err := newFacadeV14(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return &APIv13{api}, nil
+}
+
+func newFacadeV14(ctx facade.Context) (*APIv14, error) {
+	api, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv14{api}, nil
 }

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -207,6 +207,7 @@ func (facade *Facade) Proxy() (params.SSHProxyResult, error) {
 func (a *FacadeV2) Leader(_ struct{}) {}
 
 // Leader returns the unit name of the leader for the given application.
+// TODO(juju3) - remove
 func (facade *Facade) Leader(entity params.Entity) (params.StringResult, error) {
 	result := params.StringResult{}
 	application, err := names.ParseApplicationTag(entity.Tag)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2010,8 +2010,8 @@
     },
     {
         "Name": "Application",
-        "Description": "APIv13 provides the Application API facade for version 13.\nIt adds CharmOrigin. The ApplicationsInfo call populates the exposed\nendpoints field in its response entries.",
-        "Version": 13,
+        "Description": "APIv14 provides the Application API facade for version 14.\nIt adds Leader.",
+        "Version": 14,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -2236,6 +2236,18 @@
                         }
                     },
                     "description": "GetConstraints returns the constraints for a given application."
+                },
+                "Leader": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    },
+                    "description": "Leader returns the unit name of the leader for the given application."
                 },
                 "MergeBindings": {
                     "type": "object",
@@ -40446,7 +40458,7 @@
                             "$ref": "#/definitions/StringResult"
                         }
                     },
-                    "description": "Leader returns the unit name of the leader for the given application."
+                    "description": "Leader returns the unit name of the leader for the given application.\nTODO(juju3) - remove"
                 },
                 "PrivateAddress": {
                     "type": "object",

--- a/cmd/juju/commands/mocks/leaderapi_mock.go
+++ b/cmd/juju/commands/mocks/leaderapi_mock.go
@@ -47,6 +47,20 @@ func (mr *MockLeaderAPIMockRecorder) BestAPIVersion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestAPIVersion", reflect.TypeOf((*MockLeaderAPI)(nil).BestAPIVersion))
 }
 
+// Close mocks base method.
+func (m *MockLeaderAPI) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockLeaderAPIMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockLeaderAPI)(nil).Close))
+}
+
 // Leader mocks base method.
 func (m *MockLeaderAPI) Leader(arg0 string) (string, error) {
 	m.ctrl.T.Helper()

--- a/cmd/juju/commands/mocks/ssh_container_mock.go
+++ b/cmd/juju/commands/mocks/ssh_container_mock.go
@@ -119,6 +119,20 @@ func (m *MockApplicationAPI) EXPECT() *MockApplicationAPIMockRecorder {
 	return m.recorder
 }
 
+// BestAPIVersion mocks base method.
+func (m *MockApplicationAPI) BestAPIVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BestAPIVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// BestAPIVersion indicates an expected call of BestAPIVersion.
+func (mr *MockApplicationAPIMockRecorder) BestAPIVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestAPIVersion", reflect.TypeOf((*MockApplicationAPI)(nil).BestAPIVersion))
+}
+
 // Close mocks base method.
 func (m *MockApplicationAPI) Close() error {
 	m.ctrl.T.Helper()
@@ -131,6 +145,21 @@ func (m *MockApplicationAPI) Close() error {
 func (mr *MockApplicationAPIMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockApplicationAPI)(nil).Close))
+}
+
+// Leader mocks base method.
+func (m *MockApplicationAPI) Leader(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Leader", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Leader indicates an expected call of Leader.
+func (mr *MockApplicationAPIMockRecorder) Leader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Leader", reflect.TypeOf((*MockApplicationAPI)(nil).Leader), arg0)
 }
 
 // UnitsInfo mocks base method.

--- a/cmd/juju/commands/scp.go
+++ b/cmd/juju/commands/scp.go
@@ -158,7 +158,7 @@ func (c *scpCommand) Init(args []string) (err error) {
 	} else {
 		c.provider = &c.sshMachine
 	}
-
+	c.provider.setModelType(c.modelType)
 	c.provider.setArgs(args)
 	c.provider.setHostChecker(c.hostChecker)
 	c.provider.setRetryStrategy(c.retryStrategy)


### PR DESCRIPTION
juju debug-hooks was failing on a k8s charm when used with unit/leader. This is because the Leader() API was added to the SSHClient facade which is not used on k8s models. The Leader() should heave been added to the application facade. So this PR moves it there instead and bumps the facade version. It is retained on SSHClient facade for older clients. 

Also, the method to resolve the unit leader, which calls the Leader() api, was being called multiple times when running the various ssh related commands. So add logic to cache the first result and use that after.

There's also backwards compatibility code which needs to cater for the various server versions.

## QA steps

On a 2.9.32 and 2.9.33 controller (k8s and machine)
juju debug-hooks unit/leader
juju debug-code unit/leader
juju ssh unit/leader

## Bug reference

https://bugs.launchpad.net/juju/+bug/1981430
