### PR TITLE
Implement secret-get backend

### DIFF
--- a/apiserver/facades/agent/secretsmanager/access.go
+++ b/apiserver/facades/agent/secretsmanager/access.go
@@ -7,9 +7,10 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
+	coresecrets "github.com/juju/juju/core/secrets"
 )
 
-func secretAccessor(agentAppName string) common.GetAuthFunc {
+func secretOwner(agentAppName string) common.GetAuthFunc {
 	return func() (common.AuthFunc, error) {
 		return func(secretOwnerTag names.Tag) bool {
 			// We currently only support secrets owned by applications.
@@ -19,4 +20,9 @@ func secretAccessor(agentAppName string) common.GetAuthFunc {
 			return agentAppName == secretOwnerTag.Id()
 		}, nil
 	}
+}
+
+func (s *SecretsManagerAPI) checkCanRead(uri *coresecrets.URI) error {
+	// TODO(wallyworld)
+	return nil
 }

--- a/apiserver/facades/agent/secretsmanager/mocks/secretservice.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretservice.go
@@ -80,6 +80,21 @@ func (mr *MockSecretsServiceMockRecorder) GetSecret(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockSecretsService)(nil).GetSecret), arg0, arg1)
 }
 
+// GetSecretConsumer mocks base method.
+func (m *MockSecretsService) GetSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string) (*secrets.SecretConsumerMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretConsumer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecretConsumer indicates an expected call of GetSecretConsumer.
+func (mr *MockSecretsServiceMockRecorder) GetSecretConsumer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockSecretsService)(nil).GetSecretConsumer), arg0, arg1, arg2)
+}
+
 // GetSecretValue mocks base method.
 func (m *MockSecretsService) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
@@ -108,6 +123,20 @@ func (m *MockSecretsService) ListSecrets(arg0 context.Context, arg1 secrets0.Fil
 func (mr *MockSecretsServiceMockRecorder) ListSecrets(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretsService)(nil).ListSecrets), arg0, arg1)
+}
+
+// SaveSecretConsumer mocks base method.
+func (m *MockSecretsService) SaveSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 *secrets.SecretConsumerMetadata) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveSecretConsumer", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveSecretConsumer indicates an expected call of SaveSecretConsumer.
+func (mr *MockSecretsServiceMockRecorder) SaveSecretConsumer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretConsumer", reflect.TypeOf((*MockSecretsService)(nil).SaveSecretConsumer), arg0, arg1, arg2, arg3)
 }
 
 // UpdateSecret mocks base method.

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -30,7 +30,7 @@ func NewTestAPI(
 	resources facade.Resources,
 	service secrets.SecretsService,
 	secretsRotation SecretsRotation,
-	accessSecret common.GetAuthFunc,
+	manageSecret common.GetAuthFunc,
 	ownerTag names.Tag,
 	clock clock.Clock,
 ) (*SecretsManagerAPI, error) {
@@ -39,13 +39,13 @@ func NewTestAPI(
 	}
 
 	return &SecretsManagerAPI{
-		authOwner:       ownerTag,
+		authTag:         ownerTag,
 		controllerUUID:  coretesting.ControllerTag.Id(),
 		modelUUID:       coretesting.ModelTag.Id(),
 		resources:       resources,
 		secretsService:  service,
 		secretsRotation: secretsRotation,
-		accessSecret:    accessSecret,
+		manageSecret:    manageSecret,
 		clock:           clock,
 	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -32,9 +32,9 @@ func newSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 	// Work out the app name associated with the agent since this is
 	// the secret owner for newly created secrets.
 	agentTag := context.Auth().GetAuthTag()
-	agentName := agentTag.Id()
+	agentAppName := agentTag.Id()
 	if agentTag.Kind() == names.UnitTagKind {
-		agentName, _ = names.UnitApplication(agentName)
+		agentAppName, _ = names.UnitApplication(agentAppName)
 	}
 
 	// For now we just support the Juju secrets provider.
@@ -45,13 +45,13 @@ func newSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		return nil, errors.Annotate(err, "creating juju secrets service")
 	}
 	return &SecretsManagerAPI{
-		authOwner:       names.NewApplicationTag(agentName),
+		authTag:         context.Auth().GetAuthTag(),
 		controllerUUID:  context.State().ControllerUUID(),
 		modelUUID:       context.State().ModelUUID(),
 		secretsService:  service,
 		resources:       context.Resources(),
 		secretsRotation: context.State(),
-		accessSecret:    secretAccessor(agentName),
+		manageSecret:    secretOwner(agentAppName),
 		clock:           clock.WallClock,
 	}, nil
 }

