### PR TITLE
Merge 2.9

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -61,6 +61,7 @@ TEST_NAMES="agents \
             model \
             network \
             ovs_maas \
+            refresh \
             relations \
             resources \
             sidecar \

--- a/tests/suites/deploy/deploy_default_series.sh
+++ b/tests/suites/deploy/deploy_default_series.sh
@@ -1,0 +1,57 @@
+run_deploy_default_series() {
+	echo
+
+	model_name="test-deploy-default-series"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju model-config default-series=bionic
+	juju deploy ubuntu
+	juju deploy cs:ubuntu csubuntu
+
+	ubuntu_series=$(juju status --format=json | jq ".applications.ubuntu.series")
+	echo "$ubuntu_series" | check "bionic"
+
+	csubuntu_series=$(juju status --format=json | jq ".applications.csubuntu.series")
+	echo "$csubuntu_series" | check "bionic"
+
+	destroy_model "${model_name}"
+}
+
+run_deploy_not_default_series() {
+	echo
+
+	model_name="test-deploy-not-default-series"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju model-config default-series=bionic
+	juju deploy ubuntu --series focal
+	juju deploy cs:ubuntu csubuntu --series focal
+
+	ubuntu_series=$(juju status --format=json | jq ".applications.ubuntu.series")
+	echo "$ubuntu_series" | check "focal"
+
+	csubuntu_series=$(juju status --format=json | jq ".applications.csubuntu.series")
+	echo "$csubuntu_series" | check "focal"
+
+	destroy_model "${model_name}"
+}
+
+test_deploy_default_series() {
+	if [ "$(skip 'test_deploy_default_series')" ]; then
+		echo "==> TEST SKIPPED: deploy default series"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_deploy_default_series"
+		run "run_deploy_not_default_series"
+	)
+}

