### PR TITLE
[JUJU-1619] Rewriting api client storage unit tests to use gomock

### DIFF
--- a/api/client/storage/client_test.go
+++ b/api/client/storage/client_test.go
@@ -6,72 +6,68 @@ package storage_test
 import (
 	"fmt"
 
+	"github.com/golang/mock/gomock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	basetesting "github.com/juju/juju/api/base/testing"
+	basemocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/storage"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
 	jujustorage "github.com/juju/juju/storage"
-	"github.com/juju/juju/testing"
 )
 
 type storageMockSuite struct {
-	testing.BaseSuite
 }
 
 var _ = gc.Suite(&storageMockSuite{})
 
 func (s *storageMockSuite) TestStorageDetails(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	one := "shared-fs/0"
 	oneTag := names.NewStorageTag(one)
 	two := "db-dir/1000"
 	twoTag := names.NewStorageTag(two)
 	expected := set.NewStrings(oneTag.String(), twoTag.String())
 	msg := "call failure"
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: oneTag.String()},
+			{Tag: twoTag.String()},
+		},
+	}
+	instances := []params.StorageDetailsResult{
+		{
+			Result: &params.StorageDetails{StorageTag: oneTag.String()},
+		},
+		{
+			Result: &params.StorageDetails{
+				StorageTag: twoTag.String(),
+				Status: params.EntityStatus{
+					Status: "attached",
+				},
+				Persistent: true,
+			},
+		},
+		{
+			Error: apiservererrors.ServerError(errors.New(msg)),
+		},
+	}
+	results := params.StorageDetailsResults{
+		Results: instances,
+	}
+	result := new(params.StorageDetailsResults)
 
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "StorageDetails")
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("StorageDetails", args, result).SetArg(2, results).Return(nil)
 
-			args, ok := a.(params.Entities)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Entities, gc.HasLen, 2)
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 
-			if results, k := result.(*params.StorageDetailsResults); k {
-				instances := []params.StorageDetailsResult{
-					{
-						Result: &params.StorageDetails{StorageTag: oneTag.String()},
-					},
-					{
-						Result: &params.StorageDetails{
-							StorageTag: twoTag.String(),
-							Status: params.EntityStatus{
-								Status: "attached",
-							},
-							Persistent: true,
-						},
-					},
-					{
-						Error: apiservererrors.ServerError(errors.New(msg)),
-					},
-				}
-				results.Results = instances
-			}
-
-			return nil
-		})
-	storageClient := storage.NewClient(apiCaller)
 	tags := []names.StorageTag{oneTag, twoTag}
 	found, err := storageClient.StorageDetails(tags)
 	c.Assert(err, jc.ErrorIsNil)
@@ -82,60 +78,44 @@ func (s *storageMockSuite) TestStorageDetails(c *gc.C) {
 }
 
 func (s *storageMockSuite) TestStorageDetailsFacadeCallError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	msg := "facade failure"
 	one := "shared-fs/0"
 	oneTag := names.NewStorageTag(one)
 
