### PR TITLE
[JUJU-2287] Add secret provider config schema and validation

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -37,8 +37,11 @@ func (c *Client) GetSecretBackendConfig() (*provider.BackendConfig, error) {
 		return nil, errors.Trace(err)
 	}
 	return &provider.BackendConfig{
-		BackendType: result.BackendType,
-		Config:      result.Params,
+		ControllerUUID: result.ControllerUUID,
+		ModelUUID:      result.ModelUUID,
+		ModelName:      result.ModelName,
+		BackendType:    result.BackendType,
+		Config:         result.Params,
 	}, nil
 }
 

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -46,8 +46,11 @@ func (s *SecretsSuite) TestGetSecretBackendConfig(c *gc.C) {
 		c.Check(arg, gc.IsNil)
 		c.Assert(result, gc.FitsTypeOf, &params.SecretBackendConfig{})
 		*(result.(*params.SecretBackendConfig)) = params.SecretBackendConfig{
-			BackendType: "controller",
-			Params:      map[string]interface{}{"foo": "bar"},
+			ControllerUUID: coretesting.ControllerTag.Id(),
+			ModelUUID:      coretesting.ModelTag.Id(),
+			ModelName:      "fred",
+			BackendType:    "controller",
+			Params:         map[string]interface{}{"foo": "bar"},
 		}
 		return nil
 	})
@@ -55,8 +58,11 @@ func (s *SecretsSuite) TestGetSecretBackendConfig(c *gc.C) {
 	result, err := client.GetSecretBackendConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, &provider.BackendConfig{
-		BackendType: "controller",
-		Config:      map[string]interface{}{"foo": "bar"},
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendType:    "controller",
+		Config:         map[string]interface{}{"foo": "bar"},
 	})
 }
 

--- a/api/client/secretbackends/client.go
+++ b/api/client/secretbackends/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/base"
-	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -44,13 +43,17 @@ func (api *Client) ListSecretBackends(reveal bool) ([]SecretBackend, error) {
 	}
 	result := make([]SecretBackend, len(response.Results))
 	for i, r := range response.Results {
+		var resultErr error
+		if r.Error != nil {
+			resultErr = r.Error
+		}
 		details := SecretBackend{
 			Name:                r.Result.Name,
 			BackendType:         r.Result.BackendType,
 			TokenRotateInterval: r.Result.TokenRotateInterval,
 			Config:              r.Result.Config,
 			NumSecrets:          r.NumSecrets,
-			Error:               apiservererrors.RestoreError(r.Error),
+			Error:               resultErr,
 		}
 		result[i] = details
 	}

--- a/apiserver/common/secrets/mocks/provider_mock.go
+++ b/apiserver/common/secrets/mocks/provider_mock.go
@@ -120,17 +120,3 @@ func (mr *MockSecretBackendProviderMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockSecretBackendProvider)(nil).Type))
 }
-
-// ValidateConfig mocks base method.
-func (m *MockSecretBackendProvider) ValidateConfig(arg0, arg1 provider.ProviderConfig) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateConfig", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateConfig indicates an expected call of ValidateConfig.
-func (mr *MockSecretBackendProviderMockRecorder) ValidateConfig(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).ValidateConfig), arg0, arg1)
-}

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
@@ -120,17 +120,3 @@ func (mr *MockSecretBackendProviderMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockSecretBackendProvider)(nil).Type))
 }
-
-// ValidateConfig mocks base method.
-func (m *MockSecretBackendProvider) ValidateConfig(arg0, arg1 provider.ProviderConfig) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateConfig", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateConfig indicates an expected call of ValidateConfig.
-func (mr *MockSecretBackendProviderMockRecorder) ValidateConfig(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateConfig", reflect.TypeOf((*MockSecretBackendProvider)(nil).ValidateConfig), arg0, arg1)
-}

--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/leadership"
 	coresecrets "github.com/juju/juju/core/secrets"
