### PR TITLE
[JUJU-2302] Adds support for ubuntu pro images with google cloud provider

### DIFF
--- a/provider/gce/environ_broker.go
+++ b/provider/gce/environ_broker.go
@@ -138,9 +138,12 @@ func (env *environ) imageURLBase(os jujuos.OSType) (string, error) {
 
 	switch os {
 	case jujuos.Ubuntu:
-		if env.Config().ImageStream() == "daily" {
+		switch env.Config().ImageStream() {
+		case "daily":
 			base = ubuntuDailyImageBasePath
-		} else {
+		case "pro":
+			base = ubuntuProImageBasePath
+		default:
 			base = ubuntuImageBasePath
 		}
 	case jujuos.Windows:

--- a/provider/gce/environ_broker_test.go
+++ b/provider/gce/environ_broker_test.go
@@ -284,6 +284,15 @@ func (s *environBrokerSuite) TestSettingImageStreamsViaConfigToDaily(c *gc.C) {
 	c.Check(c.GetTestLog(), jc.Contains, gce.UbuntuDailyImageBasePath)
 }
 
+func (s *environBrokerSuite) TestSettingImageStreamsViaConfigToPro(c *gc.C) {
+	s.FakeConn.Inst = s.BaseInstance
+	s.UpdateConfig(c, map[string]interface{}{"image-stream": "pro"})
+	result, err := gce.NewRawInstance(s.Env, s.CallCtx, s.StartInstArgs, s.spec)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, gc.NotNil)
+	c.Check(c.GetTestLog(), jc.Contains, gce.UbuntuProImageBasePath)
+}
+
 func (s *environBrokerSuite) TestSettingBaseImagePathOverwritesImageStreams(c *gc.C) {
 	s.FakeConn.Inst = s.BaseInstance
 	s.UpdateConfig(c, map[string]interface{}{

--- a/provider/gce/export_test.go
+++ b/provider/gce/export_test.go
@@ -19,6 +19,7 @@ var (
 	GetDisks                                          = getDisks
 	UbuntuImageBasePath                               = ubuntuImageBasePath
 	UbuntuDailyImageBasePath                          = ubuntuDailyImageBasePath
+	UbuntuProImageBasePath                            = ubuntuProImageBasePath
 	WindowsImageBasePath                              = windowsImageBasePath
 )
 

--- a/provider/gce/gce.go
+++ b/provider/gce/gce.go
@@ -25,6 +25,7 @@ const (
 	// simplestreams)?
 	ubuntuImageBasePath      = "projects/ubuntu-os-cloud/global/images/"
 	ubuntuDailyImageBasePath = "projects/ubuntu-os-cloud-devel/global/images/"
+	ubuntuProImageBasePath   = "projects/ubuntu-os-pro-cloud/global/images/"
 	windowsImageBasePath     = "projects/windows-cloud/global/images/"
 )
 


### PR DESCRIPTION
This PR defines a new image base path, which is selected by `image-stream="pro"` in the model config.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
go test ./provider/gce/...

juju bootstrap google gcp
juju model-config image-stream="pro"
juju metadata add-image --series jammy ubuntu-pro-2204-jammy-v20221123 --stream pro
juju deploy ubuntu --series jammy
```

## Bug reference

[*LP1997575*](https://bugs.launchpad.net/juju/+bug/1997575)
