### PR TITLE
Make charmhub download test use postgresql as mysql doesn't have stable

### DIFF
--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -6,11 +6,11 @@ run_charmhub_download() {
 
 	ensure "test-${name}" "${file}"
 
-	output=$(juju download mysql --series focal --filepath="${TEST_DIR}/mysql.charm" 2>&1 || true)
-	check_contains "${output}" 'Fetching charm "mysql"'
+	output=$(juju download postgresql --series focal --filepath="${TEST_DIR}/postgresql.charm" 2>&1 || true)
+	check_contains "${output}" 'Fetching charm "postgresql"'
 
-	juju deploy "${TEST_DIR}/mysql.charm" mysql
-	juju wait-for application --timeout=15m mysql
+	juju deploy "${TEST_DIR}/postgresql.charm" postgresql
+	juju wait-for application --timeout=15m postgresql
 }
 
 run_charmstore_download() {


### PR DESCRIPTION
Previous error was:

14:30:38 ERROR "mysql" has no releases in channel "stable". Type
14:30:38     juju info mysql
14:30:38 for a list of supported channels.

https://jenkins.juju.canonical.com/job/test-charmhub-test-charmhub-download-lxd/154/console
