### PR TITLE
Merge pull request #15006 from wallyworld/check-backupfile

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -855,8 +855,9 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		pattern: modelRoutePrefix + "/units/:unit/resources/:resource",
 		handler: unitResourcesHandler,
 	}, {
-		pattern: modelRoutePrefix + "/backups",
-		handler: backupHandler,
+		pattern:    modelRoutePrefix + "/backups",
+		handler:    backupHandler,
+		authorizer: controllerAdminAuthorizer,
 	}, {
 		pattern:    "/migrate/charms",
 		handler:    migrateCharmsHTTPHandler,

--- a/apiserver/backup.go
+++ b/apiserver/backup.go
@@ -40,7 +40,21 @@ func (h *backupHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "GET":
 		logger.Infof("handling backups download request")
-		id, err := h.download(newBackups(), resp, req)
+		model, err := st.Model()
+		if err != nil {
+			h.sendError(resp, err)
+			return
+		}
+		modelConfig, err := model.ModelConfig()
+		if err != nil {
+			h.sendError(resp, err)
+			return
+		}
+		backupDir := backups.BackupDirToUse(modelConfig.BackupDir())
+		paths := &backups.Paths{
+			BackupDir: backupDir,
+		}
+		id, err := h.download(newBackups(paths), resp, req)
 		if err != nil {
 			h.sendError(resp, err)
 			return

--- a/apiserver/backup_test.go
+++ b/apiserver/backup_test.go
@@ -37,7 +37,7 @@ func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.backupURL = s.server.URL + fmt.Sprintf("/model/%s/backups", s.State.ModelUUID())
 	s.fake = &backupstesting.FakeBackups{}
 	s.PatchValue(apiserver.NewBackups,
-		func() backups.Backups {
+		func(path *backups.Paths) backups.Backups {
 			return s.fake
 		},
 	)
@@ -98,7 +98,10 @@ func (s *backupsSuite) TestAuthRequiresClientNotMachine(c *gc.C) {
 		URL:      s.backupURL,
 		Nonce:    "fake_nonce",
 	})
-	s.assertErrorResponse(c, resp, http.StatusInternalServerError, "tag kind machine not valid")
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusForbidden)
+	body, err := io.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(body), gc.Equals, "authorization failed: machine 0 is not a user\n")
 
 	// Now try a user login.
 	resp = s.sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "POST", URL: s.backupURL})

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -78,8 +78,7 @@ func NewAPI(backend Backend, resources facade.Resources, authorizer facade.Autho
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	backupDir := modelConfig.BackupDir()
-
+	backupDir := backups.BackupDirToUse(modelConfig.BackupDir())
 	paths := backups.Paths{
 		BackupDir: backupDir,
 		DataDir:   dataDir,

--- a/apiserver/facades/client/backups/backups_test.go
+++ b/apiserver/facades/client/backups/backups_test.go
@@ -78,7 +78,7 @@ func (s *backupsSuite) setBackups(c *gc.C, meta *backups.Metadata, err string) *
 		fake.Error = errors.Errorf(err)
 	}
 	s.PatchValue(backupsAPI.NewBackups,
-		func() backups.Backups {
+		func(paths *backups.Paths) backups.Backups {
 			return &fake
 		},
 	)

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -19,7 +19,7 @@ var waitUntilReady = func(s *mgo.Session, timeout int) error {
 // Create is the API method that requests juju to create a new backup
 // of its state.
 func (a *API) Create(args params.BackupsCreateArgs) (params.BackupsMetadataResult, error) {
-	backupsMethods := newBackups()
+	backupsMethods := newBackups(a.paths)
 
 	session := a.backend.MongoSession().Copy()
 	defer session.Close()
@@ -66,7 +66,7 @@ func (a *API) Create(args params.BackupsCreateArgs) (params.BackupsMetadataResul
 	}
 	meta.Controller.HANodes = int64(len(nodes))
 
-	fileName, err := backupsMethods.Create(meta, a.paths, dbInfo)
+	fileName, err := backupsMethods.Create(meta, dbInfo)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/state/backups/backups_test.go
+++ b/state/backups/backups_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/dustin/go-humanize"
 	"github.com/juju/collections/set"
@@ -23,7 +24,8 @@ import (
 type backupsSuite struct {
 	backupstesting.BaseSuite
 
-	api backups.Backups
+	paths *backups.Paths
+	api   backups.Backups
 
 	totalDiskMiB     uint64
 	availableDiskMiB uint64
@@ -36,7 +38,11 @@ var _ = gc.Suite(&backupsSuite{}) // Register the suite.
 func (s *backupsSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 
-	s.api = backups.NewBackups()
+	s.paths = &backups.Paths{
+		BackupDir: c.MkDir(),
+		DataDir:   c.MkDir(),
+	}
+	s.api = backups.NewBackups(s.paths)
 	s.PatchValue(backups.AvailableDisk, func(string) uint64 {
 		return s.availableDiskMiB
 	})
@@ -54,12 +60,15 @@ func (*fakeDumper) Dump(dumpDir string) error {
 	return nil
 }
 
+func (*fakeDumper) IsSnap() bool {
+	return false
+}
+
 func (s *backupsSuite) checkFailure(c *gc.C, expected string) {
 	s.PatchValue(backups.GetDBDumper, func(*backups.DBInfo) (backups.DBDumper, error) {
 		return &fakeDumper{}, nil
 	})
 
-	paths := backups.Paths{DataDir: "/var/lib/juju"}
 	targets := set.NewStrings("juju", "admin")
 	dbInfo := backups.DBInfo{
 		Address: "a", Username: "b", Password: "c",
@@ -68,20 +77,18 @@ func (s *backupsSuite) checkFailure(c *gc.C, expected string) {
 	meta := backupstesting.NewMetadataStarted()
 	meta.Notes = "some notes"
 
-	_, err := s.api.Create(meta, &paths, &dbInfo)
+	_, err := s.api.Create(meta, &dbInfo)
 	c.Check(err, gc.ErrorMatches, expected)
 }
 
 func (s *backupsSuite) TestCreateOkay(c *gc.C) {
-	dataDir := c.MkDir()
-	backupDir := c.MkDir()
 	// Patch the internals.
 	archiveFile := io.NopCloser(bytes.NewBufferString("<compressed tarball>"))
 	result := backups.NewTestCreateResult(
 		archiveFile,
 		10,
 		"<checksum>",
-		path.Join(backupDir, "test-backup.tar.gz"))
+		path.Join(s.paths.BackupDir, "test-backup.tar.gz"))
 	received, testCreate := backups.NewTestCreate(result)
 	s.PatchValue(backups.RunCreate, testCreate)
 
@@ -98,7 +105,6 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	})
 
 	// Run the backup.
-	paths := backups.Paths{BackupDir: backupDir, DataDir: dataDir}
 	targets := set.NewStrings("juju", "admin")
 	dbInfo := backups.DBInfo{
 		Address: "a", Username: "b", Password: "c",
@@ -107,13 +113,13 @@ func (s *backupsSuite) TestCreateOkay(c *gc.C) {
 	meta := backupstesting.NewMetadataStarted()
 	backupstesting.SetOrigin(meta, "<model ID>", "<machine ID>", "<hostname>")
 	meta.Notes = "some notes"
-	resultFilename, err := s.api.Create(meta, &paths, &dbInfo)
+	resultFilename, err := s.api.Create(meta, &dbInfo)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(resultFilename, gc.Equals, path.Join(backupDir, "test-backup.tar.gz"))
+	c.Assert(resultFilename, gc.Equals, path.Join(s.paths.BackupDir, "test-backup.tar.gz"))
 
 	// Test the call values.
 	resultBackupDir, filesToBackUp, _ := backups.ExposeCreateArgs(received)
-	c.Check(resultBackupDir, gc.Equals, backupDir)
+	c.Check(resultBackupDir, gc.Equals, s.paths.BackupDir)
 	c.Check(filesToBackUp, jc.SameContents, []string{"<some file>"})
 
 	c.Check(receivedDBInfo.Address, gc.Equals, "a")
@@ -197,14 +203,17 @@ func (s *backupsSuite) TestNotEnoughDiskSpaceSmallDisk(c *gc.C) {
 }
 
 func (s *backupsSuite) TestGetFileName(c *gc.C) {
-	backupDir := c.MkDir()
-	err := os.MkdirAll(backupDir, 0644)
+	backupSubDir := filepath.Join(s.paths.BackupDir, "a", "b")
+	err := os.MkdirAll(backupSubDir, 0755)
 	c.Assert(err, jc.ErrorIsNil)
-	backupFilename := path.Join(backupDir, "test-backup.tar.gz")
+	backupFilename := path.Join(backupSubDir, "juju-backup-123.tar.gz")
 	backupFile, err := os.Create(backupFilename)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = backupFile.Write([]byte("archive file testing"))
 	c.Assert(err, jc.ErrorIsNil)
+
+	_, _, err = s.api.Get("/etc/hostname")
+	c.Assert(err, gc.ErrorMatches, `backup file "/etc/hostname" not valid`)
 
 	resultMeta, resultArchive, err := s.api.Get(backupFilename)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/backups/create.go
+++ b/state/backups/create.go
@@ -122,6 +122,9 @@ func newBuilder(destinationDir string, filesToBackUp []string, db DBDumper) (b *
 	if err != nil {
 		return nil, errors.Annotate(err, "while making backups staging directory")
 	}
+	if db.IsSnap() && destinationDir == os.TempDir() {
+		stagingDir = filepath.Join(snapTmpDir, stagingDir)
+	}
 
 	// TODO(hpidcock): lp:1558657
 	finalFilename := time.Now().Format(FilenameTemplate)

--- a/state/backups/create_test.go
+++ b/state/backups/create_test.go
@@ -32,6 +32,10 @@ func (d *TestDBDumper) Dump(dumpDir string) error {
 	return nil
 }
 
+func (d *TestDBDumper) IsSnap() bool {
+	return false
+}
+
 func (s *createSuite) TestLegacy(c *gc.C) {
 	if runtime.GOOS == "windows" {
 		c.Skip("bug 1403084: Currently does not work on windows, see comments inside backups.create function")

--- a/state/backups/db.go
+++ b/state/backups/db.go
@@ -118,13 +118,16 @@ func getBackupTargetDatabases(session DBSession) (set.Strings, error) {
 const (
 	dumpName       = "mongodump"
 	snapToolPrefix = "juju-db."
-	snapTmpDir     = "/tmp/snap.juju-db"
+	snapTmpDir     = "/tmp/snap-private-tmp/snap.juju-db"
 )
 
 // DBDumper is any type that dumps something to a dump dir.
 type DBDumper interface {
 	// Dump something to dumpDir.
 	Dump(dumpDir string) error
+
+	// IsSnap returns true if we are using the juju-db snap.
+	IsSnap() bool
 }
 
 var getMongodumpPath = func() (string, error) {
@@ -194,30 +197,23 @@ func (md *mongoDumper) options(dumpDir string) []string {
 }
 
 func (md *mongoDumper) dump(dumpDir string) error {
-	options := md.options(dumpDir)
+	// Works around https://bugs.launchpad.net/snapd/+bug/1999109
+	// If running the juju-db.mongodump snap and staging to /tmp,
+	// it outputs to /tmp/snap-private-tmp/snap.juju-db/<dumpDir>
+	dumpDirArg := dumpDir
+	if md.IsSnap() && strings.HasPrefix(dumpDirArg, snapTmpDir) {
+		dumpDirArg = strings.TrimPrefix(dumpDirArg, snapTmpDir)
+	}
+
+	options := md.options(dumpDirArg)
 	if err := runCommandFn(md.binPath, options...); err != nil {
 		return errors.Annotate(err, "error dumping databases")
 	}
-
-	// If running the juju-db.mongodump Snap, it outputs to
-	// /tmp/snap.juju-db/DUMPDIR, so move to /DUMPDIR as our code expects.
-	if md.isSnap() && strings.HasPrefix(dumpDir, "/tmp") {
-		actualDir := filepath.Join(snapTmpDir, dumpDir)
-		logger.Tracef("moving from Snap dump dir %q to %q", actualDir, dumpDir)
-		err := os.Remove(dumpDir) // will be empty, delete
-		if err != nil {
-			return errors.Trace(err)
-		}
-		err = os.Rename(actualDir, dumpDir)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-
 	return nil
 }
 
-func (md *mongoDumper) isSnap() bool {
+// IsSnap returns true if we are using the juju-db snap.
+func (md *mongoDumper) IsSnap() bool {
 	return filepath.Base(md.binPath) == snapToolPrefix+dumpName
 }
 
@@ -289,7 +285,7 @@ func listDatabases(dumpDir string) (set.Strings, error) {
 	}
 	if len(dirEntries) < 2 {
 		// Should be *at least* oplog.bson and a data directory
-		return nil, errors.Errorf("too few files in dump dir (%d)", len(dirEntries))
+		return nil, errors.Errorf("too few files in dump dir %s (%d)", dumpDir, len(dirEntries))
 	}
 
 	databases := make(set.Strings)

--- a/state/backups/files.go
+++ b/state/backups/files.go
@@ -32,6 +32,14 @@ const (
 	dbSecretSnapDir = "/var/snap/juju-db/common"
 )
 
+// BackupDirToUse returns the desired backup staging dir.
+func BackupDirToUse(configuredDir string) string {
+	if configuredDir != "" {
+		return configuredDir
+	}
+	return os.TempDir()
+}
+
 // Paths holds the paths that backups needs.
 type Paths struct {
 	BackupDir string

--- a/state/backups/testing/fakes.go
+++ b/state/backups/testing/fakes.go
@@ -31,8 +31,6 @@ type FakeBackups struct {
 
 	// IDArg holds the ID that was passed in.
 	IDArg string
-	// PathsArg holds the Paths that was passed in.
-	PathsArg *backups.Paths
 	// DBInfoArg holds the ConnInfo that was passed in.
 	DBInfoArg *backups.DBInfo
 	// MetaArg holds the backup metadata that was passed in.
@@ -51,12 +49,10 @@ var _ backups.Backups = (*FakeBackups)(nil)
 // its associated metadata.
 func (b *FakeBackups) Create(
 	meta *backups.Metadata,
-	paths *backups.Paths,
 	dbInfo *backups.DBInfo,
 ) (string, error) {
 	b.Calls = append(b.Calls, "Create")
 
-	b.PathsArg = paths
 	b.DBInfoArg = dbInfo
 	b.MetaArg = meta
 


### PR DESCRIPTION
Merge https://github.com/juju/juju/pull/15006

The `--no-download` option to `create-backup` is deprecated. Nonetheless, add validation that the filename requested looks like a valid backup file and is in the configured backup dir.

Also fixes the case where the default backup dir "/tmp" doesn't work with juju-db snap.

## QA Steps

```
$ juju create-backup --no-download
WARNING --no-download flag is DEPRECATED.

...
Remote backup stored on the controller as /var/snap/juju-db/common/backups/juju-backup-20221215-235433.tar.gz
```

Then
`$ juju download-backup /var/snap/juju-db/common/backups/juju-backup-20221215-235433.tar.gz`

Also
```
$ juju download-backup /tmp/foo
ERROR Get https://[fd42:f06:88d0:34ee:216:3eff:fe42:272e]:17070/model/2d32a4b7-9f94-431f-8310-6f5a019cde4b/backups: backup file "/tmp/foo" not valid
```

## Fixes Bugs
https://bugs.launchpad.net/bugs/1999622
https://bugs.launchpad.net/bugs/1998989

