### PR TITLE
[JUJU-2007] Fix/lp 1993607

### DIFF
--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -102,6 +102,8 @@ func StoreConfig(model Model, authTag names.Tag, leadershipChecker leadership.Ch
 	readFilter := state.SecretsFilter{
 		ConsumerTags: []names.Tag{authTag},
 	}
+	// Find secrets owned by the application that should be readable for non leader units.
+	readAppOwnedFilter := state.SecretsFilter{}
 	switch t := authTag.(type) {
 	case names.UnitTag:
 		appName, _ := names.UnitApplication(t.Id())
@@ -114,9 +116,11 @@ func StoreConfig(model Model, authTag names.Tag, leadershipChecker leadership.Ch
 		if err == nil {
 			// Leader unit owns application level secrets.
 			ownedFilter.OwnerTags = append(ownedFilter.OwnerTags, authApp)
+		} else {
+			// Non leader units can read application level secrets.
+			// Find secrets owned by the application.
+			readAppOwnedFilter.OwnerTags = append(readAppOwnedFilter.OwnerTags, authApp)
 		}
-		// All units can read application level secrets.
-		readFilter.ConsumerTags = append(readFilter.ConsumerTags, authApp)
 	case names.ApplicationTag:
 	default:
 		return nil, errors.NotSupportedf("login as %q", authTag)
@@ -139,6 +143,17 @@ func StoreConfig(model Model, authTag names.Tag, leadershipChecker leadership.Ch
 	for _, md := range read {
 		readRevisions.Add(md.URI, md.Version)
 	}
+
+	if len(readAppOwnedFilter.OwnerTags) > 0 {
+		readAppOwned, err := backend.ListSecrets(readAppOwnedFilter)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for _, md := range readAppOwned {
+			readRevisions.Add(md.URI, md.Version)
+		}
+	}
+
 	logger.Debugf("secrets for %v:\nowned: %v\nconsumed:%v", authTag.String(), ownedRevisions, readRevisions)
 	cfg, err := p.StoreConfig(ma, authTag, ownedRevisions, readRevisions)
 	return cfg, errors.Trace(err)

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -132,7 +132,7 @@ func StoreConfig(model Model, authTag names.Tag, leadershipChecker leadership.Ch
 	}
 	ownedRevisions := provider.SecretRevisions{}
 	for _, md := range owned {
-		ownedRevisions.Add(md.URI, md.Version)
+		ownedRevisions.Add(md.URI, md.LatestRevision)
 	}
 
 	read, err := backend.ListSecrets(readFilter)
@@ -141,7 +141,7 @@ func StoreConfig(model Model, authTag names.Tag, leadershipChecker leadership.Ch
 	}
 	readRevisions := provider.SecretRevisions{}
 	for _, md := range read {
-		readRevisions.Add(md.URI, md.Version)
+		readRevisions.Add(md.URI, md.LatestRevision)
 	}
 
 	if len(readAppOwnedFilter.OwnerTags) > 0 {
@@ -150,7 +150,7 @@ func StoreConfig(model Model, authTag names.Tag, leadershipChecker leadership.Ch
 			return nil, errors.Trace(err)
 		}
 		for _, md := range readAppOwned {
-			readRevisions.Add(md.URI, md.Version)
+			readRevisions.Add(md.URI, md.LatestRevision)
 		}
 	}
 

--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -121,6 +121,8 @@ func StoreConfig(model Model, authTag names.Tag, leadershipChecker leadership.Ch
 			// Find secrets owned by the application.
 			readAppOwnedFilter.OwnerTags = append(readAppOwnedFilter.OwnerTags, authApp)
 		}
+		// Granted secrets can be consumed in application level for all units.
+		readFilter.ConsumerTags = append(readFilter.ConsumerTags, authApp)
 	case names.ApplicationTag:
 	default:
 		return nil, errors.NotSupportedf("login as %q", authTag)

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -127,7 +127,7 @@ func (s *secretsSuite) TestStoreConfigLeaderUnit(c *gc.C) {
 			},
 		}).Return(owned, nil),
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
-			ConsumerTags: []names.Tag{unitTag},
+			ConsumerTags: []names.Tag{unitTag, names.NewApplicationTag("gitlab")},
 		}).Return(read, nil),
 		p.EXPECT().StoreConfig(gomock.Any(), unitTag,
 			provider.SecretRevisions{"owned-1": set.NewInts(1)},
@@ -174,7 +174,7 @@ func (s *secretsSuite) TestStoreConfigNonLeaderUnit(c *gc.C) {
 			OwnerTags: []names.Tag{unitTag},
 		}).Return(unitOwned, nil),
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
-			ConsumerTags: []names.Tag{unitTag},
+			ConsumerTags: []names.Tag{unitTag, names.NewApplicationTag("gitlab")},
 		}).Return(read, nil),
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
 			OwnerTags: []names.Tag{names.NewApplicationTag("gitlab")},

--- a/apiserver/facades/agent/secretsmanager/access.go
+++ b/apiserver/facades/agent/secretsmanager/access.go
@@ -47,7 +47,6 @@ func (s *SecretsManagerAPI) canManage(uri *coresecrets.URI) (leadership.Token, e
 			// leader unit can manage app owned secret.
 			return s.leadershipToken()
 		}
