### PR TITLE
Fix panic when trying to match storage class.

### DIFF
--- a/caas/kubernetes/provider/metadata.go
+++ b/caas/kubernetes/provider/metadata.go
@@ -251,13 +251,14 @@ func (k *kubernetesClient) CheckDefaultWorkloadStorage(cloudType string, storage
 }
 
 func storageClassMatches(preferredStorage caas.PreferredStorage, storageProvisioner *caas.StorageProvisioner) error {
+	if storageProvisioner == nil || preferredStorage.Provisioner != storageProvisioner.Provisioner {
+		return &caas.NonPreferredStorageError{PreferredStorage: preferredStorage}
+	}
+
 	if preferredStorage.SupportsDefault && storageProvisioner.IsDefault {
 		return nil
 	}
 
-	if storageProvisioner == nil || preferredStorage.Provisioner != storageProvisioner.Provisioner {
-		return &caas.NonPreferredStorageError{PreferredStorage: preferredStorage}
-	}
 	for k, v := range preferredStorage.Parameters {
 		param, ok := storageProvisioner.Parameters[k]
 		if !ok || param != v {

--- a/caas/kubernetes/provider/metadata_test.go
+++ b/caas/kubernetes/provider/metadata_test.go
@@ -483,6 +483,14 @@ func (s *K8sMetadataSuite) TestCheckDefaultWorkloadStorageUnknownCluster(c *gc.C
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *K8sMetadataSuite) TestCheckDefaultWorkloadStorageUnknownDefault(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	err := s.broker.CheckDefaultWorkloadStorage("gce", nil)
+	c.Assert(err, jc.Satisfies, caas.IsNonPreferredStorageError)
+}
+
 func (s *K8sMetadataSuite) TestCheckDefaultWorkloadStorageNonpreferred(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
Fixes panic when trying to match storage classes when ambiguous.

## QA steps

Use add-k8s to add a k8s cloud with two storage classes but no default.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1996808