### PR TITLE
[JUJU-1762] Adds support for building DQLITE into jujud.

### DIFF
--- a/scripts/dqlite/Makefile
+++ b/scripts/dqlite/Makefile
@@ -1,261 +1,78 @@
 SHELL = bash
 .ONESHELL:
 
-PROJECT_DIR ?= $(GOPATH)/src/github.com/juju/juju
+PROJECT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+BUILD_DIR ?= $(PROJECT_DIR)/_build
+
+SETUP_SCRIPT ?= ${PROJECT_DIR}/scripts/dqlite/setup-ubuntu.sh
+BUILD_SCRIPT ?= ${PROJECT_DIR}/scripts/dqlite/build.sh
 
 DQLITE_BUILD_IMAGE=ubuntu:22.04
-DQLITE_BUILD_CONTAINER=lib-build-server
-
-DQLITE_ARCHIVE_DEPS_PATH=${PROJECT_DIR}/scripts/dqlite
-DQLITE_ARCHIVE_NAME=dqlite-deps
-DQLITE_ARCHIVE_PATH=${DQLITE_ARCHIVE_DEPS_PATH}/${DQLITE_ARCHIVE_NAME}.tar.bz2
-
+DQLITE_BUILD_CONTAINER_PREFIX=juju-dqlite-build-server
+DQLITE_ARCHIVE_NAME=juju-dqlite-static-lib-deps.tar.bz2
+DQLITE_UNPACKED_ARCHIVE_NAME=juju-dqlite-static-lib-deps
 DQLITE_S3_BUCKET=s3://dqlite-static-libs
-DQLITE_S3_ARCHIVE_NAME=$(shell date -u +"%Y-%m-%d")-dqlite-deps-$(shell uname -m).tar.bz2
-DQLITE_S3_ARCHIVE_PATH=${DQLITE_S3_BUCKET}/${DQLITE_S3_ARCHIVE_NAME}
+DQLITE_PLATFORMS ?= linux/amd64 linux/arm64
 
-DQLITE_EXTRACTED_DEPS_PATH=${PROJECT_DIR}/_deps
-DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH=${DQLITE_EXTRACTED_DEPS_PATH}/juju-dqlite-static-lib-deps
+dep_platform_targets = $(addprefix dqlite-deps-build-, $(subst /,_,${1})))
+dep_platform_path = $(addprefix ${BUILD_DIR}/, $(addsuffix /dep/${DQLITE_UNPACKED_ARCHIVE_NAME}, $(subst /,_, $1)))
+dqlite_s3_archive_path = $(addprefix ${DQLITE_S3_BUCKET}/,$(shell date -u +"%Y-%m-%d")-dqlite-deps-$1.tar.bz2)
+dqlite_s3_latest_archive_path = $(addprefix ${DQLITE_S3_BUCKET}/,latest-dqlite-deps-$1.tar.bz2)
 
-# Versions for Dqlite and upstream dependencies.
-TAG_LIBTIRPC=upstream/1.3.3
-TAG_LIBNSL=v2.0.0
-TAG_LIBUV=v1.44.2
-TAG_LIBLZ4=v1.9.4
-TAG_RAFT=v0.16.0
-TAG_SQLITE=version-3.40.0
-TAG_DQLITE=v1.12.0
+define DQLITE_ARCHIVE_TARGETS
+	$(call dep_platform_targets,${DQLITE_PLATFORMS})
+endef
 
-.PHONY: install-deps-on-controller build-and-install-jujud
+.PHONY: phony_explicit
+phony_explicit:
+## phone_explicit is a dummy target that can be added to pattern targets to
+## them phony make.
 
-${DQLITE_ARCHIVE_PATH}:
-	@lxc delete -f ${DQLITE_BUILD_CONTAINER} &>/dev/null || true
+.PHONY: build-dqlite
+build-dqlite: ${DQLITE_ARCHIVE_TARGETS}
 
-	@echo "DQLITE: Creating build box using ${DQLITE_BUILD_IMAGE}"
-	@lxc launch ${DQLITE_BUILD_IMAGE} ${DQLITE_BUILD_CONTAINER}
+${BUILD_DIR}/%/dep/${DQLITE_UNPACKED_ARCHIVE_NAME}: ${BUILD_DIR}/%/dep/${DQLITE_ARCHIVE_NAME}
+	@tar -xjf ${BUILD_DIR}/$*/dep/${DQLITE_ARCHIVE_NAME} -C ${BUILD_DIR}/$*/dep/
 
