### PR TITLE
[JUJU-2166] Default to lxd snap 5.0/stable instead of latest/stable

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1898,7 +1898,7 @@ func (s *withImageMetadataSuite) TestContainerManagerConfigImageMetadata(c *gc.C
 		container.ConfigModelUUID:           coretesting.ModelTag.Id(),
 		config.ContainerImageStreamKey:      "daily",
 		config.ContainerImageMetadataURLKey: "https://images.linuxcontainers.org/",
-		config.LXDSnapChannel:               "latest/stable",
+		config.LXDSnapChannel:               "5.0/stable",
 	})
 }
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -472,6 +472,9 @@ const (
 
 	// DefaultActionResultsSize is the default size of the action results.
 	DefaultActionResultsSize = "5G"
+
+	// DefaultLxdSnapChannel is the default lxd snap channel to install on host vms.
+	DefaultLxdSnapChannel = "5.0/stable"
 )
 
 var defaultConfigValues = map[string]interface{}{
@@ -522,7 +525,7 @@ var defaultConfigValues = map[string]interface{}{
 	CloudInitUserDataKey:            "",
 	ContainerInheritPropertiesKey:   "",
 	BackupDirKey:                    "",
-	LXDSnapChannel:                  "latest/stable",
+	LXDSnapChannel:                  DefaultLxdSnapChannel,
 
 	CharmHubURLKey: charmhub.CharmHubServerURL,
 


### PR DESCRIPTION
We install the lxd snap on host vms to manage containers on that vm.
We need to default to a specific lxd LTS version, not latest.
5.0/stable is the supported version we'll use.

## QA steps

bootstrap
juju deploy ubuntu --to lxd

check lxd snap version on host machine