### PR TITLE
Using "echo -e" for juju-proxy.sh output to interpret escaped newlines

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -1307,7 +1307,7 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmds := cloudcfg.RunCmds()
-	first := `[ -e /etc/profile.d/juju-proxy.sh ] || echo '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`
+	first := `[ -e /etc/profile.d/juju-proxy.sh ] || echo -e '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`
 	expected := []string{
 		`export http_proxy=http://user@10.0.0.1`,
 		`export HTTP_PROXY=http://user@10.0.0.1`,

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -327,7 +327,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 		// If the new juju proxies are used, the legacy proxies will not be set, and the
 		// /etc/juju-proxy.conf file will be empty.
 		`[ -e /etc/profile.d/juju-proxy.sh ] || ` +
-			`echo '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`)
+			`echo -e '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`)
 	if w.icfg.LegacyProxySettings.HasProxySet() {
 		exportedProxyEnv := w.icfg.LegacyProxySettings.AsScriptEnvironment()
 		w.conf.AddScripts(strings.Split(exportedProxyEnv, "\n")...)


### PR DESCRIPTION
Use `echo -e` to interpret backslash escapes and put newlines into `/etc/profile.d/juju-proxy.sh`.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
~- [] Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
~- [] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Confirm there is no "command not found" output when doing `juju ssh` to a bootstrapped controller and that the content of `/etc/profile.d/juju-proxy.sh` is as desired.

Currently:

```
$ juju bootstrap lxd


$ juju ssh -m controller 0
[...]
n#: command not found


$ juju ssh -m controller 0 'cat /etc/profile.d/juju-proxy.sh'
\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n
```

Desired:

```
$ juju bootstrap lxd


$ juju ssh -m controller 0
[no "command not found" error]


$ juju ssh -m controller 0 'cat /etc/profile.d/juju-proxy.sh'

# Added by juju
[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"

```