### PR TITLE
[JUJU-2874] Dqlite dependency bump

### DIFF
--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -31,9 +31,9 @@ TAG_LIBTIRPC=upstream/1.3.3
 TAG_LIBNSL=v2.0.0
 TAG_LIBUV=v1.44.2
 TAG_LIBLZ4=v1.9.4
-TAG_RAFT=v0.16.0
+TAG_RAFT=v0.17.1
 TAG_SQLITE=version-3.40.0
-TAG_DQLITE=v1.12.0
+TAG_DQLITE=v1.14.0
 
 S3_BUCKET=s3://dqlite-static-libs
 S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${BUILD_ARCH}.tar.bz2


### PR DESCRIPTION
Bump the dqlite dependencies so that we can take advantage of the new changes. In reality, we actually need to use these latest dependencies so we can also bring in the latest LXD code. This code[1] moves the C code out of the shared package in the lxd project. This then allows us to cross-compile on different OSes and architectures easily. Unblocking the following PR[2]  that's currently in draft.

The process for the dependency bump is the following:

 - Bump the tags for the dependencies in env.sh
 - Test they work with `make dqlite-build-lxd`
 - Push them up to a branch and merge (can be a feature branch, but must be under juju/juju namespace).
 - Run the changes in jenkins[3]
 - Update the SHAs in dqlite-install.sh and push the changes to develop.

This process should ensure that we have staged and secured the build artefacts, before deploying them to everyone else.

We might want to consider running a script to test if the dependencies are at the right sha, but that can be for another PR.

 1. https://github.com/lxc/lxd/pull/11376
 2. https://github.com/juju/juju/pull/15183
 3. https://jenkins.juju.canonical.com/job/build-dqlite/

## QA steps

```sh
$ make dqlite-build-lxd
```