### PR TITLE
[JUJU-3387] Fill consumer label on facade layer 

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -286,6 +286,7 @@ func (s *SecretsManagerAPI) removeSecret(uri *coresecrets.URI, revisions ...int)
 }
 
 // GetConsumerSecretsRevisionInfo returns the latest secret revisions for the specified secrets.
+// This facade method is used for remote watcher to get the latest secret revisions and labels for a secret changed hook.
 func (s *SecretsManagerAPI) GetConsumerSecretsRevisionInfo(args params.GetSecretConsumerInfoArgs) (params.SecretConsumerInfoResults, error) {
 	result := params.SecretConsumerInfoResults{
 		Results: make([]params.SecretConsumerInfoResult, len(args.URIs)),
@@ -316,7 +317,25 @@ func (s *SecretsManagerAPI) getSecretConsumerInfo(consumerTag names.Tag, uriStr 
 	if !s.canRead(uri, consumerTag) {
 		return nil, apiservererrors.ErrPerm
 	}
-	return s.secretsConsumer.GetSecretConsumer(uri, consumerTag)
+	consumer, err := s.secretsConsumer.GetSecretConsumer(uri, consumerTag)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if consumer.Label != "" {
+		return consumer, nil
+	}
+	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, "", false)
+	if errors.Is(err, errors.NotFound) {
+		// The secret is owned by a different application.
+		return consumer, nil
+	}
+	if err != nil {
+		return nil, errors.Annotatef(err, "cannot get secret metadata for %q", uri)
+	}
+	// We allow units to access the application owned secrets using the application owner label,
+	// so we copy the owner label to consumer metadata.
+	consumer.Label = md.Label
+	return consumer, nil
 }
 
 // GetSecretMetadata returns metadata for the caller's secrets.
@@ -447,9 +466,9 @@ func (s *SecretsManagerAPI) isLeaderUnit() (bool, error) {
 	return err == nil, nil
 }
 
-func (s *SecretsManagerAPI) handleAppOwnedSecretForUnits(md *coresecrets.SecretMetadata) (*coresecrets.SecretMetadata, error) {
-	// If the secret is owned by the app, and the caller is a peer unit, we create a fake consumer doc for triggering events to notify the uniters.
-	// The peer units should get the secret using owner label but should not set a consumer label.
+// For the application owned secret, if the caller is a peer unit, we create a fake consumer doc for triggering events to notify the uniters.
+// The peer units should get the secret using owner label but should not set a consumer label.
+func (s *SecretsManagerAPI) ensureConsumerMetadataForAppOwnedSecretsForPeerUnits(md *coresecrets.SecretMetadata) (*coresecrets.SecretMetadata, error) {
 	consumer, err := s.secretsConsumer.GetSecretConsumer(md.URI, s.authTag)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)
@@ -466,17 +485,17 @@ func (s *SecretsManagerAPI) handleAppOwnedSecretForUnits(md *coresecrets.SecretM
 	return md, nil
 }
 
-func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecrets.URI, label string) (md *coresecrets.SecretMetadata, err error) {
+func (s *SecretsManagerAPI) getAppOwnedOrUnitOwnedSecretMetadata(uri *coresecrets.URI, label string, ensureConsumerMetaData bool) (md *coresecrets.SecretMetadata, err error) {
 	notFoundErr := errors.NotFoundf("secret %q", uri)
 	if label != "" {
 		notFoundErr = errors.NotFoundf("secret with label %q", label)
 	}
 	defer func() {
-		if md == nil || md.OwnerTag == s.authTag.String() {
+		if md == nil || md.OwnerTag == s.authTag.String() || !ensureConsumerMetaData {
 			// Either errored out or found a secret owned by the caller.
 			return
 		}
-		md, err = s.handleAppOwnedSecretForUnits(md)
+		md, err = s.ensureConsumerMetadataForAppOwnedSecretsForPeerUnits(md)
 	}()
 
 	filter := state.SecretsFilter{
@@ -534,7 +553,7 @@ func (s *SecretsManagerAPI) getSecretContent(arg params.GetSecretContentArg) (*s
 		}
 	}
 	// Owner units should always have the URI because we resolved the label to URI on uniter side already.
-	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, arg.Label)
+	md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(uri, arg.Label, true)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39368,7 +39368,7 @@
                             "$ref": "#/definitions/SecretConsumerInfoResults"
                         }
                     },
-                    "description": "GetConsumerSecretsRevisionInfo returns the latest secret revisions for the specified secrets."
+                    "description": "GetConsumerSecretsRevisionInfo returns the latest secret revisions for the specified secrets.\nThis facade method is used for remote watcher to get the latest secret revisions and labels for a secret changed hook."
                 },
                 "GetSecretBackendConfig": {
                     "type": "object",
@@ -45082,7 +45082,7 @@
                             "$ref": "#/definitions/SecretConsumerInfoResults"
                         }
                     },
