### PR TITLE
[JUJU-3382] Fix endpoint parse at lxd bootstrap

### DIFF
--- a/provider/lxd/environ.go
+++ b/provider/lxd/environ.go
@@ -6,7 +6,6 @@ package lxd
 import (
 	stdcontext "context"
 	"net"
-	"net/netip"
 	"net/url"
 	"runtime"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/juju/utils/v3/arch"
 	"github.com/lxc/lxd/shared/api"
 
+	"github.com/juju/juju/container/lxd"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/network"
@@ -471,31 +471,37 @@ func (env *environ) DetectSeries() (string, error) {
 
 // DetectHardware returns the hardware characteristics for the controller for
 // this environment. This method is part of the environs.HardwareCharacteristicsDetector
-// interface. On an LXD cloud, it must first check if it is a localhost cloud,
-// in that case, we only fill the Arch.
+// interface. On an LXD cloud, it must first check if it is a local cloud, in
+// that case, we only fill the Arch constraint.
+// This method should always return nil errors, because it is run during
+// bootstrap and its only purpose is to update the Arch constraint so in case
+// of an error the default arch is used and the bootstrap can continue.
 func (env *environ) DetectHardware() (*instance.HardwareCharacteristics, error) {
-	// The returned error is willingly ignored, because this should not
-	// break bootstrapping (we detect hardware before bootstrapping),
-	// instead, bootstrapping should fallback to default hardware arch.
-	var endpointIP net.IP
-	endpointURL, err := url.Parse(env.cloud.Endpoint)
+	// In order to determine if this is a local lxd cloud, we need to
+	// extract its endpoint IP.
+	// The endpoint can be formatted either as https://host:port,
+	// https://host, host:port, host, https://IP:port, https://IP,
+	// IP:port, or only IP, so we try to parse it as a URL but first
+	// ensuring it contains the correct scheme.
+	endpointURL, err := url.Parse(lxd.EnsureHTTPS(env.cloud.Endpoint))
 	if err != nil {
-		addrPort, err := netip.ParseAddrPort(env.cloud.Endpoint)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		endpointIP = net.ParseIP(addrPort.Addr().String())
-	} else {
-		endpointIP = net.ParseIP(endpointURL.Hostname())
+		logger.Debugf("error parsing endpoint as url: %s", err.Error())
+		return nil, nil
 	}
+	endpointIP := net.ParseIP(endpointURL.Hostname())
 	if endpointIP == nil {
 		return nil, nil
 	}
+	// The returned error is deliberately ignored, because this should not
+	// break bootstrapping (we detect hardware before bootstrapping),
+	// instead, bootstrapping should fallback to default hardware arch.
 	isLocal, _ := network.IsLocalAddress(endpointIP)
 	if !isLocal {
 		return nil, nil
 	}
-
+	// If the host is a local IP address, then we set the
+	// arch to be the runtime.GOARCH on the returned
+	// HardwareCharacteristics.
 	arch := arch.NormaliseArch(runtime.GOARCH)
 	return &instance.HardwareCharacteristics{
 		Arch: &arch,
@@ -503,8 +509,9 @@ func (env *environ) DetectHardware() (*instance.HardwareCharacteristics, error) 
 
 }
 
-// UpdateModelConstraints always returns false because we don't want to update
-// model constraints for manual env.
+// UpdateModelConstraints always returns true for lxd clusters because it will
+// need to update Arch constraint in the case of a local lxd cluster according
+// to DetectHardware().
 func (e *environ) UpdateModelConstraints() bool {
 	return true
 }

--- a/provider/lxd/environ_broker_test.go
+++ b/provider/lxd/environ_broker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/series"
+	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/lxd"
 )
@@ -99,7 +100,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 		exp.HostArch().Return(arch.AMD64),
 	)
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	_, err := env.StartInstance(s.callCtx, s.GetStartInstanceArgs(c))
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -138,7 +139,7 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 		exp.HostArch().Return(arch.AMD64),
 	)
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	_, err := env.StartInstance(s.callCtx, s.GetStartInstanceArgs(c))
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -210,7 +211,7 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 		exp.HostArch().Return(arch.AMD64),
 	)
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	startArgs := s.GetStartInstanceArgs(c)
 	startArgs.SubnetsToZones = []map[network.Id][]string{
 		// The following are bogus subnet names that shouldn't
@@ -285,7 +286,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 	tExp.UpdateInstanceState(gomock.Any(), gomock.Any(), "").Return(startOp, nil)
 	tExp.GetInstance(gomock.Any()).Return(&api.Instance{Type: "container"}, lxdtesting.ETag, nil)
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 
 	args := s.GetStartInstanceArgs(c)
 	args.Placement = "zone=node01"
@@ -311,7 +312,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotPresent(c *gc.C) {
 		sExp.GetClusterMembers().Return(members, nil),
 	)
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 
 	args := s.GetStartInstanceArgs(c)
 	args.Placement = "zone=node03"
@@ -337,7 +338,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementNotAvailable(c *gc.C)
 		sExp.GetClusterMembers().Return(members, nil),
 	)
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 
 	args := s.GetStartInstanceArgs(c)
 	args.Placement = "zone=node01"
