### PR TITLE
[JUJU-2315] Update remove application

### DIFF
--- a/featuretests/cmd_juju_application_test.go
+++ b/featuretests/cmd_juju_application_test.go
@@ -133,7 +133,7 @@ wordpress:
 func (s *cmdApplicationSuite) TestRemoveApplication(c *gc.C) {
 	s.setupApplications(c)
 
-	ctx, err := cmdtesting.RunCommand(c, application.NewRemoveApplicationCommand(), "wordpress")
+	ctx, err := cmdtesting.RunCommand(c, application.NewRemoveApplicationCommand(), "--no-prompt", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "will remove application wordpress\n")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -11,6 +11,8 @@ export BOOTSTRAP_SERIES="${BOOTSTRAP_SERIES:-}"
 export BUILD_AGENT="${BUILD_AGENT:-false}"
 export RUN_SUBTEST="${RUN_SUBTEST:-}"
 
+export JUJU_SKIP_CONFIRMATION=1
+
 export CURRENT_LTS="jammy"
 
 current_pwd=$(pwd)


### PR DESCRIPTION
Now that behaviour has converged, use ConfirmationCommandBase in remove-application

This makes prompting the default

Also fix unit tests

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Verify unit tests pass
Verify `juju remove-application` asks for a y/N confirmation by default
