### PR TITLE
[JUJU-2265] Added JUJU_SKIP_CONFIRMATION to osenv.

### DIFF
--- a/juju/osenv/vars.go
+++ b/juju/osenv/vars.go
@@ -54,8 +54,8 @@ const (
 	// timestamps to be written in RFC3339 format.
 	JujuStatusIsoTimeEnvKey = "JUJU_STATUS_ISO_TIME"
 
-	// JujuSkipConfirgmationEnvKey if set is used to manage the confirmation
-	// process for the destoying and removal commands.
+	// JujuSkipConfirmationEnvKey if set is used to manage the confirmation
+	// process for the destroying and removal commands.
 	JujuSkipConfirmationEnvKey = "JUJU_SKIP_CONFIRMATION"
 
 	// XDGDataHome is a path where data for the running user

--- a/juju/osenv/vars.go
+++ b/juju/osenv/vars.go
@@ -54,6 +54,10 @@ const (
 	// timestamps to be written in RFC3339 format.
 	JujuStatusIsoTimeEnvKey = "JUJU_STATUS_ISO_TIME"
 
+	// JujuSkipConfirgmationEnvKey if set is used to manage the confirmation
+	// process for the destoying and removal commands.
+	JujuSkipConfirmationEnvKey = "JUJU_SKIP_CONFIRMATION"
+
 	// XDGDataHome is a path where data for the running user
 	// should be stored according to the xdg standard.
 	XDGDataHome = "XDG_DATA_HOME"


### PR DESCRIPTION
This PR adds JUJU_SKIP_CONFIRMATION env var definition to osenv. This need by us for further implementation of confirmation for removal and destroying commands.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
just check the source code
```
