### PR TITLE
change min LXD version to 5.0

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -410,7 +410,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 		).Return(map[string]int{"xenial": 2}, nil),
 		// - check LXD version.
 		serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 		ctrlModel.EXPECT().Owner().Return(names.NewUserTag("admin")),
 		ctrlModel.EXPECT().Name().Return("controller"),
 
@@ -457,7 +457,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 		}, nil),
 		// - check LXD version.
 		serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 		model1.EXPECT().Owner().Return(names.NewUserTag("admin")),
 		model1.EXPECT().Name().Return("model-1"),
 	)
@@ -477,13 +477,13 @@ cannot upgrade to "3.9.99" due to issues with these models:
 - mongo version has to be "4.4" at least, but current version is "4.3"
 - the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): xenial(2)
-- LXD version has to be at least "5.2.0", but current version is only "5.1.0"
+- LXD version has to be at least "5.0.0", but current version is only "4.0.0"
 "admin/model-1":
 - current model ("2.9.0") has to be upgraded to "2.9.2" at least
 - model is under "exporting" mode, upgrade blocked
 - the model hosts deprecated windows machine(s): win10(1) win7(3)
 - the model hosts deprecated ubuntu machine(s): artful(1) cosmic(2) disco(3) eoan(4) groovy(5) hirsute(6) impish(7) precise(8) quantal(9) raring(10) saucy(11) trusty(12) utopic(13) vivid(14) wily(15) xenial(16) yakkety(17) zesty(18)
-- LXD version has to be at least "5.2.0", but current version is only "5.1.0"`[1:])
+- LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
 
 func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, dryRun bool) {
@@ -671,7 +671,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 		}, nil),
 		// - check LXD version.
 		serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 		model.EXPECT().Owner().Return(names.NewUserTag("admin")),
 		model.EXPECT().Name().Return("model-1"),
 	)
@@ -688,7 +688,7 @@ cannot upgrade to "3.9.99" due to issues with these models:
 - unexpected upgrade series lock found
 - the model hosts deprecated windows machine(s): win10(1) win7(3)
 - the model hosts deprecated ubuntu machine(s): artful(1) cosmic(2) disco(3) eoan(4) groovy(5) hirsute(6) impish(7) precise(8) quantal(9) raring(10) saucy(11) trusty(12) utopic(13) vivid(14) wily(15) xenial(16) yakkety(17) zesty(18)
-- LXD version has to be at least "5.2.0", but current version is only "5.1.0"`[1:])
+- LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
 
 func (s *modelUpgradeSuite) TestAbortCurrentUpgrade(c *gc.C) {

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -110,7 +110,7 @@ func (s *SourcePrecheckSuite) TestTargetController3Failed(c *gc.C) {
 
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
-	server.EXPECT().ServerVersion().Return("5.1")
+	server.EXPECT().ServerVersion().Return("4.0")
 
 	err := migration.SourcePrecheck(
 		backend, version.MustParse("3.0.0"), allAlivePresence(), allAlivePresence(),
@@ -125,7 +125,7 @@ cannot migrate to controller ("3.0.0") due to issues:
 - unexpected upgrade series lock found
 - the model hosts deprecated windows machine(s): win10(1) win7(2)
 - the model hosts deprecated ubuntu machine(s): trusty(3) vivid(2) xenial(1)
-- LXD version has to be at least "5.2.0", but current version is only "5.1.0"`[1:])
+- LXD version has to be at least "5.0.0", but current version is only "4.0.0"`[1:])
 }
 
 func (*SourcePrecheckSuite) TestTargetController2Failed(c *gc.C) {

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -288,7 +288,7 @@ func checkMongoVersionForControllerModel(modelUUID string, pool StatePool, st St
 // For testing.
 var NewServerFactory = lxd.NewServerFactory
 
-var minLXDVersion = version.Number{Major: 5, Minor: 2}
+var minLXDVersion = version.Number{Major: 5, Minor: 0}
 
 func getCheckForLXDVersion(
 	cloudspec environscloudspec.CloudSpec,

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -433,12 +433,13 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 	cloudSpec := environscloudspec.CloudSpec{Type: "lxd"}
 	gomock.InOrder(
 		serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.1"),
+		server.EXPECT().ServerVersion().Return("4.0"),
 	)
 
 	blocker, err := upgradevalidation.GetCheckForLXDVersion(
 		cloudSpec, upgradevalidation.MinLXDVersion,
 	)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.2.0", but current version is only "5.1.0"`)
+	c.Assert(blocker, gc.NotNil)
+	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
 }


### PR DESCRIPTION
Now that bug in LXD 5.0 that broke jammy has been fixed, We add support for LXD 5.0 when migrating models to a 3.0 target.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
- install lxd version 5.0
- bootstrap 2.9.36, deploy a small model
- bootstrap 3.0.0
- switch to 2.9 controller
- juju migrate 29model 30controller
running juju status on 2.9 model will show progress, eventually `juju status` will show that model has been migrated. you can then switch to the model on the other controller and use it.