### PR TITLE
[JUJU-2170] Fixed juju run action command for coslite test in 3.0

### DIFF
--- a/tests/suites/coslite/cl.sh
+++ b/tests/suites/coslite/cl.sh
@@ -14,7 +14,7 @@ run_deploy_coslite() {
 	wait_for 0 "$(not_idle_list) | length" 1800
 
 	# run-action will change in 3.0
-	admin_passwd=$(juju run-action --wait grafana/0 get-admin-password --format json | jq '.["unit-grafana-0"]["results"]["admin-password"]')
+	admin_passwd=$(juju run grafana/0 get-admin-password --wait=2m --format json | jq '.["unit-grafana-0"]["results"]["admin-password"]')
 	if [ -z "$admin_passwd" ]; then
 		echo "expected to get admin password for grafana/0"
 		exit 1


### PR DESCRIPTION
This PR changes `juju run-action` to `juju run` in coslite test (juju 3.0).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p k8s -c microk8s coslite
```
