### PR TITLE
[JUJU-2987] Add support for migrating models with cross model secrets

### DIFF
--- a/api/controller/remoterelations/remoterelations.go
+++ b/api/controller/remoterelations/remoterelations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -262,7 +263,7 @@ func (c *Client) ControllerAPIInfoForModel(modelUUID string) (*api.Info, error) 
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		return nil, result.Error
+		return nil, apiservererrors.RestoreError(result.Error)
 	}
 	return &api.Info{
 		Addrs:    result.Addresses,

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -831,7 +831,7 @@ func (s *watcherSuite) setupSecretsRevisionWatcher(
 	return uri, assertChange, assertNoChange, stop
 }
 
-func (s *watcherSuite) TestSecretsRevisionWatcher(c *gc.C) {
+func (s *watcherSuite) TestCrossModelSecretsRevisionWatcher(c *gc.C) {
 	uri, assertChange, assertNoChange, stop := s.setupSecretsRevisionWatcher(c)
 	defer stop()
 
@@ -840,7 +840,7 @@ func (s *watcherSuite) TestSecretsRevisionWatcher(c *gc.C) {
 	// Initial event - no changes since we're at rev 1 still.
 	assertChange(nil, 0)
 
-	err := s.State.SaveSecretConsumer(uri, names.NewUnitTag("foo/0"), &secrets.SecretConsumerMetadata{
+	err := s.State.SaveSecretRemoteConsumer(uri, names.NewUnitTag("foo/0"), &secrets.SecretConsumerMetadata{
 		CurrentRevision: 1,
 		LatestRevision:  1,
 	})

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -230,7 +230,7 @@ func (s *CrossModelSecretsAPI) getSecretContent(arg params.GetRemoteSecretConten
 }
 
 func (s *CrossModelSecretsAPI) updateConsumedRevision(secretsState SecretsState, secretsConsumer SecretsConsumer, consumer names.Tag, uri *coresecrets.URI, refresh bool) (int, error) {
-	consumerInfo, err := secretsConsumer.GetSecretConsumer(uri, consumer)
+	consumerInfo, err := secretsConsumer.GetSecretRemoteConsumer(uri, consumer)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return 0, errors.Trace(err)
 	}
@@ -248,7 +248,7 @@ func (s *CrossModelSecretsAPI) updateConsumedRevision(secretsState SecretsState,
 		}
 		consumerInfo.LatestRevision = md.LatestRevision
 		consumerInfo.CurrentRevision = md.LatestRevision
-		if err := secretsConsumer.SaveSecretConsumer(uri, consumer, consumerInfo); err != nil {
+		if err := secretsConsumer.SaveSecretRemoteConsumer(uri, consumer, consumerInfo); err != nil {
 			return 0, errors.Trace(err)
 		}
 	}

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -169,14 +169,14 @@ func (s *CrossModelSecretsSuite) assertGetSecretContentInfo(c *gc.C, newConsumer
 
 	consumerTag := names.NewUnitTag("remote-app/666")
 	if newConsumer {
-		s.secretsConsumer.EXPECT().GetSecretConsumer(uri, consumerTag).Return(nil, errors.NotFoundf(""))
+		s.secretsConsumer.EXPECT().GetSecretRemoteConsumer(uri, consumerTag).Return(nil, errors.NotFoundf(""))
 	} else {
-		s.secretsConsumer.EXPECT().GetSecretConsumer(uri, consumerTag).Return(&coresecrets.SecretConsumerMetadata{CurrentRevision: 69}, nil)
+		s.secretsConsumer.EXPECT().GetSecretRemoteConsumer(uri, consumerTag).Return(&coresecrets.SecretConsumerMetadata{CurrentRevision: 69}, nil)
 	}
 	s.secretsState.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{
 		LatestRevision: 667,
 	}, nil)
-	s.secretsConsumer.EXPECT().SaveSecretConsumer(uri, consumerTag, &coresecrets.SecretConsumerMetadata{
+	s.secretsConsumer.EXPECT().SaveSecretRemoteConsumer(uri, consumerTag, &coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 667,
 		LatestRevision:  667,
 	}).Return(nil)

--- a/apiserver/facades/controller/crossmodelsecrets/mocks/secretsconsumer.go
+++ b/apiserver/facades/controller/crossmodelsecrets/mocks/secretsconsumer.go
@@ -35,33 +35,33 @@ func (m *MockSecretsConsumer) EXPECT() *MockSecretsConsumerMockRecorder {
 	return m.recorder
 }
 
-// GetSecretConsumer mocks base method.
-func (m *MockSecretsConsumer) GetSecretConsumer(arg0 *secrets.URI, arg1 names.Tag) (*secrets.SecretConsumerMetadata, error) {
+// GetSecretRemoteConsumer mocks base method.
+func (m *MockSecretsConsumer) GetSecretRemoteConsumer(arg0 *secrets.URI, arg1 names.Tag) (*secrets.SecretConsumerMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretConsumer", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetSecretRemoteConsumer", arg0, arg1)
 	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSecretConsumer indicates an expected call of GetSecretConsumer.
-func (mr *MockSecretsConsumerMockRecorder) GetSecretConsumer(arg0, arg1 interface{}) *gomock.Call {
+// GetSecretRemoteConsumer indicates an expected call of GetSecretRemoteConsumer.
+func (mr *MockSecretsConsumerMockRecorder) GetSecretRemoteConsumer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).GetSecretConsumer), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretRemoteConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).GetSecretRemoteConsumer), arg0, arg1)
 }
 
-// SaveSecretConsumer mocks base method.
-func (m *MockSecretsConsumer) SaveSecretConsumer(arg0 *secrets.URI, arg1 names.Tag, arg2 *secrets.SecretConsumerMetadata) error {
+// SaveSecretRemoteConsumer mocks base method.
+func (m *MockSecretsConsumer) SaveSecretRemoteConsumer(arg0 *secrets.URI, arg1 names.Tag, arg2 *secrets.SecretConsumerMetadata) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveSecretConsumer", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SaveSecretRemoteConsumer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SaveSecretConsumer indicates an expected call of SaveSecretConsumer.
-func (mr *MockSecretsConsumerMockRecorder) SaveSecretConsumer(arg0, arg1, arg2 interface{}) *gomock.Call {
+// SaveSecretRemoteConsumer indicates an expected call of SaveSecretRemoteConsumer.
+func (mr *MockSecretsConsumerMockRecorder) SaveSecretRemoteConsumer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).SaveSecretConsumer), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSecretRemoteConsumer", reflect.TypeOf((*MockSecretsConsumer)(nil).SaveSecretRemoteConsumer), arg0, arg1, arg2)
 }
 
 // SecretAccess mocks base method.

--- a/apiserver/facades/controller/crossmodelsecrets/state.go
+++ b/apiserver/facades/controller/crossmodelsecrets/state.go
@@ -19,8 +19,8 @@ type SecretsState interface {
 }
 
 type SecretsConsumer interface {
-	GetSecretConsumer(*secrets.URI, names.Tag) (*secrets.SecretConsumerMetadata, error)
-	SaveSecretConsumer(*secrets.URI, names.Tag, *secrets.SecretConsumerMetadata) error
+	GetSecretRemoteConsumer(*secrets.URI, names.Tag) (*secrets.SecretConsumerMetadata, error)
+	SaveSecretRemoteConsumer(*secrets.URI, names.Tag, *secrets.SecretConsumerMetadata) error
 	SecretAccess(uri *secrets.URI, subject names.Tag) (secrets.SecretRole, error)
 	SecretAccessScope(uri *secrets.URI, subject names.Tag) (names.Tag, error)
 }

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -550,6 +550,12 @@ func allCollections() CollectionSchema {
 			}},
 		},
 
