### PR TITLE
[JUJU-1765] Increase timeout for etcd to come up in model migration test

### DIFF
--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -88,7 +88,7 @@ run_model_migration_version() {
 
 	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
 	wait_for "easyrsa" "$(idle_condition "easyrsa" 0)"
-	wait_for "active" '.applications["etcd"] | ."application-status".current'
+	wait_for "active" '.applications["etcd"] | ."application-status".current' 900
 	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 1)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 2)"


### PR DESCRIPTION
From my tests on Jenkins nodes, the default timeout cuts it very close, so often the test fails when it would have succeeded if it waited a little longer 

Increase the timeout to 900s (15m)

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run
```
BOOTSTRAP_PROVIDER=lxd BOOTSTRAP_CLOUD=lxd SHORT_GIT_COMMIT=1ad7d36 JUJU_VERSION=2.9.35 JUJU_BUILD_NUMBER=0 ./main.sh -v -s 'test_model_config,test_model_multi,test_model_metrics,test_model_destroy' model
```
on a Jenkins node. Preferably multiple times to ensure the new timeout is long enough
