### PR TITLE
Fix cli/local_charms test due to deleted GitHub repo

### DIFF
--- a/tests/suites/cli/local_charms.sh
+++ b/tests/suites/cli/local_charms.sh
@@ -8,7 +8,7 @@ run_deploy_local_charm_revision() {
 	TMP=$(mktemp -d -t ci-XXXXXXXXXX)
 
 	cd "${TMP}" || exit 1
-	git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
+	git clone --depth=1 --quiet https://git.launchpad.net/ntp-charm ntp
 	cd "${TMP}/ntp" || exit 1
 	SHA_OF_NTP=\"$(git describe --dirty --always)\"
 
@@ -38,11 +38,11 @@ run_deploy_local_charm_revision_no_vcs() {
 	TMP=$(mktemp -d -t ci-XXXXXXXXXX)
 
 	cd "${TMP}" || exit 1
-	git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
+	git clone --depth=1 --quiet https://git.launchpad.net/ntp-charm ntp
 	cd "${TMP}/ntp" || exit 1
 	rm -rf .git
 	# make sure that no version file exists.
-	rm version
+	rm -f version
 
 	OUTPUT=$(juju deploy --debug . 2>&1)
 
@@ -61,7 +61,7 @@ run_deploy_local_charm_revision_no_vcs_but_version_file() {
 	TMP=$(mktemp -d -t ci-XXXXXXXXXX)
 
 	cd "${TMP}" || exit 1
-	git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
+	git clone --depth=1 --quiet https://git.launchpad.net/ntp-charm ntp
 	cd "${TMP}/ntp" || exit 1
 	rm -rf .git
 	touch version
@@ -101,7 +101,7 @@ run_deploy_local_charm_revision_relative_path() {
 	create_local_git_folder
 	SHA_OF_TMP=\"$(git describe --dirty --always)\"
 	# create ${TMP}/ntp git folder
-	git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
+	git clone --depth=1 --quiet https://git.launchpad.net/ntp-charm ntp
 
 	# state: ${TMP} is wrong git ${TMP}/ntp is correct git
 	juju deploy ./ntp 2>&1
@@ -138,7 +138,7 @@ run_deploy_local_charm_revision_invalid_git() {
 	TMP=$(mktemp -d -t ci-XXXXXXXXXX)
 
 	cd "${TMP_CHARM_GIT}" || exit 1
-	git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git ntp
+	git clone --depth=1 --quiet https://git.launchpad.net/ntp-charm ntp
 
 	cd "${TMP_CHARM_GIT}/ntp" || exit 1
 	WANTED_CHARM_SHA=\"$(git describe --dirty --always)\"


### PR DESCRIPTION
These tests use https://github.com/lampkicking/charm-ntp, which stopped
working on the 14th of July (presumably it was deleted). So go back to
using https://git.launchpad.net/ntp-charm, which is the charm used on
Charmhub and presumably more stable. The test used to use this URL
until it was changed in
https://github.com/juju/juju/commit/c508cfad05d20a6f8b56d0768cae67ae22c865d8

Also add "-f" to "rm version" as the version file may or may not exist.

For some reason locally I get a different error than the test does,
presumably because of how I've configured git (with a username?) vs
how it's configured in the test infra. I get:

$ git clone --depth=1 --quiet https://github.com/lampkicking/charm-ntp.git
remote: Repository not found.
fatal: repository 'https://github.com/lampkicking/charm-ntp.git/' not found

But the [test failure](https://jenkins.juju.canonical.com/job/test-cli-test-local-charms-lxd/157/console) shows:

fatal: could not read Username for 'https://github.com': No such device or address

I'm pretty sure it's the same underlying cause, though. We'll soon see.

## QA Steps:

```
$ juju bootstrap lxd
$ cd tests
$ ./main.sh -l localhost-localhost cli test_local_charms
```