### PR TITLE
[JUJU-2240] disallow migration or upgrade of a model to 3.1 if charm store charms used in model

### DIFF
--- a/apiserver/facades/client/modelupgrader/mocks/state_mock.go
+++ b/apiserver/facades/client/modelupgrader/mocks/state_mock.go
@@ -121,6 +121,21 @@ func (mr *MockStateMockRecorder) AbortCurrentUpgrade() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AbortCurrentUpgrade", reflect.TypeOf((*MockState)(nil).AbortCurrentUpgrade))
 }
 
+// AllCharmURLs mocks base method.
+func (m *MockState) AllCharmURLs() ([]*string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllCharmURLs")
+	ret0, _ := ret[0].([]*string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllCharmURLs indicates an expected call of AllCharmURLs.
+func (mr *MockStateMockRecorder) AllCharmURLs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockState)(nil).AllCharmURLs))
+}
+
 // AllModelUUIDs mocks base method.
 func (m *MockState) AllModelUUIDs() ([]string, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/modelupgrader/shims.go
+++ b/apiserver/facades/client/modelupgrader/shims.go
@@ -33,6 +33,7 @@ type State interface {
 	SetModelAgentVersion(newVersion version.Number, stream *string, ignoreAgentVersions bool) error
 	AbortCurrentUpgrade() error
 	ControllerConfig() (controller.Config, error)
+	AllCharmURLs() ([]*string, error)
 }
 
 type SystemState interface {
@@ -129,6 +130,10 @@ func (s stateShim) MongoCurrentStatus() (*replicaset.Status, error) {
 		s.mgosession = s.PooledState.MongoSession()
 	}
 	return replicaset.CurrentStatus(s.mgosession)
+}
+
+func (s stateShim) AllCharmURLs() ([]*string, error) {
+	return s.PooledState.AllCharmURLs()
 }
 
 type modelShim struct {

--- a/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
@@ -68,6 +68,21 @@ func (mr *MockPrecheckBackendMockRecorder) AllApplications() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllApplications", reflect.TypeOf((*MockPrecheckBackend)(nil).AllApplications))
 }
 
+// AllCharmURLs mocks base method.
+func (m *MockPrecheckBackend) AllCharmURLs() ([]*string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllCharmURLs")
+	ret0, _ := ret[0].([]*string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllCharmURLs indicates an expected call of AllCharmURLs.
+func (mr *MockPrecheckBackendMockRecorder) AllCharmURLs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockPrecheckBackend)(nil).AllCharmURLs))
+}
+
 // AllMachines mocks base method.
 func (m *MockPrecheckBackend) AllMachines() ([]migration.PrecheckMachine, error) {
 	m.ctrl.T.Helper()

--- a/migration/precheck.go
+++ b/migration/precheck.go
@@ -33,6 +33,7 @@ type PrecheckBackend interface {
 	AllMachines() ([]PrecheckMachine, error)
 	AllApplications() ([]PrecheckApplication, error)
 	AllRelations() ([]PrecheckRelation, error)
+	AllCharmURLs() ([]*string, error)
 	ControllerBackend() (PrecheckBackend, error)
 	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
 	HasUpgradeSeriesLocks() (bool, error)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -932,6 +932,10 @@ func (b *fakeBackend) MongoCurrentStatus() (*replicaset.Status, error) {
 	return b.mongoCurrentStatus, b.mongoCurrentStatusErr
 }
 
+func (b *fakeBackend) AllCharmURLs() ([]*string, error) {
+	return nil, errors.NotFoundf("charms")
+}
+
 type fakePool struct {
 	models []migration.PrecheckModel
 }

--- a/state/charm.go
+++ b/state/charm.go
@@ -1141,3 +1141,28 @@ func (st *State) AddCharmMetadata(info CharmInfo) (*Charm, error) {
 	}
 	return ch, nil
 }
+
+// AllCharmURLs returns a slice of strings representing charm.URLs for every
+// charm deployed in this model.
+func (st *State) AllCharmURLs() ([]*string, error) {
+	applications, closer := st.db().GetCollection(charmsC)
+	defer closer()
+
+	var docs []struct {
+		CharmURL *string `bson:"url"`
+	}
+	err := applications.Find(bson.D{}).All(&docs)
+	if err == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("charms")
+	}
+	if err != nil {
+		return nil, errors.Errorf("cannot get all charm URLs")
+	}
+
+	curls := make([]*string, len(docs))
+	for i, v := range docs {
+		curls[i] = v.CharmURL
+	}
+
+	return curls, nil
+}

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -737,6 +737,19 @@ func (s *CharmSuite) TestAddCharmMetadata(c *gc.C) {
 	c.Assert(ch2.IsUploaded(), jc.IsTrue, gc.Commentf("expected charm with populated SHA/storage path to have the PendingUpload flag unset"))
 }
 
