### PR TITLE
Merge 2.9

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -125,6 +125,20 @@ type DeployArgs struct {
 	Force bool
 }
 
+// Leader returns the unit name for the leader of the provided application.
+func (c *Client) Leader(app string) (string, error) {
+	var result params.StringResult
+	p := params.Entity{Tag: names.NewApplicationTag(app).String()}
+
+	if err := c.facade.FacadeCall("Leader", p, &result); err != nil {
+		return "", errors.Trace(err)
+	}
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return result.Result, nil
+}
+
 // Deploy obtains the charm, either locally or from the charm store, and deploys
 // it. Placement directives, if provided, specify the machine on which the charm
 // is deployed.

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -1387,3 +1387,19 @@ func (s *applicationSuite) TestUnexpose(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 }
+
+func (s *applicationSuite) TestLeader(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		c.Check(objType, gc.Equals, "Application")
+		c.Check(request, gc.Equals, "Leader")
+		c.Assert(arg, gc.Equals, params.Entity{Tag: names.NewApplicationTag("ubuntu").String()})
+		c.Assert(result, gc.FitsTypeOf, &params.StringResult{})
+		*(result.(*params.StringResult)) = params.StringResult{Result: "ubuntu/42"}
+		return nil
+	})
+
+	facade := application.NewClient(apiCaller)
+	obtainedUnit, err := facade.Leader("ubuntu")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtainedUnit, gc.Equals, "ubuntu/42")
+}

--- a/api/client/sshclient/facade.go
+++ b/api/client/sshclient/facade.go
@@ -100,19 +100,6 @@ func (facade *Facade) PublicKeys(target string) ([]string, error) {
 	return out.Results[0].PublicKeys, nil
 }
 
-// Leader returns the unit name for the leader of the provided application.
-func (facade *Facade) Leader(app string) (string, error) {
-	var result params.StringResult
-	p := params.Entity{Tag: names.NewApplicationTag(app).String()}
-	if err := facade.caller.FacadeCall("Leader", p, &result); err != nil {
-		return "", err
-	}
-	if result.Error != nil {
-		return "", result.Error
-	}
-	return result.Result, nil
-}
-
 // Proxy returns whether SSH connections should be proxied through the
 // controller hosts for the associated model.
 func (facade *Facade) Proxy() (bool, error) {

--- a/api/client/sshclient/facade_test.go
+++ b/api/client/sshclient/facade_test.go
@@ -280,19 +280,3 @@ func (s *FacadeSuite) TestProxyError(c *gc.C) {
 	_, err := facade.Proxy()
 	c.Check(err, gc.ErrorMatches, "boom")
 }
-
-func (s *FacadeSuite) TestLeader(c *gc.C) {
-	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "SSHClient")
-		c.Check(request, gc.Equals, "Leader")
-		c.Assert(arg, gc.Equals, params.Entity{Tag: names.NewApplicationTag("ubuntu").String()})
-		c.Assert(result, gc.FitsTypeOf, &params.StringResult{})
-		*(result.(*params.StringResult)) = params.StringResult{Result: "ubuntu/42"}
-		return nil
-	})
-
-	facade := sshclient.NewFacade(apiCaller)
-	obtainedUnit, err := facade.Leader("ubuntu")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(obtainedUnit, gc.Equals, "ubuntu/42")
-}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -18,7 +18,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              3,
 	"AllWatcher":                   2,
 	"Annotations":                  2,
-	"Application":                  13,
+	"Application":                  14,
 	"ApplicationOffers":            4,
 	"ApplicationScaler":            1,
 	"Backups":                      3,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -62,8 +62,8 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.application")
 
-// APIv13 provides the Application API facade for version 13.
-type APIv13 struct {
+// APIv14 provides the Application API facade for version 14.
+type APIv14 struct {
 	*APIBase
 }
 
@@ -2942,4 +2942,23 @@ func checkCAASMinVersion(ch Charm, caasVersion *version.Number) (err error) {
 		))
 	}
 	return nil
