### PR TITLE
[JUJU-1833]Integration refesh switch

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -60,6 +60,7 @@ TEST_NAMES="agents \
             model \
             network \
             ovs_maas \
+            refresh \
             relations \
             resources \
             sidecar \

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -1,0 +1,71 @@
+run_refresh_cs() {
+	echo
+
+	model_name="test-refresh-cs"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy cs:ubuntu-19
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added"; then
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	printf "${OUT}\n"
+
+	# Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_local() {
+	echo
+
+	model_name="test-refresh-local"
+	file="${TEST_DIR}/${model_name}.log"
+	charm_name="${TEST_DIR}/ubuntu.charm"
+
+	ensure "${model_name}" "${file}"
+
+	juju download ubuntu --no-progress - >"${charm_name}"
+	juju deploy "${charm_name}" ubuntu
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --path "${charm_name}" 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added local charm"; then
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+test_basic() {
+	if [ "$(skip 'test_basic')" ]; then
+		echo "==> TEST SKIPPED: basic refresh"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_refresh_cs"
+		run "run_refresh_local"
+	)
+}

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -11,9 +11,11 @@ run_refresh_cs() {
 
 	OUT=$(juju refresh ubuntu 2>&1 || true)
 	if echo "${OUT}" | grep -E -vq "Added"; then
+		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
 		exit 5
 	fi
+	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
 	# Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
@@ -40,9 +42,11 @@ run_refresh_local() {
 
 	OUT=$(juju refresh ubuntu --path "${charm_name}" 2>&1 || true)
 	if echo "${OUT}" | grep -E -vq "Added local charm"; then
+		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
 		exit 5
 	fi
+	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
 	# Added local charm "ubuntu", revision 2, to the model

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -1,4 +1,5 @@
 run_refresh_cs() {
+	# Test a plain juju refresh with a charm store charm
 	echo
 
 	model_name="test-refresh-cs"
@@ -28,6 +29,7 @@ run_refresh_cs() {
 }
 
 run_refresh_local() {
+	# Test a plain juju refresh with a local charm
 	echo
 
 	model_name="test-refresh-local"

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -11,9 +11,11 @@ run_refresh_switch_cs_to_ch() {
 
 	OUT=$(juju refresh ubuntu --switch ch:ubuntu 2>&1 || true)
 	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
+		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
 		exit 5
 	fi
+	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
 	# Added local charm "ubuntu", revision 2, to the model
@@ -38,9 +40,11 @@ run_refresh_switch_cs_to_ch_channel() {
 
 	OUT=$(juju refresh ubuntu --switch ch:ubuntu --channel edge 2>&1 || true)
 	if echo "${OUT}" | grep -E -vq "in channel edge"; then
+		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
 		exit 5
 	fi
+	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
 	# Added local charm "ubuntu", revision 2, to the model
@@ -68,9 +72,11 @@ run_refresh_switch_local_to_ch_channel() {
 
 	OUT=$(juju refresh ubuntu --switch ch:ubuntu --channel edge 2>&1 || true)
 	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
+		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
 		exit 5
 	fi
+	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
 	# Added local charm "ubuntu", revision 2, to the model
@@ -95,6 +101,7 @@ run_refresh_switch_channel() {
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	OUT=$(juju refresh juju-qa-test --channel 2.0/edge 2>&1 || true)
+	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
 	# Added local charm "ubuntu", revision 2, to the model

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -1,4 +1,5 @@
 run_refresh_switch_cs_to_ch() {
+	# Test juju refresh from a charm store charm to a charm hub charm
 	echo
 
 	model_name="test-refresh-switch-ch"
@@ -28,6 +29,7 @@ run_refresh_switch_cs_to_ch() {
 }
 
 run_refresh_switch_cs_to_ch_channel() {
+	# Test juju refresh from a charm store charm to a charm hub charm with a specific channel
 	echo
 
 	model_name="test-refresh-switch-ch-channel"
@@ -58,6 +60,7 @@ run_refresh_switch_cs_to_ch_channel() {
 }
 
 run_refresh_switch_local_to_ch_channel() {
+	# Test juju refresh from a local charm to a charm hub charm with a specific channel
 	echo
 
 	model_name="test-refresh-local-switch-ch"
@@ -90,6 +93,7 @@ run_refresh_switch_local_to_ch_channel() {
 }
 
 run_refresh_switch_channel() {
+	# Test juju refresh switching from one channel to another
 	echo
 
 	model_name="test-refresh-switch-channel"

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -1,0 +1,126 @@
+run_refresh_switch_cs_to_ch() {
+	echo
+
+	model_name="test-refresh-switch-ch"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy cs:ubuntu-19
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --switch ch:ubuntu 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_switch_cs_to_ch_channel() {
+	echo
+
+	model_name="test-refresh-switch-ch-channel"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy cs:ubuntu-19
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --switch ch:ubuntu --channel edge 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "in channel edge"; then
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_switch_local_to_ch_channel() {
+	echo
+
+	model_name="test-refresh-local-switch-ch"
+	file="${TEST_DIR}/${model_name}.log"
+	charm_name="${TEST_DIR}/ubuntu.charm"
+
+	ensure "${model_name}" "${file}"
+
+	juju download ubuntu --no-progress - >"${charm_name}"
+	juju deploy "${charm_name}" ubuntu
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --switch ch:ubuntu --channel edge 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_switch_channel() {
+	echo
+
+	model_name="test-refresh-switch-channel"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy juju-qa-test
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	OUT=$(juju refresh juju-qa-test --channel 2.0/edge 2>&1 || true)
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/edge")"
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	destroy_model "${model_name}"
+}
+
+test_switch() {
+	if [ "$(skip 'test_switch')" ]; then
+		echo "==> TEST SKIPPED: refresh switch"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_refresh_switch_cs_to_ch"
+		run "run_refresh_switch_cs_to_ch_channel"
+		run "run_refresh_switch_local_to_ch_channel"
+		run "run_refresh_switch_channel"
+	)
+}

--- a/tests/suites/refresh/task.sh
+++ b/tests/suites/refresh/task.sh
@@ -1,0 +1,20 @@
+test_refresh() {
+	if [ "$(skip 'test_refresh')" ]; then
+		echo "==> TEST SKIPPED: Refresh tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-refresh-ctl.log"
+
+	bootstrap "test-refresh-ctl" "${file}"
+
+	test_basic
+	test_switch
+
+	destroy_controller "test-refresh-ctl"
+}


### PR DESCRIPTION
Implemented integration tests for the `juju refresh` command and updated a deploy by revision test related to `juju refresh`.

## QA steps

```sh
(cd tests ; ./main.sh refresh)
(cd tests ; ./main.sh deploy test_deploy_revision)
```
