### PR TITLE
Fix controller config type coercion for time.Duration

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -365,7 +365,7 @@ func (s *loginSuite) setupRateLimiting(c *gc.C) {
 	err := s.State.UpdateControllerConfig(
 		map[string]interface{}{
 			corecontroller.AgentRateLimitMax:  1,
-			corecontroller.AgentRateLimitRate: time.Second,
+			corecontroller.AgentRateLimitRate: time.Second.String(),
 		}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/controller/config.go
+++ b/cmd/juju/controller/config.go
@@ -234,7 +234,7 @@ func (c *configCommand) setConfig(client controllerAPI, ctx *cmd.Context) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	parsed, err := controller.NewConfig(ctrl.ControllerUUID, ctrl.CACert, attrs)
+	_, err = controller.NewConfig(ctrl.ControllerUUID, ctrl.CACert, attrs)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -243,7 +243,7 @@ func (c *configCommand) setConfig(client controllerAPI, ctx *cmd.Context) error 
 	values := make(map[string]interface{})
 	for k := range attrs {
 		if controller.AllowedUpdateConfigAttributes.Contains(k) {
-			values[k] = parsed[k]
+			values[k] = attrs[k]
 		} else {
 			extraValues.Add(k)
 		}

--- a/cmd/juju/controller/config_test.go
+++ b/cmd/juju/controller/config_test.go
@@ -214,7 +214,7 @@ func (s *ConfigSuite) TestSettingFromBothNoOverlap(c *gc.C) {
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
 		"juju-ha-space":         "value",
-		"audit-log-max-backups": 123,
+		"audit-log-max-backups": "123",
 	})
 }
 
@@ -232,7 +232,7 @@ func (s *ConfigSuite) TestSettingFromBothArgFirst(c *gc.C) {
 	// probably not worth fixing - I don't think people will try to
 	// set an option from a file and then override it from an arg.
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": 123,
+		"audit-log-max-backups": "123",
 	})
 }
 
@@ -246,7 +246,7 @@ func (s *ConfigSuite) TestSettingFromBothFileFirst(c *gc.C) {
 	c.Assert(output, gc.Equals, "")
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": 123,
+		"audit-log-max-backups": "123",
 	})
 }
 

--- a/cmd/juju/controller/config_test.go
+++ b/cmd/juju/controller/config_test.go
@@ -178,6 +178,17 @@ func (s *ConfigSuite) TestSettingKey(c *gc.C) {
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{"juju-ha-space": "value"})
 }
 
+func (s *ConfigSuite) TestSettingDuration(c *gc.C) {
+	var api fakeControllerAPI
+	context, err := s.runWithAPI(c, &api, "api-port-open-delay=100ms")
+	c.Assert(err, jc.ErrorIsNil)
+
+	output := strings.TrimSpace(cmdtesting.Stdout(context))
+	c.Assert(output, gc.Equals, "")
+
+	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{"api-port-open-delay": "100ms"})
+}
+
 func (s *ConfigSuite) TestSettingComplexKey(c *gc.C) {
 	var api fakeControllerAPI
 	context, err := s.runWithAPI(c, &api, "features=[value1,value2]")
@@ -214,7 +225,7 @@ func (s *ConfigSuite) TestSettingFromBothNoOverlap(c *gc.C) {
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
 		"juju-ha-space":         "value",
-		"audit-log-max-backups": "123",
+		"audit-log-max-backups": 123,
 	})
 }
 
@@ -232,7 +243,7 @@ func (s *ConfigSuite) TestSettingFromBothArgFirst(c *gc.C) {
 	// probably not worth fixing - I don't think people will try to
 	// set an option from a file and then override it from an arg.
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": "123",
+		"audit-log-max-backups": 123,
 	})
 }
 
@@ -246,7 +257,7 @@ func (s *ConfigSuite) TestSettingFromBothFileFirst(c *gc.C) {
 	c.Assert(output, gc.Equals, "")
 
 	c.Assert(api.values, gc.DeepEquals, map[string]interface{}{
-		"audit-log-max-backups": "123",
+		"audit-log-max-backups": 123,
 	})
 }
 

