### PR TITLE
The juju find and info tests don't need a controller

### DIFF
--- a/tests/suites/charmhub/find.sh
+++ b/tests/suites/charmhub/find.sh
@@ -1,75 +1,35 @@
 run_charmhub_find_specific() {
 	echo
-	name="charmhub-find-specific"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	output=$(juju find ubuntu 2>&1 || true)
 	check_not_contains "${output}" "No matching charms for"
 	check_contains "${output}" ubuntu
-
-	destroy_model "test-${name}"
 }
 
 run_charmhub_find_all() {
 	echo
-	name="charmhub-find-all"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	output=$(juju find 2>&1 || true)
 
 	check_contains "${output}" "No search term specified. Here are some interesting charms"
-
-	destroy_model "test-${name}"
 }
 
 run_charmhub_find_json() {
 	echo
-	name="charmhub-find-json"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	# There should always be 1 charm with ubuntu in the name,
 	# charms should always have at least 1 supported base.
 	output=$(juju find ubuntu --format json | jq '.[0].supports | length')
 	check_gt "${output}" "0"
-
-	destroy_model "test-${name}"
 }
 
 run_charmhub_find_not_matching() {
 	echo
-	name="charmhub-find-not-matching"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	output=$(juju find "nosuchcharmorbundleeverl33t" 2>&1)
 	check_contains "${output}" "No matching charms or bundles"
-
-	destroy_model "test-${name}"
 }
 
 run_charmstore_find() {
 	echo
-	name="charmstore-find"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	output=$(juju find cs:ubuntu 2>&1 || true)
 	check_contains "${output}" "No matching charms or bundles"
-
-	destroy_model "test-${name}"
 }
 
 test_charmhub_find() {

--- a/tests/suites/charmhub/info.sh
+++ b/tests/suites/charmhub/info.sh
@@ -1,11 +1,5 @@
 run_charmhub_info() {
 	echo
-	name="charmhub-info"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	output=$(juju info ubuntu 2>&1 || true)
 	#
 	# These keys will not be printed if the data does not exist.
@@ -20,18 +14,10 @@ run_charmhub_info() {
 	# Only available via flag, which is not used here.
 	#
 	check_not_contains "$output" "config"
-
-	destroy_model "test-${name}"
 }
 
 run_charmhub_info_config() {
 	echo
-	name="charmhub-info-config"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	output=$(juju info ubuntu --config 2>&1 || true)
 	#
 	# These keys will not be printed if the data does not exist.
@@ -46,36 +32,18 @@ run_charmhub_info_config() {
 	# Only printed with the flag.
 	#
 	check_contains "$output" "config"
-
-	destroy_model "test-${name}"
 }
 
 run_charmhub_info_json() {
 	echo
-	name="charmhub-info-config"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	output=$(juju info ubuntu --format json | jq .charm.config.Options.hostname.Type)
 	check_contains "${output}" "string"
-
-	destroy_model "test-${name}"
 }
 
 run_charmstore_info() {
 	echo
-	name="charmstore-info"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
 	output=$(juju info cs:ubuntu 2>&1 || true)
 	check_contains "$output" 'ERROR "cs:ubuntu" is not a Charm Hub charm'
-
-	destroy_model "test-${name}"
 }
 
 test_charmhub_info() {

--- a/tests/suites/charmhub/task.sh
+++ b/tests/suites/charmhub/task.sh
@@ -11,11 +11,13 @@ test_charmhub() {
 
 	file="${TEST_DIR}/test-charmhub.log"
 
+	# These tests don't need a controller.
+	test_charmhub_find
+	test_charmhub_info
+
 	bootstrap "test-charmhub" "${file}"
 
 	test_charmhub_download
-	test_charmhub_find
-	test_charmhub_info
 
 	destroy_controller "test-charmhub"
 }


### PR DESCRIPTION
The CI tests for find and info don't use a controller, so don't start one or add a model.

Should fix flakey CI failures.