### PR TITLE
[JUJU-1585] [refresh] correct error when local charm not found

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -349,8 +349,11 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	// Ensure that the switchURL (if provided) always contains a schema. If
 	// one is missing inject the default value we selected above.
 	if c.SwitchURL != "" {
-		if c.SwitchURL, err = charm.EnsureSchema(c.SwitchURL, defaultCharmSchema); err != nil {
-			return errors.Trace(err)
+		// Don't prepend `ch:` when referring to a local charm
+		if !refresher.IsLocalURL(c.SwitchURL) {
+			if c.SwitchURL, err = charm.EnsureSchema(c.SwitchURL, defaultCharmSchema); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -219,9 +219,22 @@ func (d *localCharmRefresher) Refresh() (*CharmID, error) {
 		return nil, errors.Trace(err)
 	}
 
+	if IsLocalURL(d.charmRef) {
+		// This was clearly meant to refer to a local charm, which we've not
+		// been able to find, so return the error
+		return nil, errors.Annotatef(err, "%q", d.charmRef)
+	}
+
 	// Not a valid local charm, in this case, we should move onto the next
 	// refresher.
 	return nil, ErrExhausted
+}
+
+// IsLocalURL checks if the provided URL refers to a local charm (i.e. it
+// begins with one of  `/`  `./`  `../` ).
+func IsLocalURL(url string) bool {
+	return strings.HasPrefix(url, "/") || strings.HasPrefix(url, "./") ||
+		strings.HasPrefix(url, "../")
 }
 
 func (d *localCharmRefresher) String() string {


### PR DESCRIPTION
`juju refresh` was returning an incorrect error when the argument to `--path` or `--switch` was a local charm, and the given file/directory didn't exist.

```console
$ juju refresh tiny-bash --path ./non/existent
ERROR charm or bundle URL has invalid form: "cs:./non/existent"
$ juju refresh tiny-bash --switch ./non/existent
ERROR cannot parse architecture in URL "ch:./non/existent": architecture name "." not valid
```

I've now fixed these errors so that we are not trying to search Charmhub / Charmstore for local charms.

```console
$ juju refresh tiny-bash --path ./non/existent
ERROR "./non/existent": file does not exist
$ juju refresh tiny-bash --switch ./non/existent
ERROR "./non/existent": file does not exist
```

I've also added unit tests to verify my changes.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## Bug reference

https://bugs.launchpad.net/juju/+bug/1929108