@@ -355,7 +356,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementBadArgument(c *gc.C) 
 	gomock.InOrder(
 		sExp.HostArch().Return(arch.AMD64),
 	)
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 
 	args := s.GetStartInstanceArgs(c)
 	args.Placement = "breakfast=eggs"
@@ -401,7 +402,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 		InstanceType: &it,
 	}
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	_, err := env.StartInstance(s.callCtx, args)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -443,7 +444,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndVirtType(c *gc.C
 		VirtType:     &virtType,
 	}
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	_, err := env.StartInstance(s.callCtx, args)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -481,7 +482,7 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *gc.C) {
 	args := s.GetStartInstanceArgs(c)
 	args.CharmLXDProfiles = []string{"juju-model-test-0"}
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	_, err := env.StartInstance(s.callCtx, args)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -494,7 +495,7 @@ func (s *environBrokerSuite) TestStartInstanceNoTools(c *gc.C) {
 	exp := svr.EXPECT()
 	exp.HostArch().Return(arch.PPC64EL)
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	_, err := env.StartInstance(s.callCtx, s.GetStartInstanceArgs(c))
 	c.Assert(err, gc.ErrorMatches, "no matching agent binaries available")
 }
@@ -514,7 +515,7 @@ func (s *environBrokerSuite) TestStartInstanceInvalidCredentials(c *gc.C) {
 		exp.CreateContainerFromSpec(gomock.Any()).Return(&containerlxd.Container{}, fmt.Errorf("not authorized")),
 	)
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	_, err := env.StartInstance(s.callCtx, s.GetStartInstanceArgs(c))
 	c.Assert(err, gc.ErrorMatches, "not authorized")
 	c.Assert(s.invalidCredential, jc.IsTrue)
@@ -527,7 +528,7 @@ func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
 
 	svr.EXPECT().RemoveContainers([]string{"juju-f75cba-1", "juju-f75cba-2"})
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	err := env.StopInstances(s.callCtx, "juju-f75cba-1", "juju-f75cba-2", "not-in-namespace-so-ignored")
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -540,7 +541,7 @@ func (s *environBrokerSuite) TestStopInstancesInvalidCredentials(c *gc.C) {
 
 	svr.EXPECT().RemoveContainers([]string{"juju-f75cba-1", "juju-f75cba-2"}).Return(fmt.Errorf("not authorized"))
 
-	env := s.NewEnviron(c, svr, nil)
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	err := env.StopInstances(s.callCtx, "juju-f75cba-1", "juju-f75cba-2", "not-in-namespace-so-ignored")
 	c.Assert(err, gc.ErrorMatches, "not authorized")
 	c.Assert(s.invalidCredential, jc.IsTrue)
@@ -551,7 +552,7 @@ func (s *environBrokerSuite) TestImageSourcesDefault(c *gc.C) {
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
 
-	sources, err := lxd.GetImageSources(s.NewEnviron(c, svr, nil))
+	sources, err := lxd.GetImageSources(s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{}))
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.checkSources(c, sources, []string{
@@ -567,7 +568,7 @@ func (s *environBrokerSuite) TestImageMetadataURL(c *gc.C) {
 
 	env := s.NewEnviron(c, svr, map[string]interface{}{
 		"image-metadata-url": "https://my-test.com/images/",
-	})
+	}, environscloudspec.CloudSpec{})
 
 	sources, err := lxd.GetImageSources(env)
 	c.Assert(err, jc.ErrorIsNil)
@@ -587,7 +588,7 @@ func (s *environBrokerSuite) TestImageMetadataURLEnsuresHTTPS(c *gc.C) {
 	// HTTP should be converted to HTTPS.
 	env := s.NewEnviron(c, svr, map[string]interface{}{
 		"image-metadata-url": "http://my-test.com/images/",
-	})
+	}, environscloudspec.CloudSpec{})
 
 	sources, err := lxd.GetImageSources(env)
 	c.Assert(err, jc.ErrorIsNil)
@@ -606,7 +607,7 @@ func (s *environBrokerSuite) TestImageStreamReleased(c *gc.C) {
 
 	env := s.NewEnviron(c, svr, map[string]interface{}{
 		"image-stream": "released",
-	})
+	}, environscloudspec.CloudSpec{})
 
 	sources, err := lxd.GetImageSources(env)
 	c.Assert(err, jc.ErrorIsNil)
@@ -624,7 +625,7 @@ func (s *environBrokerSuite) TestImageStreamDaily(c *gc.C) {
 
 	env := s.NewEnviron(c, svr, map[string]interface{}{
 		"image-stream": "daily",
-	})
+	}, environscloudspec.CloudSpec{})
 
 	sources, err := lxd.GetImageSources(env)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/lxd/environ_network_test.go
