### PR TITLE
[JUJU-2332] [JUJU-2338] Add support for secret backend migration

### DIFF
--- a/api/client/secretbackends/client.go
+++ b/api/client/secretbackends/client.go
@@ -69,6 +69,7 @@ func (api *Client) ListSecretBackends(reveal bool) ([]SecretBackend, error) {
 
 // CreateSecretBackend holds details for creating a secret backend.
 type CreateSecretBackend struct {
+	ID                  string
 	Name                string
 	BackendType         string
 	TokenRotateInterval *time.Duration
@@ -80,6 +81,7 @@ func (api *Client) AddSecretBackend(backend CreateSecretBackend) error {
 	var results params.ErrorResults
 	args := params.AddSecretBackendArgs{
 		Args: []params.AddSecretBackendArg{{
+			ID: backend.ID,
 			SecretBackend: params.SecretBackend{
 				Name:                backend.Name,
 				TokenRotateInterval: backend.TokenRotateInterval,

--- a/api/client/secretbackends/client_test.go
+++ b/api/client/secretbackends/client_test.go
@@ -76,6 +76,7 @@ func (s *SecretBackendsSuite) TestListSecretBackends(c *gc.C) {
 
 func (s *SecretBackendsSuite) TestAddSecretsBackend(c *gc.C) {
 	backend := secretbackends.CreateSecretBackend{
+		ID:                  "backend-id",
 		Name:                "foo",
 		BackendType:         "vault",
 		TokenRotateInterval: ptr(666 * time.Minute),
@@ -88,6 +89,7 @@ func (s *SecretBackendsSuite) TestAddSecretsBackend(c *gc.C) {
 		c.Check(request, gc.Equals, "AddSecretBackends")
 		c.Check(arg, jc.DeepEquals, params.AddSecretBackendArgs{
 			Args: []params.AddSecretBackendArg{{
+				ID: "backend-id",
 				SecretBackend: params.SecretBackend{
 					Name:                backend.Name,
 					BackendType:         backend.BackendType,

--- a/apiserver/common/secrets/mocks/state_mock.go
+++ b/apiserver/common/secrets/mocks/state_mock.go
@@ -217,11 +217,12 @@ func (m *MockSecretBackendsStorage) EXPECT() *MockSecretBackendsStorageMockRecor
 }
 
 // CreateSecretBackend mocks base method.
-func (m *MockSecretBackendsStorage) CreateSecretBackend(arg0 state.CreateSecretBackendParams) error {
+func (m *MockSecretBackendsStorage) CreateSecretBackend(arg0 state.CreateSecretBackendParams) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecretBackend", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateSecretBackend indicates an expected call of CreateSecretBackend.

--- a/apiserver/facades/client/secretbackends/mocks/secretsbackendstate.go
+++ b/apiserver/facades/client/secretbackends/mocks/secretsbackendstate.go
@@ -36,11 +36,12 @@ func (m *MockSecretsBackendState) EXPECT() *MockSecretsBackendStateMockRecorder 
 }
 
 // CreateSecretBackend mocks base method.
-func (m *MockSecretsBackendState) CreateSecretBackend(arg0 state.CreateSecretBackendParams) error {
+func (m *MockSecretsBackendState) CreateSecretBackend(arg0 state.CreateSecretBackendParams) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecretBackend", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateSecretBackend indicates an expected call of CreateSecretBackend.

--- a/apiserver/facades/client/secretbackends/state.go
+++ b/apiserver/facades/client/secretbackends/state.go
@@ -14,7 +14,7 @@ import (
 
 // SecretsBackendState is used to access the juju state database.
 type SecretsBackendState interface {
-	CreateSecretBackend(params state.CreateSecretBackendParams) error
+	CreateSecretBackend(params state.CreateSecretBackendParams) (string, error)
 	UpdateSecretBackend(params state.UpdateSecretBackendParams) error
 	DeleteSecretBackend(name string, force bool) error
 	ListSecretBackends() ([]*secrets.SecretBackend, error)

--- a/cmd/juju/secretbackends/add.go
+++ b/cmd/juju/secretbackends/add.go
@@ -30,6 +30,7 @@ type addSecretBackendCommand struct {
 
 	Name        string
 	BackendType string
+	ImportID    string
 
 	// Attributes from a file.
 	ConfigFile cmd.FileVar
@@ -94,6 +95,7 @@ func (c *addSecretBackendCommand) Info() *cmd.Info {
 // SetFlags implements cmd.SetFlags.
 func (c *addSecretBackendCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(&c.ConfigFile, "config", "path to yaml-formatted configuration file")
+	f.StringVar(&c.ImportID, "import-id", "", "add the backend with the specified id")
 }
 
 func (c *addSecretBackendCommand) Init(args []string) error {
@@ -210,6 +212,7 @@ func (c *addSecretBackendCommand) Run(ctxt *cmd.Context) error {
 	}
 
 	backend := secretbackends.CreateSecretBackend{
+		ID:                  c.ImportID,
 		Name:                c.Name,
 		BackendType:         c.BackendType,
 		TokenRotateInterval: tokenRotateInterval,

--- a/cmd/juju/secretbackends/add_test.go
+++ b/cmd/juju/secretbackends/add_test.go
@@ -93,6 +93,24 @@ func (s *AddSuite) TestAdd(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *AddSuite) TestAddWithID(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.addSecretBackendsAPI.EXPECT().AddSecretBackend(
+		apisecretbackends.CreateSecretBackend{
+			ID:          "backend-id",
+			Name:        "myvault",
+			BackendType: "vault",
+			Config:      map[string]interface{}{"endpoint": "http://vault"},
+		}).Return(nil)
+	s.addSecretBackendsAPI.EXPECT().Close().Return(nil)
+
+	_, err := cmdtesting.RunCommand(c, secretbackends.NewAddCommandForTest(s.store, s.addSecretBackendsAPI),
+		"myvault", "vault", "endpoint=http://vault", "--import-id", "backend-id",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *AddSuite) TestAddFromFile(c *gc.C) {
 	defer s.setup(c).Finish()
 

--- a/cmd/juju/secretbackends/list.go
+++ b/cmd/juju/secretbackends/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/utils/v3"
 
 	"github.com/juju/juju/api/client/secretbackends"
 	jujucmd "github.com/juju/juju/cmd"
@@ -137,12 +138,15 @@ func gatherSecretBackendInfo(backends []secretbackends.SecretBackend) map[string
 			Status:              b.Status,
 			Message:             b.Message,
 		}
-		// Only display the ID if there's an error.
+		// Only display the ID if there's an error or it's an external backend.
 		if b.Error != nil {
 			info.ID = b.ID
 			info.Name = "error-" + b.ID
 			info.Status = status.Error
 			info.Error = b.Error.Error()
+		}
+		if !utils.IsValidUUIDString(b.ID) {
+			info.ID = b.ID
 		}
 		if len(b.Config) > 0 {
 			info.Config = make(provider.ConfigAttrs)

--- a/cmd/juju/secretbackends/list_test.go
+++ b/cmd/juju/secretbackends/list_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/cmd/juju/secretbackends/mocks"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/jujuclient"
+	coretesting "github.com/juju/juju/testing"
 )
 
 type ListSuite struct {
@@ -86,6 +87,7 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 
 	s.secretBackendsAPI.EXPECT().ListSecretBackends(true).Return(
 		[]apisecretbackends.SecretBackend{{
+			ID:                  "vault-id",
 			Name:                "myvault",
 			BackendType:         "vault",
 			TokenRotateInterval: ptr(666 * time.Minute),
@@ -94,6 +96,7 @@ func (s *ListSuite) TestListYAML(c *gc.C) {
 			Status:              status.Error,
 			Message:             "vault is sealed",
 		}, {
+			ID:          coretesting.ControllerTag.Id(),
 			Name:        "internal",
 			BackendType: "controller",
 			NumSecrets:  668,
@@ -126,6 +129,7 @@ myvault:
   secrets: 666
   status: error
   message: vault is sealed
+  id: vault-id
 `[1:])
 }
 

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -268,7 +268,6 @@ type AddSecretBackendArg struct {
 	SecretBackend
 	// Include the ID so we can optionally
 	// import existing backend metadata.
-	// TODO(wallyworld)
 	ID string `json:"id,omitempty"`
 }
 


### PR DESCRIPTION
When migrating a model containing secrets stored in external backends, the import step will check that the backend(s) have been set up on the target controller. If not the migrate will abort.

There's also a new `--import-id` option for `add-secret-backend`. You can use `secret-backends --format yaml` to see the backend details including id. You can add a backend to the target controller and pass in the existing id from the source controller. The backend will be added using the existing id (instead of a new one) and so the migrate will work.

NB the import does not check that the target backend config matches the source controller, just that there is a backend with the same id. This info is not available. The user will need to ensure that they add the backend to the target controller with the same config as in the source controller. We could add extra validation to check each and every revision is accessible when the import is done if this is an issue.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

create a model and set up vault
add a secret
migrate the model to the new controller -> error
run secret-backends --format yaml to see the backend id
add vault to the target controller, eg `juju add-secret-backend myvault vault --import-id aaa --config /path/to/config`
migrate the model -> success