### PR TITLE
[JUJU-2116]: Store default-base in model-config

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -436,6 +436,10 @@ type DestroyUnitsParams struct {
 	// will wait before forcing the next step to kick-off. This parameter
 	// only makes sense in combination with 'force' set to 'true'.
 	MaxWait *time.Duration
+
+	// DryRun specifies whether to perform the destroy action or
+	// just return what this action will destroy
+	DryRun bool
 }
 
 // DestroyUnits decreases the number of units dedicated to one or more
@@ -459,6 +463,7 @@ func (c *Client) DestroyUnits(in DestroyUnitsParams) ([]params.DestroyUnitResult
 			DestroyStorage: in.DestroyStorage,
 			Force:          in.Force,
 			MaxWait:        in.MaxWait,
+			DryRun:         in.DryRun,
 		})
 	}
 	if len(args.Units) == 0 {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1413,6 +1413,21 @@ func addApplicationUnits(backend Backend, modelType state.ModelType, args params
 	)
 }
 
+func (api *APIv15) DestroyUnit(argsV15 params.DestroyUnitsParamsV15) (params.DestroyUnitResults, error) {
+	args := params.DestroyUnitsParams{
+		Units: transform.Slice(argsV15.Units, func(p params.DestroyUnitParamsV15) params.DestroyUnitParams {
+			return params.DestroyUnitParams{
+				UnitTag:        p.UnitTag,
+				DestroyStorage: p.DestroyStorage,
+				Force:          p.Force,
+				MaxWait:        p.MaxWait,
+				DryRun:         false,
+			}
+		}),
+	}
+	return api.APIBase.DestroyUnit(args)
+}
+
 // DestroyUnit removes a given set of application units.
 func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
 	if api.modelType == state.ModelTypeCAAS {

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -17,7 +17,7 @@ func Register(registry facade.FacadeRegistry) {
 		return newFacadeV15(ctx)
 	}, reflect.TypeOf((*APIv15)(nil)))
 	registry.MustRegister("Application", 16, func(ctx facade.Context) (facade.Facade, error) {
-		return newFacadeV16(ctx) // DestroyApplication gains dry-run
+		return newFacadeV16(ctx) // DestroyApplication & DestroyUnit gains dry-run
 	}, reflect.TypeOf((*APIv16)(nil)))
 }
 

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -11,6 +11,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -122,15 +123,47 @@ func (c *ModelConfigAPI) ModelGet() (params.ModelConfigResults, error) {
 		if attr == config.AuthorizedKeysKey {
 			continue
 		}
+
+		// TODO (stickupkid): Remove this when we remove series.
+		// This essentially, always ensures that we report back a default-series
+		// if we have a default-base.
+		if attr == config.DefaultBaseKey && val.Value != "" {
+			base, err := series.ParseBaseFromString(val.Value.(string))
+			if err != nil {
+				return result, errors.Trace(err)
+			}
+
+			s, err := series.GetSeriesFromBase(base)
+			if err != nil {
+				return result, errors.Trace(err)
+			}
+
+			result.Config[config.DefaultSeriesKey] = params.ConfigValue{
+				Source: val.Source,
+				Value:  s,
+			}
+		}
+
 		// Only admins get to see attributes marked as secret.
 		if attr, ok := defaultSchema[attr]; ok && attr.Secret && !isAdmin {
 			continue
 		}
+
 		result.Config[attr] = params.ConfigValue{
 			Value:  val.Value,
 			Source: val.Source,
 		}
 	}
+
+	// TODO (stickupkid): For backwards compatibility we need to ensure that
+	// we always report back a default-series.
+	if _, ok := result.Config[config.DefaultSeriesKey]; !ok {
+		result.Config[config.DefaultSeriesKey] = params.ConfigValue{
+			Value:  "",
+			Source: "default",
+		}
+	}
+
 	return result, nil
 }
 
@@ -159,6 +192,9 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 		}
 	}
 
+	// Series to base translations.
+	checkUpdateDefaultBase := c.checkUpdateDefaultBase()
+
 	// Make sure we don't allow changing agent-version.
 	checkAgentVersion := c.checkAgentVersion()
 
@@ -173,7 +209,49 @@ func (c *ModelConfigAPI) ModelSet(args params.ModelSet) error {
 
 	// Replace any deprecated attributes with their new values.
 	attrs := config.ProcessDeprecatedAttributes(args.Config)
-	return c.backend.UpdateModelConfig(attrs, nil, checkAgentVersion, checkLogTrace, checkDefaultSpace, checkCharmhubURL)
+	return c.backend.UpdateModelConfig(attrs,
+		nil,
+		checkAgentVersion,
+		checkLogTrace,
+		checkDefaultSpace,
+		checkCharmhubURL,
+		checkUpdateDefaultBase,
+	)
+}
+
+func (c *ModelConfigAPI) checkUpdateDefaultBase() state.ValidateConfigFunc {
+	return func(updateAttrs map[string]interface{}, removeAttrs []string, oldConfig *config.Config) error {
+		cfgSeries, defaultSeriesOK := updateAttrs[config.DefaultSeriesKey]
+		_, defaultBaseOK := updateAttrs[config.DefaultBaseKey]
+
+		// If there is no default series, there is nothing to do.
+		if !defaultSeriesOK {
+			return nil
+		} else if defaultSeriesOK && defaultBaseOK {
+			// If the default-series is set and the default-base is set, error
+			// out, as you can't change both.
+			return errors.New("cannot set both default-series and default-base")
+		}
+
+		if defaultSeriesOK {
+			// If the default-series is set, but empty, then we need to patch the
+			// base.
+			if cfgSeries == "" {
+				updateAttrs[config.DefaultBaseKey] = ""
+			} else {
+				// Ensure that the new default-series updates the default-base.
+				base, err := series.GetBaseFromSeries(cfgSeries.(string))
+				if err != nil {
+					return errors.Trace(err)
+				}
+
+				updateAttrs[config.DefaultBaseKey] = base.String()
+			}
+			// Always remove the default-series.
+			delete(updateAttrs, config.DefaultSeriesKey)
+		}
+		return nil
+	}
 }
 
 func (c *ModelConfigAPI) checkLogTrace() state.ValidateConfigFunc {
@@ -264,6 +342,16 @@ func (c *ModelConfigAPI) ModelUnset(args params.ModelUnset) error {
 	if err := c.check.ChangeAllowed(); err != nil {
 		return errors.Trace(err)
 	}
+
+	// If we're attempting to remove the default-series, then we need to
+	// swap that out for the default-base.
+	for i, key := range args.Keys {
+		if key == config.DefaultSeriesKey {
+			args.Keys[i] = config.DefaultBaseKey
+			break
+		}
+	}
+
 	return c.backend.UpdateModelConfig(nil, args.Keys)
 }
 

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -217,6 +217,7 @@ func (s *modelInfoSuite) expectedModelInfo(c *gc.C, credentialValidity *bool) pa
 		CloudRegion:        "some-region",
 		CloudCredentialTag: "cloudcred-some-cloud_bob_some-credential",
 		DefaultSeries:      jujuversion.DefaultSupportedLTS(),
+		DefaultBase:        jujuversion.DefaultSupportedLTSBase().String(),
 		Life:               life.Dying,
 		Status: params.EntityStatus{
 			Status: status.Destroying,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/controller/modelmanager"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -34,6 +35,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var (
@@ -882,9 +884,22 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag, withSecrets bool) (pa
 	}
 	if err == nil {
 		info.ProviderType = cfg.Type()
-		info.DefaultSeries = config.PreferredSeries(cfg)
+
 		if agentVersion, exists := cfg.AgentVersion(); exists {
 			info.AgentVersion = &agentVersion
+		}
+
+		// TODO(stickupkid): Series is deprecated, always use a base as the
+		// source of truth.
+		defaultBase := config.PreferredBase(cfg)
+		info.DefaultBase = defaultBase.String()
+		if defaultSeries, err := series.GetSeriesFromBase(defaultBase); err == nil {
+			info.DefaultSeries = defaultSeries
+		} else {
+			logger.Errorf("cannot get default series from base %q: %v", defaultBase, err)
+			// This is slightly defensive, but we should always show a series
+			// in the model info.
+			info.DefaultSeries = jujuversion.DefaultSupportedLTS()
 		}
 	}
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3337,6 +3337,9 @@
                         "destroy-storage": {
                             "type": "boolean"
                         },
+                        "dry-run": {
+                            "type": "boolean"
+                        },
                         "force": {
                             "type": "boolean"
                         },
@@ -3349,8 +3352,7 @@
                     },
                     "additionalProperties": false,
                     "required": [
-                        "unit-tag",
-                        "force"
+                        "unit-tag"
                     ]
                 },
                 "DestroyUnitResult": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -31448,6 +31448,9 @@
                         "controller-uuid": {
                             "type": "string"
                         },
