### PR TITLE
Fix typo ('credenitals')

### DIFF
--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -224,7 +224,7 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 	if err != nil {
 		logger.Errorf("%v", err)
 		ctx.Infof("Use \n* 'juju add-credential -c' to upload a credential to a controller or\n" +
-			"* 'juju autoload-credentials' to add credenitals from local files or\n" +
+			"* 'juju autoload-credentials' to add credentials from local files or\n" +
 			"* 'juju add-model --credential' to use a local credential.\n" +
 			"Use 'juju credentials' to list all available credentials.\n")
 		return cmd.ErrSilent

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -285,7 +285,7 @@ func (s *AddModelSuite) TestCredentialsOtherUserCredentialNotFound(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Use 
 * 'juju add-credential -c' to upload a credential to a controller or
-* 'juju autoload-credentials' to add credenitals from local files or
+* 'juju autoload-credentials' to add credentials from local files or
 * 'juju add-model --credential' to use a local credential.
 Use 'juju credentials' to list all available credentials.
 `[1:])
@@ -370,7 +370,7 @@ func (s *AddModelSuite) TestControllerCredentialsDetectedAmbiguous(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 Use 
 * 'juju add-credential -c' to upload a credential to a controller or
-* 'juju autoload-credentials' to add credenitals from local files or
+* 'juju autoload-credentials' to add credentials from local files or
 * 'juju add-model --credential' to use a local credential.
 Use 'juju credentials' to list all available credentials.
 `[1:])


### PR DESCRIPTION
Noticed this typo when reporting this linked bug, fixed in the code and the related tests:

https://bugs.launchpad.net/juju/+bug/1992903