### PR TITLE
Show revision during "juju download"; make default path include rN

### DIFF
--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -230,7 +230,12 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 		path = fmt.Sprintf("%s%s.%s", entity.Name, short, entityType)
 	}
 
-	cmdContext.Infof("Fetching %s %q using %q channel and base %q", entityType, entity.Name, normChannel, normBase)
+	revisionStr := ""
+	if entity.Revision != 0 {
+		revisionStr = fmt.Sprintf(" revision %d", entity.Revision)
+	}
+	cmdContext.Infof("Fetching %s %q%s using %q channel and base %q",
+		entityType, entity.Name, revisionStr, normChannel, normBase)
 
 	resourceURL, err := url.Parse(entity.Download.URL)
 	if err != nil {

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -219,23 +219,13 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 	entitySHA := entity.Download.HashSHA256
 
 	path := c.archivePath
-	if c.archivePath == "" {
-		// Use the sha256 to create a unique path for every download. The
-		// consequence of this is that same sha binary blobs will overwrite
-		// each other. That should be ok, as the sha will match.
-		var short string
-		if len(entitySHA) >= 7 {
-			short = fmt.Sprintf("_%s", entitySHA[0:7])
-		}
-		path = fmt.Sprintf("%s%s.%s", entity.Name, short, entityType)
+	if path == "" {
+		// Use the revision number to create a unique path for every download.
+		path = fmt.Sprintf("%s_r%d.%s", entity.Name, entity.Revision, entityType)
 	}
 
-	revisionStr := ""
-	if entity.Revision != 0 {
-		revisionStr = fmt.Sprintf(" revision %d", entity.Revision)
-	}
-	cmdContext.Infof("Fetching %s %q%s using %q channel and base %q",
-		entityType, entity.Name, revisionStr, normChannel, normBase)
+	cmdContext.Infof("Fetching %s %q revision %d using %q channel and base %q",
+		entityType, entity.Name, entity.Revision, normChannel, normBase)
 
 	resourceURL, err := url.Parse(entity.Download.URL)
 	if err != nil {

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -89,6 +89,11 @@ func (s *downloadSuite) TestRun(c *gc.C) {
 	ctx := commandContextForTest(c)
 	err = command.Run(ctx)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, "(?s)"+`
+Fetching charm "test" revision 123 using "stable" channel and base "amd64/ubuntu/22.04"
+Install the "test" charm with:
+    juju deploy ./test_.*\.charm
+`[1:])
 }
 
 func (s *downloadSuite) TestRunWithStdout(c *gc.C) {
@@ -222,6 +227,7 @@ func (s *downloadSuite) expectRefresh(charmHubURL string) {
 					HashSHA256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					URL:        charmHubURL,
 				},
+				Revision: 123,
 			},
 		}}, nil
 	})

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -92,7 +92,7 @@ func (s *downloadSuite) TestRun(c *gc.C) {
 	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, "(?s)"+`
 Fetching charm "test" revision 123 using "stable" channel and base "amd64/ubuntu/22.04"
 Install the "test" charm with:
-    juju deploy ./test_.*\.charm
+    juju deploy ./test_r123\.charm
 `[1:])
 }
 
@@ -282,11 +282,11 @@ func (s *downloadSuite) expectRefreshUnsupportedSeries() {
 func (s *downloadSuite) expectDownload(c *gc.C, charmHubURL string) {
 	resourceURL, err := url.Parse(charmHubURL)
 	c.Assert(err, jc.ErrorIsNil)
-	s.charmHubAPI.EXPECT().Download(gomock.Any(), resourceURL, "test_e3b0c44.charm", gomock.Any()).Return(nil)
+	s.charmHubAPI.EXPECT().Download(gomock.Any(), resourceURL, "test_r123.charm", gomock.Any()).Return(nil)
 }
 
 func (s *downloadSuite) expectFilesystem(c *gc.C) {
 	s.file.EXPECT().Read(gomock.Any()).Return(0, io.EOF).AnyTimes()
 	s.file.EXPECT().Close().Return(nil)
-	s.filesystem.EXPECT().Open("test_e3b0c44.charm").Return(s.file, nil)
+	s.filesystem.EXPECT().Open("test_r123.charm").Return(s.file, nil)
 }


### PR DESCRIPTION
This PR shows the revision number in the stderr output when running `juju download`, so you can cross-reference it with `juju info` output.

It also changes the default filename to include the revision number, for example from `mycharm_39ef98b.charm` (using `sha[:7]`) to `mycharm_r42.charm` (@hmlanigan's suggestion).

I found the lack of revision when using `juju download` made it harder to see what was going on when testing `juju info` and then `juju download` on a charm with multiple channels and arches. Also, it matches how we show revision during `juju deploy` (including `juju deploy --dry-run`).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
# before
$ juju download ubuntu-advantage
Fetching charm "ubuntu-advantage" using "stable" channel and base "amd64/ubuntu/22.04"
Install the "ubuntu-advantage" charm with:
    juju deploy ./ubuntu-advantage_73b9262.charm

# after
$ juju download ubuntu-advantage
Fetching charm "ubuntu-advantage" revision 39 using "stable" channel and base "amd64/ubuntu/22.04"
Install the "ubuntu-advantage" charm with:
    juju deploy ./ubuntu-advantage_r39.charm
```
