### PR TITLE
[JUJU-2506] autocompletion of channel in empty model

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -387,7 +387,7 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 		// A change was made in cmd/v3.0.2 output.go that broke the consistency in output for the
 		// default formatter by removing the newline delimiter. Hence we prefix '\n' in the text below.
 		// https://github.com/juju/cmd/commit/be22fa661a798055c801f1511aee226db249ef95
-		_, _ = fmt.Fprintf(ctx.Stdout, "\nModel %q is empty.\n", modelName)
+		ctx.Infof("\nModel %q is empty.", modelName)
 	} else {
 		plural := func() string {
 			if len(c.patterns) == 1 {
@@ -395,7 +395,7 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 			}
 			return "s"
 		}
-		_, _ = fmt.Fprintf(ctx.Stdout, "Nothing matched specified filter%v.", plural())
+		ctx.Infof("Nothing matched specified filter%v.", plural())
 	}
 
 	return nil

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -387,7 +387,7 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 		// A change was made in cmd/v3.0.2 output.go that broke the consistency in output for the
 		// default formatter by removing the newline delimiter. Hence we prefix '\n' in the text below.
 		// https://github.com/juju/cmd/commit/be22fa661a798055c801f1511aee226db249ef95
-		ctx.Infof("\nModel %q is empty.", modelName)
+		_, _ = fmt.Fprintf(ctx.Stdout, "\nModel %q is empty.\n", modelName)
 	} else {
 		plural := func() string {
 			if len(c.patterns) == 1 {
@@ -395,7 +395,7 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 			}
 			return "s"
 		}
-		ctx.Infof("Nothing matched specified filter%v.", plural())
+		_, _ = fmt.Fprintf(ctx.Stdout, "Nothing matched specified filter%v.", plural())
 	}
 
 	return nil

--- a/etc/bash_completion.d/juju
+++ b/etc/bash_completion.d/juju
@@ -119,7 +119,7 @@ _JUJU_2_juju_status_cache_fname() {
     local model=$(_get_current_model)
     local juju_status_file=${cache_dir}/juju-status-"${model}"
     _JUJU_2_cache_cmd ${_JUJU_2_cache_TTL} \
-      echo ${_juju_cmd_JUJU_2?} status --model "${model}" --format json
+      echo ${_juju_cmd_JUJU_2?} status --model "${model}" --format json 2>/dev/null
     return $?
 }
 # Print (return) all machines


### PR DESCRIPTION
This PR fixed the bug with auto-completion. The details are in the bug [report](https://bugs.launchpad.net/juju/+bug/1993517).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
juju boostap lxd lxd
juju add-model m
juju deploy tiny-bash --ch
# Press TAB-button twice
```

## Documentation changes

Nope

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993517