### PR TITLE
[JUJU-1647, JUJU-1918] Rewrite api/client/payloads unit tests to use gomock

### DIFF
--- a/api/client/cloud/cloud_test.go
+++ b/api/client/cloud/cloud_test.go
@@ -813,26 +813,18 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResults(c *gc.C) {
 
 	args := params.UpdateCredentialArgs{
 		Force: false,
-		Credentials: []params.TaggedCredential{{
-			Tag: "cloudcred-foo_bob_bar0",
+	}
+	count := 2
+	for tag, credential := range createCredentials(count) {
+		args.Credentials = append(args.Credentials, params.TaggedCredential{
+			Tag: tag,
 			Credential: params.CloudCredential{
-				AuthType: "userpass",
-				Attributes: map[string]string{
-					"username": "admin",
-					"password": "adm1n",
-				},
+				AuthType:   string(credential.AuthType()),
+				Attributes: credential.Attributes(),
 			},
-		},
-			{
-				Tag: "cloudcred-foo_bob_bar1",
-				Credential: params.CloudCredential{
-					AuthType: "userpass",
-					Attributes: map[string]string{
-						"username": "admin",
-						"password": "adm1n",
-					},
-				},
-			}}}
+		})
+	}
+
 	res := new(params.UpdateCredentialResults)
 	results := params.UpdateCredentialResults{
 		Results: []params.UpdateCredentialResult{
@@ -843,7 +835,6 @@ func (s *cloudSuite) TestUpdateCloudsCredentialsManyMatchingResults(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall("UpdateCredentialsCheckModels", args, res).SetArg(2, results).Return(nil)
 	client := cloudapi.NewClientFromCaller(mockFacadeCaller)
 
-	count := 2
 	result, err := client.UpdateCloudsCredentials(createCredentials(count), false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, count)

--- a/api/client/payloads/client_test.go
+++ b/api/client/payloads/client_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
 	"github.com/juju/names/v4"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,30 +17,15 @@ import (
 )
 
 type ClientSuite struct {
-	testing.IsolationSuite
-
-	facade    *mocks.MockFacadeCaller
-	apiCaller *mocks.MockAPICallCloser
-	client    *payloads.Client
+	facade *mocks.MockFacadeCaller
+	client *payloads.Client
 }
 
 var _ = gc.Suite(&ClientSuite{})
 
-func (s *ClientSuite) setUpMocks(c *gc.C) *gomock.Controller {
-	ctrl := gomock.NewController(c)
-
-	s.apiCaller = mocks.NewMockAPICallCloser(ctrl)
-	s.apiCaller.EXPECT().BestFacadeVersion(gomock.Any()).Return(3).AnyTimes()
-
-	s.facade = mocks.NewMockFacadeCaller(ctrl)
-	s.facade.EXPECT().RawAPICaller().Return(s.apiCaller).AnyTimes()
-	s.facade.EXPECT().BestAPIVersion().Return(1).AnyTimes()
-	s.client = payloads.NewClientForTest(s.facade)
-	return ctrl
-}
-
 func (s *ClientSuite) TestList(c *gc.C) {
-	defer s.setUpMocks(c).Finish()
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
 	args := &params.PayloadListArgs{
 		Patterns: []string{"a-tag", "a-application/0"},
@@ -59,9 +43,12 @@ func (s *ClientSuite) TestList(c *gc.C) {
 	resultParams := params.PayloadListResults{
 		Results: []params.Payload{payloadResult},
 	}
-	s.facade.EXPECT().FacadeCall("List", args, gomock.Any()).SetArg(2, resultParams).Return(nil)
 
-	results, err := s.client.ListFull("a-tag", "a-application/0")
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("List", args, gomock.Any()).SetArg(2, resultParams).Return(nil)
+	client := payloads.NewClientFromCaller(mockFacadeCaller)
+
+	results, err := client.ListFull("a-tag", "a-application/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(results, jc.DeepEquals, []corepayloads.FullPayloadInfo{
 		{

--- a/api/client/payloads/helpers_test.go
+++ b/api/client/payloads/helpers_test.go
@@ -6,7 +6,6 @@ package payloads
 import (
 	"github.com/juju/charm/v9"
 	"github.com/juju/names/v4"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,7 +14,6 @@ import (
 )
 
 type helpersSuite struct {
-	testing.IsolationSuite
 }
 
 var _ = gc.Suite(&helpersSuite{})

--- a/api/client/payloads/package_test.go
+++ b/api/client/payloads/package_test.go
@@ -15,17 +15,8 @@ func Test(t *testing.T) {
 	gc.TestingT(t)
 }
 
-func NewClientForTest(caller base.FacadeCaller) *Client {
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
 	return &Client{
-		ClientFacade: noopCloser{caller},
-		facade:       caller,
+		facade: caller,
 	}
-}
-
-type noopCloser struct {
-	base.FacadeCaller
-}
-
-func (noopCloser) Close() error {
-	return nil
 }


### PR DESCRIPTION
The unit tests for api/client/payloads now use go mock and not juju/testing. All unit tests should pass.