### PR TITLE
Fix k8s model CI teardown

### DIFF
--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -197,7 +197,7 @@ func (c *killCommand) DirectDestroyRemaining(
 	hostedConfig, err := api.HostedModelConfigs()
 	if err != nil {
 		hasErrors = true
-		logger.Errorf("unable to retrieve hosted model config: %v", err)
+		logger.Warningf("unable to retrieve hosted model config: %v", err)
 	}
 	ctrlUUID := ""
 	// try to get controller UUID or just ignore.
@@ -214,26 +214,26 @@ func (c *killCommand) DirectDestroyRemaining(
 			// Only model name is guaranteed to be set in the result
 			// when an error is returned.
 			hasErrors = true
-			logger.Errorf("could not kill %s directly: %v", model.Name, model.Error)
+			logger.Warningf("could not kill %s directly: %v", model.Name, model.Error)
 			continue
 		}
 		ctx.Infof("Killing %s/%s directly", model.Owner.Id(), model.Name)
 		cfg, err := config.New(config.NoDefaults, model.Config)
 		if err != nil {
-			logger.Errorf(err.Error())
+			logger.Warningf(err.Error())
 			hasErrors = true
 			continue
 		}
 		p, err := environs.Provider(model.CloudSpec.Type)
 		if err != nil {
-			logger.Errorf(err.Error())
+			logger.Warningf(err.Error())
 			hasErrors = true
 			continue
 		}
 
 		modelCloudSpec, err := transformModelCloudSpecForInstanceRoles(model.Name, model.CloudSpec, controllerCloudSpec)
 		if err != nil {
-			logger.Errorf("could not kill %s directly: %v", model.Name, err)
+			logger.Warningf("could not kill %s directly: %v", model.Name, err)
 			continue
 		}
 
@@ -250,13 +250,13 @@ func (c *killCommand) DirectDestroyRemaining(
 				env, err = environs.Open(stdcontext.TODO(), cloudProvider, openParams)
 			}
 			if err != nil {
-				logger.Errorf(err.Error())
+				logger.Warningf(err.Error())
 				hasErrors = true
 				continue
 			}
 			cloudCallCtx := cloudCallContext(c.credentialAPIFunctionForModel(model.Name))
 			if err := env.Destroy(cloudCallCtx); err != nil {
-				logger.Errorf(err.Error())
+				logger.Warningf(err.Error())
 				hasErrors = true
 				continue
 			}
@@ -264,7 +264,7 @@ func (c *killCommand) DirectDestroyRemaining(
 		ctx.Infof("  done")
 	}
 	if hasErrors {
-		logger.Errorf("there were problems destroying some models, manual intervention may be necessary to ensure resources are released")
+		logger.Warningf("there were problems destroying some models, manual intervention may be necessary to ensure resources are released")
 	} else {
 		ctx.Infof("All hosted models destroyed, cleaning up controller machines")
 	}

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -56,6 +56,8 @@ run_deploy_caas_workload() {
 
 	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current' 300
 	wait_for "active" '.applications["mediawiki-k8s"] | ."application-status".current'
+
+	destroy_model "${model_name}"
 }
 
 test_deploy_ck() {


### PR DESCRIPTION
The ck test deploys a k8s model on a CK deployment. But it doesn't destroy the k8s model. And then during controller teardown, the CK model is destroyed first, leading to a timeout trying to destroy the k9s model, as the cluster is gone

Also, kill-controller logs errors during the final destroy or else phase, and these cause the test to exit 1. But it's kill controller so we change the logs to warnings.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

`./main.sh ck`
