### PR TITLE
[JUJU-1189] fix persistent storage tests

### DIFF
--- a/tests/includes/storage.sh
+++ b/tests/includes/storage.sh
@@ -1,4 +1,4 @@
-# this function will match that a given query exists in the output.
+# assert_storage function will match that a given query exists in the output.
 assert_storage() {
 	local name query
 	name=${1:?"name is missing"}
@@ -7,7 +7,7 @@ assert_storage() {
 	juju storage --format json | jq "${query}" | check "${name}"
 }
 
-# used to check for the life status for a given application storage. Uses a combination of the storage name and its unit index to query.
+# life_status checks for the life status for a given application storage. Uses a combination of the storage name and its unit index to query.
 life_status() {
 	local name unit_index
 	name=${1}
@@ -16,7 +16,7 @@ life_status() {
 	echo ".storage[\"$name/$unit_index\"][\"life\"]"
 }
 
-# used to check for the storage kind using the combination of the storage name and its unit index to query.
+# kind_name checks for the storage kind using the combination of the storage name and its unit index to query.
 kind_name() {
 	local name unit_index
 	name=${1}
@@ -25,7 +25,7 @@ kind_name() {
 	echo ".storage[\"$name/$unit_index\"][\"kind\"]"
 }
 
-# used to check for the storage label for a given application. The key's index is the application index.
+# label checks for the storage label for a given application. The key's index is the application index.
 label() {
 	local app_index
 	app_index=${1}
@@ -43,7 +43,7 @@ unit_attachment() {
 	echo ".storage[\"$name/$app_index\"] | .attachments | .units | keys[$unit_index]"
 }
 
-# used to query for a storage application's attached unit life status using a combination of the storage application name and applicaiton index together with
+# unit_state queries for a storage application's attached unit life status using a combination of the storage application name and applicaiton index together with
 # the storage unit name and storage unit index to filter.
 unit_state() {
 	local app_name app_index unit_name unit_index
@@ -55,41 +55,7 @@ unit_state() {
 	echo ".storage[\"$app_name/$app_index\"] | .attachments | .units[\"$unit_name/$unit_index\"][\"life\"]"
 }
 
-# like wait_for but for storage formats. Used to wait for a certain condition in charm storage.
-wait_for_storage() {
-	local name query timeout
-
-	name=${1}
-	query=${2}
-	timeout=${3:-600} # default timeout: 600s = 10m
-
-	attempt=0
-	start_time="$(date -u +%s)"
-	# shellcheck disable=SC2046,SC2143
-	until [[ "$(juju storage --format=json 2>/dev/null | jq -S "${query}" | grep "${name}")" ]]; do
-		echo "[+] (attempt ${attempt}) polling status for" "${query} => ${name}"
-		juju storage 2>&1 | sed 's/^/    | /g'
-		sleep "${SHORT_TIMEOUT}"
-
-		elapsed=$(date -u +%s)-$start_time
-		if [[ ${elapsed} -ge ${timeout} ]]; then
-			echo "[-] $(red 'timed out waiting for')" "$(red "${name}")"
-			exit 1
-		fi
-
-		attempt=$((attempt + 1))
-	done
-
-	if [[ ${attempt} -gt 0 ]]; then
-		echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
-		juju storage 2>&1 | sed 's/^/    | /g'
-		# Although juju reports as an idle condition, some charms require a
-		# breathe period to ensure things have actually settled.
-		sleep "${SHORT_TIMEOUT}"
-	fi
-}
-
-# used to check for the current status of the given volume for a filesystem matched by the volume number and volume index combination e.g 0/0, 2/1, 3/1
+# filesystem_status used to check for the current status of the given volume for a filesystem matched by the volume number and volume index combination e.g 0/0, 2/1, 3/1
 filesystem_status() {
 	local name volume_num volume_index
 	volume_num=${1}

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -278,3 +278,36 @@ wait_for_systemd_service_files_to_appear() {
 	echo $(red "Timed out waiting for the systemd unit files for ${unit} to appear")
 	exit 1
 }
+7# wait_for_storage is like wait_for but for storage formats. Used to wait for a certain condition in charm storage.
+wait_for_storage() {
+	local name query timeout
+
+	name=${1}
+	query=${2}
+	timeout=${3:-600} # default timeout: 600s = 10m
+
+	attempt=0
+	start_time="$(date -u +%s)"
+	# shellcheck disable=SC2046,SC2143
+	until [[ "$(juju storage --format=json 2>/dev/null | jq -S "${query}" | grep "${name}")" ]]; do
+		echo "[+] (attempt ${attempt}) polling status for" "${query} => ${name}"
+		juju storage 2>&1 | sed 's/^/    | /g'
+		sleep "${SHORT_TIMEOUT}"
+
+		elapsed=$(date -u +%s)-$start_time
+		if [[ ${elapsed} -ge ${timeout} ]]; then
+			echo "[-] $(red 'timed out waiting for')" "$(red "${name}")"
+			exit 1
+		fi
+
+		attempt=$((attempt + 1))
+	done
+
+	if [[ ${attempt} -gt 0 ]]; then
+		echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
+		juju storage 2>&1 | sed 's/^/    | /g'
+		# Although juju reports as an idle condition, some charms require a
+		# breathe period to ensure things have actually settled.
+		sleep "${SHORT_TIMEOUT}"
+	fi
+}

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -278,7 +278,8 @@ wait_for_systemd_service_files_to_appear() {
 	echo $(red "Timed out waiting for the systemd unit files for ${unit} to appear")
 	exit 1
 }
-7# wait_for_storage is like wait_for but for storage formats. Used to wait for a certain condition in charm storage.
+
+# wait_for_storage is like wait_for but for storage formats. Used to wait for a certain condition in charm storage.
 wait_for_storage() {
 	local name query timeout
 

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -138,7 +138,7 @@ run_charm_storage() {
 }
 
 test_charm_storage() {
-	if [ "$(skip 'test-charm-storage')" ]; then
+	if [ "$(skip 'test_charm_storage')" ]; then
 		echo "==> TEST SKIPPED: charm storage tests"
 		return
 	fi

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -132,8 +132,6 @@ run_charm_storage() {
 	juju remove-application dummy-storage-mp --destroy-storage
 	echo "All charm storage tests PASSED"
 
-	# wait for all storage units to removed
-	wait_for "{}" ".storage"
 	destroy_model "${model_name}"
 }
 

--- a/tests/suites/storage/persistent_storage.sh
+++ b/tests/suites/storage/persistent_storage.sh
@@ -128,7 +128,7 @@ run_persistent_storage() {
 }
 
 test_persistent_storage() {
-	if [ "$(skip 'test-persistent-storage')" ]; then
+	if [ "$(skip 'test_persistent_storage')" ]; then
 		echo "==> TEST SKIPPED: persistent storage tests"
 		return
 	fi


### PR DESCRIPTION
This PR makes some minor fixes around the naming of the skipped tests. Replacing hyphen delimiters with underscores and also doing some small house keeping  in the includes directory.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- [X] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
./main.sh -v -p aws -c aws storage 
```
