### PR TITLE
go.mod specifies go version 1.19. Set install-dependencies to check go.mod for version to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 GOHOSTOS=$(shell go env GOHOSTOS)
 GOHOSTARCH=$(shell go env GOHOSTARCH)
-GO_MOD_VERSION=$(shell grep -P "^go \d+\.\d+" go.mod | cut -d ' ' -f 2)
-GO_INSTALLED_VERSION=$(shell go version | cut -d ' ' -f 3 | sed -e /go/s///)
+GO_MOD_VERSION=$(shell grep -P "^go" go.mod | awk '{print $$2}')
+GO_INSTALLED_VERSION=$(shell go version | awk '{print $$3}' | sed -e /.*go/s///)
 export CGO_ENABLED=0
 
 BUILD_DIR ?= $(PROJECT_DIR)/_build
@@ -349,7 +349,7 @@ ifeq ("$(GO_INSTALLED_VERSION)","")
 else
 ifeq ($(shell if [ "$(GO_INSTALLED_VERSION)" \< "$(GO_MOD_VERSION)" ]; then echo 1; fi),1)
 	$(warning "warning: version of go too low: use 'snap refresh go --channel=$(GO_MOD_VERSION)'")
-	$(error "error Installed go version $(GO_INSTALLED_VERSION) less than required go version $(GO_MOD_VERSION)")
+	$(error "error Installed go version '$(GO_INSTALLED_VERSION)' less than required go version '$(GO_MOD_VERSION)'")
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -338,11 +338,11 @@ endif
 # PPA includes the required mongodb-server binaries.
 install-snap-dependencies:
 ## install-snap-dependencies: Install the supported snap dependencies
-ifeq ($(shell go version | grep -o "go1.18" || true),go1.18)
-	@echo Using installed go-1.18
+ifeq ($(shell go version | grep -o "go1.19" || true),go1.19)
+	@echo Using installed go-1.19
 else
-	@echo Installing go-1.18 snap
-	@sudo snap install go --channel=1.18/stable --classic
+	@echo Installing go-1.19 snap
+	@sudo snap install go --channel=1.19/stable --classic
 endif
 
 WAIT_FOR_DPKG=bash -c '. "${PROJECT_DIR}/make_functions.sh"; wait_for_dpkg "$$@"' wait_for_dpkg

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 GOHOSTOS=$(shell go env GOHOSTOS)
 GOHOSTARCH=$(shell go env GOHOSTARCH)
+GO_MOD_VERSION=$(shell grep -P "^go \d+\.\d+" go.mod | cut -d ' ' -f 2)
 export CGO_ENABLED=0
 
 BUILD_DIR ?= $(PROJECT_DIR)/_build
@@ -338,11 +339,11 @@ endif
 # PPA includes the required mongodb-server binaries.
 install-snap-dependencies:
 ## install-snap-dependencies: Install the supported snap dependencies
-ifeq ($(shell go version | grep -o "go1.19" || true),go1.19)
-	@echo Using installed go-1.19
+ifeq ($(shell go version | cut -d ' ' -f 3 | sed -e /go/s///),$(GO_MOD_VERSION))
+	@echo 'Using installed go-$(GO_MOD_VERSION)'
 else
-	@echo Installing go-1.19 snap
-	@sudo snap install go --channel=1.19/stable --classic
+	@echo 'Installing go-$(GO_MOD_VERSION) snap'
+	@sudo snap install go --channel=$(GO_MOD_VERSION)/stable --classic
 endif
 
 WAIT_FOR_DPKG=bash -c '. "${PROJECT_DIR}/make_functions.sh"; wait_for_dpkg "$$@"' wait_for_dpkg


### PR DESCRIPTION
Previously "make install-dependencies" would try to install go 1.18 even though go.mod specifies go version 1.19.

*Why this change is needed and what it does.*

The file go.mod specifies that go version 1.19 is to be used. But the Makefile still has go version 1.18 as an installed
version when the command `make install-dependencies `runs. 

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
make install-dependencies
```

uses go version 1.19 instead of version 1.18