-		return nil, apiservererrors.ErrPerm
 	case names.ApplicationTag:
 		// TODO(wallyworld) - remove auth tag kind check when podspec charms are gone.
 		if s.hasRole(uri, appTag, coresecrets.RoleManage) {

--- a/apiserver/facades/agent/secretsmanager/access_test.go
+++ b/apiserver/facades/agent/secretsmanager/access_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsmanager_test
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/juju/errors"
+	"github.com/juju/names/v4"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coresecrets "github.com/juju/juju/core/secrets"
+)
+
+func (s *SecretsManagerSuite) TestCanManageOwnerUnit(c *gc.C) {
+	s.authTag = names.NewUnitTag("mariadb/0")
+	defer s.setup(c).Finish()
+
+	uri := coresecrets.NewURI()
+	gomock.InOrder(
+		s.secretsConsumer.EXPECT().SecretAccess(uri, names.NewUnitTag("mariadb/0")).Return(coresecrets.RoleManage, nil),
+	)
+
+	token, err := s.facade.CanManage(uri)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(token.Check(), jc.ErrorIsNil)
+}
+
+func (s *SecretsManagerSuite) TestCanManageLeaderUnitAppSecret(c *gc.C) {
+	s.authTag = names.NewUnitTag("mariadb/0")
+	defer s.setup(c).Finish()
+
+	uri := coresecrets.NewURI()
+	gomock.InOrder(
+		s.secretsConsumer.EXPECT().SecretAccess(uri, names.NewUnitTag("mariadb/0")).Return(coresecrets.RoleNone, errors.NotFoundf("")),
+		s.secretsConsumer.EXPECT().SecretAccess(uri, names.NewApplicationTag("mariadb")).Return(coresecrets.RoleManage, nil),
+		s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token),
+		s.token.EXPECT().Check().Return(nil),
+	)
+
+	_, err := s.facade.CanManage(uri)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *SecretsManagerSuite) TestCanManageAppTagLogin(c *gc.C) {
+	s.authTag = names.NewApplicationTag("mariadb")
+	defer s.setup(c).Finish()
+
+	uri := coresecrets.NewURI()
+	gomock.InOrder(
+		s.secretsConsumer.EXPECT().SecretAccess(uri, names.NewApplicationTag("mariadb")).Return(coresecrets.RoleManage, nil),
+	)
+
+	token, err := s.facade.CanManage(uri)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(token.Check(), jc.ErrorIsNil)
+}

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -14,6 +14,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/leadership"
+	coresecrets "github.com/juju/juju/core/secrets"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -57,4 +58,8 @@ func NewTestAPI(
 		providerGetter:    providerGetter,
 		clock:             clock,
 	}, nil
