### PR TITLE
[JUJU-1874] Remove Legacy LXC Support

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -5,8 +5,6 @@ package agentbootstrap_test
 
 import (
 	stdcontext "context"
-	"os"
-	"path/filepath"
 
 	mgotesting "github.com/juju/mgo/v3/testing"
 	"github.com/juju/names/v4"
@@ -66,24 +64,8 @@ func (s *bootstrapSuite) TearDownTest(c *gc.C) {
 func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	dataDir := c.MkDir()
 
-	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
-	netConf := []byte(`
-  # comments ignored
-LXC_BR= ignored
-LXC_ADDR = "fooo"
-LXC_BRIDGE="foobar" # detected
-anything else ignored
-LXC_BRIDGE="ignored"`[1:])
-	err := os.WriteFile(lxcFakeNetConfig, netConf, 0644)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
-		if name == "foobar" {
-			return []string{
-				"10.0.3.1",
-				"10.0.3.4",
-			}, nil
-		} else if name == network.DefaultLXDBridge {
+		if name == network.DefaultLXDBridge {
 			return []string{
 				"10.0.4.1",
 				"10.0.4.4",
@@ -95,7 +77,6 @@ LXC_BRIDGE="ignored"`[1:])
 		c.Fatalf("unknown bridge in testing: %v", name)
 		return nil, nil
 	})
-	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
 
 	configParams := agent.AgentConfigParams{
 		Paths:             agent.Paths{DataDir: dataDir},
@@ -127,12 +108,10 @@ LXC_BRIDGE="ignored"`[1:])
 	initialAddrs := corenetwork.NewMachineAddresses([]string{
 		"zeroonetwothree",
 		"0.1.2.3",
-		"10.0.3.1", // lxc bridge address filtered.
-		"10.0.3.4", // lxc bridge address filtered (-"-).
 		"10.0.3.3", // not a lxc bridge address
 		"10.0.4.1", // lxd bridge address filtered.
 		"10.0.4.4", // lxd bridge address filtered.
-		"10.0.4.5", // not an lxd bridge address
+		"10.0.4.5", // not a lxd bridge address
 	}).AsProviderAddresses()
 	filteredAddrs := corenetwork.NewSpaceAddresses(
 		"zeroonetwothree",

--- a/container/lxd/cluster.go
+++ b/container/lxd/cluster.go
@@ -10,7 +10,7 @@ func (s *Server) ClusterSupported() bool {
 // UseTargetServer returns a new Server based on the input target node name.
 // It is intended for use when operations must target specific nodes in a
 // cluster.
-func (s Server) UseTargetServer(name string) (*Server, error) {
+func (s *Server) UseTargetServer(name string) (*Server, error) {
 	logger.Debugf("creating LXD server for cluster node %q", name)
 	return NewServer(s.UseTarget(name))
 }

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -233,7 +233,7 @@ func (s *Server) ContainerAddresses(name string) ([]corenetwork.ProviderAddress,
 
 	var results []corenetwork.ProviderAddress
 	for netName, net := range networks {
-		if netName == network.DefaultLXCBridge || netName == network.DefaultLXDBridge {
+		if netName == network.DefaultLXDBridge {
 			continue
 		}
 		for _, addr := range net.Addresses {

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -201,22 +201,6 @@ func (s *containerSuite) TestContainerAddresses(c *gc.C) {
 					},
 				},
 			},
-			"lxcbr0": {
-				Addresses: []api.InstanceStateNetworkAddress{
-					{
-						Family:  "inet",
-						Address: "10.0.5.12",
-						Netmask: "24",
-						Scope:   "global",
-					},
-					{
-						Family:  "inet6",
-						Address: "fe80::216:3eff:fe3b:e432",
-						Netmask: "64",
-						Scope:   "link",
-					},
-				},
-			},
 			"lxdbr0": {
 				Addresses: []api.InstanceStateNetworkAddress{
 					{

--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -24,7 +24,6 @@ import (
 var logger = loggo.GetLogger("juju.network.containerizer")
 
 var skippedDeviceNames = set.NewStrings(
-	network.DefaultLXCBridge,
 	network.DefaultLXDBridge,
 	network.DefaultKVMBridge,
 )

--- a/network/containerizer/bridgepolicy_integration_test.go
+++ b/network/containerizer/bridgepolicy_integration_test.go
@@ -170,8 +170,6 @@ func (s *bridgePolicyStateSuite) createLoopbackNIC(c *gc.C, machine containerize
 func (s *bridgePolicyStateSuite) createAllDefaultDevices(c *gc.C, machine containerizer.Machine) {
 	// loopback
 	s.createLoopbackNIC(c, machine)
-	// container.DefaultLxcBridge
-	s.createBridgeWithIP(c, machine, "lxcbr0", "10.0.3.1/24")
 	// container.DefaultLxdBridge
 	s.createBridgeWithIP(c, machine, "lxdbr0", "10.0.4.1/24")
 	// container.DefaultKvmBridge

--- a/network/network.go
+++ b/network/network.go
@@ -4,10 +4,8 @@
 package network
 
 import (
-	"bufio"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 
 	"github.com/juju/errors"
@@ -22,9 +20,6 @@ var logger = loggo.GetLogger("juju.network")
 
 // UnknownId can be used whenever an Id is needed but not known.
 const UnknownId = ""
-
-// DefaultLXCBridge is the bridge that gets used for LXC containers
-const DefaultLXCBridge = "lxcbr0"
 
 // DefaultLXDBridge is the bridge that gets used for LXD containers
 const DefaultLXDBridge = "lxdbr0"
@@ -46,10 +41,6 @@ type DeviceToBridge struct {
 	// MACAddress is the MAC address of the device to be bridged
 	MACAddress string
 }
-
-// LXCNetDefaultConfig is the location of the default network config
-// of the lxc package. It's exported to allow cross-package testing.
-var LXCNetDefaultConfig = "/etc/default/lxc-net"
 
 // AddressesForInterfaceName returns the addresses in string form for the
 // given interface name. It's exported to facilitate cross-package testing.
@@ -145,44 +136,6 @@ func filterAddrs(
 	return filtered
 }
 
-// gatherLXCAddresses tries to discover the default lxc bridge name
-// and all of its addresses. See LP bug #1416928.
-func gatherLXCAddresses(toRemove map[string][]string) {
-	file, err := os.Open(LXCNetDefaultConfig)
-	if os.IsNotExist(err) {
-		// No lxc-net config found, nothing to do.
-		logger.Debugf("no lxc bridge addresses to filter for machine")
-		return
-	} else if err != nil {
-		// Just log it, as it's not fatal.
-		logger.Errorf("cannot open %q: %v", LXCNetDefaultConfig, err)
-		return
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		switch {
-		case strings.HasPrefix(line, "#"):
-			// Skip comments.
-		case strings.HasPrefix(line, "LXC_BRIDGE"):
-			// Extract <name> from LXC_BRIDGE="<name>".
-			parts := strings.Split(line, `"`)
-			if len(parts) < 2 {
-				logger.Debugf("ignoring invalid line '%s' in %q", line, LXCNetDefaultConfig)
-				continue
-			}
-			bridgeName := strings.TrimSpace(parts[1])
-			gatherBridgeAddresses(bridgeName, toRemove)
-			return
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		logger.Debugf("failed to read %q: %v (ignoring)", LXCNetDefaultConfig, err)
-	}
-}
-
 func gatherBridgeAddresses(bridgeName string, toRemove map[string][]string) {
 	addrs, err := AddressesForInterfaceName(bridgeName)
 	if err != nil {
@@ -199,7 +152,6 @@ func gatherBridgeAddresses(bridgeName string, toRemove map[string][]string) {
 // This includes addresses used by the local Fan network.
 func FilterBridgeAddresses(addresses corenetwork.ProviderAddresses) corenetwork.ProviderAddresses {
 	addressesToRemove := make(map[string][]string)
-	gatherLXCAddresses(addressesToRemove)
 	gatherBridgeAddresses(DefaultLXDBridge, addressesToRemove)
 	gatherBridgeAddresses(DefaultKVMBridge, addressesToRemove)
 	gatherFanAddresses(addresses, addressesToRemove)

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -5,8 +5,6 @@ package network_test
 
 import (
 	"net"
-	"os"
-	"path/filepath"
 
 	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
@@ -112,29 +110,8 @@ type NetworkSuite struct {
 var _ = gc.Suite(&NetworkSuite{})
 
 func (s *NetworkSuite) TestFilterBridgeAddresses(c *gc.C) {
-	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
-	// We create an LXC bridge named "foobar", and then put 10.0.3.1,
-	// 10.0.3.4 and 10.0.3.5/24 on that bridge.
-	// We also put 10.0.4.1 and 10.0.5.1/24 onto whatever bridge LXD is
-	// configured to use.
-	// And 192.168.122.1 on virbr0
-	netConf := []byte(`
-  # comments ignored
-LXC_BR= ignored
-LXC_ADDR = "fooo"
- LXC_BRIDGE = " foobar " # detected, spaces stripped
-anything else ignored
-LXC_BRIDGE="ignored"`[1:])
-	err := os.WriteFile(lxcFakeNetConfig, netConf, 0644)
-	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
-		if name == "foobar" {
-			return []string{
-				"10.0.3.1",
-				"10.0.3.4",
-				"10.0.3.5/24",
-			}, nil
-		} else if name == network.DefaultLXDBridge {
+		if name == network.DefaultLXDBridge {
 			return []string{
 				"10.0.4.1",
 				"10.0.5.1/24",
@@ -147,16 +124,11 @@ LXC_BRIDGE="ignored"`[1:])
 		c.Fatalf("unknown bridge name: %q", name)
 		return nil, nil
 	})
-	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
 
 	inputAddresses := corenetwork.NewMachineAddresses([]string{
 		"127.0.0.1",
 		"2001:db8::1",
 		"10.0.0.1",
-		"10.0.3.1",      // filtered (directly as IP)
-		"10.0.3.3",      // filtered (by the 10.0.3.5/24 CIDR)
-		"10.0.3.5",      // filtered (directly)
-		"10.0.3.4",      // filtered (directly)
 		"10.0.4.1",      // filtered (directly from LXD bridge)
 		"10.0.5.10",     // filtered (from LXD bridge, 10.0.5.1/24)
 		"10.0.6.10",     // unfiltered

--- a/state/linklayerdevices_test.go
+++ b/state/linklayerdevices_test.go
@@ -956,7 +956,6 @@ func (s *linkLayerDevicesStateSuite) TestSetLinkLayerDevicesAllowsParentBridgeDe
 	// when deciding which host bridges to use for the container NICs.
 	s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, network.DefaultLXDBridge, "vethX", 1)
 	s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, network.DefaultKVMBridge, "vethY", 1)
-	s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, network.DefaultLXCBridge, "vethZ", 1)
 	parentDevice, _ := s.addParentBridgeDeviceWithContainerDevicesAsChildren(c, "br-eth1.250", "eth", 1)
 	childDevice, err := s.containerMachine.LinkLayerDevice("eth0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/apiaddressupdater/apiaddressupdater_test.go
+++ b/worker/apiaddressupdater/apiaddressupdater_test.go
@@ -4,8 +4,6 @@
 package apiaddressupdater_test
 
 import (
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/juju/errors"
@@ -35,11 +33,10 @@ func (s *APIAddressUpdaterSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
 	err := s.State.SetAPIHostPorts(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	// By default mock these to better isolate the test from the real machine.
+
 	s.PatchValue(&network.AddressesForInterfaceName, func(string) ([]string, error) {
 		return nil, nil
 	})
-	s.PatchValue(&network.LXCNetDefaultConfig, "")
 }
 
 type apiAddressSetter struct {
@@ -195,23 +192,8 @@ func (s *APIAddressUpdaterSuite) TestAddressChangeEmpty(c *gc.C) {
 }
 
 func (s *APIAddressUpdaterSuite) TestBridgeAddressesFiltering(c *gc.C) {
-	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
-	netConf := []byte(`
-  # comments ignored
-LXC_BR= ignored
-LXC_ADDR = "fooo"
-LXC_BRIDGE="foobar" # detected
-anything else ignored
-LXC_BRIDGE="ignored"`[1:])
-	err := os.WriteFile(lxcFakeNetConfig, netConf, 0644)
-	c.Assert(err, jc.ErrorIsNil)
 	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
-		if name == "foobar" {
-			return []string{
-				"10.0.3.1",
-				"10.0.3.4",
-			}, nil
-		} else if name == network.DefaultLXDBridge {
+		if name == network.DefaultLXDBridge {
 			return []string{
 				"10.0.4.1",
 				"10.0.4.4",
@@ -224,21 +206,18 @@ LXC_BRIDGE="ignored"`[1:])
 		c.Fatalf("unknown bridge in testing: %v", name)
 		return nil, nil
 	})
-	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
 
 	initialServers := []corenetwork.SpaceHostPorts{
 		corenetwork.NewSpaceHostPorts(1234, "localhost", "127.0.0.1"),
 		corenetwork.NewSpaceHostPorts(
 			4321,
-			"10.0.3.1",      // filtered
-			"10.0.3.3",      // not filtered (not a lxc bridge address)
+			"10.0.3.3",      // not filtered
 			"10.0.4.1",      // filtered lxd bridge address
 			"10.0.4.2",      // not filtered
 			"192.168.122.1", // filtered default virbr0
 		),
-		corenetwork.NewSpaceHostPorts(4242, "10.0.3.4"), // filtered
 	}
-	err = s.State.SetAPIHostPorts(initialServers)
+	err := s.State.SetAPIHostPorts(initialServers)
 	c.Assert(err, jc.ErrorIsNil)
 
 	setter := &apiAddressSetter{servers: make(chan []corenetwork.HostPorts, 1)}
@@ -257,11 +236,8 @@ LXC_BRIDGE="ignored"`[1:])
 		corenetwork.NewSpaceHostPorts(1234, "localhost", "127.0.0.1"),
 		corenetwork.NewSpaceHostPorts(
 			4001,
-			"10.0.3.1", // filtered
-			"10.0.3.3", // not filtered (not a lxc bridge address)
+			"10.0.3.3", // not filtered
 		),
-		corenetwork.NewSpaceHostPorts(4200, "10.0.3.4"), // filtered
-		corenetwork.NewSpaceHostPorts(4200, "10.0.4.1"), // filtered
 	}
 
 	expServer1 := corenetwork.ProviderHostPorts{

--- a/worker/machiner/machiner_test.go
+++ b/worker/machiner/machiner_test.go
@@ -5,8 +5,6 @@ package machiner_test
 
 import (
 	"net"
-	"os"
-	"path/filepath"
 	stdtesting "testing"
 
 	"github.com/juju/errors"
@@ -365,22 +363,15 @@ func (s *MachinerSuite) TestSetMachineAddresses(c *gc.C) {
 	s.addresses = []net.Addr{
 		&net.IPAddr{IP: net.IPv4(10, 0, 0, 1)},
 		&net.IPAddr{IP: net.IPv4(127, 0, 0, 1)},
-		&net.IPAddr{IP: net.IPv4(10, 0, 3, 1)}, // lxc bridge address ignored
 		&net.IPAddr{IP: net.IPv6loopback},
-		&net.UnixAddr{},                        // not IP, ignored
-		&net.IPAddr{IP: net.IPv4(10, 0, 3, 4)}, // lxc bridge address ignored
+		&net.UnixAddr{}, // not IP, ignored
 		&net.IPNet{IP: net.ParseIP("2001:db8::1")},
 		&net.IPAddr{IP: net.IPv4(169, 254, 1, 20)}, // LinkLocal Ignored
 		&net.IPNet{IP: net.ParseIP("fe80::1")},     // LinkLocal Ignored
 	}
 
 	s.PatchValue(&network.AddressesForInterfaceName, func(name string) ([]string, error) {
-		if name == "foobar" {
-			return []string{
-				"10.0.3.1",
-				"10.0.3.4",
-			}, nil
-		} else if name == network.DefaultLXDBridge {
+		if name == network.DefaultLXDBridge {
 			return []string{
 				"10.0.4.1",
 				"10.0.4.4",
@@ -393,18 +384,6 @@ func (s *MachinerSuite) TestSetMachineAddresses(c *gc.C) {
 		c.Fatalf("unknown bridge in testing: %v", name)
 		return nil, nil
 	})
-
-	lxcFakeNetConfig := filepath.Join(c.MkDir(), "lxc-net")
-	netConf := []byte(`
-  # comments ignored
-LXC_BR= ignored
-LXC_ADDR = "fooo"
-LXC_BRIDGE="foobar" # detected
-anything else ignored
-LXC_BRIDGE="ignored"`[1:])
-	err := os.WriteFile(lxcFakeNetConfig, netConf, 0644)
-	c.Assert(err, jc.ErrorIsNil)
-	s.PatchValue(&network.LXCNetDefaultConfig, lxcFakeNetConfig)
 
 	mr := s.makeMachiner(c, false)
 	c.Assert(stopWorker(mr), jc.ErrorIsNil)


### PR DESCRIPTION
Juju 3.0 drops support for some old OS and LXD versions. This is already reflected in the code base.

Here, we continue dropping legacy logic along these lines, removing detection of the LXC (note not LXD) bridges and interrogation of the LXC bridge configuration file.

## QA steps

Deploy a workload to container-in-machine and ensure that there are no errors.

## Documentation changes

None.

## Bug reference

N/A
