### PR TITLE
[JUJU-1476] Fix deploy resource by revision

### DIFF
--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -192,7 +192,7 @@ func (d deployUploader) validateResources() error {
 }
 
 // charmStoreResources returns which resources revisions will need to be retrieved
-// either as they where explicitly requested by the user for that rev or they
+// either as they were explicitly requested by the user for that rev or they
 // weren't provided by the user.
 func (d deployUploader) charmStoreResources(uploads map[string]string, revisions map[string]int) []charmresource.Resource {
 	var resources []charmresource.Resource


### PR DESCRIPTION
Allow for gathering resource data from charmhub by name as a fallback if an ID isn't provided.

## QA steps

```sh
(cd tests ; ./main.sh -v deploy test_deploy_revision )
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1982352