### PR TITLE
2.9 merge into 3.0

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -207,6 +207,7 @@ type mockApplication struct {
 	scale                int
 	unitsWatcher         *statetesting.MockStringsWatcher
 	unitsChanges         chan []string
+	watcher              *statetesting.MockNotifyWatcher
 	charmPending         bool
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -37,11 +37,12 @@ type mockState struct {
 	testing.Stub
 
 	common.APIAddressAccessor
-	model              *mockModel
-	applicationWatcher *mockStringsWatcher
-	app                *mockApplication
-	resource           *mockResources
-	operatorRepo       string
+	model                   *mockModel
+	applicationWatcher      *mockStringsWatcher
+	app                     *mockApplication
+	resource                *mockResources
+	operatorRepo            string
+	controllerConfigWatcher *statetesting.MockNotifyWatcher
 }
 
 func newMockState() *mockState {
@@ -50,6 +51,11 @@ func newMockState() *mockState {
 	}
 	st.model = &mockModel{state: st}
 	return st
+}
+
+func (st *mockState) WatchControllerConfig() state.NotifyWatcher {
+	st.MethodCall(st, "WatchControllerConfig")
+	return st.controllerConfigWatcher
 }
 
 func (st *mockState) WatchApplications() state.StringsWatcher {
@@ -137,7 +143,8 @@ func (m *mockStoragePoolManager) Get(name string) (*storage.Config, error) {
 
 type mockModel struct {
 	testing.Stub
-	state *mockState
+	state              *mockState
+	modelConfigChanges *statetesting.MockNotifyWatcher
 }
 
 func (m *mockModel) UUID() string {
@@ -176,6 +183,11 @@ func (m *mockModel) Containers(providerIds ...string) ([]state.CloudContainer, e
 	}
 
 	return containers, nil
+}
+
+func (m *mockModel) WatchForModelConfigChanges() state.NotifyWatcher {
+	m.MethodCall(m, "WatchForModelConfigChanges")
+	return m.modelConfigChanges
 }
 
 type mockApplication struct {
@@ -320,6 +332,11 @@ func (a *mockApplication) ClearResources() error {
 func (a *mockApplication) WatchUnits() state.StringsWatcher {
 	a.MethodCall(a, "WatchUnits")
 	return a.unitsWatcher
+}
+
+func (a *mockApplication) Watch() state.NotifyWatcher {
+	a.MethodCall(a, "Watch")
+	return a.watcher
 }
 
 type mockCharm struct {

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -199,6 +199,57 @@ func (a *API) WatchApplications() (params.StringsWatchResult, error) {
 	return params.StringsWatchResult{}, watcher.EnsureErr(watch)
 }
 
+// WatchProvisioningInfo provides a watcher for changes that affect the
+// information returned by ProvisioningInfo. This is useful for ensuring the
+// latest application stated is ensured.
+func (a *API) WatchProvisioningInfo(args params.Entities) (params.NotifyWatchResults, error) {
+	var result params.NotifyWatchResults
+	result.Results = make([]params.NotifyWatchResult, len(args.Entities))
+	for i, entity := range args.Entities {
+		appName, err := names.ParseApplicationTag(entity.Tag)
+		if err != nil {
+			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		res, err := a.watchProvisioningInfo(appName)
+		if err != nil {
+			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		result.Results[i].NotifyWatcherId = res.NotifyWatcherId
+	}
+	return result, nil
+}
+
+func (a *API) watchProvisioningInfo(appName names.ApplicationTag) (params.NotifyWatchResult, error) {
+	result := params.NotifyWatchResult{}
+	app, err := a.state.Application(appName.Id())
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	model, err := a.state.Model()
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+
+	modelConfigWatcher := model.WatchForModelConfigChanges()
+	appWatcher := app.Watch()
+	controllerConfigWatcher := a.ctrlSt.WatchControllerConfig()
+
+	multiWatcher := common.NewMultiNotifyWatcher(appWatcher, controllerConfigWatcher, modelConfigWatcher)
+
+	if _, ok := <-multiWatcher.Changes(); ok {
+		result.NotifyWatcherId = a.resources.Register(multiWatcher)
+	} else {
+		return result, watcher.EnsureErr(multiWatcher)
+	}
+
+	return result, nil
+}
+
 // ProvisioningInfo returns the info needed to provision a caas application.
 func (a *API) ProvisioningInfo(args params.Entities) (params.CAASApplicationProvisioningInfoResults, error) {
 	var result params.CAASApplicationProvisioningInfoResults

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -38,12 +38,14 @@ type CAASApplicationControllerState interface {
 	ModelUUID() string
 	APIHostPortsForAgents() ([]network.SpaceHostPorts, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
+	WatchControllerConfig() state.NotifyWatcher
 }
 
 type Model interface {
 	UUID() string
 	ModelConfig() (*config.Config, error)
 	Containers(providerIds ...string) ([]state.CloudContainer, error)
+	WatchForModelConfigChanges() state.NotifyWatcher
 }
 
 type Application interface {
@@ -64,6 +66,7 @@ type Application interface {
 	ApplicationConfig() (coreconfig.ConfigAttributes, error)
 	GetScale() int
 	ClearResources() error
+	Watch() state.NotifyWatcher
 	WatchUnits() state.StringsWatcher
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -6424,6 +6424,18 @@
                     },
                     "description": "WatchApplications starts a StringsWatcher to watch applications\ndeployed to this model."
                 },
+                "WatchProvisioningInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    },
+                    "description": "WatchProvisioningInfo provides a watcher for changes that affect the\ninformation returned by ProvisioningInfo. This is useful for ensuring the\nlatest application stated is ensured."
+                },
                 "WatchUnits": {
                     "type": "object",
                     "properties": {

--- a/caas/application.go
+++ b/caas/application.go
@@ -43,9 +43,6 @@ type Application interface {
 	// Service returns the service associated with the application.
 	Service() (*Service, error)
 
-	// Upgrade upgrades the app to the specified version.
-	Upgrade(version.Number) error
-
 	ServiceInterface
 }
 

--- a/caas/kubernetes/provider/application.go
+++ b/caas/kubernetes/provider/application.go
@@ -4,10 +4,6 @@
 package provider
 
 import (
-	"github.com/juju/errors"
-	"github.com/juju/names/v4"
-	"github.com/juju/version/v2"
-
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/application"
 )
@@ -25,16 +21,4 @@ func (k *kubernetesClient) Application(name string, deploymentType caas.Deployme
 		k.clock,
 		k.randomPrefix,
 	)
-}
-
-func (k *kubernetesClient) upgradeApplication(agentTag names.Tag, vers version.Number) error {
-	appName, err := names.UnitApplication(agentTag.Id())
-	if err != nil {
-		return errors.Trace(err)
-	}
-	app := k.Application(
-		appName,
-		caas.DeploymentStateful, // TODO(sidecar): we hardcode it to stateful for now, it needs to be fixed soon!
-	)
-	return app.Upgrade(vers)
 }

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1534,11 +1534,6 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				},
 				{
 					Name:      constants.CharmVolumeName,
-					MountPath: "/containeragent/pebble",
-					SubPath:   "containeragent/pebble",
-				},
-				{
-					Name:      constants.CharmVolumeName,
 					MountPath: "/charm/bin",
 					SubPath:   "charm/bin",
 				},

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -34,7 +34,6 @@ import (
 	k8sutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	k8swatcher "github.com/juju/juju/caas/kubernetes/provider/watcher"
 	k8swatchertest "github.com/juju/juju/caas/kubernetes/provider/watcher/test"
-	"github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/paths"
@@ -55,7 +54,11 @@ type applicationSuite struct {
 	k8sWatcherFn k8swatcher.NewK8sWatcherFunc
 	watchers     []k8swatcher.KubernetesNotifyWatcher
 	applier      *resourcesmocks.MockApplier
+
+	version version.Number
 }
+
+const defaultAgentVersion = "2.9.37"
 
 var _ = gc.Suite(&applicationSuite{})
 
@@ -111,7 +114,11 @@ func (s *applicationSuite) getApp(c *gc.C, deploymentType caas.DeploymentType, m
 	), ctrl
 }
 
-func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivateImageRepo bool, cons constraints.Value, trust bool, checkMainResource func()) {
+func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivateImageRepo bool, cons constraints.Value, trust bool, agentVersion string, checkMainResource func()) {
+	if agentVersion == "" {
+		agentVersion = defaultAgentVersion
+	}
+
 	appSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gitlab-application-config",
@@ -120,7 +127,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": agentVersion},
 		},
 		Data: map[string][]byte{
 			"JUJU_K8S_APPLICATION":          []byte("gitlab"),
@@ -138,7 +145,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": agentVersion},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "gitlab"},
@@ -158,7 +165,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": agentVersion},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
@@ -173,7 +180,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": agentVersion},
 		},
 		AutomountServiceAccountToken: pointer.BoolPtr(false),
 	}
@@ -185,7 +192,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": agentVersion},
 		},
 	}
 	if trust {
@@ -231,7 +238,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": agentVersion},
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
@@ -250,7 +257,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": agentVersion},
 		},
 	}
 	if trust {
@@ -267,7 +274,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": agentVersion},
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
@@ -282,7 +289,7 @@ func (s *applicationSuite) assertEnsure(c *gc.C, app caas.Application, isPrivate
 
 	c.Assert(app.Ensure(
 		caas.ApplicationConfig{
-			AgentVersion:         version.MustParse("1.1.1"),
+			AgentVersion:         version.MustParse(agentVersion),
 			IsPrivateImageRepo:   isPrivateImageRepo,
 			AgentImagePath:       "operator/image-path:1.1.1",
 			CharmBaseImagePath:   "ubuntu@22.04",
@@ -474,11 +481,6 @@ func getPodSpec() corev1.PodSpec {
 				},
 				{
 					Name:      "charm-data",
-					MountPath: "/containeragent/pebble",
-					SubPath:   "containeragent/pebble",
-				},
-				{
-					Name:      "charm-data",
 					MountPath: "/charm/bin",
 					SubPath:   "charm/bin",
 				},
@@ -486,6 +488,11 @@ func getPodSpec() corev1.PodSpec {
 					Name:      "charm-data",
 					MountPath: "/charm/containers",
 					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/pebble",
+					SubPath:   "containeragent/pebble",
 				},
 			},
 		}},
@@ -525,7 +532,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    3,
+				FailureThreshold:    1,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -538,14 +545,22 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    3,
+				FailureThreshold:    1,
+			},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
 			},
 			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "charm-data",
-					MountPath: "/var/lib/pebble/default",
-					SubPath:   "containeragent/pebble",
-				},
 				{
 					Name:      "charm-data",
 					MountPath: "/charm/bin",
@@ -561,6 +576,11 @@ func getPodSpec() corev1.PodSpec {
 					Name:      "charm-data",
 					MountPath: "/charm/containers",
 					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
 				},
 				{
 					Name:      "gitlab-database-appuuid",
@@ -594,7 +614,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    3,
+				FailureThreshold:    1,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -607,7 +627,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    3,
+				FailureThreshold:    1,
 			},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:  int64Ptr(0),
@@ -657,7 +677,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    3,
+				FailureThreshold:    1,
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -670,7 +690,7 @@ func getPodSpec() corev1.PodSpec {
 				TimeoutSeconds:      1,
 				PeriodSeconds:       5,
 				SuccessThreshold:    1,
-				FailureThreshold:    3,
+				FailureThreshold:    1,
 			},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:  int64Ptr(0),
@@ -704,7 +724,7 @@ func getPodSpec() corev1.PodSpec {
 func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, true, func() {
+		c, app, false, constraints.Value{}, true, "", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(svc, gc.DeepEquals, &corev1.Service{
@@ -716,7 +736,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version": "1.1.1",
+						"juju.is/version": "2.9.37",
 						"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 					},
 				},
@@ -739,7 +759,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "1.1.1",
+						"juju.is/version":  "2.9.37",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -753,7 +773,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "1.1.1"},
+							Annotations: map[string]string{"juju.is/version": "2.9.37"},
 						},
 						Spec: getPodSpec(),
 					},
@@ -792,7 +812,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 func (s *applicationSuite) TestEnsureTrusted(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, true, func() {},
+		c, app, false, constraints.Value{}, true, "", func() {},
 	)
 	s.assertDelete(c, app)
 }
@@ -800,7 +820,7 @@ func (s *applicationSuite) TestEnsureTrusted(c *gc.C) {
 func (s *applicationSuite) TestEnsureUntrusted(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, false, func() {},
+		c, app, false, constraints.Value{}, false, "", func() {},
 	)
 	s.assertDelete(c, app)
 }
@@ -816,7 +836,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 		podSpec.ImagePullSecrets...,
 	)
 	s.assertEnsure(
-		c, app, true, constraints.Value{}, true, func() {
+		c, app, true, constraints.Value{}, true, "", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(svc, gc.DeepEquals, &corev1.Service{
@@ -828,7 +848,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version": "1.1.1",
+						"juju.is/version": "2.9.37",
 						"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 					},
 				},
@@ -851,7 +871,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "1.1.1",
+						"juju.is/version":  "2.9.37",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -865,7 +885,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "1.1.1"},
+							Annotations: map[string]string{"juju.is/version": "2.9.37"},
 						},
 						Spec: podSpec,
 					},
@@ -904,7 +924,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateless, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, true, func() {
+		c, app, false, constraints.Value{}, true, "", func() {
 			ss, err := s.client.AppsV1().Deployments("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 
@@ -951,7 +971,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "1.1.1",
+						"juju.is/version":  "2.9.37",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -963,7 +983,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "1.1.1"},
+							Annotations: map[string]string{"juju.is/version": "2.9.37"},
 						},
 						Spec: podSpec,
 					},
@@ -977,7 +997,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentDaemon, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, true, func() {
+		c, app, false, constraints.Value{}, true, "", func() {
 			ss, err := s.client.AppsV1().DaemonSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 
@@ -1024,7 +1044,7 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "1.1.1",
+						"juju.is/version":  "2.9.37",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -1035,7 +1055,7 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "1.1.1"},
+							Annotations: map[string]string{"juju.is/version": "2.9.37"},
 						},
 						Spec: podSpec,
 					},
@@ -1070,7 +1090,7 @@ func (s *applicationSuite) TestExistsDeployment(c *gc.C) {
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -1109,7 +1129,7 @@ func (s *applicationSuite) TestExistsStatefulSet(c *gc.C) {
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -1149,7 +1169,7 @@ func (s *applicationSuite) TestExistsDaemonSet(c *gc.C) {
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
@@ -1170,93 +1190,24 @@ func (s *applicationSuite) TestExistsDaemonSet(c *gc.C) {
 	})
 }
 
+// Test upgrades are performed by ensure. Regression bug for lp1997253
 func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
-	// Not mock applier and ensure the resources created in the s.client.
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, true, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, true, "2.9.34", func() {})
 
-	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
-	defer ctrl.Finish()
+	s.assertEnsure(c, app, false, constraints.Value{}, true, "2.9.37", func() {})
 
-	targetVersion := version.MustParse("2.9.1")
-	versionKey := k8sutils.AnnotationVersionKey(app.IsLegacyLabels())
+	ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+	c.Assert(err, jc.ErrorIsNil)
 
-	assertExpectedVersion := func(r application.AnnotationUpdater) {
-		c.Assert(r.Get(context.Background(), s.client), jc.ErrorIsNil)
-		c.Assert(r.GetAnnotations()[versionKey], gc.Equals, "1.1.1")
-		r.SetAnnotations(annotations.New(r.GetAnnotations()).Add(
-			versionKey, targetVersion.String(),
-		))
-	}
-
-	headlessSvc := resources.NewService("gitlab-endpoints", "test", nil)
-	assertExpectedVersion(headlessSvc)
-
-	ss := resources.NewStatefulSet("gitlab", "test", nil)
-	assertExpectedVersion(ss)
-	ss.Spec.Template.SetAnnotations(annotations.New(ss.Spec.Template.GetAnnotations()).Add(
-		versionKey, targetVersion.String(),
-	))
-	initContainer := ss.Spec.Template.Spec.InitContainers[0]
-	c.Assert(initContainer.Image, gc.Equals, `operator/image-path:1.1.1`)
-	initContainer.Image = `operator/image-path:2.9.1`
-	ss.Spec.Template.Spec.InitContainers = []corev1.Container{initContainer}
-
-	secret := resources.NewSecret("gitlab-application-config", "test", nil)
-	assertExpectedVersion(secret)
-
-	sa := resources.NewServiceAccount("gitlab", "test", nil)
-	assertExpectedVersion(sa)
-
-	role := resources.NewRole("gitlab", "test", nil)
-	assertExpectedVersion(role)
-
-	rolebinding := resources.NewRoleBinding("gitlab", "test", nil)
-	assertExpectedVersion(rolebinding)
-
-	clusterrole := resources.NewClusterRole("test-gitlab", nil)
-	assertExpectedVersion(clusterrole)
-
-	clusterrolebinding := resources.NewClusterRoleBinding("test-gitlab", nil)
-	assertExpectedVersion(clusterrolebinding)
-
-	svc := resources.NewService("gitlab", "test", nil)
-	assertExpectedVersion(svc)
-
-	gomock.InOrder(
-		s.applier.EXPECT().Apply(headlessSvc),
-		s.applier.EXPECT().Apply(ss),
-		s.applier.EXPECT().Apply(secret),
-		s.applier.EXPECT().Apply(sa),
-		s.applier.EXPECT().Apply(role),
-		s.applier.EXPECT().Apply(rolebinding),
-		s.applier.EXPECT().Apply(clusterrole),
-		s.applier.EXPECT().Apply(clusterrolebinding),
-		s.applier.EXPECT().Apply(svc),
-		s.applier.EXPECT().Run(context.Background(), s.client, false).Return(nil),
-	)
-	c.Assert(app.Upgrade(targetVersion), jc.ErrorIsNil)
-}
-
-func (s *applicationSuite) TestUpgradeStateless(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
-	defer ctrl.Finish()
-	err := app.Upgrade(version.MustParse("2.9.1"))
-	c.Assert(err, gc.ErrorMatches, `upgrade for deployment type "stateless" not supported`)
-}
-
-func (s *applicationSuite) TestUpgradeDaemon(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentDaemon, true)
-	defer ctrl.Finish()
-	err := app.Upgrade(version.MustParse("2.9.1"))
-	c.Assert(err, gc.ErrorMatches, `upgrade for deployment type "daemon" not supported`)
-}
-
-func (s *applicationSuite) TestUpgradeNotsupported(c *gc.C) {
-	app, ctrl := s.getApp(c, "bad-deployment-type", true)
-	defer ctrl.Finish()
-	err := app.Upgrade(version.MustParse("2.9.1"))
-	c.Assert(err, gc.ErrorMatches, `unknown deployment type "bad-deployment-type" not supported`)
+	c.Assert(len(ss.Spec.Template.Spec.InitContainers), gc.Equals, 1)
+	c.Assert(ss.Spec.Template.Spec.InitContainers[0].Args, jc.DeepEquals, []string{
+		"init",
+		"--containeragent-pebble-dir", "/containeragent/pebble",
+		"--charm-modified-version", "9001",
+		"--data-dir", "/var/lib/juju",
+		"--bin-dir", "/charm/bin",
+	})
 }
 
 func (s *applicationSuite) TestDeleteStateful(c *gc.C) {
@@ -1385,7 +1336,7 @@ func (s *applicationSuite) assertState(c *gc.C, deploymentType caas.DeploymentTy
 			Name:        "pod1",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 	}
 	_, err := s.client.CoreV1().Pods("test").Create(context.TODO(),
@@ -1398,7 +1349,7 @@ func (s *applicationSuite) assertState(c *gc.C, deploymentType caas.DeploymentTy
 			Name:        "pod2",
 			Namespace:   "test",
 			Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 	}
 	_, err = s.client.CoreV1().Pods("test").Create(context.TODO(),
@@ -1425,7 +1376,7 @@ func (s *applicationSuite) TestStateStateful(c *gc.C) {
 					"app.kubernetes.io/name":       "gitlab",
 					"app.kubernetes.io/managed-by": "juju",
 				},
-				Annotations: map[string]string{"juju.is/version": "1.1.1"},
+				Annotations: map[string]string{"juju.is/version": "2.9.37"},
 			},
 			Spec: appsv1.StatefulSetSpec{
 				Selector: &metav1.LabelSelector{
@@ -1453,7 +1404,7 @@ func (s *applicationSuite) TestStateStateless(c *gc.C) {
 					"app.kubernetes.io/name":       "gitlab",
 					"app.kubernetes.io/managed-by": "juju",
 				},
-				Annotations: map[string]string{"juju.is/version": "1.1.1"},
+				Annotations: map[string]string{"juju.is/version": "2.9.37"},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
@@ -1481,7 +1432,7 @@ func (s *applicationSuite) TestStateDaemon(c *gc.C) {
 					"app.kubernetes.io/name":       "gitlab",
 					"app.kubernetes.io/managed-by": "juju",
 				},
-				Annotations: map[string]string{"juju.is/version": "1.1.1"},
+				Annotations: map[string]string{"juju.is/version": "2.9.37"},
 			},
 			Spec: appsv1.DaemonSetSpec{
 				Selector: &metav1.LabelSelector{
@@ -1508,7 +1459,7 @@ func getDefaultSvc() *corev1.Service {
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app.kubernetes.io/name": "gitlab"},
@@ -1535,7 +1486,7 @@ func (s *applicationSuite) TestUpdatePortsStatelessUpdateContainerPorts(c *gc.C)
 					"app.kubernetes.io/managed-by": "juju",
 				},
 				Annotations: map[string]string{
-					"juju.is/version":  "1.1.1",
+					"juju.is/version":  "2.9.37",
 					"app.juju.is/uuid": "appuuid",
 				},
 			},
@@ -1546,7 +1497,7 @@ func (s *applicationSuite) TestUpdatePortsStatelessUpdateContainerPorts(c *gc.C)
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-						Annotations: map[string]string{"juju.is/version": "1.1.1"},
+						Annotations: map[string]string{"juju.is/version": "2.9.37"},
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{
@@ -1665,7 +1616,7 @@ func (s *applicationSuite) TestUpdatePortsStatefulUpdateContainerPorts(c *gc.C) 
 					"app.kubernetes.io/managed-by": "juju",
 				},
 				Annotations: map[string]string{
-					"juju.is/version":  "1.1.1",
+					"juju.is/version":  "2.9.37",
 					"app.juju.is/uuid": "appuuid",
 				},
 			},
@@ -1676,7 +1627,7 @@ func (s *applicationSuite) TestUpdatePortsStatefulUpdateContainerPorts(c *gc.C) 
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-						Annotations: map[string]string{"juju.is/version": "1.1.1"},
+						Annotations: map[string]string{"juju.is/version": "2.9.37"},
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{
@@ -1795,7 +1746,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdateContainerPorts(c *gc.C) {
 					"app.kubernetes.io/managed-by": "juju",
 				},
 				Annotations: map[string]string{
-					"juju.is/version":  "1.1.1",
+					"juju.is/version":  "2.9.37",
 					"app.juju.is/uuid": "appuuid",
 				},
 			},
@@ -1806,7 +1757,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdateContainerPorts(c *gc.C) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-						Annotations: map[string]string{"juju.is/version": "1.1.1"},
+						Annotations: map[string]string{"juju.is/version": "2.9.37"},
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{
@@ -2025,7 +1976,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 				Namespace:   s.namespace,
 				Name:        fmt.Sprintf("%s-%d", s.appName, i),
 				Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-				Annotations: map[string]string{"juju.is/version": "1.1.1"},
+				Annotations: map[string]string{"juju.is/version": "2.9.37"},
 			},
 			Spec: podSpec,
 			Status: corev1.PodStatus{
@@ -2501,7 +2452,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 func (s *applicationSuite) TestServiceActive(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, false, func() {},
+		c, app, false, constraints.Value{}, false, "", func() {},
 	)
 	defer s.assertDelete(c, app)
 
@@ -2540,7 +2491,7 @@ func (s *applicationSuite) TestServiceActive(c *gc.C) {
 func (s *applicationSuite) TestServiceNotSupportedDaemon(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentDaemon, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, false, func() {},
+		c, app, false, constraints.Value{}, false, "", func() {},
 	)
 	defer s.assertDelete(c, app)
 
@@ -2557,7 +2508,7 @@ func (s *applicationSuite) TestServiceNotSupportedDaemon(c *gc.C) {
 func (s *applicationSuite) TestServiceNotSupportedStateless(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateless, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, false, func() {},
+		c, app, false, constraints.Value{}, false, "", func() {},
 	)
 	defer s.assertDelete(c, app)
 
@@ -2574,7 +2525,7 @@ func (s *applicationSuite) TestServiceNotSupportedStateless(c *gc.C) {
 func (s *applicationSuite) TestServiceTerminated(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, false, func() {},
+		c, app, false, constraints.Value{}, false, "", func() {},
 	)
 	defer s.assertDelete(c, app)
 
@@ -2614,7 +2565,7 @@ func (s *applicationSuite) TestServiceTerminated(c *gc.C) {
 func (s *applicationSuite) TestServiceError(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, false, func() {},
+		c, app, false, constraints.Value{}, false, "", func() {},
 	)
 	defer s.assertDelete(c, app)
 
@@ -2673,7 +2624,7 @@ func (s *applicationSuite) TestServiceError(c *gc.C) {
 func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, func() {
+		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, "", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(svc, gc.DeepEquals, &corev1.Service{
@@ -2685,7 +2636,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version": "1.1.1",
+						"juju.is/version": "2.9.37",
 						"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
 					},
 				},
@@ -2721,7 +2672,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 						"app.kubernetes.io/managed-by": "juju",
 					},
 					Annotations: map[string]string{
-						"juju.is/version":  "1.1.1",
+						"juju.is/version":  "2.9.37",
 						"app.juju.is/uuid": "appuuid",
 					},
 				},
@@ -2735,7 +2686,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
-							Annotations: map[string]string{"juju.is/version": "1.1.1"},
+							Annotations: map[string]string{"juju.is/version": "2.9.37"},
 						},
 						Spec: ps,
 					},
@@ -2781,7 +2732,7 @@ func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
@@ -2802,7 +2753,7 @@ func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Annotations: map[string]string{"juju.is/version": "1.1.1"},
+			Annotations: map[string]string{"juju.is/version": "2.9.37"},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
@@ -2813,7 +2764,7 @@ func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
 		metav1.CreateOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.assertEnsure(c, app, false, constraints.Value{}, true, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, true, "", func() {})
 
 	_, err = s.client.CoreV1().Secrets(s.namespace).Get(context.TODO(), "gitlab-oldcontainer-secret", metav1.GetOptions{})
 	c.Assert(err, gc.ErrorMatches, `secrets "gitlab-oldcontainer-secret" not found`)
@@ -2920,7 +2871,7 @@ func (s *applicationSuite) TestLimits(c *gc.C) {
 
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, func() {
+		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, "", func() {
 			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			for _, ctr := range ss.Spec.Template.Spec.Containers {

--- a/caas/kubernetes/provider/application/scale_test.go
+++ b/caas/kubernetes/provider/application/scale_test.go
@@ -17,7 +17,7 @@ import (
 
 func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
 	ss, err := s.client.AppsV1().StatefulSets(s.namespace).Get(
@@ -31,7 +31,7 @@ func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateless, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
 	dep, err := s.client.AppsV1().Deployments(s.namespace).Get(
@@ -45,7 +45,7 @@ func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 
 func (s *applicationSuite) TestApplicationScaleStatefulLessThanZero(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
-	s.assertEnsure(c, app, false, constraints.Value{}, false, func() {})
+	s.assertEnsure(c, app, false, constraints.Value{}, false, "", func() {})
 
 	c.Assert(errors.IsNotValid(app.Scale(-1)), jc.IsTrue)
 }

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -655,11 +655,6 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 			VolumeMounts: []core.VolumeMount{
 				{
 					Name:      "charm-data",
-					MountPath: "/var/lib/pebble/default",
-					SubPath:   "containeragent/pebble",
-				},
-				{
-					Name:      "charm-data",
 					MountPath: "/charm/bin",
 					SubPath:   "charm/bin",
 					ReadOnly:  true,
@@ -673,6 +668,11 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 					Name:      "charm-data",
 					MountPath: "/charm/containers",
 					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
 				},
 				{
 					Name:      "juju-controller-test-agent-conf",
@@ -924,16 +924,16 @@ EOF
 				SubPath:   "var/lib/juju",
 			}, {
 				Name:      "charm-data",
-				MountPath: "/containeragent/pebble",
-				SubPath:   "containeragent/pebble",
-			}, {
-				Name:      "charm-data",
 				MountPath: "/charm/bin",
 				SubPath:   "charm/bin",
 			}, {
 				Name:      "charm-data",
 				MountPath: "/charm/containers",
 				SubPath:   "charm/containers",
+			}, {
+				Name:      "charm-data",
+				MountPath: "/containeragent/pebble",
+				SubPath:   "containeragent/pebble",
 			}, {
 				Name:      "juju-controller-test-agent-conf",
 				MountPath: "/var/lib/juju/template-agent.conf",

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -40,7 +40,9 @@ func (k *kubernetesClient) Upgrade(agentTag string, vers version.Number) error {
 	case names.ModelTagKind:
 		return k.upgradeModelOperator(tag, vers)
 	case names.UnitTagKind:
-		return k.upgradeApplication(tag, vers)
+		// Sidecar charms don't have an upgrade step.
+		// See PR 14974
+		return nil
 	}
 	return errors.NotImplementedf("k8s upgrade for agent tag %q", agentTag)
 }

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -10,7 +10,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
-	version "github.com/juju/version/v2"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -194,20 +193,6 @@ func (m *MockApplication) UpdateService(arg0 caas.ServiceParam) error {
 func (mr *MockApplicationMockRecorder) UpdateService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockApplication)(nil).UpdateService), arg0)
-}
-
-// Upgrade mocks base method.
-func (m *MockApplication) Upgrade(arg0 version.Number) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upgrade", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Upgrade indicates an expected call of Upgrade.
-func (mr *MockApplicationMockRecorder) Upgrade(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upgrade", reflect.TypeOf((*MockApplication)(nil).Upgrade), arg0)
 }
 
 // Watch mocks base method.

--- a/tests/suites/static_analysis/lint_shell.sh
+++ b/tests/suites/static_analysis/lint_shell.sh
@@ -1,5 +1,5 @@
 run_shellcheck() {
-	OUT=$(shellcheck --shell=bash tests/main.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
+	OUT=$(shellcheck --shell=bash --severity=warning tests/main.sh tests/includes/*.sh tests/suites/**/*.sh 2>&1 || true)
 	if [ -n "${OUT}" ]; then
 		echo ""
 		echo "$(red 'Found some issues:')"

--- a/worker/caasapplicationprovisioner/application.go
+++ b/worker/caasapplicationprovisioner/application.go
@@ -196,7 +196,7 @@ func (a *appWorker) loop() error {
 	}
 
 	var appChanges watcher.NotifyChannel
-	var appStateChanges watcher.NotifyChannel
+	var appProvisionChanges watcher.NotifyChannel
 	var replicaChanges watcher.NotifyChannel
 	var lastReportedStatus map[string]status.StatusInfo
 
@@ -245,15 +245,15 @@ func (a *appWorker) loop() error {
 		a.life = appLife
 		switch appLife {
 		case life.Alive:
-			if appStateChanges == nil {
-				appStateWatcher, err := a.facade.WatchApplication(a.name)
+			if appProvisionChanges == nil {
+				appProvisionWatcher, err := a.facade.WatchProvisioningInfo(a.name)
 				if err != nil {
-					return errors.Annotatef(err, "failed to watch facade for changes to application %q", a.name)
+					return errors.Annotatef(err, "failed to watch facade for changes to application provisioning %q", a.name)
 				}
-				if err := a.catacomb.Add(appStateWatcher); err != nil {
+				if err := a.catacomb.Add(appProvisionWatcher); err != nil {
 					return errors.Trace(err)
 				}
-				appStateChanges = appStateWatcher.Changes()
+				appProvisionChanges = appProvisionWatcher.Changes()
 			}
 			err = a.alive(app)
 			if errors.Is(err, errors.NotProvisioned) {
@@ -376,7 +376,7 @@ func (a *appWorker) loop() error {
 			}
 		case <-a.catacomb.Dying():
 			return a.catacomb.ErrDying()
-		case <-appStateChanges:
+		case <-appProvisionChanges:
 			err = handleChange()
 			if err != nil {
 				return errors.Trace(err)

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -63,13 +63,14 @@ type testCase struct {
 	brokerApp  *caasmocks.MockApplication
 	unitFacade *mocks.MockCAASUnitProvisionerFacade
 
-	appScaleChan     chan struct{}
-	notifyReady      chan struct{}
-	appStateChan     chan struct{}
-	appChan          chan struct{}
-	appReplicasChan  chan struct{}
-	appTrustHashChan chan []string
-	unitsChan        chan []string
+	appScaleChan         chan struct{}
+	notifyReady          chan struct{}
+	appStateChan         chan struct{}
+	appChan              chan struct{}
+	appReplicasChan      chan struct{}
+	appTrustHashChan     chan []string
+	unitsChan            chan []string
+	provisioningInfoChan chan struct{}
 }
 
 func (s *ApplicationWorkerSuite) getWorker(c *gc.C, name string) (func(...*gomock.Call) worker.Worker, testCase, *gomock.Controller) {
@@ -130,6 +131,7 @@ func (s *ApplicationWorkerSuite) getWorker(c *gc.C, name string) (func(...*gomoc
 	tc.appReplicasChan = make(chan struct{}, 1)
 	tc.appTrustHashChan = make(chan []string, 1)
 	tc.unitsChan = make(chan []string, 1)
+	tc.provisioningInfoChan = make(chan struct{}, 1)
 
 	startFunc := func(additionalAssertCalls ...*gomock.Call) worker.Worker {
 		config := caasapplicationprovisioner.AppWorkerConfig{
@@ -483,8 +485,10 @@ func (s *ApplicationWorkerSuite) assertWorker(c *gc.C, name string) {
 		steps := []func(){
 			// Test replica changes.
 			func() { tc.appReplicasChan <- struct{}{} },
+
 			// Test app state changes.
-			func() { tc.appStateChan <- struct{}{} },
+			func() { tc.provisioningInfoChan <- struct{}{} },
+
 			// Test app changes from cloud.
 			func() { tc.appChan <- struct{}{} },
 			// Test Notify - dying.

--- a/worker/caasapplicationprovisioner/application_test.go
+++ b/worker/caasapplicationprovisioner/application_test.go
@@ -167,7 +167,7 @@ func (s *ApplicationWorkerSuite) getWorker(c *gc.C, name string) (func(...*gomoc
 			tc.facade.EXPECT().WatchUnits(name).Return(watchertest.NewMockStringsWatcher(tc.unitsChan), nil),
 			// Initial run - Ensure() for the application.
 			tc.facade.EXPECT().Life(name).Return(life.Alive, nil),
-			tc.facade.EXPECT().WatchApplication(name).Return(watchertest.NewMockNotifyWatcher(tc.appStateChan), nil),
+			tc.facade.EXPECT().WatchProvisioningInfo(name).Return(watchertest.NewMockNotifyWatcher(tc.provisioningInfoChan), nil),
 			tc.facade.EXPECT().ProvisioningInfo(name).Return(s.appProvisioningInfo, nil),
 			tc.facade.EXPECT().CharmInfo("cs:test").Return(s.appCharmInfo, nil),
 			tc.brokerApp.EXPECT().Exists().Return(caas.DeploymentState{}, nil),

--- a/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -246,6 +246,21 @@ func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplications() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplications", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplications))
 }
 
+// WatchProvisioningInfo mocks base method.
+func (m *MockCAASProvisionerFacade) WatchProvisioningInfo(arg0 string) (watcher.NotifyWatcher, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchProvisioningInfo", arg0)
+	ret0, _ := ret[0].(watcher.NotifyWatcher)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchProvisioningInfo indicates an expected call of WatchProvisioningInfo.
+func (mr *MockCAASProvisionerFacadeMockRecorder) WatchProvisioningInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchProvisioningInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchProvisioningInfo), arg0)
+}
+
 // WatchUnits mocks base method.
 func (m *MockCAASProvisionerFacade) WatchUnits(arg0 string) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()

--- a/worker/caasapplicationprovisioner/worker.go
+++ b/worker/caasapplicationprovisioner/worker.go
@@ -61,6 +61,7 @@ type CAASProvisionerFacade interface {
 	ClearApplicationResources(appName string) error
 	WatchUnits(application string) (watcher.StringsWatcher, error)
 	RemoveUnit(unitName string) error
+	WatchProvisioningInfo(string) (watcher.NotifyWatcher, error)
 }
 
 // CAASBroker exposes CAAS broker functionality to a worker.


### PR DESCRIPTION
Forward merge of 2.9 into 3.0

Conflicts:
            api/controller/caasapplicationprovisioner/client.go
            apiserver/backup_test.go
            apiserver/facades/client/backups/create.go
            apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
            caas/kubernetes/provider/application/application.go
            caas/mocks/application_mock.go
            state/backups/db.go
            worker/caasapplicationprovisioner/application_test.go