### PR TITLE
[JUJU-1591]Rewrite api/client/modelconfig unit tests to use gomock

### DIFF
--- a/api/client/modelconfig/package_test.go
+++ b/api/client/modelconfig/package_test.go
@@ -1,14 +1,22 @@
 // Copyright 2016 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package modelconfig_test
+package modelconfig
 
 import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
 )
 
 func Test(t *testing.T) {
 	gc.TestingT(t)
+}
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
 }


### PR DESCRIPTION
The unit tests for api/client/modelconfig now use go mock. 

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*All unit tests should pass.*

