### PR TITLE
Fix show-secret CLI when using --reveal.

### DIFF
--- a/api/client/secrets/client.go
+++ b/api/client/secrets/client.go
@@ -74,10 +74,11 @@ func (api *Client) ListSecrets(reveal bool, filter secrets.Filter) ([]SecretDeta
 		details.Revisions = make([]secrets.SecretRevisionMetadata, len(r.Revisions))
 		for i, r := range r.Revisions {
 			details.Revisions[i] = secrets.SecretRevisionMetadata{
-				Revision:   r.Revision,
-				CreateTime: r.CreateTime,
-				UpdateTime: r.UpdateTime,
-				ExpireTime: r.ExpireTime,
+				Revision:    r.Revision,
+				BackendName: r.BackendName,
+				CreateTime:  r.CreateTime,
+				UpdateTime:  r.UpdateTime,
+				ExpireTime:  r.ExpireTime,
 			}
 		}
 		if reveal && r.Value != nil {

--- a/api/client/secrets/client_test.go
+++ b/api/client/secrets/client_test.go
@@ -70,6 +70,12 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 					CreateTime: now,
 					UpdateTime: now.Add(time.Second),
 					ExpireTime: ptr(now.Add(time.Hour)),
+				}, {
+					Revision:    667,
+					CreateTime:  now,
+					UpdateTime:  now.Add(time.Second),
+					ExpireTime:  ptr(now.Add(time.Hour)),
+					BackendName: ptr("some backend"),
 				}},
 				Value: &params.SecretValueResult{Data: data},
 			}},
