### PR TITLE
[JUJU-1607] Add secrets grant/revoke api and hook commands

### DIFF
--- a/apiserver/facades/agent/secretsmanager/mocks/secretsconsumer.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsconsumer.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	secrets "github.com/juju/juju/core/secrets"
 	state "github.com/juju/juju/state"
+	names "github.com/juju/names/v4"
 )
 
 // MockSecretsConsumer is a mock of SecretsConsumer interface.
@@ -48,6 +49,34 @@ func (m *MockSecretsConsumer) GetSecretConsumer(arg0 *secrets.URI, arg1 string) 
 func (mr *MockSecretsConsumerMockRecorder) GetSecretConsumer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).GetSecretConsumer), arg0, arg1)
+}
+
+// GrantSecret mocks base method.
+func (m *MockSecretsConsumer) GrantSecret(arg0 *secrets.URI, arg1, arg2 names.Tag, arg3 secrets.SecretRole) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GrantSecret", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GrantSecret indicates an expected call of GrantSecret.
+func (mr *MockSecretsConsumerMockRecorder) GrantSecret(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantSecret", reflect.TypeOf((*MockSecretsConsumer)(nil).GrantSecret), arg0, arg1, arg2, arg3)
+}
+
+// RevokeSecret mocks base method.
+func (m *MockSecretsConsumer) RevokeSecret(arg0 *secrets.URI, arg1, arg2 names.Tag) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeSecret", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokeSecret indicates an expected call of RevokeSecret.
+func (mr *MockSecretsConsumerMockRecorder) RevokeSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecret", reflect.TypeOf((*MockSecretsConsumer)(nil).RevokeSecret), arg0, arg1, arg2)
 }
 
 // SaveSecretConsumer mocks base method.

--- a/apiserver/facades/agent/secretsmanager/state.go
+++ b/apiserver/facades/agent/secretsmanager/state.go
@@ -6,6 +6,8 @@ package secretsmanager
 import (
 	"time"
 
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/state"
 )
@@ -21,4 +23,6 @@ type SecretsConsumer interface {
 	GetSecretConsumer(*secrets.URI, string) (*secrets.SecretConsumerMetadata, error)
 	SaveSecretConsumer(*secrets.URI, string, *secrets.SecretConsumerMetadata) error
 	WatchConsumedSecretsChanges(string) state.StringsWatcher
+	GrantSecret(uri *secrets.URI, scope names.Tag, subject names.Tag, role secrets.SecretRole) error
+	RevokeSecret(uri *secrets.URI, scope names.Tag, subject names.Tag) error
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38601,6 +38601,30 @@
                     },
                     "description": "GetSecretValues returns the secret values for the specified secrets."
                 },
+                "SecretsGrant": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/GrantRevokeSecretArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SecretsGrant grants access to a secret for the specified subjects."
+                },
+                "SecretsRevoke": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/GrantRevokeSecretArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SecretsRevoke revokes access to a secret for the specified subjects."
+                },
                 "SecretsRotated": {
                     "type": "object",
                     "properties": {
@@ -38835,6 +38859,48 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/GetSecretValueArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "GrantRevokeSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope-tag": {
+                            "type": "string"
+                        },
+                        "subject-tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "scope-tag",
+                        "subject-tags",
+                        "role"
+                    ]
+                },
+                "GrantRevokeSecretArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GrantRevokeSecretArg"
                             }
                         }
                     },

--- a/core/secrets/rbac.go
+++ b/core/secrets/rbac.go
@@ -11,3 +11,12 @@ const (
 	RoleRotate = SecretRole("rotate")
 	RoleManage = SecretRole("manage")
 )
+
+// IsValid returns true if r is a valid secret role.
+func (r SecretRole) IsValid() bool {
+	switch r {
+	case RoleView, RoleRotate, RoleManage:
+		return true
+	}
+	return false
+}

--- a/core/secrets/rotate.go
+++ b/core/secrets/rotate.go
@@ -26,7 +26,7 @@ func (p RotatePolicy) String() string {
 	return string(p)
 }
 
