### PR TITLE
Merge pull request #14768 from manadart/2.9-do-not-filter-all-fan

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -154,20 +154,9 @@ func FilterBridgeAddresses(addresses corenetwork.ProviderAddresses) corenetwork.
 	addressesToRemove := make(map[string][]string)
 	gatherBridgeAddresses(DefaultLXDBridge, addressesToRemove)
 	gatherBridgeAddresses(DefaultKVMBridge, addressesToRemove)
-	gatherFanAddresses(addresses, addressesToRemove)
 	filtered := filterAddrs(addresses, addressesToRemove)
 	logger.Debugf("addresses after filtering: %v", filtered)
 	return filtered
-}
-
-func gatherFanAddresses(addresses corenetwork.ProviderAddresses, addressesToRemove map[string][]string) {
-	var fanAddrs []string
-	for _, addr := range addresses {
-		if addr.Scope == corenetwork.ScopeFanLocal {
-			fanAddrs = append(fanAddrs, addr.Value)
-		}
-	}
-	addressesToRemove["fan"] = fanAddrs
 }
 
 // QuoteSpaces takes a slice of space names, and returns a nicely formatted

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -135,7 +135,7 @@ func (s *NetworkSuite) TestFilterBridgeAddresses(c *gc.C) {
 		"192.168.122.1", // filtered (from virbr0 bridge, 192.168.122.1)
 		"192.168.123.42",
 		"localhost",    // unfiltered because it isn't an IP address
-		"252.16.134.1", // filtered Class E reserved address, used by Fan.
+		"252.16.134.1", // unfiltered Class E reserved address, used by Fan.
 	}).AsProviderAddresses()
 	filteredAddresses := corenetwork.NewMachineAddresses([]string{
 		"127.0.0.1",
@@ -144,6 +144,7 @@ func (s *NetworkSuite) TestFilterBridgeAddresses(c *gc.C) {
 		"10.0.6.10",
 		"192.168.123.42",
 		"localhost",
+		"252.16.134.1",
 	}).AsProviderAddresses()
 	c.Assert(network.FilterBridgeAddresses(inputAddresses), jc.DeepEquals, filteredAddresses)
 }


### PR DESCRIPTION
https://github.com/juju/juju/pull/14768

Patch https://github.com/juju/juju/pull/14611 went out with 2.9.35. It filters Fan addresses from those that are advertised to agents as usable for Juju API communication.

This however, breaks Anbox cloud appliance, which uses the LXD provider in combination with Fan networking. In that situation, all controller addresses are filtered from those to be set in agent configuration, and deploying such agents fails.

Here we revert the filtering that was added.

## QA steps

- Bootstrap to AWS.
- Check that Fan addresses are included in agent configuration:
```
juju:PRIMARY> db.controllers.find({"_id": "apiHostPortsForAgents"}).pretty()
{
 "_id" : "apiHostPortsForAgents",
 "apihostports" : [
 [
 {
 "value" : "54.159.29.145",
 "addresstype" : "ipv4",
 "networkscope" : "public",
 "port" : 17070,
 "spaceid" : "0"
 },
 {
 "value" : "172.31.16.134",
 "addresstype" : "ipv4",
 "networkscope" : "local-cloud",
 "port" : 17070,
 "spaceid" : "0"
 },
 {
 "value" : "252.16.134.1",
 "addresstype" : "ipv4",
 "networkscope" : "local-fan",
 "port" : 17070
 },
 {
 "value" : "127.0.0.1",
 "addresstype" : "ipv4",
 "networkscope" : "local-machine",
 "port" : 17070
 },
 {
 "value" : "::1",
 "addresstype" : "ipv6",
 "networkscope" : "local-machine",
 "port" : 17070
 }
 ]
 ],
 "txn-revno" : NumberLong(5),
 "txn-queue" : [
 "6321c73701cb932137c859d6_7e30d7b3"
 ]
}
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993137

