### PR TITLE
[JUJU-2576] Optimise status

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1338,7 +1338,8 @@ func (context *statusContext) processApplication(application *state.Application)
 		processedStatus.WorkloadVersion = versions[0].Message
 	}
 
-	if processedStatus.WorkloadVersion == "" && context.model.Type() == state.ModelTypeCAAS {
+	modelType := context.model.Type()
+	if processedStatus.WorkloadVersion == "" && modelType == state.ModelTypeCAAS {
 		// We'll punt on using the docker image name.
 		caasModel, err := context.model.CAASModel()
 		if err != nil {
@@ -1362,16 +1363,18 @@ func (context *statusContext) processApplication(application *state.Application)
 			}
 		}
 	}
-	serviceInfo, err := application.ServiceInfo()
-	if err == nil {
-		processedStatus.ProviderId = serviceInfo.ProviderId()
-		if len(serviceInfo.Addresses()) > 0 {
-			processedStatus.PublicAddress = serviceInfo.Addresses()[0].Value
+	if modelType == state.ModelTypeCAAS {
+		serviceInfo, err := application.ServiceInfo()
+		if err == nil {
+			processedStatus.ProviderId = serviceInfo.ProviderId()
+			if len(serviceInfo.Addresses()) > 0 {
+				processedStatus.PublicAddress = serviceInfo.Addresses()[0].Value
+			}
+		} else {
+			logger.Debugf("no service details for %v: %v", application.Name(), err)
 		}
-	} else {
-		logger.Debugf("no service details for %v: %v", application.Name(), err)
+		processedStatus.Scale = application.GetScale()
 	}
-	processedStatus.Scale = application.GetScale()
 	processedStatus.EndpointBindings = context.allAppsUnitsCharmBindings.endpointBindings[application.Name()]
 	return processedStatus
 }


### PR DESCRIPTION
FullStatus was unnecessarily calling CAAS-only methods for non-CAAS models. Optimise this

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Verify for both CAAS and IAAS models that `juju status` is unaffected when applications are deployed

Verify that `DEBUG juju.apiserver.client no service details for blah:blah` is no longer logged by the controller when getting the status of an IAAS model

## Bug Reference

https://bugs.launchpad.net/juju/+bug/1989183