### PR TITLE
[JUJU-3400] Fix base bundle checks on constraints

### DIFF
--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -255,23 +255,10 @@ func ComposeAndVerifyBundle(base BundleDataSource, pathToOverlays []string) (*ch
 		_, err := constraints.Parse(s)
 		return err
 	}
-	verifyBaseConstraints := func(s string) error {
-		bundleConstraints, err := constraints.Parse(s)
-		if err != nil {
-			return err
-		}
-		if bundleConstraints.HasImageID() {
-			return errors.NotSupportedf("'image-id' constraint in a base bundle")
-		}
-		return nil
-	}
-	verifyStorage := func(s string) error {
-		_, err := storage.ParseConstraints(s)
-		return err
-	}
-	verifyDevices := func(s string) error {
-		_, err := devices.ParseConstraints(s)
-		return err
+	// verify that the base bundle does not contain image-id constraint
+	err := verifyBaseBundle(base)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
 	}
 
 	var dsList []charm.BundleDataSource
@@ -292,16 +279,9 @@ func ComposeAndVerifyBundle(base BundleDataSource, pathToOverlays []string) (*ch
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	// validate that base bundle does not include an unsupported constraint
-	baseBundleData, _, err := charm.ExtractBaseAndOverlayParts(bundleData)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	if err := verifyBundle(baseBundleData, base.BasePath(), verifyBaseConstraints, verifyStorage, verifyDevices); err != nil {
-		return nil, nil, errors.Trace(err)
-	}
+
 	// verify composed (base + overlay bundles)
-	if err = verifyBundle(bundleData, base.BasePath(), verifyConstraints, verifyStorage, verifyDevices); err != nil {
+	if err = verifyBundle(bundleData, base.BasePath(), verifyConstraints); err != nil {
 		return nil, nil, errors.Trace(err)
 	}
 
@@ -319,7 +299,31 @@ func gatherErrors(ds BundleDataSource) []error {
 	return returnErrors
 }
 
-func verifyBundle(data *charm.BundleData, bundleDir string, verifyConstraints, verifyStorage, verifyDevices func(string) error) error {
+func verifyBaseBundle(base BundleDataSource) error {
+	verifyBaseConstraints := func(s string) error {
+		bundleConstraints, err := constraints.Parse(s)
+		if err != nil {
+			return err
+		}
+		if bundleConstraints.HasImageID() {
+			return errors.NotSupportedf("'image-id' constraint in a base bundle")
+		}
+		return nil
+	}
+
+	return verifyBundle(base.Parts()[0].Data, base.BasePath(), verifyBaseConstraints)
+}
+
+func verifyBundle(data *charm.BundleData, bundleDir string, verifyConstraints func(string) error) error {
+	verifyStorage := func(s string) error {
+		_, err := storage.ParseConstraints(s)
+		return err
+	}
+	verifyDevices := func(s string) error {
+		_, err := devices.ParseConstraints(s)
+		return err
+	}
+
 	var verifyError error
 	if bundleDir == "" {
 		verifyError = data.Verify(verifyConstraints, verifyStorage, verifyDevices)

--- a/tests/suites/deploy/bundles/overlay_bundle_image_id.yaml
+++ b/tests/suites/deploy/bundles/overlay_bundle_image_id.yaml
@@ -1,0 +1,12 @@
+applications:
+    ubuntu:
+        charm: ubuntu
+        scale: 1
+
+---
+
+applications:
+    ubuntu:
+        series: jammy
+        scale: 2
+        constraints: image-id=ubuntu-bf2  

--- a/tests/suites/deploy/bundles/overlay_bundle_image_id_on_base_bundle.yaml
+++ b/tests/suites/deploy/bundles/overlay_bundle_image_id_on_base_bundle.yaml
@@ -1,0 +1,13 @@
+applications:
+    ubuntu:
+        charm: ubuntu
+        scale: 1
+        constraints: image-id=ubuntu-bf2  
+
+---
+
+applications:
+    ubuntu:
+        series: jammy
+        scale: 2
+        constraints: image-id=ubuntu-bf2-v2  

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -28,6 +28,37 @@ run_deploy_bundle_overlay() {
 	destroy_model "test-bundles-deploy-overlay"
 }
 
+run_deploy_bundle_overlay_with_image_id() {
+	echo
+
+	file="${TEST_DIR}/test-bundles-deploy-overlay-image-id.log"
+
+	ensure "test-bundles-deploy-overlay-image-id" "${file}"
+
+	bundle=./tests/suites/deploy/bundles/overlay_bundle_image_id.yaml
+	juju deploy ${bundle}
+
+	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 0)"
+	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 1)"
+
+	destroy_model "test-bundles-deploy-overlay-image-id"
+}
+
+run_deploy_bundle_overlay_with_image_id_on_base_bundle() {
+	echo
+
+	file="${TEST_DIR}/test-bundles-deploy-overlay-image-id-on-base-bundle.log"
+
+	ensure "test-bundles-deploy-overlay-image-id-on-base-bundle" "${file}"
+
+	bundle=./tests/suites/deploy/bundles/overlay_bundle_image_id_on_base_bundle.yaml
+
+	got=$(juju deploy ${bundle} 2>&1 || true)
+	check_contains "${got}" "'image-id' constraint in a base bundle not supported"
+
+	destroy_model "test-bundles-deploy-overlay-image-id-on-base-bundle"
+}
+
 run_deploy_cmr_bundle() {
 	echo
 
@@ -297,6 +328,8 @@ test_deploy_bundles() {
 
 		run "run_deploy_bundle"
 		run "run_deploy_bundle_overlay"
+		run "run_deploy_bundle_overlay_with_image_id"
+		run "run_deploy_bundle_overlay_with_image_id_on_base_bundle"
 		run "run_deploy_exported_charmhub_bundle_with_fixed_revisions"
 		run "run_deploy_exported_charmhub_bundle_with_float_revisions"
 		run "run_deploy_trusted_bundle"


### PR DESCRIPTION
The image-id constraint is not allowed on base bundles, only on overlays. In order to enforce this, a check was performed on the base bundle using the method charm.ExtractBaseAndOverlayParts(). The issue is that this method does not return the original base bundle but the resulting merged one with overlays.

This patch removes this call and adds a new check only on the original base bundle.

## Checklist

*If an item is not applicable, use `~strikethrough~`.*

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/develop/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Create these bundles: 

bundle.yaml:
```yaml
applications:
  prometheus2:
    charm: prometheus2
    channel: stable
    revision: 48
    num_units: 1
```
overlay-bundle.yaml:
```yaml
applications:
  prometheus2:
    series: focal
    constraints: image-id=ubuntu-bf2-v2
```
Then running:
```
$ juju deploy ./bundle.yaml --overlay ./overlay-bundle.yaml
```
Should return no errors.

## Bug reference

https://bugs.launchpad.net/juju/+bug/2013341
