### PR TITLE
[JUJU-3345] Fix permission issue when a consumer is related to more than one offer

### DIFF
--- a/apiserver/facades/controller/crossmodelsecrets/mocks/crossmodel.go
+++ b/apiserver/facades/controller/crossmodelsecrets/mocks/crossmodel.go
@@ -34,20 +34,19 @@ func (m *MockCrossModelState) EXPECT() *MockCrossModelStateMockRecorder {
 	return m.recorder
 }
 
-// GetConsumerInfo mocks base method.
-func (m *MockCrossModelState) GetConsumerInfo(arg0 string) (names.Tag, string, error) {
+// GetRemoteApplicationTag mocks base method.
+func (m *MockCrossModelState) GetRemoteApplicationTag(arg0 string) (names.Tag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConsumerInfo", arg0)
+	ret := m.ctrl.Call(m, "GetRemoteApplicationTag", arg0)
 	ret0, _ := ret[0].(names.Tag)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// GetConsumerInfo indicates an expected call of GetConsumerInfo.
-func (mr *MockCrossModelStateMockRecorder) GetConsumerInfo(arg0 interface{}) *gomock.Call {
+// GetRemoteApplicationTag indicates an expected call of GetRemoteApplicationTag.
+func (mr *MockCrossModelStateMockRecorder) GetRemoteApplicationTag(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumerInfo", reflect.TypeOf((*MockCrossModelState)(nil).GetConsumerInfo), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteApplicationTag", reflect.TypeOf((*MockCrossModelState)(nil).GetRemoteApplicationTag), arg0)
 }
 
 // GetToken mocks base method.

--- a/apiserver/facades/controller/crossmodelsecrets/register.go
+++ b/apiserver/facades/controller/crossmodelsecrets/register.go
@@ -50,10 +50,7 @@ func newStateCrossModelSecretsAPI(ctx facade.Context) (*CrossModelSecretsAPI, er
 		st.ModelUUID(),
 		secretInfoGetter,
 		secretBackendConfigGetter,
-		&crossModelShim{
-			RemoteEntities: st.RemoteEntities(),
-			State:          st,
-		},
+		&crossModelShim{st.RemoteEntities()},
 		&stateBackendShim{st},
 	)
 }

--- a/apiserver/facades/controller/crossmodelsecrets/state.go
+++ b/apiserver/facades/controller/crossmodelsecrets/state.go
@@ -26,7 +26,7 @@ type SecretsConsumer interface {
 }
 
 type CrossModelState interface {
-	GetConsumerInfo(string) (names.Tag, string, error)
+	GetRemoteApplicationTag(string) (names.Tag, error)
 	GetToken(entity names.Tag) (string, error)
 }
 
@@ -52,19 +52,10 @@ func (s *stateBackendShim) HasEndpoint(key string, app string) (bool, error) {
 
 type crossModelShim struct {
 	*state.RemoteEntities
-	*state.State
 }
 
-// GetConsumerInfo returns the consumer remote application proxy
-// for the token, plus the offer uuid.
-func (s *crossModelShim) GetConsumerInfo(token string) (names.Tag, string, error) {
-	appTag, err := s.RemoteEntities.GetRemoteEntity(token)
-	if err != nil {
-		return nil, "", errors.Trace(err)
-	}
-	app, err := s.State.RemoteApplication(appTag.Id())
-	if err != nil {
-		return nil, "", errors.Trace(err)
-	}
-	return appTag, app.OfferUUID(), nil
+// GetRemoteApplicationTag returns the consumer remote application
+// tag for the token.
+func (s *crossModelShim) GetRemoteApplicationTag(token string) (names.Tag, error) {
+	return s.RemoteEntities.GetRemoteEntity(token)
 }


### PR DESCRIPTION
We have an old bug in cross model relations where a remote app consumer proxy only has a single offer uuid attribute, but can be related to more than one offer. That issue potentially affects offer removal and is a separate problem to fix.

The trouble is we used that as part of checking permissions to read a secret, and depending on the order of relating to > 1 offer, the permission check would fail.

The fix is to avoid using the (incorrectly saved) offer uuid on the remote app proxy. The macaroon is validated anyway so the check strictly speaking is not needed.

## QA steps

deploy and offer keystone and rabbitmq-server
in a different model, deploy nova-compute and relate to rabbitmq-server then keystone (order is important)
create and share a secret in the keystone app
read the secret in the nova-compute app
