### PR TITLE
[JUJU-2036] Fix issue with unit agent looping after secret remove

### DIFF
--- a/worker/uniter/remotestate/watcher.go
+++ b/worker/uniter/remotestate/watcher.go
@@ -340,6 +340,15 @@ func (w *RemoteStateWatcher) ExpireRevisionCompleted(expiredRevision string) {
 	}
 }
 
+// RemoveSecretsCompleted is called when secrets have been deleted.
+func (w *RemoteStateWatcher) RemoveSecretsCompleted(uris []string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	deleted := set.NewStrings(uris...)
+	currentDeleted := set.NewStrings(w.current.DeletedSecrets...)
+	w.current.DeletedSecrets = currentDeleted.Difference(deleted).Values()
+}
+
 func (w *RemoteStateWatcher) setUp(unitTag names.UnitTag) (err error) {
 	// TODO(axw) move this logic
 	defer func() {
@@ -987,6 +996,7 @@ func (w *RemoteStateWatcher) secretsChanged(secretURIs []string) error {
 		}
 	}
 	w.logger.Debugf("deleted secrets: %v", w.current.DeletedSecrets)
+	w.logger.Debugf("obsolete secrets: %v", w.current.ObsoleteSecretRevisions)
 	return nil
 }
 

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -109,7 +109,7 @@ func (s *baseResolverSuite) SetUpTest(c *gc.C, modelType model.ModelType, reboot
 		StopRetryHookTimer:  func() { s.stub.AddCall("StopRetryHookTimer") },
 		ShouldRetryHooks:    true,
 		UpgradeSeries:       upgradeseries.NewResolver(logger),
-		Secrets:             secrets.NewSecretsResolver(logger, secretsTracker, func(_ string) {}, func(_ string) {}),
+		Secrets:             secrets.NewSecretsResolver(logger, secretsTracker, func(_ string) {}, func(_ string) {}, func(_ []string) {}),
 		Reboot:              reboot.NewResolver(logger, rebootDetected),
 		Leadership:          leadership.NewResolver(logger),
 		Actions:             uniteractions.NewResolver(logger),

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -511,6 +511,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				u.secretsTracker,
 				watcher.RotateSecretCompleted,
 				watcher.ExpireRevisionCompleted,
+				watcher.RemoveSecretsCompleted,
 			),
 			Logger: u.logger,
 		}


### PR DESCRIPTION
When removing a secret, the unit agent's snapshot of remote state was not being updated after the completion of processing, so that the resolver was continuously triggered to handle the deletion. We add a commit handler to the secret deletion operation to remove the deleted secrets from the watcher emote state.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju exec --unit controller/0 -- "secret-add foo=bar"
secret:cdddcfsfudkjil03ctcg
$ juju exec --unit controller/0 -- "secret-get cdddcfsfudkjil03ctcg"
foo: bar
$ juju exec --unit controller/0 -- "secret-remove cdddcfsfudkjil03ctcg
```

repeat the above

## Bug reference

https://bugs.launchpad.net/bugs/1994971
