### PR TITLE
[JUJU-2221] Add unused dryrun option to remove machine client and apiserver

### DIFF
--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -216,13 +216,15 @@ func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, max
 		basetesting.APICallerFunc(func(objType string, version int, id, request string, a, response interface{}) error {
 			c.Assert(request, gc.Equals, "DestroyMachineWithParams")
 			c.Assert(a, jc.DeepEquals, params.DestroyMachinesParams{
-				Keep:  true,
-				Force: true,
-				MachineTags: []string{
-					"machine-0",
-					"machine-0-lxd-1",
+				DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+					Keep:  true,
+					Force: true,
+					MachineTags: []string{
+						"machine-0",
+						"machine-0-lxd-1",
+					},
+					MaxWait: maxWait,
 				},
-				MaxWait: maxWait,
 			})
 			c.Assert(response, gc.FitsTypeOf, &params.DestroyMachineResults{})
 			out := response.(*params.DestroyMachineResults)
@@ -235,14 +237,14 @@ func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, max
 func (s *MachinemanagerSuite) TestDestroyMachinesWithParamsNoWait(c *gc.C) {
 	noWait := 0 * time.Second
 	client, expected := s.clientToTestDestroyMachinesWithParams(c, &noWait)
-	results, err := client.DestroyMachinesWithParams(true, true, &noWait, "0", "0/lxd/1")
+	results, err := client.DestroyMachinesWithParams(true, true, false, &noWait, "0", "0/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expected)
 }
 
 func (s *MachinemanagerSuite) TestDestroyMachinesWithParamsNilWait(c *gc.C) {
 	client, expected := s.clientToTestDestroyMachinesWithParams(c, (*time.Duration)(nil))
-	results, err := client.DestroyMachinesWithParams(true, true, (*time.Duration)(nil), "0", "0/lxd/1")
+	results, err := client.DestroyMachinesWithParams(true, true, false, (*time.Duration)(nil), "0", "0/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expected)
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -69,7 +69,7 @@ var facadeVersions = map[string]int{
 	"LogForwarding":                1,
 	"Logger":                       1,
 	"MachineActions":               1,
-	"MachineManager":               9,
+	"MachineManager":               10,
 	"MachineUndertaker":            1,
 	"Machiner":                     5,
 	"MeterStatus":                  2,

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1163,7 +1163,9 @@ func (s *loginSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
 
 	// Call something else.
 	destroyReq := &params.DestroyMachinesParams{
-		MachineTags: []string{addResults.Machines[0].Machine},
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			MachineTags: []string{addResults.Machines[0].Machine},
+		},
 	}
 	err = conn.APICall("MachineManager", machineManagerFacadeVersion, "", "DestroyMachineWithParams", destroyReq, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1493,7 +1495,7 @@ func (s *migrationSuite) TestExportingModel(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 
 	// Modifying commands like destroy machines are not.
-	_, err = machineclient.NewClient(userConn).DestroyMachinesWithParams(false, false, nil, "42")
+	_, err = machineclient.NewClient(userConn).DestroyMachinesWithParams(false, false, false, nil, "42")
 	c.Check(err, gc.ErrorMatches, "model migration in progress")
 }
 

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -81,9 +81,25 @@ type MachineManagerAPI struct {
 	callContext environscontext.ProviderCallContext
 }
 
-// NewFacadeV8 create a new server-side MachineManager API facade. This
+type MachineManagerV9 struct {
+	*MachineManagerAPI
+}
+
+// NewFacadeV9 create a new server-side MachineManager API facade. This
 // is used for facade registration.
-func NewFacadeV8(ctx facade.Context) (*MachineManagerAPI, error) {
+func NewFacadeV9(ctx facade.Context) (*MachineManagerV9, error) {
+	api, err := NewFacadeV10(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &MachineManagerV9{
+		MachineManagerAPI: api,
+	}, nil
+}
+
+// NewFacadeV10 create a new server-side MachineManager API facade. This
+// is used for facade registration.
+func NewFacadeV10(ctx facade.Context) (*MachineManagerAPI, error) {
 	st := ctx.State()
 	model, err := st.Model()
 	if err != nil {
@@ -435,10 +451,19 @@ func (mm *MachineManagerAPI) DestroyMachineWithParams(args params.DestroyMachine
 	for i, tag := range args.MachineTags {
 		entities.Entities[i].Tag = tag
 	}
-	return mm.destroyMachine(entities, args.Force, args.Keep, common.MaxWait(args.MaxWait))
+	return mm.destroyMachine(entities, args.Force, args.Keep, args.DryRun, common.MaxWait(args.MaxWait))
 }
 
-func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bool, maxWait time.Duration) (params.DestroyMachineResults, error) {
+// DestroyMachineWithParams removes a set of machines from the model.
+func (mm *MachineManagerV9) DestroyMachineWithParams(args params.DestroyMachinesParamsV9) (params.DestroyMachineResults, error) {
+	entities := params.Entities{Entities: make([]params.Entity, len(args.MachineTags))}
+	for i, tag := range args.MachineTags {
+		entities.Entities[i].Tag = tag
+	}
+	return mm.destroyMachine(entities, args.Force, args.Keep, false, common.MaxWait(args.MaxWait))
+}
+
+func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep, dryRun bool, maxWait time.Duration) (params.DestroyMachineResults, error) {
 	if err := mm.authorizer.CanWrite(); err != nil {
 		return params.DestroyMachineResults{}, err
 	}
@@ -483,7 +508,7 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 			continue
 		}
 		if force {
-			info.DestroyedContainers, err = mm.destoryContainer(containers, force, keep, maxWait)
+			info.DestroyedContainers, err = mm.destoryContainer(containers, force, keep, dryRun, maxWait)
 			if err != nil {
 				fail(err)
 				continue
@@ -555,7 +580,7 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep bo
 	return params.DestroyMachineResults{Results: results}, nil
 }
 
-func (mm *MachineManagerAPI) destoryContainer(containers []string, force, keep bool, maxWait time.Duration) ([]params.DestroyMachineResult, error) {
+func (mm *MachineManagerAPI) destoryContainer(containers []string, force, keep, dryRun bool, maxWait time.Duration) ([]params.DestroyMachineResult, error) {
 	if containers == nil || len(containers) == 0 {
 		return nil, nil
 	}
@@ -563,7 +588,7 @@ func (mm *MachineManagerAPI) destoryContainer(containers []string, force, keep b
 	for i, container := range containers {
 		entities.Entities[i] = params.Entity{Tag: names.NewMachineTag(container).String()}
 	}
-	results, err := mm.destroyMachine(entities, force, keep, maxWait)
+	results, err := mm.destroyMachine(entities, force, keep, dryRun, maxWait)
 	return results.Results, err
 }
 

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -354,8 +354,10 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedAllStorageRetrieval
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		MachineTags: []string{"machine-0"},
-		MaxWait:     &noWait,
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			MachineTags: []string{"machine-0"},
+			MaxWait:     &noWait,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -379,8 +381,10 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedSomeUnitStorageRetr
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		MachineTags: []string{"machine-0"},
-		MaxWait:     &noWait,
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			MachineTags: []string{"machine-0"},
+			MaxWait:     &noWait,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -408,8 +412,10 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedSomeStorageRetrieva
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		MachineTags: []string{"machine-0", "machine-1"},
-		MaxWait:     &noWait,
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			MachineTags: []string{"machine-0", "machine-1"},
+			MaxWait:     &noWait,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -444,9 +450,11 @@ func (s *DestroyMachineManagerSuite) TestForceDestroyMachineFailedSomeStorageRet
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		Force:       true,
-		MachineTags: []string{"machine-0", "machine-1"},
-		MaxWait:     &noWait,
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			Force:       true,
+			MachineTags: []string{"machine-0", "machine-1"},
+			MaxWait:     &noWait,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -485,10 +493,12 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNoWait(c *gc.C)
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		Keep:        true,
-		Force:       true,
-		MachineTags: []string{"machine-0"},
-		MaxWait:     &noWait,
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			Keep:        true,
+			Force:       true,
+			MachineTags: []string{"machine-0"},
+			MaxWait:     &noWait,
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -521,10 +531,12 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNilWait(c *gc.C
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		Keep:        true,
-		Force:       true,
-		MachineTags: []string{"machine-0"},
-		// This will use max wait of system default for delay between cleanup operations.
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			Keep:        true,
+			Force:       true,
+			MachineTags: []string{"machine-0"},
+			// This will use max wait of system default for delay between cleanup operations.
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -557,8 +569,10 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainers(c *gc.C) {
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		Force:       false,
-		MachineTags: []string{"machine-0"},
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			Force:       false,
+			MachineTags: []string{"machine-0"},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -582,8 +596,10 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainersWithForce(c
 	s.st.EXPECT().Machine("0/lxd/0").Return(container0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		Force:       true,
-		MachineTags: []string{"machine-0"},
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			Force:       true,
+			MachineTags: []string{"machine-0"},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{

--- a/apiserver/facades/client/machinemanager/register.go
+++ b/apiserver/facades/client/machinemanager/register.go
@@ -6,23 +6,15 @@ package machinemanager
 import (
 	"reflect"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/apiserver/facade"
 )
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("MachineManager", 9, func(ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV9(ctx)
+		return NewFacadeV9(ctx)
+	}, reflect.TypeOf((*MachineManagerV9)(nil)))
+	registry.MustRegister("MachineManager", 10, func(ctx facade.Context) (facade.Facade, error) {
+		return NewFacadeV10(ctx) // DestroyMachineWithParams gains dry-run
 	}, reflect.TypeOf((*MachineManagerAPI)(nil)))
-}
-
-// newFacadeV9 creates a new server-side MachineManager API facade.
-func newFacadeV9(ctx facade.Context) (*MachineManagerAPI, error) {
-	machineManagerAPI, err := NewFacadeV8(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return machineManagerAPI, nil
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -26295,7 +26295,7 @@
     {
         "Name": "MachineManager",
         "Description": "MachineManagerAPI provides access to the MachineManager API facade.",
-        "Version": 9,
+        "Version": 10,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -26662,6 +26662,37 @@
                     "additionalProperties": false
                 },
                 "DestroyMachinesParams": {
+                    "type": "object",
+                    "properties": {
+                        "DestroyMachinesParamsV9": {
+                            "$ref": "#/definitions/DestroyMachinesParamsV9"
+                        },
+                        "dry-run": {
+                            "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "keep": {
+                            "type": "boolean"
+                        },
+                        "machine-tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-tags",
+                        "DestroyMachinesParamsV9"
+                    ]
+                },
+                "DestroyMachinesParamsV9": {
                     "type": "object",
                     "properties": {
                         "force": {

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -223,7 +223,7 @@ type ModelConfigAPI interface {
 
 type MachineManagerAPI interface {
 	AddMachines([]params.AddMachineParams) ([]params.AddMachinesResult, error)
-	DestroyMachinesWithParams(force, keep bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error)
+	DestroyMachinesWithParams(force, keep, dryRun bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error)
 	ModelUUID() (string, bool)
 	ProvisioningScript(params.ProvisioningScriptParams) (script string, err error)
 	Close() error

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -256,7 +256,7 @@ func (f *fakeAddMachineAPI) AddMachines(args []params.AddMachineParams) ([]param
 	return results, nil
 }
 
-func (f *fakeAddMachineAPI) DestroyMachinesWithParams(force, keep bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
+func (f *fakeAddMachineAPI) DestroyMachinesWithParams(force, keep, dryRun bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
 	return nil, errors.NotImplementedf("ForceDestroyMachinesWithParams")
 }
 

--- a/environs/manual/provisioner.go
+++ b/environs/manual/provisioner.go
@@ -61,6 +61,6 @@ type ProvisionMachineArgs struct {
 // consumer from the actual API implementation type.
 type ProvisioningClientAPI interface {
 	AddMachines([]params.AddMachineParams) ([]params.AddMachinesResult, error)
-	DestroyMachinesWithParams(force, keep bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error)
+	DestroyMachinesWithParams(force, keep, dryRun bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error)
 	ProvisioningScript(params.ProvisioningScriptParams) (script string, err error)
 }

--- a/environs/manual/sshprovisioner/provisioner.go
+++ b/environs/manual/sshprovisioner/provisioner.go
@@ -21,7 +21,7 @@ func ProvisionMachine(args manual.ProvisionMachineArgs) (machineId string, err e
 	defer func() {
 		if machineId != "" && err != nil {
 			logger.Errorf("provisioning failed, removing machine %v: %v", machineId, err)
-			results, cleanupErr := args.Client.DestroyMachinesWithParams(false, false, nil, machineId)
+			results, cleanupErr := args.Client.DestroyMachinesWithParams(false, false, false, nil, machineId)
 			if cleanupErr == nil {
 				cleanupErr = results[0].Error
 			}

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -272,8 +272,8 @@ type AddMachinesResult struct {
 	Error   *Error `json:"error,omitempty"`
 }
 
-// DestroyMachinesParams holds parameters for the DestroyMachinesWithParams call.
-type DestroyMachinesParams struct {
+// DestroyMachinesParamsV9 holds parameters for the v9 DestroyMachinesWithParams call.
+type DestroyMachinesParamsV9 struct {
 	MachineTags []string `json:"machine-tags"`
 	Force       bool     `json:"force,omitempty"`
 	Keep        bool     `json:"keep,omitempty"`
@@ -282,6 +282,12 @@ type DestroyMachinesParams struct {
 	// will wait before forcing the next step to kick-off. This parameter
 	// only makes sense in combination with 'force' set to 'true'.
 	MaxWait *time.Duration `json:"max-wait,omitempty"`
+}
+
+// DestroyMachinesParams holds parameters for the v9 DestroyMachinesWithParams call.
+type DestroyMachinesParams struct {
+	DestroyMachinesParamsV9
+	DryRun bool `json:"dry-run,omitempty"`
 }
 
 // RecordAgentStartInformationArgs holds the parameters for updating the


### PR DESCRIPTION
This will be used when removing machines to generate a preview of what
is going to be destroyed

At the moment, don't change any behaviour, just accept the new param

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Run unit tests

With both a new and old controller, verify that `remove-machine` works as before