### PR TITLE
[JUJU-3302] Add support for juju 3.1 secret backend facade methods

### DIFF
--- a/api/agent/secretsmanager/client.go
+++ b/api/agent/secretsmanager/client.go
@@ -40,7 +40,7 @@ func (c *Client) GetSecretBackendConfig(backendID *string) (*provider.ModelBacke
 	if backendID != nil {
 		args.BackendIDs = []string{*backendID}
 	}
-	err := c.facade.FacadeCall("GetSecretBackendConfig", args, &results)
+	err := c.facade.FacadeCall("GetSecretBackendConfigs", args, &results)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)
 	}

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -42,7 +42,7 @@ func (s *SecretsSuite) TestGetSecretBackendConfig(c *gc.C) {
 		c.Check(objType, gc.Equals, "SecretsManager")
 		c.Check(version, gc.Equals, 0)
 		c.Check(id, gc.Equals, "")
-		c.Check(request, gc.Equals, "GetSecretBackendConfig")
+		c.Check(request, gc.Equals, "GetSecretBackendConfigs")
 		c.Check(arg, jc.DeepEquals, params.SecretBackendArgs{
 			BackendIDs: []string{"active-id"},
 		})

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -108,7 +108,7 @@ var facadeVersions = map[string]int{
 	"SecretBackendsRotateWatcher":  1,
 	"SecretsRevisionWatcher":       1,
 	"Secrets":                      1,
-	"SecretsManager":               1,
+	"SecretsManager":               2,
 	"Singular":                     2,
 	"Spaces":                       6,
 	"SSHClient":                    4,

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -225,7 +225,7 @@ func (s *secretsSuite) assertBackendConfigInfoLeaderUnit(c *gc.C, wanted []strin
 		p.EXPECT().RestrictedConfig(&adminCfg, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil),
 	)
 
-	info, err := secrets.BackendConfigInfo(model, wanted, unitTag, leadershipChecker)
+	info, err := secrets.BackendConfigInfo(model, wanted, false, unitTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
 		ActiveID: "backend-id",
@@ -335,7 +335,7 @@ func (s *secretsSuite) TestBackendConfigInfoNonLeaderUnit(c *gc.C) {
 		p.EXPECT().RestrictedConfig(&adminCfg, unitTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil),
 	)
 
-	info, err := secrets.BackendConfigInfo(model, []string{"backend-id"}, unitTag, leadershipChecker)
+	info, err := secrets.BackendConfigInfo(model, []string{"backend-id"}, false, unitTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
 		ActiveID: "backend-id",
@@ -424,7 +424,7 @@ func (s *secretsSuite) TestBackendConfigInfoAppTagLogin(c *gc.C) {
 		p.EXPECT().RestrictedConfig(&adminCfg, appTag, ownedRevs, readRevs).Return(&adminCfg.BackendConfig, nil),
 	)
 
-	info, err := secrets.BackendConfigInfo(model, []string{"backend-id"}, appTag, leadershipChecker)
+	info, err := secrets.BackendConfigInfo(model, []string{"backend-id"}, false, appTag, leadershipChecker)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &provider.ModelBackendConfigInfo{
 		ActiveID: "backend-id",
@@ -475,6 +475,6 @@ func (s *secretsSuite) TestBackendConfigInfoFailedInvalidAuthTag(c *gc.C) {
 		p.EXPECT().Initialise(gomock.Any()).Return(nil),
 	)
 
-	_, err := secrets.BackendConfigInfo(model, []string{"some-id"}, badTag, leadershipChecker)
+	_, err := secrets.BackendConfigInfo(model, []string{"some-id"}, false, badTag, leadershipChecker)
 	c.Assert(err, gc.ErrorMatches, `login as "user-foo" not supported`)
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -82,7 +82,11 @@ func (s *SecretsManagerSuite) setup(c *gc.C) *gomock.Controller {
 
 	s.clock = testclock.NewClock(time.Now())
 
-	backendConfigGetter := func(backendIds []string) (*provider.ModelBackendConfigInfo, error) {
+	backendConfigGetter := func(backendIds []string, wantAll bool) (*provider.ModelBackendConfigInfo, error) {
+		// wantAll is for 3.1 compatibility only.
+		if wantAll {
+			return nil, errors.NotSupportedf("wantAll")
+		}
 		return &provider.ModelBackendConfigInfo{
 			ActiveID: "backend-id",
 			Configs: map[string]provider.ModelBackendConfig{
@@ -153,10 +157,10 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-func (s *SecretsManagerSuite) TestGetSecretBackendConfig(c *gc.C) {
+func (s *SecretsManagerSuite) TestGetSecretBackendConfigs(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	result, err := s.facade.GetSecretBackendConfig(params.SecretBackendArgs{
+	result, err := s.facade.GetSecretBackendConfigs(params.SecretBackendArgs{
 		BackendIDs: []string{"backend-id"},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39875,7 +39875,7 @@
     {
         "Name": "SecretsManager",
         "Description": "SecretsManagerAPI is the implementation for the SecretsManager facade.",
-        "Version": 1,
+        "Version": 2,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -39921,7 +39921,7 @@
                     },
                     "description": "GetConsumerSecretsRevisionInfo returns the latest secret revisions for the specified secrets."
                 },
-                "GetSecretBackendConfig": {
+                "GetSecretBackendConfigs": {
                     "type": "object",
                     "properties": {
                         "Params": {
@@ -39931,7 +39931,7 @@
                             "$ref": "#/definitions/SecretBackendConfigResults"
                         }
                     },
-                    "description": "GetSecretBackendConfig gets the config needed to create a client to secret backends."
+                    "description": "GetSecretBackendConfigs gets the config needed to create a client to secret backends."
                 },
                 "GetSecretContentInfo": {
                     "type": "object",
@@ -45806,7 +45806,7 @@
                     },
                     "description": "GetRawK8sSpec gets the raw k8s specs for a set of applications."
                 },
-                "GetSecretBackendConfig": {
+                "GetSecretBackendConfigs": {
                     "type": "object",
                     "properties": {
                         "Params": {
@@ -45816,7 +45816,7 @@
                             "$ref": "#/definitions/SecretBackendConfigResults"
                         }
                     },
-                    "description": "GetSecretBackendConfig gets the config needed to create a client to secret backends."
+                    "description": "GetSecretBackendConfigs gets the config needed to create a client to secret backends."
                 },
                 "GetSecretContentInfo": {
                     "type": "object",

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -12,6 +12,16 @@ import (
 	"github.com/juju/juju/core/secrets"
 )
 
+// SecretBackendConfigResultsV1 holds config info for creating
+// secret backend clients for a specific model.
+type SecretBackendConfigResultsV1 struct {
+	ControllerUUID string                         `json:"model-controller"`
+	ModelUUID      string                         `json:"model-uuid"`
+	ModelName      string                         `json:"model-name"`
+	ActiveID       string                         `json:"active-id"`
+	Configs        map[string]SecretBackendConfig `json:"configs,omitempty"`
+}
+
 // SecretBackendArgs holds args for querying secret backends.
 type SecretBackendArgs struct {
 	BackendIDs []string `json:"backend-ids"`


### PR DESCRIPTION
Juju 3.1 models can be migrated to a 3.2 controller. So we need to support 2 secret backend config methods that are used in 3.1 but removed in 3.2. This PR adds back the missing methods, and renames the 3.2 version of the method to disambiguate it.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

bootstrap 3.1 controller
add a model
add vault backend
deploy a charm and add a secret
get the secret value
migrate model to a 3.2 controller
get the secret value