+func (s *CharmSuite) TestAllCharmURLs(c *gc.C) {
+	ch1 := s.AddTestingCharm(c, "dummy")
+	state.AddTestingApplication(c, s.State, "testme", ch1)
+
+	ch2 := state.AddTestingCharmhubCharmForSeries(c, s.State, "jammy", "dummy")
+	state.AddTestingApplication(c, s.State, "testme-jammy", ch2)
+
+	curls, err := s.State.AllCharmURLs()
+	c.Assert(err, jc.ErrorIsNil)
+	// One application from SetUpTest
+	c.Assert(len(curls), gc.Equals, 3, gc.Commentf("%v", curls))
+}
+
 type CharmTestHelperSuite struct {
 	ConnSuite
 }

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -738,16 +738,13 @@ func (s *CharmSuite) TestAddCharmMetadata(c *gc.C) {
 }
 
 func (s *CharmSuite) TestAllCharmURLs(c *gc.C) {
-	ch1 := s.AddTestingCharm(c, "dummy")
-	state.AddTestingApplication(c, s.State, "testme", ch1)
-
 	ch2 := state.AddTestingCharmhubCharmForSeries(c, s.State, "jammy", "dummy")
 	state.AddTestingApplication(c, s.State, "testme-jammy", ch2)
 
 	curls, err := s.State.AllCharmURLs()
 	c.Assert(err, jc.ErrorIsNil)
 	// One application from SetUpTest
-	c.Assert(len(curls), gc.Equals, 3, gc.Commentf("%v", curls))
+	c.Assert(len(curls), gc.Equals, 2, gc.Commentf("%v", curls))
 }
 
 type CharmTestHelperSuite struct {

--- a/upgrades/upgradevalidation/interfaces.go
+++ b/upgrades/upgradevalidation/interfaces.go
@@ -19,6 +19,7 @@ type StatePool interface {
 
 // State represents a point of use interface for modelling a current model.
 type State interface {
+	AllCharmURLs() ([]*string, error)
 	HasUpgradeSeriesLocks() (bool, error)
 	MachineCountForBase(base ...state.Base) (map[string]int, error)
 	MongoCurrentStatus() (*replicaset.Status, error)

--- a/upgrades/upgradevalidation/migrate.go
+++ b/upgrades/upgradevalidation/migrate.go
@@ -23,6 +23,9 @@ func ValidatorsForModelMigrationSource(
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
 		)
+		if targetVersion.Minor >= 1 {
+			validators = append(validators, checkForCharmStoreCharms)
+		}
 	}
 	return validators
 }

--- a/upgrades/upgradevalidation/mocks/state_mock.go
+++ b/upgrades/upgradevalidation/mocks/state_mock.go
@@ -75,6 +75,21 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// AllCharmURLs mocks base method.
+func (m *MockState) AllCharmURLs() ([]*string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllCharmURLs")
+	ret0, _ := ret[0].([]*string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllCharmURLs indicates an expected call of AllCharmURLs.
+func (mr *MockStateMockRecorder) AllCharmURLs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockState)(nil).AllCharmURLs))
+}
+
 // HasUpgradeSeriesLocks mocks base method.
 func (m *MockState) HasUpgradeSeriesLocks() (bool, error) {
 	m.ctrl.T.Helper()

--- a/upgrades/upgradevalidation/package_test.go
+++ b/upgrades/upgradevalidation/package_test.go
@@ -6,14 +6,14 @@ package upgradevalidation
 import (
 	stdtesting "testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/state_mock.go github.com/juju/juju/upgrades/upgradevalidation StatePool,State,Model
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/lxd_mock.go github.com/juju/juju/provider/lxd ServerFactory,Server
 
 func TestAll(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+	gc.TestingT(t)
 }
 
 var (
@@ -25,4 +25,5 @@ var (
 	CheckMongoStatusForControllerUpgrade        = checkMongoStatusForControllerUpgrade
 	CheckMongoVersionForControllerModel         = checkMongoVersionForControllerModel
 	GetCheckForLXDVersion                       = getCheckForLXDVersion
+	CheckForCharmStoreCharms                    = checkForCharmStoreCharms
 )

--- a/upgrades/upgradevalidation/upgrade.go
+++ b/upgrades/upgradevalidation/upgrade.go
@@ -25,6 +25,9 @@ func ValidatorsForControllerUpgrade(
 				checkForDeprecatedUbuntuSeriesForModel,
 				getCheckForLXDVersion(cloudspec),
 			)
+			if targetVersion.Minor >= 1 {
+				validators = append(validators, checkForCharmStoreCharms)
+			}
 		}
 		return validators
 	}
@@ -39,6 +42,10 @@ func ValidatorsForControllerUpgrade(
 			getCheckForLXDVersion(cloudspec),
 		)
 	}
