### PR TITLE
[JUJU-2355] CI: Speed up go generate

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Regenerate code
         shell: bash
         run: |
-          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 0 -I% go generate -x $(realpath %)
+          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 2 -I% go generate -x $(realpath %)
 
       - name: Check diff
         if: success() || failure()

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -40,7 +40,8 @@ jobs:
 
       - name: Regenerate code
         shell: bash
-        run: go generate -x ./...
+        run: |
+          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -I% go generate -x $(realpath %)
 
       - name: Check diff
         if: success() || failure()

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Regenerate code
         shell: bash
         run: |
-          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -I% go generate -x $(realpath %)
+          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 0 -I% go generate -x $(realpath %)
 
       - name: Check diff
         if: success() || failure()

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -41,6 +41,16 @@ jobs:
       - name: Regenerate code
         shell: bash
         run: |
+          # Running go generate by itself is slow over a large codebase, where
+          # all generate directives are dispersed over many files. Instead, the
+          # following uses tools for locating and extracting the directives,
+          # before piping them to go generate in parallel.
+          #
+          #  1. grep for go generate directive in the go files recursively.
+          #  2. Grab the file name of each select file.
+          #  3. Unique every file, so we only go generate the file once.
+          #  4. Using xargs perform go generate in parallel.
+          #
           grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 2 -I% go generate -x $(realpath %)
 
       - name: Check diff


### PR DESCRIPTION
The following attempt to speed up github/generate workflow. The go generate command takes forever to trawl the codebase, so instead, we'll use grep to select the go generates and do it manually.

We then have the option of parallelizing the generate commands.

## Checklist

- [x] Comments saying why design decisions were made

## QA steps

See the github action.

