### PR TITLE
[JUJU-1968] Prepare test-magma to use caas-image-repo

### DIFF
--- a/tests/suites/magma/task.sh
+++ b/tests/suites/magma/task.sh
@@ -11,6 +11,9 @@ test_magma() {
 
 	file="${TEST_DIR}/test-magma.log"
 
+	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
+	fi
 	bootstrap "test-magma" "${file}"
 
 	case "${BOOTSTRAP_PROVIDER:-}" in


### PR DESCRIPTION
This PR makes test-magma integration test using `caas-image-repo`. This will help to launch this test correctly at Jenkins.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

Check that test still working locally  

```sh
cd tests
./main.sh -v -p k8s -c microk8s magma
```
