### PR TITLE
[JUJU-1556] Fix intermittent failure in TxnWatcherSuite.TestDoubleUpdate

### DIFF
--- a/state/watcher/txnwatcher_test.go
+++ b/state/watcher/txnwatcher_test.go
@@ -4,6 +4,7 @@
 package watcher_test
 
 import (
+	"sync"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -175,7 +176,7 @@ func (s *TxnWatcherSuite) TestInsert(c *gc.C) {
 	revno := s.insert(c, "test", "a")
 
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
 		{"test", "a", revno},
@@ -189,7 +190,7 @@ func (s *TxnWatcherSuite) TestUpdate(c *gc.C) {
 	revno := s.update(c, "test", "a")
 
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
 		{"test", "a", revno},
@@ -203,7 +204,7 @@ func (s *TxnWatcherSuite) TestRemove(c *gc.C) {
 	revno := s.remove(c, "test", "a")
 
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
 		{"test", "a", revno},
@@ -218,7 +219,7 @@ func (s *TxnWatcherSuite) TestWatchOrder(c *gc.C) {
 	revno3 := s.insert(c, "test", "c")
 
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
 		{"test", "a", revno1},
@@ -233,7 +234,7 @@ func (s *TxnWatcherSuite) TestTransactionWithMultiple(c *gc.C) {
 	revnos := s.insertAll(c, "test", "a", "b", "c")
 
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
 		{"test", "a", revnos[0]},
@@ -265,7 +266,7 @@ func (s *TxnWatcherSuite) TestScale(c *gc.C) {
 	c.Assert(count, gc.Equals, N)
 
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 
 	for i := 0; i < N; i++ {
 		c.Assert(hub.values[i].Id, gc.Equals, i)
@@ -280,7 +281,7 @@ func (s *TxnWatcherSuite) TestInsertThenRemove(c *gc.C) {
 	revno2 := s.remove(c, "test", "a")
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 2)
 
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
 		{"test", "a", revno1},
@@ -291,13 +292,16 @@ func (s *TxnWatcherSuite) TestInsertThenRemove(c *gc.C) {
 func (s *TxnWatcherSuite) TestDoubleUpdate(c *gc.C) {
 	_, hub := s.newWatcher(c, 2)
 
+	hub.setupSync()
 	revno1 := s.insert(c, "test", "a")
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
+	hub.waitSync()
+
 	s.update(c, "test", "a")
 	revno3 := s.update(c, "test", "a")
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 2)
 
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
 		{"test", "a", revno1},
@@ -328,7 +332,7 @@ func (s *TxnWatcherSuite) TestErrorRetry(c *gc.C) {
 
 	fakeIter.err = nil
 	s.advanceTime(c, watcher.TxnWatcherErrorShortWait, 2)
-	hub.waitForExpected(c)
+	hub.waitForExpected()
 	c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
 		{"test", "a", revno},
 	})
@@ -344,7 +348,7 @@ func (s *TxnWatcherSuite) TestOutOfSyncError(c *gc.C) {
 	s.insert(c, "test", "a")
 
 	s.advanceTime(c, watcher.TxnWatcherShortWait, 1)
-	hub.waitForError(c)
+	hub.waitForError()
 }
 
 type fakeIterator struct {
@@ -374,6 +378,9 @@ type fakeHub struct {
 	values []watcher.Change
 	done   chan struct{}
 	error  chan struct{}
+
+	syncMu sync.RWMutex
+	sync   chan struct{}
 }
 
 func newFakeHub(c *gc.C, expected int) *fakeHub {
@@ -390,6 +397,8 @@ func (hub *fakeHub) Publish(topic string, data interface{}) func() {
 	case watcher.TxnWatcherCollection:
 		change := data.(watcher.Change)
 		hub.values = append(hub.values, change)
+		hub.doSync()
+
 		if len(hub.values) == hub.expect {
 			close(hub.done)
 		}
@@ -401,18 +410,71 @@ func (hub *fakeHub) Publish(topic string, data interface{}) func() {
 	return nil
 }
 
-func (hub *fakeHub) waitForExpected(c *gc.C) {
-	select {
-	case <-hub.done:
-	case <-time.After(testing.LongWait):
-		c.Error("hub didn't get the expected number of changes")
+// setupSync should be called prior to clock advancement if you need to
+// synchronise on a subsequent change.
+// This can be used to prevent a scenario where steps like:
+// - change
+// - clock advance
+// - change
+// race with the worker loop causing both change events to be processed
+// in a single pass.
+// Failing to call waitSync at some point after setupSync will block the
+// hub from processing publish events.
+func (hub *fakeHub) setupSync() {
+	hub.syncMu.Lock()
+	defer hub.syncMu.Unlock()
+
+	if hub.sync != nil {
+		hub.c.Errorf("sync is already set up; did you fail to call waitSync?")
+	}
+	hub.sync = make(chan struct{})
+}
+
+// This is executed on a different Goroutine to setupSync and waitSync;
+// hence the read lock protection.
+func (hub *fakeHub) doSync() {
+	hub.syncMu.RLock()
+	defer hub.syncMu.RUnlock()
+
+	if hub.sync != nil {
+		hub.sync <- struct{}{}
 	}
 }
 
-func (hub *fakeHub) waitForError(c *gc.C) {
+// waitSync unblocks after a publish event.
+// if setupSync was not called prior, an error results.
+func (hub *fakeHub) waitSync() {
+	hub.syncMu.RLock()
+	if hub.sync == nil {
+		hub.syncMu.RUnlock()
+		hub.c.Errorf("waitSync called without preceding setupSync")
+		return
+	}
+
+	select {
+	case <-hub.sync:
+	case <-time.After(testing.LongWait):
+		hub.c.Error("hub did not receive a publish event")
+	}
+
+	hub.syncMu.RUnlock()
+	hub.syncMu.Lock()
+	hub.sync = nil
+	hub.syncMu.Unlock()
+}
+
+func (hub *fakeHub) waitForExpected() {
+	select {
+	case <-hub.done:
+	case <-time.After(testing.LongWait):
+		hub.c.Error("hub didn't get the expected number of changes")
+	}
+}
+
+func (hub *fakeHub) waitForError() {
 	select {
 	case <-hub.error:
 	case <-time.After(testing.LongWait):
-		c.Error("hub didn't get an error")
+		hub.c.Error("hub didn't get an error")
 	}
 }


### PR DESCRIPTION
On arm64 it has been observed that changes *after* test clock advancement can be processed in a single loop pass. This causes some test scenarios to fail intermittently.

It looks like this:
```
11:17:08 FAIL: txnwatcher_test.go:346: TxnWatcherSuite.TestDoubleUpdate
11:17:08 
11:17:08 [LOG] 0:00.024 TRACE test loop started
11:17:08 insert("test", "a") => revno 2
11:17:08 [LOG] 0:00.050 TRACE test txn watcher 0x4000133500 starting sync
11:17:08 [LOG] 0:00.054 TRACE test 0x4000133500 step 1 got changelog document: bson.D{bson.DocElem{Name:"_id", Value:"b\xe8\xe6\xfd\xccP\f\x01-\xf3\x84`"}, bson.DocElem{Name:"test", Value:bson.D{bson.DocElem{Name:"d", Value:[]interface {}{"a"}}, bson.DocElem{Name:"r", Value:[]interface {}{3}}}}}
11:17:08 [LOG] 0:00.054 TRACE test 0x4000133500 step 2 got changelog document: bson.D{bson.DocElem{Name:"_id", Value:"b\xe8\xe6\xfd\xccP\f\x01-\xf3\x84_"}, bson.DocElem{Name:"test", Value:bson.D{bson.DocElem{Name:"d", Value:[]interface {}{"a"}}, bson.DocElem{Name:"r", Value:[]interface {}{2}}}}}
11:17:08 update("test", "a") => revno 3
11:17:08 update("test", "a") => revno 4
11:17:08 [LOG] 0:00.059 TRACE test txn watcher 0x4000133500 starting sync
11:17:08 [LOG] 0:00.059 TRACE test 0x4000133500 step 4 got changelog document: bson.D{bson.DocElem{Name:"_id", Value:"b\xe8\xe6\xfd\xccP\f\x01-\xf3\x84a"}, bson.DocElem{Name:"test", Value:bson.D{bson.DocElem{Name:"d", Value:[]interface {}{"a"}}, bson.DocElem{Name:"r", Value:[]interface {}{4}}}}}
11:17:08 txnwatcher_test.go:358:
11:17:08     c.Assert(hub.values, jc.DeepEquals, []watcher.Change{
11:17:08         {"test", "a", revno1},
11:17:08         {"test", "a", revno3},
11:17:08     })
11:17:08 ... obtained []watcher.Change = []watcher.Change{watcher.Change{C:"test", Id:"a", Revno:3}, watcher.Change{C:"test", Id:"a", Revno:4}}
11:17:08 ... expected []watcher.Change = []watcher.Change{watcher.Change{C:"test", Id:"a", Revno:2}, watcher.Change{C:"test", Id:"a", Revno:4}}
11:17:08 ... mismatch at [0].Revno: unequal; obtained 3; expected 2
11:17:08 
11:17:08 [LOG] 0:00.060 TRACE test loop finished
```

Here we introduce the ability to set up a synchronisation on the next hub `Publish` event.

## QA steps

Stress test the `TxnWatcherSuite` with `-race`

## Documentation changes

None.

## Bug reference

N/A
