### PR TITLE
[JUJU-2219] OpenStack - Allow subnets without AZs to be considered for space constraints/bindings

### DIFF
--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1406,23 +1406,41 @@ func (e *Environ) networksForInstance(
 	// We know that we are operating in the single configured network.
 	networkID := networks[0].NetworkId
 
-	// Attempt to filter the subnet IDs for the configured availability zone.
-	// If there is no configured zone, consider all subnet IDs.
+	// Attempt to filter the constraint/binding subnet IDs for the supplied
+	// availability zone.
+	// The zone is supplied by the provisioner based on its attempt to maintain
+	// distribution of units across zones.
+	// The zones recorded against O7k subnets in Juju are affected by the
+	// `availability_zone_hints` attribute on the network where they reside,
+	// and the default AZ configuration for the project.
+	// They are a read-only attribute.
+	// If a subnet in the subnets-to-zones map has no zones, we assume a basic
+	// O7k set-up where networks are not zone-limited. We log a warning and
+	// consider all the supplied subnets.
+	// See:
+	// - https://docs.openstack.org/neutron/latest/admin/config-az.html#availability-zone-related-attributes
+	// - https://docs.openstack.org/neutron/latest/admin/ovn/availability_zones.html#network-availability-zones
 	az := args.AvailabilityZone
 	subnetIDsForZone := make([][]network.Id, len(args.SubnetsToZones))
 	for i, nic := range args.SubnetsToZones {
-		var subnetIDs []network.Id
-		if az != "" {
-			var err error
-			if subnetIDs, err = network.FindSubnetIDsForAvailabilityZone(az, nic); err != nil {
-				return nil, errors.Annotatef(err, "getting subnets in zone %q", az)
+		subnetIDs, err := network.FindSubnetIDsForAvailabilityZone(az, nic)
+		if err != nil {
+			// We found no subnets in the zone.
+			// Add subnets without zone-limited networks.
+			for subnetID, zones := range nic {
+				if len(zones) == 0 {
+					logger.Warningf(
+						"subnet %q is not in a network with availability zones listed; assuming availability in zone %q",
+						subnetID, az)
+					subnetIDs = append(subnetIDs, subnetID)
+				}
 			}
+
 			if len(subnetIDs) == 0 {
-				return nil, errors.Errorf("availability zone %q has no subnets satisfying space constraints", az)
-			}
-		} else {
-			for subnetID := range nic {
-				subnetIDs = append(subnetIDs, subnetID)
+				// If we still have no candidate subnets, then they are all in
+				// networks with availability zones, and none of those zones
+				// match the input one. Return the error we have in hand.
+				return nil, errors.Annotatef(err, "determining subnets in zone %q", az)
 			}
 		}
 


### PR DESCRIPTION
There exist simple OpenStack set-ups (such as the author's _ServerStack_ project) that have networks without availability zone hints or scheduled availability zones.

This is a valid state according to the [Neutron specification](https://github.com/openstack/neutron-specs/blob/master/specs/mitaka/availability-zone.rst#proposed-change).

When the provisioner attempts to start a machine in a particular AZ, the presence of space constraints/bindings _and_ subnets without AZs causes provisioning to fail.

Here we accommodate O7k projects with networks that do not have `availability_zones`. In these cases, we will consider constrained subnets as valid for use on machine ports when:
- No other subnets are identified as valid targets in the current attempted AZ.
- The subnets have no availability zones according to Juju.

## QA steps

- First ensure that we will use a network without AZ hints. This is my network from _ServerStack_:
```
openstack network show manadart_admin_net
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| admin_state_up            | UP                                   |
| availability_zone_hints   |                                      |
| availability_zones        |                                      |
| created_at                | 2018-07-10T14:05:18Z                 |
...
+---------------------------+--------------------------------------+
```
- Bootstrap including such a network as config. In my case `--config network=manadart_admin_net`.
- Add a model with the same config.
- Create a new space with `juju add-space beta <subnet-cidr-from-this-network>`.
- `juju add-machine --constraints spaces=beta` should successfully create a machine.

## Documentation changes

None.

## Bug reference

N/A
