### PR TITLE
[JUJU-1200] Wait for CRM to be active before migrating

### DIFF
--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -27,7 +27,7 @@ wait_for() {
 		sleep "${SHORT_TIMEOUT}"
 
 		elapsed=$(date -u +%s)-$start_time
-		if [[ "${elapsed}" -ge ${timeout} ]]; then
+		if [[ ${elapsed} -ge ${timeout} ]]; then
 			echo "[-] $(red 'timed out waiting for')" "$(red "${name}")"
 			exit 1
 		fi

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -75,6 +75,9 @@ run_model_migration_saas_common() {
 	juju consume "${BOOTSTRAPPED_JUJU_CTRL_NAME}:admin/model-migration-saas.dummy-source"
 	juju relate dummy-sink dummy-source
 
+	juju switch "model-migration-saas"
+	wait_for "1" '.offers["dummy-source"]["active-connected-count"]'
+
 	juju migrate "model-migration-saas" "alt-model-migration-saas"
 	juju switch "alt-model-migration-saas"
 
@@ -136,6 +139,8 @@ run_model_migration_saas_external() {
 	juju relate dummy-sink dummy-source
 
 	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+	wait_for "1" '.offers["dummy-source"]["active-connected-count"]'
+
 	juju migrate "model-migration-saas" "model-migration-saas-target"
 	juju switch "model-migration-saas-target"
 

--- a/tests/suites/upgrade/streams.sh
+++ b/tests/suites/upgrade/streams.sh
@@ -19,8 +19,7 @@ run_simplestream_metadata_prior_stable() {
 	major=$(echo "${previous_version}" | cut -d '.' -f 1)
 	minor=$(echo "${previous_version}" | cut -d '.' -f 2)
 
-	if snap info juju | grep -q "installed"
-	then
+	if snap info juju | grep -q "installed"; then
 		action="refresh"
 	else
 		action="install"


### PR DESCRIPTION
Model migration tests using cross-model relations were often failing because the migration would be started before the CRM was active. Resolve this by waiting until the CRM is active in effected tests 

Also fix some shfmt lint failures

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v -s 'test_model_config,test_model_multi,test_model_metrics' model
```
