### PR TITLE
[JUJU-1740] better error message for add model with no credential

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -248,6 +248,11 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	addModelClient := c.newAddModelAPI(root)
 	model, err := addModelClient.CreateModel(c.Name, modelOwner, cloudTag.Id(), cloudRegion, credentialTag, attrs)
 	if err != nil {
+		if strings.HasPrefix(errors.Cause(err).Error(), "getting credential") {
+			err = errors.NewNotFound(nil,
+				fmt.Sprintf("%v\nSee `juju add-credential %s --help` for instructions", err, cloudTag.Id()))
+			return errors.Trace(err)
+		}
 		if params.IsCodeUnauthorized(err) {
 			common.PermissionsMessage(ctx.Stderr, "add a model")
 		}


### PR DESCRIPTION
This PR addresses this bug https://bugs.launchpad.net/juju/+bug/1988565. Adds some extra context to the returned error message.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Add a new user with superuser controller access and login to a controller:
```sh
juju bootstrap lxd lxd
juju change-user-password
juju add-user superadmin
juju grant superadmin superuser
juju change-user-password superadmin
juju logout
juju login
```
After login as `superadmin`, let's check our rights:

```
juju users
```

Add try to add model

```
juju add-model test-model
```
The result should be the ERROR:
```
$ juju add-model test-model
ERROR getting credential: cloud credential "localhost/superadmin/localhost" not found
See `juju add-credential localhost --help` for instructions
```