### PR TITLE
[JUJU-1494] Fast refresh charm

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -324,6 +324,15 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	// There is a timing window where deploy has been called and the charm
+	// is not yet downloaded. Check here to verify the origin has an ID,
+	// otherwise refresh result may be in accurate. We could do use the
+	// retry package, but the issue is only seen in automated test due to
+	// speed. Can always use retry if it becomes an issue.
+	if oldOrigin.Source == commoncharm.OriginCharmHub && oldOrigin.ID == "" {
+		return errors.Errorf("%q deploy incomplete, please try refresh again in a little bit.", c.ApplicationName)
+	}
+
 	// Set a default URL schema for charm URLs that don't provide one.
 	var defaultCharmSchema = charm.CharmHub
 

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -326,7 +326,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 
 	// There is a timing window where deploy has been called and the charm
 	// is not yet downloaded. Check here to verify the origin has an ID,
-	// otherwise refresh result may be in accurate. We could do use the
+	// otherwise refresh result may be in accurate. We could use the
 	// retry package, but the issue is only seen in automated test due to
 	// speed. Can always use retry if it becomes an issue.
 	if oldOrigin.Source == commoncharm.OriginCharmHub && oldOrigin.ID == "" {

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -616,6 +616,14 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 	})
 }
 
+func (s *RefreshSuite) TestUpgradeFailWithoutCharmHubOriginID(c *gc.C) {
+	s.resolvedChannel = csclientparams.BetaChannel
+	s.charmAPIClient.charmOrigin.Source = "charm-hub"
+	_, err := s.runRefresh(c, "foo", "--channel=beta")
+	c.Assert(err, gc.ErrorMatches, "\"foo\" deploy incomplete, please try refresh again in a little bit.")
+	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin")
+}
+
 func (s *RefreshSuite) TestSwitch(c *gc.C) {
 	_, err := s.runRefresh(c, "foo", "--switch=cs:~other/trusty/anotherriak")
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Check charm origin ID before attempting to refresh charmhub charms. Prevents a case where refresh called before charm is downloaded.

Account for change to refresh in updated run_deploy_revision_upgrade.

Drive by fix of run_deploy_revision_fail.

## QA steps

```sh
(cd tests ; ./main.sh -v deploy test_deploy_revision )
```

