### PR TITLE
[JUJU-3243] Add image-id constraint to export-bundle output

### DIFF
--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -817,6 +817,9 @@ func (b *BundleAPI) constraints(cons description.Constraints) []string {
 	if instType := cons.InstanceType(); instType != "" {
 		result = append(result, "instance-type="+instType)
 	}
+	if imageID := cons.ImageID(); imageID != "" {
+		result = append(result, "image-id="+imageID)
+	}
 	if container := cons.Container(); container != "" {
 		result = append(result, "container="+container)
 	}

--- a/core/bundle/changes/changes_test.go
+++ b/core/bundle/changes/changes_test.go
@@ -1622,7 +1622,7 @@ func (s *changesSuite) TestMachinesWithConstraintsAndAnnotations(c *gc.C) {
                     - new
         machines:
             1:
-                constraints: "cpu-cores=4"
+                constraints: "cpu-cores=4 image-id=ubuntu-bf2"
                 annotations:
                     foo: bar
         `
@@ -1668,15 +1668,15 @@ func (s *changesSuite) TestMachinesWithConstraintsAndAnnotations(c *gc.C) {
 		Id:     "addMachines-2",
 		Method: "addMachines",
 		Params: bundlechanges.AddMachineParams{
-			Constraints: "cpu-cores=4",
+			Constraints: "cpu-cores=4 image-id=ubuntu-bf2",
 		},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{
-				Constraints: "cpu-cores=4",
+				Constraints: "cpu-cores=4 image-id=ubuntu-bf2",
 			},
 		},
 		Args: map[string]interface{}{
-			"constraints": "cpu-cores=4",
+			"constraints": "cpu-cores=4 image-id=ubuntu-bf2",
 		},
 	}, {
 		Id:     "setAnnotations-3",
@@ -2803,7 +2803,7 @@ func (s *changesSuite) TestUnitPlacedToNewMachineWithConstraints(c *gc.C) {
                 num_units: 1
                 to:
                     - new
-                constraints: "cpu-cores=4"
+                constraints: "cpu-cores=4 image-id=ubuntu-bf2"
         `
 	expected := []record{{
 		Id:     "addCharm-0",
@@ -2829,14 +2829,14 @@ func (s *changesSuite) TestUnitPlacedToNewMachineWithConstraints(c *gc.C) {
 			Application: "django",
 			Series:      "jammy",
 			Channel:     "stable",
-			Constraints: "cpu-cores=4",
+			Constraints: "cpu-cores=4 image-id=ubuntu-bf2",
 		},
 		GUIArgs: []interface{}{
 			"$addCharm-0",
 			"jammy",
 			"django",
 			map[string]interface{}{},
-			"cpu-cores=4",
+			"cpu-cores=4 image-id=ubuntu-bf2",
 			map[string]string{},
 			map[string]string{},
 			map[string]int{},
@@ -2847,7 +2847,7 @@ func (s *changesSuite) TestUnitPlacedToNewMachineWithConstraints(c *gc.C) {
 			"application": "django",
 			"charm":       "$addCharm-0",
 			"channel":     "stable",
-			"constraints": "cpu-cores=4",
+			"constraints": "cpu-cores=4 image-id=ubuntu-bf2",
 			"series":      "jammy",
 		},
 		Requires: []string{"addCharm-0"},
@@ -2855,17 +2855,17 @@ func (s *changesSuite) TestUnitPlacedToNewMachineWithConstraints(c *gc.C) {
 		Id:     "addMachines-3",
 		Method: "addMachines",
 		Params: bundlechanges.AddMachineParams{
-			Constraints: "cpu-cores=4",
+			Constraints: "cpu-cores=4 image-id=ubuntu-bf2",
 			Series:      "jammy",
 		},
 		GUIArgs: []interface{}{
 			bundlechanges.AddMachineOptions{
 				Series:      "jammy",
-				Constraints: "cpu-cores=4",
+				Constraints: "cpu-cores=4 image-id=ubuntu-bf2",
 			},
 		},
 		Args: map[string]interface{}{
-			"constraints": "cpu-cores=4",
+			"constraints": "cpu-cores=4 image-id=ubuntu-bf2",
 			"series":      "jammy",
 		},
 	}, {
@@ -4030,7 +4030,7 @@ func (s *changesSuite) TestAppWithDifferentConstraints(c *gc.C) {
                         charm: ch:django
                         revision: 4
                         channel: stable
-                        constraints: cpu-cores=4 cpu-power=42
+                        constraints: cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
@@ -4053,7 +4053,7 @@ func (s *changesSuite) TestAppWithDifferentConstraints(c *gc.C) {
 		},
 	}
 	expectedChanges := []string{
-		`set constraints for django to "cpu-cores=4 cpu-power=42"`,
+		`set constraints for django to "cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2"`,
 	}
 	s.checkBundleExistingModelWithRevisionParser(c, bundleContent, existingModel, expectedChanges, func(string, series.Base, string, string, int) (string, int, error) {
 		return "stable", 4, nil
@@ -4065,10 +4065,10 @@ func (s *changesSuite) TestAppsWithArchConstraints(c *gc.C) {
                 applications:
                     django-one:
                         charm: ch:django
-                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
                     django-two:
                         charm: ch:django
-                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
             `
 	expectedChanges := []string{
 		"upload charm django from charm-hub with architecture=amd64",
@@ -4086,12 +4086,12 @@ func (s *changesSuite) TestExistingAppsWithArchConstraints(c *gc.C) {
                         charm: ch:django
                         revision: 4
                         channel: stable
-                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
                     django-two:
                         charm: ch:django
                         revision: 4
                         channel: stable
-                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
@@ -4115,7 +4115,7 @@ func (s *changesSuite) TestExistingAppsWithArchConstraints(c *gc.C) {
 		},
 	}
 	expectedChanges := []string{
-		"set constraints for django-one to \"arch=amd64 cpu-cores=4 cpu-power=42\"",
+		"set constraints for django-one to \"arch=amd64 cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2\"",
 		"upload charm django from charm-hub with revision 4 with architecture=s390x",
 		"deploy application django-two from charm-hub with stable using django",
 	}
@@ -4131,12 +4131,12 @@ func (s *changesSuite) TestExistingAppsWithoutArchConstraints(c *gc.C) {
                         charm: ch:django
                         revision: 4
                         channel: stable
-                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
                     django-two:
                         charm: ch:django
                         revision: 4
                         channel: stable
-                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
             `
 	existingModel := &bundlechanges.Model{
 		Applications: map[string]*bundlechanges.Application{
@@ -4161,7 +4161,7 @@ func (s *changesSuite) TestExistingAppsWithoutArchConstraints(c *gc.C) {
 	}
 	expectedChanges := []string{
 		"upload charm django from charm-hub with revision 4 with architecture=amd64",
-		"set constraints for django-one to \"arch=amd64 cpu-cores=4 cpu-power=42\"",
+		"set constraints for django-one to \"arch=amd64 cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2\"",
 		"upload charm django from charm-hub with revision 4 with architecture=s390x",
 		"deploy application django-two from charm-hub with stable using django",
 	}
@@ -4175,15 +4175,15 @@ func (s *changesSuite) TestAppsWithSeriesAndArchConstraints(c *gc.C) {
                 applications:
                     django-one:
                         charm: ch:django
-                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
                         series: bionic
                     django-two:
                         charm: ch:django
-                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
                         series: bionic
                     django-three:
                         charm: ch:django
-                        constraints: arch=s390x cpu-cores=4 cpu-power=42
+                        constraints: arch=s390x cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
                         series: focal
             `
 	expectedChanges := []string{
@@ -4202,7 +4202,7 @@ func (s *changesSuite) TestAppWithArchConstraints(c *gc.C) {
                 applications:
                     django:
                         charm: ch:django
-                        constraints: arch=amd64 cpu-cores=4 cpu-power=42
+                        constraints: arch=amd64 cpu-cores=4 cpu-power=42 image-id=ubuntu-bf2
             `
 	expectedChanges := []string{
 		"upload charm django from charm-hub with architecture=amd64",

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/juju/clock v1.0.3
 	github.com/juju/cmd/v3 v3.0.5
 	github.com/juju/collections v1.0.2
-	github.com/juju/description/v4 v4.0.6
+	github.com/juju/description/v4 v4.0.8
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/mittwald/vaultgo v0.1.1
 	github.com/oracle/oci-go-sdk/v47 v47.1.0
 	github.com/packethost/packngo v0.28.1
+	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
@@ -245,7 +246,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.2 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -796,6 +796,8 @@ github.com/juju/collections v1.0.2 h1:y9t99Nq/uUZksJgWehiWxIr2vB1UG3hUT7LBNy1xiH
 github.com/juju/collections v1.0.2/go.mod h1:kYJowQZYtHDvYDfZOvgf3Mt7mjKYwm/k1nqnJoMYOUc=
 github.com/juju/description/v4 v4.0.6 h1:fYzSD2eXZHII0VJGRHFtQY8Idaa/VvEkLEWNgsBYzqI=
 github.com/juju/description/v4 v4.0.6/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
+github.com/juju/description/v4 v4.0.8 h1:aGHXVW68CyWia5q6c83qv5f1UX6s+I+HW0L4UAB0jfo=
+github.com/juju/description/v4 v4.0.8/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/go.sum
+++ b/go.sum
@@ -794,8 +794,6 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.2 h1:y9t99Nq/uUZksJgWehiWxIr2vB1UG3hUT7LBNy1xiH8=
 github.com/juju/collections v1.0.2/go.mod h1:kYJowQZYtHDvYDfZOvgf3Mt7mjKYwm/k1nqnJoMYOUc=
-github.com/juju/description/v4 v4.0.6 h1:fYzSD2eXZHII0VJGRHFtQY8Idaa/VvEkLEWNgsBYzqI=
-github.com/juju/description/v4 v4.0.6/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/description/v4 v4.0.8 h1:aGHXVW68CyWia5q6c83qv5f1UX6s+I+HW0L4UAB0jfo=
 github.com/juju/description/v4 v4.0.8/go.mod h1:LRv+oC6zWwK+MpIEC3TCzRXjw5d75WK1HjcvNTWP+e8=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -2366,6 +2366,7 @@ func (e *exporter) constraintsArgs(globalKey string) (description.ConstraintsArg
 		Container:        optionalString("container"),
 		CpuCores:         optionalInt("cpucores"),
 		CpuPower:         optionalInt("cpupower"),
+		ImageID:          optionalString("imageid"),
 		InstanceType:     optionalString("instancetype"),
 		Memory:           optionalInt("mem"),
 		RootDisk:         optionalInt("rootdisk"),


### PR DESCRIPTION
Description dependency has been bumped to v4.0.8 to include the new image-id constraint.

Also some tests have been added to validate correct merge of the bundle and overlay bundle constraints.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

The best way to validate the correct bundle usage with the new constraint is by applying the 3 scenarios (under How to merge constraints of base and overlay bundles) in: https://docs.google.com/document/d/1fje2N-xn21eE0Mr-immQh5kqwbwBuqp71N8r1gc1-hQ