-	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "StorageDetails")
+	result := new(params.StorageDetailsResults)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("StorageDetails", gomock.AssignableToTypeOf(params.Entities{}), result).SetArg(2, params.StorageDetailsResults{}).Return(errors.New(msg))
 
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(apiCaller)
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	found, err := storageClient.StorageDetails([]names.StorageTag{oneTag})
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 	c.Assert(found, gc.HasLen, 0)
 }
 
 func (s *storageMockSuite) TestListStorageDetails(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	storageTag := names.NewStorageTag("db-dir/1000")
+	result := new(params.StorageDetailsListResults)
+	results := params.StorageDetailsListResults{
+		Results: []params.StorageDetailsListResult{{
+			Result: []params.StorageDetails{{
+				StorageTag: storageTag.String(),
+				Status: params.EntityStatus{
+					Status: "attached",
+				},
+				Persistent: true,
+			}},
+		}},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListStorageDetails", gomock.AssignableToTypeOf(params.StorageFilters{}), result).SetArg(2, results).Return(nil)
 
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListStorageDetails")
-			c.Check(a, jc.DeepEquals, params.StorageFilters{
-				[]params.StorageFilter{{}},
-			})
-
-			c.Assert(result, gc.FitsTypeOf, &params.StorageDetailsListResults{})
-			results := result.(*params.StorageDetailsListResults)
-			results.Results = []params.StorageDetailsListResult{{
-				Result: []params.StorageDetails{{
-					StorageTag: storageTag.String(),
-					Status: params.EntityStatus{
-						Status: "attached",
-					},
-					Persistent: true,
-				}},
-			}}
-
-			return nil
-		},
-	)
-	storageClient := storage.NewClient(apiCaller)
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	found, err := storageClient.ListStorageDetails()
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 1)
@@ -151,26 +131,27 @@ func (s *storageMockSuite) TestListStorageDetails(c *gc.C) {
 }
 
 func (s *storageMockSuite) TestListStorageDetailsFacadeCallError(c *gc.C) {
-	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListStorageDetails")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(apiCaller)
+	msg := "facade failure"
+
+	result := new(params.StorageDetailsListResults)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListStorageDetails", gomock.AssignableToTypeOf(params.StorageFilters{}), result).SetArg(2, params.StorageDetailsListResults{}).Return(errors.New(msg))
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	found, err := storageClient.ListStorageDetails()
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 	c.Assert(found, gc.HasLen, 0)
 }
 
 func (s *storageMockSuite) TestListPools(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	someNames := []string{"a", "b"}
+	types := []string{"1"}
 	expected := []params.StoragePool{
 		{Name: "name0", Provider: "type0"},
 		{Name: "name1", Provider: "type1"},
@@ -178,38 +159,30 @@ func (s *storageMockSuite) TestListPools(c *gc.C) {
 	}
 	want := len(expected)
 
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListPools")
+	args := params.StoragePoolFilters{
+		Filters: []params.StoragePoolFilter{{
+			Names:     someNames,
+			Providers: types,
+		}},
+	}
+	result := new(params.StoragePoolsResults)
+	pools := make([]params.StoragePool, want)
+	for i := 0; i < want; i++ {
+		pools[i] = params.StoragePool{
+			Name:     fmt.Sprintf("name%v", i),
+			Provider: fmt.Sprintf("type%v", i),
+		}
+	}
+	results := params.StoragePoolsResults{
+		Results: []params.StoragePoolsResult{{
+			Result: pools,
+		}},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListPools", args, result).SetArg(2, results).Return(nil)
 
-			args := a.(params.StoragePoolFilters)
-			c.Assert(args.Filters, gc.HasLen, 1)
-			c.Assert(args.Filters[0].Names, gc.HasLen, 2)
-			c.Assert(args.Filters[0].Providers, gc.HasLen, 1)
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 
-			results := result.(*params.StoragePoolsResults)
-			pools := make([]params.StoragePool, want)
-			for i := 0; i < want; i++ {
-				pools[i] = params.StoragePool{
-					Name:     fmt.Sprintf("name%v", i),
-					Provider: fmt.Sprintf("type%v", i),
-				}
-			}
-			results.Results = []params.StoragePoolsResult{{
-				Result: pools,
-			}}
-
-			return nil
-		})
-	storageClient := storage.NewClient(apiCaller)
-	someNames := []string{"a", "b"}
-	types := []string{"1"}
 	found, err := storageClient.ListPools(types, someNames)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, want)
@@ -217,141 +190,96 @@ func (s *storageMockSuite) TestListPools(c *gc.C) {
 }
 
 func (s *storageMockSuite) TestListPoolsFacadeCallError(c *gc.C) {
-	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListPools")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(apiCaller)
+	msg := "facade failure"
+
+	result := new(params.StoragePoolsResults)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListPools", gomock.AssignableToTypeOf(params.StoragePoolFilters{}), result).SetArg(2, params.StoragePoolsResults{}).Return(errors.New(msg))
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	found, err := storageClient.ListPools(nil, nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 	c.Assert(found, gc.HasLen, 0)
 }
 
 func (s *storageMockSuite) TestCreatePool(c *gc.C) {
-	var called bool
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	poolName := "poolName"
 	poolType := "poolType"
 	poolConfig := map[string]interface{}{
 		"test": "one",
 		"pass": true,
 	}
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			called = true
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "CreatePool")
-
-			args, ok := a.(params.StoragePoolArgs)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Pools, gc.HasLen, 1)
-
-			c.Assert(args.Pools[0].Name, gc.Equals, poolName)
-			c.Assert(args.Pools[0].Provider, gc.Equals, poolType)
-			c.Assert(args.Pools[0].Attrs, gc.DeepEquals, poolConfig)
-			results := result.(*params.ErrorResults)
-
-			results.Results = make([]params.ErrorResult, len(args.Pools))
-			return nil
+	args := params.StoragePoolArgs{
+		Pools: []params.StoragePool{{
+			Name:     poolName,
+			Provider: poolType,
+			Attrs:    poolConfig,
 		},
-	)
-	storageClient := storage.NewClient(apiCaller)
+		}}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Pools)),
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("CreatePool", args, result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	err := storageClient.CreatePool(poolName, poolType, poolConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *storageMockSuite) TestCreatePoolFacadeCallError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "CreatePool")
 
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(apiCaller)
-	err := storageClient.CreatePool("", "", nil)
-	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
-}
+	result := new(params.ErrorResults)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("CreatePool", gomock.AssignableToTypeOf(params.StoragePoolArgs{}), result).Return(errors.New(msg))
 
