### PR TITLE
Build "supports:" field as set rather than slice to avoid dupes

### DIFF
--- a/cmd/juju/charmhub/convert.go
+++ b/cmd/juju/charmhub/convert.go
@@ -40,12 +40,14 @@ func convertCharmInfoResult(info transport.InfoResponse, arch, series string) (I
 		ir.Charm, isKubernetes = convertCharm(info)
 	}
 
+	seriesSet := set.NewStrings()
 	for _, base := range info.DefaultRelease.Revision.Bases {
 		s, _ := coreseries.VersionSeries(base.Channel)
 		if s != "" {
-			ir.Series = append(ir.Series, s)
+			seriesSet.Add(s)
 		}
 	}
+	ir.Series = seriesSet.SortedValues()
 
 	var err error
 	ir.Tracks, ir.Channels, err = filterChannels(info.ChannelMap, isKubernetes, arch, series)

--- a/cmd/juju/charmhub/convert.go
+++ b/cmd/juju/charmhub/convert.go
@@ -40,14 +40,16 @@ func convertCharmInfoResult(info transport.InfoResponse, arch, series string) (I
 		ir.Charm, isKubernetes = convertCharm(info)
 	}
 
-	seriesSet := set.NewStrings()
+	seen := set.NewStrings()
 	for _, base := range info.DefaultRelease.Revision.Bases {
 		s, _ := coreseries.VersionSeries(base.Channel)
 		if s != "" {
-			seriesSet.Add(s)
+			if !seen.Contains(s) {
+				ir.Series = append(ir.Series, s)
+				seen.Add(s)
+			}
 		}
 	}
-	ir.Series = seriesSet.SortedValues()
 
 	var err error
 	ir.Tracks, ir.Channels, err = filterChannels(info.ChannelMap, isKubernetes, arch, series)


### PR DESCRIPTION
This fixes the issue with the "supports:" field in `juju info` output sometimes showing duplicates.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
$ juju info juju-qa-refresher
...
supports: xenial, bionic, focal, jammy
...
```

Old output was:

```sh
$ juju info juju-qa-refresher
...
supports: xenial, xenial, xenial, xenial, bionic, bionic, bionic, bionic, focal, focal,
  focal, focal, jammy, jammy, jammy, jammy
...
```