### PR TITLE
Fix application facades

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -18,7 +18,7 @@ var facadeVersions = map[string]int{
 	"AllModelWatcher":              4,
 	"AllWatcher":                   3,
 	"Annotations":                  2,
-	"Application":                  16,
+	"Application":                  17,
 	"ApplicationOffers":            4,
 	"ApplicationScaler":            1,
 	"Backups":                      3,

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1441,6 +1441,42 @@ func (api *APIv15) DestroyUnit(argsV15 params.DestroyUnitsParamsV15) (params.Des
 	return api.APIBase.DestroyUnit(args)
 }
 
+// DestroyUnits removes a given set of application units.
+//
+// NOTE(axw) this exists only for backwards compatibility,
+// for API facade versions 1-3; clients should prefer its
+// successor, DestroyUnit, below. Until all consumers have
+// been updated, or we bump a major version, we can't drop
+// this.
+//
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
+func (api *APIBase) DestroyUnits(args params.DestroyApplicationUnits) error {
+	var errs []error
+	entities := params.DestroyUnitsParams{
+		Units: make([]params.DestroyUnitParams, 0, len(args.UnitNames)),
+	}
+	for _, unitName := range args.UnitNames {
+		if !names.IsValidUnit(unitName) {
+			errs = append(errs, errors.NotValidf("unit name %q", unitName))
+			continue
+		}
+		entities.Units = append(entities.Units, params.DestroyUnitParams{
+			UnitTag: names.NewUnitTag(unitName).String(),
+		})
+	}
+	results, err := api.DestroyUnit(entities)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, result := range results.Results {
+		if result.Error != nil {
+			errs = append(errs, result.Error)
+		}
+	}
+	return apiservererrors.DestroyErr("units", args.UnitNames, errs)
+}
+
 // DestroyUnit removes a given set of application units.
 func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyUnitResults, error) {
 	if api.modelType == state.ModelTypeCAAS {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1542,6 +1542,35 @@ func (api *APIBase) DestroyUnit(args params.DestroyUnitsParams) (params.DestroyU
 	}, nil
 }
 
+// Destroy destroys a given application, local or remote.
+//
+// NOTE(axw) this exists only for backwards compatibility,
+// for API facade versions 1-3; clients should prefer its
+// successor, DestroyApplication, below. Until all consumers
+// have been updated, or we bump a major version, we can't
+// drop this.
+//
+// TODO(axw) 2017-03-16 #1673323
+// Drop this in Juju 3.0.
+func (api *APIBase) Destroy(in params.ApplicationDestroy) error {
+	if !names.IsValidApplication(in.ApplicationName) {
+		return errors.NotValidf("application name %q", in.ApplicationName)
+	}
+	args := params.DestroyApplicationsParams{
+		Applications: []params.DestroyApplicationParams{{
+			ApplicationTag: names.NewApplicationTag(in.ApplicationName).String(),
+		}},
+	}
+	results, err := api.DestroyApplication(args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := results.Results[0].Error; err != nil {
+		return apiservererrors.ServerError(err)
+	}
+	return nil
+}
+
 // DestroyApplication removes a given set of applications.
 func (api *APIv15) DestroyApplication(argsV15 params.DestroyApplicationsParamsV15) (params.DestroyApplicationResults, error) {
 	args := params.DestroyApplicationsParams{

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -955,10 +955,170 @@ func (s *applicationSuite) TestBlockChangesApplicationUnexpose(c *gc.C) {
 	s.assertApplicationUnexposeBlocked(c, app, "TestBlockChangesApplicationUnexpose")
 }
 
+var applicationDestroyTests = []struct {
+	about       string
+	application string
+	err         string
+}{
+	{
+		about:       "unknown application name",
+		application: "unknown-application",
+		err:         `application "unknown-application" not found`,
+	},
+	{
+		about:       "destroy an application",
+		application: "dummy-application",
+	},
+	{
+		about:       "destroy an already destroyed application",
+		application: "dummy-application",
+		err:         `application "dummy-application" not found`,
+	},
+}
+
+func (s *applicationSuite) TestApplicationDestroy(c *gc.C) {
+	s.AddTestingApplication(c, "dummy-application", s.AddTestingCharm(c, "dummy"))
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "remote-application",
+		SourceModel: s.Model.ModelTag(),
+		Token:       "t0",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	for i, t := range applicationDestroyTests {
+		c.Logf("test %d. %s", i, t.about)
+		err := s.applicationAPI.Destroy(params.ApplicationDestroy{ApplicationName: t.application})
+		if t.err != "" {
+			c.Assert(err, gc.ErrorMatches, t.err)
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+		}
+	}
+
+	// Now do Destroy on an application with units. Destroy will
+	// cause the application to be not-Alive, but will not remove its
+	// document.
+	s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	applicationName := "wordpress"
+	app, err := s.State.Application(applicationName)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.applicationAPI.Destroy(params.ApplicationDestroy{ApplicationName: applicationName})
+	c.Assert(err, jc.ErrorIsNil)
+	err = app.Refresh()
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
 func assertLife(c *gc.C, entity state.Living, life state.Life) {
 	err := entity.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(entity.Life(), gc.Equals, life)
+}
+
+func (s *applicationSuite) TestBlockApplicationDestroy(c *gc.C) {
+	s.AddTestingApplication(c, "dummy-application", s.AddTestingCharm(c, "dummy"))
+
+	// block remove-objects
+	s.BlockRemoveObject(c, "TestBlockApplicationDestroy")
+	err := s.applicationAPI.Destroy(params.ApplicationDestroy{ApplicationName: "dummy-application"})
+	s.AssertBlocked(c, err, "TestBlockApplicationDestroy")
+	// Tests may have invalid application names.
+	app, err := s.State.Application("dummy-application")
+	if err == nil {
+		// For valid application names, check that application is alive :-)
+		assertLife(c, app, state.Alive)
+	}
+}
+
+func (s *applicationSuite) TestDestroyControllerApplicationNotAllowed(c *gc.C) {
+	s.AddTestingApplication(c, "controller-application", s.AddTestingCharm(c, "juju-controller"))
+
+	err := s.applicationAPI.Destroy(params.ApplicationDestroy{"controller-application"})
+	c.Assert(err, gc.ErrorMatches, "removing the controller application not supported")
+}
+
+func (s *applicationSuite) TestDestroyPrincipalUnits(c *gc.C) {
+	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	units := make([]*state.Unit, 5)
+	for i := range units {
+		unit, err := wordpress.AddUnit(state.AddUnitParams{})
+		c.Assert(err, jc.ErrorIsNil)
+		unit.AssignToNewMachine()
+		c.Assert(err, jc.ErrorIsNil)
+		now := time.Now()
+		sInfo := status.StatusInfo{
+			Status:  status.Idle,
+			Message: "",
+			Since:   &now,
+		}
+		err = unit.SetAgentStatus(sInfo)
+		c.Assert(err, jc.ErrorIsNil)
+		units[i] = unit
+	}
+	s.assertDestroyPrincipalUnits(c, units)
+}
+
+func (s *applicationSuite) TestDestroySubordinateUnits(c *gc.C) {
+	wordpress := s.AddTestingApplication(c, "wordpress", s.AddTestingCharm(c, "wordpress"))
+	wordpress0, err := wordpress.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	s.AddTestingApplication(c, "logging", s.AddTestingCharm(c, "logging"))
+	eps, err := s.State.InferEndpoints("logging", "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+	ru, err := rel.Unit(wordpress0)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ru.EnterScope(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	logging0, err := s.State.Unit("logging/0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Try to destroy the subordinate alone; check it fails.
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
+		UnitNames: []string{"logging/0"},
+	})
+	c.Assert(err, gc.ErrorMatches, `no units were destroyed: unit "logging/0" is a subordinate, .*`)
+	assertLife(c, logging0, state.Alive)
+
+	s.assertDestroySubordinateUnits(c, wordpress0, logging0)
+}
+
+func (s *applicationSuite) assertDestroyPrincipalUnits(c *gc.C, units []*state.Unit) {
+	// Destroy 2 of them; check they become Dying.
+	err := s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
+		UnitNames: []string{"wordpress/0", "wordpress/1"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	assertLife(c, units[0], state.Dying)
+	assertLife(c, units[1], state.Dying)
+
+	// Try to destroy an Alive one and a Dying one; check
+	// it destroys the Alive one and ignores the Dying one.
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
+		UnitNames: []string{"wordpress/2", "wordpress/0"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	assertLife(c, units[2], state.Dying)
+
+	// Try to destroy an Alive one along with a nonexistent one; check that
+	// the valid instruction is followed but the invalid one is warned about.
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
+		UnitNames: []string{"boojum/123", "wordpress/3"},
+	})
+	c.Assert(err, gc.ErrorMatches, `some units were not destroyed: unit "boojum/123" does not exist`)
+	assertLife(c, units[3], state.Dying)
+
+	// Make one Dead, and destroy an Alive one alongside it; check no errors.
+	wp0, err := s.State.Unit("wordpress/0")
+	c.Assert(err, jc.ErrorIsNil)
+	err = wp0.EnsureDead()
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.applicationAPI.DestroyUnits(params.DestroyApplicationUnits{
+		UnitNames: []string{"wordpress/0", "wordpress/4"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	assertLife(c, units[0], state.Dead)
+	assertLife(c, units[4], state.Dying)
 }
 
 func (s *applicationSuite) setupDestroyPrincipalUnits(c *gc.C) []*state.Unit {

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -366,7 +366,8 @@ func (s *ApplicationSuite) TestSetCharmWithBlockRemove(c *gc.C) {
 
 func (s *ApplicationSuite) TestSetCharmWithBlockChange(c *gc.C) {
 	s.changeAllowed = errors.New("change blocked")
-	defer s.setup(c).Finish()
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
 
 	err := s.api.SetCharm(params.ApplicationSetCharm{
 		ApplicationName: "postgresql",

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1127,7 +1127,7 @@ func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
 	defer ctrl.Finish()
 
 	app := s.expectDefaultApplication(ctrl)
-	s.backend.EXPECT().Application("postgresql").MinTimes(1).Return(app, nil)
+	s.backend.EXPECT().Application("postgresql").AnyTimes().Return(app, nil)
 
 	// unit 0 loop
 	unit0 := s.expectUnit(ctrl, "postgresql/0")
@@ -1171,29 +1171,12 @@ func (s *ApplicationSuite) TestDestroyUnit(c *gc.C) {
 	}})
 }
 
-func (s *ApplicationSuite) TestDestroyUnitWithChangeBlock(c *gc.C) {
-	s.changeAllowed = errors.New("change blocked")
-	s.TestDestroyUnit(c)
-}
-
-func (s *ApplicationSuite) TestDestroyUnitWithRemoveBlock(c *gc.C) {
-	s.removeAllowed = errors.New("remove blocked")
-	defer s.setup(c).Finish()
-
-	_, err := s.api.DestroyUnit(params.DestroyUnitsParams{
-		Units: []params.DestroyUnitParams{{
-			UnitTag: "unit-postgresql-1",
-		}},
-	})
-	c.Assert(err, gc.ErrorMatches, "remove blocked")
-}
-
 func (s *ApplicationSuite) TestForceDestroyUnit(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()
 
 	app := s.expectDefaultApplication(ctrl)
-	s.backend.EXPECT().Application("postgresql").MinTimes(1).Return(app, nil)
+	s.backend.EXPECT().Application("postgresql").AnyTimes().Return(app, nil)
 
 	// unit 0 loop
 	unit0 := s.expectUnit(ctrl, "postgresql/0")

--- a/apiserver/facades/client/application/register.go
+++ b/apiserver/facades/client/application/register.go
@@ -19,10 +19,21 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Application", 16, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV16(ctx) // DestroyApplication & DestroyUnit gains dry-run
 	}, reflect.TypeOf((*APIv16)(nil)))
+	registry.MustRegister("Application", 17, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV17(ctx) // Drop deprecated DestroyUnits & Destroy facades
+	}, reflect.TypeOf((*APIv17)(nil)))
+}
+
+func newFacadeV17(ctx facade.Context) (*APIv17, error) {
+	api, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &APIv17{api}, nil
 }
 
 func newFacadeV16(ctx facade.Context) (*APIv16, error) {
-	api, err := newFacadeBase(ctx)
+	api, err := newFacadeV17(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1928,6 +1928,15 @@
                     },
                     "description": "Deploy fetches the charms from the charm store and deploys them\nusing the specified placement directives."
                 },
+                "Destroy": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationDestroy"
+                        }
+                    },
+                    "description": "Destroy destroys a given application, local or remote.\n\nNOTE(axw) this exists only for backwards compatibility,\nfor API facade versions 1-3; clients should prefer its\nsuccessor, DestroyApplication, below. Until all consumers\nhave been updated, or we bump a major version, we can't\ndrop this.\n\nTODO(axw) 2017-03-16 #1673323\nDrop this in Juju 3.0."
+                },
                 "DestroyApplication": {
                     "type": "object",
                     "properties": {
@@ -2413,6 +2422,18 @@
                         "config-yaml",
                         "constraints",
                         "Force"
+                    ]
+                },
+                "ApplicationDestroy": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application"
                     ]
                 },
                 "ApplicationExpose": {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1833,8 +1833,8 @@
     },
     {
         "Name": "Application",
-        "Description": "APIv16 provides the Application API facade for version 16.",
-        "Version": 16,
+        "Description": "APIv17 provides the Application API facade for version 17.",
+        "Version": 17,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -1932,10 +1932,9 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/ApplicationDestroy"
+                            "$ref": "#/definitions/"
                         }
-                    },
-                    "description": "Destroy destroys a given application, local or remote.\n\nNOTE(axw) this exists only for backwards compatibility,\nfor API facade versions 1-3; clients should prefer its\nsuccessor, DestroyApplication, below. Until all consumers\nhave been updated, or we bump a major version, we can't\ndrop this.\n\nTODO(axw) 2017-03-16 #1673323\nDrop this in Juju 3.0."
+                    }
                 },
                 "DestroyApplication": {
                     "type": "object",
@@ -1986,10 +1985,9 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/DestroyApplicationUnits"
+                            "$ref": "#/definitions/"
                         }
