### PR TITLE
[JUJU-2284] Reject charm store charms from Deploy and SetCharms, Upload on the controller side.

### DIFF
--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -224,10 +224,10 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 		schema = "local"
 	}
 	if schema != "local" {
-		// charmstore and charmhub charms may only be uploaded into models
-		// which are being imported during model migrations. There's currently
-		// no other time where it makes sense to accept charm store
-		// charms through this endpoint.
+		// charmhub charms may only be uploaded into models
+		// which are being imported during model migrations.
+		// There's currently no other time where it makes sense
+		// to accept repository charms through this endpoint.
 		if isImporting, err := modelIsImporting(st); err != nil {
 			return nil, errors.Trace(err)
 		} else if !isImporting {
@@ -282,10 +282,6 @@ func (h *charmsHandler) processPost(r *http.Request, st *state.State) (*charm.UR
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-
-	case charm.CharmStore:
-		curl.User = query.Get("user")
-		fallthrough
 
 	case charm.CharmHub:
 		// If a revision argument is provided, it takes precedence

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -347,7 +347,7 @@ func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
 func (s *charmsSuite) TestNonLocalCharmUploadFailsIfNotMigrating(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	curl := charm.MustParseURL(
-		fmt.Sprintf("cs:quantal/%s-%d", ch.Meta().Name, ch.Revision()),
+		fmt.Sprintf("ch:quantal/%s-%d", ch.Meta().Name, ch.Revision()),
 	)
 	info := state.CharmInfo{
 		Charm:       ch,
@@ -363,14 +363,14 @@ func (s *charmsSuite) TestNonLocalCharmUploadFailsIfNotMigrating(c *gc.C) {
 }
 
 func (s *charmsSuite) TestNonLocalCharmUpload(c *gc.C) {
-	// Check that upload of charms with the "cs:" schema works (for
+	// Check that upload of charms with the "ch:" schema works (for
 	// model migrations).
 	s.setModelImporting(c)
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 
-	resp := s.uploadRequest(c, s.charmsURI("?schema=cs&series=quantal"), "application/zip", &fileReader{path: ch.Path})
+	resp := s.uploadRequest(c, s.charmsURI("?schema=ch&series=quantal"), "application/zip", &fileReader{path: ch.Path})
 
-	expectedURL := charm.MustParseURL("cs:quantal/dummy-1")
+	expectedURL := charm.MustParseURL("ch:quantal/dummy-1")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
@@ -419,9 +419,9 @@ func (s *charmsSuite) TestCharmUploadWithUserOverride(c *gc.C) {
 	s.setModelImporting(c)
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 
-	resp := s.uploadRequest(c, s.charmsURI("?schema=cs&user=bobo"), "application/zip", &fileReader{path: ch.Path})
+	resp := s.uploadRequest(c, s.charmsURI("?schema=ch"), "application/zip", &fileReader{path: ch.Path})
 
-	expectedURL := charm.MustParseURL("cs:~bobo/dummy-1")
+	expectedURL := charm.MustParseURL("ch:dummy-1")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)
@@ -433,9 +433,9 @@ func (s *charmsSuite) TestNonLocalCharmUploadWithRevisionOverride(c *gc.C) {
 	s.setModelImporting(c)
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 
-	resp := s.uploadRequest(c, s.charmsURI("?schema=cs&&revision=99"), "application/zip", &fileReader{path: ch.Path})
+	resp := s.uploadRequest(c, s.charmsURI("?schema=ch&&revision=99"), "application/zip", &fileReader{path: ch.Path})
 
-	expectedURL := charm.MustParseURL("cs:dummy-99")
+	expectedURL := charm.MustParseURL("ch:dummy-99")
 	s.assertUploadResponse(c, resp, expectedURL.String())
 	sch, err := s.State.Charm(expectedURL)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/charms.go
+++ b/apiserver/common/charms.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/errors"
 
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/storage"
 )
@@ -78,4 +79,18 @@ func CharmArchiveEntry(charmPath, entryPath string, wantIcon bool) ([]byte, erro
 		return []byte(DefaultCharmIcon), nil
 	}
 	return nil, errors.NotFoundf("charm file")
+}
+
+// ValidateCharmOrigin validates the Source of the charm origin for args received
+// in a facade. This may evolve over time to include more pieces.
+func ValidateCharmOrigin(o *params.CharmOrigin) error {
+	switch {
+	case o == nil:
+		return errors.BadRequestf("charm origin source required")
+	case corecharm.CharmHub.Matches(o.Source), corecharm.Local.Matches(o.Source):
+		// Valid charm origin sources
+	default:
+		return errors.BadRequestf("%q not a valid charm origin source", o.Source)
+	}
+	return nil
 }

--- a/apiserver/common/charms_test.go
+++ b/apiserver/common/charms_test.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package common
+
+import (
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/rpc/params"
+)
+
+type charmOriginSuite struct{}
+
+var _ = gc.Suite(&charmOriginSuite{})
+
+func (s *charmOriginSuite) TestValidateCharmOriginSuccessCharmHub(c *gc.C) {
+	err := ValidateCharmOrigin(&params.CharmOrigin{Source: "charm-hub"})
+	c.Assert(errors.Is(err, errors.BadRequest), jc.IsFalse)
+}
+
+func (s *charmOriginSuite) TestValidateCharmOriginSuccessLocal(c *gc.C) {
+	err := ValidateCharmOrigin(&params.CharmOrigin{Source: "local"})
+	c.Assert(errors.Is(err, errors.BadRequest), jc.IsFalse)
+}
+
+func (s *charmOriginSuite) TestValidateCharmOrigin(c *gc.C) {
+	err := ValidateCharmOrigin(nil)
+	c.Assert(errors.Is(err, errors.BadRequest), jc.IsTrue)
+}
+
+func (s *charmOriginSuite) TestValidateCharmOriginNilSource(c *gc.C) {
+	err := ValidateCharmOrigin(&params.CharmOrigin{Source: ""})
+	c.Assert(errors.Is(err, errors.BadRequest), jc.IsTrue)
+}
+
+func (s *charmOriginSuite) TestValidateCharmOriginBadSource(c *gc.C) {
+	err := ValidateCharmOrigin(&params.CharmOrigin{Source: "charm-store"})
+	c.Assert(errors.Is(err, errors.BadRequest), jc.IsTrue)
+}

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -274,8 +274,8 @@ func (api *APIBase) Deploy(args params.ApplicationsDeploy) (params.ErrorResults,
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		if arg.CharmOrigin != nil && !corecharm.CharmHub.Matches(arg.CharmOrigin.Source) && !corecharm.Local.Matches(arg.CharmOrigin.Source) {
-			result.Results[i].Error = apiservererrors.ServerError(errors.BadRequestf("%s not a valid charm origin source", arg.CharmOrigin.Source))
+		if err := common.ValidateCharmOrigin(arg.CharmOrigin); err != nil {
+			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
 		err := deployApplication(
@@ -897,8 +897,8 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 		return err
 	}
 
-	if args.CharmOrigin != nil && !corecharm.CharmHub.Matches(args.CharmOrigin.Source) && !corecharm.Local.Matches(args.CharmOrigin.Source) {
-		return errors.BadRequestf("%q not a valid charm origin source", args.CharmOrigin.Source)
+	if err := common.ValidateCharmOrigin(args.CharmOrigin); err != nil {
+		return err
 	}
 
 	// when forced units in error, don't block

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -93,7 +93,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) *application.APIv15 {
 }
 
 func (s *applicationSuite) setupApplicationDeploy(c *gc.C, args string) (*charm.URL, charm.Charm, constraints.Value) {
-	curl, ch := s.addCharmToState(c, "cs:jammy/dummy-42", "dummy")
+	curl, ch := s.addCharmToState(c, "ch:jammy/dummy-42", "dummy")
 	cons := constraints.MustParse(args)
 	return curl, ch, cons
 }
@@ -102,7 +102,7 @@ func (s *applicationSuite) assertApplicationDeployPrincipal(c *gc.C, curl *charm
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application",
 			NumUnits:        3,
 			Constraints:     mem4g,
@@ -117,7 +117,7 @@ func (s *applicationSuite) assertApplicationDeployPrincipalBlocked(c *gc.C, msg 
 	_, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application",
 			NumUnits:        3,
 			Constraints:     mem4g,
@@ -144,11 +144,11 @@ func (s *applicationSuite) TestBlockChangesApplicationDeployPrincipal(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationDeploySubordinate(c *gc.C) {
-	curl, ch := s.addCharmToState(c, "cs:utopic/logging-47", "logging")
+	curl, ch := s.addCharmToState(c, "ch:utopic/logging-47", "logging")
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application-name",
 		}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -178,11 +178,11 @@ func (s *applicationSuite) combinedSettings(ch *state.Charm, inSettings charm.Se
 }
 
 func (s *applicationSuite) TestApplicationDeployConfig(c *gc.C) {
-	curl, _ := s.addCharmToState(c, "cs:jammy/dummy-0", "dummy")
+	curl, _ := s.addCharmToState(c, "ch:jammy/dummy-0", "dummy")
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application-name",
 			NumUnits:        1,
 			ConfigYAML:      "application-name:\n  username: fred",
@@ -203,11 +203,11 @@ func (s *applicationSuite) TestApplicationDeployConfig(c *gc.C) {
 func (s *applicationSuite) TestApplicationDeployConfigError(c *gc.C) {
 	// TODO(fwereade): test Config/ConfigYAML handling directly on srvClient.
 	// Can't be done cleanly until it's extracted similarly to Machiner.
-	curl, _ := s.addCharmToState(c, "cs:jammy/dummy-0", "dummy")
+	curl, _ := s.addCharmToState(c, "ch:jammy/dummy-0", "dummy")
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application-name",
 			NumUnits:        1,
 			ConfigYAML:      "application-name:\n  skill-level: fred",
@@ -220,7 +220,7 @@ func (s *applicationSuite) TestApplicationDeployConfigError(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
-	curl, ch := s.addCharmToState(c, "cs:jammy/dummy-0", "dummy")
+	curl, ch := s.addCharmToState(c, "ch:jammy/dummy-0", "dummy")
 
 	machine, err := s.State.AddMachine(state.UbuntuBase("22.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -236,7 +236,7 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application-name",
 			NumUnits:        1,
 			ConfigYAML:      "application-name:\n  username: fred",
@@ -268,7 +268,7 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C) {
-	curl, ch := s.addCharmToState(c, "cs:jammy/lxd-profile-0", "lxd-profile")
+	curl, ch := s.addCharmToState(c, "ch:jammy/lxd-profile-0", "lxd-profile")
 
 	machine, err := s.State.AddMachine(state.UbuntuBase("22.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -284,7 +284,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C)
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application-name",
 			NumUnits:        1,
 		}}})
@@ -322,7 +322,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C)
 }
 
 func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAndForceStillSucceeds(c *gc.C) {
-	curl, ch := s.addCharmToState(c, "cs:jammy/lxd-profile-fail-0", "lxd-profile-fail")
+	curl, ch := s.addCharmToState(c, "ch:jammy/lxd-profile-fail-0", "lxd-profile-fail")
 
 	machine, err := s.State.AddMachine(state.UbuntuBase("22.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
@@ -338,7 +338,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application-name",
 			NumUnits:        1,
 		}}})
@@ -378,7 +378,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 func (s *applicationSuite) TestApplicationDeployToMachineNotFound(c *gc.C) {
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
-			CharmURL:        "cs:jammy/application-name-1",
+			CharmURL:        "ch:jammy/application-name-1",
 			CharmOrigin:     &params.CharmOrigin{Source: "charm-store", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}},
 			ApplicationName: "application-name",
 			NumUnits:        1,
@@ -393,11 +393,11 @@ func (s *applicationSuite) TestApplicationDeployToMachineNotFound(c *gc.C) {
 }
 
 func (s *applicationSuite) deployApplicationForUpdateTests(c *gc.C) {
-	curl, _ := s.addCharmToState(c, "cs:jammy/dummy-1", "dummy")
+	curl, _ := s.addCharmToState(c, "ch:jammy/dummy-1", "dummy")
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        curl.String(),
-			CharmOrigin:     createCharmOriginFromURL(c, curl),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			ApplicationName: "application",
 			NumUnits:        1,
 		}}})
@@ -408,7 +408,7 @@ func (s *applicationSuite) deployApplicationForUpdateTests(c *gc.C) {
 
 func (s *applicationSuite) setupApplicationUpdate(c *gc.C) string {
 	s.deployApplicationForUpdateTests(c)
-	curl, _ := s.addCharmToState(c, "cs:jammy/wordpress-3", "wordpress")
+	curl, _ := s.addCharmToState(c, "ch:jammy/wordpress-3", "wordpress")
 	return curl.String()
 }
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -379,7 +379,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineNotFound(c *gc.C) {
 	results, err := s.applicationAPI.Deploy(params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			CharmURL:        "ch:jammy/application-name-1",
-			CharmOrigin:     &params.CharmOrigin{Source: "charm-store", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}},
+			CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}},
 			ApplicationName: "application-name",
 			NumUnits:        1,
 			Placement:       []*instance.Placement{instance.MustParsePlacement("42")},
@@ -1318,9 +1318,6 @@ func (s *applicationSuite) TestRemoteRelationApplicationNotFound(c *gc.C) {
 // have been updated to return NotSupported errors for Juju 3.
 func (s *applicationSuite) addCharmToState(c *gc.C, charmURL string, name string) (*charm.URL, charm.Charm) {
 	curl := charm.MustParseURL(charmURL)
-	if curl.User == "" {
-		curl.User = "who"
-	}
 
 	if curl.Revision < 0 {
 		base := curl.String()

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1336,7 +1336,7 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[1].Error, gc.ErrorMatches, "charm-store not a valid charm origin source")
+	c.Assert(results.Results[1].Error, gc.ErrorMatches, `"charm-store" not a valid charm origin source`)
 	c.Assert(results.Results[2].Error, gc.IsNil)
 
 	c.Assert(s.deployParams["foo"].CharmOrigin.Source, gc.Equals, corecharm.Source("local"))
@@ -1455,6 +1455,10 @@ func (s *ApplicationSuite) TestApplicationDeployPlacement(c *gc.C) {
 	c.Assert(s.deployParams["my-app"].Placement, gc.DeepEquals, placement)
 }
 
+func validCharmOriginForTest() *params.CharmOrigin {
+	return &params.CharmOrigin{Source: "charm-hub"}
+}
+
 func (s *ApplicationSuite) TestApplicationDeployWithPlacementLockedError(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()
@@ -1471,14 +1475,17 @@ func (s *ApplicationSuite) TestApplicationDeployWithPlacementLockedError(c *gc.C
 	args := []params.ApplicationDeploy{{
 		ApplicationName: "machine-placement",
 		CharmURL:        curl.String(),
+		CharmOrigin:     validCharmOriginForTest(),
 		Placement:       []*instance.Placement{{Scope: "#", Directive: "0"}},
 	}, {
 		ApplicationName: "container-placement",
 		CharmURL:        curl.String(),
+		CharmOrigin:     validCharmOriginForTest(),
 		Placement:       []*instance.Placement{{Scope: "lxd", Directive: "0"}},
 	}, {
 		ApplicationName: "container-placement-locked-parent",
 		CharmURL:        curl.String(),
+		CharmOrigin:     validCharmOriginForTest(),
 		Placement:       []*instance.Placement{{Scope: "#", Directive: "0/lxd/0"}},
 	}}
 	results, err := s.api.Deploy(params.ApplicationsDeploy{
@@ -1527,6 +1534,7 @@ func (s *ApplicationSuite) TestApplicationDeploymentRemovesPendingResourcesOnFai
 			// CharmURL is missing to ensure deployApplication fails
 			// so that we can assert pending app resources are removed
 			ApplicationName: "my-app",
+			CharmOrigin:     validCharmOriginForTest(),
 			Resources:       resources,
 		}},
 	})

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -269,7 +269,7 @@ func (s *ApplicationSuite) expectDefaultApplication(ctrl *gomock.Controller) *mo
 func (s *ApplicationSuite) expectApplicationWithCharm(ctrl *gomock.Controller, ch application.Charm, name string) *mocks.MockApplication {
 	app := s.expectApplication(ctrl, name)
 	app.EXPECT().Charm().Return(ch, true, nil).AnyTimes()
-	curl := fmt.Sprintf("cs:%s-42", name)
+	curl := fmt.Sprintf("ch:%s-42", name)
 	app.EXPECT().CharmURL().Return(&curl, false).AnyTimes()
 	return app
 }
@@ -338,23 +338,20 @@ func (s *ApplicationSuite) TestSetCharm(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("cs:something-else")
+	curl := charm.MustParseURL("ch:something-else")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
 	app.EXPECT().SetCharm(state.SetCharmConfig{
-		Charm: &state.Charm{},
-		CharmOrigin: &state.CharmOrigin{
-			Source:   "charm-store",
-			Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
-		},
+		Charm:       &state.Charm{},
+		CharmOrigin: createStateCharmOriginFromURL(curl),
 	})
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:something-else",
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmURL:        curl.String(),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -370,10 +367,22 @@ func (s *ApplicationSuite) TestSetCharmWithBlockChange(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:something-else",
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmURL:        "ch:something-else",
+		CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
 	})
 	c.Assert(err, gc.ErrorMatches, "change blocked")
+}
+
+func (s *ApplicationSuite) TestSetCharmRejectCharmStore(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	err := s.api.SetCharm(params.ApplicationSetCharm{
+		ApplicationName: "postgresql",
+		CharmURL:        "cs:something-else",
+		CharmOrigin:     &params.CharmOrigin{Source: "charm-store", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+	})
+	c.Assert(err, gc.ErrorMatches, `"charm-store" not a valid charm origin source`)
 }
 
 func (s *ApplicationSuite) TestSetCharmForceUnits(c *gc.C) {
@@ -381,25 +390,22 @@ func (s *ApplicationSuite) TestSetCharmForceUnits(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("cs:something-else")
+	curl := charm.MustParseURL("ch:something-else")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
 	app.EXPECT().SetCharm(state.SetCharmConfig{
-		Charm: &state.Charm{},
-		CharmOrigin: &state.CharmOrigin{
-			Source:   "charm-store",
-			Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
-		},
-		ForceUnits: true,
+		Charm:       &state.Charm{},
+		CharmOrigin: createStateCharmOriginFromURL(curl),
+		ForceUnits:  true,
 	})
 
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:something-else",
+		CharmURL:        curl.String(),
 		ForceUnits:      true,
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -414,10 +420,11 @@ func (s *ApplicationSuite) TestSetCharmInvalidApplication(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.backend.EXPECT().Application("badapplication").Return(nil, errors.NotFoundf(`application "badapplication"`))
-
+	curl := charm.MustParseURL("ch:something-else")
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "badapplication",
-		CharmURL:        "cs:something-else",
+		CharmURL:        curl.String(),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		ForceBase:       true,
 		ForceUnits:      true,
 	})
@@ -429,16 +436,13 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
 	app.EXPECT().SetCharm(state.SetCharmConfig{
-		Charm: &state.Charm{},
-		CharmOrigin: &state.CharmOrigin{
-			Source:   "charm-store",
-			Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
-		},
+		Charm:       &state.Charm{},
+		CharmOrigin: createStateCharmOriginFromURL(curl),
 		StorageConstraints: map[string]state.StorageConstraints{
 			"a": {},
 			"b": {Pool: "radiant"},
@@ -453,14 +457,14 @@ func (s *ApplicationSuite) TestSetCharmStorageConstraints(c *gc.C) {
 	}
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
+		CharmURL:        "ch:postgresql",
 		StorageConstraints: map[string]params.StorageConstraints{
 			"a": {},
 			"b": {Pool: "radiant"},
 			"c": {Size: toUint64Ptr(123)},
 			"d": {Count: toUint64Ptr(456)},
 		},
-		CharmOrigin: &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmOrigin: createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -471,7 +475,7 @@ func (s *ApplicationSuite) TestSetCAASCharmInvalid(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectCharm(ctrl, &charm.Meta{Deployment: &charm.Deployment{}}, nil, nil)
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -479,8 +483,8 @@ func (s *ApplicationSuite) TestSetCAASCharmInvalid(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmURL:        "ch:postgresql",
+		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, gc.NotNil)
 	msg := strings.Replace(err.Error(), "\n", "", -1)
@@ -492,25 +496,22 @@ func (s *ApplicationSuite) TestSetCharmConfigSettings(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
 	app.EXPECT().SetCharm(state.SetCharmConfig{
-		Charm: &state.Charm{},
-		CharmOrigin: &state.CharmOrigin{
-			Source:   "charm-store",
-			Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
-		},
+		Charm:          &state.Charm{},
+		CharmOrigin:    createStateCharmOriginFromURL(curl),
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	})
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
+		CharmURL:        "ch:postgresql",
 		ConfigSettings:  map[string]string{"stringOption": "value"},
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -529,8 +530,8 @@ func (s *ApplicationSuite) TestSetCharmDisallowDowngradeFormat(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "ch:postgresql",
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmURL:        curl.String(),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, gc.ErrorMatches, "cannot downgrade from v2 charm format to v1")
 }
@@ -548,7 +549,7 @@ func (s *ApplicationSuite) TestSetCharmUpgradeFormat(c *gc.C) {
 	}, &charm.Manifest{Bases: []charm.Base{{ // len(bases)>0 means it's a v2 charm
 		Name: "ubuntu",
 		Channel: charm.Channel{
-			Track: "20.04",
+			Track: "22.04",
 			Risk:  "stable",
 		},
 	}}}, nil)
@@ -557,18 +558,15 @@ func (s *ApplicationSuite) TestSetCharmUpgradeFormat(c *gc.C) {
 
 	app := s.expectDefaultApplication(ctrl)
 	app.EXPECT().SetCharm(state.SetCharmConfig{
-		Charm: &state.Charm{},
-		CharmOrigin: &state.CharmOrigin{
-			Source:   "charm-hub",
-			Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
-		},
+		Charm:       &state.Charm{},
+		CharmOrigin: createStateCharmOriginFromURL(curl),
 	}).Return(nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
 		CharmURL:        "ch:postgresql",
-		CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -578,24 +576,21 @@ func (s *ApplicationSuite) TestSetCharmConfigSettingsYAML(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
 	app.EXPECT().SetCharm(state.SetCharmConfig{
-		Charm: &state.Charm{},
-		CharmOrigin: &state.CharmOrigin{
-			Source:   "charm-store",
-			Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
-		},
+		Charm:          &state.Charm{},
+		CharmOrigin:    createStateCharmOriginFromURL(curl),
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	}).Return(nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmURL:        curl.String(),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		ConfigSettingsYAML: `
 postgresql:
   stringOption: value
@@ -617,18 +612,15 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultLxdProfilerCharm(ctrl)
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	currentCh := s.expectDefaultLxdProfilerCharm(ctrl)
 	app := s.expectApplicationWithCharm(ctrl, currentCh, "postgresql")
 	app.EXPECT().AgentTools().Return(&agentTools, nil)
 	app.EXPECT().SetCharm(state.SetCharmConfig{
-		Charm: &state.Charm{},
-		CharmOrigin: &state.CharmOrigin{
-			Source:   "charm-store",
-			Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
-		},
+		Charm:          &state.Charm{},
+		CharmOrigin:    createStateCharmOriginFromURL(curl),
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	}).Return(nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
@@ -637,8 +629,8 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithNewerAgentVersion(c *gc.C) 
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmURL:        curl.String(),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		ConfigSettings:  map[string]string{"stringOption": "value"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -649,7 +641,7 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultLxdProfilerCharm(ctrl)
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	currentCh := s.expectDefaultLxdProfilerCharm(ctrl)
@@ -661,8 +653,8 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithOldAgentVersion(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmURL:        curl.String(),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		ConfigSettings:  map[string]string{"stringOption": "value"},
 	})
 	c.Assert(err, gc.ErrorMatches, "Unable to upgrade LXDProfile charms with the current model version. "+
@@ -674,18 +666,15 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectLxdProfilerCharm(ctrl, &charm.LXDProfile{})
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	currentCh := s.expectDefaultLxdProfilerCharm(ctrl)
 	app := s.expectApplicationWithCharm(ctrl, currentCh, "postgresql")
 	app.EXPECT().AgentTools().Return(&agentTools, nil)
 	app.EXPECT().SetCharm(state.SetCharmConfig{
-		Charm: &state.Charm{},
-		CharmOrigin: &state.CharmOrigin{
-			Source:   "charm-store",
-			Platform: &state.Platform{OS: "ubuntu", Channel: "20.04"},
-		},
+		Charm:          &state.Charm{},
+		CharmOrigin:    createStateCharmOriginFromURL(curl),
 		ConfigSettings: charm.Settings{"stringOption": "value"},
 	}).Return(nil)
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
@@ -694,9 +683,9 @@ func (s *ApplicationSuite) TestLXDProfileSetCharmWithEmptyProfile(c *gc.C) {
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
+		CharmURL:        curl.String(),
 		ConfigSettings:  map[string]string{"stringOption": "value"},
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -726,7 +715,7 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfied(c *gc.C) {
 		},
 	)
 
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -735,9 +724,9 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfied(c *gc.C) {
 	// Try to upgrade the charm
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
+		CharmURL:        "ch:postgresql",
 		ConfigSettings:  map[string]string{"stringOption": "value"},
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmOrigin:     createCharmOriginFromURL(curl),
 	})
 	c.Assert(err, gc.ErrorMatches, `(?m).*Charm feature requirements cannot be met.*`)
 }
@@ -767,7 +756,7 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfiedWithForce(c *gc.C) {
 		},
 	)
 
-	curl := charm.MustParseURL("cs:postgresql")
+	curl := charm.MustParseURL("ch:postgresql")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	app := s.expectDefaultApplication(ctrl)
@@ -777,8 +766,8 @@ func (s *ApplicationSuite) TestSetCharmAssumesNotSatisfiedWithForce(c *gc.C) {
 	// Try to upgrade the charm
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",
-		CharmURL:        "cs:postgresql",
-		CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+		CharmURL:        "ch:postgresql",
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		ConfigSettings:  map[string]string{"stringOption": "value"},
 		Force:           true,
 	})
@@ -1313,7 +1302,7 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	s.backend.EXPECT().Charm(gomock.Any()).Return(ch, nil).Times(3)
+	s.backend.EXPECT().Charm(gomock.Any()).Return(ch, nil).Times(2)
 
 	track := "latest"
 	args := params.ApplicationsDeploy{
@@ -1328,7 +1317,6 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 			CharmOrigin: &params.CharmOrigin{
 				Source: "charm-store",
 				Risk:   "stable",
-				Track:  &track,
 				Base:   params.Base{Name: "ubuntu", Channel: "20.04/stable"},
 			},
 			NumUnits: 1,
@@ -1338,6 +1326,7 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 			CharmOrigin: &params.CharmOrigin{
 				Source: "charm-hub",
 				Risk:   "stable",
+				Track:  &track,
 				Base:   params.Base{Name: "ubuntu", Channel: "20.04/stable"},
 			},
 			NumUnits: 1,
@@ -1347,22 +1336,28 @@ func (s *ApplicationSuite) TestDeployCharmOrigin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 3)
 	c.Assert(results.Results[0].Error, gc.IsNil)
-	c.Assert(results.Results[1].Error, gc.IsNil)
+	c.Assert(results.Results[1].Error, gc.ErrorMatches, "charm-store not a valid charm origin source")
 	c.Assert(results.Results[2].Error, gc.IsNil)
 
 	c.Assert(s.deployParams["foo"].CharmOrigin.Source, gc.Equals, corecharm.Source("local"))
-	c.Assert(s.deployParams["bar"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-store"))
 	c.Assert(s.deployParams["hub"].CharmOrigin.Source, gc.Equals, corecharm.Source("charm-hub"))
 }
 
-func createCharmOriginFromURL(c *gc.C, curl *charm.URL) *params.CharmOrigin {
+func createCharmOriginFromURL(curl *charm.URL) *params.CharmOrigin {
 	switch curl.Schema {
-	case "cs":
-		return &params.CharmOrigin{Source: "charm-store", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}}
 	case "local":
 		return &params.CharmOrigin{Source: "local", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}}
 	default:
 		return &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}}
+	}
+}
+
+func createStateCharmOriginFromURL(curl *charm.URL) *state.CharmOrigin {
+	switch curl.Schema {
+	case "local":
+		return &state.CharmOrigin{Source: "local", Platform: &state.Platform{OS: "ubuntu", Channel: "22.04"}}
+	default:
+		return &state.CharmOrigin{Source: "charm-hub", Platform: &state.Platform{OS: "ubuntu", Channel: "22.04"}}
 	}
 }
 
@@ -1374,7 +1369,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 		"data":    {Type: charm.StorageBlock},
 		"allecto": {Type: charm.StorageBlock},
 	}}, nil, &charm.Config{})
-	curl := charm.MustParseURL("cs:utopic/storage-block-10")
+	curl := charm.MustParseURL("ch:utopic/storage-block-10")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	storageConstraints := map[string]storage.Constraints{
@@ -1387,7 +1382,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithStorage(c *gc.C) {
 	args := params.ApplicationDeploy{
 		ApplicationName: "my-app",
 		CharmURL:        curl.String(),
-		CharmOrigin:     createCharmOriginFromURL(c, curl),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 		Storage:         storageConstraints,
 	}
@@ -1409,13 +1404,13 @@ func (s *ApplicationSuite) TestApplicationDeployDefaultFilesystemStorage(c *gc.C
 	ch := s.expectCharm(ctrl, &charm.Meta{Storage: map[string]charm.Storage{
 		"data": {Type: charm.StorageFilesystem, ReadOnly: true},
 	}}, nil, &charm.Config{})
-	curl := charm.MustParseURL("cs:utopic/storage-filesystem-1")
+	curl := charm.MustParseURL("ch:utopic/storage-filesystem-1")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	args := params.ApplicationDeploy{
 		ApplicationName: "my-app",
 		CharmURL:        curl.String(),
-		CharmOrigin:     createCharmOriginFromURL(c, curl),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 	}
 	results, err := s.api.Deploy(params.ApplicationsDeploy{
@@ -1432,7 +1427,7 @@ func (s *ApplicationSuite) TestApplicationDeployPlacement(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("cs:precise/dummy-42")
+	curl := charm.MustParseURL("ch:precise/dummy-42")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil)
 
 	machine := mocks.NewMockMachine(ctrl)
@@ -1446,7 +1441,7 @@ func (s *ApplicationSuite) TestApplicationDeployPlacement(c *gc.C) {
 	args := params.ApplicationDeploy{
 		ApplicationName: "my-app",
 		CharmURL:        curl.String(),
-		CharmOrigin:     createCharmOriginFromURL(c, curl),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 		Placement:       placement,
 	}
@@ -1472,7 +1467,7 @@ func (s *ApplicationSuite) TestApplicationDeployWithPlacementLockedError(c *gc.C
 	containerMachine.EXPECT().IsParentLockedForSeriesUpgrade().Return(true, nil).MinTimes(1)
 	s.backend.EXPECT().Machine("0/lxd/0").Return(containerMachine, nil).MinTimes(1)
 
-	curl := charm.MustParseURL("cs:precise/dummy-42")
+	curl := charm.MustParseURL("ch:precise/dummy-42")
 	args := []params.ApplicationDeploy{{
 		ApplicationName: "machine-placement",
 		CharmURL:        curl.String(),
@@ -1498,9 +1493,9 @@ func (s *ApplicationSuite) TestApplicationDeployWithPlacementLockedError(c *gc.C
 }
 
 func (s *ApplicationSuite) TestApplicationDeployFailCharmOrigin(c *gc.C) {
-	originId := createCharmOriginFromURL(c, charm.MustParseURL("cs:jammy/test-42"))
+	originId := createCharmOriginFromURL(charm.MustParseURL("ch:jammy/test-42"))
 	originId.ID = "testingID"
-	originHash := createCharmOriginFromURL(c, charm.MustParseURL("cs:jammy/test-42"))
+	originHash := createCharmOriginFromURL(charm.MustParseURL("ch:jammy/test-42"))
 	originHash.Hash = "testing-hash"
 
 	args := []params.ApplicationDeploy{{
@@ -1546,14 +1541,14 @@ func (s *ApplicationSuite) TestApplicationDeploymentTrust(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("cs:precise/dummy-42")
+	curl := charm.MustParseURL("ch:precise/dummy-42")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil).MinTimes(1)
 
 	withTrust := map[string]string{"trust": "true"}
 	args := params.ApplicationDeploy{
 		ApplicationName: "my-app",
 		CharmURL:        curl.String(),
-		CharmOrigin:     createCharmOriginFromURL(c, curl),
+		CharmOrigin:     createCharmOriginFromURL(curl),
 		NumUnits:        1,
 		Config:          withTrust,
 	}
@@ -1574,13 +1569,13 @@ func (s *ApplicationSuite) TestClientApplicationsDeployWithBindings(c *gc.C) {
 	defer ctrl.Finish()
 
 	ch := s.expectDefaultCharm(ctrl)
-	curl := charm.MustParseURL("cs:focal/riak-42")
+	curl := charm.MustParseURL("ch:focal/riak-42")
 	s.backend.EXPECT().Charm(curl).Return(ch, nil).MinTimes(1)
 
 	args := []params.ApplicationDeploy{{
 		ApplicationName: "old",
 		CharmURL:        curl.String(),
-		CharmOrigin:     &params.CharmOrigin{Source: "charm-store", Base: params.Base{Name: "ubuntu", Channel: "focal"}},
+		CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "focal"}},
 		NumUnits:        1,
 		EndpointBindings: map[string]string{
 			"endpoint": "a-space",
@@ -1590,7 +1585,7 @@ func (s *ApplicationSuite) TestClientApplicationsDeployWithBindings(c *gc.C) {
 	}, {
 		ApplicationName: "regular",
 		CharmURL:        curl.String(),
-		CharmOrigin:     &params.CharmOrigin{Source: "charm-store", Base: params.Base{Name: "ubuntu", Channel: "focal"}},
+		CharmOrigin:     &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "focal"}},
 		NumUnits:        1,
 		EndpointBindings: map[string]string{
 			"endpoint": "42",
@@ -1735,11 +1730,12 @@ func (s *ApplicationSuite) TestDeployCAASInvalidServiceType(c *gc.C) {
 	ch := s.expectDefaultCharm(ctrl)
 	s.backend.EXPECT().Charm(gomock.Any()).Return(ch, nil)
 
+	curl := charm.MustParseURL("local:foo-0")
 	args := params.ApplicationsDeploy{
 		Applications: []params.ApplicationDeploy{{
 			ApplicationName: "foo",
-			CharmURL:        "local:foo-0",
-			CharmOrigin:     &params.CharmOrigin{Base: params.Base{Name: "ubuntu", Channel: "20.04/stable"}},
+			CharmURL:        curl.String(),
+			CharmOrigin:     createCharmOriginFromURL(curl),
 			NumUnits:        1,
 			Config:          map[string]string{"kubernetes-service-type": "ClusterIP", "intOption": "2"},
 		}},
@@ -3043,7 +3039,7 @@ func (s *ApplicationSuite) TestUnitsInfo(c *gc.C) {
 		Machine:         "0",
 		OpenedPorts:     []string{"100-102/tcp"},
 		PublicAddress:   "10.0.0.1",
-		Charm:           "cs:postgresql-42",
+		Charm:           "ch:postgresql-42",
 		Leader:          true,
 		Life:            state.Alive.String(),
 		RelationData: []params.EndpointRelationData{{
@@ -3105,7 +3101,7 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 		Machine:         "0",
 		OpenedPorts:     []string{"100-102/tcp"},
 		PublicAddress:   "10.0.0.1",
-		Charm:           "cs:postgresql-42",
+		Charm:           "ch:postgresql-42",
 		Leader:          true,
 		Life:            state.Alive.String(),
 		RelationData: []params.EndpointRelationData{{
@@ -3130,7 +3126,7 @@ func (s *ApplicationSuite) TestUnitsInfoForApplication(c *gc.C) {
 		Machine:         "1",
 		OpenedPorts:     []string{"100-102/tcp"},
 		PublicAddress:   "10.0.0.1",
-		Charm:           "cs:postgresql-42",
+		Charm:           "ch:postgresql-42",
 		Leader:          false,
 		Life:            state.Alive.String(),
 		RelationData: []params.EndpointRelationData{{
@@ -3403,7 +3399,7 @@ func (s *ApplicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.IsNil)
-	c.Assert(result.URL, gc.Equals, "cs:postgresql-42")
+	c.Assert(result.URL, gc.Equals, "ch:postgresql-42")
 
 	latest := "latest"
 	branch := "foo"

--- a/apiserver/facades/client/application/updateseries_test.go
+++ b/apiserver/facades/client/application/updateseries_test.go
@@ -114,7 +114,7 @@ func (s StateValidatorSuite) TestValidateApplicationWithFallbackSeries(c *gc.C) 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	url := charm.MustParseURL("cs:focal/foo-1")
+	url := charm.MustParseURL("ch:focal/foo-1")
 
 	ch := NewMockCharm(ctrl)
 	ch.EXPECT().Meta().Return(&charm.Meta{}).MinTimes(2)
@@ -138,14 +138,14 @@ func (s StateValidatorSuite) TestValidateApplicationWithUnsupportedSeries(c *gc.
 		Series: []string{"xenial", "bionic"},
 	}).MinTimes(2)
 	ch.EXPECT().Manifest().Return(nil).AnyTimes()
-	ch.EXPECT().String().Return("cs:foo-1")
+	ch.EXPECT().String().Return("ch:foo-1")
 
 	application := NewMockApplication(ctrl)
 	application.EXPECT().Charm().Return(ch, false, nil)
 
 	validator := stateSeriesValidator{}
 	err := validator.ValidateApplication(application, coreseries.MakeDefaultBase("ubuntu", "20.04"), false)
-	c.Assert(err, gc.ErrorMatches, `series "focal" not supported by charm "cs:foo-1", supported series are: xenial, bionic`)
+	c.Assert(err, gc.ErrorMatches, `series "focal" not supported by charm "ch:foo-1", supported series are: xenial, bionic`)
 }
 
 func (s StateValidatorSuite) TestValidateApplicationWithUnsupportedSeriesWithForce(c *gc.C) {


### PR DESCRIPTION
Reject charms without a source of charm-hub or local from Deploy and SetCharm, as well as when Upload is called. Initial part of removing charmstore charm support from the controller. Biggest change to the unit tests using cs charms.

## QA steps
No change to charm hub or local deploy
```sh
(cd tests; ./main.sh deploy test_deploy_charms)
```

Deploy of a charmstore charm should fail. The error message will improve with the completion of [JUJU-2230](https://warthogs.atlassian.net/browse/JUJU-2230).
```sh
$ juju deploy cs:ubuntu csubuntu
WARNING Charm store charms, those with cs: before the charm name, will not be supported in juju 3.1.
	Migration of this model to a juju 3.1 controller will be prohibited.
Located charm "ubuntu" in charm-store, revision 21
Deploying "csubuntu" from charm-store charm "ubuntu", revision 21 in channel stable on ubuntu@20.04/stable
ERROR charm-store not a valid charm origin source
```

## Documentation changes

(cd tests ; ./main.sh -v resources)

