### PR TITLE
[JUJU-1487] Update the unit watcher used by the lxdprofile watcher

### DIFF
--- a/state/watcher.go
+++ b/state/watcher.go
@@ -411,7 +411,7 @@ func (st *State) WatchApplicationCharms() StringsWatcher {
 
 // WatchUnits notifies when units change.
 func (st *State) WatchUnits() StringsWatcher {
-	return newLifecycleWatcher(st, unitsC, nil, isLocalID(st), nil)
+	return newCollectionWatcher(st, colWCfg{col: unitsC})
 }
 
 // WatchMachines notifies when machines change.

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -108,10 +108,15 @@ run_deploy_lxd_to_machine() {
 
 	ensure "${model_name}" "${file}"
 
-	juju add-machine -n 1 --series=bionic
+	juju add-machine -n 2 --series=bionic
 
 	charm=./tests/suites/deploy/charms/lxd-profile-alt
 	juju deploy "${charm}" --to 0 --series=bionic
+
+	# Test the case where we wait for the machine to start
+	# before deploying the unit.
+	wait_for_machine_agent_status "1" "started"
+	juju add-unit lxd-profile-alt --to 1
 
 	wait_for "lxd-profile-alt" "$(idle_condition "lxd-profile-alt")"
 


### PR DESCRIPTION
The LXD profile watcher uses several state watchers to notify when the profiles on a machine should be re-evaluated. For units, the events of interest are units being added, life going to dead, and assigned machine changes. The state watcher being used was a lifecycle watcher which notified on add and removal (not dead) but did not notify on changes to the unit itself like assigned machine changes.

Here we change the underlying unit watcher to an collection watcher. This notifies of adds and changes, but not removals. That's ok because the lxd profile watcher checks for transition to dead which has the same effect.

## QA steps

To trigger the bug, add a machine and wait for it to be fully provisioned.

juju add-machine --series focal

The deploy the charm.

juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to 0 --series focal --force

Previously this would fail with a message in status: required charm profile not yet applied to machine

## Bug reference

https://bugs.launchpad.net/juju/+bug/1982329