-	coretesting "github.com/juju/juju/testing"
 )
 
 func TestPackage(t *testing.T) {
@@ -48,7 +47,6 @@ func NewTestAPI(
 
 	return &SecretsManagerAPI{
 		authTag:             authTag,
-		modelUUID:           coretesting.ModelTag.Id(),
 		resources:           resources,
 		leadershipChecker:   leadership,
 		secretsBackend:      backend,

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -49,7 +49,6 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 	}
 	return &SecretsManagerAPI{
 		authTag:             context.Auth().GetAuthTag(),
-		modelUUID:           context.State().ModelUUID(),
 		leadershipChecker:   leadershipChecker,
 		secretsBackend:      secretsBackend,
 		resources:           context.Resources(),

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -27,8 +27,6 @@ var logger = loggo.GetLogger("juju.apiserver.secretsmanager")
 
 // SecretsManagerAPI is the implementation for the SecretsManager facade.
 type SecretsManagerAPI struct {
-	modelUUID string
-
 	leadershipChecker leadership.Checker
 	secretsBackend    SecretsBackend
 	resources         facade.Resources
@@ -54,8 +52,11 @@ func (s *SecretsManagerAPI) GetSecretBackendConfig() (params.SecretBackendConfig
 		return params.SecretBackendConfig{}, errors.Trace(err)
 	}
 	result := params.SecretBackendConfig{
-		BackendType: cfg.BackendType,
-		Params:      cfg.Config,
+		ControllerUUID: cfg.ControllerUUID,
+		ModelUUID:      cfg.ModelUUID,
+		ModelName:      cfg.ModelName,
+		BackendType:    cfg.BackendType,
+		Params:         cfg.Config,
 	}
 	return result, nil
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/secrets"
 	"github.com/juju/juju/secrets/provider"
 	"github.com/juju/juju/state"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type SecretsManagerSuite struct {
@@ -80,8 +81,11 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 
 	storeConfigGetter := func() (*provider.BackendConfig, error) {
 		return &provider.BackendConfig{
-			BackendType: "controller",
-			Config:      map[string]interface{}{"foo": "bar"},
+			ControllerUUID: coretesting.ControllerTag.Id(),
+			ModelUUID:      coretesting.ModelTag.Id(),
+			ModelName:      "fred",
+			BackendType:    "controller",
+			Config:         map[string]interface{}{"foo": "bar"},
 		}, nil
 	}
 	providerGetter := func() (provider.SecretBackendProvider, provider.Model, error) {
@@ -127,8 +131,11 @@ func (s *SecretsManagerSuite) TestGetSecretBackendConfig(c *gc.C) {
 	result, err := s.facade.GetSecretBackendConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.SecretBackendConfig{
-		BackendType: "controller",
-		Params:      map[string]interface{}{"foo": "bar"},
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendType:    "controller",
+		Params:         map[string]interface{}{"foo": "bar"},
 	})
 }
 

--- a/apiserver/facades/client/secretbackends/secrets_test.go
+++ b/apiserver/facades/client/secretbackends/secrets_test.go
@@ -71,7 +71,10 @@ func (s *SecretsSuite) assertListSecretBackends(c *gc.C, reveal bool) {
 	facade, err := secretbackends.NewTestAPI(s.secretsState, s.authorizer)
 	c.Assert(err, jc.ErrorIsNil)
 
-	config := map[string]interface{}{"foo": "bar"}
+	config := map[string]interface{}{
+		"endpoint": "http://vault",
+		"token":    "s.ajehjdee",
+	}
 	s.secretsState.EXPECT().ListSecretBackends().Return(
 		[]*coresecrets.SecretBackend{{
 			Name:                "myvault",
@@ -83,6 +86,9 @@ func (s *SecretsSuite) assertListSecretBackends(c *gc.C, reveal bool) {
 
 	results, err := facade.ListSecretBackends(params.ListSecretBackendsArgs{Reveal: reveal})
 	c.Assert(err, jc.ErrorIsNil)
+	if !reveal {
+		delete(config, "token")
+	}
 	c.Assert(results, jc.DeepEquals, params.ListSecretBackendsResults{
 		Results: []params.SecretBackendResult{{
 			Result: params.SecretBackend{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39299,6 +39299,15 @@
                 "SecretBackendConfig": {
                     "type": "object",
                     "properties": {
+                        "model-controller": {
+                            "type": "string"
+                        },
+                        "model-name": {
+                            "type": "string"
+                        },
+                        "model-uuid": {
+                            "type": "string"
+                        },
                         "params": {
                             "type": "object",
                             "patternProperties": {
@@ -39314,6 +39323,9 @@
                     },
                     "additionalProperties": false,
                     "required": [
+                        "model-controller",
+                        "model-uuid",
+                        "model-name",
                         "type"
                     ]
                 },
@@ -47370,6 +47382,15 @@
                 "SecretBackendConfig": {
                     "type": "object",
                     "properties": {
+                        "model-controller": {
+                            "type": "string"
+                        },
+                        "model-name": {
+                            "type": "string"
+                        },
+                        "model-uuid": {
+                            "type": "string"
+                        },
                         "params": {
                             "type": "object",
                             "patternProperties": {
@@ -47385,6 +47406,9 @@
                     },
                     "additionalProperties": false,
                     "required": [
+                        "model-controller",
+                        "model-uuid",
+                        "model-name",
                         "type"
                     ]
                 },

--- a/cmd/juju/secretbackends/add.go
+++ b/cmd/juju/secretbackends/add.go
@@ -174,9 +174,12 @@ func (c *addSecretBackendCommand) Run(ctxt *cmd.Context) error {
 	if err != nil {
 		return errors.Annotatef(err, "invalid secret backend %q", c.BackendType)
 	}
-	err = p.ValidateConfig(nil, attrs)
-	if err != nil {
-		return errors.Annotate(err, "invalid provider config")
+	configValidator, ok := p.(provider.ProviderConfig)
+	if ok {
+		err = configValidator.ValidateConfig(nil, attrs)
+		if err != nil {
+			return errors.Annotate(err, "invalid provider config")
+		}
 	}
 
 	backend := secretbackends.SecretBackend{

--- a/cmd/juju/secretbackends/list.go
+++ b/cmd/juju/secretbackends/list.go
@@ -83,12 +83,12 @@ func (c *listSecretBackendsCommand) SetFlags(f *gnuflag.FlagSet) {
 type secretBackendsByName map[string]secretBackendDisplayDetails
 
 type secretBackendDisplayDetails struct {
-	Name                string                  `json:"name" yaml:"name"`
-	Backend             string                  `json:"backend" yaml:"backend"`
-	TokenRotateInterval *time.Duration          `json:"token-rotate-interval,omitempty" yaml:"token-rotate-interval,omitempty"`
-	Config              provider.ProviderConfig `json:"config,omitempty" yaml:"config,omitempty"`
-	NumSecrets          int                     `json:"secrets,omitempty" yaml:"secrets,omitempty"`
-	Error               error                   `json:"error,omitempty" yaml:"error,omitempty"`
+	Name                string               `json:"name" yaml:"name"`
+	Backend             string               `json:"backend" yaml:"backend"`
+	TokenRotateInterval *time.Duration       `json:"token-rotate-interval,omitempty" yaml:"token-rotate-interval,omitempty"`
+	Config              provider.ConfigAttrs `json:"config,omitempty" yaml:"config,omitempty"`
+	NumSecrets          int                  `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	Error               error                `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
 // Run implements cmd.Run.
@@ -126,7 +126,7 @@ func gatherSecretBackendInfo(backends []secretbackends.SecretBackend) map[string
 			Error:               b.Error,
 		}
 		if len(b.Config) > 0 {
-			info.Config = make(provider.ProviderConfig)
+			info.Config = make(provider.ConfigAttrs)
 			for k, v := range b.Config {
 				info.Config[k] = v
 			}

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -174,7 +174,7 @@ func gatherSecretInfo(secrets []apisecrets.SecretDetails, reveal, includeRevisio
 				}
 			}
 		}
-		if reveal && !m.Value.IsEmpty() {
+		if reveal && m.Value != nil && !m.Value.IsEmpty() {
 			valueDetails := &secretValueDetails{}
 			val, err := m.Value.Values()
 			if err != nil {

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -11,8 +11,11 @@ import (
 
 // SecretBackendConfig holds config for creating a secret backend client.
 type SecretBackendConfig struct {
-	BackendType string                 `json:"type"`
-	Params      map[string]interface{} `json:"params,omitempty"`
+	ControllerUUID string                 `json:"model-controller"`
+	ModelUUID      string                 `json:"model-uuid"`
+	ModelName      string                 `json:"model-name"`
+	BackendType    string                 `json:"type"`
+	Params         map[string]interface{} `json:"params,omitempty"`
 }
 
 // SecretContentParams holds params for representing the content of a secret.

--- a/secrets/provider/backend.go
+++ b/secrets/provider/backend.go
@@ -18,10 +18,9 @@ type SecretsBackend interface {
 
 // BackendConfig is used when constructing a secrets backend.
 type BackendConfig struct {
-	BackendType string
-	// TODO(wallyworld) - use a schema
-	Config ProviderConfig
+	ControllerUUID string
+	ModelUUID      string
+	ModelName      string
+	BackendType    string
+	Config         ConfigAttrs
 }
-
-// ProviderConfig defines config for a secrets backend provider.
-type ProviderConfig map[string]interface{}

--- a/secrets/provider/juju/provider.go
+++ b/secrets/provider/juju/provider.go
@@ -4,7 +4,6 @@
 package juju
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/secrets/provider"
@@ -23,14 +22,6 @@ func NewProvider() provider.SecretBackendProvider {
 }
 
 type jujuProvider struct {
-}
-
-// ValidateConfig implements SecretBackendProvider.
-func (p jujuProvider) ValidateConfig(oldCfg, newCfg provider.ProviderConfig) error {
-	if len(newCfg) > 0 {
-		return errors.New("the internal secrets backend does not use any config")
-	}
-	return nil
 }
 
 func (p jujuProvider) Type() string {
@@ -57,7 +48,12 @@ func (p jujuProvider) CleanupSecrets(m provider.Model, tag names.Tag, removed pr
 func (p jujuProvider) BackendConfig(
 	m provider.Model, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
-	return &provider.BackendConfig{BackendType: BackendType}, nil
+	return &provider.BackendConfig{
+		ControllerUUID: m.ControllerUUID(),
+		ModelUUID:      m.UUID(),
+		ModelName:      m.Name(),
+		BackendType:    BackendType,
+	}, nil
 }
 
 // NewBackend returns a nil backend since the Juju backend saves

--- a/secrets/provider/kubernetes/provider_test.go
+++ b/secrets/provider/kubernetes/provider_test.go
@@ -39,24 +39,17 @@ func (*providerSuite) TestBackendConfig(c *gc.C) {
 	cfg, err := p.BackendConfig(mockModel{}, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals, &provider.BackendConfig{
-		BackendType: kubernetes.BackendType,
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendType:    kubernetes.BackendType,
 		Config: map[string]interface{}{
 			"ca-certs":            []string{"cert-data"},
-			"controller-uuid":     coretesting.ControllerTag.Id(),
 			"credential":          `{"auth-type":"access-key","Attributes":{"foo":"bar"}}`,
 			"endpoint":            "http://nowhere",
 			"is-controller-cloud": true,
-			"model-name":          "fred",
-			"model-uuid":          coretesting.ModelTag.Id(),
 		},
 	})
-}
-
-func (*providerSuite) TestValidateConfig(c *gc.C) {
-	p, err := provider.Provider(kubernetes.BackendType)
-	c.Assert(err, jc.ErrorIsNil)
-	err = p.ValidateConfig(nil, map[string]interface{}{"foo": "bar"})
-	c.Assert(err, gc.ErrorMatches, "the k8s secrets backend does not use any config")
 }
 
 func (s *providerSuite) assertBackendConfigWithTag(c *gc.C, isControllerCloud bool) {
@@ -100,15 +93,15 @@ func (s *providerSuite) assertBackendConfigWithTag(c *gc.C, isControllerCloud bo
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	expected := &provider.BackendConfig{
-		BackendType: kubernetes.BackendType,
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendType:    kubernetes.BackendType,
 		Config: map[string]interface{}{
 			"ca-certs":            []string{"cert-data"},
-			"controller-uuid":     coretesting.ControllerTag.Id(),
 			"credential":          `{"auth-type":"access-key","Attributes":{"Token":"token","password":"","username":""}}`,
 			"endpoint":            "http://nowhere",
 			"is-controller-cloud": isControllerCloud,
-			"model-name":          "fred",
-			"model-uuid":          coretesting.ModelTag.Id(),
 		},
 	}
 	if isControllerCloud {

--- a/secrets/provider/provider.go
+++ b/secrets/provider/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v4"
+	"gopkg.in/juju/environschema.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/secrets"
@@ -58,14 +59,21 @@ const (
 	Internal = "internal"
 )
 
-// SecretBackendProvider instances create secret backends.
-type SecretBackendProvider interface {
-	// TODO(wallyworld) - add config schema methods
+// ConfigAttrs defines config attributes for a secrets backend provider.
+type ConfigAttrs map[string]interface{}
+
+// ProviderConfig is implemented by providers that support config validation.
+type ProviderConfig interface {
+	// ConfigSchema returns the fields defining the provider config.
+	ConfigSchema() environschema.Fields
 
 	// ValidateConfig returns an error if the new
 	//provider config is not valid.
-	ValidateConfig(oldCfg, newCfg ProviderConfig) error
+	ValidateConfig(oldCfg, newCfg ConfigAttrs) error
+}
 
+// SecretBackendProvider instances create secret backends.
+type SecretBackendProvider interface {
 	// Type is the type of the backend.
 	Type() string
 

--- a/secrets/provider/vault/config.go
+++ b/secrets/provider/vault/config.go
@@ -1,0 +1,163 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vault
+
+import (
+	"net/url"
+
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"gopkg.in/juju/environschema.v1"
+
+	coreconfig "github.com/juju/juju/core/config"
+	"github.com/juju/juju/secrets/provider"
+)
+
+const (
+	EndpointKey      = "endpoint"
+	NamespaceKey     = "namespace"
+	TokenKey         = "token"
+	CACertKey        = "ca-cert"
+	ClientCertKey    = "client-cert"
+	ClientKeyKey     = "client-key"
+	TLSServerNameKey = "tls-server-name"
+	UnsealKeysKey    = "unseal-keys"
+)
+
+var configSchema = environschema.Fields{
+	EndpointKey: {
+		Description: "The vault service endpoint.",
+		Type:        environschema.Tstring,
+		Immutable:   true,
+		Mandatory:   true,
+	},
+	TokenKey: {
+		Description: "The vault access token.",
+		Type:        environschema.Tstring,
+		Secret:      true,
+	},
+	NamespaceKey: {
+		Description: "The namespace in which to store secrets.",
+		Type:        environschema.Tstring,
+	},
+	CACertKey: {
+		Description: "The vault CA certificate.",
+		Type:        environschema.Tstring,
+	},
+	ClientCertKey: {
+		Description: "The vault client certificate.",
+		Type:        environschema.Tstring,
+	},
+	ClientKeyKey: {
+		Description: "The vault client certificate key.",
+		Type:        environschema.Tstring,
+		Secret:      true,
+	},
+	UnsealKeysKey: {
+		Description: "The keys used to unseal the vault.",
+		Type:        environschema.Tlist,
+		Secret:      true,
+	},
+	TLSServerNameKey: {
+		Description: "The vault TLS server name.",
+		Type:        environschema.Tstring,
+	},
+}
+
+var configDefaults = schema.Defaults{}
+
+type backendConfig struct {
+	validAttrs map[string]interface{}
+}
+
+func (c *backendConfig) endpoint() string {
+	return c.validAttrs[EndpointKey].(string)
+}
+
+func (c *backendConfig) namespace() string {
+	v, _ := c.validAttrs[NamespaceKey].(string)
+	return v
+}
+
+func (c *backendConfig) token() string {
+	v, _ := c.validAttrs[TokenKey].(string)
+	return v
+}
+
+func (c *backendConfig) unsealKeys() []string {
+	return c.validAttrs[UnsealKeysKey].([]string)
+}
+
+func (c *backendConfig) clientCert() string {
+	v, _ := c.validAttrs[ClientCertKey].(string)
+	return v
+}
+
+func (c *backendConfig) clientKey() string {
+	v, _ := c.validAttrs[ClientKeyKey].(string)
+	return v
+}
+
+func (c *backendConfig) caCert() string {
+	v, _ := c.validAttrs[CACertKey].(string)
+	return v
+}
+
+func (c *backendConfig) tlsServerName() string {
+	v, _ := c.validAttrs[TLSServerNameKey].(string)
+	return v
+}
+
+// ConfigSchema implements SecretBackendProvider.
+func (p vaultProvider) ConfigSchema() environschema.Fields {
+	return configSchema
+}
+
+// ValidateConfig implements SecretBackendProvider.
+func (p vaultProvider) ValidateConfig(oldCfg, newCfg provider.ConfigAttrs) error {
+	newValidCfg, err := newConfig(newCfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = url.Parse(newValidCfg.endpoint())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	clientCert := newValidCfg.clientCert()
+	clientKey := newValidCfg.clientKey()
+	if clientCert != "" && clientKey == "" {
+		return errors.NotValidf("vault config missing client key")
+	}
+	if clientCert == "" && clientKey != "" {
+		return errors.NotValidf("vault config missing client certificate")
+	}
+
+	if oldCfg == nil {
+		return nil
+	}
+	oldValidCfg, err := newConfig(oldCfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for n, field := range configSchema {
+		if !field.Immutable {
+			continue
+		}
+		oldV := oldValidCfg.validAttrs[n]
+		newV := newValidCfg.validAttrs[n]
+		if oldV != newV {
+			return errors.Errorf("cannot change config %q from %q to %q", n, oldV, newV)
+		}
+	}
+	return nil
+}
+
+func newConfig(attrs map[string]interface{}) (*backendConfig, error) {
+	cfg, err := coreconfig.NewConfig(attrs, configSchema, configDefaults)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &backendConfig{cfg.Attributes()}, nil
+}

--- a/secrets/provider/vault/config.go
+++ b/secrets/provider/vault/config.go
@@ -22,7 +22,6 @@ const (
 	ClientCertKey    = "client-cert"
 	ClientKeyKey     = "client-key"
 	TLSServerNameKey = "tls-server-name"
-	UnsealKeysKey    = "unseal-keys"
 )
 
 var configSchema = environschema.Fields{
@@ -54,11 +53,6 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Secret:      true,
 	},
-	UnsealKeysKey: {
-		Description: "The keys used to unseal the vault.",
-		Type:        environschema.Tlist,
-		Secret:      true,
-	},
 	TLSServerNameKey: {
 		Description: "The vault TLS server name.",
 		Type:        environschema.Tstring,
@@ -83,10 +77,6 @@ func (c *backendConfig) namespace() string {
 func (c *backendConfig) token() string {
 	v, _ := c.validAttrs[TokenKey].(string)
 	return v
-}
-
-func (c *backendConfig) unsealKeys() []string {
-	return c.validAttrs[UnsealKeysKey].([]string)
 }
 
 func (c *backendConfig) clientCert() string {

--- a/secrets/provider/vault/config_test.go
+++ b/secrets/provider/vault/config_test.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package vault_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/secrets/provider"
+	_ "github.com/juju/juju/secrets/provider/all"
+	jujuvault "github.com/juju/juju/secrets/provider/vault"
+)
+
+type configSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&configSuite{})
+
+func (s *configSuite) TestValidateConfig(c *gc.C) {
+	p, err := provider.Provider(jujuvault.BackendType)
+	c.Assert(err, jc.ErrorIsNil)
+	configValidator, ok := p.(provider.ProviderConfig)
+	c.Assert(ok, jc.IsTrue)
+	for _, t := range []struct {
+		cfg    map[string]interface{}
+		oldCfg map[string]interface{}
+		err    string
+	}{{
+		cfg: map[string]interface{}{},
+		err: "endpoint: expected string, got nothing",
+	}, {
+		cfg:    map[string]interface{}{"endpoint": "newep"},
+		oldCfg: map[string]interface{}{"endpoint": "oldep"},
+		err:    `cannot change config "endpoint" from "oldep" to "newep"`,
+	}, {
+		cfg: map[string]interface{}{"endpoint": "newep", "client-cert": "aaa"},
+		err: `vault config missing client key not valid`,
+	}, {
+		cfg: map[string]interface{}{"endpoint": "newep", "client-key": "aaa"},
+		err: `vault config missing client certificate not valid`,
+	}} {
+		err = configValidator.ValidateConfig(t.oldCfg, t.cfg)
+		c.Assert(err, gc.ErrorMatches, t.err)
+	}
+}

--- a/secrets/provider/vault/provider.go
+++ b/secrets/provider/vault/provider.go
@@ -174,25 +174,6 @@ func (p vaultProvider) adminConfig(m provider.Model) (*provider.BackendConfig, e
 	for k, v := range b.Config {
 		backendCfg.Config[k] = v
 	}
-	keys, _ := b.Config[UnsealKeysKey].([]string)
-	// If keys are provided, we need to unseal the vault.
-	// (If not, the vault needs to be unsealed already).
-	if len(keys) == 0 {
-		return backendCfg, nil
-	}
-
-	vaultClient, err := p.newBackend(backendCfg)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	sys := vaultClient.client.Sys()
-	for _, key := range keys {
-		_, err := sys.Unseal(key)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-
 	return backendCfg, nil
 }
 

--- a/secrets/provider/vault/provider_test.go
+++ b/secrets/provider/vault/provider_test.go
@@ -54,21 +54,6 @@ func (s *providerSuite) TestBackendConfig(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
-func (s *providerSuite) TestValidateConfig(c *gc.C) {
-	p, err := provider.Provider(jujuvault.BackendType)
-	c.Assert(err, jc.ErrorIsNil)
-	for _, t := range []struct {
-		cfg map[string]interface{}
-		err string
-	}{{
-		cfg: map[string]interface{}{},
-		err: "missing endpoint not valid",
-	}} {
-		err = p.ValidateConfig(nil, t.cfg)
-		c.Assert(err, gc.ErrorMatches, t.err)
-	}
-}
-
 func (s *providerSuite) TestNewBackend(c *gc.C) {
 	p, err := provider.Provider(jujuvault.BackendType)
 	c.Assert(err, jc.ErrorIsNil)
@@ -76,8 +61,6 @@ func (s *providerSuite) TestNewBackend(c *gc.C) {
 	cfg := &provider.BackendConfig{
 		BackendType: jujuvault.BackendType,
 		Config: map[string]interface{}{
-			"controller-uuid": coretesting.ControllerTag.Id(),
-			"model-uuid":      coretesting.ModelTag.Id(),
 			"endpoint":        "http://vault-ip:8200/",
 			"namespace":       "ns",
 			"token":           "vault-token",
@@ -122,8 +105,6 @@ func (mockModel) GetSecretBackend() (*secrets.SecretBackend, error) {
 		Name:        "myk8s",
 		BackendType: "vault",
 		Config: map[string]interface{}{
-			"controller-uuid": coretesting.ControllerTag.Id(),
-			"model-uuid":      coretesting.ModelTag.Id(),
 			"endpoint":        "http://vault-ip:8200/",
 			"namespace":       "ns",
 			"token":           "vault-token",


### PR DESCRIPTION
Secret providers now support a schema for their config attributes.
The schema is used to validate config when creating a backend and also to understand which config attributes are secret and should not be displayed by default when listing backends.

So far, this is implemented for vault. k8s backends just use the current model cluster, but we will need config when we support external k8s clusters.

Also remove unseal keys used for developers.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

bootstrap on lxd and add a vault backend

```
cat /path/to/vaultcfg.yaml
endpoint: "http://10.0.0.77:8200"
token: "hvs.OuTFPv7qV1AiyXYfwkDYRMwv"
unseal-keys:
  - r/QmaheRvVVqppU78t3cCGZnIealuGPmWc6JBfo7Gjs=

juju add-secret-backend myvault vault --config /path/to/vaultcfg.yaml
juju model-config secret-backend=myvault
juju exec --unit controller/0 "secret-add foo=bar"
secret:ce4kvahk9k63k9kjm4rg

juju show-secret secret:ce4kvahk9k63k9kjm4rg --reveal
ce4kvahk9k63k9kjm4rg:
  revision: 1
  owner: controller
  created: 2022-12-02T01:06:51Z
  updated: 2022-12-02T01:06:51Z
  content:
    foo: bar

juju secret-backends --format yaml --reveal
internal:
  name: internal
  backend: controller
  secrets: 666
myvault:
  name: myvault
  backend: vault
  config:
    endpoint: http://10.0.0.77:8200
    token: hvs.OuTFPv7qV1AiyXYfwkDYRMwv
    unseal-keys:
    - r/QmaheRvVVqppU78t3cCGZnIealuGPmWc6JBfo7Gjs=
  secrets: 666

```
check the secret is stored in vault

switch the backend
```
juju model-config secret-backend=internal
```
add a secret and get the value; check the secret is stored in mongo


do the same on a k8s model, noting that no backend config is needed - it just uses k8s out of the box.