### PR TITLE
[JUJU-2518] Add show-secret-backend CLI command

### DIFF
--- a/api/client/secretbackends/client.go
+++ b/api/client/secretbackends/client.go
@@ -38,10 +38,10 @@ type SecretBackend struct {
 	Error               error
 }
 
-// ListSecretBackends lists the available secret backends.
-func (api *Client) ListSecretBackends(reveal bool) ([]SecretBackend, error) {
+// ListSecretBackends lists the specified secret backends, or all available if no names are provided.
+func (api *Client) ListSecretBackends(names []string, reveal bool) ([]SecretBackend, error) {
 	var response params.ListSecretBackendsResults
-	err := api.facade.FacadeCall("ListSecretBackends", params.ListSecretBackendsArgs{Reveal: reveal}, &response)
+	err := api.facade.FacadeCall("ListSecretBackends", params.ListSecretBackendsArgs{Names: names, Reveal: reveal}, &response)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/client/secretbackends/client_test.go
+++ b/api/client/secretbackends/client_test.go
@@ -41,7 +41,7 @@ func (s *SecretBackendsSuite) TestListSecretBackends(c *gc.C) {
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
 		c.Check(request, gc.Equals, "ListSecretBackends")
-		c.Check(arg, jc.DeepEquals, params.ListSecretBackendsArgs{Reveal: true})
+		c.Check(arg, jc.DeepEquals, params.ListSecretBackendsArgs{Names: []string{"myvault"}, Reveal: true})
 		c.Assert(result, gc.FitsTypeOf, &params.ListSecretBackendsResults{})
 		*(result.(*params.ListSecretBackendsResults)) = params.ListSecretBackendsResults{
 			[]params.SecretBackendResult{{
@@ -60,7 +60,7 @@ func (s *SecretBackendsSuite) TestListSecretBackends(c *gc.C) {
 		return nil
 	})
 	client := secretbackends.NewClient(apiCaller)
-	result, err := client.ListSecretBackends(true)
+	result, err := client.ListSecretBackends([]string{"myvault"}, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []secretbackends.SecretBackend{{
 		Name:                "foo",

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -981,7 +981,7 @@ func (m *ModelManagerAPI) getModelInfo(tag names.ModelTag, withSecrets bool) (pa
 	}
 	if withSecrets && canSeeMachinesAndSecrets {
 		if info.SecretBackends, err = commonsecrets.BackendSummaryInfo(
-			m.state, st, st, st.ControllerUUID(), false, false,
+			m.state, st, st, st.ControllerUUID(), false, commonsecrets.BackendFilter{},
 		); shouldErr(err) {
 			return params.ModelInfo{}, err
 		}

--- a/apiserver/facades/client/secretbackends/secrets.go
+++ b/apiserver/facades/client/secretbackends/secrets.go
@@ -177,7 +177,8 @@ func (s *SecretBackendsAPI) ListSecretBackends(arg params.ListSecretBackendsArgs
 		}
 	}
 
-	results, err := commonsecrets.BackendSummaryInfo(s.statePool, s.backendState, s.secretState, s.controllerUUID, arg.Reveal, true)
+	results, err := commonsecrets.BackendSummaryInfo(
+		s.statePool, s.backendState, s.secretState, s.controllerUUID, arg.Reveal, commonsecrets.BackendFilter{Names: arg.Names, All: true})
 	if err != nil {
 		return params.ListSecretBackendsResults{}, errors.Trace(err)
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -38680,12 +38680,19 @@
                 "ListSecretBackendsArgs": {
                     "type": "object",
                     "properties": {
+                        "names": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "reveal": {
                             "type": "boolean"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
+                        "names",
                         "reveal"
                     ]
                 },

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -572,6 +572,7 @@ func registerCommands(r commandRegistry) {
 	r.Register(secretbackends.NewAddSecretBackendCommand())
 	r.Register(secretbackends.NewUpdateSecretBackendCommand())
 	r.Register(secretbackends.NewRemoveSecretBackendCommand())
+	r.Register(secretbackends.NewShowSecretBackendCommand())
 
 	// Payload commands.
 	r.Register(payload.NewListCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -435,6 +435,7 @@ var commandNames = []string{
 	"show-offer",
 	"show-operation",
 	"show-secret",
+	"show-secret-backend",
 	"show-status-log",
 	"show-storage",
 	"show-space",

--- a/cmd/juju/secretbackends/add.go
+++ b/cmd/juju/secretbackends/add.go
@@ -57,6 +57,7 @@ Examples:
 See also:
     list-secret-backends
     remove-secret-backend
+    show-secret-backend
     update-secret-backend
 `
 

--- a/cmd/juju/secretbackends/list.go
+++ b/cmd/juju/secretbackends/list.go
@@ -40,12 +40,13 @@ Examples:
 See also:
     add-secret-backend
     remove-secret-backend
+    show-secret-backend
     update-secret-backend
 `
 
 // ListSecretBackendsAPI is the secrets client API.
 type ListSecretBackendsAPI interface {
-	ListSecretBackends(bool) ([]secretbackends.SecretBackend, error)
+	ListSecretBackends([]string, bool) ([]secretbackends.SecretBackend, error)
 	Close() error
 }
 
@@ -115,7 +116,7 @@ func (c *listSecretBackendsCommand) Run(ctxt *cmd.Context) error {
 	}
 	defer api.Close()
 
-	result, err := api.ListSecretBackends(c.revealSecrets)
+	result, err := api.ListSecretBackends(nil, c.revealSecrets)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/secretbackends/list_test.go
+++ b/cmd/juju/secretbackends/list_test.go
@@ -52,7 +52,7 @@ func ptr[T any](v T) *T {
 func (s *ListSuite) TestListTabular(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.secretBackendsAPI.EXPECT().ListSecretBackends(false).Return(
+	s.secretBackendsAPI.EXPECT().ListSecretBackends(nil, false).Return(
 		[]apisecretbackends.SecretBackend{{
 			Name:                "myvault",
 			BackendType:         "vault",
@@ -85,7 +85,7 @@ myvault   vault       666      error: vault is sealed
 func (s *ListSuite) TestListYAML(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.secretBackendsAPI.EXPECT().ListSecretBackends(true).Return(
+	s.secretBackendsAPI.EXPECT().ListSecretBackends(nil, true).Return(
 		[]apisecretbackends.SecretBackend{{
 			ID:                  "vault-id",
 			Name:                "myvault",
@@ -136,7 +136,7 @@ myvault:
 func (s *ListSuite) TestListJSON(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.secretBackendsAPI.EXPECT().ListSecretBackends(true).Return(
+	s.secretBackendsAPI.EXPECT().ListSecretBackends(nil, true).Return(
 		[]apisecretbackends.SecretBackend{{
 			Name:        "internal",
 			BackendType: "controller",

--- a/cmd/juju/secretbackends/mocks/secretbackendsapi.go
+++ b/cmd/juju/secretbackends/mocks/secretbackendsapi.go
@@ -49,18 +49,18 @@ func (mr *MockListSecretBackendsAPIMockRecorder) Close() *gomock.Call {
 }
 
 // ListSecretBackends mocks base method.
-func (m *MockListSecretBackendsAPI) ListSecretBackends(arg0 bool) ([]secretbackends.SecretBackend, error) {
+func (m *MockListSecretBackendsAPI) ListSecretBackends(arg0 []string, arg1 bool) ([]secretbackends.SecretBackend, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSecretBackends", arg0)
+	ret := m.ctrl.Call(m, "ListSecretBackends", arg0, arg1)
 	ret0, _ := ret[0].([]secretbackends.SecretBackend)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSecretBackends indicates an expected call of ListSecretBackends.
-func (mr *MockListSecretBackendsAPIMockRecorder) ListSecretBackends(arg0 interface{}) *gomock.Call {
+func (mr *MockListSecretBackendsAPIMockRecorder) ListSecretBackends(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretBackends", reflect.TypeOf((*MockListSecretBackendsAPI)(nil).ListSecretBackends), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretBackends", reflect.TypeOf((*MockListSecretBackendsAPI)(nil).ListSecretBackends), arg0, arg1)
 }
 
 // MockAddSecretBackendsAPI is a mock of AddSecretBackendsAPI interface.

--- a/cmd/juju/secretbackends/package_test.go
+++ b/cmd/juju/secretbackends/package_test.go
@@ -26,6 +26,15 @@ func NewListCommandForTest(store jujuclient.ClientStore, listSecretsAPI ListSecr
 	return c
 }
 
+// NewShowCommandForTest returns a show secret backend command for testing.
+func NewShowCommandForTest(store jujuclient.ClientStore, showSecretsAPI ListSecretBackendsAPI) *showSecretBackendCommand {
+	c := &showSecretBackendCommand{
+		ShowSecretBackendsAPIFunc: func() (ShowSecretBackendsAPI, error) { return showSecretsAPI, nil },
+	}
+	c.SetClientStore(store)
+	return c
+}
+
 // NewAddCommandForTest returns an add secret backends command for testing.
 func NewAddCommandForTest(store jujuclient.ClientStore, addSecretBackendsAPI AddSecretBackendsAPI) *addSecretBackendCommand {
 	c := &addSecretBackendCommand{

--- a/cmd/juju/secretbackends/remove.go
+++ b/cmd/juju/secretbackends/remove.go
@@ -37,6 +37,8 @@ Examples:
 See also:
     add-secret-backend
     list-secret-backends
+    show-secret-backend
+    update-secret-backend
 `
 
 // RemoveSecretBackendsAPI is the secrets client API.

--- a/cmd/juju/secretbackends/show.go
+++ b/cmd/juju/secretbackends/show.go
@@ -1,0 +1,105 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretbackends
+
+import (
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+
+	"github.com/juju/juju/api/client/secretbackends"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/cmd/output"
+)
+
+type showSecretBackendCommand struct {
+	modelcmd.ControllerCommandBase
+	out cmd.Output
+
+	ShowSecretBackendsAPIFunc func() (ShowSecretBackendsAPI, error)
+	backendName               string
+	revealSecrets             bool
+}
+
+var showSecretBackendsDoc = `
+Displays the specified secret backend.
+
+Examples:
+    juju show-secret-backend myvault
+    juju secret-backends myvault --reveal
+
+See also:
+    add-secret-backend
+    list-secret-backends
+    remove-secret-backend
+    update-secret-backend
+`
+
+// ShowSecretBackendsAPI is the secrets client API.
+type ShowSecretBackendsAPI interface {
+	ListSecretBackends([]string, bool) ([]secretbackends.SecretBackend, error)
+	Close() error
+}
+
+// NewShowSecretBackendCommand returns a command to show a secrets backend.
+func NewShowSecretBackendCommand() cmd.Command {
+	c := &showSecretBackendCommand{}
+	c.ShowSecretBackendsAPIFunc = c.secretBackendsAPI
+
+	return modelcmd.WrapController(c)
+}
+
+func (c *showSecretBackendCommand) secretBackendsAPI() (ShowSecretBackendsAPI, error) {
+	root, err := c.NewAPIRoot()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return secretbackends.NewClient(root), nil
+
+}
+
+// Info implements cmd.Info.
+func (c *showSecretBackendCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "show-secret-backend",
+		Purpose: "Displays the specified secret backend.",
+		Doc:     showSecretBackendsDoc,
+	})
+}
+
+// SetFlags implements cmd.SetFlags.
+func (c *showSecretBackendCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&c.revealSecrets, "reveal", false, "Include sensitive backend config content")
+	c.out.AddFlags(f, "yaml", output.DefaultFormatters)
+}
+
+// Init implements cmd.Init.
+func (c *showSecretBackendCommand) Init(args []string) error {
+	if len(args) < 1 {
+		return errors.New("must specify backend name")
+	}
+	c.backendName = args[0]
+	return cmd.CheckEmpty(args[1:])
+}
+
+// Run implements cmd.Run.
+func (c *showSecretBackendCommand) Run(ctxt *cmd.Context) error {
+	api, err := c.ShowSecretBackendsAPIFunc()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer api.Close()
+
+	result, err := api.ListSecretBackends([]string{c.backendName}, c.revealSecrets)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	details := gatherSecretBackendInfo(result)
+	if len(details) == 0 {
+		ctxt.Infof("no secret backends have been added to this controller\n")
+		return nil
+	}
+	return c.out.Write(ctxt, details)
+}

--- a/cmd/juju/secretbackends/show_test.go
+++ b/cmd/juju/secretbackends/show_test.go
@@ -1,0 +1,77 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretbackends_test
+
+import (
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/juju/cmd/v3/cmdtesting"
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apisecretbackends "github.com/juju/juju/api/client/secretbackends"
+	"github.com/juju/juju/cmd/juju/secretbackends"
+	"github.com/juju/juju/cmd/juju/secretbackends/mocks"
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/jujuclient"
+)
+
+type ShowSuite struct {
+	jujutesting.IsolationSuite
+	store             *jujuclient.MemStore
+	secretBackendsAPI *mocks.MockListSecretBackendsAPI
+}
+
+var _ = gc.Suite(&ShowSuite{})
+
+func (s *ShowSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	store := jujuclient.NewMemStore()
+	store.Controllers["mycontroller"] = jujuclient.ControllerDetails{}
+	store.CurrentControllerName = "mycontroller"
+	s.store = store
+}
+
+func (s *ShowSuite) setup(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+
+	s.secretBackendsAPI = mocks.NewMockListSecretBackendsAPI(ctrl)
+
+	return ctrl
+}
+
+func (s *ShowSuite) TestShowYAML(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.secretBackendsAPI.EXPECT().ListSecretBackends([]string{"myvault"}, true).Return(
+		[]apisecretbackends.SecretBackend{{
+			ID:                  "vault-id",
+			Name:                "myvault",
+			BackendType:         "vault",
+			TokenRotateInterval: ptr(666 * time.Minute),
+			Config:              map[string]interface{}{"endpoint": "http://vault"},
+			NumSecrets:          666,
+			Status:              status.Error,
+			Message:             "vault is sealed",
+		}}, nil)
+
+	s.secretBackendsAPI.EXPECT().Close().Return(nil)
+
+	ctx, err := cmdtesting.RunCommand(c, secretbackends.NewShowCommandForTest(s.store, s.secretBackendsAPI), "myvault", "--reveal")
+	c.Assert(err, jc.ErrorIsNil)
+	out := cmdtesting.Stdout(ctx)
+	c.Assert(out, gc.Equals, `
+myvault:
+  backend: vault
+  token-rotate-interval: 11h6m0s
+  config:
+    endpoint: http://vault
+  secrets: 666
+  status: error
+  message: vault is sealed
+  id: vault-id
+`[1:])
+}

--- a/cmd/juju/secretbackends/update.go
+++ b/cmd/juju/secretbackends/update.go
@@ -58,6 +58,7 @@ See also:
     add-secret-backends
     list-secret-backends
     remove-secret-backend
+    show-secret-backend
 `
 
 // UpdateSecretBackendsAPI is the secrets client API.

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -307,7 +307,8 @@ type UpdateSecretBackendArg struct {
 
 // ListSecretBackendsArgs holds the args for listing secret backends.
 type ListSecretBackendsArgs struct {
-	Reveal bool `json:"reveal"`
+	Names  []string `json:"names"`
+	Reveal bool     `json:"reveal"`
 }
 
 // SecretBackend holds secret backend details.


### PR DESCRIPTION
Add a show-secret-backend CLI command.
PR includes the CLI and necessary facade changes.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [X] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Add a secret backend (eg myvault) to a model
`juju show-secretbackend myvault`
`juju show-secretbackend internal`