### PR TITLE
[JUJU-1482] Moved case BOOTSTRAP_PROVIDER logic from task.sh

### DIFF
--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -1,88 +1,25 @@
-run_constraints_lxd() {
-  # Echo out to ensure nice output to the test suite.
-  echo
-
-  file="${TEST_DIR}/constraints-lxd.txt"
-
-  ensure "constraints-lxd" "${file}"
-
-  echo "Deploy 2 machines with different constraints"
-  juju add-machine --constraints "cores=2"
-  juju add-machine --constraints "cores=2 mem=2G"
-
-  wait_for_machine_agent_status "0" "started"
-  wait_for_machine_agent_status "1" "started"
-
-  echo "Ensure machine 0 has 2 cores"
-  machine0_hardware=$(juju machines --format json | jq -r '.["machines"]["0"]["hardware"]')
-  check_contains "${machine0_hardware}" "cores=2"
-
-  echo "Ensure machine 1 has 2 cores and 2G memory"
-  machine1_hardware=$(juju machines --format json | jq -r '.["machines"]["1"]["hardware"]')
-  check_contains "${machine1_hardware}" "cores=2"
-  check_contains "${machine1_hardware}" "mem=2048M"
-
-  destroy_model "constraints-lxd"
-}
-
-run_constraints_aws() {
-  # Echo out to ensure nice output to the test suite.
-  echo
-
-  file="${TEST_DIR}/constraints-aws.txt"
-
-  ensure "constraints-aws" "${file}"
-
-  echo "Deploy 3 machines with different constraints"
-  juju add-machine --constraints "root-disk=16G"
-  juju add-machine --constraints "cores=4 root-disk=16G"
-  juju add-machine --constraints "instance-type=t2.nano"
-
-  wait_for_machine_agent_status "0" "started"
-  wait_for_machine_agent_status "1" "started"
-  wait_for_machine_agent_status "2" "started"
-
-  echo "Ensure machine 0 has 16G root disk"
-  machine0_hardware=$(juju machines --format json | jq -r '.["machines"]["0"]["hardware"]')
-  machine0_rootdisk=$(echo "$machine0_hardware" | awk '{for(i=1;i<=NF;i++){if($i ~ /root-disk/){print $i}}}')
-  check_ge "${machine0_rootdisk}" "root-disk=16384M"
-
-  echo "Ensure machine 1 has 4 cores and 16G root disk"
-  machine1_hardware=$(juju machines --format json | jq -r '.["machines"]["1"]["hardware"]')
-  machine1_cores=$(echo "$machine1_hardware" | awk '{for(i=1;i<=NF;i++){if($i ~ /cores/){print $i}}}')
-  machine1_rootdisk=$(echo "$machine1_hardware" | awk '{for(i=1;i<=NF;i++){if($i ~ /root-disk/){print $i}}}')
-  check_ge "${machine1_cores}" "cores=4"
-  check_ge "${machine1_rootdisk}" "root-disk=16384M"
-
-	echo "Ensure machine 2 has t2.nano instance type"
-  machine2_constraints=$(juju machines --format json | jq -r '.["machines"]["2"]["constraints"]')
-  check_contains "${machine2_constraints}" "instance-type=t2.nano"
-
-  destroy_model "constraints-aws"
-}
-
-test_constraints_lxd() {
-  if [ "$(skip 'test_constraints_lxd')" ]; then
-  		echo "==> TEST SKIPPED: constraints lxd"
+test_constraints_common() {
+  if [ "$(skip 'test_constraints_common')" ]; then
+  		echo "==> TEST SKIPPED: constraints common tests"
   		return
   fi
 
   (
   		set_verbosity
-  		cd .. || exit
-  		run "run_constraints_lxd"
-  )
-}
 
-test_constraints_aws() {
-  if [ "$(skip 'test_constraints_aws')" ]; then
-  		echo "==> TEST SKIPPED: constraints aws"
-  		return
-  fi
-
-  (
-  		set_verbosity
   		cd .. || exit
-  		run "run_constraints_aws"
+
+  		case "${BOOTSTRAP_PROVIDER:-}" in
+      "lxd" | "lxd-remote" | "localhost")
+        run "run_constraints_lxd"
+        ;;
+      "aws" | "ec2")
+        export BOOTSTRAP_PROVIDER="manual"
+        run "run_constraints_aws"
+        ;;
+      *)
+        echo "==> TEST SKIPPED: constraints - tests for LXD and AWS only"
+        ;;
+      esac
   )
 }

