### PR TITLE
[JUJU-3026] Refactor default-credential command docs

### DIFF
--- a/cmd/juju/cloud/defaultcredential.go
+++ b/cmd/juju/cloud/defaultcredential.go
@@ -35,16 +35,13 @@ To unset previously set default credential for a cloud, use --reset option.
 To view currently set default credential for a cloud, use the command
 without a credential name argument.
 
-Examples:
+`
+
+const usageSetDefaultCredentialExamples = `
     juju default-credential google credential_name
     juju default-credential google
     juju default-credential google --reset
-
-See also: 
-    credentials
-    add-credential
-    remove-credential
-    autoload-credentials`
+`
 
 type setDefaultCredentialCommand struct {
 	cmd.CommandBase
@@ -64,11 +61,18 @@ func NewSetDefaultCredentialCommand() cmd.Command {
 
 func (c *setDefaultCredentialCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "default-credential",
-		Aliases: []string{"set-default-credentials"},
-		Args:    "<cloud name> [<credential name>]",
-		Purpose: usageSetDefaultCredentialSummary,
-		Doc:     usageSetDefaultCredentialDetails,
+		Name:     "default-credential",
+		Aliases:  []string{"set-default-credentials"},
+		Args:     "<cloud name> [<credential name>]",
+		Purpose:  usageSetDefaultCredentialSummary,
+		Doc:      usageSetDefaultCredentialDetails,
+		Examples: usageSetDefaultCredentialExamples,
+		SeeAlso: []string{
+			"credentials",
+			"add-credential",
+			"remove-credential",
+			"autoload-credentials",
+		},
 	})
 }
 


### PR DESCRIPTION

Moved Examples and See also to fields inside Info.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [x] Code style: imports ordered, good names, simple structure, etc
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

 Run `juju documentation --split --out=tmp` 

## Documentation changes

This is a documentation PR.
