### PR TITLE
Update Pebble version; remove use of external pebble/plan

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/canonical/pebble/plan"
 	"github.com/juju/charm/v10"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -48,6 +47,7 @@ import (
 	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/mongo"
+	"github.com/juju/juju/service/pebble/plan"
 	"github.com/juju/juju/version"
 )
 

--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/canonical/pebble/plan"
 	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -27,6 +26,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/constants"
 	"github.com/juju/juju/cmd/containeragent/utils"
+	"github.com/juju/juju/service/pebble/plan"
 	"github.com/juju/juju/worker/apicaller"
 )
 

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -93,6 +93,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"rpc",
 		"rpc/jsoncodec",
 		"service/common",
+		"service/pebble/plan",
 		"service/snap",
 		"service/systemd",
 		"state/errors",

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.9.0
 	github.com/aws/smithy-go v1.8.0
 	github.com/bmizerany/pat v0.0.0-20160217103242-c068ca2f0aac
-	github.com/canonical/pebble v0.0.0-20221010231311-dfff36380603
+	github.com/canonical/pebble v0.0.0-20230127043025-054e5fbebc6b
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.7.1+incompatible
@@ -148,6 +148,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43 // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/creack/pty v1.1.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,10 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/canonical/pebble v0.0.0-20221010231311-dfff36380603 h1:dNUWQ+B76pFtLM3cHfq8t+vEvQlsjEF8p7oZIgJu7Ek=
-github.com/canonical/pebble v0.0.0-20221010231311-dfff36380603/go.mod h1:qAIw8HY2rZZZ7QOhG9wD/4rtXvPJfvaOg+uWbhSABpc=
+github.com/canonical/pebble v0.0.0-20230127043025-054e5fbebc6b h1:pVYPfyf4CHvbUseS1B6Nbkv9RMkBeX95AZbB9pwswVM=
+github.com/canonical/pebble v0.0.0-20230127043025-054e5fbebc6b/go.mod h1:j3uyWpPkuWf8u0kB2v7n/XGVpYIg4luGetpSngCvzac=
+github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43 h1:bey1JgA3D2EBabr2a7kWKj+JlEPxX1akv8rcRromotA=
+github.com/canonical/x-go v0.0.0-20230113154138-0ccdb0b57a43/go.mod h1:A0/Jvt7qKuCDss37TYRNXSscVyS+tLWM5kBYipQOpWQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=

--- a/service/pebble/plan/doc.go
+++ b/service/pebble/plan/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package plan defines the various types to work with the Pebble plan and layers.
+//
+// This is a subset of the types in github.com/canonical/pebble/internal/plan.
+package plan

--- a/service/pebble/plan/doc.go
+++ b/service/pebble/plan/doc.go
@@ -3,5 +3,6 @@
 
 // Package plan defines the various types to work with the Pebble plan and layers.
 //
-// This is a subset of the types in github.com/canonical/pebble/internal/plan.
+// This is a subset of the types in github.com/canonical/pebble/internal/plan,
+// copied directly from that repository.
 package plan

