### PR TITLE
[JUJU-2951] Fix opened-ports return, merge with pending open/close port ranges

### DIFF
--- a/core/network/portrange.go
+++ b/core/network/portrange.go
@@ -16,6 +16,72 @@ import (
 // particular feature.
 type GroupedPortRanges map[string][]PortRange
 
+// MergePendingOpenPortRanges will merge this group's port ranges with the
+// provided *open* ports. If the provided range already exists in this group
+// then this method returns false and the group is not modified.
+func (grp GroupedPortRanges) MergePendingOpenPortRanges(pendingOpenRanges GroupedPortRanges) bool {
+	var modified bool
+	for endpointName, pendingRanges := range pendingOpenRanges {
+		for _, pendingRange := range pendingRanges {
+			if grp.rangeExistsForEndpoint(endpointName, pendingRange) {
+				// Exists, no op for opening.
+				continue
+			}
+			grp[endpointName] = append(grp[endpointName], pendingRange)
+			modified = true
+		}
+	}
+	return modified
+}
+
+// MergePendingClosePortRanges will merge this group's port ranges with the
+// provided *closed* ports. If the provided range does not exists in this group
+// then this method returns false and the group is not modified.
+func (grp GroupedPortRanges) MergePendingClosePortRanges(pendingCloseRanges GroupedPortRanges) bool {
+	var modified bool
+	for endpointName, pendingRanges := range pendingCloseRanges {
+		for _, pendingRange := range pendingRanges {
+			if !grp.rangeExistsForEndpoint(endpointName, pendingRange) {
+				// Not exists, no op for closing.
+				continue
+			}
+			modified = grp.removePortRange(endpointName, pendingRange)
+		}
+	}
+	return modified
+}
+
+func (grp GroupedPortRanges) removePortRange(endpointName string, portRange PortRange) bool {
+	var modified bool
+	existingRanges := grp[endpointName]
+	for i, v := range existingRanges {
+		if v != portRange {
+			continue
+		}
+		existingRanges = append(existingRanges[:i], existingRanges[i+1:]...)
+		if len(existingRanges) == 0 {
+			delete(grp, endpointName)
+		} else {
+			grp[endpointName] = existingRanges
+		}
+		modified = true
+	}
+	return modified
+}
+
+func (grp GroupedPortRanges) rangeExistsForEndpoint(endpointName string, portRange PortRange) bool {
+	if len(grp[endpointName]) == 0 {
+		return false
+	}
+
+	for _, existingRange := range grp[endpointName] {
+		if existingRange == portRange {
+			return true
+		}
+	}
+	return false
+}
+
 // UniquePortRanges returns the unique set of PortRanges in this group.
 func (grp GroupedPortRanges) UniquePortRanges() []PortRange {
 	var allPorts []PortRange


### PR DESCRIPTION
When calling `opened-ports` the resulting set did not include the pending open/close requests, this PR adds these pending requests to the result.

For this, I moved the "merge" logic functions from `state` to `core/network`, this way we can call them both from state and from the uniter `context`, thus having the pending open/close requests available and mergeable with the already opened ports.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

To correctly QA this, I had to deploy a charm that made use of `open_port()` and then `opened_ports()`, but this was merged https://github.com/canonical/operator/pull/905 recently, so the charm has to be packed, then unzip it, then replace the `/venv/ops` folder with the source `ops/` folder from https://github.com/canonical/operator and then zipped again. 
After that, we can deploy the charm. 

Here is a minimal content for `src/charm.py` (taken from https://juju.is/docs/sdk/build-and-deploy-minimal-machine-charm):
```python
...
    def _on_install(self, event):
        """
            install is the first core hook to fire when deploying.
        """
        logger.info("Step 1/3: INSTALL")
        self.unit.status = MaintenanceStatus("Step: 1/3")

        logger.info("Step 1/3: Opening tcp 5432")
        self.unit.open_port("tcp", 5432)
        opened = self.unit.opened_ports()
        logger.info("Step 1/3: opened ports: " + repr(opened))

...
```
then :
```sh
charmcraft pack
unzip mini_ubuntu-22.04-amd64.charm -d mini
rm -rf mini/venv/ops
cp -r ~/workspace/canonical/operator/ops mini/venv
zip -r mini_ubuntu-22.04-amd64.charm mini/*

juju deploy ./mini_ubuntu-22.04-amd64.charm    
```
Before this patch (develop), the logs would show:

```
unit-mini-0: 13:52:16 INFO unit.mini/0.juju-log Step 1/3: INSTALL
unit-mini-0: 13:52:16 INFO unit.mini/0.juju-log Step 1/3: Opening tcp 5432
unit-mini-0: 13:52:16 INFO unit.mini/0.juju-log Step 1/3: opened ports: set()
```

With this patch they should be:

```
unit-mini-0: 13:43:35 INFO unit.mini/0.juju-log Step 1/3: INSTALL
unit-mini-0: 13:43:35 INFO unit.mini/0.juju-log Step 1/3: Opening tcp 5432
unit-mini-0: 13:43:35 INFO unit.mini/0.juju-log Step 1/3: opened ports: {OpenedPort(protocol='tcp', port=5432)}
```



## Bug reference

https://bugs.launchpad.net/juju/+bug/2008035