### PR TITLE
[JUJU-3326] implement charm config for DeployFromRepository

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -392,15 +392,13 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		}
 
 		// Process the --config args.
-		// TODO: ensure that all config is in configYAML,
-		// for now, appConfig is ignored.
-		appConfig, configYAML, err := utils.ProcessConfig(ctx, c.model.Filesystem(), c.configOptions, c.trust)
+		appName := c.userRequestedURL.Name
+		if c.applicationName != "" {
+			appName = c.applicationName
+		}
+		configYAML, err := utils.CombinedConfig(ctx, c.model.Filesystem(), c.configOptions, appName)
 		if err != nil {
 			return errors.Trace(err)
-		}
-		// At deploy time, there's no need to include "trust=false" as missing is the same thing.
-		if !c.trust {
-			delete(appConfig, app.TrustConfigOptionName)
 		}
 
 		info, _, errs := deployAPI.DeployFromRepository(application.DeployFromRepositoryArg{


### PR DESCRIPTION
Config for DeployFromRepository should now work as expected. In the client, the key/value pair config is combined with the config provided via file. Trust is an application config, but remains separate rather than special handling.

There should be no change in how config is used from the user point of view. Both key/value pairs and a config yaml file can be provided. Key/value pairs take priory over the config from a file. Values can also be provided via file using the `@` symbol.

I have to work out the application name logic so there are some contortions right now.
## QA steps

Please try various method to provide config - try to break the config logic.

```sh
$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju bootstrap localhost test
$ juju add-model five

$ cat > config.yaml << EOT
testme:
  skill: 7
  status: test status message
EOT

$ JUJU_DEV_FEATURE_FLAGS=server-side-charm-deploy juju deploy juju-qa-test testme --config status=override --config ./config.yaml --trust
application.DeployInfo{
    ...
}

$ juju config testme
application: testme
application-config:
  trust:
    ...
    value: true
charm: juju-qa-test
settings:
...
  skill:
    ...
    value: 7
  status:
    ...
    value: override
...
```

