### PR TITLE
[JUJU-2715] Forces Juju to create IMDSv2 instances only.

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -668,6 +668,13 @@ func (e *environ) StartInstance(
 		SecurityGroupIds:    groupIDs,
 		BlockDeviceMappings: blockDeviceMappings,
 		ImageId:             aws.String(spec.Image.Id),
+		MetadataOptions: &types.InstanceMetadataOptionsRequest{
+			HttpEndpoint: types.InstanceMetadataEndpointStateEnabled,
+			// By forcing HTTP tokens here we move all created instances over to
+			// IMDSv2.
+			// Fixes lp1960568
+			HttpTokens: types.HttpTokensStateRequired,
+		},
 	}
 
 	runArgs := commonRunArgs


### PR DESCRIPTION
Juju currently deploys machines into AWS EC2 with instance metadata that works for both v2 and v1 of IMDS. V1 of IMDS is long fazed out of AWS and is kept around for legacy purposes and provides an ongoing security risk that Juju users won't tolerate.

With this change we strictly force new instances created by Juju to only work with IMDSv2.

Writing regression tests for this in the current provider model is quite difficult. This commit asks the user to validate the change manually.

As part of this PR I have checked cloud-init supports IMDSv2 for all of the Ubuntu release we care about in 3.1.

Pre this change Juju was creating all instances with the following:
```
"MetadataOptions": {
    "State": "applied",
    "HttpTokens": "optional",
    "HttpPutResponseHopLimit": 1,
    "HttpEndpoint": "enabled",
    "HttpProtocolIpv6": "disabled",
    "InstanceMetadataTags": "disabled"
}
```

Reference Material:
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. Bootstrap Juju to aws
2. Once the bootstrap has complete inspect the ec2 instance with `aws ec2 describe-instances`. You may need to filter this output down to just the machine in question. This can be lazily found by matching the ip address Juju reports during bootstrap.
3. The next step is to validate the `MetadataOptions` key map. It should have it's `HttpTokens` key set to required. Required is the secret sauce that forces IMDsv2
```
"MetadataOptions": {
    "State": "applied",
    "HttpTokens": "required",
    "HttpPutResponseHopLimit": 1,
    "HttpEndpoint": "enabled",
    "HttpProtocolIpv6": "disabled",
    "InstanceMetadataTags": "disabled"
},
```

Second part is to repeat the steps above again but this time we also want to check instance profiles still work:
1. Bootstrap with `juju bootstrap --bootstrap-constraints="instance-role=auto" aws`
2. Confirm the same steps from above.
3. Add a new Juju machine and deploy a workload. Check that everything comes up successfully.

## Documentation changes

Investigating with Dora

## Bug reference

https://bugs.launchpad.net/juju/+bug/1960568
