### PR TITLE
Check backup filename when downloading

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -864,8 +864,9 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		pattern: modelRoutePrefix + "/units/:unit/resources/:resource",
 		handler: unitResourcesHandler,
 	}, {
-		pattern: modelRoutePrefix + "/backups",
-		handler: backupHandler,
+		pattern:    modelRoutePrefix + "/backups",
+		handler:    backupHandler,
+		authorizer: controllerAdminAuthorizer,
 	}, {
 		pattern:    "/migrate/charms",
 		handler:    migrateCharmsHTTPHandler,

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/juju/errors"
 
@@ -41,7 +42,25 @@ func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "GET":
 		logger.Infof("handling backups download request")
-		id, err := h.download(newBackups(), resp, req)
+		model, err := st.Model()
+		if err != nil {
+			h.sendError(resp, err)
+			return
+		}
+		modelConfig, err := model.ModelConfig()
+		if err != nil {
+			h.sendError(resp, err)
+			return
+		}
+		backupDir := modelConfig.BackupDir()
+		if backupDir == "" {
+			backupDir = os.TempDir()
+		}
+
+		paths := &backups.Paths{
+			BackupDir: backupDir,
+		}
+		id, err := h.download(newBackups(paths), resp, req)
 		if err != nil {
 			h.sendError(resp, err)
 			return

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -4,6 +4,8 @@
 package backups
 
 import (
+	"os"
+
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v2"
 	"github.com/juju/names/v4"
@@ -109,6 +111,9 @@ func NewAPI(backend Backend, resources facade.Resources, authorizer facade.Autho
 		return nil, errors.Trace(err)
 	}
 	backupDir := modelConfig.BackupDir()
+	if backupDir == "" {
+		backupDir = os.TempDir()
+	}
 
 	paths := backups.Paths{
 		BackupDir: backupDir,

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -78,7 +78,7 @@ func (s *backupsSuite) setBackups(c *gc.C, meta *backups.Metadata, err string) *
 		fake.Error = errors.Errorf(err)
 	}
 	s.PatchValue(backupsAPI.NewBackups,
-		func() backups.Backups {
+		func(paths *backups.Paths) backups.Backups {
 			return &fake
 		},
 	)

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -33,7 +33,7 @@ func (a *API) Create(args params.BackupsCreateArgs) (params.BackupsMetadataResul
 }
 
 func (a *APIv2) Create(args params.BackupsCreateArgs) (params.BackupsMetadataResult, error) {
-	backupsMethods := newBackups()
+	backupsMethods := newBackups(a.paths)
 
 	session := a.backend.MongoSession().Copy()
 	defer session.Close()
@@ -88,7 +88,7 @@ func (a *APIv2) Create(args params.BackupsCreateArgs) (params.BackupsMetadataRes
 	}
 	meta.Controller.HANodes = int64(len(nodes))
 
-	fileName, err := backupsMethods.Create(meta, a.paths, dbInfo)
+	fileName, err := backupsMethods.Create(meta, dbInfo)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/state/backups/backups_test.go
+++ b/state/backups/backups_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/dustin/go-humanize"
 	"github.com/juju/collections/set"
@@ -24,7 +25,8 @@ import (
 type backupsSuite struct {
 	backupstesting.BaseSuite
 
-	api backups.Backups
+	paths *backups.Paths
+	api   backups.Backups
 
 	totalDiskMiB     uint64
 	availableDiskMiB uint64
@@ -37,7 +39,11 @@ var _ = gc.Suite(&backupsSuite{}) // Register the suite.
 func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	s.api = backups.NewBackups()
+	s.paths = &backups.Paths{
+		BackupDir: c.MkDir(),
+		DataDir:   c.MkDir(),
+	}
+	s.api = backups.NewBackups(s.paths)
 	s.PatchValue(backups.AvailableDisk, func(string) uint64 {
 		return s.availableDiskMiB
 	})
@@ -60,7 +66,6 @@ func (s *backupsSuite) checkFailure(c *gc.C, expected string) {
 		return &fakeDumper{}, nil
 	})
 
-	paths := backups.Paths{DataDir: "/var/lib/juju"}
 	targets := set.NewStrings("juju", "admin")
 	dbInfo := backups.DBInfo{
 		Address: "a", Username: "b", Password: "c",
@@ -69,20 +74,18 @@ func (s *backupsSuite) checkFailure(c *gc.C, expected string) {
 	meta := backupstesting.NewMetadataStarted()
 	meta.Notes = "some notes"
 
-	_, err := s.api.Create(meta, &paths, &dbInfo)
+	_, err := s.api.Create(meta, &dbInfo)
 	c.Check(err, gc.ErrorMatches, expected)
 }
 
 func (s *backupsSuite) TestCreateOkay(c *gc.C) {
-	dataDir := c.MkDir()
-	backupDir := c.MkDir()
 	// Patch the internals.
 	archiveFile := ioutil.NopCloser(bytes.NewBufferString("<compressed tarball>"))
 	result := backups.NewTestCreateResult(
 		archiveFile,
 		10,
 		"<checksum>",
-		path.Join(backupDir, "test-backup.tar.gz"))
+		path.Join(s.paths.BackupDir, "test-backup.tar.gz"))
 	received, testCreate := backups.NewTestCreate(result)
 	s.PatchValue(backups.RunCreate, testCreate)
 
@@ -99,7 +102,6 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	})
 
 	// Run the backup.
-	paths := backups.Paths{BackupDir: backupDir, DataDir: dataDir}
 	targets := set.NewStrings("juju", "admin")
 	dbInfo := backups.DBInfo{
 		Address: "a", Username: "b", Password: "c",
@@ -108,13 +110,13 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	meta := backupstesting.NewMetadataStarted()
 	backupstesting.SetOrigin(meta, "<model ID>", "<machine ID>", "<hostname>")
 	meta.Notes = "some notes"
-	resultFilename, err := s.api.Create(meta, &paths, &dbInfo)
+	resultFilename, err := s.api.Create(meta, &dbInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(resultFilename, gc.Equals, path.Join(backupDir, "test-backup.tar.gz"))
+	c.Assert(resultFilename, gc.Equals, path.Join(s.paths.BackupDir, "test-backup.tar.gz"))
 
 	// Test the call values.
 	resultBackupDir, filesToBackUp, _ := backups.ExposeCreateArgs(received)
-	c.Check(resultBackupDir, gc.Equals, backupDir)
+	c.Check(resultBackupDir, gc.Equals, s.paths.BackupDir)
 	c.Check(filesToBackUp, jc.SameContents, []string{"<some file>"})
 
 	c.Check(receivedDBInfo.Address, gc.Equals, "a")
@@ -198,14 +200,17 @@ func (s *backupsSuite) TestNotEnoughDiskSpaceSmallDisk(c *gc.C) {
 }
 
 func (s *backupsSuite) TestGetFileName(c *gc.C) {
-	backupDir := c.MkDir()
-	err := os.MkdirAll(backupDir, 0644)
+	backupSubDir := filepath.Join(s.paths.BackupDir, "a", "b")
+	err := os.MkdirAll(backupSubDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	backupFilename := path.Join(backupDir, "test-backup.tar.gz")
+	backupFilename := path.Join(backupSubDir, "juju-backup-123.tar.gz")
 	backupFile, err := os.Create(backupFilename)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = backupFile.Write([]byte("archive file testing"))
 	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.api.Get("/etc/hostname")
+	c.Assert(err, gc.ErrorMatches, `backup file "/etc/hostname" not valid`)
 
 	resultMeta, resultArchive, err := s.api.Get(backupFilename)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/backups/testing/fakes.go
+++ b/state/backups/testing/fakes.go
@@ -31,8 +31,6 @@ type FakeBackups struct {
 
 	// IDArg holds the ID that was passed in.
 	IDArg string
-	// PathsArg holds the Paths that was passed in.
-	PathsArg *backups.Paths
 	// DBInfoArg holds the ConnInfo that was passed in.
 	DBInfoArg *backups.DBInfo
 	// MetaArg holds the backup metadata that was passed in.
@@ -51,12 +49,10 @@ var _ backups.Backups = (*FakeBackups)(nil)
 // its associated metadata.
 func (b *FakeBackups) Create(
 	meta *backups.Metadata,
-	paths *backups.Paths,
 	dbInfo *backups.DBInfo,
 ) (string, error) {
 	b.Calls = append(b.Calls, "Create")
 
-	b.PathsArg = paths
 	b.DBInfoArg = dbInfo
 	b.MetaArg = meta
 


### PR DESCRIPTION
The `--no-download` option to `create-backup` is deprecated. Nonetheless, add validation that the filename requested looks like a valid backup file and is in the configured backup dir.

## QA steps

```
$ juju create-backup --no-download
WARNING --no-download flag is DEPRECATED.

...
Remote backup stored on the controller as /var/snap/juju-db/common/backups/juju-backup-20221215-235433.tar.gz
```

Then
`$ juju download-backup /var/snap/juju-db/common/backups/juju-backup-20221215-235433.tar.gz`

Also
```
$ juju download-backup /tmp/foo
ERROR Get https://[fd42:f06:88d0:34ee:216:3eff:fe42:272e]:17070/model/2d32a4b7-9f94-431f-8310-6f5a019cde4b/backups: backup file "/tmp/foo" not valid
```

## Bug reference

https://bugs.launchpad.net/bugs/1999622
