### PR TITLE
[JUJU-2586] Fix LP19988587 Can't switch from edge channel to stable channel

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -430,7 +430,8 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 	charmID, err := factory.Run(cfg)
-	if err == nil {
+	switch {
+	case err == nil:
 		curl := charmID.URL
 		charmOrigin := charmID.Origin
 		// The current charm URL that's been found and selected.
@@ -439,13 +440,13 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 			channel = fmt.Sprintf(" in channel %s", charmID.Origin.Channel.String())
 		}
 		ctx.Infof("Added %s charm %q, revision %d%s, to the model", charmOrigin.Source, curl.Name, curl.Revision, channel)
-	} else if errors.Is(err, refresher.ErrAlreadyUpToDate) {
-		if len(c.Resources) == 0 {
-			// Charm already up-to-date and no resources to refresh.
-			ctx.Infof(err.Error())
-			return nil
-		}
-	} else {
+	case errors.Is(err, refresher.ErrAlreadyUpToDate) && c.Channel.String() != oldOrigin.CoreCharmOrigin().Channel.String():
+		ctx.Infof("%s. Note: all future refreshes will now use channel %q", err.Error(), charmID.Origin.Channel.String())
+	case errors.Is(err, refresher.ErrAlreadyUpToDate) && len(c.Resources) == 0:
+		// Charm already up-to-date and no resources to refresh.
+		ctx.Infof(err.Error())
+		return nil
+	default:
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 			return errors.Trace(termErr.UserErr())
 		}
@@ -453,7 +454,6 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 	}
 
 	// Next, upgrade resources.
-
 	resourceLister, err := c.NewResourceLister(apiRoot)
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -446,6 +446,8 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		// Charm already up-to-date and no resources to refresh.
 		ctx.Infof(err.Error())
 		return nil
+	case errors.Is(err, refresher.ErrAlreadyUpToDate) && len(c.Resources) > 0:
+		ctx.Infof("%s. Attempt to update resources requested.", err.Error())
 	default:
 		if termErr, ok := errors.Cause(err).(*common.TermsRequiredError); ok {
 			return errors.Trace(termErr.UserErr())

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -149,6 +149,9 @@ func (s *BaseRefreshSuite) SetUpTest(c *gc.C) {
 		bindings: map[string]string{
 			"": network.AlphaSpaceName,
 		},
+		charmOrigin: commoncharm.Origin{
+			Risk: "stable",
+		},
 	}
 	s.modelConfigGetter = newMockModelConfigGetter()
 	s.resourceLister = mockResourceLister{}
@@ -606,6 +609,28 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 		Architecture: arch.DefaultArchitecture,
 	})
 	s.charmAdder.CheckCall(c, 0, "AddCharm", s.resolvedCharmURL, origin, false)
+	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
+		ApplicationName: "foo",
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Source:       "charm-store",
+				Architecture: arch.DefaultArchitecture,
+				Risk:         "beta",
+			},
+		},
+	})
+}
+
+func (s *RefreshSuite) TestUpgradeWithChannelNoNewCharmURL(c *gc.C) {
+	// Test setting a new charm channel, without an actual
+	// charm upgrade needed.
+	s.resolvedCharmURL = charm.MustParseURL("cs:quantal/foo-1")
+	s.resolvedChannel = csclientparams.BetaChannel
+	_, err := s.runRefresh(c, "foo", "--channel=beta")
+	c.Assert(err, jc.ErrorIsNil)
+
 	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
 	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
 		ApplicationName: "foo",

--- a/state/application.go
+++ b/state/application.go
@@ -1643,6 +1643,7 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 				Assert: txn.DocExists,
 				Update: bson.D{{"$set", bson.D{
 					{"cs-channel", channel},
+					{"charm-origin.channel", cfg.CharmOrigin.Channel},
 					{"forcecharm", cfg.ForceUnits},
 				}}},
 			})

