### PR TITLE
Allows bootstrapping juju 3.0 to other arch's.

### DIFF
--- a/cmd/jujud/agent/bootstrap_test.go
+++ b/cmd/jujud/agent/bootstrap_test.go
@@ -235,6 +235,7 @@ func (s *BootstrapSuite) TestControllerCharmConstraints(c *gc.C) {
 	defer closer()
 
 	app, err := st.Application("controller")
+	c.Assert(err, jc.ErrorIsNil)
 	constraints, err := app.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
 	consArch := constraints.Arch

--- a/cmd/jujud/agent/controllercharm.go
+++ b/cmd/jujud/agent/controllercharm.go
@@ -103,7 +103,9 @@ func (c *BootstrapCommand) deployControllerCharm(st *state.State, cons constrain
 	origin.Platform.Channel = base.Channel.String()
 
 	// Once the charm is added, set up the controller application.
-	if controllerUnit, err = addControllerApplication(st, curl, *origin, controllerAddress); err != nil {
+	controllerUnit, err = addControllerApplication(
+		st, curl, *origin, cons, controllerAddress)
+	if err != nil {
 		return errors.Annotate(err, "cannot add controller application")
 	}
 
@@ -289,7 +291,13 @@ func addLocalControllerCharm(st *state.State, base coreseries.Base, charmFileNam
 }
 
 // addControllerApplication deploys and configures the controller application.
-func addControllerApplication(st *state.State, curl *charm.URL, origin corecharm.Origin, address string) (*state.Unit, error) {
+func addControllerApplication(
+	st *state.State,
+	curl *charm.URL,
+	origin corecharm.Origin,
+	cons constraints.Value,
+	address string,
+) (*state.Unit, error) {
 	ch, err := st.Charm(curl)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -326,12 +334,13 @@ func addControllerApplication(st *state.State, curl *charm.URL, origin corecharm
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Criticalf("ADD APP WITH PLATFORM: %+v", *stateOrigin.Platform)
+
 	app, err := st.AddApplication(state.AddApplicationArgs{
 		Name:              bootstrap.ControllerApplicationName,
 		Charm:             ch,
 		CharmOrigin:       stateOrigin,
 		CharmConfig:       cfg,
+		Constraints:       cons,
 		ApplicationConfig: appCfg,
 		NumUnits:          1,
 	})


### PR DESCRIPTION
Due to a recent change in juju where the controller is now considered a charm we were not passing along constraints to the application deployment of the charm. This resulted in a case where the controller charm was always trying to be deployed with amd64 instead of the arch specified at Bootstrap time.

Now these arch constraints are passed along to the controller charm deployment.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

To test this you will need to have a bootstrap target that isn't amd64. Can either set up a vm or arm64 based machine in AWS with LXD.

Bootstrap to the new machine with:

`juju bootstrap --bootstrap-constraints arch=arm64`

If everything is fixed the bootstrap should succeed with no errors. See the bug report for behavior pre this change.

## Documentation changes

N/A This should have worked out of the gate.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1994173
