### PR TITLE
Correct "snap install juju-db" channel to get Mongo 4.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,7 +309,7 @@ Many tests use a standalone instance of `mongod` as part of their setup. The
 `mongod` binary found in `$PATH` is executed by these suites.  If you don't already have MongoDB installed, or have difficulty using your installed version to run Juju tests, you may want to install the [`juju-db` snap](https://snapcraft.io/juju-db), which is guaranteed to work with Juju.
 
 ```bash
-sudo snap install juju-db
+sudo snap install juju-db --channel 4.4/stable
 sudo snap alias juju-db.mongod mongod
 sudo snap alias juju-db.mongo mongo
 ```


### PR DESCRIPTION
Currently the `snap install juju-db` would install the default `latest/stable`, which is Mongo 4.0. We need Mongo 4.4, so specify the channel in the dev contributor doc.

## QA steps

```
go test ./state/watcher  # will fail with Mongo 4.0, succeed with 4.4
```