-func (s *storageMockSuite) TestLegacyCreatePoolFacadeCallError(c *gc.C) {
-	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "CreatePool")
-
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(apiCaller)
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	err := storageClient.CreatePool("", "", nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }
 
 func (s *storageMockSuite) TestListVolumes(c *gc.C) {
-	var called bool
-	machines := []string{"0", "1"}
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			called = true
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListVolumes")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			c.Assert(a, gc.FitsTypeOf, params.VolumeFilters{})
-			args := a.(params.VolumeFilters)
-			c.Assert(args.Filters, gc.HasLen, 2)
-			c.Assert(args.Filters[0].Machines, jc.DeepEquals, []string{"machine-0"})
-			c.Assert(args.Filters[1].Machines, jc.DeepEquals, []string{"machine-1"})
+	args := params.VolumeFilters{
+		Filters: []params.VolumeFilter{
+			{Machines: []string{"machine-0"}},
+			{Machines: []string{"machine-1"}},
+		}}
+	result := new(params.VolumeDetailsListResults)
+	details := params.VolumeDetails{
+		VolumeTag: "volume-0",
+		MachineAttachments: map[string]params.VolumeAttachmentDetails{
+			"machine-0": {},
+			"machine-1": {},
+		},
+	}
+	results := params.VolumeDetailsListResults{
+		Results: []params.VolumeDetailsListResult{{
+			Result: []params.VolumeDetails{details},
+		}, {
+			Result: []params.VolumeDetails{details},
+		}},
+	}
 
-			c.Assert(result, gc.FitsTypeOf, &params.VolumeDetailsListResults{})
-			results := result.(*params.VolumeDetailsListResults)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListVolumes", args, result).SetArg(2, results).Return(nil)
 
-			details := params.VolumeDetails{
-				VolumeTag: "volume-0",
-				MachineAttachments: map[string]params.VolumeAttachmentDetails{
-					"machine-0": {},
-					"machine-1": {},
-				},
-			}
-			results.Results = []params.VolumeDetailsListResult{{
-				Result: []params.VolumeDetails{details},
-			}, {
-				Result: []params.VolumeDetails{details},
-			}}
-			return nil
-		})
-	storageClient := storage.NewClient(apiCaller)
-	found, err := storageClient.ListVolumes(machines)
-	c.Assert(called, jc.IsTrue)
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	found, err := storageClient.ListVolumes([]string{"0", "1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 2)
 	for i := 0; i < 2; i++ {
@@ -366,35 +294,25 @@ func (s *storageMockSuite) TestListVolumes(c *gc.C) {
 }
 
 func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
-	var called bool
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	tag := "ok"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			called = true
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListVolumes")
-
-			c.Assert(a, gc.FitsTypeOf, params.VolumeFilters{})
-			args := a.(params.VolumeFilters)
-			c.Assert(args.Filters, gc.HasLen, 1)
-			c.Assert(args.Filters[0].IsEmpty(), jc.IsTrue)
-
-			c.Assert(result, gc.FitsTypeOf, &params.VolumeDetailsListResults{})
-			results := result.(*params.VolumeDetailsListResults)
-			results.Results = []params.VolumeDetailsListResult{
-				{Result: []params.VolumeDetails{{VolumeTag: tag}}},
-			}
-			return nil
+	args := params.VolumeFilters{
+		Filters: []params.VolumeFilter{{}},
+	}
+	result := new(params.VolumeDetailsListResults)
+	results := params.VolumeDetailsListResults{
+		Results: []params.VolumeDetailsListResult{
+			{Result: []params.VolumeDetails{{VolumeTag: tag}}},
 		},
-	)
-	storageClient := storage.NewClient(apiCaller)
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListVolumes", args, result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	found, err := storageClient.ListVolumes(nil)
-	c.Assert(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 1)
 	c.Assert(found[0].Result, gc.HasLen, 1)
@@ -403,24 +321,35 @@ func (s *storageMockSuite) TestListVolumesEmptyFilter(c *gc.C) {
 
 func (s *storageMockSuite) TestListVolumesFacadeCallError(c *gc.C) {
 	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListVolumes")
 
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(apiCaller)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.VolumeFilters{
+		Filters: []params.VolumeFilter{{}},
+	}
+	result := new(params.VolumeDetailsListResults)
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListVolumes", args, result).Return(errors.New(msg))
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	_, err := storageClient.ListVolumes(nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }
 
 func (s *storageMockSuite) TestListFilesystems(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.FilesystemFilters{
+		Filters: []params.FilesystemFilter{{
+			Machines: []string{"machine-1"},
+		}, {
+			Machines: []string{"machine-2"},
+		}},
+	}
+	result := new(params.FilesystemDetailsListResults)
 	expected := params.FilesystemDetails{
 		FilesystemTag: "filesystem-1",
 		Info: params.FilesystemInfo{
@@ -439,34 +368,17 @@ func (s *storageMockSuite) TestListFilesystems(c *gc.C) {
 			},
 		},
 	}
-
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListFilesystems")
-
-			c.Assert(a, gc.FitsTypeOf, params.FilesystemFilters{})
-			args := a.(params.FilesystemFilters)
-			c.Assert(args.Filters, jc.DeepEquals, []params.FilesystemFilter{{
-				Machines: []string{"machine-1"},
-			}, {
-				Machines: []string{"machine-2"},
-			}})
-
-			c.Assert(result, gc.FitsTypeOf, &params.FilesystemDetailsListResults{})
-			results := result.(*params.FilesystemDetailsListResults)
-			results.Results = []params.FilesystemDetailsListResult{{
-				Result: []params.FilesystemDetails{expected},
-			}, {}}
-			return nil
+	results := params.FilesystemDetailsListResults{
+		Results: []params.FilesystemDetailsListResult{
+			{Result: []params.FilesystemDetails{expected}},
+			{},
 		},
-	)
-	storageClient := storage.NewClient(apiCaller)
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListFilesystems", args, result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	found, err := storageClient.ListFilesystems([]string{"1", "2"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(found, gc.HasLen, 2)
@@ -475,56 +387,47 @@ func (s *storageMockSuite) TestListFilesystems(c *gc.C) {
 }
 
 func (s *storageMockSuite) TestListFilesystemsEmptyFilter(c *gc.C) {
-	var called bool
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			called = true
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListFilesystems")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			c.Assert(a, gc.FitsTypeOf, params.FilesystemFilters{})
-			args := a.(params.FilesystemFilters)
-			c.Assert(args.Filters, gc.HasLen, 1)
-			c.Assert(args.Filters[0].IsEmpty(), jc.IsTrue)
+	args := params.FilesystemFilters{
+		Filters: []params.FilesystemFilter{{}},
+	}
+	result := new(params.FilesystemDetailsListResults)
+	results := params.FilesystemDetailsListResults{
+		Results: []params.FilesystemDetailsListResult{{}},
+	}
 
-			c.Assert(result, gc.FitsTypeOf, &params.FilesystemDetailsListResults{})
-			results := result.(*params.FilesystemDetailsListResults)
-			results.Results = []params.FilesystemDetailsListResult{{}}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListFilesystems", args, result).SetArg(2, results).Return(nil)
 
-			return nil
-		},
-	)
-	storageClient := storage.NewClient(apiCaller)
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	_, err := storageClient.ListFilesystems(nil)
-	c.Assert(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *storageMockSuite) TestListFilesystemsFacadeCallError(c *gc.C) {
 	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListFilesystems")
 
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(apiCaller)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.FilesystemFilters{
+		Filters: []params.FilesystemFilter{{}},
+	}
+	result := new(params.FilesystemDetailsListResults)
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListFilesystems", args, result).Return(errors.New(msg))
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	_, err := storageClient.ListFilesystems(nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }
 
 func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 	size := uint64(42)
 	cons := params.StorageConstraints{
 		Pool: "value",
@@ -550,33 +453,22 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 		}
 		return result
 	}
+	args := params.StoragesAddParams{
+		Storages: unitStorages,
+	}
+	result := new(params.AddStorageResults)
+	results := params.AddStorageResults{
+		Results: []params.AddStorageResult{
+			one(unitStorages[0].UnitTag, unitStorages[0].StorageName, unitStorages[0].Constraints),
+			one(unitStorages[1].UnitTag, unitStorages[1].StorageName, unitStorages[1].Constraints),
+			one(unitStorages[2].UnitTag, unitStorages[2].StorageName, unitStorages[2].Constraints),
+		},
+	}
 
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "AddToUnit")
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("AddToUnit", args, result).SetArg(2, results).Return(nil)
 
-			args, ok := a.(params.StoragesAddParams)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Storages, gc.HasLen, storageN)
-			c.Assert(args.Storages, gc.DeepEquals, unitStorages)
-
-			if results, k := result.(*params.AddStorageResults); k {
-				out := []params.AddStorageResult{}
-				for _, s := range args.Storages {
-					out = append(out, one(s.UnitTag, s.StorageName, s.Constraints))
-				}
-				results.Results = out
-			}
-
-			return nil
-		})
-	storageClient := storage.NewClient(apiCaller)
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	r, err := storageClient.AddToUnit(unitStorages)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r, gc.HasLen, storageN)
@@ -589,364 +481,315 @@ func (s *storageMockSuite) TestAddToUnit(c *gc.C) {
 }
 
 func (s *storageMockSuite) TestAddToUnitFacadeCallError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	unitStorages := []params.StorageAddParams{
 		{UnitTag: "u-a", StorageName: "one"},
 	}
