### PR TITLE
[JUJU-2857] AWS instance tagging on creation

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -659,6 +659,22 @@ func (e *environ) StartInstance(
 	}
 	rootDiskSize := uint64(aws.ToInt32(blockDeviceMappings[0].Ebs.VolumeSize)) * 1024
 
+	instanceName := resourceName(
+		names.NewMachineTag(args.InstanceConfig.MachineId), e.Config().Name(),
+	)
+	args.InstanceConfig.Tags[tagName] = instanceName
+
+	instanceTags := CreateTagSpecification(types.ResourceTypeInstance, args.InstanceConfig.Tags)
+
+	cfg := e.Config()
+	rootVolumeTags := tags.ResourceTags(
+		names.NewModelTag(cfg.UUID()),
+		names.NewControllerTag(args.ControllerUUID),
+		cfg,
+	)
+	rootVolumeTags[tagName] = instanceName + "-root"
+	volumeTags := CreateTagSpecification(types.ResourceTypeVolume, rootVolumeTags)
+
 	var instResp *ec2.RunInstancesOutput
 	commonRunArgs := &ec2.RunInstancesInput{
 		MinCount:            aws.Int32(1),
@@ -674,6 +690,10 @@ func (e *environ) StartInstance(
 			// IMDSv2.
 			// Fixes lp1960568
 			HttpTokens: types.HttpTokensStateRequired,
+		},
+		TagSpecifications: []types.TagSpecification{
+			instanceTags,
+			volumeTags,
 		},
 	}
 
@@ -720,29 +740,6 @@ func (e *environ) StartInstance(
 		logger.Infof("started instance %q in AZ %q, subnet %q, VPC %q", inst.Id(), instAZ, instSubnet, instVPC)
 	} else {
 		logger.Infof("started instance %q in AZ %q", inst.Id(), instAZ)
-	}
-
-	// Tag instance, for accounting and identification.
-	instanceName := resourceName(
-		names.NewMachineTag(args.InstanceConfig.MachineId), e.Config().Name(),
-	)
-	args.InstanceConfig.Tags[tagName] = instanceName
-	if err := tagResources(e.ec2Client, ctx, args.InstanceConfig.Tags, string(inst.Id())); err != nil {
-		return nil, annotateWrapError(err, "tagging instance")
-	}
-
-	// Tag the machine's root EBS volume, if it has one.
-	if inst.i.RootDeviceType == "ebs" {
-		cfg := e.Config()
-		tags := tags.ResourceTags(
-			names.NewModelTag(cfg.UUID()),
-			names.NewControllerTag(args.ControllerUUID),
-			cfg,
-		)
-		tags[tagName] = instanceName + "-root"
-		if err := tagRootDisk(e.ec2Client, ctx, tags, &inst.i); err != nil {
-			return nil, annotateWrapError(err, "tagging root disk")
-		}
 	}
 
 	hc := instance.HardwareCharacteristics{
@@ -1153,70 +1150,6 @@ func tagResources(e Client, ctx context.ProviderCallContext, tags map[string]str
 		err = retry.LastError(err)
 	}
 	return maybeConvertCredentialError(err, ctx)
-}
-
-func tagRootDisk(e Client, ctx context.ProviderCallContext, tags map[string]string, inst *types.Instance) error {
-	if len(tags) == 0 {
-		return nil
-	}
-	findVolumeID := func(inst *types.Instance) string {
-		for _, m := range inst.BlockDeviceMappings {
-			if aws.ToString(m.DeviceName) != aws.ToString(inst.RootDeviceName) {
-				continue
-			}
-			if m.Ebs == nil {
-				continue
-			}
-			return aws.ToString(m.Ebs.VolumeId)
-		}
-		return ""
-	}
-	var volumeID string
-
-	retryStrategy := retry.CallArgs{
-		Clock:       clock.WallClock,
-		MaxDuration: 5 * time.Minute,
-		Delay:       5 * time.Second,
-	}
-	retryStrategy.IsFatalError = func(err error) bool {
-		if strings.HasSuffix(ec2ErrCode(err), ".NotFound") {
-			// EC2 calls are eventually consistent; if we get a
-			// NotFound error when looking up the instance we
-			// should retry until it appears or we run out of
-			// attempts.
-			logger.Debugf("instance %v is not available yet; retrying fetch of instance information", inst.InstanceId)
-			return false
-		} else if errors.IsNotFound(err) {
-			// Volume ID not found
-			return false
-		}
-		// No need to retry for other error types
-		return true
-	}
-	retryStrategy.Func = func() error {
-		// Refresh instance
-		resp, err := e.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-			InstanceIds: []string{aws.ToString(inst.InstanceId)},
-		})
-		if err != nil {
-			return err
-		}
-		if len(resp.Reservations) > 0 && len(resp.Reservations[0].Instances) > 0 {
-			inst = &resp.Reservations[0].Instances[0]
-		}
-
-		volumeID = findVolumeID(inst)
-		if volumeID == "" {
-			return errors.NewNotFound(nil, "Volume ID not found")
-		}
-		return nil
-	}
-	err := retry.Call(retryStrategy)
-	if retry.IsAttemptsExceeded(err) || retry.IsDurationExceeded(err) {
-		return errors.New("timed out waiting for EBS volume to be associated")
-	}
-
-	return tagResources(e, ctx, tags, volumeID)
 }
 
 var runInstances = _runInstances
