### PR TITLE
[JUJU-1697] Update test with new charm revisions which support focal and jammy.

### DIFF
--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -6,9 +6,9 @@ run_deploy_revision() {
 
 	ensure "${model_name}" "${file}"
 
-	# revision 9 is in channel 2.0/edge
-	juju deploy juju-qa-test --revision 9 --channel 2.0/stable
-	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
+	# revision 23 is in channel 2.0/edge
+	juju deploy juju-qa-test --revision 23 --channel 2.0/stable
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 23)"
 
 	# check resource revision per channel specified.
 	got=$(juju resources juju-qa-test --format json | jq -S '.resources[0] | .["revision"] == "1"')
@@ -33,9 +33,9 @@ run_deploy_revision_resource() {
 
 	ensure "${model_name}" "${file}"
 
-	# revision 9 is in channel 2.0/edge
-	juju deploy juju-qa-test --revision 9 --channel 2.0/stable --resource foo-file=4
-	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
+	# revision 23 is in channel 2.0/edge
+	juju deploy juju-qa-test --revision 23 --channel 2.0/stable --resource foo-file=4
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 23)"
 
 	# check resource revision as specified in command.
 	got=$(juju resources juju-qa-test --format json | jq -S '.resources[0] | .["revision"] == "4"')
@@ -75,15 +75,15 @@ run_deploy_revision_upgrade() {
 
 	ensure "${model_name}" "${file}"
 
-	# revision 9 is in channel 2.0/edge
-	juju deploy juju-qa-test --revision 9 --channel latest/edge
-	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 9)"
+	# revision 23 is in channel 2.0/edge
+	juju deploy juju-qa-test --revision 23 --channel latest/edge
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 23)"
 
 	attempt=0
 	while true; do
 		# Ensure that refresh gets the revision from the channel
 		# listed at deploy.
-		# revision 15 is in channel latest/edge
+		# revision 21 is in channel latest/edge
 		OUT=$(juju refresh juju-qa-test 2>&1 || true)
 		if echo "${OUT}" | grep -E -q "Added"; then
 			break
@@ -97,7 +97,7 @@ run_deploy_revision_upgrade() {
 		sleep 5
 	done
 
-	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 15)"
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 21)"
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
Update the revisions used in the integration tests to use charms which support jammy and focal. See #14515 for charm changes.

## QA steps


```sh
(cd tests ; ./main.sh  deploy test_deploy_revision)
```

