### PR TITLE
[JUJU-2264] Added verification by name when destroying, killing, unregistering controller

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -22,7 +22,7 @@ import (
 
 const yesNoMsg = "\nContinue [y/N]? "
 
-var nameVerificationMsg = "\nTo continue, enter the name of the %s to be destroyed:"[1:]
+var nameVerificationMsg = "\nTo continue, enter the name of the %s to be destroyed: "
 
 type userAbortedError string
 
@@ -77,10 +77,10 @@ func CheckSkipConfirmEnvVar() (bool, error) {
 	if envVarIsSet {
 		envSkipConfirmValue, err := strconv.ParseBool(envSkipConfirmValueStr)
 		if err != nil {
-			return false, errors.Errorf("Unexpected value of JUJU_SKIP_CONFIRMATION env var, needs to be bool.")
+			return false, errors.Errorf("Unexpected value of %s env var, needs to be bool.", osenv.JujuSkipConfirmationEnvKey)
 		}
 		return envSkipConfirmValue, nil
 	} else {
-		return false, errors.NewNotFound(nil, "JUJU_SKIP+CONFIRMATION is not defined.")
+		return false, errors.NewNotFound(nil, osenv.JujuSkipConfirmationEnvKey+" is not defined.")
 	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -71,7 +71,11 @@ func UserConfirmName(verificationName string, objectType string, ctx *cmd.Contex
 // return it's boolean value
 func CheckSkipConfirmEnvVar() (bool, error) {
 	if envSkipConfirmValueStr := os.Getenv(osenv.JujuSkipConfirmationEnvKey); envSkipConfirmValueStr != "" {
-		return strconv.ParseBool(envSkipConfirmValueStr)
+		envSkipConfirmValue, err := strconv.ParseBool(envSkipConfirmValueStr)
+		if err != nil {
+			return false, errors.Errorf("Unexpected value of JUJU_SKIP_CONFIRMATION env var, needs to be bool.")
+		}
+		return envSkipConfirmValue, nil
 	} else {
 		return false, nil
 	}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"github.com/juju/juju/juju/osenv"
 	"io"
 	"os"
 	"strconv"
@@ -14,6 +13,8 @@ import (
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/juju/osenv"
 )
 
 // This file contains helper functions for generic operations commonly needed
@@ -70,15 +71,16 @@ func UserConfirmName(verificationName string, objectType string, ctx *cmd.Contex
 }
 
 // CheckSkipConfirmEnvVar check if JujuSkipConfirmationEnvKey environment variable is defined, and if yes -
-// return it's boolean value
+// returns its boolean value, if bo - returns false value
 func CheckSkipConfirmEnvVar() (bool, error) {
-	if envSkipConfirmValueStr := os.Getenv(osenv.JujuSkipConfirmationEnvKey); envSkipConfirmValueStr != "" {
+	envSkipConfirmValueStr, envVarIsSet := os.LookupEnv(osenv.JujuSkipConfirmationEnvKey)
+	if envVarIsSet {
 		envSkipConfirmValue, err := strconv.ParseBool(envSkipConfirmValueStr)
 		if err != nil {
 			return false, errors.Errorf("Unexpected value of JUJU_SKIP_CONFIRMATION env var, needs to be bool.")
 		}
 		return envSkipConfirmValue, nil
 	} else {
-		return false, nil
+		return false, errors.NewNotFound(nil, "JUJU_SKIP+CONFIRMATION is not defined.")
 	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -21,6 +21,8 @@ import (
 
 const yesNoMsg = "\nContinue [y/N]? "
 
+var nameVerificationMsg = "\nTo continue, enter the name of the %s to be destroyed:"[1:]
+
 type userAbortedError string
 
 func (e userAbortedError) Error() string {
@@ -53,7 +55,7 @@ func UserConfirmYes(ctx *cmd.Context) error {
 // UserConfirmName returns an error if we do not read a "name" of the model/controller/etc from user
 // input.
 func UserConfirmName(verificationName string, objectType string, ctx *cmd.Context) error {
-	fmt.Fprintf(ctx.Stdout, "\nTo continue, enter the name of the %s to be destroyed:", objectType)
+	fmt.Fprintf(ctx.Stdout, nameVerificationMsg, objectType)
 	scanner := bufio.NewScanner(ctx.Stdin)
 	scanner.Scan()
 	err := scanner.Err()

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -70,17 +70,16 @@ func UserConfirmName(verificationName string, objectType string, ctx *cmd.Contex
 	return nil
 }
 
-// CheckSkipConfirmEnvVar check if JujuSkipConfirmationEnvKey environment variable is defined, and if yes -
-// returns its boolean value, if bo - returns false value
-func CheckSkipConfirmEnvVar() (bool, error) {
+// CheckSkipConfirmationEnvVar returns parses and returns a boolean value for the skip confirmation env var.
+// If the env var is not set, return a NotFound error
+func CheckSkipConfirmationEnvVar() (bool, error) {
 	envSkipConfirmValueStr, envVarIsSet := os.LookupEnv(osenv.JujuSkipConfirmationEnvKey)
-	if envVarIsSet {
-		envSkipConfirmValue, err := strconv.ParseBool(envSkipConfirmValueStr)
-		if err != nil {
-			return false, errors.Errorf("Unexpected value of %s env var, needs to be bool.", osenv.JujuSkipConfirmationEnvKey)
-		}
-		return envSkipConfirmValue, nil
-	} else {
+	if !envVarIsSet {
 		return false, errors.NewNotFound(nil, osenv.JujuSkipConfirmationEnvKey+" is not defined.")
 	}
+	envSkipConfirmValue, err := strconv.ParseBool(envSkipConfirmValueStr)
+	if err != nil {
+		return false, errors.Errorf("Unexpected value of %s env var, needs to be bool.", osenv.JujuSkipConfirmationEnvKey)
+	}
+	return envSkipConfirmValue, nil
 }

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -186,7 +186,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	store := c.ClientStore()
 
 	c.ConfirmationCommandBase.Run(ctx)
-	if !(c.ConfirmationCommandBase.NeedsConfirmation()) {
+	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -186,7 +186,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	store := c.ClientStore()
 
 	c.ConfirmationCommandBase.Run(ctx)
-	if !(c.ConfirmationCommandBase.GetAssumeYes() || c.ConfirmationCommandBase.GetAssumeNoPrompt()) {
+	if !(c.ConfirmationCommandBase.NeedsConfirmation()) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")
@@ -512,7 +512,9 @@ func (c *destroyCommandBase) SetFlags(f *gnuflag.FlagSet) {
 
 // Init implements Command.Init.
 func (c *destroyCommandBase) Init(args []string) error {
-	c.ConfirmationCommandBase.Init(args)
+	if err := c.ConfirmationCommandBase.Init(args); err != nil {
+		return errors.Trace(err)
+	}
 	switch len(args) {
 	case 0:
 		return errors.New("no controller specified")

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -189,7 +189,10 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	if skipErr != nil {
 		return errors.Trace(skipErr)
 	}
-	if !(c.assumeNoPrompt || skipConfirm) {
+	if c.assumeYes {
+		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags a deprecated and will be removed in JUJU 3.1\n")
+	}
+	if !(c.assumeYes || c.assumeNoPrompt || skipConfirm) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")
@@ -467,6 +470,7 @@ to be cleaned up.
 // destroy and controller kill commands require.
 type destroyCommandBase struct {
 	modelcmd.ControllerCommandBase
+	assumeYes      bool // DEPRECATED
 	assumeNoPrompt bool
 
 	// The following fields are for mocking out
@@ -511,9 +515,8 @@ func (c *destroyCommand) getStorageAPI(modelName string) (storageAPI, error) {
 func (c *destroyCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
 	// This unused var is declared to pass a valid ptr into BoolVar
-	var assumeYesHolder bool
-	f.BoolVar(&assumeYesHolder, "y", false, "Does nothing. Option present for forward compatibility with Juju 2.9")
-	f.BoolVar(&assumeYesHolder, "yes", false, "")
+	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for forward compatibility with Juju 2.9")
+	f.BoolVar(&c.assumeYes, "yes", false, "")
 	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation")
 }
 

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -185,7 +185,10 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 
-	c.ConfirmationCommandBase.Run(ctx)
+	if err := c.ConfirmationCommandBase.Run(ctx); err != nil {
+		return errors.Trace(err)
+	}
+
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -185,14 +185,17 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 
-	skipConfirm, skipErr := jujucmd.CheckSkipConfirmEnvVar()
-	if skipErr != nil {
-		return errors.Trace(skipErr)
+	if !c.assumeNoPrompt {
+		var skipErr error
+		c.assumeNoPrompt, skipErr = jujucmd.CheckSkipConfirmEnvVar()
+		if skipErr != nil {
+			return errors.Trace(skipErr)
+		}
 	}
 	if c.assumeYes {
 		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags a deprecated and will be removed in JUJU 3.1\n")
 	}
-	if !(c.assumeYes || c.assumeNoPrompt || skipConfirm) {
+	if !(c.assumeYes || c.assumeNoPrompt) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")
@@ -514,7 +517,6 @@ func (c *destroyCommand) getStorageAPI(modelName string) (storageAPI, error) {
 // SetFlags implements Command.SetFlags.
 func (c *destroyCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
-	// This unused var is declared to pass a valid ptr into BoolVar
 	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for forward compatibility with Juju 2.9")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
 	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation")

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -187,13 +187,14 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 
 	if !c.assumeNoPrompt {
 		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
-		if skipErr != nil {
+		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
 			return errors.Trace(skipErr)
+		} else {
+			c.assumeNoPrompt = assumeNoPrompt
 		}
-		c.assumeNoPrompt = assumeNoPrompt
 	}
 	if c.assumeYes {
-		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags a deprecated and will be removed in JUJU 3.1\n")
+		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
 	}
 	if !(c.assumeYes || c.assumeNoPrompt) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
@@ -517,7 +518,7 @@ func (c *destroyCommand) getStorageAPI(modelName string) (storageAPI, error) {
 // SetFlags implements Command.SetFlags.
 func (c *destroyCommandBase) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
-	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for forward compatibility with Juju 2.9")
+	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for backwards compatibility with Juju 2.9")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
 	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation")
 }

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -186,11 +186,11 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	store := c.ClientStore()
 
 	if !c.assumeNoPrompt {
-		var skipErr error
-		c.assumeNoPrompt, skipErr = jujucmd.CheckSkipConfirmEnvVar()
+		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
 		if skipErr != nil {
 			return errors.Trace(skipErr)
 		}
+		c.assumeNoPrompt = assumeNoPrompt
 	}
 	if c.assumeYes {
 		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags a deprecated and will be removed in JUJU 3.1\n")

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -174,6 +174,14 @@ func (c *destroyCommand) Init(args []string) error {
 	if c.destroyStorage && c.releaseStorage {
 		return errors.New("--destroy-storage and --release-storage cannot both be specified")
 	}
+	if !c.assumeNoPrompt {
+		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
+		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
+			return errors.Trace(skipErr)
+		} else {
+			c.assumeNoPrompt = assumeNoPrompt
+		}
+	}
 	return c.destroyCommandBase.Init(args)
 }
 
@@ -185,14 +193,6 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 
-	if !c.assumeNoPrompt {
-		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
-		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
-			return errors.Trace(skipErr)
-		} else {
-			c.assumeNoPrompt = assumeNoPrompt
-		}
-	}
 	if c.assumeYes {
 		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
 	}

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -507,22 +507,21 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	c.Check(cmdtesting.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
 	checkControllerExistsInStore(c, "test1", s.store)
 
-	for _, answer := range []string{"test1"} {
-		stdin.Reset()
-		stdout.Reset()
-		stdin.WriteString(answer)
-		_, errc = cmdtest.RunCommandWithDummyProvider(ctx, s.newDestroyCommand(), "test1")
-		select {
-		case err := <-errc:
-			c.Check(err, jc.ErrorIsNil)
-		case <-time.After(testing.LongWait):
-			c.Fatalf("command took too long")
-		}
-		checkControllerRemovedFromStore(c, "test1", s.store)
-
-		// Add the test1 controller back into the store for the next test
-		s.resetController(c)
+	answer := "test1"
+	stdin.Reset()
+	stdout.Reset()
+	stdin.WriteString(answer)
+	_, errc = cmdtest.RunCommandWithDummyProvider(ctx, s.newDestroyCommand(), "test1")
+	select {
+	case err := <-errc:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("command took too long")
 	}
+	checkControllerRemovedFromStore(c, "test1", s.store)
+
+	// Add the test1 controller back into the store for the next test
+	s.resetController(c)
 }
 
 func (s *DestroySuite) TestBlockedDestroy(c *gc.C) {
@@ -616,7 +615,7 @@ func (s *DestroySuite) TestDestroyWithInvalidCredentialCallbackFailing(c *gc.C) 
 
 func (s *DestroySuite) TestDestroyWithInvalidCredentialCallbackFailingToCloseAPI(c *gc.C) {
 	s.controllerCredentialAPI.SetErrors(
-		nil, // call to invalidate credential succeeds
+		nil,                                           // call to invalidate credential succeeds
 		errors.New("unexpected creds callback error"), // call to close api client fails
 	)
 	// As we are throwing the error on api.Close for callback,

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -5,7 +5,7 @@ package controller_test
 
 import (
 	"bytes"
-	"os"
+	"github.com/juju/juju/juju/osenv"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -316,14 +316,11 @@ func (s *DestroySuite) TestDestroy(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyWithSkipConfirmEnvVar(c *gc.C) {
-	setEnvVarErr := os.Setenv("JUJU_SKIP_CONFIRMATION", "true")
-	c.Assert(setEnvVarErr, jc.ErrorIsNil)
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "true")
 	_, err := s.runDestroyCommand(c, "test1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
 	checkControllerRemovedFromStore(c, "test1", s.store)
-	unsetEnvVarErr := os.Unsetenv("JUJU_SKIP_CONFIRMATION")
-	c.Assert(unsetEnvVarErr, jc.ErrorIsNil)
 }
 
 func (s *DestroySuite) TestDestroyAlias(c *gc.C) {

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -293,7 +293,7 @@ func (s *DestroySuite) TestDestroyUnknownController(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyControllerNotFoundNotRemovedFromStore(c *gc.C) {
 	s.apierror = errors.NotFoundf("test1")
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, "cannot connect to API: test1 not found")
 	c.Check(c.GetTestLog(), jc.Contains, "If the controller is unusable")
 	checkControllerExistsInStore(c, "test1", s.store)
@@ -301,28 +301,28 @@ func (s *DestroySuite) TestDestroyControllerNotFoundNotRemovedFromStore(c *gc.C)
 
 func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 	s.apierror = errors.New("connection refused")
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, "cannot connect to API: connection refused")
 	c.Check(c.GetTestLog(), jc.Contains, "If the controller is unusable")
 	checkControllerExistsInStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroy(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroyAlias(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyAllModelsFlag(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-all-models")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c, "DestroyController", "AllModels", "ModelStatus", "Close")
 	timeout := 30 * time.Minute
@@ -334,7 +334,7 @@ func (s *DestroySuite) TestDestroyWithDestroyAllModelsFlag(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlag(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-storage")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	destroyStorage := true
 	timeout := 30 * time.Minute
@@ -345,7 +345,7 @@ func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlag(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyReleaseStorageFlag(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test1", "-y", "--release-storage")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--release-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	destroyStorage := false
 	timeout := 30 * time.Minute
@@ -356,12 +356,12 @@ func (s *DestroySuite) TestDestroyWithDestroyReleaseStorageFlag(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyDestroyReleaseStorageFlagsMutuallyExclusive(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-storage", "--release-storage")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-storage", "--release-storage")
 	c.Assert(err, gc.ErrorMatches, "--destroy-storage and --release-storage cannot both be specified")
 }
 
 func (s *DestroySuite) TestDestroyWithForceFlag(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test1", "-y", "--force", "--model-timeout", "10m")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--force", "--model-timeout", "10m")
 	c.Assert(err, jc.ErrorIsNil)
 	force := true
 	timeout := 10 * time.Minute
@@ -386,7 +386,7 @@ func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlagUnspecified(c *gc
 	}
 
 	s.api.SetErrors(&params.Error{Code: params.CodeHasPersistentStorage})
-	_, err := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-all-models")
 	c.Assert(err.Error(), gc.Equals, `cannot destroy controller "test1"
 
 The controller has persistent storage remaining:
@@ -405,7 +405,7 @@ into another Juju model.
 
 func (s *DestroySuite) TestDestroyControllerGetFails(c *gc.C) {
 	s.api.SetErrors(errors.NotFoundf(`controller "test3"`))
-	_, err := s.runDestroyCommand(c, "test3", "-y")
+	_, err := s.runDestroyCommand(c, "test3", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches,
 		"getting controller environ: getting model config from API: controller \"test3\" not found",
 	)
@@ -414,7 +414,7 @@ func (s *DestroySuite) TestDestroyControllerGetFails(c *gc.C) {
 
 func (s *DestroySuite) TestFailedDestroyController(c *gc.C) {
 	s.api.SetErrors(errors.New("permission denied"))
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy controller: permission denied")
 	checkControllerExistsInStore(c, "test1", s.store)
 }
@@ -425,7 +425,7 @@ func (s *DestroySuite) TestDestroyControllerAliveModels(c *gc.C) {
 		s.api.envStatus[uuid] = status
 	}
 	s.api.SetErrors(&params.Error{Code: params.CodeHasHostedModels})
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err.Error(), gc.Equals, `cannot destroy controller "test1"
 
 The controller has live models. If you want
@@ -482,8 +482,8 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	ctx.Stdout = &stdout
 	ctx.Stdin = &stdin
 
-	// Ensure confirmation is requested if "-y" is not specified.
-	stdin.WriteString("n")
+	// Ensure confirmation is requested if "--no-prompt" is not specified.
+	stdin.WriteString("wrong_test1_name")
 	_, errc := cmdtest.RunCommandWithDummyProvider(ctx, s.newDestroyCommand(), "test1")
 	select {
 	case err := <-errc:
@@ -507,7 +507,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	c.Check(cmdtesting.Stdout(ctx), gc.Matches, "WARNING!.*test1(.|\n)*")
 	checkControllerExistsInStore(c, "test1", s.store)
 
-	for _, answer := range []string{"y", "Y", "yes", "YES"} {
+	for _, answer := range []string{"test1"} {
 		stdin.Reset()
 		stdout.Reset()
 		stdin.WriteString(answer)
@@ -527,7 +527,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 
 func (s *DestroySuite) TestBlockedDestroy(c *gc.C) {
 	s.api.SetErrors(&params.Error{Code: params.CodeOperationBlocked})
-	s.runDestroyCommand(c, "test1", "-y")
+	s.runDestroyCommand(c, "test1", "--no-prompt")
 	testLog := c.GetTestLog()
 	c.Check(testLog, jc.Contains, "To enable controller destruction, please run:")
 	c.Check(testLog, jc.Contains, "juju enable-destroy-controller")
@@ -538,7 +538,7 @@ func (s *DestroySuite) TestDestroyListBlocksError(c *gc.C) {
 		&params.Error{Code: params.CodeOperationBlocked},
 		errors.New("unexpected api error"),
 	)
-	s.runDestroyCommand(c, "test1", "-y")
+	s.runDestroyCommand(c, "test1", "--no-prompt")
 	testLog := c.GetTestLog()
 	c.Check(testLog, jc.Contains, "To enable controller destruction, please run:")
 	c.Check(testLog, jc.Contains, "juju enable-destroy-controller")
@@ -566,7 +566,7 @@ func (s *DestroySuite) TestDestroyReturnsBlocks(c *gc.C) {
 			},
 		},
 	}
-	ctx, _ := s.runDestroyCommand(c, "test1", "-y", "--destroy-all-models")
+	ctx, _ := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-all-models")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Destroying controller\n"+
 		"Name   Model UUID                            Owner   Disabled commands\n"+
 		"test1  1871299e-1370-4f3e-83ab-1849ed7b1076  cheryl  destroy-model\n"+
@@ -600,7 +600,7 @@ func (s *DestroySuite) destroyAndInvalidateCredentialWithError(c *gc.C, expected
 		}
 		return environs.Destroy(controllerName, env, ctx, store)
 	}
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(called, jc.IsTrue)
 	s.controllerCredentialAPI.CheckCallNames(c, "InvalidateModelCredential", "Close")

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -5,7 +5,6 @@ package controller_test
 
 import (
 	"bytes"
-	"github.com/juju/juju/juju/osenv"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -27,6 +26,7 @@ import (
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
@@ -321,6 +321,12 @@ func (s *DestroySuite) TestDestroyWithSkipConfirmEnvVar(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
 	checkControllerRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) TestDestroyWithSkipConfirmIncorrectEnvVar(c *gc.C) {
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "incorrect_value")
+	_, err := s.runDestroyCommand(c, "test1")
+	c.Assert(err, gc.ErrorMatches, "Unexpected value of JUJU_SKIP_CONFIRMATION env var, needs to be bool.")
 }
 
 func (s *DestroySuite) TestDestroyAlias(c *gc.C) {

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -104,7 +104,15 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	store := c.ClientStore()
-	if !c.assumeNoPrompt {
+
+	skipConfirm, skipErr := jujucmd.CheckSkipConfirmEnvVar()
+	if skipErr != nil {
+		return errors.Trace(skipErr)
+	}
+	if c.assumeYes {
+		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags a deprecated and will be removed in JUJU 3.1\n")
+	}
+	if !(c.assumeYes || c.assumeNoPrompt || skipConfirm) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -105,10 +105,8 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 
-	if c.assumeYes {
-		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
-	}
-	if !(c.assumeYes || c.assumeNoPrompt) {
+	c.ConfirmationCommandBase.Run(ctx)
+	if !(c.destroyCommandBase.GetAssumeYes() || c.destroyCommandBase.GetAssumeNoPrompt()) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -106,7 +106,7 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	store := c.ClientStore()
 
 	c.ConfirmationCommandBase.Run(ctx)
-	if !(c.ConfirmationCommandBase.NeedsConfirmation()) {
+	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -105,14 +105,10 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 
-	skipConfirm, skipErr := jujucmd.CheckSkipConfirmEnvVar()
-	if skipErr != nil {
-		return errors.Trace(skipErr)
-	}
 	if c.assumeYes {
-		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags a deprecated and will be removed in JUJU 3.1\n")
+		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
 	}
-	if !(c.assumeYes || c.assumeNoPrompt || skipConfirm) {
+	if !(c.assumeYes || c.assumeNoPrompt) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -105,7 +105,9 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 
-	c.ConfirmationCommandBase.Run(ctx)
+	if err := c.ConfirmationCommandBase.Run(ctx); err != nil {
+		return errors.Trace(err)
+	}
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -106,7 +106,7 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	store := c.ClientStore()
 
 	c.ConfirmationCommandBase.Run(ctx)
-	if !(c.destroyCommandBase.NeedsConfirmation()) {
+	if !(c.ConfirmationCommandBase.NeedsConfirmation()) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -106,7 +106,7 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	store := c.ClientStore()
 
 	c.ConfirmationCommandBase.Run(ctx)
-	if !(c.destroyCommandBase.GetAssumeYes() || c.destroyCommandBase.GetAssumeNoPrompt()) {
+	if !(c.destroyCommandBase.NeedsConfirmation()) {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -104,9 +104,9 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	store := c.ClientStore()
-	if !c.assumeYes {
+	if !c.assumeNoPrompt {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
-		if err := jujucmd.UserConfirmYes(ctx); err != nil {
+		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "controller destruction")
 		}
 	}

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -102,7 +102,7 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 	}
 
 	c.ConfirmationCommandBase.Run(ctx)
-	if !(c.ConfirmationCommandBase.NeedsConfirmation()) {
+	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, unregisterMsg, c.controllerName)
 		if err := jujucmd.UserConfirmName(c.controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "unregistering controller")

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -78,8 +78,6 @@ func (c *unregisterCommand) Init(args []string) error {
 	}
 	c.controllerName, args = args[0], args[1:]
 
-	c.ConfirmationCommandBase.Init(args)
-
 	if err := jujuclient.ValidateControllerName(c.controllerName); err != nil {
 		return err
 	}
@@ -87,7 +85,7 @@ func (c *unregisterCommand) Init(args []string) error {
 	if err := cmd.CheckEmpty(args); err != nil {
 		return err
 	}
-	return nil
+	return c.ConfirmationCommandBase.Init(args)
 }
 
 var unregisterMsg = `
@@ -104,7 +102,7 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 	}
 
 	c.ConfirmationCommandBase.Run(ctx)
-	if !(c.ConfirmationCommandBase.GetAssumeYes() || c.ConfirmationCommandBase.GetAssumeNoPrompt()) {
+	if !(c.ConfirmationCommandBase.NeedsConfirmation()) {
 		fmt.Fprintf(ctx.Stdout, unregisterMsg, c.controllerName)
 		if err := jujucmd.UserConfirmName(c.controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "unregistering controller")

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -102,11 +102,11 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if !c.assumeNoPrompt {
-		var skipErr error
-		c.assumeNoPrompt, skipErr = jujucmd.CheckSkipConfirmEnvVar()
+		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
 		if skipErr != nil {
 			return errors.Trace(skipErr)
 		}
+		c.assumeNoPrompt = assumeNoPrompt
 	}
 	if c.assumeYes {
 		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags a deprecated and will be removed in JUJU 3.1\n")

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -61,7 +61,7 @@ func (c *unregisterCommand) Info() *cmd.Info {
 
 // SetFlags implements Command.SetFlags.
 func (c *unregisterCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for forward compatibility with Juju 2.9")
+	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for backwards compatibility with Juju 2.9")
 	f.BoolVar(&c.assumeYes, "yes", false, "")
 	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation")
 }
@@ -103,13 +103,14 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 
 	if !c.assumeNoPrompt {
 		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
-		if skipErr != nil {
+		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
 			return errors.Trace(skipErr)
+		} else {
+			c.assumeNoPrompt = assumeNoPrompt
 		}
-		c.assumeNoPrompt = assumeNoPrompt
 	}
 	if c.assumeYes {
-		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags a deprecated and will be removed in JUJU 3.1\n")
+		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
 	}
 	if !(c.assumeYes || c.assumeNoPrompt) {
 		fmt.Fprintf(ctx.Stdout, unregisterMsg, c.controllerName)

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -78,6 +78,15 @@ func (c *unregisterCommand) Init(args []string) error {
 	}
 	c.controllerName, args = args[0], args[1:]
 
+	if !c.assumeNoPrompt {
+		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
+		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
+			return errors.Trace(skipErr)
+		} else {
+			c.assumeNoPrompt = assumeNoPrompt
+		}
+	}
+
 	if err := jujuclient.ValidateControllerName(c.controllerName); err != nil {
 		return err
 	}
@@ -101,14 +110,6 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	if !c.assumeNoPrompt {
-		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
-		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
-			return errors.Trace(skipErr)
-		} else {
-			c.assumeNoPrompt = assumeNoPrompt
-		}
-	}
 	if c.assumeYes {
 		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
 	}

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -83,9 +83,13 @@ func (c *unregisterCommand) Init(args []string) error {
 	}
 
 	if err := cmd.CheckEmpty(args); err != nil {
-		return err
+		return errors.Trace(err)
 	}
-	return c.ConfirmationCommandBase.Init(args)
+
+	if err := c.ConfirmationCommandBase.Init(args); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 var unregisterMsg = `

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -105,7 +105,9 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	c.ConfirmationCommandBase.Run(ctx)
+	if err := c.ConfirmationCommandBase.Run(ctx); err != nil {
+		return errors.Trace(err)
+	}
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, unregisterMsg, c.controllerName)
 		if err := jujucmd.UserConfirmName(c.controllerName, "controller", ctx); err != nil {

--- a/cmd/juju/controller/unregister_test.go
+++ b/cmd/juju/controller/unregister_test.go
@@ -88,7 +88,7 @@ This command will remove connection information for controller "fake1".
 Doing so will prevent you from accessing this controller until
 you register it again.
 
-To continue, enter the name of the controller to be destroyed:`[1:]
+To continue, enter the name of the controller to be destroyed: `[1:]
 
 func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
 	var stdin, stdout bytes.Buffer

--- a/cmd/juju/controller/unregister_test.go
+++ b/cmd/juju/controller/unregister_test.go
@@ -76,7 +76,7 @@ func (s *UnregisterSuite) TestUnregisterUnknownController(c *gc.C) {
 
 func (s *UnregisterSuite) TestUnregisterController(c *gc.C) {
 	command := controller.NewUnregisterCommand(s.store)
-	_, err := cmdtesting.RunCommand(c, command, "fake1", "-y")
+	_, err := cmdtesting.RunCommand(c, command, "fake1", "--no-prompt")
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(s.store.lookupName, gc.Equals, "fake1")
@@ -88,7 +88,7 @@ This command will remove connection information for controller "fake1".
 Doing so will prevent you from accessing this controller until
 you register it again.
 
-Continue [y/N]? `[1:]
+To continue, enter the name of the controller to be destroyed:`[1:]
 
 func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
 	var stdin, stdout bytes.Buffer
@@ -143,5 +143,5 @@ func (s *UnregisterSuite) unregisterCommandConfirms(c *gc.C, answer string) {
 }
 
 func (s *UnregisterSuite) TestUnregisterCommandConfirmsOnY(c *gc.C) {
-	s.unregisterCommandConfirms(c, "y")
+	s.unregisterCommandConfirms(c, "fake1")
 }

--- a/cmd/modelcmd/confirmation.go
+++ b/cmd/modelcmd/confirmation.go
@@ -5,9 +5,11 @@ package modelcmd
 
 import (
 	"fmt"
+
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+
 	jujucmd "github.com/juju/juju/cmd"
 )
 

--- a/cmd/modelcmd/confirmation.go
+++ b/cmd/modelcmd/confirmation.go
@@ -49,5 +49,5 @@ func (c *ConfirmationCommandBase) Run(ctx *cmd.Context) error {
 
 // NeedsConfirmation returns if flags require the confirmation or not.
 func (c *ConfirmationCommandBase) NeedsConfirmation() bool {
-	return c.assumeYes || c.assumeNoPrompt
+	return !(c.assumeYes || c.assumeNoPrompt)
 }

--- a/cmd/modelcmd/confirmation.go
+++ b/cmd/modelcmd/confirmation.go
@@ -28,10 +28,11 @@ func (c *ConfirmationCommandBase) SetFlags(f *gnuflag.FlagSet) {
 // Init implements Command.Init.
 func (c *ConfirmationCommandBase) Init(args []string) error {
 	if !c.assumeNoPrompt {
-		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
+		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmationEnvVar()
 		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
 			return errors.Trace(skipErr)
-		} else {
+		}
+		if !errors.Is(skipErr, errors.NotFound) {
 			c.assumeNoPrompt = assumeNoPrompt
 		}
 	}
@@ -46,12 +47,7 @@ func (c *ConfirmationCommandBase) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-// GetAssumeYes returns assumeYes
-func (c *ConfirmationCommandBase) GetAssumeYes() bool {
-	return c.assumeYes
-}
-
-// GetAssumeNoPrompt returns assumeNoPrompt
-func (c *ConfirmationCommandBase) GetAssumeNoPrompt() bool {
-	return c.assumeNoPrompt
+// NeedsConfirmation returns if flags require the confirmation or not.
+func (c *ConfirmationCommandBase) NeedsConfirmation() bool {
+	return c.assumeYes || c.assumeNoPrompt
 }

--- a/cmd/modelcmd/confirmation.go
+++ b/cmd/modelcmd/confirmation.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcmd
+
+import (
+	"fmt"
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	jujucmd "github.com/juju/juju/cmd"
+)
+
+// ConfirmationCommandBase provides common attributes and methods that
+// commands require to confirm the execution.
+type ConfirmationCommandBase struct {
+	assumeYes      bool // DEPRECATED
+	assumeNoPrompt bool
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *ConfirmationCommandBase) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for backwards compatibility with Juju 2.9")
+	f.BoolVar(&c.assumeYes, "yes", false, "")
+	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation")
+}
+
+// Init implements Command.Init.
+func (c *ConfirmationCommandBase) Init(args []string) error {
+	if !c.assumeNoPrompt {
+		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmEnvVar()
+		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
+			return errors.Trace(skipErr)
+		} else {
+			c.assumeNoPrompt = assumeNoPrompt
+		}
+	}
+	return nil
+}
+
+// Run implements Command.Run
+func (c *ConfirmationCommandBase) Run(ctx *cmd.Context) error {
+	if c.assumeYes {
+		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
+	}
+	return nil
+}
+
+// GetAssumeYes returns assumeYes
+func (c *ConfirmationCommandBase) GetAssumeYes() bool {
+	return c.assumeYes
+}
+
+// GetAssumeNoPrompt returns assumeNoPrompt
+func (c *ConfirmationCommandBase) GetAssumeNoPrompt() bool {
+	return c.assumeNoPrompt
+}

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/juju/rpcreflect v1.0.0
 	github.com/juju/schema v1.0.1
 	github.com/juju/terms-client/v2 v2.0.0
-	github.com/juju/testing v1.0.2
+	github.com/juju/testing v1.0.3
 	github.com/juju/txn/v3 v3.0.2
 	github.com/juju/utils/v3 v3.0.0
 	github.com/juju/version/v2 v2.0.1
@@ -91,7 +91,7 @@ require (
 	github.com/juju/webbrowser v1.0.0
 	github.com/juju/worker/v3 v3.1.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/kr/pretty v0.3.1-0.20220829230305-3cd153a126da
+	github.com/kr/pretty v0.3.1
 	github.com/lxc/lxd v0.0.0-20220816180258-7e0418163fa9
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb
@@ -105,11 +105,11 @@ require (
 	github.com/rs/xid v1.4.0
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/vmware/govmomi v0.21.1-0.20191008161538-40aebf13ba45
-	golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
-	golang.org/x/net v0.0.0-20221004154528-8021a29435af
+	golang.org/x/crypto v0.3.0
+	golang.org/x/net v0.2.0
 	golang.org/x/oauth2 v0.0.0-20221006150949-b44042a4b9c1
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
-	golang.org/x/sys v0.0.0-20221010170243-090e33056c14
+	golang.org/x/sys v0.2.0
 	golang.org/x/tools v0.1.12
 	google.golang.org/api v0.84.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
@@ -260,7 +260,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/term v0.1.0 // indirect
+	golang.org/x/term v0.2.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494/go.mod h1:rUquetT0ALL
 github.com/juju/testing v1.0.0/go.mod h1:rUquetT0ALL48LHZhyRGvjjBH8xZaZ8dFClulKK5wK4=
 github.com/juju/testing v1.0.2 h1:OR90RqCd9CJONxXamZAjLknpZdtqDyxqW8IwCbgw3i4=
 github.com/juju/testing v1.0.2/go.mod h1:h3Vd2rzB57KrdsBEy6R7bmSKPzP76BnNavt7i8PerwQ=
+github.com/juju/testing v1.0.3 h1:xnF/JObHZ610p8UNC4GVCrhH9n/j4opcSh3MXwpeZl4=
+github.com/juju/testing v1.0.3/go.mod h1:1XQGptw6JWFvRWb3ewilUdTBG0oGcoI2kdX9Z1VEzhU=
 github.com/juju/txn/v3 v3.0.2 h1:ibKhRlQmslPj88QfxND8hX4Sv6rTRKOb+HSp/ti1sEg=
 github.com/juju/txn/v3 v3.0.2/go.mod h1:DlFlqNZkgzE4NolIxhSvYOok/heIOjhXLx3Z5oUTyy4=
 github.com/juju/usso v1.0.1 h1:zyQhSUJnhFZdPqVAmPeqXYlnYXv+i0Cp1Ii+aziMXGs=
@@ -921,6 +923,8 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1-0.20220829230305-3cd153a126da h1:nG9iH/xVlvthev5vEBwjFPPgnPYqtIJ1FNwZncpAvTg=
 github.com/kr/pretty v0.3.1-0.20220829230305-3cd153a126da/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -1350,6 +1354,8 @@ golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2 h1:x8vtB3zMecnlqZIwJNUUpwYKYSqCz5jXbiyv0ZJJZeI=
 golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
+golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1455,6 +1461,8 @@ golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
 golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=
+golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1605,6 +1613,8 @@ golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1613,6 +1623,8 @@ golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.2.0 h1:z85xZCsEl7bi/KwbNADeBYoOP0++7W1ipu+aGnpwzRM=
+golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -867,8 +867,6 @@ github.com/juju/testing v0.0.0-20210324180055-18c50b0c2098/go.mod h1:7lxZW0B50+x
 github.com/juju/testing v0.0.0-20220202055744-1ad0816210a6/go.mod h1:QgWc2UdIPJ8t3rnvv95tFNOsQDfpXYEZDbP281o3b2c=
 github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494/go.mod h1:rUquetT0ALL48LHZhyRGvjjBH8xZaZ8dFClulKK5wK4=
 github.com/juju/testing v1.0.0/go.mod h1:rUquetT0ALL48LHZhyRGvjjBH8xZaZ8dFClulKK5wK4=
-github.com/juju/testing v1.0.2 h1:OR90RqCd9CJONxXamZAjLknpZdtqDyxqW8IwCbgw3i4=
-github.com/juju/testing v1.0.2/go.mod h1:h3Vd2rzB57KrdsBEy6R7bmSKPzP76BnNavt7i8PerwQ=
 github.com/juju/testing v1.0.3 h1:xnF/JObHZ610p8UNC4GVCrhH9n/j4opcSh3MXwpeZl4=
 github.com/juju/testing v1.0.3/go.mod h1:1XQGptw6JWFvRWb3ewilUdTBG0oGcoI2kdX9Z1VEzhU=
 github.com/juju/txn/v3 v3.0.2 h1:ibKhRlQmslPj88QfxND8hX4Sv6rTRKOb+HSp/ti1sEg=
@@ -921,8 +919,6 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.1-0.20220829230305-3cd153a126da h1:nG9iH/xVlvthev5vEBwjFPPgnPYqtIJ1FNwZncpAvTg=
-github.com/kr/pretty v0.3.1-0.20220829230305-3cd153a126da/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -1352,8 +1348,6 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2 h1:x8vtB3zMecnlqZIwJNUUpwYKYSqCz5jXbiyv0ZJJZeI=
-golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1459,8 +1453,6 @@ golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
-golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1611,8 +1603,6 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
-golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1621,8 +1611,6 @@ golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
-golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0 h1:z85xZCsEl7bi/KwbNADeBYoOP0++7W1ipu+aGnpwzRM=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -394,9 +394,9 @@ destroy_controller() {
 
 	echo "====> Destroying juju ($(green "${name}"))"
 	if [[ ${KILL_CONTROLLER:-} != "true" ]]; then
-		echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models -y % >"${output}" 2>&1
+		echo "${name}" | xargs -I % juju destroy-controller --destroy-all-models --no-prompt % >"${output}" 2>&1
 	else
-		echo "${name}" | xargs -I % juju kill-controller -t 0 -y % >"${output}" 2>&1
+		echo "${name}" | xargs -I % juju kill-controller -t 0 --no-prompt % >"${output}" 2>&1
 	fi
 
 	set +e

--- a/tests/suites/cli/unregister.sh
+++ b/tests/suites/cli/unregister.sh
@@ -29,7 +29,7 @@ EOF
 	echo "${CONTROLLERS}" >>"${TEST_DIR}/juju/controllers.yaml"
 
 	echo "Unregister the unregister-test controller"
-	JUJU_DATA="${TEST_DIR}/juju" juju unregister --yes "unregister-test"
+	JUJU_DATA="${TEST_DIR}/juju" juju unregister --no-prompt "unregister-test"
 
 	echo "Check that temporary controllers.yaml has no controllers' data"
 	EXPECTED="controllers: {}"


### PR DESCRIPTION
This PR adds verification by name when requesting destroying, killing, and unregistering controllers. Adds support of skip confirmation env var. Adds support of `--no-prompt` flag instead of `-y`. According to specification JU057.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
juju bootstrap lxd lxd
juju bootstrap lxd lxd2
juju bootstrap lxd lxd3

juju destroy-controller lxd

juju destroy-controller lxd2 --no-prompt

JUJU_SKIP_CONRIMATION=true juju destroy-controller lxd3

cd tests/
./main.sh -v -p lxd cli test_unregister

cd ../cmd/juju/controller
go test ./...
```

## Documentation changes

TBW

