### PR TITLE
Fix test race in worker/uniter/remotestate

### DIFF
--- a/worker/uniter/remotestate/package_test.go
+++ b/worker/uniter/remotestate/package_test.go
@@ -1,14 +1,23 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package remotestate_test
+package remotestate
 
 import (
 	"testing"
 
+	"github.com/juju/worker/v3"
 	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+func SecretRotateWatcher(w *RemoteStateWatcher) worker.Worker {
+	return w.secretRotateWatcher
+}
+
+func SecretExpiryWatcherFunc(w *RemoteStateWatcher) worker.Worker {
+	return w.secretExpiryWatcher
 }


### PR DESCRIPTION
There's a test race in `worker/uniter/remotestate`. This fixes it.

## QA steps

go test --race