### PR TITLE
[JUJU-1687] Fix issues running actions with commit failures

### DIFF
--- a/cmd/juju/commands/exec.go
+++ b/cmd/juju/commands/exec.go
@@ -412,6 +412,7 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 		}
 		_, _ = ctx.Stdout.Write(formatOutput(result, stdoutKey, c.compat))
 		_, _ = ctx.Stderr.Write(formatOutput(result, stderrKey, c.compat))
+		_, _ = ctx.Stdout.Write([]byte("\n"))
 		if code, ok := result[codeKey].(int); ok && code != 0 {
 			return cmd.NewRcPassthroughError(code)
 		}
@@ -422,6 +423,7 @@ func (c *execCommand) Run(ctx *cmd.Context) error {
 		}
 		if res, ok := result[messageKey].(string); ok && res != "" {
 			_, _ = ctx.Stderr.Write([]byte(res))
+			_, _ = ctx.Stdout.Write([]byte("\n"))
 		}
 
 		return nil

--- a/cmd/juju/commands/exec_test.go
+++ b/cmd/juju/commands/exec_test.go
@@ -639,8 +639,8 @@ func (s *ExecSuite) TestSingleResponse(c *gc.C) {
 	mock := s.setupMockAPI()
 	mock.setMachinesAlive("0")
 	mockResponse := mockResponse{
-		stdout:     "stdout\n",
-		stderr:     "stderr\n",
+		stdout:     "stdout",
+		stderr:     "stderr",
 		code:       "42",
 		machineTag: "machine-0",
 	}
@@ -673,7 +673,7 @@ func (s *ExecSuite) TestSingleResponse(c *gc.C) {
 	}{{
 		message:    "smart (default)",
 		stdout:     "stdout\n",
-		stderr:     "stderr\n",
+		stderr:     "stderr",
 		errorMatch: "subprocess encountered error code 42",
 	}, {
 		message: "yaml output",

--- a/worker/uniter/actions/resolver.go
+++ b/worker/uniter/actions/resolver.go
@@ -4,6 +4,9 @@
 package actions
 
 import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/worker/common/charmrunner"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/remotestate"
 	"github.com/juju/juju/worker/uniter/resolver"
@@ -49,7 +52,7 @@ func (r *actionsResolver) NextOp(
 	localState resolver.LocalState,
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
-) (operation.Operation, error) {
+) (op operation.Operation, err error) {
 	// During CAAS unit initialization action operations are
 	// deferred until the unit is running. If the remote charm needs
 	// updating, hold off on action running.
@@ -74,6 +77,18 @@ func (r *actionsResolver) NextOp(
 	if err != nil && err != resolver.ErrNoOperation {
 		return nil, err
 	}
+
+	defer func() {
+		if errors.Cause(err) == charmrunner.ErrActionNotAvailable {
+			if localState.Step == operation.Pending {
+				r.logger.Infof("found missing action %v; ignoring", *localState.ActionId)
+				op, err = opFactory.NewFailAction(*localState.ActionId)
+			} else {
+				err = resolver.ErrNoOperation
+			}
+		}
+	}()
+
 	switch localState.Kind {
 	case operation.RunHook:
 		// We can still run actions if the unit is in a hook error state.

--- a/worker/uniter/actions/resolver_test.go
+++ b/worker/uniter/actions/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/worker/common/charmrunner"
 	"github.com/juju/juju/worker/uniter/actions"
 	"github.com/juju/juju/worker/uniter/hook"
 	"github.com/juju/juju/worker/uniter/operation"
@@ -159,7 +160,7 @@ func (s *actionsSuite) TestNextActionBlockedRemoteInitSkipHook(c *gc.C) {
 
 func (s *actionsSuite) TestActionStateKindRunAction(c *gc.C) {
 	actionResolver := s.newResolver()
-	var actionA string = "actionA"
+	actionA := "actionA"
 
 	localState := resolver.LocalState{
 		State: operation.State{
@@ -173,12 +174,12 @@ func (s *actionsSuite) TestActionStateKindRunAction(c *gc.C) {
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(op, jc.DeepEquals, mockOp("actionA"))
+	c.Assert(op, jc.DeepEquals, mockOp(actionA))
 }
 
 func (s *actionsSuite) TestActionStateKindRunActionSkipHook(c *gc.C) {
 	actionResolver := s.newResolver()
-	var actionA string = "actionA"
+	actionA := "actionA"
 
 	localState := resolver.LocalState{
 		State: operation.State{
@@ -198,7 +199,7 @@ func (s *actionsSuite) TestActionStateKindRunActionSkipHook(c *gc.C) {
 
 func (s *actionsSuite) TestActionStateKindRunActionPendingRemote(c *gc.C) {
 	actionResolver := s.newResolver()
-	var actionA string = "actionA"
+	actionA := "actionA"
 
 	localState := resolver.LocalState{
 		State: operation.State{
@@ -208,11 +209,31 @@ func (s *actionsSuite) TestActionStateKindRunActionPendingRemote(c *gc.C) {
 		CompletedActions: map[string]struct{}{},
 	}
 	remoteState := remotestate.Snapshot{
-		ActionsPending: []string{"actionA", "actionB"},
+		ActionsPending: []string{actionA, "actionB"},
 	}
 	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(op, jc.DeepEquals, mockFailAction("actionA"))
+	c.Assert(op, jc.DeepEquals, mockFailAction(actionA))
+}
+
+func (s *actionsSuite) TestPendingActionNotAvailable(c *gc.C) {
+	actionResolver := s.newResolver()
+	actionA := "666"
+
+	localState := resolver.LocalState{
+		State: operation.State{
+			Kind:     operation.RunAction,
+			Step:     operation.Pending,
+			ActionId: &actionA,
+		},
+		CompletedActions: map[string]struct{}{},
+	}
+	remoteState := remotestate.Snapshot{
+		ActionsPending: []string{"666"},
+	}
+	op, err := actionResolver.NextOp(localState, remoteState, &mockOperations{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op, jc.DeepEquals, mockFailAction(actionA))
 }
 
 type mockOperations struct {
@@ -220,6 +241,9 @@ type mockOperations struct {
 }
 
 func (m *mockOperations) NewAction(id string) (operation.Operation, error) {
+	if id == "666" {
+		return nil, charmrunner.ErrActionNotAvailable
+	}
 	return mockOp(id), nil
 }
 


### PR DESCRIPTION
When running an action, eg via juju exec, errors committing hook changes resulted in a unit agent error loop due to the pending action remaining in the uniter FSM; the action id was no longer found and the resolver didn't handle that properly.
Also, the commit error is not part of the action itself, so we need to add the error to the action results and set the return code to fail.
Also fix an unnecessary workaround for an import loop that no longer exists.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

I had to hack the context flush to return an error as the condition to cause the flush to fail is not easily produced.
deploy ubuntu charm
```sh
juju exec --unit ubuntu/0 "pwd"
/var/lib/juju/agents/unit-ubuntu-0/charm
flush failed

juju exec --unit ubuntu/0 "pwd" --format yaml
- message: committing requested changes failed
  return-code: 1
  stderr: flush failed
  stdout: |
    /var/lib/juju/agents/unit-ubuntu-0/charm
  unit: ubuntu/0
```

