### PR TITLE
[JUJU-1977] Remove debugging left behind, tidy up k8s base handling

### DIFF
--- a/api/common/charm/charmorigin.go
+++ b/api/common/charm/charmorigin.go
@@ -58,21 +58,17 @@ type Origin struct {
 	InstanceKey string
 }
 
-// WithSeries allows to update the series of an origin.
-// TODO(juju3) - remove, replace with os/channel
-func (o Origin) WithSeries(aseries string) Origin {
+// WithBase allows to update the base of an origin.
+func (o Origin) WithBase(b *series.Base) Origin {
 	other := o
-	if aseries != "" {
-		// Legacy k8s charms - assume ubuntu focal.
-		if aseries == "kubernetes" {
-			aseries = "focal"
-		}
-		other.Base, _ = series.GetBaseFromSeries(aseries)
+	other.Base = series.Base{}
+	if b != nil {
+		other.Base = *b
 	}
 	return other
 }
 
-// CharmChannel returns the the channel indicated by this origin.
+// CharmChannel returns the channel indicated by this origin.
 func (o Origin) CharmChannel() charm.Channel {
 	var track string
 	if o.Track != nil {

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -414,7 +414,7 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 				Name:     url.Name,
 				Revision: -1,
 			}
-			origin = origin.WithSeries("")
+			origin = origin.WithBase(nil)
 		}
 
 		h.ctx.Infof(formatLocatedText(ch, origin))
@@ -939,7 +939,7 @@ func (h *bundleHandler) addApplication(change *bundlechanges.AddApplicationChang
 	// Only Kubernetes bundles send the unit count and placement with the deploy API call.
 	numUnits := 0
 	var placement []*instance.Placement
-	if h.data.Type == "kubernetes" {
+	if h.data.Type == series.Kubernetes.String() {
 		numUnits = p.NumUnits
 	}
 

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -482,7 +482,16 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	// Ensure we save the origin.
-	origin = origin.WithSeries(series)
+	var base coreseries.Base
+	if series == coreseries.Kubernetes.String() {
+		base = coreseries.LegacyKubernetesBase()
+	} else {
+		base, err = coreseries.GetBaseFromSeries(series)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	origin = origin.WithBase(&base)
 
 	// In-order for the url to represent the following updates to the origin
 	// and machine, we need to ensure that the series is actually correct as

--- a/cmd/juju/application/utils/origin.go
+++ b/cmd/juju/application/utils/origin.go
@@ -35,9 +35,10 @@ func DeduceOrigin(url *charm.URL, channel charm.Channel, platform corecharm.Plat
 
 	var origin commoncharm.Origin
 	// Legacy k8s charms - assume ubuntu focal.
-	if platform.OS == "kubernetes" || platform.Channel == "kubernetes" {
-		platform.OS = "ubuntu"
-		platform.Channel = "20.04"
+	if platform.OS == coreseries.Kubernetes.String() || platform.Channel == coreseries.Kubernetes.String() {
+		b := coreseries.LegacyKubernetesBase()
+		platform.OS = b.OS
+		platform.Channel = b.Channel.Track
 	}
 	switch url.Schema {
 	case "cs":

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/naturalsort"
 
 	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/series"
 )
 
 type resolver struct {
@@ -49,7 +50,7 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 		application := applications[name]
 		// Legacy k8s charms - assume ubuntu focal.
 		if application.Series == kubernetes {
-			application.Series = "focal"
+			application.Series = series.LegacyKubernetesSeries()
 		}
 		existingApp := existing.GetApplication(name)
 		series, err := getSeries(application, defaultSeries)
@@ -1265,13 +1266,12 @@ func getSeries(application *charm.ApplicationSpec, defaultSeries string) (string
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	series := charmURL.Series
-	if series != "" {
+	if charmURL.Series != "" {
 		// Legacy k8s charms - assume ubuntu focal.
-		if series == kubernetes {
-			return "focal", nil
+		if charmURL.Series == kubernetes {
+			return series.LegacyKubernetesSeries(), nil
 		}
-		return series, nil
+		return charmURL.Series, nil
 	}
 	return defaultSeries, nil
 }

--- a/core/series/base.go
+++ b/core/series/base.go
@@ -5,7 +5,6 @@ package series
 
 import (
 	"fmt"
-	"runtime/debug"
 	"strings"
 
 	"github.com/juju/errors"
@@ -22,10 +21,6 @@ type Base struct {
 
 // ParseBase constructs a Base from the os and channel string.
 func ParseBase(os string, channel string) (Base, error) {
-	if channel == "kubernetes" {
-		logger.Criticalf("%s", debug.Stack())
-	}
-
 	if os == "" && channel == "" {
 		return Base{}, nil
 	}
@@ -41,10 +36,6 @@ func ParseBase(os string, channel string) (Base, error) {
 
 // MakeDefaultBase creates a base from an os and simple version string, eg "22.04".
 func MakeDefaultBase(os string, channel string) Base {
-	if channel == "kubernetes" {
-		logger.Criticalf("%s", debug.Stack())
-	}
-
 	return Base{OS: os, Channel: MakeDefaultChannel(channel)}
 }
 
@@ -52,21 +43,21 @@ func (b Base) String() string {
 	if b.OS == "" {
 		return ""
 	}
-	//if b.OS == "kubernetes" {
-	//	return b.OS
-	//}
 	return fmt.Sprintf("%s:%s", b.OS, b.Channel)
 }
 
+// IsCompatible returns true if base other is the same underlying
+// OS version, ignoring risk.
 func (b Base) IsCompatible(other Base) bool {
 	return b.OS == other.OS && b.Channel.Track == other.Channel.Track
 }
 
-func (b *Base) DisplayString() string {
-	if b == nil || b.OS == "" {
+// DisplayString returns the base string ignoring risk.
+func (b Base) DisplayString() string {
+	if b.Channel.Track == "" || b.OS == "" {
 		return ""
 	}
-	if b.OS == "kubernetes" {
+	if b.OS == Kubernetes.String() {
 		return b.OS
 	}
 	return b.OS + ":" + b.Channel.DisplayString()
@@ -74,9 +65,6 @@ func (b *Base) DisplayString() string {
 
 // GetBaseFromSeries returns the Base infor for a series.
 func GetBaseFromSeries(series string) (Base, error) {
-	if series == "kubernetes" {
-		logger.Criticalf("%s", debug.Stack())
-	}
 	var result Base
 	osName, err := GetOSFromSeries(series)
 	if err != nil {
@@ -116,4 +104,14 @@ func GetSeriesFromBase(v Base) (string, error) {
 		}
 	}
 	return "", errors.NotFoundf("os %q version %q", v.OS, v.Channel.Track)
+}
+
+// LegacyKubernetesBase is the ubuntu base image for legacy k8s charms.
+func LegacyKubernetesBase() Base {
+	return MakeDefaultBase("ubuntu", "20.04")
+}
+
+// LegacyKubernetesSeries is the ubuntu series for legacy k8s charms.
+func LegacyKubernetesSeries() string {
+	return "focal"
 }

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -842,7 +842,7 @@ func (s *JujuConnSuite) AddTestingCharmForSeries(c *gc.C, name, series string) *
 func (s *JujuConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Charm) *state.Application {
 	appSeries := ch.URL().Series
 	if appSeries == "kubernetes" {
-		appSeries = "focal"
+		appSeries = series.LegacyKubernetesSeries()
 	}
 	base, err := series.GetBaseFromSeries(appSeries)
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -497,7 +497,7 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 		chSeries := params.Charm.URL().Series
 		// Legacy k8s charms - assume ubuntu focal.
 		if chSeries == "kubernetes" {
-			chSeries = "focal"
+			chSeries = coreseries.LegacyKubernetesSeries()
 		}
 		base, err := coreseries.GetBaseFromSeries(chSeries)
 		c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Some debugging code was left in - remove it.

There was still a place in add-relation where we were passing the legacy "kubernetes" series to GetBaseFromSeries. That is now fixed - we are moving away from "kubernetes" as a series name.

The PR also tidies up the conversion of "kubernetes" series to "focal".

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

juju bootstrap microk8s
juju deploy kubeflow-lite

juju bootstrap lxd
juju deploy bundle.yaml
```
applications:
  juju-qa-test:
    charm: juju-qa-test
    channel: stable
    num_units: 2
  nrpe:
    charm: cs:nrpe-64
    channel: stable
  ntp:
    charm: cs:ntp-40
    channel: stable
    series: focal
  telegraf:
    charm: cs:telegraf-37
    channel: stable
  ubuntu:
    charm: ubuntu
    series: focal
    num_units: 2
      #    to:
      #      - "lxd:new"
relations:
- - ntp:juju-info
  - juju-qa-test:juju-info
- - ntp:juju-info
  - ubuntu:juju-info
- - nrpe:general-info
  - ubuntu:juju-info
- - telegraf:juju-info
  - ubuntu:juju-info
```
`juju refresh ubuntu --path /path/to/local/ubuntu`