### PR TITLE
[JUJU-2312] Remove cs-channel from application doc.

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/juju/charm/v9"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -549,7 +548,6 @@ func deployApplication(
 		ApplicationName:   args.ApplicationName,
 		Charm:             stateCharm(ch),
 		CharmOrigin:       origin,
-		Channel:           csparams.Channel(args.Channel),
 		NumUnits:          args.NumUnits,
 		ApplicationConfig: appConfig,
 		CharmConfig:       charmSettings,
@@ -797,7 +795,6 @@ type setCharmParams struct {
 	AppName               string
 	Application           Application
 	CharmOrigin           *params.CharmOrigin
-	Channel               csparams.Channel
 	ConfigSettingsStrings map[string]string
 	ConfigSettingsYAML    string
 	ResourceIDs           map[string]string
@@ -915,13 +912,11 @@ func (api *APIBase) SetCharm(args params.ApplicationSetCharm) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	channel := csparams.Channel(args.Channel)
 	return api.setCharmWithAgentValidation(
 		setCharmParams{
 			AppName:               args.ApplicationName,
 			Application:           oneApplication,
 			CharmOrigin:           args.CharmOrigin,
-			Channel:               channel,
 			ConfigSettingsStrings: args.ConfigSettings,
 			ConfigSettingsYAML:    args.ConfigSettingsYAML,
 			ResourceIDs:           args.ResourceIDs,
@@ -1085,7 +1080,6 @@ func (api *APIBase) applicationSetCharm(
 	cfg := state.SetCharmConfig{
 		Charm:              api.stateCharm(newCharm),
 		CharmOrigin:        newOrigin,
-		Channel:            params.Channel,
 		ConfigSettings:     settings,
 		ForceBase:          force.ForceBase,
 		ForceUnits:         force.ForceUnits,

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
 	"github.com/juju/charm/v9/assumes"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -2793,7 +2792,6 @@ func (s *ApplicationSuite) TestApplicationsInfoOne(c *gc.C) {
 	}).MinTimes(1)
 	app.EXPECT().ApplicationConfig().Return(coreconfig.ConfigAttributes{}, nil).MinTimes(1)
 	app.EXPECT().CharmConfig("master").Return(map[string]interface{}{"stringOption": "", "intOption": int(123)}, nil).MinTimes(1)
-	app.EXPECT().Channel().Return(csparams.DevelopmentChannel).MinTimes(1)
 
 	bindings := mocks.NewMockBindings(ctrl)
 	bindings.EXPECT().MapWithSpaceNames(gomock.Any()).Return(map[string]string{"juju-info": "myspace"}, nil).MinTimes(1)
@@ -2830,7 +2828,6 @@ func (s *ApplicationSuite) TestApplicationsInfoOneWithExposedEndpoints(c *gc.C) 
 	}).MinTimes(1)
 	app.EXPECT().ApplicationConfig().Return(coreconfig.ConfigAttributes{}, nil).MinTimes(1)
 	app.EXPECT().CharmConfig("master").Return(map[string]interface{}{"stringOption": "", "intOption": int(123)}, nil).MinTimes(1)
-	app.EXPECT().Channel().Return(csparams.DevelopmentChannel).MinTimes(1)
 
 	bindings := mocks.NewMockBindings(ctrl)
 	bindings.EXPECT().MapWithSpaceNames(gomock.Any()).Return(map[string]string{"juju-info": "myspace"}, nil).MinTimes(1)
@@ -2851,7 +2848,6 @@ func (s *ApplicationSuite) TestApplicationsInfoOneWithExposedEndpoints(c *gc.C) 
 		Tag:         "application-postgresql",
 		Charm:       "charm-postgresql",
 		Base:        params.Base{Name: "ubuntu", Channel: "22.04/stable"},
-		Channel:     "development",
 		Constraints: constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
 		Principal:   true,
 		Life:        state.Alive.String(),
@@ -2910,7 +2906,6 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 	}).MinTimes(1)
 	app.EXPECT().ApplicationConfig().Return(coreconfig.ConfigAttributes{}, nil).MinTimes(1)
 	app.EXPECT().CharmConfig("master").Return(map[string]interface{}{"stringOption": "", "intOption": int(123)}, nil).MinTimes(1)
