### PR TITLE
[JUJU-2160] Tidy up Getdeployer on client

### DIFF
--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -265,6 +265,7 @@ type DeployCommand struct {
 	// CharmOrBundle is either a charm URL, a path where a charm can be found,
 	// or a bundle name.
 	CharmOrBundle string
+	DeployerKind  deployer.DeployerType
 
 	// BundleOverlay refers to config files that specify additional bundle
 	// configuration to be merged with the main bundle.
@@ -664,7 +665,7 @@ func (c *DeployCommand) Init(args []string) error {
 	// a bundle, only the components. These flags will be verified in the
 	// GetDeployer instead.
 	if err := c.validateStorageByModelType(); err != nil {
-		if !errors.IsNotFound(err) {
+		if !errors.Is(err, errors.NotFound) {
 			return errors.Trace(err)
 		}
 		// It is possible that we will not be able to get model type to validate with.
@@ -689,6 +690,35 @@ func (c *DeployCommand) Init(args []string) error {
 	default:
 		return cmd.CheckEmpty(args[2:])
 	}
+
+	// Determine the type of deploy we have
+	// Local Bundle?
+	_, fileStatErr := c.ModelCommandBase.Filesystem().Stat(c.CharmOrBundle)
+	if fileStatErr == nil && !charm.IsValidLocalCharmOrBundlePath(c.CharmOrBundle) {
+		return errors.Errorf(""+
+			"The charm or bundle %q is ambiguous.\n"+
+			"To deploy a local charm or bundle, run `juju deploy ./%[1]s`.\n"+
+			"To deploy a charm or bundle from CharmHub, run `juju deploy ch:%[1]s`.",
+			c.CharmOrBundle,
+		)
+	}
+
+	if ds, localBundleDataErr := charm.LocalBundleDataSource(c.CharmOrBundle); localBundleDataErr == nil {
+		c.DeployerKind = &deployer.LocalBundleDeployerType{LocalBundleDataSource: ds}
+	} else if !errors.Is(localBundleDataErr, errors.NotFound) {
+		// Only raise if it's not a NotFound.
+		// Otherwise, no need to raise, it's not a bundle,
+		// continue with trying for local charm.
+		return errors.Annotatef(localBundleDataErr, "cannot deploy %v", c.CharmOrBundle)
+	}
+
+	// Local Charm?
+
+	// Predeployed local charm?
+
+	// Repository bundle?
+
+	// Repository charm.
 
 	useExisting, mapping, err := parseMachineMap(c.machineMap)
 	if err != nil {
@@ -899,6 +929,7 @@ func (c *DeployCommand) getDeployerFactory(base series.Base, defaultCharmSchema 
 		BundleStorage:      c.BundleStorage,
 		Channel:            c.Channel,
 		CharmOrBundle:      c.CharmOrBundle,
+		DeployerKind:       c.DeployerKind,
 		DefaultCharmSchema: defaultCharmSchema,
 		ConfigOptions:      c.ConfigOptions,
 		Constraints:        c.Constraints,

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -313,7 +313,7 @@ func (s *DeploySuite) TestBlockDeploy(c *gc.C) {
 
 func (s *DeploySuite) TestInvalidPath(c *gc.C) {
 	err := s.runDeploy(c, "/home/nowhere")
-	c.Assert(err, gc.ErrorMatches, `cannot resolve charm or bundle "nowhere": charm or bundle not found`)
+	c.Assert(err, gc.ErrorMatches, `no charm was found at "/home/nowhere"`)
 }
 
 func (s *DeploySuite) TestInvalidFileFormat(c *gc.C) {

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -327,6 +327,7 @@ func (d *factory) determineSeriesForLocalCharm(charmOrBundle string, getter Mode
 			Force:               d.force,
 			Conf:                modelCfg,
 			FromBundle:          false,
+			Logger:              logger,
 		}
 
 		if len(supportedSeries) == 0 {

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -70,7 +70,6 @@ func (s *deployerSuite) SetUpTest(_ *gc.C) {
 
 func (s *deployerSuite) TestGetDeployerPredeployedLocalCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
 	s.expectModelType()
 
 	cfg := s.basicDeployerConfig()
@@ -86,14 +85,12 @@ func (s *deployerSuite) TestGetDeployerPredeployedLocalCharm(c *gc.C) {
 
 func (s *deployerSuite) TestGetDeployerLocalCharm(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
 	s.expectModelGet(c)
 	cfg := s.basicDeployerConfig(series.MustParseBaseFromString("ubuntu@18.04"))
 	s.expectModelType()
 
 	dir := c.MkDir()
 	charmPath := testcharms.RepoWithSeries("bionic").ClonedDirPath(dir, "multi-series")
-
 	s.expectStat(charmPath, nil)
 	cfg.CharmOrBundle = charmPath
 
@@ -106,13 +103,13 @@ func (s *deployerSuite) TestGetDeployerLocalCharm(c *gc.C) {
 
 func (s *deployerSuite) TestGetDeployerLocalCharmError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-
+	path := "./bad.charm"
 	factory := s.newDeployerFactory().(*factory)
-	factory.charmOrBundle = "./bad.charm"
+	factory.charmOrBundle = path
 
-	s.expectStat("./bad.charm", os.ErrNotExist)
+	s.expectStat(path, os.ErrNotExist)
 
-	_, err := factory.maybePredeployedLocalCharm()
+	_, err := factory.GetDeployer(DeployerConfig{CharmOrBundle: path}, s.modelConfigGetter, nil)
 	c.Assert(err, gc.ErrorMatches, `no charm was found at "./bad.charm"`)
 }
 
@@ -123,14 +120,13 @@ func (s *deployerSuite) TestGetDeployerCharmHubCharm(c *gc.C) {
 
 func (s *deployerSuite) testGetDeployerRepositoryCharm(c *gc.C, ch *charm.URL) {
 	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
+
 	s.expectModelType()
 	// NotValid ensures that maybeReadRepositoryBundle won't find
 	// charmOrBundle is a bundle.
 	s.expectResolveBundleURL(errors.NotValidf("not a bundle"), 1)
 
 	cfg := s.basicDeployerConfig()
-	s.expectStat(ch.String(), errors.NotFoundf("file"))
 	cfg.CharmOrBundle = ch.String()
 
 	factory := s.newDeployerFactory()
@@ -160,14 +156,13 @@ func (s *deployerSuite) TestGetDeployerCharmHubCharmWithRevisionFail(c *gc.C) {
 
 func (s *deployerSuite) testGetDeployerRepositoryCharmWithRevision(c *gc.C, ch *charm.URL, cfg DeployerConfig) (Deployer, error) {
 	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
+
 	s.expectModelType()
 	// NotValid ensures that maybeReadRepositoryBundle won't find
 	// charmOrBundle is a bundle.
 	s.expectResolveBundleURL(errors.NotValidf("not a bundle"), 1)
 
 	cfg.CharmOrBundle = ch.String()
-	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 
 	factory := s.newDeployerFactory()
 	return factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
@@ -175,13 +170,11 @@ func (s *deployerSuite) testGetDeployerRepositoryCharmWithRevision(c *gc.C, ch *
 
 func (s *deployerSuite) TestSeriesOverride(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
 	s.expectModelType()
 	s.expectResolveBundleURL(errors.NotValidf("not a bundle"), 1)
 
 	cfg := s.basicDeployerConfig()
 	ch := charm.MustParseURL("ch:test-charm")
-	s.expectStat(ch.String(), errors.NotFoundf("file"))
 	cfg.CharmOrBundle = ch.String()
 
 	factory := s.newDeployerFactory()
@@ -196,7 +189,6 @@ func (s *deployerSuite) TestSeriesOverride(c *gc.C) {
 
 func (s *deployerSuite) TestGetDeployerLocalBundle(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
 
 	cfg := s.basicDeployerConfig(series.MustParseBaseFromString("ubuntu@18.04"))
 	cfg.FlagSet = &gnuflag.FlagSet{}
@@ -225,52 +217,53 @@ func (s *deployerSuite) TestGetDeployerLocalBundle(c *gc.C) {
 }
 
 func (s *deployerSuite) TestGetDeployerCharmHubBundleWithChannel(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
 	bundle := charm.MustParseURL("ch:test-bundle")
 	cfg := s.channelDeployerConfig()
 	cfg.CharmOrBundle = bundle.String()
 
-	deployer, err := s.testGetDeployerRepositoryBundle(c, cfg)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s from channel edge", bundle.String()))
-}
-
-func (s *deployerSuite) TestGetDeployerCharmHubBundleWithRevision(c *gc.C) {
-	bundle := charm.MustParseURL("ch:test-bundle")
-	cfg := s.basicDeployerConfig()
-	cfg.Revision = 8
-	cfg.CharmOrBundle = bundle.String()
-
-	deployer, err := s.testGetDeployerRepositoryBundle(c, cfg)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s with revision 8", bundle.String()))
-}
-
-func (s *deployerSuite) testGetDeployerRepositoryBundle(c *gc.C, cfg DeployerConfig) (Deployer, error) {
-	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
-
 	s.expectResolveBundleURL(nil, 1)
-
 	cfg.Base = series.MustParseBaseFromString("ubuntu@18.04")
 	cfg.FlagSet = &gnuflag.FlagSet{}
-	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
+
 	s.expectModelType()
 	s.expectGetBundle(nil)
 	s.expectData()
 
 	factory := s.newDeployerFactory()
-	return factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s from channel edge", bundle.String()))
+}
+
+func (s *deployerSuite) TestGetDeployerCharmHubBundleWithRevision(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	bundle := charm.MustParseURL("ch:test-bundle")
+	cfg := s.basicDeployerConfig()
+	cfg.Revision = 8
+	cfg.CharmOrBundle = bundle.String()
+	cfg.Base = series.MustParseBaseFromString("ubuntu@18.04")
+	cfg.FlagSet = &gnuflag.FlagSet{}
+	s.expectModelType()
+	s.expectGetBundle(nil)
+	s.expectData()
+
+	s.expectResolveBundleURL(nil, 1)
+	factory := s.newDeployerFactory()
+	deployer, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(deployer.String(), gc.Equals, fmt.Sprintf("deploy bundle: %s with revision 8", bundle.String()))
 }
 
 func (s *deployerSuite) TestGetDeployerCharmHubBundleWithRevisionURL(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
 
 	bundle := charm.MustParseURL("ch:test-bundle-8")
 	cfg := s.basicDeployerConfig(series.MustParseBaseFromString("ubuntu@18.04"))
 	cfg.CharmOrBundle = bundle.String()
 	cfg.FlagSet = &gnuflag.FlagSet{}
-	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 	s.expectModelType()
 
 	factory := s.newDeployerFactory()
@@ -280,17 +273,14 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleWithRevisionURL(c *gc.C) {
 
 func (s *deployerSuite) TestGetDeployerCharmHubBundleError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.expectFilesystem()
-
-	s.expectResolveBundleURL(nil, 1)
 
 	bundle := charm.MustParseURL("ch:test-bundle")
 	cfg := s.channelDeployerConfig(series.MustParseBaseFromString("ubuntu@18.04"))
 	cfg.Revision = 42
 	cfg.CharmOrBundle = bundle.String()
 	cfg.FlagSet = &gnuflag.FlagSet{}
-	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 	s.expectModelType()
+	s.expectResolveBundleURL(nil, 1)
 
 	factory := s.newDeployerFactory()
 	_, err := factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
@@ -362,6 +352,8 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithApplicationName(c *gc.C)
 	defer s.setupMocks(c).Finish()
 	s.expectModelGet(c)
 
+	url := "local:meshuggah"
+	s.expectStat(url, errors.NotFoundf("file"))
 	s.charmReader.EXPECT().ReadCharm("meshuggah").Return(s.charm, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
 	s.charm.EXPECT().Meta().Return(&charm.Meta{Series: []string{"focal"}}).AnyTimes()
@@ -369,12 +361,13 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithApplicationName(c *gc.C)
 	f := &factory{
 		clock:           clock.WallClock,
 		applicationName: "meshuggah",
-		charmOrBundle:   "local:meshuggah",
+		charmOrBundle:   url,
 		charmReader:     s.charmReader,
 		model:           s.modelCommand,
+		fileSystem:      s.filesystem,
 	}
 
-	_, err := f.maybeReadLocalCharm(s.modelConfigGetter)
+	_, err := f.GetDeployer(DeployerConfig{CharmOrBundle: url}, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -382,18 +375,21 @@ func (s *deployerSuite) TestMaybeReadLocalCharmErrorWithoutApplicationName(c *gc
 	defer s.setupMocks(c).Finish()
 	s.expectModelGet(c)
 
+	url := "local:meshuggah"
+	s.expectStat(url, errors.NotFoundf("file"))
 	s.charmReader.EXPECT().ReadCharm("meshuggah").Return(s.charm, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{}).AnyTimes()
 	s.charm.EXPECT().Meta().Return(&charm.Meta{Name: "meshuggah", Series: []string{"focal"}}).AnyTimes()
 
 	f := &factory{
 		clock:         clock.WallClock,
-		charmOrBundle: "local:meshuggah",
+		charmOrBundle: url,
 		charmReader:   s.charmReader,
 		model:         s.modelCommand,
+		fileSystem:    s.filesystem,
 	}
 
-	_, err := f.maybeReadLocalCharm(s.modelConfigGetter)
+	_, err := f.GetDeployer(DeployerConfig{CharmOrBundle: url}, s.modelConfigGetter, s.resolver)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -127,6 +127,7 @@ func (s *deployerSuite) testGetDeployerRepositoryCharm(c *gc.C, ch *charm.URL) {
 	s.expectResolveBundleURL(errors.NotValidf("not a bundle"), 1)
 
 	cfg := s.basicDeployerConfig()
+	s.expectStat(ch.String(), errors.NotFoundf("file"))
 	cfg.CharmOrBundle = ch.String()
 
 	factory := s.newDeployerFactory()
@@ -156,13 +157,13 @@ func (s *deployerSuite) TestGetDeployerCharmHubCharmWithRevisionFail(c *gc.C) {
 
 func (s *deployerSuite) testGetDeployerRepositoryCharmWithRevision(c *gc.C, ch *charm.URL, cfg DeployerConfig) (Deployer, error) {
 	defer s.setupMocks(c).Finish()
-
 	s.expectModelType()
 	// NotValid ensures that maybeReadRepositoryBundle won't find
 	// charmOrBundle is a bundle.
 	s.expectResolveBundleURL(errors.NotValidf("not a bundle"), 1)
 
 	cfg.CharmOrBundle = ch.String()
+	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 
 	factory := s.newDeployerFactory()
 	return factory.GetDeployer(cfg, s.modelConfigGetter, s.resolver)
@@ -175,6 +176,7 @@ func (s *deployerSuite) TestSeriesOverride(c *gc.C) {
 
 	cfg := s.basicDeployerConfig()
 	ch := charm.MustParseURL("ch:test-charm")
+	s.expectStat(ch.String(), errors.NotFoundf("file"))
 	cfg.CharmOrBundle = ch.String()
 
 	factory := s.newDeployerFactory()
@@ -226,7 +228,7 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleWithChannel(c *gc.C) {
 	s.expectResolveBundleURL(nil, 1)
 	cfg.Base = series.MustParseBaseFromString("ubuntu@18.04")
 	cfg.FlagSet = &gnuflag.FlagSet{}
-
+	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 	s.expectModelType()
 	s.expectGetBundle(nil)
 	s.expectData()
@@ -246,6 +248,7 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleWithRevision(c *gc.C) {
 	cfg.CharmOrBundle = bundle.String()
 	cfg.Base = series.MustParseBaseFromString("ubuntu@18.04")
 	cfg.FlagSet = &gnuflag.FlagSet{}
+	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 	s.expectModelType()
 	s.expectGetBundle(nil)
 	s.expectData()
@@ -264,6 +267,7 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleWithRevisionURL(c *gc.C) {
 	cfg := s.basicDeployerConfig(series.MustParseBaseFromString("ubuntu@18.04"))
 	cfg.CharmOrBundle = bundle.String()
 	cfg.FlagSet = &gnuflag.FlagSet{}
+	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 	s.expectModelType()
 
 	factory := s.newDeployerFactory()
@@ -279,6 +283,7 @@ func (s *deployerSuite) TestGetDeployerCharmHubBundleError(c *gc.C) {
 	cfg.Revision = 42
 	cfg.CharmOrBundle = bundle.String()
 	cfg.FlagSet = &gnuflag.FlagSet{}
+	s.expectStat(cfg.CharmOrBundle, errors.NotFoundf("file"))
 	s.expectModelType()
 	s.expectResolveBundleURL(nil, 1)
 

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -59,6 +59,24 @@ run_deploy_lxd_profile_charm_container() {
 	destroy_model "test-deploy-lxd-profile-container"
 }
 
+run_deploy_local_predeployed_charm() {
+  echo
+
+  model_name="test-deploy-local-predeployed-charm"
+  file="${TEST_DIR}/${model_name}.log"
+
+  ensure "${model_name}" "${file}"
+
+  juju deploy ./testcharms/charms/lxd-profile --base ubuntu@22.04
+  wait_for "lxd-profile" "$(idle_condition "lxd-profile")"
+
+  juju deploy local:jammy/lxd-profile-0 another-lxd-profile-app
+  wait_for "another-lxd-profile-app" "$(idle_condition "another-lxd-profile-app")"
+  wait_for "active" '.applications["another-lxd-profile-app"] | ."application-status".current'
+
+  destroy_model "${model_name}"
+}
+
 run_deploy_local_lxd_profile_charm() {
 	echo
 
@@ -267,6 +285,7 @@ test_deploy_charms() {
 		"lxd" | "localhost")
 			run "run_deploy_lxd_to_machine"
 			run "run_deploy_lxd_profile_charm"
+			run "run_deploy_local_predeployed_charm"
 			run "run_deploy_local_lxd_profile_charm"
 			;;
 		*)


### PR DESCRIPTION
This change tries to improve the client when determining what is being deployed (i.e. `local charm?`, `repository bundle?`, etc.)

The particular goals here are:
- [x] Reuse data gathered in deployment type determination where possible.
- [x] Reduce call count to resolvecharm.
- [ ] Find repository charms first, rather than last.


## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

There shouldn't be any change to behavior at all. So all the deploy integration tests need to pass as they are, and the code should be manually checked against redundancies etc.

## Notes & Discussion

There's a tiny little more to do here:
- The tests need to be passing
- Repository charms should be checked first (I saw that item after the fact), but with they way the validation code is structured this should be trivial.