### PR TITLE
[JUJU-2202] Deprecate charmstore charms

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -409,6 +409,8 @@ func (h *bundleHandler) resolveCharmsAndEndpoints() error {
 				Revision: -1,
 			}
 			origin = origin.WithBase(nil)
+		} else if charm.CharmStore.Matches(url.Schema) {
+			h.ctx.Warningf("Deploying %q.\n\tCharm store charms, those with cs: before the charm name, will not be supported in juju 3.1.\n\tMigration of this model to a juju 3.1 controller will be prohibited.", ch)
 		}
 
 		h.ctx.Infof(formatLocatedText(ch, origin))

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -196,12 +196,6 @@ type bundleHandler struct {
 	// status up to date.
 	watcher api.AllWatch
 
-	// warnedLXC indicates whether or not we have warned the user that the
-	// bundle they're deploying uses lxc containers, which will be treated as
-	// LXD.  This flag keeps us from writing the warning more than once per
-	// bundle.
-	warnedLXC bool
-
 	// The name and UUID of the model where the bundle is about to be deployed.
 	targetModelName string
 	targetModelUUID string
@@ -1169,17 +1163,6 @@ func (h *bundleHandler) addMachine(change *bundlechanges.AddMachineChange) error
 		Jobs:        []model.MachineJob{model.JobHostUnits},
 	}
 	if ct := p.ContainerType; ct != "" {
-		// TODO(thumper): move the warning and translation into the bundle reading code.
-
-		// for backwards compatibility with 1.x bundles, we treat lxc
-		// placement directives as lxd.
-		if ct == "lxc" {
-			if !h.warnedLXC {
-				h.ctx.Infof("Bundle has one or more containers specified as lxc. lxc containers are deprecated in Juju 2.0. lxd containers will be deployed instead.")
-				h.warnedLXC = true
-			}
-			ct = string(instance.LXD)
-		}
 		containerType, err := instance.ParseContainerType(ct)
 		if err != nil {
 			return errors.Annotatef(err, "cannot create machine for holding %s", deployedApps())

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -428,6 +428,7 @@ func (d *factory) maybeReadRepositoryBundle(resolver Resolver) (Deployer, error)
 		if curl.Revision == -1 {
 			curl = curl.WithRevision(d.revision)
 		}
+		logger.Warningf("Charm store bundles, those with cs: before the bundle name, will not be supported in juju 3.1.\n\tMigration of this model to a juju 3.1 controller will be prohibited.")
 	}
 	platform, err := utils.DeducePlatform(d.constraints, d.series, d.modelConstraints)
 	if err != nil {
@@ -517,6 +518,7 @@ func (d *factory) repositoryCharm() (Deployer, error) {
 		if userRequestedURL.Revision == -1 && d.revision != -1 {
 			userRequestedURL = userRequestedURL.WithRevision(d.revision)
 		}
+		logger.Warningf("Charm store charms, those with cs: before the charm name, will not be supported in juju 3.1.\n\tMigration of this model to a juju 3.1 controller will be prohibited.")
 	}
 	platform, err := utils.DeducePlatform(d.constraints, d.series, d.modelConstraints)
 	if err != nil {

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -410,6 +410,9 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	if err == nil {
 		curl := charmID.URL
 		charmOrigin := charmID.Origin
+		if charmOrigin.Source == corecharm.CharmStore {
+			ctx.Warningf("Charm store charms, those with cs: before the charm name, will not be supported in juju 3.1.\n\tMigration of this model to a juju 3.1 controller will be prohibited.\n\tUse the --switch flag to refresh to a non charm store version of the charm.")
+		}
 		// The current charm URL that's been found and selected.
 		channel := ""
 		if charmOrigin.Source == corecharm.CharmHub || charmOrigin.Source == corecharm.CharmStore {


### PR DESCRIPTION
Add a warning for juju users that charm store charms will not be supported in juju 3.1. Migration of a model to a juju 3.1 controller will be prohibited. Warn during deploy and refresh of charms and bundles, including charm hub bundles referencing charm store charms. Bundles should warn even during a dry run. During refresh we can suggest a resolution of use the switch flag.

Drive by to remove warning that using lxc as a container type are not supported. From juju 1.x to 2 transition. It's been at least five years to update the bundles. Just fail at this point.

## QA steps

```sh
$ juju deploy cs:ubuntu-20
WARNING Charm store charms, those with cs: before the charm name, will not be supported in juju 3.1.
	Migration of this model to a juju 3.1 controller will be prohibited.
Located charm "ubuntu" in charm-store, revision 20
Deploying "ubuntu" from charm-store charm "ubuntu", revision 20 in channel stable on ubuntu@20.04/stable

$ juju refresh ubuntu
WARNING Charm store charms, those with cs: before the charm name, will not be supported in juju 3.1.
	Migration of this model to a juju 3.1 controller will be prohibited.
	Use the --switch flag to refresh to a non charm store version of the charm.
Added charm-store charm "ubuntu", revision 21 in channel stable, to the model

$ juju deploy ./acceptancetests/repository/bundles-lxd-profile.yaml --force  --dry-run
Located charm "juju-qa-lxd-profile-without-devices" in charm-hub, channel stable
WARNING Deploying "cs:~jameinel/ubuntu-lite".
	Charm store charms, those with cs: before the charm name, will not be supported in juju 3.1.
	Migration of this model to a juju 3.1 controller will be prohibited.
Located charm "ubuntu-lite" in charm-store, channel stable
....
```
