### PR TITLE
Fix race test failures in worker/provisioner

### DIFF
--- a/worker/provisioner/container_initialisation.go
+++ b/worker/provisioner/container_initialisation.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/agent"
 	apiprovisioner "github.com/juju/juju/api/agent/provisioner"
-	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/container/broker"
 	"github.com/juju/juju/container/kvm"
@@ -54,6 +53,7 @@ type ContainerSetupParams struct {
 	Config        agent.Config
 	MachineLock   machinelock.Lock
 	CredentialAPI workercommon.CredentialAPI
+	GetNetConfig  func(network.ConfigSource) ([]params.NetworkConfig, error)
 }
 
 // NewContainerSetup returns a ContainerSetup to start the container
@@ -68,7 +68,7 @@ func NewContainerSetup(params ContainerSetupParams) *ContainerSetup {
 		config:        params.Config,
 		machineLock:   params.MachineLock,
 		credentialAPI: params.CredentialAPI,
-		getNetConfig:  common.GetObservedNetworkConfig,
+		getNetConfig:  params.GetNetConfig,
 	}
 }
 

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -152,16 +152,12 @@ func (s *containerSetupSuite) setUpContainerSetup(c *gc.C, containerType instanc
 		Config:        cfg,
 		MachineLock:   s.machineLock,
 		CredentialAPI: &credentialAPIForTest{},
+		GetNetConfig: func(_ network.ConfigSource) ([]params.NetworkConfig, error) {
+			return nil, nil
+		},
 	}
 
-	// Stub out network config getter.
-	cs := NewContainerSetup(args)
-	cs.SetGetNetConfig(
-		func(_ network.ConfigSource) ([]params.NetworkConfig, error) {
-			return nil, nil
-		})
-
-	return cs
+	return NewContainerSetup(args)
 }
 
 func (s *containerSetupSuite) setUpInitialiseContainerProvisioner(c *gc.C, containerType instance.ContainerType) *ContainerSetup {

--- a/worker/provisioner/containermanifold.go
+++ b/worker/provisioner/containermanifold.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/agent"
 	apiprovisioner "github.com/juju/juju/api/agent/provisioner"
 	"github.com/juju/juju/api/base"
+	commonapi "github.com/juju/juju/api/common"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
@@ -112,6 +113,7 @@ func (cfg ContainerManifoldConfig) start(context dependency.Context) (worker.Wor
 		Config:        agentConfig,
 		MachineLock:   cfg.MachineLock,
 		CredentialAPI: credentialAPI,
+		GetNetConfig:  commonapi.GetObservedNetworkConfig,
 	})
 
 	getContainerWatcherFunc := func() (watcher.StringsWatcher, error) {

--- a/worker/provisioner/containerworker_test.go
+++ b/worker/provisioner/containerworker_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machinelock"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
@@ -167,6 +168,9 @@ func (s *containerWorkerSuite) setUpContainerWorker(c *gc.C) worker.Worker {
 		Config:        cfg,
 		MachineLock:   s.machineLock,
 		CredentialAPI: &credentialAPIForTest{},
+		GetNetConfig: func(_ network.ConfigSource) ([]params.NetworkConfig, error) {
+			return nil, nil
+		},
 	}
 	cs := provisioner.NewContainerSetup(args)
 
@@ -176,9 +180,6 @@ func (s *containerWorkerSuite) setUpContainerWorker(c *gc.C) worker.Worker {
 	}
 	w, err := provisioner.NewContainerSetupAndProvisioner(cs, watcherFunc)
 	c.Assert(err, jc.ErrorIsNil)
-	csp, ok := w.(*provisioner.ContainerSetupAndProvisioner)
-	c.Assert(ok, jc.IsTrue)
-	provisioner.SetGetNetConfigReturnNil(csp)
 
 	return w
 }

--- a/worker/provisioner/export_test.go
+++ b/worker/provisioner/export_test.go
@@ -10,11 +10,9 @@ import (
 	"github.com/juju/version/v2"
 
 	apiprovisioner "github.com/juju/juju/api/agent/provisioner"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/rpc/params"
 )
 
 func SetObserver(p Provisioner, observer chan<- *config.Config) {
@@ -73,17 +71,6 @@ func SetupToStartMachine(p ProvisionerTask, machine apiprovisioner.MachineProvis
 	error,
 ) {
 	return p.(*provisionerTask).setupToStartMachine(machine, version)
-}
-
-func (cs *ContainerSetup) SetGetNetConfig(getNetConf func(network.ConfigSource) ([]params.NetworkConfig, error)) {
-	cs.getNetConfig = getNetConf
-}
-
-func SetGetNetConfigReturnNil(w *ContainerSetupAndProvisioner) {
-	w.cs.SetGetNetConfig(
-		func(_ network.ConfigSource) ([]params.NetworkConfig, error) {
-			return nil, nil
-		})
 }
 
 func MachineSupportsContainers(cfg ContainerManifoldConfig, pr ContainerMachineGetter, mTag names.MachineTag) (ContainerMachine, error) {


### PR DESCRIPTION
As observed here
https://jenkins.juju.canonical.com/job/unit-tests-race-amd64/609/console

We were accessing a network config helper func in the worker start up and also in test set up.
This PR refactors the container setup to avoid the concurrent access.

## QA steps

go test --race in worker/provisioner package