### PR TITLE
[JUJU-2279] Added confirmation to destroy-model in 3.0

### DIFF
--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -168,14 +168,14 @@ func (s *DestroySuite) TestDestroyUnknownModelCallsRefresh(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyCannotConnectToAPI(c *gc.C) {
 	s.stub.SetErrors(errors.New("connection refused"))
-	_, err := s.runDestroyCommand(c, "test2", "-y")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy model: connection refused")
 	c.Check(c.GetTestLog(), jc.Contains, "failed to destroy model \"test2\"")
 	checkModelExistsInStore(c, "test1:admin/test2", s.store)
 }
 
 func (s *DestroySuite) TestSystemDestroyFails(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, `"test1" is a controller; use 'juju destroy-controller' to destroy it`)
 	checkModelExistsInStore(c, "test1:admin/test1", s.store)
 }
@@ -184,7 +184,7 @@ var timeout = 30 * time.Minute
 
 func (s *DestroySuite) TestDestroy(c *gc.C) {
 	checkModelExistsInStore(c, "test1:admin/test2", s.store)
-	_, err := s.runDestroyCommand(c, "test2", "-y")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
 	s.stub.CheckCalls(c, []jutesting.StubCall{
@@ -195,7 +195,7 @@ func (s *DestroySuite) TestDestroy(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyWithPartModelUUID(c *gc.C) {
 	checkModelExistsInStore(c, "test1:admin/test2", s.store)
-	_, err := s.runDestroyCommand(c, "test2-uu", "-y")
+	_, err := s.runDestroyCommand(c, "test2-uu", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
 	s.stub.CheckCalls(c, []jutesting.StubCall{
@@ -206,7 +206,7 @@ func (s *DestroySuite) TestDestroyWithPartModelUUID(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyWithForce(c *gc.C) {
 	checkModelExistsInStore(c, "test1:admin/test2", s.store)
-	_, err := s.runDestroyCommand(c, "test2", "-y", "--force")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt", "--force")
 	c.Assert(err, jc.ErrorIsNil)
 	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
 	force := true
@@ -217,7 +217,7 @@ func (s *DestroySuite) TestDestroyWithForce(c *gc.C) {
 
 func (s *DestroySuite) TestDestroyWithForceNoWait(c *gc.C) {
 	checkModelExistsInStore(c, "test1:admin/test2", s.store)
-	_, err := s.runDestroyCommand(c, "test2", "-y", "--force", "--no-wait")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt", "--force", "--no-wait")
 	c.Assert(err, jc.ErrorIsNil)
 	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
 	force := true
@@ -230,7 +230,7 @@ func (s *DestroySuite) TestDestroyWithForceNoWait(c *gc.C) {
 func (s *DestroySuite) TestDestroyBlocks(c *gc.C) {
 	checkModelExistsInStore(c, "test1:admin/test2", s.store)
 	s.api.modelInfoErr = []*params.Error{{}, {Code: params.CodeNotFound}}
-	_, err := s.runDestroyCommand(c, "test2", "-y")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
 	c.Assert(s.api.statusCallCount, gc.Equals, 1)
@@ -238,13 +238,13 @@ func (s *DestroySuite) TestDestroyBlocks(c *gc.C) {
 
 func (s *DestroySuite) TestFailedDestroyModel(c *gc.C) {
 	s.stub.SetErrors(errors.New("permission denied"))
-	_, err := s.runDestroyCommand(c, "test1:test2", "-y")
+	_, err := s.runDestroyCommand(c, "test1:test2", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, "cannot destroy model: permission denied")
 	checkModelExistsInStore(c, "test1:admin/test2", s.store)
 }
 
 func (s *DestroySuite) TestDestroyDestroyStorage(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test2", "-y", "--destroy-storage")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt", "--destroy-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	destroyStorage := true
 	s.stub.CheckCalls(c, []jutesting.StubCall{
@@ -253,7 +253,7 @@ func (s *DestroySuite) TestDestroyDestroyStorage(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyReleaseStorage(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test2", "-y", "--release-storage")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt", "--release-storage")
 	c.Assert(err, jc.ErrorIsNil)
 	destroyStorage := false
 	s.stub.CheckCalls(c, []jutesting.StubCall{
@@ -262,14 +262,14 @@ func (s *DestroySuite) TestDestroyReleaseStorage(c *gc.C) {
 }
 
 func (s *DestroySuite) TestDestroyDestroyReleaseStorageFlagsMutuallyExclusive(c *gc.C) {
-	_, err := s.runDestroyCommand(c, "test2", "-y", "--destroy-storage", "--release-storage")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt", "--destroy-storage", "--release-storage")
 	c.Assert(err, gc.ErrorMatches, "--destroy-storage and --release-storage cannot both be specified")
 }
 
 func (s *DestroySuite) TestDestroyDestroyStorageFlagUnspecified(c *gc.C) {
 	s.stub.SetErrors(&params.Error{Code: params.CodeHasPersistentStorage})
 	s.api.modelInfoErr = []*params.Error{nil}
-	_, err := s.runDestroyCommand(c, "test2", "-y")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt")
 	c.Assert(err, gc.ErrorMatches, `cannot destroy model "test2"
 
 The model has persistent storage remaining:
@@ -302,7 +302,7 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	ctx.Stdout = &stdout
 	ctx.Stdin = &stdin
 
-	// Ensure confirmation is requested if "-y" is not specified.
+	// Ensure confirmation is requested if "--no-prompt" is not specified.
 	stdin.WriteString("n")
 	_, errc := cmdtest.RunCommandWithDummyProvider(ctx, s.NewDestroyCommand(), "test2")
 	select {
@@ -327,22 +327,22 @@ func (s *DestroySuite) TestDestroyCommandConfirmation(c *gc.C) {
 	c.Check(cmdtesting.Stdout(ctx), gc.Matches, "WARNING!.*test2(.|\n)*")
 	checkModelExistsInStore(c, "test1:admin/test2", s.store)
 
-	for _, answer := range []string{"y", "Y", "yes", "YES"} {
-		stdin.Reset()
-		stdout.Reset()
-		stdin.WriteString(answer)
-		_, errc = cmdtest.RunCommandWithDummyProvider(ctx, s.NewDestroyCommand(), "test2")
-		select {
-		case err := <-errc:
-			c.Check(err, jc.ErrorIsNil)
-		case <-time.After(testing.LongWait):
-			c.Fatalf("command took too long")
-		}
-		checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
-
-		// Add the test2 model back into the store for the next test
-		s.resetModel(c)
+	answer := "test2"
+	stdin.Reset()
+	stdout.Reset()
+	stdin.WriteString(answer)
+	_, errc = cmdtest.RunCommandWithDummyProvider(ctx, s.NewDestroyCommand(), "test2")
+	select {
+	case err := <-errc:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("command took too long")
 	}
+	checkModelRemovedFromStore(c, "test1:admin/test2", s.store)
+
+	// Add the test2 model back into the store for the next test
+	s.resetModel(c)
+
 }
 
 func (s *DestroySuite) TestDestroyCommandWait(c *gc.C) {
@@ -370,7 +370,7 @@ func (s *DestroySuite) TestDestroyCommandWait(c *gc.C) {
 
 	go func() {
 		// run destroy model cmd, and timeout in 3s.
-		ctx, err := s.runDestroyCommand(c, "test2", "-y", "-t", "3s")
+		ctx, err := s.runDestroyCommand(c, "test2", "--no-prompt", "-t", "3s")
 		outStdOut <- cmdtesting.Stdout(ctx)
 		outStdErr <- cmdtesting.Stderr(ctx)
 		outErr <- err
@@ -431,7 +431,7 @@ func (s *DestroySuite) TestDestroyCommandLeanMessage(c *gc.C) {
 
 	go func() {
 		// run destroy model cmd, and timeout in 3s.
-		ctx, err := s.runDestroyCommand(c, "test2", "-y", "-t", "3s")
+		ctx, err := s.runDestroyCommand(c, "test2", "--no-prompt", "-t", "3s")
 		outStdOut <- cmdtesting.Stdout(ctx)
 		outStdErr <- cmdtesting.Stderr(ctx)
 		outErr <- err
@@ -459,7 +459,7 @@ even with potentially orphaned cloud resources.
 
 func (s *DestroySuite) TestBlockedDestroy(c *gc.C) {
 	s.stub.SetErrors(apiservererrors.OperationBlockedError("TestBlockedDestroy"))
-	_, err := s.runDestroyCommand(c, "test2", "-y")
+	_, err := s.runDestroyCommand(c, "test2", "--no-prompt")
 	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedDestroy.*")
 }
 

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -5,7 +5,6 @@ package model_test
 
 import (
 	"bytes"
-	"github.com/juju/juju/juju/osenv"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -23,6 +22,7 @@ import (
 	"github.com/juju/juju/cmd/juju/model"
 	"github.com/juju/juju/cmd/modelcmd"
 	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	_ "github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -133,7 +133,7 @@ bootstrap() {
 		if [[ -n ${OUT} ]]; then
 			echo "${model} already exists. Use the following to clean up the environment:"
 			echo "    juju switch ${bootstrapped_name}"
-			echo "    juju destroy-model -y ${model}"
+			echo "    juju destroy-model --no-prompt ${model}"
 			exit 1
 		fi
 
@@ -335,7 +335,7 @@ destroy_model() {
 	output="${TEST_DIR}/${name}-destroy.log"
 
 	echo "====> Destroying juju model ${name}"
-	echo "${name}" | xargs -I % juju destroy-model -y --destroy-storage --timeout="$timeout" % >"${output}" 2>&1 || true
+	echo "${name}" | xargs -I % juju destroy-model --no-prompt --destroy-storage --timeout="$timeout" % >"${output}" 2>&1 || true
 	CHK=$(cat "${output}" | grep -i "ERROR\|Unable to get the model status from the API" || true)
 	if [[ -n ${CHK} ]]; then
 		printf '\nFound some issues\n'
@@ -369,7 +369,7 @@ destroy_controller() {
 		echo "====> Destroying model ($(green "${name}"))"
 
 		output="${TEST_DIR}/${name}-destroy-model.log"
-		echo "${name}" | xargs -I % juju destroy-model -y % >"${output}" 2>&1 || true
+		echo "${name}" | xargs -I % juju destroy-model --no-prompt % >"${output}" 2>&1 || true
 
 		echo "====> Destroyed model ($(green "${name}"))"
 		return

--- a/tests/suites/cli/block.sh
+++ b/tests/suites/cli/block.sh
@@ -8,7 +8,7 @@ run_block_destroy_model() {
 	ensure "${model_name}" "${file}"
 
 	juju disable-command destroy-model
-	juju destroy-model -y ${model_name} | grep -q 'the operation has been blocked' || true
+	juju destroy-model --no-prompt ${model_name} | grep -q 'the operation has been blocked' || true
 
 	juju enable-command destroy-model
 	destroy_model "${model_name}"
@@ -33,7 +33,7 @@ run_block_remove_object() {
 	# are disabled.
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "ubuntu" 0)"
 
-	juju destroy-model -y ${model_name} | grep -q 'the operation has been blocked' || true
+	juju destroy-model  ${model_name} | grep -q 'the operation has been blocked' || true
 	juju remove-application ntp | grep -q 'the operation has been blocked' || true
 	juju remove-relation ntp ubuntu | grep -q 'the operation has been blocked' || true
 	juju remove-unit ubuntu/0 | grep -q 'the operation has been blocked' || true

--- a/tests/suites/cli/block.sh
+++ b/tests/suites/cli/block.sh
@@ -33,7 +33,7 @@ run_block_remove_object() {
 	# are disabled.
 	wait_for "ntp" "$(idle_subordinate_condition "ntp" "ubuntu" 0)"
 
-	juju destroy-model  ${model_name} | grep -q 'the operation has been blocked' || true
+	juju destroy-model --no-prompt ${model_name} | grep -q 'the operation has been blocked' || true
 	juju remove-application ntp | grep -q 'the operation has been blocked' || true
 	juju remove-relation ntp ubuntu | grep -q 'the operation has been blocked' || true
 	juju remove-unit ubuntu/0 | grep -q 'the operation has been blocked' || true

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -85,7 +85,7 @@ run_secrets() {
 
 	# TODO: destroy model properly once we fix the k8s teardown issue.
 	# We destroy with --force for now.
-	juju --show-log destroy-model -y --debug --force --destroy-storage "model-secrets-k8s"
+	juju --show-log destroy-model --no-prompt --debug --force --destroy-storage "model-secrets-k8s"
 	# destroy_model "model-secrets-k8s"
 }
 


### PR DESCRIPTION
This PR adds enhanced confirmation (see JU057 spec) for `destroy-model` command. Fixes and adds unit-tests and integration tests.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
juju bootstrap lxd lxd

juju add-model test-destroy
juju destroy-model test-destroy

juju add-model test-destroy2
JUJU_SKIP_CONFIRMATION=false juju destroy-model test-destroy
JUJU_SKIP_CONFIRMATION=asfde juju destroy-model test-destroy
JUJU_SKIP_CONFIRMATION=true juju destroy-model test-destroy

juju add-model test-destroy3
juju destroy-model --no-prompt test-destroy3

go test ./cmd/juju/model/...

cd tests
./main.sh -v -p lxd cli
```
