### PR TITLE
Fixes test reference to non existent ubuntu charm.

### DIFF
--- a/tests/suites/upgrade/streams.sh
+++ b/tests/suites/upgrade/streams.sh
@@ -132,7 +132,7 @@ exec_simplestream_metadata() {
 		fi
 	done
 
-	juju upgrade-charm ubuntu --path=./tests/suites/upgrade/charms/ubuntu
+	juju upgrade-charm ubuntu
 
 	sleep 10
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"


### PR DESCRIPTION
During charm cleanup a reference was missed to an old local Ubuntu charm.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
cd tests
./main.sh -v -s 'test_upgrade_simplestream_previous' upgrade
```