### PR TITLE
Update the snap description to include listing privileged interfaces

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,9 @@ description: |
 
   **Note**
   This snap needs to read any relevant locally stored cloud credentials in order to manage resources on your behalf in a specified cloud.
+  It also can read private ssh keys. The privileged interface auto connections include:
+   - lxd
+   - ssh-keys
 
 confinement: strict
 grade: devel


### PR DESCRIPTION
Add extra info to the juju snap description to inform people that privileged interfaces are auto connected.