### PR TITLE
[JUJU-1392] Deprecation check for bootstrap/deploy/add-machine/add-model commands

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -102,7 +102,7 @@ jobs:
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
         sudo snap install snapcraft --classic
-        sudo snap install lxd
+        sudo snap install lxd --channel latest/stable
         sudo snap install yq
         sudo snap install juju --classic --channel=${{ matrix.snap_version }}
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -101,6 +101,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
+        sudo snap remove lxd --purge
         sudo snap install snapcraft --classic
         sudo snap install lxd --channel latest/stable
         sudo snap install yq

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -21,7 +21,7 @@ jobs:
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
         sudo snap install snapcraft --classic
-        sudo snap install lxd
+        sudo snap install lxd --channel latest/stable
         sudo lxd waitready
         sudo lxd init --auto
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -20,6 +20,7 @@ jobs:
       run: |
         set -euxo pipefail
         sudo apt-get remove lxd lxd-client
+        sudo snap remove lxd --purge
         sudo snap install snapcraft --classic
         sudo snap install lxd --channel latest/stable
         sudo lxd waitready

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1134,7 +1134,7 @@ func sidecarUpgradeSeries(modelConfig *environsconfig.Config, supported []string
 
 	// Use model default series, if explicitly set and supported by the charm.
 	if selected, explicit := modelConfig.DefaultSeries(); explicit {
-		if _, err := charm.SeriesForCharm(selected, supported); err == nil {
+		if _, err := corecharm.SeriesForCharm(selected, supported); err == nil {
 			// validate the series we get from the charm
 			if !supportedJuju.Contains(selected) {
 				return "", errors.NotSupportedf("series: %q", selected)
@@ -1153,7 +1153,7 @@ func sidecarUpgradeSeries(modelConfig *environsconfig.Config, supported []string
 			filtered = append(filtered, charmSeries)
 		}
 	}
-	selected, err := charm.SeriesForCharm("", filtered)
+	selected, err := corecharm.SeriesForCharm("", filtered)
 	if err == nil {
 		return selected, nil
 	}

--- a/apiserver/facades/client/application/updateseries.go
+++ b/apiserver/facades/client/application/updateseries.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/juju/charm/v9"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -141,7 +140,7 @@ func (s stateSeriesValidator) ValidateApplication(application Application, serie
 	if len(supportedSeries) == 0 {
 		supportedSeries = append(supportedSeries, ch.URL().Series)
 	}
-	_, seriesSupportedErr := charm.SeriesForCharm(series, supportedSeries)
+	_, seriesSupportedErr := corecharm.SeriesForCharm(series, supportedSeries)
 	if seriesSupportedErr != nil && !force {
 		// TODO (stickupkid): Once all commands are placed in this API, we
 		// should relocate these to the API server.

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -186,6 +186,8 @@ func (mm *MachineManagerAPI) AddMachines(args params.AddMachines) (params.AddMac
 	return results, nil
 }
 
+var supportedJujuSeries = series.WorkloadSeries
+
 func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Machine, error) {
 	if p.ParentId != "" && p.ContainerType == "" {
 		return nil, fmt.Errorf("parent machine specified without container type")
@@ -223,6 +225,13 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 			return nil, errors.Trace(err)
 		}
 		p.Series = config.PreferredSeries(conf)
+	}
+	supportedSeries, err := supportedJujuSeries(time.Now(), p.Series, "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !supportedSeries.Contains(p.Series) {
+		return nil, errors.NotSupportedf("series %q", p.Series)
 	}
 
 	var placementDirective string

--- a/apiserver/facades/client/machinemanager/upgradeseries.go
+++ b/apiserver/facades/client/machinemanager/upgradeseries.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -454,7 +453,7 @@ func (s stateSeriesValidator) verifySupportedSeries(application Application, ser
 	if len(supportedSeries) == 0 {
 		supportedSeries = append(supportedSeries, ch.URL().Series)
 	}
-	_, seriesSupportedErr := charm.SeriesForCharm(series, supportedSeries)
+	_, seriesSupportedErr := corecharm.SeriesForCharm(series, supportedSeries)
 	if seriesSupportedErr != nil && !force {
 		// TODO (stickupkid): Once all commands are placed in this API, we
 		// should relocate these to the API server.

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -112,7 +112,7 @@ func (s *configureSuite) getCloudConfig(c *gc.C, controller bool, vers version.B
 	return cloudcfg
 }
 
-var allSeries = []string{"precise", "quantal", "raring", "saucy"}
+var allSeries = []string{"jammy", "focal"}
 
 func checkIff(checker gc.Checker, condition bool) gc.Checker {
 	if condition {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -38,7 +38,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs/config"
 	apiparams "github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/storage"
@@ -48,8 +47,6 @@ import (
 type SpacesAPI interface {
 	ListSpaces() ([]apiparams.Space, error)
 }
-
-var supportedJujuSeries = series.WorkloadSeries
 
 type CharmsAPI interface {
 	store.CharmsAPI

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/charm/v9"
 	charmresource "github.com/juju/charm/v9/resource"
 	"github.com/juju/charmrepo/v7"
-	csclientparams "github.com/juju/charmrepo/v7/csclient/params"
 	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -63,8 +62,7 @@ import (
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/series"
-	"github.com/juju/juju/juju/testing"
+	jujuseries "github.com/juju/juju/core/series"
 	jjtesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
@@ -76,11 +74,6 @@ import (
 	"github.com/juju/juju/version"
 )
 
-// defaultSupportedJujuSeries is used to return canned information about what
-// juju supports in terms of the release cycle
-// see juju/os and documentation https://www.ubuntu.com/about/release-cycle
-var defaultSupportedJujuSeries = set.NewStrings("bionic", "focal", "jammy", testing.KubernetesSeriesName)
-
 var defaultLocalOrigin = commoncharm.Origin{
 	Source:       commoncharm.OriginLocal,
 	Architecture: arch.DefaultArchitecture,
@@ -89,7 +82,7 @@ var defaultLocalOrigin = commoncharm.Origin{
 }
 
 type DeploySuiteBase struct {
-	testing.RepoSuite
+	jjtesting.RepoSuite
 	coretesting.CmdBlockHelper
 	DeployResources deployer.DeployResourcesFunc
 
@@ -165,9 +158,17 @@ func (s *DeploySuiteBase) SetUpTest(c *gc.C) {
 		c.Skip("Mongo failures on macOS")
 	}
 	s.RepoSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
-		return defaultSupportedJujuSeries, nil
-	})
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
+
 	s.CmdBlockHelper = coretesting.NewCmdBlockHelper(s.APIState)
 	c.Assert(s.CmdBlockHelper, gc.NotNil)
 	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
@@ -1019,10 +1020,16 @@ func (s *CAASDeploySuiteBase) expectDeployer(c *gc.C, cfg deployer.DeployerConfi
 }
 
 func (s *CAASDeploySuiteBase) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
-		return defaultSupportedJujuSeries, nil
-	})
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
 	cookiesFile := filepath.Join(c.MkDir(), ".go-cookies")
 	s.PatchEnvironment("JUJU_COOKIEFILE", cookiesFile)
 
@@ -1445,16 +1452,22 @@ func (s *DeploySuite) TestDeployLocalWithSeriesAndForce(c *gc.C) {
 }
 
 func (s *DeploySuite) setupNonESMSeries(c *gc.C) (string, string) {
-	supported := set.NewStrings(series.SupportedJujuWorkloadSeries()...)
+	supported := set.NewStrings(jujuseries.SupportedJujuWorkloadSeries()...)
 	// Allowing kubernetes as an option, can lead to an unrelated failure:
 	// 		series "kubernetes" in a non container model not valid
 	supported.Remove("kubernetes")
-	supportedNotEMS := supported.Difference(set.NewStrings(series.ESMSupportedJujuSeries()...))
+	supportedNotEMS := supported.Difference(set.NewStrings(jujuseries.ESMSupportedJujuSeries()...))
 	c.Assert(supportedNotEMS.Size(), jc.GreaterThan, 0)
 
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
-		return supported, nil
-	})
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
 
 	nonEMSSeries := supportedNotEMS.Values()[0]
 
@@ -1963,11 +1976,6 @@ type FakeStoreStateSuite struct {
 	riak *state.Application
 }
 
-func (s *FakeStoreStateSuite) runDeploy(c *gc.C, args ...string) error {
-	_, _, err := s.runDeployWithOutput(c, args...)
-	return err
-}
-
 func (s *FakeStoreStateSuite) runDeployWithOutput(c *gc.C, args ...string) (string, string, error) {
 	deploy := s.deployCommandForState()
 	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(deploy), args...)
@@ -2285,9 +2293,17 @@ var _ = gc.Suite(&DeployUnitTestSuite{})
 
 func (s *DeployUnitTestSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
-		return defaultSupportedJujuSeries, nil
-	})
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
+
 	cookiesFile := filepath.Join(c.MkDir(), ".go-cookies")
 	s.PatchEnvironment("JUJU_COOKIEFILE", cookiesFile)
 }
@@ -2584,7 +2600,7 @@ func newDeployCommandForTest(fakeAPI *fakeDeployAPI) *DeployCommand {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			risk := csclientparams.Channel(deployCmd.Channel.Risk)
+			risk := csparams.Channel(deployCmd.Channel.Risk)
 			cstoreClient := store.NewCharmStoreClient(bakeryClient, csURL).WithChannel(risk)
 			return &store.CharmStoreAdaptor{
 				MacaroonGetter:     cstoreClient,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -436,7 +436,7 @@ func (s *DeploySuite) TestDeployFromPath(c *gc.C) {
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeries(c *gc.C) {
 	path := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "multi-series")
 	err := s.runDeploy(c, path, "--series", "quantal")
-	c.Assert(err, gc.ErrorMatches, `series "quantal" not supported by charm, supported series are: focal,jammy,bionic`)
+	c.Assert(err, gc.ErrorMatches, `series "quantal" not supported by charm, the charm supported series are: focal,jammy,bionic`)
 }
 
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesForce(c *gc.C) {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -445,6 +445,15 @@ func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesForce(c *gc.C) {
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
 	withCharmDeployable(s.fakeAPI, curl, "focal", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"jammy", "focal", "bionic", "xenial", "quantal",
+			), nil
+		},
+	)
+
 	err := s.runDeployForState(c, charmDir.Path, "--series", "quantal", "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	s.AssertApplication(c, "multi-series", curl, 1, 0)
@@ -455,6 +464,15 @@ func (s *DeploySuite) TestDeployFromPathUnsupportedLXDProfileForce(c *gc.C) {
 	curl := charm.MustParseURL("local:quantal/lxd-profile-fail-0")
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, false)
 	withCharmDeployable(s.fakeAPI, curl, "focal", charmDir.Meta(), charmDir.Metrics(), false, true, 1, nil, nil)
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"jammy", "focal", "bionic", "xenial", "quantal",
+			), nil
+		},
+	)
 
 	err := s.runDeployForState(c, charmDir.Path, "--series", "quantal", "--force")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1445,6 +1463,15 @@ func (s *DeploySuite) TestDeployLocalWithSeriesAndForce(c *gc.C) {
 	curl := charm.MustParseURL("local:quantal/terms1-1")
 	withLocalCharmDeployable(s.fakeAPI, curl, charmDir, true)
 	withCharmDeployable(s.fakeAPI, curl, "bionic", charmDir.Meta(), charmDir.Metrics(), false, true, 1, nil, nil)
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"jammy", "focal", "bionic", "xenial", "quantal",
+			), nil
+		},
+	)
 
 	err := s.runDeployForState(c, charmDir.Path, "--series", "quantal", "--force")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -436,7 +436,7 @@ func (s *DeploySuite) TestDeployFromPath(c *gc.C) {
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeries(c *gc.C) {
 	path := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "multi-series")
 	err := s.runDeploy(c, path, "--series", "quantal")
-	c.Assert(err, gc.ErrorMatches, `series "quantal" not supported by charm, the charm supported series are: focal,jammy,bionic`)
+	c.Assert(err, gc.ErrorMatches, `multi-series is not available on the following series: quantal not supported`)
 }
 
 func (s *DeploySuite) TestDeployFromPathUnsupportedSeriesForce(c *gc.C) {

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1057,7 +1057,7 @@ func (h *bundleHandler) selectedSeries(ch charm.CharmMeta, chID application.Char
 		supportedSeries = []string{chID.URL.Series}
 	}
 
-	workloadSeries, err := supportedJujuSeries(h.clock.Now(), chSeries, h.modelConfig.ImageStream())
+	workloadSeries, err := SupportedJujuSeries(h.clock.Now(), chSeries, h.modelConfig.ImageStream())
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -64,7 +64,7 @@ func (s *BundleDeployRepositorySuite) SetUpTest(_ *gc.C) {
 
 	// TODO: remove this patch once we removed all the old series from tests in current package.
 	s.PatchValue(&SupportedJujuSeries,
-		func(now time.Time, requestedSeries, imageStream string) (set.Strings, error) {
+		func(time.Time, string, string) (set.Strings, error) {
 			return set.NewStrings(
 				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
 				"jammy", "focal", "bionic", "xenial",

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
@@ -43,6 +44,8 @@ import (
 )
 
 type BundleDeployRepositorySuite struct {
+	testing.IsolationSuite
+
 	allWatcher     *mocks.MockAllWatch
 	bundleResolver *mocks.MockResolver
 	deployerAPI    *mocks.MockDeployerAPI
@@ -58,6 +61,16 @@ var _ = gc.Suite(&BundleDeployRepositorySuite{})
 func (s *BundleDeployRepositorySuite) SetUpTest(_ *gc.C) {
 	s.deployArgs = make(map[string]application.DeployArgs)
 	s.output = bytes.NewBuffer([]byte{})
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&SupportedJujuSeries,
+		func(now time.Time, requestedSeries, imageStream string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
 }
 
 func (s *BundleDeployRepositorySuite) TearDownTest(_ *gc.C) {

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -199,7 +199,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeries(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 
-	c.Assert(err, gc.ErrorMatches, "series \"focal\" not supported by charm, supported series are: jammy")
+	c.Assert(err, gc.ErrorMatches, "series \"focal\" not supported by charm, the charm supported series are: jammy")
 }
 
 func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeriesWithForce(c *gc.C) {

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -199,7 +199,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeries(c *gc.C)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
 
-	c.Assert(err, gc.ErrorMatches, "series \"focal\" not supported by charm, the charm supported series are: jammy")
+	c.Assert(err, gc.ErrorMatches, `series "focal" is not supported, supported series are: jammy`)
 }
 
 func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeriesWithForce(c *gc.C) {

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application/store"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/juju/common"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
@@ -427,9 +428,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	// argument so users can target a specific origin.
 	origin := c.id.Origin
 	storeCharmOrBundleURL, origin, supportedSeries, err := resolver.ResolveCharm(userRequestedURL, origin, false) // no --switch possible.
-	if charm.IsUnsupportedSeriesError(err) {
-		return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
-	} else if err != nil {
+	if err != nil {
 		return errors.Trace(err)
 	}
 	if err := c.validateCharmFlags(); err != nil {
@@ -459,7 +458,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		}
 	}
 
-	if charm.IsUnsupportedSeriesError(err) {
+	if corecharm.IsUnsupportedSeriesError(err) {
 		return errors.Errorf("%v. Use --force to deploy the charm anyway.", err)
 	}
 	if validationErr := charmValidationError(storeCharmOrBundleURL.Name, errors.Trace(err)); validationErr != nil {
@@ -531,10 +530,7 @@ func isEmptyOrigin(origin commoncharm.Origin, source commoncharm.OriginSource) b
 		return true
 	}
 	other.Source = source
-	if origin == other {
-		return true
-	}
-	return false
+	return origin == other
 }
 
 func formatLocatedText(curl *charm.URL, origin commoncharm.Origin) string {

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -448,7 +448,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 
 	// Get the series to use.
 	series, err := selector.charmSeries()
-	logger.Tracef("Using series %s from %v to deploy %v", series, supportedSeries, userRequestedURL)
+	logger.Infof("Using series %q from %v to deploy %v", series, supportedSeries, userRequestedURL)
 
 	imageStream := modelCfg.ImageStream()
 	// Avoid deploying charm if it's not valid for the model.

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -448,7 +448,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 
 	// Get the series to use.
 	series, err := selector.charmSeries()
-	logger.Infof("Using series %q from %v to deploy %v", series, supportedSeries, userRequestedURL)
+	logger.Tracef("Using series %q from %v to deploy %v", series, supportedSeries, userRequestedURL)
 
 	imageStream := modelCfg.ImageStream()
 	// Avoid deploying charm if it's not valid for the model.

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -612,14 +612,7 @@ func (d *factory) validateCharmSeries(seriesName string, imageStream string) err
 		return errors.Trace(err)
 	}
 
-	var found bool
-	for _, name := range workloadSeries.Values() {
-		if name == seriesName {
-			found = true
-			break
-		}
-	}
-	if !found && !d.force {
+	if !workloadSeries.Contains(seriesName) && !d.force {
 		return errors.NotSupportedf("series: %s", seriesName)
 	}
 	return nil

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -338,7 +338,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 		}
 
 		imageStream = modelCfg.ImageStream()
-		workloadSeries, err := SupportedJujuSeries(d.clock.Now(), d.series, imageStream)
+		workloadSeries, err := SupportedJujuSeries(d.clock.Now(), seriesName, imageStream)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -338,7 +338,7 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 		}
 
 		imageStream = modelCfg.ImageStream()
-		workloadSeries, err := supportedJujuSeries(d.clock.Now(), d.series, imageStream)
+		workloadSeries, err := SupportedJujuSeries(d.clock.Now(), d.series, imageStream)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -584,7 +584,7 @@ func seriesSelectorRequirements(api ModelConfigGetter, cl jujuclock.Clock, chURL
 	}
 
 	imageStream := modelCfg.ImageStream()
-	workloadSeries, err := supportedJujuSeries(cl.Now(), userRequestedSeries, imageStream)
+	workloadSeries, err := SupportedJujuSeries(cl.Now(), userRequestedSeries, imageStream)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -607,7 +607,7 @@ func (d *factory) validateCharmSeries(seriesName string, imageStream string) err
 
 	// attempt to locate the charm series from the list of known juju series
 	// that we currently support.
-	workloadSeries, err := supportedJujuSeries(d.clock.Now(), seriesName, imageStream)
+	workloadSeries, err := SupportedJujuSeries(d.clock.Now(), seriesName, imageStream)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -371,9 +371,9 @@ func (d *factory) maybeReadLocalCharm(getter ModelConfigGetter) (Deployer, error
 	// We check for several types of known error which indicate
 	// that the supplied reference was indeed a path but there was
 	// an issue reading the charm located there.
-	if charm.IsMissingSeriesError(err) {
+	if corecharm.IsMissingSeriesError(err) {
 		return nil, err
-	} else if charm.IsUnsupportedSeriesError(err) {
+	} else if corecharm.IsUnsupportedSeriesError(err) {
 		return nil, errors.Trace(err)
 	} else if errors.Cause(err) == zip.ErrFormat {
 		return nil, errors.Errorf("invalid charm or bundle provided at %q", charmOrBundle)

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -630,13 +630,10 @@ func (d *factory) validateCharmSeriesWithName(series, name string, imageStream s
 // to help provide better feedback to the user when somethings gone wrong around
 // validating a charm validation
 func charmValidationError(name string, err error) error {
-	if err != nil {
-		if errors.IsNotSupported(err) {
-			return errors.Errorf("%v is not available on the following %v", name, err)
-		}
-		return errors.Trace(err)
+	if errors.Is(err, errors.NotSupported) {
+		return errors.Errorf("%v is not available on the following %v", name, err)
 	}
-	return nil
+	return errors.Trace(err)
 }
 
 func (d *factory) validateResourcesNeededForLocalDeploy(charmMeta *charm.Meta) error {

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -97,7 +97,8 @@ type ConsumeDetails interface {
 	Close() error
 }
 
-var supportedJujuSeries = series.WorkloadSeries
+// For testing.
+var SupportedJujuSeries = series.WorkloadSeries
 
 type DeployerAPI interface {
 	// APICallCloser is needed for the DeployResourcesFunc.

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -98,6 +98,7 @@ type ConsumeDetails interface {
 }
 
 // For testing.
+// TODO: unexport it if we don't need to patch it anymore.
 var SupportedJujuSeries = series.WorkloadSeries
 
 type DeployerAPI interface {

--- a/cmd/juju/application/deployer/series_selector.go
+++ b/cmd/juju/application/deployer/series_selector.go
@@ -106,6 +106,13 @@ func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 	// At this point, because we have no idea what series the charm supports,
 	// *everything* requires --force.
 	if !s.force {
+		logger.Tracef("juju supported series %s", s.supportedJujuSeries.SortedValues())
+		logger.Tracef("charm supported series %s", s.supportedSeries)
+		if charm.IsMissingSeriesError(err) {
+			// TODO: rephrase charm.errMissingSeries!
+			return "", errors.NotValidf("the charm supported series (%v) are deprecated", s.supportedSeries)
+		}
+
 		// We know err is not nil due to above, so return the error
 		// returned to us from the charm call.
 		return "", err
@@ -143,13 +150,9 @@ func (s seriesSelector) userRequested(requestedSeries string) (string, error) {
 }
 
 func (s seriesSelector) validateSeries(seriesName string) error {
-	// if we're forcing then we don't need the following validation checks.
 	if len(s.supportedJujuSeries) == 0 {
 		// programming error
 		return errors.Errorf("expected supported juju series to exist")
-	}
-	if s.force {
-		return nil
 	}
 
 	if !s.supportedJujuSeries.Contains(seriesName) {

--- a/cmd/juju/application/deployer/series_selector.go
+++ b/cmd/juju/application/deployer/series_selector.go
@@ -4,6 +4,8 @@
 package deployer
 
 import (
+	"strings"
+
 	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -108,9 +110,8 @@ func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 	if !s.force {
 		logger.Tracef("juju supported series %s", s.supportedJujuSeries.SortedValues())
 		logger.Tracef("charm supported series %s", s.supportedSeries)
-		if charm.IsMissingSeriesError(err) {
-			// TODO: rephrase charm.errMissingSeries!
-			return "", errors.NotValidf("the charm supported series (%v) are deprecated", s.supportedSeries)
+		if charm.IsMissingSeriesError(err) && len(s.supportedSeries) > 0 {
+			return "", errors.NotSupportedf("the charm supported series %q are deprecated", strings.Join(s.supportedSeries, ", "))
 		}
 
 		// We know err is not nil due to above, so return the error

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -194,7 +194,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				conf:                defaultSeries{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			err: `series "bionic" not supported by charm, the charm supported series are: utopic,vivid`,
+			err: `series: bionic`,
 		},
 		{
 			title: "juju deploy multiseries --series=bionic --force   # unsupported forced",
@@ -244,7 +244,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				supportedSeries: []string{"bionic", "utopic", "vivid"},
 				conf:            defaultSeries{},
 			},
-			err: `series: cosmic not supported`,
+			err: `series: cosmic`,
 		},
 		{
 			title: "juju deploy bionic/multiseries --series=cosmic  # unsupported series",

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -244,7 +244,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				supportedSeries: []string{"bionic", "utopic", "vivid"},
 				conf:            defaultSeries{},
 			},
-			err: `series "cosmic" not supported by charm, the charm supported series are: bionic,utopic,vivid`,
+			err: `series: cosmic not supported`,
 		},
 		{
 			title: "juju deploy bionic/multiseries --series=cosmic  # unsupported series",

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -137,7 +137,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				conf:                defaultSeries{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			err: "series not specified and charm does not define any",
+			err: `the charm supported series "precise" are deprecated not supported`,
 		},
 		{
 			title: "juju deploy multiseries   # use charm defaults used if default series doesn't match, nothing specified",
@@ -165,16 +165,6 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: disco not supported",
-		},
-		{
-			title: "juju deploy multiseries with force  # use model series defaults if supported by charm, force",
-			seriesSelector: seriesSelector{
-				supportedSeries:     []string{"bionic", "cosmic", "disco"},
-				conf:                defaultSeries{"disco", true},
-				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
-				force:               true,
-			},
-			expectedSeries: "disco",
 		},
 		{
 			title: "juju deploy multiseries --series=bionic   # use supported requested",

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -137,7 +137,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				conf:                defaultSeries{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			err: `the charm supported series "precise" are deprecated not supported`,
+			err: `the charm defined series "precise" not supported`,
 		},
 		{
 			title: "juju deploy multiseries   # use charm defaults used if default series doesn't match, nothing specified",
@@ -194,7 +194,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				conf:                defaultSeries{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			err: `series "bionic" not supported by charm, supported series are: utopic,vivid`,
+			err: `series "bionic" not supported by charm, the charm supported series are: utopic,vivid`,
 		},
 		{
 			title: "juju deploy multiseries --series=bionic --force   # unsupported forced",
@@ -244,7 +244,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				supportedSeries: []string{"bionic", "utopic", "vivid"},
 				conf:            defaultSeries{},
 			},
-			err: `series "cosmic" not supported by charm, supported series are: bionic,utopic,vivid`,
+			err: `series "cosmic" not supported by charm, the charm supported series are: bionic,utopic,vivid`,
 		},
 		{
 			title: "juju deploy bionic/multiseries --series=cosmic  # unsupported series",

--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -259,7 +259,14 @@ type RepoSuiteBaseSuite struct {
 
 func (s *RepoSuiteBaseSuite) SetUpTest(c *gc.C) {
 	s.RepoSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
-		return defaultSupportedJujuSeries, nil
-	})
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
 }

--- a/cmd/juju/application/refresh_resources_test.go
+++ b/cmd/juju/application/refresh_resources_test.go
@@ -9,13 +9,16 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/juju/charm/v9"
 	charmresource "github.com/juju/charm/v9/resource"
 	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/juju/application/deployer"
 	"github.com/juju/juju/testcharms"
 )
 
@@ -30,6 +33,17 @@ func (s *RefreshResourceSuite) SetUpTest(c *gc.C) {
 		c.Skip("Mongo failures on macOS")
 	}
 	s.RepoSuiteBaseSuite.SetUpTest(c)
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial", "quantal",
+			), nil
+		},
+	)
+
 	chPath := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "riak")
 	err := runDeploy(c, chPath, "riak", "--series", "quantal", "--force")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/juju/charm/v9"
@@ -21,6 +22,7 @@ import (
 	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -374,6 +376,16 @@ func (s *RefreshErrorsStateSuite) SetUpSuite(c *gc.C) {
 		c.Skip("Mongo failures on macOS")
 	}
 	s.RepoSuite.SetUpSuite(c)
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
 }
 
 func (s *RefreshErrorsStateSuite) SetUpTest(c *gc.C) {
@@ -513,6 +525,16 @@ func (s *RefreshSuccessStateSuite) SetUpTest(c *gc.C) {
 		c.Skip("Mongo failures on macOS")
 	}
 	s.RepoSuite.SetUpTest(c)
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
 
 	s.charmClient = mockCharmClient{}
 	s.cmd = NewRefreshCommandForStateTest(

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -273,7 +273,7 @@ func (r baseRefresher) ResolveCharm() (*charm.URL, commoncharm.Origin, error) {
 		return nil, commoncharm.Origin{}, errors.Trace(err)
 	}
 
-	_, seriesSupportedErr := charm.SeriesForCharm(r.deployedSeries, supportedSeries)
+	_, seriesSupportedErr := corecharm.SeriesForCharm(r.deployedSeries, supportedSeries)
 	if !r.forceSeries && r.deployedSeries != "" && newURL.Series == "" && seriesSupportedErr != nil {
 		series := []string{"no series"}
 		if len(supportedSeries) > 0 {

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -6,12 +6,15 @@ package application
 import (
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/juju/application/deployer"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -33,6 +36,16 @@ func (s *RemoveApplicationSuite) SetUpTest(c *gc.C) {
 	s.CmdBlockHelper = testing.NewCmdBlockHelper(s.APIState)
 	c.Assert(s.CmdBlockHelper, gc.NotNil)
 	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
 }
 
 func runRemoveApplication(c *gc.C, args ...string) (*cmd.Context, error) {

--- a/cmd/juju/application/unexpose_test.go
+++ b/cmd/juju/application/unexpose_test.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/juju/application/deployer"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/testcharms"
@@ -30,9 +31,17 @@ func (s *UnexposeSuite) SetUpTest(c *gc.C) {
 		c.Skip("Mongo failures on macOS")
 	}
 	s.RepoSuite.SetUpTest(c)
-	s.PatchValue(&supportedJujuSeries, func(time.Time, string, string) (set.Strings, error) {
-		return defaultSupportedJujuSeries, nil
-	})
+
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
+
 	s.CmdBlockHelper = testing.NewCmdBlockHelper(s.APIState)
 	c.Assert(s.CmdBlockHelper, gc.NotNil)
 	s.AddCleanup(func(*gc.C) { s.CmdBlockHelper.Close() })

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -762,9 +762,6 @@ to create a new model to deploy %sworkloads.
 		return errors.Annotate(err, "error reading supported bootstrap series")
 	}
 	logger.Tracef("supported bootstrap series %s", supportedBootstrapSeries.SortedValues())
-	if c.BootstrapSeries != "" && !supportedBootstrapSeries.Contains(c.BootstrapSeries) {
-		return errors.NotSupportedf("series %q", c.BootstrapSeries)
-	}
 
 	bootstrapCfg.controller[controller.ControllerName] = c.controllerName
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -761,6 +761,10 @@ to create a new model to deploy %sworkloads.
 	if err != nil {
 		return errors.Annotate(err, "error reading supported bootstrap series")
 	}
+	logger.Tracef("supported bootstrap series %s", supportedBootstrapSeries.SortedValues())
+	if c.BootstrapSeries != "" && !supportedBootstrapSeries.Contains(c.BootstrapSeries) {
+		return errors.NotSupportedf("series %q", c.BootstrapSeries)
+	}
 
 	bootstrapCfg.controller[controller.ControllerName] = c.controllerName
 

--- a/cmd/juju/machine/upgradeseries.go
+++ b/cmd/juju/machine/upgradeseries.go
@@ -34,6 +34,9 @@ const (
 	CompleteCommand = "complete"
 )
 
+// For testing.
+var SupportedJujuSeries = series.WorkloadSeries
+
 var upgradeSeriesConfirmationMsg = `
 WARNING: This command will mark machine %q as being upgraded to series %q.
 This operation cannot be reverted or canceled once started.
@@ -206,7 +209,7 @@ func (c *upgradeSeriesCommand) Init(args []string) error {
 
 	if c.subCommand == PrepareCommand {
 		seriesArg := args[2]
-		workloadSeries, err := series.WorkloadSeries(time.Now(), seriesArg, "")
+		workloadSeries, err := SupportedJujuSeries(time.Now(), seriesArg, "")
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -216,7 +219,6 @@ func (c *upgradeSeriesCommand) Init(args []string) error {
 		}
 		c.series = s
 	}
-
 	return nil
 }
 

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -179,7 +179,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnv(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
-		series:   "precise",
+		series:   "jammy",
 		arch:     "amd64",
 		region:   "us-east-1",
 		endpoint: "https://ec2.us-east-1.amazonaws.com",
@@ -196,7 +196,7 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnvWithRegionOverride(c 
 	c.Assert(err, jc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
 	expected := expectedMetadata{
-		series:   "precise",
+		series:   "jammy",
 		arch:     "amd64",
 		region:   "us-west-1",
 		endpoint: "https://ec2.us-west-1.amazonaws.com",

--- a/cmd/plugins/juju-metadata/validateimagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/validateimagemetadata_test.go
@@ -102,7 +102,7 @@ func cacheTestEnvConfig(c *gc.C, store *jujuclient.MemStore) {
 	ec2Config, err := config.New(config.UseDefaults, map[string]interface{}{
 		"name":            "ec2",
 		"type":            "ec2",
-		"default-series":  "precise",
+		"default-series":  "jammy",
 		"controller-uuid": coretesting.ControllerTag.Id(),
 		"uuid":            ec2UUID,
 	})
@@ -165,7 +165,7 @@ func (s *ValidateImageMetadataSuite) setupEc2LocalMetadata(c *gc.C, region, stre
 	ep, err := resolver.ResolveEndpoint(region, ec2.EndpointResolverOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.makeLocalMetadata("1234", region, "precise", ep.URL, stream)
+	err = s.makeLocalMetadata("1234", region, "jammy", ep.URL, stream)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -201,7 +201,7 @@ func (s *ValidateImageMetadataSuite) TestEc2LocalMetadataUsingIncompleteEnvironm
 func (s *ValidateImageMetadataSuite) TestEc2LocalMetadataWithManualParams(c *gc.C) {
 	s.setupEc2LocalMetadata(c, "us-west-1", "")
 	ctx, err := runValidateImageMetadata(c, s.store,
-		"-p", "ec2", "-s", "precise", "-r", "us-west-1",
+		"-p", "ec2", "-s", "jammy", "-r", "us-west-1",
 		"-u", "https://ec2.us-west-1.amazonaws.com", "-d", s.metadataDir,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -220,7 +220,7 @@ func (s *ValidateImageMetadataSuite) TestEc2LocalMetadataNoMatch(c *gc.C) {
 	)
 	c.Check(err, gc.ErrorMatches, "(.|\n)*Resolve Metadata:(.|\n)*")
 	_, err = runValidateImageMetadata(c, s.store,
-		"-p", "ec2", "-s", "precise", "-r", "region",
+		"-p", "ec2", "-s", "jammy", "-r", "region",
 		"-u", "https://ec2.region.amazonaws.com", "-d", s.metadataDir,
 	)
 	c.Assert(err, gc.NotNil)
@@ -247,7 +247,7 @@ func (s *ValidateImageMetadataSuite) TestOpenstackLocalMetadataNoMatch(c *gc.C) 
 	err := s.makeLocalMetadata("1234", "region-2", "raring", "some-auth-url", "")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = runValidateImageMetadata(c, s.store,
-		"-p", "openstack", "-s", "precise", "-r", "region-2",
+		"-p", "openstack", "-s", "jammy", "-r", "region-2",
 		"-u", "some-auth-url", "-d", s.metadataDir,
 	)
 	c.Check(err, gc.ErrorMatches, "(.|\n)*Resolve Metadata:(.|\n)*")

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -1240,10 +1240,10 @@ func getSeries(application *charm.ApplicationSpec, defaultSeries string) (string
 	// Handle local charm paths.
 	if charm.IsValidLocalCharmOrBundlePath(application.Charm) {
 		_, charmURL, err := corecharm.NewCharmAtPath(application.Charm, defaultSeries)
-		if charm.IsMissingSeriesError(err) {
+		if corecharm.IsMissingSeriesError(err) {
 			// local charm path is valid but the charm doesn't declare a default series.
 			return defaultSeries, nil
-		} else if charm.IsUnsupportedSeriesError(err) {
+		} else if corecharm.IsUnsupportedSeriesError(err) {
 			// The bundle's default series is not supported by the charm, but we'll
 			// use it anyway. This is no different to the case above where application.Series
 			// is used without checking for potential charm incompatibility.

--- a/core/charm/charmpath.go
+++ b/core/charm/charmpath.go
@@ -74,6 +74,7 @@ func charmSeries(series string, force bool, cm charm.CharmMeta) (string, error) 
 		return series, nil
 	}
 	computedSeries, err := ComputedSeries(cm)
+	logger.Tracef("series %q, %v", series, computedSeries)
 	if err != nil {
 		return "", err
 	}

--- a/core/charm/charmpath.go
+++ b/core/charm/charmpath.go
@@ -152,7 +152,7 @@ type unsupportedSeriesError struct {
 
 func (e *unsupportedSeriesError) Error() string {
 	return fmt.Sprintf(
-		"series %q not supported by charm, supported series are: %s",
+		"series %q not supported by charm, the charm supported series are: %s",
 		e.requestedSeries, strings.Join(e.supportedSeries, ","),
 	)
 }

--- a/core/charm/charmpath_test.go
+++ b/core/charm/charmpath_test.go
@@ -122,14 +122,14 @@ func (s *charmPathSuite) TestUnsupportedSeries(c *gc.C) {
 	charmDir := filepath.Join(s.repoPath, "multi-series-charmpath")
 	s.cloneCharmDir(s.repoPath, "multi-series-charmpath")
 	_, _, err := corecharm.NewCharmAtPath(charmDir, "wily")
-	c.Assert(err, gc.ErrorMatches, `series "wily" not supported by charm, supported series are.*`)
+	c.Assert(err, gc.ErrorMatches, `series "wily" not supported by charm, the charm supported series are.*`)
 }
 
 func (s *charmPathSuite) TestUnsupportedSeriesNoForce(c *gc.C) {
 	charmDir := filepath.Join(s.repoPath, "multi-series-charmpath")
 	s.cloneCharmDir(s.repoPath, "multi-series-charmpath")
 	_, _, err := corecharm.NewCharmAtPathForceSeries(charmDir, "wily", false)
-	c.Assert(err, gc.ErrorMatches, `series "wily" not supported by charm, supported series are.*`)
+	c.Assert(err, gc.ErrorMatches, `series "wily" not supported by charm, the charm supported series are.*`)
 }
 
 func (s *charmPathSuite) TestUnsupportedSeriesForce(c *gc.C) {

--- a/core/charm/computedseries.go
+++ b/core/charm/computedseries.go
@@ -16,6 +16,39 @@ import (
 
 var logger = loggo.GetLogger("juju.core.charm")
 
+// SeriesForCharm takes a requested series and a list of series supported by a
+// charm and returns the series which is relevant.
+// If the requested series is empty, then the first supported series is used,
+// otherwise the requested series is validated against the supported series.
+func SeriesForCharm(requestedSeries string, supportedSeries []string) (string, error) {
+	// Old charm with no supported series.
+	if len(supportedSeries) == 0 {
+		if requestedSeries == "" {
+			return "", errMissingSeries
+		}
+		return requestedSeries, nil
+	}
+	// Use the charm default.
+	if requestedSeries == "" {
+		return supportedSeries[0], nil
+	}
+	for _, s := range supportedSeries {
+		if s == requestedSeries {
+			return requestedSeries, nil
+		}
+	}
+	return "", NewUnsupportedSeriesError(requestedSeries, supportedSeries)
+}
+
+// errMissingSeries is used to denote that SeriesForCharm could not determine
+// a series because a legacy charm did not declare any.
+var errMissingSeries = errors.New("series not specified and charm does not define any")
+
+// IsMissingSeriesError returns true if err is an errMissingSeries.
+func IsMissingSeriesError(err error) bool {
+	return err == errMissingSeries
+}
+
 // ComputedSeries of a charm, preserving legacy behavior.  If the charm has
 // no manifest, return series from the metadata. Otherwise return the series
 // listed in the manifest Bases as channels.

--- a/core/series/supported.go
+++ b/core/series/supported.go
@@ -141,7 +141,6 @@ func (s *supportedInfo) controllerSeries() []string {
 			continue
 		}
 		if version.ESMSupported || version.Supported {
-			logger.Criticalf("controllerSeries namedSeries.Name.String() %q, %#v", namedSeries.Name.String(), version)
 			result = append(result, namedSeries.Name.String())
 		}
 	}

--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -146,7 +146,12 @@ func updateSeriesVersions() error {
 	switch hostOS {
 	case jujuos.Ubuntu:
 		for seriesName, s := range sInfo {
-			ubuntuSeries[SeriesName(seriesName)] = seriesVersion{
+			key := SeriesName(seriesName)
+			if _, known := ubuntuSeries[key]; known {
+				// We only update unknown/new series.
+				continue
+			}
+			ubuntuSeries[key] = seriesVersion{
 				WorkloadType:             ControllerWorkloadType,
 				Version:                  s.Version,
 				LTS:                      s.LTS,

--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -74,7 +74,8 @@ func AllWorkloadOSTypes(requestedSeries, imageStream string) (set.Strings, error
 	return result, nil
 }
 
-func seriesForTypes(path string, now time.Time, requestedSeries, imageStream string) (*supportedInfo, error) {
+func seriesForTypes(
+	path string, now time.Time, requestedSeries, imageStream string) (*supportedInfo, error) {
 	// We support all of the juju series AND all the ESM supported series.
 	// Juju is congruent with the Ubuntu release cycle for its own series (not
 	// including centos), so that should be reflected here.
@@ -91,7 +92,8 @@ func seriesForTypes(path string, now time.Time, requestedSeries, imageStream str
 	}
 
 	source := series.NewDistroInfo(path)
-	supported := newSupportedInfo(source, allSeriesVersions)
+	ignoreDistroInfoUpdate := true // We do not want to update the `.Supported`.
+	supported := newSupportedInfo(source, allSeriesVersions, &ignoreDistroInfoUpdate)
 	if err := supported.compile(now); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -82,16 +82,25 @@ func seriesForTypes(path string, now time.Time, requestedSeries, imageStream str
 	seriesVersionsMutex.Lock()
 	defer seriesVersionsMutex.Unlock()
 	updateSeriesVersionsOnce()
+	all := getAllSeriesVersions()
 	if requestedSeries != "" && imageStream == Daily {
-		setSupported(allSeriesVersions, requestedSeries)
+		setSupported(all, requestedSeries)
 	}
 	source := series.NewDistroInfo(path)
-	supported := newSupportedInfo(source, allSeriesVersions)
+	supported := newSupportedInfo(source, all)
 	if err := supported.compile(now); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	return supported, nil
+}
+
+func getAllSeriesVersions() map[SeriesName]seriesVersion {
+	copy := make(map[SeriesName]seriesVersion, len(allSeriesVersions))
+	for name, v := range allSeriesVersions {
+		copy[name] = v
+	}
+	return copy
 }
 
 // GetOSFromSeries will return the operating system based

--- a/core/series/supportedseries.go
+++ b/core/series/supportedseries.go
@@ -74,26 +74,19 @@ func AllWorkloadOSTypes(requestedSeries, imageStream string) (set.Strings, error
 	return result, nil
 }
 
-func seriesForTypes(
-	path string, now time.Time, requestedSeries, imageStream string) (*supportedInfo, error) {
-	// We support all of the juju series AND all the ESM supported series.
-	// Juju is congruent with the Ubuntu release cycle for its own series (not
-	// including centos), so that should be reflected here.
-	//
+func seriesForTypes(path string, now time.Time, requestedSeries, imageStream string) (*supportedInfo, error) {
 	// For non-LTS releases; they'll appear in juju/os as default available, but
 	// after reading the `/usr/share/distro-info/ubuntu.csv` on the Ubuntu distro
 	// the non-LTS should disappear if they're not in the release window for that
 	// series.
 	seriesVersionsMutex.Lock()
 	defer seriesVersionsMutex.Unlock()
-	composeSeriesVersions()
+	updateSeriesVersionsOnce()
 	if requestedSeries != "" && imageStream == Daily {
 		setSupported(allSeriesVersions, requestedSeries)
 	}
-
 	source := series.NewDistroInfo(path)
-	ignoreDistroInfoUpdate := true // We do not want to update the `.Supported`.
-	supported := newSupportedInfo(source, allSeriesVersions, &ignoreDistroInfoUpdate)
+	supported := newSupportedInfo(source, allSeriesVersions)
 	if err := supported.compile(now); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/core/series/supportedseries_linux_test.go
+++ b/core/series/supportedseries_linux_test.go
@@ -80,6 +80,6 @@ func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
 	series, err := WorkloadSeries(time.Time{}, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
-		"bionic", "centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kubernetes",
-		"opensuseleap", "trusty", "xenial"})
+		"centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kubernetes",
+		"opensuseleap"})
 }

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -37,10 +37,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -53,10 +53,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -69,10 +69,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -85,10 +85,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap"})
 }
 
 var getOSFromSeriesTests = []struct {

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -217,7 +217,7 @@ func (s *bootstrapSuite) TestBootstrapSpecifiedBootstrapSeries(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	cfg, err := env.Config().Apply(map[string]interface{}{
-		"default-series": "wily",
+		"default-series": "focal",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
@@ -261,7 +261,7 @@ func (s *bootstrapSuite) TestBootstrapForcedBootstrapSeries(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	cfg, err := env.Config().Apply(map[string]interface{}{
-		"default-series": "wily",
+		"default-series": "jammy",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg
@@ -271,13 +271,13 @@ func (s *bootstrapSuite) TestBootstrapForcedBootstrapSeries(c *gc.C) {
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              "admin-secret",
 			CAPrivateKey:             coretesting.CAKey,
-			BootstrapSeries:          "xenial",
+			BootstrapSeries:          "focal",
 			SupportedBootstrapSeries: supportedJujuSeries,
 			Force:                    true,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(env.bootstrapCount, gc.Equals, 1)
-	c.Check(env.args.BootstrapSeries, gc.Equals, "xenial")
+	c.Check(env.args.BootstrapSeries, gc.Equals, "focal")
 	c.Check(env.args.AvailableTools.AllReleases(), jc.SameContents, []string{"ubuntu"})
 }
 
@@ -285,7 +285,7 @@ func (s *bootstrapSuite) TestBootstrapWithInvalidBootstrapSeries(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	s.setDummyStorage(c, env)
 	cfg, err := env.Config().Apply(map[string]interface{}{
-		"default-series": "spock",
+		"default-series": "jammy",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	env.cfg = cfg

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/controller"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/logfwd/syslog"
@@ -293,6 +294,9 @@ const (
 	// LoggingOutputKey is a key for determining the destination of output for
 	// logging.
 	LoggingOutputKey = "logging-output"
+
+	// DefaultSeriesKey is a key for the default Ubuntu series to use for the model.
+	DefaultSeriesKey = "default-series"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -494,7 +498,7 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	"default-series":                jujuversion.DefaultSupportedLTS(),
+	DefaultSeriesKey:                jujuversion.DefaultSupportedLTS(),
 	ProvisionerHarvestModeKey:       HarvestDestroyed.String(),
 	NumProvisionWorkersKey:          16,
 	NumContainerProvisionWorkersKey: 4,
@@ -795,6 +799,10 @@ func Validate(cfg, old *Config) error {
 		return errors.Trace(err)
 	}
 
+	if err := cfg.validateDefaultSeries(); err != nil {
+		return errors.Trace(err)
+	}
+
 	if err := cfg.validateMode(); err != nil {
 		return errors.Trace(err)
 	}
@@ -931,10 +939,28 @@ func (c *Config) DefaultSpace() string {
 	return c.asString(DefaultSpace)
 }
 
+var supportedJujuSeries = series.WorkloadSeries
+
+func (c *Config) validateDefaultSeries() error {
+	defaultSeries, configured := c.DefaultSeries()
+	if !configured {
+		return nil
+	}
+	supported, err := supportedJujuSeries(time.Now(), "", "")
+	if err != nil {
+		return errors.Annotate(err, "cannot read supported series")
+	}
+	logger.Tracef("supported series %s", supported.SortedValues())
+	if !supported.Contains(defaultSeries) {
+		return errors.NotSupportedf("series %q", defaultSeries)
+	}
+	return nil
+}
+
 // DefaultSeries returns the configured default Ubuntu series for the model,
 // and whether the default series was explicitly configured on the environment.
 func (c *Config) DefaultSeries() (string, bool) {
-	s, ok := c.defined["default-series"]
+	s, ok := c.defined[DefaultSeriesKey]
 	if !ok {
 		return "", false
 	}
@@ -1701,7 +1727,7 @@ var alwaysOptional = schema.Defaults{
 	AgentMetadataURLKey:             schema.Omit,
 	ContainerImageStreamKey:         schema.Omit,
 	ContainerImageMetadataURLKey:    schema.Omit,
-	"default-series":                schema.Omit,
+	DefaultSeriesKey:                schema.Omit,
 	"development":                   schema.Omit,
 	"ssl-hostname-verification":     schema.Omit,
 	"proxy-ssh":                     schema.Omit,
@@ -1933,7 +1959,7 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	"default-series": {
+	DefaultSeriesKey: {
 		Description: "The default series of Ubuntu to use for deploying charms",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -106,8 +106,22 @@ var configTests = []configTest{
 		about:       "Explicit series",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"default-series": "jammy",
+		}),
+	}, {
+		about:       "old series",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"default-series": "bionic",
+		}),
+		err: `series "bionic" not supported`,
+	}, {
+		about:       "bad series",
+		useDefaults: config.UseDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
 			"default-series": "my-series",
 		}),
+		err: `series "my-series" not supported`,
 	}, {
 		about:       "Explicit logging",
 		useDefaults: config.UseDefaults,
@@ -395,7 +409,7 @@ var configTests = []configTest{
 			"ssl-hostname-verification":  true,
 			"authorized-keys":            "ssh-rsa mykeys rog@rog-x220\n",
 			"region":                     "us-east-1",
-			"default-series":             "precise",
+			"default-series":             "focal",
 			"secret-key":                 "a-secret-key",
 			"access-key":                 "an-access-key",
 			"agent-version":              "1.13.2",

--- a/featuretests/cmd_juju_deploy_test.go
+++ b/featuretests/cmd_juju_deploy_test.go
@@ -4,18 +4,35 @@
 package featuretests
 
 import (
+	"time"
+
 	"github.com/juju/charm/v9"
 	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/cmd/juju/application/deployer"
 	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/testcharms"
 )
 
 type cmdDeploySuite struct {
 	testing.JujuConnSuite
+}
+
+func (s *cmdDeploySuite) SetUpTest(c *gc.C) {
+	s.JujuConnSuite.SetUpTest(c)
+	// TODO: remove this patch once we removed all the old series from tests in current package.
+	s.PatchValue(&deployer.SupportedJujuSeries,
+		func(time.Time, string, string) (set.Strings, error) {
+			return set.NewStrings(
+				"centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap",
+				"jammy", "focal", "bionic", "xenial",
+			), nil
+		},
+	)
 }
 
 func (s *cmdDeploySuite) TestLocalDeploySuccess(c *gc.C) {

--- a/provider/lxd/export_test.go
+++ b/provider/lxd/export_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	NewInstance           = newInstance
-	GetCertificates       = getCertificates
-	IsSupportedAPIVersion = isSupportedAPIVersion
+	NewInstance     = newInstance
+	GetCertificates = getCertificates
+	ParseAPIVersion = parseAPIVersion
 )
 
 func NewProviderWithMocks(

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -271,31 +271,6 @@ func (p *environProvider) DetectCloud(name string) (cloud.Cloud, error) {
 	return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
 }
 
-func (p *environProvider) detectCloud(name, path string) (cloud.Cloud, error) {
-	config, err := p.lxcConfigReader.ReadConfig(path)
-	if err != nil {
-		return cloud.Cloud{}, err
-	}
-
-	if remote, ok := config.Remotes[name]; ok {
-		return cloud.Cloud{
-			Name:        name,
-			Type:        lxdnames.ProviderType,
-			Endpoint:    remote.Addr,
-			Description: cloud.DefaultCloudDescription(lxdnames.ProviderType),
-			AuthTypes: []cloud.AuthType{
-				cloud.CertificateAuthType,
-			},
-			Regions: []cloud.Region{{
-				Name:     lxdnames.DefaultRemoteRegion,
-				Endpoint: remote.Addr,
-			}},
-		}, nil
-	}
-
-	return cloud.Cloud{}, errors.NotFoundf("cloud %s", name)
-}
-
 // FinalizeCloud is part of the environs.CloudFinalizer interface.
 func (p *environProvider) FinalizeCloud(
 	ctx environs.FinalizeCloudContext,

--- a/provider/lxd/server_integration_test.go
+++ b/provider/lxd/server_integration_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	client "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared/api"
 	gc "gopkg.in/check.v1"
@@ -18,7 +20,6 @@ import (
 	"github.com/juju/juju/cloud"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/provider/lxd"
-	"github.com/juju/testing"
 )
 
 var (
@@ -44,11 +45,6 @@ func (s *serverIntegrationSuite) TestLocalServer(c *gc.C) {
 			"https://192.168.0.1:8443",
 		},
 	}
-	serverInfo := &api.Server{
-		ServerUntrusted: api.ServerUntrusted{
-			APIVersion: "1.1",
-		},
-	}
 
 	factory, server, interfaceAddr := lxd.NewLocalServerFactory(ctrl)
 
@@ -62,7 +58,7 @@ func (s *serverIntegrationSuite) TestLocalServer(c *gc.C) {
 		server.EXPECT().StorageSupported().Return(true),
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
-		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
+		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
 	svr, err := factory.LocalServer()
@@ -87,11 +83,6 @@ func (s *serverIntegrationSuite) TestLocalServerRetrySemantics(c *gc.C) {
 			"https://192.168.0.1:8443",
 		},
 	}
-	serverInfo := &api.Server{
-		ServerUntrusted: api.ServerUntrusted{
-			APIVersion: "1.1",
-		},
-	}
 
 	factory, server, interfaceAddr := lxd.NewLocalServerFactory(ctrl)
 
@@ -109,7 +100,7 @@ func (s *serverIntegrationSuite) TestLocalServerRetrySemantics(c *gc.C) {
 		server.EXPECT().StorageSupported().Return(true),
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
-		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
+		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
 	svr, err := factory.LocalServer()
@@ -158,11 +149,6 @@ func (s *serverIntegrationSuite) TestLocalServerWithInvalidAPIVersion(c *gc.C) {
 			"https://192.168.0.1:8443",
 		},
 	}
-	serverInfo := &api.Server{
-		ServerUntrusted: api.ServerUntrusted{
-			APIVersion: "a.b",
-		},
-	}
 
 	factory, server, interfaceAddr := lxd.NewLocalServerFactory(ctrl)
 
@@ -176,7 +162,7 @@ func (s *serverIntegrationSuite) TestLocalServerWithInvalidAPIVersion(c *gc.C) {
 		server.EXPECT().StorageSupported().Return(true),
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
-		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
+		server.EXPECT().ServerVersion().Return("a.b"),
 	)
 
 	svr, err := factory.LocalServer()
@@ -314,11 +300,6 @@ func (s *serverIntegrationSuite) TestLocalServerWithStorageNotSupported(c *gc.C)
 			"https://192.168.0.1:8443",
 		},
 	}
-	serverInfo := &api.Server{
-		ServerUntrusted: api.ServerUntrusted{
-			APIVersion: "2.2",
-		},
-	}
 
 	factory, server, interfaceAddr := lxd.NewLocalServerFactory(ctrl)
 
@@ -330,7 +311,7 @@ func (s *serverIntegrationSuite) TestLocalServerWithStorageNotSupported(c *gc.C)
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
 		server.EXPECT().StorageSupported().Return(false),
-		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
+		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
 	svr, err := factory.RemoteServer(environscloudspec.CloudSpec{
@@ -353,11 +334,6 @@ func (s *serverIntegrationSuite) TestRemoteServerWithEmptyEndpointYieldsLocalSer
 			"https://192.168.0.1:8443",
 		},
 	}
-	serverInfo := &api.Server{
-		ServerUntrusted: api.ServerUntrusted{
-			APIVersion: "1.1",
-		},
-	}
 
 	factory, server, interfaceAddr := lxd.NewLocalServerFactory(ctrl)
 
@@ -371,7 +347,7 @@ func (s *serverIntegrationSuite) TestRemoteServerWithEmptyEndpointYieldsLocalSer
 		server.EXPECT().StorageSupported().Return(true),
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
-		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
+		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
 	svr, err := factory.RemoteServer(environscloudspec.CloudSpec{
@@ -387,11 +363,6 @@ func (s *serverIntegrationSuite) TestRemoteServer(c *gc.C) {
 
 	profile := &api.Profile{}
 	etag := "etag"
-	serverInfo := &api.Server{
-		ServerUntrusted: api.ServerUntrusted{
-			APIVersion: "1.1",
-		},
-	}
 
 	factory, server := lxd.NewRemoteServerFactory(ctrl)
 
@@ -399,7 +370,7 @@ func (s *serverIntegrationSuite) TestRemoteServer(c *gc.C) {
 		server.EXPECT().StorageSupported().Return(true),
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().EnsureDefaultStorage(profile, etag).Return(nil),
-		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
+		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
 	creds := cloud.NewCredential("any", map[string]string{
@@ -420,18 +391,11 @@ func (s *serverIntegrationSuite) TestRemoteServerWithNoStorage(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	etag := "etag"
-	serverInfo := &api.Server{
-		ServerUntrusted: api.ServerUntrusted{
-			APIVersion: "1.1",
-		},
-	}
-
 	factory, server := lxd.NewRemoteServerFactory(ctrl)
 
 	gomock.InOrder(
 		server.EXPECT().StorageSupported().Return(false),
-		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
+		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
 	creds := cloud.NewCredential("any", map[string]string{
@@ -483,7 +447,7 @@ func (s *serverIntegrationSuite) TestRemoteServerMissingCertificates(c *gc.C) {
 	c.Assert(errors.Cause(err).Error(), gc.Equals, "credentials not valid")
 }
 
-func (s *serverIntegrationSuite) TestRemoteServerWithGetServerError(c *gc.C) {
+func (s *serverIntegrationSuite) TestRemoteServerWithUnSupportedAPIVersion(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -491,7 +455,7 @@ func (s *serverIntegrationSuite) TestRemoteServerWithGetServerError(c *gc.C) {
 
 	gomock.InOrder(
 		server.EXPECT().StorageSupported().Return(false),
-		server.EXPECT().GetServer().Return(nil, "", errors.New("bad")),
+		server.EXPECT().ServerVersion().Return("5.1"),
 	)
 
 	creds := cloud.NewCredential("any", map[string]string{
@@ -503,48 +467,36 @@ func (s *serverIntegrationSuite) TestRemoteServerWithGetServerError(c *gc.C) {
 		Endpoint:   "https://10.0.0.9:8443",
 		Credential: &creds,
 	})
-	c.Assert(errors.Cause(err).Error(), gc.Equals, "bad")
+	c.Assert(errors.Cause(err).Error(), gc.Equals, `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`)
 }
 
 func (s *serverIntegrationSuite) TestIsSupportedAPIVersion(c *gc.C) {
 	for _, t := range []struct {
-		input    string
-		expected bool
-		output   string
+		input  string
+		output string
 	}{
 		{
-			input:    "foo",
-			expected: false,
-			output:   `LXD API version "foo": expected format <major>\.<minor>`,
+			input:  "foo",
+			output: `LXD API version "foo": expected format <major>\.<minor>`,
 		},
 		{
-			input:    "a.b",
-			expected: false,
-			output:   `major version number  a not valid`,
+			input:  "a.b",
+			output: `major version number  a not valid`,
 		},
 		{
-			input:    "0.9",
-			expected: false,
-			output:   `LXD API version "0.9": expected major version 1 or later`,
+			input:  "5.1",
+			output: `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`,
 		},
 		{
-			input:    "1.0",
-			expected: true,
-			output:   "",
-		},
-		{
-			input:    "2.0",
-			expected: true,
-			output:   "",
-		},
-		{
-			input:    "2.1",
-			expected: true,
-			output:   "",
+			input:  "5.2",
+			output: "",
 		},
 	} {
-		msg, ok := lxd.IsSupportedAPIVersion(t.input)
-		c.Check(ok, gc.Equals, t.expected)
-		c.Check(msg, gc.Matches, t.output)
+		err := lxd.ValidateAPIVersion(t.input)
+		if t.output == "" {
+			c.Check(err, jc.ErrorIsNil)
+		} else {
+			c.Check(err, gc.ErrorMatches, t.output)
+		}
 	}
 }

--- a/provider/lxd/server_test.go
+++ b/provider/lxd/server_test.go
@@ -35,3 +35,11 @@ func (s *serverSuite) TestParseAPIVersion(c *gc.C) {
 	_, err = ParseAPIVersion("1.b")
 	c.Check(err, gc.ErrorMatches, `minor version number  b not valid`)
 }
+
+func (s *serverSuite) TestValidateAPIVersion(c *gc.C) {
+	err := ValidateAPIVersion("5.2")
+	c.Check(err, jc.ErrorIsNil)
+
+	err = ValidateAPIVersion("5.1")
+	c.Check(err, gc.ErrorMatches, `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`)
+}

--- a/state/application.go
+++ b/state/application.go
@@ -2061,7 +2061,7 @@ func (a *Application) VerifySupportedSeries(series string, force bool) error {
 	if len(supportedSeries) == 0 {
 		supportedSeries = append(supportedSeries, ch.URL().Series)
 	}
-	_, seriesSupportedErr := charm.SeriesForCharm(series, supportedSeries)
+	_, seriesSupportedErr := corecharm.SeriesForCharm(series, supportedSeries)
 	if seriesSupportedErr != nil && !force {
 		return stateerrors.NewErrIncompatibleSeries(supportedSeries, series, ch.String())
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -4186,7 +4186,7 @@ func (s *StateSuite) TestSetModelAgentVersionRetriesOnConfigChange(c *gc.C) {
 	// other than the version, and make sure it retries
 	// and passes.
 	defer state.SetBeforeHooks(c, s.State, func() {
-		s.changeEnviron(c, modelConfig, "default-series", "foo")
+		s.changeEnviron(c, modelConfig, "default-series", "focal")
 	}).Check()
 
 	// Change the agent-version and ensure it has changed.
@@ -4266,9 +4266,9 @@ func (s *StateSuite) TestSetModelAgentVersionExcessiveContention(c *gc.C) {
 	// Set a hook to change the config 3 times
 	// to test we return ErrExcessiveContention.
 	hooks := []jujutxn.TestHook{
-		{Asserted: func() { s.changeEnviron(c, modelConfig, "default-series", "1") }},
-		{Asserted: func() { s.changeEnviron(c, modelConfig, "default-series", "2") }},
-		{Asserted: func() { s.changeEnviron(c, modelConfig, "default-series", "3") }},
+		{Asserted: func() { s.changeEnviron(c, modelConfig, "default-series", "focal") }},
+		{Asserted: func() { s.changeEnviron(c, modelConfig, "default-series", "jammy") }},
+		{Asserted: func() { s.changeEnviron(c, modelConfig, "default-series", "focal") }},
 	}
 
 	altCtrl, err := state.OpenController(state.OpenParams{

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -526,7 +526,7 @@ func (s *factorySuite) TestMakeModel(c *gc.C) {
 	params := &factory.ModelParams{
 		Name:        "foo",
 		Owner:       owner.UserTag(),
-		ConfigAttrs: testing.Attrs{"default-series": "precise"},
+		ConfigAttrs: testing.Attrs{"default-series": "jammy"},
 	}
 
 	st := s.Factory.MakeModel(c, params)
@@ -542,5 +542,5 @@ func (s *factorySuite) TestMakeModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "precise")
+	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "jammy")
 }

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -28,11 +28,11 @@ run_charmstore_deploy() {
 
 	ensure "test-charmstore-deploy" "${file}"
 
-	juju deploy cs:~jameinel/ubuntu-lite-6 ubuntu
+	juju deploy cs:ubuntu-19 ubuntu
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
 	juju refresh ubuntu
-	wait_for "ubuntu" "$(idle_condition_for_rev "ubuntu" "9")"
+	wait_for "ubuntu" "$(idle_condition_for_rev "ubuntu" "20")"
 
 	destroy_model "test-charmstore-deploy"
 }

--- a/upgrades/upgradevalidation/migrate.go
+++ b/upgrades/upgradevalidation/migrate.go
@@ -21,7 +21,7 @@ func ValidatorsForModelMigrationSource(
 		validators = append(validators,
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
-			getCheckForLXDVersion(cloudspec, minLXDVersion),
+			getCheckForLXDVersion(cloudspec),
 		)
 	}
 	return validators

--- a/upgrades/upgradevalidation/package_test.go
+++ b/upgrades/upgradevalidation/package_test.go
@@ -25,6 +25,4 @@ var (
 	CheckMongoStatusForControllerUpgrade        = checkMongoStatusForControllerUpgrade
 	CheckMongoVersionForControllerModel         = checkMongoVersionForControllerModel
 	GetCheckForLXDVersion                       = getCheckForLXDVersion
-
-	MinLXDVersion = minLXDVersion
 )

--- a/upgrades/upgradevalidation/upgrade.go
+++ b/upgrades/upgradevalidation/upgrade.go
@@ -23,7 +23,7 @@ func ValidatorsForControllerUpgrade(
 				checkMongoVersionForControllerModel,
 				checkNoWinMachinesForModel,
 				checkForDeprecatedUbuntuSeriesForModel,
-				getCheckForLXDVersion(cloudspec, minLXDVersion),
+				getCheckForLXDVersion(cloudspec),
 			)
 		}
 		return validators
@@ -36,7 +36,7 @@ func ValidatorsForControllerUpgrade(
 		validators = append(validators,
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
-			getCheckForLXDVersion(cloudspec, minLXDVersion),
+			getCheckForLXDVersion(cloudspec),
 		)
 	}
 	return validators
@@ -53,7 +53,7 @@ func ValidatorsForModelUpgrade(
 		validators = append(validators,
 			checkNoWinMachinesForModel,
 			checkForDeprecatedUbuntuSeriesForModel,
-			getCheckForLXDVersion(cloudspec, minLXDVersion),
+			getCheckForLXDVersion(cloudspec),
 		)
 	}
 	return validators

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -383,9 +383,7 @@ func (s *upgradeValidationSuite) assertGetCheckForLXDVersion(c *gc.C, cloudType 
 		server.EXPECT().ServerVersion().Return("5.2"),
 	)
 
-	blocker, err := upgradevalidation.GetCheckForLXDVersion(
-		cloudSpec, upgradevalidation.MinLXDVersion,
-	)("", nil, nil, nil)
+	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 }
@@ -410,9 +408,7 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionSkippedForNonLXDCloud(
 		},
 	)
 
-	blocker, err := upgradevalidation.GetCheckForLXDVersion(
-		environscloudspec.CloudSpec{Type: "foo"}, upgradevalidation.MinLXDVersion,
-	)("", nil, nil, nil)
+	blocker, err := upgradevalidation.GetCheckForLXDVersion(environscloudspec.CloudSpec{Type: "foo"})("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 }
@@ -435,9 +431,7 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 		server.EXPECT().ServerVersion().Return("5.1"),
 	)
 
-	blocker, err := upgradevalidation.GetCheckForLXDVersion(
-		cloudSpec, upgradevalidation.MinLXDVersion,
-	)("", nil, nil, nil)
+	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`)
 }


### PR DESCRIPTION
This PR adds series validation for:
1. add-machine with --series;
2. bootstrap with --bootstrap-series;
3. model config `default-series`;
4. juju deploy a charm/bundle;

This PR also deprecates LXD version < `5.2`.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ lxc version
Client version: 5.0.0
Server version: 5.0.0

$ juju bootstrap lxd k1 --config test-mode=true --build-agent --bootstrap-series=bionic
ERROR LXD version has to be at least "5.2.0", but current version is only "5.0.0"

$ lxc version
Client version: 5.4
Server version: 5.4

$ juju bootstrap lxd k1 --config test-mode=true --build-agent --bootstrap-series=bionic
Creating Juju controller "k1" on lxd/localhost
ERROR failed to bootstrap model: use --force to override: bionic not supported

### TODO: --force for bootstrap (unknown vs deprecated series)  ###
$ juju bootstrap lxd k1 --config test-mode=true --build-agent --bootstrap-series=bionic --force
Creating Juju controller "k1" on lxd/localhost
Building local Juju agent binary version 3.0-rc1 for amd64
To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md
Launching controller instance(s) on localhost/localhost...

$ juju bootstrap lxd k1 --config test-mode=true --build-agent --config default-series=bionic
ERROR series "bionic" not supported

$ juju add-model default

$ juju model-config default-series
jammy

$ juju model-config default-series=bionic
ERROR series "bionic" not supported (not supported)

$ juju deploy cs:~jameinel/ubuntu-lite-6
ERROR the charm defined series "xenial, trusty" not supported

$ juju deploy cs:~jameinel/ubuntu-lite-6 --series xenial
ERROR ubuntu-lite is not available on the following series: xenial not supported

$ juju deploy cs:~jameinel/ubuntu-lite-6 --series focal
ERROR series "focal" not supported by charm, the charm supported series are: xenial,trusty. Use --force to deploy the charm anyway.

$ juju deploy cs:~jameinel/ubuntu-lite-6 --series xenial --force
ERROR ubuntu-lite is not available on the following series: xenial not supported

$ juju deploy cs:~jameinel/ubuntu-lite-6 --series focal --force
Located charm "ubuntu-lite" in charm-store, revision 6
Deploying "ubuntu-lite" from charm-store charm "ubuntu-lite", revision 6 in channel stable on focal

$ cat ./testcharms/charm-repo/bundle/multi-doc-overlays/bundle.yaml | grep series
series: trusty

$ juju deploy ./testcharms/charm-repo/bundle/multi-doc-overlays/bundle.yaml
Located charm "apache2" in charm-store, revision 26
Located charm "wordpress" in charm-store, revision 5
Executing changes:
- upload charm apache2 from charm-store for series trusty with architecture=amd64
- deploy application apache2 from charm-store on trusty
ERROR cannot deploy bundle: apache2 is not available on the following series: trusty not supported

$ juju deploy ./testcharms/charm-repo/bundle/multi-doc-overlays/bundle.yaml --force
Located charm "apache2" in charm-store, revision 26
Located charm "wordpress" in charm-store, revision 5
Executing changes:
- upload charm apache2 from charm-store for series trusty with architecture=amd64
- deploy application apache2 from charm-store on trusty
ERROR cannot deploy bundle: apache2 is not available on the following series: trusty not supported

$ juju add-machine --series=bionic
failed to create 1 machine
ERROR series "bionic" not supported

$ juju add-machine --series=focal
created machine 1

$ juju add-machine --series=jammy
created machine 2

$ juju add-machine
created machine 3

$ juju machines --format json | jq -r '.machines | to_entries | map("\(.key)=\(.value.series)") | .[]'
0=focal
1=focal
2=jammy
3=jammy

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1981955
