### PR TITLE
[JUJU-2116]: Store default-base in model-config

### DIFF
--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -389,7 +389,7 @@ func (c *ModelConfigAPI) GetModelConstraints() (params.GetConstraintsResults, er
 	if err != nil {
 		return params.GetConstraintsResults{}, err
 	}
-	return params.GetConstraintsResults{cons}, nil
+	return params.GetConstraintsResults{Constraints: cons}, nil
 }
 
 // SetModelConstraints sets the constraints for the model.

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -57,10 +57,11 @@ func (s *modelconfigSuite) TestAdminModelGet(c *gc.C) {
 	result, err := s.api.ModelGet()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Config, jc.DeepEquals, map[string]params.ConfigValue{
-		"type":          {Value: "dummy", Source: "model"},
-		"ftp-proxy":     {Value: "http://proxy", Source: "model"},
-		"agent-version": {Value: "1.2.3.4", Source: "model"},
-		"charmhub-url":  {Value: "http://meshuggah.rocks", Source: "model"},
+		"type":           {Value: "dummy", Source: "model"},
+		"ftp-proxy":      {Value: "http://proxy", Source: "model"},
+		"agent-version":  {Value: "1.2.3.4", Source: "model"},
+		"charmhub-url":   {Value: "http://meshuggah.rocks", Source: "model"},
+		"default-series": {Value: "", Source: "default"},
 	})
 }
 
@@ -73,10 +74,11 @@ func (s *modelconfigSuite) TestUserModelGet(c *gc.C) {
 	result, err := s.api.ModelGet()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Config, jc.DeepEquals, map[string]params.ConfigValue{
-		"type":          {Value: "dummy", Source: "model"},
-		"ftp-proxy":     {Value: "http://proxy", Source: "model"},
-		"agent-version": {Value: "1.2.3.4", Source: "model"},
-		"charmhub-url":  {Value: "http://meshuggah.rocks", Source: "model"},
+		"type":           {Value: "dummy", Source: "model"},
+		"ftp-proxy":      {Value: "http://proxy", Source: "model"},
+		"agent-version":  {Value: "1.2.3.4", Source: "model"},
+		"charmhub-url":   {Value: "http://meshuggah.rocks", Source: "model"},
+		"default-series": {Value: "", Source: "default"},
 	})
 }
 

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -217,6 +217,7 @@ func (s *modelInfoSuite) expectedModelInfo(c *gc.C, credentialValidity *bool) pa
 		CloudRegion:        "some-region",
 		CloudCredentialTag: "cloudcred-some-cloud_bob_some-credential",
 		DefaultSeries:      jujuversion.DefaultSupportedLTS(),
