### PR TITLE
[JUJU-2249] Fix LP 2002114, panic running full status.

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -897,8 +897,9 @@ func (a *Application) setExposed(exposed bool, exposedEndpoints map[string]Expos
 // Charm returns the application's charm and whether units should upgrade to that
 // charm even if they are in an error state.
 func (a *Application) Charm() (*Charm, bool, error) {
-	// We don't worry about the channel since we aren't interacting
-	// with the charm store here.
+	if a.doc.CharmURL == nil {
+		return nil, false, errors.NotFoundf("charm for application %q", a.doc.Name)
+	}
 	curl, err := charm.ParseURL(*a.doc.CharmURL)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
Check pointer non nil before de-referencing it.

The question of how the db got into the situation of an application doc without a charm URL is outstanding. Nor do we have a reproducer for this bug. Initial checks show that the charm url provided to SetCharm and AddApplication are verified.

## QA steps

Unfortunately we do not have a reproducer and can only fix the result at this time, not the root cause.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2002114