### PR TITLE
Try to fix expect in Jenkins

### DIFF
--- a/tests/includes/expect-that.sh
+++ b/tests/includes/expect-that.sh
@@ -25,9 +25,12 @@ spawn ${command}
 match_max 100000
 
 ${expect_script}
+
+expect eof
+wait
+
 EOF
 
-	chmod 777 "${TEST_DIR}/${filename}.exp"
 	expect "${TEST_DIR}/${filename}.exp"
 
 }

--- a/tests/suites/user/login_password.sh
+++ b/tests/suites/user/login_password.sh
@@ -12,21 +12,12 @@ run_user_change_password() {
 
 	echo "Change test-change-password-user password"
 	expect_that "juju change-user-password test-change-password-user" "
-expect \"new password: \" {
-    send \"test-password\r\"
-    expect \"type new password again: \" {
-        send \"test-password\r\"
-        expect {
-            \"*has been changed..\" {
-                puts \"Pass\"
-                expect eof
-                wait
-            }
-        }
-    }
-}" | check "Pass"
+expect \"new password: \" { send \"test-password\r\" }
+expect \"type new password again: \" { send \"test-password\r\"; puts \"Pass\" }
+" | check "Pass"
 
 	destroy_model "user-change-password"
+
 }
 
 test_user_login_password() {


### PR DESCRIPTION
This PR is yet another try to fix expect script execution in Jenkins. According to https://cloudaffaire.com/faq/interactive-shell-script-on-jenkins/, there is a guess that we should explicitly define:
```
expect eof
wait
```
at the end of expect script (not in expect block, as was previously). The idea is that Jenkins launching this script will wait until it's finished. 

This PR reorganized expect script in the suggested form. 

PS: Not sure that it will help, but we should try.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

*Commands to run to verify that the change works.*

```sh
cd tests
./main.sh -v -p lxd user run_user_change_password
```