-
 	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "AddToUnit")
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(apiCaller)
+	args := params.StoragesAddParams{
+		Storages: unitStorages,
+	}
+	result := new(params.AddStorageResults)
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("AddToUnit", args, result).Return(errors.New(msg))
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	found, err := storageClient.AddToUnit(unitStorages)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 	c.Assert(found, gc.HasLen, 0)
 }
 
 func (s *storageMockSuite) TestRemove(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	false_ := false
-	expectedArgs := params.RemoveStorage{[]params.RemoveStorageInstance{
+	args := params.RemoveStorage{[]params.RemoveStorageInstance{
 		{Tag: "storage-foo-0", DestroyAttachments: false, DestroyStorage: false, Force: &false_},
 		{Tag: "storage-bar-1", DestroyAttachments: false, DestroyStorage: false, Force: &false_},
 	}}
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "Remove")
-			c.Check(a, jc.DeepEquals, expectedArgs)
-			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-			results := result.(*params.ErrorResults)
-			results.Results = []params.ErrorResult{
-				{},
-				{Error: &params.Error{Message: "baz"}},
-			}
-			return nil
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{
+			{},
+			{Error: &params.Error{Message: "baz"}},
 		},
-	)
-	client := storage.NewClient(apiCaller)
-	results, err := client.Remove([]string{"foo/0", "bar/1"}, false, false, &false_, nil)
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Remove", args, result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	obtained, err := storageClient.Remove([]string{"foo/0", "bar/1"}, false, false, &false_, nil)
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(results, gc.HasLen, 2)
-	c.Assert(results[0].Error, gc.IsNil)
-	c.Assert(results[1].Error, jc.DeepEquals, &params.Error{Message: "baz"})
+	c.Assert(obtained, gc.HasLen, 2)
+	c.Assert(obtained[0].Error, gc.IsNil)
+	c.Assert(obtained[1].Error, jc.DeepEquals, &params.Error{Message: "baz"})
 }
 
 func (s *storageMockSuite) TestRemoveDestroyAttachments(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	true_ := true
-	expectedArgs := params.RemoveStorage{[]params.RemoveStorageInstance{{
-		Tag:                "storage-foo-0",
-		DestroyAttachments: true,
-		DestroyStorage:     true,
-		Force:              &true_,
-	}}}
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(a, jc.DeepEquals, expectedArgs)
-			results := result.(*params.ErrorResults)
-			results.Results = []params.ErrorResult{{}}
-			return nil
-		},
-	)
-	client := storage.NewClient(apiCaller)
-	results, err := client.Remove([]string{"foo/0"}, true, true, &true_, nil)
+	args := params.RemoveStorage{[]params.RemoveStorageInstance{
+		{Tag: "storage-foo-0", DestroyAttachments: true, DestroyStorage: true, Force: &true_},
+	}}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Remove", args, result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	obtained, err := storageClient.Remove([]string{"foo/0"}, true, true, &true_, nil)
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(results, gc.HasLen, 1)
-	c.Assert(results[0].Error, gc.IsNil)
+	c.Assert(obtained, gc.HasLen, 1)
+	c.Assert(obtained[0].Error, gc.IsNil)
 }
 
 func (s *storageMockSuite) TestRemoveInvalidStorageId(c *gc.C) {
-	client := storage.NewClient(basetesting.APICallerFunc(
-		func(_ string, _ int, _, _ string, _, _ interface{}) error {
-			return nil
-		},
-	))
-	_, err := client.Remove([]string{"foo/bar"}, false, false, nil, nil)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	_, err := storageClient.Remove([]string{"foo/bar"}, false, false, nil, nil)
 	c.Check(err, gc.ErrorMatches, `storage ID "foo/bar" not valid`)
 }
 
 func (s *storageMockSuite) TestDetach(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 	expectedArgs := params.StorageDetachmentParams{
 		StorageIds: params.StorageAttachmentIds{[]params.StorageAttachmentId{
 			{StorageTag: "storage-foo-0"},
 			{StorageTag: "storage-bar-1"},
-		}}}
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "DetachStorage")
-			c.Check(a, jc.DeepEquals, expectedArgs)
-			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-			results := result.(*params.ErrorResults)
-			results.Results = []params.ErrorResult{
-				{},
-				{Error: &params.Error{Message: "baz"}},
-			}
-			return nil
+		}},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{
+			{},
+			{Error: &params.Error{Message: "baz"}},
 		},