--- a/core/secrets/rotate.go
+++ b/core/secrets/rotate.go
@@ -10,15 +10,13 @@ import "time"
 type RotatePolicy string
 
 const (
-	RotateNever       = RotatePolicy("never")
-	RotateHourly      = RotatePolicy("hourly")
-	RotateDaily       = RotatePolicy("daily")
-	RotateWeekly      = RotatePolicy("weekly")
-	RotateHalfMonthly = RotatePolicy("half-monthly")
-	RotateMonthly     = RotatePolicy("monthly")
-	RotateQuarterly   = RotatePolicy("quarterly")
-	RotateHalfYearly  = RotatePolicy("half-yearly")
-	RotateYearly      = RotatePolicy("yearly")
+	RotateNever     = RotatePolicy("never")
+	RotateHourly    = RotatePolicy("hourly")
+	RotateDaily     = RotatePolicy("daily")
+	RotateWeekly    = RotatePolicy("weekly")
+	RotateMonthly   = RotatePolicy("monthly")
+	RotateQuarterly = RotatePolicy("quarterly")
+	RotateYearly    = RotatePolicy("yearly")
 )
 
 func (p RotatePolicy) String() string {
@@ -31,9 +29,8 @@ func (p RotatePolicy) String() string {
 // IsValid returns true if v is a valid rotate policy.
 func (p RotatePolicy) IsValid() bool {
 	switch p {
-	case RotateNever, RotateHourly, RotateDaily, RotateWeekly, RotateHalfMonthly,
-		RotateMonthly, RotateQuarterly, RotateHalfYearly,
-		RotateYearly:
+	case RotateNever, RotateHourly, RotateDaily, RotateWeekly,
+		RotateMonthly, RotateQuarterly, RotateYearly:
 		return true
 	}
 	return false
@@ -57,14 +54,10 @@ func (p RotatePolicy) NextRotateTime(lastRotateTime *time.Time) *time.Time {
 		result = lastRotated.AddDate(0, 0, 1)
 	case RotateWeekly:
 		result = lastRotated.AddDate(0, 0, 7)
-	case RotateHalfMonthly:
-		result = lastRotated.AddDate(0, 0, 14)
 	case RotateMonthly:
 		result = lastRotated.AddDate(0, 1, 0)
 	case RotateQuarterly:
 		result = lastRotated.AddDate(0, 3, 0)
-	case RotateHalfYearly:
-		result = lastRotated.AddDate(0, 6, 0)
 	case RotateYearly:
 		result = lastRotated.AddDate(1, 0, 0)
 	}

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -147,3 +147,14 @@ type SecretMetadata struct {
 	CreateTime     time.Time
 	UpdateTime     time.Time
 }
+
+// SecretConsumerMetadata holds metadata about a secret
+// for a consumer of the secret.
+type SecretConsumerMetadata struct {
+	// Label is used when notifying the consumer
+	// about changes to the secret.
+	Label string
+	// Revision is current revision the
+	// consumer wants to read.
+	Revision int
+}

--- a/secrets/interface.go
+++ b/secrets/interface.go
@@ -80,6 +80,12 @@ type SecretsService interface {
 	// GetSecret returns the metadata for the specified secret.
 	GetSecret(context.Context, *secrets.URI) (*secrets.SecretMetadata, error)
 
+	// GetSecretConsumer returns metadata about the consumer of a secret.
+	GetSecretConsumer(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, error)
+
+	// SaveSecretConsumer saves metadata about the consumer of a secret.
+	SaveSecretConsumer(context.Context, *secrets.URI, string, *secrets.SecretConsumerMetadata) error
+
 	// GetSecretValue returns the value of the specified secret.
 	GetSecretValue(context.Context, *secrets.URI, int) (secrets.SecretValue, error)
 

--- a/secrets/provider/juju/mocks/secretstore.go
+++ b/secrets/provider/juju/mocks/secretstore.go
@@ -65,6 +65,21 @@ func (mr *MockSecretsStoreMockRecorder) GetSecret(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockSecretsStore)(nil).GetSecret), arg0)
 }
 
+// GetSecretConsumer mocks base method.
+func (m *MockSecretsStore) GetSecretConsumer(arg0 *secrets.URI, arg1 string) (*secrets.SecretConsumerMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretConsumer", arg0, arg1)
+	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecretConsumer indicates an expected call of GetSecretConsumer.
+func (mr *MockSecretsStoreMockRecorder) GetSecretConsumer(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockSecretsStore)(nil).GetSecretConsumer), arg0, arg1)
+}
+
 // GetSecretValue mocks base method.
 func (m *MockSecretsStore) GetSecretValue(arg0 *secrets.URI, arg1 int) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
