### PR TITLE
[JUJU-2309] Add unused dry-run option to DestroyUnits

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -436,6 +436,10 @@ type DestroyUnitsParams struct {
 	// will wait before forcing the next step to kick-off. This parameter
 	// only makes sense in combination with 'force' set to 'true'.
 	MaxWait *time.Duration
+
+	// DryRun specifies whether to perform the destroy action or
+	// just return what this action will destroy
+	DryRun bool
 }
 
 // DestroyUnits decreases the number of units dedicated to one or more
@@ -459,6 +463,7 @@ func (c *Client) DestroyUnits(in DestroyUnitsParams) ([]params.DestroyUnitResult
 			DestroyStorage: in.DestroyStorage,
 			Force:          in.Force,
 			MaxWait:        in.MaxWait,
+			DryRun:         in.DryRun,
 		})
 	}
 	if len(args.Units) == 0 {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1426,6 +1426,21 @@ func addApplicationUnits(backend Backend, modelType state.ModelType, args params
 	)
 }
 
+func (api *APIv15) DestroyUnit(argsV15 params.DestroyUnitsParamsV15) (params.DestroyUnitResults, error) {
+	args := params.DestroyUnitsParams{
+		Units: transform.Slice(argsV15.Units, func(p params.DestroyUnitParamsV15) params.DestroyUnitParams {
+			return params.DestroyUnitParams{
+				UnitTag:        p.UnitTag,
+				DestroyStorage: p.DestroyStorage,
+				Force:          p.Force,
+				MaxWait:        p.MaxWait,
+				DryRun:         false,
+			}
+		}),
+	}
+	return api.APIBase.DestroyUnit(args)
+}
+
 // DestroyUnit removes a given set of application units.
 func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
 	if api.modelType == state.ModelTypeCAAS {

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -17,7 +17,7 @@ func Register(registry facade.FacadeRegistry) {
 		return newFacadeV15(ctx)
 	}, reflect.TypeOf((*APIv15)(nil)))
 	registry.MustRegister("Application", 16, func(ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV16(ctx) // DestroyApplication gains dry-run
+		return newFacadeV16(ctx) // DestroyApplication & DestroyUnit gains dry-run
 	}, reflect.TypeOf((*APIv16)(nil)))
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3337,6 +3337,9 @@
                         "destroy-storage": {
                             "type": "boolean"
                         },
+                        "dry-run": {
+                            "type": "boolean"
+                        },
                         "force": {
                             "type": "boolean"
                         },
@@ -3349,8 +3352,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "unit-tag",
-                        "force"
+                        "unit-tag"
                     ]
                 },
                 "DestroyUnitResult": {

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -281,6 +281,7 @@ func (c *removeUnitCommand) removeUnits(ctx *cmd.Context, client RemoveApplicati
 		DestroyStorage: c.DestroyStorage,
 		Force:          c.Force,
 		MaxWait:        maxWait,
+		DryRun:         false,
 	})
 	if err != nil {
 		return block.ProcessBlockedError(err, block.BlockRemove)

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -520,6 +520,30 @@ type ApplicationMergeBindings struct {
 	Force          bool              `json:"force"`
 }
 
+// DestroyUnitsParamsV15 holds bulk parameters for the Application.DestroyUnit call.
+type DestroyUnitsParamsV15 struct {
+	Units []DestroyUnitParamsV15 `json:"units"`
+}
+
+// DestroyUnitParams holds parameters for the Application.DestroyUnit call.
+type DestroyUnitParamsV15 struct {
+	// UnitTag holds the tag of the unit to destroy.
+	UnitTag string `json:"unit-tag"`
+
+	// DestroyStorage controls whether or not storage
+	// attached to the unit should be destroyed.
+	DestroyStorage bool `json:"destroy-storage,omitempty"`
+
+	// Force controls whether or not the destruction of an application
+	// will be forced, i.e. ignore operational errors.
+	Force bool `json:"force"`
+
+	// MaxWait specifies the amount of time that each step in unit removal
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
+}
+
 // DestroyUnitsParams holds bulk parameters for the Application.DestroyUnit call.
 type DestroyUnitsParams struct {
 	Units []DestroyUnitParams `json:"units"`
@@ -536,12 +560,16 @@ type DestroyUnitParams struct {
 
 	// Force controls whether or not the destruction of an application
 	// will be forced, i.e. ignore operational errors.
-	Force bool `json:"force"`
+	Force bool `json:"force,omitempty"`
 
 	// MaxWait specifies the amount of time that each step in unit removal
 	// will wait before forcing the next step to kick-off. This parameter
 	// only makes sense in combination with 'force' set to 'true'.
 	MaxWait *time.Duration `json:"max-wait,omitempty"`
+
+	// DryRun specifies whether to perform the destroy action or
+	// just return what this action will destroy
+	DryRun bool `json:"dry-run,omitempty"`
 }
 
 // Creds holds credentials for identifying an entity.


### PR DESCRIPTION
At the moment, this option does not change behaviour and is not exposed to the client

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

Verify unit test still pass
Verify `remove-unit` functions as before with both 'new' and 'old' controller