### PR TITLE
Update secret hook commands for new syntax

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38628,6 +38628,9 @@
                 "CreateSecretArg": {
                     "type": "object",
                     "properties": {
+                        "UpsertSecretArg": {
+                            "$ref": "#/definitions/UpsertSecretArg"
+                        },
                         "data": {
                             "type": "object",
                             "patternProperties": {
@@ -38639,6 +38642,16 @@
                         "description": {
                             "type": "string"
                         },
+                        "expiry": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
                         "params": {
                             "type": "object",
                             "patternProperties": {
@@ -38648,21 +38661,16 @@
                                 }
                             }
                         },
-                        "rotate-interval": {
-                            "type": "integer"
-                        },
-                        "tags": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
+                        "rotate-policy": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "rotate-interval"
+                        "rotate-policy",
+                        "expiry",
+                        "UpsertSecretArg",
+                        "owner-tag"
                     ]
                 },
                 "CreateSecretArgs": {
@@ -38938,6 +38946,9 @@
                 "UpdateSecretArg": {
                     "type": "object",
                     "properties": {
+                        "UpsertSecretArg": {
+                            "$ref": "#/definitions/UpsertSecretArg"
+                        },
                         "data": {
                             "type": "object",
                             "patternProperties": {
@@ -38949,6 +38960,13 @@
                         "description": {
                             "type": "string"
                         },
+                        "expiry": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
                         "params": {
                             "type": "object",
                             "patternProperties": {
@@ -38958,16 +38976,8 @@
                                 }
                             }
                         },
-                        "rotate-interval": {
-                            "type": "integer"
-                        },
-                        "tags": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
+                        "rotate-policy": {
+                            "type": "string"
                         },
                         "uri": {
                             "type": "string"
@@ -38975,8 +38985,10 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "uri",
-                        "rotate-interval"
+                        "rotate-policy",
+                        "expiry",
+                        "UpsertSecretArg",
+                        "uri"
                     ]
                 },
                 "UpdateSecretArgs": {
@@ -38992,6 +39004,46 @@
                     "additionalProperties": false,
                     "required": [
                         "args"
+                    ]
+                },
+                "UpsertSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "expiry": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "rotate-policy",
+                        "expiry"
                     ]
                 }
             }

--- a/core/secrets/createsecret.go
+++ b/core/secrets/createsecret.go
@@ -5,56 +5,82 @@ package secrets
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"regexp"
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/v3"
+	"gopkg.in/yaml.v2"
 )
+
+var keyRegExp = regexp.MustCompile("^([a-z](?:-?[a-z0-9]){2,})$")
 
 // SecretData holds secret key values.
 type SecretData map[string]string
 