-	@echo "DQLITE: Waiting for ${DQLITE_BUILD_CONTAINER} to become ready..."
-	@lxc exec ${DQLITE_BUILD_CONTAINER} -- bash -c 'while [ "$$(systemctl is-system-running 2>/dev/null)" != "running" ] && [ "$$(systemctl is-system-running 2>/dev/null)" != "degraded" ]; do :; done'
+${BUILD_DIR}/%/dep/${DQLITE_ARCHIVE_NAME}:
+	@$(eval s3_latest_archive_path = $(call dqlite_s3_latest_archive_path,$*))
+	@mkdir -p "${BUILD_DIR}/$*/dep"
+	@echo "DQLITE: Pulling ${s3_latest_archive_path} from s3"
+	@aws s3 cp ${s3_latest_archive_path} ${BUILD_DIR}/$*/dep/${DQLITE_ARCHIVE_NAME}
 
-	@echo "DQLITE: Preparing provisioning script: /tmp/setup-build-farm.sh"
-	@cat <<- 'EOF' >/tmp/setup-build-farm.sh
-		#!/bin/bash
-		set -e
+dqlite-deps-build-%: phony_explicit
+	@$(eval container = ${DQLITE_BUILD_CONTAINER_PREFIX}-$(subst _,-,$*))
+	@$(eval os_arch_tuple = $(subst _,/,$*))
+	@lxc delete -f ${container} &>/dev/null || true
 
-		# TODO: Make this script idempotent, so that it checks for the
-		# existence of repositories, requiring only a pull and not a full clone.
+	@echo "DQLITE: Creating build container \"${container}\" using ${DQLITE_BUILD_IMAGE}"
+	@lxc launch ${DQLITE_BUILD_IMAGE} ${container}
 
-		# Setup build env
-		apt-get update
-		apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install \
-			gcc automake libtool make gettext autopoint pkg-config tclsh tcl libsqlite3-dev
+	@echo "DQLITE: Waiting for ${container} to become ready..."
+	@lxc exec ${container} -- bash -c 'while [ "$$(systemctl is-system-running 2>/dev/null)" != "running" ] && [ "$$(systemctl is-system-running 2>/dev/null)" != "degraded" ]; do :; done'
 
-		mkdir build
-		cd build
+	@echo "DQLITE: Pushing setup script to ${container}"
+	@lxc file push ${SETUP_SCRIPT} ${container}/tmp/setup.sh
 
-		# Checkout and build musl. We will use this to avoid depending
-		# on the hosts libc.
-		#
-		# TODO: investigate zig-gcc as an alternative.
-		wget https://musl.libc.org/releases/musl-1.2.3.tar.gz
-		tar xf musl-1.2.3.tar.gz
-		cd musl-1.2.3
-		./configure
-		make install
-	
-		export PATH=$${PATH}:/usr/local/musl/bin
-		export CC=musl-gcc
-		cd ..
+	@echo "DQLITE: Executing setup script"
+	@lxc exec -T ${container} bash /tmp/setup.sh
 
-		# Setup symlinks so we can access additional headers that 
-		# don't ship with musl but are needed for our builds
-		ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm
-		ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic
-		ln -s /usr/include/linux /usr/local/musl/include/linux
+	@echo "DQLITE: Pushing build script to ${container}"
+	@lxc file push ${BUILD_SCRIPT} ${container}/tmp/build.sh
 
