### PR TITLE
[JUJU-2241] Reword charm resource origin store in output

### DIFF
--- a/cmd/juju/resource/formatter.go
+++ b/cmd/juju/resource/formatter.go
@@ -173,9 +173,6 @@ func combinedOrigin(used bool, r resources.Resource) string {
 	if r.Origin == charmresource.OriginUpload && used && r.Username != "" {
 		return r.Username
 	}
-	if r.Origin == charmresource.OriginStore {
-		return "charmstore"
-	}
 	return r.Origin.String()
 }
 

--- a/cmd/juju/resource/formatter_test.go
+++ b/cmd/juju/resource/formatter_test.go
@@ -87,7 +87,7 @@ func (s *SvcFormatterSuite) TestFormatSvcResource(c *gc.C) {
 		Username:         r.Username,
 		CombinedRevision: "5",
 		UsedYesNo:        "yes",
-		CombinedOrigin:   "charmstore",
+		CombinedOrigin:   "store",
 	})
 }
 

--- a/cmd/juju/resource/list_test.go
+++ b/cmd/juju/resource/list_test.go
@@ -187,8 +187,8 @@ func (s *ShowApplicationSuite) TestRun(c *gc.C) {
 
 	c.Check(stdout, gc.Equals, `
 Resource  Supplied by  Revision
-openjdk   charmstore   7
-rsc1234   charmstore   15
+openjdk   store        7
+rsc1234   store        15
 website   upload       -
 website2  Bill User    2012-12-12T12:12
 

--- a/cmd/juju/resource/output_tabular_test.go
+++ b/cmd/juju/resource/output_tabular_test.go
@@ -124,7 +124,7 @@ func (s *AppTabularSuite) TestFormatApplicationOkay(c *gc.C) {
 	data := s.formatTabular(c, formatted)
 	c.Check(data, gc.Equals, `
 Resource  Supplied by  Revision
-openjdk   charmstore   7
+openjdk   store        7
 `[1:])
 }
 
@@ -251,8 +251,8 @@ func (s *AppTabularSuite) TestFormatSvcTabularMulti(c *gc.C) {
 	// Notes: sorted by name, then by revision, newest first.
 	c.Check(data, gc.Equals, `
 Resource  Supplied by  Revision
-openjdk   charmstore   7
-openjdk2  charmstore   8
+openjdk   store        7
+openjdk2  store        8
 website   upload       -
 website2  Bill User    2012-12-12T12:12
 


### PR DESCRIPTION
"charmstore" is confusing as it refers to a charm resource which was downloaded from a store or repository, not the actual charm store. 

Part of removing charm store support from juju.

## QA steps

```sh
$ juju deploy juju-qa-test
$ juju resources juju-qa-test
Resource  Supplied by  Revision
foo-file  store        2
```
