### PR TITLE
[JUJU-1859] Remove Lease Trapdoor

### DIFF
--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -582,7 +582,7 @@ func (s *watcherSuite) setupSecretRotationWatcher(
 
 type fakeToken struct{}
 
-func (t *fakeToken) Check(int, interface{}) error {
+func (t *fakeToken) Check() error {
 	return nil
 }
 

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -262,7 +262,7 @@ func (r relationShim) ReplaceApplicationSettings(appName string, values map[stri
 type successfulToken struct{}
 
 // Check is all of the lease.Token interface.
-func (t successfulToken) Check(attempt int, key interface{}) error {
+func (t successfulToken) Check() error {
 	return nil
 }
 

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -130,7 +130,7 @@ type token struct {
 	isLeader bool
 }
 
-func (t *token) Check(attempt int, trapdoorKey interface{}) error {
+func (t *token) Check() error {
 	if !t.isLeader {
 		return errors.New("not leader")
 	}

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -82,7 +82,7 @@ func StoreConfig(model *state.Model, authTag names.Tag, leadershipChecker leader
 	authApp := names.NewApplicationTag(appName)
 	if authTag.Kind() == names.UnitTagKind {
 		token := leadershipChecker.LeadershipCheck(appName, authTag.Id())
-		err := token.Check(0, nil)
+		err := token.Check()
 		if err != nil && !leadership.IsNotLeaderError(err) {
 			return nil, errors.Trace(err)
 		}

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -97,10 +97,10 @@ func (s *ApplicationStatusSetter) SetStatus(args params.SetStatus) (params.Error
 		token := s.leadershipChecker.LeadershipCheck(serviceId, unitId)
 
 		// TODO(fwereade) pass token into SetStatus instead of checking here.
-		if err := token.Check(0, nil); err != nil {
-			// TODO(fwereade) this should probably be apiservererrors.ErrPerm is certain cases,
-			// but I don't think I implemented an exported ErrNotLeader. I
-			// should have done, though.
+		if err := token.Check(); err != nil {
+			// TODO(fwereade) this should probably be apiservererrors.ErrPerm in certain cases,
+			// but I don't think I implemented an exported ErrNotLeader.
+			// I should have done, though.
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/facades/agent/secretsmanager/access.go
+++ b/apiserver/facades/agent/secretsmanager/access.go
@@ -83,7 +83,7 @@ func (s *SecretsManagerAPI) ownerToken(ownerTag names.Tag) (leadership.Token, er
 type successfulToken struct{}
 
 // Check implements lease.Token.
-func (t successfulToken) Check(_ int, _ interface{}) error {
+func (t successfulToken) Check() error {
 	return nil
 }
 
@@ -92,7 +92,7 @@ func (t successfulToken) Check(_ int, _ interface{}) error {
 func (s *SecretsManagerAPI) leadershipToken() (leadership.Token, error) {
 	appName := authTagApp(s.authTag)
 	token := s.leadershipChecker.LeadershipCheck(appName, s.authTag.Id())
-	if err := token.Check(0, nil); err != nil {
+	if err := token.Check(); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return token, nil

--- a/apiserver/facades/agent/secretsmanager/mocks/leadershipchecker.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/leadershipchecker.go
@@ -72,15 +72,15 @@ func (m *MockToken) EXPECT() *MockTokenMockRecorder {
 }
 
 // Check mocks base method.
-func (m *MockToken) Check(arg0 int, arg1 interface{}) error {
+func (m *MockToken) Check() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Check", arg0, arg1)
+	ret := m.ctrl.Call(m, "Check")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Check indicates an expected call of Check.
-func (mr *MockTokenMockRecorder) Check(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockTokenMockRecorder) Check() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockToken)(nil).Check), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockToken)(nil).Check))
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -163,7 +163,7 @@ func (s *SecretsManagerSuite) TestCreateSecrets(c *gc.C) {
 	}
 	var gotURI *coresecrets.URI
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 	s.secretsBackend.EXPECT().CreateSecret(gomock.Any(), p).DoAndReturn(
 		func(uri *coresecrets.URI, p state.CreateSecretParams) (*coresecrets.SecretMetadata, error) {
 			ownerTag := names.NewApplicationTag("mariadb")
@@ -229,7 +229,7 @@ func (s *SecretsManagerSuite) TestCreateSecretDuplicateLabel(c *gc.C) {
 		},
 	}
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 	s.secretsBackend.EXPECT().CreateSecret(gomock.Any(), p).Return(
 		nil, fmt.Errorf("dup label %w", state.LabelExists),
 	)
@@ -289,7 +289,7 @@ func (s *SecretsManagerSuite) TestUpdateSecrets(c *gc.C) {
 		},
 	)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token).Times(2)
-	s.token.EXPECT().Check(0, nil).Return(nil).Times(2)
+	s.token.EXPECT().Check().Return(nil).Times(2)
 	s.expectSecretAccessQuery(2)
 
 	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
@@ -339,7 +339,7 @@ func (s *SecretsManagerSuite) TestUpdateSecretDuplicateLabel(c *gc.C) {
 		nil, fmt.Errorf("dup label %w", state.LabelExists),
 	)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 	s.expectSecretAccessQuery(1)
 
 	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
@@ -365,7 +365,7 @@ func (s *SecretsManagerSuite) TestRemoveSecrets(c *gc.C) {
 	expectURI := *uri
 	s.secretsBackend.EXPECT().DeleteSecret(&expectURI, []int{666}).Return(true, nil)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 	s.expectSecretAccessQuery(1)
 	s.provider.EXPECT().CleanupSecrets(mockModel{}, []*coresecrets.URI{uri}).Return(nil)
 
@@ -388,7 +388,7 @@ func (s *SecretsManagerSuite) TestRemoveSecretRevision(c *gc.C) {
 	expectURI := *uri
 	s.secretsBackend.EXPECT().DeleteSecret(&expectURI, []int{666}).Return(false, nil)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 	s.expectSecretAccessQuery(1)
 
 	results, err := s.facade.RemoveSecrets(params.DeleteSecretArgs{
@@ -431,7 +431,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 
 	now := time.Now()
 	uri := coresecrets.NewURI()
@@ -559,7 +559,7 @@ func (s *SecretsManagerSuite) TestWatchObsolete(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 	s.secretsBackend.EXPECT().WatchObsolete(
 		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
 		s.secretsWatcher, nil,
@@ -589,7 +589,7 @@ func (s *SecretsManagerSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 	s.secretTriggers.EXPECT().WatchSecretsRotationChanges(
 		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
 		s.secretsTriggerWatcher, nil,
@@ -738,7 +738,7 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 	s.secretTriggers.EXPECT().WatchSecretRevisionsExpiryChanges(
 		[]names.Tag{names.NewUnitTag("mariadb/0"), names.NewApplicationTag("mariadb")}).Return(
 		s.secretsTriggerWatcher, nil,
@@ -790,7 +790,7 @@ func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 		Role:        coresecrets.RoleView,
 	}).Return(errors.New("boom"))
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 
 	result, err := s.facade.SecretsGrant(params.GrantRevokeSecretArgs{
 		Args: []params.GrantRevokeSecretArg{{
@@ -834,7 +834,7 @@ func (s *SecretsManagerSuite) TestSecretsRevoke(c *gc.C) {
 		Role:        coresecrets.RoleView,
 	}).Return(errors.New("boom"))
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
-	s.token.EXPECT().Check(0, nil).Return(nil)
+	s.token.EXPECT().Check().Return(nil)
 
 	result, err := s.facade.SecretsRevoke(params.GrantRevokeSecretArgs{
 		Args: []params.GrantRevokeSecretArg{{

--- a/apiserver/facades/agent/uniter/status.go
+++ b/apiserver/facades/agent/uniter/status.go
@@ -147,10 +147,10 @@ func (s *StatusAPI) ApplicationStatus(args params.Entities) (params.ApplicationS
 
 		// ...so we can check the unit's application leadership...
 		token := s.leadershipChecker.LeadershipCheck(applicationId, unitId)
-		if err := token.Check(0, nil); err != nil {
-			// TODO(fwereade) this should probably be ErrPerm is certain cases,
-			// but I don't think I implemented an exported ErrNotLeader. I
-			// should have done, though.
+		if err := token.Check(); err != nil {
+			// TODO(fwereade) this should probably be ErrPerm in certain cases,
+			// but I don't think I implemented an exported ErrNotLeader.
+			// I should have done, though.
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1287,7 +1287,7 @@ func (u *UniterAPI) readLocalApplicationSettings(relTag string, appTag names.App
 		}
 		// For provider-requirer relations only allow the
 		// leader unit to read the application settings.
-		return token.Check(0, nil) == nil
+		return token.Check() == nil
 	}
 
 	return u.getRelationAppSettings(canAccessSettings, relTag, appTag)
@@ -1468,7 +1468,7 @@ func (u *UniterAPI) SetRelationStatus(args params.RelationStatusArgs) (params.Er
 			return err
 		}
 		token := checker.LeadershipCheck(unit.ApplicationName(), unit.Name())
-		if err := token.Check(0, nil); err != nil {
+		if err := token.Check(); err != nil {
 			return errors.Trace(err)
 		}
 

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -4562,7 +4562,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChangesWhenNotLeader(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
-			{Error: &params.Error{Message: `prerequisites failed: "wordpress/1" is not leader of "wordpress"`}},
+			{Error: &params.Error{Message: `checking leadership continuity: "wordpress/1" is not leader of "wordpress"`}},
 		},
 	})
 }
@@ -4806,7 +4806,7 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChangesCAASNotLeader(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
-			{Error: &params.Error{Message: `prerequisites failed: "` + gitlabUnit.Tag().Id() + `" is not leader of "` + gitlab.Name() + `"`}},
+			{Error: &params.Error{Message: `checking leadership continuity: "` + gitlabUnit.Tag().Id() + `" is not leader of "` + gitlab.Name() + `"`}},
 		},
 	})
 }
@@ -5034,7 +5034,7 @@ type fakeToken struct {
 	err error
 }
 
-func (t *fakeToken) Check(int, interface{}) error {
+func (t *fakeToken) Check() error {
 	return t.err
 }
 
@@ -5047,7 +5047,7 @@ type token struct {
 	unit, application string
 }
 
-func (t *token) Check(attempt int, trapdoorKey interface{}) error {
+func (t *token) Check() error {
 	if !t.isLeader {
 		return leadership.NewNotLeaderError(t.unit, t.application)
 	}

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -35,8 +35,8 @@ type leadershipToken struct {
 }
 
 // Check is part of the leadership.Token interface.
-func (t leadershipToken) Check(attempt int, out interface{}) error {
-	err := t.token.Check(attempt, out)
+func (t leadershipToken) Check() error {
+	err := t.token.Check()
 	if errors.Cause(err) == lease.ErrNotHeld {
 		return leadership.NewNotLeaderError(t.unitName, t.applicationName)
 	}

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -69,7 +69,7 @@ type Claimer interface {
 	BlockUntilLeadershipReleased(applicationId string, cancel <-chan struct{}) (err error)
 }
 
-// Claimer exposes leadership revocation capabilities.
+// Revoker exposes leadership revocation capabilities.
 type Revoker interface {
 	// RevokeLeadership revokes leadership of the named application
 	// on behalf of the named unit.
@@ -97,25 +97,8 @@ type Pinner interface {
 
 // Token represents a unit's leadership of its application.
 type Token interface {
-
-	// Check returns an error if the condition it embodies no longer
-	// holds.  If you pass a non-nil trapdoorKey value into Check, it
-	// must be a pointer to data of the correct type, into which the
-	// token's content will be copied.
-	//
-	// The "correct type" is implementation-specific, and no implementation
-	// is obliged to accept any non-nil parameter; but methods that return
-	// Tokens should explain whether, and how, they will expose their content.
-	//
-	// In practice, most Token implementations will likely expect *[]txn.Op,
-	// so that they can be used to gate mgo/txn-based state changes.
-	//
-	// If a non-nil trapdoorKey value is passed, attempt should be how
-	// many times this check has been tried previously (for example,
-	// in a buildTxn function it'll be the transaction attempt). This
-	// enables the token to generate different ops for the second
-	// attempt (the raft lease implementation uses this).
-	Check(attempt int, trapdoorKey interface{}) error
+	// Check returns an error if the condition it embodies no longer holds.
+	Check() error
 }
 
 // Checker exposes leadership testing capabilities.

--- a/core/lease/interface.go
+++ b/core/lease/interface.go
@@ -72,26 +72,9 @@ type Checker interface {
 // Token represents a fact -- but not necessarily a *true* fact -- about some
 // holder's ownership of some lease.
 type Token interface {
-
 	// Check returns ErrNotHeld if the lease it represents is not held
-	// by the holder it represents. If attempt is 0, trapdoorKey is
-	// nil, and Check returns nil, then the token continues to
-	// represent a true fact.
-	//
-	// Attempt is the number of times this check has been tried (not
-	// necessarily with this token instance). This enables an
-	// implementation to vary how it deals with trapdoorKey across
-	// attempts. For example, the raft implementation generates
-	// different ops for the first attempt than for subsequent
-	// attempts.
-	//
-	// If the token represents a true fact and trapdoorKey is *not*
-	// nil, it will be passed through layers for the attention of the
-	// underlying lease.Client implementation. If you need to do this,
-	// consult the documentation for the particular Client you're
-	// using to determine what key should be passed and what errors
-	// that might induce.
-	Check(attempt int, trapdoorKey interface{}) error
+	// by the holder it represents.
+	Check() error
 }
 
 // Reader describes retrieval of all leases and holders

--- a/core/raftlease/store.go
+++ b/core/raftlease/store.go
@@ -72,7 +72,6 @@ type ReadonlyFSM interface {
 type StoreConfig struct {
 	FSM              ReadonlyFSM
 	Client           Client
-	Trapdoor         TrapdoorFunc
 	Clock            clock.Clock
 	MetricsCollector MetricsCollector
 }
@@ -135,23 +134,12 @@ func (s *Store) RevokeLease(key lease.Key, holder string, stop <-chan struct{}) 
 
 // Leases is part of lease.Store.
 func (s *Store) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
-	leaseMap := s.fsm.Leases(s.config.Clock.Now, keys...)
-	s.addTrapdoors(leaseMap)
-	return leaseMap
+	return s.fsm.Leases(s.config.Clock.Now, keys...)
 }
 
 // LeaseGroup is part of Lease.Store.
 func (s *Store) LeaseGroup(namespace, modelUUID string) map[lease.Key]lease.Info {
-	leaseMap := s.fsm.LeaseGroup(s.config.Clock.Now, namespace, modelUUID)
-	s.addTrapdoors(leaseMap)
-	return leaseMap
-}
-
-func (s *Store) addTrapdoors(leaseMap map[lease.Key]lease.Info) {
-	for k, v := range leaseMap {
-		v.Trapdoor = s.config.Trapdoor(k, v.Holder)
-		leaseMap[k] = v
-	}
+	return s.fsm.LeaseGroup(s.config.Clock.Now, namespace, modelUUID)
 }
 
 // PinLease is part of lease.Store.

--- a/core/raftlease/store_test.go
+++ b/core/raftlease/store_test.go
@@ -46,8 +46,7 @@ func (s *storeSuite) SetUpTest(c *gc.C) {
 
 	metrics := raftlease.NewOperationClientMetrics(s.clock)
 	s.store = raftlease.NewStore(raftlease.StoreConfig{
-		FSM:      s.fsm,
-		Trapdoor: FakeTrapdoor,
+		FSM: s.fsm,
 		Client: raftlease.NewPubsubClient(raftlease.PubsubClientConfig{
 			Hub:            s.hub,
 			RequestTopic:   "lease.request",
@@ -434,19 +433,9 @@ func (s *storeSuite) TestLeases(c *gc.C) {
 	c.Assert(r1.Holder, gc.Equals, "verdi")
 	c.Assert(r1.Expiry, gc.Equals, in10Seconds)
 
-	// Can't compare trapdoors directly.
-	var out string
-	err := r1.Trapdoor(0, &out)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.Equals, "{quam olim abrahe} held by verdi")
-
 	r2 := result[lease2]
 	c.Assert(r2.Holder, gc.Equals, "mozart")
 	c.Assert(r2.Expiry, gc.Equals, in5Seconds)
-
-	err = r2.Trapdoor(0, &out)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.Equals, "{la cry mosa} held by mozart")
 }
 
 func (s *storeSuite) TestLeasesFilter(c *gc.C) {
@@ -479,19 +468,9 @@ func (s *storeSuite) TestLeaseGroup(c *gc.C) {
 	c.Assert(r1.Holder, gc.Equals, "verdi")
 	c.Assert(r1.Expiry, gc.Equals, in10Seconds)
 
-	// Can't compare trapdoors directly.
-	var out string
-	err := r1.Trapdoor(0, &out)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.Equals, "{quam olim abrahe} held by verdi")
-
 	r2 := result[lease2]
 	c.Assert(r2.Holder, gc.Equals, "mozart")
 	c.Assert(r2.Expiry, gc.Equals, in5Seconds)
-
-	err = r2.Trapdoor(0, &out)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(out, gc.Equals, "{la cry mosa} held by mozart")
 }
 
 func (s *storeSuite) TestPin(c *gc.C) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1067,7 +1067,7 @@ func leaseManager(controllerUUID string, st *state.State) (*lease.Manager, error
 	target := st.LeaseNotifyTarget(
 		loggo.GetLogger("juju.state.raftlease"),
 	)
-	dummyStore := newLeaseStore(clock.WallClock, target, st.LeaseTrapdoorFunc())
+	dummyStore := newLeaseStore(clock.WallClock, target)
 	return lease.NewManager(lease.ManagerConfig{
 		Secretary:            lease.SecretaryFinder(controllerUUID),
 		Store:                dummyStore,

--- a/provider/dummy/leasestore.go
+++ b/provider/dummy/leasestore.go
@@ -17,11 +17,10 @@ import (
 // leaseStore implements lease.Store as simply as possible for use in
 // the dummy provider. Heavily cribbed from raftlease.FSM.
 type leaseStore struct {
-	mu       sync.Mutex
-	clock    clock.Clock
-	entries  map[lease.Key]*entry
-	trapdoor raftlease.TrapdoorFunc
-	target   raftlease.NotifyTarget
+	mu      sync.Mutex
+	clock   clock.Clock
+	entries map[lease.Key]*entry
+	target  raftlease.NotifyTarget
 }
 
 // entry holds the details of a lease.
@@ -37,12 +36,11 @@ type entry struct {
 	duration time.Duration
 }
 
-func newLeaseStore(clock clock.Clock, target raftlease.NotifyTarget, trapdoor raftlease.TrapdoorFunc) *leaseStore {
+func newLeaseStore(clock clock.Clock, target raftlease.NotifyTarget) *leaseStore {
 	return &leaseStore{
-		clock:    clock,
-		entries:  make(map[lease.Key]*entry),
-		target:   target,
-		trapdoor: trapdoor,
+		clock:   clock,
+		entries: make(map[lease.Key]*entry),
+		target:  target,
 	}
 }
 
@@ -123,9 +121,8 @@ func (s *leaseStore) Leases(keys ...lease.Key) map[lease.Key]lease.Info {
 		}
 
 		results[key] = lease.Info{
-			Holder:   entry.holder,
-			Expiry:   entry.start.Add(entry.duration),
-			Trapdoor: s.trapdoor(key, entry.holder),
+			Holder: entry.holder,
+			Expiry: entry.start.Add(entry.duration),
 		}
 	}
 	return results

--- a/state/leadership.go
+++ b/state/leadership.go
@@ -21,13 +21,12 @@ func leadershipSettingsKey(applicationId string) string {
 	return fmt.Sprintf("a#%s#leader", applicationId)
 }
 
-// buildTxnWithLeadership returns a transaction source that combines the supplied source
-// with checks and asserts on the supplied token.
+// buildTxnWithLeadership returns a transaction source
+// that reasserts application leadership continuity.
 func buildTxnWithLeadership(buildTxn jujutxn.TransactionSource, token leadership.Token) jujutxn.TransactionSource {
 	return func(attempt int) ([]txn.Op, error) {
-		var prereqs []txn.Op
-		if err := token.Check(attempt, &prereqs); err != nil {
-			return nil, errors.Annotatef(err, "prerequisites failed")
+		if err := token.Check(); err != nil {
+			return nil, errors.Annotatef(err, "checking leadership continuity")
 		}
 		ops, err := buildTxn(attempt)
 		if err == jujutxn.ErrNoOperations {
@@ -35,6 +34,6 @@ func buildTxnWithLeadership(buildTxn jujutxn.TransactionSource, token leadership
 		} else if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return append(prereqs, ops...), nil
+		return ops, nil
 	}
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1809,7 +1809,7 @@ func (s *MigrationExportSuite) TestOperations(c *gc.C) {
 type goodToken struct{}
 
 // Check implements leadership.Token
-func (*goodToken) Check(int, interface{}) error {
+func (*goodToken) Check() error {
 	return nil
 }
 

--- a/state/relation_test.go
+++ b/state/relation_test.go
@@ -1046,35 +1046,9 @@ func (s *RelationSuite) TestUpdateApplicationSettingsNotLeader(c *gc.C) {
 			"rendezvouse": "rendezvous",
 		},
 	)
-	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" application "mysql": prerequisites failed: not the leader`)
+	c.Assert(err, gc.ErrorMatches,
+		`relation "wordpress:db mysql:server" application "mysql": checking leadership continuity: not the leader`)
 
-	settingsMap, err := relation.ApplicationSettings("mysql")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(settingsMap, gc.HasLen, 0)
-}
-
-func (s *RelationSuite) TestUpdateApplicationSettingsRace(c *gc.C) {
-	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
-	eps, err := s.State.InferEndpoints("mysql", "wordpress")
-	c.Assert(err, jc.ErrorIsNil)
-	relation, err := s.State.AddRelation(eps...)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// raceToken indicates it holds leadership but yields txn.Ops that
-	// fail assertion to simulate a race in the DB, then fails on the
-	// second attempt indicating that leadership was lost.
-	var token raceToken
-	err = relation.UpdateApplicationSettings(
-		"mysql",
-		&token,
-		map[string]interface{}{
-			"rendezvouse": "rendezvous",
-		},
-	)
-	c.Assert(err, gc.ErrorMatches, `relation "wordpress:db mysql:server" application "mysql": prerequisites failed: too late`)
-
-	c.Assert(token.checkedOnce, gc.Equals, true)
 	settingsMap, err := relation.ApplicationSettings("mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settingsMap, gc.HasLen, 0)

--- a/state/state.go
+++ b/state/state.go
@@ -428,12 +428,6 @@ func (st *State) LeaseNotifyTarget(logger raftleasestore.Logger) raftlease.Notif
 	return raftleasestore.NewNotifyTarget(&environMongo{st}, leaseHoldersC, logger)
 }
 
-// LeaseTrapdoorFunc returns a raftlease.TrapdoorFunc for checking
-// lease state in a database.
-func (st *State) LeaseTrapdoorFunc() raftlease.TrapdoorFunc {
-	return raftleasestore.MakeTrapdoorFunc(&environMongo{st}, leaseHoldersC)
-}
-
 // ModelUUID returns the model UUID for the model
 // controlled by this state instance.
 func (st *State) ModelUUID() string {

--- a/worker/lease/check.go
+++ b/worker/lease/check.go
@@ -19,8 +19,7 @@ type token struct {
 }
 
 // Check is part of the lease.Token interface.
-func (t token) Check(attempt int, trapdoorKey interface{}) error {
-
+func (t token) Check() error {
 	// This validation, which could be done at Token creation time, is deferred
 	// until this point for historical reasons. In particular, this code was
 	// extracted from a *leadership* implementation which has a LeadershipCheck
@@ -36,24 +35,20 @@ func (t token) Check(attempt int, trapdoorKey interface{}) error {
 		return errors.Annotatef(err, "cannot check holder %q", t.holderName)
 	}
 	return check{
-		leaseKey:    t.leaseKey,
-		holderName:  t.holderName,
-		attempt:     attempt,
-		trapdoorKey: trapdoorKey,
-		response:    make(chan error),
-		stop:        t.stop,
+		leaseKey:   t.leaseKey,
+		holderName: t.holderName,
+		response:   make(chan error),
+		stop:       t.stop,
 	}.invoke(t.checks)
 }
 
 // check is used to deliver lease-check requests to a manager's loop
 // goroutine on behalf of a token (as returned by LeadershipCheck).
 type check struct {
-	leaseKey    lease.Key
-	holderName  string
-	attempt     int
-	trapdoorKey interface{}
-	response    chan error
-	stop        <-chan struct{}
+	leaseKey   lease.Key
+	holderName string
+	response   chan error
+	stop       <-chan struct{}
 }
 
 // invoke sends the check on the supplied channel and waits for an error

--- a/worker/lease/manager.go
+++ b/worker/lease/manager.go
@@ -560,8 +560,6 @@ func (manager *Manager) handleCheck(check check) error {
 		}
 
 		response = lease.ErrNotHeld
-	} else if check.trapdoorKey != nil {
-		response = info.Trapdoor(check.attempt, check.trapdoorKey)
 	}
 	check.respond(errors.Trace(response))
 	return nil

--- a/worker/lease/manager_block_test.go
+++ b/worker/lease/manager_block_test.go
@@ -146,7 +146,7 @@ func (s *WaitUntilExpiredSuite) TestLeadershipExpiredEarly(c *gc.C) {
 		// it turns out the lease had already been expired by someone else.
 		checker, err := manager.Checker("namespace", "model")
 		c.Assert(err, jc.ErrorIsNil)
-		err = checker.Token("redis", "redis/99").Check(0, nil)
+		err = checker.Token("redis", "redis/99").Check()
 		c.Assert(err, gc.ErrorMatches, "lease not held")
 
 		// Simulate the delayed synchronisation by removing the lease.
@@ -188,7 +188,7 @@ func (s *WaitUntilExpiredSuite) TestMultiple(c *gc.C) {
 		// Induce a scheduled block check by making an unexpected check.
 		checker, err := manager.Checker("namespace", "model")
 		c.Assert(err, jc.ErrorIsNil)
-		err = checker.Token("redis", "redis/99").Check(0, nil)
+		err = checker.Token("redis", "redis/99").Check()
 		c.Assert(err, gc.ErrorMatches, "lease not held")
 
 		// Deleting the redis lease should cause unblocks for the redis

--- a/worker/lease/manager_check_test.go
+++ b/worker/lease/manager_check_test.go
@@ -34,7 +34,7 @@ func (s *TokenSuite) TestSuccess(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(0, nil)
+		err := token.Check()
 		c.Check(err, jc.ErrorIsNil)
 	})
 }
@@ -43,7 +43,7 @@ func (s *TokenSuite) TestFailureMissing(c *gc.C) {
 	fix := &Fixture{}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(0, nil)
+		err := token.Check()
 		c.Check(errors.Cause(err), gc.Equals, corelease.ErrNotHeld)
 	})
 }
@@ -60,7 +60,7 @@ func (s *TokenSuite) TestFailureOtherHolder(c *gc.C) {
 	}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(0, nil)
+		err := token.Check()
 		c.Check(errors.Cause(err), gc.Equals, corelease.ErrNotHeld)
 	})
 }

--- a/worker/lease/manager_cross_test.go
+++ b/worker/lease/manager_cross_test.go
@@ -143,10 +143,10 @@ func (s *CrossSuite) testChecks(c *gc.C, lease1, lease2 corelease.Key) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		t1 := checker1.Token(lease1.Lease, "sgt-howie")
-		c.Assert(t1.Check(0, nil), gc.Equals, nil)
+		c.Assert(t1.Check(), gc.Equals, nil)
 
 		t2 := checker2.Token(lease2.Lease, "sgt-howie")
-		err = t2.Check(0, nil)
+		err = t2.Check()
 		c.Assert(errors.Cause(err), gc.Equals, corelease.ErrNotHeld)
 	})
 }

--- a/worker/lease/manager_validation_test.go
+++ b/worker/lease/manager_validation_test.go
@@ -132,7 +132,7 @@ func (s *ValidationSuite) TestToken_LeaseName(c *gc.C) {
 	fix := &Fixture{}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("INVALID", "bar/0")
-		err := token.Check(0, nil)
+		err := token.Check()
 		c.Check(err, gc.ErrorMatches, `cannot check lease "INVALID": name not valid`)
 		c.Check(err, jc.Satisfies, errors.IsNotValid)
 	})
@@ -142,7 +142,7 @@ func (s *ValidationSuite) TestToken_HolderName(c *gc.C) {
 	fix := &Fixture{}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
 		token := getChecker(c, manager).Token("foo", "INVALID")
-		err := token.Check(0, nil)
+		err := token.Check()
 		c.Check(err, gc.ErrorMatches, `cannot check holder "INVALID": name not valid`)
 		c.Check(err, jc.Satisfies, errors.IsNotValid)
 	})

--- a/worker/lease/manager_validation_test.go
+++ b/worker/lease/manager_validation_test.go
@@ -148,31 +148,6 @@ func (s *ValidationSuite) TestToken_HolderName(c *gc.C) {
 	})
 }
 
-func (s *ValidationSuite) TestTokenOutPtr(c *gc.C) {
-	expectKey := "bad"
-	expectErr := errors.New("bad")
-
-	fix := &Fixture{
-		leases: map[corelease.Key]corelease.Info{
-			key("redis"): {
-				Holder: "redis/0",
-				Expiry: offset(time.Second),
-				Trapdoor: func(attempt int, gotKey interface{}) error {
-					c.Check(attempt, gc.Equals, 27)
-					c.Check(gotKey, gc.Equals, &expectKey)
-					return expectErr
-				},
-			},
-		},
-	}
-	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {
-		token := getChecker(c, manager).Token("redis", "redis/0")
-		err := token.Check(27, &expectKey)
-		cause := errors.Cause(err)
-		c.Check(cause, gc.Equals, expectErr)
-	})
-}
-
 func (s *ValidationSuite) TestWaitUntilExpired_LeaseName(c *gc.C) {
 	fix := &Fixture{}
 	fix.RunTest(c, func(manager *lease.Manager, _ *testclock.Clock) {

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -185,7 +185,6 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 
 	s.store = s.config.NewStore(raftlease.StoreConfig{
 		FSM:              s.config.FSM,
-		Trapdoor:         st.LeaseTrapdoorFunc(),
 		Client:           client,
 		Clock:            clock,
 		MetricsCollector: metrics,

--- a/worker/uniter/runner/context/flush_test.go
+++ b/worker/uniter/runner/context/flush_test.go
@@ -312,7 +312,7 @@ func (s *FlushContextSuite) TestRunHookAddUnitStorageOnSuccess(c *gc.C) {
 
 type fakeToken struct{}
 
-func (t *fakeToken) Check(int, interface{}) error {
+func (t *fakeToken) Check() error {
 	return nil
 }
 

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -1574,7 +1574,7 @@ func (s setLeaderSettings) step(c *gc.C, ctx *testContext) {
 
 type successToken struct{}
 
-func (successToken) Check(int, interface{}) error {
+func (successToken) Check() error {
 	return nil
 }
 
@@ -1690,7 +1690,7 @@ func (s createSecret) step(c *gc.C, ctx *testContext) {
 
 type fakeToken struct{}
 
-func (t *fakeToken) Check(int, interface{}) error {
+func (t *fakeToken) Check() error {
 	return nil
 }
 


### PR DESCRIPTION
The lease trapdoor mechanism works in the following way:
- A leadership claim/expiry results in a side-effect update to a lease holders collection in Mongo.
- When a leadership check is made against the lease manager, a `Token` is returned.
- This token has an associated trapdoor function.
- The token is passed to certain `TransactionSource` yielding methods, where the token's `Check` method is called to ensure that we are still the leader. That method call can accept a `TransactionSource` that is decorated by the trapdoor function (if leadership is still held) with an assertion for the lease holder in Mongo.

Despite the assurances sought by this method, there are still possible races. Furthermore, it adds complexity that is difficult to comprehend for those working on Juju, and (critically) requires that the Raft worker has a dependency on the state worker so that we can update the lease holders collection.

We want to break this dependency and simplify the logic ahead of moving leases into Dqlite.

This first step involves removing the trapdoor functionality from the token. We still do the latest possible check when building transactions for updates requiring leadership to be held, but the lease store (backed by Raft) is the only source of truth.

Forthcoming patches will:
- Change remaining logic looking at Mongo for lease holders, to use the Raft-backed lease manager.
- Remove altogether, any updates to Mongo following lease acquisition/loss.

## QA steps

Deploy a decent-sized bundle and wait for quiescence. [Charmed K8s on AWS](https://ubuntu.com/kubernetes/docs/aws-integration) is suitable.

## Documentation changes

None.

## Bug reference

N/A
