### PR TITLE
Remove pointless state private methods that wrap public ones

### DIFF
--- a/state/action.go
+++ b/state/action.go
@@ -601,7 +601,7 @@ func newActionDoc(mb modelBackend, operationID string, receiverTag names.Tag, ac
 		actionId = actionUUID.String()
 	}
 	actionLogger.Debugf("newActionDoc name: '%s', receiver: '%s', actionId: '%s'", actionName, receiverTag, actionId)
-	modelUUID := mb.modelUUID()
+	modelUUID := mb.ModelUUID()
 	return actionDoc{
 			DocId:      mb.docID(actionId),
 			ModelUUID:  modelUUID,

--- a/state/address.go
+++ b/state/address.go
@@ -280,8 +280,8 @@ func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHost
 		logger.Debugf("getting api hostports for CAAS: public %t, addresses %v", public, addresses)
 	}()
 
-	if st.modelUUID() != st.controllerModelTag.Id() {
-		return nil, errors.Errorf("CAAS API host ports only available on the controller model, not %q", st.modelUUID())
+	if st.ModelUUID() != st.controllerModelTag.Id() {
+		return nil, errors.Errorf("CAAS API host ports only available on the controller model, not %q", st.ModelUUID())
 	}
 
 	controllerConfig, err := st.ControllerConfig()

--- a/state/application.go
+++ b/state/application.go
@@ -3278,7 +3278,7 @@ func (a *Application) UnitStatuses() (map[string]status.StatusInfo, error) {
 	defer closer()
 	// Agent status is u#unit-name
 	// Workload status is u#unit-name#charm
-	selector := fmt.Sprintf("^%s:u#%s/\\d+(#charm)?$", a.st.modelUUID(), a.doc.Name)
+	selector := fmt.Sprintf("^%s:u#%s/\\d+(#charm)?$", a.st.ModelUUID(), a.doc.Name)
 	var docs []statusDocWithID
 	err := col.Find(bson.M{"_id": bson.M{"$regex": selector}}).All(&docs)
 	if err != nil {

--- a/state/backend.go
+++ b/state/backend.go
@@ -17,6 +17,9 @@ import (
 // modelBackend collects together some useful internal state methods for
 // accessing mongo and mapping local and global ids to one another.
 type modelBackend interface {
+	ModelUUID() string
+	IsController() bool
+
 	// docID generates a globally unique ID value
 	// where the model UUID is prefixed to the
 	// localID.
@@ -39,9 +42,7 @@ type modelBackend interface {
 
 	clock() clock.Clock
 	db() Database
-	modelUUID() string
 	modelName() (string, error)
-	isController() bool
 	txnLogWatcher() watcher.BaseWatcher
 }
 
@@ -69,20 +70,12 @@ func (st *State) clock() clock.Clock {
 	return st.stateClock
 }
 
-func (st *State) modelUUID() string {
-	return st.ModelUUID()
-}
-
 func (st *State) modelName() (string, error) {
 	m, err := st.Model()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
 	return m.Name(), nil
-}
-
-func (st *State) isController() bool {
-	return st.IsController()
 }
 
 func (st *State) nowToTheSecond() time.Time {

--- a/state/block.go
+++ b/state/block.go
@@ -293,8 +293,8 @@ func createModelBlockOps(mb modelBackend, t BlockType, msg string) ([]txn.Op, er
 	// need to change format.
 	newDoc := blockDoc{
 		DocID:     mb.docID(id),
-		ModelUUID: mb.modelUUID(),
-		Tag:       names.NewModelTag(mb.modelUUID()).String(),
+		ModelUUID: mb.ModelUUID(),
+		Tag:       names.NewModelTag(mb.ModelUUID()).String(),
 		Type:      t,
 		Message:   msg,
 	}

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -264,7 +264,7 @@ func (st *State) cleanupResourceBlob(storagePath string) error {
 		return nil
 	}
 
-	storage := statestorage.NewStorage(st.modelUUID(), st.MongoSession())
+	storage := statestorage.NewStorage(st.ModelUUID(), st.MongoSession())
 	err := storage.Remove(storagePath)
 	if errors.IsNotFound(err) {
 		return nil

--- a/state/dump.go
+++ b/state/dump.go
@@ -35,8 +35,8 @@ func getModelDoc(mb modelBackend) (map[string]interface{}, error) {
 	defer closer()
 
 	var doc map[string]interface{}
-	if err := coll.FindId(mb.modelUUID()).One(&doc); err != nil {
-		return nil, errors.Annotatef(err, "reading model %q", mb.modelUUID())
+	if err := coll.FindId(mb.ModelUUID()).One(&doc); err != nil {
+		return nil, errors.Annotatef(err, "reading model %q", mb.ModelUUID())
 	}
 	return doc, nil
 

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -1103,7 +1103,7 @@ func (s ModelBackendShim) db() Database {
 	return s.Database
 }
 
-func (s ModelBackendShim) modelUUID() string {
+func (s ModelBackendShim) ModelUUID() string {
 	return ""
 }
 
@@ -1111,7 +1111,7 @@ func (s ModelBackendShim) modelName() (string, error) {
 	return "", nil
 }
 
-func (s ModelBackendShim) isController() bool {
+func (s ModelBackendShim) IsController() bool {
 	return false
 }
 

--- a/state/meterstatus.go
+++ b/state/meterstatus.go
@@ -132,7 +132,7 @@ func (u *Unit) SetMeterStatus(codeStr, info string) error {
 // createMeterStatusOp returns the operation needed to create the meter status
 // document associated with the given globalKey.
 func createMeterStatusOp(mb modelBackend, globalKey string, doc *meterStatusDoc) txn.Op {
-	doc.ModelUUID = mb.modelUUID()
+	doc.ModelUUID = mb.ModelUUID()
 	return txn.Op{
 		C:      meterStatusC,
 		Id:     mb.docID(globalKey),

--- a/state/model.go
+++ b/state/model.go
@@ -1647,7 +1647,7 @@ func removeModelFilesystemRefOp(mb modelBackend, filesystemId string) txn.Op {
 func addModelEntityRefOp(mb modelBackend, entityField, entityId string) txn.Op {
 	return txn.Op{
 		C:      modelEntityRefsC,
-		Id:     mb.modelUUID(),
+		Id:     mb.ModelUUID(),
 		Assert: txn.DocExists,
 		Update: bson.D{{"$addToSet", bson.D{{entityField, entityId}}}},
 	}
@@ -1656,7 +1656,7 @@ func addModelEntityRefOp(mb modelBackend, entityField, entityId string) txn.Op {
 func removeModelEntityRefOp(mb modelBackend, entityField, entityId string) txn.Op {
 	return txn.Op{
 		C:      modelEntityRefsC,
-		Id:     mb.modelUUID(),
+		Id:     mb.ModelUUID(),
 		Update: bson.D{{"$pull", bson.D{{entityField, entityId}}}},
 	}
 }

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -386,7 +386,7 @@ func (st *State) isControllerOrModelAdmin(user names.UserTag) (bool, error) {
 	if isAdmin {
 		return true, nil
 	}
-	ua, err := st.UserAccess(user, names.NewModelTag(st.modelUUID()))
+	ua, err := st.UserAccess(user, names.NewModelTag(st.ModelUUID()))
 	if errors.IsNotFound(err) {
 		return false, nil
 	}

--- a/state/operation.go
+++ b/state/operation.go
@@ -211,7 +211,7 @@ func newOperationDoc(mb modelBackend, summary string, count int) (operationDoc, 
 		return operationDoc{}, "", errors.Trace(err)
 	}
 	operationID := strconv.Itoa(id)
-	modelUUID := mb.modelUUID()
+	modelUUID := mb.ModelUUID()
 	return operationDoc{
 		DocId:            mb.docID(operationID),
 		ModelUUID:        modelUUID,

--- a/state/prune.go
+++ b/state/prune.go
@@ -146,7 +146,7 @@ func (p *collectionPruner) pruneByAge() error {
 	}
 
 	query := bson.D{
-		{"model-uuid", p.st.modelUUID()},
+		{"model-uuid", p.st.ModelUUID()},
 		{p.ageField, bson.M{"$gt": notSet, "$lt": age}},
 	}
 	query = append(query, p.filter...)
@@ -198,7 +198,7 @@ func (*collectionPruner) toDeleteCalculator(coll *mgo.Collection, maxSizeMB int,
 }
 
 func (p *collectionPruner) pruneBySize() error {
-	if !p.st.isController() {
+	if !p.st.IsController() {
 		// Only prune by size in the controller. Otherwise we might
 		// find that multiple pruners are trying to delete the latest
 		// 1000 rows and end up with more deleted than we expect.

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -28,7 +28,7 @@ func sequence(mb modelBackend, name string) (int, error) {
 		Update: bson.M{
 			"$set": bson.M{
 				"name":       name,
-				"model-uuid": mb.modelUUID(),
+				"model-uuid": mb.ModelUUID(),
 			},
 			"$inc": bson.M{"counter": 1},
 		},
@@ -67,7 +67,7 @@ func resetSequence(mb modelBackend, name string) error {
 func sequenceWithMin(mb modelBackend, name string, minVal int) (int, error) {
 	sequences, closer := mb.db().GetRawCollection(sequenceC)
 	defer closer()
-	updater := newDbSeqUpdater(sequences, mb.modelUUID(), name)
+	updater := newDbSeqUpdater(sequences, mb.ModelUUID(), name)
 	return updateSeqWithMin(updater, minVal)
 }
 

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -3616,7 +3616,7 @@ func (s *upgradesSuite) TestConvertAddressSpaceIDs(c *gc.C) {
 	mod := s.makeModel(c, "the-model", coretesting.Attrs{})
 	defer func() { _ = mod.Close() }()
 
-	uuid := mod.modelUUID()
+	uuid := mod.ModelUUID()
 	s.makeMachine(c, uuid, "0", Alive)
 	s.makeMachine(c, uuid, "1", Alive)
 
@@ -4928,12 +4928,12 @@ func (s *upgradesSuite) TestRemoveUnusedLinkLayerDeviceProviderIDs(c *gc.C) {
 	pidCol, pidCloser := s.state.db().GetRawCollection(providerIDsC)
 	defer pidCloser()
 
-	keepLLD := bson.M{"_id": model1.modelUUID() + ":linklayerdevice:keep"}
-	keepSubnet := bson.M{"_id": model1.modelUUID() + ":subnet:keep"}
+	keepLLD := bson.M{"_id": model1.ModelUUID() + ":linklayerdevice:keep"}
+	keepSubnet := bson.M{"_id": model1.ModelUUID() + ":subnet:keep"}
 	docs := []interface{}{
 		keepLLD,
 		keepSubnet,
-		bson.M{"_id": model1.modelUUID() + ":linklayerdevice:delete"},
+		bson.M{"_id": model1.ModelUUID() + ":linklayerdevice:delete"},
 	}
 	err := pidCol.Insert(docs...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -5227,16 +5227,16 @@ func (s *upgradesSuite) TestUpdateDHCPAddressConfigs(c *gc.C) {
 	defer closer()
 
 	docs := []interface{}{
-		bson.M{"_id": model1.modelUUID() + ":m#0#d#eth0#ip#10.10.10.10", "config-method": "dynamic"},
-		bson.M{"_id": model1.modelUUID() + ":m#1#d#eth1#ip#20.20.20.20", "config-method": network.ConfigStatic},
+		bson.M{"_id": model1.ModelUUID() + ":m#0#d#eth0#ip#10.10.10.10", "config-method": "dynamic"},
+		bson.M{"_id": model1.ModelUUID() + ":m#1#d#eth1#ip#20.20.20.20", "config-method": network.ConfigStatic},
 	}
 	err := col.Insert(docs...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The first of the docs has an upgraded config method.
 	s.assertUpgradedData(c, UpdateDHCPAddressConfigs, upgradedData(col, []bson.M{
-		{"_id": model1.modelUUID() + ":m#0#d#eth0#ip#10.10.10.10", "config-method": string(network.ConfigDHCP)},
-		{"_id": model1.modelUUID() + ":m#1#d#eth1#ip#20.20.20.20", "config-method": string(network.ConfigStatic)},
+		{"_id": model1.ModelUUID() + ":m#0#d#eth0#ip#10.10.10.10", "config-method": string(network.ConfigDHCP)},
+		{"_id": model1.ModelUUID() + ":m#1#d#eth1#ip#20.20.20.20", "config-method": string(network.ConfigStatic)},
 	}))
 }
 
@@ -5930,8 +5930,8 @@ func (s *upgradesSuite) TestRemoveOrphanedLinkLayerDevices(c *gc.C) {
 
 	// Only the link-layer data for the second machine should be retained.
 	devExp := bsonMById{{
-		"_id":               ensureModelUUID(s.state.modelUUID(), fmt.Sprintf("m#%s#d#eth0", m1.Id())),
-		"model-uuid":        s.state.modelUUID(),
+		"_id":               ensureModelUUID(s.state.ModelUUID(), fmt.Sprintf("m#%s#d#eth0", m1.Id())),
+		"model-uuid":        s.state.ModelUUID(),
 		"is-auto-start":     false,
 		"is-up":             false,
 		"mac-address":       "",
@@ -5944,8 +5944,8 @@ func (s *upgradesSuite) TestRemoveOrphanedLinkLayerDevices(c *gc.C) {
 	}}
 
 	addrExp := bsonMById{{
-		"_id":           ensureModelUUID(s.state.modelUUID(), fmt.Sprintf("m#%s#d#eth0#ip#192.168.0.99", m1.Id())),
-		"model-uuid":    s.state.modelUUID(),
+		"_id":           ensureModelUUID(s.state.ModelUUID(), fmt.Sprintf("m#%s#d#eth0#ip#192.168.0.99", m1.Id())),
+		"model-uuid":    s.state.ModelUUID(),
 		"config-method": "",
 		"device-name":   "eth0",
 		"machine-id":    m1.Id(),
@@ -6018,7 +6018,7 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      false,
 			"life":                   0,
-			"model-uuid":             model0.modelUUID(),
+			"model-uuid":             model0.ModelUUID(),
 			"name":                   "remote-application",
 			"offer-uuid":             "",
 			"relationcount":          0,
@@ -6032,7 +6032,7 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      false,
 			"life":                   0,
-			"model-uuid":             model0.modelUUID(),
+			"model-uuid":             model0.ModelUUID(),
 			"name":                   "remote-application2",
 			"offer-uuid":             "",
 			"relationcount":          0,
@@ -6046,7 +6046,7 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      false,
 			"life":                   0,
-			"model-uuid":             model0.modelUUID(),
+			"model-uuid":             model0.ModelUUID(),
 			"name":                   "remote-application3",
 			"offer-uuid":             "",
 			"relationcount":          0,
@@ -6060,7 +6060,7 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      true,
 			"life":                   0,
-			"model-uuid":             model0.modelUUID(),
+			"model-uuid":             model0.ModelUUID(),
 			"name":                   "remote-application4",
 			"offer-uuid":             "",
 			"relationcount":          0,
@@ -6074,7 +6074,7 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfo(c *gc.C) {
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      false,
 			"life":                   0,
-			"model-uuid":             model1.modelUUID(),
+			"model-uuid":             model1.ModelUUID(),
 			"name":                   "remote-application5",
 			"offer-uuid":             "",
 			"relationcount":          0,
@@ -6156,7 +6156,7 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfoFixRefCount(c *gc.C) {
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      false,
 			"life":                   0,
-			"model-uuid":             model0.modelUUID(),
+			"model-uuid":             model0.ModelUUID(),
 			"name":                   "remote-application",
 			"offer-uuid":             "",
 			"relationcount":          0,
@@ -6170,7 +6170,7 @@ func (s *upgradesSuite) TestUpdateExternalControllerInfoFixRefCount(c *gc.C) {
 			"endpoints":              []interface{}{},
 			"is-consumer-proxy":      false,
 			"life":                   0,
-			"model-uuid":             model0.modelUUID(),
+			"model-uuid":             model0.ModelUUID(),
 			"name":                   "remote-application2",
 			"offer-uuid":             "",
 			"relationcount":          0,

--- a/state/workers.go
+++ b/state/workers.go
@@ -46,7 +46,7 @@ func newWorkers(st *State, hub *pubsub.SimpleHub) (*workers, error) {
 		return watcher.NewHubWatcher(watcher.HubWatcherConfig{
 			Hub:       hub,
 			Clock:     st.clock(),
-			ModelUUID: st.modelUUID(),
+			ModelUUID: st.ModelUUID(),
 			Logger:    loggo.GetLogger("juju.state.watcher"),
 		})
 	})


### PR DESCRIPTION
There is a `modelBackend` interface used by watchers, that declares a clutch of private methods. Some of these methods are declared on `state` and simply call the public method of the same name/signature.

Over time, these private methods have been recruited in various places.

This is silly. We can just use the public method signatures on the interface, remove the wrapper methods and change all the callers to use the public method - saves us some stack work.

## QA steps

Mechanical change only - tests pass.
