### PR TITLE
Use the lastest upstream dustin/humanize repo and not our override

### DIFF
--- a/cmd/juju/status/status_test.go
+++ b/cmd/juju/status/status_test.go
@@ -64,12 +64,12 @@ func (s *MinimalStatusSuite) TestGoodCallWithStorage(c *gc.C) {
 Model  Controller  Cloud/Region  Version
 test   test        foo           
 
-Storage Unit  Storage ID    Type        Pool      Mountpoint  Size    Status    Message
-              persistent/1  filesystem                                detached  
-postgresql/0  db-dir/1100   block                             3.0MiB  attached  
-transcode/0   db-dir/1000   block                                     pending   creating volume
-transcode/0   shared-fs/0   filesystem  radiance  /mnt/doom   1.0GiB  attached  
-transcode/1   shared-fs/0   filesystem  radiance  /mnt/huang  1.0GiB  attached  
+Storage Unit  Storage ID    Type        Pool      Mountpoint  Size     Status    Message
+              persistent/1  filesystem                                 detached  
+postgresql/0  db-dir/1100   block                             3.0 MiB  attached  
+transcode/0   db-dir/1000   block                                      pending   creating volume
+transcode/0   shared-fs/0   filesystem  radiance  /mnt/doom   1.0 GiB  attached  
+transcode/1   shared-fs/0   filesystem  radiance  /mnt/huang  1.0 GiB  attached  
 `[1:])
 }
 

--- a/cmd/juju/storage/filesystemlist_test.go
+++ b/cmd/juju/storage/filesystemlist_test.go
@@ -89,13 +89,13 @@ func (s *ListSuite) TestFilesystemListWithErrorResults(c *gc.C) {
 }
 
 var expectedFilesystemListTabular = `
-Machine  Unit         Storage ID   ID   Volume  Provider ID                       Mountpoint  Size    State      Message
-0        abc/0        db-dir/1001  0/0  0/1     provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached   
-0        transcode/0  shared-fs/0  4            provider-supplied-filesystem-4    /mnt/doom   1.0GiB  attached   
-0                                  1            provider-supplied-filesystem-1                2.0GiB  attaching  failed to attach, will retry
-1        transcode/1  shared-fs/0  4            provider-supplied-filesystem-4    /mnt/huang  1.0GiB  attached   
-1                                  2            provider-supplied-filesystem-2    /mnt/zion   3.0MiB  attached   
-1                                  3                                                          42MiB   pending    
+Machine  Unit         Storage ID   ID   Volume  Provider ID                       Mountpoint  Size     State      Message
+0        abc/0        db-dir/1001  0/0  0/1     provider-supplied-filesystem-0-0  /mnt/fuji   512 MiB  attached   
+0        transcode/0  shared-fs/0  4            provider-supplied-filesystem-4    /mnt/doom   1.0 GiB  attached   
+0                                  1            provider-supplied-filesystem-1                2.0 GiB  attaching  failed to attach, will retry
+1        transcode/1  shared-fs/0  4            provider-supplied-filesystem-4    /mnt/huang  1.0 GiB  attached   
+1                                  2            provider-supplied-filesystem-2    /mnt/zion   3.0 MiB  attached   
+1                                  3                                                          42 MiB   pending    
 `[1:]
 
 func (s *ListSuite) TestFilesystemListTabular(c *gc.C) {
@@ -115,8 +115,8 @@ func (s *ListSuite) TestFilesystemListTabular(c *gc.C) {
 }
 
 var expectedCAASFilesystemListTabular = `
-Unit     Storage ID   ID   Provider ID                       Mountpoint  Size    State     Message
-mysql/0  db-dir/1001  0/0  provider-supplied-filesystem-0-0  /mnt/fuji   512MiB  attached  
+Unit     Storage ID   ID   Provider ID                       Mountpoint  Size     State     Message
+mysql/0  db-dir/1001  0/0  provider-supplied-filesystem-0-0  /mnt/fuji   512 MiB  attached  
 `[1:]
 
 func (s *ListSuite) TestCAASFilesystemListTabular(c *gc.C) {

--- a/cmd/juju/storage/list_test.go
+++ b/cmd/juju/storage/list_test.go
@@ -43,12 +43,12 @@ func (s *ListSuite) TestList(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-Unit          Storage ID    Type        Pool      Size    Status    Message
-              persistent/1  filesystem                    detached  
-postgresql/0  db-dir/1100   block                 3.0MiB  attached  
-transcode/0   db-dir/1000   block                         pending   creating volume
-transcode/0   shared-fs/0   filesystem  radiance  1.0GiB  attached  
-transcode/1   shared-fs/0   filesystem  radiance  1.0GiB  attached  
+Unit          Storage ID    Type        Pool      Size     Status    Message
+              persistent/1  filesystem                     detached  
+postgresql/0  db-dir/1100   block                 3.0 MiB  attached  
+transcode/0   db-dir/1000   block                          pending   creating volume
+transcode/0   shared-fs/0   filesystem  radiance  1.0 GiB  attached  
+transcode/1   shared-fs/0   filesystem  radiance  1.0 GiB  attached  
 `[1:])
 }
 
