### PR TITLE
[JUJU-3302] Add option al support for getting secret backend config info fron a 3.2 controller

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -107,7 +107,7 @@ var facadeVersions = map[string]int{
 	"SecretBackendsManager":        1,
 	"SecretBackendsRotateWatcher":  1,
 	"Secrets":                      1,
-	"SecretsManager":               1,
+	"SecretsManager":               2,
 	"Singular":                     2,
 	"Spaces":                       6,
 	"SSHClient":                    4,

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -55,12 +55,12 @@ func (s *SecretsManagerAPI) GetSecretStoreConfig() (params.SecretBackendConfig, 
 }
 
 // GetSecretBackendConfig gets the config needed to create a client to secret backends.
-func (s *SecretsManagerAPI) GetSecretBackendConfig() (params.SecretBackendConfigResults, error) {
+func (s *SecretsManagerAPI) GetSecretBackendConfig() (params.SecretBackendConfigResultsV1, error) {
 	cfgInfo, err := s.backendConfigGetter()
 	if err != nil {
-		return params.SecretBackendConfigResults{}, errors.Trace(err)
+		return params.SecretBackendConfigResultsV1{}, errors.Trace(err)
 	}
-	result := params.SecretBackendConfigResults{
+	result := params.SecretBackendConfigResultsV1{
 		ControllerUUID: cfgInfo.ControllerUUID,
 		ModelUUID:      cfgInfo.ModelUUID,
 		ModelName:      cfgInfo.ModelName,

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -142,7 +142,7 @@ func (s *SecretsManagerSuite) TestGetSecretBackendConfig(c *gc.C) {
 
 	result, err := s.facade.GetSecretBackendConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, jc.DeepEquals, params.SecretBackendConfigResults{
+	c.Assert(result, jc.DeepEquals, params.SecretBackendConfigResultsV1{
 		ControllerUUID: coretesting.ControllerTag.Id(),
 		ModelUUID:      coretesting.ModelTag.Id(),
 		ModelName:      "fred",

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39374,7 +39374,7 @@
                     "type": "object",
                     "properties": {
                         "Result": {
-                            "$ref": "#/definitions/SecretBackendConfigResults"
+                            "$ref": "#/definitions/SecretBackendConfigResultsV1"
                         }
                     },
                     "description": "GetSecretBackendConfig gets the config needed to create a client to secret backends."
@@ -39905,7 +39905,7 @@
                         "type"
                     ]
                 },
-                "SecretBackendConfigResults": {
+                "SecretBackendConfigResultsV1": {
                     "type": "object",
                     "properties": {
                         "active-id": {
@@ -45135,7 +45135,7 @@
                     "type": "object",
                     "properties": {
                         "Result": {
-                            "$ref": "#/definitions/SecretBackendConfigResults"
+                            "$ref": "#/definitions/SecretBackendConfigResultsV1"
                         }
                     },
                     "description": "GetSecretBackendConfig gets the config needed to create a client to secret backends."
@@ -48135,7 +48135,7 @@
                         "type"
                     ]
                 },
-                "SecretBackendConfigResults": {
+                "SecretBackendConfigResultsV1": {
                     "type": "object",
                     "properties": {
                         "active-id": {

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -9,14 +9,36 @@ import (
 	"github.com/juju/juju/core/secrets"
 )
 
-// SecretBackendConfigResults holds config info for creating
+// SecretBackendConfigResultsV1 holds config info for creating
 // secret backend clients for a specific model.
-type SecretBackendConfigResults struct {
+type SecretBackendConfigResultsV1 struct {
 	ControllerUUID string                         `json:"model-controller"`
 	ModelUUID      string                         `json:"model-uuid"`
 	ModelName      string                         `json:"model-name"`
 	ActiveID       string                         `json:"active-id"`
 	Configs        map[string]SecretBackendConfig `json:"configs,omitempty"`
+}
+
+// SecretBackendArgs holds args for querying secret backends.
+type SecretBackendArgs struct {
+	BackendIDs []string `json:"backend-ids"`
+}
+
+// SecretBackendConfigResults holds config info for creating
+// secret backend clients for a specific model.
+type SecretBackendConfigResults struct {
+	ActiveID string                               `json:"active-id"`
+	Results  map[string]SecretBackendConfigResult `json:"results,omitempty"`
+}
+
+// SecretBackendConfigResult holds config info for creating
+// secret backend clients for a specific model.
+type SecretBackendConfigResult struct {
+	ControllerUUID string              `json:"model-controller"`
+	ModelUUID      string              `json:"model-uuid"`
+	ModelName      string              `json:"model-name"`
+	Draining       bool                `json:"draining"`
+	Config         SecretBackendConfig `json:"config,omitempty"`
 }
 
 // SecretBackendConfig holds config for creating a secret backend client.


### PR DESCRIPTION
Add support for using the v2 secrets manager facade to get backend config info from a 3.2 controller.
This allows a 3.1 model to operate on a 3.2 controller and take advantage of the newer api if available.

## QA steps

bootstrap 
add a model
add vault backend
deploy a charm and add a secret
get the secret value
migrate model to a 3.2 controller
get the secret value
