### PR TITLE
[JUJU-2157] Fixed teardown issue in magma test

### DIFF
--- a/tests/suites/magma/task.sh
+++ b/tests/suites/magma/task.sh
@@ -29,4 +29,5 @@ test_magma() {
 
 	# Magma takes too long to tear down (1h+), so forcibly destroy it
 	export KILL_CONTROLLER=true
+	destroy_controller "test-magma"
 }


### PR DESCRIPTION
This PR adds a destroy-controller step after the KILL_CONTROLLER variable export.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

```sh
cd tests
./main.sh -v -p k8s -c microk8s magma
```
