### PR TITLE
[JUJU-2641] Container teardown fix

### DIFF
--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/canonical/pebble/plan"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -25,6 +24,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/constants"
 	"github.com/juju/juju/cmd/containeragent/utils"
+	"github.com/juju/juju/service/pebble/plan"
 	"github.com/juju/juju/worker/apicaller"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -148,6 +148,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
@@ -257,3 +258,5 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
 replace github.com/dustin/go-humanize v1.0.0 => github.com/dustin/go-humanize v0.0.0-20141228071148-145fabdb1ab7
 
 replace github.com/hashicorp/raft-boltdb => github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5
+
+replace github.com/canonical/pebble => github.com/tlm/pebble v0.0.0-20230131233641-2f4dace4504e

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac h1:X5YRFJiteUM3rajABEYJSzw1KWgmp1ulPFKxpfLm0M4=
 github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/canonical/pebble v0.0.0-20221004042842-d7797bb9b104 h1:TQh8Yl5LkcWUr1A/09yWGLW1hYRO5OmE6zmb7aFI0Yg=
-github.com/canonical/pebble v0.0.0-20221004042842-d7797bb9b104/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
+github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43 h1:bey1JgA3D2EBabr2a7kWKj+JlEPxX1akv8rcRromotA=
+github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43/go.mod h1:A0/Jvt7qKuCDss37TYRNXSscVyS+tLWM5kBYipQOpWQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -876,6 +876,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tlm/pebble v0.0.0-20230131233641-2f4dace4504e h1:s5Qauj1bVv2ct/o1TH15Z66S8oSNWW1w/0JOjVUOyFM=
+github.com/tlm/pebble v0.0.0-20230131233641-2f4dace4504e/go.mod h1:j3uyWpPkuWf8u0kB2v7n/XGVpYIg4luGetpSngCvzac=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/service/pebble/plan/plan.go
+++ b/service/pebble/plan/plan.go
@@ -1,0 +1,128 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Plan constructs are copied directly from the Pebble code base to Juju without
+// any modification. We perform this copy as the Pebble package does not isolate
+// plan types fully and will cause Juju to not compile correctly on systems that
+// are not Linux based.
+//
+// The code can be found at https://github.com/canonical/pebble/internal/plan
+//
+// Do not modify this file. Instead propose a change against Pebble and then
+// copy the changes over.
+package plan
+
+const (
+	StartupUnknown  ServiceStartup = ""
+	StartupEnabled  ServiceStartup = "enabled"
+	StartupDisabled ServiceStartup = "disabled"
+)
+
+const (
+	UnknownOverride Override = ""
+	MergeOverride   Override = "merge"
+	ReplaceOverride Override = "replace"
+)
+
+const (
+	ActionUnset    ServiceAction = ""
+	ActionRestart  ServiceAction = "restart"
+	ActionShutdown ServiceAction = "shutdown"
+	ActionIgnore   ServiceAction = "ignore"
+)
+
+const (
+	UnsetLevel CheckLevel = ""
+	AliveLevel CheckLevel = "alive"
+	ReadyLevel CheckLevel = "ready"
+)
+
+type Plan struct {
+	Layers   []*Layer            `yaml:"-"`
+	Services map[string]*Service `yaml:"services,omitempty"`
+	Checks   map[string]*Check   `yaml:"checks,omitempty"`
+}
+
+type Layer struct {
+	Order       int                 `yaml:"-"`
+	Label       string              `yaml:"-"`
+	Summary     string              `yaml:"summary,omitempty"`
+	Description string              `yaml:"description,omitempty"`
+	Services    map[string]*Service `yaml:"services,omitempty"`
+	Checks      map[string]*Check   `yaml:"checks,omitempty"`
+}
+
+type Service struct {
+	// Basic details
+	Name        string         `yaml:"-"`
+	Summary     string         `yaml:"summary,omitempty"`
+	Description string         `yaml:"description,omitempty"`
+	Startup     ServiceStartup `yaml:"startup,omitempty"`
+	Override    Override       `yaml:"override,omitempty"`
+	Command     string         `yaml:"command,omitempty"`
+
+	// Service dependencies
+	After    []string `yaml:"after,omitempty"`
+	Before   []string `yaml:"before,omitempty"`
+	Requires []string `yaml:"requires,omitempty"`
+
+	// Options for command execution
+	Environment map[string]string `yaml:"environment,omitempty"`
+	UserID      *int              `yaml:"user-id,omitempty"`
+	User        string            `yaml:"user,omitempty"`
+	GroupID     *int              `yaml:"group-id,omitempty"`
+	Group       string            `yaml:"group,omitempty"`
+
+	// Auto-restart and backoff functionality
+	OnSuccess      ServiceAction            `yaml:"on-success,omitempty"`
+	OnFailure      ServiceAction            `yaml:"on-failure,omitempty"`
+	OnCheckFailure map[string]ServiceAction `yaml:"on-check-failure,omitempty"`
+	BackoffDelay   OptionalDuration         `yaml:"backoff-delay,omitempty"`
+	BackoffFactor  OptionalFloat            `yaml:"backoff-factor,omitempty"`
+	BackoffLimit   OptionalDuration         `yaml:"backoff-limit,omitempty"`
+}
+
+type Check struct {
+	// Basic details
+	Name     string     `yaml:"-"`
+	Override Override   `yaml:"override,omitempty"`
+	Level    CheckLevel `yaml:"level,omitempty"`
+
+	// Common check settings
+	Period    OptionalDuration `yaml:"period,omitempty"`
+	Timeout   OptionalDuration `yaml:"timeout,omitempty"`
+	Threshold int              `yaml:"threshold,omitempty"`
+
+	// Type-specific check settings (only one of these can be set)
+	HTTP *HTTPCheck `yaml:"http,omitempty"`
+	TCP  *TCPCheck  `yaml:"tcp,omitempty"`
+	Exec *ExecCheck `yaml:"exec,omitempty"`
+}
+
+type ExecCheck struct {
+	Command     string            `yaml:"command,omitempty"`
+	Environment map[string]string `yaml:"environment,omitempty"`
+	UserID      *int              `yaml:"user-id,omitempty"`
+	User        string            `yaml:"user,omitempty"`
+	GroupID     *int              `yaml:"group-id,omitempty"`
+	Group       string            `yaml:"group,omitempty"`
+	WorkingDir  string            `yaml:"working-dir,omitempty"`
+}
+
+type TCPCheck struct {
+	Port int    `yaml:"port,omitempty"`
+	Host string `yaml:"host,omitempty"`
+}
+
+type HTTPCheck struct {
+	URL     string            `yaml:"url,omitempty"`
+	Headers map[string]string `yaml:"headers,omitempty"`
+}
+
+type CheckLevel string
+
+type Override string
+
+type ServiceAction string
+
+type ServiceStartup string

