### PR TITLE
Fix unused listSecretsExamples.

### DIFF
--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -65,10 +65,11 @@ func (c *listSecretsCommand) secretsAPI() (ListSecretsAPI, error) {
 // Info implements cmd.Info.
 func (c *listSecretsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "secrets",
-		Purpose: "Lists secrets available in the model.",
-		Doc:     listSecretsDoc,
-		Aliases: []string{"list-secrets"},
+		Name:     "secrets",
+		Purpose:  "Lists secrets available in the model.",
+		Doc:      listSecretsDoc,
+		Examples: listSecretsExamples,
+		Aliases:  []string{"list-secrets"},
 	})
 }
 


### PR DESCRIPTION
Unused linter picked up this missing use of an examples constant.

## QA steps

N/A as it will be tested by the 3.1 to develop merge pr.

## Documentation changes

N/A

## Bug reference

N/A