+}
+
+// Leader returns the unit name of the leader for the given application.
+func (api *APIBase) Leader(entity params.Entity) (params.StringResult, error) {
+	result := params.StringResult{}
+	application, err := names.ParseApplicationTag(entity.Tag)
+	if err != nil {
+		return result, err
+	}
+	leaders, err := api.leadershipReader.Leaders()
+	if err != nil {
+		return result, errors.Annotate(err, "could not fetch leaders")
+	}
+	var ok bool
+	result.Result, ok = leaders[application.Name]
+	if !ok || result.Result == "" {
+		result.Error = apiservererrors.ServerError(errors.NotFoundf("leader for %s", entity.Tag))
+	}
+	return result, nil
 }

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -44,7 +44,7 @@ type applicationSuite struct {
 	jujutesting.JujuConnSuite
 	commontesting.BlockHelper
 
-	applicationAPI *application.APIv13
+	applicationAPI *application.APIv14
 	application    *state.Application
 	authorizer     *apiservertesting.FakeAuthorizer
 	lastKnownRev   map[string]int
@@ -66,7 +66,7 @@ func (s *applicationSuite) SetUpTest(c *gc.C) {
 	s.lastKnownRev = make(map[string]int)
 }
 
-func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv13 {
+func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv14 {
 	resources := common.NewResources()
 	c.Assert(resources.RegisterNamed("dataDir", common.StringResource(c.MkDir())), jc.ErrorIsNil)
 	storageAccess, err := application.GetStorageState(s.State)
@@ -92,7 +92,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv13 {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	return &application.APIv13{api}
+	return &application.APIv14{api}
 }
 
 func (s *applicationSuite) TestCharmConfig(c *gc.C) {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -63,7 +63,7 @@ type ApplicationSuite struct {
 	env          environs.Environ
 	blockChecker mockBlockChecker
 	authorizer   apiservertesting.FakeAuthorizer
-	api          *application.APIv13
+	api          *application.APIv14
 	deployParams map[string]application.DeployApplicationParams
 }
 
@@ -95,7 +95,7 @@ func (s *ApplicationSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		s.caasBroker,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.api = &application.APIv13{api}
+	s.api = &application.APIv14{api}
 }
 
 func (s *ApplicationSuite) SetUpTest(c *gc.C) {
@@ -2334,4 +2334,11 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfiedWithForce(c *gc.C) {
 		Force:           true,
 	})
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("expected SetCharm to succeed when --force is set"))
+}
+
+func (s *ApplicationSuite) TestLeader(c *gc.C) {
+	result, err := s.api.Leader(params.Entity{Tag: names.NewApplicationTag("postgresql").String()})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.Result, gc.Equals, "postgresql/0")
 }

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -23,7 +23,7 @@ func GetModel(m *state.Model) Model {
 	return modelShim{m}
 }
 
-func SetModelType(api *APIv13, modelType state.ModelType) {
+func SetModelType(api *APIv14, modelType state.ModelType) {
 	api.modelType = modelType
 }
 

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -31,7 +31,7 @@ import (
 type getSuite struct {
 	jujutesting.JujuConnSuite
 
-	applicationAPI *application.APIv13
+	applicationAPI *application.APIv14
 	authorizer     apiservertesting.FakeAuthorizer
 }
 
@@ -64,7 +64,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 		nil, // CAAS Broker not used in this suite.
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	s.applicationAPI = &application.APIv13{api}
+	s.applicationAPI = &application.APIv14{api}
 }
 
 func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -7,20 +7,21 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Application", 13, func(ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV13(ctx)
-	}, reflect.TypeOf((*APIv13)(nil))) // Adds CharmOrigin to Deploy
+	registry.MustRegister("Application", 14, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV14(ctx)
+	}, reflect.TypeOf((*APIv14)(nil)))
 }
 
-func newFacadeV13(ctx facade.Context) (*APIv13, error) {
+func newFacadeV14(ctx facade.Context) (*APIv14, error) {
 	api, err := newFacadeBase(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &APIv13{api}, nil
+	return &APIv14{api}, nil
 }

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
-	"github.com/juju/names/v4"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -197,23 +196,4 @@ func (facade *Facade) Proxy() (params.SSHProxyResult, error) {
 		return params.SSHProxyResult{}, err
 	}
 	return params.SSHProxyResult{UseProxy: config.ProxySSH()}, nil
-}
-
-// Leader returns the unit name of the leader for the given application.
-func (facade *Facade) Leader(entity params.Entity) (params.StringResult, error) {
-	result := params.StringResult{}
-	application, err := names.ParseApplicationTag(entity.Tag)
-	if err != nil {
-		return result, err
-	}
-	leaders, err := facade.leadershipReader.Leaders()
-	if err != nil {
-		return result, errors.Annotate(err, "could not fetch leaders")
-	}
-	var ok bool
-	result.Result, ok = leaders[application.Name]
-	if !ok || result.Result == "" {
-		result.Error = apiservererrors.ServerError(errors.NotFoundf("leader for %s", entity.Tag))
-	}
-	return result, nil
 }

--- a/apiserver/facades/client/sshclient/facade_test.go
+++ b/apiserver/facades/client/sshclient/facade_test.go
@@ -4,7 +4,6 @@
 package sshclient_test
 
 import (
-	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jujutesting "github.com/juju/testing"
@@ -184,19 +183,6 @@ func (s *facadeSuite) TestProxyFalse(c *gc.C) {
 	s.backend.stub.CheckCalls(c, []jujutesting.StubCall{
 		{"ModelConfig", []interface{}{}},
 	})
-}
-
-func (s *facadeSuite) TestLeader(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	mockReader := NewMockReader(ctrl)
-	mockReader.EXPECT().Leaders().Return(map[string]string{"testme": "ubuntu/4", "ubuntu": "ubuntu/5"}, nil)
-	facade, err := sshclient.InternalFacade(s.backend, mockReader, s.authorizer, s.callContext)
-	c.Assert(err, jc.ErrorIsNil)
-	result, err := facade.Leader(params.Entity{Tag: names.NewApplicationTag("ubuntu").String()})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.Result, gc.Equals, "ubuntu/5")
 }
 
 type mockBackend struct {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1833,8 +1833,8 @@
     },
     {
         "Name": "Application",
-        "Description": "APIv13 provides the Application API facade for version 13.",
-        "Version": 13,
+        "Description": "APIv14 provides the Application API facade for version 14.",
+        "Version": 14,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -2047,6 +2047,18 @@
                         }
                     },
                     "description": "GetConstraints returns the constraints for a given application."
