### PR TITLE
Print available agent binaries in natural order

### DIFF
--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
+	"github.com/juju/naturalsort"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/api/client/modelconfig"
@@ -290,7 +291,7 @@ func formatVersions(agents coretools.Versions) string {
 	for _, agent := range agents {
 		formatted.Add(fmt.Sprintf("    %s", agent.AgentVersion().String()))
 	}
-	return strings.Join(formatted.SortedValues(), "\n")
+	return strings.Join(naturalsort.Sort(formatted.Values()), "\n")
 }
 
 type toolsAPI interface {


### PR DESCRIPTION
Log output is currently like this:

```
cmd upgrademodel.go:880 available agent binaries:
    ...
    2.8.0
    2.8.1
    2.8.10
    2.8.11
    2.8.13
    2.8.2
    2.8.3
    ...
```

We should sort it in natural order instead.
```
    ...
    2.8.8
    2.8.9
    2.8.10
    2.8.11
    ...
```

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~