### PR TITLE
[JUJU-1661] Better detection of LXD support

### DIFF
--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -11,9 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/lxc/lxd/shared"
+
 	"github.com/juju/errors"
 	lxd "github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/shared"
 )
 
 type Protocol string
@@ -141,8 +142,8 @@ func connectImageRemote(remote ServerSpec) (lxd.ImageServer, error) {
 	return nil, fmt.Errorf("bad protocol supplied for connection: %v", remote.Protocol)
 }
 
-func connectLocal() (lxd.InstanceServer, error) {
-	client, err := lxd.ConnectLXDUnix(SocketPath(nil), nil)
+func connectLocal() (lxd.ContainerServer, error) {
+	client, err := lxd.ConnectLXDUnix(SocketPath(shared.IsUnixSocket), nil)
 	return client, errors.Trace(err)
 }
 
@@ -174,9 +175,6 @@ func SocketPath(isSocket func(path string) bool) string {
 		logger.Debugf("using environment LXD_DIR as socket path: %q", path)
 	} else {
 		path = filepath.FromSlash("/var/snap/lxd/common/lxd")
-		if isSocket == nil {
-			isSocket = shared.IsUnixSocket
-		}
 		if isSocket(filepath.Join(path, "unix.socket")) {
 			logger.Debugf("using LXD snap socket: %q", path)
 		} else {

--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -11,10 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/lxc/lxd/shared"
-
 	"github.com/juju/errors"
 	lxd "github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/shared"
 )
 
 type Protocol string
@@ -142,7 +141,7 @@ func connectImageRemote(remote ServerSpec) (lxd.ImageServer, error) {
 	return nil, fmt.Errorf("bad protocol supplied for connection: %v", remote.Protocol)
 }
 
-func connectLocal() (lxd.ContainerServer, error) {
+func connectLocal() (lxd.InstanceServer, error) {
 	client, err := lxd.ConnectLXDUnix(SocketPath(shared.IsUnixSocket), nil)
 	return client, errors.Trace(err)
 }

--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -164,25 +164,26 @@ func ConnectRemote(spec ServerSpec) (lxd.InstanceServer, error) {
 //   - LXD_DIR environment variable.
 //   - Snap socket.
 //   - Debian socket.
-// We give preference to LXD installed via Snap.
-// isSocket defaults to socket detection from the LXD shared package.
-// TODO (manadart 2018-04-30) This looks like it can be achieved by using a
-// combination of VarPath and HostPath from lxd.shared, in which case this
-// can be deprecated in their favour.
+// An empty string is returned if no socket path can be determined.
 func SocketPath(isSocket func(path string) bool) string {
-	path := os.Getenv("LXD_DIR")
-	if path != "" {
-		logger.Debugf("using environment LXD_DIR as socket path: %q", path)
-	} else {
-		path = filepath.FromSlash("/var/snap/lxd/common/lxd")
-		if isSocket(filepath.Join(path, "unix.socket")) {
-			logger.Debugf("using LXD snap socket: %q", path)
-		} else {
-			path = filepath.FromSlash("/var/lib/lxd")
-			logger.Debugf("LXD snap socket not found, falling back to debian socket: %q", path)
+	for _, maybePath := range []string{
+		os.Getenv("LXD_DIR"),
+		filepath.FromSlash("/var/snap/lxd/common/lxd"),
+		filepath.FromSlash("/var/lib/lxd"),
+	} {
+		if maybePath == "" {
+			continue
+		}
+
+		maybePath = filepath.Join(maybePath, "unix.socket")
+		if isSocket(maybePath) {
+			logger.Debugf("using LXD socket at path: %q", maybePath)
+			return maybePath
 		}
 	}
-	return filepath.Join(path, "unix.socket")
+
+	logger.Debugf("unable to detect LXD socket path")
+	return ""
 }
 
 // EnsureHTTPS takes a URI and ensures that it is a HTTPS URL.

--- a/container/lxd/connection_test.go
+++ b/container/lxd/connection_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/lxc/lxd/shared"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/container/lxd"
@@ -22,7 +23,7 @@ var _ = gc.Suite(&connectionSuite{})
 
 func (s *connectionSuite) TestLxdSocketPathLxdDirSet(c *gc.C) {
 	c.Assert(os.Setenv("LXD_DIR", "foobar"), jc.ErrorIsNil)
-	path := lxd.SocketPath(nil)
+	path := lxd.SocketPath(shared.IsUnixSocket)
 	c.Check(path, gc.Equals, filepath.Join("foobar", "unix.socket"))
 }
 

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jujuarch "github.com/juju/utils/v3/arch"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -172,9 +173,9 @@ func (m *containerManager) ensureInitialized() error {
 }
 
 // IsInitialized implements container.Manager.
-// It returns true if this host is running an OS that supports LXD by default.
+// It returns true if we can find a LXD socket on this host.
 func (m *containerManager) IsInitialized() bool {
-	return HasSupport()
+	return SocketPath(shared.IsUnixSocket) != ""
 }
 
 // getContainerSpec generates a spec for creating a new container.

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	lxdclient "github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/shared"
 	lxdapi "github.com/lxc/lxd/shared/api"
 	gc "gopkg.in/check.v1"
 
@@ -340,7 +341,7 @@ func (s *managerSuite) TestIsInitialized(c *gc.C) {
 	mgr, err := lxd.NewContainerManager(getBaseConfig(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(mgr.IsInitialized(), gc.Equals, lxd.HasSupport())
+	c.Check(mgr.IsInitialized(), gc.Equals, lxd.SocketPath(shared.IsUnixSocket) != "")
 }
 
 func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C) {

--- a/container/lxd/package_test.go
+++ b/container/lxd/package_test.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}
+
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/clock_mock.go github.com/juju/clock Clock

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -13,25 +13,7 @@ import (
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
-
-	"github.com/juju/juju/core/os"
 )
-
-// osSupport is the list of operating system types for which Juju supports
-// communicating with LXD via a local socket, by default.
-var osSupport = []os.OSType{os.Ubuntu}
-
-// HasSupport returns true if the current OS supports LXD containers by
-// default
-func HasSupport() bool {
-	t := os.HostOS()
-	for _, v := range osSupport {
-		if v == t {
-			return true
-		}
-	}
-	return false
-}
 
 // Server extends the upstream LXD container server.
 type Server struct {

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -33,8 +33,6 @@ func HasSupport() bool {
 	return false
 }
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/clock_mock.go github.com/juju/clock Clock
-
 // Server extends the upstream LXD container server.
 type Server struct {
 	lxd.InstanceServer


### PR DESCRIPTION
To date, support for LXD containers on a machine has been determined by whether or not the OS is Ubuntu. This determination is incorrect for custom images without LXD.

Here we remove the `HasSupport` method, which returned true if we were running on Ubuntu. The only place it is used, `containerManager.IsInitialised`, now uses the `SocketPath` method, returning false if no LXD socket can be found.

To this end `SocketPath` now returns an empty string when no socket is found, rather than always defaulting to the socket for deb-installed LXD.

A side-effect of this will be to make LXD usable on operating systems like CentOS if it happens to be installed.

## QA steps

Deploy something to LXD-in-machine.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1986877
