### PR TITLE
[JUJU-2689] Skip test-cli-test-model-config-lxd 3.1

### DIFF
--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -51,7 +51,9 @@ test_model_config() {
 
 		cd .. || exit
 
-		run "run_model_config_isomorphic"
+    # TODO(anvial):This subtest is comment out because we support both 'default-series' and 'default-base'.
+    # We need to return this subtest back when we fully drop series support.
+    #	run "run_model_config_isomorphic"
 		run "run_model_config_cloudinit_userdata"
 	)
 }

--- a/tests/suites/cli/model_config.sh
+++ b/tests/suites/cli/model_config.sh
@@ -30,7 +30,7 @@ EOF
 	OUT=$(juju model-config cloudinit-userdata)
 	echo "${OUT}" | grep -q "shellcheck"
 
-	# cloudinit-userdata is not present from the default tabluar output
+	# cloudinit-userdata is not present from the default tabular output
 	! juju model-config cloudinit-userdata | grep -q "^cloudinit-userdata: |$"
 
 	# cloudinit-userdata is hidden in the normal output
@@ -51,9 +51,9 @@ test_model_config() {
 
 		cd .. || exit
 
-    # TODO(anvial):This subtest is comment out because we support both 'default-series' and 'default-base'.
-    # We need to return this subtest back when we fully drop series support.
-    #	run "run_model_config_isomorphic"
+		# TODO(anvial): this subtest is commented because we support both 'default-series' and 'default-base'.
+		# We need to return this subtest back when we fully drop series support.
+		#	run "run_model_config_isomorphic"
 		run "run_model_config_cloudinit_userdata"
 	)
 }


### PR DESCRIPTION
This PR comments subtest to support both 'default-series' and 'default-base', and the isomorphic characteristic for `juju model-config` is not TRUE until we fully drop the series support.

PS: We need to return this subtest when we fully drop series support.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

```sh
cd tests
./main.sh -p lxd cli test_model_config
```
