### PR TITLE
Remove unused relation WriteSettings and UpdateSettings methods

### DIFF
--- a/api/agent/uniter/relationunit.go
+++ b/api/agent/uniter/relationunit.go
@@ -170,27 +170,3 @@ func (ru *RelationUnit) ReadSettings(name string) (params.Settings, error) {
 	}
 	return result.Settings, nil
 }
-
-// UpdateRelationSettings is used to record any changes to settings for this unit and application.
-// It is only valid to update application settings if this unit is the leader, otherwise
-// it is a NotLeader error. Note that either unit or application is allowed to be nil.
-func (ru *RelationUnit) UpdateRelationSettings(unit, application params.Settings) error {
-	var result params.ErrorResults
-	args := params.RelationUnitsSettings{
-		RelationUnits: []params.RelationUnitSettings{{
-			Relation:            ru.relation.tag.String(),
-			Unit:                ru.unitTag.String(),
-			Settings:            unit,
-			ApplicationSettings: application,
-		}},
-	}
-	err := ru.st.facade.FacadeCall("UpdateSettings", args, &result)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = result.OneError()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return nil
-}

--- a/api/agent/uniter/relationunit_test.go
+++ b/api/agent/uniter/relationunit_test.go
@@ -88,24 +88,6 @@ func (s *relationUnitSuite) getRelationUnit(c *gc.C) *uniter.RelationUnit {
 					"baz": "1",
 				},
 			}
-		case "UpdateSettings":
-			c.Assert(arg, gc.DeepEquals, params.RelationUnitsSettings{
-				RelationUnits: []params.RelationUnitSettings{{
-					Relation: "relation-wordpress.db#mysql.server",
-					Unit:     "unit-mysql-0",
-					Settings: params.Settings{
-						"some":  "settings",
-						"other": "things",
-					},
-					ApplicationSettings: params.Settings{
-						"foo": "bar",
-						"baz": "1",
-					}},
-				}})
-			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-			*(result.(*params.ErrorResults)) = params.ErrorResults{
-				Results: []params.ErrorResult{{Error: &params.Error{Message: "pow"}}},
-			}
 		default:
 			c.Fatalf("unexpected api call %q", request)
 		}
@@ -207,18 +189,4 @@ func (s *relationUnitSuite) TestWatchRelationUnits(c *gc.C) {
 
 	// Initial event.
 	wc.AssertChange([]string{"mysql/0"}, []string{"mysql"}, []string{"666"})
-}
-
-func (s *relationUnitSuite) TestUpdateRelationSettings(c *gc.C) {
-	relUnit := s.getRelationUnit(c)
-	err := relUnit.UpdateRelationSettings(
-		params.Settings{
-			"some":  "settings",
-			"other": "things",
-		},
-		params.Settings{
-			"foo": "bar",
-			"baz": "1",
-		})
-	c.Assert(err, gc.ErrorMatches, "pow")
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1697,6 +1697,7 @@ func (u *UniterAPI) ReadRemoteSettings(args params.RelationUnitPairs) (params.Se
 // UpdateSettings persists all changes made to the local settings of
 // all given pairs of relation and unit. Keys with empty values are
 // considered a signal to delete these values.
+// TODO(juju3) - remove
 func (u *UniterAPI) UpdateSettings(args params.RelationUnitsSettings) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.RelationUnits)),

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -46276,7 +46276,7 @@
                             "$ref": "#/definitions/ErrorResults"
                         }
                     },
