### PR TITLE
[JUJU-2377] Static analysis output is broken subtly.

### DIFF
--- a/tests/includes/run.sh
+++ b/tests/includes/run.sh
@@ -35,7 +35,7 @@ run() {
 
 	END_TIME=$(date +%s)
 
-	echo -e "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
+	echo -e "\r\033[1A\033[0K===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
 }
 
 # run_linter will run until the end of a pipeline even if there is a failure.
@@ -78,9 +78,9 @@ run_linter() {
 	END_TIME=$(date +%s)
 
 	if [[ ${cmd_status} -eq 0 ]]; then
-		echo -e "\r===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
+		echo -e "\r\033[1A\033[0K===> [ $(green "✔") ] Success: ${DESC} ($((END_TIME - START_TIME))s)"
 	else
-		echo -e "\r===> [ $(red "x") ] Fail: ${DESC} ($((END_TIME - START_TIME))s)"
+		echo -e "\r\033[1A\033[0K===> [ $(red "x") ] Fail: ${DESC} ($((END_TIME - START_TIME))s)"
 		exit 1
 	fi
 }


### PR DESCRIPTION
Previously this worked, but unfortunately, it's broken in some weird and unfortunate way. Fixing it is trivial, just use the correct escape codes to move to the previous line.

The solution now makes the output a lot more concise.


## QA steps

```sh
$ make static-analysis

==> Checking for dependencies
==> Using Juju located at /home/simon/go/bin/juju
==> TEST BEGIN: test_static_analysis (tmp.cjF)
===> [ ✔ ] Success: copyright (1s)
===> [ ✔ ] Success: check doc go (8s)
===> [ ✔ ] Success: go (15s)
===> [ ✔ ] Success: go tidy (0s)
===> [ ✔ ] Success: shellcheck (5s)
===> [ ✔ ] Success: shfmt (0s)
===> [ ✔ ] Success: trailing whitespace (0s)
===> [ ✔ ] Success: compileall (1s)
===> [ ✔ ] Success: schema (8s)
==> TEST DONE: test_static_analysis (38s)
==> Cleaning up
====> Completed cleaning up jujus

==> Test result: success
==> Tests Removed: /home/simon/go/src/github.com/juju/juju/tests/tmp.cjF
==> TEST COMPLETE
```

Instead of:

```sh
$ make static-analysis

==> Checking for dependencies
==> Using Juju located at /home/simon/go/bin/juju
==> TEST BEGIN: test_static_analysis (tmp.qEl)
===> [   ] Running: copyright
===> [ ✔ ] Success: copyright (0s)
===> [   ] Running: check doc go
===> [ ✔ ] Success: check doc go (9s)
===> [   ] Running: go
===> [ ✔ ] Success: go (15s)
===> [   ] Running: go tidy
===> [ ✔ ] Success: go tidy (0s)
===> [   ] Running: shellcheck
===> [ ✔ ] Success: shellcheck (5s)
===> [   ] Running: shfmt
===> [ ✔ ] Success: shfmt (0s)
===> [   ] Running: trailing whitespace
===> [ ✔ ] Success: trailing whitespace (0s)
===> [   ] Running: compileall
===> [ ✔ ] Success: compileall (0s)
===> [   ] Running: schema
===> [ ✔ ] Success: schema (9s)
==> TEST DONE: test_static_analysis (38s)
==> Cleaning up
====> Completed cleaning up jujus

==> Test result: success
==> Tests Removed: /home/simon/go/src/github.com/juju/juju/tests/tmp.qEl
==> TEST COMPLETE
```

## Bug reference

https://warthogs.atlassian.net/browse/JUJU-2377


[JUJU-2377]: https://warthogs.atlassian.net/browse/JUJU-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