### PR TITLE
[JUJU-3308] Thread DB Getter through to the APIServer

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -179,6 +179,7 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 			return 0
 		},
 		SysLogger: noopSysLogger{},
+		DBGetter:  apiserver.StubDBGetter{},
 	}
 }
 

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/cache"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
@@ -35,6 +36,7 @@ type Context struct {
 	LeadershipReader_   leadership.Reader
 	SingularClaimer_    lease.Claimer
 	CharmhubHTTPClient_ facade.HTTPClient
+	ControllerDB_       coredatabase.TrackedDB
 	// Identity is not part of the facade.Context interface, but is instead
 	// used to make sure that the context objects are the same.
 	Identity string
@@ -148,4 +150,8 @@ func (context Context) HTTPClient(purpose facade.HTTPClientPurpose) facade.HTTPC
 	default:
 		return nil
 	}
+}
+
+func (context Context) ControllerDB() (coredatabase.TrackedDB, error) {
+	return context.ControllerDB_, nil
 }

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/names/v4"
 
 	"github.com/juju/juju/core/cache"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
@@ -146,6 +147,9 @@ type Context interface {
 
 	// HTTPClient returns an HTTP client to use for the given purpose.
 	HTTPClient(purpose HTTPClientPurpose) HTTPClient
+
+	// ControllerDB returns a TrackedDB reference for the controller database.
+	ControllerDB() (coredatabase.TrackedDB, error)
 }
 
 // RequestRecorder is implemented by types that can record information about

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -151,14 +151,12 @@ type Context interface {
 // RequestRecorder is implemented by types that can record information about
 // successful and unsuccessful http requests.
 type RequestRecorder interface {
-	// Record an outgoing request which produced an http.Response.
+	// Record an outgoing request that produced a http.Response.
 	Record(method string, url *url.URL, res *http.Response, rtt time.Duration)
 
-	// Record an outgoing request which returned back an error.
+	// RecordError records an outgoing request that returned back an error.
 	RecordError(method string, url *url.URL, err error)
 }
-
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/facade_mock.go github.com/juju/juju/apiserver/facade Resources,Authorizer
 
 // Authorizer represents the authenticated entity using the API server.
 type Authorizer interface {

--- a/apiserver/facade/package_test.go
+++ b/apiserver/facade/package_test.go
@@ -9,6 +9,8 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/facade_mock.go github.com/juju/juju/apiserver/facade Resources,Authorizer
+
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/core/cache"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
@@ -71,6 +72,7 @@ func (ctx *charmsSuiteContext) LeadershipPinner(string) (leadership.Pinner, erro
 func (ctx *charmsSuiteContext) LeadershipReader(string) (leadership.Reader, error)    { return nil, nil }
 func (ctx *charmsSuiteContext) SingularClaimer() (lease.Claimer, error)               { return nil, nil }
 func (ctx *charmsSuiteContext) HTTPClient(facade.HTTPClientPurpose) facade.HTTPClient { return nil }
+func (ctx *charmsSuiteContext) ControllerDB() (coredatabase.TrackedDB, error)         { return nil, nil }
 
 func (s *charmsSuite) SetUpTest(c *gc.C) {
 	s.JujuConnSuite.SetUpTest(c)

--- a/apiserver/facades/controller/caasmodelconfigmanager/facade.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/facade.go
@@ -9,8 +9,6 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
-//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/context_mock.go github.com/juju/juju/apiserver/facade Authorizer,Context,Resources
-
 // Facade allows model config manager clients to watch controller config changes and fetch controller config.
 type Facade struct {
 	auth                facade.Authorizer

--- a/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	facade "github.com/juju/juju/apiserver/facade"
 	cache "github.com/juju/juju/core/cache"
+	database "github.com/juju/juju/core/database"
 	leadership "github.com/juju/juju/core/leadership"
 	lease "github.com/juju/juju/core/lease"
 	multiwatcher "github.com/juju/juju/core/multiwatcher"
@@ -275,6 +276,21 @@ func (m *MockContext) Controller() *cache.Controller {
 func (mr *MockContextMockRecorder) Controller() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Controller", reflect.TypeOf((*MockContext)(nil).Controller))
+}
+
+// ControllerDB mocks base method.
+func (m *MockContext) ControllerDB() (database.TrackedDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerDB")
+	ret0, _ := ret[0].(database.TrackedDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerDB indicates an expected call of ControllerDB.
+func (mr *MockContextMockRecorder) ControllerDB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerDB", reflect.TypeOf((*MockContext)(nil).ControllerDB))
 }
 
 // Dispose mocks base method.

--- a/apiserver/facades/controller/caasmodelconfigmanager/package_test.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/package_test.go
@@ -9,6 +9,8 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run github.com/golang/mock/mockgen -package mocks -destination mocks/context_mock.go github.com/juju/juju/apiserver/facade Authorizer,Context,Resources
+
 func TestAll(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/apiserver/package_test.go
+++ b/apiserver/package_test.go
@@ -1,11 +1,13 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package apiserver_test
+package apiserver
 
 import (
 	"testing"
 
+	"github.com/juju/errors"
+	coredatabase "github.com/juju/juju/core/database"
 	coretesting "github.com/juju/juju/testing"
 )
 
@@ -15,4 +17,13 @@ import (
 
 func TestPackage(t *testing.T) {
 	coretesting.MgoTestPackage(t)
+}
+
+type StubDBGetter struct{}
+
+func (s StubDBGetter) GetDB(name string) (coredatabase.TrackedDB, error) {
+	if name != "controller" {
+		return nil, errors.Errorf(`expected a request for "controller" DB; got %q`, name)
+	}
+	return nil, nil
 }

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/cache"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
@@ -600,6 +601,12 @@ func (ctx *facadeContext) HTTPClient(purpose facade.HTTPClientPurpose) facade.HT
 	default:
 		return nil
 	}
+}
+
+// ControllerDB returns a TrackedDB reference for the controller database.
+func (ctx *facadeContext) ControllerDB() (coredatabase.TrackedDB, error) {
+	db, err := ctx.r.shared.dbGetter.GetDB(coredatabase.ControllerNS)
+	return db, errors.Trace(err)
 }
 
 // adminRoot dispatches API calls to those available to an anonymous connection

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/cache"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
@@ -46,6 +47,7 @@ type sharedServerContext struct {
 	logger              loggo.Logger
 	cancel              <-chan struct{}
 	charmhubHTTPClient  facade.HTTPClient
+	dbGetter            coredatabase.DBGetter
 
 	configMutex      sync.RWMutex
 	controllerConfig jujucontroller.Config
@@ -64,6 +66,7 @@ type sharedServerConfig struct {
 	controllerConfig    jujucontroller.Config
 	logger              loggo.Logger
 	charmhubHTTPClient  facade.HTTPClient
+	dbGetter            coredatabase.DBGetter
 }
 
 func (c *sharedServerConfig) validate() error {
@@ -88,6 +91,9 @@ func (c *sharedServerConfig) validate() error {
 	if c.controllerConfig == nil {
 		return errors.NotValidf("nil controllerConfig")
 	}
+	if c.dbGetter == nil {
+		return errors.NotValidf("nil dbGetter")
+	}
 	return nil
 }
 
@@ -105,6 +111,7 @@ func newSharedServerContext(config sharedServerConfig) (*sharedServerContext, er
 		logger:              config.logger,
 		controllerConfig:    config.controllerConfig,
 		charmhubHTTPClient:  config.charmhubHTTPClient,
+		dbGetter:            config.dbGetter,
 	}
 	ctx.features = config.controllerConfig.Features()
 	// We are able to get the current controller config before subscribing to changes

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -81,6 +81,7 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 		leaseManager:        &lease.Manager{},
 		controllerConfig:    controllerConfig,
 		logger:              loggo.GetLogger("test"),
+		dbGetter:            StubDBGetter{},
 	}
 }
 

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -649,10 +649,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			LeaseManagerName:       leaseManagerName,
 			UpgradeGateName:        upgradeStepsGateName,
 			AuditConfigUpdaterName: auditConfigUpdaterName,
-			// Synthetic dependency - if raft-transport bounces we
-			// need to bounce api-server too, otherwise http-server
-			// can't shutdown properly.
 			CharmhubHTTPClientName: charmhubHTTPClientName,
+			DBAccessorName:         dbAccessorName,
 
 			PrometheusRegisterer:              config.PrometheusRegisterer,
 			RegisterIntrospectionHTTPHandlers: config.RegisterIntrospectionHTTPHandlers,

--- a/core/database/interface.go
+++ b/core/database/interface.go
@@ -3,12 +3,13 @@
 
 package database
 
-// DBGetter describes the ability to supply a sql.DB
-// reference for a particular database.
+// DBGetter describes the ability to supply a TrackedDB reference for a
+// particular database.
 type DBGetter interface {
-	// GetDB returns a sql.DB reference for the dqlite-backed database that
+	// GetDB returns a TrackedDB reference for the dqlite-backed database that
 	// contains the data for the specified namespace.
-	// A NotFound error is returned if the worker is unaware of the requested DB.
+	// A NotFound error is returned if the worker is unaware of the requested
+	// DB.
 	GetDB(namespace string) (TrackedDB, error)
 }
 

--- a/core/database/interface.go
+++ b/core/database/interface.go
@@ -11,3 +11,8 @@ type DBGetter interface {
 	// A NotFound error is returned if the worker is unaware of the requested DB.
 	GetDB(namespace string) (TrackedDB, error)
 }
+
+const (
+	// ControllerNS is the namespace for the controller database.
+	ControllerNS = "controller"
+)

--- a/core/database/interface.go
+++ b/core/database/interface.go
@@ -1,0 +1,13 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package database
+
+// DBGetter describes the ability to supply a sql.DB
+// reference for a particular database.
+type DBGetter interface {
+	// GetDB returns a sql.DB reference for the dqlite-backed database that
+	// contains the data for the specified namespace.
+	// A NotFound error is returned if the worker is unaware of the requested DB.
+	GetDB(namespace string) (TrackedDB, error)
+}

--- a/worker/apiserver/worker.go
+++ b/worker/apiserver/worker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/core/auditlog"
 	"github.com/juju/juju/core/cache"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/multiwatcher"
 	"github.com/juju/juju/core/presence"
@@ -44,6 +45,8 @@ type Config struct {
 	MetricsCollector                  *apiserver.Collector
 	EmbeddedCommand                   apiserver.ExecEmbeddedCommandFunc
 	CharmhubHTTPClient                HTTPClient
+	// DBGetter supplies sql.DB references on request, for named databases.
+	DBGetter coredatabase.DBGetter
 }
 
 type HTTPClient interface {
@@ -104,6 +107,9 @@ func (config Config) Validate() error {
 	if config.CharmhubHTTPClient == nil {
 		return errors.NotValidf("nil CharmhubHTTPClient")
 	}
+	if config.DBGetter == nil {
+		return errors.NotValidf("nil DBGetter")
+	}
 	return nil
 }
 
@@ -162,6 +168,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		ExecEmbeddedCommand:           config.EmbeddedCommand,
 		SysLogger:                     config.SysLogger,
 		CharmhubHTTPClient:            config.CharmhubHTTPClient,
+		DBGetter:                      config.DBGetter,
 	}
 	return config.NewServer(serverConfig)
 }

--- a/worker/apiserver/worker_state_test.go
+++ b/worker/apiserver/worker_state_test.go
@@ -120,5 +120,6 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 		MetricsCollector:    s.metricsCollector,
 		SysLogger:           s.sysLogger,
 		CharmhubHTTPClient:  s.charmhubHTTPClient,
+		DBGetter:            s.dbGetter,
 	})
 }

--- a/worker/apiserver/worker_test.go
+++ b/worker/apiserver/worker_test.go
@@ -44,6 +44,7 @@ type workerFixture struct {
 	multiwatcherFactory  multiwatcher.Factory
 	sysLogger            syslogger.SysLogger
 	charmhubHTTPClient   *http.Client
+	dbGetter             stubDBGetter
 }
 
 func (s *workerFixture) SetUpTest(c *gc.C) {
@@ -89,6 +90,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		MetricsCollector:                  s.metricsCollector,
 		SysLogger:                         s.sysLogger,
 		CharmhubHTTPClient:                s.charmhubHTTPClient,
+		DBGetter:                          s.dbGetter,
 	}
 }
 
@@ -152,6 +154,9 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 	}, {
 		func(cfg *apiserver.Config) { cfg.SysLogger = nil },
 		"nil SysLogger not valid",
+	}, {
+		func(cfg *apiserver.Config) { cfg.DBGetter = nil },
+		"nil DBGetter not valid",
 	}}
 	for i, test := range tests {
 		c.Logf("test #%d (%s)", i, test.expect)

--- a/worker/changestream/worker.go
+++ b/worker/changestream/worker.go
@@ -13,19 +13,18 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/worker/changestream/eventqueue"
 	"github.com/juju/juju/worker/changestream/stream"
-	"github.com/juju/juju/worker/dbaccessor"
 	"github.com/juju/juju/worker/filenotifywatcher"
 )
 
 // DBGetter describes the ability to supply a sql.DB
 // reference for a particular database.
