### PR TITLE
Merge 3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/juju/clock v1.0.3
 	github.com/juju/cmd/v3 v3.0.4
 	github.com/juju/collections v1.0.2
-	github.com/juju/description/v4 v4.0.4
+	github.com/juju/description/v4 v4.0.5
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -765,8 +765,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.2 h1:y9t99Nq/uUZksJgWehiWxIr2vB1UG3hUT7LBNy1xiH8=
 github.com/juju/collections v1.0.2/go.mod h1:kYJowQZYtHDvYDfZOvgf3Mt7mjKYwm/k1nqnJoMYOUc=
-github.com/juju/description/v4 v4.0.4 h1:cyAMrylcmtR8iU/Y1F5awkYjYFKecw16INcS9GUS9V8=
-github.com/juju/description/v4 v4.0.4/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
+github.com/juju/description/v4 v4.0.5 h1:6CGEH36FWgKpEJT0inbmU4FJbsrzQZGAIJ5O+MiDPSU=
+github.com/juju/description/v4 v4.0.5/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/state/migration_description_mock_test.go
+++ b/state/migration_description_mock_test.go
@@ -473,6 +473,20 @@ func (mr *MockRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockRemoteApplication) Endpoints() []description.RemoteEndpoint {
 	m.ctrl.T.Helper()

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/juju/charm/v10"
 	"github.com/juju/collections/set"
+	"github.com/juju/description/v4"
 	"github.com/juju/errors"
 	"github.com/juju/featureflag"
 	"github.com/juju/loggo"
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/names/v4"
-
-	"github.com/juju/description/v4"
 
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1604,6 +1604,7 @@ func (i *importer) makeRemoteApplicationDoc(app description.RemoteApplication) *
 		IsConsumerProxy: app.IsConsumerProxy(),
 		Bindings:        app.Bindings(),
 		Macaroon:        app.Macaroon(),
+		Version:         app.ConsumeVersion(),
 	}
 	descEndpoints := app.Endpoints()
 	eps := make([]remoteEndpointDoc, len(descEndpoints))

--- a/state/migrations/description_mock_test.go
+++ b/state/migrations/description_mock_test.go
@@ -394,6 +394,20 @@ func (mr *MockRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockRemoteApplication) Endpoints() []description.RemoteEndpoint {
 	m.ctrl.T.Helper()

--- a/state/migrations/remoteapplications.go
+++ b/state/migrations/remoteapplications.go
@@ -23,6 +23,7 @@ type MigrationRemoteApplication interface {
 	Spaces() []MigrationRemoteSpace
 	GlobalKey() string
 	Macaroon() string
+	ConsumeVersion() int
 }
 
 // MigrationRemoteEndpoint is an in-place representation of the state.Endpoint
@@ -111,6 +112,7 @@ func (m ExportRemoteApplications) addRemoteApplication(src RemoteApplicationSour
 		IsConsumerProxy: app.IsConsumerProxy(),
 		Bindings:        app.Bindings(),
 		Macaroon:        app.Macaroon(),
+		ConsumeVersion:  app.ConsumeVersion(),
 	}
 	descApp := dst.AddRemoteApplication(args)
 

--- a/state/migrations/remoteapplications_mock_test.go
+++ b/state/migrations/remoteapplications_mock_test.go
@@ -49,6 +49,20 @@ func (mr *MockMigrationRemoteApplicationMockRecorder) Bindings() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bindings", reflect.TypeOf((*MockMigrationRemoteApplication)(nil).Bindings))
 }
 
