### PR TITLE
[JUJU-1725] Backport: add support for juju status application leader

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -59,7 +59,8 @@ func (s byTime) Less(i, j int) bool {
 }
 
 // applicationStatusHistory returns status history for the given (remote) application.
-func (c *Client) applicationStatusHistory(appTag names.ApplicationTag, filter status.StatusHistoryFilter, kind status.HistoryKind) ([]params.DetailedStatus, error) {
+func (c *Client) applicationStatusHistory(appTag names.ApplicationTag, filter status.StatusHistoryFilter,
+	kind status.HistoryKind) ([]params.DetailedStatus, error) {
 	var (
 		app status.StatusHistoryGetter
 		err error
@@ -80,7 +81,8 @@ func (c *Client) applicationStatusHistory(appTag names.ApplicationTag, filter st
 }
 
 // unitStatusHistory returns a list of status history entries for unit agents or workloads.
-func (c *Client) unitStatusHistory(unitTag names.UnitTag, filter status.StatusHistoryFilter, kind status.HistoryKind) ([]params.DetailedStatus, error) {
+func (c *Client) unitStatusHistory(unitTag names.UnitTag, filter status.StatusHistoryFilter,
+	kind status.HistoryKind) ([]params.DetailedStatus, error) {
 	unit, err := c.api.stateAccessor.Unit(unitTag.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -113,7 +115,8 @@ func (c *Client) unitStatusHistory(unitTag names.UnitTag, filter status.StatusHi
 }
 
 // machineStatusHistory returns status history for the given machine.
-func (c *Client) machineStatusHistory(machineTag names.MachineTag, filter status.StatusHistoryFilter, kind status.HistoryKind) ([]params.DetailedStatus, error) {
+func (c *Client) machineStatusHistory(machineTag names.MachineTag, filter status.StatusHistoryFilter,
+	kind status.HistoryKind) ([]params.DetailedStatus, error) {
 	machine, err := c.api.stateAccessor.Machine(machineTag.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -205,7 +208,8 @@ func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.Stat
 		results.Results = append(results.Results,
 			params.StatusHistoryResult{
 				History: params.History{Statuses: hist},
-				Error:   apiservererrors.ServerError(errors.Annotatef(err, "fetching status history for %q", request.Tag)),
+				Error: apiservererrors.ServerError(errors.Annotatef(err, "fetching status history for %q",
+					request.Tag)),
 			})
 	}
 	return results
@@ -301,7 +305,8 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	logger.Tracef("Relations: %v", context.relations)
 
 	if len(args.Patterns) > 0 {
-		predicate := BuildPredicateFor(args.Patterns)
+		patterns := resolveLeaderUnits(args.Patterns, context.leaders)
+		predicate := BuildPredicateFor(patterns)
 
 		// First, attempt to match machines. Any units on those
 		// machines are implicitly matched.
@@ -429,7 +434,8 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		}
 
 		// Filter branches
-		context.branches = filterBranches(context.branches, matchedApps, matchedUnits.Union(set.NewStrings(args.Patterns...)))
+		context.branches = filterBranches(context.branches, matchedApps,
+			matchedUnits.Union(set.NewStrings(args.Patterns...)))
 	}
 
 	modelStatus, err := c.modelStatus()
@@ -448,7 +454,24 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	}, nil
 }
 
-func filterBranches(ctxBranches map[string]cache.Branch, matchedApps, matchedForBranches set.Strings) map[string]cache.Branch {
+// resolveLeaderUnits resolves the passed in leader pattern to an existing application leader unit
+// and then replaces it inplace in the patterns
+func resolveLeaderUnits(patterns []string, leaders map[string]string) []string {
+	for i, v := range patterns {
+		if strings.Contains(v, "leader") {
+			application := strings.Split(v, "/")[0]
+			unit, ok := leaders[application]
+			if ok {
+				patterns[i] = unit
+				continue
+			}
+		}
+	}
+	return patterns
+}
+
+func filterBranches(ctxBranches map[string]cache.Branch,
+	matchedApps, matchedForBranches set.Strings) map[string]cache.Branch {
 	// Filter branches based on matchedApps which contains
 	// the application name if matching on application or unit.
 	unmatchedBranches := set.NewStrings()
@@ -681,7 +704,8 @@ func fetchControllerNodes(st Backend) (map[string]state.ControllerNode, error) {
 //
 // All are required to determine a machine's network interfaces configuration,
 // so we want all or none.
-func fetchNetworkInterfaces(st Backend, spaceInfos network.SpaceInfos) (map[string][]*state.Address, map[string]map[string]set.Strings, map[string][]*state.LinkLayerDevice, error) {
+func fetchNetworkInterfaces(st Backend, spaceInfos network.SpaceInfos) (map[string][]*state.Address,
+	map[string]map[string]set.Strings, map[string][]*state.LinkLayerDevice, error) {
 	ipAddresses := make(map[string][]*state.Address)
 	spacesPerMachine := make(map[string]map[string]set.Strings)
 	subnets, err := st.AllSubnets()
@@ -762,7 +786,8 @@ func fetchNetworkInterfaces(st Backend, spaceInfos network.SpaceInfos) (map[stri
 
 // fetchAllApplicationsAndUnits returns a map from application name to application,
 // a map from application name to unit name to unit, and a map from base charm URL to latest URL.
-func fetchAllApplicationsAndUnits(st Backend, model *state.Model, spaceInfos network.SpaceInfos) (applicationStatusInfo, error) {
+func fetchAllApplicationsAndUnits(st Backend, model *state.Model, spaceInfos network.SpaceInfos) (applicationStatusInfo,
+	error) {
 	appMap := make(map[string]*state.Application)
 	unitMap := make(map[string]map[string]*state.Unit)
 	latestCharms := make(map[charm.URL]*state.Charm)
@@ -990,7 +1015,8 @@ func (c *statusContext) processMachines() map[string]params.MachineStatus {
 		for _, machine := range machines[1:] {
 			parent, ok := aCache[container.ParentId(machine.Id())]
 			if !ok {
-				logger.Errorf("programmer error, please file a bug, reference this whole log line: %q, %q", id, machine.Id())
+				logger.Errorf("programmer error, please file a bug, reference this whole log line: %q, %q", id,
+					machine.Id())
 				continue
 			}
 
@@ -1002,7 +1028,8 @@ func (c *statusContext) processMachines() map[string]params.MachineStatus {
 	return machinesMap
 }
 
-func (c *statusContext) makeMachineStatus(machine *state.Machine, appStatusInfo applicationStatusInfo) (status params.MachineStatus) {
+func (c *statusContext) makeMachineStatus(machine *state.Machine,
+	appStatusInfo applicationStatusInfo) (status params.MachineStatus) {
 	machineID := machine.Id()
 	ipAddresses := c.ipAddresses[machineID]
 	spaces := c.spaces[machineID]
@@ -1349,7 +1376,8 @@ func (context *statusContext) processApplication(application *state.Application)
 	return processedStatus
 }
 
-func (context *statusContext) mapExposedEndpointsFromState(exposedEndpoints map[string]state.ExposedEndpoint) (map[string]params.ExposedEndpoint, error) {
+func (context *statusContext) mapExposedEndpointsFromState(exposedEndpoints map[string]state.ExposedEndpoint) (map[string]params.ExposedEndpoint,
+	error) {
 	if len(exposedEndpoints) == 0 {
 		return nil, nil
 	}
@@ -1459,7 +1487,8 @@ func (context *statusContext) processUnitMeterStatuses(units map[string]*state.U
 			continue
 		}
 		if isColorStatus(meterStatus.Code) {
-			unitsMap[unit.Name()] = params.MeterStatus{Color: strings.ToLower(meterStatus.Code.String()), Message: meterStatus.Info}
+			unitsMap[unit.Name()] = params.MeterStatus{Color: strings.ToLower(meterStatus.Code.String()),
+				Message: meterStatus.Info}
 		}
 	}
 	if len(unitsMap) > 0 {
@@ -1468,7 +1497,8 @@ func (context *statusContext) processUnitMeterStatuses(units map[string]*state.U
 	return nil
 }
 
-func (context *statusContext) processUnits(units map[string]*state.Unit, applicationCharm string, expectWorkload bool) map[string]params.UnitStatus {
+func (context *statusContext) processUnits(units map[string]*state.Unit, applicationCharm string,
+	expectWorkload bool) map[string]params.UnitStatus {
 	unitsMap := make(map[string]params.UnitStatus)
 	for _, unit := range units {
 		unitsMap[unit.Name()] = context.processUnit(unit, applicationCharm, expectWorkload)
@@ -1501,7 +1531,8 @@ func (context *statusContext) unitPublicAddress(unit *state.Unit) string {
 	return addr.Value
 }
 
-func (context *statusContext) processUnit(unit *state.Unit, applicationCharm string, expectWorkload bool) params.UnitStatus {
+func (context *statusContext) processUnit(unit *state.Unit, applicationCharm string,
+	expectWorkload bool) params.UnitStatus {
 	var result params.UnitStatus
 	if context.model.Type() == state.ModelTypeIAAS {
 		result.PublicAddress = context.unitPublicAddress(unit)
@@ -1576,7 +1607,8 @@ func (context *statusContext) unitByName(name string) *state.Unit {
 	return context.allAppsUnitsCharmBindings.units[applicationName][name]
 }
 
-func (context *statusContext) processApplicationRelations(application *state.Application) (related map[string][]string, subord []string, err error) {
+func (context *statusContext) processApplicationRelations(application *state.Application) (related map[string][]string,
+	subord []string, err error) {
 	subordSet := make(set.Strings)
 	related = make(map[string][]string)
 	relations := context.relations[application.Name()]
@@ -1604,7 +1636,8 @@ func (context *statusContext) processApplicationRelations(application *state.App
 	return related, subordSet.SortedValues(), nil
 }
 
-func (context *statusContext) processRemoteApplicationRelations(application *state.RemoteApplication) (related map[string][]string, err error) {
+func (context *statusContext) processRemoteApplicationRelations(application *state.RemoteApplication) (related map[string][]string,
+	err error) {
 	related = make(map[string][]string)
 	relations := context.relations[application.Name()]
 	for _, relation := range relations {
@@ -1663,7 +1696,8 @@ func (c *contextUnit) Status() (status.StatusInfo, error) {
 }
 
 // processUnitAndAgentStatus retrieves status information for both unit and unitAgents.
-func (c *statusContext) processUnitAndAgentStatus(unit *state.Unit, expectWorkload bool) (agentStatus, workloadStatus params.DetailedStatus) {
+func (c *statusContext) processUnitAndAgentStatus(unit *state.Unit,
+	expectWorkload bool) (agentStatus, workloadStatus params.DetailedStatus) {
 	wrapped := &contextUnit{unit, expectWorkload, c}
 	agent, workload := c.presence.UnitStatus(wrapped)
 	populateStatusFromStatusInfoAndErr(&agentStatus, agent.Status, agent.Err)

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -553,7 +553,8 @@ func addUnitWithVersion(c *gc.C, application *state.Application, version string)
 	return unit
 }
 
-func (s *statusUnitTestSuite) checkAppVersion(c *gc.C, application *state.Application, expectedVersion string) params.ApplicationStatus {
+func (s *statusUnitTestSuite) checkAppVersion(c *gc.C, application *state.Application,
+	expectedVersion string) params.ApplicationStatus {
 	client := apiclient.NewClient(s.APIState)
 	status, err := client.Status(nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -909,7 +910,8 @@ func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 
 	s.ctrl = gomock.NewController(c)
 	charmhubClient := mocks.NewMockCharmhubRefreshClient(s.ctrl)
-	charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{
+	charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), gomock.Any(),
+		gomock.Any()).Return([]transport.RefreshResponse{
 		{Entity: transport.RefreshEntity{Revision: 42}},
 	}, nil)
 	newCharmhubClient := func(st charmrevisionupdater.State) (charmrevisionupdater.CharmhubRefreshClient, error) {
@@ -917,7 +919,8 @@ func (s *statusUpgradeUnitSuite) SetUpTest(c *gc.C) {
 	}
 
 	var err error
-	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, clock.WallClock, newCharmstoreClient, newCharmhubClient)
+	s.charmrevisionupdater, err = charmrevisionupdater.NewCharmRevisionUpdaterAPIState(state, clock.WallClock,
+		newCharmstoreClient, newCharmhubClient)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -1152,9 +1155,10 @@ func (s *CAASStatusSuite) TestStatusWorkloadVersionSetByCharm(c *gc.C) {
 type filteringBranchesSuite struct {
 	baseSuite
 
-	appA string
-	appB string
-	subB string
+	appA    string
+	appB    string
+	subB    string
+	leaders map[string]string
 }
 
 var _ = gc.Suite(&filteringBranchesSuite{})
@@ -1244,6 +1248,24 @@ func (s *filteringBranchesSuite) TestFullStatusBranchFilterUnit(c *gc.C) {
 	c.Assert(status.Applications, gc.HasLen, 1)
 }
 
+func (s *filteringBranchesSuite) TestFullStatusBranchFilterUnitLeader(c *gc.C) {
+	s.assertBranchAssignUnit(c, "apple", s.appA+"/0")
+	err := s.State.AddBranch("banana", "test-user")
+	c.Assert(err, jc.ErrorIsNil)
+
+	client := s.clientForTest(c)
+
+	status, err := client.FullStatus(params.StatusParams{
+		Patterns: []string{s.appA + "/leader"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(status.Branches, gc.HasLen, 1)
+	b, ok := status.Branches["apple"]
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(b.AssignedUnits, jc.DeepEquals, map[string][]string{s.appA: {s.appA + "/0"}})
+	c.Assert(status.Applications, gc.HasLen, 1)
+}
+
 func (s *filteringBranchesSuite) TestFullStatusBranchFilterApplication(c *gc.C) {
 	err := s.State.AddBranch("apple", "test-user")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1315,8 +1337,10 @@ func (s *filteringBranchesSuite) clientForTest(c *gc.C) *client.Client {
 			Tag:        s.AdminUserTag(c),
 			Controller: true,
 		},
-		Resources_:        common.NewResources(),
-		LeadershipReader_: mockLeadershipReader{},
+		Resources_: common.NewResources(),
+		LeadershipReader_: mockLeadershipReader{
+			leaders: map[string]string{s.appA: s.appA + "/0"},
+		},
 	}
 	client, err := client.NewFacade(ctx)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1343,10 +1367,12 @@ func (s *filteringBranchesSuite) assertBranchAssignApplication(c *gc.C, bName, a
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-type mockLeadershipReader struct{}
+type mockLeadershipReader struct {
+	leaders map[string]string
+}
 
 func (m mockLeadershipReader) Leaders() (map[string]string, error) {
-	return make(map[string]string), nil
+	return m.leaders, nil
 }
 
 func setGenerationsControllerConfig(c *gc.C, st *state.State) {


### PR DESCRIPTION
This is a backport of this [PR](https://github.com/juju/juju/pull/14460)

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
juju deploy postgresql
juju deploy haproxy
juju status postgresql/leader mysql/leader haproxy/leader
Model    Controller  Cloud/Region         Version    SLA          Timestamp
testing  local       localhost/localhost  3.0-rc1.1  unsupported  17:36:21+03:00

App         Version  Status       Scale  Charm       Channel  Rev  Exposed  Message
haproxy              maintenance      1  haproxy     stable    66  no       Configuring HAProxy
postgresql  12.11    active           1  postgresql  stable   241  no       Live master (12.11)

Unit           Workload     Agent  Machine  Public address  Ports     Message
haproxy/0*     maintenance  idle   0        10.117.119.67             Configuring HAProxy
postgresql/0*  active       idle   8        10.117.119.143  5432/tcp  Live master (12.11)

Machine  State    Address         Inst id        Series  AZ  Message
0        started  10.117.119.67   juju-093fe5-0  xenial      Running
8        started  10.117.119.143  juju-093fe5-8  focal       Running
```