### PR TITLE
Drop unused api client form destroy-controller

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -139,14 +139,6 @@ type destroyControllerAPI interface {
 	ControllerConfig() (controller.Config, error)
 }
 
-// destroyClientAPI defines the methods on the client API endpoint that the
-// destroy command might call.
-type destroyClientAPI interface {
-	Close() error
-	ModelGet() (map[string]interface{}, error)
-	DestroyModel() error
-}
-
 // Info implements Command.Info.
 func (c *destroyCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
@@ -494,9 +486,8 @@ type destroyCommandBase struct {
 
 	// The following fields are for mocking out
 	// api behavior for testing.
-	api       destroyControllerAPI
-	apierr    error
-	clientapi destroyClientAPI
+	api    destroyControllerAPI
+	apierr error
 
 	controllerCredentialAPIFunc newCredentialAPIFunc
 

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -97,7 +97,6 @@ func NewEnableDestroyControllerCommandForTest(api removeBlocksAPI, store jujucli
 // client endpoints mocked out.
 func NewDestroyCommandForTest(
 	api destroyControllerAPI,
-	clientapi destroyClientAPI,
 	store jujuclient.ClientStore,
 	apierr error,
 	controllerCredentialAPIFunc newCredentialAPIFunc,
@@ -107,7 +106,6 @@ func NewDestroyCommandForTest(
 	cmd := &destroyCommand{
 		destroyCommandBase: destroyCommandBase{
 			api:                         api,
-			clientapi:                   clientapi,
 			apierr:                      apierr,
 			controllerCredentialAPIFunc: controllerCredentialAPIFunc,
 			environsDestroy:             environsDestroy,
@@ -125,7 +123,6 @@ func NewDestroyCommandForTest(
 // endpoints mocked out.
 func NewKillCommandForTest(
 	api destroyControllerAPI,
-	clientapi destroyClientAPI,
 	store jujuclient.ClientStore,
 	apierr error,
 	clock clock.Clock,
@@ -136,7 +133,6 @@ func NewKillCommandForTest(
 	kill := &killCommand{
 		destroyCommandBase: destroyCommandBase{
 			api:                         api,
-			clientapi:                   clientapi,
 			apierr:                      apierr,
 			controllerCredentialAPIFunc: controllerCredentialAPIFunc,
 			environsDestroy:             environsDestroy,

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -51,7 +51,7 @@ func (s *KillSuite) newKillCommand() cmd.Command {
 		clock = testclock.NewClock(time.Now())
 	}
 	return controller.NewKillCommandForTest(
-		s.api, s.clientapi, s.store, s.apierror, clock, nil,
+		s.api, s.store, s.apierror, clock, nil,
 		func() (controller.CredentialAPI, error) { return s.controllerCredentialAPI, nil },
 		environs.Destroy,
 	)
@@ -381,7 +381,6 @@ func (s *KillSuite) TestKillWithAPIConnection(c *gc.C) {
 		DestroyModels:  true,
 		DestroyStorage: &destroyStorage,
 	})
-	c.Assert(s.clientapi.destroycalled, jc.IsFalse)
 	checkControllerRemovedFromStore(c, "test1", s.store)
 }
 
@@ -442,7 +441,7 @@ func (s *KillSuite) TestKillAPIPermErrFails(c *gc.C) {
 	testDialer := func(*api.Info, api.DialOpts) (api.Connection, error) {
 		return nil, apiservererrors.ErrPerm
 	}
-	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock.WallClock, testDialer,
+	cmd := controller.NewKillCommandForTest(nil, s.store, nil, clock.WallClock, testDialer,
 		func() (controller.CredentialAPI, error) { return s.controllerCredentialAPI, nil },
 		environs.Destroy,
 	)
@@ -461,7 +460,7 @@ func (s *KillSuite) TestKillEarlyAPIConnectionTimeout(c *gc.C) {
 		return nil, errors.New("kill command waited too long")
 	}
 
-	cmd := controller.NewKillCommandForTest(nil, nil, s.store, nil, clock, testDialer,
+	cmd := controller.NewKillCommandForTest(nil, s.store, nil, clock, testDialer,
 		func() (controller.CredentialAPI, error) { return s.controllerCredentialAPI, nil },
 		environs.Destroy,
 	)


### PR DESCRIPTION
Drop unused api client form destroy-controller

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

Compiling and passing unit tests should be enough