### PR TITLE
Remove feature flag from k8s secret test

### DIFF
--- a/tests/suites/secrets_k8s/task.sh
+++ b/tests/suites/secrets_k8s/task.sh
@@ -11,9 +11,6 @@ test_secrets_k8s() {
 
 	file="${TEST_DIR}/test-secrets-k8s.log"
 
-	# TODO: remove feature flag when secret is fully ready.
-	export JUJU_DEV_FEATURE_FLAGS=developer-mode
-
 	bootstrap "test-secrets-k8s" "${file}"
 
 	test_secrets


### PR DESCRIPTION
We no longer need the feature flag for secrets tests.