### PR TITLE
[JUJU-1458]clean_up_coloring_functions_in juju_run

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -75,7 +75,7 @@ func (c *runCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, "plain", map[string]cmd.Formatter{
 		"yaml":  c.formatYaml,
 		"json":  c.formatJson,
-		"plain": c.printOutput,
+		"plain": c.printRunOutput,
 	})
 
 	f.BoolVar(&c.background, "background", false, "Run the task in the background")
@@ -110,108 +110,25 @@ func (c *runCommandBase) ensureAPI() (err error) {
 func (c *runCommandBase) operationResults(ctx *cmd.Context, results *actionapi.EnqueuedActions) error {
 
 	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		return c.processOperationResults(ctx, results)
+		return c.processOperationResults(ctx, false, results)
 	}
 
 	if c.color {
-		return c.processOperationResultsWithColor(ctx, results)
+		return c.processOperationResults(ctx, true, results)
 	}
 
 	if isTerminal(ctx.Stdout) && !c.noColor {
-		return c.processOperationResultsWithColor(ctx, results)
+		return c.processOperationResults(ctx, true, results)
 	}
 
 	if !isTerminal(ctx.Stdout) && c.color {
-		return c.processOperationResultsWithColor(ctx, results)
+		return c.processOperationResults(ctx, true, results)
 	}
 
-	return c.processOperationResults(ctx, results)
+	return c.processOperationResults(ctx, false, results)
 }
 
