### PR TITLE
Fix `test-agents-lxd`

### DIFF
--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -7,12 +7,12 @@ run_charmstore_charmrevisionupdater() {
 
 	ensure "${model_name}" "${file}"
 
-	# Deploy an old revision of mysql
-	juju deploy cs:mysql-55
+	# Deploy an old revision of postgresql
+	juju deploy cs:postgresql-238
 
 	# Wait for revision update worker to update the available revision.
-	# eg can-upgrade-to: cs:mysql-58
-	wait_for "cs:mysql-" '.applications["mysql"] | ."can-upgrade-to"'
+	# eg can-upgrade-to: cs:postgresql-239
+	wait_for "cs:postgresql-" '.applications["postgresql"] | ."can-upgrade-to"'
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
The gating test `test-agents-lxd` was failing because it was trying to deploy a **very** old revision of mysql, which runs on trusty. Juju 3.0 didn't seem to like the trusty machine.

Newer versions of the mysql charm currently aren't working on focal (e.g. [these](https://github.com/canonical/mysql-operator/issues/22) [issues](https://github.com/canonical/mysql-operator/issues/23)), so I've decided to use `postgresql` instead.

## QA steps

```sh
cd tests
./main.sh -v agents
```