### PR TITLE
Use generics to simplify core/network address matching

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -252,7 +252,7 @@ func networkAddressesToStateArgs(
 			ProviderSubnetID:  dev.ProviderSubnetId,
 			ConfigMethod:      configType,
 			CIDRAddress:       cidrAddress,
-			DNSServers:        dev.DNSServers.ToIPAddresses(),
+			DNSServers:        dev.DNSServers.Values(),
 			DNSSearchDomains:  dev.DNSSearchDomains,
 			GatewayAddress:    dev.GatewayAddress.Value,
 			IsDefaultGateway:  dev.IsDefaultGateway,

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -469,10 +469,10 @@ func (a ProviderAddress) String() string {
 // supporting conversion to SpaceAddresses.
 type ProviderAddresses []ProviderAddress
 
-// ToIPAddresses transforms the ProviderAddresses to a string slice containing
+// Values transforms the ProviderAddresses to a string slice containing
 // their raw IP values.
-func (pas ProviderAddresses) ToIPAddresses() []string {
-	return toIPAddresses(pas)
+func (pas ProviderAddresses) Values() []string {
+	return toStrings(pas)
 }
 
 // ToSpaceAddresses transforms the ProviderAddresses to SpaceAddresses by using
@@ -571,15 +571,7 @@ func NewSpaceAddresses(inAddresses ...string) (outAddresses SpaceAddresses) {
 // Values returns a slice of strings containing the IP/host-name of each of
 // the receiver addresses.
 func (sas SpaceAddresses) Values() []string {
-	if sas == nil {
-		return nil
-	}
-
-	values := make([]string, len(sas))
-	for i, a := range sas {
-		values[i] = a.Value
-	}
-	return values
+	return toStrings(sas)
 }
 
 // ToProviderAddresses transforms the SpaceAddresses to ProviderAddresses by using
@@ -882,9 +874,9 @@ func IsNoAddressError(err error) bool {
 	return ok
 }
 
-// toIPAddresses returns the IP addresses in string form for input
+// toStrings returns the IP addresses in string form for input
 // that is a slice of types implementing the Address interface.
-func toIPAddresses[T Address](addrs []T) []string {
+func toStrings[T Address](addrs []T) []string {
 	if addrs == nil {
 		return nil
 	}

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -472,15 +472,7 @@ type ProviderAddresses []ProviderAddress
 // ToIPAddresses transforms the ProviderAddresses to a string slice containing
 // their raw IP values.
 func (pas ProviderAddresses) ToIPAddresses() []string {
-	if pas == nil {
-		return nil
-	}
-
-	ips := make([]string, len(pas))
-	for i, addr := range pas {
-		ips[i] = addr.Value
-	}
-	return ips
+	return toIPAddresses(pas)
 }
 
 // ToSpaceAddresses transforms the ProviderAddresses to SpaceAddresses by using
@@ -515,7 +507,7 @@ func (pas ProviderAddresses) ToSpaceAddresses(lookup SpaceLookup) (SpaceAddresse
 // OneMatchingScope returns the address that best satisfies the input scope
 // matching function. The boolean return indicates if a match was found.
 func (pas ProviderAddresses) OneMatchingScope(getMatcher ScopeMatchFunc) (ProviderAddress, bool) {
-	indexes := indexesForScope(len(pas), func(i int) Address { return pas[i] }, getMatcher)
+	indexes := indexesForScope(pas, getMatcher)
 	if len(indexes) == 0 {
 		return ProviderAddress{}, false
 	}
@@ -657,15 +649,7 @@ func (sas SpaceAddresses) OneMatchingScope(getMatcher ScopeMatchFunc) (SpaceAddr
 // AllMatchingScope returns the addresses that best satisfy the input scope
 // matching function.
 func (sas SpaceAddresses) AllMatchingScope(getMatcher ScopeMatchFunc) SpaceAddresses {
-	indexes := indexesForScope(len(sas), func(i int) Address { return sas[i] }, getMatcher)
-	if len(indexes) == 0 {
-		return nil
-	}
-	out := make(SpaceAddresses, len(indexes))
-	for i, index := range indexes {
-		out[i] = sas[index]
-	}
-	return out
+	return allMatchingScope(sas, getMatcher)
 }
 
 // EqualTo returns true if this set of SpaceAddresses is equal to other.
@@ -771,62 +755,6 @@ func ScopeMatchCloudLocal(addr Address) ScopeMatch {
 		return secondFallbackScope
 	}
 	return invalidScope
-}
-
-type addressByIndexFunc func(index int) Address
-
-// indexesForScope returns the indexes of the addresses with the best
-// matching scope and type (according to the matchFunc).
-// An empty slice is returned if there were no suitable addresses.
-func indexesForScope(numAddr int, getAddrFunc addressByIndexFunc, matchFunc ScopeMatchFunc) []int {
-	matches := filterAndCollateAddressIndexes(numAddr, getAddrFunc, matchFunc)
-
-	for _, matchType := range scopeMatchHierarchy() {
-		indexes, ok := matches[matchType]
-		if ok && len(indexes) > 0 {
-			return indexes
-		}
-	}
-	return nil
-}
-
-// indexesByScopeMatch filters address indexes by matching scope,
-// then returns them in descending order of best match.
-func indexesByScopeMatch(numAddr int, getAddrFunc addressByIndexFunc, matchFunc ScopeMatchFunc) []int {
-	matches := filterAndCollateAddressIndexes(numAddr, getAddrFunc, matchFunc)
-
-	var prioritized []int
-	for _, matchType := range scopeMatchHierarchy() {
-		indexes, ok := matches[matchType]
-		if ok && len(indexes) > 0 {
-			prioritized = append(prioritized, indexes...)
-		}
-	}
-	return prioritized
-}
-
-// filterAndCollateAddressIndexes filters address indexes using the input scope
-// matching function, then returns the results grouped by scope match quality.
-// Invalid results are omitted.
-func filterAndCollateAddressIndexes(
-	numAddr int, getAddrFunc addressByIndexFunc, matchFunc ScopeMatchFunc,
-) map[ScopeMatch][]int {
-	matches := make(map[ScopeMatch][]int)
-	for i := 0; i < numAddr; i++ {
-		matchType := matchFunc(getAddrFunc(i))
-		if matchType != invalidScope {
-			matches[matchType] = append(matches[matchType], i)
-		}
-	}
-	return matches
-}
-
-func scopeMatchHierarchy() []ScopeMatch {
-	return []ScopeMatch{
-		exactScopeIPv4, exactScope,
-		firstFallbackScopeIPv4, firstFallbackScope,
-		secondFallbackScopeIPv4, secondFallbackScope,
-	}
 }
 
 // MergedAddresses provides a single list of addresses without duplicates
@@ -952,4 +880,82 @@ func IsNoAddressError(err error) bool {
 	err = errors.Cause(err)
 	_, ok := err.(*noAddress)
 	return ok
+}
+
+// toIPAddresses returns the IP addresses in string form for input
+// that is a slice of types implementing the Address interface.
+func toIPAddresses[T Address](addrs []T) []string {
+	if addrs == nil {
+		return nil
+	}
+
+	ips := make([]string, len(addrs))
+	for i, addr := range addrs {
+		ips[i] = addr.Host()
+	}
+	return ips
+}
+
+func allMatchingScope[T Address](addrs []T, getMatcher ScopeMatchFunc) []T {
+	indexes := indexesForScope(addrs, getMatcher)
+	if len(indexes) == 0 {
+		return nil
+	}
+	out := make([]T, len(indexes))
+	for i, index := range indexes {
+		out[i] = addrs[index]
+	}
+	return out
+}
+
+// indexesForScope returns the indexes of the addresses with the best
+// matching scope and type (according to the matchFunc).
+// An empty slice is returned if there were no suitable addresses.
+func indexesForScope[T Address](addrs []T, matchFunc ScopeMatchFunc) []int {
+	matches := filterAndCollateAddressIndexes(addrs, matchFunc)
+
+	for _, matchType := range scopeMatchHierarchy() {
+		indexes, ok := matches[matchType]
+		if ok && len(indexes) > 0 {
+			return indexes
+		}
+	}
+	return nil
+}
+
+// indexesByScopeMatch filters address indexes by matching scope,
+// then returns them in descending order of best match.
+func indexesByScopeMatch[T Address](addrs []T, matchFunc ScopeMatchFunc) []int {
+	matches := filterAndCollateAddressIndexes(addrs, matchFunc)
+
+	var prioritized []int
+	for _, matchType := range scopeMatchHierarchy() {
+		indexes, ok := matches[matchType]
+		if ok && len(indexes) > 0 {
+			prioritized = append(prioritized, indexes...)
+		}
+	}
+	return prioritized
+}
+
+// filterAndCollateAddressIndexes filters address indexes using the input scope
+// matching function, then returns the results grouped by scope match quality.
+// Invalid results are omitted.
+func filterAndCollateAddressIndexes[T Address](addrs []T, matchFunc ScopeMatchFunc) map[ScopeMatch][]int {
+	matches := make(map[ScopeMatch][]int)
+	for i, addr := range addrs {
+		matchType := matchFunc(addr)
+		if matchType != invalidScope {
+			matches[matchType] = append(matches[matchType], i)
+		}
+	}
+	return matches
+}
+
+func scopeMatchHierarchy() []ScopeMatch {
+	return []ScopeMatch{
+		exactScopeIPv4, exactScope,
+		firstFallbackScopeIPv4, firstFallbackScope,
+		secondFallbackScopeIPv4, secondFallbackScope,
+	}
 }

--- a/core/network/hostport.go
+++ b/core/network/hostport.go
@@ -69,7 +69,7 @@ func (hps HostPorts) Unique() HostPorts {
 // matching function and returns them in NetAddr form.
 // If there are no suitable addresses then an empty slice is returned.
 func (hps HostPorts) PrioritizedForScope(getMatcher ScopeMatchFunc) []string {
-	indexes := indexesByScopeMatch(len(hps), func(i int) Address { return hps[i].(Address) }, getMatcher)
+	indexes := indexesByScopeMatch(hps, getMatcher)
 	out := make([]string, len(indexes))
 	for i, index := range indexes {
 		out[i] = DialAddress(hps[index])
@@ -309,7 +309,7 @@ func (hps SpaceHostPorts) InSpaces(spaces ...SpaceInfo) (SpaceHostPorts, bool) {
 // AllMatchingScope returns the HostPorts that best satisfy the input scope
 // matching function, as strings usable as arguments to net.Dial.
 func (hps SpaceHostPorts) AllMatchingScope(getMatcher ScopeMatchFunc) []string {
-	indexes := indexesForScope(len(hps), func(i int) Address { return hps[i].SpaceAddress }, getMatcher)
+	indexes := indexesForScope(hps, getMatcher)
 	out := make([]string, 0, len(indexes))
 	for _, index := range indexes {
 		out = append(out, DialAddress(hps[index]))


### PR DESCRIPTION
The address scope matching functionality has long had chicanery in its abstractions to work around Go's lack of generics.

Now that we have them available, we can begin to simplify the logic, also paving the way to introduce common functionality more widely across the `Address` implementations as we need it.

## QA steps

The changes are mechanical only. Passing tests verify correctness.

## Documentation changes

None.

## Bug reference

N/A
