### PR TITLE
[JUJU-1843] Add Kubeflow integration tests

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -124,7 +124,7 @@ bootstrap() {
 	if [[ ${BOOTSTRAP_REUSE} == "true" ]]; then
 		echo "====> Reusing bootstrapped juju ($(green "${version}:${cloud}"))"
 
-		OUT=$(juju models -c "${bootstrapped_name}" --format=json 2>/dev/null | jq '.models[] | .["short-name"]' | grep "${model}" || true)
+		OUT=$(juju models -c "${bootstrapped_name}" --format=json 2>/dev/null | jq -r ".models[] | .[\"short-name\"] | select(. == \"${model}\")" || true)
 		if [[ -n ${OUT} ]]; then
 			echo "${model} already exists. Use the following to clean up the environment:"
 			echo "    juju switch ${bootstrapped_name}"

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -55,6 +55,7 @@ TEST_NAMES="agents \
             expose_ec2 \
             hooks \
             hooktools \
+			kubeflow \
             machine \
             magma \
             manual \

--- a/tests/suites/kubeflow/deploy_kubeflow.sh
+++ b/tests/suites/kubeflow/deploy_kubeflow.sh
@@ -1,0 +1,37 @@
+# Run the canonical/kubeflow-ci integration test suite from a stable channel of kubeflow
+# with our build of Juju under test
+run_deploy_kubeflow() {
+	echo
+
+	file="${TEST_DIR}/deploy-kubeflow.txt"
+
+	# charmed-kubeflow must be deployed to a namespace called 'kubeflow'
+	# https://git.io/J6d35
+	ensure "kubeflow" "${file}"
+
+	echo "==> Installing tox"
+	pip3 install tox
+
+	echo "==> Cloning ci repo"
+	kubeflow_ci_dir=$(mktemp -d)
+	git clone "https://github.com/canonical/kubeflow-ci" "${kubeflow_ci_dir}"
+
+	echo "==> Running CI"
+	cd "${kubeflow_ci_dir}" || exit
+	python3 -m tox -e test_1dot6 -- --channel=1.6/stable
+}
+
+test_deploy_kubeflow() {
+	if [ "$(skip 'test_deploy_kubeflow')" ]; then
+		echo "==> TEST SKIPPED: test_deploy_kubeflow"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_deploy_kubeflow"
+	)
+}

--- a/tests/suites/kubeflow/task.sh
+++ b/tests/suites/kubeflow/task.sh
@@ -1,0 +1,42 @@
+test_kubeflow() {
+	if [ "$(skip 'test_kubeflow')" ]; then
+		echo "==> TEST SKIPPED: kubeflow tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju charmcraft
+
+	file="${TEST_DIR}/test-deploy-kubeflow.log"
+
+	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
+	fi
+
+	case "${BOOTSTRAP_PROVIDER:-}" in
+	"k8s")
+		# Charmed kubeflow 1.6 only supports k8s 1.22
+		# https://charmed-kubeflow.io/docs/install
+		microk8s kubectl version -o json | jq -r '.serverVersion | .major+"."+.minor' | check "1.22"
+
+		bootstrap "test-kubeflow" "${file}"
+
+		microk8s disable metallb
+		microk8s enable "metallb:10.64.140.43-10.64.140.49"
+
+		KUBECONFIG="$(mktemp)"
+		microk8s config >"${KUBECONFIG}"
+		export KUBECONFIG
+
+		test_deploy_kubeflow
+		;;
+	*)
+		echo "==> TEST SKIPPED: test_deploy_kubeflow test runs on k8s only"
+		;;
+	esac
+
+	export KILL_CONTROLLER=true
+	destroy_controller "test-kubeflow"
+}


### PR DESCRIPTION
Fortunately the charmed-kubeflow team already have an integration test siute for verifying charmed-kubeflow can be deployed.

Write a test suite which acts as a shim around their test suite, testing a stable charmed-kubeflow to the iteration of juju under test

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
BOOTSTRAP_PROVIDER=k8s BOOTSTRAP_CLOUD=microk8s ./main.sh -v kubeflow
```

If you wish to be extra sure, try running this on an ephemeral jenkins runner image

Note: at the moment, there a fair degree of instability with charmed-kubeflow's ci suite. It is both rapidly changing, and doesn't consistently pass. As of writing, this test suite succeeds about half the time, so the suite will be living in proving grounds for the time being