### PR TITLE
[JUJU-1490] Fix test deploy test deploy bundles aws

### DIFF
--- a/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
@@ -1,0 +1,30 @@
+series: bionic
+applications:
+  influxdb:
+    charm: influxdb
+    channel: stable
+    revision: -1
+    num_units: 1
+    to:
+    - "0"
+    constraints: arch=amd64
+  telegraf:
+    charm: telegraf
+    channel: stable
+    revision: -1
+  ubuntu:
+    charm: ubuntu
+    channel: stable
+    revision: -1
+    num_units: 1
+    to:
+    - "1"
+    constraints: arch=amd64
+machines:
+  "0": {}
+  "1": {}
+relations:
+- - telegraf:juju-info
+  - ubuntu:juju-info
+- - telegraf:influxdb-api
+  - influxdb:query

--- a/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
@@ -1,0 +1,27 @@
+series: bionic
+applications:
+  influxdb:
+    charm: influxdb
+    channel: stable
+    num_units: 1
+    to:
+    - "0"
+    constraints: arch=amd64
+  telegraf:
+    charm: telegraf
+    channel: stable
+  ubuntu:
+    charm: ubuntu
+    channel: stable
+    num_units: 1
+    to:
+    - "1"
+    constraints: arch=amd64
+machines:
+  "0": {}
+  "1": {}
+relations:
+- - telegraf:juju-info
+  - ubuntu:juju-info
+- - telegraf:influxdb-api
+  - influxdb:query

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -104,11 +104,12 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
   " "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 
 	# The model should be updated immediately, so we can export the bundle before 
-	# everything is done deploying
-	echo "Compare export-bundle with telegraf_bundle_with_revisions"
-	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
-	# we need to use -w flag because file after yq and juju export-bundle yaml generator have different space policies
-	diff -u -w "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported-bundle.yaml"
+  	# everything is done deploying
+  	echo "Compare export-bundle with telegraf_bundle_with_revisions"
+  	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
+  	# to have the same output format with telegraf_bundle_with_revisions.yaml
+  	yq -i . "${TEST_DIR}/exported-bundle.yaml"
+  	diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported-bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-float-revisions"
 }

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -74,8 +74,8 @@ run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
 	destroy_model "test-export-bundles-deploy-with-fixed-revisions"
 }
 
