### PR TITLE
Handle new base format in status for bash tests

### DIFF
--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -44,8 +44,13 @@ manual_deploy() {
 
 	juju enable-ha >"${TEST_DIR}/enable-ha.log" 2>&1
 
-	machine_base=$(juju machines --format=json | jq -r '.machines | .["0"] | .base')
+	machine_base=$(juju machines --format=json | jq -r '.machines | .["0"] | (.base.name+":"+.base.channel)')
 	machine_series=$(base_to_series "${machine_base}")
+
+	if [[ -z ${machine_series} ]]; then
+		echo "machine 0 has invalid series"
+		exit 1
+	fi
 
 	juju deploy ubuntu --to=0 --series="${machine_series}"
 

--- a/tests/suites/upgrade_series/series.sh
+++ b/tests/suites/upgrade_series/series.sh
@@ -38,13 +38,13 @@ assert_machine_series() {
 	local machine expected_series actual_base actual_series
 	machine=$1
 	expected_series=$2
-	actual_base=$(juju status --format=json | jq -r ".machines[\"$machine\"].base")
+	actual_base=$(juju status --format=json | jq -r ".machines[\"$machine\"] | (.base.name+\":\"+.base.channel)")
 	actual_series=$(base_to_series "${actual_base}")
 
 	if [[ $expected_series == "$actual_series" ]]; then
-		echo "Machine $machine has series $actual_base"
+		echo "Machine $machine has series $actual_series from base $actual_base"
 	else
-		echo "Machine $machine has series $actual_series, expected $expected_series"
+		echo "Machine $machine has series $actual_series from base $actual_base, expected $expected_series"
 		exit 1
 	fi
 }


### PR DESCRIPTION
Base in status was changed to include base as a struct not a string.

This PR updates the base_to_series helper to account for that.

## QA steps

`./main upgrade_series`