### PR TITLE
[JUJU-1693] Add secret-get --metadata and enforce label uniqueness

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -47,6 +47,9 @@ func (s *SecretsManagerAPI) CreateSecrets(args params.CreateSecretArgs) (params.
 	for i, arg := range args.Args {
 		ID, err := s.createSecret(ctx, arg)
 		result.Results[i].Result = ID
+		if errors.Is(err, state.LabelExists) {
+			err = errors.AlreadyExistsf("secret with label %q", *arg.Label)
+		}
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil
@@ -118,6 +121,9 @@ func (s *SecretsManagerAPI) UpdateSecrets(args params.UpdateSecretArgs) (params.
 	ctx := context.Background()
 	for i, arg := range args.Args {
 		err := s.updateSecret(ctx, arg)
+		if errors.Is(err, state.LabelExists) {
+			err = errors.AlreadyExistsf("secret with label %q", *arg.Label)
+		}
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -541,32 +541,32 @@ func allCollections() CollectionSchema {
 		cloudServicesC: {},
 
 		secretMetadataC: {
-			global: true,
 			indexes: []mgo.Index{{
-				Key: []string{"controller-uuid", "model-uuid", "_id"},
+				Key: []string{"model-uuid", "_id"},
 			}},
 		},
 
 		secretRevisionsC: {
-			global: true,
+			indexes: []mgo.Index{{
+				Key: []string{"revision", "_id"},
+			}},
 		},
 
 		secretConsumersC: {
 			indexes: []mgo.Index{{
-				Key: []string{"consumer-tag"},
+				Key: []string{"consumer-tag", "model-uuid"},
 			}},
 		},
 
 		secretPermissionsC: {
 			indexes: []mgo.Index{{
-				Key: []string{"subject-tag", "scope-tag"},
+				Key: []string{"subject-tag", "scope-tag", "model-uuid"},
 			}},
 		},
 
 		secretRotateC: {
-			global: true,
 			indexes: []mgo.Index{{
-				Key: []string{"owner-tag"},
+				Key: []string{"owner-tag", "model-uuid"},
 			}},
 		},
 

--- a/state/application.go
+++ b/state/application.go
@@ -691,6 +691,11 @@ func (a *Application) removeOps(asserts bson.D, op *ForcedOperation) ([]txn.Op, 
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, secretPermissionsOps...)
+	secretLabelOps, err := a.st.removeOwnerSecretLabelOps(a.ApplicationTag())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, secretLabelOps...)
 
 	// Note that appCharmDecRefOps might not catch the final decref
 	// when run in a transaction that decrefs more than once. So we
@@ -2717,6 +2722,10 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	if op.FatalError(err) {
 		return nil, errors.Trace(err)
 	}
+	secretLabelOps, err := a.st.removeOwnerSecretLabelOps(u.Tag())
+	if op.FatalError(err) {
+		return nil, errors.Trace(err)
+	}
 
 	observedFieldsMatch := bson.D{
 		{"charmurl", u.doc.CharmURL},
@@ -2743,6 +2752,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	ops = append(ops, resOps...)
 	ops = append(ops, hostOps...)
 	ops = append(ops, secretPermissionsOps...)
+	ops = append(ops, secretLabelOps...)
 
 	m, err := a.st.Model()
 	if err != nil {

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3245,6 +3245,7 @@ func (s *ApplicationSuite) TestDestroyAlsoDeletesOwnedSecrets(c *gc.C) {
 		Owner:   s.mysql.Tag().String(),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken: &fakeToken{},
+			Label:       ptr("label"),
 			Data:        map[string]string{"foo": "bar"},
 		},
 	}
@@ -3253,8 +3254,10 @@ func (s *ApplicationSuite) TestDestroyAlsoDeletesOwnedSecrets(c *gc.C) {
 
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = store.GetSecret(uri)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	// Create again, no label clash.
+	s.AddTestingApplication(c, "mysql", s.charm)
+	_, err = store.CreateSecret(uri, cp)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *ApplicationSuite) TestApplicationCleanupRemovesStorageConstraints(c *gc.C) {

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -87,8 +87,35 @@ func (s *SecretsSuite) TestCreate(c *gc.C) {
 		UpdateTime:       now,
 	})
 
+	p.Label = nil
 	_, err = s.store.CreateSecret(uri, p)
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+}
+
+func (s *SecretsSuite) TestCreateDuplicateLabel(c *gc.C) {
+	uri := secrets.NewURI()
+	uri.ControllerUUID = s.State.ControllerUUID()
+	now := s.Clock.Now().Round(time.Second).UTC()
+	p := state.CreateSecretParams{
+		Version: 1,
+		Owner:   s.owner.Tag().String(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken:    &fakeToken{},
+			RotatePolicy:   ptr(secrets.RotateDaily),
+			NextRotateTime: ptr(now.Add(time.Minute)),
+			Description:    ptr("my secret"),
+			Label:          ptr("foobar"),
+			ExpireTime:     ptr(now.Add(time.Hour)),
+			Params:         nil,
+			Data:           map[string]string{"foo": "bar"},
+		},
+	}
+	_, err := s.store.CreateSecret(uri, p)
+	c.Assert(err, jc.ErrorIsNil)
+	uri2 := secrets.NewURI()
+	uri2.ControllerUUID = s.State.ControllerUUID()
+	_, err = s.store.CreateSecret(uri2, p)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
 }
 
 func (s *SecretsSuite) TestCreateDyingOwner(c *gc.C) {
@@ -311,6 +338,39 @@ func (s *SecretsSuite) TestUpdateExpiry(c *gc.C) {
 		LeaderToken: &fakeToken{},
 		ExpireTime:  ptr(now.Add(time.Minute)),
 	})
+}
+
+func (s *SecretsSuite) TestUpdateDuplicateLabel(c *gc.C) {
+	uri := secrets.NewURI()
+	uri.ControllerUUID = s.State.ControllerUUID()
+	cp := state.CreateSecretParams{
+		Version: 1,
+		Owner:   s.owner.Tag().String(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken: &fakeToken{},
+			Label:       ptr("label"),
+			Description: ptr("description"),
+			Data:        map[string]string{"foo": "bar"},
+		},
+	}
+	_, err := s.store.CreateSecret(uri, cp)
+	c.Assert(err, jc.ErrorIsNil)
+	uri2 := secrets.NewURI()
+	uri2.ControllerUUID = s.State.ControllerUUID()
+	cp.Label = ptr("label2")
+	_, err = s.store.CreateSecret(uri2, cp)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.store.UpdateSecret(uri, state.UpdateSecretParams{
+		LeaderToken: &fakeToken{},
+		Label:       ptr("label2"),
+	})
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+
+	_, err = s.store.UpdateSecret(uri, state.UpdateSecretParams{
+		LeaderToken: &fakeToken{},
+		Label:       ptr("label"),
+	})
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *SecretsSuite) TestUpdateData(c *gc.C) {
@@ -858,7 +918,7 @@ func (s *SecretsSuite) TestDelete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that other secret info remains intact.
-	secretRevisionsCollection, closer := state.GetRawCollection(s.State, "secretRevisions")
+	secretRevisionsCollection, closer := state.GetCollection(s.State, "secretRevisions")
 	defer closer()
 	n, err := secretRevisionsCollection.FindId(uri2.ID + "/1").Count()
 	c.Assert(err, jc.ErrorIsNil)
@@ -867,7 +927,7 @@ func (s *SecretsSuite) TestDelete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
 
-	secretRotateCollection, closer := state.GetRawCollection(s.State, "secretRotate")
+	secretRotateCollection, closer := state.GetCollection(s.State, "secretRotate")
 	defer closer()
 	n, err = secretRotateCollection.FindId(uri2.ID).Count()
 	c.Assert(err, jc.ErrorIsNil)
@@ -876,30 +936,30 @@ func (s *SecretsSuite) TestDelete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
 
-	secretConsumersCollection, closer := state.GetRawCollection(s.State, "secretConsumers")
+	secretConsumersCollection, closer := state.GetCollection(s.State, "secretConsumers")
 	defer closer()
-	n, err = secretConsumersCollection.FindId(state.DocID(s.State, uri2.ID) + "#unit-mariadb-0").Count()
+	n, err = secretConsumersCollection.FindId(uri2.ID + "#unit-mariadb-0").Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
 	n, err = secretConsumersCollection.Find(nil).Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
 
-	secretPermissionsCollection, closer := state.GetRawCollection(s.State, "secretPermissions")
+	secretPermissionsCollection, closer := state.GetCollection(s.State, "secretPermissions")
 	defer closer()
-	n, err = secretPermissionsCollection.FindId(state.DocID(s.State, uri2.ID) + "#application-wordpress").Count()
+	n, err = secretPermissionsCollection.FindId(uri2.ID + "#application-wordpress").Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
 	n, err = secretPermissionsCollection.Find(nil).Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
 
-	refCountsCollection, closer := state.GetRawCollection(s.State, "refcounts")
+	refCountsCollection, closer := state.GetCollection(s.State, "refcounts")
 	defer closer()
-	n, err = refCountsCollection.FindId(state.DocID(s.State, uri2.ID) + "#consumer").Count()
+	n, err = refCountsCollection.FindId(uri2.ID + "#consumer").Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 1)
-	n, err = refCountsCollection.FindId(state.DocID(s.State, uri1.ID) + "#consumer").Count()
+	n, err = refCountsCollection.FindId(uri1.ID + "#consumer").Count()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(n, gc.Equals, 0)
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1308,8 +1308,7 @@ func (ctx *HookContext) doFlush(process string) error {
 	commitReq, numChanges := b.Build()
 	if numChanges > 0 {
 		if err := ctx.unit.CommitHookChanges(commitReq); err != nil {
-			err = errors.Annotatef(err, "cannot apply changes")
-			ctx.logger.Errorf("%v", err)
+			ctx.logger.Errorf("cannot apply changes: %v", err)
 			return errors.Trace(err)
 		}
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -894,7 +894,7 @@ func (s *mockHookContextSuite) TestActionFlushError(c *gc.C) {
 				Status:    "failed",
 				Message:   "committing requested changes failed",
 				Results: map[string]interface{}{
-					"stderr":      "cannot apply changes: flush failed",
+					"stderr":      "flush failed",
 					"return-code": "1",
 				},
 			}}})


### PR DESCRIPTION
Add a new `secret-get --metadata` command to fetch just secret metadata.
Also enforce unique labels.
And cleanup some issues with the secret collections in mongo.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

deploy ubuntu charm
```
juju exec --unit ubuntu/0 "secret-add data=foo --label=foo"
secret:cc452i9vd6n21aea8d00

juju exec --unit ubuntu/0 "secret-get secret:cc452i9vd6n21aea8d00"
data: foo

juju exec --unit ubuntu/0 "secret-get secret:cc452i9vd6n21aea8d00 --metadata"
cc452i9vd6n21aea8d00:
  revision: 1
  label: foo
  rotation: never

juju exec --unit ubuntu/0 "secret-get secret:cc452i9vd6n21aea8d00 --metadata --label foo"
ERROR specify either a secret URI or label but not both to fetch metadata

juju exec --unit ubuntu/0 "secret-get --metadata --label foo"
cc452i9vd6n21aea8d00:
  revision: 1
  label: foo
  rotation: never

juju exec --unit ubuntu/0 "secret-add data=foo --label=foo"
ERROR secret with label "foo" already exists
```
