### PR TITLE
[JUJU-2482] Allow consuming of related changes

### DIFF
--- a/worker/storageprovisioner/export_test.go
+++ b/worker/storageprovisioner/export_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 var (
-	NewManagedFilesystemSource = &newManagedFilesystemSource
+	NewManagedFilesystemSource     = &newManagedFilesystemSource
+	DefaultDependentChangesTimeout = &defaultDependentChangesTimeout
 )
 
 func StorageWorker(parent worker.Worker, appName string) (worker.Worker, bool) {

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -332,11 +332,12 @@ func newMockVolumeAccessor() *mockVolumeAccessor {
 
 type mockFilesystemAccessor struct {
 	testing.Stub
-	filesystemsWatcher     *mockStringsWatcher
-	attachmentsWatcher     *mockAttachmentsWatcher
-	provisionedMachines    map[string]instance.Id
-	provisionedFilesystems map[string]params.Filesystem
-	provisionedAttachments map[params.MachineStorageId]params.FilesystemAttachment
+	filesystemsWatcher             *mockStringsWatcher
+	attachmentsWatcher             *mockAttachmentsWatcher
+	provisionedMachines            map[string]instance.Id
+	provisionedMachinesFilesystems map[string]params.Filesystem
+	provisionedFilesystems         map[string]params.Filesystem
+	provisionedAttachments         map[params.MachineStorageId]params.FilesystemAttachment
 
 	setFilesystemInfo           func([]params.Filesystem) ([]params.ErrorResult, error)
 	setFilesystemAttachmentInfo func([]params.FilesystemAttachment) ([]params.ErrorResult, error)
@@ -437,8 +438,10 @@ func (f *mockFilesystemAccessor) FilesystemAttachmentParams(ids []params.Machine
 		// Parameters are returned regardless of whether the attachment
 		// exists; this is to support reattachment.
 		instanceId := f.provisionedMachines[id.MachineTag]
+		filesystemId := f.provisionedMachinesFilesystems[id.AttachmentTag].Info.FilesystemId
 		result = append(result, params.FilesystemAttachmentParamsResult{Result: params.FilesystemAttachmentParams{
 			MachineTag:    id.MachineTag,
+			FilesystemId:  filesystemId,
 			FilesystemTag: id.AttachmentTag,
 			InstanceId:    string(instanceId),
 			Provider:      "dummy",
@@ -464,11 +467,12 @@ func (f *mockFilesystemAccessor) SetFilesystemAttachmentInfo(filesystemAttachmen
 
 func newMockFilesystemAccessor() *mockFilesystemAccessor {
 	return &mockFilesystemAccessor{
-		filesystemsWatcher:     newMockStringsWatcher(),
-		attachmentsWatcher:     newMockAttachmentsWatcher(),
-		provisionedMachines:    make(map[string]instance.Id),
-		provisionedFilesystems: make(map[string]params.Filesystem),
-		provisionedAttachments: make(map[params.MachineStorageId]params.FilesystemAttachment),
+		filesystemsWatcher:             newMockStringsWatcher(),
+		attachmentsWatcher:             newMockAttachmentsWatcher(),
+		provisionedMachines:            make(map[string]instance.Id),
+		provisionedFilesystems:         make(map[string]params.Filesystem),
+		provisionedMachinesFilesystems: make(map[string]params.Filesystem),
+		provisionedAttachments:         make(map[params.MachineStorageId]params.FilesystemAttachment),
 	}
 }
 

--- a/worker/storageprovisioner/storageprovisioner_test.go
+++ b/worker/storageprovisioner/storageprovisioner_test.go
@@ -57,6 +57,7 @@ func (s *storageProvisionerSuite) SetUpTest(c *gc.C) {
 			return s.managedFilesystemSource
 		},
 	)
+	s.PatchValue(storageprovisioner.DefaultDependentChangesTimeout, 10*time.Millisecond)
 }
 
 func (s *storageProvisionerSuite) TestStartStop(c *gc.C) {
@@ -2121,6 +2122,7 @@ func (s *caasStorageProvisionerSuite) SetUpTest(c *gc.C) {
 			"dummy": s.provider,
 		},
 	}
+	s.PatchValue(storageprovisioner.DefaultDependentChangesTimeout, 10*time.Millisecond)
 }
 
 func (s *caasStorageProvisionerSuite) TestDetachVolumesUnattached(c *gc.C) {


### PR DESCRIPTION
The following changes make attaching a filesysystem more reliable after a machine restart.

When a machine is restarted the order of changes from the watchers are not guaranteed to be executed. Such that the go select case semantics actually forces a shuffle if there a multiple select cases with buffered channel values. This exacerbated when the machine is restarted and relaunching the agent will get all the initial values from the all the watchers. As this is random, it wasn't always obvious when this might happen. It depends on the number of select case statements with values and only if filesystem changes happens after filesystem attachment changes. So if a filesystem changes is in a different order, but is before filesystem attachment changes then you wouldn't see the filesystem attachment issue.

The fix here is to consume any relational dependant changes before working on child changes. As filesystem changes can be processed all at once before processing the round of attachments, the change should ensure an normalised ordering.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


```sh
$ juju bootstrap lxd test
$ juju deploy postgresql --channel edge
$ juju ssh postgresql/0
$ lsblk | grep /var/lib/postgresql/data
└─nvme0n1p2 259:2    0 465.3G  0 part /var/lib/postgresql/data
```

The following needs to be retried multiple times to ensure it works, as it's non-deterministic.

```
$ juju show-machine 0 --format=json | jq -r '.machines["0"].hostname' | xargs -I% lxc restart %
$ juju ssh postgresql/0
$ lsblk | grep /var/lib/postgresql/data
└─nvme0n1p2 259:2    0 465.3G  0 part /var/lib/postgresql/data
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1999758
