### PR TITLE
Don't embed previous param versions into latest params

### DIFF
--- a/api/client/machinemanager/machinemanager.go
+++ b/api/client/machinemanager/machinemanager.go
@@ -65,13 +65,11 @@ func (client *Client) AddMachines(machineParams []params.AddMachineParams) ([]pa
 // is determined by the force and keep parameters.
 func (client *Client) DestroyMachinesWithParams(force, keep, dryRun bool, maxWait *time.Duration, machines ...string) ([]params.DestroyMachineResult, error) {
 	args := params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			Force:       force,
-			Keep:        keep,
-			MachineTags: make([]string, 0, len(machines)),
-			MaxWait:     maxWait,
-		},
-		DryRun: dryRun,
+		Force:       force,
+		Keep:        keep,
+		DryRun:      dryRun,
+		MachineTags: make([]string, 0, len(machines)),
+		MaxWait:     maxWait,
 	}
 	allResults := make([]params.DestroyMachineResult, len(machines))
 	index := make([]int, 0, len(machines))

--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -216,15 +216,13 @@ func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, max
 		basetesting.APICallerFunc(func(objType string, version int, id, request string, a, response interface{}) error {
 			c.Assert(request, gc.Equals, "DestroyMachineWithParams")
 			c.Assert(a, jc.DeepEquals, params.DestroyMachinesParams{
-				DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-					Keep:  true,
-					Force: true,
-					MachineTags: []string{
-						"machine-0",
-						"machine-0-lxd-1",
-					},
-					MaxWait: maxWait,
+				Keep:  true,
+				Force: true,
+				MachineTags: []string{
+					"machine-0",
+					"machine-0-lxd-1",
 				},
+				MaxWait: maxWait,
 			})
 			c.Assert(response, gc.FitsTypeOf, &params.DestroyMachineResults{})
 			out := response.(*params.DestroyMachineResults)

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -1163,9 +1163,7 @@ func (s *loginSuite) TestAuditLoggingUsesExcludeMethods(c *gc.C) {
 
 	// Call something else.
 	destroyReq := &params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			MachineTags: []string{addResults.Machines[0].Machine},
-		},
+		MachineTags: []string{addResults.Machines[0].Machine},
 	}
 	err = conn.APICall("MachineManager", machineManagerFacadeVersion, "", "DestroyMachineWithParams", destroyReq, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -354,10 +354,8 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedAllStorageRetrieval
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			MachineTags: []string{"machine-0"},
-			MaxWait:     &noWait,
-		},
+		MachineTags: []string{"machine-0"},
+		MaxWait:     &noWait,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -381,10 +379,8 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedSomeUnitStorageRetr
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			MachineTags: []string{"machine-0"},
-			MaxWait:     &noWait,
-		},
+		MachineTags: []string{"machine-0"},
+		MaxWait:     &noWait,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -412,10 +408,8 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineFailedSomeStorageRetrieva
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			MachineTags: []string{"machine-0", "machine-1"},
-			MaxWait:     &noWait,
-		},
+		MachineTags: []string{"machine-0", "machine-1"},
+		MaxWait:     &noWait,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -450,11 +444,9 @@ func (s *DestroyMachineManagerSuite) TestForceDestroyMachineFailedSomeStorageRet
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			Force:       true,
-			MachineTags: []string{"machine-0", "machine-1"},
-			MaxWait:     &noWait,
-		},
+		Force:       true,
+		MachineTags: []string{"machine-0", "machine-1"},
+		MaxWait:     &noWait,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -490,10 +482,8 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineDryRun(c *gc.C) {
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			MachineTags: []string{"machine-0"},
-		},
-		DryRun: true,
+		MachineTags: []string{"machine-0"},
+		DryRun:      true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -527,10 +517,8 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainersDryRun(c *g
 	s.st.EXPECT().Machine("0/lxd/0").Return(container0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			MachineTags: []string{"machine-0"},
-		},
-		DryRun: true,
+		MachineTags: []string{"machine-0"},
+		DryRun:      true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -580,12 +568,10 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNoWait(c *gc.C)
 
 	noWait := 0 * time.Second
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			Keep:        true,
-			Force:       true,
-			MachineTags: []string{"machine-0"},
-			MaxWait:     &noWait,
-		},
+		Keep:        true,
+		Force:       true,
+		MachineTags: []string{"machine-0"},
+		MaxWait:     &noWait,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -618,12 +604,10 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNilWait(c *gc.C
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			Keep:        true,
-			Force:       true,
-			MachineTags: []string{"machine-0"},
-			// This will use max wait of system default for delay between cleanup operations.
-		},
+		Keep:        true,
+		Force:       true,
+		MachineTags: []string{"machine-0"},
+		// This will use max wait of system default for delay between cleanup operations.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -656,10 +640,8 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainers(c *gc.C) {
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			Force:       false,
-			MachineTags: []string{"machine-0"},
-		},
+		Force:       false,
+		MachineTags: []string{"machine-0"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{
@@ -683,10 +665,8 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithContainersWithForce(c
 	s.st.EXPECT().Machine("0/lxd/0").Return(container0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(params.DestroyMachinesParams{
-		DestroyMachinesParamsV9: params.DestroyMachinesParamsV9{
-			Force:       true,
-			MachineTags: []string{"machine-0"},
-		},
+		Force:       true,
+		MachineTags: []string{"machine-0"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.DestroyMachineResults{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -26619,37 +26619,9 @@
                 "DestroyMachinesParams": {
                     "type": "object",
                     "properties": {
-                        "DestroyMachinesParamsV9": {
-                            "$ref": "#/definitions/DestroyMachinesParamsV9"
-                        },
                         "dry-run": {
                             "type": "boolean"
                         },
-                        "force": {
-                            "type": "boolean"
-                        },
-                        "keep": {
-                            "type": "boolean"
-                        },
-                        "machine-tags": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "max-wait": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "machine-tags",
-                        "DestroyMachinesParamsV9"
-                    ]
-                },
-                "DestroyMachinesParamsV9": {
-                    "type": "object",
-                    "properties": {
                         "force": {
                             "type": "boolean"
                         },

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -284,10 +284,17 @@ type DestroyMachinesParamsV9 struct {
 	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
-// DestroyMachinesParams holds parameters for the v9 DestroyMachinesWithParams call.
+// DestroyMachinesParams holds parameters for the latest DestroyMachinesWithParams call.
 type DestroyMachinesParams struct {
-	DestroyMachinesParamsV9
-	DryRun bool `json:"dry-run,omitempty"`
+	MachineTags []string `json:"machine-tags"`
+	Force       bool     `json:"force,omitempty"`
+	Keep        bool     `json:"keep,omitempty"`
+	DryRun      bool     `json:"dry-run,omitempty"`
+
+	// MaxWait specifies the amount of time that each step in machine destroy process
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
 // RecordAgentStartInformationArgs holds the parameters for updating the


### PR DESCRIPTION
Specifically for destroy machine params

This was mistakenly added in a previous PR

## QA steps

Verify unit tests pass

`juju remove-machine` should also work across controller versions