### PR TITLE
Fix trace log message.

### DIFF
--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -128,7 +128,7 @@ func (v *vmTemplateManager) getVMArch(ctx context.Context, vmObj *object.Virtual
 }
 
 func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, series string, agentArch string) (*object.VirtualMachine, string, error) {
-	logger.Tracef("getImportedTemplate for series %q, arch %q", agentArch)
+	logger.Tracef("getImportedTemplate for series %q, arch %q", series, agentArch)
 	seriesTemplatesFolder := v.seriesTemplateFolder(series)
 	seriesTemplates, err := v.client.ListVMTemplates(ctx, path.Join(seriesTemplatesFolder, "*"))
 	if err != nil {


### PR DESCRIPTION
Make the trace log message more useful by providing all the data implied, rather than half of it.

## QA steps

Deploy a machine on ESX with logging conning: juju.provider.vmware=TRACE