-// IsValid returns true if v is a valid rotate policy.
+// IsValid returns true if p is a valid rotate policy.
 func (p RotatePolicy) IsValid() bool {
 	switch p {
 	case RotateNever, RotateHourly, RotateDaily, RotateWeekly,

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -153,3 +153,23 @@ type SecretRotatedArg struct {
 	URI  string    `json:"uri"`
 	When time.Time `json:"when"`
 }
+
+// GrantRevokeSecretArgs holds args for changing access to secrets.
+type GrantRevokeSecretArgs struct {
+	Args []GrantRevokeSecretArg `json:"args"`
+}
+
+// GrantRevokeSecretArg holds the args for changing access to a secret.
+type GrantRevokeSecretArg struct {
+	// URI identifies the secret to grant.
+	URI string `json:"uri"`
+
+	// ScopeTag is defines the entity to which the access is scoped.
+	ScopeTag string `json:"scope-tag"`
+
+	// OwnerTag is the owner of the secret.
+	SubjectTags []string `json:"subject-tags"`
+
+	// Role is the role being granted.
+	Role string `json:"role"`
+}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -13,25 +13,25 @@ import (
 // allCollections should be the single source of truth for information about
 // any collection we use. It's broken up into 4 main sections:
 //
-//  * infrastructure: we really don't have any business touching these once
-//    we've created them. They should have the rawAccess attribute set, so that
-//    multiModelRunner will consider them forbidden.
+//   - infrastructure: we really don't have any business touching these once
+//     we've created them. They should have the rawAccess attribute set, so that
+//     multiModelRunner will consider them forbidden.
 //
-//  * global: these hold information external to models. They may include
-//    model metadata, or references; but they're generally not relevant
-//    from the perspective of a given model.
+//   - global: these hold information external to models. They may include
+//     model metadata, or references; but they're generally not relevant
+//     from the perspective of a given model.
 //
-//  * local (in opposition to global; and for want of a better term): these
-//    hold information relevant *within* specific models (machines,
-//    applications, relations, settings, bookkeeping, etc) and should generally be
-//    read via an modelStateCollection, and written via a multiModelRunner. This is
-//    the most common form of collection, and the above access should usually
-//    be automatic via Database.Collection and Database.Runner.
+//   - local (in opposition to global; and for want of a better term): these
+//     hold information relevant *within* specific models (machines,
+//     applications, relations, settings, bookkeeping, etc) and should generally be
+//     read via an modelStateCollection, and written via a multiModelRunner. This is
+//     the most common form of collection, and the above access should usually
+//     be automatic via Database.Collection and Database.Runner.
 //
-//  * raw-access: there's certainly data that's a poor fit for mgo/txn. Most
-//    forms of logs, for example, will benefit both from the speedy insert and
-//    worry-free bulk deletion; so raw-access collections are fine. Just don't
-//    try to run transactions that reference them.
+//   - raw-access: there's certainly data that's a poor fit for mgo/txn. Most
+//     forms of logs, for example, will benefit both from the speedy insert and
+//     worry-free bulk deletion; so raw-access collections are fine. Just don't
+//     try to run transactions that reference them.
 //
 // Please do not use collections not referenced here; and when adding new
 // collections, please document them, and make an effort to put them in an
@@ -560,7 +560,6 @@ func allCollections() CollectionSchema {
 		},
 
 		secretConsumersC: {
-			global: true,
 			indexes: []mgo.Index{{
 				Key: []string{"consumer-tag"},
 			}},

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/mgo/v3/txn"
+	"github.com/juju/names/v4"
 	jujutxn "github.com/juju/txn/v3"
 	"gopkg.in/tomb.v2"
 
@@ -549,6 +550,16 @@ func (st *State) WatchConsumedSecretsChanges(consumer string) StringsWatcher {
 			return uri.String()
 		},
 	})
+}
+
+// GrantSecret implements SecretsService.
+func (st *State) GrantSecret(uri *secrets.URI, scope, subject names.Tag, role secrets.SecretRole) error {
+	return errors.NotImplementedf("GrantSecret")
+}
+
+// RevokeSecret implements SecretsService.
+func (st *State) RevokeSecret(uri *secrets.URI, scope, subject names.Tag) error {
+	return errors.NotImplementedf("RevokeSecret")
 }
 
 type secretRotationDoc struct {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -773,7 +773,7 @@ func (ctx *HookContext) GrantSecret(uri string, args *jujuc.SecretGrantRevokeArg
 	return ctx.secretFacade.Grant(uri, &secretsmanager.SecretRevokeGrantArgs{
 		ApplicationName: args.ApplicationName,
 		UnitName:        args.UnitName,
-		RelationId:      args.RelationId,
+		RelationKey:     args.RelationKey,
 		Role:            coresecrets.RoleView,
 	})
 }
@@ -783,6 +783,7 @@ func (ctx *HookContext) RevokeSecret(uri string, args *jujuc.SecretGrantRevokeAr
 	return ctx.secretFacade.Revoke(uri, &secretsmanager.SecretRevokeGrantArgs{
 		ApplicationName: args.ApplicationName,
 		UnitName:        args.UnitName,
+		RelationKey:     args.RelationKey,
 	})
 }
 

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -26,6 +26,7 @@ import (
 
 // Context is the interface that all hook helper commands
 // depend on to interact with the rest of the system.
+//
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/context_mock.go github.com/juju/juju/worker/uniter/runner/jujuc Context
 type Context interface {
 	HookContext
@@ -182,7 +183,7 @@ type SecretUpsertArgs struct {
 type SecretGrantRevokeArgs struct {
 	ApplicationName *string
 	UnitName        *string
-	RelationId      *int
+	RelationKey     *string
 	Role            *secrets.SecretRole
 }
 
@@ -343,6 +344,7 @@ type ContextRelations interface {
 }
 
 // ContextRelation expresses the capabilities of a hook with respect to a relation.
+//
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/context_relation_mock.go github.com/juju/juju/worker/uniter/runner/jujuc ContextRelation
 type ContextRelation interface {
 
@@ -351,6 +353,9 @@ type ContextRelation interface {
 
 	// Name returns the name the locally executing charm assigned to this relation.
 	Name() string
+
+	// RelationTag returns the relation tag.
+	RelationTag() names.RelationTag
 
 	// FakeId returns a string of the form "relation-name:123", which uniquely
 	// identifies the relation to the hook. In reality, the identification

--- a/worker/uniter/runner/jujuc/jujuctesting/relation.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/relation.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/relation"
@@ -80,6 +81,14 @@ func (r *ContextRelation) Name() string {
 	_ = r.stub.NextErr()
 
 	return r.info.Name
+}
+
+// RelationTag implements jujuc.ContextRelation.
+func (r *ContextRelation) RelationTag() names.RelationTag {
+	r.stub.AddCall("RelationTag")
+	_ = r.stub.NextErr()
+
+	return names.NewRelationTag("wordpress:db mediawiki:db")
 }
 
 // FakeId implements jujuc.ContextRelation.

--- a/worker/uniter/runner/jujuc/mocks/context_relation_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_relation_mock.go
@@ -12,6 +12,7 @@ import (
 	relation "github.com/juju/juju/core/relation"
 	params "github.com/juju/juju/rpc/params"
 	jujuc "github.com/juju/juju/worker/uniter/runner/jujuc"
+	names "github.com/juju/names/v4"
 )
 
 // MockContextRelation is a mock of ContextRelation interface.
@@ -136,6 +137,20 @@ func (m *MockContextRelation) ReadSettings(arg0 string) (params.Settings, error)
 func (mr *MockContextRelationMockRecorder) ReadSettings(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSettings", reflect.TypeOf((*MockContextRelation)(nil).ReadSettings), arg0)
+}
+
+// RelationTag mocks base method.
+func (m *MockContextRelation) RelationTag() names.RelationTag {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RelationTag")
+	ret0, _ := ret[0].(names.RelationTag)
+	return ret0
+}
+
+// RelationTag indicates an expected call of RelationTag.
+func (mr *MockContextRelationMockRecorder) RelationTag() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationTag", reflect.TypeOf((*MockContextRelation)(nil).RelationTag))
 }
 
 // RemoteApplicationName mocks base method.

--- a/worker/uniter/runner/jujuc/secret-grant_test.go
+++ b/worker/uniter/runner/jujuc/secret-grant_test.go
@@ -19,7 +19,9 @@ type SecretGrantSuite struct {
 var _ = gc.Suite(&SecretGrantSuite{})
 
 func (s *SecretGrantSuite) TestGrantSecretInvalidArgs(c *gc.C) {
-	hctx, _ := s.ContextSuite.NewHookContext()
+	hctx, info := s.ContextSuite.NewHookContext()
+	info.SetNewRelation(1, "db", s.Stub)
+	info.SetAsRelationHook(1, "mediawiki/0")
 
 	for _, t := range []struct {
 		args []string
@@ -27,21 +29,18 @@ func (s *SecretGrantSuite) TestGrantSecretInvalidArgs(c *gc.C) {
 	}{
 		{
 			args: []string{},
-			err:  "ERROR missing secret name",
+			err:  "ERROR missing secret URI",
 		}, {
-			args: []string{"password"},
-			err:  `ERROR missing application or unit`,
+			args: []string{"foo"},
+			err:  `ERROR secret URI "foo" not valid`,
 		}, {
-			args: []string{"password", "--app", "0/foo"},
-			err:  `ERROR application "0/foo" not valid`,
-		}, {
-			args: []string{"password", "--unit", "foo"},
+			args: []string{"secret:9m4e2mr0ui3e8a215n4g", "--unit", "foo"},
 			err:  `ERROR unit "foo" not valid`,
 		}, {
-			args: []string{"password", "--app", "foo", "--relation", "foo"},
+			args: []string{"secret:9m4e2mr0ui3e8a215n4g", "--relation", "foo"},
 			err:  `ERROR invalid value "foo" for option --relation: invalid relation id`,
 		}, {
-			args: []string{"password", "--app", "foo", "--relation", "-666"},
+			args: []string{"secret:9m4e2mr0ui3e8a215n4g", "--relation", "-666"},
 			err:  `ERROR invalid value "-666" for option --relation: relation not found`,
 		},
 	} {
@@ -58,23 +57,61 @@ func (s *SecretGrantSuite) TestGrantSecretInvalidArgs(c *gc.C) {
 func (s *SecretGrantSuite) TestGrantSecret(c *gc.C) {
 	hctx, info := s.ContextSuite.NewHookContext()
 	info.SetNewRelation(1, "db", s.Stub)
-	info.SetAsRelationHook(1, "mediawiki")
+	info.SetAsRelationHook(1, "mediawiki/0")
 
 	com, err := jujuc.NewCommand(hctx, "secret-grant")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
-		"password", "--app", "foo",
+		"secret:9m4e2mr0ui3e8a215n4g",
 		"--relation", "db:1",
 	})
 
 	c.Assert(code, gc.Equals, 0)
-	app := "foo"
-	relId := 1
 	args := &jujuc.SecretGrantRevokeArgs{
-		ApplicationName: &app,
-		RelationId:      &relId,
+		RelationKey: ptr("wordpress:db mediawiki:db"),
 	}
-	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "GrantSecret")
-	s.Stub.CheckCall(c, 4, "GrantSecret", "password", args)
+	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "Relation", "RelationTag", "GrantSecret")
+	s.Stub.CheckCall(c, 6, "GrantSecret", "secret:9m4e2mr0ui3e8a215n4g", args)
+}
+
+func (s *SecretGrantSuite) TestGrantSecretUnit(c *gc.C) {
+	hctx, info := s.ContextSuite.NewHookContext()
+	info.SetNewRelation(1, "db", s.Stub)
+	info.SetAsRelationHook(1, "mediawiki/0")
+
+	com, err := jujuc.NewCommand(hctx, "secret-grant")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
+		"secret:9m4e2mr0ui3e8a215n4g",
+		"--relation", "db:1",
+		"--unit", "mediawiki/0",
+	})
+
+	c.Assert(code, gc.Equals, 0)
+	args := &jujuc.SecretGrantRevokeArgs{
+		RelationKey:     ptr("wordpress:db mediawiki:db"),
+		ApplicationName: ptr("mediawiki"),
+		UnitName:        ptr("mediawiki/0"),
+	}
+	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "RemoteApplicationName", "RemoteUnitName", "Relation", "RelationTag", "GrantSecret")
+	s.Stub.CheckCall(c, 8, "GrantSecret", "secret:9m4e2mr0ui3e8a215n4g", args)
+}
+
+func (s *SecretGrantSuite) TestGrantSecretWrongUnit(c *gc.C) {
+	hctx, info := s.ContextSuite.NewHookContext()
+	info.SetNewRelation(1, "db", s.Stub)
+	info.SetAsRelationHook(1, "mediawiki/0")
+
+	com, err := jujuc.NewCommand(hctx, "secret-grant")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
+		"secret:9m4e2mr0ui3e8a215n4g",
+		"--relation", "db:1",
+		"--unit", "foo/0",
+	})
+
+	c.Assert(code, gc.Equals, 2)
 }

--- a/worker/uniter/runner/jujuc/secret-revoke.go
+++ b/worker/uniter/runner/jujuc/secret-revoke.go
@@ -10,20 +10,30 @@ import (
 	"github.com/juju/names/v4"
 
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/core/secrets"
 )
 
 type secretRevokeCommand struct {
 	cmd.CommandBase
 	ctx Context
 
-	name string
+	uri  string
 	app  string
 	unit string
+
+	relationId      int
+	relationIdProxy gnuflag.Value
 }
 
 // NewSecretRevokeCommand returns a command to revoke access to a secret.
 func NewSecretRevokeCommand(ctx Context) (cmd.Command, error) {
-	return &secretRevokeCommand{ctx: ctx}, nil
+	cmd := &secretRevokeCommand{ctx: ctx}
+	var err error
+	cmd.relationIdProxy, err = NewRelationIdValue(ctx, &cmd.relationId)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return cmd, nil
 }
 
 // Info implements cmd.Command.
@@ -32,14 +42,18 @@ func (c *secretRevokeCommand) Info() *cmd.Info {
 Revoke access to view the value of a specified secret.
 Access may be revoked from an application (all units of
 that application lose access), or from a specified unit.
+If run in a relation hook, the related application's 
+access is revoked.
 
 Examples:
-    secret-revoke password --app mediawiki
-    secret-revoke password --unit mediawiki/6
+    secret-revoke secret:9m4e2mr0ui3e8a215n4g
+    secret-revoke secret:9m4e2mr0ui3e8a215n4g --relation 1
+    secret-revoke secret:9m4e2mr0ui3e8a215n4g --app mediawiki
+    secret-revoke secret:9m4e2mr0ui3e8a215n4g --unit mediawiki/6
 `
 	return jujucmd.Info(&cmd.Info{
 		Name:    "secret-revoke",
-		Args:    "<name>",
+		Args:    "<ID>",
 		Purpose: "revoke access to a secret",
 		Doc:     doc,
 	})
@@ -50,23 +64,41 @@ func (c *secretRevokeCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.app, "app", "", "the application to revoke access")
 	f.StringVar(&c.app, "application", "", "")
 	f.StringVar(&c.unit, "unit", "", "the unit to revoke access")
+	f.Var(c.relationIdProxy, "r", "the relation for which to revoke the grant")
+	f.Var(c.relationIdProxy, "relation", "the relation for which to revoke the grant")
 }
 
 // Init implements cmd.Command.
 func (c *secretRevokeCommand) Init(args []string) error {
 	if len(args) < 1 {
-		return errors.New("missing secret name")
+		return errors.New("missing secret URI")
 	}
-	if c.app == "" && c.unit == "" {
-		return errors.New("missing application or unit")
+	c.uri = args[0]
+	if _, err := secrets.ParseURI(c.uri); err != nil {
+		return errors.Trace(err)
 	}
-	if c.app != "" && !names.IsValidApplication(c.app) {
-		return errors.NotValidf("application %q", c.app)
+	count := 0
+	if c.relationId >= 0 {
+		count++
 	}
-	if c.unit != "" && !names.IsValidUnit(c.unit) {
-		return errors.NotValidf("unit %q", c.unit)
+	if c.app != "" {
+		count++
+		if !names.IsValidApplication(c.app) {
+			return errors.NotValidf("application %q", c.app)
+		}
 	}
-	c.name = args[0]
+	if c.unit != "" {
+		count++
+		if !names.IsValidUnit(c.unit) {
+			return errors.NotValidf("unit %q", c.unit)
+		}
+	}
+	if count == 0 {
+		return errors.New("missing relation or application or unit")
+	}
+	if count != 1 {
+		return errors.New("specify only one of relation or application or unit")
+	}
 	return cmd.CheckEmpty(args[1:])
 }
 
@@ -79,6 +111,21 @@ func (c *secretRevokeCommand) Run(_ *cmd.Context) error {
 	if c.unit != "" {
 		args.UnitName = &c.unit
 	}
+	if c.relationId >= 0 {
+		r, err := c.ctx.Relation(c.relationId)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		key := r.RelationTag().Id()
+		args.RelationKey = &key
+		remoteAppName, err := remoteAppForRelation(c.ctx, c.unit)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if remoteAppName != "" {
+			args.ApplicationName = &remoteAppName
+		}
+	}
 
-	return c.ctx.RevokeSecret(c.name, args)
+	return c.ctx.RevokeSecret(c.uri, args)
 }

--- a/worker/uniter/runner/jujuc/secret-revoke_test.go
+++ b/worker/uniter/runner/jujuc/secret-revoke_test.go
@@ -27,16 +27,19 @@ func (s *SecretRevokeSuite) TestRevokeSecretInvalidArgs(c *gc.C) {
 	}{
 		{
 			args: []string{},
-			err:  "ERROR missing secret name",
+			err:  "ERROR missing secret URI",
 		}, {
-			args: []string{"password"},
-			err:  `ERROR missing application or unit`,
+			args: []string{"secret:9m4e2mr0ui3e8a215n4g"},
+			err:  `ERROR missing relation or application or unit`,
 		}, {
-			args: []string{"password", "--app", "0/foo"},
+			args: []string{"secret:9m4e2mr0ui3e8a215n4g", "--app", "0/foo"},
 			err:  `ERROR application "0/foo" not valid`,
 		}, {
-			args: []string{"password", "--unit", "foo"},
+			args: []string{"secret:9m4e2mr0ui3e8a215n4g", "--unit", "foo"},
 			err:  `ERROR unit "foo" not valid`,
+		}, {
+			args: []string{"secret:9m4e2mr0ui3e8a215n4g", "--relation", "-666"},
+			err:  `ERROR invalid value "-666" for option --relation: relation not found`,
 		},
 	} {
 		com, err := jujuc.NewCommand(hctx, "secret-revoke")
@@ -49,21 +52,41 @@ func (s *SecretRevokeSuite) TestRevokeSecretInvalidArgs(c *gc.C) {
 	}
 }
 
-func (s *SecretRevokeSuite) TestRevokeSecret(c *gc.C) {
+func (s *SecretRevokeSuite) TestRevokeSecretForApp(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
 	com, err := jujuc.NewCommand(hctx, "secret-revoke")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
-		"password", "--app", "foo",
+		"secret:9m4e2mr0ui3e8a215n4g", "--app", "foo",
 	})
 
 	c.Assert(code, gc.Equals, 0)
-	app := "foo"
 	args := &jujuc.SecretGrantRevokeArgs{
-		ApplicationName: &app,
+		ApplicationName: ptr("foo"),
 	}
-	s.Stub.CheckCallNames(c, "RevokeSecret")
-	s.Stub.CheckCall(c, 0, "RevokeSecret", "password", args)
+	s.Stub.CheckCallNames(c, "HookRelation", "RevokeSecret")
+	s.Stub.CheckCall(c, 1, "RevokeSecret", "secret:9m4e2mr0ui3e8a215n4g", args)
+}
+
+func (s *SecretRevokeSuite) TestRevokeSecretForRelation(c *gc.C) {
+	hctx, info := s.ContextSuite.NewHookContext()
+	info.SetNewRelation(1, "db", s.Stub)
+	info.SetAsRelationHook(1, "mediawiki/0")
+
+	com, err := jujuc.NewCommand(hctx, "secret-revoke")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
+		"secret:9m4e2mr0ui3e8a215n4g", "--relation", "1",
+	})
+
+	c.Assert(code, gc.Equals, 0)
+	args := &jujuc.SecretGrantRevokeArgs{
+		ApplicationName: ptr("mediawiki"),
+		RelationKey:     ptr("wordpress:db mediawiki:db"),
+	}
+	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "Relation", "RelationTag", "RemoteApplicationName", "RemoteUnitName", "RevokeSecret")
+	s.Stub.CheckCall(c, 8, "RevokeSecret", "secret:9m4e2mr0ui3e8a215n4g", args)
 }


### PR DESCRIPTION
The PR adds the secrets grant and revoke hook commands and the front end api and apiserver backend.
A followup PR will implement the actual backend on top of state.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Just unit tests for this PR