### PR TITLE
Remove unused code in destroy-model and destroy-controller cmd

### DIFF
--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -51,11 +51,10 @@ var _ = gc.Suite(&DestroySuite{})
 
 type baseDestroySuite struct {
 	testing.FakeJujuXDGDataHomeSuite
-	api        *fakeDestroyAPI
-	clientapi  *fakeDestroyAPIClient
-	storageAPI *mockStorageAPI
-	store      *jujuclient.MemStore
-	apierror   error
+	api       *fakeDestroyAPI
+	clientapi *fakeDestroyAPIClient
+	store     *jujuclient.MemStore
+	apierror  error
 
 	controllerCredentialAPI *mockCredentialAPI
 	environsDestroy         func(string, environs.ControllerDestroyer, context.ProviderCallContext, jujuclient.ControllerStore) error
@@ -176,7 +175,6 @@ func (s *baseDestroySuite) SetUpTest(c *gc.C) {
 	}
 	s.apierror = nil
 
-	s.storageAPI = &mockStorageAPI{}
 	s.controllerCredentialAPI = &mockCredentialAPI{}
 	s.environsDestroy = environs.Destroy
 
@@ -256,7 +254,7 @@ func (s *DestroySuite) runDestroyCommand(c *gc.C, args ...string) (*cmd.Context,
 
 func (s *DestroySuite) newDestroyCommand() cmd.Command {
 	return controller.NewDestroyCommandForTest(
-		s.api, s.clientapi, s.storageAPI, s.store, s.apierror,
+		s.api, s.clientapi, s.store, s.apierror,
 		func() (controller.CredentialAPI, error) { return s.controllerCredentialAPI, nil },
 		s.environsDestroy,
 	)
@@ -636,21 +634,6 @@ func (s *DestroySuite) TestDestroyWithInvalidCredentialCallbackFailingToCloseAPI
 	// As we are throwing the error on api.Close for callback,
 	// the actual call to destroy should succeed.
 	s.destroyAndInvalidateCredential(c)
-}
-
-type mockStorageAPI struct {
-	gitjujutesting.Stub
-	storage []params.StorageDetails
-}
-
-func (m *mockStorageAPI) Close() error {
-	m.MethodCall(m, "Close")
-	return m.NextErr()
-}
-
-func (m *mockStorageAPI) ListStorageDetails() ([]params.StorageDetails, error) {
-	m.MethodCall(m, "ListStorageDetails")
-	return m.storage, m.NextErr()
 }
 
 type mockCredentialAPI struct {

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -98,7 +98,6 @@ func NewEnableDestroyControllerCommandForTest(api removeBlocksAPI, store jujucli
 func NewDestroyCommandForTest(
 	api destroyControllerAPI,
 	clientapi destroyClientAPI,
-	storageAPI storageAPI,
 	store jujuclient.ClientStore,
 	apierr error,
 	controllerCredentialAPIFunc newCredentialAPIFunc,
@@ -113,7 +112,6 @@ func NewDestroyCommandForTest(
 			controllerCredentialAPIFunc: controllerCredentialAPIFunc,
 			environsDestroy:             environsDestroy,
 		},
-		storageAPI: storageAPI,
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.WrapController(

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -32,7 +32,6 @@ import (
 type DestroySuite struct {
 	testing.FakeJujuXDGDataHomeSuite
 	api             *fakeAPI
-	storageAPI      *mockStorageAPI
 	stub            *jutesting.Stub
 	budgetAPIClient *mockBudgetAPIClient
 	store           *jujuclient.MemStore
@@ -89,7 +88,6 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 	s.api = &fakeAPI{
 		Stub: s.stub,
 	}
-	s.storageAPI = &mockStorageAPI{Stub: s.stub}
 	s.clock = testclock.NewClock(time.Now())
 
 	s.store = jujuclient.NewMemStore()
@@ -109,12 +107,12 @@ func (s *DestroySuite) SetUpTest(c *gc.C) {
 }
 
 func (s *DestroySuite) runDestroyCommand(c *gc.C, args ...string) (*cmd.Context, error) {
-	command := model.NewDestroyCommandForTest(s.api, s.storageAPI, s.clock, noOpRefresh, s.store)
+	command := model.NewDestroyCommandForTest(s.api, s.clock, noOpRefresh, s.store)
 	return cmdtesting.RunCommand(c, command, args...)
 }
 
 func (s *DestroySuite) NewDestroyCommand() cmd.Command {
-	return model.NewDestroyCommandForTest(s.api, s.storageAPI, s.clock, noOpRefresh, s.store)
+	return model.NewDestroyCommandForTest(s.api, s.clock, noOpRefresh, s.store)
 }
 
 func checkModelExistsInStore(c *gc.C, name string, store jujuclient.ClientStore) {
@@ -161,7 +159,7 @@ func (s *DestroySuite) TestDestroyUnknownModelCallsRefresh(c *gc.C) {
 		return nil
 	}
 
-	command := model.NewDestroyCommandForTest(s.api, s.storageAPI, s.clock, refresh, s.store)
+	command := model.NewDestroyCommandForTest(s.api, s.clock, refresh, s.store)
 	_, err := cmdtesting.RunCommand(c, command, "foo")
 	c.Check(called, jc.IsTrue)
 	c.Check(err, gc.ErrorMatches, `model test1:admin/foo not found`)
@@ -491,16 +489,4 @@ type mockBudgetAPIClient struct {
 func (c *mockBudgetAPIClient) DeleteBudget(model string) (string, error) {
 	c.MethodCall(c, "DeleteBudget", model)
 	return "Budget removed.", c.NextErr()
-}
-
-type mockStorageAPI struct {
-	*jutesting.Stub
-	storage []params.StorageDetails
-}
-
-func (*mockStorageAPI) Close() error { return nil }
-
-func (m *mockStorageAPI) ListStorageDetails() ([]params.StorageDetails, error) {
-	m.MethodCall(m, "ListStorageDetails")
-	return m.storage, m.NextErr()
 }

--- a/cmd/juju/model/export_test.go
+++ b/cmd/juju/model/export_test.go
@@ -82,14 +82,12 @@ func NewExportBundleCommandForTest(bundleAPI ExportBundleAPI, store jujuclient.C
 // NewDestroyCommandForTest returns a DestroyCommand with the api provided as specified.
 func NewDestroyCommandForTest(
 	api DestroyModelAPI,
-	storageAPI StorageAPI,
 	clk jujuclock.Clock,
 	refreshFunc func(jujuclient.ClientStore, string) error, store jujuclient.ClientStore,
 ) cmd.Command {
 	cmd := &destroyCommand{
-		api:        api,
-		clock:      clk,
-		storageAPI: storageAPI,
+		api:   api,
+		clock: clk,
 	}
 	cmd.SetClientStore(store)
 	cmd.SetModelRefresh(refreshFunc)


### PR DESCRIPTION
It's likely some API interfaces which were used in a previous version were left behind. Remove these and cleanup the client

## QA steps

Verify juju builds correctly and unit tests pass

Also verify that destroy-model and destroy-controller still function for models/controllers with storage