### PR TITLE
[JUJU-1587] Fix test race in dummy provider

### DIFF
--- a/agent/tools/symlinks_test.go
+++ b/agent/tools/symlinks_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&SymlinksSuite{})
 
 func (s *SymlinksSuite) SetUpTest(c *gc.C) {
 	s.dataDir = c.MkDir()
-	s.toolsDir = tools.SharedToolsDir(s.dataDir, testing.CurrentVersion(c))
+	s.toolsDir = tools.SharedToolsDir(s.dataDir, testing.CurrentVersion())
 	err := os.MkdirAll(s.toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("created %s", s.toolsDir)

--- a/api/agent/provisioner/provisioner_test.go
+++ b/api/agent/provisioner/provisioner_test.go
@@ -774,7 +774,7 @@ func (s *provisionerSuite) TestFindToolsLogicError(c *gc.C) {
 }
 
 func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logicError error) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	var toolsList = coretools.List{&coretools.Tools{Version: current}}
 	var called bool
 	var a string

--- a/api/agent/upgrader/unitupgrader_test.go
+++ b/api/agent/upgrader/unitupgrader_test.go
@@ -76,19 +76,19 @@ func (s *unitUpgraderSuite) addMachineApplicationCharmAndUnit(c *gc.C, appName s
 }
 
 func (s *unitUpgraderSuite) TestSetVersionWrongUnit(c *gc.C) {
-	err := s.st.SetVersion("unit-wordpress-42", testing.CurrentVersion(c))
+	err := s.st.SetVersion("unit-wordpress-42", testing.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *unitUpgraderSuite) TestSetVersionNotUnit(c *gc.C) {
-	err := s.st.SetVersion("foo-42", testing.CurrentVersion(c))
+	err := s.st.SetVersion("foo-42", testing.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *unitUpgraderSuite) TestSetVersion(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	agentTools, err := s.rawUnit.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(agentTools, gc.IsNil)
@@ -115,7 +115,7 @@ func (s *unitUpgraderSuite) TestToolsNotUnit(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestTools(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
 	s.rawMachine.SetAgentVersion(current)
@@ -162,7 +162,7 @@ func (s *unitUpgraderSuite) TestWatchAPIVersionNotUnit(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersion(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
 	s.rawMachine.SetAgentVersion(current)

--- a/api/agent/upgrader/upgrader_test.go
+++ b/api/agent/upgrader/upgrader_test.go
@@ -51,19 +51,19 @@ func (s *machineUpgraderSuite) TestNew(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestSetVersionWrongMachine(c *gc.C) {
-	err := s.st.SetVersion("machine-42", coretesting.CurrentVersion(c))
+	err := s.st.SetVersion("machine-42", coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *machineUpgraderSuite) TestSetVersionNotMachine(c *gc.C) {
-	err := s.st.SetVersion("foo-42", coretesting.CurrentVersion(c))
+	err := s.st.SetVersion("foo-42", coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *machineUpgraderSuite) TestSetVersion(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	agentTools, err := s.rawMachine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(agentTools, gc.IsNil)
@@ -90,7 +90,7 @@ func (s *machineUpgraderSuite) TestToolsNotMachine(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestTools(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -132,7 +132,7 @@ func (s *machineUpgraderSuite) TestWatchAPIVersion(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestDesiredVersion(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -74,7 +74,7 @@ func (s *getToolsSuite) TestTools(c *gc.C) {
 		},
 	}
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	configAttrs := map[string]interface{}{
 		"name":                 "some-name",
 		"type":                 "some-type",
@@ -127,7 +127,7 @@ func (s *getToolsSuite) TestSeriesTools(c *gc.C) {
 	)
 	c.Assert(tg, gc.NotNil)
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	currentCopy := current
 	currentCopy.Release = coretesting.HostSeries(c)
 	configAttrs := map[string]interface{}{
@@ -217,7 +217,7 @@ func (s *setToolsSuite) TestSetTools(c *gc.C) {
 	ts := common.NewToolsSetter(s.entityFinder, getCanWrite)
 	c.Assert(ts, gc.NotNil)
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	args := params.EntitiesVersion{
 		AgentTools: []params.EntityVersion{{
 			Tag: "machine-0",
@@ -261,7 +261,7 @@ func (s *setToolsSuite) TestToolsSetError(c *gc.C) {
 		AgentTools: []params.EntityVersion{{
 			Tag: "machine-42",
 			Tools: &params.Version{
-				Version: coretesting.CurrentVersion(c),
+				Version: coretesting.CurrentVersion(),
 			},
 		}},
 	}
@@ -311,7 +311,7 @@ func (s *findToolsSuite) expectMatchingStorageTools(c *gc.C, storageMetadata []b
 }
 
 func (s *findToolsSuite) expectBootstrapEnvionConfig(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	configAttrs := map[string]interface{}{
 		"name":                 "some-name",
 		"type":                 "some-type",
@@ -590,7 +590,7 @@ func (s *findToolsSuite) TestFindToolsExactNotInStorage(c *gc.C) {
 
 func (s *findToolsSuite) testFindToolsExact(c *gc.C, inStorage bool, develVersion bool) {
 	var called bool
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	s.PatchValue(common.EnvtoolsFindTools, func(_ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		called = true
 		c.Assert(filter.Number, gc.Equals, jujuversion.Current)
@@ -662,7 +662,7 @@ func (s *getUrlSuite) TestToolsURLGetterNoAPIHostPorts(c *gc.C) {
 	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents().Return(nil, nil)
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
-	_, err := g.ToolsURLs(coretesting.CurrentVersion(c))
+	_, err := g.ToolsURLs(coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "no suitable API server address to pick from")
 }
 
@@ -672,7 +672,7 @@ func (s *getUrlSuite) TestToolsURLGetterAPIHostPortsError(c *gc.C) {
 	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents().Return(nil, errors.New("oh noes"))
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
-	_, err := g.ToolsURLs(coretesting.CurrentVersion(c))
+	_, err := g.ToolsURLs(coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "oh noes")
 }
 
@@ -684,7 +684,7 @@ func (s *getUrlSuite) TestToolsURLGetter(c *gc.C) {
 	}, nil)
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	urls, err := g.ToolsURLs(current)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(urls, jc.DeepEquals, []string{

--- a/apiserver/facades/agent/upgrader/unitupgrader_test.go
+++ b/apiserver/facades/agent/upgrader/unitupgrader_test.go
@@ -183,7 +183,7 @@ func (s *unitUpgraderSuite) TestToolsForAgent(c *gc.C) {
 	// The machine must have its existing tools set before we query for the
 	// next tools. This is so that we can grab Arch and OSType without
 	// having to pass it in again
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -220,7 +220,7 @@ func (s *unitUpgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 		AgentTools: []params.EntityVersion{{
 			Tag: s.rawUnit.Tag().String(),
 			Tools: &params.Version{
-				Version: testing.CurrentVersion(c),
+				Version: testing.CurrentVersion(),
 			},
 		}},
 	}
@@ -232,7 +232,7 @@ func (s *unitUpgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestSetTools(c *gc.C) {
-	cur := testing.CurrentVersion(c)
+	cur := testing.CurrentVersion()
 	_, err := s.rawUnit.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	args := params.EntitiesVersion{
@@ -290,7 +290,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{
@@ -311,7 +311,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{{Tag: s.rawUnit.Tag().String()}}}

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -242,7 +242,7 @@ func (s *upgraderSuite) TestToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *upgraderSuite) TestToolsForAgent(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	agent := params.Entity{Tag: s.rawMachine.Tag().String()}
 
 	// The machine must have its existing tools set before we query for the
@@ -284,7 +284,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 		AgentTools: []params.EntityVersion{{
 			Tag: s.rawMachine.Tag().String(),
 			Tools: &params.Version{
-				Version: coretesting.CurrentVersion(c),
+				Version: coretesting.CurrentVersion(),
 			},
 		}},
 	}
@@ -296,7 +296,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *upgraderSuite) TestSetTools(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	_, err := s.rawMachine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	args := params.EntitiesVersion{
@@ -378,7 +378,7 @@ func (s *upgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
 func (s *upgraderSuite) bumpDesiredAgentVersion(c *gc.C) version.Number {
 	// In order to call SetModelAgentVersion we have to first SetTools on
 	// all the existing machines
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	err := s.apiMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.rawMachine.SetAgentVersion(current)

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -435,7 +435,7 @@ func (s *toolsSuite) TestUploadConvertsSeries(c *gc.C) {
 
 func (s *toolsSuite) TestDownloadModelUUIDPath(c *gc.C) {
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
-		Version: testing.CurrentVersion(c).String(),
+		Version: testing.CurrentVersion().String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})
@@ -501,7 +501,7 @@ func (s *toolsSuite) TestDownloadOtherModelUUIDPath(c *gc.C) {
 	defer newSt.Close()
 
 	tools := s.storeFakeTools(c, newSt, "abc", binarystorage.Metadata{
-		Version: testing.CurrentVersion(c).String(),
+		Version: testing.CurrentVersion().String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})
@@ -510,7 +510,7 @@ func (s *toolsSuite) TestDownloadOtherModelUUIDPath(c *gc.C) {
 
 func (s *toolsSuite) TestDownloadTopLevelPath(c *gc.C) {
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
-		Version: testing.CurrentVersion(c).String(),
+		Version: testing.CurrentVersion().String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/arch"
 	"github.com/juju/version/v2"
+
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
@@ -256,7 +257,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 			uploadVers := version.MustParseBinary(test.upload)
 			bootstrapVersion.Number = uploadVers.Number
 		}
-		restore = restore.Add(testing.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, bootstrapVersion.Number)))
+		restore = restore.Add(testing.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(bootstrapVersion.Number)))
 	}
 
 	if test.hostArch != "" {
@@ -1393,7 +1394,7 @@ my-dummy-cloud
 func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 	patchedVersion := version.MustParse(vers)
 	patchedVersion.Build = 1
-	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, patchedVersion))
+	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(patchedVersion))
 	sourceDir := createToolsSource(c, vAll)
 	s.PatchValue(&envtools.DefaultBaseURL, sourceDir)
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -156,12 +156,12 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "check version command returns a fully qualified version string",
 		args:    []string{"version"},
 		code:    0,
-		out:     testing.CurrentVersion(c).String() + "\n",
+		out:     testing.CurrentVersion().String() + "\n",
 	}, {
 		summary: "check --version command returns a fully qualified version string",
 		args:    []string{"--version"},
 		code:    0,
-		out:     testing.CurrentVersion(c).String() + "\n",
+		out:     testing.CurrentVersion().String() + "\n",
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
 		out := badrun(c, t.code, t.args...)
@@ -270,7 +270,7 @@ func (s *MainSuite) TestRunNoUpdateCloud(c *gc.C) {
 }
 
 func checkVersionOutput(c *gc.C, output string) {
-	ver := testing.CurrentVersion(c)
+	ver := testing.CurrentVersion()
 	c.Check(output, gc.Equals, ver.String()+"\n")
 }
 

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -177,7 +177,7 @@ func (s *syncToolSuite) TestAPIAdapterUploadTools(c *gc.C) {
 	defer ctrl.Finish()
 	fakeAPI := mocks.NewMockSyncToolAPI(ctrl)
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	uploadToolsErr := errors.New("uh oh")
 	fakeAPI.EXPECT().UploadTools(bytes.NewReader([]byte("abc")), current).Return(nil, uploadToolsErr)
 

--- a/cmd/juju/commands/upgradecontroller_test.go
+++ b/cmd/juju/commands/upgradecontroller_test.go
@@ -98,7 +98,7 @@ func (s *UpgradeControllerBaseSuite) TestUpgradeWithRealUpload(c *gc.C) {
 	_, cmd := s.upgradeControllerCommand(c, nil)
 	_, err := cmdtesting.RunCommand(c, cmd, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	vers.Build = 1
 	s.checkToolsUploaded(c, vers, vers.Number)
 }

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -579,7 +579,7 @@ func (s *UpgradeJujuSuite) TestUpgradeJujuWithRealUpload(c *gc.C) {
 	defer ctrl.Finish()
 	_, err := cmdtesting.RunCommand(c, command, "--build-agent")
 	c.Assert(err, jc.ErrorIsNil)
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	vers.Build = 1
 	s.checkToolsUploaded(c, vers, vers.Number)
 }
@@ -1115,7 +1115,7 @@ func (s *UpgradeJujuSuite) TestResetPreviousUpgradeLegacy(c *gc.C) {
 }
 
 func NewFakeUpgradeJujuAPI(c *gc.C, st *state.State) *fakeUpgradeJujuAPI {
-	nextVersion := coretesting.CurrentVersion(c)
+	nextVersion := coretesting.CurrentVersion()
 	nextVersion.Minor++
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1705,7 +1705,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c 
 	})
 
 	c.Assert(agentVersion.Build, gc.Equals, 0)
-	builtVersion := coretesting.CurrentVersion(c)
+	builtVersion := coretesting.CurrentVersion()
 	targetVersion := builtVersion.Number
 	builtVersion.Build++
 	gomock.InOrder(
@@ -1751,7 +1751,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionAlreadyUpToDate(c *gc.
 	})
 
 	c.Assert(agentVersion.Build, gc.Equals, 0)
-	targetVersion := coretesting.CurrentVersion(c)
+	targetVersion := coretesting.CurrentVersion()
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
 		s.controllerAPI.EXPECT().ModelConfig().Return(cfg, nil),
@@ -1828,7 +1828,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 		"agent-version": agentVersion.String(),
 	})
 
-	targetVersion := coretesting.CurrentVersion(c).Number
+	targetVersion := coretesting.CurrentVersion().Number
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
 		s.controllerAPI.EXPECT().ModelConfig().Return(cfg, nil),
@@ -1869,7 +1869,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 		"uuid": coretesting.ControllerTag.Id(),
 	})
 
-	builtVersion := coretesting.CurrentVersion(c)
+	builtVersion := coretesting.CurrentVersion()
 	targetVersion := builtVersion.Number
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(modelCfg, nil),
@@ -1965,7 +1965,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithBuildAgent(c *gc.C) {
 		"agent-version": agentVersion.String(),
 	})
 	c.Assert(agentVersion.Build, gc.Equals, 0)
-	builtVersion := coretesting.CurrentVersion(c)
+	builtVersion := coretesting.CurrentVersion()
 	builtVersion.Build++
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -117,7 +117,7 @@ type AgentSuite struct {
 // with the given entity name. It returns the agent's configuration and the
 // current tools.
 func (s *AgentSuite) PrimeAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	return s.PrimeAgentVersion(c, tag, password, vers)
 }
 
@@ -172,7 +172,7 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 // a state agent with the given entity name. It returns the agent's
 // configuration and the current tools.
 func (s *AgentSuite) PrimeStateAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	return s.PrimeStateAgentVersion(c, tag, password, vers)
 }
 

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -125,7 +125,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.makeTestModel(c)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	toolsDir := filepath.FromSlash(agenttools.SharedToolsDir(s.dataDir, current))
 	err := os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
@@ -678,7 +678,7 @@ func (s *BootstrapSuite) TestDownloadedToolsMetadata(c *gc.C) {
 func (s *BootstrapSuite) TestUploadedToolsMetadata(c *gc.C) {
 	// Tools uploaded over ssh.
 	s.writeDownloadedTools(c, &tools.Tools{
-		Version: testing.CurrentVersion(c),
+		Version: testing.CurrentVersion(),
 		URL:     "file:///does/not/matter",
 	})
 	s.testToolsMetadata(c)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -422,7 +422,7 @@ func (s *MachineSuite) waitProvisioned(c *gc.C, unit *state.Unit) (*state.Machin
 }
 
 func (s *MachineSuite) testUpgradeRequest(c *gc.C, agent runner, tag string, currentTools *tools.Tools) {
-	newVers := coretesting.CurrentVersion(c)
+	newVers := coretesting.CurrentVersion()
 	newVers.Patch++
 	newTools := envtesting.AssertUploadFakeToolsVersions(
 		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), newVers)[0]
@@ -726,7 +726,7 @@ func (s *MachineSuite) assertAgentSetsToolsVersion(c *gc.C, job state.MachineJob
 		}
 		return false, nil
 	})
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	vers.Minor--
 	m, _, _ := s.primeAgentVersion(c, vers, job)
 	ctrl, a := s.newAgent(c, m)
@@ -1136,7 +1136,7 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	s.primeAgentWithMachine(c, m, vers)
 	ctrl, a := s.newAgent(c, m)
 	defer ctrl.Finish()

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -111,7 +111,7 @@ func (s *commonMachineSuite) TearDownTest(c *gc.C) {
 // machine agent's directory.  It returns the new machine, the
 // agent's configuration and the tools currently running.
 func (s *commonMachineSuite) primeAgent(c *gc.C, jobs ...state.MachineJob) (m *state.Machine, agentConfig agent.ConfigSetterWriter, tools *tools.Tools) {
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	return s.primeAgentVersion(c, vers, jobs...)
 }
 

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -194,7 +194,7 @@ func (s *toolsSuite) TestFindAvailableToolsNoUpload(c *gc.C) {
 }
 
 func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
-	currentVersion := coretesting.CurrentVersion(c)
+	currentVersion := coretesting.CurrentVersion()
 	currentVersion.Major = 2
 	currentVersion.Minor = 3
 	s.PatchValue(&jujuversion.Current, currentVersion.Number)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -145,7 +145,7 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	t.UploadFakeTools(c, stor, "released", "released")
 	t.toolsStorage = stor
-	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(c, version.Zero))
+	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(coretesting.FakeVersionNumber))
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {
@@ -964,7 +964,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 		c.Skip("HasProvisioner is false; cannot test deployment")
 	}
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	other := current
 	other.Release = "quantal"
 

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -231,11 +231,11 @@ func (s *uploadSuite) SetUpTest(c *gc.C) {
 func (s *uploadSuite) patchBundleTools(c *gc.C, v version.Number) {
 	// Mock out building of tools. Sync should not care about the contents
 	// of tools archives, other than that they hash correctly.
-	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, v))
+	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(v))
 }
 
 func (s *uploadSuite) assertEqualsCurrentVersion(c *gc.C, v version.Binary) {
-	c.Assert(v, gc.Equals, coretesting.CurrentVersion(c))
+	c.Assert(v, gc.Equals, coretesting.CurrentVersion())
 }
 
 func (s *uploadSuite) TearDownTest(c *gc.C) {
@@ -276,7 +276,7 @@ func (s *uploadSuite) TestUploadAndForceVersion(c *gc.C) {
 		func(version.Number) version.Number { return forceVersion },
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion(c))
+	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion())
 }
 
 func (s *uploadSuite) TestSyncTools(c *gc.C) {
@@ -316,7 +316,7 @@ func (s *uploadSuite) TestSyncAndForceVersion(c *gc.C) {
 	t, err := sync.SyncBuiltTools(ss, s.targetStorage, "released", builtTools)
 	c.Assert(err, jc.ErrorIsNil)
 	// Reported version from build call matches the real jujud version.
-	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion(c))
+	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion())
 }
 
 func (s *uploadSuite) assertUploadedTools(c *gc.C, t *coretools.Tools, expectOSTypes []string, stream string) {
@@ -418,7 +418,7 @@ func (s *badBuildSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *badBuildSuite) assertEqualsCurrentVersion(c *gc.C, v version.Binary) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	c.Assert(v, gc.Equals, current)
 }
 
@@ -432,7 +432,7 @@ func (s *badBuildSuite) TestBundleToolsBadBuild(c *gc.C) {
 	c.Assert(sha256Hash, gc.Equals, "")
 	c.Assert(err, gc.ErrorMatches, `(?m)cannot build jujud agent binary from source: .*`)
 
-	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, jujuversion.Current))
+	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(jujuversion.Current))
 
 	// Test that BundleTools func passes after it is
 	// mocked out
@@ -445,7 +445,7 @@ func (s *badBuildSuite) TestBundleToolsBadBuild(c *gc.C) {
 
 func (s *badBuildSuite) patchExecCommand(c *gc.C) {
 	execCommand := s.GetExecCommand(jujutesting.PatchExecConfig{
-		Stdout: coretesting.CurrentVersion(c).String(),
+		Stdout: coretesting.CurrentVersion().String(),
 		Args:   make(chan []string, 2),
 	})
 	s.PatchValue(&envtools.ExecCommand, execCommand)
@@ -463,8 +463,8 @@ func (s *badBuildSuite) TestBuildToolsBadBuild(c *gc.C) {
 
 	// Test that BuildAgentTarball func passes after BundleTools func is
 	// mocked out
-	forceVersion := coretesting.CurrentVersion(c).Number
-	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, forceVersion))
+	forceVersion := coretesting.CurrentVersion().Number
+	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(forceVersion))
 	builtTools, err = sync.BuildAgentTarball(true, "released",
 		func(version.Number) version.Number { return forceVersion },
 	)
@@ -585,7 +585,7 @@ func (s *uploadSuite) testStorageToolsUploaderWriteMirrors(c *gc.C, writeMirrors
 		"released",
 		"released",
 		&coretools.Tools{
-			Version: coretesting.CurrentVersion(c),
+			Version: coretesting.CurrentVersion(),
 			Size:    7,
 			SHA256:  "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
 		}, []byte("content"))

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -277,7 +277,7 @@ func UploadFakeTools(c *gc.C, stor storage.Storage, toolsDir, stream string, arc
 // RemoveFakeTools deletes the fake tools from the supplied storage.
 func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	c.Logf("removing fake tools")
-	toolsVersion := coretesting.CurrentVersion(c)
+	toolsVersion := coretesting.CurrentVersion()
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/juju/collections/set"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
@@ -35,14 +36,16 @@ import (
 	coretools "github.com/juju/juju/tools"
 )
 
-func GetMockBundleTools(c *gc.C, expectedForceVersion version.Number) tools.BundleToolsFunc {
+func GetMockBundleTools(expectedForceVersion version.Number) tools.BundleToolsFunc {
 	return func(
 		build bool, w io.Writer,
 		getForceVersion func(version.Number) version.Number,
 	) (version.Binary, version.Number, bool, string, error) {
-		vers := coretesting.CurrentVersion(c)
+		vers := coretesting.CurrentVersion()
 		forceVersion := getForceVersion(vers.Number)
-		c.Assert(forceVersion, jc.DeepEquals, expectedForceVersion)
+		if forceVersion.Compare(expectedForceVersion) != 0 {
+			return version.Binary{}, version.Number{}, false, "", errors.Errorf("%#v != expected %#v", forceVersion, expectedForceVersion)
+		}
 		sha256Hash := fmt.Sprintf("%x", sha256.New().Sum(nil))
 		return vers, forceVersion, false, sha256Hash, nil
 	}
@@ -55,7 +58,7 @@ func GetMockBuildTools(c *gc.C) sync.BuildAgentTarballFunc {
 		build bool, stream string,
 		getForceVersion func(version.Number) version.Number,
 	) (*sync.BuiltAgent, error) {
-		vers := coretesting.CurrentVersion(c)
+		vers := coretesting.CurrentVersion()
 		vers.Number = getForceVersion(vers.Number)
 
 		tgz, checksum := coretesting.TarGz(

--- a/featuretests/introspection_test.go
+++ b/featuretests/introspection_test.go
@@ -68,7 +68,7 @@ func (s *introspectionSuite) startMachineAgent(c *gc.C) (*agentcmd.MachineAgent,
 	err := m.SetMongoPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 
-	vers := testing.CurrentVersion(c)
+	vers := testing.CurrentVersion()
 	return s.startAgent(c, m.Tag(), password, vers, false)
 }
 

--- a/featuretests/tools_test.go
+++ b/featuretests/tools_test.go
@@ -111,7 +111,7 @@ func (s *toolsDownloadSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", current)[0]
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader("!"), 1)
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,7 +126,7 @@ func (s *toolsDownloadSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", current)[0]
 	sameSize := strings.Repeat("!", int(tools.Size))
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader(sameSize), tools.Size)

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -61,7 +61,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 	agenttest.InstallFakeEnsureMongo(s)
 
-	s.oldVersion = coretesting.CurrentVersion(c)
+	s.oldVersion = coretesting.CurrentVersion()
 	s.oldVersion.Major--
 
 	// Don't wait so long in tests.

--- a/testing/base.go
+++ b/testing/base.go
@@ -330,7 +330,7 @@ func GetExportedFields(arg interface{}) set.Strings {
 }
 
 // CurrentVersion returns the current Juju version, asserting on error.
-func CurrentVersion(c *gc.C) version.Binary {
+func CurrentVersion() version.Binary {
 	return version.Binary{
 		Number:  jujuversion.Current,
 		Arch:    arch.HostArch(),

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -317,7 +317,7 @@ func (factory *Factory) MakeMachineNested(c *gc.C, parentId string, params *Mach
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetProvisioned(params.InstanceId, params.DisplayName, params.Nonce, params.Characteristics)
 	c.Assert(err, jc.ErrorIsNil)
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	return m
@@ -383,7 +383,7 @@ func (factory *Factory) makeMachineReturningPassword(c *gc.C, params *MachinePar
 		err := machine.SetProviderAddresses(params.Addresses...)
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	return machine, params.Password

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -295,7 +295,7 @@ func (s *WorkerSuite) TestWorkerDownloadsCharm(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "WatchContainerStart", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion())
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 4, "WatchContainerStart", "gitlab", "(?:juju-pod-init|)")
 	s.client.CheckCall(c, 6, "Watch", "gitlab")
@@ -525,7 +525,7 @@ func (s *WorkerSuite) TestContainerStart(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "WatchContainerStart", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion())
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 4, "WatchContainerStart", "gitlab", "(?:juju-pod-init|)")
 	s.client.CheckCall(c, 6, "Watch", "gitlab")
@@ -570,7 +570,7 @@ func (s *WorkerSuite) TestOperatorNoWaitContainerStart(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion())
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 5, "Watch", "gitlab")
 }

--- a/worker/deployer/package_test.go
+++ b/worker/deployer/package_test.go
@@ -35,7 +35,7 @@ type BaseSuite struct {
 func (s *BaseSuite) InitializeCurrentToolsDir(c *gc.C, dataDir string) {
 	// Initialize the tools directory for the agent.
 	// This should be <DataDir>/tools/<version>-<series>-<arch>.
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	toolsDir := tools.SharedToolsDir(dataDir, current)
 	// Make that directory.
 	err := os.MkdirAll(toolsDir, 0755)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -226,7 +226,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Id(), gc.Equals, "0")
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -57,7 +57,7 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 	// wedged, so dump the logs.
 	coretesting.DumpTestLogsAfter(time.Minute, c, s)
 
-	s.oldVersion = coretesting.CurrentVersion(c)
+	s.oldVersion = coretesting.CurrentVersion()
 	s.oldVersion.Major = 1
 	s.oldVersion.Minor = 16
 


### PR DESCRIPTION
There 's a mock function `GetMockBundleTools` which was being passed a `gc.C` to assert against. But this was being done in a suite setup function which is verboten since a different `gc.C` gets used when running the tests. And the dummy provider was passing in a version param which would always cause the version assert in the mocked function to fail. But the failure would not be logged against the correct test due to the multiple `gc.C` issue.

The fix is to have the mocked function return an error and let the upstream caller fail if there's an issue.

Also `testing.CurrentVersion()` does not need a `gc.C`.

## QA steps

Run unit tests
