### PR TITLE
Fix bug in spaces test setup

### DIFF
--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -33,16 +33,16 @@ test_spaces_ec2() {
 
 setup_nic_for_space_tests() {
 	isolated_subnet_id=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=172.31.254.0/24 2>/dev/null | jq -r '.Subnets[0].SubnetId')
-	if [ -z "$isolated_subnet_id" ]; then
+	if [ "$isolated_subnet_id" == "null" ]; then
 		# shellcheck disable=SC2046
-		echo $(red 'To run these tests you need to create a subnet with name "isolated" and CIDR "172.31.254/24"')
+		echo $(red 'To run these tests you need to create a subnet with name "isolated" and CIDR "172.31.254/24"') 1>&2
 		exit 1
 	fi
 
 	hotplug_nic_id=$(aws ec2 create-network-interface --subnet-id "$isolated_subnet_id" --description="hot-pluggable NIC for space tests" 2>/dev/null | jq -r '.NetworkInterface.NetworkInterfaceId')
-	if [ -z "$hotplug_nic_id" ]; then
+	if [ "$hotplug_nic_id" == "null" ]; then
 		# shellcheck disable=SC2046
-		echo $(red "Unable to create extra NIC for space tests; please check that your account has permissions to create NICs")
+		echo $(red "Unable to create extra NIC for space tests; please check that your account has permissions to create NICs") 1>&2
 		exit 1
 	fi
 


### PR DESCRIPTION
Errors were not displaying because they were posted to stdout, which is captured into a variable. Instead send to stderr

Also, if checks were failing, because if jq fails, when the output is captured and is stringified it turns to the string 'null'

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ensure `aws ec2 describe-subnets --filters Name=cidr-block,Values=172.31.254.0/24` returns an empty list of subnets and run:
```
BOOTSTRAP_PROVIDER=aws BOOTSTRAP_CLOUD=aws BOOTSTRAP_REGION=eu-west-2 ./main.sh -v spaces_ec2
```
Expect a quick failure with `To run these tests you need to create a subnet with name "isolated" and CIDR "172.31.254/24"`