### PR TITLE
[JUJU-1962] Replace controller charm risk -> controller charm channel

### DIFF
--- a/cloudconfig/instancecfg/instancecfg.go
+++ b/cloudconfig/instancecfg/instancecfg.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/charm/v9"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -299,8 +300,8 @@ type StateInitializationParams struct {
 	// ControllerCharmPath points to a controller charm on Charmhub.
 	ControllerCharmPath string
 
-	// ControllerCharmRisk is used when deploying the controller charm.
-	ControllerCharmRisk string
+	// ControllerCharmChannel is used when deploying the controller charm.
+	ControllerCharmChannel charm.Channel
 
 	// ControllerInheritedConfig is a set of config attributes to be shared by all
 	// models managed by this controller.
@@ -364,7 +365,7 @@ type stateInitializationParamsInternal struct {
 	ControllerCloudCredentialName           string                            `yaml:"controller-cloud-credential-name,omitempty"`
 	ControllerCloudCredential               *cloud.Credential                 `yaml:"controller-cloud-credential,omitempty"`
 	ControllerCharmPath                     string                            `yaml:"controller-charm-path,omitempty"`
-	ControllerCharmRisk                     string                            `yaml:"controller-charm-risk,omitempty"`
+	ControllerCharmChannel                  charm.Channel                     `yaml:"controller-charm-channel,omitempty"`
 }
 
 // Marshal marshals StateInitializationParams to an opaque byte array.
@@ -396,7 +397,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		ControllerCloudCredentialName:           p.ControllerCloudCredentialName,
 		ControllerCloudCredential:               p.ControllerCloudCredential,
 		ControllerCharmPath:                     p.ControllerCharmPath,
-		ControllerCharmRisk:                     p.ControllerCharmRisk,
+		ControllerCharmChannel:                  p.ControllerCharmChannel,
 	}
 	return yaml.Marshal(&internal)
 }
@@ -439,7 +440,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		ControllerCloudCredentialName:           internal.ControllerCloudCredentialName,
 		ControllerCloudCredential:               internal.ControllerCloudCredential,
 		ControllerCharmPath:                     internal.ControllerCharmPath,
-		ControllerCharmRisk:                     internal.ControllerCharmRisk,
+		ControllerCharmChannel:                  internal.ControllerCharmChannel,
 	}
 	return nil
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2140,9 +2140,9 @@ func (s *BootstrapSuite) TestBootstrapWithLocalControllerCharm(c *gc.C) {
 	}
 }
 
-func (s *BootstrapSuite) TestBootstrapInvalidControllerCharmRisk(c *gc.C) {
-	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "--controller-charm-risk", "foo")
-	c.Assert(err, gc.ErrorMatches, `controller charm risk "foo" not valid`)
+func (s *BootstrapSuite) TestBootstrapInvalidControllerCharmChannel(c *gc.C) {
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "--controller-charm-channel", "3.0/foo")
+	c.Assert(err, gc.ErrorMatches, `controller charm channel "3.0/foo" not valid`)
 }
 
 func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *gc.C) {

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -372,7 +372,7 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 	}
 
 	// Deploy and set up the controller charm and application.
-	if err := c.deployControllerCharm(st, args.BootstrapMachineConstraints, args.ControllerCharmPath, args.ControllerCharmRisk, isCAAS, controllerUnitPassword); err != nil {
+	if err := c.deployControllerCharm(st, args.BootstrapMachineConstraints, args.ControllerCharmPath, args.ControllerCharmChannel, isCAAS, controllerUnitPassword); err != nil {
 		return errors.Annotate(err, "cannot deploy controller application")
 	}
 

--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -225,7 +225,7 @@ func (s *BootstrapSuite) TestStoreControllerCharm(c *gc.C) {
 	})
 
 	curl := charm.MustParseURL(controllerCharmURL)
-	channel := corecharm.MustParseChannel("beta")
+	channel := corecharm.MustParseChannel("3.0/beta")
 	origin := corecharm.Origin{
 		Source:  corecharm.CharmHub,
 		Channel: &channel,
@@ -817,7 +817,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 		Type:      "dummy",
 		AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 	}
