### PR TITLE
[JUJU-2235] Remove support for charm store charms from resources command.

### DIFF
--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -231,7 +231,7 @@ func resolveCharm(raw string) (*charm.URL, error) {
 		return nil, errors.NotSupportedf("charm bundles")
 	}
 	if !charm.CharmHub.Matches(charmURL.Schema) {
-		return nil, errors.BadRequestf("only supported with charm hub charms")
+		return nil, errors.BadRequestf("only supported with charmhub charms")
 	}
 
 	return charmURL, nil

--- a/cmd/juju/resource/charmresources.go
+++ b/cmd/juju/resource/charmresources.go
@@ -230,6 +230,9 @@ func resolveCharm(raw string) (*charm.URL, error) {
 	if charmURL.Series == "bundle" {
 		return nil, errors.NotSupportedf("charm bundles")
 	}
+	if !charm.CharmHub.Matches(charmURL.Schema) {
+		return nil, errors.BadRequestf("only supported with charm hub charms")
+	}
 
 	return charmURL, nil
 }

--- a/cmd/juju/resource/charmresources_test.go
+++ b/cmd/juju/resource/charmresources_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/charm/v9"
 	charmresource "github.com/juju/charm/v9/resource"
 	jujucmd "github.com/juju/cmd/v3"
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -94,27 +93,17 @@ website   2
 	)
 	s.stub.CheckCall(c, 0, "ListResources", []jujuresource.CharmID{
 		{
-			URL:     charm.MustParseURL("ch:a-charm"),
+			URL:     charm.MustParseURL("a-charm"),
 			Channel: corecharm.MustParseChannel("stable"),
 		},
 	})
