### PR TITLE
[JUJU-1638, JUJU-1785] Rewrite api/client/machinemanager unit tests to use gomock

### DIFF
--- a/api/client/imagemetadatamanager/client_test.go
+++ b/api/client/imagemetadatamanager/client_test.go
@@ -170,12 +170,6 @@ func (s *imagemetadataSuite) TestSaveFacadeCallErrorResult(c *gc.C) {
 	c.Assert(errors.Cause(err), gc.ErrorMatches, msg)
 }
 
-var versionFromSeries = func(s string) string {
-	// For testing purposes only, there will not be an error :D
-	v, _ := series.SeriesVersion(s)
-	return v
-}
-
 func (s *imagemetadataSuite) TestDelete(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -210,9 +210,7 @@ func (s *MachinemanagerSuite) TestProvisioningScript(c *gc.C) {
 	c.Assert(script, gc.Equals, "script")
 }
 
-func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, maxWait *time.Duration) (*machinemanager.Client, []params.DestroyMachineResult) {
-	ctrl := gomock.NewController(c)
-
+func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, maxWait *time.Duration, ctrl *gomock.Controller) (*machinemanager.Client, []params.DestroyMachineResult) {
 	expectedResults := []params.DestroyMachineResult{{
 		Error: &params.Error{Message: "boo"},
 	}, {
@@ -242,15 +240,19 @@ func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, max
 }
 
 func (s *MachinemanagerSuite) TestDestroyMachinesWithParamsNoWait(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 	noWait := 0 * time.Second
-	client, expected := s.clientToTestDestroyMachinesWithParams(c, &noWait)
+	client, expected := s.clientToTestDestroyMachinesWithParams(c, &noWait, ctrl)
 	results, err := client.DestroyMachinesWithParams(true, true, &noWait, "0", "0/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expected)
 }
 
 func (s *MachinemanagerSuite) TestDestroyMachinesWithParamsNilWait(c *gc.C) {
-	client, expected := s.clientToTestDestroyMachinesWithParams(c, (*time.Duration)(nil))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	client, expected := s.clientToTestDestroyMachinesWithParams(c, (*time.Duration)(nil), ctrl)
 	results, err := client.DestroyMachinesWithParams(true, true, (*time.Duration)(nil), "0", "0/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expected)

--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -4,61 +4,34 @@
 package machinemanager_test
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	basetesting "github.com/juju/juju/api/base/testing"
+	basemocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/machinemanager"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/storage"
-	coretesting "github.com/juju/juju/testing"
 )
 
 var _ = gc.Suite(&MachinemanagerSuite{})
 
 type MachinemanagerSuite struct {
-	coretesting.BaseSuite
-}
-
-func newClient(f basetesting.APICallerFunc) *machinemanager.Client {
-	return machinemanager.NewClient(f)
 }
 
 func (s *MachinemanagerSuite) TestAddMachines(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	apiResult := []params.AddMachinesResult{
 		{Machine: "machine-1", Error: nil},
 		{Machine: "machine-2", Error: nil},
 	}
-
-	var callCount int
-	st := newClient(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "MachineManager")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "AddMachines")
-		c.Check(arg, gc.DeepEquals, params.AddMachines{
-			MachineParams: []params.AddMachineParams{
-				{
-					Series: "jammy",
-					Disks:  []storage.Constraints{{Pool: "loop", Size: 1}},
-				},
-				{
-					Series: "focal",
-				},
-			},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.AddMachinesResults{})
-		*(result.(*params.AddMachinesResults)) = params.AddMachinesResults{
-			Machines: apiResult,
-		}
-		callCount++
-		return nil
-	})
 
 	machines := []params.AddMachineParams{{
 		Series: "jammy",
@@ -66,80 +39,119 @@ func (s *MachinemanagerSuite) TestAddMachines(c *gc.C) {
 	}, {
 		Series: "focal",
 	}}
+
+	args := params.AddMachines{
+		MachineParams: []params.AddMachineParams{
+			{
+				Series: "jammy",
+				Disks:  []storage.Constraints{{Pool: "loop", Size: 1}},
+			},
+			{
+				Series: "focal",
+			},
+		},
+	}
+	res := new(params.AddMachinesResults)
+	results := params.AddMachinesResults{
+		Machines: apiResult,
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("AddMachines", args, res).SetArg(2, results).Return(nil)
+	st := machinemanager.NewClientFromCaller(mockFacadeCaller)
+
 	result, err := st.AddMachines(machines)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, apiResult)
-	c.Check(callCount, gc.Equals, 1)
 }
 
 func (s *MachinemanagerSuite) TestAddMachinesClientError(c *gc.C) {
-	st := newClient(func(objType string, version int, id, request string, arg, result interface{}) error {
-		return errors.New("blargh")
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.AddMachines{
+		MachineParams: []params.AddMachineParams{{Series: "focal"}},
+	}
+	res := new(params.AddMachinesResults)
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	st := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	mockFacadeCaller.EXPECT().FacadeCall("AddMachines", args, res).Return(errors.New("blargh"))
 	_, err := st.AddMachines([]params.AddMachineParams{{Series: "focal"}})
 	c.Check(err, gc.ErrorMatches, "blargh")
 }
 
 func (s *MachinemanagerSuite) TestAddMachinesServerError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	apiResult := []params.AddMachinesResult{{
 		Error: &params.Error{Message: "MSG", Code: "621"},
 	}}
 
-	st := newClient(func(objType string, version int, id, request string, arg, result interface{}) error {
-		*(result.(*params.AddMachinesResults)) = params.AddMachinesResults{
-			Machines: apiResult,
-		}
-		return nil
-	})
 	machines := []params.AddMachineParams{{
 		Series: "jammy",
 	}}
+	args := params.AddMachines{
+		MachineParams: machines,
+	}
+	res := new(params.AddMachinesResults)
+	ress := params.AddMachinesResults{
+		Machines: apiResult,
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("AddMachines", args, res).SetArg(2, ress).Return(nil)
+	st := machinemanager.NewClientFromCaller(mockFacadeCaller)
 	results, err := st.AddMachines(machines)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, apiResult)
 }
 
 func (s *MachinemanagerSuite) TestAddMachinesResultCountInvalid(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	for _, n := range []int{0, 2} {
-		st := newClient(func(objType string, version int, id, request string, arg, result interface{}) error {
-			var results []params.AddMachinesResult
-			for i := 0; i < n; i++ {
-				results = append(results, params.AddMachinesResult{
-					Error: &params.Error{Message: "MSG", Code: "621"},
-				})
-			}
-			*(result.(*params.AddMachinesResults)) = params.AddMachinesResults{Machines: results}
-			return nil
-		})
 		machines := []params.AddMachineParams{{
 			Series: "jammy",
 		}}
+		args := params.AddMachines{
+			MachineParams: machines,
+		}
+		res := new(params.AddMachinesResults)
+		var results []params.AddMachinesResult
+		for i := 0; i < n; i++ {
+			results = append(results, params.AddMachinesResult{
+				Error: &params.Error{Message: "MSG", Code: "621"},
+			})
+		}
+		ress := params.AddMachinesResults{
+			Machines: results,
+		}
+		mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+		mockFacadeCaller.EXPECT().FacadeCall("AddMachines", args, res).SetArg(2, ress).Return(nil)
+		st := machinemanager.NewClientFromCaller(mockFacadeCaller)
 		_, err := st.AddMachines(machines)
 		c.Check(err, gc.ErrorMatches, fmt.Sprintf("expected 1 result, got %d", n))
 	}
 }
 
 func (s *MachinemanagerSuite) TestRetryProvisioning(c *gc.C) {
-	client := machinemanager.NewClient(
-		basetesting.BestVersionCaller{
-			BestVersion: 7,
-			APICallerFunc: basetesting.APICallerFunc(func(objType string, version int, id, request string, a, response interface{}) error {
-				c.Assert(request, gc.Equals, "RetryProvisioning")
-				c.Assert(version, gc.Equals, 7)
-				c.Assert(a, jc.DeepEquals, params.RetryProvisioningArgs{
-					Machines: []string{
-						"machine-0",
-						"machine-1",
-					},
-				})
-				c.Assert(response, gc.FitsTypeOf, &params.ErrorResults{})
-				out := response.(*params.ErrorResults)
-				*out = params.ErrorResults{Results: []params.ErrorResult{
-					{Error: &params.Error{Code: "boom"}},
-					{}},
-				}
-				return nil
-			})})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.RetryProvisioningArgs{
+		All: false,
+		Machines: []string{
+			names.NewMachineTag("0").String(),
+			names.NewMachineTag("1").String()},
+	}
+	res := new(params.ErrorResults)
+	ress := params.ErrorResults{Results: []params.ErrorResult{
+		{Error: &params.Error{Code: "boom"}},
+		{}},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("RetryProvisioning", args, res).SetArg(2, ress).Return(nil)
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
 	result, err := client.RetryProvisioning(false, names.NewMachineTag("0"), names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []params.ErrorResult{
@@ -149,23 +161,21 @@ func (s *MachinemanagerSuite) TestRetryProvisioning(c *gc.C) {
 }
 
 func (s *MachinemanagerSuite) TestRetryProvisioningAll(c *gc.C) {
-	client := machinemanager.NewClient(
-		basetesting.BestVersionCaller{
-			BestVersion: 7,
-			APICallerFunc: basetesting.APICallerFunc(func(objType string, version int, id, request string, a, response interface{}) error {
-				c.Assert(request, gc.Equals, "RetryProvisioning")
-				c.Assert(version, gc.Equals, 7)
-				c.Assert(a, jc.DeepEquals, params.RetryProvisioningArgs{
-					All: true,
-				})
-				c.Assert(response, gc.FitsTypeOf, &params.ErrorResults{})
-				out := response.(*params.ErrorResults)
-				*out = params.ErrorResults{Results: []params.ErrorResult{
-					{Error: &params.Error{Code: "boom"}},
-					{}},
-				}
-				return nil
-			})})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.RetryProvisioningArgs{
+		All:      true,
+		Machines: []string{},
+	}
+	res := new(params.ErrorResults)
+	ress := params.ErrorResults{Results: []params.ErrorResult{
+		{Error: &params.Error{Code: "boom"}},
+		{}},
+	}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("RetryProvisioning", args, res).SetArg(2, ress).Return(nil)
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
 	result, err := client.RetryProvisioning(true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []params.ErrorResult{
@@ -175,23 +185,21 @@ func (s *MachinemanagerSuite) TestRetryProvisioningAll(c *gc.C) {
 }
 
 func (s *MachinemanagerSuite) TestProvisioningScript(c *gc.C) {
-	client := machinemanager.NewClient(
-		basetesting.BestVersionCaller{
-			BestVersion: 7,
-			APICallerFunc: basetesting.APICallerFunc(func(objType string, version int, id, request string, a, response interface{}) error {
-				c.Assert(request, gc.Equals, "ProvisioningScript")
-				c.Assert(version, gc.Equals, 7)
-				c.Assert(a, jc.DeepEquals, params.ProvisioningScriptParams{
-					MachineId:              "0",
-					Nonce:                  "nonce",
-					DataDir:                "/path/to/data",
-					DisablePackageCommands: true,
-				})
-				c.Assert(response, gc.FitsTypeOf, &params.ProvisioningScriptResult{})
-				out := response.(*params.ProvisioningScriptResult)
-				*out = params.ProvisioningScriptResult{Script: "script"}
-				return nil
-			})})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.ProvisioningScriptParams{
+		MachineId:              "0",
+		Nonce:                  "nonce",
+		DataDir:                "/path/to/data",
+		DisablePackageCommands: true,
+	}
+	res := new(params.ProvisioningScriptResult)
+	ress := params.ProvisioningScriptResult{Script: "script"}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ProvisioningScript", args, res).SetArg(2, ress).Return(nil)
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+
 	script, err := client.ProvisioningScript(params.ProvisioningScriptParams{
 		MachineId:              "0",
 		Nonce:                  "nonce",
@@ -203,6 +211,8 @@ func (s *MachinemanagerSuite) TestProvisioningScript(c *gc.C) {
 }
 
 func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, maxWait *time.Duration) (*machinemanager.Client, []params.DestroyMachineResult) {
+	ctrl := gomock.NewController(c)
+
 	expectedResults := []params.DestroyMachineResult{{
 		Error: &params.Error{Message: "boo"},
 	}, {
@@ -212,23 +222,22 @@ func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, max
 			DetachedStorage:  []params.Entity{{Tag: "storage-pgdata-1"}},
 		},
 	}}
-	client := machinemanager.NewClient(
-		basetesting.APICallerFunc(func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "DestroyMachineWithParams")
-			c.Assert(a, jc.DeepEquals, params.DestroyMachinesParams{
-				Keep:  true,
-				Force: true,
-				MachineTags: []string{
-					"machine-0",
-					"machine-0-lxd-1",
-				},
-				MaxWait: maxWait,
-			})
-			c.Assert(response, gc.FitsTypeOf, &params.DestroyMachineResults{})
-			out := response.(*params.DestroyMachineResults)
-			*out = params.DestroyMachineResults{Results: expectedResults}
-			return nil
-		}))
+
+	args := params.DestroyMachinesParams{
+		Keep:  true,
+		Force: true,
+		MachineTags: []string{
+			"machine-0",
+			"machine-0-lxd-1",
+		},
+		MaxWait: maxWait,
+	}
+	res := new(params.DestroyMachineResults)
+	ress := params.DestroyMachineResults{Results: expectedResults}
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyMachineWithParams", args, res).SetArg(2, ress).Return(nil)
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+
 	return client, expectedResults
 }
 

--- a/api/client/machinemanager/package_test.go
+++ b/api/client/machinemanager/package_test.go
@@ -1,14 +1,22 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package machinemanager_test
+package machinemanager
 
 import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
 )
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
 }


### PR DESCRIPTION
The unit tests for `api/client/machinemanager` now use go mock and not juju/testing. All unit tests should pass.