### PR TITLE
Enabled deploy_aks suite

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -51,6 +51,7 @@ TEST_NAMES="agents \
             credential \
             ck \
             deploy \
+            deploy_aks \
             deploy_caas \
             expose_ec2 \
             hooks \

--- a/tests/suites/deploy_aks/deploy_aks.sh
+++ b/tests/suites/deploy_aks/deploy_aks.sh
@@ -11,7 +11,8 @@ run_deploy_aks_charms() {
 	juju deploy mattermost-k8s
 	juju relate mattermost-k8s postgresql-k8s:db
 
-	wait_for 2 '[.applications[] | select(."application-status".current == "active")] | length'
+	wait_for "postgresql-k8s" "$(idle_condition "postgresql-k8s" 1)"
+	wait_for "mattermost-k8s" "$(idle_condition "mattermost-k8s" 0)"
 
 	# TODO(anvial): we can return this check after fixing issue with flapping connection by curl in aks environment.
 	#	echo "Verify application is reachable"


### PR DESCRIPTION
This PR adds a suite in `tests/main.sh` list to generate tests in `juju-qa-jenkins`. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

none
