### PR TITLE
Fix cloud init schema.

### DIFF
--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -131,9 +131,9 @@ func (cfg *cloudConfig) AddUser(user *User) {
 		newUser["shell"] = user.Shell
 	}
 	if user.SSHAuthorizedKeys != "" {
-		newUser["ssh-authorized-keys"] = annotateKeys(user.SSHAuthorizedKeys)
+		newUser["ssh_authorized_keys"] = annotateKeys(user.SSHAuthorizedKeys)
 	}
-	if user.Sudo != nil {
+	if user.Sudo != "" {
 		newUser["sudo"] = user.Sudo
 	}
 	cfg.SetAttr("users", append(users, newUser))

--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -147,7 +147,7 @@ var ctests = []struct {
 			map[string]any{
 				"name":        "auser",
 				"lock_passwd": true,
-				"ssh-authorized-keys": []string{
+				"ssh_authorized_keys": []string{
 					fmt.Sprintf("%s Juju:user@host", sshtesting.ValidKeyOne.Key),
 					fmt.Sprintf("%s Juju:another@host", sshtesting.ValidKeyTwo.Key),
 				},
@@ -190,10 +190,10 @@ var ctests = []struct {
 				"lock_passwd": true,
 				"groups":      []string{"agroup", "bgroup"},
 				"shell":       "/bin/sh",
-				"ssh-authorized-keys": []string{
+				"ssh_authorized_keys": []string{
 					sshtesting.ValidKeyOne.Key + " Juju:sshkey",
 				},
-				"sudo": []string{"ALL=(ALL) ALL"},
+				"sudo": "ALL=(ALL) ALL",
 			},
 		},
 	},
@@ -203,7 +203,7 @@ var ctests = []struct {
 			Groups:            []string{"agroup", "bgroup"},
 			Shell:             "/bin/sh",
 			SSHAuthorizedKeys: sshtesting.ValidKeyOne.Key + "\n",
-			Sudo:              []string{"ALL=(ALL) ALL"},
+			Sudo:              "ALL=(ALL) ALL",
 		})
 		return nil
 	},

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -391,7 +391,7 @@ type User struct {
 	SSHAuthorizedKeys string
 
 	// Sudo directives to add.
-	Sudo []string
+	Sudo string
 }
 
 // UsersConfig is the interface for managing user additions

--- a/cloudconfig/providerinit/providerinit_test.go
+++ b/cloudconfig/providerinit/providerinit_test.go
@@ -247,8 +247,8 @@ func (*CloudInitSuite) testUserData(c *gc.C, series string, bootstrap bool) {
 						"floppy", "netdev", "plugdev",
 						"sudo", "video"},
 					"shell":               "/bin/bash",
-					"sudo":                []interface{}{"ALL=(ALL) NOPASSWD:ALL"},
-					"ssh-authorized-keys": []interface{}{"wheredidileavemykeys"},
+					"sudo":                "ALL=(ALL) NOPASSWD:ALL",
+					"ssh_authorized_keys": []interface{}{"wheredidileavemykeys"},
 				},
 			}
 		}

--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -171,7 +171,7 @@ func SetUbuntuUser(conf cloudinit.CloudConfig, authorizedKeys string) {
 			Name:              "ubuntu",
 			Groups:            groups,
 			Shell:             "/bin/bash",
-			Sudo:              []string{"ALL=(ALL) NOPASSWD:ALL"},
+			Sudo:              "ALL=(ALL) NOPASSWD:ALL",
 			SSHAuthorizedKeys: authorizedKeys,
 		})
 	}

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -1497,13 +1497,13 @@ func expectedUbuntuUser(groups, keys []string) map[string]interface{} {
 		"name":        "ubuntu",
 		"lock_passwd": true,
 		"shell":       "/bin/bash",
-		"sudo":        []interface{}{"ALL=(ALL) NOPASSWD:ALL"},
+		"sudo":        "ALL=(ALL) NOPASSWD:ALL",
 	}
 	if groups != nil {
 		user["groups"] = groups
 	}
 	if keys != nil {
-		user["ssh-authorized-keys"] = keys
+		user["ssh_authorized_keys"] = keys
 	}
 	return map[string]interface{}{
 		"users": []map[string]interface{}{user},


### PR DESCRIPTION
Fix the cloud-init user config to match the schema defined by https://cloudinit.readthedocs.io/en/latest/topics/modules.html#users-and-groups

Note `ssh_authorized_keys` uses underscores not hyphens.
Note `sudo` takes a string not a list of strings.

Depends on #14667 

## QA steps

*Commands to run to verify that the change works.*

```sh
QA steps here
```

## Documentation changes

N/A

## Bug reference

N/A