### PR TITLE
Clean up secrets when a model is destroyed

### DIFF
--- a/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
@@ -35,6 +35,20 @@ func (m *MockSecretStoreProvider) EXPECT() *MockSecretStoreProviderMockRecorder 
 	return m.recorder
 }
 
+// CleanupModel mocks base method.
+func (m *MockSecretStoreProvider) CleanupModel(arg0 provider.Model) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupModel", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupModel indicates an expected call of CleanupModel.
+func (mr *MockSecretStoreProviderMockRecorder) CleanupModel(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupModel", reflect.TypeOf((*MockSecretStoreProvider)(nil).CleanupModel), arg0)
+}
+
 // CleanupSecrets mocks base method.
 func (m *MockSecretStoreProvider) CleanupSecrets(arg0 provider.Model, arg1 []*secrets.URI) error {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/undertaker/mock_test.go
+++ b/apiserver/facades/controller/undertaker/mock_test.go
@@ -10,9 +10,12 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/facades/controller/undertaker"
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/secrets/provider"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 // mockState implements State interface and allows inspection of called
@@ -111,6 +114,22 @@ type mockModel struct {
 	statusData map[string]interface{}
 }
 
+func (m *mockModel) ControllerUUID() string {
+	return coretesting.ControllerTag.Id()
+}
+
+func (m *mockModel) Cloud() (cloud.Cloud, error) {
+	return cloud.Cloud{}, errors.NotImplemented
+}
+
+func (m *mockModel) CloudCredential() (*cloud.Credential, error) {
+	return nil, errors.NotImplemented
+}
+
+func (m *mockModel) Config() (*config.Config, error) {
+	return nil, errors.NotImplemented
+}
+
 var _ undertaker.Model = (*mockModel)(nil)
 
 func (m *mockModel) Owner() names.UserTag {
@@ -160,4 +179,14 @@ type mockWatcher struct {
 
 func (w *mockWatcher) Changes() <-chan struct{} {
 	return w.changes
+}
+
+type mockSecrets struct {
+	provider.SecretStoreProvider
+	cleanedUUID string
+}
+
+func (m *mockSecrets) CleanupModel(model provider.Model) error {
+	m.cleanedUUID = model.UUID()
+	return nil
 }

--- a/apiserver/facades/controller/undertaker/register.go
+++ b/apiserver/facades/controller/undertaker/register.go
@@ -7,7 +7,10 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/apiserver/common/secrets"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/secrets/provider"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -24,6 +27,12 @@ func newUndertakerFacade(ctx facade.Context) (*UndertakerAPI, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	return newUndertakerAPI(&stateShim{st, m}, ctx.Resources(), ctx.Auth())
+	secretsProviderGetter := func() (provider.SecretStoreProvider, provider.Model, error) {
+		model, err := st.Model()
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		return secrets.ProviderInfoForModel(model)
+	}
+	return newUndertakerAPI(&stateShim{st, m}, ctx.Resources(), ctx.Auth(), secretsProviderGetter)
 }

--- a/apiserver/facades/controller/undertaker/undertaker_test.go
+++ b/apiserver/facades/controller/undertaker/undertaker_test.go
@@ -6,6 +6,7 @@ package undertaker_test
 import (
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -15,12 +16,14 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/secrets/provider"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
 )
 
 type undertakerSuite struct {
 	coretesting.BaseSuite
+	secrets *mockSecrets
 }
 
 var _ = gc.Suite(&undertakerSuite{})
@@ -37,7 +40,10 @@ func (s *undertakerSuite) setupStateAndAPI(c *gc.C, isSystem bool, modelName str
 	}
 
 	st := newMockState(names.NewUserTag("admin"), modelName, isSystem)
-	api, err := undertaker.NewUndertaker(st, nil, authorizer)
+	s.secrets = &mockSecrets{}
+	api, err := undertaker.NewUndertaker(st, nil, authorizer, func() (provider.SecretStoreProvider, provider.Model, error) {
+		return s.secrets, st.model, nil
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	return st, api
 }
@@ -52,7 +58,9 @@ func (s *undertakerSuite) TestNoPerms(c *gc.C) {
 		_, err := undertaker.NewUndertaker(
 			st,
 			nil,
-			authorizer,
+			authorizer, func() (provider.SecretStoreProvider, provider.Model, error) {
+				return nil, nil, errors.NotImplemented
+			},
 		)
 		c.Assert(err, gc.ErrorMatches, "permission denied")
 	}
@@ -138,6 +146,7 @@ func (s *undertakerSuite) TestDeadRemoveModel(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(otherSt.removed, jc.IsTrue)
+	c.Assert(s.secrets.cleanedUUID, gc.Equals, otherSt.model.uuid)
 }
 
 func (s *undertakerSuite) TestModelConfig(c *gc.C) {

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -73,6 +73,7 @@ import (
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/pubsub/apiserver"
 	"github.com/juju/juju/rpc/params"
+	_ "github.com/juju/juju/secrets/provider/all"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/storage"
 	coretesting "github.com/juju/juju/testing"

--- a/secrets/provider/juju/secrets.go
+++ b/secrets/provider/juju/secrets.go
@@ -26,6 +26,11 @@ func (p jujuProvider) Initialise(m provider.Model) error {
 	return nil
 }
 
+// CleanupModel is not used.
+func (p jujuProvider) CleanupModel(m provider.Model) error {
+	return nil
+}
+
 // CleanupSecrets is not used.
 func (p jujuProvider) CleanupSecrets(m provider.Model, removed []*secrets.URI) error {
 	return nil

--- a/secrets/provider/kubernetes/secrets.go
+++ b/secrets/provider/kubernetes/secrets.go
@@ -37,6 +37,11 @@ func (p k8sProvider) Initialise(m provider.Model) error {
 	return nil
 }
 
+// CleanupModel is not used.
+func (p k8sProvider) CleanupModel(m provider.Model) error {
+	return nil
+}
+
 // CleanupSecrets is not used.
 func (p k8sProvider) CleanupSecrets(m provider.Model, removed []*secrets.URI) error {
 	return nil

--- a/secrets/provider/provider.go
+++ b/secrets/provider/provider.go
@@ -30,6 +30,10 @@ type SecretStoreProvider interface {
 	// with the removed secrets.
 	CleanupSecrets(m Model, removed []*secrets.URI) error
 
+	// CleanupModel removes any secrets / ACLs / resources
+	// associated with the model.
+	CleanupModel(m Model) error
+
 	// StoreConfig returns the config needed to create a vault secrets store client
 	// used to manage owned secrets and read shared secrets.
 	StoreConfig(m Model, adminUser bool, owned []*secrets.URI, read []*secrets.URI) (*StoreConfig, error)

--- a/secrets/provider/vault/errors.go
+++ b/secrets/provider/vault/errors.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vault
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/secrets"
+)
+
+func isNotFound(err error) bool {
+	var apiErr *api.ResponseError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusNotFound
+	}
+	return false
+}
+
+func isAlreadyExists(err error, message string) bool {
+	var apiErr *api.ResponseError
+	if errors.As(err, &apiErr) {
+		errMessage := strings.Join(apiErr.Errors, ",")
+		return apiErr.StatusCode == http.StatusBadRequest && strings.Contains(errMessage, message)
+	}
+	return false
+}
+
+func maybePermissionDenied(err error) error {
+	var apiErr *api.ResponseError
+	if errors.As(err, &apiErr) {
+		if apiErr.StatusCode == http.StatusForbidden {
+			return errors.WithType(err, secrets.PermissionDenied)
+		}
+	}
+	return err
+}

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -12,6 +12,9 @@ import (
 	"github.com/juju/juju/secrets/provider"
 )
 
+// PermissionDenied is returned when an api fails due to a permission issue.
+const PermissionDenied = errors.ConstError("permission denied")
+
 // secretsClient wraps a Juju secrets manager client.
 // If a store is specified, the secret content is managed
 // by the store instead of being stored in the Juju database.


### PR DESCRIPTION
When a model is destroyed, ensure any secrets related resources for that model are removed from the secrets store.

Also, for vault, add client-cert and client-key config options. And some improved error handling.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

See https://github.com/juju/juju/pull/14576
Plus, destroy a model with secrets and check vault to ensure there are no remaining policy or secrets left behind.