--- a/service/pebble/plan/types.go
+++ b/service/pebble/plan/types.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Plan constructs are copied directly from the Pebble code base to Juju without
+// any modification. We perform this copy as the Pebble package does not isolate
+// plan types fully and will cause Juju to not compile correctly on systems that
+// are not Linux based.
+//
+// The code can be found at https://github.com/canonical/pebble/internal/plan
+//
+// Do not modify this file. Instead propose a change against Pebble and then
+// copy the changes over.
+package plan
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type OptionalDuration struct {
+	Value time.Duration
+	IsSet bool
+}
+
+func (o OptionalDuration) IsZero() bool {
+	return !o.IsSet
+}
+
+func (o OptionalDuration) MarshalYAML() (interface{}, error) {
+	if !o.IsSet {
+		return nil, nil
+	}
+	return o.Value.String(), nil
+}
+
+func (o *OptionalDuration) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("duration must be a YAML string")
+	}
+	duration, err := time.ParseDuration(value.Value)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q", value.Value)
+	}
+	o.Value = duration
+	o.IsSet = true
+	return nil
+}
+
+type OptionalFloat struct {
+	Value float64
+	IsSet bool
+}
+
+func (o OptionalFloat) IsZero() bool {
+	return !o.IsSet
+}
+
+func (o OptionalFloat) MarshalYAML() (interface{}, error) {
+	if !o.IsSet {
+		return nil, nil
+	}
+	return o.Value, nil
+}
+
+func (o *OptionalFloat) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("value must be a YAML number")
+	}
+	n, err := strconv.ParseFloat(value.Value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid floating-point number %q", value.Value)
+	}
+	o.Value = n
+	o.IsSet = true
+	return nil
+}

