### PR TITLE
Fix error message when trying to integrate 2 times in a row

### DIFF
--- a/cmd/juju/application/integrate.go
+++ b/cmd/juju/application/integrate.go
@@ -293,7 +293,7 @@ func (c *addRelationCommand) Run(ctx *cmd.Context) error {
 		splitError := strings.Join(strings.Split(err.Error(), ": "), "\n")
 		infoErr := errors.Errorf(`
 
-Use 'juju status --integrations' to view the current integrations.`)
+Use 'juju status --relations' to view the current relations.`)
 		return errors.Annotatef(infoErr, splitError)
 	}
 	if err != nil {

--- a/featuretests/cmd_juju_relation_test.go
+++ b/featuretests/cmd_juju_relation_test.go
@@ -42,7 +42,7 @@ func (s *CmdRelationSuite) TestAddRelationSuccessOnAlreadyExists(c *gc.C) {
 	c.Check(cmdtesting.Stderr(context), jc.Contains, `ERROR cannot add relation "wordpress:db mysql:server"
 relation wordpress:db mysql:server (already exists): 
 
-Use 'juju status --integrations' to view the current integrations.
+Use 'juju status --relations' to view the current relations.
 `)
 }
 


### PR DESCRIPTION
When trying to "integrate" 2 times in a row, juju complains like this:
```
$ juju integrate lxd overlord:admin/cos.grafana-dashboards
ERROR cannot add relation "grafana-dashboards:grafana-dashboard lxd:grafana-dashboard"
relation grafana-dashboards:grafana-dashboard lxd:grafana-dashboard (already exists):

Use 'juju status --integrations' to view the current integrations.
```
This `--integrations` flag doesn't exist, so this PR fixes this error message.

_Note: [this PR](https://github.com/juju/juju/pull/15066) adds the `--integrations` flag to `status`, but it is on hold and must not yet be merged._

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run the same `juju integrate ...` twice (no matter which apps you're integrating), the second time you'll get:

```sh
$ juju integrate prometheus2:grafana-source grafana:grafana-source

ERROR cannot add relation "grafana:grafana-source prometheus2:grafana-source"
relation grafana:grafana-source prometheus2:grafana-source (already exists):

Use 'juju status --relations' to view the current relations.
```

Instead of:

```sh
$ juju integrate prometheus2:grafana-source grafana:grafana-source

ERROR cannot add relation "grafana:grafana-source prometheus2:grafana-source"
relation grafana:grafana-source prometheus2:grafana-source (already exists):

Use 'juju status --integrations' to view the current integrations.
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1999271