### PR TITLE
owner + consumer labels should be unique for each unit/application;

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -97,7 +97,7 @@ func (c *Client) GetContentInfo(uri *coresecrets.URI, label string, refresh, pee
 		return nil, apiservererrors.RestoreError(err)
 	}
 	result := results.Results[0].Content
-	content := &secrets.ContentParams{ProviderId: result.ProviderId}
+	content := &secrets.ContentParams{BackendId: result.BackendId}
 	if len(result.Data) > 0 {
 		content.SecretValue = coresecrets.NewSecretValue(result.Data)
 	}
@@ -216,16 +216,16 @@ func (c *Client) SecretMetadata(filter coresecrets.Filter) ([]coresecrets.Secret
 			LatestExpireTime: info.LatestExpireTime,
 			NextRotateTime:   info.NextRotateTime,
 		}
-		providerIds := make(map[int]string)
+		BackendIds := make(map[int]string)
 		for _, r := range info.Revisions {
-			if r.ProviderId == nil {
+			if r.BackendId == nil {
 				continue
 			}
-			providerIds[r.Revision] = *r.ProviderId
+			BackendIds[r.Revision] = *r.BackendId
 		}
 		result = append(result, coresecrets.SecretOwnerMetadata{
-			Metadata:    md,
-			ProviderIds: providerIds,
+			Metadata:   md,
+			BackendIds: BackendIds,
 		})
 	}
 	return result, nil

--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -216,16 +216,16 @@ func (c *Client) SecretMetadata(filter coresecrets.Filter) ([]coresecrets.Secret
 			LatestExpireTime: info.LatestExpireTime,
 			NextRotateTime:   info.NextRotateTime,
 		}
-		BackendIds := make(map[int]string)
+		backendIds := make(map[int]string)
 		for _, r := range info.Revisions {
 			if r.BackendId == nil {
 				continue
 			}
-			BackendIds[r.Revision] = *r.BackendId
+			backendIds[r.Revision] = *r.BackendId
 		}
 		result = append(result, coresecrets.SecretOwnerMetadata{
 			Metadata:   md,
-			BackendIds: BackendIds,
+			BackendIds: backendIds,
 		})
 	}
 	return result, nil

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -182,8 +182,8 @@ func (s *SecretsSuite) TestGetSecretMetadata(c *gc.C) {
 				NextRotateTime:   &now,
 				LatestExpireTime: &now,
 				Revisions: []params.SecretRevision{{
-					Revision:   666,
-					ProviderId: ptr("provider-id"),
+					Revision:  666,
+					BackendId: ptr("backend-id"),
 				}, {
 					Revision: 667,
 				}},
@@ -204,7 +204,7 @@ func (s *SecretsSuite) TestGetSecretMetadata(c *gc.C) {
 		c.Assert(info.Metadata.LatestRevision, gc.Equals, 666)
 		c.Assert(info.Metadata.LatestExpireTime, gc.Equals, &now)
 		c.Assert(info.Metadata.NextRotateTime, gc.Equals, &now)
-		c.Assert(info.ProviderIds, jc.DeepEquals, map[int]string{666: "provider-id"})
+		c.Assert(info.BackendIds, jc.DeepEquals, map[int]string{666: "backend-id"})
 	}
 }
 

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -939,7 +939,7 @@ type SecretUpsertArg struct {
 	Description  *string
 	Label        *string
 	Value        secrets.SecretValue
-	ProviderId   *string
+	BackendId    *string
 }
 
 // SecretCreateArg holds parameters for creating a secret.
@@ -984,8 +984,8 @@ func (b *CommitHookParamsBuilder) AddSecretCreates(creates []SecretCreateArg) {
 				Description:  c.Description,
 				Label:        c.Label,
 				Content: params.SecretContentParams{
-					Data:       data,
-					ProviderId: c.ProviderId,
+					Data:      data,
+					BackendId: c.BackendId,
 				},
 			},
 			URI:      &uriStr,
@@ -1017,8 +1017,8 @@ func (b *CommitHookParamsBuilder) AddSecretUpdates(updates []SecretUpsertArg) {
 				Description:  u.Description,
 				Label:        u.Label,
 				Content: params.SecretContentParams{
-					Data:       data,
-					ProviderId: u.ProviderId,
+					Data:      data,
+					BackendId: u.BackendId,
 				},
 			},
 			URI: u.URI.String(),

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -387,11 +387,11 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 			return nil, apiservererrors.ErrPerm
 		}
 
