### PR TITLE
[JUJU-2099] Fixed test-deploy-magma in 3.0

### DIFF
--- a/tests/suites/magma/magma.sh
+++ b/tests/suites/magma/magma.sh
@@ -18,16 +18,16 @@ run_deploy_magma() {
 
 	echo "Get cert file and request password for it"
 	juju scp --container="magma-orc8r-certifier" orc8r-certifier/0:/var/opt/magma/certs/admin_operator.pfx "${TEST_DIR}/admin_operator.pfx"
-	cert_password=$(juju run-action orc8r-certifier/leader get-pfx-package-password --wait --format=json | jq -r '."unit-orc8r-certifier-0".results.password')
+	cert_password=$(juju run orc8r-certifier/leader get-pfx-package-password --wait --format=json | jq -r '."unit-orc8r-certifier-0".results.password')
 
 	echo "Get IP address of NMS nginx proxy"
-	nms_ip=$(juju run-action orc8r-orchestrator/leader get-load-balancer-services --wait --format=json | jq -r '."unit-orc8r-orchestrator-0".results."nginx-proxy"')
+	nms_ip=$(juju run orc8r-orchestrator/leader get-load-balancer-services --wait --format=json | jq -r '."unit-orc8r-orchestrator-0".results."nginx-proxy"')
 
 	echo "Try to get access to Magma web interface via cert"
 	curl --insecure -s --cert-type P12 --cert "${TEST_DIR}"/admin_operator.pfx:"${cert_password}" https://"${nms_ip}":443 | jq -r ".errorCode" | check "USER_NOT_LOGGED_IN"
 
 	echo "Get NMS admin username"
-	admin_username=$(juju run-action nms-magmalte/leader get-master-admin-credentials --wait --format=json | jq -r '."unit-nms-magmalte-0".results."admin-username"')
+	admin_username=$(juju run nms-magmalte/leader get-master-admin-credentials --wait --format=json | jq -r '."unit-nms-magmalte-0".results."admin-username"')
 	echo "${admin_username}" | check "admin@juju.com"
 
 	destroy_model "${model_name}"


### PR DESCRIPTION
This PR changes `juju run-action` to `juju run` in the test code to fit the new juju CLI. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p k8s -c microk8s magma test_deploy_magma
```