-}
-
-func (s *CharmResourcesSuite) TestCharmhub(c *gc.C) {
-	s.client.stub.SetErrors(errors.Errorf("charmhub charms are currently not supported"))
-
-	command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
-	code, stdout, stderr := runCmd(c, command, "a-charm")
-	c.Check(code, gc.Equals, 1)
-	c.Check(stdout, gc.Equals, "")
-	c.Check(stderr, gc.Equals, "ERROR charmhub charms are currently not supported\n")
 }
 
 func (s *CharmResourcesSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
 	command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
-	code, stdout, stderr := runCmd(c, command, "ch:a-charm")
+	code, stdout, stderr := runCmd(c, command, "a-charm")
 	c.Check(code, gc.Equals, 0)
 
 	c.Check(stderr, gc.Equals, "No resources to display.\n")

--- a/cmd/juju/resource/charmresources_test.go
+++ b/cmd/juju/resource/charmresources_test.go
@@ -80,7 +80,7 @@ func (s *CharmResourcesSuite) TestOkay(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{resources}
 
 	command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
-	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
+	code, stdout, stderr := runCmd(c, command, "a-charm")
 	c.Check(code, gc.Equals, 0)
 
 	c.Check(stdout, gc.Equals, `
@@ -94,7 +94,7 @@ website   2
 	)
 	s.stub.CheckCall(c, 0, "ListResources", []jujuresource.CharmID{
 		{
-			URL:     charm.MustParseURL("cs:a-charm"),
+			URL:     charm.MustParseURL("ch:a-charm"),
 			Channel: corecharm.MustParseChannel("stable"),
 		},
 	})
@@ -114,7 +114,7 @@ func (s *CharmResourcesSuite) TestNoResources(c *gc.C) {
 	s.client.ReturnListResources = [][]charmresource.Resource{{}}
 
 	command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
-	code, stdout, stderr := runCmd(c, command, "cs:a-charm")
+	code, stdout, stderr := runCmd(c, command, "ch:a-charm")
 	c.Check(code, gc.Equals, 0)
 
 	c.Check(stderr, gc.Equals, "No resources to display.\n")
@@ -186,7 +186,7 @@ website   1
 		command := resourcecmd.NewCharmResourcesCommandForTest(s.client)
 		args := []string{
 			"--format", format,
-			"cs:a-charm",
+			"ch:a-charm",
 		}
 		code, stdout, stderr := runCmd(c, command, args...)
 		c.Check(code, gc.Equals, 0)
@@ -210,7 +210,7 @@ func (s *CharmResourcesSuite) TestChannelFlag(c *gc.C) {
 
 	code, _, stderr := runCmd(c, command,
 		"--channel", "development",
-		"cs:a-charm",
+		"ch:a-charm",
 	)
 
 	c.Check(code, gc.Equals, 0)

--- a/cmd/juju/resource/deploy_test.go
+++ b/cmd/juju/resource/deploy_test.go
@@ -40,11 +40,10 @@ func (s *DeploySuite) SetUpTest(c *gc.C) {
 
 func (s DeploySuite) TestDeployResourcesWithoutFiles(c *gc.C) {
 	deps := uploadDeps{stub: s.stub}
-	cURL := charm.MustParseURL("cs:~a-user/trusty/spam-5")
+	cURL := charm.MustParseURL("spam")
 	chID := apiresources.CharmID{
 		URL: cURL,
 	}
-	csMac := &macaroon.Macaroon{}
 	resources := map[string]charmresource.Meta{
 		"store-tarball": {
 			Name: "store-tarball",
@@ -59,12 +58,11 @@ func (s DeploySuite) TestDeployResourcesWithoutFiles(c *gc.C) {
 	}
 
 	ids, err := DeployResources(DeployResourcesArgs{
-		ApplicationID:      "mysql",
-		CharmID:            chID,
-		CharmStoreMacaroon: csMac,
-		ResourceValues:     nil,
-		Client:             deps,
-		ResourcesMeta:      resources,
+		ApplicationID:  "mysql",
+		CharmID:        chID,
+		ResourceValues: nil,
+		Client:         deps,
+		ResourcesMeta:  resources,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -74,7 +72,7 @@ func (s DeploySuite) TestDeployResourcesWithoutFiles(c *gc.C) {
 	})
 
 	s.stub.CheckCallNames(c, "AddPendingResources")
-	s.stub.CheckCall(c, 0, "AddPendingResources", "mysql", chID, csMac, []charmresource.Resource{{
+	s.stub.CheckCall(c, 0, "AddPendingResources", "mysql", chID, []charmresource.Resource{{
 		Meta:     resources["store-tarball"],
 		Origin:   charmresource.OriginStore,
 		Revision: -1,
@@ -87,15 +85,13 @@ func (s DeploySuite) TestDeployResourcesWithoutFiles(c *gc.C) {
 
 func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
 	deps := uploadDeps{stub: s.stub, data: []byte("file contents")}
-	cURL := charm.MustParseURL("cs:~a-user/trusty/spam-5")
+	cURL := charm.MustParseURL("spam")
 	chID := apiresources.CharmID{
 		URL: cURL,
 	}
-	csMac := &macaroon.Macaroon{}
 	du := deployUploader{
 		applicationID: "mysql",
 		chID:          chID,
-		csMac:         csMac,
 		client:        deps,
 		resources: map[string]charmresource.Meta{
 			"upload": {
@@ -131,7 +127,7 @@ func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
 			Revision: -1,
 		},
 	}
-	s.stub.CheckCall(c, 1, "AddPendingResources", "mysql", chID, csMac, expectedStore)
+	s.stub.CheckCall(c, 1, "AddPendingResources", "mysql", chID, expectedStore)
 	s.stub.CheckCall(c, 2, "Open", "foobar.txt")
 
 	expectedUpload := charmresource.Resource{
@@ -143,15 +139,13 @@ func (s DeploySuite) TestUploadFilesOnly(c *gc.C) {
 
 func (s DeploySuite) TestUploadRevisionsOnly(c *gc.C) {
 	deps := uploadDeps{stub: s.stub}
-	cURL := charm.MustParseURL("cs:~a-user/trusty/spam-5")
+	cURL := charm.MustParseURL("spam")
 	chID := apiresources.CharmID{
 		URL: cURL,
 	}
-	csMac := &macaroon.Macaroon{}
 	du := deployUploader{
 		applicationID: "mysql",
 		chID:          chID,
-		csMac:         csMac,
 		client:        deps,
 		resources: map[string]charmresource.Meta{
 			"upload": {
@@ -189,20 +183,18 @@ func (s DeploySuite) TestUploadRevisionsOnly(c *gc.C) {
 		Origin:   charmresource.OriginStore,
 		Revision: -1,
 	}}
-	s.stub.CheckCall(c, 0, "AddPendingResources", "mysql", chID, csMac, expectedStore)
+	s.stub.CheckCall(c, 0, "AddPendingResources", "mysql", chID, expectedStore)
 }
 
 func (s DeploySuite) TestUploadFilesAndRevisions(c *gc.C) {
 	deps := uploadDeps{stub: s.stub, data: []byte("file contents")}
-	cURL := charm.MustParseURL("cs:~a-user/trusty/spam-5")
+	cURL := charm.MustParseURL("spam")
 	chID := apiresources.CharmID{
 		URL: cURL,
 	}
-	csMac := &macaroon.Macaroon{}
 	du := deployUploader{
 		applicationID: "mysql",
 		chID:          chID,
-		csMac:         csMac,
 		client:        deps,
 		resources: map[string]charmresource.Meta{
 			"upload": {
@@ -240,7 +232,7 @@ func (s DeploySuite) TestUploadFilesAndRevisions(c *gc.C) {
 			Revision: 3,
 		},
 	}
-	s.stub.CheckCall(c, 1, "AddPendingResources", "mysql", chID, csMac, expectedStore)
+	s.stub.CheckCall(c, 1, "AddPendingResources", "mysql", chID, expectedStore)
 	s.stub.CheckCall(c, 2, "Open", "foobar.txt")
 
 	expectedUpload := charmresource.Resource{
@@ -408,11 +400,10 @@ password: 'hunter2',,
 			deps.data = []byte(t.fileContents)
 		}
 
-		cURL := charm.MustParseURL("cs:~a-user/mysql-k8s-5")
+		cURL := charm.MustParseURL("mysql-k8s")
 		chID := apiresources.CharmID{
 			URL: cURL,
 		}
-		csMac := &macaroon.Macaroon{}
 		resourceMeta := map[string]charmresource.Meta{
 			"mysql_image": {
 				Name: "mysql_image",
@@ -427,7 +418,6 @@ password: 'hunter2',,
 		du := deployUploader{
 			applicationID: "mysql",
 			chID:          chID,
-			csMac:         csMac,
 			client:        deps,
 			resources:     resourceMeta,
 			filesystem:    deps,
@@ -552,9 +542,9 @@ type uploadDeps struct {
 	data []byte
 }
 
-func (s uploadDeps) AddPendingResources(applicationID string, charmID apiresources.CharmID, csMac *macaroon.Macaroon, resources []charmresource.Resource) (ids []string, err error) {
+func (s uploadDeps) AddPendingResources(applicationID string, charmID apiresources.CharmID, _ *macaroon.Macaroon, resources []charmresource.Resource) (ids []string, err error) {
 	charmresource.Sort(resources)
-	s.stub.AddCall("AddPendingResources", applicationID, charmID, csMac, resources)
+	s.stub.AddCall("AddPendingResources", applicationID, charmID, resources)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, err
 	}

--- a/cmd/juju/resource/list.go
+++ b/cmd/juju/resource/list.go
@@ -60,7 +60,7 @@ func (c *ListCommand) Info() *cmd.Info {
 		Doc: `
 This command shows the resources required by and those in use by an existing
 application or unit in your model.  When run for an application, it will also show any
-updates available for resources from the charmstore.
+updates available for resources from a store.
 `,
 	})
 }

--- a/cmd/juju/resource/list_test.go
+++ b/cmd/juju/resource/list_test.go
@@ -69,7 +69,7 @@ func (s *ShowApplicationSuite) TestInfo(c *gc.C) {
 		Doc: `
 This command shows the resources required by and those in use by an existing
 application or unit in your model.  When run for an application, it will also show any
-updates available for resources from the charmstore.
+updates available for resources from a store.
 `,
 		FlagKnownAs:    "option",
 		ShowSuperFlags: []string{"show-log", "debug", "logging-config", "verbose", "quiet", "h", "help"},

--- a/featuretests/cmd_juju_resources_test.go
+++ b/featuretests/cmd_juju_resources_test.go
@@ -106,7 +106,7 @@ upload-resource   -
 }
 
 func (s *ResourcesCmdSuite) runCharmResourcesCommand(c *gc.C) {
-	charmName := fmt.Sprintf("cs:%s", s.charmName)
+	charmName := fmt.Sprintf("ch:%s", s.charmName)
 	context, err := cmdtesting.RunCommand(c, resource.NewCharmResourcesCommandWithClient(s.client), charmName)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stderr(context), gc.Equals, "")


### PR DESCRIPTION
Remove support for charm store charms from resources command and improve error message if charmstore charm supplied.

The macaroon will be removed from AddPendingResource and the deploy function later. For now they will be ignored if passed.

## QA steps

```sh
$ juju deploy juju-qa-test
$ juju resources juju-qa-test
Resource  Supplied by  Revision
foo-file  charmstore        2
$ juju charm-resources juju-qa-test
Resource  Revision
foo-file  2
$ juju charm-resources cs:ubuntu
ERROR only supported with charm hub charms
```