### PR TITLE
[JUJU-2582] Migrate settings/scopes for relations to remote applications

### DIFF
--- a/apiserver/facades/controller/remoterelations/interface.go
+++ b/apiserver/facades/controller/remoterelations/interface.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// RemoteRelationState provides the subset of global state required by the
+// RemoteRelationsState provides the subset of global state required by the
 // remote relations facade.
 type RemoteRelationsState interface {
 	common.Backend

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -18,7 +18,7 @@ import (
 	"github.com/juju/juju/state/watcher"
 )
 
-// API provides access to version 1 of the remote relations API facade.
+// APIv1 provides access to version 1 of the remote relations API facade.
 type APIv1 struct {
 	*API
 }
@@ -379,10 +379,6 @@ func (api *API) WatchLocalRelationChanges(args params.Entities) (params.RemoteRe
 	return results, nil
 }
 
-// Mask out new methods from the old API versions. The API reflection
-// code in rpc/rpcreflect/type.go:newMethod skips 2-argument methods,
-// so this removes the method as far as the RPC machinery is concerned.
-//
 // WatchLocalRelationChanges doesn't exist before the v2 API.
 func (api *APIv1) WatchLocalRelationChanges(_, _ struct{}) {}
 

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -857,7 +857,6 @@ func (w *srvRelationStatusWatcher) Next() (params.RelationLifeSuspendedStatusWat
 type srvOfferStatusWatcher struct {
 	watcherCommon
 	st      *state.State
-	model   *cache.Model
 	watcher crossmodelrelations.OfferWatcher
 }
 
@@ -867,10 +866,6 @@ func newOfferStatusWatcher(context facade.Context) (facade.Facade, error) {
 	resources := context.Resources()
 
 	st := context.State()
-	model, err := context.CachedModel(st.ModelUUID())
-	if err != nil {
-		return watcherCommon{}, err
-	}
 
 	// TODO(wallyworld) - enhance this watcher to support
 	// anonymous api calls with macaroons.
@@ -884,7 +879,6 @@ func newOfferStatusWatcher(context facade.Context) (facade.Facade, error) {
 	return &srvOfferStatusWatcher{
 		watcherCommon: newWatcherCommon(context),
 		st:            st,
-		model:         model,
 		watcher:       watcher,
 	}, nil
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -2612,7 +2612,7 @@ func (s *MigrationExportSuite) TestRelationWithNoStatus(c *gc.C) {
 	c.Assert(rels[0].Status(), gc.IsNil)
 }
 
-func (s *MigrationExportSuite) TestRemoteRelationSettingsForLocalUnitInCMR(c *gc.C) {
+func (s *MigrationExportSuite) TestRemoteRelationSettingsForUnitsInCMR(c *gc.C) {
 	mac, err := newMacaroon("apimac")
 	c.Assert(err, gc.IsNil)
 
@@ -2658,10 +2658,18 @@ func (s *MigrationExportSuite) TestRemoteRelationSettingsForLocalUnitInCMR(c *gc
 	c.Assert(err, jc.ErrorIsNil)
 
 	wordpress0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
-	ru, err := rel.Unit(wordpress0)
+	localRU, err := rel.Unit(wordpress0)
 	c.Assert(err, jc.ErrorIsNil)
+
 	wordpressSettings := map[string]interface{}{"name": "wordpress/0"}
-	err = ru.EnterScope(wordpressSettings)
+	err = localRU.EnterScope(wordpressSettings)
+	c.Assert(err, jc.ErrorIsNil)
+
+	remoteRU, err := rel.RemoteUnit("gravy-rainbow/0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	gravySettings := map[string]interface{}{"name": "gravy-rainbow/0"}
+	err = remoteRU.EnterScope(gravySettings)
 	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := s.State.Export()
@@ -2673,14 +2681,11 @@ func (s *MigrationExportSuite) TestRemoteRelationSettingsForLocalUnitInCMR(c *gc
 	c.Assert(exRel.Endpoints(), gc.HasLen, 2)
 
 	for _, exEp := range exRel.Endpoints() {
-		// We expect that the relation settings for the local application unit
-		// are recorded against its relation endpoint,
-		// but the remote application has no unit settings.
 		if exEp.ApplicationName() == "wordpress" {
 			c.Check(exEp.Settings(wordpress0.Name()), jc.DeepEquals, wordpressSettings)
 		} else {
 			c.Check(exEp.ApplicationName(), gc.Equals, "gravy-rainbow")
-			c.Check(exEp.AllSettings(), gc.HasLen, 0)
+			c.Check(exEp.Settings("gravy-rainbow/0"), jc.DeepEquals, gravySettings)
 		}
 	}
 }

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1333,14 +1333,16 @@ func (s *MigrationImportSuite) TestRelations(c *gc.C) {
 	state.AddTestingApplication(c, s.State, "mysql", state.AddTestingCharm(c, s.State, "mysql"))
 	eps, err := s.State.InferEndpoints("mysql", "wordpress")
 	c.Assert(err, jc.ErrorIsNil)
+
 	rel, err := s.State.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = rel.SetStatus(status.StatusInfo{Status: status.Joined})
 	c.Assert(err, jc.ErrorIsNil)
-	wordpress_0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
 
-	ru, err := rel.Unit(wordpress_0)
+	wordpress0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	ru, err := rel.Unit(wordpress0)
 	c.Assert(err, jc.ErrorIsNil)
+
 	relSettings := map[string]interface{}{
 		"name": "wordpress/0",
 	}
@@ -1369,6 +1371,60 @@ func (s *MigrationImportSuite) TestRelations(c *gc.C) {
 	settings, err := ru.Settings()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings.Map(), gc.DeepEquals, relSettings)
+}
+
+func (s *MigrationImportSuite) TestCMRRemoteRelationScope(c *gc.C) {
+	_, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "gravy-rainbow",
+		URL:         "me/model.rainbow",
+		SourceModel: s.Model.ModelTag(),
+		Token:       "charisma",
+		OfferUUID:   "offer-uuid",
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "db",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	wordpress := state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
+	eps, err := s.State.InferEndpoints("gravy-rainbow", "wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(eps...)
+	c.Assert(err, jc.ErrorIsNil)
+
+	wordpress0 := s.Factory.MakeUnit(c, &factory.UnitParams{Application: wordpress})
+	localRU, err := rel.Unit(wordpress0)
+	c.Assert(err, jc.ErrorIsNil)
+
+	wordpressSettings := map[string]interface{}{"name": "wordpress/0"}
+	err = localRU.EnterScope(wordpressSettings)
+	c.Assert(err, jc.ErrorIsNil)
+
+	remoteRU, err := rel.RemoteUnit("gravy-rainbow/0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	gravySettings := map[string]interface{}{"name": "gravy-rainbow/0"}
+	err = remoteRU.EnterScope(gravySettings)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, newSt := s.importModel(c, s.State)
+
+	newWordpress, err := newSt.Application("wordpress")
+	c.Assert(err, jc.ErrorIsNil)
+
+	rels, err := newWordpress.Relations()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(rels, gc.HasLen, 1)
+
+	ru, err := rels[0].RemoteUnit("gravy-rainbow/0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	inScope, err := ru.InScope()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(inScope, jc.IsTrue)
 }
 
 func (s *MigrationImportSuite) assertRelationsMissingStatus(c *gc.C, hasUnits bool) {


### PR DESCRIPTION
When migrating a model offering a SAAS with established relations, we neither export nor import relation settings (and by derivation scope documents) for remote units.

This is one of the causes of such relations being removed immediately upon migration of the offer-side model.

Here, we ensure that units in scope have their relation settings and scopes preserved during migration.

## QA steps

Note that this is one step in fixing migrated CMRs. In this example the relation still breaks, but we can verify that the scopes are preserved initially.

- Set up the offer, consumer and targets.
```
for c in "cns" "src" "dst"; do juju bootstrap lxd $c --no-gui; done
juju switch src; juju deploy ./testcharms/charms/dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju consume src:admin/default.dummy-source; juju deploy ./testcharms/charms/dummy-sink; juju relate dummy-source dummy-sink
juju switch dst; juju destroy-model default -y
```
- Connect to Mongo on the `dst` controller, where we will continuously run:
```
db.relationscopes.find().pretty()
```
- Switch to the `src` controller and migrate default to `dst`.
- We should see both scope documents appear in the `dst` database before the relation gets broken.

## Documentation changes

None.

## Bug reference


