### PR TITLE
juju info: show fields in better order

### DIFF
--- a/cmd/juju/charmhub/doc.go
+++ b/cmd/juju/charmhub/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package charmhub implements the Charmhub-related CLI commands, such as
+// "juju info", "juju find", and so on.
+package charmhub

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -107,13 +107,13 @@ func (iw infoWriter) writeClosedChannelToBuffer(w *UnicodeWriter, name string, h
 
 type bundleInfoOutput struct {
 	Name        string `yaml:"name,omitempty"`
-	ID          string `yaml:"bundle-id,omitempty"`
-	Summary     string `yaml:"summary,omitempty"`
 	Publisher   string `yaml:"publisher,omitempty"`
+	Summary     string `yaml:"summary,omitempty"`
+	Description string `yaml:"description,omitempty"`
+	StoreURL    string `yaml:"store-url,omitempty"`
+	ID          string `yaml:"bundle-id,omitempty"`
 	Supports    string `yaml:"supports,omitempty"`
 	Tags        string `yaml:"tags,omitempty"`
-	StoreURL    string `yaml:"store-url,omitempty"`
-	Description string `yaml:"description,omitempty"`
 	Charms      string `yaml:"charms,omitempty"`
 	Channels    string `yaml:"channels,omitempty"`
 	Installed   string `yaml:"installed,omitempty"`
@@ -138,14 +138,14 @@ func (b bundleInfoWriter) Print() error {
 
 type charmInfoOutput struct {
 	Name        string                 `yaml:"name,omitempty"`
-	ID          string                 `yaml:"charm-id,omitempty"`
-	Summary     string                 `yaml:"summary,omitempty"`
 	Publisher   string                 `yaml:"publisher,omitempty"`
+	Summary     string                 `yaml:"summary,omitempty"`
+	Description string                 `yaml:"description,omitempty"`
+	StoreURL    string                 `yaml:"store-url,omitempty"`
+	ID          string                 `yaml:"charm-id,omitempty"`
 	Supports    string                 `yaml:"supports,omitempty"`
 	Tags        string                 `yaml:"tags,omitempty"`
 	Subordinate bool                   `yaml:"subordinate"`
-	StoreURL    string                 `yaml:"store-url,omitempty"`
-	Description string                 `yaml:"description,omitempty"`
 	Relations   relationOutput         `yaml:"relations,omitempty"`
 	Channels    string                 `yaml:"channels,omitempty"`
 	Installed   string                 `yaml:"installed,omitempty"`

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -27,16 +27,16 @@ func (s *printInfoSuite) TestCharmPrintInfo(c *gc.C) {
 
 	obtained := ctx.Stdout.(*bytes.Buffer).String()
 	expected := `name: wordpress
-charm-id: charmCHARMcharmCHARMcharmCHARM01
-summary: WordPress is a full featured web blogging tool, this charm deploys it.
 publisher: Wordress Charmers
-supports: bionic, xenial
-tags: app, seven
-subordinate: true
+summary: WordPress is a full featured web blogging tool, this charm deploys it.
 description: |-
   This will install and setup WordPress optimized to run in the cloud.
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
+charm-id: charmCHARMcharmCHARMcharmCHARM01
+supports: bionic, xenial
+tags: app, seven
+subordinate: true
 relations:
   provides:
     one: two
@@ -61,16 +61,16 @@ func (s *printInfoSuite) TestCharmPrintInfoWithConfig(c *gc.C) {
 
 	obtained := ctx.Stdout.(*bytes.Buffer).String()
 	expected := `name: wordpress
-charm-id: charmCHARMcharmCHARMcharmCHARM01
-summary: WordPress is a full featured web blogging tool, this charm deploys it.
 publisher: Wordress Charmers
-supports: bionic, xenial
-tags: app, seven
-subordinate: true
+summary: WordPress is a full featured web blogging tool, this charm deploys it.
 description: |-
   This will install and setup WordPress optimized to run in the cloud.
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
+charm-id: charmCHARMcharmCHARMcharmCHARM01
+supports: bionic, xenial
+tags: app, seven
+subordinate: true
 relations:
   provides:
     one: two
@@ -149,11 +149,11 @@ func (s *printInfoSuite) TestBundlePrintInfo(c *gc.C) {
 
 	obtained := ctx.Stdout.(*bytes.Buffer).String()
 	expected := `name: osm
-bundle-id: bundleBUNDLEbundleBUNDLEbundle01
-summary: A bundle by charmed-osm.
 publisher: charmed-osm
-tags: networking
+summary: A bundle by charmed-osm.
 description: Single instance OSM bundle.
+bundle-id: bundleBUNDLEbundleBUNDLEbundle01
+tags: networking
 channels: |
   latest/stable:     1.0.3  2019-12-16  (16)  12MB
   latest/candidate:  1.0.3  2019-12-16  (17)  12MB


### PR DESCRIPTION
[LP 1969111)](https://bugs.launchpad.net/juju/+bug/1969111) notes that we want to show "summary" next to "description", so do that. Also move "publisher" up per John's layout, and move "store-url" down per Daniele's comment on the bug.

Tested via Go tests. We do have integration tests of `juju info`, but they don't test the key ordering (probably for the better).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Just run `juju info` and ensure the fields are in this order: name, publisher, summary, description, store-url, and so on.

```sh
$ juju info postgresql
name: postgresql
publisher: Data Platform
summary: PostgreSQL object-relational SQL database (supported version)
description: |
  PostgreSQL is a powerful, open source object-relational database system.
  It has more than 15 years of active development and a proven
  architecture that has earned it a strong reputation for reliability,
  data integrity, and correctness. It is fully ACID compliant, has full
  support for foreign keys, joins, views, triggers, and stored procedures
  (in multiple languages). It includes most SQL:2008 data types, including
  INTEGER, NUMERIC, BOOLEAN, CHAR, VARCHAR, DATE, INTERVAL, and TIMESTAMP.
  It also supports storage of binary large objects, including pictures,
  sounds, or video. It has native programming interfaces for C/C++, Java,
  .Net, Perl, Python, Ruby, Tcl, ODBC, among others, and exceptional
  documentation (http://www.postgresql.org/docs/manuals/).
store-url: https://charmhub.io/postgresql
charm-id: ChgcZB3RhaDOnhkAv9cgRg52LhjBbDt8
supports: focal, bionic, xenial
tags: databases
subordinate: false
relations:
  provides:
    data: block-storage
    db: pgsql
    db-admin: pgsql
    local-monitors: local-monitors
    master: pgreplication
    nrpe-external-master: nrpe-external-master
    syslog: syslog
  requires: {}
channels: |
  latest/stable:     initial-reactive-256-gf4424fe-dirty  2022-07-25  (241)  5MB
  latest/candidate:  ↑
  latest/beta:       ↑
  latest/edge:       245  2022-08-29  (245)  6MB
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1969111