-func (c *runCommandBase) processOperationResults(ctx *cmd.Context, results *actionapi.EnqueuedActions) error {
-	var runningTasks []enqueuedAction
-	var enqueueErrs []string
-	for _, a := range results.Actions {
-		if a.Error != nil {
-			enqueueErrs = append(enqueueErrs, a.Error.Error())
-			continue
-		}
-		runningTasks = append(runningTasks, enqueuedAction{
-			task:     a.Action.ID,
-			receiver: a.Action.Receiver,
-		})
-	}
-	operationID := results.OperationID
-	numTasks := len(runningTasks)
-	if !c.background && numTasks > 0 {
-		var plural string
-		if numTasks > 1 {
-			plural = "s"
-		}
-		c.progressf(ctx, "Running operation %s with %d task%s", operationID, numTasks, plural)
-	}
-
-	var actionID string
-	info := make(map[string]interface{}, numTasks)
-	for _, result := range runningTasks {
-		actionID = result.task
-
-		if !c.background {
-			c.progressf(ctx, "  - task %s on %s", actionID, result.receiver)
-		}
-		info[result.receiverId()] = map[string]string{
-			"id": result.task,
-		}
-	}
-	if !c.background {
-		c.progressf(ctx, "")
-	}
-	if numTasks == 0 {
-		ctx.Infof("Operation %s failed to schedule any tasks:\n%s", operationID, strings.Join(enqueueErrs, "\n"))
-		return nil
-	}
-	if len(enqueueErrs) > 0 {
-		ctx.Infof("Some actions could not be scheduled:\n%s\n", strings.Join(enqueueErrs, "\n"))
-		ctx.Infof("")
-	}
-	if c.background {
-		if numTasks == 1 {
-			ctx.Infof("Scheduled operation %s with task %s", operationID, actionID)
-			ctx.Infof("Check operation status with 'juju show-operation %s'", operationID)
-			ctx.Infof("Check task status with 'juju show-task %s'", actionID)
-		} else {
-			ctx.Infof("Scheduled operation %s with %d tasks", operationID, numTasks)
-			_ = cmd.FormatYaml(ctx.Stdout, info)
-			ctx.Infof("Check operation status with 'juju show-operation %s'", operationID)
-			ctx.Infof("Check task status with 'juju show-task <id>'")
-		}
-		return nil
-	}
-	failed, err := c.waitForTasks(ctx, runningTasks, info)
-	if err != nil {
-		return errors.Trace(err)
-	} else if len(failed) > 0 {
-		var plural string
-		if len(failed) > 1 {
-			plural = "s"
-		}
-		list := make([]string, 0, len(failed))
-		for k, v := range failed {
-			list = append(list, fmt.Sprintf(" - id %q with return code %d", k, v))
-		}
-		sort.Strings(list)
-
-		return errors.Errorf(`
-the following task%s failed:
-%s
-
-use 'juju show-task' to inspect the failure%s
-`[1:], plural, strings.Join(list, "\n"), plural)
-	}
-	return nil
-}
-
-func (c *runCommandBase) processOperationResultsWithColor(ctx *cmd.Context, results *actionapi.EnqueuedActions) error {
+func (c *runCommandBase) processOperationResults(ctx *cmd.Context, forceColor bool, results *actionapi.EnqueuedActions) error {
 	var runningTasks []enqueuedAction
 	var enqueueErrs []string
 	for _, a := range results.Actions {
@@ -233,7 +150,11 @@ func (c *runCommandBase) processOperationResultsWithColor(ctx *cmd.Context, resu
 		if numTasks > 1 {
 			plural = "s"
 		}
-		c.progressf(ctx, "Running operation %s with %s task%s", opIDColored, numTasksColored, plural)
+		if forceColor {
+			c.progressf(ctx, "Running operation %s with %s task%s", opIDColored, numTasksColored, plural)
+		} else {
+			c.progressf(ctx, "Running operation %s with %d task%s", operationID, numTasks, plural)
+		}
 	}
 
 	var actionID string
@@ -242,7 +163,11 @@ func (c *runCommandBase) processOperationResultsWithColor(ctx *cmd.Context, resu
 		actionID = result.task
 
 		if !c.background {
-			c.progressf(ctx, "  - task %s on %s", colorVal(output.InfoHighlight, actionID), colorVal(output.EmphasisHighlight.DefaultBold, result.receiver))
+			if forceColor {
+				c.progressf(ctx, "  - task %s on %s", colorVal(output.InfoHighlight, actionID), colorVal(output.EmphasisHighlight.DefaultBold, result.receiver))
+			} else {
+				c.progressf(ctx, "  - task %s on %s", actionID, result.receiver)
+			}
 		}
 		info[result.receiverId()] = map[string]string{
 			"id": result.task,
@@ -252,26 +177,39 @@ func (c *runCommandBase) processOperationResultsWithColor(ctx *cmd.Context, resu
 		c.progressf(ctx, "")
 	}
 	if numTasks == 0 {
-		ctx.Infof("Operation %s failed to schedule any tasks:\n%s", opIDColored, colorVal(output.ErrorHighlight, strings.Join(enqueueErrs, "\n")))
+		if forceColor {
+			ctx.Infof("Operation %s failed to schedule any tasks:\n%s", opIDColored, colorVal(output.ErrorHighlight, strings.Join(enqueueErrs, "\n")))
+		} else {
+			ctx.Infof("Operation %s failed to schedule any tasks:\n%s", operationID, strings.Join(enqueueErrs, "\n"))
+		}
 		return nil
 	}
 	if len(enqueueErrs) > 0 {
-		ctx.Infof("Some actions could not be scheduled:\n%s\n", colorVal(output.ErrorHighlight, strings.Join(enqueueErrs, "\n")))
+		if forceColor {
+			ctx.Infof("Some actions could not be scheduled:\n%s\n", colorVal(output.ErrorHighlight, strings.Join(enqueueErrs, "\n")))
+		} else {
+			ctx.Infof("Some actions could not be scheduled:\n%s\n", strings.Join(enqueueErrs, "\n"))
+		}
 		ctx.Infof("")
 	}
-
-	actionIdColored := colorVal(output.InfoHighlight, actionID)
-
-	if c.background {
+	printInfo := func(opID, actionId, nTasks interface{}) {
 		if numTasks == 1 {
-			ctx.Infof("Scheduled operation %s with task %s", opIDColored, actionIdColored)
-			ctx.Infof("Check operation status with 'juju show-operation %s'", opIDColored)
-			ctx.Infof("Check task status with 'juju show-task %s'", actionIdColored)
+			ctx.Infof("Scheduled operation %s with task %s", opID, actionId)
+			ctx.Infof("Check operation status with 'juju show-operation %s'", opID)
+			ctx.Infof("Check task status with 'juju show-task %s'", actionId)
 		} else {
-			ctx.Infof("Scheduled operation %s with %v tasks", opIDColored, numTasksColored)
+			ctx.Infof("Scheduled operation %s with %v tasks", opID, nTasks)
 			_ = output.FormatYamlWithColor(ctx.Stdout, info)
-			ctx.Infof("Check operation status with 'juju show-operation %s'", opIDColored)
+			ctx.Infof("Check operation status with 'juju show-operation %s'", opID)
 			ctx.Infof("Check task status with 'juju show-task <id>'")
+		}
+	}
+	actionIdColored := colorVal(output.InfoHighlight, actionID)
+	if c.background {
+		if forceColor {
+			printInfo(opIDColored, actionIdColored, numTasksColored)
+		} else {
+			printInfo(operationID, actionID, numTasks)
 		}
 		return nil
 	}
@@ -285,8 +223,11 @@ func (c *runCommandBase) processOperationResultsWithColor(ctx *cmd.Context, resu
 		}
 		list := make([]string, 0, len(failed))
 		for k, v := range failed {
-
-			list = append(list, fmt.Sprintf(" - id %q with return code %v", k, colorVal(output.EmphasisHighlight.Magenta, v)))
+			if forceColor {
+				list = append(list, fmt.Sprintf(" - id %q with return code %v", k, colorVal(output.EmphasisHighlight.Magenta, v)))
+			} else {
+				list = append(list, fmt.Sprintf(" - id %q with return code %d", k, v))
+			}
 		}
 		sort.Strings(list)
 
@@ -426,24 +367,15 @@ func (c *runCommandBase) progressf(ctx *cmd.Context, format string, params ...in
 	}
 }
 
-func (c *runCommandBase) printOutput(writer io.Writer, value interface{}) error {
-	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		return printPlainOutput(writer, value)
+func (c *runCommandBase) printRunOutput(writer io.Writer, value interface{}) error {
+	if c.noColor {
+		if _, ok := os.LookupEnv("NO_COLOR"); !ok {
+			defer os.Unsetenv("NO_COLOR")
+			os.Setenv("NO_COLOR", "")
+		}
 	}
 
-	if c.color {
-		return printColoredOutput(writer, value)
-	}
-
-	if isTerminal(writer) && !c.noColor {
-		return printColoredOutput(writer, value)
-	}
-
-	if !isTerminal(writer) && c.color {
-		return printColoredOutput(writer, value)
-	}
-
-	return printPlainOutput(writer, value)
+	return printPlainOutput(writer, c.color, value)
 }
 
 func (c *runCommandBase) formatYaml(writer io.Writer, value interface{}) error {
@@ -608,10 +540,20 @@ func (a *enqueuedAction) GoString() string {
 // results map for plain output.
 var filteredOutputKeys = set.NewStrings("return-code", "stdout", "stderr", "stdout-encoding", "stderr-encoding")
 
-func printPlainOutput(writer io.Writer, value interface{}) error {
+// invoked by showtask.go
+func printOutput(writer io.Writer, value interface{}) error {
+	return printPlainOutput(writer, false, value)
+}
+
+func printPlainOutput(writer io.Writer, forceColor bool, value interface{}) error {
 	info, ok := value.(map[string]interface{})
 	if !ok {
 		return errors.Errorf("expected value of type %T, got %T", info, value)
+	}
+
+	w := output.PrintWriter{Writer: output.Writer(writer)}
+	if forceColor {
+		w.SetColorCapable(forceColor)
 	}
 
 	// actionOutput contains the action-set data of each action result.
@@ -677,91 +619,7 @@ func printPlainOutput(writer io.Writer, value interface{}) error {
 		return cmd.FormatYaml(writer, actionInfo)
 	}
 	for _, msg := range actionOutput {
-		fmt.Fprintln(writer, msg)
-	}
-	if stdout != "" {
-		fmt.Fprintln(writer, strings.Trim(stdout, "\n"))
-	}
-	if stderr != "" {
-		fmt.Fprintln(writer, strings.Trim(stderr, "\n"))
-	}
-	return nil
-}
-
-func printColoredOutput(writer io.Writer, value interface{}) error {
-	info, ok := value.(map[string]interface{})
-	if !ok {
-		return errors.Errorf("expected value of type %T, got %T", info, value)
-	}
-
-	// actionOutput contains the action-set data of each action result.
-	// If there's only one action result, just that data is printed.
-	var actionOutput = make(map[string]string)
-
-	// actionInfo contains the id and stdout of each action result.
-	// It will be printed if there's more than one action result.
-	var actionInfo = make(map[string]map[string]interface{})
-
-	/*
-		Parse action YAML data that looks like this:
-
-		mysql/0:
-		  id: "1"
-		  results:
-		    <action data here>
-		  status: completed
-	*/
-	var resultMetadata map[string]interface{}
-	var stdout, stderr string
-	for k := range info {
-		resultMetadata, ok = info[k].(map[string]interface{})
-		if !ok {
-			return errors.Errorf("expected value of type %T, got %T", resultMetadata, info[k])
-		}
-		resultData, ok := resultMetadata["results"].(map[string]interface{})
-		if ok {
-			resultDataCopy := make(map[string]interface{})
-			for k, v := range resultData {
-				k = strings.ToLower(k)
-				if k == "stdout" && v != "" {
-					stdout = fmt.Sprint(v)
-				}
-				if k == "stderr" && v != "" {
-					stderr = fmt.Sprint(v)
-				}
-				if !filteredOutputKeys.Contains(k) {
-					resultDataCopy[k] = v
-				}
-			}
-			if len(resultDataCopy) > 0 {
-				data, err := yaml.Marshal(resultDataCopy)
-				if err == nil {
-					actionOutput[k] = string(data)
-				} else {
-					actionOutput[k] = fmt.Sprintf("%v", resultDataCopy)
-				}
-			}
-		} else {
-			status, ok := resultMetadata["status"].(string)
-			if !ok {
-				status = "has unknown status"
-			}
-			actionOutput[k] = fmt.Sprintf("Task %v %v\n", resultMetadata["id"], status)
-		}
-		actionInfo[k] = map[string]interface{}{
-			"id":     resultMetadata["id"],
-			"output": actionOutput[k],
-		}
-	}
-	if len(actionOutput) > 1 {
-		return output.FormatYamlWithColor(writer, actionInfo)
-	}
-
-	w := ansiterm.NewWriter(writer)
-	w.SetColorCapable(true)
-
-	for _, msg := range actionOutput {
-		fmt.Fprintln(w, colorVal(output.GoodHighlight, msg))
+		w.Println(output.GoodHighlight, msg)
 	}
 	if stdout != "" {
 		fmt.Fprintln(writer, strings.Trim(stdout, "\n"))

--- a/cmd/juju/action/exec.go
+++ b/cmd/juju/action/exec.go
@@ -256,5 +256,5 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}
 
-	return c.processOperationResults(ctx, &runResults)
+	return c.operationResults(ctx, &runResults)
 }

--- a/cmd/juju/action/showtask.go
+++ b/cmd/juju/action/showtask.go
@@ -75,7 +75,7 @@ func (c *showTaskCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.out.AddFlags(f, defaultFormatter, map[string]cmd.Formatter{
 		"yaml":  cmd.FormatYaml,
 		"json":  cmd.FormatJson,
-		"plain": printPlainOutput,
+		"plain": printOutput,
 	})
 
 	f.DurationVar(&c.wait, "wait", defaultTaskWait, "Maximum wait time for a task to complete")

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -142,6 +142,26 @@ func StatusColor(status status.Status) *ansiterm.Context {
 	return statusColors[status]
 }
 
+// PrintWriter decorates the ansiterm.Writer object.
+type PrintWriter struct {
+	*ansiterm.Writer
+}
+
+// Print writes each value.
+func (w *PrintWriter) Print(ctx *ansiterm.Context, values ...interface{}) {
+	for _, v := range values {
+		ctx.Fprintf(w, "%v", v)
+	}
+}
+
+// Println writes each value.
+func (w *PrintWriter) Println(ctx *ansiterm.Context, values ...interface{}) {
+	for _, v := range values {
+		ctx.Fprintf(w, "%v", v)
+	}
+	fmt.Fprintln(w)
+}
+
 // CurrentHighlight is the color used to show the current
 // controller, user or model in tabular
 var CurrentHighlight = ansiterm.Foreground(ansiterm.Green)


### PR DESCRIPTION
`Juju run` had multiple repetitions of logic to accomodate coloring output. This was against the DRY principle. This PR intends to clean up and remove repeated logic and consolidate coloring logic in common functions, and abstract where necessary.

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps
```sh
juju deploy juju-qa-test
juju run juju-qa-test/0 fortune 
juju run juju-qa-test/0 fortune --color
watch juju run juju-qa-test/0 fortune
watch --color juju run fortune/0 fortune --color
NO_COLOR="" juju run juju-qa-test/0 fortune --color
NO_COLOR="" juju run juju-qa-test/0 fortune
juju run juju-qa-test/0 fortune | cat
```