### PR TITLE
Fix for url that when followed gives a 404 error.

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/juju/provider/common"
 )
 
-const bootstrapMessage = `To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md`
+const bootstrapMessage = `To configure your system to better support LXD containers, please see: https://linuxcontainers.org/lxd/docs/master/explanation/performance_tuning/`
 
 type baseProvider interface {
 	// BootstrapEnv bootstraps a Juju environment.

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -104,7 +104,7 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 	c.Check(result.CloudBootstrapFinalizer, gc.NotNil)
 
 	out := cmdtesting.Stderr(ctx)
-	c.Assert(out, gc.Equals, "To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md\n")
+	c.Assert(out, gc.Equals, "To configure your system to better support LXD containers, please see: https://linuxcontainers.org/lxd/docs/master/explanation/performance_tuning/\n")
 }
 
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {


### PR DESCRIPTION
Why this change is needed:

Message from "juju bootstrap localhost ..." gives 

> To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md

However that URL returns as 404. Fix to new documentation location https://linuxcontainers.org/lxd/docs/master/explanation/performance_tuning/

Note: I linked to linuxcontainers.org instead of github because the raw github has {} code that renders references at the linuxcontainers.org doc site. 

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju bootstrap localhost <name>
```
and check that the URL returned for LXD documentation works.