### PR TITLE
[JUJU-2229] No charmstore support in bundle code on the client

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/juju/charm/v9"
 	charmresource "github.com/juju/charm/v9/resource"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
 	"github.com/juju/collections/set"
@@ -2486,11 +2485,6 @@ func (f *fakeDeployAPI) Consume(arg crossmodel.ConsumeApplicationArgs) (string, 
 func (f *fakeDeployAPI) GrantOffer(user, access string, offerURLs ...string) error {
 	res := f.MethodCall(f, "GrantOffer", user, access, offerURLs)
 	return jujutesting.TypeAssertError(res[0])
-}
-
-func (f *fakeDeployAPI) ResolveWithPreferredChannel(url *charm.URL, risk csparams.Channel) (*charm.URL, csparams.Channel, []string, error) {
-	results := f.MethodCall(f, "ResolveWithPreferredChannel", url)
-	return results[0].(*charm.URL), results[1].(csparams.Channel), results[2].([]string), results[3].(error)
 }
 
 func stringToInterface(args []string) []interface{} {

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -2261,7 +2261,6 @@ type fakeDeployAPI struct {
 	deployer.DeployerAPI
 	*jujutesting.CallMocker
 	deployerFactoryFunc func(dep deployer.DeployerDependencies) deployer.DeployerFactory
-	charmRepoFunc       func() (*store.CharmStoreAdaptor, error)
 	modelCons           constraints.Value
 }
 
@@ -2494,18 +2493,6 @@ func (f *fakeDeployAPI) ResolveWithPreferredChannel(url *charm.URL, risk csparam
 	return results[0].(*charm.URL), results[1].(csparams.Channel), results[2].([]string), results[3].(error)
 }
 
-type fakeCharmStoreAPI struct {
-	*fakeDeployAPI
-}
-
-func (f *fakeCharmStoreAPI) GetBundle(url *charm.URL, _ string) (charm.Bundle, error) {
-	results := f.MethodCall(f, "GetBundle", url)
-	if results == nil {
-		return nil, errors.NotFoundf("bundle %v", url)
-	}
-	return results[0].(charm.Bundle), jujutesting.TypeAssertError(results[1])
-}
-
 func stringToInterface(args []string) []interface{} {
 	interfaceArgs := make([]interface{}, len(args))
 	for i, a := range args {
@@ -2517,9 +2504,6 @@ func stringToInterface(args []string) []interface{} {
 func vanillaFakeModelAPI(cfgAttrs map[string]interface{}) *fakeDeployAPI {
 	var logger loggo.Logger
 	fakeAPI := &fakeDeployAPI{CallMocker: jujutesting.NewCallMocker(logger)}
-	fakeAPI.charmRepoFunc = func() (*store.CharmStoreAdaptor, error) {
-		return &store.CharmStoreAdaptor{}, nil
-	}
 
 	fakeAPI.Call("Close").Returns(error(nil))
 	fakeAPI.Call("ModelGet").Returns(cfgAttrs, error(nil))

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -273,7 +273,7 @@ type repositoryBundle struct {
 // String returns a string description of the deployer.
 func (d *repositoryBundle) String() string {
 	str := fmt.Sprintf("deploy bundle: %s", d.bundleURL.String())
-	if isEmptyOrigin(d.origin, commoncharm.OriginCharmStore) {
+	if isEmptyOrigin(d.origin, commoncharm.OriginCharmHub) {
 		return str
 	}
 	var revision string

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -165,6 +165,8 @@ type bundleHandler struct {
 	// data is the original bundle data that we want to deploy.
 	data *charm.BundleData
 
+	bundleURL *charm.URL
+
 	// unitStatus reflects the environment status and maps unit names to their
 	// corresponding machine identifiers. This is kept updated by both change
 	// handlers (addCharm, addApplication etc.) and by updateUnitStatus.
@@ -457,7 +459,9 @@ func (h *bundleHandler) constructChannelAndOrigin(curl *charm.URL, charmBase ser
 
 func (h *bundleHandler) getChanges() error {
 	bundleURL := ""
-
+	if h.bundleURL != nil {
+		bundleURL = h.bundleURL.String()
+	}
 	// TODO(stickupkid): The following should use the new
 	// Bundle.getChangesMapArgs, with the fallback to Bundle.getChanges and
 	// with controllers without a Bundle facade should use the bundlechanges

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -135,13 +135,13 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSuccess(c *gc.C) {
 	s.assertDeployArgsConfig(c, "mysql", map[string]interface{}{"foo": "bar"})
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Located charm \"mysql\" in charm-hub\n"+
-		"Located charm \"wordpress\" in charm-hub\n"+
+		"Located charm \"mysql\" in charm-hub, channel stable\n"+
+		"Located charm \"wordpress\" in charm-hub, channel stable\n"+
 		"Executing changes:\n"+
-		"- upload charm mysql from charm-hub for series xenial with architecture=amd64\n"+
-		"- deploy application mysql from charm-hub on xenial\n"+
-		"- upload charm wordpress from charm-hub for series xenial with architecture=amd64\n"+
-		"- deploy application wordpress from charm-hub on xenial\n"+
+		"- upload charm mysql from charm-hub for series xenial with revision 42 with architecture=amd64\n"+
+		"- deploy application mysql from charm-hub on xenial with stable\n"+
+		"- upload charm wordpress from charm-hub for series xenial with revision 47 with architecture=amd64\n"+
+		"- deploy application wordpress from charm-hub on xenial with stable\n"+
 		"- add new machine 0\n"+
 		"- add new machine 1\n"+
 		"- add relation wordpress:db - mysql:db\n"+
@@ -155,6 +155,8 @@ series: bionic
 applications:
   mysql:
     charm: ch:mysql
+    revision: 42
+    channel: stable
     series: xenial
     num_units: 1
     options:
@@ -163,6 +165,8 @@ applications:
     - "0"
   wordpress:
     charm: ch:wordpress
+    revision: 47
+    channel: stable
     series: xenial
     num_units: 1
     to:
@@ -536,13 +540,13 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleStorage(c *gc.C) {
 	s.assertDeployArgsStorage(c, "mysql", map[string]storage.Constraints{"database": {Pool: "mysql-pv", Size: 0x14, Count: 0x1}})
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Located charm \"mysql\" in charm-hub\n"+
-		"Located charm \"wordpress\" in charm-hub\n"+
+		"Located charm \"mysql\" in charm-hub, channel stable\n"+
+		"Located charm \"wordpress\" in charm-hub, channel stable\n"+
 		"Executing changes:\n"+
-		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n"+
-		"- deploy application mysql from charm-hub on bionic\n"+
-		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n"+
-		"- deploy application wordpress from charm-hub on bionic\n"+
+		"- upload charm mysql from charm-hub for series bionic with revision 42 with architecture=amd64\n"+
+		"- deploy application mysql from charm-hub on bionic with stable\n"+
+		"- upload charm wordpress from charm-hub for series bionic with revision 47 with architecture=amd64\n"+
+		"- deploy application wordpress from charm-hub on bionic with stable\n"+
 		"- add new machine 0\n"+
 		"- add new machine 1\n"+
 		"- add relation wordpress:db - mysql:db\n"+
@@ -556,6 +560,8 @@ series: bionic
 applications:
   mysql:
     charm: ch:mysql
+    revision: 42
+    channel: stable
     num_units: 1
     storage:
       database: mysql-pv,20M
@@ -563,6 +569,8 @@ applications:
     - "0"
   wordpress:
     charm: ch:wordpress
+    revision: 47
+    channel: stable
     num_units: 1
     to:
     - "1"
@@ -782,13 +790,13 @@ func (s *BundleDeployRepositorySuite) testExistingModel(c *gc.C, dryRun bool) {
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "ubuntu", "18.04")
 
 	expectedOutput := "" +
-		"Located charm \"mysql\" in charm-hub\n" +
-		"Located charm \"wordpress\" in charm-hub\n" +
+		"Located charm \"mysql\" in charm-hub, channel stable\n" +
+		"Located charm \"wordpress\" in charm-hub, channel stable\n" +
 		"Executing changes:\n" +
-		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n" +
-		"- deploy application mysql from charm-hub on bionic\n" +
-		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n" +
-		"- deploy application wordpress from charm-hub on bionic\n" +
+		"- upload charm mysql from charm-hub for series bionic with revision 42 with architecture=amd64\n" +
+		"- deploy application mysql from charm-hub on bionic with stable\n" +
+		"- upload charm wordpress from charm-hub for series bionic with revision 47 with architecture=amd64\n" +
+		"- deploy application wordpress from charm-hub on bionic with stable\n" +
 		"- add new machine 0\n" +
 		"- add new machine 1\n" +
 		"- add relation wordpress:db - mysql:db\n" +
@@ -797,23 +805,23 @@ func (s *BundleDeployRepositorySuite) testExistingModel(c *gc.C, dryRun bool) {
 		"Deploy of bundle completed.\n"
 
 	changeOutput := "" +
-		"Located charm \"mysql\" in charm-hub\n" +
-		"Located charm \"wordpress\" in charm-hub\n" +
+		"Located charm \"mysql\" in charm-hub, channel stable\n" +
+		"Located charm \"wordpress\" in charm-hub, channel stable\n" +
 		"Executing changes:\n" +
-		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n" +
-		"- upgrade mysql from charm-hub using charm mysql for series bionic\n" +
-		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n" +
-		"- upgrade wordpress from charm-hub using charm wordpress for series bionic\n" +
+		"- upload charm mysql from charm-hub for series bionic with revision 42 with architecture=amd64\n" +
+		"- upgrade mysql from charm-hub using charm mysql for series bionic from channel stable\n" +
+		"- upload charm wordpress from charm-hub for series bionic with revision 47 with architecture=amd64\n" +
+		"- upgrade wordpress from charm-hub using charm wordpress for series bionic from channel stable\n" +
 		"Deploy of bundle completed.\n"
 
 	dryRunOutput := "" +
-		"Located charm \"mysql\" in charm-hub\n" +
-		"Located charm \"wordpress\" in charm-hub\n" +
+		"Located charm \"mysql\" in charm-hub, channel stable\n" +
+		"Located charm \"wordpress\" in charm-hub, channel stable\n" +
 		"Changes to deploy bundle:\n" +
-		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n" +
-		"- upgrade mysql from charm-hub using charm mysql for series bionic\n" +
-		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n" +
-		"- upgrade wordpress from charm-hub using charm wordpress for series bionic\n"
+		"- upload charm mysql from charm-hub for series bionic with revision 42 with architecture=amd64\n" +
+		"- upgrade mysql from charm-hub using charm mysql for series bionic from channel stable\n" +
+		"- upload charm wordpress from charm-hub for series bionic with revision 47 with architecture=amd64\n" +
+		"- upgrade wordpress from charm-hub using charm wordpress for series bionic from channel stable\n"
 	c.Check(s.output.String(), gc.Equals, expectedOutput)
 
 	// Setup to run with --dry-run, no changes
@@ -942,6 +950,8 @@ series: bionic
 applications:
   wordpress:
     charm: ch:wordpress
+    revision: 52
+    channel: stable
     num_units: 1
     options:
       blog-title: new title
@@ -950,6 +960,8 @@ applications:
     - "1"
   mysql:
     charm: ch:mysql
+    revision: 42
+    channel: stable
     num_units: 1
     storage:
       database: mysql-pv,20M
@@ -1000,13 +1012,13 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleApplicationUpgrade(c *gc.C
 	s.runDeploy(c, wordpressBundleWithStorageUpgradeConstraints)
 
 	c.Assert(s.output.String(), gc.Equals, ""+
-		"Located charm \"mysql\" in charm-hub\n"+
-		"Located charm \"wordpress\" in charm-hub\n"+
+		"Located charm \"mysql\" in charm-hub, channel stable\n"+
+		"Located charm \"wordpress\" in charm-hub, channel stable\n"+
 		"Executing changes:\n"+
-		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n"+
-		"- upgrade mysql from charm-hub using charm mysql for series bionic\n"+
-		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n"+
-		"- upgrade wordpress from charm-hub using charm wordpress for series bionic\n"+
+		"- upload charm mysql from charm-hub for series bionic with revision 42 with architecture=amd64\n"+
+		"- upgrade mysql from charm-hub using charm mysql for series bionic from channel stable\n"+
+		"- upload charm wordpress from charm-hub for series bionic with revision 52 with architecture=amd64\n"+
+		"- upgrade wordpress from charm-hub using charm wordpress for series bionic from channel stable\n"+
 		"- set application options for wordpress\n"+
 		"- set constraints for wordpress to \"spaces=new cores=8\"\n"+
 		"Deploy of bundle completed.\n",
@@ -1369,11 +1381,15 @@ const unitColocationWithUnitBundle = `
        applications:
            mem:
                charm: ch:mem
+               revision: 47
+               channel: stable
                series: xenial
                num_units: 3
                to: [1, new]
            django:
                charm: ch:django
+               revision: 42
+               channel: stable
                series: xenial
                num_units: 5
                to:

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -154,7 +154,7 @@ const wordpressBundle = `
 series: bionic
 applications:
   mysql:
-    charm: cs:mysql-42
+    charm: ch:mysql
     series: xenial
     num_units: 1
     options:
@@ -162,7 +162,7 @@ applications:
     to:
     - "0"
   wordpress:
-    charm: cs:wordpress-47
+    charm: ch:wordpress
     series: xenial
     num_units: 1
     to:
@@ -176,83 +176,6 @@ relations:
 - - wordpress:db
   - mysql:db
 `
-
-func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeries(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-	s.expectEmptyModelToStart(c)
-	s.expectWatchAll()
-	s.expectResolveCharm(nil)
-
-	mysqlCurl := charm.MustParseURL("cs:mysql-42")
-	charmInfo := &apicharms.CharmInfo{
-		Revision: mysqlCurl.Revision,
-		URL:      mysqlCurl.String(),
-		Meta: &charm.Meta{
-			Series: []string{"jammy"},
-		},
-	}
-	s.expectAddCharm(false)
-	s.expectCharmInfo(mysqlCurl.String(), charmInfo)
-
-	// For wordpress
-	s.expectResolveCharm(nil)
-
-	bundleData, err := charm.ReadBundleData(strings.NewReader(wordpressBundleInvalidSeries))
-	c.Assert(err, jc.ErrorIsNil)
-	err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpec())
-
-	c.Assert(err, gc.ErrorMatches, `series "focal" is not supported, supported series are: jammy`)
-}
-
-func (s *BundleDeployRepositorySuite) TestDeployBundleWithInvalidSeriesWithForce(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-	s.expectEmptyModelToStart(c)
-	s.expectWatchAll()
-
-	mysqlCurl := charm.MustParseURL("cs:mysql-42")
-	wordpressCurl := charm.MustParseURL("cs:wordpress-47")
-	chUnits := []charmUnit{
-		{
-			charmMetaSeries:      []string{"jammy"},
-			curl:                 mysqlCurl,
-			force:                true,
-			machine:              "0",
-			machineUbuntuVersion: "20.04",
-		},
-		{
-			charmMetaSeries:      []string{"focal", "jammy"},
-			curl:                 wordpressCurl,
-			force:                true,
-			machine:              "1",
-			machineUbuntuVersion: "18.04",
-		},
-	}
-	s.setupCharmUnits(chUnits)
-
-	s.expectAddRelation([]string{"wordpress:db", "mysql:db"})
-
-	spec := s.bundleDeploySpec()
-	spec.force = true
-	s.runDeployWithSpec(c, wordpressBundleInvalidSeries, spec)
-
-	c.Assert(s.deployArgs, gc.HasLen, 2)
-	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "18.04")
-	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "ubuntu", "20.04")
-	c.Check(s.output.String(), gc.Equals, ""+
-		"Located charm \"mysql\" in charm-hub, revision 42\n"+
-		"Located charm \"wordpress\" in charm-hub, revision 47\n"+
-		"Executing changes:\n"+
-		"- upload charm mysql from charm-store for series focal with architecture=amd64\n"+
-		"- deploy application mysql from charm-store on focal\n"+
-		"- upload charm wordpress from charm-store for series bionic with architecture=amd64\n"+
-		"- deploy application wordpress from charm-store on bionic\n"+
-		"- add new machine 0\n"+
-		"- add new machine 1\n"+
-		"- add relation wordpress:db - mysql:db\n"+
-		"- add unit mysql/0 to new machine 0\n"+
-		"- add unit wordpress/0 to new machine 1\n"+
-		"Deploy of bundle completed.\n")
-}
 
 const multiApplicationBundle = `
 name: istio
@@ -291,65 +214,13 @@ func (s *BundleDeployRepositorySuite) TestDeployAddCharmHasSeries(c *gc.C) {
 	s.assertDeployArgs(c, fullPilotURL.String(), "istio-pilot", "ubuntu", "20.04")
 }
 
-func (s *BundleDeployRepositorySuite) setupCharmUnitsNew(charmUnits []charmUnit) {
-	for _, chUnit := range charmUnits {
-		switch chUnit.curl.Schema {
-		case "cs", "ch":
-			resolveSeries := chUnit.resolveSeries
-			if len(resolveSeries) == 0 {
-				resolveSeries = []string{"bionic", "focal", "xenial"}
-			}
-			s.expectResolveCharmWithSeries(resolveSeries, nil)
-			s.expectAddCharm(chUnit.force)
-		case "local":
-			s.expectAddLocalCharm(chUnit.curl, chUnit.force)
-		}
-		charmInfo := &apicharms.CharmInfo{
-			Revision: chUnit.curl.Revision,
-			URL:      chUnit.curl.String(),
-			Meta: &charm.Meta{
-				Series: chUnit.charmMetaSeries,
-			},
-		}
-		s.expectCharmInfo(chUnit.curl.String(), charmInfo)
-		s.expectDeploy()
-		if chUnit.machineUbuntuVersion != "kubernetes" {
-			s.expectAddMachine(chUnit.machine, chUnit.machineUbuntuVersion)
-			s.expectAddOneUnit(chUnit.curl.Name, chUnit.machine, "0")
-		}
-	}
-}
-
-const wordpressBundleInvalidSeries = `
-series: bionic
-applications:
-  mysql:
-    charm: cs:mysql-42
-    series: focal
-    num_units: 1
-    to:
-    - "0"
-  wordpress:
-    charm: cs:wordpress-47
-    num_units: 1
-    to:
-    - "1"
-machines:
-  "0":
-    series: focal
-  "1": {}
-relations:
-- - wordpress:db
-  - mysql:db
-`
-
 func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mariadbCurl := charm.MustParseURL("cs:~juju/mariadb-k8s")
-	gitlabCurl := charm.MustParseURL("cs:~juju/gitlab-k8s")
+	mariadbCurl := charm.MustParseURL("ch:bionic/mariadb-k8s")
+	gitlabCurl := charm.MustParseURL("ch:bionic/gitlab-k8s")
 	chUnits := []charmUnit{
 		{
 			curl:                 mariadbCurl,
@@ -368,8 +239,8 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	s.runDeploy(c, kubernetesGitlabBundle)
 
 	c.Assert(s.deployArgs, gc.HasLen, 2)
-	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "ubuntu", "20.04")
-	s.assertDeployArgs(c, mariadbCurl.String(), "mariadb", "ubuntu", "20.04")
+	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "ubuntu", "18.04")
+	s.assertDeployArgs(c, mariadbCurl.String(), "mariadb", "ubuntu", "18.04")
 	s.assertDeployArgsStorage(c, "mariadb", map[string]storage.Constraints{"database": {Pool: "mariadb-pv", Size: 0x14, Count: 0x1}})
 	s.assertDeployArgsConfig(c, "mariadb", map[string]interface{}{"dataset-size": "70%"})
 
@@ -377,10 +248,10 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 		"Located charm \"gitlab-k8s\" in charm-hub\n"+
 		"Located charm \"mariadb-k8s\" in charm-hub\n"+
 		"Executing changes:\n"+
-		"- upload charm gitlab-k8s from charm-store with architecture=amd64\n"+
-		"- deploy application gitlab from charm-store with 1 unit using gitlab-k8s\n"+
-		"- upload charm mariadb-k8s from charm-store with architecture=amd64\n"+
-		"- deploy application mariadb from charm-store with 2 units using mariadb-k8s\n"+
+		"- upload charm gitlab-k8s from charm-hub with architecture=amd64\n"+
+		"- deploy application gitlab from charm-hub with 1 unit using gitlab-k8s\n"+
+		"- upload charm mariadb-k8s from charm-hub with architecture=amd64\n"+
+		"- deploy application mariadb from charm-hub with 2 units using mariadb-k8s\n"+
 		"- add relation gitlab:mysql - mariadb:server\n"+
 		"Deploy of bundle completed.\n")
 }
@@ -389,7 +260,7 @@ const kubernetesGitlabBundle = `
 bundle: kubernetes
 applications:
   mariadb:
-    charm: cs:~juju/mariadb-k8s
+    charm: ch:mariadb-k8s
     scale: 2
     constraints: mem=1G
     options:
@@ -397,7 +268,7 @@ applications:
     storage:
       database: mariadb-pv,20M
   gitlab:
-    charm: cs:~juju/gitlab-k8s
+    charm: ch:gitlab-k8s
     placement: foo=bar
     scale: 1
 relations:
@@ -708,9 +579,11 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleDevices(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	bitcoinCurl := s.expectCharmhubK8sCharm(charm.MustParseURL("ch:bitcoin-miner"), 3)
-	dashboardCurl := s.expectCharmhubK8sCharm(charm.MustParseURL("ch:dashboard4miner"), 43)
+	bitcoinCurl := s.expectCharmhubK8sCharm(charm.MustParseURL("ch:bitcoin-miner"))
+	dashboardCurl := s.expectCharmhubK8sCharm(charm.MustParseURL("ch:dashboard4miner"))
 	s.expectAddRelation([]string{"dashboard4miner:miner", "bitcoin-miner:miner"})
+	s.expectAddOneUnit("bitcoin-miner", "", "1")
+	s.expectAddOneUnit("dashboard4miner", "", "1")
 
 	spec := s.bundleDeploySpec()
 	devConstraints := map[string]devices.Constraints{
@@ -724,24 +597,26 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleDevices(c *gc.C) {
 	s.runDeployWithSpec(c, kubernetesBitcoinBundle, spec)
 
 	c.Assert(s.deployArgs, gc.HasLen, 2)
-	s.assertDeployArgs(c, dashboardCurl.String(), dashboardCurl.Name, "ubuntu", "20.04")
-	s.assertDeployArgs(c, bitcoinCurl.String(), bitcoinCurl.Name, "ubuntu", "20.04")
+	s.assertDeployArgs(c, dashboardCurl.String(), dashboardCurl.Name, "kubernetes", "kubernetes")
+	s.assertDeployArgs(c, bitcoinCurl.String(), bitcoinCurl.Name, "kubernetes", "kubernetes")
 	s.assertDeployArgsDevices(c, bitcoinCurl.Name, devConstraints)
 
 	c.Check(s.output.String(), gc.Equals, ""+
 		"Located charm \"bitcoin-miner\" in charm-hub\n"+
 		"Located charm \"dashboard4miner\" in charm-hub\n"+
 		"Executing changes:\n"+
-		"- upload charm bitcoin-miner from charm-store with architecture=amd64\n"+
-		"- deploy application bitcoin-miner from charm-store with 1 unit\n"+
-		"- upload charm dashboard4miner from charm-store with architecture=amd64\n"+
-		"- deploy application dashboard4miner from charm-store with 1 unit\n"+
+		"- upload charm bitcoin-miner from charm-hub with architecture=amd64\n"+
+		"- deploy application bitcoin-miner from charm-hub\n"+
+		"- upload charm dashboard4miner from charm-hub with architecture=amd64\n"+
+		"- deploy application dashboard4miner from charm-hub\n"+
 		"- add relation dashboard4miner:miner - bitcoin-miner:miner\n"+
+		"- add unit bitcoin-miner/0 to new machine 0\n"+
+		"- add unit dashboard4miner/0 to new machine 1\n"+
 		"Deploy of bundle completed.\n")
 }
 
-func (s *BundleDeployRepositorySuite) expectCharmhubK8sCharm(curl *charm.URL, rev int) *charm.URL {
-	fullCurl := curl.WithRevision(rev)
+func (s *BundleDeployRepositorySuite) expectCharmhubK8sCharm(curl *charm.URL) *charm.URL {
+	fullCurl := curl.WithSeries("kubernetes")
 	// Called from resolveCharmsAndEndpoints & resolveCharmChannelAndRevision && addCharm
 	s.bundleResolver.EXPECT().ResolveCharm(
 		curl,
@@ -752,18 +627,7 @@ func (s *BundleDeployRepositorySuite) expectCharmhubK8sCharm(curl *charm.URL, re
 		func(curl *charm.URL, origin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error) {
 			origin.Type = "charm"
 			return fullCurl, origin, []string{"kubernetes"}, nil
-		}).Times(1)
-
-	s.bundleResolver.EXPECT().ResolveCharm(
-		fullCurl,
-		gomock.AssignableToTypeOf(commoncharm.Origin{}),
-		false,
-	).DoAndReturn(
-		// Ensure the same curl that is provided, is returned.
-		func(curl *charm.URL, origin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []string, error) {
-			origin.Type = "charm"
-			return curl, origin, []string{"kubernetes"}, nil
-		}).Times(1)
+		}).Times(3)
 
 	s.deployerAPI.EXPECT().AddCharm(
 		fullCurl,
@@ -802,13 +666,12 @@ func (s *BundleDeployRepositorySuite) expectCharmhubK8sCharm(curl *charm.URL, re
 }
 
 const kubernetesBitcoinBundle = `
-bundle: kubernetes
 applications:
     dashboard4miner:
-        charm: cs:dashboard4miner
+        charm: ch:dashboard4miner
         num_units: 1
     bitcoin-miner:
-        charm: cs:bitcoin-miner
+        charm: ch:bitcoin-miner
         num_units: 1
         devices:
             bitcoinminer: 1,nvidia.com/gpu
@@ -821,8 +684,8 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundle(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	bitcoinCurl := charm.MustParseURL("bitcoin-miner")
-	dashboardCurl := charm.MustParseURL("dashboard4miner")
+	bitcoinCurl := charm.MustParseURL("ch:bitcoin-miner")
+	dashboardCurl := charm.MustParseURL("ch:dashboard4miner")
 	chUnits := []charmUnit{
 		{
 			curl:                 bitcoinCurl,
@@ -882,8 +745,8 @@ func (s *BundleDeployRepositorySuite) testExistingModel(c *gc.C, dryRun bool) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mysqlCurl := charm.MustParseURL("cs:mysql-42")
-	wordpressCurl := charm.MustParseURL("cs:wordpress-47")
+	mysqlCurl := charm.MustParseURL("ch:mysql")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	chUnits := []charmUnit{
 		{
 			curl:                 mysqlCurl,
@@ -902,6 +765,15 @@ func (s *BundleDeployRepositorySuite) testExistingModel(c *gc.C, dryRun bool) {
 	s.expectAddRelation([]string{"wordpress:db", "mysql:db"})
 	s.expectResolveCharm(nil)
 
+	if !dryRun {
+		s.expectAddCharm(false)
+		s.expectCharmInfo("ch:mysql", &apicharms.CharmInfo{URL: mysqlCurl.String(), Meta: &charm.Meta{}})
+		s.expectSetCharm(c, "mysql")
+		s.expectAddCharm(false)
+		s.expectCharmInfo("ch:wordpress", &apicharms.CharmInfo{URL: wordpressCurl.String(), Meta: &charm.Meta{}})
+		s.expectSetCharm(c, "wordpress")
+	}
+
 	spec := s.bundleDeploySpec()
 	s.runDeployWithSpec(c, wordpressBundleWithStorage, spec)
 
@@ -910,19 +782,38 @@ func (s *BundleDeployRepositorySuite) testExistingModel(c *gc.C, dryRun bool) {
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "ubuntu", "18.04")
 
 	expectedOutput := "" +
-		"Located charm \"mysql\" in charm-hub, revision 42\n" +
-		"Located charm \"wordpress\" in charm-hub, revision 47\n" +
+		"Located charm \"mysql\" in charm-hub\n" +
+		"Located charm \"wordpress\" in charm-hub\n" +
 		"Executing changes:\n" +
-		"- upload charm mysql from charm-store for series bionic with architecture=amd64\n" +
-		"- deploy application mysql from charm-store on bionic\n" +
-		"- upload charm wordpress from charm-store for series bionic with architecture=amd64\n" +
-		"- deploy application wordpress from charm-store on bionic\n" +
+		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n" +
+		"- deploy application mysql from charm-hub on bionic\n" +
+		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n" +
+		"- deploy application wordpress from charm-hub on bionic\n" +
 		"- add new machine 0\n" +
 		"- add new machine 1\n" +
 		"- add relation wordpress:db - mysql:db\n" +
 		"- add unit mysql/0 to new machine 0\n" +
 		"- add unit wordpress/0 to new machine 1\n" +
 		"Deploy of bundle completed.\n"
+
+	changeOutput := "" +
+		"Located charm \"mysql\" in charm-hub\n" +
+		"Located charm \"wordpress\" in charm-hub\n" +
+		"Executing changes:\n" +
+		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n" +
+		"- upgrade mysql from charm-hub using charm mysql for series bionic\n" +
+		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n" +
+		"- upgrade wordpress from charm-hub using charm wordpress for series bionic\n" +
+		"Deploy of bundle completed.\n"
+
+	dryRunOutput := "" +
+		"Located charm \"mysql\" in charm-hub\n" +
+		"Located charm \"wordpress\" in charm-hub\n" +
+		"Changes to deploy bundle:\n" +
+		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n" +
+		"- upgrade mysql from charm-hub using charm mysql for series bionic\n" +
+		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n" +
+		"- upgrade wordpress from charm-hub using charm wordpress for series bionic\n"
 	c.Check(s.output.String(), gc.Equals, expectedOutput)
 
 	// Setup to run with --dry-run, no changes
@@ -931,18 +822,20 @@ func (s *BundleDeployRepositorySuite) testExistingModel(c *gc.C, dryRun bool) {
 	s.expectDeployerAPIModelGet(c)
 	s.expectWatchAll()
 
-	expectedOutput += "No changes to apply.\n"
+	if dryRun {
+		changeOutput = dryRunOutput
+	}
 	spec.dryRun = dryRun
 	spec.useExistingMachines = true
 	spec.bundleMachines = map[string]string{}
 	s.runDeployWithSpec(c, wordpressBundleWithStorage, spec)
-	c.Check(s.output.String(), gc.Equals, expectedOutput)
+	c.Check(s.output.String(), gc.Equals, expectedOutput+changeOutput)
 }
 
 const charmWithResourcesBundle = `
        applications:
            django:
-               charm: cs:django
+               charm: ch:django
                series: xenial
    `
 
@@ -953,7 +846,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleResources(c *gc.C) {
 
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
-	djangoCurl := charm.MustParseURL("cs:django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	charmInfo := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
 		URL:      djangoCurl.String(),
@@ -993,7 +886,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleResources(c *gc.C) {
 const specifyResourcesBundle = `
        applications:
            django:
-               charm: cs:django
+               charm: ch:django
                series: xenial
                resources:
                    one: 4
@@ -1006,7 +899,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSpecifyResources(c *gc.C) 
 
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
-	djangoCurl := charm.MustParseURL("cs:django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	charmInfo := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
 		URL:      djangoCurl.String(),
@@ -1048,7 +941,7 @@ const wordpressBundleWithStorageUpgradeConstraints = `
 series: bionic
 applications:
   wordpress:
-    charm: cs:wordpress-52
+    charm: ch:wordpress
     num_units: 1
     options:
       blog-title: new title
@@ -1056,7 +949,7 @@ applications:
     to:
     - "1"
   mysql:
-    charm: cs:mysql-42
+    charm: ch:mysql
     num_units: 1
     storage:
       database: mysql-pv,20M
@@ -1077,17 +970,29 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleApplicationUpgrade(c *gc.C
 	s.expectDeployerAPIModelGet(c)
 	s.expectWatchAll()
 	s.expectResolveCharm(nil)
-	wordpressCurl := charm.MustParseURL("cs:wordpress-52")
+	s.expectResolveCharm(nil)
+
+	mysqlCurl := charm.MustParseURL("ch:mysql")
 	s.expectAddCharm(false)
-	s.expectSetCharm(c, "wordpress")
+	s.expectSetCharm(c, "mysql")
 	charmInfo := &apicharms.CharmInfo{
-		Revision: wordpressCurl.Revision,
-		URL:      wordpressCurl.String(),
+		URL: mysqlCurl.String(),
 		Meta: &charm.Meta{
 			Series: []string{"bionic", "xenial"},
 		},
 	}
-	s.expectCharmInfo(wordpressCurl.String(), charmInfo)
+	s.expectCharmInfo(mysqlCurl.String(), charmInfo)
+
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
+	s.expectAddCharm(false)
+	s.expectSetCharm(c, "wordpress")
+	wpCharmInfo := &apicharms.CharmInfo{
+		URL: wordpressCurl.String(),
+		Meta: &charm.Meta{
+			Series: []string{"bionic", "xenial"},
+		},
+	}
+	s.expectCharmInfo(wordpressCurl.String(), wpCharmInfo)
 
 	s.expectSetConfig(c, "wordpress", map[string]interface{}{"blog-title": "new title"})
 	s.expectSetConstraints("wordpress", "spaces=new cores=8")
@@ -1095,10 +1000,13 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleApplicationUpgrade(c *gc.C
 	s.runDeploy(c, wordpressBundleWithStorageUpgradeConstraints)
 
 	c.Assert(s.output.String(), gc.Equals, ""+
-		"Located charm \"wordpress\" in charm-hub, revision 52\n"+
+		"Located charm \"mysql\" in charm-hub\n"+
+		"Located charm \"wordpress\" in charm-hub\n"+
 		"Executing changes:\n"+
-		"- upload charm wordpress from charm-store for series bionic with architecture=amd64\n"+
-		"- upgrade wordpress from charm-store using charm wordpress for series bionic\n"+
+		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n"+
+		"- upgrade mysql from charm-hub using charm mysql for series bionic\n"+
+		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n"+
+		"- upgrade wordpress from charm-hub using charm wordpress for series bionic\n"+
 		"- set application options for wordpress\n"+
 		"- set constraints for wordpress to \"spaces=new cores=8\"\n"+
 		"Deploy of bundle completed.\n",
@@ -1109,19 +1017,19 @@ const wordpressBundleWithStorageUpgradeRelations = `
 series: bionic
 applications:
   mysql:
-    charm: cs:mysql-42
+    charm: ch:mysql
     num_units: 1
     storage:
       database: mysql-pv,20M
     to:
     - "0"
   wordpress:
-    charm: cs:wordpress-47
+    charm: ch:wordpress
     num_units: 1
     to:
     - "1"
   varnish:
-    charm: cs:varnish
+    charm: ch:varnish
     num_units: 1
     to: 
     - "2"
@@ -1141,25 +1049,33 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleNewRelations(c *gc.C) {
 	s.expectDeployerAPIModelGet(c)
 	s.expectWatchAll()
 	s.expectResolveCharm(nil)
-	varnishCurl := charm.MustParseURL("cs:varnish")
-	chUnits := []charmUnit{
-		{
-			charmMetaSeries:      []string{"bionic", "xenial"},
-			curl:                 varnishCurl,
-			machine:              "2",
-			machineUbuntuVersion: "18.04",
-		},
-	}
-	s.setupCharmUnits(chUnits)
+	s.expectAddCharm(false)
+	s.expectAddCharm(false)
+	s.expectAddCharm(false)
+	s.expectCharmInfo("ch:mysql", &apicharms.CharmInfo{Meta: &charm.Meta{}})
+	s.expectCharmInfo("ch:varnish", &apicharms.CharmInfo{Meta: &charm.Meta{}})
+	s.expectCharmInfo("ch:wordpress", &apicharms.CharmInfo{Meta: &charm.Meta{}})
+	s.expectSetCharm(c, "mysql")
+	s.expectSetCharm(c, "wordpress")
+	s.expectDeploy()
+	s.expectAddMachine("0", "18.04")
+	s.expectAddOneUnit("varnish", "0", "0")
+
 	s.expectAddRelation([]string{"varnish:webcache", "wordpress:cache"})
 
 	s.runDeploy(c, wordpressBundleWithStorageUpgradeRelations)
 
 	c.Assert(s.output.String(), gc.Equals, ""+
+		"Located charm \"mysql\" in charm-hub\n"+
 		"Located charm \"varnish\" in charm-hub\n"+
+		"Located charm \"wordpress\" in charm-hub\n"+
 		"Executing changes:\n"+
-		"- upload charm varnish from charm-store for series bionic with architecture=amd64\n"+
-		"- deploy application varnish from charm-store on bionic\n"+
+		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n"+
+		"- upgrade mysql from charm-hub using charm mysql for series bionic\n"+
+		"- upload charm varnish from charm-hub for series bionic with architecture=amd64\n"+
+		"- deploy application varnish from charm-hub on bionic\n"+
+		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n"+
+		"- upgrade wordpress from charm-hub using charm wordpress for series bionic\n"+
 		"- add new machine 2\n"+
 		"- add relation varnish:webcache - wordpress:cache\n"+
 		"- add unit varnish/0 to new machine 2\n"+
@@ -1170,7 +1086,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleNewRelations(c *gc.C) {
 const machineUnitPlacementBundle = `
       applications:
           wordpress:
-              charm: cs:xenial/wordpress
+              charm: ch:xenial/wordpress
               num_units: 2
               to:
                   - 1
@@ -1178,7 +1094,7 @@ const machineUnitPlacementBundle = `
               options:
                   blog-title: these are the voyages
           mysql:
-              charm: cs:xenial/mysql
+              charm: ch:xenial/mysql
               num_units: 2
               to:
                   - lxd:wordpress/0
@@ -1202,7 +1118,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMachinesUnitsPlacement(c *
 	s.expectAddContainer("0", "0/lxd/0", "16.04", "lxd")
 	s.expectAddContainer("1", "1/lxd/0", "16.04", "lxd")
 
-	wordpressCurl := charm.MustParseURL("cs:wordpress")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
 		Revision: wordpressCurl.Revision,
@@ -1217,7 +1133,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMachinesUnitsPlacement(c *
 	s.expectAddOneUnit("wordpress", "0", "0")
 	s.expectAddOneUnit("wordpress", "1/lxd/0", "1")
 
-	mysqlCurl := charm.MustParseURL("cs:mysql")
+	mysqlCurl := charm.MustParseURL("ch:mysql")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
 		Revision: mysqlCurl.Revision,
@@ -1238,7 +1154,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMachinesUnitsPlacement(c *
 const machineAttributesBundle = `
        applications:
            django:
-               charm: cs:django
+               charm: ch:django
                series: xenial
                num_units: 2
                to:
@@ -1259,7 +1175,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMachineAttributes(c *gc.C)
 
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
-	djangoCurl := charm.MustParseURL("cs:django")
+	djangoCurl := charm.MustParseURL("ch:django")
 	charmInfo := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
 		URL:      djangoCurl.String(),
@@ -1295,17 +1211,19 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleTwiceScaleUp(c *gc.C) {
 	s.expectWatchAll()
 	s.expectResolveCharm(nil)
 
-	djangoCurl := charm.MustParseURL("cs:django-42")
+	djangoCurl := charm.MustParseURL("ch:django")
 	s.expectResolveCharmWithSeries([]string{"bionic", "xenial"}, nil)
 	s.expectAddCharm(false)
+	s.expectAddCharm(false)
 	charmInfo := &apicharms.CharmInfo{
-		Revision: djangoCurl.Revision,
-		URL:      djangoCurl.String(),
+		URL: djangoCurl.String(),
 		Meta: &charm.Meta{
 			Series: []string{"bionic", "xenial"},
 		},
 	}
 	s.expectCharmInfo(djangoCurl.String(), charmInfo)
+	s.expectCharmInfo(djangoCurl.String(), charmInfo)
+	s.expectSetCharm(c, "django")
 	s.expectDeploy()
 	s.expectAddOneUnit("django", "", "0")
 	s.expectAddOneUnit("django", "", "1")
@@ -1313,7 +1231,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleTwiceScaleUp(c *gc.C) {
 	s.runDeploy(c, `
        applications:
            django:
-               charm: cs:django-42
+               charm: ch:django
                series: xenial
                num_units: 2
    `)
@@ -1330,7 +1248,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleTwiceScaleUp(c *gc.C) {
 	s.runDeploy(c, `
        applications:
            django:
-               charm: cs:django-42
+               charm: ch:django
                series: xenial
                num_units: 5
    `)
@@ -1342,7 +1260,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedInApplication(c 
 	s.expectWatchAll()
 	s.expectResolveCharm(nil)
 
-	wordpressCurl := charm.MustParseURL("cs:wordpress")
+	wordpressCurl := charm.MustParseURL("ch:bionic/wordpress")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
 		Revision: wordpressCurl.Revision,
@@ -1363,7 +1281,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedInApplication(c 
 		{Entity: &params.UnitInfo{Name: "wordpress/1", MachineId: "1"}},
 	}, nil)
 
-	djangoCurl := charm.MustParseURL("cs:django-42")
+	djangoCurl := charm.MustParseURL("ch:bionic/django")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
@@ -1381,10 +1299,10 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedInApplication(c 
 	s.runDeploy(c, `
        applications:
            wordpress:
-               charm: cs:wordpress
+               charm: ch:wordpress
                num_units: 3
            django:
-               charm: cs:django-42
+               charm: ch:django
                num_units: 2
                to: [wordpress]
    `)
@@ -1393,11 +1311,11 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedInApplication(c 
 const peerContainerBundle = `
        applications:
            wordpress:
-               charm: cs:wordpress
+               charm: ch:wordpress
                num_units: 2
                to: ["lxd:new"]
            django:
-               charm: cs:django-42
+               charm: ch:django
                num_units: 2
                to: ["lxd:wordpress"]
    `
@@ -1413,11 +1331,10 @@ func (s *BundleDeployRepositorySuite) TestDeployBundlePeerContainer(c *gc.C) {
 	s.expectAddContainer("0", "0/lxd/1", "", "lxd")
 	s.expectAddContainer("1", "1/lxd/1", "", "lxd")
 
-	wordpressCurl := charm.MustParseURL("cs:wordpress")
+	wordpressCurl := charm.MustParseURL("ch:bionic/wordpress")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
-		Revision: wordpressCurl.Revision,
-		URL:      wordpressCurl.String(),
+		URL: wordpressCurl.String(),
 		Meta: &charm.Meta{
 			Series: []string{"bionic", "xenial"},
 		},
@@ -1428,11 +1345,10 @@ func (s *BundleDeployRepositorySuite) TestDeployBundlePeerContainer(c *gc.C) {
 	s.expectAddOneUnit("wordpress", "0/lxd/0", "0")
 	s.expectAddOneUnit("wordpress", "1/lxd/0", "1")
 
-	djangoCurl := charm.MustParseURL("cs:django-42")
+	djangoCurl := charm.MustParseURL("ch:bionic/django")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
-		Revision: djangoCurl.Revision,
-		URL:      djangoCurl.String(),
+		URL: djangoCurl.String(),
 		Meta: &charm.Meta{
 			Series: []string{"bionic", "xenial"},
 		},
@@ -1452,12 +1368,12 @@ func (s *BundleDeployRepositorySuite) TestDeployBundlePeerContainer(c *gc.C) {
 const unitColocationWithUnitBundle = `
        applications:
            mem:
-               charm: cs:mem-47
+               charm: ch:mem
                series: xenial
                num_units: 3
                to: [1, new]
            django:
-               charm: cs:django-42
+               charm: ch:django
                series: xenial
                num_units: 5
                to:
@@ -1466,7 +1382,7 @@ const unitColocationWithUnitBundle = `
                    - lxd:mem/2
                    - kvm:ror
            ror:
-               charm: cs:rails
+               charm: ch:rails
                series: xenial
                num_units: 2
                to:
@@ -1493,7 +1409,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitColocationWithUnit(c *
 	s.expectAddContainer("0", "0/kvm/0", "16.04", "kvm")
 
 	// Setup for mem charm
-	memCurl := charm.MustParseURL("cs:mem-47")
+	memCurl := charm.MustParseURL("ch:mem")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
 		Revision: memCurl.Revision,
@@ -1510,7 +1426,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitColocationWithUnit(c *
 	s.expectAddOneUnit("mem", "2", "2")
 
 	// Setup for django charm
-	djangoCurl := charm.MustParseURL("cs:django-42")
+	djangoCurl := charm.MustParseURL("ch:django")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
@@ -1529,7 +1445,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitColocationWithUnit(c *
 	s.expectAddOneUnit("django", "0/kvm/0", "4")
 
 	// Setup for rails charm
-	railsCurl := charm.MustParseURL("cs:rails")
+	railsCurl := charm.MustParseURL("ch:rails")
 	s.expectResolveCharm(nil)
 	charmInfo3 := &apicharms.CharmInfo{
 		Revision: railsCurl.Revision,
@@ -1551,11 +1467,11 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitColocationWithUnit(c *
 const switchBundle = `
        applications:
            django:
-               charm: cs:django
+               charm: ch:django
                series: bionic
                num_units: 1
            rails:
-               charm: cs:rails-47
+               charm: ch:rails
                series: bionic
                num_units: 1
    `
@@ -1569,18 +1485,30 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSwitch(c *gc.C) {
 
 	s.expectGetAnnotationsEmpty()
 
-	railsCurl := charm.MustParseURL("cs:rails-47")
+	djangoCurl := charm.MustParseURL("ch:django")
 	s.expectResolveCharm(nil)
 	s.expectAddCharm(false)
 	charmInfo := &apicharms.CharmInfo{
+		URL: djangoCurl.String(),
+		Meta: &charm.Meta{
+			Series: []string{"bionic", "xenial"},
+		},
+	}
+	s.expectCharmInfo(djangoCurl.String(), charmInfo)
+	s.expectSetCharm(c, "django")
+	s.expectDeploy()
+
+	railsCurl := charm.MustParseURL("ch:rails")
+	s.expectResolveCharm(nil)
+	s.expectAddCharm(false)
+	rCharmInfo := &apicharms.CharmInfo{
 		Revision: railsCurl.Revision,
 		URL:      railsCurl.String(),
 		Meta: &charm.Meta{
 			Series: []string{"bionic", "xenial"},
 		},
 	}
-	s.expectCharmInfo(railsCurl.String(), charmInfo)
-	s.expectDeploy()
+	s.expectCharmInfo(railsCurl.String(), rCharmInfo)
 	s.expectAddOneUnit(railsCurl.Name, "", "0")
 
 	// Redeploy a very similar bundle with another application unit. The new unit
@@ -1592,14 +1520,14 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSwitch(c *gc.C) {
 const annotationsBundle = `
         applications:
             django:
-                charm: cs:django
+                charm: ch:django
                 num_units: 1
                 annotations:
                     key1: value1
                     key2: value2
                 to: [1]
             mem:
-                charm: cs:mem-47
+                charm: ch:mem
                 num_units: 1
                 to: [0]
         machines:
@@ -1615,8 +1543,8 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleAnnotations(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	djangoCurl := charm.MustParseURL("ch:django")
-	memCurl := charm.MustParseURL("ch:mem")
+	djangoCurl := charm.MustParseURL("ch:bionic/django")
+	memCurl := charm.MustParseURL("ch:bionic/mem")
 	chUnits := []charmUnit{
 		{
 			curl:                 memCurl,
@@ -1634,7 +1562,6 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleAnnotations(c *gc.C) {
 	s.setupCharmUnits(chUnits)
 	s.expectSetAnnotation("application-django", map[string]string{"key1": "value1", "key2": "value2"})
 	s.expectSetAnnotation("machine-1", map[string]string{"foo": "bar"})
-	s.expectCharmInfo("ch:bionic/django", &apicharms.CharmInfo{URL: "ch:bionic/django"})
 
 	s.runDeploy(c, annotationsBundle)
 }
@@ -1671,7 +1598,12 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleAnnotationsChanges(c *gc.C
 	s.expectWatchAll()
 	s.expectResolveCharmWithSeries([]string{"bionic", "xenial"}, nil)
 	s.expectAddCharm(false)
+	s.expectCharmInfo("ch:bionic/django", &apicharms.CharmInfo{
+		URL:  "ch:bionic/django",
+		Meta: &charm.Meta{},
+	})
 
+	s.expectSetCharm(c, "django")
 	s.expectSetAnnotation("application-django", map[string]string{"key1": "new value!"})
 	s.expectSetAnnotation("machine-1", map[string]string{"answer": "42"})
 
@@ -1706,7 +1638,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleInvalidMachineContainerTyp
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("cs:wordpress-47")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	s.expectAddCharm(false)
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
@@ -1724,7 +1656,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleInvalidMachineContainerTyp
        series: bionic
        applications:
            wp:
-               charm: cs:wordpress-47
+               charm: ch:wordpress
                num_units: 1
                to: ["bad:1"]
        machines:
@@ -1754,7 +1686,7 @@ func (s *BundleDeployRepositorySuite) testDeployBundleUnitPlacedToMachines(c *gc
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("cs:wordpress-47")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
 	s.expectAddCharm(false)
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
@@ -1786,7 +1718,7 @@ func (s *BundleDeployRepositorySuite) testDeployBundleUnitPlacedToMachines(c *gc
        series: bionic
        applications:
            wp:
-               charm: cs:wordpress-47
+               charm: ch:wordpress
                num_units: 7
                to:
                    - new
@@ -1802,10 +1734,10 @@ func (s *BundleDeployRepositorySuite) testDeployBundleUnitPlacedToMachines(c *gc
 	s.runDeploy(c, quickBundle)
 
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Located charm \"wordpress\" in charm-hub, revision 47\n"+
+		"Located charm \"wordpress\" in charm-hub\n"+
 		"Executing changes:\n"+
-		"- upload charm wordpress from charm-store for series bionic with architecture=amd64\n"+
-		"- deploy application wp from charm-store on bionic using wordpress\n"+
+		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n"+
+		"- deploy application wp from charm-hub on bionic using wordpress\n"+
 		"- add new machine 0 (bundle machine 4)\n"+
 		"- add new machine 1 (bundle machine 8)\n"+
 		"- add new machine 2\n"+
@@ -1829,7 +1761,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleExpose(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("cs:wordpress-47")
+	wordpressCurl := charm.MustParseURL("ch:bionic/wordpress")
 	chUnits := []charmUnit{
 		{
 			charmMetaSeries:      []string{"bionic", "xenial"},
@@ -1843,7 +1775,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleExpose(c *gc.C) {
 	content := `
        applications:
            wordpress:
-               charm: cs:wordpress-47
+               charm: ch:wordpress
                num_units: 1
                expose: true
    `
@@ -1851,10 +1783,10 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleExpose(c *gc.C) {
 
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "18.04")
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Located charm \"wordpress\" in charm-hub, revision 47\n"+
+		"Located charm \"wordpress\" in charm-hub\n"+
 		"Executing changes:\n"+
-		"- upload charm wordpress from charm-store with architecture=amd64\n"+
-		"- deploy application wordpress from charm-store\n"+
+		"- upload charm wordpress from charm-hub with architecture=amd64\n"+
+		"- deploy application wordpress from charm-hub\n"+
 		"- expose all endpoints of wordpress and allow access from CIDRs 0.0.0.0/0 and ::/0\n"+
 		"- add unit wordpress/0 to new machine 0\n"+
 		"Deploy of bundle completed.\n")
@@ -1865,10 +1797,10 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMultipleRelations(c *gc.C)
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("cs:wordpress-47")
-	mysqlCurl := charm.MustParseURL("cs:mysql-32")
-	pgresCurl := charm.MustParseURL("cs:xenial/postgres-2")
-	varnishCurl := charm.MustParseURL("cs:xenial/varnish")
+	wordpressCurl := charm.MustParseURL("ch:wordpress")
+	mysqlCurl := charm.MustParseURL("ch:mysql")
+	pgresCurl := charm.MustParseURL("ch:postgres")
+	varnishCurl := charm.MustParseURL("ch:varnish")
 	chUnits := []charmUnit{
 		{
 			charmMetaSeries:      []string{"bionic", "xenial"},
@@ -1898,16 +1830,16 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMultipleRelations(c *gc.C)
        series: bionic
        applications:
            wordpress:
-               charm: cs:wordpress-47
+               charm: ch:wordpress
                num_units: 1
            mysql:
-               charm: cs:mysql-32
+               charm: ch:mysql
                num_units: 1
            postgres:
-               charm: cs:xenial/postgres-2
+               charm: ch:xenial/postgres
                num_units: 1
            varnish:
-               charm: cs:xenial/varnish
+               charm: ch:xenial/varnish
                num_units: 1
        relations:
            - ["wordpress:db", "mysql:server"]
@@ -1917,22 +1849,22 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleMultipleRelations(c *gc.C)
 
 	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "18.04")
 	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "ubuntu", "18.04")
-	s.assertDeployArgs(c, varnishCurl.String(), "varnish", "ubuntu", "16.04")
-	s.assertDeployArgs(c, pgresCurl.String(), "postgres", "ubuntu", "16.04")
+	s.assertDeployArgs(c, varnishCurl.String(), "varnish", "ubuntu", "18.04")
+	s.assertDeployArgs(c, pgresCurl.String(), "postgres", "ubuntu", "18.04")
 	c.Check(s.output.String(), gc.Equals, ""+
-		"Located charm \"mysql\" in charm-hub, revision 32\n"+
-		"Located charm \"postgres\" in charm-hub, revision 2\n"+
+		"Located charm \"mysql\" in charm-hub\n"+
+		"Located charm \"postgres\" in charm-hub\n"+
 		"Located charm \"varnish\" in charm-hub\n"+
-		"Located charm \"wordpress\" in charm-hub, revision 47\n"+
+		"Located charm \"wordpress\" in charm-hub\n"+
 		"Executing changes:\n"+
-		"- upload charm mysql from charm-store for series bionic with architecture=amd64\n"+
-		"- deploy application mysql from charm-store on bionic\n"+
-		"- upload charm postgres from charm-store for series xenial with architecture=amd64\n"+
-		"- deploy application postgres from charm-store on xenial\n"+
-		"- upload charm varnish from charm-store for series xenial with architecture=amd64\n"+
-		"- deploy application varnish from charm-store on xenial\n"+
-		"- upload charm wordpress from charm-store for series bionic with architecture=amd64\n"+
-		"- deploy application wordpress from charm-store on bionic\n"+
+		"- upload charm mysql from charm-hub for series bionic with architecture=amd64\n"+
+		"- deploy application mysql from charm-hub on bionic\n"+
+		"- upload charm postgres from charm-hub for series bionic with architecture=amd64\n"+
+		"- deploy application postgres from charm-hub on bionic\n"+
+		"- upload charm varnish from charm-hub for series bionic with architecture=amd64\n"+
+		"- deploy application varnish from charm-hub on bionic\n"+
+		"- upload charm wordpress from charm-hub for series bionic with architecture=amd64\n"+
+		"- deploy application wordpress from charm-hub on bionic\n"+
 		"- add relation wordpress:db - mysql:server\n"+
 		"- add relation varnish:webcache - wordpress:cache\n"+
 		"- add unit mysql/0 to new machine 0\n"+
@@ -2166,7 +2098,7 @@ type charmUnit struct {
 func (s *BundleDeployRepositorySuite) setupCharmUnits(charmUnits []charmUnit) {
 	for _, chUnit := range charmUnits {
 		switch chUnit.curl.Schema {
-		case "cs", "ch":
+		case "ch":
 			resolveSeries := chUnit.resolveSeries
 			if len(resolveSeries) == 0 {
 				resolveSeries = []string{"bionic", "focal", "xenial"}
@@ -2292,7 +2224,7 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusWordpressBundle() {
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"mysql": {
-				Charm:        "cs:mysql-42",
+				Charm:        "ch:mysql",
 				Scale:        1,
 				Base:         params.Base{Name: "ubuntu", Channel: "18.04"},
 				CharmChannel: "stable",
@@ -2301,7 +2233,7 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusWordpressBundle() {
 				},
 			},
 			"wordpress": {
-				Charm:        "cs:wordpress-47",
+				Charm:        "ch:wordpress",
 				Scale:        1,
 				Base:         params.Base{Name: "ubuntu", Channel: "18.04"},
 				CharmChannel: "stable",
@@ -2334,7 +2266,7 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjangoBundle() {
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"django": {
-				Charm: "cs:django",
+				Charm: "ch:django",
 				Scale: 1,
 				Base:  params.Base{Name: "ubuntu", Channel: "18.04"},
 				Units: map[string]params.UnitStatus{
@@ -2360,7 +2292,7 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjangoMemBundle() {
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"django": {
-				Charm:        "cs:django",
+				Charm:        "ch:django",
 				Scale:        1,
 				Base:         params.Base{Name: "ubuntu", Channel: "18.04"},
 				CharmChannel: "stable",
@@ -2369,7 +2301,7 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjangoMemBundle() {
 				},
 			},
 			"mem": {
-				Charm:        "cs:mem-47",
+				Charm:        "ch:mem",
 				Scale:        1,
 				Base:         params.Base{Name: "ubuntu", Channel: "18.04"},
 				CharmChannel: "stable",
@@ -2396,7 +2328,7 @@ func (s *BundleDeployRepositorySuite) expectDeployerAPIStatusDjango2Units() {
 		},
 		Applications: map[string]params.ApplicationStatus{
 			"django": {
-				Charm:        "cs:django-42",
+				Charm:        "ch:django",
 				Scale:        1,
 				Base:         params.Base{Name: "ubuntu", Channel: "16.04"},
 				CharmChannel: "stable",

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -388,7 +388,7 @@ type repositoryCharm struct {
 func (c *repositoryCharm) String() string {
 	str := fmt.Sprintf("deploy charm: %s", c.userRequestedURL.String())
 	origin := c.id.Origin
-	if isEmptyOrigin(origin, commoncharm.OriginCharmStore) {
+	if isEmptyOrigin(origin, commoncharm.OriginCharmHub) {
 		return str
 	}
 	var revision string
@@ -411,9 +411,7 @@ func (c *repositoryCharm) String() string {
 func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver) error {
 	userRequestedURL := c.userRequestedURL
 	location := "charmhub"
-	if charm.CharmStore.Matches(userRequestedURL.Schema) {
-		location = "charm-store"
-	}
+
 	ctx.Verbosef("Preparing to deploy %q from the %s", userRequestedURL.Name, location)
 
 	modelCfg, workloadSeries, err := seriesSelectorRequirements(deployAPI, c.clock, userRequestedURL)

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -224,19 +224,8 @@ func (s *deployerSuite) TestGetDeployerLocalBundle(c *gc.C) {
 	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy local bundle from: %s", bundlePath))
 }
 
-func (s *deployerSuite) TestGetDeployerCharmStoreBundle(c *gc.C) {
-	bundle := charm.MustParseURL("cs:test-bundle")
-	cfg := s.basicDeployerConfig()
-
-	cfg.CharmOrBundle = bundle.String()
-
-	deployer, err := s.testGetDeployerRepositoryBundle(c, cfg)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s", bundle.String()))
-}
-
-func (s *deployerSuite) TestGetDeployerCharmStoreBundleWithChannel(c *gc.C) {
-	bundle := charm.MustParseURL("cs:test-bundle")
+func (s *deployerSuite) TestGetDeployerCharmHubBundleWithChannel(c *gc.C) {
+	bundle := charm.MustParseURL("ch:test-bundle")
 	cfg := s.channelDeployerConfig()
 	cfg.CharmOrBundle = bundle.String()
 
@@ -320,16 +309,12 @@ func (s *deployerSuite) TestResolveCharmURL(c *gc.C) {
 		url:           &charm.URL{Schema: "ch", Name: "wordpress", Revision: -1},
 	}, {
 		defaultSchema: charm.CharmHub,
-		path:          "cs:wordpress",
-		url:           &charm.URL{Schema: "cs", Name: "wordpress", Revision: -1},
-	}, {
-		defaultSchema: charm.CharmHub,
 		path:          "local:wordpress",
 		url:           &charm.URL{Schema: "local", Name: "wordpress", Revision: -1},
 	}, {
 		defaultSchema: charm.CharmHub,
-		path:          "cs:~user/series/name",
-		url:           &charm.URL{Schema: "cs", User: "user", Name: "name", Series: "series", Revision: -1},
+		path:          "ch:series/name",
+		url:           &charm.URL{Schema: "ch", User: "", Name: "name", Series: "series", Revision: -1},
 	}, {
 		defaultSchema: charm.CharmHub,
 		path:          "wordpress",

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -229,7 +229,7 @@ func (c *diffBundleCommand) Run(ctx *cmd.Context) error {
 	defer func() { _ = apiRoot.Close() }()
 
 	// Load up the bundle data, with includes and overlays.
-	baseSrc, err := c.bundleDataSource(apiRoot, base)
+	baseSrc, err := c.bundleDataSource(ctx, apiRoot, base)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -302,7 +302,7 @@ func missingRelationEndpoint(rel string) bool {
 	return len(tokens) != 2 || tokens[1] == ""
 }
 
-func (c *diffBundleCommand) bundleDataSource(apiRoot base.APICallCloser, base series.Base) (charm.BundleDataSource, error) {
+func (c *diffBundleCommand) bundleDataSource(ctx *cmd.Context, apiRoot base.APICallCloser, base series.Base) (charm.BundleDataSource, error) {
 	ds, err := charm.LocalBundleDataSource(c.bundle)
 
 	// NotValid/NotFound means we should try interpreting it as a charm store
@@ -339,7 +339,7 @@ func (c *diffBundleCommand) bundleDataSource(apiRoot base.APICallCloser, base se
 	bundleURL, bundleOrigin, err := charmAdaptor.ResolveBundleURL(bURL, origin)
 	if err != nil {
 		if errors.Is(err, errors.NotValid) {
-			return nil, errors.Errorf("%q can not be found or is not a valid bundle", c.bundle)
+			ctx.Verbosef("%q can not be found or is not a valid bundle", c.bundle)
 		}
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/diffbundle_test.go
+++ b/cmd/juju/application/diffbundle_test.go
@@ -122,9 +122,6 @@ applications:
   grafana:
     missing: bundle
   prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
     options:
       ontology:
         bundle: anselm
@@ -146,9 +143,6 @@ applications:
   grafana:
     missing: bundle
   prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
     options:
       ontology:
         bundle: anselm
@@ -175,9 +169,6 @@ applications:
   grafana:
     missing: bundle
   prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
     options:
       ontology:
         bundle: hume
@@ -204,9 +195,6 @@ applications:
   grafana:
     missing: bundle
   prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
     options:
       admin-user:
         bundle: lovecraft
@@ -243,11 +231,7 @@ func (s *diffSuite) TestCharmSeriesBundle(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-applications:
-  prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
+{}
 `[1:])
 }
 
@@ -267,9 +251,6 @@ applications:
   grafana:
     missing: bundle
   prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
     options:
       ontology:
         bundle: anselm
@@ -305,9 +286,6 @@ applications:
   grafana:
     missing: bundle
   prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
     options:
       ontology:
         bundle: anselm
@@ -369,7 +347,9 @@ func (s *diffSuite) TestExposedEndpoints(c *gc.C) {
 			bundle: `
 applications:
   prometheus:
-    charm: 'ch:prometheus2'
+    charm: 'prometheus'
+    revision: 7
+    channel: stable
     num_units: 1
     series: xenial
     expose: true
@@ -382,9 +362,6 @@ machines:
 			expDiff: `
 applications:
   prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
     exposed_endpoints:
       "":
         bundle:
@@ -409,7 +386,9 @@ applications:
 			bundle: `
 applications:
   prometheus:
-    charm: 'ch:prometheus2'
+    charm: 'prometheus'
+    revision: 7
+    channel: stable
     num_units: 1
     series: xenial
     to:
@@ -431,9 +410,6 @@ applications:
 			expDiff: `
 applications:
   prometheus:
-    charm:
-      bundle: ch:prometheus2
-      model: prometheus2
     exposed_endpoints:
       "":
         bundle:
@@ -498,17 +474,19 @@ func makeAPIResponsesWithRelations(relations []params.RelationStatus) map[string
 		"Client.FullStatus": params.FullStatus{
 			Applications: map[string]params.ApplicationStatus{
 				"prometheus": {
-					Charm: "ch:prometheus2",
-					Base:  params.Base{Name: "ubuntu", Channel: "16.04"},
-					Life:  "alive",
+					Charm:        "ch:prometheus2-47",
+					CharmChannel: "stable",
+					Base:         params.Base{Name: "ubuntu", Channel: "16.04"},
+					Life:         "alive",
 					Units: map[string]params.UnitStatus{
 						"prometheus/0": {Machine: "0"},
 					},
 				},
 				"grafana": {
-					Charm: "ch:grafana-19",
-					Base:  params.Base{Name: "ubuntu", Channel: "18.04"},
-					Life:  "alive",
+					Charm:        "ch:grafana-19",
+					CharmChannel: "stable",
+					Base:         params.Base{Name: "ubuntu", Channel: "18.04"},
+					Life:         "alive",
 					Units: map[string]params.UnitStatus{
 						"grafana/0": {Machine: "1"},
 					},
@@ -568,9 +546,10 @@ func makeAPIResponsesWithExposedEndpoints(exposedEndpoints map[string]params.Exp
 		"Client.FullStatus": params.FullStatus{
 			Applications: map[string]params.ApplicationStatus{
 				"prometheus": {
-					Charm: "ch:prometheus2",
-					Base:  params.Base{Name: "ubuntu", Channel: "16.04"},
-					Life:  "alive",
+					Charm:        "ch:prometheus-7",
+					CharmChannel: "stable",
+					Base:         params.Base{Name: "ubuntu", Channel: "16.04"},
+					Life:         "alive",
 					Units: map[string]params.UnitStatus{
 						"prometheus/0": {Machine: "0"},
 					},
@@ -670,7 +649,9 @@ const (
 	testCharmHubBundle = `
 applications:
   prometheus:
-    charm: 'ch:prometheus2'
+    charm: 'prometheus2'
+    revision: 47
+    channel: stable
     num_units: 1
     series: xenial
     options:
@@ -687,7 +668,9 @@ machines:
 	withInclude = `
 applications:
   prometheus:
-    charm: 'ch:prometheus2'
+    charm: 'prometheus2'
+    revision: 7
+    channel: stable
     num_units: 1
     series: xenial
     options:
@@ -745,7 +728,9 @@ relations:
 series: bionic
 applications:
   prometheus:
-    charm: 'ch:prometheus2'
+    charm: 'prometheus2'
+    revision: 7
+    channel: stable
     num_units: 1
     series: xenial
     constraints: 'cores=3'
@@ -755,6 +740,8 @@ applications:
       - 0
   grafana:
     charm: 'grafana'
+    revision: 19
+    channel: stable
     num_units: 1
     constraints: 'cores=3'
     options:

--- a/cmd/juju/application/store/charmadapter_test.go
+++ b/cmd/juju/application/store/charmadapter_test.go
@@ -84,13 +84,13 @@ func (s *resolveSuite) TestResolveCharmNotCSCharm(c *gc.C) {
 func (s *resolveSuite) TestResolveBundle(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl, err := charm.ParseURL("cs:testme-3")
+	curl, err := charm.ParseURL("ch:testme")
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectCharmResolutionCall(curl, "edge", nil)
 
 	curl.Series = "bundle"
 	origin := commoncharm.Origin{
-		Source: commoncharm.OriginCharmStore,
+		Source: commoncharm.OriginCharmHub,
 		Risk:   "edge",
 	}
 	charmAdapter := store.NewCharmAdaptor(s.charmsAPI, func() (store.DownloadBundleClient, error) {
@@ -105,13 +105,13 @@ func (s *resolveSuite) TestResolveBundle(c *gc.C) {
 func (s *resolveSuite) TestResolveNotBundle(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	curl, err := charm.ParseURL("cs:testme-3")
+	curl, err := charm.ParseURL("ch:testme")
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectCharmResolutionCall(curl, "edge", nil)
 
 	curl.Series = "bionic"
 	origin := commoncharm.Origin{
-		Source: commoncharm.OriginCharmStore,
+		Source: commoncharm.OriginCharmHub,
 		Risk:   "edge",
 	}
 	charmAdapter := store.NewCharmAdaptor(s.charmsAPI, func() (store.DownloadBundleClient, error) {

--- a/cmd/juju/application/store/interface.go
+++ b/cmd/juju/application/store/interface.go
@@ -5,7 +5,6 @@ package store
 
 import (
 	"github.com/juju/charm/v9"
-	csparams "github.com/juju/charmrepo/v7/csclient/params"
 
 	apicharm "github.com/juju/juju/api/client/charms"
 	commoncharm "github.com/juju/juju/api/common/charm"
@@ -17,14 +16,6 @@ type CharmAdder interface {
 	AddLocalCharm(*charm.URL, charm.Charm, bool) (*charm.URL, error) // not used in utils
 	AddCharm(*charm.URL, commoncharm.Origin, bool) (commoncharm.Origin, error)
 	CheckCharmPlacement(string, *charm.URL) error
-}
-
-// CharmrepoForDeploy is a stripped-down version of the
-// gopkg.in/juju/charmrepo.v4 Interface interface. It is
-// used by tests that embed a DeploySuiteBase.
-type CharmrepoForDeploy interface {
-	GetBundle(bundleURL *charm.URL, path string) (charm.Bundle, error)
-	ResolveWithPreferredChannel(*charm.URL, csparams.Channel) (*charm.URL, csparams.Channel, []string, error)
 }
 
 // CharmsAPI is functionality needed by the CharmAdapter from the Charms API.

--- a/cmd/juju/application/store/store.go
+++ b/cmd/juju/application/store/store.go
@@ -4,15 +4,11 @@
 package store
 
 import (
-	"github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
 	"github.com/juju/charm/v9"
-	"github.com/juju/charmrepo/v7"
-	"github.com/juju/charmrepo/v7/csclient"
 	"github.com/juju/errors"
 
 	commoncharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/version"
 )
 
 // AddCharmFromURL calls the appropriate client API calls to add the
@@ -26,26 +22,4 @@ func AddCharmFromURL(client CharmAdder, curl *charm.URL, origin commoncharm.Orig
 		return nil, commoncharm.Origin{}, errors.Trace(err)
 	}
 	return curl, resultOrigin, nil
-}
-
-// NewCharmStoreClient is called to obtain a charm store client.
-// It is defined as a variable so it can be changed for testing purposes.
-var NewCharmStoreClient = func(client *httpbakery.Client, csURL string) *csclient.Client {
-	return csclient.New(csclient.Params{
-		URL:            csURL,
-		BakeryClient:   client,
-		UserAgentValue: version.UserAgentVersion,
-	})
-}
-
-// NewCharmStoreAdaptor combines charm store functionality with the ability to get a macaroon.
-func NewCharmStoreAdaptor(client *httpbakery.Client, csURL string) *CharmStoreAdaptor {
-	cstoreClient := NewCharmStoreClient(client, csURL)
-	return &CharmStoreAdaptor{
-		CharmrepoForDeploy: charmrepo.NewCharmStoreFromClient(cstoreClient),
-	}
-}
-
-type CharmStoreAdaptor struct {
-	CharmrepoForDeploy
 }


### PR DESCRIPTION
Removes the use of CharmStore charms from the bundle code in the client. 

Continuation of #15013 that removed the charmstore support from deploy and refresh. Relates to #14968, #14985 etc. The main planning story is at https://warthogs.atlassian.net/browse/JUJU-2201

## QA Steps

CharmStore charms are not supported, so this doesn't change any behavior.