### PR TITLE
[JUJU-2585] GitHub action go build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
 
     - name: Build
       run: |
-        GOOS=${{ matrix.platform.os }} GOARCH=${{ matrix.platform.arch }} make go-install
+        GOOS=${{ matrix.platform.os }} GOARCH=${{ matrix.platform.arch }} make go-build


### PR DESCRIPTION
The following uses go-build instead of go-install. The difference is key here. go-install can only build and install (the latter is important here) on the target platform. go-build can still build on any platform. Because of this the Makefile is configured to do this.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Github tests

## QA steps

Github build passes for s390x, arm64 and ppc64le
