### PR TITLE
Fixes for 3.1 CLI client with 3.0 controller

### DIFF
--- a/api/client/secretbackends/client.go
+++ b/api/client/secretbackends/client.go
@@ -38,8 +38,14 @@ type SecretBackend struct {
 	Error               error
 }
 
+var notSupported = errors.NotSupportedf("secret backends on this juju version")
+
 // ListSecretBackends lists the specified secret backends, or all available if no names are provided.
 func (api *Client) ListSecretBackends(names []string, reveal bool) ([]SecretBackend, error) {
+	if api.BestAPIVersion() < 1 {
+		return nil, notSupported
+	}
+
 	var response params.ListSecretBackendsResults
 	err := api.facade.FacadeCall("ListSecretBackends", params.ListSecretBackendsArgs{Names: names, Reveal: reveal}, &response)
 	if err != nil {
@@ -78,6 +84,10 @@ type CreateSecretBackend struct {
 
 // AddSecretBackend adds the specified secret backend.
 func (api *Client) AddSecretBackend(backend CreateSecretBackend) error {
+	if api.BestAPIVersion() < 1 {
+		return notSupported
+	}
+
 	var results params.ErrorResults
 	args := params.AddSecretBackendArgs{
 		Args: []params.AddSecretBackendArg{{
@@ -108,6 +118,10 @@ type UpdateSecretBackend struct {
 
 // UpdateSecretBackend updates the specified secret backend.
 func (api *Client) UpdateSecretBackend(arg UpdateSecretBackend, force bool) error {
+	if api.BestAPIVersion() < 1 {
+		return notSupported
+	}
+
 	var results params.ErrorResults
 	args := params.UpdateSecretBackendArgs{
 		Args: []params.UpdateSecretBackendArg{{
@@ -128,6 +142,10 @@ func (api *Client) UpdateSecretBackend(arg UpdateSecretBackend, force bool) erro
 
 // RemoveSecretBackend removes the specified secret backend.
 func (api *Client) RemoveSecretBackend(name string, force bool) error {
+	if api.BestAPIVersion() < 1 {
+		return notSupported
+	}
+
 	var results params.ErrorResults
 	args := params.RemoveSecretBackendArgs{
 		Args: []params.RemoveSecretBackendArg{{

--- a/api/client/secretbackends/client_test.go
+++ b/api/client/secretbackends/client_test.go
@@ -36,29 +36,31 @@ func ptr[T any](v T) *T {
 
 func (s *SecretBackendsSuite) TestListSecretBackends(c *gc.C) {
 	config := map[string]interface{}{"foo": "bar"}
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "SecretBackends")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "ListSecretBackends")
-		c.Check(arg, jc.DeepEquals, params.ListSecretBackendsArgs{Names: []string{"myvault"}, Reveal: true})
-		c.Assert(result, gc.FitsTypeOf, &params.ListSecretBackendsResults{})
-		*(result.(*params.ListSecretBackendsResults)) = params.ListSecretBackendsResults{
-			[]params.SecretBackendResult{{
-				Result: params.SecretBackend{
-					Name:                "foo",
-					BackendType:         "vault",
-					TokenRotateInterval: ptr(666 * time.Minute),
-					Config:              config,
-				},
-				ID:         "backend-id",
-				NumSecrets: 666,
-				Status:     "error",
-				Message:    "vault is sealed",
-			}},
-		}
-		return nil
-	})
+	apiCaller := testing.BestVersionCaller{
+		APICallerFunc: testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "SecretBackends")
+			c.Check(version, gc.Equals, 1)
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "ListSecretBackends")
+			c.Check(arg, jc.DeepEquals, params.ListSecretBackendsArgs{Names: []string{"myvault"}, Reveal: true})
+			c.Assert(result, gc.FitsTypeOf, &params.ListSecretBackendsResults{})
+			*(result.(*params.ListSecretBackendsResults)) = params.ListSecretBackendsResults{
+				[]params.SecretBackendResult{{
+					Result: params.SecretBackend{
+						Name:                "foo",
+						BackendType:         "vault",
+						TokenRotateInterval: ptr(666 * time.Minute),
+						Config:              config,
+					},
+					ID:         "backend-id",
+					NumSecrets: 666,
+					Status:     "error",
+					Message:    "vault is sealed",
+				}},
+			}
+			return nil
+		}), BestVersion: 1,
+	}
 	client := secretbackends.NewClient(apiCaller)
 	result, err := client.ListSecretBackends([]string{"myvault"}, true)
 	c.Assert(err, jc.ErrorIsNil)
@@ -82,55 +84,59 @@ func (s *SecretBackendsSuite) TestAddSecretsBackend(c *gc.C) {
 		TokenRotateInterval: ptr(666 * time.Minute),
 		Config:              map[string]interface{}{"foo": "bar"},
 	}
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "SecretBackends")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "AddSecretBackends")
-		c.Check(arg, jc.DeepEquals, params.AddSecretBackendArgs{
-			Args: []params.AddSecretBackendArg{{
-				ID: "backend-id",
-				SecretBackend: params.SecretBackend{
-					Name:                backend.Name,
-					BackendType:         backend.BackendType,
-					TokenRotateInterval: backend.TokenRotateInterval,
-					Config:              backend.Config,
-				},
-			}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		return nil
-	})
+	apiCaller := testing.BestVersionCaller{
+		APICallerFunc: testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "SecretBackends")
+			c.Check(version, gc.Equals, 1)
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "AddSecretBackends")
+			c.Check(arg, jc.DeepEquals, params.AddSecretBackendArgs{
+				Args: []params.AddSecretBackendArg{{
+					ID: "backend-id",
+					SecretBackend: params.SecretBackend{
+						Name:                backend.Name,
+						BackendType:         backend.BackendType,
+						TokenRotateInterval: backend.TokenRotateInterval,
+						Config:              backend.Config,
+					},
+				}},
+			})
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			*(result.(*params.ErrorResults)) = params.ErrorResults{
+				Results: []params.ErrorResult{{
+					Error: &params.Error{Message: "FAIL"},
+				}},
+			}
+			return nil
+		}), BestVersion: 1,
+	}
 	client := secretbackends.NewClient(apiCaller)
 	err := client.AddSecretBackend(backend)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
 func (s *SecretBackendsSuite) TestRemoveSecretsBackend(c *gc.C) {
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "SecretBackends")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "RemoveSecretBackends")
-		c.Check(arg, jc.DeepEquals, params.RemoveSecretBackendArgs{
-			Args: []params.RemoveSecretBackendArg{{
-				Name:  "foo",
-				Force: true,
-			}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		return nil
-	})
+	apiCaller := testing.BestVersionCaller{
+		APICallerFunc: testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "SecretBackends")
+			c.Check(version, gc.Equals, 1)
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "RemoveSecretBackends")
+			c.Check(arg, jc.DeepEquals, params.RemoveSecretBackendArgs{
+				Args: []params.RemoveSecretBackendArg{{
+					Name:  "foo",
+					Force: true,
+				}},
+			})
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			*(result.(*params.ErrorResults)) = params.ErrorResults{
+				Results: []params.ErrorResult{{
+					Error: &params.Error{Message: "FAIL"},
+				}},
+			}
+			return nil
+		}), BestVersion: 1,
+	}
 	client := secretbackends.NewClient(apiCaller)
 	err := client.RemoveSecretBackend("foo", true)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
@@ -143,28 +149,30 @@ func (s *SecretBackendsSuite) TestUpdateSecretsBackend(c *gc.C) {
 		TokenRotateInterval: ptr(666 * time.Minute),
 		Config:              map[string]interface{}{"foo": "bar"},
 	}
-	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
-		c.Check(objType, gc.Equals, "SecretBackends")
-		c.Check(version, gc.Equals, 0)
-		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "UpdateSecretBackends")
-		c.Check(arg, jc.DeepEquals, params.UpdateSecretBackendArgs{
-			Args: []params.UpdateSecretBackendArg{{
-				Name:                backend.Name,
-				TokenRotateInterval: backend.TokenRotateInterval,
-				Config:              backend.Config,
-				NameChange:          backend.NameChange,
-				Force:               true,
-			}},
-		})
-		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
-		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
-		}
-		return nil
-	})
+	apiCaller := testing.BestVersionCaller{
+		APICallerFunc: testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+			c.Check(objType, gc.Equals, "SecretBackends")
+			c.Check(version, gc.Equals, 1)
+			c.Check(id, gc.Equals, "")
+			c.Check(request, gc.Equals, "UpdateSecretBackends")
+			c.Check(arg, jc.DeepEquals, params.UpdateSecretBackendArgs{
+				Args: []params.UpdateSecretBackendArg{{
+					Name:                backend.Name,
+					TokenRotateInterval: backend.TokenRotateInterval,
+					Config:              backend.Config,
+					NameChange:          backend.NameChange,
+					Force:               true,
+				}},
+			})
+			c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
+			*(result.(*params.ErrorResults)) = params.ErrorResults{
+				Results: []params.ErrorResult{{
+					Error: &params.Error{Message: "FAIL"},
+				}},
+			}
+			return nil
+		}), BestVersion: 1,
+	}
 	client := secretbackends.NewClient(apiCaller)
 	err := client.UpdateSecretBackend(backend, true)
 	c.Assert(err, gc.ErrorMatches, "FAIL")

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -397,6 +397,18 @@ var configTests = []configTest{
 		}),
 		err: `unknown severity level "bar"`,
 	}, {
+		about:       "compatible with older empty, now mandatory",
+		useDefaults: config.NoDefaults,
+		attrs: sampleConfig.Merge(testing.Attrs{
+			"secret-backend": "",
+		}),
+	}, {
+		about:       "compatible with older missing, now mandatory",
+		useDefaults: config.NoDefaults,
+		attrs: minimalConfigAttrs.Merge(testing.Attrs{
+			"resource-tags": []string{},
+		}),
+	}, {
 		about:       "Sample configuration",
 		useDefaults: config.UseDefaults,
 		attrs:       sampleConfig,


### PR DESCRIPTION
Using a 3.1 CLI against a 3.0 controller to do things like upgrade model or destroy controller failed.
The issue was the `secret-backend` config was `""` in 3.0 and is mandatory in 3.1. The config parsing was tweaked to handle cases where an item was strictly not optional, had a default, but was set to empty and the NoDefaults option was used.

Also with the secret backend CLI, print a nicer error if not supported.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Use a 3.1 client with a 3.0 controller.
Test upgrade model, destroy controller and secret backend commands.