### PR TITLE
[JUJU-1499] State debug-log decoupling

### DIFF
--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -32,8 +32,8 @@ func handleDebugLogDBRequest(
 	socket debugLogSocket,
 	stop <-chan struct{},
 ) error {
-	params := makeLogTailerParams(reqParams)
-	tailer, err := newLogTailer(st, params)
+	tailerParams := makeLogTailerParams(reqParams)
+	tailer, err := newLogTailer(st, tailerParams)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -68,8 +68,8 @@ func handleDebugLogDBRequest(
 	}
 }
 
-func makeLogTailerParams(reqParams debugLogParams) state.LogTailerParams {
-	params := state.LogTailerParams{
+func makeLogTailerParams(reqParams debugLogParams) corelogger.LogTailerParams {
+	tailerParams := corelogger.LogTailerParams{
 		MinLevel:      reqParams.filterLevel,
 		NoTail:        reqParams.noTail,
 		StartTime:     reqParams.startTime,
@@ -82,9 +82,9 @@ func makeLogTailerParams(reqParams debugLogParams) state.LogTailerParams {
 		ExcludeLabel:  reqParams.excludeLabel,
 	}
 	if reqParams.fromTheStart {
-		params.InitialLines = 0
+		tailerParams.InitialLines = 0
 	}
-	return params
+	return tailerParams
 }
 
 func formatLogRecord(r *corelogger.LogRecord) *params.LogMessage {
@@ -101,6 +101,6 @@ func formatLogRecord(r *corelogger.LogRecord) *params.LogMessage {
 
 var newLogTailer = _newLogTailer // For replacing in tests
 
-func _newLogTailer(st state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
-	return state.NewLogTailer(st, params)
+func _newLogTailer(st state.LogTailerState, params corelogger.LogTailerParams) (corelogger.LogTailer, error) {
+	return state.NewLogTailer(st, params, nil)
 }

--- a/apiserver/debuglog_db.go
+++ b/apiserver/debuglog_db.go
@@ -101,6 +101,6 @@ func formatLogRecord(r *corelogger.LogRecord) *params.LogMessage {
 
 var newLogTailer = _newLogTailer // For replacing in tests
 
-func _newLogTailer(st state.LogTailerState, params state.LogTailerParams) (state.LogTailer, error) {
+func _newLogTailer(st state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
 	return state.NewLogTailer(st, params)
 }

--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -52,7 +52,7 @@ func (s *debugLogDBIntSuite) TestParamConversion(c *gc.C) {
 	}
 
 	called := false
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params corelogger.LogTailerParams) (corelogger.LogTailer, error) {
 		called = true
 
 		// Start time will be used once the client is extended to send
@@ -85,7 +85,7 @@ func (s *debugLogDBIntSuite) TestParamConversionReplay(c *gc.C) {
 	}
 
 	called := false
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params corelogger.LogTailerParams) (corelogger.LogTailer, error) {
 		called = true
 
 		c.Assert(params.StartTime.IsZero(), jc.IsTrue)
@@ -120,9 +120,12 @@ func (s *debugLogDBIntSuite) TestFullRequest(c *gc.C) {
 		Level:    loggo.ERROR,
 		Message:  "whoops",
 	}
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
-		return tailer, nil
-	})
+	s.PatchValue(
+		&newLogTailer,
+		func(_ state.LogTailerState, params corelogger.LogTailerParams) (corelogger.LogTailer, error) {
+			return tailer, nil
+		},
+	)
 
 	stop := make(chan struct{})
 	done := s.runRequest(debugLogParams{}, stop)
@@ -157,7 +160,7 @@ func (s *debugLogDBIntSuite) TestTimeout(c *gc.C) {
 		Level:    loggo.ERROR,
 		Message:  "whoops",
 	}
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params corelogger.LogTailerParams) (corelogger.LogTailer, error) {
 		return tailer, nil
 	})
 
@@ -179,7 +182,7 @@ func (s *debugLogDBIntSuite) TestTimeout(c *gc.C) {
 
 func (s *debugLogDBIntSuite) TestRequestStopsWhenTailerStops(c *gc.C) {
 	tailer := newFakeLogTailer()
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params corelogger.LogTailerParams) (corelogger.LogTailer, error) {
 		close(tailer.logsCh) // make the request stop immediately
 		return tailer, nil
 	})
@@ -202,7 +205,7 @@ func (s *debugLogDBIntSuite) TestMaxLines(c *gc.C) {
 			Message:  "stuff happened",
 		}
 	}
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params corelogger.LogTailerParams) (corelogger.LogTailer, error) {
 		return tailer, nil
 	})
 

--- a/apiserver/debuglog_db_internal_test.go
+++ b/apiserver/debuglog_db_internal_test.go
@@ -52,7 +52,7 @@ func (s *debugLogDBIntSuite) TestParamConversion(c *gc.C) {
 	}
 
 	called := false
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (state.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
 		called = true
 
 		// Start time will be used once the client is extended to send
@@ -85,7 +85,7 @@ func (s *debugLogDBIntSuite) TestParamConversionReplay(c *gc.C) {
 	}
 
 	called := false
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (state.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
 		called = true
 
 		c.Assert(params.StartTime.IsZero(), jc.IsTrue)
@@ -120,7 +120,7 @@ func (s *debugLogDBIntSuite) TestFullRequest(c *gc.C) {
 		Level:    loggo.ERROR,
 		Message:  "whoops",
 	}
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (state.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
 		return tailer, nil
 	})
 
@@ -157,7 +157,7 @@ func (s *debugLogDBIntSuite) TestTimeout(c *gc.C) {
 		Level:    loggo.ERROR,
 		Message:  "whoops",
 	}
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (state.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
 		return tailer, nil
 	})
 
@@ -179,7 +179,7 @@ func (s *debugLogDBIntSuite) TestTimeout(c *gc.C) {
 
 func (s *debugLogDBIntSuite) TestRequestStopsWhenTailerStops(c *gc.C) {
 	tailer := newFakeLogTailer()
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (state.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
 		close(tailer.logsCh) // make the request stop immediately
 		return tailer, nil
 	})
@@ -202,7 +202,7 @@ func (s *debugLogDBIntSuite) TestMaxLines(c *gc.C) {
 			Message:  "stuff happened",
 		}
 	}
-	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (state.LogTailer, error) {
+	s.PatchValue(&newLogTailer, func(_ state.LogTailerState, params state.LogTailerParams) (corelogger.LogTailer, error) {
 		return tailer, nil
 	})
 
@@ -269,7 +269,7 @@ func newFakeLogTailer() *fakeLogTailer {
 }
 
 type fakeLogTailer struct {
-	state.LogTailer
+	corelogger.LogTailer
 	logsCh  chan *corelogger.LogRecord
 	stopped bool
 }

--- a/apiserver/logstream.go
+++ b/apiserver/logstream.go
@@ -21,7 +21,7 @@ import (
 
 type logStreamSource interface {
 	getStart(sink string) (time.Time, error)
-	newTailer(state.LogTailerParams) (corelogger.LogTailer, error)
+	newTailer(corelogger.LogTailerParams) (corelogger.LogTailer, error)
 }
 
 type messageWriter interface {
@@ -126,7 +126,7 @@ func (h *logStreamEndpointHandler) newTailer(
 		}
 	}
 
-	tailerArgs := state.LogTailerParams{
+	tailerArgs := corelogger.LogTailerParams{
 		StartTime:    start,
 		InitialLines: cfg.MaxLookbackRecords,
 	}
@@ -176,8 +176,8 @@ func (st logStreamState) getStart(sink string) (time.Time, error) {
 	return time.Unix(0, lastSentTimestamp), nil
 }
 
-func (st logStreamState) newTailer(args state.LogTailerParams) (corelogger.LogTailer, error) {
-	tailer, err := state.NewLogTailer(st, args)
+func (st logStreamState) newTailer(args corelogger.LogTailerParams) (corelogger.LogTailer, error) {
+	tailer, err := state.NewLogTailer(st, args, nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -252,7 +252,7 @@ type stubSource struct {
 	stub *testing.Stub
 
 	ReturnGetStart  int64
-	ReturnNewTailer state.LogTailer
+	ReturnNewTailer corelogger.LogTailer
 }
 
 func (s *stubSource) newSource(req *http.Request) (logStreamSource, state.PoolHelper, error) {
@@ -277,7 +277,7 @@ func (s *stubSource) getStart(sink string) (time.Time, error) {
 	return time.Unix(s.ReturnGetStart, 0), nil
 }
 
-func (s *stubSource) newTailer(args state.LogTailerParams) (state.LogTailer, error) {
+func (s *stubSource) newTailer(args state.LogTailerParams) (corelogger.LogTailer, error) {
 	s.stub.AddCall("newTailer", args)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -287,7 +287,7 @@ func (s *stubSource) newTailer(args state.LogTailerParams) (state.LogTailer, err
 }
 
 type stubLogTailer struct {
-	state.LogTailer
+	corelogger.LogTailer
 	stub *testing.Stub
 
 	ReturnLogs <-chan *corelogger.LogRecord

--- a/apiserver/logstream_test.go
+++ b/apiserver/logstream_test.go
@@ -54,7 +54,7 @@ func (s *LogStreamIntSuite) TestParamConversion(c *gc.C) {
 
 	stub.CheckCallNames(c, "newSource", "getStart", "newTailer")
 	stub.CheckCall(c, 1, "getStart", "spam")
-	stub.CheckCall(c, 2, "newTailer", state.LogTailerParams{
+	stub.CheckCall(c, 2, "newTailer", corelogger.LogTailerParams{
 		StartTime:    time.Unix(10, 0),
 		InitialLines: 100,
 	})
@@ -92,7 +92,7 @@ func (s *LogStreamIntSuite) TestParamStartTruncate(c *gc.C) {
 
 	stub.CheckCallNames(c, "newSource", "getStart", "newTailer")
 	stub.CheckCall(c, 1, "getStart", "spam")
-	stub.CheckCall(c, 2, "newTailer", state.LogTailerParams{
+	stub.CheckCall(c, 2, "newTailer", corelogger.LogTailerParams{
 		StartTime: now.Add(-2 * time.Hour),
 	})
 }
@@ -277,7 +277,7 @@ func (s *stubSource) getStart(sink string) (time.Time, error) {
 	return time.Unix(s.ReturnGetStart, 0), nil
 }
 
-func (s *stubSource) newTailer(args state.LogTailerParams) (corelogger.LogTailer, error) {
+func (s *stubSource) newTailer(args corelogger.LogTailerParams) (corelogger.LogTailer, error) {
 	s.stub.AddCall("newTailer", args)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/agent"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/jujud/agent/agentconf"
+	corelogger "github.com/juju/juju/core/logger"
 	corenames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state"
@@ -191,7 +192,7 @@ func (c *dumpLogsCommand) dumpLogsForEnv(ctx *cmd.Context, statePool *state.Stat
 	writer := bufio.NewWriter(file)
 	defer writer.Flush()
 
-	tailer, err := state.NewLogTailer(st, state.LogTailerParams{NoTail: true})
+	tailer, err := state.NewLogTailer(st, corelogger.LogTailerParams{NoTail: true}, nil)
 	if err != nil {
 		return errors.Annotate(err, "failed to create a log tailer")
 	}

--- a/core/logger/tailer.go
+++ b/core/logger/tailer.go
@@ -1,5 +1,11 @@
 package logger
 
+import (
+	"time"
+
+	"github.com/juju/loggo"
+)
+
 // LogTailer allows for retrieval of Juju's logs.
 // It first returns any matching already recorded logs and
 // then waits for additional matching logs as they appear.
@@ -18,4 +24,20 @@ type LogTailer interface {
 	// Err returns the error that caused the LogTailer to stopped.
 	// If it hasn't stopped or stopped without error nil will be returned.
 	Err() error
+}
+
+// LogTailerParams specifies the filtering a LogTailer should
+// apply to log records in order to decide which to return.
+type LogTailerParams struct {
+	StartID       int64
+	StartTime     time.Time
+	MinLevel      loggo.Level
+	InitialLines  int
+	NoTail        bool
+	IncludeEntity []string
+	ExcludeEntity []string
+	IncludeModule []string
+	ExcludeModule []string
+	IncludeLabel  []string
+	ExcludeLabel  []string
 }

--- a/core/logger/tailer.go
+++ b/core/logger/tailer.go
@@ -1,0 +1,21 @@
+package logger
+
+// LogTailer allows for retrieval of Juju's logs.
+// It first returns any matching already recorded logs and
+// then waits for additional matching logs as they appear.
+type LogTailer interface {
+	// Logs returns the channel through which the LogTailer returns Juju logs.
+	// It will be closed when the tailer stops.
+	Logs() <-chan *LogRecord
+
+	// Dying returns a channel which will be closed as the LogTailer stops.
+	Dying() <-chan struct{}
+
+	// Stop is used to request that the LogTailer stops.
+	// It blocks until the LogTailer has stopped.
+	Stop() error
+
+	// Err returns the error that caused the LogTailer to stopped.
+	// If it hasn't stopped or stopped without error nil will be returned.
+	Err() error
+}

--- a/core/logger/tailer.go
+++ b/core/logger/tailer.go
@@ -1,3 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package logger
 
 import (

--- a/state/logs.go
+++ b/state/logs.go
@@ -421,28 +421,6 @@ func (logger *DbLogger) Close() error {
 	return nil
 }
 
-// LogTailer allows for retrieval of Juju's logs from MongoDB. It
-// first returns any matching already recorded logs and then waits for
-// additional matching logs as they appear.
-type LogTailer interface {
-	// Logs returns the channel through which the LogTailer returns
-	// Juju logs. It will be closed when the tailer stops.
-	Logs() <-chan *corelogger.LogRecord
-
-	// Dying returns a channel which will be closed as the LogTailer
-	// stops.
-	Dying() <-chan struct{}
-
-	// Stop is used to request that the LogTailer stops. It blocks
-	// unil the LogTailer has stopped.
-	Stop() error
-
-	// Err returns the error that caused the LogTailer to stopped. If
-	// it hasn't stopped or stopped without error nil will be
-	// returned.
-	Err() error
-}
-
 // LogTailerParams specifies the filtering a LogTailer should apply to
 // logs in order to decide which to return.
 type LogTailerParams struct {
@@ -492,7 +470,7 @@ type LogTailerState interface {
 
 // NewLogTailer returns a LogTailer which filters according to the
 // parameters given.
-func NewLogTailer(st LogTailerState, params LogTailerParams) (LogTailer, error) {
+func NewLogTailer(st LogTailerState, params LogTailerParams) (corelogger.LogTailer, error) {
 	session := st.MongoSession().Copy()
 	t := &logTailer{
 		modelUUID:       st.ModelUUID(),

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -302,7 +302,7 @@ func (s *LogTailerSuite) TestLogDeletionDuringTailing(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer loggo.RemoveWriter("test")
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{}, s.oplogColl)
+	tailer, err := state.NewLogTailer(s.otherState, corelogger.LogTailerParams{}, s.oplogColl)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -333,7 +333,7 @@ func (s *LogTailerSuite) TestTimeFiltering(c *gc.C) {
 	// Add 5 logs that should be returned.
 	want := logTemplate{Message: "want"}
 	s.writeLogsT(c, s.otherUUID, threshT, threshT.Add(5*time.Second), 5, want)
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{StartTime: threshT}, s.oplogColl)
+	tailer, err := state.NewLogTailer(s.otherState, corelogger.LogTailerParams{StartTime: threshT}, s.oplogColl)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 	s.assertTailer(c, tailer, 5, want)
@@ -356,7 +356,7 @@ func (s *LogTailerSuite) TestOplogTransition(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, logTemplate{Message: strconv.Itoa(i)})
 	}
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{}, s.oplogColl)
+	tailer, err := state.NewLogTailer(s.otherState, corelogger.LogTailerParams{}, s.oplogColl)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 	for i := 0; i < 5; i++ {
@@ -388,7 +388,7 @@ func (s *LogTailerSuite) TestModelFiltering(c *gc.C) {
 		s.assertTailer(c, tailer, 1, good)
 	}
 
-	s.checkLogTailerFiltering(c, s.otherState, state.LogTailerParams{}, writeLogs, assert)
+	s.checkLogTailerFiltering(c, s.otherState, corelogger.LogTailerParams{}, writeLogs, assert)
 }
 
 func (s *LogTailerSuite) TestTailingLogsOnlyForOneModel(c *gc.C) {
@@ -430,7 +430,7 @@ func (s *LogTailerSuite) TestTailingLogsOnlyForOneModel(c *gc.C) {
 			}
 		}
 	}
-	s.checkLogTailerFiltering(c, s.State, state.LogTailerParams{}, writeLogs, assert)
+	s.checkLogTailerFiltering(c, s.State, corelogger.LogTailerParams{}, writeLogs, assert)
 }
 
 func (s *LogTailerSuite) TestLevelFiltering(c *gc.C) {
@@ -441,7 +441,7 @@ func (s *LogTailerSuite) TestLevelFiltering(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, info)
 		s.writeLogs(c, s.otherUUID, 1, error)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		MinLevel: loggo.INFO,
 	}
 	assert := func(tailer corelogger.LogTailer) {
@@ -456,7 +456,7 @@ func (s *LogTailerSuite) TestInitialLines(c *gc.C) {
 	s.writeLogs(c, s.otherUUID, 3, logTemplate{Message: "dont want"})
 	s.writeLogs(c, s.otherUUID, 5, expected)
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{InitialLines: 5}, nil)
+	tailer, err := state.NewLogTailer(s.otherState, corelogger.LogTailerParams{InitialLines: 5}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -475,7 +475,7 @@ func (s *LogTailerSuite) TestRecordsAddedOutOfTimeOrder(c *gc.C) {
 	migrated := logTemplate{Message: "transferred by migration"}
 	s.writeLogsT(c, s.otherUUID, t1, t1, 1, migrated)
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{}, nil)
+	tailer, err := state.NewLogTailer(s.otherState, corelogger.LogTailerParams{}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -488,7 +488,7 @@ func (s *LogTailerSuite) TestInitialLinesWithNotEnoughLines(c *gc.C) {
 	expected := logTemplate{Message: "want"}
 	s.writeLogs(c, s.otherUUID, 2, expected)
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{InitialLines: 5}, nil)
+	tailer, err := state.NewLogTailer(s.otherState, corelogger.LogTailerParams{InitialLines: 5}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -506,7 +506,7 @@ func (s *LogTailerSuite) TestNoTail(c *gc.C) {
 	err := s.writeLogToOplog(s.otherUUID, doc)
 	c.Assert(err, jc.ErrorIsNil)
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{NoTail: true}, nil)
+	tailer, err := state.NewLogTailer(s.otherState, corelogger.LogTailerParams{NoTail: true}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Not strictly necessary, just in case NoTail doesn't work in the test.
 	defer tailer.Stop()
@@ -541,7 +541,7 @@ func (s *LogTailerSuite) TestIncludeEntity(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, foo1)
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		IncludeEntity: []string{
 			"unit-foo-0",
 			"unit-foo-1",
@@ -564,7 +564,7 @@ func (s *LogTailerSuite) TestIncludeEntityWildcard(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, foo1)
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		IncludeEntity: []string{
 			"unit-foo*",
 		},
@@ -586,7 +586,7 @@ func (s *LogTailerSuite) TestExcludeEntity(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, foo1)
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		ExcludeEntity: []string{
 			"machine-0",
 			"unit-foo-0",
@@ -608,7 +608,7 @@ func (s *LogTailerSuite) TestExcludeEntityWildcard(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, foo1)
 		s.writeLogs(c, s.otherUUID, 3, machine0)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		ExcludeEntity: []string{
 			"machine*",
 			"unit-*-0",
@@ -633,7 +633,7 @@ func (s *LogTailerSuite) TestIncludeModule(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, mod0)
 		s.writeLogs(c, s.otherUUID, 1, mod2)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		IncludeModule: []string{"juju.thing", "elsewhere"},
 	}
 	assert := func(tailer corelogger.LogTailer) {
@@ -657,7 +657,7 @@ func (s *LogTailerSuite) TestExcludeModule(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, mod0)
 		s.writeLogs(c, s.otherUUID, 1, mod2)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		ExcludeModule: []string{"juju.thing", "elsewhere"},
 	}
 	assert := func(tailer corelogger.LogTailer) {
@@ -679,7 +679,7 @@ func (s *LogTailerSuite) TestIncludeExcludeModule(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, baz)
 		s.writeLogs(c, s.otherUUID, 1, qux)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		IncludeModule: []string{"foo", "bar", "qux"},
 		ExcludeModule: []string{"foo", "bar"},
 	}
@@ -704,7 +704,7 @@ func (s *LogTailerSuite) TestIncludeLabels(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, mod0)
 		s.writeLogs(c, s.otherUUID, 1, mod2)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		IncludeLabel: []string{"juju_thing", "elsewhere"},
 	}
 	assert := func(tailer corelogger.LogTailer) {
@@ -727,7 +727,7 @@ func (s *LogTailerSuite) TestExcludeLabels(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, mod0)
 		s.writeLogs(c, s.otherUUID, 1, mod2)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		ExcludeLabel: []string{"juju_thing", "juju_thing_hai", "elsewhere"},
 	}
 	assert := func(tailer corelogger.LogTailer) {
@@ -749,7 +749,7 @@ func (s *LogTailerSuite) TestIncludeExcludeLabels(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, baz)
 		s.writeLogs(c, s.otherUUID, 1, qux)
 	}
-	params := state.LogTailerParams{
+	params := corelogger.LogTailerParams{
 		IncludeLabel: []string{"foo", "bar", "qux"},
 		ExcludeLabel: []string{"foo", "bar"},
 	}
@@ -764,7 +764,7 @@ func (s *LogTailerSuite) TestIncludeExcludeLabels(c *gc.C) {
 func (s *LogTailerSuite) checkLogTailerFiltering(
 	c *gc.C,
 	st *state.State,
-	params state.LogTailerParams,
+	params corelogger.LogTailerParams,
 	writeLogs func(),
 	assertTailer func(corelogger.LogTailer),
 ) {

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -302,9 +302,7 @@ func (s *LogTailerSuite) TestLogDeletionDuringTailing(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer loggo.RemoveWriter("test")
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
-		Oplog: s.oplogColl,
-	})
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{}, s.oplogColl)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -335,10 +333,7 @@ func (s *LogTailerSuite) TestTimeFiltering(c *gc.C) {
 	// Add 5 logs that should be returned.
 	want := logTemplate{Message: "want"}
 	s.writeLogsT(c, s.otherUUID, threshT, threshT.Add(5*time.Second), 5, want)
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
-		StartTime: threshT,
-		Oplog:     s.oplogColl,
-	})
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{StartTime: threshT}, s.oplogColl)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 	s.assertTailer(c, tailer, 5, want)
@@ -361,9 +356,7 @@ func (s *LogTailerSuite) TestOplogTransition(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, logTemplate{Message: strconv.Itoa(i)})
 	}
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
-		Oplog: s.oplogColl,
-	})
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{}, s.oplogColl)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 	for i := 0; i < 5; i++ {
@@ -463,9 +456,7 @@ func (s *LogTailerSuite) TestInitialLines(c *gc.C) {
 	s.writeLogs(c, s.otherUUID, 3, logTemplate{Message: "dont want"})
 	s.writeLogs(c, s.otherUUID, 5, expected)
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
-		InitialLines: 5,
-	})
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{InitialLines: 5}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -484,7 +475,7 @@ func (s *LogTailerSuite) TestRecordsAddedOutOfTimeOrder(c *gc.C) {
 	migrated := logTemplate{Message: "transferred by migration"}
 	s.writeLogsT(c, s.otherUUID, t1, t1, 1, migrated)
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{})
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -497,9 +488,7 @@ func (s *LogTailerSuite) TestInitialLinesWithNotEnoughLines(c *gc.C) {
 	expected := logTemplate{Message: "want"}
 	s.writeLogs(c, s.otherUUID, 2, expected)
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
-		InitialLines: 5,
-	})
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{InitialLines: 5}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 
@@ -517,9 +506,7 @@ func (s *LogTailerSuite) TestNoTail(c *gc.C) {
 	err := s.writeLogToOplog(s.otherUUID, doc)
 	c.Assert(err, jc.ErrorIsNil)
 
-	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{
-		NoTail: true,
-	})
+	tailer, err := state.NewLogTailer(s.otherState, state.LogTailerParams{NoTail: true}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Not strictly necessary, just in case NoTail doesn't work in the test.
 	defer tailer.Stop()
@@ -784,8 +771,7 @@ func (s *LogTailerSuite) checkLogTailerFiltering(
 	// Check the tailer does the right thing when reading from the
 	// logs collection.
 	writeLogs()
-	params.Oplog = s.oplogColl
-	tailer, err := state.NewLogTailer(st, params)
+	tailer, err := state.NewLogTailer(st, params, s.oplogColl)
 	c.Assert(err, jc.ErrorIsNil)
 	defer tailer.Stop()
 	assertTailer(tailer)

--- a/state/logs_test.go
+++ b/state/logs_test.go
@@ -390,7 +390,7 @@ func (s *LogTailerSuite) TestModelFiltering(c *gc.C) {
 		s.writeLogs(c, s.otherUUID, 1, good)
 	}
 
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		// Only the entries the s.State's UUID should be reported.
 		s.assertTailer(c, tailer, 1, good)
 	}
@@ -411,7 +411,7 @@ func (s *LogTailerSuite) TestTailingLogsOnlyForOneModel(c *gc.C) {
 		})
 	}
 
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		messages := map[string]bool{}
 		defer func() {
 			c.Assert(messages, gc.HasLen, 2)
@@ -451,7 +451,7 @@ func (s *LogTailerSuite) TestLevelFiltering(c *gc.C) {
 	params := state.LogTailerParams{
 		MinLevel: loggo.INFO,
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 1, info)
 		s.assertTailer(c, tailer, 1, error)
 	}
@@ -560,7 +560,7 @@ func (s *LogTailerSuite) TestIncludeEntity(c *gc.C) {
 			"unit-foo-1",
 		},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 2, foo0)
 		s.assertTailer(c, tailer, 1, foo1)
 	}
@@ -582,7 +582,7 @@ func (s *LogTailerSuite) TestIncludeEntityWildcard(c *gc.C) {
 			"unit-foo*",
 		},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 2, foo0)
 		s.assertTailer(c, tailer, 1, foo1)
 	}
@@ -605,7 +605,7 @@ func (s *LogTailerSuite) TestExcludeEntity(c *gc.C) {
 			"unit-foo-0",
 		},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 1, foo1)
 	}
 	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
@@ -627,7 +627,7 @@ func (s *LogTailerSuite) TestExcludeEntityWildcard(c *gc.C) {
 			"unit-*-0",
 		},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 1, foo1)
 	}
 	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
@@ -649,7 +649,7 @@ func (s *LogTailerSuite) TestIncludeModule(c *gc.C) {
 	params := state.LogTailerParams{
 		IncludeModule: []string{"juju.thing", "elsewhere"},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 1, mod1)
 		s.assertTailer(c, tailer, 1, subMod1)
 		s.assertTailer(c, tailer, 1, mod2)
@@ -673,7 +673,7 @@ func (s *LogTailerSuite) TestExcludeModule(c *gc.C) {
 	params := state.LogTailerParams{
 		ExcludeModule: []string{"juju.thing", "elsewhere"},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 2, mod0)
 	}
 	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
@@ -696,7 +696,7 @@ func (s *LogTailerSuite) TestIncludeExcludeModule(c *gc.C) {
 		IncludeModule: []string{"foo", "bar", "qux"},
 		ExcludeModule: []string{"foo", "bar"},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		// Except just "qux" because "foo" and "bar" were included and
 		// then excluded.
 		s.assertTailer(c, tailer, 1, qux)
@@ -720,7 +720,7 @@ func (s *LogTailerSuite) TestIncludeLabels(c *gc.C) {
 	params := state.LogTailerParams{
 		IncludeLabel: []string{"juju_thing", "elsewhere"},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 1, mod1)
 		s.assertTailer(c, tailer, 1, mod2)
 	}
@@ -743,7 +743,7 @@ func (s *LogTailerSuite) TestExcludeLabels(c *gc.C) {
 	params := state.LogTailerParams{
 		ExcludeLabel: []string{"juju_thing", "juju_thing_hai", "elsewhere"},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		s.assertTailer(c, tailer, 2, mod0)
 	}
 	s.checkLogTailerFiltering(c, s.otherState, params, writeLogs, assert)
@@ -766,7 +766,7 @@ func (s *LogTailerSuite) TestIncludeExcludeLabels(c *gc.C) {
 		IncludeLabel: []string{"foo", "bar", "qux"},
 		ExcludeLabel: []string{"foo", "bar"},
 	}
-	assert := func(tailer state.LogTailer) {
+	assert := func(tailer corelogger.LogTailer) {
 		// Except just "qux" because "foo" and "bar" were included and
 		// then excluded.
 		s.assertTailer(c, tailer, 1, qux)
@@ -779,7 +779,7 @@ func (s *LogTailerSuite) checkLogTailerFiltering(
 	st *state.State,
 	params state.LogTailerParams,
 	writeLogs func(),
-	assertTailer func(state.LogTailer),
+	assertTailer func(corelogger.LogTailer),
 ) {
 	// Check the tailer does the right thing when reading from the
 	// logs collection.
@@ -888,7 +888,7 @@ func (s *LogTailerSuite) logTemplateToDoc(lt logTemplate, t time.Time) interface
 	)
 }
 
-func (s *LogTailerSuite) assertTailer(c *gc.C, tailer state.LogTailer, expectedCount int, lt logTemplate) {
+func (s *LogTailerSuite) assertTailer(c *gc.C, tailer corelogger.LogTailer, expectedCount int, lt logTemplate) {
 	s.normaliseLogTemplate(&lt)
 
 	timeout := time.After(coretesting.LongWait)


### PR DESCRIPTION
This is mechanical refactoring to decouple the `LogTailer` interface and `LogTailerParams` from state. We need to do this in order to implement non-Mongo implementations supporting the `debug-log` command.

They are relocated to `core/logger`, and the `opLog` article remains in state by becoming an argument to the `NewLogTailer` constructor.

## QA steps

Just bootstrap and check that `juju debug-log` works.

## Documentation changes

None.

## Bug reference

N/A
