### PR TITLE
[JUJU-1480] Add support for retry-provisioning --all

### DIFF
--- a/api/client/client/client.go
+++ b/api/client/client/client.go
@@ -116,7 +116,10 @@ func (c *Client) Resolved(unit string, retry bool) error {
 // RetryProvisioning updates the provisioning status of a machine allowing the
 // provisioner to retry.
 // TODO(juju3) - remove
-func (c *Client) RetryProvisioning(machines ...names.MachineTag) ([]params.ErrorResult, error) {
+func (c *Client) RetryProvisioning(all bool, machines ...names.MachineTag) ([]params.ErrorResult, error) {
+	if all {
+		return nil, errors.New(`retry provisioning "all" not supported by this version of Juju`)
+	}
 	p := params.Entities{}
 	p.Entities = make([]params.Entity, len(machines))
 	for i, machine := range machines {

--- a/api/client/machinemanager/machinemanager.go
+++ b/api/client/machinemanager/machinemanager.go
@@ -144,11 +144,13 @@ func (c *Client) ProvisioningScript(args params.ProvisioningScriptParams) (scrip
 
 // RetryProvisioning updates the provisioning status of a machine allowing the
 // provisioner to retry.
-func (c *Client) RetryProvisioning(machines ...names.MachineTag) ([]params.ErrorResult, error) {
-	p := params.Entities{}
-	p.Entities = make([]params.Entity, len(machines))
+func (c *Client) RetryProvisioning(all bool, machines ...names.MachineTag) ([]params.ErrorResult, error) {
+	p := params.RetryProvisioningArgs{
+		All: all,
+	}
+	p.Machines = make([]string, len(machines))
 	for i, machine := range machines {
-		p.Entities[i] = params.Entity{Tag: machine.String()}
+		p.Machines[i] = machine.String()
 	}
 	var results params.ErrorResults
 	err := c.facade.FacadeCall("RetryProvisioning", p, &results)

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -392,7 +393,7 @@ func (mm *MachineManagerAPI) ProvisioningScript(args params.ProvisioningScriptPa
 func (api *MachineManagerAPIV6) RetryProvisioning(_ struct{}) {}
 
 // RetryProvisioning marks a provisioning error as transient on the machines.
-func (mm *MachineManagerAPI) RetryProvisioning(p params.Entities) (params.ErrorResults, error) {
+func (mm *MachineManagerAPI) RetryProvisioning(p params.RetryProvisioningArgs) (params.ErrorResults, error) {
 	if err := mm.authorizer.CanWrite(); err != nil {
 		return params.ErrorResults{}, err
 	}
@@ -400,37 +401,33 @@ func (mm *MachineManagerAPI) RetryProvisioning(p params.Entities) (params.ErrorR
 	if err := mm.check.ChangeAllowed(); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
-	result := params.ErrorResults{
-		Results: make([]params.ErrorResult, len(p.Entities)),
+	result := params.ErrorResults{}
+	machines, err := mm.st.AllMachines()
+	if err != nil {
+		return params.ErrorResults{}, errors.Trace(err)
 	}
-	for i, e := range p.Entities {
-		tag, err := names.ParseMachineTag(e.Tag)
+	wanted := set.NewStrings()
+	for _, tagStr := range p.Machines {
+		tag, err := names.ParseMachineTag(tagStr)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
+			result.Results = append(result.Results, params.ErrorResult{Error: apiservererrors.ServerError(err)})
 			continue
 		}
-		if err := mm.updateInstanceStatus(tag, map[string]interface{}{"transient": true}); err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
+		wanted.Add(tag.Id())
+	}
+	for _, m := range machines {
+		if !p.All && !wanted.Contains(m.Id()) {
+			continue
+		}
+		if err := mm.maybeUpdateInstanceStatus(p.All, m, map[string]interface{}{"transient": true}); err != nil {
+			result.Results = append(result.Results, params.ErrorResult{Error: apiservererrors.ServerError(err)})
 		}
 	}
 	return result, nil
 }
 
-type instanceStatus interface {
-	InstanceStatus() (status.StatusInfo, error)
-	SetInstanceStatus(sInfo status.StatusInfo) error
-}
-
-func (mm *MachineManagerAPI) updateInstanceStatus(tag names.Tag, data map[string]interface{}) error {
-	entity0, err := mm.st.FindEntity(tag)
-	if err != nil {
-		return err
-	}
-	statusGetterSetter, ok := entity0.(instanceStatus)
-	if !ok {
-		return apiservererrors.NotSupportedError(tag, "getting status")
-	}
-	existingStatusInfo, err := statusGetterSetter.InstanceStatus()
+func (mm *MachineManagerAPI) maybeUpdateInstanceStatus(all bool, m Machine, data map[string]interface{}) error {
+	existingStatusInfo, err := m.InstanceStatus()
 	if err != nil {
 		return err
 	}
@@ -443,7 +440,12 @@ func (mm *MachineManagerAPI) updateInstanceStatus(tag names.Tag, data map[string
 		}
 	}
 	if len(newData) > 0 && existingStatusInfo.Status != status.Error && existingStatusInfo.Status != status.ProvisioningError {
-		return fmt.Errorf("%s is not in an error state (%v)", names.ReadableString(tag), existingStatusInfo.Status)
+		// If a specifc machine has been asked for and it's not in error, that's a problem.
+		if !all {
+			return fmt.Errorf("machine %s is not in an error state (%v)", m.Id(), existingStatusInfo.Status)
+		}
+		// Otherwise just skip it.
+		return nil
 	}
 	// TODO(perrito666) 2016-05-02 lp:1558657
 	now := time.Now()
@@ -453,7 +455,7 @@ func (mm *MachineManagerAPI) updateInstanceStatus(tag names.Tag, data map[string
 		Data:    newData,
 		Since:   &now,
 	}
-	return statusGetterSetter.SetInstanceStatus(sInfo)
+	return m.SetInstanceStatus(sInfo)
 }
 
 // DestroyMachine removes a set of machines from the model.

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -741,7 +741,7 @@ func (s *ProvisioningMachineManagerSuite) setup(c *gc.C) *gomock.Controller {
 	s.ctrlSt.EXPECT().ControllerTag().Return(coretesting.ControllerTag).AnyTimes()
 
 	s.pool = mocks.NewMockPool(ctrl)
-	s.pool.EXPECT().SystemState().Return(s.ctrlSt, nil)
+	s.pool.EXPECT().SystemState().Return(s.ctrlSt, nil).AnyTimes()
 
 	s.model = mocks.NewMockModel(ctrl)
 	s.model.EXPECT().UUID().Return("uuid").AnyTimes()
@@ -850,6 +850,75 @@ func (s *ProvisioningMachineManagerSuite) TestProvisioningScriptDisablePackageCo
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Script, gc.Not(jc.Contains), "apt-get update")
 	c.Assert(result.Script, gc.Not(jc.Contains), "apt-get upgrade")
+}
+
+type statusMatcher struct {
+	c        *gc.C
+	expected status.StatusInfo
+}
+
+func (m statusMatcher) Matches(x interface{}) bool {
+	obtained, ok := x.(status.StatusInfo)
+	m.c.Assert(ok, jc.IsTrue)
+	if !ok {
+		return false
+	}
+
+	m.c.Assert(obtained.Since, gc.NotNil)
+	obtained.Since = nil
+	m.c.Assert(obtained, jc.DeepEquals, m.expected)
+	return true
+}
+
+func (m statusMatcher) String() string {
+	return "Match the status.StatusInfo value"
+}
+
+func (s *ProvisioningMachineManagerSuite) TestRetryProvisioning(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	s.st.EXPECT().GetBlockForType(state.ChangeBlock).Return(nil, false, nil).AnyTimes()
+
+	machine0 := mocks.NewMockMachine(ctrl)
+	machine0.EXPECT().Id().Return("0")
+	machine0.EXPECT().InstanceStatus().Return(status.StatusInfo{Status: "provisioning error"}, nil)
+	machine0.EXPECT().SetInstanceStatus(statusMatcher{c: c, expected: status.StatusInfo{
+		Status: status.ProvisioningError,
+		Data:   map[string]interface{}{"transient": true},
+	}}).Return(nil)
+	machine1 := mocks.NewMockMachine(ctrl)
+	machine1.EXPECT().Id().Return("1")
+	s.st.EXPECT().AllMachines().Return([]machinemanager.Machine{machine0, machine1}, nil)
+
+	results, err := s.api.RetryProvisioning(params.RetryProvisioningArgs{
+		Machines: []string{"machine-0"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{})
+}
+
+func (s *ProvisioningMachineManagerSuite) TestRetryProvisioningAll(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	s.st.EXPECT().GetBlockForType(state.ChangeBlock).Return(nil, false, nil).AnyTimes()
+
+	machine0 := mocks.NewMockMachine(ctrl)
+	machine0.EXPECT().InstanceStatus().Return(status.StatusInfo{Status: "provisioning error"}, nil)
+	machine0.EXPECT().SetInstanceStatus(statusMatcher{c: c, expected: status.StatusInfo{
+		Status: status.ProvisioningError,
+		Data:   map[string]interface{}{"transient": true},
+	}}).Return(nil)
+	machine1 := mocks.NewMockMachine(ctrl)
+	machine1.EXPECT().InstanceStatus().Return(status.StatusInfo{Status: "pending"}, nil)
+	s.st.EXPECT().AllMachines().Return([]machinemanager.Machine{machine0, machine1}, nil)
+
+	results, err := s.api.RetryProvisioning(params.RetryProvisioningArgs{
+		All: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.ErrorResults{})
 }
 
 type UpgradeSeriesMachineManagerSuite struct{}

--- a/apiserver/facades/client/machinemanager/mocks/types_mock.go
+++ b/apiserver/facades/client/machinemanager/mocks/types_mock.go
@@ -94,6 +94,21 @@ func (mr *MockBackendMockRecorder) AddOneMachine(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOneMachine", reflect.TypeOf((*MockBackend)(nil).AddOneMachine), arg0)
 }
 
+// AllMachines mocks base method.
+func (m *MockBackend) AllMachines() ([]machinemanager.Machine, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllMachines")
+	ret0, _ := ret[0].([]machinemanager.Machine)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllMachines indicates an expected call of AllMachines.
+func (mr *MockBackendMockRecorder) AllMachines() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachines", reflect.TypeOf((*MockBackend)(nil).AllMachines))
+}
+
 // AllSpaceInfos mocks base method.
 func (m *MockBackend) AllSpaceInfos() (network.SpaceInfos, error) {
 	m.ctrl.T.Helper()
@@ -122,21 +137,6 @@ func (m *MockBackend) Application(arg0 string) (machinemanager.Application, erro
 func (mr *MockBackendMockRecorder) Application(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockBackend)(nil).Application), arg0)
-}
-
-// FindEntity mocks base method.
-func (m *MockBackend) FindEntity(arg0 names.Tag) (state.Entity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindEntity", arg0)
-	ret0, _ := ret[0].(state.Entity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindEntity indicates an expected call of FindEntity.
-func (mr *MockBackendMockRecorder) FindEntity(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindEntity", reflect.TypeOf((*MockBackend)(nil).FindEntity), arg0)
 }
 
 // GetBlockForType mocks base method.
@@ -657,6 +657,21 @@ func (mr *MockMachineMockRecorder) Id() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
 }
 
+// InstanceStatus mocks base method.
+func (m *MockMachine) InstanceStatus() (status.StatusInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstanceStatus")
+	ret0, _ := ret[0].(status.StatusInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InstanceStatus indicates an expected call of InstanceStatus.
+func (mr *MockMachineMockRecorder) InstanceStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachine)(nil).InstanceStatus))
+}
+
 // IsLockedForSeriesUpgrade mocks base method.
 func (m *MockMachine) IsLockedForSeriesUpgrade() (bool, error) {
 	m.ctrl.T.Helper()
@@ -726,6 +741,20 @@ func (m *MockMachine) Series() string {
 func (mr *MockMachineMockRecorder) Series() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Series", reflect.TypeOf((*MockMachine)(nil).Series))
+}
+
+// SetInstanceStatus mocks base method.
+func (m *MockMachine) SetInstanceStatus(arg0 status.StatusInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetInstanceStatus indicates an expected call of SetInstanceStatus.
+func (mr *MockMachineMockRecorder) SetInstanceStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachine)(nil).SetInstanceStatus), arg0)
 }
 
 // SetKeepInstance mocks base method.

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -37,13 +37,13 @@ type Backend interface {
 	// Application returns a application state by name.
 	Application(string) (Application, error)
 	Machine(string) (Machine, error)
+	AllMachines() ([]Machine, error)
 	Unit(string) (Unit, error)
 	Model() (Model, error)
 	GetBlockForType(t state.BlockType) (state.Block, bool, error)
 	AddOneMachine(template state.MachineTemplate) (*state.Machine, error)
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (*state.Machine, error)
 	AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (*state.Machine, error)
-	FindEntity(names.Tag) (state.Entity, error)
 	ToolsStorage() (binarystorage.StorageCloser, error)
 }
 
@@ -97,6 +97,8 @@ type Machine interface {
 	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error)
 	SetUpgradeSeriesStatus(model.UpgradeSeriesStatus, string) error
 	ApplicationNames() ([]string, error)
+	InstanceStatus() (status.StatusInfo, error)
+	SetInstanceStatus(sInfo status.StatusInfo) error
 }
 
 type Application interface {
@@ -134,6 +136,18 @@ func (s stateShim) Machine(name string) (Machine, error) {
 	return machineShim{
 		Machine: m,
 	}, nil
+}
+
+func (s stateShim) AllMachines() ([]Machine, error) {
+	all, err := s.State.AllMachines()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]Machine, len(all))
+	for i, m := range all {
+		result[i] = machineShim{Machine: m}
+	}
+	return result, nil
 }
 
 func (s stateShim) Unit(name string) (Unit, error) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -28646,7 +28646,7 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/Entities"
+                            "$ref": "#/definitions/RetryProvisioningArgs"
                         },
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
@@ -29237,6 +29237,24 @@
                     "additionalProperties": false,
                     "required": [
                         "script"
+                    ]
+                },
+                "RetryProvisioningArgs": {
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean"
+                        },
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "all"
                     ]
                 },
                 "StringsResult": {

--- a/cmd/juju/model/retryprovisioning.go
+++ b/cmd/juju/model/retryprovisioning.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
 
 	apiclient "github.com/juju/juju/api/client/client"
@@ -29,13 +30,15 @@ type retryProvisioningCommand struct {
 	modelcmd.IAASOnlyCommand
 	Machines []names.MachineTag
 	api      RetryProvisioningAPI
+
+	all bool
 }
 
 // RetryProvisioningAPI defines methods on the client API
 // that the retry-provisioning command calls.
 type RetryProvisioningAPI interface {
 	Close() error
-	RetryProvisioning(machines ...names.MachineTag) ([]params.ErrorResult, error)
+	RetryProvisioning(all bool, machines ...names.MachineTag) ([]params.ErrorResult, error)
 }
 
 func (c *retryProvisioningCommand) Info() *cmd.Info {
@@ -46,9 +49,16 @@ func (c *retryProvisioningCommand) Info() *cmd.Info {
 	})
 }
 
+func (c *retryProvisioningCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.all, "all", false, "retry provisioning all failed machines")
+}
+
 func (c *retryProvisioningCommand) Init(args []string) error {
-	if len(args) == 0 {
+	if !c.all && len(args) == 0 {
 		return errors.Errorf("no machine specified")
+	}
+	if c.all && len(args) > 0 {
+		return errors.Errorf("specify machines or --all but not both")
 	}
 	c.Machines = make([]names.MachineTag, len(args))
 	for i, arg := range args {
@@ -75,6 +85,9 @@ func (c *retryProvisioningCommand) getAPI() (RetryProvisioningAPI, error) {
 	if client.BestAPIVersion() > 6 {
 		return client, nil
 	}
+	if c.all {
+		return nil, errors.New("this version of Juju does not support --all")
+	}
 	return apiclient.NewClient(root), nil
 }
 
@@ -85,7 +98,7 @@ func (c *retryProvisioningCommand) Run(context *cmd.Context) error {
 	}
 	defer client.Close()
 
-	results, err := client.RetryProvisioning(c.Machines...)
+	results, err := client.RetryProvisioning(c.all, c.Machines...)
 	if err != nil {
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -782,6 +782,12 @@ type AgentVersionResult struct {
 	Version version.Number `json:"version"`
 }
 
+// RetryProvisioningArgs holds args for retrying machine provisioning.
+type RetryProvisioningArgs struct {
+	Machines []string `json:"machines,omitempty"`
+	All      bool     `json:"all"`
+}
+
 // ProvisioningInfoBase holds machine provisioning info common
 // across different versions of the provisioner API facade.
 type ProvisioningInfoBase struct {


### PR DESCRIPTION
When many machines fail to provision, having a `--all` option for `juju retry-provisioning` is useful.

## QA steps

I had to introduce a deliberate provisioning error to the code. When a machine failed to provision
`juju retry-provisioning --all`
would correctly cause the failed machine to retry, ignoring the others.

And
`juju retry-provisioning X`
would still correctly target that specific machine

## Bug reference

https://bugs.launchpad.net/juju/+bug/1940440
