### PR TITLE
[JUJU-1150]Remove feature flag added for syslog log-sink

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -45,8 +45,9 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
+
 	"github.com/juju/juju/core/resources"
-	"github.com/juju/juju/feature"
+
 	"github.com/juju/juju/pubsub/apiserver"
 	controllermsg "github.com/juju/juju/pubsub/controller"
 	"github.com/juju/juju/resource"
@@ -324,9 +325,6 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 		return nil, errors.Trace(err)
 	}
 	loggingOutputs, _ := modelConfig.LoggingOutput()
-	if !controllerConfig.Features().Contains(feature.LoggingOutput) {
-		loggingOutputs = []string{}
-	}
 
 	srv := &Server{
 		clock:                         cfg.Clock,
@@ -684,7 +682,8 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	embeddedCLIHandler := newEmbeddedCLIHandler(httpCtxt)
 	debugLogHandler := newDebugLogDBHandler(
 		httpCtxt, srv.authenticator,
-		tagKindAuthorizer{names.MachineTagKind, names.ControllerAgentTagKind, names.UserTagKind, names.ApplicationTagKind})
+		tagKindAuthorizer{names.MachineTagKind, names.ControllerAgentTagKind, names.UserTagKind,
+			names.ApplicationTagKind})
 	pubsubHandler := newPubSubHandler(httpCtxt, srv.shared.centralHub)
 	logSinkHandler := logsink.NewHTTPHandler(
 		newAgentLogWriteCloserFunc(httpCtxt, srv.logSinkWriter, &srv.apiServerLoggers),
@@ -728,7 +727,8 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	modelToolsUploadAuthorizer := tagKindAuthorizer{names.UserTagKind}
 	modelToolsDownloadHandler := newToolsDownloadHandler(httpCtxt)
 	resourcesHandler := &ResourcesHandler{
-		StateAuthFunc: func(req *http.Request, tagKinds ...string) (ResourcesBackend, state.PoolHelper, names.Tag, error) {
+		StateAuthFunc: func(req *http.Request, tagKinds ...string) (ResourcesBackend, state.PoolHelper, names.Tag,
+			error) {
 			st, entity, err := httpCtxt.stateForRequestAuthenticatedTag(req, tagKinds...)
 			if err != nil {
 				return nil, nil, nil, errors.Trace(err)

--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -4,11 +4,12 @@
 package modelconfig
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
-	"github.com/juju/names/v4"
 )
 
 // Backend contains the state.State methods used in this package,

--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -4,13 +4,11 @@
 package modelconfig
 
 import (
-	"github.com/juju/names/v4"
-
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
+	"github.com/juju/names/v4"
 )
 
 // Backend contains the state.State methods used in this package,
@@ -25,7 +23,6 @@ type Backend interface {
 	SetSLA(level, owner string, credentials []byte) error
 	SLALevel() (string, error)
 	SpaceByName(string) error
-	ControllerConfig() (controller.Config, error)
 	SetModelConstraints(value constraints.Value) error
 	ModelConstraints() (constraints.Value, error)
 }

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -5,6 +5,11 @@ package modelconfig_test
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
 	"github.com/juju/juju/apiserver/facades/client/modelconfig"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/constraints"
@@ -14,10 +19,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
-	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
 )
 
 type modelconfigSuite struct {

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -5,22 +5,19 @@ package modelconfig_test
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/names/v4"
-	gitjujutesting "github.com/juju/testing"
-	jc "github.com/juju/testing/checkers"
-	gc "gopkg.in/check.v1"
-
 	"github.com/juju/juju/apiserver/facades/client/modelconfig"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/provider/dummy"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testing"
+	"github.com/juju/names/v4"
+	gitjujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 )
 
 type modelconfigSuite struct {
@@ -201,17 +198,6 @@ func (s *modelconfigSuite) TestUserCannotSetLogTrace(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `only controller admins can set a model's logging level to TRACE`)
 }
 
-func (s *modelconfigSuite) TestCannotSetLoggingOutputWithoutFeatureFlag(c *gc.C) {
-	args := params.ModelSet{
-		map[string]interface{}{"logging-output": "syslog"},
-	}
-	err := s.api.ModelSet(args)
-	c.Assert(err, gc.ErrorMatches, `cannot set "logging-output" without setting the "logging-output" feature flag`)
-	s.backend.features = feature.LoggingOutput
-	err = s.api.ModelSet(args)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *modelconfigSuite) TestModelUnset(c *gc.C) {
 	err := s.backend.UpdateModelConfig(map[string]interface{}{"abc": 123}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -308,7 +294,8 @@ func (m *mockBackend) Sequences() (map[string]int, error) {
 	return nil, nil
 }
 
-func (m *mockBackend) UpdateModelConfig(update map[string]interface{}, remove []string, validate ...state.ValidateConfigFunc) error {
+func (m *mockBackend) UpdateModelConfig(update map[string]interface{}, remove []string,
+	validate ...state.ValidateConfigFunc) error {
 	for _, validateFunc := range validate {
 		if err := validateFunc(update, remove, m.old); err != nil {
 			return err
@@ -349,12 +336,6 @@ func (m *mockBackend) SLALevel() (string, error) {
 
 func (m *mockBackend) SpaceByName(string) error {
 	return nil
-}
-
-func (m *mockBackend) ControllerConfig() (controller.Config, error) {
-	cfg := testing.FakeControllerConfig()
-	cfg[controller.Features] = []interface{}{m.features}
-	return cfg, nil
 }
 
 type mockBlock struct {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/space"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -426,11 +425,6 @@ func (m *ModelManagerAPI) newModel(
 	controllerCfg, err := m.state.ControllerConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
-	}
-
-	_, ok := newConfig.LoggingOutput()
-	if ok && !controllerCfg.Features().Contains(feature.LoggingOutput) {
-		return nil, errors.Errorf("cannot set %q without setting the %q feature flag", config.LoggingOutputKey, feature.LoggingOutput)
 	}
 
 	// Create the Environ.

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -22,7 +22,6 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/network"
@@ -31,7 +30,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
-	"github.com/juju/juju/feature"
 	jujutesting "github.com/juju/juju/juju/testing"
 	_ "github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/dummy"
@@ -438,23 +436,6 @@ func (s *modelManagerSuite) TestCreateModelUnknownCredential(c *gc.C) {
 	}
 	_, err := s.api.CreateModel(args)
 	c.Assert(err, gc.ErrorMatches, `getting credential: credential not found`)
-}
-
-func (s *modelManagerSuite) TestCreateModelLoggingOutputChecksFlag(c *gc.C) {
-	args := params.ModelCreateArgs{
-		Name:     "foo",
-		OwnerTag: "user-admin",
-		Config: map[string]interface{}{
-			"logging-output": "syslog",
-		},
-	}
-	_, err := s.api.CreateModel(args)
-	c.Assert(err, gc.ErrorMatches, `cannot set "logging-output" without setting the "logging-output" feature flag`)
-	cfg := coretesting.FakeControllerConfig()
-	cfg[controller.Features] = []interface{}{feature.LoggingOutput}
-	s.st.controllerCfg = &cfg
-	_, err = s.api.CreateModel(args)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *modelManagerSuite) TestCreateCAASModelArgs(c *gc.C) {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -305,24 +305,31 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.BootstrapSeries, "bootstrap-series", "", "Specify the series of the bootstrap machine")
 	f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine")
 	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build local version of agent binary before bootstrapping")
-	f.StringVar(&c.JujuDbSnapPath, "db-snap", "", "Path to a locally built .snap to use as the internal juju-db service.")
+	f.StringVar(&c.JujuDbSnapPath, "db-snap", "",
+		"Path to a locally built .snap to use as the internal juju-db service.")
 	f.StringVar(&c.JujuDbSnapAssertionsPath, "db-snap-asserts", "", "Path to a local .assert file. Requires --db-snap")
 	f.StringVar(&c.MetadataSource, "metadata-source", "", "Local path to use as agent and/or image metadata source")
 	f.StringVar(&c.Placement, "to", "", "Placement directive indicating an instance to bootstrap")
-	f.BoolVar(&c.KeepBrokenEnvironment, "keep-broken", false, "Do not destroy the provisioned controller instance if bootstrap fails")
+	f.BoolVar(&c.KeepBrokenEnvironment, "keep-broken", false,
+		"Do not destroy the provisioned controller instance if bootstrap fails")
 	f.BoolVar(&c.AutoUpgrade, "auto-upgrade", false, "After bootstrap, upgrade to the latest patch release")
 	f.StringVar(&c.AgentVersionParam, "agent-version", "", "Version of agent binaries to use for Juju agents")
 	f.StringVar(&c.CredentialName, "credential", "", "Credentials to use when bootstrapping")
-	f.Var(&c.config, "config", "Specify a controller configuration file, or one or more configuration\n    options\n    (--config config.yaml [--config key=value ...])")
-	f.Var(&c.modelDefaults, "model-default", "Specify a configuration file, or one or more configuration\n    options to be set for all models, unless otherwise specified\n    (--model-default config.yaml [--model-default key=value ...])")
-	f.Var(&c.storagePool, "storage-pool", "Specify options for an initial storage pool\n    'name' and 'type' are required, plus any additional attributes\n    (--storage-pool pool-config.yaml [--storage-pool key=value ...])")
+	f.Var(&c.config, "config",
+		"Specify a controller configuration file, or one or more configuration\n    options\n    (--config config.yaml [--config key=value ...])")
+	f.Var(&c.modelDefaults, "model-default",
+		"Specify a configuration file, or one or more configuration\n    options to be set for all models, unless otherwise specified\n    (--model-default config.yaml [--model-default key=value ...])")
+	f.Var(&c.storagePool, "storage-pool",
+		"Specify options for an initial storage pool\n    'name' and 'type' are required, plus any additional attributes\n    (--storage-pool pool-config.yaml [--storage-pool key=value ...])")
 	f.StringVar(&c.initialModelName, "add-model", "", "Name of an initial model to create on the new controller")
-	f.BoolVar(&c.showClouds, "clouds", false, "Print the available clouds which can be used to bootstrap a Juju environment")
+	f.BoolVar(&c.showClouds, "clouds", false,
+		"Print the available clouds which can be used to bootstrap a Juju environment")
 	f.StringVar(&c.showRegionsForCloud, "regions", "", "Print the available regions for the specified cloud")
 	f.BoolVar(&c.noSwitch, "no-switch", false, "Do not switch to the newly created controller")
 	f.BoolVar(&c.Force, "force", false, "Allow the bypassing of checks such as supported series")
 	f.StringVar(&c.ControllerCharmPath, "controller-charm-path", "", "Path to a locally built controller charm")
-	f.StringVar(&c.ControllerCharmRisk, "controller-charm-risk", "beta", "The controller charm risk if not using a local charm")
+	f.StringVar(&c.ControllerCharmRisk, "controller-charm-risk", "beta",
+		"The controller charm risk if not using a local charm")
 }
 
 func (c *bootstrapCommand) Init(args []string) (err error) {
@@ -361,7 +368,8 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 			return errors.Errorf("--controller-charm-path %q is not a valid charm", c.ControllerCharmPath)
 		}
 		if ch.Meta().Name != bootstrap.ControllerCharmName {
-			return errors.Errorf("--controller-charm-path %q is not a %q charm", c.ControllerCharmPath, bootstrap.ControllerCharmName)
+			return errors.Errorf("--controller-charm-path %q is not a %q charm", c.ControllerCharmPath,
+				bootstrap.ControllerCharmName)
 		}
 	}
 	if c.ControllerCharmRisk != "" {
@@ -416,7 +424,8 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		}
 	}
 	if c.AgentVersion != nil && (c.AgentVersion.Major != jujuversion.Current.Major || c.AgentVersion.Minor != jujuversion.Current.Minor) {
-		return errors.Errorf("this client can only bootstrap %v.%v agents", jujuversion.Current.Major, jujuversion.Current.Minor)
+		return errors.Errorf("this client can only bootstrap %v.%v agents", jujuversion.Current.Major,
+			jujuversion.Current.Minor)
 	}
 
 	switch len(args) {
@@ -442,7 +451,8 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 // BootstrapInterface provides bootstrap functionality that Run calls to support cleaner testing.
 type BootstrapInterface interface {
 	// Bootstrap bootstraps a controller.
-	Bootstrap(ctx environs.BootstrapContext, environ environs.BootstrapEnviron, callCtx envcontext.ProviderCallContext, args bootstrap.BootstrapParams) error
+	Bootstrap(ctx environs.BootstrapContext, environ environs.BootstrapEnviron, callCtx envcontext.ProviderCallContext,
+		args bootstrap.BootstrapParams) error
 
 	// CloudDetector returns a CloudDetector for the given provider,
 	// if the provider supports it.
@@ -459,7 +469,8 @@ type BootstrapInterface interface {
 
 type bootstrapFuncs struct{}
 
-func (b bootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.BootstrapEnviron, callCtx envcontext.ProviderCallContext, args bootstrap.BootstrapParams) error {
+func (b bootstrapFuncs) Bootstrap(ctx environs.BootstrapContext, env environs.BootstrapEnviron,
+	callCtx envcontext.ProviderCallContext, args bootstrap.BootstrapParams) error {
 	return bootstrap.Bootstrap(ctx, env, callCtx, args)
 }
 
@@ -664,7 +675,8 @@ to create a new model to deploy %sworkloads.
 	credentials, regionName, err := c.credentialsAndRegionName(ctx, provider, cloud)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			err = errors.NewNotFound(nil, fmt.Sprintf("%v\nSee `juju add-credential %s --help` for instructions", err, cloud.Name))
+			err = errors.NewNotFound(nil,
+				fmt.Sprintf("%v\nSee `juju add-credential %s --help` for instructions", err, cloud.Name))
 		}
 
 		if err == cmd.ErrSilent {
@@ -1195,7 +1207,8 @@ func (c *bootstrapCommand) detectCloud(
 	ctx.Verbosef("cloud %q not found, trying as a provider name", c.Cloud)
 	provider, err := environs.Provider(c.Cloud)
 	if errors.IsNotFound(err) {
-		return fail(errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-public-clouds")))
+		return fail(errors.NewNotFound(nil,
+			fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-public-clouds")))
 	} else if err != nil {
 		return fail(errors.Trace(err))
 	}
@@ -1205,7 +1218,8 @@ func (c *bootstrapCommand) detectCloud(
 			"provider %q does not support detecting regions",
 			c.Cloud,
 		)
-		return fail(errors.NewNotFound(nil, fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-public-clouds")))
+		return fail(errors.NewNotFound(nil,
+			fmt.Sprintf("unknown cloud %q, please try %q", c.Cloud, "juju update-public-clouds")))
 	}
 
 	var cloudEndpoint string
@@ -1519,18 +1533,14 @@ func (c *bootstrapCommand) bootstrapConfigs(
 		return bootstrapConfigs{}, errors.Annotate(err, "finalizing authorized-keys")
 	}
 
-	v, ok := bootstrapModelConfig[config.LoggingOutputKey]
-	if ok && v != "" && !controllerConfig.Features().Contains(feature.LoggingOutput) {
-		return bootstrapConfigs{}, errors.Errorf("cannot set %q without setting the %q feature flag", config.LoggingOutputKey, feature.LoggingOutput)
-	}
-
 	// We need to do an Azure specific check here to ensure that
 	// if a resource-group-name is specified, the user has also
 	// not specified a default model, otherwise we end up with 2
 	// models with the same resource group name.
 	resourceGroupName, ok := bootstrapModelConfig["resource-group-name"]
 	if ok && resourceGroupName != "" && c.initialModelName != "" {
-		return bootstrapConfigs{}, errors.Errorf("if using resource-group-name %q then a workload model cannot be specified as well", resourceGroupName)
+		return bootstrapConfigs{}, errors.Errorf("if using resource-group-name %q then a workload model cannot be specified as well",
+			resourceGroupName)
 	}
 
 	logger.Debugf("preparing controller with config: %v", bootstrapModelConfig)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -467,11 +467,6 @@ var bootstrapTests = []bootstrapTest{{
 	err:  `storage pool requires a type`,
 }}
 
-func (s *BootstrapSuite) TestRunModelLoggingOutputChecksFlag(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "dummy", "my-controller", "--config", "logging-output=syslog")
-	c.Check(err, gc.ErrorMatches, `cannot set "logging-output" without setting the "logging-output" feature flag`)
-}
-
 func (s *BootstrapSuite) TestRunCloudNameUnknown(c *gc.C) {
 	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "unknown", "my-controller")
 	c.Check(err, gc.ErrorMatches, `unknown cloud "unknown", please try "juju update-public-clouds"`)

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -40,6 +40,3 @@ const Secrets = "secrets"
 // RaftAPILeases will switch all lease store management transport, currently
 // handled by Pubsub to facade API interaction.
 const RaftAPILeases = "raft-api-leases"
-
-// LoggingOutput enables the ability to configure different logging backends.
-const LoggingOutput = "logging-output"

--- a/worker/modelworkermanager/shim.go
+++ b/worker/modelworkermanager/shim.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/juju/controller"
 	corelogger "github.com/juju/juju/core/logger"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/state"
 )
 
@@ -44,13 +43,6 @@ func (g StatePoolController) RecordLogger(modelUUID string) (RecordLogger, error
 		return nil, errors.Trace(err)
 	}
 	loggingOutputs, _ := config.LoggingOutput()
-	controllerConfig, err := ps.ControllerConfig()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if !controllerConfig.Features().Contains(feature.LoggingOutput) {
-		loggingOutputs = []string{}
-	}
 	return g.getLoggers(loggingOutputs, ps), nil
 }
 


### PR DESCRIPTION
This PR reverts this [one](https://github.com/juju/juju/pull/13971) and removes the logoutput feature flag. The feature flag was added to the `2.9` branch in order to require a specific opt-in action for using Syslog as a log-sink instead of MongoDB and brought forward to `develop`. We want to remove the flag from the develop branch, as it will become a standard feature. When we move to a SQL-based back-end, it will be the only log-sink option.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
$ juju bootstrap aws/eu-west-1 test --config "logging-output=syslog"
  Creating Juju controller "aws-eu-west-1" on aws/eu-west-1
  ...
$ juju bootstrap aws test --config "logging-output=syslog,database"
$ juju add-model foo --config logging-output=syslog
$ juju model-config logging-output=syslog
```