### PR TITLE
[JUJU-3394] Record the jwt auth token along side te macaroon on the cmr app entity

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -794,6 +794,7 @@ func (c *Client) Consume(arg crossmodel.ConsumeApplicationArgs) (string, error) 
 			ApplicationOfferDetails: arg.Offer,
 			ApplicationAlias:        arg.ApplicationAlias,
 			Macaroon:                arg.Macaroon,
+			AuthToken:               arg.AuthToken,
 		}},
 	}
 	if arg.ControllerInfo != nil {

--- a/api/client/application/client_test.go
+++ b/api/client/application/client_test.go
@@ -595,6 +595,7 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 				ApplicationAlias:        "alias",
 				ApplicationOfferDetails: offer,
 				Macaroon:                mac,
+				AuthToken:               "auth-token",
 				ControllerInfo:          controllerInfo,
 			},
 		},
@@ -607,6 +608,7 @@ func (s *applicationSuite) TestConsume(c *gc.C) {
 		Offer:            offer,
 		ApplicationAlias: "alias",
 		Macaroon:         mac,
+		AuthToken:        "auth-token",
 		ControllerInfo: &crossmodel.ControllerInfo{
 			ControllerTag: coretesting.ControllerTag,
 			Alias:         "controller-alias",

--- a/api/client/applicationoffers/client.go
+++ b/api/client/applicationoffers/client.go
@@ -254,7 +254,7 @@ func (c *Client) FindApplicationOffers(filters ...crossmodel.ApplicationOfferFil
 	return convertOffersResultsToModel(offers.Results)
 }
 
-// GetConsumeDetails returns details necessary to consue an offer at a given URL.
+// GetConsumeDetails returns details necessary to consume an offer at a given URL.
 func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, error) {
 
 	url, err := crossmodel.ParseOfferURL(urlStr)
@@ -289,6 +289,7 @@ func (c *Client) GetConsumeDetails(urlStr string) (params.ConsumeOfferDetails, e
 	return params.ConsumeOfferDetails{
 		Offer:          theOne.Offer,
 		Macaroon:       theOne.Macaroon,
+		AuthToken:      theOne.AuthToken,
 		ControllerInfo: theOne.ControllerInfo,
 	}, nil
 }

--- a/api/client/applicationoffers/client_test.go
+++ b/api/client/applicationoffers/client_test.go
@@ -496,6 +496,7 @@ func (s *crossmodelMockSuite) TestGetConsumeDetails(c *gc.C) {
 				ConsumeOfferDetails: params.ConsumeOfferDetails{
 					Offer:          &offer,
 					Macaroon:       mac,
+					AuthToken:      "auth-token",
 					ControllerInfo: controllerInfo,
 				},
 			},
@@ -510,6 +511,7 @@ func (s *crossmodelMockSuite) TestGetConsumeDetails(c *gc.C) {
 	c.Assert(details, jc.DeepEquals, params.ConsumeOfferDetails{
 		Offer:          &offer,
 		Macaroon:       mac,
+		AuthToken:      "auth-token",
 		ControllerInfo: controllerInfo,
 	})
 }

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -228,7 +228,7 @@ func (a *admin) authenticate(ctx context.Context, req params.LoginRequest) (*aut
 		userLogin:           true,
 	}
 
-	logger.Debugf("request loginToken: %q", req.Token)
+	logger.Debugf("request authToken: %q", req.Token)
 	if req.Token == "" && req.AuthTag != "" {
 		tag, err := names.ParseTag(req.AuthTag)
 		if err == nil {
@@ -289,10 +289,11 @@ func (a *admin) authenticate(ctx context.Context, req params.LoginRequest) (*aut
 		if req.Token != "" {
 			tok, entity, err := a.srv.jwtTokenService.Parse(ctx, req.Token)
 			if err != nil {
-				return nil, a.handleAuthError(errors.Annotate(err, "parsing request loginToken"))
+				return nil, a.handleAuthError(errors.Annotate(err, "parsing request authToken"))
 			}
 			a.root.entity = entity
-			a.root.loginToken = tok
+			a.root.authTokenString = req.Token
+			a.root.authToken = tok
 		} else {
 			authParams := authentication.AuthParams{
 				AuthTag:       result.tag,
@@ -408,7 +409,7 @@ func (a *admin) fillLoginDetails(result *authResult, lastConnection *time.Time) 
 	// Send back user info if user
 	if result.userLogin {
 		userTag := a.root.entity.Tag().(names.UserTag)
-		if token := a.root.loginToken; token != nil {
+		if token := a.root.authToken; token != nil {
 			// We're passing in known valid tag kinds here, so we'll not get an error.
 			controllerAccess, err := permissionFromToken(token, a.root.state.ControllerTag())
 			if err != nil {

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -406,7 +406,7 @@ func newServer(cfg ServerConfig) (_ *Server, err error) {
 	srv.shared.cancel = srv.tomb.Dying()
 
 	// The auth context for authenticating access to application offers.
-	srv.offerAuthCtxt, err = newOfferAuthcontext(cfg.StatePool)
+	srv.offerAuthCtxt, err = newOfferAuthContext(cfg.StatePool, srv.jwtTokenService)
 	if err != nil {
 		unsubscribeControllerConfig()
 		return nil, errors.Trace(err)
@@ -1115,7 +1115,6 @@ func (srv *Server) serveConn(
 	if err != nil {
 		conn.ServeRoot(&errRoot{errors.Trace(err)}, recorderFactory, serverError)
 	} else {
-		srv.offerAuthCtxt = srv.offerAuthCtxt.WithPermissionChecker(h.EntityHasPermission)
 		srv.shared.entityHasPermission = h.EntityHasPermission
 		// Set up the admin apis used to accept logins and direct
 		// requests to the relevant business facade.

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -75,7 +75,7 @@ func TestingAPIRoot(facades *facade.Registry) rpc.Root {
 func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State) (*apiHandler, *common.Resources) {
 	authenticator, err := stateauthenticator.NewAuthenticator(pool, clock.WallClock)
 	c.Assert(err, jc.ErrorIsNil)
-	offerAuthCtxt, err := newOfferAuthcontext(pool)
+	offerAuthCtxt, err := newOfferAuthContext(pool, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	srv := &Server{
 		authenticator: authenticator,
@@ -105,7 +105,7 @@ func TestingAPIHandlerWithToken(c *gc.C, pool *state.StatePool, st *state.State,
 	user, err := names.ParseUserTag(jwt.Subject())
 	c.Assert(err, jc.ErrorIsNil)
 	h.entity = tokenEntity{user: user}
-	h.loginToken = jwt
+	h.authToken = jwt
 	return h, hr
 }
 

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -204,6 +204,9 @@ type Authorizer interface {
 	// target by the given entity.
 	EntityHasPermission(entity names.Tag, operation permission.Access, target names.Tag) (bool, error)
 
+	// AuthTokenString returns the jwt passed to login.
+	AuthTokenString() string
+
 	// ConnectedModel returns the UUID of the model to which the API
 	// connection was made.
 	ConnectedModel() string

--- a/apiserver/facade/mocks/facade_mock.go
+++ b/apiserver/facade/mocks/facade_mock.go
@@ -185,6 +185,20 @@ func (mr *MockAuthorizerMockRecorder) AuthOwner(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthOwner", reflect.TypeOf((*MockAuthorizer)(nil).AuthOwner), arg0)
 }
 
+// AuthTokenString mocks base method.
+func (m *MockAuthorizer) AuthTokenString() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthTokenString")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// AuthTokenString indicates an expected call of AuthTokenString.
+func (mr *MockAuthorizerMockRecorder) AuthTokenString() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthTokenString", reflect.TypeOf((*MockAuthorizer)(nil).AuthTokenString))
+}
+
 // AuthUnitAgent mocks base method.
 func (m *MockAuthorizer) AuthUnitAgent() bool {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2094,7 +2094,7 @@ func (api *APIBase) consumeOne(arg params.ConsumeApplicationArg) error {
 	if appName == "" {
 		appName = arg.OfferName
 	}
-	_, err = api.saveRemoteApplication(sourceModelTag, appName, externalControllerUUID, arg.ApplicationOfferDetails, arg.Macaroon)
+	_, err = api.saveRemoteApplication(sourceModelTag, appName, externalControllerUUID, arg.ApplicationOfferDetails, arg.Macaroon, arg.AuthToken)
 	return err
 }
 
@@ -2106,6 +2106,7 @@ func (api *APIBase) saveRemoteApplication(
 	externalControllerUUID string,
 	offer params.ApplicationOfferDetails,
 	mac *macaroon.Macaroon,
+	authToken string,
 ) (RemoteApplication, error) {
 	remoteEps := make([]charm.Relation, len(offer.Endpoints))
 	for j, ep := range offer.Endpoints {
@@ -2152,6 +2153,7 @@ func (api *APIBase) saveRemoteApplication(
 		Spaces:                 remoteSpaces,
 		Bindings:               offer.Bindings,
 		Macaroon:               mac,
+		AuthToken:              authToken,
 	})
 }
 

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -133,6 +133,7 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 		Endpoints:   []charm.Relation{{Name: "database", Interface: "mysql", Role: "provider"}},
 		Spaces:      []*environs.ProviderSpaceInfo{},
 		Macaroon:    testMac,
+		AuthToken:   "auth-token",
 	}
 
 	s.consumeApplicationArgs = params.ConsumeApplicationArgs{
@@ -145,7 +146,8 @@ func (s *ApplicationSuite) SetUpTest(c *gc.C) {
 				Endpoints:              []params.RemoteEndpoint{{Name: "database", Interface: "mysql", Role: "provider"}},
 				OfferURL:               "othermodel.hosted-mysql",
 			},
-			Macaroon: testMac,
+			Macaroon:  testMac,
+			AuthToken: "auth-token",
 		}},
 	}
 }

--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -40,7 +40,7 @@ func (s *offerAccessSuite) SetUpTest(c *gc.C) {
 
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery)
+	s.authContext, err = crossmodel.NewAuthContext(s.mockState, thirdPartyKey, s.bakery, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	api, err := applicationoffers.CreateOffersAPI(

--- a/apiserver/facades/client/client/mocks/facade_mock.go
+++ b/apiserver/facades/client/client/mocks/facade_mock.go
@@ -119,6 +119,20 @@ func (mr *MockAuthorizerMockRecorder) AuthOwner(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthOwner", reflect.TypeOf((*MockAuthorizer)(nil).AuthOwner), arg0)
 }
 
+// AuthTokenString mocks base method.
+func (m *MockAuthorizer) AuthTokenString() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthTokenString")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// AuthTokenString indicates an expected call of AuthTokenString.
+func (mr *MockAuthorizerMockRecorder) AuthTokenString() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthTokenString", reflect.TypeOf((*MockAuthorizer)(nil).AuthTokenString))
+}
+
 // AuthUnitAgent mocks base method.
 func (m *MockAuthorizer) AuthUnitAgent() bool {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/sshclient/mocks/authorizer_mock.go
+++ b/apiserver/facades/client/sshclient/mocks/authorizer_mock.go
@@ -119,6 +119,20 @@ func (mr *MockAuthorizerMockRecorder) AuthOwner(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthOwner", reflect.TypeOf((*MockAuthorizer)(nil).AuthOwner), arg0)
 }
 
+// AuthTokenString mocks base method.
+func (m *MockAuthorizer) AuthTokenString() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthTokenString")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// AuthTokenString indicates an expected call of AuthTokenString.
+func (mr *MockAuthorizerMockRecorder) AuthTokenString() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthTokenString", reflect.TypeOf((*MockAuthorizer)(nil).AuthTokenString))
+}
+
 // AuthUnitAgent mocks base method.
 func (m *MockAuthorizer) AuthUnitAgent() bool {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/mocks/context_mock.go
@@ -126,6 +126,20 @@ func (mr *MockAuthorizerMockRecorder) AuthOwner(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthOwner", reflect.TypeOf((*MockAuthorizer)(nil).AuthOwner), arg0)
 }
 
+// AuthTokenString mocks base method.
+func (m *MockAuthorizer) AuthTokenString() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthTokenString")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// AuthTokenString indicates an expected call of AuthTokenString.
+func (mr *MockAuthorizerMockRecorder) AuthTokenString() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthTokenString", reflect.TypeOf((*MockAuthorizer)(nil).AuthTokenString))
+}
+
 // AuthUnitAgent mocks base method.
 func (m *MockAuthorizer) AuthUnitAgent() bool {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -95,7 +95,7 @@ func (s *crossmodelRelationsSuite) SetUpTest(c *gc.C) {
 	}
 	var err error
 	thirdPartyKey := bakery.MustGenerateKey()
-	s.authContext, err = commoncrossmodel.NewAuthContext(s.st, thirdPartyKey, s.bakery)
+	s.authContext, err = commoncrossmodel.NewAuthContext(s.st, thirdPartyKey, s.bakery, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	api, err := crossmodelrelations.NewCrossModelRelationsAPI(
 		s.st, fw, s.resources, s.authorizer,

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -88,7 +88,7 @@ func (s *CrossModelSecretsSuite) SetUpTest(c *gc.C) {
 		OpsAuthorizer: crossmodel.CrossModelAuthorizer{},
 	})
 	s.bakery = &mockBakery{bakery}
-	s.authContext, err = crossmodel.NewAuthContext(nil, key, s.bakery)
+	s.authContext, err = crossmodel.NewAuthContext(nil, key, s.bakery, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -3116,6 +3116,9 @@
                         "application-description": {
                             "type": "string"
                         },
+                        "auth-token": {
+                            "type": "string"
+                        },
                         "bindings": {
                             "type": "object",
                             "patternProperties": {
@@ -4605,6 +4608,9 @@
                 "ConsumeOfferDetails": {
                     "type": "object",
                     "properties": {
+                        "auth-token": {
+                            "type": "string"
+                        },
                         "external-controller": {
                             "$ref": "#/definitions/ExternalControllerInfo"
                         },
@@ -4637,6 +4643,9 @@
                     "properties": {
                         "ConsumeOfferDetails": {
                             "$ref": "#/definitions/ConsumeOfferDetails"
+                        },
+                        "auth-token": {
+                            "type": "string"
                         },
                         "error": {
                             "$ref": "#/definitions/Error"
@@ -20129,6 +20138,9 @@
                     "type": "object",
                     "properties": {
                         "application-token": {
+                            "type": "string"
+                        },
+                        "auth-token": {
                             "type": "string"
                         },
                         "bakery-version": {

--- a/apiserver/localofferauth.go
+++ b/apiserver/localofferauth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/bakeryutil"
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/core/macaroon"
@@ -42,7 +43,7 @@ func addOfferAuthHandlers(offerAuthCtxt *crossmodel.AuthContext, mux *apiserverh
 	_ = mux.AddHandler("GET", localOfferAccessLocationPath+"/publickey", appOfferDischargeMux)
 }
 
-func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error) {
+func newOfferAuthContext(pool *state.StatePool, tokenParser authentication.TokenParser) (*crossmodel.AuthContext, error) {
 	// Create a bakery service for discharging third-party caveats for
 	// local offer access authentication. This service does not persist keys;
 	// its macaroons should be very short-lived.
@@ -80,7 +81,7 @@ func newOfferAuthcontext(pool *state.StatePool) (*crossmodel.AuthContext, error)
 		localOfferBakery, location, localOfferBakeryKey, store, locator,
 	}
 	authCtx, err := crossmodel.NewAuthContext(
-		crossmodel.GetBackend(st), key, offerBakery)
+		crossmodel.GetBackend(st), key, offerBakery, tokenParser, permissionFromToken)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/logintoken.go
+++ b/apiserver/logintoken.go
@@ -46,11 +46,11 @@ func (j *jwtService) RegisterJWKSCache(ctx context.Context, client *http.Client)
 // Parse parses the bytes into a jwt.
 func (j *jwtService) Parse(ctx context.Context, tok string) (jwt.Token, state.Entity, error) {
 	if j == nil || j.refreshURL == "" {
-		return nil, nil, errors.New("no jwt loginToken parser configured")
+		return nil, nil, errors.New("no jwt authToken parser configured")
 	}
 	tokBytes, err := base64.StdEncoding.DecodeString(tok)
 	if err != nil {
-		return nil, nil, errors.Annotate(err, "invalid jwt loginToken in request")
+		return nil, nil, errors.Annotate(err, "invalid jwt authToken in request")
 	}
 
 	jwkSet, err := j.cache.Get(ctx, j.refreshURL)
@@ -73,7 +73,7 @@ func (j *jwtService) Parse(ctx context.Context, tok string) (jwt.Token, state.En
 func userFromToken(token jwt.Token) (state.Entity, error) {
 	userTag, err := names.ParseUserTag(token.Subject())
 	if err != nil {
-		return nil, errors.Annotate(err, "invalid user tag in loginToken")
+		return nil, errors.Annotate(err, "invalid user tag in authToken")
 	}
 	return tokenEntity{userTag}, nil
 }
@@ -94,7 +94,7 @@ func permissionFromToken(token jwt.Token, subject names.Tag) (permission.Access,
 	}
 	accessClaims, ok := token.PrivateClaims()["access"].(map[string]interface{})
 	if !ok || len(accessClaims) == 0 {
-		logger.Warningf("loginToken contains invalid access claims: %v", token.PrivateClaims()["access"])
+		logger.Warningf("authToken contains invalid access claims: %v", token.PrivateClaims()["access"])
 		return permission.NoAccess, nil
 	}
 	access, ok := accessClaims[subject.String()]

--- a/apiserver/logintoken_test.go
+++ b/apiserver/logintoken_test.go
@@ -134,7 +134,7 @@ func (s *loginTokenSuite) TestLoginInvalidUser(c *gc.C) {
 
 	var response params.LoginResult
 	err = st.APICall("Admin", 3, "", "Login", request, &response)
-	c.Assert(err, gc.ErrorMatches, `parsing request loginToken: invalid user tag in loginToken: "machine-0" is not a valid user tag`)
+	c.Assert(err, gc.ErrorMatches, `parsing request authToken: invalid user tag in authToken: "machine-0" is not a valid user tag`)
 }
 
 func (s *loginTokenSuite) TestLoginInvalidPermission(c *gc.C) {

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -13,11 +13,13 @@ import (
 
 // FakeAuthorizer implements the facade.Authorizer interface.
 type FakeAuthorizer struct {
-	Tag         names.Tag
-	Controller  bool
-	ModelUUID   string
-	AdminTag    names.UserTag
-	HasWriteTag names.UserTag
+	Tag           names.Tag
+	Controller    bool
+	ModelUUID     string
+	AdminTag      names.UserTag
+	HasConsumeTag names.UserTag
+	HasWriteTag   names.UserTag
+	AuthToken     string
 }
 
 func (fa FakeAuthorizer) AuthOwner(tag names.Tag) bool {
@@ -142,5 +144,13 @@ func (fa FakeAuthorizer) EntityHasPermission(entity names.Tag, operation permiss
 	if fa.AdminTag != emptyTag && entity == fa.AdminTag {
 		return true, nil
 	}
+	if operation == permission.ConsumeAccess && fa.HasConsumeTag != emptyTag && entity == fa.HasConsumeTag {
+		return true, nil
+	}
 	return false, nil
+}
+
+// AuthTokenString returns the jwt passed to login.
+func (fa FakeAuthorizer) AuthTokenString() string {
+	return fa.AuthToken
 }

--- a/cmd/juju/application/consume.go
+++ b/cmd/juju/application/consume.go
@@ -160,6 +160,7 @@ func (c *consumeCommand) Run(ctx *cmd.Context) error {
 		Offer:            *consumeDetails.Offer,
 		ApplicationAlias: c.applicationAlias,
 		Macaroon:         consumeDetails.Macaroon,
+		AuthToken:        consumeDetails.AuthToken,
 	}
 	if consumeDetails.ControllerInfo != nil {
 		controllerTag, err := names.ParseControllerTag(consumeDetails.ControllerInfo.ControllerTag)

--- a/cmd/juju/application/consume_test.go
+++ b/cmd/juju/application/consume_test.go
@@ -112,6 +112,7 @@ func (s *ConsumeSuite) assertSuccessModelDotApplication(c *gc.C, alias string) {
 			Offer:            params.ApplicationOfferDetails{OfferName: "an offer", OfferURL: "ctrl:bob/booster.uke"},
 			ApplicationAlias: alias,
 			Macaroon:         mac,
+			AuthToken:        "auth-token",
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: coretesting.ControllerTag,
 				Alias:         "controller-alias",
@@ -157,8 +158,9 @@ func (a *mockConsumeAPI) GetConsumeDetails(url string) (params.ConsumeOfferDetai
 		return params.ConsumeOfferDetails{}, err
 	}
 	return params.ConsumeOfferDetails{
-		Offer:    &params.ApplicationOfferDetails{OfferName: "an offer", OfferURL: "bob/booster.uke"},
-		Macaroon: mac,
+		Offer:     &params.ApplicationOfferDetails{OfferName: "an offer", OfferURL: "bob/booster.uke"},
+		Macaroon:  mac,
+		AuthToken: "auth-token",
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: coretesting.ControllerTag.String(),
 			Alias:         "controller-alias",

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -970,7 +970,8 @@ func (s *DeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
 			OfferName: "mysql",
 			OfferURL:  "admin/default.mysql",
 		},
-		Macaroon: mac,
+		Macaroon:  mac,
+		AuthToken: "auth-token",
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: coretesting.ControllerTag.String(),
 			Addrs:         []string{"192.168.1.0"},
@@ -987,6 +988,7 @@ func (s *DeploySuite) TestDeployBundleWithSAAS(c *gc.C) {
 			},
 			ApplicationAlias: "mysql",
 			Macaroon:         mac,
+			AuthToken:        "auth-token",
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: coretesting.ControllerTag,
 				Alias:         "controller-alias",

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -1481,11 +1481,12 @@ func (h *bundleHandler) consumeOffer(change *bundlechanges.ConsumeOfferChange) e
 	offerURL.Source = url.Source
 	consumeDetails.Offer.OfferURL = offerURL.String()
 
-	// construct the cosume application arguments
+	// construct the consume application arguments
 	arg := crossmodel.ConsumeApplicationArgs{
 		Offer:            *consumeDetails.Offer,
 		ApplicationAlias: p.ApplicationName,
 		Macaroon:         consumeDetails.Macaroon,
+		AuthToken:        consumeDetails.AuthToken,
 	}
 	if consumeDetails.ControllerInfo != nil {
 		controllerTag, err := names.ParseControllerTag(consumeDetails.ControllerInfo.ControllerTag)

--- a/cmd/juju/application/integrate.go
+++ b/cmd/juju/application/integrate.go
@@ -343,6 +343,7 @@ func (c *addRelationCommand) maybeConsumeOffer(targetClient applicationAddRelati
 		Offer:            *consumeDetails.Offer,
 		ApplicationAlias: c.remoteEndpoint.ApplicationName,
 		Macaroon:         consumeDetails.Macaroon,
+		AuthToken:        consumeDetails.AuthToken,
 	}
 	if consumeDetails.ControllerInfo != nil {
 		controllerTag, err := names.ParseControllerTag(consumeDetails.ControllerInfo.ControllerTag)

--- a/cmd/juju/application/integrateremote_test.go
+++ b/cmd/juju/application/integrateremote_test.go
@@ -49,6 +49,7 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationToOneRemoteApplication(c *
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
+			AuthToken:        "auth-token",
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: testing.ControllerTag,
 				Addrs:         []string{"192.168.1.0"},
@@ -70,6 +71,7 @@ func (s *AddRemoteRelationSuiteNewAPI) TestAddRelationAnyRemoteApplication(c *gc
 			},
 			ApplicationAlias: "applicationname2",
 			Macaroon:         s.mac,
+			AuthToken:        "auth-token",
 			ControllerInfo: &crossmodel.ControllerInfo{
 				ControllerTag: testing.ControllerTag,
 				Addrs:         []string{"192.168.1.0"},
@@ -238,7 +240,8 @@ func (m *mockAddRelationAPI) GetConsumeDetails(url string) (params.ConsumeOfferD
 			OfferName: "hosted-mysql",
 			OfferURL:  "bob/prod.hosted-mysql",
 		},
-		Macaroon: m.mac,
+		Macaroon:  m.mac,
+		AuthToken: "auth-token",
 		ControllerInfo: &params.ExternalControllerInfo{
 			ControllerTag: testing.ControllerTag.String(),
 			Addrs:         []string{"192.168.1.0"},

--- a/core/crossmodel/interface.go
+++ b/core/crossmodel/interface.go
@@ -66,6 +66,9 @@ type ConsumeApplicationArgs struct {
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon
 
+	// AuthToken is the JWT used for auth.
+	AuthToken string
+
 	// ControllerInfo contains connection details to the controller
 	// hosting the offer.
 	ControllerInfo *ControllerInfo

--- a/rpc/params/crossmodel.go
+++ b/rpc/params/crossmodel.go
@@ -184,6 +184,9 @@ type ConsumeApplicationArg struct {
 	// Macaroon is used for authentication.
 	Macaroon *macaroon.Macaroon `json:"macaroon,omitempty"`
 
+	// AuthToken is the JWT used for auth.
+	AuthToken string `json:"auth-token,omitempty"`
+
 	// ControllerInfo contains connection details to the controller
 	// hosting the offer.
 	ControllerInfo *ExternalControllerInfo `json:"external-controller,omitempty"`
@@ -545,6 +548,9 @@ type RegisterRemoteRelationArg struct {
 
 	// BakeryVersion is the version of the bakery used to mint macaroons.
 	BakeryVersion bakery.Version `json:"bakery-version,omitempty"`
+
+	// AuthToken is the JWT used for auth.
+	AuthToken string `json:"auth-token,omitempty"`
 }
 
 // RegisterRemoteRelationArgs holds args used to add remote relations.
@@ -626,6 +632,7 @@ type RemoteApplicationInfoResults struct {
 type ConsumeOfferDetails struct {
 	Offer          *ApplicationOfferDetails `json:"offer,omitempty"`
 	Macaroon       *macaroon.Macaroon       `json:"macaroon,omitempty"`
+	AuthToken      string                   `json:"auth-token,omitempty"`
 	ControllerInfo *ExternalControllerInfo  `json:"external-controller,omitempty"`
 }
 

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/juju/charm/v10"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -85,9 +86,13 @@ func ApplicationOfferEndpoint(offer crossmodel.ApplicationOffer, relationName st
 }
 
 // TODO(wallyworld) - remove when we use UUID everywhere
-func applicationOfferUUID(st *State, offerName string) (string, error) {
+func applicationOfferUUID(st *State, offerNameOrUUID string) (string, error) {
+	_, err := uuid.ParseUUID(offerNameOrUUID)
+	if err == nil {
+		return offerNameOrUUID, nil
+	}
 	appOffers := &applicationOffers{st: st}
-	offer, err := appOffers.ApplicationOffer(offerName)
+	offer, err := appOffers.ApplicationOffer(offerNameOrUUID)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/state/applicationofferuser.go
+++ b/state/applicationofferuser.go
@@ -52,7 +52,7 @@ func (st *State) CreateOfferAccess(offer names.ApplicationOfferTag, user names.U
 		}
 	}
 
-	offerUUID, err := applicationOfferUUID(st, offer.Name)
+	offerUUID, err := applicationOfferUUID(st, offer.Id())
 	if err != nil {
 		return errors.Annotate(err, "creating offer access")
 	}
@@ -70,7 +70,7 @@ func (st *State) UpdateOfferAccess(offer names.ApplicationOfferTag, user names.U
 	if err := permission.ValidateOfferAccess(access); err != nil {
 		return errors.Trace(err)
 	}
-	offerUUID, err := applicationOfferUUID(st, offer.Name)
+	offerUUID, err := applicationOfferUUID(st, offer.Id())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -167,7 +167,7 @@ func (st *State) suspendRevokedRelationsOps(offerUUID, userId string) ([]txn.Op,
 
 // RemoveOfferAccess removes the access permission for a user on an offer.
 func (st *State) RemoveOfferAccess(offer names.ApplicationOfferTag, user names.UserTag) error {
-	offerUUID, err := applicationOfferUUID(st, offer.Name)
+	offerUUID, err := applicationOfferUUID(st, offer.Id())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -2418,6 +2418,8 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 		},
 		// Macaroon not exported.
 		Macaroon: mac,
+		// AuthToken not exported.
+		AuthToken: "auth-token",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	state.AddTestingApplication(c, s.State, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
@@ -2597,6 +2599,8 @@ func (s *MigrationExportSuite) TestRemoteRelationSettingsForUnitsInCMR(c *gc.C) 
 		},
 		// Macaroon not exported.
 		Macaroon: mac,
+		// AuthToken not exported.
+		AuthToken: "auth-token",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/model.go
+++ b/state/model.go
@@ -379,12 +379,6 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 	}
 	prereqOps = append(prereqOps, assertCloudCredentialOp)
 
-	if owner.IsLocal() {
-		if _, err := st.User(owner); err != nil {
-			return nil, nil, errors.Annotate(err, "cannot create model")
-		}
-	}
-
 	uuid := args.Config.UUID()
 	session := st.session.Copy()
 	newSt, err := newState(

--- a/state/model_test.go
+++ b/state/model_test.go
@@ -77,21 +77,6 @@ func (s *ModelSuite) TestModelDestroyWithoutVolumes(c *gc.C) {
 	c.Assert(model.Life(), gc.Equals, state.Dying)
 }
 
-func (s *ModelSuite) TestNewModelNonExistentLocalUser(c *gc.C) {
-	cfg, _ := s.createTestModelConfig(c)
-	owner := names.NewUserTag("non-existent@local")
-
-	_, _, err := s.Controller.NewModel(state.ModelArgs{
-		Type:                    state.ModelTypeIAAS,
-		CloudName:               "dummy",
-		CloudRegion:             "dummy-region",
-		Config:                  cfg,
-		Owner:                   owner,
-		StorageProviderRegistry: storage.StaticProviderRegistry{},
-	})
-	c.Assert(err, gc.ErrorMatches, `cannot create model: user "non-existent" not found`)
-}
-
 func (s *ModelSuite) TestSetPassword(c *gc.C) {
 	testSetPassword(c, func() (state.Authenticator, error) {
 		return s.State.Model()

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -47,6 +47,7 @@ type remoteApplicationDoc struct {
 	IsConsumerProxy      bool                `bson:"is-consumer-proxy"`
 	Version              int                 `bson:"version"`
 	Macaroon             string              `bson:"macaroon,omitempty"`
+	AuthToken            string              `bson:"auth-token,omitempty"`
 }
 
 // remoteEndpointDoc represents the internal state of a remote application endpoint in MongoDB.
@@ -774,6 +775,11 @@ func (s *RemoteApplication) Macaroon() (*macaroon.Macaroon, error) {
 	return &mac, nil
 }
 
+// AuthToken returns the encoded JWT.
+func (s *RemoteApplication) AuthToken() string {
+	return s.doc.AuthToken
+}
+
 // String returns the application name.
 func (s *RemoteApplication) String() string {
 	return s.doc.Name
@@ -846,6 +852,9 @@ type AddRemoteApplicationParams struct {
 
 	// Macaroon is used for authentication on the offering side.
 	Macaroon *macaroon.Macaroon
+
+	// AuthToken is the JWT used for auth.
+	AuthToken string
 }
 
 // Validate returns an error if there's a problem with the
@@ -921,6 +930,7 @@ func (st *State) AddRemoteApplication(args AddRemoteApplicationParams) (_ *Remot
 		IsConsumerProxy:      args.IsConsumerProxy,
 		Version:              version,
 		Macaroon:             macJSON,
+		AuthToken:            args.AuthToken,
 	}
 	eps := make([]remoteEndpointDoc, len(args.Endpoints))
 	for i, ep := range args.Endpoints {

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -118,6 +118,7 @@ func (s *remoteApplicationSuite) makeRemoteApplication(c *gc.C, name, url string
 		Spaces:                 spaces,
 		Bindings:               bindings,
 		Macaroon:               mac,
+		AuthToken:              "auth-token",
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -370,12 +371,13 @@ func (s *remoteApplicationSuite) TestMysqlEndpoints(c *gc.C) {
 	c.Assert(eps, gc.DeepEquals, []state.Endpoint{serverEP, adminEp, loggingEp})
 }
 
-func (s *remoteApplicationSuite) TestMacaroon(c *gc.C) {
+func (s *remoteApplicationSuite) TestAuth(c *gc.C) {
 	mac, err := newMacaroon("test")
 	c.Assert(err, jc.ErrorIsNil)
 	appMac, err := s.application.Macaroon()
 	c.Assert(err, jc.ErrorIsNil)
 	assertMacaroonEquals(c, appMac, mac)
+	c.Assert(s.application.AuthToken(), gc.Equals, "auth-token")
 }
 
 func (s *remoteApplicationSuite) TestApplicationRefresh(c *gc.C) {


### PR DESCRIPTION
As a first step in allowing cross model relations to work with JAAS auth tokens, this PR records the auth token on the remote application. The macaroon is stored there - we need to now add the auth token as well. Only one of these will be set.

The macaroon or auth token is used when making cross controller cmr calls. There are several of these api calls. This PR prototypes the register remote relation call. The token is checked but there's no refresh yet if it is invalid.

The cross model auth is reworked to handle both macaroon and token checks.

As a drive by, remove the user in db check for model owner. This is checked in the facade anyway and we are trying to move away from a model owner attribute, and it also breaks jaas rebac.

## QA steps

Check that cross model relations still works for the juju cli. JAAS will validate the auth token stuff.
add a model and deploy juju-qa-dummy-source and offer
add a model and deploy juju-qa-dummy-sink and consume the offer and relate
add a user and grant consume on the offer and add-model on the controller cloud
login as that user and add a model and consume and relate the offer
