### PR TITLE
[JUJU-2880] Selectively generate Netplan "match" stanza

### DIFF
--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -115,7 +115,7 @@ func (cfg *centOSCloudConfig) PackagePreferences() []packaging.PackagePreference
 	return []packaging.PackagePreferences{}
 }
 
-// Render is defined on the the Renderer interface.
+// RenderYAML is defined on the the Renderer interface.
 func (cfg *centOSCloudConfig) RenderYAML() ([]byte, error) {
 	// Save the fields that we will modify
 	var oldruncmds []string
@@ -258,6 +258,6 @@ func (cfg *centOSCloudConfig) updateProxySettings(PackageManagerProxyConfig) err
 
 // AddNetworkConfig is defined on the NetworkingConfig interface.
 // TODO(wpk) This has to be implemented for CentOS on VSphere to work properly!
-func (cfg *centOSCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error {
+func (cfg *centOSCloudConfig) AddNetworkConfig(corenetwork.InterfaceInfos, bool) error {
 	return nil
 }

--- a/cloudconfig/cloudinit/cloudinit_win.go
+++ b/cloudconfig/cloudinit/cloudinit_win.go
@@ -122,6 +122,6 @@ func (cfg *windowsCloudConfig) updateProxySettings(PackageManagerProxyConfig) er
 }
 
 // AddNetworkConfig is defined on the NetworkingConfig interface.
-func (cfg *windowsCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error {
+func (cfg *windowsCloudConfig) AddNetworkConfig(corenetwork.InterfaceInfos, bool) error {
 	return nil
 }

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -33,8 +33,6 @@ type CloudConfig interface {
 	// GetSeries returns the series this CloudConfig was made for.
 	GetSeries() string
 
-	// CloudConfig also contains all the smaller interfaces for config
-	// management:
 	UsersConfig
 	SystemUpdateConfig
 	SystemUpgradeConfig
@@ -291,8 +289,8 @@ type RootUserConfig interface {
 	// This option is set to true (ie. disabled) by default.
 	SetDisableRoot(bool)
 
-	// UnsetDisable unsets the value set with SetDisableRoot, returning it to the
-	// cloudinit-defined default of true.
+	// UnsetDisableRoot unsets the value set with SetDisableRoot,
+	// returning it to the cloudinit-defined default of true.
 	UnsetDisableRoot()
 
 	// DisableRoot returns the value set by SetDisableRoot or false if the
@@ -413,7 +411,7 @@ type HostnameConfig interface {
 // NetworkingConfig is the interface for managing configuration of network
 type NetworkingConfig interface {
 	// AddNetworkConfig adds network config from interfaces to the container.
-	AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error
+	AddNetworkConfig(interfaces corenetwork.InterfaceInfos, matchHWAddr bool) error
 }
 
 // New returns a new Config with no options set.

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -322,12 +322,12 @@ func (s *NetworkUbuntuSuite) TestGenerateENIConfig(c *gc.C) {
 }
 
 func (s *NetworkUbuntuSuite) TestGenerateNetplan(c *gc.C) {
-	data, err := cloudinit.GenerateNetplan(nil)
+	data, err := cloudinit.GenerateNetplan(nil, true)
 	c.Assert(err, gc.ErrorMatches, "missing container network config")
 	c.Assert(data, gc.Equals, "")
 
 	netConfig := container.BridgeNetworkConfig(0, s.fakeInterfaces)
-	data, err = cloudinit.GenerateNetplan(netConfig.Interfaces)
+	data, err = cloudinit.GenerateNetplan(netConfig.Interfaces, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(data, gc.Equals, s.expectedFullNetplan)
 }
@@ -350,7 +350,7 @@ func (s *NetworkUbuntuSuite) TestGenerateNetplanSkipIPv6LinkLocalDNS(c *gc.C) {
 	}}
 
 	netConfig := container.BridgeNetworkConfig(0, s.fakeInterfaces)
-	data, err := cloudinit.GenerateNetplan(netConfig.Interfaces)
+	data, err := cloudinit.GenerateNetplan(netConfig.Interfaces, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(data, gc.Equals, `
@@ -364,12 +364,37 @@ network:
 `[1:])
 }
 
+func (s *NetworkUbuntuSuite) TestGenerateNetplanWithMatchStanza(c *gc.C) {
+	s.fakeInterfaces = corenetwork.InterfaceInfos{{
+		InterfaceName: "any5",
+		ConfigType:    corenetwork.ConfigStatic,
+		MACAddress:    "aa:bb:cc:dd:ee:f5",
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewMachineAddress("10.0.0.5", corenetwork.WithCIDR("10.0.0.0/8")).AsProviderAddress()},
+	}}
+
+	netConfig := container.BridgeNetworkConfig(0, s.fakeInterfaces)
+	data, err := cloudinit.GenerateNetplan(netConfig.Interfaces, true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(data, gc.Equals, `
+network:
+  version: 2
+  ethernets:
+    any5:
+      match:
+        macaddress: aa:bb:cc:dd:ee:f5
+      addresses:
+      - 10.0.0.5/8
+`[1:])
+}
+
 func (s *NetworkUbuntuSuite) TestAddNetworkConfigSampleConfig(c *gc.C) {
 	netConfig := container.BridgeNetworkConfig(0, s.fakeInterfaces)
 	cloudConf, err := cloudinit.New("xenial")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudConf, gc.NotNil)
-	err = cloudConf.AddNetworkConfig(netConfig.Interfaces)
+	err = cloudConf.AddNetworkConfig(netConfig.Interfaces, false)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected := s.expectedSampleConfigHeader

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -31,7 +31,7 @@ func WriteUserData(
 	networkConfig *container.NetworkConfig,
 	directory string,
 ) (string, error) {
-	userData, err := CloudInitUserData(instanceConfig, networkConfig)
+	userData, err := CloudInitUserData(instanceConfig, networkConfig, true)
 	if err != nil {
 		logger.Errorf("failed to create user data: %v", err)
 		return "", err
@@ -53,6 +53,7 @@ func WriteCloudInitFile(directory string, userData []byte) (string, error) {
 func CloudInitUserData(
 	instanceConfig *instancecfg.InstanceConfig,
 	networkConfig *container.NetworkConfig,
+	matchHWAddr bool,
 ) ([]byte, error) {
 	cloudConfig, err := cloudinit.New(instanceConfig.Series)
 	if err != nil {
@@ -62,7 +63,7 @@ func CloudInitUserData(
 	if networkConfig != nil {
 		interfaces = networkConfig.Interfaces
 	}
-	err = cloudConfig.AddNetworkConfig(interfaces)
+	err = cloudConfig.AddNetworkConfig(interfaces, matchHWAddr)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -78,7 +78,7 @@ func CloudInitDataExcludingOutputSection(data string) []string {
 func (s *UserDataSuite) TestCloudInitUserDataNoNetworkConfig(c *gc.C) {
 	instanceConfig, err := containertesting.MockMachineConfig("1/lxd/0")
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := containerinit.CloudInitUserData(instanceConfig, nil)
+	data, err := containerinit.CloudInitUserData(instanceConfig, nil, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.NotNil)
 
@@ -99,7 +99,7 @@ func (s *UserDataSuite) TestCloudInitUserDataSomeNetworkConfig(c *gc.C) {
 		ConfigType:    network.ConfigDHCP,
 	}}
 	netConfig := container.BridgeNetworkConfig(0, nics)
-	data, err := containerinit.CloudInitUserData(instanceConfig, netConfig)
+	data, err := containerinit.CloudInitUserData(instanceConfig, netConfig, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.NotNil)
 

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -247,7 +247,7 @@ func (m *containerManager) getContainerSpec(
 
 	// CloudInitUserData creates our own ENI/netplan.
 	// We need to disable cloud-init networking to make it work.
-	userData, err := containerinit.CloudInitUserData(instanceConfig, networkConfig)
+	userData, err := containerinit.CloudInitUserData(instanceConfig, networkConfig, false)
 	if err != nil {
 		return ContainerSpec{}, errors.Trace(err)
 	}

--- a/provider/lxd/environ_broker.go
+++ b/provider/lxd/environ_broker.go
@@ -209,7 +209,7 @@ func (env *environ) getContainerSpec(
 		if err != nil {
 			return cSpec, errors.Trace(err)
 		}
-		if err := cloudCfg.AddNetworkConfig(info); err != nil {
+		if err := cloudCfg.AddNetworkConfig(info, false); err != nil {
 			return cSpec, errors.Trace(err)
 		}
 

--- a/provider/openstack/cloud_mock_test.go
+++ b/provider/openstack/cloud_mock_test.go
@@ -35,15 +35,15 @@ func (m *MockNetworkingConfig) EXPECT() *MockNetworkingConfigMockRecorder {
 }
 
 // AddNetworkConfig mocks base method.
-func (m *MockNetworkingConfig) AddNetworkConfig(arg0 network.InterfaceInfos) error {
+func (m *MockNetworkingConfig) AddNetworkConfig(arg0 network.InterfaceInfos, arg1 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddNetworkConfig", arg0)
+	ret := m.ctrl.Call(m, "AddNetworkConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddNetworkConfig indicates an expected call of AddNetworkConfig.
-func (mr *MockNetworkingConfigMockRecorder) AddNetworkConfig(arg0 interface{}) *gomock.Call {
+func (mr *MockNetworkingConfigMockRecorder) AddNetworkConfig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNetworkConfig", reflect.TypeOf((*MockNetworkingConfig)(nil).AddNetworkConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNetworkConfig", reflect.TypeOf((*MockNetworkingConfig)(nil).AddNetworkConfig), arg0, arg1)
 }

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1507,7 +1507,7 @@ func (e *Environ) networksForInstance(
 		}
 	}
 
-	err = cloudCfg.AddNetworkConfig(netInfo)
+	err = cloudCfg.AddNetworkConfig(netInfo, true)
 
 	if err != nil {
 		err1 := e.DeletePorts(subnetNetworks)

--- a/provider/openstack/provider_test.go
+++ b/provider/openstack/provider_test.go
@@ -955,7 +955,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 		Addresses:     network.NewMachineAddresses([]string{"10.10.10.1"}).AsProviderAddresses(),
 		ConfigType:    network.ConfigDHCP,
 		Origin:        network.OriginProvider,
-	}}).Return(nil)
+	}}, true).Return(nil)
 
 	siParams := environs.StartInstanceParams{
 		AvailabilityZone: "eu-west-az",

--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -233,7 +233,7 @@ func (env *sessionEnviron) newRawInstance(
 	}
 	// TODO(wpk) There's no (known) way to tell cloud-init to disable network (using cloudinit.CloudInitNetworkConfigDisabled)
 	// so the network might be double-configured. That should be ok as long as we're using DHCP.
-	err = cloudcfg.AddNetworkConfig(interfaces)
+	err = cloudcfg.AddNetworkConfig(interfaces, true)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}


### PR DESCRIPTION
With #15194 we removed the `match` stanza from generated Netplan configuration.

This resulted in the same symptom for KVM that we were experiencing intermittently for 22.04 LXD containers.

The reason is that for KVM, we get a different (kernel-generated) network device name than the one configured. This means that we _need_ the MAC matching stanza to assign an IP address to the device.

Here we parameterise the cloud-init generation for network config so that the caller can apply the `match` stanza for hardware addresses at need.

The only place it is omitted is the LXD container manager.

## QA steps

Bootstrap to a substrate such as MAAS and ensure that both KVM and LXD containers can be provisioned on hosts.

## Documentation changes

None.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2007977
