### PR TITLE
[JUJU01492] Ensure AddCharm has a series

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -451,17 +451,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 	ctx.Verbosef("Preparing to deploy %q from the %s", userRequestedURL.Name, location)
 
-	// resolver.resolve potentially updates the series of anything
-	// passed in. Store this for use in seriesSelector.
-	userRequestedSeries := userRequestedURL.Series
-
-	modelCfg, err := getModelConfig(deployAPI)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	imageStream := modelCfg.ImageStream()
-	workloadSeries, err := supportedJujuSeries(c.clock.Now(), userRequestedSeries, imageStream)
+	modelCfg, workloadSeries, err := seriesSelectorRequirements(deployAPI, c.clock, userRequestedURL)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -481,7 +471,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	selector := seriesSelector{
-		charmURLSeries:      userRequestedSeries,
+		charmURLSeries:      userRequestedURL.Series,
 		seriesFlag:          c.series,
 		supportedSeries:     supportedSeries,
 		supportedJujuSeries: workloadSeries,
@@ -494,6 +484,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	series, err := selector.charmSeries()
 	logger.Tracef("Using series %s from %v to deploy %v", series, supportedSeries, userRequestedURL)
 
+	imageStream := modelCfg.ImageStream()
 	// Avoid deploying charm if it's not valid for the model.
 	// We check this first before possibly suggesting --force.
 	if err == nil {


### PR DESCRIPTION
Before calling AddCharm, ensure we have a series selected after calling ResolveCharm.

A little refactoring around requirements for using the series selector and pulling out deploy a local charm to its own method.

## QA steps

Deploy the simple charm in the bug: https://bugs.launchpad.net/juju/+bug/1982921/comments/3 to a microk8s model

With a machine controller, deploy the following bundle
```
series: focal
applications:
  oneubuntu:
    charm: ubuntu
  twoubuntu:
    charm: ubuntu
  threeubuntu:
    charm: ubuntu
    revision: 19
    channel: stable
  fourubuntu:
    charm: ubuntu
  fiveubuntu:
    charm: ubuntu
    revision: 18
    channel: stable
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1982921
