### PR TITLE
[JUJU-2101] Fixed teardown and increased timeout for wait_for (test-deploy-magma)

### DIFF
--- a/tests/suites/magma/magma.sh
+++ b/tests/suites/magma/magma.sh
@@ -11,9 +11,10 @@ run_deploy_magma() {
 
 	echo "Deploy Magma project"
 	overlay_path="./tests/suites/magma/overlay/overlay.yaml"
-	juju deploy magma-orc8r --overlay "${overlay_path}" --trust --channel=edge
+	juju deploy magma-orc8r --overlay "${overlay_path}" --trust --channel=beta
 
 	echo "Check all Magma project components have ACTIVE status"
+	# Magical number 34 means that all 34 apps from the magma bundle has the same status
 	wait_for 34 '[.applications[] | select(."application-status".current == "active")] | length' 3600
 
 	echo "Get cert file and request password for it"

--- a/tests/suites/magma/magma.sh
+++ b/tests/suites/magma/magma.sh
@@ -14,7 +14,7 @@ run_deploy_magma() {
 	juju deploy magma-orc8r --overlay "${overlay_path}" --trust --channel=edge
 
 	echo "Check all Magma project components have ACTIVE status"
-	wait_for 34 '[.applications[] | select(."application-status".current == "active")] | length' 1800
+	wait_for 34 '[.applications[] | select(."application-status".current == "active")] | length' 3600
 
 	echo "Get cert file and request password for it"
 	juju scp --container="magma-orc8r-certifier" orc8r-certifier/0:/var/opt/magma/certs/admin_operator.pfx "${TEST_DIR}/admin_operator.pfx"
@@ -30,7 +30,6 @@ run_deploy_magma() {
 	admin_username=$(juju run-action nms-magmalte/leader get-master-admin-credentials --wait --format=json | jq -r '."unit-nms-magmalte-0".results."admin-username"')
 	echo "${admin_username}" | check "admin@juju.com"
 
-	destroy_model "${model_name}"
 }
 
 test_deploy_magma() {


### PR DESCRIPTION
This PR deletes the `destroy_model` to allow force kill-controller (the test takes too long to teardown). Also, it increases timeout for `wait_for` function to 3600, because sometimes these were issues (too long agent installation) with grafana-k8s charm on edge.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

```sh
cd tests
./main.sh -v -p k8s -c microk8s magma test_deploy_magma
```