-                    },
-                    "description": "DestroyUnits removes a given set of application units.\n\nNOTE(axw) this exists only for backwards compatibility,\nfor API facade versions 1-3; clients should prefer its\nsuccessor, DestroyUnit, below. Until all consumers have\nbeen updated, or we bump a major version, we can't drop\nthis.\n\nTODO(axw) 2017-03-16 #1673323\nDrop this in Juju 3.0."
+                    }
                 },
                 "Expose": {
                     "type": "object",
@@ -2197,6 +2195,10 @@
                 }
             },
             "definitions": {
+                "": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
                 "AddApplicationUnits": {
                     "type": "object",
                     "properties": {
@@ -2431,18 +2433,6 @@
                         "config-yaml",
                         "constraints",
                         "Force"
-                    ]
-                },
-                "ApplicationDestroy": {
-                    "type": "object",
-                    "properties": {
-                        "application": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "application"
                     ]
                 },
                 "ApplicationExpose": {
@@ -3270,21 +3260,6 @@
                         }
                     },
                     "additionalProperties": false
-                },
-                "DestroyApplicationUnits": {
-                    "type": "object",
-                    "properties": {
-                        "unit-names": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "unit-names"
-                    ]
                 },
                 "DestroyApplicationsParams": {
                     "type": "object",

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1982,6 +1982,15 @@
                     },
                     "description": "DestroyUnit removes a given set of application units."
                 },
