### PR TITLE
Change included paths for GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,16 @@
 name: "Build"
 on:
   push:
-    paths-ignore:
-      - 'acceptancetests/**'
-      - 'doc/**'
-      - 'snap/**'
-      - 'testcharms/**'
-      - 'testing/**'
-      - 'tests/**'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '.github/workflows/build.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - 'acceptancetests/**'
-      - 'doc/**'
-      - 'snap/**'
-      - 'testcharms/**'
-      - 'testing/**'
-      - 'tests/**'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '.github/workflows/build.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,22 +1,16 @@
 name: "Client Tests"
 on:
   push:
-    paths-ignore:
-      - 'acceptancetests/**'
-      - 'doc/**'
-      - 'snap/**'
-      - 'testcharms/**'
-      - 'testing/**'
-      - 'tests/**'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '.github/workflows/client-tests.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - 'acceptancetests/**'
-      - 'doc/**'
-      - 'snap/**'
-      - 'testcharms/**'
-      - 'testing/**'
-      - 'tests/**'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '.github/workflows/client-tests.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,22 +1,16 @@
 name: "Generate"
 on:
   push:
-    paths-ignore:
-      - 'acceptancetests/**'
-      - 'doc/**'
-      - 'snap/**'
-      - 'testcharms/**'
-      - 'testing/**'
-      - 'tests/**'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '.github/workflows/gen.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - 'acceptancetests/**'
-      - 'doc/**'
-      - 'snap/**'
-      - 'testcharms/**'
-      - 'testing/**'
-      - 'tests/**'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '.github/workflows/gen.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,8 +1,26 @@
 name: "Smoke"
 on:
   push:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'snap/**'
+      - 'testcharms/**'
+      - 'tests/main.sh'
+      - 'tests/includes/**'
+      - 'tests/suites/smoke/**'
+      - '.github/workflows/smoke.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'snap/**'
+      - 'testcharms/**'
+      - 'tests/main.sh'
+      - 'tests/includes/**'
+      - 'tests/suites/smoke/**'
+      - '.github/workflows/smoke.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,8 +1,18 @@
 name: "Snapcraft"
 on:
   push:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'snap/**'
+      - '.github/workflows/snap.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'snap/**'
+      - '.github/workflows/snap.yml'
   workflow_dispatch:
 permissions:
   contents: read

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,8 +1,20 @@
 name: "Static Analysis"
 on:
   push:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '**.sh'
+      - '**.py'
+      - '.github/workflows/static-analysis.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - '**.sh'
+      - '**.py'
+      - '.github/workflows/static-analysis.yml'
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
Most of the tests should only run when a Go file or go.mod changes. I've updated the paths that trigger each test, so we don't get full test runs on PRs like #14637.