### PR TITLE
[JUJU-1715] Fixes error messages when adding k8s models.

### DIFF
--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -995,7 +995,7 @@ func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDNameSpace
 				},
 			}, nil),
 	)
-	s.setupBroker(c, ctrl, testing.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc, `namespace "test" may already be in use`).Finish()
+	s.setupBroker(c, ctrl, testing.ControllerTag.Id(), newK8sClientFunc, newK8sRestFunc, randomPrefixFunc, "").Finish()
 }
 
 func (s *K8sBrokerSuite) TestFileSetToVolumeFiles(c *gc.C) {

--- a/caas/kubernetes/provider/labels.go
+++ b/caas/kubernetes/provider/labels.go
@@ -3,7 +3,18 @@
 
 package provider
 
+import (
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/juju/juju/caas/kubernetes/provider/utils"
+)
+
 // IsLegacyLabels indicates if this provider is operating on a legacy label schema
 func (k *kubernetesClient) IsLegacyLabels() bool {
 	return k.isLegacyLabels
+}
+
+func isK8sObjectOwnedByJuju(objMeta meta.ObjectMeta) bool {
+	return utils.HasLabels(labels.Set(objMeta.Labels), utils.LabelsJuju)
 }

--- a/caas/kubernetes/provider/utils/labels.go
+++ b/caas/kubernetes/provider/utils/labels.go
@@ -49,7 +49,11 @@ func IsLegacyModelLabels(namespace, model string, namespaceI core.NamespaceInter
 		return true, errors.Annotatef(err, "unable to determine legacy status for namespace %s", namespace)
 	}
 
-	return !HasLabels(ns.Labels, LabelsForModel(model, false)), nil
+	if !HasLabels(ns.Labels, LabelsForModel(model, false)) &&
+		HasLabels(ns.Labels, LabelsForModel(model, true)) {
+		return true, nil
+	}
+	return false, nil
 }
 
 // LabelsForApp returns the labels that should be on a k8s object for a given

--- a/caas/kubernetes/provider/utils/labels_test.go
+++ b/caas/kubernetes/provider/utils/labels_test.go
@@ -77,6 +77,26 @@ func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
 				},
 			},
 		},
+		{
+			IsLegacy: false,
+			Model:    "legacy-model-label-test-2",
+			Namespace: &core.Namespace{
+				ObjectMeta: meta.ObjectMeta{
+					Name:   "legacy-model-label-test-2",
+					Labels: map[string]string{},
+				},
+			},
+		},
+		{
+			IsLegacy: true,
+			Model:    "legacy-model-label-test-3",
+			Namespace: &core.Namespace{
+				ObjectMeta: meta.ObjectMeta{
+					Name:   "legacy-model-label-test-3",
+					Labels: map[string]string{"juju-model": "legacy-model-label-test-3"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When adding k8s models where there already exists a namespace with the
same name we run into two scenarios. The first is for an existing
namespace that is owned by another Juju controller and the second is for
namespaces that have been created in a k8s clusters outside the control
of Juju.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Add a namespace to a k8s cluster with the name test. Bootstrap a new Juju controller to the same cluster and run `juju add-model test` and check that the error message returns indicates the collision.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1955067
