### PR TITLE
[JUJU-2021] Include all revisions for StoreConfig();

### DIFF
--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -128,37 +128,42 @@ func StoreConfig(model Model, authTag names.Tag, leadershipChecker leadership.Ch
 		return nil, errors.NotSupportedf("login as %q", authTag)
 	}
 
-	owned, err := backend.ListSecrets(ownedFilter)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	ownedRevisions := provider.SecretRevisions{}
-	for _, md := range owned {
-		ownedRevisions.Add(md.URI, md.LatestRevision)
+	if err := getRevisions(backend, ownedFilter, ownedRevisions); err != nil {
+		return nil, errors.Trace(err)
 	}
 
-	read, err := backend.ListSecrets(readFilter)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	readRevisions := provider.SecretRevisions{}
-	for _, md := range read {
-		readRevisions.Add(md.URI, md.LatestRevision)
+	if err := getRevisions(backend, readFilter, readRevisions); err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	if len(readAppOwnedFilter.OwnerTags) > 0 {
-		readAppOwned, err := backend.ListSecrets(readAppOwnedFilter)
-		if err != nil {
+		if err := getRevisions(backend, readAppOwnedFilter, readRevisions); err != nil {
 			return nil, errors.Trace(err)
-		}
-		for _, md := range readAppOwned {
-			readRevisions.Add(md.URI, md.LatestRevision)
 		}
 	}
 
 	logger.Debugf("secrets for %v:\nowned: %v\nconsumed:%v", authTag.String(), ownedRevisions, readRevisions)
 	cfg, err := p.StoreConfig(ma, authTag, ownedRevisions, readRevisions)
 	return cfg, errors.Trace(err)
+}
+
+func getRevisions(backend state.SecretsStore, filter state.SecretsFilter, revisions provider.SecretRevisions) error {
+	secrets, err := backend.ListSecrets(filter)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, md := range secrets {
+		revs, err := backend.ListSecretRevisions(md.URI)
+		if err != nil {
+			return errors.Annotatef(err, "cannot get revisions for secret %q", md.URI)
+		}
+		for _, rev := range revs {
+			revisions.Add(md.URI, rev.Revision)
+		}
+	}
+	return nil
 }
 
 // StoreForInspect returns the config to create a secret store client able

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -52,7 +52,7 @@ func (s *secretsSuite) TestProviderInfoForModel(c *gc.C) {
 	c.Assert(p.Type(), gc.Equals, "vault")
 }
 
-func (s *secretsSuite) TestProviderInfoForModelJujuDefault(c *gc.C) {
+func (s *secretsSuite) TestProviderInfoForModelJujuDefaultIAAS(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -64,15 +64,27 @@ func (s *secretsSuite) TestProviderInfoForModelJujuDefault(c *gc.C) {
 	gomock.InOrder(
 		model.EXPECT().Config().Return(cfg, nil),
 		model.EXPECT().Type().Return(state.ModelTypeIAAS),
-
-		model.EXPECT().Config().Return(cfg, nil),
-		model.EXPECT().Type().Return(state.ModelTypeCAAS),
 	)
 	p, _, err := secrets.ProviderInfoForModel(model)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(p.Type(), gc.Equals, "juju")
+}
 
-	p, _, err = secrets.ProviderInfoForModel(model)
+func (s *secretsSuite) TestProviderInfoForModelJujuDefaultCAAS(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	model := mocks.NewMockModel(ctrl)
+
+	cfg := coretesting.CustomModelConfig(c, coretesting.Attrs{
+		"secret-store": "",
+	})
+	gomock.InOrder(
+		model.EXPECT().Config().Return(cfg, nil),
+		model.EXPECT().Type().Return(state.ModelTypeCAAS),
+	)
+
+	p, _, err := secrets.ProviderInfoForModel(model)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(p.Type(), gc.Equals, "kubernetes")
 }
@@ -108,10 +120,10 @@ func (s *secretsSuite) TestStoreConfigLeaderUnit(c *gc.C) {
 	s.PatchValue(&secrets.GetStateBackEnd, func(secrets.Model) state.SecretsStore { return backend })
 
 	owned := []*coresecrets.SecretMetadata{
-		{URI: &coresecrets.URI{ID: "owned-1"}, LatestRevision: 1},
+		{URI: &coresecrets.URI{ID: "owned-1"}},
 	}
 	read := []*coresecrets.SecretMetadata{
-		{URI: &coresecrets.URI{ID: "read-1"}, LatestRevision: 2},
+		{URI: &coresecrets.URI{ID: "read-1"}},
 	}
 	gomock.InOrder(
 		model.EXPECT().Config().Return(coretesting.ModelConfig(c), nil),
@@ -126,12 +138,21 @@ func (s *secretsSuite) TestStoreConfigLeaderUnit(c *gc.C) {
 				unitTag, names.NewApplicationTag("gitlab"),
 			},
 		}).Return(owned, nil),
+		backend.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "owned-1"}).
+			Return([]*coresecrets.SecretRevisionMetadata{
+				{Revision: 1},
+				{Revision: 2},
+			}, nil),
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
 			ConsumerTags: []names.Tag{unitTag, names.NewApplicationTag("gitlab")},
 		}).Return(read, nil),
