### PR TITLE
Merge 2.9

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,7 +29,6 @@ jobs:
       run: |
         set -euxo pipefail
         
-        sudo apt-get remove lxd lxd-client
         if snap info lxd | grep "installed"; then
           sudo snap refresh lxd --channel=latest/stable
         else

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -26,7 +26,6 @@ jobs:
         set -euxo pipefail
         sudo snap install snapcraft --classic
         
-        sudo apt-get remove lxd lxd-client
         if snap info lxd | grep "installed"; then
           sudo snap refresh lxd --channel=latest/stable
         else

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -77,7 +77,6 @@ jobs:
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'localhost'
         shell: bash
         run: |
-          sudo apt-get remove lxd lxd-client
           if snap info lxd | grep "installed"; then
             sudo snap refresh lxd --channel=latest/stable
           else

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -93,13 +93,13 @@ func (s *RegisterSuite) TestInit(c *gc.C) {
 }
 
 func (s *RegisterSuite) TestRegister(c *gc.C) {
-	s.testRegisterSuccess(c, nil, "", false)
+	s.testRegisterSuccess(c, nil, "", false, false)
 	c.Assert(s.listModelsControllerName, gc.Equals, "controller-name")
 	c.Assert(s.listModelsUserName, gc.Equals, "bob")
 }
 
 func (s *RegisterSuite) TestRegisterWithProxy(c *gc.C) {
-	s.testRegisterSuccess(c, nil, "", true)
+	s.testRegisterSuccess(c, nil, "", true, false)
 	c.Assert(s.listModelsControllerName, gc.Equals, "controller-name")
 	c.Assert(s.listModelsUserName, gc.Equals, "bob")
 }
@@ -125,7 +125,7 @@ Welcome, bob. You are now logged into "controller-name".
 
 Current model set to "carol/theoneandonly".
 `[1:])
-	s.testRegisterSuccess(c, prompter, "", false)
+	s.testRegisterSuccess(c, prompter, "", false, false)
 	c.Assert(
 		s.store.Models["controller-name"].CurrentModel,
 		gc.Equals, "carol/theoneandonly",
@@ -163,7 +163,7 @@ one of them:
   - juju switch model2
 `[1:])
 	defer prompter.CheckDone()
-	s.testRegisterSuccess(c, prompter, "", false)
+	s.testRegisterSuccess(c, prompter, "", false, false)
 
 	// When there are multiple models, no current model will be set.
 	// Instead, the command will output the list of models and inform
@@ -177,7 +177,7 @@ one of them:
 // default prompter will be used.
 // If controllerName is non-empty, that name will be expected
 // to be the name of the registered controller.
