### PR TITLE
[JUJU-2463] fix LP1999060 single charm multi app bundle failures

### DIFF
--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -107,18 +107,13 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
 		return errors.Trace(err)
 	}
 
-	resolvedOrigin := app.CharmOrigin()
-	if resolvedOrigin == nil {
-		return errors.NotFoundf("download charm for application %q; resolved origin", appTag.Name)
-	}
-
 	// In the case of deploying multiple applications utilizing the
 	// same charm, keep going to allow DownloadAndStore to return
 	// the correct origin to be saved below. The charm will not
 	// actually be downloaded more than once. The method will just
 	// provide the correct origin. Necessary for deploying resources
 	// and refreshing charms.
-	if !app.CharmPendingToBeDownloaded() && resolvedOrigin.ID != "" {
+	if !app.CharmPendingToBeDownloaded() {
 		return nil // nothing to do
 	}
 
@@ -131,6 +126,11 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
 	macaroons, err := pendingCharm.Macaroon()
 	if err != nil {
 		return errors.Trace(err)
+	}
+
+	resolvedOrigin := app.CharmOrigin()
+	if resolvedOrigin == nil {
+		return errors.NotFoundf("download charm for application %q; resolved origin", appTag.Name)
 	}
 
 	downloader, err := a.getDownloader()

--- a/apiserver/facades/controller/charmdownloader/charmdownloader.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader.go
@@ -107,7 +107,18 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
 		return errors.Trace(err)
 	}
 
