### PR TITLE
[JUJU-1553] Fix migration prechecks for cross model relations

### DIFF
--- a/migration/precheck_shim.go
+++ b/migration/precheck_shim.go
@@ -152,8 +152,24 @@ func (s *precheckRelationShim) Unit(pu PrecheckUnit) (PrecheckRelationUnit, erro
 	return ru, errors.Trace(err)
 }
 
-// IsCrossModel implements PreCheckRelation.
-func (s *precheckRelationShim) IsCrossModel() (bool, error) {
-	_, result, err := s.Relation.RemoteApplication()
-	return result, errors.Trace(err)
+// AllRemoteUnits implements PreCheckRelation.
+func (s *precheckRelationShim) AllRemoteUnits(appName string) ([]PrecheckRelationUnit, error) {
+	all, err := s.Relation.AllRemoteUnits(appName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	out := make([]PrecheckRelationUnit, len(all))
+	for i, ru := range all {
+		out[i] = ru
+	}
+	return out, nil
+}
+
+// RemoteApplication implements PreCheckRelation.
+func (s *precheckRelationShim) RemoteApplication() (string, bool, error) {
+	app, isCrossModel, err := s.Relation.RemoteApplication()
+	if isCrossModel {
+		return app.Name(), true, nil
+	}
+	return "", false, errors.Trace(err)
 }


### PR DESCRIPTION
A failing CI test led to the discovery of this issue - when doing migration prechecks and ensuring that relations were fully formed, any cross model relations were ignored. Thus in scope checks were not done and so instead of an (expected) precheck failure, the error surfaced later during model export for which errors are not expected. The relation precheck logic is updated to include cross model relations.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

bootstrap a controller, add two models
in one model, deploy juju-qa-dummy-source and offer it
in other model, deploy juju-qa-dummy-sink and consume juju-qa-dummy-source

bootstrap a second controller and migrate both models to the new controller

juju relate dummy-sink dummy-source && juju migrate c test2
ERROR source prechecks failed: unit dummy-sink/0 hasn't joined relation "dummy-source:sink dummy-sink:source" yet

migrate again and it will work second time