### PR TITLE
[JUJU-2252] WIP: Adding support of env var to manage skip-confirmation.

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
@@ -1066,11 +1065,7 @@ func (c Config) SkipConfirmation() bool {
 		return v.(bool)
 	}
 	if environmentValue := os.Getenv(osenv.JujuSkipConfirmationEnvKey); environmentValue != "" {
-		boolValue, err := strconv.ParseBool(environmentValue)
-		if err != nil {
-			errors.Errorf("Value (%s) of JUJU_SKIP_CONFIRMATION env var is not a boolean", osenv.JujuSkipConfirmationEnvKey)
-		}
-		return boolValue
+		return true
 	} else {
 		return DefaultSkipConfirmation
 	}

--- a/controller/config.go
+++ b/controller/config.go
@@ -5,8 +5,11 @@ package controller
 
 import (
 	"fmt"
+	"github.com/juju/juju/juju/osenv"
 	"net/url"
+	"os"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
@@ -1062,7 +1065,15 @@ func (c Config) SkipConfirmation() bool {
 	if v, ok := c[SkipConfirmation]; ok {
 		return v.(bool)
 	}
-	return DefaultSkipConfirmation
+	if environmentValue := os.Getenv(osenv.JujuSkipConfirmationEnvKey); environmentValue != "" {
+		boolValue, err := strconv.ParseBool(environmentValue)
+		if err != nil {
+			errors.Errorf("Value (%s) of JUJU_SKIP_CONFIRMATION env var is not a boolean", osenv.JujuSkipConfirmationEnvKey)
+		}
+		return boolValue
+	} else {
+		return DefaultSkipConfirmation
+	}
 }
 
 // Validate ensures that config is a valid configuration.

--- a/juju/osenv/vars.go
+++ b/juju/osenv/vars.go
@@ -54,6 +54,10 @@ const (
 	// timestamps to be written in RFC3339 format.
 	JujuStatusIsoTimeEnvKey = "JUJU_STATUS_ISO_TIME"
 
+	// JujuSkipConfirmationEnvKey is the env var which if true, will disable confirmation for removal
+	// and destroying commands in Juju CLI.
+	JujuSkipConfirmationEnvKey = "JUJU_SKIP_CONFIRMATION"
+
 	// XDGDataHome is a path where data for the running user
 	// should be stored according to the xdg standard.
 	XDGDataHome = "XDG_DATA_HOME"


### PR DESCRIPTION
This PR adds support of env var to manage skip-confirmation.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
JUJU_SKIP_CONFIRMATION=false juju bootstrap lxd lxd
juju controller-config | grep skip-confirmation
```

## Documentation changes

TBW
