### PR TITLE
[JUJU-1526] Fixed test deploy test deploy bundles aws in 3.0

### DIFF
--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -3,6 +3,7 @@ applications:
   influxdb:
     charm: influxdb
     channel: stable
+    revision: 24
     num_units: 1
     to:
     - "0"
@@ -10,6 +11,7 @@ applications:
   telegraf:
     charm: telegraf
     channel: stable
+    revision: 49
   ubuntu:
     charm: ubuntu
     channel: stable

--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -11,11 +11,11 @@ applications:
   telegraf:
     charm: telegraf
     channel: stable
-    revision: 29
+    revision: 42
   ubuntu:
     charm: ubuntu
     channel: stable
-    revision: 12
+    revision: 17
     num_units: 1
     to:
     - "1"

--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -1,7 +1,7 @@
-series: focal
+series: bionic
 applications:
   influxdb:
-    charm: cs:influxdb
+    charm: influxdb
     channel: stable
     revision: 22
     num_units: 1
@@ -9,11 +9,11 @@ applications:
     - "0"
     constraints: arch=amd64
   telegraf:
-    charm: cs:telegraf
+    charm: telegraf
     channel: stable
     revision: 29
   ubuntu:
-    charm: cs:ubuntu
+    charm: ubuntu
     channel: stable
     revision: 12
     num_units: 1

--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -1,9 +1,9 @@
-series: bionic
+series: focal
 applications:
   influxdb:
     charm: influxdb
     channel: stable
-    revision: 22
+    revision: 23
     num_units: 1
     to:
     - "0"
@@ -11,11 +11,11 @@ applications:
   telegraf:
     charm: telegraf
     channel: stable
-    revision: 42
+    revision: 48
   ubuntu:
     charm: ubuntu
     channel: stable
-    revision: 17
+    revision: 20
     num_units: 1
     to:
     - "1"

--- a/tests/suites/deploy/bundles/telegraf_bundle.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle.yaml
@@ -1,21 +1,21 @@
 series: focal
 applications:
   influxdb:
-    charm: influxdb
+    charm: cs:influxdb
     channel: stable
-    revision: 24
+    revision: 22
     num_units: 1
     to:
     - "0"
     constraints: arch=amd64
   telegraf:
-    charm: telegraf
+    charm: cs:telegraf
     channel: stable
-    revision: 49
+    revision: 29
   ubuntu:
-    charm: ubuntu
+    charm: cs:ubuntu
     channel: stable
-    revision: 20
+    revision: 12
     num_units: 1
     to:
     - "1"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -57,9 +57,9 @@ run_deploy_cmr_bundle() {
 	destroy_model "other"
 }
 
-# run_deploy_exported_charmstore_bundle_with_fixed_revisions tests how juju deploys
-# a charmstore bundle that specifies revisions for its charms
-run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
+# run_deploy_exported_charmhub_bundle_with_fixed_revisions tests how juju deploys
+# a charmhub bundle that specifies revisions for its charms
+run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 	echo
 
 	file="${TEST_DIR}/test-export-bundles-deploy-with-fixed-revisions.log"
@@ -238,7 +238,7 @@ test_deploy_bundles() {
 
 		run "run_deploy_bundle"
 		run "run_deploy_bundle_overlay"
-		run "run_deploy_exported_charmstore_bundle_with_fixed_revisions"
+		run "run_deploy_exported_charmhub_bundle_with_fixed_revisions"
 		run "run_deploy_exported_charmhub_bundle_with_float_revisions"
 		run "run_deploy_trusted_bundle"
 		run "run_deploy_charmhub_bundle"


### PR DESCRIPTION
This patch provides a fix for `test-deploy-test-deploy-bundles-aws` test in 3.0.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
./main.py -v -p aws deploy
```
