### PR TITLE
[JUJU-3009] Refactor change-user-password command docs

### DIFF
--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -39,20 +39,14 @@ This will invalidate any passwords that were previously set
 and registration strings that were previously issued for a user.
 This option will issue a new registration string to be used with
 ` + "`juju register`" + `.  
+`
 
-
-Examples:
-
+const examples = `
     juju change-user-password
     juju change-user-password bob
     juju change-user-password bob --reset
     juju change-user-password -c another-known-controller
     juju change-user-password bob --controller another-known-controller
-
-See also:
-    add-user
-    register
-
 `
 
 func NewChangePasswordCommand() cmd.Command {
@@ -84,10 +78,15 @@ func (c *changePasswordCommand) SetFlags(f *gnuflag.FlagSet) {
 // Info implements Command.Info.
 func (c *changePasswordCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "change-user-password",
-		Args:    "[username]",
-		Purpose: "Changes the password for the current or specified Juju user.",
-		Doc:     userChangePasswordDoc,
+		Name:     "change-user-password",
+		Args:     "[username]",
+		Purpose:  "Changes the password for the current or specified Juju user.",
+		Doc:      userChangePasswordDoc,
+		Examples: examples,
+		SeeAlso: []string{
+			"add-user",
+			"register",
+		},
 	})
 }
 

--- a/cmd/juju/user/change_password.go
+++ b/cmd/juju/user/change_password.go
@@ -41,7 +41,7 @@ This option will issue a new registration string to be used with
 ` + "`juju register`" + `.  
 `
 
-const examples = `
+const examplesChangePassword = `
     juju change-user-password
     juju change-user-password bob
     juju change-user-password bob --reset
@@ -82,7 +82,7 @@ func (c *changePasswordCommand) Info() *cmd.Info {
 		Args:     "[username]",
 		Purpose:  "Changes the password for the current or specified Juju user.",
 		Doc:      userChangePasswordDoc,
-		Examples: examples,
+		Examples: examplesChangePassword,
 		SeeAlso: []string{
 			"add-user",
 			"register",


### PR DESCRIPTION
Moved Examples and See also to fields inside Info.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

 Run `juju documentation --split --out=tmp` 

## Documentation changes

This is a documentation PR.
