### PR TITLE
Refactor secrets to use new URI format and api args

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -99,11 +99,11 @@ func (c *Client) Update(uri string, cfg *secrets.SecretConfig, value secrets.Sec
 // GetValue returns the value of a secret.
 func (c *Client) GetValue(uri string) (secrets.SecretValue, error) {
 	arg := params.GetSecretArg{}
-	secretUrl, err := secrets.ParseURI(uri)
+	secretUri, err := secrets.ParseURI(uri)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	arg.URI = secretUrl.String()
+	arg.URI = secretUri.String()
 
 	var results params.SecretValueResults
 
@@ -145,8 +145,8 @@ func (c *Client) WatchSecretsRotationChanges(ownerTag string) (watcher.SecretRot
 }
 
 // SecretRotated records when a secret was last rotated.
-func (c *Client) SecretRotated(url string, when time.Time) error {
-	secretUrl, err := secrets.ParseURI(url)
+func (c *Client) SecretRotated(uri string, when time.Time) error {
+	secretUri, err := secrets.ParseURI(uri)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -154,7 +154,7 @@ func (c *Client) SecretRotated(url string, when time.Time) error {
 	var results params.ErrorResults
 	args := params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
-			URI:  secretUrl.String(),
+			URI:  secretUri.String(),
 			When: when,
 		}},
 	}

--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -4,7 +4,6 @@
 package secretsmanager
 
 import (
-	"strings"
 	"time"
 
 	"github.com/juju/errors"
@@ -29,11 +28,7 @@ func NewClient(caller base.APICaller) *Client {
 }
 
 // Create creates a new secret.
-func (c *Client) Create(cfg *secrets.SecretConfig, secretType secrets.SecretType, value secrets.SecretValue) (string, error) {
-	if err := cfg.Validate(); err != nil {
-		return "", errors.Trace(err)
-	}
-
+func (c *Client) Create(cfg *secrets.SecretConfig, value secrets.SecretValue) (string, error) {
 	var data secrets.SecretData
 	if value != nil {
 		data = value.EncodedValues()
@@ -42,13 +37,8 @@ func (c *Client) Create(cfg *secrets.SecretConfig, secretType secrets.SecretType
 	var results params.StringResults
 
 	arg := params.CreateSecretArg{
-		Type:   string(secretType),
-		Path:   cfg.Path,
 		Params: cfg.Params,
 		Data:   data,
-	}
-	if cfg.Status != nil {
-		arg.Status = string(*cfg.Status)
 	}
 	if cfg.RotateInterval != nil {
 		arg.RotateInterval = *cfg.RotateInterval
@@ -74,13 +64,10 @@ func (c *Client) Create(cfg *secrets.SecretConfig, secretType secrets.SecretType
 }
 
 // Update updates an existing secret value and/or config like rotate interval.
-func (c *Client) Update(url string, cfg *secrets.SecretConfig, value secrets.SecretValue) (string, error) {
-	secretUrl, err := secrets.ParseURL(url)
+func (c *Client) Update(uri string, cfg *secrets.SecretConfig, value secrets.SecretValue) error {
+	secretUri, err := secrets.ParseURI(uri)
 	if err != nil {
-		return "", errors.Trace(err)
-	}
-	if err := cfg.Validate(); err != nil {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	}
 
 	var data secrets.SecretData
@@ -91,46 +78,32 @@ func (c *Client) Update(url string, cfg *secrets.SecretConfig, value secrets.Sec
 		}
 	}
 
-	var results params.StringResults
+	var results params.ErrorResults
 
 	arg := params.UpdateSecretArg{
-		URL:            secretUrl.ID(),
+		URI:            secretUri.String(),
 		RotateInterval: cfg.RotateInterval,
 		Description:    cfg.Description,
 		Tags:           cfg.Tags,
 		Params:         cfg.Params,
 		Data:           data,
 	}
-	if cfg.Status != nil {
-		statusStr := string(*cfg.Status)
-		arg.Status = &statusStr
-	}
 	if err := c.facade.FacadeCall("UpdateSecrets", params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{arg},
 	}, &results); err != nil {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	}
-	if n := len(results.Results); n != 1 {
-		return "", errors.Errorf("expected 1 result, got %d", n)
-	}
-	if err := results.Results[0].Error; err != nil {
-		return "", err
-	}
-	return results.Results[0].Result, nil
+	return results.OneError()
 }
 
 // GetValue returns the value of a secret.
-func (c *Client) GetValue(urlOrId string) (secrets.SecretValue, error) {
+func (c *Client) GetValue(uri string) (secrets.SecretValue, error) {
 	arg := params.GetSecretArg{}
-	if strings.HasPrefix(urlOrId, secrets.SecretScheme+"://") {
-		secretUrl, err := secrets.ParseURL(urlOrId)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		arg.URL = secretUrl.ID()
-	} else {
-		arg.ID = urlOrId
+	secretUrl, err := secrets.ParseURI(uri)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+	arg.URI = secretUrl.String()
 
 	var results params.SecretValueResults
 
@@ -173,7 +146,7 @@ func (c *Client) WatchSecretsRotationChanges(ownerTag string) (watcher.SecretRot
 
 // SecretRotated records when a secret was last rotated.
 func (c *Client) SecretRotated(url string, when time.Time) error {
-	secretUrl, err := secrets.ParseURL(url)
+	secretUrl, err := secrets.ParseURI(url)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -181,7 +154,7 @@ func (c *Client) SecretRotated(url string, when time.Time) error {
 	var results params.ErrorResults
 	args := params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
-			URL:  secretUrl.ID(),
+			URI:  secretUrl.String(),
 			When: when,
 		}},
 	}

--- a/api/agent/secretsmanager/doc.go
+++ b/api/agent/secretsmanager/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package secretsmanager provides the api client
+// for the secretsmanager facade.
+package secretsmanager

--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -44,13 +44,11 @@ func (api *Client) ListSecrets(showSecrets bool) ([]SecretDetails, error) {
 	for i, r := range response.Results {
 		details := SecretDetails{
 			Metadata: secrets.SecretMetadata{
-				Path:           r.Path,
 				RotateInterval: r.RotateInterval,
 				Version:        r.Version,
-				Status:         secrets.SecretStatus(r.Status),
 				Description:    r.Description,
+				OwnerTag:       r.OwnerTag,
 				Tags:           r.Tags,
-				ID:             r.ID,
 				Provider:       r.Provider,
 				ProviderID:     r.ProviderID,
 				Revision:       r.Revision,
@@ -58,9 +56,9 @@ func (api *Client) ListSecrets(showSecrets bool) ([]SecretDetails, error) {
 				UpdateTime:     r.UpdateTime,
 			},
 		}
-		url, err := secrets.ParseURL(r.URL)
+		uri, err := secrets.ParseURI(r.URI)
 		if err == nil {
-			details.Metadata.URL = url
+			details.Metadata.URI = uri
 		} else {
 			details.Error = err.Error()
 		}

--- a/api/client/secrets/client_test.go
+++ b/api/client/secrets/client_test.go
@@ -33,6 +33,7 @@ func (s *SecretsSuite) TestNewClient(c *gc.C) {
 func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 	data := map[string]string{"foo": "bar"}
 	now := time.Now()
+	uri := secrets.NewURI()
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Check(objType, gc.Equals, "Secrets")
 		c.Check(version, gc.Equals, 0)
@@ -44,14 +45,12 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 		c.Assert(result, gc.FitsTypeOf, &params.ListSecretResults{})
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			[]params.ListSecretResult{{
-				URL:            "secret://app/mariadb/password",
-				Path:           "app/password",
+				URI:            uri.String(),
 				RotateInterval: time.Hour,
 				Version:        1,
-				Status:         "active",
 				Description:    "shhh",
+				OwnerTag:       "application-mysql",
 				Tags:           map[string]string{"foo": "bar"},
-				ID:             1,
 				Provider:       "juju",
 				ProviderID:     "provider-id",
 				Revision:       2,
@@ -65,17 +64,14 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 	client := apisecrets.NewClient(apiCaller)
 	result, err := client.ListSecrets(true)
 	c.Assert(err, jc.ErrorIsNil)
-	URL := secrets.NewSimpleURL("app/mariadb/password")
 	c.Assert(result, jc.DeepEquals, []apisecrets.SecretDetails{{
 		Metadata: secrets.SecretMetadata{
-			URL:            URL,
-			Path:           "app/password",
+			URI:            uri,
 			RotateInterval: time.Hour,
 			Version:        1,
-			Status:         secrets.StatusActive,
 			Description:    "shhh",
+			OwnerTag:       "application-mysql",
 			Tags:           map[string]string{"foo": "bar"},
-			ID:             1,
 			Provider:       "juju",
 			ProviderID:     "provider-id",
 			Revision:       2,
@@ -90,7 +86,7 @@ func (s *SecretsSuite) TestListSecretsError(c *gc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			[]params.ListSecretResult{{
-				URL: "secret://app/password",
+				URI: "secret:9m4e2mr0ui3e8a215n4g",
 				Value: &params.SecretValueResult{
 					Error: &params.Error{Message: "boom"},
 				},

--- a/api/client/secrets/doc.go
+++ b/api/client/secrets/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package secrets provides the api client
+// for the secrets facade.
+package secrets

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -908,12 +908,12 @@ func NewSecretsRotationWatcher(
 // mergeChanges combines the changes in current and newChanges, such that we end up with
 // only one change per rotation config change in the result; the most recent change wins.
 func (w *secretsRotationWatcher) mergeChanges(current, newChanges []watcher.SecretRotationChange) []watcher.SecretRotationChange {
-	chMap := make(map[int]watcher.SecretRotationChange)
+	chMap := make(map[string]watcher.SecretRotationChange)
 	for _, c := range current {
-		chMap[c.ID] = c
+		chMap[c.URI.String()] = c
 	}
 	for _, c := range newChanges {
-		chMap[c.ID] = c
+		chMap[c.URI.String()] = c
 	}
 	result := make([]watcher.SecretRotationChange, len(chMap))
 	i := 0
@@ -932,14 +932,13 @@ func (w *secretsRotationWatcher) loop(initialChanges []params.SecretRotationChan
 	copyChanges := func(changes []params.SecretRotationChange) []watcher.SecretRotationChange {
 		result := make([]watcher.SecretRotationChange, len(changes))
 		for i, ch := range changes {
-			url, err := secrets.ParseURL(ch.URL)
+			uri, err := secrets.ParseURI(ch.URI)
 			if err != nil {
-				logger.Errorf("ignoring invalid secret URL: %q", ch.URL)
+				logger.Errorf("ignoring invalid secret URI: %q", ch.URI)
 				continue
 			}
 			result[i] = watcher.SecretRotationChange{
-				ID:             ch.ID,
-				URL:            url,
+				URI:            uri,
 				RotateInterval: ch.RotateInterval,
 				LastRotateTime: ch.LastRotateTime,
 			}

--- a/apiserver/facades/agent/secretsmanager/doc.go
+++ b/apiserver/facades/agent/secretsmanager/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package secretsmanager provides the backend
+// implementation for the secretsmanager facade.
+package secretsmanager

--- a/apiserver/facades/agent/secretsmanager/mocks/secretservice.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretservice.go
@@ -37,7 +37,7 @@ func (m *MockSecretsService) EXPECT() *MockSecretsServiceMockRecorder {
 }
 
 // CreateSecret mocks base method.
-func (m *MockSecretsService) CreateSecret(arg0 context.Context, arg1 *secrets.URL, arg2 secrets0.CreateParams) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsService) CreateSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secrets0.CreateParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)
@@ -52,7 +52,7 @@ func (mr *MockSecretsServiceMockRecorder) CreateSecret(arg0, arg1, arg2 interfac
 }
 
 // DeleteSecret mocks base method.
-func (m *MockSecretsService) DeleteSecret(arg0 context.Context, arg1 *secrets.URL) error {
+func (m *MockSecretsService) DeleteSecret(arg0 context.Context, arg1 *secrets.URI) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecret", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -66,7 +66,7 @@ func (mr *MockSecretsServiceMockRecorder) DeleteSecret(arg0, arg1 interface{}) *
 }
 
 // GetSecret mocks base method.
-func (m *MockSecretsService) GetSecret(arg0 context.Context, arg1 *secrets.URL) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsService) GetSecret(arg0 context.Context, arg1 *secrets.URI) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecret", arg0, arg1)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)
@@ -81,18 +81,18 @@ func (mr *MockSecretsServiceMockRecorder) GetSecret(arg0, arg1 interface{}) *gom
 }
 
 // GetSecretValue mocks base method.
-func (m *MockSecretsService) GetSecretValue(arg0 context.Context, arg1 *secrets.URL) (secrets.SecretValue, error) {
+func (m *MockSecretsService) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretValue", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetSecretValue", arg0, arg1, arg2)
 	ret0, _ := ret[0].(secrets.SecretValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecretValue indicates an expected call of GetSecretValue.
-func (mr *MockSecretsServiceMockRecorder) GetSecretValue(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSecretsServiceMockRecorder) GetSecretValue(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockSecretsService)(nil).GetSecretValue), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockSecretsService)(nil).GetSecretValue), arg0, arg1, arg2)
 }
 
 // ListSecrets mocks base method.
@@ -111,7 +111,7 @@ func (mr *MockSecretsServiceMockRecorder) ListSecrets(arg0, arg1 interface{}) *g
 }
 
 // UpdateSecret mocks base method.
-func (m *MockSecretsService) UpdateSecret(arg0 context.Context, arg1 *secrets.URL, arg2 secrets0.UpdateParams) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsService) UpdateSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secrets0.UpdateParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsrotationservice.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsrotationservice.go
@@ -37,7 +37,7 @@ func (m *MockSecretsRotation) EXPECT() *MockSecretsRotationMockRecorder {
 }
 
 // SecretRotated mocks base method.
-func (m *MockSecretsRotation) SecretRotated(arg0 *secrets.URL, arg1 time.Time) error {
+func (m *MockSecretsRotation) SecretRotated(arg0 *secrets.URI, arg1 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SecretRotated", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/apiserver/facades/agent/secretsmanager/state.go
+++ b/apiserver/facades/agent/secretsmanager/state.go
@@ -13,5 +13,5 @@ import (
 // SecretsRotation instances provide secret rotation apis.
 type SecretsRotation interface {
 	WatchSecretsRotationChanges(owner string) state.SecretsRotationWatcher
-	SecretRotated(url *secrets.URL, when time.Time) error
+	SecretRotated(uri *secrets.URI, when time.Time) error
 }

--- a/apiserver/facades/client/secrets/doc.go
+++ b/apiserver/facades/client/secrets/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package secrets provides the backend
+// implementation for the secrets facade.
+package secrets

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -68,14 +68,12 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 	result.Results = make([]params.ListSecretResult, len(metadata))
 	for i, m := range metadata {
 		secretResult := params.ListSecretResult{
-			URL:            m.URL.String(),
-			Path:           m.Path,
+			URI:            m.URI.String(),
 			RotateInterval: m.RotateInterval,
 			Version:        m.Version,
-			Status:         string(m.Status),
 			Description:    m.Description,
+			OwnerTag:       m.OwnerTag,
 			Tags:           m.Tags,
-			ID:             m.ID,
 			Provider:       m.Provider,
 			ProviderID:     m.ProviderID,
 			Revision:       m.Revision,
@@ -83,7 +81,7 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			UpdateTime:     m.UpdateTime,
 		}
 		if arg.ShowSecrets {
-			val, err := s.secretsService.GetSecretValue(ctx, m.URL)
+			val, err := s.secretsService.GetSecretValue(ctx, m.URI, m.Revision)
 			valueResult := &params.SecretValueResult{
 				Error: apiservererrors.ServerError(err),
 			}

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -71,20 +71,15 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	now := time.Now()
-	URL := &coresecrets.URL{
-		ControllerUUID: coretesting.ControllerTag.Id(),
-		ModelUUID:      coretesting.ModelTag.Id(),
-		Path:           "app/password",
-	}
+	uri := coresecrets.NewURI()
+	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	metadata := []*coresecrets.SecretMetadata{{
-		URL:            URL,
-		Path:           "app/password",
+		URI:            uri,
 		RotateInterval: time.Hour,
 		Version:        1,
-		Status:         coresecrets.StatusActive,
 		Description:    "shhh",
+		OwnerTag:       "application-mysql",
 		Tags:           map[string]string{"foo": "bar"},
-		ID:             666,
 		Provider:       "juju",
 		ProviderID:     "abcd",
 		Revision:       2,
@@ -100,7 +95,7 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 		valueResult = &params.SecretValueResult{
 			Data: map[string]string{"foo": "bar"},
 		}
-		s.secretsService.EXPECT().GetSecretValue(gomock.Any(), URL).Return(
+		s.secretsService.EXPECT().GetSecretValue(gomock.Any(), uri, 2).Return(
 			coresecrets.NewSecretValue(valueResult.Data), nil,
 		)
 	}
@@ -109,14 +104,12 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
-			URL:            URL.String(),
-			Path:           "app/password",
+			URI:            uri.String(),
 			RotateInterval: time.Hour,
 			Version:        1,
-			Status:         "active",
 			Description:    "shhh",
+			OwnerTag:       "application-mysql",
 			Tags:           map[string]string{"foo": "bar"},
-			ID:             666,
 			Provider:       "juju",
 			ProviderID:     "abcd",
 			Revision:       2,

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38454,10 +38454,7 @@
                         "description": {
                             "type": "string"
                         },
-                        "int": {
-                            "type": "integer"
-                        },
-                        "path": {
+                        "owner-tag": {
                             "type": "string"
                         },
                         "provider": {
@@ -38472,9 +38469,6 @@
                         "rotate-interval": {
                             "type": "integer"
                         },
-                        "status": {
-                            "type": "string"
-                        },
                         "tags": {
                             "type": "object",
                             "patternProperties": {
@@ -38487,7 +38481,7 @@
                             "type": "string",
                             "format": "date-time"
                         },
-                        "url": {
+                        "uri": {
                             "type": "string"
                         },
                         "value": {
@@ -38499,12 +38493,10 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "url",
-                        "path",
+                        "uri",
                         "version",
                         "rotate-interval",
-                        "status",
-                        "int",
+                        "owner-tag",
                         "provider",
                         "revision",
                         "create-time",
@@ -38614,7 +38606,7 @@
                             "$ref": "#/definitions/UpdateSecretArgs"
                         },
                         "Result": {
-                            "$ref": "#/definitions/StringResults"
+                            "$ref": "#/definitions/ErrorResults"
                         }
                     },
                     "description": "UpdateSecrets updates the specified secrets."
@@ -38656,14 +38648,8 @@
                                 }
                             }
                         },
-                        "path": {
-                            "type": "string"
-                        },
                         "rotate-interval": {
                             "type": "integer"
-                        },
-                        "status": {
-                            "type": "string"
                         },
                         "tags": {
                             "type": "object",
@@ -38672,17 +38658,11 @@
                                     "type": "string"
                                 }
                             }
-                        },
-                        "type": {
-                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "type",
-                        "path",
-                        "rotate-interval",
-                        "status"
+                        "rotate-interval"
                     ]
                 },
                 "CreateSecretArgs": {
@@ -38779,14 +38759,14 @@
                 "GetSecretArg": {
                     "type": "object",
                     "properties": {
-                        "id": {
-                            "type": "string"
-                        },
-                        "url": {
+                        "uri": {
                             "type": "string"
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "required": [
+                        "uri"
+                    ]
                 },
                 "GetSecretArgs": {
                     "type": "object",
@@ -38806,7 +38786,7 @@
                 "SecretRotatedArg": {
                     "type": "object",
                     "properties": {
-                        "url": {
+                        "uri": {
                             "type": "string"
                         },
                         "when": {
@@ -38816,7 +38796,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "url",
+                        "uri",
                         "when"
                     ]
                 },
@@ -38845,17 +38825,13 @@
                         "rotate-interval": {
                             "type": "integer"
                         },
-                        "secret-id": {
-                            "type": "integer"
-                        },
-                        "url": {
+                        "uri": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "secret-id",
-                        "url",
+                        "uri",
                         "rotate-interval",
                         "last-rotate-time"
                     ]
@@ -38985,9 +38961,6 @@
                         "rotate-interval": {
                             "type": "integer"
                         },
-                        "status": {
-                            "type": "string"
-                        },
                         "tags": {
                             "type": "object",
                             "patternProperties": {
@@ -38996,15 +38969,14 @@
                                 }
                             }
                         },
-                        "url": {
+                        "uri": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "url",
-                        "rotate-interval",
-                        "status"
+                        "uri",
+                        "rotate-interval"
                     ]
                 },
                 "UpdateSecretArgs": {
@@ -39088,17 +39060,13 @@
                         "rotate-interval": {
                             "type": "integer"
                         },
-                        "secret-id": {
-                            "type": "integer"
-                        },
-                        "url": {
+                        "uri": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "secret-id",
-                        "url",
+                        "uri",
                         "rotate-interval",
                         "last-rotate-time"
                     ]

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -1340,8 +1340,7 @@ func (w *srvSecretRotationWatcher) translateChanges(changes []corewatcher.Secret
 	result := make([]params.SecretRotationChange, len(changes))
 	for i, c := range changes {
 		result[i] = params.SecretRotationChange{
-			ID:             c.ID,
-			URL:            c.URL.ID(),
+			URI:            c.URI.String(),
 			RotateInterval: c.RotateInterval,
 			LastRotateTime: c.LastRotateTime,
 		}

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -134,7 +134,7 @@ var expectedCommands = []string{
 	"relation-list",
 	"relation-set",
 	"resource-get",
-	"secret-create",
+	"secret-add",
 	"secret-get",
 	"secret-grant",
 	"secret-revoke",

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
 
 	apisecrets "github.com/juju/juju/api/client/secrets"
 	jujucmd "github.com/juju/juju/cmd"
@@ -93,21 +94,19 @@ type secretValueDetails struct {
 }
 
 type secretDisplayDetails struct {
-	ID             int                  `json:"ID" yaml:"ID"`
-	URL            string               `json:"URL" yaml:"URL"`
-	Revision       int                  `json:"revision" yaml:"revision"`
-	Path           string               `json:"path" yaml:"path"`
-	Status         secrets.SecretStatus `json:"status" yaml:"status"`
-	RotateInterval time.Duration        `json:"rotate-interval,omitempty" yaml:"rotate-interval,omitempty"`
-	Version        int                  `json:"version" yaml:"version"`
-	Description    string               `json:"description,omitempty" yaml:"description,omitempty"`
-	Tags           map[string]string    `json:"tags,omitempty" yaml:"tags,omitempty"`
-	Provider       string               `json:"backend" yaml:"backend"`
-	ProviderID     string               `json:"backend-id,omitempty" yaml:"backend-id,omitempty"`
-	CreateTime     time.Time            `json:"create-time" yaml:"create-time"`
-	UpdateTime     time.Time            `json:"update-time" yaml:"update-time"`
-	Error          string               `json:"error,omitempty" yaml:"error,omitempty"`
-	Value          *secretValueDetails  `json:"value,omitempty" yaml:"value,omitempty"`
+	URI            string              `json:"URI" yaml:"URI"`
+	Revision       int                 `json:"revision" yaml:"revision"`
+	RotateInterval time.Duration       `json:"rotate-interval,omitempty" yaml:"rotate-interval,omitempty"`
+	Version        int                 `json:"version" yaml:"version"`
+	Description    string              `json:"description,omitempty" yaml:"description,omitempty"`
+	Owner          string              `json:"owner,omitempty" yaml:"owner,omitempty"`
+	Tags           map[string]string   `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Provider       string              `json:"backend" yaml:"backend"`
+	ProviderID     string              `json:"backend-id,omitempty" yaml:"backend-id,omitempty"`
+	CreateTime     time.Time           `json:"create-time" yaml:"create-time"`
+	UpdateTime     time.Time           `json:"update-time" yaml:"update-time"`
+	Error          string              `json:"error,omitempty" yaml:"error,omitempty"`
+	Value          *secretValueDetails `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Run implements cmd.Run.
@@ -129,15 +128,17 @@ func (c *listSecretsCommand) Run(ctxt *cmd.Context) error {
 	}
 	details := make([]secretDisplayDetails, len(result))
 	for i, m := range result {
+		ownerId := ""
+		if owner, err := names.ParseTag(m.Metadata.OwnerTag); err == nil {
+			ownerId = owner.Id()
+		}
 		details[i] = secretDisplayDetails{
-			URL:            m.Metadata.URL.ShortString(),
-			Path:           m.Metadata.Path,
+			URI:            m.Metadata.URI.ShortString(),
 			RotateInterval: m.Metadata.RotateInterval,
 			Version:        m.Metadata.Version,
-			Status:         m.Metadata.Status,
 			Description:    m.Metadata.Description,
+			Owner:          ownerId,
 			Tags:           m.Metadata.Tags,
-			ID:             m.Metadata.ID,
 			Provider:       m.Metadata.Provider,
 			ProviderID:     m.Metadata.ProviderID,
 			Revision:       m.Metadata.Revision,
@@ -170,14 +171,14 @@ func formatSecretsTabular(writer io.Writer, value interface{}) error {
 	w := output.Wrapper{tw}
 	w.SetColumnAlignRight(1)
 
-	w.Println("ID", "Revision", "Rotate", "Backend", "Path", "Age")
+	w.Println("URI", "Revision", "Rotate", "Backend", "Age")
 	sort.Slice(secrets, func(i, j int) bool {
-		return secrets[i].ID < secrets[j].ID
+		return secrets[i].URI < secrets[j].URI
 	})
 	now := time.Now()
 	for _, s := range secrets {
 		age := common.UserFriendlyDuration(s.UpdateTime, now)
-		w.Print(s.ID, s.Revision, common.HumaniseInterval(s.RotateInterval), s.Provider, s.Path, age)
+		w.Print(s.URI, s.Revision, common.HumaniseInterval(s.RotateInterval), s.Provider, age)
 		w.Println()
 	}
 	return tw.Flush()

--- a/cmd/juju/secrets/list_test.go
+++ b/cmd/juju/secrets/list_test.go
@@ -4,6 +4,7 @@
 package secrets_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -46,48 +47,48 @@ func (s *ListSuite) setup(c *gc.C) *gomock.Controller {
 func (s *ListSuite) TestListTabular(c *gc.C) {
 	defer s.setup(c).Finish()
 
+	uri := coresecrets.NewURI()
+	uri2 := coresecrets.NewURI()
 	s.secretsAPI.EXPECT().ListSecrets(false).Return(
 		[]apisecrets.SecretDetails{{
 			Metadata: coresecrets.SecretMetadata{
-				ID: 666, RotateInterval: time.Hour,
-				Revision: 2, Path: "app/mariadb/password", Provider: "juju"},
+				URI: uri, RotateInterval: time.Hour,
+				Revision: 2, Provider: "juju"},
 		}, {
 			Metadata: coresecrets.SecretMetadata{
-				ID:       667,
-				Revision: 1, Path: "app/gitlab/apitoken", Provider: "juju"},
+				URI:      uri2,
+				Revision: 1, Provider: "juju"},
 		}}, nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
 
 	ctx, err := cmdtesting.RunCommand(c, secrets.NewListCommandForTest(s.store, s.secretsAPI))
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, `
-ID   Revision  Rotate  Backend  Path                  Age
-666         2  1h      juju     app/mariadb/password  0001-01-01  
-667         1  never   juju     app/gitlab/apitoken   0001-01-01  
-`[1:])
+	c.Assert(out, gc.Equals, fmt.Sprintf(`
+URI                          Revision  Rotate  Backend  Age
+%s         2  1h      juju     0001-01-01  
+%s         1  never   juju     0001-01-01  
+`[1:], uri.ShortString(), uri2.ShortString()))
 }
 
 func (s *ListSuite) TestListYAML(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	secretUrl, err := coresecrets.ParseURL("secret://app/mariadb/password")
-	c.Assert(err, jc.ErrorIsNil)
-	secretUrl2, err := coresecrets.ParseURL("secret://app/gitlab/apitoken")
-	c.Assert(err, jc.ErrorIsNil)
+	uri := coresecrets.NewURI()
+	uri2 := coresecrets.NewURI()
 	s.secretsAPI.EXPECT().ListSecrets(true).Return(
 		[]apisecrets.SecretDetails{{
 			Metadata: coresecrets.SecretMetadata{
-				URL: secretUrl, ID: 666, RotateInterval: time.Hour,
-				Version: 1, Revision: 2, Path: "app/mariadb/password", Provider: "juju",
-				Status: coresecrets.StatusActive, Description: "my secret",
-				Tags: map[string]string{"foo": "bar"},
+				URI: uri, RotateInterval: time.Hour,
+				Version: 1, Revision: 2, Provider: "juju",
+				Description: "my secret",
+				OwnerTag:    "application-mysql",
+				Tags:        map[string]string{"foo": "bar"},
 			},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
 		}, {
 			Metadata: coresecrets.SecretMetadata{
-				URL: secretUrl2, ID: 667, Version: 1, Revision: 1, Path: "app/gitlab/apitoken", Provider: "juju",
-				Status: coresecrets.StatusStaged,
+				URI: uri2, Version: 1, Revision: 1, Provider: "juju",
 			},
 			Error: "boom",
 		}}, nil)
@@ -96,15 +97,13 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, secrets.NewListCommandForTest(s.store, s.secretsAPI), "--format", "yaml", "--show-secrets")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, `
-- ID: 666
-  URL: secret://app/mariadb/password
+	c.Assert(out, gc.Equals, fmt.Sprintf(`
+- URI: %s
   revision: 2
-  path: app/mariadb/password
-  status: active
   rotate-interval: 1h0m0s
   version: 1
   description: my secret
+  owner: mysql
   tags:
     foo: bar
   backend: juju
@@ -112,30 +111,25 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
   update-time: 0001-01-01T00:00:00Z
   value:
     foo: bar
-- ID: 667
-  URL: secret://app/gitlab/apitoken
+- URI: %s
   revision: 1
-  path: app/gitlab/apitoken
-  status: staged
   version: 1
   backend: juju
   create-time: 0001-01-01T00:00:00Z
   update-time: 0001-01-01T00:00:00Z
   error: boom
-`[1:])
+`[1:], uri.ShortString(), uri2.ShortString()))
 }
 
 func (s *ListSuite) TestListJSON(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	secretUrl, err := coresecrets.ParseURL("secret://app/mariadb/password")
-	c.Assert(err, jc.ErrorIsNil)
+	uri := coresecrets.NewURI()
 	s.secretsAPI.EXPECT().ListSecrets(true).Return(
 		[]apisecrets.SecretDetails{{
 			Metadata: coresecrets.SecretMetadata{
-				URL: secretUrl, ID: 666,
-				Version: 1, Revision: 2, Path: "app/mariadb/password", Provider: "juju",
-				Status: coresecrets.StatusActive,
+				URI:     uri,
+				Version: 1, Revision: 2, Provider: "juju",
 			},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
 		}}, nil)
@@ -144,7 +138,7 @@ func (s *ListSuite) TestListJSON(c *gc.C) {
 	ctx, err := cmdtesting.RunCommand(c, secrets.NewListCommandForTest(s.store, s.secretsAPI), "--format", "json", "--show-secrets")
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, gc.Equals, `
-[{"ID":666,"URL":"secret://app/mariadb/password","revision":2,"path":"app/mariadb/password","status":"active","version":1,"backend":"juju","create-time":"0001-01-01T00:00:00Z","update-time":"0001-01-01T00:00:00Z","value":{"Data":{"foo":"bar"}}}]
-`[1:])
+	c.Assert(out, gc.Equals, fmt.Sprintf(`
+[{"URI":"%s","revision":2,"version":1,"backend":"juju","create-time":"0001-01-01T00:00:00Z","update-time":"0001-01-01T00:00:00Z","value":{"Data":{"foo":"bar"}}}]
+`[1:], uri.ShortString()))
 }

--- a/core/secrets/doc.go
+++ b/core/secrets/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package secrets is used for the core secrets data model.
+package secrets

--- a/core/secrets/secret_test.go
+++ b/core/secrets/secret_test.go
@@ -5,229 +5,107 @@ package secrets_test
 
 import (
 	jc "github.com/juju/testing/checkers"
+	"github.com/rs/xid"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/secrets"
 )
 
-type SecretConfigSuite struct{}
+type SecretURISuite struct{}
 
-var _ = gc.Suite(&SecretConfigSuite{})
-
-func (s *SecretConfigSuite) TestNewSecretConfig(c *gc.C) {
-	cfg := secrets.NewSecretConfig("app", "catalog")
-	err := cfg.Validate()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg, jc.DeepEquals, &secrets.SecretConfig{
-		Path:   "app/catalog",
-		Params: nil,
-	})
-}
-
-func (s *SecretConfigSuite) TestNewPasswordSecretConfig(c *gc.C) {
-	cfg := secrets.NewPasswordSecretConfig(10, true, "app", "mariadb", "password")
-	err := cfg.Validate()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg, jc.DeepEquals, &secrets.SecretConfig{
-		Path: "app/mariadb/password",
-		Params: map[string]interface{}{
-			"password-length":        10,
-			"password-special-chars": true,
-		},
-	})
-}
-
-func (s *SecretConfigSuite) TestSecretConfigPath(c *gc.C) {
-	cfg := secrets.NewPasswordSecretConfig(10, true, "app", "password")
-	cfg.Path = "foo=bar"
-	err := cfg.Validate()
-	c.Assert(err, gc.ErrorMatches, `secret path "foo=bar" not valid`)
-}
-
-type SecretURLSuite struct{}
-
-var _ = gc.Suite(&SecretURLSuite{})
+var _ = gc.Suite(&SecretURISuite{})
 
 const (
 	controllerUUID = "555be5b3-987b-4848-80d0-966289f735f1"
-	modelUUID      = "3fe4d1cd-17d3-418d-82a9-547f1949b835"
+	secretID       = "9m4e2mr0ui3e8a215n4g"
+	secretURI      = "secret:9m4e2mr0ui3e8a215n4g"
 )
 
-func (s *SecretURLSuite) TestParseURL(c *gc.C) {
+func (s *SecretURISuite) TestParseURI(c *gc.C) {
 	for _, t := range []struct {
+		in       string
 		str      string
 		shortStr string
-		expected *secrets.URL
+		expected *secrets.URI
 		err      string
 	}{
 		{
-			str: "http://nope",
-			err: `secret URL scheme "http" not valid`,
+			in:  "http:nope",
+			err: `secret URI scheme "http" not valid`,
 		}, {
-			str: "secret://a/b/c",
-			err: `secret URL "secret://a/b/c" not valid`,
+			in:  "secret:a/b/c",
+			err: `secret URI "secret:a/b/c" not valid`,
 		}, {
-			str: "secret://missingversion",
-			err: `secret URL "secret://missingversion" not valid`,
+			in:  "secret:a.b.",
+			err: `secret URI "secret:a.b." not valid`,
 		}, {
-			str: "secret://a.b.",
-			err: `secret URL "secret://a.b." not valid`,
+			in:  "secret:a.b#",
+			err: `secret URI "secret:a.b#" not valid`,
 		}, {
-			str: "secret://a.b#",
-			err: `secret URL "secret://a.b#" not valid`,
-		}, {
-			str:      "secret://app/mariadb/password",
-			shortStr: "secret://app/mariadb/password",
-			expected: &secrets.URL{
-				Path: "app/mariadb/password",
+			in:       secretURI,
+			shortStr: secretURI,
+			expected: &secrets.URI{
+				ID: secretID,
 			},
 		}, {
-			str:      "secret://app/mariadb/password2/666",
-			shortStr: "secret://app/mariadb/password2/666",
-			expected: &secrets.URL{
-				Path:     "app/mariadb/password2",
-				Revision: 666,
+			in:       secretID,
+			str:      secretURI,
+			shortStr: secretURI,
+			expected: &secrets.URI{
+				ID: secretID,
 			},
 		}, {
-			str:      "secret://app/mariadb-k8s/password#attr",
-			shortStr: "secret://app/mariadb-k8s/password#attr",
-			expected: &secrets.URL{
-				Path:      "app/mariadb-k8s/password",
-				Attribute: "attr",
-			},
-		}, {
-			str:      "secret://app/mariadb/password/666#attr",
-			shortStr: "secret://app/mariadb/password/666#attr",
-			expected: &secrets.URL{
-				Path:      "app/mariadb/password",
-				Attribute: "attr",
-				Revision:  666,
-			},
-		}, {
-			str:      "secret://" + controllerUUID + "/app/mariadb/password",
-			shortStr: "secret://app/mariadb/password",
-			expected: &secrets.URL{
+			in:       "secret:" + controllerUUID + "/" + secretID,
+			shortStr: secretURI,
+			expected: &secrets.URI{
 				ControllerUUID: controllerUUID,
-				Path:           "app/mariadb/password",
-			},
-		}, {
-			str:      "secret://" + controllerUUID + "/" + modelUUID + "/app/mariadb/password",
-			shortStr: "secret://app/mariadb/password",
-			expected: &secrets.URL{
-				ControllerUUID: controllerUUID,
-				ModelUUID:      modelUUID,
-				Path:           "app/mariadb/password",
-			},
-		}, {
-			str:      "secret://" + controllerUUID + "/" + modelUUID + "/app/mariadb/password#attr",
-			shortStr: "secret://app/mariadb/password#attr",
-			expected: &secrets.URL{
-				ControllerUUID: controllerUUID,
-				ModelUUID:      modelUUID,
-				Path:           "app/mariadb/password",
-				Attribute:      "attr",
+				ID:             secretID,
 			},
 		},
 	} {
-		result, err := secrets.ParseURL(t.str)
+		result, err := secrets.ParseURI(t.in)
 		if t.err != "" || result == nil {
 			c.Check(err, gc.ErrorMatches, t.err)
 		} else {
 			c.Check(result, jc.DeepEquals, t.expected)
 			c.Check(result.ShortString(), gc.Equals, t.shortStr)
-			c.Check(result.String(), gc.Equals, t.str)
+			if t.str != "" {
+				c.Check(result.String(), gc.Equals, t.str)
+			} else {
+				c.Check(result.String(), gc.Equals, t.in)
+			}
 		}
 	}
 }
 
-func (s *SecretURLSuite) TestString(c *gc.C) {
-	expected := &secrets.URL{
+func (s *SecretURISuite) TestString(c *gc.C) {
+	expected := &secrets.URI{
 		ControllerUUID: controllerUUID,
-		ModelUUID:      modelUUID,
-		Path:           "app/mariadb/password",
-		Attribute:      "attr",
+		ID:             secretID,
 	}
 	str := expected.String()
-	c.Assert(str, gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password#attr")
-	url, err := secrets.ParseURL(str)
+	c.Assert(str, gc.Equals, "secret:"+controllerUUID+"/"+secretID)
+	uri, err := secrets.ParseURI(str)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(url, jc.DeepEquals, expected)
+	c.Assert(uri, jc.DeepEquals, expected)
 }
 
-func (s *SecretURLSuite) TestStringWithRevision(c *gc.C) {
-	URL := &secrets.URL{
+func (s *SecretURISuite) TestShortString(c *gc.C) {
+	expected := &secrets.URI{
 		ControllerUUID: controllerUUID,
-		ModelUUID:      modelUUID,
-		Path:           "app/mariadb/password",
-		Attribute:      "attr",
-	}
-	str := URL.String()
-	c.Assert(str, gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password#attr")
-	URL.Revision = 1
-	str = URL.String()
-	c.Assert(str, gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password/1#attr")
-}
-
-func (s *SecretURLSuite) TestShortString(c *gc.C) {
-	expected := &secrets.URL{
-		ControllerUUID: controllerUUID,
-		ModelUUID:      modelUUID,
-		Path:           "app/mariadb/password",
-		Attribute:      "attr",
+		ID:             secretID,
 	}
 	str := expected.ShortString()
-	c.Assert(str, gc.Equals, "secret://app/mariadb/password#attr")
-	url, err := secrets.ParseURL(str)
+	c.Assert(str, gc.Equals, secretURI)
+	uri, err := secrets.ParseURI(str)
 	c.Assert(err, jc.ErrorIsNil)
 	expected.ControllerUUID = ""
-	expected.ModelUUID = ""
-	c.Assert(url, jc.DeepEquals, expected)
+	c.Assert(uri, jc.DeepEquals, expected)
 }
 
-func (s *SecretURLSuite) TestID(c *gc.C) {
-	expected := &secrets.URL{
-		ControllerUUID: controllerUUID,
-		ModelUUID:      modelUUID,
-		Path:           "app/mariadb/password",
-		Attribute:      "attr",
-	}
-	c.Assert(expected.ID(), gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password")
-}
-
-func (s *SecretURLSuite) TestWithRevision(c *gc.C) {
-	expected := &secrets.URL{
-		ControllerUUID: controllerUUID,
-		ModelUUID:      modelUUID,
-		Path:           "app/mariadb/password",
-		Attribute:      "attr",
-	}
-	expected = expected.WithRevision(666)
-	c.Assert(expected.String(), gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password/666#attr")
-}
-
-func (s *SecretURLSuite) TestWithAttribute(c *gc.C) {
-	expected := &secrets.URL{
-		ControllerUUID: controllerUUID,
-		ModelUUID:      modelUUID,
-		Path:           "app/mariadb/password",
-	}
-	expected = expected.WithAttribute("attr")
-	c.Assert(expected.String(), gc.Equals, "secret://"+controllerUUID+"/"+modelUUID+"/app/mariadb/password#attr")
-}
-
-func (s *SecretURLSuite) TestNewSimpleURL(c *gc.C) {
-	URL := secrets.NewSimpleURL("app/mariadb/password")
-	c.Assert(URL.String(), gc.Equals, "secret://app/mariadb/password")
-}
-
-func (s *SecretURLSuite) TestOwnerApplication(c *gc.C) {
-	URL := secrets.NewSimpleURL("app/mariadb/password")
-	app, ok := URL.OwnerApplication()
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(app, gc.Equals, "mariadb")
-
-	URL2 := secrets.NewSimpleURL("unit/mariadb-0/password")
-	_, ok = URL2.OwnerApplication()
-	c.Assert(ok, jc.IsFalse)
-
+func (s *SecretURISuite) TestNew(c *gc.C) {
+	URI := secrets.NewURI()
+	c.Assert(URI.ControllerUUID, gc.Equals, "")
+	_, err := xid.FromString(URI.ID)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/core/watcher/secrets.go
+++ b/core/watcher/secrets.go
@@ -11,8 +11,7 @@ import (
 
 // SecretRotationChange describes changes to secret rotation config.
 type SecretRotationChange struct {
-	ID             int
-	URL            *secrets.URL
+	URI            *secrets.URI
 	RotateInterval time.Duration
 	LastRotateTime time.Time
 }

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/pkg/sftp v1.13.4
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
+	github.com/rs/xid v1.4.0
 	github.com/vishvananda/netlink v1.2.0-beta
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa

--- a/go.sum
+++ b/go.sum
@@ -825,6 +825,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
+github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -14,17 +14,8 @@ type CreateSecretArgs struct {
 
 // CreateSecretArg holds the args for creating a secret.
 type CreateSecretArg struct {
-	// Type is "blob" for secrets where the data is passed
-	// in here; "password" is use for where the actual
-	// value is generated server side using arguments
-	// in Params.
-	Type string `json:"type"`
-	// Path represents a unique string used to identify a secret.
-	Path string `json:"path"`
 	// RotateInterval is how often a secret should be rotated.
 	RotateInterval time.Duration `json:"rotate-interval"`
-	// Status represents the secret's status.
-	Status string `json:"status"`
 	// Description represents the secret's description.
 	Description string `json:"description,omitempty"`
 	// Params are used when generating secrets server side.
@@ -44,11 +35,9 @@ type UpdateSecretArgs struct {
 // UpdateSecretArg holds the args for creating a secret.
 type UpdateSecretArg struct {
 	// URL identifies the secret to update.
-	URL string `json:"url"`
+	URI string `json:"uri"`
 	// RotateInterval is how often a secret should be rotated.
 	RotateInterval *time.Duration `json:"rotate-interval"`
-	// Status represents the secret's status.
-	Status *string `json:"status"`
 	// Description represents the secret's description.
 	Description *string `json:"description,omitempty"`
 	// Tags are the secret tags.
@@ -67,10 +56,8 @@ type GetSecretArgs struct {
 }
 
 // GetSecretArg holds the args for getting a secret.
-// Either specify a URL or ID.
 type GetSecretArg struct {
-	URL string `json:"url,omitempty"`
-	ID  string `json:"id,omitempty"`
+	URI string `json:"uri"`
 }
 
 // SecretValueResults holds secret value results.
@@ -96,14 +83,12 @@ type ListSecretResults struct {
 
 // ListSecretResult is the result of getting secret metadata.
 type ListSecretResult struct {
-	URL            string             `json:"url"`
-	Path           string             `json:"path"`
+	URI            string             `json:"uri"`
 	Version        int                `json:"version"`
 	RotateInterval time.Duration      `json:"rotate-interval"`
-	Status         string             `json:"status"`
 	Description    string             `json:"description,omitempty"`
+	OwnerTag       string             `json:"owner-tag"`
 	Tags           map[string]string  `json:"tags,omitempty"`
-	ID             int                `json:"int"`
 	Provider       string             `json:"provider"`
 	ProviderID     string             `json:"provider-id,omitempty"`
 	Revision       int                `json:"revision"`
@@ -114,8 +99,7 @@ type ListSecretResult struct {
 
 // SecretRotationChange describes a change to a secret rotation config.
 type SecretRotationChange struct {
-	ID             int           `json:"secret-id"`
-	URL            string        `json:"url"`
+	URI            string        `json:"uri"`
 	RotateInterval time.Duration `json:"rotate-interval"`
 	LastRotateTime time.Time     `json:"last-rotate-time"`
 }
@@ -140,6 +124,6 @@ type SecretRotatedArgs struct {
 
 // SecretRotatedArg holds the args for updating rotated secret info.
 type SecretRotatedArg struct {
-	URL  string    `json:"url"`
+	URI  string    `json:"uri"`
 	When time.Time `json:"when"`
 }

--- a/secrets/doc.go
+++ b/secrets/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package secrets provides the service layer for the
+// various secrets backends.
+package secrets

--- a/secrets/interface.go
+++ b/secrets/interface.go
@@ -19,11 +19,8 @@ const (
 type CreateParams struct {
 	ProviderLabel  string
 	Version        int
-	Type           secrets.SecretType
 	Owner          string
-	Path           string
 	RotateInterval time.Duration
-	Status         secrets.SecretStatus
 	Description    string
 	Tags           map[string]string
 	Params         map[string]interface{}
@@ -33,7 +30,6 @@ type CreateParams struct {
 // UpdateParams are used to update a secret.
 type UpdateParams struct {
 	RotateInterval *time.Duration
-	Status         *secrets.SecretStatus
 	Description    *string
 	Tags           *map[string]string
 	Params         map[string]interface{}
@@ -48,22 +44,22 @@ type Filter struct {
 // SecretsService instances provide a backend for storing secrets values.
 type SecretsService interface {
 	// CreateSecret creates a new secret and returns a URL for accessing the secret value.
-	CreateSecret(ctx context.Context, URL *secrets.URL, p CreateParams) (*secrets.SecretMetadata, error)
+	CreateSecret(context.Context, *secrets.URI, CreateParams) (*secrets.SecretMetadata, error)
 
 	// UpdateSecret updates a given secret with a new secret value.
-	UpdateSecret(ctx context.Context, URL *secrets.URL, p UpdateParams) (*secrets.SecretMetadata, error)
+	UpdateSecret(context.Context, *secrets.URI, UpdateParams) (*secrets.SecretMetadata, error)
 
 	// DeleteSecret deletes the specified secret.
-	DeleteSecret(ctx context.Context, URL *secrets.URL) error
+	DeleteSecret(context.Context, *secrets.URI) error
 
 	// GetSecret returns the metadata for the specified secret.
-	GetSecret(ctx context.Context, URL *secrets.URL) (*secrets.SecretMetadata, error)
+	GetSecret(context.Context, *secrets.URI) (*secrets.SecretMetadata, error)
 
 	// GetSecretValue returns the value of the specified secret.
-	GetSecretValue(ctx context.Context, URL *secrets.URL) (secrets.SecretValue, error)
+	GetSecretValue(context.Context, *secrets.URI, int) (secrets.SecretValue, error)
 
 	// ListSecrets returns secret metadata using the specified filter.
-	ListSecrets(ctx context.Context, filter Filter) ([]*secrets.SecretMetadata, error)
+	ListSecrets(context.Context, Filter) ([]*secrets.SecretMetadata, error)
 }
 
 // ProviderConfig is used when constructing a secrets provider.

--- a/secrets/provider/juju/doc.go
+++ b/secrets/provider/juju/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package juju provides the juju secrets backend.
+package juju

--- a/secrets/provider/juju/mocks/secretstore.go
+++ b/secrets/provider/juju/mocks/secretstore.go
@@ -36,7 +36,7 @@ func (m *MockSecretsStore) EXPECT() *MockSecretsStoreMockRecorder {
 }
 
 // CreateSecret mocks base method.
-func (m *MockSecretsStore) CreateSecret(arg0 *secrets.URL, arg1 state.CreateSecretParams) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsStore) CreateSecret(arg0 *secrets.URI, arg1 state.CreateSecretParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)
@@ -51,7 +51,7 @@ func (mr *MockSecretsStoreMockRecorder) CreateSecret(arg0, arg1 interface{}) *go
 }
 
 // GetSecret mocks base method.
-func (m *MockSecretsStore) GetSecret(arg0 *secrets.URL) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsStore) GetSecret(arg0 *secrets.URI) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecret", arg0)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)
@@ -66,18 +66,18 @@ func (mr *MockSecretsStoreMockRecorder) GetSecret(arg0 interface{}) *gomock.Call
 }
 
 // GetSecretValue mocks base method.
-func (m *MockSecretsStore) GetSecretValue(arg0 *secrets.URL) (secrets.SecretValue, error) {
+func (m *MockSecretsStore) GetSecretValue(arg0 *secrets.URI, arg1 int) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretValue", arg0)
+	ret := m.ctrl.Call(m, "GetSecretValue", arg0, arg1)
 	ret0, _ := ret[0].(secrets.SecretValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecretValue indicates an expected call of GetSecretValue.
-func (mr *MockSecretsStoreMockRecorder) GetSecretValue(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretsStoreMockRecorder) GetSecretValue(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockSecretsStore)(nil).GetSecretValue), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockSecretsStore)(nil).GetSecretValue), arg0, arg1)
 }
 
 // ListSecrets mocks base method.
@@ -96,7 +96,7 @@ func (mr *MockSecretsStoreMockRecorder) ListSecrets(arg0 interface{}) *gomock.Ca
 }
 
 // UpdateSecret mocks base method.
-func (m *MockSecretsStore) UpdateSecret(arg0 *secrets.URL, arg1 state.UpdateSecretParams) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsStore) UpdateSecret(arg0 *secrets.URI, arg1 state.UpdateSecretParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)

--- a/secrets/provider/juju/secrets.go
+++ b/secrets/provider/juju/secrets.go
@@ -36,16 +36,13 @@ func NewSecretService(cfg secrets.ProviderConfig) (*secretsService, error) {
 }
 
 // CreateSecret implements SecretsService.
-func (s secretsService) CreateSecret(ctx context.Context, URL *coresecrets.URL, p secrets.CreateParams) (*coresecrets.SecretMetadata, error) {
-	metadata, err := s.backend.CreateSecret(URL, state.CreateSecretParams{
+func (s secretsService) CreateSecret(ctx context.Context, uri *coresecrets.URI, p secrets.CreateParams) (*coresecrets.SecretMetadata, error) {
+	metadata, err := s.backend.CreateSecret(uri, state.CreateSecretParams{
 		ProviderLabel:  Provider,
 		Version:        p.Version,
-		Type:           p.Type,
 		Owner:          p.Owner,
-		Path:           p.Path,
 		RotateInterval: p.RotateInterval,
 		Description:    p.Description,
-		Status:         p.Status,
 		Tags:           p.Tags,
 		Params:         p.Params,
 		Data:           p.Data,
@@ -57,21 +54,13 @@ func (s secretsService) CreateSecret(ctx context.Context, URL *coresecrets.URL, 
 }
 
 // GetSecretValue implements SecretsService.
-func (s secretsService) GetSecretValue(ctx context.Context, URL *coresecrets.URL) (coresecrets.SecretValue, error) {
-	// If no specific revision asked for, use the latest.
-	if URL.Revision == 0 {
-		metadata, err := s.GetSecret(ctx, URL)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		URL = metadata.URL.WithRevision(metadata.Revision)
-	}
-	return s.backend.GetSecretValue(URL)
+func (s secretsService) GetSecretValue(ctx context.Context, uri *coresecrets.URI, revision int) (coresecrets.SecretValue, error) {
+	return s.backend.GetSecretValue(uri, revision)
 }
 
 // GetSecret implements SecretsService.
-func (s secretsService) GetSecret(ctx context.Context, URL *coresecrets.URL) (*coresecrets.SecretMetadata, error) {
-	return s.backend.GetSecret(URL.WithRevision(0).WithAttribute(""))
+func (s secretsService) GetSecret(ctx context.Context, uri *coresecrets.URI) (*coresecrets.SecretMetadata, error) {
+	return s.backend.GetSecret(uri)
 }
 
 // ListSecrets implements SecretsService.
@@ -80,11 +69,10 @@ func (s secretsService) ListSecrets(ctx context.Context, filter secrets.Filter) 
 }
 
 // UpdateSecret implements SecretsService.
-func (s secretsService) UpdateSecret(ctx context.Context, URL *coresecrets.URL, p secrets.UpdateParams) (*coresecrets.SecretMetadata, error) {
-	metadata, err := s.backend.UpdateSecret(URL, state.UpdateSecretParams{
+func (s secretsService) UpdateSecret(ctx context.Context, uri *coresecrets.URI, p secrets.UpdateParams) (*coresecrets.SecretMetadata, error) {
+	metadata, err := s.backend.UpdateSecret(uri, state.UpdateSecretParams{
 		RotateInterval: p.RotateInterval,
 		Description:    p.Description,
-		Status:         p.Status,
 		Tags:           p.Tags,
 		Params:         p.Params,
 		Data:           p.Data,
@@ -98,6 +86,6 @@ func (s secretsService) UpdateSecret(ctx context.Context, URL *coresecrets.URL, 
 // TODO(wallyworld)
 
 // DeleteSecret implements SecretsService.
-func (s secretsService) DeleteSecret(ctx context.Context, URL *coresecrets.URL) error {
+func (s secretsService) DeleteSecret(ctx context.Context, uri *coresecrets.URI) error {
 	return errors.NotImplementedf("DeleteSecret")
 }

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1068,7 +1068,7 @@ func MachinePortOps(st *State, m description.Machine) ([]txn.Op, error) {
 	return []txn.Op{resolver.machinePortsOp(m)}, nil
 }
 
-func GetSecretRotateTime(c *gc.C, st *State, id int) time.Time {
+func GetSecretRotateTime(c *gc.C, st *State, id string) time.Time {
 	secretRotateCollection, closer := st.db().GetCollection(secretRotateC)
 	defer closer()
 

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -48,8 +48,8 @@ type Info struct {
 	// It is only set for the pre-series-upgrade hook.
 	SeriesUpgradeTarget string `yaml:"series-upgrade-target,omitempty"`
 
-	// SecretURL is the secret URL relevant to the hook.
-	SecretURL string `yaml:"secret-url,omitempty"`
+	// SecretURI is the secret URI relevant to the hook.
+	SecretURI string `yaml:"secret-uri,omitempty"`
 }
 
 // Validate returns an error if the info is not valid.
@@ -96,11 +96,11 @@ func (hi Info) Validate() error {
 	case hooks.LeaderElected, hooks.LeaderDeposed, hooks.LeaderSettingsChanged:
 		return nil
 	case hooks.SecretRotate:
-		if hi.SecretURL == "" {
+		if hi.SecretURI == "" {
 			return errors.Errorf("%q hook requires a secret URL", hi.Kind)
 		}
-		if _, err := secrets.ParseURL(hi.SecretURL); err != nil {
-			return errors.Errorf("invalid secret URL %q", hi.SecretURL)
+		if _, err := secrets.ParseURI(hi.SecretURI); err != nil {
+			return errors.Errorf("invalid secret URL %q", hi.SecretURI)
 		}
 		return nil
 	}

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -53,7 +53,7 @@ var validateTests = []struct {
 		hook.Info{Kind: hooks.SecretRotate},
 		`"secret-rotate" hook requires a secret URL`,
 	}, {
-		hook.Info{Kind: hooks.SecretRotate, SecretURL: "foo"},
+		hook.Info{Kind: hooks.SecretRotate, SecretURI: "foo"},
 		`invalid secret URL "foo"`,
 	},
 	{hook.Info{Kind: hooks.Install}, ""},

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -164,6 +164,6 @@ func (opc *operationCallbacks) RemoteInit(runningStatus remotestate.ContainerRun
 }
 
 // SetSecretRotated is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) SetSecretRotated(url string, when time.Time) error {
-	return opc.u.secrets.SecretRotated(url, when)
+func (opc *operationCallbacks) SetSecretRotated(uri string, when time.Time) error {
+	return opc.u.secrets.SecretRotated(uri, when)
 }

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -51,7 +51,7 @@ func (rh *runHook) String() string {
 	case rh.info.Kind.IsStorage():
 		suffix = fmt.Sprintf(" (%s)", rh.info.StorageId)
 	case rh.info.Kind.IsSecret():
-		suffix = fmt.Sprintf(" (%s)", rh.info.SecretURL)
+		suffix = fmt.Sprintf(" (%s)", rh.info.SecretURI)
 	}
 	return fmt.Sprintf("run %s%s hook", rh.info.Kind, suffix)
 }
@@ -103,7 +103,7 @@ func RunningHookMessage(hookName string, info hook.Info) string {
 		return fmt.Sprintf("running %s hook for %s", hookName, info.RemoteUnit)
 	}
 	if info.Kind.IsSecret() {
-		return fmt.Sprintf("running %s hook for %s", hookName, info.SecretURL)
+		return fmt.Sprintf("running %s hook for %s", hookName, info.SecretURI)
 	}
 	return fmt.Sprintf("running %s hook", hookName)
 }
@@ -294,7 +294,7 @@ func (rh *runHook) Commit(state State) (*State, error) {
 		message := createUpgradeSeriesStatusMessage(rh.name, rh.hookFound)
 		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, message)
 	case hooks.SecretRotate:
-		err = rh.callbacks.SetSecretRotated(rh.info.SecretURL, time.Now())
+		err = rh.callbacks.SetSecretRotated(rh.info.SecretURI, time.Now())
 	}
 	if err != nil {
 		return nil, err

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -884,10 +884,10 @@ func (s *RunHookSuite) TestRunningHookMessageForSecretsHooks(c *gc.C) {
 		"secret-rotate",
 		hook.Info{
 			Kind:      hooks.SecretRotate,
-			SecretURL: "secret://app/mariadb/password",
+			SecretURI: "secret:9m4e2mr0ui3e8a215n4g",
 		},
 	)
-	c.Assert(msg, gc.Equals, `running secret-rotate hook for secret://app/mariadb/password`)
+	c.Assert(msg, gc.Equals, `running secret-rotate hook for secret:9m4e2mr0ui3e8a215n4g`)
 }
 
 func (s *RunHookSuite) TestCommitSuccess_SecretRotate_SetRotated(c *gc.C) {
@@ -896,7 +896,7 @@ func (s *RunHookSuite) TestCommitSuccess_SecretRotate_SetRotated(c *gc.C) {
 	}
 	factory := newOpFactory(nil, callbacks)
 	op, err := factory.NewRunHook(hook.Info{
-		Kind: hooks.SecretRotate, SecretURL: "secret://app/mariadb/password",
+		Kind: hooks.SecretRotate, SecretURI: "secret:9m4e2mr0ui3e8a215n4g",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -909,7 +909,7 @@ func (s *RunHookSuite) TestCommitSuccess_SecretRotate_SetRotated(c *gc.C) {
 	newState, err := op.Commit(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, jc.DeepEquals, expectState)
-	c.Assert(callbacks.rotatedSecretURL, gc.Equals, "secret://app/mariadb/password")
+	c.Assert(callbacks.rotatedSecretURL, gc.Equals, "secret:9m4e2mr0ui3e8a215n4g")
 	c.Assert(callbacks.rotatedSecretTime.After(now), jc.IsTrue)
 }
 
@@ -927,7 +927,7 @@ func (s *RunHookSuite) TestPrepareHookError_SecretRotate_NotLeader(c *gc.C) {
 	factory := newOpFactory(runnerFactory, callbacks)
 
 	op, err := factory.NewRunHook(hook.Info{
-		Kind: hooks.SecretRotate, SecretURL: "secret://app/mariadb/password",
+		Kind: hooks.SecretRotate, SecretURI: "secret:9m4e2mr0ui3e8a215n4g",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -909,7 +909,7 @@ func (s *RunHookSuite) TestCommitSuccess_SecretRotate_SetRotated(c *gc.C) {
 	newState, err := op.Commit(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(newState, jc.DeepEquals, expectState)
-	c.Assert(callbacks.rotatedSecretURL, gc.Equals, "secret:9m4e2mr0ui3e8a215n4g")
+	c.Assert(callbacks.rotatedSecretURI, gc.Equals, "secret:9m4e2mr0ui3e8a215n4g")
 	c.Assert(callbacks.rotatedSecretTime.After(now), jc.IsTrue)
 }
 

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -229,7 +229,7 @@ type CommitHookCallbacks struct {
 	operation.Callbacks
 	*MockCommitHook
 
-	rotatedSecretURL  string
+	rotatedSecretURI  string
 	rotatedSecretTime time.Time
 }
 
@@ -238,7 +238,7 @@ func (cb *CommitHookCallbacks) CommitHook(hookInfo hook.Info) error {
 }
 
 func (cb *CommitHookCallbacks) SetSecretRotated(url string, when time.Time) error {
-	cb.rotatedSecretURL = url
+	cb.rotatedSecretURI = url
 	cb.rotatedSecretTime = when
 	return nil
 }

--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -687,12 +687,12 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			waitLeader = nil
 			waitMinion = w.leadershipTracker.WaitMinion().Ready()
 
-		case urls, ok := <-w.rotateSecretsChanges:
-			if !ok || len(urls) == 0 {
+		case uris, ok := <-w.rotateSecretsChanges:
+			if !ok || len(uris) == 0 {
 				continue
 			}
-			w.logger.Debugf("got rotate secret URLS: %q", urls)
-			w.rotateSecretURLs(urls)
+			w.logger.Debugf("got rotate secret URIs: %q", uris)
+			w.rotateSecretURIs(uris)
 
 		case change := <-w.storageAttachmentChanges:
 			w.logger.Debugf("storage attachment change for %s: %v", w.unit.Tag().Id(), change)
@@ -943,9 +943,9 @@ func (w *RemoteStateWatcher) leadershipChanged(isLeader bool) error {
 	return nil
 }
 
-// rotateSecretURLs adds the specified URLs to those that need
+// rotateSecretURIs adds the specified URLs to those that need
 // to be rotated.
-func (w *RemoteStateWatcher) rotateSecretURLs(urls []string) {
+func (w *RemoteStateWatcher) rotateSecretURIs(urls []string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -466,7 +466,7 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	s.st.unit.storageWatcher.changes <- []string{}
 	assertOneChange()
 
-	secretURLs := []string{"secret://app/mariadb/password", "secret://app/mysql/password"}
+	secretURLs := []string{"secret:9m4e2mr0ui3e8a215n4g", "secret:8b4e2mr1wi3e8a215n5h"}
 	s.rotateSecretWatcher.rotateCh <- secretURLs
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().SecretRotations, jc.DeepEquals, secretURLs)
@@ -1146,7 +1146,7 @@ func (s *WatcherSuite) TestRotateSecretsSignal(c *gc.C) {
 	c.Assert(snap.SecretRotations, gc.HasLen, 0)
 
 	select {
-	case s.rotateSecretWatcher.rotateCh <- []string{"secret://app/mariadb/password"}:
+	case s.rotateSecretWatcher.rotateCh <- []string{"secret:9m4e2mr0ui3e8a215n4g"}:
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("timed out waiting to signal rotate secret channel")
 	}
@@ -1158,7 +1158,7 @@ func (s *WatcherSuite) TestRotateSecretsSignal(c *gc.C) {
 
 	// Adding same event twice shouldn't re-add it.
 	select {
-	case s.rotateSecretWatcher.rotateCh <- []string{"secret://app/mariadb/password"}:
+	case s.rotateSecretWatcher.rotateCh <- []string{"secret:9m4e2mr0ui3e8a215n4g"}:
 	case <-time.After(testing.ShortWait):
 		c.Fatalf("timed out waiting to signal rotate secret channel")
 	}
@@ -1166,9 +1166,9 @@ func (s *WatcherSuite) TestRotateSecretsSignal(c *gc.C) {
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 
 	snap = s.watcher.Snapshot()
-	c.Assert(snap.SecretRotations, gc.DeepEquals, []string{"secret://app/mariadb/password"})
+	c.Assert(snap.SecretRotations, gc.DeepEquals, []string{"secret:9m4e2mr0ui3e8a215n4g"})
 
-	s.watcher.RotateSecretCompleted("secret://app/mariadb/password")
+	s.watcher.RotateSecretCompleted("secret:9m4e2mr0ui3e8a215n4g")
 	snap = s.watcher.Snapshot()
 	c.Assert(snap.SecretRotations, gc.HasLen, 0)
 }
@@ -1191,9 +1191,9 @@ func (s *WatcherSuite) TestLeaderRunsRotateWatcher(c *gc.C) {
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
 	c.Assert(s.watcher.Snapshot().Leader, jc.IsTrue)
 
-	s.rotateSecretWatcher.rotateCh <- []string{"secret://app/mysql/password"}
+	s.rotateSecretWatcher.rotateCh <- []string{"secret:8b4e2mr1wi3e8a215n5h"}
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
-	c.Assert(s.watcher.Snapshot().SecretRotations, jc.DeepEquals, []string{"secret://app/mysql/password"})
+	c.Assert(s.watcher.Snapshot().SecretRotations, jc.DeepEquals, []string{"secret:8b4e2mr1wi3e8a215n5h"})
 
 	// When not a leader anymore, stop the worker.
 	s.leadership.minionTicket.ch <- struct{}{}

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -466,10 +466,10 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *gc.C) {
 	s.st.unit.storageWatcher.changes <- []string{}
 	assertOneChange()
 
-	secretURLs := []string{"secret:9m4e2mr0ui3e8a215n4g", "secret:8b4e2mr1wi3e8a215n5h"}
-	s.rotateSecretWatcher.rotateCh <- secretURLs
+	secretURIs := []string{"secret:9m4e2mr0ui3e8a215n4g", "secret:8b4e2mr1wi3e8a215n5h"}
+	s.rotateSecretWatcher.rotateCh <- secretURIs
 	assertOneChange()
-	c.Assert(s.watcher.Snapshot().SecretRotations, jc.DeepEquals, secretURLs)
+	c.Assert(s.watcher.Snapshot().SecretRotations, jc.DeepEquals, secretURIs)
 
 	s.st.unit.configSettingsWatcher.changes <- []string{"confighash2"}
 	assertOneChange()

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -602,11 +602,11 @@ func (s *resolverSuite) TestRunsSecretRotated(c *gc.C) {
 		},
 	}
 	s.remoteState.Leader = true
-	s.remoteState.SecretRotations = []string{"secret://app/mariadb/password"}
+	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(op.String(), gc.Equals, "run secret-rotate (secret://app/mariadb/password) hook")
+	c.Assert(op.String(), gc.Equals, "run secret-rotate (secret:9m4e2mr0ui3e8a215n4g) hook")
 }
 
 func (s *conflictedResolverSuite) TestNextOpConflicted(c *gc.C) {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1397,10 +1397,10 @@ func (ctx *HookContext) WorkloadName() (string, error) {
 	return ctx.workloadName, nil
 }
 
-// SecretURL returns the secret URL for secret hooks.
+// SecretURI returns the secret URL for secret hooks.
 // This is not yet used by any hook commands - it is exported
 // for tests to use.
-func (ctx *HookContext) SecretURL() (string, error) {
+func (ctx *HookContext) SecretURI() (string, error) {
 	if ctx.secretURI == "" {
 		return "", errors.NotFoundf("secret URL")
 	}

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -271,7 +271,7 @@ func (f *contextFactory) HookContext(hookInfo hook.Info) (*HookContext, error) {
 		ctx.seriesUpgradeTarget = hookInfo.SeriesUpgradeTarget
 	}
 	if hookInfo.Kind.IsSecret() {
-		ctx.secretURL = hookInfo.SecretURL
+		ctx.secretURI = hookInfo.SecretURI
 	}
 	ctx.id = f.newId(hookName)
 	ctx.hookName = hookName

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -302,12 +302,12 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 func (s *ContextFactorySuite) TestSecretHookContext(c *gc.C) {
 	hi := hook.Info{
 		Kind:      hooks.SecretRotate,
-		SecretURL: "secret://app/mariadb/password",
+		SecretURI: "secret:9m4e2mr0ui3e8a215n4g",
 	}
 	ctx, err := s.factory.HookContext(hi)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AssertCoreContext(c, ctx)
-	s.AssertSecretContext(c, ctx, hi.SecretURL)
+	s.AssertSecretContext(c, ctx, hi.SecretURI)
 	s.AssertNotWorkloadContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertNotRelationContext(c, ctx)

--- a/worker/uniter/runner/context/env_test.go
+++ b/worker/uniter/runner/context/env_test.go
@@ -128,10 +128,10 @@ func (s *EnvSuite) getContext(newProxyOnly bool) (ctx *context.HookContext, expe
 }
 
 func (s *EnvSuite) setSecret(ctx *context.HookContext) (expectVars []string) {
-	url := secrets.NewSimpleURL("app/mariadb/password")
-	context.SetEnvironmentHookContextSecret(ctx, url.ID())
+	url := secrets.NewURI()
+	context.SetEnvironmentHookContextSecret(ctx, url.ShortString())
 	return []string{
-		"JUJU_SECRET_URL=" + url.ID(),
+		"JUJU_SECRET_URL=" + url.ShortString(),
 	}
 }
 

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -122,8 +122,8 @@ func NewMockUnitHookContextWithSecrets(mockUnit *mocks.MockHookUnit, client *sec
 }
 
 // SetEnvironmentHookContextSecret exists purely to set the fields used in hookVars.
-func SetEnvironmentHookContextSecret(context *HookContext, secretURL string) {
-	context.secretURL = secretURL
+func SetEnvironmentHookContextSecret(context *HookContext, secretURI string) {
+	context.secretURI = secretURI
 }
 
 // SetEnvironmentHookContextRelation exists purely to set the fields used in hookVars.

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -362,13 +362,13 @@ func (s *HookContextSuite) AssertNotWorkloadContext(c *gc.C, ctx *runnercontext.
 	c.Assert(workloadName, gc.Equals, "")
 }
 
-func (s *HookContextSuite) AssertSecretContext(c *gc.C, ctx *runnercontext.HookContext, secretURL string) {
-	URL, _ := ctx.SecretURL()
-	c.Assert(URL, gc.Equals, secretURL)
+func (s *HookContextSuite) AssertSecretContext(c *gc.C, ctx *runnercontext.HookContext, secretURI string) {
+	uri, _ := ctx.SecretURI()
+	c.Assert(uri, gc.Equals, secretURI)
 }
 
 func (s *HookContextSuite) AssertNotSecretContext(c *gc.C, ctx *runnercontext.HookContext) {
-	workloadName, err := ctx.SecretURL()
+	workloadName, err := ctx.SecretURI()
 	c.Assert(err, gc.NotNil)
 	c.Assert(workloadName, gc.Equals, "")
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -167,17 +167,11 @@ type ContextUnit interface {
 
 // SecretUpsertArgs specifies args used to create or update a secret.
 type SecretUpsertArgs struct {
-	// Type is the secret type (only used for insert).
-	Type secrets.SecretType
-
 	// Value is the new secret value or nil to not update.
 	Value secrets.SecretValue
 
 	// RotateInterval is the new rotate interval or nil to not update.
 	RotateInterval *time.Duration
-
-	// Status is whether a secret is pending or active or nil to not update.
-	Status *secrets.SecretStatus
 
 	// Description describes the secret or nil to not update.
 	Description *string
@@ -197,19 +191,19 @@ type SecretGrantRevokeArgs struct {
 // ContextSecrets is the part of a hook context related to secrets.
 type ContextSecrets interface {
 	// GetSecret returns the value of the specified secret.
-	GetSecret(ID string) (secrets.SecretValue, error)
+	GetSecret(string) (secrets.SecretValue, error)
 
 	// CreateSecret creates a secret with the specified data.
-	CreateSecret(name string, args *SecretUpsertArgs) (string, error)
+	CreateSecret(args *SecretUpsertArgs) (string, error)
 
 	// UpdateSecret creates a secret with the specified data.
-	UpdateSecret(name string, args *SecretUpsertArgs) (string, error)
+	UpdateSecret(string, *SecretUpsertArgs) error
 
 	// GrantSecret grants access to the specified secret.
-	GrantSecret(name string, args *SecretGrantRevokeArgs) error
+	GrantSecret(string, *SecretGrantRevokeArgs) error
 
 	// RevokeSecret revokes access to the specified secret.
-	RevokeSecret(name string, args *SecretGrantRevokeArgs) error
+	RevokeSecret(string, *SecretGrantRevokeArgs) error
 }
 
 // ContextStatus is the part of a hook context related to the unit's status.

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -16,31 +16,31 @@ type ContextSecrets struct {
 }
 
 // GetSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) GetSecret(ID string) (secrets.SecretValue, error) {
-	c.stub.AddCall("GetSecret", ID)
+func (c *ContextSecrets) GetSecret(uri string) (secrets.SecretValue, error) {
+	c.stub.AddCall("GetSecret", uri)
 	return c.SecretValue, nil
 }
 
 // CreateSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) CreateSecret(name string, args *jujuc.SecretUpsertArgs) (string, error) {
-	c.stub.AddCall("CreateSecret", name, args)
-	return "secret://app." + name, nil
+func (c *ContextSecrets) CreateSecret(args *jujuc.SecretUpsertArgs) (string, error) {
+	c.stub.AddCall("CreateSecret", args)
+	return "secret:9m4e2mr0ui3e8a215n4g", nil
 }
 
 // UpdateSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) UpdateSecret(name string, args *jujuc.SecretUpsertArgs) (string, error) {
-	c.stub.AddCall("UpdateSecret", name, args)
-	return "secret://app." + name, nil
+func (c *ContextSecrets) UpdateSecret(uri string, args *jujuc.SecretUpsertArgs) error {
+	c.stub.AddCall("UpdateSecret", uri, args)
+	return nil
 }
 
 // GrantSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) GrantSecret(name string, args *jujuc.SecretGrantRevokeArgs) error {
-	c.stub.AddCall("GrantSecret", name, args)
+func (c *ContextSecrets) GrantSecret(uri string, args *jujuc.SecretGrantRevokeArgs) error {
+	c.stub.AddCall("GrantSecret", uri, args)
 	return nil
 }
 
 // RevokeSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) RevokeSecret(name string, args *jujuc.SecretGrantRevokeArgs) error {
-	c.stub.AddCall("RevokeSecret", name, args)
+func (c *ContextSecrets) RevokeSecret(uri string, args *jujuc.SecretGrantRevokeArgs) error {
+	c.stub.AddCall("RevokeSecret", uri, args)
 	return nil
 }

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -175,18 +175,18 @@ func (mr *MockContextMockRecorder) ConfigSettings() *gomock.Call {
 }
 
 // CreateSecret mocks base method.
-func (m *MockContext) CreateSecret(arg0 string, arg1 *jujuc.SecretUpsertArgs) (string, error) {
+func (m *MockContext) CreateSecret(arg0 *jujuc.SecretUpsertArgs) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateSecret", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecret indicates an expected call of CreateSecret.
-func (mr *MockContextMockRecorder) CreateSecret(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) CreateSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockContext)(nil).CreateSecret), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockContext)(nil).CreateSecret), arg0)
 }
 
 // DeleteCharmStateValue mocks base method.
@@ -858,12 +858,11 @@ func (mr *MockContextMockRecorder) UpdateActionResults(arg0, arg1 interface{}) *
 }
 
 // UpdateSecret mocks base method.
-func (m *MockContext) UpdateSecret(arg0 string, arg1 *jujuc.SecretUpsertArgs) (string, error) {
+func (m *MockContext) UpdateSecret(arg0 string, arg1 *jujuc.SecretUpsertArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // UpdateSecret indicates an expected call of UpdateSecret.

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -38,7 +38,7 @@ func (*RestrictedContext) GetCharmState() (map[string]string, error) {
 	return nil, ErrRestrictedContext
 }
 
-// GetSingleCharmStateValue implements jujuc.unitCharmStateContext.
+// GetCharmStateValue implements jujuc.unitCharmStateContext.
 func (*RestrictedContext) GetCharmStateValue(string) (string, error) {
 	return "", ErrRestrictedContext
 }
@@ -254,26 +254,26 @@ func (*RestrictedContext) WorkloadName() (string, error) {
 }
 
 // GetSecret implements runner.Context.
-func (ctx *RestrictedContext) GetSecret(ID string) (secrets.SecretValue, error) {
+func (ctx *RestrictedContext) GetSecret(string) (secrets.SecretValue, error) {
 	return nil, ErrRestrictedContext
 }
 
 // CreateSecret implements runner.Context.
-func (ctx *RestrictedContext) CreateSecret(name string, args *SecretUpsertArgs) (string, error) {
+func (ctx *RestrictedContext) CreateSecret(*SecretUpsertArgs) (string, error) {
 	return "", ErrRestrictedContext
 }
 
 // UpdateSecret implements runner.Context.
-func (ctx *RestrictedContext) UpdateSecret(name string, args *SecretUpsertArgs) (string, error) {
-	return "", ErrRestrictedContext
+func (ctx *RestrictedContext) UpdateSecret(string, *SecretUpsertArgs) error {
+	return ErrRestrictedContext
 }
 
 // GrantSecret implements runner.Context.
-func (c *RestrictedContext) GrantSecret(name string, args *SecretGrantRevokeArgs) error {
+func (c *RestrictedContext) GrantSecret(string, *SecretGrantRevokeArgs) error {
 	return nil
 }
 
 // RevokeSecret implements runner.Context.
-func (c *RestrictedContext) RevokeSecret(name string, args *SecretGrantRevokeArgs) error {
+func (c *RestrictedContext) RevokeSecret(string, *SecretGrantRevokeArgs) error {
 	return nil
 }

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -16,7 +16,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 )
 
-type secretCreateCommand struct {
+type secretAddCommand struct {
 	cmd.CommandBase
 	ctx Context
 
@@ -27,40 +27,40 @@ type secretCreateCommand struct {
 	data           map[string]string
 }
 
-// NewSecretCreateCommand returns a command to create a secret.
-func NewSecretCreateCommand(ctx Context) (cmd.Command, error) {
-	return &secretCreateCommand{
+// NewSecretAddCommand returns a command to add a secret.
+func NewSecretAddCommand(ctx Context) (cmd.Command, error) {
+	return &secretAddCommand{
 		ctx:            ctx,
 		rotateInterval: -1,
 	}, nil
 }
 
 // Info implements cmd.Command.
-func (c *secretCreateCommand) Info() *cmd.Info {
+func (c *secretAddCommand) Info() *cmd.Info {
 	doc := `
-Create a secret with either a single value or a list of key values.
+Add a secret with either a single value or a list of key values.
 If --base64 is specified, the values are already in base64 format and no
 encoding will be performed, otherwise the values will be base64 encoded
 prior to being stored.
 
 Examples:
-    secret-create 34ae35facd4
-    secret-create --base64 AA==
-    secret-create --rotate 24h s3cret 
-    secret-create --tag foo=bar --tag hello=world \
+    secret-add 34ae35facd4
+    secret-add --base64 AA==
+    secret-add --rotate 24h s3cret 
+    secret-add --tag foo=bar --tag hello=world \
         --description "my database password" \
         s3cret 
 `
 	return jujucmd.Info(&cmd.Info{
-		Name:    "secret-create",
+		Name:    "secret-add",
 		Args:    "[value|key=value...]",
-		Purpose: "create a new secret",
+		Purpose: "add a new secret",
 		Doc:     doc,
 	})
 }
 
 // SetFlags implements cmd.Command.
-func (c *secretCreateCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *secretAddCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.asBase64, "base64", false,
 		`specify the supplied values are base64 encoded strings`)
 	f.DurationVar(&c.rotateInterval, "rotate", 0, "how often the secret should be rotated")
@@ -69,7 +69,7 @@ func (c *secretCreateCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 // Init implements cmd.Command.
-func (c *secretCreateCommand) Init(args []string) error {
+func (c *secretAddCommand) Init(args []string) error {
 	if len(args) < 1 {
 		return errors.New("missing secret value")
 	}
@@ -83,7 +83,7 @@ func (c *secretCreateCommand) Init(args []string) error {
 }
 
 // Run implements cmd.Command.
-func (c *secretCreateCommand) Run(ctx *cmd.Context) error {
+func (c *secretAddCommand) Run(ctx *cmd.Context) error {
 	value := secrets.NewSecretValue(c.data)
 	id, err := c.ctx.CreateSecret(&SecretUpsertArgs{
 		Value:          value,

--- a/worker/uniter/runner/jujuc/secret-add_test.go
+++ b/worker/uniter/runner/jujuc/secret-add_test.go
@@ -17,13 +17,13 @@ import (
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
-type SecretCreateSuite struct {
+type SecretAddSuite struct {
 	ContextSuite
 }
 
-var _ = gc.Suite(&SecretCreateSuite{})
+var _ = gc.Suite(&SecretAddSuite{})
 
-func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
+func (s *SecretAddSuite) TestCreateSecretInvalidArgs(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
 	for _, t := range []struct {
@@ -44,7 +44,7 @@ func (s *SecretCreateSuite) TestCreateSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR rotate interval "-1h0m0s" not valid`,
 		},
 	} {
-		com, err := jujuc.NewCommand(hctx, "secret-create")
+		com, err := jujuc.NewCommand(hctx, "secret-add")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -66,10 +66,10 @@ func tagPtr(t map[string]string) *map[string]string {
 	return &t
 }
 
-func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
+func (s *SecretAddSuite) TestCreateSecret(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewCommand(hctx, "secret-create")
+	com, err := jujuc.NewCommand(hctx, "secret-add")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
@@ -90,10 +90,10 @@ func (s *SecretCreateSuite) TestCreateSecret(c *gc.C) {
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret:9m4e2mr0ui3e8a215n4g\n")
 }
 
-func (s *SecretCreateSuite) TestCreateSecretBase64(c *gc.C) {
+func (s *SecretAddSuite) TestCreateSecretBase64(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewCommand(hctx, "secret-create")
+	com, err := jujuc.NewCommand(hctx, "secret-add")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--base64", "token=key="})

--- a/worker/uniter/runner/jujuc/secret-create.go
+++ b/worker/uniter/runner/jujuc/secret-create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+
 	"github.com/juju/juju/core/secrets"
 
 	jujucmd "github.com/juju/juju/cmd"
@@ -19,10 +20,8 @@ type secretCreateCommand struct {
 	cmd.CommandBase
 	ctx Context
 
-	id             string
 	asBase64       bool
 	rotateInterval time.Duration
-	staged         bool
 	description    string
 	tags           map[string]string
 	data           map[string]string
@@ -45,16 +44,16 @@ encoding will be performed, otherwise the values will be base64 encoded
 prior to being stored.
 
 Examples:
-    secret-create apitoken 34ae35facd4
-    secret-create --base64 password AA==
-    secret-create --rotate 24h password s3cret 
+    secret-create 34ae35facd4
+    secret-create --base64 AA==
+    secret-create --rotate 24h s3cret 
     secret-create --tag foo=bar --tag hello=world \
         --description "my database password" \
-        password s3cret 
+        s3cret 
 `
 	return jujucmd.Info(&cmd.Info{
 		Name:    "secret-create",
-		Args:    "<id> [value|key=value...]",
+		Args:    "[value|key=value...]",
 		Purpose: "create a new secret",
 		Doc:     doc,
 	})
@@ -64,8 +63,6 @@ Examples:
 func (c *secretCreateCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.asBase64, "base64", false,
 		`specify the supplied values are base64 encoded strings`)
-	f.BoolVar(&c.staged, "staged", false,
-		"specify whether the secret should be staged rather than active")
 	f.DurationVar(&c.rotateInterval, "rotate", 0, "how often the secret should be rotated")
 	f.StringVar(&c.description, "description", "", "the secret description")
 	f.Var(cmd.StringMap{&c.tags}, "tag", "tag to apply to the secret")
@@ -74,33 +71,23 @@ func (c *secretCreateCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init implements cmd.Command.
 func (c *secretCreateCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.New("missing secret name")
-	}
-	if len(args) < 2 {
 		return errors.New("missing secret value")
 	}
 	if c.rotateInterval < 0 {
 		return errors.NotValidf("rotate interval %q", c.rotateInterval)
 	}
-	c.id = args[0]
 
 	var err error
-	c.data, err = secrets.CreatSecretData(c.asBase64, args[1:])
+	c.data, err = secrets.CreatSecretData(c.asBase64, args)
 	return err
 }
 
 // Run implements cmd.Command.
 func (c *secretCreateCommand) Run(ctx *cmd.Context) error {
 	value := secrets.NewSecretValue(c.data)
-	status := secrets.StatusActive
-	if c.staged {
-		status = secrets.StatusStaged
-	}
-	id, err := c.ctx.CreateSecret(c.id, &SecretUpsertArgs{
-		Type:           secrets.TypeBlob,
+	id, err := c.ctx.CreateSecret(&SecretUpsertArgs{
 		Value:          value,
 		RotateInterval: &c.rotateInterval,
-		Status:         &status,
 		Description:    &c.description,
 		Tags:           &c.tags,
 	})

--- a/worker/uniter/runner/jujuc/secret-get.go
+++ b/worker/uniter/runner/jujuc/secret-get.go
@@ -20,7 +20,7 @@ type secretGetCommand struct {
 	ctx Context
 	out cmd.Output
 
-	secretUrl *secrets.URL
+	secretUri *secrets.URI
 	asBase64  bool
 }
 
@@ -74,7 +74,7 @@ func (c *secretGetCommand) Init(args []string) (err error) {
 	if len(args) < 1 {
 		return errors.New("missing secret name")
 	}
-	c.secretUrl, err = secrets.ParseURL(args[0])
+	c.secretUri, err = secrets.ParseURI(args[0])
 	if err != nil {
 		return errors.NotValidf("secret URL %q", args[0])
 	}
@@ -83,7 +83,7 @@ func (c *secretGetCommand) Init(args []string) (err error) {
 
 // Run implements cmd.Command.
 func (c *secretGetCommand) Run(ctx *cmd.Context) error {
-	value, err := c.ctx.GetSecret(c.secretUrl.String())
+	value, err := c.ctx.GetSecret(c.secretUri.String())
 	if err != nil {
 		return err
 	}
@@ -94,11 +94,7 @@ func (c *secretGetCommand) Run(ctx *cmd.Context) error {
 			val, _ = value.EncodedValue()
 		} else {
 			valMap := value.EncodedValues()
-			if c.secretUrl.Attribute != "" {
-				val = valMap[c.secretUrl.Attribute]
-			} else {
-				val = valMap
-			}
+			val = valMap
 		}
 	} else {
 		if value.Singular() {
@@ -111,11 +107,7 @@ func (c *secretGetCommand) Run(ctx *cmd.Context) error {
 			if err != nil {
 				return err
 			}
-			if c.secretUrl.Attribute != "" {
-				val = valMap[c.secretUrl.Attribute]
-			} else {
-				val = valMap
-			}
+			val = valMap
 		}
 	}
 	return c.out.Write(ctx, val)

--- a/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-get_test.go
@@ -31,10 +31,10 @@ func (s *SecretGetSuite) TestSecretGetSingularString(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "s3cret!\n")
 }
@@ -48,10 +48,10 @@ func (s *SecretGetSuite) TestSecretGetStringJson(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password", "--format", "json"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "--format", "json"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `{"key":"s3cret!"}`+"\n")
 }
@@ -65,10 +65,10 @@ func (s *SecretGetSuite) TestSecretGetSingularEncoded(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password", "--base64"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "--base64"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "czNjcmV0IQ==\n")
 }
@@ -83,10 +83,10 @@ func (s *SecretGetSuite) TestSecretGet(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
 cert: cert
@@ -104,31 +104,13 @@ func (s *SecretGetSuite) TestSecretGetEncoded(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password", "--base64"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "--base64"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
 cert: Y2VydA==
 key: a2V5
 `[1:])
-}
-
-func (s *SecretGetSuite) TestSecretGetAttribute(c *gc.C) {
-	hctx, _ := s.ContextSuite.NewHookContext()
-	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
-		"cert": base64.StdEncoding.EncodeToString([]byte("cert")),
-		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
-	})
-
-	com, err := jujuc.NewCommand(hctx, "secret-get")
-	c.Assert(err, jc.ErrorIsNil)
-	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret://app/mariadb/password#cert"})
-	c.Assert(code, gc.Equals, 0)
-
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret://app/mariadb/password#cert"}}})
-	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, "cert\n")
 }

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -83,7 +83,7 @@ func constructCommandCreator(name string, newCmd functionCmdCreator) creator {
 }
 
 var secretCommands = map[string]creator{
-	"secret-create": NewSecretCreateCommand,
+	"secret-add":    NewSecretAddCommand,
 	"secret-update": NewSecretUpdateCommand,
 	"secret-get":    NewSecretGetCommand,
 	"secret-grant":  NewSecretGrantCommand,

--- a/worker/uniter/secrets/rotatesecrets.go
+++ b/worker/uniter/secrets/rotatesecrets.go
@@ -50,7 +50,7 @@ func (s *secretsResolver) NextOp(
 	url := remoteState.SecretRotations[0]
 	op, err := opFactory.NewRunHook(hook.Info{
 		Kind:      hooks.SecretRotate,
-		SecretURL: url,
+		SecretURI: url,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/worker/uniter/secrets/rotatesecrets.go
+++ b/worker/uniter/secrets/rotatesecrets.go
@@ -47,16 +47,16 @@ func (s *secretsResolver) NextOp(
 		return nil, resolver.ErrNoOperation
 	}
 
-	url := remoteState.SecretRotations[0]
+	uri := remoteState.SecretRotations[0]
 	op, err := opFactory.NewRunHook(hook.Info{
 		Kind:      hooks.SecretRotate,
-		SecretURI: url,
+		SecretURI: uri,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	opCompleted := func() {
-		s.rotatedSecrets(url)
+		s.rotatedSecrets(uri)
 	}
 	return &secretCompleter{op, opCompleted}, nil
 }

--- a/worker/uniter/secrets/rotatesecrets_test.go
+++ b/worker/uniter/secrets/rotatesecrets_test.go
@@ -62,7 +62,7 @@ func (s *rotateSecretsSuite) TestNextOpNotInstalled(c *gc.C) {
 			Kind: operation.Continue,
 		},
 	}
-	s.remoteState.SecretRotations = []string{"secret://app/mariadb/password"}
+	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
@@ -75,7 +75,7 @@ func (s *rotateSecretsSuite) TestNextOpNotLeader(c *gc.C) {
 		},
 	}
 	s.remoteState.Leader = false
-	s.remoteState.SecretRotations = []string{"secret://app/mariadb/password"}
+	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
@@ -88,7 +88,7 @@ func (s *rotateSecretsSuite) TestNextOpNotAlive(c *gc.C) {
 		},
 	}
 	s.remoteState.Life = life.Dying
-	s.remoteState.SecretRotations = []string{"secret://app/mariadb/password"}
+	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
@@ -100,7 +100,7 @@ func (s *rotateSecretsSuite) TestNextOpNotReady(c *gc.C) {
 			Installed: true,
 		},
 	}
-	s.remoteState.SecretRotations = []string{"secret://app/mariadb/password"}
+	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
@@ -115,10 +115,10 @@ func (s *rotateSecretsSuite) TestNextOpRotate(c *gc.C) {
 			Installed: true,
 		},
 	}
-	s.remoteState.SecretRotations = []string{"secret://app/mariadb/password"}
+	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(op.String(), gc.Equals, "run secret-rotate (secret://app/mariadb/password) hook")
+	c.Assert(op.String(), gc.Equals, "run secret-rotate (secret:9m4e2mr0ui3e8a215n4g) hook")
 }
 
 func (s *rotateSecretsSuite) TestRotateCommit(c *gc.C) {
@@ -131,7 +131,7 @@ func (s *rotateSecretsSuite) TestRotateCommit(c *gc.C) {
 			Installed: true,
 		},
 	}
-	s.remoteState.SecretRotations = []string{"secret://app/mariadb/password"}
+	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 	var rotatedURL string
 	s.rotatedSecret = func(url string) {
 		rotatedURL = url
@@ -141,18 +141,18 @@ func (s *rotateSecretsSuite) TestRotateCommit(c *gc.C) {
 
 	hi := hook.Info{
 		Kind:      hooks.SecretRotate,
-		SecretURL: "secret://app/mariadb/password",
+		SecretURI: "secret:9m4e2mr0ui3e8a215n4g",
 	}
 	s.mockCallbacks.EXPECT().CommitHook(hi).Return(nil)
 	now := time.Now()
-	s.mockCallbacks.EXPECT().SetSecretRotated("secret://app/mariadb/password", gomock.Any()).DoAndReturn(
+	s.mockCallbacks.EXPECT().SetSecretRotated("secret:9m4e2mr0ui3e8a215n4g", gomock.Any()).DoAndReturn(
 		func(url string, when time.Time) error {
-			c.Assert(url, gc.Equals, "secret://app/mariadb/password")
+			c.Assert(url, gc.Equals, "secret:9m4e2mr0ui3e8a215n4g")
 			c.Assert(when.After(now), jc.IsTrue)
 			return nil
 		},
 	)
 	_, err = op.Commit(operation.State{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rotatedURL, gc.Equals, "secret://app/mariadb/password")
+	c.Assert(rotatedURL, gc.Equals, "secret:9m4e2mr0ui3e8a215n4g")
 }

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -973,7 +973,7 @@ func (u *Uniter) reportHookError(hookInfo hook.Info) error {
 		}
 	}
 	if hookInfo.Kind.IsSecret() {
-		statusData["secret-url"] = hookInfo.SecretURL
+		statusData["secret-uri"] = hookInfo.SecretURI
 	}
 	statusData["hook"] = hookName
 	statusMessage := fmt.Sprintf("hook failed: %q", hookMessage)

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/agent/tools"
-	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
@@ -466,8 +465,8 @@ func (s *UniterSuite) TestUniterRotateSecretHook(c *gc.C) {
 			createUniter{},
 			waitHooks(startupHooks(false)),
 			waitUnitAgent{status: status.Idle},
-			createSecret{"app/u/password"},
-			rotateSecret{secrets.NewURI().ShortString()},
+			createSecret{},
+			rotateSecret{},
 			waitHooks{"secret-rotate"},
 		),
 	})

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -467,7 +467,7 @@ func (s *UniterSuite) TestUniterRotateSecretHook(c *gc.C) {
 			waitHooks(startupHooks(false)),
 			waitUnitAgent{status: status.Idle},
 			createSecret{"app/u/password"},
-			rotateSecret{secrets.NewSimpleURL("app/u/password").ID()},
+			rotateSecret{secrets.NewURI().ShortString()},
 			waitHooks{"secret-rotate"},
 		),
 	})

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -130,10 +130,11 @@ type testContext struct {
 	application            *state.Application
 	unit                   *state.Unit
 	uniter                 *uniter.Uniter
-	relatedSvc             *state.Application
+	relatedApplication     *state.Application
 	relation               *state.Relation
 	relationUnits          map[string]*state.RelationUnit
 	subordinate            *state.Unit
+	createdSecretURI       string
 	updateStatusHookTicker *manualTicker
 	containerNames         []string
 	pebbleClients          map[string]*fakePebbleClient
@@ -1157,8 +1158,8 @@ func (s addRelation) step(c *gc.C, ctx *testContext) {
 	if ctx.relation != nil {
 		panic("don't add two relations!")
 	}
-	if ctx.relatedSvc == nil {
-		ctx.relatedSvc = ctx.s.AddTestingApplication(c, "mysql", ctx.s.AddTestingCharm(c, "mysql"))
+	if ctx.relatedApplication == nil {
+		ctx.relatedApplication = ctx.s.AddTestingApplication(c, "mysql", ctx.s.AddTestingCharm(c, "mysql"))
 	}
 	eps, err := ctx.st.InferEndpoints(ctx.application.Name(), "mysql")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1192,7 +1193,7 @@ func (s addRelation) step(c *gc.C, ctx *testContext) {
 type addRelationUnit struct{}
 
 func (s addRelationUnit) step(c *gc.C, ctx *testContext) {
-	u, err := ctx.relatedSvc.AddUnit(state.AddUnitParams{})
+	u, err := ctx.relatedApplication.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := ctx.relation.Unit(u)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1641,27 +1642,24 @@ func (s verifyStorageDetached) step(c *gc.C, ctx *testContext) {
 	c.Assert(storageAttachments, gc.HasLen, 0)
 }
 
-type createSecret struct {
-	secretPath string
-}
+type createSecret struct{}
 
 func (s createSecret) step(c *gc.C, ctx *testContext) {
 	hr := time.Hour
-	_, err := ctx.secretsFacade.Create(&secrets.SecretConfig{
+	uri, err := ctx.secretsFacade.Create(&secrets.SecretConfig{
 		RotateInterval: &hr,
 	}, secrets.NewSecretValue(map[string]string{"foo": "bar"}))
 	c.Assert(err, jc.ErrorIsNil)
+	ctx.createdSecretURI = uri
 }
 
-type rotateSecret struct {
-	secretURL string
-}
+type rotateSecret struct{}
 
 func (s rotateSecret) step(c *gc.C, ctx *testContext) {
 	select {
-	case ctx.secretsRotateCh <- []string{s.secretURL}:
+	case ctx.secretsRotateCh <- []string{ctx.createdSecretURI}:
 	case <-time.After(coretesting.LongWait):
-		c.Fatalf("sending rotate secret change for %q", s.secretURL)
+		c.Fatalf("sending rotate secret change for %q", ctx.createdSecretURI)
 	}
 }
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1647,12 +1647,9 @@ type createSecret struct {
 
 func (s createSecret) step(c *gc.C, ctx *testContext) {
 	hr := time.Hour
-	active := secrets.StatusActive
 	_, err := ctx.secretsFacade.Create(&secrets.SecretConfig{
-		Path:           s.secretPath,
 		RotateInterval: &hr,
-		Status:         &active,
-	}, secrets.TypeBlob, secrets.NewSecretValue(map[string]string{"foo": "bar"}))
+	}, secrets.NewSecretValue(map[string]string{"foo": "bar"}))
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
Initial refactor of secrets based on new spec. This PR introduces the new URI format with the resulting changes woven through the various api layers. Next PRs will continue the refactoring.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [X] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

boostrap and deploy a charm, eg ubuntu
```
$ juju exec --unit ubuntu/0 "secret-add --tag foo=bar --description blah secret!"
secret:cbm3aqfnuod28tu36h50
$ juju secrets
URI                          Revision  Rotate  Backend  Age
secret:cbm3aqfnuod28tu36h50         1  never   juju     5 seconds ago  
$ juju exec --unit ubuntu/0 "secret-get secret:cbm3aqfnuod28tu36h50"
secret!
```
