### PR TITLE
[JUJU-2874] Ensure build tags are passed when building

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -382,6 +382,7 @@ parts:
       github.com/juju/juju/version.build: ""
     go-static: true
     go-strip: true
+    go-buildtags: ["libsqlite3", "dqlite"]
     go-cgo-enabled: "1"
     go-cgo-cc: "musl-gcc"
     go-cgo-cflags: "-I/usr/local/musl/include"


### PR DESCRIPTION
Ensure that the build tags for dqlite are correctly passed in when building jujud. This is the next step in the process for ensuring jujud is correct and valid.


## QA steps

```sh
$ snapcraft --use-lxd
```


