### PR TITLE
[JUJU-1751] [caas/exec] filter namespaces by model UUID

### DIFF
--- a/cmd/juju/commands/export_test.go
+++ b/cmd/juju/commands/export_test.go
@@ -82,7 +82,7 @@ func NewSSHContainer(
 		applicationAPI:     applicationAPI,
 		charmsAPI:          charmsAPI,
 		execClient:         execClient,
-		execClientGetter: func(string, cloudspec.CloudSpec) (k8sexec.Executor, error) {
+		execClientGetter: func(string, string, cloudspec.CloudSpec) (k8sexec.Executor, error) {
 			return execClient, nil
 		},
 		remote:    remote,

--- a/cmd/juju/commands/ssh_container.go
+++ b/cmd/juju/commands/ssh_container.go
@@ -47,7 +47,7 @@ type sshContainer struct {
 	modelAPI           ModelAPI
 	applicationAPI     ApplicationAPI
 	charmsAPI          CharmsAPI
-	execClientGetter   func(string, cloudspec.CloudSpec) (k8sexec.Executor, error)
+	execClientGetter   func(string, string, cloudspec.CloudSpec) (k8sexec.Executor, error)
 	execClient         k8sexec.Executor
 	statusAPIGetter    statusAPIGetterFunc
 	// TODO(juju3) - remove
@@ -440,7 +440,7 @@ func (c *sshContainer) getExecClient() (k8sexec.Executor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.execClientGetter(mInfo.Result.Name, cloudSpec)
+	return c.execClientGetter(c.modelName, c.modelUUID, cloudSpec)
 }
 
 func (c *sshContainer) maybePopulateTargetViaField(_ *resolvedTarget, _ func([]string) (*params.FullStatus, error)) error {


### PR DESCRIPTION
Fixes [lp#1988921](https://bugs.launchpad.net/juju/+bug/1988921):

> On Juju 3.0-beta4 (and probably 2.9 as well):
> ```
> $ juju bootstrap microk8s c1
> $ juju bootstrap microk8s c2
> $ juju switch controller
> $ juju ssh controller/0
> ERROR multiple controllers running on the cluster
> ```
> 
> The issue is in caas/kubernetes/provider/exec/exec.go, ln 113, func modelNameToNameSpace. We ask the client to list namespaces with the label "controller". This is going to match the "controller" model for every controller on the cluster.

We solve this by filtering search results using the model UUID.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju bootstrap microk8s c1
$ juju bootstrap microk8s c2
$ juju switch controller
$ juju ssh controller/0
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1988921
