### PR TITLE
Merge 2.9 into 3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/juju/clock v1.0.3
 	github.com/juju/cmd/v3 v3.0.2
 	github.com/juju/collections v1.0.2
-	github.com/juju/description/v4 v4.0.1
+	github.com/juju/description/v4 v4.0.5
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -767,8 +767,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.2 h1:y9t99Nq/uUZksJgWehiWxIr2vB1UG3hUT7LBNy1xiH8=
 github.com/juju/collections v1.0.2/go.mod h1:kYJowQZYtHDvYDfZOvgf3Mt7mjKYwm/k1nqnJoMYOUc=
-github.com/juju/description/v4 v4.0.1 h1:+JpvTFh0LSvGO3zkLeD/yijv+zVIrEBp36WyO9QCYd8=
-github.com/juju/description/v4 v4.0.1/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
+github.com/juju/description/v4 v4.0.5 h1:6CGEH36FWgKpEJT0inbmU4FJbsrzQZGAIJ5O+MiDPSU=
+github.com/juju/description/v4 v4.0.5/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/state/migration_description_mock_test.go
+++ b/state/migration_description_mock_test.go
@@ -473,6 +473,20 @@ func (mr *MockRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockRemoteApplication) Endpoints() []description.RemoteEndpoint {
 	m.ctrl.T.Helper()

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1785,7 +1785,6 @@ func (e *exporter) secrets() error {
 			Created:    rev.CreateTime,
 			Updated:    rev.UpdateTime,
 			ExpireTime: rev.ExpireTime,
-			BackendId:  rev.BackendId,
 		}
 		if len(rev.Data) > 0 {
 			revArg.Content = make(secrets.SecretData)

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -2683,7 +2683,7 @@ func (s *MigrationExportSuite) TestSecrets(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	md, err = store.UpdateSecret(md.URI, state.UpdateSecretParams{
 		LeaderToken: &fakeToken{},
-		BackendId:   ptr("backend-id"),
+		Data:        map[string]string{"foo": "bar2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
@@ -2724,7 +2724,7 @@ func (s *MigrationExportSuite) TestSecrets(c *gc.C) {
 	c.Assert(revisions, gc.HasLen, 2)
 	c.Assert(revisions[0].Content(), jc.DeepEquals, map[string]string{"foo": "bar"})
 	c.Assert(revisions[0].ExpireTime(), jc.DeepEquals, ptr(expire))
-	c.Assert(revisions[1].BackendId(), jc.DeepEquals, ptr("backend-id"))
+	c.Assert(revisions[1].Content(), jc.DeepEquals, map[string]string{"foo": "bar2"})
 	consumers := secret.Consumers()
 	c.Assert(consumers, gc.HasLen, 1)
 	info := consumers[0]

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1622,6 +1622,7 @@ func (i *importer) makeRemoteApplicationDoc(app description.RemoteApplication) *
 		IsConsumerProxy: app.IsConsumerProxy(),
 		Bindings:        app.Bindings(),
 		Macaroon:        app.Macaroon(),
+		Version:         app.ConsumeVersion(),
 	}
 	descEndpoints := app.Endpoints()
 	eps := make([]remoteEndpointDoc, len(descEndpoints))

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -581,7 +581,6 @@ func (ImportSecrets) Execute(src SecretsInput, runner TransactionRunner) error {
 					ExpireTime: rev.ExpireTime(),
 					Obsolete:   rev.Obsolete(),
 					Data:       dataCopy,
-					BackendId:  rev.BackendId(),
 					OwnerTag:   owner.String(),
 				},
 			})

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2522,10 +2522,11 @@ func (s *MigrationImportSuite) TestPayloads(c *gc.C) {
 
 func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 	remoteApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
-		Name:        "gravy-rainbow",
-		URL:         "me/model.rainbow",
-		SourceModel: s.Model.ModelTag(),
-		Token:       "charisma",
+		Name:           "gravy-rainbow",
+		URL:            "me/model.rainbow",
+		SourceModel:    s.Model.ModelTag(),
+		Token:          "charisma",
+		ConsumeVersion: 1,
 		Endpoints: []charm.Relation{{
 			Interface: "mysql",
 			Name:      "db",
@@ -2585,6 +2586,7 @@ func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 
 	remoteApplication := remoteApplications[0]
 	c.Assert(remoteApplication.Name(), gc.Equals, "gravy-rainbow")
+	c.Assert(remoteApplication.ConsumeVersion(), gc.Equals, 1)
 
 	url, _ := remoteApplication.URL()
 	c.Assert(url, gc.Equals, "me/model.rainbow")

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2997,7 +2997,7 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	updateTime := time.Now().UTC().Round(time.Second)
 	md, err = store.UpdateSecret(md.URI, state.UpdateSecretParams{
 		LeaderToken: &fakeToken{},
-		BackendId:   ptr("backend-id"),
+		Data:        map[string]string{"foo": "bar2"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
@@ -3034,13 +3034,11 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	mc.AddExpr(`_.UpdateTime`, jc.Almost, jc.ExpectedValue)
 	c.Assert(revs, mc, []*secrets.SecretRevisionMetadata{{
 		Revision:   1,
-		BackendId:  nil,
 		CreateTime: createTime,
 		UpdateTime: updateTime,
 		ExpireTime: &expire,
 	}, {
 		Revision:   2,
-		BackendId:  ptr("backend-id"),
 		CreateTime: createTime,
 		UpdateTime: createTime,
 	}})

--- a/state/migrations/description_mock_test.go
+++ b/state/migrations/description_mock_test.go
@@ -394,6 +394,20 @@ func (mr *MockRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockRemoteApplication) Endpoints() []description.RemoteEndpoint {
 	m.ctrl.T.Helper()

--- a/state/migrations/remoteapplications.go
+++ b/state/migrations/remoteapplications.go
@@ -23,6 +23,7 @@ type MigrationRemoteApplication interface {
 	Spaces() []MigrationRemoteSpace
 	GlobalKey() string
 	Macaroon() string
+	ConsumeVersion() int
 }
 
 // MigrationRemoteEndpoint is an in-place representation of the state.Endpoint
@@ -111,6 +112,7 @@ func (m ExportRemoteApplications) addRemoteApplication(src RemoteApplicationSour
 		IsConsumerProxy: app.IsConsumerProxy(),
 		Bindings:        app.Bindings(),
 		Macaroon:        app.Macaroon(),
+		ConsumeVersion:  app.ConsumeVersion(),
 	}
 	descApp := dst.AddRemoteApplication(args)
 

--- a/state/migrations/remoteapplications_mock_test.go
+++ b/state/migrations/remoteapplications_mock_test.go
@@ -49,6 +49,20 @@ func (mr *MockMigrationRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockMigrationRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockMigrationRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockMigrationRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockMigrationRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockMigrationRemoteApplication) Endpoints() ([]MigrationRemoteEndpoint, error) {
 	m.ctrl.T.Helper()

--- a/state/migrations/remoteapplications_test.go
+++ b/state/migrations/remoteapplications_test.go
@@ -28,6 +28,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -107,6 +108,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -143,6 +145,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEndpoints
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -171,6 +174,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEndpoints
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -193,6 +197,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -217,6 +222,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -227,7 +233,9 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 	c.Assert(err, gc.ErrorMatches, "fail")
 }
 
-func (s *RemoteApplicationsExportSuite) migrationRemoteApplication(ctrl *gomock.Controller, fn func(expect *MockMigrationRemoteApplicationMockRecorder)) *MockMigrationRemoteApplication {
+func (s *RemoteApplicationsExportSuite) migrationRemoteApplication(
+	ctrl *gomock.Controller, fn func(expect *MockMigrationRemoteApplicationMockRecorder),
+) *MockMigrationRemoteApplication {
 	entity := NewMockMigrationRemoteApplication(ctrl)
 	fn(entity.EXPECT())
 	return entity


### PR DESCRIPTION
Merge from 2.9 to bring forward https://github.com/juju/juju/pull/15145.

The `description` dependency corresponding to this branch is updated to accommodate fixes for migrating CMRs.