### PR TITLE
Merge pull request #14860 from wallyworld/juju-content-plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,6 +129,14 @@ hooks:
   disconnect-plug-peers: {}
   post-refresh: {}
 
+slots:
+  juju-bin:
+    interface: content
+    content: juju
+    source:
+      read:
+        - $SNAP/bin
+
 plugs:
   peers:
     interface: content


### PR DESCRIPTION
This change somehow got missed previously when 3.0 merged into develop.

Add a new content interface to the snap to allow other snaps to access the juju binary.

Also remove an obsolete check for microk8s in the path.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Tested with a local microstack snap.
Shell into the snap and run juju bootstrap microk8s

## Bug reference

https://bugs.launchpad.net/juju/+bug/1990797

