### PR TITLE
[JUJU-1921] Add GitHub smoke tests for MicroK8s

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,8 +46,8 @@ jobs:
       if: matrix.cloud == 'microk8s'
       uses: balchua/microk8s-actions@v0.3.1
       with:
-        channel: "1.23/stable"
-        addons: '["dns", "storage"]'
+        channel: "1.25/stable"
+        addons: '["dns", "hostpath-storage", "rbac"]'
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -68,7 +68,8 @@ jobs:
     - name: Update microk8s operator image
       if: matrix.cloud == 'microk8s'
       run: |
-        make microk8s-operator-update
+        # TODO: use temporary Docker account (set DOCKER_USERNAME env var)
+        sg microk8s 'make microk8s-operator-update'
 
     - name: Smoke test (LXD)
       if: matrix.cloud == 'localhost'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,6 +22,10 @@ jobs:
     name: Smoke
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        cloud: ["localhost", "microk8s"]
     steps:
 
     - name: Install Dependencies
@@ -35,7 +39,15 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup LXD
+      if: matrix.cloud == 'localhost'
       uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd
+
+    - name: Setup MicroK8s
+      if: matrix.cloud == 'microk8s'
+      uses: balchua/microk8s-actions@v0.3.1
+      with:
+        channel: "1.23/stable"
+        addons: '["dns", "storage"]'
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -53,8 +65,21 @@ jobs:
       run: |
         make go-install
 
-    - name: Smoke Test
+    - name: Update microk8s operator image
+      if: matrix.cloud == 'microk8s'
+      run: |
+        make microk8s-operator-update
+
+    - name: Smoke test (LXD)
+      if: matrix.cloud == 'localhost'
       shell: bash
       run: |
         cd tests
         ./main.sh -v -s 'test_build' smoke
+
+    - name: Smoke test (MicroK8s)
+      if: matrix.cloud == 'microk8s'
+      shell: bash
+      run: |
+        cd tests
+        sg microk8s './main.sh -c microk8s -s test_build -v smoke'

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -281,8 +281,8 @@ pre_bootstrap() {
 	fi
 
 	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
-  	export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
-  fi
+		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
+	fi
 
 	echo "BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"
 }

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -280,6 +280,10 @@ pre_bootstrap() {
 		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --bootstrap-constraints arch=${BOOTSTRAP_ARCH}"
 	fi
 
+	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
+  	export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
+  fi
+
 	echo "BOOTSTRAP_ADDITIONAL_ARGS => ${BOOTSTRAP_ADDITIONAL_ARGS}"
 }
 

--- a/tests/suites/caasadmission/task.sh
+++ b/tests/suites/caasadmission/task.sh
@@ -4,10 +4,6 @@ test_caasadmission() {
 		return
 	fi
 
-	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
-	fi
-
 	set_verbosity
 
 	case "${BOOTSTRAP_PROVIDER:-}" in

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -11,9 +11,6 @@ test_ck() {
 
 	file="${TEST_DIR}/test-ck.log"
 
-	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
-	fi
 	bootstrap "test-ck" "${file}"
 
 	test_deploy_ck

--- a/tests/suites/coslite/task.sh
+++ b/tests/suites/coslite/task.sh
@@ -11,9 +11,6 @@ test_coslite() {
 
 	file="${TEST_DIR}/test_coslite.log"
 
-	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
-	fi
 	bootstrap "test-coslite" "${file}"
 
 	case "${BOOTSTRAP_PROVIDER:-}" in

--- a/tests/suites/deploy_caas/task.sh
+++ b/tests/suites/deploy_caas/task.sh
@@ -11,9 +11,6 @@ test_deploy_caas() {
 
 	file="${TEST_DIR}/test-deploy-caas.log"
 
-	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
-	fi
 	bootstrap "test-deploy-caas" "${file}"
 
 	case "${BOOTSTRAP_PROVIDER:-}" in

--- a/tests/suites/kubeflow/task.sh
+++ b/tests/suites/kubeflow/task.sh
@@ -11,10 +11,6 @@ test_kubeflow() {
 
 	file="${TEST_DIR}/test-deploy-kubeflow.log"
 
-	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
-	fi
-
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"k8s")
 		# Charmed kubeflow 1.6 only supports k8s 1.22

--- a/tests/suites/magma/task.sh
+++ b/tests/suites/magma/task.sh
@@ -11,9 +11,6 @@ test_magma() {
 
 	file="${TEST_DIR}/test-magma.log"
 
-	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
-	fi
 	bootstrap "test-magma" "${file}"
 
 	case "${BOOTSTRAP_PROVIDER:-}" in

--- a/tests/suites/sidecar/task.sh
+++ b/tests/suites/sidecar/task.sh
@@ -4,10 +4,6 @@ test_sidecar() {
 		return
 	fi
 
-	if [[ -n ${OPERATOR_IMAGE_ACCOUNT:-} ]]; then
-		export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --config caas-image-repo=${OPERATOR_IMAGE_ACCOUNT}"
-	fi
-
 	set_verbosity
 
 	case "${BOOTSTRAP_PROVIDER:-}" in

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -18,6 +18,8 @@ run_local_deploy() {
 	# Wait for the refresh to happen and then wait again.
 	wait_for "upgrade hook ran v2" "$(workload_status "refresher" 0)"
 
+	# On microk8s, there's a bug where the application blocks the model teardown
+	# TODO: remove the next line once this bug is fixed.
 	juju remove-application refresher
 	destroy_model "test-local-deploy"
 }
@@ -35,6 +37,8 @@ run_charmstore_deploy() {
 	juju refresh ubuntu-lite
 	wait_for "ubuntu-lite" "$(idle_condition_for_rev "ubuntu-lite" "10")"
 
+	# On microk8s, there's a bug where the application blocks the model teardown
+	# TODO: remove the next line once this bug is fixed.
 	juju remove-application ubuntu-lite
 	destroy_model "test-charmstore-deploy"
 }

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -16,8 +16,9 @@ run_local_deploy() {
 	juju refresh refresher
 
 	# Wait for the refresh to happen and then wait again.
-	wait_for "upgrade hook ran v2" "$(workloadstatus "refresher" 0)"
+	wait_for "upgrade hook ran v2" "$(workload_status "refresher" 0)"
 
+	juju remove-application refresher
 	destroy_model "test-local-deploy"
 }
 
@@ -34,6 +35,7 @@ run_charmstore_deploy() {
 	juju refresh ubuntu-lite
 	wait_for "ubuntu-lite" "$(idle_condition_for_rev "ubuntu-lite" "10")"
 
+	juju remove-application ubuntu-lite
 	destroy_model "test-charmstore-deploy"
 }
 


### PR DESCRIPTION
Title.

Drive-by smoke test improvements:
- Fix typo in `workload_status`
- Call `juju remove-application` before `destroy_model`. This fixes an issue where the model teardown times out on MicroK8s because the application is still live.

## QA steps

Wait for "Smoke / Smoke (microk8s)" workflow to pass below.