### PR TITLE
Thread through the context.Context

### DIFF
--- a/apiserver/common/addresses.go
+++ b/apiserver/common/addresses.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
@@ -38,7 +40,7 @@ func NewAPIAddresser(getter APIAddressAccessor, resources facade.Resources) *API
 }
 
 // APIHostPorts returns the API server addresses.
-func (a *APIAddresser) APIHostPorts() (params.APIHostPortsResult, error) {
+func (a *APIAddresser) APIHostPorts(ctx context.Context) (params.APIHostPortsResult, error) {
 	sSvrs, err := a.getter.APIHostPortsForAgents()
 	if err != nil {
 		return params.APIHostPortsResult{}, err
@@ -56,7 +58,7 @@ func (a *APIAddresser) APIHostPorts() (params.APIHostPortsResult, error) {
 }
 
 // WatchAPIHostPorts watches the API server addresses.
-func (a *APIAddresser) WatchAPIHostPorts() (params.NotifyWatchResult, error) {
+func (a *APIAddresser) WatchAPIHostPorts(ctx context.Context) (params.NotifyWatchResult, error) {
 	watch := a.getter.WatchAPIHostPortsForAgents()
 	if _, ok := <-watch.Changes(); ok {
 		return params.NotifyWatchResult{
@@ -67,7 +69,7 @@ func (a *APIAddresser) WatchAPIHostPorts() (params.NotifyWatchResult, error) {
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (a *APIAddresser) APIAddresses() (params.StringsResult, error) {
+func (a *APIAddresser) APIAddresses(ctx context.Context) (params.StringsResult, error) {
 	addrs, err := apiAddresses(a.getter)
 	if err != nil {
 		return params.StringsResult{}, err

--- a/apiserver/common/addresses_test.go
+++ b/apiserver/common/addresses_test.go
@@ -4,6 +4,8 @@
 package common_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -35,7 +37,7 @@ func (s *apiAddresserSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *apiAddresserSuite) TestAPIAddresses(c *gc.C) {
-	result, err := s.addresser.APIAddresses()
+	result, err := s.addresser.APIAddresses(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Result, gc.DeepEquals, []string{"apiaddresses:1", "apiaddresses:2"})
 }
@@ -59,7 +61,7 @@ func (s *apiAddresserSuite) TestAPIAddressesPrivateFirst(c *gc.C) {
 		}
 	}
 
-	result, err := s.addresser.APIAddresses()
+	result, err := s.addresser.APIAddresses(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(result.Result, gc.DeepEquals, []string{

--- a/apiserver/common/cloudspec/cloudspec.go
+++ b/apiserver/common/cloudspec/cloudspec.go
@@ -4,6 +4,8 @@
 package cloudspec
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -21,13 +23,13 @@ import (
 // CloudSpecer defines the CloudSpec api interface
 type CloudSpecer interface {
 	// WatchCloudSpecsChanges returns a watcher for cloud spec changes.
-	WatchCloudSpecsChanges(args params.Entities) (params.NotifyWatchResults, error)
+	WatchCloudSpecsChanges(context.Context, params.Entities) (params.NotifyWatchResults, error)
 
 	// CloudSpec returns the model's cloud spec.
-	CloudSpec(args params.Entities) (params.CloudSpecResults, error)
+	CloudSpec(context.Context, params.Entities) (params.CloudSpecResults, error)
 
 	// GetCloudSpec constructs the CloudSpec for a validated and authorized model.
-	GetCloudSpec(tag names.ModelTag) params.CloudSpecResult
+	GetCloudSpec(context.Context, names.ModelTag) params.CloudSpecResult
 }
 
 type CloudSpecAPI struct {
@@ -123,7 +125,7 @@ func k8sCloudSpecChanger(
 }
 
 // CloudSpec returns the model's cloud spec.
-func (s CloudSpecAPI) CloudSpec(args params.Entities) (params.CloudSpecResults, error) {
+func (s CloudSpecAPI) CloudSpec(ctx context.Context, args params.Entities) (params.CloudSpecResults, error) {
 	authFunc, err := s.getAuthFunc()
 	if err != nil {
 		return params.CloudSpecResults{}, err
@@ -141,13 +143,13 @@ func (s CloudSpecAPI) CloudSpec(args params.Entities) (params.CloudSpecResults, 
 			results.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
-		results.Results[i] = s.GetCloudSpec(tag)
+		results.Results[i] = s.GetCloudSpec(ctx, tag)
 	}
 	return results, nil
 }
 
 // GetCloudSpec constructs the CloudSpec for a validated and authorized model.
-func (s CloudSpecAPI) GetCloudSpec(tag names.ModelTag) params.CloudSpecResult {
+func (s CloudSpecAPI) GetCloudSpec(ctx context.Context, tag names.ModelTag) params.CloudSpecResult {
 	var result params.CloudSpecResult
 	spec, err := s.getCloudSpec(tag)
 	if err != nil {
@@ -177,7 +179,7 @@ func (s CloudSpecAPI) GetCloudSpec(tag names.ModelTag) params.CloudSpecResult {
 }
 
 // WatchCloudSpecsChanges returns a watcher for cloud spec changes.
-func (s CloudSpecAPI) WatchCloudSpecsChanges(args params.Entities) (params.NotifyWatchResults, error) {
+func (s CloudSpecAPI) WatchCloudSpecsChanges(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	authFunc, err := s.getAuthFunc()
 	if err != nil {
 		return params.NotifyWatchResults{}, err

--- a/apiserver/common/cloudspec/cloudspec_test.go
+++ b/apiserver/common/cloudspec/cloudspec_test.go
@@ -4,6 +4,7 @@
 package cloudspec_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v4"
@@ -86,7 +87,7 @@ func (s *CloudSpecSuite) getTestCloudSpec(credentialContentWatcher state.NotifyW
 func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 	otherModelTag := names.NewModelTag(utils.MustNewUUID().String())
 	machineTag := names.NewMachineTag("42")
-	result, err := s.api.CloudSpec(params.Entities{Entities: []params.Entity{
+	result, err := s.api.CloudSpec(context.TODO(), params.Entities{Entities: []params.Entity{
 		{coretesting.ModelTag.String()},
 		{otherModelTag.String()},
 		{machineTag.String()},
@@ -128,7 +129,7 @@ func (s *CloudSpecSuite) TestCloudSpec(c *gc.C) {
 func (s *CloudSpecSuite) TestWatchCloudSpecsChanges(c *gc.C) {
 	otherModelTag := names.NewModelTag(utils.MustNewUUID().String())
 	machineTag := names.NewMachineTag("42")
-	result, err := s.api.WatchCloudSpecsChanges(params.Entities{Entities: []params.Entity{
+	result, err := s.api.WatchCloudSpecsChanges(context.TODO(), params.Entities{Entities: []params.Entity{
 		{coretesting.ModelTag.String()},
 		{otherModelTag.String()},
 		{machineTag.String()},
@@ -158,7 +159,7 @@ func (s *CloudSpecSuite) TestWatchCloudSpecsChanges(c *gc.C) {
 
 func (s *CloudSpecSuite) TestWatchCloudSpecsNoCredentialContentToWatch(c *gc.C) {
 	s.api = s.getTestCloudSpec(nil)
-	result, err := s.api.WatchCloudSpecsChanges(params.Entities{Entities: []params.Entity{
+	result, err := s.api.WatchCloudSpecsChanges(context.TODO(), params.Entities{Entities: []params.Entity{
 		{coretesting.ModelTag.String()},
 	}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -176,7 +177,7 @@ func (s *CloudSpecSuite) TestWatchCloudSpecsNoCredentialContentToWatch(c *gc.C) 
 
 func (s *CloudSpecSuite) TestCloudSpecNilCredential(c *gc.C) {
 	s.result.Credential = nil
-	result, err := s.api.CloudSpec(params.Entities{
+	result, err := s.api.CloudSpec(context.TODO(), params.Entities{
 		Entities: []params.Entity{{coretesting.ModelTag.String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -198,7 +199,7 @@ func (s *CloudSpecSuite) TestCloudSpecNilCredential(c *gc.C) {
 func (s *CloudSpecSuite) TestCloudSpecGetAuthFuncError(c *gc.C) {
 	expect := errors.New("bewm")
 	s.SetErrors(expect)
-	result, err := s.api.CloudSpec(params.Entities{
+	result, err := s.api.CloudSpec(context.TODO(), params.Entities{
 		Entities: []params.Entity{{coretesting.ModelTag.String()}},
 	})
 	c.Assert(err, gc.Equals, expect)
@@ -207,7 +208,7 @@ func (s *CloudSpecSuite) TestCloudSpecGetAuthFuncError(c *gc.C) {
 
 func (s *CloudSpecSuite) TestCloudSpecCloudSpecError(c *gc.C) {
 	s.SetErrors(nil, errors.New("bewm"))
-	result, err := s.api.CloudSpec(params.Entities{
+	result, err := s.api.CloudSpec(context.TODO(), params.Entities{
 		Entities: []params.Entity{{coretesting.ModelTag.String()}},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -26,7 +28,7 @@ func NewStateControllerConfig(st ControllerConfigState) *ControllerConfigAPI {
 }
 
 // ControllerConfig returns the controller's configuration.
-func (s *ControllerConfigAPI) ControllerConfig() (params.ControllerConfigResult, error) {
+func (s *ControllerConfigAPI) ControllerConfig(context.Context) (params.ControllerConfigResult, error) {
 	result := params.ControllerConfigResult{}
 	config, err := s.st.ControllerConfig()
 	if err != nil {
@@ -37,7 +39,7 @@ func (s *ControllerConfigAPI) ControllerConfig() (params.ControllerConfigResult,
 }
 
 // ControllerAPIInfoForModels returns the controller api connection details for the specified models.
-func (s *ControllerConfigAPI) ControllerAPIInfoForModels(args params.Entities) (params.ControllerAPIInfoResults, error) {
+func (s *ControllerConfigAPI) ControllerAPIInfoForModels(ctx context.Context, args params.Entities) (params.ControllerAPIInfoResults, error) {
 	var result params.ControllerAPIInfoResults
 	result.Results = make([]params.ControllerAPIInfoResult, len(args.Entities))
 	for i, entity := range args.Entities {

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/golang/mock/gomock"
@@ -63,7 +64,7 @@ func (s *controllerConfigSuite) TestControllerConfigSuccess(c *gc.C) {
 		nil,
 	)
 
-	result, err := s.cc.ControllerConfig()
+	result, err := s.cc.ControllerConfig(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(map[string]interface{}(result.Config), jc.DeepEquals, map[string]interface{}{
 		"ca-cert":         testing.CACert,
@@ -77,7 +78,7 @@ func (s *controllerConfigSuite) TestControllerConfigFetchError(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.st.EXPECT().ControllerConfig().Return(nil, fmt.Errorf("pow"))
-	_, err := s.cc.ControllerConfig()
+	_, err := s.cc.ControllerConfig(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 
@@ -96,7 +97,7 @@ func (s *controllerConfigSuite) TestControllerInfo(c *gc.C) {
 	s.st.EXPECT().ModelExists(testing.ModelTag.Id()).Return(true, nil)
 	s.expectStateControllerInfo(c)
 
-	results, err := s.cc.ControllerAPIInfoForModels(params.Entities{
+	results, err := s.cc.ControllerAPIInfoForModels(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: testing.ModelTag.String()}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -126,7 +127,7 @@ func (s *controllerInfoSuite) SetUpTest(c *gc.C) {
 
 func (s *controllerInfoSuite) TestControllerInfoLocalModel(c *gc.C) {
 	cc := common.NewStateControllerConfig(s.State)
-	results, err := cc.ControllerAPIInfoForModels(params.Entities{
+	results, err := cc.ControllerAPIInfoForModels(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: s.localModel.ModelTag().String()}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -150,7 +151,7 @@ func (s *controllerInfoSuite) TestControllerInfoExternalModel(c *gc.C) {
 	_, err := ec.Save(info, modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	cc := common.NewStateControllerConfig(s.State)
-	results, err := cc.ControllerAPIInfoForModels(params.Entities{
+	results, err := cc.ControllerAPIInfoForModels(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: names.NewModelTag(modelUUID).String()}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
@@ -188,7 +189,7 @@ func (s *controllerInfoSuite) TestControllerInfoMigratedController(c *gc.C) {
 	c.Assert(model.Destroy(state.DestroyModelParams{}), jc.ErrorIsNil)
 	c.Assert(modelState.RemoveDyingModel(), jc.ErrorIsNil)
 
-	externalControllerInfo, err := cc.ControllerAPIInfoForModels(params.Entities{
+	externalControllerInfo, err := cc.ControllerAPIInfoForModels(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: names.NewModelTag(model.UUID()).String()}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(len(externalControllerInfo.Results), gc.Equals, 1)

--- a/apiserver/common/credentialcommon/cloudcredential.go
+++ b/apiserver/common/credentialcommon/cloudcredential.go
@@ -4,6 +4,8 @@
 package credentialcommon
 
 import (
+	"context"
+
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
 )
@@ -23,7 +25,7 @@ func NewCredentialManagerAPI(backend StateBackend) *CredentialManagerAPI {
 }
 
 // InvalidateModelCredential marks the cloud credential for this model as invalid.
-func (api *CredentialManagerAPI) InvalidateModelCredential(args params.InvalidateCredentialArg) (params.ErrorResult, error) {
+func (api *CredentialManagerAPI) InvalidateModelCredential(ctx context.Context, args params.InvalidateCredentialArg) (params.ErrorResult, error) {
 	err := api.backend.InvalidateModelCredential(args.Reason)
 	if err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil

--- a/apiserver/common/credentialcommon/cloudcredential_test.go
+++ b/apiserver/common/credentialcommon/cloudcredential_test.go
@@ -4,6 +4,8 @@
 package credentialcommon_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -31,7 +33,7 @@ func (s *CredentialSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CredentialSuite) TestInvalidateModelCredential(c *gc.C) {
-	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
+	result, err := s.api.InvalidateModelCredential(context.TODO(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -42,7 +44,7 @@ func (s *CredentialSuite) TestInvalidateModelCredential(c *gc.C) {
 func (s *CredentialSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
+	result, err := s.api.InvalidateModelCredential(context.TODO(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: apiservererrors.ServerError(expected)})
 	s.backend.CheckCalls(c, []testing.StubCall{

--- a/apiserver/common/ensuredead.go
+++ b/apiserver/common/ensuredead.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -52,7 +54,7 @@ func (d *DeadEnsurer) ensureEntityDead(tag names.Tag) error {
 // EnsureDead calls EnsureDead on each given entity from state. It
 // will fail if the entity is not present. If it's Alive, nothing will
 // happen (see state/EnsureDead() for units or machines).
-func (d *DeadEnsurer) EnsureDead(args params.Entities) (params.ErrorResults, error) {
+func (d *DeadEnsurer) EnsureDead(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}

--- a/apiserver/common/ensuredead_test.go
+++ b/apiserver/common/ensuredead_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v4"
@@ -66,7 +67,7 @@ func (*deadEnsurerSuite) TestEnsureDead(c *gc.C) {
 	entities := params.Entities{[]params.Entity{
 		{"unit-x-0"}, {"unit-x-1"}, {"unit-x-2"}, {"unit-x-3"}, {"unit-x-4"}, {"unit-x-5"},
 	}}
-	result, err := d.EnsureDead(entities)
+	result, err := d.EnsureDead(context.TODO(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(afterDeadCalled, jc.IsTrue)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
@@ -86,7 +87,7 @@ func (*deadEnsurerSuite) TestEnsureDeadError(c *gc.C) {
 		return nil, fmt.Errorf("pow")
 	}
 	d := common.NewDeadEnsurer(&fakeState{}, nil, getCanModify)
-	_, err := d.EnsureDead(params.Entities{[]params.Entity{{"x0"}}})
+	_, err := d.EnsureDead(context.TODO(), params.Entities{[]params.Entity{{"x0"}}})
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 
@@ -95,7 +96,7 @@ func (*removeSuite) TestEnsureDeadNoArgsNoError(c *gc.C) {
 		return nil, fmt.Errorf("pow")
 	}
 	d := common.NewDeadEnsurer(&fakeState{}, nil, getCanModify)
-	result, err := d.EnsureDead(params.Entities{})
+	result, err := d.EnsureDead(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 0)
 }

--- a/apiserver/common/getstatus.go
+++ b/apiserver/common/getstatus.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v4"
@@ -53,7 +54,7 @@ func (s *StatusGetter) getEntityStatus(tag names.Tag) params.StatusResult {
 }
 
 // Status returns the status of each given entity.
-func (s *StatusGetter) Status(args params.Entities) (params.StatusResults, error) {
+func (s *StatusGetter) Status(ctx context.Context, args params.Entities) (params.StatusResults, error) {
 	result := params.StatusResults{
 		Results: make([]params.StatusResult, len(args.Entities)),
 	}

--- a/apiserver/common/getstatus_test.go
+++ b/apiserver/common/getstatus_test.go
@@ -4,6 +4,8 @@
 package common_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -35,7 +37,7 @@ func (s *statusGetterSuite) SetUpTest(c *gc.C) {
 func (s *statusGetterSuite) TestUnauthorized(c *gc.C) {
 	tag := names.NewMachineTag("42")
 	s.badTag = tag
-	result, err := s.getter.Status(params.Entities{[]params.Entity{{
+	result, err := s.getter.Status(context.TODO(), params.Entities{[]params.Entity{{
 		tag.String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -44,7 +46,7 @@ func (s *statusGetterSuite) TestUnauthorized(c *gc.C) {
 }
 
 func (s *statusGetterSuite) TestNotATag(c *gc.C) {
-	result, err := s.getter.Status(params.Entities{[]params.Entity{{
+	result, err := s.getter.Status(context.TODO(), params.Entities{[]params.Entity{{
 		"not a tag",
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -53,7 +55,7 @@ func (s *statusGetterSuite) TestNotATag(c *gc.C) {
 }
 
 func (s *statusGetterSuite) TestNotFound(c *gc.C) {
-	result, err := s.getter.Status(params.Entities{[]params.Entity{{
+	result, err := s.getter.Status(context.TODO(), params.Entities{[]params.Entity{{
 		names.NewMachineTag("42").String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -63,7 +65,7 @@ func (s *statusGetterSuite) TestNotFound(c *gc.C) {
 
 func (s *statusGetterSuite) TestGetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
-	result, err := s.getter.Status(params.Entities{[]params.Entity{{
+	result, err := s.getter.Status(context.TODO(), params.Entities{[]params.Entity{{
 		machine.Tag().String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -80,7 +82,7 @@ func (s *statusGetterSuite) TestGetUnitStatus(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
 		Status: status.Maintenance,
 	}})
-	result, err := s.getter.Status(params.Entities{[]params.Entity{{
+	result, err := s.getter.Status(context.TODO(), params.Entities{[]params.Entity{{
 		unit.Tag().String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -94,7 +96,7 @@ func (s *statusGetterSuite) TestGetApplicationStatus(c *gc.C) {
 	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
 		Status: status.Maintenance,
 	}})
-	result, err := s.getter.Status(params.Entities{[]params.Entity{{
+	result, err := s.getter.Status(context.TODO(), params.Entities{[]params.Entity{{
 		app.Tag().String(),
 	}}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -107,7 +109,7 @@ func (s *statusGetterSuite) TestGetApplicationStatus(c *gc.C) {
 func (s *statusGetterSuite) TestBulk(c *gc.C) {
 	s.badTag = names.NewMachineTag("42")
 	machine := s.Factory.MakeMachine(c, nil)
-	result, err := s.getter.Status(params.Entities{[]params.Entity{{
+	result, err := s.getter.Status(context.TODO(), params.Entities{[]params.Entity{{
 		s.badTag.String(),
 	}, {
 		machine.Tag().String(),

--- a/apiserver/common/instanceidgetter.go
+++ b/apiserver/common/instanceidgetter.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -43,7 +45,7 @@ func (ig *InstanceIdGetter) getInstanceId(tag names.Tag) (instance.Id, error) {
 
 // InstanceId returns the provider specific instance id for each given
 // machine or an CodeNotProvisioned error, if not set.
-func (ig *InstanceIdGetter) InstanceId(args params.Entities) (params.StringResults, error) {
+func (ig *InstanceIdGetter) InstanceId(ctx context.Context, args params.Entities) (params.StringResults, error) {
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Entities)),
 	}

--- a/apiserver/common/instanceidgetter_test.go
+++ b/apiserver/common/instanceidgetter_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v4"
@@ -56,7 +57,7 @@ func (*instanceIdGetterSuite) TestInstanceId(c *gc.C) {
 	entities := params.Entities{[]params.Entity{
 		{"unit-x-0"}, {"unit-x-1"}, {"unit-x-2"}, {"unit-x-3"}, {"unit-x-4"},
 	}}
-	results, err := ig.InstanceId(entities)
+	results, err := ig.InstanceId(context.TODO(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -74,6 +75,6 @@ func (*instanceIdGetterSuite) TestInstanceIdError(c *gc.C) {
 		return nil, fmt.Errorf("pow")
 	}
 	ig := common.NewInstanceIdGetter(&fakeState{}, getCanRead)
-	_, err := ig.InstanceId(params.Entities{[]params.Entity{{"unit-x-0"}}})
+	_, err := ig.InstanceId(context.TODO(), params.Entities{[]params.Entity{{"unit-x-0"}}})
 	c.Assert(err, gc.ErrorMatches, "pow")
 }

--- a/apiserver/common/life.go
+++ b/apiserver/common/life.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -41,7 +43,7 @@ func (lg *LifeGetter) oneLife(tag names.Tag) (life.Value, error) {
 }
 
 // Life returns the life status of every supplied entity, where available.
-func (lg *LifeGetter) Life(args params.Entities) (params.LifeResults, error) {
+func (lg *LifeGetter) Life(ctx context.Context, args params.Entities) (params.LifeResults, error) {
 	result := params.LifeResults{
 		Results: make([]params.LifeResult, len(args.Entities)),
 	}

--- a/apiserver/common/life_test.go
+++ b/apiserver/common/life_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v4"
@@ -52,7 +53,7 @@ func (*lifeSuite) TestLife(c *gc.C) {
 	entities := params.Entities{[]params.Entity{
 		{"unit-x-0"}, {"unit-x-1"}, {"unit-x-2"}, {"unit-x-3"}, {"unit-x-4"},
 	}}
-	results, err := lg.Life(entities)
+	results, err := lg.Life(context.TODO(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
@@ -70,7 +71,7 @@ func (*lifeSuite) TestLifeError(c *gc.C) {
 		return nil, fmt.Errorf("pow")
 	}
 	lg := common.NewLifeGetter(&fakeState{}, getCanRead)
-	_, err := lg.Life(params.Entities{[]params.Entity{{"x0"}}})
+	_, err := lg.Life(context.TODO(), params.Entities{[]params.Entity{{"x0"}}})
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 
@@ -79,7 +80,7 @@ func (*lifeSuite) TestLifeNoArgsNoError(c *gc.C) {
 		return nil, fmt.Errorf("pow")
 	}
 	lg := common.NewLifeGetter(&fakeState{}, getCanRead)
-	result, err := lg.Life(params.Entities{})
+	result, err := lg.Life(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 0)
 }

--- a/apiserver/common/mocks/tools_mock.go
+++ b/apiserver/common/mocks/tools_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -41,18 +42,18 @@ func (m *MockToolsFinder) EXPECT() *MockToolsFinderMockRecorder {
 }
 
 // FindAgents mocks base method.
-func (m *MockToolsFinder) FindAgents(arg0 common.FindAgentsParams) (tools.List, error) {
+func (m *MockToolsFinder) FindAgents(arg0 context.Context, arg1 common.FindAgentsParams) (tools.List, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAgents", arg0)
+	ret := m.ctrl.Call(m, "FindAgents", arg0, arg1)
 	ret0, _ := ret[0].(tools.List)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAgents indicates an expected call of FindAgents.
-func (mr *MockToolsFinderMockRecorder) FindAgents(arg0 interface{}) *gomock.Call {
+func (mr *MockToolsFinderMockRecorder) FindAgents(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAgents", reflect.TypeOf((*MockToolsFinder)(nil).FindAgents), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAgents", reflect.TypeOf((*MockToolsFinder)(nil).FindAgents), arg0, arg1)
 }
 
 // MockToolsFindEntity is a mock of ToolsFindEntity interface.

--- a/apiserver/common/modelmachineswatcher.go
+++ b/apiserver/common/modelmachineswatcher.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -42,7 +43,7 @@ func NewModelMachinesWatcher(st state.ModelMachinesWatcher, resources facade.Res
 // WatchModelMachines returns a StringsWatcher that notifies of
 // changes to the life cycles of the top level machines in the current
 // model.
-func (e *ModelMachinesWatcher) WatchModelMachines() (params.StringsWatchResult, error) {
+func (e *ModelMachinesWatcher) WatchModelMachines(ctx context.Context) (params.StringsWatchResult, error) {
 	result := params.StringsWatchResult{}
 	if !e.authorizer.AuthController() {
 		return result, apiservererrors.ErrPerm
@@ -61,7 +62,7 @@ func (e *ModelMachinesWatcher) WatchModelMachines() (params.StringsWatchResult, 
 
 // WatchModelMachineStartTimes watches the non-container machines in the model
 // for changes to the Life or AgentStartTime fields and reports them as a batch.
-func (e *ModelMachinesWatcher) WatchModelMachineStartTimes() (params.StringsWatchResult, error) {
+func (e *ModelMachinesWatcher) WatchModelMachineStartTimes(ctx context.Context) (params.StringsWatchResult, error) {
 	result := params.StringsWatchResult{}
 	if !e.authorizer.AuthController() {
 		return result, apiservererrors.ErrPerm

--- a/apiserver/common/modelmachineswatcher_test.go
+++ b/apiserver/common/modelmachineswatcher_test.go
@@ -4,6 +4,8 @@
 package common_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -45,7 +47,7 @@ func (s *modelMachinesWatcherSuite) TestWatchModelMachines(c *gc.C) {
 		resources,
 		authorizer,
 	)
-	result, err := e.WatchModelMachines()
+	result, err := e.WatchModelMachines(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StringsWatchResult{"1", []string{"foo"}, nil})
 	c.Assert(resources.Count(), gc.Equals, 1)
@@ -63,7 +65,7 @@ func (s *modelMachinesWatcherSuite) TestWatchAuthError(c *gc.C) {
 		resources,
 		authorizer,
 	)
-	_, err := e.WatchModelMachines()
+	_, err := e.WatchModelMachines(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(resources.Count(), gc.Equals, 0)
 }

--- a/apiserver/common/modelwatcher.go
+++ b/apiserver/common/modelwatcher.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -37,7 +39,7 @@ func NewModelWatcher(st state.ModelAccessor, resources facade.Resources, authori
 // Note that although the NotifyWatchResult contains an Error field,
 // it's not used because we are only returning a single watcher,
 // so we use the regular error return.
-func (m *ModelWatcher) WatchForModelConfigChanges() (params.NotifyWatchResult, error) {
+func (m *ModelWatcher) WatchForModelConfigChanges(ctx context.Context) (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
 	watch := m.st.WatchForModelConfigChanges()
 	// Consume the initial event. Technically, API
@@ -53,7 +55,7 @@ func (m *ModelWatcher) WatchForModelConfigChanges() (params.NotifyWatchResult, e
 }
 
 // ModelConfig returns the current model's configuration.
-func (m *ModelWatcher) ModelConfig() (params.ModelConfigResult, error) {
+func (m *ModelWatcher) ModelConfig(ctx context.Context) (params.ModelConfigResult, error) {
 	result := params.ModelConfigResult{}
 	config, err := m.st.ModelConfig()
 	if err != nil {

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -61,7 +61,7 @@ func (s *modelWatcherSuite) TestWatchSuccess(c *gc.C) {
 		resources,
 		nil,
 	)
-	result, err := e.WatchForModelConfigChanges()
+	result, err := e.WatchForModelConfigChanges(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{"1", nil})
 	c.Assert(resources.Count(), gc.Equals, 1)
@@ -78,7 +78,7 @@ func (*modelWatcherSuite) TestModelConfigSuccess(c *gc.C) {
 		nil,
 		authorizer,
 	)
-	result, err := e.ModelConfig()
+	result, err := e.ModelConfig(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	// Make sure we can read the secret attribute (i.e. it's not masked).
 	c.Check(result.Config["secret"], gc.Equals, "pork")
@@ -97,7 +97,7 @@ func (*modelWatcherSuite) TestModelConfigFetchError(c *gc.C) {
 		nil,
 		authorizer,
 	)
-	_, err := e.ModelConfig()
+	_, err := e.ModelConfig(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 

--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -7,6 +7,7 @@
 package networkingcommon
 
 import (
+	"context"
 	"net"
 	"strings"
 
@@ -65,7 +66,7 @@ func NewNetworkConfigAPI(st *state.State, getCanModify common.GetAuthFunc) (*Net
 // identified by the input args.
 // This config is merged with the new network config supplied in the
 // same args and updated if it has changed.
-func (api *NetworkConfigAPI) SetObservedNetworkConfig(args params.SetMachineNetworkConfig) error {
+func (api *NetworkConfigAPI) SetObservedNetworkConfig(ctx context.Context, args params.SetMachineNetworkConfig) error {
 	m, err := api.getMachineForSettingNetworkConfig(args.Tag)
 	if err != nil {
 		return errors.Trace(err)

--- a/apiserver/common/networkingcommon/networkconfigapi_test.go
+++ b/apiserver/common/networkingcommon/networkconfigapi_test.go
@@ -4,6 +4,8 @@
 package networkingcommon_test
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3/txn"
@@ -51,7 +53,7 @@ func (s *networkConfigSuite) TestSetObservedNetworkConfigMachineNotFoundPermissi
 
 	s.state.EXPECT().Machine("1").Return(nil, errors.NotFoundf("nope"))
 
-	err := s.NewNetworkConfigAPI(s.state, s.getModelOp).SetObservedNetworkConfig(params.SetMachineNetworkConfig{
+	err := s.NewNetworkConfigAPI(s.state, s.getModelOp).SetObservedNetworkConfig(context.TODO(), params.SetMachineNetworkConfig{
 		Tag:    "machine-1",
 		Config: nil,
 	})
@@ -569,7 +571,7 @@ func (s *networkConfigSuite) expectMachine() {
 }
 
 func (s *networkConfigSuite) callAPI(c *gc.C, config []params.NetworkConfig) {
-	c.Assert(s.NewNetworkConfigAPI(s.state, s.getModelOp).SetObservedNetworkConfig(params.SetMachineNetworkConfig{
+	c.Assert(s.NewNetworkConfigAPI(s.state, s.getModelOp).SetObservedNetworkConfig(context.TODO(), params.SetMachineNetworkConfig{
 		Tag:    s.tag.String(),
 		Config: config,
 	}), jc.ErrorIsNil)

--- a/apiserver/common/password.go
+++ b/apiserver/common/password.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -32,7 +34,7 @@ func NewPasswordChanger(st state.EntityFinder, getCanChange GetAuthFunc) *Passwo
 }
 
 // SetPasswords sets the given password for each supplied entity, if possible.
-func (pc *PasswordChanger) SetPasswords(args params.EntityPasswords) (params.ErrorResults, error) {
+func (pc *PasswordChanger) SetPasswords(ctx context.Context, args params.EntityPasswords) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Changes)),
 	}

--- a/apiserver/common/password_test.go
+++ b/apiserver/common/password_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -130,7 +131,7 @@ func (*passwordSuite) TestSetPasswords(c *gc.C) {
 			Password: fmt.Sprintf("%spass", tag),
 		})
 	}
-	results, err := pc.SetPasswords(params.EntityPasswords{
+	results, err := pc.SetPasswords(context.TODO(), params.EntityPasswords{
 		Changes: changes,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -169,7 +170,7 @@ func (*passwordSuite) TestSetPasswordsError(c *gc.C) {
 			Password: fmt.Sprintf("%spass", tag),
 		})
 	}
-	_, err := pc.SetPasswords(params.EntityPasswords{Changes: changes})
+	_, err := pc.SetPasswords(context.TODO(), params.EntityPasswords{Changes: changes})
 	c.Assert(err, gc.ErrorMatches, "splat")
 }
 
@@ -178,7 +179,7 @@ func (*passwordSuite) TestSetPasswordsNoArgsNoError(c *gc.C) {
 		return nil, fmt.Errorf("splat")
 	}
 	pc := common.NewPasswordChanger(&fakeState{}, getCanChange)
-	result, err := pc.SetPasswords(params.EntityPasswords{})
+	result, err := pc.SetPasswords(context.TODO(), params.EntityPasswords{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 0)
 }

--- a/apiserver/common/reboot.go
+++ b/apiserver/common/reboot.go
@@ -5,6 +5,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -39,7 +41,7 @@ func (r *RebootRequester) oneRequest(tag names.Tag) error {
 }
 
 // RequestReboot sets the reboot flag on the provided machines
-func (r *RebootRequester) RequestReboot(args params.Entities) (params.ErrorResults, error) {
+func (r *RebootRequester) RequestReboot(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -100,7 +102,7 @@ func (r *RebootActionGetter) getOneAction(tag names.Tag) (params.RebootAction, e
 // a reboot flag set on the machine parent or grandparent, will
 // cause the machine to shutdown (params.ShouldShutdown).
 // If no reboot flag is set, the machine should do nothing (params.ShouldDoNothing).
-func (r *RebootActionGetter) GetRebootAction(args params.Entities) (params.RebootActionResults, error) {
+func (r *RebootActionGetter) GetRebootAction(ctx context.Context, args params.Entities) (params.RebootActionResults, error) {
 	result := params.RebootActionResults{
 		Results: make([]params.RebootActionResult, len(args.Entities)),
 	}
@@ -152,7 +154,7 @@ func (r *RebootFlagClearer) clearOneFlag(tag names.Tag) error {
 }
 
 // ClearReboot will clear the reboot flag on provided machines, if it exists.
-func (r *RebootFlagClearer) ClearReboot(args params.Entities) (params.ErrorResults, error) {
+func (r *RebootFlagClearer) ClearReboot(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}

--- a/apiserver/common/remove.go
+++ b/apiserver/common/remove.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -67,7 +68,7 @@ func (r *Remover) removeEntity(tag names.Tag) error {
 
 // Remove removes every given entity from state, calling EnsureDead
 // first, then Remove. It will fail if the entity is not present.
-func (r *Remover) Remove(args params.Entities) (params.ErrorResults, error) {
+func (r *Remover) Remove(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}

--- a/apiserver/common/remove_test.go
+++ b/apiserver/common/remove_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v4"
@@ -73,7 +74,7 @@ func (*removeSuite) TestRemove(c *gc.C) {
 	entities := params.Entities{[]params.Entity{
 		{"unit-x-0"}, {"unit-x-1"}, {"unit-x-2"}, {"unit-x-3"}, {"unit-x-4"}, {"unit-x-5"}, {"unit-x-6"},
 	}}
-	result, err := r.Remove(entities)
+	result, err := r.Remove(context.TODO(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(afterDeadCalled, jc.IsTrue)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
@@ -93,7 +94,7 @@ func (*removeSuite) TestRemove(c *gc.C) {
 	afterDeadCalled = false
 	r = common.NewRemover(st, afterDead, false, getCanModify)
 	entities = params.Entities{[]params.Entity{{"unit-x-0"}, {"unit-x-1"}}}
-	result, err = r.Remove(entities)
+	result, err = r.Remove(context.TODO(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(afterDeadCalled, jc.IsFalse)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
@@ -109,7 +110,7 @@ func (*removeSuite) TestRemoveError(c *gc.C) {
 		return nil, fmt.Errorf("pow")
 	}
 	r := common.NewRemover(&fakeState{}, nil, true, getCanModify)
-	_, err := r.Remove(params.Entities{[]params.Entity{{"x0"}}})
+	_, err := r.Remove(context.TODO(), params.Entities{[]params.Entity{{"x0"}}})
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 
@@ -118,7 +119,7 @@ func (*removeSuite) TestRemoveNoArgsNoError(c *gc.C) {
 		return nil, fmt.Errorf("pow")
 	}
 	r := common.NewRemover(&fakeState{}, nil, true, getCanModify)
-	result, err := r.Remove(params.Entities{})
+	result, err := r.Remove(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 0)
 }

--- a/apiserver/common/setstatus.go
+++ b/apiserver/common/setstatus.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -159,7 +160,7 @@ func (s *StatusSetter) setEntityStatus(tag names.Tag, entityStatus status.Status
 }
 
 // SetStatus sets the status of each given entity.
-func (s *StatusSetter) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (s *StatusSetter) SetStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -193,7 +194,7 @@ type UnitAgentFinder struct {
 }
 
 // FindEntity implements state.EntityFinder and returns unit agents.
-func (ua *UnitAgentFinder) FindEntity(tag names.Tag) (state.Entity, error) {
+func (ua *UnitAgentFinder) FindEntity(ctx context.Context, tag names.Tag) (state.Entity, error) {
 	_, ok := tag.(names.UnitTag)
 	if !ok {
 		return nil, errors.Errorf("unsupported tag %T", tag)

--- a/apiserver/common/setstatus_test.go
+++ b/apiserver/common/setstatus_test.go
@@ -4,6 +4,8 @@
 package common_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -34,7 +36,7 @@ func (s *statusSetterSuite) SetUpTest(c *gc.C) {
 func (s *statusSetterSuite) TestUnauthorized(c *gc.C) {
 	tag := names.NewMachineTag("42")
 	s.badTag = tag
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
+	result, err := s.setter.SetStatus(context.TODO(), params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    tag.String(),
 		Status: status.Executing.String(),
 	}}})
@@ -44,7 +46,7 @@ func (s *statusSetterSuite) TestUnauthorized(c *gc.C) {
 }
 
 func (s *statusSetterSuite) TestNotATag(c *gc.C) {
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
+	result, err := s.setter.SetStatus(context.TODO(), params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    "not a tag",
 		Status: status.Executing.String(),
 	}}})
@@ -54,7 +56,7 @@ func (s *statusSetterSuite) TestNotATag(c *gc.C) {
 }
 
 func (s *statusSetterSuite) TestNotFound(c *gc.C) {
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
+	result, err := s.setter.SetStatus(context.TODO(), params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    names.NewMachineTag("42").String(),
 		Status: status.Down.String(),
 	}}})
@@ -65,7 +67,7 @@ func (s *statusSetterSuite) TestNotFound(c *gc.C) {
 
 func (s *statusSetterSuite) TestSetMachineStatus(c *gc.C) {
 	machine := s.Factory.MakeMachine(c, nil)
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
+	result, err := s.setter.SetStatus(context.TODO(), params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    machine.Tag().String(),
 		Status: status.Started.String(),
 	}}})
@@ -87,7 +89,7 @@ func (s *statusSetterSuite) TestSetUnitStatus(c *gc.C) {
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Status: &status.StatusInfo{
 		Status: status.Maintenance,
 	}})
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
+	result, err := s.setter.SetStatus(context.TODO(), params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    unit.Tag().String(),
 		Status: status.Active.String(),
 	}}})
@@ -109,7 +111,7 @@ func (s *statusSetterSuite) TestSetServiceStatus(c *gc.C) {
 	service := s.Factory.MakeApplication(c, &factory.ApplicationParams{Status: &status.StatusInfo{
 		Status: status.Maintenance,
 	}})
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
+	result, err := s.setter.SetStatus(context.TODO(), params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    service.Tag().String(),
 		Status: status.Active.String(),
 	}}})
@@ -126,7 +128,7 @@ func (s *statusSetterSuite) TestSetServiceStatus(c *gc.C) {
 
 func (s *statusSetterSuite) TestBulk(c *gc.C) {
 	s.badTag = names.NewMachineTag("42")
-	result, err := s.setter.SetStatus(params.SetStatus{[]params.EntityStatusArgs{{
+	result, err := s.setter.SetStatus(context.TODO(), params.SetStatus{[]params.EntityStatusArgs{{
 		Tag:    s.badTag.String(),
 		Status: status.Active.String(),
 	}, {
@@ -291,21 +293,21 @@ func (unitAgentFinderSuite) TestFindEntity(c *gc.C) {
 		},
 	}
 	ua := &common.UnitAgentFinder{f}
-	entity, err := ua.FindEntity(names.NewUnitTag("unit/0"))
+	entity, err := ua.FindEntity(context.TODO(), names.NewUnitTag("unit/0"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(entity, gc.DeepEquals, f.unit.agent)
 }
 
 func (unitAgentFinderSuite) TestFindEntityBadTag(c *gc.C) {
 	ua := &common.UnitAgentFinder{fakeEntityFinder{}}
-	_, err := ua.FindEntity(names.NewApplicationTag("foo"))
+	_, err := ua.FindEntity(context.TODO(), names.NewApplicationTag("foo"))
 	c.Assert(err, gc.ErrorMatches, "unsupported tag.*")
 }
 
 func (unitAgentFinderSuite) TestFindEntityErr(c *gc.C) {
 	f := fakeEntityFinder{err: errors.Errorf("boo")}
 	ua := &common.UnitAgentFinder{f}
-	_, err := ua.FindEntity(names.NewUnitTag("unit/0"))
+	_, err := ua.FindEntity(context.TODO(), names.NewUnitTag("unit/0"))
 	c.Assert(errors.Cause(err), gc.Equals, f.err)
 }
 

--- a/apiserver/common/testing/modelwatcher.go
+++ b/apiserver/common/testing/modelwatcher.go
@@ -4,6 +4,8 @@
 package testing
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,8 +16,8 @@ import (
 )
 
 type ModelWatcher interface {
-	WatchForModelConfigChanges() (params.NotifyWatchResult, error)
-	ModelConfig() (params.ModelConfigResult, error)
+	WatchForModelConfigChanges(context.Context) (params.NotifyWatchResult, error)
+	ModelConfig(context.Context) (params.ModelConfigResult, error)
 }
 
 type ModelWatcherTest struct {
@@ -44,7 +46,7 @@ func (s *ModelWatcherTest) AssertModelConfig(c *gc.C, modelWatcher ModelWatcher)
 	modelConfig, err := model.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := modelWatcher.ModelConfig()
+	result, err := modelWatcher.ModelConfig(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 
 	configAttributes := modelConfig.AllAttrs()
@@ -58,7 +60,7 @@ func (s *ModelWatcherTest) TestModelConfig(c *gc.C) {
 func (s *ModelWatcherTest) TestWatchForModelConfigChanges(c *gc.C) {
 	c.Assert(s.res.Count(), gc.Equals, 0)
 
-	result, err := s.modelWatcher.WatchForModelConfigChanges()
+	result, err := s.modelWatcher.WatchForModelConfigChanges(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{
 		NotifyWatcherId: "1",

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/golang/mock/gomock"
@@ -88,7 +89,7 @@ func (s *getToolsSuite) TestTools(c *gc.C) {
 
 	s.entityFinder.EXPECT().FindEntity(names.NewMachineTag("0")).Return(s.machine0, nil)
 	s.machine0.EXPECT().AgentTools().Return(&coretools.Tools{Version: current}, nil)
-	s.toolsFinder.EXPECT().FindAgents(common.FindAgentsParams{
+	s.toolsFinder.EXPECT().FindAgents(context.TODO(), common.FindAgentsParams{
 		Number: current.Number,
 		OSType: current.Release,
 		Arch:   current.Arch,
@@ -99,7 +100,7 @@ func (s *getToolsSuite) TestTools(c *gc.C) {
 
 	s.entityFinder.EXPECT().FindEntity(names.NewMachineTag("42")).Return(nil, apiservertesting.NotFoundError("machine 42"))
 
-	result, err := tg.Tools(args)
+	result, err := tg.Tools(context.TODO(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)
@@ -142,7 +143,7 @@ func (s *getToolsSuite) TestOSTools(c *gc.C) {
 
 	s.entityFinder.EXPECT().FindEntity(names.NewMachineTag("0")).Return(s.machine0, nil)
 	s.machine0.EXPECT().AgentTools().Return(&coretools.Tools{Version: currentCopy}, nil)
-	s.toolsFinder.EXPECT().FindAgents(common.FindAgentsParams{
+	s.toolsFinder.EXPECT().FindAgents(context.TODO(), common.FindAgentsParams{
 		Number: currentCopy.Number,
 		OSType: currentCopy.Release,
 		Arch:   currentCopy.Arch,
@@ -155,7 +156,7 @@ func (s *getToolsSuite) TestOSTools(c *gc.C) {
 		Entities: []params.Entity{
 			{Tag: "machine-0"},
 		}}
-	result, err := tg.Tools(args)
+	result, err := tg.Tools(context.TODO(), args)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
@@ -181,7 +182,7 @@ func (s *getToolsSuite) TestToolsError(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: "machine-42"}},
 	}
-	result, err := tg.Tools(args)
+	result, err := tg.Tools(context.TODO(), args)
 	c.Assert(err, gc.ErrorMatches, "splat")
 	c.Assert(result.Results, gc.HasLen, 1)
 }
@@ -240,7 +241,7 @@ func (s *setToolsSuite) TestSetTools(c *gc.C) {
 
 	s.entityFinder.EXPECT().FindEntity(names.NewMachineTag("42")).Return(nil, apiservertesting.NotFoundError("machine 42"))
 
-	result, err := ts.SetTools(args)
+	result, err := ts.SetTools(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 3)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -263,7 +264,7 @@ func (s *setToolsSuite) TestToolsSetError(c *gc.C) {
 			},
 		}},
 	}
-	result, err := ts.SetTools(args)
+	result, err := ts.SetTools(context.TODO(), args)
 	c.Assert(err, gc.ErrorMatches, "splat")
 	c.Assert(result.Results, gc.HasLen, 1)
 }
@@ -361,7 +362,7 @@ func (s *findToolsSuite) TestFindToolsMatchMajor(c *gc.C) {
 		nil, s.toolsStorageGetter, s.urlGetter, s.newEnviron,
 	)
 
-	result, err := toolsFinder.FindAgents(common.FindAgentsParams{
+	result, err := toolsFinder.FindAgents(context.TODO(), common.FindAgentsParams{
 		MajorVersion: 123,
 		MinorVersion: 456,
 		OSType:       "windows",
@@ -416,7 +417,7 @@ func (s *findToolsSuite) TestFindToolsRequestAgentStream(c *gc.C) {
 	toolsFinder := common.NewToolsFinder(
 		nil, s.toolsStorageGetter, s.urlGetter, s.newEnviron,
 	)
-	result, err := toolsFinder.FindAgents(common.FindAgentsParams{
+	result, err := toolsFinder.FindAgents(context.TODO(), common.FindAgentsParams{
 		MajorVersion: 123,
 		MinorVersion: 456,
 		OSType:       "windows",
@@ -449,7 +450,7 @@ func (s *findToolsSuite) TestFindToolsNotFound(c *gc.C) {
 	s.expectBootstrapEnvironConfig(c)
 
 	toolsFinder := common.NewToolsFinder(nil, s.toolsStorageGetter, nil, s.newEnviron)
-	_, err := toolsFinder.FindAgents(common.FindAgentsParams{})
+	_, err := toolsFinder.FindAgents(context.TODO(), common.FindAgentsParams{})
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
@@ -502,7 +503,7 @@ func (s *findToolsSuite) testFindToolsExact(c *gc.C, inStorage bool, develVersio
 		return nil, errors.NotFoundf("tools")
 	})
 	toolsFinder := common.NewToolsFinder(nil, s.toolsStorageGetter, s.urlGetter, s.newEnviron)
-	_, err := toolsFinder.FindAgents(common.FindAgentsParams{
+	_, err := toolsFinder.FindAgents(context.TODO(), common.FindAgentsParams{
 		Number: jujuversion.Current,
 		OSType: current.Release,
 		Arch:   arch.HostArch(),
@@ -528,7 +529,7 @@ func (s *findToolsSuite) TestFindToolsToolsStorageError(c *gc.C) {
 	s.expectMatchingStorageTools(nil, errors.New("AllMetadata failed"))
 
 	toolsFinder := common.NewToolsFinder(nil, s.toolsStorageGetter, s.urlGetter, s.newEnviron)
-	_, err := toolsFinder.FindAgents(common.FindAgentsParams{})
+	_, err := toolsFinder.FindAgents(context.TODO(), common.FindAgentsParams{})
 	// ToolsStorage errors always cause FindAgents to bail. Only
 	// if AllMetadata succeeds but returns nothing that matches
 	// do we continue on to searching simplestreams.

--- a/apiserver/common/unitswatcher.go
+++ b/apiserver/common/unitswatcher.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -59,7 +61,7 @@ func (u *UnitsWatcher) watchOneEntityUnits(canWatch AuthFunc, tag names.Tag) (pa
 
 // WatchUnits starts a StringsWatcher to watch all units belonging to
 // to any entity (machine or service) passed in args.
-func (u *UnitsWatcher) WatchUnits(args params.Entities) (params.StringsWatchResults, error) {
+func (u *UnitsWatcher) WatchUnits(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	result := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}

--- a/apiserver/common/unitswatcher_test.go
+++ b/apiserver/common/unitswatcher_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v4"
@@ -75,7 +76,7 @@ func (*unitsWatcherSuite) TestWatchUnits(c *gc.C) {
 	entities := params.Entities{[]params.Entity{
 		{"unit-x-0"}, {"unit-x-1"}, {"unit-x-2"}, {"unit-x-3"},
 	}}
-	result, err := w.WatchUnits(entities)
+	result, err := w.WatchUnits(context.TODO(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -97,7 +98,7 @@ func (*unitsWatcherSuite) TestWatchUnitsError(c *gc.C) {
 		resources,
 		getCanWatch,
 	)
-	_, err := w.WatchUnits(params.Entities{[]params.Entity{{"x0"}}})
+	_, err := w.WatchUnits(context.TODO(), params.Entities{[]params.Entity{{"x0"}}})
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 
@@ -111,7 +112,7 @@ func (*unitsWatcherSuite) TestWatchNoArgsNoError(c *gc.C) {
 		resources,
 		getCanWatch,
 	)
-	result, err := w.WatchUnits(params.Entities{})
+	result, err := w.WatchUnits(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 0)
 }

--- a/apiserver/common/watch.go
+++ b/apiserver/common/watch.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -58,7 +59,7 @@ func (a *AgentEntityWatcher) watchEntity(tag names.Tag) (string, error) {
 }
 
 // Watch starts an NotifyWatcher for each given entity.
-func (a *AgentEntityWatcher) Watch(args params.Entities) (params.NotifyWatchResults, error) {
+func (a *AgentEntityWatcher) Watch(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	result := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}

--- a/apiserver/common/watch_test.go
+++ b/apiserver/common/watch_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v4"
@@ -50,7 +51,7 @@ func (*agentEntityWatcherSuite) TestWatch(c *gc.C) {
 	entities := params.Entities{[]params.Entity{
 		{"unit-x-0"}, {"unit-x-1"}, {"unit-x-2"}, {"unit-x-3"},
 	}}
-	result, err := a.Watch(entities)
+	result, err := a.Watch(context.TODO(), entities)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -72,7 +73,7 @@ func (*agentEntityWatcherSuite) TestWatchError(c *gc.C) {
 		resources,
 		getCanWatch,
 	)
-	_, err := a.Watch(params.Entities{[]params.Entity{{"x0"}}})
+	_, err := a.Watch(context.TODO(), params.Entities{[]params.Entity{{"x0"}}})
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 
@@ -86,7 +87,7 @@ func (*agentEntityWatcherSuite) TestWatchNoArgsNoError(c *gc.C) {
 		resources,
 		getCanWatch,
 	)
-	result, err := a.Watch(params.Entities{})
+	result, err := a.Watch(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 0)
 }

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -7,6 +7,8 @@
 package agent
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -35,7 +37,7 @@ type AgentAPI struct {
 	resources facade.Resources
 }
 
-func (api *AgentAPI) GetEntities(args params.Entities) params.AgentGetEntitiesResults {
+func (api *AgentAPI) GetEntities(ctx context.Context, args params.Entities) params.AgentGetEntitiesResults {
 	results := params.AgentGetEntitiesResults{
 		Entities: make([]params.AgentGetEntitiesResult, len(args.Entities)),
 	}
@@ -77,7 +79,7 @@ func (api *AgentAPI) getEntity(tag names.Tag) (result params.AgentGetEntitiesRes
 	return
 }
 
-func (api *AgentAPI) StateServingInfo() (result params.StateServingInfo, err error) {
+func (api *AgentAPI) StateServingInfo(ctx context.Context) (result params.StateServingInfo, err error) {
 	if !api.auth.AuthController() {
 		err = apiservererrors.ErrPerm
 		return
@@ -111,7 +113,7 @@ func (api *AgentAPI) StateServingInfo() (result params.StateServingInfo, err err
 // be overridden by tests.
 var MongoIsMaster = mongo.IsMaster
 
-func (api *AgentAPI) IsMaster() (params.IsMasterResult, error) {
+func (api *AgentAPI) IsMaster(ctx context.Context) (params.IsMasterResult, error) {
 	if !api.auth.AuthController() {
 		return params.IsMasterResult{}, apiservererrors.ErrPerm
 	}
@@ -140,7 +142,7 @@ func stateJobsToAPIParamsJobs(jobs []state.MachineJob) []model.MachineJob {
 }
 
 // WatchCredentials watches for changes to the specified credentials.
-func (api *AgentAPI) WatchCredentials(args params.Entities) (params.NotifyWatchResults, error) {
+func (api *AgentAPI) WatchCredentials(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	if !api.auth.AuthController() {
 		return params.NotifyWatchResults{}, apiservererrors.ErrPerm
 	}

--- a/apiserver/facades/agent/agent/agent_test.go
+++ b/apiserver/facades/agent/agent/agent_test.go
@@ -4,6 +4,7 @@
 package agent_test
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/names/v4"
@@ -109,7 +110,7 @@ func (s *agentSuite) TestGetEntities(c *gc.C) {
 		Auth_:      s.authorizer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results := api.GetEntities(args)
+	results := api.GetEntities(context.TODO(), args)
 	c.Assert(results, gc.DeepEquals, params.AgentGetEntitiesResults{
 		Entities: []params.AgentGetEntitiesResult{
 			{
@@ -143,7 +144,7 @@ func (s *agentSuite) TestGetEntitiesContainer(c *gc.C) {
 			{Tag: "machine-42"},
 		},
 	}
-	results := api.GetEntities(args)
+	results := api.GetEntities(context.TODO(), args)
 	c.Assert(results, gc.DeepEquals, params.AgentGetEntitiesResults{
 		Entities: []params.AgentGetEntitiesResult{
 			{Error: apiservertesting.ErrUnauthorized},
@@ -180,7 +181,7 @@ func (s *agentSuite) TestGetEntitiesNotFound(c *gc.C) {
 		Auth_:      s.authorizer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results := api.GetEntities(params.Entities{
+	results := api.GetEntities(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: "machine-1"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -201,7 +202,7 @@ func (s *agentSuite) TestSetPasswords(c *gc.C) {
 		Auth_:      s.authorizer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := api.SetPasswords(params.EntityPasswords{
+	results, err := api.SetPasswords(context.TODO(), params.EntityPasswords{
 		Changes: []params.EntityPassword{
 			{Tag: "machine-0", Password: "xxx-12345678901234567890"},
 			{Tag: "machine-1", Password: "yyy-12345678901234567890"},
@@ -229,7 +230,7 @@ func (s *agentSuite) TestSetPasswordsShort(c *gc.C) {
 		Auth_:      s.authorizer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := api.SetPasswords(params.EntityPasswords{
+	results, err := api.SetPasswords(context.TODO(), params.EntityPasswords{
 		Changes: []params.EntityPassword{
 			{Tag: "machine-1", Password: "yyy"},
 		},
@@ -260,7 +261,7 @@ func (s *agentSuite) TestClearReboot(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rFlag, jc.IsTrue)
 
-	result, err := api.ClearReboot(args)
+	result, err := api.ClearReboot(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -286,7 +287,7 @@ func (s *agentSuite) TestWatchCredentials(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	tag := names.NewCloudCredentialTag("dummy/fred/default")
-	result, err := api.WatchCredentials(params.Entities{Entities: []params.Entity{{Tag: tag.String()}}})
+	result, err := api.WatchCredentials(context.TODO(), params.Entities{Entities: []params.Entity{{Tag: tag.String()}}})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.NotifyWatchResults{Results: []params.NotifyWatchResult{{"1", nil}}})
 	c.Assert(s.resources.Count(), gc.Equals, 1)
@@ -313,7 +314,7 @@ func (s *agentSuite) TestWatchAuthError(c *gc.C) {
 		Auth_:      authorizer,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = api.WatchCredentials(params.Entities{})
+	_, err = api.WatchCredentials(context.TODO(), params.Entities{})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 }

--- a/apiserver/facades/agent/caasadmission/caasadmission.go
+++ b/apiserver/facades/agent/caasadmission/caasadmission.go
@@ -5,10 +5,8 @@ package caasadmission
 
 import (
 	"github.com/juju/juju/apiserver/common"
-	"github.com/juju/juju/apiserver/facade"
 )
 
 type Facade struct {
-	auth facade.Authorizer
 	*common.ControllerConfigAPI
 }

--- a/apiserver/facades/agent/caasadmission/register.go
+++ b/apiserver/facades/agent/caasadmission/register.go
@@ -25,7 +25,6 @@ func newStateFacade(ctx facade.Context) (*Facade, error) {
 	}
 
 	return &Facade{
-		auth:                authorizer,
 		ControllerConfigAPI: common.NewStateControllerConfig(ctx.State()),
 	}, nil
 }

--- a/apiserver/facades/agent/caasagent/caasagent.go
+++ b/apiserver/facades/agent/caasagent/caasagent.go
@@ -6,13 +6,10 @@ package caasagent
 import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/cloudspec"
-	"github.com/juju/juju/apiserver/facade"
 )
 
 // FacadeV2 is the V2 facade of the caas agent
 type FacadeV2 struct {
-	auth      facade.Authorizer
-	resources facade.Resources
 	cloudspec.CloudSpecer
 	*common.ModelWatcher
 	*common.ControllerConfigAPI

--- a/apiserver/facades/agent/caasagent/register.go
+++ b/apiserver/facades/agent/caasagent/register.go
@@ -46,7 +46,5 @@ func newStateFacadeV2(ctx facade.Context) (*FacadeV2, error) {
 		CloudSpecer:         cloudSpecAPI,
 		ModelWatcher:        common.NewModelWatcher(model, resources, authorizer),
 		ControllerConfigAPI: common.NewStateControllerConfig(ctx.State()),
-		auth:                authorizer,
-		resources:           resources,
 	}, nil
 }

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -4,6 +4,7 @@
 package caasapplication
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -66,7 +67,7 @@ func NewFacade(
 }
 
 // UnitIntroduction sets the status of each given entity.
-func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.CAASUnitIntroductionResult, error) {
+func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntroductionArgs) (params.CAASUnitIntroductionResult, error) {
 	tag, ok := f.auth.GetAuthTag().(names.ApplicationTag)
 	if !ok {
 		return params.CAASUnitIntroductionResult{}, apiservererrors.ErrPerm
@@ -317,7 +318,7 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 // UnitTerminating should be called by the CAASUnitTerminationWorker when
 // the agent receives a signal to exit. UnitTerminating will return how
 // the agent should shutdown.
-func (f *Facade) UnitTerminating(args params.Entity) (params.CAASUnitTerminationResult, error) {
+func (f *Facade) UnitTerminating(ctx context.Context, args params.Entity) (params.CAASUnitTerminationResult, error) {
 	tag, ok := f.auth.GetAuthTag().(names.UnitTag)
 	if !ok {
 		return params.CAASUnitTerminationResult{}, apiservererrors.ErrPerm

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -4,6 +4,7 @@
 package caasapplication_test
 
 import (
+	"context"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -80,7 +81,7 @@ func (s *CAASApplicationSuite) TestAddUnit(c *gc.C) {
 		}},
 	}
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.Result.UnitName, gc.Equals, "gitlab/0")
@@ -119,7 +120,7 @@ func (s *CAASApplicationSuite) TestReuseUnitByName(c *gc.C) {
 		}},
 	}
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.Result.UnitName, gc.Equals, "gitlab/0")
@@ -153,7 +154,7 @@ func (s *CAASApplicationSuite) TestFindByProviderID(c *gc.C) {
 	}
 	s.st.units["gitlab/0"].SetErrors(errors.NotFoundf("cloud container"))
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.Result.UnitName, gc.Equals, "gitlab/0")
@@ -190,7 +191,7 @@ func (s *CAASApplicationSuite) TestAgentConf(c *gc.C) {
 		}},
 	}
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.Result.UnitName, gc.Equals, "gitlab/0")
@@ -233,7 +234,7 @@ func (s *CAASApplicationSuite) TestDyingApplication(c *gc.C) {
 
 	s.st.app.life = state.Dying
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, `application not provisioned`)
 }
@@ -245,7 +246,7 @@ func (s *CAASApplicationSuite) TestMissingArgUUID(c *gc.C) {
 
 	s.st.app.life = state.Dying
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, `pod-uuid not valid`)
 }
@@ -257,7 +258,7 @@ func (s *CAASApplicationSuite) TestMissingArgName(c *gc.C) {
 
 	s.st.app.life = state.Dying
 
-	results, err := s.facade.UnitIntroduction(args)
+	results, err := s.facade.UnitIntroduction(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.ErrorMatches, `pod-name not valid`)
 }
@@ -287,7 +288,7 @@ func (s *CAASApplicationSuite) TestUnitTerminatingAgentWillRestart(c *gc.C) {
 	args := params.Entity{
 		Tag: "unit-gitlab-0",
 	}
-	results, err := s.facade.UnitTerminating(args)
+	results, err := s.facade.UnitTerminating(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.WillRestart, jc.IsTrue)
@@ -318,7 +319,7 @@ func (s *CAASApplicationSuite) TestUnitTerminatingAgentDying(c *gc.C) {
 	args := params.Entity{
 		Tag: "unit-gitlab-0",
 	}
-	results, err := s.facade.UnitTerminating(args)
+	results, err := s.facade.UnitTerminating(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.WillRestart, jc.IsFalse)

--- a/apiserver/facades/agent/caasoperator/operator.go
+++ b/apiserver/facades/agent/caasoperator/operator.go
@@ -4,6 +4,8 @@
 package caasoperator
 
 import (
+	"context"
+
 	"github.com/juju/charm/v9"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -79,7 +81,7 @@ func NewFacade(
 }
 
 // CurrentModel returns the name and UUID for the current juju model.
-func (f *Facade) CurrentModel() (params.ModelResult, error) {
+func (f *Facade) CurrentModel(ctx context.Context) (params.ModelResult, error) {
 	return params.ModelResult{
 		Name: f.model.Name(),
 		UUID: f.model.UUID(),
@@ -88,7 +90,7 @@ func (f *Facade) CurrentModel() (params.ModelResult, error) {
 }
 
 // SetStatus sets the status of each given entity.
-func (f *Facade) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
+func (f *Facade) SetStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
@@ -122,7 +124,7 @@ func (f *Facade) setStatus(tag names.ApplicationTag, info status.StatusInfo) err
 }
 
 // Charm returns the charm info for all given applications.
-func (f *Facade) Charm(args params.Entities) (params.ApplicationCharmResults, error) {
+func (f *Facade) Charm(ctx context.Context, args params.Entities) (params.ApplicationCharmResults, error) {
 	results := params.ApplicationCharmResults{
 		Results: make([]params.ApplicationCharmResult, len(args.Entities)),
 	}
@@ -163,7 +165,7 @@ func (f *Facade) Charm(args params.Entities) (params.ApplicationCharmResults, er
 
 // SetPodSpec sets the container specs for a set of applications.
 // TODO(juju3) - remove
-func (f *Facade) SetPodSpec(args params.SetPodSpecParams) (params.ErrorResults, error) {
+func (f *Facade) SetPodSpec(ctx context.Context, args params.SetPodSpecParams) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Specs)),
 	}
@@ -195,7 +197,7 @@ func (f *Facade) SetPodSpec(args params.SetPodSpecParams) (params.ErrorResults, 
 // WatchUnits starts a StringsWatcher to watch changes to the
 // lifecycle states of units for the specified applications in
 // this model.
-func (f *Facade) WatchUnits(args params.Entities) (params.StringsWatchResults, error) {
+func (f *Facade) WatchUnits(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	results := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Entities)),
 	}
@@ -229,7 +231,7 @@ func (f *Facade) watchUnits(tagString string) (string, []string, error) {
 
 // WatchContainerStart starts a StringWatcher to watch for container start events
 // on the CAAS api for a specific application and container.
-func (f *Facade) WatchContainerStart(args params.WatchContainerStartArgs) (params.StringsWatchResults, error) {
+func (f *Facade) WatchContainerStart(ctx context.Context, args params.WatchContainerStartArgs) (params.StringsWatchResults, error) {
 	results := params.StringsWatchResults{
 		Results: make([]params.StringsWatchResult, len(args.Args)),
 	}
@@ -268,6 +270,6 @@ func (f *Facade) watchContainerStart(tagString string, containerName string) (st
 // It is implemented here directly as a result of removing it from
 // embedded APIAddresser *without* bumping the facade version.
 // It should be blanked when this facade version is next incremented.
-func (f *Facade) ModelUUID() params.StringResult {
+func (f *Facade) ModelUUID(ctx context.Context) params.StringResult {
 	return params.StringResult{Result: f.model.UUID()}
 }

--- a/apiserver/facades/agent/caasoperator/operator_test.go
+++ b/apiserver/facades/agent/caasoperator/operator_test.go
@@ -4,6 +4,8 @@
 package caasoperator_test
 
 import (
+	"context"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -82,7 +84,7 @@ func (s *CAASOperatorSuite) TestSetStatus(c *gc.C) {
 		}},
 	}
 
-	results, err := s.facade.SetStatus(args)
+	results, err := s.facade.SetStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -112,7 +114,7 @@ func (s *CAASOperatorSuite) TestCharm(c *gc.C) {
 		},
 	}
 
-	results, err := s.facade.Charm(args)
+	results, err := s.facade.Charm(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ApplicationCharmResults{
 		Results: []params.ApplicationCharmResult{{
@@ -141,7 +143,7 @@ func (s *CAASOperatorSuite) TestCharm(c *gc.C) {
 func (s *CAASOperatorSuite) TestWatchUnits(c *gc.C) {
 	s.st.app.unitsChanges <- []string{"gitlab/0", "gitlab/1"}
 
-	results, err := s.facade.WatchUnits(params.Entities{
+	results, err := s.facade.WatchUnits(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "application-gitlab"},
 			{Tag: "unit-gitlab-0"},
@@ -161,7 +163,7 @@ func (s *CAASOperatorSuite) TestWatchUnits(c *gc.C) {
 }
 
 func (s *CAASOperatorSuite) TestLife(c *gc.C) {
-	results, err := s.facade.Life(params.Entities{
+	results, err := s.facade.Life(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "unit-gitlab-0"},
 			{Tag: "application-gitlab"},
@@ -184,7 +186,7 @@ func (s *CAASOperatorSuite) TestLife(c *gc.C) {
 }
 
 func (s *CAASOperatorSuite) TestRemove(c *gc.C) {
-	results, err := s.facade.Remove(params.Entities{
+	results, err := s.facade.Remove(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "unit-gitlab-0"},
 			{Tag: "machine-0"},
@@ -232,7 +234,7 @@ containers:
 
 	s.st.model.SetErrors(nil, errors.New("bloop"))
 
-	results, err := s.facade.SetPodSpec(args)
+	results, err := s.facade.SetPodSpec(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{
@@ -274,7 +276,7 @@ containers:
 }
 
 func (s *CAASOperatorSuite) TestModel(c *gc.C) {
-	result, err := s.facade.CurrentModel()
+	result, err := s.facade.CurrentModel(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ModelResult{
 		Name: "some-model",
@@ -293,7 +295,7 @@ func (s *CAASOperatorSuite) TestWatch(c *gc.C) {
 		{Tag: "application-mysql"},
 		{Tag: "unit-mysql-0"},
 	}}
-	result, err := s.facade.Watch(args)
+	result, err := s.facade.Watch(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -312,7 +314,7 @@ func (s *CAASOperatorSuite) TestWatch(c *gc.C) {
 
 func (s *CAASOperatorSuite) TestSetTools(c *gc.C) {
 	vers := version.MustParseBinary("2.99.0-ubuntu-amd64")
-	results, err := s.facade.SetTools(params.EntitiesVersion{
+	results, err := s.facade.SetTools(context.TODO(), params.EntitiesVersion{
 		AgentTools: []params.EntityVersion{
 			{Tag: "application-gitlab", Tools: &params.Version{Version: vers}},
 			{Tag: "machine-0", Tools: &params.Version{Version: vers}},
@@ -333,13 +335,13 @@ func (s *CAASOperatorSuite) TestSetTools(c *gc.C) {
 }
 
 func (s *CAASOperatorSuite) TestAddresses(c *gc.C) {
-	_, err := s.facade.APIAddresses()
+	_, err := s.facade.APIAddresses(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCallNames(c, "Model", "APIHostPortsForAgents")
 }
 
 func (s *CAASOperatorSuite) TestWatchAPIHostPorts(c *gc.C) {
-	_, err := s.facade.WatchAPIHostPorts()
+	_, err := s.facade.WatchAPIHostPorts(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	s.st.CheckCallNames(c, "Model", "WatchAPIHostPortsForAgents")
 }
@@ -358,7 +360,7 @@ func (s *CAASOperatorSuite) TestWatchContainerStart(c *gc.C) {
 		},
 	}
 
-	results, err := s.facade.WatchContainerStart(params.WatchContainerStartArgs{
+	results, err := s.facade.WatchContainerStart(context.TODO(), params.WatchContainerStartArgs{
 		Args: []params.WatchContainerStartArg{
 			{Entity: params.Entity{Tag: "application-gitlab"}, Container: "container"},
 			{Entity: params.Entity{Tag: "unit-gitlab-0"}, Container: "container"},

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator.go
@@ -4,6 +4,8 @@
 package credentialvalidator
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
@@ -19,18 +21,18 @@ var logger = loggo.GetLogger("juju.api.credentialvalidator")
 // CredentialValidatorV2 defines the methods on version 2 facade for the
 // credentialvalidator API endpoint.
 type CredentialValidatorV2 interface {
-	InvalidateModelCredential(params.InvalidateCredentialArg) (params.ErrorResult, error)
-	ModelCredential() (params.ModelCredential, error)
-	WatchCredential(params.Entity) (params.NotifyWatchResult, error)
-	WatchModelCredential() (params.NotifyWatchResult, error)
+	InvalidateModelCredential(context.Context, params.InvalidateCredentialArg) (params.ErrorResult, error)
+	ModelCredential(context.Context) (params.ModelCredential, error)
+	WatchCredential(context.Context, params.Entity) (params.NotifyWatchResult, error)
+	WatchModelCredential(context.Context) (params.NotifyWatchResult, error)
 }
 
 // CredentialValidatorV1 defines the methods on version 1 facade
 // for the credentialvalidator API endpoint.
 type CredentialValidatorV1 interface {
-	InvalidateModelCredential(params.InvalidateCredentialArg) (params.ErrorResult, error)
-	ModelCredential() (params.ModelCredential, error)
-	WatchCredential(params.Entity) (params.NotifyWatchResult, error)
+	InvalidateModelCredential(context.Context, params.InvalidateCredentialArg) (params.ErrorResult, error)
+	ModelCredential(context.Context) (params.ModelCredential, error)
+	WatchCredential(context.Context, params.Entity) (params.NotifyWatchResult, error)
 }
 
 type CredentialValidatorAPI struct {
@@ -58,7 +60,7 @@ func internalNewCredentialValidatorAPI(backend Backend, resources facade.Resourc
 
 // WatchCredential returns a NotifyWatcher that observes
 // changes to a given cloud credential.
-func (api *CredentialValidatorAPI) WatchCredential(tag params.Entity) (params.NotifyWatchResult, error) {
+func (api *CredentialValidatorAPI) WatchCredential(ctx context.Context, tag params.Entity) (params.NotifyWatchResult, error) {
 	fail := func(failure error) (params.NotifyWatchResult, error) {
 		return params.NotifyWatchResult{}, apiservererrors.ServerError(failure)
 	}
@@ -91,7 +93,7 @@ func (api *CredentialValidatorAPI) WatchCredential(tag params.Entity) (params.No
 }
 
 // ModelCredential returns cloud credential information for a  model.
-func (api *CredentialValidatorAPI) ModelCredential() (params.ModelCredential, error) {
+func (api *CredentialValidatorAPI) ModelCredential(ctx context.Context) (params.ModelCredential, error) {
 	c, err := api.backend.ModelCredential()
 	if err != nil {
 		return params.ModelCredential{}, apiservererrors.ServerError(err)
@@ -106,7 +108,7 @@ func (api *CredentialValidatorAPI) ModelCredential() (params.ModelCredential, er
 }
 
 // WatchModelCredential returns a NotifyWatcher that watches what cloud credential a model uses.
-func (api *CredentialValidatorAPI) WatchModelCredential() (params.NotifyWatchResult, error) {
+func (api *CredentialValidatorAPI) WatchModelCredential(ctx context.Context) (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
 	watch, err := api.backend.WatchModelCredential()
 	if err != nil {

--- a/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
+++ b/apiserver/facades/agent/credentialvalidator/credentialvalidator_test.go
@@ -4,6 +4,8 @@
 package credentialvalidator_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -47,7 +49,7 @@ func (s *CredentialValidatorSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestModelCredential(c *gc.C) {
-	result, err := s.api.ModelCredential()
+	result, err := s.api.ModelCredential(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ModelCredential{
 		Model:           names.NewModelTag(modelUUID).String(),
@@ -61,13 +63,13 @@ func (s *CredentialValidatorSuite) TestModelCredentialNotNeeded(c *gc.C) {
 	s.backend.mc.Exists = false
 	s.backend.mc.Credential = names.CloudCredentialTag{}
 	s.backend.mc.Valid = false
-	result, err := s.api.ModelCredential()
+	result, err := s.api.ModelCredential(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ModelCredential{Model: names.NewModelTag(modelUUID).String()})
 }
 
 func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
-	result, err := s.api.WatchCredential(params.Entity{credentialTag.String()})
+	result, err := s.api.WatchCredential(context.TODO(), params.Entity{credentialTag.String()})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{"1", nil})
 	c.Assert(s.resources.Count(), gc.Equals, 1)
@@ -75,19 +77,19 @@ func (s *CredentialValidatorSuite) TestWatchCredential(c *gc.C) {
 
 func (s *CredentialValidatorSuite) TestWatchCredentialNotUsedInThisModel(c *gc.C) {
 	s.backend.isUsed = false
-	_, err := s.api.WatchCredential(params.Entity{credentialTag.String()})
+	_, err := s.api.WatchCredential(context.TODO(), params.Entity{credentialTag.String()})
 	c.Assert(err, gc.ErrorMatches, apiservererrors.ErrPerm.Error())
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 }
 
 func (s *CredentialValidatorSuite) TestWatchCredentialInvalidTag(c *gc.C) {
-	_, err := s.api.WatchCredential(params.Entity{"my-tag"})
+	_, err := s.api.WatchCredential(context.TODO(), params.Entity{"my-tag"})
 	c.Assert(err, gc.ErrorMatches, `"my-tag" is not a valid tag`)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 }
 
 func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
-	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
+	result, err := s.api.InvalidateModelCredential(context.TODO(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -98,7 +100,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredential(c *gc.C) {
 func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 	expected := errors.New("boom")
 	s.backend.SetErrors(expected)
-	result, err := s.api.InvalidateModelCredential(params.InvalidateCredentialArg{"not again"})
+	result, err := s.api.InvalidateModelCredential(context.TODO(), params.InvalidateCredentialArg{"not again"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResult{Error: apiservererrors.ServerError(expected)})
 	s.backend.CheckCalls(c, []testing.StubCall{
@@ -107,7 +109,7 @@ func (s *CredentialValidatorSuite) TestInvalidateModelCredentialError(c *gc.C) {
 }
 
 func (s *CredentialValidatorSuite) TestWatchModelCredential(c *gc.C) {
-	result, err := s.api.WatchModelCredential()
+	result, err := s.api.WatchModelCredential(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{"1", nil})
 	c.Assert(s.resources.Count(), gc.Equals, 1)
@@ -115,7 +117,7 @@ func (s *CredentialValidatorSuite) TestWatchModelCredential(c *gc.C) {
 
 func (s *CredentialValidatorSuite) TestWatchModelCredentialError(c *gc.C) {
 	s.backend.SetErrors(errors.New("no nope niet"))
-	_, err := s.api.WatchModelCredential()
+	_, err := s.api.WatchModelCredential(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "no nope niet")
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 }

--- a/apiserver/facades/agent/deployer/deployer.go
+++ b/apiserver/facades/agent/deployer/deployer.go
@@ -4,6 +4,7 @@
 package deployer
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -87,8 +88,8 @@ func NewDeployerAPI(ctx facade.Context) (*DeployerAPI, error) {
 
 // ConnectionInfo returns all the address information that the
 // deployer task needs in one call.
-func (d *DeployerAPI) ConnectionInfo() (result params.DeployerConnectionValues, err error) {
-	apiAddrs, err := d.APIAddresses()
+func (d *DeployerAPI) ConnectionInfo(ctx context.Context) (result params.DeployerConnectionValues, err error) {
+	apiAddrs, err := d.APIAddresses(ctx)
 	if err != nil {
 		return result, err
 	}
@@ -99,15 +100,15 @@ func (d *DeployerAPI) ConnectionInfo() (result params.DeployerConnectionValues, 
 }
 
 // SetStatus sets the status of the specified entities.
-func (d *DeployerAPI) SetStatus(args params.SetStatus) (params.ErrorResults, error) {
-	return d.StatusSetter.SetStatus(args)
+func (d *DeployerAPI) SetStatus(ctx context.Context, args params.SetStatus) (params.ErrorResults, error) {
+	return d.StatusSetter.SetStatus(ctx, args)
 }
 
 // ModelUUID returns the model UUID that this facade is deploying into.
 // It is implemented here directly as a result of removing it from
 // embedded APIAddresser *without* bumping the facade version.
 // It should be blanked when this facade version is next incremented.
-func (d *DeployerAPI) ModelUUID() params.StringResult {
+func (d *DeployerAPI) ModelUUID(ctx context.Context) params.StringResult {
 	return params.StringResult{Result: d.st.ModelUUID()}
 }
 

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -4,6 +4,7 @@
 package deployer_test
 
 import (
+	"context"
 	"sort"
 	stdtesting "testing"
 
@@ -147,7 +148,7 @@ func (s *deployerSuite) TestWatchUnits(c *gc.C) {
 		{Tag: "machine-0"},
 		{Tag: "machine-42"},
 	}}
-	result, err := s.deployer.WatchUnits(args)
+	result, err := s.deployer.WatchUnits(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(result.Results[0].Changes)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
@@ -179,7 +180,7 @@ func (s *deployerSuite) TestSetPasswords(c *gc.C) {
 			{Tag: "unit-fake-42", Password: "abc-12345678901234567890"},
 		},
 	}
-	results, err := s.deployer.SetPasswords(args)
+	results, err := s.deployer.SetPasswords(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -206,7 +207,7 @@ func (s *deployerSuite) TestSetPasswords(c *gc.C) {
 	err = s.subordinate0.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	results, err = s.deployer.SetPasswords(params.EntityPasswords{
+	results, err = s.deployer.SetPasswords(context.TODO(), params.EntityPasswords{
 		Changes: []params.EntityPassword{
 			{Tag: "unit-logging-0", Password: "blah-12345678901234567890"},
 		},
@@ -235,7 +236,7 @@ func (s *deployerSuite) TestLife(c *gc.C) {
 		{Tag: "unit-logging-0"},
 		{Tag: "unit-fake-42"},
 	}}
-	result, err := s.deployer.Life(args)
+	result, err := s.deployer.Life(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
@@ -254,7 +255,7 @@ func (s *deployerSuite) TestLife(c *gc.C) {
 	err = s.subordinate0.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	result, err = s.deployer.Life(params.Entities{
+	result, err = s.deployer.Life(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "unit-logging-0"},
 		},
@@ -278,7 +279,7 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 		{Tag: "unit-logging-0"},
 		{Tag: "unit-fake-42"},
 	}}
-	result, err := s.deployer.Remove(args)
+	result, err := s.deployer.Remove(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -307,7 +308,7 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 	args = params.Entities{
 		Entities: []params.Entity{{Tag: "unit-logging-0"}},
 	}
-	result, err = s.deployer.Remove(args)
+	result, err = s.deployer.Remove(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{nil}},
@@ -318,7 +319,7 @@ func (s *deployerSuite) TestRemove(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	// Make sure the subordinate is detected as removed.
-	result, err = s.deployer.Remove(args)
+	result, err = s.deployer.Remove(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{apiservertesting.ErrUnauthorized}},
@@ -341,7 +342,7 @@ func (s *deployerSuite) TestConnectionInfo(c *gc.C) {
 		APIAddresses: []string{"1.2.3.4:1234", "0.1.2.3:1234"},
 	}
 
-	result, err := s.deployer.ConnectionInfo()
+	result, err := s.deployer.ConnectionInfo(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, expected)
 }
@@ -354,7 +355,7 @@ func (s *deployerSuite) TestSetStatus(c *gc.C) {
 			{Tag: "unit-fake-42", Status: "blocked", Info: "waiting", Data: map[string]interface{}{"foo": "bar"}},
 		},
 	}
-	results, err := s.deployer.SetStatus(args)
+	results, err := s.deployer.SetStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{

--- a/apiserver/facades/agent/diskmanager/diskmanager.go
+++ b/apiserver/facades/agent/diskmanager/diskmanager.go
@@ -4,6 +4,8 @@
 package diskmanager
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -25,7 +27,7 @@ var getState = func(st *state.State) stateInterface {
 	return stateShim{st}
 }
 
-func (d *DiskManagerAPI) SetMachineBlockDevices(args params.SetMachineBlockDevices) (params.ErrorResults, error) {
+func (d *DiskManagerAPI) SetMachineBlockDevices(ctx context.Context, args params.SetMachineBlockDevices) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.MachineBlockDevices)),
 	}

--- a/apiserver/facades/agent/diskmanager/diskmanager_test.go
+++ b/apiserver/facades/agent/diskmanager/diskmanager_test.go
@@ -4,6 +4,7 @@
 package diskmanager_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v4"
@@ -47,7 +48,7 @@ func (s *DiskManagerSuite) SetUpTest(c *gc.C) {
 
 func (s *DiskManagerSuite) TestSetMachineBlockDevices(c *gc.C) {
 	devices := []storage.BlockDevice{{DeviceName: "sda"}, {DeviceName: "sdb"}}
-	results, err := s.api.SetMachineBlockDevices(params.SetMachineBlockDevices{
+	results, err := s.api.SetMachineBlockDevices(context.TODO(), params.SetMachineBlockDevices{
 		MachineBlockDevices: []params.MachineBlockDevices{{
 			Machine:      "machine-0",
 			BlockDevices: devices,
@@ -60,7 +61,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevices(c *gc.C) {
 }
 
 func (s *DiskManagerSuite) TestSetMachineBlockDevicesEmptyArgs(c *gc.C) {
-	results, err := s.api.SetMachineBlockDevices(params.SetMachineBlockDevices{})
+	results, err := s.api.SetMachineBlockDevices(context.TODO(), params.SetMachineBlockDevices{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -75,7 +76,7 @@ func (s *DiskManagerSuite) TestNewDiskManagerAPINonMachine(c *gc.C) {
 }
 
 func (s *DiskManagerSuite) TestSetMachineBlockDevicesInvalidTags(c *gc.C) {
-	results, err := s.api.SetMachineBlockDevices(params.SetMachineBlockDevices{
+	results, err := s.api.SetMachineBlockDevices(context.TODO(), params.SetMachineBlockDevices{
 		MachineBlockDevices: []params.MachineBlockDevices{{
 			Machine: "machine-0",
 		}, {
@@ -99,7 +100,7 @@ func (s *DiskManagerSuite) TestSetMachineBlockDevicesInvalidTags(c *gc.C) {
 
 func (s *DiskManagerSuite) TestSetMachineBlockDevicesStateError(c *gc.C) {
 	s.st.err = errors.New("boom")
-	results, err := s.api.SetMachineBlockDevices(params.SetMachineBlockDevices{
+	results, err := s.api.SetMachineBlockDevices(context.TODO(), params.SetMachineBlockDevices{
 		MachineBlockDevices: []params.MachineBlockDevices{{
 			Machine: "machine-0",
 		}},

--- a/apiserver/facades/agent/fanconfigurer/fanconfigurer.go
+++ b/apiserver/facades/agent/fanconfigurer/fanconfigurer.go
@@ -4,6 +4,8 @@
 package fanconfigurer
 
 import (
+	"context"
+
 	"github.com/juju/juju/apiserver/common/networkingcommon"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -14,8 +16,8 @@ import (
 
 // FanConfigurer defines the methods on fanconfigurer API endpoint.
 type FanConfigurer interface {
-	WatchForFanConfigChanges() (params.NotifyWatchResult, error)
-	FanConfig() (params.FanConfigResult, error)
+	WatchForFanConfigChanges(context.Context) (params.NotifyWatchResult, error)
+	FanConfig(context.Context) (params.FanConfigResult, error)
 }
 
 type FanConfigurerAPI struct {
@@ -41,7 +43,7 @@ func NewFanConfigurerAPIForModel(model state.ModelAccessor, resources facade.Res
 // changes to the FAN configuration.
 // so we use the regular error return.
 // TODO(wpk) 2017-09-21 We should use Model directly, and watch only for FanConfig changes.
-func (m *FanConfigurerAPI) WatchForFanConfigChanges() (params.NotifyWatchResult, error) {
+func (m *FanConfigurerAPI) WatchForFanConfigChanges(ctx context.Context) (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
 	watch := m.model.WatchForModelConfigChanges()
 	// Consume the initial event. Technically, API
@@ -57,7 +59,7 @@ func (m *FanConfigurerAPI) WatchForFanConfigChanges() (params.NotifyWatchResult,
 }
 
 // FanConfig returns current FAN configuration.
-func (m *FanConfigurerAPI) FanConfig() (params.FanConfigResult, error) {
+func (m *FanConfigurerAPI) FanConfig(ctx context.Context) (params.FanConfigResult, error) {
 	result := params.FanConfigResult{}
 	config, err := m.model.ModelConfig()
 	if err != nil {

--- a/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
+++ b/apiserver/facades/agent/fanconfigurer/fanconfigurer_test.go
@@ -65,7 +65,7 @@ func (s *fanconfigurerSuite) TestWatchSuccess(c *gc.C) {
 		authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := e.WatchForFanConfigChanges()
+	result, err := e.WatchForFanConfigChanges(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{"1", nil})
 	c.Assert(resources.Count(), gc.Equals, 1)
@@ -101,7 +101,7 @@ func (s *fanconfigurerSuite) TestFanConfigSuccess(c *gc.C) {
 		authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	result, err := e.FanConfig()
+	result, err := e.FanConfig(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Fans, gc.HasLen, 2)
 	c.Check(result.Fans[0].Underlay, gc.Equals, "10.100.0.0/16")
@@ -125,7 +125,7 @@ func (s *fanconfigurerSuite) TestFanConfigFetchError(c *gc.C) {
 		authorizer,
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = e.FanConfig()
+	_, err = e.FanConfig(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "pow")
 }
 

--- a/apiserver/facades/agent/hostkeyreporter/facade.go
+++ b/apiserver/facades/agent/hostkeyreporter/facade.go
@@ -4,6 +4,8 @@
 package hostkeyreporter
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -35,7 +37,7 @@ func New(backend Backend, _ facade.Resources, authorizer facade.Authorizer) (*Fa
 }
 
 // ReportKeys sets the SSH host keys for one or more entities.
-func (facade *Facade) ReportKeys(args params.SSHHostKeySet) (params.ErrorResults, error) {
+func (facade *Facade) ReportKeys(ctx context.Context, args params.SSHHostKeySet) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.EntityKeys)),
 	}

--- a/apiserver/facades/agent/hostkeyreporter/facade_test.go
+++ b/apiserver/facades/agent/hostkeyreporter/facade_test.go
@@ -4,6 +4,8 @@
 package hostkeyreporter_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -47,7 +49,7 @@ func (s *facadeSuite) TestReportKeys(c *gc.C) {
 			},
 		},
 	}
-	result, err := s.facade.ReportKeys(args)
+	result, err := s.facade.ReportKeys(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -4,6 +4,7 @@
 package instancemutater_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -123,7 +124,7 @@ func (s *InstanceMutaterAPILifeSuite) TestLife(c *gc.C) {
 	})
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.Life(params.Entities{
+	results, err := facade.Life(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: "machine-0"}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -144,7 +145,7 @@ func (s *InstanceMutaterAPILifeSuite) TestLifeWithInvalidType(c *gc.C) {
 	s.expectLife(s.machineTag)
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.Life(params.Entities{
+	results, err := facade.Life(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: "user-0"}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -174,7 +175,7 @@ func (s *InstanceMutaterAPILifeSuite) TestLifeWithParentId(c *gc.C) {
 	})
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.Life(params.Entities{
+	results, err := facade.Life(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: "machine-0-lxd-0"}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -197,7 +198,7 @@ func (s *InstanceMutaterAPILifeSuite) TestLifeWithInvalidParentId(c *gc.C) {
 	s.expectLife(machineTag)
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.Life(params.Entities{
+	results, err := facade.Life(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: "machine-1-lxd-0"}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -263,7 +264,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfo(c *gc
 	s.expectName()
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
+	results, err := facade.CharmProfilingInfo(context.TODO(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.InstanceId, gc.Equals, instance.Id("0"))
@@ -306,7 +307,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithNo
 	s.expectName()
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
+	results, err := facade.CharmProfilingInfo(context.TODO(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Error, gc.IsNil)
 	c.Assert(results.InstanceId, gc.Equals, instance.Id("0"))
@@ -347,7 +348,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithIn
 	s.expectFindMachineError(s.machineTag, errors.New("not found"))
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
+	results, err := facade.CharmProfilingInfo(context.TODO(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Error, gc.ErrorMatches, "not found")
 }
@@ -361,7 +362,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithMa
 	s.expectInstanceIdNotProvisioned()
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.CharmProfilingInfo(params.Entity{Tag: "machine-0"})
+	results, err := facade.CharmProfilingInfo(context.TODO(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(results.Error, gc.ErrorMatches, "machine-0: attempting to get instanceId: ")
 	c.Assert(results.InstanceId, gc.Equals, instance.Id(""))
@@ -470,7 +471,7 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfiles(c *gc.C) 
 	s.expectSetProfiles(profiles, nil)
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.SetCharmProfiles(params.SetProfileArgs{
+	results, err := facade.SetCharmProfiles(context.TODO(), params.SetProfileArgs{
 		Args: []params.SetProfileArg{
 			{
 				Entity:   params.Entity{Tag: "machine-0"},
@@ -496,7 +497,7 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfilesWithError(
 	s.expectSetProfiles(profiles, errors.New("Failure"))
 	facade := s.facadeAPIForScenario(c)
 
-	results, err := facade.SetCharmProfiles(params.SetProfileArgs{
+	results, err := facade.SetCharmProfiles(context.TODO(), params.SetProfileArgs{
 		Args: []params.SetProfileArg{
 			{
 				Entity:   params.Entity{Tag: "machine-0"},
@@ -549,7 +550,7 @@ func (s *InstanceMutaterAPISetModificationStatusSuite) TestSetModificationStatus
 	s.expectSetModificationStatus(status.Applied, "applied", nil)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.SetModificationStatus(params.SetStatus{
+	result, err := facade.SetModificationStatus(context.TODO(), params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: "machine-0", Status: "applied", Info: "applied", Data: nil},
 		},
@@ -571,7 +572,7 @@ func (s *InstanceMutaterAPISetModificationStatusSuite) TestSetModificationStatus
 	s.expectSetModificationStatus(status.Applied, "applied", errors.New("failed"))
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.SetModificationStatus(params.SetStatus{
+	result, err := facade.SetModificationStatus(context.TODO(), params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: "machine-0", Status: "applied", Info: "applied", Data: nil},
 		},
@@ -625,7 +626,7 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchModelMachines(c *gc.C) {
 	s.expectWatchModelMachinesWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchModelMachines()
+	result, err := facade.WatchModelMachines(context.TODO())
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{
 		StringsWatcherId: "1",
@@ -642,7 +643,7 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchModelMachinesWithClosedC
 	s.expectWatchModelMachinesWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
 
-	_, err := facade.WatchModelMachines()
+	_, err := facade.WatchModelMachines(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "cannot obtain initial model machines")
 }
 
@@ -654,7 +655,7 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchMachines(c *gc.C) {
 	s.expectWatchMachinesWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchMachines()
+	result, err := facade.WatchMachines(context.TODO())
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{
 		StringsWatcherId: "1",
@@ -671,7 +672,7 @@ func (s *InstanceMutaterAPIWatchMachinesSuite) TestWatchMachinesWithClosedChanne
 	s.expectWatchMachinesWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
 
-	_, err := facade.WatchMachines()
+	_, err := facade.WatchMachines(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "cannot obtain initial model machines")
 }
 
@@ -751,7 +752,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectWatchLXDProfileVerificationNeededWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: s.machineTag.String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -770,7 +771,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectLife(s.machineTag)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: names.NewUserTag("bob@local").String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -789,7 +790,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectWatchLXDProfileVerificationNeededWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: s.machineTag.String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -808,7 +809,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectWatchLXDProfileVerificationNeededWithManualMachine()
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: s.machineTag.String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -827,7 +828,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) TestWatchLXDP
 	s.expectWatchLXDProfileVerificationNeededError()
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchLXDProfileVerificationNeeded(params.Entities{
+	result, err := facade.WatchLXDProfileVerificationNeeded(context.TODO(), params.Entities{
 		Entities: []params.Entity{{Tag: s.machineTag.String()}},
 	})
 	c.Assert(err, gc.IsNil)
@@ -854,7 +855,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLX
 
 	s.state.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 	s.machine.EXPECT().IsManual().Return(false, nil)
-	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine).Return(s.watcher, nil)
+	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(gomock.AssignableToTypeOf(context.TODO()), s.machine).Return(s.watcher, nil)
 	s.watcher.EXPECT().Changes().Return(ch)
 	s.resources.EXPECT().Register(s.watcher).Return("1")
 }
@@ -865,14 +866,14 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLX
 
 	s.state.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 	s.machine.EXPECT().IsManual().Return(false, nil)
-	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine).Return(s.watcher, nil)
+	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(gomock.AssignableToTypeOf(context.TODO()), s.machine).Return(s.watcher, nil)
 	s.watcher.EXPECT().Changes().Return(ch)
 }
 
 func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLXDProfileVerificationNeededError() {
 	s.state.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 	s.machine.EXPECT().IsManual().Return(false, nil)
-	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine).Return(s.watcher, errors.New("watcher error"))
+	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(gomock.AssignableToTypeOf(context.TODO()), s.machine).Return(s.watcher, errors.New("watcher error"))
 }
 
 func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLXDProfileVerificationNeededWithManualMachine() {
@@ -881,7 +882,7 @@ func (s *InstanceMutaterAPIWatchLXDProfileVerificationNeededSuite) expectWatchLX
 
 	s.state.EXPECT().Machine(s.machineTag.Id()).Return(s.machine, nil)
 	s.machine.EXPECT().IsManual().Return(true, nil)
-	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(s.machine).Times(0)
+	s.mutatorWatcher.EXPECT().WatchLXDProfileVerificationForMachine(gomock.AssignableToTypeOf(context.TODO()), s.machine).Times(0)
 }
 
 type InstanceMutaterAPIWatchContainersSuite struct {
@@ -910,7 +911,7 @@ func (s *InstanceMutaterAPIWatchContainersSuite) TestWatchContainers(c *gc.C) {
 	s.expectWatchContainersWithNotify(1)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchContainers(params.Entity{Tag: s.machineTag.String()})
+	result, err := facade.WatchContainers(context.TODO(), params.Entity{Tag: s.machineTag.String()})
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{
 		StringsWatcherId: "1",
@@ -926,7 +927,7 @@ func (s *InstanceMutaterAPIWatchContainersSuite) TestWatchContainersWithInvalidT
 	s.expectLife(s.machineTag)
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchContainers(params.Entity{Tag: names.NewUserTag("bob@local").String()})
+	result, err := facade.WatchContainers(context.TODO(), params.Entity{Tag: names.NewUserTag("bob@local").String()})
 	c.Logf("%#v", err)
 	c.Assert(err, gc.ErrorMatches, "\"user-bob\" is not a valid machine tag")
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{})
@@ -940,7 +941,7 @@ func (s *InstanceMutaterAPIWatchContainersSuite) TestWatchContainersWithClosedCh
 	s.expectWatchContainersWithClosedChannel()
 	facade := s.facadeAPIForScenario(c)
 
-	result, err := facade.WatchContainers(params.Entity{Tag: s.machineTag.String()})
+	result, err := facade.WatchContainers(context.TODO(), params.Entity{Tag: s.machineTag.String()})
 	c.Assert(err, gc.ErrorMatches, "cannot obtain initial machine containers")
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{})
 }

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -42,18 +43,18 @@ func (m *MockInstanceMutatorWatcher) EXPECT() *MockInstanceMutatorWatcherMockRec
 }
 
 // WatchLXDProfileVerificationForMachine mocks base method.
-func (m *MockInstanceMutatorWatcher) WatchLXDProfileVerificationForMachine(arg0 instancemutater.Machine) (state.NotifyWatcher, error) {
+func (m *MockInstanceMutatorWatcher) WatchLXDProfileVerificationForMachine(arg0 context.Context, arg1 instancemutater.Machine) (state.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationForMachine", arg0)
+	ret := m.ctrl.Call(m, "WatchLXDProfileVerificationForMachine", arg0, arg1)
 	ret0, _ := ret[0].(state.NotifyWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchLXDProfileVerificationForMachine indicates an expected call of WatchLXDProfileVerificationForMachine.
-func (mr *MockInstanceMutatorWatcherMockRecorder) WatchLXDProfileVerificationForMachine(arg0 interface{}) *gomock.Call {
+func (mr *MockInstanceMutatorWatcherMockRecorder) WatchLXDProfileVerificationForMachine(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationForMachine", reflect.TypeOf((*MockInstanceMutatorWatcher)(nil).WatchLXDProfileVerificationForMachine), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfileVerificationForMachine", reflect.TypeOf((*MockInstanceMutatorWatcher)(nil).WatchLXDProfileVerificationForMachine), arg0, arg1)
 }
 
 // MockInstanceMutaterState is a mock of InstanceMutaterState interface.

--- a/apiserver/facades/agent/keyupdater/authorisedkeys.go
+++ b/apiserver/facades/agent/keyupdater/authorisedkeys.go
@@ -4,6 +4,8 @@
 package keyupdater
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/utils/v3/ssh"
@@ -18,8 +20,8 @@ import (
 
 // KeyUpdater defines the methods on the keyupdater API end point.
 type KeyUpdater interface {
-	AuthorisedKeys(args params.Entities) (params.StringsResults, error)
-	WatchAuthorisedKeys(args params.Entities) (params.NotifyWatchResults, error)
+	AuthorisedKeys(ctx context.Context, args params.Entities) (params.StringsResults, error)
+	WatchAuthorisedKeys(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error)
 }
 
 // KeyUpdaterAPI implements the KeyUpdater interface and is the concrete
@@ -38,7 +40,7 @@ var _ KeyUpdater = (*KeyUpdaterAPI)(nil)
 // for the specified machines.
 // The current implementation relies on global authorised keys being stored in the model config.
 // This will change as new user management and authorisation functionality is added.
-func (api *KeyUpdaterAPI) WatchAuthorisedKeys(arg params.Entities) (params.NotifyWatchResults, error) {
+func (api *KeyUpdaterAPI) WatchAuthorisedKeys(ctx context.Context, arg params.Entities) (params.NotifyWatchResults, error) {
 	results := make([]params.NotifyWatchResult, len(arg.Entities))
 
 	canRead, err := api.getCanRead()
@@ -81,7 +83,7 @@ func (api *KeyUpdaterAPI) WatchAuthorisedKeys(arg params.Entities) (params.Notif
 // AuthorisedKeys reports the authorised ssh keys for the specified machines.
 // The current implementation relies on global authorised keys being stored in the model config.
 // This will change as new user management and authorisation functionality is added.
-func (api *KeyUpdaterAPI) AuthorisedKeys(arg params.Entities) (params.StringsResults, error) {
+func (api *KeyUpdaterAPI) AuthorisedKeys(ctx context.Context, arg params.Entities) (params.StringsResults, error) {
 	if len(arg.Entities) == 0 {
 		return params.StringsResults{}, nil
 	}

--- a/apiserver/facades/agent/keyupdater/authorisedkeys_test.go
+++ b/apiserver/facades/agent/keyupdater/authorisedkeys_test.go
@@ -4,6 +4,8 @@
 package keyupdater_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -80,7 +82,7 @@ func (s *authorisedKeysSuite) TestNewKeyUpdaterAPIRefusesNonMachineAgent(c *gc.C
 
 func (s *authorisedKeysSuite) TestWatchAuthorisedKeysNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results, err := s.keyupdater.WatchAuthorisedKeys(params.Entities{})
+	results, err := s.keyupdater.WatchAuthorisedKeys(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -101,7 +103,7 @@ func (s *authorisedKeysSuite) TestWatchAuthorisedKeys(c *gc.C) {
 			{Tag: "machine-42"},
 		},
 	}
-	results, err := s.keyupdater.WatchAuthorisedKeys(args)
+	results, err := s.keyupdater.WatchAuthorisedKeys(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -128,7 +130,7 @@ func (s *authorisedKeysSuite) TestWatchAuthorisedKeys(c *gc.C) {
 
 func (s *authorisedKeysSuite) TestAuthorisedKeysForNoone(c *gc.C) {
 	// Not an error to request nothing, dumb, but not an error.
-	results, err := s.keyupdater.AuthorisedKeys(params.Entities{})
+	results, err := s.keyupdater.AuthorisedKeys(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -143,7 +145,7 @@ func (s *authorisedKeysSuite) TestAuthorisedKeys(c *gc.C) {
 			{Tag: "machine-42"},
 		},
 	}
-	results, err := s.keyupdater.AuthorisedKeys(args)
+	results, err := s.keyupdater.AuthorisedKeys(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{

--- a/apiserver/facades/agent/leadership/interface.go
+++ b/apiserver/facades/agent/leadership/interface.go
@@ -16,7 +16,7 @@ import (
 type LeadershipService interface {
 
 	// ClaimLeadership makes a leadership claim with the given parameters.
-	ClaimLeadership(params params.ClaimLeadershipBulkParams) (params.ClaimLeadershipBulkResults, error)
+	ClaimLeadership(ctx context.Context, params params.ClaimLeadershipBulkParams) (params.ClaimLeadershipBulkResults, error)
 
 	// BlockUntilLeadershipReleased blocks the caller until leadership is
 	// released for the given service.

--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -49,7 +49,7 @@ type leadershipService struct {
 }
 
 // ClaimLeadership is part of the LeadershipService interface.
-func (m *leadershipService) ClaimLeadership(args params.ClaimLeadershipBulkParams) (params.ClaimLeadershipBulkResults, error) {
+func (m *leadershipService) ClaimLeadership(ctx context.Context, args params.ClaimLeadershipBulkParams) (params.ClaimLeadershipBulkResults, error) {
 
 	results := make([]params.ErrorResult, len(args.Params))
 	for pIdx, p := range args.Params {

--- a/apiserver/facades/agent/leadership/leadership_test.go
+++ b/apiserver/facades/agent/leadership/leadership_test.go
@@ -107,7 +107,7 @@ func (s *leadershipSuite) TestClaimLeadershipTranslation(c *gc.C) {
 	}
 
 	ldrSvc := newLeadershipService(c, claimer, nil)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -137,7 +137,7 @@ func (s *leadershipSuite) TestClaimLeadershipApplicationAgent(c *gc.C) {
 		tag: names.NewApplicationTag(StubAppNm),
 	}
 	ldrSvc := newLeadershipService(c, claimer, authorizer)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -164,7 +164,7 @@ func (s *leadershipSuite) TestClaimLeadershipDeniedError(c *gc.C) {
 	}
 
 	ldrSvc := newLeadershipService(c, claimer, nil)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -182,7 +182,7 @@ func (s *leadershipSuite) TestClaimLeadershipDeniedError(c *gc.C) {
 func (s *leadershipSuite) TestClaimLeadershipBadService(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
 
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  "application-bad/0",
@@ -199,7 +199,7 @@ func (s *leadershipSuite) TestClaimLeadershipBadService(c *gc.C) {
 func (s *leadershipSuite) TestClaimLeadershipBadUnit(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
 
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -216,7 +216,7 @@ func (s *leadershipSuite) TestClaimLeadershipBadUnit(c *gc.C) {
 func (s *leadershipSuite) TestClaimLeadershipDurationTooShort(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
 
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -233,7 +233,7 @@ func (s *leadershipSuite) TestClaimLeadershipDurationTooShort(c *gc.C) {
 func (s *leadershipSuite) TestClaimLeadershipDurationTooLong(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
 
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -292,7 +292,7 @@ func (s *leadershipSuite) TestClaimLeadershipFailBadUnit(c *gc.C) {
 	}
 
 	ldrSvc := newLeadershipService(c, nil, authorizer)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag(StubAppNm).String(),
@@ -310,7 +310,7 @@ func (s *leadershipSuite) TestClaimLeadershipFailBadUnit(c *gc.C) {
 
 func (s *leadershipSuite) TestClaimLeadershipFailBadService(c *gc.C) {
 	ldrSvc := newLeadershipService(c, nil, nil)
-	results, err := ldrSvc.ClaimLeadership(params.ClaimLeadershipBulkParams{
+	results, err := ldrSvc.ClaimLeadership(context.TODO(), params.ClaimLeadershipBulkParams{
 		Params: []params.ClaimLeadershipParams{
 			{
 				ApplicationTag:  names.NewApplicationTag("lol-different").String(),

--- a/apiserver/facades/agent/logger/logger.go
+++ b/apiserver/facades/agent/logger/logger.go
@@ -4,6 +4,8 @@
 package logger
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -19,8 +21,8 @@ import (
 // endpoint because our rpc mechanism panics.  However, I still feel that this
 // provides a useful documentation purpose.
 type Logger interface {
-	WatchLoggingConfig(args params.Entities) params.NotifyWatchResults
-	LoggingConfig(args params.Entities) params.StringResults
+	WatchLoggingConfig(ctx context.Context, args params.Entities) params.NotifyWatchResults
+	LoggingConfig(ctx context.Context, args params.Entities) params.StringResults
 }
 
 // LoggerAPI implements the Logger interface and is the concrete
@@ -38,7 +40,7 @@ var _ Logger = (*LoggerAPI)(nil)
 // for the agents specified..  Unfortunately the current infrastructure makes
 // watching parts of the config non-trivial, so currently any change to the
 // config will cause the watcher to notify the client.
-func (api *LoggerAPI) WatchLoggingConfig(arg params.Entities) params.NotifyWatchResults {
+func (api *LoggerAPI) WatchLoggingConfig(ctx context.Context, arg params.Entities) params.NotifyWatchResults {
 	result := make([]params.NotifyWatchResult, len(arg.Entities))
 	for i, entity := range arg.Entities {
 		tag, err := names.ParseTag(entity.Tag)
@@ -65,7 +67,7 @@ func (api *LoggerAPI) WatchLoggingConfig(arg params.Entities) params.NotifyWatch
 }
 
 // LoggingConfig reports the logging configuration for the agents specified.
-func (api *LoggerAPI) LoggingConfig(arg params.Entities) params.StringResults {
+func (api *LoggerAPI) LoggingConfig(ctx context.Context, arg params.Entities) params.StringResults {
 	if len(arg.Entities) == 0 {
 		return params.StringResults{}
 	}

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -4,6 +4,8 @@
 package logger_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3/workertest"
@@ -105,7 +107,7 @@ func (s *loggerSuite) TestNewLoggerAPIAcceptsApplicationAgent(c *gc.C) {
 
 func (s *loggerSuite) TestWatchLoggingConfigNothing(c *gc.C) {
 	// Not an error to watch nothing
-	results := s.logger.WatchLoggingConfig(params.Entities{})
+	results := s.logger.WatchLoggingConfig(context.TODO(), params.Entities{})
 	c.Assert(results.Results, gc.HasLen, 0)
 }
 
@@ -120,7 +122,7 @@ func (s *loggerSuite) TestWatchLoggingConfig(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
 	}
-	results := s.logger.WatchLoggingConfig(args)
+	results := s.logger.WatchLoggingConfig(context.TODO(), args)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].NotifyWatcherId, gc.Not(gc.Equals), "")
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -137,7 +139,7 @@ func (s *loggerSuite) TestWatchLoggingConfigRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: "machine-12354"}},
 	}
-	results := s.logger.WatchLoggingConfig(args)
+	results := s.logger.WatchLoggingConfig(context.TODO(), args)
 	// It is not an error to make the request, but the specific item is rejected
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].NotifyWatcherId, gc.Equals, "")
@@ -146,7 +148,7 @@ func (s *loggerSuite) TestWatchLoggingConfigRefusesWrongAgent(c *gc.C) {
 
 func (s *loggerSuite) TestLoggingConfigForNoone(c *gc.C) {
 	// Not an error to request nothing, dumb, but not an error.
-	results := s.logger.LoggingConfig(params.Entities{})
+	results := s.logger.LoggingConfig(context.TODO(), params.Entities{})
 	c.Assert(results.Results, gc.HasLen, 0)
 }
 
@@ -154,7 +156,7 @@ func (s *loggerSuite) TestLoggingConfigRefusesWrongAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: "machine-12354"}},
 	}
-	results := s.logger.LoggingConfig(args)
+	results := s.logger.LoggingConfig(context.TODO(), args)
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
 	c.Assert(result.Error, gc.DeepEquals, apiservertesting.ErrUnauthorized)
@@ -167,7 +169,7 @@ func (s *loggerSuite) TestLoggingConfigForAgent(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.rawMachine.Tag().String()}},
 	}
-	results := s.logger.LoggingConfig(args)
+	results := s.logger.LoggingConfig(context.TODO(), args)
 	c.Assert(results.Results, gc.HasLen, 1)
 	result := results.Results[0]
 	c.Assert(result.Error, gc.IsNil)

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -4,6 +4,8 @@
 package machine
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -75,7 +77,7 @@ func (api *MachinerAPI) getMachine(tag string, authChecker common.AuthFunc) (*st
 	return entity.(*state.Machine), nil
 }
 
-func (api *MachinerAPI) SetMachineAddresses(args params.SetMachinesAddresses) (params.ErrorResults, error) {
+func (api *MachinerAPI) SetMachineAddresses(ctx context.Context, args params.SetMachinesAddresses) (params.ErrorResults, error) {
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.MachineAddresses)),
 	}

--- a/apiserver/facades/agent/machine/machiner_test.go
+++ b/apiserver/facades/agent/machine/machiner_test.go
@@ -4,6 +4,7 @@
 package machine_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/loggo"
@@ -87,7 +88,7 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 			{Tag: "machine-0", Status: status.Stopped.String(), Info: "foobar"},
 			{Tag: "machine-42", Status: status.Started.String(), Info: "blah"},
 		}}
-	result, err := s.machiner.SetStatus(args)
+	result, err := s.machiner.SetStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -121,7 +122,7 @@ func (s *machinerSuite) TestLife(c *gc.C) {
 		{Tag: "machine-0"},
 		{Tag: "machine-42"},
 	}}
-	result, err := s.machiner.Life(args)
+	result, err := s.machiner.Life(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
@@ -141,7 +142,7 @@ func (s *machinerSuite) TestEnsureDead(c *gc.C) {
 		{Tag: "machine-0"},
 		{Tag: "machine-42"},
 	}}
-	result, err := s.machiner.EnsureDead(args)
+	result, err := s.machiner.EnsureDead(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -162,7 +163,7 @@ func (s *machinerSuite) TestEnsureDead(c *gc.C) {
 	args = params.Entities{
 		Entities: []params.Entity{{Tag: "machine-1"}},
 	}
-	result, err = s.machiner.EnsureDead(args)
+	result, err = s.machiner.EnsureDead(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{{nil}},
@@ -188,7 +189,7 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 		{Tag: "machine-42", Addresses: params.FromMachineAddresses(addresses...)},
 	}}
 
-	result, err := s.machiner.SetMachineAddresses(args)
+	result, err := s.machiner.SetMachineAddresses(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -217,7 +218,7 @@ func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	args := params.SetMachinesAddresses{MachineAddresses: []params.MachineAddresses{
 		{Tag: "machine-1", Addresses: params.FromMachineAddresses(addresses...)},
 	}}
-	result, err := s.machiner.SetMachineAddresses(args)
+	result, err := s.machiner.SetMachineAddresses(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -229,7 +230,7 @@ func (s *machinerSuite) TestSetEmptyMachineAddresses(c *gc.C) {
 	c.Assert(s.machine1.MachineAddresses(), gc.HasLen, 2)
 
 	args.MachineAddresses[0].Addresses = nil
-	result, err = s.machiner.SetMachineAddresses(args)
+	result, err = s.machiner.SetMachineAddresses(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -274,7 +275,7 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	// We just set up the machiner, make sure there aren't pending events
 	// before we set up the watcher.
 	s.WaitForModelWatchersIdle(c, s.Model.UUID())
-	result, err := s.machiner.Watch(args)
+	result, err := s.machiner.Watch(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{

--- a/apiserver/facades/agent/machineactions/machineactions.go
+++ b/apiserver/facades/agent/machineactions/machineactions.go
@@ -5,6 +5,8 @@
 package machineactions
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/apiserver/common"
@@ -47,26 +49,26 @@ func NewFacade(
 
 // Actions returns the Actions by Tags passed and ensures that the machine asking
 // for them is the machine that has the actions
-func (f *Facade) Actions(args params.Entities) params.ActionResults {
+func (f *Facade) Actions(ctx context.Context, args params.Entities) params.ActionResults {
 	actionFn := common.AuthAndActionFromTagFn(f.accessMachine, f.backend.ActionByTag)
 	return common.Actions(args, actionFn)
 }
 
 // BeginActions marks the actions represented by the passed in Tags as running.
-func (f *Facade) BeginActions(args params.Entities) params.ErrorResults {
+func (f *Facade) BeginActions(ctx context.Context, args params.Entities) params.ErrorResults {
 	actionFn := common.AuthAndActionFromTagFn(f.accessMachine, f.backend.ActionByTag)
 	return common.BeginActions(args, actionFn)
 }
 
 // FinishActions saves the result of a completed Action
-func (f *Facade) FinishActions(args params.ActionExecutionResults) params.ErrorResults {
+func (f *Facade) FinishActions(ctx context.Context, args params.ActionExecutionResults) params.ErrorResults {
 	actionFn := common.AuthAndActionFromTagFn(f.accessMachine, f.backend.ActionByTag)
 	return common.FinishActions(args, actionFn)
 }
 
 // WatchActionNotifications returns a StringsWatcher for observing
 // incoming action calls to a machine.
-func (f *Facade) WatchActionNotifications(args params.Entities) params.StringsWatchResults {
+func (f *Facade) WatchActionNotifications(ctx context.Context, args params.Entities) params.StringsWatchResults {
 	tagToActionReceiver := f.backend.TagToActionReceiverFn(f.backend.FindEntity)
 	watchOne := common.WatchPendingActionsForReceiver(tagToActionReceiver, f.resources.Register)
 	return common.WatchActionNotifications(args, f.accessMachine, watchOne)
@@ -75,7 +77,7 @@ func (f *Facade) WatchActionNotifications(args params.Entities) params.StringsWa
 // RunningActions lists the actions running for the entities passed in.
 // If we end up needing more than ListRunning at some point we could follow/abstract
 // what's done in the client actions package.
-func (f *Facade) RunningActions(args params.Entities) params.ActionsByReceivers {
+func (f *Facade) RunningActions(ctx context.Context, args params.Entities) params.ActionsByReceivers {
 	canAccess := f.accessMachine
 	tagToActionReceiver := f.backend.TagToActionReceiverFn(f.backend.FindEntity)
 

--- a/apiserver/facades/agent/machineactions/machineactions_test.go
+++ b/apiserver/facades/agent/machineactions/machineactions_test.go
@@ -5,6 +5,7 @@
 package machineactions_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v4"
@@ -51,7 +52,7 @@ func (*FacadeSuite) TestRunningActions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	stub.SetErrors(errors.New("boom"))
-	results := facade.RunningActions(entities(
+	results := facade.RunningActions(context.TODO(), entities(
 		"valid", // we will cause this one to err out
 		"valid",
 		"invalid",
@@ -98,10 +99,7 @@ func (auth agentAuth) AuthMachineAgent() bool {
 }
 
 func (auth agentAuth) AuthOwner(tag names.Tag) bool {
-	if tag.String() == "valid" {
-		return true
-	}
-	return false
+	return tag.String() == "valid"
 }
 
 // mockBackend implements machineactions.Backend for use in the tests.

--- a/apiserver/facades/agent/meterstatus/meterstatus.go
+++ b/apiserver/facades/agent/meterstatus/meterstatus.go
@@ -4,6 +4,8 @@
 package meterstatus
 
 import (
+	"context"
+
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 
@@ -21,8 +23,8 @@ var logger = loggo.GetLogger("juju.apiserver.meterstatus")
 
 // MeterStatus defines the methods exported by the meter status API facade.
 type MeterStatus interface {
-	GetMeterStatus(args params.Entities) (params.MeterStatusResults, error)
-	WatchMeterStatus(args params.Entities) (params.NotifyWatchResults, error)
+	GetMeterStatus(ctx context.Context, args params.Entities) (params.MeterStatusResults, error)
+	WatchMeterStatus(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error)
 }
 
 // MeterStatusState represents the state of an model required by the MeterStatus.
@@ -78,7 +80,7 @@ func NewMeterStatusAPI(
 
 // WatchMeterStatus returns a NotifyWatcher for observing changes
 // to each unit's meter status.
-func (m *MeterStatusAPI) WatchMeterStatus(args params.Entities) (params.NotifyWatchResults, error) {
+func (m *MeterStatusAPI) WatchMeterStatus(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	result := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}
@@ -116,7 +118,7 @@ func (m *MeterStatusAPI) watchOneUnitMeterStatus(tag names.UnitTag) (string, err
 }
 
 // GetMeterStatus returns meter status information for each unit.
-func (m *MeterStatusAPI) GetMeterStatus(args params.Entities) (params.MeterStatusResults, error) {
+func (m *MeterStatusAPI) GetMeterStatus(ctx context.Context, args params.Entities) (params.MeterStatusResults, error) {
 	result := params.MeterStatusResults{
 		Results: make([]params.MeterStatusResult, len(args.Entities)),
 	}

--- a/apiserver/facades/agent/meterstatus/meterstatus_test.go
+++ b/apiserver/facades/agent/meterstatus/meterstatus_test.go
@@ -4,6 +4,8 @@
 package meterstatus_test
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
@@ -59,7 +61,7 @@ func (s *meterStatusSuite) TestGetMeterStatusUnauthenticated(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	otherunit := s.Factory.MakeUnit(c, &jujufactory.UnitParams{Application: application})
 	args := params.Entities{Entities: []params.Entity{{otherunit.Tag().String()}}}
-	result, err := s.status.GetMeterStatus(args)
+	result, err := s.status.GetMeterStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.ErrorMatches, "permission denied")
@@ -79,7 +81,7 @@ func (s *meterStatusSuite) TestGetMeterStatusBadTag(c *gc.C) {
 	for i, tag := range tags {
 		args.Entities[i] = params.Entity{Tag: tag}
 	}
-	result, err := s.status.GetMeterStatus(args)
+	result, err := s.status.GetMeterStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, len(tags))
 	for i, result := range result.Results {
@@ -115,7 +117,7 @@ func (s *meterStatusSuite) TestWatchMeterStatus(c *gc.C) {
 		{Tag: s.unit.UnitTag().String()},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := status.WatchMeterStatus(args)
+	result, err := status.WatchMeterStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -143,7 +145,7 @@ func (s *meterStatusSuite) TestWatchMeterStatusWithStateChange(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: s.unit.UnitTag().String()},
 	}}
-	result, err := status.WatchMeterStatus(args)
+	result, err := status.WatchMeterStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -180,7 +182,7 @@ func (s *meterStatusSuite) TestWatchMeterStatusWithApplicationTag(c *gc.C) {
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: unit.UnitTag().String()},
 	}}
-	result, err := status.WatchMeterStatus(args)
+	result, err := status.WatchMeterStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{

--- a/apiserver/facades/agent/meterstatus/testing/tests.go
+++ b/apiserver/facades/agent/meterstatus/testing/tests.go
@@ -4,6 +4,8 @@
 package testing
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -18,7 +20,7 @@ import (
 // TestGetMeterStatus tests unit meter status retrieval.
 func TestGetMeterStatus(c *gc.C, status meterstatus.MeterStatus, unit *jujustate.Unit) {
 	args := params.Entities{Entities: []params.Entity{{Tag: unit.Tag().String()}}}
-	result, err := status.GetMeterStatus(args)
+	result, err := status.GetMeterStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -31,7 +33,7 @@ func TestGetMeterStatus(c *gc.C, status meterstatus.MeterStatus, unit *jujustate
 	err = unit.SetMeterStatus(newCode, newInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err = status.GetMeterStatus(args)
+	result, err = status.GetMeterStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
@@ -47,7 +49,7 @@ func TestWatchMeterStatus(c *gc.C, status meterstatus.MeterStatus, unit *jujusta
 		{Tag: unit.UnitTag().String()},
 		{Tag: "unit-foo-42"},
 	}}
-	result, err := status.WatchMeterStatus(args)
+	result, err := status.WatchMeterStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{

--- a/apiserver/facades/agent/metricsadder/metricsadder.go
+++ b/apiserver/facades/agent/metricsadder/metricsadder.go
@@ -4,6 +4,8 @@
 package metricsadder
 
 import (
+	"context"
+
 	"github.com/juju/names/v4"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -14,7 +16,7 @@ import (
 // MetricsAdder defines methods that are used to store metric batches in the state.
 type MetricsAdder interface {
 	// AddMetricBatches stores the specified metric batches in the state.
-	AddMetricBatches(batches params.MetricBatchParams) (params.ErrorResults, error)
+	AddMetricBatches(ctx context.Context, batches params.MetricBatchParams) (params.ErrorResults, error)
 }
 
 // MetricsAdderAPI implements the metrics adder interface and is the concrete
@@ -26,7 +28,7 @@ type MetricsAdderAPI struct {
 var _ MetricsAdder = (*MetricsAdderAPI)(nil)
 
 // AddMetricBatches implements the MetricsAdder interface.
-func (api *MetricsAdderAPI) AddMetricBatches(args params.MetricBatchParams) (params.ErrorResults, error) {
+func (api *MetricsAdderAPI) AddMetricBatches(ctx context.Context, args params.MetricBatchParams) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Batches)),
 	}

--- a/apiserver/facades/agent/metricsadder/metricsadder_test.go
+++ b/apiserver/facades/agent/metricsadder/metricsadder_test.go
@@ -4,6 +4,7 @@
 package metricsadder_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -105,7 +106,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatch(c *gc.C) {
 	}}
 	uuid := utils.MustNewUUID().String()
 
-	result, err := s.adder.AddMetricBatches(params.MetricBatchParams{
+	result, err := s.adder.AddMetricBatches(context.TODO(), params.MetricBatchParams{
 		Batches: []params.MetricBatchParam{{
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
@@ -141,7 +142,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchNoCharmURL(c *gc.C) {
 	metrics := []params.Metric{{Key: "pings", Value: "5", Time: time.Now().UTC()}}
 	uuid := utils.MustNewUUID().String()
 
-	result, err := s.adder.AddMetricBatches(params.MetricBatchParams{
+	result, err := s.adder.AddMetricBatches(context.TODO(), params.MetricBatchParams{
 		Batches: []params.MetricBatchParam{{
 			Tag: s.meteredUnit.Tag().String(),
 			Batch: params.MetricBatch{
@@ -192,7 +193,7 @@ func (s *metricsAdderSuite) TestAddMetricsBatchDiffTag(c *gc.C) {
 
 	for i, test := range tests {
 		c.Logf("test %d: %s -> %s", i, test.about, test.tag)
-		result, err := s.adder.AddMetricBatches(params.MetricBatchParams{
+		result, err := s.adder.AddMetricBatches(context.TODO(), params.MetricBatchParams{
 			Batches: []params.MetricBatchParam{{
 				Tag: test.tag,
 				Batch: params.MetricBatch{

--- a/apiserver/facades/agent/migrationflag/facade.go
+++ b/apiserver/facades/agent/migrationflag/facade.go
@@ -4,6 +4,8 @@
 package migrationflag
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -56,7 +58,7 @@ func (facade *Facade) auth(tagString string) error {
 
 // Phase returns the current migration phase or an error for every
 // supplied entity.
-func (facade *Facade) Phase(entities params.Entities) params.PhaseResults {
+func (facade *Facade) Phase(ctx context.Context, entities params.Entities) params.PhaseResults {
 	count := len(entities.Entities)
 	results := params.PhaseResults{
 		Results: make([]params.PhaseResult, count),
@@ -83,7 +85,7 @@ func (facade *Facade) onePhase(tagString string) (string, error) {
 
 // Watch returns an id for use with the NotifyWatcher facade, or an
 // error, for every supplied entity.
-func (facade *Facade) Watch(entities params.Entities) params.NotifyWatchResults {
+func (facade *Facade) Watch(ctx context.Context, entities params.Entities) params.NotifyWatchResults {
 	count := len(entities.Entities)
 	results := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, count),

--- a/apiserver/facades/agent/migrationflag/facade_test.go
+++ b/apiserver/facades/agent/migrationflag/facade_test.go
@@ -4,6 +4,8 @@
 package migrationflag_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -52,7 +54,7 @@ func (*FacadeSuite) TestPhaseSuccess(c *gc.C) {
 	facade, err := migrationflag.New(backend, nil, authOK)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results := facade.Phase(entities(
+	results := facade.Phase(context.TODO(), entities(
 		coretesting.ModelTag.String(),
 		coretesting.ModelTag.String(),
 	))
@@ -73,7 +75,7 @@ func (*FacadeSuite) TestPhaseErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// 3 entities: unparseable, unauthorized, call error.
-	results := facade.Phase(entities(
+	results := facade.Phase(context.TODO(), entities(
 		"urgle",
 		unknownModel,
 		coretesting.ModelTag.String(),
@@ -102,7 +104,7 @@ func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
 	facade, err := migrationflag.New(backend, resources, authOK)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results := facade.Watch(entities(
+	results := facade.Watch(context.TODO(), entities(
 		coretesting.ModelTag.String(),
 		coretesting.ModelTag.String(),
 	))
@@ -130,7 +132,7 @@ func (*FacadeSuite) TestWatchErrors(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// 3 entities: unparseable, unauthorized, closed channel.
-	results := facade.Watch(entities(
+	results := facade.Watch(context.TODO(), entities(
 		"urgle",
 		unknownModel,
 		coretesting.ModelTag.String(),

--- a/apiserver/facades/agent/migrationminion/migrationminion.go
+++ b/apiserver/facades/agent/migrationminion/migrationminion.go
@@ -4,6 +4,8 @@
 package migrationminion
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -44,7 +46,7 @@ func NewAPI(
 //
 // The MigrationStatusWatcher facade must be used to receive events
 // from the watcher.
-func (api *API) Watch() (params.NotifyWatchResult, error) {
+func (api *API) Watch(context.Context) (params.NotifyWatchResult, error) {
 	w := api.backend.WatchMigrationStatus()
 	return params.NotifyWatchResult{
 		NotifyWatcherId: api.resources.Register(w),
@@ -53,7 +55,7 @@ func (api *API) Watch() (params.NotifyWatchResult, error) {
 
 // Report allows a migration minion to submit whether it succeeded or
 // failed for a specific migration phase.
-func (api *API) Report(info params.MinionReport) error {
+func (api *API) Report(ctx context.Context, info params.MinionReport) error {
 	phase, ok := migration.ParsePhase(info.Phase)
 	if !ok {
 		return errors.New("unable to parse phase")

--- a/apiserver/facades/agent/migrationminion/migrationminion_test.go
+++ b/apiserver/facades/agent/migrationminion/migrationminion_test.go
@@ -4,6 +4,8 @@
 package migrationminion_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/testing"
@@ -71,14 +73,14 @@ func (s *Suite) TestAuthNotAgent(c *gc.C) {
 
 func (s *Suite) TestWatch(c *gc.C) {
 	api := s.mustMakeAPI(c)
-	result, err := api.Watch()
+	result, err := api.Watch(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.resources.Get(result.NotifyWatcherId), gc.NotNil)
 }
 
 func (s *Suite) TestReport(c *gc.C) {
 	api := s.mustMakeAPI(c)
-	err := api.Report(params.MinionReport{
+	err := api.Report(context.TODO(), params.MinionReport{
 		MigrationId: "id",
 		Phase:       "IMPORT",
 		Success:     true,
@@ -92,7 +94,7 @@ func (s *Suite) TestReport(c *gc.C) {
 
 func (s *Suite) TestReportInvalidPhase(c *gc.C) {
 	api := s.mustMakeAPI(c)
-	err := api.Report(params.MinionReport{
+	err := api.Report(context.TODO(), params.MinionReport{
 		MigrationId: "id",
 		Phase:       "WTF",
 		Success:     true,
@@ -104,7 +106,7 @@ func (s *Suite) TestReportNoSuchMigration(c *gc.C) {
 	failure := errors.NotFoundf("model")
 	s.backend.modelLookupErr = failure
 	api := s.mustMakeAPI(c)
-	err := api.Report(params.MinionReport{
+	err := api.Report(context.TODO(), params.MinionReport{
 		MigrationId: "id",
 		Phase:       "QUIESCE",
 		Success:     false,

--- a/apiserver/facades/agent/payloadshookcontext/unitfacade.go
+++ b/apiserver/facades/agent/payloadshookcontext/unitfacade.go
@@ -4,6 +4,8 @@
 package payloadshookcontext
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -56,7 +58,7 @@ func NewUnitFacade(backend UnitPayloadBackend) *UnitFacade {
 }
 
 // Track stores a payload to be tracked in state.
-func (uf UnitFacade) Track(args params.TrackPayloadArgs) (params.PayloadResults, error) {
+func (uf UnitFacade) Track(ctx context.Context, args params.TrackPayloadArgs) (params.PayloadResults, error) {
 	logger.Debugf("tracking %d payloads from API", len(args.Payloads))
 
 	var r params.PayloadResults
@@ -88,7 +90,7 @@ func (uf UnitFacade) track(pl payloads.Payload) (string, error) {
 // List builds the list of payload being tracked for
 // the given unit and IDs. If no IDs are provided then all tracked
 // payloads for the unit are returned.
-func (uf UnitFacade) List(args params.Entities) (params.PayloadResults, error) {
+func (uf UnitFacade) List(ctx context.Context, args params.Entities) (params.PayloadResults, error) {
 	if len(args.Entities) == 0 {
 		return uf.listAll()
 	}
@@ -140,7 +142,7 @@ func (uf UnitFacade) listAll() (params.PayloadResults, error) {
 }
 
 // LookUp identifies the payload with the provided name and raw ID.
-func (uf UnitFacade) LookUp(args params.LookUpPayloadArgs) (params.PayloadResults, error) {
+func (uf UnitFacade) LookUp(ctx context.Context, args params.LookUpPayloadArgs) (params.PayloadResults, error) {
 	var r params.PayloadResults
 	for _, arg := range args.Args {
 		id, err := uf.backend.LookUp(arg.Name, arg.ID)
@@ -151,7 +153,7 @@ func (uf UnitFacade) LookUp(args params.LookUpPayloadArgs) (params.PayloadResult
 }
 
 // SetStatus sets the raw status of a payload.
-func (uf UnitFacade) SetStatus(args params.SetPayloadStatusArgs) (params.PayloadResults, error) {
+func (uf UnitFacade) SetStatus(ctx context.Context, args params.SetPayloadStatusArgs) (params.PayloadResults, error) {
 	var r params.PayloadResults
 	for _, arg := range args.Args {
 		id, err := api.API2ID(arg.Tag)
@@ -167,7 +169,7 @@ func (uf UnitFacade) SetStatus(args params.SetPayloadStatusArgs) (params.Payload
 }
 
 // Untrack marks the identified payload as no longer being tracked.
-func (uf UnitFacade) Untrack(args params.Entities) (params.PayloadResults, error) {
+func (uf UnitFacade) Untrack(ctx context.Context, args params.Entities) (params.PayloadResults, error) {
 	var r params.PayloadResults
 	for _, entity := range args.Entities {
 		id, err := api.API2ID(entity.Tag)

--- a/apiserver/facades/agent/payloadshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/payloadshookcontext/unitfacade_test.go
@@ -4,6 +4,8 @@
 package payloadshookcontext_test
 
 import (
+	"context"
+
 	"github.com/juju/charm/v9"
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -48,7 +50,7 @@ func (s *suite) TestTrack(c *gc.C) {
 		}},
 	}
 
-	res, err := a.Track(args)
+	res, err := a.Track(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(res, jc.DeepEquals, params.PayloadResults{
@@ -98,7 +100,7 @@ func (s *suite) TestListOne(c *gc.C) {
 			Tag: names.NewPayloadTag(id).String(),
 		}},
 	}
-	results, err := a.List(args)
+	results, err := a.List(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := params.Payload{
@@ -145,7 +147,7 @@ func (s *suite) TestListAll(c *gc.C) {
 
 	a := unitfacade.NewUnitFacade(s.state)
 	args := params.Entities{}
-	results, err := a.List(args)
+	results, err := a.List(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := params.Payload{
@@ -180,7 +182,7 @@ func (s *suite) TestLookUpOkay(c *gc.C) {
 			ID:   "bar",
 		}},
 	}
-	res, err := a.LookUp(args)
+	res, err := a.LookUp(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCalls(c, []testing.StubCall{{
@@ -221,7 +223,7 @@ func (s *suite) TestLookUpMixed(c *gc.C) {
 			ID:   "eggs",
 		}},
 	}
-	res, err := a.LookUp(args)
+	res, err := a.LookUp(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.stub.CheckCallNames(c, "LookUp", "LookUp", "LookUp")
@@ -262,7 +264,7 @@ func (s *suite) TestSetStatus(c *gc.C) {
 			Status: payloads.StateRunning,
 		}},
 	}
-	res, err := a.SetStatus(args)
+	res, err := a.SetStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.state.id, gc.Equals, id)
@@ -289,7 +291,7 @@ func (s *suite) TestUntrack(c *gc.C) {
 			Tag: names.NewPayloadTag(id).String(),
 		}},
 	}
-	res, err := a.Untrack(args)
+	res, err := a.Untrack(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.state.id, gc.Equals, id)
@@ -312,7 +314,7 @@ func (s *suite) TestUntrackEmptyID(c *gc.C) {
 			Tag: "",
 		}},
 	}
-	res, err := a.Untrack(args)
+	res, err := a.Untrack(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.state.id, gc.Equals, "")
@@ -336,7 +338,7 @@ func (s *suite) TestUntrackNoIDs(c *gc.C) {
 	args := params.Entities{
 		Entities: []params.Entity{},
 	}
-	res, err := a.Untrack(args)
+	res, err := a.Untrack(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(s.state.id, gc.Equals, id)

--- a/apiserver/facades/agent/provisioner/container_test.go
+++ b/apiserver/facades/agent/provisioner/container_test.go
@@ -4,6 +4,8 @@
 package provisioner_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -68,7 +70,7 @@ func (s *containerProvisionerSuite) TestPrepareContainerInterfaceInfoPermission(
 			Tag: "unit-mysql-0", // not a valid machine tag
 		}}}
 	// Only machine 0 can have it's containers updated.
-	results, err := aProvisioner.PrepareContainerInterfaceInfo(args)
+	results, err := aProvisioner.PrepareContainerInterfaceInfo(context.TODO(), args)
 	c.Assert(err, gc.ErrorMatches, "dummy provider network config not supported")
 	c.Skip("dummy provider needs networking https://pad.lv/1651974")
 	// Overall request is ok
@@ -121,7 +123,7 @@ func (s *containerProvisionerSuite) TestHostChangesForContainersPermission(c *gc
 			Tag: "unit-mysql-0", // not a valid machine tag
 		}}}
 	// Only machine 0 can have it's containers updated.
-	results, err := aProvisioner.HostChangesForContainers(args)
+	results, err := aProvisioner.HostChangesForContainers(context.TODO(), args)
 	c.Assert(err, gc.ErrorMatches, "dummy provider network config not supported")
 	c.Skip("dummy provider needs networking https://pad.lv/1651974")
 	// Overall request is ok

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	"context"
 	"fmt"
 	stdtesting "testing"
 	"time"
@@ -156,7 +157,7 @@ func (s *withoutControllerSuite) TestSetPasswords(c *gc.C) {
 			{Tag: "application-bar", Password: "abc"},
 		},
 	}
-	results, err := s.provisioner.SetPasswords(args)
+	results, err := s.provisioner.SetPasswords(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -187,7 +188,7 @@ func (s *withoutControllerSuite) TestShortSetPasswords(c *gc.C) {
 			{Tag: s.machines[1].Tag().String(), Password: "xxx1"},
 		},
 	}
-	results, err := s.provisioner.SetPasswords(args)
+	results, err := s.provisioner.SetPasswords(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches,
@@ -246,7 +247,7 @@ func (s *withoutControllerSuite) TestLifeAsMachineAgent(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := aProvisioner.Life(args)
+	result, err := aProvisioner.Life(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
@@ -279,7 +280,7 @@ func (s *withoutControllerSuite) TestLifeAsController(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.Life(args)
+	result, err := s.provisioner.Life(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{
@@ -298,7 +299,7 @@ func (s *withoutControllerSuite) TestLifeAsController(c *gc.C) {
 	err = s.machines[1].Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	result, err = s.provisioner.Life(params.Entities{
+	result, err = s.provisioner.Life(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: s.machines[1].Tag().String()},
 		},
@@ -326,7 +327,7 @@ func (s *withoutControllerSuite) TestRemove(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.Remove(args)
+	result, err := s.provisioner.Remove(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -380,7 +381,7 @@ func (s *withoutControllerSuite) TestSetStatus(c *gc.C) {
 			{Tag: "unit-foo-0", Status: status.Stopped.String(), Info: "foobar"},
 			{Tag: "application-bar", Status: status.Stopped.String(), Info: "foobar"},
 		}}
-	result, err := s.provisioner.SetStatus(args)
+	result, err := s.provisioner.SetStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -433,7 +434,7 @@ func (s *withoutControllerSuite) TestSetInstanceStatus(c *gc.C) {
 			{Tag: "unit-foo-0", Status: status.Error.String(), Info: "foobar"},
 			{Tag: "application-bar", Status: status.ProvisioningError.String(), Info: "foobar"},
 		}}
-	result, err := s.provisioner.SetInstanceStatus(args)
+	result, err := s.provisioner.SetInstanceStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -488,7 +489,7 @@ func (s *withoutControllerSuite) TestSetModificationStatus(c *gc.C) {
 			{Tag: "unit-foo-0", Status: status.Error.String(), Info: "foobar"},
 			{Tag: "application-bar", Status: status.Error.String(), Info: "foobar"},
 		}}
-	result, err := s.provisioner.SetModificationStatus(args)
+	result, err := s.provisioner.SetModificationStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -552,7 +553,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	err = s.machines[4].SetProvisioned("i-am", "", "fake_nonce", &hwChars)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.provisioner.MachinesWithTransientErrors()
+	result, err := s.provisioner.MachinesWithTransientErrors(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{
@@ -607,7 +608,7 @@ func (s *withoutControllerSuite) TestMachinesWithTransientErrorsPermission(c *gc
 	err = s.machines[3].SetInstanceStatus(sInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := aProvisioner.MachinesWithTransientErrors()
+	result, err := aProvisioner.MachinesWithTransientErrors(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StatusResults{
 		Results: []params.StatusResult{{
@@ -634,7 +635,7 @@ func (s *withoutControllerSuite) TestEnsureDead(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.EnsureDead(args)
+	result, err := s.provisioner.EnsureDead(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -699,7 +700,7 @@ func (s *withoutControllerSuite) TestWatchContainers(c *gc.C) {
 		{MachineTag: "unit-foo-0", ContainerType: ""},
 		{MachineTag: "application-bar", ContainerType: ""},
 	}}
-	result, err := s.provisioner.WatchContainers(args)
+	result, err := s.provisioner.WatchContainers(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -736,7 +737,7 @@ func (s *withoutControllerSuite) TestWatchAllContainers(c *gc.C) {
 		{MachineTag: "unit-foo-0"},
 		{MachineTag: "application-bar"},
 	}}
-	result, err := s.provisioner.WatchAllContainers(args)
+	result, err := s.provisioner.WatchAllContainers(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResults{
 		Results: []params.StringsWatchResult{
@@ -812,7 +813,7 @@ func (s *withoutControllerSuite) TestStatus(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.Status(args)
+	result, err := s.provisioner.Status(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	// Zero out the updated timestamps so we can easily check the results.
 	for i, statusResult := range result.Results {
@@ -868,7 +869,7 @@ func (s *withoutControllerSuite) TestInstanceStatus(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.InstanceStatus(args)
+	result, err := s.provisioner.InstanceStatus(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	// Zero out the updated timestamps so we can easily check the results.
 	for i, statusResult := range result.Results {
@@ -915,7 +916,7 @@ func (s *withoutControllerSuite) TestAvailabilityZone(c *gc.C) {
 		{Tag: emptyAzMachine.Tag().String()},
 		{Tag: nilAzMachine.Tag().String()},
 	}}
-	result, err := s.provisioner.AvailabilityZone(args)
+	result, err := s.provisioner.AvailabilityZone(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -940,7 +941,7 @@ func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.KeepInstance(args)
+	result, err := s.provisioner.KeepInstance(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.BoolResults{
 		Results: []params.BoolResult{
@@ -1012,7 +1013,7 @@ func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 		{Tag: s.machines[3].Tag().String()},
 		{Tag: "machine-5"},
 	}}
-	result, err := s.provisioner.DistributionGroup(args)
+	result, err := s.provisioner.DistributionGroup(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.DistributionGroupResults{
 		Results: []params.DistributionGroupResult{
@@ -1033,7 +1034,7 @@ func (s *withoutControllerSuite) TestDistributionGroupControllerAuth(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.DistributionGroup(args)
+	result, err := s.provisioner.DistributionGroup(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.DistributionGroupResults{
 		Results: []params.DistributionGroupResult{
@@ -1069,7 +1070,7 @@ func (s *withoutControllerSuite) TestDistributionGroupMachineAgentAuth(c *gc.C) 
 		{Tag: "machine-1-lxd-99"},
 		{Tag: "machine-1-lxd-99-lxd-100"},
 	}}
-	result, err := provisioner.DistributionGroup(args)
+	result, err := provisioner.DistributionGroup(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.DistributionGroupResults{
 		Results: []params.DistributionGroupResult{
@@ -1131,7 +1132,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineId(c *gc.C) {
 		{Tag: s.machines[3].Tag().String()},
 		{Tag: "machine-5"},
 	}}
-	result, err := s.provisioner.DistributionGroupByMachineId(args)
+	result, err := s.provisioner.DistributionGroupByMachineId(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{
@@ -1152,7 +1153,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineIdControllerAuth(
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.DistributionGroupByMachineId(args)
+	result, err := s.provisioner.DistributionGroupByMachineId(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{
@@ -1188,7 +1189,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineIdMachineAgentAut
 		{Tag: "machine-1-lxd-99"},
 		{Tag: "machine-1-lxd-99-lxd-100"},
 	}}
-	result, err := provisioner.DistributionGroupByMachineId(args)
+	result, err := provisioner.DistributionGroupByMachineId(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResults{
 		Results: []params.StringsResult{
@@ -1225,7 +1226,7 @@ func (s *withoutControllerSuite) TestConstraints(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.Constraints(args)
+	result, err := s.provisioner.Constraints(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.ConstraintsResults{
 		Results: []params.ConstraintsResult{
@@ -1299,7 +1300,7 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.SetInstanceInfo(args)
+	result, err := s.provisioner.SetInstanceInfo(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1370,7 +1371,7 @@ func (s *withoutControllerSuite) TestInstanceId(c *gc.C) {
 		{Tag: "unit-foo-0"},
 		{Tag: "application-bar"},
 	}}
-	result, err := s.provisioner.InstanceId(args)
+	result, err := s.provisioner.InstanceId(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringResults{
 		Results: []params.StringResult{
@@ -1387,7 +1388,7 @@ func (s *withoutControllerSuite) TestInstanceId(c *gc.C) {
 func (s *withoutControllerSuite) TestWatchModelMachines(c *gc.C) {
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 
-	got, err := s.provisioner.WatchModelMachines()
+	got, err := s.provisioner.WatchModelMachines(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	want := params.StringsWatchResult{
 		StringsWatcherId: "1",
@@ -1418,14 +1419,14 @@ func (s *withoutControllerSuite) TestWatchModelMachines(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := aProvisioner.WatchModelMachines()
+	result, err := aProvisioner.WatchModelMachines(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(result, gc.DeepEquals, params.StringsWatchResult{})
 }
 
 func (s *provisionerSuite) getManagerConfig(c *gc.C, typ instance.ContainerType) map[string]string {
 	args := params.ContainerManagerConfigParams{Type: typ}
-	results, err := s.provisioner.ContainerManagerConfig(args)
+	results, err := s.provisioner.ContainerManagerConfig(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	return results.ManagerConfig
 }
@@ -1443,7 +1444,7 @@ func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
 	s.PatchValue(&provisioner.ErrorRetryWaitDelay, 2*coretesting.ShortWait)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 
-	_, err := s.provisioner.WatchMachineErrorRetry()
+	_, err := s.provisioner.WatchMachineErrorRetry(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Verify the resources were registered and stop them when done.
@@ -1471,7 +1472,7 @@ func (s *withoutControllerSuite) TestWatchMachineErrorRetry(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := aProvisioner.WatchMachineErrorRetry()
+	result, err := aProvisioner.WatchMachineErrorRetry(context.TODO())
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{})
 }
@@ -1482,7 +1483,7 @@ func (s *withoutControllerSuite) TestMarkMachinesForRemoval(c *gc.C) {
 	err = s.machines[2].EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)
 
-	res, err := s.provisioner.MarkMachinesForRemoval(params.Entities{
+	res, err := s.provisioner.MarkMachinesForRemoval(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{Tag: "machine-2"},         // ok
 			{Tag: "machine-100"},       // not found
@@ -1540,7 +1541,7 @@ func (s *withoutControllerSuite) TestContainerConfig(c *gc.C) {
 		Https: "https://snap-proxy.example.com:9000",
 	}
 
-	results, err := s.provisioner.ContainerConfig()
+	results, err := s.provisioner.ContainerConfig(context.TODO())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(results.UpdateBehavior, gc.Not(gc.IsNil))
 	c.Check(results.ProviderType, gc.Equals, "dummy")
@@ -1583,7 +1584,7 @@ func (s *withoutControllerSuite) TestContainerConfigLegacy(c *gc.C) {
 		NoProxy: "127.0.0.1,localhost,::1",
 	}
 
-	results, err := s.provisioner.ContainerConfig()
+	results, err := s.provisioner.ContainerConfig(context.TODO())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(results.UpdateBehavior, gc.Not(gc.IsNil))
 	c.Check(results.ProviderType, gc.Equals, "dummy")
@@ -1609,7 +1610,7 @@ func (s *withoutControllerSuite) TestSetSupportedContainers(c *gc.C) {
 		MachineTag:     "machine-1",
 		ContainerTypes: []instance.ContainerType{instance.LXD, instance.KVM},
 	}}}
-	results, err := s.provisioner.SetSupportedContainers(args)
+	results, err := s.provisioner.SetSupportedContainers(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
 	for _, result := range results.Results {
@@ -1655,7 +1656,7 @@ func (s *withoutControllerSuite) TestSetSupportedContainersPermissions(c *gc.C) 
 		},
 	}
 	// Only machine 0 can have it's containers updated.
-	results, err := aProvisioner.SetSupportedContainers(args)
+	results, err := aProvisioner.SetSupportedContainers(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -1674,7 +1675,7 @@ func (s *withoutControllerSuite) TestSupportedContainers(c *gc.C) {
 		MachineTag:     "machine-1",
 		ContainerTypes: []instance.ContainerType{instance.LXD, instance.KVM},
 	}}}
-	_, err := s.provisioner.SetSupportedContainers(setArgs)
+	_, err := s.provisioner.SetSupportedContainers(context.TODO(), setArgs)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{{
@@ -1682,7 +1683,7 @@ func (s *withoutControllerSuite) TestSupportedContainers(c *gc.C) {
 	}, {
 		Tag: "machine-1",
 	}}}
-	results, err := s.provisioner.SupportedContainers(args)
+	results, err := s.provisioner.SupportedContainers(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
 	for _, result := range results.Results {
@@ -1706,7 +1707,7 @@ func (s *withoutControllerSuite) TestSupportedContainersWithoutBeingSet(c *gc.C)
 	}, {
 		Tag: "machine-1",
 	}}}
-	results, err := s.provisioner.SupportedContainers(args)
+	results, err := s.provisioner.SupportedContainers(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 2)
 	for _, result := range results.Results {
@@ -1719,7 +1720,7 @@ func (s *withoutControllerSuite) TestSupportedContainersWithInvalidTag(c *gc.C) 
 	args := params.Entities{Entities: []params.Entity{{
 		Tag: "user-0",
 	}}}
-	results, err := s.provisioner.SupportedContainers(args)
+	results, err := s.provisioner.SupportedContainers(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	for _, result := range results.Results {
@@ -1735,7 +1736,7 @@ func (s *withoutControllerSuite) TestSupportsNoContainers(c *gc.C) {
 			},
 		},
 	}
-	results, err := s.provisioner.SetSupportedContainers(args)
+	results, err := s.provisioner.SetSupportedContainers(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
@@ -1763,7 +1764,7 @@ func (s *withControllerSuite) TestAPIAddresses(c *gc.C) {
 	err := s.State.SetAPIHostPorts(hostPorts)
 	c.Assert(err, jc.ErrorIsNil)
 
-	result, err := s.provisioner.APIAddresses()
+	result, err := s.provisioner.APIAddresses(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.StringsResult{
 		Result: []string{"0.1.2.3:1234"},
@@ -1771,7 +1772,7 @@ func (s *withControllerSuite) TestAPIAddresses(c *gc.C) {
 }
 
 func (s *withControllerSuite) TestCACert(c *gc.C) {
-	result, err := s.provisioner.CACert()
+	result, err := s.provisioner.CACert(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.BytesResult{
 		Result: []byte(coretesting.CACert),

--- a/apiserver/facades/agent/proxyupdater/proxyupdater.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater.go
@@ -4,6 +4,8 @@
 package proxyupdater
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"github.com/juju/proxy"
@@ -20,8 +22,8 @@ import (
 
 // ProxyUpdaterV2 defines the pubic methods for the v2 facade.
 type ProxyUpdaterV2 interface {
-	ProxyConfig(args params.Entities) params.ProxyConfigResults
-	WatchForProxyConfigAndAPIHostPortChanges(args params.Entities) params.NotifyWatchResults
+	ProxyConfig(ctx context.Context, args params.Entities) params.ProxyConfigResults
+	WatchForProxyConfigAndAPIHostPortChanges(ctx context.Context, args params.Entities) params.NotifyWatchResults
 }
 
 var _ ProxyUpdaterV2 = (*API)(nil)
@@ -99,7 +101,7 @@ func (api *API) oneWatch() params.NotifyWatchResult {
 }
 
 // WatchForProxyConfigAndAPIHostPortChanges watches for changes to the proxy and api host port settings.
-func (api *API) WatchForProxyConfigAndAPIHostPortChanges(args params.Entities) params.NotifyWatchResults {
+func (api *API) WatchForProxyConfigAndAPIHostPortChanges(ctx context.Context, args params.Entities) params.NotifyWatchResults {
 	results := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}
@@ -185,7 +187,7 @@ func (api *API) proxyConfig() params.ProxyConfigResult {
 }
 
 // ProxyConfig returns the proxy settings for the current model.
-func (api *API) ProxyConfig(args params.Entities) params.ProxyConfigResults {
+func (api *API) ProxyConfig(ctx context.Context, args params.Entities) params.ProxyConfigResults {
 	var result params.ProxyConfigResult
 	errors, ok := api.authEntities(args)
 

--- a/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
+++ b/apiserver/facades/agent/proxyupdater/proxyupdater_test.go
@@ -4,6 +4,7 @@
 package proxyupdater_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/names/v4"
@@ -63,7 +64,7 @@ func (s *ProxyUpdaterSuite) SetUpTest(c *gc.C) {
 func (s *ProxyUpdaterSuite) TestWatchForProxyConfigAndAPIHostPortChanges(c *gc.C) {
 	// WatchForProxyConfigAndAPIHostPortChanges combines WatchForModelConfigChanges
 	// and WatchAPIHostPorts. Check that they are both called and we get the
-	result := s.facade.WatchForProxyConfigAndAPIHostPortChanges(s.oneEntity())
+	result := s.facade.WatchForProxyConfigAndAPIHostPortChanges(context.TODO(), s.oneEntity())
 	c.Assert(result.Results, gc.HasLen, 1)
 	c.Assert(result.Results[0].Error, gc.IsNil)
 
@@ -99,7 +100,7 @@ func (s *ProxyUpdaterSuite) TestMirrorConfig(c *gc.C) {
 		"apt-mirror": "http://mirror",
 	})
 	// Check that the ProxyConfig combines data from ModelConfig and APIHostPorts
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.TODO(), s.oneEntity())
 
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
@@ -112,7 +113,7 @@ func (s *ProxyUpdaterSuite) TestMirrorConfig(c *gc.C) {
 
 func (s *ProxyUpdaterSuite) TestProxyConfig(c *gc.C) {
 	// Check that the ProxyConfig combines data from ModelConfig and APIHostPorts
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.TODO(), s.oneEntity())
 
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
@@ -141,7 +142,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfigJujuProxy(c *gc.C) {
 		"apt-https-proxy":  "apt https proxy",
 	})
 
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.TODO(), s.oneEntity())
 
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
@@ -174,7 +175,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfigExtendsExisting(c *gc.C) {
 		"apt-https-proxy": "apt https proxy",
 		"no-proxy":        "9.9.9.9",
 	})
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.TODO(), s.oneEntity())
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
 		"APIHostPortsForAgents",
@@ -200,7 +201,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfigNoDuplicates(c *gc.C) {
 		"apt-https-proxy": "apt https proxy",
 		"no-proxy":        "0.1.2.3",
 	})
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.TODO(), s.oneEntity())
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
 		"APIHostPortsForAgents",
@@ -224,7 +225,7 @@ func (s *ProxyUpdaterSuite) TestSnapProxyConfig(c *gc.C) {
 		"snap-store-proxy":      "store proxy",
 		"snap-store-assertions": "trust us",
 	})
-	cfg := s.facade.ProxyConfig(s.oneEntity())
+	cfg := s.facade.ProxyConfig(context.TODO(), s.oneEntity())
 	s.state.Stub.CheckCallNames(c,
 		"ModelConfig",
 		"APIHostPortsForAgents",

--- a/apiserver/facades/agent/reboot/reboot.go
+++ b/apiserver/facades/agent/reboot/reboot.go
@@ -5,6 +5,8 @@
 package reboot
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
@@ -63,7 +65,7 @@ func NewRebootAPI(ctx facade.Context) (*RebootAPI, error) {
 
 // WatchForRebootEvent starts a watcher to track if there is a new
 // reboot request on the machines ID or any of its parents (in case we are a container).
-func (r *RebootAPI) WatchForRebootEvent() (params.NotifyWatchResult, error) {
+func (r *RebootAPI) WatchForRebootEvent(ctx context.Context) (params.NotifyWatchResult, error) {
 	var err error = apiservererrors.ErrPerm
 	var watch state.NotifyWatcher
 	var result params.NotifyWatchResult

--- a/apiserver/facades/agent/reboot/reboot_test.go
+++ b/apiserver/facades/agent/reboot/reboot_test.go
@@ -5,6 +5,8 @@
 package reboot_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -60,7 +62,7 @@ func (s *rebootSuite) setUpMachine(c *gc.C, machine *state.Machine) *machines {
 		{Tag: machine.Tag().String()},
 	}}
 
-	resultMachine, err := rebootAPI.WatchForRebootEvent()
+	resultMachine, err := rebootAPI.WatchForRebootEvent(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(resultMachine.NotifyWatcherId, gc.Not(gc.Equals), "")
 	c.Check(resultMachine.Error, gc.IsNil)
@@ -141,7 +143,7 @@ func (s *rebootSuite) TestWatchForRebootEvent(c *gc.C) {
 }
 
 func (s *rebootSuite) TestRequestReboot(c *gc.C) {
-	errResult, err := s.machine.rebootAPI.RequestReboot(s.machine.args)
+	errResult, err := s.machine.rebootAPI.RequestReboot(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -150,7 +152,7 @@ func (s *rebootSuite) TestRequestReboot(c *gc.C) {
 
 	s.machine.wc.AssertOneChange()
 
-	res, err := s.machine.rebootAPI.GetRebootAction(s.machine.args)
+	res, err := s.machine.rebootAPI.GetRebootAction(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
@@ -159,7 +161,7 @@ func (s *rebootSuite) TestRequestReboot(c *gc.C) {
 }
 
 func (s *rebootSuite) TestClearReboot(c *gc.C) {
-	errResult, err := s.machine.rebootAPI.RequestReboot(s.machine.args)
+	errResult, err := s.machine.rebootAPI.RequestReboot(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -169,14 +171,14 @@ func (s *rebootSuite) TestClearReboot(c *gc.C) {
 
 	s.machine.wc.AssertOneChange()
 
-	res, err := s.machine.rebootAPI.GetRebootAction(s.machine.args)
+	res, err := s.machine.rebootAPI.GetRebootAction(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldReboot},
 		}})
 
-	errResult, err = s.machine.rebootAPI.ClearReboot(s.machine.args)
+	errResult, err = s.machine.rebootAPI.ClearReboot(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -184,7 +186,7 @@ func (s *rebootSuite) TestClearReboot(c *gc.C) {
 		},
 	})
 
-	res, err = s.machine.rebootAPI.GetRebootAction(s.machine.args)
+	res, err = s.machine.rebootAPI.GetRebootAction(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
@@ -197,7 +199,7 @@ func (s *rebootSuite) TestRebootRequestFromMachine(c *gc.C) {
 	// machine should reboot
 	// container should shutdown
 	// nested container should shutdown
-	errResult, err := s.machine.rebootAPI.RequestReboot(s.machine.args)
+	errResult, err := s.machine.rebootAPI.RequestReboot(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -208,28 +210,28 @@ func (s *rebootSuite) TestRebootRequestFromMachine(c *gc.C) {
 	s.container.wc.AssertOneChange()
 	s.nestedContainer.wc.AssertOneChange()
 
-	res, err := s.machine.rebootAPI.GetRebootAction(s.machine.args)
+	res, err := s.machine.rebootAPI.GetRebootAction(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldReboot},
 		}})
 
-	res, err = s.container.rebootAPI.GetRebootAction(s.container.args)
+	res, err = s.container.rebootAPI.GetRebootAction(context.TODO(), s.container.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldShutdown},
 		}})
 
-	res, err = s.nestedContainer.rebootAPI.GetRebootAction(s.nestedContainer.args)
+	res, err = s.nestedContainer.rebootAPI.GetRebootAction(context.TODO(), s.nestedContainer.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldShutdown},
 		}})
 
-	errResult, err = s.machine.rebootAPI.ClearReboot(s.machine.args)
+	errResult, err = s.machine.rebootAPI.ClearReboot(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -247,7 +249,7 @@ func (s *rebootSuite) TestRebootRequestFromContainer(c *gc.C) {
 	// machine should do nothing
 	// container should reboot
 	// nested container should shutdown
-	errResult, err := s.container.rebootAPI.RequestReboot(s.container.args)
+	errResult, err := s.container.rebootAPI.RequestReboot(context.TODO(), s.container.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -258,28 +260,28 @@ func (s *rebootSuite) TestRebootRequestFromContainer(c *gc.C) {
 	s.container.wc.AssertOneChange()
 	s.nestedContainer.wc.AssertOneChange()
 
-	res, err := s.machine.rebootAPI.GetRebootAction(s.machine.args)
+	res, err := s.machine.rebootAPI.GetRebootAction(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldDoNothing},
 		}})
 
-	res, err = s.container.rebootAPI.GetRebootAction(s.container.args)
+	res, err = s.container.rebootAPI.GetRebootAction(context.TODO(), s.container.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldReboot},
 		}})
 
-	res, err = s.nestedContainer.rebootAPI.GetRebootAction(s.nestedContainer.args)
+	res, err = s.nestedContainer.rebootAPI.GetRebootAction(context.TODO(), s.nestedContainer.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldShutdown},
 		}})
 
-	errResult, err = s.container.rebootAPI.ClearReboot(s.container.args)
+	errResult, err = s.container.rebootAPI.ClearReboot(context.TODO(), s.container.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -297,7 +299,7 @@ func (s *rebootSuite) TestRebootRequestFromNestedContainer(c *gc.C) {
 	// machine should do nothing
 	// container should do nothing
 	// nested container should reboot
-	errResult, err := s.nestedContainer.rebootAPI.RequestReboot(s.nestedContainer.args)
+	errResult, err := s.nestedContainer.rebootAPI.RequestReboot(context.TODO(), s.nestedContainer.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{
@@ -308,28 +310,28 @@ func (s *rebootSuite) TestRebootRequestFromNestedContainer(c *gc.C) {
 	s.container.wc.AssertNoChange()
 	s.nestedContainer.wc.AssertOneChange()
 
-	res, err := s.machine.rebootAPI.GetRebootAction(s.machine.args)
+	res, err := s.machine.rebootAPI.GetRebootAction(context.TODO(), s.machine.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldDoNothing},
 		}})
 
-	res, err = s.container.rebootAPI.GetRebootAction(s.container.args)
+	res, err = s.container.rebootAPI.GetRebootAction(context.TODO(), s.container.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldDoNothing},
 		}})
 
-	res, err = s.nestedContainer.rebootAPI.GetRebootAction(s.nestedContainer.args)
+	res, err = s.nestedContainer.rebootAPI.GetRebootAction(context.TODO(), s.nestedContainer.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, params.RebootActionResults{
 		Results: []params.RebootActionResult{
 			{Result: params.ShouldReboot},
 		}})
 
-	errResult, err = s.nestedContainer.rebootAPI.ClearReboot(s.nestedContainer.args)
+	errResult, err = s.nestedContainer.rebootAPI.ClearReboot(context.TODO(), s.nestedContainer.args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(errResult, gc.DeepEquals, params.ErrorResults{
 		Results: []params.ErrorResult{

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade.go
@@ -4,6 +4,8 @@
 package resourceshookcontext
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/api/client/resources"
@@ -48,7 +50,7 @@ type UnitFacade struct {
 // GetResourceInfo returns the resource info for each of the given
 // resource names (for the implicit application). If any one is missing then
 // the corresponding result is set with errors.NotFound.
-func (uf UnitFacade) GetResourceInfo(args params.ListUnitResourcesArgs) (params.UnitResourcesResult, error) {
+func (uf UnitFacade) GetResourceInfo(ctx context.Context, args params.ListUnitResourcesArgs) (params.UnitResourcesResult, error) {
 	var r params.UnitResourcesResult
 	r.Resources = make([]params.UnitResourceResult, len(args.ResourceNames))
 

--- a/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
+++ b/apiserver/facades/agent/resourceshookcontext/unitfacade_test.go
@@ -4,6 +4,8 @@
 package resourceshookcontext_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -51,7 +53,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoOkay(c *gc.C) {
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}
 
-	results, err := uf.GetResourceInfo(params.ListUnitResourcesArgs{
+	results, err := uf.GetResourceInfo(context.TODO(), params.ListUnitResourcesArgs{
 		ResourceNames: []string{"spam", "eggs"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -74,7 +76,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoEmpty(c *gc.C) {
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}
 
-	results, err := uf.GetResourceInfo(params.ListUnitResourcesArgs{
+	results, err := uf.GetResourceInfo(context.TODO(), params.ListUnitResourcesArgs{
 		ResourceNames: []string{},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -93,7 +95,7 @@ func (s *UnitFacadeSuite) TestGetResourceInfoNotFound(c *gc.C) {
 	}
 	uf := resourceshookcontext.UnitFacade{DataStore: store}
 
-	results, err := uf.GetResourceInfo(params.ListUnitResourcesArgs{
+	results, err := uf.GetResourceInfo(context.TODO(), params.ListUnitResourcesArgs{
 		ResourceNames: []string{"eggs"},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/retrystrategy/retrystrategy.go
+++ b/apiserver/facades/agent/retrystrategy/retrystrategy.go
@@ -5,6 +5,7 @@
 package retrystrategy
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -29,8 +30,8 @@ const (
 
 // RetryStrategy defines the methods exported by the RetryStrategy API facade.
 type RetryStrategy interface {
-	RetryStrategy(params.Entities) (params.RetryStrategyResults, error)
-	WatchRetryStrategy(params.Entities) (params.NotifyWatchResults, error)
+	RetryStrategy(context.Context, params.Entities) (params.RetryStrategyResults, error)
+	WatchRetryStrategy(context.Context, params.Entities) (params.NotifyWatchResults, error)
 }
 
 // RetryStrategyAPI implements RetryStrategy
@@ -45,7 +46,7 @@ var _ RetryStrategy = (*RetryStrategyAPI)(nil)
 
 // RetryStrategy returns RetryStrategyResults that can be used by any code that uses
 // to configure the retry timer that's currently in juju utils.
-func (h *RetryStrategyAPI) RetryStrategy(args params.Entities) (params.RetryStrategyResults, error) {
+func (h *RetryStrategyAPI) RetryStrategy(ctx context.Context, args params.Entities) (params.RetryStrategyResults, error) {
 	results := params.RetryStrategyResults{
 		Results: make([]params.RetryStrategyResult, len(args.Entities)),
 	}
@@ -84,7 +85,7 @@ func (h *RetryStrategyAPI) RetryStrategy(args params.Entities) (params.RetryStra
 
 // WatchRetryStrategy watches for changes to the model. Currently we only allow
 // changes to the boolean that determines whether retries should be attempted or not.
-func (h *RetryStrategyAPI) WatchRetryStrategy(args params.Entities) (params.NotifyWatchResults, error) {
+func (h *RetryStrategyAPI) WatchRetryStrategy(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	results := params.NotifyWatchResults{
 		Results: make([]params.NotifyWatchResult, len(args.Entities)),
 	}

--- a/apiserver/facades/agent/retrystrategy/retrystrategy_test.go
+++ b/apiserver/facades/agent/retrystrategy/retrystrategy_test.go
@@ -5,6 +5,8 @@
 package retrystrategy_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -72,7 +74,7 @@ func (s *retryStrategySuite) TestRetryStrategyUnauthenticated(c *gc.C) {
 	otherUnit := s.Factory.MakeUnit(c, &jujufactory.UnitParams{Application: svc})
 	args := params.Entities{Entities: []params.Entity{{otherUnit.Tag().String()}}}
 
-	res, err := s.strategy.RetryStrategy(args)
+	res, err := s.strategy.RetryStrategy(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 1)
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, "permission denied")
@@ -84,7 +86,7 @@ func (s *retryStrategySuite) TestRetryStrategyBadTag(c *gc.C) {
 	for i, t := range tagsTests {
 		args.Entities[i] = params.Entity{Tag: t.tag}
 	}
-	res, err := s.strategy.RetryStrategy(args)
+	res, err := s.strategy.RetryStrategy(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, len(tagsTests))
 	for i, r := range res.Results {
@@ -124,7 +126,7 @@ func (s *retryStrategySuite) assertRetryStrategy(c *gc.C, tag string) {
 		RetryTimeFactor: retrystrategy.RetryTimeFactor,
 	}
 	args := params.Entities{Entities: []params.Entity{{Tag: tag}}}
-	r, err := s.strategy.RetryStrategy(args)
+	r, err := s.strategy.RetryStrategy(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Results, gc.HasLen, 1)
 	c.Assert(r.Results[0].Error, gc.IsNil)
@@ -133,7 +135,7 @@ func (s *retryStrategySuite) assertRetryStrategy(c *gc.C, tag string) {
 	s.setRetryStrategy(c, false)
 	expected.ShouldRetry = false
 
-	r, err = s.strategy.RetryStrategy(args)
+	r, err = s.strategy.RetryStrategy(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Results, gc.HasLen, 1)
 	c.Assert(r.Results[0].Error, gc.IsNil)
@@ -154,7 +156,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategyUnauthenticated(c *gc.C) {
 	otherUnit := s.Factory.MakeUnit(c, &jujufactory.UnitParams{Application: svc})
 	args := params.Entities{Entities: []params.Entity{{otherUnit.Tag().String()}}}
 
-	res, err := s.strategy.WatchRetryStrategy(args)
+	res, err := s.strategy.WatchRetryStrategy(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, 1)
 	c.Assert(res.Results[0].Error, gc.ErrorMatches, "permission denied")
@@ -166,7 +168,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategyBadTag(c *gc.C) {
 	for i, t := range tagsTests {
 		args.Entities[i] = params.Entity{Tag: t.tag}
 	}
-	res, err := s.strategy.WatchRetryStrategy(args)
+	res, err := s.strategy.WatchRetryStrategy(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res.Results, gc.HasLen, len(tagsTests))
 	for i, r := range res.Results {
@@ -183,7 +185,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategy(c *gc.C) {
 		{Tag: s.unit.UnitTag().String()},
 		{Tag: "unit-foo-42"},
 	}}
-	r, err := s.strategy.WatchRetryStrategy(args)
+	r, err := s.strategy.WatchRetryStrategy(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r, gc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -4,6 +4,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -127,7 +128,7 @@ func ptr[T any](v T) *T {
 func (s *SecretsManagerSuite) TestGetSecretBackendConfig(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	result, err := s.facade.GetSecretBackendConfig()
+	result, err := s.facade.GetSecretBackendConfig(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, params.SecretBackendConfigResults{
 		ControllerUUID: coretesting.ControllerTag.Id(),
@@ -145,7 +146,7 @@ func (s *SecretsManagerSuite) TestGetSecretBackendConfig(c *gc.C) {
 func (s *SecretsManagerSuite) TestCreateSecretURIs(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	results, err := s.facade.CreateSecretURIs(params.CreateSecretURIsArg{
+	results, err := s.facade.CreateSecretURIs(context.TODO(), params.CreateSecretURIsArg{
 		Count: 2,
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -194,7 +195,7 @@ func (s *SecretsManagerSuite) TestCreateSecrets(c *gc.C) {
 		},
 	)
 
-	results, err := s.facade.CreateSecrets(params.CreateSecretArgs{
+	results, err := s.facade.CreateSecrets(context.TODO(), params.CreateSecretArgs{
 		Args: []params.CreateSecretArg{{
 			OwnerTag: "application-mariadb",
 			UpsertSecretArg: params.UpsertSecretArg{
@@ -246,7 +247,7 @@ func (s *SecretsManagerSuite) TestCreateSecretDuplicateLabel(c *gc.C) {
 		nil, fmt.Errorf("dup label %w", state.LabelExists),
 	)
 
-	results, err := s.facade.CreateSecrets(params.CreateSecretArgs{
+	results, err := s.facade.CreateSecrets(context.TODO(), params.CreateSecretArgs{
 		Args: []params.CreateSecretArg{{
 			OwnerTag: "application-mariadb",
 			UpsertSecretArg: params.UpsertSecretArg{
@@ -307,7 +308,7 @@ func (s *SecretsManagerSuite) TestUpdateSecrets(c *gc.C) {
 	s.token.EXPECT().Check().Return(nil).Times(2)
 	s.expectSecretAccessQuery(4)
 
-	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
+	results, err := s.facade.UpdateSecrets(context.TODO(), params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{{
 			URI: uri.String(),
 			UpsertSecretArg: params.UpsertSecretArg{
@@ -360,7 +361,7 @@ func (s *SecretsManagerSuite) TestUpdateSecretDuplicateLabel(c *gc.C) {
 	s.token.EXPECT().Check().Return(nil)
 	s.expectSecretAccessQuery(2)
 
-	results, err := s.facade.UpdateSecrets(params.UpdateSecretArgs{
+	results, err := s.facade.UpdateSecrets(context.TODO(), params.UpdateSecretArgs{
 		Args: []params.UpdateSecretArg{{
 			URI: uri.String(),
 			UpsertSecretArg: params.UpsertSecretArg{
@@ -402,7 +403,7 @@ func (s *SecretsManagerSuite) TestRemoveSecrets(c *gc.C) {
 		provider.SecretRevisions{uri.ID: set.NewStrings("rev-666")},
 	).Return(nil)
 
-	results, err := s.facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := s.facade.RemoveSecrets(context.TODO(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -424,7 +425,7 @@ func (s *SecretsManagerSuite) TestRemoveSecretRevision(c *gc.C) {
 	s.token.EXPECT().Check().Return(nil)
 	s.expectSecretAccessQuery(2)
 
-	results, err := s.facade.RemoveSecrets(params.DeleteSecretArgs{
+	results, err := s.facade.RemoveSecrets(context.TODO(), params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
 			Revisions: []int{666},
@@ -447,7 +448,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfo(c *gc.C) {
 			Label:          "label",
 		}, nil)
 
-	results, err := s.facade.GetConsumerSecretsRevisionInfo(params.GetSecretConsumerInfoArgs{
+	results, err := s.facade.GetConsumerSecretsRevisionInfo(context.TODO(), params.GetSecretConsumerInfoArgs{
 		ConsumerTag: "application-mariadb",
 		URIs:        []string{uri.String()},
 	})
@@ -491,7 +492,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 		Revision: 667,
 	}}, nil)
 
-	results, err := s.facade.GetSecretMetadata()
+	results, err := s.facade.GetSecretMetadata(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.ListSecretResults{
 		Results: []params.ListSecretResult{{
@@ -519,7 +520,7 @@ func (s *SecretsManagerSuite) TestGetSecretMetadata(c *gc.C) {
 func (s *SecretsManagerSuite) TestGetSecretContentInvalidArg(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{{}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -549,7 +550,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretURIArg(c *gc.C) 
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String()},
 		},
@@ -586,7 +587,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretLabelArg(c *gc.C
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{Label: "foo"},
 		},
@@ -629,7 +630,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForUnitAccessApplicationOwnedS
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{Label: "foo"},
 		},
@@ -672,7 +673,7 @@ func (s *SecretsManagerSuite) assertGetSecretContentConsumer(c *gc.C, isUnitAgen
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String()},
 		},
@@ -710,7 +711,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerLabelOnly(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{Label: "label"},
 		},
@@ -755,7 +756,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerFirstTime(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "label"},
 		},
@@ -795,7 +796,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateLabel(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "new-label"},
 		},
@@ -814,7 +815,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerFirstTimeUsingLabelFai
 	s.expectgetAppOwnedOrUnitOwnedSecretMetadataNotFound()
 	s.secretsConsumer.EXPECT().GetURIByConsumerLabel("label-1", names.NewUnitTag("mariadb/0")).Return(nil, errors.NotFoundf("secret"))
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{Label: "label-1"},
 		},
@@ -847,7 +848,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateArg(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Label: "label", Refresh: true},
 		},
@@ -877,7 +878,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerPeekArg(c *gc.C) {
 		val, nil, nil,
 	)
 
-	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{
+	results, err := s.facade.GetSecretContentInfo(context.TODO(), params.GetSecretContentArgs{
 		Args: []params.GetSecretContentArg{
 			{URI: uri.String(), Peek: true},
 		},
@@ -903,7 +904,7 @@ func (s *SecretsManagerSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	watchChan <- []string{uri.String()}
 	s.secretsWatcher.EXPECT().Changes().Return(watchChan)
 
-	result, err := s.facade.WatchConsumedSecretsChanges(params.Entities{
+	result, err := s.facade.WatchConsumedSecretsChanges(context.TODO(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "unit-mariadb-0",
 		}, {
@@ -937,7 +938,7 @@ func (s *SecretsManagerSuite) TestWatchObsolete(c *gc.C) {
 	watchChan <- []string{uri.String()}
 	s.secretsWatcher.EXPECT().Changes().Return(watchChan)
 
-	result, err := s.facade.WatchObsolete(params.Entities{
+	result, err := s.facade.WatchObsolete(context.TODO(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "unit-mariadb-0",
 		}, {
@@ -971,7 +972,7 @@ func (s *SecretsManagerSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	}}
 	s.secretsTriggerWatcher.EXPECT().Changes().Return(rotateChan)
 
-	result, err := s.facade.WatchSecretsRotationChanges(params.Entities{
+	result, err := s.facade.WatchSecretsRotationChanges(context.TODO(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "unit-mariadb-0",
 		}, {
@@ -1000,7 +1001,7 @@ func (s *SecretsManagerSuite) TestSecretsRotated(c *gc.C) {
 		LatestRevision: 667,
 	}, nil)
 
-	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+	result, err := s.facade.SecretsRotated(context.TODO(), params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
 			URI:              uri.String(),
 			OriginalRevision: 666,
@@ -1033,7 +1034,7 @@ func (s *SecretsManagerSuite) TestSecretsRotatedRetry(c *gc.C) {
 		LatestRevision: 666,
 	}, nil)
 
-	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+	result, err := s.facade.SecretsRotated(context.TODO(), params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
 			URI:              uri.String(),
 			OriginalRevision: 666,
@@ -1062,7 +1063,7 @@ func (s *SecretsManagerSuite) TestSecretsRotatedForce(c *gc.C) {
 		LatestRevision:   667,
 	}, nil)
 
-	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+	result, err := s.facade.SecretsRotated(context.TODO(), params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
 			URI:              uri.String(),
 			OriginalRevision: 666,
@@ -1088,7 +1089,7 @@ func (s *SecretsManagerSuite) TestSecretsRotatedThenNever(c *gc.C) {
 		LatestRevision: 667,
 	}, nil)
 
-	result, err := s.facade.SecretsRotated(params.SecretRotatedArgs{
+	result, err := s.facade.SecretsRotated(context.TODO(), params.SecretRotatedArgs{
 		Args: []params.SecretRotatedArg{{
 			URI:              uri.String(),
 			OriginalRevision: 666,
@@ -1121,7 +1122,7 @@ func (s *SecretsManagerSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 	}}
 	s.secretsTriggerWatcher.EXPECT().Changes().Return(expiryChan)
 
-	result, err := s.facade.WatchSecretRevisionsExpiryChanges(params.Entities{
+	result, err := s.facade.WatchSecretRevisionsExpiryChanges(context.TODO(), params.Entities{
 		Entities: []params.Entity{{
 			Tag: "unit-mariadb-0",
 		}, {
@@ -1158,7 +1159,7 @@ func (s *SecretsManagerSuite) TestSecretsGrant(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
 
-	result, err := s.facade.SecretsGrant(params.GrantRevokeSecretArgs{
+	result, err := s.facade.SecretsGrant(context.TODO(), params.GrantRevokeSecretArgs{
 		Args: []params.GrantRevokeSecretArg{{
 			URI:         uri.String(),
 			ScopeTag:    scopeTag.String(),
@@ -1202,7 +1203,7 @@ func (s *SecretsManagerSuite) TestSecretsRevoke(c *gc.C) {
 	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
 	s.token.EXPECT().Check().Return(nil)
 
-	result, err := s.facade.SecretsRevoke(params.GrantRevokeSecretArgs{
+	result, err := s.facade.SecretsRevoke(context.TODO(), params.GrantRevokeSecretArgs{
 		Args: []params.GrantRevokeSecretArg{{
 			URI:         uri.String(),
 			ScopeTag:    scopeTag.String(),

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner.go
@@ -4,6 +4,8 @@
 package storageprovisioner
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
@@ -222,7 +224,7 @@ func NewStorageProvisionerAPIv4(
 
 // WatchApplications starts a StringsWatcher to watch CAAS applications
 // deployed to this model.
-func (s *StorageProvisionerAPIv4) WatchApplications() (params.StringsWatchResult, error) {
+func (s *StorageProvisionerAPIv4) WatchApplications(ctx context.Context) (params.StringsWatchResult, error) {
 	watch := s.st.WatchApplications()
 	if changes, ok := <-watch.Changes(); ok {
 		return params.StringsWatchResult{
@@ -234,7 +236,7 @@ func (s *StorageProvisionerAPIv4) WatchApplications() (params.StringsWatchResult
 }
 
 // WatchBlockDevices watches for changes to the specified machines' block devices.
-func (s *StorageProvisionerAPIv4) WatchBlockDevices(args params.Entities) (params.NotifyWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchBlockDevices(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	canAccess, err := s.getBlockDevicesAuthFunc()
 	if err != nil {
 		return params.NotifyWatchResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -270,7 +272,7 @@ func (s *StorageProvisionerAPIv4) WatchBlockDevices(args params.Entities) (param
 }
 
 // WatchMachines watches for changes to the specified machines.
-func (s *StorageProvisionerAPIv4) WatchMachines(args params.Entities) (params.NotifyWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchMachines(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
 	canAccess, err := s.getMachineAuthFunc()
 	if err != nil {
 		return params.NotifyWatchResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -310,13 +312,13 @@ func (s *StorageProvisionerAPIv4) WatchMachines(args params.Entities) (params.No
 
 // WatchVolumes watches for changes to volumes scoped to the
 // entity with the tag passed to NewState.
-func (s *StorageProvisionerAPIv4) WatchVolumes(args params.Entities) (params.StringsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchVolumes(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	return s.watchStorageEntities(args, s.sb.WatchModelVolumes, s.sb.WatchMachineVolumes, nil)
 }
 
 // WatchFilesystems watches for changes to filesystems scoped
 // to the entity with the tag passed to NewState.
-func (s *StorageProvisionerAPIv4) WatchFilesystems(args params.Entities) (params.StringsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchFilesystems(ctx context.Context, args params.Entities) (params.StringsWatchResults, error) {
 	w := filesystemwatcher.Watchers{s.sb}
 	return s.watchStorageEntities(args,
 		w.WatchModelManagedFilesystems,
@@ -375,7 +377,7 @@ func (s *StorageProvisionerAPIv4) watchStorageEntities(
 
 // WatchVolumeAttachments watches for changes to volume attachments scoped to
 // the entity with the tag passed to NewState.
-func (s *StorageProvisionerAPIv4) WatchVolumeAttachments(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchVolumeAttachments(ctx context.Context, args params.Entities) (params.MachineStorageIdsWatchResults, error) {
 	return s.watchAttachments(
 		args,
 		s.sb.WatchModelVolumeAttachments,
@@ -387,7 +389,7 @@ func (s *StorageProvisionerAPIv4) WatchVolumeAttachments(args params.Entities) (
 
 // WatchFilesystemAttachments watches for changes to filesystem attachments
 // scoped to the entity with the tag passed to NewState.
-func (s *StorageProvisionerAPIv4) WatchFilesystemAttachments(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchFilesystemAttachments(ctx context.Context, args params.Entities) (params.MachineStorageIdsWatchResults, error) {
 	w := filesystemwatcher.Watchers{s.sb}
 	return s.watchAttachments(
 		args,
@@ -400,7 +402,7 @@ func (s *StorageProvisionerAPIv4) WatchFilesystemAttachments(args params.Entitie
 
 // WatchVolumeAttachmentPlans watches for changes to volume attachments for a machine for the purpose of allowing
 // that machine to run any initialization needed, for that volume to actually appear as a block device (ie: iSCSI)
-func (s *StorageProvisionerAPIv4) WatchVolumeAttachmentPlans(args params.Entities) (params.MachineStorageIdsWatchResults, error) {
+func (s *StorageProvisionerAPIv4) WatchVolumeAttachmentPlans(ctx context.Context, args params.Entities) (params.MachineStorageIdsWatchResults, error) {
 	canAccess, err := s.getMachineAuthFunc()
 	if err != nil {
 		return params.MachineStorageIdsWatchResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -443,7 +445,7 @@ func (s *StorageProvisionerAPIv4) WatchVolumeAttachmentPlans(args params.Entitie
 	return results, nil
 }
 
-func (s *StorageProvisionerAPIv4) RemoveVolumeAttachmentPlan(args params.MachineStorageIds) (params.ErrorResults, error) {
+func (s *StorageProvisionerAPIv4) RemoveVolumeAttachmentPlan(ctx context.Context, args params.MachineStorageIds) (params.ErrorResults, error) {
 	canAccess, err := s.getMachineAuthFunc()
 	if err != nil {
 		return params.ErrorResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -528,7 +530,7 @@ func (s *StorageProvisionerAPIv4) watchAttachments(
 }
 
 // Volumes returns details of volumes with the specified tags.
-func (s *StorageProvisionerAPIv4) Volumes(args params.Entities) (params.VolumeResults, error) {
+func (s *StorageProvisionerAPIv4) Volumes(ctx context.Context, args params.Entities) (params.VolumeResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.VolumeResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -563,7 +565,7 @@ func (s *StorageProvisionerAPIv4) Volumes(args params.Entities) (params.VolumeRe
 }
 
 // Filesystems returns details of filesystems with the specified tags.
-func (s *StorageProvisionerAPIv4) Filesystems(args params.Entities) (params.FilesystemResults, error) {
+func (s *StorageProvisionerAPIv4) Filesystems(ctx context.Context, args params.Entities) (params.FilesystemResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.FilesystemResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -598,7 +600,7 @@ func (s *StorageProvisionerAPIv4) Filesystems(args params.Entities) (params.File
 }
 
 // VolumeAttachmentPlans returns details of volume attachment plans with the specified IDs.
-func (s *StorageProvisionerAPIv4) VolumeAttachmentPlans(args params.MachineStorageIds) (params.VolumeAttachmentPlanResults, error) {
+func (s *StorageProvisionerAPIv4) VolumeAttachmentPlans(ctx context.Context, args params.MachineStorageIds) (params.VolumeAttachmentPlanResults, error) {
 	// NOTE(gsamfira): Containers will probably not be a concern for this at the moment
 	// revisit this if containers should be treated
 	canAccess, err := s.getMachineAuthFunc()
@@ -629,7 +631,7 @@ func (s *StorageProvisionerAPIv4) VolumeAttachmentPlans(args params.MachineStora
 }
 
 // VolumeAttachments returns details of volume attachments with the specified IDs.
-func (s *StorageProvisionerAPIv4) VolumeAttachments(args params.MachineStorageIds) (params.VolumeAttachmentResults, error) {
+func (s *StorageProvisionerAPIv4) VolumeAttachments(ctx context.Context, args params.MachineStorageIds) (params.VolumeAttachmentResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.VolumeAttachmentResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -659,7 +661,7 @@ func (s *StorageProvisionerAPIv4) VolumeAttachments(args params.MachineStorageId
 
 // VolumeBlockDevices returns details of the block devices corresponding to the
 // volume attachments with the specified IDs.
-func (s *StorageProvisionerAPIv4) VolumeBlockDevices(args params.MachineStorageIds) (params.BlockDeviceResults, error) {
+func (s *StorageProvisionerAPIv4) VolumeBlockDevices(ctx context.Context, args params.MachineStorageIds) (params.BlockDeviceResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.BlockDeviceResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -688,7 +690,7 @@ func (s *StorageProvisionerAPIv4) VolumeBlockDevices(args params.MachineStorageI
 }
 
 // FilesystemAttachments returns details of filesystem attachments with the specified IDs.
-func (s *StorageProvisionerAPIv4) FilesystemAttachments(args params.MachineStorageIds) (params.FilesystemAttachmentResults, error) {
+func (s *StorageProvisionerAPIv4) FilesystemAttachments(ctx context.Context, args params.MachineStorageIds) (params.FilesystemAttachmentResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
 	if err != nil {
 		return params.FilesystemAttachmentResults{}, apiservererrors.ServerError(apiservererrors.ErrPerm)
@@ -718,7 +720,7 @@ func (s *StorageProvisionerAPIv4) FilesystemAttachments(args params.MachineStora
 
 // VolumeParams returns the parameters for creating or destroying
 // the volumes with the specified tags.
-func (s *StorageProvisionerAPIv4) VolumeParams(args params.Entities) (params.VolumeParamsResults, error) {
+func (s *StorageProvisionerAPIv4) VolumeParams(ctx context.Context, args params.Entities) (params.VolumeParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.VolumeParamsResults{}, err
@@ -814,7 +816,7 @@ func (s *StorageProvisionerAPIv4) VolumeParams(args params.Entities) (params.Vol
 
 // RemoveVolumeParams returns the parameters for destroying
 // or releasing the volumes with the specified tags.
-func (s *StorageProvisionerAPIv4) RemoveVolumeParams(args params.Entities) (params.RemoveVolumeParamsResults, error) {
+func (s *StorageProvisionerAPIv4) RemoveVolumeParams(ctx context.Context, args params.Entities) (params.RemoveVolumeParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.RemoveVolumeParamsResults{}, err
@@ -870,7 +872,7 @@ func (s *StorageProvisionerAPIv4) RemoveVolumeParams(args params.Entities) (para
 
 // FilesystemParams returns the parameters for creating the filesystems
 // with the specified tags.
-func (s *StorageProvisionerAPIv4) FilesystemParams(args params.Entities) (params.FilesystemParamsResults, error) {
+func (s *StorageProvisionerAPIv4) FilesystemParams(ctx context.Context, args params.Entities) (params.FilesystemParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.FilesystemParamsResults{}, err
@@ -928,7 +930,7 @@ func (s *StorageProvisionerAPIv4) FilesystemParams(args params.Entities) (params
 
 // RemoveFilesystemParams returns the parameters for destroying or
 // releasing the filesystems with the specified tags.
-func (s *StorageProvisionerAPIv4) RemoveFilesystemParams(args params.Entities) (params.RemoveFilesystemParamsResults, error) {
+func (s *StorageProvisionerAPIv4) RemoveFilesystemParams(ctx context.Context, args params.Entities) (params.RemoveFilesystemParamsResults, error) {
 	canAccess, err := s.getStorageEntityAuthFunc()
 	if err != nil {
 		return params.RemoveFilesystemParamsResults{}, err
@@ -985,6 +987,7 @@ func (s *StorageProvisionerAPIv4) RemoveFilesystemParams(args params.Entities) (
 // VolumeAttachmentParams returns the parameters for creating the volume
 // attachments with the specified IDs.
 func (s *StorageProvisionerAPIv4) VolumeAttachmentParams(
+	ctx context.Context,
 	args params.MachineStorageIds,
 ) (params.VolumeAttachmentParamsResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()
@@ -1068,6 +1071,7 @@ func (s *StorageProvisionerAPIv4) VolumeAttachmentParams(
 // FilesystemAttachmentParams returns the parameters for creating the filesystem
 // attachments with the specified IDs.
 func (s *StorageProvisionerAPIv4) FilesystemAttachmentParams(
+	ctx context.Context,
 	args params.MachineStorageIds,
 ) (params.FilesystemAttachmentParamsResults, error) {
 	canAccess, err := s.getAttachmentAuthFunc()

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -4,6 +4,7 @@
 package storageprovisioner_test
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -283,7 +284,7 @@ func (s *iaasProvisionerSuite) TestHostedVolumes(c *gc.C) {
 	s.setupVolumes(c)
 	s.authorizer.Controller = false
 
-	results, err := s.api.Volumes(params.Entities{
+	results, err := s.api.Volumes(context.TODO(), params.Entities{
 		Entities: []params.Entity{{"volume-0-0"}, {"volume-1"}, {"volume-42"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -310,7 +311,7 @@ func (s *iaasProvisionerSuite) TestVolumesModel(c *gc.C) {
 	s.setupVolumes(c)
 	s.authorizer.Tag = names.NewMachineTag("2") // neither 0 nor 1
 
-	results, err := s.api.Volumes(params.Entities{
+	results, err := s.api.Volumes(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{"volume-0-0"},
 			{"volume-1"},
@@ -338,7 +339,7 @@ func (s *iaasProvisionerSuite) TestVolumesModel(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestVolumesEmptyArgs(c *gc.C) {
-	results, err := s.api.Volumes(params.Entities{})
+	results, err := s.api.Volumes(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -347,7 +348,7 @@ func (s *iaasProvisionerSuite) TestFilesystems(c *gc.C) {
 	s.setupFilesystems(c)
 	s.authorizer.Tag = names.NewMachineTag("2") // neither 0 nor 1
 
-	results, err := s.api.Filesystems(params.Entities{
+	results, err := s.api.Filesystems(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{"filesystem-0-0"},
 			{"filesystem-1"},
@@ -385,7 +386,7 @@ func (s *iaasProvisionerSuite) TestVolumeAttachments(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.VolumeAttachments(params.MachineStorageIds{
+	results, err := s.api.VolumeAttachments(context.TODO(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "volume-0-0",
@@ -430,7 +431,7 @@ func (s *iaasProvisionerSuite) TestFilesystemAttachments(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.FilesystemAttachments(params.MachineStorageIds{
+	results, err := s.api.FilesystemAttachments(context.TODO(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "filesystem-0-0",
@@ -465,7 +466,7 @@ func (s *iaasProvisionerSuite) TestFilesystemAttachments(c *gc.C) {
 func (s *iaasProvisionerSuite) TestVolumeParams(c *gc.C) {
 	// Only IAAS models support block storage right now.
 	s.setupVolumes(c)
-	results, err := s.api.VolumeParams(params.Entities{
+	results, err := s.api.VolumeParams(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{"volume-0-0"},
 			{"volume-1"},
@@ -528,7 +529,7 @@ func (s *iaasProvisionerSuite) TestVolumeParams(c *gc.C) {
 }
 
 func (s *provisionerSuite) TestVolumeParamsEmptyArgs(c *gc.C) {
-	results, err := s.api.VolumeParams(params.Entities{})
+	results, err := s.api.VolumeParams(context.TODO(), params.Entities{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 0)
 }
@@ -598,7 +599,7 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 	err = s.storageBackend.RemoveVolumeAttachment(unitMachineTag, storageVolume.VolumeTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.RemoveVolumeParams(params.Entities{
+	results, err := s.api.RemoveVolumeParams(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{"volume-0-0"},
 			{storageVolume.Tag().String()},
@@ -633,7 +634,7 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 
 func (s *iaasProvisionerSuite) TestFilesystemParams(c *gc.C) {
 	s.setupFilesystems(c)
-	results, err := s.api.FilesystemParams(params.Entities{
+	results, err := s.api.FilesystemParams(context.TODO(), params.Entities{
 		Entities: []params.Entity{{"filesystem-0-0"}, {"filesystem-1"}, {"filesystem-42"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -721,7 +722,7 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 	err = s.storageBackend.RemoveFilesystemAttachment(unitMachineTag, storageFilesystem.FilesystemTag(), false)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.RemoveFilesystemParams(params.Entities{
+	results, err := s.api.RemoveFilesystemParams(context.TODO(), params.Entities{
 		Entities: []params.Entity{
 			{"filesystem-0-0"},
 			{storageFilesystem.Tag().String()},
@@ -775,7 +776,7 @@ func (s *iaasProvisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.VolumeAttachmentParams(params.MachineStorageIds{
+	results, err := s.api.VolumeAttachmentParams(context.TODO(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "volume-0-0",
@@ -845,7 +846,7 @@ func (s *iaasProvisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	results, err := s.api.FilesystemAttachmentParams(params.MachineStorageIds{
+	results, err := s.api.FilesystemAttachmentParams(context.TODO(), params.MachineStorageIds{
 		Ids: []params.MachineStorageId{{
 			MachineTag:    "machine-0",
 			AttachmentTag: "filesystem-0-0",
@@ -1000,7 +1001,7 @@ func (s *caasProvisionerSuite) TestWatchApplications(c *gc.C) {
 		},
 	})
 
-	result, err := s.api.WatchApplications()
+	result, err := s.api.WatchApplications(context.TODO())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.StringsWatcherId, gc.Equals, "1")
 	c.Assert(result.Changes, jc.DeepEquals, []string{"mariadb"})
@@ -1030,7 +1031,7 @@ func (s *iaasProvisionerSuite) TestWatchVolumes(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	result, err := s.api.WatchVolumes(args)
+	result, err := s.api.WatchVolumes(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(result.Results[1].Changes)
 	c.Assert(result, jc.DeepEquals, params.StringsWatchResults{
@@ -1071,7 +1072,7 @@ func (s *iaasProvisionerSuite) TestWatchVolumeAttachments(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	result, err := s.api.WatchVolumeAttachments(args)
+	result, err := s.api.WatchVolumeAttachments(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Sort(byMachineAndEntity(result.Results[0].Changes))
 	sort.Sort(byMachineAndEntity(result.Results[1].Changes))
@@ -1132,7 +1133,7 @@ func (s *iaasProvisionerSuite) TestWatchFilesystems(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	result, err := s.api.WatchFilesystems(args)
+	result, err := s.api.WatchFilesystems(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Strings(result.Results[1].Changes)
 	c.Assert(result, jc.DeepEquals, params.StringsWatchResults{
@@ -1177,7 +1178,7 @@ func (s *iaasProvisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	result, err := s.api.WatchFilesystemAttachments(args)
+	result, err := s.api.WatchFilesystemAttachments(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	sort.Sort(byMachineAndEntity(result.Results[0].Changes))
 	sort.Sort(byMachineAndEntity(result.Results[1].Changes))
@@ -1234,7 +1235,7 @@ func (s *iaasProvisionerSuite) TestWatchBlockDevices(c *gc.C) {
 		{"machine-1"},
 		{"machine-42"}},
 	}
-	results, err := s.api.WatchBlockDevices(args)
+	results, err := s.api.WatchBlockDevices(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.NotifyWatchResults{
 		Results: []params.NotifyWatchResult{
@@ -1292,7 +1293,7 @@ func (s *iaasProvisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 		{MachineTag: "machine-42", AttachmentTag: "volume-42"},
 		{MachineTag: "application-mysql", AttachmentTag: "volume-1"},
 	}}
-	results, err := s.api.VolumeBlockDevices(args)
+	results, err := s.api.VolumeBlockDevices(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.BlockDeviceResults{
 		Results: []params.BlockDeviceResult{
@@ -1361,7 +1362,7 @@ func (s *iaasProvisionerSuite) TestVolumeBlockDevicesPlanBlockInfoSet(c *gc.C) {
 	args := params.MachineStorageIds{Ids: []params.MachineStorageId{
 		{MachineTag: "machine-0", AttachmentTag: "volume-0-0"},
 	}}
-	results, err := s.api.VolumeBlockDevices(args)
+	results, err := s.api.VolumeBlockDevices(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, params.BlockDeviceResults{
 		Results: []params.BlockDeviceResult{
@@ -1378,7 +1379,7 @@ func (s *iaasProvisionerSuite) TestLife(c *gc.C) {
 	// Only IAAS models support block storage right now.
 	s.setupVolumes(c)
 	args := params.Entities{Entities: []params.Entity{{"volume-0-0"}, {"volume-1"}, {"volume-42"}}}
-	result, err := s.api.Life(args)
+	result, err := s.api.Life(context.TODO(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.LifeResults{
 		Results: []params.LifeResult{


### PR DESCRIPTION
This is the start of threading through context.Context from the rpc methods through to the actual method calling. Currently context.Context is optional from the rpcreflect library, yet, it seems like a missed opportunity to not use this. With the new database changes, we would want to be able to cancel a sql transaction. Additionally, we could use the context.Context for opentracing to help debug/diagnose running issues.

The code makes a lot of changes, but it's all very mechanical.

*Why this change is needed and what it does.*

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

*Commands to run to verify that the change works.*

```sh
QA steps here
```

## Documentation changes

*How it affects user workflow (CLI or API). Delete section if not applicable.*

## Bug reference

*Link to Launchpad bug. Delete section if not applicable.*
