### PR TITLE
[JUJU-2270] - Fix/lp 1998102

### DIFF
--- a/caas/kubernetes/provider/secrets_test.go
+++ b/caas/kubernetes/provider/secrets_test.go
@@ -77,7 +77,9 @@ func (s *secretsSuite) TestGetJujuSecret(c *gc.C) {
 
 	value, err := s.broker.GetJujuSecret(context.Background(), "provider-id")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(value.EncodedValues(), jc.DeepEquals, map[string]string{
+	data, err := value.Values()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(data, jc.DeepEquals, map[string]string{
 		"foo": "bar",
 	})
 }
@@ -123,7 +125,7 @@ func (s *secretsSuite) TestSaveJujuSecret(c *gc.C) {
 	uri := secrets.NewURI()
 	providerId, err := s.broker.SaveJujuSecret(context.Background(), uri.ID+"-666",
 		secrets.NewSecretValue(map[string]string{
-			"foo": "bar",
+			"foo": "YmFy",
 		}),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -833,11 +833,13 @@ func (ctx *HookContext) getPendingSecretValue(uri *coresecrets.URI) (coresecrets
 	}
 	for _, v := range ctx.secretChanges.pendingCreates {
 		if v.URI != nil && v.URI.ID == uri.ID {
+			// The initial value of the secret is not stored in the database yet.
 			return v.Value, true
 		}
 	}
 	for _, v := range ctx.secretChanges.pendingUpdates {
 		if v.URI != nil && v.URI.ID == uri.ID {
+			// The new value of the secret is going to be updated to the database.
 			return v.Value, v.Value != nil && !v.Value.IsEmpty()
 		}
 	}


### PR DESCRIPTION
When we run `secret-get` immediately after `secret-add` in the same hook context, we will get a not found error.
This is because the `secret-add` hasn't been applied to the database yet and the uniter makes a facade call for getting the secret content.
To fix this, we should try to look for the secret from the pending changes instead.

Note: this was initially reported at https://github.com/canonical/operator/issues/857

Drive by: fix the k8s secret provider double encoding secret content.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
juju exec --unit prometheus-k8s/0 'secret-add --owner unit unit=prometheus-k8s/0 --label=prometheus-k8s/0; secret-get --label prometheus-k8s/0'
secret:ce2a3aeffbas7anp87gg
unit: prometheus-k8s/0

juju exec --unit prometheus-k8s/0 'secret-set ce2a3aeffbas7anp87gg unit=prometheus-k8s/00; secret-get --label prometheus-k8s/0'
unit: prometheus-k8s/00

mkubectl -nt1 get secret/ce2a3aeffbas7anp87gg-1 -o json | jq -r .data.unit | base64 -d
prometheus-k8s/0
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1998102
