### PR TITLE
[JUJU-1659]update_status_alias_to_show_status

### DIFF
--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -600,7 +600,7 @@ func (s *MainSuite) TestRegisterCommandsWhitelist(c *gc.C) {
 	stubRegistry := &stubRegistry{stub: &jujutesting.Stub{}}
 	registry := jujuCommandRegistry{
 		commandRegistry: stubRegistry,
-		whitelist:       set.NewStrings("show-status"),
+		whitelist:       set.NewStrings("status"),
 		excluded:        set.NewStrings(),
 	}
 	registerCommands(registry)

--- a/cmd/juju/commands/repl_test.go
+++ b/cmd/juju/commands/repl_test.go
@@ -157,7 +157,7 @@ func (s *ReplSuite) TestJujuCommandHelp(c *gc.C) {
 
 	stdout, _ := jujutesting.CaptureOutput(c, f)
 	s.assertOutMatches(c, stdout,
-		"Usage: juju show-status.*")
+		"Usage: juju status.*")
 }
 
 func (s *ReplSuite) TestRepl(c *gc.C) {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -162,11 +162,11 @@ See also:
 
 func (c *statusCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "show-status",
+		Name:    "status",
 		Args:    "[<selector> [...]]",
 		Purpose: usageSummary,
 		Doc:     usageDetails,
-		Aliases: []string{"status"},
+		Aliases: []string{"show-status"},
 	})
 }
 


### PR DESCRIPTION
This PR updates the `juju status` alias to `show-status`.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju status help 
```