--- a/state/application.go
+++ b/state/application.go
@@ -1636,16 +1636,24 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 		}}
 
 		if *a.doc.CharmURL == cfg.Charm.URL().String() {
+			updates := bson.D{
+				{"cs-channel", channel},
+				{"forcecharm", cfg.ForceUnits},
+			}
+			// Local charms will not have a channel in their charm origin
+			// TODO: (hml) 2023-02-03
+			// With juju 3.0, SetCharm should always have a CharmOrigin.
+			// Compatibility with the Update application facade method
+			// is no longer necessary.
+			if cfg.CharmOrigin != nil && cfg.CharmOrigin.Channel != nil {
+				updates = append(updates, bson.DocElem{"charm-origin.channel", cfg.CharmOrigin.Channel})
+			}
 			// Charm URL already set; just update the force flag and channel.
 			ops = append(ops, txn.Op{
 				C:      applicationsC,
 				Id:     a.doc.DocID,
 				Assert: txn.DocExists,
-				Update: bson.D{{"$set", bson.D{
-					{"cs-channel", channel},
-					{"charm-origin.channel", cfg.CharmOrigin.Channel},
-					{"forcecharm", cfg.ForceUnits},
-				}}},
+				Update: bson.D{{"$set", updates}},
 			})
 		} else {
 			// Check if the new charm specifies a relation max limit
@@ -1676,6 +1684,10 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 			newCharmModifiedVersion++
 		}
 
+		// TODO: (hml) 2023-02-03
+		// With juju 3.0, SetCharm should always have a CharmOrigin.
+		// Compatibility with the Update application facade method
+		// is no longer necessary. Modify checks appropriately.
 		if cfg.CharmOrigin != nil {
 			// Update in the application facade also calls
 			// SetCharm, though it has no current user in the
@@ -1720,7 +1732,6 @@ func (a *Application) SetCharm(cfg SetCharmConfig) (err error) {
 			// ErrNoOperations on the other hand means there's nothing to update.
 			return nil, errors.Trace(err)
 		}
-
 		return ops, nil
 	}
 

--- a/state/application_test.go
+++ b/state/application_test.go
@@ -141,6 +141,26 @@ func (s *ApplicationSuite) TestSetCharmSeries(c *gc.C) {
 	c.Assert(s.mysql.Series(), gc.DeepEquals, "new-series")
 }
 
