### PR TITLE
[JUJU-1701] Fixed test-deploy-test-deploy-bundles-aws

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -158,7 +158,7 @@ run_deploy_charmhub_bundle() {
 	juju deploy "${bundle}"
 
 	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/stable")"
-	wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "candidate")"
+	wait_for "juju-qa-test-focal" "$(charm_channel "juju-qa-test-focal" "latest/candidate")"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 	wait_for "juju-qa-test-focal" "$(idle_condition "juju-qa-test-focal" 1)"
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test")"


### PR DESCRIPTION
This patch fixed the test because (IMHO) of some changes at charmhub (11 days ago), the channel value returned differently ("latest/candidate" instead of "candidate"). 

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made

## QA steps


```sh
cd tests
./main.sh -v -p aws -c aws deploy run_deploy_charmhub_bundle
```
