### PR TITLE
Preserve mongod logs in juju k8s controller

### DIFF
--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -607,7 +607,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 		`if [ $ipv6Disabled -eq 0 ]; then`,
 		`  args="${args} --ipv6"`,
 		`fi`,
-		`$(mongod ${args})`,
+		`exec mongod ${args}`,
 		`'>/root/mongo.sh && chmod a+x /root/mongo.sh && /root/mongo.sh`,
 	}
 	statefulSetSpec.Spec.Template.Spec.Containers = []core.Container{

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -22,6 +22,6 @@ ipv6Disabled=$(sysctl net.ipv6.conf.all.disable_ipv6 -n)
 if [ $ipv6Disabled -eq 0 ]; then
   args="${args} --ipv6"
 fi
-$(mongod ${args})
+exec mongod ${args}
 `[1:]
 )


### PR DESCRIPTION
Currently, the [startup script](https://github.com/juju/juju/blob/6e28a9b06a9fb2f4106864d4430674a689113cab/caas/scripts.go#L25) used in the juju container controller uses bash command substitution to launch mongod. 

When the mongod failed to start, or some error occurred causing mongod to exit, command substitution will cause the shell to treat everything printed by mongod as a new command and try to execute that command. Of course, that’s not a command, so the only message left was some gibberish produced by shell when the shell is trying to run mongod’s output as a command. This will cause all the valuable debug information about the mongod to be lost.

Here is the example of mongod logs retrieved from Kubernetes with the current implementation:

```
/root/mongo.sh: 6: {"t":{"$date":"2022-07-26T08:40:52.827+00:00"},"s":"I",: not found
```

This PR changes the startup script to use the `exec` command to launch `mongod`.

## QA steps

Require microk8s or other kind of Kubernetes systems installed.

### Before:

```bash
juju bootstrap microk8s test-current

# trigger a mongod "failure" manually
microk8s.kubectl exec \
  -n controller-test-current \
  controller-0 --container mongodb -- pkill mongod

# retrieve logs of the killed mongod container from Kubernetes
microk8s.kubectl logs -n controller-test-current controller-0 --container mongodb -p
```

Result: 

```
/root/mongo.sh: 6: {"t":{"$date":"2022-07-26T08:40:52.827+00:00"},"s":"I",: not found
```

### After:

```bash
./_build/linux_amd64/bin/juju bootstrap microk8s test-new

# trigger a mongod "failure" manually
microk8s.kubectl exec \
  -n controller-test-new \
  controller-0 --container mongodb -- pkill mongod

# retrieve logs of the killed mongod container from Kubernetes
microk8s.kubectl logs -n controller-test-new controller-0 --container mongodb -p
```

Result:

```
{"t":{"$date":"2022-07-26T08:57:11.320+00:00"},"s":"I",  "c":"CONTROL",  "id":23285,   "ctx":"main","msg":"Automatically disabling TLS 1.0, to force-enable TLS 1.0 specify --sslDisabledProtocols 'none'"}
{"t":{"$date":"2022-07-26T08:57:11.321+00:00"},"s":"W",  "c":"ASIO",     "id":22601,   "ctx":"main","msg":"No TransportLayer configured during NetworkInterface startup"}
{"t":{"$date":"2022-07-26T08:57:11.321+00:00"},"s":"I",  "c":"NETWORK",  "id":4648601, "ctx":"main","msg":"Implicit TCP FastOpen unavailable. If TCP FastOpen is required, set tcpFastOpenServer, tcpFastOpenClient, and tcpFastOpenQueueSize."}
{"t":{"$date":"2022-07-26T08:57:11.322+00:00"},"s":"W",  "c":"ASIO",     "id":22601,   "ctx":"main","msg":"No TransportLayer configured during NetworkInterface startup"}
{"t":{"$date":"2022-07-26T08:57:11.348+00:00"},"s":"I",  "c":"STORAGE",  "id":4615611, "ctx":"initandlisten","msg":"MongoDB starting","attr":{"pid":8,"port":37017,"dbPath":"/var/lib/juju/db","architecture":"64-bit","host":"controller-0"}}
...
{"t":{"$date":"2022-07-26T08:58:10.863+00:00"},"s":"I",  "c":"-",        "id":4784931, "ctx":"SignalHandler","msg":"Dropping the scope cache for shutdown"}
{"t":{"$date":"2022-07-26T08:58:10.863+00:00"},"s":"I",  "c":"FTDC",     "id":4784926, "ctx":"SignalHandler","msg":"Shutting down full-time data capture"}
{"t":{"$date":"2022-07-26T08:58:10.863+00:00"},"s":"I",  "c":"FTDC",     "id":20626,   "ctx":"SignalHandler","msg":"Shutting down full-time diagnostic data capture"}
{"t":{"$date":"2022-07-26T08:58:10.864+00:00"},"s":"I",  "c":"CONTROL",  "id":20565,   "ctx":"SignalHandler","msg":"Now exiting"}
{"t":{"$date":"2022-07-26T08:58:10.864+00:00"},"s":"I",  "c":"CONTROL",  "id":23138,   "ctx":"SignalHandler","msg":"Shutting down","attr":{"exitCode":0}}
```
## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1982832