### PR TITLE
Juju 1469 clean up juju status oneline format coloring

### DIFF
--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -6,41 +6,18 @@ package status
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"sort"
-	"strconv"
-	"strings"
-
 	"github.com/juju/ansiterm"
 	"github.com/juju/errors"
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/naturalsort"
+	"io"
 )
 
 // FormatOneline writes a brief list of units and their subordinates.
 // Subordinates will be indented 2 spaces and listed under their
 // superiors. This format works with version 2 of the CLI.
-func FormatOneline(writer io.Writer, value interface{}) error {
-	return formatOneline(writer, value, func(out io.Writer, format, uName string, u unitStatus, level int) {
-		status := fmt.Sprintf(
-			"agent:%s, workload:%s",
-			u.JujuStatusInfo.Current,
-			u.WorkloadStatusInfo.Current,
-		)
-		fmt.Fprintf(out, format,
-			uName,
-			u.PublicAddress,
-			status,
-		)
-	})
-}
-
-// FormatOnelineWithColor appends ansi color codes to a brief list of units and their subordinates.
-// Subordinates will be indented 2 spaces and listed under their
-// superiors. This format works with version 2 of the CLI.
-func FormatOnelineWithColor(writer io.Writer, forceColor bool, value interface{}) error {
-	return formatOnelineWithColor(writer, value, func(out io.Writer, format, uName string, u unitStatus, level int) {
-
+func FormatOneline(writer io.Writer, forceColor bool, value interface{}) error {
+	return formatOneline(writer, forceColor, value, func(out io.Writer, format, uName string, u unitStatus, level int) {
 		agentColored := colorVal(output.EmphasisHighlight.DefaultBold, "agent")
 		statusInfoColored := colorVal(output.StatusColor(u.JujuStatusInfo.Current), u.JujuStatusInfo.Current)
 		workloadColored := colorVal(output.EmphasisHighlight.DefaultBold, "workload")
@@ -54,187 +31,55 @@ func FormatOnelineWithColor(writer io.Writer, forceColor bool, value interface{}
 		if forceColor {
 			statusColored := fmt.Sprintf(
 				"%s:%s, %s:%s", agentColored, statusInfoColored, workloadColored, workloadStatusInfoColored)
-
 			fPrintf(out, format, uName, publicAddressColored, statusColored)
 		} else {
 			status := fmt.Sprintf(
-				"%s:%s, %s:%s",
-				"agent",
+				"agent:%s, workload:%s",
 				u.JujuStatusInfo.Current,
-				"workload",
 				u.WorkloadStatusInfo.Current,
 			)
-
-			fPrintf(out, format, uName, u.PublicAddress, status)
+			fmt.Fprintf(out, format,
+				uName,
+				u.PublicAddress,
+				status,
+			)
 		}
 	})
 }
 
 type onelinePrintf func(out io.Writer, format, uName string, u unitStatus, level int)
 
-func formatOneline(writer io.Writer, value interface{}, printf onelinePrintf) error {
+func formatOneline(writer io.Writer, forceColor bool, value interface{}, printf onelinePrintf) error {
 	fs, valueConverted := value.(formattedStatus)
 	if !valueConverted {
 		return errors.Errorf("expected value of type %T, got %T", fs, value)
 	}
 
+	pw := &output.PrintWriter{Writer: output.Writer(writer)}
+	pw.SetColorCapable(forceColor)
 	pprint := func(uName string, u unitStatus, level int) {
-		var fmtPorts string
-		if len(u.OpenedPorts) > 0 {
-			fmtPorts = fmt.Sprintf(" %s", strings.Join(u.OpenedPorts, ", "))
-		}
-		format := indent("\n", level*2, "- %s: %s (%v)"+fmtPorts)
-		printf(writer, format, uName, u, level)
-	}
-
-	for _, svcName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
-		svc := fs.Applications[svcName]
-		for _, uName := range naturalsort.Sort(stringKeysFromMap(svc.Units)) {
-			unit := svc.Units[uName]
-			pprint(uName, unit, 0)
-			recurseUnits(unit, 1, pprint)
-		}
-	}
-
-	return nil
-}
-
-func formatOnelineWithColor(writer io.Writer, value interface{}, printf onelinePrintf) error {
-	fs, valueConverted := value.(formattedStatus)
-	if !valueConverted {
-		return errors.Errorf("expected value of type %T, got %T", fs, value)
-	}
-
-	pprint := func(uName string, u unitStatus, level int) {
-		var fmtPorts string
-		if len(u.OpenedPorts) > 0 {
-			fmtPorts = fmt.Sprintf(" %s", colorPorts(u.OpenedPorts))
-		}
-		format := indent("\n", level*2, "- %s: %s (%v)"+fmtPorts)
-		printf(writer, format, colorVal(output.GoodHighlight, uName), u, level)
-	}
-
-	for _, svcName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
-		svc := fs.Applications[svcName]
-		for _, uName := range naturalsort.Sort(stringKeysFromMap(svc.Units)) {
-			unit := svc.Units[uName]
-			pprint(uName, unit, 0)
-			recurseUnits(unit, 1, pprint)
-		}
-	}
-
-	return nil
-}
-
-func colorPorts(ps []string) string {
-	buff := &bytes.Buffer{}
-	sorted := append([]string(nil), ps...)
-	sort.Strings(sorted)
-
-	protocols := map[string]*protocol{}
-	proto := func(p string) *protocol {
-		v, ok := protocols[p]
-		if !ok {
-			v = &protocol{
-				group:      map[string]string{},
-				groups:     map[string][]string{},
-				grouped:    map[string]bool{},
-				components: map[string][]string{},
-			}
-			protocols[p] = v
-		}
-		return v
-	}
-
-	for _, port := range sorted {
-		split := strings.Split(port, "/")
-		protocolId := ""
-		if len(split) == 1 {
-			protocolId = split[0]
+		format := indent("\n", level*2, "- %s: %s (%v)")
+		if forceColor {
+			printf(writer, format, colorVal(output.GoodHighlight, uName), u, level)
 		} else {
-			protocolId = strings.Join(append([]string{""}, split[1:]...), "/")
+			printf(writer, format, uName, u, level)
 		}
-		protocol := proto(protocolId)
-		protocol.components[port] = split
-		if len(split) == 1 {
-			continue
+		if len(u.OpenedPorts) > 0 {
+			fmt.Fprint(pw, " (")
+			printPorts(pw, u.OpenedPorts)
+			fmt.Fprint(pw, ") ")
 		}
-		n, err := strconv.Atoi(split[0])
-		if err != nil || n <= 1 {
-			continue
-		}
-		prev := strings.Join(append([]string{strconv.Itoa(n - 1)}, split[1:]...), "/")
-		if _, ok := protocol.components[prev]; !ok {
-			continue
-		}
-		groupName := protocol.group[prev]
-		if groupName == "" {
-			groupName = prev
-		}
-		protocol.group[port] = groupName
-		protocol.groups[groupName] = append(protocol.groups[groupName], port)
-		protocol.grouped[port] = true
 	}
-
-	protocolKeys := []string{}
-	for k := range protocols {
-		protocolKeys = append(protocolKeys, k)
-	}
-	sort.Strings(protocolKeys)
-
-	hasOutput := false
-	for _, pk := range protocolKeys {
-		protocol := protocols[pk]
-
-		portKeys := []string{}
-		for k := range protocol.components {
-			portKeys = append(portKeys, k)
-		}
-		sort.Sort(sortablePorts(portKeys))
-
-		hasPrev := false
-		for _, port := range portKeys {
-			if protocol.grouped[port] {
-				continue
-			}
-			if hasOutput {
-				hasOutput = false
-				buff.WriteString(" ")
-			}
-			if hasPrev {
-				buff.WriteString(",")
-			}
-			hasPrev = true
-			split := protocol.components[port]
-			group := protocol.groups[port]
-			// color grouped ports.
-			if len(group) > 0 {
-				last := group[len(group)-1]
-				lastSplit := protocol.components[last]
-				portRange := fmt.Sprintf("%s-%s", split[0], lastSplit[0])
-				buff.WriteString(colorVal(output.EmphasisHighlight.BrightMagenta, portRange))
-				continue
-			}
-			// color single port with protocol.
-			if len(split) > 1 {
-				buff.WriteString(colorVal(output.EmphasisHighlight.BrightMagenta, split[0]))
-				continue
-			}
-			// Everything else.
-			break
-		}
-		if hasPrev {
-			hasOutput = true
-			if _, err := strconv.Atoi(pk); err == nil {
-				buff.WriteString(colorVal(output.EmphasisHighlight.BrightMagenta, pk))
-			} else {
-				buff.WriteString(pk)
-			}
+	for _, svcName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {
+		svc := fs.Applications[svcName]
+		for _, uName := range naturalsort.Sort(stringKeysFromMap(svc.Units)) {
+			unit := svc.Units[uName]
+			pprint(uName, unit, 0)
+			recurseUnits(unit, 1, pprint)
 		}
 	}
 
-	buff.WriteString("")
-	return buff.String()
+	return nil
 }
 
 //colorVal appends ansi color codes to the given value

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -6,11 +6,12 @@ package status
 import (
 	"bytes"
 	"fmt"
+	"io"
+
 	"github.com/juju/ansiterm"
 	"github.com/juju/errors"
 	"github.com/juju/juju/cmd/output"
 	"github.com/juju/naturalsort"
-	"io"
 )
 
 // FormatOneline writes a brief list of units and their subordinates.

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -40,10 +40,6 @@ func FormatOneline(writer io.Writer, value interface{}) error {
 // superiors. This format works with version 2 of the CLI.
 func FormatOnelineWithColor(writer io.Writer, forceColor bool, value interface{}) error {
 	return formatOnelineWithColor(writer, value, func(out io.Writer, format, uName string, u unitStatus, level int) {
-		w := output.Writer(writer)
-		if forceColor {
-			w.SetColorCapable(forceColor)
-		}
 
 		agentColored := colorVal(output.EmphasisHighlight.DefaultBold, "agent")
 		statusInfoColored := colorVal(output.StatusColor(u.JujuStatusInfo.Current), u.JujuStatusInfo.Current)
@@ -71,13 +67,6 @@ func FormatOnelineWithColor(writer io.Writer, forceColor bool, value interface{}
 
 			fPrintf(out, format, uName, u.PublicAddress, status)
 		}
-
-		//
-		//fmt.Fprintf(out, format,
-		//	uName,
-		//	colorVal(output.InfoHighlight, u.PublicAddress),
-		//	status,
-		//)
 	})
 }
 

--- a/cmd/juju/status/output_oneline.go
+++ b/cmd/juju/status/output_oneline.go
@@ -66,9 +66,8 @@ func formatOneline(writer io.Writer, forceColor bool, value interface{}, printf 
 			printf(writer, format, uName, u, level)
 		}
 		if len(u.OpenedPorts) > 0 {
-			fmt.Fprint(pw, " (")
+			fmt.Fprintf(pw, " ")
 			printPorts(pw, u.OpenedPorts)
-			fmt.Fprint(pw, ") ")
 		}
 	}
 	for _, svcName := range naturalsort.Sort(stringKeysFromMap(fs.Applications)) {

--- a/cmd/juju/status/output_summary.go
+++ b/cmd/juju/status/output_summary.go
@@ -115,7 +115,7 @@ func newSummaryFormatter(writer io.Writer, forceColor bool) *summaryFormatter {
 		openPorts:   set.NewStrings(),
 		stateToUnit: make(map[status.Status]int),
 	}
-	f.tw = output.Wrapper{TabWriter: w}
+	f.tw = &output.Wrapper{TabWriter: w}
 	return f
 }
 
@@ -126,7 +126,7 @@ type summaryFormatter struct {
 	openPorts  set.Strings
 	// status -> count
 	stateToUnit map[status.Status]int
-	tw          output.Wrapper
+	tw          *output.Wrapper
 }
 
 func (f *summaryFormatter) delimitKeysWithTabs(ctx *ansiterm.Context, values ...string) {
@@ -135,10 +135,18 @@ func (f *summaryFormatter) delimitKeysWithTabs(ctx *ansiterm.Context, values ...
 		if strings.Contains(v, ":") {
 			splitted := strings.Split(v, ":")
 			str := splitted[i]
-			ctx.Fprintf(f.tw, "%s", str)
+			if ctx != nil {
+				ctx.Fprintf(f.tw, "%s", str)
+			} else {
+				fmt.Fprintf(f.tw, "%s", str)
+			}
 			cCtx.Fprintf(f.tw, "%s\t", ":")
 		} else {
-			ctx.Fprintf(f.tw, "%s\t", v)
+			if ctx != nil {
+				ctx.Fprintf(f.tw, "%s\t", v)
+			} else {
+				fmt.Fprintf(f.tw, "%s\t", v)
+			}
 		}
 	}
 	fmt.Fprint(f.tw)
@@ -150,10 +158,18 @@ func (f *summaryFormatter) delimitValuesWithTabs(ctx *ansiterm.Context, values .
 		if strings.HasPrefix(val, "(") && strings.HasSuffix(val, ")") {
 			val = strings.Split(strings.Split(val, "(")[1], ")")[0]
 			fmt.Fprint(f.tw, "(")
-			ctx.Fprintf(f.tw, "%s", val)
+			if ctx != nil {
+				ctx.Fprintf(f.tw, "%s", val)
+			} else {
+				fmt.Fprintf(f.tw, "%s", val)
+			}
 			fmt.Fprint(f.tw, ")\t")
 		} else {
-			ctx.Fprintf(f.tw, "%s\t", v)
+			if ctx != nil {
+				ctx.Fprintf(f.tw, "%s\t", v)
+			} else {
+				fmt.Fprintf(f.tw, "%s\t", v)
+			}
 		}
 	}
 	fmt.Fprintln(f.tw)

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -120,8 +120,8 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 	return nil
 }
 
-func startSection(tw *ansiterm.TabWriter, top bool, headers ...interface{}) output.Wrapper {
-	w := output.Wrapper{TabWriter: tw}
+func startSection(tw *ansiterm.TabWriter, top bool, headers ...interface{}) *output.Wrapper {
+	w := &output.Wrapper{TabWriter: tw}
 	if !top {
 		w.Println()
 	}
@@ -143,7 +143,7 @@ func printApplications(tw *ansiterm.TabWriter, fs formattedStatus) {
 
 	metering := fs.Model.MeterStatus != nil
 	units := make(map[string]unitStatus)
-	var w output.Wrapper
+	var w *output.Wrapper
 	if fs.Model.Type == caasModelType {
 		w = startSection(tw, false, "App", "Version", "Status", "Scale", "Charm", "Channel", "Rev", "Address", "Exposed", "Message")
 	} else {
@@ -344,7 +344,13 @@ func (s sortablePorts) Swap(i, j int) {
 	s[j] = t
 }
 
-func printPorts(w output.Wrapper, ps []string) {
+type OutputWriter interface {
+	Print(values ...interface{})
+	PrintNoTab(values ...interface{})
+	PrintColorNoTab(ctx *ansiterm.Context, value interface{})
+}
+
+func printPorts(w OutputWriter, ps []string) {
 	sorted := append([]string(nil), ps...)
 	sort.Strings(sorted)
 
@@ -589,7 +595,7 @@ func printMachines(tw *ansiterm.TabWriter, standAlone bool, machines map[string]
 	endSection(tw)
 }
 
-func printMachine(w output.Wrapper, m machineStatus) {
+func printMachine(w *output.Wrapper, m machineStatus) {
 	// We want to display availability zone so extract from hardware info".
 	hw, err := instance.ParseHardware(m.Hardware)
 	if err != nil {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -458,27 +458,23 @@ func (c *statusCommand) formatYaml(writer io.Writer, value interface{}) error {
 }
 
 func (c *statusCommand) formatOneline(writer io.Writer, value interface{}) error {
-	//if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-	//	return FormatOneline(writer, value)
-	//}
-	//// NO_COLOR="" and --color=true
-	if c.color {
-		return FormatOnelineWithColor(writer, c.color, value)
+	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
+		return FormatOneline(writer, false, value)
 	}
 
-	if c.noColor {
-		return FormatOnelineWithColor(writer, !c.noColor, value)
+	if c.color {
+		return FormatOneline(writer, c.color, value)
 	}
-	//
-	//if isTerminal(writer) && !c.noColor {
-	//	return FormatOnelineWithColor(writer, value)
-	//}
-	//
-	//if !isTerminal(writer) && c.color {
-	//	return FormatOnelineWithColor(writer, value)
-	//}
-	//
-	return FormatOnelineWithColor(writer, true, value)
+
+	if isTerminal(writer) && !c.noColor {
+		return FormatOneline(writer, true, value)
+	}
+
+	if !isTerminal(writer) && c.color {
+		return FormatOneline(writer, true, value)
+	}
+
+	return FormatOneline(writer, false, value)
 }
 
 func (c *statusCommand) formatJson(writer io.Writer, value interface{}) error {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -458,23 +458,27 @@ func (c *statusCommand) formatYaml(writer io.Writer, value interface{}) error {
 }
 
 func (c *statusCommand) formatOneline(writer io.Writer, value interface{}) error {
-	if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
-		return FormatOneline(writer, value)
-	}
-	// NO_COLOR="" and --color=true
+	//if _, ok := os.LookupEnv("NO_COLOR"); (ok || os.Getenv("TERM") == "dumb") && !c.color || c.noColor {
+	//	return FormatOneline(writer, value)
+	//}
+	//// NO_COLOR="" and --color=true
 	if c.color {
-		return FormatOnelineWithColor(writer, value)
+		return FormatOnelineWithColor(writer, c.color, value)
 	}
 
-	if isTerminal(writer) && !c.noColor {
-		return FormatOnelineWithColor(writer, value)
+	if c.noColor {
+		return FormatOnelineWithColor(writer, !c.noColor, value)
 	}
-
-	if !isTerminal(writer) && c.color {
-		return FormatOnelineWithColor(writer, value)
-	}
-
-	return FormatOneline(writer, value)
+	//
+	//if isTerminal(writer) && !c.noColor {
+	//	return FormatOnelineWithColor(writer, value)
+	//}
+	//
+	//if !isTerminal(writer) && c.color {
+	//	return FormatOnelineWithColor(writer, value)
+	//}
+	//
+	return FormatOnelineWithColor(writer, true, value)
 }
 
 func (c *statusCommand) formatJson(writer io.Writer, value interface{}) error {

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -120,7 +120,7 @@ func (w *Wrapper) PrintColorNoTab(ctx *ansiterm.Context, value interface{}) {
 	}
 }
 
-// PrintHeaders writes out many tab separated values in the color context specificed.
+// PrintHeaders writes out many tab separated values in the color context specified.
 func (w *Wrapper) PrintHeaders(ctx *ansiterm.Context, values ...interface{}) {
 	for i, v := range values {
 		if i != len(values)-1 {
@@ -150,10 +150,14 @@ type PrintWriter struct {
 	*ansiterm.Writer
 }
 
-// Print writes each value.
-func (w *PrintWriter) Print(ctx *ansiterm.Context, values ...interface{}) {
+// Printf writes each value.
+func (w *PrintWriter) Printf(ctx *ansiterm.Context, format string, values ...interface{}) {
 	for _, v := range values {
-		ctx.Fprintf(w, "%v", v)
+		if ctx != nil {
+			ctx.Fprintf(w, format, v) //if ctx != nil {"%v" =format
+		} else {
+			fmt.Fprintf(w, format, v)
+		}
 	}
 }
 
@@ -163,6 +167,21 @@ func (w *PrintWriter) Println(ctx *ansiterm.Context, values ...interface{}) {
 		ctx.Fprintf(w, "%v", v)
 	}
 	fmt.Fprintln(w)
+}
+
+// Print empty tab after values
+func (w *PrintWriter) Print(values ...interface{}) {
+	w.Printf(CurrentHighlight, "%v", values...)
+}
+
+// PrintNoTab prints values without a tab delimiter
+func (w *PrintWriter) PrintNoTab(values ...interface{}) {
+	w.Printf(CurrentHighlight, "%v", values...)
+}
+
+// PrintColorNoTab writes the value out in the color context specified.
+func (w *PrintWriter) PrintColorNoTab(ctx *ansiterm.Context, value interface{}) {
+	w.Printf(ctx, "%v", value)
 }
 
 // CurrentHighlight is the color used to show the current


### PR DESCRIPTION
This PR cleans up repeat logic and consolidate coloring logic in common functions for juju status **oneline** format.

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - ~[ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - ~[ ] Comments answer the question of why design decisions were made~

## QA steps
```sh
juju deploy prometheus2
juju deploy postgresql
juju deploy telegraf
juju add-relation postgresql:db-admin telegraf
juju status --format=oneline
juju status --format=oneline --color
watch juju status --format=oneline
watch --color juju status --format=oneline --color
NO_COLOR="" juju status --format=oneline--color
NO_COLOR="" juju status --format=oneline
juju status --format=oneline | cat
```
*Replace format with each of the respective formats; `--format=line` ,`--format=short`*