-# run_deploy_exported_charmhub_bundle_with_float_revisions is to test which checks
-# how juju deploys charmhub bundles with undefined versions in bundle yaml
+# run_deploy_exported_charmhub_bundle_with_float_revisions checks how juju
+# deploys a charmhub bundle when the revisions are not pinned
 run_deploy_exported_charmhub_bundle_with_float_revisions() {
   echo
 

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -67,7 +67,7 @@ run_deploy_exported_bundle() {
 	# no need to wait for the bundle to finish deploying to
 	# check the export.
 	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
-	diff ${bundle} "${TEST_DIR}/exported-bundle.yaml"
+	diff -u ${bundle} "${TEST_DIR}/exported-bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy"
 }

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -35,7 +35,7 @@ run_deploy_cmr_bundle() {
 
 	ensure "test-cmr-bundles-deploy" "${file}"
 
-	# mysql charm does not have stable channel, so we use candidate channel
+	# mysql charm does not have stable channel, so we use the candidate channel
 	juju deploy mysql --channel=candidate
 	wait_for "mysql" ".applications | keys[0]"
 

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -103,8 +103,8 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
     .applications.ubuntu.revision = ${ubuntu_rev}
   " "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 
-	# no need to wait for the bundle to finish deploying to
-	# check the export.
+	# The model should be updated immediately, so we can export the bundle before 
+	# everything is done deploying
 	echo "Compare export-bundle with telegraf_bundle_with_revisions"
 	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
 	# we need to use -w flag because file after yq and juju export-bundle yaml generator have different space policies

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -35,8 +35,8 @@ run_deploy_cmr_bundle() {
 
 	ensure "test-cmr-bundles-deploy" "${file}"
 
-	# mysql charm does not have stable channel, so we use edge channel
-	juju deploy mysql --channel=edge
+	# mysql charm does not have stable channel, so we use candidate channel
+	juju deploy mysql --channel=candidate
 	wait_for "mysql" ".applications | keys[0]"
 
 	juju offer mysql:db

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -77,18 +77,17 @@ run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
 # run_deploy_exported_charmhub_bundle_with_float_revisions is to test which checks
 # how juju deploys charmhub bundles with undefined versions in bundle yaml
 run_deploy_exported_charmhub_bundle_with_float_revisions() {
-	echo
+  echo
 
-	file="${TEST_DIR}/test-export-bundles-deploy-with-float-revisions.log"
+  file="${TEST_DIR}/test-export-bundles-deploy-with-float-revisions.log"
 
-	ensure "test-export-bundles-deploy-with-float-revisions" "${file}"
+  ensure "test-export-bundles-deploy-with-float-revisions" "${file}"
+  bundle=./tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
+  bundle_with_fake_revisions=./tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
+  juju deploy ${bundle}
 
-	bundle=./tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
-	bundle_with_fake_revisions=./tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
-	juju deploy ${bundle}
-
-	if ! which "yq" >/dev/null 2>&1; then
-	  sudo snap install yq --classic --channel latest/stable
+  if ! which "yq" >/dev/null 2>&1; then
+    sudo snap install yq --classic --channel latest/stable
   fi
 
   echo "Get current stable revisions for charms in telegraf_bundle_without_revisions.yaml"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -103,13 +103,13 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
     .applications.ubuntu.revision = ${ubuntu_rev}
   " "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 
-	# The model should be updated immediately, so we can export the bundle before 
-  	# everything is done deploying
-  	echo "Compare export-bundle with telegraf_bundle_with_revisions"
-  	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
-  	# to have the same output format with telegraf_bundle_with_revisions.yaml
-  	yq -i . "${TEST_DIR}/exported-bundle.yaml"
-  	diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported-bundle.yaml"
+  # The model should be updated immediately, so we can export the bundle before
+  # everything is done deploying
+  echo "Compare export-bundle with telegraf_bundle_with_revisions"
+  juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
+  # to have the same output format with telegraf_bundle_with_revisions.yaml
+  yq -i . "${TEST_DIR}/exported-bundle.yaml"
+  diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported-bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-float-revisions"
 }

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -54,8 +54,8 @@ run_deploy_cmr_bundle() {
 	destroy_model "other"
 }
 
-# run_deploy_exported_charmstore_bundle_with_fixed_revisions is to test which checks
-# how juju deploys charmstore bundles with fixed revisions
+# run_deploy_exported_charmstore_bundle_with_fixed_revisions tests how juju deploys
+# a charmstore bundle that specifies revisions for its charms
 run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
 	echo
 

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -90,7 +90,7 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
     sudo snap install yq --classic --channel latest/stable
   fi
 
-  echo "Get current stable revisions for charms in telegraf_bundle_without_revisions.yaml"
+  echo "Create telegraf_bundle_without_revisions.yaml with known latest revisions from charmhub"
   influxdb_rev=$(juju info influxdb --format json | jq -r '."channel-map"."latest/stable".revision')
   telegraf_rev=$(juju info telegraf --format json | jq -r '."channel-map"."latest/stable".revision')
   ubuntu_rev=$(juju info ubuntu --format json | jq -r '."channel-map"."latest/stable".revision')

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -107,7 +107,7 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
   # everything is done deploying
   echo "Compare export-bundle with telegraf_bundle_with_revisions"
   juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
-  # to have the same output format with telegraf_bundle_with_revisions.yaml
+  # reformat the yaml to have the same format as telegraf_bundle_with_revisions.yaml
   yq -i . "${TEST_DIR}/exported-bundle.yaml"
   diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported-bundle.yaml"
 


### PR DESCRIPTION
This patch fixes issues with mysql on 2.9, and revision issues on 3.0.
Also, this patch adds new tests with float and fixed revision for charm in the bundle's yaml.

## Checklist

 ~- [ ] Requires a [pylibjuju](https://github.com/juju/python-libjuju) change~
 ~- [ ] Added [integration tests](https://github.com/juju/juju/tree/develop/tests) for the PR~
 ~- [ ] Added or updated [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) related to packages changed~
 - [x] Comments answer the question of why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p aws deploy
```

