### PR TITLE
Restore machine agent tests

### DIFF
--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -5,6 +5,7 @@ package agenttest
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/juju/clock"
@@ -114,10 +115,17 @@ func (f *FakeEnsureMongo) InitiateMongo(p peergrouper.InitiateMongoParams) error
 // AgentSuite is a fixture to be used by agent test suites.
 type AgentSuite struct {
 	testing.JujuConnSuite
+
+	// InitialDBOps can be set prior to calling PrimeStateAgentVersion,
+	// ensuring that the functions are executed against the controller database
+	// immediately after Sqlite is set up.
+	InitialDBOps []func(db *sql.DB) error
 }
 
 func (s *AgentSuite) SetUpSuite(c *gc.C) {
 	s.JujuConnSuite.SetUpSuite(c)
+
+	s.InitialDBOps = make([]func(db *sql.DB) error, 0)
 	s.PatchValue(&database.DefaultBindAddress, "127.0.0.1")
 }
 
@@ -204,7 +212,7 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	conf := s.WriteStateAgentConfig(c, tag, password, vers, model.ModelTag())
 	s.primeAPIHostPorts(c)
 
-	err = database.BootstrapDqlite(context.TODO(), database.NewOptionFactory(conf, logger), logger)
+	err = database.BootstrapDqlite(context.TODO(), database.NewOptionFactory(conf, logger), logger, s.InitialDBOps...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return conf, agentTools

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -118,7 +118,7 @@ type AgentSuite struct {
 
 	// InitialDBOps can be set prior to calling PrimeStateAgentVersion,
 	// ensuring that the functions are executed against the controller database
-	// immediately after Sqlite is set up.
+	// immediately after Dqlite is set up.
 	InitialDBOps []func(db *sql.DB) error
 }
 

--- a/pubsub/apiserver/messages.go
+++ b/pubsub/apiserver/messages.go
@@ -50,12 +50,12 @@ type DetailsRequest struct {
 }
 
 // ConnectTopic is the topic name for the published message
-// whenever an agent conntects to the API server.
+// whenever an agent connects to the API server.
 // data: `APIConnection`
 const ConnectTopic = "apiserver.agent-connect"
 
 // DisconnectTopic is the topic name for the published message
-// whenever an agent disconntects to the API server.
+// whenever an agent disconnects to the API server.
 // data: `APIConnection`
 const DisconnectTopic = "apiserver.agent-disconnect"
 

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -239,17 +239,12 @@ func (w *dbWorker) initializeDqlite() error {
 		return errors.Trace(err)
 	}
 
-	withTLS, err := opt.WithTLSOption()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	withCluster, err := opt.WithClusterOption()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	if w.dbApp, err = w.cfg.NewApp(dataDir, withAddr, withTLS, withCluster, opt.WithLogFuncOption()); err != nil {
+	if w.dbApp, err = w.cfg.NewApp(dataDir, withAddr, withCluster, opt.WithLogFuncOption()); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -31,7 +31,6 @@ func (s *workerSuite) TestGetControllerDBSuccess(c *gc.C) {
 	optExp := s.optFactory.EXPECT()
 	optExp.EnsureDataDir().Return(c.MkDir(), nil)
 	optExp.WithAddressOption().Return(nil, nil)
-	optExp.WithTLSOption().Return(nil, nil)
 	optExp.WithClusterOption().Return(nil, nil)
 	optExp.WithLogFuncOption().Return(nil)
 

--- a/worker/pubsub/subscriber.go
+++ b/worker/pubsub/subscriber.go
@@ -119,7 +119,7 @@ func newSubscriber(config WorkerConfig) (*subscriber, error) {
 }
 
 // Report returns the same information as the introspection report
-// but in the map for for the dependency engine report.
+// but in the map for the dependency engine report.
 func (s *subscriber) Report() map[string]interface{} {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -150,7 +150,7 @@ func (s *subscriber) IntrospectionReport() string {
 		result = append(result, info)
 	}
 	prefix := fmt.Sprintf("Source: %s\n\n", s.config.Origin)
-	// Sorting the result gives us consisten ordering.
+	// Sorting the result gives us consistent ordering.
 	sort.Strings(result)
 	return prefix + strings.Join(result, "\n")
 }


### PR DESCRIPTION
While working on the Dqlite branch, machine agent tests were skipped while we moved out Raft concerns and replaced the lease store backing with Dqlite.

Here we restore them, adding the test infrastructure required to orchestrate one of the tests requiring a lease to be claimed by a third party.

We also disable Dqlite node TLS, because it does not currently work with the ciphers used for testing certs. This is a temporary measure. It will be reinstated as part of the clustering rework that is in progress.

## QA steps

Tests in _github.com/juju/juju/cmd/jujud/agent_ run and pass.

## Documentation changes

None.

## Bug reference

N/A
