### PR TITLE
[JUJU-2198] Juju status with selector matching on ports substring #2

### DIFF
--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -301,10 +301,7 @@ func matchPortRanges(patterns []string, portRanges ...network.PortRange) (bool, 
 			if err != nil {
 				return false, true, err
 			}
-			pTo, err = strconv.Atoi(pNumStr)
-			if err != nil {
-				return false, true, err
-			}
+			pTo = pFrom
 		}
 		for _, patt := range patterns {
 			var pattFrom, pattTo int
@@ -324,10 +321,7 @@ func matchPortRanges(patterns []string, portRanges ...network.PortRange) (bool, 
 				if err != nil {
 					return false, true, err
 				}
-				pattTo, err = strconv.Atoi(pattNumStr)
-				if err != nil {
-					return false, true, err
-				}
+				pattTo = pattFrom
 			}
 			isPortInRange := pattFrom <= pTo && pattTo >= pFrom
 			if isPortPattern && isPortInRange && pProto == pattProto {

--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -310,13 +310,13 @@ func matchPortRanges(patterns []string, portRanges ...network.PortRange) (bool, 
 		pNumStr, pProto, _ := strings.Cut(p.String(), "/")
 		pFrom, pTo, err := getPortsFromString(pNumStr)
 		if err != nil {
-			return false, true, err
+			return false, true, nil
 		}
 		for _, patt := range patterns {
 			pattNumStr, pattProto, isPortPattern := strings.Cut(patt, "/")
 			pattFrom, pattTo, err := getPortsFromString(pattNumStr)
 			if err != nil {
-				return false, true, err
+				return false, true, nil
 			}
 			isPortInRange := pattFrom <= pTo && pattTo >= pFrom
 			if isPortPattern && isPortInRange && pProto == pattProto {

--- a/apiserver/facades/client/client/filtering.go
+++ b/apiserver/facades/client/client/filtering.go
@@ -281,47 +281,42 @@ func buildUnitMatcherShims(u *state.Unit, patterns []string) []closurePredicate 
 	}
 }
 
+// portsFromString gets "from port" and "to port" value from port string.
+func getPortsFromString(portStr string) (int, int, error) {
+	var portFrom, portTo int
+	var err error
+	portFromStr, portToStr, isPortRange := strings.Cut(portStr, "-")
+	if isPortRange {
+		portFrom, err = strconv.Atoi(portFromStr)
+		if err != nil {
+			return -1, -1, err
+		}
+		portTo, err = strconv.Atoi(portToStr)
+		if err != nil {
+			return -1, -1, err
+		}
+	} else {
+		portFrom, err = strconv.Atoi(portStr)
+		if err != nil {
+			return -1, -1, err
+		}
+		portTo = portFrom
+	}
+	return portFrom, portTo, nil
+}
+
 func matchPortRanges(patterns []string, portRanges ...network.PortRange) (bool, bool, error) {
 	for _, p := range portRanges {
-		var pFrom, pTo int
-		var err error
 		pNumStr, pProto, _ := strings.Cut(p.String(), "/")
-		pFromStr, pToStr, isPortRange := strings.Cut(pNumStr, "-")
-		if isPortRange {
-			pFrom, err = strconv.Atoi(pFromStr)
-			if err != nil {
-				return false, true, err
-			}
-			pTo, err = strconv.Atoi(pToStr)
-			if err != nil {
-				return false, true, err
-			}
-		} else {
-			pFrom, err = strconv.Atoi(pNumStr)
-			if err != nil {
-				return false, true, err
-			}
-			pTo = pFrom
+		pFrom, pTo, err := getPortsFromString(pNumStr)
+		if err != nil {
+			return false, true, err
 		}
 		for _, patt := range patterns {
-			var pattFrom, pattTo int
 			pattNumStr, pattProto, isPortPattern := strings.Cut(patt, "/")
-			pattFromStr, pattToStr, isPattRange := strings.Cut(pattNumStr, "-")
-			if isPattRange {
-				pattFrom, err = strconv.Atoi(pattFromStr)
-				if err != nil {
-					return false, true, err
-				}
-				pattTo, err = strconv.Atoi(pattToStr)
-				if err != nil {
-					return false, true, err
-				}
-			} else {
-				pattFrom, err = strconv.Atoi(pattNumStr)
-				if err != nil {
-					return false, true, err
-				}
-				pattTo = pattFrom
+			pattFrom, pattTo, err := getPortsFromString(pattNumStr)
+			if err != nil {
+				return false, true, err
 			}
 			isPortInRange := pattFrom <= pTo && pattTo >= pFrom
 			if isPortPattern && isPortInRange && pProto == pattProto {

--- a/apiserver/facades/client/client/filtering_test.go
+++ b/apiserver/facades/client/client/filtering_test.go
@@ -31,7 +31,7 @@ func (f *filteringUnitTests) TestMatchPortRanges(c *gc.C) {
 	match, ok, err = client.MatchPortRanges([]string{"90/tcp"}, network.PortRange{80, 90, "tcp"})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(ok, jc.IsTrue)
-	c.Check(match, jc.IsFalse)
+	c.Check(match, jc.IsTrue)
 
 	match, ok, err = client.MatchPortRanges([]string{"70"}, network.PortRange{7070, 7070, "tcp"})
 	c.Check(err, jc.ErrorIsNil)
@@ -39,6 +39,21 @@ func (f *filteringUnitTests) TestMatchPortRanges(c *gc.C) {
 	c.Check(match, jc.IsFalse)
 
 	match, ok, err = client.MatchPortRanges([]string{"7070"}, network.PortRange{7070, 7070, "tcp"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(ok, jc.IsTrue)
+	c.Check(match, jc.IsFalse)
+
+	match, ok, err = client.MatchPortRanges([]string{"7070/udp"}, network.PortRange{7070, 7070, "tcp"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(ok, jc.IsTrue)
+	c.Check(match, jc.IsFalse)
+
+	match, ok, err = client.MatchPortRanges([]string{"7070/tcp"}, network.PortRange{7065, 7069, "tcp"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(ok, jc.IsTrue)
+	c.Check(match, jc.IsFalse)
+
+	match, ok, err = client.MatchPortRanges([]string{"7070/tcp"}, network.PortRange{7069, 7071, "tcp"})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(ok, jc.IsTrue)
 	c.Check(match, jc.IsTrue)


### PR DESCRIPTION
This PR adds:

- strict check of port protocol to avoid confusion between port number and machine id
- correct port range filtering, now juju status will seek for interaction between application port range and filter port range


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
juju bootstrap lxd lxd
juju deploy parca --channel=edge
# Filter nothing
juju status 707
# Filter nothing
juju status 7070
# Filter nothing
juju status 7070/t
# Filter parca
juju status 7070/tcp
# Filter nothing
juju status 7070/udp
# Filter nothing
juju status 7065-7069/tcp
# Filter parca
juju status 7069-7071/tcp
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1988709