### PR TITLE
[JUJU-2168] Secret get refresh

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -72,11 +72,11 @@ func (c *Client) CreateSecretURIs(count int) ([]*coresecrets.URI, error) {
 }
 
 // GetContentInfo returns info about the content of a secret.
-func (c *Client) GetContentInfo(uri *coresecrets.URI, label string, update, peek bool) (*secrets.ContentParams, error) {
+func (c *Client) GetContentInfo(uri *coresecrets.URI, label string, refresh, peek bool) (*secrets.ContentParams, error) {
 	arg := params.GetSecretContentArg{
-		Label:  label,
-		Update: update,
-		Peek:   peek,
+		Label:   label,
+		Refresh: refresh,
+		Peek:    peek,
 	}
 	if uri != nil {
 		arg.URI = uri.String()

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -96,10 +96,10 @@ func (s *SecretsSuite) TestGetContentInfo(c *gc.C) {
 		c.Check(request, gc.Equals, "GetSecretContentInfo")
 		c.Check(arg, jc.DeepEquals, params.GetSecretContentArgs{
 			Args: []params.GetSecretContentArg{{
-				URI:    uri.String(),
-				Label:  "label",
-				Update: true,
-				Peek:   true,
+				URI:     uri.String(),
+				Label:   "label",
+				Refresh: true,
+				Peek:    true,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretContentResults{})
@@ -125,9 +125,9 @@ func (s *SecretsSuite) TestGetContentInfoLabelArgOnly(c *gc.C) {
 		c.Check(request, gc.Equals, "GetSecretContentInfo")
 		c.Check(arg, jc.DeepEquals, params.GetSecretContentArgs{
 			Args: []params.GetSecretContentArg{{
-				Label:  "label",
-				Update: true,
-				Peek:   true,
+				Label:   "label",
+				Refresh: true,
+				Peek:    true,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretContentResults{})

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -417,12 +417,12 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)
 	}
-	update := arg.Update ||
+	refresh := arg.Refresh ||
 		err != nil // Not found, so need to create one.
 	peek := arg.Peek
 
-	// Use the latest revision as the current one if --update or --peek.
-	if update || peek {
+	// Use the latest revision as the current one if --refresh or --peek.
+	if refresh || peek {
 		md, err := s.secretsBackend.GetSecret(uri)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -434,7 +434,7 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 		}
 		consumer.CurrentRevision = md.LatestRevision
 	}
-	if update || possibleUpdateLabel {
+	if refresh || possibleUpdateLabel {
 		if arg.Label != "" {
 			consumer.Label = arg.Label
 		}

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -711,7 +711,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateArg(c *gc.C) {
 
 	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
-			{URI: uri.String(), Label: "label", Update: true},
+			{URI: uri.String(), Label: "label", Refresh: true},
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38985,7 +38985,7 @@
                         "peek": {
                             "type": "boolean"
                         },
-                        "update": {
+                        "refresh": {
                             "type": "boolean"
                         },
                         "uri": {
@@ -46083,7 +46083,7 @@
                         "peek": {
                             "type": "boolean"
                         },
-                        "update": {
+                        "refresh": {
                             "type": "boolean"
                         },
                         "uri": {

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -100,11 +100,6 @@ with the specified name.
 If the cluster does not have a storage provisioning capability, use the
 --skip-storage option to add the cluster without any workload storage configured.
 
-When adding an AKS, EKS, or GKE cluster, you can use the --aks, --eks, or --gke
-option to interactively be stepped through the registration process, or you can
-supply the necessary parameters directly. For this to work, you'll have to have az,
-eksctl, or gcloud installed and logged in.
-
 Examples:
 
 When your kubeconfig file is in the default location:
@@ -122,27 +117,6 @@ To add a Kubernetes cloud using data from your kubeconfig file, when this file i
 
 To add a Kubernetes cloud using data from kubectl, when your kubeconfig file is not in the default location:
     kubectl config view --raw | juju add-k8s myk8scloud --cluster-name=my_cluster_name
-
-To add a GKE cluster 'myk8scloud' after gcloud login:
-    juju add-k8s --gke myk8scloud
-
-To add a GKE cluster specifying the project the cluster belongs to:
-    juju add-k8s --gke --project=myproject myk8scloud
-
-To specify the credential to use when accessing the  cluster:
-    juju add-k8s --gke --credential=myaccount --project=myproject myk8scloud
-
-To specify the K8s cluster region or cloud/region:
-    juju add-k8s --gke --credential=myaccount --project=myproject --region=someregion myk8scloud
-
-To add an AKS cluster named 'myk8scloud' after az login:
-    juju add-k8s --aks myk8scloud
-
-To specify the cluster to import, when you have more than one cluster:
-    juju add-k8s --aks --cluster-name mycluster myk8scloud
-
-To specify the Azure resource group of the AKS cluster:
-    juju add-k8s --aks --cluster-name mycluster --resource-group myrg myk8scloud
 
 See also:
     remove-k8s
@@ -262,10 +236,10 @@ func (c *AddCAASCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.hostCloud, "cloud", "", "k8s cluster cloud")
 	f.StringVar(&c.workloadStorage, "storage", "", "k8s storage class for workload storage")
 	f.BoolVar(&c.skipStorage, "skip-storage", false, "used when adding a cluster that doesn't have storage")
-	f.StringVar(&c.project, "project", "", "project to which the cluster belongs")
 	f.StringVar(&c.credential, "credential", "", "the credential to use when accessing the cluster")
-	f.StringVar(&c.resourceGroup, "resource-group", "", "the Azure resource group of the AKS cluster")
 	// TODO(k8s) - support k8s tooling in strict snap
+	// f.StringVar(&c.project, "project", "", "project to which the cluster belongs")
+	// f.StringVar(&c.resourceGroup, "resource-group", "", "the Azure resource group of the AKS cluster")
 	//f.BoolVar(&c.gke, "gke", false, "used when adding a GKE cluster")
 	//f.BoolVar(&c.aks, "aks", false, "used when adding an AKS cluster")
 	//f.BoolVar(&c.eks, "eks", false, "used when adding an EKS cluster")

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -82,9 +82,9 @@ Currently available charm hook tools are:
     resource-get             get the path to the locally cached resource file
     secret-add               add a new secret
     secret-get               get the content of a secret
-    secret-info-get          get a secret's metadata info
     secret-grant             grant access to a secret
     secret-ids               print secret ids
+    secret-info-get          get a secret's metadata info
     secret-remove            remove a existing secret
     secret-revoke            revoke access to a secret
     secret-set               update an existing secret
@@ -141,9 +141,9 @@ var expectedCommands = []string{
 	"resource-get",
 	"secret-add",
 	"secret-get",
-	"secret-info-get",
 	"secret-grant",
 	"secret-ids",
+	"secret-info-get",
 	"secret-remove",
 	"secret-revoke",
 	"secret-set",

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -81,7 +81,8 @@ Currently available charm hook tools are:
     relation-set             set relation settings
     resource-get             get the path to the locally cached resource file
     secret-add               add a new secret
-    secret-get               get the value of a secret
+    secret-get               get the content of a secret
+    secret-info-get          get a secret's metadata info
     secret-grant             grant access to a secret
     secret-ids               print secret ids
     secret-remove            remove a existing secret
@@ -140,6 +141,7 @@ var expectedCommands = []string{
 	"resource-get",
 	"secret-add",
 	"secret-get",
+	"secret-info-get",
 	"secret-grant",
 	"secret-ids",
 	"secret-remove",

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -111,10 +111,10 @@ type GetSecretContentArgs struct {
 
 // GetSecretContentArg holds the args for getting a secret value.
 type GetSecretContentArg struct {
-	URI    string `json:"uri"`
-	Label  string `json:"label,omitempty"`
-	Update bool   `json:"update,omitempty"`
-	Peek   bool   `json:"peek,omitempty"`
+	URI     string `json:"uri"`
+	Label   string `json:"label,omitempty"`
+	Refresh bool   `json:"refresh,omitempty"`
+	Peek    bool   `json:"peek,omitempty"`
 }
 
 // SecretContentResults holds secret value results.

--- a/secrets/interface.go
+++ b/secrets/interface.go
@@ -75,7 +75,7 @@ func (p *UpdateParams) Validate() error {
 
 type jujuAPIClient interface {
 	// GetContentInfo returns info about the content of a secret.
-	GetContentInfo(uri *secrets.URI, label string, update, peek bool) (*ContentParams, error)
+	GetContentInfo(uri *secrets.URI, label string, refresh, peek bool) (*ContentParams, error)
 	// GetSecretStoreConfig fetches the config needed to make a secret store client.
 	GetSecretStoreConfig() (*provider.StoreConfig, error)
 }
@@ -84,7 +84,7 @@ type jujuAPIClient interface {
 type Store interface {
 	// GetContent returns the content of a secret, either from an external store if
 	// one is configured, or from Juju.
-	GetContent(uri *secrets.URI, label string, update, peek bool) (secrets.SecretValue, error)
+	GetContent(uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error)
 
 	// SaveContent saves the content of a secret to an external store returning the provider id.
 	SaveContent(uri *secrets.URI, revision int, value secrets.SecretValue) (string, error)

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -45,8 +45,8 @@ func NewClient(jujuAPI jujuAPIClient) (*secretsClient, error) {
 }
 
 // GetContent implements Client.
-func (c *secretsClient) GetContent(uri *secrets.URI, label string, update, peek bool) (secrets.SecretValue, error) {
-	content, err := c.jujuAPI.GetContentInfo(uri, label, update, peek)
+func (c *secretsClient) GetContent(uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error) {
+	content, err := c.jujuAPI.GetContentInfo(uri, label, refresh, peek)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -30,15 +30,15 @@ run_secrets_juju() {
 	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" | grep 'owned-by: easyrsa-app'
 
 	# secret-get by URI - metadata.
-	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa_0" --metadata --format json | jq ".${secret_owned_by_easyrsa_0}.owner" | grep unit
-	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" --metadata --format json | jq ".${secret_owned_by_easyrsa}.owner" | grep application
+	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa_0" --format json | jq ".${secret_owned_by_easyrsa_0}.owner" | grep unit
+	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa}.owner" | grep application
 
 	# secret-get by label or consumer label - content.
 	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa_0 | grep 'owned-by: easyrsa/0'
 	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa-app | grep 'owned-by: easyrsa-app'
 
 	# secret-get by label - metadata.
-	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa_0 --metadata --format json | jq ".${secret_owned_by_easyrsa_0}.label" | grep easyrsa_0
+	juju exec --unit easyrsa/0 -- secret-info-get --label=easyrsa_0 --format json | jq ".${secret_owned_by_easyrsa_0}.label" | grep easyrsa_0
 
 	relation_id=$(juju --show-log show-unit easyrsa/0 --format json | jq '."easyrsa/0"."relation-info"[0]."relation-id"')
 	juju exec --unit easyrsa/0 -- secret-grant "$secret_owned_by_easyrsa_0" -r "$relation_id"

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -32,15 +32,15 @@ run_secrets_vault() {
 	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" | grep 'owned-by: easyrsa-app'
 
 	# secret-get by URI - metadata.
-	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa_0" --metadata --format json | jq ".${secret_owned_by_easyrsa_0}.owner" | grep unit
-	juju exec --unit easyrsa/0 -- secret-get "$secret_owned_by_easyrsa" --metadata --format json | jq ".${secret_owned_by_easyrsa}.owner" | grep application
+	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa_0" --format json | jq ".${secret_owned_by_easyrsa_0}.owner" | grep unit
+	juju exec --unit easyrsa/0 -- secret-info-get "$secret_owned_by_easyrsa" --format json | jq ".${secret_owned_by_easyrsa}.owner" | grep application
 
 	# secret-get by label or consumer label - content.
 	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa_0 | grep 'owned-by: easyrsa/0'
 	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa-app | grep 'owned-by: easyrsa-app'
 
 	# secret-get by label - metadata.
-	juju exec --unit easyrsa/0 -- secret-get --label=easyrsa_0 --metadata --format json | jq ".${secret_owned_by_easyrsa_0}.label" | grep easyrsa_0
+	juju exec --unit easyrsa/0 -- secret-info-get --label=easyrsa_0 --format json | jq ".${secret_owned_by_easyrsa_0}.label" | grep easyrsa_0
 
 	relation_id=$(juju --show-log show-unit easyrsa/0 --format json | jq '."easyrsa/0"."relation-info"[0]."relation-id"')
 	juju exec --unit easyrsa/0 -- secret-grant "$secret_owned_by_easyrsa_0" -r "$relation_id"

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -23,15 +23,15 @@ run_secrets() {
 	juju exec --unit hello/0 -- secret-get "$secret_owned_by_hello" | grep 'owned-by: hello-app'
 
 	# secret-get by URI - metadata.
-	juju exec --unit hello/0 -- secret-get "$secret_owned_by_hello_0" --metadata --format json | jq ".${secret_owned_by_hello_0}.owner" | grep unit
-	juju exec --unit hello/0 -- secret-get "$secret_owned_by_hello" --metadata --format json | jq ".${secret_owned_by_hello}.owner" | grep application
+	juju exec --unit hello/0 -- secret-info-get "$secret_owned_by_hello_0" --format json | jq ".${secret_owned_by_hello_0}.owner" | grep unit
+	juju exec --unit hello/0 -- secret-info-get "$secret_owned_by_hello" --format json | jq ".${secret_owned_by_hello}.owner" | grep application
 
 	# secret-get by label or consumer label - content.
 	juju exec --unit hello/0 -- secret-get --label=hello_0 | grep 'owned-by: hello/0'
 	juju exec --unit hello/0 -- secret-get --label=hello-app | grep 'owned-by: hello-app'
 
 	# secret-get by label - metadata.
-	juju exec --unit hello/0 -- secret-get --label=hello_0 --metadata --format json | jq ".${secret_owned_by_hello_0}.label" | grep hello_0
+	juju exec --unit hello/0 -- secret-info-get --label=hello_0 --format json | jq ".${secret_owned_by_hello_0}.label" | grep hello_0
 
 	juju --show-log deploy nginx-ingress-integrator nginx
 	juju --show-log integrate nginx hello

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -791,7 +791,7 @@ func (ctx *HookContext) lookupOwnedSecretURIByLabel(label string) (*coresecrets.
 }
 
 // GetSecret returns the value of the specified secret.
-func (ctx *HookContext) GetSecret(uri *coresecrets.URI, label string, update, peek bool) (coresecrets.SecretValue, error) {
+func (ctx *HookContext) GetSecret(uri *coresecrets.URI, label string, refresh, peek bool) (coresecrets.SecretValue, error) {
 	if uri == nil && label == "" {
 		return nil, errors.NotValidf("empty URI and label")
 	}
@@ -805,8 +805,8 @@ func (ctx *HookContext) GetSecret(uri *coresecrets.URI, label string, update, pe
 			if uri != nil {
 				return nil, errors.NewNotValid(nil, "either URI or label should be used for getting an owned secret but not both")
 			}
-			if update {
-				return nil, errors.NewNotValid(nil, "secret owner cannot use --update")
+			if refresh {
+				return nil, errors.NewNotValid(nil, "secret owner cannot use --refresh")
 			}
 			// Found owned secret, no need label anymore.
 			uri = ownedSecretURI
@@ -818,7 +818,7 @@ func (ctx *HookContext) GetSecret(uri *coresecrets.URI, label string, update, pe
 	if err != nil {
 		return nil, err
 	}
-	v, err := store.GetContent(uri, label, update, peek)
+	v, err := store.GetContent(uri, label, refresh, peek)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -987,10 +987,10 @@ func (s *mockHookContextSuite) TestSecretGet(c *gc.C) {
 		c.Assert(request, gc.Equals, "GetSecretContentInfo")
 		c.Assert(arg, gc.DeepEquals, params.GetSecretContentArgs{
 			Args: []params.GetSecretContentArg{{
-				URI:    uri.String(),
-				Label:  "label",
-				Update: true,
-				Peek:   true,
+				URI:     uri.String(),
+				Label:   "label",
+				Refresh: true,
+				Peek:    true,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretContentResults{})
@@ -1040,7 +1040,7 @@ func (s *mockHookContextSuite) TestSecretGetOwnedSecretFailedWithUpdate(c *gc.C)
 		}, nil, nil)
 
 	_, err := hookContext.GetSecret(nil, "label", true, false)
-	c.Assert(err, gc.ErrorMatches, `secret owner cannot use --update`)
+	c.Assert(err, gc.ErrorMatches, `secret owner cannot use --refresh`)
 }
 
 func (s *mockHookContextSuite) assertSecretGetOwnedSecretURILookup(
@@ -1070,9 +1070,9 @@ func (s *mockHookContextSuite) assertSecretGetOwnedSecretURILookup(
 		c.Assert(request, gc.Equals, "GetSecretContentInfo")
 		c.Assert(arg, gc.DeepEquals, params.GetSecretContentArgs{
 			Args: []params.GetSecretContentArg{{
-				URI:    uri.String(),
-				Update: false,
-				Peek:   false,
+				URI:     uri.String(),
+				Refresh: false,
+				Peek:    false,
 			}},
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.SecretContentResults{})

--- a/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -18,8 +18,8 @@ type ContextSecrets struct {
 }
 
 // GetSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) GetSecret(uri *secrets.URI, label string, update, peek bool) (secrets.SecretValue, error) {
-	c.stub.AddCall("GetSecret", uri.String(), label, update, peek)
+func (c *ContextSecrets) GetSecret(uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error) {
+	c.stub.AddCall("GetSecret", uri.String(), label, refresh, peek)
 	return c.SecretValue, nil
 }
 

--- a/worker/uniter/runner/jujuc/secret-info-get.go
+++ b/worker/uniter/runner/jujuc/secret-info-get.go
@@ -1,0 +1,121 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc
+
+import (
+	"time"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/core/secrets"
+)
+
+type secretInfoGetCommand struct {
+	cmd.CommandBase
+	ctx Context
+	out cmd.Output
+
+	secretUri *secrets.URI
+	label     string
+}
+
+// NewSecretInfoGetCommand returns a command to get secret metadata.
+func NewSecretInfoGetCommand(ctx Context) (cmd.Command, error) {
+	return &secretInfoGetCommand{ctx: ctx}, nil
+}
+
+// Info implements cmd.Command.
+func (c *secretInfoGetCommand) Info() *cmd.Info {
+	doc := `
+Get the metadata of a secret with a given secret ID.
+Either the ID or label can be used to identify the secret.
+
+Examples
+    secret-info-get secret:9m4e2mr0ui3e8a215n4g
+    secret-info-get --label db-password
+`
+	return jujucmd.Info(&cmd.Info{
+		Name:    "secret-info-get",
+		Args:    "<ID>",
+		Purpose: "get a secret's metadata info",
+		Doc:     doc,
+	})
+}
+
+// SetFlags implements cmd.Command.
+func (c *secretInfoGetCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.out.AddFlags(f, "yaml", map[string]cmd.Formatter{
+		"yaml": cmd.FormatYaml,
+		"json": cmd.FormatJson,
+	})
+	f.StringVar(&c.label, "label", "", "a label used to identify the secret")
+}
+
+// Init implements cmd.Command.
+func (c *secretInfoGetCommand) Init(args []string) (err error) {
+	if len(args) > 0 {
+		c.secretUri, err = secrets.ParseURI(args[0])
+		if err != nil {
+			return errors.NotValidf("secret URI %q", args[0])
+		}
+		args = args[1:]
+	}
+
+	if c.secretUri == nil && c.label == "" {
+		return errors.New("require either a secret URI or label")
+	}
+	if c.secretUri != nil && c.label != "" {
+		return errors.New("specify either a secret URI or label but not both")
+	}
+	return cmd.CheckEmpty(args)
+}
+
+type metadataDisplay struct {
+	LatestRevision   int                  `yaml:"revision" json:"revision"`
+	Label            string               `yaml:"label" json:"label"`
+	Owner            string               `yaml:"owner" json:"owner"`
+	Description      string               `yaml:"description,omitempty" json:"description,omitempty"`
+	RotatePolicy     secrets.RotatePolicy `yaml:"rotation,omitempty" json:"rotation,omitempty"`
+	LatestExpireTime *time.Time           `yaml:"expiry,omitempty" json:"expiry,omitempty"`
+	NextRotateTime   *time.Time           `yaml:"rotates,omitempty" json:"rotates,omitempty"`
+}
+
+// Run implements cmd.Command.
+func (c *secretInfoGetCommand) Run(ctx *cmd.Context) error {
+	all, err := c.ctx.SecretMetadata()
+	if err != nil {
+		return err
+	}
+	print := func(id string, md SecretMetadata) error {
+		return c.out.Write(ctx, map[string]metadataDisplay{
+			id: {
+				LatestRevision:   md.LatestRevision,
+				Label:            md.Label,
+				Owner:            md.Owner.Kind(),
+				Description:      md.Description,
+				RotatePolicy:     md.RotatePolicy,
+				LatestExpireTime: md.LatestExpireTime,
+				NextRotateTime:   md.NextRotateTime,
+			}})
+	}
+	var want string
+	if c.secretUri != nil {
+		want = c.secretUri.ID
+		if md, found := all[want]; found {
+			return print(want, md)
+		}
+
+	} else {
+		want = c.label
+		for id, md := range all {
+			if md.Label == want {
+				return print(id, md)
+			}
+		}
+	}
+	return errors.NotFoundf("secret %q", want)
+}

--- a/worker/uniter/runner/jujuc/secret-info-get_test.go
+++ b/worker/uniter/runner/jujuc/secret-info-get_test.go
@@ -1,0 +1,107 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package jujuc_test
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/cmd/v3/cmdtesting"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+type SecretInfoGetSuite struct {
+	ContextSuite
+}
+
+var _ = gc.Suite(&SecretInfoGetSuite{})
+
+func (s *SecretInfoGetSuite) TestSecretGetInit(c *gc.C) {
+
+	for _, t := range []struct {
+		args []string
+		err  string
+	}{{
+		args: []string{},
+		err:  "ERROR require either a secret URI or label",
+	}, {
+		args: []string{"secret:9m4e2mr0ui3e8a215n4g", "--label", "foo"},
+		err:  "ERROR specify either a secret URI or label but not both",
+	}} {
+		hctx, _ := s.ContextSuite.NewHookContext()
+		com, err := jujuc.NewCommand(hctx, "secret-info-get")
+		c.Assert(err, jc.ErrorIsNil)
+		ctx := cmdtesting.Context(c)
+		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
+		c.Check(code, gc.Equals, 2)
+		c.Check(bufferString(ctx.Stderr), gc.Equals, t.err+"\n")
+	}
+}
+
+func (s *SecretInfoGetSuite) TestSecretInfoGetURI(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
+	c.Assert(code, gc.Equals, 0)
+
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
+9m4e2mr0ui3e8a215n4g:
+  revision: 666
+  label: label
+  owner: application
+  description: description
+  rotation: hourly
+`[1:])
+}
+
+func (s *SecretInfoGetSuite) TestSecretInfoGetFailedNotFound(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:cd88u16ffbaql5kgmlh0"})
+	c.Assert(code, gc.Equals, 1)
+
+	c.Assert(bufferString(ctx.Stderr), gc.Matches, `ERROR secret "cd88u16ffbaql5kgmlh0" not found\n`)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, ``)
+}
+
+func (s *SecretInfoGetSuite) TestSecretInfoGetByLabelFailedNotFound(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--label", "not-found-label"})
+	c.Assert(code, gc.Equals, 1)
+
+	c.Assert(bufferString(ctx.Stderr), gc.Matches, `ERROR secret "not-found-label" not found\n`)
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, ``)
+}
+
+func (s *SecretInfoGetSuite) TestSecretInfoGetByLabel(c *gc.C) {
+	hctx, _ := s.ContextSuite.NewHookContext()
+
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
+	c.Assert(err, jc.ErrorIsNil)
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--label", "label"})
+	c.Assert(code, gc.Equals, 0)
+
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Assert(bufferString(ctx.Stdout), gc.Equals, `
+9m4e2mr0ui3e8a215n4g:
+  revision: 666
+  label: label
+  owner: application
+  description: description
+  rotation: hourly
+`[1:])
+}

--- a/worker/uniter/runner/jujuc/server.go
+++ b/worker/uniter/runner/jujuc/server.go
@@ -81,13 +81,14 @@ func constructCommandCreator(name string, newCmd functionCmdCreator) creator {
 }
 
 var secretCommands = map[string]creator{
-	"secret-add":    NewSecretAddCommand,
-	"secret-set":    NewSecretSetCommand,
-	"secret-remove": NewSecretRemoveCommand,
-	"secret-get":    NewSecretGetCommand,
-	"secret-grant":  NewSecretGrantCommand,
-	"secret-revoke": NewSecretRevokeCommand,
-	"secret-ids":    NewSecretIdsCommand,
+	"secret-add":      NewSecretAddCommand,
+	"secret-set":      NewSecretSetCommand,
+	"secret-remove":   NewSecretRemoveCommand,
+	"secret-get":      NewSecretGetCommand,
+	"secret-info-get": NewSecretInfoGetCommand,
+	"secret-grant":    NewSecretGrantCommand,
+	"secret-revoke":   NewSecretRevokeCommand,
+	"secret-ids":      NewSecretIdsCommand,
 }
 
 var storageCommands = map[string]creator{


### PR DESCRIPTION
The `--update` arg to `secret-get` is renamed to `--refresh`.

The `--metadata` option is removed and instead a new `secret-info-get` command is introduced.

Drive by - remove aks, gke, eks from inline help for add-k8s command since these are not supported with the strict snap.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju exec --unit controller/0 "secret-add --label baz foo=bar"
secret:cdq3ok0kk8o3j04m3m00
$ juju exec --unit controller/0 "secret-get secret:cdq3ok0kk8o3j04m3m00"
foo: bar
$ juju exec --unit controller/0 "secret-info-get --label baz"
cdq3ok0kk8o3j04m3m00:
  revision: 1
  label: baz
  owner: application
  rotation: never
$ juju exec --unit controller/0 "secret-info-get --label baz --format json"
{"cdq3ok0kk8o3j04m3m00":{"revision":1,"label":"baz","owner":"application","rotation":"never"}}
$ juju exec --unit controller/0 "secret-info-get secret:cdq3ok0kk8o3j04m3m00"
cdq3ok0kk8o3j04m3m00:
  revision: 1
  label: baz
  owner: application
  rotation: never

```