### PR TITLE
Use puts instead of exit and send_user in expect script

### DIFF
--- a/tests/includes/expect-that.sh
+++ b/tests/includes/expect-that.sh
@@ -16,15 +16,19 @@ expect_that() {
 	timeout=${3:-10} # default timeout: 10s
 
 	cat >"${TEST_DIR}/${filename}.exp" <<EOF
-#!/usr/bin/expect
-proc abort { } { puts \"\rFail\" ; exit 2 }
+#!/usr/bin/expect -f
+proc abort { } { puts "\nFail" }
 expect_before timeout abort
 
 set timeout ${timeout}
+log_user 0
 spawn ${command}
 match_max 100000
 
 ${expect_script}
 EOF
+
+	chmod 777 "${TEST_DIR}/${filename}.exp"
 	expect "${TEST_DIR}/${filename}.exp"
+
 }

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -17,11 +17,11 @@ expect \"new password: \" {
     expect \"type new password again: \" {
         send \"test-password\r\"
         expect {
-            \"*has been changed.\" { puts \"Success\" }
+            \"*has been changed.\" { puts \"Pass\" }
             eof { puts \"Fail\" }
         }
     }
-}" | check "Success"
+}" | check "Pass"
 
 	destroy_model "user-change-password"
 }


### PR DESCRIPTION
We continue struggling with expect script in Jenkins environment. Because the problem reproduces only in Jenkins, we are limited in debugging possibilities.

This PR:

- uses `puts` instead of `send_user` and `exit`, which looks like a more clear way to interact with the parent script
- disables expect stript  additional output (except `puts`) by using `log_user 0` option
- explicitly give rights for execution in `expect_that` function

PS: if it does not help, we will continue investigating the problem; in the worst case, we put this test to the `proving-grounds` group.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps


```sh
cd tests
./main.sh -v -p lxd user test_user_login_password
```
