### PR TITLE
More reliable testing of action commands by using dilated wall clock.

### DIFF
--- a/cmd/juju/action/exec_test.go
+++ b/cmd/juju/action/exec_test.go
@@ -471,12 +471,6 @@ func (s *ExecSuite) TestTimeout(c *gc.C) {
 		)
 	}()
 
-	numExpectedTimers := 3
-	for t := 0; t < 1; t++ {
-		err2 := s.clock.WaitAdvance(2*time.Second, testing.ShortWait, numExpectedTimers)
-		c.Assert(err2, jc.ErrorIsNil)
-		numExpectedTimers = 1
-	}
 	wg.Wait()
 	c.Check(err, gc.ErrorMatches, "timed out waiting for results from: machine 1, machine 2")
 
@@ -763,8 +757,8 @@ mysql/0:
 	c.Assert(cmdtesting.Stdout(context), gc.Equals, expectedOutput)
 }
 
-func testClock() *testclock.Clock {
-	return testclock.NewClock(time.Now())
+func testClock() testclock.AdvanceableClock {
+	return testclock.NewDilatedWallClock(10 * time.Millisecond)
 }
 
 func (s *ExecSuite) TestBlockAllMachines(c *gc.C) {

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -49,7 +49,7 @@ type BaseActionSuite struct {
 
 	modelFlags []string
 	store      *jujuclient.MemStore
-	clock      *testclock.Clock
+	clock      testclock.AdvanceableClock
 }
 
 func (s *BaseActionSuite) SetUpTest(c *gc.C) {

--- a/cmd/juju/action/showoperation_test.go
+++ b/cmd/juju/action/showoperation_test.go
@@ -13,12 +13,10 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	actionapi "github.com/juju/juju/api/client/action"
 	"github.com/juju/juju/cmd/juju/action"
-	"github.com/juju/juju/testing"
 )
 
 type ShowOperationSuite struct {
@@ -78,7 +76,6 @@ func (s *ShowOperationSuite) TestRun(c *gc.C) {
 		withAPIDelay      time.Duration
 		withAPITimeout    time.Duration
 		withAPIResponse   actionapi.Operations
-		withTicks         int
 		withAPIError      string
 		withFormat        string
 		expectedErr       string
@@ -89,7 +86,6 @@ func (s *ShowOperationSuite) TestRun(c *gc.C) {
 		withClientWait:    "2s",
 		withAPIDelay:      3 * time.Second,
 		withAPITimeout:    5 * time.Second,
-		withTicks:         1,
 		withClientQueryID: operationId,
 		withAPIResponse: actionapi.Operations{
 			Operations: []actionapi.Operation{{
@@ -138,7 +134,6 @@ error: an apiserver error
 		withClientWait:    "10s",
 		withClientQueryID: operationId,
 		withAPITimeout:    3 * time.Second,
-		withTicks:         2,
 		withAPIResponse: actionapi.Operations{
 			Operations: []actionapi.Operation{{
 				ID:     operationId,
@@ -209,7 +204,6 @@ tasks:
 		withClientQueryID: operationId,
 		withClientWait:    "1s",
 		withAPITimeout:    2 * time.Second,
-		withTicks:         1,
 		withAPIResponse: actionapi.Operations{
 			Operations: []actionapi.Operation{{
 				ID:      operationId,
@@ -260,7 +254,6 @@ tasks:
 		withAPITimeout:    5 * time.Second,
 		withClientWait:    "3s",
 		withAPIDelay:      1 * time.Second,
-		withTicks:         1,
 		withAPIResponse: actionapi.Operations{
 			Operations: []actionapi.Operation{{
 				ID:      operationId,
@@ -333,24 +326,6 @@ timing:
 				t.withAPIError,
 			)
 
-			numExpectedTimers := 0
-			// Ensure the api timeout timer is registered.
-			if t.withAPITimeout > 0 {
-				numExpectedTimers++
-			}
-			// And the api delay timer.
-			if t.withAPIDelay > 0 {
-				numExpectedTimers++
-			}
-			err := s.clock.WaitAdvance(0*time.Second, testing.ShortWait, numExpectedTimers)
-			c.Assert(err, jc.ErrorIsNil)
-
-			// Ensure the cmd max wait timer is registered. But this only happens
-			// during Run() so check for it later.
-			if t.withClientWait != "" {
-				numExpectedTimers++
-			}
-
 			s.testRunHelper(
 				c,
 				fakeClient,
@@ -361,8 +336,6 @@ timing:
 				t.withClientQueryID,
 				modelFlag,
 				t.watch,
-				t.withTicks,
-				numExpectedTimers,
 			)
 		}
 	}
@@ -370,7 +343,7 @@ timing:
 
 func (s *ShowOperationSuite) testRunHelper(c *gc.C, client *fakeAPIClient,
 	expectedErr, expectedOutput, format, wait, query, modelFlag string,
-	watch bool, numTicks int, numExpectedTimers int,
+	watch bool,
 ) {
 	unpatch := s.patchAPIClient(client)
 	defer unpatch()
@@ -398,14 +371,6 @@ func (s *ShowOperationSuite) testRunHelper(c *gc.C, client *fakeAPIClient,
 		ctx, err = cmdtesting.RunCommand(c, runCmd, args...)
 	}()
 
-	if numTicks > 0 {
-		numExpectedTimers += 1
-	}
-	for t := 0; t < numTicks; t++ {
-		err2 := s.clock.WaitAdvance(2*time.Second, testing.ShortWait, numExpectedTimers)
-		c.Assert(err2, jc.ErrorIsNil)
-		numExpectedTimers--
-	}
 	wg.Wait()
 
 	if expectedErr != "" {


### PR DESCRIPTION
Action unit tests would sometimes get stuck waiting indefinitely on heavily loaded systems using -race.
Using the dilated wall clock will ensure tests are less concerned with implementation, more concerned with the behaviour. 

## QA steps

Run unit tests in race with overloaded system.

## Documentation changes

N/A

## Bug reference

N/A