-type DBGetter = dbaccessor.DBGetter
+type DBGetter = coredatabase.DBGetter
 
 // FileNotifyWatcher is the interface that the worker uses to interact with the
 // file notify watcher.
 type FileNotifyWatcher = filenotifywatcher.FileNotifyWatcher
 
-// FileNotifyWatcher represents a way to watch for changes in a namespace folder
+// FileNotifier represents a way to watch for changes in a namespace folder
 // directory.
 type FileNotifier interface {
 	// Changes returns a channel if a file was created or deleted.

--- a/worker/dbaccessor/manifold.go
+++ b/worker/dbaccessor/manifold.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/worker/v3/dependency"
 
 	coreagent "github.com/juju/juju/agent"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/database"
 	"github.com/juju/juju/database/app"
 	"github.com/juju/juju/worker/common"
@@ -105,8 +106,8 @@ func dbAccessorOutput(in worker.Worker, out interface{}) error {
 	}
 
 	switch out := out.(type) {
-	case *DBGetter:
-		var target DBGetter = w
+	case *coredatabase.DBGetter:
+		var target coredatabase.DBGetter = w
 		*out = target
 	default:
 		return errors.Errorf("expected output of *dbaccessor.DBGetter, got %T", out)

--- a/worker/dbaccessor/package_mock_test.go
+++ b/worker/dbaccessor/package_mock_test.go
@@ -10,7 +10,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	database "github.com/juju/juju/core/database"
 	app "github.com/juju/juju/database/app"
 )
 
@@ -217,44 +216,6 @@ func (mr *MockNodeManagerMockRecorder) WithTLSOption() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithTLSOption", reflect.TypeOf((*MockNodeManager)(nil).WithTLSOption))
 }
 