+	if targetVersion.Major >= 3 && targetVersion.Minor >= 1 {
+		validators = append(validators, checkForCharmStoreCharms)
+	}
+
 	return validators
 }
 
@@ -55,6 +62,9 @@ func ValidatorsForModelUpgrade(
 			checkForDeprecatedUbuntuSeriesForModel,
 			getCheckForLXDVersion(cloudspec),
 		)
+		if targetVersion.Minor >= 1 {
+			validators = append(validators, checkForCharmStoreCharms)
+		}
 	}
 	return validators
 }

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/juju/charm/v9"
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	jujuhttp "github.com/juju/http/v2"
 	"github.com/juju/replicaset/v3"
@@ -156,7 +158,7 @@ var windowsSeries = []string{
 	"win2016", "win2016hv", "win2019", "win7", "win8", "win81", "win10",
 }
 
-func checkNoWinMachinesForModel(modelUUID string, pool StatePool, st State, model Model) (*Blocker, error) {
+func checkNoWinMachinesForModel(_ string, _ StatePool, st State, _ Model) (*Blocker, error) {
 	windowsBases := make([]state.Base, len(windowsSeries))
 	for i, s := range windowsSeries {
 		windowsBases[i] = state.Base{OS: "windows", Channel: s}
@@ -188,7 +190,7 @@ func stringifyMachineCounts(result map[string]int) string {
 }
 
 func checkForDeprecatedUbuntuSeriesForModel(
-	modelUUID string, pool StatePool, st State, model Model,
+	_ string, _ StatePool, st State, _ Model,
 ) (*Blocker, error) {
 	supported := false
 	var deprecatedBases []state.Base
@@ -209,6 +211,39 @@ func checkForDeprecatedUbuntuSeriesForModel(
 	if len(result) > 0 {
 		return NewBlocker("the model hosts deprecated ubuntu machine(s): %s",
 			stringifyMachineCounts(result),
+		), nil
+	}
+	return nil, nil
+}
+
+func checkForCharmStoreCharms(_ string, _ StatePool, st State, _ Model) (*Blocker, error) {
+	curls, err := st.AllCharmURLs()
+	if errors.Is(err, errors.NotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	result := set.NewStrings()
+	for _, curlStr := range curls {
+		if curlStr == nil {
+			return nil, errors.New("malformed charm in database with no URL")
+		}
+		curl, err := charm.ParseURL(*curlStr)
+		if err != nil {
+			logger.Errorf("error from ParseURL: %s", err)
+			return nil, errors.New(fmt.Sprintf("malformed charm url in database: %q", *curlStr))
+		}
+		// TODO 6-dec-2022
+		// Update check once charm's ValidateSchema rejects charm store charms.
+		if !charm.CharmHub.Matches(curl.Schema) && !charm.Local.Matches(curl.Schema) {
+			c := curl.WithSeries("").WithArchitecture("")
+			result.Add(c.String())
+		}
+	}
+	if !result.IsEmpty() {
+		return NewBlocker("the model hosts deprecated charm store charms(s): %s",
+			strings.Join(result.SortedValues(), ", "),
 		), nil
 	}
 	return nil, nil
@@ -289,7 +324,7 @@ func checkMongoStatusForControllerUpgrade(modelUUID string, pool StatePool, st S
 	return nil, nil
 }
 
-func checkMongoVersionForControllerModel(modelUUID string, pool StatePool, st State, model Model) (*Blocker, error) {
+func checkMongoVersionForControllerModel(_ string, pool StatePool, _ State, _ Model) (*Blocker, error) {
 	v, err := pool.MongoVersion()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -67,10 +67,10 @@ func (s *upgradeValidationSuite) TestModelUpgradeCheckFailEarly(c *gc.C) {
 	defer ctrl.Finish()
 
 	statePool := mocks.NewMockStatePool(ctrl)
-	state := mocks.NewMockState(ctrl)
+	st := mocks.NewMockState(ctrl)
 	model := mocks.NewMockModel(ctrl)
 
-	checker := upgradevalidation.NewModelUpgradeCheck("", statePool, state, model,
+	checker := upgradevalidation.NewModelUpgradeCheck("", statePool, st, model,
 		func(modelUUID string, pool upgradevalidation.StatePool, st upgradevalidation.State, model upgradevalidation.Model) (*upgradevalidation.Blocker, error) {
 			return upgradevalidation.NewBlocker("model migration is in process"), nil
 		},
@@ -89,14 +89,12 @@ func (s *upgradeValidationSuite) TestModelUpgradeCheck(c *gc.C) {
 	defer ctrl.Finish()
 
 	statePool := mocks.NewMockStatePool(ctrl)
-	state := mocks.NewMockState(ctrl)
+	st := mocks.NewMockState(ctrl)
 	model := mocks.NewMockModel(ctrl)
-	gomock.InOrder(
-		model.EXPECT().Owner().Return(names.NewUserTag("admin")),
-		model.EXPECT().Name().Return("model-1"),
-	)
+	model.EXPECT().Owner().Return(names.NewUserTag("admin"))
+	model.EXPECT().Name().Return("model-1")
 
-	checker := upgradevalidation.NewModelUpgradeCheck(coretesting.ModelTag.Id(), statePool, state, model,
+	checker := upgradevalidation.NewModelUpgradeCheck(coretesting.ModelTag.Id(), statePool, st, model,
 		func(modelUUID string, pool upgradevalidation.StatePool, st upgradevalidation.State, model upgradevalidation.Model) (*upgradevalidation.Blocker, error) {
 			return upgradevalidation.NewBlocker("model migration is in process"), nil
 		},
@@ -117,17 +115,17 @@ func (s *upgradeValidationSuite) TestCheckNoWinMachinesForModel(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	state := mocks.NewMockState(ctrl)
+	st := mocks.NewMockState(ctrl)
 	gomock.InOrder(
-		state.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil),
-		state.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 2}, nil),
+		st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil),
+		st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 2}, nil),
 	)
 
-	blocker, err := upgradevalidation.CheckNoWinMachinesForModel("", nil, state, nil)
+	blocker, err := upgradevalidation.CheckNoWinMachinesForModel("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 
-	blocker, err = upgradevalidation.CheckNoWinMachinesForModel("", nil, state, nil)
+	blocker, err = upgradevalidation.CheckNoWinMachinesForModel("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker.Error(), gc.Equals, `the model hosts deprecated windows machine(s): win10(1) win7(2)`)
 }
@@ -136,12 +134,10 @@ func (s *upgradeValidationSuite) TestCheckForDeprecatedUbuntuSeriesForModel(c *g
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	state := mocks.NewMockState(ctrl)
-	gomock.InOrder(
-		state.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{"xenial": 1, "vivid": 2, "trusty": 3}, nil),
-	)
+	st := mocks.NewMockState(ctrl)
+	st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{"xenial": 1, "vivid": 2, "trusty": 3}, nil)
 
-	blocker, err := upgradevalidation.CheckForDeprecatedUbuntuSeriesForModel("", nil, state, nil)
+	blocker, err := upgradevalidation.CheckForDeprecatedUbuntuSeriesForModel("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker.Error(), gc.Equals, `the model hosts deprecated ubuntu machine(s): trusty(3) vivid(2) xenial(1)`)
 }
@@ -150,22 +146,22 @@ func (s *upgradeValidationSuite) TestGetCheckUpgradeSeriesLockForModel(c *gc.C) 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	state := mocks.NewMockState(ctrl)
+	st := mocks.NewMockState(ctrl)
 	gomock.InOrder(
-		state.EXPECT().HasUpgradeSeriesLocks().Return(false, nil),
-		state.EXPECT().HasUpgradeSeriesLocks().Return(true, nil),
-		state.EXPECT().HasUpgradeSeriesLocks().Return(true, nil),
+		st.EXPECT().HasUpgradeSeriesLocks().Return(false, nil),
+		st.EXPECT().HasUpgradeSeriesLocks().Return(true, nil),
+		st.EXPECT().HasUpgradeSeriesLocks().Return(true, nil),
 	)
 
-	blocker, err := upgradevalidation.GetCheckUpgradeSeriesLockForModel(false)("", nil, state, nil)
+	blocker, err := upgradevalidation.GetCheckUpgradeSeriesLockForModel(false)("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 
-	blocker, err = upgradevalidation.GetCheckUpgradeSeriesLockForModel(true)("", nil, state, nil)
+	blocker, err = upgradevalidation.GetCheckUpgradeSeriesLockForModel(true)("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 
-	blocker, err = upgradevalidation.GetCheckUpgradeSeriesLockForModel(false)("", nil, state, nil)
+	blocker, err = upgradevalidation.GetCheckUpgradeSeriesLockForModel(false)("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker.Error(), gc.Equals, `unexpected upgrade series lock found`)
 }
@@ -243,9 +239,9 @@ func (s *upgradeValidationSuite) TestCheckMongoStatusForControllerUpgrade(c *gc.
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	state := mocks.NewMockState(ctrl)
+	st := mocks.NewMockState(ctrl)
 	gomock.InOrder(
-		state.EXPECT().MongoCurrentStatus().Return(&replicaset.Status{
+		st.EXPECT().MongoCurrentStatus().Return(&replicaset.Status{
 			Members: []replicaset.MemberStatus{
 				{
 					Id:      1,
@@ -264,7 +260,7 @@ func (s *upgradeValidationSuite) TestCheckMongoStatusForControllerUpgrade(c *gc.
 				},
 			},
 		}, nil),
-		state.EXPECT().MongoCurrentStatus().Return(&replicaset.Status{
+		st.EXPECT().MongoCurrentStatus().Return(&replicaset.Status{
 			Members: []replicaset.MemberStatus{
 				{
 					Id:      1,
@@ -310,11 +306,11 @@ func (s *upgradeValidationSuite) TestCheckMongoStatusForControllerUpgrade(c *gc.
 		}, nil),
 	)
 
-	blocker, err := upgradevalidation.CheckMongoStatusForControllerUpgrade("", nil, state, nil)
+	blocker, err := upgradevalidation.CheckMongoStatusForControllerUpgrade("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 
-	blocker, err = upgradevalidation.CheckMongoStatusForControllerUpgrade("", nil, state, nil)
+	blocker, err = upgradevalidation.CheckMongoStatusForControllerUpgrade("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker.Error(), gc.Equals, `unable to upgrade, database node 1 (1.1.1.1) has state RECOVERING, node 2 (2.2.2.2) has state FATAL, node 3 (3.3.3.3) has state STARTUP2, node 4 (4.4.4.4) has state UNKNOWN, node 5 (5.5.5.5) has state ARBITER, node 6 (6.6.6.6) has state DOWN, node 7 (7.7.7.7) has state ROLLBACK, node 8 (8.8.8.8) has state SHUNNED`)
 }
@@ -352,10 +348,8 @@ func (s *upgradeValidationSuite) assertGetCheckForLXDVersion(c *gc.C, cloudType 
 	)
 
 	cloudSpec := environscloudspec.CloudSpec{Type: cloudType}
-	gomock.InOrder(
-		serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("5.2"),
-	)
+	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
+	server.EXPECT().ServerVersion().Return("5.2")
 
 	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -400,13 +394,58 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 		},
 	)
 	cloudSpec := environscloudspec.CloudSpec{Type: "lxd"}
-	gomock.InOrder(
-		serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil),
-		server.EXPECT().ServerVersion().Return("4.0"),
-	)
+	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
+	server.EXPECT().ServerVersion().Return("4.0")
 
 	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec)("", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.NotNil)
 	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)
+}
+
+func (s *upgradeValidationSuite) TestCheckForCharmStoreCharms(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	one := "ch:amd64/jammy/test-4"
+	two := "cs:jammy/cstest-4"
+	three := "cs:cstest-4"
+	four := "local:quantal/quantal-mysql-7"
+	five := "cs:jammy/five-42"
+
+	st := mocks.NewMockState(ctrl)
+	st.EXPECT().AllCharmURLs().Return([]*string{
+		&one,
+		&two,
+		&three,
+		&four,
+		&five,
+	}, nil)
+
+	blocker, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocker.Error(), gc.Equals, `the model hosts deprecated charm store charms(s): cs:cstest-4, cs:five-42`)
+}
+
+func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsNotFound(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	st := mocks.NewMockState(ctrl)
+	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
+
+	blocker, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocker, gc.IsNil)
+}
+
+func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	st := mocks.NewMockState(ctrl)
+	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.BadRequestf("charm urls"))
+
+	_, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
+	c.Assert(errors.Is(err, errors.BadRequest), jc.IsTrue)
 }


### PR DESCRIPTION
3.1 will no support charm store charms. Ensure that none exist in models migrating or upgrading to 3.1.

## QA steps

Bootstrap a juju 3.0 controller and add a model with charmhub, local and charm store charms to it. Try to upgrade to 3.1, and see if fail. Remove the charmstore application from the model and try again. This time succeeding.

Bootstrap a juju 3.0  and 3.1 controllers. Add a model to the 3.0 controller with charmhub, local and charm store charms to it. Try to migrate it to 3.1, and see if fail. Remove the charmstore application from the model and try again. This time succeeding.

Try other scenarios of upgrade/migration as well. 
