### PR TITLE
[JUJU-1880] Fix snapcraft test on 2.9

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -29,9 +29,15 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
-        sudo apt-get remove lxd lxd-client
         sudo snap install snapcraft --classic
-        sudo snap install lxd
+        
+        sudo apt-get remove lxd lxd-client
+        if snap info lxd | grep "installed"; then
+          sudo snap refresh lxd --channel=latest/stable
+        else
+          sudo snap install lxd --channel=latest/stable
+        fi        
+        
         sudo lxd waitready
         sudo lxd init --auto
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,20 +1,10 @@
 name: "Static Analysis"
 on:
   push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - '**.sh'
-      - '**.py'
-      - '.github/workflows/static-analysis.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - '**.sh'
-      - '**.py'
-      - '.github/workflows/static-analysis.yml'
+#   paths:
+#     DON'T SET - these are "required" so they need to run on every PR
   workflow_dispatch:
 permissions:
   contents: read
@@ -27,6 +17,25 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
+    - name: Determine which tests to run
+      uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          go:
+            - '**.go'
+            - 'go.mod'
+          sh:
+            - '**.sh'
+          python:
+            - '**.py'
+          static-analysis:
+            - '.github/workflows/static-analysis.yml'
+            - 'Makefile'
+            - 'tests/main.sh'
+            - 'tests/includes/**'
+            - 'tests/suites/static_analysis/**'
 
     - name: Find required go version
       id: go-version
@@ -53,16 +62,19 @@ jobs:
       run: go mod download
 
     - name: "Static Analysis: Copyright"
+      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
       run: |
         STATIC_ANALYSIS_JOB=test_copyright make static-analysis
       shell: bash
 
     - name: "Static Analysis: Shell Check"
+      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.sh == 'true'
       run: |
         STATIC_ANALYSIS_JOB=test_static_analysis_shell make static-analysis
       shell: bash
 
     - name: "Static Analysis: Go Check"
+      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
       run: |
         # Explicitly set GOROOT to avoid golangci-lint/issues/3107
         export "GOROOT=$(go env GOROOT)"
@@ -70,6 +82,7 @@ jobs:
       shell: bash
 
     - name: "Static Analysis: Python Check"
+      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.python == 'true'
       run: |
         STATIC_ANALYSIS_JOB=test_static_analysis_python make static-analysis
       shell: bash
@@ -83,23 +96,43 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Check if there is anything to test
+      uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          schema:
+            - 'apiserver/facades/schema.json'
+            - 'generate/schemagen/**'
+            - '**.go'
+            - 'go.mod'
+            - '.github/workflows/static-analysis.yml'
+            - 'Makefile'
+            - 'tests/main.sh'
+            - 'tests/includes/**'
+            - 'tests/suites/static_analysis/schema.sh'
+
     - name: Find required go version
+      if: steps.filter.outputs.schema == 'true'
       id: go-version
       run: |
         set -euxo pipefail
         echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
 
     - name: Set up Go
+      if: steps.filter.outputs.schema == 'true'
       uses: actions/setup-go@v3
       with:
         go-version: ${{ steps.go-version.outputs.version }}
       id: go
 
     - name: Install Dependencies
+      if: steps.filter.outputs.schema == 'true'
       run: |
         sudo apt install expect
 
     - name: Schema Check
+      if: steps.filter.outputs.schema == 'true'
       run: |
         STATIC_ANALYSIS_JOB=test_schema make static-analysis
       shell: bash

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,12 +44,20 @@ echo "failed" | grep -q "passes"   # fails
 
 ## Getting started
 
-Before running tests, you'll need to install `jq`, `yq`, `shellcheck` and `golangci-lint`:
+Before running tests, you'll need to install `jq`, `yq`, `shellcheck` and `expect`:
 
 ```sh
 sudo snap install jq
 sudo snap install yq
 sudo snap install shellcheck
+sudo snap install expect
+```
+
+`curl` is also required, but this should be preinstalled on most systems.
+
+The static analysis tests also require `golangci-lint`:
+
+```
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
 ```
 


### PR DESCRIPTION
The "Snapcraft" GitHub action has been failing on 2.9 - this PR fixes it. We just need to use the latest version of LXD.

I also updated the Bash tests readme as it was out of sync with the code.

Finally, I had to partially revert #14660 since the "Static Analysis" GitHub Actions are "required" for all PRs. I've set the Action to always run, but the individual testing steps may be skipped depending on the changed files.

## QA steps

Wait for "Snapcraft" GitHub action to pass.