### PR TITLE
[JUJU-1817] Add support for secrets to be owned by units

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -131,19 +131,16 @@ func (c *Client) WatchConsumedSecretsChanges(unitName string) (watcher.StringsWa
 //
 // Obsolete revisions results are "uri/revno" and deleted
 // secret results are "uri".
-func (c *Client) WatchObsolete(appName string) (watcher.StringsWatcher, error) {
-	var results params.StringsWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: names.NewApplicationTag(appName).String()}},
+func (c *Client) WatchObsolete(ownerTags ...names.Tag) (watcher.StringsWatcher, error) {
+	var result params.StringsWatchResult
+	args := params.Entities{Entities: make([]params.Entity, len(ownerTags))}
+	for i, tag := range ownerTags {
+		args.Entities[i] = params.Entity{Tag: tag.String()}
 	}
-	err := c.facade.FacadeCall("WatchObsolete", args, &results)
+	err := c.facade.FacadeCall("WatchObsolete", args, &result)
 	if err != nil {
 		return nil, err
 	}
-	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
 	if result.Error != nil {
 		return nil, apiservererrors.RestoreError(result.Error)
 	}
@@ -209,6 +206,7 @@ func (c *Client) SecretMetadata(filter coresecrets.Filter) ([]coresecrets.Secret
 		}
 		md := coresecrets.SecretMetadata{
 			URI:              uri,
+			OwnerTag:         info.OwnerTag,
 			Description:      info.Description,
 			Label:            info.Label,
 			RotatePolicy:     coresecrets.RotatePolicy(info.RotatePolicy),
@@ -233,19 +231,16 @@ func (c *Client) SecretMetadata(filter coresecrets.Filter) ([]coresecrets.Secret
 
 // WatchSecretsRotationChanges returns a watcher which serves changes to
 // secrets rotation config for any secrets managed by the specified owner.
-func (c *Client) WatchSecretsRotationChanges(ownerTag string) (watcher.SecretTriggerWatcher, error) {
-	var results params.SecretTriggerWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: ownerTag}},
+func (c *Client) WatchSecretsRotationChanges(ownerTags ...names.Tag) (watcher.SecretTriggerWatcher, error) {
+	var result params.SecretTriggerWatchResult
+	args := params.Entities{Entities: make([]params.Entity, len(ownerTags))}
+	for i, tag := range ownerTags {
+		args.Entities[i] = params.Entity{Tag: tag.String()}
 	}
-	err := c.facade.FacadeCall("WatchSecretsRotationChanges", args, &results)
+	err := c.facade.FacadeCall("WatchSecretsRotationChanges", args, &result)
 	if err != nil {
 		return nil, err
 	}
-	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -283,19 +278,16 @@ func (c *Client) SecretRotated(uri string, oldRevision int) error {
 
 // WatchSecretRevisionsExpiryChanges returns a watcher which serves changes to
 // secret revision expiry config for any secrets managed by the specified owner.
-func (c *Client) WatchSecretRevisionsExpiryChanges(ownerTag string) (watcher.SecretTriggerWatcher, error) {
-	var results params.SecretTriggerWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: ownerTag}},
+func (c *Client) WatchSecretRevisionsExpiryChanges(ownerTags ...names.Tag) (watcher.SecretTriggerWatcher, error) {
+	var result params.SecretTriggerWatchResult
+	args := params.Entities{Entities: make([]params.Entity, len(ownerTags))}
+	for i, tag := range ownerTags {
+		args.Entities[i] = params.Entity{Tag: tag.String()}
 	}
-	err := c.facade.FacadeCall("WatchSecretRevisionsExpiryChanges", args, &results)
+	err := c.facade.FacadeCall("WatchSecretRevisionsExpiryChanges", args, &result)
 	if err != nil {
 		return nil, err
 	}
-	if len(results.Results) != 1 {
-		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
 	if result.Error != nil {
 		return nil, result.Error
 	}

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -6,6 +6,7 @@ package secretsmanager_test
 import (
 	"time"
 
+	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -147,6 +148,7 @@ func (s *SecretsSuite) TestGetSecretMetadata(c *gc.C) {
 		*(result.(*params.ListSecretResults)) = params.ListSecretResults{
 			Results: []params.ListSecretResult{{
 				URI:              uri.String(),
+				OwnerTag:         "application-mariadb",
 				Label:            "label",
 				LatestRevision:   666,
 				NextRotateTime:   &now,
@@ -169,6 +171,7 @@ func (s *SecretsSuite) TestGetSecretMetadata(c *gc.C) {
 	c.Assert(result, gc.HasLen, 1)
 	for _, info := range result {
 		c.Assert(info.Metadata.URI.String(), gc.Equals, uri.String())
+		c.Assert(info.Metadata.OwnerTag, gc.Equals, "application-mariadb")
 		c.Assert(info.Metadata.Label, gc.Equals, "label")
 		c.Assert(info.Metadata.LatestRevision, gc.Equals, 666)
 		c.Assert(info.Metadata.LatestExpireTime, gc.Equals, &now)
@@ -238,18 +241,16 @@ func (s *SecretsSuite) TestWatchObsolete(c *gc.C) {
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "WatchObsolete")
 		c.Check(arg, jc.DeepEquals, params.Entities{
-			Entities: []params.Entity{{Tag: "application-app"}},
+			Entities: []params.Entity{{Tag: "unit-foo-0"}},
 		})
-		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
-		*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
-			[]params.StringsWatchResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
+		c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResult{})
+		*(result.(*params.StringsWatchResult)) = params.StringsWatchResult{
+			Error: &params.Error{Message: "FAIL"},
 		}
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	_, err := client.WatchObsolete("app")
+	_, err := client.WatchObsolete(names.NewUnitTag("foo/0"))
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -262,16 +263,14 @@ func (s *SecretsSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 		c.Check(arg, jc.DeepEquals, params.Entities{
 			Entities: []params.Entity{{Tag: "application-app"}},
 		})
-		c.Assert(result, gc.FitsTypeOf, &params.SecretTriggerWatchResults{})
-		*(result.(*params.SecretTriggerWatchResults)) = params.SecretTriggerWatchResults{
-			[]params.SecretTriggerWatchResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
+		c.Assert(result, gc.FitsTypeOf, &params.SecretTriggerWatchResult{})
+		*(result.(*params.SecretTriggerWatchResult)) = params.SecretTriggerWatchResult{
+			Error: &params.Error{Message: "FAIL"},
 		}
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	_, err := client.WatchSecretsRotationChanges("application-app")
+	_, err := client.WatchSecretsRotationChanges(names.NewApplicationTag("app"))
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -309,16 +308,14 @@ func (s *SecretsSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 		c.Check(arg, jc.DeepEquals, params.Entities{
 			Entities: []params.Entity{{Tag: "application-app"}},
 		})
-		c.Assert(result, gc.FitsTypeOf, &params.SecretTriggerWatchResults{})
-		*(result.(*params.SecretTriggerWatchResults)) = params.SecretTriggerWatchResults{
-			[]params.SecretTriggerWatchResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
+		c.Assert(result, gc.FitsTypeOf, &params.SecretTriggerWatchResult{})
+		*(result.(*params.SecretTriggerWatchResult)) = params.SecretTriggerWatchResult{
+			Error: &params.Error{Message: "FAIL"},
 		}
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	_, err := client.WatchSecretRevisionsExpiryChanges("application-app")
+	_, err := client.WatchSecretRevisionsExpiryChanges(names.NewApplicationTag("app"))
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -515,11 +515,14 @@ func (s *watcherSuite) setupSecretRotationWatcher(
 	c *gc.C,
 ) (*secrets.URI, func(corewatcher.SecretTriggerChange), func(), func()) {
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "mysql"})
+	unit, password := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
+		Application: app,
+	})
 	store := state.NewSecrets(s.State)
 	uri := secrets.NewURI()
 	nexRotateTime := time.Now().Add(time.Hour)
 	_, err := store.CreateSecret(uri, state.CreateSecretParams{
-		Owner: "application-mysql",
+		Owner: unit.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken:    &fakeToken{},
 			RotatePolicy:   ptr(secrets.RotateDaily),
@@ -531,9 +534,6 @@ func (s *watcherSuite) setupSecretRotationWatcher(
 
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
-	unit, password := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
-		Application: app,
-	})
 	apiInfo := s.APIInfo(c)
 	apiInfo.Tag = unit.Tag()
 	apiInfo.Password = password
@@ -543,7 +543,7 @@ func (s *watcherSuite) setupSecretRotationWatcher(
 	c.Assert(err, jc.ErrorIsNil)
 
 	client := secretsmanager.NewClient(apiConn)
-	w, err := client.WatchSecretsRotationChanges("application-mysql")
+	w, err := client.WatchSecretsRotationChanges(unit.Tag())
 	if !c.Check(err, jc.ErrorIsNil) {
 		_ = apiConn.Close()
 		c.FailNow()
@@ -622,11 +622,14 @@ func (s *watcherSuite) setupSecretExpiryWatcher(
 	c *gc.C,
 ) (*secrets.URI, func(corewatcher.SecretTriggerChange), func(), func()) {
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "mysql"})
+	unit, password := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
+		Application: app,
+	})
 	store := state.NewSecrets(s.State)
 	uri := secrets.NewURI()
 	nexRotateTime := time.Now().Add(time.Hour)
 	_, err := store.CreateSecret(uri, state.CreateSecretParams{
-		Owner: "application-mysql",
+		Owner: unit.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken:    &fakeToken{},
 			RotatePolicy:   ptr(secrets.RotateDaily),
@@ -638,9 +641,6 @@ func (s *watcherSuite) setupSecretExpiryWatcher(
 
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
 
-	unit, password := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
-		Application: app,
-	})
 	apiInfo := s.APIInfo(c)
 	apiInfo.Tag = unit.Tag()
 	apiInfo.Password = password
@@ -650,7 +650,7 @@ func (s *watcherSuite) setupSecretExpiryWatcher(
 	c.Assert(err, jc.ErrorIsNil)
 
 	client := secretsmanager.NewClient(apiConn)
-	w, err := client.WatchSecretsRotationChanges("application-mysql")
+	w, err := client.WatchSecretsRotationChanges(unit.Tag())
 	if !c.Check(err, jc.ErrorIsNil) {
 		_ = apiConn.Close()
 		c.FailNow()

--- a/apiserver/facades/agent/secretsmanager/access.go
+++ b/apiserver/facades/agent/secretsmanager/access.go
@@ -4,8 +4,11 @@
 package secretsmanager
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/core/leadership"
 	coresecrets "github.com/juju/juju/core/secrets"
 )
 
@@ -26,36 +29,71 @@ func (s *SecretsManagerAPI) hasRole(uri *coresecrets.URI, entity names.Tag, role
 	return err == nil && hasRole.Allowed(role)
 }
 
-func (s *SecretsManagerAPI) canManage(uri *coresecrets.URI, entity names.Tag) bool {
-	// Manage access is granted on a per app basis;
-	// Any unit from the allowed app can manage.
-	authAppName := authTagApp(entity)
-	if authAppName == "" {
-		return false
+// canManage checks that the authenticated caller can manage the secret, and returns a
+// token to ensure leadership if that is required; ie if the request is for a secret
+// owned by an application, the entity must be the unit leader.
+func (s *SecretsManagerAPI) canManage(uri *coresecrets.URI) (leadership.Token, error) {
+	// TODO(wallyworld) - remove auth tag kind check when podspec charms are gone.
+	if s.authTag.Kind() == names.UnitTagKind && s.hasRole(uri, s.authTag, coresecrets.RoleManage) {
+		return successfulToken{}, nil
 	}
-	app := names.NewApplicationTag(authAppName)
-	return s.hasRole(uri, app, coresecrets.RoleManage)
+	if s.authTag.Kind() != names.ApplicationTagKind {
+		return s.leadershipToken()
+	}
+	appName := authTagApp(s.authTag)
+	appTag := names.NewApplicationTag(appName)
+	if s.hasRole(uri, appTag, coresecrets.RoleManage) {
+		return successfulToken{}, nil
+	}
+	return nil, apiservererrors.ErrPerm
 }
 
+// canRead returns true if the specified entity can read the secret.
 func (s *SecretsManagerAPI) canRead(uri *coresecrets.URI, entity names.Tag) bool {
-	if s.canManage(uri, entity) {
-		return true
-	}
 	// First try looking up unit access.
 	hasRole, _ := s.secretsConsumer.SecretAccess(uri, entity)
 	if hasRole.Allowed(coresecrets.RoleView) {
 		return true
 	}
-	// If no unit level access granted, try for the app.
-	authAppName := authTagApp(entity)
-	if authAppName == "" {
-		return false
-	}
-	app := names.NewApplicationTag(authAppName)
-	hasRole, _ = s.secretsConsumer.SecretAccess(uri, app)
+	// TODO(wallyworld) - remove when podspec charms are gone.
+	appName := authTagApp(s.authTag)
+	hasRole, _ = s.secretsConsumer.SecretAccess(uri, names.NewApplicationTag(appName))
 	return hasRole.Allowed(coresecrets.RoleView)
 }
 
 func (s *SecretsManagerAPI) isSameApplication(tag names.Tag) bool {
 	return authTagApp(s.authTag) == authTagApp(tag)
+}
+
+// ownerToken returns a token used to determine if the specified entity
+// is owned by the authenticated caller.
+func (s *SecretsManagerAPI) ownerToken(ownerTag names.Tag) (leadership.Token, error) {
+	if !s.isSameApplication(ownerTag) {
+		return nil, apiservererrors.ErrPerm
+	}
+	// A unit can create a secret so long as the
+	// secret owner is that unit's app.
+	// TODO(wallyworld) - remove auth tag kind check when podspec charms are gone.
+	if s.authTag.Kind() == names.ApplicationTagKind || s.authTag.Id() == ownerTag.Id() {
+		return successfulToken{}, nil
+	}
+	return s.leadershipToken()
+}
+
+type successfulToken struct{}
+
+// Check implements lease.Token.
+func (t successfulToken) Check(_ int, _ interface{}) error {
+	return nil
+}
+
+// leadershipToken returns a token used to determine if the authenticated
+// caller is the unit leader of its application.
+func (s *SecretsManagerAPI) leadershipToken() (leadership.Token, error) {
+	appName := authTagApp(s.authTag)
+	token := s.leadershipChecker.LeadershipCheck(appName, s.authTag.Id())
+	if err := token.Check(0, nil); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return token, nil
 }

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsbackend.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsbackend.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	secrets "github.com/juju/juju/core/secrets"
 	state "github.com/juju/juju/state"
+	names "github.com/juju/names/v4"
 )
 
 // MockSecretsBackend is a mock of SecretsBackend interface.
@@ -51,18 +52,23 @@ func (mr *MockSecretsBackendMockRecorder) CreateSecret(arg0, arg1 interface{}) *
 }
 
 // DeleteSecret mocks base method.
-func (m *MockSecretsBackend) DeleteSecret(arg0 *secrets.URI, arg1 []int) (bool, error) {
+func (m *MockSecretsBackend) DeleteSecret(arg0 *secrets.URI, arg1 ...int) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSecret", arg0, arg1)
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteSecret", varargs...)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeleteSecret indicates an expected call of DeleteSecret.
-func (mr *MockSecretsBackendMockRecorder) DeleteSecret(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSecretsBackendMockRecorder) DeleteSecret(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockSecretsBackend)(nil).DeleteSecret), arg0, arg1)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockSecretsBackend)(nil).DeleteSecret), varargs...)
 }
 
 // GetSecret mocks base method.
@@ -139,4 +145,19 @@ func (m *MockSecretsBackend) UpdateSecret(arg0 *secrets.URI, arg1 state.UpdateSe
 func (mr *MockSecretsBackendMockRecorder) UpdateSecret(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecret", reflect.TypeOf((*MockSecretsBackend)(nil).UpdateSecret), arg0, arg1)
+}
+
+// WatchObsolete mocks base method.
+func (m *MockSecretsBackend) WatchObsolete(arg0 []names.Tag) (state.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchObsolete", arg0)
+	ret0, _ := ret[0].(state.StringsWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchObsolete indicates an expected call of WatchObsolete.
+func (mr *MockSecretsBackendMockRecorder) WatchObsolete(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretsBackend)(nil).WatchObsolete), arg0)
 }

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsconsumer.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsconsumer.go
@@ -37,7 +37,7 @@ func (m *MockSecretsConsumer) EXPECT() *MockSecretsConsumerMockRecorder {
 }
 
 // GetSecretConsumer mocks base method.
-func (m *MockSecretsConsumer) GetSecretConsumer(arg0 *secrets.URI, arg1 string) (*secrets.SecretConsumerMetadata, error) {
+func (m *MockSecretsConsumer) GetSecretConsumer(arg0 *secrets.URI, arg1 names.Tag) (*secrets.SecretConsumerMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretConsumer", arg0, arg1)
 	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
@@ -80,7 +80,7 @@ func (mr *MockSecretsConsumerMockRecorder) RevokeSecretAccess(arg0, arg1 interfa
 }
 
 // SaveSecretConsumer mocks base method.
-func (m *MockSecretsConsumer) SaveSecretConsumer(arg0 *secrets.URI, arg1 string, arg2 *secrets.SecretConsumerMetadata) error {
+func (m *MockSecretsConsumer) SaveSecretConsumer(arg0 *secrets.URI, arg1 names.Tag, arg2 *secrets.SecretConsumerMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveSecretConsumer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -109,7 +109,7 @@ func (mr *MockSecretsConsumerMockRecorder) SecretAccess(arg0, arg1 interface{}) 
 }
 
 // WatchConsumedSecretsChanges mocks base method.
-func (m *MockSecretsConsumer) WatchConsumedSecretsChanges(arg0 string) (state.StringsWatcher, error) {
+func (m *MockSecretsConsumer) WatchConsumedSecretsChanges(arg0 names.Tag) (state.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchConsumedSecretsChanges", arg0)
 	ret0, _ := ret[0].(state.StringsWatcher)
@@ -121,19 +121,4 @@ func (m *MockSecretsConsumer) WatchConsumedSecretsChanges(arg0 string) (state.St
 func (mr *MockSecretsConsumerMockRecorder) WatchConsumedSecretsChanges(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConsumedSecretsChanges", reflect.TypeOf((*MockSecretsConsumer)(nil).WatchConsumedSecretsChanges), arg0)
-}
-
-// WatchObsolete mocks base method.
-func (m *MockSecretsConsumer) WatchObsolete(arg0 string) (state.StringsWatcher, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchObsolete", arg0)
-	ret0, _ := ret[0].(state.StringsWatcher)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchObsolete indicates an expected call of WatchObsolete.
-func (mr *MockSecretsConsumerMockRecorder) WatchObsolete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretsConsumer)(nil).WatchObsolete), arg0)
 }

--- a/apiserver/facades/agent/secretsmanager/mocks/secrettriggers.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secrettriggers.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	secrets "github.com/juju/juju/core/secrets"
 	state "github.com/juju/juju/state"
+	names "github.com/juju/names/v4"
 )
 
 // MockSecretTriggers is a mock of SecretTriggers interface.
@@ -51,11 +52,12 @@ func (mr *MockSecretTriggersMockRecorder) SecretRotated(arg0, arg1 interface{}) 
 }
 
 // WatchSecretRevisionsExpiryChanges mocks base method.
-func (m *MockSecretTriggers) WatchSecretRevisionsExpiryChanges(arg0 string) state.SecretsTriggerWatcher {
+func (m *MockSecretTriggers) WatchSecretRevisionsExpiryChanges(arg0 []names.Tag) (state.SecretsTriggerWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchSecretRevisionsExpiryChanges", arg0)
 	ret0, _ := ret[0].(state.SecretsTriggerWatcher)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // WatchSecretRevisionsExpiryChanges indicates an expected call of WatchSecretRevisionsExpiryChanges.
@@ -65,11 +67,12 @@ func (mr *MockSecretTriggersMockRecorder) WatchSecretRevisionsExpiryChanges(arg0
 }
 
 // WatchSecretsRotationChanges mocks base method.
-func (m *MockSecretTriggers) WatchSecretsRotationChanges(arg0 string) state.SecretsTriggerWatcher {
+func (m *MockSecretTriggers) WatchSecretsRotationChanges(arg0 []names.Tag) (state.SecretsTriggerWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchSecretsRotationChanges", arg0)
 	ret0, _ := ret[0].(state.SecretsTriggerWatcher)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // WatchSecretsRotationChanges indicates an expected call of WatchSecretsRotationChanges.

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -38,7 +38,7 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return secrets.StoreConfig(model, context.Auth().GetAuthTag())
+		return secrets.StoreConfig(model, context.Auth().GetAuthTag(), leadershipChecker)
 	}
 	providerGetter := func() (provider.SecretStoreProvider, provider.Model, error) {
 		model, err := context.State().Model()

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -149,7 +149,7 @@ func (s *SecretsManagerSuite) TestCreateSecrets(c *gc.C) {
 
 	p := state.CreateSecretParams{
 		Version: secrets.Version,
-		Owner:   "application-mariadb",
+		Owner:   names.NewApplicationTag("mariadb"),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken:    s.token,
 			RotatePolicy:   ptr(coresecrets.RotateDaily),
@@ -221,7 +221,7 @@ func (s *SecretsManagerSuite) TestCreateSecretDuplicateLabel(c *gc.C) {
 
 	p := state.CreateSecretParams{
 		Version: secrets.Version,
-		Owner:   "application-mariadb",
+		Owner:   names.NewApplicationTag("mariadb"),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken: s.token,
 			Label:       ptr("foobar"),
@@ -408,7 +408,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfo(c *gc.C) {
 
 	s.expectSecretAccessQuery(1)
 	uri := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, "application-mariadb").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, names.NewApplicationTag("mariadb")).Return(
 		&coresecrets.SecretConsumerMetadata{
 			LatestRevision: 666,
 			Label:          "label",
@@ -430,13 +430,17 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfo(c *gc.C) {
 func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 	defer s.setup(c).Finish()
 
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	s.token.EXPECT().Check(0, nil).Return(nil)
+
 	now := time.Now()
 	uri := coresecrets.NewURI()
 	s.secretsBackend.EXPECT().ListSecrets(
 		state.SecretsFilter{
-			OwnerTag: ptr("application-mariadb"),
+			OwnerTags: []names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")},
 		}).Return([]*coresecrets.SecretMetadata{{
 		URI:              uri,
+		OwnerTag:         "application-mariadb",
 		Description:      "description",
 		Label:            "label",
 		RotatePolicy:     coresecrets.RotateHourly,
@@ -456,6 +460,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
 			URI:              uri.String(),
+			OwnerTag:         "application-mariadb",
 			Description:      "description",
 			Label:            "label",
 			RotatePolicy:     coresecrets.RotateHourly.String(),
@@ -479,19 +484,19 @@ func (s *SecretsManagerSuite) TestGetSecretContent(c *gc.C) {
 	data := map[string]string{"foo": "bar"}
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, "unit-mariadb-0").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, names.NewUnitTag("mariadb/0")).Return(
 		&coresecrets.SecretConsumerMetadata{CurrentRevision: 666}, nil)
 
 	// Secret 2 has not been consumed before.
 	data2 := map[string]string{"foo": "bar2"}
 	val2 := coresecrets.NewSecretValue(data2)
 	uri2 := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumer(uri2, "unit-mariadb-0").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumer(uri2, names.NewUnitTag("mariadb/0")).Return(
 		nil, errors.NotFoundf("secret"))
 	s.expectSecretAccessQuery(2)
 	s.secretsBackend.EXPECT().GetSecret(uri2).Return(&coresecrets.SecretMetadata{LatestRevision: 668}, nil)
 	s.secretsConsumer.EXPECT().SaveSecretConsumer(
-		uri2, "unit-mariadb-0", &coresecrets.SecretConsumerMetadata{
+		uri2, names.NewUnitTag("mariadb/0"), &coresecrets.SecretConsumerMetadata{
 			CurrentRevision: 668,
 			LatestRevision:  668,
 		}).Return(nil)
@@ -522,7 +527,7 @@ func (s *SecretsManagerSuite) TestGetSecretContent(c *gc.C) {
 func (s *SecretsManagerSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.secretsConsumer.EXPECT().WatchConsumedSecretsChanges("unit-mariadb-0").Return(
+	s.secretsConsumer.EXPECT().WatchConsumedSecretsChanges(names.NewUnitTag("mariadb/0")).Return(
 		s.secretsWatcher, nil,
 	)
 	s.resources.EXPECT().Register(s.secretsWatcher).Return("1")
@@ -550,11 +555,44 @@ func (s *SecretsManagerSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	})
 }
 
+func (s *SecretsManagerSuite) TestWatchObsolete(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.secretsBackend.EXPECT().WatchObsolete(
+		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
+		s.secretsWatcher, nil,
+	)
+	s.resources.EXPECT().Register(s.secretsWatcher).Return("1")
+
+	uri := coresecrets.NewURI()
+	watchChan := make(chan []string, 1)
+	watchChan <- []string{uri.String()}
+	s.secretsWatcher.EXPECT().Changes().Return(watchChan)
+
+	result, err := s.facade.WatchObsolete(params.Entities{
+		Entities: []params.Entity{{
+			Tag: "unit-mariadb-0",
+		}, {
+			Tag: "application-mariadb",
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.StringsWatchResult{
+		StringsWatcherId: "1",
+		Changes:          []string{uri.String()},
+	})
+}
+
 func (s *SecretsManagerSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.secretTriggers.EXPECT().WatchSecretsRotationChanges("application-mariadb").Return(
-		s.secretsTriggerWatcher,
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.secretTriggers.EXPECT().WatchSecretsRotationChanges(
+		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
+		s.secretsTriggerWatcher, nil,
 	)
 	s.resources.EXPECT().Register(s.secretsTriggerWatcher).Return("1")
 
@@ -569,21 +607,17 @@ func (s *SecretsManagerSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 
 	result, err := s.facade.WatchSecretsRotationChanges(params.Entities{
 		Entities: []params.Entity{{
-			Tag: "application-mariadb",
+			Tag: "unit-mariadb-0",
 		}, {
-			Tag: "application-foo",
+			Tag: "application-mariadb",
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, params.SecretTriggerWatchResults{
-		Results: []params.SecretTriggerWatchResult{{
-			WatcherId: "1",
-			Changes: []params.SecretTriggerChange{{
-				URI:             uri.String(),
-				NextTriggerTime: next,
-			}},
-		}, {
-			Error: &params.Error{Code: "unauthorized access", Message: "permission denied"},
+	c.Assert(result, jc.DeepEquals, params.SecretTriggerWatchResult{
+		WatcherId: "1",
+		Changes: []params.SecretTriggerChange{{
+			URI:             uri.String(),
+			NextTriggerTime: next,
 		}},
 	})
 }
@@ -649,6 +683,35 @@ func (s *SecretsManagerSuite) TestSecretsRotatedRetry(c *gc.C) {
 	})
 }
 
+func (s *SecretsManagerSuite) TestSecretsRotatedForce(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	uri := coresecrets.NewURI()
+	nextRotateTime := s.clock.Now().Add(coresecrets.RotateRetryDelay)
+	s.secretTriggers.EXPECT().SecretRotated(uri, nextRotateTime).Return(errors.New("boom"))
+	s.secretsBackend.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{
+		OwnerTag:         "application-mariadb",
+		RotatePolicy:     coresecrets.RotateHourly,
+		LatestExpireTime: ptr(s.clock.Now().Add(50 * time.Minute)),
+		LatestRevision:   667,
+	}, nil)
+
+	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+		Args: []params.SecretRotatedArg{{
+			URI:              uri.String(),
+			OriginalRevision: 666,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result, jc.DeepEquals, params.ErrorResults{
+		Results: []params.ErrorResult{
+			{
+				Error: &params.Error{Code: "", Message: `boom`},
+			},
+		},
+	})
+}
+
 func (s *SecretsManagerSuite) TestSecretsRotatedThenNever(c *gc.C) {
 	defer s.setup(c).Finish()
 
@@ -674,8 +737,11 @@ func (s *SecretsManagerSuite) TestSecretsRotatedThenNever(c *gc.C) {
 func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.secretTriggers.EXPECT().WatchSecretRevisionsExpiryChanges("application-mariadb").Return(
-		s.secretsTriggerWatcher,
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.secretTriggers.EXPECT().WatchSecretRevisionsExpiryChanges(
+		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
+		s.secretsTriggerWatcher, nil,
 	)
 	s.resources.EXPECT().Register(s.secretsTriggerWatcher).Return("1")
 
@@ -691,22 +757,18 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 
 	result, err := s.facade.WatchSecretRevisionsExpiryChanges(params.Entities{
 		Entities: []params.Entity{{
-			Tag: "application-mariadb",
+			Tag: "unit-mariadb-0",
 		}, {
-			Tag: "application-foo",
+			Tag: "application-mariadb",
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, params.SecretTriggerWatchResults{
-		Results: []params.SecretTriggerWatchResult{{
-			WatcherId: "1",
-			Changes: []params.SecretTriggerChange{{
-				URI:             uri.String(),
-				Revision:        666,
-				NextTriggerTime: next,
-			}},
-		}, {
-			Error: &params.Error{Code: "unauthorized access", Message: "permission denied"},
+	c.Assert(result, jc.DeepEquals, params.SecretTriggerWatchResult{
+		WatcherId: "1",
+		Changes: []params.SecretTriggerChange{{
+			URI:             uri.String(),
+			Revision:        666,
+			NextTriggerTime: next,
 		}},
 	})
 }
@@ -714,7 +776,7 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.expectSecretAccessQuery(2)
+	s.expectSecretAccessQuery(1)
 	uri := coresecrets.NewURI()
 	subjectTag := names.NewUnitTag("wordpress/0")
 	scopeTag := names.NewRelationTag("wordpress:db mysql:server")
@@ -758,7 +820,7 @@ func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 func (s *SecretsManagerSuite) TestSecretsRevoke(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.expectSecretAccessQuery(2)
+	s.expectSecretAccessQuery(1)
 	uri := coresecrets.NewURI()
 	subjectTag := names.NewUnitTag("wordpress/0")
 	scopeTag := names.NewRelationTag("wordpress:db mysql:server")

--- a/apiserver/facades/agent/secretsmanager/state.go
+++ b/apiserver/facades/agent/secretsmanager/state.go
@@ -14,17 +14,16 @@ import (
 
 // SecretTriggers instances provide secret rotation/expiry apis.
 type SecretTriggers interface {
-	WatchSecretsRotationChanges(owner string) state.SecretsTriggerWatcher
-	WatchSecretRevisionsExpiryChanges(owner string) state.SecretsTriggerWatcher
+	WatchSecretsRotationChanges(owners []names.Tag) (state.SecretsTriggerWatcher, error)
+	WatchSecretRevisionsExpiryChanges(owners []names.Tag) (state.SecretsTriggerWatcher, error)
 	SecretRotated(uri *secrets.URI, next time.Time) error
 }
 
 // SecretsConsumer instances provide secret consumer apis.
 type SecretsConsumer interface {
-	GetSecretConsumer(*secrets.URI, string) (*secrets.SecretConsumerMetadata, error)
-	SaveSecretConsumer(*secrets.URI, string, *secrets.SecretConsumerMetadata) error
-	WatchConsumedSecretsChanges(string) (state.StringsWatcher, error)
-	WatchObsolete(string) (state.StringsWatcher, error)
+	GetSecretConsumer(*secrets.URI, names.Tag) (*secrets.SecretConsumerMetadata, error)
+	SaveSecretConsumer(*secrets.URI, names.Tag, *secrets.SecretConsumerMetadata) error
+	WatchConsumedSecretsChanges(consumer names.Tag) (state.StringsWatcher, error)
 	GrantSecretAccess(*secrets.URI, state.SecretAccessParams) error
 	RevokeSecretAccess(*secrets.URI, state.SecretAccessParams) error
 	SecretAccess(uri *secrets.URI, subject names.Tag) (secrets.SecretRole, error)
@@ -33,9 +32,10 @@ type SecretsConsumer interface {
 type SecretsBackend interface {
 	CreateSecret(*secrets.URI, state.CreateSecretParams) (*secrets.SecretMetadata, error)
 	UpdateSecret(*secrets.URI, state.UpdateSecretParams) (*secrets.SecretMetadata, error)
-	DeleteSecret(*secrets.URI, []int) (bool, error)
+	DeleteSecret(*secrets.URI, ...int) (bool, error)
 	GetSecret(*secrets.URI) (*secrets.SecretMetadata, error)
 	GetSecretValue(*secrets.URI, int) (secrets.SecretValue, *string, error)
 	ListSecrets(state.SecretsFilter) ([]*secrets.SecretMetadata, error)
 	ListSecretRevisions(uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error)
+	WatchObsolete(owners []names.Tag) (state.StringsWatcher, error)
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4581,7 +4581,7 @@ func (s *uniterSuite) TestCommitHookChangesWithSecrets(c *gc.C) {
 			LeaderToken: &token{isLeader: true},
 			Data:        map[string]string{"foo2": "bar"},
 		},
-		Owner: s.wordpress.Tag().String(),
+		Owner: s.wordpress.Tag(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.GrantSecretAccess(uri2, state.SecretAccessParams{
@@ -4597,7 +4597,7 @@ func (s *uniterSuite) TestCommitHookChangesWithSecrets(c *gc.C) {
 			LeaderToken: &token{isLeader: true},
 			Data:        map[string]string{"foo3": "bar"},
 		},
-		Owner: s.wordpress.Tag().String(),
+		Owner: s.wordpress.Tag(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.GrantSecretAccess(uri3, state.SecretAccessParams{

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -71,10 +71,17 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			return params.ListSecretResults{}, errors.Trace(err)
 		}
 	}
-	metadata, err := s.backend.ListSecrets(state.SecretsFilter{
-		URI:      uri,
-		OwnerTag: arg.Filter.OwnerTag,
-	})
+	filter := state.SecretsFilter{
+		URI: uri,
+	}
+	if arg.Filter.OwnerTag != nil {
+		tag, err := names.ParseTag(*arg.Filter.OwnerTag)
+		if err != nil {
+			return params.ListSecretResults{}, errors.Trace(err)
+		}
+		filter.OwnerTags = []names.Tag{tag}
+	}
+	metadata, err := s.backend.ListSecrets(filter)
 	if err != nil {
 		return params.ListSecretResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38750,7 +38750,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/StringsWatchResults"
+                            "$ref": "#/definitions/StringsWatchResult"
                         }
                     },
                     "description": "WatchObsolete returns a watcher for notifying when:\n  - a secret owned by the entity is deleted\n  - a secret revision owed by the entity no longer\n    has any consumers\n\nObsolete revisions results are \"uri/revno\" and deleted\nsecret results are \"uri\"."
@@ -38762,7 +38762,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/SecretTriggerWatchResults"
+                            "$ref": "#/definitions/SecretTriggerWatchResult"
                         }
                     },
                     "description": "WatchSecretRevisionsExpiryChanges sets up a watcher to notify of changes to secret revision expiry config."
@@ -38774,7 +38774,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/SecretTriggerWatchResults"
+                            "$ref": "#/definitions/SecretTriggerWatchResult"
                         }
                     },
                     "description": "WatchSecretsRotationChanges sets up a watcher to notify of changes to secret rotation config."
@@ -39338,21 +39338,6 @@
                     "required": [
                         "watcher-id",
                         "changes"
-                    ]
-                },
-                "SecretTriggerWatchResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/SecretTriggerWatchResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
                     ]
                 },
                 "SecretValueResult": {
@@ -45024,7 +45009,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/StringsWatchResults"
+                            "$ref": "#/definitions/StringsWatchResult"
                         }
                     },
                     "description": "WatchObsolete returns a watcher for notifying when:\n  - a secret owned by the entity is deleted\n  - a secret revision owed by the entity no longer\n    has any consumers\n\nObsolete revisions results are \"uri/revno\" and deleted\nsecret results are \"uri\"."
@@ -45048,7 +45033,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/SecretTriggerWatchResults"
+                            "$ref": "#/definitions/SecretTriggerWatchResult"
                         }
                     },
                     "description": "WatchSecretRevisionsExpiryChanges sets up a watcher to notify of changes to secret revision expiry config."
@@ -45060,7 +45045,7 @@
                             "$ref": "#/definitions/Entities"
                         },
                         "Result": {
-                            "$ref": "#/definitions/SecretTriggerWatchResults"
+                            "$ref": "#/definitions/SecretTriggerWatchResult"
                         }
                     },
                     "description": "WatchSecretsRotationChanges sets up a watcher to notify of changes to secret rotation config."
@@ -47415,21 +47400,6 @@
                     "required": [
                         "watcher-id",
                         "changes"
-                    ]
-                },
-                "SecretTriggerWatchResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/SecretTriggerWatchResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
                     ]
                 },
                 "SecretValueResult": {

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -8,7 +8,6 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/testing"
 )
 
@@ -20,7 +19,7 @@ var _ = gc.Suite(&HelpToolSuite{})
 
 func (suite *HelpToolSuite) SetUpTest(c *gc.C) {
 	suite.FakeJujuXDGDataHomeSuite.SetUpTest(c)
-	setFeatureFlags(feature.Secrets)
+	setFeatureFlags("")
 }
 
 func (suite *HelpToolSuite) TestHelpToolHelp(c *gc.C) {
@@ -81,6 +80,13 @@ Currently available charm hook tools are:
     relation-list            list relation units
     relation-set             set relation settings
     resource-get             get the path to the locally cached resource file
+    secret-add               add a new secret
+    secret-get               get the value of a secret
+    secret-grant             grant access to a secret
+    secret-ids               print secret ids
+    secret-remove            remove a existing secret
+    secret-revoke            revoke access to a secret
+    secret-set               update an existing secret
     state-delete             delete server-side-state key value pair
     state-get                print server-side-state value
     state-set                set server-side-state values

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -568,10 +568,8 @@ func registerCommands(r commandRegistry) {
 	r.Register(charmhub.NewDownloadCommand())
 
 	// Secrets.
-	if featureflag.Enabled(feature.Secrets) {
-		r.Register(secrets.NewListSecretsCommand())
-		r.Register(secrets.NewShowSecretsCommand())
-	}
+	r.Register(secrets.NewListSecretsCommand())
+	r.Register(secrets.NewShowSecretsCommand())
 
 	// Payload commands.
 	r.Register(payload.NewListCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/cmd/juju/cloud"
 	"github.com/juju/juju/cmd/modelcmd"
 	jujuos "github.com/juju/juju/core/os"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/testing"
@@ -370,6 +369,7 @@ var commandNames = []string{
 	"list-plans",
 	"list-regions",
 	"list-resources",
+	"list-secrets",
 	"list-spaces",
 	"list-ssh-keys",
 	"list-storage",
@@ -424,6 +424,7 @@ var commandNames = []string{
 	"run",
 	"scale-application",
 	"scp",
+	"secrets",
 	"set-credential",
 	"set-constraints",
 	"set-default-credential",
@@ -444,6 +445,7 @@ var commandNames = []string{
 	"show-model",
 	"show-offer",
 	"show-operation",
+	"show-secret",
 	"show-status",
 	"show-status-log",
 	"show-storage",
@@ -486,9 +488,7 @@ var commandNames = []string{
 }
 
 // optionalFeatures are feature flags that impact registration of commands.
-var optionalFeatures = []string{
-	feature.Secrets,
-}
+var optionalFeatures = []string{}
 
 // These are the commands that are behind the `devFeatures`.
 var commandNamesBehindFlags = set.NewStrings(

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -128,7 +128,11 @@ func (c *listSecretsCommand) Run(ctxt *cmd.Context) error {
 
 	filter := secrets.Filter{}
 	if c.owner != "" {
-		owner := names.NewApplicationTag(c.owner).String()
+		ownerTag, err := names.ParseTag(c.owner)
+		if err != nil {
+			return errors.Maskf(err, "invalid owner %q", c.owner)
+		}
+		owner := ownerTag.String()
 		filter.OwnerTag = &owner
 	}
 	result, err := api.ListSecrets(c.revealSecrets, filter)

--- a/core/watcher/secrets.go
+++ b/core/watcher/secrets.go
@@ -25,7 +25,12 @@ func (s SecretTriggerChange) GoString() string {
 	}
 	whenMsg := "never"
 	if !s.NextTriggerTime.IsZero() {
-		whenMsg = fmt.Sprintf("in %v at %s", s.NextTriggerTime.Sub(time.Now()), s.NextTriggerTime.Format(time.RFC3339))
+		interval := s.NextTriggerTime.Sub(time.Now())
+		if interval < 0 {
+			whenMsg = fmt.Sprintf("%v ago at %s", -interval, s.NextTriggerTime.Format(time.RFC3339))
+		} else {
+			whenMsg = fmt.Sprintf("in %v at %s", interval, s.NextTriggerTime.Format(time.RFC3339))
+		}
 	}
 	return fmt.Sprintf("%s%s trigger: %s", s.URI.ID, revMsg, whenMsg)
 }

--- a/feature/flags.go
+++ b/feature/flags.go
@@ -34,10 +34,7 @@ const Generations = "generations"
 // RawK8sSpec indicates that it's allowed to set k8s spec using raw yaml format.
 const RawK8sSpec = "raw-k8s-spec"
 
-// Secrets enables the secrets feature.
-const Secrets = "secrets"
-
-// SecretStores enables external secrets stores.
+// SecretStores enables automatic use of external secrets stores.
 const SecretStores = "secret-stores"
 
 // RaftAPILeases will switch all lease store management transport, currently

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -191,12 +191,6 @@ type SecretTriggerWatchResult struct {
 	Error     *Error                `json:"error,omitempty"`
 }
 
-// SecretTriggerWatchResults holds the results for any API call which ends up
-// returning a list of SecretTriggerWatchResult.
-type SecretTriggerWatchResults struct {
-	Results []SecretTriggerWatchResult `json:"results"`
-}
-
 // SecretRotatedArgs holds the args for updating rotated secret info.
 type SecretRotatedArgs struct {
 	Args []SecretRotatedArg `json:"args"`

--- a/state/application.go
+++ b/state/application.go
@@ -384,15 +384,12 @@ func (op *DestroyApplicationOperation) eraseHistory() error {
 }
 
 func (op *DestroyApplicationOperation) deleteSecrets() error {
-	store := NewSecrets(op.app.st)
 	ownedURIs, err := op.app.st.referencedSecrets(op.app.Tag(), "owner-tag")
 	if err != nil {
 		return errors.Trace(err)
 	}
-	for _, uri := range ownedURIs {
-		if _, err := store.DeleteSecret(uri, nil); err != nil {
-			return errors.Annotatef(err, "deleting owned secret %q", uri.String())
-		}
+	if _, err := op.app.st.deleteSecrets(ownedURIs); err != nil {
+		return errors.Annotatef(err, "deleting owned secrets for %q", op.app.Name())
 	}
 	return nil
 }

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -3211,7 +3211,7 @@ func (s *ApplicationSuite) TestDestroyAlsoDeletesSecretPermissions(c *gc.C) {
 	uri := secrets.NewURI()
 	cp := state.CreateSecretParams{
 		Version: 1,
-		Owner:   s.mysql.Tag().String(),
+		Owner:   s.mysql.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken: &fakeToken{},
 			Data:        map[string]string{"foo": "bar"},
@@ -3242,7 +3242,7 @@ func (s *ApplicationSuite) TestDestroyAlsoDeletesOwnedSecrets(c *gc.C) {
 	uri := secrets.NewURI()
 	cp := state.CreateSecretParams{
 		Version: 1,
-		Owner:   s.mysql.Tag().String(),
+		Owner:   s.mysql.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken: &fakeToken{},
 			Label:       ptr("label"),
@@ -3254,6 +3254,9 @@ func (s *ApplicationSuite) TestDestroyAlsoDeletesOwnedSecrets(c *gc.C) {
 
 	err = s.mysql.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
+	_, err = store.GetSecret(uri)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
 	// Create again, no label clash.
 	s.AddTestingApplication(c, "mysql", s.charm)
 	_, err = store.CreateSecret(uri, cp)

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -716,7 +716,7 @@ func (s *RelationSuite) TestRemoveAlsoDeletesSecretPermissions(c *gc.C) {
 	uri := secrets.NewURI()
 	cp := state.CreateSecretParams{
 		Version: 1,
-		Owner:   app.Tag().String(),
+		Owner:   app.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken: &fakeToken{},
 			Data:        map[string]string{"foo": "bar"},

--- a/worker/secretexpire/mocks/client_mock.go
+++ b/worker/secretexpire/mocks/client_mock.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	watcher "github.com/juju/juju/core/watcher"
+	names "github.com/juju/names/v4"
 )
 
 // MockSecretManagerFacade is a mock of SecretManagerFacade interface.
@@ -35,16 +36,20 @@ func (m *MockSecretManagerFacade) EXPECT() *MockSecretManagerFacadeMockRecorder 
 }
 
 // WatchSecretRevisionsExpiryChanges mocks base method.
-func (m *MockSecretManagerFacade) WatchSecretRevisionsExpiryChanges(arg0 string) (watcher.SecretTriggerWatcher, error) {
+func (m *MockSecretManagerFacade) WatchSecretRevisionsExpiryChanges(arg0 ...names.Tag) (watcher.SecretTriggerWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchSecretRevisionsExpiryChanges", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WatchSecretRevisionsExpiryChanges", varargs...)
 	ret0, _ := ret[0].(watcher.SecretTriggerWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchSecretRevisionsExpiryChanges indicates an expected call of WatchSecretRevisionsExpiryChanges.
-func (mr *MockSecretManagerFacadeMockRecorder) WatchSecretRevisionsExpiryChanges(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretManagerFacadeMockRecorder) WatchSecretRevisionsExpiryChanges(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretRevisionsExpiryChanges", reflect.TypeOf((*MockSecretManagerFacade)(nil).WatchSecretRevisionsExpiryChanges), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretRevisionsExpiryChanges", reflect.TypeOf((*MockSecretManagerFacade)(nil).WatchSecretRevisionsExpiryChanges), arg0...)
 }

--- a/worker/secretexpire/secretexpire_test.go
+++ b/worker/secretexpire/secretexpire_test.go
@@ -56,7 +56,7 @@ func (s *workerSuite) setup(c *gc.C) *gomock.Controller {
 		Clock:               s.clock,
 		SecretManagerFacade: s.facade,
 		Logger:              loggo.GetLogger("test"),
-		SecretOwner:         names.NewApplicationTag("mariadb"),
+		SecretOwners:        []names.Tag{names.NewApplicationTag("mariadb")},
 		ExpireRevisions:     s.expiredSecrets,
 	}
 	return ctrl
@@ -70,8 +70,8 @@ func (s *workerSuite) TestValidateConfig(c *gc.C) {
 	}, `nil Facade not valid`)
 
 	s.testValidateConfig(c, func(config *secretexpire.Config) {
-		config.SecretOwner = nil
-	}, `nil SecretOwner not valid`)
+		config.SecretOwners = nil
+	}, `empty SecretOwners not valid`)
 
 	s.testValidateConfig(c, func(config *secretexpire.Config) {
 		config.ExpireRevisions = nil
@@ -93,7 +93,7 @@ func (s *workerSuite) testValidateConfig(c *gc.C, f func(*secretexpire.Config), 
 }
 
 func (s *workerSuite) expectWorker() {
-	s.facade.EXPECT().WatchSecretRevisionsExpiryChanges(s.config.SecretOwner.String()).Return(s.triggerWatcher, nil)
+	s.facade.EXPECT().WatchSecretRevisionsExpiryChanges(s.config.SecretOwners).Return(s.triggerWatcher, nil)
 	s.triggerWatcher.EXPECT().Changes().AnyTimes().Return(s.expiryConfigChanges)
 	s.triggerWatcher.EXPECT().Kill().MaxTimes(1)
 	s.triggerWatcher.EXPECT().Wait().Return(nil).MinTimes(1)

--- a/worker/secretrotate/mocks/client_mock.go
+++ b/worker/secretrotate/mocks/client_mock.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	watcher "github.com/juju/juju/core/watcher"
+	names "github.com/juju/names/v4"
 )
 
 // MockSecretManagerFacade is a mock of SecretManagerFacade interface.
@@ -35,16 +36,20 @@ func (m *MockSecretManagerFacade) EXPECT() *MockSecretManagerFacadeMockRecorder 
 }
 
 // WatchSecretsRotationChanges mocks base method.
-func (m *MockSecretManagerFacade) WatchSecretsRotationChanges(arg0 string) (watcher.SecretTriggerWatcher, error) {
+func (m *MockSecretManagerFacade) WatchSecretsRotationChanges(arg0 ...names.Tag) (watcher.SecretTriggerWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchSecretsRotationChanges", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WatchSecretsRotationChanges", varargs...)
 	ret0, _ := ret[0].(watcher.SecretTriggerWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchSecretsRotationChanges indicates an expected call of WatchSecretsRotationChanges.
-func (mr *MockSecretManagerFacadeMockRecorder) WatchSecretsRotationChanges(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretManagerFacadeMockRecorder) WatchSecretsRotationChanges(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretsRotationChanges", reflect.TypeOf((*MockSecretManagerFacade)(nil).WatchSecretsRotationChanges), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretsRotationChanges", reflect.TypeOf((*MockSecretManagerFacade)(nil).WatchSecretsRotationChanges), arg0...)
 }

--- a/worker/secretrotate/secretrotate.go
+++ b/worker/secretrotate/secretrotate.go
@@ -30,7 +30,7 @@ type Logger interface {
 
 // SecretManagerFacade instances provide a watcher for secret rotation changes.
 type SecretManagerFacade interface {
-	WatchSecretsRotationChanges(ownerTag string) (watcher.SecretTriggerWatcher, error)
+	WatchSecretsRotationChanges(ownerTags ...names.Tag) (watcher.SecretTriggerWatcher, error)
 }
 
 // Config defines the operation of the Worker.
@@ -39,7 +39,7 @@ type Config struct {
 	Logger              Logger
 	Clock               clock.Clock
 
-	SecretOwner   names.Tag
+	SecretOwners  []names.Tag
 	RotateSecrets chan<- []string
 }
 
@@ -54,8 +54,8 @@ func (config Config) Validate() error {
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
 	}
-	if config.SecretOwner == nil {
-		return errors.NotValidf("nil SecretOwner")
+	if len(config.SecretOwners) == 0 {
+		return errors.NotValidf("empty SecretOwners")
 	}
 	if config.RotateSecrets == nil {
 		return errors.NotValidf("nil RotateSecretsChannel")
@@ -111,7 +111,7 @@ func (w *Worker) Wait() error {
 }
 
 func (w *Worker) loop() (err error) {
-	changes, err := w.config.SecretManagerFacade.WatchSecretsRotationChanges(w.config.SecretOwner.String())
+	changes, err := w.config.SecretManagerFacade.WatchSecretsRotationChanges(w.config.SecretOwners...)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -138,7 +138,7 @@ func (w *Worker) loop() (err error) {
 }
 
 func (w *Worker) rotate(now time.Time) {
-	w.config.Logger.Debugf("processing secret rotation for %q at %s", w.config.SecretOwner, now)
+	w.config.Logger.Debugf("processing secret rotation for %q at %s", w.config.SecretOwners, now)
 
 	var toRotate []string
 	for id, info := range w.secrets {
@@ -213,7 +213,7 @@ func (w *Worker) computeNextRotateTime() {
 	}
 
 	nextDuration := soonestRotateTime.Sub(now)
-	w.config.Logger.Debugf("next secret for %q will rotate in %v at %s", w.config.SecretOwner, nextDuration, soonestRotateTime)
+	w.config.Logger.Debugf("next secret for %q will rotate in %v at %s", w.config.SecretOwners, nextDuration, soonestRotateTime)
 
 	w.nextTrigger = soonestRotateTime
 	if w.timer == nil {

--- a/worker/secretrotate/secretrotate_test.go
+++ b/worker/secretrotate/secretrotate_test.go
@@ -55,7 +55,7 @@ func (s *workerSuite) setup(c *gc.C) *gomock.Controller {
 		Clock:               s.clock,
 		SecretManagerFacade: s.facade,
 		Logger:              loggo.GetLogger("test"),
-		SecretOwner:         names.NewApplicationTag("mariadb"),
+		SecretOwners:        []names.Tag{names.NewApplicationTag("mariadb")},
 		RotateSecrets:       s.rotatedSecrets,
 	}
 	return ctrl
@@ -69,8 +69,8 @@ func (s *workerSuite) TestValidateConfig(c *gc.C) {
 	}, `nil Facade not valid`)
 
 	s.testValidateConfig(c, func(config *secretrotate.Config) {
-		config.SecretOwner = nil
-	}, `nil SecretOwner not valid`)
+		config.SecretOwners = nil
+	}, `empty SecretOwners not valid`)
 
 	s.testValidateConfig(c, func(config *secretrotate.Config) {
 		config.RotateSecrets = nil
@@ -92,7 +92,7 @@ func (s *workerSuite) testValidateConfig(c *gc.C, f func(*secretrotate.Config), 
 }
 
 func (s *workerSuite) expectWorker() {
-	s.facade.EXPECT().WatchSecretsRotationChanges(s.config.SecretOwner.String()).Return(s.rotateWatcher, nil)
+	s.facade.EXPECT().WatchSecretsRotationChanges(s.config.SecretOwners).Return(s.rotateWatcher, nil)
 	s.rotateWatcher.EXPECT().Changes().AnyTimes().Return(s.rotateConfigChanges)
 	s.rotateWatcher.EXPECT().Kill().MaxTimes(1)
 	s.rotateWatcher.EXPECT().Wait().Return(nil).MinTimes(1)

--- a/worker/uniter/operation/runhook_test.go
+++ b/worker/uniter/operation/runhook_test.go
@@ -931,30 +931,15 @@ func (s *RunHookSuite) TestCommitSuccess_SecretRotate_SetRotated(c *gc.C) {
 	c.Assert(callbacks.rotatedOldRevision, gc.Equals, 666)
 }
 
-func (s *RunHookSuite) TestPrepareHookError_SecretRotate_NotLeader(c *gc.C) {
-	callbacks := &PrepareHookCallbacks{
-		MockPrepareHook: &MockPrepareHook{nil, string(hooks.SecretRotate), nil},
-	}
-	runnerFactory := &MockRunnerFactory{
-		MockNewHookRunner: &MockNewHookRunner{
-			runner: &MockRunner{
-				context: &MockContext{isLeader: false},
-			},
-		},
-	}
-	factory := newOpFactory(runnerFactory, callbacks)
-
-	op, err := factory.NewRunHook(hook.Info{
-		Kind: hooks.SecretRotate, SecretURI: "secret:9m4e2mr0ui3e8a215n4g",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	_, err = op.Prepare(operation.State{})
-	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
+func (s *RunHookSuite) TestPrepareSecretHookError_NotLeader(c *gc.C) {
+	s.assertPrepareSecretHookErrorNotLeader(c, hooks.SecretRotate)
+	s.assertPrepareSecretHookErrorNotLeader(c, hooks.SecretExpired)
+	s.assertPrepareSecretHookErrorNotLeader(c, hooks.SecretRemove)
 }
-func (s *RunHookSuite) TestPrepareHookError_SecretExpired_NotLeader(c *gc.C) {
+
+func (s *RunHookSuite) assertPrepareSecretHookErrorNotLeader(c *gc.C, kind hooks.Kind) {
 	callbacks := &PrepareHookCallbacks{
-		MockPrepareHook: &MockPrepareHook{nil, string(hooks.SecretExpired), nil},
+		MockPrepareHook: &MockPrepareHook{nil, string(kind), nil},
 	}
 	runnerFactory := &MockRunnerFactory{
 		MockNewHookRunner: &MockNewHookRunner{
@@ -966,7 +951,7 @@ func (s *RunHookSuite) TestPrepareHookError_SecretExpired_NotLeader(c *gc.C) {
 	factory := newOpFactory(runnerFactory, callbacks)
 
 	op, err := factory.NewRunHook(hook.Info{
-		Kind: hooks.SecretExpired, SecretURI: "secret:9m4e2mr0ui3e8a215n4g", SecretRevision: 666,
+		Kind: kind, SecretURI: "secret:9m4e2mr0ui3e8a215n4g", SecretRevision: 666,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/operation/util_test.go
+++ b/worker/uniter/operation/util_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/charm/v9/hooks"
 	"github.com/juju/errors"
+	"github.com/juju/names/v4"
 	"github.com/juju/testing"
 	utilexec "github.com/juju/utils/v3/exec"
 
@@ -338,6 +339,7 @@ func (mock *MockContext) SecretMetadata() (map[string]jujuc.SecretMetadata, erro
 		"9m4e2mr0ui3e8a215n4g": {
 			Description:    "description",
 			Label:          "label",
+			Owner:          names.NewApplicationTag("mariadb"),
 			RotatePolicy:   secrets.RotateHourly,
 			LatestRevision: 666,
 		},

--- a/worker/uniter/remotestate/mock_test.go
+++ b/worker/uniter/remotestate/mock_test.go
@@ -422,7 +422,7 @@ type mockSecretsClient struct {
 	secretsWatcher          *mockStringsWatcher
 	secretsRevisionsWatcher *mockStringsWatcher
 	unitName                string
-	appName                 string
+	owners                  []names.Tag
 }
 
 func (m *mockSecretsClient) WatchConsumedSecretsChanges(unitName string) (watcher.StringsWatcher, error) {
@@ -447,7 +447,7 @@ func (m *mockSecretsClient) GetConsumerSecretsRevisionInfo(unitName string, uris
 	return result, nil
 }
 
-func (m *mockSecretsClient) WatchObsolete(appName string) (watcher.StringsWatcher, error) {
-	m.appName = appName
+func (m *mockSecretsClient) WatchObsolete(owners ...names.Tag) (watcher.StringsWatcher, error) {
+	m.owners = owners
 	return m.secretsRevisionsWatcher, nil
 }

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -197,7 +197,7 @@ func (s *WatcherSuite) setupWatcherConfig() remotestate.WatcherConfig {
 		EnforcedCharmModifiedVersion: s.enforcedCharmModifiedVersion,
 		LeadershipTracker:            s.leadership,
 		SecretsClient:                s.secretsClient,
-		SecretRotateWatcherFunc: func(u names.UnitTag, rotateCh chan []string) (worker.Worker, error) {
+		SecretRotateWatcherFunc: func(u names.UnitTag, isLeader bool, rotateCh chan []string) (worker.Worker, error) {
 			select {
 			case s.rotateSecretWatcherEvent <- u.Id():
 			default:
@@ -208,7 +208,7 @@ func (s *WatcherSuite) setupWatcherConfig() remotestate.WatcherConfig {
 			}
 			return s.rotateSecretWatcher, nil
 		},
-		SecretExpiryWatcherFunc: func(u names.UnitTag, expireCh chan []string) (worker.Worker, error) {
+		SecretExpiryWatcherFunc: func(u names.UnitTag, isLeader bool, expireCh chan []string) (worker.Worker, error) {
 			select {
 			case s.expireRevisionWatcherEvent <- u.Id():
 			default:
@@ -321,7 +321,6 @@ func (s *WatcherSuite) signalAll() {
 	s.st.unit.storageWatcher.changes <- []string{}
 	s.applicationWatcher.changes <- struct{}{}
 	s.secretsClient.secretsWatcher.changes <- []string{}
-	s.secretsClient.secretsRevisionsWatcher.changes <- []string{}
 	if s.st.modelType == model.IAAS {
 		s.st.unit.upgradeSeriesWatcher.changes <- struct{}{}
 		s.st.unit.instanceDataWatcher.changes <- struct{}{}

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -416,7 +416,7 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 
 	ctx.portRangeChanges = newPortRangeChangeRecorder(ctx.logger, f.unit.Tag(), machPortRanges)
 	ctx.secretChanges = newSecretsChangeRecorder(ctx.logger)
-	owner := f.unit.ApplicationTag().String()
+	owner := f.unit.Tag().String()
 	info, err := ctx.secretsClient.SecretMetadata(secrets.Filter{
 		OwnerTag: &owner,
 	})
@@ -430,9 +430,14 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 		for rev, id := range v.ProviderIds {
 			providerIds[rev] = id
 		}
+		ownerTag, err := names.ParseTag(md.OwnerTag)
+		if err != nil {
+			return err
+		}
 		ctx.secretMetadata[md.URI.ID] = jujuc.SecretMetadata{
 			Description:      md.Description,
 			Label:            md.Label,
+			Owner:            ownerTag,
 			RotatePolicy:     md.RotatePolicy,
 			LatestRevision:   md.LatestRevision,
 			LatestExpireTime: md.LatestExpireTime,

--- a/worker/uniter/runner/context/flush_test.go
+++ b/worker/uniter/runner/context/flush_test.go
@@ -329,7 +329,7 @@ func (s *FlushContextSuite) TestRunHookUpdatesSecrets(c *gc.C) {
 			LeaderToken: &fakeToken{},
 			Data:        map[string]string{"foo": "bar"},
 		},
-		Owner: s.application.Tag().String(),
+		Owner: s.application.Tag(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
@@ -345,7 +345,7 @@ func (s *FlushContextSuite) TestRunHookUpdatesSecrets(c *gc.C) {
 			LeaderToken: &fakeToken{},
 			Data:        map[string]string{"foo2": "bar"},
 		},
-		Owner: s.application.Tag().String(),
+		Owner: s.application.Tag(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.GrantSecretAccess(uri2, state.SecretAccessParams{
@@ -357,11 +357,11 @@ func (s *FlushContextSuite) TestRunHookUpdatesSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.secretMetadata = map[string]jujuc.SecretMetadata{
-		uri.ID: {Description: "some secret", LatestRevision: 1},
+		uri.ID: {Description: "some secret", LatestRevision: 1, Owner: names.NewApplicationTag("mariadb")},
 	}
 	ctx := s.context(c)
 
-	err = ctx.UpdateSecret(uri, &jujuc.SecretUpsertArgs{
+	err = ctx.UpdateSecret(uri, &jujuc.SecretUpdateArgs{
 		RotatePolicy: ptr(secrets.RotateDaily),
 		Description:  ptr("a secret"),
 		Label:        ptr("foobar"),

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -319,6 +319,7 @@ func (s *HookContextSuite) AssertCoreContext(c *gc.C, ctx *runnercontext.HookCon
 	for id, v := range info {
 		c.Assert(id, gc.Equals, "9m4e2mr0ui3e8a215n4g")
 		c.Assert(v.Label, gc.Equals, "label")
+		c.Assert(v.Owner.String(), gc.Equals, "application-mariadb")
 		c.Assert(v.Description, gc.Equals, "description")
 		c.Assert(v.RotatePolicy, gc.Equals, secrets.RotateHourly)
 		c.Assert(v.LatestRevision, gc.Equals, 666)

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -166,9 +166,17 @@ type ContextUnit interface {
 	CloudSpec() (*params.CloudSpec, error)
 }
 
-// SecretUpsertArgs specifies args used to create or update a secret.
+// SecretCreateArgs specifies args used to create a secret.
+// Nil values are not included in the create.
+type SecretCreateArgs struct {
+	SecretUpdateArgs
+
+	OwnerTag names.Tag
+}
+
+// SecretUpdateArgs specifies args used to update a secret.
 // Nil values are not included in the update.
-type SecretUpsertArgs struct {
+type SecretUpdateArgs struct {
 	// Value is the new secret value or nil to not update.
 	Value secrets.SecretValue
 
@@ -189,6 +197,7 @@ type SecretGrantRevokeArgs struct {
 
 // SecretMetadata holds a secret's metadata.
 type SecretMetadata struct {
+	Owner            names.Tag
 	Description      string
 	Label            string
 	RotatePolicy     secrets.RotatePolicy
@@ -204,10 +213,10 @@ type ContextSecrets interface {
 	GetSecret(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)
 
 	// CreateSecret creates a secret with the specified data.
-	CreateSecret(*SecretUpsertArgs) (*secrets.URI, error)
+	CreateSecret(*SecretCreateArgs) (*secrets.URI, error)
 
 	// UpdateSecret creates a secret with the specified data.
-	UpdateSecret(*secrets.URI, *SecretUpsertArgs) error
+	UpdateSecret(*secrets.URI, *SecretUpdateArgs) error
 
 	// RemoveSecret removes a secret with the specified uri.
 	RemoveSecret(*secrets.URI, *int) error

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -4,6 +4,8 @@
 package jujuctesting
 
 import (
+	"github.com/juju/names/v4"
+
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 )
@@ -22,14 +24,14 @@ func (c *ContextSecrets) GetSecret(uri *secrets.URI, label string, update, peek 
 }
 
 // CreateSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) CreateSecret(args *jujuc.SecretUpsertArgs) (*secrets.URI, error) {
+func (c *ContextSecrets) CreateSecret(args *jujuc.SecretCreateArgs) (*secrets.URI, error) {
 	c.stub.AddCall("CreateSecret", args)
 	uri, _ := secrets.ParseURI("secret:9m4e2mr0ui3e8a215n4g")
 	return uri, nil
 }
 
 // UpdateSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) UpdateSecret(uri *secrets.URI, args *jujuc.SecretUpsertArgs) error {
+func (c *ContextSecrets) UpdateSecret(uri *secrets.URI, args *jujuc.SecretUpdateArgs) error {
 	c.stub.AddCall("UpdateSecret", uri.String(), args)
 	return nil
 }
@@ -47,6 +49,7 @@ func (c *ContextSecrets) SecretMetadata() (map[string]jujuc.SecretMetadata, erro
 		"9m4e2mr0ui3e8a215n4g": {
 			LatestRevision: 666,
 			Label:          "label",
+			Owner:          names.NewApplicationTag("mariadb"),
 			Description:    "description",
 			RotatePolicy:   secrets.RotateHourly,
 		},

--- a/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -175,7 +175,7 @@ func (mr *MockContextMockRecorder) ConfigSettings() *gomock.Call {
 }
 
 // CreateSecret mocks base method.
-func (m *MockContext) CreateSecret(arg0 *jujuc.SecretUpsertArgs) (*secrets.URI, error) {
+func (m *MockContext) CreateSecret(arg0 *jujuc.SecretCreateArgs) (*secrets.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", arg0)
 	ret0, _ := ret[0].(*secrets.URI)
@@ -887,7 +887,7 @@ func (mr *MockContextMockRecorder) UpdateActionResults(arg0, arg1 interface{}) *
 }
 
 // UpdateSecret mocks base method.
-func (m *MockContext) UpdateSecret(arg0 *secrets.URI, arg1 *jujuc.SecretUpsertArgs) error {
+func (m *MockContext) UpdateSecret(arg0 *secrets.URI, arg1 *jujuc.SecretUpdateArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/worker/uniter/runner/jujuc/restricted.go
+++ b/worker/uniter/runner/jujuc/restricted.go
@@ -259,12 +259,12 @@ func (ctx *RestrictedContext) GetSecret(*secrets.URI, string, bool, bool) (secre
 }
 
 // CreateSecret implements runner.Context.
-func (ctx *RestrictedContext) CreateSecret(*SecretUpsertArgs) (*secrets.URI, error) {
+func (ctx *RestrictedContext) CreateSecret(args *SecretCreateArgs) (*secrets.URI, error) {
 	return nil, ErrRestrictedContext
 }
 
 // UpdateSecret implements runner.Context.
-func (ctx *RestrictedContext) UpdateSecret(*secrets.URI, *SecretUpsertArgs) error {
+func (ctx *RestrictedContext) UpdateSecret(*secrets.URI, *SecretUpdateArgs) error {
 	return ErrRestrictedContext
 }
 

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/core/secrets"
 
@@ -20,6 +21,7 @@ type secretUpsertCommand struct {
 	cmd.CommandBase
 	ctx Context
 
+	owner        string
 	rotatePolicy string
 	description  string
 	label        string
@@ -46,13 +48,19 @@ func NewSecretAddCommand(ctx Context) (cmd.Command, error) {
 func (c *secretAddCommand) Info() *cmd.Info {
 	doc := `
 Add a secret with a list of key values.
+
 If a value has the '#base64' suffix, it is already in base64 format and no
 encoding will be performed, otherwise the value will be base64 encoded
 prior to being stored.
 
+By default, a secret is owned by the application, meaning only the unit
+leader can manage it. Use "--owner unit" to create a secret owned by the
+specific unit which created it.
+
 Examples:
     secret-add token=34ae35facd4
     secret-add key#base64 AA==
+    secret-add --owner unit token=s3cret 
     secret-add --rotate monthly token=s3cret 
     secret-add --expire 24h token=s3cret 
     secret-add --expire 2025-01-01T06:06:06 token=s3cret 
@@ -78,6 +86,7 @@ func (c *secretUpsertCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.description, "description", "", "the secret description")
 	f.StringVar(&c.label, "label", "", "a label used to identify the secret in hooks")
 	f.StringVar(&c.fileName, "file", "", "a YAML file containing secret key values")
+	f.StringVar(&c.owner, "owner", "application", "the owner of the secret, either the application or unit")
 }
 
 const rcf3339NoTZ = "2006-01-02T15:04:05"
@@ -104,6 +113,10 @@ func (c *secretUpsertCommand) Init(args []string) error {
 	if c.rotatePolicy != "" && !secrets.RotatePolicy(c.rotatePolicy).IsValid() {
 		return errors.NotValidf("rotate policy %q", c.rotatePolicy)
 	}
+	if c.owner != "application" && c.owner != "unit" {
+		return errors.NotValidf("secret owner %q", c.owner)
+	}
+
 	var err error
 	c.data, err = secrets.CreateSecretData(args)
 	if err != nil || c.fileName == "" {
@@ -119,9 +132,9 @@ func (c *secretUpsertCommand) Init(args []string) error {
 	return nil
 }
 
-func (c *secretUpsertCommand) marshallArg() *SecretUpsertArgs {
+func (c *secretUpsertCommand) marshallArg() *SecretUpdateArgs {
 	value := secrets.NewSecretValue(c.data)
-	arg := &SecretUpsertArgs{
+	arg := &SecretUpdateArgs{
 		Value: value,
 	}
 	if c.rotatePolicy != "" {
@@ -150,7 +163,19 @@ func (c *secretAddCommand) Init(args []string) error {
 
 // Run implements cmd.Command.
 func (c *secretAddCommand) Run(ctx *cmd.Context) error {
-	uri, err := c.ctx.CreateSecret(c.marshallArg())
+	unitName := c.ctx.UnitName()
+	var ownerTag names.Tag
+	appName, _ := names.UnitApplication(unitName)
+	ownerTag = names.NewApplicationTag(appName)
+	if c.owner == "unit" {
+		ownerTag = names.NewUnitTag(unitName)
+	}
+	updateArgs := c.marshallArg()
+	arg := &SecretCreateArgs{
+		SecretUpdateArgs: *updateArgs,
+		OwnerTag:         ownerTag,
+	}
+	uri, err := c.ctx.CreateSecret(arg)
 	if err != nil {
 		return err
 	}

--- a/worker/uniter/runner/jujuc/secret-get.go
+++ b/worker/uniter/runner/jujuc/secret-get.go
@@ -60,8 +60,8 @@ Examples
     secret-get --metadata --label db-password
 `
 	return jujucmd.Info(&cmd.Info{
-		Name:    "secret-get [key[#base64]]",
-		Args:    "<ID>",
+		Name:    "secret-get",
+		Args:    "<ID> [key[#base64]]",
 		Purpose: "get the value of a secret",
 		Doc:     doc,
 	})
@@ -119,6 +119,7 @@ func (c *secretGetCommand) Init(args []string) (err error) {
 type metadataDisplay struct {
 	LatestRevision   int                  `yaml:"revision" json:"revision"`
 	Label            string               `yaml:"label" json:"label"`
+	Owner            string               `yaml:"owner" json:"owner"`
 	Description      string               `yaml:"description,omitempty" json:"description,omitempty"`
 	RotatePolicy     secrets.RotatePolicy `yaml:"rotation,omitempty" json:"rotation,omitempty"`
 	LatestExpireTime *time.Time           `yaml:"expiry,omitempty" json:"expiry,omitempty"`
@@ -158,6 +159,7 @@ func (c *secretGetCommand) Run(ctx *cmd.Context) error {
 			got: {
 				LatestRevision:   md.LatestRevision,
 				Label:            md.Label,
+				Owner:            md.Owner.Kind(),
 				Description:      md.Description,
 				RotatePolicy:     md.RotatePolicy,
 				LatestExpireTime: md.LatestExpireTime,

--- a/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-get_test.go
@@ -186,6 +186,7 @@ func (s *SecretGetSuite) TestSecretGetMetadata(c *gc.C) {
 9m4e2mr0ui3e8a215n4g:
   revision: 666
   label: label
+  owner: application
   description: description
   rotation: hourly
 `[1:])
@@ -205,6 +206,7 @@ func (s *SecretGetSuite) TestSecretGetMetadataByLabel(c *gc.C) {
 9m4e2mr0ui3e8a215n4g:
   revision: 666
   label: label
+  owner: application
   description: description
   rotation: hourly
 `[1:])

--- a/worker/uniter/runner/jujuc/secret-set_test.go
+++ b/worker/uniter/runner/jujuc/secret-set_test.go
@@ -79,7 +79,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 
 	c.Assert(code, gc.Equals, 0)
 	val := coresecrets.NewSecretValue(map[string]string{"data": "c2VjcmV0"})
-	expectedArgs := &jujuc.SecretUpsertArgs{
+	expectedArgs := &jujuc.SecretUpdateArgs{
 		Value:        val,
 		RotatePolicy: ptr(coresecrets.RotateDaily),
 		Description:  ptr("sssshhhh"),
@@ -89,7 +89,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 	call := s.Stub.Calls()[0]
 	c.Assert(call.Args, gc.HasLen, 2)
 	c.Assert(call.Args[0], gc.Equals, "secret:9m4e2mr0ui3e8a215n4g")
-	args, ok := call.Args[1].(*jujuc.SecretUpsertArgs)
+	args, ok := call.Args[1].(*jujuc.SecretUpdateArgs)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(args.ExpireTime, gc.NotNil)
 	c.Assert(args.ExpireTime.After(expectedExpiry), jc.IsTrue)
@@ -107,7 +107,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretBase64(c *gc.C) {
 
 	c.Assert(code, gc.Equals, 0)
 	val := coresecrets.NewSecretValue(map[string]string{"token": "key="})
-	args := &jujuc.SecretUpsertArgs{
+	args := &jujuc.SecretUpdateArgs{
 		Value: val,
 	}
 	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UpdateSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g", args}}})
@@ -122,7 +122,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretRotateInterval(c *gc.C) {
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--rotate", "daily", "secret:9m4e2mr0ui3e8a215n4g"})
 
 	c.Assert(code, gc.Equals, 0)
-	args := &jujuc.SecretUpsertArgs{
+	args := &jujuc.SecretUpdateArgs{
 		Value:        coresecrets.NewSecretValue(nil),
 		RotatePolicy: ptr(coresecrets.RotateDaily),
 	}
@@ -156,7 +156,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretFromFile(c *gc.C) {
 		"key":         "c2VjcmV0",
 		"another-key": `R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLCAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=`,
 	})
-	args := &jujuc.SecretUpsertArgs{
+	args := &jujuc.SecretUpdateArgs{
 		Value: val,
 	}
 	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UpdateSecret", Args: []interface{}{"secret:9m4e2mr0ui3e8a215n4g", args}}})

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -16,12 +16,10 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
-	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/v3/exec"
 
 	jujucmd "github.com/juju/juju/cmd"
-	"github.com/juju/juju/feature"
 	"github.com/juju/juju/juju/sockets"
 )
 
@@ -126,9 +124,7 @@ func allEnabledCommands() map[string]creator {
 	add(leaderCommands)
 	add(resourceCommands)
 	add(payloadCommands)
-	if featureflag.Enabled(feature.Secrets) {
-		add(secretCommands)
-	}
+	add(secretCommands)
 	return all
 }
 

--- a/worker/uniter/runner/jujuc/util_test.go
+++ b/worker/uniter/runner/jujuc/util_test.go
@@ -12,8 +12,6 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/feature"
-
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
 	"github.com/juju/juju/worker/uniter/runner/jujuc/jujuctesting"
@@ -40,7 +38,6 @@ type ContextSuite struct {
 }
 
 func (s *ContextSuite) SetUpTest(c *gc.C) {
-	s.SetInitialFeatureFlags(feature.Secrets)
 	s.ContextSuite.SetUpTest(c)
 	s.BaseSuite.SetUpTest(c)
 }

--- a/worker/uniter/runner/mocks/context_mock.go
+++ b/worker/uniter/runner/mocks/context_mock.go
@@ -192,7 +192,7 @@ func (mr *MockContextMockRecorder) ConfigSettings() *gomock.Call {
 }
 
 // CreateSecret mocks base method.
-func (m *MockContext) CreateSecret(arg0 *jujuc.SecretUpsertArgs) (*secrets.URI, error) {
+func (m *MockContext) CreateSecret(arg0 *jujuc.SecretCreateArgs) (*secrets.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", arg0)
 	ret0, _ := ret[0].(*secrets.URI)
@@ -1013,7 +1013,7 @@ func (mr *MockContextMockRecorder) UpdateActionResults(arg0, arg1 interface{}) *
 }
 
 // UpdateSecret mocks base method.
-func (m *MockContext) UpdateSecret(arg0 *secrets.URI, arg1 *jujuc.SecretUpsertArgs) error {
+func (m *MockContext) UpdateSecret(arg0 *secrets.URI, arg1 *jujuc.SecretUpdateArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/worker/uniter/runner/testing/utils.go
+++ b/worker/uniter/runner/testing/utils.go
@@ -156,6 +156,7 @@ func (s SecretsContextAccessor) SecretMetadata(filter secrets.Filter) ([]secrets
 		Metadata: secrets.SecretMetadata{
 			URI:            uri,
 			LatestRevision: 666,
+			OwnerTag:       "application-mariadb",
 			Description:    "description",
 			RotatePolicy:   secrets.RotateHourly,
 			Label:          "label",

--- a/worker/uniter/secrets/mocks/client_mock.go
+++ b/worker/uniter/secrets/mocks/client_mock.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	secrets "github.com/juju/juju/core/secrets"
 	watcher "github.com/juju/juju/core/watcher"
+	names "github.com/juju/names/v4"
 )
 
 // MockSecretsClient is a mock of SecretsClient interface.
@@ -81,16 +82,20 @@ func (mr *MockSecretsClientMockRecorder) WatchConsumedSecretsChanges(arg0 interf
 }
 
 // WatchObsolete mocks base method.
-func (m *MockSecretsClient) WatchObsolete(arg0 string) (watcher.StringsWatcher, error) {
+func (m *MockSecretsClient) WatchObsolete(arg0 ...names.Tag) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchObsolete", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WatchObsolete", varargs...)
 	ret0, _ := ret[0].(watcher.StringsWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchObsolete indicates an expected call of WatchObsolete.
-func (mr *MockSecretsClientMockRecorder) WatchObsolete(arg0 interface{}) *gomock.Call {
+func (mr *MockSecretsClientMockRecorder) WatchObsolete(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretsClient)(nil).WatchObsolete), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretsClient)(nil).WatchObsolete), arg0...)
 }

--- a/worker/uniter/secrets/resolver.go
+++ b/worker/uniter/secrets/resolver.go
@@ -106,11 +106,6 @@ func (s *secretsResolver) rotateOp(
 		return nil, resolver.ErrNoOperation
 	}
 
-	// Nothing to do if we're no longer the leader.
-	if !remoteState.Leader {
-		return nil, resolver.ErrNoOperation
-	}
-
 	uri := remoteState.SecretRotations[0]
 	op, err := opFactory.NewRunHook(hook.Info{
 		Kind:      hooks.SecretRotate,
@@ -140,11 +135,6 @@ func (s *secretsResolver) expireOp(
 	opFactory operation.Factory,
 ) (operation.Operation, error) {
 	if len(remoteState.ExpiredSecretRevisions) == 0 {
-		return nil, resolver.ErrNoOperation
-	}
-
-	// Nothing to do if we're no longer the leader.
-	if !remoteState.Leader {
 		return nil, resolver.ErrNoOperation
 	}
 

--- a/worker/uniter/secrets/resolver_test.go
+++ b/worker/uniter/secrets/resolver_test.go
@@ -40,8 +40,7 @@ var _ = gc.Suite(&triggerSecretsSuite{})
 
 func (s *triggerSecretsSuite) SetUpTest(_ *gc.C) {
 	s.remoteState = remotestate.Snapshot{
-		Leader: true,
-		Life:   life.Alive,
+		Life: life.Alive,
 	}
 
 	s.rotatedSecret = nil
@@ -79,19 +78,6 @@ func (s *triggerSecretsSuite) TestNextOpNotInstalled(c *gc.C) {
 			Kind: operation.Continue,
 		},
 	}
-	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
-	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
-	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
-}
-
-func (s *triggerSecretsSuite) TestNextOpNotLeader(c *gc.C) {
-	localState := resolver.LocalState{
-		State: operation.State{
-			Kind:      operation.Continue,
-			Installed: true,
-		},
-	}
-	s.remoteState.Leader = false
 	s.remoteState.SecretRotations = []string{"secret:9m4e2mr0ui3e8a215n4g"}
 	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)

--- a/worker/uniter/secrets/secrets.go
+++ b/worker/uniter/secrets/secrets.go
@@ -84,8 +84,7 @@ func (s *Secrets) init() error {
 			s.secretsState.ConsumedSecretInfo = updated
 		}
 	}
-	ownerApp, _ := names.UnitApplication(s.unitTag.Id())
-	owner := names.NewApplicationTag(ownerApp).String()
+	owner := s.unitTag.String()
 	metadata, err := s.client.SecretMetadata(coresecrets.Filter{
 		OwnerTag: &owner,
 	})

--- a/worker/uniter/secrets/secrets_test.go
+++ b/worker/uniter/secrets/secrets_test.go
@@ -59,7 +59,7 @@ func (s *secretsSuite) TestCommitSecretChanged(c *gc.C) {
 		[]string{"secret:666e2mr0ui3e8a215n4g", "secret:9m4e2mr0ui3e8a215n4g"}).Return(
 		map[string]coresecrets.SecretRevisionInfo{"secret:9m4e2mr0ui3e8a215n4g": {Revision: 667}}, nil,
 	)
-	s.secretsClient.EXPECT().SecretMetadata(coresecrets.Filter{OwnerTag: ptr("application-foo")}).Return(nil, nil)
+	s.secretsClient.EXPECT().SecretMetadata(coresecrets.Filter{OwnerTag: ptr("unit-foo-0")}).Return(nil, nil)
 
 	s.stateReadWriter.EXPECT().SetState(params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
@@ -99,7 +99,7 @@ func (s *secretsSuite) TestCommitSecretRemove(c *gc.C) {
 			},
 		},
 	)}, nil)
-	s.secretsClient.EXPECT().SecretMetadata(coresecrets.Filter{OwnerTag: ptr("application-foo")}).Return(
+	s.secretsClient.EXPECT().SecretMetadata(coresecrets.Filter{OwnerTag: ptr("unit-foo-0")}).Return(
 		[]coresecrets.SecretOwnerMetadata{{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "9m4e2mr0ui3e8a215n4g"}}}}, nil)
 	s.stateReadWriter.EXPECT().SetState(params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
@@ -152,7 +152,7 @@ func (s *secretsSuite) TestCommitNoOpSecretsRemoved(c *gc.C) {
 			"secret:9m4e2mr0ui3e8a215n4g": {Revision: 667},
 		}, nil,
 	)
-	s.secretsClient.EXPECT().SecretMetadata(coresecrets.Filter{OwnerTag: ptr("application-foo")}).Return(
+	s.secretsClient.EXPECT().SecretMetadata(coresecrets.Filter{OwnerTag: ptr("unit-foo-0")}).Return(
 		[]coresecrets.SecretOwnerMetadata{
 			{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "9m4e2mr0ui3e8a215n4g"}}},
 			{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "666e2mr0ui3e8a215n4g"}}},

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -595,12 +595,12 @@ func (s startUniter) step(c *gc.C, ctx *testContext) {
 			}
 			return client, nil
 		},
-		SecretRotateWatcherFunc: func(u names.UnitTag, secretsChanged chan []string) (worker.Worker, error) {
+		SecretRotateWatcherFunc: func(u names.UnitTag, isLeader bool, secretsChanged chan []string) (worker.Worker, error) {
 			c.Assert(u.String(), gc.Equals, s.unitTag)
 			ctx.secretsRotateCh = secretsChanged
 			return watchertest.NewMockStringsWatcher(ctx.secretsRotateCh), nil
 		},
-		SecretExpiryWatcherFunc: func(u names.UnitTag, secretsChanged chan []string) (worker.Worker, error) {
+		SecretExpiryWatcherFunc: func(u names.UnitTag, isLeader bool, secretsChanged chan []string) (worker.Worker, error) {
 			c.Assert(u.String(), gc.Equals, s.unitTag)
 			ctx.secretsExpireCh = secretsChanged
 			return watchertest.NewMockStringsWatcher(ctx.secretsExpireCh), nil
@@ -1675,7 +1675,7 @@ func (s createSecret) step(c *gc.C, ctx *testContext) {
 			NextRotateTime: ptr(time.Now().Add(time.Hour)),
 			Data:           map[string]string{"foo": "bar"},
 		},
-		Owner: names.NewApplicationTag(s.applicationName).String(),
+		Owner: names.NewApplicationTag(s.applicationName),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	appTag := names.NewApplicationTag(s.applicationName)


### PR DESCRIPTION
Secrets can now be owned by units as well as applications.

The key changes include:
- the unit agent determines if it needs to watch just its own secrets, or if leader, it also watches for application owned secrets
- api facades adjusted to implement the new query logic (passing in multiple owners, get one watcher back)
- state backend watchers query on multiple owners
- secret-add has a --owner arg
- secret-get displays the owner

When a leadership change occurs, the expiry, rotation, obsolete secret watchers are closed and restarted since what to watch for has changed. ie leader watchers for app secrets as well as its own, non leaders don't.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

deploy charms and create secrets
```sh
juju deploy juju-qa-dummy-source --to 0
Located charm "juju-qa-dummy-source" in charm-hub, revision 6
Deploying "juju-qa-dummy-source" from charm-hub charm "juju-qa-dummy-source", revision 6 in channel stable on jammy
juju deploy juju-qa-dummy-sink --to 0
Located charm "juju-qa-dummy-sink" in charm-hub, revision 7
Deploying "juju-qa-dummy-sink" from charm-hub charm "juju-qa-dummy-sink", revision 7 in channel stable on jammy
juju relate dummy-source dummy-sink
juju exec --unit dummy-source/0 "secret-add foo=bar"
secret:cchr66ccsqejkuq92k70
juju exec --unit dummy-source/0 "secret-grant -r 0 secret:cchr66ccsqejkuq92k70"
juju exec --unit dummy-source/0 "secret-add foo=barunit --owner=unit"
secret:cchr6j4csqejkuq92k7g

juju secrets
ID                    Owner           Rotation  Revision  Last updated
cchr66ccsqejkuq92k70  dummy-source    never            2  9 seconds ago  
cchr6j4csqejkuq92k7g  dummy-source/0  never            1  1 minute ago   
```
update secret expiry times - expiry hooks run
```sh
juju exec --unit dummy-source/0 "secret-update secret:cchr66ccsqejkuq92k70 --expire=2m"
juju exec --unit dummy-source/0 "secret-update secret:cchr6j4csqejkuq92k7g --expire=2m"
...
juju show-status-log dummy-source/0
...
16 Sep 2022 09:23:41+10:00  juju-unit  executing    running secret-expired hook for secret:cchr66ccsqejkuq92k70/1
16 Sep 2022 09:23:41+10:00  juju-unit  executing    running secret-expired hook for secret:cchr6j4csqejkuq92k7g/1
...
```
read the secret so a secret-remove hook can be fired
```sh
juju exec --unit dummy-sink/0 "secret-get secret:cchr66ccsqejkuq92k70"
foo: bar
juju exec --unit dummy-source/0 "secret-update secret:cchr66ccsqejkuq92k70 foo=bar2"
juju exec --unit dummy-sink/0 "secret-get secret:cchr66ccsqejkuq92k70 --update"
foo: bar2

juju show-status-log dummy-source/0
...
16 Sep 2022 09:25:54+10:00  juju-unit  executing  running secret-remove hook for secret:cchr66ccsqejkuq92k70/1
```
add second dummy-source unit as a non-leader
```sh
juju add-unit dummy-source
juju exec --unit dummy-source/1 "secret-add foo1=barunit --owner=unit"
secret:cchr82kcsqejkuq92k80

juju secrets
ID                    Owner           Rotation  Revision  Last updated
cchr66ccsqejkuq92k70  dummy-source    never            2  45 seconds ago  
cchr6j4csqejkuq92k7g  dummy-source/0  never            1  2 minutes ago   
cchr82kcsqejkuq92k80  dummy-source/1  never            1  4 seconds ago   
```

remove the leader unit and ensure hooks for application owned secret fires on the new leader
```sh
juju remove-unit dummy-source/0
removing unit dummy-source/0

juju secrets
ID                    Owner           Rotation  Revision  Last updated
cchr66ccsqejkuq92k70  dummy-source    never            2  4 minutes ago  
cchr82kcsqejkuq92k80  dummy-source/1  never            1  4 minutes ago  

juju show-status-log dummy-source/1
...
16 Sep 2022 09:27:15+10:00  juju-unit  executing    running leader-elected hook
16 Sep 2022 09:27:15+10:00  juju-unit  executing    running secret-expired hook for secret:cchr66ccsqejkuq92k70/1

juju exec --unit dummy-source/1 "secret-update secret:cchr66ccsqejkuq92k70 foo=bar3"
juju exec --unit dummy-sink/0 "secret-get secret:cchr66ccsqejkuq92k70 --update"
foo: bar3

juju show-status-log dummy-source/1
...
16 Sep 2022 09:32:46+10:00  juju-unit  executing  running secret-remove hook for secret:cchr66ccsqejkuq92k70/2
```
new unit also still runs its own secret hooks
```sh
juju exec --unit dummy-source/1 "secret-update secret:cchr82kcsqejkuq92k80 --expire=2m"

juju show-status-log dummy-source/1
...
16 Sep 2022 09:48:12+10:00  juju-unit  executing  running secret-expired hook for secret:cchr82kcsqejkuq92k80/1
```

