### PR TITLE
Kill controller at end of ck test

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -376,7 +376,11 @@ destroy_controller() {
 	output="${TEST_DIR}/${name}-destroy-controller.log"
 
 	echo "====> Destroying juju ($(green "${name}"))"
-	echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+	if [[ ${KILL_CONTROLLER:-} != "true" ]]; then
+		echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+	else
+		echo "${name}" | xargs -I % juju kill-controller -t 0 -y % >"${output}" 2>&1
+	fi
 
 	set +e
 	CHK=$(cat "${output}" | grep -i "ERROR" || true)

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -18,8 +18,6 @@ test_ck() {
 
 	test_deploy_ck
 
-	if [[ ${BOOTSTRAP_REUSE:-} != "true" ]]; then
-		# CK takes too long to tear down (1h+), so forcibly destroy it
-		juju kill-controller -y -t 0 "${BOOTSTRAPPED_JUJU_CTRL_NAME}" || true
-	fi
+	# CK takes too long to tear down (1h+), so forcibly destroy it
+	export KILL_CONTROLLER=true
 }


### PR DESCRIPTION
Add support to allow a bash integration test to ask for the controller to be killed.
Used in the ck test as it takes too long to tear down.

## QA steps

`./main.sh ck`
