### PR TITLE
[JUJU-2351] Bootstrap to LXD VM

### DIFF
--- a/apiserver/common/machine.go
+++ b/apiserver/common/machine.go
@@ -189,6 +189,7 @@ func ModelMachineInfo(st ModelManagerBackend) (machineInfo []params.ModelMachine
 				CpuPower:         hw.CpuPower,
 				Tags:             hw.Tags,
 				AvailabilityZone: hw.AvailabilityZone,
+				VirtType:         hw.VirtType,
 			}
 			mInfo.Hardware = hwParams
 		}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -26729,6 +26729,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "virt-type": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -34225,6 +34228,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "virt-type": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -18611,6 +18611,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "virt-type": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false
@@ -31189,6 +31192,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "virt-type": {
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -19,39 +19,10 @@ import (
 	"github.com/lxc/lxd/shared/version"
 
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/network"
 )
-
-// VirtType represents the type of virtualisation used by a container.
-type VirtType = api.InstanceType
-
-const (
-	// DefaultInstanceType is the default instance type to use when no virtType
-	// is specified.
-	DefaultInstanceType = api.InstanceTypeContainer
-)
-
-// ParseVirtType parses a string into a VirtType.
-func ParseVirtType(s string) (VirtType, error) {
-	switch strings.ToLower(s) {
-	case "container", "":
-		return api.InstanceTypeContainer, nil
-	case "virtual-machine":
-		return api.InstanceTypeVM, nil
-	}
-	return "", errors.NotValidf("LXD VirtType %q", s)
-}
-
-// MustParseVirtType returns the VirtType for the given string, or panics if
-// it's not valid.
-func MustParseVirtType(s string) VirtType {
-	v, err := ParseVirtType(s)
-	if err != nil {
-		panic(err)
-	}
-	return v
-}
 
 const (
 	UserNamespacePrefix = "user."
@@ -70,7 +41,7 @@ type ContainerSpec struct {
 	Config       map[string]string
 	Profiles     []string
 	InstanceType string
-	VirtType     VirtType
+	VirtType     instance.VirtType
 }
 
 // minMiBVersion is the minimum LXD version that we are sure will recognise the
@@ -134,7 +105,7 @@ func (c *ContainerSpec) ApplyConstraints(serverVersion string, cons constraints.
 	}
 
 	if cons.HasVirtType() {
-		virtType, err := ParseVirtType(*cons.VirtType)
+		virtType, err := instance.ParseVirtType(*cons.VirtType)
 		if err == nil {
 			c.VirtType = virtType
 		}

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -215,6 +215,14 @@ func (s *Server) AliveContainers(prefix string) ([]Container, error) {
 // FilterContainers retrieves the list of containers from the server and filters
 // them based on the input namespace prefix and any supplied statuses.
 func (s *Server) FilterContainers(prefix string, statuses ...string) ([]Container, error) {
+	// The retry here is required here because when creating a virtual machine
+	// container type, it does not always appear in the list of containers.
+	// There doesn't seem to be a status that's available to us that indicates
+	// that the machine is being created, but not yet quite alive.
+	//
+	// As we're trying to not have any logic that differentiates between
+	// containers and virtual machines, at a higher level, we retry here to
+	// prevent leaking the difference.
 	var containers []Container
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -128,6 +128,11 @@ func (c *Container) Arch() string {
 	return arch.NormaliseArch(c.Architecture)
 }
 
+// VirtType returns the virtualisation type of the container.
+func (c *Container) VirtType() instance.VirtType {
+	return instance.VirtType(c.Type)
+}
+
 // CPUs returns the configured limit for number of container CPU cores.
 // If unset, zero is returned.
 func (c *Container) CPUs() uint {
@@ -338,8 +343,9 @@ func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	c := Container{*container}
-	return &c, nil
+	return &Container{
+		Instance: *container,
+	}, nil
 }
 
 func (s *Server) handleAlreadyExistsError(err error, spec ContainerSpec, ephemeral bool) (*Container, error) {

--- a/container/lxd/container.go
+++ b/container/lxd/container.go
@@ -301,11 +301,12 @@ func (s *Server) ContainerAddresses(name string) ([]corenetwork.ProviderAddress,
 func (s *Server) CreateContainerFromSpec(spec ContainerSpec) (*Container, error) {
 	logger.Infof("starting new container %q (image %q)", spec.Name, spec.Image.Image.Filename)
 	logger.Debugf("new container has profiles %v", spec.Profiles)
+
 	ephemeral := false
 	req := api.InstancesPost{
 		Name:         spec.Name,
 		InstanceType: spec.InstanceType,
-		Type:         spec.VirtType,
+		Type:         instance.NormaliseVirtType(spec.VirtType),
 		InstancePut: api.InstancePut{
 			Architecture: spec.Architecture,
 			Profiles:     spec.Profiles,

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/container/lxd/mocks"
 	lxdtesting "github.com/juju/juju/container/lxd/testing"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/network"
@@ -41,6 +42,12 @@ func (s *containerSuite) TestContainerArch(c *gc.C) {
 	container := lxd.Container{}
 	container.Architecture = lxdArch
 	c.Check(container.Arch(), gc.Equals, arch.AMD64)
+}
+
+func (s *containerSuite) TestContainerVirtType(c *gc.C) {
+	container := lxd.Container{}
+	container.Type = string(instance.DefaultInstanceType)
+	c.Check(container.VirtType(), gc.Equals, api.InstanceTypeContainer)
 }
 
 func (s *containerSuite) TestContainerCPUs(c *gc.C) {

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -737,10 +737,4 @@ func (s *managerSuite) TestSpecApplyConstraints(c *gc.C) {
 	spec.ApplyConstraints("3.10.0", cons)
 	c.Check(spec.Config, gc.DeepEquals, exp)
 	c.Check(spec.InstanceType, gc.Equals, instType)
-
-	// Uses the "MB" suffix.
-	exp["limits.memory"] = "2046MB"
-	spec.ApplyConstraints("2.0.11", cons)
-	c.Check(spec.Config, gc.DeepEquals, exp)
-	c.Check(spec.InstanceType, gc.Equals, instType)
 }

--- a/container/lxd/container_test.go
+++ b/container/lxd/container_test.go
@@ -346,6 +346,7 @@ func (s *containerSuite) TestCreateContainerFromSpecSuccess(c *gc.C) {
 
 	createReq := api.InstancesPost{
 		Name: spec.Name,
+		Type: api.InstanceTypeContainer,
 		InstancePut: api.InstancePut{
 			Profiles:  spec.Profiles,
 			Devices:   spec.Devices,
@@ -410,6 +411,7 @@ func (s *containerSuite) TestCreateContainerFromSpecAlreadyExists(c *gc.C) {
 
 	createReq := api.InstancesPost{
 		Name: spec.Name,
+		Type: api.InstanceTypeContainer,
 		InstancePut: api.InstancePut{
 			Profiles:  spec.Profiles,
 			Devices:   spec.Devices,
@@ -473,6 +475,7 @@ func (s *containerSuite) TestCreateContainerFromSpecAlreadyExistsNotCorrectSpec(
 
 	createReq := api.InstancesPost{
 		Name: spec.Name,
+		Type: api.InstanceTypeContainer,
 		InstancePut: api.InstancePut{
 			Profiles:  spec.Profiles,
 			Devices:   spec.Devices,
@@ -533,6 +536,7 @@ func (s *containerSuite) TestCreateContainerFromSpecStartFailed(c *gc.C) {
 
 	createReq := api.InstancesPost{
 		Name: spec.Name,
+		Type: api.InstanceTypeContainer,
 		InstancePut: api.InstancePut{
 			Profiles:  spec.Profiles,
 			Devices:   spec.Devices,

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -12,6 +12,7 @@ import (
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared/api"
 
+	"github.com/juju/juju/core/instance"
 	jujuos "github.com/juju/juju/core/os"
 	jujuseries "github.com/juju/juju/core/series"
 	"github.com/juju/juju/core/status"
@@ -38,7 +39,7 @@ type SourcedImage struct {
 func (s *Server) FindImage(
 	base jujuseries.Base,
 	arch string,
-	virtType VirtType,
+	virtType instance.VirtType,
 	sources []ServerSpec,
 	copyLocal bool,
 	callback environs.StatusCallbackFunc,
@@ -175,7 +176,7 @@ func (s *Server) CopyRemoteImage(
 // baseLocalAlias returns the alias to assign to images for the
 // specified series. The alias is juju-specific, to support the
 // user supplying a customised image (e.g. CentOS with cloud-init).
-func baseLocalAlias(base, arch string, virtType VirtType) string {
+func baseLocalAlias(base, arch string, virtType instance.VirtType) string {
 	// We use a different alias for VMs, so that we can distinguish between
 	// a VM image and a container image. We don't add anything to the alias
 	// for containers to keep backwards compatibility with older versions
@@ -199,7 +200,7 @@ func baseRemoteAliases(base jujuseries.Base, arch string) ([]string, error) {
 	}, nil
 }
 
-func isCompatibleVirtType(virtType VirtType, instanceType string) bool {
+func isCompatibleVirtType(virtType instance.VirtType, instanceType string) bool {
 	if instanceType == "" && (virtType == api.InstanceTypeAny || virtType == api.InstanceTypeContainer) {
 		return true
 	}

--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -36,7 +36,9 @@ type SourcedImage struct {
 // Copied images will have the juju/series/arch alias added to them.
 // The callback argument is used to report copy progress.
 func (s *Server) FindImage(
-	base jujuseries.Base, arch string,
+	base jujuseries.Base,
+	arch string,
+	virtType VirtType,
 	sources []ServerSpec,
 	copyLocal bool,
 	callback environs.StatusCallbackFunc,
@@ -46,7 +48,7 @@ func (s *Server) FindImage(
 	}
 
 	// First we check if we have the image locally.
-	localAlias := baseLocalAlias(base.DisplayString(), arch)
+	localAlias := baseLocalAlias(base.DisplayString(), arch, virtType)
 	var target string
 	entry, _, err := s.GetImageAlias(localAlias)
 	if err != nil && !IsLXDNotFound(err) {
@@ -57,7 +59,7 @@ func (s *Server) FindImage(
 		// We already have an image with the given alias, so just use that.
 		target = entry.Target
 		image, _, err := s.GetImage(target)
-		if err == nil {
+		if isCompatibleVirtType(virtType, image.Type) && err == nil {
 			logger.Debugf("Found image locally - %q %q", image.Filename, target)
 			return SourcedImage{
 				Image:     image,
@@ -84,7 +86,7 @@ func (s *Server) FindImage(
 			continue
 		}
 		for _, alias := range aliases {
-			if res, _, err := source.GetImageAliasType("container", alias); err == nil && res != nil && res.Target != "" {
+			if res, _, err := source.GetImageAliasType(string(virtType), alias); err == nil && res != nil && res.Target != "" {
 				target = res.Target
 				break
 			}
@@ -173,29 +175,55 @@ func (s *Server) CopyRemoteImage(
 // baseLocalAlias returns the alias to assign to images for the
 // specified series. The alias is juju-specific, to support the
 // user supplying a customised image (e.g. CentOS with cloud-init).
-func baseLocalAlias(base, arch string) string {
-	return fmt.Sprintf("juju/%s/%s", base, arch)
+func baseLocalAlias(base, arch string, virtType VirtType) string {
+	// We use a different alias for VMs, so that we can distinguish between
+	// a VM image and a container image. We don't add anything to the alias
+	// for containers to keep backwards compatibility with older versions
+	// of the image aliases.
+	switch virtType {
+	case api.InstanceTypeVM:
+		return fmt.Sprintf("juju/%s/%s/vm", base, arch)
+	default:
+		return fmt.Sprintf("juju/%s/%s", base, arch)
+	}
 }
 
 // baseRemoteAliases returns the aliases to look for in remotes.
 func baseRemoteAliases(base jujuseries.Base, arch string) ([]string, error) {
+	alias, err := constructBaseRemoteAlias(base, arch)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return []string{
+		alias,
+	}, nil
+}
+
+func isCompatibleVirtType(virtType VirtType, instanceType string) bool {
+	if instanceType == "" && (virtType == api.InstanceTypeAny || virtType == api.InstanceTypeContainer) {
+		return true
+	}
+	return string(virtType) == instanceType
+}
+
+func constructBaseRemoteAlias(base jujuseries.Base, arch string) (string, error) {
 	seriesOS := jujuos.OSTypeForName(base.OS)
 	switch seriesOS {
 	case jujuos.Ubuntu:
-		return []string{path.Join(base.Channel.Track, arch)}, nil
+		return path.Join(base.Channel.Track, arch), nil
 	case jujuos.CentOS:
 		if arch == jujuarch.AMD64 {
 			switch base.Channel.Track {
 			case "7", "8":
-				return []string{fmt.Sprintf("centos/%s/cloud/amd64", base.Channel.Track)}, nil
+				return fmt.Sprintf("centos/%s/cloud/amd64", base.Channel.Track), nil
 			case "9":
-				return []string{"centos/9-Stream/cloud/amd64"}, nil
+				return "centos/9-Stream/cloud/amd64", nil
 			}
 		}
 	case jujuos.OpenSUSE:
 		if base.Channel.Track == "opensuse42" && arch == jujuarch.AMD64 {
-			return []string{"opensuse/42.2/amd64"}, nil
+			return "opensuse/42.2/amd64", nil
 		}
 	}
-	return nil, errors.NotSupportedf("base %q", base.DisplayString())
+	return "", errors.NotSupportedf("base %q", base.DisplayString())
 }

--- a/container/lxd/image_test.go
+++ b/container/lxd/image_test.go
@@ -68,7 +68,7 @@ func (s *imageSuite) TestFindImageLocalServer(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(iSvr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	found, err := jujuSvr.FindImage(series.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), []lxd.ServerSpec{{}}, false, nil)
+	found, err := jujuSvr.FindImage(series.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, []lxd.ServerSpec{{}}, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, iSvr)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -83,7 +83,7 @@ func (s *imageSuite) TestFindImageLocalServerUnknownSeries(c *gc.C) {
 	jujuSvr, err := lxd.NewServer(iSvr)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = jujuSvr.FindImage(series.MakeDefaultBase("pldlinux", "18.04"), s.Arch(), []lxd.ServerSpec{{}}, false, nil)
+	_, err = jujuSvr.FindImage(series.MakeDefaultBase("pldlinux", "18.04"), s.Arch(), lxdapi.InstanceTypeContainer, []lxd.ServerSpec{{}}, false, nil)
 	c.Check(err, gc.ErrorMatches, `base.*pldlinux.*`)
 }
 
@@ -117,7 +117,7 @@ func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 		{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol},
 		{Name: "server-that-should-not-be-touched", Protocol: lxd.LXDProtocol},
 	}
-	found, err := jujuSvr.FindImage(series.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), remotes, false, nil)
+	found, err := jujuSvr.FindImage(series.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, false, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, rSvr2)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -154,7 +154,7 @@ func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 	remotes := []lxd.ServerSpec{
 		{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol},
 	}
-	found, err := jujuSvr.FindImage(series.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), remotes, true, nil)
+	found, err := jujuSvr.FindImage(series.MakeDefaultBase("ubuntu", "16.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, true, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(found.LXDServer, gc.Equals, iSvr)
 	c.Check(*found.Image, gc.DeepEquals, image)
@@ -182,7 +182,7 @@ func (s *imageSuite) TestFindImageRemoteServersNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	remotes := []lxd.ServerSpec{{Name: "server-that-has-image", Protocol: lxd.SimpleStreamsProtocol}}
-	_, err = jujuSvr.FindImage(series.MakeDefaultBase("ubuntu", "18.04"), s.Arch(), remotes, false, nil)
+	_, err = jujuSvr.FindImage(series.MakeDefaultBase("ubuntu", "18.04"), s.Arch(), lxdapi.InstanceTypeContainer, remotes, false, nil)
 	c.Assert(err, gc.ErrorMatches, ".*failed to retrieve image.*")
 }
 

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -196,7 +196,7 @@ func (m *containerManager) getContainerSpec(
 
 	virtType := api.InstanceTypeContainer
 	if cons.HasVirtType() {
-		v, err := ParseVirtType(*cons.VirtType)
+		v, err := instance.ParseVirtType(*cons.VirtType)
 		if err != nil {
 			return ContainerSpec{}, errors.Trace(err)
 		}

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -133,8 +133,16 @@ func (m *containerManager) CreateContainer(
 	}
 	_ = callback(status.Running, "Container started", nil)
 
-	return &lxdInstance{c.Name, m.server.InstanceServer},
-		&instance.HardwareCharacteristics{AvailabilityZone: &m.availabilityZone}, nil
+	virtType := string(spec.VirtType)
+	hardware := &instance.HardwareCharacteristics{
+		AvailabilityZone: &m.availabilityZone,
+		VirtType:         &virtType,
+	}
+
+	return &lxdInstance{
+		id:     c.Name,
+		server: m.server.InstanceServer,
+	}, hardware, nil
 }
 
 // ListContainers implements container.Manager.

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -194,12 +194,21 @@ func (m *containerManager) getContainerSpec(
 		return ContainerSpec{}, errors.Trace(err)
 	}
 
+	virtType := api.InstanceTypeContainer
+	if cons.HasVirtType() {
+		v, err := ParseVirtType(*cons.VirtType)
+		if err != nil {
+			return ContainerSpec{}, errors.Trace(err)
+		}
+		virtType = v
+	}
+
 	// Lock around finding an image.
 	// The provisioner works concurrently to create containers.
 	// If an image needs to be copied from a remote, we don't want many
 	// goroutines attempting to do it at once.
 	m.imageMutex.Lock()
-	found, err := m.server.FindImage(base, jujuarch.HostArch(), imageSources, true, callback)
+	found, err := m.server.FindImage(base, jujuarch.HostArch(), virtType, imageSources, true, callback)
 	m.imageMutex.Unlock()
 	if err != nil {
 		return ContainerSpec{}, errors.Annotatef(err, "acquiring LXD image")

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -329,7 +329,7 @@ func (s *managerSuite) TestListContainers(c *gc.C) {
 		{Name: "nothing-to-see-here-please", Type: "container"},
 	}
 
-	s.cSvr.EXPECT().GetInstances(lxdapi.InstanceTypeContainer).Return(containers, nil)
+	s.cSvr.EXPECT().GetInstances(lxdapi.InstanceTypeAny).Return(containers, nil)
 
 	result, err := s.manager.ListContainers()
 	c.Assert(err, jc.ErrorIsNil)

--- a/core/instance/hardwarecharacteristics_test.go
+++ b/core/instance/hardwarecharacteristics_test.go
@@ -404,10 +404,37 @@ var parseHardwareTests = []parseHardwareTestSpec{
 		err:     `bad "availability-zone" characteristic: already set`,
 	},
 
+	// "virt-type" in detail.
+	{
+		summary: "set virt-type empty",
+		args:    []string{"virt-type="},
+		hc:      &HC{VirtType: nil},
+	}, {
+		summary: "set virt-type non-empty",
+		args:    []string{"virt-type=container"},
+		hc:      &HC{VirtType: stringPtr("container")},
+	}, {
+		summary: "set virt-type quoted",
+		args:    []string{`virt-type="container"`},
+		hc:      &HC{VirtType: stringPtr("container")},
+	}, {
+		summary: "set virt-type quoted multi errors",
+		args:    []string{`virt-type="container",virtual-machine`},
+		err:     `malformed characteristic ",virtual-machine"`,
+	}, {
+		summary: "double set virt-type together",
+		args:    []string{"virt-type=container virt-type=container"},
+		err:     `bad "virt-type" characteristic: already set`,
+	}, {
+		summary: "double set virt-type separately",
+		args:    []string{"virt-type=container", "virt-type="},
+		err:     `bad "virt-type" characteristic: already set`,
+	},
+
 	// Everything at once.
 	{
 		summary: "kitchen sink together",
-		args:    []string{" root-disk=4G mem=2T  arch=i386  cores=4096 cpu-power=9001 availability-zone=a_zone"},
+		args:    []string{" root-disk=4G mem=2T  arch=i386  cores=4096 cpu-power=9001 availability-zone=a_zone virt-type=container"},
 		hc: &HC{
 			RootDisk:         uint64Ptr(4096),
 			Mem:              uint64Ptr(2097152),
@@ -415,10 +442,11 @@ var parseHardwareTests = []parseHardwareTestSpec{
 			CpuCores:         uint64Ptr(4096),
 			CpuPower:         uint64Ptr(9001),
 			AvailabilityZone: stringPtr("a_zone"),
+			VirtType:         stringPtr("container"),
 		},
 	}, {
 		summary: "kitchen sink separately",
-		args:    []string{"root-disk=4G", "mem=2T", "cores=4096", "cpu-power=9001", "arch=armhf", "availability-zone=a_zone"},
+		args:    []string{"root-disk=4G", "mem=2T", "cores=4096", "cpu-power=9001", "arch=armhf", "availability-zone=a_zone", "virt-type=container"},
 		hc: &HC{
 			RootDisk:         uint64Ptr(4096),
 			Mem:              uint64Ptr(2097152),
@@ -426,10 +454,11 @@ var parseHardwareTests = []parseHardwareTestSpec{
 			CpuCores:         uint64Ptr(4096),
 			CpuPower:         uint64Ptr(9001),
 			AvailabilityZone: stringPtr("a_zone"),
+			VirtType:         stringPtr("container"),
 		},
 	}, {
 		summary: "kitchen sink together quoted",
-		args:    []string{`root-disk=4G mem=2T arch=i386 cores=4096 cpu-power=9001 availability-zone="A Zone" tags="a b"`},
+		args:    []string{`root-disk=4G mem=2T arch=i386 cores=4096 cpu-power=9001 availability-zone="A Zone" tags="a b" virt-type="container"`},
 		hc: &HC{
 			RootDisk:         uint64Ptr(4096),
 			Mem:              uint64Ptr(2097152),
@@ -438,6 +467,7 @@ var parseHardwareTests = []parseHardwareTestSpec{
 			CpuPower:         uint64Ptr(9001),
 			AvailabilityZone: stringPtr("A Zone"),
 			Tags:             &[]string{"a b"},
+			VirtType:         stringPtr("container"),
 		},
 	},
 }
@@ -455,7 +485,7 @@ func (s *HardwareSuite) TestParseHardware(c *gc.C) {
 func (s HardwareSuite) TestClone(c *gc.C) {
 	var hcNil *instance.HardwareCharacteristics
 	c.Assert(hcNil.Clone(), gc.IsNil)
-	hc := instance.MustParseHardware("root-disk=4G", "mem=2T", "cores=4096", "cpu-power=9001", "arch=armhf", "availability-zone=a_zone")
+	hc := instance.MustParseHardware("root-disk=4G", "mem=2T", "cores=4096", "cpu-power=9001", "arch=armhf", "availability-zone=a_zone", "virt-type=virtual-machine")
 	hc2 := hc.Clone()
 	c.Assert(hc, jc.DeepEquals, *hc2)
 }

--- a/core/instance/virttype.go
+++ b/core/instance/virttype.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instance
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// VirtType represents the type of virtualisation used by a container.
+type VirtType = api.InstanceType
+
+const (
+	// DefaultInstanceType is the default instance type to use when no virtType
+	// is specified.
+	DefaultInstanceType = api.InstanceTypeContainer
+)
+
+// ParseVirtType parses a string into a VirtType.
+func ParseVirtType(s string) (VirtType, error) {
+	switch strings.ToLower(s) {
+	case "container", "":
+		return api.InstanceTypeContainer, nil
+	case "virtual-machine":
+		return api.InstanceTypeVM, nil
+	}
+	return "", errors.NotValidf("LXD VirtType %q", s)
+}
+
+// MustParseVirtType returns the VirtType for the given string, or panics if
+// it's not valid.
+func MustParseVirtType(s string) VirtType {
+	v, err := ParseVirtType(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/core/instance/virttype.go
+++ b/core/instance/virttype.go
@@ -22,20 +22,36 @@ const (
 // ParseVirtType parses a string into a VirtType.
 func ParseVirtType(s string) (VirtType, error) {
 	switch strings.ToLower(s) {
-	case "container", "":
+	case "container":
 		return api.InstanceTypeContainer, nil
 	case "virtual-machine":
 		return api.InstanceTypeVM, nil
+	case "":
+		// Constraints are optional and the absence of a constraint will
+		// fallback to the default instance type (container). This allows
+		// adding a machine without specifying a virt-type.
+		return DefaultInstanceType, nil
 	}
 	return "", errors.NotValidf("LXD VirtType %q", s)
 }
 
 // MustParseVirtType returns the VirtType for the given string, or panics if
 // it's not valid.
+// Only use this in tests.
 func MustParseVirtType(s string) VirtType {
 	v, err := ParseVirtType(s)
 	if err != nil {
 		panic(err)
 	}
 	return v
+}
+
+// NormaliseVirtType converts the any type, which represents an unspecified
+// virtual type to a container type. Juju doesn't current support the idea of
+// selecting any type of container type.
+func NormaliseVirtType(virtType api.InstanceType) api.InstanceType {
+	if virtType == api.InstanceTypeAny {
+		return api.InstanceTypeContainer
+	}
+	return virtType
 }

--- a/core/instance/virttype.go
+++ b/core/instance/virttype.go
@@ -46,7 +46,7 @@ func MustParseVirtType(s string) VirtType {
 	return v
 }
 
-// NormaliseVirtType converts the any type, which represents an unspecified
+// NormaliseVirtType converts the "any" type, which represents an unspecified
 // virtual type to a container type. Juju doesn't current support the idea of
 // selecting any type of container type.
 func NormaliseVirtType(virtType api.InstanceType) api.InstanceType {

--- a/core/instance/virttype_test.go
+++ b/core/instance/virttype_test.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package instance
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/lxc/lxd/shared/api"
+	gc "gopkg.in/check.v1"
+)
+
+type VirtTypeSuite struct{}
+
+var _ = gc.Suite(&VirtTypeSuite{})
+
+func (s *VirtTypeSuite) TestParseVirtType(c *gc.C) {
+	parseVirtTypeTests := []struct {
+		arg   string
+		value VirtType
+		err   string
+	}{{
+		arg:   "",
+		value: DefaultInstanceType,
+	}, {
+		arg:   "container",
+		value: api.InstanceTypeContainer,
+	}, {
+		arg:   "virtual-machine",
+		value: api.InstanceTypeVM,
+	}, {
+		arg: "foo",
+		err: `LXD VirtType "foo" not valid`,
+	}}
+	for i, t := range parseVirtTypeTests {
+		c.Logf("test %d: %s", i, t.arg)
+		v, err := ParseVirtType(t.arg)
+		if t.err == "" {
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(v, gc.Equals, t.value)
+		} else {
+			c.Check(err, gc.ErrorMatches, t.err)
+		}
+	}
+}

--- a/core/instance/virttype_test.go
+++ b/core/instance/virttype_test.go
@@ -42,3 +42,24 @@ func (s *VirtTypeSuite) TestParseVirtType(c *gc.C) {
 		}
 	}
 }
+
+func (s *VirtTypeSuite) TestNormaliseVirtType(c *gc.C) {
+	virtTypes := []struct {
+		arg      VirtType
+		expected VirtType
+	}{{
+		arg:      api.InstanceTypeAny,
+		expected: api.InstanceTypeContainer,
+	}, {
+		arg:      api.InstanceTypeContainer,
+		expected: api.InstanceTypeContainer,
+	}, {
+		arg:      api.InstanceTypeVM,
+		expected: api.InstanceTypeVM,
+	}}
+	for i, t := range virtTypes {
+		c.Logf("test %d: %s", i, t.arg)
+		v := NormaliseVirtType(t.arg)
+		c.Check(v, gc.Equals, t.expected)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/juju/clock v1.0.2
 	github.com/juju/cmd/v3 v3.0.2
 	github.com/juju/collections v1.0.1
-	github.com/juju/description/v4 v4.0.3
+	github.com/juju/description/v4 v4.0.4
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -767,8 +767,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.1 h1:H2NjGyWYNYVX0SGx5sLARPF6pGqzSTvKIE0HUlOYyCQ=
 github.com/juju/collections v1.0.1/go.mod h1:kYJowQZYtHDvYDfZOvgf3Mt7mjKYwm/k1nqnJoMYOUc=
-github.com/juju/description/v4 v4.0.3 h1:kUYMZA73XehUrRCt9v+TOQZIwUdffBPe0YIpZK76Z3Q=
-github.com/juju/description/v4 v4.0.3/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
+github.com/juju/description/v4 v4.0.4 h1:cyAMrylcmtR8iU/Y1F5awkYjYFKecw16INcS9GUS9V8=
+github.com/juju/description/v4 v4.0.4/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -387,6 +387,10 @@ func formatHardware(hw *instance.HardwareCharacteristics) string {
 	if hw.CpuCores != nil && *hw.CpuCores > 0 {
 		out = append(out, fmt.Sprintf("cores=%d", *hw.CpuCores))
 	}
+	// If the virt-type is the default, don't print it out, as it's just noise.
+	if hw.VirtType != nil && *hw.VirtType != "" && *hw.VirtType != string(instance.DefaultInstanceType) {
+		out = append(out, fmt.Sprintf("virt-type=%s", *hw.VirtType))
+	}
 	return strings.Join(out, " ")
 }
 

--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -965,16 +965,29 @@ func (s *FormatHardwareSuite) TestMem(c *gc.C) {
 	s.check(c, &instance.HardwareCharacteristics{Mem: &mem}, "mem=2.6G")
 }
 
+func (s *FormatHardwareSuite) TestVirtType(c *gc.C) {
+	var virtType string
+	s.check(c, &instance.HardwareCharacteristics{VirtType: &virtType}, "")
+	virtType = string(instance.DefaultInstanceType)
+	s.check(c, &instance.HardwareCharacteristics{VirtType: &virtType}, "")
+	virtType = "virtual-machine"
+	s.check(c, &instance.HardwareCharacteristics{VirtType: &virtType}, "virt-type=virtual-machine")
+}
+
 func (s *FormatHardwareSuite) TestAll(c *gc.C) {
-	arch := "ppc64"
-	var cores uint64 = 2
-	var mem uint64 = 123
+	var (
+		arch            = "ppc64"
+		cores    uint64 = 2
+		mem      uint64 = 123
+		virtType        = "virtual-machine"
+	)
 	hw := &instance.HardwareCharacteristics{
 		Arch:     &arch,
 		CpuCores: &cores,
 		Mem:      &mem,
+		VirtType: &virtType,
 	}
-	s.check(c, hw, "arch=ppc64 mem=123M cores=2")
+	s.check(c, hw, "arch=ppc64 mem=123M cores=2 virt-type=virtual-machine")
 }
 
 func fakeAvailableTools() tools.List {

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -408,6 +408,7 @@ func (env *environ) getHardwareCharacteristics(
 		Arch:     &archStr,
 		CpuCores: &cores,
 		Mem:      &mem,
+		VirtType: &container.Type,
 	}
 }
 

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -57,7 +57,7 @@ func (env *environ) StartInstance(
 	return &result, nil
 }
 
-func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (string, lxd.VirtType, error) {
+func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (string, instance.VirtType, error) {
 	// Use the HostArch to determine the tools to use.
 	arch := env.server().HostArch()
 	tools, err := args.Tools.Match(tools.Filter{Arch: arch})
@@ -70,9 +70,9 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (str
 
 	// Parse the virt-type from the constraints, so we can pass it to the
 	// findImage function.
-	virtType := lxd.DefaultInstanceType
+	virtType := instance.DefaultInstanceType
 	if args.Constraints.HasVirtType() {
-		if virtType, err = lxd.ParseVirtType(*args.Constraints.VirtType); err != nil {
+		if virtType, err = instance.ParseVirtType(*args.Constraints.VirtType); err != nil {
 			return "", "", errors.Trace(err)
 		}
 	}
@@ -90,7 +90,7 @@ func (env *environ) newContainer(
 	ctx context.ProviderCallContext,
 	args environs.StartInstanceParams,
 	arch string,
-	virtType lxd.VirtType,
+	virtType instance.VirtType,
 ) (*lxd.Container, error) {
 	// Note: other providers have the ImageMetadata already read for them
 	// and passed in as args.ImageMetadata. However, lxd provider doesn't

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -32,12 +32,12 @@ func (env *environ) StartInstance(
 ) (*environs.StartInstanceResult, error) {
 	logger.Debugf("StartInstance: %q, %s", args.InstanceConfig.MachineId, args.InstanceConfig.Base)
 
-	arch, err := env.finishInstanceConfig(args)
+	arch, virtType, err := env.finishInstanceConfig(args)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	container, err := env.newContainer(ctx, args, arch)
+	container, err := env.newContainer(ctx, args, arch, virtType)
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		if args.StatusCallback != nil {
@@ -57,19 +57,30 @@ func (env *environ) StartInstance(
 	return &result, nil
 }
 
-func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (string, error) {
+func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (string, lxd.VirtType, error) {
+	// Use the HostArch to determine the tools to use.
 	arch := env.server().HostArch()
 	tools, err := args.Tools.Match(tools.Filter{Arch: arch})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", "", errors.Trace(err)
 	}
 	if err := args.InstanceConfig.SetTools(tools); err != nil {
-		return "", errors.Trace(err)
+		return "", "", errors.Trace(err)
 	}
+
+	// Parse the virt-type from the constraints, so we can pass it to the
+	// findImage function.
+	var virtType lxd.VirtType
+	if args.Constraints.HasVirtType() {
+		if virtType, err = lxd.ParseVirtType(*args.Constraints.VirtType); err != nil {
+			return "", "", errors.Trace(err)
+		}
+	}
+
 	if err := instancecfg.FinishInstanceConfig(args.InstanceConfig, env.Config()); err != nil {
-		return "", errors.Trace(err)
+		return "", "", errors.Trace(err)
 	}
-	return arch, nil
+	return arch, virtType, nil
 }
 
 // newContainer is where the new physical instance is actually
@@ -79,6 +90,7 @@ func (env *environ) newContainer(
 	ctx context.ProviderCallContext,
 	args environs.StartInstanceParams,
 	arch string,
+	virtType lxd.VirtType,
 ) (*lxd.Container, error) {
 	// Note: other providers have the ImageMetadata already read for them
 	// and passed in as args.ImageMetadata. However, lxd provider doesn't
@@ -112,7 +124,7 @@ func (env *environ) newContainer(
 		return nil, errors.Trace(err)
 	}
 
-	image, err := target.FindImage(args.InstanceConfig.Base, arch, imageSources, true, statusCallback)
+	image, err := target.FindImage(args.InstanceConfig.Base, arch, virtType, imageSources, true, statusCallback)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -70,7 +70,7 @@ func (env *environ) finishInstanceConfig(args environs.StartInstanceParams) (str
 
 	// Parse the virt-type from the constraints, so we can pass it to the
 	// findImage function.
-	var virtType lxd.VirtType
+	virtType := lxd.DefaultInstanceType
 	if args.Constraints.HasVirtType() {
 		if virtType, err = lxd.ParseVirtType(*args.Constraints.VirtType); err != nil {
 			return "", "", errors.Trace(err)

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -92,7 +92,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -131,7 +131,7 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -203,7 +203,7 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(profileNICs, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -384,7 +384,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -429,7 +429,7 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
@@ -466,7 +466,7 @@ func (s *environBrokerSuite) TestStartInstanceInvalidCredentials(c *gc.C) {
 	exp := svr.EXPECT()
 	gomock.InOrder(
 		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
 		exp.CreateContainerFromSpec(gomock.Any()).Return(&containerlxd.Container{}, fmt.Errorf("not authorized")),

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -424,14 +424,12 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndVirtType(c *gc.C
 	}
 
 	exp := svr.EXPECT()
-	gomock.InOrder(
-		exp.HostArch().Return(arch.AMD64),
-		exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeVM, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
-		exp.ServerVersion().Return("3.10.0"),
-		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
-		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil),
-		exp.HostArch().Return(arch.AMD64),
-	)
+	exp.HostArch().Return(arch.AMD64)
+	exp.FindImage(series.MakeDefaultBase("ubuntu", "22.04"), arch.AMD64, api.InstanceTypeVM, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil)
+	exp.ServerVersion().Return("3.10.0")
+	exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil)
+	exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{}, nil)
+	exp.HostArch().Return(arch.AMD64)
 
 	args := s.GetStartInstanceArgs(c)
 	cores := uint64(2)

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -21,7 +21,6 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 var unsupportedConstraints = []string{
 	constraints.CpuPower,
 	constraints.Tags,
-	constraints.VirtType,
 	constraints.Container,
 	constraints.AllocatePublicIP,
 }

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -32,6 +32,7 @@ func (env *environ) ConstraintsValidator(ctx context.ProviderCallContext) (const
 
 	validator.RegisterUnsupported(unsupportedConstraints)
 	validator.RegisterVocabulary(constraints.Arch, env.server().SupportedArches())
+	validator.RegisterVocabulary(constraints.VirtType, []string{"", "container", "virtual-machine"})
 
 	return validator, nil
 }

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -135,7 +135,6 @@ func (s *environPolicySuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 		"instance-type=some-type",
 		"cores=2",
 		"cpu-power=250",
-		"virt-type=kvm",
 	}, " "))
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
@@ -143,7 +142,6 @@ func (s *environPolicySuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	expected := []string{
 		"tags",
 		"cpu-power",
-		"virt-type",
 	}
 	c.Check(unsupported, jc.SameContents, expected)
 }

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -97,13 +97,39 @@ func (s *environPolicySuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `availability zone "a-zone" not valid`)
 }
 
-func (s *environPolicySuite) TestConstraintsValidatorOkay(c *gc.C) {
+func (s *environPolicySuite) TestConstraintsValidatorArch(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	validator, err := s.env.ConstraintsValidator(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("arch=amd64")
+	unsupported, err := validator.Validate(cons)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(unsupported, gc.HasLen, 0)
+}
+
+func (s *environPolicySuite) TestConstraintsValidatorVirtType(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	validator, err := s.env.ConstraintsValidator(s.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons := constraints.MustParse("virt-type=container")
+	unsupported, err := validator.Validate(cons)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(unsupported, gc.HasLen, 0)
+}
+
+func (s *environPolicySuite) TestConstraintsValidatorEmptyVirtType(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	validator, err := s.env.ConstraintsValidator(s.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons := constraints.MustParse("virt-type=")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -135,6 +161,7 @@ func (s *environPolicySuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 		"instance-type=some-type",
 		"cores=2",
 		"cpu-power=250",
+		"virt-type=virtual-machine",
 	}, " "))
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/lxd/package_mock_test.go
+++ b/provider/lxd/package_mock_test.go
@@ -260,18 +260,18 @@ func (mr *MockServerMockRecorder) FilterContainers(arg0 interface{}, arg1 ...int
 }
 
 // FindImage mocks base method.
-func (m *MockServer) FindImage(arg0 series.Base, arg1 string, arg2 []lxd.ServerSpec, arg3 bool, arg4 environs.StatusCallbackFunc) (lxd.SourcedImage, error) {
+func (m *MockServer) FindImage(arg0 series.Base, arg1 string, arg2 api.InstanceType, arg3 []lxd.ServerSpec, arg4 bool, arg5 environs.StatusCallbackFunc) (lxd.SourcedImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(lxd.SourcedImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindImage indicates an expected call of FindImage.
-func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // GetCertificate mocks base method.

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/container/lxd"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs"
@@ -35,7 +36,7 @@ import (
 // Server defines an interface of all localized methods that the environment
 // and provider utilizes.
 type Server interface {
-	FindImage(series.Base, string, lxd.VirtType, []lxd.ServerSpec, bool, environs.StatusCallbackFunc) (lxd.SourcedImage, error)
+	FindImage(series.Base, string, instance.VirtType, []lxd.ServerSpec, bool, environs.StatusCallbackFunc) (lxd.SourcedImage, error)
 	GetServer() (server *lxdapi.Server, ETag string, err error)
 	ServerVersion() string
 	GetConnectionInfo() (info *lxdclient.ConnectionInfo, err error)

--- a/provider/lxd/server.go
+++ b/provider/lxd/server.go
@@ -35,7 +35,7 @@ import (
 // Server defines an interface of all localized methods that the environment
 // and provider utilizes.
 type Server interface {
-	FindImage(series.Base, string, []lxd.ServerSpec, bool, environs.StatusCallbackFunc) (lxd.SourcedImage, error)
+	FindImage(series.Base, string, lxd.VirtType, []lxd.ServerSpec, bool, environs.StatusCallbackFunc) (lxd.SourcedImage, error)
 	GetServer() (server *lxdapi.Server, ETag string, err error)
 	ServerVersion() string
 	GetConnectionInfo() (info *lxdclient.ConnectionInfo, err error)

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -421,7 +421,7 @@ func (conn *StubClient) CreateContainerFromSpec(spec lxd.ContainerSpec) (*lxd.Co
 }
 
 func (conn *StubClient) FindImage(
-	base series.Base, arch string, sources []lxd.ServerSpec, copyLocal bool, callback environs.StatusCallbackFunc,
+	base series.Base, arch string, virtType lxd.VirtType, sources []lxd.ServerSpec, copyLocal bool, callback environs.StatusCallbackFunc,
 ) (lxd.SourcedImage, error) {
 	conn.AddCall("FindImage", base.DisplayString(), arch)
 	if err := conn.NextErr(); err != nil {

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -421,7 +421,7 @@ func (conn *StubClient) CreateContainerFromSpec(spec lxd.ContainerSpec) (*lxd.Co
 }
 
 func (conn *StubClient) FindImage(
-	base series.Base, arch string, virtType lxd.VirtType, sources []lxd.ServerSpec, copyLocal bool, callback environs.StatusCallbackFunc,
+	base series.Base, arch string, virtType instance.VirtType, sources []lxd.ServerSpec, copyLocal bool, callback environs.StatusCallbackFunc,
 ) (lxd.SourcedImage, error) {
 	conn.AddCall("FindImage", base.DisplayString(), arch)
 	if err := conn.NextErr(); err != nil {

--- a/rpc/params/model.go
+++ b/rpc/params/model.go
@@ -340,6 +340,7 @@ type MachineHardware struct {
 	CpuPower         *uint64   `json:"cpu-power,omitempty"`
 	Tags             *[]string `json:"tags,omitempty"`
 	AvailabilityZone *string   `json:"availability-zone,omitempty"`
+	VirtType         *string   `json:"virt-type,omitempty"`
 }
 
 // ModelVolumeInfo holds information about a volume in a model.

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -309,6 +309,7 @@ func (st *State) addMachineOps(template MachineTemplate) (*machineDoc, []txn.Op,
 				CpuPower:       template.HardwareCharacteristics.CpuPower,
 				Tags:           template.HardwareCharacteristics.Tags,
 				AvailZone:      template.HardwareCharacteristics.AvailabilityZone,
+				VirtType:       template.HardwareCharacteristics.VirtType,
 			},
 		})
 	}

--- a/state/machine.go
+++ b/state/machine.go
@@ -1444,6 +1444,7 @@ func (m *Machine) SetProvisioned(
 		CpuPower:       characteristics.CpuPower,
 		Tags:           characteristics.Tags,
 		AvailZone:      characteristics.AvailabilityZone,
+		VirtType:       characteristics.VirtType,
 	}
 
 	ops := []txn.Op{

--- a/state/machine.go
+++ b/state/machine.go
@@ -246,6 +246,7 @@ type instanceData struct {
 	CpuPower       *uint64     `bson:"cpupower,omitempty"`
 	Tags           *[]string   `bson:"tags,omitempty"`
 	AvailZone      *string     `bson:"availzone,omitempty"`
+	VirtType       *string     `bson:"virt-type,omitempty"`
 
 	// KeepInstance is set to true if, on machine removal from Juju,
 	// the cloud instance should be retained.
@@ -266,6 +267,7 @@ func hardwareCharacteristics(instData instanceData) *instance.HardwareCharacteri
 		CpuPower:         instData.CpuPower,
 		Tags:             instData.Tags,
 		AvailabilityZone: instData.AvailZone,
+		VirtType:         instData.VirtType,
 	}
 }
 

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -649,6 +649,9 @@ func (e *exporter) newCloudInstanceArgs(data instanceData) description.CloudInst
 	if data.AvailZone != nil {
 		inst.AvailabilityZone = *data.AvailZone
 	}
+	if data.VirtType != nil {
+		inst.VirtType = *data.VirtType
+	}
 	if len(data.CharmProfiles) > 0 {
 		inst.CharmProfiles = data.CharmProfiles
 	}

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -650,6 +650,9 @@ func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudIns
 	if az := inst.AvailabilityZone(); az != "" {
 		doc.AvailZone = &az
 	}
+	if vt := inst.VirtType(); vt != "" {
+		doc.VirtType = &vt
+	}
 	if profiles := inst.CharmProfiles(); len(profiles) > 0 {
 		doc.CharmProfiles = profiles
 	}

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -373,6 +373,7 @@ func (s *MigrationSuite) TestInstanceDataFields(c *gc.C) {
 		"CpuPower",
 		"Tags",
 		"AvailZone",
+		"VirtType",
 		"CharmProfiles",
 	)
 	s.AssertExportedFields(c, instanceData{}, migrated.Union(ignored))

--- a/state/unit.go
+++ b/state/unit.go
@@ -2535,6 +2535,12 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 	if cons.HasZones() {
 		suitableTerms = append(suitableTerms, bson.DocElem{"availzone", bson.D{{"$in", *cons.Zones}}})
 	}
+	// VirtType is orthogonal to the containertype, i.e. an LXC container can
+	// be a container or a virtual machine. Once KVM is removed, we can drop
+	// the containertype and rely just on the virt-type.
+	if cons.HasVirtType() {
+		suitableTerms = append(suitableTerms, bson.DocElem{"virttype", *cons.VirtType})
+	}
 	if len(suitableTerms) > 0 {
 		instanceDataCollection, iCloser := db.GetCollection(instanceDataC)
 		defer iCloser()

--- a/upgrades/upgradevalidation/mocks/lxd_mock.go
+++ b/upgrades/upgradevalidation/mocks/lxd_mock.go
@@ -344,18 +344,18 @@ func (mr *MockServerMockRecorder) FilterContainers(arg0 interface{}, arg1 ...int
 }
 
 // FindImage mocks base method.
-func (m *MockServer) FindImage(arg0 series.Base, arg1 string, arg2 []lxd.ServerSpec, arg3 bool, arg4 environs.StatusCallbackFunc) (lxd.SourcedImage, error) {
+func (m *MockServer) FindImage(arg0 series.Base, arg1 string, arg2 api.InstanceType, arg3 []lxd.ServerSpec, arg4 bool, arg5 environs.StatusCallbackFunc) (lxd.SourcedImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "FindImage", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(lxd.SourcedImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindImage indicates an expected call of FindImage.
-func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockServerMockRecorder) FindImage(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImage", reflect.TypeOf((*MockServer)(nil).FindImage), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // GetCertificate mocks base method.


### PR DESCRIPTION
This set of changes allows bootstrapping to an LXD vm instead of a container. Some of the work to move to the agnostic API for both virt-types (container and virtual-machines) was done previously, but there were a few missing gaps. The following PR fixes those missing gaps in the following ways:
 
  1. Removal of the LXD unsupported type, allowing the removal of the warning.
  2. Selection of image type based on the `virt-type` constraint
  3. Location of image alias based on the `virtual-machine` using a `/vm` suffix. This is backward compatible with LXD juju image aliases, so spinning up new machines won't require a new image fetch for existing images.
  4. Storing of the `virt-type` in the instance data to allow exposing the hardware characteristics correctly.
  5. Retry and back-off when waiting for a VM to show up as active. This also affects the non-`virtual-machine` path, but shouldn't cause any issues.
  6. Bootstrapping and then enabling HA, creates the correct `virtual-machine` `virt-type`s.

What isn't included, but will be added in future PR.

  1. Preventing non-homogeneous `virt-type` container types. Deploying an application to a `virtual-machine` and also a `container` type should be blocked until we better understand the workload characteristics.

### Additionally

  1. It currently requires more memory to bootstrap a controller with a `virt-type` of `virtual-machine`, when using `build-agent`. I believe this is because of the way we're ssh'ing the binary blob to the controller. A better way might be to follow ec2 lead and scp (`lxc file push`) the blob directly. For that reason, you need to set the memory constraint higher, when bootstrapping with build-agent.
  2. I'm not sold on the full "vitural-machine" and "container" naming, but I'm just passing through what LXD expects.
  3. Maybe we expose the `virt-type` in `juju status` for lxd substrate?

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Bootstrap

```sh
$juju bootstrap lxd test --build-agent --bootstrap-constraints="virt-type=virtual-machine mem=8G"
$ juju status -m controller
Model       Controller  Cloud/Region  Version      SLA          Timestamp
controller  test        lxd/default   3.1-beta1.1  unsupported  14:28:27Z

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.1/stable   14  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.207.121.55

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.207.121.55  juju-f4134b-0  ubuntu@22.04      Running
```

```sh
$ juju show-machine -m controller 0
model: controller
machines:
  "0":
    juju-status:
      current: started
      since: 04 Jan 2023 14:27:33Z
      version: 3.1-beta1.1
    hostname: juju-f4134b-0
    dns-name: 10.207.121.55
    ip-addresses:
    - 10.207.121.55
    - fd42:7412:28cf:1097:216:3eff:fe3d:8cef
    instance-id: juju-f4134b-0
    machine-status:
      current: running
      message: Running
      since: 04 Jan 2023 14:27:43Z
    modification-status:
      current: applied
      since: 04 Jan 2023 14:27:37Z
    base:
      name: ubuntu
      channel: "22.04"
    network-interfaces:
      enp5s0:
        ip-addresses:
        - 10.207.121.55
        - fd42:7412:28cf:1097:216:3eff:fe3d:8cef
        mac-address: 00:16:3e:3d:8c:ef
        gateway: 10.207.121.1 10.207.121.1
        space: alpha
        is-up: true
    constraints: mem=12288M virt-type=virtual-machine
    hardware: arch=amd64 cores=0 mem=12288M virt-type=virtual-machine
    controller-member-status: has-vote
    ha-primary: true
```

Notice the `virt-type` is correctly set in mongo.

```sh
$ juju mongo
juju:PRIMARY> db.instanceData.find()
{ "_id" : "c495559c-2c38-4072-866a-25fadc29c7bc:0", "machineid" : "0", "instanceid" : "juju-29c7bc-0", "display-name" : "", "model-uuid" : "c495559c-2c38-4072-866a-25fadc29c7bc", "arch" : "amd64", "mem" : NumberLong(12288), "cpucores" : NumberLong(0), "virt-type" : "virtual-machine", "txn-revno" : 2 }
```

### Enable-HA

Note: I'm not sure why we're getting IPv6 over IPv4 in the status ([Happy Eyeballs?](https://en.wikipedia.org/wiki/Happy_Eyeballs))

```sh
$ juju enable-ha
juju status -m controller
Model       Controller  Cloud/Region  Version      SLA          Timestamp
controller  test        lxd/default   3.1-beta1.1  unsupported  14:48:25Z

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      3  juju-controller  3.1/stable   14  no

Unit           Workload  Agent  Machine  Public address                          Ports  Message
controller/0   active    idle   0        10.207.121.55
controller/1   active    idle   1        fd42:7412:28cf:1097:216:3eff:fe55:3e22
controller/2*  active    idle   2        fd42:7412:28cf:1097:216:3eff:fea6:7210

Machine  State    Address                                 Inst id        Base          AZ  Message
0        started  10.207.121.55                           juju-f4134b-0  ubuntu@22.04      Running
1        started  fd42:7412:28cf:1097:216:3eff:fe55:3e22  juju-f4134b-1  ubuntu@22.04      Running
2        started  fd42:7412:28cf:1097:216:3eff:fea6:7210  juju-f4134b-2  ubuntu@22.04      Running
```

### Add Machine

This can take some time...

```sh
$ juju add-machine --constraints="virt-type=virtual-machine"
created machine 0
$ juju status
Model    Controller  Cloud/Region  Version      SLA          Timestamp
default  test        lxd/default   3.1-beta1.1  unsupported  14:53:59Z

Machine  State    Address         Inst id        Base          AZ  Message
0        pending  10.207.121.211  juju-75adc3-0  ubuntu@22.04      Running
```

```sh
juju show-machine 0
model: default
machines:
  "0":
    juju-status:
      current: started
      since: 04 Jan 2023 14:54:03Z
      version: 3.1-beta1.1
    hostname: juju-75adc3-0
    dns-name: 10.207.121.211
    ip-addresses:
    - 10.207.121.211
    - fd42:7412:28cf:1097:216:3eff:fe10:1136
    instance-id: juju-75adc3-0
    machine-status:
      current: running
      message: Running
      since: 04 Jan 2023 14:53:43Z
    modification-status:
      current: idle
      since: 04 Jan 2023 14:52:07Z
    base:
      name: ubuntu
      channel: "22.04"
    network-interfaces:
      enp5s0:
        ip-addresses:
        - 10.207.121.211
        - fd42:7412:28cf:1097:216:3eff:fe10:1136
        mac-address: 00:16:3e:10:11:36
        gateway: 10.207.121.1 10.207.121.1
        space: alpha
        is-up: true
    constraints: virt-type=virtual-machine
    hardware: arch=amd64 cores=0 mem=0M virt-type=virtual-machine
```

## Documentation changes

@tmihoc This will now deploy to LXD vms via a `virt-type` constraint.

## Bug reference

https://warthogs.atlassian.net/browse/JUJU-2351
