### PR TITLE
OpenStack auth: if we know it's a v3 server, don't fall back to v2 auth

### DIFF
--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -82,7 +82,7 @@ type Value struct {
 	// empty list will override any default tags, where a nil list will not.
 	Tags *[]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 
-	// InstanceRole, if not nil, indicates that the specificed role/profile for
+	// InstanceRole, if not nil, indicates that the specified role/profile for
 	// the given cloud should be used. Only valid for clouds which support
 	// instance roles. Currently only for AWS with instance-profiles
 	InstanceRole *string `json:"instance-role,omitempty" yaml:"instance-role,omitempty"`

--- a/provider/gce/environ_instance.go
+++ b/provider/gce/environ_instance.go
@@ -175,7 +175,7 @@ func (env *environ) parsePlacement(ctx context.ProviderCallContext, placement st
 	return nil, errors.Errorf("unknown placement directive: %v", placement)
 }
 
-// checkInstanceType is used to ensure the the provided constraints
+// checkInstanceType is used to ensure the provided constraints
 // specify a recognized instance type.
 func (env *environ) checkInstanceType(ctx context.ProviderCallContext, cons constraints.Value) bool {
 	if cons.InstanceType == nil || *cons.InstanceType == "" {

--- a/provider/openstack/client.go
+++ b/provider/openstack/client.go
@@ -130,7 +130,7 @@ func (c *ClientFactory) Init() error {
 	return nil
 }
 
-// AuthClient returns an goose AuthenticatingClient.
+// AuthClient returns a goose AuthenticatingClient.
 func (c *ClientFactory) AuthClient() client.AuthenticatingClient {
 	return c.authClient
 }
@@ -175,7 +175,7 @@ func (c *ClientFactory) getClientState(options ...ClientOption) (client.Authenti
 		}
 
 		// Walk over the options to verify if the AuthUserPassV3 exists, if it
-		// does exist use that to attempt authenticate.
+		// does exist use that to attempt authentication.
 		var authOption *identity.AuthOption
 		for _, option := range authOptions {
 			if option.Mode == identity.AuthUserPassV3 {
@@ -201,9 +201,13 @@ func (c *ClientFactory) getClientState(options ...ClientOption) (client.Authenti
 		}
 
 		// If the AuthUserPassV3 client can authenticate, use it.
-		// Otherwise fallback to the v2 client.
+		// Otherwise, fall back to the v2 client.
 		if err = newClientV3.Authenticate(); err == nil {
 			return newClientV3, nil
+		}
+		if identityClientVersion == 3 {
+			// We know it's a v3 server, so we can't fall back to v2.
+			return nil, errors.Trace(err)
 		}
 	}
 	return newClient, nil

--- a/provider/openstack/client.go
+++ b/provider/openstack/client.go
@@ -201,7 +201,6 @@ func (c *ClientFactory) getClientState(options ...ClientOption) (client.Authenti
 		}
 
 		// If the AuthUserPassV3 client can authenticate, use it.
-		// Otherwise, fall back to the v2 client.
 		if err = newClientV3.Authenticate(); err == nil {
 			return newClientV3, nil
 		}
@@ -209,6 +208,7 @@ func (c *ClientFactory) getClientState(options ...ClientOption) (client.Authenti
 			// We know it's a v3 server, so we can't fall back to v2.
 			return nil, errors.Trace(err)
 		}
+		// Otherwise, fall back to the v2 client.
 	}
 	return newClient, nil
 }

--- a/provider/openstack/client_test.go
+++ b/provider/openstack/client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-goose/goose/v5/client"
 	"github.com/go-goose/goose/v5/identity"
 	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -57,6 +58,54 @@ func (s *clientSuite) TestFactoryNeutron(c *gc.C) {
 	nova, err := factory.Neutron()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(nova, gc.NotNil)
+}
+
+func (s *clientSuite) TestFactoryAuthFallbackSuccess(c *gc.C) {
+	err := s.testFactoryAuthFallback(c, nil)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *clientSuite) TestFactoryAuthFallbackError(c *gc.C) {
+	err := s.testFactoryAuthFallback(c, errors.New("bad auth"))
+	c.Assert(err, gc.ErrorMatches, "bad auth")
+}
+
+func (s *clientSuite) testFactoryAuthFallback(c *gc.C, authErr error) error {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockClient := NewMockAuthenticatingClient(ctrl)
+	mockClient.EXPECT().SetRequiredServiceTypes([]string{"compute"}).AnyTimes()
+	mockClient.EXPECT().IdentityAuthOptions().Return(identity.AuthOptions{
+		{
+			Mode:     identity.AuthUserPassV3,
+			Endpoint: "https://sharedhost.foo:443/identity/v3/",
+		},
+	}, nil)
+	mockClient.EXPECT().Authenticate().Return(authErr)
+
+	mockConfig := NewMockSSLHostnameConfig(ctrl)
+	mockConfig.EXPECT().SSLHostnameVerification().Return(true).AnyTimes()
+
+	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+		CredAttrUserName:          "admin",
+		CredAttrPassword:          "password",
+		CredAttrProjectDomainName: "default",
+		CredAttrUserDomainName:    "",
+		CredAttrDomainName:        "default",
+		CredAttrVersion:           "2",
+	})
+
+	spec := environscloudspec.CloudSpec{
+		Region:     "default",
+		Endpoint:   "https://sharedhost.foo:443/identity/v3/",
+		Credential: &cred,
+	}
+
+	factory := NewClientFactory(spec, mockConfig)
+	factory.clientFunc = makeClientFunc(mockClient)
+
+	return factory.Init()
 }
 
 func (s *clientSuite) setupMockFactory(ctrl *gomock.Controller, times int) *ClientFactory {

--- a/provider/openstack/doc.go
+++ b/provider/openstack/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package openstack implements the OpenStack provider, registered with
+// environs under the name "openstack".
+package openstack


### PR DESCRIPTION
This slightly improves the error message during OpenStack authentication when the code is trying to authenticate against a v3 server but the credentials look like v2 credentials. Previously the code would fall back to using a v2 client and the next call would give a 404 error, now it doesn't fall back when it knows the server is v3 ("v3" in the URL) so we get a 401 authentication error immediately.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

* Set up an OpenStack cluster for testing (I used the single VM [devstack](https://docs.openstack.org/devstack/yoga/guides/single-vm.html) system using Multipass). This took at least 45 minutes to initialize the VM, set up all the packages, etc.
* Set up a Juju cloud using `juju add-cloud` with the novarc file method described [here](https://juju.is/docs/olm/openstack). The novarc file can be downloaded from the cluster's Dashboard, using the "Download OpenStack RC file" button under API Access.
* Add a credential, but make the password incorrect so auth is going to fail (I changed "password" to "passwordx").
* Try to `juju bootstrap openstack`.

However, here's where I started to run into trouble. First I got this error:

```
$ juju bootstrap openstack
ERROR cannot create a client: version part of identity url http://10.244.209.44/identity not valid
```

Fix is to update Juju's `clouds.yaml` regions endpoint from "endpoint: http://10.244.209.44/identity" to "endpoint: http://10.244.209.44/identity/v3". Not sure why this isn't included in the novarc correctly, as it's definitely a v3 endpoint.

The next error I got was

```
ERROR auth options fetching failed
caused by: request available auth options: request (http://10.244.209.44/) returned unexpected status: 200; error info: 

... lots of HTML output ...
```

This is because goose's client.baseURL is not set (""). It doesn't look like it can be set via config due to the use of NewClient, which is what's being used here. So you have to hack-fix goose [here](https://github.com/go-goose/goose/blob/e7e49e456da1f62c629a2fc6944fe96b2af94368/client/client.go#L701) (and use replace for goose in `go.mod`):

```diff
$ git diff
diff --git a/client/client.go b/client/client.go
index 2b10185..e812d3e 100644
--- a/client/client.go
+++ b/client/client.go
@@ -698,7 +698,7 @@ func (c *authenticatingClient) IdentityAuthOptions() (identity.AuthOptions, erro
                        return identity.AuthOptions{}, gooseerrors.Newf(err, "trying to determine auth information url")
                }
                // this cannot fail.
-               authInfoPath, _ := url.Parse("/")
+               authInfoPath, _ := url.Parse("/identity") // TODO
                baseURL = parsedURL.ResolveReference(authInfoPath).String()
        }
        authOptions, err := identity.FetchAuthOptions(baseURL, c.httpClient, c.logger)
```

I don't understand how this ever worked. I'm guessing that most OpenStack installs have a root of "/" (with the domain being `identity.foo.bar` or whatever), whereas with devstack you're using an IP address with a base URL of "/identity". I think Goose needs fixing here, but I've spent enough time on this now and don't really know what the correct fix is anyway.

With those two fixes in place, now when you `juju bootstrap openstack` you'll actually see the issue at hand.

```
# BEFORE fix
$ juju bootstrap openstack
ERROR authentication failed.: authentication failed
caused by: requesting token failed
caused by: Resource at http://10.244.209.44/identity/v3/tokens not found
caused by: request (http://10.244.209.44/identity/v3/tokens) returned unexpected status: 404; error info: <!doctype html>
<html lang=en>
<title>404 Not Found</title>
<h1>Not Found</h1>
<p>The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.</p>

# AFTER fix
$ juju bootstrap openstack
ERROR authentication failed
caused by: requesting token: Unauthorised URL http://10.244.209.44/identity/v3/auth/tokens
caused by: request (http://10.244.209.44/identity/v3/auth/tokens) returned unexpected status: 401; error info: Failed: 401 error: The request you have made requires authentication.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1980474