### PR TITLE
[JUJU-3340] Charm deploy must fail if image-id constraint is used and no explicit base is provided

### DIFF
--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -569,7 +569,7 @@ func (v *deployFromRepositoryValidator) resolveCharm(curl *charm.URL, requestedO
 	}
 
 	// Get the series to use.
-	series, err := selector.CharmSeries()
+	series, _, err := selector.CharmSeries()
 	deployRepoLogger.Tracef("Using series %q from %v to deploy %v", series, supportedSeries, curl)
 	if charm.IsUnsupportedSeriesError(err) {
 		msg := fmt.Sprintf("%v. Use --force to deploy the charm anyway.", err)

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -670,9 +670,13 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 			FromBundle:          true,
 			Logger:              logger,
 		}
+		err = selector.Validate()
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		// Get the series to use.
-		chSeries, _, err := selector.CharmSeries()
+		chSeries, err := selector.CharmSeries()
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1007,7 +1011,11 @@ func (h *bundleHandler) selectedSeries(ch charm.CharmMeta, chID application.Char
 		FromBundle:          true,
 		Logger:              logger,
 	}
-	selectedSeries, _, err := selector.CharmSeries()
+	err = selector.Validate()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	selectedSeries, err := selector.CharmSeries()
 	return selectedSeries, charmValidationError(curl.Name, errors.Trace(err))
 }
 

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -672,7 +672,7 @@ func (h *bundleHandler) addCharm(change *bundlechanges.AddCharmChange) error {
 		}
 
 		// Get the series to use.
-		chSeries, err := selector.CharmSeries()
+		chSeries, _, err := selector.CharmSeries()
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -1007,7 +1007,7 @@ func (h *bundleHandler) selectedSeries(ch charm.CharmMeta, chID application.Char
 		FromBundle:          true,
 		Logger:              logger,
 	}
-	selectedSeries, err := selector.CharmSeries()
+	selectedSeries, _, err := selector.CharmSeries()
 	return selectedSeries, charmValidationError(curl.Name, errors.Trace(err))
 }
 

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -485,7 +485,13 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 	}
 
 	// Get the series to use.
-	series, err := selector.CharmSeries()
+	series, isDefaultSeries, err := selector.CharmSeries()
+	// If the image-id constraint is provided then base must be explicitly
+	// provided either by flag either by model-config default base.
+	if (c.constraints.HasImageID() || c.modelConstraints.HasImageID()) && isDefaultSeries {
+		return errors.Forbiddenf("base must be explicitly provided when image-id constraint is used")
+	}
+
 	logger.Tracef("Using series %q from %v to deploy %v", series, supportedSeries, userRequestedURL)
 
 	imageStream := modelCfg.ImageStream()

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -482,15 +482,15 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		Conf:                modelCfg,
 		FromBundle:          false,
 		Logger:              logger,
+		UsingImageID:        (c.constraints.HasImageID() || c.modelConstraints.HasImageID()),
+	}
+	err = selector.Validate()
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	// Get the series to use.
-	series, isDefaultSeries, err := selector.CharmSeries()
-	// If the image-id constraint is provided then base must be explicitly
-	// provided either by flag either by model-config default base.
-	if (c.constraints.HasImageID() || c.modelConstraints.HasImageID()) && isDefaultSeries {
-		return errors.Forbiddenf("base must be explicitly provided when image-id constraint is used")
-	}
+	series, err := selector.CharmSeries()
 
 	logger.Tracef("Using series %q from %v to deploy %v", series, supportedSeries, userRequestedURL)
 

--- a/core/charm/series_selector_test.go
+++ b/core/charm/series_selector_test.go
@@ -21,8 +21,9 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 
 		SeriesSelector
 
-		expectedSeries string
-		err            string
+		expectedSeries          string
+		expectedIsDefaultSeries bool
+		err                     string
 	}{
 		{
 			// Simple selectors first, no supported series.
@@ -107,7 +108,8 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				Force: true,
 				Conf:  defaultBase{},
 			},
-			expectedSeries: "jammy",
+			expectedSeries:          "jammy",
+			expectedIsDefaultSeries: true,
 		},
 
 		// Now charms with supported series.
