### PR TITLE
Force focal for cli block integration tests

### DIFF
--- a/tests/suites/cli/block.sh
+++ b/tests/suites/cli/block.sh
@@ -23,7 +23,7 @@ run_block_remove_object() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy ubuntu
+	juju deploy ubuntu --series focal
 	juju deploy ntp
 	juju add-relation ntp ubuntu
 
@@ -56,7 +56,7 @@ run_block_all() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy ubuntu
+	juju deploy ubuntu --series focal
 	juju expose ubuntu
 
 	juju disable-command all


### PR DESCRIPTION
This is because the ntp charm is currently broken on Jammy

## Checklist

 - ~[ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 - [x] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR
 - ~[ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
BOOTSTRAP_PROVIDR=lxd BOOTSTREAP_CLOUD=lxd ./main.sh -v cli test_block_commands -s '"test_display_clouds,test_local_charms,test_model_config,test_model_defaults"'
```
