### PR TITLE
[JUJU-2228] remove charmstore charms from integration tests.

### DIFF
--- a/tests/suites/agents/key_workers_run.sh
+++ b/tests/suites/agents/key_workers_run.sh
@@ -1,22 +1,3 @@
-run_charmstore_charmrevisionupdater() {
-	# Echo out to ensure nice output to the test suite.
-	echo
-
-	model_name="test-cs-charmrevisionupdater"
-	file="${TEST_DIR}/${model_name}.log"
-
-	ensure "${model_name}" "${file}"
-
-	# Deploy an old revision of postgresql
-	juju deploy cs:postgresql-238 --series focal
-
-	# Wait for revision update worker to update the available revision.
-	# eg can-upgrade-to: cs:postgresql-239
-	wait_for "cs:postgresql-" '.applications["postgresql"] | ."can-upgrade-to"'
-
-	destroy_model "${model_name}"
-}
-
 run_charmhub_charmrevisionupdater() {
 	# Echo out to ensure nice output to the test suite.
 	echo
@@ -48,6 +29,5 @@ test_charmrevisionupdater() {
 		cd .. || exit
 
 		run "run_charmhub_charmrevisionupdater"
-		run "run_charmstore_charmrevisionupdater"
 	)
 }

--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -44,7 +44,7 @@ run_deploy_ck() {
 	juju --show-log run "$integrator_app_name/leader" --wait=10m purge-subnet-tags
 }
 