@@ -119,7 +121,8 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				Conf:                defaultBase{},
 				SupportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			expectedSeries: "bionic",
+			expectedSeries:          "bionic",
+			expectedIsDefaultSeries: true,
 		},
 		{
 			title: "juju deploy multiseries with invalid series  # use charm default, nothing specified, no default series",
@@ -128,7 +131,8 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 				Conf:                defaultBase{},
 				SupportedJujuSeries: set.NewStrings("bionic", "cosmic"),
 			},
-			expectedSeries: "bionic",
+			expectedSeries:          "bionic",
+			expectedIsDefaultSeries: true,
 		},
 		{
 			title: "juju deploy multiseries with invalid serie  # use charm default, nothing specified, no default series",
@@ -277,12 +281,13 @@ func (s *SeriesSelectorSuite) TestCharmSeries(c *gc.C) {
 	for i, test := range deploySeriesTests {
 		c.Logf("test %d [%s]", i, test.title)
 		test.SeriesSelector.Logger = &noOpLogger{}
-		series, err := test.SeriesSelector.CharmSeries()
+		series, isDefaultSeries, err := test.SeriesSelector.CharmSeries()
 		if test.err != "" {
 			c.Check(err, gc.ErrorMatches, test.err)
 		} else {
 			c.Check(err, jc.ErrorIsNil)
 			c.Check(series, gc.Equals, test.expectedSeries)
+			c.Check(isDefaultSeries, gc.Equals, test.expectedIsDefaultSeries)
 		}
 	}
 }


### PR DESCRIPTION
Since we introduced image-id constraint, we must be sure that users don't mix up the image-id with the base/series, since those concepts are quite close.

Therefore, forcing the user to provide explicitly the base (either through --base flag or through model-config) makes the distinction a little more clear.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

### Validate repository charm:
```sh
$ juju deploy prometheus2 --constraints="image-id=ubuntu-bf2"
ERROR base must be explicitly provided when image-id constraint is used
```
If the base is passed through model-config, then no error is returned:
```sh
$ juju model-config default-base="ubuntu@20.04"
$ juju deploy prometheus2 --constraints="image-id=ubuntu-bf2"
Located charm "prometheus2" in charm-hub, revision 48
Deploying "prometheus2" from charm-hub charm "prometheus2", revision 48 in channel stable on ubuntu@20.04/stable
```
If the base is passed through --base flag, then no error is returned:
```sh
$ juju model-config default-base=""
$ juju deploy prometheus2 --constraints="image-id=ubuntu-bf2" --base "ubuntu@20.04"
Located charm "prometheus2" in charm-hub, revision 48
Deploying "prometheus2" from charm-hub charm "prometheus2", revision 48 in channel stable on ubuntu@20.04/stable
```

### Validate local charm (you need a local charm file):
```sh
$ juju deploy ./prometheus2_r33.charm --constraints="image-id=ubuntu-bf2"
ERROR base must be explicitly provided when image-id constraint is used
```
If the base is passed through model-config, then no error is returned:
```sh
$ juju model-config default-base="ubuntu@20.04"
$ juju deploy ./prometheus2_r33.charm --constraints="image-id=ubuntu-bf2"
Located local charm "prometheus2", revision 0
Deploying "prometheus2" from local charm "prometheus2", revision 0 on ubuntu@20.04/stable
```
If the base is passed through --base flag, then no error is returned:
```sh
$ juju model-config default-base=""
$ juju deploy  ./prometheus2_r33.charm --constraints="image-id=ubuntu-bf2" --base "ubuntu@20.04"
Located local charm "prometheus2", revision 0
Deploying "prometheus2" from local charm "prometheus2", revision 0 on ubuntu@20.04/stable
```
