### PR TITLE
Fix output of bash tests

### DIFF
--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -12,7 +12,7 @@ run() {
 
 	DESC=$(echo "${1}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
 
-	echo -n "===> [   ] Running: ${DESC}"
+	echo "===> [   ] Running: ${DESC}"
 
 	START_TIME=$(date +%s)
 
@@ -53,7 +53,7 @@ run_linter() {
 
 	DESC=$(echo "${1}" | sed -E "s/^run_//g" | sed -E "s/_/ /g")
 
-	echo -n "===> [   ] Running: ${DESC}"
+	echo "===> [   ] Running: ${DESC}"
 
 	START_TIME=$(date +%s)
 


### PR DESCRIPTION
The bash test output was not quite right:
```
...
===> [   ] Running: simplestream metadata last stable===> Using jujud version 3.0-beta3-ubuntu-amd64
...
```
I added a newline to make this format correctly.
```
...
===> [   ] Running: simplestream metadata last stable
===> Using jujud version 3.0-beta3-ubuntu-amd64
...
```

## QA steps

```sh
cd tests
./main.sh -v <any-test-suite>
```