### PR TITLE
[JUJU-1488] Do 3 retries when we get "EOF" error from Charmhub API

### DIFF
--- a/charmhub/doc.go
+++ b/charmhub/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package charmhub is an HTTP client for sending requests to the Charmhub API.
+//
+// Call NewClient to create a client, and then Client's methods to perform
+// individual requests, such as "info" or "refresh".
+//
+// This package automatically handles retries, request logging, and so on.
+// To enable fine-grained request logging, set the logging label "charmhub" to
+// TRACE (or set "metrics" to TRACE for logging request times).
+package charmhub

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -113,17 +113,17 @@ func requestHTTPClient(recorder jujuhttp.RequestRecorder, policy jujuhttp.RetryP
 // apiRequester creates a wrapper around the HTTPClient to allow for better
 // error handling.
 type apiRequester struct {
-	httpClient        HTTPClient
-	logger            Logger
-	retryInitialDelay time.Duration
+	httpClient HTTPClient
+	logger     Logger
+	retryDelay time.Duration
 }
 
 // newAPIRequester creates a new http.Client for making requests to a server.
 func newAPIRequester(httpClient HTTPClient, logger Logger) *apiRequester {
 	return &apiRequester{
-		httpClient:        httpClient,
-		logger:            logger,
-		retryInitialDelay: time.Second,
+		httpClient: httpClient,
+		logger:     logger,
+		retryDelay: 3 * time.Second,
 	}
 }
 
@@ -165,11 +165,10 @@ func (t *apiRequester) Do(req *http.Request) (*http.Response, error) {
 		NotifyFunc: func(lastError error, attempt int) {
 			t.logger.Errorf("Charmhub API error (attempt %d): %v", attempt, lastError)
 		},
-		Attempts:    4,
-		Delay:       t.retryInitialDelay,
-		BackoffFunc: retry.DoubleDelay,
-		Clock:       clock.WallClock,
-		Stop:        req.Context().Done(),
+		Attempts: 2,
+		Delay:    t.retryDelay,
+		Clock:    clock.WallClock,
+		Stop:     req.Context().Done(),
 	})
 	return resp, err
 }

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -7,8 +7,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
@@ -80,6 +83,94 @@ func (s *APIRequesterSuite) TestDoWithNotFoundResponse(c *gc.C) {
 	resp, err := requester.Do(req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusNotFound)
+}
+
+func (s *APIRequesterSuite) TestDoRetrySuccess(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	req := MustNewRequest(c, "http://api.foo.bar")
+
+	mockHTTPClient := NewMockHTTPClient(ctrl)
+	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
+	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
+	mockHTTPClient.EXPECT().Do(req).Return(emptyResponse(), nil)
+
+	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
+	requester.retryInitialDelay = time.Microsecond
+	resp, err := requester.Do(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+}
+
+func (s *APIRequesterSuite) TestDoRetrySuccessBody(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	req, err := http.NewRequest("POST", "http://api.foo.bar", strings.NewReader("body"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	mockHTTPClient := NewMockHTTPClient(ctrl)
+	mockHTTPClient.EXPECT().Do(req).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+		b, err := io.ReadAll(req.Body)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(string(b), gc.Equals, "body")
+		return nil, io.EOF
+	})
+	mockHTTPClient.EXPECT().Do(req).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+		b, err := io.ReadAll(req.Body)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(string(b), gc.Equals, "body")
+		return emptyResponse(), nil
+	})
+
+	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
+	requester.retryInitialDelay = time.Microsecond
+	resp, err := requester.Do(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+}
+
+func (s *APIRequesterSuite) TestDoRetryMaxAttempts(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	req := MustNewRequest(c, "http://api.foo.bar")
+
+	mockHTTPClient := NewMockHTTPClient(ctrl)
+	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
+	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
+	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
+	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
+
+	start := time.Now()
+	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
+	requester.retryInitialDelay = time.Microsecond
+	_, err := requester.Do(req)
+	c.Assert(err, gc.ErrorMatches, `exceeded 4 attempts: EOF`)
+	elapsed := time.Since(start)
+	c.Assert(elapsed >= (1+2+4)*time.Microsecond, gc.Equals, true)
+}
+
+func (s *APIRequesterSuite) TestDoRetryContextCanceled(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel right away
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://api.foo.bar", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mockHTTPClient := NewMockHTTPClient(ctrl)
+	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
+
+	start := time.Now()
+	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
+	requester.retryInitialDelay = time.Second
+	_, err = requester.Do(req)
+	c.Assert(err, gc.ErrorMatches, `context canceled`)
+	elapsed := time.Since(start)
+	c.Assert(elapsed < 250*time.Millisecond, gc.Equals, true)
 }
 
 type RESTSuite struct {

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -93,11 +93,10 @@ func (s *APIRequesterSuite) TestDoRetrySuccess(c *gc.C) {
 
 	mockHTTPClient := NewMockHTTPClient(ctrl)
 	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
-	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
 	mockHTTPClient.EXPECT().Do(req).Return(emptyResponse(), nil)
 
 	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
-	requester.retryInitialDelay = time.Microsecond
+	requester.retryDelay = time.Microsecond
 	resp, err := requester.Do(req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
@@ -125,7 +124,7 @@ func (s *APIRequesterSuite) TestDoRetrySuccessBody(c *gc.C) {
 	})
 
 	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
-	requester.retryInitialDelay = time.Microsecond
+	requester.retryDelay = time.Microsecond
 	resp, err := requester.Do(req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
@@ -140,12 +139,10 @@ func (s *APIRequesterSuite) TestDoRetryMaxAttempts(c *gc.C) {
 	mockHTTPClient := NewMockHTTPClient(ctrl)
 	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
 	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
-	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
-	mockHTTPClient.EXPECT().Do(req).Return(nil, io.EOF)
 
 	start := time.Now()
 	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
-	requester.retryInitialDelay = time.Microsecond
+	requester.retryDelay = time.Microsecond
 	_, err := requester.Do(req)
 	c.Assert(err, gc.ErrorMatches, `attempt count exceeded: EOF`)
 	elapsed := time.Since(start)
@@ -166,7 +163,7 @@ func (s *APIRequesterSuite) TestDoRetryContextCanceled(c *gc.C) {
 
 	start := time.Now()
 	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
-	requester.retryInitialDelay = time.Second
+	requester.retryDelay = time.Second
 	_, err = requester.Do(req)
 	c.Assert(err, gc.ErrorMatches, `retry stopped`)
 	elapsed := time.Since(start)

--- a/charmhub/http_test.go
+++ b/charmhub/http_test.go
@@ -147,7 +147,7 @@ func (s *APIRequesterSuite) TestDoRetryMaxAttempts(c *gc.C) {
 	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
 	requester.retryInitialDelay = time.Microsecond
 	_, err := requester.Do(req)
-	c.Assert(err, gc.ErrorMatches, `exceeded 4 attempts: EOF`)
+	c.Assert(err, gc.ErrorMatches, `attempt count exceeded: EOF`)
 	elapsed := time.Since(start)
 	c.Assert(elapsed >= (1+2+4)*time.Microsecond, gc.Equals, true)
 }
@@ -168,7 +168,7 @@ func (s *APIRequesterSuite) TestDoRetryContextCanceled(c *gc.C) {
 	requester := newAPIRequester(mockHTTPClient, &FakeLogger{})
 	requester.retryInitialDelay = time.Second
 	_, err = requester.Do(req)
-	c.Assert(err, gc.ErrorMatches, `context canceled`)
+	c.Assert(err, gc.ErrorMatches, `retry stopped`)
 	elapsed := time.Since(start)
 	c.Assert(elapsed < 250*time.Millisecond, gc.Equals, true)
 }

--- a/charmhub/path/doc.go
+++ b/charmhub/path/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package path defines helpers for constructing Charmhub API URL paths.
+package path

--- a/charmhub/transport/doc.go
+++ b/charmhub/transport/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package transport defines the request and response structs for use with the
+// Charmhub API client.
+package transport


### PR DESCRIPTION
We get these weird errors from Charmhub every so often, for example:

```
ERROR resolving with preferred channel: Post "https://api.charmhub.io/v2/charms/refresh": EOF
```

These aren't valid HTTP responses, so we can't use the existing
juju/http retry logic as it only works for valid HTTP responses with
certain 40x and 50x status codes. This is an empty TCP response.

So retry 3 times (4 attempts) in this EOF case. We need to read in POST
bodies up-front because the http library will be reading/copying them
to the network more than once if a retry occurs. But they shouldn't be
huge, so this seems reasonable.

I used a test client and net.Listen server to reproduce this exact
case, to ensure the io.EOF test works on the real responses we got.
Here is the code for that:

* Client: https://pastebin.canonical.com/p/4RGNKggrK6/
* Server: https://pastebin.canonical.com/p/jtFfNP3GFF/

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run unit tests with `go test ./charmhub`. Deploy a charm/bundle and use the Juju Charmhub commands to exercise this code path, for example:

```
# Basic deploy of charm and bundle
$ juju bootstrap lxd
$ time juju deploy postgresql
$ time juju deploy charmed-kubernetes

# Other commands that hit the Charmhub API
$ juju info postgresql --logging-config='#charmhub=TRACE' --show-log
$ juju find postgres --logging-config='#charmhub=TRACE' --show-log
$ juju download postgresql --logging-config='#charmhub=TRACE' --show-log --series=xenial
$ juju download, juju refresh etc.
```