### PR TITLE
[JUJU-2433] Dqlite bind address detection by device

### DIFF
--- a/database/bootstrap_test.go
+++ b/database/bootstrap_test.go
@@ -46,8 +46,8 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 			return err
 		}
 
-		if count != 3 {
-			return fmt.Errorf("expected 3 rows, got %d", count)
+		if count != 2 {
+			return fmt.Errorf("expected 2 rows, got %d", count)
 		}
 
 		return nil

--- a/database/option_test.go
+++ b/database/option_test.go
@@ -6,7 +6,6 @@ package database
 import (
 	"fmt"
 	"math/rand"
-	"net"
 	"os"
 	"strconv"
 
@@ -54,36 +53,13 @@ func (s *optionSuite) TestEnsureDataDirSuccess(c *gc.C) {
 func (s *optionSuite) TestWithAddressOptionSuccess(c *gc.C) {
 	f := NewOptionFactory(nil, stubLogger{})
 
-	f.interfaceAddrs = func() ([]net.Addr, error) {
-		return []net.Addr{
-			&net.IPAddr{IP: net.ParseIP("10.0.0.5")},
-			&net.IPAddr{IP: net.ParseIP("127.0.0.1")},
-		}, nil
-	}
-
-	// We can not actually test the realisation of this option,
-	// as the options type from the go-dqlite is not exported.
-	// We are also unable to test by creating a new dqlite app,
-	// because it fails to bind to the contrived address.
-	// The best we can do is check that we selected an address
-	// based on the absence of an error.
-	_, err := f.WithAddressOption()
+	withAddress, err := f.WithAddressOption()
 	c.Assert(err, jc.ErrorIsNil)
-}
 
-func (s *optionSuite) TestWithAddressOptionMultipleAddressError(c *gc.C) {
-	f := NewOptionFactory(nil, stubLogger{})
+	dqlite, err := app.New(c.MkDir(), withAddress)
+	c.Assert(err, jc.ErrorIsNil)
 
-	f.interfaceAddrs = func() ([]net.Addr, error) {
-		return []net.Addr{
-			&net.IPAddr{IP: net.ParseIP("10.0.0.5")},
-			&net.IPAddr{IP: net.ParseIP("10.0.0.6")},
-		}, nil
-	}
-
-	_, err := f.WithAddressOption()
-	c.Assert(err, gc.ErrorMatches,
-		`.* found \[local-cloud:10.0.0.5 local-cloud:10.0.0.6\]`)
+	_ = dqlite.Close()
 }
 
 func (s *optionSuite) TestWithTLSOptionSuccess(c *gc.C) {
@@ -100,22 +76,19 @@ func (s *optionSuite) TestWithTLSOptionSuccess(c *gc.C) {
 }
 
 func (s *optionSuite) TestWithClusterOptionSuccess(c *gc.C) {
+	// Hack to get a bind address to add to config.
+	h := NewOptionFactory(fakeAgentConfig{}, stubLogger{})
+	err := h.ensureBindAddress()
+
 	cfg := fakeAgentConfig{
 		apiAddrs: []string{
 			"10.0.0.5:17070",
-			"10.0.0.6:17070",
-			"10.0.0.7:17070",
+			h.bindAddress,     // Filtered out as not being us.
 			"127.0.0.1:17070", // Filtered out as a non-local-cloud address.
 		},
 	}
 
 	f := NewOptionFactory(cfg, stubLogger{})
-
-	f.interfaceAddrs = func() ([]net.Addr, error) {
-		return []net.Addr{
-			&net.IPAddr{IP: net.ParseIP("10.0.0.5")}, // One of the unique local-cloud addresses.
-		}, nil
-	}
 
 	withCluster, err := f.WithClusterOption()
 	c.Assert(err, jc.ErrorIsNil)
@@ -127,15 +100,13 @@ func (s *optionSuite) TestWithClusterOptionSuccess(c *gc.C) {
 }
 
 func (s *optionSuite) TestWithClusterNotHASuccess(c *gc.C) {
-	cfg := fakeAgentConfig{apiAddrs: []string{"10.0.0.5:17070"}}
+	// Hack to get a bind address to add to config.
+	h := NewOptionFactory(fakeAgentConfig{}, stubLogger{})
+	err := h.ensureBindAddress()
+
+	cfg := fakeAgentConfig{apiAddrs: []string{h.bindAddress}}
 
 	f := NewOptionFactory(cfg, stubLogger{})
-
-	f.interfaceAddrs = func() ([]net.Addr, error) {
-		return []net.Addr{
-			&net.IPAddr{IP: net.ParseIP("10.0.0.5")},
-		}, nil
-	}
 
 	withCluster, err := f.WithClusterOption()
 	c.Assert(err, jc.ErrorIsNil)

--- a/database/option_test.go
+++ b/database/option_test.go
@@ -6,6 +6,7 @@ package database
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"strconv"
 
@@ -115,6 +116,20 @@ func (s *optionSuite) TestWithClusterNotHASuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_ = dqlite.Close()
+}
+
+func (s *optionSuite) TestIgnoreInterface(c *gc.C) {
+	shouldIgnore := []string{
+		"lxdbr0",
+		"virbr0",
+		"docker0",
+	}
+	for _, devName := range shouldIgnore {
+		c.Check(ignoreInterface(net.Interface{Name: devName}), jc.IsTrue)
+	}
+
+	c.Check(ignoreInterface(net.Interface{Flags: net.FlagLoopback}), jc.IsTrue)
+	c.Check(ignoreInterface(net.Interface{Name: "enp5s0"}), jc.IsFalse)
 }
 
 type fakeAgentConfig struct {

--- a/network/network.go
+++ b/network/network.go
@@ -28,6 +28,9 @@ const DefaultLXDBridge = "lxdbr0"
 // Note: we don't import this from 'container' to avoid import loops
 const DefaultKVMBridge = "virbr0"
 
+// DefaultDockerBridge is the bridge that is set up by Docker.
+const DefaultDockerBridge = "docker0"
+
 // DeviceToBridge gives the information about a particular device that
 // should be bridged.
 type DeviceToBridge struct {


### PR DESCRIPTION
The first incarnation of address detection for Dqlite binding, we had the possibility of picking up a local-cloud address that was actually for one of the common default bridge devices.

Here we change the address detection to be device centric, so we can filter out certain devices.

We also add the ability to override the bind address for testing purposes.

## QA steps

Just run a bootstrap.

## Documentation changes

None.

## Bug reference

N/A
