### PR TITLE
Check that /etc/netplan directory is not empty

### DIFF
--- a/container/broker/instance_broker.go
+++ b/container/broker/instance_broker.go
@@ -122,14 +122,22 @@ func prepareHost(config Config) PrepareHostFunc {
 	}
 }
 
+var openFunc = os.Open
+
+func Readdirnames(f *os.File, n int) (names []string, err error) {
+	return f.Readdirnames(n)
+}
+
+var readDirFunc = Readdirnames
+
 func isDirectoryEmpty(directory string) (bool, error) {
-	f, err := os.Open(directory)
+	f, err := openFunc(directory)
 	if err != nil {
 		return false, err
 	}
 	defer f.Close()
 
-	_, err = f.Readdirnames(1)
+	_, err = readDirFunc(f, 1)
 	if err == io.EOF {
 		return true, nil
 	}

--- a/container/broker/instance_broker_test.go
+++ b/container/broker/instance_broker_test.go
@@ -1,0 +1,43 @@
+package broker
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func mockOpen(name string) (*os.File, error) {
+	return os.Open(".")
+}
+
+func mockReaddirnamesInterfaces(f *os.File, n int) (names []string, err error) {
+	return nil, io.EOF
+}
+
+func mockReaddirnamesNetplan(f *os.File, n int) (names []string, err error) {
+	return nil, nil
+}
+
+func TestDefaultBridger(t *testing.T) {
+	openFunc = mockOpen
+
+	readDirFunc = mockReaddirnamesNetplan
+	bridger, err := defaultBridger()
+	if err != nil {
+		t.Fail()
+	}
+	if reflect.TypeOf(bridger).Elem().Name() != "netplanBridger" {
+		t.Fail()
+	}
+
+	readDirFunc = mockReaddirnamesInterfaces
+	bridger, err = defaultBridger()
+	if err != nil {
+		t.Fail()
+	}
+	if reflect.TypeOf(bridger).Elem().Name() != "etcNetworkInterfacesBridger" {
+		t.Fail()
+	}
+}
+


### PR DESCRIPTION
It is not enough to check that the /etc/netplan directory exists to be
sure that the system uses netplan. Some systems upgraded from Xenial to
Bionic have an empty /etc/netplan folder but still use /etc/network/interfaces

## QA steps

* See https://github.com/juju/juju/pull/11564
* Test an upgraded system from Xenial to Bionic. The netplan package is installed and creates the empty /etc/netplan directory but the system is still using /etc/network/interfaces

## Bug reference

https://bugs.launchpad.net/juju/+bug/1942917