-		# Grab the queue.h file that does not ship with musl
-		wget https://dev.midipix.org/compat/musl-compat/raw/main/f/include/sys/queue.h -O /usr/local/musl/include/sys/queue.h
-
-		# Install compile dependencies for statically linking everything:
-		# --------------------------------------------------------------
-		# libtirpc (required by libnsl)
-		# libnsl (required by dqlite)
-		# libuv (required by raft)
-		# liblz4 (required by raft)
-		# raft (required by dqlite)
-		# sqlite3 (required by dqlite)
-		# dqlite
-		
-		# libtirpc
-		git clone https://salsa.debian.org/debian/libtirpc.git --depth 1 --branch ${TAG_LIBTIRPC}
-		cd libtirpc
-		chmod +x autogen.sh
-		./autogen.sh
-		./configure --disable-shared --disable-gssapi
-		make
-		cd ../
-
-		# libnsl
-		git clone https://github.com/thkukuk/libnsl --depth 1 --branch ${TAG_LIBNSL}
-		cd libnsl
-		./autogen.sh
-		autoreconf -i
-		autoconf
-		CFLAGS="-I$${PWD}/../libtirpc/tirpc" \
-		       LDFLAGS="-L$${PWD}/../libtirpc/src" \
-		       TIRPC_CFLAGS="-I$${PWD}/../libtirpc/tirpc" \
-		       TIRPC_LIBS="-L$${PWD}/../libtirpc/src" \
-		       ./configure --disable-shared
-		make
-		cd ../
-
-		# libuv
-		git clone https://github.com/libuv/libuv.git --depth 1 --branch ${TAG_LIBUV}
-		cd libuv
-		./autogen.sh
-		./configure # we need the .so files as well; see note below
-		make
-		cd ../
-
-		# liblz4
-		git clone https://github.com/lz4/lz4.git --depth 1 --branch ${TAG_LIBLZ4}
-		cd lz4
-		make lib
-		cd ../
-
-		# raft
-		git clone https://github.com/canonical/raft.git --depth 1 --branch ${TAG_RAFT}
-		cd raft
-		autoreconf -i
-		CFLAGS="-I$${PWD}/../libuv/include -I$${PWD}/../lz4/lib" \
-		       LDFLAGS="-L$${PWD}/../libuv/.libs -L$${PWD}/../lz4/lib" \
-		       UV_CFLAGS="-I$${PWD}/../libuv/include" \
-		       UV_LIBS="-L$${PWD}/../libuv/.libs" \
-		       LZ4_CFLAGS="-I$${PWD}/../lz4/lib" \
-		       LZ4_LIBS="-L$${PWD}/../lz4/lib" \
-		       ./configure --disable-shared
-		make
-		cd ../
-
-		# sqlite3
-		git clone https://github.com/sqlite/sqlite.git --depth 1 --branch ${TAG_SQLITE}
-		cd sqlite
-		./configure --disable-shared
-		make
-		cd ../
-	
-		# dqlite
-		git clone https://github.com/canonical/dqlite.git --depth 1 --branch ${TAG_DQLITE}
-		cd dqlite
-		autoreconf -i
-		CFLAGS="-I$${PWD}/../raft/include -I$${PWD}/../sqlite -I$${PWD}/../libuv/include -I$${PWD}/../lz4/lib -I/usr/local/musl/include -Werror=implicit-function-declaration" \
-		       LDFLAGS="-L$${PWD}/../raft/.libs -L$${PWD}/../libuv/.libs -L$${PWD}/../lz4/lib -L$${PWD}/../libnsl/src" \
-		       RAFT_CFLAGS="-I$${PWD}/../raft/include" \
-		       RAFT_LIBS="-L$${PWD}/../raft/.libs" \
-		       UV_CFLAGS="-I$${PWD}/../libuv/include" \
-		       UV_LIBS="-L$${PWD}/../libuv/.libs" \
-		       SQLITE_CFLAGS="-I$${PWD}/../sqlite" \
-		       ./configure --disable-shared
-		make
-		cd ../
-		
-		rm -Rf juju-dqlite-static-lib-deps
-		mkdir juju-dqlite-static-lib-deps
-
-		# Collect .a files
-		# NOTE: for some strange reason we *also* require the libuv and
-		# liblz4 .so files for the final juju link step even though the
-		# resulting artifact is statically linked.
-		cp libuv/.libs/* juju-dqlite-static-lib-deps/
-		cp lz4/lib/*.a juju-dqlite-static-lib-deps/
-		cp lz4/lib/*.so* juju-dqlite-static-lib-deps/
-		cp raft/.libs/*.a juju-dqlite-static-lib-deps/
-		cp sqlite/.libs/*.a juju-dqlite-static-lib-deps/
-		cp dqlite/.libs/*.a juju-dqlite-static-lib-deps/
-
-		# Collect required headers
-		mkdir juju-dqlite-static-lib-deps/include
-		cp -r raft/include/* juju-dqlite-static-lib-deps/include
-		cp -r sqlite/*.h juju-dqlite-static-lib-deps/include
-		cp -r dqlite/include/* juju-dqlite-static-lib-deps/include
-
-		tar cjvf juju-dqlite-static-lib-deps.tar.bz2 juju-dqlite-static-lib-deps
-	EOF
-
-	@echo "DQLITE: Pushing provisioning script to ${DQLITE_BUILD_CONTAINER}"
-	@lxc file push /tmp/setup-build-farm.sh ${DQLITE_BUILD_CONTAINER}/root/setup-build-farm.sh
-
-	@echo "DQLITE: Executing provisioning script"
-	@lxc exec -t ${DQLITE_BUILD_CONTAINER} bash /root/setup-build-farm.sh
+	@echo "DQLITE: Executing build script"
+	@lxc exec -T ${container} --env BUILD_DIR="/tmp/build_$*" bash /tmp/build.sh ${os_arch_tuple}
 
 	@echo "DQLITE: Pulling lib archive"
-	@lxc file pull ${DQLITE_BUILD_CONTAINER}/root/build/juju-dqlite-static-lib-deps.tar.bz2 $@
-	@lxc delete -f $(DQLITE_BUILD_CONTAINER)
+	@mkdir -p "${BUILD_DIR}/$*/dep"
+	@lxc file pull ${container}/tmp/build_$*/juju-dqlite-static-lib-deps.tar.bz2 $@
 
