### PR TITLE
[JUJU-3281] Introspection format debug argument

### DIFF
--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -80,21 +80,36 @@ juju_agent () {
 }
 
 juju_goroutines () {
-  juju_agent debug/pprof/goroutine?debug=1
+  local D=1
+  if ! test -z $1; then
+    D=$1
+    shift
+  fi
+  juju_agent debug/pprof/goroutine?debug=$D
 }
 
 juju_cpu_profile () {
-  N=30
+  local N=30
   if test -n "$1"; then
     N=$1
     shift
   fi
+  local D=1
+  if ! test -z $1; then
+    D=$1
+    shift
+  fi
   echo "Sampling CPU for $N seconds." >&2
-  juju_agent "debug/pprof/profile?debug=1&seconds=$N"
+  juju_agent "debug/pprof/profile?debug=$D&seconds=$N"
 }
 
 juju_heap_profile () {
-  juju_agent debug/pprof/heap?debug=1
+  local D=1
+  if ! test -z $1; then
+    D=$1
+    shift
+  fi
+  juju_agent debug/pprof/heap?debug=$D
 }
 
 juju_engine_report () {
@@ -118,7 +133,12 @@ juju_presence_report () {
 }
 
 juju_statetracker_report () {
-  juju_agent debug/pprof/juju/state/tracker?debug=1
+  local D=1
+  if ! test -z $1; then
+    D=$1
+    shift
+  fi
+  juju_agent debug/pprof/juju/state/tracker?debug=$D
 }
 
 juju_machine_lock () {


### PR DESCRIPTION
The following allows the introspection tools to be provided with an additional formatting argument. Currently, the debug format output was chosen (debug=1) as you didn't need any additional tools to read the output from the output of the tools. This means that we can't always take advantage of tooling that helps track down leaks or stopped goroutines. The documentation states that "Passing debug=1 writes the legacy text format"[1]. Unfortunately, a lot of tooling takes advantage of debug=2.

The solution is simple, have a default of 1, but allow passing in another option. For example:

    juju_goroutines 2

This is backwards compatible with what tooling we already have.

 1. https://pkg.go.dev/runtime/pprof#Profile.WriteTo


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
 
## QA steps

```sh
$ juju bootstrap lxd test --build-agent
$ juju ssh -m controller 0
$ juju_goroutines
$ juju_goroutines 2
$ juju_goroutines 1
$ juju_goroutines 0
```
