### PR TITLE
Test 3.0/candidate instead of 3.0/beta;

### DIFF
--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -65,7 +65,7 @@ run_model_migration_version() {
 
 	# test against beta channel for devel
 	# TODO: change back to stable once 3.0 released.
-	channel="$major_minor/beta"
+	channel="$major_minor/candidate"
 
 	stable_version=$(snap info juju | yq ".channels[\"$channel\"]" | cut -d' ' -f1)
 	echo "stable_version ==> $stable_version"


### PR DESCRIPTION
Run `run_model_migration_version` against 3.0/candidate instead of 3.0/beta;