### PR TITLE
[JUJU-1451] exec: print output for multiple units

### DIFF
--- a/cmd/juju/action/common.go
+++ b/cmd/juju/action/common.go
@@ -15,9 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mattn/go-isatty"
-	"gopkg.in/yaml.v2"
-
 	"github.com/juju/ansiterm"
 	"github.com/juju/charm/v9"
 	"github.com/juju/clock"
@@ -25,13 +22,16 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v4"
+	"github.com/mattn/go-isatty"
+	"gopkg.in/yaml.v2"
+
 	actionapi "github.com/juju/juju/api/client/action"
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/juju/core/actions"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/loggo"
-	"github.com/juju/names/v4"
 )
 
 var logger = loggo.GetLogger("juju.cmd.juju.action")
@@ -71,13 +71,18 @@ type runCommandBase struct {
 
 // SetFlags offers an option for YAML output.
 func (c *runCommandBase) SetFlags(f *gnuflag.FlagSet) {
-	c.ActionCommandBase.SetFlags(f)
 	c.out.AddFlags(f, "plain", map[string]cmd.Formatter{
 		"yaml":  c.formatYaml,
 		"json":  c.formatJson,
 		"plain": c.printRunOutput,
 	})
+	c.setNonFormatFlags(f)
+}
 
+// SetNonFormatFlags sets all flags except the format one. This is needed by
+// e.g. exec to define its own formatting flags.
+func (c *runCommandBase) setNonFormatFlags(f *gnuflag.FlagSet) {
+	c.ActionCommandBase.SetFlags(f)
 	f.BoolVar(&c.background, "background", false, "Run the task in the background")
 	f.DurationVar(&c.wait, "wait", 0, "Maximum wait time for a task to complete")
 	f.BoolVar(&c.noColor, "no-color", false, "Disable ANSI color codes in output")


### PR DESCRIPTION
When `juju exec` was run targeting multiple units, only one unit's output would be printed. The plain formatter `printPlainOutput` in `common.go` wasn't suitable for the exec output, and I didn't want to change it since it is used by other commands. Therefore, I've written a new formatter `printExecOutput` which prints the output of `juju exec` correctly. I've also added some unit tests to verify.

## QA steps

Assuming a bootstrapped controller:
```console
$ juju add-model tinybash
$ juju deploy tiny-bash --num-units 3
$ juju exec --application tiny-bash -- hostname
tiny-bash/0:
juju-68972e-0

tiny-bash/1:
juju-68972e-1

tiny-bash/2:
juju-68972e-2

$
```

## Bug reference

This fixes [lp#1980677](https://bugs.launchpad.net/juju/+bug/1980677). 