### PR TITLE
[JUJU-2823] Fix generate

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -28,9 +28,6 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: "go get dependencies"
-        run: go get ./...
-
       - name: "Install musl & dqlite"
         shell: bash
         run: |
@@ -56,6 +53,7 @@ jobs:
           #  3. Unique every file, so we only go generate the file once.
           #  4. Using xargs perform go generate in parallel.
           #
+          ls -la .
           make run-go-generate
 
       - name: "Check diff"

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -28,11 +28,6 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: "Install musl & dqlite"
-        shell: bash
-        run: |
-          sudo make musl-install dqlite-install
-
       - name: "Delete all mocks"
         shell: bash
         run: |
@@ -53,8 +48,7 @@ jobs:
           #  3. Unique every file, so we only go generate the file once.
           #  4. Using xargs perform go generate in parallel.
           #
-          ls -la .
-          make run-go-generate
+          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 2 -I% go generate -x $(realpath %)
 
       - name: "Check diff"
         if: success() || failure()

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 _build/
-_deps/
+_deps*
 cmd/juju/juju
 cmd/jujud/jujud
 cmd/builddb/builddb

--- a/Makefile
+++ b/Makefile
@@ -420,17 +420,6 @@ run-go-tests: musl-install-if-missing dqlite-install-if-missing
 		CGO_ENABLED=1 \
 		go test -v -mod=$(JUJU_GOMOD_MODE) -tags=$(BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) ${TEST_PACKAGES} -check.v -check.f $(TEST_FILTER)
 
-run-go-generate: musl-install-if-missing dqlite-install-if-missing
-## run-go-generate: Generate go code
-	@PATH=${MUSL_BIN_PATH}:${PATH} \
-		CC="musl-gcc" \
-		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
-		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
-		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
-		CGO_ENABLED=1 \
-		go generate -x ./...
-
 .PHONY: install
 install: rebuild-schema go-install
 ## install: Install Juju binaries with a rebuilt schema

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ run-tests: musl-install-if-missing dqlite-install-if-missing
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
-		go test -v -mod=$(JUJU_GOMOD_MODE) -tags=$(BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES) -check.v
+		go test -v -mod=$(JUJU_GOMOD_MODE) -tags=$(BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -ldflags ${CGO_LINK_FLAGS} -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES) -check.v
 	@rm -r $(TMP)
 
 run-go-tests: musl-install-if-missing dqlite-install-if-missing
@@ -418,7 +418,7 @@ run-go-tests: musl-install-if-missing dqlite-install-if-missing
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
-		go test -v -mod=$(JUJU_GOMOD_MODE) -tags=$(BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) ${TEST_PACKAGES} -check.v -check.f $(TEST_FILTER)
+		go test -v -mod=$(JUJU_GOMOD_MODE) -tags=$(BUILD_TAGS) $(TEST_ARGS) $(CHECK_ARGS) -ldflags ${CGO_LINK_FLAGS} -test.timeout=$(TEST_TIMEOUT) ${TEST_PACKAGES} -check.v -check.f $(TEST_FILTER)
 
 .PHONY: install
 install: rebuild-schema go-install


### PR DESCRIPTION
The following fixes the go generate command, by putting back to just using go generate directly. We can do this because we mock out the dqlite packages, allowing us to not setup the whole cgo tool chain.

Additionally, we now install amd64 musl from a cache build. This requires us passing ldflags into the go tests. This isn't always required and it's machine to machine dependent. I'm unsure why it's only required on some of them, but setting it for all of them works.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

go generate passes.