### PR TITLE
[JUJU-1402] Search through existing relations when removing

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2218,16 +2218,9 @@ func (api *APIBase) DestroyRelation(args params.DestroyRelation) (err error) {
 	if err := api.check.RemoveAllowed(); err != nil {
 		return errors.Trace(err)
 	}
-	var (
-		rel Relation
-		eps []state.Endpoint
-	)
+	var rel Relation
 	if len(args.Endpoints) > 0 {
-		eps, err = api.backend.InferEndpoints(args.Endpoints...)
-		if err != nil {
-			return err
-		}
-		rel, err = api.backend.EndpointsRelation(eps...)
+		rel, err = api.backend.InferActiveRelation(args.Endpoints...)
 	} else {
 		rel, err = api.backend.Relation(args.RelationId)
 	}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -675,19 +675,19 @@ func (s *ApplicationSuite) TestDestroyRelation(c *gc.C) {
 	err := s.api.DestroyRelation(params.DestroyRelation{Endpoints: []string{"a", "b"}})
 	c.Assert(err, jc.ErrorIsNil)
 	s.blockChecker.CheckCallNames(c, "RemoveAllowed")
-	s.backend.CheckCallNames(c, "InferEndpoints", "EndpointsRelation")
-	s.backend.CheckCall(c, 0, "InferEndpoints", []string{"a", "b"})
+	s.backend.CheckCallNames(c, "InferActiveRelation")
+	s.backend.CheckCall(c, 0, "InferActiveRelation", []string{"a", "b"})
 	s.relation.CheckCallNames(c, "DestroyWithForce")
 }
 
 func (s *ApplicationSuite) TestDestroyRelationNoRelationsFound(c *gc.C) {
-	s.backend.SetErrors(nil, errors.New("no relations found"))
+	s.backend.SetErrors(errors.New("no relations found"))
 	err := s.api.DestroyRelation(params.DestroyRelation{Endpoints: []string{"a", "b"}})
 	c.Assert(err, gc.ErrorMatches, "no relations found")
 }
 
 func (s *ApplicationSuite) TestDestroyRelationRelationNotFound(c *gc.C) {
-	s.backend.SetErrors(nil, errors.NotFoundf(`relation "a:b c:d"`))
+	s.backend.SetErrors(errors.NotFoundf(`relation "a:b c:d"`))
 	err := s.api.DestroyRelation(params.DestroyRelation{Endpoints: []string{"a:b", "c:d"}})
 	c.Assert(err, gc.ErrorMatches, `relation "a:b c:d" not found`)
 }

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -40,9 +40,9 @@ type Backend interface {
 	AddRemoteApplication(state.AddRemoteApplicationParams) (RemoteApplication, error)
 	AddRelation(...state.Endpoint) (Relation, error)
 	Charm(*charm.URL) (Charm, error)
-	EndpointsRelation(...state.Endpoint) (Relation, error)
 	Relation(int) (Relation, error)
 	InferEndpoints(...string) ([]state.Endpoint, error)
+	InferActiveRelation(...string) (Relation, error)
 	Machine(string) (Machine, error)
 	Model() (Model, error)
 	Unit(string) (Unit, error)
@@ -357,14 +357,6 @@ func (s stateShim) Charm(curl *charm.URL) (Charm, error) {
 	return stateCharmShim{ch}, nil
 }
 
-func (s stateShim) EndpointsRelation(eps ...state.Endpoint) (Relation, error) {
-	r, err := s.State.EndpointsRelation(eps...)
-	if err != nil {
-		return nil, err
-	}
-	return stateRelationShim{r, s.State}, nil
-}
-
 func (s stateShim) Model() (Model, error) {
 	m, err := s.State.Model()
 	if err != nil {
@@ -375,6 +367,14 @@ func (s stateShim) Model() (Model, error) {
 
 func (s stateShim) Relation(id int) (Relation, error) {
 	r, err := s.State.Relation(id)
+	if err != nil {
+		return nil, err
+	}
+	return stateRelationShim{r, s.State}, nil
+}
+
+func (s stateShim) InferActiveRelation(names ...string) (Relation, error) {
+	r, err := s.State.InferActiveRelation(names...)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/client/application/mock_test.go
+++ b/apiserver/facades/client/application/mock_test.go
@@ -666,8 +666,8 @@ func (m *mockBackend) InferEndpoints(endpoints ...string) ([]state.Endpoint, err
 	return nil, errors.Errorf("no relations found")
 }
 
-func (m *mockBackend) EndpointsRelation(endpoints ...state.Endpoint) (application.Relation, error) {
-	m.MethodCall(m, "EndpointsRelation", endpoints)
+func (m *mockBackend) InferActiveRelation(endpoints ...string) (application.Relation, error) {
+	m.MethodCall(m, "InferActiveRelation", endpoints)
 	if err := m.NextErr(); err != nil {
 		return nil, err
 	}

--- a/featuretests/cmd_juju_relation_test.go
+++ b/featuretests/cmd_juju_relation_test.go
@@ -51,5 +51,5 @@ func (s *CmdRelationSuite) TestRemoveRelationSuccess(c *gc.C) {
 }
 
 func (s *CmdRelationSuite) TestRemoveRelationFail(c *gc.C) {
-	runCommandExpectFailure(c, "remove-relation", `relation "wordpress:db mysql:server" not found`, s.apps...)
+	runCommandExpectFailure(c, "remove-relation", `ERROR relation matching "wordpress mysql" not found (not found)`, s.apps...)
 }

--- a/state/application.go
+++ b/state/application.go
@@ -2734,16 +2734,37 @@ func allUnits(st *State, application string) (units []*Unit, err error) {
 
 // Relations returns a Relation for every relation the application is in.
 func (a *Application) Relations() (relations []*Relation, err error) {
-	return applicationRelations(a.st, a.doc.Name)
+	return matchingRelations(a.st, a.doc.Name)
 }
 
-func applicationRelations(st *State, name string) (relations []*Relation, err error) {
-	defer errors.DeferredAnnotatef(&err, "can't get relations for application %q", name)
+// matchingRelations returns all relations matching the application(s)/endpoint(s) provided
+// There must be 1 or 2 supplied names, of the form <application>[:<relation>]
+func matchingRelations(st *State, names ...string) (relations []*Relation, err error) {
+	defer errors.DeferredAnnotatef(&err, "can't get relations matching %q", strings.Join(names, " "))
 	relationsCollection, closer := st.db().GetCollection(relationsC)
 	defer closer()
 
+	var conditions []bson.D
+	for _, name := range names {
+		appName, relName, err := splitEndpointName(name)
+		if err != nil {
+			return nil, err
+		}
+		if relName == "" {
+			conditions = append(conditions, bson.D{{"endpoints.applicationname", appName}})
+		} else {
+			conditions = append(conditions, bson.D{{"endpoints", bson.D{{"$elemMatch", bson.D{
+				{"applicationname", appName},
+				{"relation.name", relName},
+			}}}}})
+		}
+	}
+
 	docs := []relationDoc{}
-	err = relationsCollection.Find(bson.D{{"endpoints.applicationname", name}}).All(&docs)
+	err = relationsCollection.Find(bson.D{{
+		"$and", conditions,
+	}}).All(&docs)
+
 	if err != nil {
 		return nil, err
 	}

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -780,7 +780,7 @@ func (s *RemoteApplication) Refresh() error {
 
 // Relations returns a Relation for every relation the application is in.
 func (s *RemoteApplication) Relations() (relations []*Relation, err error) {
-	return applicationRelations(s.st, s.doc.Name)
+	return matchingRelations(s.st, s.doc.Name)
 }
 
 // AddRemoteApplicationParams contains the parameters for adding a remote application

--- a/state/state.go
+++ b/state/state.go
@@ -1968,7 +1968,7 @@ func (st *State) InferEndpoints(names ...string) ([]Endpoint, error) {
 	// Collect all possible sane endpoint lists.
 	var candidates [][]Endpoint
 	switch len(names) {
-	// Implcitly assume this is a peer relationship, as they have only one endpoint
+	// Implicitly assume this is a peer relation, as they have only one endpoint
 	case 1:
 		eps, err := st.endpoints(names[0], isPeer)
 		if err != nil {
@@ -1977,7 +1977,7 @@ func (st *State) InferEndpoints(names ...string) ([]Endpoint, error) {
 		for _, ep := range eps {
 			candidates = append(candidates, []Endpoint{ep})
 		}
-	// All other relationships are between two endpoints
+	// All other relations are between two endpoints
 	case 2:
 		eps1, err := st.endpoints(names[0], notPeer)
 		if err != nil {

--- a/state/unit.go
+++ b/state/unit.go
@@ -1048,7 +1048,7 @@ func (op *RemoveUnitOperation) removeOps() (ops []txn.Op, err error) {
 	// EnsureDead does not require that it already be Dying, so this is the
 	// only point at which we can safely backstop lp:1233457 and mitigate
 	// the impact of unit agent bugs that leave relation scopes occupied).
-	relations, err := applicationRelations(op.unit.st, op.unit.doc.Application)
+	relations, err := matchingRelations(op.unit.st, op.unit.doc.Application)
 	if op.FatalError(err) {
 		return nil, err
 	} else {
@@ -1119,7 +1119,7 @@ type relationPredicate func(ru *RelationUnit) (bool, error)
 
 // relations implements RelationsJoined and RelationsInScope.
 func (u *Unit) relations(predicate relationPredicate) ([]*Relation, error) {
-	candidates, err := applicationRelations(u.st, u.doc.Application)
+	candidates, err := matchingRelations(u.st, u.doc.Application)
 	if err != nil {
 		return nil, err
 	}

--- a/testcharms/charm-repo/quantal/mysql-alternative/metadata.yaml
+++ b/testcharms/charm-repo/quantal/mysql-alternative/metadata.yaml
@@ -7,3 +7,5 @@ provides:
   dev:
     interface: mysql
     limit: 2
+  test:
+    interface: mysql


### PR DESCRIPTION
Previously, when checking for ambiguity in relations, juju would
check every potential relation, instead of looking through
relations that actually exist

Now query mongo to find all existing relations which match some
spec, and check for ambiguity by just checking the length of this slice

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

#### Deploy and relate some applications to create a potentially ambiguous relation
```
$ juju bootstrap lxd lxd
$ juju deploy grafana
$ juju deploy ceph-dashboard
$ juju relate grafana:dashboards ceph-dashboard:grafana-dashboard
$ juju status --relations
Model    Controller  Cloud/Region         Version   SLA          Timestamp
default  lxd         localhost/localhost  2.9.33.1  unsupported  17:53:18+01:00

App             Version  Status   Scale  Charm           Channel  Rev  Exposed  Message
ceph-dashboard           unknown      0  ceph-dashboard  stable     2  no       
grafana                  active       1  grafana         stable    56  no       Ready

Unit        Workload  Agent  Machine  Public address  Ports     Message
grafana/0*  active    idle   0        10.219.211.77   3000/tcp  Ready

Machine  State    Address        Inst id        Series  AZ  Message
0        started  10.219.211.77  juju-37d5c1-0  focal       Running

Relation provider                 Requirer            Interface          Type     Message
ceph-dashboard:grafana-dashboard  grafana:dashboards  grafana-dashboard  regular  
```
(NOTE: potentially re-establish relation between tests to restore status to the above

#### Attempt to remove w/o specifying relation
```
$ juju remove-relation grafana ceph-dashboard
$ echo $?
0
```
(then verify relation has been removed)

#### Attempt to remove with relations

```
$ juju remove-relation grafana:dashboards ceph-dashboard
```
and
```
$ juju remove-relation grafana ceph-dashboard:grafana-dashboard
```
and
```
$ juju remove-relation grafana:dashboards ceph-dashboard:grafana-dashboard
```

#### Attempt to remove a non-existing relation

```
$ juju remove-relation grafana ceph-dashboard:foo
ERROR relation "grafana ceph-dashboard:foo" not found (not found)
```
and
```
$ juju remove-relation grafana:bar ceph-dashboard
ERROR relation "grafana:bar ceph-dashboard" not found (not found)
```

#### Check attempt to remove ambiguous relation
```
$ juju relate grafana:website ceph-dashboard:prometheus
$ juju status
...
Relation provider                 Requirer                   Interface          Type     Message
ceph-dashboard:grafana-dashboard  grafana:dashboards         grafana-dashboard  regular  
grafana:website                   ceph-dashboard:prometheus  http               regular  

$ juju remove-relation grafana ceph-dashboard
ERROR ambiguous relation: "grafana ceph-dashboard" could refer to "grafana:dashboards ceph-dashboard:grafana-dashboard"; "ceph-dashboard:prometheus grafana:website"
```
then check it can be removed with:
```
$ juju remove-relation grafana:dashboards ceph-dashboard
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1964265
