### PR TITLE
[JUJU-1207] Update spaces_ec2 test suite

### DIFF
--- a/tests/suites/spaces_ec2/machines_in_spaces.sh
+++ b/tests/suites/spaces_ec2/machines_in_spaces.sh
@@ -1,0 +1,59 @@
+# Deploy some machines with spaces constraints and then
+# check that they have been deployed as expected
+run_machines_in_spaces() {
+	echo
+
+	file="${TEST_DIR}/test-machines-in-spaces.log"
+
+	ensure "machines-in-spaces" "${file}"
+
+	echo "Setup spaces"
+	juju reload-spaces
+	juju add-space isolated 172.31.254.0/24
+
+	juju add-machine --constraints spaces=alpha -n2
+	juju add-machine --constraints spaces=isolated
+
+	wait_for_machine_agent_status "0" "started"
+	wait_for_machine_agent_status "1" "started"
+	wait_for_machine_agent_status "2" "started"
+
+	echo "Verify machines are assigned to correct spaces"
+	alpha_cidrs="$(juju spaces --format json | jq -r '.spaces[] | select(.name == "alpha").subnets | to_entries[] | select(.value["provider-id"] | contains("INFAN") | not) | .key')"
+	assert_machine_ip_is_in_cidrs "0" "${alpha_cidrs}"
+	machine_1_space_ip=$(assert_machine_ip_is_in_cidrs "1" "${alpha_cidrs}")
+	machine_2_space_ip=$(assert_machine_ip_is_in_cidrs "2" "172.31.254.0/24")
+
+	# Sometimes it can take a bit for an ec2 machine's public ip to come up on Juju
+	wait_for "3" '.machines["0"]["ip-addresses"] | length'
+
+	echo "Verify machines can ping each other within and across spaces"
+	juju ssh 0 "ping -c4 ${machine_1_space_ip}"
+	juju ssh 0 "ping -c4 ${machine_2_space_ip}"
+
+	echo "Attempt assigning a container to a different space to it's host machine and assert this fails"
+	juju add-machine lxd:0 --constraints spaces=isolated
+	wait_for "provisioning error" '.machines["0"].containers["0/lxd/0"]["machine-status"].current'
+
+	# A container lying around in error state will cause destroy_model to return non-zero
+	echo "Destroy container"
+	juju remove-machine "0/lxd/0"
+	wait_for "false" '.machines["0"] | has("containers")'
+
+	destroy_model "machines-in-spaces"
+}
+
+test_machines_in_spaces() {
+	if [ "$(skip 'test_machines_in_spaces')" ]; then
+		echo "==> TEST SKIPPED: assert machines added to spaces"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_machines_in_spaces" "$@"
+	)
+}

--- a/tests/suites/spaces_ec2/task.sh
+++ b/tests/suites/spaces_ec2/task.sh
@@ -4,22 +4,26 @@ test_spaces_ec2() {
 		return
 	fi
 
+	# Ensure that the aws cli and juju both use the same aws region
+	export AWS_DEFAULT_REGION="${BOOTSTRAP_REGION}"
+
 	set_verbosity
 
 	echo "==> Checking for dependencies"
 	check_dependencies juju aws
 
-	echo "==> Checking for stale NIC resources"
-	cleanup_stale_nics
+	echo "==> Ensure subnet for alternative space exists"
+	subnet_id=$(ensure_subnet)
 
 	echo "==> Setting up additional EC2 resources for tests"
-	hotplug_nic_id=$(setup_nic_for_space_tests)
+	hotplug_nic_id=$(setup_nic_for_space_tests "${subnet_id}")
 	echo "[+] created secondary NIC with ID ${hotplug_nic_id}"
 
 	file="${TEST_DIR}/test-spaces-ec2.log"
 
 	bootstrap "test-spaces-ec2" "${file}"
 
+	test_machines_in_spaces
 	test_upgrade_charm_with_bind "$hotplug_nic_id"
 	test_juju_bind "$hotplug_nic_id"
 
@@ -31,14 +35,22 @@ test_spaces_ec2() {
 	aws ec2 delete-network-interface --network-interface-id "$hotplug_nic_id" 2>/dev/null
 }
 
-setup_nic_for_space_tests() {
+ensure_subnet() {
 	isolated_subnet_id=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=172.31.254.0/24 2>/dev/null | jq -r '.Subnets[0].SubnetId')
-	if [ "$isolated_subnet_id" == "null" ]; then
-		# shellcheck disable=SC2046
-		echo $(red 'To run these tests you need to create a subnet with name "isolated" and CIDR "172.31.254/24"') 1>&2
-		exit 1
+	if [ "$isolated_subnet_id" != "null" ]; then
+		cleanup_stale_nics
+		echo "$isolated_subnet_id"
+		exit 0
 	fi
 
+	# Create a subnet in the default vpc
+	vpc_id=$(aws ec2 describe-vpcs | jq -r ".Vpcs[0].VpcId")
+	subnet_id=$(aws ec2 create-subnet --vpc-id "${vpc_id}" --cidr-block "172.31.254.0/24" | jq -r ".Subnet.SubnetId")
+	echo "${subnet_id}"
+}
+
+setup_nic_for_space_tests() {
+	isolated_subnet_id=${1}
 	hotplug_nic_id=$(aws ec2 create-network-interface --subnet-id "$isolated_subnet_id" --description="hot-pluggable NIC for space tests" 2>/dev/null | jq -r '.NetworkInterface.NetworkInterfaceId')
 	if [ "$hotplug_nic_id" == "null" ]; then
 		# shellcheck disable=SC2046

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -9,7 +9,9 @@
 add_multi_nic_machine() {
 	hotplug_nic_id=$1
 
-	juju add-machine
+	# Ensure machine is deployed to the same az as our nic
+	az=$(aws ec2 describe-network-interfaces --filters Name=network-interface-id,Values="$hotplug_nic_id" | jq -r ".NetworkInterfaces[0].AvailabilityZone")
+	juju add-machine --constraints zones="${az}"
 	juju_machine_id=$(juju show-machine --format json | jq -r '.["machines"] | keys[0]')
 	echo "[+] waiting for machine ${juju_machine_id} to start..."
 


### PR DESCRIPTION
Idempotently create a subnet, instead of asserting one exists

Add some simple tests for machine in spaces to cover important parts of assess_network_spaces.py

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Once without a 172.31.254.0/24 subnet in the applicable aws region and once with
```sh
BOOTSTRAP_PROVIDER=aws BOOTSTRAP_CLOUD=aws BOOTSTRAP_REGION=eu-west-2 ./main.sh -v spaces_ec2
```
