### PR TITLE
[JUJU-2197] Backport sidecar affinity support

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,7 +29,6 @@ jobs:
       run: |
         set -euxo pipefail
         
-        sudo apt-get remove lxd lxd-client
         if snap info lxd | grep "installed"; then
           sudo snap refresh lxd --channel=latest/stable
         else

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -26,7 +26,6 @@ jobs:
         set -euxo pipefail
         sudo snap install snapcraft --classic
         
-        sudo apt-get remove lxd lxd-client
         if snap info lxd | grep "installed"; then
           sudo snap refresh lxd --channel=latest/stable
         else

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -40,7 +40,6 @@ jobs:
           sudo snap install yq
           sudo snap install juju --classic --channel=${{ matrix.snap_version }}
           
-          sudo apt-get remove lxd lxd-client
           if snap info lxd | grep "installed"; then
             sudo snap remove lxd --purge
           fi

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -421,7 +421,7 @@ func (s *applicationSuite) assertDelete(c *gc.C, app caas.Application) {
 	c.Assert(statefulSets.Items, gc.IsNil)
 }
 
-func getPodSpec(c *gc.C) corev1.PodSpec {
+func getPodSpec() corev1.PodSpec {
 	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 	return corev1.PodSpec{
 		ServiceAccountName:            "gitlab",
@@ -755,7 +755,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
 							Annotations: map[string]string{"juju.is/version": "1.1.1"},
 						},
-						Spec: getPodSpec(c),
+						Spec: getPodSpec(),
 					},
 					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 						{
@@ -808,7 +808,7 @@ func (s *applicationSuite) TestEnsureUntrusted(c *gc.C) {
 func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 
-	podSpec := getPodSpec(c)
+	podSpec := getPodSpec()
 	podSpec.ImagePullSecrets = append(
 		[]corev1.LocalObjectReference{
 			{Name: constants.CAASImageRepoSecretName},
@@ -934,7 +934,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 				},
 			})
 
-			podSpec := getPodSpec(c)
+			podSpec := getPodSpec()
 			podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 				Name: "gitlab-database-appuuid",
 				VolumeSource: corev1.VolumeSource{
@@ -1007,7 +1007,7 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 				},
 			})
 