@@ -93,6 +108,20 @@ func (m *MockSecretsStore) ListSecrets(arg0 state.SecretsFilter) ([]*secrets.Sec
 func (mr *MockSecretsStoreMockRecorder) ListSecrets(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretsStore)(nil).ListSecrets), arg0)
+}
+
+// SaveSecretConsumer mocks base method.
+func (m *MockSecretsStore) SaveSecretConsumer(arg0 *secrets.URI, arg1 string, arg2 *secrets.SecretConsumerMetadata) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveSecretConsumer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveSecretConsumer indicates an expected call of SaveSecretConsumer.
+func (mr *MockSecretsStoreMockRecorder) SaveSecretConsumer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretConsumer", reflect.TypeOf((*MockSecretsStore)(nil).SaveSecretConsumer), arg0, arg1, arg2)
 }
 
 // UpdateSecret mocks base method.

--- a/secrets/provider/juju/secrets.go
+++ b/secrets/provider/juju/secrets.go
@@ -70,6 +70,16 @@ func (s secretsService) GetSecret(ctx context.Context, uri *coresecrets.URI) (*c
 	return s.backend.GetSecret(uri)
 }
 
+// GetSecretConsumer implements SecretsService.
+func (s secretsService) GetSecretConsumer(ctx context.Context, uri *coresecrets.URI, owner string) (*coresecrets.SecretConsumerMetadata, error) {
+	return s.backend.GetSecretConsumer(uri, owner)
+}
+
+// SaveSecretConsumer implements SecretsService.
+func (s secretsService) SaveSecretConsumer(ctx context.Context, uri *coresecrets.URI, consumerTag string, sc *coresecrets.SecretConsumerMetadata) error {
+	return s.backend.SaveSecretConsumer(uri, consumerTag, sc)
+}
+
 // ListSecrets implements SecretsService.
 func (s secretsService) ListSecrets(ctx context.Context, filter secrets.Filter) ([]*coresecrets.SecretMetadata, error) {
 	return s.backend.ListSecrets(state.SecretsFilter{})

--- a/secrets/provider/juju/secrets_test.go
+++ b/secrets/provider/juju/secrets_test.go
@@ -246,3 +246,38 @@ func (s *SecretsManagerSuite) TestListSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, metadata)
 }
