### PR TITLE
[JUJU-1656] Add a new secret-ids hook command

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -199,6 +199,26 @@ func (s *SecretsManagerAPI) getSecretConsumerInfo(consumerTag names.Tag, uriStr 
 	return s.secretsConsumer.GetSecretConsumer(uri, consumerTag.String())
 }
 
+// GetSecretIds returns the caller's secret ids and their labels.
+func (s *SecretsManagerAPI) GetSecretIds() (params.SecretIdResults, error) {
+	var result params.SecretIdResults
+	ctx := context.Background()
+	secrets, err := s.secretsService.ListSecrets(ctx, secrets.Filter{
+		OwnerTag: names.NewApplicationTag(authTagApp(s.authTag)).String(),
+	})
+	if err != nil {
+		result.Error = apiservererrors.ServerError(err)
+		return result, nil
+	}
+	result.Result = make(map[string]params.SecretIdResult)
+	for _, md := range secrets {
+		result.Result[md.URI.ShortString()] = params.SecretIdResult{
+			Label: md.Label,
+		}
+	}
+	return result, nil
+}
+
 // GetSecretValues returns the secret values for the specified secrets.
 func (s *SecretsManagerAPI) GetSecretValues(args params.GetSecretValueArgs) (params.SecretValueResults, error) {
 	result := params.SecretValueResults{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38577,6 +38577,15 @@
                     },
                     "description": "GetLatestSecretsRevisionInfo returns the latest secret revisions for the specified secrets."
                 },
