### PR TITLE
Update canonical/has-signed-canonical-cla to v1.1.7

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@3eb79ef290553f0de096b3948a6770c15171fb15 # v1
+        uses: canonical/has-signed-canonical-cla@1.1.7
         with:
           accept-existing-contributors: true


### PR DESCRIPTION
Pull in action updates including moving to Node 16, which will fix some deprecation warnings in our Actions pipeline.

## QA steps

Ensure "CLA Check" passes below.
