### PR TITLE
Fix static-analysis pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -627,5 +627,6 @@ STATIC_ANALYSIS_JOB ?=
 .PHONY: static-analysis
 static-analysis: dqlite-install-if-missing
 ## static-analysis: Check the go code using static-analysis
-	@export CGO_ENABLED=1
-	@cd tests && ./main.sh static_analysis ${STATIC_ANALYSIS_JOB}
+	@cd tests && CGO_ENABLED=1 \
+		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
+		./main.sh static_analysis ${STATIC_ANALYSIS_JOB}


### PR DESCRIPTION
Due to weird make rules about environment variables the env var CGO_ENABLED (which should be set to 1) wasn't picked up so defaulted to 0.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing

## QA steps

Verify static-analysis github action succeeds