-# s3 puts here are without an ACL.
-# The bucket uses policies that allow GetObject to anyone,
-# and PutObject to select Juju team accounts.
-dqlite-deps-push: ${DQLITE_ARCHIVE_PATH}
-	@echo "DQLITE: Pushing ${DQLITE_S3_ARCHIVE_PATH} to s3"
-	aws s3 cp $< ${DQLITE_S3_ARCHIVE_PATH}
-	@echo "DQLITE: Pushing latest-dqlite-deps-$(shell uname -m).tar.bz2 to s3"
-	aws s3 cp ${DQLITE_S3_ARCHIVE_PATH} ${DQLITE_S3_BUCKET}/latest-dqlite-deps-$(shell uname -m).tar.bz2
+dqlite-deps-push-%: phony_explicit ${BUILD_DIR}/%/dep/${DQLITE_ARCHIVE_NAME}
+	@$(eval archive_path = ${BUILD_DIR}/$*/dep/${DQLITE_ARCHIVE_NAME})
+	@$(eval s3_archive_path = $(call dqlite_s3_archive_path,$*))
+	@echo "DQLITE: Pushing ${archive_path} to s3"
+	@aws s3 cp --acl public-read ${archive_path} ${s3_archive_path}
+	@echo "DQLITE: making ${s3_archive_path} latest in s3"
+	@aws s3 cp --acl public-read ${s3_archive_path} $(call dqlite_s3_latest_archive_path,$*)
 