-	)
-	client := storage.NewClient(apiCaller)
-	results, err := client.Detach([]string{"foo/0", "bar/1"}, nil, nil)
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DetachStorage", expectedArgs, result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	obtained, err := storageClient.Detach([]string{"foo/0", "bar/1"}, nil, nil)
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(results, gc.HasLen, 2)
-	c.Assert(results[0].Error, gc.IsNil)
-	c.Assert(results[1].Error, jc.DeepEquals, &params.Error{Message: "baz"})
+	c.Assert(obtained, gc.HasLen, 2)
+	c.Assert(obtained[0].Error, gc.IsNil)
+	c.Assert(obtained[1].Error, jc.DeepEquals, &params.Error{Message: "baz"})
 }
 
 func (s *storageMockSuite) TestDetachArityMismatch(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, result interface{}) error {
-			results := result.(*params.ErrorResults)
-			results.Results = []params.ErrorResult{{}, {}, {}}
-			return nil
-		},
-	)
-	client := storage.NewClient(apiCaller)
-	_, err := client.Detach([]string{"foo/0", "bar/1"}, nil, nil)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{}, {}, {}},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DetachStorage", gomock.AssignableToTypeOf(params.StorageDetachmentParams{}), result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	_, err := storageClient.Detach([]string{"foo/0", "bar/1"}, nil, nil)
 	c.Check(err, gc.ErrorMatches, `expected 2 result\(s\), got 3`)
 }
 
 func (s *storageMockSuite) TestAttach(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "Attach")
