### PR TITLE
[JUJU-1493] Fix race condition removing a charm with an lxd profile

### DIFF
--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -332,23 +332,31 @@ func (api *InstanceMutaterAPI) machineLXDProfileInfo(m Machine) (lxdProfileInfo,
 	if err != nil {
 		return empty, errors.Trace(err)
 	}
-	changeResults := make([]params.ProfileInfoResult, len(units))
-	for i, unit := range units {
+
+	var changeResults []params.ProfileInfoResult
+	for _, unit := range units {
+		if unit.Life() == state.Dead {
+			logger.Debugf("unit %q is dead, do not load profile", unit.Name())
+			continue
+		}
 		appName := unit.ApplicationName()
 		app, err := api.st.Application(appName)
 		if err != nil {
-			changeResults[i].Error = apiservererrors.ServerError(err)
+			changeResults = append(changeResults, params.ProfileInfoResult{
+				Error: apiservererrors.ServerError(err)})
 			continue
 		}
 		cURL := app.CharmURL()
 		chURL, err := charm.ParseURL(*cURL)
 		if err != nil {
-			changeResults[i].Error = apiservererrors.ServerError(err)
+			changeResults = append(changeResults, params.ProfileInfoResult{
+				Error: apiservererrors.ServerError(err)})
 			continue
 		}
 		ch, err := api.st.Charm(chURL)
 		if err != nil {
-			changeResults[i].Error = apiservererrors.ServerError(err)
+			changeResults = append(changeResults, params.ProfileInfoResult{
+				Error: apiservererrors.ServerError(err)})
 			continue
 		}
 
@@ -360,11 +368,11 @@ func (api *InstanceMutaterAPI) machineLXDProfileInfo(m Machine) (lxdProfileInfo,
 				Devices:     profile.Devices,
 			}
 		}
-		changeResults[i] = params.ProfileInfoResult{
+		changeResults = append(changeResults, params.ProfileInfoResult{
 			ApplicationName: appName,
 			Revision:        ch.Revision(),
 			Profile:         normalised,
-		}
+		})
 	}
 	modelName, err := api.st.ModelName()
 	if err != nil {

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -257,7 +257,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfo(c *gc
 	s.expectLife(s.machineTag)
 	s.expectMachine(s.machineTag, s.machine)
 	s.expectInstanceId("0")
-	s.expectUnits(1)
+	s.expectUnits(state.Alive)
 	s.expectCharmProfiles()
 	s.expectProfileExtraction()
 	s.expectName()
@@ -299,7 +299,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithNo
 	s.expectLife(s.machineTag)
 	s.expectMachine(s.machineTag, s.machine)
 	s.expectInstanceId("0")
-	s.expectUnits(2)
+	s.expectUnits(state.Alive, state.Alive, state.Dead)
 	s.expectCharmProfiles()
 	s.expectProfileExtraction()
 	s.expectProfileExtractionWithEmpty()
@@ -378,11 +378,15 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectInstanceIdNotProvision
 	s.machine.EXPECT().InstanceId().Return(instance.Id("0"), params.Error{Code: params.CodeNotProvisioned})
 }
 
-func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectUnits(times int) {
+func (s *InstanceMutaterAPICharmProfilingInfoSuite) expectUnits(lives ...state.Life) {
 	machineExp := s.machine.EXPECT()
-	units := make([]instancemutater.Unit, times)
-	for i := 0; i < times; i++ {
+	units := make([]instancemutater.Unit, len(lives))
+	for i := 0; i < len(lives); i++ {
 		units[i] = s.unit
+		s.unit.EXPECT().Life().Return(lives[i])
+		if lives[i] == state.Dead {
+			s.unit.EXPECT().Name().Return("foo")
+		}
 	}
 	machineExp.Units().Return(units, nil)
 }

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
@@ -186,8 +186,6 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateWithProf
 
 func (s *lxdProfileWatcherSuite) assertAddSubordinate() {
 	// Add a new subordinate unit with a profile of a new application.
-	s.state.EXPECT().Unit("principal/0").Return(s.principal, nil)
-	s.principal.EXPECT().AssignedMachineId().Return("0", nil)
 
 	s.state.EXPECT().Unit("foo/0").Return(s.unit, nil)
 	s.unit.EXPECT().Life().Return(state.Alive)
@@ -219,8 +217,6 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateWithProf
 	another.EXPECT().AssignedMachineId().Return("0", nil)
 	s.state.EXPECT().Unit("foo/1").Return(another, nil)
 
-	s.state.EXPECT().Unit("principal/0").Return(s.principal, nil)
-	s.principal.EXPECT().AssignedMachineId().Return("0", nil)
 	s.unitChanges <- []string{"foo/1"}
 	s.wc0.AssertOneChange()
 
@@ -228,8 +224,6 @@ func (s *lxdProfileWatcherSuite) TestMachineLXDProfileWatcherSubordinateWithProf
 	another.EXPECT().Life().Return(state.Alive)
 	another.EXPECT().PrincipalName().Return("principal/0", true)
 	another.EXPECT().AssignedMachineId().Return("0", nil)
-	s.state.EXPECT().Unit("principal/0").Return(s.principal, nil)
-	s.principal.EXPECT().AssignedMachineId().Return("0", nil)
 	s.state.EXPECT().Unit("foo/1").Return(another, nil)
 	s.unitChanges <- []string{"foo/1"}
 	s.wc0.AssertNoChange()

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -128,7 +128,7 @@ func (c *lxdProfileCharmV2) LXDProfile() lxdprofile.Profile {
 	}
 }
 
-// ExternalLXDProfileAPIv2 can be used for API registration.
+// NewExternalLXDProfileAPIv2 can be used for API registration.
 func NewExternalLXDProfileAPIv2(
 	st *state.State,
 	resources facade.Resources,

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -144,6 +144,7 @@ type StartInstanceResult struct {
 	VolumeAttachments []storage.VolumeAttachment
 }
 
+// InstanceBroker defines methods for managing vm or container instances.
 // TODO(wallyworld) - we want this in the environs/instance package but import loops
 // stop that from being possible right now.
 type InstanceBroker interface {
@@ -180,7 +181,7 @@ type LXDProfiler interface {
 	// and removing profiles from the lxd server.
 	AssignLXDProfiles(instID string, profilesNames []string, profilePosts []lxdprofile.ProfilePost) ([]string, error)
 
-	// MaybeWriteLXDProfile, write given LXDProfile to if not already there.
+	// MaybeWriteLXDProfile writes the given LXDProfile to if not already there.
 	MaybeWriteLXDProfile(pName string, put lxdprofile.Profile) error
 
 	// LXDProfileNames returns all the profiles associated to a container name


### PR DESCRIPTION
When removing a unit with a charm with an lxd profile from a machine, depending on timing, the lxd profile would not be updated.
The root cause was that the unit went to Dead but the `machineLXDProfileInfo()` call was loading all units and not ignoring the dead ones.

As a driveby, the logic to figure out the assigned machine id when watching units with a charm with a lxd profile was extracted to a helper method. A result is that we avoid making an extra call to `AssignedMachineId()` (tests updated accordingly). For subordinate units, if the unit has a machine id, we use it. If it is not yet known, we then try the principal unit's machine id and use that.

## QA steps

juju bootstrap lxd
juju deploy ubuntu --series focal
juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --to 0 --series focal --force

wait for things to settle

juju remove-unit lxd-profile-alt/0
lxc profile show juju-controller-lxd-profile-alt-0

check that used_by is empty

## Bug reference

https://bugs.launchpad.net/juju/+bug/1982599

