### PR TITLE
[JUJU-2566] Add local model infrastructre for firing the secret-changed hook for cmr secrets

### DIFF
--- a/api/controller/remoterelations/remoterelations.go
+++ b/api/controller/remoterelations/remoterelations.go
@@ -313,3 +313,26 @@ func (c *Client) UpdateControllerForModel(controller crossmodel.ControllerInfo, 
 	}
 	return nil
 }
+
+// ConsumeRemoteSecretChanges updates the local model with secret revision  changes
+// originating from the remote/offering model.
+func (c *Client) ConsumeRemoteSecretChanges(changes []watcher.SecretRevisionChange) error {
+	if len(changes) == 0 {
+		return nil
+	}
+	args := params.LatestSecretRevisionChanges{
+		Changes: make([]params.SecretRevisionChange, len(changes)),
+	}
+	for i, c := range changes {
+		args.Changes[i] = params.SecretRevisionChange{
+			URI:      c.URI.String(),
+			Revision: c.Revision,
+		}
+	}
+	var results params.ErrorResults
+	err := c.facade.FacadeCall("ConsumeRemoteSecretChanges", args, &results)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return results.Combine()
+}

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
+	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/state"
 )
@@ -98,6 +99,10 @@ type Backend interface {
 
 	// RemoveSecretConsumer removes secret references for the specified consumer.
 	RemoveSecretConsumer(consumer names.Tag) error
+
+	// UpdateSecretConsumerOperation returns an operation for updating the latest revision
+	// for any consumers of the secret.
+	UpdateSecretConsumerOperation(uri *coresecrets.URI, latestRevision int) (state.ModelOperation, error)
 }
 
 // Relation provides access a relation in global state.

