### PR TITLE
[JUJU-2343] Thread base through info and download

### DIFF
--- a/cmd/juju/charmhub/charmhub.go
+++ b/cmd/juju/charmhub/charmhub.go
@@ -36,8 +36,11 @@ type charmHubCommand struct {
 
 	arch        string
 	arches      arch.Arches
-	series      string
+	base        string
 	charmHubURL string
+
+	// DEPRECATED: Use --base instead.
+	series string
 
 	CharmHubClientFunc func(charmhub.Config) (CharmHubClient, error)
 }

--- a/cmd/juju/charmhub/convert.go
+++ b/cmd/juju/charmhub/convert.go
@@ -20,7 +20,7 @@ import (
 	coreseries "github.com/juju/juju/core/series"
 )
 
-func convertInfoResponse(info transport.InfoResponse, arch, series string) (InfoResponse, error) {
+func convertInfoResponse(info transport.InfoResponse, arch string, base coreseries.Base) (InfoResponse, error) {
 	ir := InfoResponse{
 		Type:        string(info.Type),
 		ID:          info.ID,
@@ -51,7 +51,7 @@ func convertInfoResponse(info transport.InfoResponse, arch, series string) (Info
 	}
 
 	var err error
-	ir.Tracks, ir.Channels, err = filterChannels(info.ChannelMap, arch, series)
+	ir.Tracks, ir.Channels, err = filterChannels(info.ChannelMap, arch, base)
 	if err != nil {
 		return ir, errors.Trace(err)
 	}
@@ -109,34 +109,32 @@ func convertCharm(info transport.InfoResponse) *Charm {
 	return ch
 }
 
-func includeChannel(p []corecharm.Platform, architecture, series string) bool {
+func includeChannel(p []corecharm.Platform, architecture string, base coreseries.Base) bool {
 	allArch := architecture == ArchAll
-	allSeries := series == SeriesAll
 
 	// If we're searching for everything then we can skip the filtering logic
 	// and return immediately.
-	if allArch && allSeries {
+	if allArch && base.Empty() {
 		return true
 	}
 
 	archSet := channelArches(p)
-	seriesSet := channelSeries(p)
+	basesSet := channelBases(p)
+
+	contains := func(bases []Base, base coreseries.Base) bool {
+		for _, b := range bases {
+			if b.Name == base.OS && b.Channel == base.Channel.Track {
+				return true
+			}
+		}
+		return false
+	}
 
 	if (allArch || archSet.Contains(architecture)) &&
-		(allSeries || seriesSet.Contains(series) || seriesSet.Contains(SeriesAll)) {
+		(base.Empty() || contains(basesSet, base)) {
 		return true
 	}
 	return false
-}
-
-func channelSeries(platforms []corecharm.Platform) set.Strings {
-	series := set.NewStrings()
-	for _, v := range platforms {
-		if s, err := coreseries.GetSeriesFromChannel(v.OS, v.Channel); err == nil {
-			series.Add(s)
-		}
-	}
-	return series
 }
 
 func channelBases(platforms []corecharm.Platform) []Base {
@@ -302,8 +300,8 @@ func formatRelationPart(r map[string]charm.Relation) (map[string]string, bool) {
 
 // filterChannels returns channel map data in a format that facilitates
 // determining track order and open vs closed channels for displaying channel
-// data. The result is filtered on series and arch.
-func filterChannels(channelMap []transport.InfoChannelMap, arch, series string) ([]string, RevisionsMap, error) {
+// data. The result is filtered on base and arch.
+func filterChannels(channelMap []transport.InfoChannelMap, arch string, base coreseries.Base) ([]string, RevisionsMap, error) {
 	var trackList []string
 
 	tracksSeen := set.NewStrings()
@@ -322,7 +320,7 @@ func filterChannels(channelMap []transport.InfoChannelMap, arch, series string) 
 		}
 
 		platforms := convertBasesToPlatforms(cm.Revision.Bases)
-		if !includeChannel(platforms, arch, series) {
+		if !includeChannel(platforms, arch, base) {
 			continue
 		}
 

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/cmd/output/progress"
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/series"
 	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/juju/version"
 )
@@ -88,7 +89,8 @@ func (c *downloadCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.charmHubCommand.SetFlags(f)
 
 	f.StringVar(&c.arch, "arch", ArchAll, fmt.Sprintf("specify an arch <%s>", c.archArgumentList()))
-	f.StringVar(&c.series, "series", SeriesAll, "specify a series")
+	f.StringVar(&c.series, "series", SeriesAll, "specify a series. DEPRECATED use --base")
+	f.StringVar(&c.base, "base", "", "specify a base")
 	f.StringVar(&c.channel, "channel", "", "specify a channel to use instead of the default release")
 	f.StringVar(&c.archivePath, "filepath", "", "filepath location of the charm to download to")
 	f.BoolVar(&c.noProgress, "no-progress", false, "disable the progress bar")
@@ -97,6 +99,10 @@ func (c *downloadCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init initializes the download command, including validating the provided
 // flags. It implements part of the cmd.Command interface.
 func (c *downloadCommand) Init(args []string) error {
+	if c.base != "" && (c.series != "" && c.series != SeriesAll) {
+		return errors.New("--series and --base cannot be specified together")
+	}
+
 	if err := c.charmHubCommand.Init(args); err != nil {
 		return errors.Trace(err)
 	}
@@ -135,6 +141,28 @@ func (c *downloadCommand) validateCharmOrBundle(charmOrBundle string) (*charm.UR
 // Run is the business logic of the download command.  It implements the meaty
 // part of the cmd.Command interface.
 func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
+	var (
+		base series.Base
+		err  error
+	)
+	// Note: we validated that both series and base cannot be specified in
+	// Init(), so it's safe to assume that only one of them is set here.
+	if c.series == SeriesAll {
+		c.series = ""
+	} else if c.series != "" {
+		cmdContext.Warningf("series flag is deprecated, use --base instead")
+		if base, err = series.GetBaseFromSeries(c.series); err != nil {
+			return errors.Annotatef(err, "attempting to convert %q to a base", c.series)
+		}
+		c.base = base.String()
+		c.series = ""
+	}
+	if c.base != "" {
+		if base, err = series.ParseBaseFromString(c.base); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	cfg := charmhub.Config{
 		URL:    c.charmHubURL,
 		Logger: downloadLogger{Context: cmdContext},
@@ -169,13 +197,8 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 	if pArch == "all" || pArch == "" {
 		pArch = arch.DefaultArchitecture
 	}
-	pSeries := c.series
-	if pSeries == "all" || pSeries == "" {
-		pSeries = version.DefaultSupportedLTS()
-	}
-	base, err := coreseries.GetBaseFromSeries(pSeries)
-	if err != nil {
-		return errors.Trace(err)
+	if base.Empty() {
+		base = version.DefaultSupportedLTSBase()
 	}
 	platform := fmt.Sprintf("%s/%s/%s", pArch, base.OS, base.Channel.Track)
 	normBase, err := corecharm.ParsePlatformNormalize(platform)
@@ -204,7 +227,7 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 	for _, res := range results {
 		if res.Error != nil {
 			if res.Error.Code == transport.ErrorCodeRevisionNotFound {
-				return c.suggested(pSeries, normChannel.String(), res.Error.Extra.Releases, cmdContext)
+				return c.suggested(base, normChannel.String(), res.Error.Extra.Releases, cmdContext)
 			}
 			return errors.Errorf("unable to locate %s: %s", c.charmOrBundle, res.Error.Message)
 		}
@@ -273,33 +296,22 @@ Install the %q %s with:
 	return nil
 }
 
-func (c *downloadCommand) suggested(requestedSeries string, channel string, releases []transport.Release, cmdContext *cmd.Context) error {
-	series := set.NewStrings()
+func (c *downloadCommand) suggested(requestedBase coreseries.Base, channel string, releases []transport.Release, cmdContext *cmd.Context) error {
+	bases := set.NewStrings()
 	for _, rel := range releases {
 		if rel.Channel == channel {
-			platform := corecharm.Platform{
-				Architecture: rel.Base.Architecture,
-				OS:           rel.Base.Name,
-				Channel:      rel.Base.Channel,
-			}
-			s, err := coreseries.GetSeriesFromChannel(platform.OS, platform.Channel)
-			if err == nil {
-				series.Add(s)
-			} else {
-				// Shouldn't happen, log and continue if verbose is set.
-				cmdContext.Verbosef("%s of %s", err, rel.Base.Name)
-			}
+			bases.Add(coreseries.MakeDefaultBase(rel.Base.Name, rel.Base.Channel).DisplayString())
 		}
 	}
-	if series.IsEmpty() {
+	if bases.IsEmpty() {
 		// No releases in this channel
 		return errors.Errorf(`%q has no releases in channel %q. Type
     juju info %s
 for a list of supported channels.`,
 			c.charmOrBundle, channel, c.charmOrBundle)
 	}
-	return errors.Errorf("%q does not support series %q in channel %q.  Supported series are: %s.",
-		c.charmOrBundle, requestedSeries, channel, strings.Join(series.SortedValues(), ", "))
+	return errors.Errorf("%q does not support base %q in channel %q.  Supported bases are: %s.",
+		c.charmOrBundle, requestedBase.DisplayString(), channel, strings.Join(bases.SortedValues(), ", "))
 }
 
 func (c *downloadCommand) calculateHash(path string) (string, error) {

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -35,7 +35,9 @@ const (
 	downloadSummary = "Locates and then downloads a CharmHub charm."
 	downloadDoc     = `
 Download a charm to the current directory from the CharmHub store
-by a specified name.
+by a specified name. Downloading for a specific base can be done via
+--base. --base can be specified using the OS name and the version of
+the OS, separated by @. For example, --base ubuntu@22.04.
 
 Adding a hyphen as the second argument allows the download to be piped
 to stdout.

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -139,7 +139,7 @@ func (s *downloadSuite) TestRunWithCustomCharmHubURL(c *gc.C) {
 func (s *downloadSuite) TestRunWithUnsupportedSeries(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	s.expectRefreshUnsupportedSeries()
+	s.expectRefreshUnsupportedBase()
 
 	command := &downloadCommand{
 		charmHubCommand: s.newCharmHubCommand(),
@@ -150,13 +150,13 @@ func (s *downloadSuite) TestRunWithUnsupportedSeries(c *gc.C) {
 
 	ctx := commandContextForTest(c)
 	err = command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, `"test" does not support series "jammy" in channel "stable".  Supported series are: bionic, trusty, xenial.`)
+	c.Assert(err, gc.ErrorMatches, `"test" does not support base "ubuntu@22.04" in channel "stable".  Supported bases are: ubuntu@14.04, ubuntu@16.04, ubuntu@18.04.`)
 }
 
 func (s *downloadSuite) TestRunWithNoStableRelease(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	s.expectRefreshUnsupportedSeries()
+	s.expectRefreshUnsupportedBase()
 
 	command := &downloadCommand{
 		charmHubCommand: s.newCharmHubCommand(),
@@ -233,7 +233,7 @@ func (s *downloadSuite) expectRefresh(charmHubURL string) {
 	})
 }
 
-func (s *downloadSuite) expectRefreshUnsupportedSeries() {
+func (s *downloadSuite) expectRefreshUnsupportedBase() {
 	s.charmHubAPI.EXPECT().Refresh(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, cfg charmhub.RefreshConfig) ([]transport.RefreshResponse, error) {
 		instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
 

--- a/cmd/juju/charmhub/findwriter.go
+++ b/cmd/juju/charmhub/findwriter.go
@@ -130,7 +130,7 @@ func (f findWriter) Print() error {
 			case ColumnNameOS:
 				colValues = append(colValues, strings.Join(result.OS, ","))
 			case ColumnNameSupports:
-				colValues = append(colValues, strings.Join(basesToSeries(result.Supports), ","))
+				colValues = append(colValues, strings.Join(basesDisplay(result.Supports), ","))
 			case ColumnNamePublisher:
 				colValues = append(colValues, result.Publisher)
 			case ColumnNameSummary:

--- a/cmd/juju/charmhub/findwriter_test.go
+++ b/cmd/juju/charmhub/findwriter_test.go
@@ -56,10 +56,10 @@ func (s *printFindSuite) TestCharmPrintFind(c *gc.C) {
 
 	obtained := ctx.Stdout.(*bytes.Buffer).String()
 	expected := `
-Name       Bundle  Version  Architectures  Supports            Publisher           Summary
-wordpress  -       1.0.3    all            bionic              WordPress Charmers  WordPress is a full featured web blogging
-                                                                                   tool, this charm deploys it.
-osm        Y       3.2.3    all            bionic,focal,jammy  charmed-osm         Single instance OSM bundle.
+Name       Bundle  Version  Architectures  Supports                                Publisher           Summary
+wordpress  -       1.0.3    all            ubuntu@18.04                            WordPress Charmers  WordPress is a full featured web blogging
+                                                                                                       tool, this charm deploys it.
+osm        Y       3.2.3    all            ubuntu@18.04,ubuntu@20.04,ubuntu@22.04  charmed-osm         Single instance OSM bundle.
 
 `[1:]
 	c.Assert(obtained, gc.Equals, expected)
@@ -102,9 +102,9 @@ func (s *printFindSuite) TestCharmPrintFindWithMissingData(c *gc.C) {
 
 	obtained := ctx.Stdout.(*bytes.Buffer).String()
 	expected := `
-Name       Bundle  Version  Architectures  Supports            Publisher           Summary
-wordpress  -                                                   WordPress Charmers  
-osm        Y       3.2.3    all            bionic,focal,jammy  charmed-osm         Single instance OSM bundle.
+Name       Bundle  Version  Architectures  Supports                                Publisher           Summary
+wordpress  -                                                                       WordPress Charmers  
+osm        Y       3.2.3    all            ubuntu@18.04,ubuntu@20.04,ubuntu@22.04  charmed-osm         Single instance OSM bundle.
 
 `[1:]
 	c.Assert(obtained, gc.Equals, expected)

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/charmhub"
 	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/core/series"
 )
 
 const (
@@ -22,8 +23,8 @@ const (
 	infoDoc     = `
 The charm can be specified by name or by path.
 
-Channels displayed are supported by any series.
-To see channels supported for only a specific series, use the --series flag.
+Channels displayed are supported by any base.
+To see channels supported for only a specific base, use the --base flag.
 
 Examples:
     juju info postgresql
@@ -74,7 +75,8 @@ func (c *infoCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.charmHubCommand.SetFlags(f)
 
 	f.StringVar(&c.arch, "arch", ArchAll, fmt.Sprintf("specify an arch <%s>", c.archArgumentList()))
-	f.StringVar(&c.series, "series", SeriesAll, "specify a series")
+	f.StringVar(&c.series, "series", SeriesAll, "specify a series. DEPRECATED use --base")
+	f.StringVar(&c.base, "base", "", "specify a base")
 	f.StringVar(&c.channel, "channel", "", "specify a channel to use instead of the default release")
 	f.BoolVar(&c.config, "config", false, "display config for this charm")
 	f.StringVar(&c.unicode, "unicode", "auto", "display output using unicode <auto|never|always>")
@@ -88,6 +90,10 @@ func (c *infoCommand) SetFlags(f *gnuflag.FlagSet) {
 // Init initializes the info command, including validating the provided
 // flags. It implements part of the cmd.Command interface.
 func (c *infoCommand) Init(args []string) error {
+	if c.base != "" && (c.series != "" && c.series != SeriesAll) {
+		return errors.New("--series and --base cannot be specified together")
+	}
+
 	if err := c.charmHubCommand.Init(args); err != nil {
 		return errors.Trace(err)
 	}
@@ -125,6 +131,28 @@ func (c *infoCommand) validateCharmOrBundle(charmOrBundle string) error {
 // Run is the business logic of the info command.  It implements the meaty
 // part of the cmd.Command interface.
 func (c *infoCommand) Run(cmdContext *cmd.Context) error {
+	var (
+		base series.Base
+		err  error
+	)
+	// Note: we validated that both series and base cannot be specified in
+	// Init(), so it's safe to assume that only one of them is set here.
+	if c.series == SeriesAll {
+		c.series = ""
+	} else if c.series != "" {
+		cmdContext.Warningf("series flag is deprecated, use --base instead")
+		if base, err = series.GetBaseFromSeries(c.series); err != nil {
+			return errors.Annotatef(err, "attempting to convert %q to a base", c.series)
+		}
+		c.base = base.String()
+		c.series = ""
+	}
+	if c.base != "" {
+		if base, err = series.ParseBaseFromString(c.base); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	cfg := charmhub.Config{
 		URL:    c.charmHubURL,
 		Logger: logger,
@@ -154,7 +182,7 @@ func (c *infoCommand) Run(cmdContext *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	view, err := convertInfoResponse(info, c.arch, c.series)
+	view, err := convertInfoResponse(info, c.arch, base)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -177,14 +205,14 @@ func (c *infoCommand) formatter(writer io.Writer, value interface{}) error {
 	// Default is to include both architecture and bases
 	mode := baseModeBoth
 	switch {
-	case c.arch != ArchAll && c.series != SeriesAll:
-		// If --arch and --series given, don't show arch or bases
+	case c.arch != ArchAll && c.base != "":
+		// If --arch and --base given, don't show arch or bases
 		mode = baseModeNone
-	case c.arch != ArchAll && c.series == SeriesAll:
+	case c.arch != ArchAll && c.base == "":
 		// If only --arch given, show bases
 		mode = baseModeBases
-	case c.arch == ArchAll && c.series != SeriesAll:
-		// If only --series given, show arch
+	case c.arch == ArchAll && c.base != "":
+		// If only --base given, show arch
 		mode = baseModeArches
 	}
 

--- a/cmd/juju/charmhub/info.go
+++ b/cmd/juju/charmhub/info.go
@@ -25,6 +25,8 @@ The charm can be specified by name or by path.
 
 Channels displayed are supported by any base.
 To see channels supported for only a specific base, use the --base flag.
+--base can be specified using the OS name and the version of the OS, 
+separated by @. For example, --base ubuntu@22.04.
 
 Examples:
     juju info postgresql

--- a/cmd/juju/charmhub/infowriter.go
+++ b/cmd/juju/charmhub/infowriter.go
@@ -107,7 +107,7 @@ func (iw infoWriter) channels() string {
 			case baseModeBases:
 				latest := revisions[0]
 				args := []any{formatRevision(latest, true)}
-				bases := strings.Join(basesToSeries(latest.Bases), ", ")
+				bases := strings.Join(basesDisplay(latest.Bases), ", ")
 				if bases != "" {
 					args = append(args, bases)
 				}
@@ -119,7 +119,7 @@ func (iw infoWriter) channels() string {
 				if arches != "" {
 					args = append(args, arches)
 				}
-				bases := strings.Join(basesToSeries(latest.Bases), ", ")
+				bases := strings.Join(basesDisplay(latest.Bases), ", ")
 				if bases != "" {
 					args = append(args, bases)
 				}
@@ -143,27 +143,19 @@ func formatRevision(r Revision, showName bool) string {
 		namePrefix, r.Version, r.ReleasedAt[:10], r.Revision, sizeToStr(r.Size))
 }
 
-// basesToSeries converts a list of bases to a list of series ("jammy").
-// Any bases that can't be mapped will be included in the
-// result unmodified.
-//
-// NOTE: This will go away when we switch to --base and bases output.
-func basesToSeries(bases []Base) []string {
-	series := make([]string, len(bases))
+// basesDisplay returns a slice of bases in the format "name@channel".
+func basesDisplay(bases []Base) []string {
+	strs := make([]string, len(bases))
 	for i, b := range bases {
 		base, err := coreseries.ParseBase(b.Name, b.Channel)
 		if err != nil {
-			series[i] = base.DisplayString()
+			strs[i] = base.DisplayString()
 			continue
 		}
-		s, err := coreseries.GetSeriesFromBase(base)
-		if err != nil {
-			series[i] = base.DisplayString()
-			continue
-		}
-		series[i] = s
+
+		strs[i] = b.Name + "@" + b.Channel
 	}
-	return series
+	return strs
 }
 
 type bundleInfoOutput struct {
@@ -227,7 +219,7 @@ func (c charmInfoWriter) Print() error {
 		ID:          c.in.ID,
 		Summary:     c.in.Summary,
 		Publisher:   c.in.Publisher,
-		Supports:    strings.Join(basesToSeries(c.in.Supports), ", "),
+		Supports:    strings.Join(basesDisplay(c.in.Supports), ", "),
 		StoreURL:    c.in.StoreURL,
 		Description: c.in.Description,
 		Channels:    c.channels(),

--- a/cmd/juju/charmhub/infowriter_test.go
+++ b/cmd/juju/charmhub/infowriter_test.go
@@ -34,7 +34,7 @@ description: |-
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
 charm-id: charmCHARMcharmCHARMcharmCHARM01
-supports: bionic, xenial
+supports: ubuntu@18.04, ubuntu@16.04
 tags: app, seven
 subordinate: true
 relations:
@@ -44,9 +44,9 @@ relations:
   requires:
     five: six
 channels: |
-  latest/stable:     1.0.3  2019-12-16  (16)  12MB  amd64  jammy, focal
-  latest/candidate:  1.0.3  2019-12-16  (17)  12MB  amd64  jammy
-  latest/beta:       1.0.3  2019-12-16  (17)  12MB  amd64  jammy
+  latest/stable:     1.0.3  2019-12-16  (16)  12MB  amd64  ubuntu@22.04, ubuntu@20.04
+  latest/candidate:  1.0.3  2019-12-16  (17)  12MB  amd64  ubuntu@22.04
+  latest/beta:       1.0.3  2019-12-16  (17)  12MB  amd64  ubuntu@22.04
   latest/edge:       1.0.3  2019-12-16  (18)  12MB  amd64  coolos@3.14
 `
 	c.Assert(obtained, gc.Equals, expected)
@@ -68,7 +68,7 @@ description: |-
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
 charm-id: charmCHARMcharmCHARMcharmCHARM01
-supports: bionic, xenial
+supports: ubuntu@18.04, ubuntu@16.04
 tags: app, seven
 subordinate: true
 relations:
@@ -102,7 +102,7 @@ description: |-
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
 charm-id: charmCHARMcharmCHARMcharmCHARM01
-supports: bionic, xenial
+supports: ubuntu@18.04, ubuntu@16.04
 tags: app, seven
 subordinate: true
 relations:
@@ -137,7 +137,7 @@ description: |-
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
 charm-id: charmCHARMcharmCHARMcharmCHARM01
-supports: bionic, xenial
+supports: ubuntu@18.04, ubuntu@16.04
 tags: app, seven
 subordinate: true
 relations:
@@ -147,9 +147,9 @@ relations:
   requires:
     five: six
 channels: |
-  latest/stable:     1.0.3  2019-12-16  (16)  12MB  jammy, focal
-  latest/candidate:  1.0.3  2019-12-16  (17)  12MB  jammy
-  latest/beta:       1.0.3  2019-12-16  (17)  12MB  jammy
+  latest/stable:     1.0.3  2019-12-16  (16)  12MB  ubuntu@22.04, ubuntu@20.04
+  latest/candidate:  1.0.3  2019-12-16  (17)  12MB  ubuntu@22.04
+  latest/beta:       1.0.3  2019-12-16  (17)  12MB  ubuntu@22.04
   latest/edge:       1.0.3  2019-12-16  (18)  12MB  coolos@3.14
 `
 	c.Assert(obtained, gc.Equals, expected)
@@ -171,7 +171,7 @@ description: |-
   By default it will place Ngnix and php-fpm configured to scale horizontally with
   Nginx's reverse proxy.
 charm-id: charmCHARMcharmCHARMcharmCHARM01
-supports: bionic, xenial
+supports: ubuntu@18.04, ubuntu@16.04
 tags: app, seven
 subordinate: true
 relations:

--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -6,7 +6,7 @@ run_charmhub_download() {
 
 	ensure "test-${name}" "${file}"
 
-	output=$(juju download postgresql --series focal --filepath="${TEST_DIR}/postgresql.charm" 2>&1 || true)
+	output=$(juju download postgresql --base ubuntu@20.04 --filepath="${TEST_DIR}/postgresql.charm" 2>&1 || true)
 	check_contains "${output}" 'Fetching charm "postgresql"'
 
 	juju deploy "${TEST_DIR}/postgresql.charm" postgresql


### PR DESCRIPTION
~~**Requires:** https://github.com/juju/juju/pull/15020 to land first. Will rebase once landed.~~

The following deprecates series in favour of base. Adds a warning if
you're using a series. It removes all of the conversion between charmhub
base and series (which is a string) and core series base type. This
means the code is a lot simpler.

The output has no series in it and refers to base. All output is now
bases.

There is still some complexity around "all", but we will be able to drop
that in favour of an empty base type.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


### Without a base

```sh
juju info ubuntu

name: ubuntu
publisher: charmers
summary: A pristine Ubuntu Server
description: |
  This simply deploys the Ubuntu Cloud/Server image
store-url: https://charmhub.io/ubuntu
charm-id: DksXQKAQTZfsUmBAGanZAhpoS4dpmXel
supports: ubuntu@16.04, ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
subordinate: false
channels: |
  latest/stable:     21  2022-09-15  (21)  2MB  amd64  ubuntu@16.04, ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
  latest/candidate:  21  2022-09-15  (21)  2MB  amd64  ubuntu@16.04, ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
  latest/beta:       21  2022-09-15  (21)  2MB  amd64  ubuntu@16.04, ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
  latest/edge:       21  2022-09-15  (21)  2MB  amd64  ubuntu@16.04, ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
```

### With a base

```sh
$ juju info ubuntu --base=ubuntu@22.04
ubuntu@22.04
name: ubuntu
publisher: charmers
summary: A pristine Ubuntu Server
description: |
  This simply deploys the Ubuntu Cloud/Server image
store-url: https://charmhub.io/ubuntu
charm-id: DksXQKAQTZfsUmBAGanZAhpoS4dpmXel
supports: ubuntu@16.04, ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
subordinate: false
channels: |
  latest/stable:     21  2022-09-15  (21)  2MB  amd64
  latest/candidate:  21  2022-09-15  (21)  2MB  amd64
  latest/beta:       21  2022-09-15  (21)  2MB  amd64
  latest/edge:       21  2022-09-15  (21)  2MB  amd64

```
### With a series

```sh
$ juju info ubuntu --series=jammy
WARNING series flag is deprecated, use --base instead
ubuntu@22.04/stable
name: ubuntu
publisher: charmers
summary: A pristine Ubuntu Server
description: |
  This simply deploys the Ubuntu Cloud/Server image
store-url: https://charmhub.io/ubuntu
charm-id: DksXQKAQTZfsUmBAGanZAhpoS4dpmXel
supports: ubuntu@16.04, ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
subordinate: false
channels: |
  latest/stable:     21  2022-09-15  (21)  2MB  amd64
  latest/candidate:  21  2022-09-15  (21)  2MB  amd64
  latest/beta:       21  2022-09-15  (21)  2MB  amd64
  latest/edge:       21  2022-09-15  (21)  2MB  amd64
```

### With both a series and a base

```sh
$ juju info ubuntu --series=jammy --base=ubuntu@22.04
ERROR --series and --base cannot be specified together
```

## Documentation changes

@tmihoc we'll be outputting bases instead of series for info and downloads.
