### PR TITLE
Fix consumed secret watcher to return initial data

### DIFF
--- a/state/secrets.go
+++ b/state/secrets.go
@@ -1336,16 +1336,26 @@ func (w *consumedSecretsWatcher) Changes() <-chan []string {
 	return w.out
 }
 
-func (w *consumedSecretsWatcher) initial() error {
+func (w *consumedSecretsWatcher) initial() ([]string, error) {
 	var doc secretConsumerDoc
 	secretConsumersCollection, closer := w.db.GetCollection(secretConsumersC)
 	defer closer()
 
+	var ids []string
 	iter := secretConsumersCollection.Find(bson.D{{"consumer-tag", w.consumer}}).Iter()
 	for iter.Next(&doc) {
 		w.knownRevisions[doc.DocID] = doc.LatestRevision
+		if doc.LatestRevision < 2 {
+			continue
+		}
+		uriStr := strings.Split(w.backend.localID(doc.DocID), "#")[0]
+		uri, err := secrets.ParseURI(uriStr)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ids = append(ids, uri.String())
 	}
-	return errors.Trace(iter.Close())
+	return ids, errors.Trace(iter.Close())
 }
 
 func (w *consumedSecretsWatcher) merge(currentChanges []string, change watcher.Change) ([]string, error) {
@@ -1403,11 +1413,11 @@ func (w *consumedSecretsWatcher) loop() (err error) {
 	w.watcher.WatchCollectionWithFilter(secretConsumersC, ch, filter)
 	defer w.watcher.UnwatchCollection(secretConsumersC, ch)
 
-	if err = w.initial(); err != nil {
+	changes, err := w.initial()
+	if err != nil {
 		return errors.Trace(err)
 	}
 
-	var changes []string
 	out := w.out
 	for {
 		select {


### PR DESCRIPTION
The consumed secrets watcher was not returning data when the watcher was first started. This doesn't affect normal operation because we don't fire an event until the rev no is > 1 anyway, but we were missing getting data on an agent restart if the secret had newer revisions.

## QA steps

Just a regression test. Share a secret, update it, and ensure the consumer charm runs the secret-changed-hook.