### PR TITLE
[JUJU-1506] Changed command summary from 3SG to 2SG.

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -43,7 +43,7 @@ type CloudMetadataStore interface {
 }
 
 var usageAddCloudSummary = `
-Adds a cloud definition to Juju.`[1:]
+Add a cloud definition to Juju.`[1:]
 
 var usageAddCloudDetails = `
 Juju needs to know how to connect to clouds. A cloud definition 


### PR DESCRIPTION
## Please provide the following details to expedite review (and delete this heading)

I've noticed inconsistencies in the command summary lines---some use second person singular and others third person singular. It becomes grating when you look at a global summary (e.g., juju help commands, also cascading into https://juju.is/docs/olm/commands). I think it's best to use second person throughout.

## Checklist

 - [ ] Comments answer the question of why design decisions were made

## QA steps

```sh
juju help add-cloud
```

## Documentation changes

Update https://juju.is/docs/olm/juju-add-cloud .
