### PR TITLE
[JUJU-3343] dont prompt force when forcing

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -115,7 +115,7 @@ var usageSummary = `
 Destroys a controller.`[1:]
 
 var destroySysMsg = `
-This command with destroy the %q controller and all its resources
+This command will destroy the %q controller and all its resources
 `[1:]
 
 var destroySysMsgDetails = `

--- a/cmd/juju/machine/remove.go
+++ b/cmd/juju/machine/remove.go
@@ -218,7 +218,7 @@ func (c *removeCommand) performDryRun(ctx *cmd.Context, client RemoveMachineAPI)
 	}
 	ctx.Warningf(removeMachineMsgPrefix)
 	_ = c.logResults(ctx, results)
-	if c.runNeedsForce(results) {
+	if c.runNeedsForce(results) && !c.Force {
 		ctx.Infof("\nThis will require `--force`")
 	}
 	return nil


### PR DESCRIPTION
Also flyby fix a spelling mistake

## QA steps

```
$ juju bootstrap aws/eu-west-2 aws
$ juju add-model m
$ juju add-machine
$ juju add-machine lxd:0
$ juju model-config mode="requires-prompt"
$ juju remove-machine 0
WARNING This command will perform the following actions:
will remove machine 0
will remove machine 0/lxd/0

This will require `--force`

Continue [y/N]? n

$ juju remove-machine 0 --force
WARNING This command will perform the following actions:
will remove machine 0
will remove machine 0/lxd/0

Continue [y/N]? y
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2011629