### PR TITLE
Merge 2.9 into 3.0

### DIFF
--- a/core/series/supportedseries_linux_test.go
+++ b/core/series/supportedseries_linux_test.go
@@ -80,6 +80,6 @@ func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
 	series, err := WorkloadSeries(time.Time{}, "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
-		"centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kubernetes",
+		"centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kinetic", "kubernetes",
 		"opensuseleap"})
 }

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -36,10 +36,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos9", "centos8", "centos7", "genericlinux", "kubernetes", "opensuseleap"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "centos9", "centos8", "centos7", "genericlinux", "kubernetes", "opensuseleap"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -52,10 +52,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos9", "centos8", "centos7", "genericlinux", "kubernetes", "opensuseleap"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "centos9", "centos8", "centos7", "genericlinux", "kubernetes", "opensuseleap"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -68,10 +68,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos9", "centos8", "centos7", "genericlinux", "kubernetes", "opensuseleap"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "centos9", "centos8", "centos7", "genericlinux", "kubernetes", "opensuseleap"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -84,10 +84,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "centos9", "centos8", "centos7", "genericlinux", "kubernetes", "opensuseleap"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"kinetic", "jammy", "focal", "centos9", "centos8", "centos7", "genericlinux", "kubernetes", "opensuseleap"})
 }
 
 var getOSFromSeriesTests = []struct {


### PR DESCRIPTION
Merge 2.9 branch into 3.0 to bring forward:
- #14795 from manadart/2.9-kinetic-series-support
- #14789 from wallyworld/missing-platform-os

Conflicts:
- apiserver/facades/client/application/application.go
- apiserver/facades/client/application/application_test.go
- core/series/supportedseries_linux_test.go
- core/series/supportedseries_test.go