### PR TITLE
[JUJU-2253] Added --no-prompt flag to destroy-controller/kill-controller/unregister

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -553,6 +553,9 @@ func (c *destroyCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
+	// This unused var is declared to pass a valid ptr into BoolVar
+	var noPromptHolder bool
+	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -62,6 +62,9 @@ func (c *unregisterCommand) Info() *cmd.Info {
 func (c *unregisterCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.BoolVar(&c.assumeYes, "y", false, "Do not prompt for confirmation")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
+	// This unused var is declared to pass a valid ptr into BoolVar
+	var noPromptHolder bool
+	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
 }
 
 // SetClientStore implements Command.SetClientStore.


### PR DESCRIPTION
This PR the flag `--no-prompt` for compatability with Juju 3. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc


## QA steps

```sh
juju bootstrap lxd lxd
juju destroy-controller --no-prompt lxd

juju bootstrap lxd lxd2
juju kill-controller --no-prompt lxd2

juju unregister --help | grep --no-prompt
```