-		val, BackendId, err := s.secretsBackend.GetSecretValue(uri, revision)
+		val, backendId, err := s.secretsBackend.GetSecretValue(uri, revision)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return &secrets.ContentParams{SecretValue: val, BackendId: BackendId}, nil
+		return &secrets.ContentParams{SecretValue: val, BackendId: backendId}, nil
 	}
 
 	var uri *coresecrets.URI

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -85,7 +85,7 @@ func (s *SecretsManagerAPI) CreateSecrets(args params.CreateSecretArgs) (params.
 }
 
 func (s *SecretsManagerAPI) createSecret(arg params.CreateSecretArg) (string, error) {
-	if len(arg.Content.Data) == 0 && arg.Content.ProviderId == nil {
+	if len(arg.Content.Data) == 0 && arg.Content.BackendId == nil {
 		return "", errors.NotValidf("empty secret value")
 	}
 	// A unit can only create secrets owned by its app.
@@ -143,7 +143,7 @@ func fromUpsertParams(p params.UpsertSecretArg, token leadership.Token, nextRota
 		Label:          p.Label,
 		Params:         p.Params,
 		Data:           p.Content.Data,
-		ProviderId:     p.Content.ProviderId,
+		BackendId:      p.Content.BackendId,
 	}
 }
 
@@ -168,7 +168,7 @@ func (s *SecretsManagerAPI) updateSecret(arg params.UpdateSecretArg) error {
 		return errors.Trace(err)
 	}
 	if arg.RotatePolicy == nil && arg.Description == nil && arg.ExpireTime == nil &&
-		arg.Label == nil && len(arg.Params) == 0 && len(arg.Content.Data) == 0 && arg.Content.ProviderId == nil {
+		arg.Label == nil && len(arg.Params) == 0 && len(arg.Content.Data) == 0 && arg.Content.BackendId == nil {
 		return errors.New("at least one attribute to update must be specified")
 	}
 	token, err := s.canManage(uri)
@@ -314,8 +314,8 @@ func (s *SecretsManagerAPI) GetSecretMetadata() (params.ListSecretResults, error
 		}
 		for _, r := range revs {
 			result.Results[i].Revisions = append(result.Results[i].Revisions, params.SecretRevision{
-				Revision:   r.Revision,
-				ProviderId: r.ProviderId,
+				Revision:  r.Revision,
+				BackendId: r.BackendId,
 			})
 		}
 	}
@@ -334,7 +334,7 @@ func (s *SecretsManagerAPI) GetSecretContentInfo(args params.GetSecretContentArg
 			continue
 		}
 		contentParams := params.SecretContentParams{
-			ProviderId: content.ProviderId,
+			BackendId: content.BackendId,
 		}
 		if content.SecretValue != nil {
 			contentParams.Data = content.SecretValue.EncodedValues()
@@ -344,21 +344,37 @@ func (s *SecretsManagerAPI) GetSecretContentInfo(args params.GetSecretContentArg
 	return result, nil
 }
 
-func (s *SecretsManagerAPI) getOwnerSecretMetadata(uri *coresecrets.URI) (*coresecrets.SecretMetadata, error) {
-	md, err := s.secretsBackend.GetSecret(uri)
+func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecrets.URI, label string) (md *coresecrets.SecretMetadata, _ error) {
+	filter := state.SecretsFilter{
+		OwnerTags: []names.Tag{s.authTag},
+	}
+	if s.authTag.Kind() == names.UnitTagKind {
+		// Units can access application owned secrets.
+		appOwner := names.NewApplicationTag(authTagApp(s.authTag))
+		filter.OwnerTags = append(filter.OwnerTags, appOwner)
+	}
+	mds, err := s.secretsBackend.ListSecrets(filter)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if s.authTag.String() != md.OwnerTag {
-		// Invisible for non owner users.
-		return nil, errors.NotFoundf("secret %s", uri)
+	for _, md := range mds {
+		if uri != nil && md.URI.ID == uri.ID {
+			return md, nil
+		}
+		if label != "" && md.Label == label {
+			return md, nil
+		}
 	}
-	return md, nil
+	if uri != nil {
+		return nil, errors.NotFoundf("secret %q", uri)
+	}
+	return nil, errors.NotFoundf("secret with label %q", label)
 }
 
 func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*secrets.ContentParams, error) {
 	// Only the owner can access secrets via the secret metadata label added by the owner.
-	// (Note: the leader unit is not the owner of the application secrets).
+	// (Note: the leader unit is treated as the owner of the application secrets, and non
+	// leader units can read the secret using owner label but cannot update them).
 	// Consumers get to use their own label.
 	// Both owners and consumers can also just use the secret URI.
 
@@ -371,11 +387,11 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 			return nil, apiservererrors.ErrPerm
 		}
 
-		val, providerId, err := s.secretsBackend.GetSecretValue(uri, revision)
+		val, BackendId, err := s.secretsBackend.GetSecretValue(uri, revision)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return &secrets.ContentParams{SecretValue: val, ProviderId: providerId}, nil
+		return &secrets.ContentParams{SecretValue: val, BackendId: BackendId}, nil
 	}
 
 	var uri *coresecrets.URI
@@ -388,20 +404,21 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 		}
 	}
 
-	if uri != nil && arg.Label == "" {
-		md, err := s.getOwnerSecretMetadata(uri)
-		if err != nil && !errors.Is(err, errors.NotFound) {
-			return nil, errors.Trace(err)
-		}
-		if md != nil {
-			// Owner can access the content directly.
-			return getSecretValue(md.URI, md.LatestRevision)
-		}
+	// Owner units should always have the UIR because we resolved the label to URI on uiter side already.
+	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, arg.Label)
+	if err != nil && !errors.Is(err, errors.NotFound) {
+		return nil, errors.Trace(err)
 	}
+	if md != nil {
+		// 1. secrets can be accesed by owners;
+		// 2. application owned secrets can be accessed by all the units of the application using owner label or URI.
+		return getSecretValue(md.URI, md.LatestRevision)
+	}
+
+	// This is a consumer agent.
 
 	// arg.Label is the consumer label for consumers.
 	possibleUpdateLabel := arg.Label != "" && uri != nil
