### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/agent/tools/symlinks_test.go
+++ b/agent/tools/symlinks_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&SymlinksSuite{})
 
 func (s *SymlinksSuite) SetUpTest(c *gc.C) {
 	s.dataDir = c.MkDir()
-	s.toolsDir = tools.SharedToolsDir(s.dataDir, testing.CurrentVersion(c))
+	s.toolsDir = tools.SharedToolsDir(s.dataDir, testing.CurrentVersion())
 	err := os.MkdirAll(s.toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Logf("created %s", s.toolsDir)

--- a/api/agent/provisioner/provisioner_test.go
+++ b/api/agent/provisioner/provisioner_test.go
@@ -758,7 +758,7 @@ func (s *provisionerSuite) TestFindToolsLogicError(c *gc.C) {
 }
 
 func (s *provisionerSuite) testFindTools(c *gc.C, matchArch bool, apiError, logicError error) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	var toolsList = coretools.List{&coretools.Tools{Version: current}}
 	var called bool
 	var a string

--- a/api/agent/upgrader/unitupgrader_test.go
+++ b/api/agent/upgrader/unitupgrader_test.go
@@ -76,19 +76,19 @@ func (s *unitUpgraderSuite) addMachineApplicationCharmAndUnit(c *gc.C, appName s
 }
 
 func (s *unitUpgraderSuite) TestSetVersionWrongUnit(c *gc.C) {
-	err := s.st.SetVersion("unit-wordpress-42", testing.CurrentVersion(c))
+	err := s.st.SetVersion("unit-wordpress-42", testing.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *unitUpgraderSuite) TestSetVersionNotUnit(c *gc.C) {
-	err := s.st.SetVersion("foo-42", testing.CurrentVersion(c))
+	err := s.st.SetVersion("foo-42", testing.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *unitUpgraderSuite) TestSetVersion(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	agentTools, err := s.rawUnit.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(agentTools, gc.IsNil)
@@ -115,7 +115,7 @@ func (s *unitUpgraderSuite) TestToolsNotUnit(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestTools(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
 	s.rawMachine.SetAgentVersion(current)
@@ -162,7 +162,7 @@ func (s *unitUpgraderSuite) TestWatchAPIVersionNotUnit(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersion(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	curTools := &tools.Tools{Version: current, URL: ""}
 	curTools.Version.Minor++
 	s.rawMachine.SetAgentVersion(current)

--- a/api/agent/upgrader/upgrader_test.go
+++ b/api/agent/upgrader/upgrader_test.go
@@ -51,19 +51,19 @@ func (s *machineUpgraderSuite) TestNew(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestSetVersionWrongMachine(c *gc.C) {
-	err := s.st.SetVersion("machine-42", coretesting.CurrentVersion(c))
+	err := s.st.SetVersion("machine-42", coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *machineUpgraderSuite) TestSetVersionNotMachine(c *gc.C) {
-	err := s.st.SetVersion("foo-42", coretesting.CurrentVersion(c))
+	err := s.st.SetVersion("foo-42", coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(err, jc.Satisfies, params.IsCodeUnauthorized)
 }
 
 func (s *machineUpgraderSuite) TestSetVersion(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	agentTools, err := s.rawMachine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(agentTools, gc.IsNil)
@@ -90,7 +90,7 @@ func (s *machineUpgraderSuite) TestToolsNotMachine(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestTools(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -132,7 +132,7 @@ func (s *machineUpgraderSuite) TestWatchAPIVersion(c *gc.C) {
 }
 
 func (s *machineUpgraderSuite) TestDesiredVersion(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -74,7 +74,7 @@ func (s *getToolsSuite) TestTools(c *gc.C) {
 		},
 	}
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	configAttrs := map[string]interface{}{
 		"name":                 "some-name",
 		"type":                 "some-type",
@@ -162,7 +162,7 @@ func (s *setToolsSuite) TestSetTools(c *gc.C) {
 	ts := common.NewToolsSetter(s.entityFinder, getCanWrite)
 	c.Assert(ts, gc.NotNil)
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	args := params.EntitiesVersion{
 		AgentTools: []params.EntityVersion{{
 			Tag: "machine-0",
@@ -206,7 +206,7 @@ func (s *setToolsSuite) TestToolsSetError(c *gc.C) {
 		AgentTools: []params.EntityVersion{{
 			Tag: "machine-42",
 			Tools: &params.Version{
-				Version: coretesting.CurrentVersion(c),
+				Version: coretesting.CurrentVersion(),
 			},
 		}},
 	}
@@ -256,7 +256,7 @@ func (s *findToolsSuite) expectMatchingStorageTools(c *gc.C, storageMetadata []b
 }
 
 func (s *findToolsSuite) expectBootstrapEnvironConfig(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	configAttrs := map[string]interface{}{
 		"name":                 "some-name",
 		"type":                 "some-type",
@@ -434,7 +434,7 @@ func (s *findToolsSuite) TestFindToolsExactNotInStorage(c *gc.C) {
 
 func (s *findToolsSuite) testFindToolsExact(c *gc.C, inStorage bool, develVersion bool) {
 	var called bool
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	s.PatchValue(common.EnvtoolsFindTools, func(_ envtools.SimplestreamsFetcher, e environs.BootstrapEnviron, major, minor int, stream []string, filter coretools.Filter) (list coretools.List, err error) {
 		called = true
 		c.Assert(filter.Number, gc.Equals, jujuversion.Current)
@@ -506,7 +506,7 @@ func (s *getUrlSuite) TestToolsURLGetterNoAPIHostPorts(c *gc.C) {
 	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents().Return(nil, nil)
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
-	_, err := g.ToolsURLs(coretesting.CurrentVersion(c))
+	_, err := g.ToolsURLs(coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "no suitable API server address to pick from")
 }
 
@@ -516,7 +516,7 @@ func (s *getUrlSuite) TestToolsURLGetterAPIHostPortsError(c *gc.C) {
 	s.apiHostPortsGetter.EXPECT().APIHostPortsForAgents().Return(nil, errors.New("oh noes"))
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
-	_, err := g.ToolsURLs(coretesting.CurrentVersion(c))
+	_, err := g.ToolsURLs(coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "oh noes")
 }
 
@@ -528,7 +528,7 @@ func (s *getUrlSuite) TestToolsURLGetter(c *gc.C) {
 	}, nil)
 
 	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	urls, err := g.ToolsURLs(current)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(urls, jc.DeepEquals, []string{

--- a/apiserver/facades/agent/upgrader/unitupgrader_test.go
+++ b/apiserver/facades/agent/upgrader/unitupgrader_test.go
@@ -183,7 +183,7 @@ func (s *unitUpgraderSuite) TestToolsForAgent(c *gc.C) {
 	// The machine must have its existing tools set before we query for the
 	// next tools. This is so that we can grab Arch and OSType without
 	// having to pass it in again
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -220,7 +220,7 @@ func (s *unitUpgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 		AgentTools: []params.EntityVersion{{
 			Tag: s.rawUnit.Tag().String(),
 			Tools: &params.Version{
-				Version: testing.CurrentVersion(c),
+				Version: testing.CurrentVersion(),
 			},
 		}},
 	}
@@ -232,7 +232,7 @@ func (s *unitUpgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestSetTools(c *gc.C) {
-	cur := testing.CurrentVersion(c)
+	cur := testing.CurrentVersion()
 	_, err := s.rawUnit.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	args := params.EntitiesVersion{
@@ -290,7 +290,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{
@@ -311,7 +311,7 @@ func (s *unitUpgraderSuite) TestDesiredVersionNoticesMixedAgents(c *gc.C) {
 }
 
 func (s *unitUpgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err := s.rawMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{{Tag: s.rawUnit.Tag().String()}}}

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -242,7 +242,7 @@ func (s *upgraderSuite) TestToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *upgraderSuite) TestToolsForAgent(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	agent := params.Entity{Tag: s.rawMachine.Tag().String()}
 
 	// The machine must have its existing tools set before we query for the
@@ -284,7 +284,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 		AgentTools: []params.EntityVersion{{
 			Tag: s.rawMachine.Tag().String(),
 			Tools: &params.Version{
-				Version: coretesting.CurrentVersion(c),
+				Version: coretesting.CurrentVersion(),
 			},
 		}},
 	}
@@ -296,7 +296,7 @@ func (s *upgraderSuite) TestSetToolsRefusesWrongAgent(c *gc.C) {
 }
 
 func (s *upgraderSuite) TestSetTools(c *gc.C) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	_, err := s.rawMachine.AgentTools()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	args := params.EntitiesVersion{
@@ -378,7 +378,7 @@ func (s *upgraderSuite) TestDesiredVersionForAgent(c *gc.C) {
 func (s *upgraderSuite) bumpDesiredAgentVersion(c *gc.C) version.Number {
 	// In order to call SetModelAgentVersion we have to first SetTools on
 	// all the existing machines
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	err := s.apiMachine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.rawMachine.SetAgentVersion(current)

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -435,7 +435,7 @@ func (s *toolsSuite) TestUploadConvertsSeries(c *gc.C) {
 
 func (s *toolsSuite) TestDownloadModelUUIDPath(c *gc.C) {
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
-		Version: testing.CurrentVersion(c).String(),
+		Version: testing.CurrentVersion().String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})
@@ -447,7 +447,7 @@ func (s *toolsSuite) TestDownloadOtherModelUUIDPath(c *gc.C) {
 	defer newSt.Close()
 
 	tools := s.storeFakeTools(c, newSt, "abc", binarystorage.Metadata{
-		Version: testing.CurrentVersion(c).String(),
+		Version: testing.CurrentVersion().String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})
@@ -456,7 +456,7 @@ func (s *toolsSuite) TestDownloadOtherModelUUIDPath(c *gc.C) {
 
 func (s *toolsSuite) TestDownloadTopLevelPath(c *gc.C) {
 	tools := s.storeFakeTools(c, s.State, "abc", binarystorage.Metadata{
-		Version: testing.CurrentVersion(c).String(),
+		Version: testing.CurrentVersion().String(),
 		Size:    3,
 		SHA256:  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 	})

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -339,8 +339,11 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	// Ensure that the switchURL (if provided) always contains a schema. If
 	// one is missing inject the default value we selected above.
 	if c.SwitchURL != "" {
-		if c.SwitchURL, err = charm.EnsureSchema(c.SwitchURL, defaultCharmSchema); err != nil {
-			return errors.Trace(err)
+		// Don't prepend `ch:` when referring to a local charm
+		if !refresher.IsLocalURL(c.SwitchURL) {
+			if c.SwitchURL, err = charm.EnsureSchema(c.SwitchURL, defaultCharmSchema); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -921,6 +921,35 @@ func (s *RefreshSuccessStateSuite) TestCharmPath(c *gc.C) {
 	s.assertLocalRevision(c, 42, myriakPath)
 }
 
+func (s *RefreshSuccessStateSuite) TestCharmPathNotFound(c *gc.C) {
+	myriakPath := filepath.Join(c.MkDir(), "riak")
+	_, err := os.Stat(myriakPath)
+	c.Assert(err, gc.ErrorMatches, ".*no such file or directory")
+	_, err = s.runRefresh(c, s.cmd, "riak", "--path", myriakPath)
+	c.Assert(err, gc.ErrorMatches, ".*file does not exist")
+}
+
+func (s *RefreshSuccessStateSuite) TestSwitchToLocal(c *gc.C) {
+	myriakPath := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "riak")
+
+	// Change the revision to 42 and upgrade to it with explicit revision.
+	err := ioutil.WriteFile(path.Join(myriakPath, "revision"), []byte("42"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.runRefresh(c, s.cmd, "riak", "--switch", myriakPath)
+	c.Assert(err, jc.ErrorIsNil)
+	curl := s.assertUpgraded(c, s.riak, 42, false)
+	c.Assert(curl.String(), gc.Equals, "local:bionic/riak-42")
+	s.assertLocalRevision(c, 42, myriakPath)
+}
+
+func (s *RefreshSuccessStateSuite) TestSwitchToLocalNotFound(c *gc.C) {
+	myriakPath := filepath.Join(c.MkDir(), "riak")
+	_, err := os.Stat(myriakPath)
+	c.Assert(err, gc.ErrorMatches, ".*no such file or directory")
+	_, err = s.runRefresh(c, s.cmd, "riak", "--switch", myriakPath)
+	c.Assert(err, gc.ErrorMatches, ".*file does not exist")
+}
+
 func (s *RefreshSuccessStateSuite) TestCharmPathNoRevUpgrade(c *gc.C) {
 	// Revision 7 is running to start with.
 	myriakPath := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "riak")

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -219,9 +219,22 @@ func (d *localCharmRefresher) Refresh() (*CharmID, error) {
 		return nil, errors.Trace(err)
 	}
 
+	if IsLocalURL(d.charmRef) {
+		// This was clearly meant to refer to a local charm, which we've not
+		// been able to find, so return the error
+		return nil, errors.Annotatef(err, "%q", d.charmRef)
+	}
+
 	// Not a valid local charm, in this case, we should move onto the next
 	// refresher.
 	return nil, ErrExhausted
+}
+
+// IsLocalURL checks if the provided URL refers to a local charm (i.e. it
+// begins with one of  `/`  `./`  `../` ).
+func IsLocalURL(url string) bool {
+	return strings.HasPrefix(url, "/") || strings.HasPrefix(url, "./") ||
+		strings.HasPrefix(url, "../")
 }
 
 func (d *localCharmRefresher) String() string {

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -39,7 +39,7 @@ Providing the ` + "`-f <credentials.yaml>` " + `option switches to the
 non-interactive mode. <credentials.yaml> must be a path to a correctly 
 formatted YAML-formatted file. 
 
-Sample yaml file shows four credentials being stored against three clouds:
+Sample yaml file shows five credentials being stored against four clouds:
 
   credentials:
     aws:
@@ -54,12 +54,19 @@ Sample yaml file shows four credentials being stored against three clouds:
         application-password: <password>
         subscription-id: <uuid>
     lxd:
-      <credential-name>:
+      <credential-a>:
         auth-type: interactive
         trust-password: <password>
-      <credential-name>:
+      <credential-b>:
         auth-type: interactive
         trust-password: <password>
+    google:
+      <credential-name>:
+        auth-type: oauth2
+        project-id: <project-id>
+        private-key: <private-key>
+        client-email: <email>
+        client-id: <client-id>
 
 The <credential-name> parameter of each credential is arbitrary, but must
 be unique within each <cloud-name>. This allows allow each cloud to store 

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/arch"
 	"github.com/juju/version/v2"
+
 	gc "gopkg.in/check.v1"
 	k8scmd "k8s.io/client-go/tools/clientcmd"
 
@@ -240,7 +241,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 			uploadVers := version.MustParseBinary(test.upload)
 			bootstrapVersion.Number = uploadVers.Number
 		}
-		restore = restore.Add(testing.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, bootstrapVersion.Number)))
+		restore = restore.Add(testing.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(bootstrapVersion.Number)))
 	}
 
 	if test.hostArch != "" {
@@ -1357,7 +1358,7 @@ my-dummy-cloud
 func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 	patchedVersion := version.MustParse(vers)
 	patchedVersion.Build = 1
-	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, patchedVersion))
+	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(patchedVersion))
 	sourceDir := createToolsSource(c, vAll)
 	s.PatchValue(&envtools.DefaultBaseURL, sourceDir)
 

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -155,12 +155,12 @@ func (s *MainSuite) TestRunMain(c *gc.C) {
 		summary: "check version command returns a fully qualified version string",
 		args:    []string{"version"},
 		code:    0,
-		out:     testing.CurrentVersion(c).String() + "\n",
+		out:     testing.CurrentVersion().String() + "\n",
 	}, {
 		summary: "check --version command returns a fully qualified version string",
 		args:    []string{"--version"},
 		code:    0,
-		out:     testing.CurrentVersion(c).String() + "\n",
+		out:     testing.CurrentVersion().String() + "\n",
 	}} {
 		c.Logf("test %d: %s", i, t.summary)
 		out := badrun(c, t.code, t.args...)
@@ -263,7 +263,7 @@ func (s *MainSuite) TestRunNoUpdateCloud(c *gc.C) {
 }
 
 func checkVersionOutput(c *gc.C, output string) {
-	ver := testing.CurrentVersion(c)
+	ver := testing.CurrentVersion()
 	c.Check(output, gc.Equals, ver.String()+"\n")
 }
 

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -177,7 +177,7 @@ func (s *syncToolSuite) TestAPIAdapterUploadTools(c *gc.C) {
 	defer ctrl.Finish()
 	fakeAPI := mocks.NewMockSyncToolAPI(ctrl)
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	uploadToolsErr := errors.New("uh oh")
 	fakeAPI.EXPECT().UploadTools(bytes.NewReader([]byte("abc")), current).Return(nil, uploadToolsErr)
 

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -221,7 +221,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c 
 	})
 
 	c.Assert(agentVersion.Build, gc.Equals, 0)
-	builtVersion := coretesting.CurrentVersion(c)
+	builtVersion := coretesting.CurrentVersion()
 	targetVersion := builtVersion.Number
 	builtVersion.Build++
 	gomock.InOrder(
@@ -267,7 +267,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionAlreadyUpToDate(c *gc.
 	})
 
 	c.Assert(agentVersion.Build, gc.Equals, 0)
-	targetVersion := coretesting.CurrentVersion(c)
+	targetVersion := coretesting.CurrentVersion()
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
 		s.controllerAPI.EXPECT().ModelConfig().Return(cfg, nil),
@@ -344,7 +344,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 		"agent-version": agentVersion.String(),
 	})
 
-	targetVersion := coretesting.CurrentVersion(c).Number
+	targetVersion := coretesting.CurrentVersion().Number
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
 		s.controllerAPI.EXPECT().ModelConfig().Return(cfg, nil),
@@ -385,7 +385,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 		"uuid": coretesting.ControllerTag.Id(),
 	})
 
-	builtVersion := coretesting.CurrentVersion(c)
+	builtVersion := coretesting.CurrentVersion()
 	targetVersion := builtVersion.Number
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(modelCfg, nil),
@@ -481,7 +481,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithBuildAgent(c *gc.C) {
 		"agent-version": agentVersion.String(),
 	})
 	c.Assert(agentVersion.Build, gc.Equals, 0)
-	builtVersion := coretesting.CurrentVersion(c)
+	builtVersion := coretesting.CurrentVersion()
 	builtVersion.Build++
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -113,7 +113,7 @@ type AgentSuite struct {
 // with the given entity name. It returns the agent's configuration and the
 // current tools.
 func (s *AgentSuite) PrimeAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	return s.PrimeAgentVersion(c, tag, password, vers)
 }
 
@@ -168,7 +168,7 @@ func (s *AgentSuite) PrimeAgentVersion(c *gc.C, tag names.Tag, password string, 
 // a state agent with the given entity name. It returns the agent's
 // configuration and the current tools.
 func (s *AgentSuite) PrimeStateAgent(c *gc.C, tag names.Tag, password string) (agent.ConfigSetterWriter, *coretools.Tools) {
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	return s.PrimeStateAgentVersion(c, tag, password, vers)
 }
 

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -133,7 +133,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	s.makeTestModel(c)
 
 	// Create fake tools.tar.gz and downloaded-tools.txt.
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	toolsDir := filepath.FromSlash(agenttools.SharedToolsDir(s.dataDir, current))
 	err := os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
@@ -672,7 +672,7 @@ func (s *BootstrapSuite) TestDownloadedToolsMetadata(c *gc.C) {
 func (s *BootstrapSuite) TestUploadedToolsMetadata(c *gc.C) {
 	// Tools uploaded over ssh.
 	s.writeDownloadedTools(c, &tools.Tools{
-		Version: testing.CurrentVersion(c),
+		Version: testing.CurrentVersion(),
 		URL:     "file:///does/not/matter",
 	})
 	s.testToolsMetadata(c)

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -422,7 +422,7 @@ func (s *MachineSuite) waitProvisioned(c *gc.C, unit *state.Unit) (*state.Machin
 }
 
 func (s *MachineSuite) testUpgradeRequest(c *gc.C, agent runner, tag string, currentTools *tools.Tools) {
-	newVers := coretesting.CurrentVersion(c)
+	newVers := coretesting.CurrentVersion()
 	newVers.Patch++
 	newTools := envtesting.AssertUploadFakeToolsVersions(
 		c, s.DefaultToolsStorage, s.Environ.Config().AgentStream(), s.Environ.Config().AgentStream(), newVers)[0]
@@ -736,7 +736,7 @@ func (s *MachineSuite) assertAgentSetsToolsVersion(c *gc.C, job state.MachineJob
 		}
 		return false, nil
 	})
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	vers.Minor--
 	m, _, _ := s.primeAgentVersion(c, vers, job)
 	ctrl, a := s.newAgent(c, m)
@@ -1136,7 +1136,7 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	s.primeAgentWithMachine(c, m, vers)
 	ctrl, a := s.newAgent(c, m)
 	defer ctrl.Finish()

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -109,7 +109,7 @@ func (s *commonMachineSuite) TearDownTest(c *gc.C) {
 // machine agent's directory.  It returns the new machine, the
 // agent's configuration and the tools currently running.
 func (s *commonMachineSuite) primeAgent(c *gc.C, jobs ...state.MachineJob) (m *state.Machine, agentConfig agent.ConfigSetterWriter, tools *tools.Tools) {
-	vers := coretesting.CurrentVersion(c)
+	vers := coretesting.CurrentVersion()
 	return s.primeAgentVersion(c, vers, jobs...)
 }
 

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -216,11 +216,12 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentBadNicType(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches,
 		`profile "default": no network device found with nictype "bridged" or "macvlan"\n`+
 			`\tthe following devices were checked: eth0\n`+
-			`Note: juju does not support IPv6.\n`+
-			`Reconfigure lxd to use a network of type "bridged" or "macvlan", disabling IPv6.`)
+			`Reconfigure lxd to use a network of type "bridged" or "macvlan".`)
 }
 
-func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
+// Juju used to fail when IPv6 was enabled on the lxd network. This test now
+// checks regression to make sure that we know longer fail.
+func (s *networkSuite) TestVerifyNetworkDeviceIPv6PresentNoFail(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	cSvr := s.NewMockServerWithExtensions(ctrl, "network")
@@ -230,7 +231,7 @@ func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
 		Managed: true,
 		NetworkPut: lxdapi.NetworkPut{
 			Config: map[string]string{
-				"ipv6.address": "something-not-nothing",
+				"ipv6.address": "2001:DB8::1",
 			},
 		},
 	}
@@ -240,10 +241,7 @@ func (s *networkSuite) TestVerifyNetworkDeviceIPv6Present(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = jujuSvr.VerifyNetworkDevice(defaultLegacyProfileWithNIC(), "")
-	c.Assert(err, gc.ErrorMatches,
-		`profile "default": juju does not support IPv6. Disable IPv6 in LXD via:\n`+
-			`\tlxc network set lxdbr0 ipv6.address none\n`+
-			`and run the command again`)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *networkSuite) TestVerifyNetworkDeviceNotPresentCreated(c *gc.C) {

--- a/environs/bootstrap/tools_test.go
+++ b/environs/bootstrap/tools_test.go
@@ -183,7 +183,7 @@ func (s *toolsSuite) TestFindAvailableToolsNoUpload(c *gc.C) {
 }
 
 func (s *toolsSuite) TestFindAvailableToolsSpecificVersion(c *gc.C) {
-	currentVersion := coretesting.CurrentVersion(c)
+	currentVersion := coretesting.CurrentVersion()
 	currentVersion.Major = 2
 	currentVersion.Minor = 3
 	s.PatchValue(&jujuversion.Current, currentVersion.Number)

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -145,7 +145,7 @@ func (t *LiveTests) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	t.UploadFakeTools(c, stor, "released", "released")
 	t.toolsStorage = stor
-	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(c, version.Zero))
+	t.CleanupSuite.PatchValue(&envtools.BundleTools, envtoolstesting.GetMockBundleTools(coretesting.FakeVersionNumber))
 }
 
 func (t *LiveTests) TearDownSuite(c *gc.C) {
@@ -964,7 +964,7 @@ func (t *LiveTests) TestBootstrapWithDefaultSeries(c *gc.C) {
 		c.Skip("HasProvisioner is false; cannot test deployment")
 	}
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	other := current
 	other.Release = "quantal"
 

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -224,11 +224,11 @@ func (s *uploadSuite) SetUpTest(c *gc.C) {
 func (s *uploadSuite) patchBundleTools(c *gc.C, v version.Number) {
 	// Mock out building of tools. Sync should not care about the contents
 	// of tools archives, other than that they hash correctly.
-	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, v))
+	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(v))
 }
 
 func (s *uploadSuite) assertEqualsCurrentVersion(c *gc.C, v version.Binary) {
-	c.Assert(v, gc.Equals, coretesting.CurrentVersion(c))
+	c.Assert(v, gc.Equals, coretesting.CurrentVersion())
 }
 
 func (s *uploadSuite) TearDownTest(c *gc.C) {
@@ -269,7 +269,7 @@ func (s *uploadSuite) TestUploadAndForceVersion(c *gc.C) {
 		func(version.Number) version.Number { return forceVersion },
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion(c))
+	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion())
 }
 
 func (s *uploadSuite) TestSyncTools(c *gc.C) {
@@ -309,7 +309,7 @@ func (s *uploadSuite) TestSyncAndForceVersion(c *gc.C) {
 	t, err := sync.SyncBuiltTools(ss, s.targetStorage, "released", builtTools)
 	c.Assert(err, jc.ErrorIsNil)
 	// Reported version from build call matches the real jujud version.
-	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion(c))
+	c.Assert(t.Version, gc.Equals, coretesting.CurrentVersion())
 }
 
 func (s *uploadSuite) assertUploadedTools(c *gc.C, t *coretools.Tools, expectOSTypes []string, stream string) {
@@ -408,7 +408,7 @@ func (s *badBuildSuite) TearDownTest(c *gc.C) {
 }
 
 func (s *badBuildSuite) assertEqualsCurrentVersion(c *gc.C, v version.Binary) {
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	c.Assert(v, gc.Equals, current)
 }
 
@@ -422,7 +422,7 @@ func (s *badBuildSuite) TestBundleToolsBadBuild(c *gc.C) {
 	c.Assert(sha256Hash, gc.Equals, "")
 	c.Assert(err, gc.ErrorMatches, `(?m)cannot build jujud agent binary from source: .*`)
 
-	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, jujuversion.Current))
+	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(jujuversion.Current))
 
 	// Test that BundleTools func passes after it is
 	// mocked out
@@ -435,7 +435,7 @@ func (s *badBuildSuite) TestBundleToolsBadBuild(c *gc.C) {
 
 func (s *badBuildSuite) patchExecCommand(c *gc.C) {
 	execCommand := s.GetExecCommand(jujutesting.PatchExecConfig{
-		Stdout: coretesting.CurrentVersion(c).String(),
+		Stdout: coretesting.CurrentVersion().String(),
 		Args:   make(chan []string, 2),
 	})
 	s.PatchValue(&envtools.ExecCommand, execCommand)
@@ -453,8 +453,8 @@ func (s *badBuildSuite) TestBuildToolsBadBuild(c *gc.C) {
 
 	// Test that BuildAgentTarball func passes after BundleTools func is
 	// mocked out
-	forceVersion := coretesting.CurrentVersion(c).Number
-	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(c, forceVersion))
+	forceVersion := coretesting.CurrentVersion().Number
+	s.PatchValue(&envtools.BundleTools, toolstesting.GetMockBundleTools(forceVersion))
 	builtTools, err = sync.BuildAgentTarball(true, "released",
 		func(version.Number) version.Number { return forceVersion },
 	)
@@ -575,7 +575,7 @@ func (s *uploadSuite) testStorageToolsUploaderWriteMirrors(c *gc.C, writeMirrors
 		"released",
 		"released",
 		&coretools.Tools{
-			Version: coretesting.CurrentVersion(c),
+			Version: coretesting.CurrentVersion(),
 			Size:    7,
 			SHA256:  "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
 		}, []byte("content"))

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -277,7 +277,7 @@ func UploadFakeTools(c *gc.C, stor storage.Storage, toolsDir, stream string, arc
 // RemoveFakeTools deletes the fake tools from the supplied storage.
 func RemoveFakeTools(c *gc.C, stor storage.Storage, toolsDir string) {
 	c.Logf("removing fake tools")
-	toolsVersion := coretesting.CurrentVersion(c)
+	toolsVersion := coretesting.CurrentVersion()
 	name := envtools.StorageName(toolsVersion, toolsDir)
 	err := stor.Remove(name)
 	c.Check(err, jc.ErrorIsNil)

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/juju/collections/set"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
@@ -35,14 +36,16 @@ import (
 	coretools "github.com/juju/juju/tools"
 )
 
-func GetMockBundleTools(c *gc.C, expectedForceVersion version.Number) tools.BundleToolsFunc {
+func GetMockBundleTools(expectedForceVersion version.Number) tools.BundleToolsFunc {
 	return func(
 		build bool, w io.Writer,
 		getForceVersion func(version.Number) version.Number,
 	) (version.Binary, version.Number, bool, string, error) {
-		vers := coretesting.CurrentVersion(c)
+		vers := coretesting.CurrentVersion()
 		forceVersion := getForceVersion(vers.Number)
-		c.Assert(forceVersion, jc.DeepEquals, expectedForceVersion)
+		if forceVersion.Compare(expectedForceVersion) != 0 {
+			return version.Binary{}, version.Number{}, false, "", errors.Errorf("%#v != expected %#v", forceVersion, expectedForceVersion)
+		}
 		sha256Hash := fmt.Sprintf("%x", sha256.New().Sum(nil))
 		return vers, forceVersion, false, sha256Hash, nil
 	}
@@ -55,7 +58,7 @@ func GetMockBuildTools(c *gc.C) sync.BuildAgentTarballFunc {
 		build bool, stream string,
 		getForceVersion func(version.Number) version.Number,
 	) (*sync.BuiltAgent, error) {
-		vers := coretesting.CurrentVersion(c)
+		vers := coretesting.CurrentVersion()
 		vers.Number = getForceVersion(vers.Number)
 
 		tgz, checksum := coretesting.TarGz(

--- a/featuretests/introspection_test.go
+++ b/featuretests/introspection_test.go
@@ -68,7 +68,7 @@ func (s *introspectionSuite) startMachineAgent(c *gc.C) (*agentcmd.MachineAgent,
 	err := m.SetMongoPassword(password)
 	c.Assert(err, jc.ErrorIsNil)
 
-	vers := testing.CurrentVersion(c)
+	vers := testing.CurrentVersion()
 	return s.startAgent(c, m.Tag(), password, vers, false)
 }
 

--- a/featuretests/tools_test.go
+++ b/featuretests/tools_test.go
@@ -111,7 +111,7 @@ func (s *toolsDownloadSuite) TestDownloadFetchesAndVerifiesSize(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", current)[0]
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader("!"), 1)
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,7 +126,7 @@ func (s *toolsDownloadSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 	s.PatchValue(&jujuversion.Current, testing.FakeVersionNumber)
 	stor := s.DefaultToolsStorage
 	envtesting.RemoveTools(c, stor, "released")
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	tools := envtesting.AssertUploadFakeToolsVersions(c, stor, "released", "released", current)[0]
 	sameSize := strings.Repeat("!", int(tools.Size))
 	err := stor.Put(envtools.StorageName(tools.Version, "released"), strings.NewReader(sameSize), tools.Size)

--- a/featuretests/upgrade_test.go
+++ b/featuretests/upgrade_test.go
@@ -62,7 +62,7 @@ func (s *upgradeSuite) SetUpTest(c *gc.C) {
 	s.AgentSuite.SetUpTest(c)
 	agenttest.InstallFakeEnsureMongo(s, s.DataDir())
 
-	s.oldVersion = coretesting.CurrentVersion(c)
+	s.oldVersion = coretesting.CurrentVersion()
 	s.oldVersion.Major--
 
 	// Don't wait so long in tests.

--- a/testing/base.go
+++ b/testing/base.go
@@ -300,7 +300,7 @@ func GetExportedFields(arg interface{}) set.Strings {
 }
 
 // CurrentVersion returns the current Juju version, asserting on error.
-func CurrentVersion(c *gc.C) version.Binary {
+func CurrentVersion() version.Binary {
 	return version.Binary{
 		Number:  jujuversion.Current,
 		Arch:    arch.HostArch(),

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -317,7 +317,7 @@ func (factory *Factory) MakeMachineNested(c *gc.C, parentId string, params *Mach
 	c.Assert(err, jc.ErrorIsNil)
 	err = m.SetProvisioned(params.InstanceId, params.DisplayName, params.Nonce, params.Characteristics)
 	c.Assert(err, jc.ErrorIsNil)
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err = m.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	return m
@@ -383,7 +383,7 @@ func (factory *Factory) makeMachineReturningPassword(c *gc.C, params *MachinePar
 		err := machine.SetProviderAddresses(params.Addresses...)
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	current := testing.CurrentVersion(c)
+	current := testing.CurrentVersion()
 	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 	return machine, params.Password

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,9 +44,11 @@ echo "failed" | grep -q "passes"   # fails
 
 ## Getting started
 
-Before running tests, you'll need to install `shellcheck` and `golangci-lint`:
+Before running tests, you'll need to install `jq`, `yq`, `shellcheck` and `golangci-lint`:
 
 ```sh
+sudo snap install jq
+sudo snap install yq
 sudo snap install shellcheck
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
 ```

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -266,7 +266,11 @@ pre_bootstrap() {
 		# In CI tests, both Build and OfficialBuild are set.
 		# Juju confuses when it needs to decide the operator image tag to use.
 		# So we need to explicitly set the agent version for CI tests.
-		version=$(juju_version)
+		if [[ -n ${JUJU_VERSION:-} ]]; then
+			version=${JUJU_VERSION}
+		else
+			version=$(juju_version)
+		fi
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -270,7 +270,7 @@ pre_bootstrap() {
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
 
-	if [[ ${MODEL_ARCH:-} != "amd64" ]]; then
+	if [[ -n ${SHORT_GIT_COMMIT:-} ]];  then
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/ --config agent-stream=build-${SHORT_GIT_COMMIT}"
 	fi
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -269,6 +269,11 @@ pre_bootstrap() {
 		version=$(juju_version)
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
+
+	if [[ ${MODEL_ARCH:-} != "amd64" ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/ --config agent-stream=build-${SHORT_GIT_COMMIT}"
+	fi
+
 	echo "BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"
 }
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -270,7 +270,7 @@ pre_bootstrap() {
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
 
-	if [[ -n ${SHORT_GIT_COMMIT:-} ]];  then
+	if [[ -n ${SHORT_GIT_COMMIT:-} ]]; then
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/ --config agent-stream=build-${SHORT_GIT_COMMIT}"
 	fi
 

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -379,7 +379,11 @@ destroy_controller() {
 	output="${TEST_DIR}/${name}-destroy-controller.log"
 
 	echo "====> Destroying juju ($(green "${name}"))"
-	echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+	if [[ ${KILL_CONTROLLER:-} != "true" ]]; then
+		echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+	else
+		echo "${name}" | xargs -I % juju kill-controller -t 0 -y % >"${output}" 2>&1
+	fi
 
 	set +e
 	CHK=$(cat "${output}" | grep -i "ERROR" || true)

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -265,13 +265,14 @@ pre_bootstrap() {
 	else
 		# In CI tests, both Build and OfficialBuild are set.
 		# Juju confuses when it needs to decide the operator image tag to use.
-		# So we need to explicitely set the agent version for CI tests.
+		# So we need to explicitly set the agent version for CI tests.
 		version=$(juju_version)
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --agent-version=${version}"
 	fi
 
 	if [[ -n ${SHORT_GIT_COMMIT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/ --config agent-stream=build-${SHORT_GIT_COMMIT}"
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-metadata-url=https://ci-run-streams.s3.amazonaws.com/builds/build-${SHORT_GIT_COMMIT}/"
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-stream=build-${SHORT_GIT_COMMIT}"
 	fi
 
 	echo "BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -1,31 +1,33 @@
-# SHORT_TIMEOUT creates a consistent short timeout of the wait_for condition.
+# SHORT_TIMEOUT is the time between polling attempts.
 SHORT_TIMEOUT=5
 
 # wait_for defines the ability to wait for a given condition to happen in a
 # juju status output. The output is JSON, so everything that the API server
 # knows about should be valid.
 # The query argument is a jq query.
-# The default timeout is 10 minutes (120 attempts @ 5 seconds each).
-# You can change this by providing the max_attempts argument.
+# The default timeout is 10 minutes. You can change this by providing the
+# timeout argument (an integer number of seconds).
 #
 # ```
-# wait_for <model name> <query> [<max_attempts>]
+# wait_for <model name> <query> [<timeout>]
 # ```
 wait_for() {
-	local name query max_attempts
+	local name query timeout
 
 	name=${1}
 	query=${2}
-	max_attempts=${3:-120} # default timeout: 120x5s = 10m
+	timeout=${3:-600} # default timeout: 600s = 10m
 
 	attempt=0
+	start_time="$(date -u +%s)"
 	# shellcheck disable=SC2046,SC2143
 	until [[ "$(juju status --format=json 2>/dev/null | jq -S "${query}" | grep "${name}")" ]]; do
 		echo "[+] (attempt ${attempt}) polling status for" "${query} => ${name}"
 		juju status --relations 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
 
-		if [[ "${attempt}" -ge ${max_attempts} ]]; then
+		elapsed=$(date -u +%s)-$start_time
+		if [[ ${elapsed} -ge ${timeout} ]]; then
 			echo "[-] $(red 'timed out waiting for')" "$(red "${name}")"
 			exit 1
 		fi

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -231,7 +231,7 @@ fi
 echo ""
 
 echo "==> Checking for dependencies"
-check_dependencies curl jq shellcheck
+check_dependencies curl jq yq shellcheck
 
 if [[ ${USER:-'root'} == "root" ]]; then
 	echo "The testsuite must not be run as root." >&2

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -75,6 +75,6 @@ test_deploy_ck() {
 
 		run "run_deploy_caas_workload"
 
-		destroy_model "${run_deploy_ck_name}" 45m
+		destroy_model "${run_deploy_ck_name}" 60m
 	)
 }

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -54,7 +54,7 @@ run_deploy_caas_workload() {
 	juju deploy cs:~juju/mediawiki-k8s-4 --config kubernetes-service-type=loadbalancer
 	juju relate mediawiki-k8s:db mariadb-k8s:server
 
-	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current'
+	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current' 300
 	wait_for "active" '.applications["mediawiki-k8s"] | ."application-status".current'
 }
 

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -4,7 +4,7 @@ run_deploy_ck() {
 	echo
 
 	local name model_name file overlay_path kube_home storage_path
-	name="${2}"
+	name="deploy-ck"
 	model_name="${name}"
 	file="${TEST_DIR}/${model_name}.log"
 
@@ -56,8 +56,6 @@ run_deploy_caas_workload() {
 
 	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current'
 	wait_for "active" '.applications["mediawiki-k8s"] | ."application-status".current'
-
-	destroy_model "${model_name}"
 }
 
 test_deploy_ck() {
@@ -70,11 +68,8 @@ test_deploy_ck() {
 		set_verbosity
 
 		cd .. || exit
-		local run_deploy_ck_name="deploy-ck"
-		run "run_deploy_ck" "${run_deploy_ck_name}"
 
+		run "run_deploy_ck"
 		run "run_deploy_caas_workload"
-
-		destroy_model "${run_deploy_ck_name}" 60m
 	)
 }

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -18,8 +18,6 @@ test_ck() {
 
 	test_deploy_ck
 
-	if [[ ${BOOTSTRAP_REUSE:-} != "true" ]]; then
-		# CK takes too long to tear down (1h+), so forcibly destroy it
-		juju kill-controller -y -t 0 "${BOOTSTRAPPED_JUJU_CTRL_NAME}" || true
-	fi
+	# CK takes too long to tear down (1h+), so forcibly destroy it
+	export KILL_CONTROLLER=true
 }

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -18,5 +18,6 @@ test_ck() {
 
 	test_deploy_ck
 
-	destroy_controller "test-ck"
+	# CK takes too long to tear down (1h+), so forcibly destroy it
+	juju kill-controller -y -t 0s "test-ck" || true
 }

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -18,6 +18,8 @@ test_ck() {
 
 	test_deploy_ck
 
-	# CK takes too long to tear down (1h+), so forcibly destroy it
-	juju kill-controller -y -t 0s "test-ck" || true
+	if [[ ${BOOTSTRAP_REUSE:-} != "true" ]]; then
+		# CK takes too long to tear down (1h+), so forcibly destroy it
+		juju kill-controller -y -t 0 "${BOOTSTRAPPED_JUJU_CTRL_NAME}" || true
+	fi
 }

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -71,11 +71,14 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
-	if [[ -n ${MODEL_ARCH:-} ]]; then
+	if [[ -n ${MODEL_ARCH:-} ]];
+	then
 		yq -i "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
 		" "${TEST_DIR}/telegraf_bundle.yaml"
+	else
+		yq -i . "${TEST_DIR}/telegraf_bundle-bundle.yaml"
 	fi
 	# no need to wait for the bundle to finish deploying to
 	# check the export.

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -72,9 +72,6 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
 	if [[ -n ${MODEL_ARCH:-} ]]; then
-		if ! which "yq" >/dev/null 2>&1; then
-			sudo snap install yq --classic --channel latest/stable
-		fi
 		yq -i "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
@@ -100,10 +97,6 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	bundle=./tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
 	bundle_with_fake_revisions=./tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
 	juju deploy ${bundle}
-
-	if ! which "yq" >/dev/null 2>&1; then
-		sudo snap install yq --classic --channel latest/stable
-	fi
 
 	echo "Create telegraf_bundle_without_revisions.yaml with known latest revisions from charmhub"
 	influxdb_rev=$(juju info influxdb --format json | jq -r '."channel-map"."latest/stable".revision')

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -69,10 +69,22 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 	bundle=./tests/suites/deploy/bundles/telegraf_bundle.yaml
 	juju deploy ${bundle}
 
+	echo "Make a copy of reference yaml"
+	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
+	if [[ -n ${MODEL_ARCH:-} ]]; then
+		if ! which "yq" >/dev/null 2>&1; then
+			sudo snap install yq --classic --channel latest/stable
+		fi
+		yq -i "
+			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
+			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
+		" "${TEST_DIR}/telegraf_bundle.yaml"
+	fi
 	# no need to wait for the bundle to finish deploying to
 	# check the export.
 	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
-	diff -u ${bundle} "${TEST_DIR}/exported-bundle.yaml"
+	yq -i . "${TEST_DIR}/exported-bundle.yaml"
+	diff -u "${TEST_DIR}/telegraf_bundle.yaml" "${TEST_DIR}/exported-bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-fixed-revisions"
 }
@@ -101,10 +113,17 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	echo "Make a copy of reference yaml and insert revisions in it"
 	cp ${bundle_with_fake_revisions} "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 	yq -i "
-    .applications.influxdb.revision = ${influxdb_rev} |
-    .applications.telegraf.revision = ${telegraf_rev} |
-    .applications.ubuntu.revision = ${ubuntu_rev}
-  " "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
+		.applications.influxdb.revision = ${influxdb_rev} |
+		.applications.telegraf.revision = ${telegraf_rev} |
+		.applications.ubuntu.revision = ${ubuntu_rev}
+	" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
+
+	if [[ -n ${MODEL_ARCH:-} ]]; then
+		yq -i "
+			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
+			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
+		" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
+	fi
 
 	# The model should be updated immediately, so we can export the bundle before
 	# everything is done deploying

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -71,8 +71,7 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
-	if [[ -n ${MODEL_ARCH:-} ]];
-	then
+	if [[ -n ${MODEL_ARCH:-} ]]; then
 		yq -i "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -77,13 +77,14 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
 		" "${TEST_DIR}/telegraf_bundle.yaml"
 	else
-		yq -i . "${TEST_DIR}/telegraf_bundle-bundle.yaml"
+		yq -i . "${TEST_DIR}/telegraf_bundle.yaml"
 	fi
 	# no need to wait for the bundle to finish deploying to
 	# check the export.
-	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
-	yq -i . "${TEST_DIR}/exported-bundle.yaml"
-	diff -u "${TEST_DIR}/telegraf_bundle.yaml" "${TEST_DIR}/exported-bundle.yaml"
+	echo "Compare export-bundle with telegraf_bundle"
+	juju export-bundle --filename "${TEST_DIR}/exported_bundle.yaml"
+	yq -i . "${TEST_DIR}/exported_bundle.yaml"
+	diff -u "${TEST_DIR}/telegraf_bundle.yaml" "${TEST_DIR}/exported_bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-fixed-revisions"
 }
@@ -123,10 +124,10 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	# The model should be updated immediately, so we can export the bundle before
 	# everything is done deploying
 	echo "Compare export-bundle with telegraf_bundle_with_revisions"
-	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
+	juju export-bundle --filename "${TEST_DIR}/exported_bundle.yaml"
 	# reformat the yaml to have the same format as telegraf_bundle_with_revisions.yaml
-	yq -i . "${TEST_DIR}/exported-bundle.yaml"
-	diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported-bundle.yaml"
+	yq -i . "${TEST_DIR}/exported_bundle.yaml"
+	diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported_bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-float-revisions"
 }

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -291,7 +291,7 @@ func (s *WorkerSuite) TestWorkerDownloadsCharm(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "WatchContainerStart", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion())
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 4, "WatchContainerStart", "gitlab", "(?:juju-pod-init|)")
 	s.client.CheckCall(c, 6, "Watch", "gitlab")
@@ -521,7 +521,7 @@ func (s *WorkerSuite) TestContainerStart(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "WatchContainerStart", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion())
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 4, "WatchContainerStart", "gitlab", "(?:juju-pod-init|)")
 	s.client.CheckCall(c, 6, "Watch", "gitlab")
@@ -566,7 +566,7 @@ func (s *WorkerSuite) TestOperatorNoWaitContainerStart(c *gc.C) {
 
 	s.client.CheckCallNames(c, "Charm", "SetStatus", "SetVersion", "WatchUnits", "SetStatus", "Watch", "Charm", "Life")
 	s.client.CheckCall(c, 0, "Charm", "gitlab")
-	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion(c))
+	s.client.CheckCall(c, 2, "SetVersion", "gitlab", coretesting.CurrentVersion())
 	s.client.CheckCall(c, 3, "WatchUnits", "gitlab")
 	s.client.CheckCall(c, 5, "Watch", "gitlab")
 }

--- a/worker/deployer/package_test.go
+++ b/worker/deployer/package_test.go
@@ -30,7 +30,7 @@ type BaseSuite struct {
 func (s *BaseSuite) InitializeCurrentToolsDir(c *gc.C, dataDir string) {
 	// Initialize the tools directory for the agent.
 	// This should be <DataDir>/tools/<version>-<series>-<arch>.
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	toolsDir := tools.SharedToolsDir(dataDir, current)
 	// Make that directory.
 	err := os.MkdirAll(toolsDir, 0755)

--- a/worker/provisioner/provisioner_test.go
+++ b/worker/provisioner/provisioner_test.go
@@ -226,7 +226,7 @@ func (s *CommonProvisionerSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machine.Id(), gc.Equals, "0")
 
-	current := coretesting.CurrentVersion(c)
+	current := coretesting.CurrentVersion()
 	err = machine.SetAgentVersion(current)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/upgradesteps/worker_test.go
+++ b/worker/upgradesteps/worker_test.go
@@ -57,7 +57,7 @@ func (s *UpgradeSuite) SetUpTest(c *gc.C) {
 	// wedged, so dump the logs.
 	coretesting.DumpTestLogsAfter(time.Minute, c, s)
 
-	s.oldVersion = coretesting.CurrentVersion(c)
+	s.oldVersion = coretesting.CurrentVersion()
 	s.oldVersion.Major = 1
 	s.oldVersion.Minor = 16
 


### PR DESCRIPTION
Pull requests:
- #14424 
- #14428 
- #14430 
- #14431 
- #14433 
- #14434 
- #14437 
- #14439 
- #14440 
- #14442 
- #14444
- #14445 
- #14446 
- #14448
- #14453 
- Updated `github.com/juju/charm/v9` to v9.0.4.

Conflicts:
- apiserver/common/tools_test.go
- cmd/juju/commands/upgradecontroller_test.go
- cmd/juju/commands/upgrademodel_test.go
- go.mod
- go.sum
- scripts/win-installer/setup.iss
- snap/snapcraft.yaml
- version/version.go

Note: ignoring #14427 since this is due to be reverted (see #14449).