### PR TITLE
[JUJU-2273] Add confirmation to remove application

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1613,6 +1613,11 @@ func (api *APIBase) DestroyApplication(args params.DestroyApplicationsParams) (p
 				info.DetachedStorage = append(info.DetachedStorage, detached...)
 			}
 		}
+
+		if arg.DryRun {
+			return &info, nil
+		}
+
 		op := app.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
 		op.Force = arg.Force

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -870,31 +870,17 @@ func (s *ApplicationSuite) expectStorageInstance(ctrl *gomock.Controller, name s
 	return storageInstace
 }
 
-func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
-	ctrl := s.setup(c)
-	defer ctrl.Finish()
-
-	app := s.expectDefaultApplication(ctrl)
-	app.EXPECT().AllUnits().Return([]application.Unit{
-		s.expectUnit(ctrl, "postgresql/0"),
-		s.expectUnit(ctrl, "postgresql/1"),
-	}, nil)
-	app.EXPECT().DestroyOperation().Return(&state.DestroyApplicationOperation{})
-	s.backend.EXPECT().Application("postgresql").Return(app, nil)
-
+func (s *ApplicationSuite) expectDefaultStorageAttachments(ctrl *gomock.Controller) {
 	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/0")).Return([]state.StorageAttachment{
 		s.expectStorageAttachment(ctrl, "pgdata/0"),
 		s.expectStorageAttachment(ctrl, "pgdata/1"),
 	}, nil)
 	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/0")).Return(s.expectStorageInstance(ctrl, "pgdata/0"), nil)
 	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/1")).Return(s.expectStorageInstance(ctrl, "pgdata/1"), nil)
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/1")).Return(nil, nil)
+	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/1")).Return([]state.StorageAttachment{}, nil)
+}
 
-	s.backend.EXPECT().ApplyOperation(&state.DestroyApplicationOperation{}).Return(nil)
-
-	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
-		Applications: []params.DestroyApplicationParams{{ApplicationTag: "application-postgresql"}},
-	})
+func (s *ApplicationSuite) assertDefaultDestruction(c *gc.C, results params.DestroyApplicationResults, err error) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0], jc.DeepEquals, params.DestroyApplicationResult{
@@ -911,6 +897,30 @@ func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
 			},
 		},
 	})
+}
+
+func (s *ApplicationSuite) TestDestroyApplication(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	app := s.expectDefaultApplication(ctrl)
+	app.EXPECT().AllUnits().Return([]application.Unit{
+		s.expectUnit(ctrl, "postgresql/0"),
+		s.expectUnit(ctrl, "postgresql/1"),
+	}, nil)
+	app.EXPECT().DestroyOperation().Return(&state.DestroyApplicationOperation{})
+	s.backend.EXPECT().Application("postgresql").Return(app, nil)
+
+	s.expectDefaultStorageAttachments(ctrl)
+
+	s.backend.EXPECT().ApplyOperation(&state.DestroyApplicationOperation{}).Return(nil)
+
+	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+		Applications: []params.DestroyApplicationParams{{
+			ApplicationTag: "application-postgresql",
+		}},
+	})
+	s.assertDefaultDestruction(c, results, err)
 }
 
 func (s *ApplicationSuite) TestDestroyApplicationWithBlockChange(c *gc.C) {
@@ -942,13 +952,7 @@ func (s *ApplicationSuite) TestForceDestroyApplication(c *gc.C) {
 	app.EXPECT().DestroyOperation().Return(&state.DestroyApplicationOperation{})
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/0")).Return([]state.StorageAttachment{
-		s.expectStorageAttachment(ctrl, "pgdata/0"),
-		s.expectStorageAttachment(ctrl, "pgdata/1"),
-	}, nil)
-	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/0")).Return(s.expectStorageInstance(ctrl, "pgdata/0"), nil)
-	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/1")).Return(s.expectStorageInstance(ctrl, "pgdata/1"), nil)
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/1")).Return(nil, nil)
+	s.expectDefaultStorageAttachments(ctrl)
 
 	zero := time.Duration(0)
 
