### PR TITLE
[JUJU-2920] Fix download and info ci tests

### DIFF
--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -22,7 +22,7 @@ run_charmstore_download() {
 	ensure "test-${name}" "${file}"
 
 	output=$(juju download cs:meshuggah 2>&1 || echo "not found")
-	check_contains "${output}" '"cs:meshuggah" is not a Charmhub charm'
+	check_contains "${output}" 'ERROR charm or bundle name, "cs:meshuggah", is not valid'
 }
 
 run_unknown_download() {

--- a/tests/suites/charmhub/download.sh
+++ b/tests/suites/charmhub/download.sh
@@ -2,39 +2,45 @@ run_charmhub_download() {
 	echo
 	name="charmhub-download"
 
-	file="${TEST_DIR}/test-${name}.log"
+	file="${TEST_DIR}/${name}.log"
 
-	ensure "test-${name}" "${file}"
+	ensure "${name}" "${file}"
 
 	output=$(juju download postgresql --base ubuntu@20.04 --filepath="${TEST_DIR}/postgresql.charm" 2>&1 || true)
 	check_contains "${output}" 'Fetching charm "postgresql"'
 
 	juju deploy "${TEST_DIR}/postgresql.charm" postgresql
 	juju wait-for application --timeout=15m postgresql
+
+	destroy_model "${name}"
 }
 
 run_charmstore_download() {
 	echo
-	name="charmstore-download"
+	name="test-charmstore-download"
 
-	file="${TEST_DIR}/test-${name}.log"
+	file="${TEST_DIR}/${name}.log"
 
-	ensure "test-${name}" "${file}"
+	ensure "${name}" "${file}"
 
 	output=$(juju download cs:meshuggah 2>&1 || echo "not found")
 	check_contains "${output}" 'ERROR charm or bundle name, "cs:meshuggah", is not valid'
+
+	destroy_model "${name}"
 }
 
 run_unknown_download() {
 	echo
-	name="unknown-download"
+	name="test-unknown-download"
 
-	file="${TEST_DIR}/test-${name}.log"
+	file="${TEST_DIR}/${name}.log"
 
-	ensure "test-${name}" "${file}"
+	ensure "${name}" "${file}"
 
 	output=$(juju download meshuggah 2>&1 || echo "not found")
 	check_contains "${output}" "The Charm with the given name was not found in the Store"
+
+	destroy_model "${name}"
 }
 
 test_charmhub_download() {

--- a/tests/suites/charmhub/info.sh
+++ b/tests/suites/charmhub/info.sh
@@ -43,7 +43,7 @@ run_charmhub_info_json() {
 run_charmstore_info() {
 	echo
 	output=$(juju info cs:ubuntu 2>&1 || true)
-	check_contains "$output" 'ERROR "cs:ubuntu" is not a Charm Hub charm'
+	check_contains "$output" 'ERROR charm or bundle name, "cs:ubuntu", is not valid'
 }
 
 test_charmhub_info() {


### PR DESCRIPTION
The charmhub info and download CI tests needed output updates after charmstore was removed from juju in 3.1.

While testing, noticed that the models created weren't destroyed, so fixed that as well.

## QA steps

Tests should all be successful and the controller should not contain "extra" models after completion

```sh
$ juju bootstrap localhost testme
$ (cd tests ; ./main.sh -v -l testme charmhub)
$ juju models
Controller: testme

Model       Cloud/Region         Type  Status     Machines  Units  Access  Last connection
controller  localhost/localhost  lxd   available         1      1  admin   just now
```
