### PR TITLE
Run all checks on main branch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,15 @@
+# GitHub Actions CI
+
+This folder consists of a series of workflows which run on the GitHub repo
+(pull requests and the main branches).
+
+There are some workflows that we don't need to run on every PR. For example,
+if we are just changing documentation, we don't need to re-run the build tests.
+To determine when a workflow runs, we can set `on.pull_request.paths` or
+`on.pull_request.paths-ignore` in the yaml definition.
+
+Note that the static analysis checks are marked as "required", so we
+**need these to run on every PR** (even if there are no code changes).
+
+Furthermore, we want all the checks to run on the main branch, so please
+**don't** set `on.push.paths` or `on.push.paths-ignore` in the workflow yaml.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: "Build"
 on:
   push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - '.github/workflows/build.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,10 +1,6 @@
 name: "Client Tests"
 on:
   push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - '.github/workflows/client-tests.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -1,10 +1,6 @@
 name: "Generate"
 on:
   push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - '.github/workflows/gen.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,15 +1,6 @@
 name: "Smoke"
 on:
   push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'snap/**'
-      - 'testcharms/**'
-      - 'tests/main.sh'
-      - 'tests/includes/**'
-      - 'tests/suites/smoke/**'
-      - '.github/workflows/smoke.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,11 +1,6 @@
 name: "Snapcraft"
 on:
   push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'snap/**'
-      - '.github/workflows/snap.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:


### PR DESCRIPTION
Slight amendment to #14660. We want all checks to run on the main branch (2.9 or develop), so remove the `paths` filter in the `push` event.

As a drive-by, I added a readme explaining some of the filters in the workflow yaml files.