### PR TITLE
[JUJU-1579] Fix "no matching agent binaries available" error for arm64 tests

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -263,7 +263,11 @@ pre_bootstrap() {
 		# In CI tests, both Build and OfficialBuild are set.
 		# Juju confuses when it needs to decide the operator image tag to use.
 		# So we need to explicitly set the agent version for CI tests.
-		version=$(juju_version)
+		if [[ -n ${JUJU_VERSION:-} ]]; then
+			version=${JUJU_VERSION}
+		else
+			version=$(juju_version)
+		fi
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -262,13 +262,14 @@ pre_bootstrap() {
 	else
 		# In CI tests, both Build and OfficialBuild are set.
 		# Juju confuses when it needs to decide the operator image tag to use.
-		# So we need to explicitely set the agent version for CI tests.
+		# So we need to explicitly set the agent version for CI tests.
 		version=$(juju_version)
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
 
 	if [[ -n ${SHORT_GIT_COMMIT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/ --config agent-stream=build-${SHORT_GIT_COMMIT}"
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/"
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-stream=build-${SHORT_GIT_COMMIT}"
 	fi
 
 	echo "BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"


### PR DESCRIPTION
This PR added needed model-defaults to use custom agent binaries source. Using custom binaries source will unblock hybrid deployment for deploy testing suite when controller uses AMD arch, and workload machines use ARM arch.


## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
export MODEL_ARCH=arm64
export SHORT_GIT_COMMIT=ebf8545
export JUJU_VERSION=2.9.34.344
./main.sh -v -p aws deploy test_deploy_bundles
./main.sh -v -p aws deploy test_deploy_charms
```
