### PR TITLE
[JUJU-2921] If a hook receives SIGTERM, requeue it without error

### DIFF
--- a/worker/meterstatus/runner.go
+++ b/worker/meterstatus/runner.go
@@ -87,6 +87,8 @@ func (w *hookRunner) RunHook(code, info string, interrupt <-chan struct{}) {
 	switch {
 	case charmrunner.IsMissingHookError(cause):
 		w.logger.Infof("skipped %q hook (missing)", string(hooks.MeterStatusChanged))
+	case cause == runner.ErrTerminated:
+		w.logger.Warningf("%q hook was terminated", hooks.MeterStatusChanged)
 	case err != nil:
 		w.logger.Errorf("error running %q: %v", hooks.MeterStatusChanged, err)
 	default:

--- a/worker/uniter/operation/deploy.go
+++ b/worker/uniter/operation/deploy.go
@@ -92,6 +92,7 @@ func (d *deploy) Commit(state State) (*State, error) {
 	if hookInfo := d.interruptedHook(state); hookInfo != nil {
 		change.Hook = hookInfo
 		change.Step = Pending
+		change.HookStep = state.HookStep
 	} else {
 		change.Hook = &hook.Info{Kind: deployHookKinds[d.kind]}
 		change.Step = Queued
@@ -123,6 +124,7 @@ func (d *deploy) getState(state State, step Step) *State {
 		Step:     step,
 		CharmURL: d.charmURL,
 		Hook:     d.interruptedHook(state),
+		HookStep: state.HookStep,
 	}.apply(state)
 }
 

--- a/worker/uniter/operation/deploy_test.go
+++ b/worker/uniter/operation/deploy_test.go
@@ -569,17 +569,20 @@ func (s *DeploySuite) testCommitInterruptedHook(c *gc.C, newDeploy newDeploy) {
 
 	op, err := newDeploy(factory, "cs:quantal/x-0")
 	c.Assert(err, jc.ErrorIsNil)
+	hookStep := operation.Done
 	newState, err := op.Commit(operation.State{
 		Kind:     operation.Upgrade,
 		Step:     operation.Done,
 		CharmURL: "", // doesn't actually matter here
 		Hook:     &hook.Info{Kind: hooks.ConfigChanged},
+		HookStep: &hookStep,
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(newState, gc.DeepEquals, &operation.State{
-		Kind: operation.RunHook,
-		Step: operation.Pending,
-		Hook: &hook.Info{Kind: hooks.ConfigChanged},
+		Kind:     operation.RunHook,
+		Step:     operation.Pending,
+		Hook:     &hook.Info{Kind: hooks.ConfigChanged},
+		HookStep: &hookStep,
 	})
 }
 

--- a/worker/uniter/operation/runhook.go
+++ b/worker/uniter/operation/runhook.go
@@ -135,6 +135,19 @@ func (rh *runHook) Execute(state State) (*State, error) {
 		fallthrough
 	case cause == context.ErrReboot:
 		err = ErrNeedsReboot
+	case cause == runner.ErrTerminated:
+		// Queue the hook again so it is re-run.
+		// It is likely the whole process group was terminated as
+		// part of shutdown, but in case not, the unit agent will
+		// treat the hook as pending (not queued) and record a hook error.
+		rh.logger.Warningf("hook %q was terminated", rh.name)
+		step = Queued
+		return stateChange{
+			Kind:     RunHook,
+			Step:     step,
+			Hook:     &rh.info,
+			HookStep: &step,
+		}.apply(state), runner.ErrTerminated
 	case err == nil:
 	default:
 		rh.logger.Errorf("hook %q (via %s) failed: %v", rh.name, handlerType, err)
@@ -158,6 +171,7 @@ func (rh *runHook) Execute(state State) (*State, error) {
 		Kind:            RunHook,
 		Step:            step,
 		Hook:            &rh.info,
+		HookStep:        &step,
 		HasRunStatusSet: hasRunStatusSet,
 	}.apply(state), err
 }

--- a/worker/uniter/resolver.go
+++ b/worker/uniter/resolver.go
@@ -138,9 +138,19 @@ func (s *uniterResolver) NextOp(
 		return op, err
 	}
 
+	// If we are to shut down, we don't want to start running any more queued/pending hooks.
+	if remoteState.Shutdown {
+		logger.Debugf("unit agent is shutting down, will not run pending/queued hooks")
+		return s.nextOp(localState, remoteState, opFactory)
+	}
+
 	switch localState.Kind {
 	case operation.RunHook:
-		switch localState.Step {
+		step := localState.Step
+		if localState.HookStep != nil {
+			step = *localState.HookStep
+		}
+		switch step {
 		case operation.Pending:
 			logger.Infof("awaiting error resolution for %q hook", localState.Hook.Kind)
 			return s.nextOpHookError(localState, remoteState, opFactory)
@@ -171,7 +181,7 @@ func (s *uniterResolver) NextOp(
 			return opFactory.NewSkipHook(*localState.Hook)
 
 		default:
-			return nil, errors.Errorf("unknown operation step %v", localState.Step)
+			return nil, errors.Errorf("unknown hook operation step %v", step)
 		}
 
 	case operation.Continue:

--- a/worker/uniter/resolver/interface.go
+++ b/worker/uniter/resolver/interface.go
@@ -101,4 +101,7 @@ type LocalState struct {
 	// OutdatedRemoteCharm is true when an upgrade has happened but the remotestate
 	// needs an update.
 	OutdatedRemoteCharm bool
+
+	// HookWasShutdown is true if the hook exited due to a SIGTERM.
+	HookWasShutdown bool
 }

--- a/worker/uniter/resolver_test.go
+++ b/worker/uniter/resolver_test.go
@@ -252,6 +252,57 @@ func (s *iaasResolverSuite) TestUniterIdlesWhenRemoteStateIsUpgradeSeriesComplet
 	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
 }
 
+func (s *resolverSuite) TestQueuedHookOnAgentRestart(c *gc.C) {
+	s.resolver = uniter.NewUniterResolver(s.resolverConfig)
+	s.reportHookError = func(hook.Info) error { return errors.New("unexpected") }
+	queued := operation.Queued
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+		State: operation.State{
+			Kind:      operation.RunHook,
+			Step:      operation.Pending,
+			Installed: true,
+			Started:   true,
+			Hook: &hook.Info{
+				Kind: hooks.ConfigChanged,
+			},
+			HookStep: &queued,
+		},
+	}
+	op, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(op.String(), gc.Equals, "run config-changed hook")
+	s.stub.CheckNoCalls(c)
+}
+
+func (s *resolverSuite) TestPendingHookOnAgentRestart(c *gc.C) {
+	s.resolverConfig.ShouldRetryHooks = false
+	s.resolver = uniter.NewUniterResolver(s.resolverConfig)
+	hookError := false
+	s.reportHookError = func(hook.Info) error {
+		hookError = true
+		return nil
+	}
+	queued := operation.Pending
+	localState := resolver.LocalState{
+		CharmURL: s.charmURL,
+		State: operation.State{
+			Kind:      operation.RunHook,
+			Step:      operation.Pending,
+			Installed: true,
+			Started:   true,
+			Hook: &hook.Info{
+				Kind: hooks.ConfigChanged,
+			},
+			HookStep: &queued,
+		},
+	}
+	_, err := s.resolver.NextOp(localState, s.remoteState, s.opFactory)
+	c.Assert(err, gc.Equals, resolver.ErrNoOperation)
+	c.Assert(hookError, jc.IsTrue)
+	s.stub.CheckNoCalls(c)
+}
+
 func (s *resolverSuite) TestHookErrorDoesNotStartRetryTimerIfShouldRetryFalse(c *gc.C) {
 	s.resolverConfig.ShouldRetryHooks = false
 	s.resolver = uniter.NewUniterResolver(s.resolverConfig)

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"unicode/utf8"
 
@@ -595,6 +596,11 @@ func (runner *runner) runCharmProcessOnRemote(hook, hookName, charmDir string, e
 	return errors.Trace(err)
 }
 
+const (
+	// ErrTerminated indicate the hook or action exited due to a SIGTERM or SIGKILL signal.
+	ErrTerminated = errors.ConstError("terminated")
+)
+
 // Check still tested
 func (runner *runner) runCharmProcessOnLocal(hook, hookName, charmDir string, env []string) error {
 	hookCmd := hookCommand(hook)
@@ -676,6 +682,12 @@ func (runner *runner) runCharmProcessOnLocal(hook, hookName, charmDir string, en
 		}
 		if err := runner.updateActionResults(resp); err != nil {
 			return errors.Trace(err)
+		}
+	}
+	if exitError, ok := exitErr.(*exec.ExitError); ok && exitError != nil {
+		waitStatus := exitError.ProcessState.Sys().(syscall.WaitStatus)
+		if waitStatus.Signal() == syscall.SIGTERM || waitStatus.Signal() == syscall.SIGKILL {
+			return errors.Trace(ErrTerminated)
 		}
 	}
 

--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -532,6 +532,9 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				// Loop back around. The resolver can tell that it is in
 				// an error state by inspecting the operation state.
 				err = nil
+			case runner.ErrTerminated:
+				localState.HookWasShutdown = true
+				err = nil
 			case resolver.ErrTerminate:
 				err = u.terminate()
 			case resolver.ErrRestart:


### PR DESCRIPTION
As per the attached bug, running hooks which receive a sigterm are put into error state. But the sigterm could just be because the pod is being restarted due to a pod spec change, or rescheduled. When the pod is running again, manual intervention is needed to resolve the hook error.

Here we inspect the hook error, and if it is due to sigterm we re-queue the hook and do not put it in error state. If the agent itself is being terminated, it will do so and then run the hook when it starts again. If the hook died because just the hook process was terminated by someone or something, it will also just be re-run. 

For k8s, there's an existing worker which listens for the sig term and sets it on the uniter remote state. We use this to inform how the terminated hook is processed. If the agent is not terminating, we still record the hook error.


## QA steps

Tested so far on a machine charm - add a sleep 1000 to the config-changed hook.
When the hook is paused, send a sigterm to the hook process. See the logs emit a warning that the hook was terminated and watch the hook get re-run again straight away. There will be no hook error state in juju status.

On k8s, deploy a charm, with sleep 100 in the config hook.
Once the agent is blocked running the hook, use kubectl to delete the unit's pod.
The status-log should not show any hook errors.
The config-changed hook should run again after the pod restart.
And after the config-changed hook completes, the subsequent start / pebble-ready hooks should run.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2008443
