### PR TITLE
[JUJU-1777] Exclude Fan IPs from API Addresses

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -6,7 +6,6 @@ package agentbootstrap_test
 import (
 	stdcontext "context"
 	"io/ioutil"
-	"net"
 	"path/filepath"
 
 	mgotesting "github.com/juju/mgo/v2/testing"
@@ -77,18 +76,16 @@ LXC_BRIDGE="ignored"`[1:])
 	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
 		if name == "foobar" {
-			// The addresses on the LXC bridge
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
-				&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+			return []string{
+				"10.0.3.1",
+				"10.0.3.4",
 			}, nil
 		} else if name == network.DefaultLXDBridge {
-			// The addresses on the LXD bridge
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
-				&net.IPAddr{IP: net.IPv4(10, 0, 4, 4)},
+			return []string{
+				"10.0.4.1",
+				"10.0.4.4",
 			}, nil
 		} else if name == network.DefaultKVMBridge {
 			// claim we don't have a virbr0 bridge

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -127,23 +127,21 @@ anything else ignored
 LXC_BRIDGE="ignored"`[1:])
 	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
 		if name == "foobar" {
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
-				&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
-				// Try a CIDR 10.0.3.5/24 as well.
-				&net.IPNet{IP: net.IPv4(10, 0, 3, 5), Mask: net.IPv4Mask(255, 255, 255, 0)},
+			return []string{
+				"10.0.3.1",
+				"10.0.3.4",
+				"10.0.3.5/24",
 			}, nil
 		} else if name == network.DefaultLXDBridge {
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
-				// Try a CIDR 10.0.5.1/24 as well.
-				&net.IPNet{IP: net.IPv4(10, 0, 5, 1), Mask: net.IPv4Mask(255, 255, 255, 0)},
+			return []string{
+				"10.0.4.1",
+				"10.0.5.1/24",
 			}, nil
 		} else if name == network.DefaultKVMBridge {
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(192, 168, 122, 1)},
+			return []string{
+				"192.168.122.1",
 			}, nil
 		}
 		c.Fatalf("unknown bridge name: %q", name)

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -162,7 +162,8 @@ LXC_BRIDGE="ignored"`[1:])
 		"10.0.6.10",     // unfiltered
 		"192.168.122.1", // filtered (from virbr0 bridge, 192.168.122.1)
 		"192.168.123.42",
-		"localhost", // unfiltered because it isn't an IP address
+		"localhost",    // unfiltered because it isn't an IP address
+		"252.16.134.1", // filtered Class E reserved address, used by Fan.
 	}).AsProviderAddresses()
 	filteredAddresses := corenetwork.NewMachineAddresses([]string{
 		"127.0.0.1",

--- a/worker/apiaddressupdater/apiaddressupdater_test.go
+++ b/worker/apiaddressupdater/apiaddressupdater_test.go
@@ -5,7 +5,6 @@ package apiaddressupdater_test
 
 import (
 	"io/ioutil"
-	"net"
 	"path/filepath"
 	"time"
 
@@ -37,7 +36,7 @@ func (s *APIAddressUpdaterSuite) SetUpTest(c *gc.C) {
 	err := s.State.SetAPIHostPorts(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// By default mock these to better isolate the test from the real machine.
-	s.PatchValue(&network.InterfaceByNameAddrs, func(string) ([]net.Addr, error) {
+	s.PatchValue(&network.AddressesForInterfaceName, func(string) ([]string, error) {
 		return nil, nil
 	})
 	s.PatchValue(&network.LXCNetDefaultConfig, "")
@@ -211,22 +210,20 @@ anything else ignored
 LXC_BRIDGE="ignored"`[1:])
 	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
 		if name == "foobar" {
-			// The addresses on the LXC bridge
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
-				&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+			return []string{
+				"10.0.3.1",
+				"10.0.3.4",
 			}, nil
 		} else if name == network.DefaultLXDBridge {
-			// The addresses on the LXD bridge
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
-				&net.IPAddr{IP: net.IPv4(10, 0, 4, 4)},
+			return []string{
+				"10.0.4.1",
+				"10.0.4.4",
 			}, nil
 		} else if name == network.DefaultKVMBridge {
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(192, 168, 122, 1)},
+			return []string{
+				"192.168.122.1",
 			}, nil
 		}
 		c.Fatalf("unknown bridge in testing: %v", name)

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -374,22 +374,20 @@ func (s *MachinerSuite) TestSetMachineAddresses(c *gc.C) {
 		&net.IPNet{IP: net.ParseIP("fe80::1")},     // LinkLocal Ignored
 	}
 
-	s.PatchValue(&network.InterfaceByNameAddrs, func(name string) ([]net.Addr, error) {
+	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
 		if name == "foobar" {
-			// The addresses on the LXC bridge
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)},
-				&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)},
+			return []string{
+				"10.0.3.1",
+				"10.0.3.4",
 			}, nil
 		} else if name == network.DefaultLXDBridge {
-			// The addresses on the LXD bridge
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(10, 0, 4, 1)},
-				&net.IPAddr{IP: net.IPv4(10, 0, 4, 4)},
+			return []string{
+				"10.0.4.1",
+				"10.0.4.4",
 			}, nil
 		} else if name == network.DefaultKVMBridge {
-			return []net.Addr{
-				&net.IPAddr{IP: net.IPv4(192, 168, 1, 1)},
+			return []string{
+				"192.168.122.1",
 			}, nil
 		}
 		c.Fatalf("unknown bridge in testing: %v", name)


### PR DESCRIPTION
Agent config for API addresses includes local Fan addresses on the controller when Fan network is set up. These are not usable for controller communication.

Here we include such addresses as those filtered as bridges, meaning they will not be in agent configuration, and never tried for controller communication

## QA steps

Prior to this patch, connecting to Mongo on an AWS controller, one can observe these addresses in the _controllers_ collection:
```
juju:PRIMARY> db.controllers.find({"_id": "apiHostPortsForAgents"}).pretty()
{
        "_id" : "apiHostPortsForAgents",
        "apihostports" : [
                [
                        {
                                "value" : "54.159.29.145",
                                "addresstype" : "ipv4",
                                "networkscope" : "public",
                                "port" : 17070,
                                "spaceid" : "0"
                        },
                        {
                                "value" : "172.31.16.134",
                                "addresstype" : "ipv4",
                                "networkscope" : "local-cloud",
                                "port" : 17070,
                                "spaceid" : "0"
                        },
                        {
                                "value" : "252.16.134.1",
                                "addresstype" : "ipv4",
                                "networkscope" : "local-fan",
                                "port" : 17070
                        },
                        {
                                "value" : "127.0.0.1",
                                "addresstype" : "ipv4",
                                "networkscope" : "local-machine",
                                "port" : 17070
                        },
                        {
                                "value" : "::1",
                                "addresstype" : "ipv6",
                                "networkscope" : "local-machine",
                                "port" : 17070
                        }
                ]
        ],
        "txn-revno" : NumberLong(5),
        "txn-queue" : [
                "6321c73701cb932137c859d6_7e30d7b3"
        ]
}
```

Bootstrapping with this patch will result in the same document without the "local-fan" scoped address.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1942804
