### PR TITLE
[JUJU-1480] Fix display of upgrading-from for subordinate units

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1550,7 +1550,18 @@ func (context *statusContext) processUnit(unit *state.Unit, applicationCharm str
 			subUnit := context.unitByName(name)
 			// subUnit may be nil if subordinate was filtered out.
 			if subUnit != nil {
-				result.Subordinates[name] = context.processUnit(subUnit, applicationCharm, true)
+				subUnitAppCharm := ""
+				subUnitApp, err := subUnit.Application()
+				if err != nil {
+					logger.Debugf("error fetching subordinate application for %q", subUnit.ApplicationName())
+				}
+				subUnitAppCh, _, err := subUnitApp.Charm()
+				if err == nil {
+					subUnitAppCharm = subUnitAppCh.String()
+				} else {
+					logger.Debugf("error fetching subordinate application charm for %q", subUnit.ApplicationName())
+				}
+				result.Subordinates[name] = context.processUnit(subUnit, subUnitAppCharm, true)
 			}
 		}
 	}


### PR DESCRIPTION
When status was being collated for units, subordinate processing was passing in the application charm URL of the principal app, not the subordinate app. This caused the "upgrading-from" value to be incorrectly set.

## QA steps

```
juju deploy ubuntu 
juju deploy cs:~container-log-archive-charmers/container-log-archive-18
juju relate ubuntu container-log-archive
juju status --format yaml
```
ssh into machine 0 and stop machine agent

```
juju upgrade-charm cs:~container-log-archive-charmers/container-log-archive
juju status --format yaml
```

ssh into machine 0 and start machine agent

```
juju status --format yaml
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1981022
