### PR TITLE
[JUJU-2642] - Fix/lp 2004220

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -248,13 +248,13 @@ is determined by the contents of the charm at the specified path.
 number with --switch, give it in the charm URL, for instance "cs:wordpress-5"
 would specify revision number 5 of the wordpress charm.
 
-Use of the --force-units option is not generally recommended; units upgraded 
-while in an error state will not have refreshed hooks executed, and may cause 
+Use of the --force-units option is not generally recommended; units upgraded
+while in an error state will not have refreshed hooks executed, and may cause
 unexpected behavior.
 
---force option for LXD Profiles is not generally recommended when upgrading an 
-application; overriding profiles on the container may cause unexpected 
-behavior. 
+--force option for LXD Profiles is not generally recommended when upgrading an
+application; overriding profiles on the container may cause unexpected
+behavior.
 `
 
 func (c *refreshCommand) Info() *cmd.Info {

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -1085,11 +1085,38 @@ func (st *State) GetSecretConsumer(uri *secrets.URI, consumer names.Tag) (*secre
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &secrets.SecretConsumerMetadata{
+	md := &secrets.SecretConsumerMetadata{
 		Label:           doc.Label,
 		CurrentRevision: doc.CurrentRevision,
 		LatestRevision:  doc.LatestRevision,
-	}, nil
+	}
+
+	if md.Label == "" {
+		// Note: the leader unit always has the label cached on the uniter side, but non leaders does not.
+		// Therefore, below logic (fixes https://bugs.launchpad.net/juju/+bug/2004220) makes application
+		// owned secrets' label visible for non leader units' secret-changed hook.
+		equalOrOwned := func(consumerTag, ownerTag names.Tag) bool {
+			if consumerTag.Id() == ownerTag.Id() {
+				return true
+			}
+			applicationName, _ := names.UnitApplication(consumerTag.Id())
+			return ownerTag.Id() == applicationName
+		}
+
+		store := NewSecrets(st)
+		secret, err := store.GetSecret(uri)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ownerTag, err := names.ParseTag(secret.OwnerTag)
+		if err != nil {
+			return nil, errors.Annotate(err, "invalid owner tag")
+		}
+		if equalOrOwned(consumer, ownerTag) {
+			md.Label = secret.Label
+		}
+	}
+	return md, nil
 }
 
 func (st *State) removeSecretConsumer(uri *secrets.URI) error {

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -1092,9 +1092,9 @@ func (st *State) GetSecretConsumer(uri *secrets.URI, consumer names.Tag) (*secre
 	}
 
 	if md.Label == "" {
-		// Note: the leader unit always has the label cached on the uniter side, but non leaders does not.
+		// Note: the leader unit always has the label cached on the uniter side, but non leaders do not.
 		// Therefore, below logic (fixes https://bugs.launchpad.net/juju/+bug/2004220) makes application
-		// owned secrets' label visible for non leader units' secret-changed hook.
+		// owned secrets' labels visible for non leader units' secret-changed hook.
 		equalOrOwned := func(consumerTag, ownerTag names.Tag) bool {
 			if consumerTag.Id() == ownerTag.Id() {
 				return true

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -303,8 +303,11 @@ func (f *contextFactory) HookContext(hookInfo hook.Info) (*HookContext, error) {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			uri, _ := secrets.ParseURI(ctx.secretURI)
-			md, _ := info[uri.ID]
+			uri, err := secrets.ParseURI(ctx.secretURI)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			md := info[uri.ID]
 			ctx.secretLabel = md.Label
 		}
 	}


### PR DESCRIPTION
This PR ensures the application-owned secret's owner label visible for its own non-leader units in the `secret-changed` hook context.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju exec --unit snappass-test/1 'cat /var/lib/juju/agents/unit-snappass-test-1/charm/hooks/secret-changed'


#!/bin/bash
juju-log "secret-changed uri=$JUJU_SECRET_ID label=$JUJU_SECRET_LABEL"


juju exec --unit snappass-test/0 'secret-set secret:cfcu75uffbas7amkm0d0 test=test1 --label=test1'

juju debug-log --color --replay -m t1
...
unit-snappass-test-1: 16:48:03 INFO unit.snappass-test/1.juju-log Running legacy hooks/secret-changed.
unit-snappass-test-1: 16:48:03 INFO unit.snappass-test/1.juju-log secret-changed uri=secret:cfcu75uffbas7amkm0d0 label=test1
...
```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2004220
