### PR TITLE
[JUJU-2246] - Fix/lp 1997289

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -461,8 +461,8 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 		return nil, errors.Trace(err)
 	}
 	if md != nil {
-		// 1. secrets can be accesed by owners;
-		// 2. application owned secrets can be accessed by the leader unit of the application using owner label or URI.
+		// 1. secrets can be accesed by the owner;
+		// 2. application owned secrets can be accessed by all the units of the application using owner label or URI.
 		return getSecretValue(md.URI, md.LatestRevision)
 	}
 

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -278,15 +278,13 @@ func (s *SecretsManagerAPI) GetSecretMetadata() (params.ListSecretResults, error
 	}
 	// Unit leaders can also get metadata for secrets owned by the app.
 	// TODO(wallyworld) - temp fix for old podspec charms
-	if s.authTag.Kind() != names.ApplicationTagKind {
-		_, err := s.leadershipToken()
-		if err != nil && !leadership.IsNotLeaderError(err) {
-			return result, errors.Trace(err)
-		}
-		if err == nil {
-			appOwner := names.NewApplicationTag(authTagApp(s.authTag))
-			filter.OwnerTags = append(filter.OwnerTags, appOwner)
-		}
+	isLeader, err := s.isLeaderUnit()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	if isLeader {
+		appOwner := names.NewApplicationTag(authTagApp(s.authTag))
+		filter.OwnerTags = append(filter.OwnerTags, appOwner)
 	}
 
 	secrets, err := s.secretsBackend.ListSecrets(filter)
@@ -344,16 +342,79 @@ func (s *SecretsManagerAPI) GetSecretContentInfo(args params.GetSecretContentArg
 	return result, nil
 }
 
-func (s *SecretsManagerAPI) getOwnerSecretMetadata(uri *coresecrets.URI) (*coresecrets.SecretMetadata, error) {
-	md, err := s.secretsBackend.GetSecret(uri)
+func (s *SecretsManagerAPI) isLeaderUnit() (bool, error) {
+	if s.authTag.Kind() != names.UnitTagKind {
+		return false, nil
+	}
+	_, err := s.leadershipToken()
+	if err != nil && !leadership.IsNotLeaderError(err) {
+		return false, errors.Trace(err)
+	}
+	return err == nil, nil
+}
+
+func (s *SecretsManagerAPI) handleAppOwnedSecretForPeerUnts(md *coresecrets.SecretMetadata) (*coresecrets.SecretMetadata, error) {
+	// If the secret is owned by the app, and the caller is a peer unit, we create a fake consumer doc for triggering events to notify the uniters.
+	// The peer units should get the secret using owner label but should not set a consumer label.
+	consumer, err := s.secretsConsumer.GetSecretConsumer(md.URI, s.authTag)
+	if err != nil && !errors.Is(err, errors.NotFound) {
+		return nil, errors.Trace(err)
+	}
+	if consumer == nil {
+		consumer = &coresecrets.SecretConsumerMetadata{
+			LatestRevision: md.LatestRevision,
+		}
+	}
+	consumer.CurrentRevision = md.LatestRevision
+	if err := s.secretsConsumer.SaveSecretConsumer(md.URI, s.authTag, consumer); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return md, nil
+}
+
+func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecrets.URI, label string) (md *coresecrets.SecretMetadata, err error) {
+	notFoundErr := errors.NotFoundf("secret %q", uri)
+	if label != "" {
+		notFoundErr = errors.NotFoundf("secret with label %q", label)
+	}
+	defer func() {
+		if md == nil || md.OwnerTag == s.authTag.String() {
+			// Either not found or found a secret owned by the caller.
+			return
+		}
+		// If the secret is owned by the app, check if the unit is a leader.
+		var isLeader bool
+		if isLeader, err = s.isLeaderUnit(); err != nil {
+			md = nil
+			return
+		}
+		if isLeader {
+			return
+		}
+		md, err = s.handleAppOwnedSecretForPeerUnts(md)
+	}()
+
+	filter := state.SecretsFilter{
+		OwnerTags: []names.Tag{s.authTag},
+	}
+	if s.authTag.Kind() == names.UnitTagKind {
+		// Units can access application owned secrets.
+		appOwner := names.NewApplicationTag(authTagApp(s.authTag))
+		filter.OwnerTags = append(filter.OwnerTags, appOwner)
+	}
+	mds, err := s.secretsBackend.ListSecrets(filter)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if s.authTag.String() != md.OwnerTag {
-		// Invisible for non owner users.
-		return nil, errors.NotFoundf("secret %s", uri)
+	for _, md := range mds {
+		if uri != nil && md.URI.ID == uri.ID {
+			return md, nil
+		}
+		if label != "" && md.Label == label {
+			return md, nil
+		}
 	}
-	return md, nil
+	return nil, notFoundErr
 }
 
 func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*secrets.ContentParams, error) {
@@ -387,16 +448,15 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 			return nil, errors.Trace(err)
 		}
 	}
