### PR TITLE
[smoke tests] remove snap

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - '**.go'
       - 'go.mod'
-      - 'snap/**'
       - 'testcharms/**'
       - 'tests/main.sh'
       - 'tests/includes/**'
@@ -29,7 +28,6 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
-        sudo snap install snapcraft --classic
         
         sudo apt-get remove lxd lxd-client
         if snap info lxd | grep "installed"; then
@@ -66,21 +64,13 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-    - name: Build snap
+    - name: Install local Juju
       shell: bash
       run: |
-        set -euxo pipefail
-        snapcraft --use-lxd
-
-    - name: Install snap
-      shell: bash
-      run: |
-        set -euxo pipefail
-        sudo snap install *.snap --dangerous --classic
+        make go-install
 
     - name: Smoke Test
       shell: bash
       run: |
         cd tests
-        ./main.sh -v smoke
-
+        ./main.sh -v -s 'test_build' smoke


### PR DESCRIPTION
Smoke tests are supposed to run quickly and reveal any major issues introduced. Currently, they take 15-20 mins to run, because they have to build and install the snap first.

However, we already have a Snapcraft test to check that the snap works. Hence, we can remove the snapcraft step from the smoke tests. We replace this with a build step, which will build a local Juju that we can test instead.

## QA steps

Check that "Smoke" Github action passes below.