+                        "default-base": {
+                            "type": "string"
+                        },
                         "default-series": {
                             "type": "string"
                         },

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -39,7 +39,7 @@ func IsUserAbortedError(err error) bool {
 // UserConfirmYes returns an error if we do not read a "y" or "yes" from user
 // input.
 func UserConfirmYes(ctx *cmd.Context) error {
-	fmt.Fprint(ctx.Stdout, yesNoMsg)
+	fmt.Fprint(ctx.Stderr, yesNoMsg)
 	scanner := bufio.NewScanner(ctx.Stdin)
 	scanner.Scan()
 	err := scanner.Err()
@@ -56,7 +56,7 @@ func UserConfirmYes(ctx *cmd.Context) error {
 // UserConfirmName returns an error if we do not read a "name" of the model/controller/etc from user
 // input.
 func UserConfirmName(verificationName string, objectType string, ctx *cmd.Context) error {
-	fmt.Fprintf(ctx.Stdout, nameVerificationMsg, objectType)
+	fmt.Fprintf(ctx.Stderr, nameVerificationMsg, objectType)
 	scanner := bufio.NewScanner(ctx.Stdin)
 	scanner.Scan()
 	err := scanner.Err()

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -425,8 +425,8 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	// argument so users can target a specific origin.
 	origin := c.id.Origin
 	var usingDefaultSeries bool
-	if defaultSeries, ok := modelCfg.DefaultSeries(); ok && origin.Base.Channel.Empty() {
-		base, err := coreseries.GetBaseFromSeries(defaultSeries)
+	if defaultBase, ok := modelCfg.DefaultBase(); ok && origin.Base.Channel.Empty() {
+		base, err := coreseries.ParseBaseFromString(defaultBase)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -29,13 +29,13 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 
 			title: "juju deploy simple   # no default series, no supported series",
 			seriesSelector: seriesSelector{
-				conf: defaultSeries{},
+				conf: defaultBase{},
 			},
 			err: "series not specified and charm does not define any",
 		}, {
 			title: "juju deploy simple   # default series set, no supported series",
 			seriesSelector: seriesSelector{
-				conf:                defaultSeries{"bionic", true},
+				conf:                defaultBase{"ubuntu@18.04", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -43,7 +43,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 		{
 			title: "juju deploy simple with old series  # default series set, no supported series",
 			seriesSelector: seriesSelector{
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: wily not supported",
@@ -52,7 +52,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --series=precise   # default series set, no supported series",
 			seriesSelector: seriesSelector{
 				seriesFlag:          "precise",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: precise not supported",
@@ -60,7 +60,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --series=bionic   # default series set, no supported series, no supported juju series",
 			seriesSelector: seriesSelector{
 				seriesFlag: "bionic",
-				conf:       defaultSeries{"wily", true},
+				conf:       defaultBase{"ubuntu@15.10", true},
 			},
 			err: "expected supported juju series to exist",
 		},
@@ -68,7 +68,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --series=bionic   # default series set, no supported series",
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -77,7 +77,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy trusty/simple   # charm series set, default series set, no supported series",
 			seriesSelector: seriesSelector{
 				charmURLSeries:      "trusty",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: trusty not supported",
@@ -86,7 +86,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy bionic/simple   # charm series set, default series set, no supported series",
 			seriesSelector: seriesSelector{
 				charmURLSeries:      "bionic",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -96,7 +96,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
 				charmURLSeries:      "cosmic",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -105,7 +105,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --force   # no default series, no supported series, use LTS (jammy)",
 			seriesSelector: seriesSelector{
 				force: true,
-				conf:  defaultSeries{},
+				conf:  defaultBase{},
 			},
 			expectedSeries: "jammy",
 		},
@@ -116,7 +116,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries   # use charm default, nothing specified, no default series",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -125,7 +125,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries with invalid series  # use charm default, nothing specified, no default series",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"precise", "bionic", "cosmic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -134,7 +134,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries with invalid serie  # use charm default, nothing specified, no default series",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"precise"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: `the charm defined series "precise" not supported`,
@@ -143,7 +143,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries   # use charm defaults used if default series doesn't match, nothing specified",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic"},
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: `series "wily" is not supported, supported series are: bionic,cosmic`,
@@ -152,7 +152,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries   # use model series defaults if supported by charm",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic", "disco"},
-				conf:                defaultSeries{"disco", true},
+				conf:                defaultBase{"ubuntu@19.04", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic", "disco"),
 			},
 			expectedSeries: "disco",
@@ -161,7 +161,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries   # use model series defaults if supported by charm",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic", "disco"},
-				conf:                defaultSeries{"disco", true},
+				conf:                defaultBase{"ubuntu@19.04", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: disco not supported",
@@ -171,7 +171,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
 				supportedSeries:     []string{"utopic", "vivid", "bionic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -181,7 +181,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
 				supportedSeries:     []string{"cosmic", "bionic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -191,7 +191,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
 				supportedSeries:     []string{"utopic", "vivid"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: `series: bionic`,
@@ -202,7 +202,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				seriesFlag:      "bionic",
 				supportedSeries: []string{"utopic", "vivid"},
 				force:           true,
-				conf:            defaultSeries{},
+				conf:            defaultBase{},
 			},
 			err: "expected supported juju series to exist",
 		},
@@ -211,7 +211,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				charmURLSeries:      "bionic",
 				supportedSeries:     []string{"utopic", "vivid", "bionic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -221,7 +221,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				charmURLSeries:  "bionic",
 				supportedSeries: []string{"utopic", "vivid", "bionic"},
-				conf:            defaultSeries{},
+				conf:            defaultBase{},
 			},
 			err: "expected supported juju series to exist",
 		},
@@ -231,7 +231,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				seriesFlag:          "cosmic",
 				charmURLSeries:      "bionic",
 				supportedSeries:     []string{"utopic", "vivid", "bionic", "cosmic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "cosmic",
@@ -242,7 +242,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				seriesFlag:      "cosmic",
 				charmURLSeries:  "bionic",
 				supportedSeries: []string{"bionic", "utopic", "vivid"},
-				conf:            defaultSeries{},
+				conf:            defaultBase{},
 			},
 			err: `series: cosmic`,
 		},
@@ -252,7 +252,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				seriesFlag:          "cosmic",
 				charmURLSeries:      "bionic",
 				supportedSeries:     []string{"bionic", "utopic", "vivid", "cosmic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "cosmic",
@@ -264,7 +264,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				charmURLSeries:  "bionic",
 				supportedSeries: []string{"bionic", "utopic", "vivid"},
 				force:           true,
-				conf:            defaultSeries{},
+				conf:            defaultBase{},
 			},
 			err: "expected supported juju series to exist",
 		},
@@ -286,11 +286,11 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 	}
 }
 
-type defaultSeries struct {
-	series   string
+type defaultBase struct {
+	base     string
 	explicit bool
 }
 
-func (d defaultSeries) DefaultSeries() (string, bool) {
-	return d.series, d.explicit
+func (d defaultBase) DefaultBase() (string, bool) {
+	return d.base, d.explicit
 }

--- a/cmd/juju/application/removeapplication_test.go
+++ b/cmd/juju/application/removeapplication_test.go
@@ -176,7 +176,7 @@ func (s *removeApplicationSuite) TestRemoveApplicationPrompt(c *gc.C) {
 
 	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, `
 (?s)WARNING! This command:
-`[1:])
+.*`[1:])
 	c.Assert(cmdtesting.Stdout(ctx), gc.Matches, `
 (?s)will remove application real-app
 .*`[1:])

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -281,6 +281,7 @@ func (c *removeUnitCommand) removeUnits(ctx *cmd.Context, client RemoveApplicati
 		DestroyStorage: c.DestroyStorage,
 		Force:          c.Force,
 		MaxWait:        maxWait,
+		DryRun:         false,
 	})
 	if err != nil {
 		return block.ProcessBlockedError(err, block.BlockRemove)

--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -7,13 +7,11 @@ import (
 	"time"
 
 	"github.com/juju/cmd/v3"
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/api/client/application"
-	"github.com/juju/juju/api/client/storage"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
@@ -193,41 +191,6 @@ func (c *removeUnitCommand) getAPI() (RemoveApplicationAPI, error) {
 	}
 	api := application.NewClient(root)
 	return api, nil
-}
-
-func (c *removeUnitCommand) getStorageAPI() (storageAPI, error) {
-	root, err := c.NewAPIRoot()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return storage.NewClient(root), nil
-}
-
-func (c *removeUnitCommand) unitsHaveStorage(unitNames []string) (bool, error) {
-	client, err := c.getStorageAPI()
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	defer client.Close()
-
-	storages, err := client.ListStorageDetails()
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	namesSet := set.NewStrings(unitNames...)
-	for _, s := range storages {
-		if s.OwnerTag == "" {
-			continue
-		}
-		owner, err := names.ParseTag(s.OwnerTag)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		if owner.Kind() == names.UnitTagKind && namesSet.Contains(owner.Id()) {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // Run connects to the environment specified on the command line and destroys

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1242,6 +1242,24 @@ func (s *BootstrapSuite) TestBootstrapCalledWithMetadataDir(c *gc.C) {
 	c.Assert(bootstrapFuncs.args.MetadataDir, gc.Equals, sourceDir)
 }
 
+func (s *BootstrapSuite) TestBootstrapCalledWitBase(c *gc.C) {
+	sourceDir, _ := createImageMetadata(c)
+	resetJujuXDGDataHome(c)
+
+	var bootstrapFuncs fakeBootstrapFuncs
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrapFuncs
+	})
+
+	cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(),
+		"--metadata-source", sourceDir, "--constraints", "mem=4G",
+		"dummy-cloud/region-1", "devcontroller",
+		"--config", "default-base=ubuntu@22.04",
+	)
+	c.Assert(bootstrapFuncs.args.MetadataDir, gc.Equals, sourceDir)
+}
+
 func (s *BootstrapSuite) checkBootstrapWithVersion(c *gc.C, vers, expect string) {
 	resetJujuXDGDataHome(c)
 
@@ -1270,6 +1288,36 @@ func (s *BootstrapSuite) TestBootstrapWithVersionNumber(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapWithBinaryVersionNumber(c *gc.C) {
 	s.checkBootstrapWithVersion(c, "2.3.4-jammy-ppc64", "2.3.4")
+}
+
+func (s *BootstrapSuite) checkBootstrapBaseWithVersion(c *gc.C, vers, expect string) {
+	resetJujuXDGDataHome(c)
+
+	var bootstrapFuncs fakeBootstrapFuncs
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrapFuncs
+	})
+
+	num := jujuversion.Current
+	num.Major = 2
+	num.Minor = 3
+	s.PatchValue(&jujuversion.Current, num)
+	cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(),
+		"--agent-version", vers,
+		"dummy-cloud/region-1", "devcontroller",
+		"--config", "default-base=ubuntu@22.04",
+	)
+	c.Assert(bootstrapFuncs.args.AgentVersion, gc.NotNil)
+	c.Assert(*bootstrapFuncs.args.AgentVersion, gc.Equals, version.MustParse(expect))
+}
+
+func (s *BootstrapSuite) TestBootstrapBaseWithVersionNumber(c *gc.C) {
+	s.checkBootstrapBaseWithVersion(c, "2.3.4", "2.3.4")
+}
+
+func (s *BootstrapSuite) TestBootstrapBaseWithBinaryVersionNumber(c *gc.C) {
+	s.checkBootstrapBaseWithVersion(c, "2.3.4-jammy-ppc64", "2.3.4")
 }
 
 func (s *BootstrapSuite) TestBootstrapWithAutoUpgrade(c *gc.C) {
@@ -1567,15 +1615,10 @@ func (s *BootstrapSuite) TestBootstrapProviderManyDetectedCredentials(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapWithBootstrapSeries(c *gc.C) {
 	s.patchVersionAndSeries(c, "jammy")
-	ctx, err := cmdtesting.RunCommand(
+	_, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl", "--bootstrap-series", "spock",
 	)
-	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on no-cloud-regions(.|\n)*")
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-	c.Check(s.tw.Log(), jc.LogMatches, []jc.SimpleMessage{
-		{loggo.ERROR, "failed to bootstrap model: series \"spock\" not valid"},
-		{loggo.DEBUG, "(error details.*)"},
-	})
+	c.Assert(err, gc.ErrorMatches, `cannot determine base for series "spock"`)
 }
 
 func (s *BootstrapSuite) TestBootstrapWithDeprecatedSeries(c *gc.C) {
@@ -1602,7 +1645,25 @@ func (s *BootstrapSuite) TestBootstrapWithBootstrapSeriesDoesNotUseFallbackButSt
 		"--bootstrap-series", "spock",
 		"--config", "default-series=kirk",
 	)
-	c.Assert(err, gc.ErrorMatches, `series "kirk" not supported`)
+	c.Assert(err, gc.ErrorMatches, `cannot determine base for series "spock"`)
+}
+
+func (s *BootstrapSuite) TestBootstrapBaseWithNoBootstrapSeriesUsesFallbackButStillFails(c *gc.C) {
+	s.patchVersionAndSeries(c, "jammy")
+	_, err := cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl", "--config", "default-base=spock",
+	)
+	c.Assert(err, gc.ErrorMatches, `invalid default base "spock": expected base string to contain os and channel separated by '@'`)
+}
+
+func (s *BootstrapSuite) TestBootstrapBaseWithBootstrapSeriesDoesNotUseFallbackButStillFails(c *gc.C) {
+	s.patchVersionAndSeries(c, "jammy")
+	_, err := cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl",
+		"--bootstrap-base", "spock",
+		"--config", "default-base=kirk",
+	)
+	c.Assert(err, gc.ErrorMatches, `base "spock" not valid`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderFileCredential(c *gc.C) {

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -106,7 +106,7 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if c.ConfirmationCommandBase.NeedsConfirmation() {
-		fmt.Fprintf(ctx.Stdout, unregisterMsg, c.controllerName)
+		fmt.Fprintf(ctx.Stderr, unregisterMsg, c.controllerName)
 		if err := jujucmd.UserConfirmName(c.controllerName, "controller", ctx); err != nil {
 			return errors.Annotate(err, "unregistering controller")
 		}

--- a/cmd/juju/controller/unregister_test.go
+++ b/cmd/juju/controller/unregister_test.go
@@ -91,10 +91,10 @@ you register it again.
 To continue, enter the name of the controller to be destroyed: `[1:]
 
 func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
-	var stdin, stdout bytes.Buffer
+	var stdin, stderr bytes.Buffer
 	ctx, err := cmd.DefaultContext()
 	c.Assert(err, jc.ErrorIsNil)
-	ctx.Stdout = &stdout
+	ctx.Stderr = &stderr
 	ctx.Stdin = &stdin
 
 	// Ensure confirmation is requested if "-y" is not specified.
@@ -107,7 +107,7 @@ func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
 	case <-time.After(testing.LongWait):
 		c.Fatalf("command took too long")
 	}
-	c.Check(cmdtesting.Stdout(ctx), gc.Equals, unregisterMsg)
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, unregisterMsg)
 	c.Check(s.store.lookupName, gc.Equals, "fake1")
 	c.Check(s.store.removedName, gc.Equals, "")
 }

--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -149,7 +149,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if !c.assumeYes && c.force {
-		fmt.Fprintf(ctx.Stdout, removeOfferMsg, strings.Join(c.offers, ", "))
+		fmt.Fprintf(ctx.Stderr, removeOfferMsg, strings.Join(c.offers, ", "))
 
 		if err := jujucmd.UserConfirmYes(ctx); err != nil {
 			return errors.Annotate(err, "offer removal")

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -96,7 +96,6 @@ func (s *removeSuite) TestRemoveForceMessage(c *gc.C) {
 	err = cmdtesting.InitCommand(com, []string{"fred/model.db2", "--force"})
 	c.Assert(err, jc.ErrorIsNil)
 	com.Run(ctx)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 
 	expected := `
 WARNING! This command will remove offers: fred/model.db2
@@ -104,7 +103,7 @@ This includes all relations to those offers.
 
 Continue [y/N]? `[1:]
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expected)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expected)
 }
 
 func (s *removeSuite) TestRemoveNameOnly(c *gc.C) {

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -175,7 +175,7 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	if c.NeedsConfirmation() {
 		err := c.performDryRun(ctx, client)
 		if err == errDryRunNotSupported {
-			fmt.Fprintf(ctx.Stdout, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
+			fmt.Fprintf(ctx.Stderr, removeMachineMsgNoDryRun, strings.Join(c.MachineIds, ", "))
 		} else if err != nil {
 			return errors.Trace(err)
 		}
@@ -202,7 +202,7 @@ func (c *removeCommand) performDryRun(ctx *cmd.Context, client RemoveMachineAPI)
 	if err := block.ProcessBlockedError(err, block.BlockRemove); err != nil {
 		return errors.Trace(err)
 	}
-	fmt.Fprint(ctx.Stdout, removeMachineMsgPrefix)
+	fmt.Fprint(ctx.Stderr, removeMachineMsgPrefix)
 	if err := c.logResults(ctx, results, false); err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/machine/remove_test.go
+++ b/cmd/juju/machine/remove_test.go
@@ -267,9 +267,12 @@ func (s *RemoveMachineSuite) TestRemoveOutputDryRun(c *gc.C) {
 
 	ctx, err := s.run(c, "--dry-run", "1", "2")
 	c.Assert(err, jc.ErrorIsNil)
+	stderr := cmdtesting.Stderr(ctx)
 	stdout := cmdtesting.Stdout(ctx)
-	c.Assert(stdout, gc.Equals, `
+	c.Assert(stderr, gc.Equals, `
 WARNING! This command:
+`[1:])
+	c.Assert(stdout, gc.Equals, `
 will remove machine 1
 will remove machine 2
 `[1:])

--- a/cmd/juju/machine/upgrademachine_test.go
+++ b/cmd/juju/machine/upgrademachine_test.go
@@ -211,7 +211,7 @@ func (s *UpgradeSeriesSuite) TestPrepareCommandShouldAcceptYesAbbreviation(c *gc
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldPromptUserForConfirmation(c *gc.C) {
 	ctx, err := s.runUpgradeSeriesCommandWithConfirmation(c, "y", machineArg, machine.PrepareCommand, seriesArg)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ctx.Stdout.(*bytes.Buffer).String(), jc.HasSuffix, "Continue [y/N]? ")
+	c.Assert(ctx.Stderr.(*bytes.Buffer).String(), gc.Matches, `(?s).*Continue \[y\/N\]\? .*`)
 }
 
 func (s *UpgradeSeriesSuite) TestPrepareCommandShouldIndicateOnlySubordinatesOnMachine(c *gc.C) {

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -342,11 +342,6 @@ func (c *configCommand) setConfig(client configCommandAPI, attrs config.Attrs) e
 
 // getConfig writes the value of a single model config key to the cmd.Context.
 func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) error {
-	// if certBytes != nil {
-	// 	_, _ = ctx.Stdout.Write(certBytes)
-	// 	return nil
-	// }
-
 	attrs, err := c.getFilteredModel(client)
 	if err != nil {
 		return err
@@ -355,7 +350,9 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 	if len(c.configBase.KeysToGet) == 0 {
 		return errors.New("c.configBase.KeysToGet is empty")
 	}
-	if value, found := attrs[c.configBase.KeysToGet[0]]; found {
+
+	key := c.configBase.KeysToGet[0]
+	if value, found := attrs[key]; found {
 		if c.out.Name() == "tabular" {
 			// The user has not specified that they want
 			// YAML or JSON formatting, so we print out
@@ -371,7 +368,7 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 	// Key not found - error
 	mod, _ := c.ModelIdentifier()
 	return errors.Errorf("%q is not a key of the currently targeted model: %q",
-		c.configBase.KeysToGet[0], mod)
+		key, mod)
 }
 
 // getAllConfig writes the full model config to the cmd.Context.

--- a/cmd/juju/space/remove.go
+++ b/cmd/juju/space/remove.go
@@ -153,9 +153,9 @@ func (c *RemoveCommand) handleForceOption(api SpaceAPI, currentModel string, ctx
 
 	errorList := buildRemoveErrorList(result, currentModel)
 	if len(errorList) == 0 {
-		fmt.Fprintf(ctx.Stdout, removeSpaceMsgNoBounds)
+		fmt.Fprintf(ctx.Stderr, removeSpaceMsgNoBounds)
 	} else {
-		fmt.Fprintf(ctx.Stdout, removeSpaceMsgBounds, strings.Join(errorList, "\n"))
+		fmt.Fprintf(ctx.Stderr, removeSpaceMsgBounds, strings.Join(errorList, "\n"))
 	}
 	if err := jujucmd.UserConfirmYes(ctx); err != nil {
 		return errors.Annotate(err, "space removal")

--- a/cmd/juju/space/remove_test.go
+++ b/cmd/juju/space/remove_test.go
@@ -144,7 +144,7 @@ Continue [y/N]? `[1:]
 
 	ctx, _, err := s.runCommand(c, api, spaceName, "--force")
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedErrMsg)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedErrMsg)
 	c.Assert(err, gc.ErrorMatches, `cannot remove space "myspace": space removal: aborted`)
 }
 
@@ -191,7 +191,7 @@ Continue [y/N]? `[1:]
 
 	ctx, _, err := s.runCommand(c, api, spaceName, "--force")
 
-	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, expectedErrMsg)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, expectedErrMsg)
 	c.Assert(err, gc.ErrorMatches, `cannot remove space "default": space removal: aborted`)
 }
 

--- a/core/series/base.go
+++ b/core/series/base.go
@@ -48,9 +48,24 @@ func ParseBaseFromString(b string) (Base, error) {
 	return Base{OS: parts[0], Channel: channel}, nil
 }
 
+// MustParseBaseFromString is like ParseBaseFromString but panics if the string
+// is invalid.
+func MustParseBaseFromString(b string) Base {
+	base, err := ParseBaseFromString(b)
+	if err != nil {
+		panic(err)
+	}
+	return base
+}
+
 // MakeDefaultBase creates a base from an os and simple version string, eg "22.04".
 func MakeDefaultBase(os string, channel string) Base {
 	return Base{OS: os, Channel: MakeDefaultChannel(channel)}
+}
+
+// Empty returns true if the base is empty.
+func (b Base) Empty() bool {
+	return b.OS == "" && b.Channel.Empty()
 }
 
 func (b Base) String() string {

--- a/core/series/supportedbases.go
+++ b/core/series/supportedbases.go
@@ -1,0 +1,100 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package series
+
+import (
+	"sort"
+	"time"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+)
+
+// ControllerBases returns the supported workload bases available to it at the
+// execution time.
+func ControllerBases(now time.Time, requestedBase Base, imageStream string) ([]Base, error) {
+	return seriesToBase(requestedBase, func(requestedSeries string) (set.Strings, error) {
+		// The DistroInfo is currently in series, so we need to convert it to
+		// base to get the correct series.
+		return ControllerSeries(now, requestedSeries, imageStream)
+	})
+}
+
+// WorkloadBases returns the supported workload bases available to it at the
+// execution time.
+func WorkloadBases(now time.Time, requestedBase Base, imageStream string) ([]Base, error) {
+	return seriesToBase(requestedBase, func(requestedSeries string) (set.Strings, error) {
+		// The DistroInfo is currently in series, so we need to convert it to
+		// base to get the correct series.
+		return WorkloadSeries(now, requestedSeries, imageStream)
+	})
+}
+
+func seriesToBase(requestedBase Base, fn func(string) (set.Strings, error)) ([]Base, error) {
+	var requestedSeries string
+	if !requestedBase.Empty() {
+		var err error
+		requestedSeries, err = GetSeriesFromBase(requestedBase)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	series, err := fn(requestedSeries)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	bases := map[Base]struct{}{}
+	for _, s := range series.Values() {
+		b, err := GetBaseFromSeries(s)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		bases[b] = struct{}{}
+	}
+
+	results := make([]Base, 0, len(bases))
+	for b := range bases {
+		results = append(results, b)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].String() < results[j].String()
+	})
+	return results, nil
+}
+
+// BaseSeriesVersion returns the series version for the given base.
+// TODO(stickupkid): The underlying series version should be a base, until that
+// logic has changes, just convert between base and series.
+func BaseSeriesVersion(base Base) (string, error) {
+	s, err := GetSeriesFromBase(base)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return SeriesVersion(s)
+}
+
+// UbuntuBaseVersion returns the series version for the given base.
+// TODO(stickupkid): The underlying series version should be a base, until that
+// logic has changes, just convert between base and series.
+func UbuntuBaseVersion(base Base) (string, error) {
+	s, err := GetSeriesFromBase(base)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return UbuntuSeriesVersion(s)
+}
+
+// LatestLTSBase returns the latest LTS base.
+// TODO(stickupkid): The underlying series version should be a base, until that
+// logic has changes, just convert between base and series.
+func LatestLTSBase() Base {
+	lts := LatestLTS()
+	b, err := GetBaseFromSeries(lts)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/core/series/supportedbases_test.go
+++ b/core/series/supportedbases_test.go
@@ -1,0 +1,72 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package series
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type BasesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&BasesSuite{})
+
+func (s *BasesSuite) TestWorkloadBases(c *gc.C) {
+	tests := []struct {
+		name          string
+		requestedBase Base
+		imageStream   string
+		err           string
+		expectedBase  []Base
+	}{{
+		name:          "no base",
+		requestedBase: Base{},
+		imageStream:   Daily,
+		expectedBase: []Base{
+			MustParseBaseFromString("centos@7/stable"),
+			MustParseBaseFromString("centos@8/stable"),
+			MustParseBaseFromString("centos@9/stable"),
+			MustParseBaseFromString("genericlinux@genericlinux/stable"),
+			MustParseBaseFromString("kubernetes@kubernetes"),
+			MustParseBaseFromString("opensuse@opensuse42/stable"),
+			MustParseBaseFromString("ubuntu@20.04/stable"),
+			MustParseBaseFromString("ubuntu@22.04/stable"),
+		},
+	}, {
+		name:          "requested base",
+		requestedBase: MustParseBaseFromString("ubuntu@22.04"),
+		imageStream:   Daily,
+		expectedBase: []Base{
+			MustParseBaseFromString("centos@7/stable"),
+			MustParseBaseFromString("centos@8/stable"),
+			MustParseBaseFromString("centos@9/stable"),
+			MustParseBaseFromString("genericlinux@genericlinux/stable"),
+			MustParseBaseFromString("kubernetes@kubernetes"),
+			MustParseBaseFromString("opensuse@opensuse42/stable"),
+			MustParseBaseFromString("ubuntu@20.04/stable"),
+			MustParseBaseFromString("ubuntu@22.04/stable"),
+		},
+	}, {
+		name:          "invalid base",
+		requestedBase: MustParseBaseFromString("foo@bar"),
+		imageStream:   Daily,
+		err:           `os "foo" version "bar" not found`,
+	}}
+	for _, test := range tests {
+		c.Logf("test %q", test.name)
+
+		result, err := WorkloadBases(time.Now(), test.requestedBase, test.imageStream)
+		if test.err != "" {
+			c.Assert(err, gc.ErrorMatches, test.err)
+			continue
+		}
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result, gc.DeepEquals, test.expectedBase)
+	}
+}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -70,14 +70,6 @@ type BootstrapParams struct {
 	// ControllerName is the controller name.
 	ControllerName string
 
-	// BootstrapSeries, if specified, is the series to use for the
-	// initial bootstrap machine.
-	BootstrapSeries string
-
-	// SupportedBootstrapSeries is a supported set of series to use for
-	// validating against the bootstrap series.
-	SupportedBootstrapSeries set.Strings
-
 	// BootstrapImage, if specified, is the image ID to use for the
 	// initial bootstrap machine.
 	BootstrapImage string
@@ -180,6 +172,14 @@ type BootstrapParams struct {
 
 	// ExtraAgentValuesForTesting are testing only values written to the agent config file.
 	ExtraAgentValuesForTesting map[string]string
+
+	// BootstrapBase, if specified, is the base to use for the
+	// initial bootstrap machine (deprecated use BootstrapBase).
+	BootstrapBase series.Base
+
+	// SupportedBootstrapBase is a supported set of bases to use for
+	// validating against the bootstrap base.
+	SupportedBootstrapBases []series.Base
 }
 
 // Validate validates the bootstrap parameters.
@@ -196,9 +196,10 @@ func (p BootstrapParams) Validate() error {
 	if p.CAPrivateKey == "" {
 		return errors.New("empty ca-private-key")
 	}
-	if p.SupportedBootstrapSeries == nil || p.SupportedBootstrapSeries.Size() == 0 {
-		return errors.NotValidf("supported bootstrap series")
+	if p.SupportedBootstrapBases == nil || len(p.SupportedBootstrapBases) == 0 {
+		return errors.NotValidf("supported bootstrap bases")
 	}
+
 	// TODO(axw) validate other things.
 	return nil
 }
@@ -247,8 +248,8 @@ func bootstrapCAAS(
 	if args.BootstrapImage != "" {
 		return errors.NotSupportedf("--bootstrap-image when bootstrapping a k8s controller")
 	}
-	if args.BootstrapSeries != "" {
-		return errors.NotSupportedf("--bootstrap-series when bootstrapping a k8s controller")
+	if !args.BootstrapBase.Empty() {
+		return errors.NotSupportedf("--bootstrap-base when bootstrapping a k8s controller")
 	}
 
 	constraintsValidator, err := environ.ConstraintsValidator(callCtx)
@@ -353,9 +354,13 @@ func bootstrapIAAS(
 			return errors.Trace(err)
 		}
 
-		if args.BootstrapSeries == "" && detectedSeries != "" {
-			args.BootstrapSeries = detectedSeries
-			logger.Debugf("auto-selecting bootstrap series %q", args.BootstrapSeries)
+		if args.BootstrapBase.Empty() && detectedSeries != "" {
+			base, err := series.GetBaseFromSeries(detectedSeries)
+			if err != nil {
+				base = jujuversion.DefaultSupportedLTSBase()
+			}
+			args.BootstrapBase = base
+			logger.Debugf("auto-selecting bootstrap series %q", args.BootstrapBase.String())
 		}
 		if args.BootstrapConstraints.Arch == nil && args.ModelConstraints.Arch == nil && detectedHW.Arch != nil {
 			arch := *detectedHW.Arch
@@ -364,20 +369,20 @@ func bootstrapIAAS(
 		}
 	}
 
-	requestedBootstrapSeries, err := series.ValidateSeries(
-		args.SupportedBootstrapSeries,
-		args.BootstrapSeries,
-		config.PreferredSeries(cfg),
+	requestedBootstrapBase, err := series.ValidateBase(
+		args.SupportedBootstrapBases,
+		args.BootstrapBase,
+		config.PreferredBase(cfg),
 	)
 	if !args.Force && err != nil {
 		// If the series isn't valid at all, then don't prompt users to use
 		// the --force flag.
-		if _, err := series.UbuntuSeriesVersion(requestedBootstrapSeries); err != nil {
-			return errors.NotValidf("series %q", requestedBootstrapSeries)
+		if _, err := series.UbuntuBaseVersion(requestedBootstrapBase); err != nil {
+			return errors.NotValidf("base %q", requestedBootstrapBase.String())
 		}
 		return errors.Annotatef(err, "use --force to override")
 	}
-	bootstrapSeries := &requestedBootstrapSeries
+	bootstrapBase := requestedBootstrapBase
 
 	var bootstrapArchForImageSearch string
 	if args.BootstrapConstraints.Arch != nil {
@@ -395,7 +400,7 @@ func bootstrapIAAS(
 	ctx.Verbosef("Loading image metadata")
 	imageMetadata, err := bootstrapImageMetadata(environ,
 		ss,
-		bootstrapSeries,
+		&bootstrapBase,
 		bootstrapArchForImageSearch,
 		args.BootstrapImage,
 		&customImageMetadata,
@@ -467,7 +472,7 @@ func bootstrapIAAS(
 		}
 		ctx.Infof("Looking for %vpackaged Juju agent version %s for %s", latestPatchTxt, versionTxt, bootstrapArch)
 
-		availableTools, err = findPackagedTools(environ, ss, args.AgentVersion, &bootstrapArch, bootstrapSeries)
+		availableTools, err = findPackagedTools(environ, ss, args.AgentVersion, &bootstrapArch, &bootstrapBase)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
@@ -489,7 +494,7 @@ func bootstrapIAAS(
 		if args.BuildAgentTarball == nil {
 			return errors.New("cannot build agent binary to upload")
 		}
-		if err = validateUploadAllowed(environ, &bootstrapArch, bootstrapSeries, constraintsValidator); err != nil {
+		if err = validateUploadAllowed(environ, &bootstrapArch, &bootstrapBase, constraintsValidator); err != nil {
 			return err
 		}
 		if args.BuildAgent {
@@ -690,14 +695,34 @@ func Bootstrap(
 	if err := args.Validate(); err != nil {
 		return errors.Annotate(err, "validating bootstrap parameters")
 	}
+
+	// TODO(stickupkid): Once environs doesn't have a dependency on series, we
+	// can remove this conversion.
+	var bootstrapSeries string
+	if !args.BootstrapBase.Empty() {
+		var err error
+		bootstrapSeries, err = series.GetSeriesFromBase(args.BootstrapBase)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	supportedBootstrapSeries := set.NewStrings()
+	for _, base := range args.SupportedBootstrapBases {
+		s, err := series.GetSeriesFromBase(base)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		supportedBootstrapSeries.Add(s)
+	}
+
 	bootstrapParams := environs.BootstrapParams{
 		CloudName:                  args.Cloud.Name,
 		CloudRegion:                args.CloudRegion,
 		ControllerConfig:           args.ControllerConfig,
 		ModelConstraints:           args.ModelConstraints,
 		StoragePools:               args.StoragePools,
-		BootstrapSeries:            args.BootstrapSeries,
-		SupportedBootstrapSeries:   args.SupportedBootstrapSeries,
+		BootstrapSeries:            bootstrapSeries,
+		SupportedBootstrapSeries:   supportedBootstrapSeries,
 		Placement:                  args.Placement,
 		Force:                      args.Force,
 		ExtraAgentValuesForTesting: args.ExtraAgentValuesForTesting,
@@ -887,7 +912,7 @@ func userPublicSigningKey() (string, error) {
 func bootstrapImageMetadata(
 	environ environs.BootstrapEnviron,
 	fetcher imagemetadata.SimplestreamsFetcher,
-	bootstrapSeries *string,
+	bootstrapBase *series.Base,
 	bootstrapArch string,
 	bootstrapImageId string,
 	customImageMetadata *[]*imagemetadata.ImageMetadata,
@@ -912,10 +937,10 @@ func bootstrapImageMetadata(
 	}
 
 	if bootstrapImageId != "" {
-		if bootstrapSeries == nil {
-			return nil, errors.NotValidf("no series specified with bootstrap image")
+		if bootstrapBase == nil {
+			return nil, errors.NotValidf("no base specified with bootstrap image")
 		}
-		seriesVersion, err := series.SeriesVersion(*bootstrapSeries)
+		seriesVersion, err := series.BaseSeriesVersion(*bootstrapBase)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -302,6 +302,10 @@ const (
 	// explicitly use for charms unless otherwise provided.
 	DefaultSeriesKey = "default-series"
 
+	// DefaultBaseKey is a key for determining the base a model should
+	// explicitly use for charms unless otherwise provided.
+	DefaultBaseKey = "default-base"
+
 	// SecretBackendKey is used to specify the secret backend.
 	SecretBackendKey = "secret-backend"
 )
@@ -370,35 +374,28 @@ func (method HarvestMode) HarvestUnknown() bool {
 	return method&HarvestUnknown != 0
 }
 
-// HasDefaultSeries defines a interface if a type has a default series or not.
-type HasDefaultSeries interface {
-	DefaultSeries() (string, bool)
-}
-
 // GetDefaultSupportedLTS returns the DefaultSupportedLTS.
 // This is exposed for one reason and one reason only; testing!
 // The fact that PreferredSeries doesn't take an argument for a default series
 // as a fallback. We then have to expose this so we can exercise the branching
 // code for other scenarios makes me sad.
-var GetDefaultSupportedLTS = jujuversion.DefaultSupportedLTS
+var GetDefaultSupportedLTSBase = jujuversion.DefaultSupportedLTSBase
 
-// PreferredSeries returns the preferred series to use when a charm does not
-// explicitly specify a series.
-func PreferredSeries(cfg HasDefaultSeries) string {
-	if series, ok := cfg.DefaultSeries(); ok {
-		return series
-	}
-	return GetDefaultSupportedLTS()
+// HasDefaultBase defines a interface if a type has a default base or not.
+type HasDefaultBase interface {
+	DefaultBase() (string, bool)
 }
 
 // PreferredBase returns the preferred base to use when a charm does not
 // explicitly specify a base.
-func PreferredBase(cfg HasDefaultSeries) series.Base {
-	ser, ok := cfg.DefaultSeries()
-	if !ok {
-		return jujuversion.DefaultSupportedLTSBase()
+func PreferredBase(cfg HasDefaultBase) series.Base {
+	base, ok := cfg.DefaultBase()
+	if ok {
+		// We can safely ignore the error here as we know that we have
+		// validated the base when we set it.
+		return series.MustParseBaseFromString(base)
 	}
-	return series.MakeDefaultBase("ubuntu", ser)
+	return GetDefaultSupportedLTSBase()
 }
 
 // Config holds an immutable environment configuration.
@@ -527,7 +524,8 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	DefaultSeriesKey:                "",
+	DefaultBaseKey: "",
+
 	ProvisionerHarvestModeKey:       HarvestDestroyed.String(),
 	NumProvisionWorkersKey:          16,
 	NumContainerProvisionWorkersKey: 4,
@@ -838,7 +836,7 @@ func Validate(cfg, old *Config) error {
 		return errors.Trace(err)
 	}
 
-	if err := cfg.validateDefaultSeries(); err != nil {
+	if err := cfg.validateDefaultBase(); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -978,28 +976,39 @@ func (c *Config) DefaultSpace() string {
 	return c.asString(DefaultSpace)
 }
 
-var supportedJujuSeries = series.WorkloadSeries
-
-func (c *Config) validateDefaultSeries() error {
-	defaultSeries, configured := c.DefaultSeries()
+func (c *Config) validateDefaultBase() error {
+	defaultBase, configured := c.DefaultBase()
 	if !configured {
 		return nil
 	}
-	supported, err := supportedJujuSeries(time.Now(), "", "")
+
+	parsedBase, err := series.ParseBaseFromString(defaultBase)
 	if err != nil {
-		return errors.Annotate(err, "cannot read supported series")
+		return errors.Annotatef(err, "invalid default base %q", defaultBase)
 	}
-	logger.Tracef("supported series %s", supported.SortedValues())
-	if !supported.Contains(defaultSeries) {
-		return errors.NotSupportedf("series %q", defaultSeries)
+
+	supported, err := series.WorkloadBases(time.Now(), series.Base{}, "")
+	if err != nil {
+		return errors.Annotate(err, "cannot read supported bases")
+	}
+	logger.Tracef("supported bases %s", supported)
+	var found bool
+	for _, supportedBase := range supported {
+		if parsedBase.IsCompatible(supportedBase) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return errors.NotSupportedf("base %q", defaultBase)
 	}
 	return nil
 }
 
-// DefaultSeries returns the configured default Ubuntu series for the model,
-// and whether the default series was explicitly configured on the environment.
-func (c *Config) DefaultSeries() (string, bool) {
-	s, ok := c.defined[DefaultSeriesKey]
+// DefaultBase returns the configured default base for the model, and whether
+// the default base was explicitly configured on the environment.
+func (c *Config) DefaultBase() (string, bool) {
+	s, ok := c.defined[DefaultBaseKey]
 	if !ok {
 		return "", false
 	}
@@ -1007,7 +1016,7 @@ func (c *Config) DefaultSeries() (string, bool) {
 	case string:
 		return s, s != ""
 	default:
-		logger.Errorf("invalid default-series: %q", s)
+		logger.Errorf("invalid default-base: %q", s)
 		return "", false
 	}
 }
@@ -1772,7 +1781,7 @@ var alwaysOptional = schema.Defaults{
 	AgentMetadataURLKey:             schema.Omit,
 	ContainerImageStreamKey:         schema.Omit,
 	ContainerImageMetadataURLKey:    schema.Omit,
-	DefaultSeriesKey:                schema.Omit,
+	DefaultBaseKey:                  schema.Omit,
 	"development":                   schema.Omit,
 	"ssl-hostname-verification":     schema.Omit,
 	"proxy-ssh":                     schema.Omit,
@@ -2020,8 +2029,8 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	DefaultSeriesKey: {
-		Description: "The default series of Ubuntu to use for deploying charms, will act like --series when deploying charms",
+	DefaultBaseKey: {
+		Description: "The default base image to use for deploying charms, will act like --base when deploying charms",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -55,7 +55,7 @@ var sampleConfig = testing.Attrs{
 	"unknown":                    "my-unknown",
 	"ssl-hostname-verification":  true,
 	"development":                false,
-	"default-series":             jujuversion.DefaultSupportedLTS(),
+	"default-base":               jujuversion.DefaultSupportedLTSBase().String(),
 	"disable-network-management": false,
 	"ignore-machine-addresses":   false,
 	"automatically-retry-hooks":  true,
@@ -106,25 +106,25 @@ var configTests = []configTest{
 			"container-image-metadata-url": "container-image-metadata-url-value",
 		}),
 	}, {
-		about:       "Explicit series",
+		about:       "Explicit base",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"default-series": "jammy",
+			"default-base": "ubuntu@20.04",
 		}),
 	}, {
-		about:       "old series",
+		about:       "old base",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"default-series": "bionic",
+			"default-base": "ubuntu@18.04",
 		}),
-		err: `series "bionic" not supported`,
+		err: `base "ubuntu@18.04" not supported`,
 	}, {
-		about:       "bad series",
+		about:       "bad base",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"default-series": "my-series",
+			"default-base": "my-series",
 		}),
-		err: `series "my-series" not supported`,
+		err: `invalid default base "my-series": expected base string to contain os and channel separated by '@'`,
 	}, {
 		about:       "Explicit logging",
 		useDefaults: config.UseDefaults,
@@ -413,6 +413,7 @@ var configTests = []configTest{
 			"authorized-keys":            "ssh-rsa mykeys rog@rog-x220\n",
 			"region":                     "us-east-1",
 			"default-series":             "focal",
+			"default-base":               "ubuntu@20.04",
 			"secret-key":                 "a-secret-key",
 			"access-key":                 "an-access-key",
 			"agent-version":              "1.13.2",
@@ -692,14 +693,14 @@ func (test configTest) check(c *gc.C) {
 	dev, _ := test.attrs["development"].(bool)
 	c.Assert(cfg.Development(), gc.Equals, dev)
 
-	seriesAttr, _ := test.attrs["default-series"].(string)
-	defaultSeries, ok := cfg.DefaultSeries()
-	if seriesAttr != "" {
+	baseAttr, _ := test.attrs["default-base"].(string)
+	defaultBase, ok := cfg.DefaultBase()
+	if baseAttr != "" {
 		c.Assert(ok, jc.IsTrue)
-		c.Assert(defaultSeries, gc.Equals, seriesAttr)
+		c.Assert(defaultBase, gc.Equals, baseAttr)
 	} else {
 		c.Assert(ok, jc.IsFalse)
-		c.Assert(defaultSeries, gc.Equals, "")
+		c.Assert(defaultBase, gc.Equals, "")
 	}
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {
@@ -849,7 +850,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 		"firewall-mode":              config.FwInstance,
 		"unknown":                    "my-unknown",
 		"ssl-hostname-verification":  true,
-		"default-series":             jujuversion.DefaultSupportedLTS(),
+		"default-base":               jujuversion.DefaultSupportedLTSBase().String(),
 		"disable-network-management": false,
 		"ignore-machine-addresses":   false,
 		"automatically-retry-hooks":  true,

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -217,12 +217,12 @@ func (t *LiveTests) bootstrapParams() bootstrap.BootstrapParams {
 			Regions:   regions,
 			Endpoint:  t.CloudEndpoint,
 		},
-		CloudRegion:              t.CloudRegion,
-		CloudCredential:          &credential,
-		CloudCredentialName:      "credential",
-		AdminSecret:              AdminSecret,
-		CAPrivateKey:             coretesting.CAKey,
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		CloudRegion:             t.CloudRegion,
+		CloudCredential:         &credential,
+		CloudCredentialName:     "credential",
+		AdminSecret:             AdminSecret,
+		CAPrivateKey:            coretesting.CAKey,
+		SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 	}
 }
 

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -217,12 +217,12 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 			Regions:   regions,
 			Endpoint:  t.CloudEndpoint,
 		},
-		CloudRegion:              t.CloudRegion,
-		CloudCredential:          &credential,
-		CloudCredentialName:      "credential",
-		AdminSecret:              AdminSecret,
-		CAPrivateKey:             coretesting.CAKey,
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		CloudRegion:             t.CloudRegion,
+		CloudCredential:         &credential,
+		CloudCredentialName:     "credential",
+		AdminSecret:             AdminSecret,
+		CAPrivateKey:            coretesting.CAKey,
+		SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 	}
 
 	e := t.Prepare(c)

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -72,10 +72,10 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	envtesting.UploadFakeTools(c, stor, cfg.AgentStream(), cfg.AgentStream())
 	err = bootstrap.Bootstrap(ctx, env, context.NewEmptyCloudCallContext(), bootstrap.BootstrapParams{
-		ControllerConfig:         controllerCfg,
-		AdminSecret:              "admin-secret",
-		CAPrivateKey:             testing.CAKey,
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        controllerCfg,
+		AdminSecret:             "admin-secret",
+		CAPrivateKey:            testing.CAKey,
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -582,11 +582,11 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 				},
 			},
 		},
-		CloudCredential:          cloudSpec.Credential,
-		CloudCredentialName:      "cred",
-		AdminSecret:              AdminSecret,
-		CAPrivateKey:             testing.CAKey,
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		CloudCredential:         cloudSpec.Credential,
+		CloudCredentialName:     "cred",
+		AdminSecret:             AdminSecret,
+		CAPrivateKey:            testing.CAKey,
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -182,8 +182,13 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 		return errors.Trace(err)
 	}
 
-	preferredSeries := config.PreferredSeries(env.Config())
+	preferredBase := config.PreferredBase(env.Config())
+
 	if params.ImageMetadata == nil {
+		preferredSeries, err := series.GetSeriesFromBase(preferredBase)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		vers, err := imagemetadata.ImageRelease(preferredSeries)
 		if err != nil {
 			return errors.Trace(err)
@@ -201,16 +206,12 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 
 	machineNonce := "fake_nonce"
 	apiInfo := FakeAPIInfo(machineId)
-	base, err := series.GetBaseFromSeries(preferredSeries)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	instanceConfig, err := instancecfg.NewInstanceConfig(
 		testing.ControllerTag,
 		machineId,
 		machineNonce,
 		imagemetadata.ReleasedStream,
-		base,
+		preferredBase,
 		apiInfo,
 	)
 	if err != nil {

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1583,14 +1583,14 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 			ControllerConfig: testing.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
 			CAPrivateKey:     testing.CAKey,
-			BootstrapSeries:  "jammy",
+			BootstrapBase:    coreseries.MustParseBaseFromString("ubuntu@22.04"),
 			BuildAgentTarball: func(
 				build bool, _ string, _ func(version.Number) version.Number,
 			) (*sync.BuiltAgent, error) {
 				c.Assert(build, jc.IsFalse)
 				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
 			},
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	// If we aren't on amd64, this should correctly fail. See also:
@@ -1634,14 +1634,14 @@ func (s *environSuite) TestBootstrapCustomResourceGroup(c *gc.C) {
 			ControllerConfig: testing.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
 			CAPrivateKey:     testing.CAKey,
-			BootstrapSeries:  "jammy",
+			BootstrapBase:    coreseries.MustParseBaseFromString("ubuntu@22.04"),
 			BuildAgentTarball: func(
 				build bool, _ string, _ func(version.Number) version.Number,
 			) (*sync.BuiltAgent, error) {
 				c.Assert(build, jc.IsFalse)
 				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
 			},
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	// If we aren't on amd64, this should correctly fail. See also:

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -85,31 +85,45 @@ func BootstrapInstance(
 	// no way to make sure that only one succeeds.
 
 	// First thing, ensure we have tools otherwise there's no point.
-	selectedSeries, err := coreseries.ValidateSeries(
-		args.SupportedBootstrapSeries,
-		args.BootstrapSeries,
-		config.PreferredSeries(env.Config()),
+	supportedBootstrapBase := make([]series.Base, len(args.SupportedBootstrapSeries))
+	for i, b := range args.SupportedBootstrapSeries.SortedValues() {
+		sb, err := series.GetBaseFromSeries(b)
+		if err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+		supportedBootstrapBase[i] = sb
+	}
+
+	var bootstrapBase series.Base
+	if args.BootstrapSeries != "" {
+		b, err := series.GetBaseFromSeries(args.BootstrapSeries)
+		if err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+		bootstrapBase = b
+	}
+
+	requestedBootstrapBase, err := coreseries.ValidateBase(
+		supportedBootstrapBase,
+		bootstrapBase,
+		config.PreferredBase(env.Config()),
 	)
 	if !args.Force && err != nil {
-		// If the series isn't valid at all, then don't prompt users to use
+		// If the base isn't valid at all, then don't prompt users to use
 		// the --force flag.
-		if _, err := series.UbuntuSeriesVersion(selectedSeries); err != nil {
-			return nil, nil, nil, errors.NotValidf("series %q", selectedSeries)
+		if _, err := series.UbuntuBaseVersion(requestedBootstrapBase); err != nil {
+			return nil, nil, nil, errors.NotValidf("base %q", requestedBootstrapBase.String())
 		}
 		return nil, nil, nil, errors.Annotatef(err, "use --force to override")
 	}
-	// The series we're attempting to bootstrap is empty, show a friendly
+	// The base we're attempting to bootstrap is empty, show a friendly
 	// error message, rather than the more cryptic error messages that follow
 	// onwards.
-	if selectedSeries == "" {
-		return nil, nil, nil, errors.NotValidf("bootstrap instance series")
-	}
-	selectedBase, err := coreseries.GetBaseFromSeries(selectedSeries)
-	if selectedSeries == "" {
-		return nil, nil, nil, errors.NotValidf("bootstrap instance series %q", selectedSeries)
+	if requestedBootstrapBase.Empty() {
+		return nil, nil, nil, errors.NotValidf("bootstrap instance base")
 	}
 	availableTools, err := args.AvailableTools.Match(coretools.Filter{
-		OSType: selectedBase.OS,
+		OSType: requestedBootstrapBase.OS,
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -117,7 +131,7 @@ func BootstrapInstance(
 
 	// Filter image metadata to the selected series.
 	var imageMetadata []*imagemetadata.ImageMetadata
-	seriesVersion, err := series.SeriesVersion(selectedSeries)
+	seriesVersion, err := series.BaseSeriesVersion(requestedBootstrapBase)
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}
@@ -143,7 +157,7 @@ func BootstrapInstance(
 	}
 	envCfg := env.Config()
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(
-		args.ControllerConfig, args.BootstrapConstraints, args.ModelConstraints, selectedBase, publicKey,
+		args.ControllerConfig, args.BootstrapConstraints, args.ModelConstraints, requestedBootstrapBase, publicKey,
 		args.ExtraAgentValuesForTesting,
 	)
 	if err != nil {
@@ -325,7 +339,7 @@ func BootstrapInstance(
 		}
 		return FinishBootstrap(ctx, client, env, callCtx, result.Instance, icfg, opts)
 	}
-	return result, &selectedBase, finalizer, nil
+	return result, &requestedBootstrapBase, finalizer, nil
 }
 
 func startInstanceZones(env environs.Environ, ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) ([]string, error) {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -145,9 +145,9 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 				Type:      "dummy",
 				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			},
-			AdminSecret:              AdminSecret,
-			CAPrivateKey:             testing.CAKey,
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			AdminSecret:             AdminSecret,
+			CAPrivateKey:            testing.CAKey,
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	return netenv

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -39,7 +39,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
-	coreseries "github.com/juju/juju/core/series"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
@@ -477,14 +477,19 @@ func (e *environ) PrecheckInstance(ctx context.ProviderCallContext, args environ
 
 // AgentMetadataLookupParams returns parameters which are used to query agent simple-streams metadata.
 func (e *environ) AgentMetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	series := config.PreferredSeries(e.ecfg())
-	hostOSType := coreseries.DefaultOSTypeNameFromSeries(series)
-	return e.metadataLookupParams(region, hostOSType)
+	base := config.PreferredBase(e.ecfg())
+	return e.metadataLookupParams(region, base.OS)
 }
 
 // ImageMetadataLookupParams returns parameters which are used to query image simple-streams metadata.
 func (e *environ) ImageMetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	release, err := imagemetadata.ImageRelease(config.PreferredSeries(e.ecfg()))
+	base := config.PreferredBase(e.ecfg())
+	baseSeries, err := series.GetSeriesFromBase(base)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	release, err := imagemetadata.ImageRelease(baseSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -348,11 +348,11 @@ func (t *localServerSuite) prepareWithParamsAndBootstrapWithVPCID(c *gc.C, param
 
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			Placement:                "zone=test-available",
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			Placement:               "zone=test-available",
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -376,11 +376,11 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			BootstrapSeries:          coreseries.LatestLTS(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			BootstrapBase:           coreseries.LatestLTSBase(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -450,10 +450,10 @@ func (t *localServerSuite) TestTerminateInstancesIgnoresNotFound(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -529,10 +529,10 @@ func (t *localServerSuite) TestGetTerminatedInstances(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -697,10 +697,10 @@ func (t *localServerSuite) TestInstanceStatus(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	t.srv.ec2srv.SetInitialInstanceState(ec2test.Terminated)
@@ -1171,12 +1171,12 @@ func (t *localServerSuite) prepareAndBootstrapWithConfig(c *gc.C, config coretes
 
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			BootstrapConstraints:     constraints,
-			ControllerConfig:         controllerConfig,
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			Placement:                "zone=test-available",
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			BootstrapConstraints:    constraints,
+			ControllerConfig:        controllerConfig,
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			Placement:               "zone=test-available",
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	return env
@@ -1598,10 +1598,10 @@ func (t *localServerSuite) setUpInstanceWithDefaultVpc(c *gc.C) (environs.Networ
 	env := t.prepareEnviron(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/maas/maas_environ_whitebox_test.go
+++ b/provider/maas/maas_environ_whitebox_test.go
@@ -698,10 +698,10 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {
 	env := suite.makeEnviron(c, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -722,10 +722,10 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentRetry(c *gc.C) {
 	env := suite.makeEnviron(c, nil)
 	bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -746,10 +746,10 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentSucceeds(c *gc.C) {
 	env := suite.makeEnviron(c, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -2261,10 +2261,10 @@ func (suite *maasEnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -2395,8 +2395,8 @@ func (suite *maasEnvironSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 			CAPrivateKey:     coretesting.CAKey,
 			// Disable auto-uploading by setting the agent version
 			// to something that's not the current version.
-			AgentVersion:             &vers,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			AgentVersion:            &vers,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -2411,10 +2411,10 @@ func (suite *maasEnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -3344,10 +3344,10 @@ func bootstrapEnvWithConstraints(c *gc.C, env environs.Environ, cons constraints
 	return bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		context.NewEmptyCloudCallContext(),
 		bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
-			BootstrapConstraints:     cons,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
+			BootstrapConstraints:    cons,
 		})
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -45,7 +45,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
-	coreseries "github.com/juju/juju/core/series"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
@@ -2210,14 +2210,19 @@ func (e *Environ) terminateInstanceNetworkPorts(id instance.Id) error {
 
 // AgentMetadataLookupParams returns parameters which are used to query agent simple-streams metadata.
 func (e *Environ) AgentMetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	series := config.PreferredSeries(e.ecfg())
-	hostOSType := coreseries.DefaultOSTypeNameFromSeries(series)
-	return e.metadataLookupParams(region, hostOSType)
+	base := config.PreferredBase(e.ecfg())
+	return e.metadataLookupParams(region, base.OS)
 }
 
 // ImageMetadataLookupParams returns parameters which are used to query image simple-streams metadata.
 func (e *Environ) ImageMetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	release, err := imagemetadata.ImageRelease(config.PreferredSeries(e.ecfg()))
+	base := config.PreferredBase(e.ecfg())
+	baseSeries, err := series.GetSeriesFromBase(base)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	release, err := imagemetadata.ImageRelease(baseSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/rpc/params/model.go
+++ b/rpc/params/model.go
@@ -145,7 +145,8 @@ type ModelInfo struct {
 	ControllerUUID     string `json:"controller-uuid"`
 	IsController       bool   `json:"is-controller"`
 	ProviderType       string `json:"provider-type,omitempty"`
-	DefaultSeries      string `json:"default-series,omitempty"`
+	DefaultSeries      string `json:"default-series,omitempty"` // default-series is deprecated, use default-base
+	DefaultBase        string `json:"default-base,omitempty"`
 	CloudTag           string `json:"cloud-tag"`
 	CloudRegion        string `json:"cloud-region,omitempty"`
 	CloudCredentialTag string `json:"cloud-credential-tag,omitempty"`

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -520,6 +520,30 @@ type ApplicationMergeBindings struct {
 	Force          bool              `json:"force"`
 }
 
+// DestroyUnitsParamsV15 holds bulk parameters for the Application.DestroyUnit call.
+type DestroyUnitsParamsV15 struct {
+	Units []DestroyUnitParamsV15 `json:"units"`
+}
+
+// DestroyUnitParams holds parameters for the Application.DestroyUnit call.
+type DestroyUnitParamsV15 struct {
+	// UnitTag holds the tag of the unit to destroy.
+	UnitTag string `json:"unit-tag"`
+
+	// DestroyStorage controls whether or not storage
+	// attached to the unit should be destroyed.
+	DestroyStorage bool `json:"destroy-storage,omitempty"`
+
+	// Force controls whether or not the destruction of an application
+	// will be forced, i.e. ignore operational errors.
+	Force bool `json:"force"`
+
+	// MaxWait specifies the amount of time that each step in unit removal
+	// will wait before forcing the next step to kick-off. This parameter
+	// only makes sense in combination with 'force' set to 'true'.
+	MaxWait *time.Duration `json:"max-wait,omitempty"`
+}
+
 // DestroyUnitsParams holds bulk parameters for the Application.DestroyUnit call.
 type DestroyUnitsParams struct {
 	Units []DestroyUnitParams `json:"units"`
@@ -536,12 +560,16 @@ type DestroyUnitParams struct {
 
 	// Force controls whether or not the destruction of an application
 	// will be forced, i.e. ignore operational errors.
-	Force bool `json:"force"`
+	Force bool `json:"force,omitempty"`
 
 	// MaxWait specifies the amount of time that each step in unit removal
 	// will wait before forcing the next step to kick-off. This parameter
 	// only makes sense in combination with 'force' set to 'true'.
 	MaxWait *time.Duration `json:"max-wait,omitempty"`
+
+	// DryRun specifies whether to perform the destroy action or
+	// just return what this action will destroy
+	DryRun bool `json:"dry-run,omitempty"`
 }
 
 // Creds holds credentials for identifying an entity.

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -265,7 +265,21 @@ func modelConfig(attrs map[string]interface{}) (*config.Config, error) {
 	// Using MustParse as the value parsed will never change.
 	newer := version.MustParse("2.9.35")
 	if comp := toolsVersion.Compare(newer); comp < 0 {
-		attrs[config.DefaultSeriesKey] = ""
+		attrs[config.DefaultBaseKey] = ""
+		delete(attrs, config.DefaultSeriesKey)
+	}
+
+	if v, ok := attrs[config.DefaultSeriesKey]; ok {
+		if v == "" {
+			attrs[config.DefaultBaseKey] = ""
+		} else {
+			s, err := series.GetBaseFromSeries(v.(string))
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			attrs[config.DefaultBaseKey] = s.String()
+		}
+		delete(attrs, config.DefaultSeriesKey)
 	}
 
 	// Ensure the expected default secret-backend value is set.
@@ -284,7 +298,6 @@ func modelConfig(attrs map[string]interface{}) (*config.Config, error) {
 type ImportStateMigration struct {
 	src        description.Model
 	dst        Database
-	importer   *importer
 	migrations []func() error
 }
 

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2740,14 +2740,14 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestImportingModelWithDefaultSeriesBefore2935(c *gc.C) {
-	defaultSeries, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.7.8"))
-	c.Assert(ok, jc.IsFalse, gc.Commentf("value: %q", defaultSeries))
+	defaultBase, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.7.8"))
+	c.Assert(ok, jc.IsFalse, gc.Commentf("value: %q", defaultBase))
 }
 
 func (s *MigrationImportSuite) TestImportingModelWithDefaultSeriesAfter2935(c *gc.C) {
-	defaultSeries, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.9.35"))
+	defaultBase, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.9.35"))
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(defaultSeries, gc.Equals, "jammy")
+	c.Assert(defaultBase, gc.Equals, "ubuntu@22.04/stable")
 }
 
 func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, toolsVer version.Number) (string, bool) {
@@ -2774,7 +2774,7 @@ func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, tool
 
 	importedCfg, err := imported.Config()
 	c.Assert(err, jc.ErrorIsNil)
-	return importedCfg.DefaultSeries()
+	return importedCfg.DefaultBase()
 }
 
 func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C) {

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
@@ -57,6 +58,7 @@ type ModelSummary struct {
 	// Needs Config()
 	ProviderType  string
 	DefaultSeries string
+	DefaultBase   series.Base
 	AgentVersion  *version.Number
 
 	// Needs Statuses collection
@@ -121,8 +123,6 @@ func newProcessorFromModelDocs(st *State, modelDocs []modelDoc, user names.UserT
 			CloudTag:           names.NewCloudTag(doc.Cloud).String(),
 			CloudRegion:        doc.CloudRegion,
 			CloudCredentialTag: cloudCred,
-			/// Users:              make(map[string]UserAccessInfo),
-			/// Machines:           make(map[string]MachineModelInfo),
 		}
 		p.indexByUUID[doc.UUID] = i
 		p.modelUUIDs[i] = doc.UUID
@@ -157,7 +157,14 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 		}
 		detail := &(p.summaries[idx])
 		detail.ProviderType = cfg.Type()
-		detail.DefaultSeries = config.PreferredSeries(cfg)
+		detail.DefaultBase = config.PreferredBase(cfg)
+
+		// TODO(stickupkid): Ensure we fill in the default series for now, we
+		// can switch that out later.
+		if detail.DefaultSeries, err = series.GetSeriesFromBase(detail.DefaultBase); err != nil {
+			return errors.Trace(err)
+		}
+
 		if agentVersion, exists := cfg.AgentVersion(); exists {
 			detail.AgentVersion = &agentVersion
 		}

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs/config"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -35,6 +36,14 @@ var (
 	// FakeSupportedJujuSeries is used to provide a series of canned results
 	// of series to test bootstrap code against.
 	FakeSupportedJujuSeries = set.NewStrings("focal", "jammy", jujuversion.DefaultSupportedLTS())
+
+	// FakeSupportedJujuBases is used to provide a list of canned results
+	// of a base to test bootstrap code against.
+	FakeSupportedJujuBases = []series.Base{
+		series.MustParseBaseFromString("ubuntu@20.04"),
+		series.MustParseBaseFromString("ubuntu@22.04"),
+		jujuversion.DefaultSupportedLTSBase(),
+	}
 )
 
 // FakeVersionNumber is a valid version number that can be used in testing.

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -236,7 +236,6 @@ if [[ $# -eq 0 ]]; then
 		echo "$(red '---------------------------------------')"
 		echo ""
 		show_help
-		exit 1
 	fi
 fi
 


### PR DESCRIPTION
The basic premise for this change is to start pushing `default-base` through the stack so that we no longer have to depend on `series`. This is one step towards the end goal. This has a lot of changes because we're now stating that we prefer a base over a series. We should still be backward compatible, allowing a series to be selected if there is no base.

We attempt to keep `default-series` and `default-base` in sync at the API facade layer. So the following is possible:

```sh
$ juju model-config -m controller default-base=ubuntu@22.04
$ juju model-config -m controller default-series
jammy
$ juju model-config -m controller default-series=focal
$ juju model-config -m controller default-base
ubuntu@20.04
$ juju model-config -m controller default-base=""
$ juju model-config -m controller default-series

$ juju model-config -m controller default-base

$ juju model-config -m controller default-base=blah@blah
ERROR os "blah" version "blah" not found (not found)
```


Additional work in bootstrap was also required, as the model config forced changes at the CLI. Internally the boostrap args will use bases before it hits the environ bootstrap params. We can push bases through that at another PR.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

### Series not found:

```sh
$ juju bootstrap lxd test --build-agent --model-default default-series=foo
WARNING the default-series configuration option is deprecated, use default-base instead
ERROR series "foo" not supported
```

### Invalid base:

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-base=foo
ERROR base "foo" not valid
```

### Invalid series:

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-series=foo
ERROR cannot determine base for series "foo"
```

### Can not supply both default-series or default-base

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-series=foo --bootstrap-base=bar
ERROR cannot specify both --bootstrap-series and --bootstrap-base
```

### Using a base

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-base=ubuntu@22.04
```

### Using a series

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-series=jammy
```

### Model config changes

```sh
$ juju model-config -m controller default-base=ubuntu@22.04
$ juju model-config -m controller default-series
jammy
$ juju model-config -m controller default-series=focal
$ juju model-config -m controller default-base
ubuntu@20.04
$ juju model-config -m controller default-base=""
$ juju model-config -m controller default-series

$ juju model-config -m controller default-base

$ juju model-config -m controller default-base=blah@blah
ERROR os "blah" version "blah" not found (not found)
```

### Deploying with model config

```sh
$ juju add-model default
$ juju model-config default-base=ubuntu@22.04
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 21
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 21 in channel stable on ubuntu@22.04/stable
$ juju model-config default-series=focal
$ juju model-config default-base
ubuntu@20.04/stable
$ juju deploy ubuntu ubuntux
Located charm "ubuntu" in charm-hub, revision 21
Deploying "ubuntux" from charm-hub charm "ubuntu", revision 21 in channel stable on ubuntu@20.04/stable
```

## Documentation changes

@tmihoc we're now deprecating `default-series` for `juju bootstrap` and in `juju model-config`.

## Jira reference

https://warthogs.atlassian.net/browse/JUJU-2116

