### PR TITLE
[WIP] Run `jujud` as non-root user in OCI images

### DIFF
--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -4,8 +4,12 @@ ARG TARGETARCH
 ARG BUILDOS
 
 # Add the syslog user for audit logging.
-RUN useradd --system -M syslog
-RUN usermod -s /usr/sbin/nologin syslog
+RUN useradd --system -M -s /usr/sbin/nologin syslog
+
+# Create a user under which jujud can run
+RUN useradd --system -M -s /usr/sbin/nologin jujud && \
+    mkdir -p /var/lib/juju && \
+    chown -R jujud:jujud /var/lib/juju
 
 # Some Python dependencies.
 RUN apt-get update \
@@ -31,10 +35,12 @@ RUN mkdir -p /tmp/wheelhouse
 COPY docker-staging/requirements.txt /tmp/wheelhouse/requirements.txt
 RUN pip3 install -r /tmp/wheelhouse/requirements.txt
 
-WORKDIR /var/lib/juju
 COPY ${TARGETOS}_${TARGETARCH}/bin/jujud /opt/
 COPY ${TARGETOS}_${TARGETARCH}/bin/jujuc /opt/
 COPY ${TARGETOS}_${TARGETARCH}/bin/containeragent /opt/
 COPY ${TARGETOS}_${TARGETARCH}/bin/pebble /opt/
+
+USER jujud
+WORKDIR /var/lib/juju
 
 ENTRYPOINT ["sh", "-c"]


### PR DESCRIPTION
This is draft, and mostly to satisfy my own curiosity about what would break in CI if we ran jujud as a non-root user by default, or at least adjusted the image to provide a non-root user!

Related to: https://bugs.launchpad.net/juju/+bug/1996221?comments=all

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

*Commands to run to verify that the change works.*

```sh
QA steps here
```

## Documentation changes

*How it affects user workflow (CLI or API). Delete section if not applicable.*

## Bug reference

*Link to Launchpad bug. Delete section if not applicable.*