+func (s *ApplicationSuite) TestSetCharmUpdateChannelURLNoChange(c *gc.C) {
+	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)
+
+	origin := s.mysql.CharmOrigin()
+	origin.Channel = &state.Channel{Risk: "stable"}
+
+	cfg := state.SetCharmConfig{
+		Charm:       sch,
+		CharmOrigin: origin,
+	}
+	err := s.mysql.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.mysql.CharmOrigin().Channel.Risk, gc.DeepEquals, "stable")
+
+	cfg.CharmOrigin.Channel.Risk = "candidate"
+	err = s.mysql.SetCharm(cfg)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.mysql.CharmOrigin().Channel.Risk, gc.DeepEquals, "candidate")
+}
+
 func (s *ApplicationSuite) TestSetCharmCharmOriginNoChange(c *gc.C) {
 	// Add a compatible charm.
 	sch := s.AddMetaCharm(c, "mysql", metaBase, 2)

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -60,6 +60,63 @@ run_refresh_local() {
 	destroy_model "${model_name}"
 }
 
+run_refresh_channel() {
+	# Test juju refresh from one channel to another
+	echo
+
+	model_name="test-refresh-switch-channel"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy juju-qa-test
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	OUT=$(juju refresh juju-qa-test --channel 2.0/edge 2>&1 || true)
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	# format: Added local charm "ubuntu", revision 2, to the model
+	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/edge")"
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_channel_no_new_revision() {
+	# Test juju refresh from one channel to another, with no new
+	# charm revision.
+	echo
+
+	model_name="test-refresh-switch-channel-no-new-revision"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy ubuntu
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --channel edge 2>&1 || true)
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	if echo "${OUT}" | grep -E -vq "all future refreshes will now use channel"; then
+		# shellcheck disable=SC2046
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
 test_basic() {
 	if [ "$(skip 'test_basic')" ]; then
 		echo "==> TEST SKIPPED: basic refresh"
@@ -73,5 +130,7 @@ test_basic() {
 
 		run "run_refresh_cs"
 		run "run_refresh_local"
+		run "run_refresh_channel"
+		run "run_refresh_channel_no_new_revision"
 	)
 }

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -19,7 +19,7 @@ run_refresh_cs() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
+	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
@@ -51,7 +51,7 @@ run_refresh_local() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# Added local charm "ubuntu", revision 2, to the model
+	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
@@ -64,7 +64,7 @@ run_refresh_channel() {
 	# Test juju refresh from one channel to another
 	echo
 
-	model_name="test-refresh-switch-channel"
+	model_name="test-refresh-channel"
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
@@ -76,7 +76,7 @@ run_refresh_channel() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# format: Added local charm "ubuntu", revision 2, to the model
+	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
@@ -91,7 +91,7 @@ run_refresh_channel_no_new_revision() {
 	# charm revision.
 	echo
 
-	model_name="test-refresh-switch-channel-no-new-revision"
+	model_name="test-refresh-channel-no-new-revision"
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -19,10 +19,43 @@ run_refresh_switch_cs_to_ch() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# Added local charm "ubuntu", revision 2, to the model
+	# format: Added local charm "ubuntu", revision 2, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_switch_cs_to_ch_no_new_revision() {
+	# Test juju refresh from a charm store charm to a charm hub charm, with no new
+	# charm revision.
+	echo
+
+	model_name="test-refresh-switch-ch"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	OUT=$(juju deploy cs:ubuntu2 >&1 || true)
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+	# format: Added local charm "ubuntu", revision 2, to the model
+	cs_revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --switch ch:ubuntu 2>&1 || true)
+	if echo "${OUT}" | grep -E -vq "Added charm-hub charm"; then
+		# shellcheck disable=SC2046
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	wait_for "ubuntu" "$(charm_rev "ubuntu" "${cs_revision}")"
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
 	destroy_model "${model_name}"
@@ -49,7 +82,7 @@ run_refresh_switch_cs_to_ch_channel() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# Added local charm "ubuntu", revision 2, to the model
+	# format: Added local charm "ubuntu", revision 2, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
@@ -82,7 +115,7 @@ run_refresh_switch_local_to_ch_channel() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# Added local charm "ubuntu", revision 2, to the model
+	# format: Added local charm "ubuntu", revision 2, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
@@ -108,12 +141,43 @@ run_refresh_switch_channel() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# Added local charm "ubuntu", revision 2, to the model
+	# format: Added local charm "ubuntu", revision 2, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
 	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/edge")"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	destroy_model "${model_name}"
+}
+
+run_refresh_switch_channel_no_new_revision() {
+	# Test juju refresh switching from one channel to another, with no new
+	# charm revision.
+	echo
+
+	model_name="test-refresh-switch-channel-no-new-revision"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	juju deploy ubuntu
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
+
+	OUT=$(juju refresh ubuntu --channel edge 2>&1 || true)
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	if echo "${OUT}" | grep -E -vq "all future refreshes will now use channel"; then
+		# shellcheck disable=SC2046
+		echo $(red "failed refreshing charm: ${OUT}")
+		exit 5
+	fi
+	# shellcheck disable=SC2059
+	printf "${OUT}\n"
+
+	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
+	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
 	destroy_model "${model_name}"
 }
@@ -130,8 +194,10 @@ test_switch() {
 		cd .. || exit
 
 		run "run_refresh_switch_cs_to_ch"
+		run "run_refresh_switch_cs_to_ch_no_new_revision"
 		run "run_refresh_switch_cs_to_ch_channel"
 		run "run_refresh_switch_local_to_ch_channel"
 		run "run_refresh_switch_channel"
+		run "run_refresh_switch_channel_no_new_revision"
 	)
 }

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -125,63 +125,6 @@ run_refresh_switch_local_to_ch_channel() {
 	destroy_model "${model_name}"
 }
 
-run_refresh_switch_channel() {
-	# Test juju refresh switching from one channel to another
-	echo
-
-	model_name="test-refresh-switch-channel"
-	file="${TEST_DIR}/${model_name}.log"
-
-	ensure "${model_name}" "${file}"
-
-	juju deploy juju-qa-test
-	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-
-	OUT=$(juju refresh juju-qa-test --channel 2.0/edge 2>&1 || true)
-	# shellcheck disable=SC2059
-	printf "${OUT}\n"
-
-	# format: Added local charm "ubuntu", revision 2, to the model
-	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
-
-	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/edge")"
-	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-
-	destroy_model "${model_name}"
-}
-
-run_refresh_switch_channel_no_new_revision() {
-	# Test juju refresh switching from one channel to another, with no new
-	# charm revision.
-	echo
-
-	model_name="test-refresh-switch-channel-no-new-revision"
-	file="${TEST_DIR}/${model_name}.log"
-
-	ensure "${model_name}" "${file}"
-
-	juju deploy ubuntu
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
-
-	OUT=$(juju refresh ubuntu --channel edge 2>&1 || true)
-	# shellcheck disable=SC2059
-	printf "${OUT}\n"
-
-	if echo "${OUT}" | grep -E -vq "all future refreshes will now use channel"; then
-		# shellcheck disable=SC2046
-		echo $(red "failed refreshing charm: ${OUT}")
-		exit 5
-	fi
-	# shellcheck disable=SC2059
-	printf "${OUT}\n"
-
-	wait_for "ubuntu" "$(charm_channel "ubuntu" "edge")"
-	wait_for "ubuntu" "$(idle_condition "ubuntu")"
-
-	destroy_model "${model_name}"
-}
-
 test_switch() {
 	if [ "$(skip 'test_switch')" ]; then
 		echo "==> TEST SKIPPED: refresh switch"
@@ -197,7 +140,5 @@ test_switch() {
 		run "run_refresh_switch_cs_to_ch_no_new_revision"
 		run "run_refresh_switch_cs_to_ch_channel"
 		run "run_refresh_switch_local_to_ch_channel"
-		run "run_refresh_switch_channel"
-		run "run_refresh_switch_channel_no_new_revision"
 	)
 }

--- a/tests/suites/refresh/switch.sh
+++ b/tests/suites/refresh/switch.sh
@@ -19,7 +19,7 @@ run_refresh_switch_cs_to_ch() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# format: Added local charm "ubuntu", revision 2, to the model
+	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
@@ -33,15 +33,15 @@ run_refresh_switch_cs_to_ch_no_new_revision() {
 	# charm revision.
 	echo
 
-	model_name="test-refresh-switch-ch"
+	model_name="test-refresh-switch-ch-no-new-revision"
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
 
-	OUT=$(juju deploy cs:ubuntu2 >&1 || true)
+	OUT=$(juju deploy cs:ubuntu >&1 || true)
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
-	# format: Added local charm "ubuntu", revision 2, to the model
+	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	cs_revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
@@ -82,7 +82,7 @@ run_refresh_switch_cs_to_ch_channel() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# format: Added local charm "ubuntu", revision 2, to the model
+	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
@@ -115,7 +115,7 @@ run_refresh_switch_local_to_ch_channel() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
-	# format: Added local charm "ubuntu", revision 2, to the model
+	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"


### PR DESCRIPTION

Allow an application's channel to be updated when refreshing even if the charm revision is the same so no other change is needed. This fixes a regression in behavior between charm hub and charm store charms. Because it's a regression, only a small change was required.

## QA steps

Today, all risk levels of the latest track for the ubuntu charm are the same. Makes a good test candidate.

```sh
$ juju deploy ubuntu
$ juju refresh ubuntu --channel edge
charm "ubuntu": already up-to-date. Note: all future refreshes will now use channel "edge"
```
## Bug reference

https://bugs.launchpad.net/juju/+bug/1988587
