### PR TITLE
Test model migration from 2.9 -> 3.0

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,102 @@
+name: "Migrate"
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'snap/**'
+      - '.github/workflows/migrate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Migrate
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO: add microk8s tests
+        cloud: ["lxd"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        if: matrix.cloud == 'lxd'
+        uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
+
+      - name: Install Juju 2.9
+        run: sudo snap install juju --channel 2.9/stable --classic
+
+      - name: Bootstrap a 2.9 controller and model
+        run: |
+          juju bootstrap lxd test29
+          # will be inside default model
+          juju deploy ubuntu
+          
+          # TODO: use juju-restore
+          # TODO: add users/permissions/models and test that those migrate over
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+
+      - name: Set up Go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Upgrade client to 3.0
+        run: |
+          sudo snap remove juju --purge
+          make go-install &>/dev/null
+
+      - name: Bootstrap 3.0 controller
+        run: |
+          juju bootstrap lxd test30
+          juju switch controller
+          juju wait-for application controller
+
+        # TODO: create backup and juju restore
+
+      - name: Migrate default model to 3.0 controller
+        run: |
+          juju switch test29
+          
+          # Ensure application is fully deployed
+          juju wait-for application ubuntu
+          
+          # Wait a few secs for the machine status to update
+          # so that migration prechecks pass.
+          sleep 10
+          
+          juju migrate default test30
+
+      - name: Check the migration was successful
+        run: |
+          set -x
+          juju switch test30
+          
+          # Wait for 'default' model to come through
+          attempt=0
+          while true; do
+            RES=$(juju models | grep 'default' || true)
+            if [[ -n $RES ]]; then
+              break
+            fi
+            sleep 5
+            attempt=$((attempt+1))
+            if [ "$attempt" -eq 10 ]; then
+              echo "Migration timed out"
+              exit 1
+            fi
+          done
+          
+          juju switch default
+          juju wait-for application ubuntu


### PR DESCRIPTION
Now that controller upgrades from 2.9 -> 3.0 are not allowed, in #14847 we changed the GitHub upgrade tests to upgrade patch versions instead. Model migration is now the recommended way to move from Juju 2.9 to 3.0. Here we add a GitHub Action to test this model migration - filling in the gap left by the old upgrade tests.

## QA steps

Check the new "Migrate" GitHub workflow passes.