-	app.EXPECT().Channel().Return(csparams.DevelopmentChannel).MinTimes(1)
 
 	bindings := mocks.NewMockBindings(ctrl)
 	bindings.EXPECT().MapWithSpaceNames(gomock.Any()).Return(map[string]string{"juju-info": "myspace"}, nil).MinTimes(1)
@@ -2929,7 +2924,6 @@ func (s *ApplicationSuite) TestApplicationsInfoMany(c *gc.C) {
 		Tag:         "application-postgresql",
 		Charm:       "charm-postgresql",
 		Base:        params.Base{Name: "ubuntu", Channel: "22.04/stable"},
-		Channel:     "development",
 		Constraints: constraints.MustParse("arch=amd64 mem=4G cores=1 root-disk=8G"),
 		Principal:   true,
 		Life:        state.Alive.String(),

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/juju/charm/v9"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/schema"
@@ -77,7 +76,6 @@ type Application interface {
 	ApplicationTag() names.ApplicationTag
 	Charm() (Charm, bool, error)
 	CharmURL() (*string, bool)
-	Channel() csparams.Channel
 	CharmOrigin() *state.CharmOrigin
 	ClearExposed() error
 	CharmConfig(string) (charm.Settings, error)

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/charm/v9"
 	"github.com/juju/charm/v9/assumes"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -36,7 +35,6 @@ type DeployApplicationParams struct {
 	ApplicationName   string
 	Charm             *state.Charm
 	CharmOrigin       corecharm.Origin
-	Channel           csparams.Channel
 	ApplicationConfig *config.Config
 	CharmConfig       charm.Settings
 	Constraints       constraints.Value
@@ -107,7 +105,6 @@ func DeployApplication(st ApplicationDeployer, model Model, args DeployApplicati
 		Name:              args.ApplicationName,
 		Charm:             args.Charm,
 		CharmOrigin:       origin,
-		Channel:           args.Channel,
 		Storage:           stateStorageConstraints(args.Storage),
 		Devices:           stateDeviceConstraints(args.Devices),
 		AttachStorage:     args.AttachStorage,

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -84,7 +84,7 @@ func (api *APIBase) getConfig(
 		return params.ApplicationGetResults{}, err
 	}
 
-	appChannel := string(app.Channel())
+	var appChannel string
 
 	// If the applications charm origin is from charm-hub, then build the real
 	// channel and send that back.

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v9"
-	params "github.com/juju/charmrepo/v7/csclient/params"
 	storagecommon "github.com/juju/juju/apiserver/common/storagecommon"
 	application "github.com/juju/juju/apiserver/facades/client/application"
 	cloud "github.com/juju/juju/cloud"
@@ -971,20 +970,6 @@ func (m *MockApplication) ChangeScale(arg0 int) (int, error) {
 func (mr *MockApplicationMockRecorder) ChangeScale(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeScale", reflect.TypeOf((*MockApplication)(nil).ChangeScale), arg0)
-}
-
-// Channel mocks base method.
-func (m *MockApplication) Channel() params.Channel {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Channel")
-	ret0, _ := ret[0].(params.Channel)
-	return ret0
-}
-
-// Channel indicates an expected call of Channel.
-func (mr *MockApplicationMockRecorder) Channel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Channel", reflect.TypeOf((*MockApplication)(nil).Channel))
 }
 
 // Charm mocks base method.

--- a/apiserver/facades/client/application/updateseries_mocks_test.go
+++ b/apiserver/facades/client/application/updateseries_mocks_test.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v9 "github.com/juju/charm/v9"
-	params "github.com/juju/charmrepo/v7/csclient/params"
 	charmhub "github.com/juju/juju/charmhub"
 	transport "github.com/juju/juju/charmhub/transport"
 	config "github.com/juju/juju/core/config"
@@ -133,20 +132,6 @@ func (m *MockApplication) ChangeScale(arg0 int) (int, error) {
 func (mr *MockApplicationMockRecorder) ChangeScale(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeScale", reflect.TypeOf((*MockApplication)(nil).ChangeScale), arg0)
-}
-
-// Channel mocks base method.
-func (m *MockApplication) Channel() params.Channel {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Channel")
-	ret0, _ := ret[0].(params.Channel)
-	return ret0
-}
-
-// Channel indicates an expected call of Channel.
-func (mr *MockApplicationMockRecorder) Channel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Channel", reflect.TypeOf((*MockApplication)(nil).Channel))
 }
 
 // Charm mocks base method.

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1265,8 +1265,6 @@ func (context *statusContext) processApplication(application *state.Application)
 			Risk:   charm.Risk(stChannel.Risk),
 			Branch: stChannel.Branch,
 		}).Normalize().String()
-	} else {
-		channel = string(application.Channel())
 	}
 
 	origin := application.CharmOrigin()

--- a/apiserver/facades/controller/charmrevisionupdater/interface.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface.go
@@ -5,7 +5,6 @@ package charmrevisionupdater
 
 import (
 	"github.com/juju/charm/v9"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -33,7 +32,6 @@ type State interface {
 type Application interface {
 	CharmURL() (curl *string, force bool)
 	CharmOrigin() *state.CharmOrigin
-	Channel() csparams.Channel
 	ApplicationTag() names.ApplicationTag
 	UnitCount() int
 }

--- a/apiserver/facades/controller/charmrevisionupdater/interface_test.go
+++ b/apiserver/facades/controller/charmrevisionupdater/interface_test.go
@@ -57,7 +57,6 @@ func makeApplication(ctrl *gomock.Controller, schema, charmName, charmID, appID 
 			Channel:      "20.04/stable",
 		},
 	}).AnyTimes()
-	app.EXPECT().Channel().Return(csparams.Channel("latest/stable")).AnyTimes()
 	app.EXPECT().ApplicationTag().Return(names.ApplicationTag{Name: appID}).AnyTimes()
 
 	return app

--- a/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
+++ b/apiserver/facades/controller/charmrevisionupdater/mocks/mocks.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	charm "github.com/juju/charm/v9"
-	params "github.com/juju/charmrepo/v7/csclient/params"
 	charmrevisionupdater "github.com/juju/juju/apiserver/facades/controller/charmrevisionupdater"
 	charmhub "github.com/juju/juju/charmhub"
 	transport "github.com/juju/juju/charmhub/transport"
@@ -57,20 +56,6 @@ func (m *MockApplication) ApplicationTag() names.ApplicationTag {
 func (mr *MockApplicationMockRecorder) ApplicationTag() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationTag", reflect.TypeOf((*MockApplication)(nil).ApplicationTag))
-}
-
-// Channel mocks base method.
-func (m *MockApplication) Channel() params.Channel {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Channel")
-	ret0, _ := ret[0].(params.Channel)
-	return ret0
-}
-
-// Channel indicates an expected call of Channel.
-func (mr *MockApplicationMockRecorder) Channel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Channel", reflect.TypeOf((*MockApplication)(nil).Channel))
 }
 
 // CharmOrigin mocks base method.

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -203,8 +203,7 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 				continue
 			}
 			cid := charmstore.CharmID{
-				URL:     curl,
-				Channel: application.Channel(),
+				URL: curl,
 			}
 			if telemetry {
 				series, err := coreseries.GetSeriesFromChannel(origin.Platform.OS, origin.Platform.Channel)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -351,10 +351,17 @@ func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Applica
 	if origin == nil {
 		base, err := coreseries.GetBaseFromSeries(params.ch.URL().Series)
 		c.Assert(err, jc.ErrorIsNil)
-		origin = &CharmOrigin{Platform: &Platform{
-			OS:      base.OS,
-			Channel: base.Channel.String(),
-		}}
+		var channel *Channel
+		// local charms cannot have a channel
+		if charm.CharmHub.Matches(params.ch.URL().Schema) {
+			channel = &Channel{Risk: "stable"}
+		}
+		origin = &CharmOrigin{
+			Channel: channel,
+			Platform: &Platform{
+				OS:      base.OS,
+				Channel: base.Channel.String(),
+			}}
 	}
 	app, err := params.st.AddApplication(AddApplicationArgs{
 		Name:             params.name,

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -838,7 +838,6 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		Type:                 e.model.Type(),
 		Subordinate:          application.doc.Subordinate,
 		CharmURL:             *application.doc.CharmURL,
-		Channel:              application.doc.Channel,
 		CharmModifiedVersion: application.doc.CharmModifiedVersion,
 		ForceCharm:           application.doc.ForceCharm,
 		Exposed:              application.doc.Exposed,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1390,7 +1390,7 @@ func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, err
 			return nil, errors.Trace(err)
 		}
 		track := c.Track
-		if charm.CharmHub.Matches(co.Source()) && track == "" {
+		if corecharm.CharmHub.Matches(co.Source()) && track == "" {
 			track = "latest"
 		}
 		channel = &Channel{

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -399,7 +399,6 @@ func (s *MigrationSuite) TestApplicationDocFields(c *gc.C) {
 		"Name",
 		"Subordinate",
 		"CharmURL",
-		"Channel",
 		"CharmModifiedVersion",
 		"CharmOrigin",
 		"ForceCharm",

--- a/state/state.go
+++ b/state/state.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/juju/charm/v9"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -1082,7 +1081,6 @@ type AddApplicationArgs struct {
 	Name              string
 	Charm             *Charm
 	CharmOrigin       *CharmOrigin
-	Channel           csparams.Channel
 	Storage           map[string]StorageConstraints
 	Devices           map[string]DeviceConstraints
 	AttachStorage     []names.StorageTag
@@ -1254,7 +1252,6 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		Subordinate:   subordinate,
 		CharmURL:      &cURL,
 		CharmOrigin:   *args.CharmOrigin,
-		Channel:       string(args.Channel),
 		RelationCount: len(peers),
 		Life:          Alive,
 		UnitCount:     args.NumUnits,


### PR DESCRIPTION
There were 2 channels in the application doc, one in the old style csparams channel which was just a risk in the newer charmhub/snap style. With the removal of charm store support, the old style is no longer used, thus can be removed from the db.

The client and api side pieces will be handled in a different PR removing support for charm store for deploy. 

No changes to the SetApplication and Deploy params, these will both be changing in the near future with the new API work. And with the removal of charm store support will be ignored if provided.

Channel is not removed from the charmstore package which is slated for removal as part of this project. Removal from the juju client will happen with the work there to remove charmstore.

Drive by to update fix for LP1984061, charm.Charmhub is not the same as corecharm.Charmhub.

## QA steps

To test the bug code updated.
```sh
$ juju bootstrap localhost dst
$ juju bootstrap localhost src
$ juju add-model move-me
$ juju deploy ./testcharms/charm-repo/quantal/lxd-profile-alt --series focal --force
Located local charm "lxd-profile-alt", revision 0
Deploying "lxd-profile-alt" from local charm "lxd-profile-alt", revision 0 on ubuntu@20.04/stable
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 21
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 21 in channel stable on ubuntu@20.04/stable

# once the model has settled
$ juju migrate move-me dst

# when complete, switch models and check the db. Only charmhub charms will have a charm origin channel.
$ juju switch dst:move-me

juju:PRIMARY> db.applications.find({},{"charm-origin.channel":1}).pretty()
....
{
	"_id" : "44e2a292-dfff-4849-882e-e9daf6b5075e:lxd-profile-alt",
	"charm-origin" : {

	}
}
{
	"_id" : "44e2a292-dfff-4849-882e-e9daf6b5075e:ubuntu",
	"charm-origin" : {
		"channel" : {
			"track" : "latest",
			"risk" : "stable"
		}
	}
}

```