### PR TITLE
Equinix Provider - Fix LXD Init on 2.9

### DIFF
--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -273,6 +273,7 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 		return nil, errors.Trace(err)
 	}
 	cloudCfg.AddPackage("iptables-persistent")
+	cloudCfg.AddPackage("jq")
 
 	// Set a default INPUT policy of drop, permitting ssh
 	acceptInputPort := "iptables -A INPUT -p tcp --dport %d -j ACCEPT"
@@ -382,9 +383,16 @@ done
 
 while true; do
     fan_net=$(ip route | grep fan | awk '{print $1}')
+	fan_net_name=$(ip route | grep fan | awk '{print $3}')
     if [ -z "$fan_net" ]; then
         sleep 15
         continue
+    fi
+
+    fan_dhcp_rule=$(iptables -t filter -L INPUT -v | grep "${fan_net_name}")
+    if [ -z "$fan_dhcp_rule" ]; then
+        echo "[juju fixup] installing iptables rule to allow DHCP traffic from FAN network"
+        iptables -t filter -I INPUT -i $fan_net_name -p udp -m udp --dport 67 -j ACCEPT
     fi
 
     masq_rule=$(iptables -t nat -S POSTROUTING | egrep "${fan_net}.*MASQUERADE")


### PR DESCRIPTION
Signed-off-by: Chris Privitere <cprivitere@equinix.com>

This is a port of #15054 to 2.9. When I submitted it, I didn't realize the proper pattern was to start with 2.9 and you would auto merge changes forward.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

*Commands to run to verify that the change works.*

```sh
juju add-credential equinix
#add credential
juju bootstrap equinix/da equinix
juju deploy etcd --to lxd
#validate that the container starts and gets an IP address, etcd in particular will want some additional cert stuff set up, but you can ignore that for this test.
```