### PR TITLE
[JUJU-2396] Reduce dependence on charmrepo

### DIFF
--- a/api/client/charms/client_test.go
+++ b/api/client/charms/client_test.go
@@ -65,7 +65,7 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 
 	curl := charm.MustParseURL("cs:a-charm")
 	curl2 := charm.MustParseURL("cs:jammy/dummy-1")
-	no := "no"
+	no := ""
 	edge := "edge"
 	stable := "stable"
 

--- a/api/client/charms/client_test.go
+++ b/api/client/charms/client_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
 	charmresource "github.com/juju/charm/v9/resource"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -66,9 +65,9 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 
 	curl := charm.MustParseURL("cs:a-charm")
 	curl2 := charm.MustParseURL("cs:jammy/dummy-1")
-	no := string(csparams.NoChannel)
-	edge := string(csparams.EdgeChannel)
-	stable := string(csparams.StableChannel)
+	no := "no"
+	edge := "edge"
+	stable := "stable"
 
 	noChannelParamsOrigin := params.CharmOrigin{Source: "charm-store"}
 	edgeChannelParamsOrigin := params.CharmOrigin{Source: "charm-store", Risk: edge}

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3"
 	"github.com/juju/names/v4"
@@ -178,18 +177,16 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 	seriesCurl, err := charm.ParseURL("ch:amd64/focal/testme")
 	c.Assert(err, jc.ErrorIsNil)
 
-	edge := string(csparams.EdgeChannel)
-	stable := string(csparams.StableChannel)
 	edgeOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
 		Type:         "charm",
-		Risk:         edge,
+		Risk:         "edge",
 		Architecture: "amd64",
 	}
 	stableOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
 		Type:         "charm",
-		Risk:         stable,
+		Risk:         "stable",
 		Architecture: "amd64",
 	}
 
@@ -250,11 +247,10 @@ func (s *charmsMockSuite) TestResolveCharmNoDefinedSeries(c *gc.C) {
 	seriesCurl, err := charm.ParseURL("ch:focal/testme")
 	c.Assert(err, jc.ErrorIsNil)
 
-	edge := string(csparams.EdgeChannel)
 	edgeOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
 		Type:         "charm",
-		Risk:         edge,
+		Risk:         "edge",
 		Architecture: "amd64",
 	}
 
