### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/apiserver/common/resource.go
+++ b/apiserver/common/resource.go
@@ -93,9 +93,9 @@ func (rs *Resources) Stop(id string) error {
 	if r == nil {
 		return nil
 	}
-	err := r.Stop()
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
+	err := r.Stop()
 	delete(rs.resources, id)
 	for pos := 0; pos < len(rs.stack); pos++ {
 		if rs.stack[pos] == id {

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -471,7 +471,7 @@ func (api *CrossModelRelationsAPI) WatchOfferStatus(
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		// TODO: move full watcher to the model cache.
+
 		w, err := api.offerStatusWatcher(api.st, arg.OfferUUID)
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -590,6 +590,7 @@ func (s *crossmodelRelationsSuite) TestWatchOfferStatus(c *gc.C) {
 	c.Assert(results.Results[2].Error.ErrorCode(), gc.Equals, params.CodeUnauthorized)
 	c.Assert(s.watchedOffers, jc.DeepEquals, []string{"mysql-uuid"})
 	s.st.CheckCalls(c, []testing.StubCall{
+		{"IsMigrationActive", nil},
 		{"Application", []interface{}{"mysql"}},
 	})
 	app.CheckCalls(c, []testing.StubCall{

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -754,7 +754,7 @@ func (s *cloudinitSuite) TestCloudInitConfigCloudInitUserData(c *gc.C) {
 	ending := []string{
 		`rm $bin/tools.tar.gz && rm $bin/juju2.3.4-ubuntu-amd64.sha256`, // last line of juju specified cmds
 		`mkdir /tmp/postruncmd`,
-		`mkdir /tmp/postruncmd2`,
+		`mkdir "/tmp/postruncmd 2"`,
 	}
 	c.Assert(len(cmds), jc.GreaterThan, 6)
 	c.Assert(cmds[:3], gc.DeepEquals, beginning)
@@ -780,10 +780,10 @@ packages:
   - 'python-glanceclient'
 preruncmd:
   - mkdir /tmp/preruncmd
-  - mkdir /tmp/preruncmd2
+  - ["mkdir", "/tmp/preruncmd2"]
 postruncmd:
   - mkdir /tmp/postruncmd
-  - mkdir /tmp/postruncmd2
+  - ["mkdir", "/tmp/postruncmd 2"]
 package_upgrade: false
 test-key:
   - test line one
@@ -814,6 +814,42 @@ func (*cloudinitSuite) bootstrapConfigScripts(c *gc.C) []string {
 		}
 	}
 	return scripts
+}
+
+func (s *cloudinitSuite) TestCloudInitPreruncmdError(c *gc.C) {
+	environConfig := minimalModelConfig(c)
+	environConfig, err := environConfig.Apply(map[string]interface{}{
+		config.CloudInitUserDataKey: `
+preruncmd:
+  - 42
+`,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	instanceCfg := s.createInstanceConfig(c, environConfig)
+	cloudcfg, err := cloudinit.New("xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	udata, err := cloudconfig.NewUserdataConfig(instanceCfg, cloudcfg)
+	c.Assert(err, jc.ErrorIsNil)
+	err = udata.Configure()
+	c.Assert(err, gc.ErrorMatches, `invalid preruncmd: .* got int`)
+}
+
+func (s *cloudinitSuite) TestCloudInitPostruncmdError(c *gc.C) {
+	environConfig := minimalModelConfig(c)
+	environConfig, err := environConfig.Apply(map[string]interface{}{
+		config.CloudInitUserDataKey: `
+postruncmd:
+  - ["foo", 3.14]
+`,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	instanceCfg := s.createInstanceConfig(c, environConfig)
+	cloudcfg, err := cloudinit.New("xenial")
+	c.Assert(err, jc.ErrorIsNil)
+	udata, err := cloudconfig.NewUserdataConfig(instanceCfg, cloudcfg)
+	c.Assert(err, jc.ErrorIsNil)
+	err = udata.Configure()
+	c.Assert(err, gc.ErrorMatches, `invalid postruncmd: .* got list containing float64`)
 }
 
 func (s *cloudinitSuite) TestCloudInitConfigureBootstrapLogging(c *gc.C) {

--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -231,28 +231,44 @@ func applicationConfigValue(key string, valueMap interface{}) (interface{}, erro
 }
 
 // ComposeAndVerifyBundle merges base and overlays then verifies the
-// combined bundle data.
-func ComposeAndVerifyBundle(base BundleDataSource, pathToOverlays []string) (*charm.BundleData, error) {
+// combined bundle data. Returns a slice of errors encountered while
+// processing the bundle. They are for informational purposes and do
+// not require failing the bundle deployment.
+func ComposeAndVerifyBundle(base BundleDataSource, pathToOverlays []string) (*charm.BundleData, []error, error) {
 	var dsList []charm.BundleDataSource
+	unMarshallErrors := make([]error, 0)
+	unMarshallErrors = append(unMarshallErrors, gatherErrors(base)...)
 
 	dsList = append(dsList, base)
 	for _, pathToOverlay := range pathToOverlays {
 		ds, err := charm.LocalBundleDataSource(pathToOverlay)
 		if err != nil {
-			return nil, errors.Annotatef(err, "unable to process overlays")
+			return nil, nil, errors.Annotatef(err, "unable to process overlays")
 		}
 		dsList = append(dsList, ds)
+		unMarshallErrors = append(unMarshallErrors, gatherErrors(ds)...)
 	}
 
 	bundleData, err := charm.ReadAndMergeBundleData(dsList...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 	if err = verifyBundle(bundleData, base.BasePath()); err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
-	return bundleData, nil
+	return bundleData, unMarshallErrors, nil
+}
+
+func gatherErrors(ds BundleDataSource) []error {
+	returnErrors := make([]error, 0)
+	for _, p := range ds.Parts() {
+		if p.UnmarshallError == nil {
+			continue
+		}
+		returnErrors = append(returnErrors, p.UnmarshallError)
+	}
+	return returnErrors
 }
 
 func verifyBundle(data *charm.BundleData, bundleDir string) error {

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -96,10 +96,12 @@ func (d *deployBundle) deploy(
 
 	// Compose bundle to be deployed and check its validity before running
 	// any pre/post checks.
-	var bundleData *charm.BundleData
-	if bundleData, err = bundle.ComposeAndVerifyBundle(d.bundleDataSource, d.bundleOverlayFile); err != nil {
+	bundleData, unmarshalErrors, err := bundle.ComposeAndVerifyBundle(d.bundleDataSource, d.bundleOverlayFile)
+	if err != nil {
 		return errors.Annotatef(err, "cannot deploy bundle")
 	}
+	d.printDryRunUnmarshalErrors(ctx, unmarshalErrors)
+
 	d.bundleDir = d.bundleDataSource.BasePath()
 
 	// Short-circuit trust checks if the operator specifies '--force'
@@ -172,6 +174,25 @@ Please repeat the deploy command with the --trust argument if you consent to tru
 		return errors.Annotate(err, "cannot deploy bundle")
 	}
 	return nil
+}
+
+func (d *deployBundle) printDryRunUnmarshalErrors(ctx *cmd.Context, unmarshalErrors []error) {
+	if !d.dryRun {
+		return
+	}
+	// During a dry run, print any unmarshalling errors from the
+	// bundles and overlays
+	var msg string
+	for _, err := range unmarshalErrors {
+		if err == nil {
+			continue
+		}
+		msg = fmt.Sprintf("%s\n %s\n", msg, err)
+	}
+	if msg == "" {
+		return
+	}
+	ctx.Warningf("These fields%swill be ignored during deployment\n", msg)
 }
 
 func (d *deployBundle) makeBundleDeploySpec(ctx *cmd.Context, apiRoot DeployerAPI) (bundleDeploySpec, error) {

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -205,7 +205,7 @@ func (c *diffBundleCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	bundle, err := appbundle.ComposeAndVerifyBundle(baseSrc, c.bundleOverlays)
+	bundle, _, err := appbundle.ComposeAndVerifyBundle(baseSrc, c.bundleOverlays)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/core/migration/errors.go
+++ b/core/migration/errors.go
@@ -1,0 +1,8 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import "github.com/juju/errors"
+
+const ErrMigrating = errors.ConstError("model is being migrated")

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -37,6 +37,7 @@ run_deploy_cmr_bundle() {
 
 	juju deploy easyrsa
 	wait_for "easyrsa" ".applications | keys[0]"
+	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
 
 	juju offer easyrsa:client
 	juju add-model other
@@ -50,10 +51,15 @@ run_deploy_cmr_bundle() {
 	# https://charmhub.io/wordpress
 	juju deploy "${TEST_DIR}/cmr_bundles_test_deploy.yaml"
 
+	wait_for "active" '.applications["etcd"] | ."application-status".current'
 	wait_for "etcd" "$(idle_condition "etcd")"
+	wait_for "active" "$(workload_status "etcd" 0).current"
 
-	destroy_model "test-cmr-bundles-deploy"
+	# TODO: no need to remove-relation before destroying model once we fixed(lp:1952221).
+	juju remove-relation etcd easyrsa
+
 	destroy_model "other"
+	destroy_model "test-cmr-bundles-deploy"
 }
 
 # run_deploy_exported_charmhub_bundle_with_fixed_revisions tests how juju deploys

--- a/tests/suites/hooktools/state_tools.sh
+++ b/tests/suites/hooktools/state_tools.sh
@@ -42,7 +42,7 @@ run_state_set_clash_uniter_state() {
 	juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'
 
 	# force a hook
-	juju exec --unit ubuntu-lite/0 hooks/install
+	juju exec --unit ubuntu-lite/0 hooks/update-status
 
 	# verify charm set values
 	juju exec --unit ubuntu-lite/0 'state-get | grep -q "one: two"'


### PR DESCRIPTION
Merge from 2.9 to bring forward:
- #14469 from manadart/2.9-no-terminate-migrating-offers
- #14542 from hpidcock/fix-resource-stop-race
- #14535 from benhoyt/fix-cloudinit-panic
- #14474 from hmlanigan/validate-bundle-dry-run
- #14537 from ycliuhw/ci-fix
- #14536 from ycliuhw/ci-fix

Only trivial dependency conflicts.