### PR TITLE
Update juju/packaging to v2.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/juju/names/v4 v4.0.0
 	github.com/juju/naturalsort v1.0.0
 	github.com/juju/os/v2 v2.2.3
-	github.com/juju/packaging/v2 v2.0.0
+	github.com/juju/packaging/v2 v2.0.1
 	github.com/juju/persistent-cookiejar v1.0.0
 	github.com/juju/proxy v1.0.0
 	github.com/juju/pubsub/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ github.com/juju/naturalsort v1.0.0 h1:kGmUUy3h8mJ5/SJYaqKOBR3f3owEd5R52Lh+Tjg/dN
 github.com/juju/naturalsort v1.0.0/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os/v2 v2.2.3 h1:5SnGWfzFTXcFwu/sd9qEEf/No3UZxivOjJuWmsHI4N4=
 github.com/juju/os/v2 v2.2.3/go.mod h1:xGfP9I+Xb/A03NcGBsoJgwr084hPckkQHecaHuV3wBQ=
-github.com/juju/packaging/v2 v2.0.0 h1:wsm7nb1Kyjuf7XQb9Sfx87axkTv15bD0efsKy3faOEk=
-github.com/juju/packaging/v2 v2.0.0/go.mod h1:JC+FIRTJXGLt9wA+iP3ltkzv+aWVMMojB/R47uIAK0Y=
+github.com/juju/packaging/v2 v2.0.1 h1:KeTfqx3Z0c6RcM053GJH7mplroXoRSuh/dK5vqDQLn8=
+github.com/juju/packaging/v2 v2.0.1/go.mod h1:JC+FIRTJXGLt9wA+iP3ltkzv+aWVMMojB/R47uIAK0Y=
 github.com/juju/persistent-cookiejar v1.0.0 h1:Ag7+QLzqC2m+OYXy2QQnRjb3gTkEBSZagZ6QozwT3EQ=
 github.com/juju/persistent-cookiejar v1.0.0/go.mod h1:zrbmo4nBKaiP/Ez3F67ewkMbzGYfXyMvRtbOfuAwG0w=
 github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSwAjh/uLXDM=


### PR DESCRIPTION
Pulls in juju/packaging#18 and fixes the issue described there (bootstrap hanging forever).

## QA steps

Turn off your internet connection and run

```console
$ juju bootstrap lxd c
...
Running machine configuration script...
...
Err:1 http://archive.ubuntu.com/ubuntu focal/main amd64 msr-tools amd64 1.3-3
  Temporary failure resolving 'archive.ubuntu.com'
Err:2 http://archive.ubuntu.com/ubuntu focal/main amd64 cpu-checker amd64 0.7-1.1
  Temporary failure resolving 'archive.ubuntu.com'
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/m/msr-tools/msr-tools_1.3-3_amd64.deb  Temporary failure resolving 'archive.ubuntu.com'
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/cpu-checker/cpu-checker_0.7-1.1_amd64.deb  Temporary failure resolving 'archive.ubuntu.com'
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
...
ERROR failed to bootstrap model: subprocess encountered error code 100 
```

## Bug reference
https://bugs.launchpad.net/juju/+bug/1969706
https://bugs.launchpad.net/juju/+bug/1993914