-                    "description": "UpdateSettings persists all changes made to the local settings of\nall given pairs of relation and unit. Keys with empty values are\nconsidered a signal to delete these values."
+                    "description": "UpdateSettings persists all changes made to the local settings of\nall given pairs of relation and unit. Keys with empty values are\nconsidered a signal to delete these values.\nTODO(juju3) - remove"
                 },
                 "UpgradeSeriesUnitStatus": {
                     "type": "object",

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -374,6 +374,7 @@ type RelationUnitPairs struct {
 
 // RelationUnitSettings holds a relation tag, a unit tag and local
 // unit and app-level settings.
+// TODO(juju3) - remove
 type RelationUnitSettings struct {
 	Relation            string   `json:"relation"`
 	Unit                string   `json:"unit"`
@@ -383,6 +384,7 @@ type RelationUnitSettings struct {
 
 // RelationUnitsSettings holds the arguments for making a EnterScope
 // or UpdateRelationSettings API calls.
+// TODO(juju3) - remove
 type RelationUnitsSettings struct {
 	RelationUnits []RelationUnitSettings `json:"relation-units"`
 }

--- a/worker/uniter/relation/interface.go
+++ b/worker/uniter/relation/interface.go
@@ -259,11 +259,6 @@ type RelationUnit interface {
 	// Settings returns a Settings which allows access to the unit's settings
 	// within the relation.
 	Settings() (*uniter.Settings, error)
-
-	// UpdateRelationSettings is used to record any changes to settings for
-	// this unit and application. It is only valid to update application
-	// settings if this unit is the leader.
-	UpdateRelationSettings(unit, application params.Settings) error
 }
 
 // Relationer encapsulates the methods from relationer required by a stateTracker.

--- a/worker/uniter/relation/mocks/mock_uniter_api.go
+++ b/worker/uniter/relation/mocks/mock_uniter_api.go
@@ -498,17 +498,3 @@ func (mr *MockRelationUnitMockRecorder) Settings() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Settings", reflect.TypeOf((*MockRelationUnit)(nil).Settings))
 }
-
-// UpdateRelationSettings mocks base method.
-func (m *MockRelationUnit) UpdateRelationSettings(arg0, arg1 params.Settings) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRelationSettings", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateRelationSettings indicates an expected call of UpdateRelationSettings.
-func (mr *MockRelationUnitMockRecorder) UpdateRelationSettings(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRelationSettings", reflect.TypeOf((*MockRelationUnit)(nil).UpdateRelationSettings), arg0, arg1)
-}

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -27,8 +27,7 @@ type Relation interface {
 	// Suspended returns the relation's current suspended status.
 	Suspended() bool
 
-	// Refresh refreshes the contents of the relation from the underlying
-	// state.
+	// SetStatus updates the status of the relation.
 	SetStatus(status relation.Status) error
 
 	// Tag returns the relation tag.
@@ -61,10 +60,6 @@ type RelationUnit interface {
 	// Settings returns a Settings which allows access to the unit's settings
 	// within the relation.
 	Settings() (*uniter.Settings, error)
-
-	// UpdateRelationSettings is used to record any changes to settings for
-	// this unit and application.
-	UpdateRelationSettings(unit, application params.Settings) error
 }
 
 type RelationUnitShim struct {
@@ -155,12 +150,6 @@ func (ctx *ContextRelation) ApplicationSettings() (jujuc.Settings, error) {
 		ctx.applicationSettings = settings
 	}
 	return ctx.applicationSettings, nil
-}
-
-// WriteSettings persists all changes made to the relation settings (unit and application)
-func (ctx *ContextRelation) WriteSettings() error {
-	unitSettings, appSettings := ctx.FinalSettings()
-	return errors.Trace(ctx.ru.UpdateRelationSettings(unitSettings, appSettings))
 }
 
 // FinalSettings returns the changes made to the relation settings (unit and application)

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -143,39 +143,6 @@ func (s *ContextRelationSuite) TestNonMemberCaching(c *gc.C) {
 	c.Assert(m, gc.DeepEquals, expectSettings)
 }
 
-func (s *ContextRelationSuite) TestLocalSettings(c *gc.C) {
-	ctx := context.NewContextRelation(s.relUnit, nil)
-
-	// Change Settings...
-	node, err := ctx.Settings()
-	c.Assert(err, jc.ErrorIsNil)
-	expectSettings := node.Map()
-	expectOldMap := convertSettings(expectSettings)
-	node.Set("change", "exciting")
-
-	// ...and check it's not written to state.
-	settings, err := s.ru.ReadSettings("u/0")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(settings, gc.DeepEquals, expectOldMap)
-
-	// Write settings...
-	err = ctx.WriteSettings()
-	c.Assert(err, jc.ErrorIsNil)
-
-	// ...and check it was written to state.
-	settings, err = s.ru.ReadSettings("u/0")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(settings, gc.DeepEquals, map[string]interface{}{"change": "exciting"})
-}
-
-func convertSettings(settings params.Settings) map[string]interface{} {
-	result := make(map[string]interface{})
-	for k, v := range settings {
-		result[k] = v
-	}
-	return result
-}
-
 func convertMap(settingsMap map[string]interface{}) params.Settings {
 	result := make(params.Settings)
 	for k, v := range settingsMap {


### PR DESCRIPTION
The `UpdateRelationSettings` uniter facade method is only called by `WriteSettings` which is unused.
So remove these methods and any tests.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Internal refactor - run unit tests.