+                "GetSecretIds": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/SecretIdResults"
+                        }
+                    },
+                    "description": "GetSecretIds returns the caller's secret ids and their labels."
+                },
                 "GetSecretValues": {
                     "type": "object",
                     "properties": {
@@ -38945,6 +38954,38 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "SecretIdResult": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "label"
+                    ]
+                },
+                "SecretIdResults": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/SecretIdResult"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
                     ]
                 },
                 "SecretRotatedArg": {

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -137,6 +137,7 @@ var expectedCommands = []string{
 	"secret-add",
 	"secret-get",
 	"secret-grant",
+	"secret-ids",
 	"secret-remove",
 	"secret-revoke",
 	"secret-update",

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -66,6 +66,17 @@ type SecretURIArg struct {
 	URI string `json:"uri"`
 }
 
+// SecretIdResult is the result of getting secret ID data.
+type SecretIdResult struct {
+	Label string `json:"label"`
+}
+
+// SecretIdResults holds results for getting secret IDs.
+type SecretIdResults struct {
+	Result map[string]SecretIdResult `json:"result"`
+	Error  *Error                    `json:"error,omitempty"`
+}
+
 // GetSecretConsumerInfoArgs holds the args for getting secret
 // consumer metadata.
 type GetSecretConsumerInfoArgs struct {

--- a/secrets/interface.go
+++ b/secrets/interface.go
@@ -73,7 +73,7 @@ func (p *UpsertParams) Validate() error {
 
 // Filter is used when querying secrets.
 type Filter struct {
-	// TODO(wallyworld)
+	OwnerTag string
 }
 
 // SecretsService instances provide a backend for storing secrets values.

--- a/secrets/provider/juju/secrets.go
+++ b/secrets/provider/juju/secrets.go
@@ -73,7 +73,10 @@ func (s secretsService) GetSecret(ctx context.Context, uri *coresecrets.URI) (*c
 
 // ListSecrets implements SecretsService.
 func (s secretsService) ListSecrets(ctx context.Context, filter secrets.Filter) ([]*coresecrets.SecretMetadata, error) {
-	return s.backend.ListSecrets(state.SecretsFilter{})
+	f := state.SecretsFilter{
+		OwnerTag: filter.OwnerTag,
+	}
+	return s.backend.ListSecrets(f)
 }
 
 // UpdateSecret implements SecretsService.

--- a/secrets/provider/juju/secrets_test.go
+++ b/secrets/provider/juju/secrets_test.go
@@ -253,11 +253,15 @@ func (s *SecretsManagerSuite) TestListSecrets(c *gc.C) {
 		URI:      uri,
 		Revision: 2,
 	}}
-	s.secretsStore.EXPECT().ListSecrets(state.SecretsFilter{}).Return(
+	s.secretsStore.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTag: "application-mariadb",
+	}).Return(
 		metadata, nil,
 	)
 
-	result, err := service.ListSecrets(context.Background(), secrets.Filter{})
+	result, err := service.ListSecrets(context.Background(), secrets.Filter{
+		OwnerTag: "application-mariadb",
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, metadata)
 }

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -160,7 +160,17 @@ func (s *SecretsSuite) TestList(c *gc.C) {
 	_, err := s.store.CreateSecret(uri, p)
 	c.Assert(err, jc.ErrorIsNil)
 
-	list, err := s.store.ListSecrets(state.SecretsFilter{})
+	// Create another secret to ensure it is excluded.
+	uri2 := secrets.NewURI()
+	uri2.ControllerUUID = s.State.ControllerUUID()
+	p.Owner = "application-wordpress"
+	p.Scope = "application-wordpress"
+	_, err = s.store.CreateSecret(uri2, p)
+	c.Assert(err, jc.ErrorIsNil)
+
+	list, err := s.store.ListSecrets(state.SecretsFilter{
+		OwnerTag: s.owner.Tag().String(),
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(list, jc.DeepEquals, []*secrets.SecretMetadata{{
 		URI:            uri,

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -64,6 +64,7 @@ func (s *ContextFactorySuite) SetUpTest(c *gc.C) {
 		Tracker:          &runnertesting.FakeTracker{},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,
+		Secrets:          s.secrets,
 		Payloads:         s.payloads,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
@@ -277,6 +278,7 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 		Tracker:          &runnertesting.FakeTracker{},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,
+		Secrets:          s.secrets,
 		Payloads:         s.payloads,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
@@ -301,13 +303,14 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 
 func (s *ContextFactorySuite) TestSecretHookContext(c *gc.C) {
 	hi := hook.Info{
-		Kind:      hooks.SecretRotate,
-		SecretURI: "secret:9m4e2mr0ui3e8a215n4g",
+		Kind:        hooks.SecretRotate,
+		SecretURI:   "secret:9m4e2mr0ui3e8a215n4g",
+		SecretLabel: "label",
 	}
 	ctx, err := s.factory.HookContext(hi)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AssertCoreContext(c, ctx)
-	s.AssertSecretContext(c, ctx, hi.SecretURI)
+	s.AssertSecretContext(c, ctx, hi.SecretURI, hi.SecretLabel)
 	s.AssertNotWorkloadContext(c, ctx)
 	s.AssertNotActionContext(c, ctx)
 	s.AssertNotRelationContext(c, ctx)
@@ -369,6 +372,7 @@ func (s *ContextFactorySuite) setupPodSpec(c *gc.C) (*state.State, context.Conte
 		},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,
+		Secrets:          s.secrets,
 		Payloads:         s.payloads,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
@@ -578,6 +582,7 @@ func (s *ContextFactorySuite) TestNewHookContextCAASModel(c *gc.C) {
 		},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,
+		Secrets:          s.secrets,
 		Payloads:         s.payloads,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -114,10 +114,10 @@ func NewMockUnitHookContextWithState(unitName string, mockUnit *mocks.MockHookUn
 
 func NewMockUnitHookContextWithSecrets(mockUnit *mocks.MockHookUnit, client *secretsmanager.Client) *HookContext {
 	return &HookContext{
-		unitName:     mockUnit.Tag().Id(),
-		unit:         mockUnit,
-		secretFacade: client,
-		logger:       loggo.GetLogger("test"),
+		unitName: mockUnit.Tag().Id(),
+		unit:     mockUnit,
+		secrets:  client,
+		logger:   loggo.GetLogger("test"),
 	}
 }
 

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -43,6 +43,7 @@ type HookContextSuite struct {
 	relch       *state.Charm
 	relunits    map[int]*state.RelationUnit
 	storage     *runnertesting.StorageContextAccessor
+	secrets     *runnertesting.SecretsContextAccessor
 	clock       *testclock.Clock
 
 	st             api.Connection
@@ -122,6 +123,7 @@ func (s *HookContextSuite) SetUpTest(c *gc.C) {
 			},
 		},
 	}
+	s.secrets = &runnertesting.SecretsContextAccessor{}
 
 	s.clock = testclock.NewClock(time.Time{})
 }
@@ -305,6 +307,14 @@ func (s *HookContextSuite) AssertCoreContext(c *gc.C, ctx *runnercontext.HookCon
 	az, err := ctx.AvailabilityZone()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(az, gc.Equals, "a-zone")
+
+	secretIds, err := ctx.SecretIds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(secretIds, gc.HasLen, 1)
+	for uri, label := range secretIds {
+		c.Assert(uri.ShortString(), gc.Equals, "secret:secret:9m4e2mr0ui3e8a215n4g")
+		c.Assert(label, gc.Equals, "label")
+	}
 }
 
 func (s *HookContextSuite) AssertNotActionContext(c *gc.C, ctx *runnercontext.HookContext) {
@@ -362,9 +372,10 @@ func (s *HookContextSuite) AssertNotWorkloadContext(c *gc.C, ctx *runnercontext.
 	c.Assert(workloadName, gc.Equals, "")
 }
 
-func (s *HookContextSuite) AssertSecretContext(c *gc.C, ctx *runnercontext.HookContext, secretURI string) {
+func (s *HookContextSuite) AssertSecretContext(c *gc.C, ctx *runnercontext.HookContext, secretURI, label string) {
 	uri, _ := ctx.SecretURI()
 	c.Assert(uri, gc.Equals, secretURI)
+	c.Assert(ctx.SecretLabel(), gc.Equals, label)
 }
 
 func (s *HookContextSuite) AssertNotSecretContext(c *gc.C, ctx *runnercontext.HookContext) {

--- a/worker/uniter/runner/factory_test.go
+++ b/worker/uniter/runner/factory_test.go
@@ -173,6 +173,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 		Tracker:          &runnertesting.FakeTracker{},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,
+		Secrets:          s.secrets,
 		Payloads:         s.payloads,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -206,6 +206,9 @@ type ContextSecrets interface {
 
 	// RevokeSecret revokes access to the specified secret.
 	RevokeSecret(string, *SecretGrantRevokeArgs) error
+
+	// SecretIds gets the secret ids and their labels created by the charm.
+	SecretIds() (map[*secrets.URI]string, error)
 }
 
 // ContextStatus is the part of a hook context related to the unit's status.

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -39,6 +39,11 @@ func (c *ContextSecrets) RemoveSecret(uri string) error {
 	return nil
 }
 
+func (c *ContextSecrets) SecretIds() (map[*secrets.URI]string, error) {
+	c.stub.AddCall("SecretIds")
+	return nil, nil
+}
+
 // GrantSecret implements jujuc.ContextSecrets.
 func (c *ContextSecrets) GrantSecret(uri string, args *jujuc.SecretGrantRevokeArgs) error {
 	c.stub.AddCall("GrantSecret", uri, args)

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -629,6 +629,21 @@ func (mr *MockContextMockRecorder) RevokeSecret(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecret", reflect.TypeOf((*MockContext)(nil).RevokeSecret), arg0, arg1)
 }
 
+// SecretIds mocks base method.
+func (m *MockContext) SecretIds() (map[*secrets.URI]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretIds")
+	ret0, _ := ret[0].(map[*secrets.URI]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SecretIds indicates an expected call of SecretIds.
+func (mr *MockContextMockRecorder) SecretIds() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretIds", reflect.TypeOf((*MockContext)(nil).SecretIds))
+}
+
 // SetActionFailed mocks base method.
 func (m *MockContext) SetActionFailed() error {
 	m.ctrl.T.Helper()

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -272,6 +272,10 @@ func (ctx *RestrictedContext) RemoveSecret(string) error {
 	return ErrRestrictedContext
 }
 
+func (ctx *RestrictedContext) SecretIds() (map[*secrets.URI]string, error) {
+	return nil, ErrRestrictedContext
+}
+
 // GrantSecret implements runner.Context.
 func (c *RestrictedContext) GrantSecret(string, *SecretGrantRevokeArgs) error {
 	return nil

--- a/worker/uniter/runner/jujuc/secret-ids.go
+++ b/worker/uniter/runner/jujuc/secret-ids.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/gnuflag"
+
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+type secretIdsCommand struct {
+	cmd.CommandBase
+	ctx Context
+
+	out cmd.Output
+}
+
+// NewSecretIdsCommand returns a command to list the IDs and labels of secrets.
+// created by this app.
+func NewSecretIdsCommand(ctx Context) (cmd.Command, error) {
+	return &secretIdsCommand{ctx: ctx}, nil
+}
+
+// Info implements cmd.Command.
+func (c *secretIdsCommand) Info() *cmd.Info {
+	doc := `
+Returns the secret ids and labels for secrets owned by the application.
+
+Examples:
+    secret-ids
+`
+	return jujucmd.Info(&cmd.Info{
+		Name:    "secret-ids",
+		Purpose: "print secret ids and their labels",
+		Doc:     doc,
+	})
+}
+
+// SetFlags implements cmd.Command.
+func (c *secretIdsCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+}
+
+// Init implements cmd.Command.
+func (c *secretIdsCommand) Init(args []string) error {
+	return cmd.CheckEmpty(args)
+}
+
+// Run implements cmd.Command.
+func (c *secretIdsCommand) Run(ctx *cmd.Context) error {
+	result, err := c.ctx.SecretIds()
+	if err != nil {
+		return err
+	}
+	out := make(map[string]string)
+	for uri, label := range result {
+		out[uri.ShortString()] = label
+	}
+	return c.out.Write(ctx, out)
+}

--- a/worker/uniter/runner/jujuc/secret-ids_test.go
+++ b/worker/uniter/runner/jujuc/secret-ids_test.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type SecretIdsSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&SecretIdsSuite{})
+
+func (s *SecretIdsSuite) TestSecretIds(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, "secret-ids")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, nil)
+
+	c.Assert(code, gc.Equals, 0)
+	s.Stub.CheckCallNames(c, "SecretIds")
+}

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -89,6 +89,7 @@ var secretCommands = map[string]creator{
 	"secret-get":    NewSecretGetCommand,
 	"secret-grant":  NewSecretGrantCommand,
 	"secret-revoke": NewSecretRevokeCommand,
+	"secret-ids":    NewSecretIdsCommand,
 }
 
 var storageCommands = map[string]creator{

--- a/worker/uniter/runner/testing/utils.go
+++ b/worker/uniter/runner/testing/utils.go
@@ -12,8 +12,10 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/juju/sockets"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/worker/uniter/runner/context"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
 
@@ -140,4 +142,14 @@ func (ft *FakeTicket) Ready() <-chan struct{} {
 	c := make(chan struct{})
 	close(c)
 	return c
+}
+
+type SecretsContextAccessor struct {
+	context.SecretsAccessor
+}
+
+func (s SecretsContextAccessor) SecretIds() (map[*secrets.URI]string, error) {
+	return map[*secrets.URI]string{
+		{ID: "secret:9m4e2mr0ui3e8a215n4g"}: "label",
+	}, nil
 }

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -55,6 +55,7 @@ type ContextSuite struct {
 	apiUnit     *uniter.Unit
 	payloads    *uniter.PayloadFacadeClient
 	storage     *runnertesting.StorageContextAccessor
+	secrets     *runnertesting.SecretsContextAccessor
 
 	apiRelunits map[int]*uniter.RelationUnit
 	relch       *state.Charm
@@ -80,6 +81,7 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 			},
 		},
 	}
+	s.secrets = &runnertesting.SecretsContextAccessor{}
 
 	password, err := utils.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
@@ -116,6 +118,7 @@ func (s *ContextSuite) SetUpTest(c *gc.C) {
 		Tracker:          &runnertesting.FakeTracker{},
 		GetRelationInfos: s.getRelationInfos,
 		Storage:          s.storage,
+		Secrets:          s.secrets,
 		Paths:            s.paths,
 		Clock:            testclock.NewClock(time.Time{}),
 		Logger:           loggo.GetLogger("test"),


### PR DESCRIPTION
Add a new `secret-ids` hook command to allow a charm to fetch ids of secrets it has created.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
juju deploy juju-qa-dummy-source
juju deploy juju-qa-dummy-sink
juju exec --unit dummy-source/0 "secret-add data=foo"
secret:cbu845lr22hiulmck5b0
juju exec --unit dummy-source/0 "secret-add data=foo2 --label=bar"
secret:cbu899tr22hij99hg2m0
juju exec --unit dummy-sink/0 "secret-add data=foo --label=baz"
secret:cbu89p5r22hihr6gc8gg

juju exec --unit dummy-source/0 "secret-ids"
secret:cbu845lr22hiulmck5b0: ""
secret:cbu899tr22hij99hg2m0: bar

juju exec --unit dummy-sink/0 "secret-ids"
secret:cbu89p5r22hihr6gc8gg: baz

```
