### PR TITLE
Bump golangci-lint to be compatible with go 1.20

### DIFF
--- a/.github/golangci-lint.config.yaml
+++ b/.github/golangci-lint.config.yaml
@@ -32,8 +32,7 @@ linters:
     - ineffassign
     - misspell
     - unconvert
-    - deadcode
-    - varcheck
+    - exportloopref
 run:
   timeout: 30m
 skip-dirs:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -48,7 +48,7 @@ jobs:
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.1
         sudo snap install shfmt
         sudo apt install expect
     

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -206,7 +206,8 @@ func (f *Facade) UnitIntroduction(args params.CAASUnitIntroductionArgs) (params.
 		return errResp(err)
 	}
 	var pod *caas.Unit
-	for _, p := range pods {
+	for _, v := range pods {
+		p := v
 		if p.Id == args.PodName {
 			pod = &p
 			break

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -903,6 +903,7 @@ func (m *ModelManagerAPI) ListModels(user params.Entity) (params.UserModelList, 
 			// no reason to fail the request here, as it wasn't the users fault
 			logger.Warningf("for model %v, got an invalid owner: %q", mi.UUID, mi.Owner)
 		}
+		lastConnection := mi.LastConnection
 		result.UserModels = append(result.UserModels, params.UserModel{
 			Model: params.Model{
 				Name:     mi.Name,
@@ -910,7 +911,7 @@ func (m *ModelManagerAPI) ListModels(user params.Entity) (params.UserModelList, 
 				Type:     string(mi.Type),
 				OwnerTag: ownerTag.String(),
 			},
-			LastConnection: &mi.LastConnection,
+			LastConnection: &lastConnection,
 		})
 	}
 

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -186,7 +186,8 @@ func (api *CrossModelRelationsAPI) registerRemoteRelation(relation params.Regist
 
 	// Does the requested local endpoint exist?
 	var localEndpoint *state.Endpoint
-	for _, ep := range eps {
+	for _, v := range eps {
+		ep := v
 		if ep.Name == relation.LocalEndpointName {
 			localEndpoint = &ep
 			break

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -657,7 +657,8 @@ func (k *kubernetesClient) GetService(appName string, mode caas.DeploymentMode, 
 	)
 	// We may have the stateful set or deployment but service not done yet.
 	if len(servicesList.Items) > 0 {
-		for _, s := range servicesList.Items {
+		for _, v := range servicesList.Items {
+			s := v
 			// Ignore any headless service for this app.
 			if !strings.HasSuffix(s.Name, "-endpoints") {
 				svc = &s

--- a/cmd/juju/action/cancel.go
+++ b/cmd/juju/action/cancel.go
@@ -113,7 +113,8 @@ func (c *cancelCommand) Run(ctx *cmd.Context) error {
 	var failedCancels []unCanceledAction
 	var canceledActions []actionapi.ActionResult
 
-	for i, result := range actions {
+	for i, v := range actions {
+		result := v
 		if result.Action != nil {
 			canceledActions = append(canceledActions, result)
 		} else {

--- a/cmd/juju/commands/migrate_test.go
+++ b/cmd/juju/commands/migrate_test.go
@@ -473,7 +473,8 @@ func (m *fakeModelAPI) ModelInfo(tags []names.ModelTag) ([]params.ModelInfoResul
 	)
 
 	modelUUID := tags[0].Id()
-	for _, model := range m.modelInfo {
+	for _, v := range m.modelInfo {
+		model := v
 		if model.UUID == modelUUID {
 			mi = &model
 			break

--- a/cmd/juju/gui/gui.go
+++ b/cmd/juju/gui/gui.go
@@ -145,8 +145,9 @@ func (c *guiCommand) Run(ctx *cmd.Context) error {
 	}
 	var vers *version.Number
 	for _, v := range versions {
-		if v.Current {
-			vers = &v.Version
+		ver := v
+		if ver.Current {
+			vers = &ver.Version
 			break
 		}
 	}

--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -202,14 +202,15 @@ type StorageAddAPI interface {
 
 func (c *addCommand) createStorageAddParams() []params.StorageAddParams {
 	all := make([]params.StorageAddParams, 0, len(c.storageCons))
-	for one, cons := range c.storageCons {
+	for one, sc := range c.storageCons {
+		cons := sc
 		all = append(all, params.StorageAddParams{
 			UnitTag:     c.unitTag.String(),
 			StorageName: one,
 			Constraints: params.StorageConstraints{
-				cons.Pool,
-				&cons.Size,
-				&cons.Count,
+				Pool:  cons.Pool,
+				Size:  &cons.Size,
+				Count: &cons.Count,
 			},
 		})
 	}

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -680,9 +680,11 @@ func (g bootstrapConfigGetter) getBootstrapConfigParams(controllerName string) (
 		// DetectCredential ensures that there is only one credential
 		// to choose from. It's still in a map, though, hence for..range.
 		var credentialName string
-		for name, one := range cloudCredential.AuthCredentials {
+		for name, v := range cloudCredential.AuthCredentials {
+			one := v
 			credential = &one
 			credentialName = name
+			break
 		}
 		credential, err = FinalizeFileContent(credential, provider)
 		if err != nil {

--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -127,6 +127,9 @@ func detectSeriesAndHardwareCharacteristics(host string) (hc instance.HardwareCh
 	memkB := strings.Fields(lines[2])[1] // "MemTotal: NNN kB"
 	hc.Mem = new(uint64)
 	*hc.Mem, err = strconv.ParseUint(memkB, 10, 0)
+	if err != nil {
+		return hc, "", errors.Annotatef(err, "parsing %q", lines[2])
+	}
 	*hc.Mem /= 1024
 
 	// For each "physical id", count the number of cores.

--- a/provider/azure/storage.go
+++ b/provider/azure/storage.go
@@ -977,7 +977,8 @@ func getStorageAccountKey(
 
 	// We need a storage key with full permissions.
 	var fullKey *legacystorage.AccountKey
-	for _, key := range *listKeysResult.Keys {
+	for _, v := range *listKeysResult.Keys {
+		key := v
 		logger.Debugf("storage account key: %#v", key)
 		// At least some of the time, Azure returns the permissions
 		// in title-case, which does not match the constant.

--- a/provider/openstack/client.go
+++ b/provider/openstack/client.go
@@ -177,7 +177,8 @@ func (c *ClientFactory) getClientState(options ...ClientOption) (client.Authenti
 		// Walk over the options to verify if the AuthUserPassV3 exists, if it
 		// does exist use that to attempt authentication.
 		var authOption *identity.AuthOption
-		for _, option := range authOptions {
+		for _, v := range authOptions {
+			option := v
 			if option.Mode == identity.AuthUserPassV3 {
 				authOption = &option
 				break

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1830,7 +1830,8 @@ func (e *exporter) readAllMeterStatus() (map[string]*meterStatusDoc, error) {
 	}
 	e.logger.Debugf("found %d meter status docs", len(docs))
 	result := make(map[string]*meterStatusDoc)
-	for _, doc := range docs {
+	for _, v := range docs {
+		doc := v
 		result[e.st.localID(doc.DocID)] = &doc
 	}
 	return result, nil
@@ -1864,7 +1865,8 @@ func (e *exporter) readAllCloudServices() (map[string]*cloudServiceDoc, error) {
 	}
 	e.logger.Debugf("found %d cloud service docs", len(docs))
 	result := make(map[string]*cloudServiceDoc)
-	for _, doc := range docs {
+	for _, v := range docs {
+		doc := v
 		result[e.st.localID(doc.DocID)] = &doc
 	}
 	return result, nil
@@ -1888,7 +1890,8 @@ func (e *exporter) readAllCloudContainers() (map[string]*cloudContainerDoc, erro
 	}
 	e.logger.Debugf("found %d cloud container docs", len(docs))
 	result := make(map[string]*cloudContainerDoc)
-	for _, doc := range docs {
+	for _, v := range docs {
+		doc := v
 		result[e.st.localID(doc.Id)] = &doc
 	}
 	return result, nil

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,7 +58,7 @@ sudo snap install expect
 The static analysis tests also require `golangci-lint`:
 
 ```
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
 ```
 
 To get started, it's best to quickly look at the help command from the runner.

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -1,7 +1,7 @@
 run_go() {
 	VER=$(golangci-lint --version | tr -s ' ' | cut -d ' ' -f 4 | cut -d '.' -f 1,2)
-	if [[ ${VER} != "1.46" ]] && [[ ${VER} != "v1.46" ]]; then
-		(echo >&2 -e '\nError: golangci-lint version does not match 1.46. Please upgrade/downgrade to the right version.')
+	if [[ ${VER} != "1.52" ]] && [[ ${VER} != "v1.52" ]]; then
+		(echo >&2 -e '\nError: golangci-lint version does not match 1.52. Please upgrade/downgrade to the right version.')
 		exit 1
 	fi
 	OUT=$(golangci-lint run -c .github/golangci-lint.config.yaml 2>&1)

--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -69,6 +69,9 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 		return errors.Annotate(err, "could not parse charm URL")
 	}
 	expectedSha256, err := info.ArchiveSha256()
+	if err != nil {
+		return errors.Annotatef(err, "failed to get archive sha256 for charm %q", info.String())
+	}
 	req := downloader.Request{
 		URL:       curl,
 		TargetDir: downloadsPath(d.path),

--- a/worker/uniter/runner/jujuc/storage-add.go
+++ b/worker/uniter/runner/jujuc/storage-add.go
@@ -47,17 +47,18 @@ func (s *StorageAddCommand) Init(args []string) error {
 		return errors.New("storage add requires a storage directive")
 	}
 
-	cons, err := storage.ParseConstraintsMap(args, false)
+	constraintsMap, err := storage.ParseConstraintsMap(args, false)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	s.all = make(map[string]params.StorageConstraints, len(cons))
-	for k, v := range cons {
-		if v != (storage.Constraints{Count: v.Count}) {
+	s.all = make(map[string]params.StorageConstraints, len(constraintsMap))
+	for k, v := range constraintsMap {
+		cons := v
+		if cons != (storage.Constraints{Count: cons.Count}) {
 			return errors.Errorf("only count can be specified for %q", k)
 		}
-		s.all[k] = params.StorageConstraints{Count: &v.Count}
+		s.all[k] = params.StorageConstraints{Count: &cons.Count}
 	}
 	return nil
 }


### PR DESCRIPTION
Also fixes a few bugs with exported loop variables, the rest are to silence the new linter, exportloopref.

Fixes a few errors picked up by ineffassign.

## QA steps

Run linters, unit tests, check the changes made.

## Documentation changes

N/A

## Bug reference

N/A