### PR TITLE
[ck test] redirect ec2 -> aws

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -182,6 +182,10 @@ while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
 		if [[ -z ${PROVIDER} ]]; then
 			PROVIDER="${CLOUD}"
 		fi
+		# We want "ec2" to redirect to "aws". This is needed e.g. for the ck tests
+		if [[ ${PROVIDER} == "ec2" ]]; then
+			PROVIDER="aws"
+		fi
 		export BOOTSTRAP_PROVIDER="${PROVIDER}"
 		export BOOTSTRAP_CLOUD="${CLOUD}"
 		;;


### PR DESCRIPTION
When running the ck tests locally (with a pre-bootstrapped aws controller), they were failing with the error:
```
ERROR cannot deploy bundle: unable to process overlays: "./tests/suites/ck/overlay/ec2.yaml" not found
```
Essentially, the bootstrap provider was being set to `ec2` rather than `aws`, based on the output of
```console
$ juju clouds
Cloud         Regions  Default    Type  Credentials  Source    Description
aws           22       us-east-1  ec2   1            public    Amazon Web Services
```
Hence it was trying to find `./tests/suites/ck/overlay/ec2.yaml` and it couldn't - it should be looking for `./tests/suites/ck/overlay/aws.yaml`. This PR inserts a small check inside the `-l` flag parsing local to make sure it is set to `aws` instead.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
./main.sh -v ck
```