### PR TITLE
[JUJU-2340] Fixes upgrade bugs for sidecar charms in 2.9

### DIFF
--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -4,6 +4,8 @@
 package caasapplicationprovisioner
 
 import (
+	"fmt"
+
 	"github.com/juju/charm/v8"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -114,6 +116,30 @@ func (c *Client) Life(entityName string) (life.Value, error) {
 		return "", maybeNotFound(err)
 	}
 	return results.Results[0].Life, nil
+}
+
+func (c *Client) WatchProvisioningInfo(applicationName string) (watcher.NotifyWatcher, error) {
+	args := params.Entities{
+		Entities: []params.Entity{
+			{Tag: names.NewApplicationTag(applicationName).String()},
+		},
+	}
+	var results params.NotifyWatchResults
+
+	if err := c.facade.FacadeCall("WatchProvisioningInfo", args, &results); err != nil {
+		return nil, err
+	}
+
+	if len(results.Results) != 1 {
+		return nil, fmt.Errorf("expected 1 result when watching provisioning info for application %q", applicationName)
+	}
+
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result), nil
 }
 
 // ProvisioningInfo holds the info needed to provision an operator.

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -201,6 +201,57 @@ func (a *API) WatchApplications() (params.StringsWatchResult, error) {
 	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
 }
 
+// WatchProvisioningInfo provides a watcher for changes that affect the
+// information returned by ProvisioningInfo. This is useful for ensuring the
+// latest application stated is ensured.
+func (a *API) WatchProvisioningInfo(args params.Entities) (params.NotifyWatchResults, error) {
+	var result params.NotifyWatchResults
+	result.Results = make([]params.NotifyWatchResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		appName, err := names.ParseApplicationTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		res, err := a.watchProvisioningInfo(appName)
+		if err != nil {
+			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		result.Results[i].NotifyWatcherId = res.NotifyWatcherId
+	}
+	return result, nil
+}
+
+func (a *API) watchProvisioningInfo(appName names.ApplicationTag) (params.NotifyWatchResult, error) {
+	result := params.NotifyWatchResult{}
+	app, err := a.state.Application(appName.Id())
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	model, err := a.state.Model()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	modelConfigWatcher := model.WatchForModelConfigChanges()
+	appWatcher := app.Watch()
+	controllerConfigWatcher := a.ctrlSt.WatchControllerConfig()
+
+	multiWatcher := common.NewMultiNotifyWatcher(appWatcher, controllerConfigWatcher, modelConfigWatcher)
+
+	if _, ok := <-multiWatcher.Changes(); ok {
+		result.NotifyWatcherId = a.resources.Register(multiWatcher)
+	} else {
+		return result, watcher.EnsureErr(multiWatcher)
+	}
+
+	return result, nil
+}
+
 // ProvisioningInfo returns the info needed to provision a caas application.
 func (a *API) ProvisioningInfo(args params.Entities) (params.CAASApplicationProvisioningInfoResults, error) {
 	var result params.CAASApplicationProvisioningInfoResults

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -38,12 +38,14 @@ type CAASApplicationControllerState interface {
 	ModelUUID() string
 	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
+	WatchControllerConfig() state.NotifyWatcher
 }
 
 type Model interface {
 	UUID() string
 	ModelConfig() (*config.Config, error)
 	Containers(providerIds ...string) ([]state.CloudContainer, error)
+	WatchForModelConfigChanges() state.NotifyWatcher
 }
 
 type Application interface {
@@ -63,6 +65,7 @@ type Application interface {
 	ApplicationConfig() (coreconfig.ConfigAttributes, error)
 	GetScale() int
 	ClearResources() error
+	Watch() state.NotifyWatcher
 	WatchUnits() state.StringsWatcher
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6875,6 +6875,18 @@
                     },
                     "description": "WatchApplications starts a StringsWatcher to watch applications\ndeployed to this model."
                 },
+                "WatchProvisioningInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    },
+                    "description": "WatchProvisioningInfo provides a watcher for changes that affect the\ninformation returned by ProvisioningInfo. This is useful for ensuring the\nlatest application stated is ensured."
+                },
                 "WatchUnits": {
                     "type": "object",
                     "properties": {

--- a/caas/application.go
+++ b/caas/application.go
@@ -39,9 +39,6 @@ type Application interface {
 	// Service returns the service associated with the application.
 	Service() (*Service, error)
 
-	// Upgrade upgrades the app to the specified version.
-	Upgrade(version.Number) error
-
 	ServiceInterface
 }
 

--- a/caas/kubernetes/provider/application.go
+++ b/caas/kubernetes/provider/application.go
@@ -4,10 +4,6 @@
 package provider
 
 import (
-	"github.com/juju/errors"
-	"github.com/juju/names/v4"
-	"github.com/juju/version/v2"
-
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/application"
 )
@@ -25,16 +21,4 @@ func (k *kubernetesClient) Application(name string, deploymentType caas.Deployme
 		k.clock,
 		k.randomPrefix,
 	)
-}
-
-func (k *kubernetesClient) upgradeApplication(agentTag names.Tag, vers version.Number) error {
-	appName, err := names.UnitApplication(agentTag.Id())
-	if err != nil {
-		return errors.Trace(err)
-	}
-	app := k.Application(
-		appName,
-		caas.DeploymentStateful, // TODO(sidecar): we hardcode it to stateful for now, it needs to be fixed soon!
-	)
-	return app.Upgrade(vers)
 }

--- a/caas/kubernetes/provider/application/scale_test.go
+++ b/caas/kubernetes/provider/application/scale_test.go
@@ -17,7 +17,7 @@ import (
 
 func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
 	ss, err := s.client.AppsV1().StatefulSets(s.namespace).Get(
@@ -31,7 +31,7 @@ func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateless, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
 	dep, err := s.client.AppsV1().Deployments(s.namespace).Get(
@@ -45,7 +45,7 @@ func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationScaleStatefulLessThanZero(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, "", func() {})
 
 	c.Assert(errors.IsNotValid(app.Scale(-1)), jc.IsTrue)
 }

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -36,7 +36,9 @@ func (k *kubernetesClient) Upgrade(agentTag string, vers version.Number) error {
 	case names.ModelTagKind:
 		return k.upgradeModelOperator(tag, vers)
 	case names.UnitTagKind:
-		return k.upgradeApplication(tag, vers)
+		// Sidecarms don't have an upgrade step.
+		// See PR 14974
+		return nil
 	}
 	return errors.NotImplementedf("k8s upgrade for agent tag %q", agentTag)
 }

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -10,7 +10,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
-	version "github.com/juju/version/v2"
 )
 
 // MockApplication is a mock of Application interface.
@@ -178,20 +177,6 @@ func (m *MockApplication) UpdateService(arg0 caas.ServiceParam) error {
 func (mr *MockApplicationMockRecorder) UpdateService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockApplication)(nil).UpdateService), arg0)
