### PR TITLE
[JUJU-3300] Fix docker build with new buildx that produces an incompatible image.

### DIFF
--- a/make_functions.sh
+++ b/make_functions.sh
@@ -123,11 +123,12 @@ build_push_operator_image() {
     WORKDIR=$(_make_docker_staging_dir)
     cp "${PROJECT_DIR}/caas/Dockerfile" "${WORKDIR}/"
     cp "${PROJECT_DIR}/caas/requirements.txt" "${WORKDIR}/"
-    DOCKER_BUILDKIT=1 "$DOCKER_BIN" buildx build \
+    BUILDX_NO_DEFAULT_ATTESTATIONS=true DOCKER_BUILDKIT=1 "$DOCKER_BIN" buildx build \
         --builder "$DOCKER_BUILDX_CONTEXT" \
         -f "${WORKDIR}/Dockerfile" \
         -t "$(operator_image_path)" \
         --platform="$build_multi_osarch" \
+        --provenance=false \
         ${output} \
         "${BUILD_DIR}"
 }


### PR DESCRIPTION
Docker buildx now supports sboms and provenance, which is fantastic, unfortunately our upgrade logic that connects to the registry to determine which versions and architectures are supported for an upgrade, does not support the new manifest format.

## QA steps

Upload to a registry and check you can upgrade-controller.

## Documentation changes

N/A

## Bug reference

https://bugs.launchpad.net/juju/+bug/2011631