### PR TITLE
[JUJU-1636, JUJU-1783] Rewrite api/client/highavailability unit tests to use gomock

### DIFF
--- a/api/client/highavailability/package_test.go
+++ b/api/client/highavailability/package_test.go
@@ -1,0 +1,22 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package highavailability
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
+}


### PR DESCRIPTION
The unit tests for `api/client/highavailability` now use go mock and not juju/testing. All unit tests should pass.