### PR TITLE
Fix secretrotate worker test race failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/juju/blobstore/v3 v3.0.2
 	github.com/juju/charm/v9 v9.0.6
 	github.com/juju/charmrepo/v7 v7.0.1
-	github.com/juju/clock v1.0.2
+	github.com/juju/clock v1.0.3
 	github.com/juju/cmd/v3 v3.0.2
 	github.com/juju/collections v1.0.1
 	github.com/juju/description/v4 v4.0.1

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c/go.mod h1:nD0vlnrUjcjJh
 github.com/juju/clock v0.0.0-20220202072423-1b0f830854c4/go.mod h1:zDZCPSgCJQINeZtQwHx2/cFk4seaBC8Yiqe8V82xiP0=
 github.com/juju/clock v0.0.0-20220203021603-d9deb868a28a/go.mod h1:GZ/FY8Cqw3KHG6DwRVPUKbSPTAwyrU28xFi5cqZnLsc=
 github.com/juju/clock v1.0.0/go.mod h1:GZ/FY8Cqw3KHG6DwRVPUKbSPTAwyrU28xFi5cqZnLsc=
-github.com/juju/clock v1.0.2 h1:dJFdUGjtR/76l6U5WLVVI/B3i6+u3Nb9F9s1m+xxrxo=
-github.com/juju/clock v1.0.2/go.mod h1:HIBvJ8kiV/n7UHwKuCkdYL4l/MDECztHR2sAvWDxxf0=
+github.com/juju/clock v1.0.3 h1:yJHIsWXeU8j3QcBdiess09SzfiXRRrsjKPn2whnMeds=
+github.com/juju/clock v1.0.3/go.mod h1:HIBvJ8kiV/n7UHwKuCkdYL4l/MDECztHR2sAvWDxxf0=
 github.com/juju/cmd v0.0.0-20171107070456-e74f39857ca0/go.mod h1:yWJQHl73rdSX4DHVKGqkAip+huBslxRwS8m9CrOLq18=
 github.com/juju/cmd/v3 v3.0.0-20220202061353-b1cc80b193b0/go.mod h1:EoGJiEG+vbMwO9l+Es0SDTlaQPjH6nLcnnc4NfZB3cY=
 github.com/juju/cmd/v3 v3.0.2 h1:N+jsD+PrdDYol9UpSvTmllgPmTGqdk5cSJ/CPqV4rb4=


### PR DESCRIPTION
The old test clock was causing issues in the race tests for the rotate secrets worker.
Here we use the dilated test clock instead. During migration to this, a bug was found upstream so an updated `juju/clock` dependency is brought in.

## QA steps

go test --race