+		backend.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "read-1"}).
+			Return([]*coresecrets.SecretRevisionMetadata{
+				{Revision: 1},
+			}, nil),
 		p.EXPECT().StoreConfig(gomock.Any(), unitTag,
-			provider.SecretRevisions{"owned-1": set.NewInts(1)},
-			provider.SecretRevisions{"read-1": set.NewInts(2)},
+			provider.SecretRevisions{"owned-1": set.NewInts(1, 2)},
+			provider.SecretRevisions{"read-1": set.NewInts(1)},
 		).Return(nil, nil),
 	)
 
@@ -154,13 +175,13 @@ func (s *secretsSuite) TestStoreConfigNonLeaderUnit(c *gc.C) {
 	s.PatchValue(&secrets.GetStateBackEnd, func(secrets.Model) state.SecretsStore { return backend })
 
 	unitOwned := []*coresecrets.SecretMetadata{
-		{URI: &coresecrets.URI{ID: "owned-1"}, LatestRevision: 1},
+		{URI: &coresecrets.URI{ID: "owned-1"}},
 	}
 	appOwned := []*coresecrets.SecretMetadata{
-		{URI: &coresecrets.URI{ID: "app-owned-1"}, LatestRevision: 1},
+		{URI: &coresecrets.URI{ID: "app-owned-1"}},
 	}
 	read := []*coresecrets.SecretMetadata{
-		{URI: &coresecrets.URI{ID: "read-1"}, LatestRevision: 2},
+		{URI: &coresecrets.URI{ID: "read-1"}},
 	}
 	gomock.InOrder(
 		model.EXPECT().Config().Return(coretesting.ModelConfig(c), nil),
@@ -173,15 +194,30 @@ func (s *secretsSuite) TestStoreConfigNonLeaderUnit(c *gc.C) {
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
 			OwnerTags: []names.Tag{unitTag},
 		}).Return(unitOwned, nil),
+		backend.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "owned-1"}).
+			Return([]*coresecrets.SecretRevisionMetadata{
+				{Revision: 1},
+				{Revision: 2},
+			}, nil),
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
 			ConsumerTags: []names.Tag{unitTag, names.NewApplicationTag("gitlab")},
 		}).Return(read, nil),
+		backend.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "read-1"}).
+			Return([]*coresecrets.SecretRevisionMetadata{
+				{Revision: 1},
+			}, nil),
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
 			OwnerTags: []names.Tag{names.NewApplicationTag("gitlab")},
 		}).Return(appOwned, nil),
+		backend.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "app-owned-1"}).
+			Return([]*coresecrets.SecretRevisionMetadata{
+				{Revision: 1},
+				{Revision: 2},
+				{Revision: 3},
+			}, nil),
 		p.EXPECT().StoreConfig(gomock.Any(), unitTag,
-			provider.SecretRevisions{"owned-1": set.NewInts(1)},
-			provider.SecretRevisions{"read-1": set.NewInts(2), "app-owned-1": set.NewInts(1)},
+			provider.SecretRevisions{"owned-1": set.NewInts(1, 2)},
+			provider.SecretRevisions{"read-1": set.NewInts(1), "app-owned-1": set.NewInts(1, 2, 3)},
 		).Return(nil, nil),
 	)
 
