### PR TITLE
[JJUJU-1594] Fixed test-export-bundles-deploy-with-fixed-revisions whitespaces issue

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -74,13 +74,14 @@ run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
 		" "${TEST_DIR}/telegraf_bundle.yaml"
 	else
-		yq -i . "${TEST_DIR}/telegraf_bundle-bundle.yaml"
+		yq -i . "${TEST_DIR}/telegraf_bundle.yaml"
 	fi
 	# no need to wait for the bundle to finish deploying to
 	# check the export.
-	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
-	yq -i . "${TEST_DIR}/exported-bundle.yaml"
-	diff -u "${TEST_DIR}/telegraf_bundle.yaml" "${TEST_DIR}/exported-bundle.yaml"
+	echo "Compare export-bundle with telegraf_bundle"
+	juju export-bundle --filename "${TEST_DIR}/exported_bundle.yaml"
+	yq -i . "${TEST_DIR}/exported_bundle.yaml"
+	diff -u "${TEST_DIR}/telegraf_bundle.yaml" "${TEST_DIR}/exported_bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-fixed-revisions"
 }
@@ -120,10 +121,10 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	# The model should be updated immediately, so we can export the bundle before
 	# everything is done deploying
 	echo "Compare export-bundle with telegraf_bundle_with_revisions"
-	juju export-bundle --filename "${TEST_DIR}/exported-bundle.yaml"
+	juju export-bundle --filename "${TEST_DIR}/exported_bundle.yaml"
 	# reformat the yaml to have the same format as telegraf_bundle_with_revisions.yaml
-	yq -i . "${TEST_DIR}/exported-bundle.yaml"
-	diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported-bundle.yaml"
+	yq -i . "${TEST_DIR}/exported_bundle.yaml"
+	diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported_bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-float-revisions"
 }

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -68,8 +68,7 @@ run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
 
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
-	if [[ -n ${MODEL_ARCH:-} ]];
-	then
+	if [[ -n ${MODEL_ARCH:-} ]]; then
 		yq -i "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -68,11 +68,14 @@ run_deploy_exported_charmstore_bundle_with_fixed_revisions() {
 
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
-	if [[ -n ${MODEL_ARCH:-} ]]; then
+	if [[ -n ${MODEL_ARCH:-} ]];
+	then
 		yq -i "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
 		" "${TEST_DIR}/telegraf_bundle.yaml"
+	else
+		yq -i . "${TEST_DIR}/telegraf_bundle-bundle.yaml"
 	fi
 	# no need to wait for the bundle to finish deploying to
 	# check the export.


### PR DESCRIPTION
This PR adds additional processing by the 'yq' tool (for `telegraf_bundle.yaml`) if the variable MODEL_ARCH is not defined.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
./main.sh -v -p aws deploy run_deploy_exported_charmstore_bundle_with_fixed_revisions
```