--- a/service/pebble/plan/plan.go
+++ b/service/pebble/plan/plan.go
@@ -1,0 +1,119 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package plan
+
+type Layer struct {
+	Order       int                 `yaml:"-"`
+	Label       string              `yaml:"-"`
+	Summary     string              `yaml:"summary,omitempty"`
+	Description string              `yaml:"description,omitempty"`
+	Services    map[string]*Service `yaml:"services,omitempty"`
+	Checks      map[string]*Check   `yaml:"checks,omitempty"`
+}
+
+type Service struct {
+	// Basic details
+	Name        string         `yaml:"-"`
+	Summary     string         `yaml:"summary,omitempty"`
+	Description string         `yaml:"description,omitempty"`
+	Startup     ServiceStartup `yaml:"startup,omitempty"`
+	Override    Override       `yaml:"override,omitempty"`
+	Command     string         `yaml:"command,omitempty"`
+
+	// Service dependencies
+	After    []string `yaml:"after,omitempty"`
+	Before   []string `yaml:"before,omitempty"`
+	Requires []string `yaml:"requires,omitempty"`
+
+	// Options for command execution
+	Environment map[string]string `yaml:"environment,omitempty"`
+	UserID      *int              `yaml:"user-id,omitempty"`
+	User        string            `yaml:"user,omitempty"`
+	GroupID     *int              `yaml:"group-id,omitempty"`
+	Group       string            `yaml:"group,omitempty"`
+
+	// Auto-restart and backoff functionality
+	OnSuccess      ServiceAction            `yaml:"on-success,omitempty"`
+	OnFailure      ServiceAction            `yaml:"on-failure,omitempty"`
+	OnCheckFailure map[string]ServiceAction `yaml:"on-check-failure,omitempty"`
+	BackoffDelay   OptionalDuration         `yaml:"backoff-delay,omitempty"`
+	BackoffFactor  OptionalFloat            `yaml:"backoff-factor,omitempty"`
+	BackoffLimit   OptionalDuration         `yaml:"backoff-limit,omitempty"`
+}
+
+type ServiceStartup string
+
+const (
+	StartupUnknown  ServiceStartup = ""
+	StartupEnabled  ServiceStartup = "enabled"
+	StartupDisabled ServiceStartup = "disabled"
+)
+
+// Override specifies the layer override mechanism (for services and checks).
+type Override string
+
+const (
+	UnknownOverride Override = ""
+	MergeOverride   Override = "merge"
+	ReplaceOverride Override = "replace"
+)
+
+type ServiceAction string
+
+const (
+	ActionUnset    ServiceAction = ""
+	ActionRestart  ServiceAction = "restart"
+	ActionShutdown ServiceAction = "shutdown"
+	ActionIgnore   ServiceAction = "ignore"
+)
+
+// Check specifies configuration for a single health check.
+type Check struct {
+	// Basic details
+	Name     string     `yaml:"-"`
+	Override Override   `yaml:"override,omitempty"`
+	Level    CheckLevel `yaml:"level,omitempty"`
+
+	// Common check settings
+	Period    OptionalDuration `yaml:"period,omitempty"`
+	Timeout   OptionalDuration `yaml:"timeout,omitempty"`
+	Threshold int              `yaml:"threshold,omitempty"`
+
+	// Type-specific check settings (only one of these can be set)
+	HTTP *HTTPCheck `yaml:"http,omitempty"`
+	TCP  *TCPCheck  `yaml:"tcp,omitempty"`
+	Exec *ExecCheck `yaml:"exec,omitempty"`
+}
+
+// CheckLevel specifies the optional check level.
+type CheckLevel string
+
+const (
+	UnsetLevel CheckLevel = ""
+	AliveLevel CheckLevel = "alive"
+	ReadyLevel CheckLevel = "ready"
+)
+
+// HTTPCheck holds the configuration for an HTTP health check.
+type HTTPCheck struct {
+	URL     string            `yaml:"url,omitempty"`
+	Headers map[string]string `yaml:"headers,omitempty"`
+}
+
+// TCPCheck holds the configuration for an HTTP health check.
+type TCPCheck struct {
+	Port int    `yaml:"port,omitempty"`
+	Host string `yaml:"host,omitempty"`
+}
+
+// ExecCheck holds the configuration for an exec health check.
+type ExecCheck struct {
+	Command     string            `yaml:"command,omitempty"`
+	Environment map[string]string `yaml:"environment,omitempty"`
+	UserID      *int              `yaml:"user-id,omitempty"`
+	User        string            `yaml:"user,omitempty"`
+	GroupID     *int              `yaml:"group-id,omitempty"`
+	Group       string            `yaml:"group,omitempty"`
+	WorkingDir  string            `yaml:"working-dir,omitempty"`
+}

--- a/service/pebble/plan/types.go
+++ b/service/pebble/plan/types.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package plan
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type OptionalDuration struct {
+	Value time.Duration
+	IsSet bool
+}
+
+func (o OptionalDuration) IsZero() bool {
+	return !o.IsSet
+}
+
+func (o OptionalDuration) MarshalYAML() (interface{}, error) {
+	if !o.IsSet {
+		return nil, nil
+	}
+	return o.Value.String(), nil
+}
+
+func (o *OptionalDuration) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("duration must be a YAML string")
+	}
+	duration, err := time.ParseDuration(value.Value)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q", value.Value)
+	}
+	o.Value = duration
+	o.IsSet = true
+	return nil
+}
+
+type OptionalFloat struct {
+	Value float64
+	IsSet bool
+}
+
+func (o OptionalFloat) IsZero() bool {
+	return !o.IsSet
+}
+
+func (o OptionalFloat) MarshalYAML() (interface{}, error) {
+	if !o.IsSet {
+		return nil, nil
+	}
+	return o.Value, nil
+}
+
+func (o *OptionalFloat) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("value must be a YAML number")
+	}
+	n, err := strconv.ParseFloat(value.Value, 64)
+	if err != nil {
+		return fmt.Errorf("invalid floating-point number %q", value.Value)
+	}
+	o.Value = n
+	o.IsSet = true
+	return nil
+}


### PR DESCRIPTION
We were previously using the version of Pebble that had the exported "plan" package. However, this was reverted to an internal package in https://github.com/canonical/pebble/pull/157. So this PR does two things:

1) Avoids the use of the (now-nonexistent) canonical/pebble/plan package by copying a subset of the plan structs into a local `service/pebble/plan` package. Note that there's **no new code here**, it's all copied, so the new files don't need thorough review.
2) Update to the latest version of Pebble. This includes the commits shown at https://github.com/canonical/pebble/compare/dfff363...054e5fb. The main changes:

* Revert move of plan package
* Add "ls" client command
* Add "mkdir" client command
* Improve README
* Add "current-since" field to services API and CLI
* Add "rm" client command
* Use strutil and randutil from x-go library

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