+                "DestroyUnits": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyApplicationUnits"
+                        }
+                    },
+                    "description": "DestroyUnits removes a given set of application units.\n\nNOTE(axw) this exists only for backwards compatibility,\nfor API facade versions 1-3; clients should prefer its\nsuccessor, DestroyUnit, below. Until all consumers have\nbeen updated, or we bump a major version, we can't drop\nthis.\n\nTODO(axw) 2017-03-16 #1673323\nDrop this in Juju 3.0."
+                },
                 "Expose": {
                     "type": "object",
                     "properties": {
@@ -3261,6 +3270,21 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "DestroyApplicationUnits": {
+                    "type": "object",
+                    "properties": {
+                        "unit-names": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit-names"
+                    ]
                 },
                 "DestroyApplicationsParams": {
                     "type": "object",

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -286,6 +286,12 @@ type UpdateApplicationServiceArg struct {
 	Generation *int64 `json:"generation,omitempty"`
 }
 
+// ApplicationDestroy holds the parameters for making the deprecated
+// Application.Destroy call.
+type ApplicationDestroy struct {
+	ApplicationName string `json:"application"`
+}
+
 // DestroyApplicationsParams holds bulk parameters for the
 // Application.DestroyApplication call.
 type DestroyApplicationsParamsV15 struct {

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -544,6 +544,12 @@ type DestroyUnitParamsV15 struct {
 	MaxWait *time.Duration `json:"max-wait,omitempty"`
 }
 
+// DestroyApplicationUnits holds parameters for the deprecated
+// Application.DestroyUnits call.
+type DestroyApplicationUnits struct {
+	UnitNames []string `json:"unit-names"`
+}
+
 // DestroyUnitsParams holds bulk parameters for the Application.DestroyUnit call.
 type DestroyUnitsParams struct {
 	Units []DestroyUnitParams `json:"units"`


### PR DESCRIPTION
Restore facades on application 16 that were incorrectly dropped and increment facade to 17

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Verify unit tests pass

Verify DestroyUnits facade can be called using application facade 15 or 16
