### PR TITLE
[JUJU-2713] Fixed test-refresh suite in 3.0

### DIFF
--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -11,7 +11,9 @@ run_refresh_cs() {
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
 	OUT=$(juju refresh ubuntu 2>&1 || true)
-	if echo "${OUT}" | grep -E -vq "Added"; then
+	if echo "${OUT}" | grep -E -q "Added"; then
+	  echo "refresh passed successfully"
+	else
 		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")
 		exit 5
@@ -20,7 +22,7 @@ run_refresh_cs() {
 	printf "${OUT}\n"
 
 	# Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
-	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
+	revision=$(echo "${OUT}" | tail -n 1 | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 
 	wait_for "ubuntu" "$(charm_rev "ubuntu" "${revision}")"
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -12,7 +12,7 @@ run_refresh_cs() {
 
 	OUT=$(juju refresh ubuntu 2>&1 || true)
 	if echo "${OUT}" | grep -E -q "Added"; then
-	  echo "refresh passed successfully"
+		echo "refresh passed successfully"
 	else
 		# shellcheck disable=SC2046
 		echo $(red "failed refreshing charm: ${OUT}")


### PR DESCRIPTION
This PR fixes `juju refresh` output check and revision check. The problem was in the additional WARNING that was introduced in 3.0 (in the `refresh` command). Now test checks are WARNING-agnostic :)

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```sh
cd tests; ./main.sh -p lxd refresh
```
