### PR TITLE
[JUJU-2178] Moves local resource validation code into a separate file and export

### DIFF
--- a/cmd/juju/application/utils/utils.go
+++ b/cmd/juju/application/utils/utils.go
@@ -395,3 +395,14 @@ func settingsFromYaml(ctx *cmd.Context, configOptions configFlag, appName string
 	}
 	return settings, nil
 }
+
+func CheckFile(name, path string, fs modelcmd.Filesystem) error {
+	_, err := fs.Stat(path)
+	if os.IsNotExist(err) {
+		return errors.Annotatef(err, "file for resource %q", name)
+	}
+	if err != nil {
+		return errors.Annotatef(err, "can't read file for resource %q", name)
+	}
+	return nil
+}

--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -4,11 +4,13 @@
 package resource
 
 import (
+	"io"
+
 	charmresource "github.com/juju/charm/v10/resource"
 	"github.com/juju/errors"
+
 	apiresources "github.com/juju/juju/api/client/resources"
 	"github.com/juju/juju/cmd/modelcmd"
-	"io"
 )
 
 // DeployClient exposes the functionality of the resources API needed

--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -4,21 +4,11 @@
 package resource
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"strings"
-
 	charmresource "github.com/juju/charm/v10/resource"
 	"github.com/juju/errors"
-	"gopkg.in/yaml.v2"
-
 	apiresources "github.com/juju/juju/api/client/resources"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/resources"
+	"io"
 )
 
 // DeployClient exposes the functionality of the resources API needed
@@ -77,8 +67,6 @@ func DeployResources(args DeployResourcesArgs) (ids map[string]string, err error
 	return ids, nil
 }
 