+
+func (s *SecretsManagerSuite) TestGetSecretConsumer(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	service := juju.NewTestService(s.secretsStore)
+
+	uri, _ := coresecrets.ParseURI("secret:9m4e2mr0ui3e8a215n4g")
+	consumer := &coresecrets.SecretConsumerMetadata{
+		Label:    "foobar",
+		Revision: 2,
+	}
+	s.secretsStore.EXPECT().GetSecretConsumer(uri, "application-mariadb").Return(
+		consumer, nil,
+	)
+
+	result, err := service.GetSecretConsumer(context.Background(), uri, "application-mariadb")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, consumer)
+}
+
+func (s *SecretsManagerSuite) TestSaveSecretConsumer(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	service := juju.NewTestService(s.secretsStore)
+
+	uri, _ := coresecrets.ParseURI("secret:9m4e2mr0ui3e8a215n4g")
+	consumer := &coresecrets.SecretConsumerMetadata{
+		Label:    "foobar",
+		Revision: 2,
+	}
+	s.secretsStore.EXPECT().SaveSecretConsumer(uri, "application-wordpress", consumer).Return(nil)
+
+	err := service.SaveSecretConsumer(context.Background(), uri, "application-wordpress", consumer)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -559,10 +559,17 @@ func allCollections() CollectionSchema {
 			global: true,
 		},
 
+		secretConsumersC: {
+			global: true,
+			indexes: []mgo.Index{{
+				Key: []string{"consumer-tag"},
+			}},
+		},
+
 		secretRotateC: {
 			global: true,
 			indexes: []mgo.Index{{
-				Key: []string{"owner"},
+				Key: []string{"owner-tag"},
 			}},
 		},
 
@@ -678,5 +685,6 @@ const (
 	// Secrets
 	secretMetadataC  = "secretMetadata"
 	secretRevisionsC = "secretRevisions"
+	secretConsumersC = "secretConsumers"
 	secretRotateC    = "secretRotate"
 )

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1073,7 +1073,7 @@ func GetSecretRotateTime(c *gc.C, st *State, id string) time.Time {
 	defer closer()
 
 	var doc secretRotationDoc
-	err := secretRotateCollection.FindId(secretGlobalKey(id)).One(&doc)
+	err := secretRotateCollection.FindId(id).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	return doc.LastRotateTime.UTC()
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -218,6 +218,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// secrets
 		secretMetadataC,
 		secretRevisionsC,
+		secretConsumersC,
 		secretRotateC,
 	)
 


### PR DESCRIPTION
Implement the backend for secret-get. This change introduces a new secret consumers collection to hold the last revision read by a given consumer. Getting a secret uses the appropriate revision for the consumer.

Also a few driveby fixes: remove unused rotation policies, rename a few things.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
$ juju deploy ubuntu aaa 
Located charm "ubuntu" in charm-hub, revision 20
Deploying "aaa" from charm-hub charm "ubuntu", revision 20 in channel stable on jammy
$ juju deploy ubuntu bbb
Located charm "ubuntu" in charm-hub, revision 20
Deploying "bbb" from charm-hub charm "ubuntu", revision 20 in channel stable on jammy
$ juju exec --unit aaa/0 "secret-add data=foo"
secret:cbpf52o35o8id349kh6g
$ juju exec --unit bbb/0 "secret-get secret:cbpf52o35o8id349kh6g --label foo"
data: foo
$ juju exec --unit aaa/0 "secret-update secret:cbpf52o35o8id349kh6g data=foo2"
$ juju exec --unit bbb/0 "secret-get secret:cbpf52o35o8id349kh6g"
data: foo
$ juju exec --unit bbb/0 "secret-get secret:cbpf52o35o8id349kh6g --peek"
data: foo2
$ juju exec --unit bbb/0 "secret-get secret:cbpf52o35o8id349kh6g"
data: foo
$ juju exec --unit bbb/0 "secret-get secret:cbpf52o35o8id349kh6g --update"
data: foo2
$ juju exec --unit bbb/0 "secret-get secret:cbpf52o35o8id349kh6g"
data: foo2
```

