### PR TITLE
Enable content addressable downloads

### DIFF
--- a/scripts/dqlite/Makefile
+++ b/scripts/dqlite/Makefile
@@ -1,6 +1,3 @@
-SHELL = bash
-.ONESHELL:
-
 PROJECT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 DQLITE_BUILD_MACHINE ?= $(shell uname -m)
@@ -9,10 +6,6 @@ DQLITE_BUILD_ARCH ?= $(shell go env GOARCH)
 DQLITE_ARCHIVE_DEPS_PATH=${PROJECT_DIR}/scripts/dqlite
 DQLITE_ARCHIVE_NAME=dqlite-deps
 DQLITE_ARCHIVE_PATH=${DQLITE_ARCHIVE_DEPS_PATH}/${DQLITE_ARCHIVE_NAME}.tar.bz2
-
-DQLITE_S3_BUCKET=s3://dqlite-static-libs
-DQLITE_S3_ARCHIVE_NAME=$(shell date -u +"%Y-%m-%d")-dqlite-deps-${DQLITE_BUILD_ARCH}.tar.bz2
-DQLITE_S3_ARCHIVE_PATH=${DQLITE_S3_BUCKET}/${DQLITE_S3_ARCHIVE_NAME}
 
 DQLITE_EXTRACTED_DEPS_PATH=${PROJECT_DIR}/_deps
 DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH=${DQLITE_EXTRACTED_DEPS_PATH}/dqlite-deps-${DQLITE_BUILD_ARCH}
@@ -28,14 +21,8 @@ dqlite-build-lxd: ${DQLITE_ARCHIVE_PATH}
 dqlite-build:
 	@./scripts/dqlite/scripts/dqlite/build.sh
 
-# s3 puts here are without an ACL.
-# The bucket uses policies that allow GetObject to anyone,
-# and PutObject to select Juju team accounts.
-dqlite-deps-push: ${DQLITE_ARCHIVE_PATH}
-	@echo "DQLITE: Pushing ${DQLITE_S3_ARCHIVE_PATH} to s3"
-	aws s3 cp $< ${DQLITE_S3_ARCHIVE_PATH}
-	@echo "DQLITE: Pushing latest-dqlite-deps-${DQLITE_BUILD_ARCH}.tar.bz2 to s3"
-	aws s3 cp ${DQLITE_S3_ARCHIVE_PATH} ${DQLITE_S3_BUCKET}/latest-dqlite-deps-${DQLITE_BUILD_ARCH}.tar.bz2
+dqlite-push: ${DQLITE_ARCHIVE_PATH}
+	@./scripts/dqlite/scripts/dqlite/push.sh
 
 dqlite-install:
 	@./scripts/dqlite/scripts/dqlite/install.sh
@@ -49,16 +36,8 @@ musl-install:
 musl-install-if-missing:
 	@./scripts/dqlite/scripts/musl/install-if-missing.sh
 
-################################################################################
-# REPL
-#
-# Accessing the dqlite repl on a given controller for debugging purposes.
-################################################################################
+repl-install:
+	@./scripts/dqlite/script/repl/install.sh
 
-juju-dqlite-repl-deps-on-controller:
-	@juju exec -m controller --machine=0 'sudo which rlwrap &>/dev/null || sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install rlwrap'
-	@juju exec -m controller --machine=0 'sudo which socat &>/dev/null || sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install socat'
-
-juju-dqlite-repl: juju-dqlite-repl-deps-on-controller
-	@echo "[+] Connecting to REPL interface to controller machine 0"
-	@juju ssh -m controller 0 'sudo rlwrap -H /root/.dqlite_repl.history socat - /var/lib/juju/dqlite/juju.sock'
+repl: repl-install
+	@./script/dqlite/script/repl/repl.sh

--- a/scripts/dqlite/scripts/dqlite/push.sh
+++ b/scripts/dqlite/scripts/dqlite/push.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+source "$(dirname $0)/../env.sh"
+
+# s3 puts here are without an ACL.
+# The bucket uses policies that allow GetObject to anyone,
+# and PutObject to select Juju team accounts.
+
+echo "Pushing ${S3_ARCHIVE_PATH} to s3"
+aws s3 cp ${ARCHIVE_PATH} ${S3_ARCHIVE_PATH}
+
+SUM=$(sha256sum ${FILE} | awk '{print $1}')
+echo "Pushing ${SUM}.tar.bz2 to s3"
+aws s3 cp ${S3_ARCHIVE_PATH} ${S3_BUCKET}/${SUM}.tar.bz2
+
+# This is the old way and is deprecated.
+echo "Pushing latest-dqlite-deps-${BUILD_ARCH}.tar.bz2 to s3"
+aws s3 cp ${S3_ARCHIVE_PATH} ${S3_BUCKET}/latest-dqlite-deps-${BUILD_ARCH}.tar.bz2

--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -32,3 +32,11 @@ TAG_LIBLZ4=v1.9.4
 TAG_RAFT=v0.16.0
 TAG_SQLITE=version-3.40.0
 TAG_DQLITE=v1.12.0
+
+S3_BUCKET=s3://dqlite-static-libs
+S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${BUILD_ARCH}.tar.bz2
+S3_ARCHIVE_PATH=${S3_BUCKET}/${S3_ARCHIVE_NAME}
+
+ARCHIVE_DEPS_PATH=${PROJECT_DIR}/scripts/dqlite
+ARCHIVE_NAME=dqlite-deps
+ARCHIVE_PATH=${ARCHIVE_DEPS_PATH}/${ARCHIVE_NAME}.tar.bz2

--- a/scripts/dqlite/scripts/repl/install.sh
+++ b/scripts/dqlite/scripts/repl/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+MACHINE=${MACHINE:-0}
+
+juju exec -m controller --machine=${MACHINE} 'sudo which rlwrap &>/dev/null || sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install rlwrap socat'

--- a/scripts/dqlite/scripts/repl/repl.sh
+++ b/scripts/dqlite/scripts/repl/repl.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+MACHINE=${MACHINE:-0}
+
+juju ssh -m controller ${MACHINE} 'sudo rlwrap -H /root/.dqlite_repl.history socat - /var/lib/juju/dqlite/juju.sock'


### PR DESCRIPTION
The following changes the file names to be content addressable. This should help address some of the warts of the chicken and egg problem. The problem is how do you distribute your new dqlite changes to others without overriding the latest stable tar files. You could use a date, but that prevents adding multiple libs for the same day, we could use a timestamp, but doesn't really serve any more information than what we already have on the filesystem. Instead, if we use the sha256 of the file itself as the file name, we can then have multiple ones. Additionally, we may get the possibility of reducing how much we store if the files built with the same dependencies build to the same sha (I doubt it because of date/time impacting the builds).

The workflow for updating a lib then becomes:

 1. You build locally testing the changes.
 2. You push your sha256 file (tar.bz2 suffix) to s3
 3. Others can override the sha256 values in ./scripts/dqlite/scripts/dqlite/dqlite-install.sh
 4. Once verified those sha256 can be committed to Juju and others will start to pick them up.

If the files aren't good, we can remove them manually.

If we're worried about the s3 bucket becoming large, we can add folders for released/proposed/develop etc.

As a driveby, I've finally removed the one shell, so the make file should be fully portable (this was tech-debt from the early prototype).

## Checklist

- [
- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
$ make dqlite-install
```
