### PR TITLE
[JUJU-1516] Set module to use v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/juju
+module github.com/juju/juju/v2
 
 go 1.18
 


### PR DESCRIPTION
Change `go.mod` to set the current version as a v2 module. This change would simplify the consumption of the juju repo from third-parties when using semantic versioning.

## Checklist

NA

## QA steps

NA

```sh
QA steps here
```

## Documentation changes

NA

## Bug reference

NA
