### PR TITLE
disable upgrades from 2.9

### DIFF
--- a/state/collection_test.go
+++ b/state/collection_test.go
@@ -144,7 +144,7 @@ func (s *collectionSuite) TestModelStateCollection(c *gc.C) {
 	st1 := s.Factory.MakeModel(c, nil)
 	defer st1.Close()
 	f1 := factory.NewFactory(st1, s.StatePool)
-	otherM0 := f1.MakeMachine(c, &factory.MachineParams{Base: state.UbuntuBase("jammy")})
+	otherM0 := f1.MakeMachine(c, &factory.MachineParams{Base: state.UbuntuBase("22.04")})
 
 	// Ensure that the first machine in each model have overlapping ids
 	// (otherwise tests may not fail when they should)
@@ -170,7 +170,7 @@ func (s *collectionSuite) TestModelStateCollection(c *gc.C) {
 		{
 			label: "Find filters by model",
 			test: func() (int, error) {
-				return machines0.Find(bson.D{{"base", m0.Base()}}).Count()
+				return machines0.Find(bson.D{{"base.channel", m0.Base().Channel}}).Count()
 			},
 			expectedCount: 2,
 		},
@@ -312,7 +312,7 @@ func (s *collectionSuite) TestModelStateCollection(c *gc.C) {
 				// Attempt to remove the trusty machine in the second
 				// model with the collection that's filtering for the
 				// first model - nothing should get removed.
-				err := machines0.Writeable().Remove(bson.D{{"base", state.UbuntuBase("22.04")}})
+				err := machines0.Writeable().Remove(bson.D{{"base.channel", state.UbuntuBase("22.04").Channel}})
 				c.Assert(err, gc.ErrorMatches, "not found")
 				return s.machines.Count()
 			},

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -27,7 +27,8 @@ func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (boo
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
-	3: version.MustParse("2.9.36"),
+	// We don't support upgrading in place from 2.9 yet.
+	//3: version.MustParse("2.9.36"),
 }
 
 // UpgradeToAllowed returns true if a major version upgrade is allowed


### PR DESCRIPTION
Quick fix to disable upgrades from 2.9.
Plus a driveby cleanup of a state test.
