### PR TITLE
[JUJU-1468] Fixed test agents lxd

### DIFF
--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -46,7 +46,7 @@ test_charmrevisionupdater() {
 
 		cd .. || exit
 
-		run "run_charmstore_charmrevisionupdater"
 		run "run_charmhub_charmrevisionupdater"
+		run "run_charmstore_charmrevisionupdater"
 	)
 }

--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -1,22 +1,3 @@
-run_charmstore_charmrevisionupdater() {
-	# Echo out to ensure nice output to the test suite.
-	echo
-
-	model_name="test-cs-charmrevisionupdater"
-	file="${TEST_DIR}/${model_name}.log"
-
-	ensure "${model_name}" "${file}"
-
-	# Deploy an old revision of mysql
-	juju deploy cs:mysql-55
-
-	# Wait for revision update worker to update the available revision.
-	# eg can-upgrade-to: cs:mysql-58
-	wait_for "cs:mysql-" '.applications["mysql"] | ."can-upgrade-to"'
-
-	destroy_model "${model_name}"
-}
-
 run_charmhub_charmrevisionupdater() {
 	# Echo out to ensure nice output to the test suite.
 	echo
@@ -48,6 +29,5 @@ test_charmrevisionupdater() {
 		cd .. || exit
 
 		run "run_charmhub_charmrevisionupdater"
-		run "run_charmstore_charmrevisionupdater"
 	)
 }

--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -1,3 +1,21 @@
+run_charmstore_charmrevisionupdater() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	model_name="test-cs-charmrevisionupdater"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	# Deploy an old revision of mysql
+	juju deploy cs:postgresql-230
+
+	# Wait for revision update worker to update the available revision.
+	wait_for "cs:postgresql-" '.applications["postgresql"] | ."can-upgrade-to"'
+
+	destroy_model "${model_name}"
+}
+
 run_charmhub_charmrevisionupdater() {
 	# Echo out to ensure nice output to the test suite.
 	echo
@@ -28,6 +46,7 @@ test_charmrevisionupdater() {
 
 		cd .. || exit
 
+		run "run_charmstore_charmrevisionupdater"
 		run "run_charmhub_charmrevisionupdater"
 	)
 }


### PR DESCRIPTION
Dropped the charmstore test, which used the old MySQL charm. There is no need to force MySQL charm to switch to another channel because we have yet another test for charmhub in the same suite.

## Checklist

 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p lxd -c lxd agents
```

## Documentation changes

None

## Bug reference

None
