### PR TITLE
Fix controller name in ck test teardown

### DIFF
--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -18,6 +18,8 @@ test_ck() {
 
 	test_deploy_ck
 
-	# CK takes too long to tear down (1h+), so forcibly destroy it
-	juju kill-controller -y -t 0s "test-ck" || true
+	if [[ ${BOOTSTRAP_REUSE:-} != "true" ]]; then
+		# CK takes too long to tear down (1h+), so forcibly destroy it
+		juju kill-controller -y -t 0 "${BOOTSTRAPPED_JUJU_CTRL_NAME}" || true
+	fi
 }


### PR DESCRIPTION
A small fix to use the correct controller name in ck test teardown.

## QA steps

```sh
./main.sh ck
```


