### PR TITLE
[JUJU-2821] Add (S3) object storage endpoint for charms 

### DIFF
--- a/apiserver/httpcontext/model_test.go
+++ b/apiserver/httpcontext/model_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/httpcontext"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -20,6 +21,7 @@ type ModelHandlersSuite struct {
 	testing.IsolationSuite
 	impliedHandler *httpcontext.ImpliedModelHandler
 	queryHandler   *httpcontext.QueryModelHandler
+	bucketHandler  *httpcontext.BucketModelHandler
 	server         *httptest.Server
 }
 
@@ -38,9 +40,14 @@ func (s *ModelHandlersSuite) SetUpTest(c *gc.C) {
 		Handler: h,
 		Query:   "modeluuid",
 	}
-	mux := http.NewServeMux()
-	mux.Handle("/query", s.queryHandler)
-	mux.Handle("/implied", s.impliedHandler)
+	s.bucketHandler = &httpcontext.BucketModelHandler{
+		Handler: h,
+		Query:   ":bucket",
+	}
+	mux := apiserverhttp.NewMux()
+	mux.AddHandler("GET", "/query", s.queryHandler)
+	mux.AddHandler("GET", "/implied", s.impliedHandler)
+	mux.AddHandler("GET", "/:bucket/charms/:object", s.bucketHandler)
 	s.server = httptest.NewServer(mux)
 }
 
@@ -80,4 +87,37 @@ func (s *ModelHandlersSuite) TestQueryInvalidModelUUID(c *gc.C) {
 	out, err := io.ReadAll(resp.Body)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(out), gc.Equals, `invalid model UUID "zing"`+"\n")
+}
+
+func (s *ModelHandlersSuite) TestBucket(c *gc.C) {
+	resp, err := s.server.Client().Get(s.server.URL + "/model-" + coretesting.ModelTag.Id() + "/charms/somecharm-abcd0123")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+	defer resp.Body.Close()
+
+	out, err := io.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, coretesting.ModelTag.Id())
+}
+
+func (s *ModelHandlersSuite) TestInvalidBucket(c *gc.C) {
+	resp, err := s.server.Client().Get(s.server.URL + "/modelwrongbucket/charms/somecharm-abcd0123")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusBadRequest)
+	defer resp.Body.Close()
+
+	out, err := io.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `invalid bucket format "modelwrongbucket"`+"\n")
+}
+
+func (s *ModelHandlersSuite) TestBucketInvalidModelUUID(c *gc.C) {
+	resp, err := s.server.Client().Get(s.server.URL + "/model-wrongbucket/charms/somecharm-abcd0123")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusBadRequest)
+	defer resp.Body.Close()
+
+	out, err := io.ReadAll(resp.Body)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(out), gc.Equals, `invalid model UUID "wrongbucket"`+"\n")
 }

