### PR TITLE
[JUJU-2020] Reject if no data to set for secret-set;

### DIFF
--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -969,7 +969,7 @@ func (b *CommitHookParamsBuilder) AddSecretCreates(creates []SecretCreateArg) {
 	for i, c := range creates {
 
 		var data secrets.SecretData
-		if !c.Value.IsEmpty() {
+		if c.Value != nil {
 			data = c.Value.EncodedValues()
 		}
 		if len(data) == 0 {
@@ -1003,7 +1003,7 @@ func (b *CommitHookParamsBuilder) AddSecretUpdates(updates []SecretUpsertArg) {
 	for i, u := range updates {
 
 		var data secrets.SecretData
-		if !u.Value.IsEmpty() {
+		if u.Value != nil {
 			data = u.Value.EncodedValues()
 		}
 		if len(data) == 0 {

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -969,7 +969,7 @@ func (b *CommitHookParamsBuilder) AddSecretCreates(creates []SecretCreateArg) {
 	for i, c := range creates {
 
 		var data secrets.SecretData
-		if c.Value != nil {
+		if !c.Value.IsEmpty() {
 			data = c.Value.EncodedValues()
 		}
 		if len(data) == 0 {
@@ -1003,7 +1003,7 @@ func (b *CommitHookParamsBuilder) AddSecretUpdates(updates []SecretUpsertArg) {
 	for i, u := range updates {
 
 		var data secrets.SecretData
-		if u.Value != nil {
+		if !u.Value.IsEmpty() {
 			data = u.Value.EncodedValues()
 		}
 		if len(data) == 0 {

--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -82,7 +82,9 @@ func (api *Client) ListSecrets(reveal bool, filter secrets.Filter) ([]SecretDeta
 		}
 		if reveal && r.Value != nil {
 			if r.Value.Error == nil {
-				details.Value = secrets.NewSecretValue(r.Value.Data)
+				if data := secrets.NewSecretValue(r.Value.Data); !data.IsEmpty() {
+					details.Value = data
+				}
 			} else {
 				details.Error = r.Value.Error.Error()
 			}

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades/upgradevalidation"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -219,14 +220,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c 
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
-	// TODO (hml) 19-oct-2022
-	// Once upgrade from 2.9 to 3.0 is supported, go back to
-	// using coretesting.FakeVersionNumber in this test.
-	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	c.Assert(agentVersion.Build, gc.Equals, 0)
 	builtVersion := coretesting.CurrentVersion()
@@ -269,14 +267,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionAlreadyUpToDate(c *gc.
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
-	// TODO (hml) 19-oct-2022
-	// Once upgrade from 2.9 to 3.0 is supported, go back to
-	// using coretesting.FakeVersionNumber in this test.
-	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	c.Assert(agentVersion.Build, gc.Equals, 0)
 	targetVersion := coretesting.CurrentVersion()
@@ -351,14 +346,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
-	// TODO (hml) 19-oct-2022
-	// Once upgrade from 2.9 to 3.0 is supported, go back to
-	// using coretesting.FakeVersionNumber in this test.
-	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	targetVersion := coretesting.CurrentVersion().Number
 	gomock.InOrder(
@@ -390,14 +382,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
-	// TODO (hml) 19-oct-2022
-	// Once upgrade from 2.9 to 3.0 is supported, go back to
-	// using coretesting.FakeVersionNumber in this test.
-	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := coretesting.FakeVersionNumber
 	modelCfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 	controllerCfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 		// This isn't right, but it's ok for testing because it's not important here.

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -174,7 +174,7 @@ func gatherSecretInfo(secrets []apisecrets.SecretDetails, reveal, includeRevisio
 				}
 			}
 		}
-		if reveal && m.Value != nil {
+		if reveal && !m.Value.IsEmpty() {
 			valueDetails := &secretValueDetails{}
 			val, err := m.Value.Values()
 			if err != nil {

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1431,7 +1431,7 @@ func (ctx *HookContext) doFlush(process string) error {
 	for i, u := range ctx.secretChanges.pendingUpdates {
 		// Juju checks that the current revision is stable when updating metadata so it's
 		// safe to increment here knowing the same value will be saved in Juju.
-		if u.Value == nil {
+		if u.Value.IsEmpty() {
 			pendingUpdates[i] = u.SecretUpsertArg
 			continue
 		}

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -119,8 +119,11 @@ func (c *secretUpsertCommand) Init(args []string) error {
 
 	var err error
 	c.data, err = secrets.CreateSecretData(args)
-	if err != nil || c.fileName == "" {
+	if err != nil {
 		return errors.Trace(err)
+	}
+	if c.fileName == "" {
+		return nil
 	}
 	dataFromFile, err := secrets.ReadSecretData(c.fileName)
 	if err != nil {


### PR DESCRIPTION
Reject if no data to set for secret-set;

Drive-by: https://github.com/juju/juju/commit/75cad4d54ebc0cd5559524c52630cd6f93eb20fe#diff-4e6ff69fdc9202141c194ed7a0fd730a47d4ae2fa8a04e45607a2148c9341302 This change was lost in one of previous forward port (2.9 -> 3.0) PR, so add it back as a drive-by.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju exec --unit hello-kubecon/0 -- secret-add --owner unit
ERROR missing secret value or filename
ERROR the following task failed:
 - id "2" with return code 2

use 'juju show-task' to inspect the failure

$ juju exec --unit hello-kubecon/0 -- secret-add
ERROR missing secret value or filename
ERROR the following task failed:
 - id "4" with return code 2

use 'juju show-task' to inspect the failure

$ juju exec --unit hello-kubecon/0 -- secret-add --owner unit foo=unit0
secret:cdb2fauffbaq6mbn4e8g

$ juju exec --unit hello-kubecon/0 -- secret-set cdb2fauffbaq6mbn4e8g
updating secrets: at least one attribute to update must be specified

$ juju exec --unit hello-kubecon/0 -- secret-set cdb2fauffbaq6mbn4e8g --label unit0

$ juju exec --unit hello-kubecon/0 -- secret-get --label unit0
foo: unit0

```

## Documentation changes

No

## Bug reference

No