-dqlite-deps-pull:
-	@echo "DQLITE: Cleaning up deps path"
-	@mkdir -p ${DQLITE_EXTRACTED_DEPS_PATH}
-	@rm -rf ${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}
-	@echo "DQLITE: Pulling latest-dqlite-deps-$(shell uname -m).tar.bz2 from s3"
-	wget -q -O- https://dqlite-static-libs.s3.amazonaws.com/latest-dqlite-deps-$(shell uname -m).tar.bz2 - | tar xjf - -C ${DQLITE_EXTRACTED_DEPS_PATH}
-
-dqlite-deps-check:
-	@if [ ! -d ${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} ]; then \
-		$(MAKE) -s dqlite-deps-pull; \
-	fi
-
-################################################################################
-# musl
-################################################################################
-
-.PHONY: musl-ensure-symlink musl-check musl-install-if-missing
-musl-ensure-symlink:
-	@test -d /usr/local/musl/$(d) || echo "Please run 'sudo ln -s $(s) /usr/local/musl/$(d)'"
-
-musl-check:
-	@PATH=${PATH}:/usr/local/musl/bin which musl-gcc >/dev/null || echo "Please run 'sudo make musl-install'"
-	# @$(MAKE) -s musl-ensure-symlink d=include/asm s=/usr/include/$(shell uname -m)-linux-gnu/asm
-	# @$(MAKE) -s musl-ensure-symlink d=include/asm-generic s=/usr/include/asm-generic
-	@$(MAKE) -s musl-ensure-symlink d=include/linux s=/usr/include/linux
-
-musl-install:
-	mkdir -p /tmp/musl
-	wget -q https://musl.libc.org/releases/musl-1.2.3.tar.gz -O - | tar -xzf - -C /tmp/musl
-	cd /tmp/musl/musl-1.2.3
-	./configure
-	make install
-
-	cd -
-	# Setup symlinks so we can access additional headers that 
-	# don't ship with musl but are needed for our builds
-	ln -s /usr/include/$(shell uname -m)-linux-gnu/asm /usr/local/musl/include/asm
-	ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic
-	ln -s /usr/include/linux /usr/local/musl/include/linux
-
-musl-install-if-missing:
-	@PATH=${PATH}:/usr/local/musl/bin which musl-gcc >/dev/null || { echo "Installing required musl dependencies"; sudo ${MAKE} musl-install; }
-
-################################################################################
-# REPL
-#
-# Accessing the dqlite repl on a given controller for debugging purposes.
-################################################################################
-
-JUJU_CONTROLLER_BOX ?= $(shell juju status -m controller --format=json | jq -r '.machines | .["0"] | .["instance-id"]')
-
-juju-dqlite-repl-deps-on-controller:
-	@lxc exec -t ${JUJU_CONTROLLER_BOX} -- bash -c 'which rlwrap &>/dev/null || apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install rlwrap'
-	@lxc exec -t ${JUJU_CONTROLLER_BOX} -- bash -c 'which socat &>/dev/null || apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install socat'
-
-juju-dqlite-repl: juju-dqlite-repl-deps-on-controller
-	@echo "[+] Connecting to REPL interface on controller: ${JUJU_CONTROLLER_BOX}"
-	@lxc exec -t ${JUJU_CONTROLLER_BOX} -- bash -c 'rlwrap -H /root/.dqlite_repl.history socat - /var/lib/juju/dqlite/juju.sock'
+dqlite-deps-push: phony_explicit $(addprefix dqlite-deps-push-,$(subst /,_,${DQLITE_PLATFORMS}))

