### PR TITLE
[JUJU-1824] run Pebble in api-server container

### DIFF
--- a/caas/application.go
+++ b/caas/application.go
@@ -101,6 +101,13 @@ type ApplicationConfig struct {
 	// Containers is the list of containers that make up the container (excluding uniter and init containers).
 	Containers map[string]ContainerConfig
 
+	// ExistingContainers is a list of names for containers which will be added
+	// to the application pod spec outside the ApplicationPodSpec method.
+	// These containers will be added to the JUJU_CONTAINER_NAMES env variable
+	// in the charm container, but we will not create new container specs for
+	// them, as they are assumed to already exist.
+	ExistingContainers []string
+
 	// IntroductionSecret
 	IntroductionSecret string
 	// ControllerAddresses is a comma separated list of controller addresses.

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -641,7 +641,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			Env: []core.EnvVar{
 				{
 					Name:  "JUJU_CONTAINER_NAMES",
-					Value: "",
+					Value: "api-server",
 				},
 				{
 					Name:  osenv.JujuFeatureFlagEnvKey,
@@ -764,7 +764,22 @@ mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujud $JUJU_TOOLS_DIR/jujud
 
 test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf || JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujud bootstrap-state $JUJU_DATA_DIR/bootstrap-params --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s
-JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-to-stderr --debug
+
+mkdir -p /var/lib/pebble/default/layers
+cat > /var/lib/pebble/default/layers/001-jujud.yaml <<EOF
+summary: jujud service
+services:
+    jujud:
+        summary: Juju controller agent
+        startup: enabled
+        override: replace
+        command: $JUJU_TOOLS_DIR/jujud machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-to-stderr --debug
+        environment:
+            JUJU_DEV_FEATURE_FLAGS: developer-mode
+
+EOF
+
+/opt/pebble run --http :38811 --verbose
 `[1:],
 			},
 			WorkingDir: "/var/lib/juju",
@@ -803,6 +818,54 @@ JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujud machine --data-dir $
 					SubPath:   "bootstrap-params",
 					ReadOnly:  true,
 				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/api-server",
+				},
+			},
+			StartupProbe: &core.Probe{
+				ProbeHandler: core.ProbeHandler{
+					HTTPGet: &core.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38811"),
+					},
+				},
+				InitialDelaySeconds: 3,
+				TimeoutSeconds:      3,
+				PeriodSeconds:       3,
+				SuccessThreshold:    1,
+				FailureThreshold:    5,
+			},
+			LivenessProbe: &core.Probe{
+				ProbeHandler: core.ProbeHandler{
+					HTTPGet: &core.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38811"),
+					},
+				},
+				InitialDelaySeconds: 1,
+				TimeoutSeconds:      3,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    2,
+			},
+			ReadinessProbe: &core.Probe{
+				ProbeHandler: core.ProbeHandler{
+					HTTPGet: &core.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.Parse("38811"),
+					},
+				},
+				InitialDelaySeconds: 1,
+				TimeoutSeconds:      3,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    2,
+			},
+			SecurityContext: &core.SecurityContext{
+				RunAsUser:  pointer.Int64Ptr(0),
+				RunAsGroup: pointer.Int64Ptr(0),
 			},
 		},
 	}
@@ -816,7 +879,7 @@ JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujud machine --data-dir $
 		Env: []core.EnvVar{
 			{
 				Name:  "JUJU_CONTAINER_NAMES",
-				Value: "",
+				Value: "api-server",
 			},
 			{
 				Name: "JUJU_K8S_POD_NAME",

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -60,6 +60,9 @@ const (
 
 	// ControllerServiceFQDNTemplate is the FQDN of the controller service using the cluster DNS.
 	ControllerServiceFQDNTemplate = "controller-service.controller-%s.svc.cluster.local"
+
+	// CharmVolumeName is the name of the k8s volume where shared charm data is stored.
+	CharmVolumeName = "charm-data"
 )
 
 // DefaultPropagationPolicy returns the default propagation policy.

--- a/caas/kubernetes/provider/pebble/doc.go
+++ b/caas/kubernetes/provider/pebble/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package pebble defines constants (probe handlers, health check ports)
+// to be used in Pebble container specs.
+package pebble

--- a/caas/kubernetes/provider/pebble/pebble.go
+++ b/caas/kubernetes/provider/pebble/pebble.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pebble
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Probe constants
+const (
+	alivePath = "/v1/health?level=alive"
+	readyPath = "/v1/health?level=ready"
+)
+
+func StartupHandler(port string) corev1.ProbeHandler {
+	return corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: alivePath,
+			Port: intstr.Parse(port),
+		},
+	}
+}
+
+func LivenessHandler(port string) corev1.ProbeHandler {
+	return corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: alivePath,
+			Port: intstr.Parse(port),
+		},
+	}
+}
+
+func ReadinessHandler(port string) corev1.ProbeHandler {
+	return corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: readyPath,
+			Port: intstr.Parse(port),
+		},
+	}
+}
+
+// Reserved Pebble health check ports for each container.
+// All ports from 38813 onwards are reserved for workload containers
+// Additional ports should be allocated backwards
+// e.g. 38812, 38811, 38810, ...
+const (
+	// for api-server container (jujud)
+	ApiServerHealthCheckPort = "38811"
+
+	// for charm container (containeragent)
+	CharmHealthCheckPort = "38812"
+
+	// Arbitrary, but PEBBLE -> P38813 -> Port 38813
+	// workload containers start at this value and increment
+	// see WorkloadHealthCheckPort function below
+	workloadHealthCheckPortStart = 38813
+)
+
+// WorkloadHealthCheckPort returns the HTTP port to use for Pebble
+// health checks on workload container i, where i = 0, 1, 2, ...
+func WorkloadHealthCheckPort(i int) string {
+	return fmt.Sprint(workloadHealthCheckPortStart + i)
+}

--- a/caas/scripts.go
+++ b/caas/scripts.go
@@ -42,4 +42,23 @@ cp /opt/jujud %[1]s/jujud
 
 %[2]s
 `[1:]
+
+	// APIServerStartUpSh is the start script for the "api-server" container
+	// in the controller pod (Pebble running jujud).
+	APIServerStartUpSh = `
+export JUJU_DATA_DIR=%[1]s
+export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
+
+mkdir -p $JUJU_TOOLS_DIR
+cp /opt/jujud $JUJU_TOOLS_DIR/jujud
+
+%[2]s
+
+mkdir -p /var/lib/pebble/default/layers
+cat > /var/lib/pebble/default/layers/001-jujud.yaml <<EOF
+%[3]s
+EOF
+
+/opt/pebble run --http :%[4]s --verbose
+`[1:]
 )

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.9.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20221004042842-d7797bb9b104
+	github.com/canonical/pebble v0.0.0-20221010231311-dfff36380603
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/canonical/pebble v0.0.0-20221004042842-d7797bb9b104 h1:TQh8Yl5LkcWUr1A/09yWGLW1hYRO5OmE6zmb7aFI0Yg=
-github.com/canonical/pebble v0.0.0-20221004042842-d7797bb9b104/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
+github.com/canonical/pebble v0.0.0-20221010231311-dfff36380603 h1:dNUWQ+B76pFtLM3cHfq8t+vEvQlsjEF8p7oZIgJu7Ek=
+github.com/canonical/pebble v0.0.0-20221010231311-dfff36380603/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -73,7 +73,7 @@ operator_image_path() {
 }
 
 
-# build_push_operator_image is responsible for doing the heavy lifiting when it
+# build_push_operator_image is responsible for doing the heavy lifting when it
 # comes time to build the Juju oci operator image. This function can also build
 # the operator image for multiple architectures at once. Takes 2 arguments that
 # describe one or more platforms to build for and whether to push the image.


### PR DESCRIPTION
Pebble will be used to run jujud in the `api-server` container on k8s. There is [WIP](https://github.com/canonical/pebble/pull/155) to support log forwarding to Loki in Pebble. Once both these things come together, we will easily be able to get Juju controller agent logs in Loki.

TODO:
- [x] clean up commented code
- [x] rebase once #14699 lands
- [x] make sure CI passes
- [x] clean up git history

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
make go-build
make microk8s-operator-update
juju bootstrap microk8s c
microk8s kubectl describe pod -n controller-c controller-0
```