### PR TITLE
[JUJU-2313] Remove charmstore-url model config

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
-	"github.com/juju/charmrepo/v7/csclient"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -111,9 +110,6 @@ const (
 
 	// CACertKey is the key for the controller's CA certificate attribute.
 	CACertKey = "ca-cert"
-
-	// CharmStoreURL is the key for the url to use for charmstore API calls
-	CharmStoreURL = "charmstore-url"
 
 	// ControllerUUIDKey is the key for the controller UUID attribute.
 	ControllerUUIDKey = "controller-uuid"
@@ -396,7 +392,6 @@ var (
 		AutocertDNSNameKey,
 		AutocertURLKey,
 		CACertKey,
-		CharmStoreURL,
 		ControllerAPIPort,
 		ControllerName,
 		ControllerUUIDKey,
@@ -759,15 +754,6 @@ func (c Config) Features() set.Strings {
 		}
 	}
 	return features
-}
-
-// CharmStoreURL returns the URL to use for charmstore api calls.
-func (c Config) CharmStoreURL() string {
-	url := c.asString(CharmStoreURL)
-	if url == "" {
-		return csclient.ServerURL
-	}
-	return url
 }
 
 // ControllerName returns the name for the controller
@@ -1375,7 +1361,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	CAASOperatorImagePath:            schema.String(),
 	CAASImageRepo:                    schema.String(),
 	Features:                         schema.List(schema.String()),
-	CharmStoreURL:                    schema.String(),
 	MeteringURL:                      schema.String(),
 	MaxCharmStateSize:                schema.ForceInt(),
 	MaxAgentStateSize:                schema.ForceInt(),
@@ -1422,7 +1407,6 @@ var configChecker = schema.FieldMap(schema.Fields{
 	CAASOperatorImagePath:            schema.Omit,
 	CAASImageRepo:                    schema.Omit,
 	Features:                         schema.Omit,
-	CharmStoreURL:                    csclient.ServerURL,
 	MeteringURL:                      romulus.DefaultAPIRoot,
 	MaxCharmStateSize:                DefaultMaxCharmStateSize,
 	MaxAgentStateSize:                DefaultMaxAgentStateSize,
@@ -1597,10 +1581,6 @@ Use "caas-image-repo" instead.`,
 	Features: {
 		Type:        environschema.Tlist,
 		Description: `A list of runtime changeable features to be updated`,
-	},
-	CharmStoreURL: {
-		Type:        environschema.Tstring,
-		Description: `The url for charmstore API calls`,
 	},
 	MeteringURL: {
 		Type:        environschema.Tstring,

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/juju/charmrepo/v7/csclient"
 	"github.com/juju/collections/set"
 	"github.com/juju/loggo"
 	"github.com/juju/romulus"
@@ -731,16 +730,6 @@ func (s *ConfigSuite) TestCAASImageRepo(c *gc.C) {
 	}
 }
 
-func (s *ConfigSuite) TestCharmstoreURLDefault(c *gc.C) {
-	cfg, err := controller.NewConfig(
-		testing.ControllerTag.Id(),
-		testing.CACert,
-		map[string]interface{}{},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(cfg.CharmStoreURL(), gc.Equals, csclient.ServerURL)
-}
-
 func (s *ConfigSuite) TestControllerNameDefault(c *gc.C) {
 	cfg := controller.Config{}
 	c.Check(cfg.ControllerName(), gc.Equals, "")
@@ -756,19 +745,6 @@ func (s *ConfigSuite) TestControllerNameSetGet(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(cfg.ControllerName(), gc.Equals, "test")
-}
-
-func (s *ConfigSuite) TestCharmstoreURLSettingValue(c *gc.C) {
-	csURL := "http://homestarrunner.com/charmstore"
-	cfg, err := controller.NewConfig(
-		testing.ControllerTag.Id(),
-		testing.CACert,
-		map[string]interface{}{
-			controller.CharmStoreURL: csURL,
-		},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.CharmStoreURL(), gc.Equals, csURL)
 }
 
 func (s *ConfigSuite) TestMeteringURLDefault(c *gc.C) {

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -40,7 +40,6 @@ func (s *ControllerSuite) TestControllerAndModelConfigInitialisation(c *gc.C) {
 		controller.AutocertDNSNameKey,
 		controller.CAASImageRepo,
 		controller.CAASOperatorImagePath,
-		controller.CharmStoreURL,
 		controller.ControllerAPIPort,
 		controller.ControllerName,
 		controller.Features,


### PR DESCRIPTION
Remove charmstore-url model config, part of removing charmstore support from juju.

## QA steps

Below should have a message that it doesn't exist.
```sh
$ juju controller-config charmstore-url
```

## Documentation changes

Remove related references