-			podSpec := getPodSpec(c)
+			podSpec := getPodSpec()
 			podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 				Name: "gitlab-database-appuuid",
 				VolumeSource: corev1.VolumeSource{
@@ -1965,7 +1965,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 
 	for i := 0; i < 9; i++ {
-		podSpec := getPodSpec(c)
+		podSpec := getPodSpec()
 		podSpec.Volumes = append(podSpec.Volumes,
 			corev1.Volume{
 				Name: "gitlab-database-appuuid",
@@ -2697,7 +2697,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 				},
 			})
 
-			ps := getPodSpec(c)
+			ps := getPodSpec()
 			ps.NodeSelector = map[string]string{
 				"kubernetes.io/arch": "arm64",
 			}

--- a/caas/kubernetes/provider/application/constraints.go
+++ b/caas/kubernetes/provider/application/constraints.go
@@ -1,0 +1,296 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/v3/arch"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/core/constraints"
+)
+
+// ConstraintApplier defines the function type for configuring constraint for a pod.
+type ConstraintApplier func(pod *core.PodSpec, resourceName core.ResourceName, value string) error
+
+// ApplyConstraints applies the specified constraints to the pod.
+func ApplyConstraints(pod *core.PodSpec, appName string, cons constraints.Value, configureConstraint ConstraintApplier) error {
+	// TODO(allow resource limits to be applied to each container).
+	// For now we only do resource requests, one container is sufficient for
+	// scheduling purposes.
+	if mem := cons.Mem; mem != nil {
+		if err := configureConstraint(pod, core.ResourceMemory, fmt.Sprintf("%dMi", *mem)); err != nil {
+			return errors.Annotatef(err, "configuring memory constraint for %s", appName)
+		}
+	}
+	if cpu := cons.CpuPower; cpu != nil {
+		if err := configureConstraint(pod, core.ResourceCPU, fmt.Sprintf("%dm", *cpu)); err != nil {
+			return errors.Annotatef(err, "configuring cpu constraint for %s", appName)
+		}
+	}
+	nodeSelector := map[string]string(nil)
+	if cons.HasArch() {
+		cpuArch := *cons.Arch
+		cpuArch = arch.NormaliseArch(cpuArch)
+		// Convert to Golang arch string
+		switch cpuArch {
+		case arch.AMD64:
+			cpuArch = "amd64"
+		case arch.ARM64:
+			cpuArch = "arm64"
+		case arch.PPC64EL:
+			cpuArch = "ppc64le"
+		case arch.S390X:
+			cpuArch = "s390x"
+		default:
+			return errors.NotSupportedf("architecture %q", cpuArch)
+		}
+		nodeSelector = map[string]string{"kubernetes.io/arch": cpuArch}
+	}
+	if pod.NodeSelector != nil {
+		for k, v := range nodeSelector {
+			pod.NodeSelector[k] = v
+		}
+	} else if nodeSelector != nil {
+		pod.NodeSelector = nodeSelector
+	}
+
+	// Translate tags to pod or node affinity.
+	// Tag names are prefixed with "pod.", "anti-pod.", or "node."
+	// with the default being "node".
+	// The tag 'topology-key', if set, is used for the affinity topology key value.
+	if cons.Tags != nil {
+		affinityLabels := make(map[string]string)
+		for _, labelPair := range *cons.Tags {
+			parts := strings.Split(labelPair, "=")
+			if len(parts) != 2 {
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
+			}
+			key := strings.Trim(parts[0], " ")
+			value := strings.Trim(parts[1], " ")
+			affinityLabels[key] = value
+		}
+
+		if err := processNodeAffinity(pod, affinityLabels); err != nil {
+			return errors.Annotatef(err, "configuring node affinity for %s", appName)
+		}
+		if err := processPodAffinity(pod, affinityLabels); err != nil {
+			return errors.Annotatef(err, "configuring pod affinity for %s", appName)
+		}
+	}
+	if cons.Zones != nil {
+		zones := *cons.Zones
+		affinity := pod.Affinity
+		if affinity == nil {
+			affinity = &core.Affinity{
+				NodeAffinity: &core.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+						NodeSelectorTerms: []core.NodeSelectorTerm{{}},
+					},
+				},
+			}
+			pod.Affinity = affinity
+		}
+		selector := &affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+		selector.MatchExpressions = append(selector.MatchExpressions,
+			core.NodeSelectorRequirement{
+				Key:      "failure-domain.beta.kubernetes.io/zone",
+				Operator: core.NodeSelectorOpIn,
+				Values:   zones,
+			})
+	}
+	return nil
+}
+
+const (
+	podPrefix      = "pod."
+	antiPodPrefix  = "anti-pod."
+	topologyKeyTag = "topology-key"
+	nodePrefix     = "node."
+)
+
+func processNodeAffinity(pod *core.PodSpec, affinityLabels map[string]string) error {
+	affinityTags := make(map[string]string)
+	for key, value := range affinityLabels {
+		keyVal := key
+		if strings.HasPrefix(key, "^") {
+			if len(key) == 1 {
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
+			}
+			key = key[1:]
+		}
+		if strings.HasPrefix(key, podPrefix) || strings.HasPrefix(key, antiPodPrefix) {
+			continue
+		}
+		key = strings.TrimPrefix(keyVal, nodePrefix)
+		affinityTags[key] = value
+	}
+
+	updateSelectorTerms := func(nodeSelectorTerm *core.NodeSelectorTerm, tags map[string]string) {
+		// Sort for stable ordering.
+		var keys []string
+		for k := range tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, tag := range keys {
+			allValues := strings.Split(tags[tag], "|")
+			for i, v := range allValues {
+				allValues[i] = strings.Trim(v, " ")
+			}
+			op := core.NodeSelectorOpIn
+			if strings.HasPrefix(tag, "^") {
+				tag = tag[1:]
+				op = core.NodeSelectorOpNotIn
+			}
+			nodeSelectorTerm.MatchExpressions = append(nodeSelectorTerm.MatchExpressions, core.NodeSelectorRequirement{
+				Key:      tag,
+				Operator: op,
+				Values:   allValues,
+			})
+		}
+	}
+	var nodeSelectorTerm core.NodeSelectorTerm
+	updateSelectorTerms(&nodeSelectorTerm, affinityTags)
+	if pod.Affinity == nil {
+		pod.Affinity = &core.Affinity{}
+	}
+	pod.Affinity.NodeAffinity = &core.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+			NodeSelectorTerms: []core.NodeSelectorTerm{nodeSelectorTerm},
+		},
+	}
+	return nil
+}
+
+func processPodAffinity(pod *core.PodSpec, affinityLabels map[string]string) error {
+	affinityTags := make(map[string]string)
+	antiAffinityTags := make(map[string]string)
+	for key, value := range affinityLabels {
+		notVal := false
+		if strings.HasPrefix(key, "^") {
+			if len(key) == 1 {
+				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
+			}
+			notVal = true
+			key = key[1:]
+		}
+		if !strings.HasPrefix(key, podPrefix) && !strings.HasPrefix(key, antiPodPrefix) {
+			continue
+		}
+		if strings.HasPrefix(key, podPrefix) {
+			key = strings.TrimPrefix(key, podPrefix)
+			if notVal {
+				key = "^" + key
+			}
+			affinityTags[key] = value
+		}
+		if strings.HasPrefix(key, antiPodPrefix) {
+			key = strings.TrimPrefix(key, antiPodPrefix)
+			if notVal {
+				key = "^" + key
+			}
+			antiAffinityTags[key] = value
+		}
+	}
+	if len(affinityTags) == 0 && len(antiAffinityTags) == 0 {
+		return nil
+	}
+
+	updateAffinityTerm := func(affinityTerm *core.PodAffinityTerm, tags map[string]string) {
+		// Sort for stable ordering.
+		var keys []string
+		for k := range tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var (
+			labelSelector v1.LabelSelector
+			topologyKey   string
+		)
+		for _, tag := range keys {
+			if tag == topologyKeyTag {
+				topologyKey = tags[tag]
+				continue
+			}
+			allValues := strings.Split(tags[tag], "|")
+			for i, v := range allValues {
+				allValues[i] = strings.Trim(v, " ")
+			}
+			op := v1.LabelSelectorOpIn
+			if strings.HasPrefix(tag, "^") {
+				tag = tag[1:]
+				op = v1.LabelSelectorOpNotIn
+			}
+			labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, v1.LabelSelectorRequirement{
+				Key:      tag,
+				Operator: op,
+				Values:   allValues,
+			})
+		}
+		affinityTerm.LabelSelector = &labelSelector
+		if topologyKey != "" {
+			affinityTerm.TopologyKey = topologyKey
+		}
+	}
+	if pod.Affinity == nil {
+		pod.Affinity = &core.Affinity{}
+	}
+	var affinityTerm core.PodAffinityTerm
+	updateAffinityTerm(&affinityTerm, affinityTags)
+	if len(affinityTerm.LabelSelector.MatchExpressions) > 0 {
+		pod.Affinity.PodAffinity = &core.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{affinityTerm},
+		}
+	}
+
+	var antiAffinityTerm core.PodAffinityTerm
+	updateAffinityTerm(&antiAffinityTerm, antiAffinityTags)
+	if len(antiAffinityTerm.LabelSelector.MatchExpressions) > 0 {
+		pod.Affinity.PodAntiAffinity = &core.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{antiAffinityTerm},
+		}
+	}
+	return nil
+}
+
+// ConfigureConstraint configures the requests and limits for the resource.
+func ConfigureConstraint(pod *core.PodSpec, resourceName core.ResourceName, value string) (err error) {
+	if len(pod.Containers) == 0 {
+		return nil
+	}
+	pod.Containers[0].Resources.Requests, err = MergeConstraint(resourceName, value, pod.Containers[0].Resources.Requests)
+	if err != nil {
+		return errors.Annotatef(err, "merging request constraint %s=%s", resourceName, value)
+	}
+	for i := range pod.Containers {
+		pod.Containers[i].Resources.Limits, err = MergeConstraint(resourceName, value, pod.Containers[i].Resources.Limits)
+		if err != nil {
+			return errors.Annotatef(err, "merging limit constraint %s=%s", resourceName, value)
+		}
+	}
+	return nil
+}
+
+// MergeConstraint merges constraint spec.
+func MergeConstraint(resourceName core.ResourceName, value string, resourcesList core.ResourceList) (core.ResourceList, error) {
+	if resourcesList == nil {
+		resourcesList = core.ResourceList{}
+	}
+	if v, ok := resourcesList[resourceName]; ok {
+		return nil, errors.NotValidf("resource list for %q has already been set to %v", resourceName, v)
+	}
+	parsedValue, err := resource.ParseQuantity(value)
+	if err != nil {
+		return nil, errors.Annotatef(err, "invalid constraint value %q for %q", value, resourceName)
+	}
+	resourcesList[resourceName] = parsedValue
+	return resourcesList, nil
+}

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/agent"
 	agenttools "github.com/juju/juju/agent/tools"
 	"github.com/juju/juju/caas"
