### PR TITLE
[CI] update balchua/microk8s-actions to v0.3.1

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -43,7 +43,7 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-    - uses: balchua/microk8s-actions@98f481ca6bad1cdca5185008b9572a3102d46af3 # v0.2.2
+    - uses: balchua/microk8s-actions@v0.3.1
       with:
         channel: '${{ matrix.microk8s }}'
         # enable now to give microk8s more time to settle down.

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Setup k8s
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
-        uses: balchua/microk8s-actions@v0.2.2
+        uses: balchua/microk8s-actions@v0.3.1
         with:
           channel: "1.23/stable"
           addons: '["dns", "storage"]'


### PR DESCRIPTION
As per title.

This version should support strictly confined microk8s, so when this patch merges through to 3.0, we can move back to using this action.

## QA steps

Check that the Upgrade / microk8s tests pass below.