### PR TITLE
Update deploy_revision tests to actually check revision

### DIFF
--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -11,7 +11,8 @@ run_deploy_revision() {
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
 
 	# check resource revision per channel specified.
-	juju resources juju-qa-test --format json | jq -S '.resources[0] | .[ "revision"] == "1"'
+	got=$(juju resources juju-qa-test --format json | jq -S '.resources[0] | .["revision"] == "1"')
+	check_contains "${got}" "true"
 
 	destroy_model "${model_name}"
 }
@@ -29,7 +30,8 @@ run_deploy_revision_resource() {
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
 
 	# check resource revision as specified in command.
-	juju resources juju-qa-test --format json | jq -S '.resources[0] | .[ "revision"] == "4"'
+	got=$(juju resources juju-qa-test --format json | jq -S '.resources[0] | .["revision"] == "4"')
+	check_contains "${got}" "true"
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
Currently the code is not checking the revision, it just prints out
"true" or "false". It doesn't make the test fail, but this updates the
test to actually check this response.

Note: this is against the 2.9 branch, and won't fix the failure on 3.0.
That's something different (related to async downloads and resources
that Heather is looking at).
