### PR TITLE
More unit charm url work

### DIFF
--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -54,7 +54,7 @@ type Unit interface {
 	Application() (Application, error)
 	PrincipalName() (string, bool)
 	AssignedMachineId() (string, error)
-	CharmURL() (*charm.URL, error)
+	CharmURL() *string
 }
 
 // Charm represents point of use methods from the state Charm object.

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
@@ -91,8 +91,8 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherProfile(c *gc.C) {
 	defer workertest.CleanKill(c, s.assertStartLxdProfileWatcher(c))
 
 	s.setupPrincipalUnit()
-	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, nil)
+	curlStr := "ch:name-me"
+	s.unit.EXPECT().CharmURL().Return(&curlStr)
 	s.unitChanges <- []string{"foo/0"}
 	s.wc0.AssertOneChange()
 }
@@ -151,8 +151,8 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherAddUnit(c *gc.C) {
 	s.unit.EXPECT().Life().Return(state.Alive)
 	s.unit.EXPECT().PrincipalName().Return("", false)
 	s.unit.EXPECT().AssignedMachineId().Return("0", nil)
-	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, nil)
+	curlStr := "ch:name-me"
+	s.unit.EXPECT().CharmURL().Return(&curlStr)
 	s.unitChanges <- []string{"bar/0"}
 	s.wc0.AssertOneChange()
 }
@@ -194,8 +194,8 @@ func (s *lxdProfileWatcherSuite) assertAddSubordinate() {
 	s.unit.EXPECT().PrincipalName().Return("principal/0", true)
 	s.unit.EXPECT().AssignedMachineId().Return("0", nil)
 
-	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, nil)
+	curlStr := "ch:name-me"
+	s.unit.EXPECT().CharmURL().Return(&curlStr)
 	s.unitChanges <- []string{"foo/0"}
 }
 
@@ -290,8 +290,8 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherRemoveOnlyUnit(c *g
 	s.wc0.AssertNoChange()
 
 	s.setupPrincipalUnit()
-	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, nil)
+	curlStr := "ch:name-me"
+	s.unit.EXPECT().CharmURL().Return(&curlStr)
 	s.unitChanges <- []string{"foo/0"}
 	s.wc0.AssertOneChange()
 
@@ -346,7 +346,7 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherUnitChangeAppNotFou
 	s.machine0.EXPECT().Units().Return(nil, nil)
 
 	s.setupPrincipalUnit()
-	s.unit.EXPECT().CharmURL().Return(nil, nil)
+	s.unit.EXPECT().CharmURL().Return(nil)
 	s.unit.EXPECT().Application().Return(nil, errors.NotFoundf(""))
 
 	defer workertest.CleanKill(c, s.assertStartLxdProfileWatcher(c))
@@ -363,8 +363,9 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherUnitChangeCharmURLN
 	s.machine0.EXPECT().Units().Return(nil, nil)
 
 	s.setupPrincipalUnit()
-	curl := charm.MustParseURL("ch:name-me")
-	s.unit.EXPECT().CharmURL().Return(curl, nil)
+	curlStr := "ch:name-me"
+	s.unit.EXPECT().CharmURL().Return(&curlStr)
+	curl := charm.MustParseURL(curlStr)
 	s.state.EXPECT().Charm(curl).Return(nil, errors.NotFoundf(""))
 
 	defer workertest.CleanKill(c, s.assertStartLxdProfileWatcher(c))

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -489,12 +489,11 @@ func (mr *MockUnitMockRecorder) AssignedMachineId() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockUnit) CharmURL() (*charm.URL, error) {
+func (m *MockUnit) CharmURL() *string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
-	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*string)
+	return ret0
 }
 
 // CharmURL indicates an expected call of CharmURL.

