### PR TITLE
[JUJU-1683] Add run_model_migration_version bash test

### DIFF
--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -81,9 +81,9 @@ run_deploy_revision_upgrade() {
 
 	# Ensure that refresh gets the revision from the channel
 	# listed at deploy.
-	# revision 15 is in channel latest/edge
+	# revision 21 is in channel latest/edge
 	juju refresh juju-qa-test
-	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 15)"
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 21)"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -56,14 +56,15 @@ run_model_migration() {
 run_model_migration_version() {
 	# Reset JUJU_VERSION and SHORT_GIT_COMMIT for stable bootstrap
 	unset SHORT_GIT_COMMIT
-	export JUJU_VERSION=$(echo $JUJU_VERSION | sed "s/.$JUJU_BUILD_NUMBER//")
-	major_minor=$(echo $JUJU_VERSION |  cut -d'-' -f1 | cut -d'.' -f1,2)
-	
+	juju_version_without_build_number=$(echo "$JUJU_VERSION" | sed "s/.$JUJU_BUILD_NUMBER//")
+	export JUJU_VERSION=$juju_version_without_build_number
+	major_minor=$(echo "$JUJU_VERSION" | cut -d'-' -f1 | cut -d'.' -f1,2)
+
 	# test against beta channel for devel
 	# TODO: change back to stable once 3.0 released.
 	# channel="$major_minor/beta"  # 3.0
-	channel="$major_minor/stable"  # 2.9
-	
+	channel="$major_minor/stable" # 2.9
+
 	stable_version=$(snap info juju | yq ".channels[\"$channel\"]" | cut -d' ' -f1)
 	echo "stable_version ==> $stable_version"
 	if [[ $stable_version == "--" || $stable_version == null ]]; then
@@ -71,19 +72,19 @@ run_model_migration_version() {
 		exit 0
 	fi
 	export JUJU_VERSION=$stable_version
-	
+
 	# Unset to re-generate from the new agent-version.
 	unset BOOTSTRAP_ADDITIONAL_ARGS
 	# Ensure we have another controller available.
 	bootstrap_alt_controller "alt-model-migration-version-stable"
 	juju --show-log switch "alt-model-migration-version-stable"
 	juju --show-log add-model "model-migration-version-stable"
-	
+
 	juju --show-log deploy easyrsa
 	juju --show-log deploy etcd
 	juju --show-log add-relation etcd easyrsa
 	juju --show-log add-unit -n 2 etcd
-	
+
 	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
 	wait_for "easyrsa" "$(idle_condition "easyrsa" 0)"
 	wait_for "active" '.applications["etcd"] | ."application-status".current'
@@ -94,10 +95,10 @@ run_model_migration_version() {
 	wait_for "active" "$(workload_status "etcd" 0).current"
 	wait_for "active" "$(workload_status "etcd" 1).current"
 	wait_for "active" "$(workload_status "etcd" 2).current"
-	
+
 	# juju --show-log run etcd/0 etcd/1 etcd/2 --wait=5m health  # 3.0
-	juju --show-log run-action etcd/0 etcd/1 etcd/2 --wait=5m health  # 2.9
-	
+	juju --show-log run-action etcd/0 etcd/1 etcd/2 --wait=5m health # 2.9
+
 	juju --show-log migrate "model-migration-version-stable" "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
 	juju --show-log switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
 
@@ -106,12 +107,12 @@ run_model_migration_version() {
 
 	# Once the model has appeared, switch to it.
 	juju --show-log switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}:model-migration-version-stable"
-	
+
 	wait_for "easyrsa" "$(idle_condition "easyrsa" 0)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 1)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 2)"
-	
+
 	# Add a unit to etcd to ensure the model is functional
 	juju add-unit -n 2 etcd
 	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
@@ -119,7 +120,7 @@ run_model_migration_version() {
 	wait_for "etcd" "$(idle_condition "etcd" 1 2)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 3)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 4)"
-	
+
 	wait_for "active" "$(workload_status "etcd" 0).current"
 	wait_for "active" "$(workload_status "etcd" 1).current"
 	wait_for "active" "$(workload_status "etcd" 2).current"
@@ -127,11 +128,11 @@ run_model_migration_version() {
 	wait_for "active" "$(workload_status "etcd" 4).current"
 
 	# juju --show-log run etcd/0 etcd/1 etcd/2 etcd/3 etcd/4 --wait=50m health  # 3.0
-	juju --show-log run-action etcd/0 etcd/1 etcd/2 etcd/3 etcd/4 --wait=50m health  # 2.9
-	
+	juju --show-log run-action etcd/0 etcd/1 etcd/2 etcd/3 etcd/4 --wait=50m health # 2.9
+
 	# Clean up.
 	destroy_controller "alt-model-migration-version-stable"
-	
+
 	destroy_model "model-migration-version-stable"
 }
 

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -57,16 +57,13 @@ run_model_migration_version() {
 	# Reset JUJU_VERSION and SHORT_GIT_COMMIT for stable bootstrap
 	unset SHORT_GIT_COMMIT
 	export JUJU_VERSION=$(echo $JUJU_VERSION | sed "s/.$JUJU_BUILD_NUMBER//")
-	echo "JUJU_VERSION ==> $JUJU_VERSION"
 	major_minor=$(echo $JUJU_VERSION |  cut -d'-' -f1 | cut -d'.' -f1,2)
-	echo "major_minor ==> $major_minor"
 	
 	# test against beta channel for devel
 	# TODO: change back to stable once 3.0 released.
 	# channel="$major_minor/beta"  # 3.0
 	channel="$major_minor/stable"  # 2.9
 	
-	echo "channel ==> $channel"
 	stable_version=$(snap info juju | yq ".channels[\"$channel\"]" | cut -d' ' -f1)
 	echo "stable_version ==> $stable_version"
 	if [[ $stable_version == "--" || $stable_version == null ]]; then
@@ -336,11 +333,11 @@ test_model_migration() {
 
 		cd .. || exit
 
-		# run "run_model_migration"
+		run "run_model_migration"
 		run "run_model_migration_version"
-		# run "run_model_migration_saas_common"
-		# run "run_model_migration_saas_external"
-		# run "run_model_migration_saas_consumer"
+		run "run_model_migration_saas_common"
+		run "run_model_migration_saas_external"
+		run "run_model_migration_saas_consumer"
 	)
 }
 

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -47,6 +47,97 @@ run_model_migration() {
 	destroy_model "model-migration"
 }
 
+# Migrating an active model from stable to devel controller (twice).
+# Method:
+#   - Bootstraps a devel controller
+#   - Bootstraps the provided stable controller deploys an active application
+#   - Migrates from stable -> devel controller
+#   - Asserts the deployed application continues to work
+run_model_migration_version() {
+	# Reset JUJU_VERSION and SHORT_GIT_COMMIT for stable bootstrap
+	unset SHORT_GIT_COMMIT
+	export JUJU_VERSION=$(echo $JUJU_VERSION | sed "s/.$JUJU_BUILD_NUMBER//")
+	echo "JUJU_VERSION ==> $JUJU_VERSION"
+	major_minor=$(echo $JUJU_VERSION |  cut -d'-' -f1 | cut -d'.' -f1,2)
+	echo "major_minor ==> $major_minor"
+	
+	# test against beta channel for devel
+	# TODO: change back to stable once 3.0 released.
+	# channel="$major_minor/beta"  # 3.0
+	channel="$major_minor/stable"  # 2.9
+	
+	echo "channel ==> $channel"
+	stable_version=$(snap info juju | yq ".channels[\"$channel\"]" | cut -d' ' -f1)
+	echo "stable_version ==> $stable_version"
+	if [[ $stable_version == "--" || $stable_version == null ]]; then
+		echo "==> SKIP: run_model_migration_version because $channel is not published yet!"
+		exit 0
+	fi
+	export JUJU_VERSION=$stable_version
+	
+	# Unset to re-generate from the new agent-version.
+	unset BOOTSTRAP_ADDITIONAL_ARGS
+	# Ensure we have another controller available.
+	bootstrap_alt_controller "alt-model-migration-version-stable"
+	juju --show-log switch "alt-model-migration-version-stable"
+	juju --show-log add-model "model-migration-version-stable"
+	
+	juju --show-log deploy easyrsa
+	juju --show-log deploy etcd
+	juju --show-log add-relation etcd easyrsa
+	juju --show-log add-unit -n 2 etcd
+	
+	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
+	wait_for "easyrsa" "$(idle_condition "easyrsa" 0)"
+	wait_for "active" '.applications["etcd"] | ."application-status".current'
+	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 1)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 2)"
+
+	wait_for "active" "$(workload_status "etcd" 0).current"
+	wait_for "active" "$(workload_status "etcd" 1).current"
+	wait_for "active" "$(workload_status "etcd" 2).current"
+	
+	# juju --show-log run etcd/0 etcd/1 etcd/2 --wait=5m health  # 3.0
+	juju --show-log run-action etcd/0 etcd/1 etcd/2 --wait=5m health  # 2.9
+	
+	juju --show-log migrate "model-migration-version-stable" "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+	juju --show-log switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+
+	# Wait for the new model migration to appear in the devel controller.
+	wait_for_model "model-migration-version-stable"
+
+	# Once the model has appeared, switch to it.
+	juju --show-log switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}:model-migration-version-stable"
+	
+	wait_for "easyrsa" "$(idle_condition "easyrsa" 0)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 1)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 2)"
+	
+	# Add a unit to etcd to ensure the model is functional
+	juju add-unit -n 2 etcd
+	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 1)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 2)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 3)"
+	wait_for "etcd" "$(idle_condition "etcd" 1 4)"
+	
+	wait_for "active" "$(workload_status "etcd" 0).current"
+	wait_for "active" "$(workload_status "etcd" 1).current"
+	wait_for "active" "$(workload_status "etcd" 2).current"
+	wait_for "active" "$(workload_status "etcd" 3).current"
+	wait_for "active" "$(workload_status "etcd" 4).current"
+
+	# juju --show-log run etcd/0 etcd/1 etcd/2 etcd/3 etcd/4 --wait=50m health  # 3.0
+	juju --show-log run-action etcd/0 etcd/1 etcd/2 etcd/3 etcd/4 --wait=50m health  # 2.9
+	
+	# Clean up.
+	destroy_controller "alt-model-migration-version-stable"
+	
+	destroy_model "model-migration-version-stable"
+}
+
 # Migrating a model that is the offerer of a cross-model relation
 # consumed by another model on the same controller.
 run_model_migration_saas_common() {
@@ -245,10 +336,11 @@ test_model_migration() {
 
 		cd .. || exit
 
-		run "run_model_migration"
-		run "run_model_migration_saas_common"
-		run "run_model_migration_saas_external"
-		run "run_model_migration_saas_consumer"
+		# run "run_model_migration"
+		run "run_model_migration_version"
+		# run "run_model_migration_saas_common"
+		# run "run_model_migration_saas_external"
+		# run "run_model_migration_saas_consumer"
 	)
 }
 


### PR DESCRIPTION
Add a new bash test for model migration from the stable to current build.

Drive-by: Fix refreshed revision to 21 for juju-qa-test.

## QA steps

```console
$ JUJU_VERSION=2.9.34.666 JUJU_BUILD_NUMBER=666 ./main.sh -v -x output.txt -s '"test_model_config,test_model_destroy,test_model_metrics,test_model_multi"' model test_model_migration
```

