### PR TITLE
[JUJU-1876] do not present %%s or %s to lxd via cloudinit

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -270,7 +270,7 @@ var ctests = []struct {
 		},
 		"bootcmd": []string{
 			"install -D -m 644 /dev/null '/some/path'",
-			"printf '%s\\n' 'Explanation: test\n" +
+			"echo 'Explanation: test\n" +
 				"Package: *\n" +
 				"Pin: release n=series\n" +
 				"Pin-Priority: 123\n" +
@@ -382,7 +382,7 @@ var ctests = []struct {
 	map[string]any{
 		"runcmd": []string{
 			"install -D -m 644 /dev/null '/etc/apt/apt.conf.d/99proxy'",
-			"printf '%s\\n' '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
+			"echo '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
 		},
 	},
 	func(cfg cloudinit.CloudConfig) error {
@@ -398,7 +398,7 @@ var ctests = []struct {
 	map[string]any{
 		"runcmd": []string{
 			"install -D -m 644 /dev/null '/dev/nonsense'",
-			"printf %s AAECAw== | base64 -d > '/dev/nonsense'",
+			"echo -n AAECAw== | base64 -d > '/dev/nonsense'",
 		},
 	},
 	func(cfg cloudinit.CloudConfig) error {
@@ -414,7 +414,7 @@ var ctests = []struct {
 	map[string]any{
 		"bootcmd": []string{
 			"install -D -m 644 /dev/null '/etc/apt/apt.conf.d/99proxy'",
-			"printf '%s\\n' '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
+			"echo '\"Acquire::http::Proxy \"http://10.0.3.1:3142\";' > '/etc/apt/apt.conf.d/99proxy'",
 		},
 	},
 	func(cfg cloudinit.CloudConfig) error {

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/snap"
-	jujupackaging "github.com/juju/juju/packaging"
 	"github.com/juju/packaging/v2"
 	"github.com/juju/packaging/v2/config"
 	"github.com/juju/proxy"
 	"github.com/juju/utils/v3"
 	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/core/snap"
+	jujupackaging "github.com/juju/juju/packaging"
 )
 
 // ubuntuCloudConfig is the cloudconfig type specific to Ubuntu machines
@@ -280,7 +281,7 @@ var waitSnapSeeded = `
 n=1
 while true; do
 
-printf "Attempt $n to wait for snapd to be seeded...\n"
+echo "Attempt $n to wait for snapd to be seeded...\n"
 snap wait core seed.loaded && break
 if [ $n -eq 5 ]; then
   echo "snapd not initialised"

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -167,7 +167,7 @@ func (cfg *ubuntuCloudConfig) getCommandsForAddingPackages() ([]string, error) {
 		if !strings.HasPrefix(src.URL, "ppa:") {
 			if src.Key != "" {
 				key := utils.ShQuote(src.Key)
-				cmd := fmt.Sprintf("printf '%%s\\n' %s | apt-key add -", key)
+				cmd := fmt.Sprintf("echo %s | apt-key add -", key)
 				cmds = append(cmds, cmd)
 			}
 		}
@@ -300,7 +300,7 @@ func (cfg *ubuntuCloudConfig) updateProxySettings(proxyCfg PackageManagerProxyCo
 		pkgCmder := cfg.paccmder[jujupackaging.AptPackageManager]
 		filename := config.AptProxyConfigFile
 		cfg.AddBootCmd(fmt.Sprintf(
-			`printf '%%s\n' %s > %s`,
+			`echo %s > %s`,
 			utils.ShQuote(pkgCmder.ProxyConfigContents(aptProxy)),
 			filename))
 	}

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -418,10 +418,10 @@ def replace_ethernets(interfaces_file, output_file, devices, fail_on_missing):
             device_replacements[hwaddr] = devices[hwaddr_clean]
         else:
             if fail_on_missing:
-                print( "Can't find device with MAC " + hwaddr_clean + ", will retry")
+                print( "Can not find device with MAC " + hwaddr_clean + ", will retry")
                 return False
             else:
-                print( "WARNING: Can't find device with MAC " + hwaddr_clean + " when expected")
+                print( "WARNING: Can not find device with MAC " + hwaddr_clean + " when expected")
                 device_replacements[hwaddr] = hwaddr
     formatted = interfaces.format(**device_replacements)
     print( "Used the values in: " + str(device_replacements) + "\nto fix the interfaces file:\n" + str(interfaces) + "\ninto\n" + str(formatted))

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -386,7 +386,7 @@ def ip_parse(ip_output):
     """parses the output of the ip command
     and returns a hwaddr->nic-name dict"""
     devices = dict()
-    print("Parsing ip command output %s" % ip_output)
+    print( "Parsing ip command output" + str(ip_output))
     for ip_line in ip_output:
         ip_line_str = strdecode(ip_line, "utf-8")
         match = IP_LINE.match(ip_line_str)
@@ -398,7 +398,7 @@ def ip_parse(ip_output):
             continue
         nic_hwaddr = match.group(1)
         devices[nic_hwaddr] = nic_name
-    print("Found the following devices: %s" % str(devices))
+    print( "Found the following devices: " + str(devices))
     return devices
 
 def replace_ethernets(interfaces_file, output_file, devices, fail_on_missing):
@@ -410,7 +410,7 @@ def replace_ethernets(interfaces_file, output_file, devices, fail_on_missing):
 
     formatter = Formatter()
     hwaddrs = [v[1] for v in formatter.parse(interfaces) if v[1]]
-    print("Found the following hwaddrs: %s" % str(hwaddrs))
+    print( "Found the following hwaddrs:" + str(hwaddrs))
     device_replacements = dict()
     for hwaddr in hwaddrs:
         hwaddr_clean = hwaddr[3:].replace("_", ":")
@@ -418,14 +418,13 @@ def replace_ethernets(interfaces_file, output_file, devices, fail_on_missing):
             device_replacements[hwaddr] = devices[hwaddr_clean]
         else:
             if fail_on_missing:
-                print("Can't find device with MAC %s, will retry" % hwaddr_clean)
+                print( "Can't find device with MAC " + hwaddr_clean + ", will retry")
                 return False
             else:
-                print("WARNING: Can't find device with MAC %s when expected" % hwaddr_clean)
+                print( "WARNING: Can't find device with MAC " + hwaddr_clean + " when expected")
                 device_replacements[hwaddr] = hwaddr
     formatted = interfaces.format(**device_replacements)
-    print("Used the values in: %s\nto fix the interfaces file:\n%s\ninto\n%s" %
-           (str(device_replacements), str(interfaces), str(formatted)))
+    print( "Used the values in: " + str(device_replacements) + "\nto fix the interfaces file:\n" + str(interfaces) + "\ninto\n" + str(formatted))
 
     with open(output_file, "w") as intf_out_file:
         intf_out_file.write(formatted)

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -128,7 +128,7 @@ bootcmd:
 `
 	s.expectedSampleConfigWriting = `- install -D -m 644 /dev/null '%[1]s.templ'
 - |-
-  printf '%%s\n' '
+  echo '
   auto lo {ethaa_bb_cc_dd_ee_f0} {ethaa_bb_cc_dd_ee_f1} {ethaa_bb_cc_dd_ee_f3} {ethaa_bb_cc_dd_ee_f5}
 
   iface lo inet loopback
@@ -191,7 +191,7 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
 
 	s.expectedSampleUserData = `- install -D -m 744 /dev/null '%[2]s'
 - |-
-  printf '%%s\n' '` + networkInterfacesScriptYamled + ` ' > '%[2]s'
+  echo '` + networkInterfacesScriptYamled + ` ' > '%[2]s'
 - |2
 
   if [ ! -f /sbin/ifup ]; then
@@ -222,7 +222,7 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
 	s.expectedFullNetplanYaml = `
 - install -D -m 644 /dev/null '%[1]s'
 - |-
-  printf '%%s\n' 'network:
+  echo 'network:
     version: 2
     ethernets:
       any0:

--- a/cloudconfig/cloudinit/utils.go
+++ b/cloudconfig/cloudinit/utils.go
@@ -51,9 +51,9 @@ func addFileCmds(filename string, data []byte, mode uint, binary bool) []string 
 	// dash. Instead, we use printf (or we could use /bin/echo).
 	if binary {
 		encoded := base64.StdEncoding.EncodeToString(data)
-		cmds = append(cmds, fmt.Sprintf(`printf %%s %s | base64 -d > %s`, encoded, p))
+		cmds = append(cmds, fmt.Sprintf(`echo -n %s | base64 -d > %s`, encoded, p))
 	} else {
-		cmds = append(cmds, fmt.Sprintf(`printf '%%s\n' %s > %s`, utils.ShQuote(string(data)), p))
+		cmds = append(cmds, fmt.Sprintf(`echo %s > %s`, utils.ShQuote(string(data)), p))
 	}
 
 	return cmds

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -226,9 +226,9 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 				"script1", "script2",
 				"set -xe",
 				"install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown.conf'",
-				"printf '%s\\n' '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
+				"echo '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
 				"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
-				"printf '%s\\n' '5432' > '/var/lib/juju/nonce.txt'",
+				"echo '5432' > '/var/lib/juju/nonce.txt'",
 			},
 		}
 		// OSType with old cloudinit versions don't support adding

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -733,7 +733,7 @@ mkdir -p $gui
 install -D -m 644 /dev/null '/var/lib/juju/gui/gui.tar.bz2'
 echo -n %s | base64 -d > '/var/lib/juju/gui/gui.tar.bz2'
 [ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
-[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && echo '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
+[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && echo -n '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
 rm -f $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
 `, base64Content, guiJson))
 	checkCloudInitWithGUI(c, cfg, expectedScripts, "")
@@ -747,7 +747,7 @@ func (*cloudinitSuite) TestCloudInitWithRemoteGUI(c *gc.C) {
 mkdir -p $gui
 curl -sSf -o $gui/gui.tar.bz2 --retry 10 'https://1.2.3.4/gui.tar.bz2' || echo Unable to retrieve Juju GUI
 [ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
-[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && echo '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
+[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && echo -n '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
 rm -f $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
 `, guiJson))
 	checkCloudInitWithGUI(c, cfg, expectedScripts, "")

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -328,12 +328,12 @@ var cloudinitTests = []cloudinitTest{
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
 install -D -m 644 /dev/null '/etc/apt/preferences\.d/50-cloud-tools'
-printf '%s\\n' '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
+echo '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
 set -xe
 install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
-printf '%s\\n' '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
+echo '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
+echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
 \[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
@@ -347,16 +347,16 @@ curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
-printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
+echo '.*' > '/var/lib/juju/bootstrap-params'
 echo 'Installing Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-ubuntu-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 install -D -m 755 /dev/null '/sbin/remove-juju-services'
-printf '%s\\n' '.*' > '/sbin/remove-juju-services'
+echo '.*' > '/sbin/remove-juju-services'
 ln -s 1\.2\.3-ubuntu-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(service jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:adm /var/log/juju/machine-0\.log\\n  chmod 0640 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
@@ -372,12 +372,12 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 		upgradedToVersion: "1.2.3.123",
 		expectScripts: `
 install -D -m 644 /dev/null '/etc/apt/preferences\.d/50-cloud-tools'
-printf '%s\\n' '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
+echo '.*' > '/etc/apt/preferences\.d/50-cloud-tools'
 set -xe
 install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
-printf '%s\\n' '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
+echo '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
+echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
 \[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
@@ -391,16 +391,16 @@ curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3\.123-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3\.123-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3\.123-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3\.123-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+echo -n '{"version":"1\.2\.3\.123-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3\.123-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-0'
 cat > '/var/lib/juju/agents/machine-0/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-0/agent\.conf'
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
-printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
+echo '.*' > '/var/lib/juju/bootstrap-params'
 echo 'Installing Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3\.123-ubuntu-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 install -D -m 755 /dev/null '/sbin/remove-juju-services'
-printf '%s\\n' '.*' > '/sbin/remove-juju-services'
+echo '.*' > '/sbin/remove-juju-services'
 ln -s 1\.2\.3\.123-ubuntu-amd64 '/var/lib/juju/tools/machine-0'
 echo 'Starting Juju machine agent \(service jujud-machine-0\)'.*
 cat > /etc/init/jujud-machine-0\.conf << 'EOF'\\ndescription "juju agent for machine-0"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-0\.log\\n  chown syslog:adm /var/log/juju/machine-0\.log\\n  chmod 0640 /var/log/juju/machine-0\.log\\n\\n  exec '/var/lib/juju/tools/machine-0/jujud' machine --data-dir '/var/lib/juju' --machine-id 0 --debug >> /var/log/juju/machine-0\.log 2>&1\\nend script\\nEOF\\n
@@ -420,9 +420,9 @@ bin='/var/lib/juju/tools/1\.2\.3-ubuntu-amd64'
 curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
-printf %s '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
-printf '%s\\n' '.*' > '/var/lib/juju/bootstrap-params'
+echo '.*' > '/var/lib/juju/bootstrap-params'
 /var/lib/juju/tools/1\.2\.3-ubuntu-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
 ln -s 1\.2\.3-ubuntu-amd64 '/var/lib/juju/tools/machine-0'
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
@@ -436,9 +436,9 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 		expectScripts: `
 set -xe
 install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown\.conf'
-printf '%s\\n' '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shutdown\.conf'
+echo '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
+echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
 \[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
@@ -452,12 +452,12 @@ curl -sSfw '.*' --connect-timeout 20 --noproxy "\*" --insecure -o \$bin/tools\.t
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
-printf %s '{"version":"1\.2\.3-ubuntu-amd64","url":"https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-ubuntu-amd64","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
+echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-ubuntu-amd64","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
 mkdir -p '/var/lib/juju/agents/machine-99'
 cat > '/var/lib/juju/agents/machine-99/agent\.conf' << 'EOF'\\n.*\\nEOF
 chmod 0600 '/var/lib/juju/agents/machine-99/agent\.conf'
 install -D -m 755 /dev/null '/sbin/remove-juju-services'
-printf '%s\\n' '.*' > '/sbin/remove-juju-services'
+echo '.*' > '/sbin/remove-juju-services'
 ln -s 1\.2\.3-ubuntu-amd64 '/var/lib/juju/tools/machine-99'
 echo 'Starting Juju machine agent \(service jujud-machine-99\)'.*
 cat > /etc/init/jujud-machine-99\.conf << 'EOF'\\ndescription "juju agent for machine-99"\\nauthor "Juju Team <juju@lists\.ubuntu\.com>"\\nstart on runlevel \[2345\]\\nstop on runlevel \[!2345\]\\nrespawn\\nnormal exit 0\\n\\nlimit .*\\n\\nscript\\n\\n\\n  # Ensure log files are properly protected\\n  touch /var/log/juju/machine-99\.log\\n  chown syslog:adm /var/log/juju/machine-99\.log\\n  chmod 0640 /var/log/juju/machine-99\.log\\n\\n  exec '/var/lib/juju/tools/machine-99/jujud' machine --data-dir '/var/lib/juju' --machine-id 99 --debug >> /var/log/juju/machine-99\.log 2>&1\\nend script\\nEOF\\n
@@ -474,7 +474,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 		expectScripts: `
 set -xe
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
-printf '%s\\n' 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
+echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 .*
 `,
 	},
@@ -540,7 +540,7 @@ curl .* --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.t
 		inexactMatch:      true,
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
-printf '%s\\n' '.*bootstrap-machine-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
+echo '.*bootstrap-machine-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
@@ -553,7 +553,7 @@ printf '%s\\n' '.*bootstrap-machine-constraints: {}.*' > '/var/lib/juju/bootstra
 		inexactMatch:      true,
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
-printf '%s\\n' '.*model-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
+echo '.*model-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
@@ -573,7 +573,7 @@ printf '%s\\n' '.*model-constraints: {}.*' > '/var/lib/juju/bootstrap-params'
 		inexactMatch:      true,
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
-printf '%s\\n' '.*custom-image-metadata:.*us-east1.*.*' > '/var/lib/juju/bootstrap-params'
+echo '.*custom-image-metadata:.*us-east1.*.*' > '/var/lib/juju/bootstrap-params'
 `,
 	},
 
@@ -587,7 +587,7 @@ printf '%s\\n' '.*custom-image-metadata:.*us-east1.*.*' > '/var/lib/juju/bootstr
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
 install -D -m 644 /dev/null '.*publicsimplestreamskey'
-printf '%s\\n' 'publickey' > '.*publicsimplestreamskey'
+echo 'publickey' > '.*publicsimplestreamskey'
 `,
 	},
 
@@ -602,7 +602,7 @@ sha256sum \$bin/tools.tar.gz > \$bin/juju2.8.0-ubuntu-amd64.sha256
 grep '1234' \$bin/juju2.8.0-ubuntu-amd64.sha256 .*
 tar zxf \$bin/tools.tar.gz -C \$bin
 ln -s \$bin /var/lib/juju/tools/2.8.0-bionic-amd64
-printf %s '{"version":"2.8.0-ubuntu-amd64".*
+echo -n '{"version":"2.8.0-ubuntu-amd64".*
 mkdir -p '/var/lib/juju/agents/machine-1'
 `,
 	},
@@ -642,7 +642,7 @@ func checkEnvConfig(c *gc.C, cfg *config.Config, scripts []string) {
 func getStateInitializationParams(c *gc.C, scripts []string) instancecfg.StateInitializationParams {
 	var args instancecfg.StateInitializationParams
 	c.Assert(scripts, gc.Not(gc.HasLen), 0)
-	re := regexp.MustCompile(`printf '%s\\n' '(?s:(.+))' > '/var/lib/juju/bootstrap-params'`)
+	re := regexp.MustCompile(`echo '(?s:(.+))' > '/var/lib/juju/bootstrap-params'`)
 	for _, s := range scripts {
 		m := re.FindStringSubmatch(s)
 		if m == nil {
@@ -1286,7 +1286,7 @@ func (s *cloudinitSuite) TestAptProxyWritten(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmds := cloudcfg.BootCmds()
-	expected := "printf '%s\\n' 'Acquire::http::Proxy \"http://user@10.0.0.1\";' > /etc/apt/apt.conf.d/95-juju-proxy-settings"
+	expected := "echo 'Acquire::http::Proxy \"http://user@10.0.0.1\";' > /etc/apt/apt.conf.d/95-juju-proxy-settings"
 	c.Assert(cmds, jc.DeepEquals, []string{expected})
 }
 
@@ -1313,12 +1313,12 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 		`export no_proxy=0.1.2.3,10.0.3.1,localhost`,
 		`export NO_PROXY=0.1.2.3,10.0.3.1,localhost`,
 		``,
-		`(printf '%s\n' 'export http_proxy=http://user@10.0.0.1
+		`(echo 'export http_proxy=http://user@10.0.0.1
 export HTTP_PROXY=http://user@10.0.0.1
 export no_proxy=0.1.2.3,10.0.3.1,localhost
 export NO_PROXY=0.1.2.3,10.0.3.1,localhost
 ' > /etc/juju-proxy.conf && chmod 0644 /etc/juju-proxy.conf)`,
-		`printf '%s\n' '# To allow juju to control the global systemd proxy settings,
+		`echo '# To allow juju to control the global systemd proxy settings,
 # create symbolic links to this file from within /etc/systemd/system.conf.d/
 # and /etc/systemd/users.conf.d/.
 [Manager]

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -335,7 +335,7 @@ echo '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
-\[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
+\[ -e /etc/profile.d/juju-proxy.sh \] \|\| echo .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
@@ -343,7 +343,7 @@ chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-ubuntu-amd64'
 mkdir -p \$bin
 echo 'Fetching Juju agent version.*
-curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz'
+.* curl .* --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz'.*
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
@@ -379,7 +379,7 @@ echo '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
-\[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
+\[ -e /etc/profile.d/juju-proxy.sh \] \|\| echo .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
@@ -387,7 +387,7 @@ chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3\.123-ubuntu-amd64'
 mkdir -p \$bin
 echo 'Fetching Juju agent version.*
-curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3\.123-ubuntu-amd64\.tgz'
+curl .* --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3\.123-ubuntu-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3\.123-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3\.123-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
@@ -417,7 +417,7 @@ rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3\.123-ubuntu-amd64\.sha256
 		upgradedToVersion: "1.2.3",
 		expectScripts: `
 bin='/var/lib/juju/tools/1\.2\.3-ubuntu-amd64'
-curl .* '.*' --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz'
+curl .* --retry 10 -o \$bin/tools\.tar\.gz 'http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz'
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 echo -n '{"version":"1\.2\.3-ubuntu-amd64","url":"http://foo\.com/tools/released/juju1\.2\.3-ubuntu-amd64\.tgz","sha256":"1234","size":10}' > \$bin/downloaded-tools\.txt
@@ -440,7 +440,7 @@ echo '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shu
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
-\[ -e /etc/profile.d/juju-proxy.sh \] \|\| printf .* >> /etc/profile.d/juju-proxy.sh
+\[ -e /etc/profile.d/juju-proxy.sh \] \|\| echo .* >> /etc/profile.d/juju-proxy.sh
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
@@ -448,7 +448,7 @@ chown syslog:adm /var/log/juju
 bin='/var/lib/juju/tools/1\.2\.3-ubuntu-amd64'
 mkdir -p \$bin
 echo 'Fetching Juju agent version.*
-curl -sSfw '.*' --connect-timeout 20 --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-ubuntu-amd64'
+.* curl -sSf --connect-timeout 20 --noproxy "\*" --insecure -o \$bin/tools\.tar\.gz 'https://state-addr\.testing\.invalid:54321/deadbeef-0bad-400d-8000-4b1d0d06f00d/tools/1\.2\.3-ubuntu-amd64'.*
 sha256sum \$bin/tools\.tar\.gz > \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 grep '1234' \$bin/juju1\.2\.3-ubuntu-amd64.sha256 \|\| \(echo "Tools checksum mismatch"; exit 1\)
 tar zxf \$bin/tools.tar.gz -C \$bin
@@ -731,9 +731,9 @@ func (*cloudinitSuite) TestCloudInitWithLocalGUI(c *gc.C) {
 	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`gui='/var/lib/juju/gui'
 mkdir -p $gui
 install -D -m 644 /dev/null '/var/lib/juju/gui/gui.tar.bz2'
-printf %%s %s | base64 -d > '/var/lib/juju/gui/gui.tar.bz2'
+echo -n %s | base64 -d > '/var/lib/juju/gui/gui.tar.bz2'
 [ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
-[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && printf %%s '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
+[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && echo '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
 rm -f $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
 `, base64Content, guiJson))
 	checkCloudInitWithGUI(c, cfg, expectedScripts, "")
@@ -747,7 +747,7 @@ func (*cloudinitSuite) TestCloudInitWithRemoteGUI(c *gc.C) {
 mkdir -p $gui
 curl -sSf -o $gui/gui.tar.bz2 --retry 10 'https://1.2.3.4/gui.tar.bz2' || echo Unable to retrieve Juju GUI
 [ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256
-[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && printf %%s '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
+[ -f $gui/jujugui.sha256 ] && (grep '1234' $gui/jujugui.sha256 && echo '%s' > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)
 rm -f $gui/gui.tar.bz2 $gui/jujugui.sha256 $gui/downloaded-gui.txt
 `, guiJson))
 	checkCloudInitWithGUI(c, cfg, expectedScripts, "")
@@ -1033,7 +1033,7 @@ func assertScriptMatch(c *gc.C, got []string, expect string, exact bool) {
 				pats = pats[1:]
 				scripts = scripts[1:]
 			} else if exact {
-				c.Assert(scripts[0].line, gc.Matches, pats[0].line, gc.Commentf("line %d; expected %q; got %q; paths: %#v", scripts[0].index, pats[0].line, scripts[0].line, pats))
+				c.Assert(scripts[0].line, gc.Matches, pats[0].line, gc.Commentf("line %d;\nexpected %q;\ngot %q;\npaths: %#v", scripts[0].index, pats[0].line, scripts[0].line, pats))
 			} else {
 				scripts = scripts[1:]
 			}
@@ -1306,7 +1306,7 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmds := cloudcfg.RunCmds()
-	first := `[ -e /etc/profile.d/juju-proxy.sh ] || printf '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`
+	first := `[ -e /etc/profile.d/juju-proxy.sh ] || echo '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`
 	expected := []string{
 		`export http_proxy=http://user@10.0.0.1`,
 		`export HTTP_PROXY=http://user@10.0.0.1`,
@@ -1328,11 +1328,12 @@ DefaultEnvironment="http_proxy=http://user@10.0.0.1" "HTTP_PROXY=http://user@10.
 	found := false
 	for i, cmd := range cmds {
 		if cmd == first {
-			c.Assert(cmds[i+1:i+8], jc.DeepEquals, expected)
+			c.Assert(cmds[i+1:i+8], jc.DeepEquals, expected, gc.Commentf("obtained (%s)", cmds[i+1:i+8]))
 			found = true
 			break
 		}
 	}
+	c.Logf("\n%s\n", cmds)
 	c.Assert(found, jc.IsTrue)
 }
 
@@ -1361,7 +1362,7 @@ func (s *cloudinitSuite) TestProxyArgsAddedToCurlCommand(c *gc.C) {
 	// check to see that the first boot curl command to download tools
 	// respects the configured proxy settings.
 	cmds := cldcfg.RunCmds()
-	expectedCurlCommand := "curl -sSfw 'agent binaries from %{url_effective} downloaded: HTTP %{http_code}; time %{time_total}s; size %{size_download} bytes; speed %{speed_download} bytes/s ' --retry 10 --proxy 0.1.2.3 -o $bin/tools.tar.gz"
+	expectedCurlCommand := "curl -sSf --retry 10 --proxy 0.1.2.3 -o $bin/tools.tar.gz"
 	assertCommandsContain(c, cmds, expectedCurlCommand)
 }
 
@@ -1476,13 +1477,13 @@ func (*cloudinitSuite) TestToolsDownloadCommand(c *gc.C) {
 n=1
 while true; do
 
-    printf "Attempt $n to download agent binaries from %s...\n" 'a'
+    echo "Attempt $n to download agent binaries from 'a'...\n"
     download 'a' && echo "Agent binaries downloaded successfully." && break
 
-    printf "Attempt $n to download agent binaries from %s...\n" 'b'
+    echo "Attempt $n to download agent binaries from 'b'...\n"
     download 'b' && echo "Agent binaries downloaded successfully." && break
 
-    printf "Attempt $n to download agent binaries from %s...\n" 'c'
+    echo "Attempt $n to download agent binaries from 'c'...\n"
     download 'c' && echo "Agent binaries downloaded successfully." && break
 
     echo "Download failed, retrying in 15s"

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -684,7 +684,7 @@ func (w *unixConfigure) setUpGUI() (func(), error) {
 	w.conf.AddScripts(
 		"[ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256",
 		fmt.Sprintf(
-			`[ -f $gui/jujugui.sha256 ] && (grep '%s' $gui/jujugui.sha256 && echo %s > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)`,
+			`[ -f $gui/jujugui.sha256 ] && (grep '%s' $gui/jujugui.sha256 && echo -n %s > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)`,
 			w.icfg.Bootstrap.GUI.SHA256, shquote(string(guiJson))),
 	)
 	return func() {

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -41,7 +41,7 @@ const (
 	FileNameBootstrapParams = "bootstrap-params"
 
 	// curlCommand is the base curl command used to download tools.
-	curlCommand = "curl -sSfw 'agent binaries from %{url_effective} downloaded: HTTP %{http_code}; time %{time_total}s; size %{size_download} bytes; speed %{speed_download} bytes/s '"
+	curlCommand = "curl -sSf"
 
 	// toolsDownloadWaitTime is the number of seconds to wait between
 	// each iterations of download attempts.
@@ -53,7 +53,7 @@ const (
 n=1
 while true; do
 {{range .URLs}}
-    printf "Attempt $n to download agent binaries from %s...\n" {{shquote .}}
+    echo "Attempt $n to download agent binaries from {{shquote .}}...\n"
     {{$curl}} {{shquote .}} && echo "Agent binaries downloaded successfully." && break
 {{end}}
     echo "Download failed, retrying in {{.ToolsDownloadWaitTime}}s"
@@ -327,7 +327,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 		// If the new juju proxies are used, the legacy proxies will not be set, and the
 		// /etc/juju-proxy.conf file will be empty.
 		`[ -e /etc/profile.d/juju-proxy.sh ] || ` +
-			`printf '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`)
+			`echo '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`)
 	if w.icfg.LegacyProxySettings.HasProxySet() {
 		exportedProxyEnv := w.icfg.LegacyProxySettings.AsScriptEnvironment()
 		w.conf.AddScripts(strings.Split(exportedProxyEnv, "\n")...)
@@ -684,7 +684,7 @@ func (w *unixConfigure) setUpGUI() (func(), error) {
 	w.conf.AddScripts(
 		"[ -f $gui/gui.tar.bz2 ] && sha256sum $gui/gui.tar.bz2 > $gui/jujugui.sha256",
 		fmt.Sprintf(
-			`[ -f $gui/jujugui.sha256 ] && (grep '%s' $gui/jujugui.sha256 && printf %%s %s > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)`,
+			`[ -f $gui/jujugui.sha256 ] && (grep '%s' $gui/jujugui.sha256 && echo %s > $gui/downloaded-gui.txt || echo Juju GUI checksum mismatch)`,
 			w.icfg.Bootstrap.GUI.SHA256, shquote(string(guiJson))),
 	)
 	return func() {

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -333,11 +333,11 @@ func (w *unixConfigure) ConfigureJuju() error {
 		w.conf.AddScripts(strings.Split(exportedProxyEnv, "\n")...)
 		w.conf.AddScripts(
 			fmt.Sprintf(
-				`(printf '%%s\n' %s > /etc/juju-proxy.conf && chmod 0644 /etc/juju-proxy.conf)`,
+				`(echo %s > /etc/juju-proxy.conf && chmod 0644 /etc/juju-proxy.conf)`,
 				shquote(w.icfg.LegacyProxySettings.AsScriptEnvironment())))
 
 		// Write out systemd proxy settings
-		w.conf.AddScripts(fmt.Sprintf(`printf '%%s\n' %[1]s > /etc/juju-proxy-systemd.conf`,
+		w.conf.AddScripts(fmt.Sprintf(`echo %[1]s > /etc/juju-proxy-systemd.conf`,
 			shquote(w.icfg.LegacyProxySettings.AsSystemdDefaultEnv())))
 	}
 
@@ -632,7 +632,7 @@ func (w *unixConfigure) addDownloadToolsCmds() error {
 		return err
 	}
 	w.conf.AddScripts(
-		fmt.Sprintf("printf %%s %s > $bin/downloaded-tools.txt", shquote(string(toolsJson))),
+		fmt.Sprintf("echo -n %s > $bin/downloaded-tools.txt", shquote(string(toolsJson))),
 	)
 
 	return nil

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -417,7 +417,7 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(userDataMap["runcmd"], jc.DeepEquals, []interface{}{
 		"set -xe",
 		"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
-		"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
+		"echo 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
 	})
 
 	// check that a new instance will be started with a machine agent
@@ -494,9 +494,9 @@ func (t *localServerSuite) TestUpstartBootstrapInstanceUserDataAndState(c *gc.C)
 	c.Assert(userDataMap["runcmd"], jc.DeepEquals, []interface{}{
 		"set -xe",
 		"install -D -m 644 /dev/null '/etc/init/juju-clean-shutdown.conf'",
-		"printf '%s\\n' '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
+		"echo '\nauthor \"Juju Team <juju@lists.ubuntu.com>\"\ndescription \"Stop all network interfaces on shutdown\"\nstart on runlevel [016]\ntask\nconsole output\n\nexec /sbin/ifdown -a -v --force\n' > '/etc/init/juju-clean-shutdown.conf'",
 		"install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'",
-		"printf '%s\\n' 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
+		"echo 'user-admin:bootstrap' > '/var/lib/juju/nonce.txt'",
 	})
 
 	// check that a new instance will be started with a machine agent


### PR DESCRIPTION
Avoid lxd/cloud-init interaction bug [user-data gets broken replacing %s with %!s(MISSING)](https://github.com/lxc/lxd/issues/10231), by changing how juju creates its cloud-init for deploying a machine. A back port of work done in develop with another commit to complete the change for other areas as well.

## QA steps

Steps in bug report. Other juju bootstrap and deploy.

```sh
$ juju bootstrap aws testing
$ juju model-config lxd-snap-channel=4.0/stable
$ juju add-machine --series focal
$ juju add-machine --series focal lxd:0

# verify that 0/lxd/0 succeeds in deployment.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1990594 
