### PR TITLE
[JUJU-2703] Command sync-agent-binary accepts --agent-version instead of --version

### DIFF
--- a/cmd/juju/commands/synctools.go
+++ b/cmd/juju/commands/synctools.go
@@ -57,8 +57,8 @@ The online store will, of course, need to be contacted at some point to get
 the software.
 
 Examples:
-    juju sync-agent-binary --debug --version 2.0
-    juju sync-agent-binary --debug --version 2.0 --local-dir=/home/ubuntu/sync-agent-binary
+    juju sync-agent-binary --debug --agent-version 2.0
+    juju sync-agent-binary --debug --agent-version 2.0 --local-dir=/home/ubuntu/sync-agent-binary
 
 See also:
     upgrade-controller
@@ -76,7 +76,7 @@ func (c *syncAgentBinaryCommand) Info() *cmd.Info {
 
 func (c *syncAgentBinaryCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
-	f.StringVar(&c.versionStr, "version", "", "Copy a specific major[.minor] version")
+	f.StringVar(&c.versionStr, "agent-version", "", "Copy a specific major[.minor] version")
 	f.BoolVar(&c.dryRun, "dry-run", false, "Don't copy, just print what would be copied")
 	f.BoolVar(&c.public, "public", false, "Tools are for a public cloud, so generate mirrors information")
 	f.StringVar(&c.source, "source", "", "Local source directory")
@@ -86,7 +86,7 @@ func (c *syncAgentBinaryCommand) SetFlags(f *gnuflag.FlagSet) {
 
 func (c *syncAgentBinaryCommand) Init(args []string) error {
 	if c.versionStr == "" {
-		return errors.NewNotValid(nil, "--version is required")
+		return errors.NewNotValid(nil, "--agent-version is required")
 	}
 	var err error
 	if c.targetVersion, err = version.Parse(c.versionStr); err != nil {

--- a/cmd/juju/commands/synctools_test.go
+++ b/cmd/juju/commands/synctools_test.go
@@ -73,21 +73,21 @@ type syncToolCommandTestCase struct {
 var syncToolCommandTests = []syncToolCommandTestCase{
 	{
 		description: "minimum argument",
-		args:        []string{"--version", "2.9.99", "-m", "test-target"},
+		args:        []string{"--agent-version", "2.9.99", "-m", "test-target"},
 	},
 	{
 		description: "specifying also the synchronization source",
-		args:        []string{"--version", "2.9.99", "-m", "test-target", "--source", "/foo/bar"},
+		args:        []string{"--agent-version", "2.9.99", "-m", "test-target", "--source", "/foo/bar"},
 		source:      "/foo/bar",
 	},
 	{
 		description: "just make a dry run",
-		args:        []string{"--version", "2.9.99", "-m", "test-target", "--dry-run"},
+		args:        []string{"--agent-version", "2.9.99", "-m", "test-target", "--dry-run"},
 		dryRun:      true,
 	},
 	{
 		description: "specified public (ignored by API)",
-		args:        []string{"--version", "2.9.99", "-m", "test-target", "--public"},
+		args:        []string{"--agent-version", "2.9.99", "-m", "test-target", "--public"},
 		public:      false,
 	},
 }
@@ -129,7 +129,8 @@ func (s *syncToolSuite) TestSyncToolsCommand(c *gc.C) {
 
 func (s *syncToolSuite) TestSyncToolsCommandTargetDirectory(c *gc.C) {
 	dir := c.MkDir()
-	ctrl, run := s.getSyncAgentBinariesCommand(c, "--version", "2.9.99", "-m", "test-target", "--local-dir", dir, "--stream", "proposed")
+	ctrl, run := s.getSyncAgentBinariesCommand(
+		c, "--agent-version", "2.9.99", "-m", "test-target", "--local-dir", dir, "--stream", "proposed")
 	defer ctrl.Finish()
 
 	called := false
@@ -155,7 +156,8 @@ func (s *syncToolSuite) TestSyncToolsCommandTargetDirectory(c *gc.C) {
 
 func (s *syncToolSuite) TestSyncToolsCommandTargetDirectoryPublic(c *gc.C) {
 	dir := c.MkDir()
-	ctrl, run := s.getSyncAgentBinariesCommand(c, "--version", "2.9.99", "-m", "test-target", "--local-dir", dir, "--public")
+	ctrl, run := s.getSyncAgentBinariesCommand(
+		c, "--agent-version", "2.9.99", "-m", "test-target", "--local-dir", dir, "--public")
 	defer ctrl.Finish()
 
 	called := false
@@ -187,7 +189,8 @@ func (s *syncToolSuite) TestAPIAdapterUploadTools(c *gc.C) {
 }
 
 func (s *syncToolSuite) TestAPIAdapterBlockUploadTools(c *gc.C) {
-	ctrl, run := s.getSyncAgentBinariesCommand(c, "-m", "test-target", "--version", "2.9.99", "--local-dir", c.MkDir(), "--stream", "released")
+	ctrl, run := s.getSyncAgentBinariesCommand(
+		c, "-m", "test-target", "--agent-version", "2.9.99", "--local-dir", c.MkDir(), "--stream", "released")
 	defer ctrl.Finish()
 
 	syncTools = func(sctx *sync.SyncContext) error {


### PR DESCRIPTION
Whether supplied or not, the `sync-agent binary` command throws an error for a missing `--version` flag. When `Init` is called, the value of the target member is always detected as being unset/empty.

The flag has not worked for some time if it ever did, but under https://github.com/juju/juju/pull/14344 we removed the default behaviour of syncing the latest version and the option to supply `--all`. Since then the mandatory `--version` has effectively broken the command.

Here we simply make the flag congruent with that used by the bootstrap command, `--agent-version`

## QA steps

- Bootstrap and add a model.
- Build Juju.
- `mkdir -p ~/simplestreams/tools/released`.
- From your $GOHOME/bin directory, run `tar cvzf ~/simplestreams/tools/released/juju-<juju-version>-ubuntu-amd64.tgz containeragent  juju  jujuc  jujud  juju-metadata  juju-wait-for  pebble`.
- `juju metadata generate-agents -d ~/simplestreams --clean --prevent-fallback`.
- With this client, run `juju sync-agent-binary --agent-version <juju-version> --source ~/simplestreams/tools`.
- Check that it succeeds.

## Documentation changes

Yes. Note to talk to @tmihoc.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2006454
