### PR TITLE
Only update juju-db snap config on machines

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -875,8 +875,10 @@ func (a *MachineAgent) Restart() error {
 // in use. Why can't upgradesteps depend on the main state connection?
 func (a *MachineAgent) openStateForUpgrade() (*state.StatePool, error) {
 	agentConfig := a.CurrentConfig()
-	if err := cmdutil.EnsureMongoServerStarted(agentConfig.JujuDBSnapChannel()); err != nil {
-		return nil, errors.Trace(err)
+	if !a.isCaasAgent {
+		if err := cmdutil.EnsureMongoServerStarted(agentConfig.JujuDBSnapChannel()); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	info, ok := agentConfig.MongoInfo()
 	if !ok {


### PR DESCRIPTION
PR #14314 added a fix to ensure mongo snap config gets updated when the memory profile setting changes.
However, the refactoring done there did not exclude running this on k8s. We just need a check to ensure k8s controllers do not attempt to run the update.

## QA steps

Do the original QA steps from the first PR.

bootstrap to k8s and check logs to ensure the database upgrade worker is not restarting

