### PR TITLE
[JUJU-2419] Expect kvm-provisioner worker to run in machine manifolds

### DIFF
--- a/cmd/jujud/agent/agenttest/engine.go
+++ b/cmd/jujud/agent/agenttest/engine.go
@@ -39,14 +39,6 @@ type WorkerMatcher struct {
 	id        string
 	expect    set.Strings
 	matchTime time.Time
-	optional  set.Strings
-}
-
-// AddOptionalWorkers adds workers which may or maynot start.
-// Use sparingly. Intended when these unit tests have different
-// results based on hardware.
-func (m *WorkerMatcher) AddOptionalWorkers(optional []string) {
-	m.optional = set.NewStrings(optional...)
 }
 
 // Check returns true if the workers which are expected to be running
@@ -73,7 +65,7 @@ func (m *WorkerMatcher) checkOnce() bool {
 	m.c.Logf("\n%s: has workers %v", m.id, actual.SortedValues())
 	extras := actual.Difference(m.expect)
 	missed := m.expect.Difference(actual)
-	if (len(extras) == 0 || extras.Difference(m.optional).IsEmpty()) && len(missed) == 0 {
+	if len(extras) == 0 && len(missed) == 0 {
 		return true
 	}
 	m.c.Logf("%s: waiting for %v", m.id, missed.SortedValues())

--- a/cmd/jujud/agent/engine_test.go
+++ b/cmd/jujud/agent/engine_test.go
@@ -125,6 +125,7 @@ var (
 		"log-sender",
 		"logging-config-updater",
 		"lxd-container-provisioner",
+		"kvm-container-provisioner",
 		"machine-action-runner",
 		//"machine-setup", exits when done
 		"machiner",

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -991,7 +991,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 		// The machineSetupName manifold runs small tasks required
 		// to setup a machine, but requires the machine agent's API
-		// connection. Once its work is comlete, it stops.
+		// connection. Once its work is complete, it stops.
 		machineSetupName: ifNotMigrating(MachineStartupManifold(MachineStartupConfig{
 			APICallerName:  apiCallerName,
 			MachineStartup: config.MachineStartup,

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -55,6 +55,7 @@ import (
 	agenterrors "github.com/juju/juju/cmd/jujud/agent/errors"
 	"github.com/juju/juju/cmd/jujud/agent/mocks"
 	"github.com/juju/juju/cmd/jujud/agent/model"
+	"github.com/juju/juju/container/kvm"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/instance"
@@ -1166,10 +1167,11 @@ func (s *MachineSuite) TestMachineWorkers(c *gc.C) {
 	// Wait for it to stabilise, running as normal.
 	matcher := agenttest.NewWorkerMatcher(c, tracker, a.Tag().String(),
 		append(alwaysMachineWorkers, notMigratingMachineWorkers...))
-	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait)
-	// kvm-container-provisioner only runs where the hardware the
-	// test is run on supports kvm. This is not optimal.
-	matcher.AddOptionalWorkers([]string{"kvm-container-provisioner"})
+
+	// Indicate that this machine supports KVM containers rather than doing
+	// detection that may return true/false based on the machine running tests.
+	s.PatchValue(&kvm.IsKVMSupported, func() (bool, error) { return true, nil })
+
 	agenttest.WaitMatch(c, matcher.Check, coretesting.LongWait)
 }
 


### PR DESCRIPTION
The kvm-provisioner worker is expected to run in all machine manifolds, but uninstalls itself if KVM support is not detected.

#14834 Softened the check for the worker by adding optional workers to the engine test logic.

#14862 was merged incorrectly resulting in an extra worker assertion before including the kvm-provisioner was added as an optional worker. This causes tests to fail depending on where they are run.

Here we remove the duplicate assertion along with the optional worker logic. Instead we just patch `IsKVMSupported` to return true and use a hard expectation that the working is running.

## QA steps

`go test -v ./cmd/jujud/agent/ -check.v -check.f=MachineSuite.TestMachineWorkers`

## Documentation changes

None.

## Bug reference

N/A
