### PR TITLE
Added wait to expect script to prevent Jenkins to drop spawn process.

### DIFF
--- a/tests/includes/expect-that.sh
+++ b/tests/includes/expect-that.sh
@@ -17,11 +17,10 @@ expect_that() {
 
 	cat >"${TEST_DIR}/${filename}.exp" <<EOF
 #!/usr/bin/expect -f
-proc abort { } { puts "\nFail" }
+proc abort { } { puts "Fail" }
 expect_before timeout abort
 
 set timeout ${timeout}
-log_user 0
 spawn ${command}
 match_max 100000
 

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -17,8 +17,11 @@ expect \"new password: \" {
     expect \"type new password again: \" {
         send \"test-password\r\"
         expect {
-            \"*has been changed.\" { puts \"Pass\" }
-            eof { puts \"Fail\" }
+            \"*has been changed..\" {
+                puts \"Pass\"
+                expect eof
+                wait
+            }
         }
     }
 }" | check "Pass"


### PR DESCRIPTION
This PR adds `wait` at the end of expect script, to prevent it's dropping in Jenkins. Plus reverts debug output for future investigation.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

```sh
cd tests
/main.sh -v -p lxd user run_user_change_password
```