### PR TITLE
Allow debug mode for dqlite

### DIFF
--- a/scripts/dqlite/scripts/dqlite/dqlite-build.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-build.sh
@@ -10,6 +10,10 @@ build() {
         MACHINE_TYPE="powerpc64le"
         CUSTOM_CFLAGS="-mlong-double-64"
     fi
+    DQLITE_CONFIGURE_FLAGS=
+    if [ "${DEBUG_MODE}" = "true" ]; then
+        DQLITE_CONFIGURE_FLAGS="--enable-debug"
+    fi
 
     # Ensure that when apt installs tzdata skips it's prompt in all contexts
     sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime
@@ -127,7 +131,7 @@ build() {
             UV_CFLAGS="-I${PWD}/../libuv/include" \
             UV_LIBS="-L${PWD}/../libuv/.libs" \
             SQLITE_CFLAGS="-I${PWD}/../sqlite" \
-            ./configure --disable-shared
+            ./configure --disable-shared ${DQLITE_CONFIGURE_FLAGS}
     make
     cd ../
 

--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -4,6 +4,8 @@ set -e
 
 PROJECT_DIR=$(pwd)
 
+DEBUG_MODE=${DEBUG_MODE:-false}
+
 current_arch() {
 	case $(uname -m) in
 		x86_64) echo amd64 ;;


### PR DESCRIPTION
To help with debugging, we can enable debug mode for dqlite. This is turned off by default, until we can run with it to see if there is any performance impact.

From the looks of it, it compiles with CFLAGS+=-g instead of CFLAGS+=-O2.

## QA steps

```sh
$ make dqlite-build-lxd
```
