### PR TITLE
[JUJU-2251] Added skip-confirmation parameter to controller-config.

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -261,6 +261,9 @@ const (
 	// PublicDNSAddress is the public DNS address (and port) of the controller.
 	PublicDNSAddress = "public-dns-address"
 
+	// SkipConfirmation determines whether destroying/killing/unregistering controller require confirmation or not
+	SkipConfirmation = "skip-confirmation"
+
 	// Attribute Defaults
 
 	// DefaultApplicationResourceDownloadLimit allows unlimited
@@ -382,6 +385,9 @@ const (
 
 	// DefaultMigrationMinionWaitMax is the default value for
 	DefaultMigrationMinionWaitMax = "15m"
+
+	// DefaultSkipConfirmation is default value for skip-confirmation
+	DefaultSkipConfirmation = true
 )
 
 var (
@@ -488,6 +494,7 @@ var (
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
+		SkipConfirmation,
 	)
 
 	// DefaultAuditLogExcludeMethods is the default list of methods to
@@ -1049,6 +1056,15 @@ func (c Config) MigrationMinionWaitMax() time.Duration {
 	return val
 }
 
+// SkipConfirmation returns whether or not skip controller destroying/killing/unregistering confirmation.
+// The default is true.
+func (c Config) SkipConfirmation() bool {
+	if v, ok := c[SkipConfirmation]; ok {
+		return v.(bool)
+	}
+	return DefaultSkipConfirmation
+}
+
 // Validate ensures that config is a valid configuration.
 func Validate(c Config) error {
 	if v, ok := c[IdentityPublicKey].(string); ok {
@@ -1384,6 +1400,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MigrationMinionWaitMax:           schema.String(),
 	ApplicationResourceDownloadLimit: schema.ForceInt(),
 	ControllerResourceDownloadLimit:  schema.ForceInt(),
+	SkipConfirmation:                 schema.Bool(),
 }, schema.Defaults{
 	AgentRateLimitMax:                schema.Omit,
 	AgentRateLimitRate:               schema.Omit,
@@ -1431,6 +1448,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MigrationMinionWaitMax:           DefaultMigrationMinionWaitMax,
 	ApplicationResourceDownloadLimit: schema.Omit,
 	ControllerResourceDownloadLimit:  schema.Omit,
+	SkipConfirmation:                 DefaultSkipConfirmation,
 })
 
 // ConfigSchema holds information on all the fields defined by
@@ -1625,5 +1643,9 @@ Use "caas-image-repo" instead.`,
 	MigrationMinionWaitMax: {
 		Type:        environschema.Tstring,
 		Description: `The maximum during model migrations that the migration worker will wait for agents to report on phases of the migration`,
+	},
+	SkipConfirmation: {
+		Description: "Determines determines whether destroying/killing/unregistering controller require confirmation or not",
+		Type:        environschema.Tbool,
 	},
 }


### PR DESCRIPTION
This PR adds a new parameter (`skip-confirmation`) to the controller config. This parameter will determine whether to ask for confirmation or not while destroying/killing/unregistering the controller or not.

The default value for branch 3.0 == TRUE.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
juju boostrap lxd lxd
juju controller-config | grep skip-confirmation
```

The result should be:
```
skip-confirmation              true
```

## Documentation changes

Add skip-confirmation to: https://juju.is/docs/olm/list-of-controller-configuration-keys