--- a/scripts/dqlite/build.sh
+++ b/scripts/dqlite/build.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+TAG_LIBTIRPC=upstream/1.3.3
+TAG_LIBNSL=v2.0.0
+TAG_LIBUV=v1.44.2
+TAG_LIBLZ4=v1.9.4
+TAG_RAFT=v0.16.0
+TAG_SQLITE=version-3.40.0
+TAG_DQLITE=v1.12.0
+
+go_osarch_to_zig_target () {
+	case $1 in 
+		linux/arm64)
+			echo -n "aarch64-linux-musl"
+			;;
+		linux/amd64)
+			echo -n "x86_64-linux-musl"
+			;;
+		linux/ppc64le)
+			echo -n "powerpc64le-linux-musl"
+			;;
+		linux/ppc64el)
+			echo -n "powerpc64le-linux-musl"
+			;;
+		linux/s390x)
+			echo -n "s390x-linux-musl"
+			;;
+		*)
+			echo -n ""
+			;;
+	esac
+}
+
+		set -e
+
+		if [ -z "$1" ]; then
+			echo "you must specify the os/arch tuple to build dqlite for when running this script"
+			exit 1
+		fi
+
+		set -u
+
+		OS=$(echo $1 | cut -f 1 -d /)
+		ARCH=$(echo $1 | cut -f 2 -d /)
+		echo "### building dqlite artefacts for OS \"${OS}\" and ARCH \"${ARCH}\""
+
+		ZIG_TARGET=$(go_osarch_to_zig_target $1)
+		if [ -z $ZIG_TARGET ]; then
+			echo "unsupported os/arch pair $1"
+			exit 1
+		fi
+
+		BUILD_DIR=${BUILD_DIR:-$(pwd)/build_${OS}_${ARCH}}
+		echo "### making build dir ${BUILD_DIR}"
+		mkdir -p "${BUILD_DIR}"
+		cd "$BUILD_DIR"
+
+		export CC="zig cc -target $ZIG_TARGET -D _GNU_SOURCE"
+		echo "### setting CC to $CC"
+
+		INCLUDE_DIR="$(pwd)/include"
+		mkdir -p "$INCLUDE_DIR"
+
+		# Grab the queue.h file that does not ship with musl
+		echo "### grabbing include header <sys/queue.h>"
+		if [ ! -f "${INCLUDE_DIR}/sys/queue.h" ]; then
+			echo "### fetching queue.h"
+			mkdir -p "${INCLUDE_DIR}/sys"
+			wget https://dev.midipix.org/compat/musl-compat/raw/main/f/include/sys/queue.h -O "${INCLUDE_DIR}/sys/queue.h"
+		fi
+
+		# libtirpc
+		echo "### compiling libtirpc"
+		LIBTIRPC_DIR="$(pwd)/libtirpc"
+		if [ ! -d $LIBTIRPC_DIR ]; then
+			git clone https://salsa.debian.org/debian/libtirpc.git --depth 1 --branch ${TAG_LIBTIRPC}
+		fi
+		cd $LIBTIRPC_DIR
+		chmod +x autogen.sh
+		./autogen.sh
+		CFLAGS="-I${INCLUDE_DIR}" \
+			./configure --disable-shared --disable-gssapi --target $ZIG_TARGET --host $(uname -m)
+		make
+		cd ..
+
+		## libnsl
+		echo "### compiling libnsl"
+		LIBNSL_DIR="$(pwd)/libnsl"
+		if [ ! -d $LIBNSL_DIR ]; then
+			git clone 'https://github.com/thkukuk/libnsl.git' --depth 1 --branch ${TAG_LIBNSL}
+		fi
+		cd $LIBNSL_DIR
+		./autogen.sh
+		autoreconf -i
+		autoconf
+		CFLAGS="-I${LIBTIRPC_DIR}/tirpc" \
+		       LDFLAGS="-L${LIBTIRPC_DIR}/src" \
+		       TIRPC_CFLAGS="-I${LIBTIRPC_DIR}/tirpc" \
+		       TIRPC_LIBS="-L${LIBTIRPC_DIR}/src" \
+		       ./configure --disable-shared --target $ZIG_TARGET --host $(uname -m)
+		make
+		cd ..
+
+		## libuv
+		echo "### compiling libuv"
+		LIBUV_DIR="$(pwd)/libuv"
+		if [ ! -d $LIBUV_DIR ]; then
+			git clone https://github.com/libuv/libuv.git --depth 1 --branch ${TAG_LIBUV}
+		fi
+		cd $LIBUV_DIR
+		./autogen.sh
+		./configure --disable-shared --target $ZIG_TARGET --host $(uname -m)
+		make
+		cd ..
+
+		# liblz4
+		echo "### compiling lz4"
+		LZ4_DIR="$(pwd)/lz4"
+		if [ ! -d $LZ4_DIR ]; then
+			git clone https://github.com/lz4/lz4.git --depth 1 --branch ${TAG_LIBLZ4}
+		fi
+		cd $LZ4_DIR
+		make lib
+		cd ..
+
+		# raft
+		echo "### compiling raft"
+		RAFT_DIR="$(pwd)/raft"
+		if [ ! -d $RAFT_DIR ]; then
+			git clone https://github.com/canonical/raft.git --depth 1 --branch ${TAG_RAFT}
+		fi
+		cd $RAFT_DIR
+		autoreconf -i
+		CFLAGS="-I${LIBUV_DIR}/include -I${LZ4_DIR}/lib" \
+		       LDFLAGS="-L${LIBUV_DIR}/.libs -L${LZ4_DIR}/lib" \
+		       UV_CFLAGS="-I${LIBUV_DIR}/include" \
+		       UV_LIBS="-L${LIBUV_DIR}/.libs" \
+		       LZ4_CFLAGS="-I${LZ4_DIR}/lib" \
+		       LZ4_LIBS="-L${LZ4_DIR}/lib" \
+		       ./configure --disable-shared --target $ZIG_TARGET --host $(uname -m)
+		make
+		cd ..
+
+		# sqlite3
+		echo "### compiling sqlite3"
+		SQLITE_DIR="$(pwd)/sqlite"
+		if [ ! -d $SQLITE_DIR ]; then
+			git clone https://github.com/sqlite/sqlite.git --depth 1 --branch ${TAG_SQLITE}
+		fi
+		cd $SQLITE_DIR
+		./configure --disable-shared --target $ZIG_TARGET --host $(uname -m)
+		make
+		cd ..
+
+		# dqlite
+		echo "### compiling dqlite"
+		DQLITE_DIR="$(pwd)/dqlite"
+		if [ ! -d $DQLITE_DIR ]; then
+			git clone https://github.com/canonical/dqlite.git --depth 1 --branch ${TAG_DQLITE}
+		fi
+		cd $DQLITE_DIR
+		autoreconf -i
+		CFLAGS="-I${RAFT_DIR}/include -I${SQLITE_DIR} -I${LIBUV_DIR}/include -I${LZ4_DIR}/lib -DNDEBUG -Wno-unused-but-set-variable -Wno-unused-parameter -Wno-all"\
+		       LDFLAGS="-L${RAFT_DIR}/.libs -L${LIBUV_DIR}/.libs -L${LZ4_DIR}/lib -L${LIBNSL_DIR}/src" \
+		       RAFT_CFLAGS="-I${RAFT_DIR}/include" \
+		       RAFT_LIBS="-L${RAFT_DIR}/.libs" \
+		       UV_CFLAGS="-I${LIBUV_DIR}/include" \
+		       UV_LIBS="-L${LIBUV_DIR}/.libs" \
+		       SQLITE_CFLAGS="-I${SQLITE_DIR}" \
+		       ./configure --disable-shared --target $ZIG_TARGET --host $(uname -m)
+		make
+		cd ..
+
+		# Time to gather up all the compiled targets and make the artefacts
+		DEPS_DIR=juju-dqlite-static-lib-deps
+		DEPS_LIB_DIR=${DEPS_DIR}/lib
+		DEPS_INCLUDE_DIR=${DEPS_DIR}/include
+		rm -Rf $DEPS_DIR
+		mkdir -p $DEPS_DIR
+		mkdir -p $DEPS_LIB_DIR
+		mkdir -p $DEPS_INCLUDE_DIR
+
+		cp ${LIBUV_DIR}/.libs/libuv.a $DEPS_LIB_DIR
+		cp ${LZ4_DIR}/lib/liblz4.a $DEPS_LIB_DIR
+		cp ${RAFT_DIR}/.libs/libraft.a $DEPS_LIB_DIR
+		cp ${SQLITE_DIR}/.libs/libsqlite3.a $DEPS_LIB_DIR
+		cp ${DQLITE_DIR}/.libs/libdqlite.a $DEPS_LIB_DIR
+
+		cp -r ${RAFT_DIR}/include/* $DEPS_INCLUDE_DIR
+		cp -r ${SQLITE_DIR}/*.h $DEPS_INCLUDE_DIR
+		cp -r ${DQLITE_DIR}/include/* $DEPS_INCLUDE_DIR
+
+		tar cjvf juju-dqlite-static-lib-deps.tar.bz2 $DEPS_DIR

--- a/scripts/dqlite/setup-ubuntu.sh
+++ b/scripts/dqlite/setup-ubuntu.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This setup script is responsible for making sure a ubuntu system has the
+# necessary tools and config in place for compiling dqlite for use in jujud.
+
+		set -eu
+
+		# Setup build env
+		apt-get update
+		apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install \
+			automake \
+			libtool \
+			make \
+			gettext \
+			autopoint \
+			pkg-config \
+			tclsh tcl \
+			libsqlite3-dev
+
+		snap install zig --classic --channel beta


### PR DESCRIPTION
This change starts to introduce the necessary steps needed for compiling jujud with dqlite built in using CGO. The change in this PR is for integrating the compilation step with the changes made in the 3.0 branch.

We still need to look some issues with cross compiling s390x where by we have to pick a CPU to target so the appropriate instruction flags are turned on and used and work around or wait for an issue to be fixed with zig when cross compiling with gnu auto tools.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run the Makefile and compile jujud through normal means.

## Documentation changes

N/A

## Bug reference

N/A
