### PR TITLE
Backport fix from develop branch

### DIFF
--- a/tests/suites/backup/backup.sh
+++ b/tests/suites/backup/backup.sh
@@ -61,8 +61,8 @@ run_basic_backup_restore() {
 	# Only do this check if provider is LXD (too hard to do for all providers)
 	if [ "${BOOTSTRAP_PROVIDER}" == "lxd" ] || [ "${BOOTSTRAP_PROVIDER}" == "localhost" ]; then
 		echo "Ensure that both instances are running (restore shouldn't terminate machines)"
-		lxc info "${id0}" | grep Status | check "Status: RUNNING"
-		lxc info "${id1}" | grep Status | check "Status: RUNNING"
+		lxc list --format json | jq --arg name "${id0}" -r '.[] | select(.name==$name) | .state.status' | check Running
+		lxc list --format json | jq --arg name "${id1}" -r '.[] | select(.name==$name) | .state.status' | check Running
 	fi
 
 	destroy_model "test-basic-backup-restore"


### PR DESCRIPTION
This PR
#14310 [JUJU-1449] Fix for test-backup-lxd test in ci-gating-tests

added a fix for a backup restore test but the fix from develop branch is more accurate and preferred so is backported here.


## QA steps

`./main.sh backup`

[JUJU-1449]: https://warthogs.atlassian.net/browse/JUJU-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