### PR TITLE
[JUJU-1196] refactor nw-contrains-aws test

### DIFF
--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -1,0 +1,61 @@
+run_constraints_aws() {
+  # Echo out to ensure nice output to the test suite.
+  echo
+
+  file="${TEST_DIR}/constraints-aws.txt"
+
+#  ensure "constraints-aws" "${file}"
+
+	echo "Deploy 5 machines with different constraints"
+  juju add-machine --constraints "root-disk=16G"
+  juju add-machine --constraints "cores=1"
+  juju add-machine --constraints "cpu-power=30"
+  juju add-machine --constraints "root-disk=16G cpu-power=30"
+  juju add-machine --constraints "instance-type=i3.xlarge"
+
+  wait_for_machine_agent_status "0" "started"
+  wait_for_machine_agent_status "1" "started"
+  wait_for_machine_agent_status "2" "started"
+  wait_for_machine_agent_status "3" "started"
+  wait_for_machine_agent_status "4" "started"
+
+	echo "Ensure machine 0 has 16G root disk"
+  machine0_hardware=$(juju machines --format json | jq -r '.["machines"]["0"]["hardware"]')
+  check_contains "${machine0_hardware}" "root-disk=16384M"
+
+	echo "Ensure machine 1 has 1 core"
+  machine1_hardware=$(juju machines --format json | jq -r '.["machines"]["1"]["hardware"]')
+  check_contains "${machine1_hardware}" "cores=1"
+
+	echo "Ensure machine 2 limit cpu-power by 30"
+  machine2_constraints=$(juju machines --format json | jq -r '.["machines"]["2"]["constraints"]')
+  check_contains "${machine2_constraints}" "cpu-power=30"
+
+	echo "Ensure machine 3 has 16G root disk and limit of cpu power by 30"
+  machine3_hardware=$(juju machines --format json | jq -r '.["machines"]["3"]["hardware"]')
+  machine3_constraints=$(juju machines --format json | jq -r '.["machines"]["3"]["constraints"]')
+  check_contains "${machine3_hardware}" "root-disk=16384M"
+  check_contains "${machine3_constraints}" "cpu-power=30"
+
+	echo "Ensure machine 4 has i3.xlarge instance type"
+  machine4_constraints=$(juju machines --format json | jq -r '.["machines"]["4"]["constraints"]')
+  check_contains "${machine4_constraints}" "instance-type=i3.xlarge"
+
+#  destroy_model "constraints-aws"
+}
+
+test_constraints_aws() {
+  if [ "$(skip 'test_constraints_aws')" ] ||
+     [ "${BOOTSTRAP_PROVIDER}" != "aws" ] || [ "${BOOTSTRAP_PROVIDER}" != "aws" ]; then
+  		echo "==> TEST SKIPPED: constraints aws"
+  		return
+  fi
+
+  (
+  		set_verbosity
+
+  		cd .. || exit
+
+  		run "run_constraints_aws"
+  	)
+}

--- a/tests/suites/constraints/task.sh
+++ b/tests/suites/constraints/task.sh
@@ -1,0 +1,19 @@
+test_constraints() {
+	if [ "$(skip 'test_constraints')" ]; then
+		echo "==> TEST SKIPPED: constraints tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-constraints.txt"
+
+	bootstrap "test-constraints" "${file}"
+
+	test_constraints_aws
+
+	destroy_controller "test-constraints"
+}


### PR DESCRIPTION
This is the bash-based version of the 'nw-constaints-aws' test.

PS: old test lives [here](https://github.com/juju/juju/blob/develop/acceptancetests/assess_constraints.py)

Next steps: 

1. enable this suite (constraints) in juju Jenkins
2. remove old python-based test.

## Checklist

 - [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p aws -c aws constraints
```

## Documentation changes

None

## Bug reference

None
