### PR TITLE
Fix Bash test path

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-[ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
+[ -n "${GOPATH:-}" ] && export "PATH=${PATH}:${GOPATH}/bin"
 
 # Always ignore SC2230 ('which' is non-standard. Use builtin 'command -v' instead.)
 export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005 -e SC2001 -e SC2263"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -237,6 +237,15 @@ if [[ ${USER:-'root'} == "root" ]]; then
 	exit 1
 fi
 
+JUJU_FOUND=0
+which juju &>/dev/null || JUJU_FOUND=$?
+if [[ $JUJU_FOUND == 0 ]]; then
+	echo "==> Using Juju located at $(which juju)"
+else
+	# shellcheck disable=SC2016
+	echo '==> WARNING: no Juju found on $PATH'
+fi
+
 cleanup() {
 	# Allow for failures and stop tracing everything
 	set +ex


### PR DESCRIPTION
The Bash tests were doing
```bash
export "PATH=${GOPATH}/bin:${PATH}"
```
The issue here is that if a Juju is located in `go/bin`, the tests will use this Juju instead of the one on the user's $PATH. This can cause confusing and unexpected behaviour. It is more sensible to put `go/bin` **after** the existing $PATH, so that the tests will use Juju on the user's path.

I also added a little check to output which Juju is being used by the tests.

## QA steps

Run the following with a Juju in path, and Juju not in path:
```sh
cd tests
./main.sh -v smoke
```