### PR TITLE
[JUJU-3294] Allow suggested retry for juju download 

### DIFF
--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -158,9 +158,7 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 	defer cancel()
 
 	// Locate a release that we would expect to be default. In this case
-	// we want to fall back to latest/stable. We don't want to use the
-	// info.DefaultRelease here as that isn't actually the default release,
-	// but instead the last release and that's not what we want.
+	// we want to fall back to latest/stable.
 	channel := c.channel
 	if channel == "" {
 		channel = corecharm.DefaultChannelString

--- a/cmd/juju/charmhub/download.go
+++ b/cmd/juju/charmhub/download.go
@@ -178,44 +178,10 @@ func (c *downloadCommand) Run(cmdContext *cmd.Context) error {
 	if pSeries == "all" || pSeries == "" {
 		pSeries = version.DefaultSupportedLTS()
 	}
-	base, err := coreseries.GetBaseFromSeries(pSeries)
+
+	results, normBase, err := c.refresh(ctx, cmdContext, client, normChannel, pArch, pSeries, true)
 	if err != nil {
 		return errors.Trace(err)
-	}
-	platform := fmt.Sprintf("%s/%s/%s", pArch, base.Name, base.Channel.Track)
-	normBase, err := corecharm.ParsePlatformNormalize(platform)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Ensure we compute the base channel correctly.
-	computedNormBase := corecharm.ComputeBaseChannel(normBase)
-
-	refreshConfig, err := charmhub.InstallOneFromChannel(c.charmOrBundle, normChannel.String(), charmhub.RefreshBase{
-		Architecture: computedNormBase.Architecture,
-		Name:         computedNormBase.OS,
-		Channel:      computedNormBase.Channel,
-	})
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	results, err := client.Refresh(ctx, refreshConfig)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if len(results) == 0 {
-		return errors.NotFoundf(c.charmOrBundle)
-	}
-	// Ensure we didn't get any errors whilst querying the charmhub API
-	for _, res := range results {
-		if res.Error != nil {
-			if res.Error.Code == transport.ErrorCodeRevisionNotFound {
-				return c.suggested(pSeries, normChannel.String(), res.Error.Extra.Releases, cmdContext)
-			}
-			return errors.Errorf("unable to locate %s: %s", c.charmOrBundle, res.Error.Message)
-		}
 	}
 
 	// In theory we can get multiple responses from the refresh API, but in
@@ -286,7 +252,60 @@ Install the %q %s with:
 	return nil
 }
 
-func (c *downloadCommand) suggested(requestedSeries string, channel string, releases []transport.Release, cmdContext *cmd.Context) error {
+func (c *downloadCommand) refresh(ctx context.Context, cmdContext *cmd.Context, client CharmHubClient, normChannel charm.Channel, arch, series string, retrySuggested bool) ([]transport.RefreshResponse, *corecharm.Platform, error) {
+	base, err := coreseries.GetBaseFromSeries(series)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	platform := fmt.Sprintf("%s/%s/%s", arch, base.Name, base.Channel.Track)
+	normBase, err := corecharm.ParsePlatformNormalize(platform)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// Ensure we compute the base channel correctly.
+	computedNormBase := corecharm.ComputeBaseChannel(normBase)
+
+	refreshConfig, err := charmhub.InstallOneFromChannel(c.charmOrBundle, normChannel.String(), charmhub.RefreshBase{
+		Architecture: computedNormBase.Architecture,
+		Name:         computedNormBase.OS,
+		Channel:      computedNormBase.Channel,
+	})
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	results, err := client.Refresh(ctx, refreshConfig)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	if len(results) == 0 {
+		return nil, nil, errors.NotFoundf(c.charmOrBundle)
+	}
+	// Ensure we didn't get any errors whilst querying the charmhub API
+	for _, res := range results {
+		if res.Error != nil {
+			if res.Error.Code == transport.ErrorCodeRevisionNotFound {
+				possibleSeries, err := c.suggested(cmdContext, series, normChannel.String(), res.Error.Extra.Releases)
+				// The following will attempt to refresh the charm with the
+				// suggested series. If it can't do that, it will give up after
+				// the second attempt.
+				if retrySuggested && errors.Is(err, errors.NotSupported) && len(possibleSeries) > 0 {
+					cmdContext.Infof("Series %q is not supported for charm %q, trying series %q", series, c.charmOrBundle, possibleSeries[0])
+					return c.refresh(ctx, cmdContext, client, normChannel, arch, possibleSeries[0], false)
+				}
+				return nil, nil, errors.Trace(err)
+			}
+			return nil, nil, errors.Errorf("unable to locate %s: %s", c.charmOrBundle, res.Error.Message)
+		}
+	}
+
+	return results, &normBase, nil
+}
+
+func (c *downloadCommand) suggested(cmdContext *cmd.Context, requestedSeries string, channel string, releases []transport.Release) ([]string, error) {
+	var ordered []string
 	series := set.NewStrings()
 	for _, rel := range releases {
 		if rel.Channel == channel {
@@ -297,6 +316,9 @@ func (c *downloadCommand) suggested(requestedSeries string, channel string, rele
 			})
 			s, err := coreseries.VersionSeries(platform.Channel)
 			if err == nil {
+				if !series.Contains(s) {
+					ordered = append(ordered, s)
+				}
 				series.Add(s)
 			} else {
 				// Shouldn't happen, log and continue if verbose is set.
@@ -306,13 +328,13 @@ func (c *downloadCommand) suggested(requestedSeries string, channel string, rele
 	}
 	if series.IsEmpty() {
 		// No releases in this channel
-		return errors.Errorf(`%q has no releases in channel %q. Type
+		return nil, errors.Errorf(`%q has no releases in channel %q. Type
     juju info %s
 for a list of supported channels.`,
 			c.charmOrBundle, channel, c.charmOrBundle)
 	}
-	return errors.Errorf("%q does not support series %q in channel %q.  Supported series are: %s.",
-		c.charmOrBundle, requestedSeries, channel, strings.Join(series.SortedValues(), ", "))
+	return ordered, errors.NewNotSupported(nil, fmt.Sprintf("%q does not support series %q in channel %q.  Supported series are: %s.",
+		c.charmOrBundle, requestedSeries, channel, strings.Join(series.SortedValues(), ", ")))
 }
 
 func (c *downloadCommand) calculateHash(path string) (string, error) {

--- a/cmd/juju/charmhub/download_test.go
+++ b/cmd/juju/charmhub/download_test.go
@@ -131,9 +131,32 @@ func (s *downloadSuite) TestRunWithCustomCharmHubURL(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *downloadSuite) TestRunWithUnsupportedSeries(c *gc.C) {
+func (s *downloadSuite) TestRunWithUnsupportedSeriesPicksFirstSuggestion(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
+	url := "http://example.org/"
+
+	s.expectRefreshUnsupportedSeries()
+	s.expectRefresh(url)
+	s.expectDownload(c, url)
+	s.expectFilesystem(c)
+
+	command := &downloadCommand{
+		charmHubCommand: s.newCharmHubCommand(),
+	}
+	command.SetFilesystem(s.filesystem)
+	err := cmdtesting.InitCommand(command, []string{"test"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctx := commandContextForTest(c)
+	err = command.Run(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *downloadSuite) TestRunWithUnsupportedSeriesReturnsSecondAttempt(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	s.expectRefreshUnsupportedSeries()
 	s.expectRefreshUnsupportedSeries()
 
 	command := &downloadCommand{
@@ -145,7 +168,7 @@ func (s *downloadSuite) TestRunWithUnsupportedSeries(c *gc.C) {
 
 	ctx := commandContextForTest(c)
 	err = command.Run(ctx)
-	c.Assert(err, gc.ErrorMatches, `"test" does not support series "focal" in channel "stable".  Supported series are: bionic, trusty, xenial.`)
+	c.Assert(err, gc.ErrorMatches, `"test" does not support series "bionic" in channel "stable".  Supported series are: bionic, trusty, xenial.`)
 }
 
 func (s *downloadSuite) TestRunWithNoStableRelease(c *gc.C) {


### PR DESCRIPTION
The following will attempt to download a charm of the suggested output if there is one given. This is a simple crude implementation that looks at the return from the suggested output before attempting another go.

This is really handy if a charm hasn't got the latest LTS support.

The code just recursively calls refresh again if there is a suggestion. It lets the user know that the original series supplied wasn't supported and is going to download the next series from the response. The code ensures that we try the next one from the result set in an ordered manner. We don't use the sorted by name for this occasion.

This should remove some of the pain points of juju download for users.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju download ghost
```

Should output:

```sh
Suggested series "focal" is not supported, trying "xenial"
Fetching charm "ghost" using "stable" channel and base "amd64/ubuntu/16.04"
Install the "ghost" charm with:
    juju deploy ./ghost_808551b.charm
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1931738