### PR TITLE
[JUJU-1554] Increase `test-ck-aws` teardown timeout to 45m

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -295,12 +295,13 @@ post_add_model() {
 # model is found before attempting to do so.
 #
 # ```
-# destroy_model <model name>
+# destroy_model <model name> [<timeout>]
 # ```
 destroy_model() {
-	local name
+	local name timeout
 
 	name=${1}
+	timeout=${2:-30m}
 	shift
 
 	# shellcheck disable=SC2034
@@ -313,7 +314,7 @@ destroy_model() {
 	output="${TEST_DIR}/${name}-destroy.log"
 
 	echo "====> Destroying juju model ${name}"
-	echo "${name}" | xargs -I % juju destroy-model -y --destroy-storage % >"${output}" 2>&1 || true
+	echo "${name}" | xargs -I % juju destroy-model -y --destroy-storage --timeout="$timeout" % >"${output}" 2>&1 || true
 	CHK=$(cat "${output}" | grep -i "ERROR\|Unable to get the model status from the API" || true)
 	if [[ -n ${CHK} ]]; then
 		printf '\nFound some issues\n'

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -71,6 +71,6 @@ test_deploy_ck() {
 
 		run "run_deploy_caas_workload"
 
-		destroy_model "${run_deploy_ck_name}"
+		destroy_model "${run_deploy_ck_name}" 45m
 	)
 }


### PR DESCRIPTION
The `test-ck-aws` gating test is timing out during the teardown of the model. From manual testing, it seems the model has no issues tearing down - it just takes a long time. Therefore I've:
- added an option to `destroy_model` to allow specifying a custom timeout
- changed the ck teardown timeout from 30m to 45m.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
cd tests
./main.sh -v ck
```