### PR TITLE
[JUJU-2876] Record secret consumer info in offer model to fire releveant hooks

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -104,7 +104,7 @@ func PublishRelationChange(backend Backend, relationTag names.Tag, change params
 		}
 	}
 
-	if err := handleDepartedUnits(change, applicationTag, rel); err != nil {
+	if err := handleDepartedUnits(backend, change, applicationTag, rel); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -143,7 +143,7 @@ func handleSuspendedRelation(change params.RemoteRelationChangeEvent, rel Relati
 	return nil
 }
 
-func handleDepartedUnits(change params.RemoteRelationChangeEvent, applicationTag names.Tag, rel Relation) error {
+func handleDepartedUnits(backend Backend, change params.RemoteRelationChangeEvent, applicationTag names.Tag, rel Relation) error {
 	for _, id := range change.DepartedUnits {
 		unitTag := names.NewUnitTag(fmt.Sprintf("%s/%v", applicationTag.Id(), id))
 		logger.Debugf("unit %v has departed relation %v", unitTag.Id(), rel.Tag().Id())
@@ -153,6 +153,9 @@ func handleDepartedUnits(change params.RemoteRelationChangeEvent, applicationTag
 		}
 		logger.Debugf("%s leaving scope", unitTag.Id())
 		if err := ru.LeaveScope(); err != nil {
+			return errors.Trace(err)
+		}
+		if err := backend.RemoveSecretConsumer(unitTag); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -99,6 +99,9 @@ type Backend interface {
 
 	// ApplyOperation applies a model operation to the state.
 	ApplyOperation(op state.ModelOperation) error
+
+	// RemoveSecretConsumer removes secret references for the specified consumer.
+	RemoveSecretConsumer(consumer names.Tag) error
 }
 
 // Relation provides access a relation in global state.

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -1028,8 +1028,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 
 	s.secretsConsumer.EXPECT().SaveSecretConsumer(uri, consumer, &coresecrets.SecretConsumerMetadata{
 		Label:           "foo",
-		LatestRevision:  666,
-		CurrentRevision: 666,
+		CurrentRevision: 665,
 	})
 
 	results, err := s.facade.GetSecretContentInfo(params.GetSecretContentArgs{

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -103,6 +103,10 @@ func (st *mockState) ApplyOperation(state.ModelOperation) error {
 	return nil
 }
 
+func (st *mockState) RemoveSecretConsumer(consumer names.Tag) error {
+	return nil
+}
+
 func (st *mockState) AddRelation(eps ...state.Endpoint) (commoncrossmodel.Relation, error) {
 	rel := &mockRelation{
 		id:  len(st.relations),

--- a/apiserver/facades/controller/crossmodelsecrets/mocks/secretsconsumer.go
+++ b/apiserver/facades/controller/crossmodelsecrets/mocks/secretsconsumer.go
@@ -35,6 +35,35 @@ func (m *MockSecretsConsumer) EXPECT() *MockSecretsConsumerMockRecorder {
 	return m.recorder
 }
 
+// GetSecretConsumer mocks base method.
+func (m *MockSecretsConsumer) GetSecretConsumer(arg0 *secrets.URI, arg1 names.Tag) (*secrets.SecretConsumerMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecretConsumer", arg0, arg1)
+	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecretConsumer indicates an expected call of GetSecretConsumer.
+func (mr *MockSecretsConsumerMockRecorder) GetSecretConsumer(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).GetSecretConsumer), arg0, arg1)
+}
+
+// SaveSecretConsumer mocks base method.
+func (m *MockSecretsConsumer) SaveSecretConsumer(arg0 *secrets.URI, arg1 names.Tag, arg2 *secrets.SecretConsumerMetadata) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveSecretConsumer", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveSecretConsumer indicates an expected call of SaveSecretConsumer.
+func (mr *MockSecretsConsumerMockRecorder) SaveSecretConsumer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).SaveSecretConsumer), arg0, arg1, arg2)
+}
+
 // SecretAccess mocks base method.
 func (m *MockSecretsConsumer) SecretAccess(arg0 *secrets.URI, arg1 names.Tag) (secrets.SecretRole, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/crossmodelsecrets/state.go
+++ b/apiserver/facades/controller/crossmodelsecrets/state.go
@@ -19,6 +19,8 @@ type SecretsState interface {
 }
 
 type SecretsConsumer interface {
+	GetSecretConsumer(*secrets.URI, names.Tag) (*secrets.SecretConsumerMetadata, error)
+	SaveSecretConsumer(*secrets.URI, names.Tag, *secrets.SecretConsumerMetadata) error
 	SecretAccess(uri *secrets.URI, subject names.Tag) (secrets.SecretRole, error)
 	SecretAccessScope(uri *secrets.URI, subject names.Tag) (names.Tag, error)
 }

--- a/apiserver/facades/controller/remoterelations/mocks/remoterelations_mocks.go
+++ b/apiserver/facades/controller/remoterelations/mocks/remoterelations_mocks.go
@@ -358,6 +358,20 @@ func (mr *MockRemoteRelationsStateMockRecorder) RemoveRemoteEntity(arg0 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRemoteEntity", reflect.TypeOf((*MockRemoteRelationsState)(nil).RemoveRemoteEntity), arg0)
 }
 
+// RemoveSecretConsumer mocks base method.
+func (m *MockRemoteRelationsState) RemoveSecretConsumer(arg0 names.Tag) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveSecretConsumer", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveSecretConsumer indicates an expected call of RemoveSecretConsumer.
+func (mr *MockRemoteRelationsStateMockRecorder) RemoveSecretConsumer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecretConsumer", reflect.TypeOf((*MockRemoteRelationsState)(nil).RemoveSecretConsumer), arg0)
+}
+
 // SaveIngressNetworks mocks base method.
 func (m *MockRemoteRelationsState) SaveIngressNetworks(arg0 string, arg1 []string) (state.RelationNetworks, error) {
 	m.ctrl.T.Helper()

--- a/state/application.go
+++ b/state/application.go
@@ -391,7 +391,7 @@ func (op *DestroyApplicationOperation) deleteSecrets() error {
 		return errors.Annotatef(err, "deleting owned secrets for %q", op.app.Name())
 	}
 	// TODO(juju4) - remove
-	if err := op.app.st.removeSecretConsumer(op.app.Tag()); err != nil {
+	if err := op.app.st.RemoveSecretConsumer(op.app.Tag()); err != nil {
 		return errors.Annotatef(err, "deleting secret consumer records for %q", op.app.Name())
 	}
 	return nil

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -331,6 +331,9 @@ func (op *DestroyRemoteApplicationOperation) Done(err error) error {
 		}
 		op.AddError(errors.Errorf("force erase saas application %q history proceeded despite encountering ERROR %v", op.app, err))
 	}
+	if err := op.deleteSecretReferences(); err != nil {
+		logger.Errorf("cannot delete secret references for saas application %q: %v", op.app, err)
+	}
 	return nil
 }
 
@@ -341,6 +344,13 @@ func (op *DestroyRemoteApplicationOperation) eraseHistory() error {
 		if op.FatalError(one) {
 			return one
 		}
+	}
+	return nil
+}
+
+func (op *DestroyRemoteApplicationOperation) deleteSecretReferences() error {
+	if err := op.app.st.removeRemoteSecretConsumer(op.app.Name()); err != nil {
+		return errors.Annotatef(err, "deleting secret consumer records for %q", op.app.Name())
 	}
 	return nil
 }
@@ -499,6 +509,12 @@ func (s *RemoteApplication) removeOps(asserts bson.D) ([]txn.Op, error) {
 	}
 	tokenOps := r.removeRemoteEntityOps(s.Tag())
 	ops = append(ops, tokenOps...)
+
+	secretConsumerPermissionsOps, err := s.st.removeConsumerSecretPermissionOps(s.Tag())
+	if err != nil {
+		return nil, errors.Annotatef(err, "deleting secret consumer records for %q", s.Name())
+	}
+	ops = append(ops, secretConsumerPermissionsOps...)
 
 	// If this is the last consumed app off an external controller,
 	// also remove the external controller record.

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -16,11 +16,13 @@ import (
 
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/testing"
 	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/testing/factory"
 )
 
 type remoteApplicationSuite struct {
@@ -947,6 +949,97 @@ func (s *remoteApplicationSuite) assertDestroyWithReferencedRelation(c *gc.C, re
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	err = rel0.Refresh()
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *remoteApplicationSuite) TestDestroyAlsoDeletesSecretConsumerInfo(c *gc.C) {
+	ch := s.AddTestingCharm(c, "wordpress")
+	app := s.AddTestingApplication(c, "another", ch)
+	store := state.NewSecrets(s.State)
+	uri := secrets.NewURI()
+	cp := state.CreateSecretParams{
+		Version: 1,
+		Owner:   app.Tag(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken: &fakeToken{},
+			Label:       ptr("label"),
+			Data:        map[string]string{"foo": "bar"},
+		},
+	}
+	_, err := store.CreateSecret(uri, cp)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.SaveSecretConsumer(uri, s.application.Tag(), &secrets.SecretConsumerMetadata{CurrentRevision: 666})
+	c.Assert(err, jc.ErrorIsNil)
+
+	unit := names.NewUnitTag(s.application.Name() + "/666")
+	err = s.State.SaveSecretConsumer(uri, unit, &secrets.SecretConsumerMetadata{CurrentRevision: 667})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.GetSecretConsumer(uri, s.application.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.GetSecretConsumer(uri, unit)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.GetSecretConsumer(uri, s.application.Tag())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = s.State.GetSecretConsumer(uri, unit)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+}
+
+func (s *remoteApplicationSuite) TestDestroyAlsoDeletesSecretPermissions(c *gc.C) {
+	wpEP := []charm.Relation{
+		{Name: "db", Interface: "mysql", Role: charm.RoleRequirer, Scope: charm.ScopeGlobal},
+	}
+
+	wp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name: "remote-wordpress", OfferUUID: "offer-uuid", SourceModel: s.Model.ModelTag(),
+		Endpoints:       wpEP,
+		IsConsumerProxy: true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	mysql := s.Factory.MakeApplication(c, &factory.ApplicationParams{Name: "mysqldb"})
+
+	store := state.NewSecrets(s.State)
+	uri := secrets.NewURI()
+	cp := state.CreateSecretParams{
+		Version: 1,
+		Owner:   mysql.Tag(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken: &fakeToken{},
+			Label:       ptr("label"),
+			Data:        map[string]string{"foo": "bar"},
+		},
+	}
+	_, err = store.CreateSecret(uri, cp)
+	c.Assert(err, jc.ErrorIsNil)
+
+	mysqlEP, err := mysql.Endpoint("server")
+	c.Assert(err, jc.ErrorIsNil)
+	rel, err := s.State.AddRelation(state.Endpoint{
+		ApplicationName: "remote-wordpress",
+		Relation:        wpEP[0],
+	}, mysqlEP)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.State.GrantSecretAccess(uri, state.SecretAccessParams{
+		LeaderToken: &fakeToken{},
+		Scope:       rel.Tag(),
+		Subject:     wp.Tag(),
+		Role:        secrets.RoleView,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	access, err := s.State.SecretAccess(uri, wp.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(access, gc.Equals, secrets.RoleView)
+
+	_, err = wp.DestroyWithForce(true, time.Duration(0))
+	c.Assert(err, jc.ErrorIsNil)
+	access, err = s.State.SecretAccess(uri, wp.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(access, gc.Equals, secrets.RoleNone)
 }
 
 func (s *remoteApplicationSuite) TestDestroyRemovesStatusHistory(c *gc.C) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -614,7 +614,7 @@ func (op *DestroyUnitOperation) deleteSecrets() error {
 	if _, err := op.unit.st.deleteSecrets(ownedURIs); err != nil {
 		return errors.Annotatef(err, "deleting owned secrets for %q", op.unit.Name())
 	}
-	if err := op.unit.st.removeSecretConsumer(op.unit.Tag()); err != nil {
+	if err := op.unit.st.RemoveSecretConsumer(op.unit.Tag()); err != nil {
 		return errors.Annotatef(err, "deleting secret consumer records for %q", op.unit.Name())
 	}
 	return nil


### PR DESCRIPTION
For a cross model secret, the offering model needs to manage secret consumer info from the consuming model so that it can fire the `secret-removed` hook and remove references to the consumer when the app/units are deleted.

Also a driveby bug fix to record the correct consumed revision for peek/refresh.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

bootstrap 2 controllers, deploy juju-qa-dummy-source and offer it; in the other controller, deploy juju-qa-dummy-sink and create a cross model relation.

```
$ juju switch c1
$ juju exec --unit dummy-source/0 "secret-add foo=bar"
secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0
$ juju exec --unit dummy-source/0 "secret-grant -r 0 secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0"

$ juju switch c2
c1:admin/o -> c2:admin/c
$ juju exec --unit dummy-sink/0 "secret-get secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0"
foo: bar

$ juju switch c1
c2:admin/c -> c1:admin/o
$ juju exec --unit dummy-source/0 "secret-set secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0 foo=bar2"

$ juju switch c2
c1:admin/o -> c2:admin/c
$ juju exec --unit dummy-sink/0 "secret-get secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0"
foo: bar
$ juju exec --unit dummy-sink/0 "secret-get secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0 --peek"
foo: bar2
$ juju exec --unit dummy-sink/0 "secret-get secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0"
foo: bar
$ juju exec --unit dummy-sink/0 "secret-get secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0 --label baz"
foo: bar
$ juju exec --unit dummy-sink/0 "secret-get --label baz"
foo: bar

$ juju switch c1
c2:admin/c -> c1:admin/o
$ juju show-status-log dummy-source/0
...
02 Mar 2023 14:08:17+10:00  juju-unit  executing    running secret-remove hook for secret:cg020rhkf17hs5nd9us0/1
...


$ juju switch c2
c1:admin/o -> c2:admin/c
$ juju exec --unit dummy-sink/0 "secret-get --label baz --refresh"
foo: bar2
$ juju exec --unit dummy-sink/0 "secret-get --label baz"
foo: bar2

$ juju add-unit dummy-sink
$ juju exec --unit dummy-sink/1 "secret-get secret://bdc94272-1c0f-49e2-84f6-e3df50772020/cg020rhkf17hs5nd9us0"
foo: bar2
$ juju remove-unit dummy-sink/0
WARNING This command will perform the following actions:
will remove unit dummy-sink/0

Continue [y/N]? y

```
In a mongo shell, ensure the secret permission record for the remote proxy of dummy-source/0 is deleted.
