### PR TITLE
[JUJU-2413] Remove typed lease error

### DIFF
--- a/core/lease/errors.go
+++ b/core/lease/errors.go
@@ -37,10 +37,6 @@ const (
 	// ErrAborted indicates that the stop channel returned before the operation
 	// succeeded or failed.
 	ErrAborted = errors.ConstError("lease operation aborted")
-
-	// ErrDeadlineExceeded indicates if the underlying request was rejected
-	// because enqueuing exceeded the timeout.
-	ErrDeadlineExceeded = errors.ConstError("lease deadline exceeded")
 )
 
 // IsInvalid returns whether the specified error represents ErrInvalid
@@ -71,10 +67,4 @@ func IsAborted(err error) bool {
 // (even if it's wrapped).
 func IsNotHeld(err error) bool {
 	return errors.Cause(err) == ErrNotHeld
-}
-
-// IsDeadlineExceeded returns whether the specified error represents
-// ErrDeadlineExceeded (even if it's wrapped).
-func IsDeadlineExceeded(err error) bool {
-	return errors.Cause(err) == ErrDeadlineExceeded
 }


### PR DESCRIPTION
The deadline typed error for the lases manager was for the older implementation of leases. This typed error was used to indicate when an API didn't respond in a timely fashion.

Just removing the error is enough to ensure that we've not got any code paths in the lease manager that aren't exercised.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.