### PR TITLE
[JUJU-1588] Added 'yq' package bash-based testing system

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -44,9 +44,11 @@ echo "failed" | grep -q "passes"   # fails
 
 ## Getting started
 
-Before running tests, you'll need to install `shellcheck` and `golangci-lint`:
+Before running tests, you'll need to install `jq`, `yq`, `shellcheck` and `golangci-lint`:
 
 ```sh
+sudo snap install jq
+sudo snap install yq
 sudo snap install shellcheck
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
 ```

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -227,7 +227,7 @@ fi
 echo ""
 
 echo "==> Checking for dependencies"
-check_dependencies curl jq shellcheck
+check_dependencies curl jq yq shellcheck
 
 if [[ ${USER:-'root'} == "root" ]]; then
 	echo "The testsuite must not be run as root." >&2

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -69,9 +69,6 @@ run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
 	if [[ -n ${MODEL_ARCH:-} ]]; then
-		if ! which "yq" >/dev/null 2>&1; then
-			sudo snap install yq --classic --channel latest/stable
-		fi
 		yq -i "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
@@ -97,10 +94,6 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	bundle=./tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
 	bundle_with_fake_revisions=./tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
 	juju deploy ${bundle}
-
-	if ! which "yq" >/dev/null 2>&1; then
-		sudo snap install yq --classic --channel latest/stable
-	fi
 
 	echo "Create telegraf_bundle_without_revisions.yaml with known latest revisions from charmhub"
 	influxdb_rev=$(juju info influxdb --format json | jq -r '."channel-map"."latest/stable".revision')


### PR DESCRIPTION
This PR adds a dependency check for yq package, changes Readme for `/tests`, removes installation code for yq from tests.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
cd tests
export MODEL_ARCH=arm64
export SHORT_GIT_COMMIT=ebf8545
export JUJU_VERSION=2.9.34.344
./main.sh -v -p aws deploy test_deploy_bundles
```
