### PR TITLE
[JUJU-2268] - Add secret backend create/list to state and wire up to facade

### DIFF
--- a/api/client/secretbackends/client.go
+++ b/api/client/secretbackends/client.go
@@ -28,7 +28,7 @@ func NewClient(caller base.APICallCloser) *Client {
 type SecretBackend struct {
 	Name                string
 	Backend             string
-	TokenRotateInterval time.Duration
+	TokenRotateInterval *time.Duration
 	Config              map[string]interface{}
 }
 

--- a/api/client/secretbackends/client_test.go
+++ b/api/client/secretbackends/client_test.go
@@ -29,6 +29,10 @@ func (s *SecretBackendsSuite) TestNewClient(c *gc.C) {
 	c.Assert(client, gc.NotNil)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func (s *SecretBackendsSuite) TestListSecretBackends(c *gc.C) {
 	config := map[string]interface{}{"foo": "bar"}
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
@@ -42,7 +46,7 @@ func (s *SecretBackendsSuite) TestListSecretBackends(c *gc.C) {
 			[]params.SecretBackend{{
 				Name:                "foo",
 				Backend:             "vault",
-				TokenRotateInterval: 666 * time.Minute,
+				TokenRotateInterval: ptr(666 * time.Minute),
 				Config:              config,
 			}},
 		}
@@ -54,7 +58,7 @@ func (s *SecretBackendsSuite) TestListSecretBackends(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, []secretbackends.SecretBackend{{
 		Name:                "foo",
 		Backend:             "vault",
-		TokenRotateInterval: 666 * time.Minute,
+		TokenRotateInterval: ptr(666 * time.Minute),
 		Config:              config,
 	}})
 }
@@ -63,7 +67,7 @@ func (s *SecretBackendsSuite) TestAddSecretsBackend(c *gc.C) {
 	backend := secretbackends.SecretBackend{
 		Name:                "foo",
 		Backend:             "vault",
-		TokenRotateInterval: 666 * time.Minute,
+		TokenRotateInterval: ptr(666 * time.Minute),
 		Config:              map[string]interface{}{"foo": "bar"},
 	}
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {

--- a/apiserver/common/secrets/mocks/provider_mock.go
+++ b/apiserver/common/secrets/mocks/provider_mock.go
@@ -120,3 +120,17 @@ func (mr *MockSecretBackendProviderMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockSecretBackendProvider)(nil).Type))
 }
+
+// ValidateConfig mocks base method.
+func (m *MockSecretBackendProvider) ValidateConfig(arg0, arg1 provider.ProviderConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateConfig", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateConfig indicates an expected call of ValidateConfig.
+func (mr *MockSecretBackendProviderMockRecorder) ValidateConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).ValidateConfig), arg0, arg1)
+}

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
@@ -120,3 +120,17 @@ func (mr *MockSecretBackendProviderMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockSecretBackendProvider)(nil).Type))
 }
+
+// ValidateConfig mocks base method.
+func (m *MockSecretBackendProvider) ValidateConfig(arg0, arg1 provider.ProviderConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateConfig", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateConfig indicates an expected call of ValidateConfig.
+func (mr *MockSecretBackendProviderMockRecorder) ValidateConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).ValidateConfig), arg0, arg1)
+}

--- a/apiserver/facades/client/secretbackends/mocks/secretsbackendstate.go
+++ b/apiserver/facades/client/secretbackends/mocks/secretsbackendstate.go
@@ -35,18 +35,18 @@ func (m *MockSecretsBackendState) EXPECT() *MockSecretsBackendStateMockRecorder 
 	return m.recorder
 }
 
