### PR TITLE
[JUJU-2884] Add --trust option to charm refresh command

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1036,21 +1036,25 @@ func (api *APIBase) setCharmWithAgentValidation(
 	return api.applicationSetCharm(params, newCharm, origin)
 }
 
-// applicationSetCharm sets the charm for the given for the application.
+// applicationSetCharm sets the charm and updated config
+// for the given application.
 func (api *APIBase) applicationSetCharm(
 	params setCharmParams,
 	newCharm Charm,
 	newOrigin *state.CharmOrigin,
 ) error {
-	var err error
-	var settings charm.Settings
-	if params.ConfigSettingsYAML != "" {
-		settings, err = newCharm.Config().ParseSettingsYAML([]byte(params.ConfigSettingsYAML), params.AppName)
-	} else if len(params.ConfigSettingsStrings) > 0 {
-		settings, err = parseSettingsCompatible(newCharm.Config(), params.ConfigSettingsStrings)
+	model, err := api.backend.Model()
+	if err != nil {
+		return errors.Annotate(err, "retrieving model")
 	}
+	modelType := model.Type()
+
+	appConfig, appSchema, charmSettings, appDefaults, err := parseCharmSettings(modelType, newCharm, params.AppName, params.ConfigSettingsStrings, params.ConfigSettingsYAML, environsconfig.NoDefaults)
 	if err != nil {
 		return errors.Annotate(err, "parsing config settings")
+	}
+	if err := appConfig.Validate(); err != nil {
+		return errors.Annotate(err, "validating config settings")
 	}
 	var stateStorageConstraints map[string]state.StorageConstraints
 	if len(params.StorageConstraints) > 0 {
@@ -1068,11 +1072,6 @@ func (api *APIBase) applicationSetCharm(
 	}
 
 	// Enforce "assumes" requirements if the feature flag is enabled.
-	model, err := api.backend.Model()
-	if err != nil {
-		return errors.Annotate(err, "retrieving model")
-	}
-
 	if err := assertCharmAssumptions(newCharm.Meta().Assumes, model, api.backend.ControllerConfig); err != nil {
 		if !errors.IsNotSupported(err) || !params.Force.Force {
 			return errors.Trace(err)
@@ -1085,13 +1084,15 @@ func (api *APIBase) applicationSetCharm(
 	cfg := state.SetCharmConfig{
 		Charm:              api.stateCharm(newCharm),
 		CharmOrigin:        newOrigin,
-		ConfigSettings:     settings,
 		ForceBase:          force.ForceBase,
 		ForceUnits:         force.ForceUnits,
 		Force:              force.Force,
 		ResourceIDs:        params.ResourceIDs,
 		StorageConstraints: stateStorageConstraints,
 		EndpointBindings:   params.EndpointBindings,
+	}
+	if len(charmSettings) > 0 {
+		cfg.ConfigSettings = charmSettings
 	}
 
 	// Disallow downgrading from a v2 charm to a v1 charm.
@@ -1103,7 +1104,14 @@ func (api *APIBase) applicationSetCharm(
 		return errors.New("cannot downgrade from v2 charm format to v1")
 	}
 
-	return params.Application.SetCharm(cfg)
+	// TODO(wallyworld) - do in a single transaction
+	if err := params.Application.SetCharm(cfg); err != nil {
+		return errors.Annotate(err, "updating charm config")
+	}
+	if attr := appConfig.Attributes(); len(attr) > 0 {
+		return params.Application.UpdateApplicationConfig(attr, nil, appSchema, appDefaults)
+	}
+	return nil
 }
 
 // charmConfigFromYamlConfigValues will parse a yaml produced by juju get and

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -59,7 +59,7 @@ func (s *charmSuite) SetUpTest(c *gc.C) {
 func (s *charmSuite) TestSimpleCharmDeploy(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.modelCommand.EXPECT().BakeryClient().Return(nil, nil)
-	s.modelCommand.EXPECT().Filesystem().Return(s.filesystem)
+	s.modelCommand.EXPECT().Filesystem().Return(s.filesystem).AnyTimes()
 	s.configFlag.EXPECT().AbsoluteFileNames(gomock.Any()).Return(nil, nil)
 	s.configFlag.EXPECT().ReadConfigPairs(gomock.Any()).Return(nil, nil)
 	s.deployerAPI.EXPECT().Deploy(gomock.Any()).Return(nil)

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -241,6 +241,7 @@ func (s *RefreshSuite) TestStorageConstraints(c *gc.C) {
 		StorageConstraints: map[string]storage.Constraints{
 			"bar": {Pool: "baz", Count: 1},
 		},
+		ConfigSettings:   map[string]string{"trust": "false"},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -264,6 +265,49 @@ func (s *RefreshSuite) TestConfigSettings(c *gc.C) {
 			},
 		},
 		ConfigSettingsYAML: "foo:{}",
+		ConfigSettings:     map[string]string{"trust": "false"},
+		EndpointBindings:   map[string]string{},
+	})
+}
+
+func (s *RefreshSuite) TestConfigSettingsWithTrust(c *gc.C) {
+	_, err := s.runRefresh(c, "foo", "--trust", "--config", "foo=bar")
+	c.Assert(err, jc.ErrorIsNil)
+	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
+
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
+		ApplicationName: "foo",
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Risk: "stable",
+			},
+		},
+		ConfigSettings:   map[string]string{"trust": "true", "foo": "bar"},
+		EndpointBindings: map[string]string{},
+	})
+}
+
+func (s *RefreshSuite) TestConfigSettingsWithKeyValuesAndFile(c *gc.C) {
+	tempdir := c.MkDir()
+	configFile := filepath.Join(tempdir, "config.yaml")
+	err := os.WriteFile(configFile, []byte("foo:{}"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.runRefresh(c, "foo", "--trust", "--config", "foo=bar", "--config", configFile)
+	c.Assert(err, jc.ErrorIsNil)
+	s.charmAPIClient.CheckCallNames(c, "GetCharmURLOrigin", "Get", "SetCharm")
+
+	s.charmAPIClient.CheckCall(c, 2, "SetCharm", model.GenerationMaster, application.SetCharmConfig{
+		ApplicationName: "foo",
+		CharmID: application.CharmID{
+			URL: s.resolvedCharmURL,
+			Origin: commoncharm.Origin{
+				Risk: "stable",
+			},
+		},
+		ConfigSettingsYAML: "foo:{}",
+		ConfigSettings:     map[string]string{"trust": "true", "foo": "bar"},
 		EndpointBindings:   map[string]string{},
 	})
 }
@@ -306,6 +350,7 @@ func (s *RefreshSuite) testUpgradeWithBind(c *gc.C, expectedBindings map[string]
 				Risk: "stable",
 			},
 		},
+		ConfigSettings:   map[string]string{"trust": "false"},
 		EndpointBindings: expectedBindings,
 	})
 }