-func (s *RegisterSuite) testRegisterSuccess(c *gc.C, stdio io.ReadWriter, controllerName string, withProxy bool) {
+func (s *RegisterSuite) testRegisterSuccess(c *gc.C, stdio io.ReadWriter, controllerName string, withProxy, replace bool) {
 	if controllerName == "" {
 		controllerName = "controller-name"
 	}
@@ -227,7 +227,11 @@ Welcome, bob. You are now logged into "controller-name".
 		defer prompter.CheckDone()
 		stdio = prompter
 	}
-	err := s.run(c, stdio, registrationData)
+	args := []string{registrationData}
+	if replace {
+		args = append(args, "--replace")
+	}
+	err := s.run(c, stdio, args...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// There should have been one POST command to "/register".
@@ -271,7 +275,7 @@ Welcome, bob. You are now logged into "controller-name".
 
 func (s *RegisterSuite) TestRegisterInvalidRegistrationData(c *gc.C) {
 	err := s.run(c, nil, "not base64")
-	c.Assert(err, gc.ErrorMatches, "illegal base64 data at input byte 3")
+	c.Assert(err, gc.ErrorMatches, "invalid registration token: illegal base64 data at input byte 3")
 
 	err = s.run(c, nil, "YXNuLjEK")
 	c.Assert(err, gc.ErrorMatches, "asn1: structure error: .*")
@@ -321,7 +325,7 @@ Initial password successfully set for bob.
 
 Welcome, bob. You are now logged into "other-name".
 `[1:]+noModelsText)
-	s.testRegisterSuccess(c, prompter, "other-name", false)
+	s.testRegisterSuccess(c, prompter, "other-name", false, false)
 	prompter.AssertDone()
 }
 
@@ -406,7 +410,112 @@ Welcome, bob. You are now logged into "other-name".
 Current model set to "bob/model-name".
 `[1:])
 	defer prompter.CheckDone()
-	s.testRegisterSuccess(c, prompter, "other-name", false)
+	s.testRegisterSuccess(c, prompter, "other-name", false, false)
+}
+
+func (s *RegisterSuite) TestRegisterControllerNameExistsReplace(c *gc.C) {
+	err := s.store.AddController("controller-name", jujuclient.ControllerDetails{
+		ControllerUUID: "0d75314a-5266-4f4f-8523-415be76f92dc",
+		CACert:         testing.CACert,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	prompter := cmdtesting.NewSeqPrompter(c, "»", `
+Enter a new password: »hunter2
+
+Confirm password: »hunter2
+
+Enter a name for this controller \[replace controller-name\]: »
+Initial password successfully set for bob.
+
+Welcome, bob. You are now logged into "controller-name".
+`[1:]+noModelsText)
+	s.testRegisterSuccess(c, prompter, "controller-name", false, true)
+	prompter.AssertDone()
+}
+
+func (s *RegisterSuite) TestControllerUUIDExistsReplace(c *gc.C) {
+	// Controller has the UUID from s.testRegister to mimic a user with
+	// this controller already registered (regardless of its name).
+	err := s.store.AddController("controller-name", jujuclient.ControllerDetails{
+		ControllerUUID: mockControllerUUID,
+		CACert:         testing.CACert,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
+		return []base.UserModel{{
+			Name:  "model-name",
+			Owner: "bob",
+			UUID:  mockControllerUUID,
+			Type:  model.IAAS,
+		}}, nil
+	}
+
+	srv := s.mockServer(c, nil)
+	s.httpHandler = srv
+
+	prompter := cmdtesting.NewSeqPrompter(c, "»", `
+Enter a new password: »hunter2
+
+Confirm password: »hunter2
+
+Enter a name for this controller \[replace controller-name\]: »controller-name
+Initial password successfully set for bob.
+
+Welcome, bob. You are now logged into "controller-name".
+
+Current model set to "bob/model-name".
+`[1:])
+	s.testRegisterSuccess(c, prompter, "controller-name", false, true)
+	prompter.CheckDone()
+}
+
+func (s *RegisterSuite) TestControllerUUIDExistsRenameNotAllowed(c *gc.C) {
+	// Controller has the UUID from s.testRegister to mimic a user with
+	// this controller already registered (regardless of its name).
+	err := s.store.AddController("controller-name", jujuclient.ControllerDetails{
+		ControllerUUID: mockControllerUUID,
+		CACert:         testing.CACert,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.listModels = func(_ jujuclient.ClientStore, controllerName, userName string) ([]base.UserModel, error) {
+		return []base.UserModel{{
+			Name:  "model-name",
+			Owner: "bob",
+			UUID:  mockControllerUUID,
+			Type:  model.IAAS,
+		}}, nil
+	}
+
+	registrationData := s.encodeRegistrationData(c, jujuclient.RegistrationInfo{
+		User:           "bob",
+		SecretKey:      mockSecretKey,
+		ControllerName: "controller-name",
+	})
+
+	srv := s.mockServer(c, nil)
+	s.httpHandler = srv
+
+	prompter := cmdtesting.NewSeqPrompter(c, "»", `
+Enter a new password: »hunter2
+
+Confirm password: »hunter2
+
+Enter a name for this controller \[replace controller-name\]: »foo
+Initial password successfully set for bob.
+`[1:])
+	err = s.run(c, prompter, registrationData, "--replace")
+	c.Assert(err, gc.Not(gc.IsNil))
+	c.Assert(err.Error(), gc.Equals, `This controller has already been registered on this client as "controller-name".
+To login user "bob" run 'juju login -u bob -c controller-name'.
+To update controller details and login as user "bob":
+    1. run 'juju unregister controller-name'
+    2. request from your controller admin another registration string, i.e
+       output from 'juju change-user-password bob --reset'
+    3. re-run 'juju register' with the registration string from (2) above.
+`)
+	prompter.CheckDone()
 }
 
 func (s *RegisterSuite) TestRegisterEmptyPassword(c *gc.C) {

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -267,6 +267,7 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 		return nil, errors.New("no controller API addresses; is bootstrap still in progress?")
 	}
 	if proxyerrors.IsProxyConnectError(err) {
+		logger.Debugf("proxy connection error: %v", err)
 		if proxyerrors.ProxyType(err) == k8sproxy.ProxierTypeKey {
 			return nil, errors.New("cannot connect to k8s api server; try running 'juju update-k8s --client <k8s cloud name>'")
 		}

--- a/tests/suites/coslite/task.sh
+++ b/tests/suites/coslite/task.sh
@@ -20,7 +20,8 @@ test_coslite() {
 	"k8s")
 		# disable metallb then enable it with a new set of out ipaddr
 		microk8s disable metallb
-		microk8s enable metallb:10.1.1.1-10.1.1.1
+		IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+		microk8s enable metallb:"$IPADDR"-"$IPADDR"
 		microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w
 		microk8s kubectl rollout status deployments/coredns -n kube-system -w
 		microk8s kubectl rollout status daemonset.apps/speaker -n metallb-system -w


### PR DESCRIPTION
Merge 2.9

https://github.com/juju/juju/pull/14894
https://github.com/juju/juju/pull/14896
https://github.com/juju/juju/pull/14892
https://github.com/juju/juju/pull/14897

Conflicts mainly due to backporting stuff to 2.9 - resolve by accepting the 3.0 copy.

```
# Conflicts:
#       .github/workflows/upgrade.yml
#       caas/kubernetes/provider/application/application.go
#       caas/kubernetes/provider/application/constraints.go
#       caas/kubernetes/provider/bootstrap.go
#       caas/kubernetes/provider/bootstrap_test.go
#       caas/kubernetes/provider/k8s.go
#       caas/kubernetes/provider/k8s_test.go
#       caas/kubernetes/provider/proxy/proxier.go
#       cmd/juju/controller/register.go
#       cmd/juju/controller/register_test.go
#       go.mod
#       go.sum
#       jujuclient/proxy.go
#       proxy/factory/factory.go
#       proxy/testing/proxy.go
```

