### PR TITLE
[smoke test] use jammy

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,12 +19,14 @@ jobs:
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
         sudo snap install snapcraft --classic
-        sudo snap install lxd
+        sudo snap refresh lxd --channel latest/stable
+        
         sudo lxd waitready
         sudo lxd init --auto
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
         echo "/snap/bin" >> $GITHUB_PATH
         lxc network set lxdbr0 ipv6.address none
+        lxc version
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -5,7 +5,7 @@ run_local_deploy() {
 
 	ensure "test-local-deploy" "${file}"
 
-	juju deploy ./tests/suites/smoke/charms/ubuntu --series focal
+	juju deploy ./tests/suites/smoke/charms/ubuntu
 	wait_for "ubuntu" "$(idle_condition "ubuntu")" 60 # 60x5s = 5m
 
 	juju refresh ubuntu --path=./tests/suites/smoke/charms/ubuntu


### PR DESCRIPTION
Now that the [bug with Jammy machines](https://bugs.launchpad.net/juju/+bug/1981955) is understood, we can move the smoke test back to using jammy by default.

Don't merge until the GitHub smoke test passes.

## QA steps

```sh
cd tests
./main.sh -v smoke
```