### PR TITLE
[JUJU-2474] Fix unit status message when application is removed

### DIFF
--- a/apiserver/common/unitstatus.go
+++ b/apiserver/common/unitstatus.go
@@ -51,7 +51,14 @@ func (c *ModelPresenceContext) UnitStatus(unit UnitStatusGetter) (agent StatusAn
 		// If the unit is in error, it would be bad to throw away
 		// the error information as when the agent reconnects, that
 		// error information would then be lost.
-		if workload.Status.Status != status.Error {
+		// NOTE(nvinuesa): we must also keep the same workload status
+		// and *not* add the "agent lost" message when the workload is
+		// terminated. This happens on k8s sometimes when we remove an
+		// application but the pod is not removed immediately. See:
+		// https://bugs.launchpad.net/juju/+bug/1979292
+		if workload.Status.Status != status.Error &&
+			workload.Status.Status != status.Terminated {
+
 			workload.Status.Status = status.Unknown
 			workload.Status.Message = fmt.Sprintf("agent lost, see 'juju show-status-log %s'", unit.Name())
 		}

--- a/apiserver/common/unitstatus_test.go
+++ b/apiserver/common/unitstatus_test.go
@@ -95,6 +95,44 @@ func (s *UnitStatusSuite) TestCAASLost(c *gc.C) {
 	s.checkLost(c)
 }
 
+func (s *UnitStatusSuite) TestLostTerminated(c *gc.C) {
+	s.unit.status.Status = status.Terminated
+	s.unit.status.Message = ""
+
+	s.ctx.Presence = agentDown(s.unit.Tag().String())
+
+	agent, workload := s.ctx.UnitStatus(s.unit)
+	c.Check(agent.Status, jc.DeepEquals, status.StatusInfo{
+		Status:  status.Lost,
+		Message: "agent is not communicating with the server",
+	})
+	c.Check(agent.Err, jc.ErrorIsNil)
+	c.Check(workload.Status, jc.DeepEquals, status.StatusInfo{
+		Status:  status.Terminated,
+		Message: "",
+	})
+	c.Check(workload.Err, jc.ErrorIsNil)
+}
+
+func (s *UnitStatusSuite) TestCAASLostTerminated(c *gc.C) {
+	s.unit.shouldBeAssigned = false
+	s.unit.status.Status = status.Terminated
+	s.unit.status.Message = ""
+
+	s.ctx.Presence = agentDown(names.NewApplicationTag(s.unit.app).String())
+
+	agent, workload := s.ctx.UnitStatus(s.unit)
+	c.Check(agent.Status, jc.DeepEquals, status.StatusInfo{
+		Status:  status.Lost,
+		Message: "agent is not communicating with the server",
+	})
+	c.Check(agent.Err, jc.ErrorIsNil)
+	c.Check(workload.Status, jc.DeepEquals, status.StatusInfo{
+		Status:  status.Terminated,
+		Message: "",
+	})
+	c.Check(workload.Err, jc.ErrorIsNil)
+}
 func (s *UnitStatusSuite) TestLostAndDead(c *gc.C) {
 	s.ctx.Presence = agentDown(s.unit.Tag().String())
 	s.unit.life = state.Dead


### PR DESCRIPTION
When we remove an application and immediately after we run `juju status` we might see the application's unit with the following status line:
```sh
Unit             Workload    Agent  Address      Ports  Message
loki/0*          unknown     lost   10.1.19.171         agent lost, see 'juju show-status-log loki/0'
```
this can happen specially when working on a kubernetes cluster between the times the application was removed and the pod is effectively removed. 
This behavior is caused by the fact that when we lose contact with the agent, we cannot know what the actual status is, and therefore we pass it to `Unknown` and we set the message to `agent lost, see 'juju show-status-log loki/0`.

This patch simply checks that if the unit's workload is in state `Terminated` then we don't change the status nor the message on the unit's status.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

First deploy a cos-lite bundle on microk8s: https://juju.is/docs/olm/lma-light

Once all he applications have correctly started and the units are on status `active`, run: `juju remove-application loki`.

In parallel you should be checking the status `juju status --watch 1s`, and the status of the unit for the loki application should look like:

```sh
loki/0*          terminated  lost   10.1.19.171         unit stopped by the cloud
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1979292