### PR TITLE
Merge 2.9 into 3.0

### DIFF
--- a/caas/Dockerfile
+++ b/caas/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM public.ecr.aws/ubuntu/ubuntu:22.04
 ARG TARGETOS
 ARG TARGETARCH
 ARG BUILDOS

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -183,11 +183,6 @@ func GenerateNetplan(interfaces corenetwork.InterfaceInfos) (string, error) {
 		if info.MTU != 0 && info.MTU != 1500 {
 			iface.MTU = info.MTU
 		}
-		if info.MACAddress != "" {
-			iface.Match = map[string]string{"macaddress": info.MACAddress}
-		} else {
-			iface.Match = map[string]string{"name": info.InterfaceName}
-		}
 		for _, route := range info.Routes {
 			route := netplan.Route{
 				To:     route.DestinationCIDR,

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -220,8 +220,6 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
     version: 2
     ethernets:
       any0:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f0
         addresses:
         - 0.1.2.3/24
         gateway4: 0.1.2.1
@@ -230,8 +228,6 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
           addresses: [ns1.invalid, ns2.invalid]
         mtu: 8317
       any1:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f1
         addresses:
         - 0.2.2.4/24
         gateway4: 0.2.2.1
@@ -243,19 +239,11 @@ iface {ethaa_bb_cc_dd_ee_f5} inet6 static
           via: 0.2.2.1
           metric: 50
       any2:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f2
         dhcp4: true
       any3:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f3
         dhcp4: true
-      any4:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f4
+      any4: {}
       any5:
-        match:
-          macaddress: aa:bb:cc:dd:ee:f5
         addresses:
         - 2001:db8::dead:beef/64
         gateway6: 2001:db8::dead:f00
@@ -267,8 +255,6 @@ network:
   version: 2
   ethernets:
     any0:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f0
       addresses:
       - 0.1.2.3/24
       gateway4: 0.1.2.1
@@ -277,8 +263,6 @@ network:
         addresses: [ns1.invalid, ns2.invalid]
       mtu: 8317
     any1:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f1
       addresses:
       - 0.2.2.4/24
       gateway4: 0.2.2.1
@@ -290,19 +274,11 @@ network:
         via: 0.2.2.1
         metric: 50
     any2:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f2
       dhcp4: true
     any3:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f3
       dhcp4: true
-    any4:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f4
+    any4: {}
     any5:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f5
       addresses:
       - 2001:db8::dead:beef/64
       gateway6: 2001:db8::dead:f00
@@ -376,8 +352,6 @@ network:
   version: 2
   ethernets:
     any5:
-      match:
-        macaddress: aa:bb:cc:dd:ee:f5
       addresses:
       - 2001:db8::dead:beef/64
       gateway6: 2001:db8::dead:f00


### PR DESCRIPTION
Merge from 2.9 to bring forward:
- #15195 from juju/increment-to-2.9.41
- #15194 from manadart/2.9-netplan-omit-match
- #15192 from tlm/updated-docker-images
- #15142 from cprivitere/fix-lxd-init

Trivial version-based conflicts.
