### PR TITLE
[JUJU-2582] Migrate ConsumeVersion for remote applications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/juju/clock v1.0.2
 	github.com/juju/cmd/v3 v3.0.0
 	github.com/juju/collections v1.0.2
-	github.com/juju/description/v3 v3.0.12
+	github.com/juju/description/v3 v3.0.13
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.2 h1:y9t99Nq/uUZksJgWehiWxIr2vB1UG3hUT7LBNy1xiH8=
 github.com/juju/collections v1.0.2/go.mod h1:kYJowQZYtHDvYDfZOvgf3Mt7mjKYwm/k1nqnJoMYOUc=
-github.com/juju/description/v3 v3.0.12 h1:u3Q01AvxiMaaHW8RWtTuYk4MkhS53WrMT9YUDBnO7U4=
-github.com/juju/description/v3 v3.0.12/go.mod h1:VzqhM294IF39mV66NdIx2bTcNSkfhZTVEqrtB9ktLWk=
+github.com/juju/description/v3 v3.0.13 h1:8X9GosX44gHxRmWJZjAG6TRQK2aQMdsMfs8apzZ8pPQ=
+github.com/juju/description/v3 v3.0.13/go.mod h1:VzqhM294IF39mV66NdIx2bTcNSkfhZTVEqrtB9ktLWk=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/state/migration_description_mock_test.go
+++ b/state/migration_description_mock_test.go
@@ -473,6 +473,20 @@ func (mr *MockRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockRemoteApplication) Endpoints() []description.RemoteEndpoint {
 	m.ctrl.T.Helper()

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1765,6 +1765,7 @@ func (i *importer) makeRemoteApplicationDoc(app description.RemoteApplication) *
 		IsConsumerProxy: app.IsConsumerProxy(),
 		Bindings:        app.Bindings(),
 		Macaroon:        app.Macaroon(),
+		Version:         app.ConsumeVersion(),
 	}
 	descEndpoints := app.Endpoints()
 	eps := make([]remoteEndpointDoc, len(descEndpoints))

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2565,10 +2565,11 @@ func (s *MigrationImportSuite) TestPayloads(c *gc.C) {
 
 func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 	remoteApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:        "gravy-rainbow",
-		URL:         "me/model.rainbow",
-		SourceModel: s.Model.ModelTag(),
-		Token:       "charisma",
+		Name:           "gravy-rainbow",
+		URL:            "me/model.rainbow",
+		SourceModel:    s.Model.ModelTag(),
+		Token:          "charisma",
+		ConsumeVersion: 1,
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Name:      "db",
@@ -2628,6 +2629,7 @@ func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 
 	remoteApplication := remoteApplications[0]
 	c.Assert(remoteApplication.Name(), gc.Equals, "gravy-rainbow")
+	c.Assert(remoteApplication.ConsumeVersion(), gc.Equals, 1)
 
 	url, _ := remoteApplication.URL()
 	c.Assert(url, gc.Equals, "me/model.rainbow")

--- a/state/migrations/description_mock_test.go
+++ b/state/migrations/description_mock_test.go
@@ -394,6 +394,20 @@ func (mr *MockRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockRemoteApplication) Endpoints() []description.RemoteEndpoint {
 	m.ctrl.T.Helper()

--- a/state/migrations/remoteapplications.go
+++ b/state/migrations/remoteapplications.go
@@ -23,6 +23,7 @@ type MigrationRemoteApplication interface {
 	Spaces() []MigrationRemoteSpace
 	GlobalKey() string
 	Macaroon() string
+	ConsumeVersion() int
 }
 
 // MigrationRemoteEndpoint is an in-place representation of the state.Endpoint
@@ -111,6 +112,7 @@ func (m ExportRemoteApplications) addRemoteApplication(src RemoteApplicationSour
 		IsConsumerProxy: app.IsConsumerProxy(),
 		Bindings:        app.Bindings(),
 		Macaroon:        app.Macaroon(),
+		ConsumeVersion:  app.ConsumeVersion(),
 	}
 	descApp := dst.AddRemoteApplication(args)
 

--- a/state/migrations/remoteapplications_mock_test.go
+++ b/state/migrations/remoteapplications_mock_test.go
@@ -49,6 +49,20 @@ func (mr *MockMigrationRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockMigrationRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockMigrationRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockMigrationRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockMigrationRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockMigrationRemoteApplication) Endpoints() ([]MigrationRemoteEndpoint, error) {
 	m.ctrl.T.Helper()

--- a/state/migrations/remoteapplications_test.go
+++ b/state/migrations/remoteapplications_test.go
@@ -28,6 +28,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -107,6 +108,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -143,6 +145,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEndpoints
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -171,6 +174,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEndpoints
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -193,6 +197,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -217,6 +222,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -227,7 +233,9 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 	c.Assert(err, gc.ErrorMatches, "fail")
 }
 
-func (s *RemoteApplicationsExportSuite) migrationRemoteApplication(ctrl *gomock.Controller, fn func(expect *MockMigrationRemoteApplicationMockRecorder)) *MockMigrationRemoteApplication {
+func (s *RemoteApplicationsExportSuite) migrationRemoteApplication(
+	ctrl *gomock.Controller, fn func(expect *MockMigrationRemoteApplicationMockRecorder),
+) *MockMigrationRemoteApplication {
 	entity := NewMockMigrationRemoteApplication(ctrl)
 	fn(entity.EXPECT())
 	return entity


### PR DESCRIPTION
Under https://github.com/juju/juju/pull/13354, we added `ConsumeVersion` to remote application proxies in order that we could detect when an application with the same name consumed an offer a second time.

However, this new member was never added to the `desciption` package, and so was dropped and defaulted to 0 (zero) during model migrations.

This meant that when migrated CMRs were re-established post migration, we hit [this condition](https://github.com/juju/juju/blob/2c7465f373c463e3b0d2421a4847ef20ee320b84/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go#L224), ensuring that the existing remote application was force-destroyed before being re-created.

This logic by itself is fine, but deep in the logic for force deletion we find [this](https://github.com/juju/juju/blob/5132716900d95187e8f7e90809f53876e6e52a8b/state/relation.go#L487), which schedules a cleanup (force deletion) of the relation.

The cumulative effect has been for migrated CMRs to mysteriously disappear soon after migration completion.

Here, we update to the latest version of the `description` dependency, which includes the `ConsumeVersion` member, and ensure that it is copied over during migration. This prevents the clean-up of associated relations following migration.

## QA steps

- Set up the offer, consumer and targets.
```
for c in "cns" "src" "dst"; do juju bootstrap lxd $c --no-gui; done
juju switch src; juju deploy ./testcharms/charms/dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju consume src:admin/default.dummy-source; juju deploy ./testcharms/charms/dummy-sink; juju relate dummy-source dummy-sink
juju switch dst; juju destroy-model default -y
```
- Switch back to _src_ and wait for quiescence.
- `juju migrate default dst`, and wait for the migration to complete.
- `juju switch dst; juju config dummy-source token=DIFFERENT`.
- `juju switch cns`, then check via status that the token value change ends up reflected by _dummy-sink_.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2003708
