### PR TITLE
Fix use of `ifconfig` by falling back to `ip addr`

### DIFF
--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -73,9 +73,9 @@ func CloudInitUserData(
 	if err = udata.Configure(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	// Run ifconfig to get the addresses of the internal container at least
+	// Run ifconfig/ip addr to get the addresses of the internal container at least
 	// logged in the host.
-	cloudConfig.AddRunCmd("ifconfig")
+	cloudConfig.AddRunCmd("ifconfig || ip addr")
 
 	if instanceConfig.MachineContainerHostname != "" {
 		logger.Debugf("Cloud-init configured to set hostname")


### PR DESCRIPTION
Fix use of `ifconfig` by falling back to `ip addr`

## QA steps

Test lxd container on machine.

## Documentation changes

N/A

## Bug reference

N/A