### PR TITLE
[JUJU-3390] Improve test coverage for changestream

### DIFF
--- a/worker/changestream/stream/stream_test.go
+++ b/worker/changestream/stream/stream_test.go
@@ -4,6 +4,7 @@
 package stream
 
 import (
+	"context"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/testing"
+)
+
+const (
+	// We need to ensure that we never witness a change event. We've picked
+	// an arbitrary timeout of 1 second, which should be more than enough
+	// time for the worker to process the change.
+	witnessChangeDuration = time.Second
 )
 
 type streamSuite struct {
@@ -48,12 +56,19 @@ func (s *streamSuite) TestNoData(c *gc.C) {
 	defer workertest.DirtyKill(c, stream)
 
 	changes := stream.Changes()
-	c.Assert(changes, gc.HasLen, 0)
 
 	select {
 	case <-done:
 	case <-time.After(testing.ShortWait):
 		c.Fatal("timed out waiting for timer to fire")
+	}
+
+	// Synchronization block to ensure that we don't witness any changes.
+	select {
+	case <-time.After(witnessChangeDuration):
+		c.Assert(changes, gc.HasLen, 0)
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for changes")
 	}
 
 	workertest.CleanKill(c, stream)
@@ -421,67 +436,27 @@ func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *gc.C) 
 }
 
 func (s *streamSuite) TestOneChangeIsBlockedByFile(c *gc.C) {
-	c.Skip("intermittent failure")
 	defer s.setupMocks(c).Finish()
 
 	s.expectAnyLogs()
 	notify := s.expectFileNotifyWatcher()
+	tick := s.setupTimer()
+	done := s.expectTick(tick, 1)
 
 	s.insertNamespace(c, 1, "foo")
-
-	timeTick := s.setupTimer()
 
 	stream := New(s.TrackedDB(), s.FileNotifier, s.clock, s.logger)
 	defer workertest.DirtyKill(c, stream)
 
+	select {
+	case <-done:
+	case <-time.After(testing.ShortWait):
+		c.Fatal("timed out waiting for timer to fire")
+	}
+
 	changes := stream.Changes()
 
-	assertChange := func(expected func(<-chan changestream.ChangeEvent, string) (string, bool)) string {
-		done := s.expectTick(timeTick, 1)
-
-		change := change{
-			id:   1,
-			uuid: utils.MustNewUUID().String(),
-		}
-		s.insertChange(c, change)
-
-		uuid, witnessTick := expected(changes, change.uuid)
-		if !witnessTick {
-			return uuid
-		}
-
-		select {
-		case <-done:
-		case <-time.After(testing.LongWait):
-			c.Fatal("timed out waiting for timer to fire")
-		}
-
-		return uuid
-	}
-	expectOneChange := func(changes <-chan changestream.ChangeEvent, uuid string) (string, bool) {
-		var results []changestream.ChangeEvent
-		select {
-		case change := <-changes:
-			results = append(results, change)
-		case <-time.After(testing.LongWait):
-			c.Fatal("timed out waiting for change")
-		}
-
-		c.Assert(results, gc.HasLen, 1)
-		c.Assert(results[0].Namespace(), gc.Equals, "foo")
-		c.Assert(results[0].ChangedUUID(), gc.Equals, uuid)
-
-		return uuid, true
-	}
-	expectNoChange := func(changes <-chan changestream.ChangeEvent, uuid string) (string, bool) {
-		select {
-		case <-changes:
-			c.Fatal("timed out waiting for change")
-		case <-time.After(time.Second):
-		}
-		return uuid, false
-	}
-	expectNotify := func(block bool) {
+	expectNotifyBlock := func(block bool) {
 		notified := make(chan bool)
 		go func() {
 			defer close(notified)
@@ -490,21 +465,277 @@ func (s *streamSuite) TestOneChangeIsBlockedByFile(c *gc.C) {
 		select {
 		case <-notified:
 		case <-time.After(testing.LongWait):
-			c.Fatal("timed out waiting for change")
+			c.Fatal("timed out waiting for blocking change")
 		}
 	}
 
-	assertChange(expectOneChange)
+	expectNotifyBlock(true)
 
-	expectNotify(true)
+	first := change{
+		id:   1,
+		uuid: utils.MustNewUUID().String(),
+	}
+	s.insertChange(c, first)
 
-	uuid := assertChange(expectNoChange)
+	select {
+	case change := <-changes:
+		c.Fatalf("unexpected change %v", change)
+	case <-time.After(witnessChangeDuration):
+	}
 
-	expectNotify(false)
+	expectNotifyBlock(false)
 
-	expectOneChange(changes, uuid)
+	done = s.expectTick(tick, 1)
+	select {
+	case <-done:
+	case <-time.After(testing.ShortWait):
+		c.Fatal("timed out waiting for timer to fire")
+	}
+
+	var results []changestream.ChangeEvent
+	select {
+	case change := <-changes:
+		results = append(results, change)
+	case <-time.After(testing.ShortWait):
+		c.Fatal("timed out waiting for change")
+	}
+
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Namespace(), gc.Equals, "foo")
+	c.Assert(results[0].ChangedUUID(), gc.Equals, first.uuid)
 
 	workertest.CleanKill(c, stream)
+}
+
+func (s *streamSuite) TestReadChangesWithNoChanges(c *gc.C) {
+	stream := &Stream{
+		db: s.TrackedDB(),
+	}
+
+	s.insertNamespace(c, 1, "foo")
+
+	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
+	defer cancel()
+
+	results, err := stream.readChanges(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 0)
+}
+
+func (s *streamSuite) TestReadChangesWithOneChange(c *gc.C) {
+	stream := &Stream{
+		db: s.TrackedDB(),
+	}
+
+	s.insertNamespace(c, 1, "foo")
+
+	first := change{
+		id:   1,
+		uuid: utils.MustNewUUID().String(),
+	}
+	s.insertChange(c, first)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
+	defer cancel()
+
+	results, err := stream.readChanges(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Namespace(), gc.Equals, "foo")
+	c.Assert(results[0].ChangedUUID(), gc.Equals, first.uuid)
+}
+
+func (s *streamSuite) TestReadChangesWithMultipleSameChange(c *gc.C) {
+	stream := &Stream{
+		db: s.TrackedDB(),
+	}
+
+	s.insertNamespace(c, 1, "foo")
+
+	uuid := utils.MustNewUUID().String()
+	for i := 0; i < 10; i++ {
+		ch := change{
+			id:   1,
+			uuid: uuid,
+		}
+		s.insertChange(c, ch)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
+	defer cancel()
+
+	results, err := stream.readChanges(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 1)
+	c.Assert(results[0].Namespace(), gc.Equals, "foo")
+	c.Assert(results[0].ChangedUUID(), gc.Equals, uuid)
+}
+
+func (s *streamSuite) TestReadChangesWithMultipleChanges(c *gc.C) {
+	stream := &Stream{
+		db: s.TrackedDB(),
+	}
+
+	s.insertNamespace(c, 1, "foo")
+
+	changes := make([]change, 10)
+	for i := 0; i < 10; i++ {
+		ch := change{
+			id:   1,
+			uuid: utils.MustNewUUID().String(),
+		}
+		s.insertChange(c, ch)
+		changes[i] = ch
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
+	defer cancel()
+
+	results, err := stream.readChanges(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 10)
+	for i := range results {
+		c.Assert(results[i].Namespace(), gc.Equals, "foo")
+		c.Assert(results[i].ChangedUUID(), gc.Equals, changes[len(results)-1-i].uuid)
+	}
+}
+
+func (s *streamSuite) TestReadChangesWithMultipleChangesGroupsCorrectly(c *gc.C) {
+	stream := &Stream{
+		db: s.TrackedDB(),
+	}
+
+	s.insertNamespace(c, 1, "foo")
+
+	changes := make([]change, 10)
+	for i := 0; i < 10; i++ {
+		var (
+			ch   change
+			uuid = utils.MustNewUUID().String()
+		)
+		// Grouping is done via uuid, so we should only ever see the last change
+		// when grouping them.
+		for j := 0; j < 10; j++ {
+			ch = change{
+				id:   1,
+				uuid: uuid,
+			}
+			s.insertChange(c, ch)
+		}
+		changes[i] = ch
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
+	defer cancel()
+
+	results, err := stream.readChanges(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 10)
+	for i := range results {
+		c.Assert(results[i].Namespace(), gc.Equals, "foo")
+		c.Assert(results[i].ChangedUUID(), gc.Equals, changes[len(results)-1-i].uuid)
+	}
+}
+
+func (s *streamSuite) TestReadChangesWithMultipleChangesInterweavedGroupsCorrectly(c *gc.C) {
+	stream := &Stream{
+		db: s.TrackedDB(),
+	}
+
+	s.insertNamespace(c, 1, "foo")
+	s.insertNamespace(c, 2, "bar")
+
+	// Setup for this test is a bit more complicated to ensure that interweaving
+	// correctly groups the changes.
+
+	changes := make([]change, 5)
+
+	var (
+		uuid0 = utils.MustNewUUID().String()
+		uuid1 = utils.MustNewUUID().String()
+		uuid2 = utils.MustNewUUID().String()
+	)
+
+	{
+		ch := change{id: 1, uuid: uuid0}
+		s.insertChangeForType(c, changestream.Create, ch)
+		changes[0] = ch
+	}
+	{
+		ch := change{id: 2, uuid: uuid0}
+		s.insertChangeForType(c, changestream.Update, ch)
+		changes[1] = ch
+	}
+	{
+		ch := change{id: 1, uuid: uuid1}
+		s.insertChangeForType(c, changestream.Update, ch)
+		changes[2] = ch
+	}
+	{
+		ch := change{id: 1, uuid: uuid1}
+		s.insertChangeForType(c, changestream.Update, ch)
+		// no witness changed.
+	}
+	{
+		ch := change{id: 2, uuid: uuid0}
+		s.insertChangeForType(c, changestream.Update, ch)
+		// no witness changed.
+	}
+	{
+		ch := change{id: 1, uuid: uuid2}
+		s.insertChangeForType(c, changestream.Update, ch)
+		changes[3] = ch
+	}
+	{
+		ch := change{id: 1, uuid: uuid2}
+		s.insertChangeForType(c, changestream.Update, ch)
+		// no witness changed.
+	}
+	{
+		ch := change{id: 2, uuid: uuid0}
+		s.insertChangeForType(c, changestream.Update, ch)
+		// no witness changed.
+	}
+	{
+		ch := change{id: 1, uuid: uuid1}
+		s.insertChangeForType(c, changestream.Create, ch)
+		changes[4] = ch
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
+	defer cancel()
+
+	results, err := stream.readChanges(ctx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 5)
+
+	type changeResults struct {
+		changeType changestream.ChangeType
+		namespace  string
+		uuid       string
+	}
+
+	expected := []changeResults{
+		{changeType: changestream.Create, namespace: "foo", uuid: uuid1},
+		{changeType: changestream.Update, namespace: "bar", uuid: uuid0},
+		{changeType: changestream.Update, namespace: "foo", uuid: uuid2},
+		{changeType: changestream.Update, namespace: "foo", uuid: uuid1},
+		{changeType: changestream.Create, namespace: "foo", uuid: uuid0},
+	}
+
+	c.Logf("result %v", results)
+	for i := range results {
+		c.Logf("expected %v", expected[i])
+		c.Assert(results[i].Type(), gc.Equals, expected[i].changeType)
+		c.Assert(results[i].Namespace(), gc.Equals, expected[i].namespace)
+		c.Assert(results[i].ChangedUUID(), gc.Equals, expected[i].uuid)
+	}
 }
 
 func (s *streamSuite) insertNamespace(c *gc.C, id int, name string) {
@@ -521,9 +752,13 @@ type change struct {
 }
 
 func (s *streamSuite) insertChange(c *gc.C, changes ...change) {
+	s.insertChangeForType(c, 2, changes...)
+}
+
+func (s *streamSuite) insertChangeForType(c *gc.C, changeType changestream.ChangeType, changes ...change) {
 	q := `
 INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid)
-VALUES (2, ?, ?)
+VALUES (?, ?, ?)
 `[1:]
 
 	tx, err := s.DB().Begin()
@@ -533,8 +768,8 @@ VALUES (2, ?, ?)
 	c.Assert(err, jc.ErrorIsNil)
 
 	for _, v := range changes {
-		c.Logf("Executing insert change: %v %v", v.id, v.uuid)
-		_, err = stmt.Exec(v.id, v.uuid)
+		c.Logf("Executing insert change: edit-type: %d, %v %v", changeType, v.id, v.uuid)
+		_, err = stmt.Exec(changeType, v.id, v.uuid)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/worker/changestream/stream/stream_test.go
+++ b/worker/changestream/stream/stream_test.go
@@ -4,7 +4,6 @@
 package stream
 
 import (
-	"context"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -514,10 +513,7 @@ func (s *streamSuite) TestReadChangesWithNoChanges(c *gc.C) {
 
 	s.insertNamespace(c, 1, "foo")
 
-	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
-	defer cancel()
-
-	results, err := stream.readChanges(ctx)
+	results, err := stream.readChanges()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results, gc.HasLen, 0)
@@ -536,10 +532,7 @@ func (s *streamSuite) TestReadChangesWithOneChange(c *gc.C) {
 	}
 	s.insertChange(c, first)
 
-	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
-	defer cancel()
-
-	results, err := stream.readChanges(ctx)
+	results, err := stream.readChanges()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results, gc.HasLen, 1)
@@ -563,10 +556,7 @@ func (s *streamSuite) TestReadChangesWithMultipleSameChange(c *gc.C) {
 		s.insertChange(c, ch)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
-	defer cancel()
-
-	results, err := stream.readChanges(ctx)
+	results, err := stream.readChanges()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results, gc.HasLen, 1)
@@ -591,10 +581,7 @@ func (s *streamSuite) TestReadChangesWithMultipleChanges(c *gc.C) {
 		changes[i] = ch
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
-	defer cancel()
-
-	results, err := stream.readChanges(ctx)
+	results, err := stream.readChanges()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results, gc.HasLen, 10)
@@ -629,10 +616,7 @@ func (s *streamSuite) TestReadChangesWithMultipleChangesGroupsCorrectly(c *gc.C)
 		changes[i] = ch
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
-	defer cancel()
-
-	results, err := stream.readChanges(ctx)
+	results, err := stream.readChanges()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results, gc.HasLen, 10)
@@ -707,10 +691,7 @@ func (s *streamSuite) TestReadChangesWithMultipleChangesInterweavedGroupsCorrect
 		changes[4] = ch
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testing.LongWait)
-	defer cancel()
-
-	results, err := stream.readChanges(ctx)
+	results, err := stream.readChanges()
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results, gc.HasLen, 5)


### PR DESCRIPTION
The following improves the test coverage for the change stream package. Going back to the original code, knowing what we know about the context requirement for all requests means that changes to the code are required.

The learnings from the lease package were that every context to a txn needs to be tracked via a tomb. If we don't track the txn with a tied context to a tomb, then we may end up with a deadlock. This deadlock can not be unlocked without a restart of the service.

Tests have been added to improve confidence in the interweaving of changes from the readChanges method.

Additionally, I've taken another stab at fixing the TestOneChangeIsBlockedByFile which is currently an intermittent failure.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


```sh
$ juju bootstrap lxd test --build-agent
```

To see a working example, this is quite convoluted:

  1. Apply the following diff at the bottom of this post.
  2. `$ juju bootstrap lxd test --build-agent`
  3. `make repl-install repl`
  4. Run the commands from the repl command
  5. Insert a namespace, this is to satisfy the constraints `INSERT INTO change_log_namespace VALUES (1, 'foo');`
  6. Watch `juju debug-log -m controller` from one terminal
  7. Insert a change log item `INSERT INTO change_log (edit_type_id, namespace_id, changed_uuid) VALUES (2, 1, 'uuid1');`
 
You should now see the following logs:

```
machine-0: 17:26:23 ERROR juju.worker.changestream change event: {2 2 foo uuid1 2023-02-09 17:26:23.227}
machine-0: 17:26:23 ERROR juju.worker.lease lease manager got changes: {2 2 foo uuid1 2023-02-09 17:26:23.227}
```

INSERT LOTS OF THINGS!

------

Diff to apply to see changestream working:
 
```diff
diff --git a/cmd/jujud/agent/machine/manifolds.go b/cmd/jujud/agent/machine/manifolds.go
index 8f7d2f476b..595d1a605a 100644
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -736,6 +736,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AgentName:            agentName,
 			ClockName:            clockName,
 			DBAccessorName:       dbAccessorName,
+			ChangeStreamName:     changeStreamName,
 			Logger:               loggo.GetLogger("juju.worker.lease"),
 			LogDir:               agentConfig.LogDir(),
 			PrometheusRegisterer: config.PrometheusRegisterer,
diff --git a/worker/changestream/manifold.go b/worker/changestream/manifold.go
index df5724d48a..f16c54d7ce 100644
--- a/worker/changestream/manifold.go
+++ b/worker/changestream/manifold.go
@@ -15,6 +15,7 @@ import (
 
 // Logger represents the logging methods called.
 type Logger interface {
+	Criticalf(message string, args ...interface{})
 	Errorf(message string, args ...interface{})
 	Warningf(message string, args ...interface{})
 	Infof(message string, args ...interface{})
diff --git a/worker/changestream/stream/stream.go b/worker/changestream/stream/stream.go
index 603408c62b..f9f24d1cc1 100644
--- a/worker/changestream/stream/stream.go
+++ b/worker/changestream/stream/stream.go
@@ -21,6 +21,7 @@ type Logger interface {
 	Infof(message string, args ...interface{})
 	Debugf(message string, args ...interface{})
 	Tracef(message string, args ...interface{})
+	Criticalf(message string, args ...interface{})
 	IsTraceEnabled() bool
 }
 
@@ -147,6 +148,7 @@ func (s *Stream) loop() error {
 			}
 
 			for _, change := range changes {
+				s.logger.Criticalf("change event: %v", change)
 				if s.logger.IsTraceEnabled() {
 					s.logger.Tracef("change event: %v", change)
 				}
diff --git a/worker/lease/manifold/manifold.go b/worker/lease/manifold/manifold.go
index 77ab0e2849..7b1ccb072d 100644
--- a/worker/lease/manifold/manifold.go
+++ b/worker/lease/manifold/manifold.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/worker/changestream"
 	"github.com/juju/juju/worker/common"
 	"github.com/juju/juju/worker/lease"
 )
@@ -35,9 +36,10 @@ const (
 // ManifoldConfig holds the resources needed to start the lease
 // manager in a dependency engine.
 type ManifoldConfig struct {
-	AgentName      string
-	ClockName      string
-	DBAccessorName string
+	AgentName        string
+	ClockName        string
+	DBAccessorName   string
+	ChangeStreamName string
 
 	Logger               lease.Logger
 	LogDir               string
@@ -102,6 +104,30 @@ func (s *manifoldState) start(context dependency.Context) (worker.Worker, error)
 		return nil, errors.Trace(err)
 	}
 
+	var changeStream changestream.ChangeStream
+	if err := context.Get(s.config.ChangeStreamName, &changeStream); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	eventQueue, err := changeStream.EventQueue("controller")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	subscription, err := eventQueue.Subscribe()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	go func() {
+		for {
+			select {
+			case change := <-subscription.Changes():
+				s.config.Logger.Errorf("lease manager got changes: %v", change)
+			}
+		}
+	}()
+
 	s.store = s.config.NewStore(lease.StoreConfig{
 		TrackedDB: trackedDB,
 		Logger:    s.config.Logger,
@@ -146,6 +172,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			config.AgentName,
 			config.ClockName,
 			config.DBAccessorName,
+			config.ChangeStreamName,
 		},
 		Start:  s.start,
 		Output: s.output,
```