-	if !app.CharmPendingToBeDownloaded() {
+	resolvedOrigin := app.CharmOrigin()
+	if resolvedOrigin == nil {
+		return errors.NotFoundf("download charm for application %q; resolved origin", appTag.Name)
+	}
+
+	// In the case of deploying multiple applications utilizing the
+	// same charm, keep going to allow DownloadAndStore to return
+	// the correct origin to be saved below. The charm will not
+	// actually be downloaded more than once. The method will just
+	// provide the correct origin. Necessary for deploying resources
+	// and refreshing charms.
+	if !app.CharmPendingToBeDownloaded() && resolvedOrigin.ID != "" {
 		return nil // nothing to do
 	}
 
@@ -120,11 +131,6 @@ func (a *CharmDownloaderAPI) downloadApplicationCharm(appTag names.ApplicationTa
 	macaroons, err := pendingCharm.Macaroon()
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	resolvedOrigin := app.CharmOrigin()
-	if resolvedOrigin == nil {
-		return errors.NotFoundf("download charm for application %q; resolved origin", appTag.Name)
 	}
 
 	downloader, err := a.getDownloader()

--- a/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
+++ b/apiserver/facades/controller/charmdownloader/charmdownloader_test.go
@@ -75,11 +75,11 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharmsAuthChecks(c *gc.C) 
 	c.Assert(err, gc.Equals, apiservererrors.ErrPerm, gc.Commentf("expected ErrPerm when not authenticating as the controller"))
 }
 
-func (s *charmDownloaderSuite) TestDownloadApplicationCharms(c *gc.C) {
+func (s *charmDownloaderSuite) TestDownloadApplicationCharmsDeploy(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	charmURL := charm.MustParseURL("cs:focal/dummy-1")
+	charmURL := charm.MustParseURL("ch:focal/testme-1")
 	resolvedOrigin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{
@@ -120,11 +120,111 @@ func (s *charmDownloaderSuite) TestDownloadApplicationCharms(c *gc.C) {
 	c.Assert(got.Combine(), jc.ErrorIsNil)
 }
 
+func (s *charmDownloaderSuite) TestDownloadApplicationCharmsDeployMultiAppOneCharm(c *gc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	charmURL := charm.MustParseURL("ch:focal/testme-1")
+	resolvedOrigin := corecharm.Origin{
+		Source: "charm-hub",
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+		},
+	}
+
+	mac, err := macaroon.New(nil, []byte("id"), "", macaroon.LatestVersion)
+	c.Assert(err, jc.ErrorIsNil)
+	macaroons := macaroon.Slice{mac}
+
+	pendingCharm := mocks.NewMockCharm(ctrl)
+	pendingCharm.EXPECT().Macaroon().Return(macaroons, nil).AnyTimes()
+	pendingCharm.EXPECT().URL().Return(charmURL).AnyTimes()
+
+	appOne := mocks.NewMockApplication(ctrl)
+	appOne.EXPECT().CharmPendingToBeDownloaded().Return(true)
+	appOne.EXPECT().Charm().Return(pendingCharm, false, nil)
+	appOne.EXPECT().CharmOrigin().Return(&resolvedOrigin)
+
+	appTwo := mocks.NewMockApplication(ctrl)
+	appTwo.EXPECT().CharmPendingToBeDownloaded().Return(true)
+	appTwo.EXPECT().Charm().Return(pendingCharm, false, nil)
+	appTwo.EXPECT().CharmOrigin().Return(&resolvedOrigin)
+
+	downloadedOrigin := resolvedOrigin
+	downloadedOrigin.ID = "test-charm-id"
+	downloadedOrigin.Hash = "test-charm-hash"
+	appOne.EXPECT().SetDownloadedIDAndHash(downloadedOrigin.ID, downloadedOrigin.Hash).Return(nil)
+	appTwo.EXPECT().SetDownloadedIDAndHash(downloadedOrigin.ID, downloadedOrigin.Hash).Return(nil)
+
+	s.authChecker.EXPECT().AuthController().Return(true)
+	s.stateBackend.EXPECT().Application("ufo").Return(appOne, nil)
+	s.stateBackend.EXPECT().Application("another-ufo").Return(appTwo, nil)
+	s.downloader.EXPECT().DownloadAndStore(charmURL, resolvedOrigin, macaroons, false).Return(downloadedOrigin, nil).AnyTimes()
+
+	got, err := s.api.DownloadApplicationCharms(params.Entities{
+		Entities: []params.Entity{
+			{
+				Tag: names.NewApplicationTag("ufo").String(),
+			}, {
+				Tag: names.NewApplicationTag("another-ufo").String(),
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got.Combine(), jc.ErrorIsNil)
+}
+
+func (s *charmDownloaderSuite) TestDownloadApplicationCharmsRefresh(c *gc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	charmURL := charm.MustParseURL("ch:focal/testme-1")
+	resolvedOrigin := corecharm.Origin{
+		Source: "charm-hub",
+		ID:     "test-charm-id",
+		Hash:   "test-charm-hash",
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+		},
+	}
+
+	mac, err := macaroon.New(nil, []byte("id"), "", macaroon.LatestVersion)
+	c.Assert(err, jc.ErrorIsNil)
+	macaroons := macaroon.Slice{mac}
+
+	pendingCharm := mocks.NewMockCharm(ctrl)
+	pendingCharm.EXPECT().Macaroon().Return(macaroons, nil)
+	pendingCharm.EXPECT().URL().Return(charmURL)
+
+	app := mocks.NewMockApplication(ctrl)
+	app.EXPECT().CharmPendingToBeDownloaded().Return(true)
+	app.EXPECT().Charm().Return(pendingCharm, false, nil)
+	app.EXPECT().CharmOrigin().Return(&resolvedOrigin)
+
+	downloadedOrigin := resolvedOrigin
+	downloadedOrigin.Hash = "test-charm-hash-two"
+	app.EXPECT().SetDownloadedIDAndHash(downloadedOrigin.ID, downloadedOrigin.Hash).Return(nil)
+
+	s.authChecker.EXPECT().AuthController().Return(true)
+	s.stateBackend.EXPECT().Application("ufo").Return(app, nil)
+	s.downloader.EXPECT().DownloadAndStore(charmURL, resolvedOrigin, macaroons, false).Return(downloadedOrigin, nil)
+
+	got, err := s.api.DownloadApplicationCharms(params.Entities{
+		Entities: []params.Entity{
+			{
+				Tag: names.NewApplicationTag("ufo").String(),
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got.Combine(), jc.ErrorIsNil)
+}
+
 func (s *charmDownloaderSuite) TestDownloadApplicationCharmsSetStatusIfDownloadFails(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	charmURL := charm.MustParseURL("cs:focal/dummy-1")
+	charmURL := charm.MustParseURL("ch:focal/testme-1")
 	resolvedOrigin := corecharm.Origin{
 		Source: "charm-hub",
 		Platform: corecharm.Platform{

--- a/apiserver/facades/controller/charmdownloader/package_test.go
+++ b/apiserver/facades/controller/charmdownloader/package_test.go
@@ -6,12 +6,12 @@ package charmdownloader
 import (
 	stdtesting "testing"
 
-	"github.com/juju/juju/testing"
+	gc "gopkg.in/check.v1"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mocks.go github.com/juju/juju/apiserver/facades/controller/charmdownloader StateBackend,ModelBackend,Application,Charm,Downloader,AuthChecker,ResourcesBackend
 //go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/mock_watcher.go github.com/juju/juju/state StringsWatcher
 
 func TestAll(t *stdtesting.T) {
-	testing.MgoTestPackage(t)
+	gc.TestingT(t)
 }

--- a/state/application.go
+++ b/state/application.go
@@ -3825,8 +3825,15 @@ func (a *Application) CharmPendingToBeDownloaded() bool {
 	if err != nil {
 		return false
 	}
-
-	return !ch.IsPlaceholder() && !ch.IsUploaded()
+	origin := a.CharmOrigin()
+	if origin == nil {
+		return false
+	}
+	// The charm may be downloaded, but the application's
+	// data may not updated yet. This can happen when multiple
+	// applications share a charm.
+	notReady := origin.Source == "charm-hub" && origin.ID == ""
+	return !ch.IsPlaceholder() && !ch.IsUploaded() || notReady
 }
 
 func appUnitNames(st *State, appName string) ([]string, error) {
@@ -3867,11 +3874,7 @@ func (st *State) WatchApplicationsWithPendingCharms() StringsWatcher {
 			if app == nil {
 				return false
 			}
-			origin := app.CharmOrigin()
-			if origin == nil {
-				return false
-			}
-			return app.CharmPendingToBeDownloaded() || origin.Source == "charm-hub" && origin.ID == ""
+			return app.CharmPendingToBeDownloaded()
 		},
 		// We want to be notified for application documents as soon as
 		// they appear in the collection. As the revno for inserted

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -5361,6 +5361,32 @@ func (s *ApplicationSuite) TestWatchApplicationsWithPendingCharms(c *gc.C) {
 		Charm: ch3,
 		CharmOrigin: &state.CharmOrigin{
 			Source: "charm-hub",
+			ID:     "charm-hub-id",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertNoChange()
+
+	// Simulate a bundle deploying multiple applications from a single
+	// charm. The watcher needs to notify on the secondary applications.
+	appSameCharm, err := s.State.AddApplication(state.AddApplicationArgs{
+		Name:  "mysql-testing",
+		Charm: ch3,
+		CharmOrigin: &state.CharmOrigin{
+			Source: "charm-hub",
+			Platform: &state.Platform{
+				OS:      "ubuntu",
+				Channel: "22.04/stable",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	wc.AssertChange(appSameCharm.Name())
+	_ = appSameCharm.SetCharm(state.SetCharmConfig{
+		Charm: ch3,
+		CharmOrigin: &state.CharmOrigin{
+			Source: "charm-hub",
+			ID:     "charm-hub-id",
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -303,10 +303,22 @@ func AddTestingApplicationWithStorage(c *gc.C, st *State, name string, ch *Charm
 	}
 	base, err := coreseries.GetBaseFromSeries(series)
 	c.Assert(err, jc.ErrorIsNil)
-	origin := &CharmOrigin{Platform: &Platform{
-		OS:      base.OS,
-		Channel: base.Channel.String(),
-	}}
+	var source string
+	switch ch.URL().Schema {
+	case "local":
+		source = "local"
+	case "ch":
+		source = "charm-hub"
+	case "cs":
+		source = "charm-store"
+	}
+	origin := &CharmOrigin{
+		Source: source,
+		Platform: &Platform{
+			OS:      base.OS,
+			Channel: base.Channel.String(),
+		},
+	}
 	return addTestingApplication(c, addTestingApplicationParams{
 		st:      st,
 		name:    name,
@@ -351,10 +363,22 @@ func addTestingApplication(c *gc.C, params addTestingApplicationParams) *Applica
 	if origin == nil {
 		base, err := coreseries.GetBaseFromSeries(params.ch.URL().Series)
 		c.Assert(err, jc.ErrorIsNil)
-		origin = &CharmOrigin{Platform: &Platform{
-			OS:      base.OS,
-			Channel: base.Channel.String(),
-		}}
+		var source string
+		switch params.ch.URL().Schema {
+		case "local":
+			source = "local"
+		case "ch":
+			source = "charm-hub"
+		case "cs":
+			source = "charm-store"
+		}
+		origin = &CharmOrigin{
+			Source: source,
+			Platform: &Platform{
+				OS:      base.OS,
+				Channel: base.Channel.String(),
+			},
+		}
 	}
 	app, err := params.st.AddApplication(AddApplicationArgs{
 		Name:             params.name,

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1384,7 +1384,7 @@ func (i *importer) makeCharmOrigin(a description.Application) (*CharmOrigin, err
 			return nil, errors.Trace(err)
 		}
 		track := c.Track
-		if charm.CharmHub.Matches(co.Source()) && track == "" {
+		if corecharm.CharmHub.Matches(co.Source()) && track == "" {
 			track = "latest"
 		}
 		channel = &Channel{

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -512,7 +512,7 @@ func (s *MigrationImportSuite) setupSourceApplications(
 	application, pwd := f.MakeApplicationReturningPassword(c, &factory.ApplicationParams{
 		Charm: testCharm,
 		CharmOrigin: &state.CharmOrigin{
-			Source:   testCharm.URL().Schema,
+			Source:   "charm-store",
 			Type:     "charm",
 			Revision: &testCharm.URL().Revision,
 			Channel: &state.Channel{
@@ -2821,7 +2821,7 @@ func (s *MigrationImportSuite) TestApplicationAddLatestCharmChannelTrack(c *gc.C
 	})
 	c.Assert(testCharm.Meta().Resources, gc.HasLen, 3)
 	origin := &state.CharmOrigin{
-		Source:   testCharm.URL().Schema,
+		Source:   "charm-hub",
 		Type:     "charm",
 		Revision: &testCharm.URL().Revision,
 		Channel: &state.Channel{

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/utils/v3"
 	"github.com/juju/utils/v3/arch"
 	"github.com/juju/version/v2"
+	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/environschema.v1"
 	"gopkg.in/yaml.v2"
@@ -2827,6 +2828,8 @@ func (s *MigrationImportSuite) TestApplicationAddLatestCharmChannelTrack(c *gc.C
 		Channel: &state.Channel{
 			Risk: "edge",
 		},
+		ID:   "charm-hub-id",
+		Hash: "charmhub-hash",
 		Platform: &state.Platform{
 			Architecture: testCharm.URL().Architecture,
 			OS:           "ubuntu",
@@ -2846,7 +2849,68 @@ func (s *MigrationImportSuite) TestApplicationAddLatestCharmChannelTrack(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 	exportedOrigin := application.CharmOrigin()
 	exportedOrigin.Channel.Track = "latest"
-	c.Assert(importedApp.CharmOrigin(), gc.DeepEquals, exportedOrigin)
+	c.Assert(importedApp.CharmOrigin(), gc.DeepEquals, exportedOrigin, gc.Commentf("obtained %s", pretty.Sprint(importedApp.CharmOrigin())))
+}
+
+func (s *MigrationImportSuite) TestApplicationFillInCharmOriginID(c *gc.C) {
+	st := s.State
+	// Add a application with charm settings, app config, and leadership settings.
+	f := factory.NewFactory(st, s.StatePool)
+
+	// Add a application with charm settings, app config, and leadership settings.
+	testCharm := f.MakeCharmV2(c, &factory.CharmParams{
+		Name: "snappass-test", // it has resources
+	})
+	c.Assert(testCharm.Meta().Resources, gc.HasLen, 3)
+	origin := &state.CharmOrigin{
+		Source:   "charm-hub",
+		Type:     "charm",
+		Revision: &testCharm.URL().Revision,
+		Channel: &state.Channel{
+			Risk: "edge",
+		},
+		ID:   "charm-hub-id",
+		Hash: "charmhub-hash",
+		Platform: &state.Platform{
+			Architecture: testCharm.URL().Architecture,
+			OS:           "ubuntu",
+			Channel:      "12.10/stable",
+		},
+	}
+	appOne := f.MakeApplication(c, &factory.ApplicationParams{
+		Name:        "one",
+		Charm:       testCharm,
+		CharmOrigin: origin,
+	})
+	originNoID := origin
+	originNoID.ID = ""
+	originNoID.Hash = ""
+	appTwo := f.MakeApplication(c, &factory.ApplicationParams{
+		Name:        "two",
+		Charm:       testCharm,
+		CharmOrigin: origin,
+	})
+	appThree := f.MakeApplication(c, &factory.ApplicationParams{
+		Name:        "three",
+		Charm:       testCharm,
+		CharmOrigin: origin,
+	})
+	allApplications, err := s.State.AllApplications()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(allApplications, gc.HasLen, 3)
+
+	_, newSt := s.importModel(c, s.State)
+	importedAppOne, err := newSt.Application(appOne.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	importedAppTwo, err := newSt.Application(appTwo.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	importedAppThree, err := newSt.Application(appThree.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	obtainedChOrigOne := importedAppOne.CharmOrigin()
+	obtainedChOrigTwo := importedAppTwo.CharmOrigin()
+	obtainedChOrigThree := importedAppThree.CharmOrigin()
+	c.Assert(obtainedChOrigTwo.ID, gc.Equals, obtainedChOrigOne.ID)
+	c.Assert(obtainedChOrigThree.ID, gc.Equals, obtainedChOrigOne.ID)
 }
 
 func (s *MigrationImportSuite) TestSecrets(c *gc.C) {

--- a/state/state.go
+++ b/state/state.go
@@ -1111,6 +1111,9 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 	if args.CharmOrigin == nil {
 		return nil, errors.Errorf("charm origin is nil")
 	}
+	if args.CharmOrigin.Platform == nil {
+		return nil, errors.Errorf("charm origin platform is nil")
+	}
 
 	// If either the charm origin ID or Hash is set before a charm is
 	// downloaded, charm download will fail for charms with a forced series.

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"github.com/juju/errors"
-
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/mgo/v3/txn"
 )
@@ -94,4 +93,63 @@ func applyToAllModelSettings(st *State, change func(*settingsDoc) (bool, error))
 		return errors.Trace(st.runRawTransaction(ops))
 	}
 	return nil
+}
+
+// CorrectCharmOriginsMultiAppSingleCharm corrects application charm origins
+// where the charm has been downloaded, however the origin was not updated
+// with ID and Hash data. Per LP 1999060, usually seen with multi application
+// using same charm bundles.
+func CorrectCharmOriginsMultiAppSingleCharm(pool *StatePool) error {
+	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
+		col, closer := st.db().GetCollection(applicationsC)
+		defer closer()
+
+		var docsWithID, docsWithoutID []applicationDoc
+		if err := col.Find(bson.D{
+			{"charm-origin.id", bson.M{"$eq": ""}},
+			{"charm-origin.source", bson.M{"$eq": "charm-hub"}},
+		}).All(&docsWithoutID); err != nil {
+			return errors.Trace(err)
+		}
+		if len(docsWithoutID) == 0 {
+			return nil // nothing to do
+		}
+		if err := col.Find(bson.D{
+			{"charm-origin.id", bson.M{"$ne": ""}},
+			{"charm-origin.source", bson.M{"$eq": "charm-hub"}},
+		}).All(&docsWithID); err != nil {
+			return errors.Trace(err)
+		}
+
+		charmOrigins := make(map[string]CharmOrigin, len(docsWithID))
+		for _, doc := range docsWithID {
+			if doc.CharmURL == nil {
+				return errors.Errorf("application %q missing charm url", doc.Name)
+			}
+			charmOrigins[*doc.CharmURL] = doc.CharmOrigin
+		}
+
+		var ops []txn.Op
+		for _, doc := range docsWithoutID {
+			if doc.CharmURL == nil {
+				return errors.Errorf("application %q missing charm url", doc.Name)
+			}
+			if origin, ok := charmOrigins[*doc.CharmURL]; ok {
+				ops = append(ops, txn.Op{
+					C:      applicationsC,
+					Id:     doc.DocID,
+					Assert: txn.DocExists,
+					Update: bson.D{{"$set", bson.D{{"charm-origin.id", origin.ID},
+						{"charm-origin.hash", origin.Hash}}}},
+				})
+			} else {
+				return errors.Errorf("application %q missing charm origin for %q", doc.Name, *doc.CharmURL)
+			}
+		}
+
+		if len(ops) > 0 {
+			return errors.Trace(st.runRawTransaction(ops))
+		}
+		return nil
+	}))
 }

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -6,6 +6,7 @@ package state
 import (
 	"sort"
 
+	"github.com/juju/charm/v9"
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/names/v4"
@@ -189,6 +190,204 @@ func (s *upgradesSuite) makeApplication(c *gc.C, uuid, name string, life Life) {
 		Life:      life,
 	})
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *upgradesSuite) TestCorrectCharmOriginsMultiAppSingleCharm(c *gc.C) {
+	model1 := s.makeModel(c, "model-1", coretesting.Attrs{})
+	model2 := s.makeModel(c, "model-2", coretesting.Attrs{})
+	defer func() {
+		_ = model1.Close()
+		_ = model2.Close()
+	}()
+
+	uuid1 := model1.ModelUUID()
+	uuid2 := model2.ModelUUID()
+
+	appColl, appCloser := s.state.db().GetRawCollection(applicationsC)
+	defer appCloser()
+
+	var err error
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid1, "app1"),
+		"name":       "app1",
+		"model-uuid": uuid1,
+		"charmurl":   charm.MustParseURL("cs:test").String(),
+		"charm-origin": bson.M{
+			"source": "charm-store",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid1, "app2"),
+		"name":       "app2",
+		"model-uuid": uuid1,
+		"charmurl":   charm.MustParseURL("ch:amd64/focal/test").String(),
+		"charm-origin": bson.M{
+			"source":   "charm-hub",
+			"type":     "charm",
+			"id":       "yyyy5",
+			"hash":     "xxxx5",
+			"revision": 12,
+			"channel": bson.M{
+				"track": "latest",
+				"risk":  "edge",
+			},
+			"platform": bson.M{
+				"architecture": "amd64",
+				"os":           "ubuntu",
+				"channel":      "20.04",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid2, "app3"),
+		"name":       "app3",
+		"model-uuid": uuid2,
+		"charmurl":   charm.MustParseURL("local:test2").String(),
+		"charm-origin": bson.M{
+			"source": "local",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid2, "app4"),
+		"name":       "app4",
+		"model-uuid": uuid2,
+		"charmurl":   charm.MustParseURL("ch:amd64/focal/testtwo").String(),
+		"charm-origin": bson.M{
+			"source":   "charm-hub",
+			"type":     "charm",
+			"id":       "yyyy",
+			"hash":     "xxxx",
+			"revision": 12,
+			"channel": bson.M{
+				"track": "latest",
+				"risk":  "edge",
+			},
+			"platform": bson.M{
+				"architecture": "amd64",
+				"os":           "ubuntu",
+				"channel":      "20.04",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = appColl.Insert(bson.M{
+		"_id":        ensureModelUUID(uuid2, "app5"),
+		"name":       "app5",
+		"model-uuid": uuid2,
+		"charmurl":   charm.MustParseURL("ch:amd64/focal/testtwo").String(),
+		"charm-origin": bson.M{
+			"source":   "charm-hub",
+			"type":     "charm",
+			"id":       "",
+			"hash":     "",
+			"revision": 12,
+			"channel": bson.M{
+				"track": "8.0",
+				"risk":  "stable",
+			},
+			"platform": bson.M{
+				"architecture": "amd64",
+				"os":           "ubuntu",
+				"channel":      "20.04",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := bsonMById{
+		{
+			"_id":        ensureModelUUID(uuid1, "app1"),
+			"model-uuid": uuid1,
+			"name":       "app1",
+			"charmurl":   "cs:test",
+			"charm-origin": bson.M{
+				"source": "charm-store",
+			},
+		},
+		{
+			"_id":        ensureModelUUID(uuid1, "app2"),
+			"model-uuid": uuid1,
+			"name":       "app2",
+			"charmurl":   "ch:amd64/focal/test",
+			"charm-origin": bson.M{
+				"source":   "charm-hub",
+				"type":     "charm",
+				"id":       "yyyy5",
+				"hash":     "xxxx5",
+				"revision": 12,
+				"channel": bson.M{
+					"track": "latest",
+					"risk":  "edge",
+				},
+				"platform": bson.M{
+					"architecture": "amd64",
+					"os":           "ubuntu",
+					"channel":      "20.04",
+				},
+			},
+		},
+		{
+			"_id":        ensureModelUUID(uuid2, "app3"),
+			"model-uuid": uuid2,
+			"name":       "app3",
+			"charmurl":   "local:test2",
+			"charm-origin": bson.M{
+				"source": "local",
+			},
+		},
+		{
+			"_id":        ensureModelUUID(uuid2, "app4"),
+			"model-uuid": uuid2,
+			"name":       "app4",
+			"charmurl":   charm.MustParseURL("ch:amd64/focal/testtwo").String(),
+			"charm-origin": bson.M{
+				"source":   "charm-hub",
+				"type":     "charm",
+				"id":       "yyyy",
+				"hash":     "xxxx",
+				"revision": 12,
+				"channel": bson.M{
+					"track": "latest",
+					"risk":  "edge",
+				},
+				"platform": bson.M{
+					"architecture": "amd64",
+					"os":           "ubuntu",
+					"channel":      "20.04",
+				},
+			},
+		},
+		{
+			"_id":        ensureModelUUID(uuid2, "app5"),
+			"model-uuid": uuid2,
+			"name":       "app5",
+			"charmurl":   charm.MustParseURL("ch:amd64/focal/testtwo").String(),
+			"charm-origin": bson.M{
+				"source":   "charm-hub",
+				"type":     "charm",
+				"id":       "yyyy",
+				"hash":     "xxxx",
+				"revision": 12,
+				"channel": bson.M{
+					"track": "8.0",
+					"risk":  "stable",
+				},
+				"platform": bson.M{
+					"architecture": "amd64",
+					"os":           "ubuntu",
+					"channel":      "20.04",
+				},
+			},
+		},
+	}
+
+	sort.Sort(expected)
+	s.assertUpgradedData(c, CorrectCharmOriginsMultiAppSingleCharm,
+		upgradedData(appColl, expected),
+	)
 }
 
 type docById []bson.M

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -11,6 +11,7 @@ import (
 
 // StateBackend provides an interface for upgrading the global state database.
 type StateBackend interface {
+	CorrectCharmOriginsMultiAppSingleCharm() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -27,4 +28,8 @@ func NewStateBackend(pool *state.StatePool) StateBackend {
 
 type stateBackend struct {
 	pool *state.StatePool
+}
+
+func (s stateBackend) CorrectCharmOriginsMultiAppSingleCharm() error {
+	return state.CorrectCharmOriginsMultiAppSingleCharm(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -20,6 +20,7 @@ import (
 var stateUpgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("3.0.0"), stateStepsFor30()},
+		upgradeToVersion{version.MustParse("3.0.3"), stateStepsFor303()},
 	}
 	return steps
 }

--- a/upgrades/steps_303.go
+++ b/upgrades/steps_303.go
@@ -1,0 +1,17 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+// stateStepsFor303 returns database upgrade steps for Juju 3.0.3
+func stateStepsFor303() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "add charm-origin id and hash where missing, if charm already downloaded",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().CorrectCharmOriginsMultiAppSingleCharm()
+			},
+		},
+	}
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -597,7 +597,7 @@ func (s *upgradeSuite) TestUpgradeOperationsOrdered(c *gc.C) {
 func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
-		"3.0.0",
+		"3.0.0", "3.0.3",
 	})
 }
 


### PR DESCRIPTION
Note: 6ed17b8 was cherry-picked from #15090 

Enabling async download of charm-hub charms in juju 3.0 broke the scenario of deploying a bundle with the same charm used for multiple applications. A very common scenario in Canonical bundles.

The charmdownloader would only apply the charm-hub ID and Hash to a single application using the charm, rather than all. The worker checked to see if CharmPendingToBeDownloaded was true for an application, if so, did nothing else. Downloading the charm changed the value for all applications, however the CharmOrigin was only updated for the first one. Instead allow the downloader to handle this, it will not actually download twice, but will update the CharmOrigin. 

The second piece is to fix a timing window where the watcher for the charmdownloader may not be triggered. If the charm is downloaded before the application is added, WatchApplicationsWithPendingCharms would never notify the charmdownloader and the CharmOrigin data would not be updated. This can be seen by adding `time.Sleep(time.Minute)` to the end of addApplication in bundleHandler.

## QA steps

```sh
 (cd tests ; ./main.sh deploy test_deploy_bundles)
```

Deploy a test bundle as defined in the bug to juju 3.0.2. Test model migration and upgrade to ensure the charms can be refresh afterwards. Or in the case of k8s charms, finish downloading and installing the resource image.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1999060
