### PR TITLE
[JUJU-2222] Support multi-homing on OpenStack

### DIFF
--- a/provider/openstack/config.go
+++ b/provider/openstack/config.go
@@ -5,6 +5,7 @@ package openstack
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/juju/schema"
 	"github.com/juju/utils/v3"
@@ -69,8 +70,13 @@ func (c *environConfig) useDefaultSecurityGroup() bool {
 	return c.attrs[UseDefaultSecgroupKey].(bool)
 }
 
-func (c *environConfig) network() string {
-	return c.attrs[NetworkKey].(string)
+func (c *environConfig) networks() []string {
+	raw := strings.Split(c.attrs[NetworkKey].(string), ",")
+	res := make([]string, len(raw))
+	for i, net := range raw {
+		res[i] = strings.TrimSpace(net)
+	}
+	return res
 }
 
 func (c *environConfig) externalNetwork() string {

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -76,19 +76,19 @@ func (t configTest) check(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ecfg := e.ecfg()
-	c.Assert(ecfg.Name(), gc.Equals, "testmodel")
+	c.Check(ecfg.Name(), gc.Equals, "testmodel")
 	if t.firewallMode != "" {
-		c.Assert(ecfg.FirewallMode(), gc.Equals, t.firewallMode)
+		c.Check(ecfg.FirewallMode(), gc.Equals, t.firewallMode)
 	}
-	c.Assert(ecfg.useDefaultSecurityGroup(), gc.Equals, t.useDefaultSecurityGroup)
-	c.Assert(ecfg.networks()[0], gc.Equals, t.network)
-	c.Assert(ecfg.externalNetwork(), gc.Equals, t.externalNetwork)
+	c.Check(ecfg.useDefaultSecurityGroup(), gc.Equals, t.useDefaultSecurityGroup)
+	c.Check(ecfg.networks(), gc.DeepEquals, []string{t.network})
+	c.Check(ecfg.externalNetwork(), gc.Equals, t.externalNetwork)
 	// Default should be true
 	expectedHostnameVerification := true
 	if t.sslHostnameSet {
 		expectedHostnameVerification = t.sslHostnameVerification
 	}
-	c.Assert(ecfg.SSLHostnameVerification(), gc.Equals, expectedHostnameVerification)
+	c.Check(ecfg.SSLHostnameVerification(), gc.Equals, expectedHostnameVerification)
 	for name, expect := range t.expect {
 		actual, found := ecfg.UnknownAttrs()[name]
 		c.Check(found, jc.IsTrue)
@@ -97,7 +97,7 @@ func (t configTest) check(c *gc.C) {
 	if t.blockStorageSource != "" {
 		storage, ok := ecfg.StorageDefaultBlockSource()
 		c.Assert(ok, jc.IsTrue)
-		c.Assert(storage, gc.Equals, t.blockStorageSource)
+		c.Check(storage, gc.Equals, t.blockStorageSource)
 	}
 }
 

--- a/provider/openstack/config_test.go
+++ b/provider/openstack/config_test.go
@@ -81,7 +81,7 @@ func (t configTest) check(c *gc.C) {
 		c.Assert(ecfg.FirewallMode(), gc.Equals, t.firewallMode)
 	}
 	c.Assert(ecfg.useDefaultSecurityGroup(), gc.Equals, t.useDefaultSecurityGroup)
-	c.Assert(ecfg.network(), gc.Equals, t.network)
+	c.Assert(ecfg.networks()[0], gc.Equals, t.network)
 	c.Assert(ecfg.externalNetwork(), gc.Equals, t.externalNetwork)
 	// Default should be true
 	expectedHostnameVerification := true

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -128,8 +128,9 @@ func GetNovaClient(e environs.Environ) *nova.Client {
 }
 
 // ResolveNetworks exposes environ helper function resolveNetwork for testing
-func ResolveNetworks(e environs.Environ, networkName string, external bool) ([]string, error) {
-	return e.(*Environ).networking.ResolveNetworks(networkName, external)
+func ResolveNetworkIDs(e environs.Environ, networkName string, external bool) ([]string, error) {
+	networks, err := e.(*Environ).networking.ResolveNetworks(networkName, external)
+	return idsFromNetworks(networks), err
 }
 
 // FindNetworks exposes environ helper function FindNetworks for testing

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-goose/goose/v5/nova"
 	"github.com/go-goose/goose/v5/swift"
 	"github.com/juju/collections/set"
+	"github.com/juju/collections/transform"
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
@@ -130,7 +132,8 @@ func GetNovaClient(e environs.Environ) *nova.Client {
 // ResolveNetworks exposes environ helper function resolveNetwork for testing
 func ResolveNetworkIDs(e environs.Environ, networkName string, external bool) ([]string, error) {
 	networks, err := e.(*Environ).networking.ResolveNetworks(networkName, external)
-	return idsFromNetworks(networks), err
+	toID := func(n neutron.NetworkV2) string { return n.Id }
+	return transform.Slice(networks, toID), errors.Trace(err)
 }
 
 // FindNetworks exposes environ helper function FindNetworks for testing

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -127,9 +127,9 @@ func GetNovaClient(e environs.Environ) *nova.Client {
 	return e.(*Environ).nova()
 }
 
-// ResolveNetwork exposes environ helper function resolveNetwork for testing
-func ResolveNetwork(e environs.Environ, networkName string, external bool) (string, error) {
-	return e.(*Environ).networking.ResolveNetwork(networkName, external)
+// ResolveNetworks exposes environ helper function resolveNetwork for testing
+func ResolveNetworks(e environs.Environ, networkName string, external bool) ([]string, error) {
+	return e.(*Environ).networking.ResolveNetworks(networkName, external)
 }
 
 // FindNetworks exposes environ helper function FindNetworks for testing

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -2408,6 +2408,7 @@ func (s *localServerSuite) TestResolveNetworkUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	networkIDs, err := openstack.ResolveNetworkIDs(s.env, sampleUUID, false)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(networkIDs, gc.DeepEquals, []string{sampleUUID})
 }
 
@@ -2418,6 +2419,27 @@ func (s *localServerSuite) TestResolveNetworkLabel(c *gc.C) {
 	networkIDs, err := openstack.ResolveNetworkIDs(s.env, networkLabel, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(networkIDs, gc.DeepEquals, expectNetworkIDs)
+}
+
+func (s *localServerSuite) TestResolveNetworkLabelMultiple(c *gc.C) {
+	var networkLabel = "multi"
+
+	err := s.srv.Neutron.NeutronModel().AddNetwork(neutron.NetworkV2{
+		Id:   "multi-666",
+		Name: networkLabel,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.srv.Neutron.NeutronModel().AddNetwork(neutron.NetworkV2{
+		Id:   "multi-999",
+		Name: networkLabel,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	var expectNetworkIDs = []string{"multi-666", "multi-999"}
+	networkIDs, err := openstack.ResolveNetworkIDs(s.env, networkLabel, false)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(networkIDs, jc.SameContents, expectNetworkIDs)
 }
 
 func (s *localServerSuite) TestResolveNetworkNotPresent(c *gc.C) {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1060,14 +1060,14 @@ func (s *localServerSuite) TestDestroyControllerSpaceConstraints(c *gc.C) {
 		Constraints:      constraints.MustParse("spaces=space-1 zones=zone-0"),
 		SubnetsToZones: []map[corenetwork.Id][]string{
 			{
-				"xxx-yyy-zzz": {"zone-0"},
+				"999-01": {"zone-0"},
 			},
 		},
 	}
 	_, err := testing.StartInstanceWithParams(env, s.callCtx, controllerInstanceName, params)
 	c.Assert(err, jc.ErrorIsNil)
 	assertPorts(c, env, []portAssertion{
-		{NamePrefix: fmt.Sprintf("juju-%s-", uuid), SubnetIDs: []string{"xxx-yyy-zzz"}},
+		{NamePrefix: fmt.Sprintf("juju-%s-", uuid), SubnetIDs: []string{"999-01"}},
 	})
 
 	// The openstack runtime would assign a device_id to a port when it's

--- a/provider/openstack/network_mock_test.go
+++ b/provider/openstack/network_mock_test.go
@@ -105,21 +105,6 @@ func (mr *MockNetworkingMockRecorder) CreatePort(arg0, arg1, arg2 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePort", reflect.TypeOf((*MockNetworking)(nil).CreatePort), arg0, arg1, arg2)
 }
 
-// DefaultNetworks mocks base method.
-func (m *MockNetworking) DefaultNetworks() ([]nova.ServerNetworks, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultNetworks")
-	ret0, _ := ret[0].([]nova.ServerNetworks)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DefaultNetworks indicates an expected call of DefaultNetworks.
-func (mr *MockNetworkingMockRecorder) DefaultNetworks() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultNetworks", reflect.TypeOf((*MockNetworking)(nil).DefaultNetworks))
-}
-
 // DeletePortByID mocks base method.
 func (m *MockNetworking) DeletePortByID(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -164,19 +149,19 @@ func (mr *MockNetworkingMockRecorder) NetworkInterfaces(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInterfaces", reflect.TypeOf((*MockNetworking)(nil).NetworkInterfaces), arg0)
 }
 
-// ResolveNetwork mocks base method.
-func (m *MockNetworking) ResolveNetwork(arg0 string, arg1 bool) (string, error) {
+// ResolveNetworks mocks base method.
+func (m *MockNetworking) ResolveNetworks(arg0 string, arg1 bool) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveNetwork", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "ResolveNetworks", arg0, arg1)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ResolveNetwork indicates an expected call of ResolveNetwork.
-func (mr *MockNetworkingMockRecorder) ResolveNetwork(arg0, arg1 interface{}) *gomock.Call {
+// ResolveNetworks indicates an expected call of ResolveNetworks.
+func (mr *MockNetworkingMockRecorder) ResolveNetworks(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNetwork", reflect.TypeOf((*MockNetworking)(nil).ResolveNetwork), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveNetworks", reflect.TypeOf((*MockNetworking)(nil).ResolveNetworks), arg0, arg1)
 }
 
 // Subnets mocks base method.

--- a/provider/openstack/network_mock_test.go
+++ b/provider/openstack/network_mock_test.go
@@ -539,16 +539,16 @@ func (mr *MockNetworkingEnvironConfigMockRecorder) externalNetwork() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "externalNetwork", reflect.TypeOf((*MockNetworkingEnvironConfig)(nil).externalNetwork))
 }
 
-// network mocks base method.
-func (m *MockNetworkingEnvironConfig) network() string {
+// networks mocks base method.
+func (m *MockNetworkingEnvironConfig) networks() []string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "network")
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "networks")
+	ret0, _ := ret[0].([]string)
 	return ret0
 }
 
-// network indicates an expected call of network.
-func (mr *MockNetworkingEnvironConfigMockRecorder) network() *gomock.Call {
+// networks indicates an expected call of networks.
+func (mr *MockNetworkingEnvironConfigMockRecorder) networks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "network", reflect.TypeOf((*MockNetworkingEnvironConfig)(nil).network))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "networks", reflect.TypeOf((*MockNetworkingEnvironConfig)(nil).networks))
 }

--- a/provider/openstack/network_mock_test.go
+++ b/provider/openstack/network_mock_test.go
@@ -150,10 +150,10 @@ func (mr *MockNetworkingMockRecorder) NetworkInterfaces(arg0 interface{}) *gomoc
 }
 
 // ResolveNetworks mocks base method.
-func (m *MockNetworking) ResolveNetworks(arg0 string, arg1 bool) ([]string, error) {
+func (m *MockNetworking) ResolveNetworks(arg0 string, arg1 bool) ([]neutron.NetworkV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveNetworks", arg0, arg1)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]neutron.NetworkV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -382,7 +382,7 @@ func makeSubnetInfo(neutron NetworkingNeutron, subnet neutron.SubnetV2) (corenet
 func (n *NeutronNetworking) Subnets(instId instance.Id, subnetIds []corenetwork.Id) ([]corenetwork.SubnetInfo, error) {
 	netIds := set.NewStrings()
 	neutron := n.neutron()
-	internalNet := n.ecfg().network()
+	internalNet := n.ecfg().networks()[0]
 	netId, err := resolveNeutronNetwork(neutron, internalNet, false)
 	if err != nil {
 		// Note: (jam 2018-05-23) We don't treat this as fatal because

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -160,7 +160,7 @@ func (n *NeutronNetworking) getExternalNetworkIDsFromHostAddrs(addrs map[string]
 		return extNetworkIds, nil
 	}
 
-	logger.Debugf("unique match for external network %s not found; searching for one", externalNetwork)
+	logger.Debugf("unique match for external network %q not found; searching for one", externalNetwork)
 
 	hostAddrAZs, err := n.findNetworkAZForHostAddrs(addrs)
 	if err != nil {

--- a/provider/openstack/networking.go
+++ b/provider/openstack/networking.go
@@ -453,17 +453,6 @@ func (n *NeutronNetworking) Subnets(instId instance.Id, subnetIds []corenetwork.
 	return results, nil
 }
 
-// noNetConfigMsg is used to present resolution options when an error is
-// encountered due to missing "network" configuration.
-// Any error from attempting to resolve a network without network config set,
-// is likely due to the resolution returning multiple internal networks.
-func noNetConfigMsg(err error) string {
-	return fmt.Sprintf(
-		"%s\n\tTo resolve this error, set a value for \"network\" in model-config or model-defaults;"+
-			"\n\tor supply it via --config when creating a new model",
-		err.Error())
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron. It returns a
 // slice where the i_th element contains the list of network interfaces
 // for the i_th input instance ID.

--- a/provider/openstack/networking_interfaces.go
+++ b/provider/openstack/networking_interfaces.go
@@ -77,7 +77,7 @@ type NetworkingNeutron interface {
 // NetworkingEnvironConfig describes the environConfig methods needed for
 // Networking.
 type NetworkingEnvironConfig interface {
-	network() string
+	networks() []string
 	externalNetwork() string
 }
 

--- a/provider/openstack/networking_interfaces.go
+++ b/provider/openstack/networking_interfaces.go
@@ -19,14 +19,10 @@ type Networking interface {
 	// to the specified instance.
 	AllocatePublicIP(instance.Id) (*string, error)
 
-	// DefaultNetworks returns the set of networks that should be
-	// added by default to all new instances.
-	DefaultNetworks() ([]nova.ServerNetworks, error)
-
-	// ResolveNetwork takes either a network ID or label
+	// ResolveNetworks takes either a network ID or label
 	// with a string to specify whether the network is external
-	// and returns the corresponding network ID.
-	ResolveNetwork(string, bool) (string, error)
+	// and returns the corresponding matching network IDs.
+	ResolveNetworks(string, bool) ([]string, error)
 
 	// Subnets returns basic information about subnets known
 	// by OpenStack for the environment.

--- a/provider/openstack/networking_interfaces.go
+++ b/provider/openstack/networking_interfaces.go
@@ -21,8 +21,8 @@ type Networking interface {
 
 	// ResolveNetworks takes either a network ID or label
 	// with a string to specify whether the network is external
-	// and returns the corresponding matching network IDs.
-	ResolveNetworks(string, bool) ([]string, error)
+	// and returns the corresponding matching networks.
+	ResolveNetworks(string, bool) ([]neutron.NetworkV2, error)
 
 	// Subnets returns basic information about subnets known
 	// by OpenStack for the environment.

--- a/provider/openstack/networking_test.go
+++ b/provider/openstack/networking_test.go
@@ -322,7 +322,7 @@ func (s *networkingSuite) expectNeutronCalls(c *gc.C) *gomock.Controller {
 }
 
 func (s *networkingSuite) expectListSubnets() {
-	s.ecfg.EXPECT().network().Return("int-net")
+	s.ecfg.EXPECT().networks().Return([]string{"int-net"})
 
 	s.expectExternalNetwork()
 	s.neutron.EXPECT().ListNetworksV2(gomock.Any()).Return([]neutron.NetworkV2{

--- a/provider/openstack/networking_test.go
+++ b/provider/openstack/networking_test.go
@@ -45,7 +45,7 @@ func (s *networkingSuite) SetUpTest(c *gc.C) {
 
 func (s *networkingSuite) TestAllocatePublicIPConfiguredExternalNetwork(c *gc.C) {
 	// Get a FIP for an instance with a configured external-network,
-	// which has available FIPs.  Other external networks to exist,
+	// which has available FIPs. Other external networks do exist -
 	// at last 1 in the same AZ as the instance. Should get the FIP
 	// on the configured external-network.
 	defer s.setupMocks(c).Finish()

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1539,7 +1539,7 @@ func (e *Environ) networksForModel() ([]nova.ServerNetworks, error) {
 		return nil, errors.Annotate(err, "getting initial networks")
 	}
 
-	usingNetwork := e.ecfg().network()
+	usingNetwork := e.ecfg().networks()[0]
 	networkID, err := e.networking.ResolveNetwork(usingNetwork, false)
 	if err != nil {
 		if usingNetwork == "" {

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1542,30 +1542,30 @@ func (e *Environ) DeletePorts(networks []nova.ServerNetworks) error {
 // configuration.
 func (e *Environ) networksForModel() ([]nova.ServerNetworks, error) {
 	cfgNets := e.ecfg().networks()
-	o7kNets := set.NewStrings()
+	networkIDs := set.NewStrings()
 
 	for _, cfgNet := range cfgNets {
-		networkIDs, err := e.networking.ResolveNetworks(cfgNet, false)
+		networks, err := e.networking.ResolveNetworks(cfgNet, false)
 		if err != nil {
 			logger.Warningf("filtering networks for %q", cfgNet)
 		}
 
-		for _, netID := range networkIDs {
-			o7kNets.Add(netID)
+		for _, net := range networks {
+			networkIDs.Add(net.Id)
 		}
 	}
 
-	if len(o7kNets) == 0 {
+	if len(networkIDs) == 0 {
 		if len(cfgNets) == 1 && cfgNets[0] == "" {
 			return nil, nil
 		}
 		return nil, errors.Errorf("unable to determine networks for configured list: %v", cfgNets)
 	}
 
-	logger.Debugf("using network IDs %v", o7kNets.Values())
+	logger.Debugf("using network IDs %v", networkIDs.Values())
 
-	result := make([]nova.ServerNetworks, o7kNets.Size())
-	for i, netID := range o7kNets.Values() {
+	result := make([]nova.ServerNetworks, networkIDs.Size())
+	for i, netID := range networkIDs.Values() {
 		result[i] = nova.ServerNetworks{NetworkId: netID}
 	}
 	return result, nil

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -910,8 +910,7 @@ func (s *providerUnitTests) TestNetworksForInstance(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetwork("network-id-foo", false).Return("network-id-foo", nil)
-	expectDefaultNetworks(mockNetworking)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]string{"network-id-foo"}, nil)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
 
@@ -936,7 +935,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetwork("network-id-foo", false).Return("network-id-foo", nil)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]string{"network-id-foo"}, nil)
 	mockNetworking.EXPECT().CreatePort("", "network-id-foo", network.Id("subnet-foo")).Return(
 		&neutron.PortV2{
 			FixedIPs: []neutron.PortFixedIPsV2{{
@@ -946,7 +945,6 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 			Id:         "port-id",
 			MACAddress: "mac-address",
 		}, nil)
-	expectDefaultNetworks(mockNetworking)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
 	netCfg.EXPECT().AddNetworkConfig(network.InterfaceInfos{{
@@ -979,8 +977,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithNoMatchingAZ(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetwork("network-id-foo", false).Return("network-id-foo", nil)
-	expectDefaultNetworks(mockNetworking)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]string{"network-id-foo"}, nil)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
 
@@ -1001,7 +998,7 @@ func (s *providerUnitTests) TestNetworksForInstanceNoSubnetAZsStillConsidered(c 
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetwork("network-id-foo", false).Return("network-id-foo", nil)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]string{"network-id-foo"}, nil)
 	mockNetworking.EXPECT().CreatePort("", "network-id-foo", network.Id("subnet-foo")).Return(
 		&neutron.PortV2{
 			FixedIPs: []neutron.PortFixedIPsV2{{
@@ -1011,7 +1008,6 @@ func (s *providerUnitTests) TestNetworksForInstanceNoSubnetAZsStillConsidered(c 
 			Id:         "port-id",
 			MACAddress: "mac-address",
 		}, nil)
-	expectDefaultNetworks(mockNetworking)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
 	netCfg.EXPECT().AddNetworkConfig(network.InterfaceInfos{{
@@ -1049,12 +1045,4 @@ func envWithNetworking(net Networking) *Environ {
 		},
 		networking: net,
 	}
-}
-
-// expectDefaultNetworks will always return an empty slice as that's the current
-// implementation. Once that's been resolved we can then send back a non-empty
-// slice.
-// For now replicate the existing behaviour.
-func expectDefaultNetworks(mock *MockNetworking) {
-	mock.EXPECT().DefaultNetworks().Return([]nova.ServerNetworks{}, nil)
 }

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -910,7 +910,7 @@ func (s *providerUnitTests) TestNetworksForInstance(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]string{"network-id-foo"}, nil)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{Id: "network-id-foo"}}, nil)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
 
@@ -935,7 +935,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]string{"network-id-foo"}, nil)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{Id: "network-id-foo"}}, nil)
 	mockNetworking.EXPECT().CreatePort("", "network-id-foo", network.Id("subnet-foo")).Return(
 		&neutron.PortV2{
 			FixedIPs: []neutron.PortFixedIPsV2{{
@@ -977,7 +977,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithNoMatchingAZ(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]string{"network-id-foo"}, nil)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{Id: "network-id-foo"}}, nil)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
 
@@ -998,8 +998,9 @@ func (s *providerUnitTests) TestNetworksForInstanceNoSubnetAZsStillConsidered(c 
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]string{"network-id-foo"}, nil)
-	mockNetworking.EXPECT().CreatePort("", "network-id-foo", network.Id("subnet-foo")).Return(
+	exp := mockNetworking.EXPECT()
+	exp.ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{Id: "network-id-foo"}}, nil)
+	exp.CreatePort("", "network-id-foo", network.Id("subnet-foo")).Return(
 		&neutron.PortV2{
 			FixedIPs: []neutron.PortFixedIPsV2{{
 				IPAddress: "10.10.10.1",

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -935,7 +935,11 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{Id: "network-id-foo"}}, nil)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{
+		Id:        "network-id-foo",
+		SubnetIds: []string{"subnet-foo"},
+	}}, nil)
+
 	mockNetworking.EXPECT().CreatePort("", "network-id-foo", network.Id("subnet-foo")).Return(
 		&neutron.PortV2{
 			FixedIPs: []neutron.PortFixedIPsV2{{
@@ -977,7 +981,10 @@ func (s *providerUnitTests) TestNetworksForInstanceWithNoMatchingAZ(c *gc.C) {
 	defer ctrl.Finish()
 
 	mockNetworking := NewMockNetworking(ctrl)
-	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{Id: "network-id-foo"}}, nil)
+	mockNetworking.EXPECT().ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{
+		Id:        "network-id-foo",
+		SubnetIds: []string{"subnet-foo"},
+	}}, nil)
 
 	netCfg := NewMockNetworkingConfig(ctrl)
 
@@ -999,7 +1006,12 @@ func (s *providerUnitTests) TestNetworksForInstanceNoSubnetAZsStillConsidered(c 
 
 	mockNetworking := NewMockNetworking(ctrl)
 	exp := mockNetworking.EXPECT()
-	exp.ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{Id: "network-id-foo"}}, nil)
+
+	exp.ResolveNetworks("network-id-foo", false).Return([]neutron.NetworkV2{{
+		Id:        "network-id-foo",
+		SubnetIds: []string{"subnet-foo", "subnet-with-az"},
+	}}, nil)
+
 	exp.CreatePort("", "network-id-foo", network.Id("subnet-foo")).Return(
 		&neutron.PortV2{
 			FixedIPs: []neutron.PortFixedIPsV2{{


### PR DESCRIPTION
A long time ago, a configuration article, _network_, was introduced for OpenStack models. This has been used since to indicate the internal network that Juju should connect provisioned VMs to. It is required to be set when the OpenStack project used for the model has multiple such networks available.

This is a contrivance that works outside the preferred Juju techniques for choosing networks to connect to. For workloads and machines we have constraints and bindings; for bootstrapping, we should use placement directives.

This patch removes the requirement to configure a single internal OpenStack network for VM connectivity. It upholds the following functionality regarding the _network_ configuration item.
- The option still works and is honoured, preserving the behaviour of current deployments.
- The option can be now set with a comma-delimited list of networks in order that multiple networks are considered.
- The option can be omitted in order that all networks available to the model's OpenStack project are considered.

We will likely consider removal of this configuration article in a future major release.

## QA steps

Requires an OpenStack cloud with multiple networks and subnets available. The author was able to add new networks and subnets to both _ServerStack_ and _CanoniStack_ projects.
- Bootstrap, specifying a single value for _network_ configuration.
- Check that the controller has a single ens/eth device (disregard Fan) in the configured network.
- Check that `juju subnets -m controller` only lists subnets in the configured network.
- Add a model _without_ network configuration.
- `juju add-machine` and check that `juju show-machine x` shows a NIC in each available network.
- `juju remove-machine x` and wait for it to be gone.
- `juju add-space beta <CIDR>` using the CIDR from the network that the controller model is configured for.
- `juju deploy postgresql --bind beta` and check that `juju show-machine x` shows a single NIC in the beta subnet.
- `juju add-machine --constraints spaces=alpha,beta` and check that `juju show-machine x` shows a NIC in each network.
- `juju add-machine --constraints spaces=beta` and check that `juju show-machine x` shows a single NIC in the beta subnet.
- Add a model with multiple configured networks, for example `--config network=some-net-1,some-net-2`.
- Verify the same steps as for the network-less model above.

## Documentation changes

Likely that we'll need to update docs regarding configuring OpenStack models.

## Bug reference

N/A
