### PR TITLE
[JUJU-1926] Do no ops if nothing to remove;

### DIFF
--- a/state/secrets.go
+++ b/state/secrets.go
@@ -482,10 +482,14 @@ func (s *secretsStore) DeleteSecret(uri *secrets.URI, revisions ...int) (removed
 
 func (st *State) deleteSecrets(uris []*secrets.URI, revisions ...int) (removed bool, err error) {
 	// We will bulk delete the various artefacts, starting with the secret itself.
-	// Deleting the parent secret metadata first  will ensure that any consumers of
+	// Deleting the parent secret metadata first will ensure that any consumers of
 	// the secret get notified and subsequent attempts to access any secret
 	// attributes (revision etc) return not found.
 	// It is not practical to do this record by record in a legacy client side mgo txn operation.
+	if len(uris) == 0 && len(revisions) == 0 {
+		// Nothing to remove.
+		return false, nil
+	}
 
 	if len(uris) == 0 || len(uris) > 1 && len(revisions) > 0 {
 		return false, errors.Errorf("PROGRAMMING ERROR: invalid secret deletion args uris=%v, revisions=%v", uris, revisions)


### PR DESCRIPTION
Do no ops if no secrets need to be removed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju deploy hello-kubecon
Located charm "hello-kubecon" in charm-hub, revision 14
Deploying "hello-kubecon" from charm-hub charm "hello-kubecon", revision 14 in channel stable on ubuntu:20.04

$ juju exec --unit hello-kubecon/0  'uri=$(secret-add foo=bar); echo $uri; secret-set $uri --label=bbb;'
secret:cd1m3nmffbau3ku2d650

$ juju secrets
ID                    Owner          Rotation  Revision  Last updated
cd1m3nmffbau3ku2d650  hello-kubecon  never            1  6 seconds ago

$ juju destroy-model -y --debug --force --destroy-storage k1:t1

# at the same time watch model log
$ juju debug-log --color --replay
```

## Documentation changes

No

## Bug reference

No

