### PR TITLE
[JUJU-2952] update help messages referencing charm store

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -628,7 +628,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.UnitCommandBase.SetFlags(f)
 	c.ModelCommandBase.SetFlags(f)
 	f.IntVar(&c.NumUnits, "n", 1, "Number of application units to deploy for principal charms")
-	f.StringVar(&c.channelStr, "channel", "", "Channel to use when deploying a charm or bundle from the charm store, or charm hub")
+	f.StringVar(&c.channelStr, "channel", "", "Channel to use when deploying a charm or bundle from charm hub")
 	f.Var(&c.ConfigOptions, "config", "Either a path to yaml-formatted application config file or a key=value pair ")
 
 	f.BoolVar(&c.Trust, "trust", false, "Allows charm to run hooks that require access credentials")

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -384,16 +384,16 @@ or channel can optionally be specified:
   juju deploy ch:postgresql --channel edge
   juju deploy ch:ubuntu --revision 17 --channel edge
 
-All the above deployments use remote charms found in Charm Hub, denoted by the
-'ch:' prefix.  Remote charms with no prefix will be deployed from Charm Hub.
+All the above deployments use remote charms found in Charmhub, denoted by the
+'ch:' prefix.  Remote charms with no prefix will be deployed from Charmhub.
 
 If a channel is specified, it will be used as the source for looking up the
-charm or bundle from Charm Hub. When used in a bundle deployment context,
+charm or bundle from Charmhub. When used in a bundle deployment context,
 the specified channel is only used for retrieving the bundle and is ignored when
 looking up the charms referenced by the bundle. However, each charm within a
 bundle is allowed to explicitly specify the channel used to look it up.
 
-If a revision is specified, a channel must also be specified for Charm Hub charms
+If a revision is specified, a channel must also be specified for Charmhub charms
 and bundles.  The charm will be deployed with revision.  The channel will be used
 when refreshing the application in the future.
 
@@ -628,7 +628,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.UnitCommandBase.SetFlags(f)
 	c.ModelCommandBase.SetFlags(f)
 	f.IntVar(&c.NumUnits, "n", 1, "Number of application units to deploy for principal charms")
-	f.StringVar(&c.channelStr, "channel", "", "Channel to use when deploying a charm or bundle from charm hub")
+	f.StringVar(&c.channelStr, "channel", "", "Channel to use when deploying a charm or bundle from Charmhub")
 	f.Var(&c.ConfigOptions, "config", "Either a path to yaml-formatted application config file or a key=value pair ")
 
 	f.BoolVar(&c.Trust, "trust", false, "Allows charm to run hooks that require access credentials")

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -79,7 +79,7 @@ type DeploySuiteBase struct {
 }
 
 // deployCommand returns a deploy command that stubs out the
