### PR TITLE
[ck test] increase teardown timeout to 60m

### DIFF
--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -71,6 +71,6 @@ test_deploy_ck() {
 
 		run "run_deploy_caas_workload"
 
-		destroy_model "${run_deploy_ck_name}" 45m
+		destroy_model "${run_deploy_ck_name}" 60m
 	)
 }


### PR DESCRIPTION
CK test is still timing out during teardown. Looks like #14415 was not enough.