### PR TITLE
[JUJU-1650, JUJU-1947] Api client application to gomock

### DIFF
--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -289,7 +289,7 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 		ApplicationName: "application",
 		CharmURL:        "cs:trusty/application-1",
 		CharmOrigin: &params.CharmOrigin{
-			Source: "charm-hub",
+			Source: "charm-store",
 			Risk:   "edge",
 		},
 		Channel: "edge",
@@ -313,7 +313,7 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 		CharmID: application.CharmID{
 			URL: charm.MustParseURL("cs:trusty/application-1"),
 			Origin: apicharm.Origin{
-				Source: "charm-hub",
+				Source: "charm-store",
 				Risk:   "edge",
 			},
 		},

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -7,14 +7,14 @@ import (
 	stderrors "errors"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
-	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	basetesting "github.com/juju/juju/api/base/testing"
+	"github.com/juju/juju/api/base/mocks"
 	"github.com/juju/juju/api/client/application"
 	apicharm "github.com/juju/juju/api/common/charm"
 	apitesting "github.com/juju/juju/api/testing"
@@ -29,84 +29,92 @@ import (
 
 const newBranchName = "new-branch"
 
-type applicationSuite struct {
-	testing.IsolationSuite
-}
+type applicationSuite struct{}
 
 var _ = gc.Suite(&applicationSuite{})
 
-func newClient(f basetesting.APICallerFunc) *application.Client {
-	return application.NewClient(f)
-}
-
 func (s *applicationSuite) TestSetApplicationMetricCredentials(c *gc.C) {
-	var called bool
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		called = true
-		c.Check(objType, gc.Equals, "Application")
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "SetMetricCredentials")
-		args, ok := a.(params.ApplicationMetricCredentials)
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(args.Creds, gc.HasLen, 1)
-		c.Assert(args.Creds[0].ApplicationName, gc.Equals, "applicationA")
-		c.Assert(args.Creds[0].MetricCredentials, gc.DeepEquals, []byte("creds 1"))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-		result := response.(*params.ErrorResults)
-		result.Results = make([]params.ErrorResult, 1)
-		return nil
-	})
+	args := params.ApplicationMetricCredentials{
+		Creds: []params.ApplicationMetricCredential{
+			{
+				ApplicationName:   "applicationA",
+				MetricCredentials: []byte("creds 1"),
+			},
+		},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, 1),
+	}
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SetMetricCredentials", args, result).SetArg(2, results).Return(nil)
+	client := application.NewClientFromCaller(mockFacadeCaller)
+
 	err := client.SetMetricCredentials("applicationA", []byte("creds 1"))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestSetApplicationMetricCredentialsFails(c *gc.C) {
-	var called bool
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		called = true
-		c.Check(objType, gc.Equals, "Application")
-		c.Check(id, gc.Equals, "")
-		c.Assert(request, gc.Equals, "SetMetricCredentials")
-		result := response.(*params.ErrorResults)
-		result.Results = make([]params.ErrorResult, 1)
-		result.Results[0].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
-		return result.OneError()
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.ApplicationMetricCredentials{
+		Creds: []params.ApplicationMetricCredential{
+			{
+				ApplicationName:   "application",
+				MetricCredentials: []byte("creds"),
+			},
+		},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{
+			{
+				Error: apiservererrors.ServerError(apiservererrors.ErrPerm),
+			},
+		},
+	}
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SetMetricCredentials", args, result).SetArg(2, results).Return(nil)
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.SetMetricCredentials("application", []byte("creds"))
 	c.Assert(err, gc.ErrorMatches, "permission denied")
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestDeploy(c *gc.C) {
-	var called bool
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			called = true
-			c.Assert(request, gc.Equals, "Deploy")
-			args, ok := a.(params.ApplicationsDeploy)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Applications, gc.HasLen, 1)
-			app := args.Applications[0]
-			c.Assert(app.CharmURL, gc.Equals, "cs:trusty/a-charm-1")
-			c.Assert(app.CharmOrigin, gc.DeepEquals, &params.CharmOrigin{Source: "charm-store"})
-			c.Assert(app.ApplicationName, gc.Equals, "applicationA")
-			c.Assert(app.Series, gc.Equals, "series")
-			c.Assert(app.NumUnits, gc.Equals, 1)
-			c.Assert(app.ConfigYAML, gc.Equals, "configYAML")
-			c.Assert(app.Config, gc.DeepEquals, map[string]string{"foo": "bar"})
-			c.Assert(app.Constraints, gc.DeepEquals, constraints.MustParse("mem=4G"))
-			c.Assert(app.Placement, gc.DeepEquals, []*instance.Placement{{"scope", "directive"}})
-			c.Assert(app.EndpointBindings, gc.DeepEquals, map[string]string{"foo": "bar"})
-			c.Assert(app.Storage, gc.DeepEquals, map[string]storage.Constraints{"data": {Pool: "pool"}})
-			c.Assert(app.AttachStorage, gc.DeepEquals, []string{"storage-data-0"})
-			c.Assert(app.Resources, gc.DeepEquals, map[string]string{"foo": "bar"})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result := response.(*params.ErrorResults)
-			result.Results = make([]params.ErrorResult, 1)
-			return nil
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{Results: make([]params.ErrorResult, 1)}
+
+	deployArgs := params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{
+			{
+				CharmURL:         "cs:trusty/a-charm-1",
+				CharmOrigin:      &params.CharmOrigin{Source: "charm-store"},
+				ApplicationName:  "applicationA",
+				Series:           "series",
+				NumUnits:         1,
+				ConfigYAML:       "configYAML",
+				Config:           map[string]string{"foo": "bar"},
+				Constraints:      constraints.MustParse("mem=4G"),
+				Placement:        []*instance.Placement{{"scope", "directive"}},
+				EndpointBindings: map[string]string{"foo": "bar"},
+				Storage:          map[string]storage.Constraints{"data": {Pool: "pool"}},
+				AttachStorage:    []string{"storage-data-0"},
+				Resources:        map[string]string{"foo": "bar"},
+			},
 		},
-	))
+	}
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Deploy", deployArgs, result).SetArg(2, results).Return(nil)
 
 	args := application.DeployArgs{
 		CharmID: application.CharmID{
@@ -127,31 +135,41 @@ func (s *applicationSuite) TestDeploy(c *gc.C) {
 		Resources:        map[string]string{"foo": "bar"},
 		EndpointBindings: map[string]string{"foo": "bar"},
 	}
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.Deploy(args)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestDeployAlreadyExists(c *gc.C) {
-	var called bool
-	client := application.NewClient(basetesting.BestVersionCaller{
-		APICallerFunc: basetesting.APICallerFunc(
-			func(objType string, version int, id, request string, a, response interface{}) error {
-				called = true
-				c.Assert(request, gc.Equals, "Deploy")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-				result := response.(*params.ErrorResults)
-				result.Results = []params.ErrorResult{
-					{Error: &params.Error{
-						Message: "application already exists",
-						Code:    params.CodeAlreadyExists,
-					}},
-				}
-				return nil
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{Results: []params.ErrorResult{{Error: &params.Error{Message: "application already exists", Code: params.CodeAlreadyExists}}}}
+
+	deployArgs := params.ApplicationsDeploy{
+		Applications: []params.ApplicationDeploy{
+			{
+				CharmURL:         "cs:trusty/a-charm-1",
+				CharmOrigin:      &params.CharmOrigin{Source: "charm-store"},
+				ApplicationName:  "applicationA",
+				Series:           "series",
+				NumUnits:         1,
+				ConfigYAML:       "configYAML",
+				Config:           map[string]string{"foo": "bar"},
+				Constraints:      constraints.MustParse("mem=4G"),
+				Placement:        []*instance.Placement{{"scope", "directive"}},
+				EndpointBindings: map[string]string{"foo": "bar"},
+				Storage:          map[string]storage.Constraints{"data": {Pool: "pool"}},
+				AttachStorage:    []string{"storage-data-0"},
+				Resources:        map[string]string{"foo": "bar"},
 			},
-		),
-		BestVersion: 5,
-	})
+		},
+	}
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Deploy", deployArgs, result).SetArg(2, results).Return(nil)
 
 	args := application.DeployArgs{
 		CharmID: application.CharmID{
@@ -172,42 +190,46 @@ func (s *applicationSuite) TestDeployAlreadyExists(c *gc.C) {
 		Resources:        map[string]string{"foo": "bar"},
 		EndpointBindings: map[string]string{"foo": "bar"},
 	}
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.Deploy(args)
 	c.Assert(err, gc.ErrorMatches, `application already exists`)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestDeployAttachStorageMultipleUnits(c *gc.C) {
-	var called bool
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		called = true
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+
 	args := application.DeployArgs{
 		NumUnits:      2,
 		AttachStorage: []string{"data/0"},
 	}
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.Deploy(args)
 	c.Assert(err, gc.ErrorMatches, "cannot attach existing storage when more than one unit is requested")
-	c.Assert(called, jc.IsFalse)
 }
 
 func (s *applicationSuite) TestAddUnits(c *gc.C) {
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "AddUnits")
-			args, ok := a.(params.AddApplicationUnits)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.ApplicationName, gc.Equals, "foo")
-			c.Assert(args.NumUnits, gc.Equals, 1)
-			c.Assert(args.Placement, jc.DeepEquals, []*instance.Placement{{"scope", "directive"}})
-			c.Assert(args.AttachStorage, jc.DeepEquals, []string{"storage-data-0"})
-			result := response.(*params.AddApplicationUnitsResults)
-			result.Units = []string{"foo/0"}
-			return nil
-		},
-	))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
+	result := new(params.AddApplicationUnitsResults)
+	results := params.AddApplicationUnitsResults{
+		Units: []string{"foo/0"},
+	}
+
+	args := params.AddApplicationUnits{
+		ApplicationName: "foo",
+		NumUnits:        1,
+		Placement:       []*instance.Placement{{"scope", "directive"}},
+		AttachStorage:   []string{"storage-data-0"},
+	}
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("AddUnits", args, result).SetArg(2, results).Return(nil)
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	units, err := client.AddUnits(application.AddUnitsParams{
 		ApplicationName: "foo",
 		NumUnits:        1,
@@ -219,78 +241,73 @@ func (s *applicationSuite) TestAddUnits(c *gc.C) {
 }
 
 func (s *applicationSuite) TestAddUnitsAttachStorageMultipleUnits(c *gc.C) {
-	var called bool
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		called = true
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.AddUnits(application.AddUnitsParams{
 		NumUnits:      2,
 		AttachStorage: []string{"data/0"},
 	})
 	c.Assert(err, gc.ErrorMatches, "cannot attach existing storage when more than one unit is requested")
-	c.Assert(called, jc.IsFalse)
 }
 
 func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
-	var called bool
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		called = true
-		c.Assert(request, gc.Equals, "GetCharmURLOrigin")
-		args, ok := a.(params.ApplicationGet)
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(args.ApplicationName, gc.Equals, "application")
-		c.Assert(args.BranchName, gc.Equals, newBranchName)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-		result := response.(*params.CharmURLOriginResult)
-		result.URL = "cs:curl"
-		result.Origin = params.CharmOrigin{
-			Risk: "edge",
-		}
-		return nil
-	})
+	result := new(params.CharmURLOriginResult)
+	results := params.CharmURLOriginResult{
+		URL:    "cs:curl",
+		Origin: params.CharmOrigin{Risk: "edge"},
+	}
+	args := params.ApplicationGet{
+		ApplicationName: "application",
+		BranchName:      newBranchName,
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("GetCharmURLOrigin", args, result).SetArg(2, results).Return(nil)
+	client := application.NewClientFromCaller(mockFacadeCaller)
+
 	curl, origin, err := client.GetCharmURLOrigin(newBranchName, "application")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.DeepEquals, charm.MustParseURL("cs:curl"))
 	c.Assert(origin, gc.DeepEquals, apicharm.Origin{
 		Risk: "edge",
 	})
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestSetCharm(c *gc.C) {
-	var called bool
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	toUint64Ptr := func(v uint64) *uint64 {
 		return &v
 	}
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		called = true
-		c.Assert(request, gc.Equals, "SetCharm")
-		args, ok := a.(params.ApplicationSetCharm)
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(args.ApplicationName, gc.Equals, "application")
-		c.Assert(args.CharmURL, gc.Equals, "cs:trusty/application-1")
-		c.Assert(args.CharmOrigin, gc.DeepEquals, &params.CharmOrigin{
+	args := params.ApplicationSetCharm{
+		ApplicationName: "application",
+		CharmURL:        "cs:trusty/application-1",
+		CharmOrigin: &params.CharmOrigin{
 			Source: "charm-hub",
 			Risk:   "edge",
-		})
-		c.Assert(args.ConfigSettings, jc.DeepEquals, map[string]string{
+		},
+		Channel: "edge",
+		ConfigSettings: map[string]string{
 			"a": "b",
 			"c": "d",
-		})
-		c.Assert(args.ConfigSettingsYAML, gc.Equals, "yaml")
-		c.Assert(args.Force, gc.Equals, true)
-		c.Assert(args.ForceSeries, gc.Equals, true)
-		c.Assert(args.ForceUnits, gc.Equals, true)
-		c.Assert(args.StorageConstraints, jc.DeepEquals, map[string]params.StorageConstraints{
+		},
+		ConfigSettingsYAML: "yaml",
+		Force:              true,
+		ForceSeries:        true,
+		ForceUnits:         true,
+		StorageConstraints: map[string]params.StorageConstraints{
 			"a": {Pool: "radiant"},
 			"b": {Count: toUint64Ptr(123)},
 			"c": {Size: toUint64Ptr(123)},
-		})
-		c.Assert(args.Generation, gc.Equals, newBranchName)
-
-		return nil
-	})
+		},
+		Generation: newBranchName,
+	}
 	cfg := application.SetCharmConfig{
 		ApplicationName: "application",
 		CharmID: application.CharmID{
@@ -314,12 +331,18 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 			"c": {Size: 123},
 		},
 	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SetCharm", args, nil).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.SetCharm(newBranchName, cfg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestDestroyApplications(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	expectedResults := []params.DestroyApplicationResult{{
 		Error: &params.Error{Message: "boo"},
 	}, {
@@ -330,32 +353,42 @@ func (s *applicationSuite) TestDestroyApplications(c *gc.C) {
 		},
 	}}
 	delay := 1 * time.Minute
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		c.Assert(request, gc.Equals, "DestroyApplication")
-		c.Assert(a, jc.DeepEquals, params.DestroyApplicationsParams{
-			Applications: []params.DestroyApplicationParams{
-				{ApplicationTag: "application-foo", Force: true, MaxWait: &delay},
-				{ApplicationTag: "application-bar", Force: true, MaxWait: &delay},
-			},
-		})
-		c.Assert(response, gc.FitsTypeOf, &params.DestroyApplicationResults{})
-		out := response.(*params.DestroyApplicationResults)
-		*out = params.DestroyApplicationResults{expectedResults}
-		return nil
-	})
-	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
+	result := new(params.DestroyApplicationResults)
+	results := params.DestroyApplicationResults{expectedResults}
+	args := params.DestroyApplicationsParams{
+		Applications: []params.DestroyApplicationParams{
+			{ApplicationTag: "application-foo", Force: true, MaxWait: &delay},
+			{ApplicationTag: "application-bar", Force: true, MaxWait: &delay},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyApplication", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.DestroyApplications(application.DestroyApplicationsParams{
 		Applications: []string{"foo", "bar"},
 		Force:        true,
 		MaxWait:      &delay,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, expectedResults)
+	c.Assert(res, jc.DeepEquals, expectedResults)
 }
 
 func (s *applicationSuite) TestDestroyApplicationsArity(c *gc.C) {
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	result := new(params.DestroyApplicationResults)
+	results := params.DestroyApplicationResults{}
+	args := params.DestroyApplicationsParams{
+		Applications: []params.DestroyApplicationParams{
+			{ApplicationTag: "application-foo"},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyApplication", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.DestroyApplications(application.DestroyApplicationsParams{
 		Applications: []string{"foo"},
 	})
@@ -363,74 +396,89 @@ func (s *applicationSuite) TestDestroyApplicationsArity(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDestroyApplicationsInvalidIds(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 	expectedResults := []params.DestroyApplicationResult{{
 		Error: &params.Error{Message: `application name "!" not valid`},
 	}, {
 		Info: &params.DestroyApplicationInfo{},
 	}}
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		out := response.(*params.DestroyApplicationResults)
-		*out = params.DestroyApplicationResults{expectedResults[1:]}
-		return nil
-	})
-	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
+	result := new(params.DestroyApplicationResults)
+	results := params.DestroyApplicationResults{expectedResults[1:]}
+
+	applications := []params.DestroyApplicationParams{
+		{ApplicationTag: names.NewApplicationTag("foo").String()},
+	}
+	args := params.DestroyApplicationsParams{Applications: applications}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyApplication", args, result).SetArg(2, results).Return(nil)
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.DestroyApplications(application.DestroyApplicationsParams{
 		Applications: []string{"!", "foo"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, expectedResults)
+	c.Assert(res, jc.DeepEquals, expectedResults)
 }
 
 func (s *applicationSuite) TestDestroyConsumedApplicationsArity(c *gc.C) {
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{}
+	force := false
+	args := params.DestroyConsumedApplicationsParams{
+		Applications: []params.DestroyConsumedApplicationParams{
+			{ApplicationTag: names.NewApplicationTag("foo").String(), Force: &force},
+		},
+	}
 	destroyParams := application.DestroyConsumedApplicationParams{
 		[]string{"foo"}, false, nil,
 	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyConsumedApplications", args, result).SetArg(2, results).Return(nil)
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.DestroyConsumedApplication(destroyParams)
 	c.Assert(err, gc.ErrorMatches, `expected 1 result\(s\), got 0`)
 }
 
 func (s *applicationSuite) TestDestroyConsumedApplications(c *gc.C) {
-	var called bool
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	noWait := 1 * time.Minute
 	force := true
+	result := new(params.ErrorResults)
 	expectedResults := []params.ErrorResult{{}, {}}
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "DestroyConsumedApplications")
-			c.Assert(a, jc.DeepEquals, params.DestroyConsumedApplicationsParams{
-				Applications: []params.DestroyConsumedApplicationParams{
-					{ApplicationTag: "application-foo", Force: &force, MaxWait: &noWait},
-					{ApplicationTag: "application-bar", Force: &force, MaxWait: &noWait},
-				},
-			})
-			called = true
-			c.Assert(response, gc.FitsTypeOf, &params.ErrorResults{})
-			out := response.(*params.ErrorResults)
-			*out = params.ErrorResults{expectedResults}
-			return nil
+	results := params.ErrorResults{expectedResults}
+	args := params.DestroyConsumedApplicationsParams{
+		Applications: []params.DestroyConsumedApplicationParams{
+			{ApplicationTag: "application-foo", Force: &force, MaxWait: &noWait},
+			{ApplicationTag: "application-bar", Force: &force, MaxWait: &noWait},
 		},
-	))
-
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyConsumedApplications", args, result).SetArg(2, results).Return(nil)
 	destroyParams := application.DestroyConsumedApplicationParams{
 		[]string{"foo"}, false, &noWait,
 	}
-	results, err := client.DestroyConsumedApplication(destroyParams)
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.DestroyConsumedApplication(destroyParams)
 	c.Check(err, gc.ErrorMatches, "--force is required when --max-wait is provided")
-	c.Check(results, gc.HasLen, 0)
-	c.Assert(called, jc.IsFalse)
+	c.Check(res, gc.HasLen, 0)
 
 	destroyParams = application.DestroyConsumedApplicationParams{
 		[]string{"foo", "bar"}, force, &noWait,
 	}
-	results, err = client.DestroyConsumedApplication(destroyParams)
+	res, err = client.DestroyConsumedApplication(destroyParams)
 	c.Check(err, jc.ErrorIsNil)
-	c.Check(results, gc.HasLen, 2)
-	c.Assert(called, jc.IsTrue)
+	c.Check(res, gc.HasLen, 2)
 }
 
 func (s *applicationSuite) TestDestroyUnits(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	expectedResults := []params.DestroyUnitResult{{
 		Error: &params.Error{Message: "boo"},
 	}, {
@@ -439,33 +487,44 @@ func (s *applicationSuite) TestDestroyUnits(c *gc.C) {
 			DetachedStorage:  []params.Entity{{Tag: "storage-pgdata-1"}},
 		},
 	}}
+	result := new(params.DestroyUnitResults)
+	results := params.DestroyUnitResults{expectedResults}
 	delay := 1 * time.Minute
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		c.Assert(request, gc.Equals, "DestroyUnit")
-		c.Assert(a, jc.DeepEquals, params.DestroyUnitsParams{
-			Units: []params.DestroyUnitParams{
-				{UnitTag: "unit-foo-0", Force: true, MaxWait: &delay},
-				{UnitTag: "unit-bar-1", Force: true, MaxWait: &delay},
-			},
-		})
-		c.Assert(response, gc.FitsTypeOf, &params.DestroyUnitResults{})
-		out := response.(*params.DestroyUnitResults)
-		*out = params.DestroyUnitResults{expectedResults}
-		return nil
-	})
-	results, err := client.DestroyUnits(application.DestroyUnitsParams{
+
+	args := params.DestroyUnitsParams{
+		Units: []params.DestroyUnitParams{
+			{UnitTag: "unit-foo-0", Force: true, MaxWait: &delay},
+			{UnitTag: "unit-bar-1", Force: true, MaxWait: &delay},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyUnit", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.DestroyUnits(application.DestroyUnitsParams{
 		Units:   []string{"foo/0", "bar/1"},
 		Force:   true,
 		MaxWait: &delay,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, expectedResults)
+	c.Assert(res, jc.DeepEquals, expectedResults)
 }
 
 func (s *applicationSuite) TestDestroyUnitsArity(c *gc.C) {
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	result := new(params.DestroyUnitResults)
+	results := params.DestroyUnitResults{}
+	args := params.DestroyUnitsParams{
+		Units: []params.DestroyUnitParams{
+			{UnitTag: names.NewUnitTag("foo/0").String()},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyUnit", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.DestroyUnits(application.DestroyUnitsParams{
 		Units: []string{"foo/0"},
 	})
@@ -473,24 +532,35 @@ func (s *applicationSuite) TestDestroyUnitsArity(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDestroyUnitsInvalidIds(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	expectedResults := []params.DestroyUnitResult{{
 		Error: &params.Error{Message: `unit ID "!" not valid`},
 	}, {
 		Info: &params.DestroyUnitInfo{},
 	}}
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		out := response.(*params.DestroyUnitResults)
-		*out = params.DestroyUnitResults{expectedResults[1:]}
-		return nil
-	})
-	results, err := client.DestroyUnits(application.DestroyUnitsParams{
+	result := new(params.DestroyUnitResults)
+	results := params.DestroyUnitResults{expectedResults[1:]}
+	args := params.DestroyUnitsParams{
+		Units: []params.DestroyUnitParams{
+			{UnitTag: names.NewUnitTag("foo/0").String()},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("DestroyUnit", args, result).SetArg(2, results).Return(nil)
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.DestroyUnits(application.DestroyUnitsParams{
 		Units: []string{"!", "foo/0"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, expectedResults)
+	c.Assert(res, jc.DeepEquals, expectedResults)
 }
 
 func (s *applicationSuite) TestConsume(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	offer := params.ApplicationOfferDetails{
 		SourceModelTag:         "source model",
 		OfferName:              "an offer",
@@ -508,32 +578,22 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 		CACert:        coretesting.CACert,
 	}
 
-	var called bool
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string,
-			version int,
-			id, request string,
-			a, result interface{},
-		) error {
-			called = true
-			c.Assert(request, gc.Equals, "Consume")
-			args, ok := a.(params.ConsumeApplicationArgs)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args.Args, jc.DeepEquals, []params.ConsumeApplicationArg{
-				{
-					ApplicationAlias:        "alias",
-					ApplicationOfferDetails: offer,
-					Macaroon:                mac,
-					ControllerInfo:          controllerInfo,
-				},
-			})
-			if results, ok := result.(*params.ErrorResults); ok {
-				result := params.ErrorResult{}
-				results.Results = []params.ErrorResult{result}
-			}
-			return nil
-		})
-	client := application.NewClient(apiCaller)
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{Results: []params.ErrorResult{{}}}
+	args := params.ConsumeApplicationArgs{
+		Args: []params.ConsumeApplicationArg{
+			{
+				ApplicationAlias:        "alias",
+				ApplicationOfferDetails: offer,
+				Macaroon:                mac,
+				ControllerInfo:          controllerInfo,
+			},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Consume", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	name, err := client.Consume(crossmodel.ConsumeApplicationArgs{
 		Offer:            offer,
 		ApplicationAlias: "alias",
@@ -547,10 +607,12 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(name, gc.Equals, "alias")
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestDestroyRelation(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	false_ := false
 	true_ := true
 	zero := time.Minute * 1
@@ -565,26 +627,24 @@ func (s *applicationSuite) TestDestroyRelation(c *gc.C) {
 		{force: &false_, maxWait: &zero},
 		{force: &true_, maxWait: &zero},
 	} {
-		called := false
-		client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "DestroyRelation")
-			c.Assert(a, jc.DeepEquals, params.DestroyRelation{
-				Endpoints: []string{"ep1", "ep2"},
-				Force:     t.force,
-				MaxWait:   t.maxWait,
-			})
-			c.Assert(response, gc.IsNil)
-			called = true
-			return nil
-		})
+		args := params.DestroyRelation{
+			Endpoints: []string{"ep1", "ep2"},
+			Force:     t.force,
+			MaxWait:   t.maxWait,
+		}
+		mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+		mockFacadeCaller.EXPECT().FacadeCall("DestroyRelation", args, nil).Return(nil)
 
+		client := application.NewClientFromCaller(mockFacadeCaller)
 		err := client.DestroyRelation(t.force, t.maxWait, "ep1", "ep2")
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(called, jc.IsTrue)
 	}
 }
 
 func (s *applicationSuite) TestDestroyRelationId(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	false_ := false
 	true_ := true
 	zero := time.Minute * 1
@@ -599,107 +659,105 @@ func (s *applicationSuite) TestDestroyRelationId(c *gc.C) {
 		{force: &false_, maxWait: &zero},
 		{force: &true_, maxWait: &zero},
 	} {
-		called := false
-		client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "DestroyRelation")
-			c.Assert(a, jc.DeepEquals, params.DestroyRelation{
-				RelationId: 123,
-				Force:      t.force,
-				MaxWait:    t.maxWait,
-			})
-			c.Assert(response, gc.IsNil)
-			called = true
-			return nil
-		})
+		args := params.DestroyRelation{
+			RelationId: 123,
+			Force:      t.force,
+			MaxWait:    t.maxWait,
+		}
+		mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+		mockFacadeCaller.EXPECT().FacadeCall("DestroyRelation", args, nil).Return(nil)
+
+		client := application.NewClientFromCaller(mockFacadeCaller)
 		err := client.DestroyRelationId(123, t.force, t.maxWait)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(called, jc.IsTrue)
 	}
 }
 
 func (s *applicationSuite) TestSetRelationSuspended(c *gc.C) {
-	called := false
-	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
-		c.Assert(request, gc.Equals, "SetRelationsSuspended")
-		c.Assert(a, jc.DeepEquals, params.RelationSuspendedArgs{
-			Args: []params.RelationSuspendedArg{
-				{
-					RelationId: 123,
-					Suspended:  true,
-					Message:    "message",
-				}, {
-					RelationId: 456,
-					Suspended:  true,
-					Message:    "message",
-				}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*result.(*params.ErrorResults) = params.ErrorResults{
-			Results: []params.ErrorResult{{}, {}},
-		}
-		called = true
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{
+			{
+				RelationId: 123,
+				Suspended:  true,
+				Message:    "message",
+			}, {
+				RelationId: 456,
+				Suspended:  true,
+				Message:    "message",
+			}},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{}, {}},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SetRelationsSuspended", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.SetRelationSuspended([]int{123, 456}, true, "message")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestSetRelationSuspendedArity(c *gc.C) {
-	called := false
-	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
-		c.Assert(request, gc.Equals, "SetRelationsSuspended")
-		c.Assert(a, jc.DeepEquals, params.RelationSuspendedArgs{
-			Args: []params.RelationSuspendedArg{
-				{
-					RelationId: 123,
-					Suspended:  true,
-					Message:    "message",
-				}, {
-					RelationId: 456,
-					Suspended:  true,
-					Message:    "message",
-				}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*result.(*params.ErrorResults) = params.ErrorResults{
-			Results: []params.ErrorResult{{}},
-		}
-		called = true
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.RelationSuspendedArgs{
+		Args: []params.RelationSuspendedArg{
+			{
+				RelationId: 123,
+				Suspended:  true,
+				Message:    "message",
+			}, {
+				RelationId: 456,
+				Suspended:  true,
+				Message:    "message",
+			}},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{{}},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SetRelationsSuspended", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.SetRelationSuspended([]int{123, 456}, true, "message")
 	c.Assert(err, gc.ErrorMatches, "expected 2 results, got 1")
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestAddRelation(c *gc.C) {
-	called := false
-	client := newClient(func(objType string, version int, id, request string, a, result interface{}) error {
-		c.Assert(request, gc.Equals, "AddRelation")
-		c.Assert(a, jc.DeepEquals, params.AddRelation{
-			Endpoints: []string{"ep1", "ep2"},
-			ViaCIDRs:  []string{"cidr1", "cidr2"},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.AddRelationResults{})
-		*result.(*params.AddRelationResults) = params.AddRelationResults{
-			Endpoints: map[string]params.CharmRelation{
-				"ep1": {Name: "foo"},
-			},
-		}
-		called = true
-		return nil
-	})
-	results, err := client.AddRelation([]string{"ep1", "ep2"}, []string{"cidr1", "cidr2"})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.AddRelation{
+		Endpoints: []string{"ep1", "ep2"},
+		ViaCIDRs:  []string{"cidr1", "cidr2"},
+	}
+	result := new(params.AddRelationResults)
+	results := params.AddRelationResults{
+		Endpoints: map[string]params.CharmRelation{
+			"ep1": {Name: "foo"},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("AddRelation", args, result).SetArg(2, results).Return(nil)
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.AddRelation([]string{"ep1", "ep2"}, []string{"cidr1", "cidr2"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
-	c.Assert(results.Endpoints, jc.DeepEquals, map[string]params.CharmRelation{
+	c.Assert(res.Endpoints, jc.DeepEquals, map[string]params.CharmRelation{
 		"ep1": {Name: "foo"},
 	})
 }
 
 func (s *applicationSuite) TestGetConfig(c *gc.C) {
-	expArgs := params.ApplicationGetArgs{Args: []params.ApplicationGet{
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.ApplicationGetArgs{Args: []params.ApplicationGet{
 		{ApplicationName: "foo", BranchName: newBranchName},
 		{ApplicationName: "bar", BranchName: newBranchName},
 	}}
@@ -731,305 +789,290 @@ func (s *applicationSuite) TestGetConfig(c *gc.C) {
 			"value":       "admin001",
 		},
 	}
-
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, args, response interface{}) error {
-			c.Assert(request, gc.Equals, "CharmConfig")
-			c.Assert(args, jc.DeepEquals, expArgs)
-
-			result, ok := response.(*params.ApplicationGetConfigResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ConfigResult{
-				{Config: fooConfig}, {Config: barConfig},
-			}
-			return nil
+	result := new(params.ApplicationGetConfigResults)
+	results := params.ApplicationGetConfigResults{
+		Results: []params.ConfigResult{
+			{Config: fooConfig}, {Config: barConfig},
 		},
-	))
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("CharmConfig", args, result).SetArg(2, results).Return(nil)
 
-	results, err := client.GetConfig(newBranchName, "foo", "bar")
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.GetConfig(newBranchName, "foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, []map[string]interface{}{
+	c.Assert(res, jc.DeepEquals, []map[string]interface{}{
 		fooConfig, barConfig,
 	})
 }
 
 func (s *applicationSuite) TestGetConstraints(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	fooConstraints := constraints.MustParse("mem=4G")
 	barConstraints := constraints.MustParse("mem=128G", "cores=64")
-
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "GetConstraints")
-			args, ok := a.(params.Entities)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.Entities{
-				Entities: []params.Entity{
-					{"application-foo"}, {"application-bar"},
-				}})
-
-			result, ok := response.(*params.ApplicationGetConstraintsResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ApplicationConstraint{
-				{Constraints: fooConstraints}, {Constraints: barConstraints},
-			}
-			return nil
+	result := new(params.ApplicationGetConstraintsResults)
+	results := params.ApplicationGetConstraintsResults{
+		Results: []params.ApplicationConstraint{
+			{Constraints: fooConstraints}, {Constraints: barConstraints},
 		},
-	))
+	}
+	args := params.Entities{
+		Entities: []params.Entity{
+			{"application-foo"}, {"application-bar"},
+		}}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("GetConstraints", args, result).SetArg(2, results).Return(nil)
 
-	results, err := client.GetConstraints("foo", "bar")
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.GetConstraints("foo", "bar")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, []constraints.Value{
+	c.Assert(res, jc.DeepEquals, []constraints.Value{
 		fooConstraints, barConstraints,
 	})
 }
 
 func (s *applicationSuite) TestGetConstraintsError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	fooConstraints := constraints.MustParse("mem=4G")
-
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "GetConstraints")
-			args, ok := a.(params.Entities)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.Entities{
-				Entities: []params.Entity{
-					{"application-foo"}, {"application-bar"},
-				}})
-
-			result, ok := response.(*params.ApplicationGetConstraintsResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ApplicationConstraint{
-				{Constraints: fooConstraints},
-				{Error: &params.Error{Message: "oh no"}},
-			}
-			return nil
+	args := params.Entities{
+		Entities: []params.Entity{
+			{"application-foo"}, {"application-bar"},
+		}}
+	result := new(params.ApplicationGetConstraintsResults)
+	results := params.ApplicationGetConstraintsResults{
+		Results: []params.ApplicationConstraint{
+			{Constraints: fooConstraints},
+			{Error: &params.Error{Message: "oh no"}},
 		},
-	))
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("GetConstraints", args, result).SetArg(2, results).Return(nil)
 
-	results, err := client.GetConstraints("foo", "bar")
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.GetConstraints("foo", "bar")
 	c.Assert(err, gc.ErrorMatches, `unable to get constraints for "bar": oh no`)
-	c.Assert(results, gc.IsNil)
+	c.Assert(res, gc.IsNil)
 }
 
 func (s *applicationSuite) TestSetConfig(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	fooConfig := map[string]string{
 		"foo":   "bar",
 		"level": "high",
 	}
 	fooConfigYaml := "foo"
-
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "SetConfigs")
-			args, ok := a.(params.ConfigSetArgs)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.ConfigSetArgs{
-				Args: []params.ConfigSet{{
-					ApplicationName: "foo",
-					Config:          fooConfig,
-					ConfigYAML:      fooConfigYaml,
-					Generation:      newBranchName,
-				}}})
-			result, ok := response.(*params.ErrorResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ErrorResult{
-				{Error: &params.Error{Message: "FAIL"}},
-			}
-			return nil
+	args := params.ConfigSetArgs{
+		Args: []params.ConfigSet{{
+			ApplicationName: "foo",
+			Config:          fooConfig,
+			ConfigYAML:      fooConfigYaml,
+			Generation:      newBranchName,
+		}}}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: &params.Error{Message: "FAIL"}},
 		},
-	))
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("SetConfigs", args, result).SetArg(2, results).Return(nil)
 
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.SetConfig(newBranchName, "foo", fooConfigYaml, fooConfig)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
 func (s *applicationSuite) TestUnsetApplicationConfig(c *gc.C) {
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "UnsetApplicationsConfig")
-			args, ok := a.(params.ApplicationConfigUnsetArgs)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.ApplicationConfigUnsetArgs{
-				Args: []params.ApplicationUnset{{
-					ApplicationName: "foo",
-					Options:         []string{"option"},
-					BranchName:      newBranchName,
-				}}})
-			result, ok := response.(*params.ErrorResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ErrorResult{
-				{Error: &params.Error{Message: "FAIL"}},
-			}
-			return nil
-		},
-	))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
+	args := params.ApplicationConfigUnsetArgs{
+		Args: []params.ApplicationUnset{{
+			ApplicationName: "foo",
+			Options:         []string{"option"},
+			BranchName:      newBranchName,
+		}},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: []params.ErrorResult{
+			{Error: &params.Error{Message: "FAIL"}},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UnsetApplicationsConfig", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.UnsetApplicationConfig(newBranchName, "foo", []string{"option"})
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
 func (s *applicationSuite) TestResolveUnitErrors(c *gc.C) {
-	var called bool
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		called = true
-		c.Check(request, gc.Equals, "ResolveUnitErrors")
-		args, ok := a.(params.UnitsResolved)
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(args, jc.DeepEquals, params.UnitsResolved{
-			Retry: true,
-			Tags: params.Entities{
-				Entities: []params.Entity{
-					{Tag: "unit-mysql-0"},
-					{Tag: "unit-mysql-1"},
-				},
-			},
-		})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-		result := response.(*params.ErrorResults)
-		result.Results = make([]params.ErrorResult, 1)
-		return nil
-	})
+	args := params.UnitsResolved{
+		Retry: true,
+		Tags: params.Entities{
+			Entities: []params.Entity{
+				{Tag: "unit-mysql-0"},
+				{Tag: "unit-mysql-1"},
+			},
+		},
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, 1),
+	}
 	units := []string{"mysql/0", "mysql/1"}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ResolveUnitErrors", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.ResolveUnitErrors(units, false, true)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestResolveUnitErrorsUnitsAll(c *gc.C) {
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		c.Fail()
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	units := []string{"mysql/0"}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.ResolveUnitErrors(units, true, false)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, "specifying units with all=true not supported")
 }
 
 func (s *applicationSuite) TestResolveUnitDuplicate(c *gc.C) {
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		c.Fail()
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	units := []string{"mysql/0", "mysql/1", "mysql/0"}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.ResolveUnitErrors(units, false, false)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, "duplicate unit specified")
 }
 
 func (s *applicationSuite) TestResolveUnitErrorsInvalidUnit(c *gc.C) {
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		c.Fail()
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
 	units := []string{"mysql"}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.ResolveUnitErrors(units, false, false)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err.Error(), gc.Equals, `unit name "mysql" not valid`)
 }
 
 func (s *applicationSuite) TestResolveUnitErrorsAll(c *gc.C) {
-	var called bool
-	client := newClient(func(objType string, version int, id, request string, a, response interface{}) error {
-		called = true
-		c.Check(request, gc.Equals, "ResolveUnitErrors")
-		args, ok := a.(params.UnitsResolved)
-		c.Assert(ok, jc.IsTrue)
-		c.Assert(args, jc.DeepEquals, params.UnitsResolved{
-			All: true,
-		})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-		result := response.(*params.ErrorResults)
-		result.Results = make([]params.ErrorResult, 1)
-		return nil
-	})
+	args := params.UnitsResolved{
+		All: true,
+	}
+	result := new(params.ErrorResults)
+	results := params.ErrorResults{
+		Results: make([]params.ErrorResult, 1),
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ResolveUnitErrors", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.ResolveUnitErrors(nil, true, false)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestScaleApplication(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "ScaleApplications")
-			args, ok := a.(params.ScaleApplicationsParams)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.ScaleApplicationsParams{
-				Applications: []params.ScaleApplicationParams{
-					{ApplicationTag: "application-foo", Scale: 5, Force: true},
-				}})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result, ok := response.(*params.ScaleApplicationResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ScaleApplicationResult{
-				{Info: &params.ScaleApplicationInfo{Scale: 5}},
-			}
-			return nil
+	args := params.ScaleApplicationsParams{
+		Applications: []params.ScaleApplicationParams{
+			{ApplicationTag: "application-foo", Scale: 5, Force: true},
+		}}
+	result := new(params.ScaleApplicationResults)
+	results := params.ScaleApplicationResults{
+		Results: []params.ScaleApplicationResult{
+			{Info: &params.ScaleApplicationInfo{Scale: 5}},
 		},
-	)
-	client := application.NewClient(apiCaller)
-	results, err := client.ScaleApplication(application.ScaleApplicationParams{
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,
 		Force:           true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, params.ScaleApplicationResult{
+	c.Assert(res, jc.DeepEquals, params.ScaleApplicationResult{
 		Info: &params.ScaleApplicationInfo{Scale: 5},
 	})
 }
 
 func (s *applicationSuite) TestChangeScaleApplication(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "ScaleApplications")
-			args, ok := a.(params.ScaleApplicationsParams)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.ScaleApplicationsParams{
-				Applications: []params.ScaleApplicationParams{
-					{ApplicationTag: "application-foo", ScaleChange: 5},
-				}})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result, ok := response.(*params.ScaleApplicationResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ScaleApplicationResult{
-				{Info: &params.ScaleApplicationInfo{Scale: 7}},
-			}
-			return nil
+	args := params.ScaleApplicationsParams{
+		Applications: []params.ScaleApplicationParams{
+			{ApplicationTag: "application-foo", ScaleChange: 5},
+		}}
+	result := new(params.ScaleApplicationResults)
+	results := params.ScaleApplicationResults{
+		Results: []params.ScaleApplicationResult{
+			{Info: &params.ScaleApplicationInfo{Scale: 7}},
 		},
-	)
-	client := application.NewClient(apiCaller)
-	results, err := client.ScaleApplication(application.ScaleApplicationParams{
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		ScaleChange:     5,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, jc.DeepEquals, params.ScaleApplicationResult{
+	c.Assert(res, jc.DeepEquals, params.ScaleApplicationResult{
 		Info: &params.ScaleApplicationInfo{Scale: 7},
 	})
 }
 
 func (s *applicationSuite) TestScaleApplicationArity(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "ScaleApplications")
-			args, ok := a.(params.ScaleApplicationsParams)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.ScaleApplicationsParams{
-				Applications: []params.ScaleApplicationParams{
-					{ApplicationTag: "application-foo", Scale: 5},
-				}})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result, ok := response.(*params.ScaleApplicationResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ScaleApplicationResult{
-				{Info: &params.ScaleApplicationInfo{Scale: 5}},
-				{Info: &params.ScaleApplicationInfo{Scale: 3}},
-			}
-			return nil
+	args := params.ScaleApplicationsParams{
+		Applications: []params.ScaleApplicationParams{
+			{ApplicationTag: "application-foo", Scale: 5},
+		}}
+	result := new(params.ScaleApplicationResults)
+	results := params.ScaleApplicationResults{
+		Results: []params.ScaleApplicationResult{
+			{Info: &params.ScaleApplicationInfo{Scale: 5}},
+			{Info: &params.ScaleApplicationInfo{Scale: 3}},
 		},
-	)
-	client := application.NewClient(apiCaller)
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,
@@ -1038,13 +1081,11 @@ func (s *applicationSuite) TestScaleApplicationArity(c *gc.C) {
 }
 
 func (s *applicationSuite) TestScaleApplicationValidation(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			return nil
-		},
-	)
-	client := application.NewClient(apiCaller)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	for i, test := range []struct {
 		scale       int
 		scaleChange int
@@ -1069,25 +1110,23 @@ func (s *applicationSuite) TestScaleApplicationValidation(c *gc.C) {
 }
 
 func (s *applicationSuite) TestScaleApplicationError(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "ScaleApplications")
-			args, ok := a.(params.ScaleApplicationsParams)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.ScaleApplicationsParams{
-				Applications: []params.ScaleApplicationParams{
-					{ApplicationTag: "application-foo", Scale: 5},
-				}})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result, ok := response.(*params.ScaleApplicationResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ScaleApplicationResult{
-				{Error: &params.Error{Message: "boom"}},
-			}
-			return nil
+	result := new(params.ScaleApplicationResults)
+	results := params.ScaleApplicationResults{
+		Results: []params.ScaleApplicationResult{
+			{Error: &params.Error{Message: "boom"}},
 		},
-	)
-	client := application.NewClient(apiCaller)
+	}
+	args := params.ScaleApplicationsParams{
+		Applications: []params.ScaleApplicationParams{
+			{ApplicationTag: "application-foo", Scale: 5},
+		}}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,
@@ -1096,13 +1135,19 @@ func (s *applicationSuite) TestScaleApplicationError(c *gc.C) {
 }
 
 func (s *applicationSuite) TestScaleApplicationCallError(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "ScaleApplications")
-			return errors.New("boom")
-		},
-	)
-	client := application.NewClient(apiCaller)
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	result := new(params.ScaleApplicationResults)
+	results := params.ScaleApplicationResults{}
+	args := params.ScaleApplicationsParams{
+		Applications: []params.ScaleApplicationParams{
+			{ApplicationTag: "application-foo", Scale: 5},
+		}}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ScaleApplications", args, result).SetArg(2, results).Return(errors.New("boom"))
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.ScaleApplication(application.ScaleApplicationParams{
 		ApplicationName: "foo",
 		Scale:           5,
@@ -1111,64 +1156,59 @@ func (s *applicationSuite) TestScaleApplicationCallError(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationsInfoCallError(c *gc.C) {
-	called := false
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			called = true
-			c.Assert(request, gc.Equals, "ApplicationsInfo")
-			return errors.New("boom")
-		},
-	))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
+	args := params.Entities{make([]params.Entity, 0)}
+	result := new(params.ApplicationInfoResults)
+	results := params.ApplicationInfoResults{make([]params.ApplicationInfoResult, 0)}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ApplicationsInfo", args, result).SetArg(2, results).Return(errors.New("boom"))
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.ApplicationsInfo(nil)
 	c.Assert(err, gc.ErrorMatches, "boom")
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestApplicationsInfo(c *gc.C) {
-	called := false
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			called = true
-			c.Assert(request, gc.Equals, "ApplicationsInfo")
-			args, ok := a.(params.Entities)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.Entities{
-				Entities: []params.Entity{
-					{Tag: "application-foo"},
-					{Tag: "application-bar"},
-				}})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result, ok := response.(*params.ApplicationInfoResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ApplicationInfoResult{
-				{Error: &params.Error{Message: "boom"}},
-				{Result: &params.ApplicationResult{
-					Tag:       "application-bar",
-					Charm:     "charm-bar",
-					Series:    "bionic",
-					Channel:   "development",
-					Principal: true,
-					EndpointBindings: map[string]string{
-						"juju-info": "myspace",
-					},
-					Remote: true,
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: "application-foo"},
+			{Tag: "application-bar"},
+		}}
+	result := new(params.ApplicationInfoResults)
+	results := params.ApplicationInfoResults{
+		Results: []params.ApplicationInfoResult{
+			{Error: &params.Error{Message: "boom"}},
+			{Result: &params.ApplicationResult{
+				Tag:       "application-bar",
+				Charm:     "charm-bar",
+				Series:    "bionic",
+				Channel:   "development",
+				Principal: true,
+				EndpointBindings: map[string]string{
+					"juju-info": "myspace",
 				},
-				},
-			}
-			return nil
+				Remote: true,
+			},
+			},
 		},
-	))
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ApplicationsInfo", args, result).SetArg(2, results).Return(nil)
 
-	results, err := client.ApplicationsInfo(
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.ApplicationsInfo(
 		[]names.ApplicationTag{
 			names.NewApplicationTag("foo"),
 			names.NewApplicationTag("bar"),
 		},
 	)
-	c.Check(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, gc.DeepEquals, []params.ApplicationInfoResult{
+	c.Assert(res, gc.DeepEquals, []params.ApplicationInfoResult{
 		{Error: &params.Error{Message: "boom"}},
 		{Result: &params.ApplicationResult{
 			Tag:       "application-bar",
@@ -1185,103 +1225,99 @@ func (s *applicationSuite) TestApplicationsInfo(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationsInfoResultMismatch(c *gc.C) {
-	called := false
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			called = true
-			c.Assert(request, gc.Equals, "ApplicationsInfo")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result, ok := response.(*params.ApplicationInfoResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.ApplicationInfoResult{
-				{Error: &params.Error{Message: "boom"}},
-				{Error: &params.Error{Message: "boom again"}},
-				{Result: &params.ApplicationResult{Tag: "application-bar"}},
-			}
-			return nil
+	args := params.Entities{[]params.Entity{
+		{Tag: names.NewApplicationTag("foo").String()},
+		{Tag: names.NewApplicationTag("bar").String()},
+	}}
+	result := new(params.ApplicationInfoResults)
+	results := params.ApplicationInfoResults{
+		Results: []params.ApplicationInfoResult{
+			{Error: &params.Error{Message: "boom"}},
+			{Error: &params.Error{Message: "boom again"}},
+			{Result: &params.ApplicationResult{Tag: "application-bar"}},
 		},
-	))
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("ApplicationsInfo", args, result).SetArg(2, results).Return(nil)
 
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.ApplicationsInfo(
 		[]names.ApplicationTag{
 			names.NewApplicationTag("foo"),
 			names.NewApplicationTag("bar"),
 		},
 	)
-	c.Check(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "expected 2 results, got 3")
 }
 
 func (s *applicationSuite) TestUnitsInfoCallError(c *gc.C) {
-	called := false
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			called = true
-			c.Assert(request, gc.Equals, "UnitsInfo")
-			return errors.New("boom")
-		},
-	))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
+	args := params.Entities{make([]params.Entity, 0)}
+	result := new(params.UnitInfoResults)
+	results := params.UnitInfoResults{}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UnitsInfo", args, result).SetArg(2, results).Return(errors.New("boom"))
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.UnitsInfo(nil)
 	c.Assert(err, gc.ErrorMatches, "boom")
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestUnitsInfo(c *gc.C) {
-	called := false
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			called = true
-			c.Assert(request, gc.Equals, "UnitsInfo")
-			args, ok := a.(params.Entities)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.Entities{
-				Entities: []params.Entity{
-					{Tag: "unit-foo-0"},
-					{Tag: "unit-bar-1"},
-				}})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result, ok := response.(*params.UnitInfoResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.UnitInfoResult{
-				{Error: &params.Error{Message: "boom"}},
-				{Result: &params.UnitResult{
-					Tag:             "unit-bar-1",
-					WorkloadVersion: "666",
-					Machine:         "1",
-					OpenedPorts:     []string{"80"},
-					PublicAddress:   "10.0.0.1",
-					Charm:           "charm-bar",
-					Leader:          true,
-					RelationData: []params.EndpointRelationData{{
-						Endpoint:        "db",
-						CrossModel:      true,
-						RelatedEndpoint: "server",
-						ApplicationData: map[string]interface{}{"foo": "bar"},
-						UnitRelationData: map[string]params.RelationData{
-							"baz": {
-								InScope:  true,
-								UnitData: map[string]interface{}{"hello": "world"},
-							},
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: "unit-foo-0"},
+			{Tag: "unit-bar-1"},
+		}}
+	result := new(params.UnitInfoResults)
+	results := params.UnitInfoResults{
+		Results: []params.UnitInfoResult{
+			{Error: &params.Error{Message: "boom"}},
+			{Result: &params.UnitResult{
+				Tag:             "unit-bar-1",
+				WorkloadVersion: "666",
+				Machine:         "1",
+				OpenedPorts:     []string{"80"},
+				PublicAddress:   "10.0.0.1",
+				Charm:           "charm-bar",
+				Leader:          true,
+				RelationData: []params.EndpointRelationData{{
+					Endpoint:        "db",
+					CrossModel:      true,
+					RelatedEndpoint: "server",
+					ApplicationData: map[string]interface{}{"foo": "bar"},
+					UnitRelationData: map[string]params.RelationData{
+						"baz": {
+							InScope:  true,
+							UnitData: map[string]interface{}{"hello": "world"},
 						},
-					}},
-					ProviderId: "provider-id",
-					Address:    "192.168.1.1",
+					},
 				}},
-			}
-			return nil
+				ProviderId: "provider-id",
+				Address:    "192.168.1.1",
+			}},
 		},
-	))
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UnitsInfo", args, result).SetArg(2, results).Return(nil)
 
-	results, err := client.UnitsInfo(
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	res, err := client.UnitsInfo(
 		[]names.UnitTag{
 			names.NewUnitTag("foo/0"),
 			names.NewUnitTag("bar/1"),
 		},
 	)
-	c.Check(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, gc.DeepEquals, []application.UnitInfo{
+	c.Assert(res, gc.DeepEquals, []application.UnitInfo{
 		{Error: stderrors.New("boom")},
 		{
 			Tag:             "unit-bar-1",
@@ -1310,19 +1346,22 @@ func (s *applicationSuite) TestUnitsInfo(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUnitsInfoResultMismatch(c *gc.C) {
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			c.Assert(request, gc.Equals, "UnitsInfo")
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-			result, ok := response.(*params.UnitInfoResults)
-			c.Assert(ok, jc.IsTrue)
-			result.Results = []params.UnitInfoResult{
-				{}, {}, {},
-			}
-			return nil
-		},
-	))
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: "unit-foo-0"},
+			{Tag: "unit-bar-1"},
+		}}
+	result := new(params.UnitInfoResults)
+	results := params.UnitInfoResults{Results: []params.UnitInfoResult{
+		{}, {}, {},
+	}}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UnitsInfo", args, result).SetArg(2, results).Return(nil)
 
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	_, err := client.UnitsInfo(
 		[]names.UnitTag{
 			names.NewUnitTag("foo/0"),
@@ -1333,28 +1372,24 @@ func (s *applicationSuite) TestUnitsInfoResultMismatch(c *gc.C) {
 }
 
 func (s *applicationSuite) TestExpose(c *gc.C) {
-	called := false
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			called = true
-			c.Assert(request, gc.Equals, "Expose")
-			args, ok := a.(params.ApplicationExpose)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.ApplicationExpose{
-				ApplicationName: "foo",
-				ExposedEndpoints: map[string]params.ExposedEndpoint{
-					"": {
-						ExposeToCIDRs: []string{"0.0.0.0/0"},
-					},
-					"foo": {
-						ExposeToSpaces: []string{"outer"},
-					},
-				},
-			})
-			return nil
-		},
-	))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
+	args := params.ApplicationExpose{
+		ApplicationName: "foo",
+		ExposedEndpoints: map[string]params.ExposedEndpoint{
+			"": {
+				ExposeToCIDRs: []string{"0.0.0.0/0"},
+			},
+			"foo": {
+				ExposeToSpaces: []string{"outer"},
+			},
+		},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Expose", args, nil).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.Expose("foo", map[string]params.ExposedEndpoint{
 		"": {
 			ExposeToCIDRs: []string{"0.0.0.0/0"},
@@ -1364,42 +1399,36 @@ func (s *applicationSuite) TestExpose(c *gc.C) {
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestUnexpose(c *gc.C) {
-	called := false
-	client := application.NewClient(basetesting.APICallerFunc(
-		func(objType string, version int, id, request string, a, response interface{}) error {
-			called = true
-			c.Assert(request, gc.Equals, "Unexpose")
-			args, ok := a.(params.ApplicationUnexpose)
-			c.Assert(ok, jc.IsTrue)
-			c.Assert(args, jc.DeepEquals, params.ApplicationUnexpose{
-				ApplicationName:  "foo",
-				ExposedEndpoints: []string{"foo"},
-			})
-			return nil
-		},
-	))
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
+	args := params.ApplicationUnexpose{
+		ApplicationName:  "foo",
+		ExposedEndpoints: []string{"foo"},
+	}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Unexpose", args, nil).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
 	err := client.Unexpose("foo", []string{"foo"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(called, jc.IsTrue)
 }
 
 func (s *applicationSuite) TestLeader(c *gc.C) {
-	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "Application")
-		c.Check(request, gc.Equals, "Leader")
-		c.Assert(arg, gc.Equals, params.Entity{Tag: names.NewApplicationTag("ubuntu").String()})
-		c.Assert(result, gc.FitsTypeOf, &params.StringResult{})
-		*(result.(*params.StringResult)) = params.StringResult{Result: "ubuntu/42"}
-		return nil
-	})
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
 
-	facade := application.NewClient(apiCaller)
-	obtainedUnit, err := facade.Leader("ubuntu")
+	args := params.Entity{Tag: names.NewApplicationTag("ubuntu").String()}
+	result := new(params.StringResult)
+	results := params.StringResult{Result: "ubuntu/42"}
+	mockFacadeCaller := mocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("Leader", args, result).SetArg(2, results).Return(nil)
+
+	client := application.NewClientFromCaller(mockFacadeCaller)
+	obtainedUnit, err := client.Leader("ubuntu")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedUnit, gc.Equals, "ubuntu/42")
 }

--- a/api/client/application/export_test.go
+++ b/api/client/application/export_test.go
@@ -1,0 +1,12 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import "github.com/juju/juju/api/base"
+
+func NewClientFromCaller(caller base.FacadeCaller) *Client {
+	return &Client{
+		facade: caller,
+	}
+}


### PR DESCRIPTION
This replaces juju/testing with gomocks. All unit tests should pass.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test -v github.com/juju/juju/api/client/application -check.f applicationSuite
```