### PR TITLE
[JUJU-2394] Preliminary panic fix for no primary NIC VLAN

### DIFF
--- a/network/containerizer/bridgepolicy.go
+++ b/network/containerizer/bridgepolicy.go
@@ -246,24 +246,29 @@ func linkLayerDevicesForSpaces(host Machine, spaces corenetwork.SpaceInfos) (map
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	processedDeviceNames := set.NewStrings()
-	spaceToDevices := make(namedNICsBySpace, 0)
 
-	// First pass, iterate the addresses, lookup the associated spaces, and
-	// gather the devices.
 	addresses, err := host.AllDeviceAddresses()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	for _, addr := range addresses {
-		device, ok := deviceByName[addr.DeviceName()]
-		if !ok {
-			return nil, errors.Errorf("address %v for machine %q refers to a missing device %q",
-				addr, host.Id(), addr.DeviceName())
-		}
-		processedDeviceNames.Add(device.Name())
 
-		// We do not care about loopback devices.
+	// Iterate all addresses and key them by the address device name.
+	addressByDeviceName := make(map[string]Address)
+	for _, addr := range addresses {
+		addressByDeviceName[addr.DeviceName()] = addr
+	}
+
+	// Iterate the devices by name, lookup the associated spaces, and
+	// gather the devices.
+	spaceToDevices := make(namedNICsBySpace, 0)
+	for _, device := range deviceByName {
+		addr, ok := addressByDeviceName[device.Name()]
+		if !ok {
+			logger.Infof("device %q has no addresses, ignoring", device.Name())
+			continue
+		}
+
+		// Loopback devices are not considered part of the empty space.
 		if device.Type() == corenetwork.LoopbackDevice {
 			continue
 		}
@@ -280,21 +285,6 @@ func linkLayerDevicesForSpaces(host Machine, spaces corenetwork.SpaceInfos) (map
 			spaceID = subnet.SpaceID()
 		}
 		spaceToDevices = includeDevice(spaceToDevices, spaceID, device)
-	}
-
-	// Second pass, grab any devices we may have missed. For now, any device without an
-	// address must be in the default space.
-	for devName, device := range deviceByName {
-		if processedDeviceNames.Contains(devName) {
-			continue
-		}
-		// Loopback devices are not considered part of the empty space.
-		// Also, devices that are attached to another device also aren't
-		// considered to be in the unknown space.
-		if device.Type() == corenetwork.LoopbackDevice || device.ParentName() != "" {
-			continue
-		}
-		spaceToDevices = includeDevice(spaceToDevices, corenetwork.AlphaSpaceId, device)
 	}
 
 	result := make(map[string][]LinkLayerDevice, len(spaceToDevices))

--- a/network/containerizer/bridgepolicy_integration_test.go
+++ b/network/containerizer/bridgepolicy_integration_test.go
@@ -779,7 +779,9 @@ func (s *bridgePolicyStateSuite) TestFindMissingBridgesForContainerContainerNetw
 	// machine. Triggers the fallback code to have us bridge all devices.
 	missing, reconfigureDelay, err := bridgePolicy.FindMissingBridgesForContainer(s.machine, s.containerMachine)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(missing, jc.DeepEquals, []network.DeviceToBridge{})
+	c.Check(missing, jc.DeepEquals, []network.DeviceToBridge{
+		{DeviceName: "ens3", BridgeName: "br-ens3", MACAddress: ""},
+	})
 	c.Check(reconfigureDelay, gc.Equals, 0)
 }
 

--- a/network/containerizer/linklayerdevicesforspaces_test.go
+++ b/network/containerizer/linklayerdevicesforspaces_test.go
@@ -199,15 +199,15 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesWithNoAddress(
 
 	devices, ok := res[network.AlphaSpaceId]
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(devices, gc.HasLen, 2)
+	c.Assert(devices, gc.HasLen, 1)
 	names := make([]string, len(devices))
 	for i, dev := range devices {
 		names[i] = dev.Name()
 	}
-	c.Check(names, gc.DeepEquals, []string{"ens5", "lxdbr0"})
+	c.Check(names, gc.DeepEquals, []string{"ens5"})
 }
 
-func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesUnknownIgnoresLoopAndIncludesKnownBridges(c *gc.C) {
+func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesUnknownIgnoresLoopAndExcludesKnownBridges(c *gc.C) {
 	// TODO(jam): 2016-12-28 arguably we should also be aware of Docker
 	// devices, possibly the better plan is to look at whether there are
 	// routes from the given bridge out into the rest of the world.
@@ -231,7 +231,7 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesUnknownIgnores
 	for i, dev := range devices {
 		names[i] = dev.Name()
 	}
-	c.Check(names, gc.DeepEquals, []string{"br-ens4", "ens3", "lxcbr0", "lxdbr0", "virbr0"})
+	c.Check(names, gc.DeepEquals, []string{"br-ens4", "ens3"})
 }
 
 func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesSortOrder(c *gc.C) {
@@ -253,7 +253,6 @@ func (s *linkLayerDevForSpacesSuite) TestLinkLayerDevicesForSpacesSortOrder(c *g
 	}
 	c.Check(names, gc.DeepEquals, []string{
 		"br-eth0", "br-eth1", "br-eth1.1", "br-eth1:1", "br-eth10", "br-eth10.2",
-		"eth2", "eth3", "eth20",
 	})
 }
 
@@ -310,8 +309,6 @@ func (s *linkLayerDevForSpacesSuite) expectMachineAddressesDevices() {
 }
 
 func (s *linkLayerDevForSpacesSuite) expectNICAndBridgeWithIP(ctrl *gomock.Controller, dev, parent, spaceID string) {
-	//	s.createNICAndBridgeWithIP(c, s.machine, "eth0", "br-eth0", "10.0.0.20/24")
-
 	s.expectDevice(ctrl, dev, parent, network.EthernetDevice)
 	s.expectBridgeDevice(ctrl, parent)
 
@@ -328,8 +325,6 @@ func (s *linkLayerDevForSpacesSuite) expectNICAndBridgeWithIP(ctrl *gomock.Contr
 }
 
 func (s *linkLayerDevForSpacesSuite) expectNICWithIP(ctrl *gomock.Controller, dev, spaceID string) {
-	// s.createNICWithIP(c, s.machine, "eth0", "10.0.0.20/24")
-
 	s.expectDevice(ctrl, dev, "", network.EthernetDevice)
 
 	subnet := NewMockSubnet(ctrl)
@@ -345,8 +340,6 @@ func (s *linkLayerDevForSpacesSuite) expectNICWithIP(ctrl *gomock.Controller, de
 }
 
 func (s *linkLayerDevForSpacesSuite) expectLoopbackNIC(ctrl *gomock.Controller) {
-	// s.createLoopbackNIC(c, s.machine)
-
 	s.expectDevice(ctrl, "lo", "", network.LoopbackDevice)
 
 	address := NewMockAddress(ctrl)

--- a/provider/maas/devices.go
+++ b/provider/maas/devices.go
@@ -411,6 +411,14 @@ func (env *maasEnviron) createAndPopulateDevice(params deviceCreatorParams) (gom
 
 		subnet, knownSubnet := params.CIDRToMAASSubnet[nic.PrimaryAddress().CIDR]
 		if !knownSubnet {
+			if primaryNICVLAN == nil {
+				// There is no primary NIC VLAN, so we can't fallback to the
+				// primaryNIC VLAN. Instead we'll emit a warning that no
+				// subnet is found, nor a primary NIC VLAN is available.
+				logger.Warningf("NIC %v has no subnet and no primary NIC VLAN", nic.InterfaceName)
+				continue
+			}
+
 			logger.Warningf("NIC %v has no subnet - setting to manual and using 'primaryNIC' VLAN %d", nic.InterfaceName, primaryNICVLAN.ID())
 			createArgs.VLAN = primaryNICVLAN
 		} else {

--- a/provider/maas/maas2_environ_whitebox_test.go
+++ b/provider/maas/maas2_environ_whitebox_test.go
@@ -1138,6 +1138,145 @@ func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNic(c *gc.C)
 	c.Assert(result, jc.DeepEquals, expected)
 }
 
+func (suite *maas2EnvironSuite) TestAllocateContainerAddressesSingleNicWithNoVLAN(c *gc.C) {
+	vlan1 := fakeVLAN{
+		id:  5001,
+		mtu: 1500,
+	}
+	vlan2 := fakeVLAN{
+		id:  5002,
+		mtu: 1500,
+	}
+	subnet1 := fakeSubnet{
+		id:         3,
+		space:      "default",
+		vlan:       vlan1,
+		gateway:    "10.20.19.2",
+		cidr:       "10.20.19.0/24",
+		dnsServers: []string{"10.20.19.2", "10.20.19.3"},
+	}
+	subnet2 := fakeSubnet{
+		id:         4,
+		space:      "freckles",
+		vlan:       vlan2,
+		gateway:    "192.168.1.1",
+		cidr:       "192.168.1.0/24",
+		dnsServers: []string{"10.20.19.2", "10.20.19.3"},
+	}
+	staticRoute2to1 := fakeStaticRoute{
+		id:          1,
+		source:      subnet2,
+		destination: subnet1,
+		gatewayIP:   "192.168.1.1",
+		metric:      100,
+	}
+
+	interfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         91,
+			name:       "eth0",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "52:54:00:70:9b:fe",
+			vlan:       vlan1,
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        436,
+					subnet:    &subnet1,
+					ipAddress: "10.20.19.103",
+					mode:      "static",
+				},
+			},
+			parents:  []string{},
+			children: []string{"eth0.100", "eth0.250", "eth0.50"},
+		},
+	}
+	deviceInterfaces := []gomaasapi.Interface{
+		&fakeInterface{
+			id:         93,
+			name:       "eth1",
+			type_:      "physical",
+			enabled:    true,
+			macAddress: "53:54:00:70:9b:ff",
+			links: []gomaasapi.Link{
+				&fakeLink{
+					id:        480,
+					subnet:    &subnet2,
+					ipAddress: "192.168.1.127",
+					mode:      "static",
+				},
+			},
+			parents:  []string{},
+			children: []string{"eth0.100", "eth0.250", "eth0.50"},
+		},
+	}
+	var env *maasEnviron
+	device := &fakeDevice{
+		interfaceSet: deviceInterfaces,
+		systemID:     "foo",
+	}
+	controller := &fakeController{
+		Stub: &testing.Stub{},
+		machines: []gomaasapi.Machine{&fakeMachine{
+			Stub:         &testing.Stub{},
+			systemID:     "1",
+			architecture: arch.HostArch(),
+			interfaceSet: interfaces,
+			createDevice: device,
+		}},
+		spaces: []gomaasapi.Space{
+			fakeSpace{
+				name:    "freckles",
+				id:      4567,
+				subnets: []gomaasapi.Subnet{subnet1, subnet2},
+			},
+		},
+		devices:      []gomaasapi.Device{device},
+		staticRoutes: []gomaasapi.StaticRoute{staticRoute2to1},
+	}
+	suite.injectController(controller)
+	suite.setupFakeTools(c)
+	env = suite.makeEnviron(c, nil)
+
+	prepared := network.InterfaceInfos{{
+		MACAddress:    "52:54:00:70:9b:fe",
+		Addresses:     network.ProviderAddresses{network.NewMachineAddress("", network.WithCIDR("10.20.19.0/24")).AsProviderAddress()},
+		InterfaceName: "eth0",
+	}}
+	ignored := names.NewMachineTag("1/lxd/0")
+	result, err := env.AllocateContainerAddresses(suite.callCtx, "1", ignored, prepared)
+	c.Assert(err, jc.ErrorIsNil)
+	expected := network.InterfaceInfos{{
+		DeviceIndex:       0,
+		MACAddress:        "53:54:00:70:9b:ff",
+		ProviderId:        "93",
+		ProviderSubnetId:  "4",
+		VLANTag:           0,
+		ProviderVLANId:    "0",
+		ProviderAddressId: "480",
+		InterfaceName:     "eth1",
+		InterfaceType:     "ethernet",
+		Addresses: network.ProviderAddresses{
+			network.NewMachineAddress(
+				"192.168.1.127", network.WithCIDR("192.168.1.0/24"), network.WithConfigType(network.ConfigStatic),
+			).AsProviderAddress(network.WithSpaceName("freckles")),
+		},
+		DNSServers: network.NewMachineAddresses([]string{
+			"10.20.19.2",
+			"10.20.19.3",
+		}).AsProviderAddresses(network.WithSpaceName("freckles")),
+		MTU:            1500,
+		GatewayAddress: network.NewMachineAddress("192.168.1.1").AsProviderAddress(network.WithSpaceName("freckles")),
+		Routes: []network.Route{{
+			DestinationCIDR: subnet1.CIDR(),
+			GatewayIP:       "192.168.1.1",
+			Metric:          100,
+		}},
+		Origin: network.OriginProvider,
+	}}
+	c.Assert(result, jc.DeepEquals, expected)
+}
+
 func (suite *maas2EnvironSuite) TestAllocateContainerAddressesNoStaticRoutesAPI(c *gc.C) {
 	// MAAS 2.0 doesn't have support for static routes, and generates an Error
 	vlan1 := fakeVLAN{


### PR DESCRIPTION
To prevent the panic when a primary NIC VLAN is not available because the underlying device doesn't have an address is to filter out any device that no longer has a device. In practice, this means that we no longer fill the alpha space with devices in the second pass that didn't have an address. This should clean up some of the logic for gathering devices. MAAS will add the address via the instance poller, incase it shows up later.

Additionally, we log out when a primary NIC VLAN is nil, which will result in a warning, but doesn't stop the processing of devices.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

- Bootstrap to a MAAS configured with multiple spaces.
- `juju model-config default-space=<space-x>`
- Add a machine that is connected to multiple spaces.
- `juju deploy ubuntu --to lxd:0 --constraints "spaces=<space-x>`.
- Once settled, `juju show-machine 0` should indicate `network-interfaces` entries for both machine and container in the correct subnet/space.
- Connect to Mongo and run `db.ip.addresses.find().pretty()`. All documents should have a populated `subnet-cidr`.


## Bug reference

https://bugs.launchpad.net/juju/+bug/1994124
