### PR TITLE
[JUJU-2524] Avoid creating default lxd bridge when calling lxd init

### DIFF
--- a/api/agent/provisioner/provisioner_test.go
+++ b/api/agent/provisioner/provisioner_test.go
@@ -682,8 +682,9 @@ func (s *provisionerSuite) getManagerConfig(c *gc.C, typ instance.ContainerType)
 func (s *provisionerSuite) TestContainerManagerConfigKVM(c *gc.C) {
 	cfg := s.getManagerConfig(c, instance.KVM)
 	c.Assert(cfg, jc.DeepEquals, map[string]string{
-		container.ConfigModelUUID:      coretesting.ModelTag.Id(),
-		config.ContainerImageStreamKey: "released",
+		container.ConfigModelUUID:        coretesting.ModelTag.Id(),
+		config.ContainerImageStreamKey:   "released",
+		config.ContainerNetworkingMethod: config.ConfigDefaults()[config.ContainerNetworkingMethod].(string),
 	})
 }
 
@@ -692,8 +693,9 @@ func (s *provisionerSuite) TestContainerManagerConfigPermissive(c *gc.C) {
 	// will just return the basic type-independent configuration.
 	cfg := s.getManagerConfig(c, "invalid")
 	c.Assert(cfg, jc.DeepEquals, map[string]string{
-		container.ConfigModelUUID:      coretesting.ModelTag.Id(),
-		config.ContainerImageStreamKey: "released",
+		container.ConfigModelUUID:        coretesting.ModelTag.Id(),
+		config.ContainerImageStreamKey:   "released",
+		config.ContainerNetworkingMethod: config.ConfigDefaults()[config.ContainerNetworkingMethod].(string),
 	})
 }
 

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -334,6 +334,7 @@ func (api *ProvisionerAPI) ContainerManagerConfig(args params.ContainerManagerCo
 		cfg[config.ContainerImageMetadataURLKey] = url
 	}
 	cfg[config.ContainerImageStreamKey] = mConfig.ContainerImageStream()
+	cfg[config.ContainerNetworkingMethod] = mConfig.ContainerNetworkingMethod()
 
 	result.ManagerConfig = cfg
 	return result, nil

--- a/apiserver/facades/agent/provisioner/provisioner_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_test.go
@@ -1433,8 +1433,9 @@ func (s *provisionerSuite) getManagerConfig(c *gc.C, typ instance.ContainerType)
 func (s *withoutControllerSuite) TestContainerManagerConfigDefaults(c *gc.C) {
 	cfg := s.getManagerConfig(c, instance.KVM)
 	c.Assert(cfg, jc.DeepEquals, map[string]string{
-		container.ConfigModelUUID:      coretesting.ModelTag.Id(),
-		config.ContainerImageStreamKey: "released",
+		container.ConfigModelUUID:        coretesting.ModelTag.Id(),
+		config.ContainerImageStreamKey:   "released",
+		config.ContainerNetworkingMethod: config.ConfigDefaults()[config.ContainerNetworkingMethod].(string),
 	})
 }
 
@@ -1799,6 +1800,7 @@ func (s *withImageMetadataSuite) TestContainerManagerConfigImageMetadata(c *gc.C
 		config.ContainerImageStreamKey:      "daily",
 		config.ContainerImageMetadataURLKey: "https://images.linuxcontainers.org/",
 		config.LXDSnapChannel:               "5.0/stable",
+		config.ContainerNetworkingMethod:    config.ConfigDefaults()[config.ContainerNetworkingMethod].(string),
 	})
 }
 

--- a/container/lxd/initialisation.go
+++ b/container/lxd/initialisation.go
@@ -21,7 +21,7 @@ type containerInitialiser struct {
 var _ container.Initialiser = (*containerInitialiser)(nil)
 
 // NewContainerInitialiser  - on anything but Linux this is a NOP
-func NewContainerInitialiser(string) container.Initialiser {
+func NewContainerInitialiser(string, string) container.Initialiser {
 	return &containerInitialiser{}
 }
 

--- a/worker/provisioner/container_initialisation_test.go
+++ b/worker/provisioner/container_initialisation_test.go
@@ -200,7 +200,7 @@ func (s *containerSetupSuite) patch(c *gc.C) *gomock.Controller {
 
 	s.machine.EXPECT().MachineTag().Return(names.NewMachineTag("0")).AnyTimes()
 
-	s.PatchValue(GetContainerInitialiser, func(instance.ContainerType, map[string]string) container.Initialiser {
+	s.PatchValue(GetContainerInitialiser, func(instance.ContainerType, map[string]string, string) container.Initialiser {
 		return s.initialiser
 	})
 

--- a/worker/provisioner/containerworker_test.go
+++ b/worker/provisioner/containerworker_test.go
@@ -198,7 +198,7 @@ func (s *containerWorkerSuite) patch(c *gc.C) *gomock.Controller {
 	s.machine.EXPECT().Id().Return("0").AnyTimes()
 	s.machine.EXPECT().MachineTag().Return(names.NewMachineTag("0")).AnyTimes()
 
-	s.PatchValue(provisioner.GetContainerInitialiser, func(instance.ContainerType, map[string]string) container.Initialiser {
+	s.PatchValue(provisioner.GetContainerInitialiser, func(instance.ContainerType, map[string]string, string) container.Initialiser {
 		return s.initialiser
 	})
 


### PR DESCRIPTION
When initializing lxd, we "accidentally" create a default network bridge, no matter what the `container-network-method` is (local, fan or provider). When the method is local the bridge should still be created, and it is the only case where it should.
This happened when we ran `lxd init --auto` in the container initialization. 

This PR removes the `--auto` flag and provides `lxd init` with all the default configurations except the creation of a bridge.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

We must verify that the three container network methods (`fan`, `local`, `provider`) still work, for that we can bootstrap 3 clouds:
- LXD local
- AWS
- MAAS

Then on each one we add a machine:
```
$ juju add-machine
```
and then we ssh into the machine and check that there is no lxd network bridge created (example output):
```
$ ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: enp0s31f6: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel state DOWN mode DEFAULT group default qlen 1000
    link/ether f8:75:a4:dd:f2:b5 brd ff:ff:ff:ff:ff:ff
```
then, we add a container on the same machine:
```
$ juju add-machine lxd:0
```

Now, we run `ip link` again on machine 0: 
- on `MAAS` and `AWS` we *MUST NOT* see a `lxdbr0` network interface when we do `ip link`
- on LXD locally we should (since it is the `local` container networking method):

```
$ ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: enp0s31f6: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel state DOWN mode DEFAULT group default qlen 1000
    link/ether f8:75:a4:dd:f2:b5 brd ff:ff:ff:ff:ff:ff
7: lxdbr0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether 00:16:3e:85:3f:b2 brd ff:ff:ff:ff:ff:ff
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2000249