### PR TITLE
Disable fail-fast for GitHub build test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       matrix:
         platform:
            - { os: linux, arch: amd64 }


### PR DESCRIPTION
Default behaviour for matrix-based GitHub actions is "fail-fast", which means when one of the jobs fails, the rest are all cancelled. This is very annoying because it means when a build fails for one platform (e.g. darwin), the build job is cancelled for every other platform (ubuntu, windows, ...), so we don't get to see the result of those builds.

This PR disables the fail-fast behaviour in the `build.yml` workflow.