### PR TITLE
[JUJU-1902] Possible fix test-user-login-password issue in jenkins

### DIFF
--- a/tests/includes/expect-that.sh
+++ b/tests/includes/expect-that.sh
@@ -17,7 +17,7 @@ expect_that() {
 
 	cat >"${TEST_DIR}/${filename}.exp" <<EOF
 #!/usr/bin/expect
-proc abort { } { send_user \"\rTimeout Error!\" ; exit 2 }
+proc abort { } { puts \"\rFail\" ; exit 2 }
 expect_before timeout abort
 
 set timeout ${timeout}
@@ -25,8 +25,6 @@ spawn ${command}
 match_max 100000
 
 ${expect_script}
-
-expect eof
 EOF
-	expect "${TEST_DIR}/${filename}.exp" | check "spawn ${command}"
+	expect "${TEST_DIR}/${filename}.exp"
 }

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -7,26 +7,21 @@ run_user_change_password() {
 	file="${TEST_DIR}/test-user-change-password.log"
 	ensure "user-change-password" "${file}"
 
-	echo "Change admin password"
-	expect_that "juju change-user-password" "
+	echo "Add test-change-password-user"
+	juju add-user test-change-password-user
+
+	echo "Change test-change-password-user password"
+	expect_that "juju change-user-password test-change-password-user" "
 expect \"new password: \" {
-	send \"test-password\r\"
-	expect \"type new password again: \" {
-		send \"test-password\r\"
-	}
-}"
-
-	echo "Logout from controller"
-	juju logout
-
-	echo "Login as admin"
-	expect_that "juju login" "
-expect \"Enter username: \" {
-	send \"admin\r\"
-	expect \"please enter password for admin*\" {
-		send \"test-password\r\"
-	}
-}" 15
+    send \"test-password\r\"
+    expect \"type new password again: \" {
+        send \"test-password\r\"
+        expect {
+            \"*has been changed.\" { puts \"Success\" }
+            eof { puts \"Fail\" }
+        }
+    }
+}" | check "Success"
 
 	destroy_model "user-change-password"
 }


### PR DESCRIPTION
This PR is yet another try to fix issue with `juju change-user-password` expect script in jenkins.

This PR drops 'juju login/logout' logic from test stays only with change-user-password.
Fixed "expect eof" issue: when a check of "expect eof" happens after spawn process is closed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p lxd user test_user_login_password
```