--- a/tests/suites/deploy/task.sh
+++ b/tests/suites/deploy/task.sh
@@ -18,6 +18,7 @@ test_deploy() {
 	test_cmr_bundles_export_overlay
 	test_deploy_os
 	test_deploy_revision
+	test_deploy_default_series
 
 	destroy_controller "test-deploy-ctl"
 }

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -1,0 +1,77 @@
+run_refresh_cs() {
+	# Test a plain juju refresh with a charm store charm
+	echo
+
+	model_name="test-refresh-cs"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy cs:ubuntu-19
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added"; then
+		# shellcheck disable=SC2046
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	# Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_local() {
+	# Test a plain juju refresh with a local charm
+	echo
+
+	model_name="test-refresh-local"
+	file="${TEST_DIR}/${model_name}.log"
+	charm_name="${TEST_DIR}/ubuntu.charm"
+
+	ensure "${model_name}" "${file}"
+
+	juju download ubuntu --no-progress - >"${charm_name}"
+	juju deploy "${charm_name}" ubuntu
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --path "${charm_name}" 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added local charm"; then
+		# shellcheck disable=SC2046
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+test_basic() {
+	if [ "$(skip 'test_basic')" ]; then
+		echo "==> TEST SKIPPED: basic refresh"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_refresh_cs"
+		run "run_refresh_local"
+	)
+}

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -1,0 +1,137 @@
+run_refresh_switch_cs_to_ch() {
+	# Test juju refresh from a charm store charm to a charm hub charm
+	echo
+
+	model_name="test-refresh-switch-ch"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy cs:ubuntu-19
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --switch ch:ubuntu 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
+		# shellcheck disable=SC2046
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_switch_cs_to_ch_channel() {
+	# Test juju refresh from a charm store charm to a charm hub charm with a specific channel
+	echo
+
+	model_name="test-refresh-switch-ch-channel"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy cs:ubuntu-19
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --switch ch:ubuntu --channel edge 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "in channel edge"; then
+		# shellcheck disable=SC2046
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_switch_local_to_ch_channel() {
+	# Test juju refresh from a local charm to a charm hub charm with a specific channel
+	echo
+
+	model_name="test-refresh-local-switch-ch"
+	file="${TEST_DIR}/${model_name}.log"
+	charm_name="${TEST_DIR}/ubuntu.charm"
+
+	ensure "${model_name}" "${file}"
+
+	juju download ubuntu --no-progress - >"${charm_name}"
+	juju deploy "${charm_name}" ubuntu
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --switch ch:ubuntu --channel edge 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
+		# shellcheck disable=SC2046
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_switch_channel() {
+	# Test juju refresh switching from one channel to another
+	echo
+
+	model_name="test-refresh-switch-channel"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy juju-qa-test
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	OUT=$(juju refresh juju-qa-test --channel 2.0/edge 2>&1 || true)
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	# Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/edge")"
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	destroy_model "${model_name}"
+}
+
+test_switch() {
+	if [ "$(skip 'test_switch')" ]; then
+		echo "==> TEST SKIPPED: refresh switch"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_refresh_switch_cs_to_ch"
+		run "run_refresh_switch_cs_to_ch_channel"
+		run "run_refresh_switch_local_to_ch_channel"
+		run "run_refresh_switch_channel"
+	)
+}

--- a/tests/suites/refresh/task.sh
+++ b/tests/suites/refresh/task.sh
@@ -1,0 +1,20 @@
+test_refresh() {
+	if [ "$(skip 'test_refresh')" ]; then
+		echo "==> TEST SKIPPED: Refresh tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-refresh-ctl.log"
+
+	bootstrap "test-refresh-ctl" "${file}"
+
+	test_basic
+	test_switch
+
+	destroy_controller "test-refresh-ctl"
+}


### PR DESCRIPTION
Merge 2.9. The conflicts below were all from updating 2.9 to be compatible with 3.0 - the resolution was to accept the 3.0 version.

https://github.com/juju/juju/pull/14758
https://github.com/juju/juju/pull/14744

The only material change is the addition of the new bash tests.

```
# Conflicts:
#       api/client/application/client.go
#       api/client/client/client.go
#       api/client/resources/client.go
#       apiserver/allfacades.go
#       apiserver/facades/client/application/application.go
#       apiserver/facades/client/application/application_test.go
#       apiserver/facades/client/application/application_unit_test.go
#       apiserver/facades/client/application/get_test.go
#       apiserver/facades/client/application/register.go
#       apiserver/facades/client/charms/client.go
#       apiserver/facades/client/charms/client_test.go
#       apiserver/facades/client/charms/export_test.go
#       apiserver/facades/client/charms/register.go
#       apiserver/facades/client/client/client.go
#       apiserver/facades/client/client/register.go
#       apiserver/facades/client/machinemanager/instanceconfig.go
#       apiserver/facades/client/machinemanager/machinemanager.go
#       apiserver/facades/client/machinemanager/machinemanager_test.go
#       apiserver/facades/client/machinemanager/register.go
#       apiserver/facades/client/resources/facade.go
#       apiserver/facades/client/resources/register.go
#       apiserver/facades/client/resources/server_addpending_test.go
#       apiserver/facades/schema.json
#       cloudconfig/cloudinit/renderscript_test.go
#       cloudconfig/instancecfg/instancecfg.go
#       cloudconfig/userdatacfg_test.go
#       cmd/juju/machine/list_test.go
#       cmd/juju/machine/show_test.go
#       cmd/juju/status/formatted.go
#       cmd/juju/status/formatter.go
#       cmd/juju/status/status_internal_test.go
#       container/broker/broker_test.go
#       container/kvm/live_test.go
#       core/series/base.go
#       environs/bootstrap/bootstrap.go
#       environs/jujutest/livetests.go
#       provider/common/bootstrap.go
#       provider/common/bootstrap_test.go
#       provider/ec2/local_test.go
#       provider/equinix/environ_test.go
#       provider/gce/testing_test.go
#       provider/lxd/testing_test.go
#       provider/vsphere/environ_broker_test.go
#       worker/provisioner/provisioner_task.go

```
