### PR TITLE
[JUJU-1644, JUJU-1871] Rewrite api/client/action unit tests to use gomock

### DIFF
--- a/api/client/action/client_test.go
+++ b/api/client/action/client_test.go
@@ -4,13 +4,13 @@
 package action_test
 
 import (
-	"errors"
-
+	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	basetesting "github.com/juju/juju/api/base/testing"
+	basemocks "github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/action"
 	"github.com/juju/juju/rpc/params"
 )
@@ -21,6 +21,9 @@ type actionSuite struct {
 var _ = gc.Suite(&actionSuite{})
 
 func (s *actionSuite) TestApplicationCharmActions(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	tests := []struct {
 		description    string
 		patchResults   []params.ApplicationCharmActionsResult
@@ -88,30 +91,23 @@ func (s *actionSuite) TestApplicationCharmActions(c *gc.C) {
 
 	for i, t := range tests {
 		c.Logf("test %d: %s", i, t.description)
-		apiCaller := basetesting.BestVersionCaller{
-			APICallerFunc: basetesting.APICallerFunc(
-				func(objType string,
-					version int,
-					id, request string,
-					a, result interface{},
-				) error {
-					c.Assert(request, gc.Equals, "ApplicationsCharmsActions")
-					c.Assert(a, gc.FitsTypeOf, params.Entities{})
-					p := a.(params.Entities)
-					c.Check(p.Entities, gc.HasLen, 1)
-					c.Assert(result, gc.FitsTypeOf, &params.ApplicationsCharmActionsResults{})
-					*(result.(*params.ApplicationsCharmActionsResults)) = params.ApplicationsCharmActionsResults{
-						Results: t.patchResults,
-					}
-					if t.patchErr != "" {
-						return errors.New(t.patchErr)
-					}
-					return nil
-				},
-			),
-			BestVersion: 5,
+		args := params.Entities{
+			Entities: []params.Entity{{
+				Tag: names.NewApplicationTag("foo").String(),
+			}},
 		}
-		client := action.NewClient(apiCaller)
+		res := new(params.ApplicationsCharmActionsResults)
+		ress := params.ApplicationsCharmActionsResults{
+			Results: t.patchResults,
+		}
+		var facadeReturn error
+		if t.patchErr != "" {
+			facadeReturn = errors.New(t.patchErr)
+		}
+		mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+		mockFacadeCaller.EXPECT().FacadeCall("ApplicationsCharmsActions", args, res).SetArg(2, ress).Return(facadeReturn)
+		client := action.NewClientFromCaller(mockFacadeCaller)
+
 		result, err := client.ApplicationCharmActions("foo")
 		if t.expectedErr != "" {
 			c.Check(err, gc.ErrorMatches, t.expectedErr)
@@ -123,110 +119,89 @@ func (s *actionSuite) TestApplicationCharmActions(c *gc.C) {
 }
 
 func (s *actionSuite) TestWatchActionProgress(c *gc.C) {
-	var called bool
-	apiCaller := basetesting.BestVersionCaller{
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string,
-				version int,
-				id, request string,
-				a, result interface{},
-			) error {
-				called = true
-				c.Assert(request, gc.Equals, "WatchActionsProgress")
-				c.Assert(a, jc.DeepEquals, params.Entities{
-					Entities: []params.Entity{{
-						Tag: "action-666",
-					}},
-				})
-				c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
-				*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
-					Results: []params.StringsWatchResult{{
-						Error: &params.Error{Message: "FAIL"},
-					}},
-				}
-				return nil
-			},
-		),
-		BestVersion: 5,
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.Entities{
+		Entities: []params.Entity{{
+			Tag: "action-666",
+		}},
 	}
-	client := action.NewClient(apiCaller)
+	res := new(params.StringsWatchResults)
+	ress := params.StringsWatchResults{
+		Results: []params.StringsWatchResult{{
+			Error: &params.Error{Message: "FAIL"},
+		}},
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("WatchActionsProgress", args, res).SetArg(2, ress).Return(nil)
+	client := action.NewClientFromCaller(mockFacadeCaller)
+
 	w, err := client.WatchActionProgress("666")
 	c.Assert(w, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *actionSuite) TestWatchActionProgressArity(c *gc.C) {
-	apiCaller := basetesting.BestVersionCaller{
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string,
-				version int,
-				id, request string,
-				a, result interface{},
-			) error {
-				c.Assert(request, gc.Equals, "WatchActionsProgress")
-				c.Assert(a, jc.DeepEquals, params.Entities{
-					Entities: []params.Entity{{
-						Tag: "action-666",
-					}},
-				})
-				c.Assert(result, gc.FitsTypeOf, &params.StringsWatchResults{})
-				*(result.(*params.StringsWatchResults)) = params.StringsWatchResults{
-					Results: []params.StringsWatchResult{{
-						Error: &params.Error{Message: "FAIL"},
-					}, {
-						Error: &params.Error{Message: "ANOTHER"},
-					}},
-				}
-				return nil
-			},
-		),
-		BestVersion: 5,
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.Entities{
+		Entities: []params.Entity{{
+			Tag: "action-666",
+		}},
 	}
-	client := action.NewClient(apiCaller)
+	res := new(params.StringsWatchResults)
+	ress := params.StringsWatchResults{
+		Results: []params.StringsWatchResult{{
+			Error: &params.Error{Message: "FAIL"},
+		}, {
+			Error: &params.Error{Message: "ANOTHER"},
+		}},
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("WatchActionsProgress", args, res).SetArg(2, ress).Return(nil)
+	client := action.NewClientFromCaller(mockFacadeCaller)
+
 	_, err := client.WatchActionProgress("666")
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
 func (s *actionSuite) TestListOperations(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	offset := 100
 	limit := 200
-	apiCaller := basetesting.BestVersionCaller{
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string,
-				version int,
-				id, request string,
-				a, result interface{},
-			) error {
-				c.Assert(request, gc.Equals, "ListOperations")
-				c.Assert(a, jc.DeepEquals, params.OperationQueryArgs{
-					Applications: []string{"app"},
-					Units:        []string{"unit/0"},
-					Machines:     []string{"0"},
-					ActionNames:  []string{"backup"},
-					Status:       []string{"running"},
-					Offset:       &offset,
-					Limit:        &limit,
-				})
-				c.Assert(result, gc.FitsTypeOf, &params.OperationResults{})
-				*(result.(*params.OperationResults)) = params.OperationResults{
-					Results: []params.OperationResult{{
-						OperationTag: "operation-1",
-						Summary:      "hello",
-						Fail:         "fail",
-						Status:       "error",
-						Actions: []params.ActionResult{{
-							Action: &params.Action{Tag: "action-666", Name: "test", Receiver: "unit-mysql-0"},
-						}},
-					}},
-					Truncated: true,
-				}
-				return nil
-			},
-		),
-		BestVersion: 6,
+	args := params.OperationQueryArgs{
+		Applications: []string{"app"},
+		Units:        []string{"unit/0"},
+		Machines:     []string{"0"},
+		ActionNames:  []string{"backup"},
+		Status:       []string{"running"},
+		Offset:       &offset,
+		Limit:        &limit,
 	}
-	client := action.NewClient(apiCaller)
+	res := new(params.OperationResults)
+	ress := params.OperationResults{
+		Results: []params.OperationResult{{
+			OperationTag: "operation-1",
+			Summary:      "hello",
+			Fail:         "fail",
+			Status:       "error",
+			Actions: []params.ActionResult{{
+				Action: &params.Action{Tag: "action-666", Name: "test", Receiver: "unit-mysql-0"},
+			}},
+		}},
+		Truncated: true,
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ListOperations", args, res).SetArg(2, ress).Return(nil)
+	client := action.NewClientFromCaller(mockFacadeCaller)
+
 	result, err := client.ListOperations(action.OperationQueryArgs{
 		Applications: []string{"app"},
 		Units:        []string{"unit/0"},
@@ -252,32 +227,26 @@ func (s *actionSuite) TestListOperations(c *gc.C) {
 }
 
 func (s *actionSuite) TestOperation(c *gc.C) {
-	apiCaller := basetesting.BestVersionCaller{
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string,
-				version int,
-				id, request string,
-				a, result interface{},
-			) error {
-				c.Assert(request, gc.Equals, "Operations")
-				c.Assert(a, jc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "operation-666"}}})
-				c.Assert(result, gc.FitsTypeOf, &params.OperationResults{})
-				*(result.(*params.OperationResults)) = params.OperationResults{
-					Results: []params.OperationResult{{
-						OperationTag: "operation-1",
-						Summary:      "hello",
-						Fail:         "fail",
-						Actions: []params.ActionResult{{
-							Action: &params.Action{Tag: "action-666", Name: "test", Receiver: "unit-mysql-0"},
-						}},
-					}},
-				}
-				return nil
-			},
-		),
-		BestVersion: 6,
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.Entities{Entities: []params.Entity{{Tag: "operation-666"}}}
+	res := new(params.OperationResults)
+	ress := params.OperationResults{
+		Results: []params.OperationResult{{
+			OperationTag: "operation-1",
+			Summary:      "hello",
+			Fail:         "fail",
+			Actions: []params.ActionResult{{
+				Action: &params.Action{Tag: "action-666", Name: "test", Receiver: "unit-mysql-0"},
+			}},
+		}},
 	}
-	client := action.NewClient(apiCaller)
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Operations", args, res).SetArg(2, ress).Return(nil)
+	client := action.NewClientFromCaller(mockFacadeCaller)
+
 	result, err := client.Operation("666")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, action.Operation{
@@ -291,35 +260,9 @@ func (s *actionSuite) TestOperation(c *gc.C) {
 }
 
 func (s *actionSuite) TestEnqueueOperation(c *gc.C) {
-	apiCaller := basetesting.BestVersionCaller{
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string,
-				version int,
-				id, request string,
-				a, result interface{},
-			) error {
-				c.Assert(request, gc.Equals, "EnqueueOperation")
-				c.Assert(a, jc.DeepEquals, params.Actions{
-					Actions: []params.Action{{
-						Receiver: "unit/0",
-						Name:     "test",
-						Parameters: map[string]interface{}{
-							"foo": "bar",
-						},
-					}},
-				})
-				c.Assert(result, gc.FitsTypeOf, &params.EnqueuedActions{})
-				*(result.(*params.EnqueuedActions)) = params.EnqueuedActions{
-					OperationTag: "operation-1",
-					Actions: []params.ActionResult{{
-						Error: &params.Error{Message: "FAIL"},
-					}},
-				}
-				return nil
-			},
-		),
-		BestVersion: 6,
-	}
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	args := []action.Action{{
 		Receiver: "unit/0",
 		Name:     "test",
@@ -327,7 +270,27 @@ func (s *actionSuite) TestEnqueueOperation(c *gc.C) {
 			"foo": "bar",
 		}},
 	}
-	client := action.NewClient(apiCaller)
+	fArgs := params.Actions{
+		Actions: []params.Action{{
+			Receiver: "unit/0",
+			Name:     "test",
+			Parameters: map[string]interface{}{
+				"foo": "bar",
+			},
+		}},
+	}
+	res := new(params.EnqueuedActions)
+	ress := params.EnqueuedActions{
+		OperationTag: "operation-1",
+		Actions: []params.ActionResult{{
+			Error: &params.Error{Message: "FAIL"},
+		}},
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("EnqueueOperation", fArgs, res).SetArg(2, ress).Return(nil)
+	client := action.NewClientFromCaller(mockFacadeCaller)
+
 	result, err := client.EnqueueOperation(args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, action.EnqueuedActions{

--- a/api/client/action/package_test.go
+++ b/api/client/action/package_test.go
@@ -20,3 +20,9 @@ func NewPrunerFromCaller(caller base.FacadeCaller) *Facade {
 		facade: caller,
 	}
 }
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
+}

--- a/api/client/action/package_test.go
+++ b/api/client/action/package_test.go
@@ -1,14 +1,22 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package action_test
+package action
 
 import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api/base"
 )
 
 func TestAll(t *testing.T) {
 	gc.TestingT(t)
+}
+
+func NewPrunerFromCaller(caller base.FacadeCaller) *Facade {
+	return &Facade{
+		facade: caller,
+	}
 }


### PR DESCRIPTION
The unit tests for `api/client/action` now use go mock and not juju/testing. All unit tests should pass.