### PR TITLE
[JUJU-3391] Backport fixes for removal of user model ops

### DIFF
--- a/api/client/usermanager/client_test.go
+++ b/api/client/usermanager/client_test.go
@@ -49,7 +49,7 @@ func (s *usermanagerSuite) TestAddExistingUser(c *gc.C) {
 	s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
 
 	_, _, err := s.usermanager.AddUser("foobar", "Foo Bar", "password")
-	c.Assert(err, gc.ErrorMatches, "failed to create user: the user already exists")
+	c.Assert(err, gc.ErrorMatches, "failed to create user: user foobar already exists")
 }
 
 func (s *usermanagerSuite) TestAddUserResponseError(c *gc.C) {

--- a/state/mocks/database_mock.go
+++ b/state/mocks/database_mock.go
@@ -127,6 +127,20 @@ func (mr *MockDatabaseMockRecorder) Run(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockDatabase)(nil).Run), arg0)
 }
 
+// RunRaw mocks base method.
+func (m *MockDatabase) RunRaw(arg0 txn0.TransactionSource) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunRaw", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunRaw indicates an expected call of RunRaw.
+func (mr *MockDatabaseMockRecorder) RunRaw(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunRaw", reflect.TypeOf((*MockDatabase)(nil).RunRaw), arg0)
+}
+
 // RunRawTransaction mocks base method.
 func (m *MockDatabase) RunRawTransaction(arg0 []txn.Op) error {
 	m.ctrl.T.Helper()

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -136,6 +136,17 @@ func removeModelUserOps(modelUUID string, user names.UserTag) []txn.Op {
 		removePermissionOp(modelKey(modelUUID), userGlobalKey(userAccessID(user))),
 		{
 			C:      modelUsersC,
+			Id:     userAccessID(user),
+			Assert: txn.DocExists,
+			Remove: true,
+		}}
+}
+
+func removeModelUserOpsGlobal(modelUUID string, user names.UserTag) []txn.Op {
+	return []txn.Op{
+		removePermissionOp(modelKey(modelUUID), userGlobalKey(userAccessID(user))),
+		{
+			C:      modelUsersC,
 			Id:     ensureModelUUID(modelUUID, userAccessID(user)),
 			Assert: txn.DocExists,
 			Remove: true,

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -136,7 +136,7 @@ func removeModelUserOps(modelUUID string, user names.UserTag) []txn.Op {
 		removePermissionOp(modelKey(modelUUID), userGlobalKey(userAccessID(user))),
 		{
 			C:      modelUsersC,
-			Id:     userAccessID(user),
+			Id:     ensureModelUUID(modelUUID, userAccessID(user)),
 			Assert: txn.DocExists,
 			Remove: true,
 		}}

--- a/state/user.go
+++ b/state/user.go
@@ -71,7 +71,6 @@ func (st *State) AddUserWithSecretKey(name, displayName, creator string) (*User,
 }
 
 func (st *State) addUser(name, displayName, password, creator string, secretKey []byte) (*User, error) {
-
 	if !names.IsValidUserName(name) {
 		return nil, errors.Errorf("invalid user name %q", name)
 	}
@@ -83,9 +82,9 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 	if err == nil {
 		if foundUser.doc.Deleted {
 			// the user was deleted, we update it
-			return st.updateExistingUser(foundUser, displayName, password, creator, secretKey)
+			return st.recreateExistingUser(foundUser, name, displayName, password, creator, secretKey)
 		} else {
-			return nil, errors.New("the user already exists")
+			return nil, errors.AlreadyExistsf("user %s", name)
 		}
 	}
 
@@ -142,61 +141,98 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 	return user, nil
 }
 
-// updateExistingUser manipulates the values of an existing user in the db.
+// recreateExistingUser manipulates the values of an existing user in the db.
 // This is particularly useful when reusing existing users that were previously
 // deleted.
-func (st *State) updateExistingUser(u *User, displayName, password, creator string, secretKey []byte) (*User, error) {
-
+func (st *State) recreateExistingUser(u *User, name, displayName, password, creator string, secretKey []byte) (*User, error) {
 	dateCreated := st.nowToTheSecond()
 
-	// update the password
-	updateUser := bson.D{{"$set", bson.D{
-		{"deleted", false},
-		{"displayname", displayName},
-		{"createdby", creator},
-		{"datecreated", dateCreated},
-	}}}
-
-	if password != "" {
-		salt, err := utils.RandomSalt()
-		if err != nil {
-			return nil, err
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			err := u.Refresh()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if !u.IsDeleted() {
+				return nil, errors.AlreadyExistsf("user %s", name)
+			}
 		}
-		updateUser = append(updateUser,
-			bson.DocElem{"$set", bson.D{
-				{"passwordhash", utils.UserPasswordHash(password, salt)},
-				{"passwordsalt", salt},
-			}},
-		)
+
+		updateUser := bson.D{{"$set", bson.D{
+			{"deleted", false},
+			{"name", name},
+			{"displayname", displayName},
+			{"createdby", creator},
+			{"datecreated", dateCreated},
+			{"secretkey", secretKey},
+		}}}
+
+		// update the password
+		if password != "" {
+			salt, err := utils.RandomSalt()
+			if err != nil {
+				return nil, err
+			}
+			updateUser = append(updateUser,
+				bson.DocElem{"$set", bson.D{
+					{"passwordhash", utils.UserPasswordHash(password, salt)},
+					{"passwordsalt", salt},
+				}},
+			)
+		}
+
+		var ops []txn.Op
+
+		// ensure models that were migrating at the time of the RemoveUser call are
+		// processed now.
+		modelQuery, closer, err := st.modelQueryForUser(u.UserTag(), false)
+		defer closer()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var modelDocs []modelDoc
+		if err := modelQuery.All(&modelDocs); err != nil {
+			return nil, errors.Trace(err)
+		}
+		for _, summary := range modelDocs {
+			// remove the permission for the model
+			ops = append(ops, removeModelUserOps(summary.UUID, u.UserTag())...)
+		}
+
+		// remove previous controller permissions
+		if _, err := u.st.controllerUser(u.UserTag()); err == nil {
+			ops = append(ops, removeControllerUserOps(st.ControllerUUID(), u.UserTag())...)
+		} else if err != nil && !errors.Is(err, errors.NotFound) {
+			return nil, errors.Trace(err)
+		}
+
+		// create default new ones
+		ops = append(ops, createControllerUserOps(st.ControllerUUID(),
+			u.UserTag(),
+			names.NewUserTag(creator),
+			displayName,
+			dateCreated,
+			defaultControllerPermission)...)
+
+		// update user doc
+		ops = append(ops, txn.Op{
+			C:  usersC,
+			Id: strings.ToLower(u.Name()),
+			Assert: bson.M{
+				"deleted": true,
+			},
+			Update: updateUser,
+		})
+
+		return ops, nil
 	}
 
-	// create default new ones
-	createControllerOps := createControllerUserOps(st.ControllerUUID(),
-		u.UserTag(),
-		names.NewUserTag(creator),
-		displayName,
-		dateCreated,
-		defaultControllerPermission)
-
-	updateUserOps := []txn.Op{{
-		C:      usersC,
-		Id:     strings.ToLower(u.Name()),
-		Assert: txn.DocExists,
-		Update: updateUser,
-	}}
-	updateUserOps = append(updateUserOps, createControllerOps...)
-
-	if err := u.st.db().RunTransaction(updateUserOps); err != nil {
+	if err := u.st.db().RunRaw(buildTxn); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	// recreate the user object to return
-	toReturn, err := st.User(u.UserTag())
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return toReturn, nil
+	// recreate the user object
+	return st.User(u.UserTag())
 }
 
 // RemoveUser marks the user as deleted. This obviates the ability of a user
@@ -212,60 +248,61 @@ func (st *State) RemoveUser(tag names.UserTag) error {
 		return nil
 	}
 
-	// remove the access to all the models and the current controller
-	// first query all the models for this user
-	modelQuery, closer, err := st.modelQueryForUser(tag, false)
-	defer closer()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	var modelDocs []modelDoc
-	if err := modelQuery.All(&modelDocs); err != nil {
-		return errors.Trace(err)
-	}
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			// If it is not our first attempt, refresh the user.
+			if err := u.Refresh(); err != nil {
+				return nil, errors.Trace(err)
+			}
+			if u.IsDeleted() {
+				return nil, nil
+			}
+		}
 
-	txns := make([]txn.Op, 0)
-	for _, summary := range modelDocs {
-		// remove the permission for the model
-		txns = append(txns, removePermissionOp(modelKey(summary.UUID), userGlobalKey(userAccessID(tag))))
-		// set the target to other model
-		targetId := ensureModelUUID(summary.UUID, userAccessID(tag))
-		txns = append(txns, txn.Op{
-			C:      modelUsersC,
-			Id:     targetId,
+		// remove the access to all the models and the current controller
+		// first query all the models for this user
+		modelQuery, closer, err := st.modelQueryForUser(tag, false)
+		defer closer()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var modelDocs []modelDoc
+		if err := modelQuery.All(&modelDocs); err != nil {
+			return nil, errors.Trace(err)
+		}
+		var ops []txn.Op
+		for _, summary := range modelDocs {
+			// remove the permission for the model
+			ops = append(ops, removeModelUserOps(summary.UUID, tag)...)
+		}
+
+		// remove the user from the controller
+		ops = append(ops, removeControllerUserOps(st.ControllerUUID(), tag)...)
+
+		// new entry in the removal log
+		newRemovalLogEntry := userRemovedLogEntry{
+			RemovedBy:   u.doc.CreatedBy,
+			DateCreated: u.doc.DateCreated,
+			DateRemoved: st.nowToTheSecond(),
+		}
+		ops = append(ops, txn.Op{
+			Id:     lowercaseName,
+			C:      usersC,
 			Assert: txn.DocExists,
-			Remove: true,
+			Update: bson.M{
+				"$set": bson.M{
+					"deleted": true,
+				},
+				"$push": bson.M{
+					"removallog": bson.M{"$each": []userRemovedLogEntry{newRemovalLogEntry}},
+				},
+			},
 		})
+		return ops, nil
 	}
-
-	// remove the user from the controller
-	txns = append(txns, removeControllerUserOps(st.ControllerUUID(), tag)...)
-
-	dateRemoved := st.nowToTheSecond()
-	// new entry in the removal log
-	newRemovalLogEntry := userRemovedLogEntry{
-		RemovedBy:   u.doc.CreatedBy,
-		DateCreated: u.doc.DateCreated,
-		DateRemoved: dateRemoved,
-	}
-	removalLog := u.doc.RemovalLog
-	if removalLog == nil {
-		removalLog = make([]userRemovedLogEntry, 0)
-	}
-	removalLog = append(removalLog, newRemovalLogEntry)
-
-	op := txn.Op{
-		Id:     lowercaseName,
-		C:      usersC,
-		Assert: txn.DocExists,
-		Update: bson.M{"$set": bson.M{
-			"deleted": true, "removallog": removalLog}},
-	}
-
-	txns = append(txns, op)
 
 	// Use raw transactions to avoid model filtering
-	return st.db().RunRawTransaction(txns)
+	return st.db().RunRaw(buildTxn)
 }
 
 func createInitialUserOps(controllerUUID string, user names.UserTag, password, salt string, dateCreated time.Time) []txn.Op {
@@ -295,7 +332,6 @@ func createInitialUserOps(controllerUUID string, user names.UserTag, password, s
 
 	ops = append(ops, controllerUserOps...)
 	return ops
-
 }
 
 // getUser fetches information about the user with the

--- a/state/user.go
+++ b/state/user.go
@@ -82,7 +82,7 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 	if err == nil {
 		if foundUser.doc.Deleted {
 			// the user was deleted, we update it
-			return st.recreateExistingUser(foundUser, name, displayName, password, creator, secretKey)
+			return st.recreateDeletedUser(foundUser, name, displayName, password, creator, secretKey)
 		} else {
 			return nil, errors.AlreadyExistsf("user %s", name)
 		}
@@ -141,10 +141,10 @@ func (st *State) addUser(name, displayName, password, creator string, secretKey 
 	return user, nil
 }
 
-// recreateExistingUser manipulates the values of an existing user in the db.
+// recreateDeletedUser manipulates the values of an existing user in the db.
 // This is particularly useful when reusing existing users that were previously
 // deleted.
-func (st *State) recreateExistingUser(u *User, name, displayName, password, creator string, secretKey []byte) (*User, error) {
+func (st *State) recreateDeletedUser(u *User, name, displayName, password, creator string, secretKey []byte) (*User, error) {
 	dateCreated := st.nowToTheSecond()
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {

--- a/state/user.go
+++ b/state/user.go
@@ -214,25 +214,32 @@ func (st *State) RemoveUser(tag names.UserTag) error {
 
 	// remove the access to all the models and the current controller
 	// first query all the models for this user
-	modelsSummary, err := st.ModelSummariesForUser(tag, true)
+	modelQuery, closer, err := st.modelQueryForUser(tag, false)
+	defer closer()
 	if err != nil {
-		return err
+		return errors.Trace(err)
+	}
+	var modelDocs []modelDoc
+	if err := modelQuery.All(&modelDocs); err != nil {
+		return errors.Trace(err)
 	}
 
-	for _, summary := range modelsSummary {
-		// remove all the access permissions
-		removeModelOps := removeModelUserOps(summary.UUID, tag)
-		if err := st.db().RunTransactionFor(summary.UUID, removeModelOps); err != nil {
-			logger.Errorf("impossible to remove user from models", err)
-			return err
-		}
+	txns := make([]txn.Op, 0)
+	for _, summary := range modelDocs {
+		// remove the permission for the model
+		txns = append(txns, removePermissionOp(modelKey(summary.UUID), userGlobalKey(userAccessID(tag))))
+		// set the target to other model
+		targetId := ensureModelUUID(summary.UUID, userAccessID(tag))
+		txns = append(txns, txn.Op{
+			C:      modelUsersC,
+			Id:     targetId,
+			Assert: txn.DocExists,
+			Remove: true,
+		})
 	}
 
-	// remove the user from the user controllers
-	if err := st.removeControllerUser(tag); err != nil {
-		logger.Errorf("impossible to remove user from controller", err)
-		return err
-	}
+	// remove the user from the controller
+	txns = append(txns, removeControllerUserOps(st.ControllerUUID(), tag)...)
 
 	dateRemoved := st.nowToTheSecond()
 	// new entry in the removal log
@@ -247,24 +254,18 @@ func (st *State) RemoveUser(tag names.UserTag) error {
 	}
 	removalLog = append(removalLog, newRemovalLogEntry)
 
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		if attempt > 0 {
-			// If it is not our first attempt, refresh the user.
-			if err := u.Refresh(); err != nil {
-				return nil, errors.Trace(err)
-			}
-		}
-		ops := []txn.Op{
-			{
-				Id:     lowercaseName,
-				C:      usersC,
-				Assert: txn.DocExists,
-				Update: bson.M{"$set": bson.M{
-					"deleted": true, "removallog": removalLog}}},
-		}
-		return ops, nil
+	op := txn.Op{
+		Id:     lowercaseName,
+		C:      usersC,
+		Assert: txn.DocExists,
+		Update: bson.M{"$set": bson.M{
+			"deleted": true, "removallog": removalLog}},
 	}
-	return st.db().Run(buildTxn)
+
+	txns = append(txns, op)
+
+	// Use raw transactions to avoid model filtering
+	return st.db().RunRawTransaction(txns)
 }
 
 func createInitialUserOps(controllerUUID string, user names.UserTag, password, salt string, dateCreated time.Time) []txn.Op {

--- a/state/user.go
+++ b/state/user.go
@@ -194,9 +194,9 @@ func (st *State) recreateExistingUser(u *User, name, displayName, password, crea
 		if err := modelQuery.All(&modelDocs); err != nil {
 			return nil, errors.Trace(err)
 		}
-		for _, summary := range modelDocs {
+		for _, model := range modelDocs {
 			// remove the permission for the model
-			ops = append(ops, removeModelUserOps(summary.UUID, u.UserTag())...)
+			ops = append(ops, removeModelUserOpsGlobal(model.UUID, u.UserTag())...)
 		}
 
 		// remove previous controller permissions
@@ -271,9 +271,9 @@ func (st *State) RemoveUser(tag names.UserTag) error {
 			return nil, errors.Trace(err)
 		}
 		var ops []txn.Op
-		for _, summary := range modelDocs {
+		for _, model := range modelDocs {
 			// remove the permission for the model
-			ops = append(ops, removeModelUserOps(summary.UUID, tag)...)
+			ops = append(ops, removeModelUserOpsGlobal(model.UUID, tag)...)
 		}
 
 		// remove the user from the controller

--- a/state/user_test.go
+++ b/state/user_test.go
@@ -487,7 +487,7 @@ func (s *UserSuite) TestCaseSensitiveUsersErrors(c *gc.C) {
 
 	_, err := s.State.AddUser(
 		"boB", "ignored", "ignored", "ignored")
-	c.Assert(err, gc.ErrorMatches, "the user already exists")
+	c.Assert(err, gc.ErrorMatches, "user boB already exists")
 }
 
 func (s *UserSuite) TestCaseInsensitiveLookup(c *gc.C) {


### PR DESCRIPTION
This PR ports the fix for the broken user access reported in #15351 and #15324 

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Refer to #15324 for QA steps.
