### PR TITLE
Add caas image repo to deploy caas

### DIFF
--- a/tests/suites/deploy_caas/task.sh
+++ b/tests/suites/deploy_caas/task.sh
@@ -11,6 +11,9 @@ test_deploy_caas() {
 
 	file="${TEST_DIR}/test-deploy-caas.log"
 
+	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
+	fi
 	bootstrap "test-deploy-caas" "${file}"
 
 	case "${BOOTSTRAP_PROVIDER:-}" in


### PR DESCRIPTION
This PR makes test-deploy_caas integration test using `caas-image-repo`. This will help to launch this test correctly at Jenkins.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

Check that test still working locally  

```sh
cd tests
./main.sh -v -p k8s -c microk8s deploy_caas
```