+++ b/provider/lxd/environ_network_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
+	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/lxd"
 )
@@ -31,7 +32,7 @@ func (s *environNetSuite) TestSubnetsForUnknownContainer(c *gc.C) {
 	srv := lxd.NewMockServer(ctrl)
 	srv.EXPECT().FilterContainers("bogus").Return(nil, nil)
 
-	env := s.NewEnviron(c, srv, nil).(environs.Networking)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}).(environs.Networking)
 
 	ctx := context.NewEmptyCloudCallContext()
 	_, err := env.Subnets(ctx, "bogus", nil)
@@ -44,7 +45,7 @@ func (s *environNetSuite) TestSubnetsForServersThatLackRequiredAPIExtensions(c *
 
 	srv := lxd.NewMockServer(ctrl)
 
-	env := s.NewEnviron(c, srv, nil).(environs.Networking)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}).(environs.Networking)
 	ctx := context.NewEmptyCloudCallContext()
 
 	// Space support and by extension, subnet detection is not available.
@@ -121,7 +122,7 @@ func (s *environNetSuite) TestSubnetsForKnownContainer(c *gc.C) {
 		},
 	}, nil)
 
-	env := s.NewEnviron(c, srv, nil).(environs.Networking)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}).(environs.Networking)
 
 	ctx := context.NewEmptyCloudCallContext()
 	subnets, err := env.Subnets(ctx, "woot", nil)
@@ -186,7 +187,7 @@ func (s *environNetSuite) TestSubnetsForKnownContainerAndSubnetFiltering(c *gc.C
 		},
 	}, nil)
 
-	env := s.NewEnviron(c, srv, nil).(environs.Networking)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}).(environs.Networking)
 
 	// Filter list so we only get a single subnet
 	ctx := context.NewEmptyCloudCallContext()
@@ -281,7 +282,7 @@ func (s *environNetSuite) TestSubnetDiscoveryFallbackForOlderLXDs(c *gc.C) {
 		},
 	}, "etag", nil)
 
-	env := s.NewEnviron(c, srv, nil).(environs.Networking)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}).(environs.Networking)
 
 	ctx := context.NewEmptyCloudCallContext()
 
@@ -377,7 +378,7 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 		},
 	}, "etag", nil)
 
-	env := s.NewEnviron(c, srv, nil).(environs.Networking)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}).(environs.Networking)
 
 	ctx := context.NewEmptyCloudCallContext()
 	infos, err := env.NetworkInterfaces(ctx, []instance.Id{"woot"})
@@ -453,7 +454,7 @@ func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
 		},
 	}, "etag", nil)
 
-	env := s.NewEnviron(c, srv, nil).(environs.Networking)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}).(environs.Networking)
 
 	ctx := context.NewEmptyCloudCallContext()
 	infos, err := env.NetworkInterfaces(ctx, []instance.Id{"woot", "unknown"})
@@ -489,7 +490,7 @@ func (s *environNetSuite) TestNetworkInterfacesNoResults(c *gc.C) {
 	srv.EXPECT().GetInstance("unknown1").Return(nil, "", errors.New("not found"))
 	srv.EXPECT().GetInstance("unknown2").Return(nil, "", errors.New("not found"))
 
-	env := s.NewEnviron(c, srv, nil).(environs.Networking)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}).(environs.Networking)
 
 	ctx := context.NewEmptyCloudCallContext()
 	_, err := env.NetworkInterfaces(ctx, []instance.Id{"unknown1", "unknown2"})

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs"
+	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/provider/lxd"
 	"github.com/juju/juju/version"