@@ -550,6 +595,7 @@ func (s *RefreshSuite) TestUpgradeWithChannel(c *gc.C) {
 				Risk: "beta",
 			},
 		},
+		ConfigSettings:   map[string]string{"trust": "false"},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -572,6 +618,7 @@ func (s *RefreshSuite) TestUpgradeWithChannelNoNewCharmURL(c *gc.C) {
 				Risk: "beta",
 			},
 		},
+		ConfigSettings:   map[string]string{"trust": "false"},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -596,6 +643,7 @@ func (s *RefreshSuite) TestRefreshShouldRespectDeployedChannelByDefault(c *gc.C)
 				Risk: "beta",
 			},
 		},
+		ConfigSettings:   map[string]string{"trust": "false"},
 		EndpointBindings: map[string]string{},
 	})
 }
@@ -633,6 +681,7 @@ func (s *RefreshSuite) TestSwitch(c *gc.C) {
 				Risk:         "stable",
 			},
 		},
+		ConfigSettings:   map[string]string{"trust": "false"},
 		EndpointBindings: map[string]string{},
 	})
 	var curl *charm.URL
@@ -870,6 +919,7 @@ func (s *RefreshSuite) TestUpgradeSameVersionWithResources(c *gc.C) {
 				Risk: "stable",
 			},
 		},
+		ConfigSettings:   map[string]string{"trust": "false"},
 		EndpointBindings: map[string]string{},
 		ResourceIDs:      map[string]string{"bar": "barId"},
 	})


### PR DESCRIPTION
juju deloy command takes a `--trust` option.
It also allows `--config` to specify either key value pairs or a path to a YAML file with config.

juju refresh has neither - it does not support `--trust` and it requires `--config` to specify only a YAML file.

This PR fixes both issues, so that now refresh behaves the same as deploy:
`--trust` is supported
If both `--config key=value` and `--config=/path/to/file` are used, the key values override the YAML content.

On the apiserver side, the `parseCharmSettings` method is used by both the deploy and refresh apis to ensure consistent behaviour.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

I deployed a local test charm with a simple config schema
```
"options":
  "user":
    "type": "string"
    "description": "test"
    "default": "admin"
```

`juju deploy . --config user=fred --trust`

`juju config` showed that trust=true and user=fred.

Then `juju refresh foo --path . --trust=false --config user=mary`
updated trust and user as expected.

And testing with a YAML file like
```
foo:
  user=joe
```
`juju refresh foo --path . --config /path/to/file.yaml`
also did what was expected

## Documentation changes

@tmihoc 
We'll need to tweak the doc for `juju refresh`

## Bug reference

https://bugs.launchpad.net/juju/+bug/2004573
