### PR TITLE
Update message while k8s units are settling down

### DIFF
--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -634,7 +634,7 @@ func (a *appWorker) refreshApplicationStatus(app caas.Application, appLife life.
 		// Only set status to waiting for scale up.
 		// When the application gets scaled down, the desired units will be kept running and
 		// the application should be active always.
-		return a.setApplicationStatus(status.Waiting, "waiting for units settled down", nil)
+		return a.setApplicationStatus(status.Waiting, "waiting for units to settle down", nil)
 	}
 	return a.setApplicationStatus(status.Active, "", nil)
 }

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -682,7 +682,7 @@ func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusNewUnitsAllocating(
 			c.Assert(len(unitsAPIResultSingleActive), gc.DeepEquals, 1)
 			return unitsAPIResultSingleActive, nil
 		}),
-		tc.facade.EXPECT().SetOperatorStatus("test", status.Waiting, "waiting for units settled down", nil).
+		tc.facade.EXPECT().SetOperatorStatus("test", status.Waiting, "waiting for units to settle down", nil).
 			DoAndReturn(func(string, status.Status, string, map[string]interface{}) error {
 				close(done)
 				return nil
@@ -767,7 +767,7 @@ func (s *ApplicationWorkerSuite) TestRefreshApplicationStatusTransitionFromWaiti
 			c.Assert(len(unitsAPIResultPartialActive), gc.DeepEquals, 3)
 			return unitsAPIResultPartialActive, nil
 		}),
-		tc.facade.EXPECT().SetOperatorStatus("test", status.Waiting, "waiting for units settled down", nil).
+		tc.facade.EXPECT().SetOperatorStatus("test", status.Waiting, "waiting for units to settle down", nil).
 			DoAndReturn(func(string, status.Status, string, map[string]interface{}) error {
 				err := tc.clock.WaitAdvance(10*time.Second, coretesting.ShortWait, 2)
 				c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Trivial change to update message while k8s units are settling down.