### PR TITLE
equinix: set default deny iptables policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb
 	github.com/oracle/oci-go-sdk/v47 v47.1.0
-	github.com/packethost/packngo v0.14.0
+	github.com/packethost/packngo v0.28.1
 	github.com/pkg/sftp v1.13.5
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -767,8 +767,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/oracle/oci-go-sdk/v47 v47.1.0 h1:oXkuD18OpcE2bsl6AHMJWKcoPcQrsFq7TiNzCuDiRU8=
 github.com/oracle/oci-go-sdk/v47 v47.1.0/go.mod h1:kO/m5/YgYWrCnLqdudqvhKEUxexwGR2hc6Mogu+8QZw=
-github.com/packethost/packngo v0.14.0 h1:TIEqCO8X9N3tHDzDc1K4DW32kqUsdhguBw+CM4+/yK4=
-github.com/packethost/packngo v0.14.0/go.mod h1:YrtUNN9IRjjqN6zK+cy2IYoi3EjHfoWTWxJkI1I1Vk0=
+github.com/packethost/packngo v0.28.1 h1:2Bo64Ku3F869oUmE2IrnURanN0XAmZmhI8wTem2sq64=
+github.com/packethost/packngo v0.28.1/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -228,56 +228,16 @@ func (e *environ) SetConfig(cfg *config.Config) error {
 }
 
 var (
-	configImmutableFields = []string{}
-	configFields          = func() schema.Fields {
+	configFields = func() schema.Fields {
 		fs, _, err := configSchema.ValidationSchema()
 		if err != nil {
 			panic(err)
 		}
 		return fs
 	}()
-)
-
-var (
 	configSchema   = environschema.Fields{}
 	configDefaults = schema.Defaults{}
 )
-
-func newConfig(cfg, old *config.Config) (*environConfig, error) {
-	// Ensure that the provided config is valid.
-	if err := config.Validate(cfg, old); err != nil {
-		return nil, errors.Trace(err)
-	}
-	attrs, err := cfg.ValidateUnknownAttrs(configFields, configDefaults)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if old != nil {
-		// There's an old configuration. Validate it so that any
-		// default values are correctly coerced for when we check
-		// the old values later.
-		oldEcfg, err := newConfig(old, nil)
-		if err != nil {
-			return nil, errors.Annotatef(err, "invalid base config")
-		}
-		for _, attr := range configImmutableFields {
-			oldv, newv := oldEcfg.attrs[attr], attrs[attr]
-			if oldv != newv {
-				return nil, errors.Errorf(
-					"%s: cannot change from %v to %v",
-					attr, oldv, newv,
-				)
-			}
-		}
-	}
-
-	ecfg := &environConfig{
-		config: cfg,
-		attrs:  attrs,
-	}
-	return ecfg, nil
-}
 
 func (e *environ) configureInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (*instances.InstanceSpec, error) {
 	instanceTypes, err := e.InstanceTypes(ctx, constraints.Value{})

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -6,6 +6,7 @@ package equinix
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,6 +26,7 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
+	"github.com/juju/juju/cmd/juju/commands"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
@@ -277,7 +279,7 @@ func newConfig(cfg, old *config.Config) (*environConfig, error) {
 	return ecfg, nil
 }
 
-func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (result *environs.StartInstanceResult, resultErr error) {
+func (e *environ) configureInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (*instances.InstanceSpec, error) {
 	instanceTypes, err := e.InstanceTypes(ctx, constraints.Value{})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -302,18 +304,50 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 		return nil, errors.Trace(err)
 	}
 
-	if err := e.finishInstanceConfig(&args, spec); err != nil {
-		return nil, errors.Trace(err)
-	}
+	return spec, nil
+}
 
+func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, error) {
 	cloudCfg, err := cloudinit.New(args.InstanceConfig.Series)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	cloudCfg.AddPackage("iptables-persistent")
+
+	// Set a default INPUT policy of drop, permitting ssh
+	acceptInputPort := "iptables -A INPUT -p tcp --dport %d -j ACCEPT"
+	iptablesDefault := []string{
+		"iptables -A INPUT -m conntrack --ctstate INVALID -j DROP",
+		"iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT",
+		"iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT",
+		"iptables -A INPUT -p icmp -j ACCEPT",
+		"iptables -A INPUT -i lo -j ACCEPT",
+		"iptables -A OUTPUT -o lo -j ACCEPT",
+		"iptables -P INPUT ! -i lo -s 127.0.0.0/8 -j REJECT",
+		fmt.Sprintf("iptables -A OUTPUT -p tcp --sport %d -m conntrack --ctstate ESTABLISHED -j ACCEPT", commands.SSHPort),
+		fmt.Sprintf(acceptInputPort, commands.SSHPort),
+	}
+	if args.InstanceConfig.IsController() {
+		for _, port := range []int{
+			args.InstanceConfig.ControllerConfig.APIPort(),
+			args.InstanceConfig.ControllerConfig.StatePort(),
+			args.InstanceConfig.ControllerConfig.ControllerAPIPort(),
+		} {
+			if port != 0 {
+				iptablesDefault = append(iptablesDefault, fmt.Sprintf(acceptInputPort, port))
+			}
+		}
+	}
+	iptablesDefault = append(iptablesDefault, "iptables -A INPUT -j DROP")
+
 	cloudCfg.AddScripts(
-		// This is a dummy script injected into packet images that
+		// This is a dummy script injected into Equinix Metal images that
 		// confuses the init system detection logic used by juju.
 		"rm -f /sbin/initctl",
+	)
+
+	cloudCfg.AddScripts(
+		iptablesDefault...,
 	)
 
 	// Install additional dependencies that are present in ubuntu images
@@ -372,7 +406,7 @@ func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.S
 	cloudCfg.AddScripts(`cat << 'EOF' >> /root/juju-fixups.sh
 #!/bin/bash
 
-curl -vs http://metadata.packet.net/metadata 2>/dev/null |
+curl -vs https://metadata.platformequinix.com/metadata 2>/dev/null |
 jq -r '.network.addresses | .[] | select(.public == false) | [.gateway, .parent_block.network, .parent_block.cidr] | @tsv' |
 awk '{print $1" "$2" "$3}' |
 while read -r gw net cidr; do
@@ -403,9 +437,25 @@ while true; do
     exit 0
 done
 EOF`,
-		"(crontab -l 2>/dev/null; echo '@reboot bash /root/juju-fixups.sh') | crontab -",
-		"sh /root/juju-fixups.sh &", // the fixup script includes a polling section so it must be daemonized.
+		"sh /root/juju-fixups.sh &", // the fixup script is run once and persisted through iptables-persistent
 	)
+	return cloudCfg, nil
+}
+
+func (e *environ) StartInstance(ctx context.ProviderCallContext, args environs.StartInstanceParams) (result *environs.StartInstanceResult, resultErr error) {
+	spec, err := e.configureInstance(ctx, args)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err := e.finishInstanceConfig(&args, spec); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cloudCfg, err := getCloudConfig(args)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	userdata, err := providerinit.ComposeUserData(args.InstanceConfig, cloudCfg, EquinixRenderer{})
 	if err != nil {
@@ -458,7 +508,7 @@ EOF`,
 				continue
 			}
 
-			// Packet requires us to request at least a /31 for IPV4
+			// Equinix Metal requires us to request at least a /31 for IPV4
 			// addresses and a /127 for IPV6 ones.
 			cidrSize := 31
 			if net.AddressFamily != 4 {
@@ -506,9 +556,8 @@ EOF`,
 
 	inst := newInstance(d, e)
 
-	arch = getArchitectureFromPlan(d.Plan.Name)
-
-	return &environs.StartInstanceResult{
+	arch := getArchitectureFromPlan(d.Plan.Name)
+	r := &environs.StartInstanceResult{
 		Instance: inst,
 		Hardware: &instance.HardwareCharacteristics{
 			Arch: &arch,
@@ -516,7 +565,9 @@ EOF`,
 			// RootDisk: &instanceSpec.InstanceType.RootDisk,
 			CpuCores: &spec.InstanceType.CpuCores,
 		},
-	}, nil
+	}
+
+	return r, nil
 }
 
 func (e *environ) StopInstances(ctx context.ProviderCallContext, ids ...instance.Id) error {
@@ -626,7 +677,7 @@ func (e *environ) supportedInstanceTypes() ([]instances.InstanceType, error) {
 nextPlan:
 	for _, plan := range plans {
 		if !validPlan(plan, e.cloud.Region) {
-			logger.Tracef("Plan %s not valid in facility %s", plan.Name, e.cloud.Region)
+			logger.Tracef("Plan %s not valid in metro %s", plan.Name, e.cloud.Region)
 			continue
 		}
 
@@ -641,16 +692,38 @@ nextPlan:
 
 		}
 
+		on_demand := false
+		for _, d := range plan.DeploymentTypes {
+			if d == "on_demand" {
+				on_demand = true
+			}
+		}
+		if !on_demand {
+			continue
+		}
+
 		mem, err := parseMemValue(plan.Specs.Memory.Total)
 		if err != nil {
 			continue
 		}
 
+		// Some plans have CPU cores in the type field, e.g. "24-core".
+		// When available, multiply count by cores.
+		cores := uint64(plan.Specs.Cpus[0].Count)
+		re := regexp.MustCompile(`(\d+)[ -]core`)
+		coresMatch := re.FindStringSubmatch(plan.Specs.Cpus[0].Type)
+		if len(coresMatch) > 1 {
+			n, err := strconv.Atoi(coresMatch[1])
+			if err != nil {
+				return nil, errors.Annotate(err, "invalid cores value")
+			}
+			cores = cores * uint64(n)
+		}
 		instTypes = append(instTypes,
 			instances.InstanceType{
 				Id:       plan.ID,
 				Name:     plan.Name,
-				CpuCores: uint64(plan.Specs.Cpus[0].Count),
+				CpuCores: cores,
 				Mem:      mem,
 				Arch:     instArch,
 				// Scale per hour costs so they can be represented as an integer for sorting purposes.
@@ -672,6 +745,7 @@ func validPlan(plan packngo.Plan, region string) bool {
 		len(plan.Specs.Cpus) == 0 || plan.Specs.Cpus[0].Count == 0 {
 		return false
 	}
+
 	for _, a := range plan.AvailableInMetros {
 		// some plans are not available in-region
 		if a.Code != region {

--- a/provider/equinix/environ_test.go
+++ b/provider/equinix/environ_test.go
@@ -45,6 +45,7 @@ func (s *environProviderSuite) SetUpSuite(c *gc.C) {
 func (s *environProviderSuite) TearDownSuite(c *gc.C) {
 	s.IsolationSuite.TearDownSuite(c)
 }
+
 func (s *environProviderSuite) TearDownTest(c *gc.C) {
 	s.IsolationSuite.TearDownTest(c)
 }
@@ -266,6 +267,7 @@ func NewPackngoCreateDeviceMatcher(hostname, itype, metro, os, projectID string)
 func (m *packngoCreateDeviceMatcher) String() string {
 	return ""
 }
+
 func (m *packngoCreateDeviceMatcher) Matches(x interface{}) bool {
 	req, ok := x.(*packngo.DeviceCreateRequest)
 	if !ok {
@@ -383,7 +385,7 @@ func (s *environProviderSuite) TestStartInstance(c *gc.C) {
 				"on_demand",
 				"spot_market",
 			},
-			Class: "c3.small.x86",
+			Class: "g2.large.x86",
 			AvailableInMetros: []packngo.Metro{
 				{
 					ID:      "108b2cfb-246b-45e3-885a-bf3e82fce1a0",
@@ -426,6 +428,87 @@ func (s *environProviderSuite) TestStartInstance(c *gc.C) {
 				"spot_market",
 			},
 			Class: "c3.small.x86",
+			AvailableInMetros: []packngo.Metro{
+				{
+					ID:      "108b2cfb-246b-45e3-885a-bf3e82fce1a0",
+					Name:    "Amsterdam",
+					Code:    "am",
+					Country: "NL",
+				},
+			},
+		},
+		{
+			ID:          "18e285e0-1872-11ea-8d71-362b9e155667",
+			Slug:        "c3.large.arm",
+			Name:        "c3.large.arm",
+			Description: "c3.large.arm",
+			Line:        "baremetal",
+			Legacy:      true,
+			Specs: &packngo.Specs{
+				Cpus: []*packngo.Cpus{
+					{
+						Count: 1,
+						Type:  "Ampere Altra Q80-30 80-core processor @ 2.8GHz",
+					},
+				},
+				Memory: &packngo.Memory{
+					Total: "32GB",
+				},
+				Drives: []*packngo.Drives{
+					{
+						Count: 2,
+						Size:  "960GB",
+						Type:  "NVME",
+					},
+				},
+			},
+			Pricing: &packngo.Pricing{
+				Hour: 2,
+			},
+			DeploymentTypes: []string{
+				"on_demand",
+				"spot_market",
+			},
+			Class: "c3.large.arm",
+			AvailableInMetros: []packngo.Metro{
+				{
+					ID:      "108b2cfb-246b-45e3-885a-bf3e82fce1a0",
+					Name:    "Amsterdam",
+					Code:    "am",
+					Country: "NL",
+				},
+			},
+		},
+		{
+			ID:          "351c618b-760f-45c5-b45d-7044111a6a31",
+			Slug:        "nope.large.x86",
+			Name:        "nope.large.x86",
+			Description: "Tests that without on_demand this plan will not be returned",
+			Line:        "baremetal",
+			Legacy:      true,
+			Specs: &packngo.Specs{
+				Cpus: []*packngo.Cpus{
+					{
+						Count: 1,
+						Type:  "Intel(R) Xeon(R) E-2278G CPU @ 3.40GHz",
+					},
+				},
+				Memory: &packngo.Memory{
+					Total: "32GB",
+				},
+				Drives: []*packngo.Drives{
+					{
+						Count: 2,
+						Size:  "480GB",
+						Type:  "ssd",
+					},
+				},
+			},
+			Pricing: &packngo.Pricing{
+				Hour: 1.20,
+			},
+			DeploymentTypes: []string{},
+			Class:           "nope.small.x86",
 			AvailableInMetros: []packngo.Metro{
 				{
 					ID:      "108b2cfb-246b-45e3-885a-bf3e82fce1a0",

--- a/provider/equinix/mocks/packngo.go
+++ b/provider/equinix/mocks/packngo.go
@@ -81,6 +81,22 @@ func (mr *MockDeviceServiceMockRecorder) Get(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDeviceService)(nil).Get), arg0, arg1)
 }
 
+// GetBandwidth mocks base method.
+func (m *MockDeviceService) GetBandwidth(arg0 string, arg1 *packngo.BandwidthOpts) (*packngo.BandwidthIO, *packngo.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBandwidth", arg0, arg1)
+	ret0, _ := ret[0].(*packngo.BandwidthIO)
+	ret1, _ := ret[1].(*packngo.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBandwidth indicates an expected call of GetBandwidth.
+func (mr *MockDeviceServiceMockRecorder) GetBandwidth(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBandwidth", reflect.TypeOf((*MockDeviceService)(nil).GetBandwidth), arg0, arg1)
+}
+
 // List mocks base method.
 func (m *MockDeviceService) List(arg0 string, arg1 *packngo.GetOptions) ([]packngo.Device, *packngo.Response, error) {
 	m.ctrl.T.Helper()
@@ -203,6 +219,21 @@ func (m *MockDeviceService) Reboot(arg0 string) (*packngo.Response, error) {
 func (mr *MockDeviceServiceMockRecorder) Reboot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reboot", reflect.TypeOf((*MockDeviceService)(nil).Reboot), arg0)
+}
+
+// Reinstall mocks base method.
+func (m *MockDeviceService) Reinstall(arg0 string, arg1 *packngo.DeviceReinstallFields) (*packngo.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reinstall", arg0, arg1)
+	ret0, _ := ret[0].(*packngo.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Reinstall indicates an expected call of Reinstall.
+func (mr *MockDeviceServiceMockRecorder) Reinstall(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reinstall", reflect.TypeOf((*MockDeviceService)(nil).Reinstall), arg0, arg1)
 }
 
 // Unlock mocks base method.
@@ -385,6 +416,37 @@ func (mr *MockProjectIPServiceMockRecorder) AvailableAddresses(arg0, arg1 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableAddresses", reflect.TypeOf((*MockProjectIPService)(nil).AvailableAddresses), arg0, arg1)
 }
 
+// Create mocks base method.
+func (m *MockProjectIPService) Create(arg0 string, arg1 *packngo.IPReservationCreateRequest) (*packngo.IPAddressReservation, *packngo.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", arg0, arg1)
+	ret0, _ := ret[0].(*packngo.IPAddressReservation)
+	ret1, _ := ret[1].(*packngo.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockProjectIPServiceMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockProjectIPService)(nil).Create), arg0, arg1)
+}
+
+// Delete mocks base method.
+func (m *MockProjectIPService) Delete(arg0 string) (*packngo.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0)
+	ret0, _ := ret[0].(*packngo.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockProjectIPServiceMockRecorder) Delete(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockProjectIPService)(nil).Delete), arg0)
+}
+
 // Get mocks base method.
 func (m *MockProjectIPService) Get(arg0 string, arg1 *packngo.GetOptions) (*packngo.IPAddressReservation, *packngo.Response, error) {
 	m.ctrl.T.Helper()
@@ -433,7 +495,7 @@ func (mr *MockProjectIPServiceMockRecorder) Remove(arg0 interface{}) *gomock.Cal
 }
 
 // Request mocks base method.
-func (m *MockProjectIPService) Request(arg0 string, arg1 *packngo.IPReservationRequest) (*packngo.IPAddressReservation, *packngo.Response, error) {
+func (m *MockProjectIPService) Request(arg0 string, arg1 *packngo.IPReservationCreateRequest) (*packngo.IPAddressReservation, *packngo.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Request", arg0, arg1)
 	ret0, _ := ret[0].(*packngo.IPAddressReservation)
@@ -446,4 +508,20 @@ func (m *MockProjectIPService) Request(arg0 string, arg1 *packngo.IPReservationR
 func (mr *MockProjectIPServiceMockRecorder) Request(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockProjectIPService)(nil).Request), arg0, arg1)
+}
+
+// Update mocks base method.
+func (m *MockProjectIPService) Update(arg0 string, arg1 *packngo.IPAddressUpdateRequest, arg2 *packngo.GetOptions) (*packngo.IPAddressReservation, *packngo.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*packngo.IPAddressReservation)
+	ret1, _ := ret[1].(*packngo.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockProjectIPServiceMockRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockProjectIPService)(nil).Update), arg0, arg1, arg2)
 }


### PR DESCRIPTION
This PR applies changes for the Equinix provider:
* sets the default firewall policy to drop (follow-up to https://github.com/juju/juju/pull/13695#issuecomment-1206010419) (borrows from rackspace provider)
* filter flavors that are not available for on_demand server deployments (these plans are returned by default today because they are evaluated, incorrectly, as the best match)
* calculates CPU Core count based on text description in the plan details
* Test coverage is improved for flavor / plan selection

## QA steps

*Commands to run to verify that the change works.*

```sh
git clone https://github.com/juju/juju/
cd juju
git fetch origin pulls/14568/head:equinix-metal-iptables-policy
git checkout equinixmetal-firewaller
go install ./cmd/juju
which juju # should be the one installed in the GOBIN path

YOUR_IP=$(curl -4 icanhazip.com)
YOUR_IPV6=$(curl -6 icanhazip.com)

# One of the fixes in this PR makes it no longer necessary to specify the EM OS image and plan.

juju add-credential equinix
juju bootstrap equinix/da equinix-controller \
  --bootstrap-series=focal \
  --build-agent # to use the local linux environment development build remotely

juju deploy mysql --channel=edge --series=bionic && \
juju deploy wordpress --channel=edge --series=bionic --to=0 && \
juju add-relation wordpress mysql && \
juju expose wordpress --to-cidrs=${YOUR_IP}/32 # your ipv4, add ",${YOUR_IPV6}/128" if also available
# ^ it should now be accessible
# juju status to get the IP and load it in your browser

juju unexpose wordpress
# ^ it should no longer be accessible. verify in your browser.

# debug: if the page loads when it is not exposed, report the following log:
# TODO: how to log helpful debugging
# iptables -L -t filter 
```
