### PR TITLE
[JUJU-3185] Fix install hook failure breaking sidecar uniter.

### DIFF
--- a/worker/uniter/resolver/loop_test.go
+++ b/worker/uniter/resolver/loop_test.go
@@ -389,7 +389,7 @@ func (s *LoopSuite) TestCheckCharmUpgrade(c *gc.C) {
 			CharmURL: "cs:trusty/mysql-2",
 		},
 	}
-	s.testCheckCharmUpgradeCallsRun(c)
+	s.testCheckCharmUpgradeCallsRun(c, "Upgrade")
 }
 
 func (s *LoopSuite) TestCheckCharmUpgradeMissingCharmDir(c *gc.C) {
@@ -407,7 +407,27 @@ func (s *LoopSuite) TestCheckCharmUpgradeMissingCharmDir(c *gc.C) {
 			CharmURL: s.charmURL,
 		},
 	}
-	s.testCheckCharmUpgradeCallsRun(c)
+	s.testCheckCharmUpgradeCallsRun(c, "Upgrade")
+}
+
+func (s *LoopSuite) TestCheckCharmInstallMissingCharmDirInstallHookFail(c *gc.C) {
+	s.executor = &mockOpExecutor{
+		Executor: nil,
+		Stub:     envtesting.Stub{},
+		st: operation.State{
+			Installed: false,
+			Kind:      operation.RunHook,
+			Step:      operation.Pending,
+			Hook:      &hook.Info{Kind: hooks.Install},
+		},
+		run: nil,
+	}
+	s.watcher = &mockRemoteStateWatcher{
+		snapshot: remotestate.Snapshot{
+			CharmURL: s.charmURL,
+		},
+	}
+	s.testCheckCharmUpgradeCallsRun(c, "Install")
 }
 
 func (s *LoopSuite) TestCheckCharmUpgradeLXDProfile(c *gc.C) {
@@ -428,10 +448,10 @@ func (s *LoopSuite) TestCheckCharmUpgradeLXDProfile(c *gc.C) {
 			LXDProfileName:       "juju-test-mysql-2",
 		},
 	}
-	s.testCheckCharmUpgradeCallsRun(c)
+	s.testCheckCharmUpgradeCallsRun(c, "Upgrade")
 }
 
-func (s *LoopSuite) testCheckCharmUpgradeCallsRun(c *gc.C) {
+func (s *LoopSuite) testCheckCharmUpgradeCallsRun(c *gc.C, op string) {
 	s.opFactory = &mockOpFactory{
 		Factory: nil,
 		Stub:    envtesting.Stub{},
@@ -451,6 +471,9 @@ func (s *LoopSuite) testCheckCharmUpgradeCallsRun(c *gc.C) {
 	// Run not called
 	c.Assert(s.executor.Calls(), gc.HasLen, 4)
 	s.executor.CheckCallNames(c, "State", "State", "Run", "State")
+
+	c.Assert(s.opFactory.Calls(), gc.HasLen, 1)
+	s.opFactory.CheckCallNames(c, "New"+op)
 }
 
 func (s *LoopSuite) TestCancelledLockAcquisitionCausesRestart(c *gc.C) {

--- a/worker/uniter/resolver/mock_test.go
+++ b/worker/uniter/resolver/mock_test.go
@@ -32,6 +32,11 @@ type mockOpFactory struct {
 	op mockOp
 }
 
+func (f *mockOpFactory) NewInstall(charmURL string) (operation.Operation, error) {
+	f.MethodCall(f, "NewInstall", charmURL)
+	return f.op, f.NextErr()
+}
+
 func (f *mockOpFactory) NewUpgrade(charmURL string) (operation.Operation, error) {
 	f.MethodCall(f, "NewUpgrade", charmURL)
 	return f.op, f.NextErr()


### PR DESCRIPTION
When a sidecar charm unit fails the install hook and the pod was restarted, the unit's local state would not resume at the default (install op), instead resume by continuing the failed install hook. Because when the pod is restarted, the local filesystem is lost, therefor the charm is no longer on disk. This case was handled in everything except this exact scenario (normally we just run the upgrade op and hook to place the charm back on disk).

This fix reruns the install op in this exact situation. 

## QA steps

- Deploy a sidecar charm that fails in the install hook
- Delete the pod of the failed/blocked unit
- Wait for it to come back.
- Logs should continue to show the install hook failing, but don't say "charm missing from disk"
- Logs should also contain deployment of the charm to disk every time the pod is restarted.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/2009086