-
 	if uri == nil {
 		var err error
 		uri, err = s.secretsConsumer.GetURIByConsumerLabel(arg.Label, s.authTag)

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -506,7 +506,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentOwnerArgURI(c *gc.C) {
 			names.NewApplicationTag("mariadb"),
 		},
 	}).Return([]*coresecrets.SecretMetadata{
-		&coresecrets.SecretMetadata{
+		{
 			URI:            uri,
 			LatestRevision: 668,
 			OwnerTag:       "unit-mariadb-0",

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -129,9 +129,9 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			if arg.Filter.Revision != nil {
 				rev = *arg.Filter.Revision
 			}
-			val, providerId, err := s.backend.GetSecretValue(m.URI, rev)
-			if providerId != nil {
-				val, err = s.secretContentFromStore(*providerId)
+			val, backendId, err := s.backend.GetSecretValue(m.URI, rev)
+			if backendId != nil {
+				val, err = s.secretContentFromStore(*backendId)
 			}
 			valueResult := &params.SecretValueResult{
 				Error: apiservererrors.ServerError(err),
@@ -146,10 +146,10 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 	return result, nil
 }
 
-func (s *SecretsAPI) secretContentFromStore(providerId string) (coresecrets.SecretValue, error) {
+func (s *SecretsAPI) secretContentFromStore(backendId string) (coresecrets.SecretValue, error) {
 	store, err := s.storeGetter()
 	if err != nil {
 		return nil, err
 	}
-	return store.GetContent(context.Background(), providerId)
+	return store.GetContent(context.Background(), backendId)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38529,6 +38529,9 @@
                 "SecretRevision": {
                     "type": "object",
                     "properties": {
+                        "backend-id": {
+                            "type": "string"
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
@@ -38536,9 +38539,6 @@
                         "expire-time": {
                             "type": "string",
                             "format": "date-time"
-                        },
-                        "provider-id": {
-                            "type": "string"
                         },
                         "revision": {
                             "type": "integer"
@@ -39167,6 +39167,9 @@
                 "SecretContentParams": {
                     "type": "object",
                     "properties": {
+                        "backend-id": {
+                            "type": "string"
+                        },
                         "data": {
                             "type": "object",
                             "patternProperties": {
@@ -39174,9 +39177,6 @@
                                     "type": "string"
                                 }
                             }
-                        },
-                        "provider-id": {
-                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -39214,6 +39214,9 @@
                 "SecretRevision": {
                     "type": "object",
                     "properties": {
+                        "backend-id": {
+                            "type": "string"
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
@@ -39221,9 +39224,6 @@
                         "expire-time": {
                             "type": "string",
                             "format": "date-time"
-                        },
-                        "provider-id": {
-                            "type": "string"
                         },
                         "revision": {
                             "type": "integer"
@@ -47229,6 +47229,9 @@
                 "SecretContentParams": {
                     "type": "object",
                     "properties": {
+                        "backend-id": {
+                            "type": "string"
+                        },
                         "data": {
                             "type": "object",
                             "patternProperties": {
@@ -47236,9 +47239,6 @@
                                     "type": "string"
                                 }
                             }
-                        },
-                        "provider-id": {
-                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -47276,6 +47276,9 @@
                 "SecretRevision": {
                     "type": "object",
                     "properties": {
+                        "backend-id": {
+                            "type": "string"
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
@@ -47283,9 +47286,6 @@
                         "expire-time": {
                             "type": "string",
                             "format": "date-time"
-                        },
-                        "provider-id": {
-                            "type": "string"
                         },
                         "revision": {
                             "type": "integer"

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -238,12 +238,12 @@ func (k *kubernetesClient) GetSecretToken(name string) (string, error) {
 }
 
 // GetJujuSecret implements SecretsStore.
-func (k *kubernetesClient) GetJujuSecret(ctx context.Context, providerId string) (secrets.SecretValue, error) {
-	// providerId is the secret name.
-	secret, err := k.getSecret(providerId)
+func (k *kubernetesClient) GetJujuSecret(ctx context.Context, backendId string) (secrets.SecretValue, error) {
+	// backendId is the secret name.
+	secret, err := k.getSecret(backendId)
 	if k8serrors.IsForbidden(err) {
-		logger.Tracef("getting secret %q: %v", providerId, err)
-		return nil, errors.Unauthorizedf("cannot access %q", providerId)
+		logger.Tracef("getting secret %q: %v", backendId, err)
+		return nil, errors.Unauthorizedf("cannot access %q", backendId)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -273,12 +273,12 @@ func (k *kubernetesClient) SaveJujuSecret(ctx context.Context, name string, valu
 }
 
 // DeleteJujuSecret implements SecretsStore.
-func (k *kubernetesClient) DeleteJujuSecret(ctx context.Context, providerId string) error {
-	// providerId is the secret name.
-	secret, err := k.getSecret(providerId)
+func (k *kubernetesClient) DeleteJujuSecret(ctx context.Context, backendId string) error {
+	// backendId is the secret name.
+	secret, err := k.getSecret(backendId)
 	if k8serrors.IsForbidden(err) {
-		logger.Tracef("deleting secret %q: %v", providerId, err)
-		return errors.Unauthorizedf("cannot access %q", providerId)
+		logger.Tracef("deleting secret %q: %v", backendId, err)
+		return errors.Unauthorizedf("cannot access %q", backendId)
 	}
 	if errors.IsNotFound(err) {
 		return nil

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -146,7 +146,7 @@ type SecretMetadata struct {
 // SecretRevisionMetadata holds metadata about a secret revision.
 type SecretRevisionMetadata struct {
 	Revision   int
-	ProviderId *string
+	BackendId  *string
 	CreateTime time.Time
 	UpdateTime time.Time
 	ExpireTime *time.Time
@@ -154,8 +154,8 @@ type SecretRevisionMetadata struct {
 
 // SecretOwnerMetadata holds a secret metadata and any provider ids of revisions.
 type SecretOwnerMetadata struct {
-	Metadata    SecretMetadata
-	ProviderIds map[int]string
+	Metadata   SecretMetadata
+	BackendIds map[int]string
 }
 
 // SecretConsumerMetadata holds metadata about a secret

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/juju/clock v1.0.2
 	github.com/juju/cmd/v3 v3.0.2
 	github.com/juju/collections v1.0.0
-	github.com/juju/description/v4 v4.0.0
+	github.com/juju/description/v4 v4.0.1
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -766,8 +766,6 @@ github.com/juju/collections v0.0.0-20200605021417-0d0ec82b7271/go.mod h1:5XgO71d
 github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.0 h1:iuWddKN/SMbjLoyOpcnAl8XyBCavZm6coeFBcXQldbw=
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
-github.com/juju/description/v4 v4.0.0 h1:DxJvkygtQFcPepVrk62vSxJrEBFlsYDZl/mJ5TjdX9U=
-github.com/juju/description/v4 v4.0.0/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/description/v4 v4.0.1 h1:+JpvTFh0LSvGO3zkLeD/yijv+zVIrEBp36WyO9QCYd8=
 github.com/juju/description/v4 v4.0.1/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=

--- a/go.sum
+++ b/go.sum
@@ -768,6 +768,8 @@ github.com/juju/collections v1.0.0 h1:iuWddKN/SMbjLoyOpcnAl8XyBCavZm6coeFBcXQldb
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/description/v4 v4.0.0 h1:DxJvkygtQFcPepVrk62vSxJrEBFlsYDZl/mJ5TjdX9U=
 github.com/juju/description/v4 v4.0.0/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
+github.com/juju/description/v4 v4.0.1 h1:+JpvTFh0LSvGO3zkLeD/yijv+zVIrEBp36WyO9QCYd8=
+github.com/juju/description/v4 v4.0.1/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -19,8 +19,8 @@ type SecretStoreConfig struct {
 type SecretContentParams struct {
 	// Data is the key values of the secret value itself.
 	Data map[string]string `json:"data,omitempty"`
-	// ProviderId is the content id for when a secret store like vault is used.
-	ProviderId *string `json:"provider-id,omitempty"`
+	// BackendId is the content id for when a secret store like vault is used.
+	BackendId *string `json:"backend-id,omitempty"`
 }
 
 // UpsertSecretArg holds the args for creating or updating a secret.
@@ -154,7 +154,7 @@ type ListSecretResults struct {
 
 type SecretRevision struct {
 	Revision   int        `json:"revision"`
-	ProviderId *string    `json:"provider-id,omitempty"`
+	BackendId  *string    `json:"backend-id,omitempty"`
 	CreateTime time.Time  `json:"create-time,omitempty"`
 	UpdateTime time.Time  `json:"update-time,omitempty"`
 	ExpireTime *time.Time `json:"expire-time,omitempty"`

--- a/secrets/interface.go
+++ b/secrets/interface.go
@@ -90,5 +90,5 @@ type Store interface {
 	SaveContent(uri *secrets.URI, revision int, value secrets.SecretValue) (string, error)
 
 	// DeleteContent deletes a secret from an external store.
-	DeleteContent(BackendId string) error
+	DeleteContent(backendId string) error
 }

--- a/secrets/interface.go
+++ b/secrets/interface.go
@@ -22,12 +22,12 @@ const (
 // access the content from an external provider like vault.
 type ContentParams struct {
 	secrets.SecretValue
-	ProviderId *string
+	BackendId *string
 }
 
 // Validate returns an error if the content is invalid.
 func (p *ContentParams) Validate() error {
-	if p.ProviderId == nil && p.SecretValue == nil {
+	if p.BackendId == nil && p.SecretValue == nil {
 		return errors.NotValidf("secret content without value or provider id")
 	}
 	return nil
@@ -90,5 +90,5 @@ type Store interface {
 	SaveContent(uri *secrets.URI, revision int, value secrets.SecretValue) (string, error)
 
 	// DeleteContent deletes a secret from an external store.
-	DeleteContent(providerId string) error
+	DeleteContent(BackendId string) error
 }

--- a/secrets/provider/kubernetes/secrets.go
+++ b/secrets/provider/kubernetes/secrets.go
@@ -234,13 +234,13 @@ type k8sStore struct {
 }
 
 // GetContent implements SecretsStore.
-func (k k8sStore) GetContent(ctx context.Context, providerId string) (secrets.SecretValue, error) {
-	return k.broker.GetJujuSecret(ctx, providerId)
+func (k k8sStore) GetContent(ctx context.Context, backendId string) (secrets.SecretValue, error) {
+	return k.broker.GetJujuSecret(ctx, backendId)
 }
 
 // DeleteContent implements SecretsStore.
-func (k k8sStore) DeleteContent(ctx context.Context, providerId string) error {
-	return k.broker.DeleteJujuSecret(ctx, providerId)
+func (k k8sStore) DeleteContent(ctx context.Context, backendId string) error {
+	return k.broker.DeleteJujuSecret(ctx, backendId)
 }
 
 // SaveContent implements SecretsStore.

--- a/secrets/provider/store.go
+++ b/secrets/provider/store.go
@@ -12,8 +12,8 @@ import (
 // SecretsStore is an external secrets store like vault.
 type SecretsStore interface {
 	SaveContent(_ context.Context, uri *secrets.URI, revision int, value secrets.SecretValue) (string, error)
-	GetContent(_ context.Context, providerId string) (secrets.SecretValue, error)
-	DeleteContent(_ context.Context, providerId string) error
+	GetContent(_ context.Context, backendId string) (secrets.SecretValue, error)
+	DeleteContent(_ context.Context, backendId string) error
 }
 
 // StoreConfig is used when constructing a secrets store.

--- a/secrets/provider/vault/secrets.go
+++ b/secrets/provider/vault/secrets.go
@@ -367,14 +367,14 @@ type vaultStore struct {
 }
 
 // GetContent implements SecretsStore.
-func (k vaultStore) GetContent(ctx context.Context, providerId string) (_ secrets.SecretValue, err error) {
+func (k vaultStore) GetContent(ctx context.Context, backendId string) (_ secrets.SecretValue, err error) {
 	defer func() {
 		err = maybePermissionDenied(err)
 	}()
 
-	s, err := k.client.KVv1(k.modelUUID).Get(ctx, providerId)
+	s, err := k.client.KVv1(k.modelUUID).Get(ctx, backendId)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting secret %q", providerId)
+		return nil, errors.Annotatef(err, "getting secret %q", backendId)
 	}
 	val := make(map[string]string)
 	for k, v := range s.Data {
@@ -384,12 +384,12 @@ func (k vaultStore) GetContent(ctx context.Context, providerId string) (_ secret
 }
 
 // DeleteContent implements SecretsStore.
-func (k vaultStore) DeleteContent(ctx context.Context, providerId string) (err error) {
+func (k vaultStore) DeleteContent(ctx context.Context, backendId string) (err error) {
 	defer func() {
 		err = maybePermissionDenied(err)
 	}()
 
-	err = k.client.KVv1(k.modelUUID).Delete(ctx, providerId)
+	err = k.client.KVv1(k.modelUUID).Delete(ctx, backendId)
 	if isNotFound(err) {
 		return nil
 	}

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -55,11 +55,11 @@ func (c *secretsClient) GetContent(uri *secrets.URI, label string, refresh, peek
 	}
 	// We just support the juju backend for now.
 	// In the future, we'll use the store to lookup the secret content based on id.
-	if content.ProviderId != nil && c.store == nil {
+	if content.BackendId != nil && c.store == nil {
 		return nil, errors.NotSupportedf("secret content from external store")
 	}
-	if content.ProviderId != nil {
-		return c.store.GetContent(context.Background(), *content.ProviderId)
+	if content.BackendId != nil {
+		return c.store.GetContent(context.Background(), *content.BackendId)
 	}
 	return content.SecretValue, nil
 }
@@ -73,9 +73,9 @@ func (c *secretsClient) SaveContent(uri *secrets.URI, revision int, value secret
 }
 
 // DeleteContent implements Client.
-func (c *secretsClient) DeleteContent(providerId string) error {
+func (c *secretsClient) DeleteContent(backendId string) error {
 	if c.store == nil {
 		return errors.NotSupportedf("deleting secret content from external store")
 	}
-	return c.store.DeleteContent(context.Background(), providerId)
+	return c.store.DeleteContent(context.Background(), backendId)
 }

--- a/state/application.go
+++ b/state/application.go
@@ -688,13 +688,7 @@ func (a *Application) removeOps(asserts bson.D, op *ForcedOperation) ([]txn.Op, 
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, secretPermissionsOps...)
-	secretLabelOps, err := a.st.removeOwnerSecretLabelOps(a.ApplicationTag())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ops = append(ops, secretLabelOps...)
-
-	secretLabelOps, err = a.st.removeConsumerSecretLabelOps(a.ApplicationTag())
+	secretLabelOps, err := a.st.removeSecretLabelOps(a.ApplicationTag())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -2757,12 +2751,8 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	if op.FatalError(err) {
 		return nil, errors.Trace(err)
 	}
-	secretOwnerLabelOps, err := a.st.removeOwnerSecretLabelOps(u.Tag())
+	secretLabelOps, err := a.st.removeSecretLabelOps(u.Tag())
 	if op.FatalError(err) {
-		return nil, errors.Trace(err)
-	}
-	secretConsumerLabelOps, err := a.st.removeConsumerSecretLabelOps(u.Tag())
-	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -2791,8 +2781,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	ops = append(ops, resOps...)
 	ops = append(ops, hostOps...)
 	ops = append(ops, secretPermissionsOps...)
-	ops = append(ops, secretOwnerLabelOps...)
-	ops = append(ops, secretConsumerLabelOps...)
+	ops = append(ops, secretLabelOps...)
 
 	m, err := a.st.Model()
 	if err != nil {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1739,7 +1739,7 @@ func (e *exporter) secrets() error {
 			Created:    rev.CreateTime,
 			Updated:    rev.UpdateTime,
 			ExpireTime: rev.ExpireTime,
-			ProviderId: rev.BackendId,
+			BackendId:  rev.BackendId,
 		}
 		if len(rev.Data) > 0 {
 			revArg.Content = make(secrets.SecretData)

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1739,7 +1739,7 @@ func (e *exporter) secrets() error {
 			Created:    rev.CreateTime,
 			Updated:    rev.UpdateTime,
 			ExpireTime: rev.ExpireTime,
-			ProviderId: rev.ProviderId,
+			ProviderId: rev.BackendId,
 		}
 		if len(rev.Data) > 0 {
 			revArg.Content = make(secrets.SecretData)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -2719,7 +2719,7 @@ func (s *MigrationExportSuite) TestSecrets(c *gc.C) {
 	c.Assert(revisions, gc.HasLen, 2)
 	c.Assert(revisions[0].Content(), jc.DeepEquals, map[string]string{"foo": "bar"})
 	c.Assert(revisions[0].ExpireTime(), jc.DeepEquals, ptr(expire))
-	c.Assert(revisions[1].ProviderId(), jc.DeepEquals, ptr("backend-id"))
+	c.Assert(revisions[1].BackendId(), jc.DeepEquals, ptr("backend-id"))
 	consumers := secret.Consumers()
 	c.Assert(consumers, gc.HasLen, 1)
 	info := consumers[0]

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -2678,7 +2678,7 @@ func (s *MigrationExportSuite) TestSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	md, err = store.UpdateSecret(md.URI, state.UpdateSecretParams{
 		LeaderToken: &fakeToken{},
-		ProviderId:  ptr("provider-id"),
+		BackendId:   ptr("backend-id"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
@@ -2719,7 +2719,7 @@ func (s *MigrationExportSuite) TestSecrets(c *gc.C) {
 	c.Assert(revisions, gc.HasLen, 2)
 	c.Assert(revisions[0].Content(), jc.DeepEquals, map[string]string{"foo": "bar"})
 	c.Assert(revisions[0].ExpireTime(), jc.DeepEquals, ptr(expire))
-	c.Assert(revisions[1].ProviderId(), jc.DeepEquals, ptr("provider-id"))
+	c.Assert(revisions[1].ProviderId(), jc.DeepEquals, ptr("backend-id"))
 	consumers := secret.Consumers()
 	c.Assert(consumers, gc.HasLen, 1)
 	info := consumers[0]

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -581,7 +581,7 @@ func (ImportSecrets) Execute(src SecretsInput, runner TransactionRunner) error {
 					ExpireTime: rev.ExpireTime(),
 					Obsolete:   rev.Obsolete(),
 					Data:       dataCopy,
-					BackendId:  rev.ProviderId(),
+					BackendId:  rev.BackendId(),
 					OwnerTag:   owner.String(),
 				},
 			})

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -581,7 +581,7 @@ func (ImportSecrets) Execute(src SecretsInput, runner TransactionRunner) error {
 					ExpireTime: rev.ExpireTime(),
 					Obsolete:   rev.Obsolete(),
 					Data:       dataCopy,
-					ProviderId: rev.ProviderId(),
+					BackendId:  rev.ProviderId(),
 					OwnerTag:   owner.String(),
 				},
 			})

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2875,7 +2875,7 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	updateTime := time.Now().UTC().Round(time.Second)
 	md, err = store.UpdateSecret(md.URI, state.UpdateSecretParams{
 		LeaderToken: &fakeToken{},
-		ProviderId:  ptr("provider-id"),
+		BackendId:   ptr("backend-id"),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
@@ -2912,13 +2912,13 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	mc.AddExpr(`_.UpdateTime`, jc.Almost, jc.ExpectedValue)
 	c.Assert(revs, mc, []*secrets.SecretRevisionMetadata{{
 		Revision:   1,
-		ProviderId: nil,
+		BackendId:  nil,
 		CreateTime: createTime,
 		UpdateTime: updateTime,
 		ExpireTime: &expire,
 	}, {
 		Revision:   2,
-		ProviderId: ptr("provider-id"),
+		BackendId:  ptr("backend-id"),
 		CreateTime: createTime,
 		UpdateTime: createTime,
 	}})

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -961,7 +961,7 @@ func (s *MigrationSuite) TestSecretRevisionDocFields(c *gc.C) {
 		"UpdateTime",
 		"ExpireTime",
 		"Obsolete",
-		"ProviderId",
+		"BackendId",
 		"Data",
 		"OwnerTag",
 	)

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -96,23 +96,23 @@ func (s *SecretsSuite) TestCreate(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
 }
 
-func (s *SecretsSuite) TestCreateProviderId(c *gc.C) {
+func (s *SecretsSuite) TestCreateBackendId(c *gc.C) {
 	uri := secrets.NewURI()
 	p := state.CreateSecretParams{
 		Version: 1,
 		Owner:   s.owner.Tag(),
 		UpdateSecretParams: state.UpdateSecretParams{
 			LeaderToken: &fakeToken{},
-			ProviderId:  ptr("provider-id"),
+			BackendId:   ptr("backend-id"),
 		},
 	}
 	_, err := s.store.CreateSecret(uri, p)
 	c.Assert(err, jc.ErrorIsNil)
-	v, providerId, err := s.store.GetSecretValue(uri, 1)
+	v, backendId, err := s.store.GetSecretValue(uri, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(v.EncodedValues(), gc.HasLen, 0)
-	c.Assert(providerId, gc.NotNil)
-	c.Assert(*providerId, gc.Equals, "provider-id")
+	c.Assert(backendId, gc.NotNil)
+	c.Assert(*backendId, gc.Equals, "backend-id")
 }
 
 func (s *SecretsSuite) TestCreateDuplicateLabel(c *gc.C) {
@@ -177,9 +177,9 @@ func (s *SecretsSuite) TestGetValue(c *gc.C) {
 	md, err := s.store.CreateSecret(uri, p)
 	c.Assert(err, jc.ErrorIsNil)
 
-	val, providerId, err := s.store.GetSecretValue(md.URI, 1)
+	val, backendId, err := s.store.GetSecretValue(md.URI, 1)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(providerId, gc.IsNil)
+	c.Assert(backendId, gc.IsNil)
 	c.Assert(val.EncodedValues(), jc.DeepEquals, map[string]string{
 		"foo": "bar",
 	})
@@ -663,13 +663,13 @@ func (s *SecretsSuite) assertUpdatedSecret(c *gc.C, original *secrets.SecretMeta
 	if update.Data != nil {
 		expectedData = update.Data
 	}
-	val, providerId, err := s.store.GetSecretValue(md.URI, expectedRevision)
+	val, backendId, err := s.store.GetSecretValue(md.URI, expectedRevision)
 	c.Assert(err, jc.ErrorIsNil)
-	if update.ProviderId != nil {
-		c.Assert(providerId, gc.NotNil)
-		c.Assert(*update.ProviderId, gc.Equals, *providerId)
+	if update.BackendId != nil {
+		c.Assert(backendId, gc.NotNil)
+		c.Assert(*update.BackendId, gc.Equals, *backendId)
 	} else {
-		c.Assert(providerId, gc.IsNil)
+		c.Assert(backendId, gc.IsNil)
 		c.Assert(val.EncodedValues(), jc.DeepEquals, expectedData)
 	}
 	if update.ExpireTime != nil {
@@ -784,7 +784,7 @@ func (s *SecretsSuite) TestListSecretRevisions(c *gc.C) {
 	updateTime := s.Clock.Now().Round(time.Second).UTC()
 	s.assertUpdatedSecret(c, md, 3, state.UpdateSecretParams{
 		LeaderToken: &fakeToken{},
-		ProviderId:  ptr("provider-id"),
+		BackendId:   ptr("backend-id"),
 	})
 	updateTime2 := s.Clock.Now().Round(time.Second).UTC()
 	r, err := s.store.ListSecretRevisions(uri)
@@ -803,7 +803,7 @@ func (s *SecretsSuite) TestListSecretRevisions(c *gc.C) {
 		UpdateTime: updateTime,
 	}, {
 		Revision:   3,
-		ProviderId: ptr("provider-id"),
+		BackendId:  ptr("backend-id"),
 		CreateTime: updateTime2,
 		UpdateTime: updateTime2,
 	}})

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1415,7 +1415,7 @@ func (ctx *HookContext) doFlush(process string) error {
 	pendingUpdates := make([]uniter.SecretUpsertArg, len(ctx.secretChanges.pendingUpdates))
 	pendingDeletes := make([]uniter.SecretDeleteArg, len(ctx.secretChanges.pendingDeletes))
 	for i, c := range ctx.secretChanges.pendingCreates {
-		providerId, err := secretsStore.SaveContent(c.URI, 1, c.Value)
+		backendId, err := secretsStore.SaveContent(c.URI, 1, c.Value)
 		if errors.IsNotSupported(err) {
 			pendingCreates[i] = c
 			continue
@@ -1423,8 +1423,8 @@ func (ctx *HookContext) doFlush(process string) error {
 		if err != nil {
 			return errors.Annotatef(err, "saving content for secret %q", c.URI.ID)
 		}
-		cleanups = append(cleanups, providerId)
-		c.ProviderId = &providerId
+		cleanups = append(cleanups, backendId)
+		c.BackendId = &backendId
 		c.Value = nil
 		pendingCreates[i] = c
 	}
@@ -1435,7 +1435,7 @@ func (ctx *HookContext) doFlush(process string) error {
 			pendingUpdates[i] = u.SecretUpsertArg
 			continue
 		}
-		providerId, err := secretsStore.SaveContent(u.URI, u.CurrentRevision+1, u.Value)
+		backendId, err := secretsStore.SaveContent(u.URI, u.CurrentRevision+1, u.Value)
 		if errors.IsNotSupported(err) {
 			pendingUpdates[i] = u.SecretUpsertArg
 			continue
@@ -1443,8 +1443,8 @@ func (ctx *HookContext) doFlush(process string) error {
 		if err != nil {
 			return errors.Annotatef(err, "saving content for secret %q", u.URI.ID)
 		}
-		cleanups = append(cleanups, providerId)
-		u.ProviderId = &providerId
+		cleanups = append(cleanups, backendId)
+		u.BackendId = &backendId
 		u.Value = nil
 		pendingUpdates[i] = u.SecretUpsertArg
 	}
@@ -1455,19 +1455,19 @@ func (ctx *HookContext) doFlush(process string) error {
 		if !ok {
 			continue
 		}
-		var providerIds []string
+		var backendIds []string
 		if d.Revision == nil {
-			for _, providerId := range md.ProviderIds {
-				providerIds = append(providerIds, providerId)
+			for _, backendId := range md.BackendIds {
+				backendIds = append(backendIds, backendId)
 			}
 		} else {
-			if providerId, ok := md.ProviderIds[*d.Revision]; ok {
-				providerIds = []string{providerId}
+			if backendId, ok := md.BackendIds[*d.Revision]; ok {
+				backendIds = []string{backendId}
 			}
 		}
-		ctx.logger.Debugf("deleting secret %q provider ids: %v", d.URI.String(), providerIds)
+		ctx.logger.Debugf("deleting secret %q provider ids: %v", d.URI.String(), backendIds)
 	deleteDone:
-		for _, secretId := range providerIds {
+		for _, secretId := range backendIds {
 			if err := secretsStore.DeleteContent(secretId); err != nil {
 				if errors.IsNotSupported(err) {
 					break deleteDone

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -426,9 +426,9 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 	ctx.secretMetadata = make(map[string]jujuc.SecretMetadata)
 	for _, v := range info {
 		md := v.Metadata
-		providerIds := make(map[int]string)
-		for rev, id := range v.ProviderIds {
-			providerIds[rev] = id
+		backendIds := make(map[int]string)
+		for rev, id := range v.BackendIds {
+			backendIds[rev] = id
 		}
 		ownerTag, err := names.ParseTag(md.OwnerTag)
 		if err != nil {
@@ -442,7 +442,7 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 			LatestRevision:   md.LatestRevision,
 			LatestExpireTime: md.LatestExpireTime,
 			NextRotateTime:   md.NextRotateTime,
-			ProviderIds:      providerIds,
+			BackendIds:       backendIds,
 		}
 	}
 

--- a/worker/uniter/runner/jujuc/context.go
+++ b/worker/uniter/runner/jujuc/context.go
@@ -204,7 +204,7 @@ type SecretMetadata struct {
 	LatestRevision   int
 	LatestExpireTime *time.Time
 	NextRotateTime   *time.Time
-	ProviderIds      map[int]string
+	BackendIds       map[int]string
 }
 
 // ContextSecrets is the part of a hook context related to secrets.

--- a/worker/uniter/runner/testing/utils.go
+++ b/worker/uniter/runner/testing/utils.go
@@ -161,7 +161,7 @@ func (s SecretsContextAccessor) SecretMetadata(filter secrets.Filter) ([]secrets
 			RotatePolicy:   secrets.RotateHourly,
 			Label:          "label",
 		},
-		ProviderIds: map[int]string{666: "provider-id"},
+		BackendIds: map[int]string{666: "backend-id"},
 	}}, nil
 }
 
@@ -169,6 +169,6 @@ func (s SecretsContextAccessor) SaveContent(uri *secrets.URI, revision int, valu
 	return "", errors.NotSupportedf("")
 }
 
-func (s SecretsContextAccessor) DeleteContent(providerId string) error {
+func (s SecretsContextAccessor) DeleteContent(backendId string) error {
 	return errors.NotSupportedf("")
 }


### PR DESCRIPTION
This PR fixes owner + consumer labels should be unique for each unit/application;

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
$ juju deploy prometheus-k8s --trust

$ juju deploy kube-state-metrics

$ juju relate kube-state-metrics prometheus-k8s

$ juju scale-application prometheus-k8s 2
prometheus-k8s scaled to 2 units

$ juju exec --unit prometheus-k8s/0 'uri=$(secret-add app=prometheus-k8s); echo $uri; secret-set $uri --label=prometheus-k8s;'

secret:cdurldeffbas7aqd6oeg

$ juju exec --unit prometheus-k8s/0 'uri=$(secret-add --owner unit unit=prometheus-k8s/0); echo $uri; secret-set $uri --label=prometheus-k8s/0;'

secret:cdurlluffbas7aqd6of0

$ juju exec --unit prometheus-k8s/0 -- secret-get cdurldeffbas7aqd6oeg
app: prometheus-k8s

$ juju exec --unit prometheus-k8s/0 -- secret-get cdurlluffbas7aqd6of0
unit: prometheus-k8s/0

$ juju exec --unit prometheus-k8s/0 -- secret-get --label prometheus-k8s
app: prometheus-k8s

$ juju exec --unit prometheus-k8s/0 -- secret-get --label prometheus-k8s/0
unit: prometheus-k8s/0

$ juju exec --unit prometheus-k8s/1 -- secret-get --label prometheus-k8s
app: prometheus-k8s

$ juju exec --unit prometheus-k8s/1 -- secret-get --label prometheus-k8s/0
ERROR consumer label "prometheus-k8s/0" not found
ERROR the following task failed:
 - id "25" with return code 1

use 'juju show-task' to inspect the failure

$ juju exec --unit prometheus-k8s/0 "secret-grant -r 1 secret:cdurldeffbas7aqd6oeg"

$ juju exec --unit prometheus-k8s/0 "secret-grant -r 1 secret:cdurlluffbas7aqd6of0"

$ juju exec --unit kube-state-metrics/0 -- secret-get cdurldeffbas7aqd6oeg
app: prometheus-k8s

$ juju exec --unit kube-state-metrics/0 -- secret-get cdurlluffbas7aqd6of0
unit: prometheus-k8s/0

$ juju exec --unit kube-state-metrics/0 -- secret-get cdurnauffbas7aqd6ofg --label prometheus-k8s/0
unit: prometheus-k8s/0

$ juju exec --unit kube-state-metrics/0 -- secret-get --label prometheus-k8s/0
unit: prometheus-k8s/0

$ juju exec --unit kube-state-metrics/0 -- secret-get cdurldeffbas7aqd6oeg --label prometheus-k8s
app: prometheus-k8s

$ juju exec --unit kube-state-metrics/0 -- secret-get  --label prometheus-k8s
app: prometheus-k8s

$ juju exec --unit kube-state-metrics/0 -- secret-add --owner unit unit=kube-state-metrics/0 --label=prometheus-k8s/0
secret:cduscj6ffbas763r7r20
creating secrets: secret with label "prometheus-k8s/0" already exists
```

## Documentation changes
No

## Bug reference

No
