### PR TITLE
[JUJU-1766] Enabled run_resolve_charm for non-lxd providers

### DIFF
--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -259,19 +259,18 @@ test_deploy_charms() {
 		run "run_deploy_specific_series"
 		run "run_deploy_lxd_to_container"
 		run "run_deploy_lxd_profile_charm_container"
+		run "run_resolve_charm"
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"lxd" | "localhost")
 			run "run_deploy_lxd_to_machine"
 			run "run_deploy_lxd_profile_charm"
 			run "run_deploy_local_lxd_profile_charm"
-			run "run_resolve_charm"
 			;;
 		*)
 			echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"
 			echo "==> TEST SKIPPED: deploy_lxd_profile_charm - tests for LXD only"
 			echo "==> TEST SKIPPED: deploy_local_lxd_profile_charm - tests for LXD only"
-			echo "==> TEST SKIPPED: resolve_charm - tests for LXD only"
 			;;
 		esac
 	)


### PR DESCRIPTION
This PR enables run_resolve_charm subtest for non-lxd providers. For now, lxd provider for 'deploy' suite is not a part of stable CI, so it's more reasonable to add this test as for lxd, and for non-lxd providers. 

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p aws deploy run_resolve_charm
```
