### PR TITLE
Equinix Provider - Allow traffic from other juju machines

### DIFF
--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -274,7 +274,8 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 	}
 	cloudCfg.AddPackage("iptables-persistent")
 
-	// Set a default INPUT policy of drop, permitting ssh
+	// Set a default INPUT policy of drop, permitting ssh and 10.0.0.0/8 private
+	// network traffic.
 	acceptInputPort := "iptables -A INPUT -p tcp --dport %d -j ACCEPT"
 	iptablesDefault := []string{
 		"iptables -A INPUT -m conntrack --ctstate INVALID -j DROP",
@@ -298,6 +299,7 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 			}
 		}
 	}
+	iptablesDefault = append(iptablesDefault, "iptables -A INPUT -s 10.0.0.0/8 -j ACCEPT")
 	iptablesDefault = append(iptablesDefault, "iptables -A INPUT -j DROP")
 
 	cloudCfg.AddScripts(


### PR DESCRIPTION


Signed-off-by: Chris Privitere <cprivitere@equinix.com>

Add iptables rule to enable 10.0.0.0/8 traffic.
This allows other Equinix project member servers to talk to each other. Without this change, deploying things like charmed kubernetes requires the user to go in and manually edit the firewall of every deployed machine. This solution is far from ideal as we would ideally limit the ALLOW rule to only the servers in the user's projects. However, it's better than being completely locked down and nothing "just working" or being completely wide open and permitting traffic from anywhere.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

* Deploy a controller with an agent built from this branch
* juju add-machine
* juju ssh <machine number>
* validate the machine has an iptables allow for 10.0.0.0/8
