### PR TITLE
Fix juju introspect script to avoid grabbing unrelated directories

### DIFF
--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -46,22 +46,22 @@ juju_agent_call () {
 }
 
 juju_machine_agent_name () {
-  local machine=$(find /var/lib/juju/agents -type d -name 'machine-*' -maxdepth 1 -printf %f)
+  local machine=$(find /var/lib/juju/agents -maxdepth 1 -type d -name 'machine-*' -printf %f)
   echo $machine
 }
 
 juju_controller_agent_name () {
-  local controller=$(find /var/lib/juju/agents -type d -name 'controller-*' -maxdepth 1 -printf %f)
+  local controller=$(find /var/lib/juju/agents -maxdepth 1 -type d -name 'controller-*' -printf %f)
   echo $controller
 }
 
 juju_application_agent_name () {
-  local application=$(find /var/lib/juju/agents -type d -name 'application-*' -maxdepth 1 -printf %f)
+  local application=$(find /var/lib/juju/agents -maxdepth 1 -type d -name 'application-*' -printf %f)
   echo $application
 }
 
 juju_unit_agent_name () {
-  local unit=$(find /var/lib/juju/agents -type d -name 'unit-*' -maxdepth 1 -printf %f)
+  local unit=$(find /var/lib/juju/agents -maxdepth 1 -type d -name 'unit-*' -printf %f)
   echo $unit
 }
 

--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -46,22 +46,22 @@ juju_agent_call () {
 }
 
 juju_machine_agent_name () {
-  local machine=$(find /var/lib/juju/agents -type d -name 'machine*' -printf %f)
+  local machine=$(find /var/lib/juju/agents -type d -name 'machine-*' -maxdepth 1 -printf %f)
   echo $machine
 }
 
 juju_controller_agent_name () {
-  local controller=$(find /var/lib/juju/agents -type d -name 'controller*' -printf %f)
+  local controller=$(find /var/lib/juju/agents -type d -name 'controller-*' -maxdepth 1 -printf %f)
   echo $controller
 }
 
 juju_application_agent_name () {
-  local application=$(find /var/lib/juju/agents -type d -name 'application*' -printf %f)
+  local application=$(find /var/lib/juju/agents -type d -name 'application-*' -maxdepth 1 -printf %f)
   echo $application
 }
 
 juju_unit_agent_name () {
-  local unit=$(find /var/lib/juju/agents -type d -name 'unit*' -printf %f)
+  local unit=$(find /var/lib/juju/agents -type d -name 'unit-*' -maxdepth 1 -printf %f)
   echo $unit
 }
 


### PR DESCRIPTION
Fixes the [bitesize bug](https://bugs.launchpad.net/juju/+bug/1996637) where the juju introspection scripts grab directories that are false positives, for example the following grabs `/var/lib/juju/agents/unit-gnocchi-3/.venv/lib/python3.6/site-packages/botocore/data/machinelearning`

```bash
juju_machine_agent_name () {
  local machine=$(find /var/lib/juju/agents -type d -name 'machine*' -printf %f)
  echo $machine
}
```

This changes the `find` commands inside the scripts with 'machine-*' (i.e. adds the dash `-`) and adds `-maxdepth 1` to avoid recursing deep.

Should fix the https://bugs.launchpad.net/juju/+bug/1996637

#### QA Steps

```
 $ juju bootstrap localhost test
 $ juju deploy ubuntu
 $ juju ssh <machine-id>

 ubuntu@<container>$ cd /var/lib/juju/agents
 ubuntu@<container>$ sudo mkdir machinelearning
 ubuntu@<container>$ juju_machine_agent_name
```
