### PR TITLE
Remove tests that test testing infrastructure.

### DIFF
--- a/cmd/juju/action/exec_test.go
+++ b/cmd/juju/action/exec_test.go
@@ -758,7 +758,7 @@ mysql/0:
 }
 
 func testClock() testclock.AdvanceableClock {
-	return testclock.NewDilatedWallClock(10 * time.Millisecond)
+	return testclock.NewDilatedWallClock(100 * time.Millisecond)
 }
 
 func (s *ExecSuite) TestBlockAllMachines(c *gc.C) {

--- a/cmd/juju/action/showoperation_test.go
+++ b/cmd/juju/action/showoperation_test.go
@@ -85,7 +85,7 @@ func (s *ShowOperationSuite) TestRun(c *gc.C) {
 	}{{
 		should:            "timeout if result never comes",
 		withClientWait:    "2s",
-		withAPIDelay:      3 * time.Second,
+		withAPIDelay:      10 * time.Second,
 		withClientQueryID: operationId,
 		withAPIResponse: actionapi.Operations{
 			Operations: []actionapi.Operation{{
@@ -224,7 +224,7 @@ tasks:
 	}, {
 		should:            "set an appropriate timer and wait, get a result",
 		withClientQueryID: operationId,
-		withClientWait:    "3s",
+		withClientWait:    "10s",
 		withAPIDelay:      1 * time.Second,
 		withAPIResponse: actionapi.Operations{
 			Operations: []actionapi.Operation{{

--- a/cmd/juju/action/showtask_test.go
+++ b/cmd/juju/action/showtask_test.go
@@ -84,7 +84,7 @@ func (s *ShowTaskSuite) TestRun(c *gc.C) {
 	}{{
 		should:            "timeout if result never comes",
 		withClientWait:    "2s",
-		withAPIDelay:      3 * time.Second,
+		withAPIDelay:      10 * time.Second,
 		withClientQueryID: validActionId,
 		withAPIResponse:   []actionapi.ActionResult{{Status: "pending"}},
 		expectedErr:       "maximum wait time reached",
@@ -243,7 +243,7 @@ hello
 	}, {
 		should:            "set an appropriate timer and wait, get a result",
 		withClientQueryID: validActionId,
-		withClientWait:    "3s",
+		withClientWait:    "10s",
 		withAPIDelay:      1 * time.Second,
 		withAPIResponse: []actionapi.ActionResult{{
 			Status: "completed",

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -621,7 +621,10 @@ func (s *SecretsSuite) TestGetSecretRevision(c *gc.C) {
 	r, err := s.store.GetSecretRevision(uri, 2)
 	c.Assert(err, jc.ErrorIsNil)
 	updateTime := now.Add(time.Hour)
-	c.Assert(r, jc.DeepEquals, &secrets.SecretRevisionMetadata{
+	mc := jc.NewMultiChecker()
+	mc.AddExpr(`_.CreateTime`, jc.Almost, jc.ExpectedValue)
+	mc.AddExpr(`_.UpdateTime`, jc.Almost, jc.ExpectedValue)
+	c.Assert(r, mc, &secrets.SecretRevisionMetadata{
 		Revision:   2,
 		CreateTime: updateTime,
 		UpdateTime: updateTime,


### PR DESCRIPTION
API timeout testing logic doesn't need to be tested.
Use long testing duration by default.

## QA steps

On my machine
`stress --cpu 96 --timeout 60s` and run tests in a while loop until they fail.
With these fixes they don't fail, even though the system is heavily loaded.

## Documentation changes

N/A

## Bug reference

N/A