-			c.Check(a, jc.DeepEquals, params.StorageAttachmentIds{[]params.StorageAttachmentId{
-				{
-					StorageTag: "storage-bar-1",
-					UnitTag:    "unit-foo-0",
-				},
-				{
-					StorageTag: "storage-baz-2",
-					UnitTag:    "unit-foo-0",
-				},
-			}})
-			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-			results := result.(*params.ErrorResults)
-			results.Results = []params.ErrorResult{
-				{},
-				{Error: &params.Error{Message: "qux"}},
-			}
-			return nil
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	expectedArgs := params.StorageAttachmentIds{[]params.StorageAttachmentId{
+		{
+			StorageTag: "storage-bar-1",
+			UnitTag:    "unit-foo-0",
 		},
-	)
-	client := storage.NewClient(apiCaller)
-	results, err := client.Attach("foo/0", []string{"bar/1", "baz/2"})
+		{
+			StorageTag: "storage-baz-2",
+			UnitTag:    "unit-foo-0",
+		},
+	}}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{
+			{},
+			{Error: &params.Error{Message: "qux"}},
+		},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Attach", expectedArgs, result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	obtained, err := storageClient.Attach("foo/0", []string{"bar/1", "baz/2"})
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(results, gc.HasLen, 2)
-	c.Assert(results[0].Error, gc.IsNil)
-	c.Assert(results[1].Error, jc.DeepEquals, &params.Error{Message: "qux"})
+	c.Assert(obtained, gc.HasLen, 2)
+	c.Assert(obtained[0].Error, gc.IsNil)
+	c.Assert(obtained[1].Error, jc.DeepEquals, &params.Error{Message: "qux"})
 }
 
 func (s *storageMockSuite) TestAttachArityMismatch(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, result interface{}) error {
-			results := result.(*params.ErrorResults)
-			results.Results = []params.ErrorResult{{}, {}, {}}
-			return nil
-		},
-	)
-	client := storage.NewClient(apiCaller)
-	_, err := client.Attach("foo/0", []string{"bar/1", "baz/2"})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{}, {}, {}},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Attach", gomock.AssignableToTypeOf(params.StorageAttachmentIds{}), result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	_, err := storageClient.Attach("foo/0", []string{"bar/1", "baz/2"})
 	c.Check(err, gc.ErrorMatches, `expected 2 result\(s\), got 3`)
 }
 
 func (s *storageMockSuite) TestImport(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "Import")
