### PR TITLE
[JUJU-3301] Add lunar support and also newer bases

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -203,8 +203,6 @@ func (mm *MachineManagerAPI) AddMachines(args params.AddMachines) (params.AddMac
 	return results, nil
 }
 
-var supportedJujuSeries = coreseries.WorkloadSeries
-
 func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Machine, error) {
 	if p.ParentId != "" && p.ContainerType == "" {
 		return nil, fmt.Errorf("parent machine specified without container type")
@@ -249,18 +247,6 @@ func (mm *MachineManagerAPI) addOneMachine(p params.AddMachineParams) (*state.Ma
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-	}
-	// TODO(wallyworld) - I think we can remove this check
-	series, err := coreseries.GetSeriesFromBase(base)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	supportedSeries, err := supportedJujuSeries(time.Now(), series, "")
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if !supportedSeries.Contains(series) {
-		return nil, errors.NotSupportedf("series %q", series)
 	}
 
 	var placementDirective string

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -166,46 +166,6 @@ func (s *AddMachineManagerSuite) TestAddMachines(c *gc.C) {
 	c.Assert(machines.Machines, gc.HasLen, 2)
 }
 
-func (s *AddMachineManagerSuite) TestAddMachinesUnSupportedSeries(c *gc.C) {
-	defer s.setup(c).Finish()
-
-	apiParams := make([]params.AddMachineParams, 2)
-	for i := range apiParams {
-		apiParams[i] = params.AddMachineParams{
-			Jobs: []model.MachineJob{model.JobHostUnits},
-		}
-	}
-	apiParams[0].Base = &params.Base{Name: "ubuntu", Channel: "22.04"}
-	apiParams[1].Base = &params.Base{Name: "ubuntu", Channel: "18.04"}
-	apiParams[0].Disks = []storage.Constraints{{Size: 1, Count: 2}, {Size: 2, Count: 1}}
-	apiParams[1].Disks = []storage.Constraints{{Size: 1, Count: 2, Pool: "three"}}
-
-	s.st.EXPECT().AddOneMachine(state.MachineTemplate{
-		Base: state.UbuntuBase("22.04"),
-		Jobs: []state.MachineJob{state.JobHostUnits},
-		Volumes: []state.HostVolumeParams{
-			{
-				Volume:     state.VolumeParams{Pool: "", Size: 1},
-				Attachment: state.VolumeAttachmentParams{ReadOnly: false},
-			},
-			{
-				Volume:     state.VolumeParams{Pool: "", Size: 1},
-				Attachment: state.VolumeAttachmentParams{ReadOnly: false},
-			},
-			{
-				Volume:     state.VolumeParams{Pool: "", Size: 2},
-				Attachment: state.VolumeAttachmentParams{ReadOnly: false},
-			},
-		},
-	}).Return(&state.Machine{}, nil)
-
-	machines, err := s.api.AddMachines(params.AddMachines{MachineParams: apiParams})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machines.Machines, gc.HasLen, 2)
-	c.Assert(machines.Machines[0].Error, gc.IsNil)
-	c.Assert(machines.Machines[1].Error, gc.ErrorMatches, `series "bionic" not supported`)
-}
-
 func (s *AddMachineManagerSuite) TestAddMachinesStateError(c *gc.C) {
 	defer s.setup(c).Finish()
 

--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -65,6 +65,7 @@ var ubuntuVersions = []string{
 	"21.04",
 	"21.10",
 	"22.10",
+	"23.04",
 }
 
 var controllerCfg = controller.Config{

--- a/core/series/supported.go
+++ b/core/series/supported.go
@@ -272,6 +272,7 @@ const (
 	Impish  SeriesName = "impish"
 	Jammy   SeriesName = "jammy"
 	Kinetic SeriesName = "kinetic"
+	Lunar   SeriesName = "lunar"
 )
 
 var ubuntuSeries = map[SeriesName]seriesVersion{
@@ -371,6 +372,10 @@ var ubuntuSeries = map[SeriesName]seriesVersion{
 	Kinetic: {
 		WorkloadType: ControllerWorkloadType,
 		Version:      "22.10",
+	},
+	Lunar: {
+		WorkloadType: ControllerWorkloadType,
+		Version:      "23.04",
 	},
 }
 

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -269,16 +269,20 @@ func (s *SupportedSeriesSuite) TestUbuntuVersions(c *gc.C) {
 			WorkloadType: ControllerWorkloadType,
 			Version:      "22.10",
 		},
+		Lunar: {
+			WorkloadType: ControllerWorkloadType,
+			Version:      "23.04",
+		},
 	}
 
 	result := ubuntuVersions(nil, nil, ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "focal": "20.04", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "jammy": "22.04", "kinetic": "22.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "focal": "20.04", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "jammy": "22.04", "kinetic": "22.10", "lunar": "23.04", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
 
 	result = ubuntuVersions(boolPtr(true), boolPtr(true), ubuntuSeries)
 	c.Check(result, gc.DeepEquals, map[string]string{"focal": "20.04", "jammy": "22.04"})
 
 	result = ubuntuVersions(boolPtr(false), boolPtr(false), ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "yakkety": "16.10", "zesty": "17.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "lunar": "23.04", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "yakkety": "16.10", "zesty": "17.04"})
 
 	result = ubuntuVersions(boolPtr(true), boolPtr(false), ubuntuSeries)
 	c.Check(result, gc.DeepEquals, map[string]string{})
@@ -290,13 +294,13 @@ func (s *SupportedSeriesSuite) TestUbuntuVersions(c *gc.C) {
 	c.Check(result, gc.DeepEquals, map[string]string{"focal": "20.04", "jammy": "22.04"})
 
 	result = ubuntuVersions(boolPtr(false), nil, ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "bionic": "18.04", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "lunar": "23.04", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "trusty": "14.04", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "xenial": "16.04", "yakkety": "16.10", "zesty": "17.04"})
 
 	result = ubuntuVersions(nil, boolPtr(true), ubuntuSeries)
 	c.Check(result, gc.DeepEquals, map[string]string{"bionic": "18.04", "focal": "20.04", "jammy": "22.04", "trusty": "14.04", "xenial": "16.04"})
 
 	result = ubuntuVersions(nil, boolPtr(false), ubuntuSeries)
-	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "yakkety": "16.10", "zesty": "17.04"})
+	c.Check(result, gc.DeepEquals, map[string]string{"artful": "17.10", "cosmic": "18.10", "disco": "19.04", "eoan": "19.10", "groovy": "20.10", "hirsute": "21.04", "impish": "21.10", "kinetic": "22.10", "lunar": "23.04", "precise": "12.04", "quantal": "12.10", "raring": "13.04", "saucy": "13.10", "utopic": "14.10", "vivid": "15.04", "wily": "15.10", "yakkety": "16.10", "zesty": "17.04"})
 }
 
 func makeTempFile(c *gc.C, content string) (*os.File, func()) {

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -47,6 +47,7 @@ var ubuntuVersions = []string{
 	"21.04",
 	"21.10",
 	"22.10",
+	"23.04",
 }
 
 func makeBases(os string, vers []string) []state.Base {


### PR DESCRIPTION
If distroinfo is out of date, juju cannot deploy lunar machines.
Add lunar as a fallback.

When adding a machine, there was a check to see if a specified base is supported, but no --force override. So even using --base where we specify os and version directly, it was not possible to add a lunar or even kinetic machine, since the hard coded fallbacks did not have kinetic as a supported series. The check is removed - we still validate base when adding a charm so it's not needed for add-machine really.

## QA steps

juju bootstrap blah --bootstrap-base=ubuntu@23.04 --force
juju add-machine --base=ubuntu@23.04
juju add-machine --series=lunar


## Bug reference

https://bugs.launchpad.net/juju/+bug/2011469
