### PR TITLE
[JUJU-1747] juju config help message includes an incorrect example

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -87,7 +87,7 @@ apache2:
 If the above yaml document is stored in a file called config.yaml, the
 following command can be used to apply the config changes:
 
-juju config --file config.yaml
+juju config apache2 --file config.yaml
 
 Finally, the --reset flag can be used to revert one or more configuration
 settings back to their default value as defined in the charm metadata:


### PR DESCRIPTION
Fix incorrect juju config help message.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Search for the offending string. Should not get any output.

```sh
juju help config | grep -E "juju config --file config.yaml"  
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1987407

