### PR TITLE
Fix kvm imagepath

### DIFF
--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -302,6 +301,5 @@ func newImage(md *imagedownloads.Metadata, imageDownloadURL string, pathfinder p
 }
 
 func backingFileName(version, arch string) string {
-	vers := strings.ReplaceAll(version, ".", "_")
-	return fmt.Sprintf("%s-%s-backing-file.qcow", vers, arch)
+	return fmt.Sprintf("%s-%s-backing-file.qcow", version, arch)
 }

--- a/container/kvm/sync.go
+++ b/container/kvm/sync.go
@@ -294,7 +294,7 @@ func newImage(md *imagedownloads.Metadata, imageDownloadURL string, pathfinder p
 
 	return &Image{
 		FilePath: filepath.Join(
-			baseDir, kvm, guestDir, backingFileName(md.Release, md.Arch)),
+			baseDir, kvm, guestDir, backingFileName(md.Version, md.Arch)),
 		tmpFile:  fh,
 		runCmd:   run,
 		progress: callback,

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/paths"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/environs/imagedownloads"
 )
 
@@ -66,7 +66,7 @@ func (syncInternalSuite) TestFetcher(c *gc.C) {
 
 	// Check that our call was made as expected.
 	c.Assert(stub.Calls(), gc.HasLen, 1)
-	c.Assert(stub.Calls()[0], gc.Matches, " qemu-img convert -f qcow2 .*/juju-kvm-server.img-.* .*/guests/spammy-archless-backing-file.qcow")
+	c.Assert(stub.Calls()[0], gc.Matches, " qemu-img convert -f qcow2 .*/juju-kvm-server.img-.* .*/guests/version-archless-backing-file.qcow")
 
 }
 
@@ -102,7 +102,7 @@ func (syncInternalSuite) TestFetcherWriteFails(c *gc.C) {
 
 	// Check that our call was made as expected.
 	c.Assert(stub.Calls(), gc.HasLen, 1)
-	c.Assert(stub.Calls()[0], gc.Matches, " qemu-img convert -f qcow2 .*/juju-kvm-server.img-.* .*/guests/spammy-archless-backing-file.qcow")
+	c.Assert(stub.Calls()[0], gc.Matches, " qemu-img convert -f qcow2 .*/juju-kvm-server.img-.* .*/guests/version-archless-backing-file.qcow")
 
 }
 

--- a/container/kvm/wrappedcmds.go
+++ b/container/kvm/wrappedcmds.go
@@ -198,13 +198,13 @@ func CreateMachine(params CreateMachineParams) error {
 
 	out, err := params.runCmdAsRoot("", virsh, "define", domainPath)
 	if err != nil {
-		return errors.Annotatef(err, "failed to defined the domain for %q from %s", params.Host(), domainPath)
+		return errors.Annotatef(err, "failed to define the domain for %q from %s:%s", params.Host(), domainPath, out)
 	}
 	logger.Debugf("created domain: %s", out)
 
 	out, err = params.runCmdAsRoot("", virsh, "start", params.Host())
 	if err != nil {
-		return errors.Annotatef(err, "failed to start domain %q", params.Host())
+		return errors.Annotatef(err, "failed to start domain %q:%s", params.Host(), out)
 	}
 	logger.Debugf("started domain: %s", out)
 

--- a/container/kvm/wrappedcmds_test.go
+++ b/container/kvm/wrappedcmds_test.go
@@ -108,7 +108,7 @@ func (s *commandWrapperSuite) TestCreateMachineSuccessOnFocal(c *gc.C) {
 		tmpDir + ` genisoimage -output \/tmp\/juju-libvirtSuite-\d+\/kvm\/guests\/host00-ds\.iso -volid cidata -joliet -rock user-data meta-data network-config`,
 		// On focal, the backing image format must be explicitly specified
 		// hence the '-F raw'
-		` qemu-img create -b \/tmp/juju-libvirtSuite-\d+\/kvm\/guests\/20_04-arm64-backing-file.qcow -F raw -f qcow2 \/tmp\/juju-libvirtSuite-\d+\/kvm\/guests\/host00.qcow 8G`,
+		` qemu-img create -b \/tmp/juju-libvirtSuite-\d+\/kvm\/guests\/20.04-arm64-backing-file.qcow -F raw -f qcow2 \/tmp\/juju-libvirtSuite-\d+\/kvm\/guests\/host00.qcow 8G`,
 		` virsh define \/tmp\/juju-libvirtSuite-\d+\/host00.xml`,
 		" virsh start host00",
 	}

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -4,7 +4,7 @@
 #if GetEnv('JUJU_VERSION') != ""
 #define MyAppVersion=GetEnv('JUJU_VERSION')
 #else
-#define MyAppVersion="3.0.0"
+#define MyAppVersion="3.0-rc2"
 #endif
 
 #define MyAppName "Juju"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 3.0.0
+version: 3.0-rc2
 summary: Juju - a model-driven operator lifecycle manager for K8s and machines
 license: AGPL-3.0
 description: |

--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "3.0.0"
+const version = "3.0-rc2"
 
 // UserAgentVersion defines a user agent version used for communication for
 // outside resources.


### PR DESCRIPTION
The kvm image path was being created with the series name, not the os version.

Also change juju version to 3.0-rc2

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

In the absence of access to a cloud able to run kvm images, I used a hacked version of juju witch attempted to start kvm instances even when support was not available. The kvm image was downloaded and used to set up the guest iso etc.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993065
