### PR TITLE
Add openssh-client to snapcraft.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -118,6 +118,8 @@ parts:
           sha256: $hash
       EOF
       cp -a jujud-versions.yaml $SNAPCRAFT_PART_INSTALL/bin
+    stage-packages:
+      - openssh-client
 
 hooks:
   connect-plug-peers: {}


### PR DESCRIPTION
Add openssh-client to snapcraft for strictly confined `juju ssh` and `juju scp`

## QA steps

Build strict snap, install, test `juju ssh` and `juju scp`.

## Documentation changes

N/A

## Bug reference

N/A
