### PR TITLE
[JUJU-1583] Fixed test-deploy-test-deploy-bundles-aws for arm64 tests

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -66,10 +66,22 @@ run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
 	bundle=./tests/suites/deploy/bundles/telegraf_bundle.yaml
 	juju deploy ${bundle}
 
+	echo "Make a copy of reference yaml"
+	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
+	if [[ -n ${MODEL_ARCH:-} ]]; then
+		if ! which "yq" >/dev/null 2>&1; then
+			sudo snap install yq --classic --channel latest/stable
+		fi
+		yq -i "
+			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
+			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
+		" "${TEST_DIR}/telegraf_bundle.yaml"
+	fi
 	# no need to wait for the bundle to finish deploying to
 	# check the export.
 	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
-	diff -u ${bundle} "${TEST_DIR}/exported-bundle.yaml"
+	yq -i . "${TEST_DIR}/exported-bundle.yaml"
+	diff -u "${TEST_DIR}/telegraf_bundle.yaml" "${TEST_DIR}/exported-bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-fixed-revisions"
 }
@@ -98,10 +110,17 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	echo "Make a copy of reference yaml and insert revisions in it"
 	cp ${bundle_with_fake_revisions} "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 	yq -i "
-    .applications.influxdb.revision = ${influxdb_rev} |
-    .applications.telegraf.revision = ${telegraf_rev} |
-    .applications.ubuntu.revision = ${ubuntu_rev}
-  " "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
+		.applications.influxdb.revision = ${influxdb_rev} |
+		.applications.telegraf.revision = ${telegraf_rev} |
+		.applications.ubuntu.revision = ${ubuntu_rev}
+	" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
+
+	if [[ -n ${MODEL_ARCH:-} ]]; then
+		yq -i "
+			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
+			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
+		" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
+	fi
 
 	# The model should be updated immediately, so we can export the bundle before
 	# everything is done deploying


### PR DESCRIPTION
This PR fixes run_deploy_exported_charmhub_bundle_with_float_revisions, run_deploy_exported_charmstore_bundle_with_fixed_revisions tests by adding arch constraint in bundle yaml, which now respects MODEL_ARCH env var.

Original problem is [here](https://jenkins.juju.canonical.com/job/test-deploy-test-deploy-bundles-aws/246/console)

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
export MODEL_ARCH=arm64
export SHORT_GIT_COMMIT=ebf8545
export JUJU_VERSION=2.9.34.344
./main.sh -v -p aws deploy test_deploy_bundles
```

