### PR TITLE
Fix sidecar provisioner when deploying from charmhub too quickly.

### DIFF
--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -72,18 +72,9 @@ func (c *Client) SetPassword(appName string, password string) error {
 		return errors.Errorf("invalid number of results %d expected 1", len(result.Results))
 	}
 	if result.Results[0].Error != nil {
-		return errors.Trace(maybeNotFound(result.Results[0].Error))
+		return errors.Trace(params.TranslateWellKnownError(result.Results[0].Error))
 	}
 	return nil
-}
-
-// maybeNotFound returns an error satisfying errors.IsNotFound
-// if the supplied error has a CodeNotFound error.
-func maybeNotFound(err *params.Error) error {
-	if err == nil || !params.IsCodeNotFound(err) {
-		return err
-	}
-	return errors.NewNotFound(err, "")
 }
 
 // Life returns the lifecycle state for the specified application
@@ -110,7 +101,7 @@ func (c *Client) Life(entityName string) (life.Value, error) {
 		return "", errors.Errorf("expected 1 result, got %d", n)
 	}
 	if err := results.Results[0].Error; err != nil {
-		return "", maybeNotFound(err)
+		return "", params.TranslateWellKnownError(err)
 	}
 	return results.Results[0].Life, nil
 }
@@ -148,7 +139,7 @@ func (c *Client) ProvisioningInfo(applicationName string) (ProvisioningInfo, err
 	}
 	r := result.Results[0]
 	if err := r.Error; err != nil {
-		return ProvisioningInfo{}, errors.Trace(maybeNotFound(err))
+		return ProvisioningInfo{}, errors.Trace(params.TranslateWellKnownError(err))
 	}
 
 	info := ProvisioningInfo{
@@ -247,7 +238,7 @@ func (c *Client) Units(appName string) ([]params.CAASUnit, error) {
 	}
 	res := result.Results[0]
 	if res.Error != nil {
-		return nil, errors.Annotatef(maybeNotFound(res.Error), "unable to fetch units for %s", appName)
+		return nil, errors.Annotatef(params.TranslateWellKnownError(res.Error), "unable to fetch units for %s", appName)
 	}
 	out := make([]params.CAASUnit, len(res.Units))
 	for i, v := range res.Units {
@@ -304,7 +295,7 @@ func (c *Client) ApplicationOCIResources(appName string) (map[string]resources.D
 	}
 	res := result.Results[0]
 	if res.Error != nil {
-		return nil, errors.Annotatef(maybeNotFound(res.Error), "unable to fetch OCI image resources for %s", appName)
+		return nil, errors.Annotatef(params.TranslateWellKnownError(res.Error), "unable to fetch OCI image resources for %s", appName)
 	}
 	if res.Result == nil {
 		return nil, errors.Errorf("missing result")
@@ -340,7 +331,7 @@ func (c *Client) UpdateUnits(arg params.UpdateApplicationUnits) (*params.UpdateA
 	if firstResult.Error == nil {
 		return firstResult.Info, nil
 	}
-	return firstResult.Info, maybeNotFound(firstResult.Error)
+	return firstResult.Info, params.TranslateWellKnownError(firstResult.Error)
 }
 
 // WatchApplication returns a NotifyWatcher that notifies of
@@ -363,7 +354,7 @@ func (c *Client) ClearApplicationResources(appName string) error {
 	if result.Results[0].Error == nil {
 		return nil
 	}
-	return maybeNotFound(result.Results[0].Error)
+	return params.TranslateWellKnownError(result.Results[0].Error)
 }
 
 // WatchUnits returns a StringsWatcher that notifies of

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -21,6 +21,7 @@ import (
 var logger = loggo.GetLogger("juju.apiserver.common.errors")
 
 const (
+	// TODO(juju3): move to params
 	ErrBadId              = errors.ConstError("id not found")
 	ErrBadCreds           = errors.ConstError("invalid entity name or password")
 	ErrNoCreds            = errors.ConstError("no credentials provided")
@@ -47,12 +48,12 @@ func OperationBlockedError(msg string) error {
 	}
 }
 
-var singletonErrorCodes = map[error]string{
+var singletonErrorCodes = map[errors.ConstError]string{
 	stateerrors.ErrCannotEnterScopeYet: params.CodeCannotEnterScopeYet,
 	stateerrors.ErrCannotEnterScope:    params.CodeCannotEnterScope,
 	stateerrors.ErrUnitHasSubordinates: params.CodeUnitHasSubordinates,
 	stateerrors.ErrDead:                params.CodeDead,
-	jujutxn.ErrExcessiveContention:     params.CodeExcessiveContention,
+	jujutxn.ErrExcessiveContention:     params.CodeExcessiveContention, // TODO(dqlite): remove jujutxn.ErrExcessiveContention from api errors
 	leadership.ErrClaimDenied:          params.CodeLeadershipClaimDenied,
 	lease.ErrClaimDenied:               params.CodeLeaseClaimDenied,
 	ErrBadId:                           params.CodeNotFound,
@@ -68,14 +69,13 @@ var singletonErrorCodes = map[error]string{
 }
 
 func singletonCode(err error) (string, bool) {
-	// All error types may not be hashable; deal with
-	// that by catching the panic if we try to look up
-	// a non-hashable type.
-	defer func() {
-		_ = recover()
-	}()
-	code, ok := singletonErrorCodes[err]
-	return code, ok
+	switch e := err.(type) {
+	case errors.ConstError:
+		code, ok := singletonErrorCodes[e]
+		return code, ok
+	default:
+		return "", false
+	}
 }
 
 func singletonError(err error) (bool, error) {
@@ -285,6 +285,8 @@ func DestroyErr(desc string, ids []string, errs []error) error {
 
 // RestoreError makes a best effort at converting the given error
 // back into an error originally converted by ServerError().
+// TODO(juju3): move to params.TranslateWellKnownError
+// Prefer to use the params.TranslateWellKnownError instead.
 func RestoreError(err error) error {
 	if err == nil {
 		return nil
@@ -305,20 +307,9 @@ func RestoreError(err error) error {
 		return singleton
 	}
 
-	// TODO(ericsnow) Support the other error types handled by ServerError().
 	switch {
-	case params.IsCodeUnauthorized(err):
-		return errors.NewUnauthorized(nil, msg)
-	case params.IsCodeNotFound(err):
-		return errors.NewNotFound(nil, msg)
 	case params.IsCodeModelNotFound(err):
 		return fmt.Errorf("%s%w", msg, errors.Hide(UnknownModelError))
-	case params.IsCodeUserNotFound(err):
-		return errors.NewUserNotFound(nil, msg)
-	case params.IsCodeAlreadyExists(err):
-		return errors.NewAlreadyExists(nil, msg)
-	case params.IsCodeNotAssigned(err):
-		return errors.NewNotAssigned(nil, msg)
 	case params.IsCodeHasAssignedUnits(err):
 		// TODO(ericsnow) Handle stateerrors.HasAssignedUnitsError here.
 		// ...by parsing msg?
@@ -333,8 +324,6 @@ func RestoreError(err error) error {
 		// TODO(ericsnow) Handle isNoAddressSetError here.
 		// ...by parsing msg?
 		return err
-	case params.IsCodeNotProvisioned(err):
-		return errors.NewNotProvisioned(nil, msg)
 	case params.IsCodeUpgradeInProgress(err):
 		// TODO(ericsnow) Handle stateerrors.UpgradeInProgressError here.
 		// ...by parsing msg?
@@ -345,19 +334,9 @@ func RestoreError(err error) error {
 		return err
 	case params.IsCodeStorageAttached(err):
 		return err
-	case params.IsCodeNotSupported(err):
-		return errors.NewNotSupported(nil, msg)
-	case params.IsBadRequest(err):
-		return errors.NewBadRequest(nil, msg)
-	case params.IsMethodNotAllowed(err):
-		return errors.NewMethodNotAllowed(nil, msg)
 	case params.ErrCode(err) == params.CodeDischargeRequired:
 		// TODO(ericsnow) Handle DischargeRequiredError here.
 		return err
-	case params.IsCodeQuotaLimitExceeded(err):
-		return errors.NewQuotaLimitExceeded(nil, msg)
-	case params.IsCodeNotYetAvailable(err):
-		return errors.NewNotYetAvailable(nil, msg)
 	case params.IsCodeNotLeader(err):
 		e, ok := err.(*params.Error)
 		if !ok {
@@ -372,9 +351,8 @@ func RestoreError(err error) error {
 		return rehydrateLeaseError(err)
 	case params.IsCodeTryAgain(err):
 		return ErrTryAgain
-	case params.IsCodeNotValid(err):
-		return errors.NewNotValid(nil, msg)
 	default:
-		return err
+		// Handle all other codes here.
+		return params.TranslateWellKnownError(err)
 	}
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -195,6 +195,12 @@ type mockApplication struct {
 	scale                int
 	unitsWatcher         *statetesting.MockStringsWatcher
 	unitsChanges         chan []string
+	charmPending         bool
+}
+
+func (a *mockApplication) CharmPendingToBeDownloaded() bool {
+	a.MethodCall(a, "CharmPendingToBeDownloaded")
+	return a.charmPending
 }
 
 func (a *mockApplication) Tag() names.Tag {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -225,6 +225,15 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		return nil, errors.Trace(err)
 	}
 
+	charmURL, _ := app.CharmURL()
+	if charmURL == nil {
+		return nil, errors.NotValidf("application charm url nil")
+	}
+
+	if app.CharmPendingToBeDownloaded() {
+		return nil, errors.NotProvisionedf("charm %q pending", *charmURL)
+	}
+
 	cfg, err := a.ctrlSt.ControllerConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -286,10 +295,6 @@ func (a *API) provisioningInfo(appName names.ApplicationTag) (*params.CAASApplic
 		}
 	}
 	caCert, _ := cfg.CACert()
-	charmURL, _ := app.CharmURL()
-	if charmURL == nil {
-		return nil, errors.NotValidf("application charm url nil")
-	}
 	appConfig, err := app.ApplicationConfig()
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting application config")

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -125,6 +125,24 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	})
 }
 
+func (s *CAASApplicationProvisionerSuite) TestProvisioningInfoPendingCharmError(c *gc.C) {
+	s.st.app = &mockApplication{
+		life:         state.Alive,
+		charmPending: true,
+		charm: &mockCharm{
+			meta: &charm.Meta{},
+			url: &charm.URL{
+				Schema:   "cs",
+				Name:     "gitlab",
+				Revision: -1,
+			},
+		},
+	}
+	result, err := s.api.ProvisioningInfo(params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Results[0].Error, gc.ErrorMatches, `charm "cs:gitlab" pending not provisioned`)
+}
+
 func (s *CAASApplicationProvisionerSuite) TestSetOperatorStatus(c *gc.C) {
 	s.st.app = &mockApplication{
 		life: state.Alive,

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -48,6 +48,7 @@ type Model interface {
 
 type Application interface {
 	Charm() (ch Charm, force bool, err error)
+	CharmPendingToBeDownloaded() bool
 	SetOperatorStatus(status.StatusInfo) error
 	AllUnits() ([]Unit, error)
 	UpdateUnits(unitsOp *state.UpdateUnitsOperation) error

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/juju/schema v1.0.1
 	github.com/juju/terms-client/v2 v2.0.0
 	github.com/juju/testing v1.0.2
-	github.com/juju/txn/v3 v3.0.1
+	github.com/juju/txn/v3 v3.0.2
 	github.com/juju/utils/v3 v3.0.0
 	github.com/juju/version/v2 v2.0.1
 	github.com/juju/viddy v0.0.0-beta5

--- a/go.sum
+++ b/go.sum
@@ -864,8 +864,8 @@ github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494/go.mod h1:rUquetT0ALL
 github.com/juju/testing v1.0.0/go.mod h1:rUquetT0ALL48LHZhyRGvjjBH8xZaZ8dFClulKK5wK4=
 github.com/juju/testing v1.0.2 h1:OR90RqCd9CJONxXamZAjLknpZdtqDyxqW8IwCbgw3i4=
 github.com/juju/testing v1.0.2/go.mod h1:h3Vd2rzB57KrdsBEy6R7bmSKPzP76BnNavt7i8PerwQ=
-github.com/juju/txn/v3 v3.0.1 h1:6lz2Oa84RVgfKz8+DMR/3IlwKj/iUBUmrOv40IFSAU0=
-github.com/juju/txn/v3 v3.0.1/go.mod h1:DlFlqNZkgzE4NolIxhSvYOok/heIOjhXLx3Z5oUTyy4=
+github.com/juju/txn/v3 v3.0.2 h1:ibKhRlQmslPj88QfxND8hX4Sv6rTRKOb+HSp/ti1sEg=
+github.com/juju/txn/v3 v3.0.2/go.mod h1:DlFlqNZkgzE4NolIxhSvYOok/heIOjhXLx3Z5oUTyy4=
 github.com/juju/usso v1.0.1 h1:zyQhSUJnhFZdPqVAmPeqXYlnYXv+i0Cp1Ii+aziMXGs=
 github.com/juju/usso v1.0.1/go.mod h1:3cvBcGVmWXyHhrBHBQtpNBzca/JRg4S5XH88Hj/NsYA=
 github.com/juju/utils v0.0.0-20180424094159-2000ea4ff043/go.mod h1:6/KLg8Wz/y2KVGWEpkK9vMNGkOnu4k/cqs8Z1fKjTOk=

--- a/rpc/params/apierror.go
+++ b/rpc/params/apierror.go
@@ -163,7 +163,7 @@ func serializeToMap(v interface{}) map[string]interface{} {
 	return asMap
 }
 
-// The Code constants hold error codes for some kinds of error.
+// The Code constants hold error codes for well known errors.
 const (
 	CodeNotFound                  = "not found"
 	CodeUserNotFound              = "user not found"
@@ -213,6 +213,46 @@ const (
 	CodeNotYetAvailable           = "not yet available; try again later"
 	CodeNotValid                  = "not valid"
 )
+
+// TranslateWellKnownError translates well known wire error codes into a github.com/juju/errors error
+// that matches the error code.
+func TranslateWellKnownError(err error) error {
+	code := ErrCode(err)
+	switch code {
+	// TODO: add more error cases including DeadlineExceeded
+	// case CodeDeadlineExceeded:
+	// 	return errors.NewTimeout(err, "")
+	case CodeNotFound:
+		return errors.NewNotFound(err, "")
+	case CodeUserNotFound:
+		return errors.NewUserNotFound(err, "")
+	case CodeUnauthorized:
+		return errors.NewUnauthorized(err, "")
+	case CodeNotImplemented:
+		return errors.NewNotImplemented(err, "")
+	case CodeAlreadyExists:
+		return errors.NewAlreadyExists(err, "")
+	case CodeNotSupported:
+		return errors.NewNotSupported(err, "")
+	case CodeNotValid:
+		return errors.NewNotValid(err, "")
+	case CodeNotProvisioned:
+		return errors.NewNotProvisioned(err, "")
+	case CodeNotAssigned:
+		return errors.NewNotAssigned(err, "")
+	case CodeBadRequest:
+		return errors.NewBadRequest(err, "")
+	case CodeMethodNotAllowed:
+		return errors.NewMethodNotAllowed(err, "")
+	case CodeForbidden:
+		return errors.NewForbidden(err, "")
+	case CodeQuotaLimitExceeded:
+		return errors.NewQuotaLimitExceeded(err, "")
+	case CodeNotYetAvailable:
+		return errors.NewNotYetAvailable(err, "")
+	}
+	return err
+}
 
 // ErrCode returns the error code associated with
 // the given error, or the empty string if there

--- a/rpc/params/apierror_test.go
+++ b/rpc/params/apierror_test.go
@@ -5,6 +5,7 @@ package params_test
 
 import (
 	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/rpc"
@@ -24,4 +25,32 @@ func (*errorSuite) TestErrCode(c *gc.C) {
 
 	err = errors.Trace(err)
 	c.Check(params.ErrCode(err), gc.Equals, params.CodeDead)
+}
+
+func (*errorSuite) TestTranslateWellKnownError(c *gc.C) {
+	var tests = []struct {
+		name string
+		err  params.Error
+		test func(err error) bool
+	}{
+		{params.CodeNotFound, params.Error{Code: params.CodeNotFound, Message: "look a NotFound error"}, errors.IsNotFound},
+		{params.CodeUserNotFound, params.Error{Code: params.CodeUserNotFound, Message: "look a UserNotFound error"}, errors.IsUserNotFound},
+		{params.CodeUnauthorized, params.Error{Code: params.CodeUnauthorized, Message: "look a Unauthorized error"}, errors.IsUnauthorized},
+		{params.CodeNotImplemented, params.Error{Code: params.CodeNotImplemented, Message: "look a NotImplemented error"}, errors.IsNotImplemented},
+		{params.CodeAlreadyExists, params.Error{Code: params.CodeAlreadyExists, Message: "look a AlreadyExists error"}, errors.IsAlreadyExists},
+		{params.CodeNotSupported, params.Error{Code: params.CodeNotSupported, Message: "look a NotSupported error"}, errors.IsNotSupported},
+		{params.CodeNotValid, params.Error{Code: params.CodeNotValid, Message: "look a NotValid error"}, errors.IsNotValid},
+		{params.CodeNotProvisioned, params.Error{Code: params.CodeNotProvisioned, Message: "look a NotProvisioned error"}, errors.IsNotProvisioned},
+		{params.CodeNotAssigned, params.Error{Code: params.CodeNotAssigned, Message: "look a NotAssigned error"}, errors.IsNotAssigned},
+		{params.CodeBadRequest, params.Error{Code: params.CodeBadRequest, Message: "look a BadRequest error"}, errors.IsBadRequest},
+		{params.CodeMethodNotAllowed, params.Error{Code: params.CodeMethodNotAllowed, Message: "look a MethodNotAllowed error"}, errors.IsMethodNotAllowed},
+		{params.CodeForbidden, params.Error{Code: params.CodeForbidden, Message: "look a Forbidden error"}, errors.IsForbidden},
+		{params.CodeQuotaLimitExceeded, params.Error{Code: params.CodeQuotaLimitExceeded, Message: "look a QuotaLimitExceeded error"}, errors.IsQuotaLimitExceeded},
+		{params.CodeNotYetAvailable, params.Error{Code: params.CodeNotYetAvailable, Message: "look a NotYetAvailable error"}, errors.IsNotYetAvailable},
+	}
+
+	for _, v := range tests {
+		c.Assert(v.test(v.err), jc.IsFalse, gc.Commentf("test %s: params error is not a juju/errors error", v.name))
+		c.Assert(v.test(params.TranslateWellKnownError(v.err)), jc.IsTrue, gc.Commentf("test %s: translated error is a juju/errors error", v.name))
+	}
 }

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -257,7 +257,11 @@ func (a *appWorker) loop() error {
 				appStateChanges = appStateWatcher.Changes()
 			}
 			err = a.alive(app)
-			if err != nil {
+			if errors.Is(err, errors.NotProvisioned) {
+				// State not ready for this application to be provisioned yet.
+				// Usually because the charm has not yet been downloaded.
+				break
+			} else if err != nil {
 				return errors.Trace(err)
 			}
 			if appChanges == nil {
@@ -697,7 +701,10 @@ func (a *appWorker) alive(app caas.Application) error {
 	a.logger.Debugf("ensuring application %q exists", a.name)
 
 	provisionInfo, err := a.facade.ProvisioningInfo(a.name)
-	if err != nil {
+	if errors.Is(err, errors.NotProvisioned) {
+		a.logger.Debugf("application %s is not provisioned yet: %s", a.name, err.Error())
+		return errors.NotProvisioned
+	} else if err != nil {
 		return errors.Annotate(err, "retrieving provisioning info")
 	}
 	if provisionInfo.CharmURL == nil {


### PR DESCRIPTION
Delays the provisioning of sidcar app until charm fully downloaded.

Also cleans up some error handling.

## QA steps

```
juju deploy indico
juju debug-log
```

check for no `controller-0: 14:37:28 ERROR juju.charmhub charmhub empty id not valid`

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1991048