### PR TITLE
Merge 2.9 into develop

### DIFF
--- a/container/kvm/container.go
+++ b/container/kvm/container.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/v3/arch"
 
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/kvm/libvirt"
@@ -46,17 +45,13 @@ func (c *kvmContainer) EnsureCachedImage(params StartParams) error {
 			return imagedownloads.NewDataSource(c.fetcher, params.ImageDownloadURL)
 		}
 	}
-	var fType = BIOSFType
-	if params.Arch == arch.ARM64 {
-		fType = UEFIFType
-	}
 
 	sp := syncParams{
 		fetcher: c.fetcher,
 		arch:    params.Arch,
 		version: params.Version,
 		stream:  params.Stream,
-		fType:   fType,
+		fType:   DiskImageType,
 		srcFunc: srcFunc,
 	}
 	logger.Debugf("synchronise images for %s %s %s %s", sp.arch, sp.version, sp.stream, params.ImageDownloadURL)

--- a/container/kvm/libvirt/domainxml.go
+++ b/container/kvm/libvirt/domainxml.go
@@ -180,11 +180,8 @@ func generateFeaturesElement(p domainParams) *Features {
 func generateCPU(p domainParams) *CPU {
 	if p.Arch() == arch.ARM64 {
 		return &CPU{
-			Mode:  "custom",
-			Match: "exact",
-			Model: Model{
-				Fallback: "allow",
-				Text:     "cortex-a53"},
+			Mode:  "host-passthrough",
+			Check: "none",
 		}
 	}
 	return nil
@@ -280,7 +277,7 @@ type GIC struct {
 type CPU struct {
 	Mode  string `xml:"mode,attr,omitempty"`
 	Match string `xml:"match,attr,omitempty"`
-	Model Model  `xml:"model,omitempty"`
+	Check string `xml:"check,attr,omitempty"`
 }
 
 // Address is static. We generate a default value for it.

--- a/container/kvm/libvirt/domainxml_test.go
+++ b/container/kvm/libvirt/domainxml_test.go
@@ -75,9 +75,7 @@ var arm64DomainStr = `
         <gic version="host"></gic>
         <acpi></acpi>
     </features>
-    <cpu mode="custom" match="exact">
-        <model fallback="allow">cortex-a53</model>
-    </cpu>
+    <cpu mode="host-passthrough" check="none"></cpu>
     <devices>
         <disk device="disk" type="file">
             <driver type="qcow2" name="qemu"></driver>

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -24,13 +24,8 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 )
 
-// BIOSFType is the file type we want to fetch and use for kvm instances which
-// boot using a legacy BIOS boot loader.
-const BIOSFType = "disk1.img"
-
-// UEFIFType is the file type we want to fetch and use for kvm instances which
-// boot using UEFI. In our case this is ARM64.
-const UEFIFType = "uefi1.img"
+// DiskImageType is the file type we want to fetch and use for kvm instances.
+const DiskImageType = "disk1.img"
 
 // Oner gets the one matching item from simplestreams.
 type Oner interface {

--- a/environs/imagedownloads/simplestreams_test.go
+++ b/environs/imagedownloads/simplestreams_test.go
@@ -55,7 +55,7 @@ func (s *Suite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (Suite) TestNewSignedImagesSource(c *gc.C) {
+func (*Suite) TestNewSignedImagesSource(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	got := DefaultSource(ss)()
 	c.Check(got.Description(), jc.DeepEquals, "ubuntu cloud images")
@@ -66,7 +66,7 @@ func (Suite) TestNewSignedImagesSource(c *gc.C) {
 	c.Assert(gotURL, jc.DeepEquals, "http://cloud-images.ubuntu.com/releases/")
 }
 
-func (Suite) TestFetchManyDefaultFilter(c *gc.C) {
+func (*Suite) TestFetchManyDefaultFilter(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
@@ -93,7 +93,7 @@ func (Suite) TestFetchManyDefaultFilter(c *gc.C) {
 	}
 }
 
-func (Suite) TestFetchManyDefaultFilterAndCustomImageDownloadURL(c *gc.C) {
+func (*Suite) TestFetchManyDefaultFilterAndCustomImageDownloadURL(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
@@ -123,38 +123,37 @@ func (Suite) TestFetchManyDefaultFilterAndCustomImageDownloadURL(c *gc.C) {
 	}
 }
 
-func (Suite) TestFetchSingleDefaultFilter(c *gc.C) {
+func (*Suite) TestFetchSingleDefaultFilter(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
 	tds := []simplestreams.DataSource{
 		newTestDataSource(ss, ts.URL)}
 	constraints := &imagemetadata.ImageConstraint{
-		simplestreams.LookupParams{
+		LookupParams: simplestreams.LookupParams{
 			Arches:   []string{"ppc64el"},
 			Releases: []string{"16.04"},
 		}}
 	got, resolveInfo, err := Fetch(ss, tds, constraints, nil)
 	c.Check(resolveInfo.Signed, jc.IsTrue)
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(len(got), jc.DeepEquals, 6)
+	c.Assert(len(got), jc.DeepEquals, 8)
 	c.Check(got[0].Arch, jc.DeepEquals, "ppc64el")
 	c.Check(err, jc.ErrorIsNil)
 	for _, v := range got {
-		gotURL, err := v.DownloadURL(ts.URL)
+		_, err := v.DownloadURL(ts.URL)
 		c.Check(err, jc.ErrorIsNil)
-		c.Check(strings.HasSuffix(gotURL.String(), v.FType), jc.IsTrue)
 	}
 }
 
-func (Suite) TestFetchOneWithFilter(c *gc.C) {
+func (*Suite) TestFetchOneWithFilter(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
 	tds := []simplestreams.DataSource{
 		newTestDataSource(ss, ts.URL)}
 	constraints := &imagemetadata.ImageConstraint{
-		simplestreams.LookupParams{
+		LookupParams: simplestreams.LookupParams{
 			Arches:   []string{"ppc64el"},
 			Releases: []string{"16.04"},
 		}}
@@ -171,17 +170,17 @@ func (Suite) TestFetchOneWithFilter(c *gc.C) {
 	c.Assert(
 		gotURL.String(),
 		jc.DeepEquals,
-		"http://cloud-images.ubuntu.com/server/releases/xenial/release-20161020/ubuntu-16.04-server-cloudimg-ppc64el-disk1.img")
+		"http://cloud-images.ubuntu.com/server/releases/xenial/release-20211001/ubuntu-16.04-server-cloudimg-ppc64el-disk1.img")
 }
 
-func (Suite) TestFetchManyWithFilter(c *gc.C) {
+func (*Suite) TestFetchManyWithFilter(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
 	tds := []simplestreams.DataSource{
 		newTestDataSource(ss, ts.URL)}
 	constraints := &imagemetadata.ImageConstraint{
-		simplestreams.LookupParams{
+		LookupParams: simplestreams.LookupParams{
 			Arches:   []string{"amd64", "arm64", "ppc64el"},
 			Releases: []string{"16.04"},
 		}}
@@ -193,18 +192,17 @@ func (Suite) TestFetchManyWithFilter(c *gc.C) {
 	c.Check(got[1].Arch, jc.DeepEquals, "arm64")
 	c.Check(got[2].Arch, jc.DeepEquals, "ppc64el")
 	for i, arch := range []string{"amd64", "arm64", "ppc64el"} {
-		wantURL := fmt.Sprintf("http://cloud-images.ubuntu.com/server/releases/xenial/release-20161020/ubuntu-16.04-server-cloudimg-%s-disk1.img", arch)
+		wantURL := fmt.Sprintf("http://cloud-images.ubuntu.com/server/releases/xenial/release-20211001/ubuntu-16.04-server-cloudimg-%s-disk1.img", arch)
 		// Assuming that the operator has not overridden the image
 		// download URL parameter we pass the default empty value which
 		// should fall back to the default cloud-images.ubuntu.com URL.
 		gotURL, err := got[i].DownloadURL("")
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(gotURL.String(), jc.DeepEquals, wantURL)
-
 	}
 }
 
-func (Suite) TestOneAmd64XenialTarGz(c *gc.C) {
+func (*Suite) TestOneAmd64XenialTarGz(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
@@ -212,16 +210,16 @@ func (Suite) TestOneAmd64XenialTarGz(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(got, jc.DeepEquals, &Metadata{
 		Arch:    "amd64",
-		Release: "16.04",
+		Release: "xenial",
 		Version: "16.04",
 		FType:   "tar.gz",
-		SHA256:  "9c00e4340c636b684e93c77dd7f08ab70989faffccf1a66fb00612ca6f64d8e4",
-		Path:    "server/releases/xenial/release-20161020/ubuntu-16.04-server-cloudimg-amd64.tar.gz",
-		Size:    287271698,
+		SHA256:  "c48036699274351be132f2aec7fec9fd2da936b6b512c65b2d9fd6531e5623ea",
+		Path:    "server/releases/xenial/release-20211001/ubuntu-16.04-server-cloudimg-amd64.tar.gz",
+		Size:    287684992,
 	})
 }
 
-func (Suite) TestOneArm64JammyImg(c *gc.C) {
+func (*Suite) TestOneArm64JammyImg(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
@@ -232,30 +230,30 @@ func (Suite) TestOneArm64JammyImg(c *gc.C) {
 		Release: "jammy",
 		Version: "22.04",
 		FType:   "disk1.img",
-		SHA256:  "7da1bec20dfd78c7175155190c6fcdc16a6064be2a8bdabf13369f041c06aaf2",
-		Path:    "server/releases/jammy/release-20161020/ubuntu-22.04-server-cloudimg-arm64-disk1.img",
-		Size:    356123136,
+		SHA256:  "78b5ca0da456b228e2441bdca0cca1eab30b1b6a3eaf9594eabcb2cfc21275f3",
+		Path:    "server/releases/jammy/release-20220923/ubuntu-22.04-server-cloudimg-arm64.img",
+		Size:    642646016,
 	})
 }
 
-func (Suite) TestOnePpc64elXenialImg(c *gc.C) {
+func (*Suite) TestOneArm64FocalImg(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()
-	got, err := One(ss, "ppc64el", "16.04", "", "disk1.img", newTestDataSourceFunc(ts.URL))
+	got, err := One(ss, "arm64", "20.04", "released", "disk1.img", newTestDataSourceFunc(ts.URL))
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(got, jc.DeepEquals, &Metadata{
-		Arch:    "ppc64el",
-		Release: "16.04",
-		Version: "16.04",
+		Arch:    "arm64",
+		Release: "focal",
+		Version: "20.04",
 		FType:   "disk1.img",
-		SHA256:  "787b16d29faaa1cf2c90b7beb1a98b1e1b990fb6a5beae47c6d6f09120ed49e8",
-		Path:    "server/releases/xenial/release-20161020/ubuntu-16.04-server-cloudimg-ppc64el-disk1.img",
-		Size:    320012288,
+		SHA256:  "b8176161962c4f54e59366444bb696e92406823f643ed7bdcdd3d15d38dc0d53",
+		Path:    "server/releases/focal/release-20221003/ubuntu-20.04-server-cloudimg-arm64.img",
+		Size:    569901056,
 	})
 }
 
-func (Suite) TestOneErrors(c *gc.C) {
+func (*Suite) TestOneErrors(c *gc.C) {
 	ss := simplestreams.NewSimpleStreams(streamstesting.TestDataSourceFactory())
 	table := []struct {
 		description, arch, version, stream, ftype, errorMatch string
@@ -267,7 +265,7 @@ func (Suite) TestOneErrors(c *gc.C) {
 		{"empty ftype", "ppc64el", "20.04", "", "", `invalid parameters supplied ftype=""`},
 		{"invalid file type", "amd64", "22.04", "", "tragedy", `invalid parameters supplied ftype="tragedy"`},
 		{"all wrong except stream", "a", "t", "", "y", `invalid parameters supplied arch="a" version="t" ftype="y"`},
-		{"stream not found", "amd64", "22.04", "hourly", "disk1.img", `no results for "amd64", "jammy", "hourly", "disk1.img"`},
+		{"stream not found", "amd64", "22.04", "hourly", "disk1.img", `no results for "amd64", "22.04", "hourly", "disk1.img"`},
 	}
 	ts := httptest.NewServer(&sstreamsHandler{})
 	defer ts.Close()

--- a/environs/imagedownloads/testdata/index.sjson
+++ b/environs/imagedownloads/testdata/index.sjson
@@ -3,511 +3,932 @@ Hash: SHA512
 
 {
  "index": {
-  "com.ubuntu.cloud:released:download": {
-   "datatype": "image-downloads", 
-   "path": "streams/v1/com.ubuntu.cloud:released:download.sjson", 
-   "updated": "Fri, 04 Nov 2016 03:33:58 +0000", 
+  "com.ubuntu.cloud:released:joyent": {
+   "updated": "Mon, 16 Jul 2018 14:14:22 +0000",
+   "clouds": [
+    {
+     "region": "eu-ams-1",
+     "endpoint": "https://eu-ams-1.api.joyentcloud.com"
+    },
+    {
+     "region": "us-sw-1",
+     "endpoint": "https://us-sw-1.api.joyentcloud.com"
+    },
+    {
+     "region": "us-east-3",
+     "endpoint": "https://us-east-3.api.joyentcloud.com"
+    },
+    {
+     "region": "us-east-2",
+     "endpoint": "https://us-east-2.api.joyentcloud.com"
+    },
+    {
+     "region": "us-east-1",
+     "endpoint": "https://us-east-1.api.joyentcloud.com"
+    },
+    {
+     "region": "us-west-1",
+     "endpoint": "https://us-west-1.api.joyentcloud.com"
+    }
+   ],
+   "cloudname": "joyent",
+   "datatype": "image-ids",
+   "format": "products:1.0",
    "products": [
-    "com.ubuntu.cloud:server:15.04:arm64", 
-    "com.ubuntu.cloud:server:13.04:amd64", 
-    "com.ubuntu.cloud:server:15.04:ppc64el", 
-    "com.ubuntu.cloud:server:14.04:i386", 
-    "com.ubuntu.cloud:server:15.04:amd64", 
-    "com.ubuntu.cloud:server:10.04:amd64", 
-    "com.ubuntu.cloud:server:16.10:s390x", 
-    "com.ubuntu.cloud:server:14.10:arm64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:16.04:ppc64el", 
-    "com.ubuntu.cloud:server:15.10:armhf", 
-    "com.ubuntu.cloud:server:15.10:i386", 
-    "com.ubuntu.cloud:server:15.10:arm64", 
-    "com.ubuntu.cloud:server:13.10:amd64", 
-    "com.ubuntu.cloud:server:12.10:i386", 
-    "com.ubuntu.cloud:server:14.04:armhf", 
-    "com.ubuntu.cloud:server:16.10:powerpc", 
-    "com.ubuntu.cloud:server:16.10:amd64", 
-    "com.ubuntu.cloud:server:12.10:amd64", 
-    "com.ubuntu.cloud:server:13.04:i386", 
-    "com.ubuntu.cloud:server:14.10:ppc64el", 
-    "com.ubuntu.cloud:server:16.04:powerpc", 
-    "com.ubuntu.cloud:server:16.10:i386", 
-    "com.ubuntu.cloud:server:15.10:ppc64el", 
-    "com.ubuntu.cloud:server:12.04:i386", 
-    "com.ubuntu.cloud:server:16.10:arm64", 
-    "com.ubuntu.cloud:server:13.10:i386", 
-    "com.ubuntu.cloud:server:16.10:armhf", 
-    "com.ubuntu.cloud:server:12.04:armhf", 
-    "com.ubuntu.cloud:server:14.10:armhf", 
-    "com.ubuntu.cloud:server:13.04:armhf", 
-    "com.ubuntu.cloud:server:11.10:amd64", 
-    "com.ubuntu.cloud:server:11.10:armel", 
-    "com.ubuntu.cloud:server:16.04:armhf", 
-    "com.ubuntu.cloud:server:14.10:i386", 
-    "com.ubuntu.cloud:server:15.10:amd64", 
-    "com.ubuntu.cloud:server:12.10:armhf", 
-    "com.ubuntu.cloud:server:15.04:armhf", 
-    "com.ubuntu.cloud:server:16.10:ppc64el", 
-    "com.ubuntu.cloud:server:13.10:armhf", 
-    "com.ubuntu.cloud:server:14.04:arm64", 
-    "com.ubuntu.cloud:server:16.04:s390x", 
-    "com.ubuntu.cloud:server:16.04:amd64", 
-    "com.ubuntu.cloud:server:10.04:i386", 
-    "com.ubuntu.cloud:server:15.04:i386", 
-    "com.ubuntu.cloud:server:16.04:arm64", 
-    "com.ubuntu.cloud:server:14.04:ppc64el", 
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:16.04:i386", 
-    "com.ubuntu.cloud:server:11.10:i386", 
+    "com.ubuntu.cloud:server:13.10:amd64",
+    "com.ubuntu.cloud:server:15.10:amd64",
+    "com.ubuntu.cloud:server:13.04:amd64",
+    "com.ubuntu.cloud:server:16.04:amd64",
+    "com.ubuntu.cloud:server:15.04:amd64",
+    "com.ubuntu.cloud:server:16.10:amd64",
+    "com.ubuntu.cloud:server:14.04:amd64",
+    "com.ubuntu.cloud:server:17.04:amd64",
+    "com.ubuntu.cloud:server:12.04:amd64",
+    "com.ubuntu.cloud:server:17.10:amd64",
     "com.ubuntu.cloud:server:14.10:amd64"
-   ], 
+   ],
+   "path": "streams/v1/com.ubuntu.cloud:released:joyent.sjson"
+  },
+  "com.ubuntu.cloud:released:download": {
+   "datatype": "image-downloads",
+   "path": "streams/v1/com.ubuntu.cloud:released:download.sjson",
+   "updated": "Fri, 07 Oct 2022 03:09:23 +0000",
+   "products": [
+    "com.ubuntu.cloud:server:19.10:s390x",
+    "com.ubuntu.cloud:server:20.04:arm64",
+    "com.ubuntu.cloud:server:19.04:armhf",
+    "com.ubuntu.cloud:server:15.10:arm64",
+    "com.ubuntu.cloud:server:14.04:armhf",
+    "com.ubuntu.cloud:server:20.10:ppc64el",
+    "com.ubuntu.cloud:server:17.04:arm64",
+    "com.ubuntu.cloud:server:12.10:amd64",
+    "com.ubuntu.cloud:server:14.10:ppc64el",
+    "com.ubuntu.cloud:server:16.10:i386",
+    "com.ubuntu.cloud:server:15.10:ppc64el",
+    "com.ubuntu.cloud:server:12.04:i386",
+    "com.ubuntu.cloud:server:22.04:ppc64el",
+    "com.ubuntu.cloud:server:21.10:riscv64",
+    "com.ubuntu.cloud:server:14.10:armhf",
+    "com.ubuntu.cloud:server:20.04:s390x",
+    "com.ubuntu.cloud:server:20.10:armhf",
+    "com.ubuntu.cloud:server:21.04:ppc64el",
+    "com.ubuntu.cloud:server:15.10:amd64",
+    "com.ubuntu.cloud:server:16.04:arm64",
+    "com.ubuntu.cloud:server:17.10:i386",
+    "com.ubuntu.cloud:server:19.10:ppc64el",
+    "com.ubuntu.cloud:server:18.10:amd64",
+    "com.ubuntu.cloud:server:22.04:s390x",
+    "com.ubuntu.cloud:server:15.04:arm64",
+    "com.ubuntu.cloud:server:15.04:ppc64el",
+    "com.ubuntu.cloud:server:10.04:amd64",
+    "com.ubuntu.cloud:server:16.10:s390x",
+    "com.ubuntu.cloud:server:14.10:arm64",
+    "com.ubuntu.cloud:server:19.10:i386",
+    "com.ubuntu.cloud:server:17.04:amd64",
+    "com.ubuntu.cloud:server:18.10:armhf",
+    "com.ubuntu.cloud:server:19.04:s390x",
+    "com.ubuntu.cloud:server:13.10:amd64",
+    "com.ubuntu.cloud:server:12.10:i386",
+    "com.ubuntu.cloud:server:18.10:s390x",
+    "com.ubuntu.cloud:server:17.04:ppc64el",
+    "com.ubuntu.cloud:server:13.04:i386",
+    "com.ubuntu.cloud:server:17.10:ppc64el",
+    "com.ubuntu.cloud:server:18.04:arm64",
+    "com.ubuntu.cloud:server:13.10:i386",
+    "com.ubuntu.cloud:server:16.10:armhf",
+    "com.ubuntu.cloud:server:11.10:amd64",
+    "com.ubuntu.cloud:server:18.10:i386",
+    "com.ubuntu.cloud:server:16.04:armhf",
+    "com.ubuntu.cloud:server:21.10:amd64",
+    "com.ubuntu.cloud:server:16.10:ppc64el",
+    "com.ubuntu.cloud:server:16.04:s390x",
+    "com.ubuntu.cloud:server:11.10:i386",
+    "com.ubuntu.cloud:server:15.04:amd64",
+    "com.ubuntu.cloud:server:18.04:ppc64el",
+    "com.ubuntu.cloud:server:19.10:armhf",
+    "com.ubuntu.cloud:server:16.04:ppc64el",
+    "com.ubuntu.cloud:server:19.04:arm64",
+    "com.ubuntu.cloud:server:21.10:s390x",
+    "com.ubuntu.cloud:server:17.04:i386",
+    "com.ubuntu.cloud:server:16.10:powerpc",
+    "com.ubuntu.cloud:server:16.10:amd64",
+    "com.ubuntu.cloud:server:17.10:arm64",
+    "com.ubuntu.cloud:server:20.04:armhf",
+    "com.ubuntu.cloud:server:21.04:amd64",
+    "com.ubuntu.cloud:server:17.10:s390x",
+    "com.ubuntu.cloud:server:21.10:ppc64el",
+    "com.ubuntu.cloud:server:20.04:ppc64el",
+    "com.ubuntu.cloud:server:18.04:s390x",
+    "com.ubuntu.cloud:server:22.04:riscv64",
+    "com.ubuntu.cloud:server:14.10:i386",
+    "com.ubuntu.cloud:server:12.10:armhf",
+    "com.ubuntu.cloud:server:17.04:armhf",
+    "com.ubuntu.cloud:server:14.04:arm64",
+    "com.ubuntu.cloud:server:16.04:amd64",
+    "com.ubuntu.cloud:server:20.10:s390x",
+    "com.ubuntu.cloud:server:20.04:amd64",
+    "com.ubuntu.cloud:server:22.04:arm64",
+    "com.ubuntu.cloud:server:16.04:i386",
+    "com.ubuntu.cloud:server:15.04:armhf",
+    "com.ubuntu.cloud:server:13.04:amd64",
+    "com.ubuntu.cloud:server:14.04:i386",
+    "com.ubuntu.cloud:server:20.10:amd64",
+    "com.ubuntu.cloud:server:19.04:i386",
+    "com.ubuntu.cloud:server:14.04:amd64",
+    "com.ubuntu.cloud:server:15.04:i386",
+    "com.ubuntu.cloud:server:15.10:armhf",
+    "com.ubuntu.cloud:server:15.10:i386",
+    "com.ubuntu.cloud:server:21.10:arm64",
+    "com.ubuntu.cloud:server:17.10:amd64",
+    "com.ubuntu.cloud:server:21.04:armhf",
+    "com.ubuntu.cloud:server:19.04:ppc64el",
+    "com.ubuntu.cloud:server:17.04:s390x",
+    "com.ubuntu.cloud:server:19.04:amd64",
+    "com.ubuntu.cloud:server:10.04:i386",
+    "com.ubuntu.cloud:server:21.10:armhf",
+    "com.ubuntu.cloud:server:16.04:powerpc",
+    "com.ubuntu.cloud:server:22.04:armhf",
+    "com.ubuntu.cloud:server:20.10:arm64",
+    "com.ubuntu.cloud:server:16.10:arm64",
+    "com.ubuntu.cloud:server:18.04:i386",
+    "com.ubuntu.cloud:server:12.04:armhf",
+    "com.ubuntu.cloud:server:13.04:armhf",
+    "com.ubuntu.cloud:server:18.10:arm64",
+    "com.ubuntu.cloud:server:11.10:armel",
+    "com.ubuntu.cloud:server:19.10:arm64",
+    "com.ubuntu.cloud:server:18.04:amd64",
+    "com.ubuntu.cloud:server:13.10:armhf",
+    "com.ubuntu.cloud:server:21.04:arm64",
+    "com.ubuntu.cloud:server:19.10:amd64",
+    "com.ubuntu.cloud:server:21.04:s390x",
+    "com.ubuntu.cloud:server:14.04:ppc64el",
+    "com.ubuntu.cloud:server:17.10:armhf",
+    "com.ubuntu.cloud:server:12.04:amd64",
+    "com.ubuntu.cloud:server:18.10:ppc64el",
+    "com.ubuntu.cloud:server:18.04:armhf",
+    "com.ubuntu.cloud:server:14.10:amd64",
+    "com.ubuntu.cloud:server:22.04:amd64"
+   ],
    "format": "products:1.0"
-  }, 
-  "com.ubuntu.cloud:released:rax": {
-   "updated": "Fri, 04 Nov 2016 03:12:05 +0000", 
-   "clouds": [
-    {
-     "region": "IAD", 
-     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
-    }, 
-    {
-     "region": "DFW", 
-     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
-    }, 
-    {
-     "region": "SYD", 
-     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
-    }, 
-    {
-     "region": "HKG", 
-     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
-    }, 
-    {
-     "region": "ORD", 
-     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
-    }
-   ], 
-   "cloudname": "rax", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
-   "products": [
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:16.04:amd64"
-   ], 
-   "path": "streams/v1/com.ubuntu.cloud:released:rax.sjson"
-  }, 
-  "com.brightbox:official": {
-   "updated": "Thu, 03 Nov 2016 07:58:46 +0000", 
-   "clouds": [
-    {
-     "region": "gb1", 
-     "endpoint": "https://api.gb1.brightbox.com"
-    }
-   ], 
-   "cloudname": "brightbox", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
-   "products": [
-    "com.ubuntu.cloud:server:16.10:i386", 
-    "com.ubuntu.cloud:server:12.04:i386", 
-    "com.ubuntu.cloud:server:14.04:i386", 
-    "com.ubuntu.cloud.snappy:core:rolling:edge:amd64", 
-    "com.ubuntu.cloud:server:16.04:amd64", 
-    "com.ubuntu.cloud:server:16.10:amd64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:16.04:i386"
-   ], 
-   "path": "streams/v1/com.brightbox:official.sjson"
-  }, 
+  },
   "com.ubuntu.cloud:released:hpcloud": {
-   "updated": "Fri, 17 Jul 2015 23:16:55 +0000", 
+   "updated": "Fri, 17 Jul 2015 23:16:55 +0000",
    "clouds": [
     {
-     "region": "region-b.geo-1", 
+     "region": "region-b.geo-1",
      "endpoint": "https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/"
-    }, 
+    },
     {
-     "region": "region-a.geo-1", 
+     "region": "region-a.geo-1",
      "endpoint": "https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/"
     }
-   ], 
-   "cloudname": "hpcloud", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
+   ],
+   "cloudname": "hpcloud",
+   "datatype": "image-ids",
+   "format": "products:1.0",
    "products": [
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:12.10:amd64", 
-    "com.ubuntu.cloud:server:15.04:amd64", 
+    "com.ubuntu.cloud:server:12.04:amd64",
+    "com.ubuntu.cloud:server:14.04:amd64",
+    "com.ubuntu.cloud:server:12.10:amd64",
+    "com.ubuntu.cloud:server:15.04:amd64",
     "com.ubuntu.cloud:server:14.10:amd64"
-   ], 
+   ],
    "path": "streams/v1/com.ubuntu.cloud:released:hpcloud.sjson"
-  }, 
-  "com.ubuntu.cloud:released:azure": {
-   "updated": "Tue, 01 Nov 2016 18:54:59 +0000", 
+  },
+  "com.ubuntu.cloud:released:rax": {
+   "updated": "Wed, 29 Apr 2020 21:11:13 +0000",
    "clouds": [
     {
-     "region": "East US 2", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
+     "region": "SYD",
+     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
+    },
     {
-     "region": "UK South 2", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
+     "region": "IAD",
+     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
+    },
     {
-     "region": "Central India", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
+     "region": "DFW",
+     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
+    },
     {
-     "region": "Central US", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
+     "region": "LON",
+     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
+    },
     {
-     "region": "West US", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
+     "region": "ORD",
+     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
+    },
     {
-     "region": "UK North", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Australia East", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "North Central US", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "South India", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Korea Central", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Korea South", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "South Central US", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "East US", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "China East", 
-     "endpoint": "https://management.core.chinacloudapi.cn/"
-    }, 
-    {
-     "region": "Central US EUAP", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Canada Central", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Brazil South", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "West Europe", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Canada East", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "West India", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "East US 2 EUAP", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Japan West", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "East Asia", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Southeast Asia", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Australia Southeast", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "UK South", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "West US 2", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "China North", 
-     "endpoint": "https://management.core.chinacloudapi.cn/"
-    }, 
-    {
-     "region": "North Europe", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "UK West", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "Japan East", 
-     "endpoint": "https://management.core.windows.net/"
-    }, 
-    {
-     "region": "West Central US", 
-     "endpoint": "https://management.core.windows.net/"
+     "region": "HKG",
+     "endpoint": "https://identity.api.rackspacecloud.com/v2.0/"
     }
-   ], 
-   "cloudname": "azure", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
+   ],
+   "cloudname": "rax",
+   "datatype": "image-ids",
+   "format": "products:1.0",
+   "products": [],
+   "path": "streams/v1/com.ubuntu.cloud:released:rax.sjson"
+  },
+  "com.brightbox:official": {
+   "updated": "Fri, 07 Oct 2022 06:58:48 +0000",
+   "clouds": [
+    {
+     "region": "gb1",
+     "endpoint": "https://api.gb1.brightbox.com"
+    }
+   ],
+   "cloudname": "brightbox",
+   "datatype": "image-ids",
+   "format": "products:1.0",
    "products": [
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:16.04:amd64", 
-    "com.ubuntu.cloud:server:14.10:amd64", 
-    "com.ubuntu.cloud:server:16.10:amd64"
-   ], 
-   "path": "streams/v1/com.ubuntu.cloud:released:azure.sjson"
-  }, 
+    "com.ubuntu.cloud:server:18.04:amd64",
+    "com.ubuntu.cloud:server:14.04:i386",
+    "com.ubuntu.cloud:server:18.04:i386",
+    "com.ubuntu.cloud:server:16.04:amd64",
+    "com.ubuntu.cloud:server:14.04:amd64",
+    "com.ubuntu.cloud:server:20.04:amd64",
+    "com.ubuntu.cloud:server:16.04:i386",
+    "com.ubuntu.cloud:server:22.04:amd64"
+   ],
+   "path": "streams/v1/com.brightbox:official.sjson"
+  },
+  "com.ubuntu.cloud:released:aws": {
+   "updated": "Fri, 07 Oct 2022 03:15:37 +0000",
+   "clouds": [
+    {
+     "region": "ap-east-1",
+     "endpoint": "https://ec2.ap-east-1.amazonaws.com"
+    },
+    {
+     "region": "ap-northeast-3",
+     "endpoint": "https://ec2.ap-northeast-3.amazonaws.com"
+    },
+    {
+     "region": "us-east-1",
+     "endpoint": "https://ec2.us-east-1.amazonaws.com"
+    },
+    {
+     "region": "ap-northeast-1",
+     "endpoint": "https://ec2.ap-northeast-1.amazonaws.com"
+    },
+    {
+     "region": "eu-north-1",
+     "endpoint": "https://ec2.eu-north-1.amazonaws.com"
+    },
+    {
+     "region": "ap-northeast-2",
+     "endpoint": "https://ec2.ap-northeast-2.amazonaws.com"
+    },
+    {
+     "region": "us-west-2",
+     "endpoint": "https://ec2.us-west-2.amazonaws.com"
+    },
+    {
+     "region": "us-west-1",
+     "endpoint": "https://ec2.us-west-1.amazonaws.com"
+    },
+    {
+     "region": "us-east-2",
+     "endpoint": "https://ec2.us-east-2.amazonaws.com"
+    },
+    {
+     "region": "af-south-1",
+     "endpoint": "https://ec2.af-south-1.amazonaws.com"
+    },
+    {
+     "region": "ap-southeast-1",
+     "endpoint": "https://ec2.ap-southeast-1.amazonaws.com"
+    },
+    {
+     "region": "ap-southeast-3",
+     "endpoint": "https://ec2.ap-southeast-3.amazonaws.com"
+    },
+    {
+     "region": "ap-southeast-2",
+     "endpoint": "https://ec2.ap-southeast-2.amazonaws.com"
+    },
+    {
+     "region": "ap-south-1",
+     "endpoint": "https://ec2.ap-south-1.amazonaws.com"
+    },
+    {
+     "region": "eu-west-1",
+     "endpoint": "https://ec2.eu-west-1.amazonaws.com"
+    },
+    {
+     "region": "eu-west-2",
+     "endpoint": "https://ec2.eu-west-2.amazonaws.com"
+    },
+    {
+     "region": "eu-west-3",
+     "endpoint": "https://ec2.eu-west-3.amazonaws.com"
+    },
+    {
+     "region": "eu-south-1",
+     "endpoint": "https://ec2.eu-south-1.amazonaws.com"
+    },
+    {
+     "region": "ca-central-1",
+     "endpoint": "https://ec2.ca-central-1.amazonaws.com"
+    },
+    {
+     "region": "me-central-1",
+     "endpoint": "https://ec2.me-central-1.amazonaws.com"
+    },
+    {
+     "region": "me-south-1",
+     "endpoint": "https://ec2.me-south-1.amazonaws.com"
+    },
+    {
+     "region": "eu-central-1",
+     "endpoint": "https://ec2.eu-central-1.amazonaws.com"
+    },
+    {
+     "region": "sa-east-1",
+     "endpoint": "https://ec2.sa-east-1.amazonaws.com"
+    }
+   ],
+   "cloudname": "aws",
+   "datatype": "image-ids",
+   "format": "products:1.0",
+   "products": [
+    "com.ubuntu.cloud:server:13.04:amd64",
+    "com.ubuntu.cloud:server:14.04:i386",
+    "com.ubuntu.cloud:server:20.04:arm64",
+    "com.ubuntu.cloud:server:20.10:amd64",
+    "com.ubuntu.cloud:server:15.04:amd64",
+    "com.ubuntu.cloud:server:10.04:amd64",
+    "com.ubuntu.cloud:server:14.04:amd64",
+    "com.ubuntu.cloud:server:15.04:i386",
+    "com.ubuntu.cloud:server:17.04:amd64",
+    "com.ubuntu.cloud:server:21.10:arm64",
+    "com.ubuntu.cloud:server:17.10:amd64",
+    "com.ubuntu.cloud:server:19.04:arm64",
+    "com.ubuntu.cloud:server:13.10:amd64",
+    "com.ubuntu.cloud:server:12.10:i386",
+    "com.ubuntu.cloud:server:16.10:amd64",
+    "com.ubuntu.cloud:server:19.04:amd64",
+    "com.ubuntu.cloud:server:10.04:i386",
+    "com.ubuntu.cloud:server:13.04:i386",
+    "com.ubuntu.cloud:server:14.10:i386",
+    "com.ubuntu.cloud:server:21.04:amd64",
+    "com.ubuntu.cloud:server:20.10:arm64",
+    "com.ubuntu.cloud:server:12.04:i386",
+    "com.ubuntu.cloud:server:13.10:i386",
+    "com.ubuntu.cloud:server:21.04:arm64",
+    "com.ubuntu.cloud:server:18.10:arm64",
+    "com.ubuntu.cloud:server:11.10:amd64",
+    "com.ubuntu.cloud:server:19.10:arm64",
+    "com.ubuntu.cloud:server:12.10:amd64",
+    "com.ubuntu.cloud:server:15.10:amd64",
+    "com.ubuntu.cloud:server:21.10:amd64",
+    "com.ubuntu.cloud:server:18.04:amd64",
+    "com.ubuntu.cloud:server:16.04:arm64",
+    "com.ubuntu.cloud:server:18.10:amd64",
+    "com.ubuntu.cloud:server:16.04:amd64",
+    "com.ubuntu.cloud:server:19.10:amd64",
+    "com.ubuntu.cloud:server:20.04:amd64",
+    "com.ubuntu.cloud:server:18.04:arm64",
+    "com.ubuntu.cloud:server:22.04:arm64",
+    "com.ubuntu.cloud:server:12.04:amd64",
+    "com.ubuntu.cloud:server:11.10:i386",
+    "com.ubuntu.cloud:server:14.10:amd64",
+    "com.ubuntu.cloud:server:22.04:amd64"
+   ],
+   "path": "streams/v1/com.ubuntu.cloud:released:aws.sjson"
+  },
   "com.ubuntu.cloud:released:aws-govcloud": {
-   "updated": "Sat, 22 Oct 2016 19:05:46 +0000", 
+   "updated": "Wed, 17 Aug 2022 20:49:57 +0000",
    "clouds": [
     {
-     "region": "us-gov-west-1", 
-     "endpoint": "https://ec2.us-gov-west-1.amazonaws-govcloud.com"
+     "region": "us-gov-west-1",
+     "endpoint": "https://ec2.us-gov-west-1.amazonaws.com"
+    },
+    {
+     "region": "us-gov-east-1",
+     "endpoint": "https://ec2.us-gov-east-1.amazonaws.com"
     }
-   ], 
-   "cloudname": "aws-govcloud", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
+   ],
+   "cloudname": "aws-govcloud",
+   "datatype": "image-ids",
+   "format": "products:1.0",
    "products": [
-    "com.ubuntu.cloud:server:13.10:amd64", 
-    "com.ubuntu.cloud:server:15.10:amd64", 
-    "com.ubuntu.cloud:server:12.04:i386", 
-    "com.ubuntu.cloud:server:14.04:i386", 
-    "com.ubuntu.cloud:server:16.04:amd64", 
-    "com.ubuntu.cloud:server:13.10:i386", 
-    "com.ubuntu.cloud:server:10.04:amd64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:10.04:i386", 
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:14.10:amd64", 
-    "com.ubuntu.cloud:server:14.10:i386"
-   ], 
+    "com.ubuntu.cloud:server:14.04:i386",
+    "com.ubuntu.cloud:server:20.04:arm64",
+    "com.ubuntu.cloud:server:20.10:amd64",
+    "com.ubuntu.cloud:server:10.04:amd64",
+    "com.ubuntu.cloud:server:14.04:amd64",
+    "com.ubuntu.cloud:server:13.10:amd64",
+    "com.ubuntu.cloud:server:19.04:amd64",
+    "com.ubuntu.cloud:server:10.04:i386",
+    "com.ubuntu.cloud:server:21.04:amd64",
+    "com.ubuntu.cloud:server:20.10:arm64",
+    "com.ubuntu.cloud:server:12.04:i386",
+    "com.ubuntu.cloud:server:13.10:i386",
+    "com.ubuntu.cloud:server:21.04:arm64",
+    "com.ubuntu.cloud:server:14.10:i386",
+    "com.ubuntu.cloud:server:15.10:amd64",
+    "com.ubuntu.cloud:server:18.04:amd64",
+    "com.ubuntu.cloud:server:16.04:arm64",
+    "com.ubuntu.cloud:server:18.10:amd64",
+    "com.ubuntu.cloud:server:16.04:amd64",
+    "com.ubuntu.cloud:server:19.10:amd64",
+    "com.ubuntu.cloud:server:20.04:amd64",
+    "com.ubuntu.cloud:server:18.04:arm64",
+    "com.ubuntu.cloud:server:22.04:arm64",
+    "com.ubuntu.cloud:server:12.04:amd64",
+    "com.ubuntu.cloud:server:14.10:amd64",
+    "com.ubuntu.cloud:server:22.04:amd64"
+   ],
    "path": "streams/v1/com.ubuntu.cloud:released:aws-govcloud.sjson"
-  }, 
+  },
   "com.ubuntu.cloud:released:gce": {
-   "updated": "Thu, 20 Oct 2016 21:34:58 +0000", 
+   "updated": "Fri, 07 Oct 2022 08:50:02 +0000",
    "clouds": [
     {
-     "region": "asia-east1", 
+     "region": "europe-west1",
      "endpoint": "https://www.googleapis.com"
-    }, 
+    },
     {
-     "region": "europe-west1", 
+     "region": "us-west3",
      "endpoint": "https://www.googleapis.com"
-    }, 
+    },
     {
-     "region": "us-east1", 
+     "region": "us-south1",
      "endpoint": "https://www.googleapis.com"
-    }, 
+    },
     {
-     "region": "us-central1", 
+     "region": "europe-southwest1",
      "endpoint": "https://www.googleapis.com"
-    }, 
+    },
     {
-     "region": "us-west1", 
+     "region": "asia-east2",
      "endpoint": "https://www.googleapis.com"
-    }, 
+    },
     {
-     "region": "asia-northeast1", 
+     "region": "asia-east1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "europe-north1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "us-central1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "southamerica-west1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "asia-southeast1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "asia-southeast2",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "australia-southeast2",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "australia-southeast1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "me-west1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "us-west4",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "asia-south1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "us-west1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "us-west2",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "asia-south2",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "asia-northeast2",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "asia-northeast3",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "asia-northeast1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "europe-central2",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "europe-west8",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "europe-west9",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "europe-west2",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "europe-west3",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "us-east4",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "us-east5",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "europe-west6",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "europe-west4",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "us-east1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "northamerica-northeast1",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "northamerica-northeast2",
+     "endpoint": "https://www.googleapis.com"
+    },
+    {
+     "region": "southamerica-east1",
      "endpoint": "https://www.googleapis.com"
     }
-   ], 
-   "cloudname": "gce", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
+   ],
+   "cloudname": "gce",
+   "datatype": "image-ids",
+   "format": "products:1.0",
    "products": [
-    "com.ubuntu.cloud:server:15.10:amd64", 
-    "com.ubuntu.cloud:server:16.04:amd64", 
-    "com.ubuntu.cloud:server:15.04:amd64", 
-    "com.ubuntu.cloud:server:16.10:amd64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:14.10:amd64"
-   ], 
+    "com.ubuntu.cloud:server:15.10:amd64",
+    "com.ubuntu.cloud:server:21.10:amd64",
+    "com.ubuntu.cloud:server:18.04:amd64",
+    "com.ubuntu.cloud:server:18.10:amd64",
+    "com.ubuntu.cloud:server:20.10:amd64",
+    "com.ubuntu.cloud:server:22.04:arm64",
+    "com.ubuntu.cloud:server:16.04:amd64",
+    "com.ubuntu.cloud:server:15.04:amd64",
+    "com.ubuntu.cloud:server:19.10:amd64",
+    "com.ubuntu.cloud:server:16.10:amd64",
+    "com.ubuntu.cloud:server:19.04:amd64",
+    "com.ubuntu.cloud:server:14.04:amd64",
+    "com.ubuntu.cloud:server:20.04:arm64",
+    "com.ubuntu.cloud:server:20.04:amd64",
+    "com.ubuntu.cloud:server:18.04:arm64",
+    "com.ubuntu.cloud:server:17.04:amd64",
+    "com.ubuntu.cloud:server:12.04:amd64",
+    "com.ubuntu.cloud:server:21.04:amd64",
+    "com.ubuntu.cloud:server:17.10:amd64",
+    "com.ubuntu.cloud:server:14.10:amd64",
+    "com.ubuntu.cloud:server:22.04:amd64"
+   ],
    "path": "streams/v1/com.ubuntu.cloud:released:gce.sjson"
-  }, 
+  },
   "com.ubuntu.cloud:released:cloudsigma": {
-   "updated": "Fri, 04 Nov 2016 03:09:55 +0000", 
+   "updated": "Tue, 02 Jan 2018 10:08:53 +0000",
    "clouds": [
     {
-     "region": "zrh", 
+     "region": "zrh",
      "endpoint": "https://zrh.cloudsigma.com/"
-    }, 
+    },
     {
-     "region": "mia", 
+     "region": "mia",
      "endpoint": "https://mia.cloudsigma.com/"
-    }, 
+    },
     {
-     "region": "sjc", 
+     "region": "sjc",
      "endpoint": "https://sjc.cloudsigma.com/"
-    }, 
+    },
     {
-     "region": "wdc", 
+     "region": "wdc",
      "endpoint": "https://wdc.cloudsigma.com/"
     }
-   ], 
-   "cloudname": "cloudsigma", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
+   ],
+   "cloudname": "cloudsigma",
+   "datatype": "image-ids",
+   "format": "products:1.0",
    "products": [
-    "com.ubuntu.cloud:server:15.10:amd64", 
-    "com.ubuntu.cloud:server:16.04:amd64", 
-    "com.ubuntu.cloud:server:15.04:amd64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:14.10:amd64"
-   ], 
+    "com.ubuntu.cloud:server:15.10:amd64"
+   ],
    "path": "streams/v1/com.ubuntu.cloud:released:cloudsigma.sjson"
-  }, 
-  "com.ubuntu.cloud:released:aws": {
-   "updated": "Fri, 04 Nov 2016 03:34:00 +0000", 
+  },
+  "com.ubuntu.cloud:released:azure": {
+   "updated": "Fri, 07 Oct 2022 06:32:08 +0000",
    "clouds": [
     {
-     "region": "ap-south-1", 
-     "endpoint": "https://ec2.ap-south-1.amazonaws.com"
-    }, 
+     "region": "Germany North",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "us-east-1", 
-     "endpoint": "https://ec2.us-east-1.amazonaws.com"
-    }, 
+     "region": "France Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "ap-northeast-1", 
-     "endpoint": "https://ec2.ap-northeast-1.amazonaws.com"
-    }, 
+     "region": "Jio India Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "eu-west-1", 
-     "endpoint": "https://ec2.eu-west-1.amazonaws.com"
-    }, 
+     "region": "East US 2",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "ap-northeast-2", 
-     "endpoint": "https://ec2.ap-northeast-2.amazonaws.com"
-    }, 
+     "region": "China North 2",
+     "endpoint": "https://management.core.chinacloudapi.cn/"
+    },
     {
-     "region": "ap-southeast-1", 
-     "endpoint": "https://ec2.ap-southeast-1.amazonaws.com"
-    }, 
+     "region": "Central India",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "ap-southeast-2", 
-     "endpoint": "https://ec2.ap-southeast-2.amazonaws.com"
-    }, 
+     "region": "Jio India West",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "us-west-2", 
-     "endpoint": "https://ec2.us-west-2.amazonaws.com"
-    }, 
+     "region": "Australia Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "us-west-1", 
-     "endpoint": "https://ec2.us-west-1.amazonaws.com"
-    }, 
+     "region": "Qatar Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "eu-central-1", 
-     "endpoint": "https://ec2.eu-central-1.amazonaws.com"
-    }, 
+     "region": "Central US",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "sa-east-1", 
-     "endpoint": "https://ec2.sa-east-1.amazonaws.com"
-    }, 
+     "region": "West US",
+     "endpoint": "https://management.core.windows.net/"
+    },
     {
-     "region": "us-east-2", 
-     "endpoint": "https://ec2.us-east-2.amazonaws.com"
+     "region": "South Africa North",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "UK South",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "South India",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Korea Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Korea South",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Sweden South",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Sweden Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "UAE North",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "South Central US",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "South Africa West",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "China East 2",
+     "endpoint": "https://management.core.chinacloudapi.cn/"
+    },
+    {
+     "region": "East US",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "China East",
+     "endpoint": "https://management.core.chinacloudapi.cn/"
+    },
+    {
+     "region": "Germany West Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "UAE Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Central US EUAP",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Brazil Southeast",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Canada Central",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Switzerland West",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Brazil South",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "West Europe",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Australia Central 2",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Canada East",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Norway West",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "UK West",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "East US 2 EUAP",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Norway East",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "France South",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Japan West",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "East Asia",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Southeast Asia",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Australia Southeast",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Australia East",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "West US 2",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "West US 3",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "China North",
+     "endpoint": "https://management.core.chinacloudapi.cn/"
+    },
+    {
+     "region": "North Europe",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "North Central US",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Japan East",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "West India",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "West Central US",
+     "endpoint": "https://management.core.windows.net/"
+    },
+    {
+     "region": "Switzerland North",
+     "endpoint": "https://management.core.windows.net/"
     }
-   ], 
-   "cloudname": "aws", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
+   ],
+   "cloudname": "azure",
+   "datatype": "image-ids",
+   "format": "products:1.0",
    "products": [
-    "com.ubuntu.cloud:server:13.10:amd64", 
-    "com.ubuntu.cloud:server:15.10:amd64", 
-    "com.ubuntu.cloud:server:13.04:amd64", 
-    "com.ubuntu.cloud:server:12.10:i386", 
-    "com.ubuntu.cloud:server:12.04:i386", 
-    "com.ubuntu.cloud:server:14.04:i386", 
-    "com.ubuntu.cloud:server:16.04:amd64", 
-    "com.ubuntu.cloud:server:13.10:i386", 
-    "com.ubuntu.cloud:server:10.04:amd64", 
-    "com.ubuntu.cloud:server:15.04:amd64", 
-    "com.ubuntu.cloud:server:10.04:i386", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:12.10:amd64", 
-    "com.ubuntu.cloud:server:13.04:i386", 
-    "com.ubuntu.cloud:server:15.04:i386", 
-    "com.ubuntu.cloud:server:11.10:amd64", 
-    "com.ubuntu.cloud:server:11.10:i386", 
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:16.10:amd64", 
-    "com.ubuntu.cloud:server:14.10:amd64", 
-    "com.ubuntu.cloud:server:14.10:i386"
-   ], 
-   "path": "streams/v1/com.ubuntu.cloud:released:aws.sjson"
-  }, 
+    "com.ubuntu.cloud:server:21.10:amd64",
+    "com.ubuntu.cloud:server:18.04:amd64",
+    "com.ubuntu.cloud:server:16.04:amd64",
+    "com.ubuntu.cloud:server:19.10:amd64",
+    "com.ubuntu.cloud:server:19.04:amd64",
+    "com.ubuntu.cloud:server:14.04:amd64",
+    "com.ubuntu.cloud:server:20.04:amd64",
+    "com.ubuntu.cloud:server:12.04:amd64",
+    "com.ubuntu.cloud:server:21.04:amd64"
+   ],
+   "path": "streams/v1/com.ubuntu.cloud:released:azure.sjson"
+  },
   "com.ubuntu.cloud:released:aws-cn": {
-   "updated": "Sun, 23 Oct 2016 05:54:30 +0000", 
+   "updated": "Fri, 07 Oct 2022 08:29:52 +0000",
    "clouds": [
     {
-     "region": "cn-north-1", 
+     "region": "cn-north-1",
      "endpoint": "https://ec2.cn-north-1.amazonaws.com.cn"
+    },
+    {
+     "region": "cn-northwest-1",
+     "endpoint": "https://ec2.cn-northwest-1.amazonaws.com.cn"
     }
-   ], 
-   "cloudname": "aws-cn", 
-   "datatype": "image-ids", 
-   "format": "products:1.0", 
+   ],
+   "cloudname": "aws-cn",
+   "datatype": "image-ids",
+   "format": "products:1.0",
    "products": [
-    "com.ubuntu.cloud:server:13.10:amd64", 
-    "com.ubuntu.cloud:server:15.10:amd64", 
-    "com.ubuntu.cloud:server:12.04:i386", 
-    "com.ubuntu.cloud:server:14.04:i386", 
-    "com.ubuntu.cloud:server:16.04:amd64", 
-    "com.ubuntu.cloud:server:13.10:i386", 
-    "com.ubuntu.cloud:server:10.04:amd64", 
-    "com.ubuntu.cloud:server:15.04:amd64", 
-    "com.ubuntu.cloud:server:14.04:amd64", 
-    "com.ubuntu.cloud:server:10.04:i386", 
-    "com.ubuntu.cloud:server:12.04:amd64", 
-    "com.ubuntu.cloud:server:14.10:amd64", 
-    "com.ubuntu.cloud:server:14.10:i386"
-   ], 
+    "com.ubuntu.cloud:server:13.10:amd64",
+    "com.ubuntu.cloud:server:20.10:arm64",
+    "com.ubuntu.cloud:server:12.04:i386",
+    "com.ubuntu.cloud:server:18.04:amd64",
+    "com.ubuntu.cloud:server:14.04:i386",
+    "com.ubuntu.cloud:server:16.04:arm64",
+    "com.ubuntu.cloud:server:20.04:arm64",
+    "com.ubuntu.cloud:server:20.10:amd64",
+    "com.ubuntu.cloud:server:16.04:amd64",
+    "com.ubuntu.cloud:server:13.10:i386",
+    "com.ubuntu.cloud:server:10.04:amd64",
+    "com.ubuntu.cloud:server:21.04:arm64",
+    "com.ubuntu.cloud:server:10.04:i386",
+    "com.ubuntu.cloud:server:20.04:amd64",
+    "com.ubuntu.cloud:server:18.04:arm64",
+    "com.ubuntu.cloud:server:12.04:amd64",
+    "com.ubuntu.cloud:server:21.04:amd64",
+    "com.ubuntu.cloud:server:14.04:amd64"
+   ],
    "path": "streams/v1/com.ubuntu.cloud:released:aws-cn.sjson"
   }
- }, 
- "updated": "Fri, 04 Nov 2016 03:34:01 +0000", 
+ },
+ "updated": "Fri, 07 Oct 2022 08:51:10 +0000",
  "format": "index:1.0"
 }
 -----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.11 (GNU/Linux)
 
-iMcEAQEKADEWIQTSeSWdQWn1hD291Fy4re6pYHrq8AUCX2MV8hMcdGVzdEBzb21l
-d2hlcmUuY29tAAoJELit7qlgeurwYrMD/0Wa0YYsLPGsa8s/CanFrdnfwLyObnLY
-hBz2xZLx3DwMCLYSDxz8k1wV0LWNbubgJjXLEg6SEuN/FunewfvC4NPs2tQLW9Nx
-BgstHEEHs52/Pa+dtAaWIoAzPh7Spu73KIuii5Bvj3FDyYVYdN8LkerFG2YK01Oj
-5GvjhGpAEkjN
-=DrYm
+iQIcBAEBCgAGBQJjP+iAAAoJEH/z9AhHbPEAKMYP/A3x9hxV1p3xNKZGq5xXhFUt
+9y3FCYhs7n0v2UJbG77dKSmKH+RNfuUO6yDglQ4i8LtDtFdBcer97TzFQtdoXDtQ
+sLBedchc6yLGmXb9QtOZ6evQgsbwRDoUYFd8LAEJi8m8XvuVlzn1BtMMpGaed5Sq
+Xk/+WDQy8oBaRBlAaf/XXkbbEG+mOq/9Pg4ey5pJk67fEI3JOMpAMYzbfP15OdxJ
+EsBm8nHKX2zjAtKZZMcWn29TFmjkSNDI2ifEKRqQ4rVRzxlvx2dOddfSR5rapauM
+rz1dyoAmiPdzmn+unRKkakANEzpFTWbd9wrKFZ/oO5TKRnh14e1NW+Ht5+24srxc
+mQczi8y2W5qfuXff4hVcBpb7zq7m46j18i7oiu0kIIR42BES58BfZXWl+uQ3PnN1
+LEnuA1lpSOUnGcFGG7o4+6k5OVPwSFESJ8gHJ3KhL3uhxPF2m1+/oytkY7B5DwvZ
+aP8s5ej+SA5IrCwlGSRV/4jK3vDI3jVt/3Zi1qRongVc0/3h103qs4+1zpuHkzYJ
+4tvQWtlRJf/4K/xIpfaetnHIpx3C/BI36e9eFerfffSHc/ttr3cm1xX2peX6w1q4
+fTPpjMX+HSZytYwwyyzjr4Lhbx/2CfUkA8U1uFpooNw1vfsNysM4Kig4laDCCB49
+3XXFUfC7kYMos7mm+mVH
+=6zTp
 -----END PGP SIGNATURE-----


### PR DESCRIPTION
Merge from 2.9 to bring forward:
- #14711 from manadart/2.9-fix-kvm-image-selection
- #14598 from hpidcock/update-charm-v8

Conflicts (easily resolved) in:
- environs/imagedownloads/simplestreams_test.go
-  go.mod
-  go.sum
