### PR TITLE
[JUJU-1761] Developed the bash-based change-user-password test using the expect tool

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,6 +28,7 @@ jobs:
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
         echo "/snap/bin" >> $GITHUB_PATH
         lxc network set lxdbr0 ipv6.address none
+        sudo apt install expect
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,6 +35,7 @@ jobs:
 
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
         sudo snap install shfmt
+        sudo apt install expect
     
     - name: Download Dependencies
       run: go mod download

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -83,6 +83,10 @@ jobs:
         go-version: ${{ steps.go-version.outputs.version }}
       id: go
 
+    - name: Install Dependencies
+      run: |
+        sudo apt install expect
+
     - name: Schema Check
       run: |
         STATIC_ANALYSIS_JOB=test_schema make static-analysis

--- a/tests/includes/expect-that.sh
+++ b/tests/includes/expect-that.sh
@@ -1,0 +1,32 @@
+# expect_that the ability to work with interactive commands with expect tool.
+# The output is "OK", if tests passes successfully.
+# The expect_script argument is a expect script body.
+# The default timeout is 10 seconds.
+#
+# ```
+# expect_that <command> <expect_script> [<timeout>]
+# ```
+expect_that() {
+	local command expect_script timeout filename
+
+	command=${1}
+	filename=$(echo "${command}" | tr ' ' '-')
+	expect_script=${2}
+	timeout=${3:-10} # default timeout: 10s
+
+	cat >"${TEST_DIR}/${filename}.exp" <<EOF
+#!/usr/bin/expect
+proc abort { } { send_user \"\rTimeout Error!\" ; exit 2 }
+expect_before timeout abort
+
+set timeout ${timeout}
+spawn ${command}
+match_max 100000
+
+${expect_script}
+
+send_user \"OK\"
+expect eof
+EOF
+	expect "${TEST_DIR}/${filename}.exp"
+}

--- a/tests/includes/expect-that.sh
+++ b/tests/includes/expect-that.sh
@@ -2,6 +2,8 @@
 # The output is "OK", if tests passes successfully.
 # The expect_script argument is a expect script body.
 # The default timeout is 10 seconds.
+# NOTE: The expect tool must (!) be install via apt, because strictly-confined expect-snap
+# does not allow to execute scripts in tests folder.
 #
 # ```
 # expect_that <command> <expect_script> [<timeout>]

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -230,7 +230,7 @@ fi
 echo ""
 
 echo "==> Checking for dependencies"
-check_dependencies curl jq yq shellcheck
+check_dependencies curl jq yq shellcheck expect
 
 if [[ ${USER:-'root'} == "root" ]]; then
 	echo "The testsuite must not be run as root." >&2

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -7,7 +7,7 @@
 # expect_that <command> <expect_script> [<timeout>]
 # ```
 expect_that() {
-	local command expect_script timeout, filename
+	local command expect_script timeout filename
 
 	command=${1}
 	filename=$(echo "${command}" | tr ' ' '-')

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -1,0 +1,48 @@
+# ....
+run_user_change_password() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# The following ensures that a bootstrap juju exists.
+	file="${TEST_DIR}/test-user-change-password.log"
+	ensure "user-change-password" "${file}"
+
+	echo "Add test-user"
+	juju add-user test-user
+
+	echo "Change test-user password"
+	expect -c "
+		proc abort { } { send_user \"\rTimeout Error!\" ; exit 2 }
+		expect_before timeout abort
+
+		set timeout 10
+		spawn juju change-user-password test-user
+		match_max 100000
+		expect \"old password: \" {
+			send \"test-password\r\"
+			expect \"\rtype new password again: \" {
+				send \"test-password\r\"
+			}
+		}
+
+		send_user \"passed\"
+		expect eof
+	"
+
+	destroy_model "user-change-password"
+}
+
+test_user_login_password() {
+	if [ -n "$(skip 'test_user_login_password')" ]; then
+		echo "==> SKIP: Asked to skip user login/password tests"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_user_change_password"
+	)
+}

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -1,4 +1,4 @@
-# run_user_change_password changes the admin password, logout and tries to login with new password
+# run_user_change_password changes the 'admin' user password, logout and tries to login with new password
 run_user_change_password() {
 	# Echo out to ensure nice output to the test suite.
 	echo

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -4,7 +4,7 @@
 # The default timeout is 10 seconds.
 #
 # ```
-# wait_for <command> <expect_script>
+# wait_for <command> <expect_script> [<timeout>]
 # ```
 expect_command() {
 	local command expect_script
@@ -12,13 +12,14 @@ expect_command() {
 	command=${1}
 	filename=$(echo "${command}" | tr ' ' '-')
 	expect_script=${2}
+	timeout=${3:-10} # default timeout: 10s
 
-	cat > "${TEST_DIR}/${filename}.exp" <<EOF
+	cat >"${TEST_DIR}/${filename}.exp" <<EOF
 #!/usr/bin/expect
 proc abort { } { send_user \"\rTimeout Error!\" ; exit 2 }
 expect_before timeout abort
 
-set timeout 10
+set timeout ${timeout}
 spawn ${command}
 match_max 100000
 

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -1,12 +1,12 @@
-# expect_command the ability to work with interactive commands with expect tool.
+# expect_that the ability to work with interactive commands with expect tool.
 # The output is "OK", if tests passes successfully.
 # The expect_script argument is a expect script body.
 # The default timeout is 10 seconds.
 #
 # ```
-# wait_for <command> <expect_script> [<timeout>]
+# expect_that <command> <expect_script> [<timeout>]
 # ```
-expect_command() {
+expect_that() {
 	local command expect_script
 
 	command=${1}
@@ -41,7 +41,7 @@ run_user_change_password() {
 	ensure "user-change-password" "${file}"
 
 	echo "Change admin password"
-	expect_command "juju change-user-password" "
+	expect_that "juju change-user-password" "
 expect \"new password: \" {
 	send \"test-password\r\"
 	expect \"type new password again: \" {
@@ -53,13 +53,13 @@ expect \"new password: \" {
 	juju logout
 
 	echo "Login as admin"
-	expect_command "juju login" "
+	expect_that "juju login" "
 expect \"Enter username: \" {
 	send \"admin\r\"
 	expect \"please enter password for admin*\" {
 		send \"test-password\r\"
 	}
-}" | check "OK"
+}" 15 | check "OK"
 
 	destroy_model "user-change-password"
 }

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -7,7 +7,7 @@
 # expect_that <command> <expect_script> [<timeout>]
 # ```
 expect_that() {
-	local command expect_script
+	local command expect_script timeout, filename
 
 	command=${1}
 	filename=$(echo "${command}" | tr ' ' '-')

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -1,4 +1,36 @@
-# ....
+# expect_command the ability to work with interactive commands with expect tool.
+# The output is "OK", if tests passes successfully.
+# The expect_script argument is a expect script body.
+# The default timeout is 10 seconds.
+#
+# ```
+# wait_for <command> <expect_script>
+# ```
+expect_command() {
+	local command expect_script
+
+	command=${1}
+	filename=$(echo "${command}" | tr ' ' '-')
+	expect_script=${2}
+
+	cat > "${TEST_DIR}/${filename}.exp" <<EOF
+#!/usr/bin/expect
+proc abort { } { send_user \"\rTimeout Error!\" ; exit 2 }
+expect_before timeout abort
+
+set timeout 10
+spawn ${command}
+match_max 100000
+
+${expect_script}
+
+send_user \"OK\"
+expect eof
+EOF
+	expect "${TEST_DIR}/${filename}.exp"
+}
+
+# run_user_change_password changes the admin password, logout and tries to login with new password
 run_user_change_password() {
 	# Echo out to ensure nice output to the test suite.
 	echo
@@ -7,27 +39,26 @@ run_user_change_password() {
 	file="${TEST_DIR}/test-user-change-password.log"
 	ensure "user-change-password" "${file}"
 
-	echo "Add test-user"
-	juju add-user test-user
+	echo "Change admin password"
+	expect_command "juju change-user-password" "
+expect \"new password: \" {
+	send \"test-password\r\"
+	expect \"type new password again: \" {
+		send \"test-password\r\"
+	}
+}" | check "OK"
 
-	echo "Change test-user password"
-	expect -c "
-		proc abort { } { send_user \"\rTimeout Error!\" ; exit 2 }
-		expect_before timeout abort
+	echo "Logout from controller"
+	juju logout
 
-		set timeout 10
-		spawn juju change-user-password test-user
-		match_max 100000
-		expect \"old password: \" {
-			send \"test-password\r\"
-			expect \"\rtype new password again: \" {
-				send \"test-password\r\"
-			}
-		}
-
-		send_user \"passed\"
-		expect eof
-	"
+	echo "Login as admin"
+	expect_command "juju login" "
+expect \"Enter username: \" {
+	send \"admin\r\"
+	expect \"please enter password for admin*\" {
+		send \"test-password\r\"
+	}
+}" | check "OK"
 
 	destroy_model "user-change-password"
 }

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -1,36 +1,3 @@
-# expect_that the ability to work with interactive commands with expect tool.
-# The output is "OK", if tests passes successfully.
-# The expect_script argument is a expect script body.
-# The default timeout is 10 seconds.
-#
-# ```
-# expect_that <command> <expect_script> [<timeout>]
-# ```
-expect_that() {
-	local command expect_script timeout filename
-
-	command=${1}
-	filename=$(echo "${command}" | tr ' ' '-')
-	expect_script=${2}
-	timeout=${3:-10} # default timeout: 10s
-
-	cat >"${TEST_DIR}/${filename}.exp" <<EOF
-#!/usr/bin/expect
-proc abort { } { send_user \"\rTimeout Error!\" ; exit 2 }
-expect_before timeout abort
-
-set timeout ${timeout}
-spawn ${command}
-match_max 100000
-
-${expect_script}
-
-send_user \"OK\"
-expect eof
-EOF
-	expect "${TEST_DIR}/${filename}.exp"
-}
-
 # run_user_change_password changes the admin password, logout and tries to login with new password
 run_user_change_password() {
 	# Echo out to ensure nice output to the test suite.

--- a/tests/suites/user/task.sh
+++ b/tests/suites/user/task.sh
@@ -15,6 +15,7 @@ test_user() {
 
 	# Tests that need to be run are added here.
 	test_user_manage
+	test_user_login_password
 
 	destroy_controller "test-user"
 }


### PR DESCRIPTION
This PR adds the change-user-password test, which is an interactive command. This test uses expect tool and generates expect scripts. 

The `expect_that` function is introduced, its implementation inspired by the `wait_for` function. This function can be part of `includes` tools.

PS:
please, use the apt version of the `expect` tool to avoid access problems.
```
sudo apt install expect
```

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p lxd user run_user_change_password
```
