### PR TITLE
[JUJU-1772] Bootstrap Dqlite Controller Database

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -113,7 +113,7 @@ func InitializeState(
 		return nil, errors.Trace(err)
 	}
 
-	if err := database.BootstrapDqlite(database.NewOptionFactoryWithDefaults(c), logger); err != nil {
+	if err := database.BootstrapDqlite(database.NewOptionFactory(c), logger); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -113,7 +113,7 @@ func InitializeState(
 		return nil, errors.Trace(err)
 	}
 
-	if err := database.BootstrapDqlite(database.NewOptionFactory(c), logger); err != nil {
+	if err := database.BootstrapDqlite(stdcontext.TODO(), database.NewOptionFactory(c), logger); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/juju/juju/database"
-
 	coreraft "github.com/hashicorp/raft"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -30,6 +28,7 @@ import (
 	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/raft/queue"
+	"github.com/juju/juju/database"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/juju/juju/database"
+
 	coreraft "github.com/hashicorp/raft"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -74,7 +76,7 @@ type bootstrapController interface {
 // InitializeState should be called with the bootstrap machine's agent
 // configuration. It uses that information to create the controller, dial the
 // controller, and initialize it. It also generates a new password for the
-// bootstrap machine and calls Write to save the the configuration.
+// bootstrap machine and calls Write to save the configuration.
 //
 // The cfg values will be stored in the state's ModelConfig; the
 // machineCfg values will be used to configure the bootstrap Machine,
@@ -109,6 +111,10 @@ func InitializeState(
 	info.Password = c.OldPassword()
 
 	if err := initRaft(c); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	if err := database.BootstrapDqlite(database.NewOptionFactoryWithDefaults(c), logger); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -322,6 +322,21 @@ func NewMachineAddress(value string, options ...func(AddressMutator)) MachineAdd
 // MachineAddresses is a slice of MachineAddress
 type MachineAddresses []MachineAddress
 
+// NewMachineAddresses is a convenience function to create addresses
+// from a variable number of string arguments, applying any supplied
+// options to each address
+func NewMachineAddresses(values []string, options ...func(AddressMutator)) MachineAddresses {
+	if len(values) == 0 {
+		return nil
+	}
+
+	addrs := make(MachineAddresses, len(values))
+	for i, value := range values {
+		addrs[i] = NewMachineAddress(value, options...)
+	}
+	return addrs
+}
+
 // AsProviderAddresses is used to construct ProviderAddresses
 // element-wise from MachineAddresses
 func (as MachineAddresses) AsProviderAddresses(options ...func(mutator ProviderAddressMutator)) ProviderAddresses {
@@ -336,19 +351,16 @@ func (as MachineAddresses) AsProviderAddresses(options ...func(mutator ProviderA
 	return addrs
 }
 
-// NewMachineAddresses is a convenience function to create addresses
-// from a variable number of string arguments, applying any supplied
-// options to each address
-func NewMachineAddresses(values []string, options ...func(AddressMutator)) MachineAddresses {
-	if len(values) == 0 {
-		return nil
-	}
+// AllMatchingScope returns the addresses that satisfy
+// the input scope matching function.
+func (as MachineAddresses) AllMatchingScope(getMatcher ScopeMatchFunc) MachineAddresses {
+	return allMatchingScope(as, getMatcher)
+}
 
-	addrs := make(MachineAddresses, len(values))
-	for i, value := range values {
-		addrs[i] = NewMachineAddress(value, options...)
-	}
-	return addrs
+// Values transforms the MachineAddresses to a string slice
+// containing their raw IP values.
+func (as MachineAddresses) Values() []string {
+	return toStrings(as)
 }
 
 // deriveScope attempts to derive the network scope from an address'
@@ -638,8 +650,8 @@ func (sas SpaceAddresses) OneMatchingScope(getMatcher ScopeMatchFunc) (SpaceAddr
 	return addrs[0], true
 }
 
-// AllMatchingScope returns the addresses that best satisfy the input scope
-// matching function.
+// AllMatchingScope returns the addresses that satisfy
+// the input scope matching function.
 func (sas SpaceAddresses) AllMatchingScope(getMatcher ScopeMatchFunc) SpaceAddresses {
 	return allMatchingScope(sas, getMatcher)
 }

--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -1,0 +1,76 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+import (
+	"context"
+
+	"github.com/canonical/go-dqlite/app"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/database/schema"
+)
+
+type bootstrapOptFactory interface {
+	// EnsureDataDir ensures that a directory for Dqlite data exists at
+	// a path determined by the agent config, then returns that path.
+	EnsureDataDir() (string, error)
+
+	// WithAddressOption returns a Dqlite application option
+	// for specifying the local address:port to use.
+	WithAddressOption() (app.Option, error)
+}
+
+// BootstrapDqlite opens a new database for the controller, and runs the
+// DDL to create its schema.
+//
+// At this point we know there are no peers and that we are the only user
+// of Dqlite, so we can eschew external address and clustering concerns.
+// Those will be handled by the db-accessor worker.
+func BootstrapDqlite(opt bootstrapOptFactory, logger Logger) error {
+	dir, err := opt.EnsureDataDir()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Although we are not broadcasting this address in the bootstrap phase,
+	// the address/port set here can not be changed for this same node later.
+	// We are not using the default port, so we need to set it now.
+	withAddress, err := opt.WithAddressOption()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	dqlite, err := app.New(dir, withAddress)
+	if err != nil {
+		return errors.Annotate(err, "creating Dqlite app")
+	}
+	defer func() {
+		if err := dqlite.Close(); err != nil {
+			logger.Errorf("closing dqlite: %v", err)
+		}
+	}()
+
+	ctx := context.TODO()
+
+	if err := dqlite.Ready(ctx); err != nil {
+		return errors.Annotatef(err, "waiting for Dqlite readiness")
+	}
+
+	db, err := dqlite.Open(ctx, "controller")
+	if err != nil {
+		return errors.Annotatef(err, "opening controller database")
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			logger.Errorf("closing controller database: %v", err)
+		}
+	}()
+
+	if err := NewMigration(db, logger, schema.ControllerDDL()).Apply(); err != nil {
+		return errors.Annotate(err, "creating controller database schema")
+	}
+
+	return nil
+}

--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -68,7 +68,7 @@ func BootstrapDqlite(opt bootstrapOptFactory, logger Logger) error {
 		}
 	}()
 
-	if err := NewMigration(db, logger, schema.ControllerDDL()).Apply(); err != nil {
+	if err := NewDBMigration(db, logger, schema.ControllerDDL()).Apply(); err != nil {
 		return errors.Annotate(err, "creating controller database schema")
 	}
 

--- a/database/bootstrap.go
+++ b/database/bootstrap.go
@@ -28,7 +28,7 @@ type bootstrapOptFactory interface {
 // At this point we know there are no peers and that we are the only user
 // of Dqlite, so we can eschew external address and clustering concerns.
 // Those will be handled by the db-accessor worker.
-func BootstrapDqlite(opt bootstrapOptFactory, logger Logger) error {
+func BootstrapDqlite(ctx context.Context, opt bootstrapOptFactory, logger Logger) error {
 	dir, err := opt.EnsureDataDir()
 	if err != nil {
 		return errors.Trace(err)
@@ -51,8 +51,6 @@ func BootstrapDqlite(opt bootstrapOptFactory, logger Logger) error {
 			logger.Errorf("closing dqlite: %v", err)
 		}
 	}()
-
-	ctx := context.TODO()
 
 	if err := dqlite.Ready(ctx); err != nil {
 		return errors.Annotatef(err, "waiting for Dqlite readiness")

--- a/database/bootstrap_test.go
+++ b/database/bootstrap_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&bootstrapSuite{})
 func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 	opt := &testOptFactory{c: c}
 
-	c.Assert(BootstrapDqlite(opt, stubLogger{}), jc.ErrorIsNil)
+	c.Assert(BootstrapDqlite(context.TODO(), opt, stubLogger{}), jc.ErrorIsNil)
 
 	// Now use the same options to reopen the controller database
 	// and check that we can see bootstrap side effects.

--- a/database/bootstrap_test.go
+++ b/database/bootstrap_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/canonical/go-dqlite/app"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type bootstrapSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&bootstrapSuite{})
+
+func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
+	opt := &testOptFactory{c: c}
+
+	c.Assert(BootstrapDqlite(opt, stubLogger{}), jc.ErrorIsNil)
+
+	// Now use the same options to reopen the controller database
+	// and check that we can see bootstrap side effects.
+	dir, err := opt.EnsureDataDir()
+	c.Assert(err, jc.ErrorIsNil)
+
+	addrOpt, err := opt.WithAddressOption()
+	c.Assert(err, jc.ErrorIsNil)
+
+	dqlite, err := app.New(dir, addrOpt)
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { _ = dqlite.Close() })
+
+	ctx := context.TODO()
+	c.Assert(dqlite.Ready(ctx), jc.ErrorIsNil)
+
+	db, err := dqlite.Open(ctx, "controller")
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { _ = db.Close() })
+
+	rows, err := db.Query("SELECT COUNT(*) FROM lease_type")
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { _ = rows.Close() })
+
+	var count int
+	c.Assert(rows.Next(), jc.IsTrue)
+	c.Assert(rows.Scan(&count), jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 3)
+}
+
+type testOptFactory struct {
+	c       *gc.C
+	dataDir string
+	port    int
+}
+
+func (f *testOptFactory) EnsureDataDir() (string, error) {
+	if f.dataDir == "" {
+		f.dataDir = f.c.MkDir()
+	}
+	return f.dataDir, nil
+}
+
+func (f *testOptFactory) WithAddressOption() (app.Option, error) {
+	if f.port == 0 {
+		l, err := net.Listen("tcp", ":0")
+		f.c.Assert(err, jc.ErrorIsNil)
+		f.c.Assert(l.Close(), jc.ErrorIsNil)
+		f.port = l.Addr().(*net.TCPAddr).Port
+	}
+	return app.WithAddress(fmt.Sprintf("127.0.0.1:%d", f.port)), nil
+}

--- a/database/interface.go
+++ b/database/interface.go
@@ -1,0 +1,9 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+// Logger describes methods for emitting log output.
+type Logger interface {
+	Errorf(string, ...interface{})
+}

--- a/database/migration.go
+++ b/database/migration.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+import (
+	"database/sql"
+
+	"github.com/juju/errors"
+)
+
+// Migration is used to apply a series of deltas to a database.
+type Migration struct {
+	db     *sql.DB
+	logger Logger
+	deltas [][]string
+}
+
+// NewMigration returns a reference to a new migration that
+// is used to apply the input deltas to the input database.
+// The deltas are applied in the order supplied.
+func NewMigration(db *sql.DB, logger Logger, deltas ...[]string) *Migration {
+	return &Migration{
+		db:     db,
+		logger: logger,
+		deltas: deltas,
+	}
+}
+
+// Apply executes all deltas against the database inside a transaction.
+func (m *Migration) Apply() error {
+	tx, err := m.db.Begin()
+	if err != nil {
+		return errors.Annotatef(err, "beginning migration transaction")
+	}
+
+	for _, delta := range m.deltas {
+		for _, stmt := range delta {
+			if _, err := tx.Exec(stmt); err != nil {
+				if rbErr := tx.Rollback(); rbErr != nil {
+					m.logger.Errorf("rolling back transaction: %v", rbErr)
+				}
+				return errors.Trace(err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil {
+			m.logger.Errorf("rolling back transaction: %v", rbErr)
+		}
+		return errors.Trace(err)
+	}
+	return nil
+}

--- a/database/migration.go
+++ b/database/migration.go
@@ -9,18 +9,18 @@ import (
 	"github.com/juju/errors"
 )
 
-// Migration is used to apply a series of deltas to a database.
-type Migration struct {
+// DBMigration is used to apply a series of deltas to a database.
+type DBMigration struct {
 	db     *sql.DB
 	logger Logger
 	deltas [][]string
 }
 
-// NewMigration returns a reference to a new migration that
+// NewDBMigration returns a reference to a new migration that
 // is used to apply the input deltas to the input database.
 // The deltas are applied in the order supplied.
-func NewMigration(db *sql.DB, logger Logger, deltas ...[]string) *Migration {
-	return &Migration{
+func NewDBMigration(db *sql.DB, logger Logger, deltas ...[]string) *DBMigration {
+	return &DBMigration{
 		db:     db,
 		logger: logger,
 		deltas: deltas,
@@ -28,7 +28,7 @@ func NewMigration(db *sql.DB, logger Logger, deltas ...[]string) *Migration {
 }
 
 // Apply executes all deltas against the database inside a transaction.
-func (m *Migration) Apply() error {
+func (m *DBMigration) Apply() error {
 	tx, err := m.db.Begin()
 	if err != nil {
 		return errors.Annotatef(err, "beginning migration transaction")

--- a/database/migration_test.go
+++ b/database/migration_test.go
@@ -22,7 +22,7 @@ func (s *migrationSuite) TestMigrationSuccess(c *gc.C) {
 	}
 
 	db := s.DB()
-	m := NewMigration(db, stubLogger{}, delta)
+	m := NewDBMigration(db, stubLogger{}, delta)
 	c.Assert(m.Apply(), jc.ErrorIsNil)
 
 	rows, err := db.Query("SELECT * from band;")

--- a/database/migration_test.go
+++ b/database/migration_test.go
@@ -21,6 +21,16 @@ func (s *migrationSuite) TestMigrationSuccess(c *gc.C) {
 		"INSERT INTO band VALUES ('Blood Incantation');",
 	}
 
-	m := NewMigration(s.DB(), stubLogger{}, delta)
+	db := s.DB()
+	m := NewMigration(db, stubLogger{}, delta)
 	c.Assert(m.Apply(), jc.ErrorIsNil)
+
+	rows, err := db.Query("SELECT * from band;")
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddCleanup(func(*gc.C) { _ = rows.Close() })
+
+	var band string
+	c.Assert(rows.Next(), jc.IsTrue)
+	c.Assert(rows.Scan(&band), jc.ErrorIsNil)
+	c.Check(band, gc.Equals, "Blood Incantation")
 }

--- a/database/migration_test.go
+++ b/database/migration_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+import (
+	"github.com/juju/juju/database/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type migrationSuite struct {
+	testing.DBSuite
+}
+
+var _ = gc.Suite(&migrationSuite{})
+
+func (s *migrationSuite) TestMigrationSuccess(c *gc.C) {
+	delta := []string{
+		"CREATE TABLE band(name TEXT PRIMARY KEY);",
+		"INSERT INTO band VALUES ('Blood Incantation');",
+	}
+
+	m := NewMigration(s.DB(), stubLogger{}, delta)
+	c.Assert(m.Apply(), jc.ErrorIsNil)
+}
+
+type stubLogger struct{}
+
+func (stubLogger) Errorf(string, ...interface{}) {}

--- a/database/migration_test.go
+++ b/database/migration_test.go
@@ -24,7 +24,3 @@ func (s *migrationSuite) TestMigrationSuccess(c *gc.C) {
 	m := NewMigration(s.DB(), stubLogger{}, delta)
 	c.Assert(m.Apply(), jc.ErrorIsNil)
 }
-
-type stubLogger struct{}
-
-func (stubLogger) Errorf(string, ...interface{}) {}

--- a/database/option.go
+++ b/database/option.go
@@ -1,0 +1,73 @@
+package database
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/canonical/go-dqlite/app"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/network"
+)
+
+const dqlitePort = 17666
+
+// OptionFactory creates Dqlite `App` initialisation options.
+// These generally depend on a controller's agent config.
+type OptionFactory struct {
+	cfg            agent.Config
+	port           int
+	interfaceAddrs func() ([]net.Addr, error)
+}
+
+// NewOptionFactoryWithDefaults returns a new OptionFactory reference
+// based on the input config, but otherwise using defaults.
+func NewOptionFactoryWithDefaults(cfg agent.Config) *OptionFactory {
+	return NewOptionFactory(cfg, dqlitePort, net.InterfaceAddrs)
+}
+
+// NewOptionFactory returns a new OptionFactory reference
+// based on the input arguments.
+func NewOptionFactory(cfg agent.Config, port int, interfaceAddrs func() ([]net.Addr, error)) *OptionFactory {
+	return &OptionFactory{
+		cfg:            cfg,
+		port:           port,
+		interfaceAddrs: interfaceAddrs,
+	}
+}
+
+// WithAddressOption returns a Dqlite application option
+// for specifying the local address:port to use.
+// TODO (manadart 2022-09-07): We will need to consider what happens with
+// juju-ha-space controller configuration as it relates to this address.
+// Consider also using the generic address collection functions to filter.
+func (f *OptionFactory) WithAddressOption() (app.Option, error) {
+	sysAddrs, err := f.interfaceAddrs()
+	if err != nil {
+		return nil, errors.Annotate(err, "querying addresses of system NICs")
+	}
+
+	// Dqlite nodes should only advertise cloud-local addresses to their
+	// peers. To figure out the address to bind to, we need to scan all NIC
+	// addresses and return the first one that has cloud-local scope.
+	for _, sysAddr := range sysAddrs {
+		var host string
+
+		switch v := sysAddr.(type) {
+		case *net.IPNet:
+			host = v.IP.String()
+		case *net.IPAddr:
+			host = v.IP.String()
+		default:
+			continue
+		}
+
+		machAddr := network.NewMachineAddress(host)
+		if machAddr.Scope == network.ScopeCloudLocal {
+			return app.WithAddress(fmt.Sprintf("%s:%d", machAddr.Value, f.port)), nil
+		}
+	}
+
+	return nil, errors.NewNotFound(nil, "no suitable local address for advertising to Dqlite peers")
+}

--- a/database/option.go
+++ b/database/option.go
@@ -3,6 +3,8 @@ package database
 import (
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/canonical/go-dqlite/app"
@@ -12,9 +14,12 @@ import (
 	"github.com/juju/juju/core/network"
 )
 
-const dqlitePort = 17666
+const (
+	dqliteDataDir = "dqlite"
+	dqlitePort    = 17666
+)
 
-// OptionFactory creates Dqlite `App` initialisation options.
+// OptionFactory creates Dqlite `App` initialisation arguments and options.
 // These generally depend on a controller's agent config.
 type OptionFactory struct {
 	cfg            agent.Config
@@ -36,6 +41,14 @@ func NewOptionFactory(cfg agent.Config, port int, interfaceAddrs func() ([]net.A
 		port:           port,
 		interfaceAddrs: interfaceAddrs,
 	}
+}
+
+// EnsureDataDir ensures that a directory for Dqlite data exists at
+// a path determined by the agent config, then returns that path.
+func (f *OptionFactory) EnsureDataDir() (string, error) {
+	dir := filepath.Join(f.cfg.DataDir(), dqliteDataDir)
+	err := os.MkdirAll(dir, 0700)
+	return dir, errors.Annotatef(err, "creating directory for Dqlite data")
 }
 
 // WithAddressOption returns a Dqlite application option

--- a/database/option.go
+++ b/database/option.go
@@ -27,19 +27,13 @@ type OptionFactory struct {
 	interfaceAddrs func() ([]net.Addr, error)
 }
 
-// NewOptionFactoryWithDefaults returns a new OptionFactory reference
-// based on the input config, but otherwise using defaults.
-func NewOptionFactoryWithDefaults(cfg agent.Config) *OptionFactory {
-	return NewOptionFactory(cfg, dqlitePort, net.InterfaceAddrs)
-}
-
 // NewOptionFactory returns a new OptionFactory reference
-// based on the input arguments.
-func NewOptionFactory(cfg agent.Config, port int, interfaceAddrs func() ([]net.Addr, error)) *OptionFactory {
+// based on the input agent configuration.
+func NewOptionFactory(cfg agent.Config) *OptionFactory {
 	return &OptionFactory{
 		cfg:            cfg,
-		port:           port,
-		interfaceAddrs: interfaceAddrs,
+		port:           dqlitePort,
+		interfaceAddrs: net.InterfaceAddrs,
 	}
 }
 
@@ -51,7 +45,7 @@ func (f *OptionFactory) EnsureDataDir() (string, error) {
 	return dir, errors.Annotatef(err, "creating directory for Dqlite data")
 }
 
-// WithAddressOption returns a Dqlite application option
+// WithAddressOption returns a Dqlite application Option
 // for specifying the local address:port to use.
 // TODO (manadart 2022-09-07): We will need to consider what happens with
 // juju-ha-space controller configuration as it relates to this address.

--- a/database/option_test.go
+++ b/database/option_test.go
@@ -26,8 +26,7 @@ func (s *optionSuite) TestEnsureDataDir(c *gc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
 	cfg := dummyAgentConfig{dataDir: "/tmp/" + subDir}
-
-	f := NewOptionFactory(cfg, dqlitePort, nil)
+	f := NewOptionFactory(cfg)
 
 	expected := fmt.Sprintf("/tmp/%s/%s", subDir, dqliteDataDir)
 	s.AddCleanup(func(*gc.C) { _ = os.RemoveAll(expected) })
@@ -45,12 +44,14 @@ func (s *optionSuite) TestEnsureDataDir(c *gc.C) {
 }
 
 func (s *optionSuite) TestWithAddressOption(c *gc.C) {
-	f := NewOptionFactory(nil, dqlitePort, func() ([]net.Addr, error) {
+	f := NewOptionFactory(nil)
+
+	f.interfaceAddrs = func() ([]net.Addr, error) {
 		return []net.Addr{
 			&net.IPAddr{IP: net.ParseIP("10.0.0.5")},
 			&net.IPAddr{IP: net.ParseIP("127.0.0.1")},
 		}, nil
-	})
+	}
 
 	// We can not actually test the realisation of this option,
 	// as the options type from the go-dqlite is not exported.

--- a/database/option_test.go
+++ b/database/option_test.go
@@ -29,13 +29,17 @@ func (s *optionSuite) TestEnsureDataDir(c *gc.C) {
 	f := NewOptionFactory(cfg)
 
 	expected := fmt.Sprintf("/tmp/%s/%s", subDir, dqliteDataDir)
-	s.AddCleanup(func(*gc.C) { _ = os.RemoveAll(expected) })
+	s.AddCleanup(func(*gc.C) { _ = os.RemoveAll(cfg.DataDir()) })
 
 	// Call twice to check both the creation and extant scenarios.
-	_, err := f.EnsureDataDir()
+	dir, err := f.EnsureDataDir()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(dir, gc.Equals, expected)
+
+	_, err = os.Stat(expected)
 	c.Assert(err, jc.ErrorIsNil)
 
-	dir, err := f.EnsureDataDir()
+	dir, err = f.EnsureDataDir()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(dir, gc.Equals, expected)
 

--- a/database/option_test.go
+++ b/database/option_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+import (
+	"net"
+
+	"github.com/juju/juju/agent"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+)
+
+type optionSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&optionSuite{})
+
+func (s *optionSuite) TestWithAddressOption(c *gc.C) {
+	cfg := dummyAgentConfig{dataDir: "/tmp/dqlite"}
+
+	f := NewOptionFactory(cfg, dqlitePort, func() ([]net.Addr, error) {
+		return []net.Addr{
+			&net.IPAddr{IP: net.ParseIP("10.0.0.5")},
+			&net.IPAddr{IP: net.ParseIP("127.0.0.1")},
+		}, nil
+	})
+
+	// We can not actually test the realisation of this option,
+	// as the options type from the go-dqlite is not exported.
+	// We are also unable to test by creating a new dqlite app,
+	// because it fails to bind to the contrived address.
+	// The best we can do is check that we selected an address
+	// based on the absence of an error.
+	_, err := f.WithAddressOption()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+type dummyAgentConfig struct {
+	agent.Config
+	dataDir string
+}
+
+// DataDir implements agent.AgentConfig.
+func (cfg dummyAgentConfig) DataDir() string {
+	return cfg.dataDir
+}

--- a/database/package_test.go
+++ b/database/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/database/package_test.go
+++ b/database/package_test.go
@@ -12,3 +12,7 @@ import (
 func Test(t *testing.T) {
 	gc.TestingT(t)
 }
+
+type stubLogger struct{}
+
+func (stubLogger) Errorf(string, ...interface{}) {}

--- a/database/schema/controller.go
+++ b/database/schema/controller.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package schema
+
+// controllerDDL is used to create the controller database schema at bootstrap.
+const controllerDDL = `
+CREATE TABLE lease_type (
+	id		INT PRIMARY KEY,
+	type	TEXT
+);
+
+INSERT INTO lease_type VALUES
+	(0, 'controller'), 
+	(1, 'model' ), 
+	(2, 'application');
+
+CREATE TABLE IF NOT EXISTS lease (
+	uuid			TEXT PRIMARY KEY,
+	lease_type_id	INT NOT NULL,
+	name			TEXT,
+	holder			TEXT,
+	start			TIMESTAMP,
+	duration		INT,
+	pinned			BOOLEAN,
+	CONSTRAINT		fk_lease_lease_type
+		FOREIGN KEY	(lease_type_id)
+		REFERENCES	lease_type(id)
+);
+
+CREATE UNIQUE INDEX idx_lease_type_name
+ON lease (lease_type_id, name);
+`

--- a/database/schema/controller.go
+++ b/database/schema/controller.go
@@ -9,30 +9,36 @@ import "strings"
 func ControllerDDL() []string {
 	delta := `
 CREATE TABLE lease_type (
-	id		INT PRIMARY KEY,
-	type	TEXT
+    id   INT PRIMARY KEY,
+    type TEXT
 );
 
+CREATE UNIQUE INDEX idx_lease_type_type
+ON lease_type (type);
+
 INSERT INTO lease_type VALUES
-	(0, 'controller'), 
-	(1, 'model' ), 
-	(2, 'application');
+    (0, 'controller'), 
+    (1, 'model' ), 
+    (2, 'application');
 
 CREATE TABLE IF NOT EXISTS lease (
-	uuid			TEXT PRIMARY KEY,
-	lease_type_id	INT NOT NULL,
-	name			TEXT,
-	holder			TEXT,
-	start			TIMESTAMP,
-	duration		INT,
-	pinned			BOOLEAN,
-	CONSTRAINT		fk_lease_lease_type
-		FOREIGN KEY	(lease_type_id)
-		REFERENCES	lease_type(id)
+    uuid            TEXT PRIMARY KEY,
+    lease_type_id   INT NOT NULL,
+    name            TEXT,
+    holder          TEXT,
+    start           TIMESTAMP,
+    expiry          TIMESTAMP,
+    pinned          BOOLEAN,
+    CONSTRAINT      fk_lease_lease_type
+        FOREIGN KEY (lease_type_id)
+        REFERENCES  lease_type(id)
 );
 
 CREATE UNIQUE INDEX idx_lease_type_name
-ON lease (lease_type_id, name);`[1:]
+ON lease (lease_type_id, name);
+
+CREATE INDEX idx_lease_expiry
+ON lease (expiry);`[1:]
 
 	return strings.Split(delta, ";\n\n")
 }

--- a/database/schema/controller.go
+++ b/database/schema/controller.go
@@ -3,8 +3,11 @@
 
 package schema
 
-// controllerDDL is used to create the controller database schema at bootstrap.
-const controllerDDL = `
+import "strings"
+
+// ControllerDDL is used to create the controller database schema at bootstrap.
+func ControllerDDL() []string {
+	delta := `
 CREATE TABLE lease_type (
 	id		INT PRIMARY KEY,
 	type	TEXT
@@ -29,5 +32,7 @@ CREATE TABLE IF NOT EXISTS lease (
 );
 
 CREATE UNIQUE INDEX idx_lease_type_name
-ON lease (lease_type_id, name);
-`
+ON lease (lease_type_id, name);`[1:]
+
+	return strings.Split(delta, ";\n\n")
+}

--- a/database/testing/suite.go
+++ b/database/testing/suite.go
@@ -1,0 +1,88 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"net"
+	"strconv"
+
+	"github.com/juju/testing"
+
+	"github.com/canonical/go-dqlite/app"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+// DBSuite is used to provider a Dqlite-backed sql.DB reference to tests.
+type DBSuite struct {
+	testing.IsolationSuite
+
+	dqlite *app.App
+	db     *sql.DB
+}
+
+// SetUpSuite creates a new Dqlite application and waits for it to be ready.
+func (s *DBSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+
+	dbPath := c.MkDir()
+	port := findTCPPort(c)
+
+	var err error
+	s.dqlite, err = app.New(dbPath, app.WithAddress(fmt.Sprintf("%s:%d", "127.0.0.1", port)))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.dqlite.Ready(context.TODO())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TearDownSuite terminates the Dqlite node, releasing all resources.
+func (s *DBSuite) TearDownSuite(c *gc.C) {
+	if s.dqlite != nil {
+		err := s.dqlite.Close()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	s.IsolationSuite.TearDownSuite(c)
+}
+
+// SetUpTest opens a new, randomly named database and
+// makes it available for use by test the next test.
+func (s *DBSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	var err error
+	s.db, err = s.dqlite.Open(context.TODO(), strconv.Itoa(rand.Intn(10)))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TearDownTest closes the database opened in SetUpTest.
+// TODO (manadart 2022-09-12): There is currently no avenue for dropping a DB.
+func (s *DBSuite) TearDownTest(c *gc.C) {
+	if s.db != nil {
+		err := s.db.Close()
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	s.IsolationSuite.TearDownTest(c)
+}
+
+func (s *DBSuite) DB() *sql.DB {
+	return s.db
+}
+
+// FindTCPPort finds an unused TCP port and returns it.
+// It is prone to racing, so the port should be used as soon as it is acquired
+// to minimise the change of another process using it in the interim.
+// The chances of this should be negligible during testing.
+func findTCPPort(c *gc.C) int {
+	l, err := net.Listen("tcp", ":0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(l.Close(), jc.ErrorIsNil)
+	return l.Addr().(*net.TCPAddr).Port
+}

--- a/worker/dbaccessor/repl.go
+++ b/worker/dbaccessor/repl.go
@@ -252,7 +252,7 @@ func (r *sqlREPL) handleHelpCmd(s *replSession) {
 func (r *sqlREPL) handleOpenCommand(s *replSession) {
 	var err error
 
-	s.db, err = r.dbGetter.GetExistingDB(s.cmdParams)
+	s.db, err = r.dbGetter.GetDB(s.cmdParams)
 	if errors.IsNotFound(err) {
 		_, _ = fmt.Fprintf(s.resWriter, "No such database exists\n")
 		return

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -30,8 +30,8 @@ const (
 )
 
 type DBGetter interface {
-	GetDB(modelUUID string) (*sql.DB, error)
-	GetExistingDB(modelUUID string) (*sql.DB, error)
+	GetDB(namespace string) (*sql.DB, error)
+	GetExistingDB(namespace string) (*sql.DB, error)
 }
 
 // Hub provides an API for publishing and subscribing to incoming messages.


### PR DESCRIPTION
The initial spiking for Dqlite integration added a worker that started the Dqlite node, and was responsible for supplying `DB` instances to other workers and for clustering.

This neglected the fact that there is work we need to do to the database(s) at bootstrap, well before we have a dependency engine and attendant workers up.

Here we create a new `database` package where there is now:
- An option factory for generating Dqlite start-up options from agent configuration.
- A migration implementation for applying deltas to databases, with initial controller DDL.
- A bootstrap method for initialising Dqlite and creating the controller database, called during controller agent bootstrap.
- A testing suite implementation that uses Dqlite and supplies real `sql.DB` references for tests.

There are a couple of temporary changes included:
- A change to `make test` so that CGo is recruited. This will be superseded by changes from @tlm.
- A change so that the REPL opens databases. This also will be subject to refactor when the worker is modified to use the new `database` package.

## QA steps

- Run `make go-install`.
- Bootstrap to LXD.
- Run `make juju-dqlite-repl` this should yield a prompt.
- Enter `.open controller`.
- Check that the tables were created - `select * from lease_type;` should returns rows:
```
id      type
0       controller
1       model
2       application

Total rows: 3
```

## Documentation changes

None.

## Bug reference

N/A
