### PR TITLE
[JUJU-1952] Manual integration tests: Log all output to stdout and a log file with tee

### DIFF
--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -31,7 +31,7 @@ manual_deploy() {
 	addr_m1=${3}
 	addr_m2=${4}
 
-	juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" >"${TEST_DIR}/add-cloud.log" 2>&1
+	juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" 2>&1 | tee "${TEST_DIR}/add-cloud.log"
 
 	file="${TEST_DIR}/test-${name}.log"
 
@@ -40,10 +40,10 @@ manual_deploy() {
 	bootstrap "${cloud_name}" "test-${name}" "${file}"
 	juju switch controller
 
-	juju add-machine ssh:ubuntu@"${addr_m1}" >"${TEST_DIR}/add-machine-1.log" 2>&1
-	juju add-machine ssh:ubuntu@"${addr_m2}" >"${TEST_DIR}/add-machine-2.log" 2>&1
+	juju add-machine ssh:ubuntu@"${addr_m1}" 2>&1 | tee "${TEST_DIR}/add-machine-1.log"
+	juju add-machine ssh:ubuntu@"${addr_m2}" 2>&1 | tee "${TEST_DIR}/add-machine-2.log"
 
-	juju enable-ha --to "1,2" >"${TEST_DIR}/enable-ha.log" 2>&1
+	juju enable-ha --to "1,2" 2>&1 | tee "${TEST_DIR}/enable-ha.log"
 	wait_for "3" '[.machines[] | select(.["controller-member-status"] == "has-vote")] | length'
 
 	machine_series=$(juju machines --format=json | jq -r '.machines | .["0"] | .series')

--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -104,7 +104,7 @@ EOF
 
 	echo "${CLOUD}" >"${TEST_DIR}/cloud_name.yaml"
 
-	juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" >"${TEST_DIR}/add-cloud.log" 2>&1
+	juju add-cloud --client "${cloud_name}" "${TEST_DIR}/cloud_name.yaml" 2>&1 | tee "${TEST_DIR}/add-cloud.log"
 
 	file="${TEST_DIR}/test-${name}.log"
 
@@ -115,9 +115,9 @@ EOF
 	# Each machine is in a different subnet,
 	# which will be discovered when the agent starts.
 	echo "==> Adding Machines"
-	juju add-machine ssh:ubuntu@"${addr_m1}" >"${TEST_DIR}/add-machine-1.log" 2>&1
-	juju add-machine ssh:ubuntu@"${addr_m2}" >"${TEST_DIR}/add-machine-2.log" 2>&1
-	juju add-machine ssh:ubuntu@"${addr_m3}" >"${TEST_DIR}/add-machine-3.log" 2>&1
+	juju add-machine ssh:ubuntu@"${addr_m1}" 2>&1 | tee "${TEST_DIR}/add-machine-1.log"
+	juju add-machine ssh:ubuntu@"${addr_m2}" 2>&1 | tee "${TEST_DIR}/add-machine-2.log"
+	juju add-machine ssh:ubuntu@"${addr_m3}" 2>&1 | tee "${TEST_DIR}/add-machine-3.log"
 
 	wait_for_machine_agent_status "0" "started"
 	wait_for_machine_agent_status "1" "started"


### PR DESCRIPTION
Previously, some useful output was hidden in a log file, which is difficult to access in Jenkins. Use tee to log this output both to the console and a log file

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
BOOTSTRAP_CLOUD=aws BOOTSTRAP_PROVIDER=aws BOOTSTRAP_REGION=eu-west-1 ./main.sh -v -s 'test_spaces_manual' manual test_deploy_manual
```
and
```sh
BOOTSTRAP_CLOUD=lxd BOOTSTRAP_PROVIDER=lxd ./main.sh -v -s 'test_spaces_manual' manual test_deploy_manual
```