### PR TITLE
Better handling of /etc/profile.d/juju-proxy.sh script creation

### DIFF
--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -335,7 +335,7 @@ echo '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
-\[ -e /etc/profile.d/juju-proxy.sh \] \|\| echo .* >> /etc/profile.d/juju-proxy.sh
+if \[ ! -e /etc/profile.d/juju-proxy.sh \]; then.* >> /etc/profile.d/juju-proxy.sh\\nfi\\n
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
@@ -379,7 +379,7 @@ echo '.*"Stop all network interfaces.*' > '/etc/init/juju-clean-shutdown\.conf'
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
-\[ -e /etc/profile.d/juju-proxy.sh \] \|\| echo .* >> /etc/profile.d/juju-proxy.sh
+if \[ ! -e /etc/profile.d/juju-proxy.sh \]; then.* >> /etc/profile.d/juju-proxy.sh\\nfi\\n
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
@@ -440,7 +440,7 @@ echo '.*"Stop all network interfaces on shutdown".*' > '/etc/init/juju-clean-shu
 install -D -m 644 /dev/null '/var/lib/juju/nonce.txt'
 echo 'FAKE_NONCE' > '/var/lib/juju/nonce.txt'
 test -n "\$JUJU_PROGRESS_FD" \|\| \(exec \{JUJU_PROGRESS_FD\}>&2\) 2>/dev/null && exec \{JUJU_PROGRESS_FD\}>&2 \|\| JUJU_PROGRESS_FD=2
-\[ -e /etc/profile.d/juju-proxy.sh \] \|\| echo .* >> /etc/profile.d/juju-proxy.sh
+if \[ ! -e /etc/profile.d/juju-proxy.sh \]; then.* >> /etc/profile.d/juju-proxy.sh\\nfi\\n
 mkdir -p /var/lib/juju/locks
 \(id ubuntu &> /dev/null\) && chown ubuntu:ubuntu /var/lib/juju/locks
 mkdir -p /var/log/juju
@@ -1307,7 +1307,7 @@ func (s *cloudinitSuite) TestProxyWritten(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmds := cloudcfg.RunCmds()
-	first := `[ -e /etc/profile.d/juju-proxy.sh ] || echo -e '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`
+	first := cloudconfig.JujuProxyProfileScript
 	expected := []string{
 		`export http_proxy=http://user@10.0.0.1`,
 		`export HTTP_PROXY=http://user@10.0.0.1`,

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -99,6 +99,25 @@ if [ ! -z "$has_juju_db_snap" ]; then
   snap remove --purge juju-db
 fi
 `
+	// We look to see if the proxy line is there already as
+	// the manual provider may have had it already.
+	// We write this file out whether we are using the legacy proxy
+	// or the juju proxy to deal with runtime changes. The proxy updater worker
+	// only modifies /etc/juju-proxy.conf, so if changes are written to that file
+	// we need to make sure the profile.d file exists to reflect these changes.
+	// If the new juju proxies are used, the legacy proxies will not be set, and the
+	// /etc/juju-proxy.conf file will be empty.
+	JujuProxyProfileScript = `
+if [ ! -e /etc/profile.d/juju-proxy.sh ]; then
+  (
+    echo
+    echo '# Added by juju'
+    echo
+    echo '[ -f /etc/juju-proxy.conf ] && . /etc/juju-proxy.conf'
+    echo
+  ) >> /etc/profile.d/juju-proxy.sh
+fi
+`
 )
 
 var (
@@ -317,17 +336,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 
 	// Write out the normal proxy settings so that the settings are
 	// sourced by bash, and ssh through that.
-	w.conf.AddScripts(
-		// We look to see if the proxy line is there already as
-		// the manual provider may have had it already.
-		// We write this file out whether we are using the legacy proxy
-		// or the juju proxy to deal with runtime changes. The proxy updater worker
-		// only modifies /etc/juju-proxy.conf, so if changes are written to that file
-		// we need to make sure the profile.d file exists to reflect these changes.
-		// If the new juju proxies are used, the legacy proxies will not be set, and the
-		// /etc/juju-proxy.conf file will be empty.
-		`[ -e /etc/profile.d/juju-proxy.sh ] || ` +
-			`echo -e '\n# Added by juju\n[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"\n' >> /etc/profile.d/juju-proxy.sh`)
+	w.conf.AddScripts(JujuProxyProfileScript)
 	if w.icfg.LegacyProxySettings.HasProxySet() {
 		exportedProxyEnv := w.icfg.LegacyProxySettings.AsScriptEnvironment()
 		w.conf.AddScripts(strings.Split(exportedProxyEnv, "\n")...)


### PR DESCRIPTION
Better handling of /etc/profile.d/juju-proxy.sh script creation, so that both the controller direct script and non-controller cloud-init script behave as desired.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
~- [] Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
~- [] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Confirm there is no "command not found" output when doing `juju ssh` to a bootstrapped controller or a deployed unit and that the content of `/etc/profile.d/juju-proxy.sh` is as desired.

```
$ juju bootstrap lxd


$ juju ssh -m controller 0
[no "command not found" error]


$ juju ssh -m controller 0 'cat /etc/profile.d/juju-proxy.sh'

# Added by juju
[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"


$ juju deploy -m default ubuntu


$ juju ssh -m default 0
[no "command not found" error]


$ juju ssh -m default 0 'cat /etc/profile.d/juju-proxy.sh'

# Added by juju
[ -f "/etc/juju-proxy.conf" ] && . "/etc/juju-proxy.conf"

```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1994911
