### PR TITLE
[JUJU-2899] fix bug in ec2 tests

### DIFF
--- a/provider/ec2/internal/testing/security_groups.go
+++ b/provider/ec2/internal/testing/security_groups.go
@@ -359,8 +359,8 @@ func (srv *Server) parsePerms(in []types.IpPermission) ([]permKey, error) {
 		}
 		for _, r := range inPerm.IpRanges {
 			ec2p.IpRanges = append(ec2p.IpRanges, types.IpRange{CidrIp: r.CidrIp})
-			perms[id1] = ec2p
 		}
+		perms[id1] = ec2p
 	}
 	// Associate each set of source groups with its IPPerm.
 	for k, g := range sourceGroups {

--- a/provider/ec2/local_test.go
+++ b/provider/ec2/local_test.go
@@ -2319,7 +2319,7 @@ func (t *localServerSuite) TestInstanceGroups(c *gc.C) {
 	// that the unneeded permission that we added earlier
 	// has been deleted).
 	perms := info[0].IpPermissions
-	c.Assert(perms, gc.HasLen, 3)
+	c.Assert(perms, gc.HasLen, 5)
 	checkPortAllowed(c, perms, 22) // SSH
 	checkPortAllowed(c, perms, int32(coretesting.FakeControllerConfig().APIPort()))
 	checkSecurityGroupAllowed(c, perms, groups[0])


### PR DESCRIPTION
Sometimes IpRanges is empty, meaning that an entry if left out, defaulting to all zeros

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
go test github.com/juju/juju/provider/ec2
```