### PR TITLE
cmd/juju/status: Exported the Format method.

### DIFF
--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -76,7 +76,8 @@ func newStatusFormatter(p newStatusFormatterParams) *statusFormatter {
 	return &sf
 }
 
-func (sf *statusFormatter) format() (formattedStatus, error) {
+// Format returns the formatted model status.
+func (sf *statusFormatter) Format() (formattedStatus, error) {
 	if sf.status == nil {
 		return formattedStatus{}, nil
 	}

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -368,7 +368,7 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 		}
 	}
 
-	formatted, err := newStatusFormatter(formatterParams).format()
+	formatted, err := newStatusFormatter(formatterParams).Format()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -6157,7 +6157,7 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 	}
 	isoTime := true
 	formatter := NewStatusFormatter(status, isoTime)
-	formatted, err := formatter.format()
+	formatted, err := formatter.Format()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(formatted, jc.DeepEquals, formattedStatus{
@@ -6207,7 +6207,7 @@ func (s *StatusSuite) TestMissingControllerTimestampInFullStatus(c *gc.C) {
 	}
 	isoTime := true
 	formatter := NewStatusFormatter(status, isoTime)
-	formatted, err := formatter.format()
+	formatted, err := formatter.Format()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(formatted, jc.DeepEquals, formattedStatus{
@@ -6256,7 +6256,7 @@ func (s *StatusSuite) TestControllerTimestampInFullStatus(c *gc.C) {
 	}
 	isoTime := true
 	formatter := NewStatusFormatter(status, isoTime)
-	formatted, err := formatter.format()
+	formatted, err := formatter.Format()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(formatted, jc.DeepEquals, formattedStatus{


### PR DESCRIPTION
In JIMM we need to use the status formatter. The NewStatusFormatter is already exported, but the format method (obviously) was not.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju status
```