-                    "description": "GetConsumerSecretsRevisionInfo returns the latest secret revisions for the specified secrets."
+                    "description": "GetConsumerSecretsRevisionInfo returns the latest secret revisions for the specified secrets.\nThis facade method is used for remote watcher to get the latest secret revisions and labels for a secret changed hook."
                 },
                 "GetMeterStatus": {
                     "type": "object",

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -1286,38 +1286,11 @@ func (st *State) GetSecretConsumer(uri *secrets.URI, consumer names.Tag) (*secre
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	md := &secrets.SecretConsumerMetadata{
+	return &secrets.SecretConsumerMetadata{
 		Label:           doc.Label,
 		CurrentRevision: doc.CurrentRevision,
 		LatestRevision:  doc.LatestRevision,
-	}
-
-	if md.Label == "" {
-		// Note: the leader unit always has the label cached on the uniter side, but non leaders do not.
-		// Therefore, below logic (fixes https://bugs.launchpad.net/juju/+bug/2004220) makes application
-		// owned secrets' labels visible for non leader units' secret-changed hook.
-		equalOrOwned := func(consumerTag, ownerTag names.Tag) bool {
-			if consumerTag.Id() == ownerTag.Id() {
-				return true
-			}
-			applicationName, _ := names.UnitApplication(consumerTag.Id())
-			return ownerTag.Id() == applicationName
-		}
-
-		store := NewSecrets(st)
-		secret, err := store.GetSecret(uri)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		ownerTag, err := names.ParseTag(secret.OwnerTag)
-		if err != nil {
-			return nil, errors.Annotate(err, "invalid owner tag")
-		}
-		if equalOrOwned(consumer, ownerTag) {
-			md.Label = secret.Label
-		}
-	}
-	return md, nil
+	}, nil
 }
 
 func (st *State) removeSecretConsumerInfo(uri *secrets.URI) error {

--- a/state/secrets_test.go
+++ b/state/secrets_test.go
@@ -1078,19 +1078,8 @@ func (s *SecretsSuite) TestGetSecretConsumerAndGetSecretConsumerURI(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(uri3, jc.DeepEquals, uri)
 
-	ownerNonLeaderUnit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: s.owner})
-	err = s.State.SaveSecretConsumer(
-		// No consumer label for app owned secrets.
-		uri, ownerNonLeaderUnit.UnitTag(),
-		&secrets.SecretConsumerMetadata{CurrentRevision: 666},
-	)
-	c.Assert(err, jc.ErrorIsNil)
-
-	mdOwnerNonLeaderUnit, err := s.State.GetSecretConsumer(uri, ownerNonLeaderUnit.Tag())
-	c.Check(err, jc.ErrorIsNil)
-	// owner label visible for its own units.
-	c.Check(mdOwnerNonLeaderUnit.Label, gc.Equals, "owner-label")
-	c.Check(mdOwnerNonLeaderUnit.CurrentRevision, gc.Equals, 666)
+	_, err = s.State.GetSecretConsumer(uri, names.NewUnitTag("mysql/0"))
+	c.Check(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *SecretsSuite) TestSaveSecretConsumer(c *gc.C) {


### PR DESCRIPTION
Given we allow units to access application-owned secrets using the owner label, we also want to include the owner label in the secret-changed hook context. The previous implementation copies the owner label to the consumer doc which breaks the secret-get command. Because the label is unique per application. An application and its units can not use the label `foo` for an owner label and then a consumer label.
This PR copies the consumer label in the facade layer instead of the state layer to avoid writing the copied label into the database.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju scale-application snappass-test 2
snappass-test scaled to 2 units

juju exec --unit snappass-test/1 'cat /var/lib/juju/agents/unit-snappass-test-1/charm/hooks/secret-changed'
#!/bin/bash
juju-log "secret-changed uri=$JUJU_SECRET_ID label=$JUJU_SECRET_LABEL"


juju exec --unit snappass-test/0 'secret-add test=test1 --label=test1;'
secret:cgiipp6ffbas7aj75vhg

juju exec --unit snappass-test/0 'secret-get cgiipp6ffbas7aj75vhg'
test: test1

juju exec --unit snappass-test/0 'secret-get cgiipp6ffbas7aj75vhg'
test: test1

juju exec --unit snappass-test/0 'secret-get --label test1'
test: test1

juju exec --unit snappass-test/1 'secret-get cgiipp6ffbas7aj75vhg'
test: test1

juju exec --unit snappass-test/1 'secret-get --label test1'
test: test1

juju exec --unit snappass-test/0 'secret-set secret:cgiipp6ffbas7aj75vhg test=test1 --label=test2'

juju debug-log --color --replay -m k1:t1 | grep 'secret-changed uri=secret'
unit-snappass-test-1: 17:35:05 INFO unit.snappass-test/1.juju-log secret-changed uri=secret:cgiipp6ffbas7aj75vhg label=test2

juju exec --unit snappass-test/0 'secret-get --label test2'
test: test1

juju exec --unit snappass-test/1 'secret-get --label test2'
test: test1

```

## Documentation changes

No

## Bug reference

https://bugs.launchpad.net/juju/+bug/2012746
