### PR TITLE
[JUJU-1678] Update juju-qa-test charm.

### DIFF
--- a/testcharms/charm-hub/charms/juju-qa-test/README.md
+++ b/testcharms/charm-hub/charms/juju-qa-test/README.md
@@ -6,46 +6,46 @@ A container-based V2 metadata charm to use in testing juju.
 
 ## Usage
 
-Basic deploy: <br>
-<code>juju deploy juju-qa-test</code>
+Basic deploy: 
+`juju deploy juju-qa-test`
 
-Set the unit status to the first line of the resource, if available, one time:<br>
-<code>juju config juju-qa-test foo-file=true</code>
+Set the unit status to the first line of the resource, if available, one time:
+`juju config juju-qa-test foo-file=true`
 
-Get your fortune<br>
-<code>juju run-action juju-qa-test/0 fortune</code>
+Get your fortune
+`juju run-action juju-qa-test/0 fortune`
 
 
 ## Version, Channel, Series and History
-|Version  |Channel          |Series				 
-|----      |----            |----               
-| 11|latest/stable|bionic, xenial|
-| 14|latest/candidate|focal, bionic, xenial|
-| 20|latest/edge|groovy, focal, bionic, xenial|
-|8   |2.0/stable  |disco, bionic, xenial, trusty |
-|10      |2.0/edge   |disco, bionic, xenial, trusty   |
+| Version | Channel          | Series                        |
+| ------- | ---------------- | ----------------------------- |
+| 11      | latest/stable    | bionic, xenial                |
+| 14      | latest/candidate | focal, bionic, xenial         |
+| 20      | latest/edge      | groovy, focal, bionic, xenial |
+| 8       | 2.0/stable       | disco, bionic, xenial, trusty |
+| 10      | 2.0/edge         | disco, bionic, xenial, trusty |
 
 ## Resource versions and contents
 
 Use `juju charm-resources juju-qa-test --channel <channel>` to determine resource to charm channel correlation.
 
-|Revision  |File Contents  | Notes
-|----      |----  |----
-|1      |testing one.                     
-|2      |testing two. 
-|3      |testing one plus one. | Will be used to replace Revision 1 in a channel
-| 4 | testing four.
+| Revision | File Contents         | Notes                                           |
+| -------- | --------------------- | ----------------------------------------------- |
+| 1        | testing one.          |
+| 2        | testing two.          |
+| 3        | testing one plus one. | Will be used to replace Revision 1 in a channel |
+| 4        | testing four.         |
 
 
 ## Deployment
 
 It is expected that you have charmcraft installed via
 
-<code>snap install charmcraft</code>
+`snap install charmcraft`
 
 Then cd in to testcharms/charm-hub/charms/juju-qa-test and run
 
-<code>
-charmcraft build
+```bash
+charmcraft pack
 juju deploy juju-qa-test.charm
-</code>
+```

--- a/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
@@ -7,6 +7,8 @@ bases:
           channel: "22.04"
       run-on: 
         - name: "ubuntu"
+          channel: "18.04"
+        - name: "ubuntu"
           channel: "20.04"
         - name: "ubuntu"
           channel: "22.04"

--- a/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
@@ -1,4 +1,12 @@
 type: charm
-charmhub:
-    api_url: https://api.charmhub.io
-    storage_url: https://storage.snapcraftcontent.com
+bases:
+    - build-on:
+        - name: "ubuntu"
+          channel: "20.04"
+        - name: "ubuntu"
+          channel: "22.04"
+      run-on: 
+        - name: "ubuntu"
+          channel: "20.04"
+        - name: "ubuntu"
+          channel: "22.04"

--- a/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
@@ -16,5 +16,3 @@ resources:
     type: file
     filename: foo.txt
     description: "foo resource."
-
-

--- a/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
@@ -7,7 +7,6 @@ summary: |
 description: |
   A container-based V2 metadata charm to use in testing juju.
   It has config, actions, resources, and a relation.
-series: [focal, jammy]
 requires:
   info:
     interface: juju-info

--- a/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/metadata.yaml
@@ -7,7 +7,7 @@ summary: |
 description: |
   A container-based V2 metadata charm to use in testing juju.
   It has config, actions, resources, and a relation.
-series: [groovy, focal, bionic, xenial]
+series: [focal, jammy]
 requires:
   info:
     interface: juju-info


### PR DESCRIPTION
Update the Juju-qa-test charm to support jammy and the latest `charmcraft 2.0.0`. This should help passing qa tests.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Pack the charm with charmcraft and deploy the local charm settings `--series=jammy`

```sh
cd testcharms/charm-hub/charms/juju-qa-test
charmcraft pack
juju deploy ./juju-qa-test_ubuntu-20.04-amd64_ubuntu-22.04-amd64.charm test-jammy --series=jammy
```

## Documentation changes
NA

## Bug reference

NA
