### PR TITLE
Removes added pearl regex.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 GOHOSTOS=$(shell go env GOHOSTOS)
 GOHOSTARCH=$(shell go env GOHOSTARCH)
-GO_MOD_VERSION=$(shell grep -P "^go" go.mod | awk '{print $$2}')
+GO_MOD_VERSION=$(shell grep "^go" go.mod | awk '{print $$2}')
 GO_INSTALLED_VERSION=$(shell go version | awk '{print $$3}' | sed -e /.*go/s///)
 export CGO_ENABLED=0
 


### PR DESCRIPTION
In a recent PR there has been a grep added with a Pearl regex flag. This is not available on every os's version of grep and is not needed as we are not using Pearl extensions.

Removing in favour of vanilla regex.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run `make install` on another os that doesn't use GNU grep. i.e bsd based and check there is no grep errors.

## Documentation changes

N/A

## Bug reference
N/A
