### PR TITLE
[JUJU-2221] Add a --no-prompt flag to remove-machine/app/unit

### DIFF
--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -84,6 +84,9 @@ func (c *removeApplicationCommand) Info() *cmd.Info {
 
 func (c *removeApplicationCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
+	// This unused var is declared so we can pass a valid ptr into BoolVar
+	var noPromptHolder bool
+	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
 	f.BoolVar(&c.DestroyStorage, "destroy-storage", false, "Destroy storage attached to application units")
 	f.BoolVar(&c.Force, "force", false, "Completely remove an application and all its dependencies")
 	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through application removal without waiting for each individual step to complete")

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -106,6 +106,9 @@ func (c *removeUnitCommand) Info() *cmd.Info {
 
 func (c *removeUnitCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
+	// This unused var is declared so we can pass a valid ptr into BoolVar
+	var noPromptHolder bool
+	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
 	f.IntVar(&c.NumUnits, "num-units", 0, "Number of units to remove (k8s models only)")
 	f.BoolVar(&c.DestroyStorage, "destroy-storage", false, "Destroy storage attached to the unit")
 	f.BoolVar(&c.Force, "force", false, "Completely remove an unit and all its dependencies")

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -78,6 +78,9 @@ func (c *removeCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *removeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
+	// This unused var is declared so we can pass a valid ptr into BoolVar
+	var noPromptHolder bool
+	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
 	f.BoolVar(&c.Force, "force", false, "Completely remove a machine and all its dependencies")
 	f.BoolVar(&c.KeepInstance, "keep-instance", false, "Do not stop the running cloud instance")
 	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through machine removal without waiting for each individual step to complete")


### PR DESCRIPTION
Add a flag `no-prompt` which does nothing

This is for forward compatibility with Juju 3, where this flag will be present and change behaviour

See https://docs.google.com/document/d/1FxuFqHf67b3s2sUoTMEYjNxRlIFTG9K-L_zS-5Zf2k8/edit#

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```
juju deploy ubuntu -n3
juju remove-unit ubuntu/2 --no-prompt
juju remove-machine 1 --no-prompt --force
juju remove-application ubuntu --no-prompt
```

You can also just check `--no-prompt` is present in command help texts