### PR TITLE
[accep tests] print status if teardown fails

### DIFF
--- a/acceptancetests/deploy_stack.py
+++ b/acceptancetests/deploy_stack.py
@@ -639,10 +639,14 @@ class CreateController:
 
     def tear_down(self, has_controller):
         """Tear down via client.tear_down."""
-        if has_controller:
-            self.tear_down_client.tear_down()
-        else:
-            self.tear_down_client.kill_controller(check=True)
+        try:
+            if has_controller:
+                self.tear_down_client.tear_down()
+            else:
+                self.tear_down_client.kill_controller(check=True)
+        except:
+            safe_print_status(self.client)
+            pass
 
 
 class ExistingController:


### PR DESCRIPTION
The `nw-constraints-aws` test is failing because the controller teardown times out - it can't seem to remove one stubborn application. However, I can't seem to reproduce this bug locally. So, I've added a print status to the debugging here so we can tell which app is causing the problem.