### PR TITLE
[JUJU-1548] Default series for charms

### DIFF
--- a/cmd/juju/application/deployer/series_selector.go
+++ b/cmd/juju/application/deployer/series_selector.go
@@ -14,7 +14,6 @@ import (
 const (
 	msgUserRequestedSeries = "with the user specified series %q"
 	msgBundleSeries        = "with the series %q defined by the bundle"
-	msgDefaultModelSeries  = "with the configured model default series %q"
 	msgLatestLTSSeries     = "with the latest LTS series %q"
 )
 

--- a/cmd/juju/application/deployer/series_selector.go
+++ b/cmd/juju/application/deployer/series_selector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juju/charm/v8"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/version"
 )
 
@@ -53,11 +54,12 @@ type seriesSelector struct {
 
 // charmSeries determines what series to use with a charm.
 // Order of preference is:
-// - user requested with --series or defined by bundle when deploying
-// - user requested in charm's url (e.g. juju deploy precise/ubuntu)
-// - model default (if it matches supported series)
-// - default from charm metadata supported series / series in url
-// - default LTS
+//   - user requested with --series or defined by bundle when deploying
+//   - user requested in charm's url (e.g. juju deploy precise/ubuntu)
+//     old charmstore style urls only
+//   - model default, if set, acts like --series
+//   - default from charm metadata supported series / series in url
+//   - default LTS
 func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 	// TODO(sidecar): handle systems
 
@@ -75,14 +77,7 @@ func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 	// No series explicitly requested by the user.
 	// Use model default series, if explicitly set and supported by the charm.
 	if defaultSeries, explicit := s.conf.DefaultSeries(); explicit {
-		if _, err := charm.SeriesForCharm(defaultSeries, s.supportedSeries); err == nil {
-			// validate the series we get from the charm
-			if err := s.validateSeries(defaultSeries); err != nil {
-				return "", err
-			}
-			logger.Infof(msgDefaultModelSeries, defaultSeries)
-			return defaultSeries, nil
-		}
+		return s.userRequested(defaultSeries)
 	}
 
 	// Next fall back to the charm's list of series, filtered to what's supported
@@ -101,7 +96,7 @@ func (s seriesSelector) charmSeries() (selectedSeries string, err error) {
 	}
 
 	// Charm hasn't specified a default (likely due to being a local charm
-	// deployed by path).  Last chance, best we can do is default to LTS.
+	// deployed by path). Last chance, best we can do is default to LTS.
 
 	// At this point, because we have no idea what series the charm supports,
 	// *everything* requires --force.

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -146,7 +146,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				conf:                defaultSeries{"wily", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			expectedSeries: "bionic",
+			err: `series "wily" not supported by charm, supported series are: bionic, cosmic`,
 		},
 		{
 			title: "juju deploy multiseries   # use model series defaults if supported by charm",

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -587,9 +587,8 @@ const (
 
 // refreshConfig creates a RefreshConfig for the given input.
 // If the origin.ID is not set, a install refresh config is returned. For
-//
-//	install. Channel and Revision are mutually exclusive in the api, only
-//	one will be used.
+// install. Channel and Revision are mutually exclusive in the api, only
+// one will be used.
 //
 // If the origin.ID is set, a refresh config is returned.
 //

--- a/environs/bootstrap/prepare_test.go
+++ b/environs/bootstrap/prepare_test.go
@@ -98,7 +98,6 @@ func (s *PrepareSuite) assertPrepare(c *gc.C, skipVerify bool) {
 			controller.SetNUMAControlPolicyKey: true,
 		},
 		Config: map[string]interface{}{
-			"default-series":            "focal",
 			"firewall-mode":             "instance",
 			"ssl-hostname-verification": true,
 			"logging-config":            "<root>=INFO",

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -297,6 +297,10 @@ const (
 	// LoggingOutputKey is a key for determining the destination of output for
 	// logging.
 	LoggingOutputKey = "logging-output"
+
+	// DefaultSeries is what series a model should explicitly use for charms unless
+	// otherwise provided.
+	DefaultSeries = "default-series"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -498,7 +502,7 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	"default-series":                jujuversion.DefaultSupportedLTS(),
+	DefaultSeries:                   "",
 	ProvisionerHarvestModeKey:       HarvestDestroyed.String(),
 	NumProvisionWorkersKey:          16,
 	NumContainerProvisionWorkersKey: 4,
@@ -938,7 +942,7 @@ func (c *Config) DefaultSpace() string {
 // DefaultSeries returns the configured default Ubuntu series for the model,
 // and whether the default series was explicitly configured on the environment.
 func (c *Config) DefaultSeries() (string, bool) {
-	s, ok := c.defined["default-series"]
+	s, ok := c.defined[DefaultSeries]
 	if !ok {
 		return "", false
 	}
@@ -1725,7 +1729,7 @@ var alwaysOptional = schema.Defaults{
 	AgentMetadataURLKey:             schema.Omit,
 	ContainerImageStreamKey:         schema.Omit,
 	ContainerImageMetadataURLKey:    schema.Omit,
-	"default-series":                schema.Omit,
+	DefaultSeries:                   schema.Omit,
 	"development":                   schema.Omit,
 	"ssl-hostname-verification":     schema.Omit,
 	"proxy-ssh":                     schema.Omit,
@@ -1957,7 +1961,7 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	"default-series": {
+	DefaultSeries: {
 		Description: "The default series of Ubuntu to use for deploying charms",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -298,9 +298,9 @@ const (
 	// logging.
 	LoggingOutputKey = "logging-output"
 
-	// DefaultSeries is what series a model should explicitly use for charms unless
-	// otherwise provided.
-	DefaultSeries = "default-series"
+	// DefaultSeriesKey is a key for determining the series a model should
+	// explicitly use for charms unless otherwise provided.
+	DefaultSeriesKey = "default-series"
 )
 
 // ParseHarvestMode parses description of harvesting method and
@@ -502,7 +502,7 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	DefaultSeries:                   "",
+	DefaultSeriesKey:                "",
 	ProvisionerHarvestModeKey:       HarvestDestroyed.String(),
 	NumProvisionWorkersKey:          16,
 	NumContainerProvisionWorkersKey: 4,
@@ -939,10 +939,10 @@ func (c *Config) DefaultSpace() string {
 	return c.asString(DefaultSpace)
 }
 
-// DefaultSeries returns the configured default Ubuntu series for the model,
+// DefaultSeriesKey returns the configured default Ubuntu series for the model,
 // and whether the default series was explicitly configured on the environment.
 func (c *Config) DefaultSeries() (string, bool) {
-	s, ok := c.defined[DefaultSeries]
+	s, ok := c.defined[DefaultSeriesKey]
 	if !ok {
 		return "", false
 	}
@@ -1729,7 +1729,7 @@ var alwaysOptional = schema.Defaults{
 	AgentMetadataURLKey:             schema.Omit,
 	ContainerImageStreamKey:         schema.Omit,
 	ContainerImageMetadataURLKey:    schema.Omit,
-	DefaultSeries:                   schema.Omit,
+	DefaultSeriesKey:                schema.Omit,
 	"development":                   schema.Omit,
 	"ssl-hostname-verification":     schema.Omit,
 	"proxy-ssh":                     schema.Omit,
@@ -1961,7 +1961,7 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	DefaultSeries: {
+	DefaultSeriesKey: {
 		Description: "The default series of Ubuntu to use for deploying charms, will act like --series when deploying charms",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1962,7 +1962,7 @@ var configSchema = environschema.Fields{
 		Group:       environschema.EnvironGroup,
 	},
 	DefaultSeries: {
-		Description: "The default series of Ubuntu to use for deploying charms",
+		Description: "The default series of Ubuntu to use for deploying charms, will act like --series when deploying charms",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -683,11 +683,12 @@ func (test configTest) check(c *gc.C, home *jujutesting.FakeHome) {
 
 	seriesAttr, _ := test.attrs["default-series"].(string)
 	defaultSeries, ok := cfg.DefaultSeries()
-	c.Assert(ok, jc.IsTrue)
 	if seriesAttr != "" {
+		c.Assert(ok, jc.IsTrue)
 		c.Assert(defaultSeries, gc.Equals, seriesAttr)
 	} else {
-		c.Assert(defaultSeries, gc.Equals, jujuversion.DefaultSupportedLTS())
+		c.Assert(ok, jc.IsFalse)
+		c.Assert(defaultSeries, gc.Equals, "")
 	}
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -643,11 +643,11 @@ func (s *ConfigSuite) TestConfig(c *gc.C) {
 	s.FakeHomeSuite.Home.AddFiles(c, files...)
 	for i, test := range configTests {
 		c.Logf("test %d. %s", i, test.about)
-		test.check(c, s.FakeHomeSuite.Home)
+		test.check(c)
 	}
 }
 
-func (test configTest) check(c *gc.C, home *jujutesting.FakeHome) {
+func (test configTest) check(c *gc.C) {
 	cfg, err := config.New(test.useDefaults, test.attrs)
 	if test.err != "" {
 		c.Check(cfg, gc.IsNil)

--- a/juju/testing/repo.go
+++ b/juju/testing/repo.go
@@ -15,7 +15,6 @@ import (
 	unitassignerapi "github.com/juju/juju/api/agent/unitassigner"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
-	"github.com/juju/juju/version"
 )
 
 type RepoSuite struct {
@@ -24,10 +23,6 @@ type RepoSuite struct {
 
 func (s *RepoSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)
-	// Change the environ's config to ensure we're using the one in state.
-	updateAttrs := map[string]interface{}{"default-series": version.DefaultSupportedLTS()}
-	err := s.Model.UpdateModelConfig(updateAttrs, nil)
-	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *RepoSuite) AssertApplication(c *gc.C, name string, expectCurl *charm.URL, unitCount, relCount int) (*state.Application, []*state.Relation) {

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -70,7 +70,6 @@ import (
 	"github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	coretools "github.com/juju/juju/tools"
-	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/gate"
 	"github.com/juju/juju/worker/lease"
 	"github.com/juju/juju/worker/modelcache"
@@ -111,7 +110,6 @@ func SampleConfig() testing.Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            jujuversion.DefaultSupportedLTS(),
 		"default-space":             "",
 		"secret":                    "pork",
 		"controller":                true,

--- a/state/initialize_test.go
+++ b/state/initialize_test.go
@@ -287,7 +287,7 @@ func (s *InitializeSuite) TestInitializeWithControllerInheritedConfig(c *gc.C) {
 	uuid := cfg.UUID()
 	initial := cfg.AllAttrs()
 	controllerInheritedConfigIn := map[string]interface{}{
-		"default-series": initial["default-series"],
+		"charmhub-url": initial["charmhub-url"],
 	}
 	owner := names.NewLocalUserTag("initialize-admin")
 	controllerCfg := testing.FakeControllerConfig()

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2821,10 +2821,48 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 		CloudRegion:        testModel.CloudRegion(),
 	})
 	imported, newSt, err := s.Controller.Import(noTypeModel)
+	defer func() { _ = newSt.Close() }()
 	c.Assert(err, jc.ErrorIsNil)
-	defer newSt.Close()
 
 	c.Assert(imported.Type(), gc.Equals, state.ModelTypeIAAS)
+}
+
+func (s *MigrationImportSuite) TestImportingModelWithDefaultSeriesBefore2935(c *gc.C) {
+	defaultSeries, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.7.8"))
+	c.Assert(ok, jc.IsFalse, gc.Commentf("value: %q", defaultSeries))
+}
+
+func (s *MigrationImportSuite) TestImportingModelWithDefaultSeriesAfter2935(c *gc.C) {
+	defaultSeries, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.9.35"))
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(defaultSeries, gc.Equals, "bionic")
+}
+
+func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, toolsVer version.Number) (string, bool) {
+	testModel, err := s.State.Export()
+	c.Assert(err, jc.ErrorIsNil)
+
+	newConfig := testModel.Config()
+	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"
+	newConfig["name"] = "something-new"
+	newConfig["default-series"] = "bionic"
+	newConfig["agent-version"] = toolsVer.String()
+	importModel := description.NewModel(description.ModelArgs{
+		Type:           string(state.ModelTypeIAAS),
+		Owner:          testModel.Owner(),
+		Config:         newConfig,
+		EnvironVersion: testModel.EnvironVersion(),
+		Blocks:         testModel.Blocks(),
+		Cloud:          testModel.Cloud(),
+		CloudRegion:    testModel.CloudRegion(),
+	})
+	imported, newSt, err := s.Controller.Import(importModel)
+	defer func() { _ = newSt.Close() }()
+	c.Assert(err, jc.ErrorIsNil)
+
+	importedCfg, err := imported.Config()
+	c.Assert(err, jc.ErrorIsNil)
+	return importedCfg.DefaultSeries()
 }
 
 func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C) {

--- a/state/modelsummaries_test.go
+++ b/state/modelsummaries_test.go
@@ -262,9 +262,6 @@ func (s *ModelSummariesSuite) TestContainsConfigInformation(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 	c.Check(summaryA.AgentVersion, gc.NotNil)
 	c.Check(*summaryA.AgentVersion, gc.Equals, version)
-	series, ok := conf.DefaultSeries()
-	c.Assert(ok, jc.IsTrue)
-	c.Check(summaryA.DefaultSeries, gc.Equals, series)
 }
 
 func (s *ModelSummariesSuite) TestContainsProviderType(c *gc.C) {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -1635,7 +1635,7 @@ func CreateMissingApplicationConfig(pool *StatePool) error {
 		ID string `bson:"_id"`
 	}
 	err = settingsColl.Find(bson.M{
-		"_id": bson.M{"$regex": bson.RegEx{"application$", ""}}}).All(&applicationConfigIDs)
+		"_id": bson.M{"$regex": bson.RegEx{"#application$", ""}}}).All(&applicationConfigIDs)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -4598,11 +4598,11 @@ func RemoveDefaultSeriesFromModelConfig(pool *StatePool) error {
 	defer func() { _ = iter.Close() }()
 	var doc settingsDoc
 	for iter.Next(&doc) {
-		_, ok := doc.Settings[config.DefaultSeries]
+		_, ok := doc.Settings[config.DefaultSeriesKey]
 		if !ok {
 			continue
 		}
-		doc.Settings[config.DefaultSeries] = ""
+		doc.Settings[config.DefaultSeriesKey] = ""
 		ops = append(ops, txn.Op{
 			C:      settingsC,
 			Id:     doc.DocID,

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -7004,6 +7004,61 @@ func (s *upgradesSuite) TestCharmOriginChannelMustHaveTrack(c *gc.C) {
 	)
 }
 
+func (s *upgradesSuite) TestRemoveDefaultSeriesFromModelConfig(c *gc.C) {
+	settingsColl, settingsCloser := s.state.db().GetRawCollection(settingsC)
+	defer settingsCloser()
+	_, err := settingsColl.RemoveAll(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = settingsColl.Insert(bson.M{
+		"_id": "modelXXX:e",
+		// this document should be changed
+		"settings": bson.M{
+			"keepme":         "have value",
+			"default-series": "delete-me",
+		},
+	}, bson.M{
+		"_id": "modelXXX:a#testing",
+		// this document has no change
+		"settings": bson.M{
+			"default-series": "application has no default series",
+		},
+	}, bson.M{
+		"_id": "modelXYZ:e",
+		// this document has no change, is skipped
+		"settings": bson.M{
+			"keepme":   "have value",
+			"removeme": nil,
+		},
+	}, bson.M{
+		"_id": "modelXYZ:epool#lxd-btrfs",
+		// this document has no change
+		"settings": bson.M{
+			"keepme":   "have value",
+			"removeme": nil,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expectedSettings := []bson.M{
+		{
+			"_id":      "modelXXX:a#testing",
+			"settings": bson.M{"default-series": "application has no default series"},
+		}, {
+			"_id":      "modelXXX:e",
+			"settings": bson.M{"keepme": "have value", "default-series": ""},
+		}, {
+			"_id":      "modelXYZ:e",
+			"settings": bson.M{"keepme": "have value", "removeme": nil},
+		}, {
+			"_id":      "modelXYZ:epool#lxd-btrfs",
+			"settings": bson.M{"keepme": "have value", "removeme": nil},
+		}}
+
+	s.assertUpgradedData(c, RemoveDefaultSeriesFromModelConfig,
+		upgradedData(settingsColl, expectedSettings),
+	)
+}
+
 type docById []bson.M
 
 func (d docById) Len() int           { return len(d) }

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -77,7 +77,6 @@ func FakeConfig() Attrs {
 		"firewall-mode":             config.FwInstance,
 		"ssl-hostname-verification": true,
 		"development":               false,
-		"default-series":            jujuversion.DefaultSupportedLTS(),
 	}
 }
 

--- a/testing/factory/factory_test.go
+++ b/testing/factory/factory_test.go
@@ -516,7 +516,7 @@ func (s *factorySuite) TestMakeModelNil(c *gc.C) {
 
 	cfg, err := m.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "focal")
+	c.Assert(cfg.AllAttrs()["default-series"], gc.Equals, "")
 }
 
 func (s *factorySuite) TestMakeModel(c *gc.C) {

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -112,6 +112,7 @@ type StateBackend interface {
 	FixCharmhubLastPolltime() error
 	RemoveUseFloatingIPConfigFalse() error
 	CharmOriginChannelMustHaveTrack() error
+	RemoveDefaultSeriesFromModelConfig() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -513,4 +514,8 @@ func (s stateBackend) RemoveUseFloatingIPConfigFalse() error {
 
 func (s stateBackend) CharmOriginChannelMustHaveTrack() error {
 	return state.CharmOriginChannelMustHaveTrack(s.pool)
+}
+
+func (s stateBackend) RemoveDefaultSeriesFromModelConfig() error {
+	return state.RemoveDefaultSeriesFromModelConfig(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -63,6 +63,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.32"), stateStepsFor2932()},
 		upgradeToVersion{version.MustParse("2.9.33"), stateStepsFor2933()},
 		upgradeToVersion{version.MustParse("2.9.34"), stateStepsFor2934()},
+		upgradeToVersion{version.MustParse("2.9.35"), stateStepsFor2935()},
 	}
 	return steps
 }

--- a/upgrades/steps_2935.go
+++ b/upgrades/steps_2935.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2935 returns database upgrade steps for Juju 2.9.35
+func stateStepsFor2935() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "remove default-series value from model-config",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().RemoveDefaultSeriesFromModelConfig()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2935_test.go
+++ b/upgrades/steps_2935_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2935 = version.MustParse("2.9.35")
+
+type steps2935Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2935Suite{})
+
+func (s *steps2935Suite) TestRemoveDefaultSeriesFromModelConfig(c *gc.C) {
+	step := findStateStep(c, v2935, "remove default-series value from model-config")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -652,6 +652,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.32",
 		"2.9.33",
 		"2.9.34",
+		"2.9.35",
 	})
 }
 


### PR DESCRIPTION
Model config's default series will now act the same as using the series flag to deploy a charm. 

Historically default series in model config has been set by juju and maybe changed by users. Unfortunately there is no way to determine on pre 2.9.35 controllers who set the value. To ensure that we have a user defined value, the default series value will be cleared upon upgrade to juju 2.9.35 or migration to the same.

A follow on PR will cover this behavior for bundles.

## QA steps
Try repro steps from bug as well.

```sh
$ juju bootstrap localhost testing
# no output from the model-config command next:
$ juju model-config default-series

# deploy a charm with no default-series nor series
$ juju deploy ubuntu --dry-run 
"ubuntu" from charm-hub charm "ubuntu", revision 21 in channel stable on focal would be deployed

# Set default-series and verify used to deploy both charmhub and charmstore charms.
$ juju model-config default-series=bionic
$ juju deploy ubuntu 
Located charm "ubuntu" in charm-hub, revision 21
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 21 in channel stable on bionic
$ juju deploy cs:ubuntu csubuntu
Located charm "ubuntu" in charm-store, revision 21
Deploying "csubuntu" from charm-store charm "ubuntu", revision 21 in channel stable on bionic

# Verify that the series flag takes priority
$ juju deploy ubuntu --series jammy ubuntu-jammy
Located charm "ubuntu" in charm-hub, revision 21
Deploying "ubuntu-jammy" from charm-hub charm "ubuntu", revision 21 in channel stable on jammy

# bootstrap a 2.8 controller to test migration and upgrade.
$ juju bootstrap localhost two-eight
$ juju add-model moveme
$ juju model-config default-series
bionic
$ juju model-config default-series=focal
$ juju migrate moveme testing
# wait
$ juju switch testing:moveme
$ juju model-config default-series 
bionic

$ juju switch two-eight:default
$ juju upgrade-controller --build-agent
$ juju upgrade-juju
$ juju model-config default-series
$ 
```

## Documentation changes

We are clearing the default-series and it will now be treated the same as the series flag for deploy

## Bug reference

https://bugs.launchpad.net/juju/+bug/1966664