--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -9,7 +9,7 @@ test_constraints_common() {
 
   		cd .. || exit
 
-  		case "${BOOTSTRAP_PROVIDER:-}" in
+      case "${BOOTSTRAP_PROVIDER:-}" in
       "lxd" | "lxd-remote" | "localhost")
         run "run_constraints_lxd"
         ;;

--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -1,6 +1,6 @@
 test_constraints_common() {
   if [ "$(skip 'test_constraints_common')" ]; then
-  		echo "==> TEST SKIPPED: constraints common tests"
+  		echo "==> TEST SKIPPED: constraints"
   		return
   fi
 
@@ -9,15 +9,15 @@ test_constraints_common() {
 
   		cd .. || exit
 
-      case "${BOOTSTRAP_PROVIDER:-}" in
+  		case "${BOOTSTRAP_PROVIDER:-}" in
       "lxd" | "lxd-remote" | "localhost")
         run "run_constraints_lxd"
         ;;
-      "aws" | "ec2")
-        run "run_constraints_aws"
+      "microk8s")
+        echo "==> TEST SKIPPED: constraints - there are no test for k8s cloud"
         ;;
       *)
-        echo "==> TEST SKIPPED: constraints - tests for LXD and AWS only"
+        run "run_constraints_vm"
         ;;
       esac
   )

--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -14,7 +14,6 @@ test_constraints_common() {
         run "run_constraints_lxd"
         ;;
       "aws" | "ec2")
-        export BOOTSTRAP_PROVIDER="manual"
         run "run_constraints_aws"
         ;;
       *)

--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -10,15 +10,15 @@ test_constraints_common() {
   		cd .. || exit
 
   		case "${BOOTSTRAP_PROVIDER:-}" in
-      "lxd" | "lxd-remote" | "localhost")
-        run "run_constraints_lxd"
-        ;;
-      "microk8s")
-        echo "==> TEST SKIPPED: constraints - there are no test for k8s cloud"
-        ;;
-      *)
-        run "run_constraints_vm"
-        ;;
-      esac
+  		"lxd" | "lxd-remote" | "localhost")
+  		  run "run_constraints_lxd"
+  		  ;;
+  		"microk8s")
+  		  echo "==> TEST SKIPPED: constraints - there are no test for k8s cloud"
+  		  ;;
+  		*)
+  		  run "run_constraints_vm"
+  		  ;;
+  		esac
   )
 }

--- a/tests/suites/constraints/constraints_aws.sh
+++ b/tests/suites/constraints/constraints_aws.sh
@@ -1,0 +1,35 @@
+run_constraints_aws() {
+  # Echo out to ensure nice output to the test suite.
+  echo
+
+  file="${TEST_DIR}/constraints-aws.txt"
+
+  ensure "constraints-aws" "${file}"
+
+  echo "Deploy 3 machines with different constraints"
+  juju add-machine --constraints "root-disk=16G"
+  juju add-machine --constraints "cores=4 root-disk=16G"
+  juju add-machine --constraints "instance-type=t2.nano"
+
+  wait_for_machine_agent_status "0" "started"
+  wait_for_machine_agent_status "1" "started"
+  wait_for_machine_agent_status "2" "started"
+
+  echo "Ensure machine 0 has 16G root disk"
+  machine0_hardware=$(juju machines --format json | jq -r '.["machines"]["0"]["hardware"]')
+  machine0_rootdisk=$(echo "$machine0_hardware" | awk '{for(i=1;i<=NF;i++){if($i ~ /root-disk/){print $i}}}')
+  check_ge "${machine0_rootdisk}" "root-disk=16384M"
+
+  echo "Ensure machine 1 has 4 cores and 16G root disk"
+  machine1_hardware=$(juju machines --format json | jq -r '.["machines"]["1"]["hardware"]')
+  machine1_cores=$(echo "$machine1_hardware" | awk '{for(i=1;i<=NF;i++){if($i ~ /cores/){print $i}}}')
+  machine1_rootdisk=$(echo "$machine1_hardware" | awk '{for(i=1;i<=NF;i++){if($i ~ /root-disk/){print $i}}}')
+  check_ge "${machine1_cores}" "cores=4"
+  check_ge "${machine1_rootdisk}" "root-disk=16384M"
+
+	echo "Ensure machine 2 has t2.nano instance type"
+  machine2_constraints=$(juju machines --format json | jq -r '.["machines"]["2"]["constraints"]')
+  check_contains "${machine2_constraints}" "instance-type=t2.nano"
+
+  destroy_model "constraints-aws"
+}

