### PR TITLE
[JUJU-2585]  Allow cross compiling jujud per GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ define run_cgo_build
 	$(eval BUILD_ARCH = $(subst ppc64el,ppc64le,${ARCH}))
 	@@mkdir -p ${BBIN_DIR}
 	@echo "Building ${PACKAGE} for ${OS}/${ARCH}"
-	@env PATH=${PATH}:/usr/local/musl/bin \
+	@env PATH=${PATH}:${MUSL_CROSS_BIN_PATH} \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
 		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
@@ -244,7 +244,7 @@ endef
 
 define run_cgo_install
 	@echo "Installing ${PACKAGE}"
-	@env PATH=${PATH}:/usr/local/musl/bin \
+	env PATH=${PATH}:${MUSL_BIN_PATH} \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
 		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
@@ -318,7 +318,7 @@ ${BUILD_DIR}/%/bin/jujuc: phony_explicit
 	$(run_go_build)
 
 ${BUILD_DIR}/%/bin/jujud: PACKAGE = github.com/juju/juju/cmd/jujud
-${BUILD_DIR}/%/bin/jujud: phony_explicit musl-install-if-missing dqlite-deps-check
+${BUILD_DIR}/%/bin/jujud: phony_explicit musl-cross-arch-install dqlite-deps-check
 # build for jujud
 	$(run_cgo_build)
 

