### PR TITLE
[JUJU-1958] Fixed test-resources-test-upgrade-resources.

### DIFF
--- a/tests/suites/resources/upgrade.sh
+++ b/tests/suites/resources/upgrade.sh
@@ -33,7 +33,7 @@ run_resource_attach() {
 
 	juju deploy juju-qa-test
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-	juju attach juju-qa-test foo-file="./tests/suites/resources/foo-file.txt"
+	juju attach-resource juju-qa-test foo-file="./tests/suites/resources/foo-file.txt"
 
 	juju config juju-qa-test foo-file=true
 	# wait for config-changed, the charm will update the status
@@ -59,7 +59,7 @@ run_resource_attach_large() {
 	# Use urandom to add alpha numeric characters with new lines added to the file
 	dd if=/dev/urandom bs=1048576 count=100 2>/dev/null | base64 >"${FILE}"
 	line=$(head -n 1 "${FILE}")
-	juju attach juju-qa-test foo-file="${FILE}"
+	juju attach-resource juju-qa-test foo-file="${FILE}"
 
 	juju config juju-qa-test foo-file=true
 	# wait for config-changed, the charm will update the status


### PR DESCRIPTION
This PR changes the `juju attach` to `juju attach-resource` taking into consideration the following PR: https://github.com/juju/juju/pull/13876/

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

```sh
cd tests
./main.sh -v -p lxd resources test_upgrade_resources
```
