### PR TITLE
[JUJU-3273] Handle TODO regarding changing values in DeployInfo.

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -1022,18 +1022,22 @@ func unitInfoFromParams(in params.UnitInfoResult) UnitInfo {
 }
 
 type DeployInfo struct {
-	CharmURL string `json:"charm-url"`
-	// Channel is a string representation of the channel used to
-	// deploy the charm.
-	Channel string `json:"channel,omitempty"`
 	// Architecture is the architecture used to deploy the charm.
 	Architecture string `json:"architecture"`
 	// Base is the base used to deploy the charm.
 	Base coreseries.Base `json:"base,omitempty"`
+	// Channel is a string representation of the channel used to
+	// deploy the charm.
+	Channel string `json:"channel"`
 	// EffectiveChannel is the channel actually deployed from as determined
-	// by the charmhub response. May be empty if the same as the
-	// channel.
+	// by the charmhub response.
 	EffectiveChannel *string `json:"effective-channel,omitempty"`
+	// Is the name of the application deployed. This may vary from
+	// the charm name provided if differs in the metadata.yaml and
+	// no provided on the cli.
+	Name string `json:"name"`
+	// Revision is the revision of the charm deployed.
+	Revision int `json:"revision"`
 }
 
 type PendingResourceUpload struct {
@@ -1138,11 +1142,12 @@ func (c *Client) DeployFromRepository(arg DeployFromRepositoryArg) (DeployInfo, 
 func deployInfoFromParams(di params.DeployFromRepositoryInfo) (DeployInfo, error) {
 	base, err := coreseries.ParseBase(di.Base.Name, di.Base.Channel)
 	return DeployInfo{
-		CharmURL:         di.CharmURL,
-		Channel:          di.Channel,
 		Architecture:     di.Architecture,
 		Base:             base,
+		Channel:          di.Channel,
 		EffectiveChannel: di.EffectiveChannel,
+		Name:             di.Name,
+		Revision:         di.Revision,
 	}, err
 }
 

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -1467,7 +1467,6 @@ func (s *applicationSuite) TestDeployFromRepository(c *gc.C) {
 				{Message: "three"},
 			},
 			Info: params.DeployFromRepositoryInfo{
-				CharmURL:     "ch:arm64/jammy/ubuntu-7",
 				Channel:      candidate,
 				Architecture: "arm64",
 				Base: params.Base{
@@ -1475,6 +1474,8 @@ func (s *applicationSuite) TestDeployFromRepository(c *gc.C) {
 					Channel: "22.04",
 				},
 				EffectiveChannel: &stable,
+				Name:             "ubuntu",
+				Revision:         7,
 			},
 			PendingResourceUploads: nil,
 		}},
@@ -1495,7 +1496,6 @@ func (s *applicationSuite) TestDeployFromRepository(c *gc.C) {
 	c.Assert(errs[2], gc.ErrorMatches, "three")
 
 	c.Assert(info, gc.DeepEquals, application.DeployInfo{
-		CharmURL:     "ch:arm64/jammy/ubuntu-7",
 		Channel:      candidate,
 		Architecture: "arm64",
 		Base: series.Base{
@@ -1503,6 +1503,8 @@ func (s *applicationSuite) TestDeployFromRepository(c *gc.C) {
 			Channel: series.Channel{Track: "22.04", Risk: "stable"},
 		},
 		EffectiveChannel: &stable,
+		Name:             "ubuntu",
+		Revision:         7,
 	})
 
 }

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -88,14 +88,15 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(arg params.DeployFromRe
 	}
 
 	info := params.DeployFromRepositoryInfo{
-		CharmURL:     dt.charmURL.String(),
-		Channel:      dt.origin.Channel.String(),
 		Architecture: dt.origin.Platform.Architecture,
 		Base: params.Base{
 			Name:    dt.origin.Platform.OS,
 			Channel: dt.origin.Platform.Channel,
 		},
+		Channel:          dt.origin.Channel.String(),
 		EffectiveChannel: nil,
+		Name:             dt.applicationName,
+		Revision:         dt.charmURL.Revision,
 	}
 	if dt.dryRun {
 		return info, nil, nil
@@ -261,7 +262,7 @@ func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepository
 		errs = append(errs, err)
 	}
 
-	appName := charmURL.Name
+	appName := resolvedCharm.Meta().Name
 	if arg.ApplicationName != "" {
 		appName = arg.ApplicationName
 	}

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -73,7 +73,7 @@ func (s *validatorSuite) TestValidateSuccess(c *gc.C) {
 	dt, errs := s.getValidator().validate(arg)
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
-		applicationName: "testcharm",
+		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(essMeta),
 		charmURL:        resultURL,
 		numUnits:        1,
@@ -137,7 +137,7 @@ func (s *validatorSuite) TestValidatePlacementSuccess(c *gc.C) {
 	dt, errs := s.getValidator().validate(arg)
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
-		applicationName: "testcharm",
+		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(essMeta),
 		charmURL:        resultURL,
 		numUnits:        1,
@@ -195,7 +195,7 @@ func (s *validatorSuite) TestValidateEndpointBindingSuccess(c *gc.C) {
 	dt, errs := s.getValidator().validate(arg)
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(dt, gc.DeepEquals, deployTemplate{
-		applicationName: "testcharm",
+		applicationName: "test-charm",
 		charm:           corecharm.NewCharmInfoAdapter(essMeta),
 		charmURL:        resultURL,
 		endpoints:       endpointMap,
@@ -596,7 +596,7 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 		CharmName: "testme",
 	}
 	template := deployTemplate{
-		applicationName: "testme",
+		applicationName: "metadata-name",
 		charm:           corecharm.NewCharmInfoAdapter(corecharm.EssentialMetadata{}),
 		charmURL:        charm.MustParseURL("ch:amd64/jammy/testme-5"),
 		endpoints:       map[string]string{"to": "from"},
@@ -616,7 +616,7 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 	}
 	s.state.EXPECT().AddCharmMetadata(info).Return(&state.Charm{}, nil)
 	addAppArgs := state.AddApplicationArgs{
-		Name:  "testme",
+		Name:  "metadata-name",
 		Charm: &state.Charm{},
 		CharmOrigin: &state.CharmOrigin{
 			Source:   "charm-hub",
@@ -640,11 +640,12 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 	c.Assert(errs, gc.HasLen, 0)
 	c.Assert(resources, gc.HasLen, 0)
 	c.Assert(obtainedInfo, gc.DeepEquals, params.DeployFromRepositoryInfo{
-		CharmURL:         "ch:amd64/jammy/testme-5",
-		Channel:          "stable",
 		Architecture:     "amd64",
 		Base:             params.Base{Name: "ubuntu", Channel: "22.04"},
+		Channel:          "stable",
 		EffectiveChannel: nil,
+		Name:             "metadata-name",
+		Revision:         5,
 	})
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3302,17 +3302,22 @@
                         "channel": {
                             "type": "string"
                         },
-                        "charm-url": {
-                            "type": "string"
-                        },
                         "effective-channel": {
                             "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "charm-url",
-                        "architecture"
+                        "architecture",
+                        "channel",
+                        "name",
+                        "revision"
                     ]
                 },
                 "DeployFromRepositoryResult": {

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -649,23 +649,23 @@ type DeployFromRepositoryResult struct {
 }
 
 // DeployFromRepositoryInfo describes the charm deployed.
-// TODO: (hml)
-// Change the data here: charmurl not required, add
-// source, revision and application name. The latter may
-// different from the charm name, even if not specified
-// by the user.
 type DeployFromRepositoryInfo struct {
-	CharmURL string `json:"charm-url"`
-	// Channel is a string representation of the channel used to
-	// deploy the charm.
-	Channel string `json:"channel,omitempty"`
 	// Architecture is the architecture used to deploy the charm.
 	Architecture string `json:"architecture"`
 	// Base is the base used to deploy the charm.
 	Base Base `json:"base,omitempty"`
+	// Channel is a string representation of the channel used to
+	// deploy the charm.
+	Channel string `json:"channel"`
 	// EffectiveChannel is the channel actually deployed from as determined
 	// by the charmhub response.
 	EffectiveChannel *string `json:"effective-channel,omitempty"`
+	// Is the name of the application deployed. This may vary from
+	// the charm name provided if differs in the metadata.yaml and
+	// no provided on the cli.
+	Name string `json:"name"`
+	// Revision is the revision of the charm deployed.
+	Revision int `json:"revision"`
 }
 
 // PendingResourceUpload holds data required to upload a


### PR DESCRIPTION
Follow on to #15278 

There is no longer a need for the charm url to be returned to the CLI. Especially as we intend to replace it with a identifier. Return the name and revision of what was deployed instead. The remaining bits of what would be in the charm url are already contained in the output.

## QA steps

*Commands to run to verify that the change works.*

```sh
$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju bootstrap localhost test
$ juju add-model five

$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju deploy ubuntu
application.DeployInfo{
    Architecture: "amd64",
    Base:         series.Base{
        OS:      "ubuntu",
        Channel: series.Channel{Track:"20.04", Risk:"stable"},
    },
    Channel:          "stable",
    EffectiveChannel: (*string)(nil),
    Name:             "ubuntu",
    Revision:         21,
}
```
