### PR TITLE
[JUJU-1886] Early work for lp1951415. containeragent to pebble.

### DIFF
--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -425,7 +425,7 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 			Image:           "operator/image-path:1.1.1",
 			WorkingDir:      jujuDataDir,
 			Command:         []string{"/opt/containeragent"},
-			Args:            []string{"init", "--data-dir", "/var/lib/juju", "--bin-dir", "/charm/bin"},
+			Args:            []string{"init", "--containeragent-pebble-dir", "/containeragent/pebble", "--charm-modified-version", "9001", "--data-dir", "/var/lib/juju", "--bin-dir", "/charm/bin"},
 			Env: []corev1.EnvVar{
 				{
 					Name:  "JUJU_CONTAINER_NAMES",
@@ -465,6 +465,11 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 				},
 				{
 					Name:      "charm-data",
+					MountPath: "/containeragent/pebble",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
 					MountPath: "/charm/bin",
 					SubPath:   "charm/bin",
 				},
@@ -480,13 +485,11 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Image:           "ubuntu:20.04",
 			WorkingDir:      jujuDataDir,
-			Command:         []string{"/charm/bin/containeragent"},
+			Command:         []string{"/charm/bin/pebble"},
 			Args: []string{
-				"unit",
-				"--data-dir", jujuDataDir,
-				"--charm-modified-version", "9001",
-				"--append-env", "PATH=$PATH:/charm/bin",
-				"--show-log",
+				"run",
+				"--http", ":38812",
+				"--verbose",
 			},
 			Env: []corev1.EnvVar{
 				{
@@ -505,40 +508,35 @@ func getPodSpec(c *gc.C) corev1.PodSpec {
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: constants.AgentHTTPPathLiveness,
-						Port: intstr.Parse(constants.AgentHTTPProbePort),
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
 					},
 				},
 				InitialDelaySeconds: 30,
-				PeriodSeconds:       10,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    2,
+				FailureThreshold:    1,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: constants.AgentHTTPPathReadiness,
-						Port: intstr.Parse(constants.AgentHTTPProbePort),
+						Path: "/v1/health?level=ready",
+						Port: intstr.Parse("38812"),
 					},
 				},
 				InitialDelaySeconds: 30,
-				PeriodSeconds:       10,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    2,
-			},
-			StartupProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: constants.AgentHTTPPathStartup,
-						Port: intstr.Parse(constants.AgentHTTPProbePort),
-					},
-				},
-				InitialDelaySeconds: 30,
-				PeriodSeconds:       10,
-				SuccessThreshold:    1,
-				FailureThreshold:    2,
+				FailureThreshold:    1,
 			},
 			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
