### PR TITLE
[JUJU-1823] Bug 1990182 refresh cs to ch

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -804,6 +804,7 @@ func (s *DeploySuite) TestDeployBundlesRequiringTrust(c *gc.C) {
 	origin := commoncharm.Origin{
 		Source:       commoncharm.OriginCharmStore,
 		Architecture: arch.DefaultArchitecture,
+		OS:           "ubuntu",
 		Series:       "bionic",
 	}
 
@@ -1523,6 +1524,7 @@ func (s *DeploySuite) TestDeployWithTermsNotSigned(c *gc.C) {
 	origin := commoncharm.Origin{
 		Source:       commoncharm.OriginCharmStore,
 		Architecture: arch.DefaultArchitecture,
+		OS:           "ubuntu",
 		Series:       "bionic",
 	}
 	s.fakeAPI.Call("AddCharm", &deployURL, origin, false).Returns(origin, error(termsRequiredError))
@@ -1550,6 +1552,7 @@ func (s *DeploySuite) TestDeployWithChannel(c *gc.C) {
 	originWithSeries := commoncharm.Origin{
 		Source:       commoncharm.OriginCharmStore,
 		Architecture: arch.DefaultArchitecture,
+		OS:           "ubuntu",
 		Series:       "bionic",
 		Risk:         "beta",
 	}
@@ -2201,12 +2204,14 @@ func (s *DeploySuite) TestDeployCharmWithSomeEndpointBindingsSpecifiedSuccess(c 
 			Origin: commoncharm.Origin{
 				Source:       commoncharm.OriginCharmStore,
 				Architecture: arch.DefaultArchitecture,
+				OS:           "ubuntu",
 				Series:       "bionic",
 			},
 		},
 		CharmOrigin: commoncharm.Origin{
 			Source:       commoncharm.OriginCharmStore,
 			Architecture: arch.DefaultArchitecture,
+			OS:           "ubuntu",
 			Series:       "bionic",
 		},
 		ApplicationName: curl.Name,
@@ -2679,8 +2684,10 @@ func (f *fakeDeployAPI) ResolveCharm(url *charm.URL, preferredChannel commonchar
 		return nil, commoncharm.Origin{}, nil, errors.Errorf(
 			"unknown schema for charm URL %q", url)
 	}
+	origin := results[1].(commoncharm.Origin)
+	origin.OS = "ubuntu"
 	return results[0].(*charm.URL),
-		results[1].(commoncharm.Origin),
+		origin,
 		results[2].([]string),
 		jujutesting.TypeAssertError(results[3])
 }
@@ -2698,8 +2705,10 @@ func (f *fakeDeployAPI) ResolveBundleURL(url *charm.URL, preferredChannel common
 		}
 		return nil, commoncharm.Origin{}, errors.NotValidf("charmstore bundle %q", url)
 	}
+	origin := results[1].(commoncharm.Origin)
+	origin.OS = "ubuntu"
 	return results[0].(*charm.URL),
-		results[1].(commoncharm.Origin),
+		origin,
 		jujutesting.TypeAssertError(results[2])
 }
 
@@ -3136,9 +3145,13 @@ func withCharmRepoResolvable(
 				Architecture: arch,
 				Series:       series,
 			}
+			resolvedOrigin := origin
+			if series != "" {
+				origin.OS = "ubuntu"
+			}
 			fakeAPI.Call("ResolveCharm", url, origin, false).Returns(
 				&resultURL,
-				origin,
+				resolvedOrigin,
 				[]string{"bionic"}, // Supported series
 				error(nil),
 			)

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/arch"
 	osseries "github.com/juju/os/v2/series"
 
 	commoncharm "github.com/juju/juju/api/common/charm"
+	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
+	coreseries "github.com/juju/juju/core/series"
 )
 
 // DeduceOrigin attempts to deduce the origin from a channel and a platform.
@@ -27,7 +28,7 @@ func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Plat
 	// Arch is ultimately determined for non-local cases in the API call
 	// to `ResolveCharm`. To ensure we always have an architecture, even if
 	// somehow the DeducePlatform doesn't find one fill one in.
-	// Additionally `ResolveCharm` is not called for local charms, which are
+	// Additionally, `ResolveCharm` is not called for local charms, which are
 	// simply uploaded and deployed. We satisfy the requirement for
 	// non-empty platform architecture by making our best guess here.
 	architecture := platform.Architecture
@@ -35,21 +36,23 @@ func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Plat
 		architecture = arch.DefaultArchitecture
 	}
 
