### PR TITLE
Fix the smoke test

### DIFF
--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -5,7 +5,7 @@ run_local_deploy() {
 
 	ensure "test-local-deploy" "${file}"
 
-	juju deploy ./tests/suites/smoke/charms/ubuntu
+	juju deploy ./tests/suites/smoke/charms/ubuntu --series focal
 	wait_for "ubuntu" "$(idle_condition "ubuntu")" 60 # 60x5s = 5m
 
 	juju refresh ubuntu --path=./tests/suites/smoke/charms/ubuntu

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -6,7 +6,7 @@ run_local_deploy() {
 	ensure "test-local-deploy" "${file}"
 
 	juju deploy ./tests/suites/smoke/charms/ubuntu
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")" 60 # 60x5s = 5m
 
 	juju refresh ubuntu --path=./tests/suites/smoke/charms/ubuntu
 


### PR DESCRIPTION
The smoke test was failing because the `ubuntu` charm is not deploying properly on jammy. This was causing the GitHub smoke tests to run for 6 hours until the GitHub runners timed out.

An obvious first fix is to add a timeout to the test. I have done this in the `wait_for` function - by default this will now time out after 10 minutes, and you can alter the timeout by providing a third argument.

I've also changed the tests to run on focal until we fix the issues with jammy. Those issues seem to be:
- when the charm is deployed on jammy, the machine just stays in a "pending" state and the app/unit is "waiting" forever.
- jammy machines cannot be removed without `--force`.

## QA steps

```console
cd tests
./main.sh -v smoke
```