+				},
 				{
 					Name:      "charm-data",
 					MountPath: "/charm/bin",

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -31,6 +31,10 @@ const (
 	// AgentHTTPPathStartup is the path used for startup probes on the agent
 	AgentHTTPPathStartup = "/startup"
 
+	// DefaultPebbleDir is the default directory Pebble considers when starting
+	// up.
+	DefaultPebbleDir = "/var/lib/pebble/default"
+
 	// JujuRunServerSocketPort is the port used by juju run callbacks.
 	JujuRunServerSocketPort = 30666
 

--- a/cmd/constants/constants.go
+++ b/cmd/constants/constants.go
@@ -1,0 +1,8 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package constants
+
+const (
+	DefaultHTTPProbePort = "65301"
+)

--- a/cmd/constants/env.go
+++ b/cmd/constants/env.go
@@ -1,0 +1,8 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package constants
+
+const (
+	EnvHTTPProbePort = "HTTP_PROBE_PORT"
+)

--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -5,20 +5,25 @@ package initialize
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path"
+	"time"
 
+	"github.com/canonical/pebble/plan"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo"
 	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v3"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/agent/caasapplication"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/constants"
 	"github.com/juju/juju/cmd/containeragent/utils"
 	"github.com/juju/juju/worker/apicaller"
 )
@@ -32,6 +37,14 @@ type initCommand struct {
 	applicationAPI   ApplicationAPI
 	fileReaderWriter utils.FileReaderWriter
 	environment      utils.Environment
+
+	// charmModifiedVersion holds just that and is used for generating the
+	// pebble service to run the container agent.
+	charmModifiedVersion string
+
+	// containerAgentPebbleDir holds the path to the pebble config dir used on
+	// the container agent.
+	containerAgentPebbleDir string
 
 	dataDir string
 	binDir  string
@@ -55,6 +68,8 @@ func New() cmd.Command {
 
 // SetFlags implements Command.
 func (c *initCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.containerAgentPebbleDir, "containeragent-pebble-dir", "", "directory for container agent pebble config")
+	f.StringVar(&c.charmModifiedVersion, "charm-modified-version", "", "charm modified version for update hook")
 	f.StringVar(&c.dataDir, "data-dir", "", "directory for juju data")
 	f.StringVar(&c.binDir, "bin-dir", "", "copy juju binaries to this directory")
 }
@@ -79,6 +94,9 @@ func (c *initCommand) getApplicationAPI() (ApplicationAPI, error) {
 }
 
 func (c *initCommand) Init(args []string) error {
+	if c.containerAgentPebbleDir == "" {
+		return errors.NotValidf("--containeragent-pebble-dir")
+	}
 	if c.dataDir == "" {
 		return errors.NotValidf("--data-dir")
 	}
@@ -138,10 +156,87 @@ func (c *initCommand) Run(ctx *cmd.Context) error {
 			return nil
 		})
 	}
+
+	if err := c.ContainerAgentPebbleConfig(); err != nil {
+		return err
+	}
+
 	doCopy("/opt/pebble", path.Join(c.binDir, "pebble"))
 	doCopy("/opt/containeragent", path.Join(c.binDir, "containeragent"))
 	doCopy("/opt/jujuc", path.Join(c.binDir, "jujuc"))
 	return eg.Wait()
+}
+
+// ContainerAgentPebbleConfig is responsible for generating the container agent
+// pebble service configuration.
+func (c *initCommand) ContainerAgentPebbleConfig() error {
+	extraArgs := ""
+	// If we actually have the charmModifiedVersion let's add it the args.
+	if c.charmModifiedVersion != "" {
+		extraArgs = "--charm-modified-version " + c.charmModifiedVersion
+	}
+
+	containerAgentLayer := plan.Layer{
+		Summary: "Juju container agent service",
+		Services: map[string]*plan.Service{
+			"container-agent": {
+				Summary:  "Juju container agent",
+				Override: "replace",
+				Command: fmt.Sprintf("%s unit --data-dir %s --append-env \"PATH=$PATH:%s\" --show-log %s",
+					path.Join(c.binDir, "containeragent"),
+					c.dataDir,
+					c.binDir,
+					extraArgs),
+				Startup: "enabled",
+				OnCheckFailure: map[string]plan.ServiceAction{
+					"liveness":  "shutdown",
+					"readiness": "shutdown",
+				},
+				Environment: map[string]string{
+					constants.EnvHTTPProbePort: constants.DefaultHTTPProbePort,
+				},
+			},
+		},
+		Checks: map[string]*plan.Check{
+			"readiness": {
+				Override:  "replace",
+				Level:     "ready",
+				Period:    plan.OptionalDuration{Value: 10 * time.Second, IsSet: true},
+				Timeout:   plan.OptionalDuration{Value: 3 * time.Second, IsSet: true},
+				Threshold: 3,
+				HTTP: &plan.HTTPCheck{
+					URL: fmt.Sprintf("http://localhost:%s/readiness", constants.DefaultHTTPProbePort),
+				},
+			},
+			"liveness": {
+				Override:  "replace",
+				Level:     "ready",
+				Period:    plan.OptionalDuration{Value: 10 * time.Second, IsSet: true},
+				Timeout:   plan.OptionalDuration{Value: 3 * time.Second, IsSet: true},
+				Threshold: 3,
+				HTTP: &plan.HTTPCheck{
+					URL: fmt.Sprintf("http://localhost:%s/liveness", constants.DefaultHTTPProbePort),
+				},
+			},
+		},
+	}
+
+	layerDir := path.Join(c.containerAgentPebbleDir, "layers")
+	if err := c.fileReaderWriter.MkdirAll(layerDir, 0555); err != nil {
+		return fmt.Errorf("making pebble container agent layer dir at %q: %w", layerDir, err)
+	}
+
+	p := path.Join(layerDir, "001-container-agent.yaml")
+
+	rawConfig, err := yaml.Marshal(&containerAgentLayer)
+	if err != nil {
+		return fmt.Errorf("making pebble container agent layer yaml: %w", err)
+	}
+
+	if err := c.fileReaderWriter.WriteFile(p, rawConfig, 0444); err != nil {
+		return fmt.Errorf("writing container agent pebble configuration to %q: %w", p, err)
+	}
+	return nil
 }
 
 func (c *initCommand) CurrentConfig() agent.Config {

--- a/cmd/containeragent/initialize/command_test.go
+++ b/cmd/containeragent/initialize/command_test.go
@@ -91,6 +91,37 @@ apiport: 17070`[1:])
 	expectedContainerAgent := []byte(`CONTAINERAGENT`)
 	expectedJujuc := []byte(`JUJUC`)
 
+	expectedCAPebbleService := []byte(`summary: Juju container agent service
+services:
+    container-agent:
+        summary: Juju container agent
+        startup: enabled
+        override: replace
+        command: '/charm/bin/containeragent unit --data-dir /var/lib/juju --append-env "PATH=$PATH:/charm/bin" --show-log '
+        environment:
+            HTTP_PROBE_PORT: "65301"
+        on-check-failure:
+            liveness: shutdown
+            readiness: shutdown
+checks:
+    liveness:
+        override: replace
+        level: ready
+        period: 10s
+        timeout: 3s
+        threshold: 3
+        http:
+            url: http://localhost:65301/liveness
+    readiness:
+        override: replace
+        level: ready
+        period: 10s
+        timeout: 3s
+        threshold: 3
+        http:
+            url: http://localhost:65301/readiness
+`)
+
 	pebbleWritten := bytes.NewBuffer(nil)
 	containerAgentWritten := bytes.NewBuffer(nil)
 	jujucWritten := bytes.NewBuffer(nil)
@@ -111,11 +142,14 @@ apiport: 17070`[1:])
 		s.fileReaderWriter.EXPECT().MkdirAll("/var/lib/juju", os.FileMode(0755)).Return(nil),
 		s.fileReaderWriter.EXPECT().WriteFile("/var/lib/juju/template-agent.conf", data, os.FileMode(0644)).Return(nil),
 		s.fileReaderWriter.EXPECT().MkdirAll("/charm/bin", os.FileMode(0755)).Return(nil),