@@ -59,12 +59,12 @@ func (s *ListSuite) TestListNoPool(c *gc.C) {
 		nil,
 		// Default format is tabular
 		`
-Unit          Storage ID    Type        Size    Status    Message
-              persistent/1  filesystem          detached  
-postgresql/0  db-dir/1100   block       3.0MiB  attached  
-transcode/0   db-dir/1000   block               pending   creating volume
-transcode/0   shared-fs/0   filesystem  1.0GiB  attached  
-transcode/1   shared-fs/0   filesystem  1.0GiB  attached  
+Unit          Storage ID    Type        Size     Status    Message
+              persistent/1  filesystem           detached  
+postgresql/0  db-dir/1100   block       3.0 MiB  attached  
+transcode/0   db-dir/1000   block                pending   creating volume
+transcode/0   shared-fs/0   filesystem  1.0 GiB  attached  
+transcode/1   shared-fs/0   filesystem  1.0 GiB  attached  
 `[1:])
 }
 

--- a/cmd/juju/storage/volumelist_test.go
+++ b/cmd/juju/storage/volumelist_test.go
@@ -90,13 +90,13 @@ func (s *ListSuite) TestVolumeListWithErrorResults(c *gc.C) {
 }
 
 var expectedVolumeListTabular = `
-Machine  Unit         Storage ID   Volume ID  Provider ID                   Device  Size    State      Message
-0        abc/0        db-dir/1001  0/0        provider-supplied-volume-0-0  loop0   512MiB  attached   
-0        transcode/0  shared-fs/0  4          provider-supplied-volume-4    xvdf2   1.0GiB  attached   
-0                                  1          provider-supplied-volume-1            2.0GiB  attaching  failed to attach, will retry
-1        transcode/1  shared-fs/0  4          provider-supplied-volume-4    xvdf3   1.0GiB  attached   
-1                                  2          provider-supplied-volume-2    xvdf1   3.0MiB  attached   
-1                                  3                                                42MiB   pending    
+Machine  Unit         Storage ID   Volume ID  Provider ID                   Device  Size     State      Message
+0        abc/0        db-dir/1001  0/0        provider-supplied-volume-0-0  loop0   512 MiB  attached   
+0        transcode/0  shared-fs/0  4          provider-supplied-volume-4    xvdf2   1.0 GiB  attached   
+0                                  1          provider-supplied-volume-1            2.0 GiB  attaching  failed to attach, will retry
+1        transcode/1  shared-fs/0  4          provider-supplied-volume-4    xvdf3   1.0 GiB  attached   
+1                                  2          provider-supplied-volume-2    xvdf1   3.0 MiB  attached   
+1                                  3                                                42 MiB   pending    
 `[1:]
 
 func (s *ListSuite) TestVolumeListTabular(c *gc.C) {
@@ -117,8 +117,8 @@ func (s *ListSuite) TestVolumeListTabular(c *gc.C) {
 }
 
 var expectedCAASVolumeListTabular = `
-Unit     Storage ID   Volume ID  Provider ID                 Size    State     Message
-mysql/0  db-dir/1001  0          provider-supplied-volume-0  512MiB  attached  
+Unit     Storage ID   Volume ID  Provider ID                 Size     State     Message
+mysql/0  db-dir/1001  0          provider-supplied-volume-0  512 MiB  attached  
 `[1:]
 
 func (s *ListSuite) TestCAASVolumeListTabular(c *gc.C) {

--- a/container/kvm/sync_internal_test.go
+++ b/container/kvm/sync_internal_test.go
@@ -304,7 +304,7 @@ func (s *progressWriterSuite) TestOnlyPercentChanges(c *gc.C) {
 	for i := 1; i <= 100; i++ {
 		// We tick every 1ms and add 50kiB each time, which is
 		// 50*1024 *1000/ 1000/1000  = 51MB/s
-		expectedCB = append(expectedCB, fmt.Sprintf("copying http://host/path %d%% (51MB/s)", i))
+		expectedCB = append(expectedCB, fmt.Sprintf("copying http://host/path %d%% (51 MB/s)", i))
 	}
 	// There are 2048 calls to Write, but there should only be 100 calls to progress update
 	c.Check(len(cbLog), gc.Equals, 100)

--- a/featuretests/storage_test.go
+++ b/featuretests/storage_test.go
@@ -642,10 +642,10 @@ func (s *cmdStorageSuite) TestStorageDetachAttach(c *gc.C) {
 	ctx, err := runCommand(c, "storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-Unit             Storage ID  Type   Pool         Size    Status     Message
-                 allecto/2   block  modelscoped  1.0GiB  detaching  
-storage-block/0  data/0      block                       pending    
-storage-block/1  data/1      block                       pending    
+Unit             Storage ID  Type   Pool         Size     Status     Message
+                 allecto/2   block  modelscoped  1.0 GiB  detaching  
+storage-block/0  data/0      block                        pending    
+storage-block/1  data/1      block                        pending    
 `[1:])
 
 	// Attempt to attach the allecto storage to the second unit.
@@ -669,10 +669,10 @@ storage-block/1  data/1      block                       pending
 	ctx, err = runCommand(c, "storage")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
-Unit             Storage ID  Type   Pool         Size    Status     Message
-storage-block/0  data/0      block                       pending    
-storage-block/1  allecto/2   block  modelscoped  1.0GiB  attaching  
-storage-block/1  data/1      block                       pending    
+Unit             Storage ID  Type   Pool         Size     Status     Message
+storage-block/0  data/0      block                        pending    
+storage-block/1  allecto/2   block  modelscoped  1.0 GiB  attaching  
+storage-block/1  data/1      block                        pending    
 `[1:])
 }
 

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.7.1+incompatible
-	github.com/dustin/go-humanize v1.0.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4
 	github.com/go-logr/logr v1.2.2
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1
@@ -287,7 +287,5 @@ require (
 replace google.golang.org/grpc/naming => google.golang.org/grpc v1.29.1
 
 replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
-
-replace github.com/dustin/go-humanize v1.0.0 => github.com/dustin/go-humanize v0.0.0-20141228071148-145fabdb1ab7
 
 replace github.com/hashicorp/raft-boltdb => github.com/juju/raft-boltdb v0.0.0-20200518034108-40b112c917c5

--- a/go.sum
+++ b/go.sum
@@ -376,9 +376,10 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/dustin/go-humanize v0.0.0-20141228071148-145fabdb1ab7 h1:n/ETHd/ASEuDgfz8mVStuNUN2iUqKg4mNhxowUFhNjw=
-github.com/dustin/go-humanize v0.0.0-20141228071148-145fabdb1ab7/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/state/storage_dynamicadd_test.go
+++ b/state/storage_dynamicadd_test.go
@@ -310,7 +310,7 @@ func (s *storageAddSuite) TestAddStorageLessMinSize(c *gc.C) {
 	s.assignUnit(c, u)
 
 	_, err := s.storageBackend.AddStorageForUnit(s.unitTag, "multi2up", state.StorageConstraints{Size: 2, Count: 1})
-	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 2.0MB specified.*`)
+	c.Assert(err, gc.ErrorMatches, `.*charm "storage-block2" store "multi2up": minimum storage size is 2.0 GB, 2.0 MB specified.*`)
 	s.assertStorageCount(c, s.originalStorageCount)
 	s.assertVolumeCount(c, s.originalVolumeCount)
 	s.assertFileSystemCount(c, s.originalFilesystemCount)

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -546,7 +546,7 @@ func (s *StorageStateSuite) TestAddApplicationStorageConstraintsValidation(c *gc
 	}
 	assertErr(storageCons, `cannot add application "storage-block2": charm "storage-block2" store "multi2up": 2 instances required, 1 specified`)
 	storageCons["multi2up"] = makeStorageCons("loop-pool", 1024, 2)
-	assertErr(storageCons, `cannot add application "storage-block2": charm "storage-block2" store "multi2up": minimum storage size is 2.0GB, 1.0GB specified`)
+	assertErr(storageCons, `cannot add application "storage-block2": charm "storage-block2" store "multi2up": minimum storage size is 2.0 GB, 1.0 GB specified`)
 	storageCons["multi2up"] = makeStorageCons("loop-pool", 2048, 2)
 	storageCons["multi1to10"] = makeStorageCons("loop-pool", 1024, 11)
 	assertErr(storageCons, `cannot add application "storage-block2": charm "storage-block2" store "multi1to10": at most 10 instances supported, 11 specified`)


### PR DESCRIPTION
Were were pining `dustin/humanize` to a non-released, old version.
Here we update to the lastest upstream release, 1.0.1.

The output has changed - there's a space between the number and unit, eg "4.0GiB" is now "4.0 GiB".
This affects tabular output of some commands.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

bootstrap and deploy a charm with storage run `juju status --storage` or `juju storage --volume` etc