+		DefaultBase:        jujuversion.DefaultSupportedLTSBase().String(),
 		Life:               life.Dying,
 		Status: params.EntityStatus{
 			Status: status.Destroying,

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/controller/modelmanager"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
@@ -34,6 +35,7 @@ import (
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
 	"github.com/juju/juju/tools"
+	jujuversion "github.com/juju/juju/version"
 )
 
 var (
@@ -882,9 +884,22 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag, withSecrets bool) (pa
 	}
 	if err == nil {
 		info.ProviderType = cfg.Type()
-		info.DefaultSeries = config.PreferredSeries(cfg)
+
 		if agentVersion, exists := cfg.AgentVersion(); exists {
 			info.AgentVersion = &agentVersion
+		}
+
+		// TODO(stickupkid): Series is deprecated, always use a base as the
+		// source of truth.
+		defaultBase := config.PreferredBase(cfg)
+		info.DefaultBase = defaultBase.String()
+		if defaultSeries, err := series.GetSeriesFromBase(defaultBase); err == nil {
+			info.DefaultSeries = defaultSeries
+		} else {
+			logger.Errorf("cannot get default series from base %q: %v", defaultBase, err)
+			// This is slightly defensive, but we should always show a series
+			// in the model info.
+			info.DefaultSeries = jujuversion.DefaultSupportedLTS()
 		}
 	}
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -31446,6 +31446,9 @@
                         "controller-uuid": {
                             "type": "string"
                         },
+                        "default-base": {
+                            "type": "string"
+                        },
                         "default-series": {
                             "type": "string"
                         },

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -390,7 +390,7 @@ func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeries(c *gc.C) {
 }
 
 func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeriesUseDefaultSeries(c *gc.C) {
-	updateAttrs := map[string]interface{}{"default-series": version.DefaultSupportedLTS()}
+	updateAttrs := map[string]interface{}{"default-base": version.DefaultSupportedLTSBase().String()}
 	err := s.Model.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -405,10 +405,10 @@ func (s *DeploySuite) TestDeployFromPathOldCharmMissingSeriesUseDefaultSeries(c 
 }
 
 func (s *DeploySuite) TestDeployFromPathDefaultSeries(c *gc.C) {
-	// multi-series/metadata.yaml provides "focal" as its default series
-	// and yet, here, the model defaults to the series "jammy". This test
+	// multi-series/metadata.yaml provides "focal" as its default base
+	// and yet, here, the model defaults to the base "ubuntu@22.04". This test
 	// asserts that the model's default takes precedence.
-	updateAttrs := map[string]interface{}{"default-series": "jammy"}
+	updateAttrs := map[string]interface{}{"default-base": "ubuntu@22.04"}
 	err := s.Model.UpdateModelConfig(updateAttrs, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	charmDir := testcharms.RepoWithSeries("bionic").ClonedDir(c.MkDir(), "multi-series")

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -425,8 +425,8 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	// argument so users can target a specific origin.
 	origin := c.id.Origin
 	var usingDefaultSeries bool
-	if defaultSeries, ok := modelCfg.DefaultSeries(); ok && origin.Base.Channel.Empty() {
-		base, err := coreseries.GetBaseFromSeries(defaultSeries)
+	if defaultBase, ok := modelCfg.DefaultBase(); ok && origin.Base.Channel.Empty() {
+		base, err := coreseries.ParseBaseFromString(defaultBase)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -74,7 +74,7 @@ func (s *charmSuite) TestRepositoryCharmDeployDryRun(c *gc.C) {
 	defer ctrl.Finish()
 	s.resolver = mocks.NewMockResolver(ctrl)
 	s.expectResolveChannel()
-	s.expectDeployerAPIModelGet(c, "")
+	s.expectDeployerAPIModelGet(c, series.Base{})
 
 	dCharm := s.newDeployCharm()
 	dCharm.dryRun = true
@@ -96,7 +96,7 @@ func (s *charmSuite) TestRepositoryCharmDeployDryRunDefaultSeriesForce(c *gc.C) 
 	defer ctrl.Finish()
 	s.resolver = mocks.NewMockResolver(ctrl)
 	s.expectResolveChannel()
-	s.expectDeployerAPIModelGet(c, "jammy")
+	s.expectDeployerAPIModelGet(c, series.MustParseBaseFromString("ubuntu@22.04"))
 
 	dCharm := s.newDeployCharm()
 	dCharm.dryRun = true
@@ -178,11 +178,11 @@ func (s *charmSuite) expectResolveChannel() {
 		}).AnyTimes()
 }
 
-func (s *charmSuite) expectDeployerAPIModelGet(c *gc.C, defaultSeries string) {
+func (s *charmSuite) expectDeployerAPIModelGet(c *gc.C, defaultBase series.Base) {
 	cfg, err := config.New(true, minimalModelConfig())
 	c.Assert(err, jc.ErrorIsNil)
 	attrs := cfg.AllAttrs()
-	attrs["default-series"] = defaultSeries
+	attrs["default-base"] = defaultBase.String()
 	s.deployerAPI.EXPECT().ModelGet().Return(attrs, nil)
 }
 

--- a/cmd/juju/application/deployer/series_selector_test.go
+++ b/cmd/juju/application/deployer/series_selector_test.go
@@ -29,13 +29,13 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 
 			title: "juju deploy simple   # no default series, no supported series",
 			seriesSelector: seriesSelector{
-				conf: defaultSeries{},
+				conf: defaultBase{},
 			},
 			err: "series not specified and charm does not define any",
 		}, {
 			title: "juju deploy simple   # default series set, no supported series",
 			seriesSelector: seriesSelector{
-				conf:                defaultSeries{"bionic", true},
+				conf:                defaultBase{"ubuntu@18.04", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -43,7 +43,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 		{
 			title: "juju deploy simple with old series  # default series set, no supported series",
 			seriesSelector: seriesSelector{
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: wily not supported",
@@ -52,7 +52,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --series=precise   # default series set, no supported series",
 			seriesSelector: seriesSelector{
 				seriesFlag:          "precise",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: precise not supported",
@@ -60,7 +60,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --series=bionic   # default series set, no supported series, no supported juju series",
 			seriesSelector: seriesSelector{
 				seriesFlag: "bionic",
-				conf:       defaultSeries{"wily", true},
+				conf:       defaultBase{"ubuntu@15.10", true},
 			},
 			err: "expected supported juju series to exist",
 		},
@@ -68,7 +68,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --series=bionic   # default series set, no supported series",
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -77,7 +77,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy trusty/simple   # charm series set, default series set, no supported series",
 			seriesSelector: seriesSelector{
 				charmURLSeries:      "trusty",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: trusty not supported",
@@ -86,7 +86,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy bionic/simple   # charm series set, default series set, no supported series",
 			seriesSelector: seriesSelector{
 				charmURLSeries:      "bionic",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -96,7 +96,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
 				charmURLSeries:      "cosmic",
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -105,7 +105,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy simple --force   # no default series, no supported series, use LTS (jammy)",
 			seriesSelector: seriesSelector{
 				force: true,
-				conf:  defaultSeries{},
+				conf:  defaultBase{},
 			},
 			expectedSeries: "jammy",
 		},
@@ -116,7 +116,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries   # use charm default, nothing specified, no default series",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -125,7 +125,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries with invalid series  # use charm default, nothing specified, no default series",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"precise", "bionic", "cosmic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -134,7 +134,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries with invalid serie  # use charm default, nothing specified, no default series",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"precise"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: `the charm defined series "precise" not supported`,
@@ -143,7 +143,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries   # use charm defaults used if default series doesn't match, nothing specified",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic"},
-				conf:                defaultSeries{"wily", true},
+				conf:                defaultBase{"ubuntu@15.10", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: `series "wily" is not supported, supported series are: bionic,cosmic`,
@@ -152,7 +152,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries   # use model series defaults if supported by charm",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic", "disco"},
-				conf:                defaultSeries{"disco", true},
+				conf:                defaultBase{"ubuntu@19.04", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic", "disco"),
 			},
 			expectedSeries: "disco",
@@ -161,7 +161,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			title: "juju deploy multiseries   # use model series defaults if supported by charm",
 			seriesSelector: seriesSelector{
 				supportedSeries:     []string{"bionic", "cosmic", "disco"},
-				conf:                defaultSeries{"disco", true},
+				conf:                defaultBase{"ubuntu@19.04", true},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: "series: disco not supported",
@@ -171,7 +171,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
 				supportedSeries:     []string{"utopic", "vivid", "bionic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -181,7 +181,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
 				supportedSeries:     []string{"cosmic", "bionic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -191,7 +191,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				seriesFlag:          "bionic",
 				supportedSeries:     []string{"utopic", "vivid"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			err: `series: bionic`,
@@ -202,7 +202,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				seriesFlag:      "bionic",
 				supportedSeries: []string{"utopic", "vivid"},
 				force:           true,
-				conf:            defaultSeries{},
+				conf:            defaultBase{},
 			},
 			err: "expected supported juju series to exist",
 		},
@@ -211,7 +211,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				charmURLSeries:      "bionic",
 				supportedSeries:     []string{"utopic", "vivid", "bionic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "bionic",
@@ -221,7 +221,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 			seriesSelector: seriesSelector{
 				charmURLSeries:  "bionic",
 				supportedSeries: []string{"utopic", "vivid", "bionic"},
-				conf:            defaultSeries{},
+				conf:            defaultBase{},
 			},
 			err: "expected supported juju series to exist",
 		},
@@ -231,7 +231,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				seriesFlag:          "cosmic",
 				charmURLSeries:      "bionic",
 				supportedSeries:     []string{"utopic", "vivid", "bionic", "cosmic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "cosmic",
@@ -242,7 +242,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				seriesFlag:      "cosmic",
 				charmURLSeries:  "bionic",
 				supportedSeries: []string{"bionic", "utopic", "vivid"},
-				conf:            defaultSeries{},
+				conf:            defaultBase{},
 			},
 			err: `series: cosmic`,
 		},
@@ -252,7 +252,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				seriesFlag:          "cosmic",
 				charmURLSeries:      "bionic",
 				supportedSeries:     []string{"bionic", "utopic", "vivid", "cosmic"},
-				conf:                defaultSeries{},
+				conf:                defaultBase{},
 				supportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
 			expectedSeries: "cosmic",
@@ -264,7 +264,7 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				charmURLSeries:  "bionic",
 				supportedSeries: []string{"bionic", "utopic", "vivid"},
 				force:           true,
-				conf:            defaultSeries{},
+				conf:            defaultBase{},
 			},
 			err: "expected supported juju series to exist",
 		},
@@ -286,11 +286,11 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 	}
 }
 
-type defaultSeries struct {
-	series   string
+type defaultBase struct {
+	base     string
 	explicit bool
 }
 
-func (d defaultSeries) DefaultSeries() (string, bool) {
-	return d.series, d.explicit
+func (d defaultBase) DefaultBase() (string, bool) {
+	return d.base, d.explicit
 }

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -108,13 +108,16 @@ address.
     # How often to refresh controller addresses from the API server.
     bootstrap-addresses-delay: 10 # default: 10 seconds
 
-It is possible to override the series Juju attempts to bootstrap on to, by
-supplying a series argument to '--bootstrap-series'.
+It is possible to override the base e.g. ubuntu@22.04, Juju attempts 
+to bootstrap on to, by supplying a base argument to '--bootstrap-base'.
 
-An error is emitted if the determined series is not supported. Using the
+An error is emitted if the determined base is not supported. Using the
 '--force' option to override this check:
 
-	juju bootstrap --bootstrap-series=focal --force
+	juju bootstrap --bootstrap-base=ubuntu@22.04 --force
+
+The '--bootstrap-series' can be still used, but is deprecated in favour
+of '--bootstrap-base'.
 
 Private clouds may need to specify their own custom image metadata and
 tools/agent. Use '--metadata-source' whose value is a local directory.
@@ -179,6 +182,7 @@ Examples:
     juju bootstrap --agent-version=2.2.4 aws joe-us-east-1
     juju bootstrap --config bootstrap-timeout=1200 azure joe-eastus
     juju bootstrap aws --storage-pool name=secret --storage-pool type=ebs --storage-pool encrypted=true
+	juju bootstrap lxd --bootstrap-base=ubuntu@22.04
 
     # For a bootstrap on k8s, setting the service type of the Juju controller service to LoadBalancer
     juju bootstrap --config controller-service-type=loadbalancer
@@ -306,9 +310,9 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Set model constraints")
 	f.StringVar(&c.BootstrapConstraintsStr, "bootstrap-constraints", "", "Specify bootstrap machine constraints")
-	f.StringVar(&c.BootstrapSeries, "bootstrap-series", "", "Specify the series of the bootstrap machine (deprecated use bootstrap-series)")
+	f.StringVar(&c.BootstrapSeries, "bootstrap-series", "", "Specify the series of the bootstrap machine (deprecated use bootstrap-base)")
 	f.StringVar(&c.BootstrapBase, "bootstrap-base", "", "Specify the base of the bootstrap machine")
-	f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine")
+	f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine (requires --bootstrap-constraints specifying architecture)")
 	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build local version of agent binary before bootstrapping")
 	f.StringVar(&c.JujuDbSnapPath, "db-snap", "",
 		"Path to a locally built .snap to use as the internal juju-db service.")
@@ -1725,7 +1729,7 @@ func (c *bootstrapCommand) warnDeprecatedModelConfig(ctx *cmd.Context) error {
 	var reported bool
 	warn := func(attrs map[string]any) {
 		if _, ok := attrs["default-series"]; !reported && ok {
-			ctx.Warningf("default-series configuration option is deprecated, in favour of default-base")
+			ctx.Warningf("default-series configuration option is deprecated in favour of default-base")
 			reported = true
 		}
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1242,6 +1242,24 @@ func (s *BootstrapSuite) TestBootstrapCalledWithMetadataDir(c *gc.C) {
 	c.Assert(bootstrapFuncs.args.MetadataDir, gc.Equals, sourceDir)
 }
 
+func (s *BootstrapSuite) TestBootstrapCalledWitBase(c *gc.C) {
+	sourceDir, _ := createImageMetadata(c)
+	resetJujuXDGDataHome(c)
+
+	var bootstrapFuncs fakeBootstrapFuncs
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrapFuncs
+	})
+
+	cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(),
+		"--metadata-source", sourceDir, "--constraints", "mem=4G",
+		"dummy-cloud/region-1", "devcontroller",
+		"--config", "default-base=ubuntu@22.04",
+	)
+	c.Assert(bootstrapFuncs.args.MetadataDir, gc.Equals, sourceDir)
+}
+
 func (s *BootstrapSuite) checkBootstrapWithVersion(c *gc.C, vers, expect string) {
 	resetJujuXDGDataHome(c)
 
@@ -1270,6 +1288,36 @@ func (s *BootstrapSuite) TestBootstrapWithVersionNumber(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapWithBinaryVersionNumber(c *gc.C) {
 	s.checkBootstrapWithVersion(c, "2.3.4-jammy-ppc64", "2.3.4")
+}
+
+func (s *BootstrapSuite) checkBootstrapBaseWithVersion(c *gc.C, vers, expect string) {
+	resetJujuXDGDataHome(c)
+
+	var bootstrapFuncs fakeBootstrapFuncs
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &bootstrapFuncs
+	})
+
+	num := jujuversion.Current
+	num.Major = 2
+	num.Minor = 3
+	s.PatchValue(&jujuversion.Current, num)
+	cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(),
+		"--agent-version", vers,
+		"dummy-cloud/region-1", "devcontroller",
+		"--config", "default-base=ubuntu@22.04",
+	)
+	c.Assert(bootstrapFuncs.args.AgentVersion, gc.NotNil)
+	c.Assert(*bootstrapFuncs.args.AgentVersion, gc.Equals, version.MustParse(expect))
+}
+
+func (s *BootstrapSuite) TestBootstrapBaseWithVersionNumber(c *gc.C) {
+	s.checkBootstrapBaseWithVersion(c, "2.3.4", "2.3.4")
+}
+
+func (s *BootstrapSuite) TestBootstrapBaseWithBinaryVersionNumber(c *gc.C) {
+	s.checkBootstrapBaseWithVersion(c, "2.3.4-jammy-ppc64", "2.3.4")
 }
 
 func (s *BootstrapSuite) TestBootstrapWithAutoUpgrade(c *gc.C) {
@@ -1567,15 +1615,10 @@ func (s *BootstrapSuite) TestBootstrapProviderManyDetectedCredentials(c *gc.C) {
 
 func (s *BootstrapSuite) TestBootstrapWithBootstrapSeries(c *gc.C) {
 	s.patchVersionAndSeries(c, "jammy")
-	ctx, err := cmdtesting.RunCommand(
+	_, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl", "--bootstrap-series", "spock",
 	)
-	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "Creating Juju controller \"ctrl\" on no-cloud-regions(.|\n)*")
-	c.Assert(err, gc.ErrorMatches, cmd.ErrSilent.Error())
-	c.Check(s.tw.Log(), jc.LogMatches, []jc.SimpleMessage{
-		{loggo.ERROR, "failed to bootstrap model: series \"spock\" not valid"},
-		{loggo.DEBUG, "(error details.*)"},
-	})
+	c.Assert(err, gc.ErrorMatches, `cannot determine base for series "spock"`)
 }
 
 func (s *BootstrapSuite) TestBootstrapWithDeprecatedSeries(c *gc.C) {
@@ -1602,7 +1645,25 @@ func (s *BootstrapSuite) TestBootstrapWithBootstrapSeriesDoesNotUseFallbackButSt
 		"--bootstrap-series", "spock",
 		"--config", "default-series=kirk",
 	)
-	c.Assert(err, gc.ErrorMatches, `series "kirk" not supported`)
+	c.Assert(err, gc.ErrorMatches, `cannot determine base for series "spock"`)
+}
+
+func (s *BootstrapSuite) TestBootstrapBaseWithNoBootstrapSeriesUsesFallbackButStillFails(c *gc.C) {
+	s.patchVersionAndSeries(c, "jammy")
+	_, err := cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl", "--config", "default-base=spock",
+	)
+	c.Assert(err, gc.ErrorMatches, `invalid default base "spock": expected base string to contain os and channel separated by '@'`)
+}
+
+func (s *BootstrapSuite) TestBootstrapBaseWithBootstrapSeriesDoesNotUseFallbackButStillFails(c *gc.C) {
+	s.patchVersionAndSeries(c, "jammy")
+	_, err := cmdtesting.RunCommand(
+		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl",
+		"--bootstrap-base", "spock",
+		"--config", "default-base=kirk",
+	)
+	c.Assert(err, gc.ErrorMatches, `base "spock" not valid`)
 }
 
 func (s *BootstrapSuite) TestBootstrapProviderFileCredential(c *gc.C) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -321,6 +321,7 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 	expected := map[string]interface{}{
 		"name":            bootstrap.ControllerModelName,
 		"type":            "dummy",
+		"default-base":    "ubuntu@22.04/stable",
 		"default-series":  "jammy",
 		"authorized-keys": "public auth key\n",
 		// Dummy provider defaults
@@ -1627,7 +1628,7 @@ func (s *BootstrapSuite) TestBootstrapWithDeprecatedSeries(c *gc.C) {
 		c, s.newBootstrapCommand(), "dummy-cloud-without-regions", "ctrl",
 		"--config", "default-series=bionic",
 	)
-	c.Assert(err, gc.ErrorMatches, `series "bionic" not supported`)
+	c.Assert(err, gc.ErrorMatches, `base "ubuntu@18.04" not supported`)
 }
 
 func (s *BootstrapSuite) TestBootstrapWithNoBootstrapSeriesUsesFallbackButStillFails(c *gc.C) {
@@ -1635,7 +1636,7 @@ func (s *BootstrapSuite) TestBootstrapWithNoBootstrapSeriesUsesFallbackButStillF
 	_, err := cmdtesting.RunCommand(
 		c, s.newBootstrapCommand(), "no-cloud-regions", "ctrl", "--config", "default-series=spock",
 	)
-	c.Assert(err, gc.ErrorMatches, `series "spock" not supported`)
+	c.Assert(err, gc.ErrorMatches, `series "spock" not valid`)
 }
 
 func (s *BootstrapSuite) TestBootstrapWithBootstrapSeriesDoesNotUseFallbackButStillFails(c *gc.C) {

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -96,6 +96,9 @@ the same cloud/region as the controller model. If a region is specified
 without a cloud qualifier, then it is assumed to be in the same cloud
 as the controller model.
 
+When adding --config, the default-series key is deprecated in favour of
+default-base .e.g. ubuntu@22.04.
+
 Examples:
 
     juju add-model mymodel
@@ -627,6 +630,11 @@ func (c *addModelCommand) getConfigValues(ctx *cmd.Context) (map[string]interfac
 	if err := common.FinalizeAuthorizedKeys(ctx, attrs); err != nil {
 		if errors.Cause(err) != common.ErrNoAuthorizedKeys {
 			return nil, errors.Trace(err)
+		}
+	}
+	if _, ok := attrs[config.DefaultSeriesKey]; ok {
+		if _, ok := attrs[config.DefaultBaseKey]; ok {
+			return nil, errors.Errorf("cannot specify both default-series and default-base")
 		}
 	}
 	return attrs, nil

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -64,6 +64,9 @@ from one model to another:
       | juju model-config -c c2 --file=- --ignore-read-only-fields
 You can simultaneously read config from a yaml file and set config keys
 as above. The command-line args will override any values specified in the file.
+
+The default-series key is deprecated in favour of default-base
+e.g. default-base=ubuntu@22.04.
 `
 	modelConfigHelpDocKeys = `
 The following keys are available:
@@ -71,8 +74,8 @@ The following keys are available:
 	modelConfigHelpDocPartTwo = `
 Examples:
 
-Print the value of default-series:
-    juju model-config default-series
+Print the value of default-base:
+    juju model-config default-base
 
 Print the model config of model mycontroller:mymodel:
     juju model-config -m mycontroller:mymodel

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -87,10 +87,10 @@ Set the model config to key=value pairs defined in a file:
     juju model-config --file path/to/file.yaml
 
 Set model config values of a specific model:
-    juju model-config -m othercontroller:mymodel default-series=yakkety test-mode=false
+    juju model-config -m othercontroller:mymodel default-base=ubuntu@22.04 test-mode=false
 
 Reset the values of the provided keys to model defaults:
-    juju model-config --reset default-series,test-mode
+    juju model-config --reset default-base,test-mode
 
 See also:
     models

--- a/cmd/juju/model/config.go
+++ b/cmd/juju/model/config.go
@@ -342,11 +342,6 @@ func (c *configCommand) setConfig(client configCommandAPI, attrs config.Attrs) e
 
 // getConfig writes the value of a single model config key to the cmd.Context.
 func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) error {
-	// if certBytes != nil {
-	// 	_, _ = ctx.Stdout.Write(certBytes)
-	// 	return nil
-	// }
-
 	attrs, err := c.getFilteredModel(client)
 	if err != nil {
 		return err
@@ -355,7 +350,9 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 	if len(c.configBase.KeysToGet) == 0 {
 		return errors.New("c.configBase.KeysToGet is empty")
 	}
-	if value, found := attrs[c.configBase.KeysToGet[0]]; found {
+
+	key := c.configBase.KeysToGet[0]
+	if value, found := attrs[key]; found {
 		if c.out.Name() == "tabular" {
 			// The user has not specified that they want
 			// YAML or JSON formatting, so we print out
@@ -371,7 +368,7 @@ func (c *configCommand) getConfig(client configCommandAPI, ctx *cmd.Context) err
 	// Key not found - error
 	mod, _ := c.ModelIdentifier()
 	return errors.Errorf("%q is not a key of the currently targeted model: %q",
-		c.configBase.KeysToGet[0], mod)
+		key, mod)
 }
 
 // getAllConfig writes the full model config to the cmd.Context.

--- a/cmd/juju/model/defaults.go
+++ b/cmd/juju/model/defaults.go
@@ -104,8 +104,8 @@ us-east-1 region
 Set model default values for the aws cloud as defined in path/to/file.yaml
     juju model-defaults --cloud=aws --file path/to/file.yaml
 
-Reset the value of default-series and test-mode to default
-    juju model-defaults --reset default-series,test-mode
+Reset the value of default-base and test-mode to default
+    juju model-defaults --reset default-base,test-mode
 
 Reset the value of http-proxy for the us-east-1 region to default
     juju model-defaults --region us-east-1 --reset http-proxy

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -101,7 +101,7 @@ func (c *imageMetadataCommand) Info() *cmd.Info {
 }
 
 func (c *imageMetadataCommand) SetFlags(f *gnuflag.FlagSet) {
-	f.StringVar(&c.Series, "s", "", "the charm series")
+	f.StringVar(&c.Series, "s", "", "the charm series (deprecated use bases via -b instead)")
 	f.StringVar(&c.Base, "b", "", "the charm base")
 	f.StringVar(&c.Arch, "a", arch.AMD64, "the image achitecture")
 	f.StringVar(&c.Dir, "d", "", "the destination directory in which to place the metadata files")

--- a/core/charm/repository/charmhub.go
+++ b/core/charm/repository/charmhub.go
@@ -83,7 +83,7 @@ func (c *CharmHubRepository) ResolveWithPreferredChannel(charmURL *charm.URL, ar
 	// refresh API call. The bases can inform the consumer of the API about what
 	// they can also install *IF* the retry resolution uses a base that doesn't
 	// match their requirements. This can happen in the client if the series
-	// selection also wants to consider model-config default-series after the
+	// selection also wants to consider model-config default-base after the
 	// call.
 	var (
 		effectiveChannel  string

--- a/core/series/base.go
+++ b/core/series/base.go
@@ -48,9 +48,24 @@ func ParseBaseFromString(b string) (Base, error) {
 	return Base{OS: parts[0], Channel: channel}, nil
 }
 
+// MustParseBaseFromString is like ParseBaseFromString but panics if the string
+// is invalid.
+func MustParseBaseFromString(b string) Base {
+	base, err := ParseBaseFromString(b)
+	if err != nil {
+		panic(err)
+	}
+	return base
+}
+
 // MakeDefaultBase creates a base from an os and simple version string, eg "22.04".
 func MakeDefaultBase(os string, channel string) Base {
 	return Base{OS: os, Channel: MakeDefaultChannel(channel)}
+}
+
+// Empty returns true if the base is empty.
+func (b Base) Empty() bool {
+	return b.OS == "" && b.Channel.Empty()
 }
 
 func (b Base) String() string {

--- a/core/series/supportedbases.go
+++ b/core/series/supportedbases.go
@@ -1,0 +1,100 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package series
+
+import (
+	"sort"
+	"time"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+)
+
+// ControllerBases returns the supported workload bases available to it at the
+// execution time.
+func ControllerBases(now time.Time, requestedBase Base, imageStream string) ([]Base, error) {
+	return seriesToBase(requestedBase, func(requestedSeries string) (set.Strings, error) {
+		// The DistroInfo is currently in series, so we need to convert it to
+		// base to get the correct series.
+		return ControllerSeries(now, requestedSeries, imageStream)
+	})
+}
+
+// WorkloadBases returns the supported workload bases available to it at the
+// execution time.
+func WorkloadBases(now time.Time, requestedBase Base, imageStream string) ([]Base, error) {
+	return seriesToBase(requestedBase, func(requestedSeries string) (set.Strings, error) {
+		// The DistroInfo is currently in series, so we need to convert it to
+		// base to get the correct series.
+		return WorkloadSeries(now, requestedSeries, imageStream)
+	})
+}
+
+func seriesToBase(requestedBase Base, fn func(string) (set.Strings, error)) ([]Base, error) {
+	var requestedSeries string
+	if !requestedBase.Empty() {
+		var err error
+		requestedSeries, err = GetSeriesFromBase(requestedBase)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	series, err := fn(requestedSeries)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	bases := map[Base]struct{}{}
+	for _, s := range series.Values() {
+		b, err := GetBaseFromSeries(s)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		bases[b] = struct{}{}
+	}
+
+	results := make([]Base, 0, len(bases))
+	for b := range bases {
+		results = append(results, b)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].String() < results[j].String()
+	})
+	return results, nil
+}
+
+// BaseSeriesVersion returns the series version for the given base.
+// TODO(stickupkid): The underlying series version should be a base, until that
+// logic has changes, just convert between base and series.
+func BaseSeriesVersion(base Base) (string, error) {
+	s, err := GetSeriesFromBase(base)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return SeriesVersion(s)
+}
+
+// UbuntuBaseVersion returns the series version for the given base.
+// TODO(stickupkid): The underlying series version should be a base, until that
+// logic has changes, just convert between base and series.
+func UbuntuBaseVersion(base Base) (string, error) {
+	s, err := GetSeriesFromBase(base)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return UbuntuSeriesVersion(s)
+}
+
+// LatestLTSBase returns the latest LTS base.
+// TODO(stickupkid): The underlying series version should be a base, until that
+// logic has changes, just convert between base and series.
+func LatestLTSBase() Base {
+	lts := LatestLTS()
+	b, err := GetBaseFromSeries(lts)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/core/series/supportedbases_test.go
+++ b/core/series/supportedbases_test.go
@@ -1,0 +1,72 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package series
+
+import (
+	"time"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type BasesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&BasesSuite{})
+
+func (s *BasesSuite) TestWorkloadBases(c *gc.C) {
+	tests := []struct {
+		name          string
+		requestedBase Base
+		imageStream   string
+		err           string
+		expectedBase  []Base
+	}{{
+		name:          "no base",
+		requestedBase: Base{},
+		imageStream:   Daily,
+		expectedBase: []Base{
+			MustParseBaseFromString("centos@7/stable"),
+			MustParseBaseFromString("centos@8/stable"),
+			MustParseBaseFromString("centos@9/stable"),
+			MustParseBaseFromString("genericlinux@genericlinux/stable"),
+			MustParseBaseFromString("kubernetes@kubernetes"),
+			MustParseBaseFromString("opensuse@opensuse42/stable"),
+			MustParseBaseFromString("ubuntu@20.04/stable"),
+			MustParseBaseFromString("ubuntu@22.04/stable"),
+		},
+	}, {
+		name:          "requested base",
+		requestedBase: MustParseBaseFromString("ubuntu@22.04"),
+		imageStream:   Daily,
+		expectedBase: []Base{
+			MustParseBaseFromString("centos@7/stable"),
+			MustParseBaseFromString("centos@8/stable"),
+			MustParseBaseFromString("centos@9/stable"),
+			MustParseBaseFromString("genericlinux@genericlinux/stable"),
+			MustParseBaseFromString("kubernetes@kubernetes"),
+			MustParseBaseFromString("opensuse@opensuse42/stable"),
+			MustParseBaseFromString("ubuntu@20.04/stable"),
+			MustParseBaseFromString("ubuntu@22.04/stable"),
+		},
+	}, {
+		name:          "invalid base",
+		requestedBase: MustParseBaseFromString("foo@bar"),
+		imageStream:   Daily,
+		err:           `os "foo" version "bar" not found`,
+	}}
+	for _, test := range tests {
+		c.Logf("test %q", test.name)
+
+		result, err := WorkloadBases(time.Now(), test.requestedBase, test.imageStream)
+		if test.err != "" {
+			c.Assert(err, gc.ErrorMatches, test.err)
+			continue
+		}
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(result, gc.DeepEquals, test.expectedBase)
+	}
+}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -703,7 +703,7 @@ func Bootstrap(
 		var err error
 		bootstrapSeries, err = series.GetSeriesFromBase(args.BootstrapBase)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.NotValidf("base %q", args.BootstrapBase)
 		}
 	}
 	supportedBootstrapSeries := set.NewStrings()

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -70,14 +70,6 @@ type BootstrapParams struct {
 	// ControllerName is the controller name.
 	ControllerName string
 
-	// BootstrapSeries, if specified, is the series to use for the
-	// initial bootstrap machine.
-	BootstrapSeries string
-
-	// SupportedBootstrapSeries is a supported set of series to use for
-	// validating against the bootstrap series.
-	SupportedBootstrapSeries set.Strings
-
 	// BootstrapImage, if specified, is the image ID to use for the
 	// initial bootstrap machine.
 	BootstrapImage string
@@ -180,6 +172,14 @@ type BootstrapParams struct {
 
 	// ExtraAgentValuesForTesting are testing only values written to the agent config file.
 	ExtraAgentValuesForTesting map[string]string
+
+	// BootstrapBase, if specified, is the base to use for the
+	// initial bootstrap machine (deprecated use BootstrapBase).
+	BootstrapBase series.Base
+
+	// SupportedBootstrapBase is a supported set of bases to use for
+	// validating against the bootstrap base.
+	SupportedBootstrapBases []series.Base
 }
 
 // Validate validates the bootstrap parameters.
@@ -196,9 +196,10 @@ func (p BootstrapParams) Validate() error {
 	if p.CAPrivateKey == "" {
 		return errors.New("empty ca-private-key")
 	}
-	if p.SupportedBootstrapSeries == nil || p.SupportedBootstrapSeries.Size() == 0 {
-		return errors.NotValidf("supported bootstrap series")
+	if p.SupportedBootstrapBases == nil || len(p.SupportedBootstrapBases) == 0 {
+		return errors.NotValidf("supported bootstrap bases")
 	}
+
 	// TODO(axw) validate other things.
 	return nil
 }
@@ -247,8 +248,8 @@ func bootstrapCAAS(
 	if args.BootstrapImage != "" {
 		return errors.NotSupportedf("--bootstrap-image when bootstrapping a k8s controller")
 	}
-	if args.BootstrapSeries != "" {
-		return errors.NotSupportedf("--bootstrap-series when bootstrapping a k8s controller")
+	if !args.BootstrapBase.Empty() {
+		return errors.NotSupportedf("--bootstrap-base when bootstrapping a k8s controller")
 	}
 
 	constraintsValidator, err := environ.ConstraintsValidator(callCtx)
@@ -353,9 +354,13 @@ func bootstrapIAAS(
 			return errors.Trace(err)
 		}
 
-		if args.BootstrapSeries == "" && detectedSeries != "" {
-			args.BootstrapSeries = detectedSeries
-			logger.Debugf("auto-selecting bootstrap series %q", args.BootstrapSeries)
+		if args.BootstrapBase.Empty() && detectedSeries != "" {
+			base, err := series.GetBaseFromSeries(detectedSeries)
+			if err != nil {
+				base = jujuversion.DefaultSupportedLTSBase()
+			}
+			args.BootstrapBase = base
+			logger.Debugf("auto-selecting bootstrap series %q", args.BootstrapBase.String())
 		}
 		if args.BootstrapConstraints.Arch == nil && args.ModelConstraints.Arch == nil && detectedHW.Arch != nil {
 			arch := *detectedHW.Arch
@@ -364,20 +369,20 @@ func bootstrapIAAS(
 		}
 	}
 
-	requestedBootstrapSeries, err := series.ValidateSeries(
-		args.SupportedBootstrapSeries,
-		args.BootstrapSeries,
-		config.PreferredSeries(cfg),
+	requestedBootstrapBase, err := series.ValidateBase(
+		args.SupportedBootstrapBases,
+		args.BootstrapBase,
+		config.PreferredBase(cfg),
 	)
 	if !args.Force && err != nil {
 		// If the series isn't valid at all, then don't prompt users to use
 		// the --force flag.
-		if _, err := series.UbuntuSeriesVersion(requestedBootstrapSeries); err != nil {
-			return errors.NotValidf("series %q", requestedBootstrapSeries)
+		if _, err := series.UbuntuBaseVersion(requestedBootstrapBase); err != nil {
+			return errors.NotValidf("base %q", requestedBootstrapBase.String())
 		}
 		return errors.Annotatef(err, "use --force to override")
 	}
-	bootstrapSeries := &requestedBootstrapSeries
+	bootstrapBase := requestedBootstrapBase
 
 	var bootstrapArchForImageSearch string
 	if args.BootstrapConstraints.Arch != nil {
@@ -395,7 +400,7 @@ func bootstrapIAAS(
 	ctx.Verbosef("Loading image metadata")
 	imageMetadata, err := bootstrapImageMetadata(environ,
 		ss,
-		bootstrapSeries,
+		&bootstrapBase,
 		bootstrapArchForImageSearch,
 		args.BootstrapImage,
 		&customImageMetadata,
@@ -467,7 +472,7 @@ func bootstrapIAAS(
 		}
 		ctx.Infof("Looking for %vpackaged Juju agent version %s for %s", latestPatchTxt, versionTxt, bootstrapArch)
 
-		availableTools, err = findPackagedTools(environ, ss, args.AgentVersion, &bootstrapArch, bootstrapSeries)
+		availableTools, err = findPackagedTools(environ, ss, args.AgentVersion, &bootstrapArch, &bootstrapBase)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
@@ -489,7 +494,7 @@ func bootstrapIAAS(
 		if args.BuildAgentTarball == nil {
 			return errors.New("cannot build agent binary to upload")
 		}
-		if err = validateUploadAllowed(environ, &bootstrapArch, bootstrapSeries, constraintsValidator); err != nil {
+		if err = validateUploadAllowed(environ, &bootstrapArch, &bootstrapBase, constraintsValidator); err != nil {
 			return err
 		}
 		if args.BuildAgent {
@@ -690,14 +695,34 @@ func Bootstrap(
 	if err := args.Validate(); err != nil {
 		return errors.Annotate(err, "validating bootstrap parameters")
 	}
+
+	// TODO(stickupkid): Once environs doesn't have a dependency on series, we
+	// can remove this conversion.
+	var bootstrapSeries string
+	if !args.BootstrapBase.Empty() {
+		var err error
+		bootstrapSeries, err = series.GetSeriesFromBase(args.BootstrapBase)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	supportedBootstrapSeries := set.NewStrings()
+	for _, base := range args.SupportedBootstrapBases {
+		s, err := series.GetSeriesFromBase(base)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		supportedBootstrapSeries.Add(s)
+	}
+
 	bootstrapParams := environs.BootstrapParams{
 		CloudName:                  args.Cloud.Name,
 		CloudRegion:                args.CloudRegion,
 		ControllerConfig:           args.ControllerConfig,
 		ModelConstraints:           args.ModelConstraints,
 		StoragePools:               args.StoragePools,
-		BootstrapSeries:            args.BootstrapSeries,
-		SupportedBootstrapSeries:   args.SupportedBootstrapSeries,
+		BootstrapSeries:            bootstrapSeries,
+		SupportedBootstrapSeries:   supportedBootstrapSeries,
 		Placement:                  args.Placement,
 		Force:                      args.Force,
 		ExtraAgentValuesForTesting: args.ExtraAgentValuesForTesting,
@@ -887,7 +912,7 @@ func userPublicSigningKey() (string, error) {
 func bootstrapImageMetadata(
 	environ environs.BootstrapEnviron,
 	fetcher imagemetadata.SimplestreamsFetcher,
-	bootstrapSeries *string,
+	bootstrapBase *series.Base,
 	bootstrapArch string,
 	bootstrapImageId string,
 	customImageMetadata *[]*imagemetadata.ImageMetadata,
@@ -912,10 +937,10 @@ func bootstrapImageMetadata(
 	}
 
 	if bootstrapImageId != "" {
-		if bootstrapSeries == nil {
-			return nil, errors.NotValidf("no series specified with bootstrap image")
+		if bootstrapBase == nil {
+			return nil, errors.NotValidf("no base specified with bootstrap image")
 		}
-		seriesVersion, err := series.SeriesVersion(*bootstrapSeries)
+		seriesVersion, err := series.BaseSeriesVersion(*bootstrapBase)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -249,7 +249,7 @@ func bootstrapCAAS(
 		return errors.NotSupportedf("--bootstrap-image when bootstrapping a k8s controller")
 	}
 	if !args.BootstrapBase.Empty() {
-		return errors.NotSupportedf("--bootstrap-base when bootstrapping a k8s controller")
+		return errors.NotSupportedf("--bootstrap-series or --bootstrap-base when bootstrapping a k8s controller")
 	}
 
 	constraintsValidator, err := environ.ConstraintsValidator(callCtx)

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -302,6 +302,10 @@ const (
 	// explicitly use for charms unless otherwise provided.
 	DefaultSeriesKey = "default-series"
 
+	// DefaultBaseKey is a key for determining the base a model should
+	// explicitly use for charms unless otherwise provided.
+	DefaultBaseKey = "default-base"
+
 	// SecretBackendKey is used to specify the secret backend.
 	SecretBackendKey = "secret-backend"
 )
@@ -370,35 +374,28 @@ func (method HarvestMode) HarvestUnknown() bool {
 	return method&HarvestUnknown != 0
 }
 
-// HasDefaultSeries defines a interface if a type has a default series or not.
-type HasDefaultSeries interface {
-	DefaultSeries() (string, bool)
-}
-
 // GetDefaultSupportedLTS returns the DefaultSupportedLTS.
 // This is exposed for one reason and one reason only; testing!
 // The fact that PreferredSeries doesn't take an argument for a default series
 // as a fallback. We then have to expose this so we can exercise the branching
 // code for other scenarios makes me sad.
-var GetDefaultSupportedLTS = jujuversion.DefaultSupportedLTS
+var GetDefaultSupportedLTSBase = jujuversion.DefaultSupportedLTSBase
 
-// PreferredSeries returns the preferred series to use when a charm does not
-// explicitly specify a series.
-func PreferredSeries(cfg HasDefaultSeries) string {
-	if series, ok := cfg.DefaultSeries(); ok {
-		return series
-	}
-	return GetDefaultSupportedLTS()
+// HasDefaultBase defines a interface if a type has a default base or not.
+type HasDefaultBase interface {
+	DefaultBase() (string, bool)
 }
 
 // PreferredBase returns the preferred base to use when a charm does not
 // explicitly specify a base.
-func PreferredBase(cfg HasDefaultSeries) series.Base {
-	ser, ok := cfg.DefaultSeries()
-	if !ok {
-		return jujuversion.DefaultSupportedLTSBase()
+func PreferredBase(cfg HasDefaultBase) series.Base {
+	base, ok := cfg.DefaultBase()
+	if ok {
+		// We can safely ignore the error here as we know that we have
+		// validated the base when we set it.
+		return series.MustParseBaseFromString(base)
 	}
-	return series.MakeDefaultBase("ubuntu", ser)
+	return GetDefaultSupportedLTSBase()
 }
 
 // Config holds an immutable environment configuration.
@@ -527,7 +524,8 @@ var defaultConfigValues = map[string]interface{}{
 	NetBondReconfigureDelayKey: 17,
 	ContainerNetworkingMethod:  "",
 
-	DefaultSeriesKey:                "",
+	DefaultBaseKey: "",
+
 	ProvisionerHarvestModeKey:       HarvestDestroyed.String(),
 	NumProvisionWorkersKey:          16,
 	NumContainerProvisionWorkersKey: 4,
@@ -838,7 +836,7 @@ func Validate(cfg, old *Config) error {
 		return errors.Trace(err)
 	}
 
-	if err := cfg.validateDefaultSeries(); err != nil {
+	if err := cfg.validateDefaultBase(); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -978,28 +976,39 @@ func (c *Config) DefaultSpace() string {
 	return c.asString(DefaultSpace)
 }
 
-var supportedJujuSeries = series.WorkloadSeries
-
-func (c *Config) validateDefaultSeries() error {
-	defaultSeries, configured := c.DefaultSeries()
+func (c *Config) validateDefaultBase() error {
+	defaultBase, configured := c.DefaultBase()
 	if !configured {
 		return nil
 	}
-	supported, err := supportedJujuSeries(time.Now(), "", "")
+
+	parsedBase, err := series.ParseBaseFromString(defaultBase)
 	if err != nil {
-		return errors.Annotate(err, "cannot read supported series")
+		return errors.Annotatef(err, "invalid default base %q", defaultBase)
 	}
-	logger.Tracef("supported series %s", supported.SortedValues())
-	if !supported.Contains(defaultSeries) {
-		return errors.NotSupportedf("series %q", defaultSeries)
+
+	supported, err := series.WorkloadBases(time.Now(), series.Base{}, "")
+	if err != nil {
+		return errors.Annotate(err, "cannot read supported bases")
+	}
+	logger.Tracef("supported bases %s", supported)
+	var found bool
+	for _, supportedBase := range supported {
+		if parsedBase.IsCompatible(supportedBase) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return errors.NotSupportedf("base %q", defaultBase)
 	}
 	return nil
 }
 
-// DefaultSeries returns the configured default Ubuntu series for the model,
-// and whether the default series was explicitly configured on the environment.
-func (c *Config) DefaultSeries() (string, bool) {
-	s, ok := c.defined[DefaultSeriesKey]
+// DefaultBase returns the configured default base for the model, and whether
+// the default base was explicitly configured on the environment.
+func (c *Config) DefaultBase() (string, bool) {
+	s, ok := c.defined[DefaultBaseKey]
 	if !ok {
 		return "", false
 	}
@@ -1007,7 +1016,7 @@ func (c *Config) DefaultSeries() (string, bool) {
 	case string:
 		return s, s != ""
 	default:
-		logger.Errorf("invalid default-series: %q", s)
+		logger.Errorf("invalid default-base: %q", s)
 		return "", false
 	}
 }
@@ -1772,7 +1781,7 @@ var alwaysOptional = schema.Defaults{
 	AgentMetadataURLKey:             schema.Omit,
 	ContainerImageStreamKey:         schema.Omit,
 	ContainerImageMetadataURLKey:    schema.Omit,
-	DefaultSeriesKey:                schema.Omit,
+	DefaultBaseKey:                  schema.Omit,
 	"development":                   schema.Omit,
 	"ssl-hostname-verification":     schema.Omit,
 	"proxy-ssh":                     schema.Omit,
@@ -2020,8 +2029,8 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
-	DefaultSeriesKey: {
-		Description: "The default series of Ubuntu to use for deploying charms, will act like --series when deploying charms",
+	DefaultBaseKey: {
+		Description: "The default base image to use for deploying charms, will act like --base when deploying charms",
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -374,9 +374,9 @@ func (method HarvestMode) HarvestUnknown() bool {
 	return method&HarvestUnknown != 0
 }
 
-// GetDefaultSupportedLTS returns the DefaultSupportedLTS.
+// GetDefaultSupportedLTSBase returns the DefaultSupportedLTSBase.
 // This is exposed for one reason and one reason only; testing!
-// The fact that PreferredSeries doesn't take an argument for a default series
+// The fact that PreferredBase doesn't take an argument for a default base
 // as a fallback. We then have to expose this so we can exercise the branching
 // code for other scenarios makes me sad.
 var GetDefaultSupportedLTSBase = jujuversion.DefaultSupportedLTSBase

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -1000,7 +1000,7 @@ func (c *Config) validateDefaultBase() error {
 		}
 	}
 	if !found {
-		return errors.NotSupportedf("base %q", defaultBase)
+		return errors.NotSupportedf("base %q", parsedBase.DisplayString())
 	}
 	return nil
 }

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -55,7 +55,7 @@ var sampleConfig = testing.Attrs{
 	"unknown":                    "my-unknown",
 	"ssl-hostname-verification":  true,
 	"development":                false,
-	"default-series":             jujuversion.DefaultSupportedLTS(),
+	"default-base":               jujuversion.DefaultSupportedLTSBase().String(),
 	"disable-network-management": false,
 	"ignore-machine-addresses":   false,
 	"automatically-retry-hooks":  true,
@@ -106,25 +106,25 @@ var configTests = []configTest{
 			"container-image-metadata-url": "container-image-metadata-url-value",
 		}),
 	}, {
-		about:       "Explicit series",
+		about:       "Explicit base",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"default-series": "jammy",
+			"default-base": "ubuntu@20.04",
 		}),
 	}, {
-		about:       "old series",
+		about:       "old base",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"default-series": "bionic",
+			"default-base": "ubuntu@18.04",
 		}),
-		err: `series "bionic" not supported`,
+		err: `base "ubuntu@18.04" not supported`,
 	}, {
-		about:       "bad series",
+		about:       "bad base",
 		useDefaults: config.UseDefaults,
 		attrs: minimalConfigAttrs.Merge(testing.Attrs{
-			"default-series": "my-series",
+			"default-base": "my-series",
 		}),
-		err: `series "my-series" not supported`,
+		err: `invalid default base "my-series": expected base string to contain os and channel separated by '@'`,
 	}, {
 		about:       "Explicit logging",
 		useDefaults: config.UseDefaults,
@@ -413,6 +413,7 @@ var configTests = []configTest{
 			"authorized-keys":            "ssh-rsa mykeys rog@rog-x220\n",
 			"region":                     "us-east-1",
 			"default-series":             "focal",
+			"default-base":               "ubuntu@20.04",
 			"secret-key":                 "a-secret-key",
 			"access-key":                 "an-access-key",
 			"agent-version":              "1.13.2",
@@ -692,14 +693,14 @@ func (test configTest) check(c *gc.C) {
 	dev, _ := test.attrs["development"].(bool)
 	c.Assert(cfg.Development(), gc.Equals, dev)
 
-	seriesAttr, _ := test.attrs["default-series"].(string)
-	defaultSeries, ok := cfg.DefaultSeries()
-	if seriesAttr != "" {
+	baseAttr, _ := test.attrs["default-base"].(string)
+	defaultBase, ok := cfg.DefaultBase()
+	if baseAttr != "" {
 		c.Assert(ok, jc.IsTrue)
-		c.Assert(defaultSeries, gc.Equals, seriesAttr)
+		c.Assert(defaultBase, gc.Equals, baseAttr)
 	} else {
 		c.Assert(ok, jc.IsFalse)
-		c.Assert(defaultSeries, gc.Equals, "")
+		c.Assert(defaultBase, gc.Equals, "")
 	}
 
 	if m, _ := test.attrs["firewall-mode"].(string); m != "" {
@@ -849,7 +850,7 @@ func (s *ConfigSuite) TestConfigAttrs(c *gc.C) {
 		"firewall-mode":              config.FwInstance,
 		"unknown":                    "my-unknown",
 		"ssl-hostname-verification":  true,
-		"default-series":             jujuversion.DefaultSupportedLTS(),
+		"default-base":               jujuversion.DefaultSupportedLTSBase().String(),
 		"disable-network-management": false,
 		"ignore-machine-addresses":   false,
 		"automatically-retry-hooks":  true,

--- a/environs/jujutest/livetests.go
+++ b/environs/jujutest/livetests.go
@@ -217,12 +217,12 @@ func (t *LiveTests) bootstrapParams() bootstrap.BootstrapParams {
 			Regions:   regions,
 			Endpoint:  t.CloudEndpoint,
 		},
-		CloudRegion:              t.CloudRegion,
-		CloudCredential:          &credential,
-		CloudCredentialName:      "credential",
-		AdminSecret:              AdminSecret,
-		CAPrivateKey:             coretesting.CAKey,
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		CloudRegion:             t.CloudRegion,
+		CloudCredential:         &credential,
+		CloudCredentialName:     "credential",
+		AdminSecret:             AdminSecret,
+		CAPrivateKey:            coretesting.CAKey,
+		SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 	}
 }
 

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -217,12 +217,12 @@ func (t *Tests) TestBootstrap(c *gc.C) {
 			Regions:   regions,
 			Endpoint:  t.CloudEndpoint,
 		},
-		CloudRegion:              t.CloudRegion,
-		CloudCredential:          &credential,
-		CloudCredentialName:      "credential",
-		AdminSecret:              AdminSecret,
-		CAPrivateKey:             coretesting.CAKey,
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		CloudRegion:             t.CloudRegion,
+		CloudCredential:         &credential,
+		CloudCredentialName:     "credential",
+		AdminSecret:             AdminSecret,
+		CAPrivateKey:            coretesting.CAKey,
+		SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 	}
 
 	e := t.Prepare(c)

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -72,10 +72,10 @@ func (s *OpenSuite) TestNewDummyEnviron(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	envtesting.UploadFakeTools(c, stor, cfg.AgentStream(), cfg.AgentStream())
 	err = bootstrap.Bootstrap(ctx, env, context.NewEmptyCloudCallContext(), bootstrap.BootstrapParams{
-		ControllerConfig:         controllerCfg,
-		AdminSecret:              "admin-secret",
-		CAPrivateKey:             testing.CAKey,
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        controllerCfg,
+		AdminSecret:             "admin-secret",
+		CAPrivateKey:            testing.CAKey,
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -582,11 +582,11 @@ func (s *JujuConnSuite) setUpConn(c *gc.C) {
 				},
 			},
 		},
-		CloudCredential:          cloudSpec.Credential,
-		CloudCredentialName:      "cred",
-		AdminSecret:              AdminSecret,
-		CAPrivateKey:             testing.CAKey,
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		CloudCredential:         cloudSpec.Credential,
+		CloudCredentialName:     "cred",
+		AdminSecret:             AdminSecret,
+		CAPrivateKey:            testing.CAKey,
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -182,8 +182,13 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 		return errors.Trace(err)
 	}
 
-	preferredSeries := config.PreferredSeries(env.Config())
+	preferredBase := config.PreferredBase(env.Config())
+
 	if params.ImageMetadata == nil {
+		preferredSeries, err := series.GetSeriesFromBase(preferredBase)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		vers, err := imagemetadata.ImageRelease(preferredSeries)
 		if err != nil {
 			return errors.Trace(err)
@@ -201,16 +206,12 @@ func FillInStartInstanceParams(env environs.Environ, machineId string, isControl
 
 	machineNonce := "fake_nonce"
 	apiInfo := FakeAPIInfo(machineId)
-	base, err := series.GetBaseFromSeries(preferredSeries)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	instanceConfig, err := instancecfg.NewInstanceConfig(
 		testing.ControllerTag,
 		machineId,
 		machineNonce,
 		imagemetadata.ReleasedStream,
-		base,
+		preferredBase,
 		apiInfo,
 	)
 	if err != nil {

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -11,6 +11,8 @@ import (
 	cookiejar "github.com/juju/persistent-cookiejar"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/series"
+	"github.com/juju/juju/environs/config"
 )
 
 // MemStore is an in-memory implementation of ClientStore.
@@ -468,6 +470,24 @@ func (c *MemStore) BootstrapConfigForController(controllerName string) (*Bootstr
 	defer c.mu.Unlock()
 
 	if cfg, ok := c.BootstrapConfig[controllerName]; ok {
+		// TODO(stickupkid): This can be removed once series has been removed.
+		// This is here to keep us honest with the tests, although not required.
+		if key, ok := cfg.Config[config.DefaultBaseKey]; ok {
+			if key == nil || key == "" {
+				cfg.Config[config.DefaultSeriesKey] = ""
+			} else {
+				base, err := series.ParseBaseFromString(key.(string))
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+
+				s, err := series.GetSeriesFromBase(base)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				cfg.Config[config.DefaultSeriesKey] = s
+			}
+		}
 		return &cfg, nil
 	}
 	return nil, errors.NotFoundf("bootstrap config for controller %s", controllerName)

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1583,14 +1583,14 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 			ControllerConfig: testing.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
 			CAPrivateKey:     testing.CAKey,
-			BootstrapSeries:  "jammy",
+			BootstrapBase:    coreseries.MustParseBaseFromString("ubuntu@22.04"),
 			BuildAgentTarball: func(
 				build bool, _ string, _ func(version.Number) version.Number,
 			) (*sync.BuiltAgent, error) {
 				c.Assert(build, jc.IsFalse)
 				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
 			},
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	// If we aren't on amd64, this should correctly fail. See also:
@@ -1634,14 +1634,14 @@ func (s *environSuite) TestBootstrapCustomResourceGroup(c *gc.C) {
 			ControllerConfig: testing.FakeControllerConfig(),
 			AdminSecret:      jujutesting.AdminSecret,
 			CAPrivateKey:     testing.CAKey,
-			BootstrapSeries:  "jammy",
+			BootstrapBase:    coreseries.MustParseBaseFromString("ubuntu@22.04"),
 			BuildAgentTarball: func(
 				build bool, _ string, _ func(version.Number) version.Number,
 			) (*sync.BuiltAgent, error) {
 				c.Assert(build, jc.IsFalse)
 				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
 			},
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	// If we aren't on amd64, this should correctly fail. See also:

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -85,31 +85,45 @@ func BootstrapInstance(
 	// no way to make sure that only one succeeds.
 
 	// First thing, ensure we have tools otherwise there's no point.
-	selectedSeries, err := coreseries.ValidateSeries(
-		args.SupportedBootstrapSeries,
-		args.BootstrapSeries,
-		config.PreferredSeries(env.Config()),
+	supportedBootstrapBase := make([]series.Base, len(args.SupportedBootstrapSeries))
+	for i, b := range args.SupportedBootstrapSeries.SortedValues() {
+		sb, err := series.GetBaseFromSeries(b)
+		if err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+		supportedBootstrapBase[i] = sb
+	}
+
+	var bootstrapBase series.Base
+	if args.BootstrapSeries != "" {
+		b, err := series.GetBaseFromSeries(args.BootstrapSeries)
+		if err != nil {
+			return nil, nil, nil, errors.Trace(err)
+		}
+		bootstrapBase = b
+	}
+
+	requestedBootstrapBase, err := coreseries.ValidateBase(
+		supportedBootstrapBase,
+		bootstrapBase,
+		config.PreferredBase(env.Config()),
 	)
 	if !args.Force && err != nil {
-		// If the series isn't valid at all, then don't prompt users to use
+		// If the base isn't valid at all, then don't prompt users to use
 		// the --force flag.
-		if _, err := series.UbuntuSeriesVersion(selectedSeries); err != nil {
-			return nil, nil, nil, errors.NotValidf("series %q", selectedSeries)
+		if _, err := series.UbuntuBaseVersion(requestedBootstrapBase); err != nil {
+			return nil, nil, nil, errors.NotValidf("base %q", requestedBootstrapBase.String())
 		}
 		return nil, nil, nil, errors.Annotatef(err, "use --force to override")
 	}
-	// The series we're attempting to bootstrap is empty, show a friendly
+	// The base we're attempting to bootstrap is empty, show a friendly
 	// error message, rather than the more cryptic error messages that follow
 	// onwards.
-	if selectedSeries == "" {
-		return nil, nil, nil, errors.NotValidf("bootstrap instance series")
-	}
-	selectedBase, err := coreseries.GetBaseFromSeries(selectedSeries)
-	if selectedSeries == "" {
-		return nil, nil, nil, errors.NotValidf("bootstrap instance series %q", selectedSeries)
+	if requestedBootstrapBase.Empty() {
+		return nil, nil, nil, errors.NotValidf("bootstrap instance base")
 	}
 	availableTools, err := args.AvailableTools.Match(coretools.Filter{
-		OSType: selectedBase.OS,
+		OSType: requestedBootstrapBase.OS,
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -117,7 +131,7 @@ func BootstrapInstance(
 
 	// Filter image metadata to the selected series.
 	var imageMetadata []*imagemetadata.ImageMetadata
-	seriesVersion, err := series.SeriesVersion(selectedSeries)
+	seriesVersion, err := series.BaseSeriesVersion(requestedBootstrapBase)
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}
@@ -143,7 +157,7 @@ func BootstrapInstance(
 	}
 	envCfg := env.Config()
 	instanceConfig, err := instancecfg.NewBootstrapInstanceConfig(
-		args.ControllerConfig, args.BootstrapConstraints, args.ModelConstraints, selectedBase, publicKey,
+		args.ControllerConfig, args.BootstrapConstraints, args.ModelConstraints, requestedBootstrapBase, publicKey,
 		args.ExtraAgentValuesForTesting,
 	)
 	if err != nil {
@@ -325,7 +339,7 @@ func BootstrapInstance(
 		}
 		return FinishBootstrap(ctx, client, env, callCtx, result.Instance, icfg, opts)
 	}
-	return result, &selectedBase, finalizer, nil
+	return result, &requestedBootstrapBase, finalizer, nil
 }
 
 func startInstanceZones(env environs.Environ, ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) ([]string, error) {

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -85,11 +85,7 @@ func minimalConfig(c *gc.C) *config.Config {
 }
 
 func minimalConfigWithBase(c *gc.C, base coreseries.Base) *config.Config {
-	series, err := coreseries.GetSeriesFromBase(base)
-	if err != nil {
-		c.Assert(err, jc.ErrorIsNil)
-	}
-
+	series, _ := coreseries.GetSeriesFromBase(base)
 	attrs := map[string]interface{}{
 		"name":               "whatever",
 		"type":               "anything, really",
@@ -278,34 +274,6 @@ func (s *BootstrapSuite) TestBootstrapSeriesWithForce(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result.Arch, gc.Equals, "ppc64el") // based on hardware characteristics
 	c.Check(result.Base.String(), gc.Equals, coreseries.MakeDefaultBase("ubuntu", "16.04").String())
-}
-
-func (s *BootstrapSuite) TestBootstrapSeriesWithForceAndInvalidFallback(c *gc.C) {
-	s.PatchValue(&jujuversion.Current, coretesting.FakeVersionNumber)
-	s.PatchValue(&config.GetDefaultSupportedLTSBase, func() coreseries.Base {
-		return coreseries.Base{}
-	})
-	// We want an invalid fallback to trigger the not valid bootstrap series.
-	var mocksConfig = minimalConfigWithBase(c, coreseries.Base{})
-	getConfig := func() *config.Config {
-		return mocksConfig
-	}
-
-	env := &mockEnviron{
-		startInstance: fakeStartInstance,
-		config:        getConfig,
-	}
-	ctx := envtesting.BootstrapTODOContext(c)
-	bootstrapSeries := ""
-	availableTools := fakeAvailableTools()
-	_, err := common.Bootstrap(ctx, env, s.callCtx, environs.BootstrapParams{
-		ControllerConfig:         coretesting.FakeControllerConfig(),
-		BootstrapSeries:          bootstrapSeries,
-		AvailableTools:           availableTools,
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
-		Force:                    true,
-	})
-	c.Assert(err, gc.ErrorMatches, "bootstrap instance series not valid")
 }
 
 func (s *BootstrapSuite) TestStartInstanceDerivedZone(c *gc.C) {

--- a/provider/dummy/environs_test.go
+++ b/provider/dummy/environs_test.go
@@ -145,9 +145,9 @@ func (s *suite) bootstrapTestEnviron(c *gc.C) environs.NetworkingEnviron {
 				Type:      "dummy",
 				AuthTypes: []cloud.AuthType{cloud.EmptyAuthType},
 			},
-			AdminSecret:              AdminSecret,
-			CAPrivateKey:             testing.CAKey,
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			AdminSecret:             AdminSecret,
+			CAPrivateKey:            testing.CAKey,
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	return netenv

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -39,7 +39,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
-	coreseries "github.com/juju/juju/core/series"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
@@ -477,14 +477,19 @@ func (e *environ) PrecheckInstance(ctx context.ProviderCallContext, args environ
 
 // AgentMetadataLookupParams returns parameters which are used to query agent simple-streams metadata.
 func (e *environ) AgentMetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	series := config.PreferredSeries(e.ecfg())
-	hostOSType := coreseries.DefaultOSTypeNameFromSeries(series)
-	return e.metadataLookupParams(region, hostOSType)
+	base := config.PreferredBase(e.ecfg())
+	return e.metadataLookupParams(region, base.OS)
 }
 
 // ImageMetadataLookupParams returns parameters which are used to query image simple-streams metadata.
 func (e *environ) ImageMetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	release, err := imagemetadata.ImageRelease(config.PreferredSeries(e.ecfg()))
+	base := config.PreferredBase(e.ecfg())
+	baseSeries, err := series.GetSeriesFromBase(base)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	release, err := imagemetadata.ImageRelease(baseSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -348,11 +348,11 @@ func (t *localServerSuite) prepareWithParamsAndBootstrapWithVPCID(c *gc.C, param
 
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			Placement:                "zone=test-available",
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			Placement:               "zone=test-available",
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -376,11 +376,11 @@ func (t *localServerSuite) TestSystemdBootstrapInstanceUserDataAndState(c *gc.C)
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			BootstrapSeries:          coreseries.LatestLTS(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			BootstrapBase:           coreseries.LatestLTSBase(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -450,10 +450,10 @@ func (t *localServerSuite) TestTerminateInstancesIgnoresNotFound(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -529,10 +529,10 @@ func (t *localServerSuite) TestGetTerminatedInstances(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -697,10 +697,10 @@ func (t *localServerSuite) TestInstanceStatus(c *gc.C) {
 	env := t.Prepare(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	t.srv.ec2srv.SetInitialInstanceState(ec2test.Terminated)
@@ -1171,12 +1171,12 @@ func (t *localServerSuite) prepareAndBootstrapWithConfig(c *gc.C, config coretes
 
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			BootstrapConstraints:     constraints,
-			ControllerConfig:         controllerConfig,
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			Placement:                "zone=test-available",
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			BootstrapConstraints:    constraints,
+			ControllerConfig:        controllerConfig,
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			Placement:               "zone=test-available",
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 	return env
@@ -1598,10 +1598,10 @@ func (t *localServerSuite) setUpInstanceWithDefaultVpc(c *gc.C) (environs.Networ
 	env := t.prepareEnviron(c)
 	err := bootstrap.Bootstrap(t.BootstrapContext, env,
 		t.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 		})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/provider/maas/maas_environ_whitebox_test.go
+++ b/provider/maas/maas_environ_whitebox_test.go
@@ -698,10 +698,10 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentError(c *gc.C) {
 	env := suite.makeEnviron(c, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -722,10 +722,10 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentRetry(c *gc.C) {
 	env := suite.makeEnviron(c, nil)
 	bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -746,10 +746,10 @@ func (suite *maasEnvironSuite) TestWaitForNodeDeploymentSucceeds(c *gc.C) {
 	env := suite.makeEnviron(c, nil)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -2261,10 +2261,10 @@ func (suite *maasEnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -2395,8 +2395,8 @@ func (suite *maasEnvironSuite) TestBootstrapFailsIfNoTools(c *gc.C) {
 			CAPrivateKey:     coretesting.CAKey,
 			// Disable auto-uploading by setting the agent version
 			// to something that's not the current version.
-			AgentVersion:             &vers,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			AgentVersion:            &vers,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},
@@ -2411,10 +2411,10 @@ func (suite *maasEnvironSuite) TestBootstrapFailsIfNoNodes(c *gc.C) {
 	env := suite.makeEnviron(c, controller)
 	err := bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		suite.callCtx, bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              jujutesting.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             jujutesting.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 			DialOpts: environs.BootstrapDialOpts{
 				Timeout: coretesting.LongWait,
 			},

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -3344,10 +3344,10 @@ func bootstrapEnvWithConstraints(c *gc.C, env environs.Environ, cons constraints
 	return bootstrap.Bootstrap(envtesting.BootstrapTODOContext(c), env,
 		context.NewEmptyCloudCallContext(),
 		bootstrap.BootstrapParams{
-			ControllerConfig:         coretesting.FakeControllerConfig(),
-			AdminSecret:              testing.AdminSecret,
-			CAPrivateKey:             coretesting.CAKey,
-			SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
-			BootstrapConstraints:     cons,
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             testing.AdminSecret,
+			CAPrivateKey:            coretesting.CAKey,
+			SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
+			BootstrapConstraints:    cons,
 		})
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -45,7 +45,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/firewall"
-	coreseries "github.com/juju/juju/core/series"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
@@ -2210,14 +2210,19 @@ func (e *Environ) terminateInstanceNetworkPorts(id instance.Id) error {
 
 // AgentMetadataLookupParams returns parameters which are used to query agent simple-streams metadata.
 func (e *Environ) AgentMetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	series := config.PreferredSeries(e.ecfg())
-	hostOSType := coreseries.DefaultOSTypeNameFromSeries(series)
-	return e.metadataLookupParams(region, hostOSType)
+	base := config.PreferredBase(e.ecfg())
+	return e.metadataLookupParams(region, base.OS)
 }
 
 // ImageMetadataLookupParams returns parameters which are used to query image simple-streams metadata.
 func (e *Environ) ImageMetadataLookupParams(region string) (*simplestreams.MetadataLookupParams, error) {
-	release, err := imagemetadata.ImageRelease(config.PreferredSeries(e.ecfg()))
+	base := config.PreferredBase(e.ecfg())
+	baseSeries, err := series.GetSeriesFromBase(base)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	release, err := imagemetadata.ImageRelease(baseSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/rpc/params/model.go
+++ b/rpc/params/model.go
@@ -145,7 +145,8 @@ type ModelInfo struct {
 	ControllerUUID     string `json:"controller-uuid"`
 	IsController       bool   `json:"is-controller"`
 	ProviderType       string `json:"provider-type,omitempty"`
-	DefaultSeries      string `json:"default-series,omitempty"`
+	DefaultSeries      string `json:"default-series,omitempty"` // default-series is deprecated, use default-base
+	DefaultBase        string `json:"default-base,omitempty"`
 	CloudTag           string `json:"cloud-tag"`
 	CloudRegion        string `json:"cloud-region,omitempty"`
 	CloudCredentialTag string `json:"cloud-credential-tag,omitempty"`

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -265,7 +265,21 @@ func modelConfig(attrs map[string]interface{}) (*config.Config, error) {
 	// Using MustParse as the value parsed will never change.
 	newer := version.MustParse("2.9.35")
 	if comp := toolsVersion.Compare(newer); comp < 0 {
-		attrs[config.DefaultSeriesKey] = ""
+		attrs[config.DefaultBaseKey] = ""
+		delete(attrs, config.DefaultSeriesKey)
+	}
+
+	if v, ok := attrs[config.DefaultSeriesKey]; ok {
+		if v == "" {
+			attrs[config.DefaultBaseKey] = ""
+		} else {
+			s, err := series.GetBaseFromSeries(v.(string))
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			attrs[config.DefaultBaseKey] = s.String()
+		}
+		delete(attrs, config.DefaultSeriesKey)
 	}
 
 	// Ensure the expected default secret-backend value is set.

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2740,14 +2740,14 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) TestImportingModelWithDefaultSeriesBefore2935(c *gc.C) {
-	defaultSeries, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.7.8"))
-	c.Assert(ok, jc.IsFalse, gc.Commentf("value: %q", defaultSeries))
+	defaultBase, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.7.8"))
+	c.Assert(ok, jc.IsFalse, gc.Commentf("value: %q", defaultBase))
 }
 
 func (s *MigrationImportSuite) TestImportingModelWithDefaultSeriesAfter2935(c *gc.C) {
-	defaultSeries, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.9.35"))
+	defaultBase, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.9.35"))
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(defaultSeries, gc.Equals, "jammy")
+	c.Assert(defaultBase, gc.Equals, "ubuntu@22.04/stable")
 }
 
 func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, toolsVer version.Number) (string, bool) {
@@ -2774,7 +2774,7 @@ func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, tool
 
 	importedCfg, err := imported.Config()
 	c.Assert(err, jc.ErrorIsNil)
-	return importedCfg.DefaultSeries()
+	return importedCfg.DefaultBase()
 }
 
 func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C) {

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/mongo"
@@ -57,6 +58,7 @@ type ModelSummary struct {
 	// Needs Config()
 	ProviderType  string
 	DefaultSeries string
+	DefaultBase   series.Base
 	AgentVersion  *version.Number
 
 	// Needs Statuses collection
@@ -121,8 +123,6 @@ func newProcessorFromModelDocs(st *State, modelDocs []modelDoc, user names.UserT
 			CloudTag:           names.NewCloudTag(doc.Cloud).String(),
 			CloudRegion:        doc.CloudRegion,
 			CloudCredentialTag: cloudCred,
-			/// Users:              make(map[string]UserAccessInfo),
-			/// Machines:           make(map[string]MachineModelInfo),
 		}
 		p.indexByUUID[doc.UUID] = i
 		p.modelUUIDs[i] = doc.UUID
@@ -157,7 +157,14 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 		}
 		detail := &(p.summaries[idx])
 		detail.ProviderType = cfg.Type()
-		detail.DefaultSeries = config.PreferredSeries(cfg)
+		detail.DefaultBase = config.PreferredBase(cfg)
+
+		// TODO(stickupkid): Ensure we fill in the default series for now, we
+		// can switch that out later.
+		if detail.DefaultSeries, err = series.GetSeriesFromBase(detail.DefaultBase); err != nil {
+			return errors.Trace(err)
+		}
+
 		if agentVersion, exists := cfg.AgentVersion(); exists {
 			detail.AgentVersion = &agentVersion
 		}

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/charmhub"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs/config"
 	jujuversion "github.com/juju/juju/version"
 )
@@ -35,6 +36,14 @@ var (
 	// FakeSupportedJujuSeries is used to provide a series of canned results
 	// of series to test bootstrap code against.
 	FakeSupportedJujuSeries = set.NewStrings("focal", "jammy", jujuversion.DefaultSupportedLTS())
+
+	// FakeSupportedJujuBases is used to provide a list of canned results
+	// of a base to test bootstrap code against.
+	FakeSupportedJujuBases = []series.Base{
+		series.MustParseBaseFromString("ubuntu@20.04"),
+		series.MustParseBaseFromString("ubuntu@22.04"),
+		jujuversion.DefaultSupportedLTSBase(),
+	}
 )
 
 // FakeVersionNumber is a valid version number that can be used in testing.

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -236,7 +236,6 @@ if [[ $# -eq 0 ]]; then
 		echo "$(red '---------------------------------------')"
 		echo ""
 		show_help
-		exit 1
 	fi
 fi
 


### PR DESCRIPTION
The basic premise for this change is to start pushing `default-base` through the stack so that we no longer have to depend on `series`. This is one step towards the end goal. This has a lot of changes because we're now stating that we prefer a base over a series.

`default-series` is removed from model-config completely. We swap out the `default-series` when doing a migration import for a `default-base`. This means we only ever store a `default-base`, conversion between a base to a series is done at the API facade layer, and that is to provide backward compatibility. Once series is removed, we can then remove all those base to series conversions.

There is no synchronization happening, we're just using default-base as the source of truth and mandating that you can always go to a series. This keeps the data model clean.

```sh
$ juju model-config -m controller default-base=ubuntu@22.04
$ juju model-config -m controller default-series
jammy
$ juju model-config -m controller default-series=focal
$ juju model-config -m controller default-base
ubuntu@20.04
$ juju model-config -m controller default-base=""
$ juju model-config -m controller default-series

$ juju model-config -m controller default-base

$ juju model-config -m controller default-base=blah@blah
ERROR os "blah" version "blah" not found (not found)
```


Additional work in bootstrap was also required, as the model config forced changes at the CLI. Internally the boostrap args will use bases before it hits the environ bootstrap params. We can push bases through that at another PR.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

### Series not found:

```sh
$ juju bootstrap lxd test --build-agent --model-default default-series=foo
WARNING the default-series configuration option is deprecated, use default-base instead
ERROR series "foo" not supported
```

### Invalid base:

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-base=foo
ERROR base "foo" not valid
```

### Invalid series:

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-series=foo
ERROR cannot determine base for series "foo"
```

### Can not supply both default-series or default-base

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-series=foo --bootstrap-base=bar
ERROR cannot specify both --bootstrap-series and --bootstrap-base
```

### Using a base

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-base=ubuntu@22.04
```

### Using a series

```sh
$ juju bootstrap lxd test --build-agent --bootstrap-series=jammy
```

### Model config whilst bootstrapping:

```sh
$ juju bootstrap lxd test --build-agent --config default-series=focal
```

### Model default whilst bootstrapping:

```sh
$ juju bootstrap lxd test --build-agent --model-default default-series=focal
```

### Model config changes

```sh
$ juju model-config -m controller default-base=ubuntu@22.04
$ juju model-config -m controller default-series
jammy
$ juju model-config -m controller default-series=focal
$ juju model-config -m controller default-base
ubuntu@20.04
$ juju model-config -m controller default-base=""
$ juju model-config -m controller default-series

$ juju model-config -m controller default-base

$ juju model-config -m controller default-base=blah@blah
ERROR os "blah" version "blah" not found (not found)
```

### Deploying with model config

```sh
$ juju add-model default
$ juju model-config default-base=ubuntu@22.04
$ juju deploy ubuntu
Located charm "ubuntu" in charm-hub, revision 21
Deploying "ubuntu" from charm-hub charm "ubuntu", revision 21 in channel stable on ubuntu@22.04/stable
$ juju model-config default-series=focal
$ juju model-config default-base
ubuntu@20.04/stable
$ juju deploy ubuntu ubuntux
Located charm "ubuntu" in charm-hub, revision 21
Deploying "ubuntux" from charm-hub charm "ubuntu", revision 21 in channel stable on ubuntu@20.04/stable
```

## Documentation changes

@tmihoc we're now deprecating `default-series` for `juju bootstrap`, `juju add-model` and in `juju model-config`.

## Jira reference

https://warthogs.atlassian.net/browse/JUJU-2337