### PR TITLE
Bump juju/utils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/juju/terms-client/v2 v2.0.0
 	github.com/juju/testing v1.0.3
 	github.com/juju/txn/v3 v3.0.2
-	github.com/juju/utils/v3 v3.0.1
+	github.com/juju/utils/v3 v3.0.2
 	github.com/juju/version/v2 v2.0.1
 	github.com/juju/viddy v0.0.0-beta5
 	github.com/juju/webbrowser v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -881,8 +881,8 @@ github.com/juju/utils/v3 v3.0.0-20220130232349-cd7ecef0e94a/go.mod h1:LzwbbEN7bu
 github.com/juju/utils/v3 v3.0.0-20220202114721-338bb0530e89/go.mod h1:wf5w+8jyTh2IYnSX0sHnMJo4ZPwwuiBWn+xN3DkQg4k=
 github.com/juju/utils/v3 v3.0.0-20220203023959-c3fbc78a33b0/go.mod h1:8csUcj1VRkfjNIRzBFWzLFCMLwLqsRWvkmhfVAUwbC4=
 github.com/juju/utils/v3 v3.0.0/go.mod h1:8csUcj1VRkfjNIRzBFWzLFCMLwLqsRWvkmhfVAUwbC4=
-github.com/juju/utils/v3 v3.0.1 h1:lqeqrw/X4lNypWhYvXhhZU5CYlQNP1CwpiRxtn8VGKw=
-github.com/juju/utils/v3 v3.0.1/go.mod h1:8csUcj1VRkfjNIRzBFWzLFCMLwLqsRWvkmhfVAUwbC4=
+github.com/juju/utils/v3 v3.0.2 h1:6Hel0EXKSM4SOQFHfRel74ZvRp4O0QuxSSf3p3W2FNA=
+github.com/juju/utils/v3 v3.0.2/go.mod h1:8csUcj1VRkfjNIRzBFWzLFCMLwLqsRWvkmhfVAUwbC4=
 github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=


### PR DESCRIPTION
This is to increase the key bit size to 4096

## QA steps

Verify Juju compiles and generated 4096 RSA keys for ssh