+		secretRemoteConsumersC: {
+			indexes: []mgo.Index{{
+				Key: []string{"consumer-tag", "model-uuid"},
+			}},
+		},
+
 		secretPermissionsC: {
 			indexes: []mgo.Index{{
 				Key: []string{"subject-tag", "scope-tag", "model-uuid"},
@@ -684,13 +690,14 @@ const (
 	firewallRulesC       = "firewallRules"
 
 	// Secrets
-	secretMetadataC       = "secretMetadata"
-	secretRevisionsC      = "secretRevisions"
-	secretConsumersC      = "secretConsumers"
-	secretPermissionsC    = "secretPermissions"
-	secretRotateC         = "secretRotate"
-	secretBackendsC       = "secretBackends"
-	secretBackendsRotateC = "secretBackendsRotate"
+	secretMetadataC        = "secretMetadata"
+	secretRevisionsC       = "secretRevisions"
+	secretConsumersC       = "secretConsumers"
+	secretRemoteConsumersC = "secretRemoteConsumers"
+	secretPermissionsC     = "secretPermissions"
+	secretRotateC          = "secretRotate"
+	secretBackendsC        = "secretBackends"
+	secretBackendsRotateC  = "secretBackendsRotate"
 )
 
 // watcherIgnoreList contains all the collections in mongo that should not be watched by the

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -3130,6 +3130,15 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name: "remote-app", SourceModel: s.Model.ModelTag(), IsConsumerProxy: true})
+	c.Assert(err, jc.ErrorIsNil)
+	remoteConsumer := names.NewApplicationTag("remote-app")
+	err = s.State.SaveSecretRemoteConsumer(uri, remoteConsumer, &secrets.SecretConsumerMetadata{
+		CurrentRevision: 667,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
 	_, newSt := s.importModel(c, s.State)
 
 	store = state.NewSecrets(newSt)
@@ -3169,6 +3178,13 @@ func (s *MigrationImportSuite) TestSecrets(c *gc.C) {
 	c.Assert(info, jc.DeepEquals, &secrets.SecretConsumerMetadata{
 		Label:           "consumer label",
 		CurrentRevision: 666,
+		LatestRevision:  2,
+	})
+
+	info, err = newSt.GetSecretRemoteConsumer(uri, remoteConsumer)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(info, jc.DeepEquals, &secrets.SecretConsumerMetadata{
+		CurrentRevision: 667,
 		LatestRevision:  2,
 	})
 }

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -95,6 +95,7 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		secretRevisionsC,
 		secretRotateC,
 		secretConsumersC,
+		secretRemoteConsumersC,
 		secretPermissionsC,
 	)
 

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -968,24 +968,24 @@ func (s *remoteApplicationSuite) TestDestroyAlsoDeletesSecretConsumerInfo(c *gc.
 	_, err := store.CreateSecret(uri, cp)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.SaveSecretConsumer(uri, s.application.Tag(), &secrets.SecretConsumerMetadata{CurrentRevision: 666})
+	err = s.State.SaveSecretRemoteConsumer(uri, s.application.Tag(), &secrets.SecretConsumerMetadata{CurrentRevision: 666})
 	c.Assert(err, jc.ErrorIsNil)
 
 	unit := names.NewUnitTag(s.application.Name() + "/666")
-	err = s.State.SaveSecretConsumer(uri, unit, &secrets.SecretConsumerMetadata{CurrentRevision: 667})
+	err = s.State.SaveSecretRemoteConsumer(uri, unit, &secrets.SecretConsumerMetadata{CurrentRevision: 667})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.GetSecretConsumer(uri, s.application.Tag())
+	_, err = s.State.GetSecretRemoteConsumer(uri, s.application.Tag())
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.GetSecretConsumer(uri, unit)
+	_, err = s.State.GetSecretRemoteConsumer(uri, unit)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.application.Destroy()
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.State.GetSecretConsumer(uri, s.application.Tag())
+	_, err = s.State.GetSecretRemoteConsumer(uri, s.application.Tag())
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
-	_, err = s.State.GetSecretConsumer(uri, unit)
+	_, err = s.State.GetSecretRemoteConsumer(uri, unit)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -417,11 +417,17 @@ func (s *secretsStore) UpdateSecret(uri *secrets.URI, p UpdateSecretParams) (*se
 			}
 			ops = append(ops, countOps...)
 
-			updateConsumersOps, err := s.st.secretUpdateConsumersOps(uri, metadataDoc.LatestRevision)
+			updateConsumersOps, err := s.st.secretUpdateConsumersOps(secretConsumersC, uri, metadataDoc.LatestRevision)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 			ops = append(ops, updateConsumersOps...)
+
+			updateRemoteConsumersOps, err := s.st.secretUpdateConsumersOps(secretRemoteConsumersC, uri, metadataDoc.LatestRevision)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, updateRemoteConsumersOps...)
 
 			// Saving a new revision might result in the previous latest revision
 			// being obsolete if it had not been read yet.
@@ -683,6 +689,9 @@ func (st *State) deleteOne(uri *secrets.URI) (external []secrets.ValueRef, _ err
 	}
 
 	if err = st.removeSecretConsumerInfo(uri); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if err = st.removeSecretRemoteConsumerInfo(uri); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -1325,6 +1334,49 @@ func (st *State) GetSecretConsumer(uri *secrets.URI, consumer names.Tag) (*secre
 	return md, nil
 }
 
+type secretRemoteConsumerDoc struct {
+	DocID string `bson:"_id"`
+
+	ConsumerTag     string `bson:"consumer-tag"`
+	CurrentRevision int    `bson:"current-revision"`
+
+	// LatestRevision is denormalised here so that the
+	// consumer watcher can be triggered when a new
+	// secret revision is added.
+	LatestRevision int `bson:"latest-revision"`
+}
+
+// GetSecretRemoteConsumer gets secret consumer metadata
+// for a cross model consumer.
+func (st *State) GetSecretRemoteConsumer(uri *secrets.URI, consumer names.Tag) (*secrets.SecretConsumerMetadata, error) {
+	if uri == nil {
+		return nil, errors.NewNotValid(nil, "empty URI")
+	}
+
+	if err := st.checkExists(uri); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	secretConsumersCollection, closer := st.db().GetCollection(secretRemoteConsumersC)
+	defer closer()
+
+	key := st.secretConsumerKey(uri, consumer.String())
+	var doc secretRemoteConsumerDoc
+	err := secretConsumersCollection.FindId(key).One(&doc)
+	if errors.Cause(err) == mgo.ErrNotFound {
+		return nil, errors.NotFoundf("consumer %q metadata for secret %q", consumer, uri.String())
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	md := &secrets.SecretConsumerMetadata{
+		CurrentRevision: doc.CurrentRevision,
+		LatestRevision:  doc.LatestRevision,
+	}
+
+	return md, nil
+}
+
 func (st *State) removeSecretConsumerInfo(uri *secrets.URI) error {
 	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
 	defer closer()
@@ -1365,6 +1417,19 @@ func (st *State) removeSecretConsumerInfo(uri *secrets.URI) error {
 	return nil
 }
 
+func (st *State) removeSecretRemoteConsumerInfo(uri *secrets.URI) error {
+	secretConsumersCollection, closer := st.db().GetCollection(secretRemoteConsumersC)
+	defer closer()
+
+	_, err := secretConsumersCollection.Writeable().RemoveAll(bson.D{{
+		"_id", bson.D{{"$regex", fmt.Sprintf("%s#.*", uri.ID)}},
+	}})
+	if err != nil {
+		return errors.Annotatef(err, "cannot delete remote consumer info for %s", uri.String())
+	}
+	return nil
+}
+
 // RemoveSecretConsumer removes secret references for the specified consumer.
 func (st *State) RemoveSecretConsumer(consumer names.Tag) error {
 	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
@@ -1400,7 +1465,7 @@ func (st *State) RemoveSecretConsumer(consumer names.Tag) error {
 // removeRemoteSecretConsumer removes secret consumer info for the specified
 // remote application and also any of its units.
 func (st *State) removeRemoteSecretConsumer(appName string) error {
-	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
+	secretConsumersCollection, closer := st.db().GetCollection(secretRemoteConsumersC)
 	defer closer()
 
 	match := fmt.Sprintf("(unit|application)-%s(\\/\\d)?", appName)
@@ -1423,7 +1488,7 @@ func (u *updateSecretConsumerOperation) Build(attempt int) ([]txn.Op, error) {
 	if attempt > 0 {
 		return nil, errors.NotFoundf("secret consumers for secret %q", u.uri)
 	}
-	return u.st.secretUpdateConsumersOps(u.uri, u.latestRevision)
+	return u.st.secretUpdateConsumersOps(secretConsumersC, u.uri, u.latestRevision)
 }
 
 // Done implements ModelOperation.
@@ -1523,10 +1588,74 @@ func (st *State) SaveSecretConsumer(uri *secrets.URI, consumer names.Tag, metada
 	return st.db().Run(buildTxn)
 }
 
+// SaveSecretRemoteConsumer saves or updates secret consumer metadata
+// for a cross model consumer.
+func (st *State) SaveSecretRemoteConsumer(uri *secrets.URI, consumer names.Tag, metadata *secrets.SecretConsumerMetadata) error {
+	key := st.secretConsumerKey(uri, consumer.String())
+	secretConsumersCollection, closer := st.db().GetCollection(secretRemoteConsumersC)
+	defer closer()
+
+	var doc secretRemoteConsumerDoc
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if err := st.checkExists(uri); err != nil {
+			return nil, errors.Trace(err)
+		}
+		err := secretConsumersCollection.FindId(key).One(&doc)
+		if err != nil && err != mgo.ErrNotFound {
+			return nil, errors.Trace(err)
+		}
+		create := err != nil
+
+		var ops []txn.Op
+
+		if create {
+			ops = append(ops, txn.Op{
+				C:      secretRemoteConsumersC,
+				Id:     key,
+				Assert: txn.DocMissing,
+				Insert: secretRemoteConsumerDoc{
+					DocID:           key,
+					ConsumerTag:     consumer.String(),
+					CurrentRevision: metadata.CurrentRevision,
+					LatestRevision:  metadata.LatestRevision,
+				},
+			})
+
+			// Increment the consumer count, ensuring no new consumers
+			// are added while update is in progress.
+			countRefOps, err := st.checkConsumerCountOps(uri, 1)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, countRefOps...)
+		} else {
+			ops = append(ops, txn.Op{
+				C:      secretRemoteConsumersC,
+				Id:     key,
+				Assert: txn.DocExists,
+				Update: bson.M{"$set": bson.M{
+					"current-revision": metadata.CurrentRevision,
+				}},
+			})
+		}
+
+		// The consumer is tracking a new revision, which might result in the
+		// previous revision becoming obsolete.
+		obsoleteOps, err := st.markObsoleteRevisionOps(uri, consumer.String(), metadata.CurrentRevision)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ops = append(ops, obsoleteOps...)
+
+		return ops, nil
+	}
+	return st.db().Run(buildTxn)
+}
+
 // secretUpdateConsumersOps updates the latest secret revision number
 // on all consumers. This triggers the secrets change watcher.
-func (st *State) secretUpdateConsumersOps(uri *secrets.URI, newRevision int) ([]txn.Op, error) {
-	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
+func (st *State) secretUpdateConsumersOps(coll string, uri *secrets.URI, newRevision int) ([]txn.Op, error) {
+	secretConsumersCollection, closer := st.db().GetCollection(coll)
 	defer closer()
 
 	var (
@@ -1538,7 +1667,7 @@ func (st *State) secretUpdateConsumersOps(uri *secrets.URI, newRevision int) ([]
 	iter := secretConsumersCollection.Find(q).Iter()
 	for iter.Next(&doc) {
 		ops = append(ops, txn.Op{
-			C:      secretConsumersC,
+			C:      coll,
 			Id:     doc.DocID,
 			Assert: txn.DocExists,
 			Update: bson.M{"$set": bson.M{"latest-revision": newRevision}},
@@ -1550,14 +1679,48 @@ func (st *State) secretUpdateConsumersOps(uri *secrets.URI, newRevision int) ([]
 	return ops, nil
 }
 
-// allSecretConsumers is used for model export.
-func (s *secretsStore) allSecretConsumers() ([]secretConsumerDoc, error) {
+const (
+	idSnippet   = `[0-9a-z]{20}`
+	uuidSnippet = `[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`
+)
+
+// allLocalSecretConsumers is used for model export.
+func (s *secretsStore) allLocalSecretConsumers() ([]secretConsumerDoc, error) {
 	secretConsumerCollection, closer := s.st.db().GetCollection(secretConsumersC)
 	defer closer()
 
 	var docs []secretConsumerDoc
 
-	err := secretConsumerCollection.Find(nil).All(&docs)
+	err := secretConsumerCollection.Find(bson.D{{"_id", bson.D{{"$regex", idSnippet}}}}).All(&docs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return docs, nil
+}
+
+// allRemoteSecretConsumers is used for model export.
+func (s *secretsStore) allRemoteSecretConsumers() ([]secretConsumerDoc, error) {
+	secretConsumerCollection, closer := s.st.db().GetCollection(secretConsumersC)
+	defer closer()
+
+	var docs []secretConsumerDoc
+
+	q := fmt.Sprintf(`%s/%s`, uuidSnippet, idSnippet)
+	err := secretConsumerCollection.Find(bson.D{{"_id", bson.D{{"$regex", q}}}}).All(&docs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return docs, nil
+}
+
+// allSecretRemoteConsumers is used for model export.
+func (s *secretsStore) allSecretRemoteConsumers() ([]secretRemoteConsumerDoc, error) {
+	secretRemoteConsumerCollection, closer := s.st.db().GetCollection(secretRemoteConsumersC)
+	defer closer()
+
+	var docs []secretRemoteConsumerDoc
+
+	err := secretRemoteConsumerCollection.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1582,6 +1745,7 @@ type consumedSecretsWatcher struct {
 
 	knownRevisions map[string]int
 
+	coll       string
 	matchQuery bson.D
 	filter     func(id string) bool
 }
@@ -1593,11 +1757,13 @@ func newConsumedSecretsWatcher(st modelBackend, consumer string, remote bool) St
 		knownRevisions: make(map[string]int),
 	}
 	if !remote {
+		w.coll = secretConsumersC
 		w.matchQuery = bson.D{{"consumer-tag", consumer}}
 		w.filter = func(id string) bool {
 			return strings.HasSuffix(id, "#"+consumer)
 		}
 	} else {
+		w.coll = secretRemoteConsumersC
 		match := fmt.Sprintf("(unit|application)-%s(\\/\\d)?", consumer)
 		w.matchQuery = bson.D{{"consumer-tag", bson.D{{"$regex", match}}}}
 		w.filter = func(id string) bool {
@@ -1618,7 +1784,7 @@ func (w *consumedSecretsWatcher) Changes() <-chan []string {
 
 func (w *consumedSecretsWatcher) initial() ([]string, error) {
 	var doc secretConsumerDoc
-	secretConsumersCollection, closer := w.db.GetCollection(secretConsumersC)
+	secretConsumersCollection, closer := w.db.GetCollection(w.coll)
 	defer closer()
 
 	var ids []string
@@ -1659,7 +1825,7 @@ func (w *consumedSecretsWatcher) merge(currentChanges []string, change watcher.C
 
 	// Record added or updated.
 	var doc secretConsumerDoc
-	secretConsumerColl, closer := w.db.GetCollection(secretConsumersC)
+	secretConsumerColl, closer := w.db.GetCollection(w.coll)
 	defer closer()
 
 	err := secretConsumerColl.FindId(change.Id).Select(bson.D{{"latest-revision", 1}}).One(&doc)
@@ -1690,8 +1856,8 @@ func (w *consumedSecretsWatcher) loop() (err error) {
 		}
 		return w.filter(k)
 	}
-	w.watcher.WatchCollectionWithFilter(secretConsumersC, ch, filter)
-	defer w.watcher.UnwatchCollection(secretConsumersC, ch)
+	w.watcher.WatchCollectionWithFilter(w.coll, ch, filter)
+	defer w.watcher.UnwatchCollection(w.coll, ch)
 
 	changes, err := w.initial()
 	if err != nil {
@@ -1975,7 +2141,20 @@ func (st *State) getOrphanedSecretRevisions(uri *secrets.URI, exceptForConsumer 
 	latest := allRevisions.SortedValues()[allRevisions.Size()-1]
 	allRevisions.Remove(exceptForRev)
 
-	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
+	consumedRevs, err := st.getInUseSecretRevisions(secretConsumersC, uri, exceptForConsumer)
+	if err != nil {
+		return nil, 0, errors.Trace(err)
+	}
+	remoteConsumedRevs, err := st.getInUseSecretRevisions(secretRemoteConsumersC, uri, exceptForConsumer)
+	if err != nil {
+		return nil, 0, errors.Trace(err)
+	}
+	usedRevisions := consumedRevs.Union(remoteConsumedRevs)
+	return allRevisions.Difference(usedRevisions).Values(), latest, nil
+}
+
+func (st *State) getInUseSecretRevisions(collName string, uri *secrets.URI, exceptForConsumer string) (set.Ints, error) {
+	secretConsumersCollection, closer := st.db().GetCollection(collName)
 	defer closer()
 
 	pipe := secretConsumersCollection.Pipe([]bson.M{
@@ -2008,19 +2187,20 @@ func (st *State) getOrphanedSecretRevisions(uri *secrets.URI, exceptForConsumer 
 		},
 	})
 	var usedRevisions []map[string]int
-	err = pipe.All(&usedRevisions)
+	err := pipe.All(&usedRevisions)
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
+	result := set.NewInts()
 	if len(usedRevisions) == 0 {
-		return allRevisions.Values(), latest, nil
+		return result, nil
 	}
 
 	for revStr := range usedRevisions[0] {
 		r, _ := strconv.Atoi(revStr)
-		allRevisions.Remove(r)
+		result.Add(r)
 	}
-	return allRevisions.Values(), latest, nil
+	return result, nil
 }
 
 type secretPermissionDoc struct {

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -2387,12 +2387,12 @@ func (s *SecretsRemoteConsumerWatcherSuite) setupWatcher(c *gc.C) (state.Strings
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.SaveSecretConsumer(uri, names.NewUnitTag("remote-app/0"), &secrets.SecretConsumerMetadata{
+	err = s.State.SaveSecretRemoteConsumer(uri, names.NewUnitTag("remote-app/0"), &secrets.SecretConsumerMetadata{
 		CurrentRevision: 1,
 		LatestRevision:  1,
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.State.SaveSecretConsumer(uri2, names.NewUnitTag("remote-app/0"), &secrets.SecretConsumerMetadata{
+	err = s.State.SaveSecretRemoteConsumer(uri2, names.NewUnitTag("remote-app/0"), &secrets.SecretConsumerMetadata{
 		CurrentRevision: 1,
 		LatestRevision:  2,
 	})
@@ -2444,7 +2444,7 @@ func (s *SecretsRemoteConsumerWatcherSuite) TestWatchMultipleSecrets(c *gc.C) {
 	_, err := s.store.CreateSecret(uri2, cp)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.State.SaveSecretConsumer(uri2, names.NewUnitTag("remote-app/0"), &secrets.SecretConsumerMetadata{CurrentRevision: 1})
+	err = s.State.SaveSecretRemoteConsumer(uri2, names.NewUnitTag("remote-app/0"), &secrets.SecretConsumerMetadata{CurrentRevision: 1})
 	c.Assert(err, jc.ErrorIsNil)
 	// No event until rev > 1.
 	wc.AssertNoChange()
@@ -2473,12 +2473,12 @@ func (s *SecretsRemoteConsumerWatcherSuite) TestWatchConsumedDeleted(c *gc.C) {
 	wc := testing.NewStringsWatcherC(c, w)
 	defer testing.AssertStop(c, w)
 
-	err := s.State.SaveSecretConsumer(uri, names.NewApplicationTag("foo"), &secrets.SecretConsumerMetadata{
+	err := s.State.SaveSecretRemoteConsumer(uri, names.NewApplicationTag("foo"), &secrets.SecretConsumerMetadata{
 		CurrentRevision: 1,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
-	err = s.State.SaveSecretConsumer(uri, names.NewApplicationTag("baz"), &secrets.SecretConsumerMetadata{
+	err = s.State.SaveSecretRemoteConsumer(uri, names.NewApplicationTag("baz"), &secrets.SecretConsumerMetadata{
 		CurrentRevision: 1,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/remoterelations/remoteapplicationworker.go
+++ b/worker/remoterelations/remoteapplicationworker.go
@@ -162,7 +162,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 			if err := w.localModelFacade.SetRemoteApplicationStatus(w.applicationName, status.Error, msg); err != nil {
 				return errors.Annotatef(err, "updating remote application %v status from remote model %v", w.applicationName, w.remoteModelUUID)
 			}
-			return errors.Trace(err)
+			return errors.Annotate(err, "cannot connect to external controller")
 		}
 		defer func() {
 			if err := w.remoteModelFacade.Close(); err != nil {
@@ -294,7 +294,7 @@ func (w *remoteApplicationWorker) loop() (err error) {
 func (w *remoteApplicationWorker) newRemoteRelationsFacadeWithRedirect() error {
 	apiInfo, err := w.localModelFacade.ControllerAPIInfoForModel(w.remoteModelUUID)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "cannot get controller api info for remote model")
 	}
 	w.logger.Debugf("remote controller API addresses: %v", apiInfo.Addrs)
 


### PR DESCRIPTION
A few changes to support migrating models with cross model secrets.
Firstly, a new collection is introduced - `remoteSecretConsumers`. This is used on the offering model to record the revision info for secret viewers from the consuming model. The offering side watcher which notifies of changes to secret revisions uses this collection.
Secondly, the migrate import/export is updated to use the new support for cmr artefacts in `juju/description`.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Create 2 models on a controller. 
Deploy juju-qa-dummy-source in one model and offer the sink endpoint.
Deploy juju-qa-dummy-sink in the other model and relate to the offer.
In the dummy-source app, create a secret and share it with relation 0.
In the dummy-sink app, get the secret.

Migrate the offering model to a new controller.
In the consuming model, in the dummy sink app, get the secret and ensure it still works.