### PR TITLE
[JUJU-2837] Updates source for Ubuntu base Docker image.

### DIFF
--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM public.ecr.aws/ubuntu/ubuntu:20.04
 ARG TARGETOS
 ARG TARGETARCH
 ARG BUILDOS


### PR DESCRIPTION
Canonical only updates the Ubuntu image located on Dockerhub with patches once a month due to a policy by Docker hub. By moving to Canonicals official repository on AWS we can update our images with security patches much quicker as the update frequency is daily.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[] Go unit tests, with comments saying what you're testing~
- ~[x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

`make operator-image`

## Documentation changes

N/A

## Bug reference

N/A
