### PR TITLE
[JUJU-1829] Add support for secrets migration

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -538,7 +538,7 @@ func (s *SecretsManagerAPI) SecretsRotated(args params.SecretRotatedArgs) (param
 		willExpire := md.LatestExpireTime != nil && md.LatestExpireTime.Before(nextRotateTime)
 		forcedRotateTime := lastRotateTime.Add(coresecrets.RotateRetryDelay)
 		if willExpire {
-			logger.Warningf("secret %q rev %d will expire before next scheduled rotation", uri.String(), md.LatestExpireTime.UTC().Format(time.RFC3339))
+			logger.Warningf("secret %q rev %d will expire before next scheduled rotation", uri.String(), md.LatestRevision)
 		}
 		if willExpire && forcedRotateTime.Before(*md.LatestExpireTime) || !arg.Skip && md.LatestRevision == arg.OriginalRevision {
 			nextRotateTime = forcedRotateTime

--- a/apiserver/facades/client/bundle/state.go
+++ b/apiserver/facades/client/bundle/state.go
@@ -6,6 +6,7 @@ package bundle
 import (
 	"github.com/juju/charm/v9"
 	"github.com/juju/description/v3"
+
 	"github.com/juju/juju/state"
 )
 
@@ -39,6 +40,7 @@ func (m *stateShim) GetExportConfig() state.ExportConfig {
 	cfg.SkipUnitAgentBinaries = true
 	cfg.SkipInstanceData = true
 	cfg.SkipExternalControllers = true
+	cfg.SkipSecrets = true
 
 	return cfg
 }

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/juju/clock v1.0.2
 	github.com/juju/cmd/v3 v3.0.2
 	github.com/juju/collections v1.0.0
-	github.com/juju/description/v3 v3.0.1
+	github.com/juju/description/v3 v3.0.2
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -742,8 +742,8 @@ github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71d
 github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.0 h1:iuWddKN/SMbjLoyOpcnAl8XyBCavZm6coeFBcXQldbw=
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
-github.com/juju/description/v3 v3.0.1 h1:vFvjhSulX+DtTAVDs9FoLnCQcr8CiFD+/SwGYS4dYAg=
-github.com/juju/description/v3 v3.0.1/go.mod h1:i2ZbXp3mj6EnOgexunf9DsnsZuyOB5oT0y0Lek8vBSs=
+github.com/juju/description/v3 v3.0.2 h1:HE8qZthoYyJTefjBxzHlUVB3CYJLY9/pwDgEjFKMNjw=
+github.com/juju/description/v3 v3.0.2/go.mod h1:gPRoYLLAYVXhlR5UHLvcfC5JvQHrF6GLryozBEk0s8g=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/secrets/provider/vault/secrets.go
+++ b/secrets/provider/vault/secrets.go
@@ -233,7 +233,7 @@ func (p vaultProvider) StoreConfig(m provider.Model, adminUser bool, owned []*se
 	modelUUID := m.UUID()
 	var policies []string
 	if adminUser {
-		// For admin users, add secrets for the model can be read.
+		// For admin users, all secrets for the model can be read.
 		rule := fmt.Sprintf(`path "%s/*" {capabilities = ["read"]}`, modelUUID)
 		policyName := fmt.Sprintf("model-%s-read", modelUUID)
 		err = sys.PutPolicyWithContext(ctx, policyName, rule)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -217,6 +217,9 @@ func (ctrl *Controller) Import(model description.Model) (_ *Model, _ *State, err
 	if err := restore.storage(); err != nil {
 		return nil, nil, errors.Annotate(err, "storage")
 	}
+	if err := restore.secrets(); err != nil {
+		return nil, nil, errors.Annotate(err, "secrets")
+	}
 
 	// NOTE: at the end of the import make sure that the mode of the model
 	// is set to "imported" not "active" (or whatever we call it). This way
@@ -1657,7 +1660,7 @@ func (i *importer) firewallRules() error {
 	if err := migration.Run(); err != nil {
 		return errors.Trace(err)
 	}
-	i.logger.Debugf("importing remote applications succeeded")
+	i.logger.Debugf("importing firewall rules succeeded")
 	return nil
 }
 
@@ -2751,5 +2754,25 @@ func (i *importer) storagePools() error {
 			return errors.Annotatef(err, "creating pool %q", pool.Name())
 		}
 	}
+	return nil
+}
+
+func (i *importer) secrets() error {
+	i.logger.Debugf("importing secrets")
+	migration := &ImportStateMigration{
+		src: i.model,
+		dst: i.st.db(),
+	}
+	migration.Add(func() error {
+		m := ImportSecrets{}
+		return m.Execute(stateModelNamspaceShim{
+			Model: migration.src,
+			st:    i.st,
+		}, migration.dst)
+	})
+	if err := migration.Run(); err != nil {
+		return errors.Trace(err)
+	}
+	i.logger.Debugf("importing secrets succeeded")
 	return nil
 }

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/secrets"
 )
 
 // Migration import tasks provide a boundary of isolation between the
@@ -494,6 +495,130 @@ func (ImportExternalControllers) Execute(src ExternalControllersInput, runner Tr
 			return errors.Trace(err)
 		}
 		ops[i] = src.MakeExternalControllerOp(doc, existing)
+	}
+
+	if err := runner.RunTransaction(ops); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// SecretsDescription defines an in-place usage for reading secrets.
+type SecretsDescription interface {
+	Secrets() []description.Secret
+}
+
+// SecretsInput describes the input used for migrating secrets.
+type SecretsInput interface {
+	DocModelNamespace
+	SecretsDescription
+}
+
+// ImportSecrets describes a way to import secrets from a
+// description.
+type ImportSecrets struct{}
+
+// Execute the import on the secrets description, carefully modelling
+// the dependencies we have.
+func (ImportSecrets) Execute(src SecretsInput, runner TransactionRunner) error {
+	allSecrets := src.Secrets()
+	if len(allSecrets) == 0 {
+		return nil
+	}
+
+	var ops []txn.Op
+	for _, secret := range allSecrets {
+		uri := &secrets.URI{ID: secret.Id()}
+		docID := src.DocID(secret.Id())
+		owner, err := secret.Owner()
+		if err != nil {
+			return errors.Annotatef(err, "invalid owner for secret %q", secret.Id())
+		}
+		ops = append(ops, txn.Op{
+			C:      secretMetadataC,
+			Id:     docID,
+			Assert: txn.DocMissing,
+			Insert: secretMetadataDoc{
+				DocID:            docID,
+				Version:          secret.Version(),
+				OwnerTag:         owner.String(),
+				Description:      secret.Description(),
+				Label:            secret.Label(),
+				LatestRevision:   secret.LatestRevision(),
+				LatestExpireTime: secret.LatestExpireTime(),
+				RotatePolicy:     secret.RotatePolicy(),
+				CreateTime:       secret.Created(),
+				UpdateTime:       secret.Updated(),
+			},
+		})
+		if secret.NextRotateTime() != nil {
+			nextRotateTime := secret.NextRotateTime()
+			ops = append(ops, txn.Op{
+				C:      secretRotateC,
+				Id:     docID,
+				Assert: txn.DocMissing,
+				Insert: secretRotationDoc{
+					DocID:          docID,
+					NextRotateTime: *nextRotateTime,
+				},
+			})
+		}
+		for _, rev := range secret.Revisions() {
+			key := secretRevisionKey(uri, rev.Number())
+			dataCopy := make(secretsDataMap)
+			for k, v := range rev.Content() {
+				dataCopy[k] = v
+			}
+			ops = append(ops, txn.Op{
+				C:      secretRevisionsC,
+				Id:     key,
+				Assert: txn.DocMissing,
+				Insert: secretRevisionDoc{
+					DocID:      key,
+					Revision:   rev.Number(),
+					CreateTime: rev.Created(),
+					UpdateTime: rev.Updated(),
+					ExpireTime: rev.ExpireTime(),
+					Obsolete:   rev.Obsolete(),
+					Data:       dataCopy,
+					ProviderId: rev.ProviderId(),
+					OwnerTag:   owner.String(),
+				},
+			})
+		}
+		for subject, access := range secret.ACL() {
+			key := secretConsumerKey(uri.ID, subject)
+			ops = append(ops, txn.Op{
+				C:      secretPermissionsC,
+				Id:     key,
+				Assert: txn.DocMissing,
+				Insert: secretPermissionDoc{
+					DocID:   key,
+					Subject: subject,
+					Scope:   access.Scope(),
+					Role:    access.Role(),
+				},
+			})
+		}
+		for _, info := range secret.Consumers() {
+			consumer, err := info.Consumer()
+			if err != nil {
+				return errors.Annotatef(err, "invalid consumer for secret %q", secret.Id())
+			}
+			key := secretConsumerKey(uri.ID, consumer.String())
+			ops = append(ops, txn.Op{
+				C:      secretConsumersC,
+				Id:     key,
+				Assert: txn.DocMissing,
+				Insert: secretConsumerDoc{
+					DocID:           key,
+					ConsumerTag:     consumer.String(),
+					Label:           info.Label(),
+					CurrentRevision: info.CurrentRevision(),
+					LatestRevision:  info.LatestRevision(),
+				},
+			})
+		}
 	}
 
 	if err := runner.RunTransaction(ops); err != nil {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -89,6 +89,13 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		relationNetworksC,
 		remoteEntitiesC,
 		externalControllersC,
+
+		// secrets
+		secretMetadataC,
+		secretRevisionsC,
+		secretRotateC,
+		secretConsumersC,
+		secretPermissionsC,
 	)
 
 	ignoredCollections := set.NewStrings(
@@ -214,13 +221,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// sure the leader units' leases are claimed in the target
 		// controller when leases are managed in raft.
 		leaseHoldersC,
-
-		// secrets
-		secretMetadataC,
-		secretRevisionsC,
-		secretConsumersC,
-		secretRotateC,
-		secretPermissionsC,
 	)
 
 	modelCollections := set.NewStrings()
@@ -934,4 +934,68 @@ func (s *MigrationSuite) AssertExportedFields(c *gc.C, doc interface{}, fields s
 	// doc without thinking about the migration implications.
 	c.Check(unknown, gc.HasLen, 0)
 	c.Assert(removed, gc.HasLen, 0)
+}
+
+func (s *MigrationSuite) TestSecretMetadataDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"DocID",
+
+		// These are not exported but instead
+		// calculated from the revisions.
+		"LatestRevision",
+		"LatestExpireTime",
+	)
+	migrated := set.NewStrings(
+		"Version",
+		"OwnerTag",
+		"Description",
+		"Label",
+		"RotatePolicy",
+		"CreateTime",
+		"UpdateTime",
+	)
+	s.AssertExportedFields(c, secretMetadataDoc{}, migrated.Union(ignored))
+}
+
+func (s *MigrationSuite) TestSecretRevisionDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"DocID",
+		"TxnRevno",
+	)
+	migrated := set.NewStrings(
+		"Revision",
+		"CreateTime",
+		"UpdateTime",
+		"ExpireTime",
+		"Obsolete",
+		"ProviderId",
+		"Data",
+		"OwnerTag",
+	)
+	s.AssertExportedFields(c, secretRevisionDoc{}, migrated.Union(ignored))
+}
+
+func (s *MigrationSuite) TestSecretRotationDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"DocID",
+		"TxnRevno",
+	)
+	migrated := set.NewStrings(
+		"NextRotateTime",
+		"OwnerTag",
+	)
+	s.AssertExportedFields(c, secretRotationDoc{}, migrated.Union(ignored))
+}
+
+func (s *MigrationSuite) TestSecretConsumerDocFields(c *gc.C) {
+	ignored := set.NewStrings(
+		"DocID",
+	)
+	migrated := set.NewStrings(
+		"ConsumerTag",
+		"Label",
+		"CurrentRevision",
+		"LatestRevision",
+	)
+	s.AssertExportedFields(c, secretConsumerDoc{}, migrated.Union(ignored))
 }


### PR DESCRIPTION
Secrets are now included in a model migration.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

bootstrap 2 controllers
on c1, create a model and a secret and share it with another app
run secret-get from the other app's unit to ensure a consumer record is created
migrate the model to c2
run secret-get again to see the secret has been migrated
