### PR TITLE
[JUJU-2548] Added test-model-test-model-status to 2.9

### DIFF
--- a/tests/suites/model/status.sh
+++ b/tests/suites/model/status.sh
@@ -1,0 +1,33 @@
+# Tests that juju status for empty models is consistent.
+# There should be an empty space between the model status and the error text below it.
+run_empty_model_status() {
+	echo
+
+	file="${TEST_DIR}/test-empty-model-status.log"
+	ensure "empty-model-status" "${file}"
+
+	echo "Print out juju status for empty model"
+	status=$(juju status 2>&1)
+	# check that the 4th line matches the expected output.
+	echo "${status}" | sed -sn 4p | check 'Model "admin/empty-model-status" is empty.'
+	# check that the 3rd line is exactly one empty line.
+	echo "${status}" | sed -sn 3p | grep -c '^$' | check 1
+
+	destroy_model "empty-model-status"
+}
+
+test_model_status() {
+	if [ -n "$(skip 'test_model_status')" ]; then
+		echo "==> SKIP: Asked to skip model status tests"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_empty_model_status"
+	)
+
+}

--- a/tests/suites/model/task.sh
+++ b/tests/suites/model/task.sh
@@ -23,6 +23,7 @@ test_model() {
 	test_model_multi
 	test_model_metrics
 	test_model_destroy
+	test_model_status
 
 	destroy_controller "test-models"
 }


### PR DESCRIPTION
This PR adds test-model-test-model-status to the 2.9 branch. This test was taken from the 3.0 branch. Looks like we forgot to add in 2.9. PR will help to be CI green because we have the same job descriptions for all branches.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests
./main.sh -v -p lxd model test_model_status
```
