### PR TITLE
[JUJU-2321] Rewrite remove-unit client unit tests

### DIFF
--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -7,13 +7,11 @@ import (
 	"time"
 
 	"github.com/juju/cmd/v3"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/api/client/application"
-	"github.com/juju/juju/api/client/storage"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -193,41 +191,6 @@ func (c *removeUnitCommand) getAPI() (RemoveApplicationAPI, error) {
 	}
 	api := application.NewClient(root)
 	return api, nil
-}
-
-func (c *removeUnitCommand) getStorageAPI() (storageAPI, error) {
-	root, err := c.NewAPIRoot()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return storage.NewClient(root), nil
-}
-
-func (c *removeUnitCommand) unitsHaveStorage(unitNames []string) (bool, error) {
-	client, err := c.getStorageAPI()
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	defer client.Close()
-
-	storages, err := client.ListStorageDetails()
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	namesSet := set.NewStrings(unitNames...)
-	for _, s := range storages {
-		if s.OwnerTag == "" {
-			continue
-		}
-		owner, err := names.ParseTag(s.OwnerTag)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		if owner.Kind() == names.UnitTagKind && namesSet.Contains(owner.Id()) {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // Run connects to the environment specified on the command line and destroys


### PR DESCRIPTION
Rewrite remove-unit client unit tests to use gomock generated mocks.

This will make writing unit tests for dry-run and prompting functionality easier

Also, as a flyby remove some unused code in the client

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Verify unit tests pass and the juju client builds