### PR TITLE
[JUJU-2034] Account for altered home in strict snap when loading kube config

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -265,9 +265,10 @@ func (c *AddCAASCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.project, "project", "", "project to which the cluster belongs")
 	f.StringVar(&c.credential, "credential", "", "the credential to use when accessing the cluster")
 	f.StringVar(&c.resourceGroup, "resource-group", "", "the Azure resource group of the AKS cluster")
-	f.BoolVar(&c.gke, "gke", false, "used when adding a GKE cluster")
-	f.BoolVar(&c.aks, "aks", false, "used when adding an AKS cluster")
-	f.BoolVar(&c.eks, "eks", false, "used when adding an EKS cluster")
+	// TODO(k8s) - support k8s tooling in strict snap
+	//f.BoolVar(&c.gke, "gke", false, "used when adding a GKE cluster")
+	//f.BoolVar(&c.aks, "aks", false, "used when adding an AKS cluster")
+	//f.BoolVar(&c.eks, "eks", false, "used when adding an EKS cluster")
 }
 
 func countTrue(items ...bool) (count int) {

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -535,74 +535,75 @@ func (s *addCAASSuite) TestInit(c *gc.C) {
 			args:           []string{"--context-name", "a", "--cluster-name", "b"},
 			expectedErrStr: "only specify one of cluster-name or context-name, not both",
 		},
-		{
-			args:           []string{"--gke", "--context-name", "a"},
-			expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
-		},
-		{
-			args:           []string{"--aks", "--context-name", "a"},
-			expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
-		},
-		{
-			args:           []string{"--eks", "--context-name", "a"},
-			expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
-		},
-		{
-			args:           []string{"--gke", "--cloud", "a"},
-			expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
-		},
-		{
-			args:           []string{"--aks", "--cloud", "a"},
-			expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
-		},
-		{
-			args:           []string{"--eks", "--cloud", "a"},
-			expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
-		},
-		{
-			args:           []string{"--gke", "--region", "cloud/region"},
-			expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
-		},
-		{
-			args:           []string{"--aks", "--region", "cloud/region"},
-			expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
-		},
-		{
-			args:           []string{"--eks", "--region", "cloud/region"},
-			expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
-		},
-		{
-			args:           []string{"--project", "a"},
-			expectedErrStr: "do not specify project unless adding a GKE cluster",
-		},
-		{
-			args:           []string{"--credential", "a"},
-			expectedErrStr: "do not specify credential unless adding a GKE cluster",
-		},
-		{
-			args:           []string{"--project", "a", "--aks"},
-			expectedErrStr: "do not specify project unless adding a GKE cluster",
-		},
-		{
-			args:           []string{"--credential", "a", "--aks"},
-			expectedErrStr: "do not specify credential unless adding a GKE cluster",
-		},
-		{
-			args:           []string{"--project", "a", "--eks"},
-			expectedErrStr: "do not specify project unless adding a GKE cluster",
-		},
-		{
-			args:           []string{"--credential", "a", "--eks"},
-			expectedErrStr: "do not specify credential unless adding a GKE cluster",
-		},
-		{
-			args:           []string{"--resource-group", "rg1", "--gke"},
-			expectedErrStr: "do not specify resource-group unless adding a AKS cluster",
-		},
-		{
-			args:           []string{"--resource-group", "rg1", "--eks"},
-			expectedErrStr: "do not specify resource-group unless adding a AKS cluster",
-		},
+		// TODO(k8s) - support k8s tooling in strict snap
+		//{
+		//	args:           []string{"--gke", "--context-name", "a"},
+		//	expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
+		//},
+		//{
+		//	args:           []string{"--aks", "--context-name", "a"},
+		//	expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
+		//},
+		//{
+		//	args:           []string{"--eks", "--context-name", "a"},
+		//	expectedErrStr: "do not specify context name when adding a AKS/GKE/EKS cluster",
+		//},
+		//{
+		//	args:           []string{"--gke", "--cloud", "a"},
+		//	expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
+		//},
+		//{
+		//	args:           []string{"--aks", "--cloud", "a"},
+		//	expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
+		//},
+		//{
+		//	args:           []string{"--eks", "--cloud", "a"},
+		//	expectedErrStr: "do not specify --cloud when adding a GKE, EKS or AKS cluster",
+		//},
+		//{
+		//	args:           []string{"--gke", "--region", "cloud/region"},
+		//	expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
+		//},
+		//{
+		//	args:           []string{"--aks", "--region", "cloud/region"},
+		//	expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
+		//},
+		//{
+		//	args:           []string{"--eks", "--region", "cloud/region"},
+		//	expectedErrStr: "only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster",
+		//},
+		//{
+		//	args:           []string{"--project", "a"},
+		//	expectedErrStr: "do not specify project unless adding a GKE cluster",
+		//},
+		//{
+		//	args:           []string{"--credential", "a"},
+		//	expectedErrStr: "do not specify credential unless adding a GKE cluster",
+		//},
+		//{
+		//	args:           []string{"--project", "a", "--aks"},
+		//	expectedErrStr: "do not specify project unless adding a GKE cluster",
+		//},
+		//{
+		//	args:           []string{"--credential", "a", "--aks"},
+		//	expectedErrStr: "do not specify credential unless adding a GKE cluster",
+		//},
+		//{
+		//	args:           []string{"--project", "a", "--eks"},
+		//	expectedErrStr: "do not specify project unless adding a GKE cluster",
+		//},
+		//{
+		//	args:           []string{"--credential", "a", "--eks"},
+		//	expectedErrStr: "do not specify credential unless adding a GKE cluster",
+		//},
+		//{
+		//	args:           []string{"--resource-group", "rg1", "--gke"},
+		//	expectedErrStr: "do not specify resource-group unless adding a AKS cluster",
+		//},
+		//{
+		//	args:           []string{"--resource-group", "rg1", "--eks"},
+		//	expectedErrStr: "do not specify resource-group unless adding a AKS cluster",
+		//},
 	} {
 		args := append([]string{"myk8s"}, ts.args...)
 		command := s.makeCommand(c, true, false, true)
@@ -655,21 +656,22 @@ func (s *addCAASSuite) TestCloudAndRegionFlag(c *gc.C) {
 			title:          "missing region --cloud=brokenteststack and cloud's default region is not a cloud region",
 			cloud:          "brokenteststack",
 			expectedErrStr: `validating cloud region "azure": cloud region "azure" not valid`,
-		}, {
-			title:          "specify cloud with gke",
-			cloud:          "aws",
-			gke:            true,
-			expectedErrStr: `do not specify --cloud when adding a GKE, EKS or AKS cluster`,
-		}, {
-			title:          "specify cloud with aks",
-			cloud:          "aws",
-			aks:            true,
-			expectedErrStr: `do not specify --cloud when adding a GKE, EKS or AKS cluster`,
-		}, {
-			title:          "specify cloud/region with gke",
-			region:         "gce/us-east",
-			gke:            true,
-			expectedErrStr: `only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster`,
+			// TODO(k8s) - support k8s tooling in strict snap
+			//}, {
+			//	title:          "specify cloud with gke",
+			//	cloud:          "aws",
+			//	gke:            true,
+			//	expectedErrStr: `do not specify --cloud when adding a GKE, EKS or AKS cluster`,
+			//}, {
+			//	title:          "specify cloud with aks",
+			//	cloud:          "aws",
+			//	aks:            true,
+			//	expectedErrStr: `do not specify --cloud when adding a GKE, EKS or AKS cluster`,
+			//}, {
+			//	title:          "specify cloud/region with gke",
+			//	region:         "gce/us-east",
+			//	gke:            true,
+			//	expectedErrStr: `only specify region, not cloud/region, when adding a GKE, EKS or AKS cluster`,
 		}, {
 			title: "missing region --cloud=teststack but cloud has default region",
 			cloud: "teststack",
@@ -1222,6 +1224,7 @@ func (s *addCAASSuite) TestSkipTLSVerifyWithCertInvalid(c *gc.C) {
 }
 
 func (s *addCAASSuite) TestAddGkeCluster(c *gc.C) {
+	c.Skip("TODO(k8s) - support k8s tooling in strict snap")
 	ctrl := s.setupBroker(c)
 	defer ctrl.Finish()
 
@@ -1436,6 +1439,7 @@ func (s *addCAASSuite) TestCorrectSelectContext(c *gc.C) {
 }
 
 func (s *addCAASSuite) TestOnlyOneClusterProvider(c *gc.C) {
+	c.Skip("TODO(k8s) - support k8s tooling in strict snap")
 	command := s.makeCommand(c, true, false, true)
 	_, err := s.runCommand(c, nil, command, "myk8s", "-c", "foo", "--aks", "--gke")
 	c.Assert(err, gc.ErrorMatches, "only one of '--gke', '--eks' or '--aks' can be supplied")


### PR DESCRIPTION
When running inside the strict snap, the user's real home is set by the SNAP_REAL_HOME env var. We need to alter the k8s kube config loading rules to also look here to load the usual `~/.kube/config` file.

Also, strict snaps cannot access external cloud tools like `eksctl` etc. So we need to disable the `--gke'` `--aks` and `--eks` helpers on `add-k8s` for now.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

I compiled a strict snap and ran `juju add-k8s --client`

## Bug reference

https://bugs.launchpad.net/bugs/1994162
