### PR TITLE
[JUJU-1882] Fix smoke test on 2.9

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,9 +29,15 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
-        sudo apt-get remove lxd lxd-client
         sudo snap install snapcraft --classic
-        sudo snap install lxd
+        
+        sudo apt-get remove lxd lxd-client
+        if snap info lxd | grep "installed"; then
+          sudo snap refresh lxd --channel=latest/stable
+        else
+          sudo snap install lxd --channel=latest/stable
+        fi
+        
         sudo lxd waitready
         sudo lxd init --auto
         sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
@@ -75,7 +81,8 @@ jobs:
     - name: Smoke Test
       shell: bash
       run: |
-        cd tests && ./main.sh smoke
+        cd tests
+        ./main.sh -v smoke
 
   Upgrade:
     name: Upgrade

--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -132,6 +132,12 @@ func (o Origin) CoreCharmOrigin() corecharm.Origin {
 			Branch: branch,
 		}
 	}
+
+	platformChannel := o.Channel
+	if platformChannel == "" && o.Series != "" {
+		platformChannel, _ = series.SeriesVersion(o.Series)
+	}
+
 	return corecharm.Origin{
 		Source:   corecharm.Source(o.Source),
 		Type:     o.Type,
@@ -142,7 +148,7 @@ func (o Origin) CoreCharmOrigin() corecharm.Origin {
 		Platform: corecharm.Platform{
 			Architecture: o.Architecture,
 			OS:           o.OS,
-			Channel:      o.Channel,
+			Channel:      platformChannel,
 		},
 		InstanceKey: o.InstanceKey,
 	}

--- a/api/common/charm/charmorigin_test.go
+++ b/api/common/charm/charmorigin_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	commoncharm "github.com/juju/juju/api/common/charm"
+	corecharm "github.com/juju/juju/core/charm"
 )
 
 type originSuite struct{}
@@ -41,4 +42,33 @@ func (originSuite) TestCoreChannelWithEmptyTrack(c *gc.C) {
 func (originSuite) TestCoreChannelThatIsEmpty(c *gc.C) {
 	origin := commoncharm.Origin{}
 	c.Assert(origin.CharmChannel(), gc.DeepEquals, charm.Channel{})
+}
+
+func (originSuite) TestConvertToCoreCharmOrigin(c *gc.C) {
+	track := "latest"
+	origin := commoncharm.Origin{
+		Source:       "charm-hub",
+		ID:           "foobar",
+		Track:        &track,
+		Risk:         "stable",
+		Branch:       nil,
+		Channel:      "",
+		Series:       "focal",
+		Architecture: "amd64",
+		OS:           "ubuntu",
+	}
+
+	c.Assert(origin.CoreCharmOrigin(), gc.DeepEquals, corecharm.Origin{
+		Source: "charm-hub",
+		ID:     "foobar",
+		Channel: &charm.Channel{
+			Track: "latest",
+			Risk:  "stable",
+		},
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "20.04",
+		},
+	})
 }

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -10,7 +10,7 @@ run_local_deploy() {
 
 	ensure "test-local-deploy" "${file}"
 
-	juju deploy --revision=1 --channel=stable juju-qa-refresher
+	juju deploy --revision=1 --channel=stable --series=focal juju-qa-refresher
 	wait_for "refresher" "$(idle_condition "refresher")"
 
 	juju refresh refresher


### PR DESCRIPTION
The "Smoke / Smoke" GitHub action is failing on the 2.9 branch.
- [x] use latest version of LXD
- [x] fix the error when refreshing charm:
  ```
  ERROR origin.Platform requires a Channel, if OS set
  ```
  Possibly caused by [this change](https://github.com/juju/juju/pull/14628/files#diff-b12f327efa57a7fe4eccea8bee025ef7ede3afb837d50168eaf85c606aadf951R81)?

## QA steps

Wait for the "Smoke / Smoke" GitHub action to pass on this PR.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1991196