### PR TITLE
[JUJU-2334] Add state logic and persistence to support storing and watching secret backend rotations

### DIFF
--- a/apiserver/common/secrets/mocks/state_mock.go
+++ b/apiserver/common/secrets/mocks/state_mock.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	set "github.com/juju/collections/set"
@@ -288,6 +289,20 @@ func (m *MockSecretBackendsStorage) ListSecretBackends() ([]*secrets.SecretBacke
 func (mr *MockSecretBackendsStorageMockRecorder) ListSecretBackends() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretBackends", reflect.TypeOf((*MockSecretBackendsStorage)(nil).ListSecretBackends))
+}
+
+// SecretBackendRotated mocks base method.
+func (m *MockSecretBackendsStorage) SecretBackendRotated(arg0 string, arg1 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretBackendRotated", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SecretBackendRotated indicates an expected call of SecretBackendRotated.
+func (mr *MockSecretBackendsStorageMockRecorder) SecretBackendRotated(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackendRotated", reflect.TypeOf((*MockSecretBackendsStorage)(nil).SecretBackendRotated), arg0, arg1)
 }
 
 // UpdateSecretBackend mocks base method.

--- a/apiserver/facades/client/secretbackends/package_test.go
+++ b/apiserver/facades/client/secretbackends/package_test.go
@@ -6,6 +6,7 @@ package secretbackends
 import (
 	"testing"
 
+	"github.com/juju/clock"
 	gc "gopkg.in/check.v1"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -26,12 +27,14 @@ func NewTestAPI(
 	secretState SecretsState,
 	statePool StatePool,
 	authorizer facade.Authorizer,
+	clock clock.Clock,
 ) (*SecretBackendsAPI, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
 
 	return &SecretBackendsAPI{
+		clock:          clock,
 		authorizer:     authorizer,
 		controllerUUID: coretesting.ControllerTag.Id(),
 		statePool:      statePool,

--- a/apiserver/facades/client/secretbackends/register.go
+++ b/apiserver/facades/client/secretbackends/register.go
@@ -6,6 +6,8 @@ package secretbackends
 import (
 	"reflect"
 
+	"github.com/juju/clock"
+
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
@@ -27,6 +29,7 @@ func newSecretBackendsAPI(context facade.Context) (*SecretBackendsAPI, error) {
 	return &SecretBackendsAPI{
 		authorizer:     context.Auth(),
 		controllerUUID: context.State().ControllerUUID(),
+		clock:          clock.WallClock,
 		backendState:   state.NewSecretBackends(context.State()),
 		secretState:    state.NewSecrets(context.State()),
 		statePool:      &statePoolShim{context.StatePool()},

--- a/cmd/juju/secretbackends/add.go
+++ b/cmd/juju/secretbackends/add.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/api/client/secretbackends"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/secrets/provider"
 	_ "github.com/juju/juju/secrets/provider/all"
 )
@@ -178,8 +179,10 @@ func parseTokenRotate(attrs map[string]interface{}, zeroAllowed bool) (*time.Dur
 				return nil, errors.NewNotValid(err, "token rotate interval cannot be 0")
 			}
 			return &rotateInterval, nil
-		} else if intervalSecs < 60 {
-			return nil, errors.NewNotValid(err, fmt.Sprintf("token rotate interval %q too small, must be >= 60s", tokenRotateStr))
+		} else {
+			if _, err := secrets.NextBackendRotateTime(time.Now(), rotateInterval); err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 		return &rotateInterval, nil
 	}

--- a/cmd/juju/secretbackends/add_test.go
+++ b/cmd/juju/secretbackends/add_test.go
@@ -62,7 +62,7 @@ func (s *AddSuite) TestAddInitError(c *gc.C) {
 		err:  `invalid token rotate interval: time: invalid duration "blah"`,
 	}, {
 		args: []string{"myvault", "somevault", "foo=bar", "token-rotate=1s"},
-		err:  `token rotate interval "1s" too small, must be >= 60s`,
+		err:  `token rotate interval "1s" less than 1h not valid`,
 	}, {
 		args: []string{"myvault", "somevault", "foo=bar", "token-rotate=0"},
 		err:  `token rotate interval cannot be 0`,

--- a/cmd/juju/secretbackends/update_test.go
+++ b/cmd/juju/secretbackends/update_test.go
@@ -56,7 +56,7 @@ func (s *UpdateSuite) TestUpdateInitError(c *gc.C) {
 		err:  "must specify a config file or key/reset values",
 	}, {
 		args: []string{"myvault", "foo=bar", "token-rotate=1s"},
-		err:  `token rotate interval "1s" too small, must be >= 60s`,
+		err:  `token rotate interval "1s" less than 1h not valid`,
 	}, {
 		args: []string{"myvault", "foo=bar", "--config", "/path/to/nowhere"},
 		err:  `open /path/to/nowhere: no such file or directory`,

--- a/core/secrets/secretbackend.go
+++ b/core/secrets/secretbackend.go
@@ -6,6 +6,8 @@ package secrets
 import (
 	"fmt"
 	"time"
+
+	"github.com/juju/errors"
 )
 
 // SecretBackend defines a secrets backend.
@@ -26,4 +28,15 @@ type ValueRef struct {
 
 func (r *ValueRef) String() string {
 	return fmt.Sprintf("%s:%s", r.BackendID, r.RevisionID)
+}
+
+// NextBackendRotateTime returns the next time a token rotate is due,
+// given the supplied rotate interval.
+func NextBackendRotateTime(now time.Time, rotateInterval time.Duration) (*time.Time, error) {
+	if rotateInterval > 0 && rotateInterval < time.Hour {
+		return nil, errors.NotValidf("token rotate interval %q less than 1h", rotateInterval)
+	}
+	// Rotate a reasonable time before the token is due to expire.
+	when := now.Add(time.Duration(0.75*rotateInterval.Seconds()) * time.Second)
+	return &when, nil
 }

--- a/core/secrets/secretbackend_test.go
+++ b/core/secrets/secretbackend_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package secrets_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/secrets"
+)
+
+type SecretBackendSuite struct{}
+
+var _ = gc.Suite(&SecretBackendSuite{})
+
+func (s *SecretBackendSuite) TestNextBackendRotateTimeTooShort(c *gc.C) {
+	_, err := secrets.NextBackendRotateTime(time.Now(), time.Minute)
+	c.Assert(err, gc.ErrorMatches, `token rotate interval "1m0s" less than 1h not valid`)
+}
+
+func (s *SecretBackendSuite) TestNextBackendRotateTime(c *gc.C) {
+	now := time.Now()
+	next, err := secrets.NextBackendRotateTime(now, 200*time.Minute)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(next.Sub(now), gc.Equals, 150*time.Minute)
+}

--- a/core/watcher/secretbackends.go
+++ b/core/watcher/secretbackends.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"fmt"
+	"time"
+)
+
+// SecretBackendRotateChange describes changes to a secret backend
+// rotation trigger.
+type SecretBackendRotateChange struct {
+	ID              string
+	Name            string
+	NextTriggerTime time.Time
+}
+
+func (s SecretBackendRotateChange) GoString() string {
+	whenMsg := "never"
+	if !s.NextTriggerTime.IsZero() {
+		interval := s.NextTriggerTime.Sub(time.Now())
+		if interval < 0 {
+			whenMsg = fmt.Sprintf("%v ago at %s", -interval, s.NextTriggerTime.Format(time.RFC3339))
+		} else {
+			whenMsg = fmt.Sprintf("in %v at %s", interval, s.NextTriggerTime.Format(time.RFC3339))
+		}
+	}
+	return fmt.Sprintf("%s token rotate: %s", s.Name, whenMsg)
+}
+
+// SecretBackendRotateChannel is a change channel as described in the CoreWatcher docs.
+type SecretBackendRotateChannel <-chan []SecretBackendRotateChange
+
+// SecretBackendRotateWatcher conveniently ties a SecretBackendRotateChannel to the
+// worker.Worker that represents its validity.
+type SecretBackendRotateWatcher interface {
+	CoreWatcher
+	Changes() SecretBackendRotateChannel
+}

--- a/secrets/provider/provider.go
+++ b/secrets/provider/provider.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"sort"
+	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v4"
@@ -89,4 +90,15 @@ type SecretBackendProvider interface {
 	// NewBackend creates a secrets backend client using the
 	// specified model config.
 	NewBackend(cfg *ModelBackendConfig) (SecretsBackend, error)
+}
+
+// SupportAuthRefresh defines the methods to refresh auth tokens.
+type SupportAuthRefresh interface {
+	RefreshAuth(adminCfg *ModelBackendConfig, validFor time.Duration) (*BackendConfig, error)
+}
+
+// HasAuthRefresh returns true if the provider supports token refresh.
+func HasAuthRefresh(p SecretBackendProvider) bool {
+	_, ok := p.(SupportAuthRefresh)
+	return ok
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -567,6 +567,13 @@ func allCollections() CollectionSchema {
 			}},
 		},
 
+		secretBackendsRotateC: {
+			global: true,
+			indexes: []mgo.Index{{
+				Key: []string{"model-uuid"},
+			}},
+		},
+
 		// ----------------------
 
 		// Raw-access collections
@@ -675,12 +682,13 @@ const (
 	firewallRulesC       = "firewallRules"
 
 	// Secrets
-	secretMetadataC    = "secretMetadata"
-	secretRevisionsC   = "secretRevisions"
-	secretConsumersC   = "secretConsumers"
-	secretPermissionsC = "secretPermissions"
-	secretRotateC      = "secretRotate"
-	secretBackendsC    = "secretBackends"
+	secretMetadataC       = "secretMetadata"
+	secretRevisionsC      = "secretRevisions"
+	secretConsumersC      = "secretConsumers"
+	secretPermissionsC    = "secretPermissions"
+	secretRotateC         = "secretRotate"
+	secretBackendsC       = "secretBackends"
+	secretBackendsRotateC = "secretBackendsRotate"
 )
 
 // watcherIgnoreList contains all the collections in mongo that should not be watched by the

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1150,6 +1150,16 @@ func GetSecretNextRotateTime(c *gc.C, st *State, id string) time.Time {
 	return doc.NextRotateTime.UTC()
 }
 
+func GetSecretBackendNextRotateInfo(c *gc.C, st *State, id string) (string, time.Time) {
+	secretBackendRotateCollection, closer := st.db().GetCollection(secretBackendsRotateC)
+	defer closer()
+
+	var doc secretBackendRotationDoc
+	err := secretBackendRotateCollection.FindId(id).One(&doc)
+	c.Assert(err, jc.ErrorIsNil)
+	return doc.Name, doc.NextRotateTime.UTC()
+}
+
 // ModelBackendShim is required to live here in the export_test.go file because
 // there is issues placing this in the test files themselves. The strangeness
 // exhibits itself from the fact that `clock() clock.Clock` doesn't type

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -213,6 +213,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 
 		// Secret backends are per controller.
 		secretBackendsC,
+		secretBackendsRotateC,
 	)
 
 	// THIS SET WILL BE REMOVED WHEN MIGRATIONS ARE COMPLETE


### PR DESCRIPTION
Add support in the state layer to support managing and watching secret backend rotations.
A new collection is used to store the next rotate time for the backends, and a watcher is provided to notify of changes.
The watcher implementation is based on what was done for secret rotations.

Rotation support is added to the vault provider (the only one that supports it).

The next PR will wire up the worker and api facade to actually do the rotations.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Add a vault backend to a controller.
Update the backend to use token rotation, eg juju update-secret-backend myvault token-rotate=2h
Remove the token rotation, eg juju update-secret-backend myvault token-rotate=0s
Nothing triggers on this yet. I checked the mongo collection to see the results.