### PR TITLE
Wireup revised secrets model backend

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -41,7 +41,7 @@ func (c *Client) Create(cfg *secrets.SecretConfig, ownerTag names.Tag, value sec
 		OwnerTag: ownerTag.String(),
 		UpsertSecretArg: params.UpsertSecretArg{
 			RotatePolicy: cfg.RotatePolicy,
-			Expiry:       cfg.Expiry,
+			ExpireTime:   cfg.ExpireTime,
 			Description:  cfg.Description,
 			Label:        cfg.Label,
 			Params:       cfg.Params,
@@ -83,7 +83,7 @@ func (c *Client) Update(uri string, cfg *secrets.SecretConfig, value secrets.Sec
 		URI: secretUri.String(),
 		UpsertSecretArg: params.UpsertSecretArg{
 			RotatePolicy: cfg.RotatePolicy,
-			Expiry:       cfg.Expiry,
+			ExpireTime:   cfg.ExpireTime,
 			Description:  cfg.Description,
 			Label:        cfg.Label,
 			Params:       cfg.Params,

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -48,7 +48,7 @@ func (s *SecretsSuite) TestCreateSecret(c *gc.C) {
 				OwnerTag: "application-mysql",
 				UpsertSecretArg: params.UpsertSecretArg{
 					RotatePolicy: ptr(secrets.RotateDaily),
-					Expiry:       ptr(expiry),
+					ExpireTime:   ptr(expiry),
 					Description:  ptr("my secret"),
 					Label:        ptr("foo"),
 					Params: map[string]interface{}{
@@ -71,7 +71,7 @@ func (s *SecretsSuite) TestCreateSecret(c *gc.C) {
 	value := secrets.NewSecretValue(data)
 	cfg := &secrets.SecretConfig{
 		RotatePolicy: ptr(secrets.RotateDaily),
-		Expiry:       ptr(expiry),
+		ExpireTime:   ptr(expiry),
 		Description:  ptr("my secret"),
 		Label:        ptr("foo"),
 		Params: map[string]interface{}{
@@ -113,7 +113,7 @@ func (s *SecretsSuite) TestUpdateSecret(c *gc.C) {
 				URI: "secret:9m4e2mr0ui3e8a215n4g",
 				UpsertSecretArg: params.UpsertSecretArg{
 					RotatePolicy: ptr(secrets.RotateDaily),
-					Expiry:       ptr(expiry),
+					ExpireTime:   ptr(expiry),
 					Description:  ptr("my secret"),
 					Label:        ptr("foo"),
 					Params: map[string]interface{}{
@@ -134,7 +134,7 @@ func (s *SecretsSuite) TestUpdateSecret(c *gc.C) {
 	value := secrets.NewSecretValue(data)
 	cfg := &secrets.SecretConfig{
 		RotatePolicy: ptr(secrets.RotateDaily),
-		Expiry:       ptr(expiry),
+		ExpireTime:   ptr(expiry),
 		Description:  ptr("my secret"),
 		Label:        ptr("foo"),
 		Params: map[string]interface{}{

--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -44,13 +44,15 @@ func (api *Client) ListSecrets(showSecrets bool) ([]SecretDetails, error) {
 	for i, r := range response.Results {
 		details := SecretDetails{
 			Metadata: secrets.SecretMetadata{
-				RotateInterval: r.RotateInterval,
 				Version:        r.Version,
-				Description:    r.Description,
 				OwnerTag:       r.OwnerTag,
-				Tags:           r.Tags,
 				Provider:       r.Provider,
 				ProviderID:     r.ProviderID,
+				Description:    r.Description,
+				Label:          r.Label,
+				RotatePolicy:   secrets.RotatePolicy(r.RotatePolicy),
+				NextRotateTime: r.NextRotateTime,
+				ExpireTime:     r.ExpireTime,
 				Revision:       r.Revision,
 				CreateTime:     r.CreateTime,
 				UpdateTime:     r.UpdateTime,

--- a/api/client/secrets/client_test.go
+++ b/api/client/secrets/client_test.go
@@ -30,6 +30,10 @@ func (s *SecretsSuite) TestNewClient(c *gc.C) {
 	c.Assert(client, gc.NotNil)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 	data := map[string]string{"foo": "bar"}
 	now := time.Now()
@@ -46,13 +50,15 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			[]params.ListSecretResult{{
 				URI:            uri.String(),
-				RotateInterval: time.Hour,
 				Version:        1,
-				Description:    "shhh",
 				OwnerTag:       "application-mysql",
-				Tags:           map[string]string{"foo": "bar"},
 				Provider:       "juju",
 				ProviderID:     "provider-id",
+				RotatePolicy:   string(secrets.RotateHourly),
+				ExpireTime:     ptr(now),
+				NextRotateTime: ptr(now.Add(time.Hour)),
+				Description:    "shhh",
+				Label:          "foobar",
 				Revision:       2,
 				CreateTime:     now,
 				UpdateTime:     now.Add(time.Second),
@@ -67,13 +73,15 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, []apisecrets.SecretDetails{{
 		Metadata: secrets.SecretMetadata{
 			URI:            uri,
-			RotateInterval: time.Hour,
 			Version:        1,
-			Description:    "shhh",
 			OwnerTag:       "application-mysql",
-			Tags:           map[string]string{"foo": "bar"},
 			Provider:       "juju",
 			ProviderID:     "provider-id",
+			RotatePolicy:   secrets.RotateHourly,
+			ExpireTime:     ptr(now),
+			NextRotateTime: ptr(now.Add(time.Hour)),
+			Description:    "shhh",
+			Label:          "foobar",
 			Revision:       2,
 			CreateTime:     now,
 			UpdateTime:     now.Add(time.Second),

--- a/apiserver/facades/agent/secretsmanager/mocks/secretservice.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretservice.go
@@ -111,7 +111,7 @@ func (mr *MockSecretsServiceMockRecorder) ListSecrets(arg0, arg1 interface{}) *g
 }
 
 // UpdateSecret mocks base method.
-func (m *MockSecretsService) UpdateSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secrets0.UpdateParams) (*secrets.SecretMetadata, error) {
+func (m *MockSecretsService) UpdateSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secrets0.UpsertParams) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*secrets.SecretMetadata)

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -6,6 +6,7 @@ package secretsmanager
 import (
 	"testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/names/v4"
 	gc "gopkg.in/check.v1"
 
@@ -31,6 +32,7 @@ func NewTestAPI(
 	secretsRotation SecretsRotation,
 	accessSecret common.GetAuthFunc,
 	ownerTag names.Tag,
+	clock clock.Clock,
 ) (*SecretsManagerAPI, error) {
 	if !authorizer.AuthUnitAgent() && !authorizer.AuthApplicationAgent() {
 		return nil, apiservererrors.ErrPerm
@@ -44,5 +46,6 @@ func NewTestAPI(
 		secretsService:  service,
 		secretsRotation: secretsRotation,
 		accessSecret:    accessSecret,
+		clock:           clock,
 	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -6,6 +6,7 @@ package secretsmanager
 import (
 	"reflect"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -51,5 +52,6 @@ func newSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		resources:       context.Resources(),
 		secretsRotation: context.State(),
 		accessSecret:    secretAccessor(agentName),
+		clock:           clock.WallClock,
 	}, nil
 }

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -69,13 +69,15 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 	for i, m := range metadata {
 		secretResult := params.ListSecretResult{
 			URI:            m.URI.String(),
-			RotateInterval: m.RotateInterval,
 			Version:        m.Version,
-			Description:    m.Description,
 			OwnerTag:       m.OwnerTag,
-			Tags:           m.Tags,
 			Provider:       m.Provider,
 			ProviderID:     m.ProviderID,
+			Description:    m.Description,
+			Label:          m.Label,
+			RotatePolicy:   string(m.RotatePolicy),
+			NextRotateTime: m.NextRotateTime,
+			ExpireTime:     m.ExpireTime,
 			Revision:       m.Revision,
 			CreateTime:     m.CreateTime,
 			UpdateTime:     m.UpdateTime,

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -55,6 +55,10 @@ func (s *SecretsSuite) TestListSecretsShow(c *gc.C) {
 	s.assertListSecrets(c, true)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	defer s.setup(c).Finish()
 
@@ -75,13 +79,15 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	metadata := []*coresecrets.SecretMetadata{{
 		URI:            uri,
-		RotateInterval: time.Hour,
 		Version:        1,
-		Description:    "shhh",
 		OwnerTag:       "application-mysql",
-		Tags:           map[string]string{"foo": "bar"},
 		Provider:       "juju",
 		ProviderID:     "abcd",
+		RotatePolicy:   coresecrets.RotateHourly,
+		ExpireTime:     ptr(now),
+		NextRotateTime: ptr(now.Add(time.Hour)),
+		Description:    "shhh",
+		Label:          "foobar",
 		Revision:       2,
 		CreateTime:     now,
 		UpdateTime:     now.Add(time.Second),
@@ -105,13 +111,15 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, show bool) {
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
 			URI:            uri.String(),
-			RotateInterval: time.Hour,
 			Version:        1,
-			Description:    "shhh",
 			OwnerTag:       "application-mysql",
-			Tags:           map[string]string{"foo": "bar"},
 			Provider:       "juju",
 			ProviderID:     "abcd",
+			RotatePolicy:   string(coresecrets.RotateHourly),
+			ExpireTime:     ptr(now),
+			NextRotateTime: ptr(now.Add(time.Hour)),
+			Description:    "shhh",
+			Label:          "foobar",
 			Revision:       2,
 			CreateTime:     now,
 			UpdateTime:     now.Add(time.Second),

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38454,6 +38454,17 @@
                         "description": {
                             "type": "string"
                         },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "next-rotate-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
                         "owner-tag": {
                             "type": "string"
                         },
@@ -38466,16 +38477,8 @@
                         "revision": {
                             "type": "integer"
                         },
-                        "rotate-interval": {
-                            "type": "integer"
-                        },
-                        "tags": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
+                        "rotate-policy": {
+                            "type": "string"
                         },
                         "update-time": {
                             "type": "string",
@@ -38495,7 +38498,6 @@
                     "required": [
                         "uri",
                         "version",
-                        "rotate-interval",
                         "owner-tag",
                         "provider",
                         "revision",
@@ -38642,7 +38644,7 @@
                         "description": {
                             "type": "string"
                         },
-                        "expiry": {
+                        "expire-time": {
                             "type": "string",
                             "format": "date-time"
                         },
@@ -38667,8 +38669,6 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "rotate-policy",
-                        "expiry",
                         "UpsertSecretArg",
                         "owner-tag"
                     ]
@@ -38960,7 +38960,7 @@
                         "description": {
                             "type": "string"
                         },
-                        "expiry": {
+                        "expire-time": {
                             "type": "string",
                             "format": "date-time"
                         },
@@ -38985,8 +38985,6 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "rotate-policy",
-                        "expiry",
                         "UpsertSecretArg",
                         "uri"
                     ]
@@ -39020,7 +39018,7 @@
                         "description": {
                             "type": "string"
                         },
-                        "expiry": {
+                        "expire-time": {
                             "type": "string",
                             "format": "date-time"
                         },
@@ -39040,11 +39038,7 @@
                             "type": "string"
                         }
                     },
-                    "additionalProperties": false,
-                    "required": [
-                        "rotate-policy",
-                        "expiry"
-                    ]
+                    "additionalProperties": false
                 }
             }
         }

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -94,19 +94,21 @@ type secretValueDetails struct {
 }
 
 type secretDisplayDetails struct {
-	URI            string              `json:"URI" yaml:"URI"`
-	Revision       int                 `json:"revision" yaml:"revision"`
-	RotateInterval time.Duration       `json:"rotate-interval,omitempty" yaml:"rotate-interval,omitempty"`
-	Version        int                 `json:"version" yaml:"version"`
-	Description    string              `json:"description,omitempty" yaml:"description,omitempty"`
-	Owner          string              `json:"owner,omitempty" yaml:"owner,omitempty"`
-	Tags           map[string]string   `json:"tags,omitempty" yaml:"tags,omitempty"`
-	Provider       string              `json:"backend" yaml:"backend"`
-	ProviderID     string              `json:"backend-id,omitempty" yaml:"backend-id,omitempty"`
-	CreateTime     time.Time           `json:"create-time" yaml:"create-time"`
-	UpdateTime     time.Time           `json:"update-time" yaml:"update-time"`
-	Error          string              `json:"error,omitempty" yaml:"error,omitempty"`
-	Value          *secretValueDetails `json:"value,omitempty" yaml:"value,omitempty"`
+	URI            string               `json:"URI" yaml:"URI"`
+	Version        int                  `json:"version" yaml:"version"`
+	Owner          string               `json:"owner,omitempty" yaml:"owner,omitempty"`
+	Provider       string               `json:"backend" yaml:"backend"`
+	ProviderID     string               `json:"backend-id,omitempty" yaml:"backend-id,omitempty"`
+	Revision       int                  `json:"revision" yaml:"revision"`
+	Description    string               `json:"description,omitempty" yaml:"description,omitempty"`
+	Label          string               `json:"label,omitempty" yaml:"label,omitempty"`
+	RotatePolicy   secrets.RotatePolicy `json:"rotate-policy,omitempty" yaml:"rotate-policy,omitempty"`
+	NextRotateTime *time.Time           `json:"next-rotate-time,omitempty" yaml:"next-rotate-time,omitempty"`
+	ExpireTime     *time.Time           `json:"expire-time,omitempty" yaml:"expire-time,omitempty"`
+	CreateTime     time.Time            `json:"create-time" yaml:"create-time"`
+	UpdateTime     time.Time            `json:"update-time" yaml:"update-time"`
+	Error          string               `json:"error,omitempty" yaml:"error,omitempty"`
+	Value          *secretValueDetails  `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Run implements cmd.Run.
@@ -134,13 +136,15 @@ func (c *listSecretsCommand) Run(ctxt *cmd.Context) error {
 		}
 		details[i] = secretDisplayDetails{
 			URI:            m.Metadata.URI.ShortString(),
-			RotateInterval: m.Metadata.RotateInterval,
 			Version:        m.Metadata.Version,
-			Description:    m.Metadata.Description,
 			Owner:          ownerId,
-			Tags:           m.Metadata.Tags,
 			Provider:       m.Metadata.Provider,
 			ProviderID:     m.Metadata.ProviderID,
+			Description:    m.Metadata.Description,
+			Label:          m.Metadata.Label,
+			RotatePolicy:   m.Metadata.RotatePolicy,
+			NextRotateTime: m.Metadata.NextRotateTime,
+			ExpireTime:     m.Metadata.ExpireTime,
 			Revision:       m.Metadata.Revision,
 			CreateTime:     m.Metadata.CreateTime,
 			UpdateTime:     m.Metadata.UpdateTime,
@@ -178,7 +182,7 @@ func formatSecretsTabular(writer io.Writer, value interface{}) error {
 	now := time.Now()
 	for _, s := range secrets {
 		age := common.UserFriendlyDuration(s.UpdateTime, now)
-		w.Print(s.URI, s.Revision, common.HumaniseInterval(s.RotateInterval), s.Provider, age)
+		w.Print(s.URI, s.Revision, s.RotatePolicy, s.Provider, age)
 		w.Println()
 	}
 	return tw.Flush()

--- a/cmd/juju/secrets/list_test.go
+++ b/cmd/juju/secrets/list_test.go
@@ -5,7 +5,6 @@ package secrets_test
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -52,7 +51,7 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 	s.secretsAPI.EXPECT().ListSecrets(false).Return(
 		[]apisecrets.SecretDetails{{
 			Metadata: coresecrets.SecretMetadata{
-				URI: uri, RotateInterval: time.Hour,
+				URI: uri, RotatePolicy: coresecrets.RotateHourly,
 				Revision: 2, Provider: "juju"},
 		}, {
 			Metadata: coresecrets.SecretMetadata{
@@ -66,7 +65,7 @@ func (s *ListSuite) TestListTabular(c *gc.C) {
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
 URI                          Revision  Rotate  Backend  Age
-%s         2  1h      juju     0001-01-01  
+%s         2  hourly  juju     0001-01-01  
 %s         1  never   juju     0001-01-01  
 `[1:], uri.ShortString(), uri2.ShortString()))
 }
@@ -79,11 +78,11 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 	s.secretsAPI.EXPECT().ListSecrets(true).Return(
 		[]apisecrets.SecretDetails{{
 			Metadata: coresecrets.SecretMetadata{
-				URI: uri, RotateInterval: time.Hour,
+				URI: uri, RotatePolicy: coresecrets.RotateHourly,
 				Version: 1, Revision: 2, Provider: "juju",
 				Description: "my secret",
 				OwnerTag:    "application-mysql",
-				Tags:        map[string]string{"foo": "bar"},
+				Label:       "foobar",
 			},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
 		}, {
@@ -99,22 +98,21 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
 - URI: %s
-  revision: 2
-  rotate-interval: 1h0m0s
   version: 1
-  description: my secret
   owner: mysql
-  tags:
-    foo: bar
   backend: juju
+  revision: 2
+  description: my secret
+  label: foobar
+  rotate-policy: hourly
   create-time: 0001-01-01T00:00:00Z
   update-time: 0001-01-01T00:00:00Z
   value:
     foo: bar
 - URI: %s
-  revision: 1
   version: 1
   backend: juju
+  revision: 1
   create-time: 0001-01-01T00:00:00Z
   update-time: 0001-01-01T00:00:00Z
   error: boom
@@ -139,6 +137,6 @@ func (s *ListSuite) TestListJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-[{"URI":"%s","revision":2,"version":1,"backend":"juju","create-time":"0001-01-01T00:00:00Z","update-time":"0001-01-01T00:00:00Z","value":{"Data":{"foo":"bar"}}}]
+[{"URI":"%s","version":1,"backend":"juju","revision":2,"create-time":"0001-01-01T00:00:00Z","update-time":"0001-01-01T00:00:00Z","value":{"Data":{"foo":"bar"}}}]
 `[1:], uri.ShortString()))
 }

--- a/core/secrets/rotate.go
+++ b/core/secrets/rotate.go
@@ -3,11 +3,14 @@
 
 package secrets
 
+import "time"
+
 // RotatePolicy defines a policy for how often
 // to rotate a secret.
 type RotatePolicy string
 
 const (
+	RotateNever       = RotatePolicy("never")
 	RotateHourly      = RotatePolicy("hourly")
 	RotateDaily       = RotatePolicy("daily")
 	RotateWeekly      = RotatePolicy("weekly")
@@ -18,13 +21,55 @@ const (
 	RotateYearly      = RotatePolicy("yearly")
 )
 
+func (p RotatePolicy) String() string {
+	if p == "" {
+		return string(RotateNever)
+	}
+	return string(p)
+}
+
 // IsValid returns true if v is a valid rotate policy.
-func IsValid(v string) bool {
-	switch RotatePolicy(v) {
-	case RotateHourly, RotateDaily, RotateWeekly, RotateHalfMonthly,
+func (p RotatePolicy) IsValid() bool {
+	switch p {
+	case RotateNever, RotateHourly, RotateDaily, RotateWeekly, RotateHalfMonthly,
 		RotateMonthly, RotateQuarterly, RotateHalfYearly,
 		RotateYearly:
 		return true
 	}
 	return false
+}
+
+// NextRotateTime returns when the policy dictates a secret should be next
+// rotated given the last rotation time.
+func (p RotatePolicy) NextRotateTime(lastRotateTime *time.Time) *time.Time {
+	now := time.Now()
+	var lastRotated = now
+	if lastRotateTime != nil {
+		lastRotated = *lastRotateTime
+	}
+	var result time.Time
+	switch p {
+	case RotateNever:
+		return nil
+	case RotateHourly:
+		result = lastRotated.Add(time.Hour)
+	case RotateDaily:
+		result = lastRotated.AddDate(0, 0, 1)
+	case RotateWeekly:
+		result = lastRotated.AddDate(0, 0, 7)
+	case RotateHalfMonthly:
+		result = lastRotated.AddDate(0, 0, 14)
+	case RotateMonthly:
+		result = lastRotated.AddDate(0, 1, 0)
+	case RotateQuarterly:
+		result = lastRotated.AddDate(0, 3, 0)
+	case RotateHalfYearly:
+		result = lastRotated.AddDate(0, 6, 0)
+	case RotateYearly:
+		result = lastRotated.AddDate(1, 0, 0)
+	}
+	if result.Before(now) {
+		result = now
+	}
+	return &result
 }

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -17,7 +17,7 @@ import (
 // SecretConfig is used when creating a secret.
 type SecretConfig struct {
 	RotatePolicy *RotatePolicy
-	Expiry       *time.Time
+	ExpireTime   *time.Time
 	Description  *string
 	Label        *string
 	Params       map[string]interface{}
@@ -126,9 +126,10 @@ type SecretMetadata struct {
 	Version int
 
 	// These can be updated after creation.
-	Description    string
-	Tags           map[string]string
-	RotateInterval time.Duration
+	Description  string
+	Label        string
+	RotatePolicy RotatePolicy
+	ExpireTime   *time.Time
 
 	// Set by service on creation/update.
 
@@ -142,6 +143,7 @@ type SecretMetadata struct {
 	// secret value is changed.
 	Revision int
 
-	CreateTime time.Time
-	UpdateTime time.Time
+	NextRotateTime *time.Time
+	CreateTime     time.Time
+	UpdateTime     time.Time
 }

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -12,9 +12,9 @@ import (
 // UpsertSecretArg holds the args for creating or updating a secret.
 type UpsertSecretArg struct {
 	// RotatePolicy is how often a secret should be rotated.
-	RotatePolicy *secrets.RotatePolicy `json:"rotate-policy"`
-	// Expiry is when a secret should expire.
-	Expiry *time.Time `json:"expiry"`
+	RotatePolicy *secrets.RotatePolicy `json:"rotate-policy,omitempty"`
+	// ExpireTime is when a secret should expire.
+	ExpireTime *time.Time `json:"expire-time,omitempty"`
 	// Description represents the secret's description.
 	Description *string `json:"description,omitempty"`
 	// Tags are the secret tags.
@@ -87,12 +87,14 @@ type ListSecretResults struct {
 type ListSecretResult struct {
 	URI            string             `json:"uri"`
 	Version        int                `json:"version"`
-	RotateInterval time.Duration      `json:"rotate-interval"`
-	Description    string             `json:"description,omitempty"`
 	OwnerTag       string             `json:"owner-tag"`
-	Tags           map[string]string  `json:"tags,omitempty"`
 	Provider       string             `json:"provider"`
 	ProviderID     string             `json:"provider-id,omitempty"`
+	RotatePolicy   string             `json:"rotate-policy,omitempty"`
+	NextRotateTime *time.Time         `json:"next-rotate-time,omitempty"`
+	ExpireTime     *time.Time         `json:"expire-time,omitempty"`
+	Description    string             `json:"description,omitempty"`
+	Label          string             `json:"label,omitempty"`
 	Revision       int                `json:"revision"`
 	CreateTime     time.Time          `json:"create-time"`
 	UpdateTime     time.Time          `json:"update-time"`

--- a/secrets/provider/juju/secrets.go
+++ b/secrets/provider/juju/secrets.go
@@ -37,15 +37,22 @@ func NewSecretService(cfg secrets.ProviderConfig) (*secretsService, error) {
 
 // CreateSecret implements SecretsService.
 func (s secretsService) CreateSecret(ctx context.Context, uri *coresecrets.URI, p secrets.CreateParams) (*coresecrets.SecretMetadata, error) {
+	if err := p.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	metadata, err := s.backend.CreateSecret(uri, state.CreateSecretParams{
-		ProviderLabel:  Provider,
-		Version:        p.Version,
-		Owner:          p.Owner,
-		RotateInterval: p.RotateInterval,
-		Description:    p.Description,
-		Tags:           p.Tags,
-		Params:         p.Params,
-		Data:           p.Data,
+		ProviderLabel: Provider,
+		Version:       p.Version,
+		Owner:         p.Owner,
+		UpdateSecretParams: state.UpdateSecretParams{
+			RotatePolicy:   p.RotatePolicy,
+			NextRotateTime: p.NextRotateTime,
+			ExpireTime:     p.ExpireTime,
+			Description:    p.Description,
+			Label:          p.Label,
+			Params:         p.Params,
+			Data:           p.Data,
+		},
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "saving secret metadata")
@@ -69,11 +76,16 @@ func (s secretsService) ListSecrets(ctx context.Context, filter secrets.Filter) 
 }
 
 // UpdateSecret implements SecretsService.
-func (s secretsService) UpdateSecret(ctx context.Context, uri *coresecrets.URI, p secrets.UpdateParams) (*coresecrets.SecretMetadata, error) {
+func (s secretsService) UpdateSecret(ctx context.Context, uri *coresecrets.URI, p secrets.UpsertParams) (*coresecrets.SecretMetadata, error) {
+	if err := p.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	metadata, err := s.backend.UpdateSecret(uri, state.UpdateSecretParams{
-		RotateInterval: p.RotateInterval,
+		RotatePolicy:   p.RotatePolicy,
+		NextRotateTime: p.NextRotateTime,
+		ExpireTime:     p.ExpireTime,
 		Description:    p.Description,
-		Tags:           p.Tags,
+		Label:          p.Label,
 		Params:         p.Params,
 		Data:           p.Data,
 	})

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -555,7 +555,7 @@ func allCollections() CollectionSchema {
 			}},
 		},
 
-		secretValuesC: {
+		secretRevisionsC: {
 			global: true,
 		},
 
@@ -676,7 +676,7 @@ const (
 	firewallRulesC       = "firewallRules"
 
 	// Secrets
-	secretMetadataC = "secretMetadata"
-	secretValuesC   = "secretValues"
-	secretRotateC   = "secretRotate"
+	secretMetadataC  = "secretMetadata"
+	secretRevisionsC = "secretRevisions"
+	secretRotateC    = "secretRotate"
 )

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1075,7 +1075,7 @@ func GetSecretRotateTime(c *gc.C, st *State, id string) time.Time {
 	var doc secretRotationDoc
 	err := secretRotateCollection.FindId(secretGlobalKey(id)).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
-	return doc.LastRotateTime
+	return doc.LastRotateTime.UTC()
 }
 
 // ModelBackendShim is required to live here in the export_test.go file because

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -217,7 +217,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// secrets
 		secretMetadataC,
-		secretValuesC,
+		secretRevisionsC,
 		secretRotateC,
 	)
 

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -742,7 +742,7 @@ func (ctx *HookContext) GetSecret(name string) (coresecrets.SecretValue, error) 
 // CreateSecret creates a secret with the specified data.
 func (ctx *HookContext) CreateSecret(args *jujuc.SecretUpsertArgs) (string, error) {
 	cfg := &coresecrets.SecretConfig{
-		Expiry:       args.Expiry,
+		ExpireTime:   args.ExpireTime,
 		RotatePolicy: args.RotatePolicy,
 		Description:  args.Description,
 		Label:        args.Label,
@@ -757,7 +757,7 @@ func (ctx *HookContext) CreateSecret(args *jujuc.SecretUpsertArgs) (string, erro
 // UpdateSecret creates a secret with the specified data.
 func (ctx *HookContext) UpdateSecret(uri string, args *jujuc.SecretUpsertArgs) error {
 	cfg := &coresecrets.SecretConfig{
-		Expiry:       args.Expiry,
+		ExpireTime:   args.ExpireTime,
 		RotatePolicy: args.RotatePolicy,
 		Description:  args.Description,
 		Label:        args.Label,

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -913,7 +913,7 @@ func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
 				OwnerTag: "application-wordpress",
 				UpsertSecretArg: params.UpsertSecretArg{
 					RotatePolicy: ptr(secrets.RotateDaily),
-					Expiry:       ptr(expiry),
+					ExpireTime:   ptr(expiry),
 					Description:  ptr("my secret"),
 					Label:        ptr("foo"),
 					Data:         data,
@@ -934,7 +934,7 @@ func (s *mockHookContextSuite) TestSecretCreate(c *gc.C) {
 	id, err := hookContext.CreateSecret(&jujuc.SecretUpsertArgs{
 		Value:        value,
 		RotatePolicy: ptr(secrets.RotateDaily),
-		Expiry:       ptr(expiry),
+		ExpireTime:   ptr(expiry),
 		Description:  ptr("my secret"),
 		Label:        ptr("foo"),
 	})
@@ -958,7 +958,7 @@ func (s *mockHookContextSuite) TestSecretUpdate(c *gc.C) {
 				URI: "secret:9m4e2mr0ui3e8a215n4g",
 				UpsertSecretArg: params.UpsertSecretArg{
 					RotatePolicy: ptr(secrets.RotateDaily),
-					Expiry:       ptr(expiry),
+					ExpireTime:   ptr(expiry),
 					Description:  ptr("my secret"),
 					Label:        ptr("foo"),
 					Data:         data,
@@ -979,7 +979,7 @@ func (s *mockHookContextSuite) TestSecretUpdate(c *gc.C) {
 	err := hookContext.UpdateSecret("secret:9m4e2mr0ui3e8a215n4g", &jujuc.SecretUpsertArgs{
 		Value:        value,
 		RotatePolicy: ptr(secrets.RotateDaily),
-		Expiry:       ptr(expiry),
+		ExpireTime:   ptr(expiry),
 		Description:  ptr("my secret"),
 		Label:        ptr("foo"),
 	})

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -166,18 +166,16 @@ type ContextUnit interface {
 }
 
 // SecretUpsertArgs specifies args used to create or update a secret.
+// Nil values are not included in the update.
 type SecretUpsertArgs struct {
 	// Value is the new secret value or nil to not update.
 	Value secrets.SecretValue
 
-	// RotateInterval is the new rotate interval or nil to not update.
 	RotatePolicy *secrets.RotatePolicy
-	Expiry       *time.Time
+	ExpireTime   *time.Time
 
-	// Description describes the secret or nil to not update.
 	Description *string
-
-	Label *string
+	Label       *string
 }
 
 // SecretGrantRevokeArgs specify the args used to grant or revoke access to a secret.

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -101,7 +101,7 @@ func (c *secretUpsertCommand) Init(args []string) error {
 		}
 		c.expireTime = expireTime.UTC()
 	}
-	if c.rotatePolicy != "" && !secrets.IsValid(c.rotatePolicy) {
+	if c.rotatePolicy != "" && !secrets.RotatePolicy(c.rotatePolicy).IsValid() {
 		return errors.NotValidf("rotate policy %q", c.rotatePolicy)
 	}
 	var err error
@@ -129,7 +129,7 @@ func (c *secretUpsertCommand) marshallArg() *SecretUpsertArgs {
 		arg.RotatePolicy = &p
 	}
 	if !c.expireTime.IsZero() {
-		arg.Expiry = &c.expireTime
+		arg.ExpireTime = &c.expireTime
 	}
 	if c.description != "" {
 		arg.Description = &c.description

--- a/worker/uniter/runner/jujuc/secret-add_test.go
+++ b/worker/uniter/runner/jujuc/secret-add_test.go
@@ -92,9 +92,9 @@ func (s *SecretAddSuite) TestAddSecretExpireDuration(c *gc.C) {
 	c.Assert(call.Args, gc.HasLen, 1)
 	args, ok := call.Args[0].(*jujuc.SecretUpsertArgs)
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(args.Expiry, gc.NotNil)
-	c.Assert(args.Expiry.After(expectedExpiry), jc.IsTrue)
-	args.Expiry = nil
+	c.Assert(args.ExpireTime, gc.NotNil)
+	c.Assert(args.ExpireTime.After(expectedExpiry), jc.IsTrue)
+	args.ExpireTime = nil
 	c.Assert(args, jc.DeepEquals, expectedArgs)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret:9m4e2mr0ui3e8a215n4g\n")
 }
@@ -122,7 +122,7 @@ func (s *SecretAddSuite) TestAddSecretExpireTimestamp(c *gc.C) {
 		RotatePolicy: ptr(coresecrets.RotateDaily),
 		Description:  ptr("sssshhhh"),
 		Label:        ptr("foobar"),
-		Expiry:       ptr(expectedExpiry),
+		ExpireTime:   ptr(expectedExpiry),
 	}
 	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "CreateSecret", Args: []interface{}{args}}})
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret:9m4e2mr0ui3e8a215n4g\n")

--- a/worker/uniter/runner/jujuc/secret-update_test.go
+++ b/worker/uniter/runner/jujuc/secret-update_test.go
@@ -91,9 +91,9 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 	c.Assert(call.Args[0], gc.Equals, "secret:9m4e2mr0ui3e8a215n4g")
 	args, ok := call.Args[1].(*jujuc.SecretUpsertArgs)
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(args.Expiry, gc.NotNil)
-	c.Assert(args.Expiry.After(expectedExpiry), jc.IsTrue)
-	args.Expiry = nil
+	c.Assert(args.ExpireTime, gc.NotNil)
+	c.Assert(args.ExpireTime.After(expectedExpiry), jc.IsTrue)
+	args.ExpireTime = nil
 	c.Assert(args, jc.DeepEquals, expectedArgs)
 }
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1642,6 +1642,10 @@ func (s verifyStorageDetached) step(c *gc.C, ctx *testContext) {
 	c.Assert(storageAttachments, gc.HasLen, 0)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 type createSecret struct {
 	applicationName string
 }
@@ -1650,9 +1654,8 @@ func (s createSecret) step(c *gc.C, ctx *testContext) {
 	if s.applicationName == "" {
 		s.applicationName = "u"
 	}
-	expiry := time.Now()
 	uri, err := ctx.secretsFacade.Create(&secrets.SecretConfig{
-		Expiry: &expiry,
+		RotatePolicy: ptr(secrets.RotateDaily),
 	}, names.NewApplicationTag(s.applicationName), secrets.NewSecretValue(map[string]string{"foo": "bar"}))
 	c.Assert(err, jc.ErrorIsNil)
 	ctx.createdSecretURI = uri


### PR DESCRIPTION
The secrets hook commands and API have been updated to use the revised secrets data model. This PR updates the apiserver and state layers to match. The secrets rotation backend still needs more work in followup PRs.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Check secret create, update, get.
Bootstrap and deploy ubuntu
```
$ juju exec --unit ubuntu/0 "secret-add --label foobar --description blah secret!"
secret:cbm3aqfnuod28tu36h50
$ juju secrets
URI                          Revision  Rotate  Backend  Age
secret:cbm3aqfnuod28tu36h50         1  never   juju     5 seconds ago  
$ juju exec --unit ubuntu/0 "secret-get secret:cbm3aqfnuod28tu36h50"
secret!
```
