### PR TITLE
[JUJU-1846] Updated static-analysis.yaml in GH actions to support expect

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,6 +28,8 @@ jobs:
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
         echo "/snap/bin" >> $GITHUB_PATH
         lxc network set lxdbr0 ipv6.address none
+        sudo snap remove expect
+        sudo apt install expect
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,6 +35,7 @@ jobs:
 
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
         sudo snap install shfmt
+        sudo apt install expect
     
     - name: Download Dependencies
       run: go mod download


### PR DESCRIPTION
This PR adds the installation of the `expect` tool to be able to pass the static-analysis check_dependencies stage.

## Checklist


- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made

## QA steps

Just check the changes.