### PR TITLE
2.9 to 3.0 merge 20230210

### DIFF
--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -177,7 +177,7 @@ func (e *environ) Instances(ctx context.ProviderCallContext, ids []instance.Id) 
 
 	for i, id := range ids {
 		d, resp, err := e.equinixClient.Devices.Get(string(id), nil)
-		if err != nil && resp != nil && resp.Request.Response.StatusCode == http.StatusNotFound {
+		if err != nil && resp != nil && resp.Response.StatusCode == http.StatusNotFound {
 			logger.Warningf("instance %s not found", string(id))
 			missingInstanceCount = missingInstanceCount + 1
 			continue
@@ -833,11 +833,7 @@ func waitDeviceActive(ctx context.ProviderCallContext, c *packngo.Client, id str
 		Clock:    clock.WallClock,
 	})
 
-	if d != nil {
-		return d, nil
-	}
-
-	return nil, err
+	return d, errors.Trace(err)
 }
 
 // Helper function to get supported OS version

--- a/provider/equinix/environ_test.go
+++ b/provider/equinix/environ_test.go
@@ -736,7 +736,8 @@ func (*EquinixUtils) TestWaitDeviceActive_ReturnFailed(c *gc.C) {
 		State: "failed",
 	}, nil, nil).Times(1)
 	cl.Devices = device
-	waitDeviceActive(environContext.NewEmptyCloudCallContext(), cl, "100")
+	_, err := waitDeviceActive(environContext.NewEmptyCloudCallContext(), cl, "100")
+	c.Assert(err, gc.Not(jc.ErrorIsNil))
 }
 
 func (*EquinixUtils) TestIsDistroSupported(c *gc.C) {

--- a/provider/equinix/init.go
+++ b/provider/equinix/init.go
@@ -11,6 +11,15 @@ const (
 	providerType = "equinix"
 )
 
+const (
+	Provisioning string = "provisioning"
+	Active       string = "active"
+	ShuttingDown string = "shutting-down"
+	Stopped      string = "stopped"
+	Stopping     string = "stopping"
+	Terminated   string = "terminated"
+)
+
 func init() {
 	environs.RegisterProvider(providerType, environProvider{})
 }

--- a/provider/equinix/instance.go
+++ b/provider/equinix/instance.go
@@ -52,11 +52,11 @@ func (device *equinixDevice) Status(ctx context.ProviderCallContext) instance.St
 	var jujuStatus status.Status
 
 	switch device.State {
-	case "provisioning":
-		jujuStatus = status.Pending
-	case "active":
+	case Active:
 		jujuStatus = status.Running
-	case "shutting-down", "terminated", "stopping", "stopped":
+	case Provisioning:
+		jujuStatus = status.Pending
+	case ShuttingDown, Stopped, Stopping, Terminated:
 		jujuStatus = status.Empty
 	default:
 		jujuStatus = status.Empty

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -101,15 +101,34 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	ensure "test-export-bundles-deploy-with-float-revisions" "${file}"
 	bundle=./tests/suites/deploy/bundles/telegraf_bundle_without_revisions.yaml
 	bundle_with_fake_revisions=./tests/suites/deploy/bundles/telegraf_bundle_with_fake_revisions.yaml
-	juju deploy ${bundle}
+	cp ${bundle} "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
+	cp ${bundle_with_fake_revisions} "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml"
+	if [[ -n ${MODEL_ARCH:-} ]]; then
+		yq -i "
+      .applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
+      .applications.ubuntu.constraints = \"arch=${MODEL_ARCH}\"
+    " "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
+		yq -i "
+      .applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
+      .applications.ubuntu.constraints = \"arch=${MODEL_ARCH}\"
+    " "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml"
+	fi
+
+	juju deploy "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
 
 	echo "Create telegraf_bundle_without_revisions.yaml with known latest revisions from charmhub"
-	influxdb_rev=$(juju info influxdb --format json | jq -r '."channels"."latest"."stable"[0].revision')
-	telegraf_rev=$(juju info telegraf --format json | jq -r '."channels"."latest"."stable"[0].revision')
-	ubuntu_rev=$(juju info ubuntu --format json | jq -r '."channels"."latest"."stable"[0].revision')
+	if [[ -n ${MODEL_ARCH:-} ]]; then
+		influxdb_rev=$(juju info influxdb --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
+    telegraf_rev=$(juju info telegraf --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
+    ubuntu_rev=$(juju info ubuntu --arch="${MODEL_ARCH}" --format json | jq -r '."channels"."latest"."stable"[0].revision')
+	else
+		influxdb_rev=$(juju info influxdb --format json | jq -r '."channels"."latest"."stable"[0].revision')
+    telegraf_rev=$(juju info telegraf --format json | jq -r '."channels"."latest"."stable"[0].revision')
+    ubuntu_rev=$(juju info ubuntu --format json | jq -r '."channels"."latest"."stable"[0].revision')
+	fi
 
 	echo "Make a copy of reference yaml and insert revisions in it"
-	cp ${bundle_with_fake_revisions} "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
+	cp "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 	yq -i "
 		.applications.influxdb.revision = ${influxdb_rev} |
 		.applications.telegraf.revision = ${telegraf_rev} |
@@ -118,6 +137,8 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 
 	if [[ -n ${MODEL_ARCH:-} ]]; then
 		yq -i "
+			.applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
+			.applications.ubuntu.constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
 		" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"


### PR DESCRIPTION
Merge  2.9 to 3.0:

- 98917c75ac Merge pull request #15176 from anvial/JUJU-2740-add-model-arch-check-in-test-deploy-test-deploy-bundles-aws-for-arm-64
- f2792de100 Merge pull request #15136 from cprivitere/better-device-status
- 8d785e9b1d Merge pull request #15129 from jack-w-shaw/JUJU-2615_debug_log_for_caas
- c78f9cc831 Merge pull request #15141 from hmlanigan/198858701-refresh-switch-no-rev-change
- 23e1e9f316 Merge pull request #15154 from manadart/2.9-migration-rollback
- a02ca45561 Merge pull request #15157 from manadart/2.9-sync-agent-binary
- 505cd87903 Merge pull request #15117 from cprivitere/whitelist-10-networks
- 9161d10615 Merge pull request #15145 from manadart/2.9-migrate-remote-app-consume-version
- c864da4ff4 Merge pull request #15139 from barrettj12/upgrade-k8s
- 9bdc82445e Merge pull request #15132 from manadart/2.9-remote-relation-broken
- c68dd14781 Merge pull request #15103 from SimonRichardson/respect-model-constraints-bundle
- eb9cd5127b Merge pull request #15125 from manadart/2.9-model-backend
- 4b8d850635 Merge pull request #15116 from nvinuesa/fix-lp1979292
- 0f7817ed02 Merge pull request #15118 from cprivitere/fix-provider-typo


The only conflict is in:
`tests/suites/deploy/deploy_bundles.sh`
