### PR TITLE
Add support for exposing the juju binary via a snap content interface

### DIFF
--- a/caas/kubernetes/provider/builtin.go
+++ b/caas/kubernetes/provider/builtin.go
@@ -103,10 +103,6 @@ func getLocalMicroK8sConfig(cmdRunner CommandRunner, getKubeConfigDir func() (st
 		return getLocalMicroK8sConfigNonLinux(cmdRunner)
 	}
 
-	_, err := cmdRunner.LookPath("microk8s")
-	if err != nil {
-		return []byte{}, errors.NotFoundf("microk8s")
-	}
 	notSupportErr := errors.NewNotSupported(nil, fmt.Sprintf("juju %q can only work with strictly confined microk8s", version.Current))
 	clientConfigPath, err := getKubeConfigDir()
 	if err != nil {

--- a/caas/kubernetes/provider/builtin_test.go
+++ b/caas/kubernetes/provider/builtin_test.go
@@ -101,14 +101,6 @@ MIIDBDCCAeygAwIBAgIJAPUHbpCysNxyMA0GCSqGSIb3DQEBCwUAMBcxFTATBgNV`[1:],
 	}
 }
 
-func (s *builtinSuite) TestGetLocalMicroK8sConfigNotInstalled(c *gc.C) {
-	s.runner.Call("LookPath", "microk8s").Returns("", errors.NotFoundf("microk8s"))
-	result, err := provider.GetLocalMicroK8sConfig(s.runner, func() (string, error) { return "", nil })
-	c.Assert(err, gc.ErrorMatches, `microk8s not found`)
-	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	c.Assert(result, gc.HasLen, 0)
-}
-
 func (s *builtinSuite) TestGetLocalMicroK8sConfigFileDoesNotExists(c *gc.C) {
 	s.runner.Call("LookPath", "microk8s").Returns("", nil)
 	result, err := provider.GetLocalMicroK8sConfig(s.runner, func() (string, error) { return "non-exist-dir", nil })
@@ -149,13 +141,6 @@ func (s *builtinSuite) TestAttemptMicroK8sCloud(c *gc.C) {
 			Name: "localhost",
 		}},
 	})
-}
-
-func (s *builtinSuite) TestAttemptMicroK8sCloudErrors(c *gc.C) {
-	s.runner.Call("LookPath", "microk8s").Returns("", errors.NotFoundf("microk8s"))
-	k8sCloud, err := provider.AttemptMicroK8sCloud(s.runner, func() (string, error) { return "", nil })
-	c.Assert(err, gc.ErrorMatches, `microk8s not found`)
-	c.Assert(k8sCloud, gc.DeepEquals, cloud.Cloud{})
 }
 
 func (s *builtinSuite) assertDecideKubeConfigDir(c *gc.C, isOfficial bool, clientConfigPath string) {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,6 +129,14 @@ hooks:
   disconnect-plug-peers: {}
   post-refresh: {}
 
+slots:
+  juju-bin:
+    interface: content
+    content: juju
+    source:
+      read:
+        - $SNAP/bin
+
 plugs:
   peers:
     interface: content


### PR DESCRIPTION
Add a new content interface to the snap to allow other snaps to access the juju binary.

Also remove an obsolete check for microk8s in the path.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Tested with a local microstack snap.
Shell into the snap and run juju bootstrap microk8s

## Bug reference

https://bugs.launchpad.net/juju/+bug/1990797
