### PR TITLE
Fixes dashboard proxying bug in Juju 3.0.

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -276,7 +276,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 						Spec: *podSpec,
 					},
 					PodManagementPolicy: appsv1.ParallelPodManagement,
-					ServiceName:         headlessServiceName(a.name),
+					ServiceName:         HeadlessServiceName(a.name),
 				},
 			},
 		}
@@ -534,7 +534,7 @@ type annotationUpdater interface {
 }
 
 func (a *app) upgradeHeadlessService(applier resources.Applier, ver version.Number) error {
-	r := resources.NewService(headlessServiceName(a.name), a.namespace, nil)
+	r := resources.NewService(HeadlessServiceName(a.name), a.namespace, nil)
 	if err := r.Get(context.Background(), a.client); err != nil {
 		return errors.Trace(err)
 	}
@@ -629,12 +629,14 @@ func (a *app) Exists() (caas.DeploymentState, error) {
 	return state, nil
 }
 
-func headlessServiceName(appName string) string {
+// HeadlessServiceName is an idempotent function for returning the name of the
+// endpoints service juju make for applications.
+func HeadlessServiceName(appName string) string {
 	return fmt.Sprintf("%s-endpoints", appName)
 }
 
 func (a *app) configureHeadlessService(name string, annotation annotations.Annotation) error {
-	svc := resources.NewService(headlessServiceName(name), a.namespace, &corev1.Service{
+	svc := resources.NewService(HeadlessServiceName(name), a.namespace, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: a.labels(),
 			Annotations: annotation.
@@ -932,7 +934,7 @@ func (a *app) Delete() error {
 	switch a.deploymentType {
 	case caas.DeploymentStateful:
 		applier.Delete(resources.NewStatefulSet(a.name, a.namespace, nil))
-		applier.Delete(resources.NewService(headlessServiceName(a.name), a.namespace, nil))
+		applier.Delete(resources.NewService(HeadlessServiceName(a.name), a.namespace, nil))
 	case caas.DeploymentStateless:
 		applier.Delete(resources.NewDeployment(a.name, a.namespace, nil))
 	case caas.DeploymentDaemon:

--- a/caas/kubernetes/provider/connection.go
+++ b/caas/kubernetes/provider/connection.go
@@ -19,7 +19,11 @@ import (
 // connections to the specified application. This assume the presence of a
 // corresponding service for the application.
 func (k *kubernetesClient) ProxyToApplication(appName, remotePort string) (proxy.Proxier, error) {
-	svc, err := k.findServiceForApplication(appName)
+	svc, err := findServiceForApplication(
+		context.TODO(),
+		k.client().CoreV1().Services(k.namespace),
+		appName,
+		k.IsLegacyLabels())
 	if err != nil {
 		return nil, errors.Annotatef(err, "finding service to proxy to for application %s", appName)
 	}

--- a/caas/kubernetes/provider/services_test.go
+++ b/caas/kubernetes/provider/services_test.go
@@ -1,0 +1,147 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type servicesSuite struct {
+	client *fake.Clientset
+}
+
+var _ = gc.Suite(&servicesSuite{})
+
+func (s *servicesSuite) SetUpTest(c *gc.C) {
+	s.client = fake.NewSimpleClientset()
+}
+
+func (s *servicesSuite) TestFindServiceForApplication(c *gc.C) {
+	_, err := s.client.CoreV1().Services("test").Create(
+		context.TODO(),
+		&core.Service{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "wallyworld",
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "wallyworld",
+					"app.kubernetes.io/managed-by": "juju",
+				},
+			},
+		},
+		meta.CreateOptions{},
+	)
+
+	c.Assert(err, jc.ErrorIsNil)
+
+	svc, err := findServiceForApplication(
+		context.TODO(),
+		s.client.CoreV1().Services("test"),
+		"wallyworld",
+		false,
+	)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(svc.Name, gc.Equals, "wallyworld")
+}
+
+func (s *servicesSuite) TestFindServiceForApplicationWithEndpoints(c *gc.C) {
+	_, err := s.client.CoreV1().Services("test").Create(
+		context.TODO(),
+		&core.Service{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "wallyworld",
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "wallyworld",
+					"app.kubernetes.io/managed-by": "juju",
+				},
+			},
+		},
+		meta.CreateOptions{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.client.CoreV1().Services("test").Create(
+		context.TODO(),
+		&core.Service{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "wallyworld-endpoints",
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "wallyworld",
+					"app.kubernetes.io/managed-by": "juju",
+				},
+			},
+		},
+		meta.CreateOptions{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	svc, err := findServiceForApplication(
+		context.TODO(),
+		s.client.CoreV1().Services("test"),
+		"wallyworld",
+		false,
+	)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(svc.Name, gc.Equals, "wallyworld")
+}
+
+func (s *servicesSuite) TestFindServiceForApplicationWithMultiple(c *gc.C) {
+	_, err := s.client.CoreV1().Services("test").Create(
+		context.TODO(),
+		&core.Service{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "wallyworld",
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "wallyworld",
+					"app.kubernetes.io/managed-by": "juju",
+				},
+			},
+		},
+		meta.CreateOptions{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.client.CoreV1().Services("test").Create(
+		context.TODO(),
+		&core.Service{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "wallyworld-v2",
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "wallyworld",
+					"app.kubernetes.io/managed-by": "juju",
+				},
+			},
+		},
+		meta.CreateOptions{},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = findServiceForApplication(
+		context.TODO(),
+		s.client.CoreV1().Services("test"),
+		"wallyworld",
+		false,
+	)
+
+	c.Assert(errors.Is(err, errors.NotValid), jc.IsTrue)
+}
+
+func (s *servicesSuite) TestFindServiceForApplicationMissing(c *gc.C) {
+	_, err := findServiceForApplication(
+		context.TODO(),
+		s.client.CoreV1().Services("test"),
+		"wallyworld",
+		false,
+	)
+
+	c.Assert(errors.Is(err, errors.NotFound), jc.IsTrue)
+}


### PR DESCRIPTION
Due to a new endpoints service made by Juju for statefulset deployments our dashboard proxying mechanism has stopped working in k8s as we get confused about what service to use.

This change ignores the endpoints service when considering what service to proxy onto for the client.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
1. Bootstrap Juju to a kubernetes cluster
2. Switch to the Juju controller model. `juju switch controller`
3. Deploy the dashboard charm. `juju deploy juju-dashboard-k8s --channel=edge`
4. Relate the dashboard to the controller. `juju relate juju-dashboard-k8s controller`
5. Test the dashboard command works with. `juju dashboard`
```

## Documentation changes

N/A

## Bug reference

N/A
