### PR TITLE
[JUJU-3377] Ensure we call timer reset

### DIFF
--- a/worker/dbaccessor/package_test.go
+++ b/worker/dbaccessor/package_test.go
@@ -52,7 +52,7 @@ func (s *baseSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *baseSuite) expectAnyLogs() {
 	s.logger.EXPECT().Errorf(gomock.Any()).AnyTimes()
-	s.logger.EXPECT().Warningf(gomock.Any()).AnyTimes()
+	s.logger.EXPECT().Warningf(gomock.Any(), gomock.Any()).AnyTimes()
 	s.logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
 	s.logger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 	s.logger.EXPECT().Logf(gomock.Any(), gomock.Any()).AnyTimes()
@@ -65,8 +65,6 @@ func (s *baseSuite) expectClock() {
 
 func (s *baseSuite) setupTimer() chan time.Time {
 	s.timer.EXPECT().Stop().MinTimes(1)
-	s.timer.EXPECT().Reset(gomock.Any()).AnyTimes()
-
 	s.clock.EXPECT().NewTimer(PollInterval).Return(s.timer)
 
 	ch := make(chan time.Time)


### PR DESCRIPTION
The trackedDBWorker was missing a `timer.Reset` once a verification had occurred. Luckily, a CR spotted this before it ever reached production.

The code is simple, it just calls `timer.Reset` at the end of the timer loop. The tests were changed to ensure that the reset was called with the right interval and the right number of times.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass.

```sh
$ juju bootstrap lxd test --build-agent
$ juju debug-log -m controller
```
