### PR TITLE
[JUJU-1495] Fixed using correct folder for xenial local charms

### DIFF
--- a/acceptancetests/jujucharm.py
+++ b/acceptancetests/jujucharm.py
@@ -90,6 +90,7 @@ def local_charm_path(charm, juju_ver, series=None, repository=None,
     else:
         charm_dir = {
             'ubuntu': 'charms',
+            'ubuntu-xenial': 'xenial',
             'win': 'charms-win',
             'centos': 'charms-centos'}
         abs_path = charm
@@ -97,7 +98,7 @@ def local_charm_path(charm, juju_ver, series=None, repository=None,
             abs_path = os.path.join(repository, charm)
         elif os.environ.get('JUJU_REPOSITORY'):
             repository = os.path.join(
-                os.environ['JUJU_REPOSITORY'], charm_dir[platform])
+                os.environ['JUJU_REPOSITORY'], charm_dir[platform] if series != 'xenial' else charm_dir['ubuntu-xenial'])
             abs_path = os.path.join(repository, charm)
         return abs_path
 


### PR DESCRIPTION
This is the possible patch for `nw-deploy-xenial-arm64-lxd` test. According to [jenkins-output](https://jenkins.juju.canonical.com/job/nw-deploy-xenial-arm64-lxd/182/console), the problem is in finding charm `dummy-source`.

This patch fixes the `local_charm_path` function and adds a new option for the xenial series because the `dummy-source` for the `xenial` series leaves in another folder.

## Checklist

 - [ ] Comments answer the question of why design decisions were made

## QA steps

*Need to figure out how to test it locally*

```sh
# bootstrap aws cloud with any juju you have
juju bootstrap aws aws
juju add-machine --constraints "arch=arm64 cores=2 root-disk=32G"
# wait for the machine is started
juju ssh 0 
# inside the machine
sudo apt install make cmake python3-pip libssl-dev jq shellcheck
# install juju, based on this PR
git clone https://github.com/juju/juju.git
cd juju
git fetch origin pull/14370/head:test-branch
git checkout test-branch
make install-dependencies
make build
# init localhost cloud
newgrp lxd
sudo adduser $USER lxd
lxd init --auto
lxc network set lxdbr0 ipv6.address none
# build acceptancetests
cd acceptancetests
make install-deps
# prepare test environment
mkdir /tmp/test-run
export JUJU_HOME=/tmp/test-run
vim $JUJU_HOME/environments.yaml
#environments:
#    lxd:
#        type: lxd
#        test-mode: true
#        default-series: bionic
export JUJU_REPOSITORY=/home/ubuntu/juju/acceptancetests/repository
mkdir /tmp/artifacts
# launch test
./deploy_job.py --series xenial --arch arm64 lxd ../_build/linux_arm64/bin/juju /tmp/artifacts/ nw-deploy-xenial-arm64-lxd
```
