### PR TITLE
Update version number in upgrade model tests

### DIFF
--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -184,7 +184,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersion(c *gc.C) {
 		// using coretesting.FakeVersionNumber.String() in this
 		// test.
 		//"agent-version": coretesting.FakeVersionNumber.String(),
-		"agent-version": "3.0.1",
+		"agent-version": "3.1.0",
 	})
 
 	gomock.InOrder(
@@ -223,7 +223,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c 
 	// Once upgrade from 2.9 to 3.0 is supported, go back to
 	// using coretesting.FakeVersionNumber in this test.
 	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := version.MustParse("3.1.0")
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
@@ -273,7 +273,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionAlreadyUpToDate(c *gc.
 	// Once upgrade from 2.9 to 3.0 is supported, go back to
 	// using coretesting.FakeVersionNumber in this test.
 	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := version.MustParse("3.1.0")
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
@@ -355,7 +355,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 	// Once upgrade from 2.9 to 3.0 is supported, go back to
 	// using coretesting.FakeVersionNumber in this test.
 	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := version.MustParse("3.1.0")
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
@@ -394,7 +394,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 	// Once upgrade from 2.9 to 3.0 is supported, go back to
 	// using coretesting.FakeVersionNumber in this test.
 	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := version.MustParse("3.1.0")
 	modelCfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
@@ -436,7 +436,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionDryRun(c *gc.C) {
 		// using coretesting.FakeVersionNumber.String() in this
 		// test.
 		//"agent-version": coretesting.FakeVersionNumber.String(),
-		"agent-version": "3.0.1",
+		"agent-version": "3.1.0",
 	})
 
 	gomock.InOrder(
@@ -470,7 +470,7 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionGotBlockers(c *gc.C) {
 		// using coretesting.FakeVersionNumber.String() in this
 		// test.
 		//"agent-version": coretesting.FakeVersionNumber.String(),
-		"agent-version": "3.0.1",
+		"agent-version": "3.1.0",
 	})
 
 	gomock.InOrder(


### PR DESCRIPTION
The upgrade model client tests are failing on the current 3.0 branch. The tests were using a test version number 3.0.1. However, the tests relied on 3.0.1 being a future version - since #14807 it is the current version. So I changed this number to a future version (3.1.0) to fix them in the meantime.

As the comments note, we will change to a fake version number once the 2.9 -> 3.0 upgrade is supported, but this is not the case yet.

## QA steps

```sh
go test -v ./cmd/juju/commands -check.f upgradeNewSuite 
```

And check that the "Client Tests" GitHub Actions pass below.