### PR TITLE
Use ssh-keys interface rather than public-ssh-keys

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,7 @@ apps:
     plugs:
       - network
       - network-bind
-      - ssh-public-keys
+      - ssh-keys
       - lxd
       # Needed so that juju can still use the real ~/.local/share/juju.
       - dot-local-share-juju


### PR DESCRIPTION
Juju needs access to the user's private ssh key, eg when adding a manual machine.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1994034
