### PR TITLE
Go 1.20 in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,7 @@ parts:
   juju:
     # TODO(hpidcock): move to upstream go plugin when it has the features we need.
     plugin: juju-go
-    go-channel: 1.18/stable
+    go-channel: 1.20/stable
     # The source can be your local tree or github
     # source: https://github.com/juju/juju.git
     # If you pull a remote, set source-depth to 1 to make the fetch shorter


### PR DESCRIPTION
Fix missed snapcraft golang version to 1.20 (and to 1.19)

## QA steps

`snapcraft --use-lxd`

## Documentation changes

N/A

## Bug reference

N/A