-
-	if uri != nil && arg.Label == "" {
-		md, err := s.getOwnerSecretMetadata(uri)
-		if err != nil && !errors.Is(err, errors.NotFound) {
-			return nil, errors.Trace(err)
-		}
-		if md != nil {
-			// Owner can access the content directly.
-			return getSecretValue(md.URI, md.LatestRevision)
-		}
+	// Owner units should always have the UIR because we resolved the label to URI on uiter side already.
+	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, arg.Label)
+	if err != nil && !errors.Is(err, errors.NotFound) {
+		return nil, errors.Trace(err)
+	}
+	if md != nil {
+		// 1. secrets can be accesed by owners;
+		// 2. application owned secrets can be accessed by the leader unit of the application using owner label or URI.
+		return getSecretValue(md.URI, md.LatestRevision)
 	}
 
 	// arg.Label is the consumer label for consumers.

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -357,18 +357,16 @@ func (s *SecretsManagerAPI) handleAppOwnedSecretForPeerUnts(md *coresecrets.Secr
 	// If the secret is owned by the app, and the caller is a peer unit, we create a fake consumer doc for triggering events to notify the uniters.
 	// The peer units should get the secret using owner label but should not set a consumer label.
 	consumer, err := s.secretsConsumer.GetSecretConsumer(md.URI, s.authTag)
-	logger.Criticalf("handleAppOwnedSecretForPeerUnts: consumer: %+v, err: %+v", consumer, err)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)
 	}
 
 	if consumer == nil {
-		logger.Criticalf("creating fake consumer for %q", md.URI)
 		consumer = &coresecrets.SecretConsumerMetadata{
 			LatestRevision: md.LatestRevision,
 		}
 	}
-	// consumer.CurrentRevision = md.LatestRevision
+	logger.Debugf("saving consumer doc for application owned secret %q for peer units %q", md.URI, s.authTag)
 	if err := s.secretsConsumer.SaveSecretConsumer(md.URI, s.authTag, consumer); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -382,7 +380,6 @@ func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecret
 	}
 	defer func() {
 		if md == nil || md.OwnerTag == s.authTag.String() {
-			logger.Criticalf("found %q owned secret %+v", s.authTag, md)
 			// Either not found or found a secret owned by the caller.
 			return
 		}
@@ -393,7 +390,7 @@ func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecret
 			return
 		}
 		if isLeader {
-			logger.Criticalf("found app owned secret %+v for leader unit %q", md, s.authTag)
+			logger.Debugf("found application owned secret %q for leader unit %q", md.URI, s.authTag)
 			return
 		}
 		md, err = s.handleAppOwnedSecretForPeerUnts(md)
@@ -413,11 +410,9 @@ func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecret
 	}
 	for _, md := range mds {
 		if uri != nil && md.URI.ID == uri.ID {
-			logger.Criticalf("found secret %q", uri)
 			return md, nil
 		}
 		if label != "" && md.Label == label {
-			logger.Criticalf("found secret %q", label)
 			return md, nil
 		}
 	}
@@ -455,7 +450,7 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 			return nil, errors.Trace(err)
 		}
 	}
-	// Owner units should always have the UIR because we resolved the label to URI on uiter side already.
+	// Owner units should always have the UIR because we resolved the label to URI on uniter side already.
 	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, arg.Label)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -20,6 +20,7 @@ import (
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/agent/secretsmanager"
 	"github.com/juju/juju/apiserver/facades/agent/secretsmanager/mocks"
+	"github.com/juju/juju/core/leadership"
 	coresecrets "github.com/juju/juju/core/secrets"
 	corewatcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
@@ -492,20 +493,25 @@ func (s *SecretsManagerSuite) TestGetSecretContentInvalidArg(c *gc.C) {
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, `both uri and label are empty`)
 }
 