--- a/tests/suites/constraints/constraints_lxd.sh
+++ b/tests/suites/constraints/constraints_lxd.sh
@@ -1,0 +1,26 @@
+run_constraints_lxd() {
+  # Echo out to ensure nice output to the test suite.
+  echo
+
+  file="${TEST_DIR}/constraints-lxd.txt"
+
+  ensure "constraints-lxd" "${file}"
+
+  echo "Deploy 2 machines with different constraints"
+  juju add-machine --constraints "cores=2"
+  juju add-machine --constraints "cores=2 mem=2G"
+
+  wait_for_machine_agent_status "0" "started"
+  wait_for_machine_agent_status "1" "started"
+
+  echo "Ensure machine 0 has 2 cores"
+  machine0_hardware=$(juju machines --format json | jq -r '.["machines"]["0"]["hardware"]')
+  check_contains "${machine0_hardware}" "cores=2"
+
+  echo "Ensure machine 1 has 2 cores and 2G memory"
+  machine1_hardware=$(juju machines --format json | jq -r '.["machines"]["1"]["hardware"]')
+  check_contains "${machine1_hardware}" "cores=2"
+  check_contains "${machine1_hardware}" "mem=2048M"
+
+  destroy_model "constraints-lxd"
+}

--- a/tests/suites/constraints/constraints_vm.sh
+++ b/tests/suites/constraints/constraints_vm.sh
@@ -1,19 +1,17 @@
-run_constraints_aws() {
+run_constraints_vm() {
   # Echo out to ensure nice output to the test suite.
   echo
 
-  file="${TEST_DIR}/constraints-aws.txt"
+  file="${TEST_DIR}/constraints-vm.txt"
 
-  ensure "constraints-aws" "${file}"
+  ensure "constraints-vm" "${file}"
 
-  echo "Deploy 3 machines with different constraints"
+  echo "Deploy 2 machines with different constraints"
   juju add-machine --constraints "root-disk=16G"
   juju add-machine --constraints "cores=4 root-disk=16G"
-  juju add-machine --constraints "instance-type=t2.nano"
 
   wait_for_machine_agent_status "0" "started"
   wait_for_machine_agent_status "1" "started"
-  wait_for_machine_agent_status "2" "started"
 
   echo "Ensure machine 0 has 16G root disk"
   machine0_hardware=$(juju machines --format json | jq -r '.["machines"]["0"]["hardware"]')
@@ -27,9 +25,5 @@ run_constraints_aws() {
   check_ge "${machine1_cores}" "cores=4"
   check_ge "${machine1_rootdisk}" "root-disk=16384M"
 
-	echo "Ensure machine 2 has t2.nano instance type"
-  machine2_constraints=$(juju machines --format json | jq -r '.["machines"]["2"]["constraints"]')
-  check_contains "${machine2_constraints}" "instance-type=t2.nano"
-
-  destroy_model "constraints-aws"
+  destroy_model "constraints-vm"
 }

--- a/tests/suites/constraints/task.sh
+++ b/tests/suites/constraints/task.sh
@@ -13,15 +13,7 @@ test_constraints() {
 
 	bootstrap "test-constraints" "${file}"
 
-
-	case "${BOOTSTRAP_PROVIDER:-}" in
-  "aws")
-    test_constraints_aws
-    ;;
-  "lxd")
-    test_constraints_lxd
-    ;;
-  esac
+  test_constraints_common
 
 	destroy_controller "test-constraints"
 }


### PR DESCRIPTION
Generating constraints tests in juju-qa-jenking caused naming issues. The possible reason is that 'case BOOTSTRAP_PROVIDER' logic are task.sh file. This patch moves 'case BOOTSTRAP_PROVIDER' to constraints.sh.

## Checklist
 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
cd tests
./main -v -p lxd constraints
./main -v -p aws constraints
```

## Documentation changes

None

## Bug reference

None