### PR TITLE
[JUJU-1448] Fix charm download with forced series during deploy

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -286,6 +286,7 @@ func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults,
 				(arg.CharmOrigin.ID == "" && arg.CharmOrigin.Hash != "")) {
 			err := errors.BadRequestf("programming error, Deploy, neither CharmOrigin ID nor Hash can be set before a charm is downloaded. See CharmHubRepository GetDownloadURL.")
 			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
 		}
 		err := deployApplication(
 			api.backend,

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -441,6 +441,30 @@ func (s *applicationSuite) TestApplicationDeploy(c *gc.C) {
 	c.Assert(units, gc.HasLen, 1)
 }
 
+func (s *applicationSuite) TestApplicationDeployFailCharmOriginIDOnly(c *gc.C) {
+	origin := createCharmOriginFromURL(c, charm.MustParseURL("cs:jammy/test-42"))
+	origin.ID = "testingID"
+	s.testApplicationDeployFail(c, origin)
+}
+
+func (s *applicationSuite) TestApplicationDeployFailCharmOriginHashOnly(c *gc.C) {
+	origin := createCharmOriginFromURL(c, charm.MustParseURL("cs:jammy/test-42"))
+	origin.Hash = "testing-hash"
+	s.testApplicationDeployFail(c, origin)
+}
+
+func (s *applicationSuite) testApplicationDeployFail(c *gc.C, origin *params.CharmOrigin) {
+	args := params.ApplicationDeploy{
+		CharmOrigin: origin,
+	}
+	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{args}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error.Code, gc.Equals, "bad request")
+}
+
 func (s *applicationSuite) constraintsWithDefaultArch(c *gc.C) constraints.Value {
 	a := arch.DefaultArchitecture
 	return constraints.Value{

--- a/apiserver/facades/client/client/testing/suite.go
+++ b/apiserver/facades/client/client/testing/suite.go
@@ -188,7 +188,8 @@ func (s *CharmSuite) AddApplication(c *gc.C, charmName, applicationName string) 
 		Charm:  ch,
 		Series: "quantal",
 		CharmOrigin: &state.CharmOrigin{
-			ID: "mycharmhubid",
+			ID:   "mycharmhubid",
+			Hash: "mycharmhash",
 			Platform: &state.Platform{
 				Architecture: "amd64",
 				OS:           "ubuntu",

--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -133,10 +133,11 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
 	}
 
 	logger.Infof("downloading charm %q", pendingCharmURL)
-	if _, err := downloader.DownloadAndStore(pendingCharmURL, *resolvedOrigin, macaroons, force); err != nil {
+	downloadedOrigin, err := downloader.DownloadAndStore(pendingCharmURL, *resolvedOrigin, macaroons, force)
+	if err != nil {
 		return errors.Annotatef(err, "cannot download and store charm %q", pendingCharmURL)
 	}
-	return nil
+	return app.SetDownloadedIDAndHash(downloadedOrigin.ID, downloadedOrigin.Hash)
 }
 
 func (a *CharmDownloaderAPI) getDownloader() (Downloader, error) {

--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -137,7 +137,7 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
 	if err != nil {
 		return errors.Annotatef(err, "cannot download and store charm %q", pendingCharmURL)
 	}
-	return app.SetDownloadedIDAndHash(downloadedOrigin.ID, downloadedOrigin.Hash)
+	return errors.Trace(app.SetDownloadedIDAndHash(downloadedOrigin.ID, downloadedOrigin.Hash))
 }
 
 func (a *CharmDownloaderAPI) getDownloader() (Downloader, error) {

--- a/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
@@ -98,9 +98,14 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharms(c *gc.C) {
 	app.EXPECT().Charm().Return(pendingCharm, false, nil)
 	app.EXPECT().CharmOrigin().Return(&resolvedOrigin)
 
+	downloadedOrigin := resolvedOrigin
+	downloadedOrigin.ID = "test-charm-id"
+	downloadedOrigin.Hash = "test-charm-hash"
+	app.EXPECT().SetDownloadedIDAndHash(downloadedOrigin.ID, downloadedOrigin.Hash).Return(nil)
+
 	s.authChecker.EXPECT().AuthController().Return(true)
 	s.stateBackend.EXPECT().Application("ufo").Return(app, nil)
-	s.downloader.EXPECT().DownloadAndStore(charmURL, resolvedOrigin, macaroons, false).Return(resolvedOrigin, nil)
+	s.downloader.EXPECT().DownloadAndStore(charmURL, resolvedOrigin, macaroons, false).Return(downloadedOrigin, nil)
 
 	got, err := s.api.DownloadApplicationCharms(params.Entities{
 		Entities: []params.Entity{

--- a/apiserver/facades/controller/charmdownloader/interfaces.go
+++ b/apiserver/facades/controller/charmdownloader/interfaces.go
@@ -36,6 +36,7 @@ type Application interface {
 	SetStatus(status.StatusInfo) error
 	CharmOrigin() *corecharm.Origin
 	Charm() (Charm, bool, error)
+	SetDownloadedIDAndHash(id, hash string) error
 }
 
 // Charm provides an API for querying charm details.

--- a/apiserver/facades/controller/charmdownloader/mocks.go
+++ b/apiserver/facades/controller/charmdownloader/mocks.go
@@ -234,6 +234,20 @@ func (mr *MockApplicationMockRecorder) CharmPendingToBeDownloaded() *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmPendingToBeDownloaded", reflect.TypeOf((*MockApplication)(nil).CharmPendingToBeDownloaded))
 }
 
+// SetDownloadedIDAndHash mocks base method.
+func (m *MockApplication) SetDownloadedIDAndHash(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDownloadedIDAndHash", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetDownloadedIDAndHash indicates an expected call of SetDownloadedIDAndHash.
+func (mr *MockApplicationMockRecorder) SetDownloadedIDAndHash(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDownloadedIDAndHash", reflect.TypeOf((*MockApplication)(nil).SetDownloadedIDAndHash), arg0, arg1)
+}
+
 // SetStatus mocks base method.
 func (m *MockApplication) SetStatus(arg0 status.StatusInfo) error {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/charmdownloader/shims.go
+++ b/apiserver/facades/controller/charmdownloader/shims.go
@@ -52,6 +52,9 @@ type appShim struct {
 
 func (a appShim) CharmPendingToBeDownloaded() bool       { return a.app.CharmPendingToBeDownloaded() }
 func (a appShim) SetStatus(info status.StatusInfo) error { return a.app.SetStatus(info) }
+func (a appShim) SetDownloadedIDAndHash(id, hash string) error {
+	return a.app.SetDownloadedIDAndHash(id, hash)
+}
 
 func (a appShim) CharmOrigin() *corecharm.Origin {
 	if origin := a.app.CharmOrigin(); origin != nil {

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -50,10 +50,11 @@ type Origin struct {
 	Channel  *charm.Channel
 	Platform Platform
 
-	// InstanceKey is a unique string associated with the application. To
-	// assist with keeping KPI data in charmhub, it must be the same for every
-	// charmhub Refresh action related to an application. Create with the
-	// charmhub.CreateInstanceKey method. LP: 1944582
+	// InstanceKey is an optional unique string associated with the application.
+	// To assist with keeping KPI data in charmhub, it must be the same for every
+	// charmhub Refresh action for the Refresh api endpoint related to an
+	// application. For all other actions, a random uuid will used when the request
+	// is sent. Create with the charmhub.CreateInstanceKey method. LP: 1944582
 	InstanceKey string
 }
 

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -461,7 +461,6 @@ func (c *CharmHubRepository) getEssentialMetadataForBatch(reqs []corecharm.Metad
 			})
 		}
 
-		resolvedOrigins[resIdx].ID = refreshResult.ID
 		metaRes[resIdx].ResolvedOrigin = resolvedOrigins[resIdx]
 		metaRes[resIdx].Meta = chMeta
 		metaRes[resIdx].Config = chConfig

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -417,7 +417,8 @@ func (s *charmHubRepositorySuite) TestGetEssentialMetadata(c *gc.C) {
 	c.Assert(got[0].Meta.Name, gc.Equals, "wordpress")
 	c.Assert(got[0].Config.Options["blog-title"], gc.Not(gc.IsNil))
 	c.Assert(got[0].Manifest.Bases, gc.HasLen, 1)
-	c.Assert(got[0].ResolvedOrigin.ID, gc.Equals, "charmCHARMcharmCHARMcharmCHARM01", gc.Commentf("expected origin to be resolved"))
+	c.Assert(got[0].ResolvedOrigin.ID, gc.Equals, "", gc.Commentf("ID is only added after charm download"))
+	c.Assert(got[0].ResolvedOrigin.Hash, gc.Equals, "", gc.Commentf("Hash is only added after charm download"))
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannel(c *gc.C) {

--- a/state/application.go
+++ b/state/application.go
@@ -1749,17 +1749,17 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 // hash values. This should ONLY be done from the async downloader.
 // The hash cannot be updated if the charm origin has no ID, nor was one
 // provided as an argument. The ID cannot be changed.
-func (a *Application) SetDownloadedIDAndHash(ID, hash string) error {
-	if ID == "" && hash == "" {
-		return errors.BadRequestf("ID, %q, and hash, %q, must have values", ID, hash)
+func (a *Application) SetDownloadedIDAndHash(id, hash string) error {
+	if id == "" && hash == "" {
+		return errors.BadRequestf("ID, %q, and hash, %q, must have values", id, hash)
 	}
 	if a.doc.CharmOrigin == nil {
 		return errors.Errorf("this application has no charm origin")
 	}
-	if ID != "" && a.doc.CharmOrigin.ID != ID {
-		return errors.BadRequestf("application ID cannot be changed %q, %q", a.doc.CharmOrigin.ID, ID)
+	if id != "" && a.doc.CharmOrigin.ID != "" && a.doc.CharmOrigin.ID != id {
+		return errors.BadRequestf("application ID cannot be changed %q, %q", a.doc.CharmOrigin.ID, id)
 	}
-	if ID != "" && hash == "" {
+	if id != "" && hash == "" {
 		return errors.BadRequestf("programming error, SetDownloadedIDAndHash, cannot have an ID without a hash after downloading. See CharmHubRepository GetDownloadURL.")
 	}
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -1776,13 +1776,13 @@ func (a *Application) SetDownloadedIDAndHash(ID, hash string) error {
 			Id:     a.doc.DocID,
 			Assert: isAliveDoc,
 		}}
-		if ID != "" {
+		if id != "" {
 			ops = append(ops, txn.Op{
 				C:      applicationsC,
 				Id:     a.doc.DocID,
 				Assert: txn.DocExists,
 				Update: bson.D{{"$set", bson.D{
-					{"charm-origin.ID", ID},
+					{"charm-origin.id", id},
 				}}},
 			})
 		}
@@ -1801,8 +1801,8 @@ func (a *Application) SetDownloadedIDAndHash(ID, hash string) error {
 	if err := a.st.db().Run(buildTxn); err != nil {
 		return err
 	}
-	if ID != "" {
-		a.doc.CharmOrigin.ID = ID
+	if id != "" {
+		a.doc.CharmOrigin.ID = id
 	}
 	if hash != "" {
 		a.doc.CharmOrigin.Hash = hash

--- a/state/application.go
+++ b/state/application.go
@@ -15,6 +15,7 @@ import (
 	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/mgo/v2"
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/mgo/v2/txn"
 	"github.com/juju/names/v4"
@@ -23,7 +24,6 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
 	"gopkg.in/juju/environschema.v1"
-	"gopkg.in/mgo.v2"
 
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"

--- a/state/charm.go
+++ b/state/charm.go
@@ -71,6 +71,7 @@ type Platform struct {
 // charm was installed from (charm-hub, charm-store, local) and any additional
 // information we can utilise when making modelling decisions for upgrading or
 // changing.
+// Note: InstanceKey should never be added here. See core charm origin definition.
 type CharmOrigin struct {
 	Source   string    `bson:"source"`
 	Type     string    `bson:"type,omitempty"`

--- a/state/state.go
+++ b/state/state.go
@@ -1147,6 +1147,16 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		return nil, errors.Errorf("charm is nil")
 	}
 
+	// If either the charm origin ID or Hash is set before a charm is
+	// downloaded, charm download will fail for charms with a forced series.
+	// The logic (refreshConfig) in sending the correct request to charmhub
+	// will break.
+	if args.CharmOrigin != nil &&
+		((args.CharmOrigin.ID != "" && args.CharmOrigin.Hash == "") ||
+			(args.CharmOrigin.ID == "" && args.CharmOrigin.Hash != "")) {
+		return nil, errors.BadRequestf("programming error, AddApplication, neither CharmOrigin ID nor Hash can be set before a charm is downloaded. See CharmHubRepository GetDownloadURL.")
+	}
+
 	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1634,7 +1634,16 @@ func (s *StateSuite) TestAddApplication(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	wordpress, err := s.State.AddApplication(
-		state.AddApplicationArgs{Name: "wordpress", Charm: ch, CharmConfig: insettings, ApplicationConfig: inconfig})
+		state.AddApplicationArgs{
+			Name:              "wordpress",
+			Charm:             ch,
+			CharmConfig:       insettings,
+			ApplicationConfig: inconfig,
+			CharmOrigin: &state.CharmOrigin{
+				ID:   "charmID",
+				Hash: "testing-hash",
+			},
+		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(wordpress.Name(), gc.Equals, "wordpress")
 	c.Assert(state.GetApplicationHasResources(wordpress), jc.IsFalse)
@@ -1682,6 +1691,24 @@ func (s *StateSuite) TestAddApplication(c *gc.C) {
 	ch, _, err = mysql.Charm()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ch.URL(), gc.DeepEquals, ch.URL())
+}
+
+func (s *StateSuite) TestAddApplicationFailCharmOriginIDOnly(c *gc.C) {
+	_, err := s.State.AddApplication(state.AddApplicationArgs{
+		Name:        "testme",
+		Charm:       &state.Charm{},
+		CharmOrigin: &state.CharmOrigin{ID: "testing"},
+	})
+	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
+}
+
+func (s *StateSuite) TestAddApplicationFailCharmOriginHashOnly(c *gc.C) {
+	_, err := s.State.AddApplication(state.AddApplicationArgs{
+		Name:        "testme",
+		Charm:       &state.Charm{},
+		CharmOrigin: &state.CharmOrigin{Hash: "testing"},
+	})
+	c.Assert(err, jc.Satisfies, errors.IsBadRequest)
 }
 
 func (s *StateSuite) TestAddCAASApplication(c *gc.C) {


### PR DESCRIPTION
Fixing bugs found once the async charm downloader was enabled and removed from behind the feature flag.

A application's charm origin may only have an ID and Hash after it has been downloaded.  The refreshConfig function in the charmhub core repository will provide a correct config to all the charmhub refresh api endpoint with otherwise. 

To install a charm, download it, the install action of the refresh api allows for no base to be provided if a revision is used. Juju takes advantage of this two ways. One, download the most recent LTS charm when it does not support the series supplied by the user at deploy and using --force. Two, allow for download by revision and not channel. 

Due to reuse of refreshConfig for all refresh api calls to charmhub during deploy and refresh, including when the charm url is being resolved, the only way to know what is going on, is by having the ID or not in the charm origin. This is complicates changes in the future.

To help mitigate the complications of refreshConfig, checks related to a charm origin's id and hash to the application facade and state. However there is no way to guarantee beyond extensive testing.

The above work, uncovered that the async charm download never updated the id and hash in the charm origin after downloading. A new method was added to application in state to accomplish this.

The charm ID is needed after download of the charm and deployment as most refresh actions on the refresh api only work with an ID of a charm, rather than the charm name. Thus we do not save the charm name in the charm origin. This will allow the charm author to change the charm name in the future without impact to current deployments.

## QA steps

Test with k8s as well.

```sh
$ juju bootstrap localhost testing

# deploy a charm requiring force due to series.
$ juju deploy mysql --series jammy --force --channel edge
Located charm "mysql" in charm-hub, revision 67
Deploying "mysql" from charm-hub charm "mysql", revision 67 in channel edge on jammy

# deploy a second application with the same charm.
$ juju deploy mysql --series jammy --force --channel edge second-mysql

# deploy charm without force
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 20
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 20 in channel stable on jammy

$ juju deploy ubuntu --channel stable --revision 19 ubuntu-nineteen
Located charm "ubuntu" in charm-hub, revision 19
Deploying "ubuntu-nineteen" from charm-hub charm "ubuntu", revision 19 in channel stable on focal

# wait for unit to settle before:
$ juju refresh ubuntu-nineteen
Added charm-hub charm "ubuntu", revision 20 in channel stable, to the model

# verify the charm origins and storage path
juju:PRIMARY> db.charms.find({},{"storagepath" :1}).pretty()
{
	"_id" : "5e00c2cc-5115-455e-88b1-dff6b2580baf:ch:amd64/focal/juju-controller-9",
	"storagepath" : "charms/ch:amd64/focal/juju-controller-9-1851f742-5b6c-424f-8a64-ff1802e44ab8"
}
{
	"_id" : "14793ed4-4829-4869-89a0-e63c52eab816:ch:amd64/jammy/mysql-67",
	"storagepath" : "charms/ch:amd64/jammy/mysql-67-d3c5a41a-56ca-4739-8bf0-a13f0ab3936f"
}
{
	"_id" : "14793ed4-4829-4869-89a0-e63c52eab816:ch:amd64/jammy/ubuntu-20",
	"storagepath" : "charms/ch:amd64/jammy/ubuntu-20-db0be972-3504-41da-89be-4889f0816af4"
}
{
	"_id" : "14793ed4-4829-4869-89a0-e63c52eab816:ch:amd64/focal/ubuntu-19",
	"storagepath" : "charms/ch:amd64/focal/ubuntu-19-9901454f-012f-47c7-895d-47e3b8469f4c"
}
juju:PRIMARY> db.applications.find({},{"charm-origin.id":1, "charm-origin.hash":1}).pretty()
{
	"_id" : "5e00c2cc-5115-455e-88b1-dff6b2580baf:controller",
	"charm-origin" : {
		"id" : "WV4pShb4jnG1eXAB8HMypujHRKRXMRW9",
		"hash" : "52fd8d50f41da3457ce58c84692b7ec43d7ffd2e6baa55fb05effc12995bf5b1"
	}
}
{
	"_id" : "14793ed4-4829-4869-89a0-e63c52eab816:mysql",
	"charm-origin" : {
		"id" : "F8CtvgcznoeRSupRrY2uEa67oQtBTF7x",
		"hash" : "5721aef26530b3d26a5a481c51ca75bc5b53c00f96dd1f111cdef2bd476845e6"
	}
}
{
	"_id" : "14793ed4-4829-4869-89a0-e63c52eab816:ubuntu",
	"charm-origin" : {
		"id" : "DksXQKAQTZfsUmBAGanZAhpoS4dpmXel",
		"hash" : "458c7bde333165ae1c3360c8eb7bad911688506dea2a768aeba56bf2eebe1b6b"
	}
}
{
	"_id" : "14793ed4-4829-4869-89a0-e63c52eab816:ubuntu-nineteen",
	"charm-origin" : {
		"id" : "DksXQKAQTZfsUmBAGanZAhpoS4dpmXel",
		"hash" : "458c7bde333165ae1c3360c8eb7bad911688506dea2a768aeba56bf2eebe1b6b"
	}
}
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1981605