### PR TITLE
[JUJU-1952] Fix manual deploy integration tests

### DIFF
--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -16,6 +16,7 @@ test_deploy_manual() {
 			;;
 		"aws" | "ec2")
 			export BOOTSTRAP_PROVIDER="manual"
+			unset BOOTSTRAP_REGION
 			run "run_deploy_manual_aws"
 			;;
 		*)
@@ -38,17 +39,19 @@ manual_deploy() {
 	file="${TEST_DIR}/test-${name}.log"
 
 	bootstrap "${cloud_name}" "test-${name}" "${file}"
+	juju switch controller
 
 	juju add-machine ssh:ubuntu@"${addr_m1}" >"${TEST_DIR}/add-machine-1.log" 2>&1
 	juju add-machine ssh:ubuntu@"${addr_m2}" >"${TEST_DIR}/add-machine-2.log" 2>&1
 
-	juju enable-ha >"${TEST_DIR}/enable-ha.log" 2>&1
+	juju enable-ha --to "1,2" >"${TEST_DIR}/enable-ha.log" 2>&1
+	wait_for "3" '[.machines[] | select(.["controller-member-status"] == "has-vote")] | length'
 
 	machine_series=$(juju machines --format=json | jq -r '.machines | .["0"] | .series')
 
 	juju deploy ubuntu --to=0 --series="${machine_series}"
 
-	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 0)"
+	wait_for "ubuntu" "$(idle_condition "ubuntu" 0)"
 
 	juju remove-application ubuntu
 

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -10,8 +10,6 @@ run_deploy_manual_aws() {
 	model1="${name}-m1"
 	model2="${name}-m2"
 
-	set -eux
-
 	add_clean_func "run_cleanup_deploy_manual_aws"
 
 	# Eventually we should use BOOTSTRAP_SERIES
@@ -81,17 +79,18 @@ run_deploy_manual_aws() {
 		sg_id=$(echo "${OUT}" | jq -r '.GroupId')
 	fi
 
-	aws ec2 create-key-pair --key-name "${name}" --query 'KeyMaterial' --output text >~/.ssh/"${name}".pem
-	chmod 400 ~/.ssh/"${name}".pem
+	aws ec2 create-key-pair --key-name "${name}" --query 'KeyMaterial' --output text >"${TEST_DIR}/${name}.pem"
+	chmod 400 "${TEST_DIR}/${name}.pem"
 	echo "${name}" >>"${TEST_DIR}/ec2-key-pairs"
 
 	local addr_c addr_m1 addr_m2
 
+	echo "==> Creating machines in aws"
 	launch_and_wait_addr_ec2 "${name}" "${controller}" "${instance_image_id}" "${subnet_id}" "${sg_id}" addr_c
 	launch_and_wait_addr_ec2 "${name}" "${model1}" "${instance_image_id}" "${subnet_id}" "${sg_id}" addr_m1
 	launch_and_wait_addr_ec2 "${name}" "${model2}" "${instance_image_id}" "${subnet_id}" "${sg_id}" addr_m2
 
-	ensure_valid_ssh_hosts "${addr_c}" "${addr_m1}" "${addr_m2}"
+	ensure_valid_ssh_config "${name}.pem" "${addr_c}" "${addr_m1}" "${addr_m2}"
 
 	cloud_name="cloud-${name}"
 

--- a/tests/suites/manual/deploy_manual_lxd.sh
+++ b/tests/suites/manual/deploy_manual_lxd.sh
@@ -118,41 +118,13 @@ run_deploy_manual_lxd() {
 		eval $addr_result="'${address}'"
 	}
 
+	local addr_c addr_m1 addr_m2
+
 	launch_and_wait_addr "${controller}" addr_c
 	launch_and_wait_addr "${model1}" addr_m1
 	launch_and_wait_addr "${model2}" addr_m2
 
-	if [[ ! -f "${HOME}/.ssh/known_hosts" ]]; then
-		mkdir -p "${HOME}/.ssh"
-		touch "${HOME}/.ssh/known_hosts"
-		chmod 600 "${HOME}/.ssh/known_hosts"
-	fi
-
-	# shellcheck disable=SC2154
-	for addr in "${addr_c}" "${addr_m1}" "${addr_m2}"; do
-		ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${addr}"
-
-		attempt=0
-		while [[ ${attempt} -lt 10 ]]; do
-			OUT=$(ssh -T -n -i "${TEST_DIR}/${name}" \
-				-o IdentitiesOnly=yes \
-				-o StrictHostKeyChecking=no \
-				-o AddKeysToAgent=yes \
-				ubuntu@"${addr}" 2>&1 || true)
-			if echo "${OUT}" | grep -q -v "Could not resolve hostname"; then
-				echo "Adding ssh key to ${addr}"
-				break
-			fi
-
-			sleep 1
-			attempt=$((attempt + 1))
-		done
-
-		if [ "${attempt}" -ge 10 ]; then
-			echo "Failed to add key to ${addr}"
-			exit 1
-		fi
-	done
+	ensure_valid_ssh_config "${name}" "${addr_c}" "${addr_m1}" "${addr_m2}"
 
 	cloud_name="cloud-${name}"
 

--- a/tests/suites/manual/task.sh
+++ b/tests/suites/manual/task.sh
@@ -4,6 +4,11 @@ test_manual() {
 		return
 	fi
 
+	if [[ ${BOOTSTRAP_PROVIDER:-} == "aws" ]]; then
+		# Ensure that the aws cli and juju both use the same aws region
+		export AWS_DEFAULT_REGION="${BOOTSTRAP_REGION}"
+	fi
+
 	set_verbosity
 
 	echo "==> Checking for dependencies"

--- a/tests/suites/manual/util.sh
+++ b/tests/suites/manual/util.sh
@@ -31,38 +31,30 @@ launch_and_wait_addr_ec2() {
 	eval $addr_result="'${address}'"
 }
 
-ensure_valid_ssh_hosts() {
-	if [[ ! -f "${HOME}/.ssh/known_hosts" ]]; then
+# TODO (jack-w-shaw): Remove this once https://bugs.launchpad.net/juju/+bug/1994522
+# has been resolved
+ensure_valid_ssh_config() {
+	local name
+	name=${1}
+	shift
+
+	if [[ ! -f "${HOME}/.ssh/config" ]]; then
 		mkdir -p "${HOME}/.ssh"
-		touch "${HOME}/.ssh/known_hosts"
-		chmod 600 "${HOME}/.ssh/known_hosts"
+		touch "${HOME}/.ssh/config"
+		chmod 600 "${HOME}/.ssh/config"
 	fi
 
 	# shellcheck disable=SC2154
 	for addr in "$@"; do
-		ssh-keygen -f "${HOME}/.ssh/known_hosts" -R ubuntu@"${addr}"
-
-		attempt=0
-		while [[ ${attempt} -lt 10 ]]; do
-			OUT=$(ssh -T -n -i ~/.ssh/"${name}".pem \
-				-o IdentitiesOnly=yes \
-				-o StrictHostKeyChecking=no \
-				-o AddKeysToAgent=yes \
-				-o UserKnownHostsFile="${HOME}/.ssh/known_hosts" \
-				ubuntu@"${addr}" 2>&1 || true)
-			if echo "${OUT}" | grep -q -v "Could not resolve hostname"; then
-				echo "Adding ssh key to ${addr}"
-				break
-			fi
-
-			sleep 1
-			attempt=$((attempt + 1))
-		done
-
-		if [[ ${attempt} -ge 10 ]]; then
-			echo "Failed to add key to ${addr}"
-			exit 1
-		fi
+		HOST_BLOCK=$(
+			cat <<EOF
+Host ${addr}\n
+  IdentityFile ${TEST_DIR}/${name}\n
+  IdentitiesOnly yes\n
+  StrictHostKeyChecking no\n
+EOF
+		)
+		echo -e "${HOST_BLOCK}" >>~/.ssh/config
 	done
 }
 


### PR DESCRIPTION
Most of the changes are minor bug fixes

However, there is a fairly major change from templating `~/.ssh/known_hosts` to `~/.ssh/config`, since adding hosts to know_hosts wasn't enough to ensure a controller can be bootstrapped. This isn't ideal, to be improved further when https://bugs.launchpad.net/juju/+bug/1994522 is resolved

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
BOOTSTRAP_CLOUD=aws BOOTSTRAP_PROVIDER=aws BOOTSTRAP_REGION=eu-west-1 ./main.sh -v -s 'test_spaces_manual' manual test_deploy_manual
```
and
```sh
BOOTSTRAP_CLOUD=lxd BOOTSTRAP_PROVIDER=lxd ./main.sh -v -s 'test_spaces_manual' manual test_deploy_manual
```