+}
+
+func (s *SecretsManagerAPI) CanManage(uri *coresecrets.URI) (leadership.Token, error) {
+	return s.canManage(uri)
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -52,7 +52,7 @@ var _ = gc.Suite(&SecretsManagerSuite{})
 
 func (s *SecretsManagerSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
-	
+
 	s.authTag = names.NewUnitTag("mariadb/0")
 }
 

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -52,6 +52,8 @@ var _ = gc.Suite(&SecretsManagerSuite{})
 
 func (s *SecretsManagerSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
+	
+	s.authTag = names.NewUnitTag("mariadb/0")
 }
 
 type mockModel struct {
@@ -72,7 +74,6 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 	s.secretsWatcher = mocks.NewMockStringsWatcher(ctrl)
 	s.secretTriggers = mocks.NewMockSecretTriggers(ctrl)
 	s.secretsTriggerWatcher = mocks.NewMockSecretsTriggerWatcher(ctrl)
-	s.authTag = names.NewUnitTag("mariadb/0")
 	s.expectAuthUnitAgent()
 
 	s.clock = testclock.NewClock(time.Now())
@@ -291,7 +292,7 @@ func (s *SecretsManagerSuite) TestUpdateSecrets(c *gc.C) {
 	)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token).Times(2)
 	s.token.EXPECT().Check().Return(nil).Times(2)
-	s.expectSecretAccessQuery(2)
+	s.expectSecretAccessQuery(4)
 
 	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{{
@@ -341,7 +342,7 @@ func (s *SecretsManagerSuite) TestUpdateSecretDuplicateLabel(c *gc.C) {
 	)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
-	s.expectSecretAccessQuery(1)
+	s.expectSecretAccessQuery(2)
 
 	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{{
@@ -367,7 +368,7 @@ func (s *SecretsManagerSuite) TestRemoveSecrets(c *gc.C) {
 	s.secretsBackend.EXPECT().DeleteSecret(&expectURI, []int{666}).Return(true, nil)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
-	s.expectSecretAccessQuery(1)
+	s.expectSecretAccessQuery(2)
 	s.provider.EXPECT().CleanupSecrets(
 		mockModel{}, names.NewUnitTag("mariadb/0"),
 		provider.SecretRevisions{uri.ID: set.NewInts(666)},
@@ -393,7 +394,7 @@ func (s *SecretsManagerSuite) TestRemoveSecretRevision(c *gc.C) {
 	s.secretsBackend.EXPECT().DeleteSecret(&expectURI, []int{666}).Return(false, nil)
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
-	s.expectSecretAccessQuery(1)
+	s.expectSecretAccessQuery(2)
 
 	results, err := s.facade.RemoveSecrets(params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
@@ -1003,7 +1004,7 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.expectSecretAccessQuery(1)
+	s.expectSecretAccessQuery(2)
 	uri := coresecrets.NewURI()
 	subjectTag := names.NewUnitTag("wordpress/0")
 	scopeTag := names.NewRelationTag("wordpress:db mysql:server")
@@ -1047,7 +1048,7 @@ func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 func (s *SecretsManagerSuite) TestSecretsRevoke(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.expectSecretAccessQuery(1)
+	s.expectSecretAccessQuery(2)
 	uri := coresecrets.NewURI()
 	subjectTag := names.NewUnitTag("wordpress/0")
 	scopeTag := names.NewRelationTag("wordpress:db mysql:server")

--- a/secrets/provider/kubernetes/secrets.go
+++ b/secrets/provider/kubernetes/secrets.go
@@ -108,6 +108,7 @@ func cloudSpecToStoreConfig(controllerUUID string, cfg *config.Config, spec clou
 // StoreConfig returns the config needed to create a k8s secrets store.
 // TODO(wallyworld) - only allow access to the specified secrets
 func (p k8sProvider) StoreConfig(m provider.Model, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions) (*provider.StoreConfig, error) {
+	logger.Tracef("getting k8s store config for %q, owned %v, read %v", tag, owned, read)
 	cloudSpec, err := cloudSpecForModel(m)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -152,7 +153,6 @@ func (p k8sProvider) StoreConfig(m provider.Model, tag names.Tag, owned provider
 			cloudSpec.IsControllerCloud = false
 		}
 	}
-
 	return cloudSpecToStoreConfig(controllerUUID, cfg, cloudSpec)
 }
 


### PR DESCRIPTION
This ensures:
- the leader unit should not be able to grant non-leader units owned secrets;
- app's secret should be readable for all its own units(but it is currently only readable for the leader unit);

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju show-unit hello-kubecon/0 | grep leader
  leader: true

$ juju exec --unit hello-kubecon/0 'uri=$(secret-add --owner unit foo=unit0); echo $uri; secret-set $uri --label=unit0;'
secret:cd90nvmffbajicirb0mg

$ juju exec --unit hello-kubecon/0 'uri=$(secret-add foo=app); echo $uri; secret-set $uri --label=app;'
secret:cd90o2effbajicirb0n0

$ juju exec --unit hello-kubecon/0 -- secret-get --label=unit0
foo: unit0

$ juju exec --unit hello-kubecon/0 -- secret-get --label=unit0 --metadata
cd90nvmffbajicirb0mg:
  revision: 1
  label: unit0
  owner: unit
  rotation: never

$ juju exec --unit hello-kubecon/0 -- secret-get cd90o2effbajicirb0n0 --label=app
foo: app

$ juju exec --unit hello-kubecon/0 -- secret-get --label=app
foo: app

$ juju exec --unit hello-kubecon/0 -- secret-get --label=app --metadata
cd90o2effbajicirb0n0:
  revision: 1
  label: app
  owner: application
  rotation: never

$ juju show-unit hello-kubecon/1 | grep leader
  leader: false

$ juju exec --unit hello-kubecon/1 -- secret-get cd90o2effbajicirb0n0 --label app
foo: app

$ juju exec --unit hello-kubecon/1 -- secret-get --label=app
foo: app

$ juju exec --unit hello-kubecon/1 'uri=$(secret-add --owner unit foo=unit1); echo $uri; secret-set $uri --label=unit1;'
secret:cd90rjeffbajicirb0ng

$ juju exec --unit hello-kubecon/0 -- secret-get cd90rjeffbajicirb0ng
ERROR permission denied
ERROR the following task failed:
 - id "26" with return code 1

use 'juju show-task' to inspect the failure

$ juju exec --unit hello-kubecon/0 -- secret-grant cd90rjeffbajicirb0ng -r 0
granting secrets access: permission denied

$ juju exec --unit hello-kubecon/1 -- secret-grant cd90rjeffbajicirb0ng -r 0

$ juju exec --unit hello-kubecon/1 -- secret-grant cd90o2effbajicirb0n0 -r 0
granting secrets access: "hello-kubecon/1" is not leader of "hello-kubecon"

$ juju exec --unit hello-kubecon/0 -- secret-grant cd90o2effbajicirb0n0 -r 0

$ juju exec --unit nginx-ingress-integrator/0 -- secret-get cd90o2effbajicirb0n0
foo: app

$ juju exec --unit nginx-ingress-integrator/0 -- secret-get cd90rjeffbajicirb0ng
foo: unit1


```

## Documentation changes

No

## Bug reference

- https://bugs.launchpad.net/juju/+bug/1993607
- https://bugs.launchpad.net/juju/+bug/1993608