### PR TITLE
[JUJU-1307] Rewrote to bash based nw-resolve

### DIFF
--- a/testcharms/charms/simple-resolve/README
+++ b/testcharms/charms/simple-resolve/README
@@ -1,0 +1,3 @@
+Simple charm that errors once on the install hook, but works the next time run.
+
+Used to test juju resolve command.

--- a/testcharms/charms/simple-resolve/copyright
+++ b/testcharms/charms/simple-resolve/copyright
@@ -1,0 +1,1 @@
+Copyright 2018 Canonical Ltd.

--- a/testcharms/charms/simple-resolve/hooks/install
+++ b/testcharms/charms/simple-resolve/hooks/install
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Simple install hook that errors the first time it is run, on any subsequent 
+# run the hook will succeed (unless the canary file is removed).
+
+canary_file=/tmp/resolver.canary
+success_file=/tmp/resolver.success
+
+function exit_error() {
+    status-set blocked "Install hook failed on: $1 attempts." || true
+    exit 1
+}
+
+if [ ! -e ${canary_file} ]; then
+    echo "No canary file, exiting error."
+    echo 1 > ${canary_file}
+    exit_error 1
+fi
+
+# Need to error for x amount of times before juju stops trying automatically.
+run_count=$(cat ${canary_file})
+
+# For now juju is always re-trying. Need to just exit regardless.
+echo $((${run_count}+1)) > ${canary_file}
+exit_error ${run_count}
+
+# This will be useful when install error retries are limited to n-times. For 
+# now it retries forever and thus there is no exit condition.
+# if [ ${run_count} -le 3 ]; then
+#     echo "Incrementing and erroring"
+#     echo $((${run_count}+1)) > ${canary_file}
+#     exit_error ${run_count}
+# else
+#     echo "Canary file found, exit success."
+#     touch ${success_file}
+#     status-set maintenance "Install hook succeeded." || true
+#     exit 0
+# fi
+

--- a/testcharms/charms/simple-resolve/hooks/install
+++ b/testcharms/charms/simple-resolve/hooks/install
@@ -24,16 +24,3 @@ run_count=$(cat ${canary_file})
 echo $((${run_count}+1)) > ${canary_file}
 exit_error ${run_count}
 
-# This will be useful when install error retries are limited to n-times. For 
-# now it retries forever and thus there is no exit condition.
-# if [ ${run_count} -le 3 ]; then
-#     echo "Incrementing and erroring"
-#     echo $((${run_count}+1)) > ${canary_file}
-#     exit_error ${run_count}
-# else
-#     echo "Canary file found, exit success."
-#     touch ${success_file}
-#     status-set maintenance "Install hook succeeded." || true
-#     exit 0
-# fi
-

--- a/testcharms/charms/simple-resolve/hooks/start
+++ b/testcharms/charms/simple-resolve/hooks/start
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+install_success_file=/tmp/resolver.success
+
+status_message="No install hook"
+if [ -e ${install_success_file} ]; then
+    status_message="Install hook succeeded"
+fi
+
+echo "${status_message}"
+status-set active "${status_message}" || true

--- a/testcharms/charms/simple-resolve/metadata.yaml
+++ b/testcharms/charms/simple-resolve/metadata.yaml
@@ -1,0 +1,15 @@
+name: simple-resolve
+maintainer: Christopher Lee <chris.mclachlan-lee@canonical.com>
+summary: Purposfully error on install hook for testing resolve command.
+description: |
+  A testing charm that errors once on install hook then succeeds on the next run.
+categories:
+  - misc
+series:
+  - jammy
+  - xenial
+  - bionic
+  - trusty
+  - artful
+  - disco
+  - eoan

--- a/testcharms/charms/simple-resolve/metadata.yaml
+++ b/testcharms/charms/simple-resolve/metadata.yaml
@@ -7,9 +7,5 @@ categories:
   - misc
 series:
   - jammy
-  - xenial
+  - focal
   - bionic
-  - trusty
-  - artful
-  - disco
-  - eoan

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -238,6 +238,7 @@ run_resolve_charm() {
 
 	juju resolve --no-retry simple-resolve/0
 
+	wait_for "No install hook" '.applications["simple-resolve"] | ."application-status".message'
 	wait_for "active" '.applications["simple-resolve"] | ."application-status".current'
 
 	destroy_model "${model_name}"

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -222,6 +222,27 @@ run_deploy_lxd_to_container() {
 	destroy_model "${model_name}"
 }
 
+# Checks the install hook resolving with --no-retry flag
+run_resolve_charm() {
+	echo
+
+	model_name="test-resolve-charm"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	charm=./testcharms/charms/simple-resolve
+	juju deploy "${charm}"
+
+	wait_for "error" '.applications["simple-resolve"] | ."application-status".current'
+
+	juju resolve --no-retry simple-resolve/0
+
+	wait_for "active" '.applications["simple-resolve"] | ."application-status".current'
+
+	destroy_model "${model_name}"
+}
+
 test_deploy_charms() {
 	if [ "$(skip 'test_deploy_charms')" ]; then
 		echo "==> TEST SKIPPED: deploy charms"
@@ -243,11 +264,13 @@ test_deploy_charms() {
 			run "run_deploy_lxd_to_machine"
 			run "run_deploy_lxd_profile_charm"
 			run "run_deploy_local_lxd_profile_charm"
+			run "run_resolve_charm"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"
 			echo "==> TEST SKIPPED: deploy_lxd_profile_charm - tests for LXD only"
 			echo "==> TEST SKIPPED: deploy_local_lxd_profile_charm - tests for LXD only"
+			echo "==> TEST SKIPPED: resolve_charm - tests for LXD only"
 			;;
 		esac
 	)


### PR DESCRIPTION
This PR added a bash-based version of the `nw-resolve` test to the deploy suite. To implement the test, the `simple-resolve` charm was copied to the `testcharms` subfolder.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p lxd deploy run_resolve_charm
```
