### PR TITLE
[JUJU-1804] Don't assume ec2 network interface private ips have associations

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -1571,12 +1571,14 @@ func mapNetworkInterface(iface types.NetworkInterface, subnet types.Subnet) netw
 	}
 
 	for _, privAddr := range iface.PrivateIpAddresses {
-		if ip := aws.ToString(privAddr.Association.PublicIp); ip != "" {
-			ni.ShadowAddresses = append(ni.ShadowAddresses, network.NewMachineAddress(
-				ip,
-				network.WithScope(network.ScopePublic),
-				network.WithConfigType(network.ConfigDHCP),
-			).AsProviderAddress())
+		if privAddr.Association != nil {
+			if ip := aws.ToString(privAddr.Association.PublicIp); ip != "" {
+				ni.ShadowAddresses = append(ni.ShadowAddresses, network.NewMachineAddress(
+					ip,
+					network.WithScope(network.ScopePublic),
+					network.WithConfigType(network.ConfigDHCP),
+				).AsProviderAddress())
+			}
 		}
 
 		if aws.ToString(privAddr.PrivateIpAddress) == privateAddress {

--- a/provider/ec2/internal/testing/subnets.go
+++ b/provider/ec2/internal/testing/subnets.go
@@ -40,11 +40,11 @@ func (srv *Server) DescribeSubnets(ctx context.Context, in *ec2.DescribeSubnetsI
 }
 
 // AddSubnet inserts the given subnet in the test server, as if it was
-// created using the simulated AWS API. The Id field of v is ignored
+// created using the simulated AWS API. The Id field of sub is ignored
 // and replaced by the next subnetId counter value, prefixed by
 // "subnet-". The VPCId field of sub must be contain an existing VPC
-// id, and the AvailZone field must contain an existing AZ, otherwise
-// errors are returned. Finally, if AvailableIPCount is negative it is
+// id, and the AvailabilityZone field must contain an existing AZ,
+// otherwise errors are returned.
 func (srv *Server) AddSubnet(sub types.Subnet) (types.Subnet, error) {
 	zeroSubnet := types.Subnet{}
 


### PR DESCRIPTION
On the rare occasion this assumption is broken, the instance-poller worker regularly panics leading to all sorts of trouble

And a bit of testing infra to handle this test case

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Make sure a subnet 172.31.254.0/24 exists in aws with `Auto-assign public IPv4 address` set to false 
```
juju bootstrap aws/eu-west-2 aws-test
juju add-space isolated 172.31.254.0/24
juju add-machine --constraints spaces=isolated
juju add-machine --constraints spaces=alpha -n4
```
And verify that all machines in the alpha space register a floating ip

## Bug reference

https://bugs.launchpad.net/juju/+bug/1989136
