### PR TITLE
[JUJU-1707] fix hook tools test

### DIFF
--- a/tests/suites/hooktools/state_tools.sh
+++ b/tests/suites/hooktools/state_tools.sh
@@ -42,7 +42,7 @@ run_state_set_clash_uniter_state() {
 	juju exec --unit ubuntu/0 'state-get | grep -q "one: two"'
 
 	# force a hook
-	juju exec --unit ubuntu/0 hooks/update-status
+	juju exec --unit ubuntu/0 hooks/install
 
 	# verify charm set values
 	juju exec --unit ubuntu/0 'state-get | grep -q "one: two"'


### PR DESCRIPTION
run_state_set_clash_uniter_state of the hook tools suite was calling the update-status hook on the ubuntu charm. However rev 20 of the ubuntu charm does not have an update-status hook to call. Use install instead, other choices are start and upgrade-charm.

## QA steps

```sh
(cd tests ; ./main.sh  hooktools)
```
