### PR TITLE
[JUJU-2585] Use updated error for TestInitializeStateFailsSecondTime  

### DIFF
--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -450,7 +450,7 @@ func (s *bootstrapSuite) TestInitializeStateFailsSecondTime(c *gc.C) {
 	if err == nil {
 		_ = st.Close()
 	}
-	c.Assert(err, gc.ErrorMatches, "bootstrapping raft cluster: bootstrap only works on new clusters")
+	c.Assert(err, gc.ErrorMatches, "creating controller database schema.*")
 }
 
 func (s *bootstrapSuite) TestMachineJobFromParams(c *gc.C) {


### PR DESCRIPTION
The TestInitializeStateFailsSecondTime was using the prior error message
for attempting to bootstrap a state package twice. The new error is
actually a lot more precise and points to the reason of failure in a
much easier way to reason about.

## Checklist


- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass