### PR TITLE
Add support for BOOTSTRAP_ARCH for testing

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -276,6 +276,10 @@ pre_bootstrap() {
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --model-default agent-stream=build-${SHORT_GIT_COMMIT}"
 	fi
 
+	if [[ -n ${BOOTSTRAP_ARCH:-} ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --bootstrap-constraints arch=${BOOTSTRAP_ARCH}"
+	fi
+
 	echo "BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"
 }
 


### PR DESCRIPTION
Add support for BOOTSTRAP_ARCH for testing so we can bootstrap a different architecture than the client architecture.

## QA steps

`BOOTSTRAP_ARCH=arm64 ./main.sh -v -p aws -s test_enable_ha controller`

## Documentation changes

N/A

## Bug reference

N/A