### PR TITLE
[JUJU-1616] Add backend for secrets access control

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -175,7 +175,11 @@ func (c *Client) GetLatestSecretsRevisionInfo(unitName string, uris []string) (m
 	}
 	info := make(map[string]SecretRevisionInfo)
 	for i, latest := range results.Results {
-		if err := results.Results[i].Error; err != nil && err.Code != params.CodeNotFound {
+		if err := results.Results[i].Error; err != nil {
+			// If deleted or now unauthorised, do not report any info for this url.
+			if err.Code == params.CodeNotFound || err.Code == params.CodeUnauthorized {
+				continue
+			}
 			return nil, errors.Annotatef(err, "finding latest info for secret %q", uris[i])
 		}
 		info[uris[i]] = SecretRevisionInfo{

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -235,20 +235,26 @@ func (s *SecretsSuite) GetLatestSecretsRevisionInfo(c *gc.C) {
 		c.Check(request, gc.Equals, "GetLatestSecretsRevisionInfo")
 		c.Check(arg, jc.DeepEquals, params.GetSecretConsumerInfoArgs{
 			ConsumerTag: "unit-foo-0",
-			URIs:        []string{"secret:9m4e2mr0ui3e8a215n4g"},
+			URIs: []string{
+				"secret:9m4e2mr0ui3e8a215n4g", "secret:8n3e2mr0ui3e8a215n5h", "secret:7c5e2mr0ui3e8a2154r2"},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretConsumerInfoResults{})
 		*(result.(*params.SecretConsumerInfoResults)) = params.SecretConsumerInfoResults{
 			Results: []params.SecretConsumerInfoResult{{
 				Revision: 666,
 				Label:    "foobar",
+			}, {
+				Error: &params.Error{Code: params.CodeUnauthorized},
+			}, {
+				Error: &params.Error{Code: params.CodeNotFound},
 			}},
 		}
 		return nil
 	})
 	var info map[string]secretsmanager.SecretRevisionInfo
 	client := secretsmanager.NewClient(apiCaller)
-	info, err := client.GetLatestSecretsRevisionInfo("foo-0", []string{"secret:9m4e2mr0ui3e8a215n4g"})
+	info, err := client.GetLatestSecretsRevisionInfo("foo-0", []string{
+		"secret:9m4e2mr0ui3e8a215n4g", "secret:8n3e2mr0ui3e8a215n5h", "secret:7c5e2mr0ui3e8a2154r2"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, map[string]secretsmanager.SecretRevisionInfo{})
 }

--- a/apiserver/facades/agent/secretsmanager/access.go
+++ b/apiserver/facades/agent/secretsmanager/access.go
@@ -6,31 +6,52 @@ package secretsmanager
 import (
 	"github.com/juju/names/v4"
 
-	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/facade"
 	coresecrets "github.com/juju/juju/core/secrets"
 )
 
-func secretOwner(agentAppName string) common.GetAuthFunc {
-	return func() (common.AuthFunc, error) {
-		return func(secretOwnerTag names.Tag) bool {
-			// We currently only support secrets owned by applications.
-			if secretOwnerTag.Kind() != names.ApplicationTagKind {
-				return false
-			}
-			return agentAppName == secretOwnerTag.Id()
-		}, nil
+// authTagApp returns the application name of the authenticated entity.
+func authTagApp(authTag names.Tag) string {
+	switch authTag.Kind() {
+	case names.ApplicationTagKind:
+		return authTag.Id()
+	case names.UnitTagKind:
+		authAppName, _ := names.UnitApplication(authTag.Id())
+		return authAppName
 	}
+	return ""
 }
 
-type canReadSecretFunc func(consumer names.Tag, uri *coresecrets.URI) bool
+func (s *SecretsManagerAPI) hasRole(uri *coresecrets.URI, entity names.Tag, role coresecrets.SecretRole) bool {
+	hasRole, err := s.secretsConsumer.SecretAccess(uri, entity)
+	return err == nil && hasRole.Allowed(role)
+}
 
-func canReadSecret(authorizer facade.Authorizer) canReadSecretFunc {
-	return func(consumer names.Tag, uri *coresecrets.URI) bool {
-		if !authorizer.AuthOwner(consumer) {
-			return false
-		}
-		// TODO(wallyworld)
+func (s *SecretsManagerAPI) canManage(uri *coresecrets.URI, entity names.Tag) bool {
+	// Manage access is granted on a per app basis;
+	// Any unit from the allowed app can manage.
+	authAppName := authTagApp(entity)
+	if authAppName == "" {
+		return false
+	}
+	app := names.NewApplicationTag(authAppName)
+	return s.hasRole(uri, app, coresecrets.RoleManage)
+}
+
+func (s *SecretsManagerAPI) canRead(uri *coresecrets.URI, entity names.Tag) bool {
+	if s.canManage(uri, entity) {
 		return true
 	}
+	// First try looking up unit access.
+	hasRole, _ := s.secretsConsumer.SecretAccess(uri, entity)
+	if hasRole.Allowed(coresecrets.RoleView) {
+		return true
+	}
+	// If no unit level access granted, try for the app.
+	authAppName := authTagApp(entity)
+	if authAppName == "" {
+		return false
+	}
+	app := names.NewApplicationTag(authAppName)
+	hasRole, _ = s.secretsConsumer.SecretAccess(uri, app)
+	return hasRole.Allowed(coresecrets.RoleView)
 }

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsconsumer.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsconsumer.go
@@ -51,32 +51,32 @@ func (mr *MockSecretsConsumerMockRecorder) GetSecretConsumer(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).GetSecretConsumer), arg0, arg1)
 }
 
-// GrantSecret mocks base method.
-func (m *MockSecretsConsumer) GrantSecret(arg0 *secrets.URI, arg1, arg2 names.Tag, arg3 secrets.SecretRole) error {
+// GrantSecretAccess mocks base method.
+func (m *MockSecretsConsumer) GrantSecretAccess(arg0 *secrets.URI, arg1, arg2 names.Tag, arg3 secrets.SecretRole) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GrantSecret", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GrantSecretAccess", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// GrantSecret indicates an expected call of GrantSecret.
-func (mr *MockSecretsConsumerMockRecorder) GrantSecret(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// GrantSecretAccess indicates an expected call of GrantSecretAccess.
+func (mr *MockSecretsConsumerMockRecorder) GrantSecretAccess(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantSecret", reflect.TypeOf((*MockSecretsConsumer)(nil).GrantSecret), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantSecretAccess", reflect.TypeOf((*MockSecretsConsumer)(nil).GrantSecretAccess), arg0, arg1, arg2, arg3)
 }
 
-// RevokeSecret mocks base method.
-func (m *MockSecretsConsumer) RevokeSecret(arg0 *secrets.URI, arg1, arg2 names.Tag) error {
+// RevokeSecretAccess mocks base method.
+func (m *MockSecretsConsumer) RevokeSecretAccess(arg0 *secrets.URI, arg1 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RevokeSecret", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "RevokeSecretAccess", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RevokeSecret indicates an expected call of RevokeSecret.
-func (mr *MockSecretsConsumerMockRecorder) RevokeSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
+// RevokeSecretAccess indicates an expected call of RevokeSecretAccess.
+func (mr *MockSecretsConsumerMockRecorder) RevokeSecretAccess(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecret", reflect.TypeOf((*MockSecretsConsumer)(nil).RevokeSecret), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecretAccess", reflect.TypeOf((*MockSecretsConsumer)(nil).RevokeSecretAccess), arg0, arg1)
 }
 
 // SaveSecretConsumer mocks base method.
@@ -91,6 +91,21 @@ func (m *MockSecretsConsumer) SaveSecretConsumer(arg0 *secrets.URI, arg1 string,
 func (mr *MockSecretsConsumerMockRecorder) SaveSecretConsumer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).SaveSecretConsumer), arg0, arg1, arg2)
+}
+
+// SecretAccess mocks base method.
+func (m *MockSecretsConsumer) SecretAccess(arg0 *secrets.URI, arg1 names.Tag) (secrets.SecretRole, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretAccess", arg0, arg1)
+	ret0, _ := ret[0].(secrets.SecretRole)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SecretAccess indicates an expected call of SecretAccess.
+func (mr *MockSecretsConsumerMockRecorder) SecretAccess(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretAccess", reflect.TypeOf((*MockSecretsConsumer)(nil).SecretAccess), arg0, arg1)
 }
 
 // WatchConsumedSecretsChanges mocks base method.

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/names/v4"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/secrets"
@@ -33,8 +32,6 @@ func NewTestAPI(
 	service secrets.SecretsService,
 	consumer SecretsConsumer,
 	secretsRotation SecretsRotation,
-	manageSecret common.GetAuthFunc,
-	canRead canReadSecretFunc,
 	authTag names.Tag,
 	clock clock.Clock,
 ) (*SecretsManagerAPI, error) {
@@ -50,8 +47,6 @@ func NewTestAPI(
 		secretsService:  service,
 		secretsConsumer: consumer,
 		secretsRotation: secretsRotation,
-		manageSecret:    manageSecret,
-		canRead:         canRead,
 		clock:           clock,
 	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/names/v4"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -29,14 +28,6 @@ func newSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 	if !context.Auth().AuthUnitAgent() && !context.Auth().AuthApplicationAgent() {
 		return nil, apiservererrors.ErrPerm
 	}
-	// Work out the app name associated with the agent since this is
-	// the secret owner for newly created secrets.
-	agentTag := context.Auth().GetAuthTag()
-	agentAppName := agentTag.Id()
-	if agentTag.Kind() == names.UnitTagKind {
-		agentAppName, _ = names.UnitApplication(agentAppName)
-	}
-
 	// For now we just support the Juju secrets provider.
 	service, err := provider.NewSecretProvider(juju.Provider, secrets.ProviderConfig{
 		juju.ParamBackend: context.State(),
@@ -52,8 +43,6 @@ func newSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		resources:       context.Resources(),
 		secretsRotation: context.State(),
 		secretsConsumer: context.State(),
-		manageSecret:    secretOwner(agentAppName),
-		canRead:         canReadSecret(context.Auth()),
 		clock:           clock.WallClock,
 	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/state.go
+++ b/apiserver/facades/agent/secretsmanager/state.go
@@ -23,6 +23,7 @@ type SecretsConsumer interface {
 	GetSecretConsumer(*secrets.URI, string) (*secrets.SecretConsumerMetadata, error)
 	SaveSecretConsumer(*secrets.URI, string, *secrets.SecretConsumerMetadata) error
 	WatchConsumedSecretsChanges(string) state.StringsWatcher
-	GrantSecret(uri *secrets.URI, scope names.Tag, subject names.Tag, role secrets.SecretRole) error
-	RevokeSecret(uri *secrets.URI, scope names.Tag, subject names.Tag) error
+	GrantSecretAccess(uri *secrets.URI, scope names.Tag, subject names.Tag, role secrets.SecretRole) error
+	RevokeSecretAccess(uri *secrets.URI, subject names.Tag) error
+	SecretAccess(uri *secrets.URI, subject names.Tag) (secrets.SecretRole, error)
 }

--- a/core/secrets/rbac.go
+++ b/core/secrets/rbac.go
@@ -7,6 +7,7 @@ package secrets
 type SecretRole string
 
 const (
+	RoleNone   = SecretRole("")
 	RoleView   = SecretRole("view")
 	RoleRotate = SecretRole("rotate")
 	RoleManage = SecretRole("manage")
@@ -15,8 +16,29 @@ const (
 // IsValid returns true if r is a valid secret role.
 func (r SecretRole) IsValid() bool {
 	switch r {
-	case RoleView, RoleRotate, RoleManage:
+	case RoleNone, RoleView, RoleRotate, RoleManage:
 		return true
 	}
 	return false
+}
+
+func (r SecretRole) value() int {
+	switch r {
+	case RoleView:
+		return 1
+	case RoleRotate:
+		return 2
+	case RoleManage:
+		return 3
+	default:
+		return -1
+	}
+}
+
+func (r SecretRole) Allowed(wanted SecretRole) bool {
+	v1, v2 := r.value(), wanted.value()
+	if v1 < 0 || v2 < 0 {
+		return false
+	}
+	return v1 >= v2
 }

--- a/core/secrets/rbac_test.go
+++ b/core/secrets/rbac_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+)
+
+type RoleSuite struct{}
+
+var _ = gc.Suite(&RoleSuite{})
+
+func (s *SecretValueSuite) TestAllowed(c *gc.C) {
+	c.Assert(secrets.RoleNone.Allowed(secrets.RoleView), jc.IsFalse)
+	c.Assert(secrets.RoleNone.Allowed(secrets.RoleRotate), jc.IsFalse)
+	c.Assert(secrets.RoleNone.Allowed(secrets.RoleManage), jc.IsFalse)
+	c.Assert(secrets.RoleView.Allowed(secrets.RoleView), jc.IsTrue)
+	c.Assert(secrets.RoleView.Allowed(secrets.RoleRotate), jc.IsFalse)
+	c.Assert(secrets.RoleView.Allowed(secrets.RoleManage), jc.IsFalse)
+	c.Assert(secrets.RoleRotate.Allowed(secrets.RoleView), jc.IsTrue)
+	c.Assert(secrets.RoleRotate.Allowed(secrets.RoleRotate), jc.IsTrue)
+	c.Assert(secrets.RoleRotate.Allowed(secrets.RoleManage), jc.IsFalse)
+	c.Assert(secrets.RoleManage.Allowed(secrets.RoleView), jc.IsTrue)
+	c.Assert(secrets.RoleManage.Allowed(secrets.RoleRotate), jc.IsTrue)
+	c.Assert(secrets.RoleManage.Allowed(secrets.RoleManage), jc.IsTrue)
+}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -565,6 +565,12 @@ func allCollections() CollectionSchema {
 			}},
 		},
 
+		secretPermissionsC: {
+			indexes: []mgo.Index{{
+				Key: []string{"subject-tag", "scope-tag"},
+			}},
+		},
+
 		secretRotateC: {
 			global: true,
 			indexes: []mgo.Index{{
@@ -682,8 +688,9 @@ const (
 	firewallRulesC       = "firewallRules"
 
 	// Secrets
-	secretMetadataC  = "secretMetadata"
-	secretRevisionsC = "secretRevisions"
-	secretConsumersC = "secretConsumers"
-	secretRotateC    = "secretRotate"
+	secretMetadataC    = "secretMetadata"
+	secretRevisionsC   = "secretRevisions"
+	secretConsumersC   = "secretConsumers"
+	secretPermissionsC = "secretPermissions"
+	secretRotateC      = "secretRotate"
 )

--- a/state/application.go
+++ b/state/application.go
@@ -668,6 +668,12 @@ func (a *Application) removeOps(asserts bson.D, op *ForcedOperation) ([]txn.Op, 
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, removeOfferOps...)
+	// Remove secret permissions.
+	secretPermissionsOps, err := a.st.removeScopedSecretPermissionOps(a.Tag())
+	if op.FatalError(err) {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, secretPermissionsOps...)
 
 	// Note that appCharmDecRefOps might not catch the final decref
 	// when run in a transaction that decrefs more than once. So we
@@ -2690,6 +2696,10 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	if op.FatalError(err) {
 		return nil, errors.Trace(err)
 	}
+	secretPermissionsOps, err := a.st.removeScopedSecretPermissionOps(u.Tag())
+	if op.FatalError(err) {
+		return nil, errors.Trace(err)
+	}
 
 	observedFieldsMatch := bson.D{
 		{"charmurl", u.doc.CharmURL},
@@ -2715,6 +2725,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	ops = append(ops, portsOps...)
 	ops = append(ops, resOps...)
 	ops = append(ops, hostOps...)
+	ops = append(ops, secretPermissionsOps...)
 
 	m, err := a.st.Model()
 	if err != nil {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -43,7 +43,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		unitsC,
 		meterStatusC, // red / green status for metrics of units
 		payloadsC,
-		"resources",
+		resourcesC,
 
 		// relation
 		relationsC,
@@ -220,6 +220,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		secretRevisionsC,
 		secretConsumersC,
 		secretRotateC,
+		secretPermissionsC,
 	)
 
 	modelCollections := set.NewStrings()

--- a/state/relation.go
+++ b/state/relation.go
@@ -556,6 +556,11 @@ func (r *Relation) removeOps(ignoreApplication string, departingUnitName string,
 	ops = append(ops, tokenOps...)
 	offerOps := removeOfferConnectionsForRelationOps(r.Id())
 	ops = append(ops, offerOps...)
+	secretPermissionsOps, err := r.st.removeScopedSecretPermissionOps(r.Tag())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, secretPermissionsOps...)
 	// This cleanup does not need to be forced.
 	cleanupOp := newCleanupOp(cleanupRelationSettings, fmt.Sprintf("r#%d#", r.Id()))
 	return append(ops, cleanupOp), nil

--- a/worker/uniter/runner/jujuc/secret-grant_test.go
+++ b/worker/uniter/runner/jujuc/secret-grant_test.go
@@ -13,15 +13,13 @@ import (
 )
 
 type SecretGrantSuite struct {
-	ContextSuite
+	relationSuite
 }
 
 var _ = gc.Suite(&SecretGrantSuite{})
 
 func (s *SecretGrantSuite) TestGrantSecretInvalidArgs(c *gc.C) {
-	hctx, info := s.ContextSuite.NewHookContext()
-	info.SetNewRelation(1, "db", s.Stub)
-	info.SetAsRelationHook(1, "mediawiki/0")
+	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
 	for _, t := range []struct {
 		args []string
@@ -55,9 +53,7 @@ func (s *SecretGrantSuite) TestGrantSecretInvalidArgs(c *gc.C) {
 }
 
 func (s *SecretGrantSuite) TestGrantSecret(c *gc.C) {
-	hctx, info := s.ContextSuite.NewHookContext()
-	info.SetNewRelation(1, "db", s.Stub)
-	info.SetAsRelationHook(1, "mediawiki/0")
+	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
 	com, err := jujuc.NewCommand(hctx, "secret-grant")
 	c.Assert(err, jc.ErrorIsNil)
@@ -69,16 +65,15 @@ func (s *SecretGrantSuite) TestGrantSecret(c *gc.C) {
 
 	c.Assert(code, gc.Equals, 0)
 	args := &jujuc.SecretGrantRevokeArgs{
-		RelationKey: ptr("wordpress:db mediawiki:db"),
+		RelationKey:     ptr("wordpress:db mediawiki:db"),
+		ApplicationName: ptr("mediawiki"),
 	}
-	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "Relation", "RelationTag", "GrantSecret")
-	s.Stub.CheckCall(c, 6, "GrantSecret", "secret:9m4e2mr0ui3e8a215n4g", args)
+	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "Relation", "RelationTag", "RemoteApplicationName", "GrantSecret")
+	s.Stub.CheckCall(c, 7, "GrantSecret", "secret:9m4e2mr0ui3e8a215n4g", args)
 }
 
 func (s *SecretGrantSuite) TestGrantSecretUnit(c *gc.C) {
-	hctx, info := s.ContextSuite.NewHookContext()
-	info.SetNewRelation(1, "db", s.Stub)
-	info.SetAsRelationHook(1, "mediawiki/0")
+	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
 	com, err := jujuc.NewCommand(hctx, "secret-grant")
 	c.Assert(err, jc.ErrorIsNil)
@@ -95,14 +90,12 @@ func (s *SecretGrantSuite) TestGrantSecretUnit(c *gc.C) {
 		ApplicationName: ptr("mediawiki"),
 		UnitName:        ptr("mediawiki/0"),
 	}
-	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "RemoteApplicationName", "RemoteUnitName", "Relation", "RelationTag", "GrantSecret")
-	s.Stub.CheckCall(c, 8, "GrantSecret", "secret:9m4e2mr0ui3e8a215n4g", args)
+	s.Stub.CheckCallNames(c, "HookRelation", "Id", "FakeId", "Relation", "Relation", "RelationTag", "RemoteApplicationName", "GrantSecret")
+	s.Stub.CheckCall(c, 7, "GrantSecret", "secret:9m4e2mr0ui3e8a215n4g", args)
 }
 
 func (s *SecretGrantSuite) TestGrantSecretWrongUnit(c *gc.C) {
-	hctx, info := s.ContextSuite.NewHookContext()
-	info.SetNewRelation(1, "db", s.Stub)
-	info.SetAsRelationHook(1, "mediawiki/0")
+	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
 	com, err := jujuc.NewCommand(hctx, "secret-grant")
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/jujuc/secret-revoke.go
+++ b/worker/uniter/runner/jujuc/secret-revoke.go
@@ -43,7 +43,8 @@ Revoke access to view the value of a specified secret.
 Access may be revoked from an application (all units of
 that application lose access), or from a specified unit.
 If run in a relation hook, the related application's 
-access is revoked.
+access is revoked, unless a uni is specified, in which
+case just that unit's access is revoked.'
 
 Examples:
     secret-revoke secret:9m4e2mr0ui3e8a215n4g
@@ -77,27 +78,31 @@ func (c *secretRevokeCommand) Init(args []string) error {
 	if _, err := secrets.ParseURI(c.uri); err != nil {
 		return errors.Trace(err)
 	}
-	count := 0
-	if c.relationId >= 0 {
-		count++
-	}
 	if c.app != "" {
-		count++
 		if !names.IsValidApplication(c.app) {
 			return errors.NotValidf("application %q", c.app)
 		}
 	}
 	if c.unit != "" {
-		count++
 		if !names.IsValidUnit(c.unit) {
 			return errors.NotValidf("unit %q", c.unit)
 		}
 	}
-	if count == 0 {
-		return errors.New("missing relation or application or unit")
+	if c.app != "" && c.unit != "" {
+		return errors.New("specify only one of application or unit")
 	}
-	if count != 1 {
-		return errors.New("specify only one of relation or application or unit")
+	if c.relationId >= 0 {
+		r, err := c.ctx.Relation(c.relationId)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if c.app != "" {
+			return errors.New("do not specify both relation and app")
+		}
+		c.app = r.RemoteApplicationName()
+	}
+	if c.app == "" && c.unit == "" {
+		return errors.New("missing relation or application or unit")
 	}
 	return cmd.CheckEmpty(args[1:])
 }
@@ -110,21 +115,6 @@ func (c *secretRevokeCommand) Run(_ *cmd.Context) error {
 	}
 	if c.unit != "" {
 		args.UnitName = &c.unit
-	}
-	if c.relationId >= 0 {
-		r, err := c.ctx.Relation(c.relationId)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		key := r.RelationTag().Id()
-		args.RelationKey = &key
-		remoteAppName, err := remoteAppForRelation(c.ctx, c.unit)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if remoteAppName != "" {
-			args.ApplicationName = &remoteAppName
-		}
 	}
 
 	return c.ctx.RevokeSecret(c.uri, args)


### PR DESCRIPTION
This PR implements the secret ACL backend. The stub permission checks on the secrets manager facade were reworked to suit. It also fixes a few issues with the grant/revoke hook commands that appeared when the full QA was done.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [X] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

deploy test charms
```
juju deploy juju-qa-dummy-source
juju deploy juju-qa-dummy-sink
juju add-unit dummy-sink
```
create a secret
```
juju exec --unit dummy-source/0 "secret-add data=foo"
secret:cbtcu5efg3o24llgfr7g
```
create check the owner can update and read a secret
```
juju exec --unit dummy-source/0 "secret-update secret:cbtcu5efg3o24llgfr7g data=foo2"
juju exec --unit dummy-source/0 "secret-get secret:cbtcu5efg3o24llgfr7g"
data: foo2
```
check that unauthorised access not allowed
```
juju exec --unit dummy-sink/0 "secret-get secret:cbtcu5efg3o24llgfr7g"
ERROR permission denied
```
relate dummy-sourc to dummy-sink and grant access
```
juju relate dummy-source dummy-sink
juju exec --unit dummy-source/0 "secret-grant secret:cbtcu5efg3o24llgfr7g -r 0"
```
any unit of dummy-sink can read the secret
```
juju exec --unit dummy-sink/0 "secret-get secret:cbtcu5efg3o24llgfr7g"
data: foo2
juju exec --unit dummy-sink/1 "secret-get secret:cbtcu5efg3o24llgfr7g"
data: foo2
```
remove the relation and access goes away
```
juju remove-relation dummy-source:sink dummy-sink:source
juju exec --unit dummy-sink/1 "secret-get secret:cbtcu5efg3o24llgfr7g"
ERROR permission denied
```
add relation again and grant access just to dummy-sink/1
```
juju relate dummy-source dummy-sink
juju exec --unit dummy-source/0 "secret-grant secret:cbtcu5efg3o24llgfr7g -r 1 --unit dummy-sink/1"
juju exec --unit dummy-sink/1 "secret-get secret:cbtcu5efg3o24llgfr7g"
data: foo2
juju exec --unit dummy-sink/0 "secret-get secret:cbtcu5efg3o24llgfr7g"
ERROR permission denied
```
revoke access and check
```
juju exec --unit dummy-source/0 "secret-revoke secret:cbtcu5efg3o24llgfr7g --unit dummy-sink/1"
uju exec --unit dummy-sink/1 "secret-get secret:cbtcu5efg3o24llgfr7g"
ERROR permission denied
```

