### PR TITLE
Fix a type in secret-get command;

### DIFF
--- a/worker/uniter/runner/jujuc/secret-get.go
+++ b/worker/uniter/runner/jujuc/secret-get.go
@@ -145,7 +145,7 @@ func (c *secretGetCommand) getMetadata(ctx *cmd.Context) error {
 	}
 	var want string
 	if c.secretUri != nil {
-		want := c.secretUri.ID
+		want = c.secretUri.ID
 		if md, found := all[want]; found {
 			return print(want, md)
 		}

--- a/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-get_test.go
@@ -247,6 +247,32 @@ func (s *SecretGetSuite) TestSecretGetMetadata(c *gc.C) {
 `[1:])
 }
 
+func (s *SecretGetSuite) TestSecretGetMetadataFailedNotFound(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, "secret-get")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:cd88u16ffbaql5kgmlh0", "--metadata"})
+	c.Assert(code, gc.Equals, 1)
+
+	c.Assert(bufferString(ctx.Stderr), gc.Matches, `ERROR secret "cd88u16ffbaql5kgmlh0" not found\n`)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, ``)
+}
+
+func (s *SecretGetSuite) TestSecretGetMetadataByLabelFailedNotFound(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, "secret-get")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--metadata", "--label", "not-found-label"})
+	c.Assert(code, gc.Equals, 1)
+
+	c.Assert(bufferString(ctx.Stderr), gc.Matches, `ERROR secret "not-found-label" not found\n`)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, ``)
+}
+
 func (s *SecretGetSuite) TestSecretGetMetadataByLabel(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 


### PR DESCRIPTION
Fix a type in secret-get command;

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju exec --unit hello-kubecon/0 'uri=$(secret-add foo=app); echo $uri; secret-set $uri --label=app;'

secret:cd89l8uffbar9l7rfvm0

$ juju scale-application hello-kubecon 2

$ juju exec --unit hello-kubecon/0 -- secret-get cd89l8uffbar9l7rfvm0 --metadata --format json |
jq
{
  "cd89l8uffbar9l7rfvm0": {
    "revision": 1,
    "label": "app",
    "owner": "application",
    "rotation": "never"
  }
}

$ juju exec --unit hello-kubecon/1 -- secret-get cd89l8uffbar9l7rfvm0 --metadata --format json

ERROR secret "cd89l8uffbar9l7rfvm0" not found
ERROR the following task failed:
 - id "6" with return code 1

use 'juju show-task' to inspect the failure
```

## Documentation changes

No

## Bug reference

No
