### PR TITLE
[JUJU-2221] Add approval confirmation to remove-machine

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -507,7 +507,7 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep, d
 			fail(err)
 			continue
 		}
-		if force {
+		if force || dryRun {
 			info.DestroyedContainers, err = mm.destoryContainer(containers, force, keep, dryRun, maxWait)
 			if err != nil {
 				fail(err)
@@ -531,6 +531,12 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep, d
 				continue
 			}
 			logger.Warningf("could not deal with units' storage on machine %v: %v", machineTag.Id(), err)
+		}
+
+		if dryRun {
+			result.Info = &info
+			results[i] = result
+			continue
 		}
 
 		applicationNames, err := mm.leadership.GetMachineApplicationNames(machineTag.Id())
@@ -573,7 +579,6 @@ func (mm *MachineManagerAPI) destroyMachine(args params.Entities, force, keep, d
 					"could not unpin application leaders for machine %s with error %v", machineTag.Id(), result.Error)
 			}
 		}
-
 		result.Info = &info
 		results[i] = result
 	}

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -482,6 +482,93 @@ func (s *DestroyMachineManagerSuite) TestForceDestroyMachineFailedSomeStorageRet
 	})
 }
 
+func (s *DestroyMachineManagerSuite) TestDestroyMachineDryRun(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	machine0 := s.expectDestroyMachine(ctrl, nil, nil, false, false, false)
+	s.st.EXPECT().Machine("0").Return(machine0, nil)
+
+	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			MachineTags: []string{"machine-0"},
+		},
+		DryRun: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
+		Results: []params.DestroyMachineResult{{
+			Info: &params.DestroyMachineInfo{
+				MachineId: "0",
+				DestroyedUnits: []params.Entity{
+					{"unit-foo-0"},
+					{"unit-foo-1"},
+					{"unit-foo-2"},
+				},
+				DetachedStorage: []params.Entity{
+					{"storage-disks-0"},
+				},
+				DestroyedStorage: []params.Entity{
+					{"storage-disks-1"},
+				},
+			},
+		}},
+	})
+}
+
+func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainersDryRun(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	machine0 := s.expectDestroyMachine(ctrl, nil, []string{"0/lxd/0"}, false, false, false)
+	s.st.EXPECT().Machine("0").Return(machine0, nil)
+	container0 := s.expectDestroyMachine(ctrl, nil, nil, false, false, false)
+	s.st.EXPECT().Machine("0/lxd/0").Return(container0, nil)
+
+	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
+		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
+			MachineTags: []string{"machine-0"},
+		},
+		DryRun: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
+		Results: []params.DestroyMachineResult{{
+			Info: &params.DestroyMachineInfo{
+				MachineId: "0",
+				DestroyedUnits: []params.Entity{
+					{"unit-foo-0"},
+					{"unit-foo-1"},
+					{"unit-foo-2"},
+				},
+				DetachedStorage: []params.Entity{
+					{"storage-disks-0"},
+				},
+				DestroyedStorage: []params.Entity{
+					{"storage-disks-1"},
+				},
+				DestroyedContainers: []params.DestroyMachineResult{{
+					Info: &params.DestroyMachineInfo{
+						MachineId: "0/lxd/0",
+						DestroyedUnits: []params.Entity{
+							{"unit-foo-0"},
+							{"unit-foo-1"},
+							{"unit-foo-2"},
+						},
+						DetachedStorage: []params.Entity{
+							{"storage-disks-0"},
+						},
+						DestroyedStorage: []params.Entity{
+							{"storage-disks-1"},
+						},
+					},
+				}},
+			},
+		}},
+	})
+}
+
 func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNoWait(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()

--- a/cmd/juju/commands/machine_test.go
+++ b/cmd/juju/commands/machine_test.go
@@ -51,7 +51,7 @@ func (s *MachineSuite) TestMachineRemove(c *gc.C) {
 
 	ctx, err := s.RunCommand(c, "remove-machine", machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, `will remove machine`)
 
 	err = machine.Refresh()
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	SSHProvisioner = &sshProvisioner
+	SSHProvisioner        = &sshProvisioner
+	ErrDryRunNotSupported = errDryRunNotSupported
 )
 
 type AddCommand struct {

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -4,6 +4,10 @@
 package machine
 
 import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -16,6 +20,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -25,16 +30,18 @@ func NewRemoveCommand() cmd.Command {
 }
 
 // removeCommand causes an existing machine to be destroyed.
+// TODO(jack-w-shaw) This should inherit from ConfirmationCommandBase
+// in 3.1, once behaviours have converged
 type removeCommand struct {
 	baseMachinesCommand
-	noPrompt     bool
-	dryRun       bool
 	apiRoot      api.Connection
 	machineAPI   RemoveMachineAPI
 	MachineIds   []string
 	Force        bool
 	KeepInstance bool
 	NoWait       bool
+	NoPrompt     bool
+	DryRun       bool
 	fs           *gnuflag.FlagSet
 }
 
@@ -67,6 +74,15 @@ See also:
     add-machine
 `
 
+var removeMachineMsgNoDryRun = `
+WARNING! This command will remove machine(s) %q
+Your controller does not support a more in depth dry run
+`[1:]
+
+var removeMachineMsgPrefix = "WARNING! This command:\n"
+
+var errDryRunNotSupported = errors.New("Your controller does not support `--dry-run`")
+
 // Info implements Command.Info.
 func (c *removeCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
@@ -80,8 +96,8 @@ func (c *removeCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *removeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.noPrompt, "no-prompt", false, "Do not prompt for approval")
-	f.BoolVar(&c.dryRun, "dry-run", false, "Print what this command would be removed without removing")
+	f.BoolVar(&c.NoPrompt, "no-prompt", false, "Do not prompt for approval")
+	f.BoolVar(&c.DryRun, "dry-run", false, "Print what this command would be removed without removing")
 	f.BoolVar(&c.Force, "force", false, "Completely remove a machine and all its dependencies")
 	f.BoolVar(&c.KeepInstance, "keep-instance", false, "Do not stop the running cloud instance")
 	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through machine removal without waiting for each individual step to complete")
@@ -97,6 +113,24 @@ func (c *removeCommand) Init(args []string) error {
 			return errors.Errorf("invalid machine id %q", id)
 		}
 	}
+
+	// To maintain compatibility, in 3.0 NoPrompt should default to true.
+	// However, we still need to take into account the env var and the
+	// flag. So default initially to false, but if the env var and flag
+	// are not present, set to true.
+	// TODO(jack-w-shaw) use CheckSkipConfirmEnvVar in 3.1
+	if !c.NoPrompt {
+		if skipConf, ok := os.LookupEnv(osenv.JujuSkipConfirmationEnvKey); ok {
+			skipConfBool, err := strconv.ParseBool(skipConf)
+			if err != nil {
+				return errors.Annotatef(err, "value %q of env var %q is not a valid bool", skipConf, osenv.JujuSkipConfirmationEnvKey)
+			}
+			c.NoPrompt = skipConfBool
+		} else {
+			c.NoPrompt = true
+		}
+	}
+
 	c.MachineIds = args
 	return nil
 }
@@ -153,42 +187,93 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	results, err := client.DestroyMachinesWithParams(c.Force, c.KeepInstance, false, maxWait, c.MachineIds...)
-	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
-		return err
+	if c.DryRun {
+		return c.performDryRun(ctx, client)
 	}
 
-	anyFailed := false
-	for _, result := range results {
-		err = logRemovedMachine(ctx, result, c.KeepInstance)
-		if err != nil {
-			anyFailed = true
-			ctx.Infof("%s", err)
+	if !c.NoPrompt {
+		err := c.performDryRun(ctx, client)
+		if err == errDryRunNotSupported {
+			fmt.Fprintf(ctx.Stdout, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+		if err := jujucmd.UserConfirmYes(ctx); err != nil {
+			return errors.Annotate(err, "machine removal")
 		}
 	}
 
+	results, err := client.DestroyMachinesWithParams(c.Force, c.KeepInstance, false, maxWait, c.MachineIds...)
+	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
+		return errors.Trace(err)
+	}
+
+	logAll := c.NoPrompt || client.BestAPIVersion() < 10
+	return c.logResults(ctx, results, !logAll)
+}
+
+func (c *removeCommand) performDryRun(ctx *cmd.Context, client RemoveMachineAPI) error {
+	// TODO(jack-w-shaw) Drop this once machinemanager 9 support is dropped
+	if client.BestAPIVersion() < 10 {
+		return errDryRunNotSupported
+	}
+	results, err := client.DestroyMachinesWithParams(c.Force, c.KeepInstance, true, nil, c.MachineIds...)
+	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
+		return errors.Trace(err)
+	}
+	fmt.Fprint(ctx.Stdout, removeMachineMsgPrefix)
+	if err := c.logResults(ctx, results, false); err != nil {
+		return errors.Trace(err)
+	}
+	if c.runNeedsForce(results) {
+		fmt.Fprint(ctx.Stdout, "\nThis will require `--force`\n")
+	}
+	return nil
+}
+
+func (c *removeCommand) runNeedsForce(results []params.DestroyMachineResult) bool {
+	for _, result := range results {
+		if result.Error != nil {
+			continue
+		}
+		if len(result.Info.DestroyedContainers) > 0 || len(result.Info.DestroyedUnits) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *removeCommand) logResults(ctx *cmd.Context, results []params.DestroyMachineResult, errorOnly bool) error {
+	anyFailed := false
+	for _, result := range results {
+		if err := c.logResult(ctx, result, errorOnly); err != nil {
+			anyFailed = true
+		}
+	}
 	if anyFailed {
 		return cmd.ErrSilent
 	}
 	return nil
 }
 
-func logRemovedMachine(ctx *cmd.Context, result params.DestroyMachineResult, keepInstance bool) error {
+func (c *removeCommand) logResult(ctx *cmd.Context, result params.DestroyMachineResult, errorOnly bool) error {
 	if result.Error != nil {
-		return errors.Errorf("removing machine failed: %s", result.Error)
+		err := errors.Annotate(result.Error, "removing machine failed")
+		fmt.Fprintf(ctx.Stderr, "%s\n", err)
+		return errors.Trace(err)
 	}
-	for _, destroyContainerResult := range result.Info.DestroyedContainers {
-		err := logRemovedMachine(ctx, destroyContainerResult, keepInstance)
-		if err != nil {
-			ctx.Infof("%s", err)
-		}
-		ctx.Infof("\n")
+	if !errorOnly {
+		c.logRemovedMachine(ctx, result)
 	}
+	return c.logResults(ctx, result.Info.DestroyedContainers, errorOnly)
+}
+
+func (c *removeCommand) logRemovedMachine(ctx *cmd.Context, result params.DestroyMachineResult) {
 	id := result.Info.MachineId
-	if keepInstance {
-		ctx.Infof("removing machine %s (but retaining cloud instance)", id)
+	if c.KeepInstance {
+		fmt.Fprintf(ctx.Stdout, "will remove machine %s (but retaining cloud instance)\n", id)
 	} else {
-		ctx.Infof("removing machine %s", id)
+		fmt.Fprintf(ctx.Stdout, "will remove machine %s\n", id)
 	}
 	for _, entity := range result.Info.DestroyedUnits {
 		unitTag, err := names.ParseUnitTag(entity.Tag)
@@ -196,7 +281,7 @@ func logRemovedMachine(ctx *cmd.Context, result params.DestroyMachineResult, kee
 			logger.Warningf("%s", err)
 			continue
 		}
-		ctx.Infof("- will remove %s", names.ReadableString(unitTag))
+		fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(unitTag))
 	}
 	for _, entity := range result.Info.DestroyedStorage {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
@@ -204,7 +289,7 @@ func logRemovedMachine(ctx *cmd.Context, result params.DestroyMachineResult, kee
 			logger.Warningf("%s", err)
 			continue
 		}
-		ctx.Infof("- will remove %s", names.ReadableString(storageTag))
+		fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(storageTag))
 	}
 	for _, entity := range result.Info.DetachedStorage {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
@@ -212,7 +297,6 @@ func logRemovedMachine(ctx *cmd.Context, result params.DestroyMachineResult, kee
 			logger.Warningf("%s", err)
 			continue
 		}
-		ctx.Infof("- will detach %s", names.ReadableString(storageTag))
+		fmt.Fprintf(ctx.Stdout, "- will detach %s\n", names.ReadableString(storageTag))
 	}
-	return nil
 }

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -4,6 +4,7 @@
 package machine_test
 
 import (
+	"bytes"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -14,8 +15,11 @@ import (
 
 	"github.com/juju/juju/api"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/cmd/cmdtest"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/cmd/juju/machine/mocks"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/testing"
 )
@@ -24,6 +28,8 @@ type RemoveMachineSuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	mockApi       *mocks.MockRemoveMachineAPI
 	apiConnection *mockAPIConnection
+
+	facadeVersion int
 }
 
 var _ = gc.Suite(&RemoveMachineSuite{})
@@ -31,6 +37,7 @@ var _ = gc.Suite(&RemoveMachineSuite{})
 func (s *RemoveMachineSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.apiConnection = &mockAPIConnection{}
+	s.facadeVersion = 10
 }
 
 func (s *RemoveMachineSuite) setup(c *gc.C) *gomock.Controller {
@@ -38,12 +45,18 @@ func (s *RemoveMachineSuite) setup(c *gc.C) *gomock.Controller {
 
 	s.mockApi = mocks.NewMockRemoveMachineAPI(ctrl)
 	s.mockApi.EXPECT().Close().Return(nil).AnyTimes()
+	s.mockApi.EXPECT().BestAPIVersion().Return(s.facadeVersion).AnyTimes()
 	return ctrl
 }
 
 func (s *RemoveMachineSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	remove, _ := machine.NewRemoveCommandForTest(s.apiConnection, s.mockApi)
 	return cmdtesting.RunCommand(c, remove, args...)
+}
+
+func (s *RemoveMachineSuite) runWithContext(ctx *cmd.Context, args ...string) (chan dummy.Operation, chan error) {
+	remove, _ := machine.NewRemoveCommandForTest(s.apiConnection, s.mockApi)
+	return cmdtest.RunCommandWithDummyProvider(ctx, remove, args...)
 }
 
 func defaultDestroyMachineResult(_, _, _ bool, _ *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
@@ -62,6 +75,8 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 		machines    []string
 		force       bool
 		keep        bool
+		noPrompt    bool
+		dryRun      bool
 		errorString string
 	}{
 		{
@@ -69,27 +84,43 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 		}, {
 			args:     []string{"1"},
 			machines: []string{"1"},
+			noPrompt: true,
 		}, {
 			args:     []string{"1", "2"},
 			machines: []string{"1", "2"},
+			noPrompt: true,
 		}, {
 			args:     []string{"1", "--force"},
 			machines: []string{"1"},
 			force:    true,
+			noPrompt: true,
 		}, {
 			args:     []string{"--force", "1", "2"},
 			machines: []string{"1", "2"},
 			force:    true,
+			noPrompt: true,
 		}, {
 			args:     []string{"--keep-instance", "1", "2"},
 			machines: []string{"1", "2"},
 			keep:     true,
+			noPrompt: true,
+		}, {
+			args:     []string{"1", "2", "--no-prompt"},
+			machines: []string{"1", "2"},
+			noPrompt: true,
+		}, {
+			args:     []string{"1", "2", "--dry-run"},
+			machines: []string{"1", "2"},
+			noPrompt: true,
+			dryRun:   true,
 		}, {
 			args:        []string{"lxd"},
 			errorString: `invalid machine id "lxd"`,
+			noPrompt:    true,
 		}, {
 			args:     []string{"1/lxd/2"},
 			machines: []string{"1/lxd/2"},
+			noPrompt: true,
 		},
 	} {
 		c.Logf("test %d", i)
@@ -99,6 +130,53 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(removeCmd.Force, gc.Equals, test.force)
 			c.Check(removeCmd.KeepInstance, gc.Equals, test.keep)
+			c.Check(removeCmd.NoPrompt, gc.Equals, test.noPrompt)
+			c.Check(removeCmd.DryRun, gc.Equals, test.dryRun)
+			c.Check(removeCmd.MachineIds, jc.DeepEquals, test.machines)
+		} else {
+			c.Check(err, gc.ErrorMatches, test.errorString)
+		}
+	}
+}
+
+func (s *RemoveMachineSuite) TestInitTrueSkipConfirmationEnvVar(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "1")
+	s.TestInit(c)
+}
+
+func (s *RemoveMachineSuite) TestInitFalseSkipConfirmationEnvVar(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+	for i, test := range []struct {
+		args        []string
+		machines    []string
+		force       bool
+		keep        bool
+		noPrompt    bool
+		dryRun      bool
+		errorString string
+	}{
+		{
+			args:     []string{"1"},
+			machines: []string{"1"},
+		}, {
+			args:     []string{"1", "2", "--no-prompt"},
+			machines: []string{"1", "2"},
+			noPrompt: true,
+		},
+	} {
+		c.Logf("test %d", i)
+		wrappedCommand, removeCmd := machine.NewRemoveCommandForTest(s.apiConnection, s.mockApi)
+		err := cmdtesting.InitCommand(wrappedCommand, test.args)
+		if test.errorString == "" {
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(removeCmd.Force, gc.Equals, test.force)
+			c.Check(removeCmd.KeepInstance, gc.Equals, test.keep)
+			c.Check(removeCmd.NoPrompt, gc.Equals, test.noPrompt)
+			c.Check(removeCmd.DryRun, gc.Equals, test.dryRun)
 			c.Check(removeCmd.MachineIds, jc.DeepEquals, test.machines)
 		} else {
 			c.Check(err, gc.ErrorMatches, test.errorString)
@@ -112,6 +190,15 @@ func (s *RemoveMachineSuite) TestRemove(c *gc.C) {
 	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, false, gomock.Any(), "1", "2/lxd/1")
 
 	_, err := s.run(c, "1", "2/lxd/1")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *RemoveMachineSuite) TestRemoveNoPrompt(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, false, gomock.Any(), "1", "2/lxd/1")
+
+	_, err := s.run(c, "--no-prompt", "1", "2/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -140,9 +227,12 @@ func (s *RemoveMachineSuite) TestRemoveOutput(c *gc.C) {
 	ctx, err := s.run(c, "1", "2/lxd/1")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	stderr := cmdtesting.Stderr(ctx)
+	stdout := cmdtesting.Stdout(ctx)
 	c.Assert(stderr, gc.Equals, `
 removing machine failed: oy vey machine 1
-removing machine 2/lxd/1
+`[1:])
+	c.Assert(stdout, gc.Equals, `
+will remove machine 2/lxd/1
 - will remove unit foo/0
 - will remove storage bar/1
 - will detach storage baz/2
@@ -152,7 +242,7 @@ removing machine 2/lxd/1
 func (s *RemoveMachineSuite) TestRemoveKeep(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.mockApi.EXPECT().DestroyMachinesWithParams(false, true, false, gomock.Any(), "1", "2").DoAndReturn(defaultDestroyMachineResult)
+	s.mockApi.EXPECT().DestroyMachinesWithParams(false, true, false, gomock.Any(), "1", "2")
 
 	_, err := s.run(c, "--keep-instance", "1", "2")
 	c.Assert(err, jc.ErrorIsNil)
@@ -165,17 +255,17 @@ func (s *RemoveMachineSuite) TestRemoveOutputKeep(c *gc.C) {
 
 	ctx, err := s.run(c, "--keep-instance", "1", "2")
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := cmdtesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, `
-removing machine 1 (but retaining cloud instance)
-removing machine 2 (but retaining cloud instance)
+	stdout := cmdtesting.Stdout(ctx)
+	c.Assert(stdout, gc.Equals, `
+will remove machine 1 (but retaining cloud instance)
+will remove machine 2 (but retaining cloud instance)
 `[1:])
 }
 
 func (s *RemoveMachineSuite) TestRemoveForce(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.mockApi.EXPECT().DestroyMachinesWithParams(true, false, false, gomock.Any(), "1", "2/lxd/1").DoAndReturn(defaultDestroyMachineResult)
+	s.mockApi.EXPECT().DestroyMachinesWithParams(true, false, false, gomock.Any(), "1", "2/lxd/1")
 
 	_, err := s.run(c, "--force", "1", "2/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
@@ -204,18 +294,134 @@ func (s *RemoveMachineSuite) TestRemoveWithContainers(c *gc.C) {
 
 	ctx, err := s.run(c, "--force", "1")
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := cmdtesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, `
-removing machine 1/lxd/2
-- will remove unit foo/1
-- will remove storage bar/2
-- will detach storage baz/3
-
-removing machine 1
+	stdout := cmdtesting.Stdout(ctx)
+	c.Assert(stdout, gc.Equals, `
+will remove machine 1
 - will remove unit foo/0
 - will remove storage bar/1
 - will detach storage baz/2
+will remove machine 1/lxd/2
+- will remove unit foo/1
+- will remove storage bar/2
+- will detach storage baz/3
 `[1:])
+}
+
+func (s *RemoveMachineSuite) TestRemoveDryRun(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, true, gomock.Any(), "1", "2")
+
+	_, err := s.run(c, "--dry-run", "1", "2")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *RemoveMachineSuite) TestRemoveOutputDryRun(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, true, gomock.Any(), "1", "2").DoAndReturn(defaultDestroyMachineResult)
+
+	ctx, err := s.run(c, "--dry-run", "1", "2")
+	c.Assert(err, jc.ErrorIsNil)
+	stdout := cmdtesting.Stdout(ctx)
+	c.Assert(stdout, gc.Equals, `
+WARNING! This command:
+will remove machine 1
+will remove machine 2
+`[1:])
+}
+
+func (s *RemoveMachineSuite) TestRemoveDryRunOldFacade(c *gc.C) {
+	s.facadeVersion = 9
+	defer s.setup(c).Finish()
+
+	_, err := s.run(c, "--dry-run", "1", "2")
+	c.Assert(err, gc.Equals, machine.ErrDryRunNotSupported)
+}
+
+func (s *RemoveMachineSuite) TestRemovePromptOldFacade(c *gc.C) {
+	s.facadeVersion = 9
+	defer s.setup(c).Finish()
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	var stdin bytes.Buffer
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = &stdin
+
+	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, false, gomock.Any(), "1", "2")
+
+	stdin.WriteString("y")
+	_, errc := s.runWithContext(ctx, "1", "2")
+
+	select {
+	case err := <-errc:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("command took too long")
+	}
+}
+
+func (s *RemoveMachineSuite) TestRemovePrompt(c *gc.C) {
+	defer s.setup(c).Finish()
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	var stdin bytes.Buffer
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = &stdin
+
+	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, true, gomock.Any(), "1", "2")
+	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, false, gomock.Any(), "1", "2")
+
+	stdin.WriteString("y")
+	_, errc := s.runWithContext(ctx, "1", "2")
+
+	select {
+	case err := <-errc:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("command took too long")
+	}
+}
+
+func (s *RemoveMachineSuite) TestRemovePromptOldFacadeAborted(c *gc.C) {
+	s.facadeVersion = 9
+	defer s.setup(c).Finish()
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	ctx := cmdtesting.Context(c)
+	var stdin bytes.Buffer
+	ctx.Stdin = &stdin
+
+	stdin.WriteString("n")
+	_, errc := s.runWithContext(ctx, "1", "2")
+
+	select {
+	case err := <-errc:
+		c.Check(err, gc.ErrorMatches, "machine removal: aborted")
+	case <-time.After(testing.LongWait):
+		c.Fatal("command took too long")
+	}
+}
+
+func (s *RemoveMachineSuite) TestRemovePromptAborted(c *gc.C) {
+	defer s.setup(c).Finish()
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	ctx := cmdtesting.Context(c)
+	var stdin bytes.Buffer
+	ctx.Stdin = &stdin
+
+	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, true, gomock.Any(), "1", "2")
+
+	stdin.WriteString("n")
+	_, errc := s.runWithContext(ctx, "1", "2")
+
+	select {
+	case err := <-errc:
+		c.Check(err, gc.ErrorMatches, "machine removal: aborted")
+	case <-time.After(testing.LongWait):
+		c.Fatal("command took too long")
+	}
 }
 
 func (s *RemoveMachineSuite) TestBlockedError(c *gc.C) {


### PR DESCRIPTION
If supported by your controller, output the results of a dry run before asking for approval from the user. If after confirmation a dry-run was not run, log the (identical) results of the actual run

Implement --no-prompt flag and add --dry-run flag.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Verify behaviour is correct (according to JU057) for the following commands (from this client) on controllers from main branch and this patch. I at least one case, make sure a unit/storage is deployed to the machine

Note by default no prompt is given, so the only case there will be a prompt is when JUJU_SKIP_CONFIRMATION=0 (on 3.0)

Also, for each command a formatted output of the results should be displayed at most once. When it is possible to do a dry-run, it should be before confirmation. Otherwise afterwards when the remove has been performed

```sh
juju remove-machine n
juju remove-machine n --dry-run
juju remove-machine n --no-prompt
juju remove-machine n --no-prompt --dry-run
JUJU_SKIP_CONFIRMATION=1 juju remove-machine n
JUJU_SKIP_CONFIRMATION=0 juju remove-machine n 
```