@@ -99,6 +105,12 @@ func (s *SecretsSuite) TestListSecrets(c *gc.C) {
 			CreateTime: now,
 			UpdateTime: now.Add(time.Second),
 			ExpireTime: ptr(now.Add(time.Hour)),
+		}, {
+			Revision:    667,
+			BackendName: ptr("some backend"),
+			CreateTime:  now,
+			UpdateTime:  now.Add(time.Second),
+			ExpireTime:  ptr(now.Add(time.Hour)),
 		}},
 		Value: secrets.NewSecretValue(data),
 	}})

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -44,8 +44,7 @@ func NewSecretManagerAPI(context facade.Context) (*SecretsManagerAPI, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		cfg, _, err := secrets.AdminBackendConfigInfo(secrets.SecretsModel(model))
-		return cfg, errors.Trace(err)
+		return secrets.AdminBackendConfigInfo(secrets.SecretsModel(model))
 	}
 	return &SecretsManagerAPI{
 		authTag:             context.Auth().GetAuthTag(),

--- a/apiserver/facades/client/secrets/package_test.go
+++ b/apiserver/facades/client/secrets/package_test.go
@@ -22,7 +22,8 @@ func TestPackage(t *testing.T) {
 
 func NewTestAPI(
 	state SecretsState,
-	backendGetter func(string) (provider.SecretsBackend, error),
+	backendConfigGetter func() (*provider.ModelBackendConfigInfo, error),
+	backendGetter func(*provider.ModelBackendConfig) (provider.SecretsBackend, error),
 	authorizer facade.Authorizer,
 ) (*SecretsAPI, error) {
 	if !authorizer.AuthClient() {
@@ -30,11 +31,12 @@ func NewTestAPI(
 	}
 
 	return &SecretsAPI{
-		authorizer:     authorizer,
-		controllerUUID: coretesting.ControllerTag.Id(),
-		modelUUID:      coretesting.ModelTag.Id(),
-		state:          state,
-		backends:       make(map[string]provider.SecretsBackend),
-		backendGetter:  backendGetter,
+		authorizer:          authorizer,
+		controllerUUID:      coretesting.ControllerTag.Id(),
+		modelUUID:           coretesting.ModelTag.Id(),
+		state:               state,
+		backends:            make(map[string]provider.SecretsBackend),
+		backendConfigGetter: backendConfigGetter,
+		backendGetter:       backendGetter,
 	}, nil
 }

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -5,7 +5,6 @@ package secrets
 
 import (
 	"context"
-	"sync"
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
@@ -17,6 +16,8 @@ import (
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/secrets/provider"
+	"github.com/juju/juju/secrets/provider/juju"
+	"github.com/juju/juju/secrets/provider/kubernetes"
 	"github.com/juju/juju/state"
 )
 
@@ -25,11 +26,14 @@ type SecretsAPI struct {
 	authorizer     facade.Authorizer
 	controllerUUID string
 	modelUUID      string
+	modelName      string
 
-	state         SecretsState
-	mu            sync.Mutex
-	backends      map[string]provider.SecretsBackend
-	backendGetter func(string) (provider.SecretsBackend, error)
+	state           SecretsState
+	activeBackendID string
+	backends        map[string]provider.SecretsBackend
+
+	backendConfigGetter func() (*provider.ModelBackendConfigInfo, error)
+	backendGetter       func(*provider.ModelBackendConfig) (provider.SecretsBackend, error)
 }
 
 func (s *SecretsAPI) checkCanRead() error {
@@ -120,11 +124,24 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			UpdateTime:       m.UpdateTime,
 		}
 		for _, r := range revisionMetadata[m.URI.ID] {
+			backendName := r.BackendName
+			if backendName == nil {
+				if r.ValueRef != nil {
+					if r.ValueRef.BackendID == s.modelUUID {
+						name := kubernetes.BuiltInName(s.modelName)
+						backendName = &name
+					}
+				} else {
+					name := juju.BackendName
+					backendName = &name
+				}
+			}
 			secretResult.Revisions = append(secretResult.Revisions, params.SecretRevision{
-				Revision:   r.Revision,
-				CreateTime: r.CreateTime,
-				UpdateTime: r.UpdateTime,
-				ExpireTime: r.ExpireTime,
+				Revision:    r.Revision,
+				CreateTime:  r.CreateTime,
+				UpdateTime:  r.UpdateTime,
+				ExpireTime:  r.ExpireTime,
+				BackendName: backendName,
 			})
 		}
 		if arg.ShowSecrets {
@@ -132,10 +149,7 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 			if arg.Filter.Revision != nil {
 				rev = *arg.Filter.Revision
 			}
-			val, ref, err := s.state.GetSecretValue(m.URI, rev)
-			if ref != nil {
-				val, err = s.secretContentFromBackend(ref)
-			}
+			val, err := s.secretContentFromBackend(m.URI, rev)
 			valueResult := &params.SecretValueResult{
 				Error: apiservererrors.ServerError(err),
 			}
@@ -149,26 +163,63 @@ func (s *SecretsAPI) ListSecrets(arg params.ListSecretsArgs) (params.ListSecretR
 	return result, nil
 }
 
-func (s *SecretsAPI) getBackend(ID string) (provider.SecretsBackend, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	b, ok := s.backends[ID]
-	if ok {
-		return b, nil
-	}
-	b, err := s.backendGetter(ID)
+func (s *SecretsAPI) getBackendInfo() error {
+	info, err := s.backendConfigGetter()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
-	s.backends[ID] = b
-	return b, nil
+	for id, cfg := range info.Configs {
+		s.backends[id], err = s.backendGetter(&provider.ModelBackendConfig{
+			ControllerUUID: info.ControllerUUID,
+			ModelUUID:      info.ModelUUID,
+			ModelName:      info.ModelName,
+			BackendConfig:  cfg,
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	s.activeBackendID = info.ActiveID
+	return nil
 }
 
-func (s *SecretsAPI) secretContentFromBackend(ref *coresecrets.ValueRef) (coresecrets.SecretValue, error) {
-	backend, err := s.getBackend(ref.BackendID)
-	if err != nil {
-		return nil, err
+func (s *SecretsAPI) secretContentFromBackend(uri *coresecrets.URI, rev int) (coresecrets.SecretValue, error) {
+	if s.activeBackendID == "" {
+		err := s.getBackendInfo()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
-	return backend.GetContent(context.TODO(), ref.RevisionID)
+	lastBackendID := ""
+	for {
+		val, ref, err := s.state.GetSecretValue(uri, rev)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if ref == nil {
+			return val, nil
+		}
+
+		backendID := ref.BackendID
+		backend, ok := s.backends[backendID]
+		if !ok {
+			return nil, errors.NotFoundf("external secret backend %q, have %q", backendID, s.backends)
+		}
+		val, err = backend.GetContent(context.TODO(), ref.RevisionID)
+		if err == nil || !errors.Is(err, errors.NotFound) || lastBackendID == backendID {
+			return val, errors.Trace(err)
+		}
+		lastBackendID = backendID
+		// Secret may have been drained to the active backend.
+		if backendID != s.activeBackendID {
+			continue
+		}
+		// The active backend may have changed.
+		if initErr := s.getBackendInfo(); initErr != nil {
+			return nil, errors.Trace(initErr)
+		}
+		if s.activeBackendID == backendID {
+			return nil, errors.Trace(err)
+		}
+	}
 }

--- a/apiserver/facades/controller/undertaker/register.go
+++ b/apiserver/facades/controller/undertaker/register.go
@@ -32,8 +32,7 @@ func newUndertakerFacade(ctx facade.Context) (*UndertakerAPI, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		cfgInfo, _, err := secrets.AdminBackendConfigInfo(secrets.SecretsModel(model))
-		return cfgInfo, err
+		return secrets.AdminBackendConfigInfo(secrets.SecretsModel(model))
 	}
 	return newUndertakerAPI(&stateShim{st, m}, ctx.Resources(), ctx.Auth(), secretsBackendsGetter)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39021,6 +39021,9 @@
                 "SecretRevision": {
                     "type": "object",
                     "properties": {
+                        "backend-name": {
+                            "type": "string"
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
@@ -39796,6 +39799,9 @@
                 "SecretRevision": {
                     "type": "object",
                     "properties": {
+                        "backend-name": {
+                            "type": "string"
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"
@@ -48014,6 +48020,9 @@
                 "SecretRevision": {
                     "type": "object",
                     "properties": {
+                        "backend-name": {
+                            "type": "string"
+                        },
                         "create-time": {
                             "type": "string",
                             "format": "date-time"

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -90,6 +90,7 @@ type secretValueDetails struct {
 
 type secretRevisionDetails struct {
 	Revision   int        `json:"revision" yaml:"revision"`
+	Backend    string     `json:"backend,omitempty" yaml:"backend,omitempty"`
 	CreateTime time.Time  `json:"created" yaml:"created"`
 	UpdateTime time.Time  `json:"updated" yaml:"updated"`
 	ExpireTime *time.Time `json:"expires,omitempty" yaml:"expires,omitempty"`
@@ -166,12 +167,16 @@ func gatherSecretInfo(secrets []apisecrets.SecretDetails, reveal, includeRevisio
 		if includeRevisions {
 			info.Revisions = make([]secretRevisionDetails, len(m.Revisions))
 			for i, r := range m.Revisions {
-				info.Revisions[i] = secretRevisionDetails{
+				rev := secretRevisionDetails{
 					Revision:   r.Revision,
 					CreateTime: r.CreateTime,
 					UpdateTime: r.UpdateTime,
 					ExpireTime: r.ExpireTime,
 				}
+				if r.BackendName != nil {
+					rev.Backend = *r.BackendName
+				}
+				info.Revisions[i] = rev
 			}
 		}
 		if reveal && m.Value != nil && !m.Value.IsEmpty() {

--- a/cmd/juju/secrets/show_test.go
+++ b/cmd/juju/secrets/show_test.go
@@ -54,6 +54,10 @@ func (s *ShowSuite) TestInit(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "revision must be a positive integer")
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func (s *ShowSuite) TestShow(c *gc.C) {
 	defer s.setup(c).Finish()
 
@@ -144,7 +148,8 @@ func (s *ShowSuite) TestShowRevisions(c *gc.C) {
 			},
 			Value: coresecrets.NewSecretValue(map[string]string{"foo": "YmFy"}),
 			Revisions: []coresecrets.SecretRevisionMetadata{{
-				Revision: 666,
+				Revision:    666,
+				BackendName: ptr("some backend"),
 			}},
 		}}, nil)
 	s.secretsAPI.EXPECT().Close().Return(nil)
@@ -163,6 +168,7 @@ func (s *ShowSuite) TestShowRevisions(c *gc.C) {
   updated: 0001-01-01T00:00:00Z
   revisions:
   - revision: 666
+    backend: some backend
     created: 0001-01-01T00:00:00Z
     updated: 0001-01-01T00:00:00Z
 `[1:], uri.ID))

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -145,11 +145,12 @@ type SecretMetadata struct {
 
 // SecretRevisionMetadata holds metadata about a secret revision.
 type SecretRevisionMetadata struct {
-	Revision   int
-	ValueRef   *ValueRef
-	CreateTime time.Time
-	UpdateTime time.Time
-	ExpireTime *time.Time
+	Revision    int
+	ValueRef    *ValueRef
+	BackendName *string
+	CreateTime  time.Time
+	UpdateTime  time.Time
+	ExpireTime  *time.Time
 }
 
 // SecretOwnerMetadata holds a secret metadata and any backend references of revisions.

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -179,11 +179,12 @@ type SecretValueRef struct {
 
 // SecretRevision holds secret revision metadata.
 type SecretRevision struct {
-	Revision   int             `json:"revision"`
-	ValueRef   *SecretValueRef `json:"value-ref,omitempty"`
-	CreateTime time.Time       `json:"create-time,omitempty"`
-	UpdateTime time.Time       `json:"update-time,omitempty"`
-	ExpireTime *time.Time      `json:"expire-time,omitempty"`
+	Revision    int             `json:"revision"`
+	ValueRef    *SecretValueRef `json:"value-ref,omitempty"`
+	BackendName *string         `json:"backend-name,omitempty"`
+	CreateTime  time.Time       `json:"create-time,omitempty"`
+	UpdateTime  time.Time       `json:"update-time,omitempty"`
+	ExpireTime  *time.Time      `json:"expire-time,omitempty"`
 }
 
 // ListSecretResult is the result of getting secret metadata.

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2938,8 +2938,9 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 			BackendID:  backendID,
 			RevisionID: "rev-id",
 		},
-		CreateTime: createTime,
-		UpdateTime: createTime,
+		BackendName: ptr("myvault"),
+		CreateTime:  createTime,
+		UpdateTime:  createTime,
 	}})
 
 	access, err := newSt.SecretAccess(uri, owner.Tag())

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -972,11 +972,18 @@ func (s *SecretsSuite) TestListSecretRevisions(c *gc.C) {
 		LeaderToken: &fakeToken{},
 		Data:        newData,
 	})
+
+	backendStore := state.NewSecretBackends(s.State)
+	backendID, err := backendStore.CreateSecretBackend(state.CreateSecretBackendParams{
+		Name:        "myvault",
+		BackendType: "vault",
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	updateTime := s.Clock.Now().Round(time.Second).UTC()
 	s.assertUpdatedSecret(c, md, 3, state.UpdateSecretParams{
 		LeaderToken: &fakeToken{},
 		ValueRef: &secrets.ValueRef{
-			BackendID:  "backend-id",
+			BackendID:  backendID,
 			RevisionID: "rev-id",
 		},
 	})
@@ -998,11 +1005,12 @@ func (s *SecretsSuite) TestListSecretRevisions(c *gc.C) {
 	}, {
 		Revision: 3,
 		ValueRef: &secrets.ValueRef{
-			BackendID:  "backend-id",
+			BackendID:  backendID,
 			RevisionID: "rev-id",
 		},
-		CreateTime: updateTime2,
-		UpdateTime: updateTime2,
+		BackendName: ptr("myvault"),
+		CreateTime:  updateTime2,
+		UpdateTime:  updateTime2,
 	}})
 }
 


### PR DESCRIPTION
This fixes a bug arising from the transition to using k8s as a secret backend.
When using the `show-secret` CLI with `--reveal` to print the secret content, the content retrieval failed if it was a k8s model and the secrets were stored in k8s.
The fix was to use logic based on what was added to agents to look up the secret value to account for secrets being drained.

As a driveby, and to ensure 3.1 ships with the relevant apis, the `show-secret` command also displays the secret backend name for each externally stored revision.

## QA steps

Perform these tests on a machine and a k8s model, and also a model using vault.
bootstrap and add a secret to the controller charm
run `show-secret --reveal` and `show-secret --revisions` and check the output
the reveal should print the secret value
the revisions should include the backend name


## Bug reference

https://bugs.launchpad.net/juju/+bug/2004006
