### PR TITLE
Add Bash test suite for controller charm

### DIFF
--- a/tests/suites/controller_charm/dashboard.sh
+++ b/tests/suites/controller_charm/dashboard.sh
@@ -11,8 +11,17 @@ run_dashboard() {
 	juju deploy juju-dashboard --channel=beta
 	juju relate juju-dashboard controller.dashboard
 	wait_for "juju-dashboard" "$(idle_condition "juju-dashboard")"
-	# TODO: ensure controller charm still "active", not "error"
-	# TODO: run the juju dashboard command, check that it prints the url etc
+
+	# Ensure controller charm still "active", not "error"
+	local controller_charm_status
+	controller_charm_status=$(juju status -m controller --format json | jq -r '.applications.controller."application-status".current')
+	if [[ $controller_charm_status != 'active' ]]; then
+		exit 1
+	fi
+
+	# juju dashboard
+	# TODO: check that it prints the url etc
+	# TODO: this command will block, how do we interrupt it?
 
 	destroy_model "test-dashboard"
 }

--- a/tests/suites/controller_charm/dashboard.sh
+++ b/tests/suites/controller_charm/dashboard.sh
@@ -1,0 +1,33 @@
+run_dashboard() {
+	echo
+
+	file="${TEST_DIR}/test-dashboard.log"
+
+	ensure "test-dashboard" "${file}"
+
+	juju switch controller
+	juju offer controller:dashboard dashboard
+	juju switch test-dashboard
+	juju deploy juju-dashboard --channel=beta
+	juju relate juju-dashboard controller.dashboard
+	wait_for "juju-dashboard" "$(idle_condition "juju-dashboard")"
+	# TODO: ensure controller charm still "active", not "error"
+	# TODO: run the juju dashboard command, check that it prints the url etc
+
+	destroy_model "test-dashboard"
+}
+
+test_dashboard() {
+	if [ "$(skip 'test_dashboard')" ]; then
+		echo "==> TEST SKIPPED: dashboard relation"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_dashboard"
+	)
+}

--- a/tests/suites/controller_charm/task.sh
+++ b/tests/suites/controller_charm/task.sh
@@ -1,0 +1,22 @@
+test_controller_charm() {
+	if [ "$(skip 'test_controller_charm')" ]; then
+		echo "==> TEST SKIPPED: controller charm tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-ctr-charm.log"
+
+	bootstrap "test-ctr-charm" "${file}"
+
+	wait_for "controller" "$(idle_condition "controller")"
+	test_website
+	test_dashboard
+	# TODO(barrettj12): add tests for integration with prometheus/loki
+
+	destroy_controller "test-ctr-charm"
+}

--- a/tests/suites/controller_charm/website.sh
+++ b/tests/suites/controller_charm/website.sh
@@ -1,0 +1,32 @@
+run_website() {
+	echo
+
+	file="${TEST_DIR}/test-website.log"
+
+	ensure "test-website" "${file}"
+
+	juju switch controller
+	juju offer controller:website website
+	juju switch test-website
+	juju deploy haproxy
+	juju relate haproxy controller.website
+	wait_for "haproxy" "$(idle_condition "haproxy")"
+	# TODO: ensure controller charm still "active", not "error"
+
+	destroy_model "test-website"
+}
+
+test_website() {
+	if [ "$(skip 'test_website')" ]; then
+		echo "==> TEST SKIPPED: website relation"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_website"
+	)
+}

--- a/tests/suites/controller_charm/website.sh
+++ b/tests/suites/controller_charm/website.sh
@@ -11,7 +11,13 @@ run_website() {
 	juju deploy haproxy
 	juju relate haproxy controller.website
 	wait_for "haproxy" "$(idle_condition "haproxy")"
-	# TODO: ensure controller charm still "active", not "error"
+
+	# Ensure controller charm still "active", not "error"
+	local controller_charm_status
+	controller_charm_status=$(juju status -m controller --format json | jq -r '.applications.controller."application-status".current')
+	if [[ $controller_charm_status != 'active' ]]; then
+		exit 1
+	fi
 
 	destroy_model "test-website"
 }


### PR DESCRIPTION
Tests deployment of the controller charm, and integration with juju-dashboard and haproxy. Once Prometheus/Loki support is added, we can test integration with these too.

## QA steps

```sh
cd tests
./main.sh -v controller_charm
```