### PR TITLE
Merge 2.9 into 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,17 +32,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: Build
       run: |

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -29,19 +29,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
-
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+      uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -22,17 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Find required go version
-        id: go-version
-        run: |
-          set -euxo pipefail
-          echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
-        id: go
+          go-version-file: 'go.mod'
 
       - name: go get dependencies
         run: go get ./...

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -23,19 +23,12 @@ jobs:
 
     steps:
     - name: Checking out repo
-      uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
-
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
+      uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v3
+      uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: setup env
       shell: bash
@@ -43,7 +36,7 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-    - uses: balchua/microk8s-actions@d346061adaf14b4b113aad2ba1d6e3c5da408ef8 # v0.3.0
+    - uses: balchua/microk8s-actions@v0.3.1
       with:
         channel: '${{ matrix.microk8s }}'
         # enable now to give microk8s more time to settle down.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -47,17 +47,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: setup env
       shell: bash

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -41,19 +41,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Find required go version
-      id: go-version
-      if: env.RUN_TEST == 'RUN'
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       if: env.RUN_TEST == 'RUN'
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: Build snap
       shell: bash

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,17 +37,10 @@ jobs:
             - 'tests/includes/**'
             - 'tests/suites/static_analysis/**'
 
-    - name: Find required go version
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: Install Dependencies
       run: |
@@ -111,19 +104,11 @@ jobs:
             - 'tests/includes/**'
             - 'tests/suites/static_analysis/schema.sh'
 
-    - name: Find required go version
-      if: steps.filter.outputs.schema == 'true'
-      id: go-version
-      run: |
-        set -euxo pipefail
-        echo "::set-output name=version::$(grep '^go ' go.mod | awk '{print $2}')"
-
     - name: Set up Go
       if: steps.filter.outputs.schema == 'true'
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.go-version.outputs.version }}
-      id: go
+        go-version-file: 'go.mod'
 
     - name: Install Dependencies
       if: steps.filter.outputs.schema == 'true'

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -93,8 +93,8 @@ jobs:
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
         uses: balchua/microk8s-actions@v0.3.1
         with:
-          channel: "1.23/stable"
-          addons: '["dns", "storage"]'
+          channel: "1.25-strict/stable"
+          addons: '["dns", "hostpath-storage"]'
 
       - name: Setup local caas registry
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -52,7 +52,6 @@ jobs:
         run: |
           set -euxo pipefail
           
-          echo "go-version=$(grep '^go ' go.mod | awk '{print $2}')" >> $GITHUB_OUTPUT
           echo "base-juju-version=$(juju version | cut -d '-' -f 1)" >> $GITHUB_OUTPUT
           upstreamJujuVersion=$(grep -r "const version =" version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')
           echo "upstream-juju-version=${upstreamJujuVersion}" >> $GITHUB_OUTPUT
@@ -66,7 +65,7 @@ jobs:
         if: env.RUN_TEST == 'RUN'
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.vars.outputs.go-version }}
+          go-version-file: 'go.mod'
 
       - name: setup env
         shell: bash
