### PR TITLE
[backport] Add timeout to `wait_for` in bash tests

### DIFF
--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -1,31 +1,33 @@
-# SHORT_TIMEOUT creates a consistent short timeout of the wait_for condition.
+# SHORT_TIMEOUT is the time between polling attempts.
 SHORT_TIMEOUT=5
 
 # wait_for defines the ability to wait for a given condition to happen in a
 # juju status output. The output is JSON, so everything that the API server
 # knows about should be valid.
 # The query argument is a jq query.
-# The default timeout is 10 minutes (120 attempts @ 5 seconds each).
-# You can change this by providing the max_attempts argument.
+# The default timeout is 10 minutes. You can change this by providing the
+# timeout argument (an integer number of seconds).
 #
 # ```
-# wait_for <model name> <query> [<max_attempts>]
+# wait_for <model name> <query> [<timeout>]
 # ```
 wait_for() {
-	local name query max_attempts
+	local name query timeout
 
 	name=${1}
 	query=${2}
-	max_attempts=${3:-120} # default timeout: 120x5s = 10m
+	timeout=${3:-600} # default timeout: 600s = 10m
 
 	attempt=0
+	start_time="$(date -u +%s)"
 	# shellcheck disable=SC2046,SC2143
 	until [[ "$(juju status --format=json 2>/dev/null | jq -S "${query}" | grep "${name}")" ]]; do
 		echo "[+] (attempt ${attempt}) polling status for" "${query} => ${name}"
 		juju status --relations 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
 
-		if [[ "${attempt}" -ge ${max_attempts} ]]; then
+		elapsed=$(date -u +%s)-$start_time
+		if [[ ${elapsed} -ge ${timeout} ]]; then
 			echo "[-] $(red 'timed out waiting for')" "$(red "${name}")"
 			exit 1
 		fi
@@ -273,7 +275,7 @@ wait_for_systemd_service_files_to_appear() {
 		attempt=$((attempt + 1))
 	done
 
-	# shellcheck disable=SC2046
+	# shellcheck disable=SC2046,SC2005
 	echo $(red "Timed out waiting for the systemd unit files for ${unit} to appear")
 	exit 1
 }

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -1,3 +1,5 @@
+# Ensure that Charmed Kubernetes deploys successfully, and that we can
+# create storage on the cluster using kubectl after it's deployed.
 run_deploy_ck() {
 	echo
 
@@ -15,7 +17,7 @@ run_deploy_ck() {
 		sudo snap install kubectl --classic --channel latest/stable
 	fi
 
-	wait_for "active" '.applications["kubernetes-control-plane"] | ."application-status".current'
+	wait_for "active" '.applications["kubernetes-control-plane"] | ."application-status".current' 1800
 	wait_for "active" '.applications["kubernetes-worker"] | ."application-status".current'
 
 	kube_home="${HOME}/.kube"
@@ -29,6 +31,8 @@ run_deploy_ck() {
 	kubectl get sc -o yaml
 }
 
+# Ensure that a CAAS workload (mariadb+mediawiki) deploys successfully,
+# and that we can relate the two applications once it has.
 run_deploy_caas_workload() {
 	echo
 

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -54,7 +54,7 @@ run_deploy_caas_workload() {
 	juju deploy cs:~juju/mediawiki-k8s-4 --config kubernetes-service-type=loadbalancer
 	juju relate mediawiki-k8s:db mariadb-k8s:server
 
-	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current'
+	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current' 300
 	wait_for "active" '.applications["mediawiki-k8s"] | ."application-status".current'
 }
 


### PR DESCRIPTION
Backport of (part of) #14327 and #14360, instituting a default timeout on the bash tests' `wait_for` function.

The `test-ck-aws` is currently getting aborted on 2.9, because it is trying to poll status 1200 times. Obviously we want to have a timeout here. I've added a 5 minute timeout to wait for `mariadb-k8s` to reach an active state (should take ~2 mins).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~