### PR TITLE
[JUJU-2566] Add facade and backend calls for watching secret changes across models

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -106,6 +106,7 @@ var facadeVersions = map[string]int{
 	"SecretBackends":               1,
 	"SecretBackendsManager":        1,
 	"SecretBackendsRotateWatcher":  1,
+	"SecretsRevisionWatcher":       1,
 	"Secrets":                      1,
 	"SecretsManager":               1,
 	"Singular":                     2,

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -719,6 +719,144 @@ func (s *watcherSuite) TestSecretsExpiryWatcher(c *gc.C) {
 	assertNoChange()
 }
 
+func (s *watcherSuite) setupSecretsRevisionWatcher(
+	c *gc.C,
+) (*secrets.URI, func(uri *secrets.URI, rev int), func(), func()) {
+	remoteApp, err := s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name: "foo", OfferUUID: "offer-uuid", URL: "me/model.foo", SourceModel: s.Model.ModelTag()})
+	c.Assert(err, jc.ErrorIsNil)
+	// Export the remoteApp so it can be found with a token.
+	re := s.State.RemoteEntities()
+	token, err := re.ExportLocalEntity(remoteApp.Tag())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Set up the offer.
+	app := s.AddTestingApplication(c, "mysql", s.AddTestingCharm(c, "mysql"))
+	unit, password := s.Factory.MakeUnitReturningPassword(c, &factory.UnitParams{
+		Application: app,
+	})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "fred"})
+	offers := state.NewApplicationOffers(s.State)
+	offer, err := offers.AddOffer(crossmodel.AddApplicationOfferArgs{
+		OfferName:       "hosted-mysql",
+		ApplicationName: "mysql",
+		Owner:           "admin",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Add the consume permission for the offer so the macaroon
+	// discharge can occur.
+	err = s.State.CreateOfferAccess(
+		names.NewApplicationOfferTag("hosted-mysql"),
+		names.NewUserTag("fred"), permission.ConsumeAccess)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create a macaroon for authorisation.
+	bStore, err := s.State.NewBakeryStorage()
+	c.Assert(err, jc.ErrorIsNil)
+	b := bakery.New(bakery.BakeryParams{
+		RootKeyStore: bStore,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	mac, err := b.Oven.NewMacaroon(
+		context.Background(),
+		bakery.LatestVersion,
+		[]checkers.Caveat{
+			checkers.DeclaredCaveat("source-model-uuid", s.State.ModelUUID()),
+			checkers.DeclaredCaveat("offer-uuid", offer.OfferUUID),
+			checkers.DeclaredCaveat("username", "fred"),
+		}, bakery.Op{
+			Entity: "offer-uuid",
+			Action: "consume",
+		})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create a secret to watch.
+	store := state.NewSecrets(s.State)
+	uri := secrets.NewURI()
+	_, err = store.CreateSecret(uri, state.CreateSecretParams{
+		Owner: unit.Tag(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken:  &fakeToken{},
+			RotatePolicy: ptr(secrets.RotateDaily),
+			Data:         map[string]string{"foo": "bar"},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.WaitForModelWatchersIdle(c, s.Model.UUID())
+
+	apiInfo := s.APIInfo(c)
+	apiInfo.Tag = unit.Tag()
+	apiInfo.Password = password
+	apiInfo.ModelTag = s.Model.ModelTag()
+
+	apiConn, err := api.Open(apiInfo, api.DialOpts{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	client := crossmodelrelations.NewClient(apiConn)
+	w, err := client.WatchConsumedSecretsChanges(token, mac.M())
+	if !c.Check(err, jc.ErrorIsNil) {
+		_ = apiConn.Close()
+		c.FailNow()
+	}
+	stop := func() {
+		workertest.CleanKill(c, w)
+		_ = apiConn.Close()
+	}
+
+	assertNoChange := func() {
+		select {
+		case _, ok := <-w.Changes():
+			c.Fatalf("watcher sent unexpected change: (_, %v)", ok)
+		case <-time.After(coretesting.ShortWait):
+		}
+	}
+
+	assertChange := func(uri *secrets.URI, rev int) {
+		select {
+		case changes, ok := <-w.Changes():
+			c.Check(ok, jc.IsTrue)
+			if uri == nil {
+				c.Assert(changes, gc.HasLen, 0)
+				break
+			}
+			c.Assert(changes, gc.HasLen, 1)
+			c.Assert(changes[0].URI.String(), gc.Equals, uri.String())
+			c.Assert(changes[0].Revision, gc.Equals, rev)
+		case <-time.After(coretesting.LongWait):
+			c.Fatalf("watcher didn't emit an event")
+		}
+	}
+	return uri, assertChange, assertNoChange, stop
+}
+
+func (s *watcherSuite) TestSecretsRevisionWatcher(c *gc.C) {
+	uri, assertChange, assertNoChange, stop := s.setupSecretsRevisionWatcher(c)
+	defer stop()
+
+	store := state.NewSecrets(s.State)
+
+	// Initial event - no changes since we're at rev 1 still.
+	assertChange(nil, 0)
+
+	err := s.State.SaveSecretConsumer(uri, names.NewUnitTag("foo/0"), &secrets.SecretConsumerMetadata{
+		CurrentRevision: 1,
+		LatestRevision:  1,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	assertNoChange()
+
+	_, err = store.UpdateSecret(uri, state.UpdateSecretParams{
+		LeaderToken: &fakeToken{},
+		Data:        secrets.SecretData{"foo": "bar2"},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	assertChange(uri, 2)
+	assertNoChange()
+}
+
 type migrationSuite struct {
 	testing.JujuConnSuite
 }

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -644,6 +644,7 @@ func (s *loginSuite) TestAnonymousModelLogin(c *gc.C) {
 		{Name: "RelationStatusWatcher", Versions: []int{1}},
 		{Name: "RelationUnitsWatcher", Versions: []int{1}},
 		{Name: "RemoteRelationWatcher", Versions: []int{1}},
+		{Name: "SecretsRevisionWatcher", Versions: []int{1}},
 		{Name: "StringsWatcher", Versions: []int{1}},
 	})
 }

--- a/apiserver/allfacades.go
+++ b/apiserver/allfacades.go
@@ -239,6 +239,7 @@ func AllFacades() *facade.Registry {
 	registry.MustRegister("ModelSummaryWatcher", 1, newModelSummaryWatcher, reflect.TypeOf((*SrvModelSummaryWatcher)(nil)))
 	registry.MustRegister("SecretsTriggerWatcher", 1, newSecretsTriggerWatcher, reflect.TypeOf((*srvSecretTriggerWatcher)(nil)))
 	registry.MustRegister("SecretBackendsRotateWatcher", 1, newSecretBackendsRotateWatcher, reflect.TypeOf((*srvSecretBackendsRotateWatcher)(nil)))
+	registry.MustRegister("SecretsRevisionWatcher", 1, newSecretsRevisionWatcher, reflect.TypeOf((*srvSecretsRevisionWatcher)(nil)))
 
 	return registry
 }

--- a/apiserver/facades/controller/crosscontroller/register.go
+++ b/apiserver/facades/controller/crosscontroller/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 )

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/life"
 	corelogger "github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/watcher"
@@ -33,6 +34,7 @@ var logger = loggo.GetLoggerWithLabels("juju.apiserver.crossmodelrelations", cor
 type egressAddressWatcherFunc func(facade.Resources, firewall.State, params.Entities) (params.StringsWatchResults, error)
 type relationStatusWatcherFunc func(CrossModelRelationsState, names.RelationTag) (state.StringsWatcher, error)
 type offerStatusWatcherFunc func(CrossModelRelationsState, string) (OfferWatcher, error)
+type consumedSecretsWatcherFunc func(CrossModelRelationsState, string) (state.StringsWatcher, error)
 
 // CrossModelRelationsAPI provides access to the CrossModelRelations API facade.
 type CrossModelRelationsAPI struct {
@@ -46,9 +48,10 @@ type CrossModelRelationsAPI struct {
 	authCtxt        *commoncrossmodel.AuthContext
 	relationToOffer map[string]string
 
-	egressAddressWatcher  egressAddressWatcherFunc
-	relationStatusWatcher relationStatusWatcherFunc
-	offerStatusWatcher    offerStatusWatcherFunc
+	egressAddressWatcher   egressAddressWatcherFunc
+	relationStatusWatcher  relationStatusWatcherFunc
+	offerStatusWatcher     offerStatusWatcherFunc
+	consumedSecretsWatcher consumedSecretsWatcherFunc
 }
 
 // NewCrossModelRelationsAPI returns a new server-side CrossModelRelationsAPI facade.
@@ -61,18 +64,20 @@ func NewCrossModelRelationsAPI(
 	egressAddressWatcher egressAddressWatcherFunc,
 	relationStatusWatcher relationStatusWatcherFunc,
 	offerStatusWatcher offerStatusWatcherFunc,
+	consumedSecretsWatcher consumedSecretsWatcherFunc,
 ) (*CrossModelRelationsAPI, error) {
 	return &CrossModelRelationsAPI{
-		ctx:                   context.Background(),
-		st:                    st,
-		fw:                    fw,
-		resources:             resources,
-		authorizer:            authorizer,
-		authCtxt:              authCtxt,
-		egressAddressWatcher:  egressAddressWatcher,
-		relationStatusWatcher: relationStatusWatcher,
-		offerStatusWatcher:    offerStatusWatcher,
-		relationToOffer:       make(map[string]string),
+		ctx:                    context.Background(),
+		st:                     st,
+		fw:                     fw,
+		resources:              resources,
+		authorizer:             authorizer,
+		authCtxt:               authCtxt,
+		egressAddressWatcher:   egressAddressWatcher,
+		relationStatusWatcher:  relationStatusWatcher,
+		offerStatusWatcher:     offerStatusWatcher,
+		consumedSecretsWatcher: consumedSecretsWatcher,
+		relationToOffer:        make(map[string]string),
 	}, nil
 }
 
@@ -454,6 +459,10 @@ func watchOfferStatus(st CrossModelRelationsState, offerUUID string) (OfferWatch
 	return &offerWatcher{mw, offerUUID, offer.OfferName}, nil
 }
 
+func watchConsumedSecrets(st CrossModelRelationsState, appName string) (state.StringsWatcher, error) {
+	return st.WatchConsumedSecretsChanges(appName)
+}
+
 // WatchOfferStatus starts an OfferStatusWatcher for
 // watching the status of an offer.
 func (api *CrossModelRelationsAPI) WatchOfferStatus(
@@ -486,12 +495,77 @@ func (api *CrossModelRelationsAPI) WatchOfferStatus(
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			_ = w.Stop()
-			break
+			continue
 		}
 		results.Results[i].Changes = []params.OfferStatusChange{*change}
 		results.Results[i].OfferStatusWatcherId = api.resources.Register(w)
 	}
 	return results, nil
+}
+
+// WatchConsumedSecretsChanges returns a watcher which notifies of changes to any secrets
+// for the specified remote consumers.
+func (api *CrossModelRelationsAPI) WatchConsumedSecretsChanges(args params.WatchRemoteSecretChangesArgs) (params.SecretRevisionWatchResults, error) {
+	results := params.SecretRevisionWatchResults{
+		Results: make([]params.SecretRevisionWatchResult, len(args.Args)),
+	}
+
+	for i, arg := range args.Args {
+		appTag, offerUUID, err := api.st.GetSecretConsumerInfo(arg.ApplicationToken)
+		if err != nil {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		// Ensure the supplied macaroon allows access.
+		auth := api.authCtxt.Authenticator(api.st.ModelUUID(), offerUUID)
+		_, err = auth.CheckOfferMacaroons(api.ctx, offerUUID, arg.Macaroons, arg.BakeryVersion)
+		if err != nil {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		w, err := api.consumedSecretsWatcher(api.st, appTag.Id())
+		if err != nil {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		uris, ok := <-w.Changes()
+		if !ok {
+			return results, apiservererrors.ServerError(watcher.EnsureErr(w))
+		}
+		changes, err := api.getSecretChanges(uris)
+		if err != nil {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			_ = w.Stop()
+			continue
+		}
+		results.Results[i] = params.SecretRevisionWatchResult{
+			WatcherId: api.resources.Register(w),
+			Changes:   changes,
+		}
+	}
+	return results, nil
+}
+
+func (api *CrossModelRelationsAPI) getSecretChanges(uris []string) ([]params.SecretRevisionChange, error) {
+	changes := make([]params.SecretRevisionChange, len(uris))
+	for i, uriStr := range uris {
+		uri, err := secrets.ParseURI(uriStr)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		md, err := api.st.GetSecret(uri)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		changes[i] = params.SecretRevisionChange{
+			URI:      uri.String(),
+			Revision: md.LatestRevision,
+		}
+	}
+	return changes, nil
 }
 
 // PublishIngressNetworkChanges publishes changes to the required

--- a/apiserver/facades/controller/crossmodelrelations/register.go
+++ b/apiserver/facades/controller/crossmodelrelations/register.go
@@ -40,5 +40,6 @@ func newStateCrossModelRelationsAPI(ctx facade.Context) (*CrossModelRelationsAPI
 		firewall.WatchEgressAddressesForRelations,
 		watchRelationLifeSuspendedStatus,
 		watchOfferStatus,
+		watchConsumedSecrets,
 	)
 }

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -244,6 +244,7 @@ func (s *CrossModelSecretsAPI) getConsumedRevision(secretsState SecretsState, se
 		return 0, errors.Trace(err)
 	}
 	consumerInfo.CurrentRevision = md.LatestRevision
+	consumerInfo.LatestRevision = md.LatestRevision
 	if refresh {
 		if err := secretsConsumer.SaveSecretConsumer(uri, consumer, consumerInfo); err != nil {
 			return 0, errors.Trace(err)

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -178,6 +178,7 @@ func (s *CrossModelSecretsSuite) assertGetSecretContentInfo(c *gc.C, newConsumer
 	}, nil)
 	s.secretsConsumer.EXPECT().SaveSecretConsumer(uri, consumerTag, &coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 667,
+		LatestRevision:  667,
 	}).Return(nil)
 	s.secretsConsumer.EXPECT().SecretAccess(uri, consumer).Return(coresecrets.RoleView, nil)
 	s.secretsState.EXPECT().GetSecretValue(uri, 667).Return(

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -19824,6 +19824,18 @@
                     },
                     "description": "RegisterRemoteRelations sets up the model to participate\nin the specified relations. This operation is idempotent."
                 },
+                "WatchConsumedSecretsChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/WatchRemoteSecretChangesArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretRevisionWatchResults"
+                        }
+                    },
+                    "description": "WatchConsumedSecretsChanges returns a watcher which notifies of changes to any secrets\nfor the specified remote consumers."
+                },
                 "WatchEgressAddressesForRelations": {
                     "type": "object",
                     "properties": {
@@ -20486,6 +20498,59 @@
                         "subnets"
                     ]
                 },
+                "SecretRevisionChange": {
+                    "type": "object",
+                    "properties": {
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "revision"
+                    ]
+                },
+                "SecretRevisionWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevisionChange"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id",
+                        "changes"
+                    ]
+                },
+                "SecretRevisionWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevisionWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
                 "StringsWatchResult": {
                     "type": "object",
                     "properties": {
@@ -20563,6 +20628,42 @@
                         "life",
                         "space-tag",
                         "zones"
+                    ]
+                },
+                "WatchRemoteSecretChangesArg": {
+                    "type": "object",
+                    "properties": {
+                        "application-token": {
+                            "type": "string"
+                        },
+                        "bakery-version": {
+                            "type": "integer"
+                        },
+                        "macaroons": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Macaroon"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-token"
+                    ]
+                },
+                "WatchRemoteSecretChangesArgs": {
+                    "type": "object",
+                    "properties": {
+                        "relations": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/WatchRemoteSecretChangesArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relations"
                     ]
                 }
             }
@@ -40746,6 +40847,100 @@
                         }
                     },
                     "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "SecretsRevisionWatcher",
+        "Description": "srvSecretsRevisionWatcher defines the API wrapping a SecretsRevisionWatcher.",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Next": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/SecretRevisionWatchResult"
+                        }
+                    },
+                    "description": "Next returns when a change has occurred to an entity of the\ncollection being watched since the most recent call to Next\nor the Watch call that created the srvSecretRotationWatcher."
+                },
+                "Stop": {
+                    "type": "object",
+                    "description": "Stop stops the watcher."
+                }
+            },
+            "definitions": {
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "SecretRevisionChange": {
+                    "type": "object",
+                    "properties": {
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "revision"
+                    ]
+                },
+                "SecretRevisionWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevisionChange"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id",
+                        "changes"
+                    ]
                 }
             }
         }