-// AddSecretBackend mocks base method.
-func (m *MockSecretsBackendState) AddSecretBackend(arg0 state.CreateSecretBackendParams) error {
+// CreateSecretBackend mocks base method.
+func (m *MockSecretsBackendState) CreateSecretBackend(arg0 state.CreateSecretBackendParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddSecretBackend", arg0)
+	ret := m.ctrl.Call(m, "CreateSecretBackend", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AddSecretBackend indicates an expected call of AddSecretBackend.
-func (mr *MockSecretsBackendStateMockRecorder) AddSecretBackend(arg0 interface{}) *gomock.Call {
+// CreateSecretBackend indicates an expected call of CreateSecretBackend.
+func (mr *MockSecretsBackendStateMockRecorder) CreateSecretBackend(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSecretBackend", reflect.TypeOf((*MockSecretsBackendState)(nil).AddSecretBackend), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretBackend", reflect.TypeOf((*MockSecretsBackendState)(nil).CreateSecretBackend), arg0)
 }
 
 // ListSecretBackends mocks base method.

--- a/apiserver/facades/client/secretbackends/register.go
+++ b/apiserver/facades/client/secretbackends/register.go
@@ -8,6 +8,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/state"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -22,12 +23,10 @@ func newSecretBackendsAPI(context facade.Context) (*SecretBackendsAPI, error) {
 	if !context.Auth().AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
-	// TODO(wallyworld)
-	// state := state.NewSecretBackends(context.State())
 
 	return &SecretBackendsAPI{
 		authorizer:     context.Auth(),
 		controllerUUID: context.State().ControllerUUID(),
-		//state:        state,
+		state:          state.NewSecretBackends(context.State()),
 	}, nil
 }

--- a/apiserver/facades/client/secretbackends/state.go
+++ b/apiserver/facades/client/secretbackends/state.go
@@ -10,6 +10,6 @@ import (
 
 // SecretsBackendState is used to access the juju state database.
 type SecretsBackendState interface {
-	AddSecretBackend(params state.CreateSecretBackendParams) error
+	CreateSecretBackend(params state.CreateSecretBackendParams) error
 	ListSecretBackends() ([]*secrets.SecretBackend, error)
 }

--- a/core/secrets/secretbackend.go
+++ b/core/secrets/secretbackend.go
@@ -11,6 +11,6 @@ import (
 type SecretBackend struct {
 	Name                string
 	Backend             string
-	TokenRotateInterval time.Duration
+	TokenRotateInterval *time.Duration
 	Config              map[string]interface{}
 }

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -248,7 +248,7 @@ type SecretBackend struct {
 
 	// TokenRotateInterval is the interval to rotate
 	// the backend master access token.
-	TokenRotateInterval time.Duration `json:"token-rotate-interval,omitempty"`
+	TokenRotateInterval *time.Duration `json:"token-rotate-interval,omitempty"`
 
 	// Config are the backend's configuration attributes.
 	Config map[string]interface{} `json:"config"`

--- a/secrets/provider/backend.go
+++ b/secrets/provider/backend.go
@@ -20,5 +20,8 @@ type SecretsBackend interface {
 type BackendConfig struct {
 	BackendType string
 	// TODO(wallyworld) - use a schema
-	Config map[string]interface{}
+	Config ProviderConfig
 }
+
+// ProviderConfig defines config for a secrets backend provider.
+type ProviderConfig map[string]interface{}

--- a/secrets/provider/juju/secrets.go
+++ b/secrets/provider/juju/secrets.go
@@ -4,6 +4,7 @@
 package juju
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/secrets/provider"
@@ -16,15 +17,22 @@ const (
 
 // NewProvider returns a Juju secrets provider.
 func NewProvider() provider.SecretBackendProvider {
-	return jujuProvider{Backend}
+	return jujuProvider{}
 }
 
 type jujuProvider struct {
-	name string
+}
+
+// ValidateConfig implements SecretBackendProvider.
+func (p jujuProvider) ValidateConfig(oldCfg, newCfg provider.ProviderConfig) error {
+	if len(newCfg) > 0 {
+		return errors.New("the juju secrets backend does not use any config")
+	}
+	return nil
 }
 
 func (p jujuProvider) Type() string {
-	return p.name
+	return Backend
 }
 
 // Initialise is not used.

--- a/secrets/provider/kubernetes/secrets.go
+++ b/secrets/provider/kubernetes/secrets.go
@@ -33,15 +33,22 @@ const (
 
 // NewProvider returns a Kubernetes secrets provider.
 func NewProvider() provider.SecretBackendProvider {
-	return k8sProvider{Backend}
+	return k8sProvider{}
 }
 
 type k8sProvider struct {
-	name string
+}
+
+// ValidateConfig implements SecretBackendProvider.
+func (p k8sProvider) ValidateConfig(oldCfg, newCfg provider.ProviderConfig) error {
+	if len(newCfg) > 0 {
+		return errors.New("the k8s secrets backend does not use any config")
+	}
+	return nil
 }
 
 func (p k8sProvider) Type() string {
-	return p.name
+	return Backend
 }
 
 // Initialise is not used.

--- a/secrets/provider/kubernetes/secrets_test.go
+++ b/secrets/provider/kubernetes/secrets_test.go
@@ -51,6 +51,13 @@ func (*kubernetesSuite) TestBackendConfig(c *gc.C) {
 	})
 }
 
+func (*kubernetesSuite) TestValidateConfig(c *gc.C) {
+	p, err := provider.Provider(kubernetes.Backend)
+	c.Assert(err, jc.ErrorIsNil)
+	err = p.ValidateConfig(nil, map[string]interface{}{"foo": "bar"})
+	c.Assert(err, gc.ErrorMatches, "the k8s secrets backend does not use any config")
+}
+
 func (s *kubernetesSuite) assertBackendConfigWithTag(c *gc.C, isControllerCloud bool) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/secrets/provider/provider.go
+++ b/secrets/provider/provider.go
@@ -53,6 +53,11 @@ func (nm SecretRevisions) Names() (names []string) {
 type SecretBackendProvider interface {
 	// TODO(wallyworld) - add config schema methods
 
+	// ValidateConfig returns an error if the new
+	//provider config is not valid.
+	ValidateConfig(oldCfg, newCfg ProviderConfig) error
+
+	// Type is the type of the backend.
 	Type() string
 
 	// Initialise sets up the secrets backend to host secrets for

--- a/secrets/provider/vault/secrets.go
+++ b/secrets/provider/vault/secrets.go
@@ -30,15 +30,20 @@ const (
 
 // NewProvider returns a Vault secrets provider.
 func NewProvider() provider.SecretBackendProvider {
-	return vaultProvider{Backend}
+	return vaultProvider{}
 }
 
 type vaultProvider struct {
-	name string
 }
 
 func (p vaultProvider) Type() string {
-	return p.name
+	return Backend
+}
+
+// ValidateConfig implements SecretBackendProvider.
+func (p vaultProvider) ValidateConfig(oldCfg, newCfg provider.ProviderConfig) error {
+	// TODO(wallyworld)
+	return nil
 }
 
 // Initialise sets up a kv store mounted on the model uuid.

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -560,6 +560,13 @@ func allCollections() CollectionSchema {
 			}},
 		},
 
+		secretBackendsC: {
+			global: true,
+			indexes: []mgo.Index{{
+				Key: []string{"name"},
+			}},
+		},
+
 		// ----------------------
 
 		// Raw-access collections
@@ -673,6 +680,7 @@ const (
 	secretConsumersC   = "secretConsumers"
 	secretPermissionsC = "secretPermissions"
 	secretRotateC      = "secretRotate"
+	secretBackendsC    = "secretBackends"
 )
 
 // watcherIgnoreList contains all the collections in mongo that should not be watched by the

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -210,6 +210,9 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// running within a unit. This is a new feature that is not
 		// backwards compatible with older controllers.
 		unitStatesC,
+
+		// Secret backends are per controller.
+		secretBackendsC,
 	)
 
 	// THIS SET WILL BE REMOVED WHEN MIGRATIONS ARE COMPLETE

--- a/state/secretbackends.go
+++ b/state/secretbackends.go
@@ -3,12 +3,143 @@
 
 package state
 
-import "time"
+import (
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/mgo/v3"
+	"github.com/juju/mgo/v3/bson"
+	"github.com/juju/mgo/v3/txn"
+
+	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/mongo/utils"
+)
 
 // CreateSecretBackendParams are used to create a secret backend.
 type CreateSecretBackendParams struct {
 	Name                string
 	Backend             string
-	TokenRotateInterval time.Duration
+	TokenRotateInterval *time.Duration
 	Config              map[string]interface{}
+}
+
+// SecretBackendsStorage instances use mongo to store secret backend info.
+type SecretBackendsStorage interface {
+	CreateSecretBackend(params CreateSecretBackendParams) error
+	ListSecretBackends() ([]*secrets.SecretBackend, error)
+	GetSecretBackend(name string) (*secrets.SecretBackend, error)
+}
+
+// NewSecretBackends creates a new mongo backed secrets storage.
+func NewSecretBackends(st *State) *secretBackendsStorage {
+	return &secretBackendsStorage{st: st}
+}
+
+type secretBackendDoc struct {
+	DocID string `bson:"_id"`
+
+	Name                string           `bson:"name"`
+	Backend             string           `bson:"backend"`
+	TokenRotateInterval *time.Duration   `bson:"token-rotate-interval,omitempty"`
+	Config              backendConfigMap `bson:"config,omitempty"`
+}
+
+type backendConfigMap map[string]interface{}
+
+func (m *backendConfigMap) SetBSON(raw bson.Raw) error {
+	rawMap := make(map[string]interface{})
+	if err := raw.Unmarshal(rawMap); err != nil {
+		return err
+	}
+	*m = utils.UnescapeKeys(rawMap)
+	return nil
+}
+
+func (m backendConfigMap) GetBSON() (interface{}, error) {
+	escapedMap := utils.EscapeKeys(m)
+	return escapedMap, nil
+}
+
+type secretBackendsStorage struct {
+	st *State
+}
+
+func (s *secretBackendsStorage) secretBackendDoc(p *CreateSecretBackendParams) (*secretBackendDoc, error) {
+	backend := &secretBackendDoc{
+		DocID:               bson.NewObjectId().Hex(),
+		Name:                p.Name,
+		Backend:             p.Backend,
+		TokenRotateInterval: p.TokenRotateInterval,
+		Config:              p.Config,
+	}
+	return backend, nil
+}
+
+// CreateSecretBackend creates a new secret backend.
+func (s *secretBackendsStorage) CreateSecretBackend(p CreateSecretBackendParams) error {
+	backendDoc, err := s.secretBackendDoc(&p)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		// This isn't perfect but we don't want to use the name as the doc id.
+		// The tiny window for multiple callers to create dupe backends will
+		// go away once we transition to a SQL backend.
+		if _, err := s.GetSecretBackend(p.Name); err != nil {
+			if !errors.IsNotFound(err) {
+				return nil, errors.Annotatef(err, "checking for existing secret backend")
+			}
+		} else {
+			return nil, errors.AlreadyExistsf("secret backend %q", p.Name)
+		}
+		return []txn.Op{{
+			C:      secretBackendsC,
+			Id:     backendDoc.DocID,
+			Assert: txn.DocMissing,
+			Insert: *backendDoc,
+		}}, nil
+	}
+	return errors.Trace(s.st.db().Run(buildTxn))
+}
+
+func (s *secretBackendsStorage) toSecretBackend(doc *secretBackendDoc) *secrets.SecretBackend {
+	return &secrets.SecretBackend{
+		Name:                doc.Name,
+		Backend:             doc.Backend,
+		TokenRotateInterval: doc.TokenRotateInterval,
+		Config:              doc.Config,
+	}
+}
+
+// GetSecretBackend gets the named secret backend.
+func (s *secretBackendsStorage) GetSecretBackend(name string) (*secrets.SecretBackend, error) {
+	secretBackendsColl, closer := s.st.db().GetCollection(secretBackendsC)
+	defer closer()
+
+	var doc secretBackendDoc
+	err := secretBackendsColl.Find(bson.D{{"name", name}}).One(&doc)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("secret backend %q", name)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return s.toSecretBackend(&doc), nil
+}
+
+// ListSecretBackends lists the secret backends.
+func (s *secretBackendsStorage) ListSecretBackends() ([]*secrets.SecretBackend, error) {
+	secretBackendCollection, closer := s.st.db().GetCollection(secretBackendsC)
+	defer closer()
+
+	var docs []secretBackendDoc
+	err := secretBackendCollection.Find(nil).All(&docs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := make([]*secrets.SecretBackend, len(docs))
+	for i, doc := range docs {
+		result[i] = s.toSecretBackend(&doc)
+	}
+	return result, nil
 }

--- a/state/secretbackends_test.go
+++ b/state/secretbackends_test.go
@@ -1,0 +1,92 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state_test
+
+import (
+	"sort"
+	"time"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/testing"
+)
+
+type SecretBackendsSuite struct {
+	testing.StateSuite
+	storage state.SecretBackendsStorage
+}
+
+var _ = gc.Suite(&SecretBackendsSuite{})
+
+func (s *SecretBackendsSuite) SetUpTest(c *gc.C) {
+	s.StateSuite.SetUpTest(c)
+	s.storage = state.NewSecretBackends(s.State)
+}
+
+func (s *SecretBackendsSuite) TestCreate(c *gc.C) {
+	config := map[string]interface{}{"foo.key": "bar"}
+	p := state.CreateSecretBackendParams{
+		Name:                "myvault",
+		Backend:             "vault",
+		TokenRotateInterval: ptr(666 * time.Minute),
+		Config:              config,
+	}
+	err := s.storage.CreateSecretBackend(p)
+	c.Assert(err, jc.ErrorIsNil)
+	backend, err := s.storage.GetSecretBackend("myvault")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(backend, jc.DeepEquals, &secrets.SecretBackend{
+		Name:                "myvault",
+		Backend:             "vault",
+		TokenRotateInterval: ptr(666 * time.Minute),
+		Config:              config,
+	})
+
+	err = s.storage.CreateSecretBackend(p)
+	c.Assert(err, jc.Satisfies, errors.IsAlreadyExists)
+}
+
+func (s *SecretBackendsSuite) TestGetNotFound(c *gc.C) {
+	_, err := s.storage.GetSecretBackend("myvault")
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *SecretBackendsSuite) TestList(c *gc.C) {
+	config := map[string]interface{}{"foo.key": "bar"}
+	p := state.CreateSecretBackendParams{
+		Name:                "myvault",
+		Backend:             "vault",
+		TokenRotateInterval: ptr(666 * time.Minute),
+		Config:              config,
+	}
+	err := s.storage.CreateSecretBackend(p)
+	c.Assert(err, jc.ErrorIsNil)
+	p2 := state.CreateSecretBackendParams{
+		Name:    "myk8s",
+		Backend: "kubernetes",
+		Config:  config,
+	}
+	err = s.storage.CreateSecretBackend(p2)
+	c.Assert(err, jc.ErrorIsNil)
+	backends, err := s.storage.ListSecretBackends()
+	c.Assert(err, jc.ErrorIsNil)
+	sort.Slice(backends, func(i, j int) bool {
+		return backends[i].Name < backends[j].Name
+	})
+
+	c.Assert(backends, jc.DeepEquals, []*secrets.SecretBackend{{
+		Name:    "myk8s",
+		Backend: "kubernetes",
+		Config:  config,
+	}, {
+		Name:                "myvault",
+		Backend:             "vault",
+		TokenRotateInterval: ptr(666 * time.Minute),
+		Config:              config,
+	}})
+}


### PR DESCRIPTION
Add support to persist new secret backends and also query them.
Also skeleton implementation for backend provider config validation.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

None yet - infrastructure only