-// MockDBGetter is a mock of DBGetter interface.
-type MockDBGetter struct {
-	ctrl     *gomock.Controller
-	recorder *MockDBGetterMockRecorder
-}
-
-// MockDBGetterMockRecorder is the mock recorder for MockDBGetter.
-type MockDBGetterMockRecorder struct {
-	mock *MockDBGetter
-}
-
-// NewMockDBGetter creates a new mock instance.
-func NewMockDBGetter(ctrl *gomock.Controller) *MockDBGetter {
-	mock := &MockDBGetter{ctrl: ctrl}
-	mock.recorder = &MockDBGetterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockDBGetter) EXPECT() *MockDBGetterMockRecorder {
-	return m.recorder
-}
-
-// GetDB mocks base method.
-func (m *MockDBGetter) GetDB(namespace string) (database.TrackedDB, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDB", namespace)
-	ret0, _ := ret[0].(database.TrackedDB)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDB indicates an expected call of GetDB.
-func (mr *MockDBGetterMockRecorder) GetDB(namespace interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDB", reflect.TypeOf((*MockDBGetter)(nil).GetDB), namespace)
-}
-
 // MockDBApp is a mock of DBApp interface.
 type MockDBApp struct {
 	ctrl     *gomock.Controller
@@ -347,53 +308,4 @@ func (m *MockDBApp) Ready(arg0 context.Context) error {
 func (mr *MockDBAppMockRecorder) Ready(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ready", reflect.TypeOf((*MockDBApp)(nil).Ready), arg0)
-}
-
-// MockREPL is a mock of REPL interface.
-type MockREPL struct {
-	ctrl     *gomock.Controller
-	recorder *MockREPLMockRecorder
-}
-
-// MockREPLMockRecorder is the mock recorder for MockREPL.
-type MockREPLMockRecorder struct {
-	mock *MockREPL
-}
-
-// NewMockREPL creates a new mock instance.
-func NewMockREPL(ctrl *gomock.Controller) *MockREPL {
-	mock := &MockREPL{ctrl: ctrl}
-	mock.recorder = &MockREPLMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockREPL) EXPECT() *MockREPLMockRecorder {
-	return m.recorder
-}
-
-// Kill mocks base method.
-func (m *MockREPL) Kill() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Kill")
-}
-
-// Kill indicates an expected call of Kill.
-func (mr *MockREPLMockRecorder) Kill() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockREPL)(nil).Kill))
-}
-
-// Wait mocks base method.
-func (m *MockREPL) Wait() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Wait")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Wait indicates an expected call of Wait.
-func (mr *MockREPLMockRecorder) Wait() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockREPL)(nil).Wait))
 }

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -64,15 +64,6 @@ type NodeManager interface {
 	WithClusterOption() (app.Option, error)
 }
 
