### PR TITLE
[JUJU-1461] Ensure that bootstrap starts Mongo service

### DIFF
--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -477,8 +477,10 @@ func (c *BootstrapCommand) startMongo(isCAAS bool, addrs network.ProviderAddress
 		if err != nil {
 			return err
 		}
-		err = cmdutil.EnsureMongoServerInstalled(ensureServerParams)
-		if err != nil {
+		if err := cmdutil.EnsureMongoServerInstalled(ensureServerParams); err != nil {
+			return err
+		}
+		if err := cmdutil.EnsureMongoServerStarted(ensureServerParams.JujuDBSnapChannel); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
It appears that the refactoring done under #14314 broke up the `EnsureServer` method into `EnsureServerInstalled` and `EnsureServerStarted`, but the later was not called.

Log output indicates that we install the Snap and proceed directly to attempting to connect for replica-set initialisation, but without starting the service.
```
2022-07-15 09:49:23 INFO juju.mongo mongo.go:272 Ensuring mongo server is running; data directory /var/snap/juju-db/common; port 37017
2022-07-15 09:49:23 INFO juju.packaging manager.go:103 installing "juju-db" via "snap"
2022-07-15 09:49:23 INFO juju.packaging.manager run.go:88 Running: snap install  --channel 4.4/stable juju-db
2022-07-15 09:49:35 DEBUG juju.mongo mongo.go:399 using mongod: /snap/bin/juju-db.mongod --version:
db version v4.4.11
Build Info: {
    "version": "4.4.11",
    "gitVersion": "b7530cacde8432d2f22ed506f258ff9c3b45c5e9",
    "openSSLVersion": "OpenSSL 1.1.1f  31 Mar 2020",
    "modules": [],
    "allocator": "tcmalloc",
    "environment": {
        "distarch": "x86_64",
        "target_arch": "x86_64"
    }
}

2022-07-15 09:49:35 DEBUG juju.core.network address.go:523 selected "172.31.19.122" as address, using scope "local-cloud"
2022-07-15 09:49:35 DEBUG juju.worker.peergrouper initiate.go:37 Initiating mongo replicaset; dialInfo &mgo.DialInfo{Addrs:[]string{"localhost:37017"}, Direct:false, Timeout:300000000000, FailFast:false, Database:"", ReplicaSetName:"", Source:"", Service:"", ServiceHost:"", Mechanism:"", Username:"", Password:"", PoolLimit:0, DialServer:(func(*mgo.ServerAddr) (net.Conn, error))(0xd3d840), Dial:(func(net.Addr) (net.Conn, error))(nil)}; memberHostport "172.31.19.122:37017"; user ""; password ""
```

This means that bootstrap fails.

Here we ensure that `EnsureServerStarter` is called, and Mongo is available.

## QA steps

Bootstrap.

## Documentation changes

None.

## Bug reference

N/A
