### PR TITLE
Delete secret consumer info when a unit is removed

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -391,6 +391,10 @@ func (op *DestroyApplicationOperation) deleteSecrets() error {
 	if _, err := op.app.st.deleteSecrets(ownedURIs); err != nil {
 		return errors.Annotatef(err, "deleting owned secrets for %q", op.app.Name())
 	}
+	// TODO(juju4) - remove
+	if err := op.app.st.removeSecretConsumer(op.app.Tag()); err != nil {
+		return errors.Annotatef(err, "deleting secret consumer records for %q", op.app.Name())
+	}
 	return nil
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -614,6 +614,9 @@ func (op *DestroyUnitOperation) deleteSecrets() error {
 	if _, err := op.unit.st.deleteSecrets(ownedURIs); err != nil {
 		return errors.Annotatef(err, "deleting owned secrets for %q", op.unit.Name())
 	}
+	if err := op.unit.st.removeSecretConsumer(op.unit.Tag()); err != nil {
+		return errors.Annotatef(err, "deleting secret consumer records for %q", op.unit.Name())
+	}
 	return nil
 }
 


### PR DESCRIPTION
When removing a unit, any consumer info for secrets viewed by that unit was left behind.
This PR adds an additional step to the delete operation to remove any consumer records.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Create a share a secret
read the secret
delete the unit that read the secret
check the `secretConsumers` collection to make sure the record is removed