@@ -92,14 +91,10 @@ jobs:
 
       - name: Setup k8s
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'
-        shell: bash
-        run: |
-          set -x
-          sudo snap install microk8s --channel=1.25-strict/stable
-          sudo usermod -a -G snap_microk8s $USER
-          newgrp snap_microk8s
-          sg snap_microk8s "microk8s status --wait-ready"
-          sudo microk8s enable dns hostpath-storage
+        uses: balchua/microk8s-actions@v0.3.1
+        with:
+          channel: "1.23/stable"
+          addons: '["dns", "storage"]'
 
       - name: Setup local caas registry
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'microk8s'

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -511,11 +511,15 @@ func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
 
 	for _, r := range relations {
 		provider := strings.Split(r.Provider, ":")
-		w.PrintNoTab(provider[0])                                                       //the service name (mysql)
-		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", provider[1])) //the resource type (:cluster)
+		w.PrintNoTab(provider[0]) //the service name (mysql)
+		if len(provider) > 1 {
+			w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", provider[1])) //the resource type (:cluster)
+		}
 		requirer := strings.Split(r.Requirer, ":")
-		w.PrintNoTab(requirer[0])                                                       //the service name (mysql)
-		w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", requirer[1])) //the resource type (:cluster)
+		w.PrintNoTab(requirer[0]) //the service name (mysql)
+		if len(requirer) > 1 {
+			w.PrintColor(output.EmphasisHighlight.Magenta, fmt.Sprintf(":%s", requirer[1])) //the resource type (:cluster)
+		}
 		w.Print(r.Interface, r.Type)
 		if r.Status != string(relation.Joined) {
 			w.PrintColor(cmdcrossmodel.RelationStatusColor(relation.Status(r.Status)), r.Status)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5541,6 +5541,123 @@ foo/0  waiting   allocating  10.0.0.1  80,1555-1559/TCP
 `[1:])
 }
 
+func (s *StatusSuite) TestFormatTabularTruncateMessage(c *gc.C) {
+	longMessage := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+	longMeterStatus := meterStatus{
+		Color:   "blue",
+		Message: longMessage,
+	}
+	longStatusInfo := statusInfoContents{
+		Current: status.Active,
+		Message: longMessage,
+	}
+
+	status := formattedStatus{
+		Model: modelStatus{
+			Name:        "m",
+			Controller:  "c",
+			Cloud:       "localhost",
+			Version:     "3.0.0",
+			Status:      longStatusInfo,
+			MeterStatus: &longMeterStatus,
+		},
+		Applications: map[string]applicationStatus{
+			"foo": {
+				CharmName:    "foo",
+				CharmChannel: "latest/stable",
+				StatusInfo:   longStatusInfo,
+				Units: map[string]unitStatus{
+					"foo/0": {
+						WorkloadStatusInfo: longStatusInfo,
+						JujuStatusInfo:     longStatusInfo,
+						Machine:            "0",
+						PublicAddress:      "10.53.62.100",
+						MeterStatus:        &longMeterStatus,
+						Subordinates: map[string]unitStatus{
+							"foo/1": {
+								WorkloadStatusInfo: longStatusInfo,
+								JujuStatusInfo:     longStatusInfo,
+								Machine:            "0/lxd/0",
+								PublicAddress:      "10.53.62.101",
+								MeterStatus:        &longMeterStatus,
+							},
+						},
+					},
+				},
+			},
+		},
+		RemoteApplications: map[string]remoteApplicationStatus{
+			"bar": {
+				OfferURL:   "model.io/bar",
+				StatusInfo: longStatusInfo,
+			},
+		},
+		Machines: map[string]machineStatus{
+			"0": {
+				Id:      "0",
+				DNSName: "10.53.62.100",
+				Base: &formattedBase{
+					Name:    "ubuntu",
+					Channel: "22.04",
+				},
+				JujuStatus:         longStatusInfo,
+				MachineStatus:      longStatusInfo,
+				ModificationStatus: longStatusInfo,
+				Containers: map[string]machineStatus{
+					"0": {
+						Id:      "0/lxd/0",
+						DNSName: "10.53.62.101",
+						Base: &formattedBase{
+							Name:    "ubuntu",
+							Channel: "22.04",
+						},
+						JujuStatus:         longStatusInfo,
+						MachineStatus:      longStatusInfo,
+						ModificationStatus: longStatusInfo,
+					},
+				},
+			},
+		},
+		Relations: []relationStatus{
+			{
+				Provider:  "foo:cluster",
+				Requirer:  "bar:cluster",
+				Interface: "baz",
+				Message:   longMessage,
+			},
+		},
+	}
+
+	out := &bytes.Buffer{}
+	err := FormatTabular(out, false, status)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.String(), gc.Equals, `
+Model  Controller  Cloud/Region  Version  Notes
+m      c           localhost     3.0.0    Lorem ipsum dolor sit amet, consectetur adipisc...
+
+SAAS  Status  Store    URL
+bar   active  unknown  model.io/bar
+
+App  Version  Status  Scale  Charm  Channel        Rev  Exposed  Message
+foo           active    0/1  foo    latest/stable    0  no       Lorem ipsum dolor sit amet, consectetur adipisc...
+
+Unit     Workload  Agent   Machine  Public address  Ports  Message
+foo/0    active    active  0        10.53.62.100           Lorem ipsum dolor sit amet, consectetur adipisc...
+  foo/1  active    active  0/lxd/0  10.53.62.101           Lorem ipsum dolor sit amet, consectetur adipisc...
+
+Entity  Meter status  Message
+model   blue          Lorem ipsum dolor sit amet, consectetur adipisc...  
+foo/0   blue          Lorem ipsum dolor sit amet, consectetur adipisc...  
+
+Machine  State   Address       Inst id  Base          AZ  Message
+0        active  10.53.62.100           ubuntu@22.04      Lorem ipsum dolor sit amet, consectetur adipisc...
+0/lxd/0  active  10.53.62.101           ubuntu@22.04      Lorem ipsum dolor sit amet, consectetur adipisc...
+
+Relation provider  Requirer     Interface  Type  Message
+foo:cluster        bar:cluster  baz                Lorem ipsum dolor sit amet, consectetur adipisc...
+`[1:])
+}
+
 func (s *StatusSuite) TestStatusWithNilStatusAPI(c *gc.C) {
 	ctx := s.newContext(c)
 	defer s.resetContext(c, ctx)


### PR DESCRIPTION
- #14883 
- #14884
- #14887
- #14867
- #14889 
- #14890 

Conflicts around status changes and GitHub Actions.

Also added a defensive check in the status formatter. When we call `strings.Split`, we should check the output length to avoid a possible panic.