### PR TITLE
Consolidate min versions for upgrade and migrate

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -139,7 +139,7 @@ func (s *modelUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *gc.C, d
 	ctrl, api := s.getModelUpgraderAPI(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.1"),
 	})
 
@@ -313,7 +313,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 	ctrl, api := s.getModelUpgraderAPI(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.2"),
 	})
 
@@ -490,7 +490,7 @@ func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool) {
 	ctrl, api := s.getModelUpgraderAPI(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.1"),
 	})
 
@@ -596,7 +596,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 	ctrl, api := s.getModelUpgraderAPI(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.1"),
 	})
 

--- a/apiserver/restrict_newer_client.go
+++ b/apiserver/restrict_newer_client.go
@@ -49,7 +49,7 @@ func checkClientVersion(userLogin bool, callerVersion version.Number) func(facad
 		if !userLogin {
 			// Only recent older agents can make api calls.
 			if minAgentVersion, ok := minAgentVersions[serverVersion.Major]; !ok || callerVersion.Compare(minAgentVersion) < 0 {
-				logger.Debugf("rejected agent api all %v.%v for agent version %v", facadeName, methodName, callerVersion)
+				logger.Warningf("rejected agent api all %v.%v for agent version %v", facadeName, methodName, callerVersion)
 				return incompatibleClientError
 			}
 			return nil

--- a/apiserver/restrict_newer_client_test.go
+++ b/apiserver/restrict_newer_client_test.go
@@ -107,8 +107,8 @@ func (r *restrictNewerClientSuite) TestAlwaysDisallowedMethod(c *gc.C) {
 }
 
 func (r *restrictNewerClientSuite) TestWhitelistedClient(c *gc.C) {
-	r.assertWhitelistedClient(c, "2.9.32", false)
-	r.assertWhitelistedClient(c, "2.9.35", true)
+	r.assertWhitelistedClient(c, "2.9.35", false)
+	r.assertWhitelistedClient(c, "2.9.36", true)
 }
 
 func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, serverVers string, allowed bool) {
@@ -127,7 +127,7 @@ func (r *restrictNewerClientSuite) assertWhitelistedClient(c *gc.C, serverVers s
 
 func (r *restrictNewerClientSuite) TestAgentMethod(c *gc.C) {
 	r.PatchValue(&jujuversion.Current, version.MustParse("3.0.0"))
-	r.assertAgentMethod(c, "2.9.35", true)
+	r.assertAgentMethod(c, "2.9.36", true)
 	r.assertAgentMethod(c, "2.9.31", false)
 }
 

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -468,8 +468,18 @@ func (c *upgradeJujuCommand) upgradeWithTargetVersion(
 	ctx *cmd.Context, modelUpgrader ModelUpgraderAPI, isControllerModel, dryRun bool,
 	modelType model.ModelType, targetVersion, agentVersion version.Number,
 ) (chosenVersion version.Number, err error) {
-	chosenVersion = targetVersion
 	// juju upgrade-controller --agent-version 3.x.x
+	chosenVersion = targetVersion
+
+	if targetVersion.Major == 3 {
+		// We enabled model upgrade from 2.9.33 to 3.0 before, but we decide to disable it now.
+		// To prevent a 2.9.33-2.9.35 controller from upgrading to 3.0, we have to do this
+		// check again here to use the newly updated support version matrix.
+		_, _, err := upgradevalidation.UpgradeToAllowed(agentVersion, targetVersion)
+		if err != nil {
+			return chosenVersion, errors.Trace(err)
+		}
+	}
 	_, err = c.notifyControllerUpgrade(ctx, modelUpgrader, targetVersion, dryRun)
 	if err == nil {
 		// All good!

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -1663,9 +1663,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersion(c *gc.C) {
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
-		"agent-version": coretesting.FakeVersionNumber.String(),
+		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{3: agentVersion})
 
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
@@ -1894,9 +1896,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionDryRun(c *gc.C) {
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
-		"agent-version": coretesting.FakeVersionNumber.String(),
+		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{3: agentVersion})
 
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
@@ -1923,9 +1927,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionGotBlockers(c *gc.C) {
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
-		"agent-version": coretesting.FakeVersionNumber.String(),
+		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{3: agentVersion})
 
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -437,7 +437,7 @@ func (s *UpgradeBaseSuite) assertUpgradeTestsLegacy(c *gc.C, tests []upgradeTest
 		s.PatchValue(&jujuversion.Current, current.Number)
 		s.PatchValue(&arch.HostArch, func() string { return current.Arch })
 		s.PatchValue(&coreos.HostOS, func() coreos.OSType { return coreos.Ubuntu })
-		s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, test.upgradeMap)
+		s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, test.upgradeMap)
 		ctrl, com := upgradeJujuCommand(c, &test)
 		if ctrl != nil && s.modelManager != nil {
 			defer ctrl.Finish()
@@ -894,7 +894,7 @@ func (s *UpgradeJujuSuite) TestUpgradesDifferentMajor(c *gc.C) {
 
 		s.setUpEnvAndTools(c, test.currentVersion, test.agentVersion, test.tools)
 
-		s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, test.upgradeMap)
+		s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, test.upgradeMap)
 		ctrl, command := s.upgradeJujuCommandNoAPILegacy(c, nil)
 		defer ctrl.Finish()
 
@@ -1667,7 +1667,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersion(c *gc.C) {
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{3: agentVersion})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
@@ -1900,7 +1900,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionDryRun(c *gc.C) {
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{3: agentVersion})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),
@@ -1931,7 +1931,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionGotBlockers(c *gc.C) {
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{3: agentVersion})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	gomock.InOrder(
 		s.modelConfigAPI.EXPECT().ModelGet().Return(cfg, nil),

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -103,7 +103,7 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 	backend.hasUpgradeSeriesLocks = &hasUpgradeSeriesLocks
 	backend.machineCountForSeriesWin = map[string]int{"win10": 1, "win7": 2}
 	backend.machineCountForSeriesUbuntu = map[string]int{"xenial": 1, "vivid": 2, "trusty": 3}
-	agentVersion := version.MustParse("2.9.31")
+	agentVersion := version.MustParse("2.9.35")
 	backend.model.agentVersion = &agentVersion
 	backend.model.name = "model-1"
 	backend.model.owner = names.NewUserTag("foo")
@@ -121,7 +121,7 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, `
 cannot migrate to controller ("3.0.0") due to issues:
 "foo/model-1":
-- current model ("2.9.31") has to be upgraded to "2.9.32" at least
+- current model ("2.9.35") has to be upgraded to "2.9.36" at least
 - unexpected upgrade series lock found
 - the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): trusty(3) vivid(2) xenial(1)
@@ -525,9 +525,9 @@ func (s *TargetPrecheckSuite) TestModelMinimumVersion(c *gc.C) {
 	s.modelInfo.AgentVersion = version.MustParse("2.8.0")
 	err := s.runPrecheck(backend)
 	c.Assert(err.Error(), gc.Equals,
-		`model must be upgraded to at least version 2.9.32 before being migrated to a controller with version 3.0.0`)
+		`model must be upgraded to at least version 2.9.36 before being migrated to a controller with version 3.0.0`)
 
-	s.modelInfo.AgentVersion = version.MustParse("2.9.32")
+	s.modelInfo.AgentVersion = version.MustParse("2.9.36")
 	err = s.runPrecheck(backend)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -38,7 +38,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelMigrationSourceJuju3(c *g
 
 	gomock.InOrder(
 		// - check agent version;
-		model.EXPECT().AgentVersion().Return(version.MustParse("2.9.32"), nil),
+		model.EXPECT().AgentVersion().Return(version.MustParse("2.9.36"), nil),
 		// - check no upgrade series in process.
 		state.EXPECT().HasUpgradeSeriesLocks().Return(false, nil),
 		// - check if the model has win machines;

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -25,7 +25,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.1"),
 	})
 
@@ -160,7 +160,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju2(c *gc.C
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.1"),
 	})
 
@@ -224,7 +224,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.1"),
 	})
 
@@ -289,7 +289,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju2(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.1"),
 	})
 

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -201,7 +201,7 @@ func (s *upgradeValidationSuite) TestGetCheckTargetVersionForModel(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 		3: version.MustParse("2.9.30"),
 	})
 

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -14,7 +14,7 @@ var logger = loggo.GetLogger("juju.upgrades.validations")
 // MinMajorMigrateVersion defines the minimum version the model
 // must be running before migrating to the target controller.
 var MinMajorMigrateVersion = map[int]version.Number{
-	3: version.MustParse("2.9.32"),
+	3: version.MustParse("2.9.36"),
 }
 
 // MigrateToAllowed checks if the model can be migrated to the target controller.
@@ -28,7 +28,7 @@ func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (boo
 // must be running before a major version upgrade.
 var MinMajorUpgradeVersion = map[int]version.Number{
 	// We don't support upgrading in place from 2.9 to 3.0 yet.
-	//3: version.MustParse("2.9.35"),
+	// 3: version.MustParse("2.9.35"),
 }
 
 // UpgradeToAllowed returns true if a major version upgrade is allowed

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -25,27 +25,27 @@ var MinClientVersions = map[int]version.Number{
 	3: version.MustParse("2.9.36"),
 }
 
-// MinMajorMigrateVersion defines the minimum version the model
+// MinMajorMigrateVersions defines the minimum version the model
 // must be running before migrating to the target controller.
-var MinMajorMigrateVersion = MinAgentVersions
+var MinMajorMigrateVersions = MinAgentVersions
 
 // MigrateToAllowed checks if the model can be migrated to the target controller.
 func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (bool, version.Number, error) {
 	return versionCheck(
-		modelVersion, targetControllerVersion, MinMajorMigrateVersion, "migrate",
+		modelVersion, targetControllerVersion, MinMajorMigrateVersions, "migrate",
 	)
 }
 
-// MinMajorUpgradeVersion defines the minimum version all models
+// MinMajorUpgradeVersions defines the minimum version all models
 // must be running before a major version upgrade.
-// var MinMajorUpgradeVersion = MinAgentVersions // We don't support upgrading in place from 2.9 to 3.0 yet.
-var MinMajorUpgradeVersion = map[int]version.Number{}
+// var MinMajorUpgradeVersions = MinAgentVersions // We don't support upgrading in place from 2.9 to 3.0 yet.
+var MinMajorUpgradeVersions = map[int]version.Number{}
 
 // UpgradeToAllowed returns true if a major version upgrade is allowed
 // for the specified from and to versions.
 func UpgradeToAllowed(from, to version.Number) (bool, version.Number, error) {
 	return versionCheck(
-		from, to, MinMajorUpgradeVersion, "upgrade",
+		from, to, MinMajorUpgradeVersions, "upgrade",
 	)
 }
 

--- a/upgrades/upgradevalidation/version.go
+++ b/upgrades/upgradevalidation/version.go
@@ -11,11 +11,23 @@ import (
 
 var logger = loggo.GetLogger("juju.upgrades.validations")
 
-// MinMajorMigrateVersion defines the minimum version the model
-// must be running before migrating to the target controller.
-var MinMajorMigrateVersion = map[int]version.Number{
+// MinAgentVersions defines the minimum agent version
+// allowed to make a call to a controller with the major version.
+var MinAgentVersions = map[int]version.Number{
 	3: version.MustParse("2.9.36"),
 }
+
+// MinClientVersions defines the minimum user client version
+// allowed to make a call to a controller with the major version,
+// or the minimum controller version needed to accept a call from a
+// client with the major version.
+var MinClientVersions = map[int]version.Number{
+	3: version.MustParse("2.9.36"),
+}
+
+// MinMajorMigrateVersion defines the minimum version the model
+// must be running before migrating to the target controller.
+var MinMajorMigrateVersion = MinAgentVersions
 
 // MigrateToAllowed checks if the model can be migrated to the target controller.
 func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (bool, version.Number, error) {
@@ -26,10 +38,8 @@ func MigrateToAllowed(modelVersion, targetControllerVersion version.Number) (boo
 
 // MinMajorUpgradeVersion defines the minimum version all models
 // must be running before a major version upgrade.
-var MinMajorUpgradeVersion = map[int]version.Number{
-	// We don't support upgrading in place from 2.9 to 3.0 yet.
-	// 3: version.MustParse("2.9.35"),
-}
+// var MinMajorUpgradeVersion = MinAgentVersions // We don't support upgrading in place from 2.9 to 3.0 yet.
+var MinMajorUpgradeVersion = map[int]version.Number{}
 
 // UpgradeToAllowed returns true if a major version upgrade is allowed
 // for the specified from and to versions.

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -70,7 +70,7 @@ func (s *versionSuite) TestUpgradeToAllowed(c *gc.C) {
 func (s *versionSuite) assertUpgradeToAllowed(c *gc.C, i int, t versionCheckTC) {
 	c.Logf("testing %d", i)
 	if t.patch {
-		restore := jujutesting.PatchValue(&upgradevalidation.MinMajorUpgradeVersion, map[int]version.Number{
+		restore := jujutesting.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{
 			3: version.MustParse("2.9.35"),
 		})
 		defer restore()

--- a/upgrades/upgradevalidation/version_test.go
+++ b/upgrades/upgradevalidation/version_test.go
@@ -95,17 +95,17 @@ func (s *versionSuite) TestMigrateToAllowed(c *gc.C) {
 			from:    "2.8.0",
 			to:      "3.0.0",
 			allowed: false,
-			minVers: "2.9.32",
+			minVers: "2.9.36",
 		}, {
-			from:    "2.9.32",
+			from:    "2.9.36",
 			to:      "3.0.0",
 			allowed: true,
-			minVers: "2.9.32",
+			minVers: "2.9.36",
 		}, {
-			from:    "2.9.34",
+			from:    "2.9.37",
 			to:      "3.0.0",
 			allowed: true,
-			minVers: "2.9.32",
+			minVers: "2.9.36",
 		},
 		{
 			from:    "2.9.0",


### PR DESCRIPTION
This PR includes changes:
- move minAgentVersions, minClientVersions to MinMajorUpgradeVersion, MinMajorMigrateVersion together;
- set the min version to `2.9.36` for model migration to 3.0;

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju models -c k1 --format json | jq '.models[] | {name,"agent-version"}'
{
  "name": "admin/controller",
  "agent-version": "2.9.32"
}
{
  "name": "admin/default",
  "agent-version": "2.9.32"
}

$ juju upgrade-controller -c k1 --agent-version 3.0-rc1 --agent-stream=proposed
ERROR upgrade to "3.0-rc1" is not supported from "2.9.32"

$ juju upgrade-controller -c k1 --build-agent
no prepackaged agent binaries available, using local agent binary 2.9.36.1 (built from source)
best version:
    2.9.36.1
started upgrade to 2.9.36.1

$ juju upgrade-controller -c k1 --agent-version 3.0-rc1 --agent-stream=proposed
ERROR upgrade to "3.0-rc1" is not supported from "2.9.36.1"

$ juju models -c c3 --format json | jq '.models[] | {name,"agent-version"}'
{
  "name": "admin/controller",
  "agent-version": "3.1-beta1.1"
}

$ juju migrate k1:default c3
ERROR source prechecks failed: cannot migrate to controller ("3.1-beta1.1") due to issues:
"admin/default":
- current model ("2.9.32") has to be upgraded to "2.9.36" at least

$ juju upgrade-model -m k1:default
best version:
    2.9.36.1
started upgrade to 2.9.36.1

$ juju migrate k1:default c3
Migration started with ID "de10bcd4-ad4d-42b5-842e-179475a41bdd:0"

$ juju models -c c3 --format json | jq '.models[] | {name,"agent-version"}'
{
  "name": "admin/controller",
  "agent-version": "3.1-beta1.1"
}
{
  "name": "admin/default",
  "agent-version": "2.9.36.1"
}

$ juju bootstrap lxd k1 --config test-mode=true --agent-version 2.9.35

$ juju models -c k1 --format json | jq '.models[] | {name,"agent-version"}'
{
  "name": "admin/controller",
  "agent-version": "2.9.35"
}
{
  "name": "admin/default",
  "agent-version": "2.9.35"
}

$ juju upgrade-controller -c k1 --agent-version 3.0-rc1 --agent-stream=proposed
ERROR upgrade to "3.0-rc1" is not supported from "2.9.35"

```

## Documentation changes

Will be in the 3.0 release notes.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993168

