### PR TITLE
[JUJU-2741] Dqlite node config - detect if host is already a node

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -106,7 +106,7 @@ func InitializeState(
 	info.Tag = nil
 	info.Password = c.OldPassword()
 
-	if err := database.BootstrapDqlite(stdcontext.TODO(), database.NewOptionFactory(c, logger), logger); err != nil {
+	if err := database.BootstrapDqlite(stdcontext.TODO(), database.NewNodeManager(c, logger), logger); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -212,7 +212,7 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *gc.C, tag names.Tag, password str
 	conf := s.WriteStateAgentConfig(c, tag, password, vers, model.ModelTag())
 	s.primeAPIHostPorts(c)
 
-	err = database.BootstrapDqlite(context.TODO(), database.NewOptionFactory(conf, logger), logger, s.InitialDBOps...)
+	err = database.BootstrapDqlite(context.TODO(), database.NewNodeManager(conf, logger), logger, s.InitialDBOps...)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return conf, agentTools

--- a/database/app/dqlite_linux.go
+++ b/database/app/dqlite_linux.go
@@ -9,17 +9,13 @@ package app
 import (
 	"crypto/tls"
 	"net"
-	"time"
 
-	"github.com/canonical/go-dqlite"
 	"github.com/canonical/go-dqlite/app"
 	"github.com/canonical/go-dqlite/client"
 )
 
 // Option can be used to tweak app parameters.
 type Option = app.Option
-
-type SnapshotParams = dqlite.SnapshotParams
 
 // WithAddress sets the network address of the application node.
 //
@@ -66,84 +62,9 @@ func WithTLS(listen *tls.Config, dial *tls.Config) Option {
 	return app.WithTLS(listen, dial)
 }
 
-// WithUnixSocket allows setting a specific socket path for communication between go-dqlite and dqlite.
-//
-// The default is an empty string which means a random abstract unix socket.
-func WithUnixSocket(path string) Option {
-	return app.WithUnixSocket(path)
-}
-
-// WithVoters sets the number of nodes in the cluster that should have the
-// Voter role.
-//
-// When a new node is added to the cluster or it is started again after a
-// shutdown it will be assigned the Voter role in case the current number of
-// voters is below n.
-//
-// Similarly when a node with the Voter role is shutdown gracefully by calling
-// the Handover() method, it will try to transfer its Voter role to another
-// non-Voter node, if one is available.
-//
-// All App instances in a cluster must be created with the same WithVoters
-// setting.
-//
-// The given value must be an odd number greater than one.
-//
-// The default value is 3.
-func WithVoters(n int) Option {
-	return app.WithVoters(n)
-}
-
-// WithStandBys sets the number of nodes in the cluster that should have the
-// StandBy role.
-//
-// When a new node is added to the cluster or it is started again after a
-// shutdown it will be assigned the StandBy role in case there are already
-// enough online voters, but the current number of stand-bys is below n.
-//
-// Similarly when a node with the StandBy role is shutdown gracefully by
-// calling the Handover() method, it will try to transfer its StandBy role to
-// another non-StandBy node, if one is available.
-//
-// All App instances in a cluster must be created with the same WithStandBys
-// setting.
-//
-// The default value is 3.
-func WithStandBys(n int) Option {
-	return app.WithStandBys(n)
-}
-
-// WithRolesAdjustmentFrequency sets the frequency at which the current cluster
-// leader will check if the roles of the various nodes in the cluster matches
-// the desired setup and perform promotions/demotions to adjust the situation
-// if needed.
-//
-// The default is 30 seconds.
-func WithRolesAdjustmentFrequency(frequency time.Duration) Option {
-	return app.WithRolesAdjustmentFrequency(frequency)
-}
-
 // WithLogFunc sets a custom log function.
 func WithLogFunc(log client.LogFunc) Option {
 	return app.WithLogFunc(log)
-}
-
-// WithFailureDomain sets the node's failure domain.
-//
-// Failure domains are taken into account when deciding which nodes to promote
-// to Voter or StandBy when needed.
-func WithFailureDomain(code uint64) Option {
-	return app.WithFailureDomain(code)
-}
-
-// WithNetworkLatency sets the average one-way network latency.
-func WithNetworkLatency(latency time.Duration) Option {
-	return app.WithNetworkLatency(latency)
-}
-
-// WithSnapshotParams sets the raft snapshot parameters.
-func WithSnapshotParams(params dqlite.SnapshotParams) Option {
-	return app.WithSnapshotParams(params)
 }
 
 // App is a high-level helper for initializing a typical dqlite-based Go

--- a/database/app/dqlite_other.go
+++ b/database/app/dqlite_other.go
@@ -10,9 +10,7 @@ import (
 	"context"
 	"crypto/tls"
 	"database/sql"
-	"net"
 	"path/filepath"
-	"time"
 
 	"github.com/juju/errors"
 	_ "github.com/mattn/go-sqlite3"
@@ -22,11 +20,6 @@ import (
 
 // Option can be used to tweak app parameters.
 type Option func()
-
-type SnapshotParams struct {
-	Threshold uint64
-	Trailing  uint64
-}
 
 // WithAddress sets the network address of the application node.
 //
@@ -54,14 +47,6 @@ func WithCluster(cluster []string) Option {
 	return func() {}
 }
 
-// WithExternalConn enables passing an external dial function that will be used
-// whenever dqlite needs to make an outside connection.
-//
-// Also takes a net.Conn channel that should be received when the external connection has been accepted.
-func WithExternalConn(dialFunc client.DialFunc, acceptCh chan net.Conn) Option {
-	return func() {}
-}
-
 // WithTLS enables TLS encryption of network traffic.
 //
 // The "listen" parameter must hold the TLS configuration to use when accepting
@@ -73,83 +58,8 @@ func WithTLS(listen *tls.Config, dial *tls.Config) Option {
 	return func() {}
 }
 
-// WithUnixSocket allows setting a specific socket path for communication between go-dqlite and dqlite.
-//
-// The default is an empty string which means a random abstract unix socket.
-func WithUnixSocket(path string) Option {
-	return func() {}
-}
-
-// WithVoters sets the number of nodes in the cluster that should have the
-// Voter role.
-//
-// When a new node is added to the cluster or it is started again after a
-// shutdown it will be assigned the Voter role in case the current number of
-// voters is below n.
-//
-// Similarly when a node with the Voter role is shutdown gracefully by calling
-// the Handover() method, it will try to transfer its Voter role to another
-// non-Voter node, if one is available.
-//
-// All App instances in a cluster must be created with the same WithVoters
-// setting.
-//
-// The given value must be an odd number greater than one.
-//
-// The default value is 3.
-func WithVoters(n int) Option {
-	return func() {}
-}
-
-// WithStandBys sets the number of nodes in the cluster that should have the
-// StandBy role.
-//
-// When a new node is added to the cluster or it is started again after a
-// shutdown it will be assigned the StandBy role in case there are already
-// enough online voters, but the current number of stand-bys is below n.
-//
-// Similarly when a node with the StandBy role is shutdown gracefully by
-// calling the Handover() method, it will try to transfer its StandBy role to
-// another non-StandBy node, if one is available.
-//
-// All App instances in a cluster must be created with the same WithStandBys
-// setting.
-//
-// The default value is 3.
-func WithStandBys(n int) Option {
-	return func() {}
-}
-
-// WithRolesAdjustmentFrequency sets the frequency at which the current cluster
-// leader will check if the roles of the various nodes in the cluster matches
-// the desired setup and perform promotions/demotions to adjust the situation
-// if needed.
-//
-// The default is 30 seconds.
-func WithRolesAdjustmentFrequency(frequency time.Duration) Option {
-	return func() {}
-}
-
 // WithLogFunc sets a custom log function.
 func WithLogFunc(log client.LogFunc) Option {
-	return func() {}
-}
-
-// WithFailureDomain sets the node's failure domain.
-//
-// Failure domains are taken into account when deciding which nodes to promote
-// to Voter or StandBy when needed.
-func WithFailureDomain(code uint64) Option {
-	return func() {}
-}
-
-// WithNetworkLatency sets the average one-way network latency.
-func WithNetworkLatency(latency time.Duration) Option {
-	return func() {}
-}
-
-// WithSnapshotParams sets the raft snapshot parameters.
-func WithSnapshotParams(params SnapshotParams) Option {
 	return func() {}
 }
 

--- a/database/node_test.go
+++ b/database/node_test.go
@@ -20,17 +20,17 @@ import (
 	jujutesting "github.com/juju/juju/testing"
 )
 
-type optionSuite struct {
+type nodeManagerSuite struct {
 	testing.IsolationSuite
 }
 
-var _ = gc.Suite(&optionSuite{})
+var _ = gc.Suite(&nodeManagerSuite{})
 
-func (s *optionSuite) TestEnsureDataDirSuccess(c *gc.C) {
+func (s *nodeManagerSuite) TestEnsureDataDirSuccess(c *gc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
 	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
-	f := NewOptionFactory(cfg, stubLogger{})
+	f := NewNodeManager(cfg, stubLogger{})
 
 	expected := fmt.Sprintf("/tmp/%s/%s", subDir, dqliteDataDir)
 	s.AddCleanup(func(*gc.C) { _ = os.RemoveAll(cfg.DataDir()) })
@@ -51,8 +51,8 @@ func (s *optionSuite) TestEnsureDataDirSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *optionSuite) TestWithAddressOptionSuccess(c *gc.C) {
-	f := NewOptionFactory(nil, stubLogger{})
+func (s *nodeManagerSuite) TestWithAddressOptionSuccess(c *gc.C) {
+	f := NewNodeManager(nil, stubLogger{})
 
 	withAddress, err := f.WithAddressOption()
 	c.Assert(err, jc.ErrorIsNil)
@@ -63,9 +63,9 @@ func (s *optionSuite) TestWithAddressOptionSuccess(c *gc.C) {
 	_ = dqlite.Close()
 }
 
-func (s *optionSuite) TestWithTLSOptionSuccess(c *gc.C) {
+func (s *nodeManagerSuite) TestWithTLSOptionSuccess(c *gc.C) {
 	cfg := fakeAgentConfig{}
-	f := NewOptionFactory(cfg, stubLogger{})
+	f := NewNodeManager(cfg, stubLogger{})
 
 	withTLS, err := f.WithTLSOption()
 	c.Assert(err, jc.ErrorIsNil)
@@ -76,9 +76,9 @@ func (s *optionSuite) TestWithTLSOptionSuccess(c *gc.C) {
 	_ = dqlite.Close()
 }
 
-func (s *optionSuite) TestWithClusterOptionSuccess(c *gc.C) {
+func (s *nodeManagerSuite) TestWithClusterOptionSuccess(c *gc.C) {
 	// Hack to get a bind address to add to config.
-	h := NewOptionFactory(fakeAgentConfig{}, stubLogger{})
+	h := NewNodeManager(fakeAgentConfig{}, stubLogger{})
 	err := h.ensureBindAddress()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -90,7 +90,7 @@ func (s *optionSuite) TestWithClusterOptionSuccess(c *gc.C) {
 		},
 	}
 
-	f := NewOptionFactory(cfg, stubLogger{})
+	f := NewNodeManager(cfg, stubLogger{})
 
 	withCluster, err := f.WithClusterOption()
 	c.Assert(err, jc.ErrorIsNil)
@@ -101,15 +101,15 @@ func (s *optionSuite) TestWithClusterOptionSuccess(c *gc.C) {
 	_ = dqlite.Close()
 }
 
-func (s *optionSuite) TestWithClusterNotHASuccess(c *gc.C) {
+func (s *nodeManagerSuite) TestWithClusterNotHASuccess(c *gc.C) {
 	// Hack to get a bind address to add to config.
-	h := NewOptionFactory(fakeAgentConfig{}, stubLogger{})
+	h := NewNodeManager(fakeAgentConfig{}, stubLogger{})
 	err := h.ensureBindAddress()
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfg := fakeAgentConfig{apiAddrs: []string{h.bindAddress}}
 
-	f := NewOptionFactory(cfg, stubLogger{})
+	f := NewNodeManager(cfg, stubLogger{})
 
 	withCluster, err := f.WithClusterOption()
 	c.Assert(err, jc.ErrorIsNil)
@@ -120,7 +120,7 @@ func (s *optionSuite) TestWithClusterNotHASuccess(c *gc.C) {
 	_ = dqlite.Close()
 }
 
-func (s *optionSuite) TestIgnoreInterface(c *gc.C) {
+func (s *nodeManagerSuite) TestIgnoreInterface(c *gc.C) {
 	shouldIgnore := []string{
 		"lxdbr0",
 		"virbr0",

--- a/worker/changestream/worker.go
+++ b/worker/changestream/worker.go
@@ -20,13 +20,13 @@ type DBGetter = dbaccessor.DBGetter
 // ChangeStream represents a stream of changes that flows from the underlying
 // change log table in the database.
 type ChangeStream interface {
-	// Changes returns a channel for a given namespace. The channel will return
-	// change events that represent change log rows from the database. The
-	// change events will be monotically increasing events (monotonic in that
-	// they're always increasing, but not in that they're always sequential).
-	// The change events will be ordered by the row id and will be coalesced
-	// into a single change event if they are for the same entity and for the
-	// change type.
+	// Changes returns a channel for a given namespace (database).
+	// The channel will return events represented by change log rows
+	// from the database.
+	// The change event IDs will be monotonically increasing
+	// (though not necessarily sequential).
+	// Events will be coalesced into a single change if they are
+	// for the same entity and edit type.
 	Changes(namespace string) (<-chan changestream.ChangeEvent, error)
 }
 

--- a/worker/dbaccessor/manifold.go
+++ b/worker/dbaccessor/manifold.go
@@ -73,10 +73,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			agentConfig := agent.CurrentConfig()
 
 			cfg := WorkerConfig{
-				OptionFactory: database.NewOptionFactory(agentConfig, config.Logger),
-				Clock:         config.Clock,
-				Logger:        config.Logger,
-				NewApp:        config.NewApp,
+				NodeManager: database.NewNodeManager(agentConfig, config.Logger),
+				Clock:       config.Clock,
+				Logger:      config.Logger,
+				NewApp:      config.NewApp,
 			}
 
 			w, err := newWorker(cfg)

--- a/worker/dbaccessor/package_mock_test.go
+++ b/worker/dbaccessor/package_mock_test.go
@@ -51,6 +51,21 @@ func (mr *MockNodeManagerMockRecorder) EnsureDataDir() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDataDir", reflect.TypeOf((*MockNodeManager)(nil).EnsureDataDir))
 }
 
+// IsExistingNode mocks base method.
+func (m *MockNodeManager) IsExistingNode() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsExistingNode")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsExistingNode indicates an expected call of IsExistingNode.
+func (mr *MockNodeManagerMockRecorder) IsExistingNode() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsExistingNode", reflect.TypeOf((*MockNodeManager)(nil).IsExistingNode))
+}
+
 // WithAddressOption mocks base method.
 func (m *MockNodeManager) WithAddressOption() (app.Option, error) {
 	m.ctrl.T.Helper()

--- a/worker/dbaccessor/package_mock_test.go
+++ b/worker/dbaccessor/package_mock_test.go
@@ -13,31 +13,31 @@ import (
 	app "github.com/juju/juju/database/app"
 )
 
-// MockOptionFactory is a mock of OptionFactory interface.
-type MockOptionFactory struct {
+// MockNodeManager is a mock of NodeManager interface.
+type MockNodeManager struct {
 	ctrl     *gomock.Controller
-	recorder *MockOptionFactoryMockRecorder
+	recorder *MockNodeManagerMockRecorder
 }
 
-// MockOptionFactoryMockRecorder is the mock recorder for MockOptionFactory.
-type MockOptionFactoryMockRecorder struct {
-	mock *MockOptionFactory
+// MockNodeManagerMockRecorder is the mock recorder for MockNodeManager.
+type MockNodeManagerMockRecorder struct {
+	mock *MockNodeManager
 }
 
-// NewMockOptionFactory creates a new mock instance.
-func NewMockOptionFactory(ctrl *gomock.Controller) *MockOptionFactory {
-	mock := &MockOptionFactory{ctrl: ctrl}
-	mock.recorder = &MockOptionFactoryMockRecorder{mock}
+// NewMockNodeManager creates a new mock instance.
+func NewMockNodeManager(ctrl *gomock.Controller) *MockNodeManager {
+	mock := &MockNodeManager{ctrl: ctrl}
+	mock.recorder = &MockNodeManagerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockOptionFactory) EXPECT() *MockOptionFactoryMockRecorder {
+func (m *MockNodeManager) EXPECT() *MockNodeManagerMockRecorder {
 	return m.recorder
 }
 
 // EnsureDataDir mocks base method.
-func (m *MockOptionFactory) EnsureDataDir() (string, error) {
+func (m *MockNodeManager) EnsureDataDir() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureDataDir")
 	ret0, _ := ret[0].(string)
@@ -46,13 +46,13 @@ func (m *MockOptionFactory) EnsureDataDir() (string, error) {
 }
 
 // EnsureDataDir indicates an expected call of EnsureDataDir.
-func (mr *MockOptionFactoryMockRecorder) EnsureDataDir() *gomock.Call {
+func (mr *MockNodeManagerMockRecorder) EnsureDataDir() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDataDir", reflect.TypeOf((*MockOptionFactory)(nil).EnsureDataDir))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDataDir", reflect.TypeOf((*MockNodeManager)(nil).EnsureDataDir))
 }
 
 // WithAddressOption mocks base method.
-func (m *MockOptionFactory) WithAddressOption() (app.Option, error) {
+func (m *MockNodeManager) WithAddressOption() (app.Option, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithAddressOption")
 	ret0, _ := ret[0].(app.Option)
@@ -61,13 +61,13 @@ func (m *MockOptionFactory) WithAddressOption() (app.Option, error) {
 }
 
 // WithAddressOption indicates an expected call of WithAddressOption.
-func (mr *MockOptionFactoryMockRecorder) WithAddressOption() *gomock.Call {
+func (mr *MockNodeManagerMockRecorder) WithAddressOption() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithAddressOption", reflect.TypeOf((*MockOptionFactory)(nil).WithAddressOption))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithAddressOption", reflect.TypeOf((*MockNodeManager)(nil).WithAddressOption))
 }
 
 // WithClusterOption mocks base method.
-func (m *MockOptionFactory) WithClusterOption() (app.Option, error) {
+func (m *MockNodeManager) WithClusterOption() (app.Option, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithClusterOption")
 	ret0, _ := ret[0].(app.Option)
@@ -76,13 +76,13 @@ func (m *MockOptionFactory) WithClusterOption() (app.Option, error) {
 }
 
 // WithClusterOption indicates an expected call of WithClusterOption.
-func (mr *MockOptionFactoryMockRecorder) WithClusterOption() *gomock.Call {
+func (mr *MockNodeManagerMockRecorder) WithClusterOption() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithClusterOption", reflect.TypeOf((*MockOptionFactory)(nil).WithClusterOption))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithClusterOption", reflect.TypeOf((*MockNodeManager)(nil).WithClusterOption))
 }
 
 // WithLogFuncOption mocks base method.
-func (m *MockOptionFactory) WithLogFuncOption() app.Option {
+func (m *MockNodeManager) WithLogFuncOption() app.Option {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithLogFuncOption")
 	ret0, _ := ret[0].(app.Option)
@@ -90,13 +90,13 @@ func (m *MockOptionFactory) WithLogFuncOption() app.Option {
 }
 
 // WithLogFuncOption indicates an expected call of WithLogFuncOption.
-func (mr *MockOptionFactoryMockRecorder) WithLogFuncOption() *gomock.Call {
+func (mr *MockNodeManagerMockRecorder) WithLogFuncOption() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithLogFuncOption", reflect.TypeOf((*MockOptionFactory)(nil).WithLogFuncOption))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithLogFuncOption", reflect.TypeOf((*MockNodeManager)(nil).WithLogFuncOption))
 }
 
 // WithTLSOption mocks base method.
-func (m *MockOptionFactory) WithTLSOption() (app.Option, error) {
+func (m *MockNodeManager) WithTLSOption() (app.Option, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithTLSOption")
 	ret0, _ := ret[0].(app.Option)
@@ -105,9 +105,9 @@ func (m *MockOptionFactory) WithTLSOption() (app.Option, error) {
 }
 
 // WithTLSOption indicates an expected call of WithTLSOption.
-func (mr *MockOptionFactoryMockRecorder) WithTLSOption() *gomock.Call {
+func (mr *MockNodeManagerMockRecorder) WithTLSOption() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithTLSOption", reflect.TypeOf((*MockOptionFactory)(nil).WithTLSOption))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithTLSOption", reflect.TypeOf((*MockNodeManager)(nil).WithTLSOption))
 }
 
 // MockDBGetter is a mock of DBGetter interface.

--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -11,7 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -source worker.go -package dbaccessor -destination package_mock_test.go github.com/juju/juju/worker/dbaccessor Logger,DBApp,OptionFactory
+//go:generate go run github.com/golang/mock/mockgen -source worker.go -package dbaccessor -destination package_mock_test.go github.com/juju/juju/worker/dbaccessor Logger,DBApp,NodeManager
 //go:generate go run github.com/golang/mock/mockgen -package dbaccessor -destination logger_mock_test.go github.com/juju/juju/worker/dbaccessor Logger
 //go:generate go run github.com/golang/mock/mockgen -package dbaccessor -destination clock_mock_test.go github.com/juju/clock Clock
 

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -20,8 +20,8 @@ import (
 
 const replSocketFileName = "juju.sock"
 
-// OptionFactory creates Dqlite `App` initialisation arguments and options.
-type OptionFactory interface {
+// NodeManager creates Dqlite `App` initialisation arguments and options.
+type NodeManager interface {
 	// EnsureDataDir ensures that a directory for Dqlite data exists at
 	// a path determined by the agent config, then returns that path.
 	EnsureDataDir() (string, error)
@@ -55,15 +55,15 @@ type DBGetter interface {
 // WorkerConfig encapsulates the configuration options for the
 // dbaccessor worker.
 type WorkerConfig struct {
-	OptionFactory OptionFactory
-	Clock         clock.Clock
-	Logger        Logger
-	NewApp        func(string, ...app.Option) (DBApp, error)
+	NodeManager NodeManager
+	Clock       clock.Clock
+	Logger      Logger
+	NewApp      func(string, ...app.Option) (DBApp, error)
 }
 
 // Validate ensures that the config values are valid.
 func (c *WorkerConfig) Validate() error {
-	if c.OptionFactory == nil {
+	if c.NodeManager == nil {
 		return errors.NotValidf("missing Dqlite option factory")
 	}
 	if c.Clock == nil {
@@ -227,7 +227,7 @@ func (w *dbWorker) initializeDqlite() error {
 		return nil
 	}
 
-	opt := w.cfg.OptionFactory
+	opt := w.cfg.NodeManager
 
 	dataDir, err := opt.EnsureDataDir()
 	if err != nil {

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -18,7 +18,7 @@ import (
 type workerSuite struct {
 	baseSuite
 
-	optFactory *MockOptionFactory
+	nodeManager *MockNodeManager
 }
 
 var _ = gc.Suite(&workerSuite{})
@@ -28,7 +28,7 @@ func (s *workerSuite) TestGetControllerDBSuccess(c *gc.C) {
 
 	s.expectAnyLogs()
 
-	optExp := s.optFactory.EXPECT()
+	optExp := s.nodeManager.EXPECT()
 	optExp.EnsureDataDir().Return(c.MkDir(), nil)
 	optExp.WithAddressOption().Return(nil, nil)
 	optExp.WithClusterOption().Return(nil, nil)
@@ -55,15 +55,15 @@ func (s *workerSuite) TestGetControllerDBSuccess(c *gc.C) {
 
 func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
-	s.optFactory = NewMockOptionFactory(ctrl)
+	s.nodeManager = NewMockNodeManager(ctrl)
 	return ctrl
 }
 
 func (s *workerSuite) newWorker(c *gc.C) worker.Worker {
 	cfg := WorkerConfig{
-		OptionFactory: s.optFactory,
-		Clock:         s.clock,
-		Logger:        s.logger,
+		NodeManager: s.nodeManager,
+		Clock:       s.clock,
+		Logger:      s.logger,
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil
 		},

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -5,6 +5,7 @@ package dbaccessor
 
 import (
 	"database/sql"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	jc "github.com/juju/testing/checkers"
@@ -13,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/database/app"
+	"github.com/juju/juju/testing"
 )
 
 type workerSuite struct {
@@ -23,16 +25,17 @@ type workerSuite struct {
 
 var _ = gc.Suite(&workerSuite{})
 
-func (s *workerSuite) TestGetControllerDBSuccess(c *gc.C) {
+func (s *workerSuite) TestGetControllerDBSuccessNotExistingNode(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectAnyLogs()
 
-	optExp := s.nodeManager.EXPECT()
-	optExp.EnsureDataDir().Return(c.MkDir(), nil)
-	optExp.WithAddressOption().Return(nil, nil)
-	optExp.WithClusterOption().Return(nil, nil)
-	optExp.WithLogFuncOption().Return(nil)
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
+	mgrExp.IsExistingNode().Return(false, nil)
+	mgrExp.WithAddressOption().Return(nil, nil)
+	mgrExp.WithClusterOption().Return(nil, nil)
+	mgrExp.WithLogFuncOption().Return(nil)
 
 	appExp := s.dbApp.EXPECT()
 	appExp.Ready(gomock.Any()).Return(nil)
@@ -49,6 +52,43 @@ func (s *workerSuite) TestGetControllerDBSuccess(c *gc.C) {
 
 	_, err := getter.GetDB("controller")
 	c.Assert(err, jc.ErrorIsNil)
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectAnyLogs()
+
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
+
+	// If this is an existing node, we don't invoke
+	// the address or cluster options.
+	mgrExp.IsExistingNode().Return(true, nil)
+	mgrExp.WithLogFuncOption().Return(nil)
+
+	sync := make(chan struct{})
+
+	appExp := s.dbApp.EXPECT()
+	appExp.Ready(gomock.Any()).Return(nil)
+	appExp.ID().DoAndReturn(func() uint64 {
+		close(sync)
+		return uint64(666)
+	})
+	appExp.Open(gomock.Any(), "controller").Return(&sql.DB{}, nil)
+	appExp.Handover(gomock.Any()).Return(nil)
+	appExp.Close().Return(nil)
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	select {
+	case <-sync:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for synchronisation")
+	}
 
 	workertest.CleanKill(c, w)
 }


### PR DESCRIPTION
This is a preparatory patch, which does two main things:
- The `OptionFactory` is renamed to `NodeManager` in anticipation of its wider set of responsibilities.
- Said `NodeManager` includes a new method `IsExistingNode`, which is used by the db-accessor worker to eschew supplying options for bind address and cluster, if the host has previously been configured as a Dqlite node.

In addition, some of the shim infrastructure that we do not use has been removed from the `database` package in the interests of brevity.

## QA steps

- Bootstrap to LXD and enable HA.
- Once settled, run `juju debug-log -m controller --replay | grep dbaccessor`.
- You should observe the bootstrap node log the fact that it is already configured, followed by machines 1 and 2 indicating that they are being set up for the first time (abridged output):
```
machine-0: 12:45:05 INFO juju.worker.dbaccessor host is configured as a Dqlite node
machine-0: 12:45:05 INFO juju.worker.dbaccessor initialized Dqlite application (ID: 3297041220608546238)
...
machine-1: 12:46:36 INFO juju.worker.dbaccessor configuring host as a Dqlite node for the first time
machine-1: 12:46:36 DEBUG juju.worker.dbaccessor chose Dqlite bind address 10.246.27.109 from [10.246.27.109]
machine-1: 12:46:36 DEBUG juju.worker.dbaccessor determined Dqlite cluster members: [10.246.27.249:17666]
machine-1: 12:46:36 INFO juju.worker.dbaccessor initialized Dqlite application (ID: 17128632705061699021)
...
machine-2: 12:46:42 INFO juju.worker.dbaccessor configuring host as a Dqlite node for the first time
machine-2: 12:46:42 DEBUG juju.worker.dbaccessor chose Dqlite bind address 10.246.27.187 from [10.246.27.187]
machine-2: 12:46:42 DEBUG juju.worker.dbaccessor determined Dqlite cluster members: [10.246.27.249:17666]
machine-2: 12:47:27 INFO juju.worker.dbaccessor initialized Dqlite application (ID: 5758776007767032721)
```

## Documentation changes

None.

## Bug reference

N/A