--- a/worker/errors.go
+++ b/worker/errors.go
@@ -16,9 +16,20 @@ import (
 // might need to respond to that, perhaps by returning an error specific to
 // *its* host; depending on these values punching right through N layers (but
 // only when we want them to!) is kinda terrible.
-var (
-	ErrRestartAgent    = errors.New("agent should be restarted")
-	ErrTerminateAgent  = errors.New("agent should be terminated")
-	ErrRebootMachine   = errors.New("machine needs to reboot")
-	ErrShutdownMachine = errors.New("machine needs to shutdown")
+
+const (
+	// ErrRebootMachine indicates that the machine the agent is running on
+	// should be rebooted.
+	ErrRebootMachine = errors.ConstError("machine needs to reboot")
+
+	// ErrRestartAgent indicates that the agent should be
+	// restarted.
+	ErrRestartAgent = errors.ConstError("agent should be restarted")
+
+	// ErrShutdownMachine indicates the machine the agent is running on should
+	// be shutdown.
+	ErrShutdownMachine = errors.ConstError("machine needs to shutdown")
+
+	// ErrTerminateAgent indicates the agent should be terminated.
+	ErrTerminateAgent = errors.ConstError("agent should be terminated")
 )

--- a/worker/uniter/container/terminator.go
+++ b/worker/uniter/container/terminator.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package container
+
+import (
+	"github.com/juju/juju/worker/uniter/pebble"
+)
+
+// Terminator is responsible for providing a helper interface to the
+// uniter for ensuring the charm processes started with the containers under
+// management are shutdown cleanly.
+type Terminator interface {
+	// ShutdownContainers takes a set of containers to shutdown cleanly that are
+	// being managed  by this Uniter. Returns the subset of containers that were
+	// not able to be successfully shutdown and any errors occurred.
+	ShutdownContainers([]string) ([]string, error)
+}
+
+// noopTerminator is a noop implementation of the Terminator interface.
+type noopTerminator struct{}
+
+// NewTerminator returns a terminator that is capable of shutting down
+// containers that are running under pebble or older style Juju container
+// implementations.
+func NewTerminator(isPebble bool) Terminator {
+	// If it's not pebble then do nothing because there is nothing to do.
+	if !isPebble {
+		return &noopTerminator{}
+	}
+
+	return pebble.NewTerminator(func(container string) (pebble.TerminatorClient, error) {
+		return pebble.ClientForContainer(container)
+	})
+}
+
+// ShutdownContainers implements the Terminator interface.
+func (_ *noopTerminator) ShutdownContainers(_ []string) ([]string, error) {
+	return []string{}, nil
+}

--- a/worker/uniter/manifold.go
+++ b/worker/uniter/manifold.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/worker/common/reboot"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/uniter/charm"
+	"github.com/juju/juju/worker/uniter/container"
 	"github.com/juju/juju/worker/uniter/operation"
 	"github.com/juju/juju/worker/uniter/resolver"
 	"github.com/juju/juju/worker/uniter/runner"
@@ -159,6 +160,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Sidecar:                      config.Sidecar,
 				EnforcedCharmModifiedVersion: config.EnforcedCharmModifiedVersion,
 				ContainerNames:               config.ContainerNames,
+				ContainerTerminator:          container.NewTerminator(config.Sidecar),
 			})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/worker/uniter/pebble/container.go
+++ b/worker/uniter/pebble/container.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pebble
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/canonical/pebble/client"
+)
+
+const (
+	// pebbleSocketPathPrefix is the path prefix to apply to the pebble socket
+	// for containers.
+	pebbleSocketPathPrefix = "/charm/containers"
+
+	// pebbleSocketName is the name of the socket file used for Pebble.
+	pebbleSocketName = "pebble.socket"
+)
+
+// ClientForContainer constructs a new pebble client for the specified container
+// name.
+func ClientForContainer(container string) (*client.Client, error) {
+	sockPath := SocketPathForContainer(container)
+	config := &client.Config{
+		Socket: sockPath,
+	}
+
+	client, err := client.New(config)
+	if err != nil {
+		return client, fmt.Errorf("creating pebble client for container %q at socket path %q: %w",
+			container,
+			sockPath,
+			err)
+	}
+
+	return client, nil
+}
+
+// SocketPathForContainer generates the path to the Pebble socket for a given
+// container name.
+func SocketPathForContainer(container string) string {
+	return path.Join(pebbleSocketPathPrefix, container, pebbleSocketName)
+}

