### PR TITLE
[JUJU-2823] Copy required methods from lxc/lxd shared package

### DIFF
--- a/container/lxd/certificate.go
+++ b/container/lxd/certificate.go
@@ -12,7 +12,6 @@ import (
 	"io"
 
 	"github.com/juju/errors"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -30,7 +29,7 @@ type Certificate struct {
 // GenerateClientCertificate creates and returns a new certificate for client
 // communication with an LXD server.
 func GenerateClientCertificate() (*Certificate, error) {
-	cert, key, err := shared.GenerateMemCert(true, true)
+	cert, key, err := GenerateMemCert(true, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/container/lxd/connection.go
+++ b/container/lxd/connection.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/errors"
 	lxd "github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/shared"
 )
 
 type Protocol string
@@ -142,7 +141,7 @@ func connectImageRemote(remote ServerSpec) (lxd.ImageServer, error) {
 }
 
 func connectLocal() (lxd.InstanceServer, error) {
-	client, err := lxd.ConnectLXDUnix(SocketPath(shared.IsUnixSocket), nil)
+	client, err := lxd.ConnectLXDUnix(SocketPath(IsUnixSocket), nil)
 	return client, errors.Trace(err)
 }
 

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/os/v2/series"
 	"github.com/juju/packaging/v2/manager"
 	"github.com/juju/proxy"
-	"github.com/lxc/lxd/shared"
 
 	"github.com/juju/juju/container"
 	"github.com/juju/juju/packaging"
@@ -223,7 +222,7 @@ func ensureDependencies(lxdSnapChannel, series string) error {
 // lxdViaSnap interrogates the location of the Snap LXD socket in order
 // to determine if LXD is being provided via that method.
 var lxdViaSnap = func() bool {
-	return shared.IsUnixSocket("/var/snap/lxd/common/lxd/unix.socket")
+	return IsUnixSocket("/var/snap/lxd/common/lxd/unix.socket")
 }
 
 // randomizedOctetRange is a variable for testing purposes.

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jujuarch "github.com/juju/utils/v3/arch"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 
 	"github.com/juju/juju/cloudconfig/cloudinit"
@@ -184,7 +183,7 @@ func (m *containerManager) ensureInitialized() error {
 // IsInitialized implements container.Manager.
 // It returns true if we can find a LXD socket on this host.
 func (m *containerManager) IsInitialized() bool {
-	return SocketPath(shared.IsUnixSocket) != ""
+	return SocketPath(IsUnixSocket) != ""
 }
 
 // getContainerSpec generates a spec for creating a new container.

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -12,7 +12,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	lxdclient "github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/shared"
 	lxdapi "github.com/lxc/lxd/shared/api"
 	gc "gopkg.in/check.v1"
 
@@ -342,7 +341,7 @@ func (s *managerSuite) TestIsInitialized(c *gc.C) {
 	mgr, err := lxd.NewContainerManager(getBaseConfig(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(mgr.IsInitialized(), gc.Equals, lxd.SocketPath(shared.IsUnixSocket) != "")
+	c.Check(mgr.IsInitialized(), gc.Equals, lxd.SocketPath(lxd.IsUnixSocket) != "")
 }
 
 func (s *managerSuite) TestNetworkDevicesFromConfigWithEmptyParentDevice(c *gc.C) {

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/utils/v3/arch"
 	lxd "github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -99,9 +98,9 @@ func NewServer(svr lxd.InstanceServer) (*Server, error) {
 		serverCertificate: serverCertificate,
 		hostArch:          hostArch,
 		supportedArches:   supportedArches,
-		networkAPISupport: shared.StringInSlice("network", apiExt),
-		clusterAPISupport: shared.StringInSlice("clustering", apiExt),
-		storageAPISupport: shared.StringInSlice("storage", apiExt),
+		networkAPISupport: inSlice("network", apiExt),
+		clusterAPISupport: inSlice("clustering", apiExt),
+		storageAPISupport: inSlice("storage", apiExt),
 		serverVersion:     info.Environment.ServerVersion,
 		clock:             clock.WallClock,
 	}, nil
@@ -314,4 +313,13 @@ func IsLXDAlreadyExists(err error) bool {
 	}
 
 	return strings.Contains(strings.ToLower(err.Error()), "already exists")
+}
+
+func inSlice[T comparable](key T, list []T) bool {
+	for _, entry := range list {
+		if entry == key {
+			return true
+		}
+	}
+	return false
 }

--- a/container/lxd/shared.go
+++ b/container/lxd/shared.go
@@ -1,0 +1,137 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Licensed under the Apache 2.0 license. See github.com/lxc/lxd COPYING file for details.
+
+package lxd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"os/user"
+	"time"
+)
+
+// The following file exists because we can no longer import the
+// github.com/lxc/lxd/shared package when we build with CGO_ENABLED=1. Using
+// CGO will then compile in some lxc/lxd C code, which causes problems when
+// attempting to cross-compile.
+
+// IsUnixSocket returns true if the given path is either a Unix socket
+// or a symbolic link pointing at a Unix socket.
+func IsUnixSocket(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	return (stat.Mode() & os.ModeSocket) == os.ModeSocket
+}
+
+// GenerateMemCert creates client or server certificate and key pair,
+// returning them as byte arrays in memory.
+func GenerateMemCert(client bool, addHosts bool) ([]byte, []byte, error) {
+	privk, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to generate key: %w", err)
+	}
+
+	validFrom := time.Now()
+	validTo := validFrom.Add(10 * 365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to generate serial number: %w", err)
+	}
+
+	userEntry, err := user.Current()
+	var username string
+	if err == nil {
+		username = userEntry.Username
+		if username == "" {
+			username = "UNKNOWN"
+		}
+	} else {
+		username = "UNKNOWN"
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "UNKNOWN"
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"linuxcontainers.org"},
+			CommonName:   fmt.Sprintf("%s@%s", username, hostname),
+		},
+		NotBefore: validFrom,
+		NotAfter:  validTo,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	if client {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	} else {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+
+	if addHosts {
+		hosts, err := mynames()
+		if err != nil {
+			return nil, nil, fmt.Errorf("Failed to get my hostname: %w", err)
+		}
+
+		for _, h := range hosts {
+			ip, _, err := net.ParseCIDR(h)
+			if err == nil {
+				if !ip.IsLinkLocalUnicast() && !ip.IsLinkLocalMulticast() {
+					template.IPAddresses = append(template.IPAddresses, ip)
+				}
+			} else {
+				template.DNSNames = append(template.DNSNames, h)
+			}
+		}
+	} else if !client {
+		template.DNSNames = []string{"unspecified"}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privk.PublicKey, privk)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create certificate: %w", err)
+	}
+
+	data, err := x509.MarshalECPrivateKey(privk)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	key := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: data})
+
+	return cert, key, nil
+}
+
+// mynames a list of names for which the certificate will be valid.
+// This will include the hostname and ip address.
+func mynames() ([]string, error) {
+	h, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []string{h, "127.0.0.1/8", "::1/128"}
+	return ret, nil
+}

--- a/container/lxd/shared_test.go
+++ b/container/lxd/shared_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"encoding/pem"
+
+	lxdtesting "github.com/juju/juju/container/lxd/testing"
+	gc "gopkg.in/check.v1"
+)
+
+type sharedSuite struct {
+	lxdtesting.BaseSuite
+}
+
+var _ = gc.Suite(&sharedSuite{})
+
+func (sharedSuite) TestGenerateMemCert(c *gc.C) {
+
+	cert, key, err := GenerateMemCert(false, true)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	if cert == nil {
+		c.Error("GenerateMemCert returned a nil cert")
+		return
+	}
+
+	if key == nil {
+		c.Error("GenerateMemCert returned a nil key")
+		return
+	}
+
+	block, rest := pem.Decode(cert)
+	if len(rest) != 0 {
+		c.Errorf("GenerateMemCert returned a cert with trailing content: %q", string(rest))
+	}
+
+	if block.Type != "CERTIFICATE" {
+		c.Errorf("GenerateMemCert returned a cert with Type %q not \"CERTIFICATE\"", block.Type)
+	}
+
+	block, rest = pem.Decode(key)
+	if len(rest) != 0 {
+		c.Errorf("GenerateMemCert returned a key with trailing content: %q", string(rest))
+	}
+
+	if block.Type != "EC PRIVATE KEY" {
+		c.Errorf("GenerateMemCert returned a cert with Type %q not \"EC PRIVATE KEY\"", block.Type)
+	}
+}

