### PR TITLE
[JUJU-1210] Rewrite to bash-based nw-deploy-xenial-arm64-lxd

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -290,7 +290,9 @@ post_add_model() {
 		;;
 	esac
 
-	juju set-model-constraints "arch=${BUILD_ARCH:-}"
+	if [[ -z "${MODEL_ARCH}" ]]; then
+		juju set-model-constraints "arch=${MODEL_ARCH}"
+	fi
 }
 
 # destroy_model takes a model name and destroys a model. It first checks if the

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -152,6 +152,34 @@ bootstrap() {
 	export BOOTSTRAPPED_JUJU_CTRL_NAME="${name}"
 }
 
+# normalise_arch returns the Juju architecture corresponding to a machine's
+# reported architecture. The Juju architecture is used to filter simple
+# streams lookup of tools and images.
+normalise_arch() {
+	raw_arch=${1}
+
+	case "${raw_arch}" in
+	"amd64" | "x86_64")
+		echo "amd64"
+		;;
+	i[3456789]86)
+		echo "i386"
+		;;
+	*arm | armv*)
+		echo "armhf"
+		;;
+	"aarch64")
+		echo "arm64"
+		;;
+	"ppc64" | "ppc64el" | "ppc64le")
+		echo "ppc64el"
+		;;
+	"s390x")
+		echo "s390x"
+		;;
+	esac
+}
+
 # add_model is used to add a model for tracking. This is for internal use only
 # and shouldn't be used by any of the tests directly.
 add_model() {
@@ -289,6 +317,9 @@ post_add_model() {
 		add_images_for_vsphere
 		;;
 	esac
+
+	arch=$(uname -m)
+	juju set-model-constraints "arch=$(normalise_arch "${arch}")"
 }
 
 # destroy_model takes a model name and destroys a model. It first checks if the

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -290,7 +290,7 @@ post_add_model() {
 		;;
 	esac
 
-	if [[ -z "${MODEL_ARCH}" ]]; then
+	if [[ -z ${MODEL_ARCH} ]]; then
 		juju set-model-constraints "arch=${MODEL_ARCH}"
 	fi
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -152,34 +152,6 @@ bootstrap() {
 	export BOOTSTRAPPED_JUJU_CTRL_NAME="${name}"
 }
 
-# normalise_arch returns the Juju architecture corresponding to a machine's
-# reported architecture. The Juju architecture is used to filter simple
-# streams lookup of tools and images.
-normalise_arch() {
-	raw_arch=${1}
-
-	case "${raw_arch}" in
-	"amd64" | "x86_64")
-		echo "amd64"
-		;;
-	i[3456789]86)
-		echo "i386"
-		;;
-	*arm | armv*)
-		echo "armhf"
-		;;
-	"aarch64")
-		echo "arm64"
-		;;
-	"ppc64" | "ppc64el" | "ppc64le")
-		echo "ppc64el"
-		;;
-	"s390x")
-		echo "s390x"
-		;;
-	esac
-}
-
 # add_model is used to add a model for tracking. This is for internal use only
 # and shouldn't be used by any of the tests directly.
 add_model() {
@@ -318,8 +290,7 @@ post_add_model() {
 		;;
 	esac
 
-	arch=$(uname -m)
-	juju set-model-constraints "arch=$(normalise_arch "${arch}")"
+	juju set-model-constraints "arch=${BUILD_ARCH:-}"
 }
 
 # destroy_model takes a model name and destroys a model. It first checks if the

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -235,14 +235,14 @@ test_deploy_charms() {
 
 		run "run_deploy_charm"
 		run "run_deploy_specific_series"
-#		run "run_deploy_lxd_to_container"
-#		run "run_deploy_lxd_profile_charm_container"
+		#		run "run_deploy_lxd_to_container"
+		#		run "run_deploy_lxd_profile_charm_container"
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"lxd" | "localhost")
 			run "run_deploy_lxd_to_machine"
 			run "run_deploy_lxd_profile_charm"
-#			run "run_deploy_local_lxd_profile_charm"
+			#			run "run_deploy_local_lxd_profile_charm"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -213,7 +213,7 @@ run_deploy_lxd_to_container() {
 		attempt=$((attempt + 1))
 		if [ $attempt -eq 10 ]; then
 			# shellcheck disable=SC2046
-			echo $(red "timeout: waiting for lxc profile to show 50sec")
+			echo $(red "timeout: waiting for removal of lxc profile 50sec")
 			exit 5
 		fi
 		sleep 5
@@ -235,14 +235,14 @@ test_deploy_charms() {
 
 		run "run_deploy_charm"
 		run "run_deploy_specific_series"
-		run "run_deploy_lxd_to_container"
-		run "run_deploy_lxd_profile_charm_container"
+#		run "run_deploy_lxd_to_container"
+#		run "run_deploy_lxd_profile_charm_container"
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"lxd" | "localhost")
 			run "run_deploy_lxd_to_machine"
 			run "run_deploy_lxd_profile_charm"
-			run "run_deploy_local_lxd_profile_charm"
+#			run "run_deploy_local_lxd_profile_charm"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -235,14 +235,14 @@ test_deploy_charms() {
 
 		run "run_deploy_charm"
 		run "run_deploy_specific_series"
-		#		run "run_deploy_lxd_to_container"
-		#		run "run_deploy_lxd_profile_charm_container"
+		run "run_deploy_lxd_to_container"
+		run "run_deploy_lxd_profile_charm_container"
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"lxd" | "localhost")
 			run "run_deploy_lxd_to_machine"
 			run "run_deploy_lxd_profile_charm"
-			#			run "run_deploy_local_lxd_profile_charm"
+			run "run_deploy_local_lxd_profile_charm"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"


### PR DESCRIPTION
This patch provides changes in the deploy suite (bash-based testing system) to be able to deploy charms on arm64 machines at the same time without breaking tests when this suite is executed on amd64 machines.

IMPORTANT: I've disabled following tests: run_deploy_lxd_to_container, run_deploy_lxd_profile_charm_container, run_deploy_local_lxd_profile_charm, because we have known issue that breaks lxd-in-containers (on lxd). So, these tests commented only on passing QA steps. I'll uncomment them before merging. 

We plan this test to be targeted on AWS (on "ephemeral-focal-4c-16g-arm64" mode) in our Jenkins.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# bootstrap aws cloud with any juju you have
juju bootstrap aws aws
juju add-machine --constraints "arch=arm64 cores=2 root-disk=32G"
# wait for the machine to be started
juju ssh 0 
# inside the machine
sudo apt install make cmake python3-pip libssl-dev jq shellcheck
# install juju, based on this PR
git clone https://github.com/juju/juju.git
cd juju
git fetch origin pull/14409/head:test-branch
git checkout test-branch
make install-dependencies
make build
export GOPATH="/home/ubuntu/go:/home/ubuntu/juju/_build/linux_arm64"
export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
# init localhost cloud
sudo newgrp lxd
exit
sudo adduser $USER lxd
newgrp lxd
lxd init --auto
lxc network set lxdbr0 ipv6.address none
# launch deploy_charms tests
cd tests
export BUILD_ARCH=arm64
./main.sh -v -p lxd deploy test_deploy_charms
```
