### PR TITLE
[JUJU-1631] Rewrite api/client/block unit tests to use gomock

### DIFF
--- a/api/client/block/client_test.go
+++ b/api/client/block/client_test.go
@@ -22,6 +22,8 @@ var _ = gc.Suite(&blockMockSuite{})
 
 func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	blockType := state.DestroyBlock.String()
 	msg := "for test switch block on"
 
@@ -41,6 +43,8 @@ func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
 
 func (s *blockMockSuite) TestSwitchBlockOnError(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	errmsg := "test error"
 
 	args := params.BlockSwitchParams{
@@ -62,6 +66,8 @@ func (s *blockMockSuite) TestSwitchBlockOnError(c *gc.C) {
 
 func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	blockType := state.DestroyBlock.String()
 
 	args := params.BlockSwitchParams{
@@ -81,6 +87,8 @@ func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
 
 func (s *blockMockSuite) TestSwitchBlockOffError(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	errmsg := "test error"
 
 	args := params.BlockSwitchParams{
@@ -101,6 +109,8 @@ func (s *blockMockSuite) TestSwitchBlockOffError(c *gc.C) {
 
 func (s *blockMockSuite) TestList(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	one := params.BlockResult{
 		Result: params.Block{
 			Id:      "-42",

--- a/api/client/block/client_test.go
+++ b/api/client/block/client_test.go
@@ -6,7 +6,6 @@ package block_test
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	basemocks "github.com/juju/juju/api/base/mocks"
@@ -23,7 +22,6 @@ var _ = gc.Suite(&blockMockSuite{})
 
 func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
 	ctrl := gomock.NewController(c)
-	called := false
 	blockType := state.DestroyBlock.String()
 	msg := "for test switch block on"
 
@@ -34,23 +32,15 @@ func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
 	result := new(params.ErrorResult)
 	results := params.ErrorResult{Error: nil}
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOn", args, result).SetArg(2, results).DoAndReturn(
-		func(arg0 string, args params.BlockSwitchParams, results *params.ErrorResult) error {
-			called = true
-			c.Assert(args.Message, gc.DeepEquals, msg)
-			c.Assert(args.Type, gc.DeepEquals, blockType)
-			return nil
-		})
+	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOn", args, result).SetArg(2, results).Return(nil)
 
 	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	err := blockClient.SwitchBlockOn(blockType, msg)
-	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.IsNil)
 }
 
 func (s *blockMockSuite) TestSwitchBlockOnError(c *gc.C) {
 	ctrl := gomock.NewController(c)
-	called := false
 	errmsg := "test error"
 
 	args := params.BlockSwitchParams{
@@ -63,21 +53,15 @@ func (s *blockMockSuite) TestSwitchBlockOnError(c *gc.C) {
 	}
 
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOn", args, result).SetArg(2, results).DoAndReturn(
-		func(arg0 string, args params.BlockSwitchParams, results *params.ErrorResult) error {
-			called = true
-			return nil
-		})
+	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOn", args, result).SetArg(2, results).Return(nil)
 
 	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	err := blockClient.SwitchBlockOn("", "")
-	c.Assert(called, jc.IsTrue)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
 }
 
 func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
 	ctrl := gomock.NewController(c)
-	called := false
 	blockType := state.DestroyBlock.String()
 
 	args := params.BlockSwitchParams{
@@ -88,25 +72,15 @@ func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
 	results := params.ErrorResult{Error: nil}
 
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOff", args, result).SetArg(2, results).DoAndReturn(
-		func(arg0 string, args params.BlockSwitchParams, results *params.ErrorResult) error {
-			called = true
-			// message is never sent, so this argument should
-			// always be empty string.
-			c.Assert(args.Message, gc.DeepEquals, "")
-			c.Assert(args.Type, gc.DeepEquals, blockType)
-			return nil
-		})
+	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOff", args, result).SetArg(2, results).Return(nil)
 
 	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	err := blockClient.SwitchBlockOff(blockType)
-	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.IsNil)
 }
 
 func (s *blockMockSuite) TestSwitchBlockOffError(c *gc.C) {
 	ctrl := gomock.NewController(c)
-	called := false
 	errmsg := "test error"
 
 	args := params.BlockSwitchParams{
@@ -118,21 +92,15 @@ func (s *blockMockSuite) TestSwitchBlockOffError(c *gc.C) {
 	}
 
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOff", args, result).SetArg(2, results).DoAndReturn(
-		func(arg0 string, args params.BlockSwitchParams, results *params.ErrorResult) error {
-			called = true
-			return nil
-		})
+	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOff", args, result).SetArg(2, results).Return(nil)
 
 	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	err := blockClient.SwitchBlockOff("")
-	c.Assert(called, jc.IsTrue)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
 }
 
 func (s *blockMockSuite) TestList(c *gc.C) {
 	ctrl := gomock.NewController(c)
-	var called bool
 	one := params.BlockResult{
 		Result: params.Block{
 			Id:      "-42",
@@ -151,14 +119,9 @@ func (s *blockMockSuite) TestList(c *gc.C) {
 		Results: []params.BlockResult{one, two},
 	}
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("List", nil, result).SetArg(2, results).DoAndReturn(
-		func(arg0 string, args interface{}, results *params.BlockResults) (*params.BlockResults, error) {
-			called = true
-			return results, apiservererrors.ServerError(errors.New(errmsg))
-		})
+	mockFacadeCaller.EXPECT().FacadeCall("List", nil, result).SetArg(2, results).Return(nil)
 	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	found, err := blockClient.List()
-	c.Assert(called, jc.IsTrue)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
 	c.Assert(found, gc.HasLen, 1)
 }

--- a/api/client/block/client_test.go
+++ b/api/client/block/client_test.go
@@ -4,135 +4,134 @@
 package block_test
 
 import (
+	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	basetesting "github.com/juju/juju/api/base/testing"
+	basemocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/block"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
-	coretesting "github.com/juju/juju/testing"
 )
 
 type blockMockSuite struct {
-	coretesting.BaseSuite
-	blockClient *block.Client
 }
 
 var _ = gc.Suite(&blockMockSuite{})
 
 func (s *blockMockSuite) TestSwitchBlockOn(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	called := false
 	blockType := state.DestroyBlock.String()
 	msg := "for test switch block on"
 
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, response interface{},
-		) error {
+	args := params.BlockSwitchParams{
+		Type:    blockType,
+		Message: msg,
+	}
+	result := new(params.ErrorResult)
+	results := params.ErrorResult{Error: nil}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOn", args, result).SetArg(2, results).DoAndReturn(
+		func(arg0 string, args params.BlockSwitchParams, results *params.ErrorResult) error {
 			called = true
-			c.Check(objType, gc.Equals, "Block")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "SwitchBlockOn")
-
-			args, ok := a.(params.BlockSwitchParams)
-			c.Assert(ok, jc.IsTrue)
 			c.Assert(args.Message, gc.DeepEquals, msg)
 			c.Assert(args.Type, gc.DeepEquals, blockType)
-
-			_, ok = response.(*params.ErrorResult)
-			c.Assert(ok, jc.IsTrue)
-
 			return nil
 		})
-	blockClient := block.NewClient(apiCaller)
+
+	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	err := blockClient.SwitchBlockOn(blockType, msg)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.IsNil)
 }
 
 func (s *blockMockSuite) TestSwitchBlockOnError(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	called := false
 	errmsg := "test error"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, response interface{},
-		) error {
-			called = true
-			result, ok := response.(*params.ErrorResult)
-			c.Assert(ok, jc.IsTrue)
-			result.Error = apiservererrors.ServerError(errors.New(errmsg))
 
+	args := params.BlockSwitchParams{
+		Type:    "",
+		Message: "",
+	}
+	result := new(params.ErrorResult)
+	results := params.ErrorResult{
+		Error: apiservererrors.ServerError(errors.New(errmsg)),
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOn", args, result).SetArg(2, results).DoAndReturn(
+		func(arg0 string, args params.BlockSwitchParams, results *params.ErrorResult) error {
+			called = true
 			return nil
 		})
-	blockClient := block.NewClient(apiCaller)
+
+	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	err := blockClient.SwitchBlockOn("", "")
 	c.Assert(called, jc.IsTrue)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
 }
 
 func (s *blockMockSuite) TestSwitchBlockOff(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	called := false
 	blockType := state.DestroyBlock.String()
 
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, response interface{},
-		) error {
-			called = true
-			c.Check(objType, gc.Equals, "Block")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "SwitchBlockOff")
+	args := params.BlockSwitchParams{
+		Type:    blockType,
+		Message: "",
+	}
+	result := new(params.ErrorResult)
+	results := params.ErrorResult{Error: nil}
 
-			args, ok := a.(params.BlockSwitchParams)
-			c.Assert(ok, jc.IsTrue)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOff", args, result).SetArg(2, results).DoAndReturn(
+		func(arg0 string, args params.BlockSwitchParams, results *params.ErrorResult) error {
+			called = true
 			// message is never sent, so this argument should
 			// always be empty string.
 			c.Assert(args.Message, gc.DeepEquals, "")
 			c.Assert(args.Type, gc.DeepEquals, blockType)
-
-			_, ok = response.(*params.ErrorResult)
-			c.Assert(ok, jc.IsTrue)
-
 			return nil
 		})
-	blockClient := block.NewClient(apiCaller)
+
+	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	err := blockClient.SwitchBlockOff(blockType)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.IsNil)
 }
 
 func (s *blockMockSuite) TestSwitchBlockOffError(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	called := false
 	errmsg := "test error"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, response interface{},
-		) error {
-			called = true
-			result, ok := response.(*params.ErrorResult)
-			c.Assert(ok, jc.IsTrue)
-			result.Error = apiservererrors.ServerError(errors.New(errmsg))
 
+	args := params.BlockSwitchParams{
+		Type: "",
+	}
+	result := new(params.ErrorResult)
+	results := params.ErrorResult{
+		Error: apiservererrors.ServerError(errors.New(errmsg)),
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SwitchBlockOff", args, result).SetArg(2, results).DoAndReturn(
+		func(arg0 string, args params.BlockSwitchParams, results *params.ErrorResult) error {
+			called = true
 			return nil
 		})
-	blockClient := block.NewClient(apiCaller)
+
+	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	err := blockClient.SwitchBlockOff("")
 	c.Assert(called, jc.IsTrue)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)
 }
 
 func (s *blockMockSuite) TestList(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	var called bool
 	one := params.BlockResult{
 		Result: params.Block{
@@ -146,23 +145,18 @@ func (s *blockMockSuite) TestList(c *gc.C) {
 	two := params.BlockResult{
 		Error: apiservererrors.ServerError(errors.New(errmsg)),
 	}
-	apiCaller := basetesting.APICallerFunc(
-		func(
-			objType string,
-			version int,
-			id, request string,
-			a, response interface{}) error {
-			called = true
-			c.Check(objType, gc.Equals, "Block")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "List")
-			c.Assert(a, gc.IsNil)
 
-			result := response.(*params.BlockResults)
-			result.Results = []params.BlockResult{one, two}
-			return nil
+	result := new(params.BlockResults)
+	results := params.BlockResults{
+		Results: []params.BlockResult{one, two},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("List", nil, result).SetArg(2, results).DoAndReturn(
+		func(arg0 string, args interface{}, results *params.BlockResults) (*params.BlockResults, error) {
+			called = true
+			return results, apiservererrors.ServerError(errors.New(errmsg))
 		})
-	blockClient := block.NewClient(apiCaller)
+	blockClient := block.NewClientFromCaller(mockFacadeCaller)
 	found, err := blockClient.List()
 	c.Assert(called, jc.IsTrue)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, errmsg)

--- a/api/client/block/package_test.go
+++ b/api/client/block/package_test.go
@@ -1,14 +1,22 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package block_test
+package block
 
 import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
 )
 
 func TestAll(t *testing.T) {
 	gc.TestingT(t)
+}
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
 }


### PR DESCRIPTION
The unit tests for `api/client/block` now use go mock and not juju/testing. All unit tests should pass.