### PR TITLE
[JUJU-1624] Do not terminate migrated CMR offers

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -550,7 +550,7 @@ func (api *CrossModelRelationsAPI) WatchOfferStatus(
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		// TODO: move full watcher to the model cache.
+
 		w, err := api.offerStatusWatcher(api.st, arg.OfferUUID)
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -630,6 +630,7 @@ func (s *crossmodelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 	c.Assert(results.Results[2].Error.ErrorCode(), gc.Equals, params.CodeUnauthorized)
 	c.Assert(s.watchedOffers, jc.DeepEquals, []string{"mysql-uuid"})
 	s.st.CheckCalls(c, []testing.StubCall{
+		{"IsMigrationActive", nil},
 		{"Application", []interface{}{"mysql"}},
 	})
 	app.CheckCalls(c, []testing.StubCall{

--- a/core/migration/errors.go
+++ b/core/migration/errors.go
@@ -1,0 +1,8 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import "github.com/juju/errors"
+
+const ErrMigrating = errors.ConstError("model is being migrated")


### PR DESCRIPTION
When a model with CMR offers is migrated, there is a window where the model is removed from the source controller, but the migration phase is not yet _DONE_.

At this time the consuming model is not getting a redirect to the new controller, but the newly removed offers are indicated as _Terminated_.

Here we do not report _Terminated_ if an offer is not found during a migration. Instead we return a new error used to indicate a migration-in-progress, which is returned wholesale by the watcher instead of inside a payload. This causes the client-side to terminate the watch, and upon re-establishment, get redirected to the new controller.

## QA steps

- Bootstrap 3 controllers: _src_, _dst_ and _csm_.
- On _src_, `juju deploy postgresql && juju offer postgresql:db` and wait for completion.
- On _csm_, `juju consume src:admin/default.postgresql` and wait for the offer to be active.
- On _dst_, `juju destroy-model default -y`.
- Start watching the status on _csm_.
- On _src_ `juju migrate default dst`.
- The status for _csm_ will show the offer status transition briefly to `unknown` before back to `active`.
- Logs will show the watcher error, then re-establishment via redirection to the new controller:
```
controller-0: 15:38:58 DEBUG juju.worker.remoterelations cmr offer status changed: []watcher.OfferStatusChange{watcher.OfferStatusChange{Name:"postgresql", Status:status.StatusInfo{Status:"unknown", Message:"", Data:map[string]interface {}(nil), Since:<nil>}}}
controller-0: 15:38:58 ERROR juju.worker.remoterelations cmr error in remote application worker for postgresql: model is being migrated
controller-0: 15:39:13 DEBUG juju.worker.remoterelations cmr remote controller API addresses: [10.161.87.210:17070]
controller-0: 15:39:13 DEBUG juju.worker.remoterelations cmr received redirect; new API addresses: [10.161.87.244:17070]
controller-0: 15:39:14 DEBUG juju.worker.remoterelations cmr relations changed: &[]string(nil), true
controller-0: 15:39:14 DEBUG juju.worker.remoterelations cmr offer status changed: []watcher.OfferStatusChange{watcher.OfferStatusChange{Name:"postgresql", Status:status.StatusInfo{Status:"active", Message:"Live master (12.11)", Data:map[string]interface {}(nil), Since:time.Date(2022, time.August, 18, 12, 53, 8, 109059416, time.UTC)}}}
```

## Documentation changes

None.

## Bug reference

N/A