@@ -964,22 +968,7 @@ func (s *ApplicationSuite) TestForceDestroyApplication(c *gc.C) {
 			MaxWait:        &zero,
 		}},
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results.Results, gc.HasLen, 1)
-	c.Assert(results.Results[0], jc.DeepEquals, params.DestroyApplicationResult{
-		Info: &params.DestroyApplicationInfo{
-			DestroyedUnits: []params.Entity{
-				{Tag: "unit-postgresql-0"},
-				{Tag: "unit-postgresql-1"},
-			},
-			DetachedStorage: []params.Entity{
-				{Tag: "storage-pgdata-0"},
-			},
-			DestroyedStorage: []params.Entity{
-				{Tag: "storage-pgdata-1"},
-			},
-		},
-	})
+	s.assertDefaultDestruction(c, results, err)
 }
 
 func (s *ApplicationSuite) TestDestroyApplicationDestroyStorage(c *gc.C) {
@@ -994,13 +983,7 @@ func (s *ApplicationSuite) TestDestroyApplicationDestroyStorage(c *gc.C) {
 	app.EXPECT().DestroyOperation().Return(&state.DestroyApplicationOperation{})
 	s.backend.EXPECT().Application("postgresql").Return(app, nil)
 
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/0")).Return([]state.StorageAttachment{
-		s.expectStorageAttachment(ctrl, "pgdata/0"),
-		s.expectStorageAttachment(ctrl, "pgdata/1"),
-	}, nil)
-	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/0")).Return(s.expectStorageInstance(ctrl, "pgdata/0"), nil)
-	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/1")).Return(s.expectStorageInstance(ctrl, "pgdata/1"), nil)
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/1")).Return(nil, nil)
+	s.expectDefaultStorageAttachments(ctrl)
 
 	s.backend.EXPECT().ApplyOperation(&state.DestroyApplicationOperation{
 		DestroyStorage: true,
@@ -1026,6 +1009,27 @@ func (s *ApplicationSuite) TestDestroyApplicationDestroyStorage(c *gc.C) {
 			},
 		},
 	})
+}
+
+func (s *ApplicationSuite) TestDestroyApplicationDryRun(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	app := s.expectDefaultApplication(ctrl)
+	app.EXPECT().AllUnits().Return([]application.Unit{
+		s.expectUnit(ctrl, "postgresql/0"),
+		s.expectUnit(ctrl, "postgresql/1"),
+	}, nil)
+	s.backend.EXPECT().Application("postgresql").Return(app, nil)
+
+	s.expectDefaultStorageAttachments(ctrl)
+	results, err := s.api.DestroyApplication(params.DestroyApplicationsParams{
+		Applications: []params.DestroyApplicationParams{{
+			ApplicationTag: "application-postgresql",
+			DryRun:         true,
+		}},
+	})
+	s.assertDefaultDestruction(c, results, err)
 }
 
 func (s *ApplicationSuite) TestDestroyApplicationNotFound(c *gc.C) {
@@ -1129,14 +1133,6 @@ func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
 	unit0.EXPECT().IsPrincipal().Return(true)
 	unit0.EXPECT().DestroyOperation().Return(&state.DestroyUnitOperation{})
 	s.backend.EXPECT().Unit("postgresql/0").Return(unit0, nil)
-
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/0")).Return([]state.StorageAttachment{
-		s.expectStorageAttachment(ctrl, "pgdata/0"),
-		s.expectStorageAttachment(ctrl, "pgdata/1"),
-	}, nil)
-	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/0")).Return(s.expectStorageInstance(ctrl, "pgdata/0"), nil)
-	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/1")).Return(s.expectStorageInstance(ctrl, "pgdata/1"), nil)
-
 	s.backend.EXPECT().ApplyOperation(&state.DestroyUnitOperation{}).Return(nil)
 
 	// unit 1 loop
