### PR TITLE
Fix base_to_series for empty input

### DIFF
--- a/tests/includes/series.sh
+++ b/tests/includes/series.sh
@@ -9,7 +9,7 @@ base_to_series() {
 	base=${1}
 	IFS=':' read -ra base_parts <<<"$base"
 	os=${base_parts[0]}
-	channel=${base_parts[1]}
+	channel=${base_parts[1]:-}
 	case "${os}" in
 	"ubuntu")
 		case "${channel}" in
@@ -25,7 +25,11 @@ base_to_series() {
 		series=${os}${channel}
 		;;
 	*)
-		series=""
+		if [[ -z ${channel} ]]; then
+			series=${os}
+		else
+			series=""
+		fi
 		;;
 	esac
 	echo "${series}"


### PR DESCRIPTION
Fixes test-upgrade-series unbound var issue.

```
16:02:04     |     | Relation provider  Requirer           Interface    Type     Message
16:02:04     |     | dummy-sink:source  dummy-source:sink  dummy-token  regular  
16:02:04     | includes/series.sh: line 12: base_parts[1]: unbound variable
```