### PR TITLE
[JUJU-2156] Add support for secret-add key#file syntax

### DIFF
--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -5,6 +5,8 @@ package jujuc
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -49,9 +51,11 @@ func (c *secretAddCommand) Info() *cmd.Info {
 	doc := `
 Add a secret with a list of key values.
 
-If a value has the '#base64' suffix, it is already in base64 format and no
+If a key has the '#base64' suffix, the value is already in base64 format and no
 encoding will be performed, otherwise the value will be base64 encoded
 prior to being stored.
+
+If a key has the '#file' suffix, the value is read from the corresponding file.
 
 By default, a secret is owned by the application, meaning only the unit
 leader can manage it. Use "--owner unit" to create a secret owned by the
@@ -59,21 +63,22 @@ specific unit which created it.
 
 Examples:
     secret-add token=34ae35facd4
-    secret-add key#base64 AA==
+    secret-add key#base64=AA==
+    secret-add key#file=/path/to/file another-key=s3cret
     secret-add --owner unit token=s3cret 
     secret-add --rotate monthly token=s3cret 
     secret-add --expire 24h token=s3cret 
     secret-add --expire 2025-01-01T06:06:06 token=s3cret 
     secret-add --label db-password \
         --description "my database password" \
-        data#base64 s3cret== 
+        data#base64=s3cret== 
     secret-add --label db-password \
         --description "my database password" \
         --file=/path/to/file
 `
 	return jujucmd.Info(&cmd.Info{
 		Name:    "secret-add",
-		Args:    "[key[#base64]=value...]",
+		Args:    "[key[#base64|#file]=value...]",
 		Purpose: "add a new secret",
 		Doc:     doc,
 	})
@@ -115,6 +120,25 @@ func (c *secretUpsertCommand) Init(args []string) error {
 	}
 	if c.owner != "application" && c.owner != "unit" {
 		return errors.NotValidf("secret owner %q", c.owner)
+	}
+
+	// Process keys where content is to come from a file.
+	const fromFile = "#file"
+	for i, arg := range args {
+		idx := strings.Index(arg, "=")
+		if idx <= 0 {
+			continue
+		}
+		possibleKey := arg[0:idx]
+		if !strings.HasSuffix(possibleKey, fromFile) {
+			continue
+		}
+		key := strings.TrimSuffix(possibleKey, fromFile)
+		content, err := os.ReadFile(arg[idx+1:])
+		if err != nil {
+			return errors.Annotatef(err, "reading content for secret key %q", key)
+		}
+		args[i] = fmt.Sprintf("%s=%s", key, content)
 	}
 
 	var err error

--- a/worker/uniter/runner/jujuc/secret-add.go
+++ b/worker/uniter/runner/jujuc/secret-add.go
@@ -5,8 +5,6 @@ package jujuc
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -120,25 +118,6 @@ func (c *secretUpsertCommand) Init(args []string) error {
 	}
 	if c.owner != "application" && c.owner != "unit" {
 		return errors.NotValidf("secret owner %q", c.owner)
-	}
-
-	// Process keys where content is to come from a file.
-	const fromFile = "#file"
-	for i, arg := range args {
-		idx := strings.Index(arg, "=")
-		if idx <= 0 {
-			continue
-		}
-		possibleKey := arg[0:idx]
-		if !strings.HasSuffix(possibleKey, fromFile) {
-			continue
-		}
-		key := strings.TrimSuffix(possibleKey, fromFile)
-		content, err := os.ReadFile(arg[idx+1:])
-		if err != nil {
-			return errors.Annotatef(err, "reading content for secret key %q", key)
-		}
-		args[i] = fmt.Sprintf("%s=%s", key, content)
 	}
 
 	var err error

--- a/worker/uniter/runner/jujuc/secret-add_test.go
+++ b/worker/uniter/runner/jujuc/secret-add_test.go
@@ -193,36 +193,3 @@ func (s *SecretAddSuite) TestAddSecretFromFile(c *gc.C) {
 	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UnitName"}, {FuncName: "CreateSecret", Args: []interface{}{args}}})
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret:9m4e2mr0ui3e8a215n4g\n")
 }
-
-func (s *SecretAddSuite) TestAddSecretKeyFromFile(c *gc.C) {
-	data := `
-      -----BEGIN CERTIFICATE-----
-      MIIFYjCCA0qgAwIBAgIQKaPND9YggIG6+jOcgmpk3DANBgkqhkiG9w0BAQsFADAz
-      MRwwGgYDVQQKExNsaW51eGNvbnRhaW5lcnMub3JnMRMwEQYDVQQDDAp0aW1AZWx3
-      -----END CERTIFICATE-----`[1:]
-
-	dir := c.MkDir()
-	fileName := filepath.Join(dir, "secret-data.bin")
-	err := os.WriteFile(fileName, []byte(data), os.FileMode(0644))
-	c.Assert(err, jc.ErrorIsNil)
-
-	hctx, _ := s.ContextSuite.NewHookContext()
-	com, err := jujuc.NewCommand(hctx, "secret-add")
-	c.Assert(err, jc.ErrorIsNil)
-	ctx := cmdtesting.Context(c)
-	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"key1=value1", "key2#file=" + fileName})
-
-	c.Assert(code, gc.Equals, 0)
-	val := coresecrets.NewSecretValue(map[string]string{
-		"key1": "dmFsdWUx",
-		"key2": `ICAgICAgLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCiAgICAgIE1JSUZZakNDQTBxZ0F3SUJBZ0lRS2FQTkQ5WWdnSUc2K2pPY2dtcGszREFOQmdrcWhraUc5dzBCQVFzRkFEQXoKICAgICAgTVJ3d0dnWURWUVFLRXhOc2FXNTFlR052Ym5SaGFXNWxjbk11YjNKbk1STXdFUVlEVlFRRERBcDBhVzFBWld4MwogICAgICAtLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t`,
-	})
-	args := &jujuc.SecretCreateArgs{
-		SecretUpdateArgs: jujuc.SecretUpdateArgs{
-			Value: val,
-		},
-		OwnerTag: names.NewApplicationTag("u"),
-	}
-	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UnitName"}, {FuncName: "CreateSecret", Args: []interface{}{args}}})
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret:9m4e2mr0ui3e8a215n4g\n")
-}

