### PR TITLE
[JUJU-3245] Use image-id constraint on MAAS provider

### DIFF
--- a/provider/maas/environ.go
+++ b/provider/maas/environ.go
@@ -779,27 +779,29 @@ func (env *maasEnviron) StartInstance(
 	}
 	logger.Debugf("maas user data; %d bytes", len(userdata))
 
-	series, err := coreseries.GetSeriesFromBase(args.InstanceConfig.Base)
+	distroSeries, err := env.distroSeries(args)
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
 	}
-	var displayName string
-	var interfaces corenetwork.InterfaceInfos
-	err = inst.machine.Start(gomaasapi.StartArgs{DistroSeries: series, UserData: string(userdata)})
+	err = inst.machine.Start(gomaasapi.StartArgs{
+		DistroSeries: distroSeries,
+		UserData:     string(userdata),
+	})
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
 	}
+
 	domains, err := env.Domains(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	interfaces, err = maasNetworkInterfaces(ctx, inst, subnetsMap, domains...)
+	interfaces, err := maasNetworkInterfaces(ctx, inst, subnetsMap, domains...)
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
 	}
 	env.tagInstance(inst, args.InstanceConfig)
 
-	displayName, err = inst.displayName()
+	displayName, err := inst.displayName()
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
 	}
@@ -838,6 +840,13 @@ func (env *maasEnviron) tagInstance(inst *maasInstance, instanceConfig *instance
 	if err != nil {
 		logger.Errorf("could not set owner data for instance: %v", err)
 	}
+}
+
+func (env *maasEnviron) distroSeries(args environs.StartInstanceParams) (string, error) {
+	if args.Constraints.ImageID != nil && *args.Constraints.ImageID != "" {
+		return *args.Constraints.ImageID, nil
+	}
+	return coreseries.GetSeriesFromBase(args.InstanceConfig.Base)
 }
 
 func (env *maasEnviron) waitForNodeDeployment(ctx context.ProviderCallContext, id instance.Id, timeout time.Duration) error {

--- a/provider/maas/maas_environ_whitebox_test.go
+++ b/provider/maas/maas_environ_whitebox_test.go
@@ -2437,7 +2437,15 @@ func (suite *maasEnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	node1.zoneName = "test_zone"
 	controller.allocateMachine = node1
 
-	instance, hc := jujutesting.AssertStartInstance(c, env, suite.callCtx, suite.controllerUUID, "1")
+	instance, hc := jujutesting.AssertStartInstanceWithConstraints(
+		c,
+		env,
+		suite.callCtx,
+		suite.controllerUUID,
+		"1",
+		constraints.Value{
+			ImageID: stringp("ubuntu-bf2"),
+		})
 	c.Check(instance, gc.NotNil)
 	c.Assert(hc, gc.NotNil)
 	c.Check(hc.String(), gc.Equals, fmt.Sprintf("arch=%s cores=1 mem=1024M availability-zone=test_zone", arch.HostArch()))
@@ -2445,6 +2453,8 @@ func (suite *maasEnvironSuite) TestStartInstanceEndToEnd(c *gc.C) {
 	node1.Stub.CheckCallNames(c, "Start", "SetOwnerData")
 	startArgs, ok := node1.Stub.Calls()[0].Args[0].(gomaasapi.StartArgs)
 	c.Assert(ok, jc.IsTrue)
+
+	c.Assert(startArgs.DistroSeries, gc.Equals, "ubuntu-bf2")
 
 	decodedUserData, err := decodeUserData(startArgs.UserData)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
In order to complete the custom image support for MAAS clouds, we now implement its usage in the MAAS provider, therefore when present, the image-id constraint will be used in the `distro_series` parameter for MAAS machine start.
The `distro_seres` parameter defaulted to the base passed through config (`coreseries.GetSeriesFromBase(args.InstanceConfig.Base)`).

Note that there is no check or validation for the `image-id` constraint, this means that if we provide an `image-id` that doesn't match an existing image on MAAS, the machine deployment will fail with a MAAS error:
```sh
controller-0: 18:14:46 ERROR juju.worker.provisioner cannot start instance for machine "1": unexpected: ServerError: 400 Bad Request ({"distro_series": ["'ubuntu-bf1' is not a valid distro_series.  It should be one of: '', 'custom/ubuntu-bf2', 'ubuntu/focal', 'ubuntu/jammy'."]})
```

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This must be tested against a MAAS cloud.

1) We must create a custom maas image, we don't care if the image doesn't actually boot, we simply need that it's listed by MAAS and that we can try to deploy a machine using this image. For this end, a `boot-resource` can be created with a fake image (here I simply use any tgz, that is not correct and won't boot):
```sh
maas admin boot-resources create name='ubuntu-bf2' title='Custom Jammy' architecture='amd64/generic' filetype='tgz' content@=/home/nicolas/tmp/foo.tgz
```
2) Once we validate the image (boot-resource) is listed in MAAS, we can try to `add-machine` with juju passing the `image-id` constraint (the local maas cloud bootstrapping steps are avoided here, you can follow https://juju.is/docs/olm/maas):
```sh
juju add-machine --constraints="image-id=ubuntu-bf2"
```
3) You should see that the machine is being deployed:
```sh
Machine  State    Address     Inst id      Base          AZ       Message
3        pending  10.10.10.4  awake-chimp  ubuntu@22.04  default  Deploying: Powering on
```
and that MAAS gui shows that the machine being deployed tries to deploy `Custom Jammy` which is the title we gave to the uploaded custom image:


![maas-custom](https://user-images.githubusercontent.com/24507367/225892206-918182ad-ce52-452f-8008-3155e88b59dd.png)