-type osOpenFunc func(path string) (modelcmd.ReadSeekCloser, error)
-
 type deployUploader struct {
 	applicationID string
 	chID          apiresources.CharmID
@@ -88,15 +76,15 @@ type deployUploader struct {
 }
 
 func (d deployUploader) upload(resourceValues map[string]string, revisions map[string]int) (map[string]string, error) {
-	if err := d.validateResources(); err != nil {
+	if err := ValidateResources(d.resources); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	if err := d.checkExpectedResources(resourceValues, revisions); err != nil {
+	if err := CheckExpectedResources(resourceValues, revisions, d.resources); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	if err := d.validateResourceDetails(resourceValues); err != nil {
+	if err := ValidateResourceDetails(resourceValues, d.resources, d.filesystem); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -127,61 +115,6 @@ func (d deployUploader) upload(resourceValues map[string]string, revisions map[s
 	}
 
 	return pending, nil
-}
-
-func (d deployUploader) validateResourceDetails(res map[string]string) error {
-	for name, value := range res {
-		var err error
-		switch d.resources[name].Type {
-		case charmresource.TypeFile:
-			err = d.checkFile(name, value)
-		case charmresource.TypeContainerImage:
-			var dockerDetails resources.DockerImageDetails
-			dockerDetails, err = getDockerDetailsData(value, d.filesystem.Open)
-			if err != nil {
-				return errors.Annotatef(err, "resource %q", name)
-			}
-			// At the moment this is the same validation that occurs in getDockerDetailsData
-			err = resources.CheckDockerDetails(name, dockerDetails)
-		default:
-			return fmt.Errorf("unknown resource: %s", name)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (d deployUploader) checkFile(name, path string) error {
-	_, err := d.filesystem.Stat(path)
-	if os.IsNotExist(err) {
-		return errors.Annotatef(err, "file for resource %q", name)
-	}
-	if err != nil {
-		return errors.Annotatef(err, "can't read file for resource %q", name)
-	}
-	return nil
-}
-
-func (d deployUploader) validateResources() error {
-	var errs []error
-	for _, meta := range d.resources {
-		if err := meta.Validate(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if len(errs) == 1 {
-		return errors.Trace(errs[0])
-	}
-	if len(errs) > 1 {
-		msgs := make([]string, len(errs))
-		for i, err := range errs {
-			msgs[i] = err.Error()
-		}
-		return errors.NewNotValid(nil, strings.Join(msgs, ", "))
-	}
-	return nil
 }
 
 // storeResources returns which resources revisions will need to be retrieved
@@ -217,102 +150,4 @@ func (d deployUploader) uploadPendingResource(resourcename, resourcevalue string
 	}
 
 	return d.client.UploadPendingResource(d.applicationID, res, resourcevalue, data)
-}
-
-func (d deployUploader) checkExpectedResources(filenames map[string]string, revisions map[string]int) error {
-	var unknown []string
-	for name := range filenames {
-		if _, ok := d.resources[name]; !ok {
-			unknown = append(unknown, name)
-		}
-	}
-	for name := range revisions {
-		if _, ok := d.resources[name]; !ok {
-			unknown = append(unknown, name)
-		}
-	}
-	if len(unknown) == 1 {
-		return errors.Errorf("unrecognized resource %q", unknown[0])
-	}
-	if len(unknown) > 1 {
-		return errors.Errorf("unrecognized resources: %s", strings.Join(unknown, ", "))
-	}
-	return nil
-}
-
-// getDockerDetailsData determines if path is a local file path and extracts the
-// details from that otherwise path is considered to be a registry path.
-func getDockerDetailsData(path string, osOpen osOpenFunc) (resources.DockerImageDetails, error) {
-	f, err := osOpen(path)
-	if err == nil {
-		defer f.Close()
-		details, err := unMarshalDockerDetails(f)
-		if err != nil {
-			return details, errors.Trace(err)
-		}
-		return details, nil
-	} else if err := resources.ValidateDockerRegistryPath(path); err == nil {
-		return resources.DockerImageDetails{
-			RegistryPath: path,
-		}, nil
-	}
-	return resources.DockerImageDetails{}, errors.NotValidf("filepath or registry path: %s", path)
-
-}
-
-func unMarshalDockerDetails(data io.Reader) (resources.DockerImageDetails, error) {
-	var details resources.DockerImageDetails
-	contents, err := io.ReadAll(data)
-	if err != nil {
-		return details, errors.Trace(err)
-	}
-
-	if errJ := json.Unmarshal(contents, &details); errJ != nil {
-		if errY := yaml.Unmarshal(contents, &details); errY != nil {
-			contentType := http.DetectContentType(contents)
-			if strings.Contains(contentType, "text/plain") {
-				// Check first character - `{` means probably JSON
-				if strings.TrimSpace(string(contents))[0] == '{' {
-					return details, errors.Annotate(errJ, "json parsing")
-				}
-				return details, errY
-			}
-			return details, errors.New("expected json or yaml file containing oci-image registry details")
-		}
-	}
-	if err := resources.ValidateDockerRegistryPath(details.RegistryPath); err != nil {
-		return resources.DockerImageDetails{}, err
-	}
-	return details, nil
-}
-
-func OpenResource(resValue string, resType charmresource.Type, osOpen osOpenFunc) (modelcmd.ReadSeekCloser, error) {
-	switch resType {
-	case charmresource.TypeFile:
-		f, err := osOpen(resValue)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		return f, nil
-	case charmresource.TypeContainerImage:
-		dockerDetails, err := getDockerDetailsData(resValue, osOpen)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		data, err := yaml.Marshal(dockerDetails)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		return noopCloser{bytes.NewReader(data)}, nil
-	default:
-		return nil, errors.Errorf("unknown resource type %q", resType)
-	}
-}
-
-type noopCloser struct {
-	io.ReadSeeker
-}
-
-func (noopCloser) Close() error {
-	return nil
 }

--- a/cmd/juju/resource/validation.go
+++ b/cmd/juju/resource/validation.go
@@ -7,15 +7,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	charmresource "github.com/juju/charm/v10/resource"
-	"github.com/juju/errors"
-	"github.com/juju/juju/cmd/juju/application/utils"
-	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/resources"
-	"gopkg.in/yaml.v2"
 	"io"
 	"net/http"
 	"strings"
+
+	charmresource "github.com/juju/charm/v10/resource"
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/cmd/juju/application/utils"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/resources"
 )
 
 func ValidateResources(resources map[string]charmresource.Meta) error {

--- a/cmd/juju/resource/validation.go
+++ b/cmd/juju/resource/validation.go
@@ -20,6 +20,8 @@ import (
 	"github.com/juju/juju/core/resources"
 )
 
+// ValidateResources runs the validation checks for resource metadata
+// for each resource. Errors are consolidated and reported in a single error.
 func ValidateResources(resources map[string]charmresource.Meta) error {
 	var errs []error
 	for _, meta := range resources {
@@ -60,6 +62,9 @@ func getDockerDetailsData(path string, osOpen osOpenFunc) (resources.DockerImage
 
 }
 
+// ValidateResourceDetails validates the resource path in detail depending on if it's a local file or a container image,
+// either checks with the FS and stats the file or validate the docker registry path and makes sure the registry URL
+// resolves into a fully qualified reference.
 func ValidateResourceDetails(res map[string]string, resMeta map[string]charmresource.Meta, fs modelcmd.Filesystem) error {
 	for name, value := range res {
 		var err error
@@ -86,6 +91,7 @@ func ValidateResourceDetails(res map[string]string, resMeta map[string]charmreso
 
 type osOpenFunc func(path string) (modelcmd.ReadSeekCloser, error)
 
+// OpenResource returns a readable buffer for the given resource, which can be a local file or a docker image
 func OpenResource(resValue string, resType charmresource.Type, osOpen osOpenFunc) (modelcmd.ReadSeekCloser, error) {
 	switch resType {
 	case charmresource.TypeFile:
@@ -143,6 +149,10 @@ func unMarshalDockerDetails(data io.Reader) (resources.DockerImageDetails, error
 	return details, nil
 }
 
+// CheckExpectedResources compares the resources we expect to see (metadata) against what we see in the actual
+// deployment arguments (the filenames and revisions), and identifies the resources that we weren't expecting.
+// Note that this is different from checking if we see all the resources we expect to see, as the user can
+// attach-resource post deploy.
 func CheckExpectedResources(filenames map[string]string, revisions map[string]int, resMeta map[string]charmresource.Meta) error {
 	var unknown []string
 	for name := range filenames {

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.0+incompatible
 	github.com/dustin/go-humanize v1.0.1
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4
 	github.com/go-logr/logr v1.2.2
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1
@@ -169,7 +170,6 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell/v2 v2.5.1 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-macaroon-bakery/macaroonpb v1.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect


### PR DESCRIPTION
This was part of an attempt to validate local resources before deploy for the controller side deploy (to be able to call these from the application/deployer). The validation part didn't pan out, but this might be a nice tidy up for that validation code.

The new coming `UploadExistingPendingResources` in the client will need to call some of these functions (e.g. `OpenResource`).

There shouldn't be any changes to any functionality, therefore aside from that the CI tests should pass, only a manual code review will be required.