--- a/worker/uniter/runner/jujuc/secret-add_test.go
+++ b/worker/uniter/runner/jujuc/secret-add_test.go
@@ -193,3 +193,36 @@ func (s *SecretAddSuite) TestAddSecretFromFile(c *gc.C) {
 	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UnitName"}, {FuncName: "CreateSecret", Args: []interface{}{args}}})
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret:9m4e2mr0ui3e8a215n4g\n")
 }
+
+func (s *SecretAddSuite) TestAddSecretKeyFromFile(c *gc.C) {
+	data := `
+      -----BEGIN CERTIFICATE-----
+      MIIFYjCCA0qgAwIBAgIQKaPND9YggIG6+jOcgmpk3DANBgkqhkiG9w0BAQsFADAz
+      MRwwGgYDVQQKExNsaW51eGNvbnRhaW5lcnMub3JnMRMwEQYDVQQDDAp0aW1AZWx3
+      -----END CERTIFICATE-----`[1:]
+
+	dir := c.MkDir()
+	fileName := filepath.Join(dir, "secret-data.bin")
+	err := os.WriteFile(fileName, []byte(data), os.FileMode(0644))
+	c.Assert(err, jc.ErrorIsNil)
+
+	hctx, _ := s.ContextSuite.NewHookContext()
+	com, err := jujuc.NewCommand(hctx, "secret-add")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"key1=value1", "key2#file=" + fileName})
+
+	c.Assert(code, gc.Equals, 0)
+	val := coresecrets.NewSecretValue(map[string]string{
+		"key1": "dmFsdWUx",
+		"key2": `ICAgICAgLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCiAgICAgIE1JSUZZakNDQTBxZ0F3SUJBZ0lRS2FQTkQ5WWdnSUc2K2pPY2dtcGszREFOQmdrcWhraUc5dzBCQVFzRkFEQXoKICAgICAgTVJ3d0dnWURWUVFLRXhOc2FXNTFlR052Ym5SaGFXNWxjbk11YjNKbk1STXdFUVlEVlFRRERBcDBhVzFBWld4MwogICAgICAtLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t`,
+	})
+	args := &jujuc.SecretCreateArgs{
+		SecretUpdateArgs: jujuc.SecretUpdateArgs{
+			Value: val,
+		},
+		OwnerTag: names.NewApplicationTag("u"),
+	}
+	s.Stub.CheckCalls(c, []testing.StubCall{{FuncName: "UnitName"}, {FuncName: "CreateSecret", Args: []interface{}{args}}})
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, "secret:9m4e2mr0ui3e8a215n4g\n")
+}


### PR DESCRIPTION
The secret-add command gets support for reading individual key values from a file.
This is done via `key#file=/path/to/file`

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

`juju exec --unit controller/0 "secret-add foo#file=/var/lib/juju/agents/unit-controller-0/charm/README.md baz=bar"`

run `juju show-secret xxx --reveal` to check the secret content