@@ -203,10 +239,10 @@ func (s *secretsSuite) TestStoreConfigAppTagLogin(c *gc.C) {
 	s.PatchValue(&secrets.GetStateBackEnd, func(secrets.Model) state.SecretsStore { return backend })
 
 	owned := []*coresecrets.SecretMetadata{
-		{URI: &coresecrets.URI{ID: "owned-1"}, LatestRevision: 1},
+		{URI: &coresecrets.URI{ID: "owned-1"}},
 	}
 	read := []*coresecrets.SecretMetadata{
-		{URI: &coresecrets.URI{ID: "read-1"}, LatestRevision: 2},
+		{URI: &coresecrets.URI{ID: "read-1"}},
 	}
 	gomock.InOrder(
 		model.EXPECT().Config().Return(coretesting.ModelConfig(c), nil),
@@ -217,12 +253,21 @@ func (s *secretsSuite) TestStoreConfigAppTagLogin(c *gc.C) {
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
 			OwnerTags: []names.Tag{appTag},
 		}).Return(owned, nil),
+		backend.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "owned-1"}).
+			Return([]*coresecrets.SecretRevisionMetadata{
+				{Revision: 1},
+				{Revision: 2},
+			}, nil),
 		backend.EXPECT().ListSecrets(state.SecretsFilter{
 			ConsumerTags: []names.Tag{appTag},
 		}).Return(read, nil),
+		backend.EXPECT().ListSecretRevisions(&coresecrets.URI{ID: "read-1"}).
+			Return([]*coresecrets.SecretRevisionMetadata{
+				{Revision: 1},
+			}, nil),
 		p.EXPECT().StoreConfig(gomock.Any(), appTag,
-			provider.SecretRevisions{"owned-1": set.NewInts(1)},
-			provider.SecretRevisions{"read-1": set.NewInts(2)},
+			provider.SecretRevisions{"owned-1": set.NewInts(1, 2)},
+			provider.SecretRevisions{"read-1": set.NewInts(1)},
 		).Return(nil, nil),
 	)
 


### PR DESCRIPTION
Currently, we only pass the latest revision to the k8s secret provider for permission setup which means we are only able to access the secret content with the latest revision.
This PR ensures we pass all revisions.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju exec --unit hello-kubecon/0 -- secret-add --owner unit foo=unit0
secret:cdbm9lmffbaq4o6tlhfg

$ juju exec --unit hello-kubecon/0 -- secret-set cdbm9lmffbaq4o6tlhfg --label unit00

$ juju exec --unit hello-kubecon/0 -- secret-set cdbm9lmffbaq4o6tlhfg foo=unit00

$ juju show-secret cdbm9lmffbaq4o6tlhfg --reveal
cdbm9lmffbaq4o6tlhfg:
  revision: 2
  owner: hello-kubecon/0
  label: unit00
  created: 2022-10-25T04:23:53Z
  updated: 2022-10-25T04:25:47Z
  content:
    foo: unit00

$ juju exec --unit hello-kubecon/0 -- secret-get cdbm9lmffbaq4o6tlhfg
foo: unit00

$ mkubectl -nt1 describe role.rbac.authorization.k8s.io/unit-hello-kubecon-0
Name:         unit-hello-kubecon-0
Labels:       app.kubernetes.io/managed-by=juju
              app.kubernetes.io/name=hello-kubecon
Annotations:  <none>
PolicyRule:
  Resources     Non-Resource URLs  Resource Names            Verbs
  ---------     -----------------  --------------            -----
  secrets.*     []                 [cdbm9lmffbaq4o6tlhfg-1]  [*]
  secrets.*     []                 [cdbm9lmffbaq4o6tlhfg-2]  [*]
  secrets.*     []                 []                        [create patch]
  namespaces.*  []                 [t1]                      [get list]

$ juju exec --unit hello-kubecon/0 -- secret-grant cdbm9lmffbaq4o6tlhfg -r 0

$ juju exec --unit nginx-ingress-integrator/0 -- secret-get cdbm9lmffbaq4o6tlhfg
foo: unit00

$ mkubectl -nt1 describe role.rbac.authorization.k8s.io/unit-nginx-ingress-integrator-0
Name:         unit-nginx-ingress-integrator-0
Labels:       app.kubernetes.io/managed-by=juju
              app.kubernetes.io/name=nginx-ingress-integrator
Annotations:  <none>
PolicyRule:
  Resources     Non-Resource URLs  Resource Names            Verbs
  ---------     -----------------  --------------            -----
  secrets.*     []                 []                        [create patch]
  namespaces.*  []                 [t1]                      [get list]
  secrets.*     []                 [cdbm9lmffbaq4o6tlhfg-1]  [get]
  secrets.*     []                 [cdbm9lmffbaq4o6tlhfg-2]  [get]
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993763
