### PR TITLE
Set shellcheck minimum severity to report to warning.

### DIFF
--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -1,5 +1,5 @@
 run_shellcheck() {
-	OUT=$(shellcheck --shell=bash tests/main.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
+	OUT=$(shellcheck --shell=bash --severity=warning tests/main.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
 	if [ -n "${OUT}" ]; then
 		echo ""
 		echo "$(red 'Found some issues:')"


### PR DESCRIPTION
As seen in #15001 lint GitHub action for PRs.

shellcheck is starting to pick style concerns in the linter github action, which we do not want. Set the minimum severity to warning to avoid this. Style and info messages will not be reported.

