### PR TITLE
Improve probes to be more fault tolerant. Improve bootstrap speed. Start is ready. Stop is unready.

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -53,11 +53,16 @@ import (
 var logger = loggo.GetLogger("juju.kubernetes.provider.application")
 
 const (
+	// containerProbeInitialDelay is the initial delay in seconds before the probe starts.
 	containerProbeInitialDelay = 30
-	containerProbeTimeout      = 1
-	containerProbePeriod       = 5
-	containerProbeSuccess      = 1
-	containerProbeFailure      = 1
+	// containerProbeTimeout is the timeout for the probe to complete in seconds.
+	containerProbeTimeout = 1
+	// containerProbePeriod is the number of seconds between each probe.
+	containerProbePeriod = 5
+	// containerProbeSuccess is the number of successful probes to mark the check as healthy.
+	containerProbeSuccess = 1
+	// containerProbeFailure is the number of failed probes to mark the check as unhealthy.
+	containerProbeFailure = 3
 )
 
 type app struct {

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -525,7 +525,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -538,7 +538,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -594,7 +594,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -607,7 +607,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:  int64Ptr(0),
@@ -657,7 +657,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -670,7 +670,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    1,
+				FailureThreshold:    3,
 			},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:  int64Ptr(0),

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -699,6 +699,16 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					Protocol:      "TCP",
 				},
 			},
+			StartupProbe: &core.Probe{
+				ProbeHandler: core.ProbeHandler{
+					Exec: probCmds,
+				},
+				FailureThreshold:    60,
+				InitialDelaySeconds: 1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				TimeoutSeconds:      1,
+			},
 			ReadinessProbe: &core.Probe{
 				ProbeHandler: core.ProbeHandler{
 					Exec: probCmds,
@@ -835,7 +845,7 @@ EOF
 				TimeoutSeconds:      3,
 				PeriodSeconds:       3,
 				SuccessThreshold:    1,
-				FailureThreshold:    5,
+				FailureThreshold:    100,
 			},
 			LivenessProbe: &core.Probe{
 				ProbeHandler: core.ProbeHandler{

--- a/worker/uniter/op_callbacks.go
+++ b/worker/uniter/op_callbacks.go
@@ -68,7 +68,9 @@ func (opc *operationCallbacks) PrepareHook(hi hook.Info) (string, error) {
 func (opc *operationCallbacks) CommitHook(hi hook.Info) error {
 	switch {
 	case hi.Kind == hooks.Start:
-		opc.u.Probe.SetHasStarted()
+		opc.u.Probe.SetHasStarted(true)
+	case hi.Kind == hooks.Stop:
+		opc.u.Probe.SetHasStarted(false)
 	case hi.Kind.IsWorkload():
 	case hi.Kind.IsRelation():
 		return opc.u.relationStateTracker.CommitHook(hi)

--- a/worker/uniter/probe.go
+++ b/worker/uniter/probe.go
@@ -26,16 +26,19 @@ func (p *Probe) HasStarted() bool {
 
 // SetHasStarted sets the has started state for this probe. Should be called
 // when the uniter has started its associated charm.
-func (p *Probe) SetHasStarted() {
+func (p *Probe) SetHasStarted(started bool) {
 	p.hasStartedLock.Lock()
 	defer p.hasStartedLock.Unlock()
-	p.hasStarted = true
+	p.hasStarted = started
 }
 
 // SupportedProbes implements probe.ProbeProvider interface
 func (p *Probe) SupportedProbes() probe.SupportedProbes {
 	return probe.SupportedProbes{
-		probe.ProbeStartup: probe.ProberFn(func() (bool, error) {
+		probe.ProbeLiveness: probe.ProberFn(func() (bool, error) {
+			return true, nil
+		}),
+		probe.ProbeReadiness: probe.ProberFn(func() (bool, error) {
 			return p.HasStarted(), nil
 		}),
 	}


### PR DESCRIPTION
Improve probes to be more fault tolerant.
Improve bootstrap speed.
For unit agents Start hook means ready. Stop hook means unready.

## QA steps

Deploy a sidecar charm where the start hook errors.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1992987