### PR TITLE
juju info: get "supports" list from Charmhub instead of metadata.yaml

### DIFF
--- a/cmd/juju/charmhub/convert.go
+++ b/cmd/juju/charmhub/convert.go
@@ -39,12 +39,7 @@ func convertCharmInfoResult(info transport.InfoResponse, arch, series string) (I
 	}
 
 	for _, base := range info.DefaultRelease.Revision.Bases {
-		var s string
-		if isKubernetes {
-			s = "kubernetes"
-		} else {
-			s, _ = coreseries.VersionSeries(base.Channel)
-		}
+		s, _ := coreseries.VersionSeries(base.Channel)
 		if s != "" {
 			ir.Series = append(ir.Series, s)
 		}

--- a/cmd/juju/charmhub/convert.go
+++ b/cmd/juju/charmhub/convert.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-
 	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
@@ -29,21 +28,30 @@ func convertCharmInfoResult(info transport.InfoResponse, arch, series string) (I
 		Tags:        categories(info.Entity.Categories),
 		StoreURL:    info.Entity.StoreURL,
 	}
+	var isKubernetes bool
 	switch transport.Type(ir.Type) {
 	case transport.BundleType:
 		ir.Bundle = convertBundle(info.Entity.Charms)
 		// TODO (stickupkid): Get the Bundle.Release and set it to the
 		// InfoResponse at a high level.
 	case transport.CharmType:
-		var err error
-		ir.Charm, ir.Series, err = convertCharm(info)
-		if err != nil {
-			return InfoResponse{}, errors.Trace(err)
+		ir.Charm, isKubernetes = convertCharm(info)
+	}
+
+	for _, base := range info.DefaultRelease.Revision.Bases {
+		var s string
+		if isKubernetes {
+			s = "kubernetes"
+		} else {
+			s, _ = coreseries.VersionSeries(base.Channel)
+		}
+		if s != "" {
+			ir.Series = append(ir.Series, s)
 		}
 	}
 
 	var err error
-	ir.Tracks, ir.Channels, err = filterChannels(info.ChannelMap, isKubernetes(ir.Series), arch, series)
+	ir.Tracks, ir.Channels, err = filterChannels(info.ChannelMap, isKubernetes, arch, series)
 	if err != nil {
 		return ir, errors.Trace(err)
 	}
@@ -85,36 +93,26 @@ func convertBundle(charms []transport.Charm) *Bundle {
 	return bundle
 }
 
-func convertCharm(info transport.InfoResponse) (*Charm, []string, error) {
-	charmHubCharm := Charm{
+func convertCharm(info transport.InfoResponse) (ch *Charm, isKubernetes bool) {
+	ch = &Charm{
 		UsedBy: info.Entity.UsedBy,
 	}
-	var series []string
-	var err error
 	if meta := unmarshalCharmMetadata(info.DefaultRelease.Revision.MetadataYAML); meta != nil {
-		charmHubCharm.Subordinate = meta.Subordinate
-		charmHubCharm.Relations = transformRelations(meta.Requires, meta.Provides)
+		ch.Subordinate = meta.Subordinate
+		ch.Relations = transformRelations(meta.Requires, meta.Provides)
 
 		// TODO: hml 2021-04-15
 		// Implementation of Manifest in charmhub InfoResponse is
 		// required.  In the default-release channel map.
 		cm := charmMeta{meta: meta}
-		series, err = corecharm.ComputedSeries(cm)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
-		}
+		isKubernetes = corecharm.IsKubernetes(cm)
 	}
 	if cfg := unmarshalCharmConfig(info.DefaultRelease.Revision.ConfigYAML); cfg != nil {
-		charmHubCharm.Config = &charm.Config{
+		ch.Config = &charm.Config{
 			Options: toCharmOptionMap(cfg),
 		}
 	}
-	return &charmHubCharm, series, nil
-}
-
-func isKubernetes(series []string) bool {
-	seriesSet := set.NewStrings(series...)
-	return seriesSet.Contains("kubernetes")
+	return ch, isKubernetes
 }
 
 func includeChannel(p []corecharm.Platform, architecture, series string) bool {

--- a/cmd/juju/charmhub/convert.go
+++ b/cmd/juju/charmhub/convert.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/charmhub/transport"
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
@@ -95,10 +96,6 @@ func convertCharm(info transport.InfoResponse) (ch *Charm, isKubernetes bool) {
 	if meta := unmarshalCharmMetadata(info.DefaultRelease.Revision.MetadataYAML); meta != nil {
 		ch.Subordinate = meta.Subordinate
 		ch.Relations = transformRelations(meta.Requires, meta.Provides)
-
-		// TODO: hml 2021-04-15
-		// Implementation of Manifest in charmhub InfoResponse is
-		// required.  In the default-release channel map.
 		cm := charmMeta{meta: meta}
 		isKubernetes = corecharm.IsKubernetes(cm)
 	}

--- a/cmd/juju/charmhub/info_test.go
+++ b/cmd/juju/charmhub/info_test.go
@@ -260,8 +260,12 @@ func (s *infoSuite) expectInfo() {
 		},
 		DefaultRelease: transport.InfoChannelMap{
 			Revision: transport.InfoRevision{
-				MetadataYAML: entityMeta,
 				ConfigYAML:   entityConfig,
+				MetadataYAML: entityMeta,
+				Bases: []transport.Base{
+					{Name: "ubuntu", Channel: "18.04"},
+					{Name: "ubuntu", Channel: "16.04"},
+				},
 			},
 		},
 		ChannelMap: []transport.InfoChannelMap{{
@@ -299,7 +303,6 @@ description: |
   This will install and setup services optimized to run in the cloud.
   By default it will place Ngnix configured to scale horizontally
   with Nginx's reverse proxy.
-series: [bionic, xenial]
 provides:
   source:
     interface: dummy-token

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -112,7 +112,6 @@ type bundleInfoOutput struct {
 	Description string `yaml:"description,omitempty"`
 	StoreURL    string `yaml:"store-url,omitempty"`
 	ID          string `yaml:"bundle-id,omitempty"`
-	Supports    string `yaml:"supports,omitempty"`
 	Tags        string `yaml:"tags,omitempty"`
 	Charms      string `yaml:"charms,omitempty"`
 	Channels    string `yaml:"channels,omitempty"`


### PR DESCRIPTION
The series list from the metadata isn't what is available for deploy.
That comes from the Charmhub API response default-release bases (which
in turn comes from charmcraft and the manifest.yaml).

I also remove the ad-hoc isKubernetes function here and use
corecharm.IsKubernetes instead.

This commit also removes the unused Supports field from
bundleInfoOutput (it was never set so always omitted).

There are existing integration tests for `juju info` that check `supports`,
but only that it's present.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
# juju info [charm], then look for the "supports" field
$ juju info postgresl
$ juju info mysql
$ juju info ubuntu
$ juju info snappass-test
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1988492