### PR TITLE
Equinix Provider - Fix core constraint issues due to typo

### DIFF
--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -670,7 +670,7 @@ nextPlan:
 		// Some plans have CPU cores in the type field, e.g. "24-core".
 		// When available, multiply count by cores.
 		cores := uint64(plan.Specs.Cpus[0].Count)
-		re := regexp.MustCompile(`(\d+)[ -]core`)
+		re := regexp.MustCompile(`(\d+)[ -][Cc]ore`)
 		coresMatch := re.FindStringSubmatch(plan.Specs.Cpus[0].Type)
 		if len(coresMatch) > 1 {
 			n, err := strconv.Atoi(coresMatch[1])


### PR DESCRIPTION
Signed-off-by: Chris Privitere <cprivitere@equinix.com>

Quick PR to fix a typo in the regex used to figure out core counts based on plan descriptions in the API. All current plan descriptions capitalize the c in the word `core` and so the current code was missing the core counts. This change enable capital C to be matched as well. 

Even with this fix, the current logic only gets core counts from plans with core counts in their descriptions, which is not all of them, a further follow up with better core count logic would be desirable and is something we're considering.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

Deploy a machine with constraints for cores.
```sh
juju add-machine --constraints="cores=8"
```
Validate that juju can deploy the machine with juju status and/or juju debug-log. 

Without this change an error like this will happen:
```sh
controller-0: 17:24:15 WARNING juju.worker.provisioner machine 0 failed to start: no instance types in da matching constraints "arch=amd64 cores=8"
controller-0: 17:24:15 WARNING juju.worker.provisioner failed to start machine 0 (no instance types in da matching constraints "arch=amd64 cores=8"), retrying in 10s (1 more attempts)
controller-0: 17:24:29 ERROR juju.worker.provisioner cannot start instance for machine "0": no instance types in da matching constraints "arch=amd64 cores=8"
```