### PR TITLE
Fix trivial errors in secret backend CLI doc

### DIFF
--- a/cmd/juju/secretbackends/add.go
+++ b/cmd/juju/secretbackends/add.go
@@ -91,6 +91,7 @@ func (c *addSecretBackendCommand) Info() *cmd.Info {
 		Name:    "add-secret-backend",
 		Purpose: "Add a new secret backend to the controller.",
 		Doc:     addSecretBackendsDoc,
+		Args:    "<backend-name> <backend-type>",
 	})
 }
 

--- a/cmd/juju/secretbackends/remove.go
+++ b/cmd/juju/secretbackends/remove.go
@@ -70,6 +70,7 @@ func (c *removeSecretBackendCommand) Info() *cmd.Info {
 		Name:    "remove-secret-backend",
 		Purpose: "Removes a secret backend from the controller.",
 		Doc:     removeSecretBackendsDoc,
+		Args:    "<backend-name>",
 	})
 }
 

--- a/cmd/juju/secretbackends/show.go
+++ b/cmd/juju/secretbackends/show.go
@@ -66,6 +66,7 @@ func (c *showSecretBackendCommand) Info() *cmd.Info {
 		Name:    "show-secret-backend",
 		Purpose: "Displays the specified secret backend.",
 		Doc:     showSecretBackendsDoc,
+		Args:    "<backend-name>",
 	})
 }
 

--- a/cmd/juju/secretbackends/update.go
+++ b/cmd/juju/secretbackends/update.go
@@ -90,6 +90,7 @@ func (c *updateSecretBackendCommand) Info() *cmd.Info {
 		Name:    "update-secret-backend",
 		Purpose: "Update an existing secret backend on the controller.",
 		Doc:     updateSecretBackendsDoc,
+		Args:    "<backend-name>",
 	})
 }
 

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -2397,7 +2397,7 @@ potentially valuable resources.
 		Group:       environschema.EnvironGroup,
 	},
 	SecretBackendKey: {
-		Description: `The name of the secret store backend. (default "" which implies Juju)`,
+		Description: `The name of the secret store backend. (default "auto")`,
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},


### PR DESCRIPTION
Fix trivial CLI doc issues for secret backend commands. CLI doc was missing description of args.