### PR TITLE
[JUJU-2274] Drop -y confirmation from 3.1

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -185,10 +185,6 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 
-	if err := c.ConfirmationCommandBase.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
-
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -462,7 +462,7 @@ func (s *DestroySuite) TestDestroyControllerReattempt(c *gc.C) {
 	// and reattempt the destroy the controller; this time
 	// it succeeds.
 	s.api.SetErrors(&params.Error{Code: params.CodeHasHostedModels})
-	_, err := s.runDestroyCommand(c, "test1", "-y")
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
 	c.Assert(err, jc.ErrorIsNil)
 	s.api.CheckCallNames(c,
 		"DestroyController",

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -105,9 +105,6 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 	}
 	store := c.ClientStore()
 
-	if err := c.ConfirmationCommandBase.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, destroySysMsg, controllerName)
 		if err := jujucmd.UserConfirmName(controllerName, "controller", ctx); err != nil {

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -105,9 +105,6 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	if err := c.ConfirmationCommandBase.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stdout, unregisterMsg, c.controllerName)
 		if err := jujucmd.UserConfirmName(c.controllerName, "controller", ctx); err != nil {

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -234,10 +234,6 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 		return errors.Errorf("%q is a controller; use 'juju destroy-controller' to destroy it", modelName)
 	}
 
-	if err := c.ConfirmationCommandBase.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
-
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
 		modelType, err := c.ModelType()
 		if err != nil {

--- a/cmd/modelcmd/confirmation.go
+++ b/cmd/modelcmd/confirmation.go
@@ -4,9 +4,6 @@
 package modelcmd
 
 import (
-	"fmt"
-
-	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 
@@ -16,14 +13,11 @@ import (
 // ConfirmationCommandBase provides common attributes and methods that
 // commands require to confirm the execution.
 type ConfirmationCommandBase struct {
-	assumeYes      bool // DEPRECATED
 	assumeNoPrompt bool
 }
 
 // SetFlags implements Command.SetFlags.
 func (c *ConfirmationCommandBase) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for backwards compatibility with Juju 2.9")
-	f.BoolVar(&c.assumeYes, "yes", false, "")
 	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation")
 }
 
@@ -41,15 +35,7 @@ func (c *ConfirmationCommandBase) Init(args []string) error {
 	return nil
 }
 
-// Run implements Command.Run
-func (c *ConfirmationCommandBase) Run(ctx *cmd.Context) error {
-	if c.assumeYes {
-		fmt.Fprint(ctx.Stdout, "WARNING: '-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
-	}
-	return nil
-}
-
 // NeedsConfirmation returns if flags require the confirmation or not.
 func (c *ConfirmationCommandBase) NeedsConfirmation() bool {
-	return !(c.assumeYes || c.assumeNoPrompt)
+	return !c.assumeNoPrompt
 }

--- a/featuretests/cmd_juju_controller_test.go
+++ b/featuretests/cmd_juju_controller_test.go
@@ -363,7 +363,7 @@ func (s *cmdControllerSuite) testControllerDestroy(c *gc.C, forceAPI bool) {
 	ops := make(chan dummy.Operation, 1)
 	dummy.Listen(ops)
 
-	s.run(c, "destroy-controller", "kontroll", "-y", "--destroy-all-models", "--debug")
+	s.run(c, "destroy-controller", "kontroll", "--no-prompt", "--destroy-all-models", "--debug")
 	close(stop)
 	<-done
 
@@ -397,7 +397,7 @@ func (s *cmdControllerSuite) TestControllerKill(c *gc.C) {
 	st.SwitchBlockOn(state.DestroyBlock, "TestBlockDestroyModel")
 	st.Close()
 
-	s.run(c, "kill-controller", "kontroll", "-y")
+	s.run(c, "kill-controller", "kontroll", "--no-prompt")
 
 	store := jujuclient.NewFileClientStore()
 	_, err := store.ControllerByName("kontroll")
@@ -420,7 +420,7 @@ func (s *cmdControllerSuite) TestSystemKillCallsEnvironDestroyOnHostedEnviron(c 
 	_, err := store.ControllerByName("kontroll")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.run(c, "kill-controller", "kontroll", "-y")
+	s.run(c, "kill-controller", "kontroll", "--no-prompt")
 
 	// Ensure that Destroy was called on the hosted environ ...
 	// TODO(fwereade): how do we know it's the hosted environ?


### PR DESCRIPTION
This option is no longer supported

## QA steps

Verify that `-y` or `--yes` flags for `destroy-controller`, `kill-controller`, `unregister` or `destroy-model` lead to error
