### PR TITLE
upgrade-charm is replaced by refresh

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1476,7 +1476,7 @@ class ModelClient:
             args = args + ('--path', charm_path)
         if resvision is not None:
             args = args + ('--revision', resvision)
-        self.juju('upgrade-charm', args)
+        self.juju('refresh', args)
 
     def remove_application(self, service):
         self.juju('remove-application', (service,))

--- a/acceptancetests/jujupy/tests/test_client.py
+++ b/acceptancetests/jujupy/tests/test_client.py
@@ -1065,7 +1065,7 @@ class TestModelClient(ClientTest):
             env.upgrade_charm('foo-service',
                               '/bar/repository/angsty/mongodb')
         mock_juju.assert_called_once_with(
-            'upgrade-charm', ('foo-service', '--path',
+            'refresh', ('foo-service', '--path',
                               '/bar/repository/angsty/mongodb',))
 
     def test_remove_service(self):

--- a/cmd/juju/block/doc.go
+++ b/cmd/juju/block/doc.go
@@ -59,6 +59,6 @@ Commands that can be disabled are grouped based on logical operations as follows
     set-constraints
     sync-agents
     unexpose
-    upgrade-charm
+    refresh
     upgrade-model
 	`

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -123,7 +123,7 @@ run_deploy_lxd_to_machine() {
 	lxc profile show "juju-test-deploy-lxd-machine-lxd-profile-alt-0" |
 		grep -E "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"
 
-	juju upgrade-charm "lxd-profile-alt" --path "${charm}"
+	juju refresh "lxd-profile-alt" --path "${charm}"
 
 	# Ensure that an upgrade will be kicked off. This doesn't mean an upgrade
 	# has finished though, just started.
@@ -181,7 +181,7 @@ run_deploy_lxd_to_container() {
 	OUT=$(juju exec --machine 0 -- sh -c 'sudo lxc profile show "juju-test-deploy-lxd-container-lxd-profile-alt-0"')
 	echo "${OUT}" | grep -E "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"
 
-	juju upgrade-charm "lxd-profile-alt" --path "${charm}"
+	juju refresh "lxd-profile-alt" --path "${charm}"
 
 	# Ensure that an upgrade will be kicked off. This doesn't mean an upgrade
 	# has finished though, just started.

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -42,7 +42,7 @@ run_start_hook_fires_after_reboot() {
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
 	# Ensure that the implicit start hook does not fire after upgrading the unit
-	juju upgrade-charm ubuntu-lite --revision 10
+	juju refresh ubuntu-lite --revision 10
 	echo
 	sleep 1
 	wait_for "ubuntu-lite" "$(charm_rev "ubuntu-lite" 10)"

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -29,7 +29,7 @@ run_upgrade_charm_with_bind() {
 	assert_endpoint_binding_matches "space-defender" "defend-b" "isolated"
 
 	# Upgrade the space-defender charm and modify its bindings
-	juju upgrade-charm space-defender --bind "defend-a=alpha defend-b=alpha" --path ./testcharms/charms/space-defender
+	juju refresh space-defender --bind "defend-a=alpha defend-b=alpha" --path ./testcharms/charms/space-defender
 	wait_for "space-defender" "$(idle_condition "space-defender" 0 "${unit_index}")"
 
 	# After the upgrade, defend-a should remain attached to ens5 but

--- a/tests/suites/upgrade/streams.sh
+++ b/tests/suites/upgrade/streams.sh
@@ -124,7 +124,7 @@ exec_simplestream_metadata() {
 		fi
 	done
 
-	juju upgrade-charm ubuntu
+	juju refresh ubuntu
 
 	sleep 10
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"

--- a/worker/uniter/uniter_test.go
+++ b/worker/uniter/uniter_test.go
@@ -1520,7 +1520,7 @@ storage:
 			waitUniterDead{},
 		),
 		// TODO(axw) test that storage-attached is run for new
-		// storage attachments before upgrade-charm is run. This
+		// storage attachments before refresh is run. This
 		// requires additions to state to add storage when a charm
 		// is upgraded.
 	})


### PR DESCRIPTION
The upgrade-charm command is gone and replaced by refresh. Here we update the CI tests.
