### PR TITLE
[JUJU-3790] Remove unused agent API methods

### DIFF
--- a/api/agent/agent/machine_test.go
+++ b/api/agent/agent/machine_test.go
@@ -112,23 +112,3 @@ func (s *machineSuite) TestMachineEntity(c *gc.C) {
 	c.Assert(err, jc.Satisfies, params.IsCodeNotFound)
 	c.Assert(m, gc.IsNil)
 }
-
-func (s *machineSuite) TestClearReboot(c *gc.C) {
-	err := s.machine.SetRebootFlag(true)
-	c.Assert(err, jc.ErrorIsNil)
-	rFlag, err := s.machine.GetRebootFlag()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rFlag, jc.IsTrue)
-
-	apiSt, err := apiagent.NewState(s.st)
-	c.Assert(err, jc.ErrorIsNil)
-	entity, err := apiSt.Entity(s.machine.Tag())
-	c.Assert(err, jc.ErrorIsNil)
-
-	err = entity.ClearReboot()
-	c.Assert(err, jc.ErrorIsNil)
-
-	rFlag, err = s.machine.GetRebootFlag()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rFlag, jc.IsFalse)
-}

--- a/api/agent/agent/machine_test.go
+++ b/api/agent/agent/machine_test.go
@@ -8,14 +8,12 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/errors"
-	"github.com/juju/mgo/v3"
 	"github.com/juju/names/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api"
 	apiagent "github.com/juju/juju/api/agent/agent"
-	apiserveragent "github.com/juju/juju/apiserver/facades/agent/agent"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
@@ -62,35 +60,6 @@ func (s *servingInfoSuite) TestStateServingInfoPermission(c *gc.C) {
 	apiSt, err := apiagent.NewState(st)
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = apiSt.StateServingInfo()
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: "permission denied",
-		Code:    "unauthorized access",
-	})
-}
-
-func (s *servingInfoSuite) TestIsMaster(c *gc.C) {
-	calledIsMaster := false
-	var fakeMongoIsMaster = func(session *mgo.Session, m mongo.WithAddresses) (bool, error) {
-		calledIsMaster = true
-		return true, nil
-	}
-	s.PatchValue(&apiserveragent.MongoIsMaster, fakeMongoIsMaster)
-
-	st, _ := s.OpenAPIAsNewMachine(c, state.JobManageModel)
-	expected := true
-	apiSt, err := apiagent.NewState(st)
-	c.Assert(err, jc.ErrorIsNil)
-	result, err := apiSt.IsMaster()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.Equals, expected)
-	c.Assert(calledIsMaster, jc.IsTrue)
-}
-
-func (s *servingInfoSuite) TestIsMasterPermission(c *gc.C) {
-	st, _ := s.OpenAPIAsNewMachine(c)
-	apiSt, err := apiagent.NewState(st)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = apiSt.IsMaster()
 	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
 		Message: "permission denied",
 		Code:    "unauthorized access",

--- a/api/agent/agent/state.go
+++ b/api/agent/agent/state.go
@@ -79,18 +79,6 @@ func (st *State) StateServingInfo() (controller.StateServingInfo, error) {
 	}, nil
 }
 
-// IsMaster reports whether the connected machine
-// agent lives at the same network address as the primary
-// mongo server for the replica set.
-// This call will return an error if the connected
-// agent is not a machine agent with model-manager
-// privileges.
-func (st *State) IsMaster() (bool, error) {
-	var results params.IsMasterResult
-	err := st.facade.FacadeCall("IsMaster", nil, &results)
-	return results.Master, err
-}
-
 type Entity struct {
 	st  *State
 	tag names.Tag

--- a/api/agent/agent/state.go
+++ b/api/agent/agent/state.go
@@ -121,21 +121,6 @@ func (m *Entity) ContainerType() instance.ContainerType {
 	return m.doc.ContainerType
 }
 
-// ClearReboot clears the reboot flag of the machine.
-func (m *Entity) ClearReboot() error {
-	var result params.ErrorResults
-	args := params.SetStatus{
-		Entities: []params.EntityStatusArgs{
-			{Tag: m.tag.String()},
-		},
-	}
-	err := m.st.facade.FacadeCall("ClearReboot", args, &result)
-	if err != nil {
-		return err
-	}
-	return result.OneError()
-}
-
 // IsAllowedControllerTag returns true if the tag kind can be for a controller.
 // TODO(controlleragent) - this method is needed while IAAS controllers are still machines.
 func IsAllowedControllerTag(kind string) bool {

--- a/api/agent/agent/state.go
+++ b/api/agent/agent/state.go
@@ -121,22 +121,6 @@ func (m *Entity) ContainerType() instance.ContainerType {
 	return m.doc.ContainerType
 }
 
-// SetPassword sets the password associated with the agent's entity.
-func (m *Entity) SetPassword(password string) error {
-	var results params.ErrorResults
-	args := params.EntityPasswords{
-		Changes: []params.EntityPassword{{
-			Tag:      m.tag.String(),
-			Password: password,
-		}},
-	}
-	err := m.st.facade.FacadeCall("SetPasswords", args, &results)
-	if err != nil {
-		return err
-	}
-	return results.OneError()
-}
-
 // ClearReboot clears the reboot flag of the machine.
 func (m *Entity) ClearReboot() error {
 	var result params.ErrorResults

--- a/api/agent/agent/state.go
+++ b/api/agent/agent/state.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/common/cloudspec"
 	"github.com/juju/juju/controller"
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/rpc/params"
@@ -113,12 +112,6 @@ func (m *Entity) Life() life.Value {
 // the empty list.
 func (m *Entity) Jobs() []model.MachineJob {
 	return m.doc.Jobs
-}
-
-// ContainerType returns the type of container hosting this entity.
-// If the entity is not a machine, it returns an empty string.
-func (m *Entity) ContainerType() instance.ContainerType {
-	return m.doc.ContainerType
 }
 
 // IsAllowedControllerTag returns true if the tag kind can be for a controller.


### PR DESCRIPTION
There are some methods on the agent API that over time have become unused, or been replicated on other usage-specific APIs. These are:
- `IsMaster`
- `SetPassword`
- `ClearReboot`
- `ContainerType`

Here we remove them.

As a follow-up, we should remove whichever of these are not required from the server-side (some are embedded from the common package), and bump the version.

## QA steps

Bootstrap; deploy a workload.
