### PR TITLE
[JUJU 1951] fix failing model metric tests in proving ground

### DIFF
--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -21,7 +21,7 @@ run_model_metrics() {
 	juju relate ntp:juju-info juju-qa-test:juju-info
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test" 1)"
 
-	juju model-config -m controller logging-config="'<root>=INFO;#charmhub=TRACE'"
+	juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE"
 
 	# Restarting the controller service causes the charmrevisionupdater worker to run.
 	juju ssh -m controller 0 -- sudo systemctl restart jujud-machine-0.service
@@ -64,7 +64,7 @@ run_empty_model_metrics() {
 	wait_for_machine_agent_status 0 "started"
 	wait_for_machine_agent_status 1 "started"
 	wait_for_machine_agent_status 2 "started"
-	juju model-config -m controller logging-config="'<root>=INFO;#charmhub=TRACE'"
+	juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE"
 
 	# Restarting the controller service causes the charmrevisionupdater worker to run.
 	juju ssh -m controller 0 -- sudo systemctl restart jujud-machine-0.service
@@ -107,7 +107,7 @@ run_model_metrics_disabled() {
 	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 0)"
 	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 1)"
 	juju model-config disable-telemetry=true
-	juju model-config -m controller logging-config="'<root>=INFO;#charmhub=TRACE'"
+	juju model-config -m controller logging-config="<root>=INFO;#charmhub=TRACE"
 
 	# Restarting the controller service causes the charmrevisionupdater worker to run.
 	juju ssh -m controller 0 -- sudo systemctl restart jujud-machine-0.service

--- a/tests/suites/model/task.sh
+++ b/tests/suites/model/task.sh
@@ -11,7 +11,8 @@ test_model() {
 
 	file="${TEST_DIR}/test-models.log"
 
-	bootstrap "test-models" "${file}"
+	JUJU_AGENT_TESTING_OPTIONS=CHARM_REVISION_UPDATE_INTERVAL=15s \
+		bootstrap "test-models" "${file}"
 
 	# Tests that need to be run are added here.
 	test_model_config


### PR DESCRIPTION
-  Removes quotes around the logging-config constraints  in the [test-model-metrics tests](test-model-test-model-metrics-lxd) in proving grounds.
-  Overrides the charm revision updater interval to control how often the charm revision worker runs. (Sets it to 15s interval)
**NOTE:** A change introduced in the charmrevision worker loop. (Can't trace the PR) prevents the charm revision calling on startup.( For good reasons). We implemented a truncated exponential backoff with introduced jitter.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests 
./main.sh -v -p lxd -c localhost model test_model_metrics
```