### PR TITLE
k8s controllers accept --controller-charm-name=ch:*

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -295,6 +295,9 @@ type StateInitializationParams struct {
 	// to a controller.
 	ControllerConfig controller.Config
 
+	// ControllerCharmPath points to a controller charm on Charmhub.
+	ControllerCharmPath string
+
 	// ControllerCharmRisk is used when deploying the controller charm.
 	ControllerCharmRisk string
 
@@ -359,6 +362,7 @@ type stateInitializationParamsInternal struct {
 	ControllerCloudRegion                   string                            `yaml:"controller-cloud-region"`
 	ControllerCloudCredentialName           string                            `yaml:"controller-cloud-credential-name,omitempty"`
 	ControllerCloudCredential               *cloud.Credential                 `yaml:"controller-cloud-credential,omitempty"`
+	ControllerCharmPath                     string                            `yaml:"controller-charm-path,omitempty"`
 	ControllerCharmRisk                     string                            `yaml:"controller-charm-risk,omitempty"`
 }
 
@@ -390,6 +394,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		ControllerCloudRegion:                   p.ControllerCloudRegion,
 		ControllerCloudCredentialName:           p.ControllerCloudCredentialName,
 		ControllerCloudCredential:               p.ControllerCloudCredential,
+		ControllerCharmPath:                     p.ControllerCharmPath,
 		ControllerCharmRisk:                     p.ControllerCharmRisk,
 	}
 	return yaml.Marshal(&internal)
@@ -432,6 +437,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		ControllerCloudRegion:                   internal.ControllerCloudRegion,
 		ControllerCloudCredentialName:           internal.ControllerCloudCredentialName,
 		ControllerCloudCredential:               internal.ControllerCloudCredential,
+		ControllerCharmPath:                     internal.ControllerCharmPath,
 		ControllerCharmRisk:                     internal.ControllerCharmRisk,
 	}
 	return nil

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -374,7 +374,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	// Deploy and set up the controller charm and application.
-	if err := c.deployControllerCharm(st, args.BootstrapMachineConstraints, args.ControllerCharmRisk, isCAAS, controllerUnitPassword); err != nil {
+	if err := c.deployControllerCharm(st, args.BootstrapMachineConstraints, args.ControllerCharmPath, args.ControllerCharmRisk, isCAAS, controllerUnitPassword); err != nil {
 		return errors.Annotate(err, "cannot deploy controller application")
 	}
 

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -35,7 +35,7 @@ import (
 
 const controllerCharmURL = "ch:juju-controller"
 
-func (c *BootstrapCommand) deployControllerCharm(st *state.State, cons constraints.Value, charmRisk string, isCAAS bool, unitPassword string) (resultErr error) {
+func (c *BootstrapCommand) deployControllerCharm(st *state.State, cons constraints.Value, charmPath, charmRisk string, isCAAS bool, unitPassword string) (resultErr error) {
 	arch := corearch.DefaultArchitecture
 	series := coreseries.LatestLTS()
 	if cons.HasArch() {
@@ -90,7 +90,7 @@ func (c *BootstrapCommand) deployControllerCharm(st *state.State, cons constrain
 	// If no local charm, use the one from charmhub.
 	if err != nil {
 		source = "store"
-		if curl, origin, err = populateStoreControllerCharm(st, charmRisk, series, arch); err != nil {
+		if curl, origin, err = populateStoreControllerCharm(st, charmPath, charmRisk, series, arch); err != nil {
 			return errors.Annotate(err, "deploying charmhub controller charm")
 		}
 	}
@@ -129,7 +129,7 @@ var (
 )
 
 // populateStoreControllerCharm downloads and stores the controller charm from charmhub.
-func populateStoreControllerCharm(st *state.State, charmRisk, series, arch string) (*charm.URL, *corecharm.Origin, error) {
+func populateStoreControllerCharm(st *state.State, charmPath, charmRisk, series, arch string) (*charm.URL, *corecharm.Origin, error) {
 	model, err := st.Model()
 	if err != nil {
 		return nil, nil, err
@@ -148,7 +148,12 @@ func populateStoreControllerCharm(st *state.State, charmRisk, series, arch strin
 		return nil, nil, err
 	}
 
-	curl := charm.MustParseURL(controllerCharmURL)
+	var curl *charm.URL
+	if charmPath == "" {
+		curl = charm.MustParseURL(controllerCharmURL)
+	} else {
+		curl = charm.MustParseURL(charmPath)
+	}
 	channel, err := charm.ParseChannelNormalize(charmRisk)
 	if err != nil {
 		return nil, nil, err

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -855,6 +855,7 @@ func finalizePodBootstrapConfig(
 	pcfg.Bootstrap.ControllerServiceType = args.ControllerServiceType
 	pcfg.Bootstrap.ControllerExternalName = args.ControllerExternalName
 	pcfg.Bootstrap.ControllerExternalIPs = append([]string(nil), args.ControllerExternalIPs...)
+	pcfg.Bootstrap.ControllerCharmPath = args.ControllerCharmPath
 	pcfg.Bootstrap.ControllerCharmRisk = args.ControllerCharmRisk
 	return nil
 }


### PR DESCRIPTION
K8s controllers don't allow specifying a local controller charm, since we can't create storage on the cluster for the charm. However, this issue doesn't apply for Charmhub charms, so we should allow specifying `--controller-charm-path=ch:something` at bootstrap time.

## QA steps

*Commands to run to verify that the change works.*

```console
$ make go-build
$ make microk8s-operator-update

$ juju bootstrap microk8s c1
$ juju bootstrap microk8s c2 --controller-charm-path=ch:juju-controller
$ juju bootstrap microk8s c3 --controller-charm-path=ch:barrettj12-cc   # custom controller charm

$ juju download juju-controller --channel beta --series focal
Fetching charm "juju-controller" using "beta" channel and base "amd64/ubuntu/20.04"
Install the "juju-controller" charm with:
    juju deploy ./juju-controller_52fd8d5.charm
$ juju bootstrap microk8s c4 --controller-charm-path=./juju-controller_52fd8d5.charm
ERROR deploying a local controller charm on a k8s controller not supported
```