### PR TITLE
[JUJU-1198] Rewrite to bash-based nw-destroy-model-lxd

### DIFF
--- a/tests/suites/model/destroy.sh
+++ b/tests/suites/model/destroy.sh
@@ -20,9 +20,12 @@ run_model_destroy() {
 	echo "Ensure current model is 'model-new'"
 	juju models --format json | jq -r '."current-model"' | check model-new
 
-	echo "Destroy model 'model-new'"
 	destroy_model "model-new"
-	juju switch :model-destroy
+	is_destroyed=$(juju models --format json | jq -r '.models[] | select(."short-name" == "model-new")')
+	if [[ -z ${is_destroyed} ]]; then is_destroyed=true; fi
+	check_contains "${is_destroyed}" true
+
+	juju switch model-destroy
 
 	echo "Ensure current model is 'model-destroy'"
 	juju models --format json | jq -r '."current-model"' | check model-destroy

--- a/tests/suites/model/destroy.sh
+++ b/tests/suites/model/destroy.sh
@@ -1,0 +1,46 @@
+# Tests if Juju tracks the model properly through deletion.
+#
+# In normal behavior Juju should drop the current model selection if that
+# model is destroyed. This will fail if Juju does not drop it's current
+# selection.
+run_model_destroy() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# The following ensures that a bootstrap juju exists.
+	file="${TEST_DIR}/test-model-destroy.log"
+	ensure "model-destroy" "${file}"
+
+	echo "Ensure current model is 'model-destroy'"
+	juju models --format json | jq -r '."current-model"' | check model-destroy
+
+	echo "Add new model 'model-new'"
+	juju add-model model-new
+
+	echo "Ensure current model is 'model-new'"
+	juju models --format json | jq -r '."current-model"' | check model-new
+
+	echo "Destroy model 'model-new'"
+	destroy_model "model-new"
+	juju switch :model-destroy
+
+	echo "Ensure current model is 'model-destroy'"
+	juju models --format json | jq -r '."current-model"' | check model-destroy
+
+	destroy_model "model-destroy"
+}
+
+test_model_destroy() {
+	if [ -n "$(skip 'test_model_destroy')" ]; then
+		echo "==> SKIP: Asked to skip model destroy tests"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_model_destroy"
+	)
+}

--- a/tests/suites/model/task.sh
+++ b/tests/suites/model/task.sh
@@ -18,6 +18,7 @@ test_model() {
 	test_model_migration
 	test_model_multi
 	test_model_metrics
+	test_model_destroy
 
 	destroy_controller "test-models"
 }


### PR DESCRIPTION
This patch adds destroy model test to the model suite in bash-based tests.

Original (python-based) tests live [here](https://github.com/juju/juju/blob/ac9ddcae708eca8ec2fd885a14fb27a291e424da/acceptancetests/assess_destroy_model.py).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
./main.sh -v -p lxd model test_model_destroy
```
