### PR TITLE
Fix messed-up channels formatting for "juju info" of a bundle

### DIFF
--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -97,18 +97,33 @@ func (iw infoWriter) channels() string {
 				w.Println(formatRevision(latest, true))
 			case baseModeArches:
 				for i, r := range revisions {
+					args := []any{formatRevision(r, i == 0)}
 					arches := strings.Join(r.Arches, ", ")
-					w.Println(formatRevision(r, i == 0), arches)
+					if arches != "" {
+						args = append(args, arches)
+					}
+					w.Println(args...)
 				}
 			case baseModeBases:
 				latest := revisions[0]
+				args := []any{formatRevision(latest, true)}
 				bases := strings.Join(basesToSeries(latest.Bases), ", ")
-				w.Println(formatRevision(latest, true), bases)
+				if bases != "" {
+					args = append(args, bases)
+				}
+				w.Println(args...)
 			case baseModeBoth:
 				latest := revisions[0]
+				args := []any{formatRevision(latest, true)}
 				arches := strings.Join(latest.Arches, ", ")
+				if arches != "" {
+					args = append(args, arches)
+				}
 				bases := strings.Join(basesToSeries(latest.Bases), ", ")
-				w.Println(formatRevision(latest, true), arches, bases)
+				if bases != "" {
+					args = append(args, bases)
+				}
+				w.Println(args...)
 			}
 		}
 	}

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -202,7 +202,7 @@ config:
 func (s *printInfoSuite) TestBundleChannelClosed(c *gc.C) {
 	ir := getBundleInfoClosedTrack()
 	ctx := commandContextForTest(c)
-	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, false, "never", baseModeNone, &ir)
+	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, false, "never", baseModeBoth, &ir)
 	err := iw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -224,7 +224,7 @@ channels: |
 func (s *printInfoSuite) TestBundleChannelClosedWithUnicode(c *gc.C) {
 	ir := getBundleInfoClosedTrack()
 	ctx := commandContextForTest(c)
-	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, false, "always", baseModeNone, &ir)
+	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, false, "always", baseModeBoth, &ir)
 	err := iw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -246,7 +246,7 @@ channels: |
 func (s *printInfoSuite) TestBundlePrintInfo(c *gc.C) {
 	ir := getBundleInfoResponse()
 	ctx := commandContextForTest(c)
-	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, false, "never", baseModeNone, &ir)
+	iw := makeInfoWriter(ctx.Stdout, ctx.Warningf, false, "never", baseModeBoth, &ir)
 	err := iw.Print()
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
I broke the channels formatting (for bundles only) with the changes to `juju info` in 3.0 in PR https://github.com/juju/juju/pull/14696.

This PR fixes that. What was happening was is that in the default mode of `baseModeBoth`, arches and bases were coming through as `""`, making the `TabWriter` output 4 spaces (2 for each column) at the end of the line. This put the YAML encoder into quoted-string mode. See the before and after in the QA steps.

Also update the tests to actually test this case (`baseModeBoth` is the default mode, not `baseModeNone`).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
# BEFORE:
$ juju info charmed-kubernetes
name: charmed-kubernetes
publisher: Canonical Kubernetes
description: A highly-available, production-grade Kubernetes cluster. bundle-id: ZZagr3kLqZpwK7OtKyRrI0MxbLnvKN0G
tags: cloud
channels: "latest/stable:     1185  2022-09-01  (1185)  5kB    \nlatest/candidate:
  \ 1188  2022-09-09  (1188)  5kB    \nlatest/beta:       1183  2022-08-28  (1183)
  \ 5kB    \nlatest/edge:       1194  2022-10-17  (1194)  5kB    \n1.26/stable:       –\n1.26/candidate:
  \   –\n1.26/beta:         –\n1.26/edge:         1195  2022-10-17  (1195)  5kB    \n1.25/stable:
  \      1186  2022-09-01  (1186)  5kB    \n1.25/candidate:    1187  2022-09-09  (1187)
  \ 5kB    \n1.25/beta:         1184  2022-08-28  (1184)  5kB    \n1.25/edge:         1182
  \ 2022-08-17  (1182)  5kB    \n1.24/stable:       1155  2022-08-04  (1155)  5kB
  \   \n1.24/candidate:    1149  2022-08-02  (1149)  5kB    \n1.24/beta:         1005
  \ 2022-05-06  (1005)  1kB    \n1.24/edge:         1179  2022-08-15  (1179)  5kB
  \   \n1.23/stable:       –\n1.23/candidate:    –\n1.23/beta:         –\n1.23/edge:
  \        942  2022-03-16  (942)  1kB    \n"

# AFTER:
$ juju info charmed-kubernetes
name: charmed-kubernetes
publisher: Canonical Kubernetes
description: A highly-available, production-grade Kubernetes cluster. bundle-id: ZZagr3kLqZpwK7OtKyRrI0MxbLnvKN0G
tags: cloud
channels: |
  latest/stable:     1185  2022-09-01  (1185)  5kB
  latest/candidate:  1188  2022-09-09  (1188)  5kB
  latest/beta:       1183  2022-08-28  (1183)  5kB
  latest/edge:       1194  2022-10-17  (1194)  5kB
  1.26/stable:       –
  1.26/candidate:    –
  1.26/beta:         –
  1.26/edge:         1195  2022-10-17  (1195)  5kB
  1.25/stable:       1186  2022-09-01  (1186)  5kB
  1.25/candidate:    1187  2022-09-09  (1187)  5kB
  1.25/beta:         1184  2022-08-28  (1184)  5kB
  1.25/edge:         1182  2022-08-17  (1182)  5kB
  1.24/stable:       1155  2022-08-04  (1155)  5kB
  1.24/candidate:    1149  2022-08-02  (1149)  5kB
  1.24/beta:         1005  2022-05-06  (1005)  1kB
  1.24/edge:         1179  2022-08-15  (1179)  5kB
  1.23/stable:       –
  1.23/candidate:    –
  1.23/beta:         –
  1.23/edge:         942  2022-03-16  (942)  1kB
```
