### PR TITLE
[JUJU-1541] Add stub NetworkInterfaces call to VSphere provider

### DIFF
--- a/provider/vsphere/environ_network.go
+++ b/provider/vsphere/environ_network.go
@@ -5,20 +5,36 @@ package vsphere
 
 import (
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 )
 
 // OpenPorts is part of the environs.Firewaller interface.
-func (*environ) OpenPorts(rules firewall.IngressRules) error {
+func (*environ) OpenPorts(_ firewall.IngressRules) error {
 	return errors.Trace(errors.NotSupportedf("ClosePorts"))
 }
 
 // ClosePorts is part of the environs.Firewaller interface.
-func (*environ) ClosePorts(rules firewall.IngressRules) error {
+func (*environ) ClosePorts(_ firewall.IngressRules) error {
 	return errors.Trace(errors.NotSupportedf("ClosePorts"))
 }
 
-// IngressPorts is part of the environs.Firewaller interface.
+// IngressRules is part of the environs.Firewaller interface.
 func (*environ) IngressRules() (firewall.IngressRules, error) {
 	return nil, errors.Trace(errors.NotSupportedf("Ports"))
+}
+
+// NetworkInterfaces exists only to satisfy the Environ indirection of the
+// instance-poller worker.
+// Without this method the worker throws an error, which prevents the status of
+// instances being known.
+// The provider does not support the AllocatePublicIP constraint, which means
+// we can assume that the network configuration returned by the machine agent
+// represents the knowable link-layer data for each VM - there is no
+// elaboration available from the provider.
+func (env *environ) NetworkInterfaces(_ context.ProviderCallContext, _ []instance.Id) ([]network.InterfaceInfos, error) {
+	return nil, environs.ErrNoInstances
 }


### PR DESCRIPTION
The absence of the `NetworkInterfaces` method on the VSphere provider causes the instance-poller to throw an error every run, preventing updates to instance statuses.

Here we add a stub that just returns `ErrNoInstances`. This will allow the instance-poller to update instance statuses.

## QA steps

- Bootstrap to VSphere.
- Ensure that controller model `logging-config` includes `juju.worker.instancepoller=DEBUG`.
- Add a machine.
- Ensure that its instance status progresses from "allocating" according to the logs.
```
controller-0: 16:58:26 INFO juju.worker.instancepoller machine "0" (instance ID "juju-5ae829-0") instance status changed from {"pending" ""} to {"running" "Running"}
```
- Also ensure that the logs show the machine move from the short to the long poll group
```
controller-0: 17:47:00 DEBUG juju.worker.instancepoller moving machine "0" (instance ID "juju-5ae829-0") to long poll group
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1982865
