### PR TITLE
[JUJU-2244] Improve *-container-provider error message.

### DIFF
--- a/worker/provisioner/containermanifold.go
+++ b/worker/provisioner/containermanifold.go
@@ -172,7 +172,7 @@ func (cfg ContainerManifoldConfig) machineSupportsContainers(pr ContainerMachine
 		return nil, errors.Annotatef(err, "retrieving supported container types")
 	}
 	if !known {
-		return nil, errors.NotYetAvailablef("container types")
+		return nil, errors.NotYetAvailablef("container types not yet available")
 	}
 	if len(types) == 0 {
 		cfg.Logger.Infof("uninstalling no supported containers on %q", mTag)


### PR DESCRIPTION
NotYetAvailablef hides the error type type text making the error harder to understand on the receiving end when printed. "manifold worker returned unexpected error: container types" is not helpful as os. Improve message provided.

## QA steps

```sh
$ juju bootstrap localhost
$ juju debug-log -m controller --replay --level error
...
machine-0: 20:34:50 ERROR juju.worker.dependency "lxd-container-provisioner" manifold worker returned unexpected error: container types not yet available
machine-0: 20:34:50 ERROR juju.worker.dependency "kvm-container-provisioner" manifold worker returned unexpected error: container types not yet available
...
```