--- a/apiserver/objects.go
+++ b/apiserver/objects.go
@@ -1,0 +1,80 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+type objectsCharmHTTPHandler struct {
+	GetHandler          FailableHandlerFunc
+	LegacyCharmsHandler http.Handler
+}
+
+func (h *objectsCharmHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var err error
+	switch r.Method {
+	case "GET":
+		err = errors.Annotate(h.GetHandler(w, r), "cannot retrieve charm")
+		if err == nil {
+			// Chain call to legacy (REST API) charms handler
+			h.LegacyCharmsHandler.ServeHTTP(w, r)
+		}
+	default:
+		http.Error(w, fmt.Sprintf("http method %s not implemented", r.Method), http.StatusNotImplemented)
+		return
+	}
+
+	if err != nil {
+		if err := sendJSONError(w, r, errors.Trace(err)); err != nil {
+			logger.Errorf("%v", errors.Annotate(err, "cannot return error to user"))
+		}
+	}
+
+}
+
+// objectsCharmHandler handles charm upload through S3-compatible HTTPS in the
+// API server.
+type objectsCharmHandler struct {
+	ctxt httpContext
+}
+
+// ServeGet serves the GET method for the S3 API. This is the equivalent of the
+// `GetObject` method in the AWS S3 API.
+// Since juju's objects (S3) API only acts as a shim, this method will only
+// rewrite the http request for it to be correctly processed by the legacy
+// '/charms' handler.
+func (h *objectsCharmHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
+	st, _, err := h.ctxt.stateForRequestAuthenticated(r)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer st.Release()
+
+	query := r.URL.Query()
+	charmObjectID := query.Get(":object")
+
+	// Path param is {charmName}-{charmSha256[0:7]} so we need to split it.
+	charmSplit := strings.Split(charmObjectID, "-")
+	if len(charmSplit) < 2 {
+		return errors.NewBadRequest(errors.New(fmt.Sprintf("wrong charms object path %q", charmObjectID)), "")
+	}
+	charmSha256 := charmSplit[len(charmSplit)-1]
+
+	// Retrieve charm from state.
+	ch, err := st.CharmFromSha256(charmSha256)
+	if err != nil {
+		return errors.Annotate(err, "cannot get charm from state")
+	}
+
+	query.Add("url", ch.URL().String())
+	query.Add("file", "*")
+	r.URL.RawQuery = query.Encode()
+
+	return nil
+}

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -1,0 +1,104 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	apitesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/rpc/params"
+)
+
+type objectsSuite struct {
+	apiserverBaseSuite
+}
+
+var _ = gc.Suite(&objectsSuite{})
+
+func (s *objectsSuite) SetUpSuite(c *gc.C) {
+	s.apiserverBaseSuite.SetUpSuite(c)
+}
+
+func (s *objectsSuite) objectsCharmsURL(charmurl string) *url.URL {
+	return s.URL(fmt.Sprintf("/model-%s/charms/%s", s.State.ModelUUID(), charmurl), nil)
+}
+
+func (s *objectsSuite) objectsCharmsURI(charmurl string) string {
+	return s.objectsCharmsURL(charmurl).String()
+}
+
+func (s *objectsSuite) assertResponse(c *gc.C, resp *http.Response, expStatus int) params.CharmsResponse {
+	body := apitesting.AssertResponse(c, resp, expStatus, params.ContentTypeJSON)
+	var charmResponse params.CharmsResponse
+	err := json.Unmarshal(body, &charmResponse)
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("body: %s", body))
+	return charmResponse
+}
+
+func (s *objectsSuite) assertErrorResponse(c *gc.C, resp *http.Response, expCode int, expError string) {
+	charmResponse := s.assertResponse(c, resp, expCode)
+	c.Check(charmResponse.Error, gc.Matches, expError)
+}
+
+func (s *objectsSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBody, expContentType string) {
+	body := apitesting.AssertResponse(c, resp, http.StatusOK, expContentType)
+	c.Check(string(body), gc.Equals, expBody)
+}
+
+func (s *objectsSuite) TestObjectsCharmsServedSecurely(c *gc.C) {
+	url := s.objectsCharmsURL("")
+	url.Scheme = "http"
+	apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:       "GET",
+		URL:          url.String(),
+		ExpectStatus: http.StatusBadRequest,
+	})
+}
+
+func (s *objectsSuite) TestGETRequiresAuth(c *gc.C) {
+	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("somecharm-abcd0123")})
+	body := apitesting.AssertResponse(c, resp, http.StatusUnauthorized, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "authentication failed: no credentials provided\n")
+}
+
+func (s *objectsSuite) TestOnlyMethodGET(c *gc.C) {
+	resp := s.sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "PUT", URL: s.objectsCharmsURI("somecharm-abcd0123")})
+	body := apitesting.AssertResponse(c, resp, http.StatusMethodNotAllowed, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "Method Not Allowed\n")
+}
+
+func (s *objectsSuite) TestGetFailsWithInvalidObjectSha256(c *gc.C) {
+	uri := s.objectsCharmsURI("invalidsha256")
+	resp := s.sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
+	s.assertErrorResponse(
+		c, resp, http.StatusBadRequest,
+		`.*wrong charms object path "invalidsha256"$`,
+	)
+}
+
+func (s *objectsSuite) TestInvalidBucket(c *gc.C) {
+	wrongURL := s.URL("modelwrongbucket/charms/somecharm-abcd0123", nil)
+	resp := s.sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: wrongURL.String()})
+	body := apitesting.AssertResponse(c, resp, http.StatusBadRequest, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "invalid bucket format \"modelwrongbucket\"\n")
+}
+
+func (s *objectsSuite) TestInvalidModel(c *gc.C) {
+	wrongURL := s.URL("model-wrongbucket/charms/somecharm-abcd0123", nil)
+	resp := s.sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: wrongURL.String()})
+	body := apitesting.AssertResponse(c, resp, http.StatusBadRequest, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "invalid model UUID \"wrongbucket\"\n")
+}
+
+func (s *objectsSuite) TestInvalidObject(c *gc.C) {
+	resp := s.sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.objectsCharmsURI("invalidcharm")})
+	body := apitesting.AssertResponse(c, resp, http.StatusBadRequest, "application/json")
+	c.Assert(string(body), gc.Equals, "{\"error\":\"cannot retrieve charm: wrong charms object path \\\"invalidcharm\\\"\",\"error-code\":\"bad request\"}")
+}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -228,6 +228,8 @@ func allCollections() CollectionSchema {
 		charmsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid"},
+			}, {
+				Key: []string{"bundlesha256"},
 			}},
 		},
 		applicationsC: {


### PR DESCRIPTION
This is the first task of the epic consisting of charm download using S3 (compatible) endpoint(s). 

In this PR I added the support to download a charm using a S3-compatible client from our apiserver. The new endpoint is properly described in the spec: https://docs.google.com/document/d/1jXb7MOi1vz7wyOFitAZHLiOM7d6dKjIQFFBSElfdIME

- `GET /model-:modeluuid/charms/:charm-unique-identifier`

The *actual* charm download mechanism will be implemented in a different PR, so this is only a new endpoint on the apiserver.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This simply adds a new endpoint which is not used, so nothing to QA actually.