+	var origin commoncharm.Origin
 	switch url.Schema {
 	case "cs":
-		return commoncharm.Origin{
+		origin = commoncharm.Origin{
 			Source:       commoncharm.OriginCharmStore,
 			Risk:         string(channel.Risk),
 			Architecture: architecture,
+			OS:           platform.OS,
 			Series:       platform.Series,
-		}, nil
+		}
 	case "local":
-		return commoncharm.Origin{
+		origin = commoncharm.Origin{
 			Source:       commoncharm.OriginLocal,
 			Architecture: architecture,
 			OS:           platform.OS,
 			Series:       platform.Series,
-		}, nil
+		}
 	default:
 		var track *string
 		if channel.Track != "" {
@@ -63,7 +66,7 @@ func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Plat
 		if url.Revision != -1 {
 			revision = &url.Revision
 		}
-		return commoncharm.Origin{
+		origin = commoncharm.Origin{
 			Source:       commoncharm.OriginCharmHub,
 			Revision:     revision,
 			Risk:         string(channel.Risk),
@@ -72,8 +75,18 @@ func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Plat
 			Architecture: architecture,
 			OS:           platform.OS,
 			Series:       platform.Series,
-		}, nil
+		}
 	}
+
+	// If there is a series, ensure there is an OS.
+	if origin.Series != "" && origin.OS == "" {
+		os, err := coreseries.GetOSFromSeries(origin.Series)
+		if err != nil {
+			return commoncharm.Origin{}, err
+		}
+		origin.OS = strings.ToLower(os.String())
+	}
+	return origin, nil
 }
 
 // DeducePlatform attempts to create a Platform (architecture, os and series)

--- a/cmd/juju/application/utils/origin_test.go
+++ b/cmd/juju/application/utils/origin_test.go
@@ -4,9 +4,11 @@
 package utils_test
 
 import (
+	"github.com/juju/charm/v8"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -79,4 +81,35 @@ func (*originSuite) TestDeducePlatformWithNonUbuntuSeries(c *gc.C) {
 		OS:           "windows",
 		Series:       "win10",
 	})
+}
+
+func (*originSuite) TestDeduceOriginWithSeriesNoOS(c *gc.C) {
+	channel, _ := charm.ParseChannel("stable")
+	platform := corecharm.Platform{
+		Architecture: "amd64",
+		Series:       "focal",
+	}
+	curl := charm.MustParseURL("cs:ubuntu")
+
+	obtainedOrigin, err := utils.DeduceOrigin(curl, channel, platform)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(obtainedOrigin, gc.DeepEquals, commoncharm.Origin{
+		Source:       commoncharm.OriginCharmStore,
+		Risk:         channel.String(),
+		Architecture: "amd64",
+		OS:           "ubuntu",
+		Series:       "focal",
+	})
+}
+
+func (*originSuite) TestDeduceOriginWithSeriesNoOSFail(c *gc.C) {
+	channel, _ := charm.ParseChannel("stable")
+	platform := corecharm.Platform{
+		Architecture: "amd64",
+		Series:       "not-a-series",
+	}
+	curl := charm.MustParseURL("cs:ubuntu")
+
+	_, err := utils.DeduceOrigin(curl, channel, platform)
+	c.Assert(err, gc.ErrorMatches, ".*unknown OS for series.*")
 }

--- a/cmd/juju/application/utils/package_test.go
+++ b/cmd/juju/application/utils/package_test.go
@@ -6,9 +6,9 @@ package utils_test
 import (
 	stdtesting "testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+	gc.TestingT(t)
 }

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -199,7 +199,7 @@ func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, ar
 // validateFixOrigin, validate the origin and maybe fix as follows:
 //
 //	Platform must have an architecture.
-//	Platform can have empty series AND os.
+//	Platform can have both an empty series AND os.
 //	If series defined and os an empty string, add data.
 //	Platform must have series if os defined.
 func (c *CharmHubRepository) validateFixOrigin(origin corecharm.Origin) (corecharm.Origin, error) {

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -68,7 +68,7 @@ func NewCharmHubRepository(logger Logger, chClient CharmHubClient) *CharmHubRepo
 func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, argOrigin corecharm.Origin, macaroons macaroon.Slice) (*charm.URL, corecharm.Origin, []string, error) {
 	c.logger.Tracef("Resolving CharmHub charm %q with origin %v", charmURL, argOrigin)
 
-	requestedOrigin, err := c.validateFixOrigin(argOrigin)
+	requestedOrigin, err := c.validateAndFixOrigin(argOrigin)
 	if err != nil {
 		return nil, corecharm.Origin{}, nil, err
 	}
@@ -196,13 +196,13 @@ func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, ar
 	return resCurl, outputOrigin, supportedSeries, nil
 }
 
