### PR TITLE
[JUJU-1698] Fix rotate secrets test race

### DIFF
--- a/core/watcher/secrets.go
+++ b/core/watcher/secrets.go
@@ -4,6 +4,7 @@
 package watcher
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/juju/juju/core/secrets"
@@ -14,6 +15,10 @@ import (
 type SecretTriggerChange struct {
 	URI             *secrets.URI
 	NextTriggerTime time.Time
+}
+
+func (s SecretTriggerChange) GoString() string {
+	return fmt.Sprintf("%s trigger: in %v at %s", s.URI.ID, s.NextTriggerTime.Sub(time.Now()), s.NextTriggerTime.Format(time.RFC3339))
 }
 
 // SecretTriggerChannel is a change channel as described in the CoreWatcher docs.

--- a/worker/secretrotate/secretrotate_test.go
+++ b/worker/secretrotate/secretrotate_test.go
@@ -112,7 +112,7 @@ func (s *workerSuite) TestStartStop(c *gc.C) {
 }
 
 func (s *workerSuite) advanceClock(c *gc.C, d time.Duration) {
-	err := s.clock.WaitAdvance(d+time.Minute, testing.LongWait, 1)
+	err := s.clock.WaitAdvance(d, testing.LongWait, 1)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -176,9 +176,9 @@ func (s *workerSuite) TestSecretUpdateBeforeRotate(c *gc.C) {
 
 	s.rotateConfigChanges <- []corewatcher.SecretTriggerChange{{
 		URI:             uri,
-		NextTriggerTime: now.Add(3 * time.Hour),
+		NextTriggerTime: now.Add(time.Hour),
 	}}
-	s.advanceClock(c, 2*time.Hour+time.Minute)
+	s.advanceClock(c, 2*time.Hour)
 	s.expectRotated(c, uri.ShortString())
 }
 
@@ -205,7 +205,7 @@ func (s *workerSuite) TestSecretUpdateBeforeRotateNotTriggered(c *gc.C) {
 		URI:             uri,
 		NextTriggerTime: now.Add(2 * time.Hour),
 	}}
-	s.advanceClock(c, 29*time.Minute)
+	s.advanceClock(c, 30*time.Minute)
 	s.expectNoRotates(c)
 
 	// Final sanity check.
@@ -355,8 +355,7 @@ func (s *workerSuite) TestRotateGranularity(c *gc.C) {
 		URI:             uri,
 		NextTriggerTime: now.Add(25 * time.Second),
 	}}
-	err = s.clock.WaitAdvance(time.Second, testing.LongWait, 1) // ensure some fake time has elapsed
-	c.Assert(err, jc.ErrorIsNil)
+	s.advanceClock(c, time.Second) // ensure some fake time has elapsed
 
 	uri2 := secrets.NewURI()
 	s.rotateConfigChanges <- []corewatcher.SecretTriggerChange{{
@@ -364,7 +363,6 @@ func (s *workerSuite) TestRotateGranularity(c *gc.C) {
 		NextTriggerTime: now.Add(39 * time.Second),
 	}}
 	// First secret won't rotate before the one minute granularity.
-	err = s.clock.WaitAdvance(46*time.Second, testing.LongWait, 1)
-	c.Assert(err, jc.ErrorIsNil)
+	s.advanceClock(c, 46*time.Second)
 	s.expectRotated(c, uri.ShortString(), uri2.ShortString())
 }


### PR DESCRIPTION
Fix race failures in rotate secrets worker unit tests (there were issues managing the timer to trigger the next rotation).
Also use debug instead of trace logging and add GoString formatters instead of pretty which spewed out too much info.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
cd worker/secretrotate
go test --race
```