--- a/apiserver/restrict_anonymous.go
+++ b/apiserver/restrict_anonymous.go
@@ -22,6 +22,7 @@ var anonymousFacadeNames = set.NewStrings(
 	"RelationStatusWatcher",
 	"RelationUnitsWatcher",
 	"RemoteRelationWatcher",
+	"SecretsRevisionWatcher",
 	"StringsWatcher",
 )
 

--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -63,6 +63,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"SecretsManager",
 	"SecretBackendsManager",
 	"SecretBackendsRotateWatcher",
+	"SecretsRevisionWatcher",
 	"SecretsTriggerWatcher",
 	"Singular",
 	"StatusHistory",

--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/network"
+	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	corewatcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
@@ -1350,4 +1351,77 @@ func (w *srvSecretBackendsRotateWatcher) translateChanges(changes []corewatcher.
 		}
 	}
 	return result
+}
+
+// srvSecretsRevisionWatcher defines the API wrapping a SecretsRevisionWatcher.
+type srvSecretsRevisionWatcher struct {
+	watcherCommon
+	st      *state.State
+	watcher state.StringsWatcher
+}
+
+func newSecretsRevisionWatcher(context facade.Context) (facade.Facade, error) {
+	id := context.ID()
+	auth := context.Auth()
+	resources := context.Resources()
+
+	st := context.State()
+
+	// TODO(wallyworld) - enhance this watcher to support
+	// anonymous api calls with macaroons.
+	if auth.GetAuthTag() != nil && !isAgent(auth) {
+		return nil, apiservererrors.ErrPerm
+	}
+	watcher, ok := resources.Get(id).(state.StringsWatcher)
+	if !ok {
+		return nil, apiservererrors.ErrUnknownWatcher
+	}
+	return &srvSecretsRevisionWatcher{
+		watcherCommon: newWatcherCommon(context),
+		st:            st,
+		watcher:       watcher,
+	}, nil
+}
+
+// Next returns when a change has occurred to an entity of the
+// collection being watched since the most recent call to Next
+// or the Watch call that created the srvSecretRotationWatcher.
+func (w *srvSecretsRevisionWatcher) Next() (params.SecretRevisionWatchResult, error) {
+	if changes, ok := <-w.watcher.Changes(); ok {
+		ch, err := w.translateChanges(changes)
+		if err != nil {
+			return params.SecretRevisionWatchResult{}, errors.Trace(err)
+		}
+		return params.SecretRevisionWatchResult{
+			Changes: ch,
+		}, nil
+	}
+	err := w.watcher.Err()
+	if err == nil {
+		err = apiservererrors.ErrStoppedWatcher
+	}
+	return params.SecretRevisionWatchResult{}, err
+}
+
+func (w *srvSecretsRevisionWatcher) translateChanges(changes []string) ([]params.SecretRevisionChange, error) {
+	if changes == nil {
+		return nil, nil
+	}
+	secrets := state.NewSecrets(w.st)
+	result := make([]params.SecretRevisionChange, len(changes))
+	for i, uriStr := range changes {
+		uri, err := coresecrets.ParseURI(uriStr)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		md, err := secrets.GetSecret(uri)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		result[i] = params.SecretRevisionChange{
+			URI:      uri.String(),
+			Revision: md.LatestRevision,
+		}
+	}
+	return result, nil
 }

