### PR TITLE
[JUJU-3358] Use tags for login token access map and introduce AccessRequiredError

### DIFF
--- a/apiserver/apiserver_test.go
+++ b/apiserver/apiserver_test.go
@@ -179,8 +179,8 @@ func (s *apiserverConfigFixture) SetUpTest(c *gc.C) {
 			}
 			return 0
 		},
-		HasPermissionFunc: func(operation permission.Access, target names.Tag) (bool, error) {
-			return apiserver.CheckHasPermission(s.State, operation, target)
+		EntityHasPermissionFunc: func(user names.Tag, operation permission.Access, target names.Tag) (bool, error) {
+			return apiserver.CheckHasPermission(s.State, user, operation, target)
 		},
 		SysLogger: noopSysLogger{},
 		DBGetter:  apiserver.StubDBGetter{},

--- a/apiserver/common/crossmodel/mock_test.go
+++ b/apiserver/common/crossmodel/mock_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
-	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 	"gopkg.in/macaroon.v2"
 
@@ -34,18 +33,6 @@ func (m *mockBakery) Auth(mss ...macaroon.Slice) *bakery.AuthChecker {
 
 func (m *mockBakery) NewMacaroon(ctx context.Context, version bakery.Version, caveats []checkers.Caveat, ops ...bakery.Op) (*bakery.Macaroon, error) {
 	return m.Bakery.Oven.NewMacaroon(ctx, version, caveats, ops...)
-}
-
-type mockStatePool struct {
-	st map[string]crossmodel.Backend
-}
-
-func (st *mockStatePool) Get(modelUUID string) (crossmodel.Backend, func(), error) {
-	backend, ok := st.st[modelUUID]
-	if !ok {
-		return nil, nil, errors.NotFoundf("model for uuid %s", modelUUID)
-	}
-	return backend, func() {}, nil
 }
 
 type mockState struct {

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -12,36 +12,6 @@ import (
 	"github.com/juju/juju/state"
 )
 
-// StatePool provides the subset of a state pool.
-type StatePool interface {
-	// Get returns a State for a given model from the pool.
-	Get(modelUUID string) (Backend, func(), error)
-}
-
-type statePoolShim struct {
-	*state.StatePool
-}
-
-func (p *statePoolShim) Get(modelUUID string) (Backend, func(), error) {
-	st, err := p.StatePool.Get(modelUUID)
-	if err != nil {
-		return nil, func() {}, err
-	}
-	closer := func() {
-		st.Release()
-	}
-	model, err := st.Model()
-	if err != nil {
-		closer()
-		return nil, nil, err
-	}
-	return stateShim{st.State, model}, closer, err
-}
-
-func GetStatePool(pool *state.StatePool) StatePool {
-	return &statePoolShim{pool}
-}
-
 // GetBackend wraps a State to provide a Backend interface implementation.
 func GetBackend(st *state.State) stateShim {
 	model, err := st.Model()

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -154,6 +154,7 @@ func ServerError(err error) *params.Error {
 		notLeaderError               *NotLeaderError
 		redirectError                *RedirectError
 		upgradeSeriesValidationError *UpgradeSeriesValidationError
+		accessRequiredError          *AccessRequiredError
 	)
 	// Skip past annotations when looking for the code.
 	err = errors.Cause(err)
@@ -250,6 +251,9 @@ func ServerError(err error) *params.Error {
 		info = notLeaderError.AsMap()
 	case errors.Is(err, DeadlineExceededError):
 		code = params.CodeDeadlineExceeded
+	case errors.As(err, &accessRequiredError):
+		code = params.CodeAccessRequired
+		info = accessRequiredError.AsMap()
 	default:
 		code = params.ErrCode(err)
 	}

--- a/apiserver/errors/types.go
+++ b/apiserver/errors/types.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/permission"
 )
 
 const (
@@ -150,4 +151,24 @@ func NewNotLeaderError(serverAddress, serverID string) error {
 		serverAddress: serverAddress,
 		serverID:      serverID,
 	}
+}
+
+// AccessRequiredError is the error returned when an api
+// request needs a login token with specified permissions.
+type AccessRequiredError struct {
+	RequiredAccess map[names.Tag]permission.Access
+}
+
+// AsMap returns the data for the info part of an error param struct.
+func (e *AccessRequiredError) AsMap() map[string]interface{} {
+	result := make(map[string]interface{})
+	for t, a := range e.RequiredAccess {
+		result[t.String()] = a
+	}
+	return result
+}
+
+// Error implements the error interface.
+func (e *AccessRequiredError) Error() string {
+	return fmt.Sprintf("access permissions required: %v", e.RequiredAccess)
 }

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -208,16 +208,19 @@ func AssertHasPermission(c *gc.C, handler *apiHandler, access permission.Access,
 	c.Assert(hasPermission, gc.Equals, expect)
 }
 
-func CheckHasPermission(st *state.State, operation permission.Access, target names.Tag) (bool, error) {
-	if operation != permission.SuperuserAccess || target.Kind() != names.UserTagKind {
-		return false, errors.Errorf("%s is not a user", names.ReadableString(target))
+func CheckHasPermission(st *state.State, entity names.Tag, operation permission.Access, target names.Tag) (bool, error) {
+	if operation != permission.SuperuserAccess || entity.Kind() != names.UserTagKind {
+		return false, errors.Errorf("%s is not a user", names.ReadableString(entity))
 	}
-	isAdmin, err := st.IsControllerAdmin(target.(names.UserTag))
+	if target.Kind() != names.ControllerTagKind || target.Id() != st.ControllerUUID() {
+		return false, errors.Errorf("%s is not a valid controller", names.ReadableString(target))
+	}
+	isAdmin, err := st.IsControllerAdmin(entity.(names.UserTag))
 	if err != nil {
 		return false, err
 	}
 	if !isAdmin {
-		return false, errors.Errorf("%s is not a controller admin", names.ReadableString(target))
+		return false, errors.Errorf("%s is not a controller admin", names.ReadableString(entity))
 	}
 	return true, nil
 }

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -200,6 +200,10 @@ type Authorizer interface {
 	// target by the authenticated entity.
 	HasPermission(operation permission.Access, target names.Tag) (bool, error)
 
+	// EntityHasPermission reports whether the given access is allowed for the given
+	// target by the given entity.
+	EntityHasPermission(entity names.Tag, operation permission.Access, target names.Tag) (bool, error)
+
 	// ConnectedModel returns the UUID of the model to which the API
 	// connection was made.
 	ConnectedModel() string

--- a/apiserver/facade/mocks/facade_mock.go
+++ b/apiserver/facade/mocks/facade_mock.go
@@ -213,6 +213,21 @@ func (mr *MockAuthorizerMockRecorder) ConnectedModel() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectedModel", reflect.TypeOf((*MockAuthorizer)(nil).ConnectedModel))
 }
 
+// EntityHasPermission mocks base method.
+func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EntityHasPermission indicates an expected call of EntityHasPermission.
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+}
+
 // GetAuthTag mocks base method.
 func (m *MockAuthorizer) GetAuthTag() names.Tag {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -40,7 +40,7 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, thirdPartyKey, s.bakery)
+	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 
 	api, err := applicationoffers.CreateOffersAPI(

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -57,7 +57,7 @@ func (s *applicationOffersSuite) SetUpTest(c *gc.C) {
 	var err error
 	s.bakery = &mockBakeryService{caveats: make(map[string][]checkers.Caveat)}
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, thirdPartyKey, s.bakery)
+	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,
@@ -464,6 +464,7 @@ func (s *applicationOffersSuite) TestShow(c *gc.C) {
 	s.assertShow(c, "fred@external/prod.hosted-db2", expected)
 	// Again with an unqualified model path.
 	s.mockState.AdminTag = names.NewUserTag("fred@external")
+	s.authorizer.AdminTag = s.mockState.AdminTag
 	s.authorizer.Tag = s.mockState.AdminTag
 	expected[0].Result.Users[0].UserName = "fred@external"
 	s.applicationOffers.ResetCalls()
@@ -1149,7 +1150,7 @@ func (s *consumeSuite) SetUpTest(c *gc.C) {
 	}
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = crossmodel.NewAuthContext(&mockCommonStatePool{s.mockStatePool}, thirdPartyKey, s.bakery)
+	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := applicationoffers.CreateOffersAPI(
 		getApplicationOffers, getEnviron, getFakeControllerInfo,

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v4"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -38,7 +37,7 @@ type BaseAPI struct {
 
 // checkPermission ensures that the logged in user holds the given permission on an entity.
 func (api *BaseAPI) checkPermission(user names.UserTag, tag names.Tag, perm permission.Access) error {
-	allowed, err := common.HasPermission(api.ControllerModel.UserPermission, user, perm, tag)
+	allowed, err := api.Authorizer.EntityHasPermission(user, perm, tag)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/applicationoffers/mock_test.go
+++ b/apiserver/facades/client/applicationoffers/mock_test.go
@@ -487,14 +487,6 @@ func (st *mockStatePool) GetModel(modelUUID string) (applicationoffers.Model, fu
 	return model, func() {}, nil
 }
 
-type mockCommonStatePool struct {
-	*mockStatePool
-}
-
-func (st *mockCommonStatePool) Get(modelUUID string) (crossmodel.Backend, func(), error) {
-	return st.mockStatePool.Get(modelUUID)
-}
-
 type mockBakeryService struct {
 	authentication.ExpirableStorageBakery
 	jtesting.Stub

--- a/apiserver/facades/client/applicationoffers/register.go
+++ b/apiserver/facades/client/applicationoffers/register.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/common"
 	commoncrossmodel "github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facade"

--- a/apiserver/facades/client/client/mocks/facade_mock.go
+++ b/apiserver/facades/client/client/mocks/facade_mock.go
@@ -147,6 +147,21 @@ func (mr *MockAuthorizerMockRecorder) ConnectedModel() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectedModel", reflect.TypeOf((*MockAuthorizer)(nil).ConnectedModel))
 }
 
+// EntityHasPermission mocks base method.
+func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EntityHasPermission indicates an expected call of EntityHasPermission.
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+}
+
 // GetAuthTag mocks base method.
 func (m *MockAuthorizer) GetAuthTag() names.Tag {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/sshclient/mocks/authorizer_mock.go
+++ b/apiserver/facades/client/sshclient/mocks/authorizer_mock.go
@@ -147,6 +147,21 @@ func (mr *MockAuthorizerMockRecorder) ConnectedModel() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectedModel", reflect.TypeOf((*MockAuthorizer)(nil).ConnectedModel))
 }
 
+// EntityHasPermission mocks base method.
+func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EntityHasPermission indicates an expected call of EntityHasPermission.
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+}
+
 // GetAuthTag mocks base method.
 func (m *MockAuthorizer) GetAuthTag() names.Tag {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
@@ -154,6 +154,21 @@ func (mr *MockAuthorizerMockRecorder) ConnectedModel() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectedModel", reflect.TypeOf((*MockAuthorizer)(nil).ConnectedModel))
 }
 
+// EntityHasPermission mocks base method.
+func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EntityHasPermission indicates an expected call of EntityHasPermission.
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+}
+
 // GetAuthTag mocks base method.
 func (m *MockAuthorizer) GetAuthTag() names.Tag {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -41,13 +41,12 @@ var _ = gc.Suite(&crossmodelRelationsSuite{})
 type crossmodelRelationsSuite struct {
 	coretesting.BaseSuite
 
-	resources     *common.Resources
-	authorizer    *apiservertesting.FakeAuthorizer
-	st            *mockState
-	mockStatePool *mockStatePool
-	bakery        *mockBakeryService
-	authContext   *commoncrossmodel.AuthContext
-	api           *crossmodelrelations.CrossModelRelationsAPI
+	resources   *common.Resources
+	authorizer  *apiservertesting.FakeAuthorizer
+	st          *mockState
+	bakery      *mockBakeryService
+	authContext *commoncrossmodel.AuthContext
+	api         *crossmodelrelations.CrossModelRelationsAPI
 
 	watchedRelations       params.Entities
 	watchedOffers          []string
@@ -67,7 +66,6 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	}
 
 	s.st = newMockState()
-	s.mockStatePool = &mockStatePool{map[string]commoncrossmodel.Backend{coretesting.ModelTag.Id(): s.st}}
 	fw := &mockFirewallState{}
 	egressAddressWatcher := func(_ facade.Resources, fws firewall.State, relations params.Entities) (params.StringsWatchResults, error) {
 		c.Assert(fw, gc.Equals, fws)
@@ -97,7 +95,7 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	}
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = commoncrossmodel.NewAuthContext(s.mockStatePool, thirdPartyKey, s.bakery)
+	s.authContext, err = commoncrossmodel.NewAuthContext(s.st, thirdPartyKey, s.bakery)
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := crossmodelrelations.NewCrossModelRelationsAPI(
 		s.st, fw, s.resources, s.authorizer,

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -32,18 +32,6 @@ import (
 	coretesting "github.com/juju/juju/testing"
 )
 
-type mockStatePool struct {
-	st map[string]commoncrossmodel.Backend
-}
-
-func (st *mockStatePool) Get(modelUUID string) (commoncrossmodel.Backend, func(), error) {
-	backend, ok := st.st[modelUUID]
-	if !ok {
-		return nil, nil, errors.NotFoundf("model for uuid %s", modelUUID)
-	}
-	return backend, func() {}, nil
-}
-
 type mockState struct {
 	testing.Stub
 	crossmodelrelations.CrossModelRelationsState

--- a/apiserver/localofferauth.go
+++ b/apiserver/localofferauth.go
@@ -80,7 +80,7 @@ func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error)
 		localOfferBakery, location, localOfferBakeryKey, store, locator,
 	}
 	authCtx, err := crossmodel.NewAuthContext(
-		crossmodel.GetStatePool(pool), key, offerBakery)
+		crossmodel.GetBackend(st), key, offerBakery)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -55,7 +55,7 @@ type sharedServerContext struct {
 
 	unsubscribe func()
 
-	hasPermission hasPermissionFunc
+	entityHasPermission entityHasPermissionFunc
 }
 
 type sharedServerConfig struct {
@@ -69,7 +69,7 @@ type sharedServerConfig struct {
 	logger              loggo.Logger
 	charmhubHTTPClient  facade.HTTPClient
 	dbGetter            coredatabase.DBGetter
-	hasPermission       hasPermissionFunc
+	entityHasPermission entityHasPermissionFunc
 }
 
 func (c *sharedServerConfig) validate() error {
@@ -115,7 +115,7 @@ func newSharedServerContext(config sharedServerConfig) (*sharedServerContext, er
 		controllerConfig:    config.controllerConfig,
 		charmhubHTTPClient:  config.charmhubHTTPClient,
 		dbGetter:            config.dbGetter,
-		hasPermission:       config.hasPermission,
+		entityHasPermission: config.entityHasPermission,
 	}
 	ctx.features = config.controllerConfig.Features()
 	// We are able to get the current controller config before subscribing to changes

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -156,8 +156,8 @@ func (s *sharedServerContextSuite) newContext(c *gc.C) *sharedServerContext {
 	ctx, err := newSharedServerContext(s.config)
 	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(*gc.C) { ctx.Close() })
-	ctx.hasPermission = func(operation permission.Access, target names.Tag) (bool, error) {
-		return CheckHasPermission(s.State, operation, target)
+	ctx.entityHasPermission = func(entity names.Tag, operation permission.Access, target names.Tag) (bool, error) {
+		return CheckHasPermission(s.State, entity, operation, target)
 	}
 	return ctx
 }

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -131,3 +131,16 @@ func nameBasedHasPermission(name string, operation permission.Access, target nam
 func (fa FakeAuthorizer) ConnectedModel() string {
 	return fa.ModelUUID
 }
+
+// EntityHasPermission returns true if the passed entity is admin or has a name equal to
+// the pre-set admin tag.
+func (fa FakeAuthorizer) EntityHasPermission(entity names.Tag, operation permission.Access, target names.Tag) (bool, error) {
+	if entity.Kind() == names.UserTagKind && entity.Id() == "admin" {
+		return true, nil
+	}
+	emptyTag := names.UserTag{}
+	if fa.AdminTag != emptyTag && entity == fa.AdminTag {
+		return true, nil
+	}
+	return false, nil
+}

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -63,6 +63,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"core/network",
 		"core/os",
 		"core/paths",
+		"core/permission",
 		"core/relation",
 		"core/resources",
 		"core/secrets",

--- a/rpc/params/apierror.go
+++ b/rpc/params/apierror.go
@@ -209,9 +209,9 @@ const (
 	CodeQuotaLimitExceeded        = "quota limit exceeded"
 	CodeNotLeader                 = "not leader"
 	CodeDeadlineExceeded          = "deadline exceeded"
-	CodeLeaseError                = "lease error"
 	CodeNotYetAvailable           = "not yet available; try again later"
 	CodeNotValid                  = "not valid"
+	CodeAccessRequired            = "access required"
 )
 
 // TranslateWellKnownError translates well known wire error codes into a github.com/juju/errors error


### PR DESCRIPTION
Tweak the jwt login access map to expect controller and model tags instead of kind. This means that when cloud and offer tags are added, the access map is consistent.

Also introduce a AccessRequiredError to return across the wire when an api request is made and the login token does not have the necessary permissions. The error response will include what permissions are required, allowing the caller to try again with an updated login token.

And a small fix to bring the reported model permission in the login result in line with non-token logins.

## QA steps

Will be validated by the JAAS folks.