-// CreatSecretData creates a secret data bag from a list of arguments.
-// The arguments are either all key=value or a singular value.
-// If base64 is true, then the supplied value(s) are already base64 encoded,
-// otherwise the values are base64 encoded as they are added to the data bag.
-func CreatSecretData(asBase64 bool, args []string) (SecretData, error) {
+// CreateSecretData creates a secret data bag from a list of arguments.
+// If a key has the #base64 suffix, then the value is already base64 encoded,
+// otherwise the value is base64 encoded as it is added to the data bag.
+func CreateSecretData(args []string) (SecretData, error) {
 	data := make(SecretData)
-	haveSingularalue := false
-	for i, val := range args {
+	for _, val := range args {
 		// Remove any base64 padding ("=") before splitting the key=value.
 		stripped := strings.TrimRight(val, string(base64.StdPadding))
 		idx := strings.Index(stripped, "=")
-		keyVal := []string{val}
-		if idx > 0 {
-			keyVal = []string{
-				val[0:idx],
-				val[idx+1:],
-			}
+		if idx < 1 {
+			return nil, errors.NotValidf("key value %q", val)
 		}
-
-		var (
-			key   string
-			value string
-		)
-		if len(keyVal) == 1 {
-			if i > 0 {
-				return nil, errors.NewNotValid(nil, fmt.Sprintf("singular value %q not valid when other key values are specified", val))
-			}
-			key = singularSecretKey
-			value = keyVal[0]
-			haveSingularalue = true
-		} else {
-			key = keyVal[0]
-			value = keyVal[1]
+		keyVal := []string{
+			val[0:idx],
+			val[idx+1:],
 		}
-		if haveSingularalue && i > 0 {
-			return nil, errors.NewNotValid(nil, fmt.Sprintf("key value %q not valid when a singular value has already been specified", val))
-		}
-		if !asBase64 {
-			value = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v", value)))
-		}
+		key := keyVal[0]
+		value := keyVal[1]
 		data[key] = value
 	}
-	return data, nil
+	return encodeBase64(data)
+}
+
+// ReadSecretData reads secret data from a YAML or JSON file as key value pairs.
+func ReadSecretData(f string) (SecretData, error) {
+	attrs := make(SecretData)
+	path, err := utils.NormalizePath(f)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err := json.Unmarshal(data, &attrs); err != nil {
+		err = yaml.Unmarshal(data, &attrs)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	return encodeBase64(attrs)
+}
+
+const base64Suffix = "#base64"
+
+func encodeBase64(in SecretData) (SecretData, error) {
+	out := make(SecretData, len(in))
+	for k, v := range in {
+		if strings.HasSuffix(k, base64Suffix) {
+			k = strings.TrimSuffix(k, base64Suffix)
+			if !keyRegExp.MatchString(k) {
+				return nil, errors.NotValidf("key %q", k)
+			}
+			out[k] = v
+			continue
+		}
+		if !keyRegExp.MatchString(k) {
+			return nil, errors.NotValidf("key %q", k)
+		}
+		out[k] = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v", v)))
+	}
+	return out, nil
 }

--- a/core/secrets/rotate.go
+++ b/core/secrets/rotate.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets
+
+// RotatePolicy defines a policy for how often
+// to rotate a secret.
+type RotatePolicy string
+
+const (
+	RotateHourly      = RotatePolicy("hourly")
+	RotateDaily       = RotatePolicy("daily")
+	RotateWeekly      = RotatePolicy("weekly")
+	RotateHalfMonthly = RotatePolicy("half-monthly")
+	RotateMonthly     = RotatePolicy("monthly")
+	RotateQuarterly   = RotatePolicy("quarterly")
+	RotateHalfYearly  = RotatePolicy("half-yearly")
+	RotateYearly      = RotatePolicy("yearly")
+)
+
+// IsValid returns true if v is a valid rotate policy.
+func IsValid(v string) bool {
+	switch RotatePolicy(v) {
+	case RotateHourly, RotateDaily, RotateWeekly, RotateHalfMonthly,
+		RotateMonthly, RotateQuarterly, RotateHalfYearly,
+		RotateYearly:
+		return true
+	}
+	return false
+}

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -16,10 +16,11 @@ import (
 
 // SecretConfig is used when creating a secret.
 type SecretConfig struct {
-	RotateInterval *time.Duration
-	Description    *string
-	Tags           *map[string]string
-	Params         map[string]interface{}
+	RotatePolicy *RotatePolicy
+	Expiry       *time.Time
+	Description  *string
+	Label        *string
+	Params       map[string]interface{}
 }
 
 // URI represents a reference to a secret.

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -5,7 +5,26 @@ package params
 
 import (
 	"time"
+
+	"github.com/juju/juju/core/secrets"
 )
+
+// UpsertSecretArg holds the args for creating or updating a secret.
+type UpsertSecretArg struct {
+	// RotatePolicy is how often a secret should be rotated.
+	RotatePolicy *secrets.RotatePolicy `json:"rotate-policy"`
+	// Expiry is when a secret should expire.
+	Expiry *time.Time `json:"expiry"`
+	// Description represents the secret's description.
+	Description *string `json:"description,omitempty"`
+	// Tags are the secret tags.
+	Label *string `json:"label,omitempty"`
+	// Params are used when generating secrets server side.
+	// See core/secrets/secret.go.
+	Params map[string]interface{} `json:"params,omitempty"`
+	// Data is the key values of the secret value itself.
+	Data map[string]string `json:"data,omitempty"`
+}
 
 // CreateSecretArgs holds args for creating secrets.
 type CreateSecretArgs struct {
@@ -14,17 +33,10 @@ type CreateSecretArgs struct {
 
 // CreateSecretArg holds the args for creating a secret.
 type CreateSecretArg struct {
-	// RotateInterval is how often a secret should be rotated.
-	RotateInterval time.Duration `json:"rotate-interval"`
-	// Description represents the secret's description.
-	Description string `json:"description,omitempty"`
-	// Params are used when generating secrets server side.
-	// See core/secrets/secret.go.
-	Params map[string]interface{} `json:"params,omitempty"`
-	// Tags are the secret tags.
-	Tags map[string]string `json:"tags,omitempty"`
-	// Data is the key values of the secret value itself.
-	Data map[string]string `json:"data,omitempty"`
+	UpsertSecretArg
+
+	// OwnerTag is the owner of the secret.
+	OwnerTag string `json:"owner-tag"`
 }
 
 // UpdateSecretArgs holds args for creating secrets.
@@ -34,20 +46,10 @@ type UpdateSecretArgs struct {
 
 // UpdateSecretArg holds the args for creating a secret.
 type UpdateSecretArg struct {
-	// URL identifies the secret to update.
+	UpsertSecretArg
+
+	// URI identifies the secret to update.
 	URI string `json:"uri"`
-	// RotateInterval is how often a secret should be rotated.
-	RotateInterval *time.Duration `json:"rotate-interval"`
-	// Description represents the secret's description.
-	Description *string `json:"description,omitempty"`
-	// Tags are the secret tags.
-	Tags *map[string]string `json:"tags,omitempty"`
-	// Params are used when generating secrets server side.
-	// See core/secrets/secret.go.
-	Params map[string]interface{} `json:"params,omitempty"`
-	// Data is the key values of the secret value itself.
-	// Use an empty value to keep the current value.
-	Data map[string]string `json:"data,omitempty"`
 }
 
 // GetSecretArgs holds the args for getting secrets.

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -97,10 +97,10 @@ func (hi Info) Validate() error {
 		return nil
 	case hooks.SecretRotate:
 		if hi.SecretURI == "" {
-			return errors.Errorf("%q hook requires a secret URL", hi.Kind)
+			return errors.Errorf("%q hook requires a secret URI", hi.Kind)
 		}
 		if _, err := secrets.ParseURI(hi.SecretURI); err != nil {
-			return errors.Errorf("invalid secret URL %q", hi.SecretURI)
+			return errors.Errorf("invalid secret URI %q", hi.SecretURI)
 		}
 		return nil
 	}

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -51,10 +51,10 @@ var validateTests = []struct {
 		`"pre-series-upgrade" hook requires a target series`,
 	}, {
 		hook.Info{Kind: hooks.SecretRotate},
-		`"secret-rotate" hook requires a secret URL`,
+		`"secret-rotate" hook requires a secret URI`,
 	}, {
 		hook.Info{Kind: hooks.SecretRotate, SecretURI: "foo"},
-		`invalid secret URL "foo"`,
+		`invalid secret URI "foo"`,
 	},
 	{hook.Info{Kind: hooks.Install}, ""},
 	{hook.Info{Kind: hooks.Start}, ""},

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -89,7 +89,7 @@ type Snapshot struct {
 	// executed by this unit.
 	Commands []string
 
-	// SecretRotations is a list of secret URLs that need to be rotated.
+	// SecretRotations is a list of secret URIs that need to be rotated.
 	SecretRotations []string
 
 	// UpgradeSeriesStatus is the preparation status of

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -742,19 +742,25 @@ func (ctx *HookContext) GetSecret(name string) (coresecrets.SecretValue, error) 
 // CreateSecret creates a secret with the specified data.
 func (ctx *HookContext) CreateSecret(args *jujuc.SecretUpsertArgs) (string, error) {
 	cfg := &coresecrets.SecretConfig{
-		RotateInterval: args.RotateInterval,
-		Description:    args.Description,
-		Tags:           args.Tags,
+		Expiry:       args.Expiry,
+		RotatePolicy: args.RotatePolicy,
+		Description:  args.Description,
+		Label:        args.Label,
 	}
-	return ctx.secretFacade.Create(cfg, args.Value)
+	appName, err := names.UnitApplication(ctx.unitName)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return ctx.secretFacade.Create(cfg, names.NewApplicationTag(appName), args.Value)
 }
 
 // UpdateSecret creates a secret with the specified data.
 func (ctx *HookContext) UpdateSecret(uri string, args *jujuc.SecretUpsertArgs) error {
 	cfg := &coresecrets.SecretConfig{
-		RotateInterval: args.RotateInterval,
-		Description:    args.Description,
-		Tags:           args.Tags,
+		Expiry:       args.Expiry,
+		RotatePolicy: args.RotatePolicy,
+		Description:  args.Description,
+		Label:        args.Label,
 	}
 	return ctx.secretFacade.Update(uri, cfg, args.Value)
 }
@@ -1397,12 +1403,12 @@ func (ctx *HookContext) WorkloadName() (string, error) {
 	return ctx.workloadName, nil
 }
 
-// SecretURI returns the secret URL for secret hooks.
+// SecretURI returns the secret URI for secret hooks.
 // This is not yet used by any hook commands - it is exported
 // for tests to use.
 func (ctx *HookContext) SecretURI() (string, error) {
 	if ctx.secretURI == "" {
-		return "", errors.NotFoundf("secret URL")
+		return "", errors.NotFoundf("secret URI")
 	}
 	return ctx.secretURI, nil
 }

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -171,13 +171,13 @@ type SecretUpsertArgs struct {
 	Value secrets.SecretValue
 
 	// RotateInterval is the new rotate interval or nil to not update.
-	RotateInterval *time.Duration
+	RotatePolicy *secrets.RotatePolicy
+	Expiry       *time.Time
 
 	// Description describes the secret or nil to not update.
 	Description *string
 
-	// Tags are stored with the secret metadata or nil to not update.
-	Tags *map[string]string
+	Label *string
 }
 
 // SecretGrantRevokeArgs specify the args used to grant or revoke access to a secret.

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -16,81 +16,141 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 )
 
-type secretAddCommand struct {
+type secretUpsertCommand struct {
 	cmd.CommandBase
 	ctx Context
 
-	asBase64       bool
-	rotateInterval time.Duration
-	description    string
-	tags           map[string]string
-	data           map[string]string
+	rotatePolicy string
+	description  string
+	label        string
+	fileName     string
+
+	expireSpec string
+	expireTime time.Time
+
+	data map[string]string
+}
+
+type secretAddCommand struct {
+	secretUpsertCommand
 }
 
 // NewSecretAddCommand returns a command to add a secret.
 func NewSecretAddCommand(ctx Context) (cmd.Command, error) {
 	return &secretAddCommand{
-		ctx:            ctx,
-		rotateInterval: -1,
+		secretUpsertCommand{ctx: ctx},
 	}, nil
 }
 
 // Info implements cmd.Command.
 func (c *secretAddCommand) Info() *cmd.Info {
 	doc := `
-Add a secret with either a single value or a list of key values.
-If --base64 is specified, the values are already in base64 format and no
-encoding will be performed, otherwise the values will be base64 encoded
+Add a secret with a list of key values.
+If a value has the '#base64' suffix, it is already in base64 format and no
+encoding will be performed, otherwise the value will be base64 encoded
 prior to being stored.
 
 Examples:
-    secret-add 34ae35facd4
-    secret-add --base64 AA==
-    secret-add --rotate 24h s3cret 
-    secret-add --tag foo=bar --tag hello=world \
+    secret-add token=34ae35facd4
+    secret-add key#base64 AA==
+    secret-add --rotate monthly token=s3cret 
+    secret-add --expire 24h token=s3cret 
+    secret-add --expire 2025-01-01T06:06:06 token=s3cret 
+    secret-add --label db-password \
         --description "my database password" \
-        s3cret 
+        data#base64 s3cret== 
+    secret-add --label db-password \
+        --description "my database password" \
+        --file=/path/to/file
 `
 	return jujucmd.Info(&cmd.Info{
 		Name:    "secret-add",
-		Args:    "[value|key=value...]",
+		Args:    "[key[#base64]=value...]",
 		Purpose: "add a new secret",
 		Doc:     doc,
 	})
 }
 
 // SetFlags implements cmd.Command.
-func (c *secretAddCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.asBase64, "base64", false,
-		`specify the supplied values are base64 encoded strings`)
-	f.DurationVar(&c.rotateInterval, "rotate", 0, "how often the secret should be rotated")
+func (c *secretUpsertCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.expireSpec, "expire", "", "either a duration or time when the secret should expire")
+	f.StringVar(&c.rotatePolicy, "rotate", "", "the secret rotation policy")
 	f.StringVar(&c.description, "description", "", "the secret description")
-	f.Var(cmd.StringMap{&c.tags}, "tag", "tag to apply to the secret")
+	f.StringVar(&c.label, "label", "", "a label used to identify the secret in hooks")
+	f.StringVar(&c.fileName, "file", "", "a YAML file containing secret key values")
+}
+
+const rcf3339NoTZ = "2006-01-02T15:04:05"
+
+// Init implements cmd.Command.
+func (c *secretUpsertCommand) Init(args []string) error {
+	if c.expireSpec != "" {
+		expireTime, err := time.Parse(time.RFC3339, c.expireSpec)
+		if err != nil {
+			expireTime, err = time.Parse(rcf3339NoTZ, c.expireSpec)
+		}
+		if err != nil {
+			d, err := time.ParseDuration(c.expireSpec)
+			if err != nil {
+				return errors.NotValidf("expire time or duration %q", c.expireSpec)
+			}
+			if d <= 0 {
+				return errors.NotValidf("negative expire duration %q", c.expireSpec)
+			}
+			expireTime = time.Now().Add(d)
+		}
+		c.expireTime = expireTime.UTC()
+	}
+	if c.rotatePolicy != "" && !secrets.IsValid(c.rotatePolicy) {
+		return errors.NotValidf("rotate policy %q", c.rotatePolicy)
+	}
+	var err error
+	c.data, err = secrets.CreateSecretData(args)
+	if err != nil || c.fileName == "" {
+		return errors.Trace(err)
+	}
+	dataFromFile, err := secrets.ReadSecretData(c.fileName)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for k, v := range dataFromFile {
+		c.data[k] = v
+	}
+	return nil
+}
+
+func (c *secretUpsertCommand) marshallArg() *SecretUpsertArgs {
+	value := secrets.NewSecretValue(c.data)
+	arg := &SecretUpsertArgs{
+		Value: value,
+	}
+	if c.rotatePolicy != "" {
+		p := secrets.RotatePolicy(c.rotatePolicy)
+		arg.RotatePolicy = &p
+	}
+	if !c.expireTime.IsZero() {
+		arg.Expiry = &c.expireTime
+	}
+	if c.description != "" {
+		arg.Description = &c.description
+	}
+	if c.label != "" {
+		arg.Label = &c.label
+	}
+	return arg
 }
 
 // Init implements cmd.Command.
 func (c *secretAddCommand) Init(args []string) error {
-	if len(args) < 1 {
-		return errors.New("missing secret value")
+	if len(args) < 1 && c.fileName == "" {
+		return errors.New("missing secret value or filename")
 	}
-	if c.rotateInterval < 0 {
-		return errors.NotValidf("rotate interval %q", c.rotateInterval)
-	}
-
-	var err error
-	c.data, err = secrets.CreatSecretData(c.asBase64, args)
-	return err
+	return c.secretUpsertCommand.Init(args)
 }
 
 // Run implements cmd.Command.
 func (c *secretAddCommand) Run(ctx *cmd.Context) error {
-	value := secrets.NewSecretValue(c.data)
-	id, err := c.ctx.CreateSecret(&SecretUpsertArgs{
-		Value:          value,
-		RotateInterval: &c.rotateInterval,
-		Description:    &c.description,
-		Tags:           &c.tags,
-	})
+	id, err := c.ctx.CreateSecret(c.marshallArg())
 	if err != nil {
 		return err
 	}

--- a/worker/uniter/runner/jujuc/secret-get.go
+++ b/worker/uniter/runner/jujuc/secret-get.go
@@ -76,7 +76,7 @@ func (c *secretGetCommand) Init(args []string) (err error) {
 	}
 	c.secretUri, err = secrets.ParseURI(args[0])
 	if err != nil {
-		return errors.NotValidf("secret URL %q", args[0])
+		return errors.NotValidf("secret URI %q", args[0])
 	}
 	return cmd.CheckEmpty(args[1:])
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1642,13 +1642,18 @@ func (s verifyStorageDetached) step(c *gc.C, ctx *testContext) {
 	c.Assert(storageAttachments, gc.HasLen, 0)
 }
 
-type createSecret struct{}
+type createSecret struct {
+	applicationName string
+}
 
 func (s createSecret) step(c *gc.C, ctx *testContext) {
-	hr := time.Hour
+	if s.applicationName == "" {
+		s.applicationName = "u"
+	}
+	expiry := time.Now()
 	uri, err := ctx.secretsFacade.Create(&secrets.SecretConfig{
-		RotateInterval: &hr,
-	}, secrets.NewSecretValue(map[string]string{"foo": "bar"}))
+		Expiry: &expiry,
+	}, names.NewApplicationTag(s.applicationName), secrets.NewSecretValue(map[string]string{"foo": "bar"}))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx.createdSecretURI = uri
 }


### PR DESCRIPTION
This PR is the first of several which will update the secret hook commands to conform to the approved syntax.
The front end is wired up but the apiserver side is still todo.
The create and update commands are done. Still todo is get and remove.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

None yet - more PRs needed.

