### PR TITLE
[JUJU-1466] Filter by model uuid when querying azure instances

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1805,6 +1805,12 @@ func (env *azureEnviron) allQueuedInstances(
 			if controllerOnly && !isControllerDeployment(deployment) {
 				continue
 			}
+			if len(deployment.Tags) == 0 {
+				continue
+			}
+			if toValue(deployment.Tags[tags.JujuModel]) != env.Config().UUID() {
+				continue
+			}
 			provisioningState := armresources.ProvisioningStateCreating
 			switch deployProvisioningState {
 			case armresources.ProvisioningStateFailed,
@@ -1890,6 +1896,12 @@ func (env *azureEnviron) allProvisionedInstances(
 				}
 			}
 			if !isControllerInstance(vm, controllerUUID) {
+				continue
+			}
+			if len(vm.Tags) == 0 {
+				continue
+			}
+			if toValue(vm.Tags[tags.JujuModel]) != env.Config().UUID() {
 				continue
 			}
 			inst := &azureInstance{

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -232,6 +232,9 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 		Properties: &armresources.DeploymentPropertiesExtended{
 			ProvisioningState: to.Ptr(armresources.ProvisioningStateSucceeded),
 		},
+		Tags: map[string]*string{
+			"juju-model-uuid": to.Ptr(testing.ModelTag.Id()),
+		},
 	}
 
 	s.deployment = nil

--- a/provider/azure/instance_test.go
+++ b/provider/azure/instance_test.go
@@ -71,7 +71,8 @@ func (s *instanceSuite) SetUpTest(c *gc.C) {
 	s.vms = []*armcompute.VirtualMachine{{
 		Name: to.Ptr("machine-0"),
 		Tags: map[string]*string{
-			"juju-controller-uuid": to.Ptr("foo"),
+			"juju-controller-uuid": to.Ptr(testing.ControllerTag.Id()),
+			"juju-model-uuid":      to.Ptr(testing.ModelTag.Id()),
 			"juju-is-controller":   to.Ptr("true"),
 		},
 		Properties: &armcompute.VirtualMachineProperties{
@@ -100,6 +101,9 @@ func makeDeployment(name string, provisioningState armresources.ProvisioningStat
 		Properties: &armresources.DeploymentPropertiesExtended{
 			ProvisioningState: to.Ptr(provisioningState),
 			Dependencies:      dependencies,
+		},
+		Tags: map[string]*string{
+			"juju-model-uuid": to.Ptr(testing.ModelTag.Id()),
 		},
 	}
 }
@@ -648,7 +652,7 @@ func (s *instanceSuite) TestAllRunningInstances(c *gc.C) {
 func (s *instanceSuite) TestControllerInstancesSomePending(c *gc.C) {
 	*((s.deployments[1].Properties.Dependencies)[0].DependsOn)[0].ResourceName = "juju-controller"
 	s.sender = s.getInstancesSender()
-	ids, err := s.env.ControllerInstances(s.callCtx, "foo")
+	ids, err := s.env.ControllerInstances(s.callCtx, testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ids, gc.HasLen, 2)
 	c.Assert(ids[0], gc.Equals, instance.Id("machine-0"))
@@ -657,7 +661,7 @@ func (s *instanceSuite) TestControllerInstancesSomePending(c *gc.C) {
 
 func (s *instanceSuite) TestControllerInstances(c *gc.C) {
 	s.sender = s.getInstancesSender()
-	ids, err := s.env.ControllerInstances(s.callCtx, "foo")
+	ids, err := s.env.ControllerInstances(s.callCtx, testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ids, gc.HasLen, 1)
 	c.Assert(ids[0], gc.Equals, instance.Id("machine-0"))


### PR DESCRIPTION
When querying vm instances created by juju, there was no filtering being done to ensure the instances were tagged with the model uuid. This meant that instances not created by juju were being included in the result. Other providers like Openstack and Oracle include this filter so Azure provider should too.

## QA steps

```
RG_NAME=JujuController
LOCATION=westeurope
az group create --location $LOCATION --name $RG_NAME
az vm create --name bootstrap-vm --resource-group $RG_NAME --location $LOCATION --image $(az vm image list --all --publisher Canonical --sku "18_04-lts" | jq 'max_by(.version) | .urn' | tr -d '"') --size Standard_DS2_v2 --ssh-key-values "~/.ssh/id_rsa.pub" --admin-username azureuser  --public-ip-sku Standard
juju bootstrap azure/westeurope --config resource-group-name=JujuController --no-default-model
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1979557