### PR TITLE
[JUJU-1811] Wire up the secret expire hook in the uniter

### DIFF
--- a/worker/caasoperator/manifold_test.go
+++ b/worker/caasoperator/manifold_test.go
@@ -198,6 +198,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.UniterParams.NewDeployer = nil
 	config.UniterParams.NewProcessRunner = nil
 	config.UniterParams.SecretRotateWatcherFunc = nil
+	config.UniterParams.SecretExpiryWatcherFunc = nil
 	config.UniterParams.SecretsStoreGetter = nil
 	config.Logger = nil
 	config.ExecClientGetter = nil

--- a/worker/uniter/hook/hook.go
+++ b/worker/uniter/hook/hook.go
@@ -108,6 +108,9 @@ func (hi Info) Validate() error {
 		if _, err := secrets.ParseURI(hi.SecretURI); err != nil {
 			return errors.Errorf("invalid secret URI %q", hi.SecretURI)
 		}
+		if (hi.Kind == hooks.SecretRemove || hi.Kind == hooks.SecretExpired) && hi.SecretRevision <= 0 {
+			return errors.Errorf("%q hook requires a secret revision", hi.Kind)
+		}
 		return nil
 	}
 	return errors.Errorf("unknown hook kind %q", hi.Kind)

--- a/worker/uniter/hook/hook_test.go
+++ b/worker/uniter/hook/hook_test.go
@@ -53,6 +53,9 @@ var validateTests = []struct {
 		hook.Info{Kind: hooks.SecretRotate},
 		`"secret-rotate" hook requires a secret URI`,
 	}, {
+		hook.Info{Kind: hooks.SecretExpired, SecretURI: "secret:9m4e2mr0ui3e8a215n4g"},
+		`"secret-expired" hook requires a secret revision`,
+	}, {
 		hook.Info{Kind: hooks.SecretRotate, SecretURI: "foo"},
 		`invalid secret URI "foo"`,
 	},

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -73,7 +73,7 @@ func (rh *runHook) Prepare(state State) (*State, error) {
 	}
 
 	switch hooks.Kind(name) {
-	case hooks.LeaderElected, hooks.SecretRotate:
+	case hooks.LeaderElected, hooks.SecretRotate, hooks.SecretExpired:
 		// Check if leadership has changed between queueing of the hook and
 		// Actual execution. Skip execution if we are no longer the leader.
 		var isLeader bool
@@ -107,7 +107,11 @@ func RunningHookMessage(hookName string, info hook.Info) string {
 		return fmt.Sprintf("running %s hook for %s", hookName, info.RemoteUnit)
 	}
 	if info.Kind.IsSecret() {
-		return fmt.Sprintf("running %s hook for %s", hookName, info.SecretURI)
+		revMsg := ""
+		if info.SecretRevision > 0 {
+			revMsg = fmt.Sprintf("/%d", info.SecretRevision)
+		}
+		return fmt.Sprintf("running %s hook for %s%s", hookName, info.SecretURI, revMsg)
 	}
 	return fmt.Sprintf("running %s hook", hookName)
 }

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -401,12 +401,12 @@ func (t *mockTicket) Wait() bool {
 	return t.result
 }
 
