### PR TITLE
Fix failing CI test

### DIFF
--- a/tests/suites/spaces_ec2/machines_in_spaces.sh
+++ b/tests/suites/spaces_ec2/machines_in_spaces.sh
@@ -24,9 +24,6 @@ run_machines_in_spaces() {
 	machine_1_space_ip=$(assert_machine_ip_is_in_cidrs "1" "${alpha_cidrs}")
 	machine_2_space_ip=$(assert_machine_ip_is_in_cidrs "2" "172.31.254.0/24")
 
-	# Sometimes it can take a bit for an ec2 machine's public ip to come up on Juju
-	wait_for "3" '.machines["0"]["ip-addresses"] | length'
-
 	echo "Verify machines can ping each other within and across spaces"
 	juju ssh 0 "ping -c4 ${machine_1_space_ip}"
 	juju ssh 0 "ping -c4 ${machine_2_space_ip}"


### PR DESCRIPTION
Sometimes ec2 machine spawns only a private and public ip, so we should
not for a third

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
BOOTSTRAP_CLOUD=aws BOOTSTRAP_PROVIDER=aws BOOTSTRAP_REGION=eu-west-1 ./main.sh -s 'test_upgrade_charm_with_bind,test_juju_bind' -v spaces_ec2
```