--- a/core/watcher/secrets.go
+++ b/core/watcher/secrets.go
@@ -44,3 +44,24 @@ type SecretTriggerWatcher interface {
 	CoreWatcher
 	Changes() SecretTriggerChannel
 }
+
+// SecretRevisionChange describes changes to a secret.
+type SecretRevisionChange struct {
+	URI      *secrets.URI
+	Revision int
+}
+
+func (s SecretRevisionChange) GoString() string {
+	return fmt.Sprintf("%s/%d", s.URI.ID, s.Revision)
+}
+
+// SecretRevisionChannel is a channel used to notify of
+// changes to a secret.
+type SecretRevisionChannel <-chan []SecretRevisionChange
+
+// SecretsRevisionWatcher conveniently ties an SecretRevisionChannel to the
+// worker.Worker that represents its validity.
+type SecretsRevisionWatcher interface {
+	CoreWatcher
+	Changes() SecretRevisionChannel
+}

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -425,3 +425,42 @@ type GetRemoteSecretAccessArg struct {
 	// URI is the secret URI.
 	URI string `json:"uri"`
 }
+
+// WatchRemoteSecretChangesArgs holds args for watching
+// changes to a remote secret.
+type WatchRemoteSecretChangesArgs struct {
+	Args []WatchRemoteSecretChangesArg `json:"relations"`
+}
+
+// WatchRemoteSecretChangesArg holds info for watching
+// changes to a remote secret.
+type WatchRemoteSecretChangesArg struct {
+	// ApplicationToken is the application token on the remote model.
+	ApplicationToken string `json:"application-token"`
+
+	// Macaroons are used for authentication.
+	Macaroons macaroon.Slice `json:"macaroons,omitempty"`
+
+	// BakeryVersion is the version of the bakery used to mint macaroons.
+	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
+}
+
+// SecretRevisionChange describes a secret revision change.
+type SecretRevisionChange struct {
+	URI      string `json:"uri"`
+	Revision int    `json:"revision"`
+}
+
+// SecretRevisionWatchResult holds a SecretRevisionWatcher id, baseline state
+// (in the Changes field), and an error (if any).
+type SecretRevisionWatchResult struct {
+	WatcherId string                 `json:"watcher-id"`
+	Changes   []SecretRevisionChange `json:"changes"`
+	Error     *Error                 `json:"error,omitempty"`
+}
+
+// SecretRevisionWatchResults holds the results for any API call which ends up
+// returning a list of SecretRevisionWatchers.
+type SecretRevisionWatchResults struct {
+	Results []SecretRevisionWatchResult `json:"results"`
+}


### PR DESCRIPTION
To be able to fire the `secret-changed` hook for cross model secrets, we need a cross model secret revisions watcher. The offering model adapts the existing secret consumers watcher - for cross model consumers, we pass to the watcher the remote app name, so we need to use a regexp to query the consumers collection to pick up any remote units belonging to that app.

A new secret revisions watcher facade is added - this watcher emits change events with the secret URI and revision.

Most of the PR is the facade boilerplate. A macaroon with the same caveats as for consuming offers is used to make the watcher api calls.

The consumer side is not yet set up to process the secret changed events. This will be done next.

Also a driveby fix so that when cmr secrets use the same controller, the remote api client is correctly created. And also set the latest revision when saving the consumer record on the offering side.

## QA steps

QA for now just checks that cross model secrets still work. The test was done on a single controller which is how the drive by fix was noticed. The follow up PR with the events wired up will check that the consuming charm sees the secret-changed hook.