### PR TITLE
[JUJU-1982] Metrics test appname

### DIFF
--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -8,14 +8,15 @@ run_model_metrics() {
 	file="${TEST_DIR}/test-${testname}.log"
 	ensure "${testname}" "${file}"
 
-	juju deploy ubuntu ubuntu
+	# deploy ubuntu with a different name, check that the metric send the charm name, not the application name.
+	juju deploy ubuntu app-one
 	juju deploy juju-qa-test
 	juju deploy ntp
-	juju relate ntp ubuntu
+	juju relate ntp app-one
 
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 1)"
-	wait_for "ubuntu" "$(idle_condition "ubuntu" 0)"
-	wait_for "ntp" "$(idle_subordinate_condition "ntp" "ubuntu" 0)"
+	wait_for "app-one" "$(idle_condition "app-one" 0)"
+	wait_for "ntp" "$(idle_subordinate_condition "ntp" "app-one" 0)"
 
 	juju relate ntp:juju-info juju-qa-test:juju-info
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test" 1)"


### PR DESCRIPTION
A mass change of charms not using focal, caught the wrong thing. Focal was used as an application name, not a series to deploy. Revert the change and update so the application name is not a series.

## QA steps
Normally:
```sh
 (cd tests ; ./main.sh -v model test_model_metrics)
```

However there is something broken with the test, changes were made to juju at some point and the test no longer works. This is currently under investigation