### PR TITLE
Remove the GO ioutil pkg

### DIFF
--- a/worker/filenotifywatcher/watcher_test.go
+++ b/worker/filenotifywatcher/watcher_test.go
@@ -5,7 +5,6 @@ package filenotifywatcher
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	time "time"
@@ -23,8 +22,7 @@ type watcherSuite struct {
 var _ = gc.Suite(&watcherSuite{})
 
 func (s *watcherSuite) TestWatching(c *gc.C) {
-	dir, err := ioutil.TempDir("", "inotify")
-	c.Assert(err, jc.ErrorIsNil)
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	w, err := NewWatcher("controller", WithPath(dir))
@@ -58,8 +56,7 @@ func (s *watcherSuite) TestWatching(c *gc.C) {
 }
 
 func (s *watcherSuite) TestNotWatching(c *gc.C) {
-	dir, err := ioutil.TempDir("", "inotify")
-	c.Assert(err, jc.ErrorIsNil)
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	w, err := NewWatcher("controller", WithPath(dir))

--- a/worker/filenotifywatcher/watcher_test.go
+++ b/worker/filenotifywatcher/watcher_test.go
@@ -24,6 +24,7 @@ var _ = gc.Suite(&watcherSuite{})
 func (s *watcherSuite) TestWatching(c *gc.C) {
 	dir, err := os.MkdirTemp("", "inotify")
 	c.Assert(err, jc.ErrorIsNil)
+	defer os.RemoveAll(dir)
 
 	w, err := NewWatcher("controller", WithPath(dir))
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/filenotifywatcher/watcher_test.go
+++ b/worker/filenotifywatcher/watcher_test.go
@@ -22,8 +22,8 @@ type watcherSuite struct {
 var _ = gc.Suite(&watcherSuite{})
 
 func (s *watcherSuite) TestWatching(c *gc.C) {
-	dir := os.TempDir()
-	defer os.RemoveAll(dir)
+	dir, err := os.MkdirTemp("", "inotify")
+	c.Assert(err, jc.ErrorIsNil)
 
 	w, err := NewWatcher("controller", WithPath(dir))
 	c.Assert(err, jc.ErrorIsNil)
@@ -56,7 +56,8 @@ func (s *watcherSuite) TestWatching(c *gc.C) {
 }
 
 func (s *watcherSuite) TestNotWatching(c *gc.C) {
-	dir := os.TempDir()
+	dir, err := os.MkdirTemp("", "inotify")
+	c.Assert(err, jc.ErrorIsNil)
 	defer os.RemoveAll(dir)
 
 	w, err := NewWatcher("controller", WithPath(dir))


### PR DESCRIPTION
Remove deprecated ioutil lib form std library.
## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

This a change in a test file, so the tests must keep passing: 
```sh
go test ./worker/filenotifywatcher/watcher_test.go
```
Also all tests must pass as this is a really small change.

## Documentation changes

*How it affects user workflow (CLI or API). Delete section if not applicable.*

## Bug reference

*Link to Launchpad bug. Delete section if not applicable.*
