### PR TITLE
[JUJU-2196] Add support for replacing a controller for juju register

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 	jujuhttp "github.com/juju/http/v2"
 	"github.com/juju/names/v4"
 	"golang.org/x/crypto/nacl/secretbox"
@@ -62,7 +63,9 @@ type registerCommand struct {
 	apiOpen        api.OpenFunc
 	listModelsFunc func(_ jujuclient.ClientStore, controller, user string) ([]base.UserModel, error)
 	store          jujuclient.ClientStore
-	Arg            string
+
+	arg     string
+	replace bool
 
 	// onRunError is executed if non-nil if there is an error at the end
 	// of the Run method.
@@ -87,6 +90,11 @@ can now either add a model or wait for a model to be shared with them.
 Some machine providers will require the user to be in possession of
 certain credentials in order to add a model.
 
+If a new controller has been spun up to replace an existing one, and you want 
+to start using that replacement controller instead of the original one,
+use the --replace option to overwrite any existing controller details based
+on either a name or UUID match.
+
 When adding a controller at a public address, authentication via some
 external third party (for example Ubuntu SSO) will be required, usually
 by using a web browser.
@@ -94,6 +102,8 @@ by using a web browser.
 Examples:
 
     juju register MFATA3JvZDAnExMxMDQuMTU0LjQyLjQ0OjE3MDcwExAxMC4xMjguMC4yOjE3MDcwBCBEFCaXerhNImkKKabuX5ULWf2Bp4AzPNJEbXVWgraLrAA=
+
+    juju register --replace MFATA3JvZDAnExMxMDQuMTU0LjQyLjQ0OjE3MDcwExAxMC4xMjguMC4yOjE3MDcwBCBEFCaXerhNImkKKabuX5ULWf2Bp4AzPNJEbXVWgraLrAA=
 
     juju register public-controller.example.com
 
@@ -114,12 +124,18 @@ func (c *registerCommand) Info() *cmd.Info {
 	})
 }
 
-// SetFlags implements Command.Init.
+// SetFlags implements Command.SetFlags.
+func (c *registerCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.BoolVar(&c.replace, "replace", false, "replace any existing controller")
+}
+
+// Init implements Command.Init.
 func (c *registerCommand) Init(args []string) error {
 	if len(args) < 1 {
 		return errors.New("registration data missing")
 	}
-	c.Arg, args = args[0], args[1:]
+	c.arg, args = args[0], args[1:]
 	if err := cmd.CheckEmpty(args); err != nil {
 		return errors.Trace(err)
 	}
@@ -164,7 +180,6 @@ func (c *registerCommand) run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	if err := c.updateController(
-		ctx,
 		c.store,
 		controllerName,
 		controllerDetails,
@@ -336,7 +351,6 @@ func (c *registerCommand) nonPublicControllerDetails(ctx *cmd.Context, registrat
 // updateController prompts for a controller name and updates the
 // controller and account details in the given client store.
 func (c *registerCommand) updateController(
-	ctx *cmd.Context,
 	store jujuclient.ClientStore,
 	controllerName string,
 	controllerDetails jujuclient.ControllerDetails,
@@ -350,11 +364,25 @@ func (c *registerCommand) updateController(
 	}
 	for name, ctl := range all {
 		if ctl.ControllerUUID == controllerDetails.ControllerUUID {
-			return genAlreadyRegisteredError(name, accountDetails.User)
+			if !c.replace || controllerName != name {
+				return genAlreadyRegisteredError(name, accountDetails.User)
+			}
+			break
 		}
 	}
-	if err := store.AddController(controllerName, controllerDetails); err != nil {
-		return errors.Trace(err)
+	if c.replace {
+		if err := store.UpdateController(controllerName, controllerDetails); err != nil {
+			if !errors.IsNotFound(err) {
+				return errors.Trace(err)
+			}
+			if err := store.AddController(controllerName, controllerDetails); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	} else {
+		if err := store.AddController(controllerName, controllerDetails); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	if err := store.UpdateAccount(controllerName, accountDetails); err != nil {
 		return errors.Annotatef(err, "cannot update account information: %v", err)
@@ -434,19 +462,19 @@ type registrationParams struct {
 // the user as necessary.
 func (c *registerCommand) getParameters(ctx *cmd.Context) (*registrationParams, error) {
 	var params registrationParams
-	if strings.Contains(c.Arg, ".") || c.Arg == "localhost" {
+	if strings.Contains(c.arg, ".") || c.arg == "localhost" {
 		// Looks like a host name - no URL-encoded base64 string should
 		// contain a dot and every public controller name should.
 		// Allow localhost for development purposes.
-		params.publicHost = c.Arg
+		params.publicHost = c.arg
 		// No need for password shenanigans if we're using a public controller.
 		return &params, nil
 	}
 	// Decode key, username, controller addresses from the string supplied
 	// on the command line.
-	decodedData, err := base64.URLEncoding.DecodeString(c.Arg)
+	decodedData, err := base64.URLEncoding.DecodeString(c.arg)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "invalid registration token")
 	}
 	var info jujuclient.RegistrationInfo
 	if _, err := asn1.Unmarshal(decodedData, &info); err != nil {
@@ -563,7 +591,7 @@ func (c *registerCommand) promptNewPassword(stderr io.Writer, stdin io.Reader) (
 
 func (c *registerCommand) promptControllerName(suggestedName string, stderr io.Writer, stdin io.Reader) (string, error) {
 	if suggestedName != "" {
-		if _, err := c.store.ControllerByName(suggestedName); err == nil {
+		if _, err := c.store.ControllerByName(suggestedName); err == nil && !c.replace {
 			suggestedName = ""
 		}
 	}
@@ -571,7 +599,11 @@ func (c *registerCommand) promptControllerName(suggestedName string, stderr io.W
 		var setMsg string
 		setMsg = "Enter a name for this controller: "
 		if suggestedName != "" {
-			setMsg = fmt.Sprintf("Enter a name for this controller [%s]: ", suggestedName)
+			replace := ""
+			if c.replace {
+				replace = "replace "
+			}
+			setMsg = fmt.Sprintf("Enter a name for this controller [%s%s]: ", replace, suggestedName)
 		}
 		fmt.Fprintf(stderr, setMsg)
 		name, err := c.readLine(stdin)
@@ -587,7 +619,7 @@ func (c *registerCommand) promptControllerName(suggestedName string, stderr io.W
 			name = suggestedName
 		}
 		_, err = c.store.ControllerByName(name)
-		if err == nil {
+		if err == nil && !c.replace {
 			fmt.Fprintf(stderr, "Controller %q already exists.\n", name)
 			continue
 		}


### PR DESCRIPTION
This PR adds support for the scenario where a controller has been "cloned" into a replacement (eg to upgrade from 2.9->3.x), and we want to allow users to access the replacement controller. The `juju register` command gains a `--replace` option. This will update any existing named controller with the new IP address and other connection details. The user still has the option to choose a new name if they want so that both controllers are accessible.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

bootstrap a controller 
add a user
have that user run juju register
bootstrap a second controller
add the same user to the new controller
generate a replacement register string for the user `juju change-user-password <user> --reset`
have that user run juju register with the --replace option and choose the same controller name as before
see that the user now connects to the new controller
