### PR TITLE
[JUJU-1465] Fixed network-health.sh script

### DIFF
--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -19,8 +19,8 @@ run_network_health() {
 	juju expose network-health-focal
 	juju expose network-health-jammy
 
-	wait_for "ubuntu-focal" "$(idle_condition "ubuntu-focal" 3)"
-	wait_for "ubuntu-jammy" "$(idle_condition "ubuntu-jammy" 4)"
+	wait_for "ubuntu-focal" "$(idle_condition "ubuntu-focal" 2)"
+	wait_for "ubuntu-jammy" "$(idle_condition "ubuntu-jammy" 3)"
 	wait_for "network-health-focal" "$(idle_subordinate_condition "network-health-focal" "ubuntu-focal")"
 	wait_for "network-health-jammy" "$(idle_subordinate_condition "network-health-jammy" "ubuntu-jammy")"
 


### PR DESCRIPTION
The problem was in application indexing. Previously, we used three applications in the test, but after we dropped off xenial, we forgot to fix the indexes. That caused problems.

## Checklist

 - [ ] Comments answer the question of why design decisions were made

## QA steps


```sh
cd tests
./main.sh -v -p aws -c aws network
```

## Documentation changes

None

## Bug reference

None