--- a/apiserver/facades/agent/metricsender/sender_test.go
+++ b/apiserver/facades/agent/metricsender/sender_test.go
@@ -56,7 +56,8 @@ var _ metricsender.MetricSender = (*metricsender.HTTPSender)(nil)
 // is in use metrics get sent
 func (s *SenderSuite) TestHTTPSender(c *gc.C) {
 	metricCount := 3
-	expectedCharmURL, _ := s.unit.CharmURL()
+	expectedCharmURL := s.unit.CharmURL()
+	c.Assert(expectedCharmURL, gc.NotNil)
 
 	receiverChan := make(chan wireformat.MetricBatch, metricCount)
 	cleanup := s.startServer(c, testHandler(c, receiverChan, nil, 0))
@@ -74,7 +75,7 @@ func (s *SenderSuite) TestHTTPSender(c *gc.C) {
 	c.Assert(receiverChan, gc.HasLen, metricCount)
 	close(receiverChan)
 	for batch := range receiverChan {
-		c.Assert(batch.CharmUrl, gc.Equals, expectedCharmURL.String())
+		c.Assert(batch.CharmUrl, gc.Equals, *expectedCharmURL)
 	}
 
 	for _, metric := range metrics {

--- a/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/mocks/newlxdprofile.go
@@ -234,12 +234,11 @@ func (mr *MockLXDProfileUnitV2MockRecorder) AssignedMachineId() *gomock.Call {
 }
 
 // CharmURL mocks base method.
-func (m *MockLXDProfileUnitV2) CharmURL() (*charm.URL, error) {
+func (m *MockLXDProfileUnitV2) CharmURL() *string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CharmURL")
-	ret0, _ := ret[0].(*charm.URL)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*string)
+	return ret0
 }
 
 // CharmURL indicates an expected call of CharmURL.

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -47,7 +47,7 @@ type LXDProfileMachineV2 interface {
 type LXDProfileUnitV2 interface {
 	ApplicationName() string
 	AssignedMachineId() (string, error)
-	CharmURL() (*charm.URL, error)
+	CharmURL() *string
 	Name() string
 	Tag() names.Tag
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -692,19 +692,14 @@ func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, er
 			var unitOrApplication state.Entity
 			unitOrApplication, err = u.st.FindEntity(tag)
 			if err == nil {
-				// TODO (hmlanigan) 2022-06-08
-				// cURL can be a string pointer once unit.CharmURL()
-				// returns a string pointer as well.
-				var cURL *charm.URL
+				var cURL *string
 				var force bool
 
 				switch entity := unitOrApplication.(type) {
 				case *state.Application:
-					var cURLStr *string
-					cURLStr, force = entity.CharmURL()
-					cURL, err = charm.ParseURL(*cURLStr)
+					cURL, force = entity.CharmURL()
 				case *state.Unit:
-					cURL, err = entity.CharmURL()
+					cURL = entity.CharmURL()
 					// The force value is not actually used on the uniter's unit api.
 					if cURL != nil {
 						force = true
@@ -712,7 +707,7 @@ func (u *UniterAPI) CharmURL(args params.Entities) (params.StringBoolResults, er
 				}
 
 				if cURL != nil {
-					result.Results[i].Result = cURL.String()
+					result.Results[i].Result = *cURL
 					result.Results[i].Ok = force
 				}
 			}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -875,9 +875,9 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 	// Set wordpressUnit's charm URL first.
 	err := s.wordpressUnit.SetCharmURL(s.wpCharm.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	curl, err := s.wordpressUnit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(curl, gc.DeepEquals, s.wpCharm.URL())
+	curl := s.wordpressUnit.CharmURL()
+	c.Assert(curl, gc.NotNil)
+	c.Assert(*curl, gc.Equals, s.wpCharm.URL().String())
 
 	// Make sure wordpress application's charm is what we expect.
 	curlStr, force := s.wordpress.CharmURL()
@@ -913,8 +913,8 @@ func (s *uniterSuite) TestCharmURL(c *gc.C) {
 }
 
 func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
-	_, ok := s.wordpressUnit.CharmURL()
-	c.Assert(ok, jc.IsFalse)
+	charmURL := s.wordpressUnit.CharmURL()
+	c.Assert(charmURL, gc.IsNil)
 
 	args := params.EntitiesCharmURL{Entities: []params.EntityCharmURL{
 		{Tag: "unit-mysql-0", CharmURL: "cs:quantal/application-42"},
@@ -935,10 +935,9 @@ func (s *uniterSuite) TestSetCharmURL(c *gc.C) {
 	err = s.wordpressUnit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	charmURL, err := s.wordpressUnit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	charmURL = s.wordpressUnit.CharmURL()
 	c.Assert(charmURL, gc.NotNil)
-	c.Assert(charmURL.String(), gc.Equals, s.wpCharm.String())
+	c.Assert(*charmURL, gc.Equals, s.wpCharm.String())
 }
 
 func (s *uniterSuite) TestWorkloadVersion(c *gc.C) {

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1531,9 +1531,9 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 	if unit.IsPrincipal() {
 		result.Machine, _ = unit.AssignedMachineId()
 	}
-	curl, _ := unit.CharmURL()
-	if applicationCharm != "" && curl != nil && curl.String() != applicationCharm {
-		result.Charm = curl.String()
+	unitCharm := unit.CharmURL()
+	if applicationCharm != "" && unitCharm != nil && *unitCharm != applicationCharm {
+		result.Charm = *unitCharm
 	}
 	workloadVersion, err := context.status.UnitWorkloadVersion(unit.Name())
 	if err == nil {

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -332,14 +332,14 @@ func (s *statusUnitTestSuite) TestModelMeterStatus(c *gc.C) {
 
 func (s *statusUnitTestSuite) TestMeterStatus(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
-	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 
-	units, err := service.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 0)
 
 	for i, unit := range testUnits {
-		u, err := service.AddUnit(state.AddUnitParams{})
+		u, err := app.AddUnit(state.AddUnitParams{})
 		testUnits[i].unitName = u.Name()
 		c.Assert(err, jc.ErrorIsNil)
 		if unit.setStatus != nil {
@@ -352,12 +352,12 @@ func (s *statusUnitTestSuite) TestMeterStatus(c *gc.C) {
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.NotNil)
-	serviceStatus, ok := status.Applications[service.Name()]
+	appStatus, ok := status.Applications[app.Name()]
 	c.Assert(ok, gc.Equals, true)
 
-	c.Assert(serviceStatus.MeterStatuses, gc.HasLen, len(testUnits)-1)
+	c.Assert(appStatus.MeterStatuses, gc.HasLen, len(testUnits)-1)
 	for _, unit := range testUnits {
-		unitStatus, ok := serviceStatus.MeterStatuses[unit.unitName]
+		unitStatus, ok := appStatus.MeterStatuses[unit.unitName]
 
 		if unit.expectedStatus != nil {
 			c.Assert(ok, gc.Equals, true)
@@ -369,14 +369,14 @@ func (s *statusUnitTestSuite) TestMeterStatus(c *gc.C) {
 }
 
 func (s *statusUnitTestSuite) TestNoMeterStatusWhenNotRequired(c *gc.C) {
-	service := s.Factory.MakeApplication(c, nil)
+	app := s.Factory.MakeApplication(c, nil)
 
-	units, err := service.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 0)
 
 	for i, unit := range testUnits {
-		u, err := service.AddUnit(state.AddUnitParams{})
+		u, err := app.AddUnit(state.AddUnitParams{})
 		testUnits[i].unitName = u.Name()
 		c.Assert(err, jc.ErrorIsNil)
 		if unit.setStatus != nil {
@@ -389,22 +389,22 @@ func (s *statusUnitTestSuite) TestNoMeterStatusWhenNotRequired(c *gc.C) {
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.NotNil)
-	serviceStatus, ok := status.Applications[service.Name()]
+	appStatus, ok := status.Applications[app.Name()]
 	c.Assert(ok, gc.Equals, true)
 
-	c.Assert(serviceStatus.MeterStatuses, gc.HasLen, 0)
+	c.Assert(appStatus.MeterStatuses, gc.HasLen, 0)
 }
 
 func (s *statusUnitTestSuite) TestMeterStatusWithCredentials(c *gc.C) {
-	service := s.Factory.MakeApplication(c, nil)
-	c.Assert(service.SetMetricCredentials([]byte("magic-ticket")), jc.ErrorIsNil)
+	app := s.Factory.MakeApplication(c, nil)
+	c.Assert(app.SetMetricCredentials([]byte("magic-ticket")), jc.ErrorIsNil)
 
-	units, err := service.AllUnits()
+	units, err := app.AllUnits()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(units, gc.HasLen, 0)
 
 	for i, unit := range testUnits {
-		u, err := service.AddUnit(state.AddUnitParams{})
+		u, err := app.AddUnit(state.AddUnitParams{})
 		testUnits[i].unitName = u.Name()
 		c.Assert(err, jc.ErrorIsNil)
 		if unit.setStatus != nil {
@@ -417,12 +417,12 @@ func (s *statusUnitTestSuite) TestMeterStatusWithCredentials(c *gc.C) {
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.NotNil)
-	serviceStatus, ok := status.Applications[service.Name()]
+	appStatus, ok := status.Applications[app.Name()]
 	c.Assert(ok, gc.Equals, true)
 
-	c.Assert(serviceStatus.MeterStatuses, gc.HasLen, len(testUnits)-1)
+	c.Assert(appStatus.MeterStatuses, gc.HasLen, len(testUnits)-1)
 	for _, unit := range testUnits {
-		unitStatus, ok := serviceStatus.MeterStatuses[unit.unitName]
+		unitStatus, ok := appStatus.MeterStatuses[unit.unitName]
 
 		if unit.expectedStatus != nil {
 			c.Assert(ok, gc.Equals, true)
@@ -435,8 +435,8 @@ func (s *statusUnitTestSuite) TestMeterStatusWithCredentials(c *gc.C) {
 
 func (s *statusUnitTestSuite) TestApplicationWithExposedEndpoints(c *gc.C) {
 	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered"})
-	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
-	err := service.MergeExposeSettings(map[string]state.ExposedEndpoint{
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	err := app.MergeExposeSettings(map[string]state.ExposedEndpoint{
 		"": {
 			ExposeToSpaceIDs: []string{network.AlphaSpaceId},
 			ExposeToCIDRs:    []string{"10.0.0.0/24", "192.168.0.0/24"},
@@ -448,15 +448,44 @@ func (s *statusUnitTestSuite) TestApplicationWithExposedEndpoints(c *gc.C) {
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, gc.NotNil)
-	serviceStatus, ok := status.Applications[service.Name()]
+	appStatus, ok := status.Applications[app.Name()]
 	c.Assert(ok, gc.Equals, true)
 
-	c.Assert(serviceStatus.ExposedEndpoints, gc.DeepEquals, map[string]params.ExposedEndpoint{
+	c.Assert(appStatus.ExposedEndpoints, gc.DeepEquals, map[string]params.ExposedEndpoint{
 		"": {
 			ExposeToSpaces: []string{network.AlphaSpaceName},
 			ExposeToCIDRs:  []string{"10.0.0.0/24", "192.168.0.0/24"},
 		},
 	})
+}
+
+func (s *statusUnitTestSuite) TestUnitUpgradingFrom(c *gc.C) {
+	meteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-3"})
+	meteredCharmNew := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-5"})
+	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
+	u := s.Factory.MakeUnit(c, &factory.UnitParams{
+		Application: app,
+		SetCharmURL: true,
+	})
+	client := apiclient.NewClient(s.APIState)
+	status, err := client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.NotNil)
+	unitStatus, ok := status.Applications[app.Name()].Units[u.Name()]
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(unitStatus.Charm, gc.Equals, "")
+
+	err = app.SetCharm(state.SetCharmConfig{
+		Charm: meteredCharmNew,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	status, err = client.Status(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status, gc.NotNil)
+	unitStatus, ok = status.Applications[app.Name()].Units[u.Name()]
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(unitStatus.Charm, gc.Equals, "cs:quantal/metered-3")
 }
 
 func addUnitWithVersion(c *gc.C, application *state.Application, version string) *state.Unit {
@@ -851,9 +880,9 @@ func (s *statusUpgradeUnitSuite) TestUpdateRevisionsCharmstore(c *gc.C) {
 	client := apiclient.NewClient(s.APIState)
 	status, _ := client.Status(nil)
 
-	serviceStatus, ok := status.Applications["mysql"]
+	appStatus, ok := status.Applications["mysql"]
 	c.Assert(ok, gc.Equals, true)
-	c.Assert(serviceStatus.CanUpgradeTo, gc.Equals, "")
+	c.Assert(appStatus.CanUpgradeTo, gc.Equals, "")
 
 	// Update to the latest available charm revision.
 	result, err := s.charmrevisionupdater.UpdateLatestRevisions()
@@ -862,9 +891,9 @@ func (s *statusUpgradeUnitSuite) TestUpdateRevisionsCharmstore(c *gc.C) {
 
 	// Check if CanUpgradeTo suggests the latest revision.
 	status, _ = client.Status(nil)
-	serviceStatus, ok = status.Applications["mysql"]
+	appStatus, ok = status.Applications["mysql"]
 	c.Assert(ok, gc.Equals, true)
-	c.Assert(serviceStatus.CanUpgradeTo, gc.Equals, "cs:quantal/mysql-23")
+	c.Assert(appStatus.CanUpgradeTo, gc.Equals, "cs:quantal/mysql-23")
 }
 
 func (s *statusUpgradeUnitSuite) TestUpdateRevisionsCharmhub(c *gc.C) {
@@ -877,9 +906,9 @@ func (s *statusUpgradeUnitSuite) TestUpdateRevisionsCharmhub(c *gc.C) {
 	client := apiclient.NewClient(s.APIState)
 	status, _ := client.Status(nil)
 
-	serviceStatus, ok := status.Applications["charmhubby"]
+	appStatus, ok := status.Applications["charmhubby"]
 	c.Assert(ok, gc.Equals, true)
-	c.Assert(serviceStatus.CanUpgradeTo, gc.Equals, "")
+	c.Assert(appStatus.CanUpgradeTo, gc.Equals, "")
 
 	// Update to the latest available charm revision.
 	result, err := s.charmrevisionupdater.UpdateLatestRevisions()
@@ -888,9 +917,9 @@ func (s *statusUpgradeUnitSuite) TestUpdateRevisionsCharmhub(c *gc.C) {
 
 	// Check if CanUpgradeTo suggests the latest revision.
 	status, _ = client.Status(nil)
-	serviceStatus, ok = status.Applications["charmhubby"]
+	appStatus, ok = status.Applications["charmhubby"]
 	c.Assert(ok, gc.Equals, true)
-	c.Assert(serviceStatus.CanUpgradeTo, gc.Equals, "ch:charmhubby-42")
+	c.Assert(appStatus.CanUpgradeTo, gc.Equals, "ch:charmhubby-42")
 }
 
 type CAASStatusSuite struct {

--- a/apiserver/facades/client/metricsdebug/metricsdebug.go
+++ b/apiserver/facades/client/metricsdebug/metricsdebug.go
@@ -181,12 +181,13 @@ func (api *MetricsDebugAPI) setEntityMeterStatus(entity names.Tag, status state.
 		if err != nil {
 			return errors.Trace(err)
 		}
-		chURL, err := unit.CharmURL()
+		chURLStr := unit.CharmURL()
+		if chURLStr == nil {
+			return errors.New("no charm url")
+		}
+		chURL, err := charm.ParseURL(*chURLStr)
 		if err != nil {
 			return errors.Trace(err)
-		}
-		if chURL == nil {
-			return errors.New("no charm url")
 		}
 		if !charm.Local.Matches(chURL.Schema) {
 			return errors.New("not a local charm")

--- a/core/cache/cachetest/state.go
+++ b/core/cache/cachetest/state.go
@@ -165,9 +165,9 @@ func UnitChange(c *gc.C, modelUUID string, unit *state.Unit) cache.UnitChange {
 	}
 
 	var charmURL string
-	cURL, err := unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
-	charmURL = cURL.String()
+	if cURL := unit.CharmURL(); cURL != nil {
+		charmURL = *cURL
+	}
 
 	pr, err := unit.OpenedPortRanges()
 	if !errors.IsNotAssigned(err) {

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -6,7 +6,6 @@ package migration
 import (
 	"fmt"
 
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset/v2"
@@ -86,7 +85,7 @@ type PrecheckUnit interface {
 	Name() string
 	AgentTools() (*tools.Tools, error)
 	Life() state.Life
-	CharmURL() (*charm.URL, error)
+	CharmURL() *string
 	AgentStatus() (status.StatusInfo, error)
 	Status() (status.StatusInfo, error)
 	ShouldBeAssigned() bool
@@ -421,8 +420,8 @@ func (ctx *precheckContext) checkUnits(app PrecheckApplication, units []Precheck
 			}
 		}
 
-		unitCharmURL, _ := unit.CharmURL()
-		if *appCharmURL != unitCharmURL.String() {
+		unitCharmURL := unit.CharmURL()
+		if unitCharmURL == nil || *appCharmURL != *unitCharmURL {
 			return errors.Errorf("unit %s is upgrading", unit.Name())
 		}
 	}

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -6,7 +6,6 @@ package migration_test
 import (
 	"strings"
 
-	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/replicaset/v2"
@@ -1071,12 +1070,12 @@ func (u *fakeUnit) ShouldBeAssigned() bool {
 	return true
 }
 
-func (u *fakeUnit) CharmURL() (*charm.URL, error) {
+func (u *fakeUnit) CharmURL() *string {
 	url := u.charmURL
 	if url == "" {
 		url = "cs:foo-1"
 	}
-	return charm.MustParseURL(url), nil
+	return &url
 }
 
 func (u *fakeUnit) AgentStatus() (status.StatusInfo, error) {

--- a/resource/opener.go
+++ b/resource/opener.go
@@ -74,15 +74,18 @@ func newInternalResourceOpener(
 		NewClient() (*ResourceRetryClient, error)
 	}
 
-	var charmURL *charm.URL
+	var chURLStr *string
 	if unit != nil {
-		charmURL, _ = unit.CharmURL()
+		chURLStr = unit.CharmURL()
 	} else {
-		cURL, _ := application.CharmURL()
-		charmURL, err = charm.ParseURL(*cURL)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+		chURLStr, _ = application.CharmURL()
+	}
+	if chURLStr == nil {
+		return nil, errors.Errorf("missing charm URL for %q", appName)
+	}
+	charmURL, err := charm.ParseURL(*chURLStr)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	switch {
 	case charm.CharmHub.Matches(charmURL.Schema):

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -627,14 +627,12 @@ func (checker *ModelChecker) readApplicationsAndUnits() {
 		units, err := app.AllUnits()
 		checkErr(err, "AllUnits")
 		for _, unit := range units {
-			unitCharmURL, err := unit.CharmURL()
-			checkErr(err, "unit CharmURL")
+			unitCharmURL := unit.CharmURL()
 			if unitCharmURL == nil {
 				continue
 			}
-			unitString := unitCharmURL.String()
-			if unitString != *charmURL {
-				checker.unitReferencedCharms.Add(unitString, unit.Name())
+			if *unitCharmURL != *charmURL {
+				checker.unitReferencedCharms.Add(*unitCharmURL, unit.Name())
 			}
 			tools, err := unit.AgentTools()
 			checkErr(err, "unit AgentTools")

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -164,7 +164,10 @@ func (s *ActionSuite) TestAddAction(c *gc.C) {
 
 		if t.expectedErr == "" {
 			c.Assert(err, jc.ErrorIsNil)
-			curl, _ := t.whichUnit.CharmURL()
+			curlStr := t.whichUnit.CharmURL()
+			c.Assert(curlStr, gc.NotNil)
+			curl, err := charm.ParseURL(*curlStr)
+			c.Assert(err, jc.ErrorIsNil)
 			ch, _ := s.State.Charm(curl)
 			schema := ch.Actions()
 			c.Logf("Schema for unit %q:\n%#v", t.whichUnit.Name(), schema)

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -1977,8 +1977,8 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	// refcount.
 	u, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	_, ok := u.CharmURL()
-	c.Assert(ok, jc.IsFalse)
+	charmURL := u.CharmURL()
+	c.Assert(charmURL, gc.IsNil)
 	assertSettingsRef(c, s.State, appName, oldCh, 1)
 	assertNoSettingsRef(c, s.State, appName, newCh)
 
@@ -1986,7 +1986,9 @@ func (s *ApplicationSuite) TestSettingsRefCountWorks(c *gc.C) {
 	// used by app as well, hence 2.
 	err = u.SetCharmURL(oldCh.URL())
 	c.Assert(err, jc.ErrorIsNil)
-	curl, err := u.CharmURL()
+	charmURL = u.CharmURL()
+	c.Assert(charmURL, gc.NotNil)
+	curl, err := charm.ParseURL(*charmURL)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, oldCh.URL())
 	assertSettingsRef(c, s.State, appName, oldCh, 2)

--- a/state/machine.go
+++ b/state/machine.go
@@ -2126,12 +2126,11 @@ func (m *Machine) UpdateMachineSeries(series string) error {
 			Update: bson.D{{"$set", bson.D{{"series", series}}}},
 		}}
 		for _, unit := range units {
-			curl, _ := unit.CharmURL()
 			ops = append(ops, txn.Op{
 				C:  unitsC,
 				Id: unit.doc.DocID,
 				Assert: bson.D{{"life", Alive},
-					{"charmurl", curl},
+					{"charmurl", unit.CharmURL()},
 					{"subordinates", unit.SubordinateNames()}},
 				Update: bson.D{{"$set", bson.D{{"series", series}}}},
 			})

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -551,13 +551,13 @@ func (s *MetricSuite) TestMetricValidation(c *gc.C) {
 	}}
 	for i, t := range tests {
 		c.Logf("test %d: %s", i, t.about)
-		chURL, err := t.unit.CharmURL()
-		c.Assert(err, jc.ErrorIsNil)
+		chURL := t.unit.CharmURL()
+		c.Assert(chURL, gc.NotNil)
 		_, err = s.State.AddMetrics(
 			state.BatchParam{
 				UUID:     utils.MustNewUUID().String(),
 				Created:  now,
-				CharmURL: chURL.String(),
+				CharmURL: *chURL,
 				Metrics:  t.metrics,
 				Unit:     t.unit.UnitTag(),
 			},

--- a/state/storage.go
+++ b/state/storage.go
@@ -638,7 +638,7 @@ func validateRemoveOwnerStorageInstanceOps(si *storageInstance) ([]txn.Op, error
 			Id: app.Name(),
 			Assert: bson.D{
 				{"life", Alive},
-				{"charmurl", ch.URL},
+				{"charmurl", ch.String()},
 			},
 		})
 	case names.UnitTagKind:

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1262,22 +1262,20 @@ func (s *UnitSuite) TestRefresh(c *gc.C) {
 
 func (s *UnitSuite) TestSetCharmURLSuccess(c *gc.C) {
 	preventUnitDestroyRemove(c, s.unit)
-	curl, ok := s.unit.CharmURL()
-	c.Assert(ok, jc.IsFalse)
+	curl := s.unit.CharmURL()
 	c.Assert(curl, gc.IsNil)
 
 	err := s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, err = s.unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(curl, gc.DeepEquals, s.charm.URL())
+	curl = s.unit.CharmURL()
+	c.Assert(curl, gc.NotNil)
+	c.Assert(*curl, gc.Equals, s.charm.URL().String())
 }
 
 func (s *UnitSuite) TestSetCharmURLFailures(c *gc.C) {
 	preventUnitDestroyRemove(c, s.unit)
-	curl, ok := s.unit.CharmURL()
-	c.Assert(ok, jc.IsFalse)
+	curl := s.unit.CharmURL()
 	c.Assert(curl, gc.IsNil)
 
 	err := s.unit.SetCharmURL(nil)
@@ -1310,9 +1308,9 @@ func (s *UnitSuite) TestSetCharmURLWithDyingUnit(c *gc.C) {
 	err = s.unit.SetCharmURL(s.charm.URL())
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, err := s.unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(curl, gc.DeepEquals, s.charm.URL())
+	curl := s.unit.CharmURL()
+	c.Assert(curl, gc.NotNil)
+	c.Assert(*curl, gc.Equals, s.charm.URL().String())
 }
 
 func (s *UnitSuite) TestSetCharmURLRetriesWithDeadUnit(c *gc.C) {
@@ -1359,9 +1357,9 @@ func (s *UnitSuite) TestSetCharmURLRetriesWithDifferentURL(c *gc.C) {
 				// Verify it worked after the second attempt.
 				err := s.unit.Refresh()
 				c.Assert(err, jc.ErrorIsNil)
-				currentURL, err := s.unit.CharmURL()
-				c.Assert(err, jc.ErrorIsNil)
-				c.Assert(currentURL, jc.DeepEquals, s.charm.URL())
+				currentURL := s.unit.CharmURL()
+				c.Assert(currentURL, gc.NotNil)
+				c.Assert(*currentURL, gc.Equals, s.charm.URL().String())
 			},
 		},
 	).Check()

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -678,14 +678,14 @@ func (factory *Factory) MakeMetric(c *gc.C, params *MetricParams) *state.MetricB
 		}}
 	}
 
-	chURL, err := params.Unit.CharmURL()
-	c.Assert(err, jc.ErrorIsNil)
+	chURL := params.Unit.CharmURL()
+	c.Assert(chURL, gc.NotNil)
 
 	metric, err := factory.st.AddMetrics(
 		state.BatchParam{
 			UUID:     utils.MustNewUUID().String(),
 			Created:  *params.Time,
-			CharmURL: chURL.String(),
+			CharmURL: *chURL,
 			Metrics:  params.Metrics,
 			Unit:     params.Unit.UnitTag(),
 		})

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -401,8 +401,10 @@ func (s *factorySuite) TestMakeUnit(c *gc.C) {
 	c.Assert(saved.Life(), gc.Equals, unit.Life())
 
 	applicationCharmURL, _ := application.CharmURL()
-	unitCharmURL, _ := saved.CharmURL()
-	c.Assert(unitCharmURL.String(), gc.Equals, *applicationCharmURL)
+	c.Assert(applicationCharmURL, gc.NotNil)
+	unitCharmURL := saved.CharmURL()
+	c.Assert(unitCharmURL, gc.NotNil)
+	c.Assert(*unitCharmURL, gc.Equals, *applicationCharmURL)
 }
 
 func (s *factorySuite) TestMakeRelationNil(c *gc.C) {

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -798,13 +798,14 @@ func (s waitUnitAgent) step(c *gc.C, ctx *testContext) {
 				c.Logf("want resolved mode %q, got %q; still waiting", s.resolved, resolved)
 				continue
 			}
-			url, err := ctx.unit.CharmURL()
-			if err != nil {
-				c.Fatalf("cannot refresh unit: %v", err)
-			}
-			if url == nil {
+			urlStr := ctx.unit.CharmURL()
+			if urlStr == nil {
 				c.Logf("want unit charm %q, got nil; still waiting", curl(s.charm))
 				continue
+			}
+			url, err := corecharm.ParseURL(*urlStr)
+			if err != nil {
+				c.Fatalf("cannot refresh unit: %v", err)
 			}
 			if *url != *curl(s.charm) {
 				c.Logf("want unit charm %q, got %q; still waiting", curl(s.charm), url.String())
@@ -1033,7 +1034,9 @@ func (s verifyCharm) step(c *gc.C, ctx *testContext) {
 	err = ctx.unit.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	url, err := ctx.unit.CharmURL()
+	urlStr := ctx.unit.CharmURL()
+	c.Assert(urlStr, gc.NotNil)
+	url, err := corecharm.ParseURL(*urlStr)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url, gc.DeepEquals, curl(checkRevision))
 }


### PR DESCRIPTION
We had started migrating away from using charm.URL in state and instead want to use strings. This was done for application but not completely for unit. This PR changes the CharmURL() method on unit to return string as was done for application and updates the various tests etc.

## QA steps

bootstrap and deploy a charm