+	k8sapplication "github.com/juju/juju/caas/kubernetes/provider/application"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sproxy "github.com/juju/juju/caas/kubernetes/provider/proxy"
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
@@ -894,7 +895,8 @@ func (c *controllerStack) createControllerStatefulset() error {
 		return errors.Trace(err)
 	}
 
-	if err := processConstraints(&spec.Spec.Template.Spec, c.stackName, c.pcfg.Bootstrap.BootstrapMachineConstraints); err != nil {
+	if err := k8sapplication.ApplyConstraints(
+		&spec.Spec.Template.Spec, c.stackName, c.pcfg.Bootstrap.BootstrapMachineConstraints, k8sapplication.ConfigureConstraint); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -650,6 +650,9 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 				TimeoutSeconds:      5,
 			},
 			Resources: core.ResourceRequirements{
+				Requests: core.ResourceList{
+					core.ResourceMemory: resource.MustParse("4000Mi"),
+				},
 				Limits: core.ResourceList{
 					core.ResourceMemory: resource.MustParse("4000Mi"),
 				},

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -41,6 +40,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
+	k8sapplication "github.com/juju/juju/caas/kubernetes/provider/application"
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	k8sspecs "github.com/juju/juju/caas/kubernetes/provider/specs"
@@ -52,7 +52,6 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/assumes"
 	coreconfig "github.com/juju/juju/core/config"
-	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/paths"
 	coreresources "github.com/juju/juju/core/resources"
@@ -811,244 +810,6 @@ func (k *kubernetesClient) DeleteService(appName string) (err error) {
 	return nil
 }
 
-func processConstraints(pod *core.PodSpec, appName string, cons constraints.Value) error {
-	// TODO(caas): Allow constraints to be set at the container level.
-	if mem := cons.Mem; mem != nil {
-		if err := configureConstraint(pod, "memory", fmt.Sprintf("%dMi", *mem)); err != nil {
-			return errors.Annotatef(err, "configuring memory constraint for %s", appName)
-		}
-	}
-	if cpu := cons.CpuPower; cpu != nil {
-		if err := configureConstraint(pod, "cpu", fmt.Sprintf("%dm", *cpu)); err != nil {
-			return errors.Annotatef(err, "configuring cpu constraint for %s", appName)
-		}
-	}
-	nodeSelector := map[string]string(nil)
-	if cons.HasArch() {
-		cpuArch := *cons.Arch
-		cpuArch = arch.NormaliseArch(cpuArch)
-		// Convert to Golang arch string
-		switch cpuArch {
-		case arch.AMD64:
-			cpuArch = "amd64"
-		case arch.ARM64:
-			cpuArch = "arm64"
-		case arch.PPC64EL:
-			cpuArch = "ppc64le"
-		case arch.S390X:
-			cpuArch = "s390x"
-		default:
-			return errors.NotSupportedf("architecture %q", cpuArch)
-		}
-		nodeSelector = map[string]string{"kubernetes.io/arch": cpuArch}
-	}
-	if pod.NodeSelector != nil {
-		for k, v := range nodeSelector {
-			pod.NodeSelector[k] = v
-		}
-	} else if nodeSelector != nil {
-		pod.NodeSelector = nodeSelector
-	}
-
-	// Translate tags to pod or node affinity.
-	// Tag names are prefixed with "pod.", "anti-pod.", or "node."
-	// with the default being "node".
-	// The tag 'topology-key', if set, is used for the affinity topology key value.
-	if cons.Tags != nil {
-		affinityLabels := make(map[string]string)
-		for _, labelPair := range *cons.Tags {
-			parts := strings.Split(labelPair, "=")
-			if len(parts) != 2 {
-				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
-			}
-			key := strings.Trim(parts[0], " ")
-			value := strings.Trim(parts[1], " ")
-			affinityLabels[key] = value
-		}
-
-		if err := processNodeAffinity(pod, affinityLabels); err != nil {
-			return errors.Annotatef(err, "configuring node affinity for %s", appName)
-		}
-		if err := processPodAffinity(pod, affinityLabels); err != nil {
-			return errors.Annotatef(err, "configuring pod affinity for %s", appName)
-		}
-	}
-	if cons.Zones != nil {
-		zones := *cons.Zones
-		affinity := pod.Affinity
-		if affinity == nil {
-			affinity = &core.Affinity{
-				NodeAffinity: &core.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
-						NodeSelectorTerms: []core.NodeSelectorTerm{{}},
-					},
-				},
-			}
-			pod.Affinity = affinity
-		}
-		nodeSelector := &affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
-		nodeSelector.MatchExpressions = append(nodeSelector.MatchExpressions,
-			core.NodeSelectorRequirement{
-				Key:      "failure-domain.beta.kubernetes.io/zone",
-				Operator: core.NodeSelectorOpIn,
-				Values:   zones,
-			})
-	}
-	return nil
-}
-
-const (
-	podPrefix      = "pod."
-	antiPodPrefix  = "anti-pod."
-	topologyKeyTag = "topology-key"
-	nodePrefix     = "node."
-)
-
-func processNodeAffinity(pod *core.PodSpec, affinityLabels map[string]string) error {
-	affinityTags := make(map[string]string)
-	for key, value := range affinityLabels {
-		keyVal := key
-		if strings.HasPrefix(key, "^") {
-			if len(key) == 1 {
-				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
-			}
-			key = key[1:]
-		}
-		if strings.HasPrefix(key, podPrefix) || strings.HasPrefix(key, antiPodPrefix) {
-			continue
-		}
-		key = strings.TrimPrefix(keyVal, nodePrefix)
-		affinityTags[key] = value
-	}
-
-	updateSelectorTerms := func(nodeSelectorTerm *core.NodeSelectorTerm, tags map[string]string) {
-		// Sort for stable ordering.
-		var keys []string
-		for k := range tags {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, tag := range keys {
-			allValues := strings.Split(tags[tag], "|")
-			for i, v := range allValues {
-				allValues[i] = strings.Trim(v, " ")
-			}
-			op := core.NodeSelectorOpIn
-			if strings.HasPrefix(tag, "^") {
-				tag = tag[1:]
-				op = core.NodeSelectorOpNotIn
-			}
-			nodeSelectorTerm.MatchExpressions = append(nodeSelectorTerm.MatchExpressions, core.NodeSelectorRequirement{
-				Key:      tag,
-				Operator: op,
-				Values:   allValues,
-			})
-		}
-	}
-	var nodeSelectorTerm core.NodeSelectorTerm
-	updateSelectorTerms(&nodeSelectorTerm, affinityTags)
-	if pod.Affinity == nil {
-		pod.Affinity = &core.Affinity{}
-	}
-	pod.Affinity.NodeAffinity = &core.NodeAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
-			NodeSelectorTerms: []core.NodeSelectorTerm{nodeSelectorTerm},
-		},
-	}
-	return nil
-}
-
-func processPodAffinity(pod *core.PodSpec, affinityLabels map[string]string) error {
-	affinityTags := make(map[string]string)
-	antiAffinityTags := make(map[string]string)
-	for key, value := range affinityLabels {
-		notVal := false
-		if strings.HasPrefix(key, "^") {
-			if len(key) == 1 {
-				return errors.Errorf("invalid affinity constraints: %v", affinityLabels)
-			}
-			notVal = true
-			key = key[1:]
-		}
-		if !strings.HasPrefix(key, podPrefix) && !strings.HasPrefix(key, antiPodPrefix) {
-			continue
-		}
-		if strings.HasPrefix(key, podPrefix) {
-			key = strings.TrimPrefix(key, podPrefix)
-			if notVal {
-				key = "^" + key
-			}
-			affinityTags[key] = value
-		}
-		if strings.HasPrefix(key, antiPodPrefix) {
-			key = strings.TrimPrefix(key, antiPodPrefix)
-			if notVal {
-				key = "^" + key
-			}
-			antiAffinityTags[key] = value
-		}
-	}
-	if len(affinityTags) == 0 && len(antiAffinityTags) == 0 {
-		return nil
-	}
-
-	updateAffinityTerm := func(affinityTerm *core.PodAffinityTerm, tags map[string]string) {
-		// Sort for stable ordering.
-		var keys []string
-		for k := range tags {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		var (
-			labelSelector v1.LabelSelector
-			topologyKey   string
-		)
-		for _, tag := range keys {
-			if tag == topologyKeyTag {
-				topologyKey = tags[tag]
-				continue
-			}
-			allValues := strings.Split(tags[tag], "|")
-			for i, v := range allValues {
-				allValues[i] = strings.Trim(v, " ")
-			}
-			op := v1.LabelSelectorOpIn
-			if strings.HasPrefix(tag, "^") {
-				tag = tag[1:]
-				op = v1.LabelSelectorOpNotIn
-			}
-			labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, v1.LabelSelectorRequirement{
-				Key:      tag,
-				Operator: op,
-				Values:   allValues,
-			})
-		}
-		affinityTerm.LabelSelector = &labelSelector
-		if topologyKey != "" {
-			affinityTerm.TopologyKey = topologyKey
-		}
-	}
-	if pod.Affinity == nil {
-		pod.Affinity = &core.Affinity{}
-	}
-	var affinityTerm core.PodAffinityTerm
-	updateAffinityTerm(&affinityTerm, affinityTags)
-	if len(affinityTerm.LabelSelector.MatchExpressions) > 0 {
-		pod.Affinity.PodAffinity = &core.PodAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{affinityTerm},
-		}
-	}
-
-	var antiAffinityTerm core.PodAffinityTerm
-	updateAffinityTerm(&antiAffinityTerm, antiAffinityTags)
-	if len(antiAffinityTerm.LabelSelector.MatchExpressions) > 0 {
-		pod.Affinity.PodAntiAffinity = &core.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []core.PodAffinityTerm{antiAffinityTerm},
-		}
-	}
-	return nil
-}
-
 const applyRawSpecTimeoutSeconds = 20
 
 func (k *kubernetesClient) applyRawK8sSpec(
@@ -1263,7 +1024,9 @@ func (k *kubernetesClient) ensureService(
 			return errors.Annotatef(err, "configuring devices for %s", appName)
 		}
 	}