-	args.ControllerCharmRisk = "beta"
+	args.ControllerCharmChannel = charm.Channel{Track: "3.0", Risk: "beta"}
 	s.bootstrapParams = args
 	s.writeBootstrapParamsFile(c)
 }

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -34,7 +34,7 @@ import (
 
 const controllerCharmURL = "ch:juju-controller"
 
-func (c *BootstrapCommand) deployControllerCharm(st *state.State, cons constraints.Value, charmPath, charmRisk string, isCAAS bool, unitPassword string) (resultErr error) {
+func (c *BootstrapCommand) deployControllerCharm(st *state.State, cons constraints.Value, charmPath string, channel charm.Channel, isCAAS bool, unitPassword string) (resultErr error) {
 	arch := corearch.DefaultArchitecture
 	base := jujuversion.DefaultSupportedLTSBase()
 	if cons.HasArch() {
@@ -92,7 +92,7 @@ func (c *BootstrapCommand) deployControllerCharm(st *state.State, cons constrain
 	// If no local charm, use the one from charmhub.
 	if err != nil {
 		source = "store"
-		if curl, origin, err = populateStoreControllerCharm(st, charmPath, charmRisk, arch, base); err != nil {
+		if curl, origin, err = populateStoreControllerCharm(st, charmPath, channel, arch, base); err != nil {
 			return errors.Annotate(err, "deploying charmhub controller charm")
 		}
 	}
@@ -136,7 +136,7 @@ var (
 )
 
 // populateStoreControllerCharm downloads and stores the controller charm from charmhub.
-func populateStoreControllerCharm(st *state.State, charmPath, charmRisk, arch string, base coreseries.Base) (*charm.URL, *corecharm.Origin, error) {
+func populateStoreControllerCharm(st *state.State, charmPath string, channel charm.Channel, arch string, base coreseries.Base) (*charm.URL, *corecharm.Origin, error) {
 	model, err := st.Model()
 	if err != nil {
 		return nil, nil, err
@@ -161,7 +161,6 @@ func populateStoreControllerCharm(st *state.State, charmPath, charmRisk, arch st
 	} else {
 		curl = charm.MustParseURL(charmPath)
 	}
-	channel, err := charm.ParseChannelNormalize(charmRisk)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/juju/charm/v9"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -174,8 +175,8 @@ type BootstrapParams struct {
 	// ControllerCharmPath is a local controller charm archive.
 	ControllerCharmPath string
 
-	// ControllerCharmRisk is used when fetching the charmhub controller charm.
-	ControllerCharmRisk string
+	// ControllerCharmChannel is used when fetching the charmhub controller charm.
+	ControllerCharmChannel charm.Channel
 
 	// ExtraAgentValuesForTesting are testing only values written to the agent config file.
 	ExtraAgentValuesForTesting map[string]string
@@ -630,7 +631,7 @@ func bootstrapIAAS(
 	if err := instanceConfig.SetControllerCharm(args.ControllerCharmPath); err != nil {
 		return errors.Trace(err)
 	}
-	instanceConfig.Bootstrap.ControllerCharmRisk = args.ControllerCharmRisk
+	instanceConfig.Bootstrap.ControllerCharmChannel = args.ControllerCharmChannel
 
 	var environVersion int
 	if e, ok := environ.(environs.Environ); ok {
@@ -777,7 +778,7 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.JujuDbSnapPath = args.JujuDbSnapPath
 	icfg.Bootstrap.JujuDbSnapAssertionsPath = args.JujuDbSnapAssertionsPath
 	icfg.Bootstrap.ControllerCharm = args.ControllerCharmPath
-	icfg.Bootstrap.ControllerCharmRisk = args.ControllerCharmRisk
+	icfg.Bootstrap.ControllerCharmChannel = args.ControllerCharmChannel
 	return nil
 }
 
@@ -854,7 +855,7 @@ func finalizePodBootstrapConfig(
 	pcfg.Bootstrap.ControllerExternalName = args.ControllerExternalName
 	pcfg.Bootstrap.ControllerExternalIPs = append([]string(nil), args.ControllerExternalIPs...)
 	pcfg.Bootstrap.ControllerCharmPath = args.ControllerCharmPath
-	pcfg.Bootstrap.ControllerCharmRisk = args.ControllerCharmRisk
+	pcfg.Bootstrap.ControllerCharmChannel = args.ControllerCharmChannel
 	return nil
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/juju/charm/v9"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -874,19 +875,20 @@ func (s *bootstrapSuite) TestBootstrapControllerCharmLocal(c *gc.C) {
 	c.Assert(env.instanceConfig.Bootstrap.ControllerCharm, gc.Equals, path)
 }
 
-func (s *bootstrapSuite) TestBootstrapControllerCharmRisk(c *gc.C) {
+func (s *bootstrapSuite) TestBootstrapControllerCharmChannel(c *gc.C) {
 	env := newEnviron("foo", useDefaultKeys, nil)
 	ctx := cmdtesting.Context(c)
+	ch := charm.Channel{Track: "3.0", Risk: "beta"}
 	err := bootstrap.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), env,
 		s.callContext, bootstrap.BootstrapParams{
 			ControllerConfig:         coretesting.FakeControllerConfig(),
 			AdminSecret:              "admin-secret",
 			CAPrivateKey:             coretesting.CAKey,
 			SupportedBootstrapSeries: supportedJujuSeries,
-			ControllerCharmRisk:      "beta",
+			ControllerCharmChannel:   ch,
 		})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(env.instanceConfig.Bootstrap.ControllerCharmRisk, gc.Equals, "beta")
+	c.Assert(env.instanceConfig.Bootstrap.ControllerCharmChannel, gc.Equals, ch)
 }
 
 // createImageMetadata creates some image metadata in a local directory.


### PR DESCRIPTION
The "controller charm risk" argument has been replaced with "controller charm channel" across the board. The `juju-controller` charm will have a track for each minor version of Juju (3.0, 3.1, 3.2, ...). When bootstrapping, the track defaults to the current minor version of Juju, while the risk defaults to "stable". You can specify a different track or risk using the `--controller-charm-channel` flag.

Example on Juju 3.0:
```
--controller-charm-channel beta        ->    track "3.0", risk "beta"
--controller-charm-channel 3.1/beta    ->    track "3.1", risk "beta"
--controller-charm-channel 3.1         ->    track "3.1", risk "stable"
```

I have added a new `parseControllerCharmChannel` function in the bootstrap command to encapsulate this logic. Across the board, I have replaced `ControllerCharmRisk string` in param structs with `ControllerCharmChannel charm.Channel`. I have also updated tests to match.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju bootstrap lxd c --controller-charm-channel latest/beta
```