### PR TITLE
[JUJU-2844] Remove the "match" stanza from generated Netplan config

### DIFF
--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -183,11 +183,6 @@ func GenerateNetplan(interfaces corenetwork.InterfaceInfos) (string, error) {
 		if info.MTU != 0 && info.MTU != 1500 {
 			iface.MTU = info.MTU
 		}
-		if info.MACAddress != "" {
-			iface.Match = map[string]string{"macaddress": info.MACAddress}
-		} else {
-			iface.Match = map[string]string{"name": info.InterfaceName}
-		}
 		for _, route := range info.Routes {
 			route := netplan.Route{
 				To:     route.DestinationCIDR,

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -226,8 +226,6 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
     version: 2
     ethernets:
       any0:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f0
         addresses:
         - 0.1.2.3/24
         gateway4: 0.1.2.1
@@ -236,8 +234,6 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
           addresses: [ns1.invalid, ns2.invalid]
         mtu: 8317
       any1:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f1
         addresses:
         - 0.2.2.4/24
         gateway4: 0.2.2.1
@@ -249,19 +245,11 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
           via: 0.2.2.1
           metric: 50
       any2:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f2
         dhcp4: true
       any3:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f3
         dhcp4: true
-      any4:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f4
+      any4: {}
       any5:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f5
         addresses:
         - 2001:db8::dead:beef/64
         gateway6: 2001:db8::dead:f00
@@ -273,8 +261,6 @@ network:
   version: 2
   ethernets:
     any0:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f0
       addresses:
       - 0.1.2.3/24
       gateway4: 0.1.2.1
@@ -283,8 +269,6 @@ network:
         addresses: [ns1.invalid, ns2.invalid]
       mtu: 8317
     any1:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f1
       addresses:
       - 0.2.2.4/24
       gateway4: 0.2.2.1
@@ -296,19 +280,11 @@ network:
         via: 0.2.2.1
         metric: 50
     any2:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f2
       dhcp4: true
     any3:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f3
       dhcp4: true
-    any4:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f4
+    any4: {}
     any5:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f5
       addresses:
       - 2001:db8::dead:beef/64
       gateway6: 2001:db8::dead:f00
@@ -382,8 +358,6 @@ network:
   version: 2
   ethernets:
     any5:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f5
       addresses:
       - 2001:db8::dead:beef/64
       gateway6: 2001:db8::dead:f00


### PR DESCRIPTION
The thread in the linked bug describes a situation where a network device in the configuration we pass to container creation sometimes achieves a different MAC address to the one configured.

This has a symptom that the device gets no IP address, because the Netplan file that we render uses a `match` stanza that applies configuration based on matching the MAC address (that we configured, but did not receive). An example looks like this:
```yaml
network:
  version: 2
  ethernets:
    eth0:
      match:
        macaddress: 00:16:3e:39:b9:3e
      addresses:
      - 172.16.99.17/24
      gateway4: 172.16.99.1
      nameservers:
        search: [maas]
        addresses: [172.16.99.1]
      mtu: 1450
```

There is actually no need for the match stanza. The configuration will be applied by default to the device under which is nested, by ID.

Here we remove said stanza, ensuring that devices will get assigned IP addresses even when errant behaviour outside of Juju's control occurs.

## QA steps

- Bootstrap to a non-LXC cloud, and add a container-in-machine.
- The container should be provisioned and receive an IP address.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1991552