+// ConsumeVersion mocks base method.
+func (m *MockMigrationRemoteApplication) ConsumeVersion() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConsumeVersion")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ConsumeVersion indicates an expected call of ConsumeVersion.
+func (mr *MockMigrationRemoteApplicationMockRecorder) ConsumeVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConsumeVersion", reflect.TypeOf((*MockMigrationRemoteApplication)(nil).ConsumeVersion))
+}
+
 // Endpoints mocks base method.
 func (m *MockMigrationRemoteApplication) Endpoints() ([]MigrationRemoteEndpoint, error) {
 	m.ctrl.T.Helper()

--- a/state/migrations/remoteapplications_test.go
+++ b/state/migrations/remoteapplications_test.go
@@ -28,6 +28,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -107,6 +108,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplication(c *gc.C) {
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -143,6 +145,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEndpoints
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -171,6 +174,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithEndpoints
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -193,6 +197,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
 			expect.IsConsumerProxy().Return(false)
 			expect.Macaroon().Return("mac")
+			expect.ConsumeVersion().Return(1)
 			expect.Bindings().Return(map[string]string{
 				"binding-key": "binding-value",
 			})
@@ -217,6 +222,7 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 		SourceModel:     names.NewModelTag("uuid-2"),
 		IsConsumerProxy: false,
 		Macaroon:        "mac",
+		ConsumeVersion:  1,
 		Bindings: map[string]string{
 			"binding-key": "binding-value",
 		},
@@ -227,7 +233,9 @@ func (s *RemoteApplicationsExportSuite) TestExportRemoteApplicationWithStatusArg
 	c.Assert(err, gc.ErrorMatches, "fail")
 }
 
-func (s *RemoteApplicationsExportSuite) migrationRemoteApplication(ctrl *gomock.Controller, fn func(expect *MockMigrationRemoteApplicationMockRecorder)) *MockMigrationRemoteApplication {
+func (s *RemoteApplicationsExportSuite) migrationRemoteApplication(
+	ctrl *gomock.Controller, fn func(expect *MockMigrationRemoteApplicationMockRecorder),
+) *MockMigrationRemoteApplication {
 	entity := NewMockMigrationRemoteApplication(ctrl)
 	fn(entity.EXPECT())
 	return entity

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -934,6 +934,25 @@ func (ctx *HookContext) SecretMetadata() (map[string]jujuc.SecretMetadata, error
 	}
 
 	result := make(map[string]jujuc.SecretMetadata)
+	for _, c := range ctx.secretChanges.pendingCreates {
+		md := jujuc.SecretMetadata{
+			Owner:          c.OwnerTag,
+			LatestRevision: 1,
+		}
+		if c.Label != nil {
+			md.Label = *c.Label
+		}
+		if c.Description != nil {
+			md.Description = *c.Description
+		}
+		if c.RotatePolicy != nil {
+			md.RotatePolicy = *c.RotatePolicy
+		}
+		if c.ExpireTime != nil {
+			md.LatestExpireTime = c.ExpireTime
+		}
+		result[c.URI.ID] = md
+	}
 	for id, v := range ctx.secretMetadata {
 		if pendingDeletes.Contains(id) {
 			continue

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -591,6 +591,13 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Description: "will be removed",
 		},
 	})
+	uri3, err := ctx.CreateSecret(&jujuc.SecretCreateArgs{
+		OwnerTag: names.NewApplicationTag("foo"),
+		SecretUpdateArgs: jujuc.SecretUpdateArgs{
+			Description: ptr("a new one"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.UpdateSecret(uri, &jujuc.SecretUpdateArgs{
 		Description: ptr("another"),
 	})
@@ -606,6 +613,11 @@ func (s *InterfaceSuite) TestSecretMetadata(c *gc.C) {
 			Owner:        names.NewApplicationTag("mariadb"),
 			Description:  "another",
 			RotatePolicy: coresecrets.RotateHourly,
+		},
+		uri3.ID: {
+			Owner:          names.NewApplicationTag("foo"),
+			Description:    "a new one",
+			LatestRevision: 1,
 		},
 	})
 }

--- a/worker/uniter/runner/testing/utils.go
+++ b/worker/uniter/runner/testing/utils.go
@@ -150,6 +150,12 @@ type SecretsContextAccessor struct {
 	jujusecrets.BackendsClient
 }
 
+func (s SecretsContextAccessor) CreateSecretURIs(int) ([]*secrets.URI, error) {
+	return []*secrets.URI{{
+		ID: "8m4e2mr0ui3e8a215n4g",
+	}}, nil
+}
+
 func (s SecretsContextAccessor) SecretMetadata(filter secrets.Filter) ([]secrets.SecretOwnerMetadata, error) {
 	uri, _ := secrets.ParseURI("secret:9m4e2mr0ui3e8a215n4g")
 	return []secrets.SecretOwnerMetadata{{


### PR DESCRIPTION
Merge 3.0

#15145 [JUJU-2582] Migrate ConsumeVersion for remote applications
#15149 Return the pending secret when secret-info-get is run immediately after creating a secret

Also add an additional migration test for remote applications.

```
# Conflicts:
#       go.mod
#       go.sum
#       state/migration_export.go
#       state/migration_export_test.go
#       state/migration_import_tasks.go
#       state/migration_import_test.go
```



[JUJU-2582]: https://warthogs.atlassian.net/browse/JUJU-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