### PR TITLE
Fixes pebble liveness probe causing pebble to quit.

### DIFF
--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -181,16 +181,16 @@ func (c *initCommand) ContainerAgentPebbleConfig() error {
 		Services: map[string]*plan.Service{
 			"container-agent": {
 				Summary:  "Juju container agent",
-				Override: "replace",
+				Override: plan.ReplaceOverride,
 				Command: fmt.Sprintf("%s unit --data-dir %s --append-env \"PATH=$PATH:%s\" --show-log %s",
 					path.Join(c.binDir, "containeragent"),
 					c.dataDir,
 					c.binDir,
 					extraArgs),
-				Startup: "enabled",
+				Startup: plan.StartupEnabled,
 				OnCheckFailure: map[string]plan.ServiceAction{
-					"liveness":  "shutdown",
-					"readiness": "shutdown",
+					"liveness":  plan.ActionShutdown,
+					"readiness": plan.ActionIgnore,
 				},
 				Environment: map[string]string{
 					constants.EnvHTTPProbePort: constants.DefaultHTTPProbePort,
@@ -199,8 +199,8 @@ func (c *initCommand) ContainerAgentPebbleConfig() error {
 		},
 		Checks: map[string]*plan.Check{
 			"readiness": {
-				Override:  "replace",
-				Level:     "ready",
+				Override:  plan.ReplaceOverride,
+				Level:     plan.ReadyLevel,
 				Period:    plan.OptionalDuration{Value: 10 * time.Second, IsSet: true},
 				Timeout:   plan.OptionalDuration{Value: 3 * time.Second, IsSet: true},
 				Threshold: 3,
@@ -209,8 +209,8 @@ func (c *initCommand) ContainerAgentPebbleConfig() error {
 				},
 			},
 			"liveness": {
-				Override:  "replace",
-				Level:     "ready",
+				Override:  plan.ReplaceOverride,
+				Level:     plan.AliveLevel,
 				Period:    plan.OptionalDuration{Value: 10 * time.Second, IsSet: true},
 				Timeout:   plan.OptionalDuration{Value: 3 * time.Second, IsSet: true},
 				Threshold: 3,

--- a/cmd/containeragent/initialize/command_test.go
+++ b/cmd/containeragent/initialize/command_test.go
@@ -102,11 +102,11 @@ services:
             HTTP_PROBE_PORT: "65301"
         on-check-failure:
             liveness: shutdown
-            readiness: shutdown
+            readiness: ignore
 checks:
     liveness:
         override: replace
-        level: ready
+        level: alive
         period: 10s
         timeout: 3s
         threshold: 3


### PR DESCRIPTION
Pebble was exiting improperly when the unit agent wasn't ready, instead it should just ignore that and report it back up to the kubernetes readiness probe.

## QA steps

Deploy a charm that has an install hook that fails.

It should show as failed in `juju status`

```
Unit           Workload  Agent  Address      Ports  Message
simpletest/0*  error     idle   10.1.75.119         hook failed: "install"
```

And should show as unready in k8s output, but have 0 restarts and still be running.

```
NAME                             READY   STATUS    RESTARTS        AGE
simpletest-0                     0/1     Running   0               3m25s
```

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993309