### PR TITLE
[JUJU-1639, JUJU-1787] Rewrite api/client/metricsdebug unit tests to use gomock

### DIFF
--- a/api/client/metricsdebug/package_test.go
+++ b/api/client/metricsdebug/package_test.go
@@ -1,14 +1,21 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package metricsdebug_test
+package metricsdebug
 
 import (
 	stdtesting "testing"
 
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/testing"
 )
 
 func TestAll(t *stdtesting.T) {
 	testing.MgoTestPackage(t)
+}
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
 }


### PR DESCRIPTION
The unit tests for api/client/metricsdebug now use go mock and not juju/testing. All unit tests should pass.