### PR TITLE
Correct spelling of 'initialising' in status messages

### DIFF
--- a/cmd/juju/status/history_test.go
+++ b/cmd/juju/status/history_test.go
@@ -49,7 +49,7 @@ func (s *StatusHistorySuite) SetUpTest(c *gc.C) {
 			}, {
 				Kind:   status.KindWorkload,
 				Status: status.Waiting,
-				Info:   "agent initializing",
+				Info:   "agent initialising",
 				Since:  s.next(),
 			}, {
 				Kind:   status.KindWorkload,
@@ -102,7 +102,7 @@ Time                  Type       Status       Message
 2017-11-28 12:34:56Z  juju-unit  allocating   
 2017-11-28 12:35:56Z  workload   waiting      waiting for machine
 2017-11-28 12:36:56Z  workload   waiting      installing agent
-2017-11-28 12:37:56Z  workload   waiting      agent initializing
+2017-11-28 12:37:56Z  workload   waiting      agent initialising
 2017-11-28 12:38:56Z  workload   maintenance  installing charm software
 2017-11-28 12:39:56Z  juju-unit  executing    running install hoook
 2017-11-28 12:40:56Z  juju-unit  executing    running config-changed hoook
@@ -129,7 +129,7 @@ func (s *StatusHistorySuite) TestYaml(c *gc.C) {
   since: 2017-11-28T12:36:56Z
   type: workload
 - status: waiting
-  message: agent initializing
+  message: agent initialising
   since: 2017-11-28T12:37:56Z
   type: workload
 - status: maintenance

--- a/core/status/status.go
+++ b/core/status/status.go
@@ -236,7 +236,7 @@ const (
 	MessageWaitForMachine    = "waiting for machine"
 	MessageWaitForContainer  = "waiting for container"
 	MessageInstallingAgent   = "installing agent"
-	MessageInitializingAgent = "agent initializing"
+	MessageInitializingAgent = "agent initialising"
 	MessageInstallingCharm   = "installing charm software"
 )
 

--- a/state/caasmodel_test.go
+++ b/state/caasmodel_test.go
@@ -346,7 +346,7 @@ func (s *CAASModelSuite) TestUnitStatusNoPodSpec(c *gc.C) {
 	})
 
 	msWorkload := unitWorkloadStatus(c, m, unit.Name(), false)
-	c.Check(msWorkload.Message, gc.Equals, "agent initializing")
+	c.Check(msWorkload.Message, gc.Equals, "agent initialising")
 	c.Check(msWorkload.Status, gc.Equals, status.Waiting)
 
 	err := unit.SetStatus(status.StatusInfo{Status: status.Active, Message: "running"})


### PR DESCRIPTION
Canonical uses British English. I noticed that during the bootstrap of an agent we were reporting `agent initializing`, so this is a simple PR to correct that to the British spelling.