### PR TITLE
Update secret-get to use the new syntax

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -99,8 +99,12 @@ func (c *Client) Update(uri string, cfg *secrets.SecretConfig, value secrets.Sec
 }
 
 // GetValue returns the value of a secret.
-func (c *Client) GetValue(uri string) (secrets.SecretValue, error) {
-	arg := params.GetSecretArg{}
+func (c *Client) GetValue(uri, label string, update, peek bool) (secrets.SecretValue, error) {
+	arg := params.GetSecretArg{
+		Label:  label,
+		Update: update,
+		Peek:   peek,
+	}
 	secretUri, err := secrets.ParseURI(uri)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -169,7 +169,10 @@ func (s *SecretsSuite) TestGetSecret(c *gc.C) {
 		c.Check(request, gc.Equals, "GetSecretValues")
 		c.Check(arg, jc.DeepEquals, params.GetSecretArgs{
 			Args: []params.GetSecretArg{{
-				URI: "secret:9m4e2mr0ui3e8a215n4g",
+				URI:    "secret:9m4e2mr0ui3e8a215n4g",
+				Label:  "label",
+				Update: true,
+				Peek:   true,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretValueResults{})
@@ -181,7 +184,7 @@ func (s *SecretsSuite) TestGetSecret(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	result, err := client.GetValue("secret:9m4e2mr0ui3e8a215n4g")
+	result, err := client.GetValue("secret:9m4e2mr0ui3e8a215n4g", "label", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	value := secrets.NewSecretValue(map[string]string{"foo": "bar"})
 	c.Assert(result, jc.DeepEquals, value)
@@ -197,7 +200,7 @@ func (s *SecretsSuite) TestGetSecretsError(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	result, err := client.GetValue("secret:9m4e2mr0ui3e8a215n4g")
+	result, err := client.GetValue("secret:9m4e2mr0ui3e8a215n4g", "", true, true)
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(result, gc.IsNil)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38767,6 +38767,15 @@
                 "GetSecretArg": {
                     "type": "object",
                     "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "peek": {
+                            "type": "boolean"
+                        },
+                        "update": {
+                            "type": "boolean"
+                        },
                         "uri": {
                             "type": "string"
                         }

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -94,7 +94,7 @@ type secretValueDetails struct {
 }
 
 type secretDisplayDetails struct {
-	URI            string               `json:"URI" yaml:"URI"`
+	URI            string               `json:"uri" yaml:"uri"`
 	Version        int                  `json:"version" yaml:"version"`
 	Owner          string               `json:"owner,omitempty" yaml:"owner,omitempty"`
 	Provider       string               `json:"backend" yaml:"backend"`

--- a/cmd/juju/secrets/list_test.go
+++ b/cmd/juju/secrets/list_test.go
@@ -97,7 +97,7 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-- URI: %s
+- uri: %s
   version: 1
   owner: mysql
   backend: juju
@@ -109,7 +109,7 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
   update-time: 0001-01-01T00:00:00Z
   value:
     foo: bar
-- URI: %s
+- uri: %s
   version: 1
   backend: juju
   revision: 1
@@ -137,6 +137,6 @@ func (s *ListSuite) TestListJSON(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, fmt.Sprintf(`
-[{"URI":"%s","version":1,"backend":"juju","revision":2,"create-time":"0001-01-01T00:00:00Z","update-time":"0001-01-01T00:00:00Z","value":{"Data":{"foo":"bar"}}}]
+[{"uri":"%s","version":1,"backend":"juju","revision":2,"create-time":"0001-01-01T00:00:00Z","update-time":"0001-01-01T00:00:00Z","value":{"Data":{"foo":"bar"}}}]
 `[1:], uri.ShortString()))
 }

--- a/core/secrets/secretvalue_test.go
+++ b/core/secrets/secretvalue_test.go
@@ -27,10 +27,6 @@ func (s *SecretValueSuite) TestEncodedValues(c *gc.C) {
 		"a": base64.StdEncoding.EncodeToString([]byte("foo")),
 		"b": base64.StdEncoding.EncodeToString([]byte("1")),
 	})
-
-	c.Assert(val.Singular(), jc.IsFalse)
-	_, err := val.EncodedValue()
-	c.Assert(err, gc.ErrorMatches, "secret is not a singular value")
 }
 
 func (s *SecretValueSuite) TestValues(c *gc.C) {
@@ -46,30 +42,19 @@ func (s *SecretValueSuite) TestValues(c *gc.C) {
 		"a": "foo",
 		"b": "1",
 	})
-
-	_, err = val.Value()
-	c.Assert(err, gc.ErrorMatches, "secret is not a singular value")
 }
 
-func (s *SecretValueSuite) TestSingularValue(c *gc.C) {
+func (s *SecretValueSuite) TestKeyValue(c *gc.C) {
 	in := map[string]string{
-		"data": base64.StdEncoding.EncodeToString([]byte("foo")),
+		"a": base64.StdEncoding.EncodeToString([]byte("foo")),
+		"b": base64.StdEncoding.EncodeToString([]byte("1")),
 	}
 	val := secrets.NewSecretValue(in)
 
-	sval, err := val.Value()
+	v, err := val.KeyValue("a")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sval, gc.Equals, "foo")
-}
-
-func (s *SecretValueSuite) TestSingularEncodedValue(c *gc.C) {
-	in := map[string]string{
-		"data": base64.StdEncoding.EncodeToString([]byte("foo")),
-	}
-	val := secrets.NewSecretValue(in)
-	c.Assert(val.Singular(), jc.IsTrue)
-
-	bval, err := val.EncodedValue()
+	c.Assert(v, gc.Equals, "foo")
+	v, err = val.KeyValue("a#base64")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(bval, gc.Equals, in["data"])
+	c.Assert(v, gc.Equals, base64.StdEncoding.EncodeToString([]byte("foo")))
 }

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -59,7 +59,10 @@ type GetSecretArgs struct {
 
 // GetSecretArg holds the args for getting a secret.
 type GetSecretArg struct {
-	URI string `json:"uri"`
+	URI    string `json:"uri"`
+	Label  string `json:"label,omitempty"`
+	Update bool   `json:"update,omitempty"`
+	Peek   bool   `json:"peek,omitempty"`
 }
 
 // SecretValueResults holds secret value results.

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -731,8 +731,8 @@ func (ctx *HookContext) ConfigSettings() (charm.Settings, error) {
 }
 
 // GetSecret returns the value of the specified secret.
-func (ctx *HookContext) GetSecret(name string) (coresecrets.SecretValue, error) {
-	v, err := ctx.secretFacade.GetValue(name)
+func (ctx *HookContext) GetSecret(uri, label string, update, peek bool) (coresecrets.SecretValue, error) {
+	v, err := ctx.secretFacade.GetValue(uri, label, update, peek)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -872,7 +872,10 @@ func (s *mockHookContextSuite) TestSecretGet(c *gc.C) {
 		c.Assert(request, gc.Equals, "GetSecretValues")
 		c.Assert(arg, gc.DeepEquals, params.GetSecretArgs{
 			Args: []params.GetSecretArg{{
-				URI: "secret:9m4e2mr0ui3e8a215n4g",
+				URI:    "secret:9m4e2mr0ui3e8a215n4g",
+				Label:  "label",
+				Update: true,
+				Peek:   true,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretValueResults{})
@@ -886,7 +889,7 @@ func (s *mockHookContextSuite) TestSecretGet(c *gc.C) {
 	s.mockUnit.EXPECT().Tag().Return(names.NewUnitTag("wordpress/0")).Times(1)
 	client := secretsmanager.NewClient(apiCaller)
 	hookContext := context.NewMockUnitHookContextWithSecrets(s.mockUnit, client)
-	value, err := hookContext.GetSecret("secret:9m4e2mr0ui3e8a215n4g")
+	value, err := hookContext.GetSecret("secret:9m4e2mr0ui3e8a215n4g", "label", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(value.EncodedValues(), jc.DeepEquals, map[string]string{
 		"foo": "bar",

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -189,7 +189,7 @@ type SecretGrantRevokeArgs struct {
 // ContextSecrets is the part of a hook context related to secrets.
 type ContextSecrets interface {
 	// GetSecret returns the value of the specified secret.
-	GetSecret(string) (secrets.SecretValue, error)
+	GetSecret(string, string, bool, bool) (secrets.SecretValue, error)
 
 	// CreateSecret creates a secret with the specified data.
 	CreateSecret(args *SecretUpsertArgs) (string, error)

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -16,8 +16,8 @@ type ContextSecrets struct {
 }
 
 // GetSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) GetSecret(uri string) (secrets.SecretValue, error) {
-	c.stub.AddCall("GetSecret", uri)
+func (c *ContextSecrets) GetSecret(uri, label string, update, peek bool) (secrets.SecretValue, error) {
+	c.stub.AddCall("GetSecret", uri, label, update, peek)
 	return c.SecretValue, nil
 }
 

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -322,18 +322,18 @@ func (mr *MockContextMockRecorder) GetRawK8sSpec() *gomock.Call {
 }
 
 // GetSecret mocks base method.
-func (m *MockContext) GetSecret(arg0 string) (secrets.SecretValue, error) {
+func (m *MockContext) GetSecret(arg0, arg1 string, arg2, arg3 bool) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecret", arg0)
+	ret := m.ctrl.Call(m, "GetSecret", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(secrets.SecretValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecret indicates an expected call of GetSecret.
-func (mr *MockContextMockRecorder) GetSecret(arg0 interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0, arg1, arg2, arg3)
 }
 
 // GoalState mocks base method.

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -254,7 +254,7 @@ func (*RestrictedContext) WorkloadName() (string, error) {
 }
 
 // GetSecret implements runner.Context.
-func (ctx *RestrictedContext) GetSecret(string) (secrets.SecretValue, error) {
+func (ctx *RestrictedContext) GetSecret(string, string, bool, bool) (secrets.SecretValue, error) {
 	return nil, ErrRestrictedContext
 }
 

--- a/worker/uniter/runner/jujuc/secret-get.go
+++ b/worker/uniter/runner/jujuc/secret-get.go
@@ -4,9 +4,6 @@
 package jujuc
 
 import (
-	"fmt"
-	"io"
-
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -21,7 +18,10 @@ type secretGetCommand struct {
 	out cmd.Output
 
 	secretUri *secrets.URI
-	asBase64  bool
+	label     string
+	key       string
+	peek      bool
+	update    bool
 }
 
 // NewSecretGetCommand returns a command to get a secret value.
@@ -33,13 +33,25 @@ func NewSecretGetCommand(ctx Context) (cmd.Command, error) {
 func (c *secretGetCommand) Info() *cmd.Info {
 	doc := `
 Get the value of a secret with a given secret ID.
-For secrets with a singular value, the decoded string
-is printed, unless --base64 is specified, in which case
-the encoded base64 value is printed.
-Multiple key value secrets are printed as YAML.
+The first time the value is fetched, the latest revision is used.
+Subsequent calls will always return this same revision unless
+--peek or --update are used.
+Using --peek will fetch the latest revision just this time.
+Using --update will fetch the latest revision and continue to
+return the same revision next time unless --peek or --update is used.
+
+
+Examples
+    secret-get secret:9m4e2mr0ui3e8a215n4g
+    secret-get secret:9m4e2mr0ui3e8a215n4g token
+    secret-get secret:9m4e2mr0ui3e8a215n4g token#base64
+    secret-get secret:9m4e2mr0ui3e8a215n4g --format json
+    secret-get secret:9m4e2mr0ui3e8a215n4g --peek
+    secret-get secret:9m4e2mr0ui3e8a215n4g --update
+    secret-get secret:9m4e2mr0ui3e8a215n4g --label db-password
 `
 	return jujucmd.Info(&cmd.Info{
-		Name:    "secret-get",
+		Name:    "secret-get [key[#base64]]",
 		Args:    "<ID>",
 		Purpose: "get the value of a secret",
 		Doc:     doc,
@@ -48,67 +60,55 @@ Multiple key value secrets are printed as YAML.
 
 // SetFlags implements cmd.Command.
 func (c *secretGetCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "plain", map[string]cmd.Formatter{
-		"yaml":  cmd.FormatYaml,
-		"json":  cmd.FormatJson,
-		"plain": printPlainOutput,
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
 	})
-	f.BoolVar(&c.asBase64, "base64", false,
-		`print the singular secret value as the base64 encoded string`)
-}
-
-func printPlainOutput(writer io.Writer, val interface{}) error {
-	var str string
-	switch v := val.(type) {
-	case string:
-		str = v
-	default:
-		return cmd.FormatYaml(writer, val)
-	}
-	fmt.Fprintln(writer, str)
-	return nil
+	f.StringVar(&c.label, "label", "", "a label used to identify the secret in hooks")
+	f.BoolVar(&c.peek, "peek", false,
+		`get the latest revision just this time`)
+	f.BoolVar(&c.update, "update", false,
+		`get the latest revision and also get this same revision for subsequent calls`)
 }
 
 // Init implements cmd.Command.
 func (c *secretGetCommand) Init(args []string) (err error) {
 	if len(args) < 1 {
-		return errors.New("missing secret name")
+		return errors.New("missing secret URI")
 	}
 	c.secretUri, err = secrets.ParseURI(args[0])
 	if err != nil {
 		return errors.NotValidf("secret URI %q", args[0])
+	}
+	if c.peek && c.update {
+		return errors.New("specify one of --peek or --update but not both")
+	}
+	if len(args) > 1 {
+		c.key = args[1]
+		return cmd.CheckEmpty(args[2:])
 	}
 	return cmd.CheckEmpty(args[1:])
 }
 
 // Run implements cmd.Command.
 func (c *secretGetCommand) Run(ctx *cmd.Context) error {
-	value, err := c.ctx.GetSecret(c.secretUri.String())
+	value, err := c.ctx.GetSecret(c.secretUri.String(), c.label, c.update, c.peek)
 	if err != nil {
 		return err
 	}
 
 	var val interface{}
-	if c.asBase64 {
-		if value.Singular() {
-			val, _ = value.EncodedValue()
-		} else {
-			valMap := value.EncodedValues()
-			val = valMap
-		}
-	} else {
-		if value.Singular() {
-			val, err = value.Value()
-			if err != nil {
-				return err
-			}
-		} else {
-			valMap, err := value.Values()
-			if err != nil {
-				return err
-			}
-			val = valMap
-		}
+	val, err = value.Values()
+	if err != nil {
+		return err
+	}
+	if c.key == "" {
+		return c.out.Write(ctx, val)
+	}
+
+	val, err = value.KeyValue(c.key)
+	if err != nil {
+		return err
 	}
 	return c.out.Write(ctx, val)
 }

--- a/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-get_test.go
@@ -22,24 +22,18 @@ type SecretGetSuite struct {
 
 var _ = gc.Suite(&SecretGetSuite{})
 
-func (s *SecretGetSuite) TestSecretGetSingularString(c *gc.C) {
+func (s *SecretGetSuite) TestSecretGetInit(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
-	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
-		"data": base64.StdEncoding.EncodeToString([]byte("s3cret!")),
-	})
 
 	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
-	c.Assert(code, gc.Equals, 0)
-
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
-	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, "s3cret!\n")
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "--peek", "--update"})
+	c.Assert(code, gc.Equals, 2)
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "ERROR specify one of --peek or --update but not both\n")
 }
 
-func (s *SecretGetSuite) TestSecretGetStringJson(c *gc.C) {
+func (s *SecretGetSuite) TestSecretGetJson(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
 		"key": base64.StdEncoding.EncodeToString([]byte("s3cret!")),
@@ -51,33 +45,56 @@ func (s *SecretGetSuite) TestSecretGetStringJson(c *gc.C) {
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "--format", "json"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g", "", false, false}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `{"key":"s3cret!"}`+"\n")
 }
 
-func (s *SecretGetSuite) TestSecretGetSingularEncoded(c *gc.C) {
+func (s *SecretGetSuite) TestSecretGet(c *gc.C) {
+	s.assertSecretGet(c, false, false)
+}
+
+func (s *SecretGetSuite) TestSecretGetPeek(c *gc.C) {
+	s.assertSecretGet(c, false, true)
+}
+
+func (s *SecretGetSuite) TestSecretGetUpdate(c *gc.C) {
+	s.assertSecretGet(c, true, false)
+}
+
+func (s *SecretGetSuite) assertSecretGet(c *gc.C, update, peek bool) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
-		"data": base64.StdEncoding.EncodeToString([]byte("s3cret!")),
+		"cert": base64.StdEncoding.EncodeToString([]byte("cert")),
+		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
 	})
 
 	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "--base64"})
+	args := []string{"secret:9m4e2mr0ui3e8a215n4g", "--label", "label"}
+	if update {
+		args = append(args, "--update")
+	}
+	if peek {
+		args = append(args, "--peek")
+	}
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, args)
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g", "label", update, peek}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, "czNjcmV0IQ==\n")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
+cert: cert
+key: key
+`[1:])
 }
 
-func (s *SecretGetSuite) TestSecretGet(c *gc.C) {
+func (s *SecretGetSuite) TestSecretGetBinary(c *gc.C) {
+	encodedValue := `R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLCAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=`
 	hctx, _ := s.ContextSuite.NewHookContext()
 	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
-		"cert": base64.StdEncoding.EncodeToString([]byte("cert")),
-		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
+		"key": encodedValue,
 	})
 
 	com, err := jujuc.NewCommand(hctx, "secret-get")
@@ -86,15 +103,18 @@ func (s *SecretGetSuite) TestSecretGet(c *gc.C) {
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g", "", false, false}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
-cert: cert
-key: key
+key: !!binary |
+  R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp5
+  6enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/+
+  +f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLCAgjoEwnuNAFOhpEMTRiggcz4
+  BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=
 `[1:])
 }
 
-func (s *SecretGetSuite) TestSecretGetEncoded(c *gc.C) {
+func (s *SecretGetSuite) TestSecretGetKey(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
 		"cert": base64.StdEncoding.EncodeToString([]byte("cert")),
@@ -104,13 +124,30 @@ func (s *SecretGetSuite) TestSecretGetEncoded(c *gc.C) {
 	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "--base64"})
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "cert"})
 	c.Assert(code, gc.Equals, 0)
 
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g"}}})
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g", "", false, false}}})
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
-cert: Y2VydA==
-key: a2V5
+cert
 `[1:])
+}
+
+func (s *SecretGetSuite) TestSecretGetKeyBase64(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx.ContextSecrets.SecretValue = secrets.NewSecretValue(map[string]string{
+		"cert": base64.StdEncoding.EncodeToString([]byte("cert")),
+		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
+	})
+
+	com, err := jujuc.NewCommand(hctx, "secret-get")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "cert#base64"})
+	c.Assert(code, gc.Equals, 0)
+
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "GetSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g", "", false, false}}})
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "Y2VydA==\n")
 }


### PR DESCRIPTION
The secret-get hook command is updated to use the new CLI syntax.
`--update`, `--peek`, and `--label` options are added.
The secret value implementation is also adjusted to suit.

A followup PR will wire up the backend.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Just unit tests for this PR.