-// validateFixOrigin, validate the origin and maybe fix as follows:
+// validateAndFixOrigin, validate the origin and maybe fix as follows:
 //
 //	Platform must have an architecture.
 //	Platform can have both an empty series AND os.
-//	If series defined and os an empty string, add data.
+//	If series defined and OS an empty string, add data.
 //	Platform must have series if os defined.
-func (c *CharmHubRepository) validateFixOrigin(origin corecharm.Origin) (corecharm.Origin, error) {
+func (c *CharmHubRepository) validateAndFixOrigin(origin corecharm.Origin) (corecharm.Origin, error) {
 	p := origin.Platform
 
 	if p.Architecture == "" {

--- a/core/charm/repository/charmhub_test.go
+++ b/core/charm/repository/charmhub_test.go
@@ -136,6 +136,32 @@ func (s *charmHubRepositorySuite) TestResolveWithChannel(c *gc.C) {
 	c.Assert(obtainedSeries, jc.SameContents, []string{"focal"})
 }
 
+func (s *charmHubRepositorySuite) TestResolveWithSeriesNoOS(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectCharmRefreshInstallOneFromChannel(c)
+
+	curl := charm.MustParseURL("ch:wordpress")
+	origin := corecharm.Origin{
+		Source: "charm-hub",
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+			Series:       "focal",
+		},
+	}
+
+	repo := NewCharmHubRepository(s.logger, s.client)
+	obtainedCurl, obtainedOrigin, obtainedSeries, err := repo.ResolveWithPreferredChannel(curl, origin, nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	curl.Revision = 16
+	expected := s.expectedCURL(curl, 16, arch.DefaultArchitecture, "focal")
+
+	c.Assert(obtainedCurl, jc.DeepEquals, expected)
+	c.Assert(obtainedOrigin.Platform.Series, gc.Equals, "focal")
+	c.Assert(obtainedOrigin.Platform.OS, gc.Equals, "ubuntu")
+	c.Assert(obtainedSeries, jc.SameContents, []string{"focal"})
+}
+
 func (s *charmHubRepositorySuite) TestResolveWithoutSeries(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectCharmRefreshInstallOneFromChannel(c)

--- a/core/charm/repository/package_test.go
+++ b/core/charm/repository/package_test.go
@@ -6,7 +6,7 @@ package repository
 import (
 	"testing"
 
-	coretesting "github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/charmhub_client_mock.go github.com/juju/juju/core/charm/repository CharmHubClient
@@ -14,5 +14,5 @@ import (
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/logger_mock.go github.com/juju/juju/core/charm/repository Logger
 
 func TestPackage(t *testing.T) {
-	coretesting.MgoTestPackage(t)
+	gc.TestingT(t)
 }


### PR DESCRIPTION
The charm origin for charmstore charms does not contain an os, but does contain a series. This creates a problem when refreshing an application using the switch flag to go from a charmstore version of the charm to a charmhub version of the charm. The refresh request made to charmhub is containing an Series while missing the OS and fails. 

No upgrade step is necessary due to the validation and fixing done by these changes in this PR. If a series is correct, juju can always determine an OS for it. Do so if DeduceOrigin or ResolveCharm only have a series in the arguments. This is helps protect against bad requests from non juju clients as well when ResolveCharm is called.

Drive by change to not require mongo in testing when it's not used included

## QA steps

```sh
$ juju bootstrap --bootstrap-series bionic localhost 
$ juju deploy cs:aodh-56 csaodh-bionic --series bionic
Located charm "aodh" in charm-store, revision 56
Deploying "csaodh-bionic" from charm-store charm "aodh", revision 56 in channel stable on bionic
$ juju refresh csaodh-bionic --switch ch:aodh --channel latest/stable
Added charm-hub charm "aodh", revision 57 in channel latest/stable, to the model
Leaving endpoints in "alpha": admin, amqp, certificates, cluster, ha, identity-service, internal, mongodb, nrpe-external-master, public, shared-db
```

## Bug reference

This PR fixes part of the bug. To fix the remainer, an `apt update`, `apt upgrade` of the controller machines is required. The `/usr/share/distro-info/ubuntu.csv` file is out of date. Jujud on the controller(s) must be restarted after the file is updated.

https://bugs.launchpad.net/juju/+bug/1990182
