### PR TITLE
[JUJU-3196] Check for localhost lxd cloud to detect default arch

### DIFF
--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -4,15 +4,12 @@
 package lxd
 
 import (
-	"fmt"
 	"math/rand"
-	"net"
 	"os/exec"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/os/v2/series"
 	"github.com/juju/packaging/v2/manager"
@@ -178,10 +175,6 @@ func (ci *containerInitialiser) internalConfigureLXDBridge() error {
 	return server.ensureDefaultNetworking(profile, eTag)
 }
 
-var interfaceAddrs = func() ([]net.Addr, error) {
-	return net.InterfaceAddrs()
-}
-
 // ensureDependencies install the required dependencies for running LXD.
 func ensureDependencies(lxdSnapChannel, series string) error {
 	// If the snap is already installed, check whether the operator asked
@@ -224,85 +217,6 @@ var lxdViaSnap = func() bool {
 var randomizedOctetRange = func() []int {
 	rand.Seed(time.Now().UnixNano())
 	return rand.Perm(255)
-}
-
-// getKnownV4IPsAndCIDRs iterates all of the known Addresses on this machine
-// and groups them up into known CIDRs and IP addresses.
-func getKnownV4IPsAndCIDRs(addrFunc func() ([]net.Addr, error)) ([]net.IP, []*net.IPNet, error) {
-	addrs, err := addrFunc()
-	if err != nil {
-		return nil, nil, errors.Annotate(err, "cannot get network interface addresses")
-	}
-
-	knownIPs := []net.IP{}
-	seenIPs := set.NewStrings()
-	knownCIDRs := []*net.IPNet{}
-	seenCIDRs := set.NewStrings()
-	for _, netAddr := range addrs {
-		ip, ipNet, err := net.ParseCIDR(netAddr.String())
-		if err != nil {
-			continue
-		}
-		if ip.To4() == nil {
-			continue
-		}
-		if !seenIPs.Contains(ip.String()) {
-			knownIPs = append(knownIPs, ip)
-			seenIPs.Add(ip.String())
-		}
-		if !seenCIDRs.Contains(ipNet.String()) {
-			knownCIDRs = append(knownCIDRs, ipNet)
-			seenCIDRs.Add(ipNet.String())
-		}
-	}
-	return knownIPs, knownCIDRs, nil
-}
-
-// findNextAvailableIPv4Subnet scans the list of interfaces on the machine
-// looking for 10.0.0.0/16 networks and returns the next subnet not in
-// use, having first detected the highest subnet. The next subnet can
-// actually be lower if we overflowed 255 whilst seeking out the next
-// unused subnet. If all subnets are in use an error is returned.
-//
-// TODO(frobware): this is not an ideal solution as it doesn't take
-// into account any static routes that may be set up on the machine.
-//
-// TODO(frobware): this only caters for IPv4 setups.
-func findNextAvailableIPv4Subnet() (string, error) {
-	knownIPs, knownCIDRs, err := getKnownV4IPsAndCIDRs(interfaceAddrs)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	randomized3rdSegment := randomizedOctetRange()
-	for _, i := range randomized3rdSegment {
-		// lxd randomizes the 2nd and 3rd segments, we should be fine with the
-		// 3rd only
-		ip, ip10network, err := net.ParseCIDR(fmt.Sprintf("10.0.%d.0/24", i))
-		if err != nil {
-			return "", errors.Trace(err)
-		}
-
-		collides := false
-		for _, kIP := range knownIPs {
-			if ip10network.Contains(kIP) {
-				collides = true
-				break
-			}
-		}
-		if !collides {
-			for _, kNet := range knownCIDRs {
-				if kNet.Contains(ip) || ip10network.Contains(kNet.IP) {
-					collides = true
-					break
-				}
-			}
-		}
-		if !collides {
-			return fmt.Sprintf("%d", i), nil
-		}
-	}
-	return "", errors.New("could not find unused subnet")
 }
 
 func isRunningLocally() (bool, error) {

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -7,10 +7,6 @@
 package lxd
 
 import (
-	"errors"
-	"fmt"
-	"net"
-
 	"github.com/golang/mock/gomock"
 	"github.com/juju/packaging/v2/commands"
 	"github.com/juju/packaging/v2/manager"
@@ -245,15 +241,6 @@ func (s *InitialiserSuite) TestConfigureProxiesLXDNotRunning(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *InitialiserSuite) TestFindAvailableSubnetWithInterfaceAddrsError(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return nil, errors.New("boom!")
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.ErrorMatches, "cannot get network interface addresses: boom!")
-	c.Assert(subnet, gc.Equals, "")
-}
-
 type testFindSubnetAddr struct {
 	val string
 }
@@ -264,110 +251,6 @@ func (a testFindSubnetAddr) Network() string {
 
 func (a testFindSubnetAddr) String() string {
 	return a.val
-}
-
-func testAddresses(c *gc.C, networks ...string) ([]net.Addr, error) {
-	addrs := make([]net.Addr, 0)
-	for _, n := range networks {
-		_, _, err := net.ParseCIDR(n)
-		if err != nil {
-			return nil, err
-		}
-		c.Assert(err, gc.IsNil)
-		addrs = append(addrs, testFindSubnetAddr{n})
-	}
-	return addrs, nil
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetWithNoAddresses(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return testAddresses(c)
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "4")
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv6Only(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return testAddresses(c, "fe80::aa8e:a275:7ae0:34af/64")
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "4")
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv4OnlyAndNo10xSubnet(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return testAddresses(c, "192.168.1.64/24")
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "4")
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetWithInvalidCIDR(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return []net.Addr{
-			testFindSubnetAddr{"10.0.0.1"},
-			testFindSubnetAddr{"10.0.5.1/24"}}, nil
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "4")
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetWithIPv4AndExisting10xNetwork(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return testAddresses(c, "192.168.1.64/24", "10.0.0.1/24")
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "4")
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetWithExisting10xNetworks(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		// Note that 10.0.4.0 is a /23, so that includes 10.0.4.0/24 and 10.0.5.0/24
-		// And the one for 10.0.7.0/23 is also a /23 so it includes 10.0.6.0/24 as well as 10.0.7.0/24
-		return testAddresses(c, "192.168.1.0/24", "10.0.4.1/23", "10.0.7.5/23",
-			"::1/128", "10.0.3.1/24", "fe80::aa8e:a275:7ae0:34af/64")
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "8")
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetUpperBoundInUse(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return testAddresses(c, "10.0.255.1/24")
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "4")
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetUpperBoundAndLowerBoundInUse(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		return testAddresses(c, "10.0.255.1/24", "10.0.0.1/24")
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.IsNil)
-	c.Assert(subnet, gc.Equals, "4")
-}
-
-func (s *InitialiserSuite) TestFindAvailableSubnetWithFull10xSubnet(c *gc.C) {
-	s.PatchValue(&interfaceAddrs, func() ([]net.Addr, error) {
-		addrs := make([]net.Addr, 256)
-		for i := 0; i < 256; i++ {
-			subnet := fmt.Sprintf("10.0.%v.1/24", i)
-			addrs[i] = testFindSubnetAddr{subnet}
-		}
-		return addrs, nil
-	})
-	subnet, err := findNextAvailableIPv4Subnet()
-	c.Assert(err, gc.ErrorMatches, "could not find unused subnet")
-	c.Assert(subnet, gc.Equals, "")
 }
 
 type ConfigureInitialiserSuite struct {

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -407,6 +407,33 @@ func isIPv6UniqueLocalAddress(addrType AddressType, ip net.IP) bool {
 	return ipv6UniqueLocal.Contains(ip)
 }
 
+// InterfaceAddrs is patched for tests.
+var InterfaceAddrs = func() ([]net.Addr, error) {
+	return net.InterfaceAddrs()
+}
+
+// IsLocalAddress returns true if the provided IP address equals to one of the
+// local IP addresses.
+func IsLocalAddress(ip net.IP) (bool, error) {
+	addrs, err := InterfaceAddrs()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	for _, addr := range addrs {
+		localIP, _, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			continue
+		}
+		if localIP.To4() != nil || localIP.To16() != nil {
+			if ip.Equal(localIP) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // ProviderAddress represents an address supplied by provider logic.
 // It can include the provider's knowledge of the space in which the
 // address resides.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -362,9 +362,15 @@ func bootstrapIAAS(
 			args.BootstrapBase = base
 			logger.Debugf("auto-selecting bootstrap series %q", args.BootstrapBase.String())
 		}
-		if args.BootstrapConstraints.Arch == nil && args.ModelConstraints.Arch == nil && detectedHW.Arch != nil {
+		if args.BootstrapConstraints.Arch == nil &&
+			args.ModelConstraints.Arch == nil &&
+			detectedHW != nil &&
+			detectedHW.Arch != nil {
 			arch := *detectedHW.Arch
 			args.BootstrapConstraints.Arch = &arch
+			if detector.UpdateModelConstraints() {
+				args.ModelConstraints.Arch = &arch
+			}
 			logger.Debugf("auto-selecting bootstrap arch %q", arch)
 		}
 	}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1568,6 +1568,9 @@ func (e bootstrapEnvironWithHardwareDetection) DetectSeries() (string, error) {
 func (e bootstrapEnvironWithHardwareDetection) DetectHardware() (*instance.HardwareCharacteristics, error) {
 	return e.detectedHW, nil
 }
+func (e bootstrapEnvironWithHardwareDetection) UpdateModelConstraints() bool {
+	return false
+}
 
 func bootstrapContext(c *gc.C) (environs.BootstrapContext, *simplestreams.Simplestreams) {
 	ss := simplestreams.NewSimpleStreams(sstesting.TestDataSourceFactory())

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -636,6 +636,10 @@ type HardwareCharacteristicsDetector interface {
 	// DetectHardware returns the hardware characteristics for the
 	// controller instance.
 	DetectHardware() (*instance.HardwareCharacteristics, error)
+	// UpdateModelConstraints returns true if the model constraints should
+	// be updated based on the returns of DetectSeries() and
+	// DetectHardware().
+	UpdateModelConstraints() bool
 }
 
 // SupportedFeatureEnumerator is implemented by environments that can report

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -390,3 +390,9 @@ func (e *manualEnviron) DetectHardware() (*instance.HardwareCharacteristics, err
 	hw, _, err := e.seriesAndHardwareCharacteristics()
 	return hw, err
 }
+
+// UpdateModelConstraints always returns false because we don't want to update
+// model constraints for manual env.
+func (e *manualEnviron) UpdateModelConstraints() bool {
+	return false
+}


### PR DESCRIPTION
This patch adds the `HardwareCharacteristicsDetector` capabilities to the LXD provider with an implementation that will return the correct hw architecture *only* if the cloud being bootstrapped is a localhost LXD cloud.
The detected arch in that case will update the bootstrap constraints so that it's able to correctly download the controller charm and finish bootstrap.

This patch fixes the bootstrapping, but it will not fix other commands where no constraints are passed, because the bootstrap constraints are not passed to future created models, therefore deploying (for example) will still fail due to unsupported architecture. The full fix will come later when we add capabilities to define model default constraints at bootstrapping stage.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

A simple way to test this on your local architecture is to modify the `DefaultArchitecture` const in `core/arch/arches.go` (for example to `DefaultArchitecture = arch.S390X`) and then build again.

```sh
$ juju bootstrap localhost ctrl
$ juju add-model m
```
The bootstrapping and adding a model should work because it will detect your true architecture. If you then try to deploy:

```sh
$ juju deploy prometheus2
```
it will fail with:
```
ERROR cannot add application "prometheus2": invalid constraint value: arch=s390x
valid values are: [amd64 i386]
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2005133