### PR TITLE
[JUJU-2552] Respect model constraints bundle

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -535,7 +535,7 @@ func (h *bundleHandler) getChanges() error {
 		Bundle:           h.data,
 		BundleURL:        bundleURL,
 		Model:            h.model,
-		ConstraintGetter: addCharmConstraintsParser,
+		ConstraintGetter: addCharmConstraintsParser(h.modelConstraints),
 		CharmResolver:    h.resolveCharmChannelAndRevision,
 		Logger:           logger,
 		Force:            h.force,
@@ -1749,8 +1749,18 @@ func isUserAlreadyHasAccessErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "user already has")
 }
 
+func addCharmConstraintsParser(defaultConstraints constraints.Value) func(string) bundlechanges.ArchConstraint {
+	return func(s string) bundlechanges.ArchConstraint {
+		return bundleArchConstraint{
+			constraints:        s,
+			defaultConstraints: defaultConstraints,
+		}
+	}
+}
+
 type bundleArchConstraint struct {
-	constraints string
+	constraints        string
+	defaultConstraints constraints.Value
 }
 
 func (b bundleArchConstraint) Arch() (string, error) {
@@ -1758,13 +1768,7 @@ func (b bundleArchConstraint) Arch() (string, error) {
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return arch.ConstraintArch(cons, nil), nil
-}
-
-func addCharmConstraintsParser(s string) bundlechanges.ArchConstraint {
-	return bundleArchConstraint{
-		constraints: s,
-	}
+	return arch.ConstraintArch(cons, &b.defaultConstraints), nil
 }
 
 func verifyEndpointBindings(endpointBindings map[string]string, knownSpaceNames set.Strings) error {

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -141,6 +141,57 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleSuccess(c *gc.C) {
 		"Deploy of bundle completed.\n")
 }
 
+func (s *BundleDeployRepositorySuite) TestDeployBundleSuccessWithModelConstraints(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectEmptyModelToStart(c)
+	s.expectWatchAll()
+
+	mysqlCurl, err := charm.ParseURL("cs:mysql-42")
+	c.Assert(err, jc.ErrorIsNil)
+	wordpressCurl, err := charm.ParseURL("cs:wordpress-47")
+	c.Assert(err, jc.ErrorIsNil)
+	chUnits := []charmUnit{
+		{
+			curl:            mysqlCurl,
+			charmMetaSeries: []string{"bionic", "xenial"},
+			machine:         "0",
+			machineSeries:   "xenial",
+		},
+		{
+			charmMetaSeries: []string{"bionic", "xenial"},
+			curl:            wordpressCurl,
+			machine:         "1",
+			machineSeries:   "xenial",
+		},
+	}
+	s.setupCharmUnits(chUnits)
+	s.expectAddRelation([]string{"wordpress:db", "mysql:db"})
+
+	bundleData, err := charm.ReadBundleData(strings.NewReader(wordpressBundle))
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = bundleDeploy(charm.CharmHub, bundleData, s.bundleDeploySpecWithConstraints(constraints.MustParse("arch=arm64")))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.deployArgs, gc.HasLen, 2)
+	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "xenial")
+	s.assertDeployArgs(c, mysqlCurl.String(), "mysql", "xenial")
+
+	c.Check(s.output.String(), gc.Equals, ""+
+		"Located charm \"mysql\" in charm-store, revision 42\n"+
+		"Located charm \"wordpress\" in charm-store, revision 47\n"+
+		"Executing changes:\n"+
+		"- upload charm mysql from charm-store for series xenial with architecture=arm64\n"+
+		"- deploy application mysql from charm-store on xenial\n"+
+		"- upload charm wordpress from charm-store for series xenial with architecture=arm64\n"+
+		"- deploy application wordpress from charm-store on xenial\n"+
+		"- add new machine 0\n"+
+		"- add new machine 1\n"+
+		"- add relation wordpress:db - mysql:db\n"+
+		"- add unit mysql/0 to new machine 0\n"+
+		"- add unit wordpress/0 to new machine 1\n"+
+		"Deploy of bundle completed.\n")
+}
+
 const wordpressBundle = `
 series: bionic
 applications:
@@ -1316,6 +1367,10 @@ machines:
 `
 
 func (s *BundleDeployRepositorySuite) bundleDeploySpec() bundleDeploySpec {
+	return s.bundleDeploySpecWithConstraints(constraints.Value{})
+}
+
+func (s *BundleDeployRepositorySuite) bundleDeploySpecWithConstraints(cons constraints.Value) bundleDeploySpec {
 	deployResourcesFunc := func(_ string,
 		_ resources.CharmID,
 		_ *macaroon.Macaroon,
@@ -1333,8 +1388,9 @@ func (s *BundleDeployRepositorySuite) bundleDeploySpec() bundleDeploySpec {
 			Stderr: s.stdErr,
 			Stdout: s.stdOut,
 		},
-		bundleResolver:  s.bundleResolver,
-		deployResources: deployResourcesFunc,
+		bundleResolver:   s.bundleResolver,
+		deployResources:  deployResourcesFunc,
+		modelConstraints: cons,
 	}
 }
 


### PR DESCRIPTION
When deploying a bundle with no constraints within the application, we
should check the model constraints before attempting to fallback to the
default architecture.
This was originally coded like this because the aim was just to get the
code working. We never went back to make sure that the bundle correctly
checked every level of constraints in the right order. Those being:

 - user provided constraints
 - application constraints
 - model constraints
 - default constraints (architecture)

The code is really simple, just pass in the existing model constraints
from the model when working out what the application constraint should
be.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap aws test --build-agent
$ juju set-model-constraints "arch=arm64"
$ AGENT_PACKAGE_PLATFORMS="linux/arm64" make build
$ juju sync-agent-binaries --source $GOPATH/src/github.com/juju/juju/_build
$ cat >> bundle.yaml << 'END'
series: jammy
applications:
  ubuntu:
    series: jammy
    charm: ubuntu
    num_units: 1
END
$ juju deploy ~/bundle.yaml
Located charm "ubuntu" in charm-hub, channel stable
Executing changes:
- upload charm ubuntu from charm-hub for series jammy with architecture=arm64
- deploy application ubuntu from charm-hub on jammy
- add unit ubuntu/0 to new machine 0
Deploy of bundle completed.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1993660