@@ -639,13 +635,12 @@ func (s *charmsMockSuite) expectResolveWithPreferredChannel(times int, err error
 			resolvedOrigin := requestedOrigin
 			resolvedOrigin.Type = "charm"
 
-			if requestedOrigin.Channel == nil || csparams.Channel(requestedOrigin.Channel.Risk) == csparams.NoChannel {
+			if requestedOrigin.Channel == nil || requestedOrigin.Channel.Risk == "" {
 				if requestedOrigin.Channel == nil {
 					resolvedOrigin.Channel = new(charm.Channel)
 				}
 
-				// minor attempt at mimicing charmrepo/charmstore.go.bestChannel()
-				resolvedOrigin.Channel.Risk = charm.Risk(csparams.StableChannel)
+				resolvedOrigin.Channel.Risk = "stable"
 			}
 
 			return curl, resolvedOrigin, []string{"bionic", "focal", "xenial"}, err
@@ -663,13 +658,12 @@ func (s *charmsMockSuite) expectResolveWithPreferredChannelNoSeries() {
 			resolvedOrigin := requestedOrigin
 			resolvedOrigin.Type = "charm"
 
-			if requestedOrigin.Channel == nil || csparams.Channel(requestedOrigin.Channel.Risk) == csparams.NoChannel {
+			if requestedOrigin.Channel == nil || requestedOrigin.Channel.Risk == "" {
 				if requestedOrigin.Channel == nil {
 					resolvedOrigin.Channel = new(charm.Channel)
 				}
 
-				// minor attempt at mimicing charmrepo/charmstore.go.bestChannel()
-				resolvedOrigin.Channel.Risk = charm.Risk(csparams.StableChannel)
+				resolvedOrigin.Channel.Risk = "stable"
 			}
 
 			return curl, resolvedOrigin, []string{}, nil

--- a/charmhub/download_test.go
+++ b/charmhub/download_test.go
@@ -12,10 +12,11 @@ import (
 	"os"
 
 	"github.com/golang/mock/gomock"
-	charmrepotesting "github.com/juju/charmrepo/v7/testing"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testcharms"
 )
 
 const defaultSeries = "bionic"
@@ -124,7 +125,7 @@ func (s *DownloadSuite) createCharmArchieve(c *gc.C) []byte {
 	tmpDir, err := os.MkdirTemp("", "charm")
 	c.Assert(err, jc.ErrorIsNil)
 
-	repo := charmrepotesting.NewRepo(localCharmRepo, defaultSeries)
+	repo := testcharms.NewRepo(localCharmRepo, defaultSeries)
 	charmPath := repo.CharmArchivePath(tmpDir, "dummy")
 
 	path, err := os.ReadFile(charmPath)

--- a/charmhub/download_test.go
+++ b/charmhub/download_test.go
@@ -16,7 +16,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/testcharms"
+	"github.com/juju/juju/testcharms/repo"
 )
 
 const defaultSeries = "bionic"
@@ -125,7 +125,7 @@ func (s *DownloadSuite) createCharmArchieve(c *gc.C) []byte {
 	tmpDir, err := os.MkdirTemp("", "charm")
 	c.Assert(err, jc.ErrorIsNil)
 
-	repo := testcharms.NewRepo(localCharmRepo, defaultSeries)
+	repo := repo.NewRepo(localCharmRepo, defaultSeries)
 	charmPath := repo.CharmArchivePath(tmpDir, "dummy")
 
 	path, err := os.ReadFile(charmPath)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -11,7 +11,6 @@ import (
 	"time" // Only used for time types.
 
 	"github.com/juju/charm/v9"
-	charmrepotesting "github.com/juju/charmrepo/v7/testing"
 	"github.com/juju/clock"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
@@ -231,7 +230,7 @@ func AddTestingCharmWithSeries(c *gc.C, st *State, name string, series string) *
 	return addCharm(c, st, series, testcharms.Repo.CharmDir(name))
 }
 
-func getCharmRepo(series string) *charmrepotesting.Repo {
+func getCharmRepo(series string) *testcharms.CharmRepo {
 	// ALl testing charms for state are under `quantal` except `kubernetes`.
 	if series == "kubernetes" {
 		return testcharms.RepoForSeries(series)
@@ -384,7 +383,7 @@ func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Applica
 	return app
 }
 
-func addCustomCharmWithManifest(c *gc.C, st *State, repo *charmrepotesting.Repo, name, filename, content, series string, revision int, manifest bool) *Charm {
+func addCustomCharmWithManifest(c *gc.C, st *State, repo *testcharms.CharmRepo, name, filename, content, series string, revision int, manifest bool) *Charm {
 	path := repo.ClonedDirPath(c.MkDir(), name)
 	if filename != "" {
 		if manifest {
@@ -409,7 +408,7 @@ bases:
 	return addCharm(c, st, series, ch)
 }
 
-func addCustomCharm(c *gc.C, st *State, repo *charmrepotesting.Repo, name, filename, content, series string, revision int) *Charm {
+func addCustomCharm(c *gc.C, st *State, repo *testcharms.CharmRepo, name, filename, content, series string, revision int) *Charm {
 	return addCustomCharmWithManifest(c, st, repo, name, filename, content, series, revision, false)
 }
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/state/storage"
 	"github.com/juju/juju/state/watcher"
 	"github.com/juju/juju/testcharms"
+	"github.com/juju/juju/testcharms/repo"
 	"github.com/juju/juju/version"
 )
 
@@ -230,7 +231,7 @@ func AddTestingCharmWithSeries(c *gc.C, st *State, name string, series string) *
 	return addCharm(c, st, series, testcharms.Repo.CharmDir(name))
 }
 
-func getCharmRepo(series string) *testcharms.CharmRepo {
+func getCharmRepo(series string) *repo.CharmRepo {
 	// ALl testing charms for state are under `quantal` except `kubernetes`.
 	if series == "kubernetes" {
 		return testcharms.RepoForSeries(series)
@@ -383,7 +384,7 @@ func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Applica
 	return app
 }
 
-func addCustomCharmWithManifest(c *gc.C, st *State, repo *testcharms.CharmRepo, name, filename, content, series string, revision int, manifest bool) *Charm {
+func addCustomCharmWithManifest(c *gc.C, st *State, repo *repo.CharmRepo, name, filename, content, series string, revision int, manifest bool) *Charm {
 	path := repo.ClonedDirPath(c.MkDir(), name)
 	if filename != "" {
 		if manifest {
@@ -408,7 +409,7 @@ bases:
 	return addCharm(c, st, series, ch)
 }
 
-func addCustomCharm(c *gc.C, st *State, repo *testcharms.CharmRepo, name, filename, content, series string, revision int) *Charm {
+func addCustomCharm(c *gc.C, st *State, repo *repo.CharmRepo, name, filename, content, series string, revision int) *Charm {
 	return addCustomCharmWithManifest(c, st, repo, name, filename, content, series, revision, false)
 }
 

--- a/testcharms/charm.go
+++ b/testcharms/charm.go
@@ -10,11 +10,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/juju/charm/v9"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/charm/v9"
-	"github.com/juju/charmrepo/v7/testing"
 
 	jtesting "github.com/juju/juju/testing"
 )
@@ -26,21 +24,21 @@ const (
 )
 
 // Repo provides access to the test charm repository.
-var Repo = testing.NewRepo(localCharmRepo, defaultSeries)
+var Repo = NewRepo(localCharmRepo, defaultSeries)
 
 // Hub provides access to the test charmhub repository.
-var Hub = testing.NewRepo(localCharmHub, defaultSeries)
+var Hub = NewRepo(localCharmHub, defaultSeries)
 
 // RepoForSeries returns a new charm repository for the specified series.
 // Note: this is a bit weird, as it ignores the series if it's NOT kubernetes
 // and falls back to the default series, which makes this pretty pointless.
-func RepoForSeries(series string) *testing.Repo {
-	return testing.NewRepo(localCharmRepo, series)
+func RepoForSeries(series string) *CharmRepo {
+	return NewRepo(localCharmRepo, series)
 }
 
 // RepoWithSeries returns a new charm repository for the specified series.
-func RepoWithSeries(series string) *testing.Repo {
-	return testing.NewRepo(localCharmRepo, series)
+func RepoWithSeries(series string) *CharmRepo {
+	return NewRepo(localCharmRepo, series)
 }
 
 // CheckCharmReady ensures that a desired charm archive exists and
@@ -49,7 +47,7 @@ func CheckCharmReady(c *gc.C, charmArchive *charm.CharmArchive) {
 	fileSize := func() int64 {
 		f, err := os.Open(charmArchive.Path)
 		c.Assert(err, jc.ErrorIsNil)
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		fi, err := f.Stat()
 		c.Assert(err, jc.ErrorIsNil)

--- a/testcharms/charm.go
+++ b/testcharms/charm.go
@@ -14,6 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/testcharms/repo"
 	jtesting "github.com/juju/juju/testing"
 )
 
@@ -24,21 +25,21 @@ const (
 )
 
 // Repo provides access to the test charm repository.
-var Repo = NewRepo(localCharmRepo, defaultSeries)
+var Repo = repo.NewRepo(localCharmRepo, defaultSeries)
 
 // Hub provides access to the test charmhub repository.
-var Hub = NewRepo(localCharmHub, defaultSeries)
+var Hub = repo.NewRepo(localCharmHub, defaultSeries)
 
 // RepoForSeries returns a new charm repository for the specified series.
 // Note: this is a bit weird, as it ignores the series if it's NOT kubernetes
 // and falls back to the default series, which makes this pretty pointless.
-func RepoForSeries(series string) *CharmRepo {
-	return NewRepo(localCharmRepo, series)
+func RepoForSeries(series string) *repo.CharmRepo {
+	return repo.NewRepo(localCharmRepo, series)
 }
 
 // RepoWithSeries returns a new charm repository for the specified series.
-func RepoWithSeries(series string) *CharmRepo {
-	return NewRepo(localCharmRepo, series)
+func RepoWithSeries(series string) *repo.CharmRepo {
+	return repo.NewRepo(localCharmRepo, series)
 }
 
 // CheckCharmReady ensures that a desired charm archive exists and

--- a/testcharms/repo.go
+++ b/testcharms/repo.go
@@ -1,0 +1,177 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testcharms
+
+// File moved from github.com/juju/charmrepo/v7/testing/charm.go
+// Attempting to remove use of the charmrepo package from juju
+//with the removal of charmstore support.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/juju/charm/v9"
+	"github.com/juju/utils/v3/fs"
+)
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// NewRepo returns a new testing charm repository rooted at the given
+// path, relative to the package directory of the calling package, using
+// defaultSeries as the default series.
+func NewRepo(path, defaultSeries string) *CharmRepo {
+	// Find the repo directory. This is only OK to do
+	// because this is running in a test context
+	// so we know the source is available.
+	_, file, _, ok := runtime.Caller(1)
+	if !ok {
+		panic("cannot get caller")
+	}
+	r := &CharmRepo{
+		path:          filepath.Join(filepath.Dir(file), path),
+		defaultSeries: defaultSeries,
+	}
+	_, err := os.Stat(r.path)
+	if err != nil {
+		panic(fmt.Errorf("cannot read repository found at %q: %v", r.path, err))
+	}
+	return r
+}
+
+// CharmRepo represents a charm repository used for testing.
+type CharmRepo struct {
+	path          string
+	defaultSeries string
+}
+
+func (r *CharmRepo) Path() string {
+	return r.path
+}
+
+func clone(dst, src string) string {
+	dst = filepath.Join(dst, filepath.Base(src))
+	check(fs.Copy(src, dst))
+	return dst
+}
+
+// BundleDirPath returns the path to a bundle directory with the given name in the
+// default series
+func (r *CharmRepo) BundleDirPath(name string) string {
+	return filepath.Join(r.Path(), "bundle", name)
+}
+
+// BundleDir returns the actual charm.BundleDir named name.
+func (r *CharmRepo) BundleDir(name string) *charm.BundleDir {
+	b, err := charm.ReadBundleDir(r.BundleDirPath(name))
+	check(err)
+	return b
+}
+
+// CharmDirPath returns the path to a charm directory with the given name in the
+// default series
+func (r *CharmRepo) CharmDirPath(name string) string {
+	return filepath.Join(r.Path(), r.defaultSeries, name)
+}
+
+// CharmDir returns the actual charm.CharmDir named name.
+func (r *CharmRepo) CharmDir(name string) *charm.CharmDir {
+	ch, err := charm.ReadCharmDir(r.CharmDirPath(name))
+	check(err)
+	return ch
+}
+
+// ClonedDirPath returns the path to a new copy of the default charm directory
+// named name.
+func (r *CharmRepo) ClonedDirPath(dst, name string) string {
+	return clone(dst, r.CharmDirPath(name))
+}
+
+// ClonedDirPath returns the path to a new copy of the default bundle directory
+// named name.
+func (r *CharmRepo) ClonedBundleDirPath(dst, name string) string {
+	return clone(dst, r.BundleDirPath(name))
+}
+
+// RenamedClonedDirPath returns the path to a new copy of the default
+// charm directory named name, renamed to newName.
+func (r *CharmRepo) RenamedClonedDirPath(dst, name, newName string) string {
+	dstPath := filepath.Join(dst, newName)
+	err := fs.Copy(r.CharmDirPath(name), dstPath)
+	check(err)
+	return dstPath
+}
+
+// ClonedDir returns an actual charm.CharmDir based on a new copy of the charm directory
+// named name, in the directory dst.
+func (r *CharmRepo) ClonedDir(dst, name string) *charm.CharmDir {
+	ch, err := charm.ReadCharmDir(r.ClonedDirPath(dst, name))
+	check(err)
+	return ch
+}
+
+// ClonedURL makes a copy of the charm directory. It will create a directory
+// with the series name if it does not exist, and then clone the charm named
+// name into that directory. The return value is a URL pointing at the local
+// charm.
+func (r *CharmRepo) ClonedURL(dst, series, name string) *charm.URL {
+	dst = filepath.Join(dst, series)
+	if err := os.MkdirAll(dst, os.FileMode(0777)); err != nil {
+		panic(fmt.Errorf("cannot make destination directory: %v", err))
+	}
+	clone(dst, r.CharmDirPath(name))
+	return &charm.URL{
+		Schema:   "local",
+		Name:     name,
+		Revision: -1,
+		Series:   series,
+	}
+}
+
+// CharmArchivePath returns the path to a new charm archive file
+// in the directory dst, created from the charm directory named name.
+func (r *CharmRepo) CharmArchivePath(dst, name string) string {
+	dir := r.CharmDir(name)
+	path := filepath.Join(dst, "archive.charm")
+	file, err := os.Create(path)
+	check(err)
+	defer func() { _ = file.Close() }()
+	check(dir.ArchiveTo(file))
+	return path
+}
+
+// BundleArchivePath returns the path to a new bundle archive file
+// in the directory dst, created from the bundle directory named name.
+func (r *CharmRepo) BundleArchivePath(dst, name string) string {
+	dir := r.BundleDir(name)
+	path := filepath.Join(dst, "archive.bundle")
+	file, err := os.Create(path)
+	check(err)
+	defer func() { _ = file.Close() }()
+	check(dir.ArchiveTo(file))
+	return path
+}
+
+// CharmArchive returns an actual charm.CharmArchive created from a new
+// charm archive file created from the charm directory named name, in
+// the directory dst.
+func (r *CharmRepo) CharmArchive(dst, name string) *charm.CharmArchive {
+	ch, err := charm.ReadCharmArchive(r.CharmArchivePath(dst, name))
+	check(err)
+	return ch
+}
+
+// BundleArchive returns an actual charm.BundleArchive created from a new
+// bundle archive file created from the bundle directory named name, in
+// the directory dst.
+func (r *CharmRepo) BundleArchive(dst, name string) *charm.BundleArchive {
+	b, err := charm.ReadBundleArchive(r.BundleArchivePath(dst, name))
+	check(err)
+	return b
+}

--- a/testcharms/repo.go
+++ b/testcharms/repo.go
@@ -5,7 +5,7 @@ package testcharms
 
 // File moved from github.com/juju/charmrepo/v7/testing/charm.go
 // Attempting to remove use of the charmrepo package from juju
-//with the removal of charmstore support.
+// with the removal of charmstore support.
 
 import (
 	"fmt"

--- a/testcharms/repo/repo.go
+++ b/testcharms/repo/repo.go
@@ -1,7 +1,7 @@
 // Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package testcharms
+package repo
 
 // File moved from github.com/juju/charmrepo/v7/testing/charm.go
 // Attempting to remove use of the charmrepo package from juju


### PR DESCRIPTION
To use the charm v10 package in juju, we either have to update charm repo to a new version using charm v10, or stop using charmrepo.  The charm package is being updated to remove charmstore support for charm URLs.

Part of reducing dependence is easy, csclient params is used for the old style channels which are risk only for charmstore, being removed anyways.

We can also pull into juju the minimal testing repo functionality for use in our tests.

Much of what is left will be removed when charmstore support is removed from the juju client shortly.


## QA steps

All unit tests are successful.

