### PR TITLE
[JUJU-1635, JUJU-1782] Rewrite api/client/firewallrules unit tests to use gomock

### DIFF
--- a/api/client/firewallrules/client_test.go
+++ b/api/client/firewallrules/client_test.go
@@ -4,140 +4,114 @@
 package firewallrules_test
 
 import (
+	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	basetesting "github.com/juju/juju/api/base/testing"
+	basemocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/firewallrules"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/testing"
 )
 
 type FirewallRulesSuite struct {
-	testing.BaseSuite
 }
 
 var _ = gc.Suite(&FirewallRulesSuite{})
 
 func (s *FirewallRulesSuite) TestSetFirewallRule(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "FirewallRules")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "SetFirewallRules")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			args, ok := a.(params.FirewallRuleArgs)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Args, gc.HasLen, 1)
+	args := params.FirewallRuleArgs{
+		Args: []params.FirewallRule{{
+			KnownService:   "ssh",
+			WhitelistCIDRS: []string{"192.168.1.0/32"},
+		}},
+	}
+	res := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{
+			Error: apiservererrors.ServerError(errors.New("fail"))}},
+	}
 
-			rule := args.Args[0]
-			c.Assert(rule.KnownService, gc.Equals, params.SSHRule)
-			c.Assert(rule.WhitelistCIDRS, jc.DeepEquals, []string{"192.168.1.0/32"})
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SetFirewallRules", args, res).SetArg(2, results).Return(nil)
+	client := firewallrules.NewClientFromCaller(mockFacadeCaller)
 
-			if results, ok := result.(*params.ErrorResults); ok {
-				results.Results = []params.ErrorResult{{
-					Error: apiservererrors.ServerError(errors.New("fail"))}}
-			}
-			return nil
-		})
-
-	client := firewallrules.NewClient(apiCaller)
 	err := client.SetFirewallRule("ssh", []string{"192.168.1.0/32"})
 	c.Assert(err, gc.ErrorMatches, "fail")
 }
 
 func (s *FirewallRulesSuite) TestSetFirewallRuleFacadeCallError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	msg := "facade failure"
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "FirewallRules")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "SetFirewallRules")
-			return errors.New(msg)
-		})
-	client := firewallrules.NewClient(apiCaller)
+	args := params.FirewallRuleArgs{
+		Args: []params.FirewallRule{{
+			KnownService: "ssh",
+		}},
+	}
+	res := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{
+			Error: apiservererrors.ServerError(errors.New("fail"))}},
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SetFirewallRules", args, res).SetArg(2, results).Return(errors.New(msg))
+	client := firewallrules.NewClientFromCaller(mockFacadeCaller)
+
 	err := client.SetFirewallRule("ssh", nil)
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }
 
 func (s *FirewallRulesSuite) TestSetFirewallRuleInvalid(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Fail()
-			return errors.New("unexpected")
-		})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	client := firewallrules.NewClient(apiCaller)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	client := firewallrules.NewClientFromCaller(mockFacadeCaller)
+
 	err := client.SetFirewallRule("foo", []string{"192.168.1.0/32"})
 	c.Assert(err, gc.ErrorMatches, `known service "foo" not valid`)
 }
 
 func (s *FirewallRulesSuite) TestList(c *gc.C) {
-	called := false
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "FirewallRules")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListFirewallRules")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			called = true
-			c.Assert(a, gc.IsNil)
+	res := new(params.ListFirewallRulesResults)
+	results := params.ListFirewallRulesResults{
+		Rules: []params.FirewallRule{{
+			KnownService:   params.SSHRule,
+			WhitelistCIDRS: []string{"192.168.1.0/32"},
+		}},
+	}
 
-			if results, ok := result.(*params.ListFirewallRulesResults); ok {
-				results.Rules = []params.FirewallRule{{
-					KnownService:   params.SSHRule,
-					WhitelistCIDRS: []string{"192.168.1.0/32"},
-				}}
-			}
-			return nil
-		})
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListFirewallRules", nil, res).SetArg(2, results).Return(nil)
+	client := firewallrules.NewClientFromCaller(mockFacadeCaller)
 
