### PR TITLE
Add new Azure qatarcentral region

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -295,6 +295,10 @@ clouds:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net
+      qatarcentral:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
     description: Microsoft Azure China

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -302,6 +302,10 @@ clouds:
         endpoint: https://management.azure.com
         storage-endpoint: https://core.windows.net
         identity-endpoint: https://graph.windows.net
+      qatarcentral:
+        endpoint: https://management.azure.com
+        storage-endpoint: https://core.windows.net
+        identity-endpoint: https://graph.windows.net
   azure-china:
     type: azure
     description: Microsoft Azure China

--- a/provider/azure/deployments.go
+++ b/provider/azure/deployments.go
@@ -42,8 +42,12 @@ func (env *azureEnviron) createDeployment(
 	)
 	// We only want to wait for deployments which are not shared
 	// resources, otherwise add model operations will be held up.
+	var result armresources.DeploymentsClientCreateOrUpdateResponse
 	if err == nil && deploymentName != commonDeployment {
-		_, err = poller.PollUntilDone(ctx, nil)
+		result, err = poller.PollUntilDone(ctx, nil)
+		if err == nil && result.Properties != nil && result.Properties.Error != nil {
+			err = errors.New(toValue(result.Properties.Error.Message))
+		}
 	}
 	return errorutils.HandleCredentialError(errors.Annotatef(err, "creating Azure deployment %q", deploymentName), ctx)
 }


### PR DESCRIPTION
Azure has a new qatarcentral region.

Also a small driveby fix for better deployment error handling.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju bootstrap azure/qatarcentral
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1988511
