### PR TITLE
Fix intermittent vault test suite failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,7 @@ endif
 endif
 
 WAIT_FOR_DPKG=sh -c '. "${PROJECT_DIR}/make_functions.sh"; wait_for_dpkg "$$@"' wait_for_dpkg
-JUJU_DB_CHANNEL=5.3/stable
+JUJU_DB_CHANNEL=4.4/stable
 
 .PHONY: install-mongo-dependencies
 install-mongo-dependencies:

--- a/acceptancetests/jujupy/controller.py
+++ b/acceptancetests/jujupy/controller.py
@@ -91,4 +91,4 @@ class ControllerConfig:
     def db_snap_channel(self):
         if 'juju-db-snap-channel' in self.cfg:
             return self.cfg["juju-db-snap-channel"]
-        return "5.3/stable"
+        return "4.4/stable"

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -71,7 +71,7 @@ func (s *oplogSuite) TestWithRealOplog(c *gc.C) {
 	// Update foo.bar and see the update reported.
 	err := coll.UpdateId("thing", bson.M{"$set": bson.M{"blah": 42}})
 	c.Assert(err, jc.ErrorIsNil)
-	assertOplog("u", bson.D{{"diff", bson.D{{"i", bson.D{{"blah", 42}}}}}}, bson.D{{"_id", "thing"}})
+	assertOplog("u", bson.D{{"$set", bson.D{{"blah", 42}}}}, bson.D{{"_id", "thing"}})
 
 	// Insert into another collection (shouldn't be reported due to filter).
 	s.insertDoc(c, session, db.C("elsewhere"), bson.M{"_id": "boo"})

--- a/snap/local/wrappers/fetch-oci
+++ b/snap/local/wrappers/fetch-oci
@@ -32,7 +32,7 @@ echo "Wait for microk8s to be ready if needed."
 microk8s.status --wait-ready --timeout 30 2>&1
 juju_version=\$(/snap/bin/juju version | rev | cut -d- -f3- | rev)
 oci_image="docker.io/jujusolutions/jujud-operator:\$juju_version"
-mongo_image="docker.io/jujusolutions/juju-db:5.3"
+mongo_image="docker.io/jujusolutions/juju-db:4.4"
 
 echo "Going to cache images: \$oci_image and \$mongo_image."
 echo "Pulling: \$oci_image."


### PR DESCRIPTION
Backport a small fix from develop branch to address an intermittent failure in the vault provider suite.

Drive by - we were still using juju-db channel 5.3/stable in some places for tests. It should be 4.4

## QA steps

run unit tests