-			c.Check(a, jc.DeepEquals, params.BulkImportStorageParams{[]params.ImportStorageParams{{
-				Kind:        params.StorageKindBlock,
-				Pool:        "foo",
-				ProviderId:  "bar",
-				StorageName: "baz",
-			}}})
-			c.Assert(result, gc.FitsTypeOf, &params.ImportStorageResults{})
-			results := result.(*params.ImportStorageResults)
-			results.Results = []params.ImportStorageResult{{
-				Result: &params.ImportStorageDetails{
-					StorageTag: "storage-qux-0",
-				},
-			}}
-			return nil
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	expectedArgs := params.BulkImportStorageParams{[]params.ImportStorageParams{{
+		Kind:        params.StorageKindBlock,
+		Pool:        "foo",
+		ProviderId:  "bar",
+		StorageName: "baz",
+	}}}
+	result := new(params.ImportStorageResults)
+	results := params.ImportStorageResults{
+		Results: []params.ImportStorageResult{{
+			Result: &params.ImportStorageDetails{
+				StorageTag: "storage-qux-0",
+			},
 		},
-	)
-	client := storage.NewClient(apiCaller)
-	storageTag, err := client.Import(jujustorage.StorageKindBlock, "foo", "bar", "baz")
+		}}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Import", expectedArgs, result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	storageTag, err := storageClient.Import(jujustorage.StorageKindBlock, "foo", "bar", "baz")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storageTag, gc.Equals, names.NewStorageTag("qux/0"))
 }
 
 func (s *storageMockSuite) TestImportError(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, result interface{}) error {
-			results := result.(*params.ImportStorageResults)
-			results.Results = []params.ImportStorageResult{{
-				Error: &params.Error{Message: "qux"},
-			}}
-			return nil
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	result := new(params.ImportStorageResults)
+	results := params.ImportStorageResults{
+		Results: []params.ImportStorageResult{{
+			Error: &params.Error{Message: "qux"},
 		},
-	)
-	client := storage.NewClient(apiCaller)
-	_, err := client.Import(jujustorage.StorageKindBlock, "foo", "bar", "baz")
+		}}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Import", gomock.AssignableToTypeOf(params.BulkImportStorageParams{}), result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	_, err := storageClient.Import(jujustorage.StorageKindBlock, "foo", "bar", "baz")
 	c.Check(err, gc.ErrorMatches, "qux")
 }
 
 func (s *storageMockSuite) TestImportArityMismatch(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, result interface{}) error {
-			results := result.(*params.ImportStorageResults)
-			results.Results = []params.ImportStorageResult{{}, {}}
-			return nil
-		},
-	)
-	client := storage.NewClient(apiCaller)
-	_, err := client.Import(jujustorage.StorageKindBlock, "foo", "bar", "baz")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	result := new(params.ImportStorageResults)
+	results := params.ImportStorageResults{
+		Results: []params.ImportStorageResult{{}, {}},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Import", gomock.AssignableToTypeOf(params.BulkImportStorageParams{}), result).SetArg(2, results).Return(nil)
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
+	_, err := storageClient.Import(jujustorage.StorageKindBlock, "foo", "bar", "baz")
 	c.Check(err, gc.ErrorMatches, `expected 1 result, got 2`)
 }
 
 func (s *storageMockSuite) TestRemovePool(c *gc.C) {
-	var called bool
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	poolName := "poolName"
+	expectedArgs := params.StoragePoolDeleteArgs{
+		Pools: []params.StoragePoolDeleteArg{{
+			Name: poolName,
+		}},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(expectedArgs.Pools)),
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("RemovePool", expectedArgs, result).SetArg(2, results).Return(nil)
 
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			called = true
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "RemovePool")
-
-			args, ok := a.(params.StoragePoolDeleteArgs)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Pools, gc.HasLen, 1)
-			c.Assert(args.Pools[0].Name, gc.Equals, poolName)
-
-			results := result.(*params.ErrorResults)
-			results.Results = make([]params.ErrorResult, len(args.Pools))
-
-			return nil
-		})
-	storageClient := storage.NewClient(basetesting.BestVersionCaller{BestVersion: 5, APICallerFunc: apiCaller})
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	err := storageClient.RemovePool(poolName)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *storageMockSuite) TestRemovePoolFacadeCallError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "RemovePool")
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, 1),
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("RemovePool", gomock.AssignableToTypeOf(params.StoragePoolDeleteArgs{}), result).SetArg(2, results).Return(errors.New(msg))
 
