### PR TITLE
[JUJU-1906] Fix secret set

### DIFF
--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -241,6 +241,10 @@ func (k *kubernetesClient) GetSecretToken(name string) (string, error) {
 func (k *kubernetesClient) GetJujuSecret(ctx context.Context, providerId string) (secrets.SecretValue, error) {
 	// providerId is the secret name.
 	secret, err := k.getSecret(providerId)
+	if k8serrors.IsForbidden(err) {
+		logger.Tracef("getting secret %q: %v", providerId, err)
+		return nil, errors.Unauthorizedf("cannot access %q", providerId)
+	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -272,6 +276,10 @@ func (k *kubernetesClient) SaveJujuSecret(ctx context.Context, name string, valu
 func (k *kubernetesClient) DeleteJujuSecret(ctx context.Context, providerId string) error {
 	// providerId is the secret name.
 	secret, err := k.getSecret(providerId)
+	if k8serrors.IsForbidden(err) {
+		logger.Tracef("deleting secret %q: %v", providerId, err)
+		return errors.Unauthorizedf("cannot access %q", providerId)
+	}
 	if errors.IsNotFound(err) {
 		return nil
 	}

--- a/core/secrets/secretvalue.go
+++ b/core/secrets/secretvalue.go
@@ -33,6 +33,9 @@ type SecretValue interface {
 	// KeyValue returns the specified secret value for the key.
 	// If the key has a #base64 suffix, the returned value is base64 encoded.
 	KeyValue(string) (string, error)
+
+	// IsEmpty checks if the value is empty.
+	IsEmpty() bool
 }
 
 type secretValue struct {
@@ -46,9 +49,6 @@ type secretValue struct {
 // NewSecretValue returns a secret using the specified map of values.
 // The map values are assumed to be already base64 encoded.
 func NewSecretValue(data map[string]string) SecretValue {
-	if len(data) == 0 {
-		return nil
-	}
 	dataCopy := make(map[string][]byte, len(data))
 	for k, v := range data {
 		dataCopy[k] = append([]byte(nil), v...)
@@ -59,14 +59,16 @@ func NewSecretValue(data map[string]string) SecretValue {
 // NewSecretBytes returns a secret using the specified map of values.
 // The map values are assumed to be already base64 encoded.
 func NewSecretBytes(data map[string][]byte) SecretValue {
-	if len(data) == 0 {
-		return nil
-	}
 	dataCopy := make(map[string][]byte, len(data))
 	for k, v := range data {
 		dataCopy[k] = append([]byte(nil), v...)
 	}
 	return &secretValue{data: dataCopy}
+}
+
+// IsEmpty checks if the value is empty.
+func (v secretValue) IsEmpty() bool {
+	return len(v.data) == 0
 }
 
 // EncodedValues implements SecretValue.

--- a/core/secrets/secretvalue.go
+++ b/core/secrets/secretvalue.go
@@ -46,6 +46,9 @@ type secretValue struct {
 // NewSecretValue returns a secret using the specified map of values.
 // The map values are assumed to be already base64 encoded.
 func NewSecretValue(data map[string]string) SecretValue {
+	if len(data) == 0 {
+		return nil
+	}
 	dataCopy := make(map[string][]byte, len(data))
 	for k, v := range data {
 		dataCopy[k] = append([]byte(nil), v...)
@@ -56,6 +59,9 @@ func NewSecretValue(data map[string]string) SecretValue {
 // NewSecretBytes returns a secret using the specified map of values.
 // The map values are assumed to be already base64 encoded.
 func NewSecretBytes(data map[string][]byte) SecretValue {
+	if len(data) == 0 {
+		return nil
+	}
 	dataCopy := make(map[string][]byte, len(data))
 	for k, v := range data {
 		dataCopy[k] = append([]byte(nil), v...)

--- a/core/secrets/secretvalue_test.go
+++ b/core/secrets/secretvalue_test.go
@@ -47,7 +47,7 @@ func (s *SecretValueSuite) TestValues(c *gc.C) {
 func (s *SecretValueSuite) TestEmpty(c *gc.C) {
 	in := map[string]string{}
 	val := secrets.NewSecretValue(in)
-	c.Assert(val, gc.IsNil)
+	c.Assert(val.IsEmpty(), jc.IsTrue)
 }
 
 func (s *SecretValueSuite) TestKeyValue(c *gc.C) {

--- a/core/secrets/secretvalue_test.go
+++ b/core/secrets/secretvalue_test.go
@@ -44,6 +44,12 @@ func (s *SecretValueSuite) TestValues(c *gc.C) {
 	})
 }
 
+func (s *SecretValueSuite) TestEmpty(c *gc.C) {
+	in := map[string]string{}
+	val := secrets.NewSecretValue(in)
+	c.Assert(val, gc.IsNil)
+}
+
 func (s *SecretValueSuite) TestKeyValue(c *gc.C) {
 	in := map[string]string{
 		"a": base64.StdEncoding.EncodeToString([]byte("foo")),

--- a/worker/uniter/runner/context/secrets.go
+++ b/worker/uniter/runner/context/secrets.go
@@ -60,7 +60,7 @@ func (s *secretsChangeRecorder) update(arg uniter.SecretUpdateArg) {
 		if arg.Description != nil {
 			c.Description = arg.Description
 		}
-		if arg.Value != nil {
+		if arg.Value != nil && len(arg.Value.EncodedValues()) > 0 {
 			c.Value = arg.Value
 		}
 		if arg.RotatePolicy != nil {

--- a/worker/uniter/runner/context/secrets.go
+++ b/worker/uniter/runner/context/secrets.go
@@ -60,7 +60,7 @@ func (s *secretsChangeRecorder) update(arg uniter.SecretUpdateArg) {
 		if arg.Description != nil {
 			c.Description = arg.Description
 		}
-		if arg.Value != nil && len(arg.Value.EncodedValues()) > 0 {
+		if !arg.Value.IsEmpty() {
 			c.Value = arg.Value
 		}
 		if arg.RotatePolicy != nil {

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -171,6 +171,9 @@ func (c *secretAddCommand) Run(ctx *cmd.Context) error {
 		ownerTag = names.NewUnitTag(unitName)
 	}
 	updateArgs := c.marshallArg()
+	if updateArgs.Value == nil {
+		return errors.NotValidf("empty secret value")
+	}
 	arg := &SecretCreateArgs{
 		SecretUpdateArgs: *updateArgs,
 		OwnerTag:         ownerTag,

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -171,7 +171,7 @@ func (c *secretAddCommand) Run(ctx *cmd.Context) error {
 		ownerTag = names.NewUnitTag(unitName)
 	}
 	updateArgs := c.marshallArg()
-	if updateArgs.Value == nil {
+	if updateArgs.Value.IsEmpty() {
 		return errors.NotValidf("empty secret value")
 	}
 	arg := &SecretCreateArgs{


### PR DESCRIPTION
Currently, the `secret-set` command clears the secret content if no arg is provided.
This PR ensures we only set data if the data is provided in the `secret-set` command arg.

```console

$ juju exec --unit hello-kubecon/0  'uri=$(secret-add --owner=unit foo=bar); echo $uri;secret-set $uri --label=ccc;'
secret:ccv84seffbaqh15v1q30

$ juju show-secret ccv84seffbaqh15v1q30 --reveal
ccv84seffbaqh15v1q30:
  revision: 1
  owner: hello-kubecon/0
  label: ccc
  created: 2022-10-06T07:23:32Z
  updated: 2022-10-06T07:23:32Z
  content: {}  # empty content
```

Drive-by: surface permission denied error for secret get and delete k8s API calls.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju exec --unit hello-kubecon/0  'uri=$(secret-add --owner=unit foo=bar); echo $uri; secret-set $uri --label=aaa;'
secret:ccvs28mffbamreliccg0

$ juju exec --unit hello-kubecon/0  'uri=$(secret-add foo=bar); echo $uri; secret-set $uri --label=bbb;'
secret:ccvs2buffbamreliccgg

$ juju show-secret ccvs28mffbamreliccg0 --reveal
ccvs28mffbamreliccg0:
  revision: 1
  owner: hello-kubecon/0
  label: aaa
  created: 2022-10-07T06:03:15Z
  updated: 2022-10-07T06:03:15Z
  content:
    foo: bar

$ juju show-secret ccvs2buffbamreliccgg --reveal
ccvs2buffbamreliccgg:
  revision: 1
  owner: hello-kubecon
  label: bbb
  created: 2022-10-07T06:03:29Z
  updated: 2022-10-07T06:03:29Z
  content:
    foo: bar

```

## Documentation changes

No

## Bug reference

No
