### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -8,6 +8,9 @@ env:
   DOCKER_USERNAME: jujuqabot
   JUJU_BUILD_NUMBER: 888
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Test Kubeflow

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   smoke:


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

GitHub Actions workflows have a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflows:
https://github.com/juju/juju/runs/8239904910?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- microk8s-tests.yml
- smoke.yml

The following workflow files already have the least privileged token permission set:

- build.yml
- client-tests.yml
- snap.yml
- update-brew-formulae.yml
- cla.yml
- gen.yml
- static-analysis.yml

### Motivation and Context
This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
GitHub recommends defining minimum GITHUB_TOKEN permissions.
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>