### PR TITLE
[JUJU-2770] Cross compile by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,32 +29,21 @@ jobs:
            - { os: darwin, arch: amd64 }
 
     steps:
-    - name: Checkout
+    - name: "Checkout"
       uses: actions/checkout@v3
 
-    - name: Set up Go
+    - name: "Set up Go"
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
         cache: true
-
-    - name: "Restore musl cache"
-      id: restore-musl-cache
+    
+    - name: "Install musl"
       if: (matrix.os == 'linux')
-      uses: actions/cache/restore@v3
-      with:
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('./scripts/dqlite/Makefile') }}
-        path: |
-          ./_deps/musl-${{ runner.arch }}
+      shell: bash
+      run: |
+        sudo make MUSL_CROSS_COMPILE=0 MUSL_PLACEMENT=local musl-install
 
     - name: "Build"
       run: |
-        GOOS=${{ matrix.platform.os }} GOARCH=${{ matrix.platform.arch }} make MUSL_PLACEMENT=local go-build
-
-    - name: "Save musl cache"
-      uses: actions/cache/save@v3
-      if: (matrix.os == 'linux')
-      with:
-        key: ${{ steps.restore-musl-cache.outputs.cache-primary-key }}
-        path: |
-          ./_deps/musl-${{ runner.arch }}
+        GOOS=${{ matrix.platform.os }} GOARCH=${{ matrix.platform.arch }} make go-build

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -42,7 +42,7 @@ jobs:
       if: (matrix.os == 'ubuntu-latest')
       shell: bash
       run: |
-        sudo make musl-install dqlite-install
+        sudo make MUSL_CROSS_COMPILE=0 musl-install dqlite-install
 
     - name: "Test client (Ubuntu)"
       if: (matrix.os == 'ubuntu-latest')

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ define run_cgo_build
 	$(eval BUILD_ARCH = $(subst ppc64el,ppc64le,${ARCH}))
 	@@mkdir -p ${BBIN_DIR}
 	@echo "Building ${PACKAGE} for ${OS}/${ARCH}"
-	@env PATH=${PATH}:${MUSL_BIN_PATH} \
+	@env PATH=${MUSL_BIN_PATH}:${PATH} \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
 		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
@@ -244,7 +244,7 @@ endef
 
 define run_cgo_install
 	@echo "Installing ${PACKAGE}"
-	env PATH=${PATH}:${MUSL_BIN_PATH} \
+	env PATH=${MUSL_BIN_PATH}:${PATH} \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
 		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
@@ -393,7 +393,7 @@ run-tests: musl-install-if-missing dqlite-install-if-missing
 	$(eval TEST_PACKAGES := $(shell go list $(PROJECT)/... | sort | ([ -f "$(TEST_PACKAGE_LIST)" ] && comm -12 "$(TEST_PACKAGE_LIST)" - || cat) | grep -v $(PROJECT)$$ | grep -v $(PROJECT)/vendor/ | grep -v $(PROJECT)/acceptancetests/ | grep -v $(PROJECT)/generate/ | grep -v mocks))
 	@echo 'go test -mod=$(JUJU_GOMOD_MODE) -tags=$(BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES -check.v'
 	@TMPDIR=$(TMP) \
-		PATH=${PATH}:${MUSL_BIN_PATH} \
+		PATH=${MUSL_BIN_PATH}:${PATH} \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
 		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
@@ -411,7 +411,7 @@ run-go-tests: musl-install-if-missing dqlite-install-if-missing
 	$(eval TEST_PACKAGES ?= "./...")
 	$(eval TEST_FILTER ?= "")
 	@echo 'go test -mod=$(JUJU_GOMOD_MODE) -tags=$(BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES -check.v -check.f $(TEST_FILTER)'
-	@PATH=${PATH}:${MUSL_BIN_PATH} \
+	@PATH=${MUSL_BIN_PATH}:${PATH} \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
 		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
@@ -422,7 +422,7 @@ run-go-tests: musl-install-if-missing dqlite-install-if-missing
 
 run-go-generate: musl-install-if-missing dqlite-install-if-missing
 ## run-go-generate: Generate go code
-	@PATH=${PATH}:${MUSL_BIN_PATH} \
+	@PATH=${MUSL_BIN_PATH}:${PATH} \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
 		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \

--- a/scripts/dqlite/scripts/musl/musl-install.sh
+++ b/scripts/dqlite/scripts/musl/musl-install.sh
@@ -5,13 +5,14 @@ set -e
 source "$(dirname $0)/../env.sh"
 
 MUSL_VERSION="1.2.3"
+MUSL_CROSS_COMPILE=${MUSL_CROSS_COMPILE:-"1"}
 
-MUSL_PLACEMENT=${MUSL_PLACEMENT:-"system"}
+MUSL_LOCAL_PLACEMENT=${MUSL_LOCAL_PLACEMENT:-"system"}
 
 MUSL_LOCAL_PATH=${PROJECT_DIR}/_deps/musl-${BUILD_ARCH}
 MUSL_SYSTEM_PATH=/usr/local/musl
 
-if [ "${MUSL_PLACEMENT}" = "local" ] || [ "${BUILD_ARCH}" != "${CURRENT_ARCH}" ]; then
+if [ "${MUSL_LOCAL_PLACEMENT}" = "local" ] || [ "${MUSL_CROSS_COMPILE}" = "1" ]; then
     MUSL_PATH=${MUSL_LOCAL_PATH}
     MUSL_BIN_PATH=${MUSL_PATH}/output/bin
 else
@@ -51,7 +52,7 @@ musl_install() {
     wget -q https://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz -O - | tar -xzf - -C ${TMP_DIR}
     cd ${TMP_DIR}/musl-${MUSL_VERSION}
 
-    if [ "${MUSL_PLACEMENT}" = "local" ]; then
+    if [ "${MUSL_LOCAL_PLACEMENT}" = "local" ]; then
         echo "Installing local musl"
         musl_install_local
     else
@@ -102,12 +103,12 @@ musl_install_cross_arch() {
 }
 
 install() {
-    if [ "${BUILD_ARCH}" = "${CURRENT_ARCH}" ]; then
-        musl_install
+    if [ "${MUSL_CROSS_COMPILE}" = "1" ]; then
+        echo "Installing cross-arch musl"
+        musl_install_cross_arch
         exit 0
     fi
 
-    echo "Installing cross-arch musl"
-    musl_install_cross_arch
+    musl_install
     exit 0
 }


### PR DESCRIPTION
The following changes the default setup to fix the following problems:

 1. 22.04 brings in GCC 11.2.0, that has a libgcc_.so.1 for GCC 12.0.0 and uses _del_find_object() function. ld doesn't know how to correctly link to this, so fix this by forcing cross compiling everything. That way we know the full environment for building.
 2. We've now fixed the headers for building juju. We've picked 4.19.88, these are the LTS for the end of 2024. We'll then have to move 5.4, 5.10 or 5.15 as these are also LTS. This will require updating the musl-cross-make project.

Updating to this solves the issue on kinetic (22.10).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

Ensure that you trash your `_deps` directory in `juju/juju` if you have any issues.

```sh
$ make jujud
```
