### PR TITLE
[JUJU-2098] Fixed test-relation-data-exchange and test-relation-list-app in 3 0

### DIFF
--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -15,63 +15,57 @@ run_relation_data_exchange() {
 	juju relate dummy-sink dummy-source
 	juju config dummy-source token=becomegreen
 
-	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 1 0)"
-	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 1 1)"
-	wait_for "dummy-source" "$(idle_condition "dummy-source")"
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 0)"
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 1)"
+	wait_for "dummy-source" "$(idle_condition "dummy-source" 1 0)"
 
 	echo "Get the leader unit name"
-	non_leader_dummy_sink_unit=$(juju status dummy-sink --format json | jq -r ".applications.dummy-sink.units | to_entries[] | select(.value.leader!=true) | .key")
-	dummy_sink_relation_id=$(juju exec --unit "dummy-sink/leader" 'relation-ids db')
+	non_leader_dummy_sink_unit=$(juju status dummy-sink --format json | jq -r ".applications.\"dummy-sink\".units | to_entries[] | select(.value.leader!=true) | .key")
+	dummy_sink_relation_id=$(juju exec --unit "dummy-sink/leader" 'relation-ids source')
 	dummy_source_relation_id=$(juju exec --unit "dummy-source/leader" 'relation-ids sink')
     # stop there
 	echo "Block until the relation is joined; otherwise, the relation-set commands below will fail"
 	attempt=0
 	while true; do