-	if err := processConstraints(&workloadSpec.Pod.PodSpec, appName, params.Constraints); err != nil {
+	if err := k8sapplication.ApplyConstraints(
+		&workloadSpec.Pod.PodSpec, appName, params.Constraints, k8sapplication.ConfigureConstraint,
+	); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1460,18 +1223,6 @@ func (k *kubernetesClient) configureDevices(unitSpec *workloadSpec, devices []de
 		} else {
 			unitSpec.Pod.NodeSelector = nodeSelector
 		}
-	}
-	return nil
-}
-
-func configureConstraint(pod *core.PodSpec, constraint, value string) error {
-	for i := range pod.Containers {
-		resources := pod.Containers[i].Resources
-		err := mergeConstraint(constraint, value, &resources)
-		if err != nil {
-			return errors.Annotatef(err, "merging constraint %q to %#v", constraint, resources)
-		}
-		pod.Containers[i].Resources = resources
 	}
 	return nil
 }
@@ -2827,22 +2578,6 @@ func mergeDeviceConstraints(device devices.KubernetesDeviceParams, resources *co
 	// - https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/#clusters-containing-different-types-of-nvidia-gpus
 	resources.Limits[resourceName] = *resource.NewQuantity(device.Count, resource.DecimalSI)
 	resources.Requests[resourceName] = *resource.NewQuantity(device.Count, resource.DecimalSI)
-	return nil
-}
-
-func mergeConstraint(constraint string, value string, resources *core.ResourceRequirements) error {
-	if resources.Limits == nil {
-		resources.Limits = core.ResourceList{}
-	}
-	resourceName := core.ResourceName(constraint)
-	if v, ok := resources.Limits[resourceName]; ok {
-		return errors.NotValidf("resource limit for %q has already been set to %v!", resourceName, v)
-	}
-	parsedValue, err := resource.ParseQuantity(value)
-	if err != nil {
-		return errors.Annotatef(err, "invalid constraint value %q for %v", value, constraint)
-	}
-	resources.Limits[resourceName] = parsedValue
 	return nil
 }
 

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -7023,6 +7023,9 @@ func (s *K8sBrokerSuite) TestEnsureServiceWithConstraints(c *gc.C) {
 				"cpu":    resource.MustParse("500m"),
 			},
 		}
+		if i == 0 {
+			podSpec.Containers[i].Resources.Requests = podSpec.Containers[i].Resources.Limits
+		}
 	}
 	statefulSetArg := unitStatefulSetArg(2, "workload-storage", podSpec)
 	ociImageSecret := s.getOCIImageSecret(c, nil)


### PR DESCRIPTION
Juju 2.9 did not support pod and node affinity for sidecar charms.
Here we backport the constraints logic from 3.0.
The backport includes the setting of resource requests for the first container (was missing in 2.9, added in 3.0).

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing

## QA steps

juju deploy training-operator --constraints="tags=node.mldatanode=true,^node.mlgpunode=true"
kubectl get -o json statefulset.apps/training-operator | jq

Check the above to see the affinity rules have been applied.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993716