### PR TITLE
[JUJU-1570] Added agent-metadata-url and agent stream to pre_bootstrap

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -267,7 +267,7 @@ pre_bootstrap() {
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
 
-	if [[ -n ${SHORT_GIT_COMMIT:-} ]];  then
+	if [[ -n ${SHORT_GIT_COMMIT:-} ]]; then
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/ --config agent-stream=build-${SHORT_GIT_COMMIT}"
 	fi
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -266,6 +266,11 @@ pre_bootstrap() {
 		version=$(juju_version)
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
+
+	if [[ ${MODEL_ARCH:-} != "amd64" ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/ --config agent-stream=build-${SHORT_GIT_COMMIT}"
+	fi
+
 	echo "BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"
 }
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -267,7 +267,7 @@ pre_bootstrap() {
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
 
-	if [[ ${MODEL_ARCH:-} != "amd64" ]]; then
+	if [[ -n ${SHORT_GIT_COMMIT:-} ]];  then
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/ --config agent-stream=build-${SHORT_GIT_COMMIT}"
 	fi
 


### PR DESCRIPTION
This patch fixes "no matching agent binaries available" error in test-deploy suite (for arm64), by adding agent-metadata-url and agent stream to pre_bootstrap function in case of non-amd64 architecture in selected in MODEL_ARCH env var.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
TBW
```
