### PR TITLE
[JUJU-1803] Juju status with selector matching on ports substring edit

### DIFF
--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -282,8 +282,12 @@ func buildUnitMatcherShims(u *state.Unit, patterns []string) []closurePredicate 
 
 func matchPortRanges(patterns []string, portRanges ...network.PortRange) (bool, bool, error) {
 	for _, p := range portRanges {
+		splitPortStr := strings.Split(p.String(), "/")
+		pNum := splitPortStr[0]
 		for _, patt := range patterns {
-			if strings.HasPrefix(p.String(), patt) {
+			splitPattStr := strings.Split(patt, "/")
+			pattNum := splitPattStr[0]
+			if strings.EqualFold(pNum, pattNum) && strings.HasPrefix(p.String(), patt) {
 				return true, true, nil
 			}
 		}

--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -282,12 +282,10 @@ func buildUnitMatcherShims(u *state.Unit, patterns []string) []closurePredicate 
 
 func matchPortRanges(patterns []string, portRanges ...network.PortRange) (bool, bool, error) {
 	for _, p := range portRanges {
-		splitPortStr := strings.Split(p.String(), "/")
-		pNum := splitPortStr[0]
+		pNum, _, _ := strings.Cut(p.String(), "/")
 		for _, patt := range patterns {
-			splitPattStr := strings.Split(patt, "/")
-			pattNum := splitPattStr[0]
-			if strings.EqualFold(pNum, pattNum) && strings.HasPrefix(p.String(), patt) {
+			pattNum, _, _ := strings.Cut(patt, "/")
+			if pNum == pattNum && strings.HasPrefix(p.String(), patt) {
 				return true, true, nil
 			}
 		}

--- a/apiserver/facades/client/client/filtering_test.go
+++ b/apiserver/facades/client/client/filtering_test.go
@@ -32,6 +32,16 @@ func (f *filteringUnitTests) TestMatchPortRanges(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(ok, jc.IsTrue)
 	c.Check(match, jc.IsFalse)
+
+	match, ok, err = client.MatchPortRanges([]string{"70"}, network.PortRange{7070, 7070, "tcp"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(ok, jc.IsTrue)
+	c.Check(match, jc.IsFalse)
+
+	match, ok, err = client.MatchPortRanges([]string{"7070"}, network.PortRange{7070, 7070, "tcp"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(ok, jc.IsTrue)
+	c.Check(match, jc.IsTrue)
 }
 
 func (s *filteringUnitTests) TestMatchSubnet(c *gc.C) {


### PR DESCRIPTION
Juju status incorrectly matches on the open "Ports". For example, if you have a bunch of machines with 5666/tcp for NRPE, "juju status 566" matches them all.

This PR fixes the filtering issue for the open port range.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing

## QA steps

```sh
juju bootstrap lxd lxd
juju deploy parca --channel=edge
juju status 707
juju status 7070
juju status 7070/t
```
`707` selector shouldn't show the status of the parca unit
`7070` and `7070/t` selectors should show the status of the parca unit

## Bug reference

https://bugs.launchpad.net/juju/+bug/1988709