### PR TITLE
Add missing AWS regions

### DIFF
--- a/cloud/fallback-public-cloud.yaml
+++ b/cloud/fallback-public-cloud.yaml
@@ -23,22 +23,30 @@ clouds:
         endpoint: https://ec2.eu-west-3.amazonaws.com
       eu-central-1:
         endpoint: https://ec2.eu-central-1.amazonaws.com
+      eu-central-2:
+        endpoint: https://ec2.eu-central-2.amazonaws.com
       eu-north-1:
         endpoint: https://ec2.eu-north-1.amazonaws.com
       eu-south-1:
         endpoint: https://ec2.eu-south-1.amazonaws.com
+      eu-south-2:
+        endpoint: https://ec2.eu-south-2.amazonaws.com
       af-south-1:
         endpoint: https://ec2.af-south-1.amazonaws.com
       ap-east-1:
         endpoint: https://ec2.ap-east-1.amazonaws.com
       ap-south-1:
         endpoint: https://ec2.ap-south-1.amazonaws.com
+      ap-south-2:
+        endpoint: https://ec2.ap-south-2.amazonaws.com
       ap-southeast-1:
         endpoint: https://ec2.ap-southeast-1.amazonaws.com
       ap-southeast-2:
         endpoint: https://ec2.ap-southeast-2.amazonaws.com
       ap-southeast-3:
         endpoint: https://ec2.ap-southeast-3.amazonaws.com
+      ap-southeast-4:
+        endpoint: https://ec2.ap-southeast-4.amazonaws.com
       ap-northeast-1:
         endpoint: https://ec2.ap-northeast-1.amazonaws.com
       ap-northeast-2:
@@ -47,6 +55,8 @@ clouds:
         endpoint: https://ec2.ap-northeast-3.amazonaws.com
       me-south-1:
         endpoint: https://ec2.me-south-1.amazonaws.com
+      me-central-1:
+        endpoint: https://ec2.me-central-1.amazonaws.com
       sa-east-1:
         endpoint: https://ec2.sa-east-1.amazonaws.com
   aws-china:

--- a/cloud/fallback_public_cloud.go
+++ b/cloud/fallback_public_cloud.go
@@ -30,22 +30,30 @@ clouds:
         endpoint: https://ec2.eu-west-3.amazonaws.com
       eu-central-1:
         endpoint: https://ec2.eu-central-1.amazonaws.com
+      eu-central-2:
+        endpoint: https://ec2.eu-central-2.amazonaws.com
       eu-north-1:
         endpoint: https://ec2.eu-north-1.amazonaws.com
       eu-south-1:
         endpoint: https://ec2.eu-south-1.amazonaws.com
+      eu-south-2:
+        endpoint: https://ec2.eu-south-2.amazonaws.com
       af-south-1:
         endpoint: https://ec2.af-south-1.amazonaws.com
       ap-east-1:
         endpoint: https://ec2.ap-east-1.amazonaws.com
       ap-south-1:
         endpoint: https://ec2.ap-south-1.amazonaws.com
+      ap-south-2:
+        endpoint: https://ec2.ap-south-2.amazonaws.com
       ap-southeast-1:
         endpoint: https://ec2.ap-southeast-1.amazonaws.com
       ap-southeast-2:
         endpoint: https://ec2.ap-southeast-2.amazonaws.com
       ap-southeast-3:
         endpoint: https://ec2.ap-southeast-3.amazonaws.com
+      ap-southeast-4:
+        endpoint: https://ec2.ap-southeast-4.amazonaws.com
       ap-northeast-1:
         endpoint: https://ec2.ap-northeast-1.amazonaws.com
       ap-northeast-2:
@@ -54,6 +62,8 @@ clouds:
         endpoint: https://ec2.ap-northeast-3.amazonaws.com
       me-south-1:
         endpoint: https://ec2.me-south-1.amazonaws.com
+      me-central-1:
+        endpoint: https://ec2.me-central-1.amazonaws.com
       sa-east-1:
         endpoint: https://ec2.sa-east-1.amazonaws.com
   aws-china:

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2114,8 +2114,8 @@ ap-southeast-4
 ap-northeast-1
 ap-northeast-2
 ap-northeast-3
-me-central-1
 me-south-1
+me-central-1
 sa-east-1
 `[1:])
 }

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2099,17 +2099,22 @@ eu-west-1
 eu-west-2
 eu-west-3
 eu-central-1
+eu-central-2
 eu-north-1
 eu-south-1
+eu-south-2
 af-south-1
 ap-east-1
 ap-south-1
+ap-south-2
 ap-southeast-1
 ap-southeast-2
 ap-southeast-3
+ap-southeast-4
 ap-northeast-1
 ap-northeast-2
 ap-northeast-3
+me-central-1
 me-south-1
 sa-east-1
 `[1:])
@@ -2119,7 +2124,7 @@ func (s *BootstrapSuite) TestBootstrapInvalidRegion(c *gc.C) {
 	resetJujuXDGDataHome(c)
 	ctx, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(), "aws/eu-west")
 	c.Assert(err, gc.ErrorMatches, `region "eu-west" for cloud "aws" not valid`)
-	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ap-southeast-3, ca-central-1, eu-central-1, eu-north-1, eu-south-1, eu-west-1, eu-west-2, eu-west-3, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "Available cloud regions are af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2, ap-southeast-3, ap-southeast-4, ca-central-1, eu-central-1, eu-central-2, eu-north-1, eu-south-1, eu-south-2, eu-west-1, eu-west-2, eu-west-3, me-central-1, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2\n")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, ``)
 }
 


### PR DESCRIPTION
*Why this change is needed and what it does.*

It's required to be able to use (kind of) newer AWS regions.


