### PR TITLE
[JUJU-2741] Add IsBootstrappedNode method to NodeManager

### DIFF
--- a/database/client/dqlite_linux.go
+++ b/database/client/dqlite_linux.go
@@ -10,6 +10,14 @@ import (
 	"github.com/canonical/go-dqlite/client"
 )
 
+// YamlNodeStore persists a list addresses of dqlite nodes in a YAML file.
+type YamlNodeStore = client.YamlNodeStore
+
+// NewYamlNodeStore creates a new YamlNodeStore backed by the given YAML file.
+func NewYamlNodeStore(path string) (*YamlNodeStore, error) {
+	return client.NewYamlNodeStore(path)
+}
+
 // LogFunc is a function that can be used for logging.
 type LogFunc = client.LogFunc
 

--- a/database/client/dqlite_other.go
+++ b/database/client/dqlite_other.go
@@ -11,6 +11,20 @@ import (
 	"net"
 )
 
+type NodeInfo struct {
+	Address string
+}
+
+type YamlNodeStore struct{}
+
+func NewYamlNodeStore(_ string) (*YamlNodeStore, error) {
+	return &YamlNodeStore{}, nil
+}
+
+func (s *YamlNodeStore) Get(_ context.Context) ([]NodeInfo, error) {
+	return nil, nil
+}
+
 // LogFunc is a function that can be used for logging.
 type LogFunc = func(LogLevel, string, ...interface{})
 


### PR DESCRIPTION
The `NodeManager` has a new method `IsBootstrappedNode`, which will be used in a forthcoming patch to determine whether the current host is where we bootstrapped Dqlite, and whether it has been reconfigured since bootstrap.

It will inform branching logic when moving into HA.

Some new functionality from upstream Dqlite is now referenced, with the non-Linux shim updated accordingly.

## QA steps

Tests pass. This functionality is not yet recruited in-theatre.

## Documentation changes

None.

## Bug reference

N/A
