### PR TITLE
[JUJU-2615] Clean up entity parsing for debug-log

### DIFF
--- a/api/common/logs.go
+++ b/api/common/logs.go
@@ -22,7 +22,7 @@ import (
 // closes the connection.
 type DebugLogParams struct {
 	// IncludeEntity lists entity tags to include in the response. Tags may
-	// finish with a '*' to match a prefix e.g.: unit-mysql-*, machine-2. If
+	// include '*' wildcards e.g.: unit-mysql-*, machine-2. If
 	// none are set, then all lines are considered included.
 	IncludeEntity []string
 	// IncludeModule lists logging modules to include in the response. If none
@@ -33,7 +33,7 @@ type DebugLogParams struct {
 	// are set all labels are considered included.
 	IncludeLabel []string
 	// ExcludeEntity lists entity tags to exclude from the response. As with
-	// IncludeEntity the values may finish with a '*'.
+	// IncludeEntity the values may include '*' wildcards.
 	ExcludeEntity []string
 	// ExcludeModule lists logging modules to exclude from the response. If a
 	// module is specified, all the submodules are also excluded.

--- a/state/logs.go
+++ b/state/logs.go
@@ -797,8 +797,10 @@ func makeEntityPattern(entities []string) string {
 	var patterns []string
 	for _, entity := range entities {
 		// Convert * wildcard to the regex equivalent. This is safe
-		// because * never appears in entity names.
-		patterns = append(patterns, strings.Replace(entity, "*", ".*", -1))
+		// because * never appears in entity names. Escape any other regex.
+		escaped := regexp.QuoteMeta(entity)
+		unescapedWildcards := strings.Replace(escaped, regexp.QuoteMeta("*"), ".*", -1)
+		patterns = append(patterns, unescapedWildcards)
 	}
 	return `^(` + strings.Join(patterns, "|") + `)$`
 }


### PR DESCRIPTION
Clean up entity parsing for debug-log

Show warnings when filters filter non log giving sources

Also remove unsupported feature where debug-log filtering allows
filtering by regex, but only sometimes. Now only raw strings or
wildcards are supported

Do this by escaping regex then unescaping the wildcard when querying
Mongo. Hopefully changes to the client _should_ mean this is superfulous.

NOTE: queries can include `*` wildcard, so are not always valid tags or resource
names

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Bootstrap a machine controller, deploy some apps and try
- `juju debug-log -i ubuntu` should show logs for all ubuntu units
- `juju debug-log -i "#p[kl;"` should show a warning
- `juju debug-log -i "*"` should show all logs
- `juju debug-log -i machine-*` should show all machine logs
- `juju debug-log -i "\w+-ubuntu"` should return a warning

Bootstrap a k8s controller and try, deploy some apps and try:
- `juju debug-log -i ubuntu` should show logs for the ubuntu application
- `juju debug-log -i 0` should return a warning
- `juju debug-log -i machine-0` should return a warning
- `juju debug-log -i ubuntu/0` should return a warning

## Bug reference

https://bugs.launchpad.net/juju/+bug/1977670