### PR TITLE
Fix unbound MODEL_ARCH in bash tests

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -290,7 +290,7 @@ post_add_model() {
 		;;
 	esac
 
-	if [[ -z ${MODEL_ARCH} ]]; then
+	if [[ -n ${MODEL_ARCH:-} ]]; then
 		juju set-model-constraints "arch=${MODEL_ARCH}"
 	fi
 }


### PR DESCRIPTION
A small fix for using the new MODEL_ARCH env var in bash tests. It was unbound and the check was inverted.

## QA steps

`./main.sh deploy`

