### PR TITLE
[JUJU-1562] add support for juju status application leader

### DIFF
--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -72,7 +72,7 @@ func UnitChainPredicateFn(
 
 // BuildPredicate returns a Predicate which will evaluate a machine,
 // service, or unit against the given patterns.
-func BuildPredicateFor(patterns []string) Predicate {
+func BuildPredicateFor(patterns []string, leaders map[string]string) Predicate {
 
 	or := func(predicates ...closurePredicate) (bool, error) {
 		// Differentiate between a valid format that eliminated all
@@ -101,15 +101,15 @@ func BuildPredicateFor(patterns []string) Predicate {
 		default:
 			panic(errors.Errorf("expected a machine or an applications or a unit, got %T", i))
 		case *state.Machine:
-			shims, err := buildMachineMatcherShims(i.(*state.Machine), patterns)
+			shims, err := buildMachineMatcherShims(i.(*state.Machine), leaders, patterns)
 			if err != nil {
 				return false, err
 			}
 			return or(shims...)
 		case *state.Unit:
-			return or(buildUnitMatcherShims(i.(*state.Unit), patterns)...)
+			return or(buildUnitMatcherShims(i.(*state.Unit), leaders, patterns)...)
 		case *state.Application:
-			shims, err := buildApplicationMatcherShims(i.(*state.Application), patterns...)
+			shims, err := buildApplicationMatcherShims(i.(*state.Application), leaders, patterns...)
 			if err != nil {
 				return false, err
 			}
@@ -143,8 +143,8 @@ func matchMachineId(m *state.Machine, patterns []string) (bool, bool, error) {
 	return false, anyValid, nil
 }
 
-func unitMatchUnitName(u *state.Unit, patterns []string) (bool, bool, error) {
-	um, err := NewUnitMatcher(patterns)
+func unitMatchUnitName(u *state.Unit, params matcherParams) (bool, bool, error) {
+	um, err := NewUnitMatcher(params)
 	if err != nil {
 		// Currently, the only error possible here is a matching
 		// error. We don't want this error to hold up further
@@ -155,15 +155,15 @@ func unitMatchUnitName(u *state.Unit, patterns []string) (bool, bool, error) {
 	return um.matchUnit(u), true, nil
 }
 
-func unitMatchAgentStatus(u *state.Unit, patterns []string) (bool, bool, error) {
+func unitMatchAgentStatus(u *state.Unit, params matcherParams) (bool, bool, error) {
 	statusInfo, err := u.AgentStatus()
 	if err != nil {
 		return false, false, err
 	}
-	return matchAgentStatus(patterns, statusInfo.Status)
+	return matchAgentStatus(params.patterns, statusInfo.Status)
 }
 
-func unitMatchWorkloadStatus(u *state.Unit, patterns []string) (bool, bool, error) {
+func unitMatchWorkloadStatus(u *state.Unit, params matcherParams) (bool, bool, error) {
 	workloadStatusInfo, err := u.Status()
 	if err != nil {
 		return false, false, err
@@ -172,18 +172,18 @@ func unitMatchWorkloadStatus(u *state.Unit, patterns []string) (bool, bool, erro
 	if err != nil {
 		return false, false, err
 	}
-	return matchWorkloadStatus(patterns, workloadStatusInfo.Status, agentStatusInfo.Status)
+	return matchWorkloadStatus(params.patterns, workloadStatusInfo.Status, agentStatusInfo.Status)
 }
 
-func unitMatchExposure(u *state.Unit, patterns []string) (bool, bool, error) {
+func unitMatchExposure(u *state.Unit, params matcherParams) (bool, bool, error) {
 	s, err := u.Application()
 	if err != nil {
 		return false, false, err
 	}
-	return matchExposure(patterns, s)
+	return matchExposure(params.patterns, s)
 }
 
-func unitMatchPort(u *state.Unit, patterns []string) (bool, bool, error) {
+func unitMatchPort(u *state.Unit, params matcherParams) (bool, bool, error) {
 	unitPortRanges, err := u.OpenedPortRanges()
 	if err != nil {
 		if errors.IsNotAssigned(err) {
@@ -192,12 +192,13 @@ func unitMatchPort(u *state.Unit, patterns []string) (bool, bool, error) {
 		return false, false, err
 	}
 
-	return matchPortRanges(patterns, unitPortRanges.UniquePortRanges()...)
+	return matchPortRanges(params.patterns, unitPortRanges.UniquePortRanges()...)
 }
 
-// buildApplicationMatcherShims adds matchers for application name, application units and
+// buildApplicationMatcherShims adds matchers for application name, application units, application unit leaders and
 // whether the application is exposed.
-func buildApplicationMatcherShims(a *state.Application, patterns ...string) (shims []closurePredicate, _ error) {
+func buildApplicationMatcherShims(a *state.Application, leaders map[string]string,
+	patterns ...string) (shims []closurePredicate, _ error) {
 	// Match on name.
 	shims = append(shims, func() (bool, bool, error) {
 		for _, p := range patterns {
@@ -213,7 +214,7 @@ func buildApplicationMatcherShims(a *state.Application, patterns ...string) (shi
 
 	// If the service has an unit instance that matches any of the
 	// given criteria, consider the service a match as well.
-	unitShims, err := buildShimsForUnit(a.AllUnits, patterns...)
+	unitShims, err := buildShimsForUnit(a.AllUnits, leaders, patterns...)
 	if err != nil {
 		return nil, err
 	}
@@ -227,19 +228,20 @@ func buildApplicationMatcherShims(a *state.Application, patterns ...string) (shi
 
 	return shims, nil
 }
-
-func buildShimsForUnit(unitsFn func() ([]*state.Unit, error), patterns ...string) (shims []closurePredicate, _ error) {
+func buildShimsForUnit(unitsFn func() ([]*state.Unit, error), leaders map[string]string,
+	patterns ...string) (shims []closurePredicate, _ error) {
 	units, err := unitsFn()
 	if err != nil {
 		return nil, err
 	}
 	for _, u := range units {
-		shims = append(shims, buildUnitMatcherShims(u, patterns)...)
+		shims = append(shims, buildUnitMatcherShims(u, leaders, patterns)...)
 	}
 	return shims, nil
 }
 
-func buildMachineMatcherShims(m *state.Machine, patterns []string) (shims []closurePredicate, _ error) {
+func buildMachineMatcherShims(m *state.Machine, leaders map[string]string, patterns []string) (shims []closurePredicate,
+	_ error) {
 	// Look at machine ID.
 	shims = append(shims, func() (bool, bool, error) { return matchMachineId(m, patterns) })
 
@@ -267,9 +269,13 @@ func buildMachineMatcherShims(m *state.Machine, patterns []string) (shims []clos
 	return
 }
 
-func buildUnitMatcherShims(u *state.Unit, patterns []string) []closurePredicate {
-	closeOver := func(f func(*state.Unit, []string) (bool, bool, error)) closurePredicate {
-		return func() (bool, bool, error) { return f(u, patterns) }
+func buildUnitMatcherShims(u *state.Unit, leaders map[string]string, patterns []string) []closurePredicate {
+	closeOver := func(f func(*state.Unit, matcherParams) (bool, bool, error)) closurePredicate {
+		umParams := matcherParams{
+			patterns: patterns,
+			leaders:  leaders,
+		}
+		return func() (bool, bool, error) { return f(u, umParams) }
 	}
 	return []closurePredicate{
 		closeOver(unitMatchUnitName),
@@ -322,7 +328,8 @@ func matchExposure(patterns []string, s *state.Application) (bool, bool, error) 
 	return false, false, nil
 }
 
-func matchWorkloadStatus(patterns []string, workloadStatus status.Status, agentStatus status.Status) (bool, bool, error) {
+func matchWorkloadStatus(patterns []string, workloadStatus status.Status, agentStatus status.Status) (bool, bool,
+	error) {
 	oneValidStatus := false
 	for _, p := range patterns {
 		// If the pattern isn't a known status, ignore it.
@@ -360,6 +367,7 @@ func matchAgentStatus(patterns []string, agentStatus status.Status) (bool, bool,
 
 type unitMatcher struct {
 	patterns []string
+	leaders  map[string]string
 }
 
 // matchesAny returns true if the unitMatcher will
@@ -406,12 +414,21 @@ func (m unitMatcher) matchUnit(u *state.Unit) bool {
 // invalid syntax is encountered.
 func (m unitMatcher) matchString(s string) bool {
 	for _, pattern := range m.patterns {
-		ok, err := path.Match(pattern, s)
-		if err != nil {
-			// We validate patterns, so should never get here.
-			panic(fmt.Errorf("pattern syntax error in %q", pattern))
-		} else if ok {
-			return true
+		if strings.HasSuffix(pattern, "/leader") {
+			applicationName := strings.Split(pattern, "/")[0]
+			if leader, ok := m.leaders[applicationName]; ok {
+				if s == leader {
+					return true
+				}
+			}
+		} else {
+			ok, err := path.Match(pattern, s)
+			if err != nil {
+				// We validate patterns, so should never get here.
+				panic(fmt.Errorf("pattern syntax error in %q", pattern))
+			} else if ok {
+				return true
+			}
 		}
 	}
 	return false
@@ -429,10 +446,10 @@ var validPattern = regexp.MustCompile("^[a-z0-9-*]+$")
 // is invalid. Patterns are valid if they contain only
 // alpha-numeric characters, hyphens, or asterisks (and one
 // optional '/' to separate service/unit).
-func NewUnitMatcher(patterns []string) (unitMatcher, error) {
-	pattCopy := make([]string, len(patterns))
-	for i, pattern := range patterns {
-		pattCopy[i] = patterns[i]
+func NewUnitMatcher(params matcherParams) (unitMatcher, error) {
+	pattCopy := make([]string, len(params.patterns))
+	for i, pattern := range params.patterns {
+		pattCopy[i] = params.patterns[i]
 		fields := strings.Split(pattern, "/")
 		if len(fields) > 2 {
 			return unitMatcher{}, fmt.Errorf("pattern %q contains too many '/' characters", pattern)
@@ -446,5 +463,10 @@ func NewUnitMatcher(patterns []string) (unitMatcher, error) {
 			pattCopy[i] += "/*"
 		}
 	}
-	return unitMatcher{pattCopy}, nil
+	return unitMatcher{patterns: pattCopy, leaders: params.leaders}, nil
+}
+
+type matcherParams struct {
+	patterns []string
+	leaders  map[string]string
 }


### PR DESCRIPTION
This PR adds support for filtering application leader in `juju status application/leader`.

## Checklist
- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Bootstrap a cloud. (_You might have to wait for a while after deploying for a leader to be elected_).

```sh
juju deploy postgresql
juju deploy haproxy
juju status postgresql/leader mysql/leader haproxy/leader
Model    Controller  Cloud/Region         Version    SLA          Timestamp
testing  local       localhost/localhost  3.0-rc1.1  unsupported  17:36:21+03:00

App         Version  Status       Scale  Charm       Channel  Rev  Exposed  Message
haproxy              maintenance      1  haproxy     stable    66  no       Configuring HAProxy
postgresql  12.11    active           1  postgresql  stable   241  no       Live master (12.11)

Unit           Workload     Agent  Machine  Public address  Ports     Message
haproxy/0*     maintenance  idle   0        10.117.119.67             Configuring HAProxy
postgresql/0*  active       idle   8        10.117.119.143  5432/tcp  Live master (12.11)

Machine  State    Address         Inst id        Series  AZ  Message
0        started  10.117.119.67   juju-093fe5-0  xenial      Running
8        started  10.117.119.143  juju-093fe5-8  focal       Running
```
## Bug reference
[Launchpad Ticket](https://bugs.launchpad.net/juju/+bug/1981508).
