### PR TITLE
[JUJU-2311] no charmstore in state

### DIFF
--- a/apiserver/facades/controller/charmdownloader/interfaces.go
+++ b/apiserver/facades/controller/charmdownloader/interfaces.go
@@ -5,7 +5,6 @@ package charmdownloader
 
 import (
 	"github.com/juju/charm/v9"
-	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/facades/client/charms/services"
 	"github.com/juju/juju/controller"
@@ -42,7 +41,6 @@ type Application interface {
 // Charm provides an API for querying charm details.
 type Charm interface {
 	URL() *charm.URL
-	Macaroon() (macaroon.Slice, error)
 }
 
 // Downloader defines an API for downloading and storing charms.

--- a/apiserver/facades/controller/charmdownloader/mocks/mocks.go
+++ b/apiserver/facades/controller/charmdownloader/mocks/mocks.go
@@ -16,7 +16,6 @@ import (
 	status "github.com/juju/juju/core/status"
 	config "github.com/juju/juju/environs/config"
 	state "github.com/juju/juju/state"
-	macaroon "gopkg.in/macaroon.v2"
 )
 
 // MockStateBackend is a mock of StateBackend interface.
@@ -284,21 +283,6 @@ func NewMockCharm(ctrl *gomock.Controller) *MockCharm {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 	return m.recorder
-}
-
-// Macaroon mocks base method.
-func (m *MockCharm) Macaroon() (macaroon.Slice, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Macaroon")
-	ret0, _ := ret[0].(macaroon.Slice)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Macaroon indicates an expected call of Macaroon.
-func (mr *MockCharmMockRecorder) Macaroon() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Macaroon", reflect.TypeOf((*MockCharm)(nil).Macaroon))
 }
 
 // URL mocks base method.

--- a/state/application.go
+++ b/state/application.go
@@ -82,7 +82,7 @@ type applicationDoc struct {
 	Subordinate bool   `bson:"subordinate"`
 	// CharmURL and channel should be moved to CharmOrigin. Attempting it should
 	// be relatively straight forward, but very time consuming.
-	// When moving to CharmHub or removing CharmStore from Juju it should be
+	// When moving to CharmHub from Juju it should be
 	// tackled then.
 	CharmURL             *string      `bson:"charmurl"`
 	CharmOrigin          CharmOrigin  `bson:"charm-origin"`

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -109,7 +109,7 @@ func (s *ApplicationSuite) TestSetCharmCharmOrigin(c *gc.C) {
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
 	rev := sch.Revision()
 	origin := &state.CharmOrigin{
-		Source:   "charm-store",
+		Source:   "charm-hub",
 		Revision: &rev,
 		Platform: &state.Platform{
 			OS:      "ubuntu",
@@ -133,7 +133,7 @@ func (s *ApplicationSuite) TestSetCharmCharmOriginNoChange(c *gc.C) {
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
 	rev := sch.Revision()
 	origin := &state.CharmOrigin{
-		Source:   "charm-store",
+		Source:   "charm-hub",
 		Revision: &rev,
 	}
 	cfg := state.SetCharmConfig{
@@ -645,7 +645,7 @@ func (s *ApplicationSuite) TestClientApplicationSetCharmUnsupportedSeries(c *gc.
 		Charm: chDifferentSeries,
 	}
 	err := app.SetCharm(cfg)
-	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "application" to charm "cs:multi-series2-8": only these series are supported: trusty, wily`)
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "application" to charm "ch:multi-series2-8": only these series are supported: trusty, wily`)
 }
 
 func (s *ApplicationSuite) TestClientApplicationSetCharmUnsupportedSeriesForce(c *gc.C) {
@@ -663,7 +663,7 @@ func (s *ApplicationSuite) TestClientApplicationSetCharmUnsupportedSeriesForce(c
 	c.Assert(err, jc.ErrorIsNil)
 	ch, _, err = app.Charm()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch.String(), gc.Equals, "cs:multi-series2-8")
+	c.Assert(ch.String(), gc.Equals, "ch:multi-series2-8")
 }
 
 func (s *ApplicationSuite) TestClientApplicationSetCharmWrongOS(c *gc.C) {
@@ -676,19 +676,7 @@ func (s *ApplicationSuite) TestClientApplicationSetCharmWrongOS(c *gc.C) {
 		ForceBase: true,
 	}
 	err := app.SetCharm(cfg)
-	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "application" to charm "cs:multi-series-centos-1": OS "Ubuntu" not supported by charm`)
-}
-
-func (s *ApplicationSuite) TestSetCharmChangeSeriesWhenMovingFromCharmstoreToCharmhub(c *gc.C) {
-	// Moving from a cs to a ch charm should not prevent us from changing the series.
-	chCharm := state.AddTestingCharmhubCharmForSeries(c, s.State, "quantal", "multi-series")
-	cfg := state.SetCharmConfig{
-		Charm:      chCharm,
-		ForceUnits: true,
-	}
-
-	err := s.mysql.SetCharm(cfg)
-	c.Assert(err, jc.ErrorIsNil, gc.Commentf("expected SetCharm to work with different series when switching from a charmstore to a charmhub charm"))
+	c.Assert(err, gc.ErrorMatches, `cannot upgrade application "application" to charm "ch:multi-series-centos-1": OS "Ubuntu" not supported by charm`)
 }
 
 func (s *ApplicationSuite) TestSetCharmPreconditions(c *gc.C) {
@@ -1716,7 +1704,7 @@ func (s *ApplicationSuite) setupCharmForTestUpdateApplicationBase(c *gc.C, name 
 
 	rev := ch.Revision()
 	origin := &state.CharmOrigin{
-		Source:   "charm-store",
+		Source:   "charm-hub",
 		Revision: &rev,
 		Platform: &state.Platform{
 			OS:      "ubuntu",
@@ -1795,7 +1783,7 @@ func (s *ApplicationSuite) TestUpdateApplicationSeriesCharmURLChangedSeriesFail(
 	// Trusty is listed in only version 1 of the charm.
 	err := app.UpdateApplicationBase(state.UbuntuBase("22.04"), false)
 	c.Assert(err, gc.ErrorMatches,
-		"updating application series: series \"jammy\" not supported by charm \"cs:multi-series-2\", "+
+		"updating application series: series \"jammy\" not supported by charm \"ch:multi-series-2\", "+
 			"supported series are: focal, bionic")
 }
 

--- a/state/charm.go
+++ b/state/charm.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v4"
 	jujutxn "github.com/juju/txn/v3"
-	"gopkg.in/macaroon.v2"
 
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/series"
@@ -26,33 +25,6 @@ import (
 	"github.com/juju/juju/state/storage"
 	jujuversion "github.com/juju/juju/version"
 )
-
-type MacaroonCacheState interface {
-	Charm(*charm.URL) (*Charm, error)
-}
-
-// MacaroonCache is a type that wraps State and implements charmstore.MacaroonCache.
-type MacaroonCache struct {
-	MacaroonCacheState
-}
-
-// Set stores the macaroon on the charm.
-func (m MacaroonCache) Set(u *charm.URL, ms macaroon.Slice) error {
-	c, err := m.Charm(u)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return c.UpdateMacaroon(ms)
-}
-
-// Get retrieves the macaroon for the charm (if any).
-func (m MacaroonCache) Get(u *charm.URL) (macaroon.Slice, error) {
-	c, err := m.Charm(u)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return c.Macaroon()
-}
 
 // Channel identifies and describes completely a store channel.
 type Channel struct {
@@ -189,7 +161,6 @@ type charmDoc struct {
 	// These fields control access to the charm archive.
 	BundleSha256 string `bson:"bundlesha256"`
 	StoragePath  string `bson:"storagepath"`
-	Macaroon     []byte `bson:"macaroon"`
 
 	// The remaining fields hold data sufficient to define a
 	// charm.Charm.
@@ -252,7 +223,6 @@ type CharmInfo struct {
 	ID          *charm.URL
 	StoragePath string
 	SHA256      string
-	Macaroon    macaroon.Slice
 	Version     string
 }
 
@@ -289,13 +259,6 @@ func insertCharmOps(mb modelBackend, info CharmInfo) ([]txn.Op, error) {
 		return nil, errors.Trace(err)
 	}
 
-	if info.Macaroon != nil {
-		mac, err := info.Macaroon.MarshalBinary()
-		if err != nil {
-			return nil, errors.Annotate(err, "can't convert macaroon to binary for storage")
-		}
-		doc.Macaroon = mac
-	}
 	return insertAnyCharmOps(mb, &doc)
 }
 
@@ -402,14 +365,6 @@ func updateCharmOps(mb modelBackend, info CharmInfo, assert bson.D) ([]txn.Op, e
 
 	if err := checkCharmDataIsStorable(data); err != nil {
 		return nil, errors.Trace(err)
-	}
-
-	if len(info.Macaroon) > 0 {
-		mac, err := info.Macaroon.MarshalBinary()
-		if err != nil {
-			return nil, errors.Annotate(err, "can't convert macaroon to binary for storage")
-		}
-		data = append(data, bson.DocElem{"macaroon", mac})
 	}
 
 	op.Update = bson.D{{"$set", data}}
@@ -754,39 +709,6 @@ func (c *Charm) IsUploaded() bool {
 // rather than representing a deployed charm.
 func (c *Charm) IsPlaceholder() bool {
 	return c.doc.Placeholder
-}
-
-// Macaroon return the macaroon that can be used to request data about the charm
-// from the charmstore, or nil if the charm is not private.
-func (c *Charm) Macaroon() (macaroon.Slice, error) {
-	if len(c.doc.Macaroon) == 0 {
-		return nil, nil
-	}
-	var m macaroon.Slice
-	if err := m.UnmarshalBinary(c.doc.Macaroon); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return m, nil
-}
-
-// UpdateMacaroon updates the stored macaroon for this charm.
-func (c *Charm) UpdateMacaroon(m macaroon.Slice) error {
-	info := CharmInfo{
-		Charm:       c,
-		ID:          c.URL(),
-		StoragePath: c.StoragePath(),
-		SHA256:      c.BundleSha256(),
-		Macaroon:    m,
-	}
-	ops, err := updateCharmOps(c.st, info, nil)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := c.st.db().RunTransaction(ops); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
 }
 
 // AddCharm adds the ch charm with curl to the state.

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -15,7 +15,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/storage"
@@ -313,19 +312,6 @@ func (s *CharmSuite) TestAddCharm(c *gc.C) {
 	c.Assert(doc.CharmVersion, gc.Equals, expVersion)
 }
 
-func (s *CharmSuite) TestAddCharmWithAuth(c *gc.C) {
-	// Check that adding charms from scratch works correctly.
-	info := s.dummyCharm(c, "")
-	m, err := macaroon.New([]byte("rootkey"), []byte("id"), "loc", macaroon.LatestVersion)
-	c.Assert(err, jc.ErrorIsNil)
-	info.Macaroon = macaroon.Slice{m}
-	dummy, err := s.State.AddCharm(info)
-	c.Assert(err, jc.ErrorIsNil)
-	ms, err := dummy.Macaroon()
-	c.Assert(err, jc.ErrorIsNil)
-	assertMacaroonEquals(c, ms[0], info.Macaroon[0])
-}
-
 func (s *CharmSuite) TestAddCharmUpdatesPlaceholder(c *gc.C) {
 	// Check that adding charms updates any existing placeholder charm
 	// with the same URL.
@@ -495,10 +481,6 @@ func (s *CharmSuite) TestUpdateUploadedCharm(c *gc.C) {
 	_, err = s.State.PrepareLocalCharmUpload(info.ID)
 	c.Assert(err, jc.ErrorIsNil)
 
-	m, err := macaroon.New([]byte("rootkey"), []byte("id"), "loc", macaroon.LatestVersion)
-	c.Assert(err, jc.ErrorIsNil)
-	info.Macaroon = macaroon.Slice{m}
-	c.Assert(err, jc.ErrorIsNil)
 	sch, err = s.State.UpdateUploadedCharm(info)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sch.URL(), gc.DeepEquals, info.ID)
@@ -509,9 +491,6 @@ func (s *CharmSuite) TestUpdateUploadedCharm(c *gc.C) {
 	c.Assert(sch.Config(), gc.DeepEquals, info.Charm.Config())
 	c.Assert(sch.StoragePath(), gc.DeepEquals, info.StoragePath)
 	c.Assert(sch.BundleSha256(), gc.Equals, "missing")
-	ms, err := sch.Macaroon()
-	c.Assert(err, jc.ErrorIsNil)
-	assertMacaroonEquals(c, ms[0], info.Macaroon[0])
 }
 
 func (s *CharmSuite) TestUpdateUploadedCharmEscapesSpecialCharsInConfig(c *gc.C) {

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -263,7 +263,7 @@ func AddTestingCharmhubCharmForSeries(c *gc.C, st *State, series, name string) *
 func AddTestingCharmMultiSeries(c *gc.C, st *State, name string) *Charm {
 	ch := testcharms.Repo.CharmDir(name)
 	ident := fmt.Sprintf("%s-%d", ch.Meta().Name, ch.Revision())
-	curl := charm.MustParseURL("cs:" + ident)
+	curl := charm.MustParseURL("ch:" + ident)
 	info := CharmInfo{
 		Charm:       ch,
 		ID:          curl,

--- a/state/metrics_test.go
+++ b/state/metrics_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&MetricSuite{})
 
 func (s *MetricSuite) SetUpTest(c *gc.C) {
 	s.ConnSuite.SetUpTest(c)
-	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
+	s.meteredCharm = s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "ch:quantal/metered-1"})
 	s.application = s.Factory.MakeApplication(c, &factory.ApplicationParams{Charm: s.meteredCharm})
 	s.unit = s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.application, SetCharmURL: true})
 }
@@ -75,7 +75,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metricBatch.Unit(), gc.Equals, "metered/0")
 	c.Assert(metricBatch.ModelUUID(), gc.Equals, modelUUID)
-	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
+	c.Assert(metricBatch.CharmURL(), gc.Equals, "ch:quantal/metered-1")
 	c.Assert(metricBatch.Sent(), jc.IsFalse)
 	c.Assert(metricBatch.Created(), gc.Equals, now)
 	c.Assert(metricBatch.Metrics(), gc.HasLen, 2)
@@ -93,7 +93,7 @@ func (s *MetricSuite) TestAddMetric(c *gc.C) {
 	saved, err := s.State.MetricBatch(metricBatch.UUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(saved.Unit(), gc.Equals, "metered/0")
-	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
+	c.Assert(metricBatch.CharmURL(), gc.Equals, "ch:quantal/metered-1")
 	c.Assert(saved.Sent(), jc.IsFalse)
 	c.Assert(saved.Metrics(), gc.HasLen, 2)
 	metric = saved.Metrics()[0]
@@ -131,7 +131,7 @@ func (s *MetricSuite) TestAddMetricOrderedLabels(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metricBatch.Unit(), gc.Equals, "metered/0")
 	c.Assert(metricBatch.ModelUUID(), gc.Equals, modelUUID)
-	c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
+	c.Assert(metricBatch.CharmURL(), gc.Equals, "ch:quantal/metered-1")
 	c.Assert(metricBatch.Sent(), jc.IsFalse)
 	c.Assert(metricBatch.Created(), gc.Equals, now)
 	uniqueMetrics := metricBatch.UniqueMetrics()
@@ -367,7 +367,7 @@ func (s *MetricSuite) TestAllMetricBatches(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(metricBatches, gc.HasLen, 1)
 	c.Assert(metricBatches[0].Unit(), gc.Equals, "metered/0")
-	c.Assert(metricBatches[0].CharmURL(), gc.Equals, "cs:quantal/metered-1")
+	c.Assert(metricBatches[0].CharmURL(), gc.Equals, "ch:quantal/metered-1")
 	c.Assert(metricBatches[0].Sent(), jc.IsFalse)
 	c.Assert(metricBatches[0].Metrics(), gc.HasLen, 1)
 }
@@ -376,7 +376,7 @@ func (s *MetricSuite) TestAllMetricBatchesCustomCharmURLAndUUID(c *gc.C) {
 	now := state.NowToTheSecond(s.State)
 	m := state.Metric{Key: "pings", Value: "5", Time: now}
 	uuid := utils.MustNewUUID().String()
-	charmURL := "cs:quantal/metered-1"
+	charmURL := "ch:quantal/metered-1"
 	_, err := s.State.AddMetrics(
 		state.BatchParam{
 			UUID:     uuid,
@@ -635,7 +635,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(metricBatch.Unit(), gc.Equals, "metered/0")
 			c.Assert(metricBatch.ModelUUID(), gc.Equals, modelUUID)
-			c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
+			c.Assert(metricBatch.CharmURL(), gc.Equals, "ch:quantal/metered-1")
 			c.Assert(metricBatch.Sent(), jc.IsFalse)
 			c.Assert(metricBatch.Created(), gc.Equals, now)
 			c.Assert(metricBatch.Metrics(), gc.HasLen, 1)
@@ -648,7 +648,7 @@ func (s *MetricSuite) TestAddBuiltInMetric(c *gc.C) {
 			saved, err := s.State.MetricBatch(metricBatch.UUID())
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(saved.Unit(), gc.Equals, "metered/0")
-			c.Assert(metricBatch.CharmURL(), gc.Equals, "cs:quantal/metered-1")
+			c.Assert(metricBatch.CharmURL(), gc.Equals, "ch:quantal/metered-1")
 			c.Assert(saved.Sent(), jc.IsFalse)
 			c.Assert(saved.Metrics(), gc.HasLen, 1)
 			metric = saved.Metrics()[0]
@@ -844,7 +844,7 @@ func (s *MetricLocalCharmSuite) TestModelMetricBatches(c *gc.C) {
 	st := s.Factory.MakeModel(c, nil)
 	defer st.Close()
 	f := factory.NewFactory(st, s.StatePool)
-	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
+	meteredCharm := f.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "ch:quantal/metered-1"})
 	application := f.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := f.MakeUnit(c, &factory.UnitParams{Application: application, SetCharmURL: true})
 	_, err = st.AddMetrics(
@@ -977,7 +977,7 @@ func (s *MetricLocalCharmSuite) TestUnitMetricBatchesReturnsAllCharms(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	csMeteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
+	csMeteredCharm := s.Factory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "ch:quantal/metered-1"})
 	application := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "csmetered", Charm: csMeteredCharm})
 	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: application, SetCharmURL: true})
 	_, err = s.State.AddMetrics(
@@ -1068,7 +1068,7 @@ func (s *CrossModelMetricSuite) mustCreateMeteredModel(c *gc.C) modelData {
 	st := s.Factory.MakeModel(c, nil)
 	localFactory := factory.NewFactory(st, s.StatePool)
 
-	meteredCharm := localFactory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "cs:quantal/metered-1"})
+	meteredCharm := localFactory.MakeCharm(c, &factory.CharmParams{Name: "metered", URL: "ch:quantal/metered-1"})
 	application := localFactory.MakeApplication(c, &factory.ApplicationParams{Charm: meteredCharm})
 	unit := localFactory.MakeUnit(c, &factory.UnitParams{Application: application, SetCharmURL: true})
 	s.AddCleanup(func(*gc.C) { st.Close() })

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -854,7 +854,7 @@ func (s *ModelSuite) assertDestroyControllerAndHostedModelsWithPersistentStorage
 		Application: otherFactory.MakeApplication(c, &factory.ApplicationParams{
 			Charm: otherFactory.MakeCharm(c, &factory.CharmParams{
 				Name: "storage-block",
-				URL:  "cs:quantal/storage-block-1",
+				URL:  "ch:quantal/storage-block-1",
 			}),
 			Storage: map[string]state.StorageConstraints{
 				"data": {Count: 1, Size: 1024, Pool: "modelscoped"},

--- a/state/unit_test.go
+++ b/state/unit_test.go
@@ -1283,8 +1283,8 @@ func (s *UnitSuite) TestSetCharmURLFailures(c *gc.C) {
 	err := s.unit.SetCharmURL(nil)
 	c.Assert(err, gc.ErrorMatches, "cannot set nil charm url")
 
-	err = s.unit.SetCharmURL(charm.MustParseURL("cs:missing/one-1"))
-	c.Assert(err, gc.ErrorMatches, `unknown charm url "cs:missing/one-1"`)
+	err = s.unit.SetCharmURL(charm.MustParseURL("ch:missing/one-1"))
+	c.Assert(err, gc.ErrorMatches, `unknown charm url "ch:missing/one-1"`)
 
 	err = s.unit.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -180,7 +180,7 @@ func (s *upgradesSuite) makeApplication(c *gc.C, uuid, name string, life Life) {
 	coll, closer := s.state.db().GetRawCollection(applicationsC)
 	defer closer()
 
-	curl := "cs:test-charm"
+	curl := "ch:test-charm"
 	err := coll.Insert(applicationDoc{
 		DocID:     ensureModelUUID(uuid, name),
 		Name:      name,

--- a/state/watcher_profilecharm_test.go
+++ b/state/watcher_profilecharm_test.go
@@ -138,15 +138,15 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) TestFullWatch(c *gc.C) {
 
 	done := make(chan struct{})
 	w := s.workerForScenario(c,
-		s.expectInitialCollectionInstanceField("cs:~user/series/name-0"),
+		s.expectInitialCollectionInstanceField("ch:series/name-0"),
 		s.expectLoopCollectionFilterAndNotify([]watcher.Change{
 			{Revno: -1},
 			{Revno: 0},
 			{Revno: 1},
 		}, done),
 		s.expectLoop,
-		s.expectMergeCollectionInstanceField("cs:~user/series/name-1"),
-		s.expectMergeCollectionInstanceField("cs:~user/series/name-1"),
+		s.expectMergeCollectionInstanceField("ch:series/name-1"),
+		s.expectMergeCollectionInstanceField("ch:series/name-1"),
 		s.expectLoop,
 	)
 
@@ -161,12 +161,12 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) TestFullWatchWithNoStatu
 
 	done := make(chan struct{})
 	w := s.workerForScenario(c,
-		s.expectInitialCollectionInstanceField("cs:~user/series/name-0"),
+		s.expectInitialCollectionInstanceField("ch:series/name-0"),
 		s.expectLoopCollectionFilterAndNotify([]watcher.Change{
 			{Revno: 0},
 		}, done),
 		s.expectLoop,
-		s.expectMergeCollectionInstanceField("cs:~user/series/name-0"),
+		s.expectMergeCollectionInstanceField("ch:series/name-0"),
 		s.expectLoop,
 	)
 


### PR DESCRIPTION
Remove references to charmstore from the state package, including updating tests and removing macaroons for charms. A few unit tests specific to charmstore were also removed.

## QA steps

All UT should pass and there be not change to current behavior of juju.
