### PR TITLE
Equinix Provider - Fix Provisioning Error Checks

### DIFF
--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -177,7 +177,7 @@ func (e *environ) Instances(ctx context.ProviderCallContext, ids []instance.Id) 
 
 	for i, id := range ids {
 		d, resp, err := e.equinixClient.Devices.Get(string(id), nil)
-		if err != nil && resp != nil && resp.Request.Response.StatusCode == http.StatusNotFound {
+		if err != nil && resp != nil && resp.Response.StatusCode == http.StatusNotFound {
 			logger.Warningf("instance %s not found", string(id))
 			missingInstanceCount = missingInstanceCount + 1
 			continue
@@ -808,11 +808,7 @@ func waitDeviceActive(ctx context.ProviderCallContext, c *packngo.Client, id str
 		Clock:    clock.WallClock,
 	})
 
-	if d != nil {
-		return d, nil
-	}
-
-	return nil, err
+	return d, err
 }
 
 // Helper function to get supported OS version

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -808,7 +808,7 @@ func waitDeviceActive(ctx context.ProviderCallContext, c *packngo.Client, id str
 		Clock:    clock.WallClock,
 	})
 
-	return d, err
+	return d, errors.Trace(err)
 }
 
 // Helper function to get supported OS version

--- a/provider/equinix/environ_test.go
+++ b/provider/equinix/environ_test.go
@@ -648,7 +648,8 @@ func (*EquinixUtils) TestWaitDeviceActive_ReturnFailed(c *gc.C) {
 		State: "failed",
 	}, nil, nil).Times(1)
 	cl.Devices = device
-	waitDeviceActive(environContext.NewEmptyCloudCallContext(), cl, "100")
+	_, err := waitDeviceActive(environContext.NewEmptyCloudCallContext(), cl, "100")
+	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 
 func (*EquinixUtils) TestIsDistroSupported(c *gc.C) {

--- a/provider/equinix/init.go
+++ b/provider/equinix/init.go
@@ -8,7 +8,10 @@ import (
 )
 
 const (
-	providerType        = "equinix"
+	providerType = "equinix"
+)
+
+const (
 	Provisioning string = "provisioning"
 	Active       string = "active"
 	ShuttingDown string = "shutting-down"

--- a/provider/equinix/init.go
+++ b/provider/equinix/init.go
@@ -8,7 +8,13 @@ import (
 )
 
 const (
-	providerType = "equinix"
+	providerType        = "equinix"
+	Provisioning string = "provisioning"
+	Active       string = "active"
+	ShuttingDown string = "shutting-down"
+	Stopped      string = "stopped"
+	Stopping     string = "stopping"
+	Terminated   string = "terminated"
 )
 
 func init() {

--- a/provider/equinix/instance.go
+++ b/provider/equinix/instance.go
@@ -52,12 +52,12 @@ func (device *equinixDevice) Status(ctx context.ProviderCallContext) instance.St
 	var jujuStatus status.Status
 
 	switch device.State {
-	case "provisioning":
+	case "provisioning", "queued":
 		jujuStatus = status.Pending
 	case "active":
 		jujuStatus = status.Running
-	case "shutting-down", "terminated", "stopping", "stopped":
-		jujuStatus = status.Empty
+	case "deleted", "deprovisioning", "failed", "inactive":
+		jujuStatus = status.ProvisioningError
 	default:
 		jujuStatus = status.Empty
 	}

--- a/provider/equinix/instance.go
+++ b/provider/equinix/instance.go
@@ -52,12 +52,12 @@ func (device *equinixDevice) Status(ctx context.ProviderCallContext) instance.St
 	var jujuStatus status.Status
 
 	switch device.State {
-	case "provisioning", "queued":
-		jujuStatus = status.Pending
-	case "active":
+	case Active:
 		jujuStatus = status.Running
-	case "deleted", "deprovisioning", "failed", "inactive":
-		jujuStatus = status.ProvisioningError
+	case Provisioning:
+		jujuStatus = status.Pending
+	case ShuttingDown, Stopped, Stopping, Terminated:
+		jujuStatus = status.Empty
 	default:
 		jujuStatus = status.Empty
 	}


### PR DESCRIPTION
This PR fixes some issues with the Equinix Provider. 

* We had a typo where the environ.go Instance check that was causing a nil pointer reference and thus it couldn't properly check instance statuses.
* waitDeviceActive was manually passing a nil value instead of an error all the time. We now return the device and error all the time so that the calling functions can properly handle the errors. This permits failed provisioning to be detected and retried.
* Add a test to TestWaitDeviceActive to make sure we get an error message back when provisioning fails.
* Updated instance.go's Status() to use our actual status names when checking device state.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

There is not a simple way to QA this one due to needing to simulate a provisioning failure. We tested this on our end using some debugging tools to manually fail an instance during provisioning and verified that juju now retries provisioning instead of waiting forever.

## Documentation changes

*How it affects user workflow (CLI or API). Delete section if not applicable.*

## Bug reference

*Link to Launchpad bug. Delete section if not applicable.*