-}
-
-// Upgrade mocks base method.
-func (m *MockApplication) Upgrade(arg0 version.Number) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Upgrade indicates an expected call of Upgrade.
-func (mr *MockApplicationMockRecorder) Upgrade(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockApplication)(nil).Upgrade), arg0)
 }
 
 // Watch mocks base method.

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -195,7 +195,7 @@ func (a *appWorker) loop() error {
 	}
 
 	var appChanges watcher.NotifyChannel
-	var appStateChanges watcher.NotifyChannel
+	var appProvisionChanges watcher.NotifyChannel
 	var replicaChanges watcher.NotifyChannel
 	var lastReportedStatus map[string]status.StatusInfo
 
@@ -236,15 +236,15 @@ func (a *appWorker) loop() error {
 		a.life = appLife
 		switch appLife {
 		case life.Alive:
-			if appStateChanges == nil {
-				appStateWatcher, err := a.facade.WatchApplication(a.name)
+			if appProvisionChanges == nil {
+				appProvisionWatcher, err := a.facade.WatchProvisioningInfo(a.name)
 				if err != nil {
-					return errors.Annotatef(err, "failed to watch facade for changes to application %q", a.name)
+					return errors.Annotatef(err, "failed to watch facade for changes to application provisioning %q", a.name)
 				}
-				if err := a.catacomb.Add(appStateWatcher); err != nil {
+				if err := a.catacomb.Add(appProvisionWatcher); err != nil {
 					return errors.Trace(err)
 				}
-				appStateChanges = appStateWatcher.Changes()
+				appProvisionChanges = appProvisionWatcher.Changes()
 			}
 			err = a.alive(app)
 			if err != nil {
@@ -363,7 +363,7 @@ func (a *appWorker) loop() error {
 			}
 		case <-a.catacomb.Dying():
 			return a.catacomb.ErrDying()
-		case <-appStateChanges:
+		case <-appProvisionChanges:
 			err = handleChange()
 			if err != nil {
 				return errors.Trace(err)

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -63,13 +63,14 @@ type testCase struct {
 	brokerApp  *caasmocks.MockApplication
 	unitFacade *mocks.MockCAASUnitProvisionerFacade
 
-	appScaleChan     chan struct{}
-	notifyReady      chan struct{}
-	appStateChan     chan struct{}
-	appChan          chan struct{}
-	appReplicasChan  chan struct{}
-	appTrustHashChan chan []string
-	unitsChan        chan []string
+	appScaleChan         chan struct{}
+	notifyReady          chan struct{}
+	appStateChan         chan struct{}
+	appChan              chan struct{}
+	appReplicasChan      chan struct{}
+	appTrustHashChan     chan []string
+	unitsChan            chan []string
+	provisioningInfoChan chan struct{}
 }
 
 func (s *ApplicationWorkerSuite) getWorker(c *gc.C) (func(...*gomock.Call) worker.Worker, testCase, *gomock.Controller) {
@@ -130,6 +131,7 @@ func (s *ApplicationWorkerSuite) getWorker(c *gc.C) (func(...*gomock.Call) worke
 	tc.appReplicasChan = make(chan struct{}, 1)
 	tc.appTrustHashChan = make(chan []string, 1)
 	tc.unitsChan = make(chan []string, 1)
+	tc.provisioningInfoChan = make(chan struct{}, 1)
 
 	startFunc := func(additionalAssertCalls ...*gomock.Call) worker.Worker {
 		config := caasapplicationprovisioner.AppWorkerConfig{
@@ -160,7 +162,7 @@ func (s *ApplicationWorkerSuite) getWorker(c *gc.C) (func(...*gomock.Call) worke
 
 			// Initial run - Ensure() for the application.
 			tc.facade.EXPECT().Life("test").Return(life.Alive, nil),
-			tc.facade.EXPECT().WatchApplication("test").Return(watchertest.NewMockNotifyWatcher(tc.appStateChan), nil),
+			tc.facade.EXPECT().WatchProvisioningInfo("test").Return(watchertest.NewMockNotifyWatcher(tc.provisioningInfoChan), nil),
 			tc.facade.EXPECT().ProvisioningInfo("test").Return(s.appProvisioningInfo, nil),
 			tc.facade.EXPECT().CharmInfo("cs:test").Return(s.appCharmInfo, nil),
 			tc.brokerApp.EXPECT().Exists().Return(caas.DeploymentState{}, nil),
@@ -464,8 +466,10 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 		steps := []func(){
 			// Test replica changes.
 			func() { tc.appReplicasChan <- struct{}{} },
+
 			// Test app state changes.
-			func() { tc.appStateChan <- struct{}{} },
+			func() { tc.provisioningInfoChan <- struct{}{} },
+
 			// Test app changes from cloud.
 			func() { tc.appChan <- struct{}{} },
 			// Test Notify - dying.

--- a/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -246,6 +246,21 @@ func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplications() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplications", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplications))
 }
 
+// WatchProvisioningInfo mocks base method.
+func (m *MockCAASProvisionerFacade) WatchProvisioningInfo(arg0 string) (watcher.NotifyWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchProvisioningInfo", arg0)
+	ret0, _ := ret[0].(watcher.NotifyWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchProvisioningInfo indicates an expected call of WatchProvisioningInfo.
+func (mr *MockCAASProvisionerFacadeMockRecorder) WatchProvisioningInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchProvisioningInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchProvisioningInfo), arg0)
+}
+
 // WatchUnits mocks base method.
 func (m *MockCAASProvisionerFacade) WatchUnits(arg0 string) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -61,6 +61,7 @@ type CAASProvisionerFacade interface {
 	ClearApplicationResources(appName string) error
 	WatchUnits(application string) (watcher.StringsWatcher, error)
 	RemoveUnit(unitName string) error
+	WatchProvisioningInfo(string) (watcher.NotifyWatcher, error)
 }
 
 // CAASBroker exposes CAAS broker functionality to a worker.


### PR DESCRIPTION
In the process of developing 2.9 we have made the mistake of placing pod spec changes into the sidecar charms ensure method meant for newer versions of Juju.

With this what ends up happening is that when a user upgrades a controller the ensure method runs again for the sidecar application and try's to start overwriting the pod spec with new addition's not currently intended for the version of juju the model is running.

With this change we have placed these changes by gate's to check agent versions when ensuring. We have also removed the upgrade path for sidecard charms and moved the logic back to ensuring the state we expect for different agent versions.

Fixes lp1997253

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

To verify this fix we need to do an upgrade with Juju. The easiest way to do this is to follow the conditions described in the bug.

1. Deploy a juju 2.9.34 controller into a microk8s or minikube cluster. Make sure to set `config --caas-image-repo=<docker_username>` as part of the bootstrap.
2. Add a new model
3. Deploy snappass-test
4. Build the oci image for this PR and the juju client and push into minikube.
```sh
DOCKER_USERNAME=<docker_username> make juju minikube-operator-update
```
5. Perform the controller upgrade with `juju upgrade-controller --agent-stream=develop`
6. We now need to confirm that after controller upgrade the snappass-test pods have not gone into a crash state. We expect to see that the charm container may have restarted during the upgrade. This is happening due it loosing connection with the controller and the liveliness probes restart the container.
7. Now we need to upgrade the model with `juju upgrade-model`. We want to confirm that after the upgrade the statefulset  for snappass-test has been updated. This can be done by confirming the charm container is now being run with pebble.

If all pods come back healthy after both upgrades then this is a successful test.

## Documentation changes

N/A

## Bug reference

lp1997253
