### PR TITLE
[CI] Modernising our GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,17 +32,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: Build
       run: |

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -30,19 +30,12 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
-
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+      uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -22,17 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Find required go version
-        id: go-version
-        run: |
-          set -euxo pipefail
-          echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
-        id: go
+          go-version-file: 'go.mod'
 
       - name: go get dependencies
         run: go get ./...

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -23,19 +23,12 @@ jobs:
 
     steps:
     - name: Checking out repo
-      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
-
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+      uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: setup env
       shell: bash

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,17 +46,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: setup env
       shell: bash

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -41,19 +41,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Find required go version
-      id: go-version
-      if: env.RUN_TEST == 'RUN'
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       if: env.RUN_TEST == 'RUN'
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: Build snap
       shell: bash

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,17 +37,10 @@ jobs:
             - 'tests/includes/**'
             - 'tests/suites/static_analysis/**'
 
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: Install Dependencies
       run: |
@@ -112,19 +105,11 @@ jobs:
             - 'tests/includes/**'
             - 'tests/suites/static_analysis/schema.sh'
 
-    - name: Find required go version
-      if: steps.filter.outputs.schema == 'true'
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       if: steps.filter.outputs.schema == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: Install Dependencies
       if: steps.filter.outputs.schema == 'true'

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -61,21 +61,20 @@ jobs:
         run: |
           set -euxo pipefail
           
-          echo "::set-output name=go-version::$(grep '^go ' go.mod | awk '{print $2}')"
-          echo "::set-output name=base-juju-version::$(juju version | cut -d '-' -f 1)"
+          echo "base-juju-version=$(juju version | cut -d '-' -f 1)" >> $GITHUB_OUTPUT
           upstreamJujuVersion=$(grep -r "const version =" version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')
-          echo "::set-output name=upstream-juju-version::${upstreamJujuVersion}"
+          echo "upstream-juju-version=${upstreamJujuVersion}" >> $GITHUB_OUTPUT
           currentStableChannel="$(echo $upstreamJujuVersion | cut -d'.' -f1,2)/stable"
           currentStableVersion=$(snap info juju | yq ".channels[\"$currentStableChannel\"]" | cut -d' ' -f1)
-          echo "::set-output name=current-stable-juju-version::$currentStableVersion"
-          echo "::set-output name=juju-db-version::4.0"
+          echo "current-stable-juju-version=$currentStableVersion" >> $GITHUB_OUTPUT
+          echo "juju-db-version=4.0" >> $GITHUB_OUTPUT
         id: vars
 
       - name: Set up Go
         if: env.RUN_TEST == 'RUN'
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.vars.outputs.go-version }}
+          go-version-file: 'go.mod'
 
       - name: setup env
         shell: bash


### PR DESCRIPTION
- replace deprecated `set-output` with $GITHUB-OUTPUT
- use `go-version-file` option in actions/setup-go
- update actions/checkout and actions/setup-go