### PR TITLE
[JUJU-2547] Update fix to LP1984061. - adding latest to charm origin channel

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1419,7 +1419,7 @@ func (i *importer) makeCharmOrigin(a description.Application, units []descriptio
 			return nil, errors.Trace(err)
 		}
 		track := c.Track
-		if charm.CharmHub.Matches(co.Source()) && track == "" {
+		if corecharm.CharmHub.Matches(co.Source()) && track == "" {
 			track = "latest"
 		}
 		channel = &Channel{

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -548,7 +548,7 @@ func (s *MigrationImportSuite) setupSourceApplications(
 	application, pwd := f.MakeApplicationReturningPassword(c, &factory.ApplicationParams{
 		Charm: testCharm,
 		CharmOrigin: &state.CharmOrigin{
-			Source:   testCharm.URL().Schema,
+			Source:   "charm-store",
 			Type:     "charm",
 			Revision: &testCharm.URL().Revision,
 			Channel: &state.Channel{
@@ -2865,7 +2865,7 @@ func (s *MigrationImportSuite) TestApplicationAddLatestCharmChannelTrack(c *gc.C
 	})
 	c.Assert(testCharm.Meta().Resources, gc.HasLen, 3)
 	origin := &state.CharmOrigin{
-		Source:   testCharm.URL().Schema,
+		Source:   "charm-hub",
 		Type:     "charm",
 		Revision: &testCharm.URL().Revision,
 		Channel: &state.Channel{


### PR DESCRIPTION
Update fix in #14470.

Charm source is not based on the charm url schema, as using charm.CharmHub.Matches would imply. It's base on the core charm Source data. "ch" will not match "charm-hub".

Update other test setup doing the same wrong thing too.

## QA steps

```sh
$ juju bootstrap localhost dst 
$ juju bootstrap localhost src --agent-version 2.9.32
$ juju add-model move-me
$ juju deploy cs:ubuntu csubuntu
$ juju deploy ubuntu
# wait for the unit to be active/idle
$ juju migrate move-me dst
$ juju switch dst:admin/move-me
# check juju db
juju:PRIMARY> db.applications.find({},{"charm-origin.source":1,"charm-origin.channel":1}).pretty()
{
	"_id" : "10c64d16-0b07-4c93-8525-168e7c0d799c:csubuntu",
	"charm-origin" : {
		"source" : "charm-store",
		"channel" : {
			"risk" : "stable"
		},
	}
}
{
	"_id" : "10c64d16-0b07-4c93-8525-168e7c0d799c:ubuntu",
	"charm-origin" : {
		"source" : "charm-hub",
		"channel" : {
			"track" : "latest",
			"risk" : "stable"
		},
	}
}
```