+                },
+                "Leader": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    },
+                    "description": "Leader returns the unit name of the leader for the given application."
                 },
                 "MergeBindings": {
                     "type": "object",
@@ -3839,6 +3851,21 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
                 },
                 "Subnet": {
                     "type": "object",
@@ -38103,18 +38130,6 @@
                     },
                     "description": "AllAddresses reports all addresses that might have SSH listening for each\nentity in args. The result is sorted with public addresses first.\nMachines and units are supported as entity types."
                 },
-                "Leader": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entity"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/StringResult"
-                        }
-                    },
-                    "description": "Leader returns the unit name of the leader for the given application."
-                },
                 "PrivateAddress": {
                     "type": "object",
                     "properties": {
@@ -38314,21 +38329,6 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
-                    ]
-                },
-                "StringResult": {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "result": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "result"
                     ]
                 }
             }

--- a/cmd/juju/ssh/mocks/leaderapi_mock.go
+++ b/cmd/juju/ssh/mocks/leaderapi_mock.go
@@ -33,6 +33,20 @@ func (m *MockLeaderAPI) EXPECT() *MockLeaderAPIMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockLeaderAPI) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockLeaderAPIMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockLeaderAPI)(nil).Close))
+}
+
 // Leader mocks base method.
 func (m *MockLeaderAPI) Leader(arg0 string) (string, error) {
 	m.ctrl.T.Helper()

--- a/cmd/juju/ssh/mocks/ssh_container_mock.go
+++ b/cmd/juju/ssh/mocks/ssh_container_mock.go
@@ -119,6 +119,21 @@ func (mr *MockApplicationAPIMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockApplicationAPI)(nil).Close))
 }
 
+// Leader mocks base method.
+func (m *MockApplicationAPI) Leader(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Leader", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Leader indicates an expected call of Leader.
+func (mr *MockApplicationAPIMockRecorder) Leader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Leader", reflect.TypeOf((*MockApplicationAPI)(nil).Leader), arg0)
+}
+
 // UnitsInfo mocks base method.
 func (m *MockApplicationAPI) UnitsInfo(arg0 []names.UnitTag) ([]application.UnitInfo, error) {
 	m.ctrl.T.Helper()

--- a/cmd/juju/ssh/ssh_unix_test.go
+++ b/cmd/juju/ssh/ssh_unix_test.go
@@ -281,9 +281,9 @@ func (s *SSHSuite) TestMaybeResolveLeaderUnit(c *gc.C) {
 
 	leaderAPI := mocks.NewMockLeaderAPI(ctrl)
 	leaderAPI.EXPECT().Leader("loop").Return("loop/1", nil)
-	leaderFunc := func() (LeaderAPI, error) { return leaderAPI, nil }
 
-	resolvedUnit, err := maybeResolveLeaderUnit(leaderFunc, "loop/leader")
+	ldr := leaderResolver{leaderAPI: leaderAPI}
+	resolvedUnit, err := ldr.maybeResolveLeaderUnit("loop/leader")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resolvedUnit, gc.Equals, "loop/1", gc.Commentf("expected leader to resolve to loop/1 for principal application"))
 }


### PR DESCRIPTION
Merge 2.9

#14307 [JUJU-1442] Fix debug-hooks unit/leader on k8s

Conflicts related to removing backwards compatibility code.

```
# Conflicts:
#       apiserver/facades/client/application/application.go
#       apiserver/facades/client/application/application_test.go
#       apiserver/facades/client/application/application_unit_test.go
#       apiserver/facades/client/application/get_test.go
#       apiserver/facades/schema.json
#       cmd/juju/ssh/debughooks.go
#       cmd/juju/ssh/mocks/leaderapi_mock.go
#       cmd/juju/ssh/ssh.go
#       cmd/juju/ssh/ssh_container.go
#       cmd/juju/ssh/ssh_machine.go
#       cmd/juju/ssh/ssh_unix_test.go
```

## QA steps

See PR


[JUJU-1442]: https://warthogs.atlassian.net/browse/JUJU-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