### PR TITLE
[ck test] increase timeout to 30 min

### DIFF
--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -15,7 +15,7 @@ run_deploy_ck() {
 		sudo snap install kubectl --classic --channel latest/stable
 	fi
 
-	wait_for "active" '.applications["kubernetes-control-plane"] | ."application-status".current'
+	wait_for "active" '.applications["kubernetes-control-plane"] | ."application-status".current' 360
 	wait_for "active" '.applications["kubernetes-worker"] | ."application-status".current'
 
 	kube_home="${HOME}/.kube"


### PR DESCRIPTION
My PR #14327 added a default 10 min timeout to all of the `wait_for`'s in the bash tests. This is not enough time for the `test-ck-aws` gating test, which deploys a **lot** of stuff (the last successful run took ~20 minutes for this step). I have set the timeout for this step to 30 mins (360 attempts @ 5s each), which should allow for everything to reach a steady state.