### PR TITLE
[JUJU-2975] Vault secret paths

### DIFF
--- a/secrets/provider/vault/backend.go
+++ b/secrets/provider/vault/backend.go
@@ -14,7 +14,7 @@ import (
 )
 
 type vaultBackend struct {
-	modelUUID string
+	mountPath string
 	client    *vault.Client
 }
 
@@ -24,7 +24,7 @@ func (k vaultBackend) GetContent(ctx context.Context, revisionId string) (_ secr
 		err = maybePermissionDenied(err)
 	}()
 
-	s, err := k.client.KVv1(k.modelUUID).Get(ctx, revisionId)
+	s, err := k.client.KVv1(k.mountPath).Get(ctx, revisionId)
 	if isNotFound(err) {
 		return nil, errors.NotFoundf("secret revision %q", revisionId)
 	} else if err != nil {
@@ -45,11 +45,11 @@ func (k vaultBackend) DeleteContent(ctx context.Context, revisionId string) (err
 
 	// Read the content first so we can return a not found error
 	// if it doesn't exist.
-	_, err = k.client.KVv1(k.modelUUID).Get(ctx, revisionId)
+	_, err = k.client.KVv1(k.mountPath).Get(ctx, revisionId)
 	if isNotFound(err) {
 		return errors.NotFoundf("secret revision %q", revisionId)
 	}
-	return k.client.KVv1(k.modelUUID).Delete(ctx, revisionId)
+	return k.client.KVv1(k.mountPath).Delete(ctx, revisionId)
 }
 
 // SaveContent implements SecretsBackend.
@@ -63,7 +63,7 @@ func (k vaultBackend) SaveContent(ctx context.Context, uri *secrets.URI, revisio
 	for k, v := range value.EncodedValues() {
 		val[k] = v
 	}
-	err = k.client.KVv1(k.modelUUID).Put(ctx, path, val)
+	err = k.client.KVv1(k.mountPath).Put(ctx, path, val)
 	return path, errors.Annotatef(err, "saving secret content for %q", uri)
 }
 

--- a/secrets/provider/vault/errors.go
+++ b/secrets/provider/vault/errors.go
@@ -34,6 +34,15 @@ func isAlreadyExists(err error, message string) bool {
 	return false
 }
 
+func isMountNotFound(err error) bool {
+	var apiErr *api.ResponseError
+	if errors.As(err, &apiErr) {
+		errMessage := strings.Join(apiErr.Errors, ",")
+		return apiErr.StatusCode == http.StatusBadRequest && strings.Contains(errMessage, "no matching mount")
+	}
+	return false
+}
+
 func maybePermissionDenied(err error) error {
 	var apiErr *api.ResponseError
 	if errors.As(err, &apiErr) {

--- a/secrets/provider/vault/package_test.go
+++ b/secrets/provider/vault/package_test.go
@@ -7,8 +7,14 @@ import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/secrets/provider"
 )
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
+}
+
+func MountPath(b provider.SecretsBackend) string {
+	return b.(*vaultBackend).mountPath
 }


### PR DESCRIPTION
We were creating a mount point equal to the full model UUID on vault. Also, the policies were named with the full model UUID.
This PR uses instead the shorter "modelname-uuid[:6]" format.

## QA steps

bootstrap form 3.1.1 edge snap
create secrets
check vault ui to see full model uuid is used in paths and policies
upgrade to this PR
access existing secrets
create new secret, check vault paths
remove a secret, check new and legacy policies and also secret is removed
delete model
check all artefacts including old policies are removed