### PR TITLE
Allow upgrading to 3.0

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -210,14 +210,10 @@ func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
 	err := s.State.SetModelAgentVersion(version.MustParse("2.8.0"), nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major+1)),
+		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major+2)),
 	}
 	err = s.client.SetModelAgentVersion(args)
-	// We disable upgrading to juju3 for now.
-	// 	c.Assert(err, gc.ErrorMatches, `
-	// these models must first be upgraded to at least 2.8.9 before upgrading the controller:
-	//  -admin/controller`[1:])
-	c.Assert(err, gc.ErrorMatches, `cannot upgrade, "3.0.0" is not a supported version`)
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade, "4.0.0" is not a supported version`)
 }
 
 func (s *serverSuite) TestSetModelAgentVersionForced(c *gc.C) {

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -210,10 +210,12 @@ func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
 	err := s.State.SetModelAgentVersion(version.MustParse("2.8.0"), nil, false)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.SetModelAgentVersion{
-		Version: version.MustParse(fmt.Sprintf("%d.0.0", jujuversion.Current.Major+2)),
+		Version: version.MustParse("3.0.0"),
 	}
 	err = s.client.SetModelAgentVersion(args)
-	c.Assert(err, gc.ErrorMatches, `cannot upgrade, "4.0.0" is not a supported version`)
+	c.Assert(err, gc.ErrorMatches, `
+these models must first be upgraded to at least 2.9.33 before upgrading the controller:
+ -admin/controller`[1:])
 }
 
 func (s *serverSuite) TestSetModelAgentVersionForced(c *gc.C) {

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -27,8 +27,7 @@ func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (boo
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
-	// TODO: enable here once we fix the capped txn collection issue in juju3.
-	// 3: version.MustParse("2.9.33"),
+	3: version.MustParse("2.9.33"),
 }
 
 // UpgradeToAllowed returns true if a major version upgrade is allowed

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -50,20 +50,17 @@ func (s *versionSuite) TestUpgradeToAllowed(c *gc.C) {
 		}, {
 			from:    "2.9.34",
 			to:      "3.0.0",
-			allowed: false,
-			minVers: "0.0.0",
-			patch:   false, // We disallow upgrading to 3 for now.
-			err:     `cannot upgrade, "3.0.0" is not a supported version`,
-		},
-		{
+			allowed: true,
+			minVers: "2.9.33",
+			patch:   true,
+		}, {
 			from:    "2.9.0",
 			to:      "4.0.0",
 			allowed: false,
 			minVers: "0.0.0",
 			patch:   true,
 			err:     `cannot upgrade, "4.0.0" is not a supported version`,
-		},
-		{
+		}, {
 			from:    "3.0.0",
 			to:      "2.0.0",
 			allowed: false,


### PR DESCRIPTION
Since #14298 has landed in 3.0, it is now possible to upgrade to 3.0.

## QA steps

Test an upgrade to 3.0

## Documentation changes

N/A

## Bug reference

N/A