@@ -2527,10 +2460,22 @@ func (e *environ) ensureGroup(ctx context.ProviderCallContext, controllerUUID, n
 		vpcIDParam = aws.String(chosenVPCID)
 	}
 
+	// Tag the created group with the model and controller UUIDs.
+	cfg := e.Config()
+	tags := tags.ResourceTags(
+		names.NewModelTag(cfg.UUID()),
+		names.NewControllerTag(controllerUUID),
+		cfg,
+	)
+	groupTagSpec := CreateTagSpecification(types.ResourceTypeSecurityGroup, tags)
+
 	groupResp, err := e.ec2Client.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
 		GroupName:   aws.String(name),
 		VpcId:       vpcIDParam,
 		Description: aws.String("juju group"),
+		TagSpecifications: []types.TagSpecification{
+			groupTagSpec,
+		},
 	})
 	if err != nil && ec2ErrCode(err) != "InvalidGroup.Duplicate" {
 		err = errors.Annotatef(maybeConvertCredentialError(err, ctx), "creating security group %q%s", name, inVPCLogSuffix)
@@ -2538,20 +2483,7 @@ func (e *environ) ensureGroup(ctx context.ProviderCallContext, controllerUUID, n
 	}
 
 	var have permSet
-	if err == nil {
-		groupID = aws.ToString(groupResp.GroupId)
-		// Tag the created group with the model and controller UUIDs.
-		cfg := e.Config()
-		tags := tags.ResourceTags(
-			names.NewModelTag(cfg.UUID()),
-			names.NewControllerTag(controllerUUID),
-			cfg,
-		)
-		if err := tagResources(e.ec2Client, ctx, tags, aws.ToString(groupResp.GroupId)); err != nil {
-			return groupID, errors.Annotate(err, "tagging security group")
-		}
-		logger.Debugf("created security group %q with ID %q%s", name, aws.ToString(groupResp.GroupId), inVPCLogSuffix)
-	} else {
+	if err != nil {
 		groups, err := e.securityGroupsByNameOrID(ctx, name)
 		if err != nil {
 			return "", errors.Annotatef(maybeConvertCredentialError(err, ctx), "fetching security group %q%s", name, inVPCLogSuffix)
@@ -2566,6 +2498,9 @@ func (e *environ) ensureGroup(ctx context.ProviderCallContext, controllerUUID, n
 		// so we ignore it.
 		groupID = aws.ToString(info.GroupId)
 		have = newPermSetForGroup(info.IpPermissions, &groupID)
+	} else {
+		groupID = aws.ToString(groupResp.GroupId)
+		logger.Debugf("created security group %q with ID %q%s", name, aws.ToString(groupResp.GroupId), inVPCLogSuffix)
 	}
 
 	want := newPermSetForGroup(perms, &groupID)
@@ -2833,4 +2768,22 @@ func (e *environ) SetCloudSpec(ctx stdcontext.Context, spec environscloudspec.Cl
 // This is part of the environs.FirewallFeatureQuerier interface.
 func (e *environ) SupportsRulesWithIPV6CIDRs(context.ProviderCallContext) (bool, error) {
 	return true, nil
+}
+
+// CreateTagSpecification creates an AWS tag specification for the given
+// resource type and tags.
+func CreateTagSpecification(resourceType types.ResourceType, tags map[string]string) types.TagSpecification {
+	spec := types.TagSpecification{
+		ResourceType: resourceType,
+		Tags:         make([]types.Tag, 0, len(tags)),
+	}
+
+	for k, v := range tags {
+		spec.Tags = append(spec.Tags, types.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
+	return spec
 }

--- a/provider/ec2/internal/testing/security_groups.go
+++ b/provider/ec2/internal/testing/security_groups.go
@@ -25,11 +25,13 @@ func (srv *Server) CreateSecurityGroup(ctx context.Context, in *ec2.CreateSecuri
 	if srv.group(types.GroupIdentifier{GroupName: in.GroupName}) != nil {
 		return nil, apiError("InvalidGroup.Duplicate", "group %q already exists", name)
 	}
+
 	g := &securityGroup{
 		name:        name,
 		description: aws.ToString(in.Description),
 		id:          fmt.Sprintf("sg-%d", srv.groupId.next()),
 		perms:       make(map[permKey]bool),
+		tags:        tagSpecForType(types.ResourceTypeSecurityGroup, in.TagSpecifications).Tags,
 	}
 	vpcId := aws.ToString(in.VpcId)
 	if vpcId != "" {
@@ -39,7 +41,7 @@ func (srv *Server) CreateSecurityGroup(ctx context.Context, in *ec2.CreateSecuri
 
 	resp := &ec2.CreateSecurityGroupOutput{
 		GroupId: aws.String(g.id),
-		Tags:    nil,
+		Tags:    g.tags,
 	}
 	return resp, nil
 }

--- a/provider/ec2/internal/testing/tags.go
+++ b/provider/ec2/internal/testing/tags.go
@@ -77,3 +77,24 @@ func matchTag(tags []types.Tag, key, value string) bool {
 	}
 	return false
 }
+
+func tagSpecForType(
+	resourceType types.ResourceType,
+	specs []types.TagSpecification,
+) (rval types.TagSpecification) {
+	rval = types.TagSpecification{
+		ResourceType: resourceType,
+	}
+	if specs == nil {
+		return
+	}
+
+	for _, spec := range specs {
+		if spec.ResourceType == resourceType {
+			rval = spec
+			return
+		}
+	}
+
+	return rval
+}


### PR DESCRIPTION
This change now makes Juju tag resources on creation rather then post creation. This allows users of complex AWS environments to meet strict policy for tagging of resources

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run the ec2 provider unit tests.

### Manual Testing

1. Bootstrap to AWS with `juju bootstrap aws/ap-southeast-2`
2. Once the bootstrap has completed find the ec2 instance with the aws cli using `aws ec2 describe-instances`. The easiest way to find the machine is based on the ip address reported during juju bootstrap.
3. Confirm the tags on the machine match the following (obviously the keys allowing for different values):
```json
 "Tags": [
                        {
                            "Key": "juju-is-controller",
                            "Value": "true"
                        },
                        {
                            "Key": "juju-model-uuid",
                            "Value": "f0249376-a41f-4ba7-856f-b752fbd4a245"
                        },
                        {
                            "Key": "juju-controller-uuid",
                            "Value": "e8fb08ee-239f-4bd2-80c8-63ec39bce0fe"
                        },
                        {
                            "Key": "Name",
                            "Value": "juju-controller-machine-0"
                        }
                    ],
```
4. From the machine found in step 2 confirm volume id found under block device mapping. Example `vol-0aa3b1e90c2ebd6d7`
5. Next step is to find the ec2 volume with `aws ec2 describe-volumes --region ap-southeast-2` and confirm the tags match the following:
```json
"Tags": [
                {
                    "Key": "Name",
                    "Value": "juju-controller-machine-0-root"
                },
                {
                    "Key": "juju-controller-uuid",
                    "Value": "e8fb08ee-239f-4bd2-80c8-63ec39bce0fe"
                },
                {
                    "Key": "juju-model-uuid",
                    "Value": "f0249376-a41f-4ba7-856f-b752fbd4a245"
                }
            ],
```
6. From the machine found step 2 confirm the security group ids attached to the machine. Example `sg-0bc32b06a18d279a8`
7. Next step is  to find the security group with `aws ec2 describe-security-groups --region ap-southeast-2` and confirm the tags match the following:
```json
"Tags": [
                {
                    "Key": "juju-model-uuid",
                    "Value": "f0249376-a41f-4ba7-856f-b752fbd4a245"
                },
                {
                    "Key": "juju-controller-uuid",
                    "Value": "e8fb08ee-239f-4bd2-80c8-63ec39bce0fe"
                }
            ],
```


## Documentation changes

N/A

## Bug reference

N/A
