### PR TITLE
[JUJU-1994] [refresh] retry when getting old charm ID

### DIFF
--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -38,6 +38,7 @@ func NewRefreshCommandForTest(
 	newSpacesClient func(base.APICallCloser) SpacesAPI,
 	newModelConfigClient func(base.APICallCloser) ModelConfigClient,
 	newCharmHubClient func(string) (store.DownloadBundleClient, error),
+	retryDelay time.Duration,
 
 ) cmd.Command {
 	cmd := &refreshCommand{
@@ -53,6 +54,7 @@ func NewRefreshCommandForTest(
 		NewRefresherFactory:   refresher.NewRefresherFactory,
 		ModelConfigClient:     newModelConfigClient,
 		NewCharmHubClient:     newCharmHubClient,
+		RetryDelay:            retryDelay,
 	}
 	cmd.SetClientStore(store)
 	cmd.SetAPIOpen(apiOpen)

--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -83,7 +83,7 @@ run_deploy_revision_refresh() {
 
 	# revision 21 is in channel latest/edge
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 21)"
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "latest/edge")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "edge")"
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
If you deploy a charm and then immediately refresh, it might fail. This is because the charm hasn't had time to fully download, and so the old charm ID will be empty, which could cause refresh to be inaccurate. To fix this, we will retry a few times so that the charm has time to download. This will fix a failing Bash test too (run_deploy_revision_refresh).

Builds upon #14368.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju deploy tiny-bash; juju refresh tiny-bash
cd tests
./main.sh -v deploy run_deploy_revision_refresh
```