### PR TITLE
[JUJU-2254] Do a client side check before committing hook for dup secret labels

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -840,7 +840,7 @@ func (ctx *HookContext) CreateSecret(args *jujuc.SecretCreateArgs) (*coresecrets
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ctx.secretChanges.create(uniter.SecretCreateArg{
+	err = ctx.secretChanges.create(uniter.SecretCreateArg{
 		SecretUpsertArg: uniter.SecretUpsertArg{
 			URI:          uris[0],
 			RotatePolicy: args.RotatePolicy,
@@ -851,6 +851,9 @@ func (ctx *HookContext) CreateSecret(args *jujuc.SecretCreateArgs) (*coresecrets
 		},
 		OwnerTag: args.OwnerTag,
 	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return uris[0], nil
 }
 


### PR DESCRIPTION
As reported here https://github.com/canonical/operator/issues/858

When a hook is committed, we do check for creating duplicate secret labels. But we can improve things by checking early in the pending creates before the hook is committed.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

In a hook
```
secret-add --label foo value=bar
secret-add --label foo value=baz
```

The second call will exit 1