### PR TITLE
[JUJU-1563] fix bug 1983581 inconsistent series selection

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -399,10 +399,6 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 				ch = ch.WithRevision(*spec.Revision)
 			}
 		}
-		urlForOrigin := ch
-		if spec.Revision != nil && *spec.Revision != -1 {
-			urlForOrigin = urlForOrigin.WithRevision(*spec.Revision)
-		}
 
 		channel, origin, err := h.constructChannelAndOrigin(ch, spec.Series, spec.Channel, cons)
 		if err != nil {
@@ -422,6 +418,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 				Revision: -1,
 			}
 			origin = origin.WithSeries("")
+			origin.OS = ""
 		}
 
 		h.ctx.Infof(formatLocatedText(ch, origin))

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -592,7 +592,7 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccessWithRevis
 func (s *BundleDeployRepositorySuite) expectK8sCharmByRevision(curl *charm.URL, rev int) *charm.URL {
 	// Called from resolveCharmsAndEndpoints & resolveCharmChannelAndRevision && addCharm
 	s.bundleResolver.EXPECT().ResolveCharm(
-		curl.WithRevision(rev),
+		curl,
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
 		false,
 	).DoAndReturn(


### PR DESCRIPTION
For charmstore, we resolved a series in addCharm as well as addApplication for a bundle. The blob added for a charm could be for multiple series. However with charmhub, the charm blob downloaded is for a specific base (series/os/architecture). Use that in addApplication rather than attempting again to find the correct series, when we know it already.

A bit of unused code found while working on the bug has also been removed.

## QA steps

Deploy the bundle from the bug. Also deploy other known k8s and machine bundles.

```sh
$ cat bundle.yaml
series: jammy

applications:
  octavia-from-bundle:
    charm: octavia
    channel: yoga/edge

$ juju deploy ./bundle.yaml
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1983581
