### PR TITLE
[JUJU-2740] Added model arch check in test deploy test deploy bundles aws for arm 64

### DIFF
--- a/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions_arm64.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions_arm64.yaml
@@ -1,0 +1,30 @@
+series: focal
+applications:
+  influxdb:
+    charm: influxdb
+    channel: stable
+    revision: -1
+    num_units: 1
+    to:
+    - "0"
+    constraints: arch=arm64
+  telegraf:
+    charm: telegraf
+    channel: stable
+    revision: -1
+  ubuntu:
+    charm: ubuntu
+    channel: stable
+    revision: -1
+    num_units: 1
+    to:
+    - "1"
+    constraints: arch=arm64
+machines:
+  "0": {}
+  "1": {}
+relations:
+- - telegraf:juju-info
+  - ubuntu:juju-info
+- - telegraf:influxdb-api
+  - influxdb:query

--- a/tests/suites/deploy/bundles/telegraf_bundle_without_revisions_arm64.yaml
+++ b/tests/suites/deploy/bundles/telegraf_bundle_without_revisions_arm64.yaml
@@ -1,0 +1,27 @@
+series: focal
+applications:
+  influxdb:
+    charm: influxdb
+    channel: stable
+    num_units: 1
+    to:
+    - "0"
+    constraints: arch=arm64
+  telegraf:
+    charm: telegraf
+    channel: stable
+  ubuntu:
+    charm: ubuntu
+    channel: stable
+    num_units: 1
+    to:
+    - "1"
+    constraints: arch=arm64
+machines:
+  "0": {}
+  "1": {}
+relations:
+- - telegraf:juju-info
+  - ubuntu:juju-info
+- - telegraf:influxdb-api
+  - influxdb:query


### PR DESCRIPTION
This PR added `MODEL_ARCH` check in the `juju info` command and added MODEL_ARCH check in application constraints.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made


## QA steps

```sh
cd tests
export MODEL_ARCH=arm64; export SHORT_GIT_COMMIT=f2792de; export JUJU_VERSION=2.9.40.1039;
./main.sh -v -p aws deploy run_deploy_exported_charmhub_bundle_with_float_revisions
```
