### PR TITLE
[JUJU-2522] Fixed test-ck-aws

### DIFF
--- a/tests/suites/ck/ck.sh
+++ b/tests/suites/ck/ck.sh
@@ -11,9 +11,7 @@ run_deploy_ck() {
 	ensure "${model_name}" "${file}"
 
 	overlay_path="./tests/suites/ck/overlay/${BOOTSTRAP_PROVIDER}.yaml"
-	# TODO: pin CK test to 1.24/stable for now, remove once 1.25/stable fixed.
-	# Issue: `0/5 nodes are available: 5 pod has unbound immediate PersistentVolumeClaims. preemption: 0/5 nodes are available: 5 Preemption is not helpful for scheduling.` But the cluster does have 5 READY worker nodes.
-	juju deploy charmed-kubernetes --overlay "${overlay_path}" --trust --channel 1.24/stable
+	juju deploy charmed-kubernetes --overlay "${overlay_path}" --trust
 
 	if ! which "kubectl" >/dev/null 2>&1; then
 		sudo snap install kubectl --classic --channel latest/stable

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -17,4 +17,5 @@ test_ck() {
 
 	# CK takes too long to tear down (1h+), so forcibly destroy it
 	export KILL_CONTROLLER=true
+  destroy_controller "test-ck"
 }

--- a/tests/suites/ck/task.sh
+++ b/tests/suites/ck/task.sh
@@ -17,5 +17,5 @@ test_ck() {
 
 	# CK takes too long to tear down (1h+), so forcibly destroy it
 	export KILL_CONTROLLER=true
-  destroy_controller "test-ck"
+	destroy_controller "test-ck"
 }


### PR DESCRIPTION
This PR remove focus on 1.24 ck version. The problem of this integration test was in the lack of permissions for aws user to operate with `aws-intergrator` charm.

To do it properly you need to add the following policy to your `Security credentials` in aws account:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "iam:AttachRolePolicy",
                "iam:CreateRole",
                "iam:PassRole",
                "iam:CreatePolicy",
                "iam:PutRolePolicy",
                "iam:CreateInstanceProfile",
                "iam:AddRoleToInstanceProfile"
            ],
            "Resource": "*"
        }
    ]
}
```

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
~- [ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
# add (or verify) policy in your aws account
cd tests
./main.sh -v -p aws ck
```