### PR TITLE
[JUJU-2390] Error message with no current model selected

### DIFF
--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -82,7 +82,9 @@ func (c *switchCommand) SetClientStore(store jujuclient.ClientStore) {
 }
 
 func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
-	store := modelcmd.QualifyingClientStore{c.Store}
+	store := modelcmd.QualifyingClientStore{
+		ClientStore: c.Store,
+	}
 
 	// Get the current name for logging the transition or printing
 	// the current controller/model.


### PR DESCRIPTION
With the prior change of not creating a default model, there are now occasions where the error messages are terrible from a UX perspective. For example, bootstrapping then doing juju status is really, really unhelpful. To better the UX, the solution is to just add a hint to use juju switch or juju add-model.

The code is simple, it was just never done.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

After bootstrap:

```sh
$ juju bootstrap lxd test
$ juju status
ERROR No selected model.

Only the controller model exists. Use "juju add-model" to create an initial model.
```

After creating an initial model, but removing "current-model" from `./local/share/juju/models.yaml`
Note: we print out the whole namespace, because of SAAS models.

```sh
$ juju status
ERROR No selected model.

Use "juju switch" to select one of the following models:

  - test:admin/default
```

When destroying the default model, which is a reminder to create a new default one.

```sh
juju destroy-model default
WARNING! This command will destroy the "default" model.

To continue, enter the name of the model to be destroyed: default
Destroying model
Waiting for model to be removed...
Model destroyed.
WARNING cannot read current model: No selected model.

Only the controller model exists. Use "juju add-model" to create an initial model.
```

## Bug reference

https://warthogs.atlassian.net/browse/JUJU-2390
