### PR TITLE
Exporting the status formatter and the corresponding parameter type.

### DIFF
--- a/cmd/juju/machine/base.go
+++ b/cmd/juju/machine/base.go
@@ -77,7 +77,11 @@ func (c *baselistMachinesCommand) Run(ctx *cmd.Context) error {
 		return errors.Errorf("unable to obtain the current status")
 	}
 
-	formatter := status.NewStatusFormatter(fullStatus, c.isoTime)
+	formatter := status.NewStatusFormatter(status.NewStatusFormatterParams{
+		Status:        fullStatus,
+		ISOTime:       c.isoTime,
+		ShowRelations: true,
+	})
 	formatted := formatter.MachineFormat(c.machineIds)
 	return c.out.Write(ctx, formatted)
 }

--- a/cmd/juju/status/formatter.go
+++ b/cmd/juju/status/formatter.go
@@ -37,39 +37,33 @@ type statusFormatter struct {
 	activeBranch      string
 }
 
-// NewStatusFormatter takes stored model information (params.FullStatus) and populates
-// the statusFormatter struct used in various status formatting methods
-func NewStatusFormatter(status *params.FullStatus, isoTime bool) *statusFormatter {
-	return newStatusFormatter(
-		newStatusFormatterParams{
-			status:        status,
-			isoTime:       isoTime,
-			showRelations: true,
-		})
+// NewStatusFormatterParams contains the parameters required
+// to be formatted for CLI output.
+type NewStatusFormatterParams struct {
+	Storage        *storage.CombinedStorage
+	Status         *params.FullStatus
+	ControllerName string
+	OutputName     string
+	ActiveBranch   string
+	ISOTime        bool
+	ShowRelations  bool
 }
 
-type newStatusFormatterParams struct {
-	storage                *storage.CombinedStorage
-	status                 *params.FullStatus
-	controllerName         string
-	outputName             string
-	activeBranch           string
-	isoTime, showRelations bool
-}
-
-func newStatusFormatter(p newStatusFormatterParams) *statusFormatter {
+// NewStatusFormatter returns a new status formatter used in various
+// formatting methods.
+func NewStatusFormatter(p NewStatusFormatterParams) *statusFormatter {
 	sf := statusFormatter{
-		storage:        p.storage,
-		status:         p.status,
-		controllerName: p.controllerName,
+		storage:        p.Storage,
+		status:         p.Status,
+		controllerName: p.ControllerName,
 		relations:      make(map[int]params.RelationStatus),
-		isoTime:        p.isoTime,
-		showRelations:  p.showRelations,
-		outputName:     p.outputName,
-		activeBranch:   p.activeBranch,
+		isoTime:        p.ISOTime,
+		showRelations:  p.ShowRelations,
+		outputName:     p.OutputName,
+		activeBranch:   p.ActiveBranch,
 	}
-	if p.showRelations {
-		for _, relation := range p.status.Relations {
+	if p.ShowRelations {
+		for _, relation := range p.Status.Relations {
 			sf.relations[relation.Id] = relation
 		}
 	}

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -346,29 +346,29 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 			ctx.Infof("provided %s always enabled in non tabular formats", joinedMsg)
 		}
 	}
-	formatterParams := newStatusFormatterParams{
-		status:         status,
-		controllerName: controllerName,
-		outputName:     c.out.Name(),
-		isoTime:        c.isoTime,
-		showRelations:  showRelations,
-		activeBranch:   activeBranch,
+	formatterParams := NewStatusFormatterParams{
+		Status:         status,
+		ControllerName: controllerName,
+		OutputName:     c.out.Name(),
+		ISOTime:        c.isoTime,
+		ShowRelations:  showRelations,
+		ActiveBranch:   activeBranch,
 	}
 	if showStorage {
 		storageInfo, err := c.getStorageInfo(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		formatterParams.storage = storageInfo
+		formatterParams.Storage = storageInfo
 		if storageInfo == nil || storageInfo.Empty() {
 			if c.out.Name() == "tabular" {
 				// hide storage section for tabular view if nothing to show.
-				formatterParams.storage = nil
+				formatterParams.Storage = nil
 			}
 		}
 	}
 
-	formatted, err := newStatusFormatter(formatterParams).Format()
+	formatted, err := NewStatusFormatter(formatterParams).Format()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -6125,7 +6125,10 @@ func (s *StatusSuite) TestFormatProvisioningError(c *gc.C) {
 		ControllerTimestamp: &now,
 	}
 	isoTime := true
-	formatter := NewStatusFormatter(status, isoTime)
+	formatter := NewStatusFormatter(NewStatusFormatterParams{
+		Status:  status,
+		ISOTime: isoTime,
+	})
 	formatted, err := formatter.Format()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -6175,7 +6178,10 @@ func (s *StatusSuite) TestMissingControllerTimestampInFullStatus(c *gc.C) {
 		},
 	}
 	isoTime := true
-	formatter := NewStatusFormatter(status, isoTime)
+	formatter := NewStatusFormatter(NewStatusFormatterParams{
+		Status:  status,
+		ISOTime: isoTime,
+	})
 	formatted, err := formatter.Format()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -6224,7 +6230,11 @@ func (s *StatusSuite) TestControllerTimestampInFullStatus(c *gc.C) {
 		ControllerTimestamp: &now,
 	}
 	isoTime := true
-	formatter := NewStatusFormatter(status, isoTime)
+
+	formatter := NewStatusFormatter(NewStatusFormatterParams{
+		Status:  status,
+		ISOTime: isoTime,
+	})
 	formatted, err := formatter.Format()
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.1
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang/mock v1.6.0
-	github.com/google/go-querystring v1.0.0
+	github.com/google/go-querystring v1.1.0
 	github.com/googleapis/gnostic v0.5.5
 	github.com/gorilla/handlers v0.0.0-20170224193955-13d73096a474
 	github.com/gorilla/schema v0.0.0-20160426231512-08023a0215e7
@@ -164,7 +164,7 @@ require (
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/googleapis/gax-go/v2 v2.3.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
-github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -390,8 +390,9 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
-github.com/googleapis/gax-go/v2 v2.3.0 h1:nRJtk3y8Fm770D42QV6T90ZnvFZyk7agSo3Q+Z9p3WI=
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
+github.com/googleapis/gax-go/v2 v2.4.0 h1:dS9eYAjhrE2RjmzYw2XAPvcXfmcQLtFEQWn0CR82awk=
+github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
@@ -1378,6 +1379,7 @@ google.golang.org/genproto v0.0.0-20220413183235-5e96e2839df9/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220414192740-2d67ff6cf2b4/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
+google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220720214146-176da50484ac h1:EOa+Yrhx1C0O+4pHeXeWrCwdI0tWI6IfUU56Vebs9wQ=
 google.golang.org/genproto v0.0.0-20220720214146-176da50484ac/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=


### PR DESCRIPTION
We want to use the same formatter for model status. By exporting it here, it will save code duplication.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [*] Code style: imports ordered, good names, simple structure, etc
- ~~[] Comments saying why design decisions were made~~
- ~~[] Go unit tests, with comments saying what you're testing~~
- ~~[] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~~
- ~~[] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

1. run `juju status`, make sure it works
2. run `juju status --format json`, make sure it works
3. run `juju status --format yaml`, make sure it works

## Documentation changes

N/A

## Bug reference

N/A
