### PR TITLE
[JUJU-3242] Add image-id constraint

### DIFF
--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -4237,6 +4237,9 @@
                         "cpu-power": {
                             "type": "integer"
                         },
+                        "image-id": {
+                            "type": "string"
+                        },
                         "instance-role": {
                             "type": "string"
                         },
@@ -8310,6 +8313,9 @@
                         },
                         "cpu-power": {
                             "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
                         },
                         "instance-role": {
                             "type": "string"
@@ -14455,6 +14461,9 @@
                         "cpu-power": {
                             "type": "integer"
                         },
+                        "image-id": {
+                            "type": "string"
+                        },
                         "instance-role": {
                             "type": "string"
                         },
@@ -18145,6 +18154,9 @@
                         },
                         "cpu-power": {
                             "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
                         },
                         "instance-role": {
                             "type": "string"
@@ -23933,6 +23945,9 @@
                         "cpu-power": {
                             "type": "integer"
                         },
+                        "image-id": {
+                            "type": "string"
+                        },
                         "instance-role": {
                             "type": "string"
                         },
@@ -27808,6 +27823,9 @@
                         "cpu-power": {
                             "type": "integer"
                         },
+                        "image-id": {
+                            "type": "string"
+                        },
                         "instance-role": {
                             "type": "string"
                         },
@@ -31104,6 +31122,9 @@
                         },
                         "cpu-power": {
                             "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
                         },
                         "instance-role": {
                             "type": "string"
@@ -35983,6 +36004,9 @@
                         },
                         "cpu-power": {
                             "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
                         },
                         "instance-role": {
                             "type": "string"

--- a/caas/kubernetes/provider/constraints.go
+++ b/caas/kubernetes/provider/constraints.go
@@ -15,6 +15,7 @@ var unsupportedConstraints = []string{
 	constraints.InstanceType,
 	constraints.Spaces,
 	constraints.AllocatePublicIP,
+	constraints.ImageID,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -377,6 +377,13 @@ func (env *azureEnviron) SetConfig(cfg *config.Config) error {
 	return nil
 }
 
+var unsupportedConstraints = []string{
+	constraints.CpuPower,
+	constraints.Tags,
+	constraints.VirtType,
+	constraints.ImageID,
+}
+
 // ConstraintsValidator is defined on the Environs interface.
 func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	instanceTypes, err := env.getInstanceTypes(ctx)
@@ -390,11 +397,7 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.ProviderCallContext) (
 	sort.Strings(instTypeNames)
 
 	validator := constraints.NewValidator()
-	validator.RegisterUnsupported([]string{
-		constraints.CpuPower,
-		constraints.Tags,
-		constraints.VirtType,
-	})
+	validator.RegisterUnsupported(unsupportedConstraints)
 	validator.RegisterVocabulary(
 		constraints.Arch,
 		[]string{arch.AMD64},

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1157,10 +1157,16 @@ func (e *environ) DestroyController(ctx context.ProviderCallContext, controllerU
 	return nil
 }
 
+var unsupportedConstraints = []string{
+	constraints.CpuPower,
+	constraints.VirtType,
+	constraints.ImageID,
+}
+
 // ConstraintsValidator is defined on the Environs interface.
 func (e *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
-	validator.RegisterUnsupported([]string{constraints.CpuPower, constraints.VirtType})
+	validator.RegisterUnsupported(unsupportedConstraints)
 	validator.RegisterConflicts([]string{constraints.InstanceType}, []string{constraints.Mem})
 	validator.RegisterVocabulary(constraints.Arch, []string{arch.AMD64, arch.ARM64, arch.I386, arch.PPC64EL, arch.S390X})
 	return validator, nil

--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -256,6 +256,7 @@ var unsupportedConstraints = []string{
 	// use virt-type in StartInstances
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.ImageID,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -95,9 +95,15 @@ func (e *environ) Config() *config.Config {
 	return e.ecfg.config
 }
 
+var unsupportedConstraints = []string{
+	constraints.CpuPower,
+	constraints.VirtType,
+	constraints.ImageID,
+}
+
 func (e *environ) ConstraintsValidator(ctx context.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
-	validator.RegisterUnsupported([]string{constraints.CpuPower, constraints.VirtType})
+	validator.RegisterUnsupported(unsupportedConstraints)
 	validator.RegisterConflicts([]string{constraints.InstanceType}, []string{constraints.Mem})
 	validator.RegisterVocabulary(constraints.Arch, []string{arch.AMD64, arch.ARM64, arch.I386, arch.PPC64EL})
 	return validator, nil

--- a/provider/gce/environ_policy.go
+++ b/provider/gce/environ_policy.go
@@ -34,6 +34,7 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
+	constraints.ImageID,
 }
 
 // instanceTypeConstraints defines the fields defined on each of the

--- a/provider/lxd/environ_policy.go
+++ b/provider/lxd/environ_policy.go
@@ -23,6 +23,7 @@ var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.Container,
 	constraints.AllocatePublicIP,
+	constraints.ImageID,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/provider/manual/environ.go
+++ b/provider/manual/environ.go
@@ -334,6 +334,7 @@ var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.ImageID,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/oci/environ.go
+++ b/provider/oci/environ.go
@@ -324,15 +324,16 @@ func (e *Environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerU
 	return errors.NotImplementedf("AdoptResources")
 }
 
+// list of unsupported OCI provider constraints
+var unsupportedConstraints = []string{
+	constraints.Container,
+	constraints.VirtType,
+	constraints.Tags,
+	constraints.ImageID,
+}
+
 // ConstraintsValidator implements environs.Environ.
 func (e *Environ) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
-	// list of unsupported OCI provider constraints
-	unsupportedConstraints := []string{
-		constraints.Container,
-		constraints.VirtType,
-		constraints.Tags,
-	}
-
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
 	validator.RegisterVocabulary(constraints.Arch, []string{arch.AMD64})

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -571,6 +571,7 @@ func (e *Environ) neutron() *neutron.Client {
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.CpuPower,
+	constraints.ImageID,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/provider/vsphere/environ_policy.go
+++ b/provider/vsphere/environ_policy.go
@@ -79,6 +79,7 @@ var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.ImageID,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -33,6 +33,7 @@ type constraintsDoc struct {
 	VirtType         *string
 	Zones            *[]string
 	AllocatePublicIP *bool
+	ImageID          *string
 }
 
 func newConstraintsDoc(cons constraints.Value, id string) constraintsDoc {
@@ -52,6 +53,7 @@ func newConstraintsDoc(cons constraints.Value, id string) constraintsDoc {
 		VirtType:         cons.VirtType,
 		Zones:            cons.Zones,
 		AllocatePublicIP: cons.AllocatePublicIP,
+		ImageID:          cons.ImageID,
 	}
 	return result
 }
@@ -72,6 +74,7 @@ func (doc constraintsDoc) value() constraints.Value {
 		VirtType:         doc.VirtType,
 		Zones:            doc.Zones,
 		AllocatePublicIP: doc.AllocatePublicIP,
+		ImageID:          doc.ImageID,
 	}
 	return result
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -582,6 +582,7 @@ func (s *MigrationSuite) TestConstraintsDocFields(c *gc.C) {
 		"VirtType",
 		"Zones",
 		"AllocatePublicIP",
+		"ImageID",
 	)
 	s.AssertExportedFields(c, constraintsDoc{}, fields)
 }

--- a/state/unit.go
+++ b/state/unit.go
@@ -2568,6 +2568,9 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 	if cons.HasVirtType() {
 		suitableTerms = append(suitableTerms, bson.DocElem{"virttype", *cons.VirtType})
 	}
+	if cons.HasImageID() {
+		suitableTerms = append(suitableTerms, bson.DocElem{"imageid", *cons.ImageID})
+	}
 	if len(suitableTerms) > 0 {
 		instanceDataCollection, iCloser := db.GetCollection(instanceDataC)
 		defer iCloser()


### PR DESCRIPTION
This new constraint is used in the provider's StartInstance as boot image so the implementation is provider-specific.

At a first stage, only MAAS provider is supported therefore it has been added as unsupported constraint to all providers except MAAS.

The implementation on bundles and overlay bundles, as well as the MAAS provider implementation will come in future PRs.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Trying to bootstrap a MAAS controller should not display any warnings:
```sh
j bootstrap maas-cloud c --constraints "image-id=ubuntu-bf2"
Creating Juju controller "c" on maas-cloud/default
Looking for packaged Juju agent version 3.2-beta1 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on maas-cloud/default...
```
On the other hand when bootstrapping a LXD controller a warning should be displayed (`image-id` not supported):
```sh
$ j bootstrap localhost c --constraints "image-id=ubuntu-bf2"
Creating Juju controller "c" on localhost/localhost
WARNING unsupported constraints: image-id
```
Then trying to deploy an application with the `image-id` constraint should not fail:
```sh
$ j deploy prometheus2 --constraints="image-id=ubuntu-bf2"
Located charm "prometheus2" in charm-hub, revision 48
Deploying "prometheus2" from charm-hub charm "prometheus2", revision 48 in channel stable on ubuntu@22.04/stable
```
Adding a machine with the `image-id` constraint should not fail:
```sh
$ j add-machine --constraints="image-id=ubuntu-bf2"
created machine 1
```
## Documentation changes

Since a new constraint is added, we should added it to our doc (https://juju.is/docs/olm/constraint#heading--complete-list-of-constraints). API usage should not be impacted, CLI usage should be transparent as well, only expect WARNING when bootstrapping unsupported providers with `image-id` constraint.

