### PR TITLE
[JUJU-2274] Adjust remove machine confirmation

### DIFF
--- a/cmd/juju/commands/machine_test.go
+++ b/cmd/juju/commands/machine_test.go
@@ -49,7 +49,7 @@ func (s *MachineSuite) TestMachineAdd(c *gc.C) {
 func (s *MachineSuite) TestMachineRemove(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
 
-	ctx, err := s.RunCommand(c, "remove-machine", machine.Id())
+	ctx, err := s.RunCommand(c, "remove-machine", "--no-prompt", machine.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), jc.Contains, `will remove machine`)
 

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -5,8 +5,6 @@ package machine
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +18,6 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -30,9 +27,8 @@ func NewRemoveCommand() cmd.Command {
 }
 
 // removeCommand causes an existing machine to be destroyed.
-// TODO(jack-w-shaw) This should inherit from ConfirmationCommandBase
-// in 3.1, once behaviours have converged
 type removeCommand struct {
+	modelcmd.ConfirmationCommandBase
 	baseMachinesCommand
 	apiRoot      api.Connection
 	machineAPI   RemoveMachineAPI
@@ -40,7 +36,6 @@ type removeCommand struct {
 	Force        bool
 	KeepInstance bool
 	NoWait       bool
-	NoPrompt     bool
 	DryRun       bool
 	fs           *gnuflag.FlagSet
 }
@@ -96,7 +91,7 @@ func (c *removeCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *removeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.NoPrompt, "no-prompt", false, "Do not prompt for approval")
+	c.ConfirmationCommandBase.SetFlags(f)
 	f.BoolVar(&c.DryRun, "dry-run", false, "Print what this command would be removed without removing")
 	f.BoolVar(&c.Force, "force", false, "Completely remove a machine and all its dependencies")
 	f.BoolVar(&c.KeepInstance, "keep-instance", false, "Do not stop the running cloud instance")
@@ -105,29 +100,15 @@ func (c *removeCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *removeCommand) Init(args []string) error {
+	if err := c.ConfirmationCommandBase.Init(args); err != nil {
+		return errors.Trace(err)
+	}
 	if len(args) == 0 {
 		return errors.Errorf("no machines specified")
 	}
 	for _, id := range args {
 		if !names.IsValidMachine(id) {
 			return errors.Errorf("invalid machine id %q", id)
-		}
-	}
-
-	// To maintain compatibility, in 3.0 NoPrompt should default to true.
-	// However, we still need to take into account the env var and the
-	// flag. So default initially to false, but if the env var and flag
-	// are not present, set to true.
-	// TODO(jack-w-shaw) use CheckSkipConfirmEnvVar in 3.1
-	if !c.NoPrompt {
-		if skipConf, ok := os.LookupEnv(osenv.JujuSkipConfirmationEnvKey); ok {
-			skipConfBool, err := strconv.ParseBool(skipConf)
-			if err != nil {
-				return errors.Annotatef(err, "value %q of env var %q is not a valid bool", skipConf, osenv.JujuSkipConfirmationEnvKey)
-			}
-			c.NoPrompt = skipConfBool
-		} else {
-			c.NoPrompt = true
 		}
 	}
 
@@ -191,7 +172,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 		return c.performDryRun(ctx, client)
 	}
 
-	if !c.NoPrompt {
+	if c.NeedsConfirmation() {
 		err := c.performDryRun(ctx, client)
 		if err == errDryRunNotSupported {
 			fmt.Fprintf(ctx.Stdout, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
@@ -208,7 +189,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	logAll := c.NoPrompt || client.BestAPIVersion() < 10
+	logAll := !c.NeedsConfirmation() || client.BestAPIVersion() < 10
 	return c.logResults(ctx, results, !logAll)
 }
 

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/cmd/cmdtest"
 	"github.com/juju/juju/cmd/juju/machine"
 	"github.com/juju/juju/cmd/juju/machine/mocks"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/testing"
@@ -130,52 +129,6 @@ func (s *RemoveMachineSuite) TestInit(c *gc.C) {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(removeCmd.Force, gc.Equals, test.force)
 			c.Check(removeCmd.KeepInstance, gc.Equals, test.keep)
-			c.Check(removeCmd.NoPrompt, gc.Equals, test.noPrompt)
-			c.Check(removeCmd.DryRun, gc.Equals, test.dryRun)
-			c.Check(removeCmd.MachineIds, jc.DeepEquals, test.machines)
-		} else {
-			c.Check(err, gc.ErrorMatches, test.errorString)
-		}
-	}
-}
-
-func (s *RemoveMachineSuite) TestInitTrueSkipConfirmationEnvVar(c *gc.C) {
-	defer s.setup(c).Finish()
-
-	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "1")
-	s.TestInit(c)
-}
-
-func (s *RemoveMachineSuite) TestInitFalseSkipConfirmationEnvVar(c *gc.C) {
-	defer s.setup(c).Finish()
-
-	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
-	for i, test := range []struct {
-		args        []string
-		machines    []string
-		force       bool
-		keep        bool
-		noPrompt    bool
-		dryRun      bool
-		errorString string
-	}{
-		{
-			args:     []string{"1"},
-			machines: []string{"1"},
-		}, {
-			args:     []string{"1", "2", "--no-prompt"},
-			machines: []string{"1", "2"},
-			noPrompt: true,
-		},
-	} {
-		c.Logf("test %d", i)
-		wrappedCommand, removeCmd := machine.NewRemoveCommandForTest(s.apiConnection, s.mockApi)
-		err := cmdtesting.InitCommand(wrappedCommand, test.args)
-		if test.errorString == "" {
-			c.Check(err, jc.ErrorIsNil)
-			c.Check(removeCmd.Force, gc.Equals, test.force)
-			c.Check(removeCmd.KeepInstance, gc.Equals, test.keep)
-			c.Check(removeCmd.NoPrompt, gc.Equals, test.noPrompt)
 			c.Check(removeCmd.DryRun, gc.Equals, test.dryRun)
 			c.Check(removeCmd.MachineIds, jc.DeepEquals, test.machines)
 		} else {
@@ -189,21 +142,12 @@ func (s *RemoveMachineSuite) TestRemove(c *gc.C) {
 
 	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, false, gomock.Any(), "1", "2/lxd/1")
 
-	_, err := s.run(c, "1", "2/lxd/1")
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *RemoveMachineSuite) TestRemoveNoPrompt(c *gc.C) {
-	defer s.setup(c).Finish()
-
-	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, false, gomock.Any(), "1", "2/lxd/1")
-
 	_, err := s.run(c, "--no-prompt", "1", "2/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *RemoveMachineSuite) TestRemoveNoWaitWithoutForce(c *gc.C) {
-	_, err := s.run(c, "1", "--no-wait")
+	_, err := s.run(c, "--no-prompt", "1", "--no-wait")
 	c.Assert(err, gc.ErrorMatches, `--no-wait without --force not valid`)
 }
 
@@ -224,7 +168,7 @@ func (s *RemoveMachineSuite) TestRemoveOutput(c *gc.C) {
 	}}
 	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, false, gomock.Any(), "1", "2/lxd/1").Return(results, nil)
 
-	ctx, err := s.run(c, "1", "2/lxd/1")
+	ctx, err := s.run(c, "--no-prompt", "1", "2/lxd/1")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	stderr := cmdtesting.Stderr(ctx)
 	stdout := cmdtesting.Stdout(ctx)
@@ -244,7 +188,7 @@ func (s *RemoveMachineSuite) TestRemoveKeep(c *gc.C) {
 
 	s.mockApi.EXPECT().DestroyMachinesWithParams(false, true, false, gomock.Any(), "1", "2")
 
-	_, err := s.run(c, "--keep-instance", "1", "2")
+	_, err := s.run(c, "--no-prompt", "--keep-instance", "1", "2")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -253,7 +197,7 @@ func (s *RemoveMachineSuite) TestRemoveOutputKeep(c *gc.C) {
 
 	s.mockApi.EXPECT().DestroyMachinesWithParams(false, true, false, gomock.Any(), "1", "2").DoAndReturn(defaultDestroyMachineResult)
 
-	ctx, err := s.run(c, "--keep-instance", "1", "2")
+	ctx, err := s.run(c, "--no-prompt", "--keep-instance", "1", "2")
 	c.Assert(err, jc.ErrorIsNil)
 	stdout := cmdtesting.Stdout(ctx)
 	c.Assert(stdout, gc.Equals, `
@@ -267,7 +211,7 @@ func (s *RemoveMachineSuite) TestRemoveForce(c *gc.C) {
 
 	s.mockApi.EXPECT().DestroyMachinesWithParams(true, false, false, gomock.Any(), "1", "2/lxd/1")
 
-	_, err := s.run(c, "--force", "1", "2/lxd/1")
+	_, err := s.run(c, "--no-prompt", "--force", "1", "2/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -292,7 +236,7 @@ func (s *RemoveMachineSuite) TestRemoveWithContainers(c *gc.C) {
 	}}
 	s.mockApi.EXPECT().DestroyMachinesWithParams(true, false, false, gomock.Any(), "1").Return(results, nil)
 
-	ctx, err := s.run(c, "--force", "1")
+	ctx, err := s.run(c, "--no-prompt", "--force", "1")
 	c.Assert(err, jc.ErrorIsNil)
 	stdout := cmdtesting.Stdout(ctx)
 	c.Assert(stdout, gc.Equals, `
@@ -342,7 +286,6 @@ func (s *RemoveMachineSuite) TestRemoveDryRunOldFacade(c *gc.C) {
 func (s *RemoveMachineSuite) TestRemovePromptOldFacade(c *gc.C) {
 	s.facadeVersion = 9
 	defer s.setup(c).Finish()
-	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
 
 	var stdin bytes.Buffer
 	ctx := cmdtesting.Context(c)
@@ -363,7 +306,6 @@ func (s *RemoveMachineSuite) TestRemovePromptOldFacade(c *gc.C) {
 
 func (s *RemoveMachineSuite) TestRemovePrompt(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
 
 	var stdin bytes.Buffer
 	ctx := cmdtesting.Context(c)
@@ -386,7 +328,6 @@ func (s *RemoveMachineSuite) TestRemovePrompt(c *gc.C) {
 func (s *RemoveMachineSuite) TestRemovePromptOldFacadeAborted(c *gc.C) {
 	s.facadeVersion = 9
 	defer s.setup(c).Finish()
-	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
 
 	ctx := cmdtesting.Context(c)
 	var stdin bytes.Buffer
@@ -405,7 +346,6 @@ func (s *RemoveMachineSuite) TestRemovePromptOldFacadeAborted(c *gc.C) {
 
 func (s *RemoveMachineSuite) TestRemovePromptAborted(c *gc.C) {
 	defer s.setup(c).Finish()
-	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
 
 	ctx := cmdtesting.Context(c)
 	var stdin bytes.Buffer
@@ -430,7 +370,7 @@ func (s *RemoveMachineSuite) TestBlockedError(c *gc.C) {
 	removeError := apiservererrors.OperationBlockedError("TestBlockedError")
 	s.mockApi.EXPECT().DestroyMachinesWithParams(false, false, false, gomock.Any(), "1").Return(nil, removeError)
 
-	_, err := s.run(c, "1")
+	_, err := s.run(c, "--no-prompt", "1")
 	testing.AssertOperationWasBlocked(c, err, ".*TestBlockedError.*")
 }
 
@@ -440,7 +380,7 @@ func (s *RemoveMachineSuite) TestForceBlockedError(c *gc.C) {
 	removeError := apiservererrors.OperationBlockedError("TestForceBlockedError")
 	s.mockApi.EXPECT().DestroyMachinesWithParams(true, false, false, gomock.Any(), "1").Return(nil, removeError)
 
-	_, err := s.run(c, "--force", "1")
+	_, err := s.run(c, "--no-prompt", "--force", "1")
 	testing.AssertOperationWasBlocked(c, err, ".*TestForceBlockedError.*")
 }
 

--- a/cmd/modelcmd/confirmation.go
+++ b/cmd/modelcmd/confirmation.go
@@ -25,10 +25,10 @@ func (c *ConfirmationCommandBase) SetFlags(f *gnuflag.FlagSet) {
 func (c *ConfirmationCommandBase) Init(args []string) error {
 	if !c.assumeNoPrompt {
 		assumeNoPrompt, skipErr := jujucmd.CheckSkipConfirmationEnvVar()
-		if skipErr != nil && !errors.Is(skipErr, errors.NotFound) {
+		if skipErr != nil && !errors.IsNotFound(skipErr) {
 			return errors.Trace(skipErr)
 		}
-		if !errors.Is(skipErr, errors.NotFound) {
+		if !errors.IsNotFound(skipErr) {
 			c.assumeNoPrompt = assumeNoPrompt
 		}
 	}

--- a/cmd/modelcmd/confirmation_test.go
+++ b/cmd/modelcmd/confirmation_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelcmd_test
+
+import (
+	"github.com/juju/cmd/v3/cmdtesting"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/juju/osenv"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type ConfirmationCommandBaseSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&ConfirmationCommandBaseSuite{})
+
+func (s *ConfirmationCommandBaseSuite) getCmdBase(args []string) modelcmd.ConfirmationCommandBase {
+	f := cmdtesting.NewFlagSet()
+	cmd := modelcmd.ConfirmationCommandBase{}
+	cmd.SetFlags(f)
+	f.Parse(true, args)
+	cmd.Init(f.Args())
+	return cmd
+}
+
+func (s *ConfirmationCommandBaseSuite) TestSimple(c *gc.C) {
+	commandBase := s.getCmdBase([]string{"--foo", "bar"})
+
+	c.Assert(commandBase.NeedsConfirmation(), jc.IsTrue)
+}
+
+func (s *ConfirmationCommandBaseSuite) TestNoPromptFlag(c *gc.C) {
+	commandBase := s.getCmdBase([]string{"--no-prompt", "--foo", "bar"})
+
+	c.Assert(commandBase.NeedsConfirmation(), jc.IsFalse)
+}
+
+func (s *ConfirmationCommandBaseSuite) TestSkipConfVarTrue(c *gc.C) {
+	for _, trueVal := range []string{"1", "t", "true", "TRUE"} {
+		s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, trueVal)
+
+		commandBase := s.getCmdBase([]string{"--foo", "bar"})
+
+		c.Assert(commandBase.NeedsConfirmation(), jc.IsFalse)
+	}
+}
+
+func (s *ConfirmationCommandBaseSuite) TestSkipConfVarFalse(c *gc.C) {
+	for _, falseVal := range []string{"0", "f", "false", "FALSE"} {
+		s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, falseVal)
+
+		commandBase := s.getCmdBase([]string{"--foo", "bar"})
+
+		c.Assert(commandBase.NeedsConfirmation(), jc.IsTrue)
+	}
+}
+
+func (s *ConfirmationCommandBaseSuite) TestPrecedence(c *gc.C) {
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	commandBase := s.getCmdBase([]string{"--no-prompt", "--foo", "bar"})
+
+	c.Assert(commandBase.NeedsConfirmation(), jc.IsFalse)
+}


### PR DESCRIPTION
Also set the default for no-prompt to be false

Re-write tests to use the new default. This has involved moving some
tests into a new test package for the ConfirmationCommandBase

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Verify remove-machine behaves as before, with the exception that confirmation prompt is shown by default