### PR TITLE
Force controller config changes to be coerced to schema defined types.

### DIFF
--- a/cmd/juju/controller/config.go
+++ b/cmd/juju/controller/config.go
@@ -234,7 +234,7 @@ func (c *configCommand) setConfig(client controllerAPI, ctx *cmd.Context) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	_, err = controller.NewConfig(ctrl.ControllerUUID, ctrl.CACert, attrs)
+	parsed, err := controller.NewConfig(ctrl.ControllerUUID, ctrl.CACert, attrs)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -243,7 +243,7 @@ func (c *configCommand) setConfig(client controllerAPI, ctx *cmd.Context) error 
 	values := make(map[string]interface{})
 	for k := range attrs {
 		if controller.AllowedUpdateConfigAttributes.Contains(k) {
-			values[k] = attrs[k]
+			values[k] = parsed[k]
 		} else {
 			extraValues.Add(k)
 		}

--- a/cmd/juju/controller/config_test.go
+++ b/cmd/juju/controller/config_test.go
@@ -214,7 +214,7 @@ func (s *ConfigSuite) TestSettingFromBothNoOverlap(c *gc.C) {
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
 		"juju-ha-space":         "value",
-		"audit-log-max-backups": "123",
+		"audit-log-max-backups": 123,
 	})
 }
 
@@ -232,7 +232,7 @@ func (s *ConfigSuite) TestSettingFromBothArgFirst(c *gc.C) {
 	// probably not worth fixing - I don't think people will try to
 	// set an option from a file and then override it from an arg.
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": "123",
+		"audit-log-max-backups": 123,
 	})
 }
 
@@ -246,7 +246,7 @@ func (s *ConfigSuite) TestSettingFromBothFileFirst(c *gc.C) {
 	c.Assert(output, gc.Equals, "")
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": "123",
+		"audit-log-max-backups": 123,
 	})
 }
 

--- a/state/controller.go
+++ b/state/controller.go
@@ -96,14 +96,28 @@ func (st *State) ControllerConfig() (jujucontroller.Config, error) {
 // so revert to their defaults). Only a subset of keys can be changed
 // after bootstrapping.
 func (st *State) UpdateControllerConfig(updateAttrs map[string]interface{}, removeAttrs []string) error {
-	if err := st.checkValidControllerConfig(updateAttrs, removeAttrs); err != nil {
-		return errors.Trace(err)
-	}
-
 	settings, err := readSettings(st.db(), controllersC, ControllerSettingsGlobalKey)
 	if err != nil {
 		return errors.Annotatef(err, "controller %q", st.ControllerUUID())
 	}
+	oldValues := settings.Map()
+	coerced, err := jujucontroller.NewConfig(
+		oldValues[jujucontroller.ControllerUUIDKey].(string),
+		oldValues[jujucontroller.CACertKey].(string),
+		updateAttrs,
+	)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	for k := range updateAttrs {
+		updateAttrs[k] = coerced[k]
+	}
+
+	if err := st.checkValidControllerConfig(updateAttrs, removeAttrs); err != nil {
+		return errors.Trace(err)
+	}
+
 	for _, r := range removeAttrs {
 		settings.Delete(r)
 	}


### PR DESCRIPTION
Controller config value for agent-logfile-max-backups and others could be stored in state as a string rather than an int.

## QA steps

Change `agent-logfile-max-backups`
```
juju controller-config agent-logfile-max-backups=3
```

Then check type of `agent-logfile-max-backups` with
```
juju controller-config --format json
```

`agent-logfile-max-backups` should be an int not a string.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/2001732