### PR TITLE
[JUJU-2928] fully remove users

### DIFF
--- a/api/client/usermanager/client_test.go
+++ b/api/client/usermanager/client_test.go
@@ -76,6 +76,40 @@ func (s *usermanagerSuite) TestAddUserResultCount(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
+func (s *usermanagerSuite) TestAddRemovedUser(c *gc.C) {
+	tag, _, err := s.usermanager.AddUser("jjam", "Jimmy Jam", "password")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the user exists.
+	user, err := s.State.User(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(user.Name(), gc.Equals, "jjam")
+	c.Assert(user.DisplayName(), gc.Equals, "Jimmy Jam")
+
+	// Delete the user.
+	err = s.usermanager.RemoveUser(tag.Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Assert that the user is gone.
+	_, err = s.State.User(tag)
+	c.Assert(err, gc.ErrorMatches, `user "jjam" is permanently deleted`)
+
+	err = user.Refresh()
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(user.IsDeleted(), jc.IsTrue)
+
+	// Add the user again
+	tag2, _, err := s.usermanager.AddUser("jjam", "Jimmy Again", "password2")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Ensure the user exists.
+	user2, err := s.State.User(tag2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(user2.Name(), gc.Equals, "jjam")
+	c.Assert(user2.DisplayName(), gc.Equals, "Jimmy Again")
+
+}
+
 func (s *usermanagerSuite) TestRemoveUser(c *gc.C) {
 	tag, _, err := s.usermanager.AddUser("jjam", "Jimmy Jam", "password")
 	c.Assert(err, jc.ErrorIsNil)

--- a/api/client/usermanager/client_test.go
+++ b/api/client/usermanager/client_test.go
@@ -49,7 +49,7 @@ func (s *usermanagerSuite) TestAddExistingUser(c *gc.C) {
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 
 	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
-	c.Assert(err, gc.ErrorMatches, "failed to create user: username unavailable")
+	c.Assert(err, gc.ErrorMatches, "failed to create user: the user already exists")
 }
 
 func (s *usermanagerSuite) TestAddUserResponseError(c *gc.C) {

--- a/state/user.go
+++ b/state/user.go
@@ -223,6 +223,9 @@ func (st *State) RemoveUser(tag names.UserTag) error {
 		DateRemoved: dateRemoved,
 	}
 	removalLog := u.doc.RemovalLog
+	if removalLog == nil {
+		removalLog = make([]userRemovedLogEntry, 0)
+	}
 	removalLog = append(removalLog, newRemovalLogEntry)
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/user.go
+++ b/state/user.go
@@ -150,9 +150,9 @@ func (st *State) updateExistingUser(u *User, displayName, password, creator stri
 	// update the password
 	updateUser := bson.D{{"$set", bson.D{
 		{"deleted", false},
-		{"displayName", displayName},
-		{"creator", creator},
-		{"dateCreated", dateCreated},
+		{"displayname", displayName},
+		{"createdby", creator},
+		{"datecreated", dateCreated},
 	}}}
 
 	if password != "" {
@@ -187,18 +187,17 @@ func (st *State) updateExistingUser(u *User, displayName, password, creator stri
 	updateUserOps = append(updateUserOps, removeControllerOps...)
 	updateUserOps = append(updateUserOps, createControllerOps...)
 
-	logger.Infof("%s", updateUserOps)
-
 	if err := u.st.db().RunTransaction(updateUserOps); err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	// recreate the user object to return
-	if err := u.Refresh(); err != nil {
-		return nil, errors.Annotate(err, "error refreshing user data")
+	toReturn, err := st.User(u.UserTag())
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
-	return u, nil
+	return toReturn, nil
 }
 
 // RemoveUser marks the user as deleted. This obviates the ability of a user

--- a/state/user.go
+++ b/state/user.go
@@ -71,6 +71,7 @@ func (st *State) AddUserWithSecretKey(name, displayName, creator string) (*User,
 }
 
 func (st *State) addUser(name, displayName, password, creator string, secretKey []byte) (*User, error) {
+
 	if !names.IsValidUserName(name) {
 		return nil, errors.Errorf("invalid user name %q", name)
 	}

--- a/state/user.go
+++ b/state/user.go
@@ -85,7 +85,7 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 			// the user was deleted, we update it
 			return st.updateExistingUser(foundUser, displayName, password, creator, secretKey)
 		} else {
-			return nil, errors.New("user already exists")
+			return nil, errors.New("the user already exists")
 		}
 	}
 

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -495,7 +495,7 @@ func (s *UserSuite) TestAllUsers(c *gc.C) {
 }
 
 func (s *UserSuite) TestAddDeletedUser(c *gc.C) {
-	s.Factory.MakeUser(c, &factory.UserParams{Name: "bob"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "bob", DisplayName: "displayname"})
 
 	_ = s.State.RemoveUser(names.NewUserTag("bob"))
 

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -495,7 +495,7 @@ func (s *UserSuite) TestAllUsers(c *gc.C) {
 }
 
 func (s *UserSuite) TestAddDeletedUser(c *gc.C) {
-	s.Factory.MakeUser(c, &factory.UserParams{Name: "bob", DisplayName: "displayname"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "bob"})
 
 	_ = s.State.RemoveUser(names.NewUserTag("bob"))
 
@@ -505,7 +505,7 @@ func (s *UserSuite) TestAddDeletedUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(u.Name(), gc.Equals, "bob")
 	c.Assert(u.DisplayName(), gc.Equals, "displayname")
-	c.Assert(u.CreatedBy(), gc.Equals, "creator")
+	c.Assert(u.CreatedBy(), gc.Equals, "test-admin")
 }
 
 func (s *UserSuite) TestAddUserNoSecretKey(c *gc.C) {

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -505,7 +505,7 @@ func (s *UserSuite) TestAddDeletedUser(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(u.Name(), gc.Equals, "bob")
 	c.Assert(u.DisplayName(), gc.Equals, "displayname")
-	c.Assert(u.CreatedBy(), gc.Equals, "test-admin")
+	c.Assert(u.CreatedBy(), gc.Equals, "creator")
 }
 
 func (s *UserSuite) TestAddUserNoSecretKey(c *gc.C) {

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -442,7 +442,7 @@ func (s *UserSuite) TestCaseSensitiveUsersErrors(c *gc.C) {
 
 	_, err := s.State.AddUser(
 		"boB", "ignored", "ignored", "ignored")
-	c.Assert(err, gc.ErrorMatches, "username unavailable")
+	c.Assert(err, gc.ErrorMatches, "the user already exists")
 }
 
 func (s *UserSuite) TestCaseInsensitiveLookup(c *gc.C) {
@@ -495,7 +495,7 @@ func (s *UserSuite) TestAllUsers(c *gc.C) {
 }
 
 func (s *UserSuite) TestAddDeletedUser(c *gc.C) {
-	s.Factory.MakeUser(c, &factory.UserParams{Name: "Bob"})
+	s.Factory.MakeUser(c, &factory.UserParams{Name: "bob"})
 
 	_ = s.State.RemoveUser(names.NewUserTag("bob"))
 

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -499,9 +499,13 @@ func (s *UserSuite) TestAddDeletedUser(c *gc.C) {
 
 	_ = s.State.RemoveUser(names.NewUserTag("bob"))
 
-	_, err := s.State.AddUser(
-		"bob", "ignored", "ignored", "ignored")
-	c.Assert(err, jc.Satisfies, state.IsDeletedUserError)
+	u, err := s.State.AddUser(
+		"bob", "displayname", "password", "creator")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(u.Name(), gc.Equals, "bob")
+	c.Assert(u.DisplayName(), gc.Equals, "displayname")
+	c.Assert(u.CreatedBy(), gc.Equals, "creator")
 }
 
 func (s *UserSuite) TestAddUserNoSecretKey(c *gc.C) {


### PR DESCRIPTION
The current Juju logic does not fully remove users from the database in order to maintain relevant info for auditing purposes. This makes impossible to reuse usernames. This is a problem in certain scenarios where by mistake a user is deleted and has to be created again (e.g. Terraform provider). This PR modifies the state package to permit the addition of a previously removed user. We basically, check if a returned doc was already deleted and if so, we update the doc with the new details.

***Note:*** These changes may impact the integration tests on Jenkins.

## Checklist

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Verify using the CLI that a user can be added after been removed.

```sh
juju add-user user1
add-user user1
User "user1" added
Please send this command to user1:
    juju register MHsTBXVzZXIxMEUTEzEwLjIyMC4xOC4xMjI6MTcwNzAMLltmZDQyOmNmYTE6YWRmNzo2Mjc0OjIxNjozZWZmOmZlMjQ6YzkxOV06MTcwNzAEINqzC2M6xEzIgFkxDvv-hIX8WUmBqd7XJgXYHEXpd_vdEwd0ZXN0ZGV2EwAA

"user1" has not been granted access to any models. You can use "juju grant" to grant access.
```
List users
```sh
juju users
Name    Display name  Access     Date created    Last connection
admin*  admin         superuser  19 hours ago    just now
user1                 login      51 seconds ago  never connected
```

Remove it
```sh
juju remove-user user1 --yes
User "user1" removed
```

Add it again
```sh
juju add-user user1
User "user1" added
Please send this command to user1:
    juju register MHsTBXVzZXIxMEUTEzEwLjIyMC4xOC4xMjI6MTcwNzAMLltmZDQyOmNmYTE6YWRmNzo2Mjc0OjIxNjozZWZmOmZlMjQ6YzkxOV06MTcwNzAEINqzC2M6xEzIgFkxDvv-hIX8WUmBqd7XJgXYHEXpd_vdEwd0ZXN0ZGV2EwAA

"user1" has not been granted access to any models. You can use "juju grant" to grant access.
```

If we try to add it it will simply fail because the user already exists.
```sh
juju add-user user1
ERROR failed to create user: user already exists
```

