### PR TITLE
[JUJU-2016] Check for nil return from charm.Meta() in application.Endpoints()

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -987,7 +987,12 @@ func (a *Application) Endpoints() (eps []Endpoint, err error) {
 			})
 		}
 	}
+
 	meta := ch.Meta()
+	if meta == nil {
+		return nil, errors.Errorf("nil charm metadata for application %q", a.Name())
+	}
+
 	collect(charm.RolePeer, meta.Peers)
 	collect(charm.RoleProvider, meta.Provides)
 	collect(charm.RoleRequirer, meta.Requires)


### PR DESCRIPTION
Migrating a CMR-offering model from 2.9 to 3.0 fails and renders the target unusable. This is because the following panic sends the controller into a crash loop:
```
2022-10-21 14:04:11 INFO juju.state.allwatcher allwatcher.go:1819 allwatcher loaded for model "29298de4-a591-448f-87e5-be17e10ee58a" in 9.906636ms
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x1d877f9]

goroutine 420 [running]:
github.com/juju/juju/state.(*Application).Endpoints(0xc000817b80)
        /home/joseph/go/src/github.com/juju/juju/state/application.go:991 +0x59
github.com/juju/juju/state.(*Application).Endpoint(0xc000817b80, {0xc000ecc5fe, 0x2})
        /home/joseph/go/src/github.com/juju/juju/state/application.go:1008 +0x65
github.com/juju/juju/state.getApplicationEndpoints(0xc000817b80, 0xc000ecc5e0?)
        /home/joseph/go/src/github.com/juju/juju/state/applicationoffers.go:909 +0x125
github.com/juju/juju/state.(*applicationOffers).makeApplicationOffer(0xc000bd5a98, {{0xc0009966c0, 0x2f}, {0xc0009966f0, 0x24}, {0xc000ecc5c0, 0xa},
{0xc000ecc5e0, 0xa}, {0xc000ecaf00, ...}, ...})
        /home/joseph/go/src/github.com/juju/juju/state/applicationoffers.go:898 +0xf7
github.com/juju/juju/state.(*applicationOffers).ApplicationOfferForUUID(0xc000ecc3a0?, {0xc000996510, 0x24})
        /home/joseph/go/src/github.com/juju/juju/state/applicationoffers.go:135 +0x225
github.com/juju/juju/state.(*backingApplicationOffer).updated(0xc000eaa180, 0xc0005db200)
        /home/joseph/go/src/github.com/juju/juju/state/allwatcher.go:950 +0x1a9
github.com/juju/juju/state.loadOneWatcherEntity(0xc0005db200, {0x61e7d50?, 0xc0005db180?}, {0xc00013f080, 0x24}, {0x6208a70, 0x5464d60}, {0x5853666,
0x11})
        /home/joseph/go/src/github.com/juju/juju/state/allwatcher.go:1873 +0x49b
github.com/juju/juju/state.loadAllWatcherEntities(0xc000381720, {0xc0002548c0, 0x13, 0x3?}, 0x62013b8?, {0x61dfd60?, 0xc000d8b860})
        /home/joseph/go/src/github.com/juju/juju/state/allwatcher.go:1841 +0x3c5
github.com/juju/juju/state.(*allWatcherBacking).loadAllWatcherEntitiesForModel(0xc000ef45c0, {0xc000c1e420, 0x24}, {0x61dfd60, 0xc000d8b860})
        /home/joseph/go/src/github.com/juju/juju/state/allwatcher.go:1720 +0x145
github.com/juju/juju/state.(*allWatcherBacking).GetAll(0xc000ef45c0, {0x61dfd60, 0xc000d8b860})
        /home/joseph/go/src/github.com/juju/juju/state/allwatcher.go:1698 +0xde
github.com/juju/juju/worker/multiwatcher.(*Worker).process(0xc000c0a120, {0x61ce5b0, 0xc000ef45c0}, 0xc00066f620)
        /home/joseph/go/src/github.com/juju/juju/worker/multiwatcher/worker.go:353 +0x63
github.com/juju/juju/worker/multiwatcher.(*Worker).inner.func1()
        /home/joseph/go/src/github.com/juju/juju/worker/multiwatcher/worker.go:287 +0x7e
created by github.com/juju/juju/worker/multiwatcher.(*Worker).inner
        /home/joseph/go/src/github.com/juju/juju/worker/multiwatcher/worker.go:286 +0x278
```

Guarding for nil charm metadata and returning an error fixes the issue.

## QA steps

- Bootstrap 2 controllers with 2.9.
- Deploy a workload to one, offer it, and consume it in the other.
- Bootstrap a third controller with this patch.
- Migrate the offering model to the 3.0 controller and check that it succeeds.
- The consuming model logs should show resumption of the SAAS connection.
```
controller-0: 16:49:15 ERROR juju.worker.remoterelations cmr error in remote application worker for postgresql: model is being migrated
controller-0: 16:49:30 DEBUG juju.worker.remoterelations cmr remote controller API addresses: [10.246.27.74:17070]
controller-0: 16:49:30 DEBUG juju.worker.remoterelations cmr received redirect; new API addresses: [10.246.27.26:17070]
controller-0: 16:49:30 DEBUG juju.worker.remoterelations cmr relations changed: &[]string(nil), true
controller-0: 16:49:30 DEBUG juju.worker.remoterelations cmr offer status changed: []watcher.OfferStatusChange{watcher.OfferStatusChange{Name:"postgresql", Status:status.StatusInfo{Status:"active", Message:"Live master (12.12)", Data:map[string]interface {}(nil), Since:time.Date(2022, time.October, 21, 14, 7, 19, 962397887, time.UTC)}}}
```
