### PR TITLE
[JUJU-2004] Add workaround for charm platforms with missing os

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1503,11 +1503,16 @@ func makeParamsCharmOrigin(origin *state.CharmOrigin) (params.CharmOrigin, error
 		retOrigin.Architecture = origin.Platform.Architecture
 		var base series.Base
 		if origin.Platform.Series != "" {
-			channel, err := series.SeriesVersion(origin.Platform.Series)
-			if err != nil {
-				return params.CharmOrigin{}, errors.Trace(err)
+			var err error
+			if origin.Platform.OS == "" {
+				base, err = series.GetBaseFromSeries(origin.Platform.Series)
+			} else {
+				var channel string
+				channel, err = series.SeriesVersion(origin.Platform.Series)
+				if err == nil {
+					base, err = series.ParseBase(origin.Platform.OS, channel)
+				}
 			}
-			base, err = series.ParseBase(origin.Platform.OS, channel)
 			if err != nil {
 				return params.CharmOrigin{}, errors.Trace(err)
 			}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -27,7 +27,6 @@ import (
 	commontesting "github.com/juju/juju/apiserver/common/testing"
 	"github.com/juju/juju/apiserver/facades/client/application"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -972,57 +971,6 @@ func (s *applicationSuite) TestAddCharmOverwritesPlaceholders(c *gc.C) {
 	c.Assert(sch.URL(), jc.DeepEquals, curl)
 	c.Assert(sch.IsPlaceholder(), jc.IsFalse)
 	c.Assert(sch.IsUploaded(), jc.IsTrue)
-}
-
-func (s *applicationSuite) TestApplicationGetCharmURL(c *gc.C) {
-	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
-	result, err := s.applicationAPI.GetCharmURL(params.ApplicationGet{ApplicationName: "wordpress"})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.Result, gc.Equals, "local:quantal/wordpress-3")
-}
-
-func (s *applicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
-	ch := s.AddTestingCharm(c, "wordpress")
-	rev := ch.Revision()
-	// Technically this charm origin is impossible, a local
-	// charm cannot have a channel.  Done just for testing.
-	expectedOrigin := state.CharmOrigin{
-		Source:   "local",
-		Revision: &rev,
-		Channel: &state.Channel{
-			Track:  "latest",
-			Risk:   "stable",
-			Branch: "foo",
-		},
-		Platform: &state.Platform{
-			Architecture: "amd64",
-			OS:           "ubuntu",
-			Series:       "focal",
-		},
-	}
-	app := s.AddTestingApplicationWithOrigin(c, "wordpress", ch, &expectedOrigin)
-	result, err := s.applicationAPI.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "wordpress"})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.URL, gc.Equals, "local:quantal/wordpress-3")
-
-	latest := "latest"
-	branch := "foo"
-
-	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
-		Source:       "local",
-		Risk:         "stable",
-		Revision:     &rev,
-		Track:        &latest,
-		Branch:       &branch,
-		Architecture: "amd64",
-		OS:           "ubuntu",
-		Series:       "focal",
-		Channel:      "20.04/stable",
-		Base:         params.Base{Name: "ubuntu", Channel: "20.04/stable"},
-		InstanceKey:  charmhub.CreateInstanceKey(app.ApplicationTag(), s.Model.ModelTag()),
-	})
 }
 
 func (s *applicationSuite) TestApplicationSetCharm(c *gc.C) {


### PR DESCRIPTION
Some older controllers stored charm origin without the os. Here we account for that.
The relevant state tests were rewritten as mock tests so that the specific scenario could be tested.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

deploy a local charm with a 2.8 client and a client built off this PR