### PR TITLE
[JUJU-2344] Thread base through add-machine

### DIFF
--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -55,7 +55,8 @@ machine instance from the current cloud. The machine's specifications,
 including whether the machine is virtual or physical depends on the cloud.
 
 To control which instance type is provisioned, use the --constraints and 
---base options.
+--base options. --base can be specified using the OS name and the version of
+the OS, separated by @. For example, --base ubuntu@22.04.
 
 To add storage volumes to the instance, provide a whitespace-delimited
 list of storage constraints to the --disks option. 
@@ -282,8 +283,7 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 	// Init(), so it's safe to assume that only one of them is set here.
 	if c.Series != "" {
 		if c.Series == "kubernetes" {
-			ctx.Warningf("using kubernetes as a series flag is deprecated, use --base instead")
-			base = series.LegacyKubernetesBase()
+			return fmt.Errorf(`command "add-machine" does not support container models`)
 		} else {
 			ctx.Warningf("series flag is deprecated, use --base instead")
 			if base, err = series.GetBaseFromSeries(c.Series); err != nil {

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -55,7 +55,7 @@ machine instance from the current cloud. The machine's specifications,
 including whether the machine is virtual or physical depends on the cloud.
 
 To control which instance type is provisioned, use the --constraints and 
---series options.
+--base options.
 
 To add storage volumes to the instance, provide a whitespace-delimited
 list of storage constraints to the --disks option. 
@@ -155,8 +155,12 @@ type addCommand struct {
 	baseMachinesCommand
 	modelConfigAPI    ModelConfigAPI
 	machineManagerAPI MachineManagerAPI
-	// If specified, use this series, else use the model default-series
+	// Series defines the series the machine should use instead of the
+	// default-series. DEPRECATED use --base
 	Series string
+	// Base defines the series the machine should use instead of the
+	// default-base.
+	Base string
 	// If specified, these constraints are merged with those already in the model.
 	Constraints constraints.Value
 	// If specified, these constraints are merged with those already in the model.
@@ -186,7 +190,8 @@ func (c *addCommand) Info() *cmd.Info {
 
 func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.StringVar(&c.Series, "series", "", "The operating system series to install on the new machine(s)")
+	f.StringVar(&c.Series, "series", "", "The operating system series to install on the new machine(s). DEPRECATED use --base")
+	f.StringVar(&c.Base, "base", "", "The operating system base to install on the new machine(s)")
 	f.IntVar(&c.NumMachines, "n", 1, "The number of machines to add")
 	f.StringVar(&c.ConstraintsStr, "constraints", "", "Machine constraints that overwrite those available from 'juju model-constraints' and provider's defaults")
 	f.Var(disksFlag{&c.Disks}, "disks", "Storage constraints for disks to attach to the machine(s)")
@@ -195,6 +200,9 @@ func (c *addCommand) SetFlags(f *gnuflag.FlagSet) {
 }
 
 func (c *addCommand) Init(args []string) error {
+	if c.Base != "" && c.Series != "" {
+		return errors.New("--series and --base cannot be specified together")
+	}
 	if c.Constraints.Container != nil {
 		return errors.Errorf("container constraint %q not allowed when adding a machine", *c.Constraints.Container)
 	}
@@ -266,7 +274,31 @@ func (c *addCommand) getMachineManagerAPI() (MachineManagerAPI, error) {
 }
 
 func (c *addCommand) Run(ctx *cmd.Context) error {
-	var err error
+	var (
+		base series.Base
+		err  error
+	)
+	// Note: we validated that both series and base cannot be specified in
+	// Init(), so it's safe to assume that only one of them is set here.
+	if c.Series != "" {
+		if c.Series == "kubernetes" {
+			ctx.Warningf("using kubernetes as a series flag is deprecated, use --base instead")
+			base = series.LegacyKubernetesBase()
+		} else {
+			ctx.Warningf("series flag is deprecated, use --base instead")
+			if base, err = series.GetBaseFromSeries(c.Series); err != nil {
+				return errors.Annotatef(err, "attempting to convert %q to a base", c.Series)
+			}
+		}
+		c.Base = base.String()
+		c.Series = ""
+	}
+	if c.Base != "" {
+		if base, err = series.ParseBaseFromString(c.Base); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	c.Constraints, err = common.ParseConstraints(ctx, c.ConstraintsStr)
 	if err != nil {
 		return err
@@ -318,20 +350,17 @@ func (c *addCommand) Run(ctx *cmd.Context) error {
 
 	jobs := []model.MachineJob{model.JobHostUnits}
 
-	var base *params.Base
-	if c.Series != "" {
-		info, err := series.GetBaseFromSeries(c.Series)
-		if err != nil {
-			return errors.NotValidf("machine series %q", c.Series)
-		}
-		base = &params.Base{
-			Name:    info.OS,
-			Channel: info.Channel.String(),
+	var paramsBase *params.Base
+	if !base.Empty() {
+		paramsBase = &params.Base{
+			Name:    base.OS,
+			Channel: base.Channel.String(),
 		}
 	}
+
 	machineParams := params.AddMachineParams{
 		Placement:   c.Placement,
-		Base:        base,
+		Base:        paramsBase,
 		Constraints: c.Constraints,
 		Jobs:        jobs,
 		Disks:       c.Disks,

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -127,6 +127,11 @@ func (s *AddMachineSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
 	return cmdtesting.RunCommand(c, add, args...)
 }
 
+func (s *AddMachineSuite) TestSeriesAndBaseError(c *gc.C) {
+	_, err := s.run(c, "--series=jammy", "--base=ubuntu@22.04")
+	c.Assert(err, gc.ErrorMatches, "--series and --base cannot be specified together")
+}
+
 func (s *AddMachineSuite) TestAddMachine(c *gc.C) {
 	context, err := s.run(c)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/machine/add_test.go
+++ b/cmd/juju/machine/add_test.go
@@ -39,7 +39,7 @@ func (s *AddMachineSuite) SetUpTest(c *gc.C) {
 func (s *AddMachineSuite) TestInit(c *gc.C) {
 	for i, test := range []struct {
 		args        []string
-		series      string
+		base        string
 		constraints string
 		placement   string
 		count       int
@@ -48,9 +48,9 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 		{
 			count: 1,
 		}, {
-			args:   []string{"--series", "some-series"},
-			count:  1,
-			series: "some-series",
+			args:  []string{"--base", "some-series"},
+			count: 1,
+			base:  "some-series",
 		}, {
 			args:  []string{"-n", "2"},
 			count: 2,
@@ -108,7 +108,7 @@ func (s *AddMachineSuite) TestInit(c *gc.C) {
 		err := cmdtesting.InitCommand(wrappedCommand, test.args)
 		if test.errorString == "" {
 			c.Check(err, jc.ErrorIsNil)
-			c.Check(addCmd.Series, gc.Equals, test.series)
+			c.Check(addCmd.Base, gc.Equals, test.base)
 			c.Check(addCmd.Constraints.String(), gc.Equals, test.constraints)
 			if addCmd.Placement != nil {
 				c.Check(addCmd.Placement.String(), gc.Equals, test.placement)
@@ -165,7 +165,7 @@ func (s *AddMachineSuite) TestSSHPlacementError(c *gc.C) {
 }
 
 func (s *AddMachineSuite) TestParamsPassedOn(c *gc.C) {
-	_, err := s.run(c, "--constraints", "mem=8G", "--series=jammy", "zone=nz")
+	_, err := s.run(c, "--constraints", "mem=8G", "--base=ubuntu@22.04", "zone=nz")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.fakeAddMachine.args, gc.HasLen, 1)
 
@@ -177,7 +177,7 @@ func (s *AddMachineSuite) TestParamsPassedOn(c *gc.C) {
 }
 
 func (s *AddMachineSuite) TestParamsPassedOnNTimes(c *gc.C) {
-	_, err := s.run(c, "-n", "3", "--constraints", "mem=8G", "--series=jammy")
+	_, err := s.run(c, "-n", "3", "--constraints", "mem=8G", "--base=ubuntu@22.04")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.fakeAddMachine.args, gc.HasLen, 3)
 

--- a/tests/suites/machine/machine.sh
+++ b/tests/suites/machine/machine.sh
@@ -6,7 +6,7 @@ test_log_permissions() {
 	file="${TEST_DIR}/test_log_permissions.log"
 	ensure "correct-log" "${file}"
 
-	juju deploy postgresql --series focal
+	juju deploy postgresql --base ubuntu@20.04
 
 	wait_for "started" '.machines."0"."juju-status".current'
 


### PR DESCRIPTION
The following deprecates series in favour of base. Adds a warning if you're using series. As base was already part of the params package and therefore exposed for add-machine, the actual change here, was just to deprecate --series in favour of --base.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing

## QA steps

### With base

```sh
$ juju add-machine --base=ubuntu@22.04 -n 1
created machine 3
```

### With series

```sh
$ juju add-machine --series=focal -n 1
WARNING series flag is deprecated, use --base instead
created machine 2
```

### With series and base

```sh
$ juju add-machine --series=focal --base=ubuntu@22.04 -n 1
ERROR --series and --base cannot be specified together
```

## Documentation changes

@tmihoc we'll be outputting bases instead of series for add-machine.

