### PR TITLE
[JUJU-2416] Remove batch fsm controller config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -282,10 +282,6 @@ type Config interface {
 	// performed after each write to the raft log.
 	NonSyncedWritesToRaftLog() bool
 
-	// BatchRaftFSM returns true if the raft calls should use the batching
-	// FSM.
-	BatchRaftFSM() bool
-
 	// AgentLogfileMaxSizeMB returns the maximum file size in MB of each
 	// agent/controller log file.
 	AgentLogfileMaxSizeMB() int
@@ -344,10 +340,6 @@ type configSetterOnly interface {
 	// SetNonSyncedWritesToRaftLog selects whether fsync calls are performed
 	// after each write to the raft log.
 	SetNonSyncedWritesToRaftLog(bool)
-
-	// SetBatchRaftFSM select whether raft should use the batching for writing
-	// to the FSM.
-	SetBatchRaftFSM(bool)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -422,7 +414,6 @@ type configInternal struct {
 	mongoMemoryProfile       string
 	jujuDBSnapChannel        string
 	nonSyncedWritesToRaftLog bool
-	batchRaftFSM             bool
 	agentLogfileMaxSizeMB    int
 	agentLogfileMaxBackups   int
 }
@@ -444,7 +435,6 @@ type AgentConfigParams struct {
 	MongoMemoryProfile       mongo.MemoryProfile
 	JujuDBSnapChannel        string
 	NonSyncedWritesToRaftLog bool
-	BatchRaftFSM             bool
 	AgentLogfileMaxSizeMB    int
 	AgentLogfileMaxBackups   int
 }
@@ -509,7 +499,6 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		mongoMemoryProfile:       configParams.MongoMemoryProfile.String(),
 		jujuDBSnapChannel:        configParams.JujuDBSnapChannel,
 		nonSyncedWritesToRaftLog: configParams.NonSyncedWritesToRaftLog,
-		batchRaftFSM:             configParams.BatchRaftFSM,
 		agentLogfileMaxSizeMB:    configParams.AgentLogfileMaxSizeMB,
 		agentLogfileMaxBackups:   configParams.AgentLogfileMaxBackups,
 	}
@@ -832,16 +821,6 @@ func (c *configInternal) NonSyncedWritesToRaftLog() bool {
 // SetNonSyncedWritesToRaftLog implements configSetterOnly.
 func (c *configInternal) SetNonSyncedWritesToRaftLog(nonSyncedWrites bool) {
 	c.nonSyncedWritesToRaftLog = nonSyncedWrites
-}
-
-// BatchRaftFSM implements Config.
-func (c *configInternal) BatchRaftFSM() bool {
-	return c.batchRaftFSM
-}
-
-// SetBatchRaftFSM implements configSetterOnly.
-func (c *configInternal) SetBatchRaftFSM(batchRaftFSM bool) {
-	c.batchRaftFSM = batchRaftFSM
 }
 
 // AgentLogfileMaxSizeMB implements Config.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -387,7 +387,6 @@ var attributeParams = agent.AgentConfigParams{
 	Model:                    testing.ModelTag,
 	JujuDBSnapChannel:        controller.DefaultJujuDBSnapChannel,
 	NonSyncedWritesToRaftLog: false,
-	BatchRaftFSM:             false,
 	AgentLogfileMaxSizeMB:    150,
 	AgentLogfileMaxBackups:   4,
 }
@@ -405,7 +404,6 @@ func (*suite) TestAttributes(c *gc.C) {
 	c.Assert(conf.UpgradedToVersion(), jc.DeepEquals, jujuversion.Current)
 	c.Assert(conf.JujuDBSnapChannel(), gc.Equals, "4.4/stable")
 	c.Assert(conf.NonSyncedWritesToRaftLog(), jc.IsFalse)
-	c.Assert(conf.BatchRaftFSM(), jc.IsFalse)
 	c.Assert(conf.AgentLogfileMaxSizeMB(), gc.Equals, 150)
 	c.Assert(conf.AgentLogfileMaxBackups(), gc.Equals, 4)
 }
@@ -715,16 +713,4 @@ func (*suite) TestSetSyncWritesToRaftLog(c *gc.C) {
 	conf.SetNonSyncedWritesToRaftLog(true)
 	nonSyncedWritesToRaftLog = conf.NonSyncedWritesToRaftLog()
 	c.Assert(nonSyncedWritesToRaftLog, jc.IsTrue, gc.Commentf("sync writes to raft log settings not updated"))
-}
-
-func (*suite) TestSetBatchRaftFSM(c *gc.C) {
-	conf, err := agent.NewAgentConfig(attributeParams)
-	c.Assert(err, jc.ErrorIsNil)
-
-	nonSyncedWritesToRaftLog := conf.BatchRaftFSM()
-	c.Assert(nonSyncedWritesToRaftLog, jc.IsFalse)
-
-	conf.SetBatchRaftFSM(true)
-	nonSyncedWritesToRaftLog = conf.BatchRaftFSM()
-	c.Assert(nonSyncedWritesToRaftLog, jc.IsTrue, gc.Commentf("batch raft FSM settings not updated"))
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -64,7 +64,6 @@ type format_2_0Serialization struct {
 	MongoMemoryProfile       string `yaml:"mongomemoryprofile,omitempty"`
 	JujuDBSnapChannel        string `yaml:"juju-db-snap-channel,omitempty"`
 	NonSyncedWritesToRaftLog bool   `yaml:"no-sync-writes-to-raft-log,omitempty"`
-	BatchRaftFSM             bool   `yaml:"batch-raft-fsm,omitempty"`
 }
 
 func init() {
@@ -117,7 +116,6 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 		agentLogfileMaxBackups: format.AgentLogfileMaxBackups,
 
 		nonSyncedWritesToRaftLog: format.NonSyncedWritesToRaftLog,
-		batchRaftFSM:             format.BatchRaftFSM,
 	}
 	if len(format.APIAddresses) > 0 {
 		config.apiDetails = &apiDetails{
@@ -187,7 +185,6 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 		AgentLogfileMaxBackups: config.agentLogfileMaxBackups,
 
 		NonSyncedWritesToRaftLog: config.nonSyncedWritesToRaftLog,
-		BatchRaftFSM:             config.batchRaftFSM,
 	}
 	if config.servingInfo != nil {
 		format.ControllerCert = config.servingInfo.Cert

--- a/cmd/containeragent/initialize/config.go
+++ b/cmd/containeragent/initialize/config.go
@@ -126,10 +126,6 @@ func (c *configFromEnv) NonSyncedWritesToRaftLog() bool {
 	panic("not implemented")
 }
 
-func (c *configFromEnv) BatchRaftFSM() bool {
-	panic("not implemented")
-}
-
 func (c *configFromEnv) AgentLogfileMaxSizeMB() int {
 	panic("not implemented")
 }

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -278,7 +278,6 @@ func (c *BootstrapCommand) Run(_ *cmd.Context) error {
 		}
 		agentConfig.SetJujuDBSnapChannel(args.ControllerConfig.JujuDBSnapChannel())
 		agentConfig.SetNonSyncedWritesToRaftLog(args.ControllerConfig.NonSyncedWritesToRaftLog())
-		agentConfig.SetBatchRaftFSM(args.ControllerConfig.BatchRaftFSM())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("cannot write agent config: %v", err)

--- a/controller/config.go
+++ b/controller/config.go
@@ -227,9 +227,6 @@ const (
 	// when writing to the raft log by setting this value to true.
 	NonSyncedWritesToRaftLog = "non-synced-writes-to-raft-log"
 
-	// BatchRaftFSM allows the operator to batch raft FSM calls.
-	BatchRaftFSM = "batch-raft-fsm"
-
 	// MigrationMinionWaitMax is the maximum time that the migration-master
 	// worker will wait for agents to report for a migration phase when
 	// executing a model migration.
@@ -376,10 +373,6 @@ const (
 	// non-synced-writes-to-raft-log value. It is set to false by default.
 	DefaultNonSyncedWritesToRaftLog = false
 
-	// DefaultBatchRaftFSM is the default value for batch-raft-fsm value.
-	// It is set to false by default.
-	DefaultBatchRaftFSM = false
-
 	// DefaultMigrationMinionWaitMax is the default value for
 	DefaultMigrationMinionWaitMax = "15m"
 )
@@ -432,7 +425,6 @@ var (
 		MaxCharmStateSize,
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
-		BatchRaftFSM,
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
@@ -484,7 +476,6 @@ var (
 		MaxCharmStateSize,
 		MaxAgentStateSize,
 		NonSyncedWritesToRaftLog,
-		BatchRaftFSM,
 		MigrationMinionWaitMax,
 		ApplicationResourceDownloadLimit,
 		ControllerResourceDownloadLimit,
@@ -1025,14 +1016,6 @@ func (c Config) NonSyncedWritesToRaftLog() bool {
 	return DefaultNonSyncedWritesToRaftLog
 }
 
-// BatchRaftFSM returns true if raft should use batch writing to the FSM.
-func (c Config) BatchRaftFSM() bool {
-	if v, ok := c[BatchRaftFSM]; ok {
-		return v.(bool)
-	}
-	return DefaultBatchRaftFSM
-}
-
 // MigrationMinionWaitMax returns a duration for the maximum time that the
 // migration-master worker should wait for migration-minion reports during
 // phases of a model migration.
@@ -1380,7 +1363,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxCharmStateSize:                schema.ForceInt(),
 	MaxAgentStateSize:                schema.ForceInt(),
 	NonSyncedWritesToRaftLog:         schema.Bool(),
-	BatchRaftFSM:                     schema.Bool(),
 	MigrationMinionWaitMax:           schema.String(),
 	ApplicationResourceDownloadLimit: schema.ForceInt(),
 	ControllerResourceDownloadLimit:  schema.ForceInt(),
@@ -1427,7 +1409,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxCharmStateSize:                DefaultMaxCharmStateSize,
 	MaxAgentStateSize:                DefaultMaxAgentStateSize,
 	NonSyncedWritesToRaftLog:         DefaultNonSyncedWritesToRaftLog,
-	BatchRaftFSM:                     DefaultBatchRaftFSM,
 	MigrationMinionWaitMax:           DefaultMigrationMinionWaitMax,
 	ApplicationResourceDownloadLimit: schema.Omit,
 	ControllerResourceDownloadLimit:  schema.Omit,
@@ -1617,10 +1598,6 @@ Use "caas-image-repo" instead.`,
 	NonSyncedWritesToRaftLog: {
 		Type:        environschema.Tbool,
 		Description: `Do not perform fsync calls after appending entries to the raft log. Disabling sync improves performance at the cost of reliability`,
-	},
-	BatchRaftFSM: {
-		Type:        environschema.Tbool,
-		Description: `Allow raft to use batch writing to the FSM.`,
 	},
 	MigrationMinionWaitMax: {
 		Type:        environschema.Tstring,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -371,12 +371,6 @@ var newConfigTests = []struct {
 		},
 		expectError: `non-synced-writes-to-raft-log: expected bool, got string\("I live dangerously"\)`,
 	}, {
-		about: "invalid batch-raft-fsm - string",
-		config: controller.Config{
-			controller.BatchRaftFSM: "I live dangerously",
-		},
-		expectError: `batch-raft-fsm: expected bool, got string\("I live dangerously"\)`,
-	}, {
 		about: "public-dns-address: expect string, got number",
 		config: controller.Config{
 			controller.PublicDNSAddress: 42,

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -62,7 +62,6 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.MaxCharmStateSize,
 		controller.MaxAgentStateSize,
 		controller.NonSyncedWritesToRaftLog,
-		controller.BatchRaftFSM,
 		controller.MigrationMinionWaitMax,
 		controller.AgentLogfileMaxBackups,
 		controller.AgentLogfileMaxSize,

--- a/worker/agentconfigupdater/manifold.go
+++ b/worker/agentconfigupdater/manifold.go
@@ -103,10 +103,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			configNonSyncedWritesToRaftLog := controllerConfig.NonSyncedWritesToRaftLog()
 			nonSyncedWritesToRaftLogChanged := agentsNonSyncedWritesToRaftLog != configNonSyncedWritesToRaftLog
 
-			agentsBatchRaftFSM := agent.CurrentConfig().BatchRaftFSM()
-			configBatchRaftFSM := controllerConfig.BatchRaftFSM()
-			batchRaftFSMChanged := agentsBatchRaftFSM != configBatchRaftFSM
-
 			info, err := apiState.StateServingInfo()
 			if err != nil {
 				return nil, errors.Annotate(err, "getting state serving info")
@@ -137,10 +133,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 					logger.Debugf("setting non synced writes to raft log: %t => %t", agentsNonSyncedWritesToRaftLog, configNonSyncedWritesToRaftLog)
 					config.SetNonSyncedWritesToRaftLog(configNonSyncedWritesToRaftLog)
 				}
-				if batchRaftFSMChanged {
-					logger.Debugf("setting batch raft fsm: %t => %t", agentsBatchRaftFSM, configBatchRaftFSM)
-					config.SetBatchRaftFSM(configBatchRaftFSM)
-				}
 				return nil
 			})
 			if err != nil {
@@ -169,7 +161,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				MongoProfile:             configMongoMemoryProfile,
 				JujuDBSnapChannel:        configJujuDBSnapChannel,
 				NonSyncedWritesToRaftLog: configNonSyncedWritesToRaftLog,
-				BatchRaftFSM:             configBatchRaftFSM,
 				Logger:                   config.Logger,
 			})
 		},

--- a/worker/agentconfigupdater/manifold_test.go
+++ b/worker/agentconfigupdater/manifold_test.go
@@ -357,9 +357,6 @@ type mockConfig struct {
 
 	nonSyncedWritesToRaftLog    bool
 	nonSyncedWritesToRaftLogSet bool
-
-	batchRaftFSM    bool
-	batchRaftFSMSet bool
 }
 
 func (mc *mockConfig) Tag() names.Tag {
@@ -413,15 +410,6 @@ func (mc *mockConfig) NonSyncedWritesToRaftLog() bool {
 func (mc *mockConfig) SetNonSyncedWritesToRaftLog(nonSynced bool) {
 	mc.nonSyncedWritesToRaftLog = nonSynced
 	mc.nonSyncedWritesToRaftLogSet = true
-}
-
-func (mc *mockConfig) BatchRaftFSM() bool {
-	return mc.batchRaftFSM
-}
-
-func (mc *mockConfig) SetBatchRaftFSM(batchRaftFSM bool) {
-	mc.batchRaftFSM = batchRaftFSM
-	mc.batchRaftFSMSet = true
 }
 
 func (mc *mockConfig) LogDir() string {

--- a/worker/agentconfigupdater/worker_test.go
+++ b/worker/agentconfigupdater/worker_test.go
@@ -43,7 +43,6 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 			profile:                  controller.DefaultMongoMemoryProfile,
 			snapChannel:              controller.DefaultJujuDBSnapChannel,
 			nonSyncedWritesToRaftLog: controller.DefaultNonSyncedWritesToRaftLog,
-			batchRaftFSM:             controller.DefaultBatchRaftFSM,
 		},
 	}
 	s.config = agentconfigupdater.WorkerConfig{
@@ -52,7 +51,6 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 		MongoProfile:             controller.DefaultMongoMemoryProfile,
 		JujuDBSnapChannel:        controller.DefaultJujuDBSnapChannel,
 		NonSyncedWritesToRaftLog: controller.DefaultNonSyncedWritesToRaftLog,
-		BatchRaftFSM:             controller.DefaultBatchRaftFSM,
 		Logger:                   s.logger,
 	}
 	s.initialConfigMsg = controllermsg.ConfigChangedMessage{
@@ -60,7 +58,6 @@ func (s *WorkerSuite) SetUpTest(c *gc.C) {
 			controller.MongoMemoryProfile:       controller.DefaultMongoMemoryProfile,
 			controller.JujuDBSnapChannel:        controller.DefaultJujuDBSnapChannel,
 			controller.NonSyncedWritesToRaftLog: controller.DefaultNonSyncedWritesToRaftLog,
-			controller.BatchRaftFSM:             controller.DefaultBatchRaftFSM,
 		},
 	}
 }
@@ -207,37 +204,6 @@ func (s *WorkerSuite) TestUpdateSyncWritesToRaftLog(c *gc.C) {
 	workertest.CheckAlive(c, w)
 
 	newConfig.Config[controller.NonSyncedWritesToRaftLog] = !controller.DefaultNonSyncedWritesToRaftLog
-	handled, err = s.hub.Publish(controllermsg.ConfigChanged, newConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	select {
-	case <-pubsub.Wait(handled):
-	case <-time.After(testing.LongWait):
-		c.Fatalf("event not handled")
-	}
-
-	err = workertest.CheckKilled(c, w)
-
-	c.Assert(err, gc.Equals, jworker.ErrRestartAgent)
-}
-
-func (s *WorkerSuite) TestUpdateBatchRaftFSM(c *gc.C) {
-	w, err := agentconfigupdater.NewWorker(s.config)
-	c.Assert(w, gc.NotNil)
-	c.Check(err, jc.ErrorIsNil)
-
-	newConfig := s.initialConfigMsg
-	handled, err := s.hub.Publish(controllermsg.ConfigChanged, newConfig)
-	c.Assert(err, jc.ErrorIsNil)
-	select {
-	case <-pubsub.Wait(handled):
-	case <-time.After(testing.LongWait):
-		c.Fatalf("event not handled")
-	}
-
-	// No sync flag is the same, worker still alive.
-	workertest.CheckAlive(c, w)
-
-	newConfig.Config[controller.BatchRaftFSM] = !controller.DefaultBatchRaftFSM
 	handled, err = s.hub.Publish(controllermsg.ConfigChanged, newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	select {

--- a/worker/containerbroker/mocks/agent_mock.go
+++ b/worker/containerbroker/mocks/agent_mock.go
@@ -150,20 +150,6 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
-// BatchRaftFSM mocks base method.
-func (m *MockConfig) BatchRaftFSM() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BatchRaftFSM")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// BatchRaftFSM indicates an expected call of BatchRaftFSM.
-func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
-}
-
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/instancemutater/mocks/agent_mock.go
+++ b/worker/instancemutater/mocks/agent_mock.go
@@ -150,20 +150,6 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
-// BatchRaftFSM mocks base method.
-func (m *MockConfig) BatchRaftFSM() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BatchRaftFSM")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// BatchRaftFSM indicates an expected call of BatchRaftFSM.
-func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
-}
-
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/stateconverter/mocks/agent_mock.go
+++ b/worker/stateconverter/mocks/agent_mock.go
@@ -150,20 +150,6 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
-// BatchRaftFSM mocks base method.
-func (m *MockConfig) BatchRaftFSM() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BatchRaftFSM")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// BatchRaftFSM indicates an expected call of BatchRaftFSM.
-func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
-}
-
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()

--- a/worker/upgradedatabase/mocks/agent.go
+++ b/worker/upgradedatabase/mocks/agent.go
@@ -151,20 +151,6 @@ func (mr *MockConfigMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfig)(nil).AgentLogfileMaxSizeMB))
 }
 
-// BatchRaftFSM mocks base method.
-func (m *MockConfig) BatchRaftFSM() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BatchRaftFSM")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// BatchRaftFSM indicates an expected call of BatchRaftFSM.
-func (mr *MockConfigMockRecorder) BatchRaftFSM() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfig)(nil).BatchRaftFSM))
-}
-
 // CACert mocks base method.
 func (m *MockConfig) CACert() string {
 	m.ctrl.T.Helper()
@@ -557,20 +543,6 @@ func (mr *MockConfigSetterMockRecorder) AgentLogfileMaxSizeMB() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentLogfileMaxSizeMB", reflect.TypeOf((*MockConfigSetter)(nil).AgentLogfileMaxSizeMB))
 }
 
-// BatchRaftFSM mocks base method.
-func (m *MockConfigSetter) BatchRaftFSM() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BatchRaftFSM")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// BatchRaftFSM indicates an expected call of BatchRaftFSM.
-func (mr *MockConfigSetterMockRecorder) BatchRaftFSM() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchRaftFSM", reflect.TypeOf((*MockConfigSetter)(nil).BatchRaftFSM))
-}
-
 // CACert mocks base method.
 func (m *MockConfigSetter) CACert() string {
 	m.ctrl.T.Helper()
@@ -808,18 +780,6 @@ func (m *MockConfigSetter) SetAPIHostPorts(arg0 []network.HostPorts) error {
 func (mr *MockConfigSetterMockRecorder) SetAPIHostPorts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIHostPorts", reflect.TypeOf((*MockConfigSetter)(nil).SetAPIHostPorts), arg0)
-}
-
-// SetBatchRaftFSM mocks base method.
-func (m *MockConfigSetter) SetBatchRaftFSM(arg0 bool) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetBatchRaftFSM", arg0)
-}
-
-// SetBatchRaftFSM indicates an expected call of SetBatchRaftFSM.
-func (mr *MockConfigSetterMockRecorder) SetBatchRaftFSM(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBatchRaftFSM", reflect.TypeOf((*MockConfigSetter)(nil).SetBatchRaftFSM), arg0)
 }
 
 // SetCACert mocks base method.


### PR DESCRIPTION
The batch FSM controller config flag was used by the raft API implementation to send multiple operations in one batch. This was thought to speed up the implementation. The raft API is gone, so it's no longer required to have this config flag around any longer.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Build and tests pass.
