### PR TITLE
[JUJU-1986] Change min LXD version to 5.0

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -374,7 +374,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 		ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{"xenial": 2}, nil),
 		// - check LXD version.
 		serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 		ctrlModel.EXPECT().Owner().Return(names.NewUserTag("admin")),
 		ctrlModel.EXPECT().Name().Return("controller"),
 
@@ -397,7 +397,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 		}, nil),
 		// - check LXD version.
 		serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 		model1.EXPECT().Owner().Return(names.NewUserTag("admin")),
 		model1.EXPECT().Name().Return("model-1"),
 	)
@@ -417,13 +417,13 @@ cannot upgrade to "3.9.99" due to issues with these models:
 - mongo version has to be "4.4" at least, but current version is "4.3"
 - the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): xenial(2)
-- LXD version has to be at least "5.2.0", but current version is only "5.1.0"
+- LXD version has to be at least "5.0.0", but current version is only "4.0.0"
 "admin/model-1":
 - current model ("2.9.0") has to be upgraded to "2.9.2" at least
 - model is under "exporting" mode, upgrade blocked
 - the model hosts deprecated windows machine(s): win10(1) win7(3)
 - the model hosts deprecated ubuntu machine(s): artful(1) cosmic(2) disco(3) eoan(4) groovy(5) hirsute(6) impish(7) precise(8) quantal(9) raring(10) saucy(11) trusty(12) utopic(13) vivid(14) wily(15) xenial(16) yakkety(17) zesty(18)
-- LXD version has to be at least "5.2.0", but current version is only "5.1.0"`[1:])
+- LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
 
 func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool) {
@@ -563,7 +563,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 		}, nil),
 		// - check LXD version.
 		serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 		model.EXPECT().Owner().Return(names.NewUserTag("admin")),
 		model.EXPECT().Name().Return("model-1"),
 	)
@@ -580,7 +580,7 @@ cannot upgrade to "3.9.99" due to issues with these models:
 - unexpected upgrade series lock found
 - the model hosts deprecated windows machine(s): win10(1) win7(3)
 - the model hosts deprecated ubuntu machine(s): artful(1) cosmic(2) disco(3) eoan(4) groovy(5) hirsute(6) impish(7) precise(8) quantal(9) raring(10) saucy(11) trusty(12) utopic(13) vivid(14) wily(15) xenial(16) yakkety(17) zesty(18)
-- LXD version has to be at least "5.2.0", but current version is only "5.1.0"`[1:])
+- LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
 
 func (s *modelUpgradeSuite) TestAbortCurrentUpgrade(c *gc.C) {

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -110,7 +110,7 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
-	server.EXPECT().ServerVersion().Return("5.1")
+	server.EXPECT().ServerVersion().Return("4.0")
 
 	err := migration.SourcePrecheck(
 		backend, version.MustParse("3.0.0"), allAlivePresence(), allAlivePresence(),
@@ -125,7 +125,7 @@ cannot migrate to controller ("3.0.0") due to issues:
 - unexpected upgrade series lock found
 - the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): trusty(3) vivid(2) xenial(1)
-- LXD version has to be at least "5.2.0", but current version is only "5.1.0"`[1:])
+- LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
 
 func (*SourcePrecheckSuite) TestTargetController2Failed(c *gc.C) {

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -391,7 +391,7 @@ func parseAPIVersion(s string) (version.Number, error) {
 }
 
 // minLXDVersion defines the min version of LXD we support.
-var minLXDVersion = version.Number{Major: 5, Minor: 2}
+var minLXDVersion = version.Number{Major: 5, Minor: 0}
 
 // ValidateAPIVersion validates the LXD version.
 func ValidateAPIVersion(version string) error {

--- a/provider/lxd/server_integration_test.go
+++ b/provider/lxd/server_integration_test.go
@@ -455,7 +455,7 @@ func (s *serverIntegrationSuite) TestRemoteServerWithUnSupportedAPIVersion(c *gc
 
 	gomock.InOrder(
 		server.EXPECT().StorageSupported().Return(false),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 	)
 
 	creds := cloud.NewCredential("any", map[string]string{
@@ -467,7 +467,7 @@ func (s *serverIntegrationSuite) TestRemoteServerWithUnSupportedAPIVersion(c *gc
 		Endpoint:   "https://10.0.0.9:8443",
 		Credential: &creds,
 	})
-	c.Assert(errors.Cause(err).Error(), gc.Equals, `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`)
+	c.Assert(errors.Cause(err).Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
 }
 
 func (s *serverIntegrationSuite) TestIsSupportedAPIVersion(c *gc.C) {
@@ -484,11 +484,11 @@ func (s *serverIntegrationSuite) TestIsSupportedAPIVersion(c *gc.C) {
 			output: `major version number  a not valid`,
 		},
 		{
-			input:  "5.1",
-			output: `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`,
+			input:  "4.0",
+			output: `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`,
 		},
 		{
-			input:  "5.2",
+			input:  "5.0",
 			output: "",
 		},
 	} {

--- a/provider/lxd/server_test.go
+++ b/provider/lxd/server_test.go
@@ -37,9 +37,9 @@ func (s *serverSuite) TestParseAPIVersion(c *gc.C) {
 }
 
 func (s *serverSuite) TestValidateAPIVersion(c *gc.C) {
-	err := ValidateAPIVersion("5.2")
+	err := ValidateAPIVersion("5.0")
 	c.Check(err, jc.ErrorIsNil)
 
-	err = ValidateAPIVersion("5.1")
-	c.Check(err, gc.ErrorMatches, `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`)
+	err = ValidateAPIVersion("4.0")
+	c.Check(err, gc.ErrorMatches, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
 }

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -402,10 +402,10 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 	cloudSpec := environscloudspec.CloudSpec{Type: "lxd"}
 	gomock.InOrder(
 		serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 	)
 
 	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`)
+	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
 }


### PR DESCRIPTION
#14447 disallowed Juju 3.0 with LXD < 5.2, due to a bug in earlier versions of LXD causing jammy deployments to fail. However, this bug since appears to have been fixed. Hence, we should support LXD 5.0 in Juju 3.0, as LXD 5.0 has long-term support.

## QA steps

```sh
sudo snap install lxd --channel 5.0
juju bootstrap lxd c --series jammy
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1981955
