### PR TITLE
[upgrade_series test] replace `:` with `@`

### DIFF
--- a/tests/includes/series.sh
+++ b/tests/includes/series.sh
@@ -1,4 +1,4 @@
-# base_to_series conversts a base to a series.
+# base_to_series converts a base to a series.
 # eg "ubuntu@22.04" -> "jammy"
 # ```
 # base_to_series <base>

--- a/tests/suites/upgrade_series/series.sh
+++ b/tests/suites/upgrade_series/series.sh
@@ -38,7 +38,7 @@ assert_machine_series() {
 	local machine expected_series actual_base actual_series
 	machine=$1
 	expected_series=$2
-	actual_base=$(juju status --format=json | jq -r ".machines[\"$machine\"] | (.base.name+\":\"+.base.channel)")
+	actual_base=$(juju status --format=json | jq -r ".machines[\"$machine\"] | (.base.name+\"@\"+.base.channel)")
 	actual_series=$(base_to_series "${actual_base}")
 
 	if [[ $expected_series == "$actual_series" ]]; then


### PR DESCRIPTION
`base_to_series` conversion was not working properly as we fed it a malformed base (using `:` instead of `@`). Fixes the failing upgrade_series test.

## QA steps

```sh
cd tests
./main.sh -v upgrade_series
```