### PR TITLE
[JUJU-1983] Do not allow upgrade from 2.9 to 3.0 for now.

### DIFF
--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -213,9 +213,12 @@ func (s *serverSuite) TestSetModelAgentVersionOldModels(c *gc.C) {
 		Version: version.MustParse("3.0.0"),
 	}
 	err = s.client.SetModelAgentVersion(args)
-	c.Assert(err, gc.ErrorMatches, `
-these models must first be upgraded to at least 2.9.35 before upgrading the controller:
- -admin/controller`[1:])
+	// TODO: (hml) 18-10-2022
+	// Change back when upgrades from 2.9 to 3.0 enabled again.
+	//	c.Assert(err, gc.ErrorMatches, `
+	//these models must first be upgraded to at least 2.9.35 before upgrading the controller:
+	// -admin/controller`[1:])
+	c.Assert(err, gc.ErrorMatches, `upgrade to \"3.0.0\" is not supported from \"2.8.0\"`)
 }
 
 func (s *serverSuite) TestSetModelAgentVersionForced(c *gc.C) {

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -136,7 +136,7 @@ var upgradeJujuTests = []upgradeTest{{
 	currentVersion: "2.0.0-ubuntu-amd64",
 	agentVersion:   "2.0.0",
 	args:           []string{"--agent-version", "5.2.0"},
-	expectErr:      `cannot upgrade, "5.2.0" is not a supported version`,
+	expectErr:      `upgrade to "5.2.0" is not supported from "2.0.0"`,
 }, {
 	about:          "version downgrade",
 	available:      []string{"4.2-beta2-ubuntu-amd64"},

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -238,7 +238,7 @@ func (s *upgradeValidationSuite) TestGetCheckTargetVersionForModel(c *gc.C) {
 		version.MustParse("4.1.1"),
 		upgradevalidation.UpgradeToAllowed,
 	)("", nil, nil, model)
-	c.Assert(err, gc.ErrorMatches, `cannot upgrade, "4.1.1" is not a supported version`)
+	c.Assert(err, gc.ErrorMatches, `upgrade to "4.1.1" is not supported from "2.9.31"`)
 	c.Assert(blocker, gc.IsNil)
 }
 

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -27,7 +27,8 @@ func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (boo
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
-	3: version.MustParse("2.9.35"),
+	// We don't support upgrading in place from 2.9 to 3.0 yet.
+	//3: version.MustParse("2.9.35"),
 }
 
 // UpgradeToAllowed returns true if a major version upgrade is allowed
@@ -52,7 +53,7 @@ func versionCheck(
 	minVer, ok := versionMap[to.Major]
 	logger.Debugf("from %q, to %q, versionMap %#v", from, to, versionMap)
 	if !ok {
-		return false, version.Number{}, errors.Errorf("cannot %s, %q is not a supported version", operation, to)
+		return false, version.Number{}, errors.Errorf("%s to %q is not supported from %q", operation, to, from)
 	}
 	// Allow upgrades from rc etc.
 	from.Tag = ""

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -53,7 +53,7 @@ func (s *versionSuite) TestUpgradeToAllowed(c *gc.C) {
 			allowed: false,
 			minVers: "0.0.0",
 			patch:   true,
-			err:     `cannot upgrade, "4.0.0" is not a supported version`,
+			err:     `upgrade to \"4.0.0\" is not supported from \"2.9.0\"`,
 		}, {
 			from:    "3.0.0",
 			to:      "2.0.0",
@@ -112,7 +112,7 @@ func (s *versionSuite) TestMigrateToAllowed(c *gc.C) {
 			to:      "4.0.0",
 			allowed: false,
 			minVers: "0.0.0",
-			err:     `cannot migrate, "4.0.0" is not a supported version`,
+			err:     `migrate to \"4.0.0\" is not supported from \"2.9.0\"`,
 		},
 		{
 			from:    "3.0.0",


### PR DESCRIPTION
We can enable this functionality in a future release of 2.9 in the future once all the kinks are resolved. As the agent version validation is done on the server side, this change must be made in juju 2.9.

There is a risk where 2.9.34 and 2.9.35 controllers using mongo 4.4 will be able to upgrade to juju 3.0. Most will be prevented by old mongo versions. 

Updated the error message to be more clear.

## QA steps

```sh
$ juju bootstrap localhost test-upgrade
...
$ snap refresh juju --channel 3.0/candidate
# run the next command with the snap version of juju
$ juju upgrade-controller --agent-stream proposed --agent-version 3.0-rc2
ERROR upgrade to "3.0-rc2" is not supported from "2.9.36.1"
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993168