+		s.fileReaderWriter.EXPECT().MkdirAll("/containeragent/pebble/layers", os.FileMode(0555)).Return(nil),
+		s.fileReaderWriter.EXPECT().WriteFile("/containeragent/pebble/layers/001-container-agent.yaml", expectedCAPebbleService, os.FileMode(0444)).Return(nil),
 
 		s.applicationAPI.EXPECT().Close().Times(1).Return(nil),
 	)
 
 	_, err := cmdtesting.RunCommand(c, s.cmd,
+		"--containeragent-pebble-dir", "/containeragent/pebble",
 		"--data-dir", "/var/lib/juju",
 		"--bin-dir", "/charm/bin",
 	)

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -52,6 +52,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"charmstore",
 		"cloud",
 		"cmd",
+		"cmd/constants",
 		"controller",
 		"core/charm/metrics",
 		"core/constraints",

--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/api/base"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/constants"
 	"github.com/juju/juju/cmd/containeragent/utils"
 	"github.com/juju/juju/cmd/jujud/agent/agentconf"
 	"github.com/juju/juju/cmd/jujud/agent/engine"
@@ -268,9 +269,9 @@ func (c *containerUnitAgent) ChangeConfig(mutate agent.ConfigMutator) error {
 
 // Workers returns a dependency.Engine running the k8s unit agent's responsibilities.
 func (c *containerUnitAgent) workers() (worker.Worker, error) {
-	probePort := os.Getenv(k8sconstants.EnvAgentHTTPProbePort)
+	probePort := os.Getenv(constants.EnvHTTPProbePort)
 	if probePort == "" {
-		return nil, errors.NotValidf("env %s missing", k8sconstants.EnvAgentHTTPProbePort)
+		probePort = constants.DefaultHTTPProbePort
 	}
 
 	updateAgentConfLogging := func(loggingConfig string) error {
@@ -295,6 +296,7 @@ func (c *containerUnitAgent) workers() (worker.Worker, error) {
 		PrometheusRegisterer: c.prometheusRegistry,
 		UpdateLoggerConfig:   updateAgentConfLogging,
 		PreviousAgentVersion: agentConfig.UpgradedToVersion(),
+		ProbeAddress:         "localhost",
 		ProbePort:            probePort,
 		MachineLock:          c.machineLock,
 		Clock:                c.clk,

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -90,6 +90,10 @@ type manifoldsConfig struct {
 	// config value as the logging config in the agent.conf file.
 	UpdateLoggerConfig func(string) error
 
+	// ProbeAddress describes the net dial address to use for binding the
+	// receiving agent probe requests.
+	ProbeAddress string
+
 	// ProbePort describes the http port to operator on for receiving agent
 	// probe requests.
 	ProbePort string

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.9.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20220729021256-d9b6b8c3b562
+	github.com/canonical/pebble v0.0.0-20220929050154-fb9b611ab115
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20220729021256-d9b6b8c3b562 h1:6AaAlZ1RTap/3tM875FDAPWdQUtvNrh3OV5XksgRhgo=
-github.com/canonical/pebble v0.0.0-20220729021256-d9b6b8c3b562/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
+github.com/canonical/pebble v0.0.0-20220929050154-fb9b611ab115 h1:sz1h0S2xg8Ey2SPqgfRzvD7iB8pqvx4Twx2stiCi6UI=
+github.com/canonical/pebble v0.0.0-20220929050154-fb9b611ab115/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
 github.com/canonical/pretty v0.3.1-0.20220821212646-771f4dc6714f h1:Fm69JbIBVe7mbpAhQPSCGcFO3enqhX8+mdRsCcGnc8g=
 github.com/canonical/pretty v0.3.1-0.20220821212646-771f4dc6714f/go.mod h1:tMVdMxJgEKAzwkfAW0q3SaFOCR2tWN+TwNnOvolaR+Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/worker/muxhttpserver/manifold.go
+++ b/worker/muxhttpserver/manifold.go
@@ -13,6 +13,9 @@ import (
 )
 
 type ManifoldConfig struct {
+	// Address is the host portion to use to net.Dial
+	Address string
+
 	AuthorityName string
 	Logger        Logger
 	Port          string
@@ -55,6 +58,10 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 	}
 
 	serverConfig := DefaultConfig()
+	if c.Address != "" {
+		serverConfig.Address = c.Address
+	}
+
 	if c.Port != "" {
 		serverConfig.Port = c.Port
 	}


### PR DESCRIPTION
Early work for lp1951415 that allows the container agent to run under pebble.

As part of  lp1951415 we need to move the container  agent under pebble. This PR introduces that change.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. Bootstrap Juju to a Kubernetes cluster
2. Deploy a workload and check that the container agent for each pod is running under pebble and happy.
3. Check relations.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1951415
