### PR TITLE
[gh-actions] Cache Go dependencies/build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: Build
       run: |

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -36,6 +36,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: "Install Mongo Dependencies: ubuntu-latest"
       if: (matrix.os == 'ubuntu-latest')

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - name: go get dependencies
         run: go get ./...

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: setup env
       shell: bash

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -41,6 +41,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: setup env
       shell: bash

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -38,6 +38,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: Build snap
       shell: bash

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -41,6 +41,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: Install Dependencies
       run: |
@@ -110,6 +111,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: Install Dependencies
       if: steps.filter.outputs.schema == 'true'

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - name: setup env
         shell: bash


### PR DESCRIPTION
`actions/setup-go` has an option to cache Go build artifacts. By using this, we can shave a couple minutes off the Juju build time.