-// charm store and the controller deploy API.
+// charm repository and the controller deploy API.
 func (s *DeploySuiteBase) deployCommand() *DeployCommand {
 	deploy := s.deployCommandForState()
 	deploy.NewDeployAPI = func() (deployer.DeployerAPI, error) {
@@ -95,7 +95,7 @@ func (s *DeploySuiteBase) deployCommand() *DeployCommand {
 }
 
 // deployCommandForState returns a deploy command that stubs out the
-// charm store but writes data to the juju database.
+// charm repository but writes data to the juju database.
 func (s *DeploySuiteBase) deployCommandForState() *DeployCommand {
 	deploy := newDeployCommand()
 	deploy.Steps = nil

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -393,7 +393,7 @@ func (h *bundleHandler) resolveCharmChannelAndRevision(charmURL string, charmBas
 		return charmChannel, -1, nil
 	}
 	// If the charm URL already contains a revision, return that before
-	// attempting to resolve a revision from any charm store. We can ignore the
+	// attempting to resolve a revision from any charm repository. We can ignore the
 	// error here, as we want to just parse out the charm URL.
 	// Resolution and validation of the charm URL happens further down.
 	if curl, err := charm.ParseURL(charmURL); err == nil {

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -369,7 +369,7 @@ func (c *repositoryCharm) String() string {
 	return fmt.Sprintf("%s%s%s", str, revision, channel)
 }
 
-// PrepareAndDeploy finishes preparing to deploy a charm store charm,
+// PrepareAndDeploy finishes preparing to deploy a repository charm,
 // then deploys it.
 func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerAPI, resolver Resolver) error {
 	userRequestedURL := c.userRequestedURL

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -66,7 +66,7 @@ type ModelConstraintsClient interface {
 
 const bundleDiffDoc = `
 Bundle can be a local bundle file or the name of a bundle in
-charm hub. The bundle can also be combined with overlays (in the
+Charmhub. The bundle can also be combined with overlays (in the
 same way as the deploy command) before comparing with the model.
 
 The map-machines option works similarly as for the deploy command, but
@@ -161,7 +161,7 @@ func (c *diffBundleCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.arch, "arch", "", fmt.Sprintf("specify an arch <%s>", c.archArgumentList()))
 	f.StringVar(&c.series, "series", "", "specify a series. DEPRECATED: use --base")
 	f.StringVar(&c.base, "base", "", "specify a base")
-	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the bundle from charm hub")
+	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the bundle from Charmhub")
 	f.Var(cmd.NewAppendStringsValue(&c.bundleOverlays), "overlay", "Bundles to overlay on the primary bundle, applied in order")
 	f.StringVar(&c.machineMap, "map-machines", "", "Indicates how existing machines correspond to bundle machines")
 	f.BoolVar(&c.annotations, "annotations", false, "Include differences in annotations")

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -66,7 +66,7 @@ type ModelConstraintsClient interface {
 
 const bundleDiffDoc = `
 Bundle can be a local bundle file or the name of a bundle in
-the charm store. The bundle can also be combined with overlays (in the
+charm hub. The bundle can also be combined with overlays (in the
 same way as the deploy command) before comparing with the model.
 
 The map-machines option works similarly as for the deploy command, but
@@ -161,7 +161,7 @@ func (c *diffBundleCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.arch, "arch", "", fmt.Sprintf("specify an arch <%s>", c.archArgumentList()))
 	f.StringVar(&c.series, "series", "", "specify a series. DEPRECATED: use --base")
 	f.StringVar(&c.base, "base", "", "specify a base")
-	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the bundle from the charm hub or charm store")
+	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the bundle from charm hub")
 	f.Var(cmd.NewAppendStringsValue(&c.bundleOverlays), "overlay", "Bundles to overlay on the primary bundle, applied in order")
 	f.StringVar(&c.machineMap, "map-machines", "", "Indicates how existing machines correspond to bundle machines")
 	f.BoolVar(&c.annotations, "annotations", false, "Include differences in annotations")

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -250,7 +250,7 @@ func (c *refreshCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.Force, "force", false, "Allow a charm to be refreshed which bypasses LXD profile allow list")
 	f.BoolVar(&c.ForceUnits, "force-units", false, "Refresh all units immediately, even if in error state")
-	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the charm or bundle from the charm store or charm hub")
+	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the charm from charm hub")
 	f.BoolVar(&c.ForceBase, "force-series", false, "Refresh even if series of deployed applications are not supported by the new charm")
 	f.StringVar(&c.SwitchURL, "switch", "", "Crossgrade to a different charm")
 	f.StringVar(&c.CharmPath, "path", "", "Refresh to a charm located at path")

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -250,7 +250,7 @@ func (c *refreshCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ModelCommandBase.SetFlags(f)
 	f.BoolVar(&c.Force, "force", false, "Allow a charm to be refreshed which bypasses LXD profile allow list")
 	f.BoolVar(&c.ForceUnits, "force-units", false, "Refresh all units immediately, even if in error state")
-	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the charm from charm hub")
+	f.StringVar(&c.channelStr, "channel", "", "Channel to use when getting the charm from Charmhub")
 	f.BoolVar(&c.ForceBase, "force-series", false, "Refresh even if series of deployed applications are not supported by the new charm")
 	f.StringVar(&c.SwitchURL, "switch", "", "Crossgrade to a different charm")
 	f.StringVar(&c.CharmPath, "path", "", "Refresh to a charm located at path")

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -411,5 +411,5 @@ func (r *charmHubRefresher) Refresh() (*CharmID, error) {
 }
 
 func (r *charmHubRefresher) String() string {
-	return fmt.Sprintf("attempting to refresh charm hub charm %q", r.charmRef)
+	return fmt.Sprintf("attempting to refresh Charmhub charm %q", r.charmRef)
 }


### PR DESCRIPTION
Some help messages still references the no longer supported charm store, no longer. Also there was a bad reference indicating that bundles could be refreshed, when this is not true. Juju has not concept of a bundle after deployment.

## QA steps

```sh
$ juju refresh --help | grep -i channel
--channel (= "")
    Channel to use when getting the charm from charm hub
$ juju diff-bundle --help | grep -i channel
--channel (= "")
    Channel to use when getting the bundle from charm hub
$ juju deploy --help | grep -i channel
--channel (= "")
    Channel to use when deploying a charm or bundle from charm hub
....
```