-func (s *SecretsManagerSuite) TestGetSecretContentOwnerArgURI(c *gc.C) {
+func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretURIArg(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	data := map[string]string{"foo": "bar"}
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 	s.expectSecretAccessQuery(1)
-	s.secretsBackend.EXPECT().GetSecret(uri).Return(
+	s.secretsBackend.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTags: []names.Tag{
+			names.NewUnitTag("mariadb/0"),
+			names.NewApplicationTag("mariadb"),
+		},
+	}).Return([]*coresecrets.SecretMetadata{
 		&coresecrets.SecretMetadata{
 			URI:            uri,
 			LatestRevision: 668,
-			OwnerTag:       "unit-mariadb-0",
-		}, nil,
-	)
+			OwnerTag:       s.authTag.String(),
+		},
+	}, nil)
 	s.secretsBackend.EXPECT().GetSecretValue(uri, 668).Return(
 		val, nil, nil,
 	)
@@ -523,7 +529,118 @@ func (s *SecretsManagerSuite) TestGetSecretContentOwnerArgURI(c *gc.C) {
 	})
 }
 
-func (s *SecretsManagerSuite) assertGetSecretContentConsumer(c *gc.C, notOwner bool) {
+func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretLabelArg(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	val := coresecrets.NewSecretValue(data)
+	uri := coresecrets.NewURI()
+	s.expectSecretAccessQuery(1)
+	s.secretsBackend.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTags: []names.Tag{
+			names.NewUnitTag("mariadb/0"),
+			names.NewApplicationTag("mariadb"),
+		},
+	}).Return([]*coresecrets.SecretMetadata{
+		&coresecrets.SecretMetadata{
+			URI:            uri,
+			LatestRevision: 668,
+			Label:          "foo",
+			OwnerTag:       s.authTag.String(),
+		},
+	}, nil)
+	s.secretsBackend.EXPECT().GetSecretValue(uri, 668).Return(
+		val, nil, nil,
+	)
+
+	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{Label: "foo"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
+		Results: []params.SecretContentResult{{
+			Content: params.SecretContentParams{Data: data},
+		}},
+	})
+}
+
+func (s *SecretsManagerSuite) assertGetSecretContentForLeaderUnitAccessApplicationOwnedSecret(c *gc.C, isLeader bool) {
+	defer s.setup(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	val := coresecrets.NewSecretValue(data)
+	uri := coresecrets.NewURI()
+	s.expectSecretAccessQuery(1)
+	s.secretsBackend.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTags: []names.Tag{
+			names.NewUnitTag("mariadb/0"),
+			names.NewApplicationTag("mariadb"),
+		},
+	}).Return([]*coresecrets.SecretMetadata{
+		&coresecrets.SecretMetadata{
+			URI:            uri,
+			LatestRevision: 668,
+			Label:          "foo",
+			OwnerTag:       names.NewApplicationTag("mariadb").String(),
+		},
+	}, nil)
+
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	if isLeader {
+		s.token.EXPECT().Check().Return(nil)
+	} else {
+		s.token.EXPECT().Check().Return(leadership.NewNotLeaderError("mariadb/0", "mariadb"))
+		s.secretsConsumer.EXPECT().GetSecretConsumer(uri, s.authTag).
+			Return(nil, errors.NotFoundf("secret consumer"))
+
+		s.secretsConsumer.EXPECT().SaveSecretConsumer(
+			uri, names.NewUnitTag("mariadb/0"), &coresecrets.SecretConsumerMetadata{
+				LatestRevision: 668,
+			}).Return(nil)
+	}
+
+	s.secretsBackend.EXPECT().GetSecretValue(uri, 668).Return(
+		val, nil, nil,
+	)
+
+	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+		Args: []params.GetSecretContentArg{
+			{Label: "foo"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, jc.DeepEquals, params.SecretContentResults{
+		Results: []params.SecretContentResult{{
+			Content: params.SecretContentParams{Data: data},
+		}},
+	})
+}
+
+func (s *SecretsManagerSuite) TestGetSecretContentForLeaderUnitAccessApplicationOwnedSecret(c *gc.C) {
+	s.assertGetSecretContentForLeaderUnitAccessApplicationOwnedSecret(c, true)
+}
+
+func (s *SecretsManagerSuite) TestGetSecretContentForPeerUnitsAccessApplicationOwnedSecret(c *gc.C) {
+	s.assertGetSecretContentForLeaderUnitAccessApplicationOwnedSecret(c, false)
+}
+
+func (s *SecretsManagerSuite) assertGetSecretContentConsumer(c *gc.C, isUnitAgent bool) {
+	s.authTag = names.NewApplicationTag("mariadb")
+	filter := state.SecretsFilter{
+		OwnerTags: []names.Tag{s.authTag},
+	}
+	if isUnitAgent {
+		s.authTag = names.NewUnitTag("mariadb/0")
+		filter = state.SecretsFilter{
+			OwnerTags: []names.Tag{
+				names.NewUnitTag("mariadb/0"),
+				names.NewApplicationTag("mariadb"),
+			},
+		}
+	}
+
 	defer s.setup(c).Finish()
 
 	data := map[string]string{"foo": "bar"}
@@ -531,19 +648,9 @@ func (s *SecretsManagerSuite) assertGetSecretContentConsumer(c *gc.C, notOwner b
 	uri := coresecrets.NewURI()
 	s.expectSecretAccessQuery(1)
 
-	if notOwner {
-		s.secretsBackend.EXPECT().GetSecret(uri).Return(
-			&coresecrets.SecretMetadata{
-				URI:            uri,
-				LatestRevision: 668,
-				OwnerTag:       "unit-mariadb-1", // not owner.
-			}, nil,
-		)
-	} else {
-		s.secretsBackend.EXPECT().GetSecret(uri).Return(nil, errors.NotFoundf("secret"))
-	}
+	s.secretsBackend.EXPECT().ListSecrets(filter).Return([]*coresecrets.SecretMetadata{}, nil)
 
-	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, names.NewUnitTag("mariadb/0")).
+	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, s.authTag).
 		Return(&coresecrets.SecretConsumerMetadata{CurrentRevision: 666}, nil)
 	s.secretsBackend.EXPECT().GetSecretValue(uri, 666).Return(
 		val, nil, nil,
@@ -562,16 +669,18 @@ func (s *SecretsManagerSuite) assertGetSecretContentConsumer(c *gc.C, notOwner b
 	})
 }
 
