### PR TITLE
[upgrade test] disable fail-fast

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       matrix:
         snap_version: ["2.8/stable"]
         model_type: ["localhost", "microk8s"]


### PR DESCRIPTION
This stops the MicroK8s upgrade test from being cancelled when the LXD upgrade test fails (and vice versa). Thus it allows the MicroK8s upgrade test to pass on 2.9.