-// DBGetter describes the ability to supply a sql.DB
-// reference for a particular database.
-type DBGetter interface {
-	// GetDB returns a sql.DB reference for the dqlite-backed database that
-	// contains the data for the specified namespace.
-	// A NotFound error is returned if the worker is unaware of the requested DB.
-	GetDB(namespace string) (coredatabase.TrackedDB, error)
-}
-
 // WorkerConfig encapsulates the configuration options for the
 // dbaccessor worker.
 type WorkerConfig struct {

--- a/worker/dbaccessor/worker.go
+++ b/worker/dbaccessor/worker.go
@@ -326,7 +326,7 @@ func (w *dbWorker) initializeDqlite() error {
 
 	// Open up the default controller database. Other database namespaces can
 	// be opened up in a more lazy fashion.
-	if err := w.openDatabase("controller"); err != nil {
+	if err := w.openDatabase(coredatabase.ControllerNS); err != nil {
 		return errors.Annotate(err, "opening initial databases")
 	}
 

--- a/worker/dbaccessor/worker_test.go
+++ b/worker/dbaccessor/worker_test.go
@@ -55,7 +55,7 @@ func (s *workerSuite) TestGetControllerDBSuccessNotExistingNode(c *gc.C) {
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)
 
-	getter, ok := w.(DBGetter)
+	getter, ok := w.(coredatabase.DBGetter)
 	c.Assert(ok, jc.IsTrue, gc.Commentf("worker does not implement DBGetter"))
 
 	_, err := getter.GetDB("controller")

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -97,7 +97,7 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 		return nil, errors.Trace(err)
 	}
 
-	trackedDB, err := dbGetter.GetDB("controller")
+	trackedDB, err := dbGetter.GetDB(coredatabase.ControllerNS)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -19,9 +19,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/agent"
+	coredatabase "github.com/juju/juju/core/database"
 	corelease "github.com/juju/juju/core/lease"
 	"github.com/juju/juju/worker/common"
-	"github.com/juju/juju/worker/dbaccessor"
 	"github.com/juju/juju/worker/lease"
 )
 
@@ -92,7 +92,7 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 		return nil, errors.Trace(err)
 	}
 
