### PR TITLE
Fix deploy default series

### DIFF
--- a/tests/suites/deploy/deploy_default_series.sh
+++ b/tests/suites/deploy/deploy_default_series.sh
@@ -6,16 +6,20 @@ run_deploy_default_series() {
 
 	ensure "${model_name}" "${file}"
 
+  # TODO(basebandit): remove model config default series once the discrepancy with charmhub api has been solved
 	juju model-config default-series=jammy
 	juju deploy ubuntu
 	juju deploy cs:ubuntu csubuntu
 
-  juju status --format=json | jq .
-	ubuntu_series=$(juju status --format=json | jq ".applications.ubuntu.series")
-	echo "$ubuntu_series" | check "jammy"
+	ubuntu_base_name=$(juju status --format=json | jq ".applications.ubuntu.base.name")
+	ubuntu_base_ch=$(juju status --format=json | jq ".applications.ubuntu.base.channel")
+	echo "$ubuntu_base_name" | check "ubuntu"
+	echo "$ubuntu_base_ch" | check "22.04"
 
-	csubuntu_series=$(juju status --format=json | jq ".applications.csubuntu.series")
-	echo "$csubuntu_series" | check "jammy"
+	csubuntu_base_name=$(juju status --format=json | jq ".applications.csubuntu.base.name")
+	csubuntu_base_ch=$(juju status --format=json | jq ".applications.csubuntu.base.channel")
+	echo "$csubuntu_base_name" | check "ubuntu"
+	echo "$csubuntu_base_ch" | check "22.04"
 
 	destroy_model "${model_name}"
 }
@@ -32,11 +36,15 @@ run_deploy_not_default_series() {
 	juju deploy ubuntu --series focal
 	juju deploy cs:ubuntu csubuntu --series focal
 
-	ubuntu_series=$(juju status --format=json | jq ".applications.ubuntu.series")
-	echo "$ubuntu_series" | check "focal"
+	ubuntu_base_name=$(juju status --format=json | jq ".applications.ubuntu.base.name")
+	ubuntu_base_ch=$(juju status --format=json | jq ".applications.ubuntu.base.channel")
+	echo "$ubuntu_base_name" | check "ubuntu"
+	echo "$ubuntu_base_ch" | check "20.04"
 
-	csubuntu_series=$(juju status --format=json | jq ".applications.csubuntu.series")
-	echo "$csubuntu_series" | check "focal"
+	csubuntu_base_name=$(juju status --format=json | jq ".applications.csubuntu.base.name")
+	csubuntu_base_ch=$(juju status --format=json | jq ".applications.csubuntu.base.channel")
+	echo "$csubuntu_base_name" | check "ubuntu"
+	echo "$csubuntu_base_ch" | check "20.04"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/deploy/deploy_default_series.sh
+++ b/tests/suites/deploy/deploy_default_series.sh
@@ -6,20 +6,19 @@ run_deploy_default_series() {
 
 	ensure "${model_name}" "${file}"
 
-  # TODO(basebandit): remove model config default series once the discrepancy with charmhub api has been solved
-	juju model-config default-series=jammy
+	juju model-config default-series=focal
 	juju deploy ubuntu
 	juju deploy cs:ubuntu csubuntu
 
 	ubuntu_base_name=$(juju status --format=json | jq ".applications.ubuntu.base.name")
 	ubuntu_base_ch=$(juju status --format=json | jq ".applications.ubuntu.base.channel")
 	echo "$ubuntu_base_name" | check "ubuntu"
-	echo "$ubuntu_base_ch" | check "22.04"
+	echo "$ubuntu_base_ch" | check "20.04"
 
 	csubuntu_base_name=$(juju status --format=json | jq ".applications.csubuntu.base.name")
 	csubuntu_base_ch=$(juju status --format=json | jq ".applications.csubuntu.base.channel")
 	echo "$csubuntu_base_name" | check "ubuntu"
-	echo "$csubuntu_base_ch" | check "22.04"
+	echo "$csubuntu_base_ch" | check "20.04"
 
 	destroy_model "${model_name}"
 }
@@ -32,19 +31,19 @@ run_deploy_not_default_series() {
 
 	ensure "${model_name}" "${file}"
 
-	juju model-config default-series=bionic
-	juju deploy ubuntu --series focal
-	juju deploy cs:ubuntu csubuntu --series focal
+	juju model-config default-series=focal
+	juju deploy ubuntu --series jammy
+	juju deploy cs:ubuntu csubuntu --series jammy
 
 	ubuntu_base_name=$(juju status --format=json | jq ".applications.ubuntu.base.name")
 	ubuntu_base_ch=$(juju status --format=json | jq ".applications.ubuntu.base.channel")
 	echo "$ubuntu_base_name" | check "ubuntu"
-	echo "$ubuntu_base_ch" | check "20.04"
+	echo "$ubuntu_base_ch" | check "22.04"
 
 	csubuntu_base_name=$(juju status --format=json | jq ".applications.csubuntu.base.name")
 	csubuntu_base_ch=$(juju status --format=json | jq ".applications.csubuntu.base.channel")
 	echo "$csubuntu_base_name" | check "ubuntu"
-	echo "$csubuntu_base_ch" | check "20.04"
+	echo "$csubuntu_base_ch" | check "22.04"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/deploy/deploy_default_series.sh
+++ b/tests/suites/deploy/deploy_default_series.sh
@@ -6,15 +6,16 @@ run_deploy_default_series() {
 
 	ensure "${model_name}" "${file}"
 
-	juju model-config default-series=bionic
+	juju model-config default-series=jammy
 	juju deploy ubuntu
 	juju deploy cs:ubuntu csubuntu
 
+  juju status --format=json | jq .
 	ubuntu_series=$(juju status --format=json | jq ".applications.ubuntu.series")
-	echo "$ubuntu_series" | check "bionic"
+	echo "$ubuntu_series" | check "jammy"
 
 	csubuntu_series=$(juju status --format=json | jq ".applications.csubuntu.series")
-	echo "$csubuntu_series" | check "bionic"
+	echo "$csubuntu_series" | check "jammy"
 
 	destroy_model "${model_name}"
 }


### PR DESCRIPTION
This PR changes the default series in 3.0 to jammy and makes use of the base and channel instead of series.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```sh
cd tests 
./main.sh -v -p lxd -c localhost deploy test_deploy_default_series
```