### PR TITLE
[JUJU-1200] Use CharmHub charms instead of acceptancetests charms in model tests

### DIFF
--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -47,14 +47,14 @@ run_model_migration_saas_common() {
 	bootstrap_alt_controller "alt-model-migration-saas"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy ./acceptancetests/repository/charms/dummy-source
+	juju deploy juju-qa-dummy-source
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju add-model blog
 	juju switch blog
-	juju deploy ./acceptancetests/repository/charms/dummy-sink
+	juju deploy juju-qa-dummy-sink
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -108,13 +108,13 @@ run_model_migration_saas_external() {
 	bootstrap_alt_controller "model-migration-saas-target"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy ./acceptancetests/repository/charms/dummy-source
+	juju deploy juju-qa-dummy-source
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju switch "model-migration-saas-consume"
-	juju deploy ./acceptancetests/repository/charms/dummy-sink
+	juju deploy juju-qa-dummy-sink
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
@@ -169,14 +169,14 @@ run_model_migration_saas_consumer() {
 	bootstrap_alt_controller "model-migration-saas-target"
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
-	juju deploy ./acceptancetests/repository/charms/dummy-source
+	juju deploy juju-qa-dummy-source
 	juju offer dummy-source:sink
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	juju switch "model-migration-saas-consume"
 	juju add-model "model-migration-consumer"
-	juju deploy ./acceptancetests/repository/charms/dummy-sink
+	juju deploy juju-qa-dummy-sink
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 


### PR DESCRIPTION
This is already the case in 2.9

The hard coded charms cause the test to fail when they don't deploy properly. Dummy-sink, for instance, deploys to trusty

NOTE: This doesn't fully fix the problems with this test suite, but it is an improvement

## QA steps

```sh
./main.sh -v -s 'test_model_config,test_model_multi,test_model_metrics' model
```
