### PR TITLE
Fix assertions for watcher tests and fix collection watcher

### DIFF
--- a/state/backups/create.go
+++ b/state/backups/create.go
@@ -123,6 +123,7 @@ func newBuilder(destinationDir string, filesToBackUp []string, db DBDumper) (b *
 		return nil, errors.Annotate(err, "while making backups staging directory")
 	}
 
+	// TODO(hpidcock): lp:1558657
 	finalFilename := time.Now().Format(FilenameTemplate)
 	// Populate the builder.
 	b = &builder{

--- a/state/externalcontroller_test.go
+++ b/state/externalcontroller_test.go
@@ -191,7 +191,7 @@ func (s *externalControllerSuite) TestWatch(c *gc.C) {
 
 	// Initial event.
 	wc := statetesting.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent(testing.ControllerTag.Id())
+	wc.AssertChange(testing.ControllerTag.Id())
 	wc.AssertNoChange()
 
 	// Update the controller, expect no change. We only get
@@ -204,7 +204,7 @@ func (s *externalControllerSuite) TestWatch(c *gc.C) {
 	// Remove the controller, we should get a change.
 	err = s.externalControllers.Remove(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent(testing.ControllerTag.Id())
+	wc.AssertChange(testing.ControllerTag.Id())
 	wc.AssertNoChange()
 
 	// Removing a non-existent controller shouldn't trigger
@@ -216,7 +216,7 @@ func (s *externalControllerSuite) TestWatch(c *gc.C) {
 	// Add the controller again, and we should see a change.
 	_, err = s.externalControllers.Save(controllerInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent(testing.ControllerTag.Id())
+	wc.AssertChange(testing.ControllerTag.Id())
 	wc.AssertNoChange()
 }
 

--- a/state/filesystem_test.go
+++ b/state/filesystem_test.go
@@ -423,11 +423,11 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystems(c *gc.C) {
 	w := s.storageBackend.WatchModelFilesystems()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("0", "1") // initial
+	wc.AssertChange("0", "1") // initial
 	wc.AssertNoChange()
 
 	addUnit()
-	wc.AssertChangeInSingleEvent("4", "5")
+	wc.AssertChange("4", "5")
 	wc.AssertNoChange()
 
 	err := u.Destroy()
@@ -437,7 +437,7 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystems(c *gc.C) {
 
 	err = s.storageBackend.DestroyFilesystem(filesystemTag, false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0")
+	wc.AssertChange("0")
 	wc.AssertNoChange()
 
 	machineTag := names.NewMachineTag("0")
@@ -447,7 +447,7 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystems(c *gc.C) {
 
 	err = s.storageBackend.RemoveFilesystemAttachment(machineTag, filesystemTag, false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0") // last attachment removed
+	wc.AssertChange("0") // last attachment removed
 	wc.AssertNoChange()
 }
 
@@ -467,11 +467,11 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystemAttachments(c *gc.C) 
 	w := s.storageBackend.WatchModelFilesystemAttachments()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("0:0", "0:1") // initial
+	wc.AssertChange("0:0", "0:1") // initial
 	wc.AssertNoChange()
 
 	addUnit()
-	wc.AssertChangeInSingleEvent("1:4", "1:5")
+	wc.AssertChange("1:4", "1:5")
 	wc.AssertNoChange()
 
 	err := u.Destroy()
@@ -486,12 +486,12 @@ func (s *FilesystemIAASModelSuite) TestWatchModelFilesystemAttachments(c *gc.C) 
 	machineTag := names.NewMachineTag("0")
 	err = s.storageBackend.DetachFilesystem(machineTag, filesystemTag)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0:0")
+	wc.AssertChange("0:0")
 	wc.AssertNoChange()
 
 	err = s.storageBackend.RemoveFilesystemAttachment(machineTag, filesystemTag, false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0:0")
+	wc.AssertChange("0:0")
 	wc.AssertNoChange()
 }
 
@@ -511,7 +511,7 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystems(c *gc.C) {
 	w := s.storageBackend.WatchMachineFilesystems(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("0/2", "0/3") // initial
+	wc.AssertChange("0/2", "0/3") // initial
 	wc.AssertNoChange()
 
 	addUnit()
@@ -525,7 +525,7 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystems(c *gc.C) {
 
 	err = s.storageBackend.DestroyFilesystem(filesystemTag, false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0/2")
+	wc.AssertChange("0/2")
 	wc.AssertNoChange()
 
 	attachments, err := s.storageBackend.FilesystemAttachments(filesystemTag)
@@ -536,7 +536,7 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystems(c *gc.C) {
 		err = s.storageBackend.RemoveFilesystemAttachment(a.Host(), filesystemTag, false)
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	wc.AssertChangeInSingleEvent("0/2") // Dying -> Dead
+	wc.AssertChange("0/2") // Dying -> Dead
 	wc.AssertNoChange()
 
 	err = s.storageBackend.RemoveFilesystem(filesystemTag)
@@ -568,7 +568,7 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystemAttachments(c *gc.C
 	w := s.storageBackend.WatchMachineFilesystemAttachments(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("0:0/0", "0:0/1") // initial
+	wc.AssertChange("0:0/0", "0:0/1") // initial
 	wc.AssertNoChange()
 
 	addUnit(nil)
@@ -584,16 +584,16 @@ func (s *FilesystemIAASModelSuite) TestWatchMachineFilesystemAttachments(c *gc.C
 	removeFilesystemStorageInstance(c, s.storageBackend, names.NewFilesystemTag("0/0"))
 	err = s.storageBackend.DestroyFilesystem(names.NewFilesystemTag("0/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0:0/0") // dying
+	wc.AssertChange("0:0/0") // dying
 	wc.AssertNoChange()
 
 	err = s.storageBackend.RemoveFilesystemAttachment(names.NewMachineTag("0"), names.NewFilesystemTag("0/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0:0/0") // removed
+	wc.AssertChange("0:0/0") // removed
 	wc.AssertNoChange()
 
 	addUnit(m0)
-	wc.AssertChangeInSingleEvent("0:0/8", "0:0/9")
+	wc.AssertChange("0:0/8", "0:0/9")
 	wc.AssertNoChange()
 }
 
@@ -619,7 +619,7 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystems(c *gc.C) {
 	w := s.storageBackend.WatchUnitFilesystems(app.ApplicationTag())
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("mariadb/0/0") // initial
+	wc.AssertChange("mariadb/0/0") // initial
 	wc.AssertNoChange()
 
 	app2, err := s.st.AddApplication(state.AddApplicationArgs{Name: "another", Charm: ch, Storage: storage})
@@ -635,7 +635,7 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystems(c *gc.C) {
 
 	err = s.storageBackend.DestroyFilesystem(filesystemTag, false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("mariadb/0/0")
+	wc.AssertChange("mariadb/0/0")
 	wc.AssertNoChange()
 
 	attachments, err := s.storageBackend.FilesystemAttachments(filesystemTag)
@@ -646,7 +646,7 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystems(c *gc.C) {
 		err = s.storageBackend.RemoveFilesystemAttachment(a.Host(), filesystemTag, false)
 		c.Assert(err, jc.ErrorIsNil)
 	}
-	wc.AssertChangeInSingleEvent("mariadb/0/0") // Dying -> Dead
+	wc.AssertChange("mariadb/0/0") // Dying -> Dead
 	wc.AssertNoChange()
 
 	err = s.storageBackend.RemoveFilesystem(filesystemTag)
@@ -678,7 +678,7 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystemAttachments(c *gc.C) {
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
 
-	wc.AssertChangeInSingleEvent("mariadb/0:mariadb/0/0") // initial
+	wc.AssertChange("mariadb/0:mariadb/0/0") // initial
 	wc.AssertNoChange()
 
 	app2, err := s.st.AddApplication(state.AddApplicationArgs{Name: "another", Charm: ch, Storage: storage})
@@ -696,12 +696,12 @@ func (s *FilesystemCAASModelSuite) TestWatchUnitFilesystemAttachments(c *gc.C) {
 	removeFilesystemStorageInstance(c, s.storageBackend, names.NewFilesystemTag("mariadb/0/0"))
 	err = s.storageBackend.DestroyFilesystem(names.NewFilesystemTag("mariadb/0/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("mariadb/0:mariadb/0/0") // dying
+	wc.AssertChange("mariadb/0:mariadb/0/0") // dying
 	wc.AssertNoChange()
 
 	err = s.storageBackend.RemoveFilesystemAttachment(names.NewUnitTag("mariadb/0"), names.NewFilesystemTag("mariadb/0/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("mariadb/0:mariadb/0/0") // removed
+	wc.AssertChange("mariadb/0:mariadb/0/0") // removed
 	wc.AssertNoChange()
 }
 

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -1165,20 +1165,20 @@ func (s *remoteApplicationSuite) TestWatchRemoteApplications(c *gc.C) {
 	w := s.State.WatchRemoteApplications()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("mysql") // initial
+	wc.AssertChange("mysql") // initial
 	wc.AssertNoChange()
 
 	db2, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
 		Name: "db2", SourceModel: s.Model.ModelTag()})
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("db2")
+	wc.AssertChange("db2")
 	wc.AssertNoChange()
 
 	err = db2.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 	err = db2.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	wc.AssertChangeInSingleEvent("db2")
+	wc.AssertChange("db2")
 	wc.AssertNoChange()
 }
 
@@ -1186,7 +1186,7 @@ func (s *remoteApplicationSuite) TestWatchRemoteApplicationsDying(c *gc.C) {
 	w := s.State.WatchRemoteApplications()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("mysql") // initial
+	wc.AssertChange("mysql") // initial
 	wc.AssertNoChange()
 
 	ch := s.AddTestingCharm(c, "wordpress")
@@ -1212,7 +1212,7 @@ func (s *remoteApplicationSuite) TestWatchRemoteApplicationsDying(c *gc.C) {
 	err = s.application.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 
-	wc.AssertChangeInSingleEvent("mysql")
+	wc.AssertChange("mysql")
 	wc.AssertNoChange()
 }
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -2515,7 +2515,7 @@ func (s *StateSuite) TestWatchModelsBulkEvents(c *gc.C) {
 	w := s.State.WatchModels()
 	defer statetesting.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent(alive.UUID(), dying.UUID())
+	wc.AssertChange(alive.UUID(), dying.UUID())
 
 	// Progress dying to dead, alive to dying; and see changes reported.
 	err = app.Destroy()
@@ -2526,7 +2526,7 @@ func (s *StateSuite) TestWatchModelsBulkEvents(c *gc.C) {
 	c.Assert(alive.Refresh(), jc.ErrorIsNil)
 	c.Assert(alive.Life(), gc.Equals, state.Dying)
 	c.Assert(dying.Refresh(), jc.Satisfies, errors.IsNotFound)
-	wc.AssertChangeInSingleEvent(alive.UUID())
+	wc.AssertChange(alive.UUID())
 }
 
 func (s *StateSuite) TestWatchModelsLifecycle(c *gc.C) {

--- a/state/status.go
+++ b/state/status.go
@@ -534,7 +534,6 @@ func fetchNStatusResults(col mongo.Collection, clock clock.Clock,
 	baseQuery := bson.M{"globalkey": key}
 	if filter.Delta != nil {
 		delta := *filter.Delta
-		// TODO(perrito666) 2016-10-06 lp:1558657
 		updated := clock.Now().Add(-delta)
 		baseQuery["updated"] = bson.M{"$gt": updated.UnixNano()}
 	}

--- a/state/volume_test.go
+++ b/state/volume_test.go
@@ -293,11 +293,11 @@ func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 	w := s.storageBackend.WatchModelVolumes()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("0", "1") // initial
+	wc.AssertChange("0", "1") // initial
 	wc.AssertNoChange()
 
 	addUnit()
-	wc.AssertChangeInSingleEvent("4", "5")
+	wc.AssertChange("4", "5")
 	wc.AssertNoChange()
 
 	volume, err := s.storageBackend.Volume(names.NewVolumeTag("0"))
@@ -307,7 +307,7 @@ func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 	removeStorageInstance(c, s.storageBackend, storageTag)
 	err = s.storageBackend.DestroyVolume(names.NewVolumeTag("0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0") // dying
+	wc.AssertChange("0") // dying
 	wc.AssertNoChange()
 
 	err = s.storageBackend.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"), false)
@@ -317,7 +317,7 @@ func (s *VolumeStateSuite) TestWatchModelVolumes(c *gc.C) {
 
 	err = s.storageBackend.RemoveVolume(names.NewVolumeTag("0"))
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0") // removed
+	wc.AssertChange("0") // removed
 	wc.AssertNoChange()
 }
 
@@ -334,21 +334,21 @@ func (s *VolumeStateSuite) TestWatchModelVolumeAttachments(c *gc.C) {
 	w := s.storageBackend.WatchModelVolumeAttachments()
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("0:0", "0:1") // initial
+	wc.AssertChange("0:0", "0:1") // initial
 	wc.AssertNoChange()
 
 	addUnit()
-	wc.AssertChangeInSingleEvent("1:4", "1:5")
+	wc.AssertChange("1:4", "1:5")
 	wc.AssertNoChange()
 
 	err := s.storageBackend.DetachVolume(names.NewMachineTag("0"), names.NewVolumeTag("0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0:0") // dying
+	wc.AssertChange("0:0") // dying
 	wc.AssertNoChange()
 
 	err = s.storageBackend.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0:0") // removed
+	wc.AssertChange("0:0") // removed
 	wc.AssertNoChange()
 }
 
@@ -365,7 +365,7 @@ func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 	w := s.storageBackend.WatchMachineVolumes(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("0/0", "0/1") // initial
+	wc.AssertChange("0/0", "0/1") // initial
 	wc.AssertNoChange()
 
 	addUnit()
@@ -379,7 +379,7 @@ func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 	removeStorageInstance(c, s.storageBackend, storageTag)
 	err = s.storageBackend.DestroyVolume(volume.VolumeTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0/0") // dying
+	wc.AssertChange("0/0") // dying
 	wc.AssertNoChange()
 
 	err = s.storageBackend.DestroyVolume(names.NewVolumeTag("0/0"), false)
@@ -388,7 +388,7 @@ func (s *VolumeStateSuite) TestWatchMachineVolumes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.storageBackend.RemoveVolume(names.NewVolumeTag("0/0"))
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0/0") // removed
+	wc.AssertChange("0/0") // removed
 	wc.AssertNoChange()
 }
 
@@ -413,7 +413,7 @@ func (s *VolumeStateSuite) TestWatchMachineVolumeAttachments(c *gc.C) {
 	w := s.storageBackend.WatchMachineVolumeAttachments(names.NewMachineTag("0"))
 	defer testing.AssertStop(c, w)
 	wc := testing.NewStringsWatcherC(c, w)
-	wc.AssertChangeInSingleEvent("0:0/0", "0:0/1") // initial
+	wc.AssertChange("0:0/0", "0:0/1") // initial
 	wc.AssertNoChange()
 
 	addUnit(nil)
@@ -429,16 +429,16 @@ func (s *VolumeStateSuite) TestWatchMachineVolumeAttachments(c *gc.C) {
 	removeVolumeStorageInstance(c, s.storageBackend, names.NewVolumeTag("0/0"))
 	err = s.storageBackend.DestroyVolume(names.NewVolumeTag("0/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0:0/0") // dying
+	wc.AssertChange("0:0/0") // dying
 	wc.AssertNoChange()
 
 	err = s.storageBackend.RemoveVolumeAttachment(names.NewMachineTag("0"), names.NewVolumeTag("0/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
-	wc.AssertChangeInSingleEvent("0:0/0") // removed
+	wc.AssertChange("0:0/0") // removed
 	wc.AssertNoChange()
 
 	addUnit(m0)
-	wc.AssertChangeInSingleEvent("0:0/8", "0:0/9") // added
+	wc.AssertChange("0:0/8", "0:0/9") // added
 }
 
 func (s *VolumeStateSuite) TestParseVolumeAttachmentId(c *gc.C) {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2942,6 +2942,8 @@ func (w *collectionWatcher) loop() error {
 			}
 			if len(changes) > 0 {
 				out = w.sink
+			} else {
+				out = nil
 			}
 		case out <- changes:
 			changes = []string{}


### PR DESCRIPTION
Fixes strings watcher tests being flakey when checking for single event with multiple docs changed.
Fixes collection watcher sending empty change.

## QA steps

Unit tests

## Documentation changes

N/A

## Bug reference

N/A