### PR TITLE
[JUJU-2417] Standardise jujud building

### DIFF
--- a/scripts/verify.bash
+++ b/scripts/verify.bash
@@ -19,8 +19,5 @@ else
     echo "Ignoring static analysis, run again with STATIC_ANALYSIS=1 ..."
 fi
 
-echo "checking: go build ..."
-go build $(go list github.com/juju/juju/... | grep -v /vendor/)
-
 echo "checking: tests are wired up ..."
 ./scripts/checktesting.bash


### PR DESCRIPTION
The Makefile has a standardised way of building binaries and it's shame that when dqlite was added (by me), we didn't use the new hotness. This finally fixes that and we're almost the same with a tiny few exceptions (ldflags).

Ideally, we'll move to zig to build for different architectures, but that's a bit more work (I know @tlm has done some work on this). This is the first step (read as foundation), before moving to zig.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
$ make go-install
$ make go-build
```
