### PR TITLE
[JUJU-2221] Separate confirmation prompt from warning prompt

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 
@@ -14,6 +15,8 @@ import (
 
 // This file contains helper functions for generic operations commonly needed
 // when implementing a command.
+
+const msg = "\nContinue [y/N]? "
 
 type userAbortedError string
 
@@ -30,6 +33,7 @@ func IsUserAbortedError(err error) bool {
 // UserConfirmYes returns an error if we do not read a "y" or "yes" from user
 // input.
 func UserConfirmYes(ctx *cmd.Context) error {
+	fmt.Fprint(ctx.Stdout, msg)
 	scanner := bufio.NewScanner(ctx.Stdin)
 	scanner.Scan()
 	err := scanner.Err()

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -487,7 +487,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	_, errc := cmdtest.RunCommandWithDummyProvider(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
-		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
+		c.Check(err, gc.ErrorMatches, "controller destruction: aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
@@ -500,7 +500,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	_, errc = cmdtest.RunCommandWithDummyProvider(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
-		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
+		c.Check(err, gc.ErrorMatches, "controller destruction: aborted")
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -105,8 +105,9 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 	if !c.assumeYes {
-		if err := confirmDestruction(ctx, controllerName); err != nil {
-			return err
+		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
+		if err := jujucmd.UserConfirmYes(ctx); err != nil {
+			return errors.Annotate(err, "controller destruction")
 		}
 	}
 

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -423,7 +423,7 @@ func (s *KillSuite) TestKillCommandConfirmation(c *gc.C) {
 	_, errc := cmdtest.RunCommandWithDummyProvider(ctx, s.newKillCommand(), "test1")
 	select {
 	case err := <-errc:
-		c.Check(err, gc.ErrorMatches, "controller destruction aborted")
+		c.Check(err, gc.ErrorMatches, "controller destruction: aborted")
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("command took too long")
 	}

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -93,8 +93,7 @@ var unregisterMsg = `
 This command will remove connection information for controller %q.
 Doing so will prevent you from accessing this controller until
 you register it again.
-
-Continue [y/N]?`[1:]
+`[1:]
 
 func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 

--- a/cmd/juju/controller/unregister_test.go
+++ b/cmd/juju/controller/unregister_test.go
@@ -88,7 +88,7 @@ This command will remove connection information for controller "fake1".
 Doing so will prevent you from accessing this controller until
 you register it again.
 
-Continue [y/N]?`[1:]
+Continue [y/N]? `[1:]
 
 func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
 	var stdin, stdout bytes.Buffer

--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -104,8 +104,7 @@ func (c *removeCommand) NewApplicationOffersAPI(controllerName string) (*applica
 var removeOfferMsg = `
 WARNING! This command will remove offers: %v
 This includes all relations to those offers.
-
-Continue [y/N]? `[1:]
+`[1:]
 
 // Run implements Command.Run.
 func (c *removeCommand) Run(ctx *cmd.Context) error {

--- a/cmd/juju/machine/upgrademachine.go
+++ b/cmd/juju/machine/upgrademachine.go
@@ -40,8 +40,7 @@ var SupportedJujuSeries = series.WorkloadSeries
 var upgradeSeriesConfirmationMsg = `
 WARNING: This command will mark machine %q as being upgraded to series %q.
 This operation cannot be reverted or canceled once started.
-%s
-Continue [y/N]?`[1:]
+%s`[1:]
 
 var upgradeSeriesAffectedMsg = `
 Units running on the machine will also be upgraded. These units include:

--- a/cmd/juju/machine/upgrademachine_test.go
+++ b/cmd/juju/machine/upgrademachine_test.go
@@ -211,7 +211,7 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesAbbreviation(c *gc
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldPromptUserForConfirmation(c *gc.C) {
 	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", machineArg, machine.PrepareCommand, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), jc.HasSuffix, "Continue [y/N]?")
+	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), jc.HasSuffix, "Continue [y/N]? ")
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldIndicateOnlySubordinatesOnMachine(c *gc.C) {

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -102,14 +102,12 @@ See also:
 var destroyIAASModelMsg = `
 WARNING! This command will destroy the %q model.
 This includes all machines, applications, data and other resources.
-
-Continue [y/N]? `[1:]
+`[1:]
 
 var destroyCAASModelMsg = `
 WARNING! This command will destroy the %q model.
 This includes all containers, applications, data and other resources.
-
-Continue [y/N]? `[1:]
+`[1:]
 
 // DestroyModelAPI defines the methods on the modelmanager
 // API that the destroy command calls. It is exported for mocking in tests.

--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -57,8 +57,13 @@ See also:
 var removeSpaceMsgNoBounds = `
 WARNING! This command will remove the space. 
 Safe removal possible. No constraints, bindings or controller config found with dependency on the given space.
+`[1:]
 
-Continue [y/N]? `[1:]
+var removeSpaceMsgBounds = `
+WARNING! This command will remove the space with the following existing boundaries:
+
+%v
+`[1:]
 
 // Info is defined on the cmd.Command interface.
 func (c *RemoveCommand) Info() *cmd.Info {
@@ -150,12 +155,7 @@ func (c *RemoveCommand) handleForceOption(api SpaceAPI, currentModel string, ctx
 	if len(errorList) == 0 {
 		fmt.Fprintf(ctx.Stdout, removeSpaceMsgNoBounds)
 	} else {
-		removeSpaceMsg := fmt.Sprintf(""+
-			"WARNING! This command will remove the space"+
-			" with the following existing boundaries:"+
-			"\n\n%v\n\n\n"+
-			"Continue [y/N]?", strings.Join(errorList, "\n"))
-		fmt.Fprintf(ctx.Stdout, removeSpaceMsg)
+		fmt.Fprintf(ctx.Stdout, removeSpaceMsgBounds, strings.Join(errorList, "\n"))
 	}
 	if err := jujucmd.UserConfirmYes(ctx); err != nil {
 		return errors.Annotate(err, "space removal")

--- a/cmd/juju/space/remove_test.go
+++ b/cmd/juju/space/remove_test.go
@@ -140,8 +140,7 @@ WARNING! This command will remove the space with the following existing boundari
 - "myspace" is used as a binding on: mysql, mediawiki
 - "myspace" is used for controller config(s): jujuhaspace, juuuu-space
 
-
-Continue [y/N]?`[1:]
+Continue [y/N]? `[1:]
 
 	ctx, _, err := s.runCommand(c, api, spaceName, "--force")
 


### PR DESCRIPTION
This will be useful for a future feature where we will be able to dry-run destruction commands

Also it should be the responsibility of UserConfirmYes to display the prompt asking for said input.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

Verify that:
```sh
juju destroy-controller
juju kill-controller
juju unregister
juju remove-offer
juju upgrade-machine
juju destroy-model
juju remove-space
```
all show the correct prompt (same as before)