-type mockRotateSecretsWatcher struct {
-	rotateCh chan []string
-	stopCh   chan struct{}
+type mockSecretTriggerWatcher struct {
+	ch     chan []string
+	stopCh chan struct{}
 }
 
-func (w *mockRotateSecretsWatcher) Kill() {
+func (w *mockSecretTriggerWatcher) Kill() {
 	select {
 	case <-w.stopCh:
 	default:
@@ -414,7 +414,7 @@ func (w *mockRotateSecretsWatcher) Kill() {
 	}
 }
 
-func (*mockRotateSecretsWatcher) Wait() error {
+func (*mockSecretTriggerWatcher) Wait() error {
 	return nil
 }
 

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -93,6 +93,9 @@ type Snapshot struct {
 	// SecretRotations is a list of secret URIs that need to be rotated.
 	SecretRotations []string
 
+	// ExpiredSecretRevisions is a list of secret revisions that need to be expired.
+	ExpiredSecretRevisions []string
+
 	// ConsumedSecretInfo is a list of the labels and revision info
 	// for secrets consumed by this unit.
 	// The map is keyed on secret ID.

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -109,7 +109,7 @@ func (s *baseResolverSuite) SetUpTest(c *gc.C, modelType model.ModelType, reboot
 		StopRetryHookTimer:  func() { s.stub.AddCall("StopRetryHookTimer") },
 		ShouldRetryHooks:    true,
 		UpgradeSeries:       upgradeseries.NewResolver(logger),
-		Secrets:             secrets.NewSecretsResolver(logger, secretsTracker, func(_ string) {}),
+		Secrets:             secrets.NewSecretsResolver(logger, secretsTracker, func(_ string) {}, func(_ string) {}),
 		Reboot:              reboot.NewResolver(logger, rebootDetected),
 		Leadership:          leadership.NewResolver(logger),
 		Actions:             uniteractions.NewResolver(logger),

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -472,6 +472,22 @@ func (s *UniterSuite) TestUniterRotateSecretHook(c *gc.C) {
 	})
 }
 
+func (s *UniterSuite) TestUniterSecretExpiredHook(c *gc.C) {
+	s.runUniterTests(c, []uniterTest{
+		ut(
+			"secret expired hook runs when there are secret revisions to be expired",
+			createCharm{},
+			serveCharm{},
+			createUniter{},
+			waitHooks(startupHooks(false)),
+			waitUnitAgent{status: status.Idle},
+			createSecret{},
+			expireSecret{},
+			waitHooks{"secret-expired"},
+		),
+	})
+}
+
 func (s *UniterSuite) TestUniterSecretChangedHook(c *gc.C) {
 	s.runUniterTests(c, []uniterTest{
 		ut(

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -141,6 +141,7 @@ type testContext struct {
 	containerNames         []string
 	pebbleClients          map[string]*fakePebbleClient
 	secretsRotateCh        chan []string
+	secretsExpireCh        chan []string
 	secretsClient          *secretsmanager.Client
 	secretsStore           jujusecrets.Store
 	err                    string
@@ -598,6 +599,11 @@ func (s startUniter) step(c *gc.C, ctx *testContext) {
 			c.Assert(u.String(), gc.Equals, s.unitTag)
 			ctx.secretsRotateCh = secretsChanged
 			return watchertest.NewMockStringsWatcher(ctx.secretsRotateCh), nil
+		},
+		SecretExpiryWatcherFunc: func(u names.UnitTag, secretsChanged chan []string) (worker.Worker, error) {
+			c.Assert(u.String(), gc.Equals, s.unitTag)
+			ctx.secretsExpireCh = secretsChanged
+			return watchertest.NewMockStringsWatcher(ctx.secretsExpireCh), nil
 		},
 		SecretsClient: ctx.secretsClient,
 		SecretsStoreGetter: func() (jujusecrets.Store, error) {
@@ -1715,6 +1721,16 @@ func (s rotateSecret) step(c *gc.C, ctx *testContext) {
 	case ctx.secretsRotateCh <- []string{ctx.createdSecretURI.String()}:
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("sending rotate secret change for %q", ctx.createdSecretURI)
+	}
+}
+
+type expireSecret struct{}
+
+func (s expireSecret) step(c *gc.C, ctx *testContext) {
+	select {
+	case ctx.secretsExpireCh <- []string{ctx.createdSecretURI.String() + "/1"}:
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf(`sending expire secret change for "%s/1"`, ctx.createdSecretURI)
 	}
 }
 


### PR DESCRIPTION
Building on https://github.com/juju/juju/pull/14607, the secret expire hook is wired up in the unit agent.
The trigger for the hook comes from the secret expire worker in the previous PR.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

deploy a charm with a secret-expired hook
```
juju exec --unit ubuntu/0 "secret-add foo=bar"
secret:cchbj6vuv42jl6aprnl0
juju exec --unit ubuntu/0 "secret-update secret:cchbj6vuv42jl6aprnl0 --expire 2m"
```
wait 2 minutes
```
juju show-status-log ubuntu/0
Time                        Type       Status       Message
15 Sep 2022 15:35:04+10:00  workload   waiting      waiting for machine
15 Sep 2022 15:35:04+10:00  juju-unit  allocating   
15 Sep 2022 15:35:04+10:00  workload   waiting      installing agent
15 Sep 2022 15:35:05+10:00  workload   waiting      agent initialising
15 Sep 2022 15:35:18+10:00  workload   maintenance  installing charm software
...
15 Sep 2022 15:37:48+10:00  juju-unit  executing    running secret-expired hook for secret:cchbj6vuv42jl6aprnl0/1
15 Sep 2022 15:37:49+10:00  juju-unit  idle  
```
secret not removed so wait another 5 minutes
log will contain a warning that the secret expire is being retried, hook runs again
```
unit-ubuntu-0: 15:42:48 WARNING juju.worker.uniter.secretrevisionsexpire retry attempt 1 to expire secret "secret:cchbj6vuv42jl6aprnl0" revision 1
unit-ubuntu-0: 15:42:49 INFO juju.worker.uniter.operation ran "secret-expired" hook (via hook dispatching script: dispatch)
```
remove secret, no more expired hooks
```
juju exec --unit ubuntu/0 "secret-remove secret:cchbj6vuv42jl6aprnl0"
```