### PR TITLE
[JUJU-1758] Developed the bash-based version of nw-cross-model-relations

### DIFF
--- a/tests/includes/controller.sh
+++ b/tests/includes/controller.sh
@@ -1,0 +1,18 @@
+# Bootstraps alternate controller in test
+bootstrap_alt_controller() {
+	local name
+
+	name=${1}
+
+	START_TIME=$(date +%s)
+	echo "====> Bootstrapping ${name}"
+
+	# Unset to re-generate from the new agent-version.
+	unset BOOTSTRAP_ADDITIONAL_ARGS
+
+	file="${TEST_DIR}/${name}.log"
+	juju_bootstrap "${BOOTSTRAP_CLOUD}" "${name}" "misc" "${file}"
+
+	END_TIME=$(date +%s)
+	echo "====> Bootstrapped ${name} ($((END_TIME - START_TIME))s)"
+}

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -1,0 +1,71 @@
+# Exercising the CMR Juju functionality which allows applications to
+# communicate between different models.
+# This test will exercise the following aspects:
+#  - Ensure a user is able to create an offer of an applications' endpoint
+#    including:
+#      - A user is able to consume and relate to the offer
+#      - Workload data successfully provided
+#      - The offer appears in the list-offers output
+#      - The user is able to name the offer
+#      - The user is able to remove the offer
+#  - Ensure an admin can grant a user access to an offer
+#      - The consuming user finds the offer via 'find-offer'
+#
+# The above feature tests will be run on:
+#  - A single controller environment
+run_offer_consume() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# The following ensures that a bootstrap juju exists.
+	file="${TEST_DIR}/test-offer-consume.log"
+	ensure "model-offer" "${file}"
+
+	juju deploy juju-qa-dummy-source
+	juju offer dummy-source:sink
+
+	wait_for "dummy-source" "$(idle_condition "dummy-source")"
+
+	juju add-model "model-consume"
+	juju switch "model-consume"
+	juju deploy juju-qa-dummy-sink
+
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
+
+	juju --show-log consume "${BOOTSTRAPPED_JUJU_CTRL_NAME}:admin/model-offer.dummy-source"
+	juju --show-log relate dummy-sink dummy-source
+	# wait for relation joined before migrate.
+	wait_for "dummy-source" '.applications["dummy-sink"] | .relations.source[0]'
+	sleep 30
+
+	# Change the dummy-source config for "token" and check that the change
+	# is represented in the consuming model's dummy-sink unit.
+	juju switch "model-offer"
+	juju config dummy-source token=yeah-boi
+	juju switch "model-consume"
+	wait_for "active" ".\"application-endpoints\"[\"dummy-source\"].\"application-status\".current"
+
+	# The offer must be removed before model/controller destruction will work.
+	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
+	juju switch "model-offer"
+	juju remove-offer "admin/model-offer.dummy-source" --force -y
+
+	# Clean up.
+	destroy_model "model-offer"
+	destroy_model "model-consume"
+}
+
+test_offer_consume() {
+	if [ "$(skip 'test_offer_consume')" ]; then
+		echo "==> TEST SKIPPED: offer consume"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_offer_consume"
+	)
+}

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -23,7 +23,7 @@ run_offer_consume() {
 
 	echo "Deploy consumed workload and create the offer"
 	juju deploy juju-qa-dummy-source
-	juju offer dummy-source:sink
+	juju offer dummy-source:sink dummy-offer
 
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
@@ -35,10 +35,10 @@ run_offer_consume() {
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
 
 	echo "Relate workload in consume model with offer"
-	juju --show-log consume "${BOOTSTRAPPED_JUJU_CTRL_NAME}:admin/model-offer.dummy-source"
-	juju --show-log relate dummy-sink dummy-source
+	juju --show-log consume "${BOOTSTRAPPED_JUJU_CTRL_NAME}:admin/model-offer.dummy-offer"
+	juju --show-log relate dummy-sink dummy-offer
 	# wait for relation joined before migrate.
-	wait_for "dummy-source" '.applications["dummy-sink"] | .relations.source[0]'
+	wait_for "dummy-offer" '.applications["dummy-sink"] | .relations.source[0]'
 
 	echo "Provide config if offered workload and change the status of consumed offer"
 	# Change the dummy-source config for "token" and check that the change
@@ -46,13 +46,13 @@ run_offer_consume() {
 	juju switch "model-offer"
 	juju config dummy-source token=yeah-boi
 	juju switch "model-consume"
-	wait_for "active" '."application-endpoints"["dummy-source"]."application-status".current'
+	wait_for "active" '."application-endpoints"["dummy-offer"]."application-status".current'
 
 	echo "Remove offer"
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "model-offer"
-	juju remove-offer "admin/model-offer.dummy-source" --force -y
+	juju remove-offer "admin/model-offer.dummy-offer" --force -y
 
 	echo "Clean up"
 	destroy_model "model-offer"

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -1,7 +1,7 @@
 # Exercising the CMR Juju functionality which allows applications to
 # communicate between different models.
 # This test will exercise the following aspects:
-#  - Ensure a user is able to create an offer of an applications' endpoint
+#  - Ensure a user is able to create an offer of an application's endpoint
 #    including:
 #      - A user is able to consume and relate to the offer
 #      - Workload data successfully provided
@@ -40,7 +40,7 @@ run_offer_consume() {
 	# wait for relation joined before migrate.
 	wait_for "dummy-offer" '.applications["dummy-sink"] | .relations.source[0]'
 
-	echo "Provide config if offered workload and change the status of consumed offer"
+	echo "Provide config for offered workload and change the status of consumed offer"
 	# Change the dummy-source config for "token" and check that the change
 	# is represented in the consuming model's dummy-sink unit.
 	juju switch "model-offer"
@@ -52,7 +52,7 @@ run_offer_consume() {
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "model-offer"
-	juju remove-offer "admin/model-offer.dummy-offer" --force -y
+	juju remove-offer "admin/model-offer.dummy-offer" -y
 
 	echo "Clean up"
 	destroy_model "model-offer"
@@ -108,7 +108,7 @@ run_offer_consume_cross_controller() {
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "${offer_controller}:model-offer"
-	juju remove-offer "${offer_controller}:admin/model-offer.dummy-source" --force -y
+	juju remove-offer "${offer_controller}:admin/model-offer.dummy-source" -y
 
 	echo "Clean up"
 	destroy_controller "controller-consume"

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -28,7 +28,7 @@ run_offer_consume() {
 	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	echo "Check list-offer output"
-	juju list-offers --format=json | jq -r "has(\"dummy-offer\")" | check true
+	juju list-offers --format=json | jq -r 'has("dummy-offer")' | check true
 
 	echo "Deploy workload in consume model"
 	juju add-model "model-consume"

--- a/tests/suites/cmr/task.sh
+++ b/tests/suites/cmr/task.sh
@@ -1,0 +1,20 @@
+test_cmr() {
+	if [ "$(skip 'test_cmr')" ]; then
+		echo "==> TEST SKIPPED: cross-model relations tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-cmr.log"
+
+	bootstrap "test-cmr" "${file}"
+
+	# Tests that need to be run are added here.
+	test_offer_consume
+
+	destroy_controller "test-cmr"
+}

--- a/tests/suites/cmr/task.sh
+++ b/tests/suites/cmr/task.sh
@@ -13,7 +13,6 @@ test_cmr() {
 
 	bootstrap "test-cmr" "${file}"
 
-	# Tests that need to be run are added here.
 	test_offer_consume
 
 	destroy_controller "test-cmr"

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -401,21 +401,3 @@ test_model_migration_saas_external() {
 		run "run_model_migration_saas_external"
 	)
 }
-
-bootstrap_alt_controller() {
-	local name
-
-	name=${1}
-
-	START_TIME=$(date +%s)
-	echo "====> Bootstrapping ${name}"
-
-	# Unset to re-generate from the new agent-version.
-	unset BOOTSTRAP_ADDITIONAL_ARGS
-
-	file="${TEST_DIR}/${name}.log"
-	juju_bootstrap "${BOOTSTRAP_CLOUD}" "${name}" "misc" "${file}"
-
-	END_TIME=$(date +%s)
-	echo "====> Bootstrapped ${name} ($((END_TIME - START_TIME))s)"
-}


### PR DESCRIPTION
This PR adds bash-based version of CMR tests.
These tests will exercise the following aspects:
  - Ensure a user is able to create an offer of an applications' endpoint
    including:
      - A user is able to consume and relate to the offer
      - Workload data successfully provided
      - The offer appears in the list-offers output
      - The user is able to name the offer
      - The user is able to remove the offer
  - Ensure an admin can grant a user access to an offer
      - The consuming user finds the offer via 'find-offer'

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p lxd cmr test_offer_consume
```