-		got=$(juju exec --unit "wordpress/leader" "relation-get --app -r ${wordpress_relation_id} origin wordpress" || echo 'NOT FOUND')
+		got=$(juju exec --unit "dummy-sink/leader" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" || echo 'NOT FOUND')
 		if [ "${got}" != "NOT FOUND" ]; then
 			break
 		fi
 		attempt=$((attempt + 1))
 		if [ $attempt -eq 30 ]; then
 			# shellcheck disable=SC2046
-			echo $(red "timeout: wordpress has not yet joined db relation after 30sec")
+			echo $(red "timeout: dummy-sink has not yet joined sink relation after 30sec")
 			exit 1
 		fi
 		sleep 1
 	done
 	attempt=0
 	while true; do
-		got=$(juju exec --unit 'mysql/0' "relation-get --app -r ${wordpress_relation_id} origin mysql" || echo 'NOT FOUND')
+		got=$(juju exec --unit 'dummy-source/0' "relation-get --app -r ${dummy_sink_relation_id} origin dummy-source" || echo 'NOT FOUND')
 		if [ "${got}" != "NOT FOUND" ]; then
 			break
 		fi
 		attempt=$((attempt + 1))
 		if [ $attempt -eq 30 ]; then
 			# shellcheck disable=SC2046
-			echo $(red "timeout: mysql has not yet joined db relation after 30sec")
+			echo $(red "timeout: dummy-source has not yet joined sink relation after 30sec")
 			exit 1
 		fi
 		sleep 1
 	done
 
 	echo "Exchange relation data"
-	juju exec --unit 'mysql/0' "relation-set --app -r ${mysql_relation_id} origin=mysql"
+	juju exec --unit 'dummy-source/0' "relation-set --app -r ${dummy_source_relation_id} origin=dummy-source"
 	# As the leader units, set some *application* data for both sides of a non-peer relation
-	juju exec --unit "wordpress/leader" "relation-set --app -r ${wordpress_relation_id} origin=wordpress"
-	juju exec --unit 'mysql/0' "relation-set --app -r ${mysql_relation_id} origin=mysql"
-	# As the leader wordpress unit, also set *application* data for a peer relation
-	juju exec --unit "wordpress/leader" 'relation-set --app -r loadbalancer:0 visible=to-peers'
+	juju exec --unit "dummy-sink/leader" "relation-set --app -r ${dummy_sink_relation_id} origin=dummy-sink"
+	juju exec --unit 'dummy-source/0' "relation-set --app -r ${dummy_source_relation_id} origin=dummy-source"
 
 	echo "Check 1: ensure that leaders can read the application databag for their own application"
-	juju exec --unit "wordpress/leader" "relation-get --app -r ${wordpress_relation_id} origin wordpress" | check "wordpress"
-	juju exec --unit 'mysql/0' "relation-get --app -r ${mysql_relation_id} origin mysql" | check "mysql"
-
-	echo "Check 2: ensure that any unit can read its own application databag for *peer* relations"
-	juju exec --unit "wordpress/leader" 'relation-get --app -r loadbalancer:0 visible wordpress' | check "to-peers"
-	juju exec --unit "${non_leader_wordpress_unit}" 'relation-get --app -r loadbalancer:0 visible wordpress' | check "to-peers"
+	juju exec --unit "dummy-sink/leader" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" | check "dummy-sink"
+	juju exec --unit 'dummy-source/0' "relation-get --app -r ${dummy_source_relation_id} origin dummy-source" | check "dummy-source"
 
 	echo "Check 3: ensure that non-leader units are not allowed to read their own application databag for non-peer relations"
-	juju exec --unit "${non_leader_wordpress_unit}" "relation-get --app -r ${wordpress_relation_id} origin wordpress" 2>&1 || echo "PERMISSION DENIED" | check "PERMISSION DENIED"
+	juju exec --unit "${non_leader_dummy_sink_unit}" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" 2>&1 || echo "PERMISSION DENIED" | check "PERMISSION DENIED"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -20,10 +20,10 @@ run_relation_data_exchange() {
 	wait_for "dummy-source" "$(idle_condition "dummy-source" 1 0)"
 
 	echo "Get the leader unit name"
-	non_leader_dummy_sink_unit=$(juju status dummy-sink --format json | jq -r ".applications.\"dummy-sink\".units | to_entries[] | select(.value.leader!=true) | .key")
+	non_leader_dummy_sink_unit=$(juju status dummy-sink --format json | jq -r '.applications."dummy-sink".units | to_entries[] | select(.value.leader!=true) | .key')
 	dummy_sink_relation_id=$(juju exec --unit "dummy-sink/leader" 'relation-ids source')
 	dummy_source_relation_id=$(juju exec --unit "dummy-source/leader" 'relation-ids sink')
-    # stop there
+	# stop there
 	echo "Block until the relation is joined; otherwise, the relation-set commands below will fail"
 	attempt=0
 	while true; do

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -64,7 +64,7 @@ run_relation_data_exchange() {
 	juju exec --unit "dummy-sink/leader" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" | check "dummy-sink"
 	juju exec --unit 'dummy-source/0' "relation-get --app -r ${dummy_source_relation_id} origin dummy-source" | check "dummy-source"
 
-	echo "Check 3: ensure that non-leader units are not allowed to read their own application databag for non-peer relations"
+	echo "Check 2: ensure that non-leader units are not allowed to read their own application databag for non-peer relations"
 	juju exec --unit "${non_leader_dummy_sink_unit}" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" 2>&1 || echo "PERMISSION DENIED" | check "PERMISSION DENIED"
 
 	destroy_model "${model_name}"

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -7,23 +7,23 @@ run_relation_data_exchange() {
 
 	ensure "${model_name}" "${file}"
 
-	echo "Deploy 2 wordpress instances and one mysql instance"
-	juju deploy wordpress -n 2 --force --series bionic
-	# mysql charm does not have stable channel, so we use edge channel
-	juju deploy mysql --channel=edge --force --series focal
+	echo "Deploy 2 dummy-sink instances and one dummy-source instance"
+	juju deploy ./testcharms/charms/dummy-sink -n 2
+	juju deploy ./testcharms/charms/dummy-source
 
 	echo "Establish relation"
-	juju relate wordpress mysql
+	juju relate dummy-sink dummy-source
+	juju config dummy-source token=becomegreen
 
-	wait_for "wordpress" "$(idle_condition "wordpress" 1 0)"
-	wait_for "wordpress" "$(idle_condition "wordpress" 1 1)"
-	wait_for "mysql" "$(idle_condition "mysql")"
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 1 0)"
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 1 1)"
+	wait_for "dummy-source" "$(idle_condition "dummy-source")"
 
 	echo "Get the leader unit name"
-	non_leader_wordpress_unit=$(juju status wordpress --format json | jq -r ".applications.wordpress.units | to_entries[] | select(.value.leader!=true) | .key")
-	wordpress_relation_id=$(juju exec --unit "wordpress/leader" 'relation-ids db')
-	mysql_relation_id=$(juju exec --unit "mysql/leader" 'relation-ids mysql')
-
+	non_leader_dummy_sink_unit=$(juju status dummy-sink --format json | jq -r ".applications.dummy-sink.units | to_entries[] | select(.value.leader!=true) | .key")
+	dummy_sink_relation_id=$(juju exec --unit "dummy-sink/leader" 'relation-ids db')
+	dummy_source_relation_id=$(juju exec --unit "dummy-source/leader" 'relation-ids sink')
+    # stop there
 	echo "Block until the relation is joined; otherwise, the relation-set commands below will fail"
 	attempt=0
 	while true; do

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -8,25 +8,26 @@ run_relation_list_app() {
 	ensure "${model_name}" "${file}"
 
 	echo "Deploy 2 departer instances"
-	juju deploy wordpress --force --series bionic
-	# mysql charm does not have stable channel, so we use edge channel
-	juju deploy mysql --channel=edge --force --series focal
-	juju relate wordpress mysql
-	wait_for "wordpress" "$(idle_condition "wordpress" 1 0)"
-	wait_for "mysql" "$(idle_condition "mysql" 0 0)"
+	juju deploy ./testcharms/charms/dummy-sink
+  	juju deploy ./testcharms/charms/dummy-source
+
+	echo "Establish relation"
+  	juju relate dummy-sink dummy-source
+  	juju config dummy-source token=becomegreen
+
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 0)"
+	wait_for "dummy-source" "$(idle_condition "dummy-source" 1 0)"
 
 	echo "Figure out the right relation IDs to use for our hook tool invocations"
-	db_rel_id=$(juju exec --unit mysql/0 "relation-ids mysql" | cut -d':' -f2)
-	peer_rel_id=$(juju exec --unit mysql/0 "relation-ids database-peers" | cut -d':' -f2)
+	sink_rel_id=$(juju exec --unit dummy-source/0 "relation-ids sink" | cut -d':' -f2)
 
-	echo "Remove wordpress unit"
-	# the wordpress-mysql relation is still established but there are no units present in the wordpress side
-	juju remove-unit wordpress/0
-	wait_for null '.applications."wordpress".units."wordpress/0"'
+	echo "Remove dummy-sink unit"
+	# the dummy-sink-source relation is still established but there are no units present in the dummy-sink side
+	juju remove-unit dummy-sink/0
+	wait_for null '.applications."dummy-sink".units."dummy-sink/0"'
 
 	echo "Check relation-list hook"
-	juju exec --unit mysql/0 "relation-list --app -r ${db_rel_id}" | check "wordpress"
-	juju exec --unit mysql/0 "relation-list --app -r ${peer_rel_id}" | check "mysql"
+	juju exec --unit dummy-source/0 "relation-list --app -r ${sink_rel_id}" | check "dummy-sink"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -9,11 +9,11 @@ run_relation_list_app() {
 
 	echo "Deploy 2 departer instances"
 	juju deploy ./testcharms/charms/dummy-sink
-  	juju deploy ./testcharms/charms/dummy-source
+	juju deploy ./testcharms/charms/dummy-source
 
 	echo "Establish relation"
-  	juju relate dummy-sink dummy-source
-  	juju config dummy-source token=becomegreen
+	juju relate dummy-sink dummy-source
+	juju config dummy-source token=becomegreen
 
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0 0)"
 	wait_for "dummy-source" "$(idle_condition "dummy-source" 1 0)"


### PR DESCRIPTION
This PR switches to dummy-sink and dummy-source charms instead of WordPress and Mysql. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

```sh
cd tests
./main.sh -v -p lxd relations
```
