### PR TITLE
Annotate the error when sending the pebble-ready event

### DIFF
--- a/worker/uniter/doc.go
+++ b/worker/uniter/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package uniter is the "uniter" worker which implements the capabilities of
+// the unit agent, for example running a charm's hooks in response to model
+// events. The uniter worker sets up the various components which make that
+// happen and then runs the top level event loop.
+package uniter

--- a/worker/uniter/paths.go
+++ b/worker/uniter/paths.go
@@ -1,5 +1,4 @@
 // Copyright 2012-2014 Canonical Ltd.
-
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package uniter

--- a/worker/uniter/pebblepoller.go
+++ b/worker/uniter/pebblepoller.go
@@ -123,9 +123,12 @@ func (p *pebblePoller) poll(containerName string) error {
 	lastBootID, _ := p.pebbleBootIDs[containerName]
 	p.mut.Unlock()
 	if lastBootID == info.BootID {
+		// Boot ID is the same as last time, so it's normal poll and no
+		// pebble-ready event is needed.
 		return nil
 	}
 
+	// We've just started up, so send a pebble-ready event.
 	errChan := make(chan error, 1)
 	eid := p.workloadEvents.AddWorkloadEvent(container.WorkloadEvent{
 		Type:         container.ReadyEvent,
@@ -144,7 +147,7 @@ func (p *pebblePoller) poll(containerName string) error {
 	select {
 	case err := <-errChan:
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Annotate(err, "failed to send pebble-ready event")
 		}
 	case <-p.tomb.Dying():
 		return tomb.ErrDying

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -72,10 +72,7 @@ type RebootQuerier interface {
 // RemoteInitFunc is used to init remote state
 type RemoteInitFunc func(remotestate.ContainerRunningStatus, <-chan struct{}) error
 
-// Uniter implements the capabilities of the unit agent. It is not intended to
-// implement the actual *behaviour* of the unit agent; that responsibility is
-// delegated to Mode values, which are expected to react to events and direct
-// the uniter's responses to them.
+// Uniter implements the capabilities of the unit agent, for example running hooks.
 type Uniter struct {
 	catacomb                     catacomb.Catacomb
 	st                           *uniter.State


### PR DESCRIPTION
This is so the error doesn't look like it's the Pebble polling that
failed, but clarifies that it's sending the hook itself that failed.
Will change this:

```
juju.worker.uniter pebble poll failed for container "etcd": hook failed
```

To this:

```
juju.worker.uniter pebble poll failed for container "etcd": failed to send pebble-ready event: hook failed
```

See also https://bugs.launchpad.net/juju/+bug/1982205

Also add a basic doc.go for the worker/uniter package, and remove old
text from the Uniter type that doesn't make sense anymore (there's no
Mode type at all).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
