### PR TITLE
[JUJU-1612] KVM broker does not stop VMs

### DIFF
--- a/container/kvm/container_internal_test.go
+++ b/container/kvm/container_internal_test.go
@@ -10,7 +10,6 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 )
 
-// gocheck boilerplate.
 type containerInternalSuite struct {
 	testing.IsolationSuite
 }

--- a/container/kvm/containerfactory.go
+++ b/container/kvm/containerfactory.go
@@ -12,8 +12,7 @@ type containerFactory struct {
 var _ ContainerFactory = (*containerFactory)(nil)
 
 func (factory *containerFactory) New(name string) Container {
-	alwaysFalse := false
-	return factory.new(name, &alwaysFalse)
+	return factory.new(name, nil)
 }
 
 func (factory *containerFactory) List() (result []Container, err error) {
@@ -23,7 +22,6 @@ func (factory *containerFactory) List() (result []Container, err error) {
 	}
 	for hostname, status := range machines {
 		result = append(result, factory.new(hostname, isRunning(status)))
-
 	}
 	return result, nil
 }
@@ -38,9 +36,6 @@ func (factory *containerFactory) new(name string, started *bool) *kvmContainer {
 }
 
 func isRunning(value string) *bool {
-	var result *bool = new(bool)
-	if value == "running" {
-		*result = true
-	}
-	return result
+	result := value == "running"
+	return &result
 }

--- a/container/kvm/containerfactory_test.go
+++ b/container/kvm/containerfactory_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package kvm
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type containerFactorySuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&containerFactorySuite{})
+
+func (containerFactorySuite) TestNewContainerStartedIsNil(c *gc.C) {
+	vm := new(containerFactory).New("some-kvm")
+
+	raw, ok := vm.(*kvmContainer)
+	c.Assert(ok, jc.IsTrue)
+
+	// A new container instantiated in this way must have an "unknown"
+	// started state, which will get queried and set at need.
+	c.Assert(raw.started, gc.IsNil)
+}


### PR DESCRIPTION
A change made under #13034 altered the behaviour of the KVM manager to report VMs as not running by default.

This was in error because VMs should have an unknown running state (nil boolean pointer) that is queried at need. Setting it to false by default was causing the linked bug, because in this case we eschew tear-down of the actual VM when decommissioning a machine.

Here we ensure it is unknown until it is queried.

## QA steps

- Deploy a unit to some KVM-on-machine.
- Remove the unit.
- Check that `juju ssh <machine> "sudo virsh list --all"` indicates no VMs.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1982960
