### PR TITLE
[JUJU-2437] Patch ovs-vsctl command to fix intermittent test failures

### DIFF
--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -291,6 +291,7 @@ func (s *MachineSuite) TestDyingMachine(c *gc.C) {
 }
 
 func (s *MachineSuite) TestManageModelRunsInstancePoller(c *gc.C) {
+	testing.PatchExecutableAsEchoArgs(c, s, "ovs-vsctl", 0)
 	s.AgentSuite.PatchValue(&instancepoller.ShortPoll, 500*time.Millisecond)
 	s.AgentSuite.PatchValue(&instancepoller.ShortPollCap, 500*time.Millisecond)
 


### PR DESCRIPTION
When the machine agent starts, it detects local network configuration. This includes a call to `ovs-vsctl` to interrogate any OVN bridges on the machine.

If this call fails, as seen when running tests on a machine with OVS tools installed, the machine agent crashes before updating its status to "running". When this happens, `TestManageModelRunsInstancePoller` fails.

Here we patch the call so that it exits with code 0 regardless of the machine running tests.

## QA steps

`go test -v ./cmd/jujud/agent/ -check.v -check.f=MachineSuite.TestManageModelRunsInstancePoller`
