### PR TITLE
[JUJU-1896] Changed the expect script return value check (test-user-test-user-login-password).

### DIFF
--- a/tests/includes/expect-that.sh
+++ b/tests/includes/expect-that.sh
@@ -22,14 +22,12 @@ proc abort { } { send_user \"\rTimeout Error!\" ; exit 2 }
 expect_before timeout abort
 
 set timeout ${timeout}
-spawn sh -c "${command} 2>&1"
+spawn ${command}
 match_max 100000
 
 ${expect_script}
-sleep 3
 
-send_user \"OK\"
 expect eof
 EOF
-	expect "${TEST_DIR}/${filename}.exp"
+	expect "${TEST_DIR}/${filename}.exp" | check "spawn ${command}"
 }

--- a/tests/includes/expect-that.sh
+++ b/tests/includes/expect-that.sh
@@ -1,5 +1,4 @@
 # expect_that the ability to work with interactive commands with expect tool.
-# The output is "OK", if tests passes successfully.
 # The expect_script argument is a expect script body.
 # The default timeout is 10 seconds.
 # NOTE: The expect tool must (!) be install via apt, because strictly-confined expect-snap

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -14,7 +14,7 @@ expect \"new password: \" {
 	expect \"type new password again: \" {
 		send \"test-password\r\"
 	}
-}" | check "OK"
+}"
 
 	echo "Logout from controller"
 	juju logout
@@ -26,7 +26,7 @@ expect \"Enter username: \" {
 	expect \"please enter password for admin*\" {
 		send \"test-password\r\"
 	}
-}" 15 | check "OK"
+}" 15
 
 	destroy_model "user-change-password"
 }


### PR DESCRIPTION
This PR changes the expect script return value check. Now check is integrated inside  expect_that func, so there is no need to explicitly 'check' in a pipe with expect_that.

PS: I hope that will help to avoid error issues on Jenkins's node.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p lxd user run_user_change_password
```
