### PR TITLE
[JUJU-2324] Use confirmation abstraction for remove-unit

### DIFF
--- a/cmd/juju/application/removeunit_test.go
+++ b/cmd/juju/application/removeunit_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/cmd/juju/application"
 	"github.com/juju/juju/cmd/juju/application/mocks"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/jujuclient/jujuclienttesting"
 	"github.com/juju/juju/provider/dummy"
@@ -76,7 +75,7 @@ func (s *RemoveUnitSuite) TestRemoveUnit(c *gc.C) {
 		Error: apiservererrors.ServerError(errors.New("doink")),
 	}}, nil)
 
-	ctx, err := s.runRemoveUnit(c, "unit/0", "unit/1", "unit/2")
+	ctx, err := s.runRemoveUnit(c, "--no-prompt", "unit/0", "unit/1", "unit/2")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 
 	stdout := cmdtesting.Stdout(ctx)
@@ -106,7 +105,7 @@ func (s *RemoveUnitSuite) TestRemoveUnitDestroyStorage(c *gc.C) {
 		Error: apiservererrors.ServerError(errors.New("doink")),
 	}}, nil)
 
-	ctx, err := s.runRemoveUnit(c, "unit/0", "unit/1", "unit/2", "--destroy-storage")
+	ctx, err := s.runRemoveUnit(c, "--no-prompt", "unit/0", "unit/1", "unit/2", "--destroy-storage")
 	c.Assert(err, gc.Equals, cmd.ErrSilent)
 
 	stdout := cmdtesting.Stdout(ctx)
@@ -134,7 +133,7 @@ func (s *RemoveUnitSuite) TestBlockRemoveUnit(c *gc.C) {
 		Units: []string{"some-unit-name/0"},
 	}).Return(nil, apiservererrors.OperationBlockedError("TestBlockRemoveUnit"))
 
-	s.runRemoveUnit(c, "some-unit-name/0")
+	s.runRemoveUnit(c, "--no-prompt", "some-unit-name/0")
 
 	c.Check(c.GetTestLog(), gc.Matches, "(?s).*TestBlockRemoveUnit.*")
 }
@@ -174,8 +173,6 @@ func (s *RemoveUnitSuite) TestRemoveUnitDryRunOldFacade(c *gc.C) {
 func (s *RemoveUnitSuite) TestRemoveUnitWithPrompt(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
-
 	var stdin bytes.Buffer
 	ctx := cmdtesting.Context(c)
 	ctx.Stdin = &stdin
@@ -210,8 +207,6 @@ func (s *RemoveUnitSuite) TestRemoveUnitWithPrompt(c *gc.C) {
 func (s *RemoveUnitSuite) TestRemoveUnitWithPromptOldFacade(c *gc.C) {
 	s.facadeVersion = 15
 	defer s.setup(c).Finish()
-
-	s.PatchEnvironment(osenv.JujuSkipConfirmationEnvKey, "0")
 
 	var stdin bytes.Buffer
 	ctx := cmdtesting.Context(c)


### PR DESCRIPTION
Now that confirmation behaviours have stabilised, we can use a helpful abstraction to handle this

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Verify that `remove-unit` now asks for a prompt by default. This can be skipped using `--no-prompt` or `JUJU_SKIP_CONFIRMATION=1`