### PR TITLE
[JUJU-2352] CI test to catch 1999060

### DIFF
--- a/tests/suites/deploy/bundles/multi-app-single-charm.yaml
+++ b/tests/suites/deploy/bundles/multi-app-single-charm.yaml
@@ -1,0 +1,7 @@
+applications:
+  juju-qa-test:
+    charm: juju-qa-test
+    num_units: 1
+  juju-qa-test-dup:
+    charm: juju-qa-test
+    num_units: 1


### PR DESCRIPTION
We should have caught 1999060 in testing before it became a bug, here is the test to do it. 

1999060 is a situation where juju doesn't do the correct thing for charmhub interactions when a bundle has multiple applications using the same charm. The problem was introduce with async charm download. As that type of bundle is common within bundles that Canonical supplies, add a test to ensure we don't regress in the future once the LP is fixed, and to verify the fix.

## QA steps

There are a lot of tests in bundles, you can run on aws or edit the the bundles file to not run all the other tests, just the one created if wanted.

```sh
 (cd tests ; ./main.sh deploy test_deploy_bundles)
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1999060
