### PR TITLE
[JUJU-2521] Changing prompting behaviour for 3.2

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -235,9 +235,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	ctx.Warningf(destroySysMsg, controllerName)
 	updateStatus := newTimedStatusUpdater(ctx, api, controllerEnviron.Config().UUID(), clock.WallClock)
 	modelStatus := updateStatus(0)
-	if err := c.DestroyConfirmationCommandBase.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
+
 	// check Alive models and --destroy-all-models flag usage
 	if !c.destroyModels {
 		if err := c.checkNoAliveHostedModels(modelStatus.Models); err != nil {

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -129,9 +129,6 @@ func (c *killCommand) Run(ctx *cmd.Context) error {
 		return c.environsDestroy(controllerName, controllerEnviron, cloudCallCtx, store)
 	}
 
-	if err := c.DestroyConfirmationCommandBase.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
 	if c.DestroyConfirmationCommandBase.NeedsConfirmation() {
 		updateStatus := newTimedStatusUpdater(ctx, api, controllerEnviron.Config().UUID(), clock.WallClock)
 		modelStatus := updateStatus(0)

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -102,9 +102,6 @@ func (c *unregisterCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	if err := c.DestroyConfirmationCommandBase.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
 	if c.DestroyConfirmationCommandBase.NeedsConfirmation() {
 		fmt.Fprintf(ctx.Stderr, unregisterMsg, c.controllerName)
 		if err := jujucmd.UserConfirmName(c.controllerName, "controller", ctx); err != nil {

--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -250,10 +250,6 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	}
 	defer func() { _ = api.Close() }()
 
-	if err := c.DestroyConfirmationCommandBase.Run(ctx); err != nil {
-		return errors.Trace(err)
-	}
-
 	if c.DestroyConfirmationCommandBase.NeedsConfirmation() {
 		modelStatuses, err := api.ModelStatus(names.NewModelTag(modelDetails.ModelUUID))
 		if err != nil {

--- a/cmd/modelcmd/confirmation.go
+++ b/cmd/modelcmd/confirmation.go
@@ -4,40 +4,24 @@
 package modelcmd
 
 import (
-	"github.com/juju/cmd/v3"
 	"github.com/juju/gnuflag"
 
 	"github.com/juju/juju/environs/config"
 )
 
-// ConfirmationCommandBase provides common attributes and methods that
-// commands require to confirm the execution.
-// TODO (jack-w-shaw): When confirm-removal config item defaults to true, we can combine these
-
 // DestroyConfirmationCommandBase provides common attributes and methods that
 // commands require to confirm the execution of destroy-* commands
 type DestroyConfirmationCommandBase struct {
-	assumeYes      bool // DEPRECATED
 	assumeNoPrompt bool
 }
 
 func (c *DestroyConfirmationCommandBase) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.assumeYes, "y", false, "Do not ask for confirmation. Option present for backwards compatibility with Juju 2.9")
-	f.BoolVar(&c.assumeYes, "yes", false, "")
 	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation")
-}
-
-// Run implements Command.Run
-func (c *DestroyConfirmationCommandBase) Run(ctx *cmd.Context) error {
-	if c.assumeYes {
-		ctx.Warningf("'-y'/'--yes' flags are deprecated and will be removed in Juju 3.1\n")
-	}
-	return nil
 }
 
 // NeedsConfirmation returns indicates whether confirmation is required or not.
 func (c *DestroyConfirmationCommandBase) NeedsConfirmation() bool {
-	return !(c.assumeYes || c.assumeNoPrompt)
+	return !c.assumeNoPrompt
 }
 
 type ModelConfigAPI interface {
@@ -52,7 +36,7 @@ type RemoveConfirmationCommandBase struct {
 
 // SetFlags implements Command.SetFlags.
 func (c *RemoveConfirmationCommandBase) SetFlags(f *gnuflag.FlagSet) {
-	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation")
+	f.BoolVar(&c.assumeNoPrompt, "no-prompt", false, "Do not ask for confirmation. Overrides `mode` model config setting")
 }
 
 // NeedsConfirmation returns indicates whether confirmation is required or not.

--- a/cmd/modelcmd/confirmation_test.go
+++ b/cmd/modelcmd/confirmation_test.go
@@ -40,18 +40,6 @@ func (s *DestroyConfirmationCommandBaseSuite) TestNoPromptFlag(c *gc.C) {
 	c.Assert(commandBase.NeedsConfirmation(), jc.IsFalse)
 }
 
-func (s *DestroyConfirmationCommandBaseSuite) TestYesFlag(c *gc.C) {
-	commandBase := s.getCmdBase([]string{"--yes", "--foo", "bar"})
-
-	c.Assert(commandBase.NeedsConfirmation(), jc.IsFalse)
-}
-
-func (s *DestroyConfirmationCommandBaseSuite) TestYFlag(c *gc.C) {
-	commandBase := s.getCmdBase([]string{"-y", "--foo", "bar"})
-
-	c.Assert(commandBase.NeedsConfirmation(), jc.IsFalse)
-}
-
 type RemoveConfirmationCommandBaseSuite struct {
 	modelConfigAPI *mocks.MockModelConfigAPI
 }

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -534,7 +534,7 @@ var defaultConfigValues = map[string]interface{}{
 	"enable-os-upgrade":             true,
 	"development":                   false,
 	TestModeKey:                     false,
-	ModeKey:                         "",
+	ModeKey:                         RequiresPromptsMode,
 	DisableTelemetryKey:             false,
 	TransmitVendorMetricsKey:        true,
 	UpdateStatusHookInterval:        DefaultUpdateStatusHookInterval,

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -1233,15 +1233,15 @@ func (s *ConfigSuite) TestCharmHubURL(c *gc.C) {
 func (s *ConfigSuite) TestMode(c *gc.C) {
 	cfg := newTestConfig(c, testing.Attrs{})
 	mode, ok := cfg.Mode()
-	c.Assert(ok, jc.IsFalse)
-	c.Assert(mode, gc.DeepEquals, set.NewStrings())
-
-	cfg = newTestConfig(c, testing.Attrs{
-		config.ModeKey: config.RequiresPromptsMode,
-	})
-	mode, ok = cfg.Mode()
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(mode, gc.DeepEquals, set.NewStrings(config.RequiresPromptsMode))
+
+	cfg = newTestConfig(c, testing.Attrs{
+		config.ModeKey: "",
+	})
+	mode, ok = cfg.Mode()
+	c.Assert(ok, jc.IsFalse)
+	c.Assert(mode, gc.DeepEquals, set.NewStrings())
 }
 
 func (s *ConfigSuite) TestLoggingOutput(c *gc.C) {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -237,7 +237,7 @@ juju_bootstrap() {
 
 	pre_bootstrap
 
-	command="juju bootstrap ${series} ${cloud_region} ${name} --add-model ${model} ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${series} ${cloud_region} ${name} --add-model ${model} --model-default mode= ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"


### PR DESCRIPTION
Drop the deprecated -y/--yes flags from destroy-* commands and default to requiring prompts for destroy commands

Also make sure these prompts are disabled for integration tests

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

- Ensure -y/--yes flags are not present for destroy-model, destroy-controller, kill-controller and unregister
- Ensure `juju model-config mode` returns `requires-prompts` for new models
- Ensure this means remove-* commands ask for confirmation before removing