--- a/worker/uniter/pebble/container_test.go
+++ b/worker/uniter/pebble/container_test.go
@@ -1,0 +1,28 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pebble_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/uniter/pebble"
+)
+
+type containerSuite struct{}
+
+var _ = gc.Suite(&containerSuite{})
+
+// TestClientForContainerCreation is a simple test to check that a Pebble client
+// can still be created for a fictitious container. We have no reason to check
+// the internal workings of the Pebble client creation process.
+func (_ *containerSuite) TestClientForContainerCreation(c *gc.C) {
+	_, err := pebble.ClientForContainer("testmctestface")	
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (_ *containerSuite) TestSocketPathForContainer(c *gc.C) {
+	path := pebble.SocketPathForContainer("testmctestface")
+	c.Assert(path, gc.Equals, "/charm/containers/testmctestface/pebble.socket")
+}

--- a/worker/uniter/pebble/package_test.go
+++ b/worker/uniter/pebble/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pebble_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/uniter/pebble/terminator.go
+++ b/worker/uniter/pebble/terminator.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pebble
+
+import (
+	"fmt"
+
+	"github.com/canonical/pebble/client"
+)
+
+// Terminator is a pebble specific client for terminating pebble services in
+// containers.
+type Terminator struct {
+	clientFunc TerminatorClientFunc
+}
+
+// TerminatorClient defines the very small subset of functionality needed from
+// Pebble to terminate containers.
+type TerminatorClient interface {
+	Shutdown(*client.ShutdownOptions) error
+}
+
+// TerminatorClientFunc defines the function signature needed to generate a new
+// TerminatorClient.
+type TerminatorClientFunc func(string) (TerminatorClient, error)
+
+// NewTerminator constructs a new container terminator from the client supplied
+// by clientFunc.
+func NewTerminator(clientFunc TerminatorClientFunc) *Terminator {
+	return &Terminator{
+		clientFunc: clientFunc,
+	}
+}
+
+// ShutdownContainers terminates all the Pebble instances for the set of
+// containers supplied. Return the subset of containers that were not able to be
+// shutdown and any errors.
+func (t *Terminator) ShutdownContainers(containers []string) ([]string, error) {
+	i := 0
+	for ; i < len(containers); i++ {
+		container := containers[i]
+		tc, err := t.clientFunc(container)
+		if err != nil {
+			return containers[i:],
+				fmt.Errorf("creating pebble terminator client for container %q: %w", container, err)
+		}
+
+		if err := tc.Shutdown(&client.ShutdownOptions{}); err != nil {
+			return containers[i:],
+				fmt.Errorf("shutting down pebble for container %q: %w", container, err)
+		}
+	}
+
+	return []string{}, nil
+}

--- a/worker/uniter/pebble/terminator_test.go
+++ b/worker/uniter/pebble/terminator_test.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package pebble_test
+
+import (
+	"fmt"
+	"sort"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/client"
+
+	"github.com/juju/juju/worker/uniter/pebble"
+)
+
+type terminatorSuite struct{}
+
+type mockTerminatorClient struct{
+	shutdown func(*client.ShutdownOptions) error
+}
+
+var _ = gc.Suite(&terminatorSuite{})
+
+func (m *mockTerminatorClient) Shutdown(o *client.ShutdownOptions) error {
+	if m.shutdown != nil {
+		return m.shutdown(o)
+	}
+	return nil
+}
+
+func (_ *terminatorSuite) TestShutdownContainersWithNoError(c *gc.C) {
+	terminator := pebble.NewTerminator(func(container string) (pebble.TerminatorClient, error) {
+		return &mockTerminatorClient{}, nil
+	})
+
+	notFinished, err := terminator.ShutdownContainers([]string{"test1", "test2", "test3"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(notFinished), gc.Equals, 0)
+}
+
+func (_ *terminatorSuite) TestShutdownContainersWithError(c *gc.C) {
+	containers := []string{
+		"test1",
+		"test2",
+		"test3",
+		"test4",
+		"test5",
+	}
+
+	sort.Strings(containers)
+	callCount := 0
+	terminator := pebble.NewTerminator(func(container string) (pebble.TerminatorClient, error) {
+		return &mockTerminatorClient{
+			shutdown: func(_ *client.ShutdownOptions) error {
+				callCount++
+				if callCount == 3 {
+					return fmt.Errorf("forced error")
+				}
+
+				index := sort.SearchStrings(containers, container)
+				if index == len(containers) || containers[index] != container {
+					c.Fatalf("received unknown container termination for %q", container)
+				}
+
+				containers = append(containers[:index], containers[index+1:]...)
+
+				return nil
+			},
+		}, nil
+	})
+
+	containersToTerm := make([]string, len(containers))
+	copy(containersToTerm, containers)
+
+	notFinished, err := terminator.ShutdownContainers(containersToTerm)
+	c.Assert(err, gc.NotNil)
+
+	sort.Strings(notFinished)
+	c.Assert(notFinished, jc.DeepEquals, containers)
+}


### PR DESCRIPTION
With sidecar charms we were not tearing down sidecar charms correctly. This was because when Kubernetes removes a pod it sends TERM signal to all containers and then their respective pid 0 is responsible for handling the stopping of the process. Kubernetes also has a hard grace period that it will give all containers in the pod to shutdown gracefully and after that will send SIGKILL.

With this change we are not attempting to control the order of shut down a bit better.

- First we are telling all charm containers that are running Pebble for Pebble to go ahead and ignore SIGTERM and use USR1 as it's shut down signal. This will allow the charm workloads to keep executing while the charm is running tear down hooks.

- The uniter will then process the chamr's tear down hooks and signal to all Pebble instances to shutdown.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Coming soon

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/1951415
