### PR TITLE
[JUJU-2990] Refactor add-cloud command docs

### DIFF
--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -115,19 +115,7 @@ Other cloud combinations can only be force added as the user must consider
 network routability, etc - concerns that are outside of scope of Juju.
 When forced addition is desired, use --force.
 
-Examples:
-    juju add-cloud
-    juju add-cloud --force
-    juju add-cloud mycloud ~/mycloud.yaml
-    juju add-cloud --controller mycontroller mycloud 
-    juju add-cloud --controller mycontroller mycloud --credential mycred
-    juju add-cloud --client mycloud ~/mycloud.yaml
-
-See also: 
-    clouds
-    update-cloud
-    remove-cloud
-    update-credential`
+`
 
 // AddCloudAPI - Implemented by cloudapi.Client.
 type AddCloudAPI interface {
@@ -202,6 +190,20 @@ func (c *AddCloudCommand) Info() *cmd.Info {
 		Args:    "<cloud name> [<cloud definition file>]",
 		Purpose: usageAddCloudSummary,
 		Doc:     fmt.Sprintf(usageAddCloudDetails, jujucloud.CurrentWhiteList()),
+		Examples: []string{
+			  "`juju add-cloud`",
+			  "`juju add-cloud --force`",
+			  "`juju add-cloud mycloud ~/mycloud.yaml`",
+			  "`juju add-cloud --controller mycontroller mycloud`", 
+			  "`juju add-cloud --controller mycontroller mycloud --credential mycred`",
+			  "`juju add-cloud --client mycloud ~/mycloud.yaml`",
+			  },
+		SeeAlso: []string{	
+			"clouds",
+			"update-cloud",
+			"remove-cloud",
+			"update-credential",
+			},
 	})
 }
 

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -191,19 +191,19 @@ func (c *AddCloudCommand) Info() *cmd.Info {
 		Purpose: usageAddCloudSummary,
 		Doc:     fmt.Sprintf(usageAddCloudDetails, jujucloud.CurrentWhiteList()),
 		Examples: []string{
-			  "`juju add-cloud`",
-			  "`juju add-cloud --force`",
-			  "`juju add-cloud mycloud ~/mycloud.yaml`",
-			  "`juju add-cloud --controller mycontroller mycloud`", 
-			  "`juju add-cloud --controller mycontroller mycloud --credential mycred`",
-			  "`juju add-cloud --client mycloud ~/mycloud.yaml`",
-			  },
-		SeeAlso: []string{	
+			"`juju add-cloud`",
+			"`juju add-cloud --force`",
+			"`juju add-cloud mycloud ~/mycloud.yaml`",
+			"`juju add-cloud --controller mycontroller mycloud`",
+			"`juju add-cloud --controller mycontroller mycloud --credential mycred`",
+			"`juju add-cloud --client mycloud ~/mycloud.yaml`",
+		},
+		SeeAlso: []string{
 			"clouds",
 			"update-cloud",
 			"remove-cloud",
 			"update-credential",
-			},
+		},
 	})
 }
 

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -117,14 +117,14 @@ When forced addition is desired, use --force.
 
 `
 
-var examples = []string{
-	"juju add-cloud",
-	"juju add-cloud --force",
-	"juju add-cloud mycloud ~/mycloud.yaml",
-	"juju add-cloud --controller mycontroller mycloud ",
-	"juju add-cloud --controller mycontroller mycloud --credential mycred",
-	"juju add-cloud --client mycloud ~/mycloud.yaml",
-}
+const examples = `
+    juju add-cloud
+    juju add-cloud --force
+    juju add-cloud mycloud ~/mycloud.yaml
+    juju add-cloud --controller mycontroller mycloud 
+    juju add-cloud --controller mycontroller mycloud --credential mycred
+    juju add-cloud --client mycloud ~/mycloud.yaml
+`
 
 // AddCloudAPI - Implemented by cloudapi.Client.
 type AddCloudAPI interface {

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -117,6 +117,15 @@ When forced addition is desired, use --force.
 
 `
 
+const examples = `
+    juju add-cloud
+    juju add-cloud --force
+    juju add-cloud mycloud ~/mycloud.yaml
+    juju add-cloud --controller mycontroller mycloud 
+    juju add-cloud --controller mycontroller mycloud --credential mycred
+    juju add-cloud --client mycloud ~/mycloud.yaml
+`
+
 // AddCloudAPI - Implemented by cloudapi.Client.
 type AddCloudAPI interface {
 	AddCloud(jujucloud.Cloud, bool) error
@@ -190,14 +199,7 @@ func (c *AddCloudCommand) Info() *cmd.Info {
 		Args:    "<cloud name> [<cloud definition file>]",
 		Purpose: usageAddCloudSummary,
 		Doc:     fmt.Sprintf(usageAddCloudDetails, jujucloud.CurrentWhiteList()),
-		Examples: []string{
-			"`juju add-cloud`",
-			"`juju add-cloud --force`",
-			"`juju add-cloud mycloud ~/mycloud.yaml`",
-			"`juju add-cloud --controller mycontroller mycloud`",
-			"`juju add-cloud --controller mycontroller mycloud --credential mycred`",
-			"`juju add-cloud --client mycloud ~/mycloud.yaml`",
-		},
+		Examples: examples,
 		SeeAlso: []string{
 			"clouds",
 			"update-cloud",

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -195,10 +195,10 @@ func (c *AddCloudCommand) cloudAPI() (AddCloudAPI, error) {
 // Info returns help information about the command.
 func (c *AddCloudCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "add-cloud",
-		Args:    "<cloud name> [<cloud definition file>]",
-		Purpose: usageAddCloudSummary,
-		Doc:     fmt.Sprintf(usageAddCloudDetails, jujucloud.CurrentWhiteList()),
+		Name:     "add-cloud",
+		Args:     "<cloud name> [<cloud definition file>]",
+		Purpose:  usageAddCloudSummary,
+		Doc:      fmt.Sprintf(usageAddCloudDetails, jujucloud.CurrentWhiteList()),
 		Examples: examples,
 		SeeAlso: []string{
 			"clouds",


### PR DESCRIPTION
Moved Examples and See also to fields inside Info for the add-cloud command.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

 Run `juju documentation --split --out=tmp` 


## Documentation changes

This is a documentation PR.
