### PR TITLE
[JUJU-1456] Avoid retrieving provider network config when no instances are recognised

### DIFF
--- a/core/status/status.go
+++ b/core/status/status.go
@@ -109,7 +109,7 @@ const (
 	Failed Status = "failed"
 
 	// Lost is set when:
-	// The juju agent has has not communicated with the juju server for an unexpectedly long time;
+	// The juju agent has not communicated with the juju server for an unexpectedly long time;
 	// the unit agent ought to be signalling activity, but none has been detected.
 	Lost Status = "lost"
 )
@@ -242,8 +242,8 @@ const (
 
 // KnownModificationStatus returns true if the status has a known value for
 // a modification of an instance.
-func (status Status) KnownModificationStatus() bool {
-	switch status {
+func (s Status) KnownModificationStatus() bool {
+	switch s {
 	case
 		Idle,
 		Applied,
@@ -254,8 +254,8 @@ func (status Status) KnownModificationStatus() bool {
 	return false
 }
 
-func (status Status) KnownInstanceStatus() bool {
-	switch status {
+func (s Status) KnownInstanceStatus() bool {
+	switch s {
 	case
 		Pending,
 		ProvisioningError,
@@ -271,8 +271,8 @@ func (status Status) KnownInstanceStatus() bool {
 // KnownAgentStatus returns true if status has a known value for an agent.
 // It includes every status that has ever been valid for a unit or machine agent.
 // This is used by the apiserver client facade to filter out unknown values.
-func (status Status) KnownAgentStatus() bool {
-	switch status {
+func (s Status) KnownAgentStatus() bool {
+	switch s {
 	case
 		Allocating,
 		Error,
@@ -288,11 +288,11 @@ func (status Status) KnownAgentStatus() bool {
 // KnownWorkloadStatus returns true if status has a known value for a workload.
 // It includes every status that has ever been valid for a unit agent.
 // This is used by the apiserver client facade to filter out unknown values.
-func (status Status) KnownWorkloadStatus() bool {
-	if ValidWorkloadStatus(status) {
+func (s Status) KnownWorkloadStatus() bool {
+	if ValidWorkloadStatus(s) {
 		return true
 	}
-	switch status {
+	switch s {
 	case Error: // include error so that we can filter on what the spec says is valid
 		return true
 	default:
@@ -320,8 +320,8 @@ func ValidWorkloadStatus(status Status) bool {
 // WorkloadMatches returns true if the candidate matches status,
 // taking into account that the candidate may be a legacy
 // status value which has been deprecated.
-func (status Status) WorkloadMatches(candidate Status) bool {
-	return status == candidate
+func (s Status) WorkloadMatches(candidate Status) bool {
+	return s == candidate
 }
 
 // ValidModelStatus returns true if status has a valid value (that is to say,
@@ -343,8 +343,8 @@ func ValidModelStatus(status Status) bool {
 // Matches returns true if the candidate matches status,
 // taking into account that the candidate may be a legacy
 // status value which has been deprecated.
-func (status Status) Matches(candidate Status) bool {
-	return status == candidate
+func (s Status) Matches(candidate Status) bool {
+	return s == candidate
 }
 
 // DeriveStatus is used to determine the application
@@ -356,8 +356,8 @@ func DeriveStatus(statuses []StatusInfo) StatusInfo {
 		Status: Unknown,
 	}
 	for _, unitStatus := range statuses {
-		currentSeverity := statusServerities[result.Status]
-		unitSeverity := statusServerities[unitStatus.Status]
+		currentSeverity := statusSeverities[result.Status]
+		unitSeverity := statusSeverities[unitStatus.Status]
 		if unitSeverity > currentSeverity {
 			result.Status = unitStatus.Status
 			result.Message = unitStatus.Message
@@ -370,7 +370,7 @@ func DeriveStatus(statuses []StatusInfo) StatusInfo {
 
 // statusSeverities holds status values with a severity measure.
 // Status values with higher severity are used in preference to others.
-var statusServerities = map[Status]int{
+var statusSeverities = map[Status]int{
 	Error:       100,
 	Blocked:     90,
 	Waiting:     80,

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1779,24 +1779,16 @@ func (e *Environ) Instances(ctx context.ProviderCallContext, ids []instance.Id) 
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	// Make a series of requests to cope with eventual consistency.
-	// Each request will attempt to add more instances to the requested
-	// set.
-	var foundServers []nova.ServerDetail
-	for a := shortAttempt.Start(); a.Next(); {
-		var err error
-		foundServers, err = e.listServers(ctx, ids)
-		if err != nil {
-			logger.Debugf("error listing servers: %v", err)
-			if !IsNotFoundError(err) {
-				handleCredentialError(err, ctx)
-				return nil, err
-			}
-		}
-		if len(foundServers) == len(ids) {
-			break
+
+	foundServers, err := e.listServers(ctx, ids)
+	if err != nil {
+		logger.Debugf("error listing servers: %v", err)
+		if !IsNotFoundError(err) {
+			handleCredentialError(err, ctx)
+			return nil, err
 		}
 	}
+
 	logger.Tracef("%d/%d live servers found", len(foundServers), len(ids))
 	if len(foundServers) == 0 {
 		return nil, environs.ErrNoInstances
@@ -1804,21 +1796,19 @@ func (e *Environ) Instances(ctx context.ProviderCallContext, ids []instance.Id) 
 
 	instsById := make(map[string]instances.Instance, len(foundServers))
 	for i, server := range foundServers {
-		// TODO(wallyworld): lookup the flavor details to fill in the
-		// instance type data
 		instsById[server.Id] = &openstackInstance{
 			e:            e,
 			serverDetail: &foundServers[i],
 		}
 	}
 
-	// Update the instance structs with any floating IP address that has been assigned to the instance.
-	if err := e.updateFloatingIPAddresses(ctx, instsById); err != nil {
+	// Update the instance structs with any floating IP address
+	// that has been assigned to the instance.
+	if err = e.updateFloatingIPAddresses(ctx, instsById); err != nil {
 		return nil, err
 	}
 
 	insts := make([]instances.Instance, len(ids))
-	var err error
 	for i, id := range ids {
 		if inst := instsById[string(id)]; inst != nil {
 			insts[i] = inst

--- a/worker/instancepoller/package_test.go
+++ b/worker/instancepoller/package_test.go
@@ -9,6 +9,11 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks_watcher.go github.com/juju/juju/core/watcher StringsWatcher
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks_instances.go github.com/juju/juju/environs/instances Instance
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks_cred_api.go github.com/juju/juju/worker/common CredentialAPI
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks_instancepoller.go github.com/juju/juju/worker/instancepoller Environ,Machine
+
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -358,19 +358,30 @@ func (u *updaterWorker) pollGroupMembers(groupType pollGroupType) error {
 
 	ctx := stdcontext.Background()
 	infoList, err := u.config.Environ.Instances(u.callContextFunc(ctx), instList)
-	if err != nil && !isPartialOrNoInstancesError(err) {
-		return errors.Trace(err)
+	if err != nil {
+		switch errors.Cause(err) {
+		case environs.ErrPartialInstances:
+		case environs.ErrNoInstances:
+			// If there were no instances recognised by the provider, we do not
+			// retrieve the network configuration, and will therefore have
+			// nothing to update.
+			// This can happen when machines do have instance IDs, but the
+			// instances themselves are shut down, such as we have seen for
+			// dying models.
+			return nil
+		default:
+			return errors.Trace(err)
+		}
 	}
 
 	netList, err := u.config.Environ.NetworkInterfaces(u.callContextFunc(ctx), instList)
 	if err != nil && !isPartialOrNoInstancesError(err) {
-		// NOTE(achilleasa): 2022-24-01: all existing providers (with
-		// the exception of "manual" which we don't care about in this
-		// context) implement the NetworkInterfaces method.
+		// NOTE(achilleasa): 2022-24-01: all existing providers (with the
+		// exception of "manual" which we don't care about in this context)
+		// implement the NetworkInterfaces method.
 		//
-		// This error is meant as a hint to folks working on new
-		// providers in the future to ensure that they implement this
-		// method.
+		// This error is meant as a hint to folks working on new providers
+		// in the future to ensure that they implement this method.
 		if errors.IsNotSupported(errors.Cause(err)) {
 			return errors.Errorf("BUG: substrate does not implement required NetworkInterfaces method")
 		}
@@ -379,9 +390,6 @@ func (u *updaterWorker) pollGroupMembers(groupType pollGroupType) error {
 	}
 
 	for idx, info := range infoList {
-		// No details found for this instance. This most probably means
-		// that the unit has been killed and we haven't been notified
-		// yet. Log the error and keep going.
 		if info == nil {
 			u.config.Logger.Warningf("unable to retrieve instance information for instance: %q", instList[idx])
 			continue
@@ -393,6 +401,7 @@ func (u *updaterWorker) pollGroupMembers(groupType pollGroupType) error {
 		}
 
 		entry := u.instanceIDToGroupEntry[instList[idx]]
+
 		providerStatus, providerAddrCount, err := u.processProviderInfo(entry, info, ifList)
 		if err != nil {
 			return errors.Trace(err)
@@ -416,7 +425,7 @@ func (u *updaterWorker) resolveInstanceID(entry *pollGroupEntry) error {
 
 	instID, err := entry.m.InstanceId()
 	if err != nil {
-		return errors.Annotate(err, "cannot get machine's instance ID")
+		return errors.Annotatef(err, "retrieving instance ID for machine %q", entry.m.Id())
 	}
 
 	entry.instanceID = instID
@@ -428,13 +437,17 @@ func (u *updaterWorker) resolveInstanceID(entry *pollGroupEntry) error {
 // addresses based on the information collected from the provider. It returns
 // the *instance* status and the number of provider addresses currently
 // known for the machine.
-func (u *updaterWorker) processProviderInfo(entry *pollGroupEntry, info instances.Instance, providerIfaceList network.InterfaceInfos) (status.Status, int, error) {
+func (u *updaterWorker) processProviderInfo(
+	entry *pollGroupEntry, info instances.Instance, providerInterfaces network.InterfaceInfos,
+) (status.Status, int, error) {
 	curStatus, err := entry.m.InstanceStatus()
 	if err != nil {
 		// This should never occur since the machine is provisioned. If
 		// it does occur, report an unknown status to move the machine to
 		// the short poll group.
-		u.config.Logger.Warningf("cannot get current instance status for machine %v (instance ID %q): %v", entry.m.Id(), entry.instanceID, err)
+		u.config.Logger.Warningf("cannot get current instance status for machine %v (instance ID %q): %v",
+			entry.m.Id(), entry.instanceID, err)
+
 		return status.Unknown, -1, nil
 	}
 
@@ -446,7 +459,9 @@ func (u *updaterWorker) processProviderInfo(entry *pollGroupEntry, info instance
 	}
 
 	if providerStatus != curInstStatus {
-		u.config.Logger.Infof("machine %q (instance ID %q) instance status changed from %q to %q", entry.m.Id(), entry.instanceID, curInstStatus, providerStatus)
+		u.config.Logger.Infof("machine %q (instance ID %q) instance status changed from %q to %q",
+			entry.m.Id(), entry.instanceID, curInstStatus, providerStatus)
+
 		if err = entry.m.SetInstanceStatus(providerStatus.Status, providerStatus.Message, nil); err != nil {
 			u.config.Logger.Errorf("cannot set instance status on %q: %v", entry.m, err)
 			return status.Unknown, -1, errors.Trace(err)
@@ -468,7 +483,7 @@ func (u *updaterWorker) processProviderInfo(entry *pollGroupEntry, info instance
 
 	// Check whether the provider addresses for this machine need to be
 	// updated.
-	addrCount, err := u.syncProviderAddresses(entry, info, providerIfaceList)
+	addrCount, err := u.syncProviderAddresses(entry, providerInterfaces)
 	if err != nil {
 		return status.Unknown, -1, err
 	}
@@ -480,18 +495,27 @@ func (u *updaterWorker) processProviderInfo(entry *pollGroupEntry, info instance
 // using either the provider sourced interface list.
 //
 // The call returns the count of provider addresses for the machine.
-func (u *updaterWorker) syncProviderAddresses(entry *pollGroupEntry, instInfo instances.Instance, providerIfaceList network.InterfaceInfos) (int, error) {
+func (u *updaterWorker) syncProviderAddresses(
+	entry *pollGroupEntry, providerIfaceList network.InterfaceInfos,
+) (int, error) {
 	addrs, modified, err := entry.m.SetProviderNetworkConfig(providerIfaceList)
 	if err != nil {
 		return -1, errors.Trace(err)
 	} else if modified {
-		u.config.Logger.Infof("machine %q (instance ID %q) has new addresses: %v", entry.m.Id(), entry.instanceID, addrs)
+		u.config.Logger.Infof("machine %q (instance ID %q) has new addresses: %v",
+			entry.m.Id(), entry.instanceID, addrs)
 	}
 
 	return len(addrs), nil
 }
 
-func (u *updaterWorker) maybeSwitchPollGroup(curGroup pollGroupType, entry *pollGroupEntry, curProviderStatus, curMachineStatus status.Status, providerAddrCount int) {
+func (u *updaterWorker) maybeSwitchPollGroup(
+	curGroup pollGroupType,
+	entry *pollGroupEntry,
+	curProviderStatus,
+	curMachineStatus status.Status,
+	providerAddrCount int,
+) {
 	if curProviderStatus == status.Allocating || curProviderStatus == status.Pending {
 		// Keep the machine in the short poll group until it settles.
 		entry.bumpShortPollInterval(u.config.Clock)

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -25,11 +25,6 @@ import (
 	"github.com/juju/juju/worker/common"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks_watcher.go github.com/juju/juju/core/watcher StringsWatcher
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks_instances.go github.com/juju/juju/environs/instances Instance
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks_cred_api.go github.com/juju/juju/worker/common CredentialAPI
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks_instancepoller.go github.com/juju/juju/worker/instancepoller Environ,Machine
-
 // ShortPoll and LongPoll hold the polling intervals for the instance
 // updater. When a machine has no address or is not started, it will be
 // polled at ShortPoll intervals until it does, exponentially backing off

--- a/worker/instancepoller/worker.go
+++ b/worker/instancepoller/worker.go
@@ -356,6 +356,7 @@ func (u *updaterWorker) pollGroupMembers(groupType pollGroupType) error {
 	if err != nil {
 		switch errors.Cause(err) {
 		case environs.ErrPartialInstances:
+			// Proceed and process the ones we've found.
 		case environs.ErrNoInstances:
 			// If there were no instances recognised by the provider, we do not
 			// retrieve the network configuration, and will therefore have

--- a/worker/instancepoller/worker_test.go
+++ b/worker/instancepoller/worker_test.go
@@ -110,16 +110,18 @@ func (s *pollGroupEntrySuite) TestShortPollIntervalLogic(c *gc.C) {
 	c.Assert(entry.shortPollInterval, gc.Equals, ShortPoll)
 	c.Assert(entry.shortPollAt, gc.Equals, clock.Now().Add(ShortPoll))
 
-	// Ensure that bumpping the short poll duration caps when we reach the
+	// Ensure that bumping the short poll duration caps when we reach the
 	// LongPoll interval.
 	for i := 0; entry.shortPollInterval < LongPoll && i < 100; i++ {
 		entry.bumpShortPollInterval(clock)
 	}
-	c.Assert(entry.shortPollInterval, gc.Equals, ShortPollCap, gc.Commentf("short poll interval did not reach short poll cap interval after 100 interval bumps"))
+	c.Assert(entry.shortPollInterval, gc.Equals, ShortPollCap, gc.Commentf(
+		"short poll interval did not reach short poll cap interval after 100 interval bumps"))
 
 	// Check that once we reach the short poll cap interval we stay capped at it.
 	entry.bumpShortPollInterval(clock)
-	c.Assert(entry.shortPollInterval, gc.Equals, ShortPollCap, gc.Commentf("short poll should have been capped at the short poll cap interval"))
+	c.Assert(entry.shortPollInterval, gc.Equals, ShortPollCap, gc.Commentf(
+		"short poll should have been capped at the short poll cap interval"))
 	c.Assert(entry.shortPollAt, gc.Equals, clock.Now().Add(ShortPollCap))
 }
 
@@ -417,6 +419,7 @@ func (s *workerSuite) TestBatchPollingOfGroupMembers(c *gc.C) {
 	machineTag0 := names.NewMachineTag("0")
 	machine0 := mocks.NewMockMachine(ctrl)
 	machine0.EXPECT().InstanceId().Return(instance.Id(""), apiservererrors.ServerError(errors.NotProvisionedf("not there")))
+	machine0.EXPECT().Id().Return("0")
 	updWorker.appendToShortPollGroup(machineTag0, machine0)
 
 	machineTag1 := names.NewMachineTag("1")
@@ -502,9 +505,6 @@ func (s *workerSuite) TestLongPollNoMachineInGroupKnownByProvider(c *gc.C) {
 	machine.EXPECT().InstanceId().Return(instID, nil)
 	mocked.environ.EXPECT().Instances(gomock.Any(), []instance.Id{instID}).Return(
 		nil, environs.ErrNoInstances,
-	)
-	mocked.environ.EXPECT().NetworkInterfaces(gomock.Any(), []instance.Id{instID}).Return(
-		nil, nil,
 	)
 
 	// Advance the clock to trigger processing of both the short AND long


### PR DESCRIPTION
The linked bug describes a situation where we have the instance-poller worker making many calls to retrieve servers and ports from OpenStack, for instances that the provider does not recognise.

This is occurring because the model is dying, but not being cleaned up, and the only machine(s) remaining have already had their instances removed.

Here we do two things:
- Remove the retry logic for server retrieval from `Instances` in the OpenStack provider. At present, we keep attempting to retrieve instances repeatedly for the attempt duration, until we find all IDs we queried for. We will never find them in this case and always exhaust the retries.
- Avoid calling `NetworkInterfaces` when we have no recognised instances in the poll-group. We will have nothing to update anyway, so it is a wasted call.

This is a first step in increased efficiency. It will likely be followed with a change to filter `NetworkInterfaces` in the provider call rather than filtering later, and back-offs in the next poll time when we can't find instances.

## QA steps

- Make sure you have access to an OpenStack, and the OpenStack client installed.
- Bootstrap on OpenStack.
- Reconfigure `logging-config` so that `juju.provider.openstack=TRACE`.
- `juju add-machine`.
- After the machine is up, delete the instance using `openstack server delete <name|uuid>`
- Usually a run of the instance-poller will result in logs like:
```
machine-0: 17:14:42 TRACE juju.provider.openstack 1/1 live servers found
machine-0: 17:14:43 DEBUG juju.provider.openstack finding subnets in networks: c65bc2d8-0dcd-4ebe-a072-9f71622c3ca4
```
- Within 15 minutes you should note that there is no subnet retrieval, just:
```
(nil), ProviderId:"77d7435a-c074-431b-b3ee-cc92187e2253", ProviderSpaceId:"", ProviderNetworkId:"c65bc2d8-0dcd-4ebe-a072-9f71622c3ca4", VLANTag:0, AvailabilityZones:[]string{}, SpaceID:"", SpaceName:"", FanInfo:(*network.FanCIDRs)(nil), IsPublic:false, Life:""}
machine-0: 17:14:42 DEBUG juju.provider.openstack error listing servers: failed to get details for serverId: 25737f33-c218-449f-b195-13caf288ad7c
caused by: Resource at http://10.245.161.158:8774/v2.1/servers/25737f33-c218-449f-b195-13caf288ad7c not found
caused by: request (http://10.245.161.158:8774/v2.1/servers/25737f33-c218-449f-b195-13caf288ad7c) returned unexpected status: 404; error info: {"itemNotFound": {"code": 404, "message": "Instance 25737f33-c218-449f-b195-13caf288ad7c could not be found."}}
machine-0: 17:14:42 TRACE juju.provider.openstack 0/1 live servers found
```
- CAUTION: Don't confuse seeing the subnets line associated with another model, such as the controller.

## Documentation changes

None

## Bug reference

https://bugs.launchpad.net/juju/+bug/1981597
