### PR TITLE
[ck test] kill controller afterwards

### DIFF
--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -2,7 +2,7 @@ run_deploy_ck() {
 	echo
 
 	local name model_name file overlay_path kube_home storage_path
-	name="${2}"
+	name="deploy-ck"
 	model_name="${name}"
 	file="${TEST_DIR}/${model_name}.log"
 
@@ -52,8 +52,6 @@ run_deploy_caas_workload() {
 
 	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current'
 	wait_for "active" '.applications["mediawiki-k8s"] | ."application-status".current'
-
-	destroy_model "${model_name}"
 }
 
 test_deploy_ck() {
@@ -66,11 +64,8 @@ test_deploy_ck() {
 		set_verbosity
 
 		cd .. || exit
-		local run_deploy_ck_name="deploy-ck"
-		run "run_deploy_ck" "${run_deploy_ck_name}"
 
+		run "run_deploy_ck"
 		run "run_deploy_caas_workload"
-
-		destroy_model "${run_deploy_ck_name}" 60m
 	)
 }

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -18,5 +18,6 @@ test_ck() {
 
 	test_deploy_ck
 
-	destroy_controller "test-ck"
+	# CK takes too long to tear down (1h+), so forcibly destroy it
+	juju kill-controller -y -t 0s "test-ck" || true
 }


### PR DESCRIPTION
CK test teardown is still timing out after an hour. Instead we will forcibly remove the controller with `juju kill-controller`.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
cd tests
./main.sh -v ck
```