### PR TITLE
[JUJU-2410] Remove duplicated output error in list model when not connected to a controller

### DIFF
--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -97,8 +97,7 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 		c.user = accountDetails.User
 	}
 	if !names.IsValidUser(c.user) {
-		err := errors.NotValidf("user %q", c.user)
-		return err
+		return errors.NotValidf("user %q", c.user)
 	}
 
 	c.runVars = modelsRunValues{

--- a/cmd/juju/controller/listmodels.go
+++ b/cmd/juju/controller/listmodels.go
@@ -85,12 +85,10 @@ func (c *modelsCommand) SetFlags(f *gnuflag.FlagSet) {
 func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	controllerName, err := c.ControllerName()
 	if err != nil {
-		ctx.Infof(err.Error())
 		return errors.Trace(err)
 	}
 	accountDetails, err := c.CurrentAccountDetails()
 	if err != nil {
-		ctx.Infof(err.Error())
 		return err
 	}
 	c.loggedInUser = accountDetails.User
@@ -100,7 +98,6 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 	}
 	if !names.IsValidUser(c.user) {
 		err := errors.NotValidf("user %q", c.user)
-		ctx.Infof(err.Error())
 		return err
 	}
 
@@ -113,7 +110,6 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 
 	modelmanagerAPI, err := c.getModelManagerAPI()
 	if err != nil {
-		ctx.Infof(err.Error())
 		return errors.Trace(err)
 	}
 	defer modelmanagerAPI.Close()
@@ -130,7 +126,6 @@ func (c *modelsCommand) Run(ctx *cmd.Context) error {
 		haveModels, err = c.oldModelsCommandBehaviour(ctx, modelmanagerAPI, now)
 	}
 	if err != nil {
-		ctx.Infof(err.Error())
 		return err
 	}
 	if !haveModels && c.out.Name() == "tabular" {
@@ -293,7 +288,6 @@ func (c *modelsCommand) modelSummaryFromParams(apiSummary base.UserModelSummary,
 
 	if apiSummary.ProviderType != "" {
 		summary.ProviderType = apiSummary.ProviderType
-
 	}
 	if apiSummary.CloudCredential != "" {
 		if !names.IsValidCloudCredential(apiSummary.CloudCredential) {

--- a/cmd/juju/controller/listmodels_test.go
+++ b/cmd/juju/controller/listmodels_test.go
@@ -95,17 +95,14 @@ func (f *fakeModelMgrAPIClient) ListModelSummaries(user string, all bool) ([]bas
 		cloud, err := names.ParseCloudTag(info.Result.CloudTag)
 		if err != nil {
 			cloud = names.NewCloudTag("aws")
-
 		}
 		cred, err := names.ParseCloudCredentialTag(info.Result.CloudCredentialTag)
 		if err != nil {
 			cred = names.NewCloudCredentialTag("foo/bob/one")
-
 		}
 		owner, err := names.ParseUserTag(info.Result.OwnerTag)
 		if err != nil {
 			owner = names.NewUserTag("admin")
-
 		}
 		results[i] = base.UserModelSummary{
 			Name:            info.Result.Name,
@@ -249,7 +246,7 @@ func (s *BaseModelsSuite) SetUpTest(c *gc.C) {
 		LastConnection: &last1,
 		Access:         params.ModelReadAccess,
 	}}
-	//2nd model
+	// 2nd model
 	secondModel := s.api.infos[1].Result
 	last2 := time.Date(2015, 3, 1, 0, 0, 0, 0, time.UTC)
 	secondModel.Users = []params.ModelUserInfo{{
@@ -384,19 +381,15 @@ func (s *BaseModelsSuite) TestUnrecognizedArg(c *gc.C) {
 }
 
 func (s *BaseModelsSuite) TestInvalidUser(c *gc.C) {
-	context, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "+bob")
+	_, err := cmdtesting.RunCommand(c, s.newCommand(), "--user", "+bob")
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`user "+bob" not valid`))
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, "user \"+bob\" not valid\n")
 	s.api.CheckNoCalls(c)
 }
 
 func (s *BaseModelsSuite) TestModelsError(c *gc.C) {
 	s.api.err = apiservererrors.ErrPerm
-	context, err := cmdtesting.RunCommand(c, s.newCommand())
+	_, err := cmdtesting.RunCommand(c, s.newCommand())
 	c.Assert(err, gc.ErrorMatches, ".*: permission denied")
-	c.Assert(cmdtesting.Stdout(context), gc.Equals, "")
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, "cannot list models: permission denied\n")
 	s.checkAPICalls(c, "BestAPIVersion", "ListModels", "Close")
 }
 


### PR DESCRIPTION
When running `juju models` when there is no controller registered, a duplicated error is returned:

```
$ juju models
No controllers registered.

Please either create a new controller using "juju bootstrap" or connect to
another controller that you have been given access to using "juju register".
ERROR No controllers registered.

Please either create a new controller using "juju bootstrap" or connect to
another controller that you have been given access to using "juju register".
```

This PR fixes this duplicated error log.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

First, ensure Juju has no controller registered, then list models:

```sh
$ juju models
```
the output should be as follows:

```sh
$ juju models
ERROR No controllers registered.

Please either create a new controller using "juju bootstrap" or connect to
another controller that you have been given access to using "juju register".
```
## Bonus

I also removed other duplicate logs which created wrong behavior (not yet listed as bug yet), for example:

```sh
$ juju models --user +bob
user "+bob" not valid
ERROR user "+bob" not valid
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1996506