### PR TITLE
[juju-1483] Use requested resource revision

### DIFF
--- a/resource/charmhub.go
+++ b/resource/charmhub.go
@@ -7,11 +7,9 @@ import (
 	"context"
 	"net/url"
 
+	charmresource "github.com/juju/charm/v8/resource"
 	"github.com/juju/errors"
 	"github.com/kr/pretty"
-
-	"github.com/juju/charm/v8"
-	charmresource "github.com/juju/charm/v8/resource"
 
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/charmhub/transport"
@@ -79,30 +77,26 @@ func (ch *CharmHubClient) GetResource(req ResourceRequest) (ResourceData, error)
 	ch.logger.Tracef("GetResource(%s)", pretty.Sprint(req))
 	var data ResourceData
 
+	// GetResource is called after a charm is installed, therefore the
+	// origin must have an ID. Error if not.
 	origin := req.CharmID.Origin
-
-	stChannel := origin.Channel
-	if stChannel == nil {
-		return data, errors.Errorf("missing channel for %q", req.CharmID.URL.Name)
+	if origin.Revision == nil {
+		return data, errors.BadRequestf("empty charm origin revision")
 	}
-	channel, err := charm.MakeChannel(stChannel.Track, stChannel.Risk, stChannel.Branch)
+
+	// The charm revision isn't really required here, just handy for
+	// getting the correct resource revision. Using a channel would
+	// limit resource revisions found. The resource revision is set
+	// during deploy when a resolving resources for add pending resources.
+	// This also closes a timing window where a charm and resource
+	// is updated in the channel in between deploy and resource use.
+	cfg, err := charmhub.DownloadOneFromRevision(origin.ID, *origin.Revision)
 	if err != nil {
 		return data, errors.Trace(err)
 	}
-
-	if req.CharmID.URL == nil {
-		return data, errors.Errorf("missing charm url for resource %q", req.Name)
+	if newCfg, ok := charmhub.AddResource(cfg, req.Name, req.Revision); ok {
+		cfg = newCfg
 	}
-
-	cfg, err := charmhub.DownloadOneFromChannel(origin.ID, channel.String(), charmhub.RefreshBase{
-		Architecture: origin.Platform.Architecture,
-		Name:         origin.Platform.OS,
-		Channel:      origin.Platform.Series,
-	})
-	if err != nil {
-		return data, errors.Trace(err)
-	}
-
 	refreshResp, err := ch.client.Refresh(context.TODO(), cfg)
 	if err != nil {
 		return data, errors.Trace(err)

--- a/resource/charmhub_test.go
+++ b/resource/charmhub_test.go
@@ -34,12 +34,14 @@ func (s *CharmHubSuite) TestGetResource(c *gc.C) {
 
 	cl := s.newCharmHubClient()
 	curl, _ := charm.ParseURL("ch:postgresql")
+	rev := 42
 	result, err := cl.GetResource(resource.ResourceRequest{
 		CharmID: resource.CharmID{
 			URL: curl,
 			Origin: state.CharmOrigin{
-				ID:      "mycharmhubid",
-				Channel: &state.Channel{Risk: "stable"},
+				ID:       "mycharmhubid",
+				Channel:  &state.Channel{Risk: "stable"},
+				Revision: &rev,
 				Platform: &state.Platform{
 					Architecture: "amd64",
 					OS:           "ubuntu",
@@ -48,7 +50,7 @@ func (s *CharmHubSuite) TestGetResource(c *gc.C) {
 			},
 		},
 		Name:     "wal-e",
-		Revision: 0,
+		Revision: 8,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -59,7 +61,7 @@ func (s *CharmHubSuite) TestGetResource(c *gc.C) {
 			Type: 1,
 		},
 		Origin:      2,
-		Revision:    0,
+		Revision:    8,
 		Fingerprint: fp,
 		Size:        0,
 	})
@@ -90,7 +92,7 @@ func (s *CharmHubSuite) expectRefresh() {
 							Size:       0,
 							URL:        "https://api.staging.charmhub.io/api/v1/resources/download/charm_jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD.wal-e_0"},
 						Name:     "wal-e",
-						Revision: 0,
+						Revision: 8,
 						Type:     "file",
 					},
 				},


### PR DESCRIPTION
Resource revisions were checked when adding a pending resource and the appropriate one found. However when it can time to download and install the resource, the revision was ignored for charm hub charms.

Updated the integration tests to appropriately verify this.

## QA steps

```sh
(cd tests ; ./main.sh -v deploy test_deploy_revision )
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1982406