### PR TITLE
Merge 3.0 into develop

### DIFF
--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -82,7 +82,9 @@ func (api *Client) ListSecrets(reveal bool, filter secrets.Filter) ([]SecretDeta
 		}
 		if reveal && r.Value != nil {
 			if r.Value.Error == nil {
-				details.Value = secrets.NewSecretValue(r.Value.Data)
+				if data := secrets.NewSecretValue(r.Value.Data); !data.IsEmpty() {
+					details.Value = data
+				}
 			} else {
 				details.Error = r.Value.Error.Error()
 			}

--- a/cmd/juju/commands/upgrademodel_test.go
+++ b/cmd/juju/commands/upgrademodel_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades/upgradevalidation"
 	jujuversion "github.com/juju/juju/version"
 )
 
@@ -219,14 +220,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionUploadLocalOfficial(c 
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
-	// TODO (hml) 19-oct-2022
-	// Once upgrade from 2.9 to 3.0 is supported, go back to
-	// using coretesting.FakeVersionNumber in this test.
-	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	c.Assert(agentVersion.Build, gc.Equals, 0)
 	builtVersion := coretesting.CurrentVersion()
@@ -269,14 +267,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionAlreadyUpToDate(c *gc.
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
-	// TODO (hml) 19-oct-2022
-	// Once upgrade from 2.9 to 3.0 is supported, go back to
-	// using coretesting.FakeVersionNumber in this test.
-	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	c.Assert(agentVersion.Build, gc.Equals, 0)
 	targetVersion := coretesting.CurrentVersion()
@@ -351,14 +346,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
-	// TODO (hml) 19-oct-2022
-	// Once upgrade from 2.9 to 3.0 is supported, go back to
-	// using coretesting.FakeVersionNumber in this test.
-	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := coretesting.FakeVersionNumber
 	cfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 
 	targetVersion := coretesting.CurrentVersion().Number
 	gomock.InOrder(
@@ -390,14 +382,11 @@ func (s *upgradeNewSuite) TestUpgradeModelWithAgentVersionExpectUploadFailedDueT
 	ctrl, cmd := s.upgradeJujuCommand(c, false)
 	defer ctrl.Finish()
 
-	// TODO (hml) 19-oct-2022
-	// Once upgrade from 2.9 to 3.0 is supported, go back to
-	// using coretesting.FakeVersionNumber in this test.
-	//agentVersion := coretesting.FakeVersionNumber
-	agentVersion := version.MustParse("3.0.1")
+	agentVersion := coretesting.FakeVersionNumber
 	modelCfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 	})
+	s.PatchValue(&upgradevalidation.MinMajorUpgradeVersions, map[int]version.Number{3: agentVersion})
 	controllerCfg := coretesting.FakeConfig().Merge(coretesting.Attrs{
 		"agent-version": agentVersion.String(),
 		// This isn't right, but it's ok for testing because it's not important here.

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -174,7 +174,7 @@ func gatherSecretInfo(secrets []apisecrets.SecretDetails, reveal, includeRevisio
 				}
 			}
 		}
-		if reveal && m.Value != nil {
+		if reveal && !m.Value.IsEmpty() {
 			valueDetails := &secretValueDetails{}
 			val, err := m.Value.Values()
 			if err != nil {

--- a/state/application.go
+++ b/state/application.go
@@ -987,7 +987,12 @@ func (a *Application) Endpoints() (eps []Endpoint, err error) {
 			})
 		}
 	}
+
 	meta := ch.Meta()
+	if meta == nil {
+		return nil, errors.Errorf("nil charm metadata for application %q", a.Name())
+	}
+
 	collect(charm.RolePeer, meta.Peers)
 	collect(charm.RoleProvider, meta.Provides)
 	collect(charm.RoleRequirer, meta.Requires)

--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -8,14 +8,15 @@ run_model_metrics() {
 	file="${TEST_DIR}/test-${testname}.log"
 	ensure "${testname}" "${file}"
 
-	juju deploy ubuntu ubuntu
+	# deploy ubuntu with a different name, check that the metric send the charm name, not the application name.
+	juju deploy ubuntu app-one
 	juju deploy juju-qa-test
 	juju deploy ntp
-	juju relate ntp ubuntu
+	juju relate ntp app-one
 
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 1)"
-	wait_for "ubuntu" "$(idle_condition "ubuntu" 0)"
-	wait_for "ntp" "$(idle_subordinate_condition "ntp" "ubuntu" 0)"
+	wait_for "app-one" "$(idle_condition "app-one" 0)"
+	wait_for "ntp" "$(idle_subordinate_condition "ntp" "app-one" 0)"
 
 	juju relate ntp:juju-info juju-qa-test:juju-info
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "juju-qa-test" 1)"

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -407,5 +407,6 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 
 	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocker, gc.NotNil)
 	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
 }

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1431,7 +1431,7 @@ func (ctx *HookContext) doFlush(process string) error {
 	for i, u := range ctx.secretChanges.pendingUpdates {
 		// Juju checks that the current revision is stable when updating metadata so it's
 		// safe to increment here knowing the same value will be saved in Juju.
-		if u.Value == nil {
+		if u.Value.IsEmpty() {
 			pendingUpdates[i] = u.SecretUpsertArg
 			continue
 		}

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -119,8 +119,11 @@ func (c *secretUpsertCommand) Init(args []string) error {
 
 	var err error
 	c.data, err = secrets.CreateSecretData(args)
-	if err != nil || c.fileName == "" {
+	if err != nil {
 		return errors.Trace(err)
+	}
+	if c.fileName == "" {
+		return nil
 	}
 	dataFromFile, err := secrets.ReadSecretData(c.fileName)
 	if err != nil {


### PR DESCRIPTION
Conflicts:
- scripts/win-installer/setup.iss
- snap/snapcraft.yaml
- version/version.go

All conflicts due to version change - resolved by setting version to 3.1-beta1 on develop branch.