### PR TITLE
[JUJU-1848] Integration test for default-series and charm deployment

### DIFF
--- a/tests/suites/deploy/deploy_default_series.sh
+++ b/tests/suites/deploy/deploy_default_series.sh
@@ -1,0 +1,57 @@
+run_deploy_default_series() {
+	echo
+
+	model_name="test-deploy-default-series"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju model-config default-series=bionic
+	juju deploy ubuntu
+	juju deploy cs:ubuntu csubuntu
+
+	ubuntu_series=$(juju status --format=json | jq ".applications.ubuntu.series")
+	echo "$ubuntu_series" | check "bionic"
+
+	csubuntu_series=$(juju status --format=json | jq ".applications.csubuntu.series")
+	echo "$csubuntu_series" | check "bionic"
+
+	destroy_model "${model_name}"
+}
+
+run_deploy_not_default_series() {
+	echo
+
+	model_name="test-deploy-not-default-series"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju model-config default-series=bionic
+	juju deploy ubuntu --series focal
+	juju deploy cs:ubuntu csubuntu --series focal
+
+	ubuntu_series=$(juju status --format=json | jq ".applications.ubuntu.series")
+	echo "$ubuntu_series" | check "focal"
+
+	csubuntu_series=$(juju status --format=json | jq ".applications.csubuntu.series")
+	echo "$csubuntu_series" | check "focal"
+
+	destroy_model "${model_name}"
+}
+
+test_deploy_default_series() {
+	if [ "$(skip 'test_deploy_default_series')" ]; then
+		echo "==> TEST SKIPPED: deploy default series"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_deploy_default_series"
+		run "run_deploy_not_default_series"
+	)
+}

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -18,6 +18,7 @@ test_deploy() {
 	test_cmr_bundles_export_overlay
 	test_deploy_os
 	test_deploy_revision
+	test_deploy_default_series
 
 	destroy_controller "test-deploy-ctl"
 }


### PR DESCRIPTION
Integration tests to ensure the default series changes work for charms. These tests will require edits to work with juju 3.0 due to changes around bases and series.

## QA steps


```sh
(cd tests ; ./main.sh -v deploy test_deploy_default_series)
```