@@ -243,7 +244,7 @@ func (s *environPolicySuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.svr = lxd.NewMockServer(ctrl)
 	s.svr.EXPECT().SupportedArches().Return([]string{arch.AMD64}).MaxTimes(1)
 
-	s.env = s.NewEnviron(c, s.svr, nil)
+	s.env = s.NewEnviron(c, s.svr, nil, environscloudspec.CloudSpec{})
 
 	return ctrl
 }

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs"
+	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	envcontext "github.com/juju/juju/environs/context"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/provider/lxd"
@@ -464,7 +465,7 @@ type environProfileSuite struct {
 var _ = gc.Suite(&environProfileSuite{})
 
 func (s *environProfileSuite) TestMaybeWriteLXDProfileYes(c *gc.C) {
-	defer s.setup(c).Finish()
+	defer s.setup(c, environscloudspec.CloudSpec{}).Finish()
 
 	profile := "testname"
 	s.expectMaybeWriteLXDProfile(false, profile)
@@ -479,7 +480,7 @@ func (s *environProfileSuite) TestMaybeWriteLXDProfileYes(c *gc.C) {
 }
 
 func (s *environProfileSuite) TestMaybeWriteLXDProfileNo(c *gc.C) {
-	defer s.setup(c).Finish()
+	defer s.setup(c, environscloudspec.CloudSpec{}).Finish()
 
 	profile := "testname"
 	s.expectMaybeWriteLXDProfile(true, profile)
@@ -489,7 +490,7 @@ func (s *environProfileSuite) TestMaybeWriteLXDProfileNo(c *gc.C) {
 }
 
 func (s *environProfileSuite) TestLXDProfileNames(c *gc.C) {
-	defer s.setup(c).Finish()
+	defer s.setup(c, environscloudspec.CloudSpec{}).Finish()
 
 	exp := s.svr.EXPECT()
 	exp.GetContainerProfiles("testname").Return([]string{
@@ -504,7 +505,7 @@ func (s *environProfileSuite) TestLXDProfileNames(c *gc.C) {
 }
 
 func (s *environProfileSuite) TestAssignLXDProfiles(c *gc.C) {
-	defer s.setup(c).Finish()
+	defer s.setup(c, environscloudspec.CloudSpec{}).Finish()
 
 	instId := "testme"
 	oldP := "old-profile"
@@ -531,7 +532,7 @@ func (s *environProfileSuite) TestAssignLXDProfiles(c *gc.C) {
 }
 
 func (s *environProfileSuite) TestAssignLXDProfilesErrorReturnsCurrent(c *gc.C) {
-	defer s.setup(c).Finish()
+	defer s.setup(c, environscloudspec.CloudSpec{}).Finish()
 
 	instId := "testme"
 	oldP := "old-profile"
@@ -559,10 +560,78 @@ func (s *environProfileSuite) TestAssignLXDProfilesErrorReturnsCurrent(c *gc.C) 
 	c.Assert(obtained, gc.DeepEquals, []string{"default", "juju-default", oldP})
 }
 
-func (s *environProfileSuite) setup(c *gc.C) *gomock.Controller {
+func (s *environProfileSuite) TestDetectCorrectHardwareEndpointIPPort(c *gc.C) {
+	defer s.setup(c, environscloudspec.CloudSpec{
+		Endpoint: "1.1.1.1:8888",
+	}).Finish()
+
+	detector, supported := s.lxdEnv.(environs.HardwareCharacteristicsDetector)
+	c.Assert(supported, jc.IsTrue)
+
+	hc, err := detector.DetectHardware()
+	c.Assert(err, gc.IsNil)
+	// 1.1.1.1 is not a local IP address, so we don't set ARCH in hc
+	c.Assert(hc, gc.IsNil)
+}
+
+func (s *environProfileSuite) TestDetectCorrectHardwareEndpointSchemeIPPort(c *gc.C) {
+	defer s.setup(c, environscloudspec.CloudSpec{
+		Endpoint: "http://1.1.1.1:8888",
+	}).Finish()
+
+	detector, supported := s.lxdEnv.(environs.HardwareCharacteristicsDetector)
+	c.Assert(supported, jc.IsTrue)
+
+	hc, err := detector.DetectHardware()
+	c.Assert(err, gc.IsNil)
+	// 1.1.1.1 is not a local IP address, so we don't set ARCH in hc
+	c.Assert(hc, gc.IsNil)
+}
+func (s *environProfileSuite) TestDetectCorrectHardwareEndpointHostPort(c *gc.C) {
+	defer s.setup(c, environscloudspec.CloudSpec{
+		Endpoint: "localhost:8888",
+	}).Finish()
+
+	detector, supported := s.lxdEnv.(environs.HardwareCharacteristicsDetector)
+	c.Assert(supported, jc.IsTrue)
+
+	hc, err := detector.DetectHardware()
+	c.Assert(err, gc.IsNil)
+	// localhost is not considered as a local IP address, so we don't set ARCH in hc
+	c.Assert(hc, gc.IsNil)
+}
+
+func (s *environProfileSuite) TestDetectCorrectHardwareEndpointSchemeHostPort(c *gc.C) {
+	defer s.setup(c, environscloudspec.CloudSpec{
+		Endpoint: "http://localhost:8888",
+	}).Finish()
+
+	detector, supported := s.lxdEnv.(environs.HardwareCharacteristicsDetector)
+	c.Assert(supported, jc.IsTrue)
+
+	hc, err := detector.DetectHardware()
+	c.Assert(err, gc.IsNil)
+	// localhost is not considered as a local IP address, so we don't set ARCH in hc
+	c.Assert(hc, gc.IsNil)
+}
+
+func (s *environProfileSuite) TestDetectCorrectHardwareWrongEndpoint(c *gc.C) {
+	defer s.setup(c, environscloudspec.CloudSpec{
+		Endpoint: "1.1:8888",
+	}).Finish()
+
+	detector, supported := s.lxdEnv.(environs.HardwareCharacteristicsDetector)
+	c.Assert(supported, jc.IsTrue)
+
+	hc, err := detector.DetectHardware()
+	c.Assert(err, gc.ErrorMatches, ".*IPv4 address too short")
+	c.Assert(hc, gc.IsNil)
+}
+
+func (s *environProfileSuite) setup(c *gc.C, cloudSpec environscloudspec.CloudSpec) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.svr = lxd.NewMockServer(ctrl)
-	lxdEnv, ok := s.NewEnviron(c, s.svr, nil).(environs.LXDProfiler)
+	lxdEnv, ok := s.NewEnviron(c, s.svr, nil, cloudSpec).(environs.LXDProfiler)
 	c.Assert(ok, jc.IsTrue)
 	s.lxdEnv = lxdEnv
 

--- a/provider/lxd/testing_test.go
+++ b/provider/lxd/testing_test.go
@@ -739,7 +739,7 @@ type EnvironSuite struct {
 	testing.BaseSuite
 }
 
-func (s *EnvironSuite) NewEnviron(c *gc.C, srv Server, cfgEdit map[string]interface{}) environs.Environ {
+func (s *EnvironSuite) NewEnviron(c *gc.C, srv Server, cfgEdit map[string]interface{}, cloudSpec environscloudspec.CloudSpec) environs.Environ {
 	cfg, err := testing.ModelConfig(c).Apply(ConfigAttrs)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -759,6 +759,7 @@ func (s *EnvironSuite) NewEnviron(c *gc.C, srv Server, cfgEdit map[string]interf
 		serverUnlocked: srv,
 		ecfgUnlocked:   eCfg,
 		namespace:      namespace,
+		cloud:          cloudSpec,
 	}
 }
 


### PR DESCRIPTION
When bootstrapping lxd, we detect the hardware charachteristics in order to define if we are running a local lxd cluster and therefore set the arch accordingly.

The DetectHardware method was incorrect since it didn't parse the endpoint correctly and panicked at bootstrap, this is fixed by accepting different types of endpoint formats, as the added tests show.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing


## QA steps

Firstly, create a new lxd cloud with `$ juju add-cloud` and set an endpoint like (`https://10.101.77.1:8443`) as well as a fake credential for that cloud.

Then edit `~/.local/share/juju/clouds.yaml` to modify the endpoints in the newly created lxd cloud to remove the `https` scheme:
```yaml
clouds:
  lxd-test:
    type: lxd
    auth-types: [certificate]
    endpoint: 10.101.77.1:8443
    regions:
      default:
        endpoint: 10.101.77.1:8443
```

Then when you try to bootstrap this cloud you should see:
```sh
$ juju bootstrap lxd-test
Creating Juju controller "lxd-test-default" on lxd-test/default
Looking for packaged Juju agent version 3.1.2 for amd64
```
Instead of a panic.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2013049
