### PR TITLE
Properly hide the APIs for juju 3.1

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1447,7 +1447,7 @@ func (api *APIv16) DestroyUnits(args params.DestroyApplicationUnits) error {
 	return apiservererrors.DestroyErr("units", args.UnitNames, errs)
 }
 
-func (*APIBase) DestroyUnits(_ struct{}) {}
+func (*APIBase) DestroyUnits(_, _ struct{}) {}
 
 func (api *APIv15) DestroyUnit(argsV15 params.DestroyUnitsParamsV15) (params.DestroyUnitResults, error) {
 	args := params.DestroyUnitsParams{
@@ -1587,7 +1587,7 @@ func (api *APIv16) Destroy(in params.ApplicationDestroy) error {
 	return nil
 }
 
-func (*APIBase) Destroy(_ struct{}) {}
+func (*APIBase) Destroy(_, _ struct{}) {}
 
 // DestroyApplication removes a given set of applications.
 func (api *APIv15) DestroyApplication(argsV15 params.DestroyApplicationsParamsV15) (params.DestroyApplicationResults, error) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1928,14 +1928,6 @@
                     },
                     "description": "Deploy fetches the charms from the charm store and deploys them\nusing the specified placement directives."
                 },
-                "Destroy": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/"
-                        }
-                    }
-                },
                 "DestroyApplication": {
                     "type": "object",
                     "properties": {
@@ -1980,14 +1972,6 @@
                         }
                     },
                     "description": "DestroyUnit removes a given set of application units."
-                },
-                "DestroyUnits": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/"
-                        }
-                    }
                 },
                 "Expose": {
                     "type": "object",
@@ -2195,10 +2179,6 @@
                 }
             },
             "definitions": {
-                "": {
-                    "type": "object",
-                    "additionalProperties": false
-                },
                 "AddApplicationUnits": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
We accidentally didn't do enough to suppress them. You have to have 2 arguments for the RPCReflect package to treat it as an invalid method to be exposed.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

```sh
make rebuild-schema
```

See that it does properly leave you with a `schema.json` that doesn't have Destroy/DestroyUnits or the `""` type.
