### PR TITLE
[JUJU-1586] Check namespace exists before opening k8s broker

### DIFF
--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -101,7 +101,7 @@ var errConnTimedOut = errors.New("open connection timed out")
 func (c *killCommand) Run(ctx *cmd.Context) error {
 	controllerName, err := c.ControllerName()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "getting controller name")
 	}
 	store := c.ClientStore()
 	if !c.assumeYes {
@@ -249,7 +249,10 @@ func (c *killCommand) DirectDestroyRemaining(
 			} else {
 				env, err = environs.Open(stdcontext.TODO(), cloudProvider, openParams)
 			}
-			if err != nil {
+			if errors.Is(err, errors.NotFound) {
+				logger.Warningf("model %s not found, skipping", model.Name)
+				continue
+			} else if err != nil {
 				logger.Errorf(err.Error())
 				hasErrors = true
 				continue


### PR DESCRIPTION
Run 232 of `test-ck-aws` gave a strange error during teardown:
```
16:47:04 Destroying controller "ctrl-2g0m9d1y"
16:47:04 Killing admin/test-deploy-caas-workload directly
16:47:04 ERROR unable to determine legacy status for namespace test-deploy-caas-workload:
         Get "https://54.208.82.154:443/api/v1/namespaces/test-deploy-caas-workload":
         dial tcp 54.208.82.154:443: i/o timeout
```

It seems like `kill-controller` was trying to access a model/namespace which had already been removed, and was erroring out as a result. Of course, this should be treated as a no-op/success (the model isn't there so nothing to remove), and move on to the next model.

To try and prevent problems like this in the future, I have added a check to the `kubernetesEnvironProvider.Open` function in `caas/kubernetes/provider/provider.go`. It will ask K8s if the namespace exists before attempting to open a new k8s broker. If not, it will early exit and return a not found error.

I've added a provider unit test (`TestOpenNamespaceNotFound`) to verify this. We also required some changes to `TestOpen`, namely modifying the fake k8s client so that it would respond correctly to the new namespaces call.

Finally, I added a little check in `killCommand.DirectDestroyRemaining` so that if caas.Open returns "not found", we will simply move on to the next model.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~