-	client := firewallrules.NewClient(apiCaller)
-	results, err := client.ListFirewallRules()
+	ress, err := client.ListFirewallRules()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
-	c.Assert(results, jc.DeepEquals, []params.FirewallRule{{
+	c.Assert(ress, jc.DeepEquals, []params.FirewallRule{{
 		KnownService:   params.SSHRule,
 		WhitelistCIDRS: []string{"192.168.1.0/32"},
 	}})
 }
 
 func (s *FirewallRulesSuite) TestListError(c *gc.C) {
-	called := false
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			c.Check(objType, gc.Equals, "FirewallRules")
-			c.Check(id, gc.Equals, "")
-			c.Check(request, gc.Equals, "ListFirewallRules")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			called = true
-			return errors.New("fail")
-		})
+	res := new(params.ListFirewallRulesResults)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListFirewallRules", nil, res).Return(errors.New("fail"))
+	client := firewallrules.NewClientFromCaller(mockFacadeCaller)
 
-	client := firewallrules.NewClient(apiCaller)
 	_, err := client.ListFirewallRules()
 	c.Assert(errors.Cause(err), gc.ErrorMatches, "fail")
-	c.Assert(called, jc.IsTrue)
 }

--- a/api/client/firewallrules/client_test.go
+++ b/api/client/firewallrules/client_test.go
@@ -55,13 +55,9 @@ func (s *FirewallRulesSuite) TestSetFirewallRuleFacadeCallError(c *gc.C) {
 		}},
 	}
 	res := new(params.ErrorResults)
-	results := params.ErrorResults{
-		Results: []params.ErrorResult{{
-			Error: apiservererrors.ServerError(errors.New("fail"))}},
-	}
 
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall("SetFirewallRules", args, res).SetArg(2, results).Return(errors.New(msg))
+	mockFacadeCaller.EXPECT().FacadeCall("SetFirewallRules", args, res).Return(errors.New(msg))
 	client := firewallrules.NewClientFromCaller(mockFacadeCaller)
 
 	err := client.SetFirewallRule("ssh", nil)
@@ -76,7 +72,7 @@ func (s *FirewallRulesSuite) TestSetFirewallRuleInvalid(c *gc.C) {
 	client := firewallrules.NewClientFromCaller(mockFacadeCaller)
 
 	err := client.SetFirewallRule("foo", []string{"192.168.1.0/32"})
-	c.Assert(err, gc.ErrorMatches, `known service "foo" not valid`)
+	errors.Is(err, errors.NotValid)
 }
 
 func (s *FirewallRulesSuite) TestList(c *gc.C) {
@@ -97,10 +93,7 @@ func (s *FirewallRulesSuite) TestList(c *gc.C) {
 
 	ress, err := client.ListFirewallRules()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ress, jc.DeepEquals, []params.FirewallRule{{
-		KnownService:   params.SSHRule,
-		WhitelistCIDRS: []string{"192.168.1.0/32"},
-	}})
+	c.Assert(ress, jc.DeepEquals, results.Rules)
 }
 
 func (s *FirewallRulesSuite) TestListError(c *gc.C) {

--- a/api/client/firewallrules/client_test.go
+++ b/api/client/firewallrules/client_test.go
@@ -73,6 +73,8 @@ func (s *FirewallRulesSuite) TestSetFirewallRuleInvalid(c *gc.C) {
 
 	err := client.SetFirewallRule("foo", []string{"192.168.1.0/32"})
 	errors.Is(err, errors.NotValid)
+	c.Assert(err, gc.ErrorMatches, `service "foo" not valid`)
+
 }
 
 func (s *FirewallRulesSuite) TestList(c *gc.C) {

--- a/api/client/firewallrules/package_test.go
+++ b/api/client/firewallrules/package_test.go
@@ -1,14 +1,22 @@
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package firewallrules_test
+package firewallrules
 
 import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
 )
 
 func TestAll(t *testing.T) {
 	gc.TestingT(t)
+}
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
 }

--- a/rpc/params/firewall.go
+++ b/rpc/params/firewall.go
@@ -58,5 +58,5 @@ func (v KnownServiceValue) Validate() error {
 	case SSHRule, JujuControllerRule, JujuApplicationOfferRule:
 		return nil
 	}
-	return errors.NotValidf("known service %q", v)
+	return errors.NotValidf("service %q", v)
 }


### PR DESCRIPTION
The unit tests for api/client/firewallrules now use go mock and not juju/testing. All unit tests should pass.