### PR TITLE
[JUJU-1632] Rewrite api/client/bundle unit tests to use gomock

### DIFF
--- a/api/client/bundle/client_test.go
+++ b/api/client/bundle/client_test.go
@@ -4,29 +4,22 @@
 package bundle_test
 
 import (
+	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	basetesting "github.com/juju/juju/api/base/testing"
+	basemocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/bundle"
 	"github.com/juju/juju/rpc/params"
-	coretesting "github.com/juju/juju/testing"
 )
 
-const apiVersion = 6
-
 type bundleMockSuite struct {
-	coretesting.BaseSuite
-	bundleClient *bundle.Client
 }
 
 var _ = gc.Suite(&bundleMockSuite{})
 
-func newClient(f basetesting.APICallerFunc, ver int) *bundle.Client {
-	return bundle.NewClient(basetesting.BestVersionCaller{f, ver})
-}
-
 func (s *bundleMockSuite) TestGetChanges(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	bundleURL := "cs:bundle-url"
 	bundleYAML := `applications:
 	ubuntu:
@@ -65,26 +58,18 @@ func (s *bundleMockSuite) TestGetChanges(c *gc.C) {
 			Requires: []string{"$addCharm-0"},
 		},
 	}
-	client := newClient(
-		func(objType string,
-			version int,
-			id,
-			request string,
-			args,
-			response interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Bundle")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "GetChanges")
-			c.Assert(args, gc.Equals, params.BundleChangesParams{
-				BundleDataYAML: bundleYAML,
-				BundleURL:      bundleURL,
-			})
-			result := response.(*params.BundleChangesResults)
-			result.Changes = changes
-			return nil
-		}, apiVersion,
-	)
+
+	args := params.BundleChangesParams{
+		BundleDataYAML: bundleYAML,
+		BundleURL:      bundleURL,
+	}
+	res := new(params.BundleChangesResults)
+	results := params.BundleChangesResults{
+		Changes: changes,
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("GetChanges", args, res).SetArg(2, results).Return(nil)
+	client := bundle.NewClientFromCaller(mockFacadeCaller)
 	result, err := client.GetChanges(bundleURL, bundleYAML)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Errors, gc.DeepEquals, []string(nil))
@@ -92,6 +77,7 @@ func (s *bundleMockSuite) TestGetChanges(c *gc.C) {
 }
 
 func (s *bundleMockSuite) TestGetChangesReturnsErrors(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	bundleURL := "cs:bundle-url"
 	bundleYAML := `applications:
 	ubuntu:
@@ -101,28 +87,19 @@ func (s *bundleMockSuite) TestGetChangesReturnsErrors(c *gc.C) {
 		options:
 			key: value
 			series: focal`
-	client := newClient(
-		func(objType string,
-			version int,
-			id,
-			request string,
-			args,
-			response interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Bundle")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "GetChanges")
-			c.Assert(args, gc.Equals, params.BundleChangesParams{
-				BundleDataYAML: bundleYAML,
-				BundleURL:      bundleURL,
-			})
-			result := response.(*params.BundleChangesResults)
-			result.Errors = []string{
-				"Error returned from request",
-			}
-			return nil
-		}, apiVersion,
-	)
+	args := params.BundleChangesParams{
+		BundleDataYAML: bundleYAML,
+		BundleURL:      bundleURL,
+	}
+	res := new(params.BundleChangesResults)
+	results := params.BundleChangesResults{
+		Errors: []string{
+			"Error returned from request",
+		},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("GetChanges", args, res).SetArg(2, results).Return(nil)
+	client := bundle.NewClientFromCaller(mockFacadeCaller)
 	result, err := client.GetChanges(bundleURL, bundleYAML)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Errors, gc.DeepEquals, []string{"Error returned from request"})
@@ -130,6 +107,7 @@ func (s *bundleMockSuite) TestGetChangesReturnsErrors(c *gc.C) {
 }
 
 func (s *bundleMockSuite) TestGetChangesMapArgs(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	bundleURL := "cs:bundle-url"
 	bundleYAML := `applications:
 	ubuntu:
@@ -164,26 +142,18 @@ func (s *bundleMockSuite) TestGetChangesMapArgs(c *gc.C) {
 			Requires: []string{"$addCharm-0"},
 		},
 	}
-	client := newClient(
-		func(objType string,
-			version int,
-			id,
-			request string,
-			args,
-			response interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Bundle")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "GetChangesMapArgs")
-			c.Assert(args, gc.Equals, params.BundleChangesParams{
-				BundleDataYAML: bundleYAML,
-				BundleURL:      bundleURL,
-			})
-			result := response.(*params.BundleChangesMapArgsResults)
-			result.Changes = changes
-			return nil
-		}, apiVersion,
-	)
+
+	args := params.BundleChangesParams{
+		BundleDataYAML: bundleYAML,
+		BundleURL:      bundleURL,
+	}
+	res := new(params.BundleChangesMapArgsResults)
+	results := params.BundleChangesMapArgsResults{
+		Changes: changes,
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("GetChangesMapArgs", args, res).SetArg(2, results).Return(nil)
+	client := bundle.NewClientFromCaller(mockFacadeCaller)
 	result, err := client.GetChangesMapArgs(bundleURL, bundleYAML)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Errors, gc.DeepEquals, []string(nil))
@@ -191,6 +161,7 @@ func (s *bundleMockSuite) TestGetChangesMapArgs(c *gc.C) {
 }
 
 func (s *bundleMockSuite) TestGetChangesMapArgsReturnsErrors(c *gc.C) {
+	ctrl := gomock.NewController(c)
 	bundleURL := "cs:bundle-url"
 	bundleYAML := `applications:
 	ubuntu:
@@ -202,28 +173,20 @@ func (s *bundleMockSuite) TestGetChangesMapArgsReturnsErrors(c *gc.C) {
 			series: focal
 		relations:
 			- []`
-	client := newClient(
-		func(objType string,
-			version int,
-			id,
-			request string,
-			args,
-			response interface{},
-		) error {
-			c.Check(objType, gc.Equals, "Bundle")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "GetChangesMapArgs")
-			c.Assert(args, gc.Equals, params.BundleChangesParams{
-				BundleDataYAML: bundleYAML,
-				BundleURL:      bundleURL,
-			})
-			result := response.(*params.BundleChangesMapArgsResults)
-			result.Errors = []string{
-				"Error returned from request",
-			}
-			return nil
-		}, apiVersion,
-	)
+
+	args := params.BundleChangesParams{
+		BundleDataYAML: bundleYAML,
+		BundleURL:      bundleURL,
+	}
+	res := new(params.BundleChangesMapArgsResults)
+	results := params.BundleChangesMapArgsResults{
+		Errors: []string{
+			"Error returned from request",
+		},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("GetChangesMapArgs", args, res).SetArg(2, results).Return(nil)
+	client := bundle.NewClientFromCaller(mockFacadeCaller)
 	result, err := client.GetChangesMapArgs(bundleURL, bundleYAML)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Errors, gc.DeepEquals, []string{"Error returned from request"})
@@ -231,7 +194,8 @@ func (s *bundleMockSuite) TestGetChangesMapArgsReturnsErrors(c *gc.C) {
 }
 
 func (s *bundleMockSuite) TestExportBundleLatest(c *gc.C) {
-	bundle := `applications:
+	ctrl := gomock.NewController(c)
+	bundleStr := `applications:
 	ubuntu:
 		charm: ch:ubuntu
 		series: jammy
@@ -243,22 +207,18 @@ func (s *bundleMockSuite) TestExportBundleLatest(c *gc.C) {
 			series: focal
 		relations:
 			- []`
-	client := newClient(
-		func(objType string, version int,
-			id,
-			request string,
-			args,
-			response interface{},
-		) error {
-			c.Assert(args, jc.DeepEquals, params.ExportBundleParams{
-				IncludeCharmDefaults: true,
-			})
-			result := response.(*params.StringResult)
-			result.Result = bundle
-			return nil
-		}, apiVersion,
-	)
+
+	args := params.ExportBundleParams{
+		IncludeCharmDefaults: true,
+	}
+	res := new(params.StringResult)
+	results := params.StringResult{
+		Result: bundleStr,
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ExportBundle", args, res).SetArg(2, results).Return(nil)
+	client := bundle.NewClientFromCaller(mockFacadeCaller)
 	result, err := client.ExportBundle(true)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, bundle)
+	c.Assert(result, jc.DeepEquals, bundleStr)
 }

--- a/api/client/bundle/client_test.go
+++ b/api/client/bundle/client_test.go
@@ -20,6 +20,8 @@ var _ = gc.Suite(&bundleMockSuite{})
 
 func (s *bundleMockSuite) TestGetChanges(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	bundleURL := "cs:bundle-url"
 	bundleYAML := `applications:
 	ubuntu:
@@ -78,6 +80,8 @@ func (s *bundleMockSuite) TestGetChanges(c *gc.C) {
 
 func (s *bundleMockSuite) TestGetChangesReturnsErrors(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	bundleURL := "cs:bundle-url"
 	bundleYAML := `applications:
 	ubuntu:
@@ -108,6 +112,8 @@ func (s *bundleMockSuite) TestGetChangesReturnsErrors(c *gc.C) {
 
 func (s *bundleMockSuite) TestGetChangesMapArgs(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	bundleURL := "cs:bundle-url"
 	bundleYAML := `applications:
 	ubuntu:
@@ -162,6 +168,8 @@ func (s *bundleMockSuite) TestGetChangesMapArgs(c *gc.C) {
 
 func (s *bundleMockSuite) TestGetChangesMapArgsReturnsErrors(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	bundleURL := "cs:bundle-url"
 	bundleYAML := `applications:
 	ubuntu:
@@ -195,6 +203,8 @@ func (s *bundleMockSuite) TestGetChangesMapArgsReturnsErrors(c *gc.C) {
 
 func (s *bundleMockSuite) TestExportBundleLatest(c *gc.C) {
 	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	bundleStr := `applications:
 	ubuntu:
 		charm: ch:ubuntu

--- a/api/client/bundle/package_test.go
+++ b/api/client/bundle/package_test.go
@@ -1,14 +1,22 @@
 // Copyright 2018 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package bundle_test
+package bundle
 
 import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
 )
 
 func TestAll(t *testing.T) {
 	gc.TestingT(t)
+}
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
 }


### PR DESCRIPTION
The unit tests for api/client/bundle now use go mock and not juju/testing. All unit tests should pass.