### PR TITLE
[JUJU-2516] Fix permission error when removing a vault secret

### DIFF
--- a/apiserver/facades/agent/secretsmanager/package_test.go
+++ b/apiserver/facades/agent/secretsmanager/package_test.go
@@ -37,6 +37,7 @@ func NewTestAPI(
 	consumer SecretsConsumer,
 	secretTriggers SecretTriggers,
 	backendConfigGetter commonsecrets.BackendConfigGetter,
+	adminConfigGetter commonsecrets.BackendConfigGetter,
 	authTag names.Tag,
 	clock clock.Clock,
 ) (*SecretsManagerAPI, error) {
@@ -52,6 +53,7 @@ func NewTestAPI(
 		secretsConsumer:     consumer,
 		secretsTriggers:     secretTriggers,
 		backendConfigGetter: backendConfigGetter,
+		adminConfigGetter:   adminConfigGetter,
 		clock:               clock,
 	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -39,6 +39,14 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		}
 		return secrets.BackendConfigInfo(secrets.SecretsModel(model), context.Auth().GetAuthTag(), leadershipChecker)
 	}
+	secretBackendAdminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+		model, err := context.State().Model()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		cfg, _, err := secrets.AdminBackendConfigInfo(secrets.SecretsModel(model))
+		return cfg, errors.Trace(err)
+	}
 	return &SecretsManagerAPI{
 		authTag:             context.Auth().GetAuthTag(),
 		leadershipChecker:   leadershipChecker,
@@ -48,5 +56,6 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		secretsConsumer:     context.State(),
 		clock:               clock.WallClock,
 		backendConfigGetter: secretBackendConfigGetter,
+		adminConfigGetter:   secretBackendAdminConfigGetter,
 	}, nil
 }

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -41,6 +41,7 @@ type SecretsManagerAPI struct {
 	clock             clock.Clock
 
 	backendConfigGetter commonsecrets.BackendConfigGetter
+	adminConfigGetter   commonsecrets.BackendConfigGetter
 }
 
 // GetSecretStoreConfig is for 3.0.x agents.
@@ -249,7 +250,7 @@ func (s *SecretsManagerAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.
 		return result, nil
 	}
 
-	cfgInfo, err := s.backendConfigGetter()
+	cfgInfo, err := s.adminConfigGetter()
 	if err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -90,10 +90,23 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 			},
 		}, nil
 	}
+	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
+		return &provider.ModelBackendConfigInfo{
+			ControllerUUID: coretesting.ControllerTag.Id(),
+			ModelUUID:      coretesting.ModelTag.Id(),
+			ModelName:      "fred",
+			Configs: map[string]provider.BackendConfig{
+				"backend-id": {
+					BackendType: "some-backend",
+					Config:      map[string]interface{}{"foo": "admin"},
+				},
+			},
+		}, nil
+	}
 	var err error
 	s.facade, err = secretsmanager.NewTestAPI(
 		s.authorizer, s.resources, s.leadership, s.secretsState, s.secretsConsumer, s.secretTriggers,
-		backendConfigGetter, s.authTag, s.clock)
+		backendConfigGetter, adminConfigGetter, s.authTag, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return ctrl
@@ -394,7 +407,7 @@ func (s *SecretsManagerSuite) TestRemoveSecrets(c *gc.C) {
 		ModelName:      "fred",
 		BackendConfig: provider.BackendConfig{
 			BackendType: "some-backend",
-			Config:      map[string]interface{}{"foo": "bar"},
+			Config:      map[string]interface{}{"foo": "admin"},
 		},
 	}
 	s.provider.EXPECT().CleanupSecrets(


### PR DESCRIPTION
This is a small fix for removing vault secrets.
In the final cleanup step to remove any policies for the secret, we were using an attenuated token instead of the admin token, resulting in a permission error.

## QA steps

Add a vault backend to a model
In a charm hook, create a secret, then delete the secret. Before this change, there would be an error
```
URL: GET http://10.0.0.77:8200/v1/sys/policies/acl?list=true
Code: 403. Errors:

* 1 error occurred:
        * permission denied
```


## Bug reference

https://bugs.launchpad.net/juju/+bug/1999752
