### PR TITLE
Return the pending secret when secret-info-get is run immediately after creating a secret

### DIFF
--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -934,6 +934,25 @@ func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error
 	}
 
 	result := make(map[string]jujuc.SecretMetadata)
+	for _, c := range ctx.secretChanges.pendingCreates {
+		md := jujuc.SecretMetadata{
+			Owner:          c.OwnerTag,
+			LatestRevision: 1,
+		}
+		if c.Label != nil {
+			md.Label = *c.Label
+		}
+		if c.Description != nil {
+			md.Description = *c.Description
+		}
+		if c.RotatePolicy != nil {
+			md.RotatePolicy = *c.RotatePolicy
+		}
+		if c.ExpireTime != nil {
+			md.LatestExpireTime = c.ExpireTime
+		}
+		result[c.URI.ID] = md
+	}
 	for id, v := range ctx.secretMetadata {
 		if pendingDeletes.Contains(id) {
 			continue

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -589,6 +589,13 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Description: "will be removed",
 		},
 	})
+	uri3, err := ctx.CreateSecret(&jujuc.SecretCreateArgs{
+		OwnerTag: names.NewApplicationTag("foo"),
+		SecretUpdateArgs: jujuc.SecretUpdateArgs{
+			Description: ptr("a new one"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.UpdateSecret(uri, &jujuc.SecretUpdateArgs{
 		Description: ptr("another"),
 	})
@@ -604,6 +611,11 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Owner:        names.NewApplicationTag("mariadb"),
 			Description:  "another",
 			RotatePolicy: coresecrets.RotateHourly,
+		},
+		uri3.ID: {
+			Owner:          names.NewApplicationTag("foo"),
+			Description:    "a new one",
+			LatestRevision: 1,
 		},
 	})
 }

--- a/worker/uniter/runner/testing/utils.go
+++ b/worker/uniter/runner/testing/utils.go
@@ -150,6 +150,12 @@ type SecretsContextAccessor struct {
 	jujusecrets.Backend
 }
 
+func (s SecretsContextAccessor) CreateSecretURIs(int) ([]*secrets.URI, error) {
+	return []*secrets.URI{{
+		ID: "8m4e2mr0ui3e8a215n4g",
+	}}, nil
+}
+
 func (s SecretsContextAccessor) SecretMetadata(filter secrets.Filter) ([]secrets.SecretOwnerMetadata, error) {
 	uri, _ := secrets.ParseURI("secret:9m4e2mr0ui3e8a215n4g")
 	return []secrets.SecretOwnerMetadata{{


### PR DESCRIPTION
When running secret-info-get immediately after creating a secret, the cached value should be used.

## QA steps

juju exec on a unit:
```
URI=$(secret-add foo=bar); secret-info-get $URI
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2004672
