### PR TITLE
Drop unused interface

### DIFF
--- a/state/firewallrules.go
+++ b/state/firewallrules.go
@@ -72,13 +72,6 @@ func (r *firewallRulesDoc) toRule() *FirewallRule {
 	}
 }
 
-// FirewallRuler instances provide access to firewall rules in state.
-type FirewallRuler interface {
-	Save(service firewall.WellKnownServiceType, whiteListCidrs []string) (FirewallRule, error)
-	Rule(service firewall.WellKnownServiceType) (FirewallRule, error)
-	AllRules() ([]FirewallRule, error)
-}
-
 type firewallRulesState struct {
 	st *State
 }


### PR DESCRIPTION
Interfaces should be declared where they're used anyway, so this shouldn't exist

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA Steps

Juju compiles