--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/v3"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 
 	"github.com/juju/juju/cloud"
@@ -568,7 +567,7 @@ func (certificateReadWriter) Write(path string, certPEM, keyPEM []byte) error {
 type certificateGenerator struct{}
 
 func (certificateGenerator) Generate(client bool, addHosts bool) (certPEM, keyPEM []byte, err error) {
-	return shared.GenerateMemCert(client, addHosts)
+	return lxd.GenerateMemCert(client, addHosts)
 }
 
 func endpointURL(endpoint string) (*url.URL, error) {


### PR DESCRIPTION
The following copies the required methods that juju needs from the shared package. We need to do this because there are some CGO enabled methods that are now being triggered when we build jujud with CGO_ENABLED=1.

Ideally, we would change upstream to move the CGO to a sub-package, but that dictates how Juju uses lxc/lxd package as a client, which isn't ideal.

Using these following changes should then allow us to migrate some of the header issues that we currently have when building jujud.

I've put the changes under a dual license, as Apache 2.0 should be compatible with AGPLv3, but IANAL.

Lastly, as we're copying over the generate mem cert, we should pay attention to this original source when upgrading the lxc/lxd package in go.mod, as we might find that we're no longer compatible.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.

```sh
$ juju bootstrap lxd test --build-agent
$ juju deploy ubuntu
```
