### PR TITLE
[JUJU-3355] Fix LP 2021700 - refresh charmhub charm after charm revision updater has run.

### DIFF
--- a/state/charm.go
+++ b/state/charm.go
@@ -863,7 +863,7 @@ func (st *State) Charm(curl *charm.URL) (*Charm, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !ch.IsUploaded() && !charm.CharmHub.Matches(curl.Schema) || ch.IsPlaceholder() {
+	if (!ch.IsUploaded() && !charm.CharmHub.Matches(curl.Schema)) || ch.IsPlaceholder() {
 		return nil, errors.NotFoundf("charm %q", curl.String())
 	}
 	return ch, nil

--- a/state/charm_test.go
+++ b/state/charm_test.go
@@ -720,21 +720,33 @@ func (s *CharmSuite) TestAddCharmMetadata(c *gc.C) {
 	dummy1.StoragePath = ""
 	ch1, err := s.State.AddCharmMetadata(dummy1)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch1.IsPlaceholder(), jc.IsFalse)
-	c.Assert(ch1.IsUploaded(), jc.IsFalse, gc.Commentf("expected charm with missing SHA/storage path to have the PendingUpload flag set"))
+	c.Check(ch1.IsPlaceholder(), jc.IsFalse)
+	c.Check(ch1.IsUploaded(), jc.IsFalse, gc.Commentf("expected charm with missing SHA/storage path to have the PendingUpload flag set"))
 
 	// Check that uploading the same charm ID yields the same charm
 	ch, err := s.State.AddCharmMetadata(dummy1)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch1, gc.DeepEquals, ch)
+	c.Check(ch1, gc.DeepEquals, ch)
 
 	// Check that a charm with populated sha/storage path is flagged as
 	// uploaded.
 	dummy2 := s.dummyCharm(c, "ch:quantal/dummy-2")
 	ch2, err := s.State.AddCharmMetadata(dummy2)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ch2.IsPlaceholder(), jc.IsFalse)
-	c.Assert(ch2.IsUploaded(), jc.IsTrue, gc.Commentf("expected charm with populated SHA/storage path to have the PendingUpload flag unset"))
+	c.Check(ch2.IsPlaceholder(), jc.IsFalse)
+	c.Check(ch2.IsUploaded(), jc.IsTrue, gc.Commentf("expected charm with populated SHA/storage path to have the PendingUpload flag unset"))
+}
+
+func (s *CharmSuite) TestAddCharmMetadataUpdatesPlaceholder(c *gc.C) {
+	// The charm revision updater adds a placeholder charm doc into the db.
+	// Ensure that AddCharmMetadata can handle that.
+	err := s.State.AddCharmPlaceholder(charm.MustParseURL("ch:quantal/testme-2"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	testme := s.dummyCharm(c, "ch:quantal/testme-2")
+	ch2, err := s.State.AddCharmMetadata(testme)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(ch2.IsPlaceholder(), jc.IsFalse)
 }
 
 func (s *CharmSuite) TestAllCharmURLs(c *gc.C) {


### PR DESCRIPTION
AddCharmMetadata is an essential part of queuing asynchronous charm download. It inserts the charm's metadata into the juju db before a charm is actually downloaded, thus allowing the refresh to continue as much as possible without an actual charm.

Unfortunately AddCharmMetadata naively assumed that there would never be a charm doc for the charm unless we were in the process or had downloaded it. This is not the case. The charm revisions updater worker will insert a placeholder charm doc for charm revisions different from the currently deployed charm. This is used to notify users that a charm refresh is available. 

Charm should not return placeholder charms, but AddCharmMetadata needs to see all charm docs. Added a private state method to get all charm docs. AddCharmMetadata can then update an placeholder charm doc where necessary instead of relying solely on inserting a charm doc where one does not exist.

Also updated the useless `ERROR already exists` message to be more informative.

## QA steps

```sh
$ juju deploy cs:ubuntu-19
$ juju deploy juju-qa-test --revision 19 --channel latest/edge

# while waiting for the charm to become active/idle, add a wrench to trigger the charm revision updater to run
$ juju ssh -m controller 0
$ sudo mkdir /var/lib/juju/wrench
$ sudo cat > /var/lib/juju/wrench/charmrevision << EOT
shortinterval
EOT 
$ sudo systemctl restart jujud-machine-0.server

# no refresh the two applications
$ juju refresh ubuntu
$ juju refresh juju-qa-test

# no errors should occur and a new charm should be downloaded.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2012700
