### PR TITLE
Create refCount for the label role only but not for both owner and co…

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -688,7 +688,13 @@ func (a *Application) removeOps(asserts bson.D, op *ForcedOperation) ([]txn.Op, 
 		return nil, errors.Trace(err)
 	}
 	ops = append(ops, secretPermissionsOps...)
-	secretLabelOps, err := a.st.removeSecretLabelOps(a.ApplicationTag())
+	secretLabelOps, err := a.st.removeOwnerSecretLabelOps(a.ApplicationTag())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	ops = append(ops, secretLabelOps...)
+
+	secretLabelOps, err = a.st.removeConsumerSecretLabelOps(a.ApplicationTag())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -2751,7 +2757,11 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	if op.FatalError(err) {
 		return nil, errors.Trace(err)
 	}
-	secretLabelOps, err := a.st.removeSecretLabelOps(u.Tag())
+	secretOwnerLabelOps, err := a.st.removeOwnerSecretLabelOps(u.Tag())
+	if op.FatalError(err) {
+		return nil, errors.Trace(err)
+	}
+	secretConsumerLabelOps, err := a.st.removeConsumerSecretLabelOps(u.Tag())
 	if op.FatalError(err) {
 		return nil, errors.Trace(err)
 	}
@@ -2781,7 +2791,8 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 	ops = append(ops, resOps...)
 	ops = append(ops, hostOps...)
 	ops = append(ops, secretPermissionsOps...)
-	ops = append(ops, secretLabelOps...)
+	ops = append(ops, secretOwnerLabelOps...)
+	ops = append(ops, secretConsumerLabelOps...)
 
 	m, err := a.st.Model()
 	if err != nil {


### PR DESCRIPTION
When you have your own secret with the label set to `foo`, then you set a label `foo` to a consumer secret.
Now, you run `secret-get --label foo`, the owned secret returned. The consumer secret will be invisible for getting using labels.
To fix this bug, we ensure you can only have one label `foo`, it doesn't matter the label sets to consumer secrets or owned secrets.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
juju exec --unit kube-state-metrics/0 -- secret-get ce05pfuffbas7aj59cg0 --label prometheus-k8s/0
unit: prometheus-k8s/0

juju exec --unit kube-state-metrics/0 -- secret-get ce05pceffbas7aj59cfg --label prometheus-k8s
app: prometheus-k8s

juju exec --unit kube-state-metrics/0 -- secret-get  --label prometheus-k8s/0
unit: prometheus-k8s/0

juju exec --unit kube-state-metrics/0 -- secret-get  --label prometheus-k8s
app: prometheus-k8s

juju exec --unit kube-state-metrics/0 -- secret-add --owner unit unit=kube-state-metrics/0 --label=prometheus-k8s/0
secret:ce05r06ffbas7aj59cgg
creating secrets: secret with label "prometheus-k8s/0" already exists

juju exec --unit kube-state-metrics/0 -- secret-add --owner unit unit=kube-state-metrics/0 --label=prometheus-k8s
secret:ce05r46ffbas7aj59ch0
creating secrets: secret with label "prometheus-k8s" already exists
```

## Documentation changes

No

## Bug reference

No
