### PR TITLE
Let pip be the version installed by apt, rather than downgrading it.

### DIFF
--- a/caas/requirements.txt
+++ b/caas/requirements.txt
@@ -1,4 +1,3 @@
-pip>=7.0.0,<8.2.0
 charmhelpers>=0.20.15,<1.0.0
 charms.reactive>=0.1.0,<2.0.0
 kubernetes==10.0.*


### PR DESCRIPTION
Not required for 2.9 as it doesn't build the image against jammy, but starting with jammy, python 3.10+ is installed, which breaks against the terribly old version of pip... pip v8.2.0

## QA steps

- Build image for k8s.
- Deploy a charm.

## Documentation changes

N/A

## Bug reference

N/A