-			args, ok := a.(params.StoragePoolDeleteArgs)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Pools, gc.HasLen, 1)
-			c.Assert(args.Pools[0].Name, gc.Equals, "")
-
-			results := result.(*params.ErrorResults)
-			results.Results = make([]params.ErrorResult, len(args.Pools))
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(basetesting.BestVersionCaller{BestVersion: 5, APICallerFunc: apiCaller})
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	err := storageClient.RemovePool("")
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }
 
 func (s *storageMockSuite) TestUpdatePool(c *gc.C) {
-	var called bool
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	poolName := "poolName"
 	providerType := "loop"
 	poolConfig := map[string]interface{}{
 		"test": "one",
 		"pass": true,
 	}
+	expectedArgs := params.StoragePoolArgs{
+		Pools: []params.StoragePool{{
+			Name:     poolName,
+			Provider: providerType,
+			Attrs:    poolConfig,
+		}},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(expectedArgs.Pools)),
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UpdatePool", expectedArgs, result).SetArg(2, results).Return(nil)
 
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			called = true
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "UpdatePool")
-
-			args, ok := a.(params.StoragePoolArgs)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Pools, gc.HasLen, 1)
-			c.Assert(args.Pools[0].Name, gc.Equals, poolName)
-			c.Assert(args.Pools[0].Provider, gc.Equals, providerType)
-			c.Assert(args.Pools[0].Attrs, gc.DeepEquals, poolConfig)
-
-			results := result.(*params.ErrorResults)
-			results.Results = make([]params.ErrorResult, len(args.Pools))
-
-			return nil
-		})
-	storageClient := storage.NewClient(basetesting.BestVersionCaller{BestVersion: 5, APICallerFunc: apiCaller})
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	err := storageClient.UpdatePool(poolName, providerType, poolConfig)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *storageMockSuite) TestUpdatePoolFacadeCallError(c *gc.C) {
-	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Storage")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "UpdatePool")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			return errors.New(msg)
-		})
-	storageClient := storage.NewClient(basetesting.BestVersionCaller{BestVersion: 5, APICallerFunc: apiCaller})
+	msg := "facade failure"
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, 1),
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UpdatePool", gomock.AssignableToTypeOf(params.StoragePoolArgs{}), result).SetArg(2, results).Return(errors.New(msg))
+
+	storageClient := storage.NewClientFromCaller(mockFacadeCaller)
 	err := storageClient.UpdatePool("", "", nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }

--- a/api/client/storage/export_test.go
+++ b/api/client/storage/export_test.go
@@ -1,0 +1,12 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storage
+
+import "github.com/juju/juju/api/base"
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
+}


### PR DESCRIPTION
These unit tests now use go mock and not juju/testing. All unit tests should pass.