### PR TITLE
Add namespace get and list rule for juju related roles;

### DIFF
--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -198,6 +198,15 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 		appRole.Rules = []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+				ResourceNames: []string{s.namespace},
+			},
+			{
+				APIGroups: []string{""},
 				Resources: []string{"pods", "services"},
 				Verbs: []string{
 					"get",

--- a/caas/kubernetes/provider/application/trust.go
+++ b/caas/kubernetes/provider/application/trust.go
@@ -11,23 +11,34 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-var defaultApplicationNamespaceRules = []rbacv1.PolicyRule{
-	{
-		APIGroups: []string{""},
-		Resources: []string{"pods", "services"},
-		Verbs: []string{
-			"get",
-			"list",
-			"patch",
+func getDefaultApplicationNamespaceRules(namespace string) []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+			Verbs: []string{
+				"get",
+				"list",
+			},
+			ResourceNames: []string{namespace},
 		},
-	},
-	{
-		APIGroups: []string{""},
-		Resources: []string{"pods/exec"},
-		Verbs: []string{
-			"create",
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods", "services"},
+			Verbs: []string{
+				"get",
+				"list",
+				"patch",
+			},
 		},
-	},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods/exec"},
+			Verbs: []string{
+				"create",
+			},
+		},
+	}
 }
 
 var fullAccessApplicationNamespaceRules = []rbacv1.PolicyRule{
@@ -69,11 +80,10 @@ func (a *app) applyTrust(applier resources.Applier, trust bool) error {
 }
 
 func (a *app) roleRules(trust bool) []rbacv1.PolicyRule {
-	rules := defaultApplicationNamespaceRules
 	if trust {
-		rules = fullAccessApplicationNamespaceRules
+		return fullAccessApplicationNamespaceRules
 	}
-	return rules
+	return getDefaultApplicationNamespaceRules(a.namespace)
 }
 
 func (a *app) applyRoles(applier resources.Applier, trust bool) error {

--- a/caas/kubernetes/provider/application/trust_test.go
+++ b/caas/kubernetes/provider/application/trust_test.go
@@ -110,6 +110,15 @@ func (s *applicationSuite) TestRemoveTrust(c *gc.C) {
 	c.Assert(role.Rules, jc.DeepEquals, []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+			Verbs: []string{
+				"get",
+				"list",
+			},
+			ResourceNames: []string{s.namespace},
+		},
+		{
+			APIGroups: []string{""},
 			Resources: []string{"pods", "services"},
 			Verbs:     []string{"get", "list", "patch"},
 		}, {

--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -695,6 +695,25 @@ func ensureExecRBACResources(objMeta meta.ObjectMeta, clock jujuclock.Clock, bro
 		Rules: []rbac.PolicyRule{
 			{
 				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+				ResourceNames: []string{
+					objMeta.Namespace,
+				},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs: []string{
+					"get",
+					"list",
+				},
+			},
+			{
+				APIGroups: []string{""},
 				Resources: []string{"pods/exec"},
 				Verbs: []string{
 					"create",

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -229,9 +229,32 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Name, gc.Equals, ExecRBACResourceName)
 	c.Assert(r.Namespace, gc.Equals, namespace)
-	c.Assert(r.Rules[0].APIGroups, jc.DeepEquals, []string{""})
-	c.Assert(r.Rules[0].Resources, jc.DeepEquals, []string{"pods/exec"})
-	c.Assert(r.Rules[0].Verbs, jc.DeepEquals, []string{"create"})
+	c.Assert(r.Rules, jc.DeepEquals, []rbac.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+			Verbs: []string{
+				"get",
+				"list",
+			},
+			ResourceNames: []string{namespace},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs: []string{
+				"get",
+				"list",
+			},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods/exec"},
+			Verbs: []string{
+				"create",
+			},
+		},
+	})
 
 	// The exec rolebinding.
 	rb, err = m.client.RbacV1().RoleBindings(namespace).Get(context.TODO(), ExecRBACResourceName, meta.GetOptions{})


### PR DESCRIPTION
K8s roles created by Juju should always have self namespace `get` and `list` for detecting legacy namespace labels.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ microk8s enable storage dns rbac

$ juju bootstrap microk8s 29

$ juju add-model t

$ juju deploy snappass-test
```

## Documentation changes

No

## Bug reference

No