@@ -1144,10 +1140,9 @@ func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
 	unit1.EXPECT().IsPrincipal().Return(true)
 	unit1.EXPECT().DestroyOperation().Return(&state.DestroyUnitOperation{})
 	s.backend.EXPECT().Unit("postgresql/1").Return(unit1, nil)
-
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/1")).Return([]state.StorageAttachment{}, nil)
-
 	s.backend.EXPECT().ApplyOperation(&state.DestroyUnitOperation{DestroyStorage: true}).Return(nil)
+
+	s.expectDefaultStorageAttachments(ctrl)
 
 	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{
@@ -1205,13 +1200,6 @@ func (s *ApplicationSuite) TestForceDestroyUnit(c *gc.C) {
 	unit0.EXPECT().DestroyOperation().Return(&state.DestroyUnitOperation{})
 	s.backend.EXPECT().Unit("postgresql/0").Return(unit0, nil)
 
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/0")).Return([]state.StorageAttachment{
-		s.expectStorageAttachment(ctrl, "pgdata/0"),
-		s.expectStorageAttachment(ctrl, "pgdata/1"),
-	}, nil)
-	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/0")).Return(s.expectStorageInstance(ctrl, "pgdata/0"), nil)
-	s.storageAccess.EXPECT().StorageInstance(names.NewStorageTag("pgdata/1")).Return(s.expectStorageInstance(ctrl, "pgdata/1"), nil)
-
 	zero := time.Duration(0)
 	s.backend.EXPECT().ApplyOperation(&state.DestroyUnitOperation{ForcedOperation: state.ForcedOperation{
 		Force:   true,
@@ -1223,10 +1211,9 @@ func (s *ApplicationSuite) TestForceDestroyUnit(c *gc.C) {
 	unit1.EXPECT().IsPrincipal().Return(true)
 	unit1.EXPECT().DestroyOperation().Return(&state.DestroyUnitOperation{})
 	s.backend.EXPECT().Unit("postgresql/1").Return(unit1, nil)
-
-	s.storageAccess.EXPECT().UnitStorageAttachments(names.NewUnitTag("postgresql/1")).Return([]state.StorageAttachment{}, nil)
-
 	s.backend.EXPECT().ApplyOperation(&state.DestroyUnitOperation{DestroyStorage: true}).Return(nil)
+
+	s.expectDefaultStorageAttachments(ctrl)
 
 	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
 		Units: []params.DestroyUnitParams{

--- a/cmd/juju/application/mocks/applicationapi_mock.go
+++ b/cmd/juju/application/mocks/applicationapi_mock.go
@@ -115,6 +115,20 @@ func (m *MockRemoveApplicationAPI) EXPECT() *MockRemoveApplicationAPIMockRecorde
 	return m.recorder
 }
 
+// BestAPIVersion mocks base method.
+func (m *MockRemoveApplicationAPI) BestAPIVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BestAPIVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// BestAPIVersion indicates an expected call of BestAPIVersion.
+func (mr *MockRemoveApplicationAPIMockRecorder) BestAPIVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestAPIVersion", reflect.TypeOf((*MockRemoveApplicationAPI)(nil).BestAPIVersion))
+}
+
 // Close mocks base method.
 func (m *MockRemoveApplicationAPI) Close() error {
 	m.ctrl.T.Helper()

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -4,6 +4,10 @@
 package application
 
 import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -17,6 +21,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -30,6 +35,8 @@ func NewRemoveApplicationCommand() cmd.Command {
 }
 
 // removeApplicationCommand causes an existing application to be destroyed.
+// TODO(jack-w-shaw) This should inherit from ConfirmationCommandBase in
+// 3.1, once hebaviours have converged
 type removeApplicationCommand struct {
 	modelcmd.ModelCommandBase
 
@@ -39,6 +46,8 @@ type removeApplicationCommand struct {
 	DestroyStorage   bool
 	Force            bool
 	NoWait           bool
+	NoPrompt         bool
+	DryRun           bool
 	fs               *gnuflag.FlagSet
 }
 
@@ -73,6 +82,15 @@ Examples:
     juju remove-application --force --no-wait hadoop
     juju remove-application -m test-model mariadb`[1:]
 
+var removeApplicationMsgNoDryRun = `
+WARNING! This command will remove application(s) %q
+Your controller does not support a more in depth dry run
+`[1:]
+
+var removeApplicationMsgPrefix = "WARNING! This command:\n"
+
+var errDryRunNotSupported = errors.New("Your controller does not support `--dry-run`")
+
 func (c *removeApplicationCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "remove-application",
@@ -85,8 +103,8 @@ func (c *removeApplicationCommand) Info() *cmd.Info {
 func (c *removeApplicationCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	// This unused var is declared so we can pass a valid ptr into BoolVar
-	var noPromptHolder bool
-	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
+	f.BoolVar(&c.NoPrompt, "no-prompt", false, "Do not prompt for approval")
+	f.BoolVar(&c.DryRun, "dry-run", false, "Print what this command would remove without removing")
 	f.BoolVar(&c.DestroyStorage, "destroy-storage", false, "Destroy storage attached to application units")
 	f.BoolVar(&c.Force, "force", false, "Completely remove an application and all its dependencies")
 	f.BoolVar(&c.NoWait, "no-wait", false, "Rush through application removal without waiting for each individual step to complete")
@@ -105,6 +123,24 @@ func (c *removeApplicationCommand) Init(args []string) error {
 	if !c.Force && c.NoWait {
 		return errors.NotValidf("--no-wait without --force")
 	}
+
+	// To maintain compatibility, in 3.0 NoPrompt should default to true.
+	// However, we still need to take into account the env var and the
+	// flag. So default initially to false, but if the env var and flag
+	// are not present, set to true.
+	// TODO(jack-w-shaw) use CheckSkipConfirmEnvVar in 3.1
+	if !c.NoPrompt {
+		if skipConf, ok := os.LookupEnv(osenv.JujuSkipConfirmationEnvKey); ok {
+			skipConfBool, err := strconv.ParseBool(skipConf)
+			if err != nil {
+				return errors.Annotatef(err, "value %q of env var %q is not a valid bool", skipConf, osenv.JujuSkipConfirmationEnvKey)
+			}
+			c.NoPrompt = skipConfBool
+		} else {
+			c.NoPrompt = true
+		}
+	}
+
 	c.ApplicationNames = args
 	return nil
 }
@@ -115,6 +151,7 @@ type RemoveApplicationAPI interface {
 	DestroyApplications(application.DestroyApplicationsParams) ([]params.DestroyApplicationResult, error)
 	DestroyUnits(application.DestroyUnitsParams) ([]params.DestroyUnitResult, error)
 	ModelUUID() string
+	BestAPIVersion() int
 }
 
 type storageAPI interface {
@@ -193,6 +230,22 @@ func (c *removeApplicationCommand) removeApplications(
 		maxWait = &zeroSec
 	}
 
+	if c.DryRun {
+		return c.performDryRun(ctx, client)
+	}
+
+	if !c.NoPrompt {
+		err := c.performDryRun(ctx, client)
+		if err == errDryRunNotSupported {
+			fmt.Fprintf(ctx.Stdout, removeApplicationMsgNoDryRun, strings.Join(c.ApplicationNames, ", "))
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+		if err := jujucmd.UserConfirmYes(ctx); err != nil {
+			return errors.Annotate(err, "application removal")
+		}
+	}
+
 	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
 		Applications:   c.ApplicationNames,
 		DestroyStorage: c.DestroyStorage,
@@ -203,46 +256,99 @@ func (c *removeApplicationCommand) removeApplications(
 	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
 		return errors.Trace(err)
 	}
+	logAll := c.NoPrompt || client.BestAPIVersion() < 16
+	return c.logResults(ctx, results, !logAll)
+}
+
+func (c *removeApplicationCommand) performDryRun(
+	ctx *cmd.Context,
+	client RemoveApplicationAPI,
+) error {
+	// TODO(jack-w-shaw) Drop this once application 15 support is dropped
+	if client.BestAPIVersion() < 16 {
+		return errDryRunNotSupported
+	}
+	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
+		Applications: c.ApplicationNames,
+		DryRun:       true,
+	})
+	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
+		return errors.Trace(err)
+	}
+	fmt.Fprintf(ctx.Stdout, removeApplicationMsgPrefix)
+	if err := c.logResults(ctx, results, false); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *removeApplicationCommand) logResults(
+	ctx *cmd.Context,
+	results []params.DestroyApplicationResult,
+	errorsOnly bool,
+) error {
 	anyFailed := false
 	for i, name := range c.ApplicationNames {
 		result := results[i]
-		if result.Error != nil {
+		if err := c.logResult(ctx, name, result, errorsOnly); err != nil {
 			anyFailed = true
-			err := result.Error.Error()
-			if params.IsCodeNotSupported(result.Error) {
-				err = errors.New("another user was updating application; please try again").Error()
-			}
-			ctx.Infof("removing application %s failed: %s", name, err)
-			continue
-		}
-		ctx.Infof("removing application %s", name)
-		for _, entity := range result.Info.DestroyedUnits {
-			unitTag, err := names.ParseUnitTag(entity.Tag)
-			if err != nil {
-				logger.Warningf("%s", err)
-				continue
-			}
-			ctx.Verbosef("- will remove %s", names.ReadableString(unitTag))
-		}
-		for _, entity := range result.Info.DestroyedStorage {
-			storageTag, err := names.ParseStorageTag(entity.Tag)
-			if err != nil {
-				logger.Warningf("%s", err)
-				continue
-			}
-			ctx.Infof("- will remove %s", names.ReadableString(storageTag))
-		}
-		for _, entity := range result.Info.DetachedStorage {
-			storageTag, err := names.ParseStorageTag(entity.Tag)
-			if err != nil {
-				logger.Warningf("%s", err)
-				continue
-			}
-			ctx.Infof("- will detach %s", names.ReadableString(storageTag))
 		}
 	}
 	if anyFailed {
 		return cmd.ErrSilent
 	}
 	return nil
+}
+
+func (c *removeApplicationCommand) logResult(
+	ctx *cmd.Context,
+	name string,
+	result params.DestroyApplicationResult,
+	errorsOnly bool,
+) error {
+	if result.Error != nil {
+		var err error = result.Error
+		if params.IsCodeNotSupported(result.Error) {
+			err = errors.New("another user was updating application; please try again")
+		}
+		err = errors.Annotatef(err, "removing application %s failed", name)
+		fmt.Fprintf(ctx.Stderr, "%s\n", err)
+		return errors.Trace(err)
+	}
+	if !errorsOnly {
+		c.logRemovedApplication(ctx, name, result)
+	}
+	return nil
+}
+
+func (c *removeApplicationCommand) logRemovedApplication(
+	ctx *cmd.Context,
+	name string,
+	result params.DestroyApplicationResult,
+) {
+	fmt.Fprintf(ctx.Stdout, "will remove application %s\n", name)
+	for _, entity := range result.Info.DestroyedUnits {
+		unitTag, err := names.ParseUnitTag(entity.Tag)
+		if err != nil {
+			logger.Warningf("%s", err)
+			continue
+		}
+		fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(unitTag))
+	}
+	for _, entity := range result.Info.DestroyedStorage {
+		storageTag, err := names.ParseStorageTag(entity.Tag)
+		if err != nil {
+			logger.Warningf("%s", err)
+			continue
+		}
+		fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(storageTag))
+	}
+	for _, entity := range result.Info.DetachedStorage {
+		storageTag, err := names.ParseStorageTag(entity.Tag)
+		if err != nil {
+			logger.Warningf("%s", err)
+			continue
+		}
+		fmt.Fprintf(ctx.Stdout, "- will detach %s\n", names.ReadableString(storageTag))
+	}
 }

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -237,7 +237,7 @@ func (c *removeApplicationCommand) removeApplications(
 	if !c.NoPrompt {
 		err := c.performDryRun(ctx, client)
 		if err == errDryRunNotSupported {
-			fmt.Fprintf(ctx.Stdout, removeApplicationMsgNoDryRun, strings.Join(c.ApplicationNames, ", "))
+			fmt.Fprintf(ctx.Stderr, removeApplicationMsgNoDryRun, strings.Join(c.ApplicationNames, ", "))
 		} else if err != nil {
 			return errors.Trace(err)
 		}
@@ -275,7 +275,7 @@ func (c *removeApplicationCommand) performDryRun(
 	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
 		return errors.Trace(err)
 	}
-	fmt.Fprintf(ctx.Stdout, removeApplicationMsgPrefix)
+	fmt.Fprintf(ctx.Stderr, removeApplicationMsgPrefix)
 	if err := c.logResults(ctx, results, false); err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -4,6 +4,9 @@
 package application
 
 import (
+	"bytes"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -13,14 +16,21 @@ import (
 
 	apiapplication "github.com/juju/juju/api/client/application"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/cmd/cmdtest"
 	"github.com/juju/juju/cmd/juju/application/mocks"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/testing"
 )
 
 type removeApplicationSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
 	mockApi *mocks.MockRemoveApplicationAPI
+
+	facadeVersion int
 
 	apiFunc func() (RemoveApplicationAPI, error)
 	store   *jujuclient.MemStore
@@ -29,15 +39,18 @@ type removeApplicationSuite struct {
 var _ = gc.Suite(&removeApplicationSuite{})
 
 func (s *removeApplicationSuite) SetUpTest(c *gc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.store = jujuclienttesting.MinimalStore()
 	s.apiFunc = func() (RemoveApplicationAPI, error) {
 		return s.mockApi, nil
 	}
+	s.facadeVersion = 16
 }
 
 func (s *removeApplicationSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.mockApi = mocks.NewMockRemoveApplicationAPI(ctrl)
+	s.mockApi.EXPECT().BestAPIVersion().Return(s.facadeVersion).AnyTimes()
 	s.mockApi.EXPECT().Close()
 
 	return ctrl
@@ -47,7 +60,12 @@ func (s *removeApplicationSuite) runRemoveApplication(c *gc.C, args ...string) (
 	return cmdtesting.RunCommand(c, NewRemoveApplicationCommandForTest(s.apiFunc, s.store), args...)
 }
 
-func (s *removeApplicationSuite) TestForceFlagUnset(c *gc.C) {
+func (s *removeApplicationSuite) runWithContext(ctx *cmd.Context, args ...string) (chan dummy.Operation, chan error) {
+	remove := NewRemoveApplicationCommandForTest(s.apiFunc, s.store)
+	return cmdtest.RunCommandWithDummyProvider(ctx, remove, args...)
+}
+
+func (s *removeApplicationSuite) TestRemoveApplication(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.mockApi.EXPECT().DestroyApplications(apiapplication.DestroyApplicationsParams{
@@ -59,11 +77,11 @@ func (s *removeApplicationSuite) TestForceFlagUnset(c *gc.C) {
 	ctx, err := s.runRemoveApplication(c, "real-app")
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "removing application real-app\n")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "will remove application real-app\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
-func (s *removeApplicationSuite) TestForceFlagSet(c *gc.C) {
+func (s *removeApplicationSuite) TestRemoveApplicationForce(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.mockApi.EXPECT().DestroyApplications(apiapplication.DestroyApplicationsParams{
@@ -76,8 +94,105 @@ func (s *removeApplicationSuite) TestForceFlagSet(c *gc.C) {
 	ctx, err := s.runRemoveApplication(c, "real-app", "--force")
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "removing application real-app\n")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "will remove application real-app\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+}
+
+func (s *removeApplicationSuite) TestRemoveApplicationDryRun(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.mockApi.EXPECT().DestroyApplications(apiapplication.DestroyApplicationsParams{
+		Applications: []string{"real-app"},
+		DryRun:       true,
+	}).Return([]params.DestroyApplicationResult{{
+		Info: &params.DestroyApplicationInfo{},
+	}}, nil)
+
+	ctx, err := s.runRemoveApplication(c, "real-app", "--dry-run")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+WARNING! This command:
+will remove application real-app
+`[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+}
+
+func (s *removeApplicationSuite) TestRemoveApplicationDryRunOldFacade(c *gc.C) {
+	s.facadeVersion = 15
+	defer s.setup(c).Finish()
+
+	_, err := s.runRemoveApplication(c, "real-app", "--dry-run")
+
+	c.Assert(err, gc.ErrorMatches, "Your controller does not support `--dry-run`")
+}
+
+func (s *removeApplicationSuite) TestRemoveApplicationPrompt(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	var stdin bytes.Buffer
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = &stdin
+
+	s.mockApi.EXPECT().DestroyApplications(apiapplication.DestroyApplicationsParams{
+		Applications: []string{"real-app"},
+		DryRun:       true,
+	}).Return([]params.DestroyApplicationResult{{
+		Info: &params.DestroyApplicationInfo{},
+	}}, nil)
+	s.mockApi.EXPECT().DestroyApplications(apiapplication.DestroyApplicationsParams{
+		Applications: []string{"real-app"},
+	}).Return([]params.DestroyApplicationResult{{
+		Info: &params.DestroyApplicationInfo{},
+	}}, nil)
+
+	stdin.WriteString("y")
+	_, errc := s.runWithContext(ctx, "real-app")
+
+	select {
+	case err := <-errc:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("command took too long")
+	}
+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
+(?s)WARNING! This command:
+will remove application real-app
+.*`[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+}
+
+func (s *removeApplicationSuite) TestRemoveApplicationPromptOldFacade(c *gc.C) {
+	s.facadeVersion = 15
+	defer s.setup(c).Finish()
+
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	var stdin bytes.Buffer
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = &stdin
+
+	s.mockApi.EXPECT().DestroyApplications(apiapplication.DestroyApplicationsParams{
+		Applications: []string{"real-app"},
+	}).Return([]params.DestroyApplicationResult{{
+		Info: &params.DestroyApplicationInfo{},
+	}}, nil)
+
+	stdin.WriteString("y")
+	_, errc := s.runWithContext(ctx, "real-app")
+
+	select {
+	case err := <-errc:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("command took too long")
+	}
+
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `(?s).*Your controller does not support a more in depth dry run.*`)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func setupRace(raceyApplications []string) func(args apiapplication.DestroyApplicationsParams) ([]params.DestroyApplicationResult, error) {
@@ -106,8 +221,8 @@ func (s *removeApplicationSuite) TestHandlingNotSupportedDoesNotAffectBaseCase(c
 	ctx, err := s.runRemoveApplication(c, "real-app")
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "removing application real-app\n")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "will remove application real-app\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (s *removeApplicationSuite) TestHandlingNotSupported(c *gc.C) {
@@ -120,10 +235,10 @@ func (s *removeApplicationSuite) TestHandlingNotSupported(c *gc.C) {
 	ctx, err := s.runRemoveApplication(c, "do-not-remove")
 
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ""+
-		"removing application do-not-remove failed: "+
-		"another user was updating application; please try again\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+removing application do-not-remove failed: another user was updating application; please try again
+`[1:])
 }
 
 func (s *removeApplicationSuite) TestHandlingNotSupportedMultipleApps(c *gc.C) {
@@ -136,12 +251,13 @@ func (s *removeApplicationSuite) TestHandlingNotSupportedMultipleApps(c *gc.C) {
 	ctx, err := s.runRemoveApplication(c, "real-app", "do-not-remove", "another")
 
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, ""+
-		"removing application real-app\n"+
-		"removing application do-not-remove failed: "+
-		"another user was updating application; please try again\n"+
-		"removing application another\n")
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+will remove application real-app
+will remove application another
+`[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
+removing application do-not-remove failed: another user was updating application; please try again
+`[1:])
 }
 
 func (s *removeApplicationSuite) TestDetachStorage(c *gc.C) {
@@ -158,9 +274,9 @@ func (s *removeApplicationSuite) TestDetachStorage(c *gc.C) {
 	ctx, err := s.runRemoveApplication(c, "storage-app")
 
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := cmdtesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, `
-removing application storage-app
+	stdout := cmdtesting.Stdout(ctx)
+	c.Assert(stdout, gc.Equals, `
+will remove application storage-app
 - will detach storage data/0
 - will detach storage data/1
 - will detach storage data/2
@@ -183,9 +299,9 @@ func (s *removeApplicationSuite) TestDestroyStorage(c *gc.C) {
 	ctx, err := s.runRemoveApplication(c, "storage-app", "--destroy-storage")
 
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := cmdtesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, `
-removing application storage-app
+	stdout := cmdtesting.Stdout(ctx)
+	c.Assert(stdout, gc.Equals, `
+will remove application storage-app
 - will remove storage data/0
 - will remove storage data/1
 - will remove storage data/2

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -111,11 +111,12 @@ func (s *removeApplicationSuite) TestRemoveApplicationDryRun(c *gc.C) {
 	ctx, err := s.runRemoveApplication(c, "real-app", "--dry-run")
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
 WARNING! This command:
+`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 will remove application real-app
 `[1:])
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (s *removeApplicationSuite) TestRemoveApplicationDryRunOldFacade(c *gc.C) {
@@ -158,11 +159,12 @@ func (s *removeApplicationSuite) TestRemoveApplicationPrompt(c *gc.C) {
 		c.Fatal("command took too long")
 	}
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `
 (?s)WARNING! This command:
-will remove application real-app
+`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
+(?s)will remove application real-app
 .*`[1:])
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }
 
 func (s *removeApplicationSuite) TestRemoveApplicationPromptOldFacade(c *gc.C) {
@@ -191,8 +193,7 @@ func (s *removeApplicationSuite) TestRemoveApplicationPromptOldFacade(c *gc.C) {
 		c.Fatal("command took too long")
 	}
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `(?s).*Your controller does not support a more in depth dry run.*`)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `(?s).*Your controller does not support a more in depth dry run.*`)
 }
 
 func setupRace(raceyApplications []string) func(args apiapplication.DestroyApplicationsParams) ([]params.DestroyApplicationResult, error) {

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -135,6 +135,6 @@ func (s *cmdApplicationSuite) TestRemoveApplication(c *gc.C) {
 
 	ctx, err := cmdtesting.RunCommand(c, application.NewRemoveApplicationCommand(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "removing application wordpress\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "removing application wordpress\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }

--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -135,6 +135,6 @@ func (s *cmdApplicationSuite) TestRemoveApplication(c *gc.C) {
 
 	ctx, err := cmdtesting.RunCommand(c, application.NewRemoveApplicationCommand(), "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "removing application wordpress\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "will remove application wordpress\n")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 }


### PR DESCRIPTION
Implement the dry-run option for DestroyApplication on the apiserver to generate a preview of what is about to be destroyed

For free we also get a dry-run flag

Also, as a flyby, touch up some application tests

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

With both a new and old controller, verify the following commands act as expected

```sh
juju remove-application
juju remove-application --dry-run
juju remove-application --no-prompt
JUJU_SKIP_CONFIRMATION juju remove-application
```

Make sure some of these applications have multiple units, and/or storage attachments