### PR TITLE
Replace `io/ioutil` with `io` and `os` packages

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -583,7 +582,7 @@ func ReadConfig(configFilePath string) (ConfigSetterWriter, error) {
 		format formatter
 		config *configInternal
 	)
-	configData, err := ioutil.ReadFile(configFilePath)
+	configData, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot read agent config %q", configFilePath)
 	}

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -5,7 +5,7 @@ package agentbootstrap_test
 
 import (
 	stdcontext "context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	mgotesting "github.com/juju/mgo/v3/testing"
@@ -74,7 +74,7 @@ LXC_ADDR = "fooo"
 LXC_BRIDGE="foobar" # detected
 anything else ignored
 LXC_BRIDGE="ignored"`[1:])
-	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	err := os.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {

--- a/agent/identity_test.go
+++ b/agent/identity_test.go
@@ -5,7 +5,6 @@
 package agent
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/names/v4"
@@ -54,7 +53,7 @@ func (s *identitySuite) TestWriteSystemIdentityFile(c *gc.C) {
 	err = WriteSystemIdentityFile(conf)
 	c.Assert(err, jc.ErrorIsNil)
 
-	contents, err := ioutil.ReadFile(conf.SystemIdentityPath())
+	contents, err := os.ReadFile(conf.SystemIdentityPath())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(contents), gc.Equals, servingInfo.SystemIdentity)
 

--- a/agent/tools/symlinks_test.go
+++ b/agent/tools/symlinks_test.go
@@ -4,7 +4,6 @@
 package tools_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -53,9 +52,9 @@ func (s *SymlinksSuite) testEnsureSymlinks(c *gc.C, dir string) {
 	// If we have both 'jujuc' and 'jujud' prefer 'jujuc'
 	jujucPath := filepath.Join(s.toolsDir, names.Jujuc)
 	jujudPath := filepath.Join(s.toolsDir, names.Jujud)
-	err := ioutil.WriteFile(jujucPath, []byte("first pick"), 0755)
+	err := os.WriteFile(jujucPath, []byte("first pick"), 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(jujudPath, []byte("assume sane"), 0755)
+	err = os.WriteFile(jujudPath, []byte("assume sane"), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 
 	assertLink := func(path string) time.Time {

--- a/agent/tools/tools_test.go
+++ b/agent/tools/tools_test.go
@@ -6,7 +6,6 @@ package tools_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -162,7 +161,7 @@ func (t *ToolsSuite) TestReadToolsErrors(c *gc.C) {
 	err = os.MkdirAll(dir, agenttools.DirPerm)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = ioutil.WriteFile(filepath.Join(dir, agenttools.ToolsFile), []byte(" \t\n"), 0644)
+	err = os.WriteFile(filepath.Join(dir, agenttools.ToolsFile), []byte(" \t\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	testTools, err = agenttools.ReadTools(t.dataDir, vers)
@@ -248,7 +247,7 @@ func assertFileContents(c *gc.C, dir, file, contents string, mode os.FileMode) {
 	info, err := os.Stat(file)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info.Mode()&(os.ModeType|mode), gc.Equals, mode)
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, contents)
 }

--- a/agent/tools/toolsdir.go
+++ b/agent/tools/toolsdir.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -58,7 +57,7 @@ func UnpackTools(dataDir string, tools *coretools.Tools, r io.Reader) (err error
 		return err
 	}
 	defer zr.Close()
-	f, err := ioutil.TempFile(os.TempDir(), "tools-tar")
+	f, err := os.CreateTemp(os.TempDir(), "tools-tar")
 	if err != nil {
 		return err
 	}
@@ -79,7 +78,7 @@ func UnpackTools(dataDir string, tools *coretools.Tools, r io.Reader) (err error
 	if err != nil {
 		return err
 	}
-	dir, err := ioutil.TempDir(toolsDir, "unpacking-")
+	dir, err := os.MkdirTemp(toolsDir, "unpacking-")
 	if err != nil {
 		return err
 	}
@@ -156,7 +155,7 @@ func writeFile(name string, mode os.FileMode, r io.Reader) error {
 // The tools information is json encoded in a text file, "downloaded-tools.txt".
 func ReadTools(dataDir string, vers version.Binary) (*coretools.Tools, error) {
 	dir := SharedToolsDir(dataDir, vers)
-	toolsData, err := ioutil.ReadFile(path.Join(dir, toolsFile))
+	toolsData, err := os.ReadFile(path.Join(dir, toolsFile))
 	if err != nil {
 		return nil, fmt.Errorf("cannot read agent metadata in directory %v: %v", dir, err)
 	}
@@ -194,5 +193,5 @@ func WriteToolsMetadataData(dir string, tools *coretools.Tools) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path.Join(dir, toolsFile), toolsMetadataData, filePerm)
+	return os.WriteFile(path.Join(dir, toolsFile), toolsMetadataData, filePerm)
 }

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -741,7 +740,7 @@ func gorillaDialWebsocket(ctx context.Context, urlStr string, tlsConfig *tls.Con
 			// is returned so the client can react to auth errors
 			// (for example).
 			defer resp.Body.Close()
-			body, readErr := ioutil.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
 			if readErr == nil {
 				err = errors.Errorf(
 					"%s (%s)",

--- a/api/certpool.go
+++ b/api/certpool.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -64,7 +63,7 @@ func processCertDir(pool *x509.CertPool) (count int) {
 	}
 
 	for _, match := range matches {
-		data, err := ioutil.ReadFile(match)
+		data, err := os.ReadFile(match)
 		if err != nil {
 			logger.Infof("error reading %q: %v", match, err)
 			continue

--- a/api/certpool_test.go
+++ b/api/certpool_test.go
@@ -5,7 +5,7 @@ package api_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -63,7 +63,7 @@ func (s *certPoolSuite) TestCreateCertPoolNotADir(c *gc.C) {
 	certDir := filepath.Join(c.MkDir(), "missing")
 	s.PatchValue(api.CertDir, certDir)
 	// Make the certDir a file instead...
-	c.Assert(ioutil.WriteFile(certDir, []byte("blah"), 0644), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(certDir, []byte("blah"), 0644), jc.ErrorIsNil)
 
 	pool, err := api.CreateCertPool("")
 	c.Assert(err, jc.ErrorIsNil)
@@ -102,7 +102,7 @@ func (s *certPoolSuite) TestCreateCertPoolLoadsOnlyPEMFiles(c *gc.C) {
 	certDir := c.MkDir()
 	s.PatchValue(api.CertDir, certDir)
 	s.addCert(c, filepath.Join(certDir, "first.pem"))
-	c.Assert(ioutil.WriteFile(filepath.Join(certDir, "second.cert"), []byte("blah"), 0644), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(filepath.Join(certDir, "second.cert"), []byte("blah"), 0644), jc.ErrorIsNil)
 
 	pool, err := api.CreateCertPool("")
 	c.Assert(err, jc.ErrorIsNil)
@@ -114,7 +114,7 @@ func (s *certPoolSuite) TestCreateCertPoolLoadsOnlyPEMFiles(c *gc.C) {
 func (s *certPoolSuite) TestCreateCertPoolLogsBadCerts(c *gc.C) {
 	certDir := c.MkDir()
 	s.PatchValue(api.CertDir, certDir)
-	c.Assert(ioutil.WriteFile(filepath.Join(certDir, "broken.pem"), []byte("blah"), 0644), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(filepath.Join(certDir, "broken.pem"), []byte("blah"), 0644), jc.ErrorIsNil)
 
 	pool, err := api.CreateCertPool("")
 	c.Assert(err, jc.ErrorIsNil)
@@ -135,7 +135,7 @@ func (s *certPoolSuite) addCert(c *gc.C, filename string) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filename, []byte(caCertPem), 0644)
+	err = os.WriteFile(filename, []byte(caCertPem), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/api/client/backups/download_test.go
+++ b/api/client/backups/download_test.go
@@ -5,7 +5,7 @@ package backups
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -39,7 +39,7 @@ func (s *downloadSuite) TestDownload(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = rdr.Close() }()
 
-	data, err := ioutil.ReadAll(rdr)
+	data, err := io.ReadAll(rdr)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, "success")
 }

--- a/api/client/charms/client.go
+++ b/api/client/charms/client.go
@@ -6,7 +6,6 @@ package charms
 import (
 	"archive/zip"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -206,7 +205,7 @@ func (c *Client) AddLocalCharm(curl *charm.URL, ch charm.Charm, force bool, agen
 	switch ch := ch.(type) {
 	case *charm.CharmDir:
 		var err error
-		if archive, err = ioutil.TempFile("", "charm"); err != nil {
+		if archive, err = os.CreateTemp("", "charm"); err != nil {
 			return nil, errors.Annotate(err, "cannot create temp file")
 		}
 		defer os.Remove(archive.Name())

--- a/api/client/charms/client_test.go
+++ b/api/client/charms/client_test.go
@@ -6,7 +6,7 @@ package charms_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -336,7 +336,7 @@ func (s *charmsMockSuite) TestListCharmResources(c *gc.C) {
 
 func (s *charmsMockSuite) TestZipHasHooksOnly(c *gc.C) {
 	ch := testcharms.Repo.CharmDir("storage-filesystem-subordinate") // has hooks only
-	tempFile, err := ioutil.TempFile(c.MkDir(), "charm")
+	tempFile, err := os.CreateTemp(c.MkDir(), "charm")
 	c.Assert(err, jc.ErrorIsNil)
 	defer tempFile.Close()
 	defer os.Remove(tempFile.Name())
@@ -350,7 +350,7 @@ func (s *charmsMockSuite) TestZipHasHooksOnly(c *gc.C) {
 
 func (s *charmsMockSuite) TestZipHasDispatchFileOnly(c *gc.C) {
 	ch := testcharms.Repo.CharmDir("category-dispatch") // has dispatch file only
-	tempFile, err := ioutil.TempFile(c.MkDir(), "charm")
+	tempFile, err := os.CreateTemp(c.MkDir(), "charm")
 	c.Assert(err, jc.ErrorIsNil)
 	defer tempFile.Close()
 	defer os.Remove(tempFile.Name())
@@ -364,7 +364,7 @@ func (s *charmsMockSuite) TestZipHasDispatchFileOnly(c *gc.C) {
 
 func (s *charmsMockSuite) TestZipHasNoHooksNorDispath(c *gc.C) {
 	ch := testcharms.Repo.CharmDir("category") // has no hooks nor dispatch file
-	tempFile, err := ioutil.TempFile(c.MkDir(), "charm")
+	tempFile, err := os.CreateTemp(c.MkDir(), "charm")
 	c.Assert(err, jc.ErrorIsNil)
 	defer tempFile.Close()
 	defer os.Remove(tempFile.Name())
@@ -415,7 +415,7 @@ func (s *charmsMockSuite) TestAddLocalCharm(c *gc.C) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-1"}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-1"}`)),
 	}
 	resp.Header.Add("Content-Type", "application/json")
 	mockHttpDoer.EXPECT().Do(
@@ -434,7 +434,7 @@ func (s *charmsMockSuite) TestAddLocalCharm(c *gc.C) {
 	c.Assert(savedURL.String(), gc.Equals, curl.String())
 
 	// Upload a charm directory with changed revision.
-	resp.Body = ioutil.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-42"}`))
+	resp.Body = io.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-42"}`))
 	charmDir := testcharms.Repo.ClonedDir(c.MkDir(), "dummy")
 	err = charmDir.SetDiskRevision(42)
 	c.Assert(err, jc.ErrorIsNil)
@@ -443,7 +443,7 @@ func (s *charmsMockSuite) TestAddLocalCharm(c *gc.C) {
 	c.Assert(savedURL.Revision, gc.Equals, 42)
 
 	// Upload a charm directory again, revision should be bumped.
-	resp.Body = ioutil.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-43"}`))
+	resp.Body = io.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-43"}`))
 	savedURL, err = client.AddLocalCharm(curl, charmDir, false, vers)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.WithRevision(43).String())
@@ -484,7 +484,7 @@ func (s *charmsMockSuite) TestAddLocalCharmWithLXDProfile(c *gc.C) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/lxd-profile-0"}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/lxd-profile-0"}`)),
 	}
 	resp.Header.Add("Content-Type", "application/json")
 	mockHttpDoer.EXPECT().Do(
@@ -548,7 +548,7 @@ func (s *charmsMockSuite) testAddLocalCharmWithForceSucceeds(name string, c *gc.
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/lxd-profile-0"}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/lxd-profile-0"}`)),
 	}
 	resp.Header.Add("Content-Type", "application/json")
 	mockHttpDoer.EXPECT().Do(
@@ -605,7 +605,7 @@ func (s *charmsMockSuite) TestAddLocalCharmDefinitelyWithHooks(c *gc.C) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-1"}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-1"}`)),
 	}
 	resp.Header.Add("Content-Type", "application/json")
 	mockHttpDoer.EXPECT().Do(
@@ -651,7 +651,7 @@ func (s *charmsMockSuite) TestAddLocalCharmError(c *gc.C) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-1"}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-1"}`)),
 	}
 	resp.Header.Add("Content-Type", "application/json")
 	mockHttpDoer.EXPECT().Do(
@@ -717,7 +717,7 @@ func testMinVer(t minverTest, c *gc.C) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-1"}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"charm-url": "local:quantal/dummy-1"}`)),
 	}
 	resp.Header.Add("Content-Type", "application/json")
 	mockHttpDoer.EXPECT().Do(

--- a/api/client/charms/downloader_test.go
+++ b/api/client/charms/downloader_test.go
@@ -5,7 +5,7 @@ package charms_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -45,7 +45,7 @@ func (s *charmDownloaderSuite) TestCharmOpener(c *gc.C) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(strings.NewReader(charmData)),
+		Body:       io.NopCloser(strings.NewReader(charmData)),
 	}
 	resp.Header.Add("Content-Type", "application/json")
 	mockHttpDoer.EXPECT().Do(
@@ -60,7 +60,7 @@ func (s *charmDownloaderSuite) TestCharmOpener(c *gc.C) {
 	defer reader.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(data, jc.DeepEquals, []byte(charmData))
 }

--- a/api/client/client/client_test.go
+++ b/api/client/client/client_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -81,7 +80,7 @@ func (s *clientSuite) TestUploadToolsOtherModel(c *gc.C) {
 				"series":        []string{""},
 			})
 			defer r.Body.Close()
-			obtainedTools, err := ioutil.ReadAll(r.Body)
+			obtainedTools, err := io.ReadAll(r.Body)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(obtainedTools, gc.DeepEquals, expectedTools)
 		},

--- a/api/client/modelupgrader/upgrader_test.go
+++ b/api/client/modelupgrader/upgrader_test.go
@@ -5,7 +5,7 @@ package modelupgrader_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -102,7 +102,7 @@ func (s *UpgradeModelSuite) TestUploadTools(c *gc.C) {
 		Request:    req,
 		StatusCode: http.StatusCreated,
 		Header:     http.Header{},
-		Body:       ioutil.NopCloser(strings.NewReader(`{"tools": [{"version": "2.9.100-ubuntu-amd64"}]}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"tools": [{"version": "2.9.100-ubuntu-amd64"}]}`)),
 	}
 	resp.Header.Set("Content-Type", "application/json")
 

--- a/api/client/resources/client_upload_test.go
+++ b/api/client/resources/client_upload_test.go
@@ -6,7 +6,7 @@ package resources_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -65,13 +65,13 @@ func (m reqMatcher) Matches(x interface{}) bool {
 		return false
 	}
 	obtainedCopy := *obtained
-	obtainedBody, err := ioutil.ReadAll(obtainedCopy.Body)
+	obtainedBody, err := io.ReadAll(obtainedCopy.Body)
 	m.c.Assert(err, jc.ErrorIsNil)
 	obtainedCopy.Body = nil
 	obtainedCopy.GetBody = nil
 
 	reqCopy := *m.req
-	reqBody, err := ioutil.ReadAll(reqCopy.Body)
+	reqBody, err := io.ReadAll(reqCopy.Body)
 	m.c.Assert(err, jc.ErrorIsNil)
 	reqCopy.Body = nil
 	reqCopy.GetBody = nil

--- a/api/controller/migrationmaster/client_test.go
+++ b/api/controller/migrationmaster/client_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -383,7 +382,7 @@ func setupFakeHTTP() (*migrationmaster.Client, *fakeDoer) {
 	doer := &fakeDoer{
 		response: &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(strings.NewReader(resourceContent)),
+			Body:       io.NopCloser(strings.NewReader(resourceContent)),
 		},
 	}
 	caller := &fakeHTTPCaller{
@@ -639,7 +638,7 @@ func (d *fakeDoer) Do(req *http.Request) (*http.Response, error) {
 }
 
 func checkReader(c *gc.C, r io.Reader, expected string) {
-	actual, err := ioutil.ReadAll(r)
+	actual, err := io.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(actual), gc.Equals, expected)
 }

--- a/api/controller/migrationtarget/client_test.go
+++ b/api/controller/migrationtarget/client_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/textproto"
 	"net/url"
@@ -357,7 +357,7 @@ func newFakeDoer(c *gc.C, respBody interface{}) *fakeDoer {
 	c.Assert(err, jc.ErrorIsNil)
 	resp := &http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader(body)),
+		Body:       io.NopCloser(bytes.NewReader(body)),
 	}
 	resp.Header = make(http.Header)
 	resp.Header.Add("Content-Type", "application/json")
@@ -387,7 +387,7 @@ func (d *fakeDoer) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	// ReadAll the body if it's found.
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/api/http/http_test.go
+++ b/api/http/http_test.go
@@ -5,7 +5,7 @@ package http_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -51,7 +51,7 @@ func (s *httpSuite) TestOpenURI(c *gc.C) {
 	resultResp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(strings.NewReader("2.6.6-ubuntu-amd64")),
+		Body:       io.NopCloser(strings.NewReader("2.6.6-ubuntu-amd64")),
 	}
 	resultResp.Header.Add("Content-Type", "application/json")
 	ctx := context.TODO()
@@ -66,7 +66,7 @@ func (s *httpSuite) TestOpenURI(c *gc.C) {
 	defer reader.Close()
 
 	// The fake tools content will be the version number.
-	content, err := ioutil.ReadAll(reader)
+	content, err := io.ReadAll(reader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, "2.6.6-ubuntu-amd64")
 }

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -49,7 +48,7 @@ func WebsocketDialWithErrors(dialer WebsocketDialer, urlStr string, requestHeade
 			// for a true response. While this may work for small bodies, it
 			// isn't guaranteed to work for all messages.
 			defer resp.Body.Close()
-			body, readErr := ioutil.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
 			if readErr != nil {
 				return nil, err
 			}

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net"
 	"net/http"
@@ -1588,7 +1588,7 @@ func (t errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			Request:    req,
 			StatusCode: http.StatusNotFound,
 			Header:     http.Header{"Content-Type": {"application/text"}},
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 		}, nil
 	}
 	return t.fallback.RoundTrip(req)

--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -363,7 +362,7 @@ func (s *apiserverSuite) TestRestartMessage(c *gc.C) {
 func (s *apiserverSuite) getHealth(c *gc.C) (string, int) {
 	uri := s.server.URL + "/health"
 	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	result := string(body)
 	// Ensure that the last value is a carriage return.

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -6,7 +6,6 @@ package apiserver
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/juju/errors"
@@ -77,7 +76,7 @@ func (h *backupHandler) read(req *http.Request, expectedType string) ([]byte, er
 		return nil, errors.Errorf("expected Content-Type %q, got %q", expectedType, ctype)
 	}
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, errors.Annotate(err, "while reading request body")
 	}

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/juju/errors"
@@ -44,7 +44,7 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *backupsSuite) assertErrorResponse(c *gc.C, resp *http.Response, statusCode int, msg string) *params.Error {
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(resp.StatusCode, gc.Equals, statusCode, gc.Commentf("body: %s", body))
@@ -62,7 +62,7 @@ func (s *backupsSuite) TestRequiresAuth(c *gc.C) {
 	defer resp.Body.Close()
 
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusUnauthorized)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(body), gc.Equals, "authentication failed: no credentials provided\n")
 }
@@ -114,7 +114,7 @@ func (s *backupsSuite) sendValidGet(c *gc.C) (resp *http.Response, archiveBytes 
 	c.Assert(err, jc.ErrorIsNil)
 	archiveBytes = archive.Bytes()
 	s.fake.Meta = meta
-	s.fake.Archive = ioutil.NopCloser(archive)
+	s.fake.Archive = io.NopCloser(archive)
 
 	return s.sendHTTPRequest(c, apitesting.HTTPRequestParams{
 		Method:      "GET",
@@ -149,7 +149,7 @@ func (s *backupsSuite) TestBody(c *gc.C) {
 	resp, archiveBytes := s.sendValidGet(c)
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(body, jc.DeepEquals, archiveBytes)
 }

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"os"
@@ -348,7 +347,7 @@ func (h *charmsHandler) processUploadedArchive(path string) error {
 
 	// There is one or more subdirs, so we need extract it to a temp
 	// dir and then read it as a charm dir.
-	tempDir, err := ioutil.TempDir("", "charm-extract")
+	tempDir, err := os.MkdirTemp("", "charm-extract")
 	if err != nil {
 		return errors.Annotate(err, "cannot create temp directory")
 	}
@@ -407,7 +406,7 @@ func (d byDepth) Less(i, j int) bool { return depth(d[i]) < depth(d[j]) }
 // then uploads it to storage, and finally updates the state.
 func RepackageAndUploadCharm(st *state.State, archive *charm.CharmArchive, curl *charm.URL) error {
 	// Create a temp dir to contain the extracted charm dir.
-	tempDir, err := ioutil.TempDir("", "charm-download")
+	tempDir, err := os.MkdirTemp("", "charm-download")
 	if err != nil {
 		return errors.Annotate(err, "cannot create temp directory")
 	}
@@ -579,7 +578,7 @@ func sendBundleContent(
 }
 
 func writeCharmToTempFile(r io.Reader) (string, error) {
-	tempFile, err := ioutil.TempFile("", "charm")
+	tempFile, err := os.CreateTemp("", "charm")
 	if err != nil {
 		return "", errors.Annotate(err, "creating temp file")
 	}

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -329,13 +328,13 @@ func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer reader.Close()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	c.Assert(err, jc.ErrorIsNil)
-	downloadedFile, err := ioutil.TempFile(c.MkDir(), "downloaded")
+	downloadedFile, err := os.CreateTemp(c.MkDir(), "downloaded")
 	c.Assert(err, jc.ErrorIsNil)
 	defer downloadedFile.Close()
 	defer os.Remove(downloadedFile.Name())
-	err = ioutil.WriteFile(downloadedFile.Name(), data, 0644)
+	err = os.WriteFile(downloadedFile.Name(), data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	bundle, err := charm.ReadCharmArchive(downloadedFile.Name())
@@ -643,7 +642,7 @@ func (s *charmsSuite) TestGetCharmIcon(c *gc.C) {
 	// Prepare the tests.
 	svgMimeType := mime.TypeByExtension(".svg")
 	iconPath := filepath.Join(testcharms.Repo.CharmDirPath("mysql"), "icon.svg")
-	icon, err := ioutil.ReadFile(iconPath)
+	icon, err := os.ReadFile(iconPath)
 	c.Assert(err, jc.ErrorIsNil)
 	tests := []struct {
 		about      string
@@ -726,7 +725,7 @@ func (s *charmsSuite) TestGetStarReturnsArchiveBytes(c *gc.C) {
 		testcharms.RepoWithSeries("quantal").ClonedDirPath(c.MkDir(), "dummy"))
 	c.Assert(err, jc.ErrorIsNil)
 	// Create an archive from the charm dir.
-	tempFile, err := ioutil.TempFile(c.MkDir(), "charm")
+	tempFile, err := os.CreateTemp(c.MkDir(), "charm")
 	c.Assert(err, jc.ErrorIsNil)
 	defer tempFile.Close()
 	defer os.Remove(tempFile.Name())
@@ -734,7 +733,7 @@ func (s *charmsSuite) TestGetStarReturnsArchiveBytes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: tempFile.Name()})
 
-	data, err := ioutil.ReadFile(tempFile.Name())
+	data, err := os.ReadFile(tempFile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
 	uri := s.charmsURI("?url=local:quantal/dummy-1&file=*")
@@ -803,7 +802,7 @@ func (s *charmsSuite) TestNoTempFilesLeftBehind(c *gc.C) {
 	apitesting.AssertResponse(c, resp, http.StatusOK, "application/zip")
 
 	// Ensure the tmp directory exists but nothing is in it.
-	files, err := ioutil.ReadDir(filepath.Join(s.config.DataDir, "charm-get-tmp"))
+	files, err := os.ReadDir(filepath.Join(s.config.DataDir, "charm-get-tmp"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(files, gc.HasLen, 0)
 }
@@ -815,7 +814,7 @@ type fileReader struct {
 
 func (r *fileReader) Read(out []byte) (int, error) {
 	if r.r == nil {
-		content, err := ioutil.ReadFile(r.path)
+		content, err := os.ReadFile(r.path)
 		if err != nil {
 			return 0, err
 		}

--- a/apiserver/common/charms.go
+++ b/apiserver/common/charms.go
@@ -6,7 +6,6 @@ package common
 import (
 	"archive/zip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -33,7 +32,7 @@ func ReadCharmFromStorage(store storage.Storage, dataDir, storagePath string) (s
 	}
 	defer reader.Close()
 
-	charmFile, err := ioutil.TempFile(tmpDir, "charm")
+	charmFile, err := os.CreateTemp(tmpDir, "charm")
 	if err != nil {
 		return "", errors.Annotate(err, "cannot create charm archive file")
 	}
@@ -71,7 +70,7 @@ func CharmArchiveEntry(charmPath, entryPath string, wantIcon bool) ([]byte, erro
 			return nil, errors.Annotatef(err, "unable to read file %q", entryPath)
 		}
 		defer contents.Close()
-		return ioutil.ReadAll(contents)
+		return io.ReadAll(contents)
 	}
 	if wantIcon {
 		// An icon was requested but none was found in the archive so

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -112,7 +111,7 @@ type mockResources struct {
 
 func (m *mockResources) OpenResource(applicationID string, name string) (resources.Resource, io.ReadCloser, error) {
 	out, err := json.Marshal(m.resource)
-	return resources.Resource{}, ioutil.NopCloser(bytes.NewBuffer(out)), err
+	return resources.Resource{}, io.NopCloser(bytes.NewBuffer(out)), err
 }
 
 type mockStorageRegistry struct {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"time"
 
@@ -766,7 +765,7 @@ func (a *API) ApplicationOCIResources(args params.Entities) (params.CAASApplicat
 
 func readDockerImageResource(reader io.Reader) (params.DockerImageInfo, error) {
 	var details resources.DockerImageDetails
-	contents, err := ioutil.ReadAll(reader)
+	contents, err := io.ReadAll(reader)
 	if err != nil {
 		return params.DockerImageInfo{}, errors.Trace(err)
 	}

--- a/apiserver/httpcontext/auth_test.go
+++ b/apiserver/httpcontext/auth_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
@@ -81,7 +80,7 @@ func (s *BasicAuthHandlerSuite) TestSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 	defer resp.Body.Close()
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, "hullo!")
 	s.stub.CheckCallNames(c, "Authenticate", "Authorize")
@@ -95,7 +94,7 @@ func (s *BasicAuthHandlerSuite) TestAuthenticationFailure(c *gc.C) {
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusUnauthorized)
 	defer resp.Body.Close()
 
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, "authentication failed: username/password invalid\n")
 	c.Assert(resp.Header.Get("WWW-Authenticate"), gc.Equals, `Basic realm="juju"`)
@@ -109,7 +108,7 @@ func (s *BasicAuthHandlerSuite) TestAuthorizationFailure(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusForbidden)
 	defer resp.Body.Close()
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, "authorization failed: unauthorized access for resource\n")
 	s.stub.CheckCallNames(c, "Authenticate", "Authorize")

--- a/apiserver/httpcontext/model_test.go
+++ b/apiserver/httpcontext/model_test.go
@@ -5,7 +5,6 @@ package httpcontext_test
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
@@ -56,7 +55,7 @@ func (s *ModelHandlersSuite) TestImplied(c *gc.C) {
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 	defer resp.Body.Close()
 
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, coretesting.ModelTag.Id())
 }
@@ -67,7 +66,7 @@ func (s *ModelHandlersSuite) TestQuery(c *gc.C) {
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 	defer resp.Body.Close()
 
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, coretesting.ModelTag.Id())
 }
@@ -78,7 +77,7 @@ func (s *ModelHandlersSuite) TestQueryInvalidModelUUID(c *gc.C) {
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusBadRequest)
 	defer resp.Body.Close()
 
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `invalid model UUID "zing"`+"\n")
 }

--- a/apiserver/introspection_test.go
+++ b/apiserver/introspection_test.go
@@ -4,7 +4,7 @@
 package apiserver_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	jc "github.com/juju/testing/checkers"
@@ -56,7 +56,7 @@ func (s *introspectionSuite) testAccess(c *gc.C, tag, password string) {
 	})
 	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, "gazing")
 }

--- a/apiserver/logsink_test.go
+++ b/apiserver/logsink_test.go
@@ -4,7 +4,7 @@
 package apiserver_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -75,7 +75,7 @@ func (s *logsinkSuite) checkAuthFails(c *gc.C, header http.Header, code int, mes
 	defer resp.Body.Close()
 
 	c.Assert(resp.StatusCode, gc.Equals, code)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(body), gc.Equals, message+"\n")
 }
@@ -158,7 +158,7 @@ func (s *logsinkSuite) TestLogging(c *gc.C) {
 
 	// Check that the logsink log file was populated as expected
 	logPath := filepath.Join(s.config.LogDir, "logsink.log")
-	logContents, err := ioutil.ReadFile(logPath)
+	logContents, err := os.ReadFile(logPath)
 	c.Assert(err, jc.ErrorIsNil)
 	line0 := modelUUID + ": machine-0 2015-06-01 23:02:01 INFO some.where foo.go:42 all is well \n"
 	line1 := modelUUID + ": machine-0 2015-06-01 23:02:02 ERROR else.where bar.go:99 oh noes \n"

--- a/apiserver/logtransfer_test.go
+++ b/apiserver/logtransfer_test.go
@@ -4,7 +4,7 @@
 package apiserver_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -84,7 +84,7 @@ func (s *logtransferSuite) checkAuthFails(c *gc.C, header http.Header, code int,
 	defer resp.Body.Close()
 
 	c.Assert(resp.StatusCode, gc.Equals, code)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(body), gc.Matches, message+"\n")
 }

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -5,7 +5,7 @@ package apiserver_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -96,7 +96,7 @@ func (s *pubsubSuite) checkAuthFails(c *gc.C, header http.Header, code int, mess
 	c.Assert(resp, gc.NotNil)
 	defer resp.Body.Close()
 	c.Check(resp.StatusCode, gc.Equals, code)
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Matches, message+"\n")
 }

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -6,7 +6,7 @@ package apiserver
 import (
 	"crypto/rand"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
@@ -106,7 +106,7 @@ func (h *registerUserHandler) processPost(req *http.Request, st *state.State) (
 		return names.UserTag{}, nil, err
 	}
 
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		return failure(err)
 	}

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -71,7 +71,7 @@ func (s *registrationSuite) TestRegister(c *gc.C) {
 	c.Assert(s.bob.SecretKey(), gc.IsNil)
 
 	var response params.SecretKeyLoginResponse
-	bodyData, err := ioutil.ReadAll(resp.Body)
+	bodyData, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	err = json.Unmarshal(bodyData, &response)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/resources_mig_test.go
+++ b/apiserver/resources_mig_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -160,7 +160,7 @@ func (s *resourcesUploadSuite) TestUpload(c *gc.C) {
 	res, reader, err := rSt.OpenResource(s.appName, "bin")
 	c.Assert(err, jc.ErrorIsNil)
 	defer reader.Close()
-	readContent, err := ioutil.ReadAll(reader)
+	readContent, err := io.ReadAll(reader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(readContent), gc.Equals, content)
 	c.Assert(res.ID, gc.Equals, outResp.ID)

--- a/apiserver/resources_test.go
+++ b/apiserver/resources_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -230,7 +229,7 @@ func checkHTTPResp(c *gc.C, recorder *httptest.ResponseRecorder, status int, cty
 	c.Check(hdr.Get("Content-Type"), gc.Equals, ctype)
 	c.Check(hdr.Get("Content-Length"), gc.Equals, strconv.Itoa(len(body)))
 
-	actualBody, err := ioutil.ReadAll(recorder.Body)
+	actualBody, err := io.ReadAll(recorder.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(actualBody), gc.Equals, body)
 }
@@ -248,7 +247,7 @@ const resourceBody = "body"
 func (s *fakeBackend) OpenResource(application, name string) (resources.Resource, io.ReadCloser, error) {
 	res := resources.Resource{}
 	res.Size = int64(len(resourceBody))
-	reader := ioutil.NopCloser(strings.NewReader(resourceBody))
+	reader := io.NopCloser(strings.NewReader(resourceBody))
 	return res, reader, nil
 }
 

--- a/apiserver/rest_test.go
+++ b/apiserver/rest_test.go
@@ -6,7 +6,6 @@ package apiserver_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -175,7 +174,7 @@ func (s *restSuite) TestGetRemoteApplicationIcon(c *gc.C) {
 	// Prepare the tests.
 	svgMimeType := mime.TypeByExtension(".svg")
 	iconPath := filepath.Join(testcharms.Repo.CharmDirPath("mysql"), "icon.svg")
-	icon, err := ioutil.ReadFile(iconPath)
+	icon, err := os.ReadFile(iconPath)
 	c.Assert(err, jc.ErrorIsNil)
 	tests := []struct {
 		about      string

--- a/apiserver/testing/http.go
+++ b/apiserver/testing/http.go
@@ -5,7 +5,6 @@ package testing
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	jujuhttp "github.com/juju/http/v2"
@@ -98,7 +97,7 @@ func SendHTTPRequest(c *gc.C, p HTTPRequestParams) *http.Response {
 }
 
 func AssertResponse(c *gc.C, resp *http.Response, expHTTPStatus int, expContentType string) []byte {
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(resp.StatusCode, gc.Equals, expHTTPStatus, gc.Commentf("body: %s", body))

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -308,7 +307,7 @@ func (h *toolsDownloadHandler) fetchAndCacheTools(
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		msg := fmt.Sprintf("bad HTTP response: %v", resp.Status)
-		if body, err := ioutil.ReadAll(resp.Body); err == nil {
+		if body, err := io.ReadAll(resp.Body); err == nil {
 			msg += fmt.Sprintf(" (%s)", bytes.TrimSpace(body))
 		}
 		return errors.New(msg)
@@ -453,7 +452,7 @@ func (c *cleanupCloser) Close() error {
 }
 
 func tmpCacheAndHash(r io.Reader) (data io.ReadCloser, sha256hex string, size int64, err error) {
-	tmpFile, err := ioutil.TempFile("", "jujutools*")
+	tmpFile, err := os.CreateTemp("", "jujutools*")
 	tmpFilename := tmpFile.Name()
 	cleanup := func() {
 		_ = tmpFile.Close()

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -9,9 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -123,7 +123,7 @@ func (s *baseToolsSuite) getToolsFromStorage(c *gc.C, st *state.State, vers stri
 	defer storage.Close()
 	metadata, r, err := storage.Open(vers)
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	r.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	return metadata, data
@@ -141,7 +141,7 @@ func (s *baseToolsSuite) getToolsMetadataFromStorage(c *gc.C, st *state.State) [
 func (s *baseToolsSuite) testDownload(c *gc.C, tools *coretools.Tools, uuid string) []byte {
 	resp := s.downloadRequest(c, tools.Version, uuid)
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.HasLen, int(tools.Size))
 
@@ -230,7 +230,7 @@ func (s *toolsSuite) setupToolsForUpload(c *gc.C) (coretools.List, version.Binar
 	versionStrings := []string{vers.String()}
 	expectedTools := toolstesting.MakeToolsWithCheckSum(c, localStorage, "released", versionStrings)
 	toolsFile := envtools.StorageName(vers, "released")
-	toolsContent, err := ioutil.ReadFile(filepath.Join(localStorage, toolsFile))
+	toolsContent, err := os.ReadFile(filepath.Join(localStorage, toolsFile))
 	c.Assert(err, jc.ErrorIsNil)
 	return expectedTools, vers, toolsContent
 }
@@ -422,7 +422,7 @@ func (s *toolsSuite) TestUploadConvertsSeries(c *gc.C) {
 	defer storage.Close()
 	_, r, err := storage.Open(v.String())
 	c.Assert(err, jc.ErrorIsNil)
-	uploadedData, err := ioutil.ReadAll(r)
+	uploadedData, err := io.ReadAll(r)
 	r.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(uploadedData, gc.DeepEquals, toolsContent)

--- a/caas/kubernetes/clientconfig/k8s.go
+++ b/caas/kubernetes/clientconfig/k8s.go
@@ -6,7 +6,7 @@ package clientconfig
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/errors"
@@ -52,7 +52,7 @@ func GetLocalKubeConfig() (*clientcmdapi.Config, error) {
 // reader, otherwise defaulting over to the default Kubernetes config loading
 func configFromPossibleReader(reader io.Reader) (*clientcmdapi.Config, error) {
 	if reader != nil {
-		contents, err := ioutil.ReadAll(reader)
+		contents, err := io.ReadAll(reader)
 		if err != nil {
 			return nil, errors.Annotate(err, "failed to read Kubernetes config")
 		}
@@ -170,7 +170,7 @@ func cloudsFromConfig(config *clientcmdapi.Config, cloudName string) (map[string
 
 		k8sCAData := cluster.CertificateAuthorityData
 		if len(cluster.CertificateAuthorityData) == 0 && cluster.CertificateAuthority != "" {
-			caData, err := ioutil.ReadFile(cluster.CertificateAuthority)
+			caData, err := os.ReadFile(cluster.CertificateAuthority)
 			if err != nil {
 				return CloudConfig{}, errors.Trace(err)
 			}

--- a/caas/kubernetes/clientconfig/k8s_test.go
+++ b/caas/kubernetes/clientconfig/k8s_test.go
@@ -4,7 +4,6 @@
 package clientconfig_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -175,7 +174,7 @@ func (s *k8sConfigSuite) SetUpTest(c *gc.C) {
 // The caller must close and remove the returned file.
 func (s *k8sConfigSuite) writeTempKubeConfig(c *gc.C, filename string, data string) (*os.File, error) {
 	fullpath := filepath.Join(s.dir, filename)
-	err := ioutil.WriteFile(fullpath, []byte(data), 0644)
+	err := os.WriteFile(fullpath, []byte(data), 0644)
 	if err != nil {
 		c.Fatal(err.Error())
 	}
@@ -365,7 +364,7 @@ func (s *k8sConfigSuite) TestGetMultiConfig(c *gc.C) {
 }
 
 func (s *k8sConfigSuite) TestConfigWithExternalCA(c *gc.C) {
-	caFile, err := ioutil.TempFile("", "*")
+	caFile, err := os.CreateTemp("", "*")
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = caFile.WriteString("QQ==")
 	c.Assert(err, jc.ErrorIsNil)
@@ -442,7 +441,7 @@ func (s *k8sConfigSuite) TestGetSingleConfigReadsFilePaths(c *gc.C) {
 	tempdir := c.MkDir()
 	divert := func(name string, data *[]byte, path *string) {
 		*path = filepath.Join(tempdir, name)
-		err := ioutil.WriteFile(*path, *data, 0644)
+		err := os.WriteFile(*path, *data, 0644)
 		c.Assert(err, jc.ErrorIsNil)
 		*data = nil
 	}

--- a/caas/kubernetes/cloud/cloud.go
+++ b/caas/kubernetes/cloud/cloud.go
@@ -5,7 +5,6 @@ package cloud
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/juju/errors"
 	"k8s.io/client-go/tools/clientcmd"
@@ -44,7 +43,7 @@ func buildCloudFromCluster(c *cloud.Cloud, cluster *clientcmdapi.Cluster) error 
 // ConfigFromReader does the heavy lifting of transforming a reader object into
 // a kubernetes api config
 func ConfigFromReader(reader io.Reader) (*clientcmdapi.Config, error) {
-	confBytes, err := ioutil.ReadAll(reader)
+	confBytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, errors.Annotate(err, "reading kubernetes configuration data")
 	}

--- a/caas/kubernetes/cloud/credential_test.go
+++ b/caas/kubernetes/cloud/credential_test.go
@@ -4,7 +4,7 @@
 package cloud_test
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -49,7 +49,7 @@ func (s *credentialSuite) TestValidCredentials(c *gc.C) {
 			},
 			Name: "client-cert-data-from-file",
 			PreSetup: func(a *clientcmdapi.AuthInfo) error {
-				certFile, err := ioutil.TempFile("", "")
+				certFile, err := os.CreateTemp("", "")
 				if err != nil {
 					return err
 				}
@@ -57,7 +57,7 @@ func (s *credentialSuite) TestValidCredentials(c *gc.C) {
 				if err != nil {
 					return err
 				}
-				certKeyFile, err := ioutil.TempFile("", "")
+				certKeyFile, err := os.CreateTemp("", "")
 				if err != nil {
 					return err
 				}
@@ -91,7 +91,7 @@ func (s *credentialSuite) TestValidCredentials(c *gc.C) {
 			},
 			Name: "token-from-file",
 			PreSetup: func(a *clientcmdapi.AuthInfo) error {
-				tokenFile, err := ioutil.TempFile("", "")
+				tokenFile, err := os.CreateTemp("", "")
 				if err != nil {
 					return err
 				}

--- a/caas/kubernetes/cloud/util.go
+++ b/caas/kubernetes/cloud/util.go
@@ -4,7 +4,7 @@
 package cloud
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/juju/errors"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -19,7 +19,7 @@ func dataOrFile(data []byte, fileName string) ([]byte, error) {
 	} else if fileName == "" {
 		return []byte{}, nil
 	}
-	return ioutil.ReadFile(fileName)
+	return os.ReadFile(fileName)
 }
 
 // PickCOntextByClusterName finds the first available context in the supplied
@@ -46,6 +46,6 @@ func stringOrFile(data string, fileName string) (string, error) {
 	} else if fileName == "" {
 		return "", nil
 	}
-	d, err := ioutil.ReadFile(fileName)
+	d, err := os.ReadFile(fileName)
 	return string(d), err
 }

--- a/caas/kubernetes/cloud/util_test.go
+++ b/caas/kubernetes/cloud/util_test.go
@@ -4,7 +4,7 @@
 package cloud
 
 import (
-	"io/ioutil"
+	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -40,7 +40,7 @@ func (u *utilSuite) TestDataOrFile(c *gc.C) {
 	for _, test := range tests {
 		fileName := ""
 		if len(test.fileContents) > 0 {
-			f, err := ioutil.TempFile("", "")
+			f, err := os.CreateTemp("", "")
 			fileName = f.Name()
 			c.Assert(err, jc.ErrorIsNil)
 			n, err := f.Write(test.fileContents)
@@ -76,7 +76,7 @@ func (u *utilSuite) TestStringOrFile(c *gc.C) {
 	for _, test := range tests {
 		fileName := ""
 		if test.fileContents != "" {
-			f, err := ioutil.TempFile("", "")
+			f, err := os.CreateTemp("", "")
 			fileName = f.Name()
 			c.Assert(err, jc.ErrorIsNil)
 			n, err := f.Write([]byte(test.fileContents))

--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -6,7 +6,6 @@ package provider
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -114,7 +113,7 @@ func getLocalMicroK8sConfig(cmdRunner CommandRunner, getKubeConfigDir func() (st
 		return nil, errors.Trace(err)
 	}
 	logger.Tracef("reading kubeconfig %q", clientConfigPath)
-	content, err := ioutil.ReadFile(clientConfigPath)
+	content, err := os.ReadFile(clientConfigPath)
 	if os.IsNotExist(err) {
 		return nil, errors.Annotatef(notSupportErr, "%q does not exist", clientConfigPath)
 	}

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -5,7 +5,6 @@ package provider_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -122,7 +121,7 @@ func (s *builtinSuite) prepareKubeConfigFile(c *gc.C, content string) string {
 	fileDir := filepath.Join(dir, "microk8s", "credentials")
 	os.MkdirAll(fileDir, os.ModePerm)
 	path := filepath.Join(fileDir, "client.config")
-	err := ioutil.WriteFile(path, []byte(content), 0660)
+	err := os.WriteFile(path, []byte(content), 0660)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -4,7 +4,6 @@
 package provider_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/errors"
@@ -114,7 +113,7 @@ users:
     password: test
 `
 
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	c.Assert(err, jc.ErrorIsNil)
 	defer file.Close()
 

--- a/caas/kubernetes/provider/exec/copy.go
+++ b/caas/kubernetes/provider/exec/copy.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -221,7 +220,7 @@ func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) e
 			return err
 		}
 		if stat.IsDir() {
-			files, err := ioutil.ReadDir(fpath)
+			files, err := os.ReadDir(fpath)
 			if err != nil {
 				return err
 			}

--- a/caas/kubernetes/provider/exec/copy_test.go
+++ b/caas/kubernetes/provider/exec/copy_test.go
@@ -6,7 +6,6 @@ package exec_test
 import (
 	"archive/tar"
 	"bytes"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -106,7 +105,7 @@ func (s *execSuite) TestCopyToPod(c *gc.C) {
 
 	s.suiteMocks.EXPECT().RemoteCmdExecutorGetter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(s.mockRemoteCmdExecutor, nil)
 
-	srcPath, err := ioutil.TempFile(c.MkDir(), "testfile")
+	srcPath, err := os.CreateTemp(c.MkDir(), "testfile")
 	c.Assert(err, jc.ErrorIsNil)
 	defer srcPath.Close()
 	defer os.Remove(srcPath.Name())
@@ -214,7 +213,7 @@ func (s *execSuite) TestCopyFromPod(c *gc.C) {
 
 	s.suiteMocks.EXPECT().RemoteCmdExecutorGetter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(s.mockRemoteCmdExecutor, nil)
 
-	srcPath, err := ioutil.TempFile(c.MkDir(), "testfile")
+	srcPath, err := os.CreateTemp(c.MkDir(), "testfile")
 	c.Assert(err, jc.ErrorIsNil)
 	fileContent := `test data`
 	_, err = srcPath.WriteString(fileContent)
@@ -303,7 +302,7 @@ func (s *execSuite) TestCopyFromPod(c *gc.C) {
 	select {
 	case err := <-errChan:
 		c.Assert(err, jc.ErrorIsNil)
-		data, err := ioutil.ReadFile(destPath)
+		data, err := os.ReadFile(destPath)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), gc.DeepEquals, fileContent)
 	case <-time.After(coretesting.LongWait):

--- a/caas/kubernetes/provider/specs/builder_test.go
+++ b/caas/kubernetes/provider/specs/builder_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -360,7 +359,7 @@ func (s *builderSuite) TestDeployDeploymentTypeMismatchFailed(c *gc.C) {
 func objBody(c *gc.C, object interface{}) io.ReadCloser {
 	output, err := json.MarshalIndent(object, "", "")
 	c.Assert(err, jc.ErrorIsNil)
-	return ioutil.NopCloser(bytes.NewReader(output))
+	return io.NopCloser(bytes.NewReader(output))
 }
 
 func (s *builderSuite) fakeRequest(
@@ -391,7 +390,7 @@ func (s *builderSuite) fakeRequest(
 		reqBody, err := req.GetBody()
 		c.Assert(err, jc.ErrorIsNil)
 		defer reqBody.Close()
-		reqBodyData, err := ioutil.ReadAll(reqBody)
+		reqBodyData, err := io.ReadAll(reqBody)
 		c.Assert(err, jc.ErrorIsNil)
 		reqObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, reqBodyData)
 		c.Assert(err, jc.ErrorIsNil)

--- a/caas/kubernetes/tunnel.go
+++ b/caas/kubernetes/tunnel.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -220,7 +219,7 @@ func NewTunnel(
 		config:     c,
 		Kind:       kind,
 		Namespace:  namespace,
-		Out:        ioutil.Discard,
+		Out:        io.Discard,
 		readyChan:  make(chan struct{}, 1),
 		RemotePort: remotePort,
 		stopChan:   make(chan struct{}, 1),

--- a/charmhub/download.go
+++ b/charmhub/download.go
@@ -6,7 +6,6 @@ package charmhub
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -195,7 +194,7 @@ func (c *downloadClient) downloadFromURL(ctx context.Context, resourceURL *url.U
 	// Ensure we drain the response body so this connection can be reused. As
 	// there is no error message, we have no ability other than to check the
 	// status codes.
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {

--- a/charmhub/download_test.go
+++ b/charmhub/download_test.go
@@ -6,7 +6,7 @@ package charmhub
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -31,7 +31,7 @@ func (s *DownloadSuite) TestDownloadAndRead(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	tmpFile, err := ioutil.TempFile("", "charm")
+	tmpFile, err := os.CreateTemp("", "charm")
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		err := os.Remove(tmpFile.Name())
@@ -47,7 +47,7 @@ func (s *DownloadSuite) TestDownloadAndRead(c *gc.C) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBuffer(archiveBytes)),
+			Body:       io.NopCloser(bytes.NewBuffer(archiveBytes)),
 		}, nil
 	})
 
@@ -63,7 +63,7 @@ func (s *DownloadSuite) TestDownloadAndReadWithNotFoundStatusCode(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	tmpFile, err := ioutil.TempFile("", "charm")
+	tmpFile, err := os.CreateTemp("", "charm")
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		err := os.Remove(tmpFile.Name())
@@ -77,7 +77,7 @@ func (s *DownloadSuite) TestDownloadAndReadWithNotFoundStatusCode(c *gc.C) {
 	httpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 404,
-			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+			Body:       io.NopCloser(bytes.NewBufferString("")),
 		}, nil
 	})
 
@@ -93,7 +93,7 @@ func (s *DownloadSuite) TestDownloadAndReadWithFailedStatusCode(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	tmpFile, err := ioutil.TempFile("", "charm")
+	tmpFile, err := os.CreateTemp("", "charm")
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		err := os.Remove(tmpFile.Name())
@@ -108,7 +108,7 @@ func (s *DownloadSuite) TestDownloadAndReadWithFailedStatusCode(c *gc.C) {
 		return &http.Response{
 			Status:     http.StatusText(http.StatusInternalServerError),
 			StatusCode: http.StatusInternalServerError,
-			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+			Body:       io.NopCloser(bytes.NewBufferString("")),
 		}, nil
 	})
 
@@ -121,13 +121,13 @@ func (s *DownloadSuite) TestDownloadAndReadWithFailedStatusCode(c *gc.C) {
 }
 
 func (s *DownloadSuite) createCharmArchieve(c *gc.C) []byte {
-	tmpDir, err := ioutil.TempDir("", "charm")
+	tmpDir, err := os.MkdirTemp("", "charm")
 	c.Assert(err, jc.ErrorIsNil)
 
 	repo := charmrepotesting.NewRepo(localCharmRepo, defaultSeries)
 	charmPath := repo.CharmArchivePath(tmpDir, "dummy")
 
-	path, err := ioutil.ReadFile(charmPath)
+	path, err := os.ReadFile(charmPath)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/charmhub/http.go
+++ b/charmhub/http.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -188,7 +187,7 @@ func (t *apiRequester) doOnce(req *http.Request) (*http.Response, error) {
 		potentialInvalidURL = true
 	} else if resp.StatusCode >= http.StatusInternalServerError && resp.StatusCode <= http.StatusNetworkAuthenticationRequired {
 		defer func() {
-			_, _ = io.Copy(ioutil.Discard, resp.Body)
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 		}()
 		return nil, errors.Errorf(`server error %q`, req.URL.String())
@@ -200,7 +199,7 @@ func (t *apiRequester) doOnce(req *http.Request) (*http.Response, error) {
 	// Everything will be incorrectly formatted.
 	if contentType := resp.Header.Get("Content-Type"); contentType != jsonContentType {
 		defer func() {
-			_, _ = io.Copy(ioutil.Discard, resp.Body)
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 		}()
 

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -6,7 +6,7 @@ package charmhub
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/golang/mock/gomock"
@@ -138,7 +138,7 @@ func (t *metadataHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		Proto:         "HTTP/1.1",
 		ProtoMajor:    1,
 		ProtoMinor:    1,
-		Body:          ioutil.NopCloser(bytes.NewBufferString(t.responseBody)),
+		Body:          io.NopCloser(bytes.NewBufferString(t.responseBody)),
 		ContentLength: int64(len(t.responseBody)),
 		Request:       req,
 		Header:        http.Header{"Content-Type": []string{"application/json"}},

--- a/charmstore/client_test.go
+++ b/charmstore/client_test.go
@@ -5,7 +5,7 @@ package charmstore
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/juju/charm/v9"
@@ -190,7 +190,7 @@ func (s *ClientSuite) TestListResourcesAPI2ResourcesFailure(c *gc.C) {
 func (s *ClientSuite) TestDownloadResource(c *gc.C) {
 	fp, err := resource.GenerateFingerprint(strings.NewReader("data"))
 	c.Assert(err, jc.ErrorIsNil)
-	rc := ioutil.NopCloser(strings.NewReader("data"))
+	rc := io.NopCloser(strings.NewReader("data"))
 	s.wrapper.ReturnGetResource = csclient.ResourceData{
 		ReadCloser: rc,
 		Hash:       fp.String(),
@@ -217,7 +217,7 @@ func (s *ClientSuite) TestDownloadResource(c *gc.C) {
 func (s *ClientSuite) TestGetResourceDockerType(c *gc.C) {
 	fp, err := resource.GenerateFingerprint(strings.NewReader("data"))
 	c.Assert(err, jc.ErrorIsNil)
-	rc := ioutil.NopCloser(strings.NewReader("data"))
+	rc := io.NopCloser(strings.NewReader("data"))
 	s.wrapper.ReturnGetResource = csclient.ResourceData{
 		ReadCloser: rc,
 		Hash:       fp.String(),

--- a/cloud/clouds.go
+++ b/cloud/clouds.go
@@ -5,7 +5,6 @@ package cloud
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -371,7 +370,7 @@ func JujuPublicCloudsPath() string {
 // are found, returns the fallback public cloud metadata.
 func PublicCloudMetadata(searchPath ...string) (result map[string]Cloud, fallbackUsed bool, err error) {
 	for _, file := range searchPath {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		if err != nil && os.IsNotExist(err) {
 			continue
 		}

--- a/cloud/clouds_test.go
+++ b/cloud/clouds_test.go
@@ -5,7 +5,7 @@ package cloud_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -166,7 +166,7 @@ clouds:
 `[1:]
 	dir := c.MkDir()
 	cloudyamlfile := filepath.Join(dir, "public-clouds.yaml")
-	err := ioutil.WriteFile(cloudyamlfile, []byte(metadata), 0644)
+	err := os.WriteFile(cloudyamlfile, []byte(metadata), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	clouds, fallbackUsed, err := cloud.PublicCloudMetadata(cloudyamlfile)
 	c.Assert(err, jc.ErrorIsNil)
@@ -182,7 +182,7 @@ clouds:
 }
 
 func (s *cloudSuite) TestGeneratedPublicCloudInfo(c *gc.C) {
-	cloudData, err := ioutil.ReadFile("fallback-public-cloud.yaml")
+	cloudData, err := os.ReadFile("fallback-public-cloud.yaml")
 	c.Assert(err, jc.ErrorIsNil)
 	clouds, err := cloud.ParseCloudMetadata(cloudData)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cloud/credentials.go
+++ b/cloud/credentials.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -290,7 +289,7 @@ func ExpandFilePathsOfCredential(
 			return cred, fmt.Errorf("determining file path value for credential attribute: %w", err)
 		}
 
-		contents, err := ioutil.ReadFile(abs)
+		contents, err := os.ReadFile(abs)
 		if err != nil {
 			return cred, fmt.Errorf("reading file %q contents for credential attribute %q: %w", abs, credAttr.Name, err)
 		}

--- a/cloud/credentials_test.go
+++ b/cloud/credentials_test.go
@@ -5,7 +5,7 @@ package cloud_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -555,7 +555,7 @@ func (s *credentialsSuite) TestFinalizeCredentialInvalidChoice(c *gc.C) {
 func (s *credentialsSuite) TestFinalizeCredentialFilePath(c *gc.C) {
 	dir := c.MkDir()
 	filename := filepath.Join(dir, "filename")
-	err := ioutil.WriteFile(filename, []byte{}, 0600)
+	err := os.WriteFile(filename, []byte{}, 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cred := cloud.NewCredential(
@@ -584,7 +584,7 @@ func (s *credentialsSuite) TestFinalizeCredentialFilePath(c *gc.C) {
 
 func (s *credentialsSuite) TestFinalizeCredentialRelativeFilePath(c *gc.C) {
 	absFilename := filepath.Join(utils.Home(), "filename")
-	err := ioutil.WriteFile(absFilename, []byte{}, 0600)
+	err := os.WriteFile(absFilename, []byte{}, 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cred := cloud.NewCredential(
@@ -654,7 +654,7 @@ func (s *credentialsSuite) TestValidateFileAttrValue(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "invalid file path: stat /xyz/nothing.blah: no such file or directory")
 
 	absPathNewFile := filepath.Join(utils.Home(), "new-creds.json")
-	err = ioutil.WriteFile(absPathNewFile, []byte("abc"), 0600)
+	err = os.WriteFile(absPathNewFile, []byte("abc"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	absPath, err := cloud.ValidateFileAttrValue("~/new-creds.json")
@@ -666,7 +666,7 @@ func (s *credentialsSuite) TestValidateFileAttrValue(c *gc.C) {
 }
 
 func (s *credentialsSuite) TestExpandFilePathsOfCredential(c *gc.C) {
-	tempFile, err := ioutil.TempFile("", "")
+	tempFile, err := os.CreateTemp("", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = tempFile.WriteString("test")

--- a/cloud/personalclouds.go
+++ b/cloud/personalclouds.go
@@ -7,7 +7,6 @@
 package cloud
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/errors"
@@ -35,7 +34,7 @@ func PersonalCloudMetadata() (map[string]Cloud, error) {
 // ParseCloudMetadataFile loads any cloud metadata defined
 // in the specified file.
 func ParseCloudMetadataFile(file string) (map[string]Cloud, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -53,5 +52,5 @@ func WritePersonalCloudMetadata(cloudsMap map[string]Cloud) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return ioutil.WriteFile(JujuPersonalCloudsPath(), data, os.FileMode(0600))
+	return os.WriteFile(JujuPersonalCloudsPath(), data, os.FileMode(0600))
 }

--- a/cloud/personalclouds_test.go
+++ b/cloud/personalclouds_test.go
@@ -4,7 +4,7 @@
 package cloud_test
 
 import (
-	"io/ioutil"
+	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -47,7 +47,7 @@ func (s *personalCloudSuite) TestWritePersonalClouds(c *gc.C) {
 	}
 	err := cloud.WritePersonalCloudMetadata(clouds)
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("clouds.yaml"))
+	data, err := os.ReadFile(osenv.JujuXDGDataHomePath("clouds.yaml"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, `
 clouds:
@@ -142,6 +142,6 @@ clouds:
       local:
         endpoint: http://azurestack.local
 `[1:]
-	err := ioutil.WriteFile(destPath, []byte(data), 0600)
+	err := os.WriteFile(destPath, []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -478,13 +477,13 @@ func (s *NetworkUbuntuSuite) runENIScript(c *gc.C, pythonBinary, ipCommand, inpu
 	templFile := filepath.Join(s.tempFolder, "interfaces.templ")
 	scriptFile := filepath.Join(s.tempFolder, "script.py")
 
-	err := ioutil.WriteFile(dataFile, []byte(s.originalSystemNetworkInterfaces), 0644)
+	err := os.WriteFile(dataFile, []byte(s.originalSystemNetworkInterfaces), 0644)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("Can't write interfaces file"))
 
-	err = ioutil.WriteFile(templFile, []byte(input), 0644)
+	err = os.WriteFile(templFile, []byte(input), 0644)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("Can't write interfaces.templ file"))
 
-	err = ioutil.WriteFile(scriptFile, []byte(cloudinit.NetworkInterfacesScript), 0755)
+	err = os.WriteFile(scriptFile, []byte(cloudinit.NetworkInterfacesScript), 0755)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("Can't write script file"))
 
 	script := fmt.Sprintf("%q %q --interfaces-file %q --output-file %q --command %q --wait %d --retries %d",
@@ -498,7 +497,7 @@ func (s *NetworkUbuntuSuite) runENIScript(c *gc.C, pythonBinary, ipCommand, inpu
 		dataOutFile: expectedOutput,
 		dataFile:    s.originalSystemNetworkInterfaces,
 	} {
-		data, err := ioutil.ReadFile(file)
+		data, err := os.ReadFile(file)
 		c.Assert(err, jc.ErrorIsNil, gc.Commentf("can't open %q file: %s", file, err))
 		output := string(data)
 		c.Assert(output, gc.Equals, expected)
@@ -515,7 +514,7 @@ func (s *NetworkUbuntuSuite) createMockCommand(c *gc.C, outputs []string) string
 	lastFile := ""
 	for i, output := range outputs {
 		dataFile := filepath.Join(s.tempFolder, fmt.Sprintf("%s.%d", baseName, i))
-		err := ioutil.WriteFile(dataFile, []byte(output), 0644)
+		err := os.WriteFile(dataFile, []byte(output), 0644)
 		c.Assert(err, jc.ErrorIsNil, gc.Commentf("can't write mock file"))
 		if lastFile != "" {
 			script += fmt.Sprintf("mv %q %q || true\n", dataFile, lastFile)
@@ -524,7 +523,7 @@ func (s *NetworkUbuntuSuite) createMockCommand(c *gc.C, outputs []string) string
 	}
 
 	scriptPath := filepath.Join(s.tempFolder, fmt.Sprintf("%s.sh", baseName))
-	err := ioutil.WriteFile(scriptPath, []byte(script), 0755)
+	err := os.WriteFile(scriptPath, []byte(script), 0755)
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("can't write script file"))
 	return scriptPath
 }

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -5,7 +5,7 @@
 package containerinit
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/errors"
@@ -43,7 +43,7 @@ func WriteUserData(
 // directory specified, and returns the filename.
 func WriteCloudInitFile(directory string, userData []byte) (string, error) {
 	userDataFilename := filepath.Join(directory, "cloud-init")
-	if err := ioutil.WriteFile(userDataFilename, userData, 0644); err != nil {
+	if err := os.WriteFile(userDataFilename, userData, 0644); err != nil {
 		logger.Errorf("failed to write user data: %v", err)
 		return "", err
 	}

--- a/cloudconfig/machinecloudconfig.go
+++ b/cloudconfig/machinecloudconfig.go
@@ -2,7 +2,6 @@ package cloudconfig
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -129,11 +128,11 @@ func (r *MachineInitReader) GetInitConfig() (map[string]interface{}, error) {
 func (r *MachineInitReader) getMachineCloudCfgDirData() (map[string]interface{}, error) {
 	dir := r.config.CloudInitConfigDir
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, errors.Annotate(err, "determining files in CloudInitCfgDir for the machine")
 	}
-	sortedFiles := sortableFileInfos(files)
+	sortedFiles := sortableDirEntries(files)
 	sort.Sort(sortedFiles)
 
 	cloudInit := make(map[string]interface{})
@@ -196,7 +195,7 @@ func (r *MachineInitReader) unmarshallConfigFile(file string) (map[string]interf
 // fileAsConfigMap reads the file at the input path and returns its contents as
 // raw bytes, and if possible a map of config key-values.
 func fileAsConfigMap(file string) ([]byte, map[string]interface{}, error) {
-	raw, err := ioutil.ReadFile(file)
+	raw, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, errors.Annotatef(err, "reading config from %q", file)
 	}
@@ -264,17 +263,17 @@ func nestedAptConfig(key string, val interface{}, log loggo.Logger) map[string]i
 	return nil
 }
 
-type sortableFileInfos []os.FileInfo
+type sortableDirEntries []os.DirEntry
 
-func (fil sortableFileInfos) Len() int {
+func (fil sortableDirEntries) Len() int {
 	return len(fil)
 }
 
-func (fil sortableFileInfos) Less(i, j int) bool {
+func (fil sortableDirEntries) Less(i, j int) bool {
 	return fil[i].Name() < fil[j].Name()
 }
 
-func (fil sortableFileInfos) Swap(i, j int) {
+func (fil sortableDirEntries) Swap(i, j int) {
 	fil[i], fil[j] = fil[j], fil[i]
 }
 

--- a/cloudconfig/machinecloudconfig_test.go
+++ b/cloudconfig/machinecloudconfig_test.go
@@ -1,7 +1,6 @@
 package cloudconfig_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -230,7 +229,7 @@ func (s *fromHostSuite) newMachineInitReader(series string) cloudconfig.InitRead
 }
 
 func seedData(c *gc.C, dir, name, data string) {
-	c.Assert(ioutil.WriteFile(path.Join(dir, name), []byte(data), 0644), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(path.Join(dir, name), []byte(data), 0644), jc.ErrorIsNil)
 }
 
 var dpkgLocalCloudConfig = `

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -696,7 +695,7 @@ func (*cloudinitSuite) TestCloudInitWithLocalControllerCharmArchive(c *gc.C) {
 	_ = f.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
-	content, err := ioutil.ReadFile(controllerCharmPath)
+	content, err := os.ReadFile(controllerCharmPath)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg := makeBootstrapConfig("precise", 0).setControllerCharm(controllerCharmPath)

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	stdos "os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -513,7 +513,7 @@ func (w *unixConfigure) addLocalSnapUpload() error {
 	}
 
 	logger.Infof("preparing to upload juju-db snap from %v", snapPath)
-	snapData, err := ioutil.ReadFile(snapPath)
+	snapData, err := stdos.ReadFile(snapPath)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -521,7 +521,7 @@ func (w *unixConfigure) addLocalSnapUpload() error {
 	w.conf.AddRunBinaryFile(path.Join(w.icfg.SnapDir(), snapName), snapData, 0644)
 
 	logger.Infof("preparing to upload juju-db assertions from %v", assertionsPath)
-	snapAssertionsData, err := ioutil.ReadFile(assertionsPath)
+	snapAssertionsData, err := stdos.ReadFile(assertionsPath)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -560,7 +560,7 @@ func (w *unixConfigure) addLocalControllerCharmsUpload() error {
 		}
 		charmData = buf.Bytes()
 	} else {
-		charmData, err = ioutil.ReadFile(charmPath)
+		charmData, err = stdos.ReadFile(charmPath)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -573,7 +573,7 @@ func (w *unixConfigure) addLocalControllerCharmsUpload() error {
 func (w *unixConfigure) addDownloadToolsCmds() error {
 	tools := w.icfg.ToolsList()[0]
 	if strings.HasPrefix(tools.URL, fileSchemePrefix) {
-		toolsData, err := ioutil.ReadFile(tools.URL[len(fileSchemePrefix):])
+		toolsData, err := stdos.ReadFile(tools.URL[len(fileSchemePrefix):])
 		if err != nil {
 			return err
 		}

--- a/cmd/containeragent/initialize/command_test.go
+++ b/cmd/containeragent/initialize/command_test.go
@@ -6,7 +6,6 @@ package initialize_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/golang/mock/gomock"
@@ -92,11 +91,11 @@ apiport: 17070`[1:])
 	containerAgentWritten := bytes.NewBuffer(nil)
 	jujucWritten := bytes.NewBuffer(nil)
 
-	s.fileReaderWriter.EXPECT().Reader("/opt/pebble").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedPebble)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/pebble").Times(1).Return(io.NopCloser(bytes.NewReader(expectedPebble)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/pebble", os.FileMode(0755)).Return(NopWriteCloser(pebbleWritten), nil)
-	s.fileReaderWriter.EXPECT().Reader("/opt/containeragent").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedContainerAgent)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/containeragent").Times(1).Return(io.NopCloser(bytes.NewReader(expectedContainerAgent)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/containeragent", os.FileMode(0755)).Return(NopWriteCloser(containerAgentWritten), nil)
-	s.fileReaderWriter.EXPECT().Reader("/opt/jujuc").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedJujuc)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/jujuc").Times(1).Return(io.NopCloser(bytes.NewReader(expectedJujuc)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/jujuc", os.FileMode(0755)).Return(NopWriteCloser(jujucWritten), nil)
 
 	gomock.InOrder(
@@ -136,11 +135,11 @@ func (s *initCommandSuit) TestRunConfExists(c *gc.C) {
 	containerAgentWritten := bytes.NewBuffer(nil)
 	jujucWritten := bytes.NewBuffer(nil)
 
-	s.fileReaderWriter.EXPECT().Reader("/opt/pebble").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedPebble)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/pebble").Times(1).Return(io.NopCloser(bytes.NewReader(expectedPebble)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/pebble", os.FileMode(0755)).Return(NopWriteCloser(pebbleWritten), nil)
-	s.fileReaderWriter.EXPECT().Reader("/opt/containeragent").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedContainerAgent)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/containeragent").Times(1).Return(io.NopCloser(bytes.NewReader(expectedContainerAgent)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/containeragent", os.FileMode(0755)).Return(NopWriteCloser(containerAgentWritten), nil)
-	s.fileReaderWriter.EXPECT().Reader("/opt/jujuc").Times(1).Return(ioutil.NopCloser(bytes.NewReader(expectedJujuc)), nil)
+	s.fileReaderWriter.EXPECT().Reader("/opt/jujuc").Times(1).Return(io.NopCloser(bytes.NewReader(expectedJujuc)), nil)
 	s.fileReaderWriter.EXPECT().Writer("/charm/bin/jujuc", os.FileMode(0755)).Return(NopWriteCloser(jujucWritten), nil)
 	s.fileReaderWriter.EXPECT().Stat("/var/lib/juju/template-agent.conf").Return(nil, nil)
 

--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -4,7 +4,6 @@
 package unit
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -134,7 +133,7 @@ func (c *containerUnitAgent) ensureAgentConf(dataDir string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := ioutil.WriteFile(configPath, configBytes, 0644); err != nil {
+	if err := os.WriteFile(configPath, configBytes, 0644); err != nil {
 		return errors.Annotate(err, "writing agent config file")
 	}
 

--- a/cmd/containeragent/unit/agent_test.go
+++ b/cmd/containeragent/unit/agent_test.go
@@ -5,7 +5,6 @@ package unit_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -76,7 +75,7 @@ func (s *containerUnitAgentSuite) setupCommand(c *gc.C, configChangedVal *voyeur
 
 func (s *containerUnitAgentSuite) prepareAgentConf(c *gc.C, appName string) string {
 	fPath := filepath.Join(s.dataDir, k8sconstants.TemplateFileNameAgentConf)
-	err := ioutil.WriteFile(fPath, []byte(fmt.Sprintf(agentConfigContents, appName)), 0600)
+	err := os.WriteFile(fPath, []byte(fmt.Sprintf(agentConfigContents, appName)), 0600)
 	c.Assert(err, gc.IsNil)
 	return fPath
 }

--- a/cmd/containeragent/utils/filesystem.go
+++ b/cmd/containeragent/utils/filesystem.go
@@ -5,7 +5,6 @@ package utils
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -39,11 +38,11 @@ func (fileReaderWriter) Stat(filename string) (os.FileInfo, error) {
 }
 
 func (fileReaderWriter) ReadFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func (fileReaderWriter) WriteFile(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 func (fileReaderWriter) MkdirAll(path string, perm os.FileMode) error {

--- a/cmd/juju/action/package_test.go
+++ b/cmd/juju/action/package_test.go
@@ -4,7 +4,7 @@
 package action_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -132,7 +132,7 @@ func setupValueFile(c *gc.C, dir, filename, value string) string {
 	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath(filename)
 	content := []byte(value)
-	err := ioutil.WriteFile(path, content, 0666)
+	err := os.WriteFile(path, content, 0666)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/cmd/juju/application/bundle/bundle_test.go
+++ b/cmd/juju/application/bundle/bundle_test.go
@@ -4,7 +4,7 @@
 package bundle
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -267,7 +267,7 @@ func (s *composeAndVerifyRepSuite) setupOverlayFile(c *gc.C) {
 	s.overlayDir = c.MkDir()
 	s.overlayFile = filepath.Join(s.overlayDir, "config.yaml")
 	c.Assert(
-		ioutil.WriteFile(
+		os.WriteFile(
 			s.overlayFile, []byte(`
                 applications:
                     wordpress:
@@ -276,7 +276,7 @@ func (s *composeAndVerifyRepSuite) setupOverlayFile(c *gc.C) {
             `), 0644),
 		jc.ErrorIsNil)
 	c.Assert(
-		ioutil.WriteFile(
+		os.WriteFile(
 			filepath.Join(s.overlayDir, "title"), []byte("magic bundle config"), 0644),
 		jc.ErrorIsNil)
 }

--- a/cmd/juju/application/bundle_test.go
+++ b/cmd/juju/application/bundle_test.go
@@ -5,7 +5,6 @@ package application
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -92,9 +91,9 @@ func (s *BundleDeployCharmStoreSuite) DeployBundleYAMLWithOutput(c *gc.C, conten
 func (s *BundleDeployCharmStoreSuite) makeBundleDir(c *gc.C, content string) string {
 	bundlePath := filepath.Join(c.MkDir(), "example")
 	c.Assert(os.Mkdir(bundlePath, 0777), jc.ErrorIsNil)
-	err := ioutil.WriteFile(filepath.Join(bundlePath, "bundle.yaml"), []byte(content), 0644)
+	err := os.WriteFile(filepath.Join(bundlePath, "bundle.yaml"), []byte(content), 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(bundlePath, "README.md"), []byte("README"), 0644)
+	err = os.WriteFile(filepath.Join(bundlePath, "README.md"), []byte("README"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return bundlePath
@@ -206,7 +205,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalPath(c *gc.C) {
                 series: xenial
                 num_units: 1
     `
-	err := ioutil.WriteFile(path, []byte(data), 0644)
+	err := os.WriteFile(path, []byte(data), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.runDeploy(c, path)
 	c.Assert(err, jc.ErrorIsNil)
@@ -240,7 +239,7 @@ func (s *BundleDeployCharmStoreSuite) assertDeployBundleLocalPathInvalidSeriesWi
                 charm: ./dummy
                 num_units: 1
     `
-	err := ioutil.WriteFile(path, []byte(data), 0644)
+	err := os.WriteFile(path, []byte(data), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	args := []string{path}
 	if force {
@@ -277,7 +276,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalResources(c *gc.C) {
 	dir := s.makeBundleDir(c, data)
 	testcharms.RepoWithSeries("bionic").ClonedDir(dir, "dummy-resource")
 	c.Assert(
-		ioutil.WriteFile(filepath.Join(dir, "dummy-resource.zip"), []byte("zip file"), 0644),
+		os.WriteFile(filepath.Join(dir, "dummy-resource.zip"), []byte("zip file"), 0644),
 		jc.ErrorIsNil)
 	err := s.runDeploy(c, dir)
 	c.Assert(err, jc.ErrorIsNil)
@@ -480,7 +479,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentWithBundleO
 	configDir := c.MkDir()
 	configFile := filepath.Join(configDir, "config.yaml")
 	c.Assert(
-		ioutil.WriteFile(
+		os.WriteFile(
 			configFile, []byte(`
                 applications:
                     wordpress:
@@ -489,7 +488,7 @@ func (s *BundleDeployCharmStoreSuite) TestDeployBundleLocalDeploymentWithBundleO
             `), 0644),
 		jc.ErrorIsNil)
 	c.Assert(
-		ioutil.WriteFile(
+		os.WriteFile(
 			filepath.Join(configDir, "title"), []byte("magic bundle config"), 0644),
 		jc.ErrorIsNil)
 
@@ -531,7 +530,7 @@ applications:
     charm: ./dummy
 `
 	c.Assert(
-		ioutil.WriteFile(bundleFile, []byte(bundleContent), 0644),
+		os.WriteFile(bundleFile, []byte(bundleContent), 0644),
 		jc.ErrorIsNil)
 
 	err := s.runDeploy(c, bundleFile)

--- a/cmd/juju/application/config_test.go
+++ b/cmd/juju/application/config_test.go
@@ -5,7 +5,6 @@ package application_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"strings"
 	"unicode/utf8"
@@ -561,7 +560,7 @@ func setupValueFile(c *gc.C, dir, filename, value string) string {
 	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath(filename)
 	content := []byte(value)
-	err := ioutil.WriteFile(path, content, 0666)
+	err := os.WriteFile(path, content, 0666)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }
@@ -591,7 +590,7 @@ func setupConfigFile(c *gc.C, dir string) string {
 	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath("testconfig.yaml")
 	content := []byte(yamlConfigValue)
-	err := ioutil.WriteFile(path, content, 0666)
+	err := os.WriteFile(path, content, 0666)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -334,7 +333,7 @@ func (s *DeploySuite) TestInvalidPath(c *gc.C) {
 
 func (s *DeploySuite) TestInvalidFileFormat(c *gc.C) {
 	path := filepath.Join(c.MkDir(), "bundle.yaml")
-	err := ioutil.WriteFile(path, []byte(":"), 0600)
+	err := os.WriteFile(path, []byte(":"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.runDeploy(c, path)
 	c.Assert(err, gc.ErrorMatches, `cannot deploy bundle: cannot unmarshal bundle contents:.* yaml:.*`)
@@ -593,7 +592,7 @@ func (s *DeploySuite) TestConfigValues(c *gc.C) {
 	withAliasedCharmDeployable(s.fakeAPI, curl, "dummy-name", "jammy", charmDir.Meta(), charmDir.Metrics(), false, false, 1, nil, nil)
 
 	confPath := filepath.Join(c.MkDir(), "include.txt")
-	c.Assert(ioutil.WriteFile(confPath, []byte("lorem\nipsum"), os.ModePerm), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(confPath, []byte("lorem\nipsum"), os.ModePerm), jc.ErrorIsNil)
 
 	err := s.runDeployForState(c, charmDir.Path, "dummy-application", "--config", "skill-level=9000", "--config", "outlook=good", "--config", "title=@"+confPath, "--series", "bionic")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1564,7 +1563,7 @@ func setupConfigFile(c *gc.C, dir string) string {
 	ctx := cmdtesting.ContextForDir(c, dir)
 	path := ctx.AbsPath("testconfig.yaml")
 	content := []byte("dummy-application:\n  skill-level: 9000\n  username: admin001\n\n")
-	err := ioutil.WriteFile(path, content, 0666)
+	err := os.WriteFile(path, content, 0666)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -5,7 +5,7 @@ package deployer
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -112,7 +112,7 @@ func (d *deployCharm) deploy(
 		return errors.Errorf("only a single config YAML file can be specified, got %d", len(files))
 	}
 	if len(files) == 1 {
-		configYAML, err = ioutil.ReadFile(files[0])
+		configYAML, err = os.ReadFile(files[0])
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -5,7 +5,6 @@ package deployer
 
 import (
 	"archive/zip"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -469,7 +468,7 @@ func (d *factory) maybeReadRepositoryBundle(resolver Resolver) (Deployer, error)
 	// from the charmstore we simply use the existing
 	// charmrepo.v4 API to read the base bundle and
 	// wrap it in a BundleDataSource for use by deployBundle.
-	dir, err := ioutil.TempDir("", bundleURL.Name)
+	dir, err := os.MkdirTemp("", bundleURL.Name)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -5,7 +5,6 @@ package deployer
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -455,9 +454,9 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc
 func (s *deployerSuite) makeBundleDir(c *gc.C, content string) string {
 	bundlePath := filepath.Join(c.MkDir(), "example")
 	c.Assert(os.Mkdir(bundlePath, 0777), jc.ErrorIsNil)
-	err := ioutil.WriteFile(filepath.Join(bundlePath, "bundle.yaml"), []byte(content), 0644)
+	err := os.WriteFile(filepath.Join(bundlePath, "bundle.yaml"), []byte(content), 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(bundlePath, "README.md"), []byte("README"), 0644)
+	err = os.WriteFile(filepath.Join(bundlePath, "README.md"), []byte("README"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	return bundlePath
 }

--- a/cmd/juju/application/deployer/register.go
+++ b/cmd/juju/application/deployer/register.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -272,7 +272,7 @@ func (r *RegisterMeteredCharm) registerMetrics(modelUUID, charmURL, applicationN
 	defer response.Body.Close()
 
 	if response.StatusCode == http.StatusOK {
-		b, err := ioutil.ReadAll(response.Body)
+		b, err := io.ReadAll(response.Body)
 		if err != nil {
 			return nil, errors.Annotatef(err, "failed to read the response")
 		}

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -5,7 +5,7 @@ package application
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -332,7 +332,7 @@ Consider using a CharmStore bundle instead.`
 	// GetBundle creates the directory so we actually want to create a temp
 	// directory then add a namespace (bundle name) so that charmhub get
 	// bundle can create it.
-	dir, err := ioutil.TempDir("", "diff-bundle-")
+	dir, err := os.MkdirTemp("", "diff-bundle-")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/diffbundle_test.go
+++ b/cmd/juju/application/diffbundle_test.go
@@ -5,7 +5,7 @@ package application_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -476,7 +476,7 @@ func (s *diffSuite) writeLocalBundle(c *gc.C, content string) string {
 
 func (s *diffSuite) writeFile(c *gc.C, name, content string) string {
 	path := filepath.Join(s.dir, name)
-	err := ioutil.WriteFile(path, []byte(content), 0666)
+	err := os.WriteFile(path, []byte(content), 0666)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/cmd/juju/application/refresh_resources_test.go
+++ b/cmd/juju/application/refresh_resources_test.go
@@ -5,7 +5,7 @@ package application
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 	"strings"
@@ -76,7 +76,7 @@ resources:
 `
 
 	myriakPath := testcharms.RepoWithSeries("bionic").ClonedDir(c.MkDir(), "riak")
-	err := ioutil.WriteFile(path.Join(myriakPath.Path, "metadata.yaml"), []byte(riakResourceMeta), 0644)
+	err := os.WriteFile(path.Join(myriakPath.Path, "metadata.yaml"), []byte(riakResourceMeta), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	data := []byte("some-data")
@@ -84,7 +84,7 @@ resources:
 	c.Assert(err, jc.ErrorIsNil)
 
 	resourceFile := path.Join(c.MkDir(), "data.lib")
-	err = ioutil.WriteFile(resourceFile, data, 0644)
+	err = os.WriteFile(resourceFile, data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = cmdtesting.RunCommand(c, NewRefreshCommand(),

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -6,7 +6,6 @@ package application
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -279,7 +278,7 @@ func (s *RefreshSuite) TestUseConfiguredCharmStoreURL(c *gc.C) {
 func (s *RefreshSuite) TestConfigSettings(c *gc.C) {
 	tempdir := c.MkDir()
 	configFile := filepath.Join(tempdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte("foo:{}"), 0644)
+	err := os.WriteFile(configFile, []byte("foo:{}"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.runRefresh(c, "foo", "--config", configFile)
@@ -851,9 +850,9 @@ func (s *RefreshSuccessStateSuite) TestInitWithResources(c *gc.C) {
 
 	foopath := path.Join(dir, "foo")
 	barpath := path.Join(dir, "bar")
-	err := ioutil.WriteFile(foopath, []byte("foo"), 0600)
+	err := os.WriteFile(foopath, []byte("foo"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(barpath, []byte("bar"), 0600)
+	err = os.WriteFile(barpath, []byte("bar"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	res1 := fmt.Sprintf("foo=%s", foopath)
@@ -885,7 +884,7 @@ func (s *RefreshSuite) TestUpgradeSameVersionWithResources(c *gc.C) {
 	}
 	dir := c.MkDir()
 	barpath := path.Join(dir, "bar")
-	err := ioutil.WriteFile(barpath, []byte("bar"), 0600)
+	err := os.WriteFile(barpath, []byte("bar"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	res1 := fmt.Sprintf("bar=%s", barpath)
@@ -934,7 +933,7 @@ func (s *RefreshSuccessStateSuite) TestCharmPath(c *gc.C) {
 	myriakPath := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "riak")
 
 	// Change the revision to 42 and upgrade to it with explicit revision.
-	err := ioutil.WriteFile(path.Join(myriakPath, "revision"), []byte("42"), 0644)
+	err := os.WriteFile(path.Join(myriakPath, "revision"), []byte("42"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.runRefresh(c, s.cmd, "riak", "--path", myriakPath)
 	c.Assert(err, jc.ErrorIsNil)
@@ -955,7 +954,7 @@ func (s *RefreshSuccessStateSuite) TestSwitchToLocal(c *gc.C) {
 	myriakPath := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "riak")
 
 	// Change the revision to 42 and upgrade to it with explicit revision.
-	err := ioutil.WriteFile(path.Join(myriakPath, "revision"), []byte("42"), 0644)
+	err := os.WriteFile(path.Join(myriakPath, "revision"), []byte("42"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = s.runRefresh(c, s.cmd, "riak", "--switch", myriakPath)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/application/utils/utils.go
+++ b/cmd/juju/application/utils/utils.go
@@ -6,7 +6,6 @@ package utils
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/mattn/go-isatty"
@@ -168,7 +167,7 @@ func ReadValue(ctx *cmd.Context, filesystem modelcmd.Filesystem, filename string
 	if fi.Size() > maxValueSize {
 		return "", errors.Errorf("size of option file is larger than 5M")
 	}
-	content, err := ioutil.ReadFile(ctx.AbsPath(filename))
+	content, err := os.ReadFile(ctx.AbsPath(filename))
 	if err != nil {
 		return "", errors.Errorf("cannot read option from file %q: %v", filename, err)
 	}

--- a/cmd/juju/backups/create_test.go
+++ b/cmd/juju/backups/create_test.go
@@ -5,7 +5,7 @@ package backups_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -65,7 +65,7 @@ func (s *createSuite) setFailure(failure string) *fakeAPIClient {
 
 func (s *createSuite) setDownload() *fakeAPIClient {
 	client := s.setSuccess()
-	client.archive = ioutil.NopCloser(bytes.NewBufferString(s.data))
+	client.archive = io.NopCloser(bytes.NewBufferString(s.data))
 	return client
 }
 

--- a/cmd/juju/backups/package_test.go
+++ b/cmd/juju/backups/package_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -126,7 +125,7 @@ func (s *BaseBackupsSuite) setFailure(failure string) *fakeAPIClient {
 
 func (s *BaseBackupsSuite) setDownload() *fakeAPIClient {
 	client := s.setSuccess()
-	client.archive = ioutil.NopCloser(bytes.NewBufferString(s.data))
+	client.archive = io.NopCloser(bytes.NewBufferString(s.data))
 	return client
 }
 
@@ -155,7 +154,7 @@ func (s *BaseBackupsSuite) checkArchive(c *gc.C) {
 		}
 	})
 
-	data, err := ioutil.ReadAll(archive)
+	data, err := io.ReadAll(archive)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(data), gc.Equals, s.data)
 }

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -8,7 +8,6 @@ import (
 	stdcontext "context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -368,7 +367,7 @@ func getStdinPipe(ctx *cmd.Context) (io.Reader, error) {
 		if err != nil {
 			return nil, err
 		}
-		content, err := ioutil.ReadAll(stdIn)
+		content, err := io.ReadAll(stdIn)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -5,7 +5,6 @@ package caas_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -272,7 +271,7 @@ func (s *addCAASSuite) setupBroker(c *gc.C) *gomock.Controller {
 }
 
 func CreateKubeConfigData(conf string) (string, error) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -342,7 +341,7 @@ func (s *addCAASSuite) SetUpTest(c *gc.C) {
 
 func (s *addCAASSuite) writeTempKubeConfig(c *gc.C) {
 	fullpath := filepath.Join(s.dir, "empty-config")
-	err := ioutil.WriteFile(fullpath, []byte(""), 0644)
+	err := os.WriteFile(fullpath, []byte(""), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	os.Setenv("KUBECONFIG", fullpath)
 }

--- a/cmd/juju/caas/aks_test.go
+++ b/cmd/juju/caas/aks_test.go
@@ -6,7 +6,7 @@ package caas
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +44,7 @@ func (s *aksSuite) TestGetKubeConfig(c *gc.C) {
 	aks := &aks{
 		CommandRunner: mockRunner,
 	}
-	err = ioutil.WriteFile(configFile, []byte("data"), 0644)
+	err = os.WriteFile(configFile, []byte("data"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	gomock.InOrder(
@@ -66,7 +66,7 @@ func (s *aksSuite) TestGetKubeConfig(c *gc.C) {
 	defer rdr.Close()
 
 	c.Assert(clusterName, gc.Equals, "mycluster")
-	data, err := ioutil.ReadAll(rdr)
+	data, err := io.ReadAll(rdr)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.DeepEquals, "data")
 }
@@ -127,7 +127,7 @@ func (s *aksSuite) TestInteractiveParam(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -200,7 +200,7 @@ func (s *aksSuite) TestInteractiveParamResourceGroupDefined(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -277,7 +277,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedSingleResourceGr
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -354,7 +354,7 @@ func (s *aksSuite) TestInteractiveParamsNoResourceGroupSpecifiedMultiResourceGro
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -430,7 +430,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := ""
@@ -528,7 +528,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedNoResourceGroupSpecified
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -586,7 +586,7 @@ func (s *aksSuite) TestInteractiveParamsClusterSpecifiedResourceGroupSpecified(c
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := ""

--- a/cmd/juju/caas/eks_test.go
+++ b/cmd/juju/caas/eks_test.go
@@ -5,7 +5,7 @@ package caas
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +45,7 @@ func (s *eksSuite) TestGetKubeConfig(c *gc.C) {
 		tool:          "eksctl",
 		CommandRunner: mockRunner,
 	}
-	err = ioutil.WriteFile(configFile, []byte("data"), 0644)
+	err = os.WriteFile(configFile, []byte("data"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	gomock.InOrder(
@@ -67,7 +67,7 @@ func (s *eksSuite) TestGetKubeConfig(c *gc.C) {
 	defer rdr.Close()
 
 	c.Assert(clusterName, gc.Equals, "mycluster.ap-southeast-2.eksctl.io")
-	data, err := ioutil.ReadAll(rdr)
+	data, err := io.ReadAll(rdr)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.DeepEquals, "data")
 }
@@ -104,7 +104,7 @@ func (s *eksSuite) TestInteractiveParam(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -147,7 +147,7 @@ func (s *eksSuite) TestInteractiveParamNoClusterFound(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -195,7 +195,7 @@ func (s *eksSuite) TestInteractiveParamMultiClustersLegacyCLI(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -262,7 +262,7 @@ func (s *eksSuite) TestInteractiveParamMultiClusters(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `

--- a/cmd/juju/caas/gke_test.go
+++ b/cmd/juju/caas/gke_test.go
@@ -5,7 +5,7 @@ package caas
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,7 +73,7 @@ func (s *gkeSuite) TestInteractiveParams(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -127,7 +127,7 @@ func (s *gkeSuite) TestInteractiveParamsProjectSpecified(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -175,7 +175,7 @@ func (s *gkeSuite) TestInteractiveParamsProjectAndRegionSpecified(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  stdin,
 	}
 	expected := `
@@ -218,7 +218,7 @@ func (s *gkeSuite) TestGetKubeConfig(c *gc.C) {
 	err := os.Setenv("KUBECONFIG", configFile)
 	c.Assert(err, jc.ErrorIsNil)
 	gke := &gke{CommandRunner: mockRunner}
-	err = ioutil.WriteFile(configFile, []byte("data"), 0644)
+	err = os.WriteFile(configFile, []byte("data"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	gomock.InOrder(
@@ -242,7 +242,7 @@ func (s *gkeSuite) TestGetKubeConfig(c *gc.C) {
 	defer rdr.Close()
 
 	c.Assert(clusterName, gc.Equals, "gke_myproject_asia-southeast1-a_mycluster")
-	data, err := ioutil.ReadAll(rdr)
+	data, err := io.ReadAll(rdr)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.DeepEquals, "data")
 }

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -6,7 +6,7 @@ package cloud
 import (
 	stdcontext "context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -481,7 +481,7 @@ func (c *AddCloudCommand) runInteractive(ctxt *cmd.Context) (*jujucloud.Cloud, e
 	// VerifyCertFile will return true if the schema format type "cert-filename" is used
 	// and the value is readable and a valid cert file.
 	pollster.VerifyCertFile = func(s string) (bool, string, error) {
-		out, err := ioutil.ReadFile(s)
+		out, err := os.ReadFile(s)
 		if err != nil {
 			return false, "Can't validate CA Certificate file: " + err.Error(), nil
 		}
@@ -534,7 +534,7 @@ func addCertificate(data []byte) (string, []byte, error) {
 	}
 	filename := name.(string)
 	if ok && filename != "" {
-		out, err := ioutil.ReadFile(filename)
+		out, err := os.ReadFile(filename)
 		if err != nil {
 			return filename, nil, err
 		}

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -524,7 +523,7 @@ func (*addSuite) TestInteractive(c *gc.C) {
 	ctx := &cmd.Context{
 		Dir:    c.MkDir(),
 		Stdout: out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin:  &bytes.Buffer{},
 	}
 	err = command.Run(ctx)
@@ -562,7 +561,7 @@ func (*addSuite) TestInteractiveMaas(c *gc.C) {
 
 	out := &bytes.Buffer{}
 	ctx := &cmd.Context{
-		Stdout: ioutil.Discard,
+		Stdout: io.Discard,
 		Stderr: out,
 		Stdin: strings.NewReader("" +
 			/* Select cloud type: */ "maas\n" +
@@ -645,8 +644,8 @@ func (*addSuite) TestInteractiveManualInvalidName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
-		Stdout: ioutil.Discard,
-		Stderr: ioutil.Discard,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
 		Stdin: strings.NewReader("" +
 			/* Select cloud type: */ "manual\n" +
 			/* Enter a name for the cloud: */ manCloud.Name + "\n",
@@ -696,7 +695,7 @@ func (*addSuite) TestInteractiveVSphere(c *gc.C) {
 	var stdout bytes.Buffer
 	ctx := &cmd.Context{
 		Stdout: &stdout,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin: strings.NewReader("" +
 			/* Select cloud type: */ "vsphere\n" +
 			/* Enter a name for the cloud: */ "mvs\n" +
@@ -739,8 +738,8 @@ func (*addSuite) TestInteractiveExistingNameOverride(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := &cmd.Context{
-		Stdout: ioutil.Discard,
-		Stderr: ioutil.Discard,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
 		Stdin: strings.NewReader("" +
 			/* Select cloud type: */ "manual\n" +
 			/* Enter a name for the cloud: */ "homestack\n" +
@@ -778,7 +777,7 @@ func (*addSuite) TestInteractiveExistingNameNoOverride(c *gc.C) {
 	var out bytes.Buffer
 	ctx := &cmd.Context{
 		Stdout: &out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin: strings.NewReader("" +
 			/* Select cloud type: */ "manual\n" +
 			/* Enter a name for the cloud: */ "homestack" + "\n" +
@@ -810,7 +809,7 @@ func (s *addSuite) TestInteractiveAddCloud_PromptForNameIsCorrect(c *gc.C) {
 	var out bytes.Buffer
 	ctx := &cmd.Context{
 		Stdout: &out,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdin: strings.NewReader("" +
 			/* Select cloud type: */ "manual\n",
 		),
@@ -998,7 +997,7 @@ func (*addSuite) TestInteractiveOpenstackCloudCertFail(c *gc.C) {
 	fakeCertFilename := path.Join(fakeCertDir, "cloudcert.crt")
 
 	invalidCertFilename := path.Join(fakeCertDir, "invalid.crt")
-	ioutil.WriteFile(invalidCertFilename, []byte("testing certification validation"), 0666)
+	os.WriteFile(invalidCertFilename, []byte("testing certification validation"), 0666)
 
 	input := fmt.Sprintf(""+
 		/* Select cloud type: */ "openstack\n"+
@@ -1091,7 +1090,7 @@ func (*addOpenStackSuite) TestInteractiveOpenstackCloudCertEnvVar(c *gc.C) {
 
 func testInteractiveOpenstackCloudCert(c *gc.C, fakeCertFilename, input, addStdErrMsg, stdOutMsg string) {
 	fakeCert := testing.CACert
-	ioutil.WriteFile(fakeCertFilename, []byte(fakeCert), 0666)
+	os.WriteFile(fakeCertFilename, []byte(fakeCert), 0666)
 
 	myOpenstack := jujucloud.Cloud{
 		Name:      "os1",

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -6,7 +6,7 @@ package cloud
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd/v3"
@@ -224,7 +224,7 @@ func (c *addCredentialCommand) Run(ctxt *cmd.Context) error {
 	if c.Region == "" {
 		c.Region = existingCredentials.DefaultRegion
 	}
-	data, err := ioutil.ReadFile(c.CredentialsFile)
+	data, err := os.ReadFile(c.CredentialsFile)
 	if err != nil {
 		return errors.Annotate(err, "reading credentials file")
 	}
@@ -691,7 +691,7 @@ func enterFile(name, descr string, p *interact.Pollster, expanded, optional bool
 	}
 
 	// Expand the file path to consume the contents
-	contents, err := ioutil.ReadFile(abs)
+	contents, err := os.ReadFile(abs)
 	return string(contents), errors.Trace(err)
 }
 

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -6,7 +6,6 @@ package cloud_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -133,7 +132,7 @@ credentials:
 func (s *addCredentialSuite) createTestCredentialFile(c *gc.C, content string) string {
 	dir := c.MkDir()
 	credsFile := filepath.Join(dir, "cred.yaml")
-	err := ioutil.WriteFile(credsFile, []byte(content), 0600)
+	err := os.WriteFile(credsFile, []byte(content), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	return credsFile
 }
@@ -141,7 +140,7 @@ func (s *addCredentialSuite) createTestCredentialFile(c *gc.C, content string) s
 func (s *addCredentialSuite) TestAddFromFileWithInvalidCredentialNames(c *gc.C) {
 	dir := c.MkDir()
 	sourceFile := filepath.Join(dir, "cred.yaml")
-	err := ioutil.WriteFile(sourceFile, []byte(`
+	err := os.WriteFile(sourceFile, []byte(`
 credentials:
   somecloud:
     credential with spaces:
@@ -218,7 +217,7 @@ credentials:
       username: user
       password: password
 `[1:]
-	err := ioutil.WriteFile(credsFile, []byte(data), 0600)
+	err := os.WriteFile(credsFile, []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	return credsFile
 }
@@ -624,7 +623,7 @@ Replace local credential? (y/N):
 func (s *addCredentialSuite) assertAddFileCredential(c *gc.C, input, fileKey string) {
 	dir := c.MkDir()
 	filename := filepath.Join(dir, "jsonfile")
-	err := ioutil.WriteFile(filename, []byte{}, 0600)
+	err := os.WriteFile(filename, []byte{}, 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	stdin := strings.NewReader(fmt.Sprintf(input, filename))

--- a/cmd/juju/cloud/list_test.go
+++ b/cmd/juju/cloud/list_test.go
@@ -5,7 +5,7 @@ package cloud_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -320,7 +320,7 @@ clouds:
       london:
         endpoint: http://london/1.0
 `[1:]
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmd := cloud.NewListCloudCommandForTest(
@@ -348,7 +348,7 @@ clouds:
     auth-types: [access-key]
     endpoint: http://custom
 `[1:]
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx, err := cmdtesting.RunCommand(c, cloud.NewListCloudCommandForTest(s.store, nil), "--format", "yaml", "--client")

--- a/cmd/juju/cloud/regions_test.go
+++ b/cmd/juju/cloud/regions_test.go
@@ -4,7 +4,7 @@
 package cloud_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd/v3"
@@ -48,7 +48,7 @@ clouds:
       paris:
          endpoint: "http://paris/1.0"
 `[1:]
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/cloud/remove_test.go
+++ b/cmd/juju/cloud/remove_test.go
@@ -4,7 +4,7 @@
 package cloud_test
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -74,7 +74,7 @@ func (s *removeSuite) TestRemoveNotFound(c *gc.C) {
 }
 
 func (s *removeSuite) createTestCloudData(c *gc.C) {
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("public-clouds.yaml"), []byte(`
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("public-clouds.yaml"), []byte(`
 clouds:
   prodstack:
     type: openstack
@@ -87,7 +87,7 @@ clouds:
 `[1:]), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = ioutil.WriteFile(osenv.JujuXDGDataHomePath("credentials.yaml"), []byte(`
+	err = os.WriteFile(osenv.JujuXDGDataHomePath("credentials.yaml"), []byte(`
 credentials:
   prodstack2:
     cred-name:
@@ -97,7 +97,7 @@ credentials:
 `[1:]), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(`
+	err = os.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(`
 clouds:
   homestack:
     type: openstack

--- a/cmd/juju/cloud/show_test.go
+++ b/cmd/juju/cloud/show_test.go
@@ -4,7 +4,7 @@
 package cloud_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -239,7 +239,7 @@ clouds:
       bootstrap-timeout: 1800
       use-default-secgroup: true
 `[1:]
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client")
 	c.Assert(err, jc.ErrorIsNil)
@@ -302,7 +302,7 @@ clouds:
       london:
         bootstrap-timeout: 1800
 `[1:]
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--include-config", "--client")
 	c.Assert(err, jc.ErrorIsNil)
@@ -393,7 +393,7 @@ ca-credentials:
 `[1:]
 
 func (s *showSuite) TestShowWithCACertificate(c *gc.C) {
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(yamlWithCert), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(yamlWithCert), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx, err := cmdtesting.RunCommand(c, cloud.NewShowCloudCommand(), "homestack", "--client")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/cloud/updatecloud_test.go
+++ b/cmd/juju/cloud/updatecloud_test.go
@@ -4,7 +4,7 @@
 package cloud_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -73,7 +73,7 @@ func (s *updateCloudSuite) setupCloudFileScenario(c *gc.C, yamlFile string, apiF
 }
 
 func (s *updateCloudSuite) createLocalCacheFile(c *gc.C) {
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("public-clouds.yaml"), []byte(garageMaasYamlFile), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("public-clouds.yaml"), []byte(garageMaasYamlFile), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/cloud/updatecredential.go
+++ b/cmd/juju/cloud/updatecredential.go
@@ -5,7 +5,7 @@ package cloud
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
@@ -193,7 +193,7 @@ func (c *updateCredentialCommand) Run(ctx *cmd.Context) error {
 }
 
 func credentialsFromFile(credentialsFile, cloudName, credentialName string) (map[string]jujucloud.CloudCredential, error) {
-	data, err := ioutil.ReadFile(credentialsFile)
+	data, err := os.ReadFile(credentialsFile)
 	if err != nil {
 		return nil, errors.Annotate(err, "reading credentials file")
 	}

--- a/cmd/juju/cloud/updatecredential_test.go
+++ b/cmd/juju/cloud/updatecredential_test.go
@@ -5,7 +5,6 @@ package cloud_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -70,7 +69,7 @@ func (s *updateCredentialSuite) TestBadFileSpecified(c *gc.C) {
 func (s *updateCredentialSuite) makeCredentialsTestFile(c *gc.C, data string) string {
 	dir := c.MkDir()
 	credsFile := filepath.Join(dir, "cred.yaml")
-	err := ioutil.WriteFile(credsFile, []byte(data), 0644)
+	err := os.WriteFile(credsFile, []byte(data), 0644)
 	c.Assert(err, gc.IsNil)
 	return credsFile
 }
@@ -299,7 +298,7 @@ credentials:
 }
 
 func (s *updateCredentialSuite) TestUpdateRemoteCredentialWithFilePath(c *gc.C) {
-	tmpFile, err := ioutil.TempFile("", "juju-bootstrap-test")
+	tmpFile, err := os.CreateTemp("", "juju-bootstrap-test")
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		tmpFile.Close()
@@ -330,7 +329,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteCredentialWithFilePath(c *gc.C) 
 	}
 
 	contents := []byte("{something: special}\n")
-	err = ioutil.WriteFile(tmpFile.Name(), contents, 0644)
+	err = os.WriteFile(tmpFile.Name(), contents, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Double check credential from local cache does not contain contents. We expect it to be file path.
@@ -349,7 +348,7 @@ func (s *updateCredentialSuite) TestUpdateRemoteCredentialWithFilePath(c *gc.C) 
 }
 
 func (s *updateCredentialSuite) TestUpdateLocalCredentialWithFilePath(c *gc.C) {
-	tmpFile, err := ioutil.TempFile("", "juju-bootstrap-test")
+	tmpFile, err := os.CreateTemp("", "juju-bootstrap-test")
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		tmpFile.Close()
@@ -374,7 +373,7 @@ func (s *updateCredentialSuite) TestUpdateLocalCredentialWithFilePath(c *gc.C) {
 	}
 
 	contents := []byte("{something: special}\n")
-	err = ioutil.WriteFile(tmpFile.Name(), contents, 0644)
+	err = os.WriteFile(tmpFile.Name(), contents, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	testFile := s.makeCredentialsTestFile(c, fmt.Sprintf(`
@@ -437,7 +436,7 @@ clouds:
     auth-types: [access-key]
     endpoint: http://custom
 `[1:]
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("clouds.yaml"), []byte(data), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.api.clouds = func() (map[names.CloudTag]jujucloud.Cloud, error) {

--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -269,7 +268,7 @@ func (c *updatePublicCloudsCommand) cloudAPI() (updatePublicCloudAPI, error) {
 }
 
 func decodeCheckSignature(r io.Reader, publicKey string) ([]byte, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/juju/commands/bootstrap_interactive_test.go
+++ b/cmd/juju/commands/bootstrap_interactive_test.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -97,7 +97,7 @@ func (BSInteractSuite) TestQueryCloudDefault(c *gc.C) {
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	clouds := []string{"books", "local"}
 
-	cloud, err := queryCloud(clouds, "local", scanner, ioutil.Discard)
+	cloud, err := queryCloud(clouds, "local", scanner, io.Discard)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloud, gc.Equals, "local")
 }
@@ -108,7 +108,7 @@ func (BSInteractSuite) TestInvalidCloud(c *gc.C) {
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	clouds := []string{"books", "local", "bad^cloud"}
 
-	_, err := queryCloud(clouds, "local", scanner, ioutil.Discard)
+	_, err := queryCloud(clouds, "local", scanner, io.Discard)
 	c.Assert(err, gc.ErrorMatches, `cloud name "bad\^cloud" not valid`)
 }
 
@@ -149,7 +149,7 @@ func (BSInteractSuite) TestQueryRegionDefault(c *gc.C) {
 		{Name: "jupiter-central"},
 	}
 
-	region, err := queryRegion("goggles", regions, scanner, ioutil.Discard)
+	region, err := queryRegion("goggles", regions, scanner, io.Discard)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(region, gc.Equals, regions[0].Name)
 }
@@ -173,7 +173,7 @@ func (BSInteractSuite) TestQueryNameDefault(c *gc.C) {
 	input := "\n"
 
 	scanner := bufio.NewScanner(strings.NewReader(input))
-	name, err := queryName("default-cloud", scanner, ioutil.Discard)
+	name, err := queryName("default-cloud", scanner, io.Discard)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(name, gc.Equals, "default-cloud")
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -8,7 +8,6 @@ import (
 	stdcontext "context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -698,7 +697,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsProcessedAttributes(c *
 	})
 
 	fakeSSHFile := filepath.Join(c.MkDir(), "ssh")
-	err := ioutil.WriteFile(fakeSSHFile, []byte("ssh-key"), 0600)
+	err := os.WriteFile(fakeSSHFile, []byte("ssh-key"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
@@ -743,7 +742,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultConfigStripsInheritedAttributes(c *
 	})
 
 	fakeSSHFile := filepath.Join(c.MkDir(), "ssh")
-	err := ioutil.WriteFile(fakeSSHFile, []byte("ssh-key"), 0600)
+	err := os.WriteFile(fakeSSHFile, []byte("ssh-key"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(),
@@ -1610,7 +1609,7 @@ func (s *BootstrapSuite) TestBootstrapProviderFileCredential(c *gc.C) {
 	dummyProvider, err := environs.Provider("dummy")
 	c.Assert(err, jc.ErrorIsNil)
 
-	tmpFile, err := ioutil.TempFile("", "juju-bootstrap-test")
+	tmpFile, err := os.CreateTemp("", "juju-bootstrap-test")
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		tmpFile.Close()
@@ -1619,7 +1618,7 @@ func (s *BootstrapSuite) TestBootstrapProviderFileCredential(c *gc.C) {
 	}()
 
 	contents := []byte("{something: special}\n")
-	err = ioutil.WriteFile(tmpFile.Name(), contents, 0644)
+	err = os.WriteFile(tmpFile.Name(), contents, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	unfinalizedCredential := cloud.NewEmptyCredential()
@@ -1826,7 +1825,7 @@ func (s *BootstrapSuite) TestBootstrapProviderCaseInsensitiveRegionCheck(c *gc.C
 func (s *BootstrapSuite) TestBootstrapConfigFile(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte("controller: not-a-bool\n"), 0644)
+	err := os.WriteFile(configFile, []byte("controller: not-a-bool\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.patchVersionAndSeries(c, "jammy")
@@ -1840,12 +1839,12 @@ func (s *BootstrapSuite) TestBootstrapConfigFile(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapMultipleConfigFiles(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile1 := filepath.Join(tmpdir, "config-1.yaml")
-	err := ioutil.WriteFile(configFile1, []byte(
+	err := os.WriteFile(configFile1, []byte(
 		"controller: not-a-bool\nbroken: Bootstrap\n",
 	), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	configFile2 := filepath.Join(tmpdir, "config-2.yaml")
-	err = ioutil.WriteFile(configFile2, []byte(
+	err = os.WriteFile(configFile2, []byte(
 		"controller: false\n",
 	), 0644)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1869,7 +1868,7 @@ func (s *BootstrapSuite) TestBootstrapMultipleConfigFiles(c *gc.C) {
 func (s *BootstrapSuite) TestBootstrapConfigFileAndAdHoc(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte("controller: not-a-bool\n"), 0644)
+	err := os.WriteFile(configFile, []byte("controller: not-a-bool\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.setupAutoUploadTest(c, "1.8.3", "jammy")
@@ -2245,7 +2244,7 @@ func createToolsSource(c *gc.C, versions []version.Binary) string {
 // resetJujuXDGDataHome restores an new, clean Juju home environment without tools.
 func resetJujuXDGDataHome(c *gc.C) {
 	cloudsPath := cloud.JujuPersonalCloudsPath()
-	err := ioutil.WriteFile(cloudsPath, []byte(`
+	err := os.WriteFile(cloudsPath, []byte(`
 clouds:
     dummy-cloud:
         type: dummy

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -581,7 +580,7 @@ func registerCommands(r commandRegistry) {
 type cloudToCommandAdapter struct{}
 
 func (cloudToCommandAdapter) ReadCloudData(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 func (cloudToCommandAdapter) ParseOneCloud(data []byte) (cloudfile.Cloud, error) {
 	return cloudfile.ParseOneCloud(data)

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -6,7 +6,6 @@ package commands
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -179,7 +178,7 @@ func (s *MainSuite) TestActualRunJujuArgOrder(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("test %d: %v", i, test)
 		badrun(c, 0, test...)
-		content, err := ioutil.ReadFile(logpath)
+		content, err := os.ReadFile(logpath)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(content), gc.Matches, "(.|\n)*running juju(.|\n)*command finished(.|\n)*")
 		err = os.Remove(logpath)

--- a/cmd/juju/commands/plugin_test.go
+++ b/cmd/juju/commands/plugin_test.go
@@ -6,7 +6,6 @@ package commands
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"text/template"
@@ -238,7 +237,7 @@ func (suite *PluginSuite) TestJujuControllerEnvVars(c *gc.C) {
 func (suite *PluginSuite) makePlugin(fullName, script string, perm os.FileMode) {
 	filename := gitjujutesting.HomePath(fullName)
 	content := fmt.Sprintf("#!/bin/bash --norc\n%s", script)
-	ioutil.WriteFile(filename, []byte(content), perm)
+	os.WriteFile(filename, []byte(content), perm)
 }
 
 func (suite *PluginSuite) makeWorkingPlugin(name string, perm os.FileMode) {
@@ -307,5 +306,5 @@ func (suite *PluginSuite) makeFullPlugin(params PluginParams) {
 		params.DependsOn = gitjujutesting.HomePath(params.DependsOn)
 	}
 	t.Execute(content, params)
-	ioutil.WriteFile(filename, content.Bytes(), 0755)
+	os.WriteFile(filename, content.Bytes(), 0755)
 }

--- a/cmd/juju/commands/repl.go
+++ b/cmd/juju/commands/repl.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/chzyer/readline"
@@ -83,7 +83,7 @@ func (c *replCommand) Run(ctx *cmd.Context) error {
 	if c.showHelp {
 		jujuCmd := NewJujuCommand(ctx, "")
 		f := gnuflag.NewFlagSet(c.Info().Name, gnuflag.ContinueOnError)
-		f.SetOutput(ioutil.Discard)
+		f.SetOutput(io.Discard)
 		jujuCmd.SetFlags(f)
 		if err := jujuCmd.Init([]string{"help"}); err != nil {
 			return errors.Trace(err)
@@ -95,7 +95,7 @@ func (c *replCommand) Run(ctx *cmd.Context) error {
 		return nil
 	}
 
-	history, err := ioutil.TempFile("", "juju-repl")
+	history, err := os.CreateTemp("", "juju-repl")
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -132,7 +132,7 @@ func (c *replCommand) Run(ctx *cmd.Context) error {
 		jujuCmd := NewJujuCommandWithStore(ctx, c.store, jujucmd.DefaultLog, "", replHelpHint, nil, false)
 		if c.showHelp {
 			f := gnuflag.NewFlagSet(c.Info().Name, gnuflag.ContinueOnError)
-			f.SetOutput(ioutil.Discard)
+			f.SetOutput(io.Discard)
 			jujuCmd.SetFlags(f)
 			if err := jujuCmd.Init([]string{"help"}); err != nil {
 				return errors.Trace(err)

--- a/cmd/juju/common/authkeys.go
+++ b/cmd/juju/common/authkeys.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -102,7 +101,7 @@ func ReadAuthorizedKeys(ctx *cmd.Context, path string) (string, error) {
 		if !filepath.IsAbs(f) {
 			f = filepath.Join(utils.Home(), ".ssh", f)
 		}
-		data, err := ioutil.ReadFile(f)
+		data, err := os.ReadFile(f)
 		if err != nil {
 			if firstError == nil && !os.IsNotExist(err) {
 				firstError = err

--- a/cmd/juju/common/authkeys_test.go
+++ b/cmd/juju/common/authkeys_test.go
@@ -4,7 +4,6 @@
 package common_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +53,7 @@ func (s *AuthKeysSuite) TestReadAuthorizedKeysErrors(c *gc.C) {
 }
 
 func writeFile(c *gc.C, filename string, contents string) {
-	err := ioutil.WriteFile(filename, []byte(contents), 0644)
+	err := os.WriteFile(filename, []byte(contents), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -78,7 +77,7 @@ func (s *AuthKeysSuite) TestReadAuthorizedKeysClientKeys(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	pubkeyFiles := ssh.PublicKeyFiles()
 	c.Assert(pubkeyFiles, gc.HasLen, 1)
-	data, err := ioutil.ReadFile(pubkeyFiles[0])
+	data, err := os.ReadFile(pubkeyFiles[0])
 	c.Assert(err, jc.ErrorIsNil)
 	prefix := strings.Trim(string(data), "\n") + "\n"
 

--- a/cmd/juju/common/flags.go
+++ b/cmd/juju/common/flags.go
@@ -6,7 +6,7 @@ package common
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd/v3"
@@ -83,7 +83,7 @@ func (f *ConfigFlag) ReadAttrs(ctx *cmd.Context) (map[string]interface{}, error)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		data, err := ioutil.ReadFile(ctx.AbsPath(path))
+		data, err := os.ReadFile(ctx.AbsPath(path))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/cmd/juju/common/flags_test.go
+++ b/cmd/juju/common/flags_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -91,9 +90,9 @@ func (*FlagsSuite) TestConfigFlagReadAttrs(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile1 := filepath.Join(tmpdir, "config-1.yaml")
 	configFile2 := filepath.Join(tmpdir, "config-2.yaml")
-	err := ioutil.WriteFile(configFile1, []byte(`over: "'n'out"`+"\n"), 0644)
+	err := os.WriteFile(configFile1, []byte(`over: "'n'out"`+"\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(configFile2, []byte(`over: "'n'under"`+"\n"), 0644)
+	err = os.WriteFile(configFile2, []byte(`over: "'n'under"`+"\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var f ConfigFlag
@@ -109,7 +108,7 @@ func (*FlagsSuite) TestConfigFlagReadAttrs(c *gc.C) {
 func (*FlagsSuite) TestConfigFlagReadConfigPairs(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	configFile1 := filepath.Join(ctx.Dir, "config-1.yaml")
-	err := ioutil.WriteFile(configFile1, []byte(`over: "'n'out"`+"\n"), 0644)
+	err := os.WriteFile(configFile1, []byte(`over: "'n'out"`+"\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	var f ConfigFlag

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -5,7 +5,7 @@ package controller_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/juju/cmd/v3"
@@ -543,7 +543,7 @@ func (s *AddModelSuite) TestConfigFileValuesPassedThrough(c *gc.C) {
 	}
 	bytes, err := yaml.Marshal(config)
 	c.Assert(err, jc.ErrorIsNil)
-	file, err := ioutil.TempFile(c.MkDir(), "")
+	file, err := os.CreateTemp(c.MkDir(), "")
 	c.Assert(err, jc.ErrorIsNil)
 	file.Write(bytes)
 	file.Close()
@@ -566,7 +566,7 @@ func (s *AddModelSuite) TestConfigFileWithNestedMaps(c *gc.C) {
 
 	bytes, err := yaml.Marshal(config)
 	c.Assert(err, jc.ErrorIsNil)
-	file, err := ioutil.TempFile(c.MkDir(), "")
+	file, err := os.CreateTemp(c.MkDir(), "")
 	c.Assert(err, jc.ErrorIsNil)
 	file.Write(bytes)
 	file.Close()
@@ -587,7 +587,7 @@ func (s *AddModelSuite) TestConfigFileFailsToConform(c *gc.C) {
 	}
 	bytes, err := yaml.Marshal(config)
 	c.Assert(err, jc.ErrorIsNil)
-	file, err := ioutil.TempFile(c.MkDir(), "")
+	file, err := os.CreateTemp(c.MkDir(), "")
 	c.Assert(err, jc.ErrorIsNil)
 	file.Write(bytes)
 	file.Close()
@@ -597,7 +597,7 @@ func (s *AddModelSuite) TestConfigFileFailsToConform(c *gc.C) {
 }
 
 func (s *AddModelSuite) TestConfigFileFormatError(c *gc.C) {
-	file, err := ioutil.TempFile(c.MkDir(), "")
+	file, err := os.CreateTemp(c.MkDir(), "")
 	c.Assert(err, jc.ErrorIsNil)
 	file.Write(([]byte)("not: valid: yaml"))
 	file.Close()
@@ -619,7 +619,7 @@ func (s *AddModelSuite) TestConfigValuePrecedence(c *gc.C) {
 	}
 	bytes, err := yaml.Marshal(config)
 	c.Assert(err, jc.ErrorIsNil)
-	file, err := ioutil.TempFile(c.MkDir(), "")
+	file, err := os.CreateTemp(c.MkDir(), "")
 	c.Assert(err, jc.ErrorIsNil)
 	file.Write(bytes)
 	file.Close()

--- a/cmd/juju/controller/config_test.go
+++ b/cmd/juju/controller/config_test.go
@@ -4,7 +4,7 @@
 package controller_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -241,7 +241,7 @@ func (s *ConfigSuite) TestErrorOnSetting(c *gc.C) {
 
 func writeFile(c *gc.C, name, content string) string {
 	path := filepath.Join(c.MkDir(), name)
-	err := ioutil.WriteFile(path, []byte(content), 0777)
+	err := os.WriteFile(path, []byte(content), 0777)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -624,7 +623,7 @@ func (srv *mockServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	srv.requests = append(srv.requests, r)
-	requestBody, err := ioutil.ReadAll(r.Body)
+	requestBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/juju/interact/query_test.go
+++ b/cmd/juju/interact/query_test.go
@@ -6,7 +6,7 @@ package interact
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/juju/testing"
@@ -22,7 +22,7 @@ var _ = gc.Suite(Suite{})
 
 func (Suite) TestAnswer(c *gc.C) {
 	scanner := bufio.NewScanner(strings.NewReader("hi!\n"))
-	answer, err := QueryVerify("boo: ", scanner, ioutil.Discard, ioutil.Discard, nil)
+	answer, err := QueryVerify("boo: ", scanner, io.Discard, io.Discard, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(answer, gc.Equals, "hi!")
 }
@@ -62,11 +62,11 @@ bob
 		}
 		return false, "No!", nil
 	}
-	answer, err := QueryVerify("boo: ", scanner, ioutil.Discard, ioutil.Discard, verify)
+	answer, err := QueryVerify("boo: ", scanner, io.Discard, io.Discard, verify)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(answer, gc.Equals, "ok!")
 
-	answer, err = QueryVerify("name: ", scanner, ioutil.Discard, ioutil.Discard, nil)
+	answer, err = QueryVerify("name: ", scanner, io.Discard, io.Discard, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(answer, gc.Equals, "bob")
 }

--- a/cmd/juju/model/config_test.go
+++ b/cmd/juju/model/config_test.go
@@ -4,7 +4,7 @@
 package model_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -101,7 +101,7 @@ func (s *ConfigCommandSuite) TestSingleValueOutputFile(c *gc.C) {
 	_, err := s.run(c, "--output", outpath, "special")
 	c.Assert(err, jc.ErrorIsNil)
 
-	output, err := ioutil.ReadFile(outpath)
+	output, err := os.ReadFile(outpath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(output), gc.Equals, "multi\nline\n")
 }
@@ -210,7 +210,7 @@ func (s *ConfigCommandSuite) TestSetAndResetSameKey(c *gc.C) {
 func (s *ConfigCommandSuite) TestSetFromFile(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte("special: extra\n"), 0644)
+	err := os.WriteFile(configFile, []byte("special: extra\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.run(c, "--file", configFile)
@@ -246,7 +246,7 @@ func (s *ConfigCommandSuite) TestSetFromStdin(c *gc.C) {
 func (s *ConfigCommandSuite) TestSetFromFileUsingYAML(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte(`
+	err := os.WriteFile(configFile, []byte(`
 special:
   value: extra
   source: default
@@ -266,7 +266,7 @@ special:
 func (s *ConfigCommandSuite) TestSetFromFileCombined(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte("special: extra\nunknown: bar"), 0644)
+	err := os.WriteFile(configFile, []byte("special: extra\nunknown: bar"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.run(c, "--file", configFile, "unknown=foo")
@@ -281,7 +281,7 @@ func (s *ConfigCommandSuite) TestSetFromFileCombined(c *gc.C) {
 func (s *ConfigCommandSuite) TestSetFromFileCombinedReset(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte("special: extra\nunknown: bar"), 0644)
+	err := os.WriteFile(configFile, []byte("special: extra\nunknown: bar"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.run(c, "--file", configFile, "--reset", "special,name")

--- a/cmd/juju/model/defaults_test.go
+++ b/cmd/juju/model/defaults_test.go
@@ -4,7 +4,7 @@
 package model_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -360,7 +360,7 @@ func (s *DefaultsCommandSuite) TestSetValueWithSlash(c *gc.C) {
 func (s *DefaultsCommandSuite) TestSetFromFile(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte("special: extra\n"), 0644)
+	err := os.WriteFile(configFile, []byte("special: extra\n"), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.run(c, "--file", configFile)
@@ -407,7 +407,7 @@ func (s *DefaultsCommandSuite) TestSetFromStdin(c *gc.C) {
 func (s *DefaultsCommandSuite) TestSetFromFileCombined(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte(`
+	err := os.WriteFile(configFile, []byte(`
 special: extra
 attr: foo`), 0644)
 	c.Assert(err, jc.ErrorIsNil)
@@ -430,7 +430,7 @@ attr: foo`), 0644)
 func (s *DefaultsCommandSuite) TestSetFromFileReset(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte(`
+	err := os.WriteFile(configFile, []byte(`
 special: extra
 attr: foo`), 0644)
 	c.Assert(err, jc.ErrorIsNil)
@@ -452,7 +452,7 @@ attr: foo`), 0644)
 func (s *DefaultsCommandSuite) TestSetFromFileUsingYAML(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte(`
+	err := os.WriteFile(configFile, []byte(`
 special:
   default: meshuggah
 `), 0644)
@@ -478,7 +478,7 @@ special:
 func (s *DefaultsCommandSuite) TestSetFromFileUsingYAMLTargettingController(c *gc.C) {
 	tmpdir := c.MkDir()
 	configFile := filepath.Join(tmpdir, "config.yaml")
-	err := ioutil.WriteFile(configFile, []byte(`
+	err := os.WriteFile(configFile, []byte(`
 special:
   default: meshuggah
   controller: nadir
@@ -514,7 +514,7 @@ func (s *DefaultsCommandSuite) TestSetFromFileUsingYAMLTargettingCloudRegion(c *
 		c.Logf("test %d", i)
 		tmpdir := c.MkDir()
 		configFile := filepath.Join(tmpdir, "config.yaml")
-		err := ioutil.WriteFile(configFile, []byte(`
+		err := os.WriteFile(configFile, []byte(`
 special:
   default: meshuggah
   controller: nadir

--- a/cmd/juju/model/exportbundle_test.go
+++ b/cmd/juju/model/exportbundle_test.go
@@ -5,7 +5,6 @@ package model_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -141,7 +140,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccessFilename(c *gc.C) {
 
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fakeBundle.filename))
-	output, err := ioutil.ReadFile(s.fakeBundle.filename)
+	output, err := os.ReadFile(s.fakeBundle.filename)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(string(output), gc.Equals, "applications:\n"+
 		"  magic:\n"+
@@ -175,7 +174,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleSuccesssOverwriteFilename(c *
 
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fakeBundle.filename))
-	output, err := ioutil.ReadFile(s.fakeBundle.filename)
+	output, err := os.ReadFile(s.fakeBundle.filename)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(string(output), gc.Equals, "fake-data")
 }
@@ -191,7 +190,7 @@ func (s *ExportBundleCommandSuite) TestExportBundleIncludeCharmDefaults(c *gc.C)
 
 	out := cmdtesting.Stdout(ctx)
 	c.Assert(out, gc.Equals, fmt.Sprintf("Bundle successfully exported to %s\n", s.fakeBundle.filename))
-	output, err := ioutil.ReadFile(s.fakeBundle.filename)
+	output, err := os.ReadFile(s.fakeBundle.filename)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(string(output), gc.Equals, "fake-data")
 }

--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -269,7 +268,7 @@ func getDockerDetailsData(path string, osOpen osOpenFunc) (resources.DockerImage
 
 func unMarshalDockerDetails(data io.Reader) (resources.DockerImageDetails, error) {
 	var details resources.DockerImageDetails
-	contents, err := ioutil.ReadAll(data)
+	contents, err := io.ReadAll(data)
 	if err != nil {
 		return details, errors.Trace(err)
 	}

--- a/cmd/juju/resource/deploy_test.go
+++ b/cmd/juju/resource/deploy_test.go
@@ -6,7 +6,6 @@ package resource
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -404,7 +403,7 @@ password: 'hunter2',,
 		if t.fileContents != "" {
 			dir := c.MkDir()
 			resourceValue = path.Join(dir, "details.json")
-			err := ioutil.WriteFile(resourceValue, []byte(t.fileContents), 0600)
+			err := os.WriteFile(resourceValue, []byte(t.fileContents), 0600)
 			c.Assert(err, jc.ErrorIsNil)
 			deps.data = []byte(t.fileContents)
 		}
@@ -532,7 +531,7 @@ func (s DeploySuite) TestGetDockerDetailsData(c *gc.C) {
 
 	dir := c.MkDir()
 	yamlFile := path.Join(dir, "actually-yaml-file")
-	err = ioutil.WriteFile(yamlFile, []byte("registrypath: mariadb/mariadb:10.2"), 0600)
+	err = os.WriteFile(yamlFile, []byte("registrypath: mariadb/mariadb:10.2"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	result, err = getDockerDetailsData(yamlFile, fs.Open)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/romulus/listplans/list_plans.go
+++ b/cmd/juju/romulus/listplans/list_plans.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
@@ -219,7 +218,7 @@ type descriptionModel struct {
 
 // readPlan reads, parses and returns a planModel struct representation.
 func readPlan(r io.Reader) (plan *planModel, err error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return
 	}

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -4,7 +4,6 @@
 package space_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -247,7 +246,7 @@ space2
 		s.AssertRunSucceeds(c, "", "", args...)
 		assertAPICalls()
 
-		data, err := ioutil.ReadFile(outFile)
+		data, err := os.ReadFile(outFile)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), gc.Equals, expected)
 
@@ -264,7 +263,7 @@ space2
 
 		// Write something in outFile2 to verify its contents are
 		// overwritten.
-		err = ioutil.WriteFile(outFile2, []byte("some contents"), 0644)
+		err = os.WriteFile(outFile2, []byte("some contents"), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 
 		args = makeArgs(format, short, "-o", outFile1, "--output", outFile2)
@@ -272,7 +271,7 @@ space2
 		// Check only the last output file was used, and the output
 		// file was overwritten.
 		c.Assert(outFile1, jc.DoesNotExist)
-		data, err = ioutil.ReadFile(outFile2)
+		data, err = os.ReadFile(outFile2)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), gc.Equals, expected)
 		assertAPICalls()

--- a/cmd/juju/ssh/scp_unix_test.go
+++ b/cmd/juju/ssh/scp_unix_test.go
@@ -7,7 +7,7 @@
 package ssh
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -207,7 +207,7 @@ func (s *SCPSuiteLegacy) TestSCPCommand(c *gc.C) {
 			// installed by SSHMachineSuite generates.
 			c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
 			c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
-			actual, err := ioutil.ReadFile(filepath.Join(s.binDir, "scp.args"))
+			actual, err := os.ReadFile(filepath.Join(s.binDir, "scp.args"))
 			c.Assert(err, jc.ErrorIsNil)
 			t.expected.check(c, string(actual))
 		}

--- a/cmd/juju/ssh/ssh_machine.go
+++ b/cmd/juju/ssh/ssh_machine.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -313,7 +312,7 @@ func (c *sshMachine) generateKnownHosts(targets []*resolvedTarget) (string, erro
 		return "", nil
 	}
 
-	f, err := ioutil.TempFile("", "ssh_known_hosts")
+	f, err := os.CreateTemp("", "ssh_known_hosts")
 	if err != nil {
 		return "", errors.Annotate(err, "creating known hosts file")
 	}

--- a/cmd/juju/subnet/list_test.go
+++ b/cmd/juju/subnet/list_test.go
@@ -4,7 +4,6 @@
 package subnet_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -168,7 +167,7 @@ subnets:
 		s.AssertRunSucceeds(c, "", "", args...)
 		assertAPICalls()
 
-		data, err := ioutil.ReadFile(outFile)
+		data, err := os.ReadFile(outFile)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), gc.Equals, expected)
 
@@ -183,7 +182,7 @@ subnets:
 		defer os.Remove(outFile2)
 		// Write something in outFile2 to verify its contents are
 		// overwritten.
-		err = ioutil.WriteFile(outFile2, []byte("some contents"), 0644)
+		err = os.WriteFile(outFile2, []byte("some contents"), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 
 		args = makeArgs(format, "-o", outFile1, "--output", outFile2)
@@ -191,7 +190,7 @@ subnets:
 		// Check only the last output file was used, and the output
 		// file was overwritten.
 		c.Assert(outFile1, jc.DoesNotExist)
-		data, err = ioutil.ReadFile(outFile2)
+		data, err = os.ReadFile(outFile2)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), gc.Equals, expected)
 		assertAPICalls()

--- a/cmd/juju/waitfor/query/query_test.go
+++ b/cmd/juju/waitfor/query/query_test.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
@@ -27,7 +27,7 @@ func (s *querySuite) TestSuccess(c *gc.C) {
 
 	scope := NewMockScope(ctrl)
 
-	res, err := ioutil.ReadFile("./testfiles/success")
+	res, err := os.ReadFile("./testfiles/success")
 	c.Assert(err, jc.ErrorIsNil)
 
 	buf := bufio.NewReader(bytes.NewBuffer(res))
@@ -57,7 +57,7 @@ func (s *querySuite) TestFailure(c *gc.C) {
 
 	scope := NewMockScope(ctrl)
 
-	res, err := ioutil.ReadFile("./testfiles/failure")
+	res, err := os.ReadFile("./testfiles/failure")
 	c.Assert(err, jc.ErrorIsNil)
 
 	buf := bufio.NewReader(bytes.NewBuffer(res))

--- a/cmd/jujuc/main.go
+++ b/cmd/jujuc/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -79,7 +79,7 @@ func getSocket() (sockets.Socket, error) {
 	if err != nil {
 		return sockets.Socket{}, err
 	}
-	caCert, err := ioutil.ReadFile(caCertFile)
+	caCert, err := os.ReadFile(caCertFile)
 	if err != nil {
 		return sockets.Socket{}, errors.Annotatef(err, "reading %s", caCertFile)
 	}
@@ -152,7 +152,7 @@ func hookToolMain(commandName string, ctx *cmd.Context, args []string) (code int
 	var resp exec.ExecResponse
 	err = client.Call("Jujuc.Main", req, &resp)
 	if err != nil && err.Error() == ErrNoStdinStr {
-		req.Stdin, err = ioutil.ReadAll(os.Stdin)
+		req.Stdin, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			err = errors.Annotate(err, "cannot read stdin")
 			return

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	stdcontext "context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -149,7 +148,7 @@ var (
 
 // Run initializes state for an environment.
 func (c *BootstrapCommand) Run(_ *cmd.Context) error {
-	bootstrapParamsData, err := ioutil.ReadFile(c.BootstrapParamsFile)
+	bootstrapParamsData, err := os.ReadFile(c.BootstrapParamsFile)
 	if err != nil {
 		return errors.Annotate(err, "reading bootstrap params file")
 	}
@@ -517,7 +516,7 @@ func (c *BootstrapCommand) populateTools(st *state.State) error {
 		return errors.Trace(err)
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(
+	data, err := os.ReadFile(filepath.Join(
 		agenttools.SharedToolsDir(dataDir, current),
 		"tools.tar.gz",
 	))

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -137,7 +136,7 @@ func (s *BootstrapSuite) SetUpTest(c *gc.C) {
 	toolsDir := filepath.FromSlash(agenttools.SharedToolsDir(s.dataDir, current))
 	err := os.MkdirAll(toolsDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(toolsDir, "tools.tar.gz"), nil, 0644)
+	err = os.WriteFile(filepath.Join(toolsDir, "tools.tar.gz"), nil, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	s.writeDownloadedTools(c, &tools.Tools{Version: current})
 
@@ -161,7 +160,7 @@ func (s *BootstrapSuite) writeDownloadedTools(c *gc.C, tools *tools.Tools) {
 	c.Assert(err, jc.ErrorIsNil)
 	data, err := json.Marshal(tools)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(toolsDir, "downloaded-tools.txt"), data, 0644)
+	err = os.WriteFile(filepath.Join(toolsDir, "downloaded-tools.txt"), data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -659,7 +658,7 @@ func (s *BootstrapSuite) TestSystemIdentityWritten(c *gc.C) {
 	err = cmd.Run(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	data, err := ioutil.ReadFile(filepath.Join(s.dataDir, agent.SystemIdentity))
+	data, err := os.ReadFile(filepath.Join(s.dataDir, agent.SystemIdentity))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, "private-key")
 }
@@ -838,15 +837,15 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 func (s *BootstrapSuite) writeBootstrapParamsFile(c *gc.C) {
 	data, err := s.bootstrapParams.Marshal()
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(s.bootstrapParamsFile, data, 0600)
+	err = os.WriteFile(s.bootstrapParamsFile, data, 0600)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func nullContext() environs.BootstrapContext {
 	ctx, _ := cmd.DefaultContext()
 	ctx.Stdin = io.LimitReader(nil, 0)
-	ctx.Stdout = ioutil.Discard
-	ctx.Stderr = ioutil.Discard
+	ctx.Stdout = io.Discard
+	ctx.Stderr = io.Discard
 	return modelcmd.BootstrapContext(context.Background(), ctx)
 }
 

--- a/cmd/jujud/agent/caasoperator_test.go
+++ b/cmd/jujud/agent/caasoperator_test.go
@@ -4,7 +4,6 @@
 package agent
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -165,7 +164,7 @@ func (s *CAASOperatorSuite) TestRunCopiesConfigTemplate(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	templateFile := filepath.Join(agentDir, "template-agent.conf")
 
-	err = ioutil.WriteFile(templateFile, []byte(agentConfigContents), 0600)
+	err = os.WriteFile(templateFile, []byte(agentConfigContents), 0600)
 	c.Assert(err, gc.IsNil)
 
 	a := &CaasOperatorAgent{

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	stdcontext "context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1059,7 +1058,7 @@ func (s *MachineSuite) testCertificateDNSUpdated(c *gc.C, a *MachineAgent) {
 	c.Check(expectedDnsNames.Difference(certDnsNames).IsEmpty(), jc.IsTrue)
 
 	// Check the mongo certificate file too.
-	pemContent, err := ioutil.ReadFile(filepath.Join(s.DataDir(), "server.pem"))
+	pemContent, err := os.ReadFile(filepath.Join(s.DataDir(), "server.pem"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(pemContent), gc.Equals, stateInfo.Cert+"\n"+stateInfo.PrivateKey)
 }

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -5,7 +5,7 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -95,7 +95,7 @@ func (s *commonMachineSuite) assertChannelActive(c *gc.C, aChannel chan struct{}
 }
 
 func fakeCmd(path string) {
-	err := ioutil.WriteFile(path, []byte("#!/bin/bash --norc\nexit 0"), 0755)
+	err := os.WriteFile(path, []byte("#!/bin/bash --norc\nexit 0"), 0755)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/jujud/dumplogs/dumplogs.go
+++ b/cmd/jujud/dumplogs/dumplogs.go
@@ -10,7 +10,6 @@ package dumplogs
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,7 +148,7 @@ func (c *dumpLogsCommand) Run(ctx *cmd.Context) error {
 }
 
 func (c *dumpLogsCommand) findAgentTag(dataDir string) (names.Tag, error) {
-	entries, err := ioutil.ReadDir(agent.BaseDir(dataDir))
+	entries, err := os.ReadDir(agent.BaseDir(dataDir))
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to read agent configuration base directory")
 	}

--- a/cmd/jujud/introspect/introspect_test.go
+++ b/cmd/jujud/introspect/introspect_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -180,7 +180,7 @@ func (s *IntrospectCommandSuite) TestListen(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(body), gc.Equals, "hello")
 }

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -122,7 +121,7 @@ func getSocket() (sockets.Socket, error) {
 	if err != nil {
 		return sockets.Socket{}, err
 	}
-	caCert, err := ioutil.ReadFile(caCertFile)
+	caCert, err := os.ReadFile(caCertFile)
 	if err != nil {
 		return sockets.Socket{}, errors.Annotatef(err, "reading %s", caCertFile)
 	}
@@ -178,7 +177,7 @@ func hookToolMain(commandName string, ctx *cmd.Context, args []string) (code int
 	var resp exec.ExecResponse
 	err = client.Call("Jujuc.Main", req, &resp)
 	if err != nil && err.Error() == jujuc.ErrNoStdin.Error() {
-		req.Stdin, err = ioutil.ReadAll(os.Stdin)
+		req.Stdin, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			err = errors.Annotate(err, "cannot read stdin")
 			return

--- a/cmd/jujud/reboot/reboot.go
+++ b/cmd/jujud/reboot/reboot.go
@@ -5,7 +5,6 @@
 package reboot
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -32,7 +31,7 @@ func runCommand(args []string) error {
 }
 
 var tmpFile = func() (*os.File, error) {
-	f, err := ioutil.TempFile(os.TempDir(), "juju-reboot")
+	f, err := os.CreateTemp(os.TempDir(), "juju-reboot")
 	return f, errors.Trace(err)
 }
 

--- a/cmd/jujud/run/run.go
+++ b/cmd/jujud/run/run.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -199,7 +198,7 @@ func (c *RunCommand) maybeGetUnitTag() (names.UnitTag, error) {
 		dataDir = paths.DataDir(paths.CurrentOS())
 	}
 	agentDir := filepath.Join(dataDir, "agents")
-	files, _ := ioutil.ReadDir(agentDir)
+	files, _ := os.ReadDir(agentDir)
 	var unitTags []names.UnitTag
 	for _, f := range files {
 		if f.IsDir() {
@@ -240,7 +239,7 @@ func (c *RunCommand) getSocket(op *caas.OperatorClientInfo) (sockets.Socket, err
 
 	baseDir := agent.Dir(config.DataDir, c.unit)
 	caCertFile := filepath.Join(baseDir, caas.CACertFile)
-	caCert, err := ioutil.ReadFile(caCertFile)
+	caCert, err := os.ReadFile(caCertFile)
 	if err != nil {
 		return sockets.Socket{}, errors.Annotatef(err, "reading %s", caCertFile)
 	}
@@ -291,7 +290,7 @@ func (c *RunCommand) executeInUnitContext() (*exec.ExecResponse, error) {
 
 	// juju-exec on k8s uses an operator yaml file
 	infoFilePath := filepath.Join(unitDir, caas.OperatorClientInfoFile)
-	infoFileBytes, err := ioutil.ReadFile(infoFilePath)
+	infoFileBytes, err := os.ReadFile(infoFilePath)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, errors.Annotatef(err, "reading %s", infoFilePath)
 	}

--- a/cmd/modelcmd/apicontext_test.go
+++ b/cmd/modelcmd/apicontext_test.go
@@ -5,7 +5,7 @@ package modelcmd_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -92,7 +92,7 @@ func assertClientGet(c *gc.C, client *httpbakery.Client, url string, expectBody 
 	c.Assert(err, jc.ErrorIsNil)
 	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
-	data, _ := ioutil.ReadAll(resp.Body)
+	data, _ := io.ReadAll(resp.Body)
 	c.Assert(string(data), gc.Equals, expectBody)
 }
 

--- a/cmd/modelcmd/base_test.go
+++ b/cmd/modelcmd/base_test.go
@@ -4,7 +4,7 @@
 package modelcmd_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -67,7 +67,7 @@ func (s *BaseCommandSuite) assertUnknownModel(c *gc.C, baseCmd *modelcmd.ModelCo
 	}
 	baseCmd.SetClientStore(s.store)
 	baseCmd.SetAPIOpen(apiOpen)
-	modelcmd.InitContexts(&cmd.Context{Stderr: ioutil.Discard}, baseCmd)
+	modelcmd.InitContexts(&cmd.Context{Stderr: io.Discard}, baseCmd)
 	modelcmd.SetRunStarted(baseCmd)
 	baseCmd.SetModelIdentifier("foo:admin/badmodel", false)
 	conn, err := baseCmd.NewAPIRoot()
@@ -129,7 +129,7 @@ func (s *BaseCommandSuite) TestMigratedModelErrorHandling(c *gc.C) {
 	baseCmd := new(modelcmd.ModelCommandBase)
 	baseCmd.SetClientStore(s.store)
 	baseCmd.SetAPIOpen(apiOpen)
-	modelcmd.InitContexts(&cmd.Context{Stderr: ioutil.Discard}, baseCmd)
+	modelcmd.InitContexts(&cmd.Context{Stderr: io.Discard}, baseCmd)
 	modelcmd.SetRunStarted(baseCmd)
 
 	c.Assert(baseCmd.SetModelIdentifier("foo:admin/badmodel", false), jc.ErrorIsNil)

--- a/cmd/modelcmd/credentials.go
+++ b/cmd/modelcmd/credentials.go
@@ -4,7 +4,7 @@
 package modelcmd
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
@@ -113,7 +113,7 @@ func FinalizeFileContent(credential *cloud.Credential, provider environs.Environ
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return ioutil.ReadFile(f)
+		return os.ReadFile(f)
 	}
 
 	var err error

--- a/cmd/modelcmd/credentials_test.go
+++ b/cmd/modelcmd/credentials_test.go
@@ -5,7 +5,7 @@ package modelcmd_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/golang/mock/gomock"
@@ -92,7 +92,7 @@ func (s *credentialsSuite) SetUpTest(c *gc.C) {
 
 	dir := c.MkDir()
 	keyFile := filepath.Join(dir, "keyfile")
-	err := ioutil.WriteFile(keyFile, []byte("value"), 0600)
+	err := os.WriteFile(keyFile, []byte("value"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.store = jujuclient.NewMemStore()

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -6,7 +6,7 @@ package modelcmd_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/juju/cmd/v3"
@@ -512,7 +512,7 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 func (s *macaroonLoginSuite) newModelCommandBase() *modelcmd.ModelCommandBase {
 	var c modelcmd.ModelCommandBase
 	c.SetClientStore(s.store)
-	modelcmd.InitContexts(&cmd.Context{Stderr: ioutil.Discard}, &c)
+	modelcmd.InitContexts(&cmd.Context{Stderr: io.Discard}, &c)
 	modelcmd.SetRunStarted(&c)
 	err := c.SetModelIdentifier(s.controllerName+":"+s.modelName, false)
 	if err != nil {

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,7 +75,7 @@ func (s *ImageMetadataSuite) assertCommandOutput(c *gc.C, expected expectedMetad
 	strippedOut := strings.Replace(errOut, "\n", "", -1)
 	c.Check(strippedOut, gc.Matches, `Image metadata files have been written to.*`)
 	indexpath := filepath.Join(s.dir, "images", "streams", "v1", indexFileName)
-	data, err := ioutil.ReadFile(indexpath)
+	data, err := os.ReadFile(indexpath)
 	c.Assert(err, jc.ErrorIsNil)
 	content := string(data)
 	var indices interface{}
@@ -92,7 +91,7 @@ func (s *ImageMetadataSuite) assertCommandOutput(c *gc.C, expected expectedMetad
 	c.Assert(content, jc.Contains, fmt.Sprintf(`"path": "streams/v1/%s"`, imageFileName))
 
 	imagepath := filepath.Join(s.dir, "images", "streams", "v1", imageFileName)
-	data, err = ioutil.ReadFile(imagepath)
+	data, err = os.ReadFile(imagepath)
 	c.Assert(err, jc.ErrorIsNil)
 	content = string(data)
 	var images interface{}

--- a/cmd/plugins/juju-metadata/signmetadata.go
+++ b/cmd/plugins/juju-metadata/signmetadata.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,7 +69,7 @@ func (c *signMetadataCommand) Run(context *cmd.Context) error {
 		loggo.INFO)
 	_ = loggo.RegisterWriter("signmetadata", writer)
 	defer func() { _, _ = loggo.RemoveWriter("signmetadata") }()
-	keyData, err := ioutil.ReadFile(c.keyFile)
+	keyData, err := os.ReadFile(c.keyFile)
 	if err != nil {
 		return err
 	}
@@ -99,12 +98,12 @@ func process(dir, key, passphrase string) error {
 			return errors.Errorf("encoding file %q: %v", filename, err)
 		}
 		signedFilename := strings.Replace(filename, simplestreams.UnsignedSuffix, simplestreams.SignedSuffix, -1)
-		if err = ioutil.WriteFile(signedFilename, encoded, 0644); err != nil {
+		if err = os.WriteFile(signedFilename, encoded, 0644); err != nil {
 			return errors.Errorf("writing signed file %q: %v", signedFilename, err)
 		}
 	}
 	// Now process any directories in dir.
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}

--- a/cmd/plugins/juju-metadata/signmetadata_test.go
+++ b/cmd/plugins/juju-metadata/signmetadata_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +52,7 @@ func setupJsonFiles(c *gc.C, topLevel string) {
 	content := []byte("hello world")
 	filenames := makeFileNames(topLevel)
 	for _, filename := range filenames {
-		err = ioutil.WriteFile(filename, content, 0644)
+		err = os.WriteFile(filename, content, 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }
@@ -78,7 +77,7 @@ func assertSignedFiles(c *gc.C, topLevel string) {
 func (s *SignMetadataSuite) TestSignMetadata(c *gc.C) {
 	topLevel := c.MkDir()
 	keyfile := filepath.Join(topLevel, "privatekey.asc")
-	err := ioutil.WriteFile(keyfile, []byte(sstesting.SignedMetadataPrivateKey), 0644)
+	err := os.WriteFile(keyfile, []byte(sstesting.SignedMetadataPrivateKey), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	setupJsonFiles(c, topLevel)
 

--- a/container/broker/broker_test.go
+++ b/container/broker/broker_test.go
@@ -4,8 +4,8 @@
 package broker_test
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/loggo"
@@ -284,7 +284,7 @@ nameserver ns2.dummy
 `
 
 	fakeResolvConf := filepath.Join(c.MkDir(), "fakeresolv.conf")
-	err := ioutil.WriteFile(fakeResolvConf, []byte(fakeConf), 0644)
+	err := os.WriteFile(fakeResolvConf, []byte(fakeConf), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(broker.ResolvConfFiles, []string{fakeResolvConf})
 }

--- a/container/kvm/initialisation_internal_test.go
+++ b/container/kvm/initialisation_internal_test.go
@@ -5,7 +5,6 @@ package kvm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/juju/core/paths"
@@ -23,7 +22,7 @@ type initialisationInternalSuite struct {
 var _ = gc.Suite(&initialisationInternalSuite{})
 
 func (initialisationInternalSuite) TestCreatePool(c *gc.C) {
-	tmpDir, err := ioutil.TempDir("", "juju-initialisationInternalSuite")
+	tmpDir, err := os.MkdirTemp("", "juju-initialisationInternalSuite")
 	defer func() {
 		err = os.RemoveAll(tmpDir)
 		if err != nil {
@@ -47,7 +46,7 @@ func (initialisationInternalSuite) TestCreatePool(c *gc.C) {
 }
 
 func (initialisationInternalSuite) TestStartPool(c *gc.C) {
-	tmpDir, err := ioutil.TempDir("", "juju-initialisationInternalSuite")
+	tmpDir, err := os.MkdirTemp("", "juju-initialisationInternalSuite")
 	defer func() {
 		err = os.RemoveAll(tmpDir)
 		if err != nil {
@@ -71,7 +70,7 @@ func (initialisationInternalSuite) TestStartPool(c *gc.C) {
 }
 
 func (initialisationInternalSuite) TestAutoStartPool(c *gc.C) {
-	tmpDir, err := ioutil.TempDir("", "juju-initialisationInternalSuite")
+	tmpDir, err := os.MkdirTemp("", "juju-initialisationInternalSuite")
 	defer func() {
 		err = os.RemoveAll(tmpDir)
 		if err != nil {

--- a/container/kvm/kvm_test.go
+++ b/container/kvm/kvm_test.go
@@ -5,7 +5,7 @@ package kvm_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -354,7 +354,7 @@ func (s *KVMSuite) TestIsKVMSupportedBinaryErrorsOut(c *gc.C) {
 
 	// Create mocked binary which returns an error and give the test access.
 	tmpDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(tmpDir, "kvm-ok"), []byte("#!/bin/bash\nexit 127"), 0777)
+	err := os.WriteFile(filepath.Join(tmpDir, "kvm-ok"), []byte("#!/bin/bash\nexit 127"), 0777)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(kvm.KVMPath, tmpDir)
 
@@ -370,7 +370,7 @@ func (s *KVMSuite) TestIsKVMSupportedNoPath(c *gc.C) {
 	// developers without kvm-ok.
 	s.PatchEnvironment("PATH", "")
 	tmpDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(tmpDir, "kvm-ok"), []byte("#!/bin/bash"), 0777)
+	err := os.WriteFile(filepath.Join(tmpDir, "kvm-ok"), []byte("#!/bin/bash"), 0777)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(kvm.KVMPath, tmpDir)
 
@@ -384,7 +384,7 @@ func (s *KVMSuite) TestIsKVMSupportedOnlyPath(c *gc.C) {
 	// Create a mocked binary so that this test does not fail for
 	// developers without kvm-ok.
 	tmpDir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(tmpDir, "kvm-ok"), []byte("#!/bin/bash"), 0777)
+	err := os.WriteFile(filepath.Join(tmpDir, "kvm-ok"), []byte("#!/bin/bash"), 0777)
 	c.Check(err, jc.ErrorIsNil)
 	s.PatchEnvironment("PATH", tmpDir)
 

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -291,7 +290,7 @@ func newImage(md *imagedownloads.Metadata, imageDownloadURL string, pathfinder p
 	baseDir := pathfinder(paths.CurrentOS())
 
 	// Closing this is deferred in Image.write.
-	fh, err := ioutil.TempFile("", fmt.Sprintf("juju-kvm-%s-", path.Base(dlURL.String())))
+	fh, err := os.CreateTemp("", fmt.Sprintf("juju-kvm-%s-", path.Base(dlURL.String())))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -6,7 +6,6 @@ package kvm
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -194,7 +193,7 @@ func newTestServer() *httptest.Server {
 // newTmpdir creates a tmpdir and returns pathfinder func that returns the
 // tmpdir.
 func newTmpdir() (string, pathfinderFunc, bool) {
-	td, err := ioutil.TempDir("", "juju-test-kvm-internalSuite")
+	td, err := os.MkdirTemp("", "juju-test-kvm-internalSuite")
 	if err != nil {
 		return "", nil, false
 	}

--- a/container/kvm/wrappedcmds_internal_test.go
+++ b/container/kvm/wrappedcmds_internal_test.go
@@ -5,7 +5,7 @@ package kvm
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/testing"
@@ -26,7 +26,7 @@ func (libvirtInternalSuite) TestWriteMetadata(c *gc.C) {
 
 	err := writeMetadata(d)
 	c.Check(err, jc.ErrorIsNil)
-	b, err := ioutil.ReadFile(filepath.Join(d, metadata))
+	b, err := os.ReadFile(filepath.Join(d, metadata))
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(string(b), gc.Matches, `{"instance-id": ".*-.*-.*-.*"}`)
 }

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -5,7 +5,6 @@ package kvm_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -108,7 +107,7 @@ func (commandWrapperSuite) TestCreateNoHostname(c *gc.C) {
 }
 
 func (commandWrapperSuite) TestCreateMachineSuccess(c *gc.C) {
-	tmpDir, err := ioutil.TempDir("", "juju-libvirtSuite-")
+	tmpDir, err := os.MkdirTemp("", "juju-libvirtSuite-")
 	c.Check(err, jc.ErrorIsNil)
 
 	want := []string{
@@ -126,7 +125,7 @@ func (s *commandWrapperSuite) TestCreateMachineSuccessOnFocal(c *gc.C) {
 		return "focal", nil
 	})
 
-	tmpDir, err := ioutil.TempDir("", "juju-libvirtSuite-")
+	tmpDir, err := os.MkdirTemp("", "juju-libvirtSuite-")
 	c.Check(err, jc.ErrorIsNil)
 
 	want := []string{
@@ -148,7 +147,7 @@ func assertCreateMachineSuccess(c *gc.C, tmpDir string, expCommands []string) {
 	cloudInitPath := filepath.Join(tmpDir, "cloud-init")
 	userDataPath := filepath.Join(tmpDir, "user-data")
 	networkConfigPath := filepath.Join(tmpDir, "network-config")
-	err = ioutil.WriteFile(cloudInitPath, []byte("#cloud-init\nEOF\n"), 0755)
+	err = os.WriteFile(cloudInitPath, []byte("#cloud-init\nEOF\n"), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 
 	defer func() {
@@ -178,11 +177,11 @@ func assertCreateMachineSuccess(c *gc.C, tmpDir string, expCommands []string) {
 	_, err = os.Stat(cloudInitPath)
 	c.Assert(os.IsNotExist(err), jc.IsTrue)
 
-	b, err := ioutil.ReadFile(userDataPath)
+	b, err := os.ReadFile(userDataPath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(b), jc.Contains, "#cloud-init")
 
-	b, err = ioutil.ReadFile(networkConfigPath)
+	b, err = os.ReadFile(networkConfigPath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(b), gc.Equals, "this-is-network-config")
 
@@ -193,15 +192,15 @@ func assertCreateMachineSuccess(c *gc.C, tmpDir string, expCommands []string) {
 }
 
 func (commandWrapperSuite) TestDestroyMachineSuccess(c *gc.C) {
-	tmpDir, err := ioutil.TempDir("", "juju-libvirtSuite-")
+	tmpDir, err := os.MkdirTemp("", "juju-libvirtSuite-")
 	c.Check(err, jc.ErrorIsNil)
 	guestBase := filepath.Join(tmpDir, "kvm", "guests")
 	err = os.MkdirAll(guestBase, 0700)
 	c.Check(err, jc.ErrorIsNil)
 
-	err = ioutil.WriteFile(filepath.Join(guestBase, "aname.qcow"), []byte("diskcontents"), 0700)
+	err = os.WriteFile(filepath.Join(guestBase, "aname.qcow"), []byte("diskcontents"), 0700)
 	c.Check(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(guestBase, "aname-ds.iso"), []byte("diskcontents"), 0700)
+	err = os.WriteFile(filepath.Join(guestBase, "aname-ds.iso"), []byte("diskcontents"), 0700)
 	c.Check(err, jc.ErrorIsNil)
 
 	pathfinder := func(_ paths.OS) string {

--- a/container/testing/common.go
+++ b/container/testing/common.go
@@ -4,7 +4,7 @@
 package testing
 
 import (
-	"io/ioutil"
+	"os"
 
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -76,7 +76,7 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 
 func AssertCloudInit(c *gc.C, filename string) []byte {
 	c.Assert(filename, jc.IsNonEmptyFile)
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), jc.HasPrefix, "#cloud-config\n")
 	return data

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -6,7 +6,7 @@ package controller_test
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	stdtesting "testing"
 	"time"
@@ -665,7 +665,7 @@ func (s *ConfigSuite) TestCAASImageRepo(c *gc.C) {
 				c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2`)
 				resps := &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 				}
 				return resps, nil
 			},
@@ -676,7 +676,7 @@ func (s *ConfigSuite) TestCAASImageRepo(c *gc.C) {
 				c.Assert(req.URL.String(), gc.Equals, `https://registry.foo.com/v2`)
 				resps := &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 				}
 				return resps, nil
 			},
@@ -687,7 +687,7 @@ func (s *ConfigSuite) TestCAASImageRepo(c *gc.C) {
 				c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/v2/`)
 				resps := &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 				}
 				return resps, nil
 			},

--- a/core/auditlog/auditlog_test.go
+++ b/core/auditlog/auditlog_test.go
@@ -4,7 +4,6 @@
 package auditlog_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -61,7 +60,7 @@ func (s *AuditLogSuite) TestAuditLogFile(c *gc.C) {
 	err = logFile.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
-	bytes, err := ioutil.ReadFile(filepath.Join(dir, "audit.log"))
+	bytes, err := os.ReadFile(filepath.Join(dir, "audit.log"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(bytes), gc.Equals, expectedLogContents)
 }

--- a/core/bundle/changes/changes_test.go
+++ b/core/bundle/changes/changes_test.go
@@ -6,7 +6,6 @@ package bundlechanges_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -3559,7 +3558,7 @@ series:
     - focal
     - bionic
 `[1:]
-	err = ioutil.WriteFile(filepath.Join(charmDir, "metadata.yaml"), []byte(charmMeta), 0644)
+	err = os.WriteFile(filepath.Join(charmDir, "metadata.yaml"), []byte(charmMeta), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertLocalBundleChanges(c, charmDir, bundleContent, "jammy")
 	s.assertLocalBundleChangesWithDevices(c, charmDir, bundleContent, "jammy")
@@ -3582,7 +3581,7 @@ series:
     - focal
     - bionic
 `[1:]
-	err := ioutil.WriteFile(filepath.Join(charmDir, "metadata.yaml"), []byte(charmMeta), 0644)
+	err := os.WriteFile(filepath.Join(charmDir, "metadata.yaml"), []byte(charmMeta), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertLocalBundleChanges(c, charmDir, bundleContent, "focal")
 	s.assertLocalBundleChangesWithDevices(c, charmDir, bundleContent, "focal")

--- a/core/charm/downloader/downloader.go
+++ b/core/charm/downloader/downloader.go
@@ -5,7 +5,6 @@ package downloader
 
 import (
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -147,7 +146,7 @@ func (d *Downloader) DownloadAndStore(charmURL *charm.URL, requestedOrigin corec
 	}
 
 	// Download charm blob to a temp file
-	tmpFile, err := ioutil.TempFile("", charmURL.Name)
+	tmpFile, err := os.CreateTemp("", charmURL.Name)
 	if err != nil {
 		return corecharm.Origin{}, errors.Trace(err)
 	}

--- a/core/charm/downloader/downloader_test.go
+++ b/core/charm/downloader/downloader_test.go
@@ -5,8 +5,9 @@ package downloader_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"github.com/golang/mock/gomock"
@@ -123,7 +124,7 @@ func (s *downloaderSuite) TestDownloadAndHash(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	tmpFile := filepath.Join(c.MkDir(), "ubuntu-lite.zip")
-	c.Assert(ioutil.WriteFile(tmpFile, []byte("meshuggah\n"), 0644), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(tmpFile, []byte("meshuggah\n"), 0644), jc.ErrorIsNil)
 
 	curl := charm.MustParseURL("ch:ubuntu-lite")
 	requestedOrigin := corecharm.Origin{Source: corecharm.CharmHub, Channel: mustParseChannel(c, "20.04/edge")}
@@ -234,7 +235,7 @@ func (s downloaderSuite) TestDownloadAndStore(c *gc.C) {
 		func(_ *charm.URL, dc downloader.DownloadedCharm) error {
 			c.Assert(dc.Size, gc.Equals, int64(10))
 
-			contents, err := ioutil.ReadAll(dc.CharmData)
+			contents, err := io.ReadAll(dc.CharmData)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(string(contents), gc.DeepEquals, "meshuggah\n", gc.Commentf("read charm contents do not match the data written to disk"))
 			c.Assert(dc.CharmVersion, gc.Equals, "the-version")
@@ -247,7 +248,7 @@ func (s downloaderSuite) TestDownloadAndStore(c *gc.C) {
 	s.repoGetter.EXPECT().GetCharmRepository(corecharm.CharmHub).Return(repoAdapter{s.repo}, nil)
 	s.repo.EXPECT().DownloadCharm(curl, requestedOriginWithPlatform, macaroons, gomock.Any()).DoAndReturn(
 		func(_ *charm.URL, requestedOrigin corecharm.Origin, _ macaroon.Slice, archivePath string) (downloader.CharmArchive, corecharm.Origin, error) {
-			c.Assert(ioutil.WriteFile(archivePath, []byte("meshuggah\n"), 0644), jc.ErrorIsNil)
+			c.Assert(os.WriteFile(archivePath, []byte("meshuggah\n"), 0644), jc.ErrorIsNil)
 			return s.charmArchive, resolvedOrigin, nil
 		},
 	)

--- a/core/machinelock/machinelock_test.go
+++ b/core/machinelock/machinelock_test.go
@@ -4,7 +4,6 @@
 package machinelock_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -227,7 +226,7 @@ func (s *lockSuite) TestLogfileOutput(c *gc.C) {
 	s.addHistory(c, "uniter", "update-status", "2018-07-21 15:42:11", time.Second, short)
 	s.addHistory(c, "uniter", "update-status", "2018-07-21 15:47:13", time.Second, short)
 
-	content, err := ioutil.ReadFile(s.logfile)
+	content, err := os.ReadFile(s.logfile)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(string(content), gc.Equals, `

--- a/core/network/dns_test.go
+++ b/core/network/dns_test.go
@@ -5,7 +5,6 @@ package network_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -43,7 +42,7 @@ func (*dnsSuite) TestParseResolvConfNotReadablePath(c *gc.C) {
 
 func makeResolvConf(c *gc.C, content string, perms os.FileMode) string {
 	fakeConfPath := filepath.Join(c.MkDir(), "fake")
-	err := ioutil.WriteFile(fakeConfPath, []byte(content), perms)
+	err := os.WriteFile(fakeConfPath, []byte(content), perms)
 	c.Check(err, jc.ErrorIsNil)
 	return fakeConfPath
 }

--- a/core/network/source.go
+++ b/core/network/source.go
@@ -4,8 +4,8 @@
 package network
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -106,7 +106,7 @@ func ParseInterfaceType(sysPath, interfaceName string) LinkLayerDeviceType {
 	const deviceType = "DEVTYPE="
 	location := filepath.Join(sysPath, interfaceName, "uevent")
 
-	data, err := ioutil.ReadFile(location)
+	data, err := os.ReadFile(location)
 	if err != nil {
 		logger.Debugf("ignoring error reading %q: %v", location, err)
 		return UnknownDevice

--- a/core/network/source_test.go
+++ b/core/network/source_test.go
@@ -4,7 +4,6 @@
 package network_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +33,7 @@ func (*sourceSuite) TestParseInterfaceType(c *gc.C) {
 
 		fakeUEventPath := filepath.Join(fakeInterfacePath, "uevent")
 		contents := strings.Join(lines, "\n")
-		err = ioutil.WriteFile(fakeUEventPath, []byte(contents), 0644)
+		err = os.WriteFile(fakeUEventPath, []byte(contents), 0644)
 		c.Check(err, jc.ErrorIsNil)
 		return fakeUEventPath
 	}
@@ -84,7 +83,7 @@ func (*sourceSuite) TestGetBridgePorts(c *gc.C) {
 
 		for _, portName := range portNames {
 			portPath := filepath.Join(fakePortsPath, portName)
-			err = ioutil.WriteFile(portPath, []byte(""), 0644)
+			err = os.WriteFile(portPath, []byte(""), 0644)
 			c.Check(err, jc.ErrorIsNil)
 		}
 	}

--- a/core/os/os_linux.go
+++ b/core/os/os_linux.go
@@ -5,7 +5,7 @@ package os
 
 import (
 	"errors"
-	"io/ioutil"
+	stdos "os"
 	"strings"
 	"sync"
 )
@@ -50,7 +50,7 @@ func updateOS(f string) (OSType, error) {
 //
 // See http://www.freedesktop.org/software/systemd/man/os-release.html.
 func ReadOSRelease(f string) (map[string]string, error) {
-	contents, err := ioutil.ReadFile(f)
+	contents, err := stdos.ReadFile(f)
 	if err != nil {
 		return nil, err
 	}

--- a/core/secrets/createsecret.go
+++ b/core/secrets/createsecret.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -51,7 +51,7 @@ func ReadSecretData(f string) (SecretData, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/core/secrets/createsecret_test.go
+++ b/core/secrets/createsecret_test.go
@@ -4,7 +4,6 @@
 package secrets_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -48,7 +47,7 @@ func (s *CreateSecretSuite) TestYAMLFile(c *gc.C) {
 
 	dir := c.MkDir()
 	fileName := filepath.Join(dir, "secret.yaml")
-	err := ioutil.WriteFile(fileName, []byte(data), os.FileMode(0644))
+	err := os.WriteFile(fileName, []byte(data), os.FileMode(0644))
 	c.Assert(err, jc.ErrorIsNil)
 
 	attrs, err := secrets.ReadSecretData(fileName)
@@ -68,7 +67,7 @@ func (s *CreateSecretSuite) TestJSONFile(c *gc.C) {
 
 	dir := c.MkDir()
 	fileName := filepath.Join(dir, "secret.json")
-	err := ioutil.WriteFile(fileName, []byte(data), os.FileMode(0644))
+	err := os.WriteFile(fileName, []byte(data), os.FileMode(0644))
 	c.Assert(err, jc.ErrorIsNil)
 
 	attrs, err := secrets.ReadSecretData(fileName)

--- a/core/secrets/secretvalue.go
+++ b/core/secrets/secretvalue.go
@@ -6,7 +6,7 @@ package secrets
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/juju/errors"
@@ -101,7 +101,7 @@ func (v *secretValue) KeyValue(key string) (string, error) {
 		return string(val), nil
 	}
 	b64 := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(val))
-	result, err := ioutil.ReadAll(b64)
+	result, err := io.ReadAll(b64)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -4,7 +4,6 @@
 package series
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -317,7 +316,7 @@ func (s *SupportedSeriesSuite) TestUbuntuVersions(c *gc.C) {
 }
 
 func makeTempFile(c *gc.C, content string) (*os.File, func()) {
-	tmpfile, err := ioutil.TempFile("", "distroinfo")
+	tmpfile, err := os.CreateTemp("", "distroinfo")
 	if err != nil {
 		c.Assert(err, jc.ErrorIsNil)
 	}

--- a/core/snap/assertions.go
+++ b/core/snap/assertions.go
@@ -5,7 +5,7 @@ package snap
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -48,7 +48,7 @@ func LookupAssertions(proxyURL string) (assertions, storeID string, err error) {
 		return "", "", errors.Annotatef(err, "could not retrieve assertions from proxy at %q; proxy replied with unexpected HTTP status code %d", noCredsProxyURL, res.StatusCode)
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", "", errors.Annotatef(err, "could not read assertions response from proxy at %q", noCredsProxyURL)
 	}

--- a/docker/auth.go
+++ b/docker/auth.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"time"
@@ -249,7 +248,7 @@ func NewImageRepoDetails(contentOrPath string) (o *ImageRepoDetails, err error) 
 	isPath, err := fileExists(contentOrPath)
 	if err == nil && isPath {
 		logger.Debugf("reading image repository information from %q", contentOrPath)
-		data, err = ioutil.ReadFile(contentOrPath)
+		data, err = os.ReadFile(contentOrPath)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/docker/auth_test.go
+++ b/docker/auth_test.go
@@ -5,7 +5,7 @@ package docker_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/testing"
@@ -45,7 +45,7 @@ func (s *authSuite) TestNewImageRepoDetailsReadFromFile(c *gc.C) {
 	filename := "my-caas-image-repo-config.json"
 	dir := c.MkDir()
 	fullpath := filepath.Join(dir, filename)
-	err := ioutil.WriteFile(fullpath, []byte(quayContent), 0644)
+	err := os.WriteFile(fullpath, []byte(quayContent), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	imageRepoDetails, err := docker.NewImageRepoDetails(fullpath)
 	c.Assert(err, jc.ErrorIsNil)

--- a/docker/registry/internal/acr_test.go
+++ b/docker/registry/internal/acr_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -60,7 +60,7 @@ func (s *azureContainerRegistrySuite) getRegistry(c *gc.C) (*internal.AzureConta
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusUnauthorized,
-						Body:       ioutil.NopCloser(nil),
+						Body:       io.NopCloser(nil),
 						Header: http.Header{
 							http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 								`Bearer realm="https://jujuqa.azurecr.io/oauth2/token",service="jujuqa.azurecr.io",scope="repository:jujud-operator:metadata_read"`,
@@ -78,7 +78,7 @@ func (s *azureContainerRegistrySuite) getRegistry(c *gc.C) (*internal.AzureConta
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
+						Body:       io.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
 					}, nil
 				},
 			),
@@ -88,7 +88,7 @@ func (s *azureContainerRegistrySuite) getRegistry(c *gc.C) (*internal.AzureConta
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
 					c.Assert(req.Method, gc.Equals, `GET`)
 					c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2`)
-					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 				},
 			),
 		)
@@ -138,7 +138,7 @@ func (s *azureContainerRegistrySuite) TestTagsV2(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://jujuqa.azurecr.io/oauth2/token",service="jujuqa.azurecr.io",scope="repository:jujud-operator:metadata_read"`,
@@ -155,7 +155,7 @@ func (s *azureContainerRegistrySuite) TestTagsV2(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
 				}, nil
 			},
 		),
@@ -167,7 +167,7 @@ func (s *azureContainerRegistrySuite) TestTagsV2(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -198,7 +198,7 @@ func (s *azureContainerRegistrySuite) TestTagsErrorResponseV2(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://jujuqa.azurecr.io/oauth2/token",service="jujuqa.azurecr.io",scope="repository:jujud-operator:metadata_read"`,
@@ -215,7 +215,7 @@ func (s *azureContainerRegistrySuite) TestTagsErrorResponseV2(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
 				}, nil
 			},
 		),
@@ -226,7 +226,7 @@ func (s *azureContainerRegistrySuite) TestTagsErrorResponseV2(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -249,7 +249,7 @@ func (s *azureContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C, 
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://jujuqa.azurecr.io/oauth2/token",service="jujuqa.azurecr.io",scope="repository:jujud-operator:metadata_read"`,
@@ -266,7 +266,7 @@ func (s *azureContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C, 
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
 				}, nil
 			},
 		),
@@ -280,7 +280,7 @@ func (s *azureContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C, 
 				},
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(responseData)),
+				Body:       io.NopCloser(strings.NewReader(responseData)),
 			}
 			return resps, nil
 		}),
@@ -334,7 +334,7 @@ func (s *azureContainerRegistrySuite) TestGetBlobs(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://jujuqa.azurecr.io/oauth2/token",service="jujuqa.azurecr.io",scope="repository:jujud-operator:metadata_read"`,
@@ -351,7 +351,7 @@ func (s *azureContainerRegistrySuite) TestGetBlobs(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"access_token": "jwt-token"}`)),
 				}, nil
 			},
 		),
@@ -364,7 +364,7 @@ func (s *azureContainerRegistrySuite) TestGetBlobs(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body: ioutil.NopCloser(strings.NewReader(`
+				Body: io.NopCloser(strings.NewReader(`
 {"architecture":"amd64"}
 `[1:])),
 			}

--- a/docker/registry/internal/base_client_test.go
+++ b/docker/registry/internal/base_client_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -59,7 +59,7 @@ func (s *baseSuite) getRegistry(c *gc.C) (*internal.BaseClient, *gomock.Controll
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 					Header: http.Header{
 						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 							`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -79,7 +79,7 @@ func (s *baseSuite) getRegistry(c *gc.C) (*internal.BaseClient, *gomock.Controll
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -89,7 +89,7 @@ func (s *baseSuite) getRegistry(c *gc.C) (*internal.BaseClient, *gomock.Controll
 				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
 				c.Assert(req.Method, gc.Equals, `GET`)
 				c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2`)
-				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
 	)

--- a/docker/registry/internal/base_manifests_test.go
+++ b/docker/registry/internal/base_manifests_test.go
@@ -4,7 +4,7 @@
 package internal_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -31,7 +31,7 @@ func (s *baseSuite) assertGetManifestsSchemaVersion1(c *gc.C, responseData, cont
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -48,7 +48,7 @@ func (s *baseSuite) assertGetManifestsSchemaVersion1(c *gc.C, responseData, cont
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -62,7 +62,7 @@ func (s *baseSuite) assertGetManifestsSchemaVersion1(c *gc.C, responseData, cont
 				},
 				Request:    req,
 				StatusCode: statusCode,
-				Body:       ioutil.NopCloser(strings.NewReader(responseData)),
+				Body:       io.NopCloser(strings.NewReader(responseData)),
 			}
 			return resps, nil
 		}),
@@ -145,7 +145,7 @@ func (s *baseSuite) TestGetBlobs(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -162,7 +162,7 @@ func (s *baseSuite) TestGetBlobs(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -175,7 +175,7 @@ func (s *baseSuite) TestGetBlobs(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body: ioutil.NopCloser(strings.NewReader(`
+				Body: io.NopCloser(strings.NewReader(`
 {"architecture":"amd64"}
 `[1:])),
 			}

--- a/docker/registry/internal/base_tags_test.go
+++ b/docker/registry/internal/base_tags_test.go
@@ -4,7 +4,7 @@
 package internal_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -35,7 +35,7 @@ func (s *baseSuite) TestTagsPublicRegistry(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -52,7 +52,7 @@ func (s *baseSuite) TestTagsPublicRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -63,7 +63,7 @@ func (s *baseSuite) TestTagsPublicRegistry(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -95,7 +95,7 @@ func (s *baseSuite) TestTagsPrivateRegistry(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -112,7 +112,7 @@ func (s *baseSuite) TestTagsPrivateRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -123,7 +123,7 @@ func (s *baseSuite) TestTagsPrivateRegistry(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -154,7 +154,7 @@ func (s *baseSuite) TestTagsErrorResponse(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -171,7 +171,7 @@ func (s *baseSuite) TestTagsErrorResponse(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -182,7 +182,7 @@ func (s *baseSuite) TestTagsErrorResponse(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),

--- a/docker/registry/internal/dockerhub_test.go
+++ b/docker/registry/internal/dockerhub_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -58,7 +58,7 @@ func (s *dockerhubSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Contro
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 					Header: http.Header{
 						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 							`Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -78,7 +78,7 @@ func (s *dockerhubSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Contro
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -88,7 +88,7 @@ func (s *dockerhubSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Contro
 				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
 				c.Assert(req.Method, gc.Equals, `GET`)
 				c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2`)
-				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
 	)
@@ -133,7 +133,7 @@ func (s *dockerhubSuite) TestTagsPublicRegistry(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -150,7 +150,7 @@ func (s *dockerhubSuite) TestTagsPublicRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -162,7 +162,7 @@ func (s *dockerhubSuite) TestTagsPublicRegistry(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -194,7 +194,7 @@ func (s *dockerhubSuite) TestTagsPrivateRegistry(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -211,7 +211,7 @@ func (s *dockerhubSuite) TestTagsPrivateRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -223,7 +223,7 @@ func (s *dockerhubSuite) TestTagsPrivateRegistry(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -254,7 +254,7 @@ func (s *dockerhubSuite) TestTagsErrorResponse(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -271,7 +271,7 @@ func (s *dockerhubSuite) TestTagsErrorResponse(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -282,7 +282,7 @@ func (s *dockerhubSuite) TestTagsErrorResponse(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),

--- a/docker/registry/internal/ecr_test.go
+++ b/docker/registry/internal/ecr_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -265,7 +265,7 @@ func (s *elasticContainerRegistrySuite) TestTags(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -296,7 +296,7 @@ func (s *elasticContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -322,7 +322,7 @@ func (s *elasticContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C
 				},
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(responseData)),
+				Body:       io.NopCloser(strings.NewReader(responseData)),
 			}
 			return resps, nil
 		}),
@@ -376,7 +376,7 @@ func (s *elasticContainerRegistrySuite) TestGetBlobs(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body: ioutil.NopCloser(strings.NewReader(`
+				Body: io.NopCloser(strings.NewReader(`
 {"architecture":"amd64"}
 `[1:])),
 			}

--- a/docker/registry/internal/gcr_test.go
+++ b/docker/registry/internal/gcr_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -59,7 +59,7 @@ func (s *googleContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, 
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusUnauthorized,
-						Body:       ioutil.NopCloser(nil),
+						Body:       io.NopCloser(nil),
 						Header: http.Header{
 							http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 								`Bearer realm="https://gcr.io/v2/token",service="gcr.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -77,7 +77,7 @@ func (s *googleContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, 
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+						Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 					}, nil
 				},
 			),
@@ -87,7 +87,7 @@ func (s *googleContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, 
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
 					c.Assert(req.Method, gc.Equals, `GET`)
 					c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/`)
-					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 				},
 			),
 		)
@@ -138,7 +138,7 @@ func (s *googleContainerRegistrySuite) TestTags(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://gcr.io/v2/token",service="gcr.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -155,7 +155,7 @@ func (s *googleContainerRegistrySuite) TestTags(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -166,7 +166,7 @@ func (s *googleContainerRegistrySuite) TestTags(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -197,7 +197,7 @@ func (s *googleContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://gcr.io/v2/token",service="gcr.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -214,7 +214,7 @@ func (s *googleContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -225,7 +225,7 @@ func (s *googleContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),

--- a/docker/registry/internal/github_test.go
+++ b/docker/registry/internal/github_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -63,7 +63,7 @@ func (s *githubSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Controlle
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + authToken}})
 					c.Assert(req.Method, gc.Equals, `GET`)
 					c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/v2/`)
-					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 				},
 			),
 		)
@@ -157,7 +157,7 @@ func (s *githubSuite) TestTagsPublicRegistry(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -174,7 +174,7 @@ func (s *githubSuite) TestTagsPublicRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -185,7 +185,7 @@ func (s *githubSuite) TestTagsPublicRegistry(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -218,7 +218,7 @@ func (s *githubSuite) TestTagsPrivateRegistry(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -250,7 +250,7 @@ func (s *githubSuite) TestTagsErrorResponse(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),

--- a/docker/registry/internal/gitlab_test.go
+++ b/docker/registry/internal/gitlab_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -59,7 +59,7 @@ func (s *gitlabSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Controlle
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusUnauthorized,
-						Body:       ioutil.NopCloser(nil),
+						Body:       io.NopCloser(nil),
 						Header: http.Header{
 							http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 								`Bearer realm="https://gitlab.com/jwt/auth",service="container_registry",scope="repository:jujuqa/jujud-operator:pull",error="invalid_token"`,
@@ -77,7 +77,7 @@ func (s *gitlabSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Controlle
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+						Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 					}, nil
 				},
 			),
@@ -87,7 +87,7 @@ func (s *gitlabSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Controlle
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
 					c.Assert(req.Method, gc.Equals, `GET`)
 					c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2`)
-					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 				},
 			),
 		)
@@ -134,7 +134,7 @@ func (s *gitlabSuite) TestTagsPublicRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 					Header: http.Header{
 						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 							`Bearer realm="https://gitlab.com/jwt/auth",service="container_registry",scope="repository:jujuqa/jujud-operator:pull",error="invalid_token"`,
@@ -152,7 +152,7 @@ func (s *gitlabSuite) TestTagsPublicRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -163,7 +163,7 @@ func (s *gitlabSuite) TestTagsPublicRegistry(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -196,7 +196,7 @@ func (s *gitlabSuite) TestTagsPrivateRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 					Header: http.Header{
 						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 							`Bearer realm="https://gitlab.com/jwt/auth",service="container_registry",scope="repository:jujuqa/jujud-operator:pull",error="invalid_token"`,
@@ -214,7 +214,7 @@ func (s *gitlabSuite) TestTagsPrivateRegistry(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -225,7 +225,7 @@ func (s *gitlabSuite) TestTagsPrivateRegistry(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -256,7 +256,7 @@ func (s *gitlabSuite) TestTagsErrorResponse(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://gitlab.com/jwt/auth",service="container_registry",scope="repository:jujuqa/jujud-operator:pull",error="invalid_token"`,
@@ -273,7 +273,7 @@ func (s *gitlabSuite) TestTagsErrorResponse(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -285,7 +285,7 @@ func (s *gitlabSuite) TestTagsErrorResponse(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),

--- a/docker/registry/internal/quay_test.go
+++ b/docker/registry/internal/quay_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -59,7 +59,7 @@ func (s *quayContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, *g
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusUnauthorized,
-						Body:       ioutil.NopCloser(nil),
+						Body:       io.NopCloser(nil),
 						Header: http.Header{
 							http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 								`Bearer realm="https://quay.io/v2/token",service="quay.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -77,7 +77,7 @@ func (s *quayContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, *g
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+						Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 					}, nil
 				},
 			),
@@ -87,7 +87,7 @@ func (s *quayContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, *g
 					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
 					c.Assert(req.Method, gc.Equals, `GET`)
 					c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2`)
-					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 				},
 			),
 		)
@@ -126,7 +126,7 @@ func (s *quayContainerRegistrySuite) TestTagsPublic(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -158,7 +158,7 @@ func (s *quayContainerRegistrySuite) TestTagsPrivate(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://quay.io/v2/token",service="quay.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -175,7 +175,7 @@ func (s *quayContainerRegistrySuite) TestTagsPrivate(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -186,7 +186,7 @@ func (s *quayContainerRegistrySuite) TestTagsPrivate(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),
@@ -217,7 +217,7 @@ func (s *quayContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
-				Body:       ioutil.NopCloser(nil),
+				Body:       io.NopCloser(nil),
 				Header: http.Header{
 					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 						`Bearer realm="https://quay.io/v2/token",service="quay.io",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -234,7 +234,7 @@ func (s *quayContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -245,7 +245,7 @@ func (s *quayContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
-				Body:       ioutil.NopCloser(strings.NewReader(data)),
+				Body:       io.NopCloser(strings.NewReader(data)),
 			}
 			return resps, nil
 		}),

--- a/docker/registry/internal/transports.go
+++ b/docker/registry/internal/transports.go
@@ -6,7 +6,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -255,7 +255,7 @@ func handleErrorResponse(resp *http.Response) (*http.Response, error) {
 		return resp, nil
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Annotatef(err, "reading bad response body with status code %d", resp.StatusCode)
 	}

--- a/docker/registry/internal/transports_test.go
+++ b/docker/registry/internal/transports_test.go
@@ -5,7 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -38,7 +38,7 @@ func (s *transportSuite) TestErrorTransport(c *gc.C) {
 		resps := &http.Response{
 			Request:    req,
 			StatusCode: http.StatusForbidden,
-			Body:       ioutil.NopCloser(strings.NewReader(`invalid input`)),
+			Body:       io.NopCloser(strings.NewReader(`invalid input`)),
 		}
 		return resps, nil
 	})
@@ -62,7 +62,7 @@ func (s *transportSuite) TestBasicTransport(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(``)),
+				Body:       io.NopCloser(strings.NewReader(``)),
 			}, nil
 		},
 	)
@@ -80,7 +80,7 @@ func (s *transportSuite) TestBasicTransport(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(``)),
+				Body:       io.NopCloser(strings.NewReader(``)),
 			}, nil
 		},
 	)
@@ -98,7 +98,7 @@ func (s *transportSuite) TestBasicTransport(c *gc.C) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(``)),
+				Body:       io.NopCloser(strings.NewReader(``)),
 			}, nil
 		},
 	)
@@ -123,7 +123,7 @@ func (s *transportSuite) TestTokenTransportOAuthTokenProvided(c *gc.C) {
 			func(req *http.Request) (*http.Response, error) {
 				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
 				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
-				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
 	)
@@ -152,7 +152,7 @@ func (s *transportSuite) TestTokenTransportTokenRefresh(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 					Header: http.Header{
 						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 							`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -169,7 +169,7 @@ func (s *transportSuite) TestTokenTransportTokenRefresh(c *gc.C) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token": "OAuth-jwt-token", "access_token": "OAuth-jwt-token","expires_in": 300}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token": "OAuth-jwt-token", "access_token": "OAuth-jwt-token","expires_in": 300}`)),
 				}, nil
 			},
 		),
@@ -178,7 +178,7 @@ func (s *transportSuite) TestTokenTransportTokenRefresh(c *gc.C) {
 			func(req *http.Request) (*http.Response, error) {
 				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
 				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
-				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
 	)
@@ -206,7 +206,7 @@ func (s *transportSuite) TestTokenTransportTokenRefreshFailedRealmMissing(c *gc.
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 					Header: http.Header{
 						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 							`Bearer service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
@@ -240,7 +240,7 @@ func (s *transportSuite) TestTokenTransportTokenRefreshFailedServiceMissing(c *g
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
-					Body:       ioutil.NopCloser(nil),
+					Body:       io.NopCloser(nil),
 					Header: http.Header{
 						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
 							`Bearer realm="https://auth.example.com/token",scope="repository:jujuqa/jujud-operator:pull"`,

--- a/downloader/download.go
+++ b/downloader/download.go
@@ -5,7 +5,6 @@ package downloader
 
 import (
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -113,7 +112,7 @@ func (dl *Download) download(req Request) (filename string, err error) {
 	if dir == "" {
 		dir = os.TempDir()
 	}
-	tempFile, err := ioutil.TempFile(dir, "inprogress-")
+	tempFile, err := os.CreateTemp(dir, "inprogress-")
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/downloader/download_test.go
+++ b/downloader/download_test.go
@@ -4,7 +4,6 @@
 package downloader_test
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -158,13 +157,13 @@ func (s *DownloadSuite) TestAbort(c *gc.C) {
 }
 
 func assertFileContents(c *gc.C, filename, expect string) {
-	got, err := ioutil.ReadFile(filename)
+	got, err := os.ReadFile(filename)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(got), gc.Equals, expect)
 }
 
 func checkDirEmpty(c *gc.C, dir string) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(files, gc.HasLen, 0)
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -5,7 +5,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -868,7 +867,7 @@ func userPublicSigningKey() (string, error) {
 		if err != nil {
 			return "", errors.Annotatef(err, "cannot expand key file path: %s", signingKeyFile)
 		}
-		b, err := ioutil.ReadFile(path)
+		b, err := os.ReadFile(path)
 		if err != nil {
 			return "", errors.Annotatef(err, "invalid public key file: %s", path)
 		}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -6,7 +6,7 @@ package bootstrap_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -1076,7 +1076,7 @@ func (s *bootstrapSuite) TestBootstrapCloudCredential(c *gc.C) {
 
 func (s *bootstrapSuite) TestPublicKeyEnvVar(c *gc.C) {
 	path := filepath.Join(c.MkDir(), "key")
-	ioutil.WriteFile(path, []byte("publickey"), 0644)
+	os.WriteFile(path, []byte("publickey"), 0644)
 	s.PatchEnvironment("JUJU_STREAMS_PUBLICKEY_FILE", path)
 
 	env := newEnviron("foo", useDefaultKeys, nil)
@@ -1093,7 +1093,7 @@ func (s *bootstrapSuite) TestPublicKeyEnvVar(c *gc.C) {
 
 func (s *bootstrapSuite) TestFinishBootstrapConfig(c *gc.C) {
 	path := filepath.Join(c.MkDir(), "key")
-	ioutil.WriteFile(path, []byte("publickey"), 0644)
+	os.WriteFile(path, []byte("publickey"), 0644)
 	s.PatchEnvironment("JUJU_STREAMS_PUBLICKEY_FILE", path)
 
 	password := "lisboan-pork"

--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -309,7 +308,7 @@ func readFileAttr(attrs map[string]interface{}, key, defaultPath string) (conten
 	if !filepath.IsAbs(absPath) {
 		absPath = osenv.JujuXDGDataHomePath(absPath)
 	}
-	data, err := ioutil.ReadFile(absPath)
+	data, err := os.ReadFile(absPath)
 	if err != nil {
 		return "", userSpecified, errors.Annotatef(err, "%q not set, and could not read from %q", key, path)
 	}

--- a/environs/bootstrap/config_test.go
+++ b/environs/bootstrap/config_test.go
@@ -4,7 +4,7 @@
 package bootstrap_test
 
 import (
-	"io/ioutil"
+	"os"
 	"time"
 
 	gitjujutesting "github.com/juju/testing"
@@ -71,7 +71,7 @@ func (*ConfigSuite) TestConfigValuesSpecified(c *gc.C) {
 
 func (s *ConfigSuite) addFiles(c *gc.C, files ...gitjujutesting.TestFile) {
 	for _, f := range files {
-		err := ioutil.WriteFile(osenv.JujuXDGDataHomePath(f.Name), []byte(f.Data), 0666)
+		err := os.WriteFile(osenv.JujuXDGDataHomePath(f.Name), []byte(f.Data), 0666)
 		c.Assert(err, gc.IsNil)
 	}
 }

--- a/environs/filestorage/filestorage.go
+++ b/environs/filestorage/filestorage.go
@@ -6,7 +6,6 @@ package filestorage
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -156,7 +155,7 @@ func (f *fileStorageWriter) Put(name string, r io.Reader, length int64) error {
 	}
 	defer os.Remove(tmpdir)
 	// Write to a temporary file first, and then move (atomically).
-	file, err := ioutil.TempFile(tmpdir, "juju-filestorage-")
+	file, err := os.CreateTemp(tmpdir, "juju-filestorage-")
 	if err != nil {
 		return err
 	}

--- a/environs/filestorage/filestorage_test.go
+++ b/environs/filestorage/filestorage_test.go
@@ -9,7 +9,7 @@ package filestorage_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,7 +50,7 @@ func (s *filestorageSuite) createFile(c *gc.C, name string) (fullpath string, da
 	dir := filepath.Dir(fullpath)
 	c.Assert(os.MkdirAll(dir, 0755), gc.IsNil)
 	data = []byte{1, 2, 3, 4, 5}
-	err := ioutil.WriteFile(fullpath, data, 0644)
+	err := os.WriteFile(fullpath, data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	return fullpath, data
 }
@@ -131,7 +131,7 @@ func (s *filestorageSuite) TestGet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
 	c.Assert(err, jc.ErrorIsNil)
-	b, err := ioutil.ReadAll(rc)
+	b, err := io.ReadAll(rc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(b, gc.DeepEquals, data)
 
@@ -160,7 +160,7 @@ func (s *filestorageSuite) TestPut(c *gc.C) {
 	data := []byte{1, 2, 3, 4, 5}
 	err := s.writer.Put("test-write", bytes.NewReader(data), int64(len(data)))
 	c.Assert(err, jc.ErrorIsNil)
-	b, err := ioutil.ReadFile(filepath.Join(s.dir, "test-write"))
+	b, err := os.ReadFile(filepath.Join(s.dir, "test-write"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(b, gc.DeepEquals, data)
 }
@@ -175,7 +175,7 @@ func (s *filestorageSuite) TestPutRefusesTmp(c *gc.C) {
 		Path: ".tmp/test-write",
 		Err:  os.ErrPermission,
 	})
-	_, err = ioutil.ReadFile(filepath.Join(s.dir, ".tmp", "test-write"))
+	_, err = os.ReadFile(filepath.Join(s.dir, ".tmp", "test-write"))
 	c.Assert(err, jc.Satisfies, os.IsNotExist)
 }
 
@@ -184,7 +184,7 @@ func (s *filestorageSuite) TestRemove(c *gc.C) {
 	_, file := filepath.Split(expectedpath)
 	err := s.writer.Remove(file)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = ioutil.ReadFile(expectedpath)
+	_, err = os.ReadFile(expectedpath)
 	c.Assert(err, gc.Not(gc.IsNil))
 }
 
@@ -192,7 +192,7 @@ func (s *filestorageSuite) TestRemoveAll(c *gc.C) {
 	expectedpath, _ := s.createFile(c, "test-file")
 	err := s.writer.RemoveAll()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = ioutil.ReadFile(expectedpath)
+	_, err = os.ReadFile(expectedpath)
 	c.Assert(err, gc.Not(gc.IsNil))
 }
 
@@ -216,7 +216,7 @@ func (s *filestorageSuite) TestPutTmpDir(c *gc.C) {
 
 func (s *filestorageSuite) TestPathRelativeToHome(c *gc.C) {
 	homeDir := utils.Home()
-	tempDir, err := ioutil.TempDir(homeDir, "")
+	tempDir, err := os.MkdirTemp(homeDir, "")
 	c.Assert(err, jc.ErrorIsNil)
 	defer os.RemoveAll(tempDir)
 	dirName := strings.Replace(tempDir, homeDir, "", -1)

--- a/environs/imagemetadata/testing/testing.go
+++ b/environs/imagemetadata/testing/testing.go
@@ -5,7 +5,7 @@ package testing
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path"
 	"sort"
 
@@ -68,7 +68,7 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader) []*imagemetad
 	r, err := stor.Get(path.Join("images", imageIndexMetadata.ProductsFilePath))
 	defer func() { _ = r.Close() }()
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Parse the products file metadata.

--- a/environs/manual/sshprovisioner/fakessh_test.go
+++ b/environs/manual/sshprovisioner/fakessh_test.go
@@ -6,7 +6,7 @@ package sshprovisioner_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -64,7 +64,7 @@ func installFakeSSH(c *gc.C, input, output interface{}, rc int) testing.Restorer
 	case nil:
 	case string:
 		sshexpectedinput := ssh + ".expected-input"
-		err := ioutil.WriteFile(sshexpectedinput, []byte(input), 0644)
+		err := os.WriteFile(sshexpectedinput, []byte(input), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	default:
 		c.Errorf("input has invalid type: %T", input)
@@ -80,7 +80,7 @@ func installFakeSSH(c *gc.C, input, output interface{}, rc int) testing.Restorer
 		stderr = fmt.Sprintf("cat>&2<<EOF\n%s\nEOF", output[1])
 	}
 	script := fmt.Sprintf(sshscript, stdout, stderr, rc)
-	err := ioutil.WriteFile(ssh, []byte(script), 0777)
+	err := os.WriteFile(ssh, []byte(script), 0777)
 	c.Assert(err, jc.ErrorIsNil)
 	return testing.PatchEnvPathPrepend(fakebin)
 }

--- a/environs/simplestreams/datasource_test.go
+++ b/environs/simplestreams/datasource_test.go
@@ -7,7 +7,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
@@ -34,7 +33,7 @@ func (s *datasourceSuite) assertFetch(c *gc.C, compressed bool) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = rc.Close() }()
 	c.Assert(url, gc.Equals, fmt.Sprintf("%s/streams/v1/tools_metadata.json", server.URL))
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	c.Assert(err, jc.ErrorIsNil)
 	cloudMetadata, err := simplestreams.ParseCloudMetadata(data, testing.Product_v1, url, imagemetadata.ImageMetadata{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -170,7 +169,7 @@ func (s *datasourceHTTPSSuite) TestNonVerifyingClientSucceeds(c *gc.C) {
 	// However, the urlDataSource abstraction hides that as a simple NotFound
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = reader.Close() }()
-	byteContent, err := ioutil.ReadAll(reader)
+	byteContent, err := io.ReadAll(reader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(byteContent), gc.Equals, "Greetings!\n")
 }

--- a/environs/simplestreams/decode.go
+++ b/environs/simplestreams/decode.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/clearsign"
@@ -22,7 +21,7 @@ var PGPSignatureCheckFn = func(keyring openpgp.KeyRing, signed, signature io.Rea
 // DecodeCheckSignature parses the inline signed PGP text, checks the signature,
 // and returns plain text if the signature matches.
 func DecodeCheckSignature(r io.Reader, armoredPublicKey string) ([]byte, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/environs/simplestreams/encode.go
+++ b/environs/simplestreams/encode.go
@@ -6,7 +6,6 @@ package simplestreams
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/clearsign"
@@ -32,7 +31,7 @@ func Encode(r io.Reader, armoredPrivateKey, passphrase string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	metadata, err := ioutil.ReadAll(r)
+	metadata, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/environs/simplestreams/fetchdata_test.go
+++ b/environs/simplestreams/fetchdata_test.go
@@ -6,7 +6,6 @@ package simplestreams_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -123,7 +122,7 @@ func (s *fetchDataSuite) setupDataSource(key string) {
 	s.source = testing.NewStubDataSource()
 	s.source.FetchFunc = func(path string) (io.ReadCloser, string, error) {
 		r := bytes.NewReader([]byte(s.readerData))
-		return ioutil.NopCloser(r), path, nil
+		return io.NopCloser(r), path, nil
 	}
 	s.source.PublicSigningKeyFunc = func() string {
 		return key

--- a/environs/simplestreams/simplestreams.go
+++ b/environs/simplestreams/simplestreams.go
@@ -6,7 +6,7 @@ package simplestreams
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -535,7 +535,7 @@ func fetchData(source DataSource, path string, requireSigned bool) (data []byte,
 	if requireSigned {
 		data, err = DecodeCheckSignature(rc, source.PublicSigningKey())
 	} else {
-		data, err = ioutil.ReadAll(rc)
+		data, err = io.ReadAll(rc)
 	}
 	if err != nil {
 		return nil, dataURL, errors.Annotatef(err, "cannot read data for source %q at URL %v", source.Description(), dataURL)
@@ -1124,7 +1124,7 @@ const SimplestreamsPublicKeyFile = "publicsimplestreamskey"
 // UserPublicSigningKey returns the public signing key (if defined).
 func UserPublicSigningKey() (string, error) {
 	signingKeyFile := filepath.Join(agent.DefaultPaths.ConfDir, SimplestreamsPublicKeyFile)
-	b, err := ioutil.ReadFile(signingKeyFile)
+	b, err := os.ReadFile(signingKeyFile)
 	if os.IsNotExist(err) {
 		// TODO (anastasiamac 2016-05-07)
 		// We should not swallow this error

--- a/environs/simplestreams/testing/testing.go
+++ b/environs/simplestreams/testing/testing.go
@@ -7,7 +7,7 @@ package testing
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -571,7 +571,7 @@ func AddSignedFiles(c *gc.C, files map[string]string) map[string]string {
 		all[name] = content
 		// Sign file content
 		r := strings.NewReader(content)
-		bytes, err := ioutil.ReadAll(r)
+		bytes, err := io.ReadAll(r)
 		c.Assert(err, jc.ErrorIsNil)
 		signedName, signedContent, err := SignMetadata(name, bytes)
 		c.Assert(err, jc.ErrorIsNil)

--- a/environs/storage/storage_test.go
+++ b/environs/storage/storage_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	stdtesting "testing"
 
 	jc "github.com/juju/testing/checkers"
@@ -51,7 +50,7 @@ func (s *datasourceSuite) TestFetch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
 	c.Assert(url, gc.Equals, s.baseURL+"/foo/bar/data.txt")
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.DeepEquals, []byte(sampleData))
 }
@@ -64,7 +63,7 @@ func (s *datasourceSuite) TestFetchWithBasePath(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer rc.Close()
 	c.Assert(url, gc.Equals, s.baseURL+"/base/foo/bar/data.txt")
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.DeepEquals, []byte(sampleData))
 }

--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -307,7 +306,7 @@ func buildAgentTarball(
 	// We create the entire archive before asking the environment to
 	// start uploading so that we can be sure we have archived
 	// correctly.
-	f, err := ioutil.TempFile("", "juju-tgz")
+	f, err := os.CreateTemp("", "juju-tgz")
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +338,7 @@ func buildAgentTarball(
 	}
 	logger.Infof("using %s %v aliased to %v (%dkB)", agentBinary, toolsVersion, forceVersion, (size+512)/1024)
 
-	baseToolsDir, err := ioutil.TempDir("", "juju-tools")
+	baseToolsDir, err := os.MkdirTemp("", "juju-tools")
 	if err != nil {
 		return nil, err
 	}

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -350,7 +349,7 @@ func downloadToolsRaw(c *gc.C, t *coretools.Tools) []byte {
 }
 
 func bundleTools(c *gc.C) (version.Binary, bool, string, error) {
-	f, err := ioutil.TempFile("", "juju-tgz")
+	f, err := os.CreateTemp("", "juju-tgz")
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = f.Close() }()
 	defer func() { _ = os.Remove(f.Name()) }()
@@ -392,7 +391,7 @@ func (s *badBuildSuite) SetUpTest(c *gc.C) {
 	testPath := c.MkDir()
 	s.PatchEnvPathPrepend(testPath)
 	path := filepath.Join(testPath, "go")
-	err := ioutil.WriteFile(path, []byte(badGo), 0755)
+	err := os.WriteFile(path, []byte(badGo), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check mocked go cmd errors
@@ -521,7 +520,7 @@ func (s *uploadSuite) TestMockBuildTools(c *gc.C) {
 		_, tr, err := tar.FindFile(gzr, names.Jujud)
 		c.Assert(err, jc.ErrorIsNil)
 
-		content, err := ioutil.ReadAll(tr)
+		content, err := io.ReadAll(tr)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(string(content), gc.Equals, fmt.Sprintf("jujud contents %s", vers))
 	}
@@ -585,7 +584,7 @@ func (s *uploadSuite) testStorageToolsUploaderWriteMirrors(c *gc.C, writeMirrors
 	r, err := stor.Get(path.Join(storage.BaseToolsPath, mirrorsPath))
 	if writeMirrors == envtools.WriteMirrors {
 		c.Assert(err, jc.ErrorIsNil)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		r.Close()
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), jc.Contains, `"mirrors":`)

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	io "io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -207,7 +207,7 @@ func SignFileData(stor storage.Storage, fileName string) error {
 	}
 	defer r.Close()
 
-	fileData, err := ioutil.ReadAll(r)
+	fileData, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,7 +54,7 @@ func (b *buildSuite) SetUpTest(c *gc.C) {
 
 	// Make an executable file called "juju-test" in dir2.
 	b.filePath = filepath.Join(dir2, "juju-test")
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		b.filePath,
 		[]byte("doesn't matter, we don't execute it"),
 		0755)
@@ -161,7 +160,7 @@ func (b *buildSuite) TestGetVersionFromJujud(c *gc.C) {
 
 	dir := c.MkDir()
 	cmd := filepath.Join(dir, names.Jujud)
-	err := ioutil.WriteFile(cmd, []byte{}, 0644)
+	err := os.WriteFile(cmd, []byte{}, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	v, err := tools.GetVersionFromJujud(dir)
 	c.Assert(err, jc.ErrorIsNil)
@@ -187,7 +186,7 @@ func (b *buildSuite) TestGetVersionFromJujudWithParseError(c *gc.C) {
 
 	dir := c.MkDir()
 	cmd := filepath.Join(dir, names.Jujud)
-	err := ioutil.WriteFile(cmd, []byte{}, 0644)
+	err := os.WriteFile(cmd, []byte{}, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = tools.GetVersionFromJujud(dir)
 	c.Assert(err, gc.ErrorMatches, `invalid version "oops, not a valid version" printed by jujud`)
@@ -213,7 +212,7 @@ func (b *buildSuite) TestGetVersionFromJujudWithRunError(c *gc.C) {
 
 	dir := c.MkDir()
 	cmd := filepath.Join(dir, names.Jujud)
-	err := ioutil.WriteFile(cmd, []byte{}, 0644)
+	err := os.WriteFile(cmd, []byte{}, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = tools.GetVersionFromJujud(dir)
 
@@ -241,14 +240,14 @@ func (b *buildSuite) TestGetVersionFromJujudNoJujud(c *gc.C) {
 
 func (b *buildSuite) setUpFakeBinaries(c *gc.C, versionFile string) string {
 	dir := c.MkDir()
-	err := ioutil.WriteFile(filepath.Join(dir, "juju"), []byte("some data"), 0755)
+	err := os.WriteFile(filepath.Join(dir, "juju"), []byte("some data"), 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(dir, "jujuc"), []byte(fakeBinary), 0755)
+	err = os.WriteFile(filepath.Join(dir, "jujuc"), []byte(fakeBinary), 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(dir, "jujud"), []byte(fakeBinary), 0755)
+	err = os.WriteFile(filepath.Join(dir, "jujud"), []byte(fakeBinary), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	if versionFile != "" {
-		err = ioutil.WriteFile(filepath.Join(dir, "jujud-versions.yaml"), []byte(versionFile), 0755)
+		err = os.WriteFile(filepath.Join(dir, "jujud-versions.yaml"), []byte(versionFile), 0755)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -367,7 +366,7 @@ func (b *buildSuite) TestBundleToolsWriteForceVersionFileForOfficial(c *gc.C) {
 		}
 		c.Assert(err, jc.ErrorIsNil)
 		if header.Typeflag == tar.TypeReg && header.Name == "FORCE-VERSION" {
-			forceVersionFile, err := ioutil.ReadAll(tarReader)
+			forceVersionFile, err := io.ReadAll(tarReader)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(string(forceVersionFile), gc.Equals, `1.2.3.1`)
 			break

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"path"
 	"sort"
 	"time"
@@ -398,7 +397,7 @@ func metadataUnchanged(stor storage.Storage, stream string, generatedMetadata []
 		return false, nil
 	}
 	defer existingDataReader.Close()
-	existingData, err := ioutil.ReadAll(existingDataReader)
+	existingData, err := io.ReadAll(existingDataReader)
 	if err != nil {
 		return false, err
 	}

--- a/environs/tools/simplestreams_test.go
+++ b/environs/tools/simplestreams_test.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -883,7 +882,7 @@ func (s *metadataHelperSuite) TestWriteMetadataLegacyIndex(c *gc.C) {
 	rdr, err := stor.Get("tools/streams/v1/index.json")
 	defer rdr.Close()
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadAll(rdr)
+	data, err := io.ReadAll(rdr)
 	c.Assert(err, jc.ErrorIsNil)
 	var indices simplestreams.Indices
 	err = json.Unmarshal(data, &indices)

--- a/environs/tools/testing/testing.go
+++ b/environs/tools/testing/testing.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -64,10 +63,10 @@ func GetMockBuildTools(c *gc.C) sync.BuildAgentTarballFunc {
 		tgz, checksum := coretesting.TarGz(
 			coretesting.NewTarFile(names.Jujud, 0777, "jujud contents "+vers.String()))
 
-		toolsDir, err := ioutil.TempDir("", "juju-tools-"+stream)
+		toolsDir, err := os.MkdirTemp("", "juju-tools-"+stream)
 		c.Assert(err, jc.ErrorIsNil)
 		name := "name"
-		_ = ioutil.WriteFile(filepath.Join(toolsDir, name), tgz, 0777)
+		_ = os.WriteFile(filepath.Join(toolsDir, name), tgz, 0777)
 
 		return &sync.BuiltAgent{
 			Dir:         toolsDir,
@@ -100,7 +99,7 @@ func makeTools(c *gc.C, metadataDir, stream string, versionStrings []string, wit
 		}
 		path := filepath.Join(toolsDir, fmt.Sprintf("juju-%s.tgz", binary))
 		data := binary.String()
-		err = ioutil.WriteFile(path, []byte(data), 0644)
+		err = os.WriteFile(path, []byte(data), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 		tool := &coretools.Tools{
 			Version: binary,
@@ -164,7 +163,7 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader, stream string
 	r, err := stor.Get(path.Join("tools", toolsIndexMetadata.ProductsFilePath))
 	defer func() { _ = r.Close() }()
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 
 	url, err := source.URL(toolsIndexMetadata.ProductsFilePath)
@@ -200,7 +199,7 @@ func ParseMetadataFromStorage(c *gc.C, stor storage.StorageReader, stream string
 		r, err = stor.Get(path.Join("tools", simplestreams.UnsignedMirror("v1")))
 		c.Assert(err, jc.ErrorIsNil)
 		defer r.Close()
-		data, err = ioutil.ReadAll(r)
+		data, err = io.ReadAll(r)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), jc.Contains, `"mirrors":`)
 		c.Assert(string(data), jc.Contains, tools.ToolsContentId(stream))
@@ -305,7 +304,7 @@ func UploadToDirectory(c *gc.C, dir string, streamVersions StreamVersions) map[s
 		if err := os.MkdirAll(dir, 0755); err != nil && !os.IsExist(err) {
 			c.Assert(err, jc.ErrorIsNil)
 		}
-		err := ioutil.WriteFile(path, object.data, 0644)
+		err := os.WriteFile(path, object.data, 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	return allUploaded

--- a/environs/tools/tools_test.go
+++ b/environs/tools/tools_test.go
@@ -5,7 +5,6 @@ package tools_test
 
 import (
 	stdcontext "context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -82,7 +81,7 @@ func (s *SimpleStreamsToolsSuite) reset(c *gc.C, attrs map[string]interface{}) {
 
 func (s *SimpleStreamsToolsSuite) removeTools(c *gc.C) {
 	for _, dir := range []string{s.customToolsDir, s.publicToolsDir} {
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		c.Assert(err, jc.ErrorIsNil)
 		for _, f := range files {
 			err := os.RemoveAll(filepath.Join(dir, f.Name()))

--- a/environs/tools/versionfile.go
+++ b/environs/tools/versionfile.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
@@ -26,7 +25,7 @@ type Versions struct {
 
 // ParseVersions constructs a versions object from a reader..
 func ParseVersions(r io.Reader) (*Versions, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/featuretests/agent_caasoperator_test.go
+++ b/featuretests/agent_caasoperator_test.go
@@ -4,7 +4,6 @@
 package featuretests
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -103,7 +102,7 @@ func (s *CAASOperatorSuite) primeOperator(c *gc.C, app *state.Application) {
 	}
 	data, err := info.Marshal()
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(file, data, 0644)
+	err = os.WriteFile(file, data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/featuretests/cmd_juju_resources_test.go
+++ b/featuretests/cmd_juju_resources_test.go
@@ -5,7 +5,7 @@ package featuretests
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -99,7 +99,7 @@ upload-resource   -
 
 	// Empty files are fine.
 	filename := filepath.Join(c.MkDir(), "empty.txt")
-	err = ioutil.WriteFile(filename, []byte{}, 0755)
+	err = os.WriteFile(filename, []byte{}, 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = runCommand(c, "attach-resource", s.appOneName, "install-resource="+filename)
 	c.Check(err, jc.ErrorIsNil)

--- a/featuretests/tools_test.go
+++ b/featuretests/tools_test.go
@@ -7,7 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -140,7 +140,7 @@ func (s *toolsDownloadSuite) TestDownloadFetchesAndVerifiesHash(c *gc.C) {
 func (s *toolsDownloadSuite) testDownload(c *gc.C, tools *coretools.Tools, uuid string) []byte {
 	resp := s.downloadRequest(c, tools.Version, uuid)
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.HasLen, int(tools.Size))
 
@@ -166,7 +166,7 @@ func (s *toolsDownloadSuite) getToolsFromStorage(c *gc.C, st *state.State, vers 
 	defer storage.Close()
 	metadata, r, err := storage.Open(vers)
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	r.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	return metadata, data
@@ -313,7 +313,7 @@ func bakeryGetError(resp *http.Response) error {
 	if resp.StatusCode != http.StatusUnauthorized {
 		return nil
 	}
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Annotatef(err, "cannot read body")
 	}

--- a/generate/certgen/certgen.go
+++ b/generate/certgen/certgen.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"text/template"
 	"time"
 
@@ -98,7 +98,7 @@ func main() {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile("certs_generated.go", buf.Bytes(), 0664)
+	err = os.WriteFile("certs_generated.go", buf.Bytes(), 0664)
 	if err != nil {
 		panic(err)
 	}

--- a/generate/filetoconst/filetoconst.go
+++ b/generate/filetoconst/filetoconst.go
@@ -6,7 +6,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -29,7 +28,7 @@ func main() {
 	if len(os.Args) < 5 {
 		fmt.Println("Usage: filetoconst <constname> <infile> <gofile> <copyrightyear> <pkgname>")
 	}
-	data, err := ioutil.ReadFile(os.Args[2])
+	data, err := os.ReadFile(os.Args[2])
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -57,7 +56,7 @@ func main() {
 		Pkgname:       os.Args[5],
 	})
 
-	err = ioutil.WriteFile(os.Args[3], buf.Bytes(), 0644)
+	err = os.WriteFile(os.Args[3], buf.Bytes(), 0644)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/generate/schemagen/schemagen.go
+++ b/generate/schemagen/schemagen.go
@@ -10,7 +10,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -95,7 +94,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = ioutil.WriteFile(args[0], jsonSchema, 0644)
+	err = os.WriteFile(args[0], jsonSchema, 0644)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/juju/sockets/sockets.go
+++ b/juju/sockets/sockets.go
@@ -7,7 +7,6 @@ package sockets
 import (
 	"crypto/tls"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/rpc"
 	"os"
@@ -73,10 +72,10 @@ func innerListen(soc Socket) (listener net.Listener, err error) {
 	// We first create the socket in a temporary directory as a subdirectory of
 	// the target dir so we know we can get the permissions correct and still
 	// rename the socket into the correct place.
-	// ioutil.TempDir creates the temporary directory as 0700 so it starts with
+	// os.MkdirTemp creates the temporary directory as 0700 so it starts with
 	// the right perms as well.
 	socketDir := filepath.Dir(soc.Address)
-	tempdir, err := ioutil.TempDir(socketDir, "")
+	tempdir, err := os.MkdirTemp(socketDir, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -6,7 +6,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -696,7 +695,7 @@ func AddCharm(st *state.State, curl *charm.URL, ch charm.Charm, force bool) (*st
 	switch ch := ch.(type) {
 	case *charm.CharmDir:
 		var err error
-		if f, err = ioutil.TempFile("", name); err != nil {
+		if f, err = os.CreateTemp("", name); err != nil {
 			return nil, err
 		}
 		defer os.Remove(f.Name())

--- a/jujuclient/accounts.go
+++ b/jujuclient/accounts.go
@@ -4,7 +4,6 @@
 package jujuclient
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -25,7 +24,7 @@ func JujuAccountsPath() string {
 // ReadAccountsFile loads all accounts defined in a given file.
 // If the file is not found, it is not an error.
 func ReadAccountsFile(file string) (map[string]AccountDetails, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/jujuclient/accountsfile_test.go
+++ b/jujuclient/accountsfile_test.go
@@ -4,7 +4,7 @@
 package jujuclient_test
 
 import (
-	"io/ioutil"
+	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -58,7 +58,7 @@ var (
 
 func (s *AccountsFileSuite) TestWriteFile(c *gc.C) {
 	writeTestAccountsFile(c)
-	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("accounts.yaml"))
+	data, err := os.ReadFile(osenv.JujuXDGDataHomePath("accounts.yaml"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, testAccountsYAML[1:])
 }
@@ -70,7 +70,7 @@ func (s *AccountsFileSuite) TestReadNoFile(c *gc.C) {
 }
 
 func (s *AccountsFileSuite) TestReadEmptyFile(c *gc.C) {
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("accounts.yaml"), []byte(""), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("accounts.yaml"), []byte(""), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	accounts, err := jujuclient.ReadAccountsFile(jujuclient.JujuAccountsPath())
 	c.Assert(err, jc.ErrorIsNil)
@@ -78,13 +78,13 @@ func (s *AccountsFileSuite) TestReadEmptyFile(c *gc.C) {
 }
 
 func (s *AccountsFileSuite) TestMigrateLegacyLocal(c *gc.C) {
-	err := ioutil.WriteFile(jujuclient.JujuAccountsPath(), []byte(testLegacyAccountsYAML), 0644)
+	err := os.WriteFile(jujuclient.JujuAccountsPath(), []byte(testLegacyAccountsYAML), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	accounts, err := jujuclient.ReadAccountsFile(jujuclient.JujuAccountsPath())
 	c.Assert(err, jc.ErrorIsNil)
 
-	migratedData, err := ioutil.ReadFile(jujuclient.JujuAccountsPath())
+	migratedData, err := os.ReadFile(jujuclient.JujuAccountsPath())
 	c.Assert(err, jc.ErrorIsNil)
 	migratedAccounts, err := jujuclient.ParseAccounts(migratedData)
 	c.Assert(err, jc.ErrorIsNil)

--- a/jujuclient/bootstrapconfig.go
+++ b/jujuclient/bootstrapconfig.go
@@ -4,7 +4,6 @@
 package jujuclient
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/errors"
@@ -23,7 +22,7 @@ func JujuBootstrapConfigPath() string {
 // ReadBootstrapConfigFile loads all bootstrap configurations defined in a
 // given file. If the file is not found, it is not an error.
 func ReadBootstrapConfigFile(file string) (map[string]BootstrapConfig, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/jujuclient/bootstrapconfigfile_test.go
+++ b/jujuclient/bootstrapconfigfile_test.go
@@ -4,7 +4,7 @@
 package jujuclient_test
 
 import (
-	"io/ioutil"
+	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -126,7 +126,7 @@ var testBootstrapConfig = map[string]jujuclient.BootstrapConfig{
 
 func (s *BootstrapConfigFileSuite) TestWriteFile(c *gc.C) {
 	writeTestBootstrapConfigFile(c)
-	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("bootstrap-config.yaml"))
+	data, err := os.ReadFile(osenv.JujuXDGDataHomePath("bootstrap-config.yaml"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, testBootstrapConfigYAML[1:])
 }
@@ -139,7 +139,7 @@ func (s *BootstrapConfigFileSuite) TestReadNoFile(c *gc.C) {
 
 func (s *BootstrapConfigFileSuite) TestReadEmptyFile(c *gc.C) {
 	path := osenv.JujuXDGDataHomePath("bootstrap-config.yaml")
-	err := ioutil.WriteFile(path, []byte(""), 0600)
+	err := os.WriteFile(path, []byte(""), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	configs, err := jujuclient.ReadBootstrapConfigFile(path)

--- a/jujuclient/controllers.go
+++ b/jujuclient/controllers.go
@@ -4,7 +4,6 @@
 package jujuclient
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/errors"
@@ -23,7 +22,7 @@ func JujuControllersPath() string {
 // ReadControllersFile loads all controllers defined in a given file.
 // If the file is not found, it is not an error.
 func ReadControllersFile(file string) (*Controllers, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &Controllers{}, nil

--- a/jujuclient/controllersfile_test.go
+++ b/jujuclient/controllersfile_test.go
@@ -5,7 +5,6 @@ package jujuclient_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -55,7 +54,7 @@ current-controller: mallards
 
 func (s *ControllersFileSuite) TestWriteFile(c *gc.C) {
 	writeTestControllersFile(c)
-	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("controllers.yaml"))
+	data, err := os.ReadFile(osenv.JujuXDGDataHomePath("controllers.yaml"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, testControllersYAML[1:])
 }
@@ -70,7 +69,7 @@ func (s *ControllersFileSuite) TestReadNoFile(c *gc.C) {
 
 func (s *ControllersFileSuite) TestReadPermissionsError(c *gc.C) {
 	path := filepath.Join(os.TempDir(), fmt.Sprintf("file-%d", time.Now().UnixNano()))
-	err := ioutil.WriteFile(path, []byte(""), 0377)
+	err := os.WriteFile(path, []byte(""), 0377)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = jujuclient.ReadControllersFile(path)
@@ -78,7 +77,7 @@ func (s *ControllersFileSuite) TestReadPermissionsError(c *gc.C) {
 }
 
 func (s *ControllersFileSuite) TestReadEmptyFile(c *gc.C) {
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("controllers.yaml"), []byte(""), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("controllers.yaml"), []byte(""), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerStore := jujuclient.NewFileClientStore()
@@ -140,7 +139,7 @@ current-controller: aws-test
 	fileName := "controllers.yaml"
 
 	// Contains model-count.
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath(fileName), []byte(fmt.Sprintf(fileContent, modelCount)[1:]), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath(fileName), []byte(fmt.Sprintf(fileContent, modelCount)[1:]), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	controllerStore := jujuclient.NewFileClientStore()
@@ -162,7 +161,7 @@ current-controller: aws-test
 	err = controllerStore.UpdateController("aws-test", expectedDetails)
 	c.Assert(err, jc.ErrorIsNil)
 
-	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath(fileName))
+	data, err := os.ReadFile(osenv.JujuXDGDataHomePath(fileName))
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Has no model-count reference.

--- a/jujuclient/credentials.go
+++ b/jujuclient/credentials.go
@@ -4,7 +4,6 @@
 package jujuclient
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/errors"
@@ -24,7 +23,7 @@ func JujuCredentialsPath() string {
 // ReadCredentialsFile loads all credentials defined in a given file.
 // If the file is not found, it is not an error.
 func ReadCredentialsFile(file string) (*cloud.CredentialCollection, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &cloud.CredentialCollection{}, nil

--- a/jujuclient/credentialsfile_test.go
+++ b/jujuclient/credentialsfile_test.go
@@ -4,7 +4,7 @@
 package jujuclient_test
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -45,7 +45,7 @@ credentials:
 
 func (s *CredentialsFileSuite) TestWriteFile(c *gc.C) {
 	writeTestCredentialsFile(c)
-	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("credentials.yaml"))
+	data, err := os.ReadFile(osenv.JujuXDGDataHomePath("credentials.yaml"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	var original map[string]interface{}
@@ -65,7 +65,7 @@ func (s *CredentialsFileSuite) TestReadNoFile(c *gc.C) {
 }
 
 func (s *CredentialsFileSuite) TestReadEmptyFile(c *gc.C) {
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("credentials.yaml"), []byte(""), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("credentials.yaml"), []byte(""), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	credentialstore := jujuclient.NewFileCredentialStore()

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -5,7 +5,6 @@ package jujuclient
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -30,7 +29,7 @@ func JujuModelsPath() string {
 // ReadModelsFile loads all models defined in a given file.
 // If the file is not found, it is not an error.
 func ReadModelsFile(file string) (map[string]*ControllerModels, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/jujuclient/models_test.go
+++ b/jujuclient/models_test.go
@@ -4,7 +4,6 @@
 package jujuclient_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/errors"
@@ -163,7 +162,7 @@ func (s *ModelsSuite) TestUpdateModelEmptyModels(c *gc.C) {
 	// This test exists to exercise a bug caused by the
 	// presence of a file with an empty "models" field,
 	// that would lead to a panic.
-	err := ioutil.WriteFile(jujuclient.JujuModelsPath(), []byte(`
+	err := os.WriteFile(jujuclient.JujuModelsPath(), []byte(`
 controllers:
   ctrl:
     models:

--- a/jujuclient/modelsfile_test.go
+++ b/jujuclient/modelsfile_test.go
@@ -4,7 +4,7 @@
 package jujuclient_test
 
 import (
-	"io/ioutil"
+	"os"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -91,7 +91,7 @@ var ctrlAdminModelDetails = jujuclient.ModelDetails{
 
 func (s *ModelsFileSuite) TestWriteFile(c *gc.C) {
 	writeTestModelsFile(c)
-	data, err := ioutil.ReadFile(osenv.JujuXDGDataHomePath("models.yaml"))
+	data, err := os.ReadFile(osenv.JujuXDGDataHomePath("models.yaml"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, testModelsYAML[1:])
 }
@@ -103,7 +103,7 @@ func (s *ModelsFileSuite) TestReadNoFile(c *gc.C) {
 }
 
 func (s *ModelsFileSuite) TestReadEmptyFile(c *gc.C) {
-	err := ioutil.WriteFile(osenv.JujuXDGDataHomePath("models.yaml"), []byte(""), 0600)
+	err := os.WriteFile(osenv.JujuXDGDataHomePath("models.yaml"), []byte(""), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	models, err := jujuclient.ReadModelsFile(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
@@ -112,13 +112,13 @@ func (s *ModelsFileSuite) TestReadEmptyFile(c *gc.C) {
 
 func (s *ModelsFileSuite) TestMigrateLegacyLocal(c *gc.C) {
 	s.SetFeatureFlags(feature.Branches)
-	err := ioutil.WriteFile(jujuclient.JujuModelsPath(), []byte(testLegacyModelsYAML), 0644)
+	err := os.WriteFile(jujuclient.JujuModelsPath(), []byte(testLegacyModelsYAML), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	models, err := jujuclient.ReadModelsFile(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
 
-	migratedData, err := ioutil.ReadFile(jujuclient.JujuModelsPath())
+	migratedData, err := os.ReadFile(jujuclient.JujuModelsPath())
 	c.Assert(err, jc.ErrorIsNil)
 	migratedModels, err := jujuclient.ParseModels(migratedData)
 	c.Assert(err, jc.ErrorIsNil)

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -5,7 +5,6 @@ package migration
 
 import (
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"time"
@@ -191,7 +190,7 @@ func UploadBinaries(config UploadBinariesConfig) error {
 }
 
 func streamThroughTempFile(r io.Reader) (_ io.ReadSeeker, cleanup func(), err error) {
-	tempFile, err := ioutil.TempFile("", "juju-migrate-binary")
+	tempFile, err := os.CreateTemp("", "juju-migrate-binary")
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"time"
 
@@ -261,7 +260,7 @@ func (d *fakeDownloader) OpenCharm(curl *charm.URL) (io.ReadCloser, error) {
 	urlStr := curl.String()
 	d.charms = append(d.charms, urlStr)
 	// Return the charm URL string as the fake charm content
-	return ioutil.NopCloser(bytes.NewReader([]byte(urlStr + " content"))), nil
+	return io.NopCloser(bytes.NewReader([]byte(urlStr + " content"))), nil
 }
 
 func (d *fakeDownloader) OpenURI(uri string, query url.Values) (io.ReadCloser, error) {
@@ -270,13 +269,13 @@ func (d *fakeDownloader) OpenURI(uri string, query url.Values) (io.ReadCloser, e
 	}
 	d.uris = append(d.uris, uri)
 	// Return the URI string as fake content
-	return ioutil.NopCloser(bytes.NewReader([]byte(uri))), nil
+	return io.NopCloser(bytes.NewReader([]byte(uri))), nil
 }
 
 func (d *fakeDownloader) OpenResource(app, name string) (io.ReadCloser, error) {
 	d.resources = append(d.resources, app+"/"+name)
 	// Use the resource name as the content.
-	return ioutil.NopCloser(bytes.NewReader([]byte(name))), nil
+	return io.NopCloser(bytes.NewReader([]byte(name))), nil
 }
 
 type fakeUploader struct {
@@ -288,7 +287,7 @@ type fakeUploader struct {
 }
 
 func (f *fakeUploader) UploadTools(r io.ReadSeeker, v version.Binary) (tools.List, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -297,7 +296,7 @@ func (f *fakeUploader) UploadTools(r io.ReadSeeker, v version.Binary) (tools.Lis
 }
 
 func (f *fakeUploader) UploadCharm(u *charm.URL, r io.ReadSeeker) (*charm.URL, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -314,7 +313,7 @@ func (f *fakeUploader) UploadCharm(u *charm.URL, r io.ReadSeeker) (*charm.URL, e
 }
 
 func (f *fakeUploader) UploadResource(res resources.Resource, r io.ReadSeeker) error {
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -405,7 +404,7 @@ func mongoSnapService(dataDir, configDir, snapChannel string) (MongoSnapService,
 
 	// If we're installing a local snap, then provide an absolute path
 	// as a snap <name>. snap install <name> will then do the Right Thing (TM).
-	files, err := ioutil.ReadDir(path.Join(dataDir, "snap"))
+	files, err := os.ReadDir(path.Join(dataDir, "snap"))
 	if err == nil {
 		for _, fullFileName := range files {
 			_, fileName := path.Split(fullFileName.Name())

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -6,7 +6,6 @@ package mongo_test
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -123,19 +122,19 @@ func (s *MongoSuite) expectInstallMongoSnap() {
 }
 
 func (s *MongoSuite) assertTLSKeyFile(c *gc.C, dataDir string) {
-	contents, err := ioutil.ReadFile(mongo.SSLKeyPath(dataDir))
+	contents, err := os.ReadFile(mongo.SSLKeyPath(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, testInfo.Cert+"\n"+testInfo.PrivateKey)
 }
 
 func (s *MongoSuite) assertSharedSecretFile(c *gc.C, dataDir string) {
-	contents, err := ioutil.ReadFile(mongo.SharedSecretPath(dataDir))
+	contents, err := os.ReadFile(mongo.SharedSecretPath(dataDir))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, testInfo.SharedSecret)
 }
 
 func (s *MongoSuite) assertMongoConfigFile(c *gc.C, dataDir string, ipV6 bool) {
-	contents, err := ioutil.ReadFile(s.mongodConfigPath)
+	contents, err := os.ReadFile(s.mongodConfigPath)
 	c.Assert(err, jc.ErrorIsNil)
 	part1 := fmt.Sprintf(`
 # WARNING
@@ -218,7 +217,7 @@ func (s *MongoSuite) TestEnsureServerInstalledSetsSysctlValues(c *gc.C) {
 
 	testing.PatchExecutableAsEchoArgs(c, s, "snap")
 
-	contents, err := ioutil.ReadFile(dataFilePath)
+	contents, err := os.ReadFile(dataFilePath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, "original value")
 
@@ -227,7 +226,7 @@ func (s *MongoSuite) TestEnsureServerInstalledSetsSysctlValues(c *gc.C) {
 		map[string]string{dataFilePath: "new value"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	contents, err = ioutil.ReadFile(dataFilePath)
+	contents, err = os.ReadFile(dataFilePath)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, "new value")
 }

--- a/mongo/mongodfinder_test.go
+++ b/mongo/mongodfinder_test.go
@@ -4,7 +4,6 @@
 package mongo_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -85,7 +84,7 @@ func (s *OSSearchToolsSuite) TestGetCommandOutputValid(c *gc.C) {
 func (s *OSSearchToolsSuite) TestGetCommandOutputExitNonzero(c *gc.C) {
 	dir := c.MkDir()
 	path := filepath.Join(dir, "failing")
-	err := ioutil.WriteFile(path, []byte(`#!/bin/bash --norc
+	err := os.WriteFile(path, []byte(`#!/bin/bash --norc
 echo "hello $1"
 exit 1
 `), 0755)
@@ -99,7 +98,7 @@ exit 1
 func (s *OSSearchToolsSuite) TestGetCommandOutputNonExecutable(c *gc.C) {
 	dir := c.MkDir()
 	path := filepath.Join(dir, "failing")
-	err := ioutil.WriteFile(path, []byte(`#!/bin/bash --norc
+	err := os.WriteFile(path, []byte(`#!/bin/bash --norc
 echo "shouldn't happen $1"
 `), 0644)
 	c.Assert(err, jc.ErrorIsNil)

--- a/mongo/service_test.go
+++ b/mongo/service_test.go
@@ -5,7 +5,7 @@ package mongo_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -50,7 +50,7 @@ func (s *serviceSuite) TestNewConfSnap(c *gc.C) {
 	err := mongo.WriteConfig(confArgs, confFile)
 	c.Assert(err, jc.ErrorIsNil)
 
-	contents, err := ioutil.ReadFile(confFile)
+	contents, err := os.ReadFile(confFile)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := fmt.Sprintf(`
 # WARNING

--- a/network/debinterfaces/parser.go
+++ b/network/debinterfaces/parser.go
@@ -4,7 +4,7 @@
 package debinterfaces
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -229,7 +229,7 @@ func (p parser) parseSourceDirectoryStanza() (*SourceDirectoryStanza, error) {
 		dir = filepath.Join(filepath.Dir(p.scanner.filename), dir)
 	}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 
 	if err != nil {
 		return nil, newParseError(p.scanner, err.Error())

--- a/network/debinterfaces/parser_test.go
+++ b/network/debinterfaces/parser_test.go
@@ -5,7 +5,6 @@ package debinterfaces_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -63,7 +62,7 @@ func (s *ParserSuite) TestUnsupportedInputType(c *gc.C) {
 
 func (s *ParserSuite) TestFilenameEmpty(c *gc.C) {
 	emptyFile := filepath.Join(c.MkDir(), "TestFilenameEmpty")
-	err := ioutil.WriteFile(emptyFile, []byte(""), 0644)
+	err := os.WriteFile(emptyFile, []byte(""), 0644)
 	c.Assert(err, gc.IsNil)
 	stanzas, err := debinterfaces.ParseSource(emptyFile, nil, s.expander)
 	c.Assert(err, gc.IsNil)

--- a/network/debinterfaces/scanner.go
+++ b/network/debinterfaces/scanner.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -45,7 +45,7 @@ func newScanner(filename string, src interface{}) (*lineScanner, error) {
 // the result of reading the file specified by filename.
 func readSource(filename string, src interface{}) ([]byte, error) {
 	if src == nil {
-		return ioutil.ReadFile(filename)
+		return os.ReadFile(filename)
 	}
 	switch s := src.(type) {
 	case string:

--- a/network/netplan/activate_test.go
+++ b/network/netplan/activate_test.go
@@ -4,7 +4,7 @@
 package netplan_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -65,9 +65,9 @@ func (s *ActivateSuite) TestActivateSuccess(c *gc.C) {
 	contents := make([][]byte, len(files))
 	for i, file := range files {
 		var err error
-		contents[i], err = ioutil.ReadFile(path.Join("testdata/TestReadWriteBackup", file))
+		contents[i], err = os.ReadFile(path.Join("testdata/TestReadWriteBackup", file))
 		c.Assert(err, jc.ErrorIsNil)
-		err = ioutil.WriteFile(path.Join(tempDir, file), contents[i], 0644)
+		err = os.WriteFile(path.Join(tempDir, file), contents[i], 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	result, err := netplan.BridgeAndActivate(params)
@@ -98,9 +98,9 @@ func (s *ActivateSuite) TestActivateDeviceAndVLAN(c *gc.C) {
 	contents := make([][]byte, len(files))
 	for i, file := range files {
 		var err error
-		contents[i], err = ioutil.ReadFile(path.Join("testdata/TestReadWriteBackup", file))
+		contents[i], err = os.ReadFile(path.Join("testdata/TestReadWriteBackup", file))
 		c.Assert(err, jc.ErrorIsNil)
-		err = ioutil.WriteFile(path.Join(tempDir, file), contents[i], 0644)
+		err = os.WriteFile(path.Join(tempDir, file), contents[i], 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	result, err := netplan.BridgeAndActivate(params)
@@ -131,9 +131,9 @@ func (s *ActivateSuite) TestActivateFailure(c *gc.C) {
 	contents := make([][]byte, len(files))
 	for i, file := range files {
 		var err error
-		contents[i], err = ioutil.ReadFile(path.Join("testdata/TestReadWriteBackup", file))
+		contents[i], err = os.ReadFile(path.Join("testdata/TestReadWriteBackup", file))
 		c.Assert(err, jc.ErrorIsNil)
-		err = ioutil.WriteFile(path.Join(tempDir, file), contents[i], 0644)
+		err = os.WriteFile(path.Join(tempDir, file), contents[i], 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	result, err := netplan.BridgeAndActivate(params)
@@ -145,17 +145,17 @@ func (s *ActivateSuite) TestActivateFailure(c *gc.C) {
 
 	// old files are in place and unchanged
 	for i, file := range files {
-		content, err := ioutil.ReadFile(path.Join(tempDir, file))
+		content, err := os.ReadFile(path.Join(tempDir, file))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(string(content), gc.Equals, string(contents[i]))
 	}
 	// there are no other YAML files in this directory
-	fileInfos, err := ioutil.ReadDir(tempDir)
+	dirEntries, err := os.ReadDir(tempDir)
 	c.Assert(err, jc.ErrorIsNil)
 
 	yamlCount := 0
-	for _, fileInfo := range fileInfos {
-		if !fileInfo.IsDir() && strings.HasSuffix(fileInfo.Name(), ".yaml") {
+	for _, entry := range dirEntries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".yaml") {
 			yamlCount++
 		}
 	}
@@ -187,9 +187,9 @@ func (s *ActivateSuite) TestActivateTimeout(c *gc.C) {
 	contents := make([][]byte, len(files))
 	for i, file := range files {
 		var err error
-		contents[i], err = ioutil.ReadFile(path.Join("testdata/TestReadWriteBackup", file))
+		contents[i], err = os.ReadFile(path.Join("testdata/TestReadWriteBackup", file))
 		c.Assert(err, jc.ErrorIsNil)
-		err = ioutil.WriteFile(path.Join(tempDir, file), contents[i], 0644)
+		err = os.WriteFile(path.Join(tempDir, file), contents[i], 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	result, err := netplan.BridgeAndActivate(params)

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -4,8 +4,8 @@
 package network_test
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/collections/set"
@@ -125,7 +125,7 @@ LXC_ADDR = "fooo"
  LXC_BRIDGE = " foobar " # detected, spaces stripped
 anything else ignored
 LXC_BRIDGE="ignored"`[1:])
-	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	err := os.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
 		if name == "foobar" {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -496,7 +496,7 @@ func newAzureResponseError(code int, status string) error {
 			},
 			Header:     header,
 			StatusCode: code,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		},
 	}
 }
@@ -552,7 +552,7 @@ func makeToolsList(osType string) tools.List {
 }
 
 func unmarshalRequestBody(c *gc.C, req *http.Request, out interface{}) {
-	bytes, err := ioutil.ReadAll(req.Body)
+	bytes, err := io.ReadAll(req.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	err = json.Unmarshal(bytes, out)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/azure/internal/azureauth/serviceprincipal_test.go
+++ b/provider/azure/internal/azureauth/serviceprincipal_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -272,7 +272,7 @@ func (s *InteractiveSuite) TestInteractiveRoleAssignmentAlreadyExists(c *gc.C) {
 		NewUUID:          s.newUUID,
 	}
 	sdkCtx := context.Background()
-	_, _, _, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
+	_, _, _, err := spc.InteractiveCreate(sdkCtx, io.Discard, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",
@@ -305,7 +305,7 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalAlreadyExists(c *gc.C)
 		NewUUID:          s.newUUID,
 	}
 	sdkCtx := context.Background()
-	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
+	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, io.Discard, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",
@@ -374,7 +374,7 @@ func (s *InteractiveSuite) testInteractiveRetriesCreateServicePrincipal(c *gc.C,
 		NewUUID: s.newUUID,
 	}
 	sdkCtx := context.Background()
-	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
+	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, io.Discard, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",
@@ -421,7 +421,7 @@ func (s *InteractiveSuite) TestInteractiveRetriesRoleAssignment(c *gc.C) {
 		NewUUID: s.newUUID,
 	}
 	sdkCtx := context.Background()
-	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, ioutil.Discard, azureauth.ServicePrincipalParams{
+	_, spObjectId, password, err := spc.InteractiveCreate(sdkCtx, io.Discard, azureauth.ServicePrincipalParams{
 		GraphEndpoint:             "https://graph.invalid",
 		GraphResourceId:           "https://graph.invalid",
 		ResourceManagerEndpoint:   "https://arm.invalid",

--- a/provider/azure/internal/azureauth/utils.go
+++ b/provider/azure/internal/azureauth/utils.go
@@ -6,7 +6,7 @@ package azureauth
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -59,11 +59,11 @@ func CheckForGraphError(r autorest.Responder) autorest.Responder {
 func maybeGraphError(resp *http.Response) (error, bool) {
 	if resp.Body != nil {
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Trace(err), false
 		}
-		resp.Body = ioutil.NopCloser(bytes.NewReader(b))
+		resp.Body = io.NopCloser(bytes.NewReader(b))
 
 		// Remove any UTF-8 BOM, if present.
 		b = bytes.TrimPrefix(b, []byte("\ufeff"))

--- a/provider/azure/internal/azureauth/utils_test.go
+++ b/provider/azure/internal/azureauth/utils_test.go
@@ -4,7 +4,7 @@
 package azureauth_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -71,7 +71,7 @@ func (ErrorSuite) TestCheckForGraphError(c *gc.C) {
 
 			// If the next in the chain is called then the response body should be unchanged.
 			defer resp.Body.Close()
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			c.Assert(err, jc.ErrorIsNil)
 			c.Check(string(b), gc.Equals, test.responseBody)
 			return nil
@@ -79,7 +79,7 @@ func (ErrorSuite) TestCheckForGraphError(c *gc.C) {
 
 		r = azureauth.CheckForGraphError(r)
 
-		err := r.Respond(&http.Response{Body: ioutil.NopCloser(strings.NewReader(test.responseBody))})
+		err := r.Respond(&http.Response{Body: io.NopCloser(strings.NewReader(test.responseBody))})
 		if test.expectError == "" {
 			c.Check(nextResponderCalled, gc.Equals, true)
 			continue

--- a/provider/azure/internal/azuretesting/recorder.go
+++ b/provider/azure/internal/azuretesting/recorder.go
@@ -5,7 +5,7 @@ package azuretesting
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 
@@ -30,7 +30,7 @@ func (p *RequestRecorderPolicy) Do(req *policy.Request) (*http.Response, error) 
 		if err := req.Raw().Body.Close(); err != nil {
 			return nil, err
 		}
-		reqCopy.Body = ioutil.NopCloser(&buf)
+		reqCopy.Body = io.NopCloser(&buf)
 		if err := req.RewindBody(); err != nil {
 			return nil, err
 		}
@@ -61,8 +61,8 @@ func RequestRecorder(requests *[]*http.Request) autorest.PrepareDecorator {
 				if err := req.Body.Close(); err != nil {
 					return nil, err
 				}
-				reqCopy.Body = ioutil.NopCloser(&buf)
-				req.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+				reqCopy.Body = io.NopCloser(&buf)
+				req.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
 			}
 			mu.Lock()
 			*requests = append(*requests, &reqCopy)

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -4,7 +4,7 @@
 package errorutils_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -102,7 +102,7 @@ func (*ErrorSuite) TestMaybeQuotaExceededError(c *gc.C) {
 	re := &azcore.ResponseError{
 		StatusCode: http.StatusBadRequest,
 		RawResponse: &http.Response{
-			Body: ioutil.NopCloser(buf),
+			Body: io.NopCloser(buf),
 		},
 	}
 	quotaErr, ok := errorutils.MaybeQuotaExceededError(re)
@@ -116,7 +116,7 @@ func (*ErrorSuite) TestIsConflictError(c *gc.C) {
 
 	re := &azcore.ResponseError{
 		RawResponse: &http.Response{
-			Body: ioutil.NopCloser(buf),
+			Body: io.NopCloser(buf),
 		},
 	}
 	ok := errorutils.IsConflictError(re)
@@ -151,7 +151,7 @@ func (*ErrorSuite) TestSimpleError(c *gc.C) {
 
 	re := &azcore.ResponseError{
 		RawResponse: &http.Response{
-			Body: ioutil.NopCloser(buf),
+			Body: io.NopCloser(buf),
 		},
 	}
 

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -541,7 +540,7 @@ func hostBootstrapSSHOptions(
 	}
 
 	// Create a temporary known_hosts file.
-	f, err := ioutil.TempFile("", "juju-known-hosts")
+	f, err := os.CreateTemp("", "juju-known-hosts")
 	if err != nil {
 		return nil, cleanup, errors.Trace(err)
 	}

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"crypto"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -663,7 +663,7 @@ func (s *BootstrapSuite) TestSuccess(c *gc.C) {
 		if c.Check(submatch, gc.NotNil, gc.Commentf("%s", sshArgs)) {
 			knownHostsFile := submatch[1]
 			knownHostsFile = strings.Replace(knownHostsFile, `\"`, ``, -1)
-			knownHostsBytes, err := ioutil.ReadFile(knownHostsFile)
+			knownHostsBytes, err := os.ReadFile(knownHostsFile)
 			if err != nil {
 				return err
 			}

--- a/provider/common/state.go
+++ b/provider/common/state.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/juju/errors"
 	goyaml "gopkg.in/yaml.v2"
@@ -75,7 +74,7 @@ func LoadState(stor storage.StorageReader) (*BootstrapState, error) {
 
 func loadState(r io.ReadCloser) (*BootstrapState, error) {
 	defer r.Close()
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %q: %v", StateFile, err)
 	}

--- a/provider/common/state_test.go
+++ b/provider/common/state_test.go
@@ -4,7 +4,7 @@
 package common_test
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -46,7 +46,7 @@ func (suite *StateSuite) TestCreateStateFileWritesEmptyStateFile(c *gc.C) {
 
 	reader, err := storage.Get(stor, common.StateFile)
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(data), gc.Equals, "")
 	c.Assert(url, gc.NotNil)
@@ -86,7 +86,7 @@ func (suite *StateSuite) TestSaveStateWritesStateFile(c *gc.C) {
 
 	loadedState, err := storage.Get(stor, common.StateFile)
 	c.Assert(err, jc.ErrorIsNil)
-	content, err := ioutil.ReadAll(loadedState)
+	content, err := io.ReadAll(loadedState)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(content, gc.DeepEquals, marshaledState)
 }
@@ -97,7 +97,7 @@ func (suite *StateSuite) setUpSavedState(c *gc.C, dataDir string) common.Bootstr
 	}
 	content, err := goyaml.Marshal(state)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(dataDir, common.StateFile), content, 0644)
+	err = os.WriteFile(filepath.Join(dataDir, common.StateFile), content, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	return state
 }

--- a/provider/ec2/credentials_test.go
+++ b/provider/ec2/credentials_test.go
@@ -4,7 +4,6 @@
 package ec2_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -92,7 +91,7 @@ func (s *credentialsSuite) assertDetectCredentialsKnownLocation(c *gc.C, dir str
 aws_access_key_id=aws-key-id
 aws_secret_access_key=aws-secret-access-key
 `[1:]
-	err = ioutil.WriteFile(path, []byte(credData), 0600)
+	err = os.WriteFile(path, []byte(credData), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	path = filepath.Join(location, "config")
@@ -100,7 +99,7 @@ aws_secret_access_key=aws-secret-access-key
 [default]
 region=region
 `[1:]
-	err = ioutil.WriteFile(path, []byte(regionData), 0600)
+	err = os.WriteFile(path, []byte(regionData), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Ensure any env vars are ignored.

--- a/provider/gce/credentials_test.go
+++ b/provider/gce/credentials_test.go
@@ -4,7 +4,6 @@
 package gce_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -61,7 +60,7 @@ func (s *credentialsSuite) TestOAuth2HiddenAttributes(c *gc.C) {
 func (s *credentialsSuite) TestJSONFileCredentialsValid(c *gc.C) {
 	dir := c.MkDir()
 	filename := filepath.Join(dir, "somefile")
-	err := ioutil.WriteFile(filename, []byte("contents"), 0600)
+	err := os.WriteFile(filename, []byte("contents"), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	envtesting.AssertProviderCredentialsValid(c, s.provider, "jsonfile", map[string]string{
 		// For now at least, the contents of the file are not validated
@@ -78,7 +77,7 @@ func createCredsFile(c *gc.C, path string) string {
 	}
 	creds, err := google.NewCredentials(sampleCredentialAttributes)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(path, creds.JSONKey, 0644)
+	err = os.WriteFile(path, creds.JSONKey, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	return path
 }

--- a/provider/gce/google/config.go
+++ b/provider/gce/google/config.go
@@ -6,7 +6,6 @@ package google
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/mail"
 
 	"github.com/juju/errors"
@@ -86,7 +85,7 @@ func NewCredentials(values map[string]string) (*Credentials, error) {
 // ParseJSONKey returns a new Credentials with values based on the
 // provided JSON key file contents.
 func ParseJSONKey(jsonKeyFile io.Reader) (*Credentials, error) {
-	jsonKey, err := ioutil.ReadAll(jsonKeyFile)
+	jsonKey, err := io.ReadAll(jsonKeyFile)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -181,7 +180,7 @@ func (p environProviderCredentials) detectLocalCredentials(certPEM, keyPEM []byt
 
 	label := fmt.Sprintf("LXD credential %q", lxdnames.DefaultCloud)
 	certCredential, err := p.finalizeLocalCredential(
-		ioutil.Discard, svr, string(certPEM), string(keyPEM), label,
+		io.Discard, svr, string(certPEM), string(keyPEM), label,
 	)
 	return certCredential, errors.Trace(err)
 }
@@ -538,11 +537,11 @@ type certificateReadWriter struct{}
 func (certificateReadWriter) Read(path string) ([]byte, []byte, error) {
 	clientCertPath := filepath.Join(path, "client.crt")
 	clientKeyPath := filepath.Join(path, "client.key")
-	certPEM, err := ioutil.ReadFile(clientCertPath)
+	certPEM, err := os.ReadFile(clientCertPath)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	keyPEM, err := ioutil.ReadFile(clientKeyPath)
+	keyPEM, err := os.ReadFile(clientKeyPath)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -555,10 +554,10 @@ func (certificateReadWriter) Write(path string, certPEM, keyPEM []byte) error {
 	if err := os.MkdirAll(path, 0700); err != nil {
 		return errors.Trace(err)
 	}
-	if err := ioutil.WriteFile(clientCertPath, certPEM, 0600); err != nil {
+	if err := os.WriteFile(clientCertPath, certPEM, 0600); err != nil {
 		return errors.Trace(err)
 	}
-	if err := ioutil.WriteFile(clientKeyPath, keyPEM, 0600); err != nil {
+	if err := os.WriteFile(clientKeyPath, keyPEM, 0600); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -5,7 +5,6 @@ package lxd
 
 import (
 	stdcontext "context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -412,7 +411,7 @@ func (p *environProvider) ConfigDefaults() schema.Defaults {
 type lxcConfigReader struct{}
 
 func (lxcConfigReader) ReadConfig(path string) (LXCConfig, error) {
-	configFile, err := ioutil.ReadFile(path)
+	configFile, err := os.ReadFile(path)
 	if err != nil {
 		if cause := errors.Cause(err); os.IsNotExist(cause) {
 			return LXCConfig{}, nil
@@ -429,6 +428,6 @@ func (lxcConfigReader) ReadConfig(path string) (LXCConfig, error) {
 }
 
 func (lxcConfigReader) ReadCert(path string) ([]byte, error) {
-	certFile, err := ioutil.ReadFile(path)
+	certFile, err := os.ReadFile(path)
 	return certFile, errors.Trace(err)
 }

--- a/provider/maas/credentials.go
+++ b/provider/maas/credentials.go
@@ -6,7 +6,6 @@ package maas
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +40,7 @@ func (environProviderCredentials) DetectCredentials(cloudName string) (*cloud.Cl
 	// MAAS stores credentials in a json file: ~/.maasrc
 	// {"Server": "http://<ip>/MAAS", "OAuth": "<key>"}
 	maasrc := filepath.Join(utils.Home(), ".maasrc")
-	fileBytes, err := ioutil.ReadFile(maasrc)
+	fileBytes, err := os.ReadFile(maasrc)
 	if os.IsNotExist(err) {
 		return nil, errors.NotFoundf("maas credentials")
 	}

--- a/provider/maas/environprovider_test.go
+++ b/provider/maas/environprovider_test.go
@@ -6,7 +6,7 @@ package maas
 import (
 	stdcontext "context"
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/gomaasapi/v2"
@@ -104,11 +104,11 @@ func (s *EnvironProviderSuite) TestPrepareConfigSetsDefaults(c *gc.C) {
 // create a temporary file with the given content.  The file will be cleaned
 // up at the end of the test calling this method.
 func createTempFile(c *gc.C, content []byte) string {
-	file, err := ioutil.TempFile(c.MkDir(), "")
+	file, err := os.CreateTemp(c.MkDir(), "")
 	defer file.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	filename := file.Name()
-	err = ioutil.WriteFile(filename, content, 0644)
+	err = os.WriteFile(filename, content, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	return filename
 }

--- a/provider/maas/maas_storage.go
+++ b/provider/maas/maas_storage.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 
@@ -53,7 +52,7 @@ func (stor *maasStorage) Get(name string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return ioutil.NopCloser(bytes.NewReader(contents)), nil
+	return io.NopCloser(bytes.NewReader(contents)), nil
 }
 
 // List implements storage.StorageReader

--- a/provider/maas/maas_storage_test.go
+++ b/provider/maas/maas_storage_test.go
@@ -5,7 +5,7 @@ package maas
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 
 	"github.com/juju/errors"
 	"github.com/juju/gomaasapi/v2"
@@ -68,7 +68,7 @@ func (s *maasStorageSuite) TestGetSuccess(c *gc.C) {
 	reader, err := storage.Get("grasshopper.avi")
 	c.Assert(err, jc.ErrorIsNil)
 	defer reader.Close()
-	result, err := ioutil.ReadAll(reader)
+	result, err := io.ReadAll(reader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []byte("The man in the high castle"))
 	controller.Stub.CheckCall(c, 0, "GetFile", "prefix-grasshopper.avi")

--- a/provider/oci/provider.go
+++ b/provider/oci/provider.go
@@ -6,7 +6,6 @@ package oci
 import (
 	stdcontext "context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -357,7 +356,7 @@ func (e EnvironProvider) DetectCredentials(cloudName string) (*cloud.CloudCreden
 			continue
 		}
 
-		pemFileContent, err := ioutil.ReadFile(values.KeyFile)
+		pemFileContent, err := os.ReadFile(values.KeyFile)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/provider/openstack/credentials_test.go
+++ b/provider/openstack/credentials_test.go
@@ -4,7 +4,7 @@
 package openstack_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -174,7 +174,7 @@ OS_REGION_NAME=region
 OS_PROJECT_DOMAIN_NAME=project-domain
 `[1:]
 	novarc := filepath.Join(dir, ".novarc")
-	err = ioutil.WriteFile(novarc, []byte(content), 0600)
+	err = os.WriteFile(novarc, []byte(content), 0600)
 	c.Assert(err, jc.ErrorIsNil)
 	credentials, err := s.provider.DetectCredentials("")
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -8,7 +8,7 @@ import (
 	stdcontext "context"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -2232,7 +2232,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	contentReader, imageURL, err := mappedSources["image-metadata-url"].Fetch(custom)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
-	content, err := ioutil.ReadAll(contentReader)
+	content, err := io.ReadAll(contentReader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, custom)
 	c.Check(imageURL[:8], gc.Equals, "https://")
@@ -2241,7 +2241,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 	contentReader, imageURL, err = mappedSources["keystone catalog"].Fetch(metadata)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
-	content, err = ioutil.ReadAll(contentReader)
+	content, err = io.ReadAll(contentReader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, metadata)
 	c.Check(imageURL[:8], gc.Equals, "https://")
@@ -2292,7 +2292,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSourcesWithCertificate
 	contentReader, imageURL, err := mappedSources["keystone catalog"].Fetch(metadata)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
-	content, err := ioutil.ReadAll(contentReader)
+	content, err := io.ReadAll(contentReader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, metadata)
 	c.Check(imageURL[:8], gc.Equals, "https://")
@@ -2340,7 +2340,7 @@ func (s *localHTTPSServerSuite) TestFetchFromToolsMetadataSources(c *gc.C) {
 	contentReader, metadataURL, err := sources[0].Fetch(custom)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
-	content, err := ioutil.ReadAll(contentReader)
+	content, err := io.ReadAll(contentReader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, custom)
 	c.Check(metadataURL[:8], gc.Equals, "https://")
@@ -2350,7 +2350,7 @@ func (s *localHTTPSServerSuite) TestFetchFromToolsMetadataSources(c *gc.C) {
 	contentReader, metadataURL, err = sources[1].Fetch(keystoneContainer + "/" + keystone)
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = contentReader.Close() }()
-	content, err = ioutil.ReadAll(contentReader)
+	content, err = io.ReadAll(contentReader)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, keystone)
 	c.Check(metadataURL[:8], gc.Equals, "https://")

--- a/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/provider/vsphere/internal/vsphereclient/client_test.go
@@ -6,7 +6,6 @@ package vsphereclient
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -539,7 +538,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 		var buf bytes.Buffer
 		io.Copy(&buf, r.Body)
 		rcopy := *r
-		rcopy.Body = ioutil.NopCloser(&buf)
+		rcopy.Body = io.NopCloser(&buf)
 		s.uploadRequests = append(s.uploadRequests, &rcopy)
 		if s.onImageUpload != nil {
 			s.onImageUpload(r)

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -65,7 +64,7 @@ func (s *clientSuite) TestCreateTemplateVM(c *gc.C) {
 		"streaming vmdk: 100.00% (0B/s)",
 	})
 	c.Assert(s.uploadRequests, gc.HasLen, 1)
-	contents, err := ioutil.ReadAll(s.uploadRequests[0].Body)
+	contents, err := io.ReadAll(s.uploadRequests[0].Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(contents), gc.Equals, "FakeVmdkContent")
 
@@ -798,7 +797,7 @@ func (s *clientSuite) TestVerifyMAC(c *gc.C) {
 func baseImportOVAParameters(c *gc.C, client *Client) ImportOVAParameters {
 	readOVA := func() (string, io.ReadCloser, error) {
 		r := bytes.NewReader(ovatest.FakeOVAContents())
-		return "fake-ova-location", ioutil.NopCloser(r), nil
+		return "fake-ova-location", io.NopCloser(r), nil
 	}
 	fakeSHA256 := ovatest.FakeOVASHA256()
 	fakeDS := types.ManagedObjectReference{

--- a/resource/charmhub_test.go
+++ b/resource/charmhub_test.go
@@ -5,7 +5,7 @@ package resource_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
@@ -72,7 +72,7 @@ func (s *CharmHubSuite) newCharmHubClient() *resource.CharmHubClient {
 }
 
 func (s *CharmHubSuite) expectDownloadResource() {
-	s.client.EXPECT().DownloadResource(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil)
+	s.client.EXPECT().DownloadResource(gomock.Any(), gomock.Any()).Return(io.NopCloser(bytes.NewBuffer([]byte{})), nil)
 }
 
 func (s *CharmHubSuite) expectRefresh() {

--- a/resource/opener_test.go
+++ b/resource/opener_test.go
@@ -6,7 +6,6 @@ package resource_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"sync"
 	"time"
 
@@ -184,10 +183,10 @@ func (s *OpenerSuite) expectCacheMethods(res resources.Resource, numConcurrentRe
 		s.resources.EXPECT().OpenResourceForUniter("postgresql/0", "wal-e").DoAndReturn(func(unitName, resName string) (resources.Resource, io.ReadCloser, error) {
 			s.unleash.Lock()
 			defer s.unleash.Unlock()
-			return resources.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e")
+			return resources.Resource{}, io.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e")
 		})
 	} else {
-		s.resources.EXPECT().OpenResource("postgresql", "wal-e").Return(resources.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e"))
+		s.resources.EXPECT().OpenResource("postgresql", "wal-e").Return(resources.Resource{}, io.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e"))
 	}
 	s.resources.EXPECT().GetResource("postgresql", "wal-e").Return(res, nil)
 	s.resources.EXPECT().SetResource("postgresql", "", res.Resource, gomock.Any(), state.DoNotIncrementCharmModifiedVersion).Return(res, nil)
@@ -195,9 +194,9 @@ func (s *OpenerSuite) expectCacheMethods(res resources.Resource, numConcurrentRe
 	other := res
 	other.ApplicationID = "postgreql"
 	if s.unitName != "" {
-		s.resources.EXPECT().OpenResourceForUniter("postgresql/0", "wal-e").Return(other, ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil).Times(numConcurrentRequests)
+		s.resources.EXPECT().OpenResourceForUniter("postgresql/0", "wal-e").Return(other, io.NopCloser(bytes.NewBuffer([]byte{})), nil).Times(numConcurrentRequests)
 	} else {
-		s.resources.EXPECT().OpenResource("postgresql", "wal-e").Return(other, ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil)
+		s.resources.EXPECT().OpenResource("postgresql", "wal-e").Return(other, io.NopCloser(bytes.NewBuffer([]byte{})), nil)
 	}
 }
 
@@ -220,7 +219,7 @@ func (s *OpenerSuite) TestGetResourceErrorReleasesLock(c *gc.C) {
 	s.resources.EXPECT().OpenResourceForUniter("postgresql/0", "wal-e").DoAndReturn(func(unitName, resName string) (resources.Resource, io.ReadCloser, error) {
 		s.unleash.Lock()
 		defer s.unleash.Unlock()
-		return resources.Resource{}, ioutil.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e")
+		return resources.Resource{}, io.NopCloser(bytes.NewBuffer([]byte{})), errors.NotFoundf("wal-e")
 	})
 	s.resources.EXPECT().GetResource("postgresql", "wal-e").Return(res, nil)
 	const retryCount = 3

--- a/scripts/mgo-run-txn/main.go
+++ b/scripts/mgo-run-txn/main.go
@@ -7,7 +7,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"time"
@@ -111,7 +111,7 @@ func main() {
 		fmt.Printf("error opening file %s:\n%s\n", flags.Arg(0), err)
 		os.Exit(1)
 	}
-	bytes, err := ioutil.ReadAll(f)
+	bytes, err := io.ReadAll(f)
 	if err != nil {
 		fmt.Printf("error reading file %s:\n%s\n", flags.Arg(0), err)
 		os.Exit(1)

--- a/scripts/schemadocs/schemadocs.go
+++ b/scripts/schemadocs/schemadocs.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -22,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	data, err := ioutil.ReadFile(os.Args[1])
+	data, err := os.ReadFile(os.Args[1])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/scripts/ssh-keycheck/ssh_keycheck.go
+++ b/scripts/ssh-keycheck/ssh_keycheck.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"os/user"
@@ -38,7 +38,7 @@ func getKnownHostKeys(fname string) []string {
 	}
 	defer func() { _ = f.Close() }()
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		panic(fmt.Sprintf("failed while reading known-hosts file: %q %v", fname, err))
 	}

--- a/service/snap/snap.go
+++ b/service/snap/snap.go
@@ -5,7 +5,7 @@ package snap
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -238,7 +238,7 @@ func (s Service) ConfigOverride() error {
 	}
 
 	unitOptions := systemd.ServiceLimits(s.conf)
-	data, err := ioutil.ReadAll(systemd.UnitSerialize(unitOptions))
+	data, err := io.ReadAll(systemd.UnitSerialize(unitOptions))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -248,7 +248,7 @@ func (s Service) ConfigOverride() error {
 		if err := os.MkdirAll(overridesDir, 0755); err != nil {
 			return errors.Trace(err)
 		}
-		if err := ioutil.WriteFile(filepath.Join(overridesDir, "overrides.conf"), data, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(overridesDir, "overrides.conf"), data, 0644); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/service/snap/snap_test.go
+++ b/service/snap/snap_test.go
@@ -5,7 +5,7 @@ package snap
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -92,7 +92,7 @@ func (*snapSuite) TestConfigOverride(c *gc.C) {
 	err = svc.ConfigOverride()
 	c.Assert(err, jc.ErrorIsNil)
 
-	data, err := ioutil.ReadFile(filepath.Join(dir, "snap.juju-db.daemon.service.d/overrides.conf"))
+	data, err := os.ReadFile(filepath.Join(dir, "snap.juju-db.daemon.service.d/overrides.conf"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, `
 [Service]

--- a/service/systemd/conf.go
+++ b/service/systemd/conf.go
@@ -6,7 +6,7 @@ package systemd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -137,7 +137,7 @@ func serialize(name string, conf common.Conf, renderer shell.Renderer) ([]byte, 
 	unitOptions = append(unitOptions, serializeInstall(conf)...)
 	// Don't use unit.Serialize because it has map ordering issues.
 	// Serialize copied locally, and outputs sections in alphabetical order.
-	data, err := ioutil.ReadAll(UnitSerialize(unitOptions))
+	data, err := io.ReadAll(UnitSerialize(unitOptions))
 	return data, errors.Trace(err)
 }
 

--- a/service/systemd/shims.go
+++ b/service/systemd/shims.go
@@ -4,7 +4,6 @@
 package systemd
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/juju/errors"
@@ -42,5 +41,5 @@ func (f fileSystemOps) RemoveAll(name string) error {
 // symbolic link, in which case attempting to write would return an error.
 func (f fileSystemOps) WriteFile(fileName string, data []byte, perm os.FileMode) error {
 	_ = os.Remove(fileName)
-	return errors.Trace(ioutil.WriteFile(fileName, data, perm))
+	return errors.Trace(os.WriteFile(fileName, data, perm))
 }

--- a/state/backups/archive.go
+++ b/state/backups/archive.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -84,7 +83,7 @@ type ArchiveWorkspace struct {
 }
 
 func newArchiveWorkspace() (*ArchiveWorkspace, error) {
-	rootdir, err := ioutil.TempDir("", "juju-backups-")
+	rootdir, err := os.MkdirTemp("", "juju-backups-")
 	if err != nil {
 		return nil, errors.Annotate(err, "while creating workspace dir")
 	}
@@ -200,7 +199,7 @@ func NewArchiveDataReader(r io.Reader) (*ArchiveData, error) {
 	}
 	defer func() { _ = gzr.Close() }()
 
-	data, err := ioutil.ReadAll(gzr)
+	data, err := io.ReadAll(gzr)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/backups/archive_data_test.go
+++ b/state/backups/archive_data_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -180,11 +179,11 @@ func (s *baseArchiveDataSuite) setupMetadata(c *gc.C, metadata string) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	archiveFile := newArchiveFile(c, meta)
-	compressed, err := ioutil.ReadAll(archiveFile)
+	compressed, err := io.ReadAll(archiveFile)
 	c.Assert(err, jc.ErrorIsNil)
 	gzr, err := gzip.NewReader(bytes.NewBuffer(compressed))
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := ioutil.ReadAll(gzr)
+	data, err := io.ReadAll(gzr)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.archiveFile = bytes.NewBuffer(compressed)

--- a/state/backups/archive_workspace_test.go
+++ b/state/backups/archive_workspace_test.go
@@ -4,7 +4,7 @@
 package backups_test
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/juju/testing"
@@ -69,7 +69,7 @@ func (s *workspaceSuiteV0) TestOpenBundledFile(c *gc.C) {
 	file, err := ws.OpenBundledFile("var/lib/juju/system-identity")
 	c.Assert(err, jc.ErrorIsNil)
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(data), gc.Equals, "<an ssh key goes here>")
 }

--- a/state/backups/backups_test.go
+++ b/state/backups/backups_test.go
@@ -6,7 +6,7 @@ package backups_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 
@@ -76,7 +76,7 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	dataDir := c.MkDir()
 	backupDir := c.MkDir()
 	// Patch the internals.
-	archiveFile := ioutil.NopCloser(bytes.NewBufferString("<compressed tarball>"))
+	archiveFile := io.NopCloser(bytes.NewBufferString("<compressed tarball>"))
 	result := backups.NewTestCreateResult(
 		archiveFile,
 		10,
@@ -214,7 +214,7 @@ func (s *backupsSuite) TestGetFileName(c *gc.C) {
 	// Purpose for metadata here is for the checksum to be used by the
 	// caller, so check it here.
 	c.Assert(resultMeta.FileMetadata.Checksum(), gc.NotNil)
-	b, err := ioutil.ReadAll(resultArchive)
+	b, err := io.ReadAll(resultArchive)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(b), gc.Equals, "archive file testing")
 

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -4,7 +4,6 @@
 package backups
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -274,28 +273,34 @@ func stripIgnored(ignored set.Strings, dumpDir string) error {
 // mongodump.  Note that, while mongodump is unlikely to change behavior
 // in this regard, this is not a documented guaranteed behavior.
 func listDatabases(dumpDir string) (set.Strings, error) {
-	list, err := ioutil.ReadDir(dumpDir)
+	dirEntries, err := os.ReadDir(dumpDir)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	logger.Tracef("%d files found in dump dir", len(list))
-	for _, info := range list {
+	logger.Tracef("%d files found in dump dir", len(dirEntries))
+	for _, entry := range dirEntries {
+		fi, err := entry.Info()
+		if err != nil {
+			logger.Errorf("failed to read file info: %s", entry.Name())
+			continue
+		}
+
 		logger.Tracef("file found in dump dir: %q dir=%v size=%d",
-			info.Name(), info.IsDir(), info.Size())
+			fi.Name(), fi.IsDir(), fi.Size())
 	}
-	if len(list) < 2 {
+	if len(dirEntries) < 2 {
 		// Should be *at least* oplog.bson and a data directory
-		return nil, errors.Errorf("too few files in dump dir (%d)", len(list))
+		return nil, errors.Errorf("too few files in dump dir (%d)", len(dirEntries))
 	}
 
 	databases := make(set.Strings)
-	for _, info := range list {
-		if !info.IsDir() {
+	for _, entry := range dirEntries {
+		if !entry.IsDir() {
 			// Notably, oplog.bson is thus excluded here.
 			continue
 		}
-		databases.Add(info.Name())
+		databases.Add(entry.Name())
 	}
 	return databases, nil
 }

--- a/state/backups/export_test.go
+++ b/state/backups/export_test.go
@@ -6,7 +6,6 @@ package backups
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/juju/errors"
 )
@@ -63,7 +62,7 @@ func NewTestCreate(result *createResult) (*createArgs, func(*createArgs) (*creat
 	var received createArgs
 
 	if result == nil {
-		archiveFile := ioutil.NopCloser(bytes.NewBufferString("<archive>"))
+		archiveFile := io.NopCloser(bytes.NewBufferString("<archive>"))
 		result = NewTestCreateResult(archiveFile, 10, "<checksum>", "")
 	}
 

--- a/state/backups/legacy_test.go
+++ b/state/backups/legacy_test.go
@@ -9,7 +9,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -88,7 +87,7 @@ func readTarFile(c *gc.C, tarFile io.Reader) map[string]string {
 			break
 		}
 		c.Assert(err, jc.ErrorIsNil)
-		buf, err := ioutil.ReadAll(tr)
+		buf, err := io.ReadAll(tr)
 		c.Assert(err, jc.ErrorIsNil)
 		contents[hdr.Name] = string(buf)
 	}

--- a/state/backups/metadata.go
+++ b/state/backups/metadata.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"time"
@@ -338,7 +337,7 @@ func (m *Metadata) AsJSONBuffer() (io.Reader, error) {
 
 // NewMetadataJSONReader extracts a new metadata from the JSON file.
 func NewMetadataJSONReader(in io.Reader) (*Metadata, error) {
-	data, err := ioutil.ReadAll(in)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/binarystorage/binarystorage_test.go
+++ b/state/binarystorage/binarystorage_test.go
@@ -6,7 +6,7 @@ package binarystorage_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	stdtesting "testing"
 
@@ -104,7 +104,7 @@ func (s *binaryStorageSuite) testAdd(c *gc.C, content string) {
 	defer rc.Close()
 	c.Assert(metadata, gc.Equals, addedMetadata)
 
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, content)
 }
@@ -181,7 +181,7 @@ func (s *binaryStorageSuite) TestOpen(c *gc.C) {
 		SHA256:  "hash(abc)",
 	})
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, "blah")
 }
@@ -366,7 +366,7 @@ func (s *binaryStorageSuite) assertMetadataAndContent(c *gc.C, expected binaryst
 	defer r.Close()
 	c.Assert(metadata, gc.Equals, expected)
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, content)
 }

--- a/state/binarystorage_test.go
+++ b/state/binarystorage_test.go
@@ -5,7 +5,7 @@ package state_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/juju/blobstore/v3"
@@ -185,7 +185,7 @@ func (s *binaryStorageSuite) TestToolsStorageLayered(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(rc, gc.NotNil)
 		defer rc.Close()
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), gc.Equals, contents)
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -5,7 +5,7 @@ package state
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"time" // Only used for time types.
@@ -356,11 +356,11 @@ bases:
   channel: "18.04"
 `
 			manifestYAML := filepath.Join(path, "manifest.yaml")
-			err := ioutil.WriteFile(manifestYAML, []byte(manifestContent), 0644)
+			err := os.WriteFile(manifestYAML, []byte(manifestContent), 0644)
 			c.Assert(err, jc.ErrorIsNil)
 		}
 		config := filepath.Join(path, filename)
-		err := ioutil.WriteFile(config, []byte(content), 0644)
+		err := os.WriteFile(config, []byte(content), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	ch, err := charm.ReadCharmDir(path)

--- a/state/imagestorage/image_test.go
+++ b/state/imagestorage/image_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	stdtesting "testing"
 	"time" // Only used for time types.
@@ -110,7 +109,7 @@ func (s *ImageSuite) testAddImage(c *gc.C, content string) {
 	defer rc.Close()
 	checkMetadata(c, metadata, addedMetadata)
 
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(data), gc.Equals, content)
 }
@@ -142,7 +141,7 @@ func (s *ImageSuite) TestImage(c *gc.C) {
 		SourceURL: "http://path",
 	})
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(data), gc.Equals, "blah")
 }
@@ -421,7 +420,7 @@ func (s *ImageSuite) assertImage(c *gc.C, expected *imagestorage.Metadata, conte
 	defer r.Close()
 	checkMetadata(c, metadata, expected)
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(data), gc.Equals, content)
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -6,7 +6,7 @@ package state_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"time"
 
@@ -2293,7 +2293,7 @@ func (s *MigrationExportSuite) TestResources(c *gc.C) {
 		_, reader, err := st.OpenResourceForUniter(u.Name(), "spam")
 		c.Assert(err, jc.ErrorIsNil)
 		defer reader.Close()
-		_, err = ioutil.ReadAll(reader) // Need to read the content to set the resource for the unit.
+		_, err = io.ReadAll(reader) // Need to read the content to set the resource for the unit.
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/state/resources_test.go
+++ b/state/resources_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"crypto/sha512"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sort"
 	"time"
 
@@ -333,7 +333,7 @@ func (s *ResourcesSuite) TestOpenResource(c *gc.C) {
 	spam.Timestamp = r.Timestamp
 	c.Assert(r, jc.DeepEquals, spam)
 
-	resData, err := ioutil.ReadAll(rdr)
+	resData, err := io.ReadAll(rdr)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(resData), gc.Equals, data)
 

--- a/state/storage/storage_test.go
+++ b/state/storage/storage_test.go
@@ -4,7 +4,7 @@
 package storage_test
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/juju/blobstore/v3"
@@ -62,7 +62,7 @@ func (s *StorageSuite) TestStorageGet(c *gc.C) {
 	defer r.Close()
 	c.Assert(length, gc.Equals, int64(3))
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, "abc")
 }
@@ -76,7 +76,7 @@ func (s *StorageSuite) TestStoragePut(c *gc.C) {
 	defer r.Close()
 
 	c.Assert(length, gc.Equals, int64(3))
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, "abc")
 }

--- a/storage/plans/iscsi/iscsi.go
+++ b/storage/plans/iscsi/iscsi.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -191,7 +190,7 @@ func (i *iscsiConnectionInfo) sessionBase(deviceName string) (string, error) {
 }
 
 func (i *iscsiConnectionInfo) deviceName() (string, error) {
-	items, err := ioutil.ReadDir(sysfsBlock)
+	items, err := os.ReadDir(sysfsBlock)
 	if err != nil {
 		return "", err
 	}
@@ -207,7 +206,7 @@ func (i *iscsiConnectionInfo) deviceName() (string, error) {
 			logger.Tracef("%s was not found. Skipping", tgtnameFile)
 			continue
 		}
-		tgtname, err := ioutil.ReadFile(tgtnameFile)
+		tgtname, err := os.ReadFile(tgtnameFile)
 		if err != nil {
 			return "", err
 		}

--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -4,7 +4,6 @@
 package provider_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -71,7 +70,7 @@ func testDetachFilesystems(
 	c.Assert(results, gc.HasLen, 1)
 	c.Assert(results[0], jc.ErrorIsNil)
 
-	data, err := ioutil.ReadFile(filepath.Join(etcDir, "fstab"))
+	data, err := os.ReadFile(filepath.Join(etcDir, "fstab"))
 	if os.IsNotExist(err) {
 		c.Assert(fstab, gc.Equals, "")
 		return

--- a/storage/provider/dirfuncs.go
+++ b/storage/provider/dirfuncs.go
@@ -4,7 +4,6 @@
 package provider
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -55,7 +54,7 @@ func (*osDirFuncs) lstat(path string) (fi os.FileInfo, err error) {
 }
 
 func (*osDirFuncs) fileCount(path string) (int, error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return 0, errors.Annotate(err, "could not read directory")
 	}

--- a/storage/provider/loop_test.go
+++ b/storage/provider/loop_test.go
@@ -4,7 +4,6 @@
 package provider_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -132,7 +131,7 @@ func (s *loopSuite) TestDestroyVolumes(c *gc.C) {
 	source, _ := s.loopVolumeSource(c)
 	fileName := filepath.Join(s.storageDir, "volume-0")
 
-	err := ioutil.WriteFile(fileName, nil, 0644)
+	err := os.WriteFile(fileName, nil, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	errs, err := source.DestroyVolumes(s.callCtx, []string{"volume-0"})
@@ -228,7 +227,7 @@ func (s *loopSuite) TestDetachVolumes(c *gc.C) {
 	s.commands.expect("losetup", "-d", "/dev/loop0")
 	s.commands.expect("losetup", "-d", "/dev/loop1")
 
-	err := ioutil.WriteFile(fileName, nil, 0644)
+	err := os.WriteFile(fileName, nil, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	errs, err := source.DetachVolumes(s.callCtx, []storage.VolumeAttachmentParams{{
@@ -256,7 +255,7 @@ func (s *loopSuite) TestDetachVolumesDetachFails(c *gc.C) {
 	cmd = s.commands.expect("losetup", "-d", "/dev/loop0")
 	cmd.respond("", errors.New("oy"))
 
-	err := ioutil.WriteFile(fileName, nil, 0644)
+	err := os.WriteFile(fileName, nil, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	errs, err := source.DetachVolumes(s.callCtx, []storage.VolumeAttachmentParams{{

--- a/storage/provider/managedfs.go
+++ b/storage/provider/managedfs.go
@@ -6,7 +6,6 @@ package provider
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -282,7 +281,7 @@ func ensureFstabEntry(etcDir, devicePath, UUID, mountPoint, entry string) error 
 		defer f.Close()
 	}
 
-	newFsTab, err := ioutil.TempFile(etcDir, "juju-fstab-")
+	newFsTab, err := os.CreateTemp(etcDir, "juju-fstab-")
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -399,7 +398,7 @@ func removeFstabEntry(etcDir string, mountPoint string) error {
 	scanner := bufio.NewScanner(f)
 
 	// Use a tempfile in /etc and rename when done.
-	newFsTab, err := ioutil.TempFile(etcDir, "juju-fstab-")
+	newFsTab, err := os.CreateTemp(etcDir, "juju-fstab-")
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/storage/provider/managedfs_test.go
+++ b/storage/provider/managedfs_test.go
@@ -5,7 +5,7 @@ package provider_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/names/v4"
@@ -125,7 +125,7 @@ const testMountPoint = "/in/the/place"
 
 func (s *managedfsSuite) TestAttachFilesystems(c *gc.C) {
 	nonRelatedFstabEntry := "/dev/foo /mount/point stuff"
-	err := ioutil.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(nonRelatedFstabEntry), 0644)
+	err := os.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(nonRelatedFstabEntry), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	mtabEntry := fmt.Sprintf("/dev/sda1 %s other relatime 0 0", testMountPoint)
@@ -135,7 +135,7 @@ func (s *managedfsSuite) TestAttachFilesystems(c *gc.C) {
 
 func (s *managedfsSuite) TestAttachFilesystemsMissingMtab(c *gc.C) {
 	nonRelatedFstabEntry := "/dev/foo /mount/point stuff\n"
-	err := ioutil.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(nonRelatedFstabEntry), 0644)
+	err := os.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(nonRelatedFstabEntry), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.testAttachFilesystems(c, false, false, "", "", nonRelatedFstabEntry)
@@ -143,7 +143,7 @@ func (s *managedfsSuite) TestAttachFilesystemsMissingMtab(c *gc.C) {
 
 func (s *managedfsSuite) TestAttachFilesystemsExistingFstabEntry(c *gc.C) {
 	existingFstabEntry := fmt.Sprintf("/dev/sda1 %s existing mtab stuff\n", testMountPoint)
-	err := ioutil.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(existingFstabEntry), 0644)
+	err := os.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(existingFstabEntry), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	mtabEntry := fmt.Sprintf("/dev/sda1 %s other mtab stuff", testMountPoint)
@@ -152,7 +152,7 @@ func (s *managedfsSuite) TestAttachFilesystemsExistingFstabEntry(c *gc.C) {
 
 func (s *managedfsSuite) TestAttachFilesystemsUpdateExistingFstabEntryWithUUID(c *gc.C) {
 	existingFstabEntry := fmt.Sprintf("/dev/sda1 %s existing mtab stuff\n", testMountPoint)
-	err := ioutil.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(existingFstabEntry), 0644)
+	err := os.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(existingFstabEntry), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedFstabEntry := fmt.Sprintf("# %s was on /dev/sda1 during installation\nUUID=deadbeaf %s other mtab,nofail stuff\n", testMountPoint, testMountPoint)
@@ -177,7 +177,7 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool,
 	cmd = s.commands.expect("df", "--output=source", testMountPoint)
 
 	if mtab != "" {
-		err := ioutil.WriteFile(filepath.Join(s.fakeEtcDir, "mtab"), []byte(mtab), 0644)
+		err := os.WriteFile(filepath.Join(s.fakeEtcDir, "mtab"), []byte(mtab), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -227,7 +227,7 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool,
 	}})
 
 	if fstab != "" {
-		data, err := ioutil.ReadFile(filepath.Join(s.fakeEtcDir, "fstab"))
+		data, err := os.ReadFile(filepath.Join(s.fakeEtcDir, "fstab"))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(data), gc.Equals, fstab)
 	}
@@ -236,7 +236,7 @@ func (s *managedfsSuite) testAttachFilesystems(c *gc.C, readOnly, reattach bool,
 func (s *managedfsSuite) TestDetachFilesystems(c *gc.C) {
 	nonRelatedFstabEntry := "/dev/foo /mount/point stuff\n"
 	fstabEntry := fmt.Sprintf("%s %s other mtab stuff", "/dev/sda1", testMountPoint)
-	err := ioutil.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(nonRelatedFstabEntry+fstabEntry), 0644)
+	err := os.WriteFile(filepath.Join(s.fakeEtcDir, "fstab"), []byte(nonRelatedFstabEntry+fstabEntry), 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	source := s.initSource(c)
 	testDetachFilesystems(c, s.commands, source, s.callCtx, true, s.fakeEtcDir, nonRelatedFstabEntry)

--- a/testcharms/charm.go
+++ b/testcharms/charm.go
@@ -7,7 +7,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -124,5 +123,5 @@ func InjectFilesToCharmArchive(pathToArchive string, fileContents map[string]str
 
 	// Overwrite original archive with the patched version
 	_, _ = zr.Close(), zw.Close()
-	return ioutil.WriteFile(pathToArchive, buf.Bytes(), 0644)
+	return os.WriteFile(pathToArchive, buf.Bytes(), 0644)
 }

--- a/testing/roundtripper.go
+++ b/testing/roundtripper.go
@@ -5,7 +5,7 @@ package testing
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -94,7 +94,7 @@ func newHTTPResponse(status string, statusCode int, body string) *http.Response 
 		// Parameter fields:
 		Status:        status,
 		StatusCode:    statusCode,
-		Body:          ioutil.NopCloser(strings.NewReader(body)),
+		Body:          io.NopCloser(strings.NewReader(body)),
 		ContentLength: int64(len(body)),
 	}
 }

--- a/testing/roundtripper_test.go
+++ b/testing/roundtripper_test.go
@@ -4,7 +4,7 @@
 package testing_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -29,7 +29,7 @@ func (s *metadataSuite) TestCannedRoundTripper(c *gc.C) {
 	resp, err := vrt.RoundTrip(req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp, gc.NotNil)
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, aContent)
 	c.Assert(resp.ContentLength, gc.Equals, int64(len(aContent)))
@@ -44,7 +44,7 @@ func (s *metadataSuite) TestCannedRoundTripperMissing(c *gc.C) {
 	resp, err := vrt.RoundTrip(req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(resp, gc.NotNil)
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, "")
 	c.Assert(resp.ContentLength, gc.Equals, int64(0))

--- a/version/version.go
+++ b/version/version.go
@@ -5,7 +5,6 @@ package version
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -69,7 +68,7 @@ func init() {
 	}()
 
 	toolsDir := filepath.Dir(os.Args[0])
-	v, err := ioutil.ReadFile(filepath.Join(toolsDir, "FORCE-VERSION"))
+	v, err := os.ReadFile(filepath.Join(toolsDir, "FORCE-VERSION"))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			fmt.Fprintf(os.Stderr, "WARNING: cannot read forced version: %v\n", err)

--- a/worker/apiaddressupdater/apiaddressupdater_test.go
+++ b/worker/apiaddressupdater/apiaddressupdater_test.go
@@ -4,7 +4,7 @@
 package apiaddressupdater_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -203,7 +203,7 @@ LXC_ADDR = "fooo"
 LXC_BRIDGE="foobar" # detected
 anything else ignored
 LXC_BRIDGE="ignored"`[1:])
-	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	err := os.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
 		if name == "foobar" {

--- a/worker/caasadmission/handler.go
+++ b/worker/caasadmission/handler.go
@@ -6,7 +6,7 @@ package caasadmission
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -55,7 +55,7 @@ func admissionHandler(logger Logger, rbacMapper RBACMapper, legacyLabels bool) h
 	codecFactory := serializer.NewCodecFactory(runtime.NewScheme())
 
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		data, err := ioutil.ReadAll(req.Body)
+		data, err := io.ReadAll(req.Body)
 		if err != nil {
 			logger.Errorf("digesting admission request body: %v", err)
 			http.Error(res, fmt.Sprintf("%s: reading request body",

--- a/worker/caasoperator/caasoperator.go
+++ b/worker/caasoperator/caasoperator.go
@@ -5,7 +5,6 @@ package caasoperator
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -685,8 +684,8 @@ func (op *caasOperator) remoteInit(client exec.Executor, unit names.UnitTag, run
 			Paths:        op.paths,
 			UnitTag:      unit,
 			ProviderID:   runningStatus.PodName,
-			WriteFile:    ioutil.WriteFile,
-			TempDir:      ioutil.TempDir,
+			WriteFile:    os.WriteFile,
+			TempDir:      os.MkdirTemp,
 			Clock:        op.config.Clock,
 			ReTrier:      runnerWithRetry,
 		}, cancel))

--- a/worker/caasoperator/caasoperator_test.go
+++ b/worker/caasoperator/caasoperator_test.go
@@ -4,7 +4,6 @@
 package caasoperator_test
 
 import (
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -150,7 +149,7 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 	agentBinaryDir := agenttools.ToolsDir(s.config.DataDir, "application-gitlab")
 	err = os.MkdirAll(agentBinaryDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(s.config.DataDir, "tools", "jujud"), []byte("jujud"), 0755)
+	err = os.WriteFile(filepath.Join(s.config.DataDir, "tools", "jujud"), []byte("jujud"), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -306,7 +305,7 @@ func (s *WorkerSuite) TestWorkerDownloadsCharm(c *gc.C) {
 
 	// fakeClient.Charm returns the SHA256 sum of fakeCharmContent.
 	fakeCharmPath := filepath.Join(c.MkDir(), "fake.charm")
-	err = ioutil.WriteFile(fakeCharmPath, fakeCharmContent, 0644)
+	err = os.WriteFile(fakeCharmPath, fakeCharmContent, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	f, err := os.Open(fakeCharmPath)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/caasoperator/manifold.go
+++ b/worker/caasoperator/manifold.go
@@ -6,7 +6,6 @@ package caasoperator
 import (
 	"crypto/tls"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -333,7 +332,7 @@ func socketConfig(info *caas.OperatorInfo) (*uniter.SocketConfig, error) {
 // LoadOperatorInfo loads the operator info file from the state dir.
 func LoadOperatorInfo(paths Paths) (*caas.OperatorInfo, error) {
 	filepath := path.Join(paths.State.BaseDir, caas.OperatorInfoFile)
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, errors.Annotatef(err, "reading operator info file %s", filepath)
 	}

--- a/worker/caasoperatorprovisioner/worker_test.go
+++ b/worker/caasoperatorprovisioner/worker_test.go
@@ -5,7 +5,7 @@ package caasoperatorprovisioner_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -156,7 +156,7 @@ func (s *CAASProvisionerSuite) assertOperatorCreated(c *gc.C, exists, updateCert
 	}
 
 	agentFile := filepath.Join(c.MkDir(), "agent.config")
-	err = ioutil.WriteFile(agentFile, config.AgentConf, 0644)
+	err = os.WriteFile(agentFile, config.AgentConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg, err := agent.ReadConfig(agentFile)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/deployer/package_test.go
+++ b/worker/deployer/package_test.go
@@ -5,7 +5,6 @@ package deployer_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	stdtesting "testing"
@@ -39,6 +38,6 @@ func (s *BaseSuite) InitializeCurrentToolsDir(c *gc.C, dataDir string) {
 	testTools := coretools.Tools{Version: current, URL: "http://testing.invalid/tools"}
 	data, err := json.Marshal(testTools)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(toolsPath, data, 0644)
+	err = os.WriteFile(toolsPath, data, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/worker/hostkeyreporter/worker.go
+++ b/worker/hostkeyreporter/worker.go
@@ -4,7 +4,6 @@
 package hostkeyreporter
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -100,7 +99,7 @@ func (w *hostkeyreporter) readSSHKeys() ([]string, error) {
 	}
 	keys := make([]string, 0, len(filenames))
 	for _, filename := range filenames {
-		key, err := ioutil.ReadFile(filename)
+		key, err := os.ReadFile(filename)
 		if err != nil {
 			logger.Debugf("unable to read SSH host key (skipping): %v", err)
 			continue

--- a/worker/hostkeyreporter/worker_test.go
+++ b/worker/hostkeyreporter/worker_test.go
@@ -5,7 +5,6 @@ package hostkeyreporter_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	writeKey := func(keyType string) {
 		baseName := fmt.Sprintf("ssh_host_%s_key.pub", keyType)
 		fileName := filepath.Join(sshDir, baseName)
-		err := ioutil.WriteFile(fileName, []byte(keyType), 0644)
+		err := os.WriteFile(fileName, []byte(keyType), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	writeKey("dsa")

--- a/worker/httpserver/worker_test.go
+++ b/worker/httpserver/worker_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -168,7 +167,7 @@ func (s *WorkerSuite) makeRequest(c *gc.C, url string) {
 	defer resp.Body.Close()
 
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, "hello, world")
 }
@@ -232,7 +231,7 @@ func (s *WorkerSuite) TestExitsWithTardyClients(c *gc.C) {
 		c.Fatalf("didn't stop after timeout")
 	}
 	// There should be a log file with goroutines.
-	data, err := ioutil.ReadFile(filepath.Join(s.logDir, "apiserver-debug.log"))
+	data, err := os.ReadFile(filepath.Join(s.logDir, "apiserver-debug.log"))
 	c.Assert(err, jc.ErrorIsNil)
 	lines := strings.Split(string(data), "\n")
 	c.Assert(len(lines), jc.GreaterThan, 1)

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -4,7 +4,7 @@
 package introspection
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 
@@ -26,7 +26,7 @@ func WriteProfileFunctions(profileDir string) error {
 		return nil
 	}
 	filename := profileFilename(profileDir)
-	if err := ioutil.WriteFile(filename, []byte(shellFuncs), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(shellFuncs), 0644); err != nil {
 		return errors.Annotate(err, "writing introspection bash funcs")
 	}
 	return nil

--- a/worker/introspection/script_test.go
+++ b/worker/introspection/script_test.go
@@ -4,7 +4,7 @@
 package introspection
 
 import (
-	"io/ioutil"
+	"os"
 	"runtime"
 
 	"github.com/juju/testing"
@@ -38,7 +38,7 @@ func (s *profileSuite) TestLinux(c *gc.C) {
 	err := WriteProfileFunctions(dir)
 	c.Assert(err, jc.ErrorIsNil)
 
-	content, err := ioutil.ReadFile(profileFilename(dir))
+	content, err := os.ReadFile(profileFilename(dir))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, shellFuncs)
 }

--- a/worker/introspection/worker_test.go
+++ b/worker/introspection/worker_test.go
@@ -6,7 +6,7 @@ package introspection_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -146,7 +146,7 @@ func (s *introspectionSuite) post(c *gc.C, path string, values url.Values) *http
 }
 
 func (s *introspectionSuite) body(c *gc.C, r *http.Response) string {
-	response, err := ioutil.ReadAll(r.Body)
+	response, err := io.ReadAll(r.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	return string(response)
 }

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -4,8 +4,8 @@
 package machiner_test
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	stdtesting "testing"
 
@@ -402,7 +402,7 @@ LXC_ADDR = "fooo"
 LXC_BRIDGE="foobar" # detected
 anything else ignored
 LXC_BRIDGE="ignored"`[1:])
-	err := ioutil.WriteFile(lxcFakeNetConfig, netConf, 0644)
+	err := os.WriteFile(lxcFakeNetConfig, netConf, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
 

--- a/worker/metrics/sender/sender_test.go
+++ b/worker/metrics/sender/sender_test.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"path/filepath"
 	"time"
@@ -183,7 +183,7 @@ func (s *senderSuite) TestSendingFails(c *gc.C) {
 }
 
 func (s *senderSuite) TestDataErrorIgnored(c *gc.C) {
-	err := ioutil.WriteFile(filepath.Join(s.spoolDir, "foo.meta"), []byte{}, 0644)
+	err := os.WriteFile(filepath.Join(s.spoolDir, "foo.meta"), []byte{}, 0644)
 	c.Assert(err, jc.ErrorIsNil)
 	apiSender := newTestAPIMetricSender()
 

--- a/worker/metrics/spool/listener_test.go
+++ b/worker/metrics/spool/listener_test.go
@@ -6,7 +6,6 @@ package spool_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"path/filepath"
 
@@ -53,7 +52,7 @@ func (s *listenerSuite) TestDial(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer readCloser.Close()
 
-	data, err := ioutil.ReadAll(readCloser)
+	data, err := io.ReadAll(readCloser)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, "Hello socket.")
 	s.handler.CheckCall(c, 0, "Handle")

--- a/worker/metrics/spool/manifold_test.go
+++ b/worker/metrics/spool/manifold_test.go
@@ -4,7 +4,7 @@
 package spool_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/testing"
@@ -85,7 +85,7 @@ func (s *ManifoldSuite) TestOutputBadTarget(c *gc.C) {
 }
 
 func (s *ManifoldSuite) TestCannotCreateSpoolDir(c *gc.C) {
-	c.Assert(ioutil.WriteFile(filepath.Join(s.spoolDir, "x"), nil, 0666), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(filepath.Join(s.spoolDir, "x"), nil, 0666), jc.ErrorIsNil)
 	spoolDir := filepath.Join(s.spoolDir, "x", "y")
 	context := dt.StubContext(nil, map[string]interface{}{
 		"agent-name": &dummyAgent{spoolDir: spoolDir},

--- a/worker/metrics/spool/metrics_file_test.go
+++ b/worker/metrics/spool/metrics_file_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -87,7 +86,7 @@ func (s *metricFileSuite) TestContention(c *gc.C) {
 	st, err := os.Stat(fileName)
 	c.Assert(err, gc.IsNil)
 	c.Assert(st.Size(), gc.Equals, int64(2))
-	contents, err := ioutil.ReadFile(fileName)
+	contents, err := os.ReadFile(fileName)
 	c.Assert(err, gc.IsNil)
 	c.Assert(contents, gc.DeepEquals, []byte("vi"))
 }

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -5,7 +5,7 @@ package proxyupdater
 
 import (
 	"io"
-	"io/ioutil"
+	stdos "os"
 	stdexec "os/exec"
 	"strings"
 
@@ -109,13 +109,13 @@ func (w *proxyWorker) saveProxySettings() error {
 	// - /etc/systemd/system.conf.d/juju-proxy.conf
 	// - /etc/systemd/user.conf.d/juju-proxy.conf - both in 'systemd' format
 	for _, file := range w.config.EnvFiles {
-		err := ioutil.WriteFile(file, []byte(w.proxy.AsScriptEnvironment()), 0644)
+		err := stdos.WriteFile(file, []byte(w.proxy.AsScriptEnvironment()), 0644)
 		if err != nil {
 			w.config.Logger.Errorf("Error updating environment file %s - %v", file, err)
 		}
 	}
 	for _, file := range w.config.SystemdFiles {
-		err := ioutil.WriteFile(file, []byte(w.proxy.AsSystemdDefaultEnv()), 0644)
+		err := stdos.WriteFile(file, []byte(w.proxy.AsSystemdDefaultEnv()), 0644)
 		if err != nil {
 			w.config.Logger.Errorf("Error updating systemd file - %v", err)
 		}
@@ -273,7 +273,7 @@ func (w *proxyWorker) handleAptProxyValues(aptSettings proxy.Settings, aptMirror
 
 		// Always finish with a new line.
 		content := paccmder.ProxyConfigContents(w.aptProxy) + "\n"
-		err = ioutil.WriteFile(config.AptProxyConfigFile, []byte(content), 0644)
+		err = stdos.WriteFile(config.AptProxyConfigFile, []byte(content), 0644)
 		if err != nil {
 			// It isn't really fatal, but we should record it.
 			w.config.Logger.Errorf("error writing apt proxy config file: %v", err)

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -5,7 +5,6 @@ package proxyupdater_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -156,7 +155,7 @@ func (s *ProxyUpdaterSuite) waitForFile(c *gc.C, filename, expected string) {
 			c.Fatalf("timeout while waiting for proxy settings to change")
 			return
 		case <-time.After(10 * time.Millisecond):
-			fileContent, err := ioutil.ReadFile(filename)
+			fileContent, err := os.ReadFile(filename)
 			if os.IsNotExist(err) {
 				continue
 			}

--- a/worker/raft/rafttransport/dialer.go
+++ b/worker/raft/rafttransport/dialer.go
@@ -5,7 +5,7 @@ package rafttransport
 
 import (
 	"bufio"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -66,7 +66,7 @@ func (d *Dialer) Dial(addr raft.ServerAddress, timeout time.Duration) (net.Conn,
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusSwitchingProtocols {
-		if body, err := ioutil.ReadAll(response.Body); err == nil && len(body) != 0 {
+		if body, err := io.ReadAll(response.Body); err == nil && len(body) != 0 {
 			logger.Tracef("response: %s", body)
 		}
 		return nil, errors.Errorf(

--- a/worker/syslogger/syslogger.go
+++ b/worker/syslogger/syslogger.go
@@ -5,14 +5,13 @@ package syslogger
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 // NewDiscard creates a new WriteCloser that discards all writes and the close
 // is a noop.
 func NewDiscard(priority Priority, tag string) (io.WriteCloser, error) {
 	return nopCloser{
-		Writer: ioutil.Discard,
+		Writer: io.Discard,
 	}, nil
 }
 

--- a/worker/uniter/charm/bundles_test.go
+++ b/worker/uniter/charm/bundles_test.go
@@ -4,7 +4,6 @@
 package charm_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -108,7 +107,7 @@ func (s *BundlesDirSuite) TestGet(c *gc.C) {
 	d := charm.NewBundlesDir(bunsDir, downloader, loggo.GetLogger(""))
 
 	checkDownloadsEmpty := func() {
-		files, err := ioutil.ReadDir(filepath.Join(bunsDir, "downloads"))
+		files, err := os.ReadDir(filepath.Join(bunsDir, "downloads"))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(files, gc.HasLen, 0)
 	}
@@ -172,8 +171,8 @@ func (s *ClearDownloadsSuite) TestWorks(c *gc.C) {
 	bunsDir := filepath.Join(baseDir, "bundles")
 	downloadDir := filepath.Join(bunsDir, "downloads")
 	c.Assert(os.MkdirAll(downloadDir, 0777), jc.ErrorIsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(downloadDir, "stuff"), []byte("foo"), 0755), jc.ErrorIsNil)
-	c.Assert(ioutil.WriteFile(filepath.Join(downloadDir, "thing"), []byte("bar"), 0755), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(filepath.Join(downloadDir, "stuff"), []byte("foo"), 0755), jc.ErrorIsNil)
+	c.Assert(os.WriteFile(filepath.Join(downloadDir, "thing"), []byte("bar"), 0755), jc.ErrorIsNil)
 
 	err := charm.ClearDownloads(bunsDir)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/relation/resolver_test.go
+++ b/worker/uniter/relation/resolver_test.go
@@ -4,7 +4,6 @@
 package relation_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -125,7 +124,7 @@ func (s *relationResolverSuite) SetUpTest(c *gc.C) {
 	s.charmDir = filepath.Join(c.MkDir(), "charm")
 	err := os.MkdirAll(s.charmDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(s.charmDir, "metadata.yaml"), []byte(minimalMetadata), 0755)
+	err = os.WriteFile(filepath.Join(s.charmDir, "metadata.yaml"), []byte(minimalMetadata), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 	s.leadershipContextFunc = func(accessor context.LeadershipSettingsAccessor, tracker leadership.Tracker, unitName string) context.LeadershipContext {
 		return &stubLeadershipContext{isLeader: true}

--- a/worker/uniter/relation/statetracker_test.go
+++ b/worker/uniter/relation/statetracker_test.go
@@ -4,7 +4,6 @@
 package relation_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -344,7 +343,7 @@ func (s *syncScopesSuite) setupCharmDir(c *gc.C) {
 	s.charmDir = filepath.Join(c.MkDir(), "charm")
 	err := os.MkdirAll(s.charmDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(filepath.Join(s.charmDir, "metadata.yaml"), []byte(minimalMetadata), 0755)
+	err = os.WriteFile(filepath.Join(s.charmDir, "metadata.yaml"), []byte(minimalMetadata), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/worker/uniter/runlistener.go
+++ b/worker/uniter/runlistener.go
@@ -7,9 +7,9 @@
 package uniter
 
 import (
-	"io/ioutil"
 	"net"
 	"net/rpc"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -184,7 +184,7 @@ func (r *RunListener) RunCommands(args RunCommandsArgs) (results *exec.ExecRespo
 		// TODO: Cache unit password
 		baseDir := agent.Dir(agentconfig.DataDir, names.NewUnitTag(args.UnitName))
 		infoFilePath := filepath.Join(baseDir, caas.OperatorClientInfoCacheFile)
-		d, err := ioutil.ReadFile(infoFilePath)
+		d, err := os.ReadFile(infoFilePath)
 		if err != nil {
 			return nil, errors.Annotatef(err, "reading %s", infoFilePath)
 		}

--- a/worker/uniter/runner/context/resources/content_test.go
+++ b/worker/uniter/runner/context/resources/content_test.go
@@ -4,7 +4,7 @@
 package resources_test
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 
 	charmresource "github.com/juju/charm/v9/resource"
@@ -93,7 +93,7 @@ func (s *CheckerSuite) TestVerifyOkay(c *gc.C) {
 	wrapped := checker.WrapReader(reader)
 
 	s.stub.CheckNoCalls(c)
-	data, err := ioutil.ReadAll(wrapped)
+	data, err := io.ReadAll(wrapped)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(string(data), gc.Equals, "some data")
 	err = checker.Verify()
@@ -111,7 +111,7 @@ func (s *CheckerSuite) TestVerifyFailed(c *gc.C) {
 	wrapped := checker.WrapReader(reader)
 
 	s.stub.CheckNoCalls(c)
-	_, err := ioutil.ReadAll(wrapped)
+	_, err := io.ReadAll(wrapped)
 	c.Assert(err, jc.ErrorIsNil)
 	err = checker.Verify()
 	c.Assert(err, gc.ErrorMatches, "resource size does not match expected \\(9 != 10\\)")

--- a/worker/uniter/runner/context/resources/context_test.go
+++ b/worker/uniter/runner/context/resources/context_test.go
@@ -4,7 +4,7 @@
 package resources_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/golang/mock/gomock"
@@ -49,7 +49,7 @@ func (s *ContextSuite) TestDownloadOutOfDate(c *gc.C) {
 
 	s.stub.CheckCallNames(c, "Read", "Read", "Close")
 	c.Assert(path, gc.Equals, filepath.Join(resourceDir, "spam.tgz"))
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, "some data")
 }
@@ -61,7 +61,7 @@ func (s *ContextSuite) TestContextDownloadUpToDate(c *gc.C) {
 
 	resourceDir := c.MkDir()
 	existing := filepath.Join(resourceDir, "spam.tgz")
-	err := ioutil.WriteFile(existing, []byte("some data"), 0755)
+	err := os.WriteFile(existing, []byte("some data"), 0755)
 	c.Assert(err, jc.ErrorIsNil)
 
 	client := mocks.NewMockOpenedResourceClient(ctrl)

--- a/worker/uniter/runner/context/resources/resource.go
+++ b/worker/uniter/runner/context/resources/resource.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	charmresource "github.com/juju/charm/v9/resource"
 	"github.com/juju/errors"
@@ -40,7 +39,7 @@ func OpenResource(name string, client OpenedResourceClient) (*OpenedResource, er
 		info.Path = "content.yaml"
 		// Image data is stored as json but we need to convert to YAMl
 		// as that's what the charm expects.
-		data, err := ioutil.ReadAll(reader)
+		data, err := io.ReadAll(reader)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/worker/uniter/runner/context/resources/resource_test.go
+++ b/worker/uniter/runner/context/resources/resource_test.go
@@ -4,7 +4,7 @@
 package resources_test
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/testing"
@@ -72,7 +72,7 @@ func (s *OpenedResourceSuite) TestDockerImage(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(opened.Path, gc.Equals, "content.yaml")
 	content := opened.Content()
-	data, err := ioutil.ReadAll(content.Data)
+	data, err := io.ReadAll(content.Data)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, `
 registrypath: image-name

--- a/worker/uniter/runner/debug/server.go
+++ b/worker/uniter/runner/debug/server.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,7 +51,7 @@ var waitClientExit = func(s *ServerSession) {
 // the hookName; otherwise, it will point to a script that acts as the dispatcher
 // for all hooks/actions.
 func (s *ServerSession) RunHook(hookName, charmDir string, env []string, hookRunner string) error {
-	debugDir, err := ioutil.TempDir("", "juju-debug-hooks-")
+	debugDir, err := os.MkdirTemp("", "juju-debug-hooks-")
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -119,7 +118,7 @@ func (s *ServerSession) writeDebugFiles(debugDir, help, hookRunner string) error
 		{"hook.sh", debugHooksHookScript, 0755},
 	}
 	for _, file := range files {
-		if err := ioutil.WriteFile(
+		if err := os.WriteFile(
 			filepath.Join(debugDir, file.filename),
 			[]byte(file.contents),
 			file.mode,
@@ -143,7 +142,7 @@ func (c *HooksContext) FindSession() (*ServerSession, error) {
 		}
 	}
 	// Parse the debug-hooks file for an optional hook name.
-	data, err := ioutil.ReadFile(c.ClientFileLock())
+	data, err := os.ReadFile(c.ClientFileLock())
 	if err != nil {
 		return nil, err
 	}

--- a/worker/uniter/runner/jujuc/config-get_test.go
+++ b/worker/uniter/runner/jujuc/config-get_test.go
@@ -6,7 +6,7 @@ package jujuc_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3"
@@ -155,7 +155,7 @@ func (s *ConfigGetSuite) TestOutputPath(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+	content, err := os.ReadFile(filepath.Join(ctx.Dir, "some-file"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, "False\n")
 }

--- a/worker/uniter/runner/jujuc/goal-state_test.go
+++ b/worker/uniter/runner/jujuc/goal-state_test.go
@@ -4,7 +4,7 @@
 package jujuc_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3"
@@ -105,7 +105,7 @@ func (s *GoalStateSuite) TestOutputPath(c *gc.C) {
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 		c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
 
-		content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+		content, err := os.ReadFile(filepath.Join(ctx.Dir, "some-file"))
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(string(content), gc.Equals, t.out)
 	}

--- a/worker/uniter/runner/jujuc/k8s-raw-set_test.go
+++ b/worker/uniter/runner/jujuc/k8s-raw-set_test.go
@@ -5,7 +5,7 @@ package jujuc_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3"
@@ -140,7 +140,7 @@ func (s *rawK8sSpecSetSuite) initCommand(c *gc.C, hctx jujuc.Context, yaml strin
 		ctx.Stdin = bytes.NewBufferString(yaml)
 	} else if filename != "" {
 		filename = filepath.Join(c.MkDir(), filename)
-		err := ioutil.WriteFile(filename, []byte(yaml), 0644)
+		err := os.WriteFile(filename, []byte(yaml), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 		args = append(args, "--file", filename)
 	}

--- a/worker/uniter/runner/jujuc/k8s-spec-set_test.go
+++ b/worker/uniter/runner/jujuc/k8s-spec-set_test.go
@@ -5,7 +5,7 @@ package jujuc_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3"
@@ -154,14 +154,14 @@ func (s *K8sSpecSetSuite) initCommand(
 		ctx.Stdin = bytes.NewBufferString(yaml)
 	} else if filename != "" {
 		filename = filepath.Join(c.MkDir(), filename)
-		err := ioutil.WriteFile(filename, []byte(yaml), 0644)
+		err := os.WriteFile(filename, []byte(yaml), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 		args = append(args, "--file", filename)
 	}
 	if withK8sResource {
 		k8sResourceFileName := "k8sresources.yaml"
 		k8sResourceFileName = filepath.Join(c.MkDir(), k8sResourceFileName)
-		err := ioutil.WriteFile(k8sResourceFileName, []byte(k8sResourcesYaml), 0644)
+		err := os.WriteFile(k8sResourceFileName, []byte(k8sResourcesYaml), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 		args = append(args, "--k8s-resources", k8sResourceFileName)
 	}

--- a/worker/uniter/runner/jujuc/payload-register_test.go
+++ b/worker/uniter/runner/jujuc/payload-register_test.go
@@ -4,7 +4,7 @@
 package jujuc_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/golang/mock/gomock"
@@ -124,7 +124,7 @@ func (s *registerSuite) TestRunError(c *gc.C) {
 func setupMetadata(c *gc.C) *cmd.Context {
 	dir := c.MkDir()
 	path := filepath.Join(dir, "metadata.yaml")
-	err := ioutil.WriteFile(path, []byte(metadataContents), 0660)
+	err := os.WriteFile(path, []byte(metadataContents), 0660)
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	ctx.Dir = dir

--- a/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/worker/uniter/runner/jujuc/relation-get_test.go
@@ -6,7 +6,7 @@ package jujuc_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3"
@@ -297,7 +297,7 @@ func (s *RelationGetSuite) TestOutputPath(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+	content, err := os.ReadFile(filepath.Join(ctx.Dir, "some-file"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, "pew\npew\n\n")
 }

--- a/worker/uniter/runner/jujuc/relation-set.go
+++ b/worker/uniter/runner/jujuc/relation-set.go
@@ -6,7 +6,6 @@ package jujuc
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
@@ -97,7 +96,7 @@ func (c *RelationSetCommand) Init(args []string) error {
 }
 
 func readSettings(in io.Reader) (map[string]string, error) {
-	data, err := ioutil.ReadAll(in)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/worker/uniter/runner/jujuc/relation-set_test.go
@@ -7,7 +7,7 @@ package jujuc_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3"
@@ -123,7 +123,7 @@ func (t relationSetInitTest) init(c *gc.C, s *RelationSetSuite) (cmd.Command, []
 	} else if filename != "" {
 		filename = filepath.Join(c.MkDir(), filename)
 		args[i] = filename
-		err := ioutil.WriteFile(filename, []byte(t.content), 0644)
+		err := os.WriteFile(filename, []byte(t.content), 0644)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/worker/uniter/runner/jujuc/secret-add_test.go
+++ b/worker/uniter/runner/jujuc/secret-add_test.go
@@ -4,7 +4,6 @@
 package jujuc_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -170,7 +169,7 @@ func (s *SecretAddSuite) TestAddSecretFromFile(c *gc.C) {
 
 	dir := c.MkDir()
 	fileName := filepath.Join(dir, "secret.yaml")
-	err := ioutil.WriteFile(fileName, []byte(data), os.FileMode(0644))
+	err := os.WriteFile(fileName, []byte(data), os.FileMode(0644))
 	c.Assert(err, jc.ErrorIsNil)
 
 	hctx, _ := s.ContextSuite.NewHookContext()

--- a/worker/uniter/runner/jujuc/secret-set_test.go
+++ b/worker/uniter/runner/jujuc/secret-set_test.go
@@ -4,7 +4,6 @@
 package jujuc_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -141,7 +140,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretFromFile(c *gc.C) {
 
 	dir := c.MkDir()
 	fileName := filepath.Join(dir, "secret.yaml")
-	err := ioutil.WriteFile(fileName, []byte(data), os.FileMode(0644))
+	err := os.WriteFile(fileName, []byte(data), os.FileMode(0644))
 	c.Assert(err, jc.ErrorIsNil)
 
 	hctx, _ := s.ContextSuite.NewHookContext()

--- a/worker/uniter/runner/jujuc/server_test.go
+++ b/worker/uniter/runner/jujuc/server_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -66,7 +65,7 @@ func (c *RpcCommand) Run(ctx *cmd.Context) error {
 	}
 	ctx.Stdout.Write([]byte("eye of newt\n"))
 	ctx.Stderr.Write([]byte("toe of frog\n"))
-	return ioutil.WriteFile(ctx.AbsPath("local"), []byte(c.Value), 0644)
+	return os.WriteFile(ctx.AbsPath("local"), []byte(c.Value), 0644)
 }
 
 func factory(contextId, cmdName string) (cmd.Command, error) {
@@ -135,7 +134,7 @@ func (s *ServerSuite) TestHappyPath(c *gc.C) {
 	c.Assert(resp.Code, gc.Equals, 0)
 	c.Assert(string(resp.Stdout), gc.Equals, "wool of bat\neye of newt\n")
 	c.Assert(string(resp.Stderr), gc.Equals, "toe of frog\n")
-	content, err := ioutil.ReadFile(filepath.Join(dir, "local"))
+	content, err := os.ReadFile(filepath.Join(dir, "local"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, "something")
 }

--- a/worker/uniter/runner/jujuc/status-get_test.go
+++ b/worker/uniter/runner/jujuc/status-get_test.go
@@ -5,7 +5,7 @@ package jujuc_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3"
@@ -136,7 +136,7 @@ func (s *statusGetSuite) TestOutputPath(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+	content, err := os.ReadFile(filepath.Join(ctx.Dir, "some-file"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	var out map[string]interface{}

--- a/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/worker/uniter/runner/jujuc/storage-get_test.go
@@ -5,7 +5,7 @@ package jujuc_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/juju/cmd/v3"
@@ -96,7 +96,7 @@ func (s *storageGetSuite) TestOutputPath(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+	content, err := os.ReadFile(filepath.Join(ctx.Dir, "some-file"))
 	c.Assert(err, jc.ErrorIsNil)
 
 	var out map[string]interface{}

--- a/worker/uniter/runner/jujuc/unit-get_test.go
+++ b/worker/uniter/runner/jujuc/unit-get_test.go
@@ -5,7 +5,7 @@
 package jujuc_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -70,7 +70,7 @@ func (s *UnitGetSuite) TestOutputPath(c *gc.C) {
 	c.Assert(code, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-	content, err := ioutil.ReadFile(filepath.Join(ctx.Dir, "some-file"))
+	content, err := os.ReadFile(filepath.Join(ctx.Dir, "some-file"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, "192.168.0.99\n")
 }

--- a/worker/uniter/runner/runner_test.go
+++ b/worker/uniter/runner/runner_test.go
@@ -6,7 +6,7 @@ package runner_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -303,7 +303,7 @@ func (s *RunMockContextSuite) SetUpTest(c *gc.C) {
 
 func (s *RunMockContextSuite) assertRecordedPid(c *gc.C, expectPid int) {
 	path := filepath.Join(s.paths.GetCharmDir(), "pid")
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	c.Assert(err, jc.ErrorIsNil)
 	expectContent := fmt.Sprintf("%d", expectPid)
 	c.Assert(strings.TrimRight(string(content), "\r\n"), gc.Equals, expectContent)

--- a/worker/uniter/runner/util_test.go
+++ b/worker/uniter/runner/util_test.go
@@ -5,7 +5,6 @@ package runner_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -273,7 +272,7 @@ func makeCharm(c *gc.C, spec hookSpec, charmDir string) {
 func makeCharmMetadata(c *gc.C, charmDir string) {
 	err := os.MkdirAll(charmDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(path.Join(charmDir, "metadata.yaml"), nil, 0664)
+	err = os.WriteFile(path.Join(charmDir, "metadata.yaml"), nil, 0664)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -6,7 +6,6 @@ package uniter_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1049,7 +1048,7 @@ type verifyCharm struct {
 func (s verifyCharm) step(c *gc.C, ctx *testContext) {
 	s.checkFiles.Check(c, filepath.Join(ctx.path, "charm"))
 	path := filepath.Join(ctx.path, "charm", "revision")
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(content), gc.Equals, strconv.Itoa(s.revision))
 	checkRevision := s.revision
@@ -1350,7 +1349,7 @@ func (s writeFile) step(c *gc.C, ctx *testContext) {
 	dir := filepath.Dir(path)
 	err := os.MkdirAll(dir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ioutil.WriteFile(path, nil, s.mode)
+	err = os.WriteFile(path, nil, s.mode)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/wrench/wrench_test.go
+++ b/wrench/wrench_test.go
@@ -4,7 +4,6 @@
 package wrench_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -57,7 +56,7 @@ func (s *wrenchSuite) createWrenchDir(c *gc.C) {
 
 func (s *wrenchSuite) createWrenchFile(c *gc.C, name, content string) string {
 	filename := filepath.Join(s.wrenchDir, name)
-	err := ioutil.WriteFile(filename, []byte(content), 0700)
+	err := os.WriteFile(filename, []byte(content), 0700)
 	c.Assert(err, jc.ErrorIsNil)
 	return filename
 }


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~~[ ] Go unit tests, with comments saying what you're testing~~
- ~~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~~
- ~~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

This PR does not introduce any functional changes. The code should continue to build and the existing tests should also pass.

```sh
go build ./...
```
