### PR TITLE
[JUJU-1734] Cleanup secret URI, add extra grant checks

### DIFF
--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -45,7 +45,6 @@ func NewTestAPI(
 
 	return &SecretsManagerAPI{
 		authTag:           authTag,
-		controllerUUID:    coretesting.ControllerTag.Id(),
 		modelUUID:         coretesting.ModelTag.Id(),
 		resources:         resources,
 		leadershipChecker: leadership,

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -42,7 +42,6 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 	}
 	return &SecretsManagerAPI{
 		authTag:           context.Auth().GetAuthTag(),
-		controllerUUID:    context.State().ControllerUUID(),
 		modelUUID:         context.State().ModelUUID(),
 		leadershipChecker: leadershipChecker,
 		secretsBackend:    secretsBackend,

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/secrets"
 	"github.com/juju/juju/secrets/provider"
 	"github.com/juju/juju/state"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type SecretsManagerSuite struct {
@@ -261,7 +260,6 @@ func (s *SecretsManagerSuite) TestUpdateSecrets(c *gc.C) {
 	p.Data = nil
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	expectURI.ControllerUUID = coretesting.ControllerTag.Id()
 	s.secretsBackend.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil).Times(2)
 	s.secretsBackend.EXPECT().UpdateSecret(&expectURI, p).DoAndReturn(
 		func(uri *coresecrets.URI, p state.UpdateSecretParams) (*coresecrets.SecretMetadata, error) {
@@ -284,12 +282,10 @@ func (s *SecretsManagerSuite) TestUpdateSecrets(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token).Times(2)
 	s.token.EXPECT().Check(0, nil).Return(nil).Times(2)
 	s.expectSecretAccessQuery(2)
-	uri1 := *uri
-	uri1.ControllerUUID = "deadbeef-1bad-500d-9000-4b1d0d061111"
 
 	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{{
-			URI: uri.ShortString(),
+			URI: uri.String(),
 			UpsertSecretArg: params.UpsertSecretArg{
 				RotatePolicy: ptr(coresecrets.RotateDaily),
 				ExpireTime:   ptr(s.clock.Now()),
@@ -310,16 +306,12 @@ func (s *SecretsManagerSuite) TestUpdateSecrets(c *gc.C) {
 			},
 		}, {
 			URI: uri.String(),
-		}, {
-			URI: uri1.String(),
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{}, {}, {
 			Error: &params.Error{Message: `at least one attribute to update must be specified`},
-		}, {
-			Error: &params.Error{Code: params.CodeNotValid, Message: `secret URI with controller UUID "deadbeef-1bad-500d-9000-4b1d0d061111" not valid`},
 		}},
 	})
 }
@@ -333,7 +325,6 @@ func (s *SecretsManagerSuite) TestUpdateSecretDuplicateLabel(c *gc.C) {
 	}
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	expectURI.ControllerUUID = coretesting.ControllerTag.Id()
 	s.secretsBackend.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
 	s.secretsBackend.EXPECT().UpdateSecret(&expectURI, p).Return(
 		nil, fmt.Errorf("dup label %w", state.LabelExists),
@@ -341,12 +332,10 @@ func (s *SecretsManagerSuite) TestUpdateSecretDuplicateLabel(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check(0, nil).Return(nil)
 	s.expectSecretAccessQuery(1)
-	uri1 := *uri
-	uri1.ControllerUUID = "deadbeef-1bad-500d-9000-4b1d0d061111"
 
 	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{{
-			URI: uri.ShortString(),
+			URI: uri.String(),
 			UpsertSecretArg: params.UpsertSecretArg{
 				Label: ptr("foobar"),
 			},
@@ -365,26 +354,19 @@ func (s *SecretsManagerSuite) TestRemoveSecrets(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	expectURI.ControllerUUID = coretesting.ControllerTag.Id()
 	s.secretsBackend.EXPECT().DeleteSecret(&expectURI).Return(nil)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check(0, nil).Return(nil)
 	s.expectSecretAccessQuery(1)
-	uri1 := *uri
-	uri1.ControllerUUID = "deadbeef-1bad-500d-9000-4b1d0d061111"
 
 	results, err := s.facade.RemoveSecrets(params.SecretURIArgs{
 		Args: []params.SecretURIArg{{
-			URI: expectURI.ShortString(),
-		}, {
-			URI: uri1.String(),
+			URI: expectURI.String(),
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ErrorResults{
-		Results: []params.ErrorResult{{}, {
-			Error: &params.Error{Code: params.CodeNotValid, Message: `secret URI with controller UUID "deadbeef-1bad-500d-9000-4b1d0d061111" not valid`},
-		}},
+		Results: []params.ErrorResult{{}},
 	})
 }
 
@@ -393,7 +375,6 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfo(c *gc.C) {
 
 	s.expectSecretAccessQuery(1)
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, "application-mariadb").Return(
 		&coresecrets.SecretConsumerMetadata{
 			LatestRevision: 666,
@@ -402,7 +383,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfo(c *gc.C) {
 
 	results, err := s.facade.GetConsumerSecretsRevisionInfo(params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "application-mariadb",
-		URIs:        []string{uri.ShortString()},
+		URIs:        []string{uri.String()},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.SecretConsumerInfoResults{
@@ -418,7 +399,6 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 
 	now := time.Now()
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	s.secretsBackend.EXPECT().ListSecrets(
 		state.SecretsFilter{
 			OwnerTag: ptr("application-mariadb"),
@@ -442,7 +422,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
-			URI:              uri.ShortString(),
+			URI:              uri.String(),
 			Description:      "description",
 			Label:            "label",
 			RotatePolicy:     coresecrets.RotateHourly.String(),
@@ -466,7 +446,6 @@ func (s *SecretsManagerSuite) TestGetSecretContent(c *gc.C) {
 	data := map[string]string{"foo": "bar"}
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, "unit-mariadb-0").Return(
 		&coresecrets.SecretConsumerMetadata{CurrentRevision: 666}, nil)
 
@@ -474,7 +453,6 @@ func (s *SecretsManagerSuite) TestGetSecretContent(c *gc.C) {
 	data2 := map[string]string{"foo": "bar2"}
 	val2 := coresecrets.NewSecretValue(data2)
 	uri2 := coresecrets.NewURI()
-	uri2.ControllerUUID = coretesting.ControllerTag.Id()
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri2, "unit-mariadb-0").Return(
 		nil, errors.NotFoundf("secret"))
 	s.expectSecretAccessQuery(2)
@@ -493,9 +471,9 @@ func (s *SecretsManagerSuite) TestGetSecretContent(c *gc.C) {
 
 	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{{
-			URI: uri.ShortString(),
+			URI: uri.String(),
 		}, {
-			URI: uri2.ShortString(),
+			URI: uri2.String(),
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -504,33 +482,6 @@ func (s *SecretsManagerSuite) TestGetSecretContent(c *gc.C) {
 			Content: params.SecretContentParams{Data: data},
 		}, {
 			Content: params.SecretContentParams{Data: data2},
-		}},
-	})
-}
-
-func (s *SecretsManagerSuite) TestGetSecretContentExplicitUUIDs(c *gc.C) {
-	defer s.setup(c).Finish()
-
-	data := map[string]string{"foo": "bar"}
-	val := coresecrets.NewSecretValue(data)
-	uri := coresecrets.NewURI()
-	uri.ControllerUUID = "deadbeef-1bad-500d-9000-4b1d0d061111"
-	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, "unit-mariadb-0").Return(
-		&coresecrets.SecretConsumerMetadata{CurrentRevision: 666}, nil)
-	s.expectSecretAccessQuery(1)
-	s.secretsBackend.EXPECT().GetSecretValue(uri, 666).Return(
-		val, nil, nil,
-	)
-
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
-		Args: []params.GetSecretContentArg{{
-			URI: uri.String(),
-		}},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
-		Results: []params.SecretContentResult{{
-			Content: params.SecretContentParams{Data: data},
 		}},
 	})
 }
@@ -608,7 +559,6 @@ func (s *SecretsManagerSuite) TestSecretsRotated(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	nextRotateTime := s.clock.Now().Add(time.Hour)
 	s.secretsRotationService.EXPECT().SecretRotated(uri, nextRotateTime).Return(errors.New("boom"))
 	s.secretsBackend.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{
@@ -619,7 +569,7 @@ func (s *SecretsManagerSuite) TestSecretsRotated(c *gc.C) {
 
 	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
-			URI:              uri.ShortString(),
+			URI:              uri.String(),
 			OriginalRevision: 666,
 		}, {
 			URI: "bad",
@@ -642,7 +592,6 @@ func (s *SecretsManagerSuite) TestSecretsRotatedRetry(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	nextRotateTime := s.clock.Now().Add(coresecrets.RotateRetryDelay)
 	s.secretsRotationService.EXPECT().SecretRotated(uri, nextRotateTime).Return(errors.New("boom"))
 	s.secretsBackend.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{
@@ -653,7 +602,7 @@ func (s *SecretsManagerSuite) TestSecretsRotatedRetry(c *gc.C) {
 
 	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
-			URI:              uri.ShortString(),
+			URI:              uri.String(),
 			OriginalRevision: 666,
 		}},
 	})
@@ -671,7 +620,6 @@ func (s *SecretsManagerSuite) TestSecretsRotatedThenNever(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	s.secretsBackend.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{
 		OwnerTag:       "application-mariadb",
 		RotatePolicy:   coresecrets.RotateNever,
@@ -680,7 +628,7 @@ func (s *SecretsManagerSuite) TestSecretsRotatedThenNever(c *gc.C) {
 
 	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
-			URI:              uri.ShortString(),
+			URI:              uri.String(),
 			OriginalRevision: 666,
 		}},
 	})
@@ -695,7 +643,6 @@ func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 
 	s.expectSecretAccessQuery(2)
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	subjectTag := names.NewUnitTag("wordpress/0")
 	scopeTag := names.NewRelationTag("wordpress:db mysql:server")
 	s.secretsBackend.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{
@@ -712,12 +659,12 @@ func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 
 	result, err := s.facade.SecretsGrant(params.GrantRevokeSecretArgs{
 		Args: []params.GrantRevokeSecretArg{{
-			URI:         uri.ShortString(),
+			URI:         uri.String(),
 			ScopeTag:    scopeTag.String(),
 			SubjectTags: []string{subjectTag.String()},
 			Role:        "view",
 		}, {
-			URI:      uri.ShortString(),
+			URI:      uri.String(),
 			ScopeTag: scopeTag.String(),
 			Role:     "bad",
 		}},
@@ -740,7 +687,6 @@ func (s *SecretsManagerSuite) TestSecretsRevoke(c *gc.C) {
 
 	s.expectSecretAccessQuery(2)
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	subjectTag := names.NewUnitTag("wordpress/0")
 	scopeTag := names.NewRelationTag("wordpress:db mysql:server")
 	s.secretsBackend.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{
@@ -757,12 +703,12 @@ func (s *SecretsManagerSuite) TestSecretsRevoke(c *gc.C) {
 
 	result, err := s.facade.SecretsRevoke(params.GrantRevokeSecretArgs{
 		Args: []params.GrantRevokeSecretArg{{
-			URI:         uri.ShortString(),
+			URI:         uri.String(),
 			ScopeTag:    scopeTag.String(),
 			SubjectTags: []string{subjectTag.String()},
 			Role:        "view",
 		}, {
-			URI:      uri.ShortString(),
+			URI:      uri.String(),
 			ScopeTag: scopeTag.String(),
 			Role:     "bad",
 		}},

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -85,7 +85,6 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal, withStore bool) {
 
 	now := time.Now()
 	uri := coresecrets.NewURI()
-	uri.ControllerUUID = coretesting.ControllerTag.Id()
 	metadata := []*coresecrets.SecretMetadata{{
 		URI:              uri,
 		Version:          1,

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -40,13 +40,10 @@ func (c *SecretConfig) Validate() error {
 
 // URI represents a reference to a secret.
 type URI struct {
-	ID             string
-	ControllerUUID string
+	ID string
 }
 
 const (
-	uuidSnippet = `[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}`
-
 	idSnippet = `[0-9a-z]{20}`
 
 	// SecretScheme is the URL prefix for a secret.
@@ -54,7 +51,7 @@ const (
 )
 
 var secretURIParse = regexp.MustCompile(`^` +
-	fmt.Sprintf(`((?P<ControllerUUID>%s)/)?(?P<id>%s)`, uuidSnippet, idSnippet) +
+	fmt.Sprintf(`(?P<id>%s)`, idSnippet) +
 	`$`)
 
 // ParseURI parses the specified string into a URI.
@@ -77,23 +74,14 @@ func ParseURI(str string) (*URI, error) {
 	if matches == nil {
 		return nil, errors.NotValidf("secret URI %q", str)
 	}
-	id, err := xid.FromString(matches[3])
+	id, err := xid.FromString(matches[1])
 	if err != nil {
 		return nil, errors.NotValidf("secret URI %q", str)
 	}
 	result := &URI{
-		ControllerUUID: matches[2],
-		ID:             id.String(),
+		ID: id.String(),
 	}
 	return result, nil
-}
-
-// Raw returns the URI with just the ID part.
-// Used in tests.
-func (u *URI) Raw() *URI {
-	c := *u
-	c.ControllerUUID = ""
-	return &c
 }
 
 // NewURI returns a new secret URI.
@@ -103,25 +91,12 @@ func NewURI() *URI {
 	}
 }
 
-// ShortString prints the URI without controller UUID.
-func (u *URI) ShortString() string {
-	if u == nil {
-		return ""
-	}
-	uCopy := *u
-	uCopy.ControllerUUID = ""
-	return uCopy.String()
-}
-
 // String prints the URI as a string.
 func (u *URI) String() string {
 	if u == nil {
 		return ""
 	}
 	var fullPath []string
-	if u.ControllerUUID != "" {
-		fullPath = append(fullPath, u.ControllerUUID)
-	}
 	fullPath = append(fullPath, u.ID)
 	str := strings.Join(fullPath, "/")
 	urlValue := url.URL{

--- a/core/secrets/secret_test.go
+++ b/core/secrets/secret_test.go
@@ -18,9 +18,8 @@ type SecretURISuite struct{}
 var _ = gc.Suite(&SecretURISuite{})
 
 const (
-	controllerUUID = "555be5b3-987b-4848-80d0-966289f735f1"
-	secretID       = "9m4e2mr0ui3e8a215n4g"
-	secretURI      = "secret:9m4e2mr0ui3e8a215n4g"
+	secretID  = "9m4e2mr0ui3e8a215n4g"
+	secretURI = "secret:9m4e2mr0ui3e8a215n4g"
 )
 
 func (s *SecretURISuite) TestParseURI(c *gc.C) {
@@ -56,13 +55,6 @@ func (s *SecretURISuite) TestParseURI(c *gc.C) {
 			expected: &secrets.URI{
 				ID: secretID,
 			},
-		}, {
-			in:       "secret:" + controllerUUID + "/" + secretID,
-			shortStr: secretURI,
-			expected: &secrets.URI{
-				ControllerUUID: controllerUUID,
-				ID:             secretID,
-			},
 		},
 	} {
 		result, err := secrets.ParseURI(t.in)
@@ -70,7 +62,7 @@ func (s *SecretURISuite) TestParseURI(c *gc.C) {
 			c.Check(err, gc.ErrorMatches, t.err)
 		} else {
 			c.Check(result, jc.DeepEquals, t.expected)
-			c.Check(result.ShortString(), gc.Equals, t.shortStr)
+			c.Check(result.String(), gc.Equals, t.shortStr)
 			if t.str != "" {
 				c.Check(result.String(), gc.Equals, t.str)
 			} else {
@@ -82,32 +74,17 @@ func (s *SecretURISuite) TestParseURI(c *gc.C) {
 
 func (s *SecretURISuite) TestString(c *gc.C) {
 	expected := &secrets.URI{
-		ControllerUUID: controllerUUID,
-		ID:             secretID,
+		ID: secretID,
 	}
 	str := expected.String()
-	c.Assert(str, gc.Equals, "secret:"+controllerUUID+"/"+secretID)
-	uri, err := secrets.ParseURI(str)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(uri, jc.DeepEquals, expected)
-}
-
-func (s *SecretURISuite) TestShortString(c *gc.C) {
-	expected := &secrets.URI{
-		ControllerUUID: controllerUUID,
-		ID:             secretID,
-	}
-	str := expected.ShortString()
 	c.Assert(str, gc.Equals, secretURI)
 	uri, err := secrets.ParseURI(str)
 	c.Assert(err, jc.ErrorIsNil)
-	expected.ControllerUUID = ""
 	c.Assert(uri, jc.DeepEquals, expected)
 }
 
 func (s *SecretURISuite) TestNew(c *gc.C) {
 	URI := secrets.NewURI()
-	c.Assert(URI.ControllerUUID, gc.Equals, "")
 	_, err := xid.FromString(URI.ID)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/state/application.go
+++ b/state/application.go
@@ -391,7 +391,7 @@ func (op *DestroyApplicationOperation) deleteSecrets() error {
 	}
 	for _, uri := range ownedURIs {
 		if err := store.DeleteSecret(uri); err != nil {
-			return errors.Annotatef(err, "deleting owned secret %q", uri.ShortString())
+			return errors.Annotatef(err, "deleting owned secret %q", uri.String())
 		}
 	}
 	return nil

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/juju/charm/v9"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -53,7 +54,6 @@ func ptr[T any](v T) *T {
 
 func (s *SecretsSuite) TestCreate(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	expire := now.Add(time.Hour).Round(time.Second).UTC()
@@ -95,7 +95,6 @@ func (s *SecretsSuite) TestCreate(c *gc.C) {
 
 func (s *SecretsSuite) TestCreateProviderId(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	p := state.CreateSecretParams{
 		Version: 1,
 		Owner:   s.owner.Tag().String(),
@@ -115,7 +114,6 @@ func (s *SecretsSuite) TestCreateProviderId(c *gc.C) {
 
 func (s *SecretsSuite) TestCreateDuplicateLabel(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	expire := now.Add(time.Hour).Round(time.Second).UTC()
@@ -136,7 +134,6 @@ func (s *SecretsSuite) TestCreateDuplicateLabel(c *gc.C) {
 	_, err := s.store.CreateSecret(uri, p)
 	c.Assert(err, jc.ErrorIsNil)
 	uri2 := secrets.NewURI()
-	uri2.ControllerUUID = s.State.ControllerUUID()
 	_, err = s.store.CreateSecret(uri2, p)
 	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
 }
@@ -166,7 +163,6 @@ func (s *SecretsSuite) TestGetValueNotFound(c *gc.C) {
 
 func (s *SecretsSuite) TestGetValue(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	p := state.CreateSecretParams{
 		Version: 1,
 		Owner:   s.owner.Tag().String(),
@@ -188,7 +184,6 @@ func (s *SecretsSuite) TestGetValue(c *gc.C) {
 
 func (s *SecretsSuite) TestListByOwner(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	expire := now.Add(time.Hour).Round(time.Second).UTC()
@@ -211,7 +206,6 @@ func (s *SecretsSuite) TestListByOwner(c *gc.C) {
 
 	// Create another secret to ensure it is excluded.
 	uri2 := secrets.NewURI()
-	uri2.ControllerUUID = s.State.ControllerUUID()
 	p.Owner = "application-wordpress"
 	_, err = s.store.CreateSecret(uri2, p)
 	c.Assert(err, jc.ErrorIsNil)
@@ -238,7 +232,6 @@ func (s *SecretsSuite) TestListByOwner(c *gc.C) {
 
 func (s *SecretsSuite) TestListByURI(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	expire := now.Add(time.Hour).Round(time.Second).UTC()
@@ -261,7 +254,6 @@ func (s *SecretsSuite) TestListByURI(c *gc.C) {
 
 	// Create another secret to ensure it is excluded.
 	uri2 := secrets.NewURI()
-	uri2.ControllerUUID = s.State.ControllerUUID()
 	p.Owner = "application-wordpress"
 	_, err = s.store.CreateSecret(uri2, p)
 	c.Assert(err, jc.ErrorIsNil)
@@ -294,7 +286,6 @@ func (s *SecretsSuite) TestUpdateNothing(c *gc.C) {
 
 func (s *SecretsSuite) TestUpdateAll(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	cp := state.CreateSecretParams{
@@ -324,7 +315,6 @@ func (s *SecretsSuite) TestUpdateAll(c *gc.C) {
 
 func (s *SecretsSuite) TestUpdateRotateInterval(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	cp := state.CreateSecretParams{
@@ -348,7 +338,6 @@ func (s *SecretsSuite) TestUpdateRotateInterval(c *gc.C) {
 
 func (s *SecretsSuite) TestUpdateExpiry(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	cp := state.CreateSecretParams{
@@ -371,7 +360,6 @@ func (s *SecretsSuite) TestUpdateExpiry(c *gc.C) {
 
 func (s *SecretsSuite) TestUpdateDuplicateLabel(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	cp := state.CreateSecretParams{
 		Version: 1,
 		Owner:   s.owner.Tag().String(),
@@ -385,7 +373,6 @@ func (s *SecretsSuite) TestUpdateDuplicateLabel(c *gc.C) {
 	_, err := s.store.CreateSecret(uri, cp)
 	c.Assert(err, jc.ErrorIsNil)
 	uri2 := secrets.NewURI()
-	uri2.ControllerUUID = s.State.ControllerUUID()
 	cp.Label = ptr("label2")
 	_, err = s.store.CreateSecret(uri2, cp)
 	c.Assert(err, jc.ErrorIsNil)
@@ -404,7 +391,6 @@ func (s *SecretsSuite) TestUpdateDuplicateLabel(c *gc.C) {
 
 func (s *SecretsSuite) TestUpdateData(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	cp := state.CreateSecretParams{
@@ -428,7 +414,6 @@ func (s *SecretsSuite) TestUpdateData(c *gc.C) {
 
 func (s *SecretsSuite) TestUpdateDataSetsLatestConsumerRevision(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	cp := state.CreateSecretParams{
@@ -465,7 +450,6 @@ func (s *SecretsSuite) TestUpdateDataSetsLatestConsumerRevision(c *gc.C) {
 
 func (s *SecretsSuite) TestUpdateDataSetsLatestConsumerRevisionConcurrentAdd(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	cp := state.CreateSecretParams{
 		Version: 1,
@@ -506,7 +490,6 @@ func (s *SecretsSuite) TestUpdateDataSetsLatestConsumerRevisionConcurrentAdd(c *
 
 func (s *SecretsSuite) TestUpdateDataSetsLatestConsumerRevisionConcurrentRemove(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	cp := state.CreateSecretParams{
@@ -612,7 +595,6 @@ func (s *SecretsSuite) assertUpdatedSecret(c *gc.C, original *secrets.SecretMeta
 
 func (s *SecretsSuite) TestUpdateConcurrent(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
@@ -650,7 +632,6 @@ func (s *SecretsSuite) TestUpdateConcurrent(c *gc.C) {
 
 func (s *SecretsSuite) TestListSecretRevisions(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
 	cp := state.CreateSecretParams{
@@ -679,7 +660,10 @@ func (s *SecretsSuite) TestListSecretRevisions(c *gc.C) {
 	r, err := s.store.ListSecretRevisions(uri)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(r, jc.DeepEquals, []*secrets.SecretRevisionMetadata{{
+	mc := jc.NewMultiChecker()
+	mc.AddExpr(`_.CreateTime`, jc.Almost, jc.ExpectedValue)
+	mc.AddExpr(`_.UpdateTime`, jc.Almost, jc.ExpectedValue)
+	c.Assert(r, mc, []*secrets.SecretRevisionMetadata{{
 		Revision:   1,
 		CreateTime: now,
 		UpdateTime: now,
@@ -697,7 +681,6 @@ func (s *SecretsSuite) TestListSecretRevisions(c *gc.C) {
 
 func (s *SecretsSuite) TestGetSecretRevision(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 	cp := state.CreateSecretParams{
 		Version: 1,
 		Owner:   s.owner.Tag().String(),
@@ -738,7 +721,6 @@ func (s *SecretsSuite) TestGetSecretConsumer(c *gc.C) {
 	uri := secrets.NewURI()
 	_, err := s.store.CreateSecret(uri, cp)
 	c.Assert(err, jc.ErrorIsNil)
-	uri.ControllerUUID = s.State.ControllerUUID()
 
 	_, err = s.State.GetSecretConsumer(uri, "unit-mariadb-0")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
@@ -767,7 +749,6 @@ func (s *SecretsSuite) TestSaveSecretConsumer(c *gc.C) {
 	uri := secrets.NewURI()
 	_, err := s.store.CreateSecret(uri, cp)
 	c.Assert(err, jc.ErrorIsNil)
-	uri.ControllerUUID = s.State.ControllerUUID()
 	md := &secrets.SecretConsumerMetadata{
 		Label:           "foobar",
 		CurrentRevision: 666,
@@ -797,7 +778,6 @@ func (s *SecretsSuite) TestSaveSecretConsumerConcurrent(c *gc.C) {
 	uri := secrets.NewURI()
 	_, err := s.store.CreateSecret(uri, cp)
 	c.Assert(err, jc.ErrorIsNil)
-	uri.ControllerUUID = s.State.ControllerUUID()
 	md := &secrets.SecretConsumerMetadata{
 		Label:           "foobar",
 		CurrentRevision: 666,
@@ -847,6 +827,49 @@ func (s *SecretsSuite) TestSecretGrantAccess(c *gc.C) {
 	c.Assert(access, gc.Equals, secrets.RoleView)
 }
 
+func (s *SecretsSuite) TestSecretGrantCrossModel(c *gc.C) {
+	rwordpress, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:            "remote-wordpress",
+		SourceModel:     names.NewModelTag("source-model"),
+		IsConsumerProxy: true,
+		OfferUUID:       "offer-uuid",
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Limit:     1,
+			Name:      "db",
+			Role:      charm.RoleRequirer,
+			Scope:     charm.ScopeGlobal,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wordpressEP, err := rwordpress.Endpoint("db")
+	c.Assert(err, jc.ErrorIsNil)
+	mysqlEP, err := s.owner.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
+	relation, err := s.State.AddRelation(wordpressEP, mysqlEP)
+	c.Assert(err, jc.ErrorIsNil)
+
+	uri := secrets.NewURI()
+	cp := state.CreateSecretParams{
+		Version: 1,
+		Owner:   s.owner.Tag().String(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken: &fakeToken{},
+			Data:        map[string]string{"foo": "bar"},
+		},
+	}
+	_, err = s.store.CreateSecret(uri, cp)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
+		LeaderToken: &fakeToken{},
+		Scope:       relation.Tag(),
+		Subject:     rwordpress.Tag(),
+		Role:        secrets.RoleView,
+	})
+	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
+}
+
 func (s *SecretsSuite) TestSecretGrantAccessDyingScope(c *gc.C) {
 	uri := secrets.NewURI()
 	cp := state.CreateSecretParams{
@@ -873,11 +896,45 @@ func (s *SecretsSuite) TestSecretGrantAccessDyingScope(c *gc.C) {
 	_, err = s.relation.DestroyWithForce(true, time.Second)
 	c.Assert(err, jc.ErrorIsNil)
 
-	subject := names.NewApplicationTag("wordpress")
 	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
 		LeaderToken: &fakeToken{},
 		Scope:       s.relation.Tag(),
-		Subject:     subject,
+		Subject:     wordpress.Tag(),
+		Role:        secrets.RoleView,
+	})
+	c.Assert(err, gc.ErrorMatches, `cannot grant access to secret in scope of "relation-wordpress.db#mysql.server" which is not alive`)
+}
+
+func (s *SecretsSuite) TestSecretGrantAccessDyingSubject(c *gc.C) {
+	uri := secrets.NewURI()
+	cp := state.CreateSecretParams{
+		Version: 1,
+		Owner:   s.owner.Tag().String(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken: &fakeToken{},
+			Data:        map[string]string{"foo": "bar"},
+		},
+	}
+	_, err := s.store.CreateSecret(uri, cp)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure destroy only sets app to dying.
+	wordpress, err := s.State.Application("wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	ru, err := s.relation.Unit(unit)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ru.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = wordpress.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
+		LeaderToken: &fakeToken{},
+		Scope:       s.relation.Tag(),
+		Subject:     wordpress.Tag(),
 		Role:        secrets.RoleView,
 	})
 	c.Assert(err, gc.ErrorMatches, `cannot grant access to secret in scope of "relation-wordpress.db#mysql.server" which is not alive`)
@@ -928,7 +985,6 @@ func (s *SecretsSuite) TestDelete(c *gc.C) {
 	subject := names.NewApplicationTag("wordpress")
 	create := func() *secrets.URI {
 		uri := secrets.NewURI()
-		uri.ControllerUUID = s.State.ControllerUUID()
 		now := s.Clock.Now().Round(time.Second).UTC()
 		next := now.Add(time.Minute).Round(time.Second).UTC()
 		cp := state.CreateSecretParams{
@@ -1017,7 +1073,6 @@ func (s *SecretsSuite) TestDelete(c *gc.C) {
 
 func (s *SecretsSuite) TestSecretRotated(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
@@ -1043,7 +1098,6 @@ func (s *SecretsSuite) TestSecretRotated(c *gc.C) {
 
 func (s *SecretsSuite) TestSecretRotatedConcurrent(c *gc.C) {
 	uri := secrets.NewURI()
-	uri.ControllerUUID = s.State.ControllerUUID()
 
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
@@ -1109,7 +1163,7 @@ func (s *SecretsRotationWatcherSuite) setupWatcher(c *gc.C) (state.SecretsRotati
 
 	wc := testing.NewSecretsRotationWatcherC(c, w)
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI:             md.URI.Raw(),
+		URI:             md.URI,
 		NextTriggerTime: next,
 	})
 	wc.AssertNoChange()
@@ -1132,7 +1186,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchSingleUpdate(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI:             uri.Raw(),
+		URI:             uri,
 		NextTriggerTime: next,
 	})
 	wc.AssertNoChange()
@@ -1150,7 +1204,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchDelete(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI: md.URI.Raw(),
+		URI: md.URI,
 	})
 	wc.AssertNoChange()
 }
@@ -1166,7 +1220,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchMultipleUpdatesSameSecret(c *gc.C
 	err := s.State.SecretRotated(uri, next)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI:             uri.Raw(),
+		URI:             uri,
 		NextTriggerTime: next,
 	})
 	next2 := now.Add(time.Hour).Round(time.Second).UTC()
@@ -1174,7 +1228,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchMultipleUpdatesSameSecret(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI:             uri.Raw(),
+		URI:             uri,
 		NextTriggerTime: next2,
 	})
 	wc.AssertNoChange()
@@ -1191,7 +1245,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchMultipleUpdatesSameSecretDeleted(
 	err := s.State.SecretRotated(uri, next)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI:             uri.Raw(),
+		URI:             uri,
 		NextTriggerTime: next,
 	})
 	md, err := s.store.UpdateSecret(uri, state.UpdateSecretParams{
@@ -1201,7 +1255,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchMultipleUpdatesSameSecretDeleted(
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI: md.URI.Raw(),
+		URI: md.URI,
 	})
 	wc.AssertNoChange()
 }
@@ -1217,7 +1271,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchMultipleUpdates(c *gc.C) {
 	err := s.State.SecretRotated(uri, next)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI:             uri.Raw(),
+		URI:             uri,
 		NextTriggerTime: next,
 	})
 
@@ -1235,7 +1289,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchMultipleUpdates(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI:             md2.URI.Raw(),
+		URI:             md2.URI,
 		NextTriggerTime: next2,
 	})
 
@@ -1246,7 +1300,7 @@ func (s *SecretsRotationWatcherSuite) TestWatchMultipleUpdates(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(watcher.SecretTriggerChange{
-		URI: md.URI.Raw(),
+		URI: md.URI,
 	})
 	wc.AssertNoChange()
 }

--- a/worker/secretrotate/secretrotate.go
+++ b/worker/secretrotate/secretrotate.go
@@ -145,7 +145,7 @@ func (w *Worker) rotate(now time.Time) {
 		w.config.Logger.Debugf("rotate %s at %s... time diff %s", id, info.rotateTime, info.rotateTime.Sub(now))
 		// A one minute granularity is acceptable for secret rotation.
 		if info.rotateTime.Truncate(time.Minute).Before(now) {
-			toRotate = append(toRotate, info.URI.ShortString())
+			toRotate = append(toRotate, info.URI.String())
 			// Once secret has been queued for rotation, delete it here since
 			// it will re-appear via the watcher after the rotation is actually
 			// performed and the last rotated time is updated.
@@ -172,7 +172,7 @@ func (w *Worker) handleSecretRotateChanges(changes []watcher.SecretTriggerChange
 	for _, ch := range changes {
 		// Next rotate time of 0 means the rotation has been deleted.
 		if ch.NextTriggerTime.IsZero() {
-			w.config.Logger.Debugf("secret no longer rotated: %v", ch.URI.ShortString())
+			w.config.Logger.Debugf("secret no longer rotated: %v", ch.URI.String())
 			delete(w.secrets, ch.URI.ID)
 			continue
 		}

--- a/worker/secretrotate/secretrotate_test.go
+++ b/worker/secretrotate/secretrotate_test.go
@@ -152,7 +152,7 @@ func (s *workerSuite) TestFirstSecret(c *gc.C) {
 		NextTriggerTime: next,
 	}}
 	s.advanceClock(c, time.Hour)
-	s.expectRotated(c, uri.ShortString())
+	s.expectRotated(c, uri.String())
 }
 
 func (s *workerSuite) TestSecretUpdateBeforeRotate(c *gc.C) {
@@ -179,7 +179,7 @@ func (s *workerSuite) TestSecretUpdateBeforeRotate(c *gc.C) {
 		NextTriggerTime: now.Add(time.Hour),
 	}}
 	s.advanceClock(c, 2*time.Hour)
-	s.expectRotated(c, uri.ShortString())
+	s.expectRotated(c, uri.String())
 }
 
 func (s *workerSuite) TestSecretUpdateBeforeRotateNotTriggered(c *gc.C) {
@@ -210,7 +210,7 @@ func (s *workerSuite) TestSecretUpdateBeforeRotateNotTriggered(c *gc.C) {
 
 	// Final sanity check.
 	s.advanceClock(c, time.Hour)
-	s.expectRotated(c, uri.ShortString())
+	s.expectRotated(c, uri.String())
 }
 
 func (s *workerSuite) TestNewSecretTriggersBefore(c *gc.C) {
@@ -240,10 +240,10 @@ func (s *workerSuite) TestNewSecretTriggersBefore(c *gc.C) {
 	}}
 	time.Sleep(testing.ShortWait) // ensure advanceClock happens after timer is updated
 	s.advanceClock(c, 15*time.Minute)
-	s.expectRotated(c, uri2.ShortString())
+	s.expectRotated(c, uri2.String())
 
 	s.advanceClock(c, 30*time.Minute)
-	s.expectRotated(c, uri.ShortString())
+	s.expectRotated(c, uri.String())
 }
 
 func (s *workerSuite) TestManySecretsTrigger(c *gc.C) {
@@ -272,7 +272,7 @@ func (s *workerSuite) TestManySecretsTrigger(c *gc.C) {
 	}}
 
 	s.advanceClock(c, 90*time.Minute)
-	s.expectRotated(c, uri.ShortString(), uri2.ShortString())
+	s.expectRotated(c, uri.String(), uri2.String())
 }
 
 func (s *workerSuite) TestDeleteSecretRotation(c *gc.C) {
@@ -336,7 +336,7 @@ func (s *workerSuite) TestManySecretsDeleteOne(c *gc.C) {
 	s.expectNoRotates(c)
 
 	s.advanceClock(c, 30*time.Minute)
-	s.expectRotated(c, uri.ShortString())
+	s.expectRotated(c, uri.String())
 }
 
 func (s *workerSuite) TestRotateGranularity(c *gc.C) {
@@ -364,5 +364,5 @@ func (s *workerSuite) TestRotateGranularity(c *gc.C) {
 	}}
 	// First secret won't rotate before the one minute granularity.
 	s.advanceClock(c, 46*time.Second)
-	s.expectRotated(c, uri.ShortString(), uri2.ShortString())
+	s.expectRotated(c, uri.String(), uri2.String())
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -810,7 +810,7 @@ func (ctx *HookContext) UpdateSecret(uri *coresecrets.URI, args *jujuc.SecretUps
 	}
 	md, ok := ctx.secretMetadata[uri.ID]
 	if !ok {
-		return errors.NotFoundf("secret %q", uri.ShortString())
+		return errors.NotFoundf("secret %q", uri.String())
 	}
 	ctx.secretChanges.update(uniter.SecretUpdateArg{
 		SecretUpsertArg: uniter.SecretUpsertArg{

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -154,6 +154,6 @@ func (c *secretAddCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(ctx.Stdout, uri.ShortString())
+	fmt.Fprintln(ctx.Stdout, uri.String())
 	return nil
 }


### PR DESCRIPTION
Cleanup secret URI to remove controllerUUID attribute (not used right now).
Also add extra checks when granting access - subject must be alive and disallow CMR grants.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

unit tests