### PR TITLE
[JUJU-2607] Only use low-level constructs when cleaning up model documents

### DIFF
--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -143,7 +143,7 @@ func (s *applicationOffers) AllApplicationOffers() (offers []*crossmodel.Applica
 	var docs []applicationOfferDoc
 	err := applicationOffersCollection.Find(bson.D{}).All(&docs)
 	if err != nil {
-		return nil, errors.Errorf("cannot get all application offers")
+		return nil, errors.Annotate(err, "getting application offer documents")
 	}
 	for _, doc := range docs {
 		offer, err := s.makeApplicationOffer(doc)

--- a/state/state.go
+++ b/state/state.go
@@ -240,41 +240,14 @@ func (st *State) RemoveExportingModelDocs() error {
 }
 
 func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
-	modelUUID := st.ModelUUID()
-
-	// Gather all user permissions for the model.
-	// Do this first because we remove some parent docs below.
-	var permOps []txn.Op
-	permPattern := bson.M{
-		"_id": bson.M{"$regex": "^" + permissionID(modelKey(modelUUID), "")},
-	}
-	ops, err := st.removeInCollectionOps(permissionsC, permPattern)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	permOps = append(permOps, ops...)
-	// Gather all offer permissions for the model.
-	ao := NewApplicationOffers(st)
-	allOffers, err := ao.AllApplicationOffers()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for _, offer := range allOffers {
-		permPattern = bson.M{
-			"_id": bson.M{"$regex": "^" + permissionID(applicationOfferKey(offer.OfferUUID), "")},
-		}
-		ops, err = st.removeInCollectionOps(permissionsC, permPattern)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		permOps = append(permOps, ops...)
-	}
-	err = st.db().RunTransaction(permOps)
-	if err != nil {
-		return errors.Trace(err)
+	// Remove permissions first, because we potentially
+	// remove parent documents in the following stage.
+	if err := st.removeAllModelPermissions(); err != nil {
+		return errors.Annotate(err, "removing permissions")
 	}
 
 	// Remove each collection in its own transaction.
+	modelUUID := st.ModelUUID()
 	for name, info := range st.database.Schema() {
 		if info.global || info.rawAccess {
 			continue
@@ -317,7 +290,7 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	ops = []txn.Op{{
+	ops := []txn.Op{{
 		// Cleanup the owner:envName unique key.
 		C:      usermodelnameC,
 		Id:     model.uniqueIndexID(),
@@ -343,7 +316,42 @@ func (st *State) removeAllModelDocs(modelAssertion bson.D) error {
 	if !st.IsController() {
 		ops = append(ops, decHostedModelCountOp())
 	}
-	return st.db().RunTransaction(ops)
+	return errors.Trace(st.db().RunTransaction(ops))
+}
+
+// removeAllModelPermissions removes all direct permissions documents for
+// this model, and all permissions for offers hosted by this model.
+func (st *State) removeAllModelPermissions() error {
+	var permOps []txn.Op
+	permPattern := bson.M{
+		"_id": bson.M{"$regex": "^" + permissionID(modelKey(st.ModelUUID()), "")},
+	}
+	ops, err := st.removeInCollectionOps(permissionsC, permPattern)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	permOps = append(permOps, ops...)
+
+	applicationOffersCollection, closer := st.db().GetCollection(applicationOffersC)
+	defer closer()
+
+	var offerDocs []applicationOfferDoc
+	if err := applicationOffersCollection.Find(bson.D{}).All(&offerDocs); err != nil {
+		return errors.Annotate(err, "getting application offer documents")
+	}
+
+	for _, offer := range offerDocs {
+		permPattern = bson.M{
+			"_id": bson.M{"$regex": "^" + permissionID(applicationOfferKey(offer.OfferUUID), "")},
+		}
+		ops, err = st.removeInCollectionOps(permissionsC, permPattern)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		permOps = append(permOps, ops...)
+	}
+	err = st.db().RunTransaction(permOps)
+	return errors.Trace(err)
 }
 
 // removeAllInCollectionRaw removes all the documents from the given


### PR DESCRIPTION
It was discovered that migration import failure while processing relations can lead to a situation where the model data is not correctly removed from the target controller.

In turn, the presence of partial model data on the target can lead to destructions in the source controller if the target is subsequently destroyed.

This is due to the fact that the removal logic uses business-logic constructs that rely on the integrity of data not to throw an error. This integrity cannot be guaranteed for a failed migration import, which will invariably have incomplete data.

Here we ensure that only low-level collection access is used to clean up failed migrations. This prevents certain classes of errors during roll-back, enhancing migration reliability.

Further investigation into how to prevent destruction of assets in a model that is not _active_ during controller tear-down is worth undertaking.

## QA steps

- Apply the following change on top of this patch:
```diff
diff --git a/state/migration_import.go b/state/migration_import.go
index 14b21b8dbc..b09e467ed0 100644
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1891,6 +1891,7 @@ func (i *importer) relation(rel description.Relation) error {
 				createSettingsOp(settingsC, ruKey, settings),
 			)
 		}
+		return errors.New("BOOM!")
 	}
 
 	if err := i.st.db().RunTransaction(ops); err != nil {
```
- Set up a migration scenario:
```
for c in "cns" "src" "dst"; do juju bootstrap lxd $c --no-gui; done
juju switch src; juju deploy ./testcharms/charms/dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju consume src:admin/default.dummy-source; juju deploy ./testcharms/charms/dummy-sink; juju relate dummy-source dummy-sink
juju switch dst; juju destroy-model default -y
```
- Switch back to _src_ and once quiescent, run `juju migrate default dst`.
- The migration will fail, but should allow repeated attempts. Prior to this patch, a subsequent attempt will demonstrate the presence of model data remaining on the target:
```
ERROR target prechecks failed: model named "default" already exists
```

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2004033
