### PR TITLE
[JUJU-2472] Add --integrations flag on juju-status

### DIFF
--- a/cmd/juju/status/formatted.go
+++ b/cmd/juju/status/formatted.go
@@ -21,7 +21,7 @@ type formattedStatus struct {
 	Applications       map[string]applicationStatus       `json:"applications"`
 	RemoteApplications map[string]remoteApplicationStatus `json:"application-endpoints,omitempty" yaml:"application-endpoints,omitempty"`
 	Offers             map[string]offerStatus             `json:"offers,omitempty" yaml:"offers,omitempty"`
-	Relations          []relationStatus                   `json:"-" yaml:"-"`
+	Integrations       []integrationStatus                `json:"-" yaml:"-"`
 	Storage            *storage.CombinedStorage           `json:"storage,omitempty" yaml:"storage,omitempty"`
 	Controller         *controllerStatus                  `json:"controller,omitempty" yaml:"controller,omitempty"`
 	Branches           map[string]branchStatus            `json:"branches,omitempty" yaml:"branches,omitempty"`
@@ -133,7 +133,7 @@ type applicationStatus struct {
 	Exposed          bool                  `json:"exposed" yaml:"exposed"`
 	Life             string                `json:"life,omitempty" yaml:"life,omitempty"`
 	StatusInfo       statusInfoContents    `json:"application-status,omitempty" yaml:"application-status"`
-	Relations        map[string][]string   `json:"relations,omitempty" yaml:"relations,omitempty"`
+	Integrations     map[string][]string   `json:"integrations,omitempty" yaml:"integrations,omitempty"`
 	SubordinateTo    []string              `json:"subordinate-to,omitempty" yaml:"subordinate-to,omitempty"`
 	Units            map[string]unitStatus `json:"units,omitempty" yaml:"units,omitempty"`
 	Version          string                `json:"version,omitempty" yaml:"version,omitempty"`
@@ -168,12 +168,12 @@ type remoteEndpoint struct {
 }
 
 type remoteApplicationStatus struct {
-	Err        error                     `json:"-" yaml:",omitempty"`
-	OfferURL   string                    `json:"url" yaml:"url"`
-	Endpoints  map[string]remoteEndpoint `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
-	Life       string                    `json:"life,omitempty" yaml:"life,omitempty"`
-	StatusInfo statusInfoContents        `json:"application-status,omitempty" yaml:"application-status"`
-	Relations  map[string][]string       `json:"relations,omitempty" yaml:"relations,omitempty"`
+	Err          error                     `json:"-" yaml:",omitempty"`
+	OfferURL     string                    `json:"url" yaml:"url"`
+	Endpoints    map[string]remoteEndpoint `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
+	Life         string                    `json:"life,omitempty" yaml:"life,omitempty"`
+	StatusInfo   statusInfoContents        `json:"application-status,omitempty" yaml:"application-status"`
+	Integrations map[string][]string       `json:"integrations,omitempty" yaml:"integrations,omitempty"`
 }
 
 type remoteApplicationStatusNoMarshal remoteApplicationStatus
@@ -324,7 +324,7 @@ func (s unitStatus) MarshalYAML() (interface{}, error) {
 	return unitStatusNoMarshal(s), nil
 }
 
-type relationStatus struct {
+type integrationStatus struct {
 	Provider  string
 	Requirer  string
 	Interface string

--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -110,8 +110,8 @@ func FormatTabular(writer io.Writer, forceColor bool, value interface{}) error {
 		w.Println(err.Error())
 	}
 
-	if len(fs.Relations) > 0 {
-		printRelations(tw, fs.Relations)
+	if len(fs.Integrations) > 0 {
+		printIntegrations(tw, fs.Integrations)
 	}
 
 	if fs.Storage != nil {
@@ -498,18 +498,18 @@ func printRemoteApplications(tw *ansiterm.TabWriter, remoteApplications map[stri
 	endSection(tw)
 }
 
-func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
-	sort.Slice(relations, func(i, j int) bool {
-		a, b := relations[i], relations[j]
+func printIntegrations(tw *ansiterm.TabWriter, integrations []integrationStatus) {
+	sort.Slice(integrations, func(i, j int) bool {
+		a, b := integrations[i], integrations[j]
 		if a.Provider == b.Provider {
 			return a.Requirer < b.Requirer
 		}
 		return a.Provider < b.Provider
 	})
 
-	w := startSection(tw, false, "Relation provider", "Requirer", "Interface", "Type", "Message")
+	w := startSection(tw, false, "Integration provider", "Requirer", "Interface", "Type", "Message")
 
-	for _, r := range relations {
+	for _, r := range integrations {
 		provider := strings.Split(r.Provider, ":")
 		w.PrintNoTab(provider[0]) //the service name (mysql)
 		if len(provider) > 1 {

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -64,8 +64,8 @@ type statusCommand struct {
 	color   bool
 	noColor bool
 
-	// relations indicates if 'relations' section is displayed
-	relations bool
+	// integrations indicates if 'integrations' section is displayed
+	integrations bool
 
 	// checkProvidedIgnoredFlagF indicates whether ignored options were provided by the user
 	checkProvidedIgnoredFlagF func() set.Strings
@@ -93,7 +93,7 @@ time.
 
     (<machine>|<unit>|<application>)[*]
 
-When an entity that matches <selector> is related to other applications, the 
+When an entity that matches <selector> is integrated with other applications, the 
 status of those applications will also be presented. By default (without a 
 <selector>) the status of all applications and their units will be displayed.
 
@@ -105,7 +105,7 @@ The '--format' option allows you to specify how the status report is formatted.
   --format=tabular  (default)
                     Display information about all aspects of the model in a 
                     human-centric manner. Omits some information by default.
-                    Use the '--relations' and '--storage' options to include
+                    Use the '--integrations' and '--storage' options to include
                     all available information.
 
   --format=line
@@ -135,8 +135,8 @@ Examples:
     # Report the status for applications that start with nova-
     juju status nova-*
 
-    # Include information about storage and relations in output
-    juju status --storage --relations
+    # Include information about storage and integrations in output
+    juju status --storage --integrations
 
     # Provide output as valid JSON
     juju status --format=json
@@ -174,7 +174,8 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 
 	f.BoolVar(&c.color, "color", false, "Use ANSI color codes in tabular output")
 	f.BoolVar(&c.noColor, "no-color", false, "Disable ANSI color codes in tabular output")
-	f.BoolVar(&c.relations, "relations", false, "Show 'relations' section in tabular output")
+	f.BoolVar(&c.integrations, "relations", false, "Show 'integrations' section in tabular output")
+	f.BoolVar(&c.integrations, "integrations", false, "Show 'integrations' section in tabular output")
 	f.BoolVar(&c.storage, "storage", false, "Show 'storage' section in tabular output")
 
 	f.IntVar(&c.retryCount, "retry-count", 3, "Number of times to retry API failures")
@@ -184,7 +185,7 @@ func (c *statusCommand) SetFlags(f *gnuflag.FlagSet) {
 
 	c.checkProvidedIgnoredFlagF = func() set.Strings {
 		ignoredFlagForNonTabularFormat := set.NewStrings(
-			"relations",
+			"integrations",
 			"storage",
 		)
 		provided := set.NewStrings()
@@ -328,10 +329,10 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	showRelations := c.relations
+	showIntegrations := c.integrations
 	showStorage := c.storage
 	if c.out.Name() != "tabular" {
-		showRelations = true
+		showIntegrations = true
 		showStorage = true
 		providedIgnoredFlags := c.checkProvidedIgnoredFlagF()
 		if !providedIgnoredFlags.IsEmpty() {
@@ -346,12 +347,12 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 		}
 	}
 	formatterParams := newStatusFormatterParams{
-		status:         status,
-		controllerName: controllerName,
-		outputName:     c.out.Name(),
-		isoTime:        c.isoTime,
-		showRelations:  showRelations,
-		activeBranch:   activeBranch,
+		status:           status,
+		controllerName:   controllerName,
+		outputName:       c.out.Name(),
+		isoTime:          c.isoTime,
+		showIntegrations: showIntegrations,
+		activeBranch:     activeBranch,
 	}
 	if showStorage {
 		storageInfo, err := c.getStorageInfo(ctx)

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -494,7 +494,7 @@ var (
 			"message": "somehow lost in all those logs",
 			"since":   "01 Apr 15 01:23+10:00",
 		},
-		"relations": M{
+		"integrations": M{
 			"logging-directory": L{"wordpress"},
 			"info":              L{"mysql"},
 		},
@@ -1436,7 +1436,7 @@ var statusTests = []testCase{
 				},
 				"applications": M{
 					"wordpress": wordpressCharm(M{
-						"relations": M{
+						"integrations": M{
 							"db": L{"mysql"},
 						},
 						"application-status": M{
@@ -1472,7 +1472,7 @@ var statusTests = []testCase{
 						},
 					}),
 					"mysql": mysqlCharm(M{
-						"relations": M{
+						"integrations": M{
 							"server": L{"wordpress"},
 						},
 						"application-status": M{
@@ -1547,7 +1547,7 @@ var statusTests = []testCase{
 				},
 				"applications": M{
 					"wordpress": wordpressCharm(M{
-						"relations": M{
+						"integrations": M{
 							"db": L{"mysql"},
 						},
 						"application-status": M{
@@ -1583,7 +1583,7 @@ var statusTests = []testCase{
 						},
 					}),
 					"mysql": mysqlCharm(M{
-						"relations": M{
+						"integrations": M{
 							"server": L{"wordpress"},
 						},
 						"application-status": M{
@@ -1744,7 +1744,7 @@ var statusTests = []testCase{
 			},
 		},
 	),
-	// Relation tests
+	// Integration tests
 	test( // 9
 		"complex scenario with multiple related applications",
 		addMachine{machineId: "0", job: state.JobManageModel},
@@ -1801,7 +1801,7 @@ var statusTests = []testCase{
 		relateApplications{"private", "mysql", ""},
 
 		expect{
-			what: "multiples applications with relations between some of them",
+			what: "multiples applications with integrations between some of them",
 			output: M{
 				"model": model,
 				"machines": M{
@@ -1843,7 +1843,7 @@ var statusTests = []testCase{
 							"admin-api":       network.AlphaSpaceName,
 							"cache":           network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"db":    L{"mysql"},
 							"cache": L{"varnish"},
 						},
@@ -1874,7 +1874,7 @@ var statusTests = []testCase{
 							"server-admin":   network.AlphaSpaceName,
 							"metrics-client": network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"server": L{"private", "project"},
 						},
 					}),
@@ -1909,7 +1909,7 @@ var statusTests = []testCase{
 							"":         network.AlphaSpaceName,
 							"webcache": network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"webcache": L{"project"},
 						},
 					},
@@ -1946,7 +1946,7 @@ var statusTests = []testCase{
 							"db-client":       network.AlphaSpaceName,
 							"foo-bar":         network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"db": L{"mysql"},
 						},
 					}),
@@ -2063,7 +2063,7 @@ var statusTests = []testCase{
 							"endpoint": network.AlphaSpaceName,
 							"ring":     network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"ring": L{"riak"},
 						},
 					},
@@ -2187,7 +2187,7 @@ var statusTests = []testCase{
 							"foo-bar":         network.AlphaSpaceName,
 							"logging-dir":     network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"db":          L{"mysql"},
 							"logging-dir": L{"logging"},
 						},
@@ -2235,7 +2235,7 @@ var statusTests = []testCase{
 							"server-admin":   network.AlphaSpaceName,
 							"metrics-client": network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"server":    L{"wordpress"},
 							"juju-info": L{"logging"},
 						},
@@ -2316,7 +2316,7 @@ var statusTests = []testCase{
 							"foo-bar":         network.AlphaSpaceName,
 							"logging-dir":     network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"db":          L{"mysql"},
 							"logging-dir": L{"logging"},
 						},
@@ -2364,7 +2364,7 @@ var statusTests = []testCase{
 							"server-admin":   network.AlphaSpaceName,
 							"metrics-client": network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"server":    L{"wordpress"},
 							"juju-info": L{"logging"},
 						},
@@ -2444,7 +2444,7 @@ var statusTests = []testCase{
 							"monitoring-port": network.AlphaSpaceName,
 							"url":             network.AlphaSpaceName,
 						},
-						"relations": M{
+						"integrations": M{
 							"db":          L{"mysql"},
 							"logging-dir": L{"logging"},
 						},
@@ -3381,7 +3381,7 @@ var statusTests = []testCase{
 							"current": "unknown",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"relations": M{
+						"integrations": M{
 							"server": L{"wordpress"},
 						},
 					},
@@ -3393,7 +3393,7 @@ var statusTests = []testCase{
 							"message": "waiting for machine",
 							"since":   "01 Apr 15 01:23+10:00",
 						},
-						"relations": M{
+						"integrations": M{
 							"db": L{"hosted-mysql"},
 						},
 						"units": M{
@@ -5165,16 +5165,16 @@ Machine  State    Address   Inst id       Base          AZ          Message
 Offer         Application  Charm  Rev  Connected  Endpoint  Interface  Role
 hosted-mysql  mysql        mysql  1    1/1        server    mysql      provider
 
-Relation provider      Requirer                   Interface  Type         Message
-mysql:juju-info        logging:info               juju-info  subordinate  
-mysql:server           wordpress:db               mysql      regular      suspended  
-wordpress:logging-dir  logging:logging-directory  logging    subordinate  
+Integration provider      Requirer                   Interface  Type         Message
+mysql:juju-info           logging:info               juju-info  subordinate  
+mysql:server              wordpress:db               mysql      regular      suspended  
+wordpress:logging-dir     logging:logging-directory  logging    subordinate  
 `[1:]
 
 func (s *StatusSuite) TestStatusWithFormatTabular(c *gc.C) {
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
-	code, stdout, stderr := runStatus(c, "--no-color", "--format", "tabular", "--relations")
+	code, stdout, stderr := runStatus(c, "--no-color", "--format", "tabular", "--integrations")
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 
@@ -5187,7 +5187,7 @@ func (s *StatusSuite) TestStatusWithFormatTabularValidModelUUID(c *gc.C) {
 	ctx := s.prepareTabularData(c)
 	defer s.resetContext(c, ctx)
 
-	code, stdout, stderr := runStatus(c, "--no-color", "--format", "tabular", "--relations", "-m", s.Model.UUID())
+	code, stdout, stderr := runStatus(c, "--no-color", "--format", "tabular", "--integrations", "-m", s.Model.UUID())
 	c.Check(code, gc.Equals, 0)
 	c.Check(string(stderr), gc.Equals, "")
 
@@ -5618,7 +5618,7 @@ func (s *StatusSuite) TestFormatTabularTruncateMessage(c *gc.C) {
 				},
 			},
 		},
-		Relations: []relationStatus{
+		Integrations: []integrationStatus{
 			{
 				Provider:  "foo:cluster",
 				Requirer:  "bar:cluster",
@@ -5653,8 +5653,8 @@ Machine  State   Address       Inst id  Base          AZ  Message
 0        active  10.53.62.100           ubuntu@22.04      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a...
 0/lxd/0  active  10.53.62.101           ubuntu@22.04      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a...
 
-Relation provider  Requirer     Interface  Type  Message
-foo:cluster        bar:cluster  baz                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a...
+Integration provider  Requirer     Interface  Type  Message
+foo:cluster           bar:cluster  baz                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna a...
 `[1:])
 }
 
@@ -6385,32 +6385,32 @@ func (s *StatusSuite) TestControllerTimestampInFullStatus(c *gc.C) {
 	})
 }
 
-func (s *StatusSuite) TestTabularNoRelations(c *gc.C) {
+func (s *StatusSuite) TestTabularNoIntegrations(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
 	_, stdout, stderr := runStatus(c, "--no-color")
 	c.Assert(stderr, gc.IsNil)
-	c.Assert(strings.Contains(string(stdout), "Relation provider"), jc.IsFalse)
+	c.Assert(strings.Contains(string(stdout), "Integration provider"), jc.IsFalse)
 }
 
-func (s *StatusSuite) TestTabularDisplayRelations(c *gc.C) {
+func (s *StatusSuite) TestTabularDisplayIntegrations(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--no-color", "--relations")
+	_, stdout, stderr := runStatus(c, "--no-color", "--integrations")
 	c.Assert(stderr, gc.IsNil)
-	c.Assert(strings.Contains(string(stdout), "Relation provider"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "Integration provider"), jc.IsTrue)
 }
 
-func (s *StatusSuite) TestNonTabularDisplayRelations(c *gc.C) {
+func (s *StatusSuite) TestNonTabularDisplayIntegrations(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml", "--relations")
-	c.Assert(string(stderr), gc.Equals, "provided relations option is always enabled in non tabular formats\n")
+	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml", "--integrations")
+	c.Assert(string(stderr), gc.Equals, "provided integrations option is always enabled in non tabular formats\n")
 	logger.Debugf("stdout -> \n%q", stdout)
-	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "    integrations:"), jc.IsTrue)
 	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
 }
 
@@ -6420,27 +6420,27 @@ func (s *StatusSuite) TestNonTabularDisplayStorage(c *gc.C) {
 
 	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml", "--storage")
 	c.Assert(string(stderr), gc.Equals, "provided storage option is always enabled in non tabular formats\n")
-	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "    integrations:"), jc.IsTrue)
 	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
 }
 
-func (s *StatusSuite) TestNonTabularDisplayRelationsAndStorage(c *gc.C) {
+func (s *StatusSuite) TestNonTabularDisplayIntegrationsAndStorage(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
-	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml", "--relations", "--storage")
-	c.Assert(string(stderr), gc.Equals, "provided relations, storage options are always enabled in non tabular formats\n")
-	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml", "--integrations", "--storage")
+	c.Assert(string(stderr), gc.Equals, "provided integrations, storage options are always enabled in non tabular formats\n")
+	c.Assert(strings.Contains(string(stdout), "    integrations:"), jc.IsTrue)
 	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
 }
 
-func (s *StatusSuite) TestNonTabularRelations(c *gc.C) {
+func (s *StatusSuite) TestNonTabularIntegrations(c *gc.C) {
 	ctx := s.FilteringTestSetup(c)
 	defer s.resetContext(c, ctx)
 
 	_, stdout, stderr := runStatus(c, "--no-color", "--format=yaml")
 	c.Assert(stderr, gc.IsNil)
-	c.Assert(strings.Contains(string(stdout), "    relations:"), jc.IsTrue)
+	c.Assert(strings.Contains(string(stdout), "    integrations:"), jc.IsTrue)
 	c.Assert(strings.Contains(string(stdout), "storage:"), jc.IsTrue)
 }
 

--- a/tests/includes/wait-for.sh
+++ b/tests/includes/wait-for.sh
@@ -23,7 +23,7 @@ wait_for() {
 	# shellcheck disable=SC2046,SC2143
 	until [[ "$(juju status --format=json 2>/dev/null | jq -S "${query}" | grep "${name}")" ]]; do
 		echo "[+] (attempt ${attempt}) polling status for" "${query} => ${name}"
-		juju status --relations 2>&1 | sed 's/^/    | /g'
+		juju status --integrations 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
 
 		elapsed=$(date -u +%s)-$start_time
@@ -37,7 +37,7 @@ wait_for() {
 
 	if [[ ${attempt} -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling status for')" "$(green "${name}")"
-		juju status --relations 2>&1 | sed 's/^/    | /g'
+		juju status --integrations 2>&1 | sed 's/^/    | /g'
 		# Although juju reports as an idle condition, some charms require a
 		# breathe period to ensure things have actually settled.
 		sleep "${SHORT_TIMEOUT}"


### PR DESCRIPTION
When trying to "integrate" 2 times in a row, juju complains like this:
```
$ juju integrate lxd overlord:admin/cos.grafana-dashboards
ERROR cannot add relation "grafana-dashboards:grafana-dashboard lxd:grafana-dashboard"
relation grafana-dashboards:grafana-dashboard lxd:grafana-dashboard (already exists):

Use 'juju status --integrations' to view the current integrations.
```
This `--integrations` flag doesn't exist, so this PR adds it. 

_Note: we keep the `--relations` flag at least for a minor version as proposed by @jameinel._
## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

On a properly bootstrapped controller, with 2 applications that are integrated (for example following https://juju.is/docs/olm/get-started-with-juju and deploying PostgreSQL+Mattermost and integrate them)

```sh
juju status --integrations
```

Then the default (tabular) output should contain the integrations list at the end.

_Note: I also replaced the wording on the tabular output (for example, from the tests):_
```
Integration provider      Requirer                   Interface  Type         Message
mysql:juju-info           logging:info               juju-info  subordinate  
mysql:server              wordpress:db               mysql      regular      suspended  
wordpress:logging-dir     logging:logging-directory  logging    subordinate  
```
## Documentation changes

The `status` command now has a `--integrations` flag (we also keep `--relations`). Also, all the output formats contain the "Integration" wording (`Integration provider` in tabular, `integrations` in yaml and json).

## Bug reference

https://bugs.launchpad.net/juju/+bug/1999271