### PR TITLE
[JUJU-3331] Improve secret-grant error message for cmr units

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -534,6 +534,9 @@ func (s *SecretsManagerAPI) getRemoteSecretContent(uri *coresecrets.URI, refresh
 
 	scopeToken, err := extClient.GetSecretAccessScope(uri, token, unitId)
 	if err != nil {
+		if errors.Is(err, errors.NotFound) {
+			return nil, nil, false, apiservererrors.ErrPerm
+		}
 		return nil, nil, false, errors.Trace(err)
 	}
 	logger.Debugf("secret %q scope token for %v: %s", uri.String(), token, scopeToken)


### PR DESCRIPTION
secret-grant has a --unit arg to optionally specify a unit to grant to instead of the whole app.
This does not make sense for cross model relations, so tweak the logic to present a better error message than "not found".

## QA steps

create a cross model relation
create a secret on the offering charm
use a mongo shell to look up the corresponding remote app name for the consumer proxy
attempt to grant access to the secret for a unit

```
$ juju exec --unit dummy-source/0 "secret-grant secret://c6017806-dbf1-429b-8953-e28cc4ba7495/cgd4f6sr06uh96slilkg -r 0 --unit remote-bd729e8ea6fc4e058077056da3455c43/0"
granting secrets access: cannot change access to "secret://c6017806-dbf1-429b-8953-e28cc4ba7495/cgd4f6sr06uh96slilkg" for "unit-remote-bd729e8ea6fc4e058077056da3455c43-0": sharing secrets with a unit across a cross model relation not supported
```