-	var dbGetter dbaccessor.DBGetter
+	var dbGetter coredatabase.DBGetter
 	if err := context.Get(s.config.DBAccessorName, &dbGetter); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/leaseexpiry/manifold.go
+++ b/worker/leaseexpiry/manifold.go
@@ -62,7 +62,7 @@ func (c ManifoldConfig) start(ctx dependency.Context) (worker.Worker, error) {
 		return nil, errors.Trace(err)
 	}
 
-	trackedDB, err := dbGetter.GetDB("controller")
+	trackedDB, err := dbGetter.GetDB(coredatabase.ControllerNS)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/worker/leaseexpiry/manifold.go
+++ b/worker/leaseexpiry/manifold.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
 
-	"github.com/juju/juju/worker/dbaccessor"
+	coredatabase "github.com/juju/juju/core/database"
 )
 
 // Logger represents the methods used by the worker to log details.
@@ -57,7 +57,7 @@ func (c ManifoldConfig) start(ctx dependency.Context) (worker.Worker, error) {
 		return nil, errors.Trace(err)
 	}
 
-	var dbGetter dbaccessor.DBGetter
+	var dbGetter coredatabase.DBGetter
 	if err := ctx.Get(c.DBAccessorName, &dbGetter); err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
The following pushes the db getter through the many, many, many layers
of the apiserver so that we can use it at the facade level. The work to
get the db directly hasn't been implemented, just the scaffolding for
that.

In part of doing this, I moved the DBGetter out of the worker into the
core database package, this makes it a lot cleaner when attempting to
use things from the apiserver.

Also, this exposes the underlying TrackedDB, not a raw *sql.DB. It is up
to the user of the tracked db to ensure that the db isn't stale. At no
point should you keep hold of the db reference. A new reference should be
sought after every time.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.