--- a/controller/config.go
+++ b/controller/config.go
@@ -306,8 +306,7 @@ const (
 	DefaultAPIPort int = 17070
 
 	// DefaultAPIPortOpenDelay is the default value for api-port-open-delay.
-	// It is a string representation of a time.Duration.
-	DefaultAPIPortOpenDelay = "2s"
+	DefaultAPIPortOpenDelay = 2 * time.Second
 
 	// DefaultMongoMemoryProfile is the default profile used by mongo.
 	DefaultMongoMemoryProfile = MongoProfDefault
@@ -362,7 +361,7 @@ const (
 	// processing 1000 txs seems to take about 100ms, so a sleep time of 10ms
 	// represents a 10% slowdown, but allows other systems to
 	// operate concurrently.
-	DefaultPruneTxnSleepTime = "10ms"
+	DefaultPruneTxnSleepTime = 10 * time.Millisecond
 
 	// DefaultMaxCharmStateSize is the maximum size (in bytes) of charm
 	// state data that each unit can store to the controller.
@@ -381,7 +380,7 @@ const (
 	DefaultBatchRaftFSM = false
 
 	// DefaultMigrationMinionWaitMax is the default value for
-	DefaultMigrationMinionWaitMax = "15m"
+	DefaultMigrationMinionWaitMax = 15 * time.Minute
 )
 
 var (
@@ -635,11 +634,7 @@ func (c Config) APIPort() int {
 // the APIPort once the controller has started up. Only used when
 // the ControllerAPIPort is non-zero.
 func (c Config) APIPortOpenDelay() time.Duration {
-	v := c.asString(APIPortOpenDelay)
-	// We know that v must be a parseable time.Duration for the config
-	// to be valid.
-	d, _ := time.ParseDuration(v)
-	return d
+	return c.durationOrDefault(APIPortOpenDelay, DefaultAPIPortOpenDelay)
 }
 
 // ControllerAPIPort returns the optional API port to be used for
@@ -887,11 +882,7 @@ func (c Config) ModelLogsSizeMB() int {
 // MaxDebugLogDuration is the maximum time a debug-log session is allowed
 // to run before it is terminated by the server.
 func (c Config) MaxDebugLogDuration() time.Duration {
-	duration, ok := c[MaxDebugLogDuration].(time.Duration)
-	if !ok {
-		duration = DefaultMaxDebugLogDuration
-	}
-	return duration
+	return c.durationOrDefault(MaxDebugLogDuration, DefaultMaxDebugLogDuration)
 }
 
 // MaxTxnLogSizeMB is the maximum size in MiB of the txn log collection.
@@ -916,16 +907,7 @@ func (c Config) PruneTxnQueryCount() int {
 
 // PruneTxnSleepTime is the amount of time to sleep between batches.
 func (c Config) PruneTxnSleepTime() time.Duration {
-	asInterface, ok := c[PruneTxnSleepTime]
-	if !ok {
-		asInterface = DefaultPruneTxnSleepTime
-	}
-	asStr, ok := asInterface.(string)
-	if !ok {
-		asStr = DefaultPruneTxnSleepTime
-	}
-	val, _ := time.ParseDuration(asStr)
-	return val
+	return c.durationOrDefault(PruneTxnSleepTime, DefaultPruneTxnSleepTime)
 }
 
 // PublicDNSAddress returns the DNS name of the controller.
@@ -1037,16 +1019,7 @@ func (c Config) BatchRaftFSM() bool {
 // migration-master worker should wait for migration-minion reports during
 // phases of a model migration.
 func (c Config) MigrationMinionWaitMax() time.Duration {
-	asInterface, ok := c[MigrationMinionWaitMax]
-	if !ok {
-		asInterface = DefaultMigrationMinionWaitMax
-	}
-	asStr, ok := asInterface.(string)
-	if !ok {
-		asStr = DefaultMigrationMinionWaitMax
-	}
-	val, _ := time.ParseDuration(asStr)
-	return val
+	return c.durationOrDefault(MigrationMinionWaitMax, DefaultMigrationMinionWaitMax)
 }
 
 // Validate ensures that config is a valid configuration.
@@ -1346,7 +1319,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	AuditLogMaxBackups:               schema.ForceInt(),
 	AuditLogExcludeMethods:           schema.List(schema.String()),
 	APIPort:                          schema.ForceInt(),
-	APIPortOpenDelay:                 schema.String(),
+	APIPortOpenDelay:                 schema.TimeDuration(),
 	ControllerAPIPort:                schema.ForceInt(),
 	ControllerName:                   schema.String(),
 	StatePort:                        schema.ForceInt(),
@@ -1368,7 +1341,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	ModelLogfileMaxSize:              schema.String(),
 	ModelLogsSize:                    schema.String(),
 	PruneTxnQueryCount:               schema.ForceInt(),
-	PruneTxnSleepTime:                schema.String(),
+	PruneTxnSleepTime:                schema.TimeDuration(),
 	PublicDNSAddress:                 schema.String(),
 	JujuHASpace:                      schema.String(),
 	JujuManagementSpace:              schema.String(),
@@ -1381,7 +1354,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	MaxAgentStateSize:                schema.ForceInt(),
 	NonSyncedWritesToRaftLog:         schema.Bool(),
 	BatchRaftFSM:                     schema.Bool(),
-	MigrationMinionWaitMax:           schema.String(),
+	MigrationMinionWaitMax:           schema.TimeDuration(),
 	ApplicationResourceDownloadLimit: schema.ForceInt(),
 	ControllerResourceDownloadLimit:  schema.ForceInt(),
 }, schema.Defaults{

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -248,13 +248,13 @@ var newConfigTests = []struct {
 		config: controller.Config{
 			controller.APIPortOpenDelay: "15",
 		},
-		expectError: `api-port-open-delay value "15" must be a valid duration`,
+		expectError: `api-port-open-delay: conversion to duration: time: missing unit in duration "15"`,
 	}, {
 		about: "txn-prune-sleep-time not a duration",
 		config: controller.Config{
 			controller.PruneTxnSleepTime: "15",
 		},
-		expectError: `prune-txn-sleep-time must be a valid duration \(eg "10ms"\): time: missing unit in duration "?15"?`,
+		expectError: `prune-txn-sleep-time: conversion to duration: time: missing unit in duration "15"`,
 	}, {
 		about: "mongo-memory-profile not valid",
 		config: controller.Config{
@@ -387,7 +387,7 @@ var newConfigTests = []struct {
 		config: controller.Config{
 			controller.MigrationMinionWaitMax: "15",
 		},
-		expectError: `migration-agent-wait-time value "15" must be a valid duration`,
+		expectError: `migration-agent-wait-time: conversion to duration: time: missing unit in duration "15"`,
 	}, {
 		about: "application-resource-download-limit cannot be negative",
 		config: controller.Config{
@@ -949,9 +949,7 @@ func (s *ConfigSuite) TestMigrationMinionWaitMax(c *gc.C) {
 		testing.CACert, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	defaultDuration, err := time.ParseDuration(controller.DefaultMigrationMinionWaitMax)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cfg.MigrationMinionWaitMax(), gc.Equals, defaultDuration)
+	c.Assert(cfg.MigrationMinionWaitMax(), gc.Equals, controller.DefaultMigrationMinionWaitMax)
 
 	cfg[controller.MigrationMinionWaitMax] = "500ms"
 	c.Assert(cfg.MigrationMinionWaitMax(), gc.Equals, 500*time.Millisecond)

--- a/state/controller.go
+++ b/state/controller.go
@@ -100,6 +100,20 @@ func (st *State) UpdateControllerConfig(updateAttrs map[string]interface{}, remo
 		return errors.Trace(err)
 	}
 
+	fields, _, err := jujucontroller.ConfigSchema.ValidationSchema()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for k := range updateAttrs {
+		if field, ok := fields[k]; ok {
+			v, err := field.Coerce(updateAttrs[k], []string{k})
+			if err != nil {
+				return err
+			}
+			updateAttrs[k] = v
+		}
+	}
+
 	settings, err := readSettings(st.db(), controllersC, ControllerSettingsGlobalKey)
 	if err != nil {
 		return errors.Annotatef(err, "controller %q", st.ControllerUUID())

--- a/state/controller.go
+++ b/state/controller.go
@@ -96,28 +96,14 @@ func (st *State) ControllerConfig() (jujucontroller.Config, error) {
 // so revert to their defaults). Only a subset of keys can be changed
 // after bootstrapping.
 func (st *State) UpdateControllerConfig(updateAttrs map[string]interface{}, removeAttrs []string) error {
-	settings, err := readSettings(st.db(), controllersC, ControllerSettingsGlobalKey)
-	if err != nil {
-		return errors.Annotatef(err, "controller %q", st.ControllerUUID())
-	}
-	oldValues := settings.Map()
-	coerced, err := jujucontroller.NewConfig(
-		oldValues[jujucontroller.ControllerUUIDKey].(string),
-		oldValues[jujucontroller.CACertKey].(string),
-		updateAttrs,
-	)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	for k := range updateAttrs {
-		updateAttrs[k] = coerced[k]
-	}
-
 	if err := st.checkValidControllerConfig(updateAttrs, removeAttrs); err != nil {
 		return errors.Trace(err)
 	}
 
+	settings, err := readSettings(st.db(), controllersC, ControllerSettingsGlobalKey)
+	if err != nil {
+		return errors.Annotatef(err, "controller %q", st.ControllerUUID())
+	}
 	for _, r := range removeAttrs {
 		settings.Delete(r)
 	}

--- a/state/controller_test.go
+++ b/state/controller_test.go
@@ -4,6 +4,8 @@
 package state_test
 
 import (
+	"time"
+
 	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -108,7 +110,9 @@ func (s *ControllerSuite) TestUpdateControllerConfig(c *gc.C) {
 	err = s.State.UpdateControllerConfig(map[string]interface{}{
 		controller.AuditingEnabled:     true,
 		controller.AuditLogCaptureArgs: false,
+		controller.AuditLogMaxBackups:  "10",
 		controller.PublicDNSAddress:    "controller.test.com:1234",
+		controller.APIPortOpenDelay:    "100ms",
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -117,7 +121,9 @@ func (s *ControllerSuite) TestUpdateControllerConfig(c *gc.C) {
 
 	c.Assert(newCfg.AuditingEnabled(), gc.Equals, true)
 	c.Assert(newCfg.AuditLogCaptureArgs(), gc.Equals, false)
+	c.Assert(newCfg.AuditLogMaxBackups(), gc.Equals, 10)
 	c.Assert(newCfg.PublicDNSAddress(), gc.Equals, "controller.test.com:1234")
+	c.Assert(newCfg.APIPortOpenDelay(), gc.Equals, 100*time.Millisecond)
 }
 
 func (s *ControllerSuite) TestUpdateControllerConfigRemoveYieldsDefaults(c *gc.C) {

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -113,6 +113,7 @@ type StateBackend interface {
 	RemoveUseFloatingIPConfigFalse() error
 	CharmOriginChannelMustHaveTrack() error
 	RemoveDefaultSeriesFromModelConfig() error
+	CorrectControllerConfigDurations() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -518,4 +519,8 @@ func (s stateBackend) CharmOriginChannelMustHaveTrack() error {
 
 func (s stateBackend) RemoveDefaultSeriesFromModelConfig() error {
 	return state.RemoveDefaultSeriesFromModelConfig(s.pool)
+}
+
+func (s stateBackend) CorrectControllerConfigDurations() error {
+	return state.CorrectControllerConfigDurations(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -64,6 +64,7 @@ var stateUpgradeOperations = func() []Operation {
 		upgradeToVersion{version.MustParse("2.9.33"), stateStepsFor2933()},
 		upgradeToVersion{version.MustParse("2.9.34"), stateStepsFor2934()},
 		upgradeToVersion{version.MustParse("2.9.35"), stateStepsFor2935()},
+		upgradeToVersion{version.MustParse("2.9.39"), stateStepsFor2939()},
 	}
 	return steps
 }

--- a/upgrades/steps_2939.go
+++ b/upgrades/steps_2939.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor2939 returns database upgrade steps for Juju 2.9.39
+func stateStepsFor2939() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "correct stored durations in controller config",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().CorrectControllerConfigDurations()
+			},
+		},
+	}
+}

--- a/upgrades/steps_2939_test.go
+++ b/upgrades/steps_2939_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v2939 = version.MustParse("2.9.39")
+
+type steps2939Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps2939Suite{})
+
+func (s *steps2939Suite) TestCorrectControllerConfigDurations(c *gc.C) {
+	step := findStateStep(c, v2939, "correct stored durations in controller config")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -653,6 +653,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 		"2.9.33",
 		"2.9.34",
 		"2.9.35",
+		"2.9.39",
 	})
 }
 


### PR DESCRIPTION
Juju 2.9.38 introduced type coercion on controller config before
going over the wire or going into state. This had unexpected impact
on two of the durations in controller config.

This fix improves all handling of durations, and coerces to only basic
types laid out controller.ConfigSchema.

Introduced by https://github.com/juju/juju/pull/15016

## QA steps

- bootstrap 2.9.38
- these two commands should fail
- `juju controller-config agent-ratelimit-rate=255ms`
- `juju controller-config max-debug-log-duration=23h`
- upgrade controller to this pr
- `juju controller-config agent-ratelimit-rate=255ms`
- `juju controller-config max-debug-log-duration=23h`
- `juju controller-config agent-ratelimit-rate` should return 255ms
- `juju controller-config max-debug-log-duration=23h` should return 23h or 23h0m0s

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/2003149