### PR TITLE
[JUJU-1536] Fix replicaset and juju model reconciliation for removed machines

### DIFF
--- a/api/agent/provisioner/provisioner_test.go
+++ b/api/agent/provisioner/provisioner_test.go
@@ -218,7 +218,7 @@ func (s *provisionerSuite) TestEnsureDeadAndRemove(c *gc.C) {
 	// Now try to EnsureDead machine 0 - should fail.
 	apiMachine = s.assertGetOneMachine(c, s.machine.MachineTag())
 	err = apiMachine.EnsureDead()
-	c.Assert(err, gc.ErrorMatches, "machine 0 is still a controller member")
+	c.Assert(err, gc.ErrorMatches, "machine 0 is still a non-voting controller member")
 }
 
 func (s *provisionerSuite) TestMarkForRemoval(c *gc.C) {

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -193,6 +193,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeMachineHasContainers
 	case errors.Is(err, stateerrors.StorageAttachedError):
 		code = params.CodeStorageAttached
+	case errors.Is(err, stateerrors.IsControllerMemberError):
+		code = params.CodeTryAgain
 	case errors.Is(err, UnknownModelError):
 		code = params.CodeModelNotFound
 	case errors.Is(err, errors.NotSupported):

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -5,6 +5,7 @@ package backups
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/mgo/v2"
 	"github.com/juju/replicaset/v2"
 
 	"github.com/juju/juju/mongo"
@@ -12,7 +13,9 @@ import (
 	"github.com/juju/juju/state/backups"
 )
 
-var waitUntilReady = replicaset.WaitUntilReady
+var waitUntilReady = func(s *mgo.Session, timeout int) error {
+	return replicaset.WaitUntilReady(s, timeout)
+}
 
 // Create is the API method that requests juju to create a new backup
 // of its state.  It returns the metadata for that backup.

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/juju/proxy v1.0.0
 	github.com/juju/pubsub/v2 v2.0.0
 	github.com/juju/ratelimit v1.0.2
-	github.com/juju/replicaset/v2 v2.0.1
+	github.com/juju/replicaset/v2 v2.0.2
 	github.com/juju/retry v1.0.0
 	github.com/juju/rfc/v2 v2.0.0
 	github.com/juju/romulus v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5 h1:+eWzUG6XLDSdcz
 github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5/go.mod h1:F7wHQBX+lEJkv9PhNCgNJgCeI+GISZW2RefLINbmgXU=
 github.com/juju/ratelimit v1.0.2 h1:sRxmtRiajbvrcLQT7S+JbqU0ntsb9W2yhSdNN8tWfaI=
 github.com/juju/ratelimit v1.0.2/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
-github.com/juju/replicaset/v2 v2.0.1 h1:SN/dCaKCz0QjMaJ9iAZ8V5JQ+eN/nstFfVFRaSwwHuo=
-github.com/juju/replicaset/v2 v2.0.1/go.mod h1:Mje4O+NYfZYzJKPcIVJcHQ62b63Y3T+qNXqocm4gxz0=
+github.com/juju/replicaset/v2 v2.0.2 h1:4bzoj5lPaDnZBHmJoNJgYtww402DGUNh+hIZtdS0Ufs=
+github.com/juju/replicaset/v2 v2.0.2/go.mod h1:hCXHAvcg9YZ/v5vE997LYWtbhK3zPamswgM+e9iY8r8=
 github.com/juju/retry v0.0.0-20151029024821-62c620325291/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v0.0.0-20180821225755-9058e192b216/go.mod h1:OohPQGsr4pnxwD5YljhQ+TZnuVRYpa5irjugL1Yuif4=
 github.com/juju/retry v1.0.0 h1:Tb1hFdDSPGLH/BGdYQOF7utQ9lA0ouVJX2imqgJK6tk=

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/mongo"
-	"github.com/juju/juju/tools"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/mgo/v2/bson"
 	"github.com/juju/mgo/v2/txn"
@@ -22,7 +20,9 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/controller"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/mongo"
 	stateerrors "github.com/juju/juju/state/errors"
+	"github.com/juju/juju/tools"
 )
 
 func isController(mdoc *machineDoc) bool {

--- a/state/errors/machine.go
+++ b/state/errors/machine.go
@@ -21,8 +21,13 @@ const (
 	// HasContainersError indicates that the machine had attempted to be
 	// destroyed with containers still running.
 	HasContainersError = errors.ConstError("machine is hosting containers")
+
+	// IsControllerMemberError indicates the machine had attempted to be
+	// destroyed whilst still considered a controller.
+	IsControllerMemberError = errors.ConstError("machine is still a controller member")
 )
 
+// NewHasAssignedUnitsError creates a new error that satisfies HasAssignedUnitsError.
 func NewHasAssignedUnitsError(machineId string, unitNames []string) error {
 	return errors.WithType(
 		fmt.Errorf("machine %s has unit %q assigned",
@@ -32,7 +37,7 @@ func NewHasAssignedUnitsError(machineId string, unitNames []string) error {
 	)
 }
 
-// NewHasContainersError creates a new error that satisfies HasContainersError
+// NewHasContainersError creates a new error that satisfies HasContainersError.
 func NewHasContainersError(machineId string, containerIds []string) error {
 	return errors.WithType(
 		fmt.Errorf("machine %s is hosting containers %q",
@@ -42,6 +47,7 @@ func NewHasContainersError(machineId string, containerIds []string) error {
 	)
 }
 
+// NewHasAttachmentsError creates a new error that satisfies HasAttachmentsError.
 func NewHasAttachmentsError(machineId string, attachments []names.Tag) error {
 	return errors.WithType(
 		fmt.Errorf(
@@ -49,5 +55,24 @@ func NewHasAttachmentsError(machineId string, attachments []names.Tag) error {
 			machineId,
 			attachments),
 		HasAttachmentsError,
+	)
+}
+
+const (
+	voting    = "voting"
+	nonvoting = "non-voting"
+)
+
+// NewIsControllerMemberError creates a new error that satisfies IsControllerMemberError.
+func NewIsControllerMemberError(machineId string, isVoting bool) error {
+	status := nonvoting
+	if isVoting {
+		status = voting
+	}
+	return errors.WithType(
+		fmt.Errorf(
+			"machine %s is still a %s controller member",
+			machineId, status),
+		IsControllerMemberError,
 	)
 }

--- a/state/machine.go
+++ b/state/machine.go
@@ -818,11 +818,8 @@ func (original *Machine) advanceLifecycle(life Life, force, dyingAllowContainers
 			if m.doc.Life == Dead {
 				return nil, jujutxn.ErrNoOperations
 			}
-			if hasVote {
-				return nil, fmt.Errorf("machine %s is still a voting controller member", m.doc.Id)
-			}
-			if m.IsManager() {
-				return nil, errors.Errorf("machine %s is still a controller member", m.Id())
+			if hasVote || m.IsManager() {
+				return nil, stateerrors.NewIsControllerMemberError(m.Id(), hasVote)
 			}
 			asserts = append(asserts, bson.DocElem{
 				Name: "jobs", Value: bson.D{{Name: "$nin", Value: []MachineJob{JobManageModel}}}})

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -316,7 +316,7 @@ func (s *MachineSuite) TestMachineIsContainer(c *gc.C) {
 	c.Assert(container.IsContainer(), jc.IsTrue)
 }
 
-func (s *MachineSuite) TestLifeJobManageModel(c *gc.C) {
+func (s *MachineSuite) TestLifeJobController(c *gc.C) {
 	m := s.machine0
 	err := m.Destroy()
 	c.Assert(err, gc.ErrorMatches, "controller 0 is the only controller")

--- a/worker/machiner/machiner.go
+++ b/worker/machiner/machiner.go
@@ -226,6 +226,10 @@ func (mr *Machiner) Handle(_ <-chan struct{}) error {
 			logger.Tracef("machine still has storage attached")
 			return nil
 		}
+		if params.IsCodeTryAgain(err) {
+			logger.Tracef("waiting for machine to be removed as a controller")
+			return nil
+		}
 		if params.IsCodeMachineHasContainers(err) {
 			logger.Tracef("machine still has containers")
 			return errors.Annotatef(err, "%q", mr.config.Tag)

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/state"
 )
 
 // jujuNodeKey is the key for the tag where we save a member's node id.
@@ -54,11 +55,6 @@ type desiredChanges struct {
 
 	// members is the map of Id to replicaset.Member for the desired list of controller nodes in the replicaset.
 	members map[string]*replicaset.Member
-
-	// nodeVoting tracks which of the members should be set to vote. We should preserve an odd number of voters at all
-	// time. Also, when nodes are first added to the replicaset, we wait to give them voting rights for when they
-	// have managed to sync the data from the current primary.
-	nodeVoting map[string]bool
 }
 
 // peerGroupChanges tracks the process of computing the desiredChanges to the peer group.
@@ -113,9 +109,9 @@ func newPeerGroupInfo(
 			continue
 		}
 		found := false
-		if controllers[controllerId] != nil {
+		if node, got := controllers[controllerId]; got {
 			info.recognised[controllerId] = m
-			found = true
+			found = node.host.Life() != state.Dead
 		}
 
 		// This invariably makes for N^2, but we anticipate small N.
@@ -230,7 +226,6 @@ func desiredPeerGroup(info *peerGroupInfo) (desiredChanges, error) {
 		desired: desiredChanges{
 			isChanged:       false,
 			stepDownPrimary: false,
-			nodeVoting:      map[string]bool{},
 			members:         map[string]*replicaset.Member{},
 		},
 	}
@@ -262,7 +257,6 @@ func (p *peerGroupChanges) computeDesiredPeerGroup() (desiredChanges, error) {
 
 	// Set up initial record of controller node votes. Any changes after
 	// this will trigger a peer group election.
-	p.getNodesVoting()
 	p.adjustVotes()
 
 	if err := p.updateAddresses(); err != nil {
@@ -342,6 +336,19 @@ func (p *peerGroupChanges) possiblePeerGroupChanges() {
 	for _, id := range nodeIds {
 		m := p.info.controllers[id]
 		member := p.desired.members[id]
+		if m.host.Life() != state.Alive {
+			if _, ok := p.desired.members[id]; !ok {
+				// Dead machine already removed from replicaset.
+				continue
+			}
+			logger.Debugf("controller %v has died %q, wants vote: %v", id, m.host.Life(), m.WantsVote())
+			if isPrimaryMember(p.info, id) {
+				p.desired.stepDownPrimary = true
+			}
+			delete(p.desired.members, id)
+			p.desired.isChanged = true
+			continue
+		}
 		isVoting := member != nil && isVotingMember(member)
 		wantsVote := m.WantsVote()
 		switch {
@@ -464,7 +471,6 @@ func (p *peerGroupChanges) adjustVotes() {
 	setVoting := func(memberIds []string, voting bool) {
 		for _, id := range memberIds {
 			setMemberVoting(p.desired.members[id], voting)
-			p.desired.nodeVoting[id] = voting
 		}
 	}
 
@@ -507,12 +513,6 @@ func (p *peerGroupChanges) createNonVotingMember() {
 		}
 		setMemberVoting(member, false)
 		p.desired.members[id] = member
-	}
-}
-
-func (p *peerGroupChanges) getNodesVoting() {
-	for id, m := range p.desired.members {
-		p.desired.nodeVoting[id] = isVotingMember(m)
 	}
 }
 

--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/juju/clock"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/replicaset/v2"
@@ -284,7 +285,7 @@ func (w *pgWorker) loop() error {
 			idle.Reset(IdleTime)
 			continue
 		case <-controllerChanges:
-			// A controller controller was added or removed.
+			// A controller was added or removed.
 			logger.Tracef("<-controllerChanges")
 			changed, err := w.updateControllerNodes()
 			if err != nil {
@@ -339,9 +340,9 @@ func (w *pgWorker) loop() error {
 
 		members, err := w.updateReplicaSet()
 		if err != nil {
-			if _, isReplicaSetError := err.(*replicaSetError); isReplicaSetError {
+			if errors.Is(err, replicaSetError) {
 				logger.Errorf("cannot set replicaset: %v", err)
-			} else if _, isStepDownPrimary := err.(*stepDownPrimaryError); !isStepDownPrimary {
+			} else if !errors.Is(err, stepDownPrimaryError) {
 				return errors.Trace(err)
 			} else {
 				logger.Tracef("isStepDownPrimary error: %v", err)
@@ -585,18 +586,14 @@ func (w *pgWorker) publishAPIServerDetails(
 	}
 }
 
-// replicaSetError holds an error returned as a result
+// replicaSetError means an error occurred as a result
 // of calling replicaset.Set. As this is expected to fail
 // in the normal course of things, it needs special treatment.
-type replicaSetError struct {
-	error
-}
+const replicaSetError = errors.ConstError("replicaset error")
 
 // stepDownPrimaryError means we needed to ask the primary to step down, so we should come back and re-evaluate the
 // replicaset once the new primary is voted in
-type stepDownPrimaryError struct {
-	error
-}
+const stepDownPrimaryError = errors.ConstError("primary is stepping down, must reevaluate peer group")
 
 // updateReplicaSet sets the current replica set members, and applies the
 // given voting status to nodes in the state. A mapping of controller ID
@@ -618,8 +615,8 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 			logger.Debugf("desired peer group members: \n%s", prettyReplicaSetMembers(desired.members))
 		} else {
 			var output []string
-			for id, v := range desired.nodeVoting {
-				output = append(output, fmt.Sprintf("  %s: %v", id, v))
+			for id, m := range desired.members {
+				output = append(output, fmt.Sprintf("  %s: %v", id, isVotingMember(m)))
 			}
 			logger.Debugf("no change in desired peer group, voting: \n%s", strings.Join(output, "\n"))
 		}
@@ -636,9 +633,7 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 		// reconnected so we can keep operating
 		w.config.MongoSession.Refresh()
 		// However, we no longer know who the primary is, so we have to error out and have it reevaluated
-		return nil, &stepDownPrimaryError{
-			error: errors.Errorf("primary is stepping down, must reevaluate peer group"),
-		}
+		return nil, stepDownPrimaryError
 	}
 
 	// Figure out if we are running on the mongo primary.
@@ -650,49 +645,6 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 	logger.Debugf("controller node %q primary: %v", controllerId, isPrimary)
 	if !isPrimary {
 		return desired.members, nil
-	}
-
-	// We cannot change the HasVote flag of a controller in state at exactly
-	// the same moment as changing its voting status in the replica set.
-	//
-	// Thus we need to be careful that a controller which is actually a voting
-	// member is not seen to not have a vote, because otherwise
-	// there is nothing to prevent the controller being removed.
-	//
-	// To avoid this happening, we make sure when we call SetReplicaSet,
-	// that the voting status of nodes is the union of both old
-	// and new voting nodes - that is the set of HasVote nodes
-	// is a superset of all the actual voting nodes.
-	//
-	// Only after the call has taken place do we reset the voting status
-	// of the nodes that have lost their vote.
-	//
-	// If there's a crash, the voting status may not reflect the
-	// actual voting status for a while, but when things come
-	// back on line, it will be sorted out, as desiredReplicaSet
-	// will return the actual voting status.
-	//
-	// Note that we potentially update the HasVote status of the nodes even
-	// if the members have not changed.
-	var added, removed []*controllerTracker
-	// Iterate in obvious order so we don't get weird log messages
-	votingIds := make([]string, 0, len(desired.nodeVoting))
-	for id := range desired.nodeVoting {
-		votingIds = append(votingIds, id)
-	}
-	sortAsInts(votingIds)
-	for _, id := range votingIds {
-		hasVote := desired.nodeVoting[id]
-		m := info.controllers[id]
-		switch {
-		case hasVote && !m.node.HasVote():
-			added = append(added, m)
-		case !hasVote && m.node.HasVote():
-			removed = append(removed, m)
-		}
-	}
-	if err := setHasVote(added, true); err != nil {
-		return nil, errors.Annotate(err, "adding new voters")
 	}
 
 	// Currently k8s controllers do not support HA, so only update
@@ -713,17 +665,9 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 			ms = append(ms, *m)
 		}
 		if err := w.config.MongoSession.Set(ms); err != nil {
-			// We've failed to set the replica set, so revert back
-			// to the previous settings.
-			if err1 := setHasVote(added, false); err1 != nil {
-				logger.Errorf("cannot revert controller voting after failure to change replica set: %v", err1)
-			}
-			return nil, &replicaSetError{err}
+			return nil, errors.WithType(err, replicaSetError)
 		}
 		logger.Infof("successfully updated replica set")
-	}
-	if err := setHasVote(removed, false); err != nil {
-		return nil, errors.Annotate(err, "removing non-voters")
 	}
 
 	// Reset controller status for members of the changed peer-group.
@@ -734,25 +678,65 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 			return nil, errors.Trace(err)
 		}
 	}
-	for _, tracker := range info.controllers {
+	if err := w.updateVoteStatus(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, tracker := range w.controllerTrackers {
 		if tracker.host.Life() != state.Alive && !tracker.node.HasVote() {
-			logger.Debugf("removing dying controller %s", tracker.Id())
+			logger.Debugf("removing dying controller %s references", tracker.Id())
 			if err := w.config.State.RemoveControllerReference(tracker.node); err != nil {
 				logger.Errorf("failed to remove dying controller as a controller after removing its vote: %v", err)
 			}
 		}
 	}
-	for _, removedTracker := range removed {
-		if removedTracker.host.Life() == state.Alive {
-			logger.Infof("vote removed from %v but controller is %s, should soon die", removedTracker.Id(), state.Alive)
-		}
-	}
 	return desired.members, nil
 }
 
+func (w *pgWorker) updateVoteStatus() error {
+	currentMembers, err := w.config.MongoSession.CurrentMembers()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	orphanedNodes := set.NewStrings()
+	for id := range w.controllerTrackers {
+		orphanedNodes.Add(id)
+	}
+	var voting, nonVoting []*controllerTracker
+	for _, m := range currentMembers {
+		node, ok := w.controllerTrackers[m.Tags[jujuNodeKey]]
+		orphanedNodes.Remove(node.Id())
+		if ok {
+			if !node.HasVote() && isVotingMember(&m) {
+				logger.Tracef("controller %v is now voting member", node.Id())
+				voting = append(voting, node)
+			} else if node.HasVote() && !isVotingMember(&m) {
+				logger.Tracef("controller %v is now non voting member", node.Id())
+				nonVoting = append(nonVoting, node)
+			}
+		}
+	}
+	logger.Debugf("controllers which are no longer in replicaset: %v", orphanedNodes.Values())
+	for _, id := range orphanedNodes.Values() {
+		node := w.controllerTrackers[id]
+		nonVoting = append(nonVoting, node)
+	}
+	if err := setHasVote(voting, true); err != nil {
+		return errors.Annotatef(err, "adding voters")
+	}
+	if err := setHasVote(nonVoting, false); err != nil {
+		return errors.Annotatef(err, "removing non-voters")
+	}
+	return nil
+}
+
+const (
+	voting    = "voting"
+	nonvoting = "non-voting"
+)
+
 func prettyReplicaSetMembers(members map[string]*replicaset.Member) string {
 	var result []string
-	// Its easier to read if we sort by Id.
+	// It's easier to read if we sort by Id.
 	keys := make([]string, 0, len(members))
 	for key := range members {
 		keys = append(keys, key)
@@ -760,11 +744,11 @@ func prettyReplicaSetMembers(members map[string]*replicaset.Member) string {
 	sort.Strings(keys)
 	for _, key := range keys {
 		m := members[key]
-		voting := "not-voting"
+		voteStatus := nonvoting
 		if isVotingMember(m) {
-			voting = "voting"
+			voteStatus = voting
 		}
-		result = append(result, fmt.Sprintf("    Id: %d, Tags: %v, %s", m.Id, m.Tags, voting))
+		result = append(result, fmt.Sprintf("    Id: %d, Tags: %v, %s", m.Id, m.Tags, voteStatus))
 	}
 	return strings.Join(result, "\n")
 }

--- a/worker/peergrouper/worker_test.go
+++ b/worker/peergrouper/worker_test.go
@@ -408,17 +408,12 @@ func (s *workerSuite) TestAddressChangeNoHA(c *gc.C) {
 }
 
 var fatalErrorsTests = []struct {
-	errPattern   string
-	err          error
-	expectErr    string
-	advanceCount int
+	errPattern string
+	err        error
+	expectErr  string
 }{{
 	errPattern: "State.ControllerIds",
 	expectErr:  "cannot get controller ids: sample",
-}, {
-	errPattern:   "Controller.SetHasVote 11 true",
-	expectErr:    `adding new voters: cannot set voting status of "11" to true: sample`,
-	advanceCount: 2,
 }, {
 	errPattern: "Session.CurrentStatus",
 	expectErr:  "creating peer group info: cannot get replica set status: sample",
@@ -446,9 +441,6 @@ func (s *workerSuite) TestFatalErrors(c *gc.C) {
 			w := s.newWorker(c, st, st.session, nopAPIHostPortsSetter{}, true)
 			defer workertest.DirtyKill(c, w)
 
-			for j := 0; j < testCase.advanceCount; j++ {
-				_ = s.clock.WaitAdvance(pollInterval, coretesting.ShortWait, 1)
-			}
 			done := make(chan error)
 			go func() {
 				done <- w.Wait()
@@ -1010,11 +1002,8 @@ func (s *workerSuite) TestDyingMachinesAreRemoved(c *gc.C) {
 	// When we advance the lifecycle (aka controller.Destroy()), we should notice that the controller no longer wants a vote
 	// controller.Destroy() advances to both Dying and SetWantsVote(false)
 	st.controller("11").advanceLifecycle(state.Dying, false)
-	// we should notice that we want to remove the vote first
-	update := s.mustNext(c, "removing vote")
-	assertMembers(c, update, mkMembers("0v 1 2", testIPv4))
-	// And once we don't have the vote, and we see the controller is Dying we should remove it
-	update = s.mustNext(c, "remove dying controller")
+	// We see the controller is Dying we should remove it.
+	update := s.mustNext(c, "remove dying controller")
 	assertMembers(c, update, mkMembers("0v 2", testIPv4))
 
 	// Now, controller 2 no longer has the vote, but if we now flag it as dying,
@@ -1096,10 +1085,6 @@ func (s *workerSuite) TestRemovePrimaryValidSecondaries(c *gc.C) {
 
 // recordMemberChanges starts a go routine to record member changes.
 func (s *workerSuite) recordMemberChanges(c *gc.C, w *voyeur.Watcher) {
-	type voyeurResult struct {
-		ok  bool
-		val interface{}
-	}
 	go func() {
 		for {
 			c.Logf("waiting for next update")
@@ -1213,6 +1198,7 @@ func (s *workerSuite) newWorker(
 	supportsHA bool,
 ) worker.Worker {
 	return s.newWorkerWithConfig(c, Config{
+		Clock:                s.clock,
 		State:                st,
 		MongoSession:         session,
 		APIHostPortsSetter:   apiHostPortsSetter,


### PR DESCRIPTION
The peergrouper worker is used to reconcile the mongo replicaset configuration with the controllers in the juju model.
The logic was written such that as soon as a controller machine was set to dying, it would get marked as non-voting. This would allow the machine to transition to dead and thus be deleted from the model. But if the mongo replicaset changes had not yet been propagated, removing the machine and this the voting mongo node would wedge the replicaset.

The solution is to only update the voting status in the juju model based on the observed state of the replicaset. This allows the changes to flush through mongo before the node is shutdown in juju. Once a machine goes to dead, it is then safe to remove the node from the replicaset.

As we are waiting for the changes to flush through, the "machiner" is attempting to transition the machine to dead. This will fail until the vote gets removed. There's no point in marking the machine as in Error state, so we allow the machine to remain as Stopped, just as we do if the machine still has units etc.

## Checklist

- [ x] Code style: imports ordered, good names, simple structure, etc
- [x ] Comments saying why design decisions were made
- [x ] Go unit tests, with comments saying what you're testing
- [x ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

The issue was observed in the integration tests.
bootstrap and enable-ha
In quick succession, remove machines 1 and 2 and watch juju status and juju show-controller. Things should stabilise and the remaining controller should function as normal.

Do the above but only remove one machine - the other controller should show as pending. Now enable-ha again and the 3 controllers should all get the vote.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1971627