-func (s *SecretsManagerSuite) TestGetSecretContentConsumer(c *gc.C) {
+func (s *SecretsManagerSuite) TestGetSecretContentConsumerUnitAgent(c *gc.C) {
 	s.assertGetSecretContentConsumer(c, true)
 }
 
-func (s *SecretsManagerSuite) TestGetSecretContentConsumerNotFound(c *gc.C) {
+func (s *SecretsManagerSuite) TestGetSecretContentConsumerApplicationAgent(c *gc.C) {
 	s.assertGetSecretContentConsumer(c, false)
 }
 
 func (s *SecretsManagerSuite) TestGetSecretContentConsumerLabelOnly(c *gc.C) {
 	defer s.setup(c).Finish()
+
+	s.expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound()
 
 	data := map[string]string{"foo": "bar"}
 	val := coresecrets.NewSecretValue(data)
@@ -598,6 +707,15 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerLabelOnly(c *gc.C) {
 	})
 }
 
+func (s *SecretsManagerSuite) expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound() {
+	s.secretsBackend.EXPECT().ListSecrets(state.SecretsFilter{
+		OwnerTags: []names.Tag{
+			names.NewUnitTag("mariadb/0"),
+			names.NewApplicationTag("mariadb"),
+		},
+	}).Return([]*coresecrets.SecretMetadata{}, nil)
+}
+
 func (s *SecretsManagerSuite) TestGetSecretContentConsumerFirstTime(c *gc.C) {
 	defer s.setup(c).Finish()
 
@@ -606,6 +724,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerFirstTime(c *gc.C) {
 	uri := coresecrets.NewURI()
 	s.expectSecretAccessQuery(1)
 
+	s.expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound()
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, names.NewUnitTag("mariadb/0")).
 		Return(nil, errors.NotFoundf("secret"))
 	s.secretsBackend.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{LatestRevision: 668}, nil)
@@ -641,6 +760,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateLabel(c *gc.C) {
 	uri := coresecrets.NewURI()
 	s.expectSecretAccessQuery(1)
 
+	s.expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound()
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, names.NewUnitTag("mariadb/0")).Return(
 		&coresecrets.SecretConsumerMetadata{
 			Label:           "old-label",
@@ -675,6 +795,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateLabel(c *gc.C) {
 func (s *SecretsManagerSuite) TestGetSecretContentConsumerFirstTimeUsingLabelFailed(c *gc.C) {
 	defer s.setup(c).Finish()
 
+	s.expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound()
 	s.secretsConsumer.EXPECT().GetURIByConsumerLabel("label-1", names.NewUnitTag("mariadb/0")).Return(nil, errors.NotFoundf("secret"))
 
 	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
@@ -694,6 +815,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateArg(c *gc.C) {
 	uri := coresecrets.NewURI()
 	s.expectSecretAccessQuery(1)
 
+	s.expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound()
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, names.NewUnitTag("mariadb/0")).Return(
 		&coresecrets.SecretConsumerMetadata{CurrentRevision: 666, LatestRevision: 666}, nil,
 	)
@@ -730,7 +852,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerPeekArg(c *gc.C) {
 	uri := coresecrets.NewURI()
 	s.expectSecretAccessQuery(1)
 
-	s.secretsBackend.EXPECT().GetSecret(uri).Return(nil, errors.NotFoundf("secret"))
+	s.expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound()
 	s.secretsConsumer.EXPECT().GetSecretConsumer(uri, names.NewUnitTag("mariadb/0")).Return(
 		&coresecrets.SecretConsumerMetadata{CurrentRevision: 666, LatestRevision: 666}, nil,
 	)

--- a/state/action_test.go
+++ b/state/action_test.go
@@ -371,7 +371,7 @@ func (s *ActionSuite) TestLastActionFinishCompletesOperation(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Finishing only one action does not complete the operation.
-	anAction, err = anAction.Finish(state.ActionResults{
+	_, err = anAction.Finish(state.ActionResults{
 		Status: state.ActionFailed,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v4"
 	jujutxn "github.com/juju/txn/v3"
+	"github.com/kr/pretty"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/core/leadership"
@@ -253,7 +254,7 @@ func (s *secretsStore) CreateSecret(uri *secrets.URI, p CreateSecretParams) (*se
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		var ops []txn.Op
 		if p.Label != nil {
-			uniqueLabelOps, err := s.st.uniqueSecretOwnerLabelOps(metadataDoc.OwnerTag, *p.Label)
+			uniqueLabelOps, err := s.st.uniqueSecretOwnerLabelOps(owner, *p.Label)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -341,7 +342,9 @@ func (s *secretsStore) UpdateSecret(uri *secrets.URI, p UpdateSecretParams) (*se
 		}
 		var ops []txn.Op
 		if p.Label != nil && *p.Label != metadataDoc.Label {
-			uniqueLabelOps, err := s.st.uniqueSecretOwnerLabelOps(metadataDoc.OwnerTag, *p.Label)
+			// OwnerTag has already been validated.
+			owner, _ := names.ParseTag(metadataDoc.OwnerTag)
+			uniqueLabelOps, err := s.st.uniqueSecretOwnerLabelOps(owner, *p.Label)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -892,47 +895,116 @@ func (st *State) checkConsumerCountOps(uri *secrets.URI, inc int) ([]txn.Op, err
 	return []txn.Op{countOp, incOp}, nil
 }
 
+const (
+	secretOwnerLabelKeyPrefix    = "secretOwnerlabel"
+	secretConsumerLabelKeyPrefix = "secretConsumerlabel"
+)
+
 func secretOwnerLabelKey(ownerTag string, label string) string {
-	return fmt.Sprintf("secretOwnerlabel#%s#%s", ownerTag, label)
+	return fmt.Sprintf("%s#%s#%s", secretOwnerLabelKeyPrefix, ownerTag, label)
 }
 
-func secretConsumerLabelKey(ownerTag string, label string) string {
-	return fmt.Sprintf("secretConsumerlabel#%s#%s", ownerTag, label)
+func secretConsumerLabelKey(consumerTag string, label string) string {
+	return fmt.Sprintf("%s#%s#%s", secretConsumerLabelKeyPrefix, consumerTag, label)
 }
 
-func (st *State) uniqueSecretOwnerLabelOps(ownerTag string, label string) ([]txn.Op, error) {
+func (st *State) uniqueSecretOwnerLabelOps(ownerTag names.Tag, label string) (ops []txn.Op, err error) {
+	defer func() {
+		logger.Criticalf("uniqueSecretOwnerLabelOps: %s", pretty.Sprint(ops))
+	}()
+
+	if ops, err = st.uniqueSecretLabelBaseOps(ownerTag, label); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// Check that there is no consumer with the same label.
 	assertNoConsumerLabel, err := st.uniqueSecretLabelOpsRaw(ownerTag, label, "consumer", secretConsumerLabelKey, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	ops = append(ops, assertNoConsumerLabel...)
 	// Check that there is no owner with the same label.
 	ops2, err := st.uniqueSecretLabelOpsRaw(ownerTag, label, "owner", secretOwnerLabelKey, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return append(assertNoConsumerLabel, ops2...), nil
+	return append(ops, ops2...), nil
 }
 
-func (st *State) uniqueSecretConsumerLabelOps(consumerTag string, label string) ([]txn.Op, error) {
+func (st *State) uniqueSecretConsumerLabelOps(consumerTag names.Tag, label string) (ops []txn.Op, err error) {
+	defer func() {
+		logger.Criticalf("uniqueSecretConsumerLabelOps: %s", pretty.Sprint(ops))
+	}()
+
+	if ops, err = st.uniqueSecretLabelBaseOps(consumerTag, label); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	// Check that there is no owner with the same label.
 	assertNoOwnerLabel, err := st.uniqueSecretLabelOpsRaw(consumerTag, label, "owner", secretOwnerLabelKey, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	ops = append(ops, assertNoOwnerLabel...)
 	// Check that there is no consumer with the same label.
 	ops2, err := st.uniqueSecretLabelOpsRaw(consumerTag, label, "consumer", secretConsumerLabelKey, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return append(assertNoOwnerLabel, ops2...), nil
+	return append(ops, ops2...), nil
 }
 
-func (st *State) uniqueSecretLabelOpsRaw(tag, label, role string, keyGenerator func(string, string) string, assertionOnly bool) ([]txn.Op, error) {
+func (st *State) uniqueSecretLabelBaseOps(tag names.Tag, label string) (ops []txn.Op, _ error) {
+	defer func() {
+		logger.Criticalf("uniqueSecretLabelBaseOps: %s", pretty.Sprint(ops))
+	}()
+
+	col, close := st.db().GetCollection(refcountsC)
+	defer close()
+
+	var keyPattern string
+	switch tag := tag.(type) {
+	case names.ApplicationTag:
+		// Ensure no units use this label for both owner and consumer label..
+		keyPattern = fmt.Sprintf(
+			"^%s:(%s|%s)#unit-%s-[0-9]+#%s$",
+			st.ModelUUID(), secretOwnerLabelKeyPrefix, secretConsumerLabelKeyPrefix, tag.Name, label,
+		)
+	case names.UnitTag:
+		// Ensure no application owned secret uses this label.
+		applicationName, _ := names.UnitApplication(tag.Id())
+		appTag := names.NewApplicationTag(applicationName)
+
+		keyPattern = fmt.Sprintf(
+			"^%s:(%s|%s)#%s#%s$",
+			st.ModelUUID(), secretOwnerLabelKeyPrefix, secretConsumerLabelKeyPrefix, appTag.String(), label,
+		)
+	default:
+		return nil, errors.NotSupportedf("tag type %T", tag)
+	}
+
+	count, err := col.Find(bson.M{"_id": bson.M{"$regex": keyPattern}}).Count()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if count > 0 {
+		return nil, errors.AlreadyExistsf("secret label %q", label)
+	}
+
+	return []txn.Op{
+		{
+			C:      col.Name(),
+			Id:     bson.M{"$regex": keyPattern},
+			Assert: txn.DocMissing,
+		},
+	}, nil
+}
+
+func (st *State) uniqueSecretLabelOpsRaw(tag names.Tag, label, role string, keyGenerator func(string, string) string, assertionOnly bool) ([]txn.Op, error) {
 	refCountCollection, ccloser := st.db().GetCollection(refcountsC)
 	defer ccloser()
 
-	key := keyGenerator(tag, label)
+	key := keyGenerator(tag.String(), label)
 	countOp, count, err := nsRefcounts.CurrentOp(refCountCollection, key)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1091,7 +1163,7 @@ func (st *State) SaveSecretConsumer(uri *secrets.URI, consumer names.Tag, metada
 		var ops []txn.Op
 
 		if metadata.Label != "" && (create || metadata.Label != doc.Label) {
-			uniqueLabelOps, err := st.uniqueSecretConsumerLabelOps(consumer.String(), metadata.Label)
+			uniqueLabelOps, err := st.uniqueSecretConsumerLabelOps(consumer, metadata.Label)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v4"
 	jujutxn "github.com/juju/txn/v3"
-	"github.com/kr/pretty"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/core/leadership"
@@ -910,10 +909,6 @@ func secretConsumerLabelKey(consumerTag names.Tag, label string) string {
 }
 
 func (st *State) uniqueSecretOwnerLabelOps(ownerTag names.Tag, label string) (ops []txn.Op, err error) {
-	defer func() {
-		logger.Criticalf("uniqueSecretOwnerLabelOps: %s", pretty.Sprint(ops))
-	}()
-
 	if ops, err = st.uniqueSecretLabelBaseOps(ownerTag, label); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -933,10 +928,6 @@ func (st *State) uniqueSecretOwnerLabelOps(ownerTag names.Tag, label string) (op
 }
 
 func (st *State) uniqueSecretConsumerLabelOps(consumerTag names.Tag, label string) (ops []txn.Op, err error) {
-	defer func() {
-		logger.Criticalf("uniqueSecretConsumerLabelOps: %s", pretty.Sprint(ops))
-	}()
-
 	if ops, err = st.uniqueSecretLabelBaseOps(consumerTag, label); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -956,10 +947,6 @@ func (st *State) uniqueSecretConsumerLabelOps(consumerTag names.Tag, label strin
 }
 
 func (st *State) uniqueSecretLabelBaseOps(tag names.Tag, label string) (ops []txn.Op, _ error) {
-	defer func() {
-		logger.Criticalf("uniqueSecretLabelBaseOps: %s", pretty.Sprint(ops))
-	}()
-
 	col, close := st.db().GetCollection(refcountsC)
 	defer close()
 

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -115,7 +115,7 @@ func (s *SecretsSuite) TestCreateBackendId(c *gc.C) {
 	c.Assert(*backendId, gc.Equals, "backend-id")
 }
 
-func (s *SecretsSuite) TestCreateDuplicateLabel(c *gc.C) {
+func (s *SecretsSuite) TestCreateDuplicateLabelApplicationOwned(c *gc.C) {
 	uri := secrets.NewURI()
 	now := s.Clock.Now().Round(time.Second).UTC()
 	next := now.Add(time.Minute).Round(time.Second).UTC()
@@ -134,10 +134,108 @@ func (s *SecretsSuite) TestCreateDuplicateLabel(c *gc.C) {
 			Data:           map[string]string{"foo": "bar"},
 		},
 	}
-	_, err := s.store.CreateSecret(uri, p)
+	md, err := s.store.CreateSecret(uri, p)
 	c.Assert(err, jc.ErrorIsNil)
 	uri2 := secrets.NewURI()
 	_, err = s.store.CreateSecret(uri2, p)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+
+	// Existing application owner label should not be used for owner label for its units.
+	uri3 := secrets.NewURI()
+	p.Owner = s.ownerUnit.Tag()
+	_, err = s.store.CreateSecret(uri3, p)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+
+	// Existing application owner label should not be used for consumer label for its units.
+	cmd := &secrets.SecretConsumerMetadata{
+		Label:           "foobar",
+		CurrentRevision: md.LatestRevision,
+	}
+	err = s.State.SaveSecretConsumer(uri, s.ownerUnit.Tag(), cmd)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+}
+
+func (s *SecretsSuite) TestCreateDuplicateLabelUnitOwned(c *gc.C) {
+	uri := secrets.NewURI()
+	now := s.Clock.Now().Round(time.Second).UTC()
+	next := now.Add(time.Minute).Round(time.Second).UTC()
+	expire := now.Add(time.Hour).Round(time.Second).UTC()
+	p := state.CreateSecretParams{
+		Version: 1,
+		Owner:   s.ownerUnit.Tag(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken:    &fakeToken{},
+			RotatePolicy:   ptr(secrets.RotateDaily),
+			NextRotateTime: ptr(next),
+			Description:    ptr("my secret"),
+			Label:          ptr("foobar"),
+			ExpireTime:     ptr(expire),
+			Params:         nil,
+			Data:           map[string]string{"foo": "bar"},
+		},
+	}
+	md, err := s.store.CreateSecret(uri, p)
+	c.Assert(err, jc.ErrorIsNil)
+	uri2 := secrets.NewURI()
+	_, err = s.store.CreateSecret(uri2, p)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+
+	// Existing unit owner label should not be used for owner label for the application.
+	uri3 := secrets.NewURI()
+	p.Owner = s.owner.Tag()
+	_, err = s.store.CreateSecret(uri3, p)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+
+	// Existing unit owner label should not be used for consumer label for the application.
+	cmd := &secrets.SecretConsumerMetadata{
+		Label:           "foobar",
+		CurrentRevision: md.LatestRevision,
+	}
+	err = s.State.SaveSecretConsumer(uri, s.owner.Tag(), cmd)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+}
+
+func (s *SecretsSuite) TestCreateDuplicateLabelUnitConsumed(c *gc.C) {
+	uri := secrets.NewURI()
+	p := state.CreateSecretParams{
+		Version: 1,
+		Owner:   names.NewApplicationTag("wordpress"),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken: &fakeToken{},
+			Params:      nil,
+			Data:        map[string]string{"foo": "bar"},
+		},
+	}
+	md, err := s.store.CreateSecret(uri, p)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cmd := &secrets.SecretConsumerMetadata{
+		Label:           "foobar",
+		CurrentRevision: md.LatestRevision,
+	}
+	err = s.State.SaveSecretConsumer(uri, s.ownerUnit.Tag(), cmd)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Existing unit consumer label should not be used for owner label.
+	uri2 := secrets.NewURI()
+	p.Owner = s.ownerUnit.Tag()
+	p.Label = ptr("foobar")
+	_, err = s.store.CreateSecret(uri2, p)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+
+	// Existing unit consumer label should not be used for owner label for the application.
+	uri3 := secrets.NewURI()
+	p.Owner = s.owner.Tag()
+	p.Label = ptr("foobar")
+	_, err = s.store.CreateSecret(uri3, p)
+	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
+
+	// Existing unit consumer label should not be used for consumer label for the application.
+	cmd = &secrets.SecretConsumerMetadata{
+		Label:           "foobar",
+		CurrentRevision: md.LatestRevision,
+	}
+	err = s.State.SaveSecretConsumer(uri, s.owner.Tag(), cmd)
 	c.Assert(errors.Is(err, state.LabelExists), jc.IsTrue)
 }
 

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -64,10 +64,8 @@ run_secrets() {
 	microk8s kubectl -n model-secrets-k8s get roles/unit-nginx-0 -o json | jq ".rules[] | select( has(\"resourceNames\") ) | select( .resourceNames[] | contains(\"${secret_owned_by_hello_0}-1\") ) | .verbs[0] " | grep 'get'
 	microk8s kubectl -n model-secrets-k8s get roles/unit-nginx-0 -o json | jq ".rules[] | select( has(\"resourceNames\") ) | select( .resourceNames[] | contains(\"${secret_owned_by_hello}-1\") ) | .verbs[0] " | grep 'get'
 
-	# TODO: this is a bug in the k8s secret provider. We should not need to do base64 encoding twice. Remove the 2nd decoding once the bug is fixed.
-	# Check secret content via k8s API to ensure we are using the k8s secret provider.
-	microk8s kubectl -n model-secrets-k8s get "secrets/${secret_owned_by_hello_0}-1" -o json | jq -r '.data["owned-by"]' | base64 -d | base64 -d | grep "hello/0"
-	microk8s kubectl -n model-secrets-k8s get "secrets/${secret_owned_by_hello}-1" -o json | jq -r '.data["owned-by"]' | base64 -d | base64 -d | grep "hello-app"
+	microk8s kubectl -n model-secrets-k8s get "secrets/${secret_owned_by_hello_0}-1" -o json | jq -r '.data["owned-by"]' | base64 -d | grep "hello/0"
+	microk8s kubectl -n model-secrets-k8s get "secrets/${secret_owned_by_hello}-1" -o json | jq -r '.data["owned-by"]' | base64 -d | grep "hello-app"
 
 	# secret-revoke by relation ID.
 	juju exec --unit hello/0 -- secret-revoke "$secret_owned_by_hello" --relation "$relation_id"


### PR DESCRIPTION
This PR allows units to get application-owned secrets using owner labels.

Driveby: remove TODO and temp fix for k8s secret double encode bug in tests/suites/secrets_k8s/k8s.sh

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```console
juju exec --unit prometheus-k8s/0 -- secret-add app=prometheus-k8s --label foo
secret:ce4ouseffbas7anpr0p0

juju show-secret --reveal ce4ouseffbas7anpr0p0
ce4ouseffbas7anpr0p0:
  revision: 1
  owner: prometheus-k8s
  label: foo
  created: 2022-12-02T05:38:58Z
  updated: 2022-12-02T05:38:58Z
  content:
    app: prometheus-k8s

juju exec --unit prometheus-k8s/0 -- secret-get --label foo
app: prometheus-k8s

juju exec --unit prometheus-k8s/1 -- secret-get --label foo
app: prometheus-k8s

# the label `foo` has been used for the application secret, no units can use this label anymore.
juju exec --unit prometheus-k8s/0 -- secret-add --owner unit unit=prometheus-k8s/0 --label=foo
secret:ce4ovneffbas7anpr0pg
creating secrets: secret with label "foo" already exists

juju exec --unit prometheus-k8s/1 -- secret-add --owner unit unit=prometheus-k8s/1 --label=foo
secret:ce4p0eeffbas7anpr0q0
creating secrets: secret with label "foo" already exists

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/1997289