-# Ensure that a CAAS workload (mariadb+mediawiki) deploys successfully,
+# Ensure that a CAAS workload (hello-kubecon+nginx-ingress-integrator) deploys successfully,
 # and that we can relate the two applications once it has.
 run_deploy_caas_workload() {
 	echo
@@ -63,12 +63,12 @@ run_deploy_caas_workload() {
 
 	add_model "${model_name}" "${k8s_cloud_name}" "${controller_name}" "${file}"
 
-	juju deploy cs:~juju/mariadb-k8s-3
-	juju deploy cs:~juju/mediawiki-k8s-4 --config kubernetes-service-type=loadbalancer
-	juju relate mediawiki-k8s:db mariadb-k8s:server
+	juju deploy hello-kubecon
+	juju deploy nginx-ingress-integrator
+	juju relate hello-kubecon:ingress nginx-ingress-integrator:ingress
 
-	wait_for "active" '.applications["mariadb-k8s"] | ."application-status".current' 300
-	wait_for "active" '.applications["mediawiki-k8s"] | ."application-status".current'
+	wait_for "active" '.applications["hello-kubecon"] | ."application-status".current' 300
+	wait_for "active" '.applications["nginx-ingress-integrator"] | ."application-status".current'
 }
 
 test_deploy_ck() {
@@ -79,7 +79,6 @@ test_deploy_ck() {
 
 	(
 		set_verbosity
-
 		cd .. || exit
 
 		run "run_deploy_ck"

--- a/tests/suites/deploy/deploy_default_series.sh
+++ b/tests/suites/deploy/deploy_default_series.sh
@@ -8,17 +8,11 @@ run_deploy_default_series() {
 
 	juju model-config default-series=focal
 	juju deploy ubuntu
-	juju deploy cs:ubuntu csubuntu
 
 	ubuntu_base_name=$(juju status --format=json | jq ".applications.ubuntu.base.name")
 	ubuntu_base_ch=$(juju status --format=json | jq ".applications.ubuntu.base.channel")
 	echo "$ubuntu_base_name" | check "ubuntu"
 	echo "$ubuntu_base_ch" | check "20.04"
-
-	csubuntu_base_name=$(juju status --format=json | jq ".applications.csubuntu.base.name")
-	csubuntu_base_ch=$(juju status --format=json | jq ".applications.csubuntu.base.channel")
-	echo "$csubuntu_base_name" | check "ubuntu"
-	echo "$csubuntu_base_ch" | check "20.04"
 
 	destroy_model "${model_name}"
 }
@@ -33,17 +27,11 @@ run_deploy_not_default_series() {
 
 	juju model-config default-series=focal
 	juju deploy ubuntu --series jammy
-	juju deploy cs:ubuntu csubuntu --series jammy
 
 	ubuntu_base_name=$(juju status --format=json | jq ".applications.ubuntu.base.name")
 	ubuntu_base_ch=$(juju status --format=json | jq ".applications.ubuntu.base.channel")
 	echo "$ubuntu_base_name" | check "ubuntu"
 	echo "$ubuntu_base_ch" | check "22.04"
-
-	csubuntu_base_name=$(juju status --format=json | jq ".applications.csubuntu.base.name")
-	csubuntu_base_ch=$(juju status --format=json | jq ".applications.csubuntu.base.channel")
-	echo "$csubuntu_base_name" | check "ubuntu"
-	echo "$csubuntu_base_ch" | check "22.04"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -1,33 +1,3 @@
-run_refresh_cs() {
-	# Test a plain juju refresh with a charm store charm
-	echo
-
-	model_name="test-refresh-cs"
-	file="${TEST_DIR}/${model_name}.log"
-
-	ensure "${model_name}" "${file}"
-
-	juju deploy cs:ubuntu-19
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
-
-	OUT=$(juju refresh ubuntu 2>&1 || true)
-	if echo "${OUT}" | grep -E -vq "Added"; then
-		# shellcheck disable=SC2046
-		echo $(red "failed refreshing charm: ${OUT}")
-		exit 5
-	fi
-	# shellcheck disable=SC2059
-	printf "${OUT}\n"
-
-	# Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
-	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
-
-	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
-
-	destroy_model "${model_name}"
-}
-
 run_refresh_local() {
 	# Test a plain juju refresh with a local charm
 	echo
@@ -71,7 +41,6 @@ test_basic() {
 
 		cd .. || exit
 
-		run "run_refresh_cs"
 		run "run_refresh_local"
 	)
 }

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -1,64 +1,3 @@
-run_refresh_switch_cs_to_ch() {
-	# Test juju refresh from a charm store charm to a charm hub charm
-	echo
-
-	model_name="test-refresh-switch-ch"
-	file="${TEST_DIR}/${model_name}.log"
-
-	ensure "${model_name}" "${file}"
-
-	juju deploy cs:ubuntu-19
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
-
-	OUT=$(juju refresh ubuntu --switch ch:ubuntu 2>&1 || true)
-	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
-		# shellcheck disable=SC2046
-		echo $(red "failed refreshing charm: ${OUT}")
-		exit 5
-	fi
-	# shellcheck disable=SC2059
-	printf "${OUT}\n"
-
-	# Added local charm "ubuntu", revision 2, to the model
-	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
-
-	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
-
-	destroy_model "${model_name}"
-}
-
-run_refresh_switch_cs_to_ch_channel() {
-	# Test juju refresh from a charm store charm to a charm hub charm with a specific channel
-	echo
-
-	model_name="test-refresh-switch-ch-channel"
-	file="${TEST_DIR}/${model_name}.log"
-
-	ensure "${model_name}" "${file}"
-
-	juju deploy cs:ubuntu-19
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
-
-	OUT=$(juju refresh ubuntu --switch ch:ubuntu --channel edge 2>&1 || true)
-	if echo "${OUT}" | grep -E -vq "in channel edge"; then
-		# shellcheck disable=SC2046
-		echo $(red "failed refreshing charm: ${OUT}")
-		exit 5
-	fi
-	# shellcheck disable=SC2059
-	printf "${OUT}\n"
-
-	# Added local charm "ubuntu", revision 2, to the model
-	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
-
-	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
-	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
-
-	destroy_model "${model_name}"
-}
-
 run_refresh_switch_local_to_ch_channel() {
 	# Test juju refresh from a local charm to a charm hub charm with a specific channel
 	echo
@@ -129,8 +68,6 @@ test_switch() {
 
 		cd .. || exit
 
-		run "run_refresh_switch_cs_to_ch"
-		run "run_refresh_switch_cs_to_ch_channel"
 		run "run_refresh_switch_local_to_ch_channel"
 		run "run_refresh_switch_channel"
 	)


### PR DESCRIPTION
Waiting for suggestions on replacing charms in the ck tests.

Prepare for removing charm store from juju 3.1 support by updating the integration tests to not use charmstore charms. This was already done for the most part, however some tests themselves would no longer be relevant and thus were removed. 

The use of "cs:" was left in the info, download and find command tests as they are error cases to begin with.
## QA steps

```sh
(cd tests ; ./main.sh refresh test_basic)
(cd tests ; ./main.sh refresh test_switch)
(cd tests ; ./main.sh agents test_charmrevisionupdater) <- this test has existing failures.
(cd tests ; ./main.sh deploy test_deploy_default_series)

# I cannot get the ck test to run from my local machine successfully. The charms are deployed, 
# but never come up. These two charms do install on microk8s and relate there. Not sure what
# is going on.
(cd tests ; ./main.sh -v -p aws ck)
```