--- a/scripts/dqlite/Makefile
+++ b/scripts/dqlite/Makefile
@@ -17,7 +17,13 @@ DQLITE_S3_ARCHIVE_NAME=$(shell date -u +"%Y-%m-%d")-dqlite-deps-${DQLITE_BUILD_A
 DQLITE_S3_ARCHIVE_PATH=${DQLITE_S3_BUCKET}/${DQLITE_S3_ARCHIVE_NAME}
 
 DQLITE_EXTRACTED_DEPS_PATH=${PROJECT_DIR}/_deps
-DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH=${DQLITE_EXTRACTED_DEPS_PATH}/juju-dqlite-static-lib-deps
+DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH=${DQLITE_EXTRACTED_DEPS_PATH}/dqlite-deps-${DQLITE_BUILD_ARCH}
+
+MUSL_PATH=/usr/local/musl
+MUSL_BIN_PATH=${MUSL_PATH}/bin
+
+MUSL_CROSS_PATH=$(GOPATH)/build/musl-${DQLITE_BUILD_ARCH}
+MUSL_CROSS_BIN_PATH=${MUSL_CROSS_PATH}/output/bin
 
 # Versions for Dqlite and upstream dependencies.
 TAG_LIBTIRPC=upstream/1.3.3
@@ -90,6 +96,7 @@ dqlite-deps-pull:
 	@rm -rf ${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}
 	@echo "DQLITE: Pulling latest-dqlite-deps-${DQLITE_BUILD_ARCH}.tar.bz2 from s3"
 	wget -q -O- https://dqlite-static-libs.s3.amazonaws.com/latest-dqlite-deps-${DQLITE_BUILD_ARCH}.tar.bz2 - | tar xjf - -C ${DQLITE_EXTRACTED_DEPS_PATH}
+	@mv ${DQLITE_EXTRACTED_DEPS_PATH}/juju-dqlite-static-lib-deps ${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}
 
 dqlite-deps-check:
 	@if [ ! -d ${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} ]; then \
@@ -106,8 +113,8 @@ musl-ensure-symlink:
 
 musl-check:
 	@PATH=${PATH}:/usr/local/musl/bin which musl-gcc >/dev/null || echo "Please run 'sudo make musl-install'"
-	# @$(MAKE) -s musl-ensure-symlink d=include/asm s=/usr/include/${DQLITE_BUILD_MACHINE}-linux-gnu/asm
-	# @$(MAKE) -s musl-ensure-symlink d=include/asm-generic s=/usr/include/asm-generic
+	@$(MAKE) -s musl-ensure-symlink d=include/asm s=/usr/include/${DQLITE_BUILD_MACHINE}-linux-gnu/asm
+	@$(MAKE) -s musl-ensure-symlink d=include/asm-generic s=/usr/include/asm-generic
 	@$(MAKE) -s musl-ensure-symlink d=include/linux s=/usr/include/linux
 
 musl-install:
@@ -124,8 +131,57 @@ musl-install:
 	ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic
 	ln -s /usr/include/linux /usr/local/musl/include/linux
 
+musl-cross-arch-install:
+	@PATH=${PATH}:${MUSL_CROSS_BIN_PATH} which musl-gcc >/dev/null && { echo "musl already installed ${MUSL_CROSS_PATH}"; exit 0; }
+
+	@mkdir -p ${MUSL_CROSS_PATH}
+	git clone git@github.com:richfelker/musl-cross-make.git ${MUSL_CROSS_PATH}
+	@cd ${MUSL_CROSS_PATH}
+
+	@mkdir -p ${MUSL_CROSS_PATH}/build
+
+	@if [ "${DQLITE_BUILD_ARCH}" = "amd64" ]; then
+		@echo "TARGET=x86_64-linux-musl" >> config.mak
+	fi
+	@if [ "${DQLITE_BUILD_ARCH}" = "arm64" ]; then
+		@echo "TARGET=aarch64-linux-musl" >> config.mak
+	fi
+	@if [ "${DQLITE_BUILD_ARCH}" = "s390x" ]; then
+		@echo "TARGET=s390x-linux-musl" >> config.mak
+	fi
+	@if [ "${DQLITE_BUILD_ARCH}" = "ppc64le" ]; then
+		@echo "TARGET=powerpc64le-linux-musl" >> config.mak
+	fi
+	@if [ "${DQLITE_BUILD_ARCH}" = "riscv64" ]; then
+		@echo "TARGET=riscv64-linux-musl" >> config.mak
+	fi
+
+	@echo "OUTPUT=${MUSL_CROSS_PATH}/output" >> config.mak
+	@echo "COMMON_CONFIG += CFLAGS=\"-g0 -Os\" CXXFLAGS=\"-g0 -Os\" LDFLAGS=\"-s\"" >> config.mak
+
+	@echo "Building musl-${DQLITE_BUILD_ARCH}"
+	make -j$(nproc) install || { exit 1; }
+
+	@echo "Linking musl-${DQLITE_BUILD_ARCH} to musl-gcc"
+	@cd ${MUSL_CROSS_PATH}/output/bin
+	@if [ "${DQLITE_BUILD_ARCH}" = "amd64" ]; then
+		@ln -s x86_64-linux-musl-gcc musl-gcc
+	fi
+	@if [ "${DQLITE_BUILD_ARCH}" = "arm64" ]; then
+		@ln -s aarch64-linux-musl-gcc musl-gcc
+	fi
+	@if [ "${DQLITE_BUILD_ARCH}" = "s390x" ]; then
+		@ln -s s390x-linux-musl-gcc musl-gcc
+	fi
+	@if [ "${DQLITE_BUILD_ARCH}" = "ppc64le" ]; then
+		@ln -s powerpc64le-linux-musl-gcc musl-gcc
+	fi
+	@if [ "${DQLITE_BUILD_ARCH}" = "riscv64" ]; then
+		@ln -s riscv64-linux-musl-gcc musl-gcc
+	fi
+
 musl-install-if-missing:
-	@PATH=${PATH}:/usr/local/musl/bin which musl-gcc >/dev/null || { echo "Installing required musl dependencies"; sudo ${MAKE} musl-install; }
+	@PATH=${PATH}:${MUSL_BIN_PATH} which musl-gcc >/dev/null || { echo "Installing required musl dependencies"; sudo ${MAKE} musl-install; }
 
 ################################################################################
 # REPL


### PR DESCRIPTION
Note: Requires https://github.com/juju/juju/pull/15105 to land first

----

The following allows cross compiling jujud via musl-cross-make.
musl-cross-make builds musl first for the correct architecture along
with its dependencies:

  - binutils
  - gcc
  - gmp
  - mpc
  - mpfr
  - isl

The way the make file works is that if you're attempting to install
jujud locally, it will use musl for the architecture you have locally.
For building jujud it will use the musl-cross-make. It will build the
musl in $GOPATH/build/musl-$ARCH.

I've successfully built the following:

  - amd64
  - arm64
  - s390x
  - ppc64le

Unfortunately, I'm struggling to get riscv64 building, but I'd like to
get this landed first.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

Replace arch with one from list above

```sh
$ env GOARCH="s390x" make go-agent-build
```
