### PR TITLE
Create actionNotification doc for pending actions only during model m…

### DIFF
--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1138,3 +1138,19 @@ func (st *State) ScheduleForceCleanup(kind cleanupKind, name string, maxWait tim
 func GetCollectionCappedInfo(coll *mgo.Collection) (bool, int, error) {
 	return getCollectionCappedInfo(coll)
 }
+
+func (m *Model) AllActionIDsHasActionNotifications() ([]string, error) {
+	actionNotifications, closer := m.st.db().GetCollection(actionNotificationsC)
+	defer closer()
+
+	docs := []actionNotificationDoc{}
+	err := actionNotifications.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get all actions")
+	}
+	actionIDs := make([]string, len(docs))
+	for i, doc := range docs {
+		actionIDs[i] = doc.ActionID
+	}
+	return actionIDs, nil
+}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -2191,7 +2191,7 @@ func (i *importer) addAction(action description.Action) error {
 		Insert: newDoc,
 	}}
 
-	if newDoc.Status == ActionPending {
+	if activeStatus.Contains(string(newDoc.Status)) {
 		prefix := ensureActionMarker(action.Receiver())
 		notificationDoc := &actionNotificationDoc{
 			DocId:     i.st.docID(prefix + action.Id()),

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -5,6 +5,7 @@ package state_test
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"time" // only uses time.Time values
 
@@ -1986,20 +1987,61 @@ func (s *MigrationImportSuite) TestAction(c *gc.C) {
 	m, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)
 
+	// pending action.
 	operationIDPending, err := m.EnqueueOperation("a test", 2)
 	c.Assert(err, jc.ErrorIsNil)
-	action, err := m.EnqueueAction(operationIDPending, machine.MachineTag(), "action-pending", nil, nil)
+	actionPending, err := m.EnqueueAction(operationIDPending, machine.MachineTag(), "action-pending", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(action.Status(), gc.Equals, state.ActionPending)
+	c.Assert(actionPending.Status(), gc.Equals, state.ActionPending)
 
+	// running action.
 	operationIDRunning, err := m.EnqueueOperation("another test", 2)
 	c.Assert(err, jc.ErrorIsNil)
-	action, err = m.EnqueueAction(operationIDRunning, machine.MachineTag(), "action-running", nil, nil)
+	actionRunning, err := m.EnqueueAction(operationIDRunning, machine.MachineTag(), "action-running", nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(action.Status(), gc.Equals, state.ActionPending)
-	action, err = action.Begin()
+	c.Assert(actionRunning.Status(), gc.Equals, state.ActionPending)
+	actionRunning, err = actionRunning.Begin()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(action.Status(), gc.Equals, state.ActionRunning)
+	c.Assert(actionRunning.Status(), gc.Equals, state.ActionRunning)
+
+	// aborting action.
+	operationIDAborting, err := m.EnqueueOperation("another test", 2)
+	c.Assert(err, jc.ErrorIsNil)
+	actionAborting, err := m.EnqueueAction(operationIDAborting, machine.MachineTag(), "action-aborting", nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionAborting.Status(), gc.Equals, state.ActionPending)
+	actionAborting, err = actionAborting.Begin()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionAborting.Status(), gc.Equals, state.ActionRunning)
+	actionAborting, err = actionAborting.Finish(state.ActionResults{Status: state.ActionAborting})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionAborting.Status(), gc.Equals, state.ActionAborting)
+
+	// aborted action.
+	operationIDAborted, err := m.EnqueueOperation("another test", 2)
+	c.Assert(err, jc.ErrorIsNil)
+	actionAborted, err := m.EnqueueAction(operationIDAborted, machine.MachineTag(), "action-aborted", nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionAborted.Status(), gc.Equals, state.ActionPending)
+	actionAborted, err = actionAborted.Begin()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionAborted.Status(), gc.Equals, state.ActionRunning)
+	actionAborted, err = actionAborted.Finish(state.ActionResults{Status: state.ActionAborted})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionAborted.Status(), gc.Equals, state.ActionAborted)
+
+	// completed action.
+	operationIDCompleted, err := m.EnqueueOperation("another test", 2)
+	c.Assert(err, jc.ErrorIsNil)
+	actionCompleted, err := m.EnqueueAction(operationIDCompleted, machine.MachineTag(), "action-completed", nil, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionCompleted.Status(), gc.Equals, state.ActionPending)
+	actionCompleted, err = actionCompleted.Begin()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionCompleted.Status(), gc.Equals, state.ActionRunning)
+	actionCompleted, err = actionCompleted.Finish(state.ActionResults{Status: state.ActionCompleted})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(actionCompleted.Status(), gc.Equals, state.ActionCompleted)
 
 	newModel, newState := s.importModel(c, s.State)
 	defer func() {
@@ -2008,25 +2050,54 @@ func (s *MigrationImportSuite) TestAction(c *gc.C) {
 
 	actions, err := newModel.AllActions()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actions, gc.HasLen, 2)
+	c.Assert(actions, gc.HasLen, 5)
 
-	actionPending := actions[0]
+	actionPending, err = newModel.ActionByTag(actionPending.ActionTag())
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(actionPending.Receiver(), gc.Equals, machine.Id())
 	c.Check(actionPending.Name(), gc.Equals, "action-pending")
 	c.Check(state.ActionOperationId(actionPending), gc.Equals, operationIDPending)
 	c.Check(actionPending.Status(), gc.Equals, state.ActionPending)
 
-	actionRunning := actions[1]
+	actionRunning, err = newModel.ActionByTag(actionRunning.ActionTag())
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(actionRunning.Receiver(), gc.Equals, machine.Id())
 	c.Check(actionRunning.Name(), gc.Equals, "action-running")
 	c.Check(state.ActionOperationId(actionRunning), gc.Equals, operationIDRunning)
 	c.Check(actionRunning.Status(), gc.Equals, state.ActionRunning)
 
-	// Only pending actions will have action notification docs imported.
+	actionAborting, err = newModel.ActionByTag(actionAborting.ActionTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(actionAborting.Receiver(), gc.Equals, machine.Id())
+	c.Check(actionAborting.Name(), gc.Equals, "action-aborting")
+	c.Check(state.ActionOperationId(actionAborting), gc.Equals, operationIDAborting)
+	c.Check(actionAborting.Status(), gc.Equals, state.ActionAborting)
+
+	actionAborted, err = newModel.ActionByTag(actionAborted.ActionTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(actionAborted.Receiver(), gc.Equals, machine.Id())
+	c.Check(actionAborted.Name(), gc.Equals, "action-aborted")
+	c.Check(state.ActionOperationId(actionAborted), gc.Equals, operationIDAborted)
+	c.Check(actionAborted.Status(), gc.Equals, state.ActionAborted)
+
+	actionCompleted, err = newModel.ActionByTag(actionCompleted.ActionTag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(actionCompleted.Receiver(), gc.Equals, machine.Id())
+	c.Check(actionCompleted.Name(), gc.Equals, "action-completed")
+	c.Check(state.ActionOperationId(actionCompleted), gc.Equals, operationIDCompleted)
+	c.Check(actionCompleted.Status(), gc.Equals, state.ActionCompleted)
+
+	// Only pending/running/aborting actions will have action notification docs imported.
 	actionIDs, err := newModel.AllActionIDsHasActionNotifications()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(actionIDs, gc.HasLen, 1)
-	c.Check(actionIDs[0], gc.Equals, actionPending.Id())
+	sort.Strings(actionIDs)
+	expectedIDs := []string{
+		actionRunning.Id(),
+		actionPending.Id(),
+		actionAborting.Id(),
+	}
+	sort.Strings(expectedIDs)
+	c.Check(actionIDs, gc.DeepEquals, expectedIDs)
 }
 
 func (s *MigrationImportSuite) TestOperation(c *gc.C) {


### PR DESCRIPTION
Action notification docs are created for notifying uniters to process `pending/running/aborting` action docs which means that any non-pending/running/aborting actions should never have related action notification docs at all.
If we have a non-pending/running/aborting action has an action notification doc, the uniter will receive a notification event to process a completed action which confuses the uniter and make the uniter fall into an infinite loop of the `resolver.ErrNoOperation` and blocks the uniter forever.

This PR ensures we create action notification docs for pending actions only during model migration;

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju bootstrap lxd k2 --config test-mode=true

$ juju bootstrap lxd k1 --config test-mode=true

$ juju add-model t1
Added 't1' model on localhost/localhost with credential 'localhost' for user 'admin'

$ juju deploy juju-qa-dummy-source
Located charm "juju-qa-dummy-source" in charm-hub, revision 6
Deploying "juju-qa-dummy-source" from charm-hub charm "juju-qa-dummy-source", revision 6 in channel stable on focal

$ juju run-action dummy-source/0 --wait=5m echo value=b --format yaml -m k1:t1  --debug
unit-dummy-source-0:
  UnitId: dummy-source/0
  id: "2"
  results:
    Stderr: |
      ++ action-get value
      + value=b
      + '[' -z b ']'
      + action-set echo.value=b
      + action-set outcome=success
    echo:
      value: b
    outcome: success
  status: completed
  timing:
    completed: 2022-09-08 04:27:30 +0000 UTC
    enqueued: 2022-09-08 04:27:09 +0000 UTC
    started: 2022-09-08 04:27:30 +0000 UTC

$ juju run-action dummy-source/0 --wait=5m echo value=1 --format yaml -m k1:t1
errors:
  0: 'validation failed: (root).value : must be of type string, given 1'

$ juju migrate k1:t1 k2
Migration started with ID "3df71ab6-0c8d-46d4-8f02-aae43129a33d:0"

$ juju switch k2:t1
k1:admin/t1 -> k2:admin/t1

$ juju add-unit -n 1 dummy-source

$ juju run-action dummy-source/0 --wait=5m echo value=b --format yaml -m k2:t1  --debug
unit-dummy-source-0:
  UnitId: dummy-source/0
  id: "8"
  results:
    Stderr: |
      ++ action-get value
      + value=b
      + '[' -z b ']'
      + action-set echo.value=b
      + action-set outcome=success
    echo:
      value: b
    outcome: success
  status: completed
  timing:
    completed: 2022-09-08 04:30:50 +0000 UTC
    enqueued: 2022-09-08 04:30:48 +0000 UTC
    started: 2022-09-08 04:30:49 +0000 UTC

$ juju run-action dummy-source/1 --wait=5m echo value=b --format yaml -m k2:t1  --debug
unit-dummy-source-1:
  UnitId: dummy-source/1
  id: "10"
  results:
    Stderr: |
      ++ action-get value
      + value=b
      + '[' -z b ']'
      + action-set echo.value=b
      + action-set outcome=success
    echo:
      value: b
    outcome: success
  status: completed
  timing:
    completed: 2022-09-08 04:31:12 +0000 UTC
    enqueued: 2022-09-08 04:30:56 +0000 UTC
    started: 2022-09-08 04:31:11 +0000 UTC

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1987716