### PR TITLE
[JUJU-1952] Cleanup and fix manual tests

### DIFF
--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -37,9 +37,8 @@ run_deploy_manual_aws() {
 	vpc_id=$(echo "${OUT}" | jq -r '.VpcId' || true)
 	if [[ -z ${vpc_id} ]]; then
 		# VPC doesn't exist, create one along with all the required setup.
-		vpc_id=$(aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --output text)
+		vpc_id=$(aws ec2 create-vpc --cidr-block 10.0.0.0/28 --query 'Vpc.VpcId' --tag-specifications 'ResourceType=vpc,Tags=[{Key=Name,Value=manual-deploy}]' --output text)
 		aws ec2 wait vpc-available --vpc-ids "${vpc_id}"
-		aws ec2 create-tags --resources "${vpc_id}" --tags Key=Name,Value="manual-deploy"
 
 		aws ec2 modify-vpc-attribute --vpc-id "${vpc_id}" --enable-dns-support '{"Value":true}'
 		aws ec2 modify-vpc-attribute --vpc-id "${vpc_id}" --enable-dns-hostnames '{"Value":true}'
@@ -47,8 +46,7 @@ run_deploy_manual_aws() {
 		igw_id=$(aws ec2 create-internet-gateway --query 'InternetGateway.InternetGatewayId' --output text)
 		aws ec2 attach-internet-gateway --internet-gateway-id "${igw_id}" --vpc-id "${vpc_id}"
 
-		subnet_id=$(aws ec2 create-subnet --vpc-id "${vpc_id}" --cidr-block 10.0.0.0/28 --query 'Subnet.SubnetId' --output text)
-		aws ec2 create-tags --resources "${subnet_id}" --tags Key=Name,Value="manual-deploy"
+		subnet_id=$(aws ec2 create-subnet --vpc-id "${vpc_id}" --cidr-block 10.0.0.0/28 --query 'Subnet.SubnetId' --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=manual-deploy}]' --output text)
 
 		routetable_id=$(aws ec2 create-route-table --vpc-id "${vpc_id}" --query 'RouteTable.RouteTableId' --output text)
 

--- a/tests/suites/manual/deploy_manual_lxd.sh
+++ b/tests/suites/manual/deploy_manual_lxd.sh
@@ -98,8 +98,8 @@ run_deploy_manual_lxd() {
 
 		attempt=0
 		while [[ ${attempt} -lt 30 ]]; do
-			address=$(lxc list "$1" --format json |
-				jq --raw-output '.[0].state.network.eth0.addresses | map(select( .family == "inet")) | .[0].address')
+			address=$(lxc list --format json |
+				jq --raw-output ".[] | select(.name == \"${container_name}\") | .state.network.eth0.addresses | map(select( .family == \"inet\")) | .[0].address")
 
 			if echo "${address}" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+$'; then
 				echo "Using container address ${address}"


### PR DESCRIPTION
aws was occassionally failing due to tags not being created properly

lxd tests were failing due to `lxc list foo --format json` not filtering by container name for some versions of lxc

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
BOOTSTRAP_CLOUD=aws BOOTSTRAP_PROVIDER=aws BOOTSTRAP_REGION=eu-west-1 ./main.sh -v -s 'test_spaces_manual' manual test_deploy_manual
```
and
```sh
BOOTSTRAP_CLOUD=lxd BOOTSTRAP_PROVIDER=lxd ./main.sh -v -s 'test_spaces_manual' manual test_deploy_manual
```

Run on the jenkins image to be extra sure