### PR TITLE
[JUJU-2309] Add confirmation prompt to remove-unit cmd

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1511,6 +1511,9 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 				return nil, errors.Trace(err)
 			}
 		}
+		if arg.DryRun {
+			return &info, nil
+		}
 		op := unit.DestroyOperation()
 		op.DestroyStorage = arg.DestroyStorage
 		op.Force = arg.Force

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1261,6 +1261,51 @@ func (s *ApplicationSuite) TestDestroySubordinateUnits(c *gc.C) {
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, `unit "subordinate/0" is a subordinate, .*`)
 }
 
+func (s *ApplicationSuite) TestDestroyUnitDryRun(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	app := s.expectDefaultApplication(ctrl)
+	s.backend.EXPECT().Application("postgresql").MinTimes(1).Return(app, nil)
+
+	unit0 := s.expectUnit(ctrl, "postgresql/0")
+	unit0.EXPECT().IsPrincipal().Return(true)
+	s.backend.EXPECT().Unit("postgresql/0").Return(unit0, nil)
+
+	unit1 := s.expectUnit(ctrl, "postgresql/1")
+	unit1.EXPECT().IsPrincipal().Return(true)
+	s.backend.EXPECT().Unit("postgresql/1").Return(unit1, nil)
+
+	s.expectDefaultStorageAttachments(ctrl)
+
+	results, err := s.api.DestroyUnit(params.DestroyUnitsParams{
+		Units: []params.DestroyUnitParams{
+			{
+				UnitTag: "unit-postgresql-0",
+				DryRun:  true,
+			}, {
+				UnitTag: "unit-postgresql-1",
+				DryRun:  true,
+			},
+		},
+	})
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results, jc.DeepEquals, []params.DestroyUnitResult{{
+		Info: &params.DestroyUnitInfo{
+			DetachedStorage: []params.Entity{
+				{Tag: "storage-pgdata-0"},
+			},
+			DestroyedStorage: []params.Entity{
+				{Tag: "storage-pgdata-1"},
+			},
+		},
+	}, {
+		Info: &params.DestroyUnitInfo{},
+	}})
+}
+
 func (s *ApplicationSuite) TestDeployAttachStorage(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -11,13 +11,11 @@ import (
 	"time"
 
 	"github.com/juju/cmd/v3"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/api/client/application"
-	"github.com/juju/juju/api/client/storage"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -36,7 +34,7 @@ func NewRemoveApplicationCommand() cmd.Command {
 
 // removeApplicationCommand causes an existing application to be destroyed.
 // TODO(jack-w-shaw) This should inherit from ConfirmationCommandBase in
-// 3.1, once hebaviours have converged
+// 3.1, once behaviours have converged
 type removeApplicationCommand struct {
 	modelcmd.ModelCommandBase
 
@@ -89,7 +87,7 @@ Your controller does not support a more in depth dry run
 
 var removeApplicationMsgPrefix = "WARNING! This command:\n"
 
-var errDryRunNotSupported = errors.New("Your controller does not support `--dry-run`")
+var errDryRunNotSupportedByController = errors.New("Your controller does not support `--dry-run`")
 
 func (c *removeApplicationCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
@@ -102,7 +100,6 @@ func (c *removeApplicationCommand) Info() *cmd.Info {
 
 func (c *removeApplicationCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	// This unused var is declared so we can pass a valid ptr into BoolVar
 	f.BoolVar(&c.NoPrompt, "no-prompt", false, "Do not prompt for approval")
 	f.BoolVar(&c.DryRun, "dry-run", false, "Print what this command would remove without removing")
 	f.BoolVar(&c.DestroyStorage, "destroy-storage", false, "Destroy storage attached to application units")
@@ -154,11 +151,6 @@ type RemoveApplicationAPI interface {
 	BestAPIVersion() int
 }
 
-type storageAPI interface {
-	Close() error
-	ListStorageDetails() ([]params.StorageDetails, error)
-}
-
 func (c *removeApplicationCommand) getAPI() (RemoveApplicationAPI, error) {
 	root, err := c.NewAPIRoot()
 	if err != nil {
@@ -167,50 +159,7 @@ func (c *removeApplicationCommand) getAPI() (RemoveApplicationAPI, error) {
 	return application.NewClient(root), nil
 }
 
-func (c *removeApplicationCommand) getStorageAPI() (storageAPI, error) {
-	root, err := c.NewAPIRoot()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return storage.NewClient(root), nil
-}
-
-func (c *removeApplicationCommand) applicationsHaveStorage(appNames []string) (bool, error) {
-	client, err := c.getStorageAPI()
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	defer client.Close()
-
-	storages, err := client.ListStorageDetails()
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	namesSet := set.NewStrings(appNames...)
-	for _, s := range storages {
-		if s.OwnerTag == "" {
-			continue
-		}
-		owner, err := names.ParseTag(s.OwnerTag)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		if owner.Kind() != names.UnitTagKind {
-			continue
-		}
-		appName, err := names.UnitApplication(owner.Id())
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		if namesSet.Contains(appName) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func (c *removeApplicationCommand) Run(ctx *cmd.Context) error {
-
 	client, err := c.newAPIFunc()
 	if err != nil {
 		return err
@@ -236,8 +185,8 @@ func (c *removeApplicationCommand) removeApplications(
 
 	if !c.NoPrompt {
 		err := c.performDryRun(ctx, client)
-		if err == errDryRunNotSupported {
-			fmt.Fprintf(ctx.Stderr, removeApplicationMsgNoDryRun, strings.Join(c.ApplicationNames, ", "))
+		if err == errDryRunNotSupportedByController {
+			_, _ = fmt.Fprintf(ctx.Stderr, removeApplicationMsgNoDryRun, strings.Join(c.ApplicationNames, ", "))
 		} else if err != nil {
 			return errors.Trace(err)
 		}
@@ -266,16 +215,17 @@ func (c *removeApplicationCommand) performDryRun(
 ) error {
 	// TODO(jack-w-shaw) Drop this once application 15 support is dropped
 	if client.BestAPIVersion() < 16 {
-		return errDryRunNotSupported
+		return errDryRunNotSupportedByController
 	}
 	results, err := client.DestroyApplications(application.DestroyApplicationsParams{
-		Applications: c.ApplicationNames,
-		DryRun:       true,
+		Applications:   c.ApplicationNames,
+		DestroyStorage: c.DestroyStorage,
+		DryRun:         true,
 	})
 	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
 		return errors.Trace(err)
 	}
-	fmt.Fprintf(ctx.Stderr, removeApplicationMsgPrefix)
+	_, _ = fmt.Fprintf(ctx.Stderr, removeApplicationMsgPrefix)
 	if err := c.logResults(ctx, results, false); err != nil {
 		return errors.Trace(err)
 	}
@@ -312,11 +262,11 @@ func (c *removeApplicationCommand) logResult(
 			err = errors.New("another user was updating application; please try again")
 		}
 		err = errors.Annotatef(err, "removing application %s failed", name)
-		fmt.Fprintf(ctx.Stderr, "%s\n", err)
+		_, _ = fmt.Fprintf(ctx.Stderr, "%s\n", err)
 		return errors.Trace(err)
 	}
 	if !errorsOnly {
-		c.logRemovedApplication(ctx, name, result)
+		c.logRemovedApplication(ctx, name, result.Info)
 	}
 	return nil
 }
@@ -324,31 +274,31 @@ func (c *removeApplicationCommand) logResult(
 func (c *removeApplicationCommand) logRemovedApplication(
 	ctx *cmd.Context,
 	name string,
-	result params.DestroyApplicationResult,
+	info *params.DestroyApplicationInfo,
 ) {
-	fmt.Fprintf(ctx.Stdout, "will remove application %s\n", name)
-	for _, entity := range result.Info.DestroyedUnits {
+	_, _ = fmt.Fprintf(ctx.Stdout, "will remove application %s\n", name)
+	for _, entity := range info.DestroyedUnits {
 		unitTag, err := names.ParseUnitTag(entity.Tag)
 		if err != nil {
 			logger.Warningf("%s", err)
 			continue
 		}
-		fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(unitTag))
+		_, _ = fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(unitTag))
 	}
-	for _, entity := range result.Info.DestroyedStorage {
+	for _, entity := range info.DestroyedStorage {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
 		if err != nil {
 			logger.Warningf("%s", err)
 			continue
 		}
-		fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(storageTag))
+		_, _ = fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(storageTag))
 	}
-	for _, entity := range result.Info.DetachedStorage {
+	for _, entity := range info.DetachedStorage {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
 		if err != nil {
 			logger.Warningf("%s", err)
 			continue
 		}
-		fmt.Fprintf(ctx.Stdout, "- will detach %s\n", names.ReadableString(storageTag))
+		_, _ = fmt.Fprintf(ctx.Stdout, "- will detach %s\n", names.ReadableString(storageTag))
 	}
 }

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -111,9 +111,6 @@ func (s *removeApplicationSuite) TestRemoveApplicationDryRun(c *gc.C) {
 	ctx, err := s.runRemoveApplication(c, "real-app", "--dry-run")
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-WARNING! This command:
-`[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
 will remove application real-app
 `[1:])
@@ -159,12 +156,8 @@ func (s *removeApplicationSuite) TestRemoveApplicationPrompt(c *gc.C) {
 		c.Fatal("command took too long")
 	}
 
-	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `
-(?s)WARNING! This command:
-.*`[1:])
-	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
-(?s)will remove application real-app
-.*`[1:])
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `(?s).*Continue [y/N]?.*`)
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `(?s)will remove application real-app.*`)
 }
 
 func (s *removeApplicationSuite) TestRemoveApplicationPromptOldFacade(c *gc.C) {
@@ -193,7 +186,7 @@ func (s *removeApplicationSuite) TestRemoveApplicationPromptOldFacade(c *gc.C) {
 		c.Fatal("command took too long")
 	}
 
-	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `(?s).*Your controller does not support a more in depth dry run.*`)
+	c.Assert(c.GetTestLog(), gc.Matches, `(?s).*Your controller does not support dry runs.*`)
 }
 
 func setupRace(raceyApplications []string) func(args apiapplication.DestroyApplicationsParams) ([]params.DestroyApplicationResult, error) {
@@ -238,7 +231,7 @@ func (s *removeApplicationSuite) TestHandlingNotSupported(c *gc.C) {
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-removing application do-not-remove failed: another user was updating application; please try again
+ERROR removing application do-not-remove failed: another user was updating application; please try again
 `[1:])
 }
 
@@ -257,7 +250,7 @@ will remove application real-app
 will remove application another
 `[1:])
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, `
-removing application do-not-remove failed: another user was updating application; please try again
+ERROR removing application do-not-remove failed: another user was updating application; please try again
 `[1:])
 }
 
@@ -326,7 +319,7 @@ func (s *removeApplicationSuite) TestFailure(c *gc.C) {
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 	stderr := cmdtesting.Stderr(ctx)
 	c.Assert(stderr, gc.Equals, `
-removing application gargleblaster failed: doink
+ERROR removing application gargleblaster failed: doink
 `[1:])
 }
 

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -4,6 +4,10 @@
 package application
 
 import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/juju/cmd/v3"
@@ -16,6 +20,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -25,6 +30,8 @@ func NewRemoveUnitCommand() modelcmd.ModelCommand {
 }
 
 // removeUnitCommand is responsible for destroying application units.
+// TODO(jack-w-shaw) This should inherit from modelcmd.ConfirmationCommandBase
+// in 3.1 once confirmation behaviours have converged
 type removeUnitCommand struct {
 	modelcmd.ModelCommandBase
 	DestroyStorage bool
@@ -35,6 +42,8 @@ type removeUnitCommand struct {
 	unknownModel bool
 	Force        bool
 	NoWait       bool
+	NoPrompt     bool
+	DryRun       bool
 	fs           *gnuflag.FlagSet
 }
 
@@ -93,6 +102,13 @@ See also:
     scale-application
 `
 
+var removeUnitMsgNoDryRun = `
+WARNING! This command will remove unit(s) %q
+Your controller does not support a more in depth dry run
+`[1:]
+
+var removeUnitMsgPrefix = "This command will perform the following actions:"
+
 func (c *removeUnitCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
 		Name:    "remove-unit",
@@ -104,9 +120,8 @@ func (c *removeUnitCommand) Info() *cmd.Info {
 
 func (c *removeUnitCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	// This unused var is declared so we can pass a valid ptr into BoolVar
-	var noPromptHolder bool
-	f.BoolVar(&noPromptHolder, "no-prompt", false, "Does nothing. Option present for forward compatibility with Juju 3")
+	f.BoolVar(&c.NoPrompt, "no-prompt", false, "Do not prompt for approval")
+	f.BoolVar(&c.DryRun, "dry-run", false, "Print what this command would remove without removing")
 	f.IntVar(&c.NumUnits, "num-units", 0, "Number of units to remove (k8s models only)")
 	f.BoolVar(&c.DestroyStorage, "destroy-storage", false, "Destroy storage attached to the unit")
 	f.BoolVar(&c.Force, "force", false, "Completely remove an unit and all its dependencies")
@@ -122,6 +137,25 @@ func (c *removeUnitCommand) Init(args []string) error {
 		}
 
 		c.unknownModel = true
+	}
+	if !c.Force && c.NoWait {
+		return errors.NotValidf("--no-wait without --force")
+	}
+	// To maintain compatibility, in 3.0 NoPrompt should default to true.
+	// However, we still need to take into account the env var and the
+	// flag. So default initially to false, but if the env var and flag
+	// are not present, set to true.
+	// TODO(jack-w-shaw) use CheckSkipConfirmEnvVar in 3.1
+	if !c.NoPrompt {
+		if skipConf, ok := os.LookupEnv(osenv.JujuSkipConfirmationEnvKey); ok {
+			skipConfBool, err := strconv.ParseBool(skipConf)
+			if err != nil {
+				return errors.Annotatef(err, "value %q of env var %q is not a valid bool", skipConf, osenv.JujuSkipConfirmationEnvKey)
+			}
+			c.NoPrompt = skipConfBool
+		} else {
+			c.NoPrompt = true
+		}
 	}
 	return nil
 }
@@ -139,6 +173,10 @@ func (c *removeUnitCommand) validateArgsByModelType() error {
 }
 
 func (c *removeUnitCommand) validateCAASRemoval() error {
+	if c.DryRun {
+		// TODO(caas): enable --dry-run for caas model.
+		return errors.New("`--dry-run` is not supported for kubernetes units")
+	}
 	if c.DestroyStorage {
 		// TODO(caas): enable --destroy-storage for caas model.
 		return errors.New("k8s models only support --num-units")
@@ -196,19 +234,6 @@ func (c *removeUnitCommand) getAPI() (RemoveApplicationAPI, error) {
 // Run connects to the environment specified on the command line and destroys
 // units therein.
 func (c *removeUnitCommand) Run(ctx *cmd.Context) error {
-	noWaitSet := false
-	forceSet := false
-	c.fs.Visit(func(flag *gnuflag.Flag) {
-		if flag.Name == "no-wait" {
-			noWaitSet = true
-		} else if flag.Name == "force" {
-			forceSet = true
-		}
-	})
-	if !forceSet && noWaitSet {
-		return errors.NotValidf("--no-wait without --force")
-	}
-
 	client, err := c.getAPI()
 	if err != nil {
 		return err
@@ -232,10 +257,22 @@ func (c *removeUnitCommand) Run(ctx *cmd.Context) error {
 
 func (c *removeUnitCommand) removeUnits(ctx *cmd.Context, client RemoveApplicationAPI) error {
 	var maxWait *time.Duration
-	if c.Force {
-		if c.NoWait {
-			zeroSec := 0 * time.Second
-			maxWait = &zeroSec
+	if c.NoWait {
+		zeroSec := 0 * time.Second
+		maxWait = &zeroSec
+	}
+	if c.DryRun {
+		return c.performDryRun(ctx, client)
+	}
+	if !c.NoPrompt {
+		err := c.performDryRun(ctx, client)
+		if err == errDryRunNotSupportedByController {
+			_, _ = fmt.Fprintf(ctx.Stderr, removeUnitMsgNoDryRun, strings.Join(c.EntityNames, ", "))
+		} else if err != nil {
+			return errors.Trace(err)
+		}
+		if err := jujucmd.UserConfirmYes(ctx); err != nil {
+			return errors.Annotate(err, "unit removal")
 		}
 	}
 
@@ -249,36 +286,83 @@ func (c *removeUnitCommand) removeUnits(ctx *cmd.Context, client RemoveApplicati
 	if err != nil {
 		return block.ProcessBlockedError(err, block.BlockRemove)
 	}
+	logAll := c.NoPrompt || client.BestAPIVersion() < 16
+	return c.logResults(ctx, results, !logAll)
+}
+
+func (c *removeUnitCommand) performDryRun(ctx *cmd.Context, client RemoveApplicationAPI) error {
+	// TODO(jack-w-shaw) Drop this once application 15 support is dropped
+	if client.BestAPIVersion() < 16 {
+		return errDryRunNotSupportedByController
+	}
+	results, err := client.DestroyUnits(application.DestroyUnitsParams{
+		Units:          c.EntityNames,
+		DestroyStorage: c.DestroyStorage,
+		DryRun:         true,
+	})
+	if err != nil {
+		return block.ProcessBlockedError(err, block.BlockRemove)
+	}
+	_, _ = fmt.Fprintf(ctx.Stderr, removeUnitMsgPrefix)
+	if err := c.logResults(ctx, results, false); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *removeUnitCommand) logResults(
+	ctx *cmd.Context,
+	results []params.DestroyUnitResult,
+	errorOnly bool,
+) error {
 	anyFailed := false
 	for i, name := range c.EntityNames {
 		result := results[i]
-		if result.Error != nil {
+		if err := c.logResult(ctx, name, result, errorOnly); err != nil {
 			anyFailed = true
-			ctx.Infof("removing unit %s failed: %s", name, result.Error)
-			continue
-		}
-		ctx.Infof("removing unit %s", name)
-		for _, entity := range result.Info.DestroyedStorage {
-			storageTag, err := names.ParseStorageTag(entity.Tag)
-			if err != nil {
-				logger.Warningf("%s", err)
-				continue
-			}
-			ctx.Infof("- will remove %s", names.ReadableString(storageTag))
-		}
-		for _, entity := range result.Info.DetachedStorage {
-			storageTag, err := names.ParseStorageTag(entity.Tag)
-			if err != nil {
-				logger.Warningf("%s", err)
-				continue
-			}
-			ctx.Infof("- will detach %s", names.ReadableString(storageTag))
 		}
 	}
 	if anyFailed {
 		return cmd.ErrSilent
 	}
 	return nil
+}
+
+func (c *removeUnitCommand) logResult(
+	ctx *cmd.Context,
+	name string,
+	result params.DestroyUnitResult,
+	errorOnly bool,
+) error {
+	if result.Error != nil {
+		err := errors.Annotatef(result.Error, "removing unit %s failed", name)
+		_, _ = fmt.Fprintf(ctx.Stderr, "%s\n", err)
+		return errors.Trace(err)
+	}
+	if !errorOnly {
+		c.logRemovedUnit(ctx, name, result.Info)
+	}
+	return nil
+}
+
+func (c *removeUnitCommand) logRemovedUnit(ctx *cmd.Context, name string, info *params.DestroyUnitInfo) {
+	_, _ = fmt.Fprintf(ctx.Stdout, "will remove unit %s\n", name)
+	for _, entity := range info.DestroyedStorage {
+		storageTag, err := names.ParseStorageTag(entity.Tag)
+		if err != nil {
+			logger.Warningf("%s", err)
+			continue
+		}
+		_, _ = fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(storageTag))
+	}
+	for _, entity := range info.DetachedStorage {
+		storageTag, err := names.ParseStorageTag(entity.Tag)
+		if err != nil {
+			logger.Warningf("%s", err)
+			continue
+		}
+		_, _ = fmt.Fprintf(ctx.Stdout, "- will detach %s\n", names.ReadableString(storageTag))
+	}
 }
 
 func (c *removeUnitCommand) removeCaasUnits(ctx *cmd.Context, client RemoveApplicationAPI) error {

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -88,7 +88,7 @@ will remove unit unit/1
 - will detach storage data/1
 `[1:])
 	c.Assert(stderr, gc.Equals, `
-removing unit unit/2 failed: doink
+ERROR removing unit unit/2 failed: doink
 `[1:])
 }
 
@@ -118,7 +118,7 @@ will remove unit unit/1
 - will remove storage data/1
 `[1:])
 	c.Assert(stderr, gc.Equals, `
-removing unit unit/2 failed: doink
+ERROR removing unit unit/2 failed: doink
 `[1:])
 }
 
@@ -155,10 +155,6 @@ func (s *RemoveUnitSuite) TestRemoveUnitDryRun(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	stdout := cmdtesting.Stdout(ctx)
-	stderr := cmdtesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, `
-WARNING! This command:
-`[1:])
 	c.Assert(stdout, gc.Equals, `
 will remove unit unit/0
 - will detach storage data/0
@@ -206,9 +202,6 @@ func (s *RemoveUnitSuite) TestRemoveUnitWithPrompt(c *gc.C) {
 		c.Fatal("command took too long")
 	}
 
-	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `
-(?s)WARNING! This command:
-.*`[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
 (?s)will remove unit unit/0
 .*`[1:])
@@ -240,7 +233,7 @@ func (s *RemoveUnitSuite) TestRemoveUnitWithPromptOldFacade(c *gc.C) {
 		c.Fatal("command took too long")
 	}
 
-	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `(?s).*Your controller does not support a more in depth dry run.*`)
+	c.Assert(c.GetTestLog(), gc.Matches, `(?s).*Your controller does not support dry runs.*`)
 }
 
 func (s *RemoveUnitSuite) setCaasModel() {

--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -4,6 +4,9 @@
 package application_test
 
 import (
+	"bytes"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
@@ -13,11 +16,14 @@ import (
 
 	apiapplication "github.com/juju/juju/api/client/application"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/cmd/cmdtest"
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/application/mocks"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
+	"github.com/juju/juju/provider/dummy"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/testing"
 )
@@ -33,76 +39,10 @@ type RemoveUnitSuite struct {
 
 var _ = gc.Suite(&RemoveUnitSuite{})
 
-type fakeApplicationRemoveUnitAPI struct {
-	application.RemoveApplicationAPI
-
-	units          []string
-	scale          int
-	destroyStorage bool
-	err            error
-}
-
-func (f *fakeApplicationRemoveUnitAPI) Close() error {
-	return nil
-}
-
-func (f *fakeApplicationRemoveUnitAPI) ModelUUID() string {
-	return "fake-uuid"
-}
-
-func (f *fakeApplicationRemoveUnitAPI) DestroyUnits(args apiapplication.DestroyUnitsParams) ([]params.DestroyUnitResult, error) {
-	if f.err != nil {
-		return nil, f.err
-	}
-	f.units = args.Units
-	f.destroyStorage = args.DestroyStorage
-	var result []params.DestroyUnitResult
-	for _, u := range args.Units {
-		var info *params.DestroyUnitInfo
-		var err *params.Error
-		switch u {
-		case "unit/0":
-			st := []params.Entity{{Tag: "storage-data-0"}}
-			info = &params.DestroyUnitInfo{}
-			if f.destroyStorage {
-				info.DestroyedStorage = st
-			} else {
-				info.DetachedStorage = st
-			}
-		case "unit/1":
-			st := []params.Entity{{Tag: "storage-data-1"}}
-			info = &params.DestroyUnitInfo{}
-			if f.destroyStorage {
-				info.DestroyedStorage = st
-			} else {
-				info.DetachedStorage = st
-			}
-		case "unit/2":
-			err = &params.Error{Code: params.CodeNotFound, Message: `unit "unit/2" does not exist`}
-		}
-		result = append(result, params.DestroyUnitResult{
-			Info:  info,
-			Error: err,
-		})
-	}
-	return result, nil
-}
-
-func (f *fakeApplicationRemoveUnitAPI) ScaleApplication(args apiapplication.ScaleApplicationParams) (params.ScaleApplicationResult, error) {
-	if f.err != nil {
-		return params.ScaleApplicationResult{}, f.err
-	}
-	f.scale += args.ScaleChange
-	return params.ScaleApplicationResult{
-		Info: &params.ScaleApplicationInfo{
-			Scale: f.scale,
-		},
-	}, nil
-}
-
 func (s *RemoveUnitSuite) SetUpTest(c *gc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.store = jujuclienttesting.MinimalStore()
+	s.facadeVersion = 16
 }
 
 func (s *RemoveUnitSuite) setup(c *gc.C) *gomock.Controller {
@@ -116,6 +56,11 @@ func (s *RemoveUnitSuite) setup(c *gc.C) *gomock.Controller {
 
 func (s *RemoveUnitSuite) runRemoveUnit(c *gc.C, args ...string) (*cmd.Context, error) {
 	return cmdtesting.RunCommand(c, application.NewRemoveUnitCommandForTest(s.mockApi, s.store), args...)
+}
+
+func (s *RemoveUnitSuite) runWithContext(ctx *cmd.Context, args ...string) (chan dummy.Operation, chan error) {
+	remove := application.NewRemoveUnitCommandForTest(s.mockApi, s.store)
+	return cmdtest.RunCommandWithDummyProvider(ctx, remove, args...)
 }
 
 func (s *RemoveUnitSuite) TestRemoveUnit(c *gc.C) {
@@ -134,12 +79,15 @@ func (s *RemoveUnitSuite) TestRemoveUnit(c *gc.C) {
 	ctx, err := s.runRemoveUnit(c, "unit/0", "unit/1", "unit/2")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 
+	stdout := cmdtesting.Stdout(ctx)
 	stderr := cmdtesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, `
-removing unit unit/0
+	c.Assert(stdout, gc.Equals, `
+will remove unit unit/0
 - will detach storage data/0
-removing unit unit/1
+will remove unit unit/1
 - will detach storage data/1
+`[1:])
+	c.Assert(stderr, gc.Equals, `
 removing unit unit/2 failed: doink
 `[1:])
 }
@@ -161,12 +109,15 @@ func (s *RemoveUnitSuite) TestRemoveUnitDestroyStorage(c *gc.C) {
 	ctx, err := s.runRemoveUnit(c, "unit/0", "unit/1", "unit/2", "--destroy-storage")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 
+	stdout := cmdtesting.Stdout(ctx)
 	stderr := cmdtesting.Stderr(ctx)
-	c.Assert(stderr, gc.Equals, `
-removing unit unit/0
+	c.Assert(stdout, gc.Equals, `
+will remove unit unit/0
 - will remove storage data/0
-removing unit unit/1
+will remove unit unit/1
 - will remove storage data/1
+`[1:])
+	c.Assert(stderr, gc.Equals, `
 removing unit unit/2 failed: doink
 `[1:])
 }
@@ -186,6 +137,110 @@ func (s *RemoveUnitSuite) TestBlockRemoveUnit(c *gc.C) {
 	s.runRemoveUnit(c, "some-unit-name/0")
 
 	c.Check(c.GetTestLog(), gc.Matches, "(?s).*TestBlockRemoveUnit.*")
+}
+
+func (s *RemoveUnitSuite) TestRemoveUnitDryRun(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.mockApi.EXPECT().DestroyUnits(apiapplication.DestroyUnitsParams{
+		Units:  []string{"unit/0", "unit/1"},
+		DryRun: true,
+	}).Return([]params.DestroyUnitResult{{
+		Info: &params.DestroyUnitInfo{DetachedStorage: []params.Entity{{Tag: "storage-data-0"}}},
+	}, {
+		Info: &params.DestroyUnitInfo{DetachedStorage: []params.Entity{{Tag: "storage-data-1"}}},
+	}}, nil)
+
+	ctx, err := s.runRemoveUnit(c, "--dry-run", "unit/0", "unit/1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	stdout := cmdtesting.Stdout(ctx)
+	stderr := cmdtesting.Stderr(ctx)
+	c.Assert(stderr, gc.Equals, `
+WARNING! This command:
+`[1:])
+	c.Assert(stdout, gc.Equals, `
+will remove unit unit/0
+- will detach storage data/0
+will remove unit unit/1
+- will detach storage data/1
+`[1:])
+}
+
+func (s *RemoveUnitSuite) TestRemoveUnitDryRunOldFacade(c *gc.C) {
+	s.facadeVersion = 15
+	defer s.setup(c).Finish()
+
+	_, err := s.runRemoveUnit(c, "--dry-run", "unit/0", "unit/1")
+	c.Assert(err, gc.ErrorMatches, "Your controller does not support `--dry-run`")
+}
+
+func (s *RemoveUnitSuite) TestRemoveUnitWithPrompt(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	var stdin bytes.Buffer
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = &stdin
+
+	s.mockApi.EXPECT().DestroyUnits(apiapplication.DestroyUnitsParams{
+		Units:  []string{"unit/0"},
+		DryRun: true,
+	}).Return([]params.DestroyUnitResult{{
+		Info: &params.DestroyUnitInfo{},
+	}}, nil)
+	s.mockApi.EXPECT().DestroyUnits(apiapplication.DestroyUnitsParams{
+		Units: []string{"unit/0"},
+	}).Return([]params.DestroyUnitResult{{
+		Info: &params.DestroyUnitInfo{},
+	}}, nil)
+
+	stdin.WriteString("y")
+	_, errc := s.runWithContext(ctx, "unit/0")
+
+	select {
+	case err := <-errc:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("command took too long")
+	}
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `
+(?s)WARNING! This command:
+.*`[1:])
+	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
+(?s)will remove unit unit/0
+.*`[1:])
+}
+
+func (s *RemoveUnitSuite) TestRemoveUnitWithPromptOldFacade(c *gc.C) {
+	s.facadeVersion = 15
+	defer s.setup(c).Finish()
+
+	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
+
+	var stdin bytes.Buffer
+	ctx := cmdtesting.Context(c)
+	ctx.Stdin = &stdin
+
+	s.mockApi.EXPECT().DestroyUnits(apiapplication.DestroyUnitsParams{
+		Units: []string{"unit/0"},
+	}).Return([]params.DestroyUnitResult{{
+		Info: &params.DestroyUnitInfo{},
+	}}, nil)
+
+	stdin.WriteString("y")
+	_, errc := s.runWithContext(ctx, "unit/0")
+
+	select {
+	case err := <-errc:
+		c.Check(err, jc.ErrorIsNil)
+	case <-time.After(testing.LongWait):
+		c.Fatal("command took too long")
+	}
+
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `(?s).*Your controller does not support a more in depth dry run.*`)
 }
 
 func (s *RemoveUnitSuite) setCaasModel() {

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -194,7 +194,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	if !c.NoPrompt {
 		err := c.performDryRun(ctx, client)
 		if err == errDryRunNotSupported {
-			fmt.Fprintf(ctx.Stderr, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
+			_, _ = fmt.Fprintf(ctx.Stderr, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
 		} else if err != nil {
 			return errors.Trace(err)
 		}
@@ -259,44 +259,44 @@ func (c *removeCommand) logResults(ctx *cmd.Context, results []params.DestroyMac
 func (c *removeCommand) logResult(ctx *cmd.Context, result params.DestroyMachineResult, errorOnly bool) error {
 	if result.Error != nil {
 		err := errors.Annotate(result.Error, "removing machine failed")
-		fmt.Fprintf(ctx.Stderr, "%s\n", err)
+		_, _ = fmt.Fprintf(ctx.Stderr, "%s\n", err)
 		return errors.Trace(err)
 	}
 	if !errorOnly {
-		c.logRemovedMachine(ctx, result)
+		c.logRemovedMachine(ctx, result.Info)
 	}
 	return c.logResults(ctx, result.Info.DestroyedContainers, errorOnly)
 }
 
-func (c *removeCommand) logRemovedMachine(ctx *cmd.Context, result params.DestroyMachineResult) {
-	id := result.Info.MachineId
+func (c *removeCommand) logRemovedMachine(ctx *cmd.Context, info *params.DestroyMachineInfo) {
+	id := info.MachineId
 	if c.KeepInstance {
-		fmt.Fprintf(ctx.Stdout, "will remove machine %s (but retaining cloud instance)\n", id)
+		_, _ = fmt.Fprintf(ctx.Stdout, "will remove machine %s (but retaining cloud instance)\n", id)
 	} else {
-		fmt.Fprintf(ctx.Stdout, "will remove machine %s\n", id)
+		_, _ = fmt.Fprintf(ctx.Stdout, "will remove machine %s\n", id)
 	}
-	for _, entity := range result.Info.DestroyedUnits {
+	for _, entity := range info.DestroyedUnits {
 		unitTag, err := names.ParseUnitTag(entity.Tag)
 		if err != nil {
 			logger.Warningf("%s", err)
 			continue
 		}
-		fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(unitTag))
+		_, _ = fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(unitTag))
 	}
-	for _, entity := range result.Info.DestroyedStorage {
+	for _, entity := range info.DestroyedStorage {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
 		if err != nil {
 			logger.Warningf("%s", err)
 			continue
 		}
-		fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(storageTag))
+		_, _ = fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(storageTag))
 	}
-	for _, entity := range result.Info.DetachedStorage {
+	for _, entity := range info.DetachedStorage {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
 		if err != nil {
 			logger.Warningf("%s", err)
 			continue
 		}
-		fmt.Fprintf(ctx.Stdout, "- will detach %s\n", names.ReadableString(storageTag))
+		_, _ = fmt.Fprintf(ctx.Stdout, "- will detach %s\n", names.ReadableString(storageTag))
 	}
 }

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -75,11 +75,10 @@ See also:
 `
 
 var removeMachineMsgNoDryRun = `
-WARNING! This command will remove machine(s) %q
-Your controller does not support a more in depth dry run
-`[1:]
+This command will remove machine(s) %q
+Your controller does not support dry runs`[1:]
 
-var removeMachineMsgPrefix = "WARNING! This command:\n"
+var removeMachineMsgPrefix = "This command will perform the following actions:"
 
 var errDryRunNotSupported = errors.New("Your controller does not support `--dry-run`")
 
@@ -113,7 +112,9 @@ func (c *removeCommand) Init(args []string) error {
 			return errors.Errorf("invalid machine id %q", id)
 		}
 	}
-
+	if !c.Force && c.NoWait {
+		return errors.NotValidf("--no-wait without --force")
+	}
 	// To maintain compatibility, in 3.0 NoPrompt should default to true.
 	// However, we still need to take into account the env var and the
 	// flag. So default initially to false, but if the env var and flag
@@ -161,24 +162,10 @@ func (c *removeCommand) getRemoveMachineAPI() (RemoveMachineAPI, error) {
 
 // Run implements Command.Run.
 func (c *removeCommand) Run(ctx *cmd.Context) error {
-	noWaitSet := false
-	forceSet := false
-	c.fs.Visit(func(flag *gnuflag.Flag) {
-		if flag.Name == "no-wait" {
-			noWaitSet = true
-		} else if flag.Name == "force" {
-			forceSet = true
-		}
-	})
-	if !forceSet && noWaitSet {
-		return errors.NotValidf("--no-wait without --force")
-	}
 	var maxWait *time.Duration
-	if c.Force {
-		if c.NoWait {
-			zeroSec := 0 * time.Second
-			maxWait = &zeroSec
-		}
+	if c.NoWait {
+		zeroSec := 0 * time.Second
+		maxWait = &zeroSec
 	}
 
 	client, err := c.getRemoveMachineAPI()
@@ -194,9 +181,9 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	if !c.NoPrompt {
 		err := c.performDryRun(ctx, client)
 		if err == errDryRunNotSupported {
-			_, _ = fmt.Fprintf(ctx.Stderr, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
+			ctx.Warningf(removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
 		} else if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if err := jujucmd.UserConfirmYes(ctx); err != nil {
 			return errors.Annotate(err, "machine removal")
@@ -209,7 +196,11 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	}
 
 	logAll := c.NoPrompt || client.BestAPIVersion() < 10
-	return c.logResults(ctx, results, !logAll)
+	if logAll {
+		return c.logResults(ctx, results)
+	} else {
+		return c.logErrors(ctx, results)
+	}
 }
 
 func (c *removeCommand) performDryRun(ctx *cmd.Context, client RemoveMachineAPI) error {
@@ -221,12 +212,13 @@ func (c *removeCommand) performDryRun(ctx *cmd.Context, client RemoveMachineAPI)
 	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
 		return errors.Trace(err)
 	}
-	fmt.Fprint(ctx.Stderr, removeMachineMsgPrefix)
-	if err := c.logResults(ctx, results, false); err != nil {
-		return errors.Trace(err)
+	if err := c.logErrors(ctx, results); err != nil {
+		return err
 	}
+	ctx.Warningf(removeMachineMsgPrefix)
+	_ = c.logResults(ctx, results)
 	if c.runNeedsForce(results) {
-		fmt.Fprint(ctx.Stdout, "\nThis will require `--force`\n")
+		ctx.Infof("\nThis will require `--force`")
 	}
 	return nil
 }
@@ -243,7 +235,15 @@ func (c *removeCommand) runNeedsForce(results []params.DestroyMachineResult) boo
 	return false
 }
 
-func (c *removeCommand) logResults(ctx *cmd.Context, results []params.DestroyMachineResult, errorOnly bool) error {
+func (c *removeCommand) logErrors(ctx *cmd.Context, results []params.DestroyMachineResult) error {
+	return c.log(ctx, results, true)
+}
+
+func (c *removeCommand) logResults(ctx *cmd.Context, results []params.DestroyMachineResult) error {
+	return c.log(ctx, results, false)
+}
+
+func (c *removeCommand) log(ctx *cmd.Context, results []params.DestroyMachineResult, errorOnly bool) error {
 	anyFailed := false
 	for _, result := range results {
 		if err := c.logResult(ctx, result, errorOnly); err != nil {
@@ -259,13 +259,13 @@ func (c *removeCommand) logResults(ctx *cmd.Context, results []params.DestroyMac
 func (c *removeCommand) logResult(ctx *cmd.Context, result params.DestroyMachineResult, errorOnly bool) error {
 	if result.Error != nil {
 		err := errors.Annotate(result.Error, "removing machine failed")
-		_, _ = fmt.Fprintf(ctx.Stderr, "%s\n", err)
+		cmd.WriteError(ctx.Stderr, err)
 		return errors.Trace(err)
 	}
 	if !errorOnly {
 		c.logRemovedMachine(ctx, result.Info)
 	}
-	return c.logResults(ctx, result.Info.DestroyedContainers, errorOnly)
+	return c.log(ctx, result.Info.DestroyedContainers, errorOnly)
 }
 
 func (c *removeCommand) logRemovedMachine(ctx *cmd.Context, info *params.DestroyMachineInfo) {
@@ -278,7 +278,7 @@ func (c *removeCommand) logRemovedMachine(ctx *cmd.Context, info *params.Destroy
 	for _, entity := range info.DestroyedUnits {
 		unitTag, err := names.ParseUnitTag(entity.Tag)
 		if err != nil {
-			logger.Warningf("%s", err)
+			ctx.Warningf("%s", err)
 			continue
 		}
 		_, _ = fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(unitTag))
@@ -286,7 +286,7 @@ func (c *removeCommand) logRemovedMachine(ctx *cmd.Context, info *params.Destroy
 	for _, entity := range info.DestroyedStorage {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
 		if err != nil {
-			logger.Warningf("%s", err)
+			ctx.Warningf("%s", err)
 			continue
 		}
 		_, _ = fmt.Fprintf(ctx.Stdout, "- will remove %s\n", names.ReadableString(storageTag))
@@ -294,7 +294,7 @@ func (c *removeCommand) logRemovedMachine(ctx *cmd.Context, info *params.Destroy
 	for _, entity := range info.DetachedStorage {
 		storageTag, err := names.ParseStorageTag(entity.Tag)
 		if err != nil {
-			logger.Warningf("%s", err)
+			ctx.Warningf("%s", err)
 			continue
 		}
 		_, _ = fmt.Fprintf(ctx.Stdout, "- will detach %s\n", names.ReadableString(storageTag))

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -229,7 +229,7 @@ func (s *RemoveMachineSuite) TestRemoveOutput(c *gc.C) {
 	stderr := cmdtesting.Stderr(ctx)
 	stdout := cmdtesting.Stdout(ctx)
 	c.Assert(stderr, gc.Equals, `
-removing machine failed: oy vey machine 1
+ERROR removing machine failed: oy vey machine 1
 `[1:])
 	c.Assert(stdout, gc.Equals, `
 will remove machine 2/lxd/1
@@ -323,11 +323,7 @@ func (s *RemoveMachineSuite) TestRemoveOutputDryRun(c *gc.C) {
 
 	ctx, err := s.run(c, "--dry-run", "1", "2")
 	c.Assert(err, jc.ErrorIsNil)
-	stderr := cmdtesting.Stderr(ctx)
 	stdout := cmdtesting.Stdout(ctx)
-	c.Assert(stderr, gc.Equals, `
-WARNING! This command:
-`[1:])
 	c.Assert(stdout, gc.Equals, `
 will remove machine 1
 will remove machine 2


### PR DESCRIPTION
Implement the dry-run option for DestroyUnit, and use this to generate a preview in the confirmation prompt

Also do some minor cleanups as a flyby

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

With both a new and old (i.e. the current release) controller, verify the following commands act as expected

- `juju remove-unit` & `juju remove-unit --no-prompt` should behave as before. No prompts should be shown
- `juju remove-unit --dry-run` should output a readable dry run of what will be removed for a new controller. It should fail smoothly for an old controller
- `JUJU_SKIP_CONFIRMATION=0 juju remove-unit` should prompt the user before continuing. For a new controller, a dry-run should be provided as well. 

For extra credit try removing a unit with storage attached