### PR TITLE
[JUJU-2844] Selectively omit Netplan "match" stanza (again)

### DIFF
--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -80,6 +80,16 @@ type cloudConfig struct {
 	// update_etc_hosts
 	// update_hostname
 	attrs map[string]interface{}
+
+	// omitNetplanMatchStanza if true, causes Netplan to be rendered without
+	// a stanza that matches by MAC address in order to apply configuration to
+	// a device.
+	// This will be recruited for LXD, where we have observed 22.04 containers
+	// being assigned a different MAC to the one configured.
+	// For these cases we fall back to the default match by ID (name).
+	// MAC address matching is still required by KVM where devices are assigned
+	// different names by the kernel to those we configured.
+	omitNetplanHWAddrMatch bool
 }
 
 // getPackagingConfigurer is defined on the AdvancedPackagingConfig interface.

--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -81,7 +81,7 @@ type cloudConfig struct {
 	// update_hostname
 	attrs map[string]interface{}
 
-	// omitNetplanMatchStanza if true, causes Netplan to be rendered without
+	// omitNetplanHWAddrMatch if true, causes Netplan to be rendered without
 	// a stanza that matches by MAC address in order to apply configuration to
 	// a device.
 	// This will be recruited for LXD, where we have observed 22.04 containers

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -416,71 +416,64 @@ type NetworkingConfig interface {
 	AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error
 }
 
+func WithDisableNetplanMACMatch(cfg *cloudConfig) {
+	cfg.omitNetplanHWAddrMatch = true
+}
+
 // New returns a new Config with no options set.
-func New(ser string) (CloudConfig, error) {
-	seriesos, err := series.GetOSFromSeries(ser)
+func New(ser string, opts ...func(*cloudConfig)) (CloudConfig, error) {
+	seriesOS, err := series.GetOSFromSeries(ser)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
-	switch seriesos {
+
+	cfg := &cloudConfig{
+		series: ser,
+		attrs:  make(map[string]interface{}),
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	renderer := func(name string) shell.Renderer { r, _ := shell.NewRenderer(name); return r }
+
+	switch seriesOS {
 	case os.Windows:
-		renderer, _ := shell.NewRenderer("powershell")
-		return &windowsCloudConfig{
-			&cloudConfig{
-				series:   ser,
-				renderer: renderer,
-				attrs:    make(map[string]interface{}),
-			},
-		}, nil
+		cfg.renderer = renderer("powershell")
+		return &windowsCloudConfig{cfg}, nil
 	case os.Ubuntu:
-		renderer, _ := shell.NewRenderer("bash")
-		return &ubuntuCloudConfig{
-			&cloudConfig{
-				series: ser,
-				paccmder: map[jujupackaging.PackageManagerName]commands.PackageCommander{
-					jujupackaging.AptPackageManager:  commands.NewAptPackageCommander(),
-					jujupackaging.SnapPackageManager: commands.NewSnapPackageCommander(),
-				},
-				pacconfer: map[jujupackaging.PackageManagerName]config.PackagingConfigurer{
-					jujupackaging.AptPackageManager: config.NewAptPackagingConfigurer(ser),
-				},
-				renderer: renderer,
-				attrs:    make(map[string]interface{}),
-			},
-		}, nil
+		cfg.renderer = renderer("bash")
+		cfg.paccmder = map[jujupackaging.PackageManagerName]commands.PackageCommander{
+			jujupackaging.AptPackageManager:  commands.NewAptPackageCommander(),
+			jujupackaging.SnapPackageManager: commands.NewSnapPackageCommander(),
+		}
+		cfg.pacconfer = map[jujupackaging.PackageManagerName]config.PackagingConfigurer{
+			jujupackaging.AptPackageManager: config.NewAptPackagingConfigurer(ser),
+		}
+		return &ubuntuCloudConfig{cfg}, nil
 	case os.CentOS:
-		renderer, _ := shell.NewRenderer("bash")
+		cfg.renderer = renderer("bash")
+		cfg.paccmder = map[jujupackaging.PackageManagerName]commands.PackageCommander{
+			jujupackaging.YumPackageManager: commands.NewYumPackageCommander(),
+		}
+		cfg.pacconfer = map[jujupackaging.PackageManagerName]config.PackagingConfigurer{
+			jujupackaging.YumPackageManager: config.NewYumPackagingConfigurer(ser),
+		}
 		return &centOSCloudConfig{
-			cloudConfig: &cloudConfig{
-				series: ser,
-				paccmder: map[jujupackaging.PackageManagerName]commands.PackageCommander{
-					jujupackaging.YumPackageManager: commands.NewYumPackageCommander(),
-				},
-				pacconfer: map[jujupackaging.PackageManagerName]config.PackagingConfigurer{
-					jujupackaging.YumPackageManager: config.NewYumPackagingConfigurer(ser),
-				},
-				renderer: renderer,
-				attrs:    make(map[string]interface{}),
-			},
-			helper: centOSHelper{},
+			cloudConfig: cfg,
+			helper:      centOSHelper{},
 		}, nil
 	case os.OpenSUSE:
-		renderer, _ := shell.NewRenderer("bash")
+		cfg.renderer = renderer("bash")
+		cfg.paccmder = map[jujupackaging.PackageManagerName]commands.PackageCommander{
+			jujupackaging.ZypperPackageManager: commands.NewZypperPackageCommander(),
+		}
+		cfg.pacconfer = map[jujupackaging.PackageManagerName]config.PackagingConfigurer{
+			jujupackaging.ZypperPackageManager: config.NewZypperPackagingConfigurer(ser),
+		}
 		return &centOSCloudConfig{
-			cloudConfig: &cloudConfig{
-				series: ser,
-				paccmder: map[jujupackaging.PackageManagerName]commands.PackageCommander{
-					jujupackaging.ZypperPackageManager: commands.NewZypperPackageCommander(),
-				},
-				pacconfer: map[jujupackaging.PackageManagerName]config.PackagingConfigurer{
-					jujupackaging.ZypperPackageManager: config.NewZypperPackagingConfigurer(ser),
-				},
-				renderer: renderer,
-				attrs:    make(map[string]interface{}),
-			},
-			helper: openSUSEHelper{
-				paccmder: commands.NewZypperPackageCommander(),
-			},
+			cloudConfig: cfg,
+			helper:      openSUSEHelper{paccmder: commands.NewZypperPackageCommander()},
 		}, nil
 	default:
 		return nil, errors.NotFoundf("cloudconfig for series %q", ser)

--- a/cloudconfig/cloudinit/interface_test.go
+++ b/cloudconfig/cloudinit/interface_test.go
@@ -4,6 +4,21 @@
 
 package cloudinit
 
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
 var _ CloudConfig = (*ubuntuCloudConfig)(nil)
 var _ CloudConfig = (*centOSCloudConfig)(nil)
 var _ CloudConfig = (*windowsCloudConfig)(nil)
+
+type InterfaceSuite struct{}
+
+var _ = gc.Suite(InterfaceSuite{})
+
+func (HelperSuite) TestNewCloudConfigWithoutMACMatch(c *gc.C) {
+	cfg, err := New("jammy", WithDisableNetplanMACMatch)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cfg.(*ubuntuCloudConfig).omitNetplanHWAddrMatch, jc.IsTrue)
+}

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -138,9 +138,11 @@ func GenerateENITemplate(interfaces corenetwork.InterfaceInfos) (string, error) 
 	return generatedConfig, nil
 }
 
-// GenerateNetplan renders a netplan file for one or more network
-// interfaces, using the given non-empty list of interfaces.
-func GenerateNetplan(interfaces corenetwork.InterfaceInfos) (string, error) {
+// GenerateNetplan renders a netplan file for the input non-empty collection
+// of interfaces.
+// The matchHWAddr argument indicates whether to add a match stanza for the
+// MAC address to each device.
+func GenerateNetplan(interfaces corenetwork.InterfaceInfos, matchHWAddr bool) (string, error) {
 	if len(interfaces) == 0 {
 		return "", errors.Errorf("missing container network config")
 	}
@@ -183,11 +185,11 @@ func GenerateNetplan(interfaces corenetwork.InterfaceInfos) (string, error) {
 		if info.MTU != 0 && info.MTU != 1500 {
 			iface.MTU = info.MTU
 		}
-		if info.MACAddress != "" {
+
+		if matchHWAddr && info.MACAddress != "" {
 			iface.Match = map[string]string{"macaddress": info.MACAddress}
-		} else {
-			iface.Match = map[string]string{"name": info.InterfaceName}
 		}
+
 		for _, route := range info.Routes {
 			route := netplan.Route{
 				To:     route.DestinationCIDR,
@@ -310,7 +312,7 @@ func PrepareNetworkConfigFromInterfaces(interfaces corenetwork.InterfaceInfos) (
 }
 
 // AddNetworkConfig adds configuration scripts for specified interfaces
-// to cloudconfig - using boot textfiles and boot commands. It currently
+// to cloudconfig - using boot text files and boot commands. It currently
 // supports e/n/i and netplan.
 func (cfg *ubuntuCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error {
 	if len(interfaces) != 0 {
@@ -318,7 +320,7 @@ func (cfg *ubuntuCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceI
 		if err != nil {
 			return errors.Trace(err)
 		}
-		netPlan, err := GenerateNetplan(interfaces)
+		netPlan, err := GenerateNetplan(interfaces, !cfg.omitNetplanHWAddrMatch)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -346,12 +346,12 @@ func (s *NetworkUbuntuSuite) TestGenerateENIConfig(c *gc.C) {
 }
 
 func (s *NetworkUbuntuSuite) TestGenerateNetplan(c *gc.C) {
-	data, err := cloudinit.GenerateNetplan(nil)
+	data, err := cloudinit.GenerateNetplan(nil, true)
 	c.Assert(err, gc.ErrorMatches, "missing container network config")
 	c.Assert(data, gc.Equals, "")
 
 	netConfig := container.BridgeNetworkConfig(0, s.fakeInterfaces)
-	data, err = cloudinit.GenerateNetplan(netConfig.Interfaces)
+	data, err = cloudinit.GenerateNetplan(netConfig.Interfaces, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(data, gc.Equals, s.expectedFullNetplan)
 }
@@ -374,7 +374,7 @@ func (s *NetworkUbuntuSuite) TestGenerateNetplanSkipIPv6LinkLocalDNS(c *gc.C) {
 	}}
 
 	netConfig := container.BridgeNetworkConfig(0, s.fakeInterfaces)
-	data, err := cloudinit.GenerateNetplan(netConfig.Interfaces)
+	data, err := cloudinit.GenerateNetplan(netConfig.Interfaces, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(data, gc.Equals, `
@@ -387,6 +387,29 @@ network:
       addresses:
       - 2001:db8::dead:beef/64
       gateway6: 2001:db8::dead:f00
+`[1:])
+}
+
+func (s *NetworkUbuntuSuite) TestGenerateNetplanWithoutMatchStanza(c *gc.C) {
+	s.fakeInterfaces = corenetwork.InterfaceInfos{{
+		InterfaceName: "any5",
+		ConfigType:    corenetwork.ConfigStatic,
+		MACAddress:    "aa:bb:cc:dd:ee:f5",
+		Addresses: corenetwork.ProviderAddresses{
+			corenetwork.NewMachineAddress("10.0.0.5", corenetwork.WithCIDR("10.0.0.0/8")).AsProviderAddress()},
+	}}
+
+	netConfig := container.BridgeNetworkConfig(0, s.fakeInterfaces)
+	data, err := cloudinit.GenerateNetplan(netConfig.Interfaces, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(data, gc.Equals, `
+network:
+  version: 2
+  ethernets:
+    any5:
+      addresses:
+      - 10.0.0.5/8
 `[1:])
 }
 

--- a/cloudconfig/containerinit/container_userdata.go
+++ b/cloudconfig/containerinit/container_userdata.go
@@ -5,9 +5,6 @@
 package containerinit
 
 import (
-	"io/ioutil"
-	"path/filepath"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 
@@ -18,63 +15,33 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 )
 
-var (
-	logger = loggo.GetLogger("juju.cloudconfig.containerinit")
-)
-
-// WriteUserData generates the cloud-init user-data using the
-// specified machine and network config for a container, and writes
-// the serialized form out to a cloud-init file in the directory
-// specified.
-func WriteUserData(
-	instanceConfig *instancecfg.InstanceConfig,
-	networkConfig *container.NetworkConfig,
-	directory string,
-) (string, error) {
-	userData, err := CloudInitUserData(instanceConfig, networkConfig)
-	if err != nil {
-		logger.Errorf("failed to create user data: %v", err)
-		return "", err
-	}
-	return WriteCloudInitFile(directory, userData)
-}
-
-// WriteCloudInitFile writes the data out to a cloud-init file in the
-// directory specified, and returns the filename.
-func WriteCloudInitFile(directory string, userData []byte) (string, error) {
-	userDataFilename := filepath.Join(directory, "cloud-init")
-	if err := ioutil.WriteFile(userDataFilename, userData, 0644); err != nil {
-		logger.Errorf("failed to write user data: %v", err)
-		return "", err
-	}
-	return userDataFilename, nil
-}
+var logger = loggo.GetLogger("juju.cloudconfig.containerinit")
 
 func CloudInitUserData(
+	cloudConfig cloudinit.CloudConfig,
 	instanceConfig *instancecfg.InstanceConfig,
 	networkConfig *container.NetworkConfig,
 ) ([]byte, error) {
-	cloudConfig, err := cloudinit.New(instanceConfig.Series)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	var interfaces corenetwork.InterfaceInfos
 	if networkConfig != nil {
 		interfaces = networkConfig.Interfaces
 	}
-	err = cloudConfig.AddNetworkConfig(interfaces)
-	if err != nil {
+
+	if err := cloudConfig.AddNetworkConfig(interfaces); err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	udata, err := cloudconfig.NewUserdataConfig(instanceConfig, cloudConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	if err = udata.Configure(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	// Run ifconfig/ip addr to get the addresses of the internal container at least
-	// logged in the host.
+
+	// Run ifconfig/ip addr to get the addresses of the
+	// internal container at least logged in the host.
 	cloudConfig.AddRunCmd("ifconfig || ip addr")
 
 	if instanceConfig.MachineContainerHostname != "" {
@@ -83,8 +50,5 @@ func CloudInitUserData(
 	}
 
 	data, err := cloudConfig.RenderYAML()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return data, nil
+	return data, errors.Trace(err)
 }

--- a/cloudconfig/containerinit/container_userdata_test.go
+++ b/cloudconfig/containerinit/container_userdata_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	stdtesting "testing"
 
+	"github.com/juju/juju/cloudconfig/cloudinit"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -78,7 +80,11 @@ func CloudInitDataExcludingOutputSection(data string) []string {
 func (s *UserDataSuite) TestCloudInitUserDataNoNetworkConfig(c *gc.C) {
 	instanceConfig, err := containertesting.MockMachineConfig("1/lxd/0")
 	c.Assert(err, jc.ErrorIsNil)
-	data, err := containerinit.CloudInitUserData(instanceConfig, nil)
+
+	cfg, err := cloudinit.New(instanceConfig.Series)
+	c.Assert(err, jc.ErrorIsNil)
+
+	data, err := containerinit.CloudInitUserData(cfg, instanceConfig, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.NotNil)
 
@@ -98,8 +104,11 @@ func (s *UserDataSuite) TestCloudInitUserDataSomeNetworkConfig(c *gc.C) {
 		InterfaceType: network.EthernetDevice,
 		ConfigType:    network.ConfigDHCP,
 	}}
-	netConfig := container.BridgeNetworkConfig(0, nics)
-	data, err := containerinit.CloudInitUserData(instanceConfig, netConfig)
+
+	cfg, err := cloudinit.New(instanceConfig.Series)
+	c.Assert(err, jc.ErrorIsNil)
+
+	data, err := containerinit.CloudInitUserData(cfg, instanceConfig, container.BridgeNetworkConfig(0, nics))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(data, gc.NotNil)
 

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -245,9 +245,14 @@ func (m *containerManager) getContainerSpec(
 		networkConfig.Interfaces = interfaces
 	}
 
+	cloudConfig, err := cloudinit.New(instanceConfig.Series, cloudinit.WithDisableNetplanMACMatch)
+	if err != nil {
+		return ContainerSpec{}, errors.Trace(err)
+	}
+
 	// CloudInitUserData creates our own ENI/netplan.
 	// We need to disable cloud-init networking to make it work.
-	userData, err := containerinit.CloudInitUserData(instanceConfig, networkConfig)
+	userData, err := containerinit.CloudInitUserData(cloudConfig, instanceConfig, networkConfig)
 	if err != nil {
 		return ContainerSpec{}, errors.Trace(err)
 	}


### PR DESCRIPTION
This patch supersedes #15213.

See that patch for history, QA-steps and bug.

We touch fewer files than that patch, because instead of parameterising the whole call stack we:
- Allow `CloudConfig` construction to accept options, one of which is to disable Netplan MAC matching.
- Break up `containerinit` so that we remove unecessary abstractions and allow the supply of already created `CloudConfig`.
- Ensure LXD creates its `CloudConfig` with the new option, leaving all other call sites untouched.