### PR TITLE
[JUJU-2245] Fix failing GitHub Actions

### DIFF
--- a/.github/setup-lxd/action.yml
+++ b/.github/setup-lxd/action.yml
@@ -1,0 +1,35 @@
+name: 'Setup LXD'
+description: 'Install and configure LXD on the runner'
+inputs:
+  channel:
+    description: 'Snap channel to install LXD from'
+    required: false
+    default: 'latest/stable'
+runs:
+  using: "composite"
+  steps:
+    - name: Install/refresh LXD snap
+      shell: bash
+      run: |
+        set -x
+        if snap info lxd | grep "installed"; then
+          sudo snap refresh lxd --channel=${{ inputs.channel }}
+        else
+          sudo snap install lxd --channel=${{ inputs.channel }}
+        fi
+
+    - name: Initialise LXD
+      shell: bash
+      run: |
+        set -x
+        sudo lxd waitready
+        sudo lxd init --auto
+        sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+        lxc network set lxdbr0 ipv6.address none
+
+    - name: Configure firewall
+      shell: bash
+      run: |
+        set -x
+        sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
+        sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,6 +11,7 @@ on:
       - 'tests/includes/**'
       - 'tests/suites/smoke/**'
       - '.github/workflows/smoke.yml'
+      - '.github/setup-lxd/**'
   workflow_dispatch:
 
 permissions:
@@ -28,22 +29,14 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
-        
-        if snap info lxd | grep "installed"; then
-          sudo snap refresh lxd --channel=latest/stable
-        else
-          sudo snap install lxd --channel=latest/stable
-        fi
-        
-        sudo lxd waitready
-        sudo lxd init --auto
-        sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
         echo "/snap/bin" >> $GITHUB_PATH
-        lxc network set lxdbr0 ipv6.address none
         sudo apt install expect
 
     - name: Checkout
       uses: actions/checkout@v3
+
+    - name: Setup LXD
+      uses: ./.github/setup-lxd
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -8,6 +8,7 @@ on:
       - 'go.mod'
       - 'snap/**'
       - '.github/workflows/snap.yml'
+      - '.github/setup-lxd/**'
   workflow_dispatch:
 permissions:
   contents: read
@@ -25,20 +26,13 @@ jobs:
       run: |
         set -euxo pipefail
         sudo snap install snapcraft --classic
-        
-        if snap info lxd | grep "installed"; then
-          sudo snap refresh lxd --channel=latest/stable
-        else
-          sudo snap install lxd --channel=latest/stable
-        fi        
-        
-        sudo lxd waitready
-        sudo lxd init --auto
-        sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
         echo "/snap/bin" >> $GITHUB_PATH
 
     - name: Checkout
       uses: actions/checkout@v3
+
+    - name: Setup LXD
+      uses: ./.github/setup-lxd
 
     - name: Set up Go
       if: env.RUN_TEST == 'RUN'
@@ -62,5 +56,4 @@ jobs:
       shell: bash
       run: |
         set -euxo pipefail
-        lxc network set lxdbr0 ipv6.address none
         juju bootstrap localhost

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -8,6 +8,7 @@ on:
       - 'go.mod'
       - 'snap/**'
       - '.github/workflows/upgrade.yml'
+      - '.github/setup-lxd/**'
   workflow_dispatch:
 
 permissions:
@@ -39,21 +40,16 @@ jobs:
           sudo snap install snapcraft --classic
           sudo snap install yq
           sudo snap install juju --classic --channel=${{ matrix.snap_version }}
-          
-          if snap info lxd | grep "installed"; then
-            sudo snap remove lxd --purge
-          fi
-          sudo snap install lxd --channel=4.0/candidate
-          
-          sudo lxd waitready
-          sudo lxd init --auto
-          sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-          lxc network set lxdbr0 ipv6.address none
           echo "/snap/bin" >> $GITHUB_PATH
 
       - name: Checkout
         if: env.RUN_TEST == 'RUN'
         uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: ./.github/setup-lxd
+        with:
+          channel: 4.0/candidate
 
       - name: Set some variables
         if: env.RUN_TEST == 'RUN'


### PR DESCRIPTION
Several actions were failing due to a problem with LXD. The GitHub runners have been updated and now the default firewall/iptables rules prevent LXD containers from accessing the internet. We can fix this problem by running:
```
sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
```

To avoid future bugs, I've created a `setup-lxd` GitHub Action which installs and configures LXD on the runner. Currently it's just a local action living at `.github/setup-lxd`. Once it proves stable enough, we can think about moving it out into its own repository.

## QA steps
Wait for all checks to pass on this PR.