### PR TITLE
Fix snap plug connect for ssh-keys

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -82,7 +82,7 @@ jobs:
         # manually grant permissions to juju
         sudo snap connect juju:lxd lxd
         sudo snap connect juju:dot-local-share-juju
-        sudo snap connect juju:ssh-public-keys
+        sudo snap connect juju:ssh-keys
         snap connections juju
 
     - name: Smoke Test


### PR DESCRIPTION
Fix snap plug connect for ssh-keys instead of ssh-public-keys

## QA steps

Smoke tests

## Documentation changes

N/A

## Bug reference

N/A