### PR TITLE
Fix cloudinit panic when postruncmd is lists of strings

### DIFF
--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/names/v4"
 	"github.com/juju/os/v2/series"
 	"github.com/juju/proxy"
+	"github.com/juju/utils/v3"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/agent"
@@ -149,9 +150,11 @@ func (w *unixConfigure) ConfigureBasic() error {
 	// Keep preruncmd at the beginning of any runcmd's that juju adds
 	if preruncmds, ok := w.icfg.CloudInitUserData["preruncmd"].([]interface{}); ok {
 		for i := len(preruncmds) - 1; i >= 0; i -= 1 {
-			if cmd, ok := preruncmds[i].(string); ok {
-				w.conf.PrependRunCmd(cmd)
+			cmd, err := runCmdToString(preruncmds[i])
+			if err != nil {
+				return errors.Annotate(err, "invalid preruncmd")
 			}
+			w.conf.PrependRunCmd(cmd)
 		}
 	}
 	w.conf.AddRunCmd(
@@ -257,7 +260,11 @@ func (w *unixConfigure) ConfigureJuju() error {
 	if postruncmds, ok := w.icfg.CloudInitUserData["postruncmd"].([]interface{}); ok {
 		cmds := make([]string, len(postruncmds))
 		for i, v := range postruncmds {
-			cmds[i] = v.(string)
+			cmd, err := runCmdToString(v)
+			if err != nil {
+				return errors.Annotate(err, "invalid postruncmd")
+			}
+			cmds[i] = cmd
 		}
 		defer w.conf.AddScripts(cmds...)
 	}
@@ -411,6 +418,28 @@ func (w *unixConfigure) ConfigureJuju() error {
 	w.conf.AddRunTextFile("/sbin/remove-juju-services", removeServicesScript, 0755)
 
 	return w.addMachineAgentToBoot()
+}
+
+// runCmdToString converts a postruncmd or preruncmd value to a string.
+// Per https://cloudinit.readthedocs.io/en/latest/topics/examples.html,
+// these run commands can be either a string or a list of strings.
+func runCmdToString(v any) (string, error) {
+	switch v := v.(type) {
+	case string:
+		return v, nil
+	case []any: // beware! won't be be []string
+		strs := make([]string, len(v))
+		for i, sv := range v {
+			ss, ok := sv.(string)
+			if !ok {
+				return "", errors.Errorf("expected list of strings, got list containing %T", sv)
+			}
+			strs[i] = ss
+		}
+		return utils.CommandString(strs...), nil
+	default:
+		return "", errors.Errorf("expected string or list of strings, got %T", v)
+	}
 }
 
 // Not all cloudinit-userdata attr are allowed to override, these attr have been


### PR DESCRIPTION
Per [LP 1759398](https://bugs.launchpad.net/juju/+bug/1759398), when you have a cloudinit with a `postruncmd` that is lists of strings rather than just straight strings we panic during bootstrap or machine configuration. This PR adds support for lists of strings (as well as just plain strings). Per [cloudinit docs](http://cloudinit.readthedocs.io/en/latest/topics/examples.html#run-commands-on-first-boot), `runcmd` can be strings or lists of strings.

I've applied the same handling to `preruncmd`, though we didn't panic with that one, we silently ignored the list of strings elements (which is arguably worse).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
BEFORE FIX:

$ juju bootstrap lxd --config test.yaml
Creating Juju controller "localhost-localhost" on lxd/localhost
Looking for packaged Juju agent version 2.9.34 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md
Launching controller instance(s) on localhost/localhost...
 - juju-751219-0 (arch=amd64)          
Installing Juju agent on bootstrap instance
Fetching Juju Dashboard 0.8.1
Waiting for address
Attempting to connect to 10.47.223.82:22
Connected to 10.47.223.82
Initial model "default" added
panic: interface conversion: interface {} is []interface {}, not string

goroutine 1 [running]:
github.com/juju/juju/cloudconfig.(*unixConfigure).ConfigureJuju(0xc000c6cd80)
	/home/ben/w/juju/cloudconfig/userdatacfg_unix.go:260 +0x16a7
github.com/juju/juju/provider/common.ConfigureMachine({0x4dbc960, 0xc0008d6980}, {0x4d8ff60, 0x6dfd2b0}, {0xc000077fe0, 0xc}, 0xc000644300, 0xc00077e850)
	/home/ben/w/juju/provider/common/bootstrap.go:474 +0x124
github.com/juju/juju/provider/common.glob..func1({0x4dbc960, 0xc0008d6980}, {0x4d8ff60, 0x6dfd2b0}, {0x4dcb2a8?, 0xc000134000}, {0x4db2620, 0xc000172870}, {0x4d9b8a0, 0xc000ac5250}, ...)
	/home/ben/w/juju/provider/common/bootstrap.go:423 +0x41d
github.com/juju/juju/provider/common.BootstrapInstance.func3({0x4dbc960, 0xc0008d6980}, 0xc000644300, {0x0?, 0x0?, 0x0?})
	/home/ben/w/juju/provider/common/bootstrap.go:323 +0x36a
github.com/juju/juju/environs/bootstrap.bootstrapIAAS({_, _}, {_, _}, {_, _}, {{0x0, 0x0, 0x0, 0x0, ...}, ...}, ...)
	/home/ben/w/juju/environs/bootstrap/bootstrap.go:659 +0x1fcb
github.com/juju/juju/environs/bootstrap.Bootstrap({_, _}, {_, _}, {_, _}, {{0x0, 0x0, 0x0, 0x0, ...}, ...})
	/home/ben/w/juju/environs/bootstrap/bootstrap.go:708 +0x2a9
github.com/juju/juju/cmd/juju/commands.bootstrapFuncs.Bootstrap(...)
	/home/ben/w/juju/cmd/juju/commands/bootstrap.go:451
github.com/juju/juju/cmd/juju/commands.(*bootstrapCommand).Run(0xc000748000, 0xc0002b2d20)
	/home/ben/w/juju/cmd/juju/commands/bootstrap.go:978 +0x2909
github.com/juju/juju/cmd/modelcmd.(*modelCommandWrapper).Run(0xc000569aa0, 0xc000a26540?)
	/home/ben/w/juju/cmd/modelcmd/modelcommand.go:663 +0x123
github.com/juju/juju/cmd/modelcmd.(*baseCommandWrapper).Run(0xc0008f2bd0, 0x400000006?)
	/home/ben/w/juju/cmd/modelcmd/base.go:551 +0xaf
github.com/juju/cmd/v3.(*SuperCommand).Run(0xc000318f00, 0xc0002b2d20)
	/home/ben/go/pkg/mod/github.com/juju/cmd/v3@v3.0.0/supercommand.go:523 +0x371
github.com/juju/cmd/v3.Main({0x4db4818, 0xc000318f00}, 0xc0002b2d20, {0xc00031e9c0, 0x4, 0x4})
	/home/ben/go/pkg/mod/github.com/juju/cmd/v3@v3.0.0/cmd.go:397 +0x24b
github.com/juju/juju/cmd/juju/commands.jujuMain.Run({0xc000186140?}, {0xc00018a000, 0x5, 0x5})
	/home/ben/w/juju/cmd/juju/commands/main.go:199 +0x80f
github.com/juju/juju/cmd/juju/commands.Main(...)
	/home/ben/w/juju/cmd/juju/commands/main.go:122
main.main()
	/home/ben/w/juju/cmd/juju/main.go:27 +0x72

# You'll need to Juju unregister and lxd delete the broken instance
$ juju unregister localhost-localhost
$ lxc delete juju-751219-0 --force


AFTER FIX:
$ juju bootstrap lxd --config test.yaml
Creating Juju controller "localhost-localhost" on lxd/localhost
Looking for packaged Juju agent version 2.9.34 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md
Launching controller instance(s) on localhost/localhost...
 - juju-bbcd80-0 (arch=amd64)          
Installing Juju agent on bootstrap instance
Fetching Juju Dashboard 0.8.1
Waiting for address
Attempting to connect to 10.47.223.164:22
Connected to 10.47.223.164
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.47.223.164 to verify accessibility...

Bootstrap complete, controller "localhost-localhost" is now available
Controller machines are in the "controller" model
Initial model "default" added

$ juju ssh -m controller 0
Welcome to Ubuntu 20.04.5 LTS (GNU/Linux 5.15.0-46-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Tue Aug 30 05:01:06 UTC 2022

  System load:  2.4                 Temperature:           65.5 C
  Usage of /:   88.5% of 231.49GB   Processes:             34
  Memory usage: 0%                  Users logged in:       0
  Swap usage:   0%                  IPv4 address for eth0: 10.47.223.164

  => / is using 88.5% of 231.49GB


0 updates can be applied immediately.


$ ls -al /tmp
total 64
drwxrwxrwt 16 root root 4096 Aug 30 05:01  .
drwxr-xr-x 18 root root 4096 Jul  6 21:45  ..
drwxrwxrwt  2 root root 4096 Aug 30 04:55  .ICE-unix
drwxrwxrwt  2 root root 4096 Aug 30 04:55  .Test-unix
drwxrwxrwt  2 root root 4096 Aug 30 04:55  .X11-unix
drwxrwxrwt  2 root root 4096 Aug 30 04:55  .XIM-unix
drwxrwxrwt  2 root root 4096 Aug 30 04:55  .font-unix
drwxr-xr-x  2 root root 4096 Aug 30 04:59  postruncmd
drwxr-xr-x  2 root root 4096 Aug 30 04:59 'postruncmd 2'
drwxr-xr-x  2 root root 4096 Aug 30 04:55  preruncmd
drwxr-xr-x  2 root root 4096 Aug 30 04:55 'preruncmd 2'
drwx------  3 root root 4096 Aug 30 04:58  snap.juju-db
...
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1759398