### PR TITLE
Rename secret-update to secret-set and fix a flakey test

### DIFF
--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -140,7 +140,7 @@ var expectedCommands = []string{
 	"secret-ids",
 	"secret-remove",
 	"secret-revoke",
-	"secret-update",
+	"secret-set",
 	"state-delete",
 	"state-get",
 	"state-set",

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -1570,11 +1570,20 @@ func (s *SecretsExpiryWatcherSuite) TestWatchRemoveRevision(c *gc.C) {
 	wc := testing.NewSecretsTriggerWatcherC(c, w)
 	defer testing.AssertStop(c, w)
 
+	now := s.Clock.Now().Round(time.Second).UTC()
+	triggerTime := now.Add(time.Minute).Round(time.Second).UTC()
 	_, err := s.store.UpdateSecret(uri, state.UpdateSecretParams{
 		LeaderToken: &fakeToken{},
 		Data:        map[string]string{"foo": "bar2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange(watcher.SecretTriggerChange{
+		URI:             uri,
+		Revision:        1,
+		NextTriggerTime: triggerTime,
+	})
+	wc.AssertNoChange()
+
 	_, err = s.store.DeleteSecret(uri, []int{1})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/uniter/runner/jujuc/secret-remove_test.go
+++ b/worker/uniter/runner/jujuc/secret-remove_test.go
@@ -18,7 +18,7 @@ type SecretRemoveSuite struct {
 
 var _ = gc.Suite(&SecretRemoveSuite{})
 
-func (s *SecretRemoveSuite) TestUpdateSecretInvalidArgs(c *gc.C) {
+func (s *SecretRemoveSuite) TestRemoveSecretInvalidArgs(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
 	for _, t := range []struct {
@@ -33,7 +33,7 @@ func (s *SecretRemoveSuite) TestUpdateSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR secret URI "foo" not valid`,
 		},
 	} {
-		com, err := jujuc.NewCommand(hctx, "secret-update")
+		com, err := jujuc.NewCommand(hctx, "secret-remove")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)

--- a/worker/uniter/runner/jujuc/secret-set.go
+++ b/worker/uniter/runner/jujuc/secret-set.go
@@ -17,8 +17,8 @@ type secretUpdateCommand struct {
 	secretURI *secrets.URI
 }
 
-// NewSecretUpdateCommand returns a command to create a secret.
-func NewSecretUpdateCommand(ctx Context) (cmd.Command, error) {
+// NewSecretSetCommand returns a command to create a secret.
+func NewSecretSetCommand(ctx Context) (cmd.Command, error) {
 	return &secretUpdateCommand{
 		secretUpsertCommand: secretUpsertCommand{ctx: ctx},
 	}, nil
@@ -27,30 +27,30 @@ func NewSecretUpdateCommand(ctx Context) (cmd.Command, error) {
 // Info implements cmd.Command.
 func (c *secretUpdateCommand) Info() *cmd.Info {
 	doc := `
-Update a secret with a list of key values.
+Update a secret with a list of key values, or set new metadata.
 If a value has the '#base64' suffix, it is already in base64 format and no
 encoding will be performed, otherwise the value will be base64 encoded
 prior to being stored.
 To just update selected metadata like rotate policy, do not specify any secret value.
 
 Examples:
-    secret-update secret:9m4e2mr0ui3e8a215n4g token=34ae35facd4
-    secret-update secret:9m4e2mr0ui3e8a215n4g key#base64 AA==
-    secret-update secret:9m4e2mr0ui3e8a215n4g --rotate monthly token=s3cret 
-    secret-update secret:9m4e2mr0ui3e8a215n4g --expire 24h
-    secret-update secret:9m4e2mr0ui3e8a215n4g --expire 24h token=s3cret 
-    secret-update secret:9m4e2mr0ui3e8a215n4g --expire 2025-01-01T06:06:06 token=s3cret 
-    secret-update secret:9m4e2mr0ui3e8a215n4g --label db-password \
+    secret-set secret:9m4e2mr0ui3e8a215n4g token=34ae35facd4
+    secret-set secret:9m4e2mr0ui3e8a215n4g key#base64 AA==
+    secret-set secret:9m4e2mr0ui3e8a215n4g --rotate monthly token=s3cret 
+    secret-set secret:9m4e2mr0ui3e8a215n4g --expire 24h
+    secret-set secret:9m4e2mr0ui3e8a215n4g --expire 24h token=s3cret 
+    secret-set secret:9m4e2mr0ui3e8a215n4g --expire 2025-01-01T06:06:06 token=s3cret 
+    secret-set secret:9m4e2mr0ui3e8a215n4g --label db-password \
         --description "my database password" \
         data#base64 s3cret== 
-    secret-update secret:9m4e2mr0ui3e8a215n4g --label db-password \
+    secret-set secret:9m4e2mr0ui3e8a215n4g --label db-password \
         --description "my database password"
-    secret-update secret:9m4e2mr0ui3e8a215n4g --label db-password \
+    secret-set secret:9m4e2mr0ui3e8a215n4g --label db-password \
         --description "my database password" \
         --file=/path/to/file
 `
 	return jujucmd.Info(&cmd.Info{
-		Name:    "secret-update",
+		Name:    "secret-set",
 		Args:    "<ID> [key[#base64]=value...]",
 		Purpose: "update an existing secret",
 		Doc:     doc,

--- a/worker/uniter/runner/jujuc/secret-set_test.go
+++ b/worker/uniter/runner/jujuc/secret-set_test.go
@@ -53,7 +53,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR expire time or duration "2022-01-01" not valid`,
 		},
 	} {
-		com, err := jujuc.NewCommand(hctx, "secret-update")
+		com, err := jujuc.NewCommand(hctx, "secret-set")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -67,7 +67,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
 	expectedExpiry := time.Now().Add(time.Hour)
-	com, err := jujuc.NewCommand(hctx, "secret-update")
+	com, err := jujuc.NewCommand(hctx, "secret-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
@@ -100,7 +100,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 func (s *SecretUpdateSuite) TestUpdateSecretBase64(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewCommand(hctx, "secret-update")
+	com, err := jujuc.NewCommand(hctx, "secret-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "token#base64=key="})
@@ -116,7 +116,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretBase64(c *gc.C) {
 func (s *SecretUpdateSuite) TestUpdateSecretRotateInterval(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewCommand(hctx, "secret-update")
+	com, err := jujuc.NewCommand(hctx, "secret-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--rotate", "daily", "secret:9m4e2mr0ui3e8a215n4g"})
@@ -145,7 +145,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretFromFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	hctx, _ := s.ContextSuite.NewHookContext()
-	com, err := jujuc.NewCommand(hctx, "secret-update")
+	com, err := jujuc.NewCommand(hctx, "secret-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "token#base64=key=", "--file", fileName})

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -84,7 +84,7 @@ func constructCommandCreator(name string, newCmd functionCmdCreator) creator {
 
 var secretCommands = map[string]creator{
 	"secret-add":    NewSecretAddCommand,
-	"secret-update": NewSecretUpdateCommand,
+	"secret-set":    NewSecretSetCommand,
 	"secret-remove": NewSecretRemoveCommand,
 	"secret-get":    NewSecretGetCommand,
 	"secret-grant":  NewSecretGrantCommand,


### PR DESCRIPTION
`secret-update` is renamed to `secret-set`
And a flakey test is fixed.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju exec --unit controller/0 "secret-add foo=bar"
secret:cchr6j4csqejkuq92k7g
juju exec --unit controller/0 "secret-set secret:cchr6j4csqejkuq92k7g foo=bar2"
```