### PR TITLE
Change output of prompts/warnings to stderr

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -39,7 +39,7 @@ func IsUserAbortedError(err error) bool {
 // UserConfirmYes returns an error if we do not read a "y" or "yes" from user
 // input.
 func UserConfirmYes(ctx *cmd.Context) error {
-	fmt.Fprint(ctx.Stdout, yesNoMsg)
+	fmt.Fprint(ctx.Stderr, yesNoMsg)
 	scanner := bufio.NewScanner(ctx.Stdin)
 	scanner.Scan()
 	err := scanner.Err()
@@ -56,7 +56,7 @@ func UserConfirmYes(ctx *cmd.Context) error {
 // UserConfirmName returns an error if we do not read a "name" of the model/controller/etc from user
 // input.
 func UserConfirmName(verificationName string, objectType string, ctx *cmd.Context) error {
-	fmt.Fprintf(ctx.Stdout, nameVerificationMsg, objectType)
+	fmt.Fprintf(ctx.Stderr, nameVerificationMsg, objectType)
 	scanner := bufio.NewScanner(ctx.Stdin)
 	scanner.Scan()
 	err := scanner.Err()

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -161,7 +161,7 @@ func (s *removeApplicationSuite) TestRemoveApplicationPrompt(c *gc.C) {
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `
 (?s)WARNING! This command:
-`[1:])
+.*`[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
 (?s)will remove application real-app
 .*`[1:])

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -109,7 +109,7 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
-		fmt.Fprintf(ctx.Stdout, unregisterMsg, c.controllerName)
+		fmt.Fprintf(ctx.Stderr, unregisterMsg, c.controllerName)
 		if err := jujucmd.UserConfirmName(c.controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "unregistering controller")
 		}

--- a/cmd/juju/controller/unregister_test.go
+++ b/cmd/juju/controller/unregister_test.go
@@ -91,10 +91,10 @@ you register it again.
 To continue, enter the name of the controller to be destroyed: `[1:]
 
 func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
-	var stdin, stdout bytes.Buffer
+	var stdin, stderr bytes.Buffer
 	ctx, err := cmd.DefaultContext()
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.Stdout = &stdout
+	ctx.Stderr = &stderr
 	ctx.Stdin = &stdin
 
 	// Ensure confirmation is requested if "-y" is not specified.
@@ -107,7 +107,7 @@ func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(cmdtesting.Stdout(ctx), gc.Equals, unregisterMsg)
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, unregisterMsg)
 	c.Check(s.store.lookupName, gc.Equals, "fake1")
 	c.Check(s.store.removedName, gc.Equals, "")
 }

--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -149,7 +149,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if !c.assumeYes && c.force {
-		fmt.Fprintf(ctx.Stdout, removeOfferMsg, strings.Join(c.offers, ", "))
+		fmt.Fprintf(ctx.Stderr, removeOfferMsg, strings.Join(c.offers, ", "))
 
 		if err := jujucmd.UserConfirmYes(ctx); err != nil {
 			return errors.Annotate(err, "offer removal")

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -96,7 +96,6 @@ func (s *removeSuite) TestRemoveForceMessage(c *gc.C) {
 	err = cmdtesting.InitCommand(com, []string{"fred/model.db2", "--force"})
 	c.Assert(err, jc.ErrorIsNil)
 	com.Run(ctx)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 
 	expected := `
 WARNING! This command will remove offers: fred/model.db2
@@ -104,7 +103,7 @@ This includes all relations to those offers.
 
 Continue [y/N]? `[1:]
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expected)
 }
 
 func (s *removeSuite) TestRemoveNameOnly(c *gc.C) {

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -194,7 +194,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	if !c.NoPrompt {
 		err := c.performDryRun(ctx, client)
 		if err == errDryRunNotSupported {
-			fmt.Fprintf(ctx.Stdout, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
+			fmt.Fprintf(ctx.Stderr, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
 		} else if err != nil {
 			return errors.Trace(err)
 		}
@@ -221,7 +221,7 @@ func (c *removeCommand) performDryRun(ctx *cmd.Context, client RemoveMachineAPI)
 	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
 		return errors.Trace(err)
 	}
-	fmt.Fprint(ctx.Stdout, removeMachineMsgPrefix)
+	fmt.Fprint(ctx.Stderr, removeMachineMsgPrefix)
 	if err := c.logResults(ctx, results, false); err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -323,9 +323,12 @@ func (s *RemoveMachineSuite) TestRemoveOutputDryRun(c *gc.C) {
 
 	ctx, err := s.run(c, "--dry-run", "1", "2")
 	c.Assert(err, jc.ErrorIsNil)
+	stderr := cmdtesting.Stderr(ctx)
 	stdout := cmdtesting.Stdout(ctx)
-	c.Assert(stdout, gc.Equals, `
+	c.Assert(stderr, gc.Equals, `
 WARNING! This command:
+`[1:])
+	c.Assert(stdout, gc.Equals, `
 will remove machine 1
 will remove machine 2
 `[1:])

--- a/cmd/juju/machine/upgrademachine_test.go
+++ b/cmd/juju/machine/upgrademachine_test.go
@@ -211,7 +211,7 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesAbbreviation(c *gc
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldPromptUserForConfirmation(c *gc.C) {
 	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", machineArg, machine.PrepareCommand, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), jc.HasSuffix, "Continue [y/N]? ")
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Matches, `(?s).*Continue \[y\/N\]\? .*`)
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldIndicateOnlySubordinatesOnMachine(c *gc.C) {

--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -153,9 +153,9 @@ func (c *RemoveCommand) handleForceOption(api SpaceAPI, currentModel string, ctx
 
 	errorList := buildRemoveErrorList(result, currentModel)
 	if len(errorList) == 0 {
-		fmt.Fprintf(ctx.Stdout, removeSpaceMsgNoBounds)
+		fmt.Fprintf(ctx.Stderr, removeSpaceMsgNoBounds)
 	} else {
-		fmt.Fprintf(ctx.Stdout, removeSpaceMsgBounds, strings.Join(errorList, "\n"))
+		fmt.Fprintf(ctx.Stderr, removeSpaceMsgBounds, strings.Join(errorList, "\n"))
 	}
 	if err := jujucmd.UserConfirmYes(ctx); err != nil {
 		return errors.Annotate(err, "space removal")

--- a/cmd/juju/space/remove_test.go
+++ b/cmd/juju/space/remove_test.go
@@ -144,7 +144,7 @@ Continue [y/N]? `[1:]
 
 	ctx, _, err := s.runCommand(c, api, spaceName, "--force")
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedErrMsg)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedErrMsg)
 	c.Assert(err, gc.ErrorMatches, `cannot remove space "myspace": space removal: aborted`)
 }
 
@@ -191,7 +191,7 @@ Continue [y/N]? `[1:]
 
 	ctx, _, err := s.runCommand(c, api, spaceName, "--force")
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedErrMsg)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedErrMsg)
 	c.Assert(err, gc.ErrorMatches, `cannot remove space "default": space removal: aborted`)
 }
 


### PR DESCRIPTION
The confirmation prompt text isn't an essential to the command itself. It's more of a side-effect, so it's output should go to stderr

Also, the WARNING line for remove-machine --dry-run should go to stderr. The main output of the dry-run still goes to stdout

## QA steps

Verify unit tests pass and
```
JUJU_SKIP_CONFIRMATION=0 juju destroy-model
JUJU_SKIP_CONFIRMATION=0 juju remove-machine
```
both output prompts as expected to stderr. 
