### PR TITLE
[JUJU-1559] Removes the requirement to disable v6 for lxd.

### DIFF
--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -216,11 +216,12 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentBadNicType(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches,
 		`profile "default": no network device found with nictype "bridged" or "macvlan"\n`+
 			`\tthe following devices were checked: eth0\n`+
-			`Note: juju does not support IPv6.\n`+
-			`Reconfigure lxd to use a network of type "bridged" or "macvlan", disabling IPv6.`)
+			`Reconfigure lxd to use a network of type "bridged" or "macvlan".`)
 }
 
-func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
+// Juju used to fail when IPv6 was enabled on the lxd network. This test now
+// checks regression to make sure that we know longer fail.
+func (s *networkSuite) TestVerifyNetworkDeviceIPv6PresentNoFail(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	cSvr := s.NewMockServerWithExtensions(ctrl, "network")
@@ -230,7 +231,7 @@ func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
 		Managed: true,
 		NetworkPut: lxdapi.NetworkPut{
 			Config: map[string]string{
-				"ipv6.address": "something-not-nothing",
+				"ipv6.address": "2001:DB8::1",
 			},
 		},
 	}
@@ -240,10 +241,7 @@ func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = jujuSvr.VerifyNetworkDevice(defaultLegacyProfileWithNIC(), "")
-	c.Assert(err, gc.ErrorMatches,
-		`profile "default": juju does not support IPv6. Disable IPv6 in LXD via:\n`+
-			`\tlxc network set lxdbr0 ipv6.address none\n`+
-			`and run the command again`)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *networkSuite) TestVerifyNetworkDeviceNotPresentCreated(c *gc.C) {


### PR DESCRIPTION
Until now Juju has required ipv6 support to be disbaled on the network bridge created by lxd. We can now safely operate with ipv6 in Juju.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Install a fresh lxd daemon with ipv6 enabled on the default bridge and bootstrap juju. Confirm that no errors happen during bootstrap.

Deploy a workload and confirm that the agent.conf file gets the v6 address of the controller correctly.

## Documentation changes

N/A

## Bug reference

N/A