### PR TITLE
[JUJU-1609] Add k8s container limits

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1240,9 +1240,6 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 
 	resourceRequests := corev1.ResourceList(nil)
 	millicores := 0
-	// TODO(allow resource limits to be applied to each container).
-	// For now we only do resource requests, one container is sufficient for
-	// scheduling purposes.
 	if config.Constraints.HasCpuPower() {
 		if resourceRequests == nil {
 			resourceRequests = corev1.ResourceList{}
@@ -1349,6 +1346,7 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: resourceRequests,
+			Limits:   resourceRequests,
 		},
 	}}
 
@@ -1422,6 +1420,9 @@ func (a *app) applicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 					MountPath: "/charm/container",
 					SubPath:   fmt.Sprintf("charm/containers/%s", v.Name),
 				},
+			},
+			Resources: corev1.ResourceRequirements{
+				Limits: resourceRequests,
 			},
 		}
 		if v.Image.Password != "" {

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -2694,9 +2694,13 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 			ps.NodeSelector = map[string]string{
 				"kubernetes.io/arch": "arm64",
 			}
-			ps.Containers[0].Resources.Requests = corev1.ResourceList{
+			resourceRequests := corev1.ResourceList{
 				corev1.ResourceCPU:    k8sresource.MustParse("1000m"),
 				corev1.ResourceMemory: k8sresource.MustParse("1024Mi"),
+			}
+			ps.Containers[0].Resources.Requests = resourceRequests
+			for i := range ps.Containers {
+				ps.Containers[i].Resources.Limits = resourceRequests
 			}
 
 			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})


### PR DESCRIPTION
Following discussions internally about the Kubernetes container constraints, we've decided to do a simple change to how we do limits. For now we want to set container limits (memory and cpu) to the constraint cpu/mem. It is understood that this is effectively overcommitting, but most charms only have either a single container (the charm container) or two containers (the charm container and the application container).

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
make build
make microk8s-operator-update

juju bootstrap microk8s c
juju add-model test
juju set-model-constraints mem=1G cpu-power=1000 arch=amd64
juju deploy snappass-test
microk8s kubectl get pod snappass-test-0 -n test --output=yaml
```
In the output, each container will have
```yaml
    resources:
      limits:
        cpu: "1"
        memory: 1Gi
```