--- a/apiserver/facades/controller/remoterelations/mocks/remoterelations_mocks.go
+++ b/apiserver/facades/controller/remoterelations/mocks/remoterelations_mocks.go
@@ -11,6 +11,7 @@ import (
 	crossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	crossmodel0 "github.com/juju/juju/core/crossmodel"
 	permission "github.com/juju/juju/core/permission"
+	secrets "github.com/juju/juju/core/secrets"
 	params "github.com/juju/juju/rpc/params"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v4"
@@ -397,6 +398,21 @@ func (m *MockRemoteRelationsState) UpdateControllerForModel(arg0 crossmodel0.Con
 func (mr *MockRemoteRelationsStateMockRecorder) UpdateControllerForModel(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateControllerForModel", reflect.TypeOf((*MockRemoteRelationsState)(nil).UpdateControllerForModel), arg0, arg1)
+}
+
+// UpdateSecretConsumerOperation mocks base method.
+func (m *MockRemoteRelationsState) UpdateSecretConsumerOperation(arg0 *secrets.URI, arg1 int) (state.ModelOperation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSecretConsumerOperation", arg0, arg1)
+	ret0, _ := ret[0].(state.ModelOperation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateSecretConsumerOperation indicates an expected call of UpdateSecretConsumerOperation.
+func (mr *MockRemoteRelationsStateMockRecorder) UpdateSecretConsumerOperation(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretConsumerOperation", reflect.TypeOf((*MockRemoteRelationsState)(nil).UpdateSecretConsumerOperation), arg0, arg1)
 }
 
 // UserPermission mocks base method.

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
+	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/watcher"
@@ -430,4 +431,28 @@ func (api *API) UpdateControllersForModels(args params.UpdateControllersForModel
 	}
 
 	return result, nil
+}
+
+// ConsumeRemoteSecretChanges updates the local model with secret revision changes
+// originating from the remote/offering model.
+func (api *API) ConsumeRemoteSecretChanges(args params.LatestSecretRevisionChanges) (params.ErrorResults, error) {
+	var result params.ErrorResults
+	result.Results = make([]params.ErrorResult, len(args.Changes))
+	for i, arg := range args.Changes {
+		err := api.consumeOneRemoteSecretChange(arg)
+		result.Results[i].Error = apiservererrors.ServerError(err)
+	}
+	return result, nil
+}
+
+func (api *API) consumeOneRemoteSecretChange(arg params.SecretRevisionChange) error {
+	uri, err := coresecrets.ParseURI(arg.URI)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	op, err := api.st.UpdateSecretConsumerOperation(uri, arg.Revision)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return api.st.ApplyOperation(op)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -36992,6 +36992,18 @@
                     },
                     "description": "ConsumeRemoteRelationChanges consumes changes to settings originating\nfrom the remote/offering side of relations."
                 },
+                "ConsumeRemoteSecretChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/LatestSecretRevisionChanges"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "ConsumeRemoteSecretChanges updates the local model with secret revision changes\noriginating from the remote/offering model."
+                },
                 "ControllerAPIInfoForModels": {
                     "type": "object",
                     "properties": {
@@ -37399,6 +37411,21 @@
                         "Args"
                     ]
                 },
+                "LatestSecretRevisionChanges": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevisionChange"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
                 "Macaroon": {
                     "type": "object",
                     "additionalProperties": false
@@ -37721,6 +37748,22 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "SecretRevisionChange": {
+                    "type": "object",
+                    "properties": {
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "revision"
+                    ]
                 },
                 "SetStatus": {
                     "type": "object",

--- a/core/secrets/secret_test.go
+++ b/core/secrets/secret_test.go
@@ -23,6 +23,7 @@ const (
 	secretSource    = "deadbeef-1bad-500d-9000-4b1d0d06f00d"
 	secretURI       = "secret:9m4e2mr0ui3e8a215n4g"
 	remoteSecretURI = "secret://deadbeef-1bad-500d-9000-4b1d0d06f00d/9m4e2mr0ui3e8a215n4g"
+	remoteSecretID  = "deadbeef-1bad-500d-9000-4b1d0d06f00d/9m4e2mr0ui3e8a215n4g"
 )
 
 func (s *SecretURISuite) TestParseURI(c *gc.C) {
@@ -57,6 +58,13 @@ func (s *SecretURISuite) TestParseURI(c *gc.C) {
 			},
 		}, {
 			in:  remoteSecretURI,
+			str: remoteSecretURI,
+			expected: &secrets.URI{
+				ID:         secretID,
+				SourceUUID: secretSource,
+			},
+		}, {
+			in:  remoteSecretID,
 			str: remoteSecretURI,
 			expected: &secrets.URI{
 				ID:         secretID,

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -445,6 +445,12 @@ type WatchRemoteSecretChangesArg struct {
 	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
 }
 
+// LatestSecretRevisionChanges holds a collection of secret revision changes
+// for updating consumers when secrets get new revisions added.
+type LatestSecretRevisionChanges struct {
+	Changes []SecretRevisionChange `json:"changes"`
+}
+
 // SecretRevisionChange describes a secret revision change.
 type SecretRevisionChange struct {
 	URI      string `json:"uri"`

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -2744,9 +2744,11 @@ func (i *importer) secrets() error {
 	}
 	migration.Add(func() error {
 		m := ImportSecrets{}
-		return m.Execute(stateModelNamspaceShim{
-			Model: migration.src,
-			st:    i.st,
+		return m.Execute(&secretConsumersStateShim{
+			stateModelNamspaceShim: stateModelNamspaceShim{
+				Model: migration.src,
+				st:    i.st,
+			},
 		}, migration.dst, migration.knownSecretBackends)
 	})
 	if err := migration.Run(); err != nil {

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -988,7 +988,6 @@ func (s *MigrationSuite) TestSecretRotationDocFields(c *gc.C) {
 func (s *MigrationSuite) TestSecretConsumerDocFields(c *gc.C) {
 	ignored := set.NewStrings(
 		"DocID",
-		"SourceUUID",
 	)
 	migrated := set.NewStrings(
 		"ConsumerTag",

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -1103,7 +1103,7 @@ func (s *SecretsSuite) TestGetSecretConsumerCrossModelURI(c *gc.C) {
 			Label:       strPtr("owner-label"),
 		},
 	}
-	uri := secrets.NewURI().WithSource("some-uuid")
+	uri := secrets.NewURI().WithSource("deadbeef-1bad-500d-9000-4b1d0d06f00d")
 	_, err := s.store.CreateSecret(uri, cp)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/worker/remoterelations/mock_test.go
+++ b/worker/remoterelations/mock_test.go
@@ -166,6 +166,13 @@ func (m *mockRelationsFacade) RemoteApplications(names []string) ([]params.Remot
 	return result, nil
 }
 
+func (m *mockRelationsFacade) ConsumeRemoteSecretChanges(changes []watcher.SecretRevisionChange) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "ConsumeRemoteSecretChanges", changes)
+	return nil
+}
+
 type relationEndpointInfo struct {
 	localApplicationName string
 	localEndpoint        params.RemoteEndpoint
@@ -253,6 +260,7 @@ type mockRemoteRelationsFacade struct {
 	remoteRelationWatchers  map[string]*mockRemoteRelationWatcher
 	relationsStatusWatchers map[string]*mockRelationStatusWatcher
 	offersStatusWatchers    map[string]*mockOfferStatusWatcher
+	secretsRevisionWatchers map[string]*mockSecretsRevisionWatcher
 }
 
 func newMockRemoteRelationsFacade(stub *testing.Stub) *mockRemoteRelationsFacade {
@@ -261,6 +269,7 @@ func newMockRemoteRelationsFacade(stub *testing.Stub) *mockRemoteRelationsFacade
 		remoteRelationWatchers:  make(map[string]*mockRemoteRelationWatcher),
 		relationsStatusWatchers: make(map[string]*mockRelationStatusWatcher),
 		offersStatusWatchers:    make(map[string]*mockOfferStatusWatcher),
+		secretsRevisionWatchers: make(map[string]*mockSecretsRevisionWatcher),
 	}
 }
 
@@ -321,6 +330,13 @@ func (m *mockRemoteRelationsFacade) relationsStatusWatcher(key string) (*mockRel
 	return w, ok
 }
 
+func (m *mockRemoteRelationsFacade) secretsRevisionWatcher(key string) (*mockSecretsRevisionWatcher, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w, ok := m.secretsRevisionWatchers[key]
+	return w, ok
+}
+
 func (m *mockRemoteRelationsFacade) WatchRelationSuspendedStatus(arg params.RemoteEntityArg) (watcher.RelationStatusWatcher, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -358,6 +374,17 @@ func (m *mockRemoteRelationsFacade) RelationUnitSettings(relationUnits []params.
 		}
 	}
 	return result, nil
+}
+
+func (m *mockRemoteRelationsFacade) WatchConsumedSecretsChanges(appToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stub.MethodCall(m, "WatchConsumedSecretsChanges", appToken, mac)
+	if err := m.stub.NextErr(); err != nil {
+		return nil, err
+	}
+	m.secretsRevisionWatchers[appToken] = newMockSecretsRevisionWatcher()
+	return m.secretsRevisionWatchers[appToken], nil
 }
 
 type mockWatcher struct {
@@ -405,6 +432,31 @@ func newMockStringsWatcher() *mockStringsWatcher {
 }
 
 func (w *mockStringsWatcher) Changes() watcher.StringsChannel {
+	w.MethodCall(w, "Changes")
+	return w.changes
+}
+
+type mockSecretsRevisionWatcher struct {
+	mockWatcher
+	changes chan []watcher.SecretRevisionChange
+}
+
+func newMockSecretsRevisionWatcher() *mockSecretsRevisionWatcher {
+	w := &mockSecretsRevisionWatcher{
+		changes: make(chan []watcher.SecretRevisionChange, 1),
+	}
+	w.Tomb.Go(func() error {
+		<-w.Tomb.Dying()
+		return nil
+	})
+	return w
+}
+
+func (w *mockSecretsRevisionWatcher) kill(err error) {
+	w.Tomb.Kill(err)
+}
+
+func (w *mockSecretsRevisionWatcher) Changes() watcher.SecretRevisionChannel {
 	w.MethodCall(w, "Changes")
 	return w.changes
 }

--- a/worker/remoterelations/remoterelations.go
+++ b/worker/remoterelations/remoterelations.go
@@ -66,6 +66,10 @@ type RemoteModelRelationsFacade interface {
 	// WatchOfferStatus starts an OfferStatusWatcher for watching the status
 	// of the specified offer in the remote model.
 	WatchOfferStatus(arg params.OfferArg) (watcher.OfferStatusWatcher, error)
+
+	// WatchConsumedSecretsChanges starts a watcher for any changes to secrets
+	// consumed by the specified application.
+	WatchConsumedSecretsChanges(applicationToken string, mac *macaroon.Macaroon) (watcher.SecretsRevisionWatcher, error)
 }
 
 // RemoteRelationsFacade exposes remote relation functionality to a worker.
@@ -119,6 +123,10 @@ type RemoteRelationsFacade interface {
 	// UpdateControllerForModel ensures that there is an external controller record
 	// for the input info, associated with the input model ID.
 	UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error
+
+	// ConsumeRemoteSecretChanges updates the local model with secret revision  changes
+	// originating from the remote/offering model.
+	ConsumeRemoteSecretChanges(changes []watcher.SecretRevisionChange) error
 }
 
 type newRemoteRelationsFacadeFunc func(*api.Info) (RemoteModelRelationsFacadeCloser, error)

--- a/worker/uniter/remotestate/snapshot.go
+++ b/worker/uniter/remotestate/snapshot.go
@@ -98,15 +98,15 @@ type Snapshot struct {
 
 	// ConsumedSecretInfo is a list of the labels and revision info
 	// for secrets consumed by this unit.
-	// The map is keyed on secret ID.
+	// The map is keyed on secret URI.
 	ConsumedSecretInfo map[string]secrets.SecretRevisionInfo
 
 	// ObsoleteSecretRevisions is a list of the obsolete
 	// revisions for secrets owned by this unit.
 	ObsoleteSecretRevisions map[string][]int
 
-	// DeletedSecrets is a list of deleted secrets
-	// owned by this unit.
+	// DeletedSecrets is a list of deleted secret
+	// URIs owned by this unit.
 	DeletedSecrets []string
 
 	// UpgradeMachineStatus is the preparation status of


### PR DESCRIPTION
The remote application worker receives an event when a cross model secret changes. This PR handles that event in the consuming model so that the secret-changed hook fires.

A change is made to how the secret consumer collection stores the secret URI. Instead of splitting out the source model UUID, the entire URI (with possible model uuid in it) is stored as the doc id. This is so that the watcher can correctly supply the full URI for deletes as well as changes.

To support the above, the secret URI parser is updated to handle "model/id" format.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Use the dummy source and sink charms to create a cross model relation.
Create a secret in the dummy-source charm and share it.
In the dummy-sink charm, get the secret value.
In the dummy-source charm, create a new secret revision.
Observe the dummy-source charm would run a secret-changed hook, looking at logs.